### PR TITLE
perf(infra): enable uvloop for all uvicorn-based services

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,4 +54,4 @@ COPY --from=builder /opt/venv /opt/venv
 COPY backend/ .
 
 EXPOSE 8080
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--loop", "uvloop"]

--- a/backend/agent-proxy/Dockerfile
+++ b/backend/agent-proxy/Dockerfile
@@ -9,4 +9,4 @@ COPY backend/agent-proxy/main.py .
 
 EXPOSE 8080
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--loop", "uvloop"]

--- a/backend/agent-proxy/requirements.txt
+++ b/backend/agent-proxy/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
+uvloop==0.20.0
 websockets==12.0
 firebase-admin==6.5.0
 cryptography

--- a/backend/diarizer/Dockerfile
+++ b/backend/diarizer/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=builder /opt/venv /opt/venv
 COPY backend/diarizer/ .
 
 EXPOSE 8080
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--loop", "uvloop"]

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -112,6 +112,7 @@ typing-extensions==4.15.0
 tzdata==2025.3
 urllib3==2.6.2
 uvicorn==0.40.0
+uvloop==0.20.0
 yarl==1.22.0
 zipp==3.23.0
 

--- a/backend/modal/Dockerfile
+++ b/backend/modal/Dockerfile
@@ -30,4 +30,4 @@ COPY backend/models /app/models
 COPY backend/modal/ .
 
 EXPOSE 8080
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--loop", "uvloop"]

--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -62,4 +62,4 @@ COPY backend/pusher/ ./pusher/
 COPY backend/google-credentials.json ./google-credentials.json
 
 EXPOSE 8080
-CMD ["uvicorn", "pusher.main:app", "--host", "0.0.0.0", "--port", "8080", "--ws-ping-interval", "20", "--ws-ping-timeout", "20"]
+CMD ["uvicorn", "pusher.main:app", "--host", "0.0.0.0", "--port", "8080", "--ws-ping-interval", "20", "--ws-ping-timeout", "20", "--loop", "uvloop"]

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -4,6 +4,7 @@
 # Web framework
 fastapi==0.112.0
 uvicorn==0.30.5
+uvloop==0.20.0
 starlette==0.37.2
 websockets==12.0
 httpx==0.28.0


### PR DESCRIPTION
## Summary
- Enable `uvloop` as the asyncio event loop for **all 5 uvicorn-based services** via `--loop uvloop` flag
- Add `uvloop==0.20.0` to services missing the dependency (pusher, diarizer, agent-proxy)
- uvloop is a drop-in libuv-based event loop providing 2-4x faster async I/O scheduling

## Context
Follows PR #6377 which moved all HTTP calls to async httpx with semaphore-bounded concurrency. uvloop accelerates every async operation: httpx calls, WebSocket connections, semaphore acquisition, `asyncio.sleep()`, and `run_in_executor()` dispatch.

## Services covered

| Service | Dockerfile | Requirements change | Async patterns | Notes |
|---------|-----------|-------------------|----------------|-------|
| **Backend** | `--loop uvloop` added | Already had `uvloop==0.20.0` | Heavy async (httpx, WS, semaphores) | Primary API server |
| **Pusher** | `--loop uvloop` added | `uvloop==0.20.0` added | Async WS, streaming | Real-time data hub |
| **Diarizer** | `--loop uvloop` added | `uvloop==0.20.0` added | Sync endpoints (torch/CUDA in thread pool) | GPU service |
| **Agent-proxy** | `--loop uvloop` added | `uvloop==0.20.0` added | Heavy async (WS bridge, GCE lifecycle) | VM management |
| **Modal (VAD + speaker-id)** | `--loop uvloop` added | Already has via `-r ../requirements.txt` | Sync endpoints (torch/CUDA in thread pool) | GPU service, VAD GKE |

**Not changed:**
- Notifications job (`python job.py` — not uvicorn)
- Test harness (not production)

## Changes
| File | Change |
|------|--------|
| `backend/Dockerfile` | Add `--loop uvloop` to uvicorn CMD |
| `backend/pusher/Dockerfile` | Add `--loop uvloop` to uvicorn CMD |
| `backend/pusher/requirements.txt` | Add `uvloop==0.20.0` |
| `backend/diarizer/Dockerfile` | Add `--loop uvloop` to uvicorn CMD |
| `backend/diarizer/requirements.txt` | Add `uvloop==0.20.0` |
| `backend/agent-proxy/Dockerfile` | Add `--loop uvloop` to uvicorn CMD |
| `backend/agent-proxy/requirements.txt` | Add `uvloop==0.20.0` |
| `backend/modal/Dockerfile` | Add `--loop uvloop` to uvicorn CMD |

## Test plan
- [x] Verified `uvloop` imports and works with all async patterns (semaphores, `run_in_executor`, httpx, WebSocket)
- [x] Verified sync endpoints (diarizer/VAD pattern) work correctly under uvloop (thread pool unaffected)
- [x] Real backend started with `--loop uvloop`, served HTTP and WebSocket `/v4/listen` traffic
- [x] curl tests: `/v1/users/profile`, `/v1/conversations`, `/v3/memories`, `/v1/action-items`, `/v1/approved-apps` — all 200
- [x] wscat/WebSocket: `/v4/listen` connected, Deepgram STT started, keepalive ping received
- [ ] Deploy to dev and verify all services start with uvloop

## Risks
- **Very low** — uvloop is mature, used by FastAPI/uvicorn in production widely
- Sync GPU endpoints (diarizer, VAD) run in thread pool; uvloop only manages the event loop, not CUDA ops
- `--loop uvloop` means startup hard-fails if dep is missing (desired fail-fast vs silent fallback)

Closes #6748

_by AI for @beastoin_