### PR TITLE
fix(desktop): subscription restructure — server quota, deprecation notice (#6734)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Chat limits now use server-side quota instead of local counter",
+    "Added deprecation notice for Unlimited plan subscribers with Operator upgrade option"
+  ],
   "releases": [
     {
       "version": "0.11.324",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -3903,13 +3903,16 @@ struct UserSubscriptionInfo: Codable {
   let features: [String]
   let cancelAtPeriodEnd: Bool
   let limits: SubscriptionLimitsResponse
+  let deprecated: Bool?
+  let deprecationMessage: String?
 
   enum CodingKeys: String, CodingKey {
-    case plan, status, features, limits
+    case plan, status, features, limits, deprecated
     case currentPeriodEnd = "current_period_end"
     case stripeSubscriptionId = "stripe_subscription_id"
     case currentPriceId = "current_price_id"
     case cancelAtPeriodEnd = "cancel_at_period_end"
+    case deprecationMessage = "deprecation_message"
   }
 }
 

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -1066,6 +1066,7 @@ class AuthService {
         // Stop background services that make API calls before clearing caches
         Task {
             await AgentSyncService.shared.stop()
+            await FloatingBarUsageLimiter.shared.reset()
         }
 
         // Close database and invalidate all storage caches so the next sign-in

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -49,6 +49,14 @@ final class FloatingBarUsageLimiter: ObservableObject {
         UserDefaults.standard.set(plan.rawValue, forKey: Self.cachedPlanKey)
     }
 
+    /// Reset all quota state on sign-out so the next user starts clean.
+    func reset() {
+        serverQuota = nil
+        optimisticDelta = 0
+        hasPaidPlan = false
+        UserDefaults.standard.removeObject(forKey: Self.cachedPlanKey)
+    }
+
     var isLimitReached: Bool {
         guard let quota = serverQuota else {
             // No server data yet — allow the query (server will enforce).
@@ -72,6 +80,9 @@ final class FloatingBarUsageLimiter: ObservableObject {
     var limitDescription: String {
         guard let quota = serverQuota, let limit = quota.limit else {
             return "your monthly free message limit"
+        }
+        if quota.unit == "cost_usd" {
+            return String(format: "your $%.0f %@ monthly spend limit", limit, quota.plan)
         }
         return "\(Int(limit)) \(quota.plan) messages this month"
     }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -1,33 +1,30 @@
 import Foundation
 
-/// Tracks AI chat/query usage and enforces a shared monthly limit for free users.
+/// Tracks AI chat/query usage and enforces limits using the server-side quota.
 ///
 /// Shared between the floating bar (Ask omi / PTT queries) and the main chat page
-/// (ChatProvider.sendMessage). A single 30-message monthly pool is counted against
-/// both surfaces so the free tier can't be stretched by bouncing between the two.
+/// (ChatProvider.sendMessage). The server endpoint `/v1/users/me/usage-quota` is
+/// the single source of truth for the current month's usage and plan limit.
 @MainActor
 final class FloatingBarUsageLimiter: ObservableObject {
     static let shared = FloatingBarUsageLimiter()
 
-    /// Monthly free cap, shared across floating bar + main chat.
-    static let monthlyFreeLimit = 30
-
-    /// Rolling window in seconds (30 days).
-    static let windowSeconds: Double = 30 * 24 * 3600
-
-    private static let queryTimestampsKey = "floatingBar_queryTimestamps"
     private static let cachedPlanKey = "floatingBar_cachedPlan"
 
-    @Published private(set) var monthlyQueriesUsed: Int = 0
     @Published private(set) var hasPaidPlan: Bool = false
-    private var planFetched = false
+
+    /// Server-reported quota snapshot, plus an optimistic local delta for queries
+    /// sent since the last server sync.
+    private var serverQuota: APIClient.ChatUsageQuota?
+    private var optimisticDelta: Int = 0
 
     private init() {
-        hasPaidPlan = UserDefaults.standard.string(forKey: Self.cachedPlanKey).map { $0 != "basic" } ?? false
-        pruneAndCount()
+        hasPaidPlan =
+            UserDefaults.standard.string(forKey: Self.cachedPlanKey).map { $0 != "basic" } ?? false
     }
 
-    /// Fetch the user's subscription plan from the backend (call on app launch / sign-in).
+    /// Fetch the user's subscription plan and usage quota from the backend.
+    /// Call on app launch, sign-in, and after checkout completes.
     func fetchPlan() async {
         do {
             let response = try await APIClient.shared.getUserSubscription()
@@ -35,41 +32,53 @@ final class FloatingBarUsageLimiter: ObservableObject {
         } catch {
             log("FloatingBarUsageLimiter: failed to fetch plan: \(error.localizedDescription)")
         }
+        await syncQuota()
+    }
+
+    /// Sync quota from the server, resetting the optimistic delta.
+    func syncQuota() async {
+        if let quota = await APIClient.shared.fetchChatUsageQuota() {
+            serverQuota = quota
+            optimisticDelta = 0
+        }
     }
 
     /// Update cached plan directly from an already-fetched subscription (no extra API call).
     func applyPlan(plan: SubscriptionPlanType, status: SubscriptionStatusType) {
         hasPaidPlan = plan != .basic && status == .active
         UserDefaults.standard.set(plan.rawValue, forKey: Self.cachedPlanKey)
-        planFetched = true
     }
 
     var isLimitReached: Bool {
-        !hasPaidPlan && monthlyQueriesUsed >= Self.monthlyFreeLimit
+        guard let quota = serverQuota else {
+            // No server data yet — allow the query (server will enforce).
+            return false
+        }
+        if quota.allowed {
+            // Check optimistic delta against remaining headroom.
+            guard let limit = quota.limit else { return false }
+            return (quota.used + Double(optimisticDelta)) >= limit
+        }
+        return true
     }
 
     var remainingQueries: Int {
-        hasPaidPlan ? .max : max(0, Self.monthlyFreeLimit - monthlyQueriesUsed)
+        guard let quota = serverQuota else { return .max }
+        guard quota.unit == "questions", let limit = quota.limit else { return .max }
+        return max(0, Int(limit - quota.used) - optimisticDelta)
+    }
+
+    /// Human-readable limit text for error messages.
+    var limitDescription: String {
+        guard let quota = serverQuota, let limit = quota.limit else {
+            return "your monthly free message limit"
+        }
+        return "\(Int(limit)) \(quota.plan) messages this month"
     }
 
     /// Record a query. Call after successfully sending a query from the floating bar
     /// OR the main chat page — both surfaces share this pool.
     func recordQuery() {
-        var timestamps = loadTimestamps()
-        timestamps.append(Date().timeIntervalSince1970)
-        UserDefaults.standard.set(timestamps, forKey: Self.queryTimestampsKey)
-        pruneAndCount()
-    }
-
-    private func pruneAndCount() {
-        let cutoff = Date().timeIntervalSince1970 - Self.windowSeconds
-        var timestamps = loadTimestamps()
-        timestamps.removeAll { $0 < cutoff }
-        UserDefaults.standard.set(timestamps, forKey: Self.queryTimestampsKey)
-        monthlyQueriesUsed = timestamps.count
-    }
-
-    private func loadTimestamps() -> [Double] {
-        UserDefaults.standard.array(forKey: Self.queryTimestampsKey) as? [Double] ?? []
+        optimisticDelta += 1
     }
 }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -63,8 +63,10 @@ final class FloatingBarUsageLimiter: ObservableObject {
             return false
         }
         if quota.allowed {
-            // Check optimistic delta against remaining headroom.
-            guard let limit = quota.limit else { return false }
+            // Optimistic delta only applies to question-based quotas.
+            // For cost_usd (Architect/Pro), we can't estimate cost per query
+            // locally — rely on the server snapshot alone.
+            guard quota.unit == "questions", let limit = quota.limit else { return false }
             return (quota.used + Double(optimisticDelta)) >= limit
         }
         return true

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -15,10 +15,10 @@ final class FloatingBarUsageLimiter: ObservableObject {
 
     /// Server-reported quota snapshot, plus an optimistic local delta for queries
     /// sent since the last server sync.
-    private var serverQuota: APIClient.ChatUsageQuota?
-    private var optimisticDelta: Int = 0
+    private(set) var serverQuota: APIClient.ChatUsageQuota?
+    private(set) var optimisticDelta: Int = 0
 
-    private init() {
+    init() {
         hasPaidPlan =
             UserDefaults.standard.string(forKey: Self.cachedPlanKey).map { $0 != "basic" } ?? false
     }
@@ -38,9 +38,14 @@ final class FloatingBarUsageLimiter: ObservableObject {
     /// Sync quota from the server, resetting the optimistic delta.
     func syncQuota() async {
         if let quota = await APIClient.shared.fetchChatUsageQuota() {
-            serverQuota = quota
-            optimisticDelta = 0
+            applyQuota(quota)
         }
+    }
+
+    /// Apply a quota snapshot directly (used by syncQuota and tests).
+    func applyQuota(_ quota: APIClient.ChatUsageQuota) {
+        serverQuota = quota
+        optimisticDelta = 0
     }
 
     /// Update cached plan directly from an already-fetched subscription (no extra API call).

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1473,7 +1473,7 @@ class FloatingControlBarManager {
             barWindow.state.isAILoading = false
             barWindow.state.showingAIResponse = true
             barWindow.state.currentAIMessage = ChatMessage(
-                text: "You've hit your monthly limit of \(FloatingBarUsageLimiter.monthlyFreeLimit) free messages. Upgrade to keep chatting without restrictions.",
+                text: "You've reached \(limiter.limitDescription). Upgrade to keep chatting without restrictions.",
                 sender: .ai
             )
             barWindow.resizeToResponseHeightPublic(animated: true)

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -1799,6 +1799,42 @@ struct SettingsContentView: View {
         }
       }
 
+      if let subscription = userSubscription?.subscription,
+        subscription.deprecated == true
+      {
+        settingsCard(settingId: "planusage.deprecation") {
+          VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+              Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(OmiColors.warning)
+                .scaledFont(size: 16)
+              Text("Plan Retiring")
+                .scaledFont(size: 14, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+            }
+
+            Text(
+              subscription.deprecationMessage
+                ?? "Your Unlimited plan is being retired. Try the new Operator plan — same great features at $49/mo."
+            )
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Button(action: {
+              selectedPlanIdForCheckout = "operator"
+            }) {
+              Text("Try Operator")
+                .scaledFont(size: 13, weight: .semibold)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(OmiColors.success)
+          }
+        }
+      }
+
       if shouldShowPlanPurchaseOptions {
         settingsCard(settingId: "planusage.purchase") {
           VStack(alignment: .leading, spacing: 18) {
@@ -6521,11 +6557,8 @@ struct SettingsContentView: View {
             subscription.subscription.plan != .basic && subscription.subscription.status == .active
 
           if matchedPrice && hasPaidPlan {
+            await FloatingBarUsageLimiter.shared.fetchPlan()
             await MainActor.run {
-              FloatingBarUsageLimiter.shared.applyPlan(
-                plan: subscription.subscription.plan,
-                status: subscription.subscription.status
-              )
               userSubscription = subscription
               subscriptionError = nil
               pendingSubscriptionPriceId = nil

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -2137,7 +2137,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         let usageLimiter = FloatingBarUsageLimiter.shared
         if usageLimiter.isLimitReached {
             log("ChatProvider: sendMessage blocked — free-tier monthly chat limit reached")
-            errorMessage = "You've hit your monthly limit of \(FloatingBarUsageLimiter.monthlyFreeLimit) free messages. Upgrade to keep chatting."
+            errorMessage = "You've reached \(usageLimiter.limitDescription). Upgrade to keep chatting."
             NotificationCenter.default.post(
                 name: .showUsageLimitPopup,
                 object: nil,

--- a/desktop/Desktop/Tests/FloatingBarUsageLimiterTests.swift
+++ b/desktop/Desktop/Tests/FloatingBarUsageLimiterTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class FloatingBarUsageLimiterTests: XCTestCase {
+
+  private func makeQuota(
+    plan: String = "Free",
+    unit: String = "questions",
+    used: Double = 0,
+    limit: Double? = 30,
+    percent: Double = 0,
+    allowed: Bool = true,
+    resetAt: Int? = nil
+  ) throws -> APIClient.ChatUsageQuota {
+    var json: [String: Any] = [
+      "plan": plan,
+      "plan_type": "basic",
+      "unit": unit,
+      "used": used,
+      "percent": percent,
+      "allowed": allowed,
+    ]
+    if let limit { json["limit"] = limit }
+    if let resetAt { json["reset_at"] = resetAt }
+    let data = try JSONSerialization.data(withJSONObject: json)
+    return try JSONDecoder().decode(APIClient.ChatUsageQuota.self, from: data)
+  }
+
+  // MARK: - No quota snapshot
+
+  func testNoQuotaAllowsQuery() {
+    let limiter = FloatingBarUsageLimiter()
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, .max)
+    XCTAssertEqual(limiter.limitDescription, "your monthly free message limit")
+  }
+
+  // MARK: - Question-based quota (Free / Operator / Unlimited)
+
+  func testBelowLimitAllowsQuery() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 10, limit: 30, percent: 33, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, 20)
+  }
+
+  func testExactlyAtLimitBlocks() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 30, limit: 30, percent: 100, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertTrue(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, 0)
+  }
+
+  func testRecordQueryPushesToLimit() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 29, limit: 30, percent: 96, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, 1)
+
+    limiter.recordQuery()
+    XCTAssertTrue(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, 0)
+  }
+
+  func testServerDeniedBlocks() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 30, limit: 30, percent: 100, allowed: false)
+    limiter.applyQuota(quota)
+    XCTAssertTrue(limiter.isLimitReached)
+  }
+
+  // MARK: - Cost-based quota (Architect / Pro)
+
+  func testCostUsdDoesNotApplyOptimisticDelta() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(
+      plan: "Architect", unit: "cost_usd", used: 399, limit: 400, percent: 99, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertFalse(limiter.isLimitReached)
+    // recordQuery should NOT push to limit for cost_usd
+    limiter.recordQuery()
+    limiter.recordQuery()
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, .max)
+  }
+
+  func testCostUsdServerDeniedBlocks() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(
+      plan: "Architect", unit: "cost_usd", used: 420, limit: 400, percent: 105, allowed: false)
+    limiter.applyQuota(quota)
+    XCTAssertTrue(limiter.isLimitReached)
+  }
+
+  // MARK: - limitDescription
+
+  func testLimitDescriptionQuestions() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 10, limit: 30, percent: 33, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertEqual(limiter.limitDescription, "30 Free messages this month")
+  }
+
+  func testLimitDescriptionCostUsd() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(
+      plan: "Architect", unit: "cost_usd", used: 50, limit: 400, percent: 12, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertEqual(limiter.limitDescription, "your $400 Architect monthly spend limit")
+  }
+
+  // MARK: - applyQuota resets optimistic delta
+
+  func testApplyQuotaResetsOptimisticDelta() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 10, limit: 30, percent: 33, allowed: true)
+    limiter.applyQuota(quota)
+    limiter.recordQuery()
+    limiter.recordQuery()
+    XCTAssertEqual(limiter.optimisticDelta, 2)
+
+    let freshQuota = try makeQuota(plan: "Free", used: 12, limit: 30, percent: 40, allowed: true)
+    limiter.applyQuota(freshQuota)
+    XCTAssertEqual(limiter.optimisticDelta, 0)
+    XCTAssertEqual(limiter.remainingQueries, 18)
+  }
+
+  // MARK: - reset() clears all state
+
+  func testResetClearsAll() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Plus", used: 500, limit: 500, percent: 100, allowed: false)
+    limiter.applyQuota(quota)
+    limiter.applyPlan(plan: .unlimited, status: .active)
+    limiter.recordQuery()
+    XCTAssertTrue(limiter.hasPaidPlan)
+
+    limiter.reset()
+    XCTAssertNil(limiter.serverQuota)
+    XCTAssertEqual(limiter.optimisticDelta, 0)
+    XCTAssertFalse(limiter.hasPaidPlan)
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, .max)
+  }
+
+  // MARK: - applyPlan
+
+  func testApplyPlanBasicIsNotPaid() {
+    let limiter = FloatingBarUsageLimiter()
+    limiter.applyPlan(plan: .basic, status: .active)
+    XCTAssertFalse(limiter.hasPaidPlan)
+  }
+
+  func testApplyPlanOperatorActiveIsPaid() {
+    let limiter = FloatingBarUsageLimiter()
+    limiter.applyPlan(plan: .operator, status: .active)
+    XCTAssertTrue(limiter.hasPaidPlan)
+  }
+
+  func testApplyPlanInactiveIsNotPaid() {
+    let limiter = FloatingBarUsageLimiter()
+    limiter.applyPlan(plan: .operator, status: .inactive)
+    XCTAssertFalse(limiter.hasPaidPlan)
+  }
+}

--- a/desktop/Desktop/Tests/SubscriptionInfoDecoderTests.swift
+++ b/desktop/Desktop/Tests/SubscriptionInfoDecoderTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SubscriptionInfoDecoderTests: XCTestCase {
+
+  // MARK: - Baseline decoding (no deprecation fields)
+
+  func testDecodeBasicSubscription() throws {
+    let json = """
+      {
+        "plan": "basic",
+        "status": "active",
+        "current_period_end": null,
+        "stripe_subscription_id": null,
+        "current_price_id": null,
+        "features": [],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": 3600,
+          "words_transcribed": 10000,
+          "insights_gained": 50,
+          "memories_created": 100
+        }
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .basic)
+    XCTAssertEqual(info.status, .active)
+    XCTAssertNil(info.deprecated)
+    XCTAssertNil(info.deprecationMessage)
+  }
+
+  func testDecodeOperatorPlan() throws {
+    let json = """
+      {
+        "plan": "operator",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_abc",
+        "current_price_id": "price_xyz",
+        "features": ["chat_500"],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        }
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .operator)
+    XCTAssertEqual(info.status, .active)
+    XCTAssertNil(info.deprecated)
+  }
+
+  // MARK: - Deprecation fields
+
+  func testDecodeDeprecatedUnlimited() throws {
+    let json = """
+      {
+        "plan": "unlimited",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_old",
+        "current_price_id": "price_old",
+        "features": ["chat_500"],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        },
+        "deprecated": true,
+        "deprecation_message": "Your Unlimited plan is being retired. Try the Operator plan."
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .unlimited)
+    XCTAssertEqual(info.deprecated, true)
+    XCTAssertEqual(
+      info.deprecationMessage, "Your Unlimited plan is being retired. Try the Operator plan.")
+  }
+
+  func testDecodeDeprecatedFalse() throws {
+    let json = """
+      {
+        "plan": "operator",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_new",
+        "current_price_id": "price_new",
+        "features": [],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        },
+        "deprecated": false
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.deprecated, false)
+    XCTAssertNil(info.deprecationMessage)
+  }
+
+  func testDecodeProPlan() throws {
+    let json = """
+      {
+        "plan": "pro",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_pro",
+        "current_price_id": "price_pro",
+        "features": ["automations"],
+        "cancel_at_period_end": true,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        }
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .pro)
+    XCTAssertTrue(info.cancelAtPeriodEnd)
+    XCTAssertNil(info.deprecated)
+  }
+}


### PR DESCRIPTION
## Summary

Implements 3 desktop-side changes for the subscription restructure (#6734):

- **F3 (HIGH)**: Replace local UserDefaults-based query counter with server-backed `/v1/users/me/usage-quota` endpoint. Floating bar and chat provider now display server-derived limits instead of hardcoded "30 free messages".
- **F8 (MEDIUM)**: Confirmed `operator` case already exists in `SubscriptionPlanType` enum — no code change needed.
- **Deprecation notice**: Added conditional banner on Plan & Usage settings page for Unlimited subscribers when backend returns `deprecated: true`. Includes server message or fallback text and "Try Operator" CTA button.

## Changes

| File | Change |
|------|--------|
| `FloatingBarUsageLimiter.swift` | Replaced local timestamp counter with server quota + optimistic delta pattern |
| `APIClient.swift` | Added `deprecated` and `deprecationMessage` optional fields to `UserSubscriptionInfo` |
| `AuthService.swift` | Reset quota limiter state on sign-out |
| `FloatingControlBarWindow.swift` | Dynamic limit description in floating bar error message |
| `ChatProvider.swift` | Dynamic limit description in chat error message |
| `SettingsPage.swift` | Deprecation banner + post-checkout quota sync |
| `FloatingBarUsageLimiterTests.swift` | 14 unit tests for quota logic |
| `SubscriptionInfoDecoderTests.swift` | 5 unit tests for subscription model decoding |

## Test Plan

### Unit Tests (19 total)
- **FloatingBarUsageLimiterTests** (14 tests): No quota, below/at limit, recordQuery push, server denied, cost_usd skip, limitDescription (questions + cost_usd), applyQuota reset, reset clears all, applyPlan basic/operator/inactive
- **SubscriptionInfoDecoderTests** (5 tests): Basic, Operator, Pro plan decoding, deprecated=true with message, deprecated=false

### Live Testing
- **L1**: Built named bundle `sub-6734`, injected auth, navigated to Plan & Usage. App displays "Unlimited (legacy)" plan and "67 / 500" from server quota. No crash.
- **L2**: App wired to production backend via `--yolo`. Quota endpoint returns real data. Subscription decodes correctly including absent deprecation fields.

## Risks / Edge Cases
- Deprecation banner depends on backend PR #6744 to return `deprecated: true` — currently renders as hidden (correct for non-deprecated plans)
- Cost-based quotas (Architect) deliberately skip optimistic delta — cannot estimate per-query cost client-side
- If quota endpoint fails, limiter defaults to "allow" (server enforces on actual query)

Closes #6734 (desktop scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)