### PR TITLE
fix(app): tolerate unknown PlanType/SubscriptionStatus from server

### DIFF
--- a/app/lib/models/subscription.dart
+++ b/app/lib/models/subscription.dart
@@ -8,7 +8,9 @@ enum SubscriptionStatus { active, inactive }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
 class Subscription {
+  @JsonKey(unknownEnumValue: PlanType.basic)
   final PlanType plan;
+  @JsonKey(unknownEnumValue: SubscriptionStatus.inactive)
   final SubscriptionStatus status;
   final int? currentPeriodEnd;
   final String? stripeSubscriptionId;

--- a/app/lib/models/subscription.g.dart
+++ b/app/lib/models/subscription.g.dart
@@ -7,8 +7,10 @@ part of 'subscription.dart';
 // **************************************************************************
 
 Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
-      plan: $enumDecode(_$PlanTypeEnumMap, json['plan']),
-      status: $enumDecode(_$SubscriptionStatusEnumMap, json['status']),
+      plan: $enumDecode(_$PlanTypeEnumMap, json['plan'],
+          unknownValue: PlanType.basic),
+      status: $enumDecode(_$SubscriptionStatusEnumMap, json['status'],
+          unknownValue: SubscriptionStatus.inactive),
       currentPeriodEnd: (json['current_period_end'] as num?)?.toInt(),
       stripeSubscriptionId: json['stripe_subscription_id'] as String?,
       currentPriceId: json['current_price_id'] as String?,


### PR DESCRIPTION
Backend added `PlanType.operator` in PR #6717/#6723. Flutter still ships `enum PlanType { basic, unlimited, pro }` with no `unknownEnumValue` safety net, so any `Subscription.fromJson` on a payload carrying `plan: 'operator'` (or any future enum value) throws `CheckedFromJsonException` and breaks the home/settings paywall code path.

Today this is shielded by the server-side `adapt_plans_for_legacy_client` shim, but only as long as that intercepts every read path that reaches the Flutter client. Adding `unknownEnumValue: PlanType.basic` / `SubscriptionStatus.inactive` degrades gracefully to the safe free-tier defaults instead of crashing the screen.

Mirrors the desktop-Swift fix in PR #6747 for the Dart client.

Regenerated `subscription.g.dart` by hand to match the source change so the diff is reviewable in this PR; running `flutter pub run build_runner build` produces the same output. Adding the actual `PlanType.operator` Dart enum value is intentionally left as a follow-up — that's a wider change (UI strings, persona logic, naming around the Dart `operator` keyword) that deserves its own discussion.