### PR TITLE
perf(backend): fetch only the folders populate_folder_names actually needs

### DIFF
--- a/backend/database/folders.py
+++ b/backend/database/folders.py
@@ -102,6 +102,34 @@ def get_folder(uid: str, folder_id: str) -> Optional[dict]:
     return None
 
 
+def get_folders_by_ids(uid: str, folder_ids: List[str]) -> List[dict]:
+    """Batch-fetch only the folders the caller actually needs, in a single
+    Firestore round trip via ``db.get_all`` regardless of how many ids are
+    requested. Missing ids are silently dropped — the returned list contains
+    only the folders that exist (caller can detect omissions by comparing
+    returned ids against the input set).
+
+    Use this over ``get_folder`` in a loop whenever the set of needed ids is
+    known up front (e.g. enrichment from a webhook or list payload), and
+    over ``get_folders`` whenever you only need a small subset of the user's
+    full folder collection.
+    """
+    if not folder_ids:
+        return []
+
+    user_ref = db.collection('users').document(uid)
+    folders_collection = user_ref.collection('folders')
+    refs = [folders_collection.document(folder_id) for folder_id in folder_ids]
+
+    folders = []
+    for doc in db.get_all(refs):
+        if doc.exists:
+            folder_data = doc.to_dict()
+            folder_data['id'] = doc.id
+            folders.append(folder_data)
+    return folders
+
+
 def create_folder(
     uid: str,
     name: str,

--- a/backend/tests/unit/test_folder_name_enrichment.py
+++ b/backend/tests/unit/test_folder_name_enrichment.py
@@ -127,17 +127,29 @@ from utils.conversations.render import populate_folder_names, populate_speaker_n
 # ---------------------------------------------------------------------------
 
 
+def _folder_lookup(table: dict):
+    """Build a side_effect that returns table[folder_id] (None if missing)
+    while also accepting the (uid, folder_id) signature get_folder uses."""
+
+    def _side_effect(_uid, folder_id):
+        return table.get(folder_id)
+
+    return _side_effect
+
+
 class TestAddFolderNamesToConversations:
     """Tests for populate_folder_names in developer API."""
 
     def setup_method(self):
         _mock_get_folders.reset_mock()
+        _mock_get_folder.reset_mock(side_effect=True)
+        _mock_get_folder.return_value = None
 
     def test_conversations_with_folder_id_get_folder_name(self):
-        _mock_get_folders.return_value = [
-            {'id': 'folder1', 'name': 'Work'},
-            {'id': 'folder2', 'name': 'Personal'},
-        ]
+        _mock_get_folder.side_effect = _folder_lookup({
+            'folder1': {'id': 'folder1', 'name': 'Work'},
+            'folder2': {'id': 'folder2', 'name': 'Personal'},
+        })
         conversations = [
             {'id': 'conv1', 'folder_id': 'folder1'},
             {'id': 'conv2', 'folder_id': 'folder2'},
@@ -146,7 +158,10 @@ class TestAddFolderNamesToConversations:
 
         assert conversations[0]['folder_name'] == 'Work'
         assert conversations[1]['folder_name'] == 'Personal'
-        _mock_get_folders.assert_called_once_with('uid1')
+        # One get_folder call per distinct folder_id; the old all-folders scan
+        # must not be invoked.
+        assert _mock_get_folder.call_count == 2
+        _mock_get_folders.assert_not_called()
 
     def test_conversations_without_folder_id_get_none(self):
         conversations = [
@@ -157,12 +172,12 @@ class TestAddFolderNamesToConversations:
 
         assert conversations[0]['folder_name'] is None
         assert conversations[1]['folder_name'] is None
-        _mock_get_folders.assert_not_called()
+        _mock_get_folder.assert_not_called()
 
     def test_folder_id_not_found_in_db_returns_none(self):
-        _mock_get_folders.return_value = [
-            {'id': 'folder1', 'name': 'Work'},
-        ]
+        _mock_get_folder.side_effect = _folder_lookup({
+            'folder1': {'id': 'folder1', 'name': 'Work'},
+        })
         conversations = [
             {'id': 'conv1', 'folder_id': 'deleted_folder'},
         ]
@@ -171,9 +186,9 @@ class TestAddFolderNamesToConversations:
         assert conversations[0]['folder_name'] is None
 
     def test_mixed_conversations_with_and_without_folder_id(self):
-        _mock_get_folders.return_value = [
-            {'id': 'folder1', 'name': 'Work'},
-        ]
+        _mock_get_folder.side_effect = _folder_lookup({
+            'folder1': {'id': 'folder1', 'name': 'Work'},
+        })
         conversations = [
             {'id': 'conv1', 'folder_id': 'folder1'},
             {'id': 'conv2', 'folder_id': None},
@@ -190,14 +205,15 @@ class TestAddFolderNamesToConversations:
         populate_folder_names('uid1', conversations)
 
         assert conversations == []
-        _mock_get_folders.assert_not_called()
+        _mock_get_folder.assert_not_called()
 
-    def test_batch_fetches_all_folders_once(self):
-        """Verify N+1 avoidance: get_folders is called only once regardless of conversation count."""
-        _mock_get_folders.return_value = [
-            {'id': 'f1', 'name': 'Work'},
-            {'id': 'f2', 'name': 'Personal'},
-        ]
+    def test_only_distinct_folder_ids_are_fetched(self):
+        """Per-id fetch invariant: get_folder is called exactly once per
+        distinct folder_id, regardless of conversation count."""
+        _mock_get_folder.side_effect = _folder_lookup({
+            'f1': {'id': 'f1', 'name': 'Work'},
+            'f2': {'id': 'f2', 'name': 'Personal'},
+        })
         conversations = [
             {'id': 'conv1', 'folder_id': 'f1'},
             {'id': 'conv2', 'folder_id': 'f2'},
@@ -205,7 +221,8 @@ class TestAddFolderNamesToConversations:
         ]
         populate_folder_names('uid1', conversations)
 
-        assert _mock_get_folders.call_count == 1
+        assert _mock_get_folder.call_count == 2  # f1 and f2 each fetched once
+        _mock_get_folders.assert_not_called()
 
 
 class TestAddFolderNamesWebhookPayload:
@@ -213,15 +230,20 @@ class TestAddFolderNamesWebhookPayload:
 
     def setup_method(self):
         _mock_get_folders.reset_mock()
+        _mock_get_folder.reset_mock(side_effect=True)
+        _mock_get_folder.return_value = None
 
     def test_payload_with_folder_id_gets_folder_name(self):
-        _mock_get_folders.return_value = [{'id': 'folder1', 'name': 'Work'}]
+        _mock_get_folder.side_effect = _folder_lookup({
+            'folder1': {'id': 'folder1', 'name': 'Work'},
+        })
         payload = {'folder_id': 'folder1'}
 
         populate_folder_names('uid1', [payload])
 
         assert payload['folder_name'] == 'Work'
-        _mock_get_folders.assert_called_once_with('uid1')
+        _mock_get_folder.assert_called_once_with('uid1', 'folder1')
+        _mock_get_folders.assert_not_called()
 
     def test_payload_without_folder_id_gets_none(self):
         payload = {'folder_id': None}
@@ -229,7 +251,7 @@ class TestAddFolderNamesWebhookPayload:
         populate_folder_names('uid1', [payload])
 
         assert payload['folder_name'] is None
-        _mock_get_folders.assert_not_called()
+        _mock_get_folder.assert_not_called()
 
     def test_payload_missing_folder_id_key_gets_none(self):
         payload = {}
@@ -237,10 +259,10 @@ class TestAddFolderNamesWebhookPayload:
         populate_folder_names('uid1', [payload])
 
         assert payload['folder_name'] is None
-        _mock_get_folders.assert_not_called()
+        _mock_get_folder.assert_not_called()
 
     def test_folder_not_found_in_db_returns_none(self):
-        _mock_get_folders.return_value = []
+        # default _mock_get_folder.return_value=None → unknown folder yields None
         payload = {'folder_id': 'deleted_folder'}
 
         populate_folder_names('uid1', [payload])

--- a/backend/tests/unit/test_folder_name_enrichment.py
+++ b/backend/tests/unit/test_folder_name_enrichment.py
@@ -74,8 +74,10 @@ users_mod.get_people_by_ids = MagicMock(return_value=[])
 folders_mod = sys.modules["database.folders"]
 _mock_get_folders = MagicMock(return_value=[])
 _mock_get_folder = MagicMock(return_value=None)
+_mock_get_folders_by_ids = MagicMock(return_value=[])
 folders_mod.get_folders = _mock_get_folders
 folders_mod.get_folder = _mock_get_folder
+folders_mod.get_folders_by_ids = _mock_get_folders_by_ids
 
 # ---------------------------------------------------------------------------
 # Stub firebase_admin
@@ -127,12 +129,13 @@ from utils.conversations.render import populate_folder_names, populate_speaker_n
 # ---------------------------------------------------------------------------
 
 
-def _folder_lookup(table: dict):
-    """Build a side_effect that returns table[folder_id] (None if missing)
-    while also accepting the (uid, folder_id) signature get_folder uses."""
+def _batch_lookup(table: dict):
+    """Build a side_effect for get_folders_by_ids that returns the matching
+    folder dicts for the requested ids (missing ids are silently dropped,
+    matching real Firestore get_all behaviour)."""
 
-    def _side_effect(_uid, folder_id):
-        return table.get(folder_id)
+    def _side_effect(_uid, folder_ids):
+        return [table[fid] for fid in folder_ids if fid in table]
 
     return _side_effect
 
@@ -144,12 +147,16 @@ class TestAddFolderNamesToConversations:
         _mock_get_folders.reset_mock()
         _mock_get_folder.reset_mock(side_effect=True)
         _mock_get_folder.return_value = None
+        _mock_get_folders_by_ids.reset_mock(side_effect=True)
+        _mock_get_folders_by_ids.return_value = []
 
     def test_conversations_with_folder_id_get_folder_name(self):
-        _mock_get_folder.side_effect = _folder_lookup({
-            'folder1': {'id': 'folder1', 'name': 'Work'},
-            'folder2': {'id': 'folder2', 'name': 'Personal'},
-        })
+        _mock_get_folders_by_ids.side_effect = _batch_lookup(
+            {
+                'folder1': {'id': 'folder1', 'name': 'Work'},
+                'folder2': {'id': 'folder2', 'name': 'Personal'},
+            }
+        )
         conversations = [
             {'id': 'conv1', 'folder_id': 'folder1'},
             {'id': 'conv2', 'folder_id': 'folder2'},
@@ -158,9 +165,10 @@ class TestAddFolderNamesToConversations:
 
         assert conversations[0]['folder_name'] == 'Work'
         assert conversations[1]['folder_name'] == 'Personal'
-        # One get_folder call per distinct folder_id; the old all-folders scan
-        # must not be invoked.
-        assert _mock_get_folder.call_count == 2
+        # One batch call total — neither the per-id loop nor the all-folders
+        # scan should be invoked.
+        assert _mock_get_folders_by_ids.call_count == 1
+        _mock_get_folder.assert_not_called()
         _mock_get_folders.assert_not_called()
 
     def test_conversations_without_folder_id_get_none(self):
@@ -172,12 +180,14 @@ class TestAddFolderNamesToConversations:
 
         assert conversations[0]['folder_name'] is None
         assert conversations[1]['folder_name'] is None
-        _mock_get_folder.assert_not_called()
+        _mock_get_folders_by_ids.assert_not_called()
 
     def test_folder_id_not_found_in_db_returns_none(self):
-        _mock_get_folder.side_effect = _folder_lookup({
-            'folder1': {'id': 'folder1', 'name': 'Work'},
-        })
+        _mock_get_folders_by_ids.side_effect = _batch_lookup(
+            {
+                'folder1': {'id': 'folder1', 'name': 'Work'},
+            }
+        )
         conversations = [
             {'id': 'conv1', 'folder_id': 'deleted_folder'},
         ]
@@ -186,9 +196,11 @@ class TestAddFolderNamesToConversations:
         assert conversations[0]['folder_name'] is None
 
     def test_mixed_conversations_with_and_without_folder_id(self):
-        _mock_get_folder.side_effect = _folder_lookup({
-            'folder1': {'id': 'folder1', 'name': 'Work'},
-        })
+        _mock_get_folders_by_ids.side_effect = _batch_lookup(
+            {
+                'folder1': {'id': 'folder1', 'name': 'Work'},
+            }
+        )
         conversations = [
             {'id': 'conv1', 'folder_id': 'folder1'},
             {'id': 'conv2', 'folder_id': None},
@@ -205,15 +217,18 @@ class TestAddFolderNamesToConversations:
         populate_folder_names('uid1', conversations)
 
         assert conversations == []
-        _mock_get_folder.assert_not_called()
+        _mock_get_folders_by_ids.assert_not_called()
 
-    def test_only_distinct_folder_ids_are_fetched(self):
-        """Per-id fetch invariant: get_folder is called exactly once per
-        distinct folder_id, regardless of conversation count."""
-        _mock_get_folder.side_effect = _folder_lookup({
-            'f1': {'id': 'f1', 'name': 'Work'},
-            'f2': {'id': 'f2', 'name': 'Personal'},
-        })
+    def test_distinct_folder_ids_fetched_in_one_batch(self):
+        """Batch invariant: get_folders_by_ids is called exactly once with
+        the de-duplicated set of folder_ids, regardless of conversation
+        count."""
+        _mock_get_folders_by_ids.side_effect = _batch_lookup(
+            {
+                'f1': {'id': 'f1', 'name': 'Work'},
+                'f2': {'id': 'f2', 'name': 'Personal'},
+            }
+        )
         conversations = [
             {'id': 'conv1', 'folder_id': 'f1'},
             {'id': 'conv2', 'folder_id': 'f2'},
@@ -221,7 +236,11 @@ class TestAddFolderNamesToConversations:
         ]
         populate_folder_names('uid1', conversations)
 
-        assert _mock_get_folder.call_count == 2  # f1 and f2 each fetched once
+        assert _mock_get_folders_by_ids.call_count == 1
+        call_uid, call_ids = _mock_get_folders_by_ids.call_args.args
+        assert call_uid == 'uid1'
+        assert sorted(call_ids) == ['f1', 'f2']  # de-duplicated
+        _mock_get_folder.assert_not_called()
         _mock_get_folders.assert_not_called()
 
 
@@ -232,17 +251,22 @@ class TestAddFolderNamesWebhookPayload:
         _mock_get_folders.reset_mock()
         _mock_get_folder.reset_mock(side_effect=True)
         _mock_get_folder.return_value = None
+        _mock_get_folders_by_ids.reset_mock(side_effect=True)
+        _mock_get_folders_by_ids.return_value = []
 
     def test_payload_with_folder_id_gets_folder_name(self):
-        _mock_get_folder.side_effect = _folder_lookup({
-            'folder1': {'id': 'folder1', 'name': 'Work'},
-        })
+        _mock_get_folders_by_ids.side_effect = _batch_lookup(
+            {
+                'folder1': {'id': 'folder1', 'name': 'Work'},
+            }
+        )
         payload = {'folder_id': 'folder1'}
 
         populate_folder_names('uid1', [payload])
 
         assert payload['folder_name'] == 'Work'
-        _mock_get_folder.assert_called_once_with('uid1', 'folder1')
+        _mock_get_folders_by_ids.assert_called_once_with('uid1', ['folder1'])
+        _mock_get_folder.assert_not_called()
         _mock_get_folders.assert_not_called()
 
     def test_payload_without_folder_id_gets_none(self):
@@ -251,7 +275,7 @@ class TestAddFolderNamesWebhookPayload:
         populate_folder_names('uid1', [payload])
 
         assert payload['folder_name'] is None
-        _mock_get_folder.assert_not_called()
+        _mock_get_folders_by_ids.assert_not_called()
 
     def test_payload_missing_folder_id_key_gets_none(self):
         payload = {}
@@ -259,10 +283,10 @@ class TestAddFolderNamesWebhookPayload:
         populate_folder_names('uid1', [payload])
 
         assert payload['folder_name'] is None
-        _mock_get_folder.assert_not_called()
+        _mock_get_folders_by_ids.assert_not_called()
 
     def test_folder_not_found_in_db_returns_none(self):
-        # default _mock_get_folder.return_value=None → unknown folder yields None
+        # default _mock_get_folders_by_ids.return_value=[] → unknown id yields None
         payload = {'folder_id': 'deleted_folder'}
 
         populate_folder_names('uid1', [payload])

--- a/backend/utils/conversations/render.py
+++ b/backend/utils/conversations/render.py
@@ -49,7 +49,9 @@ def populate_speaker_names(uid: str, conversations: List[Dict]) -> None:
 def populate_folder_names(uid: str, conversations: List[Dict]) -> None:
     """Add folder_name to conversations based on folder_id mappings.
 
-    Mutates conversation dicts in-place. Batch-loads all folder IDs in one query.
+    Mutates conversation dicts in-place. Issues one folders_db.get_folder
+    lookup per distinct folder_id referenced by the input — bounded by the
+    number of distinct ids in the payload (typically 1 for webhooks).
     """
     folder_ids = set()
     for conv in conversations:

--- a/backend/utils/conversations/render.py
+++ b/backend/utils/conversations/render.py
@@ -61,8 +61,15 @@ def populate_folder_names(uid: str, conversations: List[Dict]) -> None:
             conv['folder_name'] = None
         return
 
-    all_folders = folders_db.get_folders(uid)
-    folder_map = {f['id']: f['name'] for f in all_folders}
+    # Fetch only the folder docs we actually need. Webhook callers typically
+    # render 1 conversation with 1 folder_id — pulling the user's full folder
+    # list (folders_db.get_folders) was O(total folders) per webhook, even
+    # for a single-conversation payload.
+    folder_map = {}
+    for folder_id in folder_ids:
+        folder = folders_db.get_folder(uid, folder_id)
+        if folder:
+            folder_map[folder['id']] = folder['name']
 
     for conv in conversations:
         folder_id = conv.get('folder_id')

--- a/backend/utils/conversations/render.py
+++ b/backend/utils/conversations/render.py
@@ -49,9 +49,11 @@ def populate_speaker_names(uid: str, conversations: List[Dict]) -> None:
 def populate_folder_names(uid: str, conversations: List[Dict]) -> None:
     """Add folder_name to conversations based on folder_id mappings.
 
-    Mutates conversation dicts in-place. Issues one folders_db.get_folder
-    lookup per distinct folder_id referenced by the input — bounded by the
-    number of distinct ids in the payload (typically 1 for webhooks).
+    Mutates conversation dicts in-place. Issues a single
+    ``folders_db.get_folders_by_ids`` batch fetch for the distinct folder
+    ids referenced by the input — one Firestore round trip regardless of
+    how many distinct ids are present, instead of an O(distinct_ids) loop
+    of per-id lookups.
     """
     folder_ids = set()
     for conv in conversations:
@@ -63,15 +65,8 @@ def populate_folder_names(uid: str, conversations: List[Dict]) -> None:
             conv['folder_name'] = None
         return
 
-    # Fetch only the folder docs we actually need. Webhook callers typically
-    # render 1 conversation with 1 folder_id — pulling the user's full folder
-    # list (folders_db.get_folders) was O(total folders) per webhook, even
-    # for a single-conversation payload.
-    folder_map = {}
-    for folder_id in folder_ids:
-        folder = folders_db.get_folder(uid, folder_id)
-        if folder:
-            folder_map[folder['id']] = folder['name']
+    folders = folders_db.get_folders_by_ids(uid, list(folder_ids))
+    folder_map = {f['id']: f['name'] for f in folders}
 
     for conv in conversations:
         folder_id = conv.get('folder_id')


### PR DESCRIPTION
`populate_folder_names` (in `backend/utils/conversations/render.py`) was calling `folders_db.get_folders(uid)` — which streams every folder document the user owns — then keeping just the ones referenced by the conversation set. The function is invoked per-payload from webhooks (`utils/webhooks.py:43` calls it with a single-conversation list), so a user with N folders paid O(N) Firestore document reads on every webhook delivery, even when the payload only referenced one `folder_id`.

Switching to per-id `get_folder` lookups bounds the read count by the number of distinct `folder_ids` in the payload (typically 1). Same result, smaller bill, no behavior change.

Trade-off: K serial round-trips instead of one streamed query — fine when K is 0–2 (the webhook case) and still a win for any K < total user folders. Happy to switch to a Firestore `document.get_all()` batch if the team prefers a single round-trip.