### PR TITLE
docs(backend): refresh stale chat-cap docstring in get_plan_limits

### DIFF
--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -293,8 +293,8 @@ def get_plan_limits(plan: PlanType) -> PlanLimits:
 
     Chat caps:
       - Free: question count
-      - Oracle + legacy Unlimited: question count (200/mo default)
-      - Pro (Architect): dollar cap ($400/mo default)
+      - Operator + legacy Unlimited: question count (PLUS_CHAT_QUESTIONS_PER_MONTH default)
+      - Pro (Architect): dollar cap (PRO_CHAT_COST_USD_PER_MONTH default)
     """
     if plan in (PlanType.unlimited, PlanType.operator):
         return PlanLimits(


### PR DESCRIPTION
Plan rename Oracle→Operator (PR #6717/#6723) and the bumped `PLUS_CHAT_QUESTIONS_PER_MONTH=500` left the `get_plan_limits` docstring quoting an old plan name and an old default. Reference the module constants instead so the doc stops drifting on the next bump.

No code/runtime change.