### PR TITLE
observability(backend): log when should_show_new_plans fail-opens on parse error

### DIFF
--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -99,9 +99,14 @@ def should_show_new_plans(platform: Optional[str], app_version: Optional[str]) -
 
     try:
         return _compare_versions(app_version, NEW_PLANS_MIN_DESKTOP_VERSION) >= 0
-    except Exception:
+    except Exception as e:
         # Malformed version — fail-open on macOS rather than show the old
-        # catalog to a desktop client.
+        # catalog to a desktop client. Logged so ops can distinguish a real
+        # parser regression from a one-off bad header.
+        logger.warning(
+            f"should_show_new_plans: failed to parse X-App-Version, falling open "
+            f"(platform={sanitize(str(platform))} version={sanitize(str(app_version))} err={sanitize(str(e))})"
+        )
         return True
 
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -102,10 +102,15 @@ def should_show_new_plans(platform: Optional[str], app_version: Optional[str]) -
     except Exception as e:
         # Malformed version — fail-open on macOS rather than show the old
         # catalog to a desktop client. Logged so ops can distinguish a real
-        # parser regression from a one-off bad header.
+        # parser regression from a one-off bad header. Newline / CR are
+        # escaped before sanitize() so a crafted X-App-Version header cannot
+        # forge synthetic log lines (CWE-117).
+        def _safe(v):
+            return sanitize(str(v).replace('\r', '\\r').replace('\n', '\\n'))
+
         logger.warning(
             f"should_show_new_plans: failed to parse X-App-Version, falling open "
-            f"(platform={sanitize(str(platform))} version={sanitize(str(app_version))} err={sanitize(str(e))})"
+            f"(platform={_safe(platform)} version={_safe(app_version)} err={_safe(e)})"
         )
         return True
 


### PR DESCRIPTION
The malformed-version branch in `should_show_new_plans` intentionally falls open to `True` so a real desktop user with a one-off bad `X-App-Version` header doesn't get bumped back to the legacy catalog (per the existing comment and PR #6730). The branch is silent today, so a regression in `_compare_versions` or a CDN that mangles the header surfaces the same way as "everyone's headers are fine".

Adds a single `logger.warning` with sanitized platform/version/err so ops can tell the two apart. No behavior change — the function still returns `True` exactly when it did before.

Sanitization via `utils.log_sanitizer.sanitize` per backend logging guidance.

Tested manually that the line trips when `app_version='not-a-version'`.