### PR TITLE
fix(backend): cancel active stripe subscriptions in delete-account flow

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -155,7 +155,30 @@ def delete_account(
             else:
                 raise
 
-        # 3. Wipe Firestore subcollections in the background — can take minutes
+        # 3. Stop the user being billed for a subscription they no longer
+        #    have an account to manage. Period-end cancel matches the
+        #    existing cancel_subscription helper used elsewhere; flip to
+        #    immediate cancel here if compliance prefers no grace period.
+        #    Stripe failure must not block the deletion flow — the user
+        #    already pressed delete; reconciliation can happen via webhook.
+        try:
+            customer_id = users_db.get_stripe_customer_id(uid)
+            if customer_id:
+                result = stripe_utils.cancel_all_active_subscriptions(customer_id)
+                if result['cancelled']:
+                    logger.info(
+                        f'delete_account stripe period-end-cancel for {uid} '
+                        f'subs={result["cancelled"]} skipped={result["skipped"]}'
+                    )
+                if result['errors']:
+                    logger.error(
+                        f'delete_account stripe partial failures for {uid}: '
+                        f'{sanitize(str(result["errors"]))}'
+                    )
+        except Exception as e:
+            logger.error(f'delete_account stripe cancel raised for {uid}: {sanitize(str(e))}')
+
+        # 4. Wipe Firestore subcollections in the background — can take minutes
         #    for heavy users and would otherwise time out at the load balancer.
         threading.Thread(target=_background_wipe_user_data, args=(uid,), daemon=True).start()
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -87,6 +87,7 @@ pytest tests/unit/test_desktop_migration.py -v
 pytest tests/unit/test_staged_tasks_batch_scores.py -v
 pytest tests/unit/test_dg_start_guard.py -v
 pytest tests/unit/test_available_plans_resilience.py -v
+pytest tests/unit/test_cancel_all_active_subscriptions.py -v
 pytest tests/unit/test_voice_duration_limiter.py -v
 pytest tests/unit/test_async_webhooks.py -v
 pytest tests/unit/test_async_app_integrations.py -v

--- a/backend/tests/unit/test_cancel_all_active_subscriptions.py
+++ b/backend/tests/unit/test_cancel_all_active_subscriptions.py
@@ -1,0 +1,181 @@
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+# Heavy deps must be stubbed before importing utils.stripe so the import
+# does not pull in real GCP/Redis clients.
+sys.modules.setdefault("stripe", MagicMock())
+sys.modules.setdefault("database._client", MagicMock())
+sys.modules.setdefault("database.redis_db", MagicMock())
+
+_database_module = sys.modules.setdefault("database", types.ModuleType("database"))
+_database_module.redis_db = sys.modules["database.redis_db"]
+
+_pycountry_module = sys.modules.setdefault("pycountry", types.ModuleType("pycountry"))
+_pycountry_module.countries = MagicMock()
+
+from utils import stripe as stripe_utils  # noqa: E402
+
+
+def _fake_sub(sub_id, cancel_at_period_end=False):
+    sub = MagicMock()
+    sub.id = sub_id
+    sub.cancel_at_period_end = cancel_at_period_end
+    return sub
+
+
+class _FakeListing:
+    """Mimic stripe.ListObject — only auto_paging_iter is used by the helper."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def auto_paging_iter(self):
+        return iter(self._items)
+
+
+def _setup_stripe(active=None, trialing=None, list_side_effect=None, modify_side_effect=None):
+    stripe_utils.stripe.Subscription = MagicMock()
+
+    def _list(customer, status, limit):
+        if list_side_effect is not None:
+            res = list_side_effect(status)
+            if isinstance(res, Exception):
+                raise res
+            return res
+        if status == 'active':
+            return _FakeListing(active or [])
+        if status == 'trialing':
+            return _FakeListing(trialing or [])
+        return _FakeListing([])
+
+    stripe_utils.stripe.Subscription.list.side_effect = _list
+
+    if modify_side_effect is not None:
+        stripe_utils.stripe.Subscription.modify.side_effect = modify_side_effect
+    else:
+        stripe_utils.stripe.Subscription.modify.return_value = MagicMock()
+
+
+def test_cancels_active_and_trialing_subscriptions():
+    _setup_stripe(
+        active=[_fake_sub('sub_a1'), _fake_sub('sub_a2')],
+        trialing=[_fake_sub('sub_t1')],
+    )
+
+    result = stripe_utils.cancel_all_active_subscriptions('cus_123')
+
+    assert result['cancelled'] == ['sub_a1', 'sub_a2', 'sub_t1']
+    assert result['skipped'] == []
+    assert result['errors'] == []
+
+    modify_calls = stripe_utils.stripe.Subscription.modify.call_args_list
+    assert [c.args[0] for c in modify_calls] == ['sub_a1', 'sub_a2', 'sub_t1']
+    for call in modify_calls:
+        assert call.kwargs == {'cancel_at_period_end': True}
+
+
+def test_idempotent_when_already_scheduled_for_cancellation():
+    _setup_stripe(
+        active=[
+            _fake_sub('sub_already', cancel_at_period_end=True),
+            _fake_sub('sub_fresh'),
+        ],
+    )
+
+    result = stripe_utils.cancel_all_active_subscriptions('cus_123')
+
+    assert result['cancelled'] == ['sub_fresh']
+    assert result['skipped'] == ['sub_already']
+    assert result['errors'] == []
+    # The already-scheduled sub must not be modified again.
+    modified_ids = [c.args[0] for c in stripe_utils.stripe.Subscription.modify.call_args_list]
+    assert 'sub_already' not in modified_ids
+
+
+def test_per_subscription_modify_failure_is_captured_and_loop_continues():
+    def _modify(sub_id, cancel_at_period_end):
+        if sub_id == 'sub_bad':
+            raise RuntimeError('stripe 500 on sub_bad')
+        return MagicMock()
+
+    _setup_stripe(
+        active=[_fake_sub('sub_ok1'), _fake_sub('sub_bad'), _fake_sub('sub_ok2')],
+        modify_side_effect=_modify,
+    )
+
+    result = stripe_utils.cancel_all_active_subscriptions('cus_123')
+
+    assert result['cancelled'] == ['sub_ok1', 'sub_ok2']
+    assert result['skipped'] == []
+    assert result['errors'] == [{'context': 'sub_bad', 'err': 'stripe 500 on sub_bad'}]
+
+
+def test_list_call_failure_for_one_status_does_not_block_the_other():
+    def _list(status):
+        if status == 'active':
+            raise RuntimeError('stripe outage on active list')
+        return _FakeListing([_fake_sub('sub_t1')])
+
+    _setup_stripe(list_side_effect=_list)
+
+    result = stripe_utils.cancel_all_active_subscriptions('cus_123')
+
+    assert result['cancelled'] == ['sub_t1']
+    assert result['skipped'] == []
+    assert result['errors'] == [{'context': 'list:active', 'err': 'stripe outage on active list'}]
+
+
+def test_no_subscriptions_returns_empty_lists():
+    _setup_stripe()
+
+    result = stripe_utils.cancel_all_active_subscriptions('cus_empty')
+
+    assert result == {'cancelled': [], 'skipped': [], 'errors': []}
+    stripe_utils.stripe.Subscription.modify.assert_not_called()
+
+
+def test_pagination_via_auto_paging_iter_processes_all_pages():
+    # 45 active subs across what would be multiple pages — we don't care about
+    # page boundaries here, only that auto_paging_iter is the iteration source
+    # and every sub is processed exactly once.
+    many = [_fake_sub(f'sub_{i}') for i in range(45)]
+    _setup_stripe(active=many)
+
+    result = stripe_utils.cancel_all_active_subscriptions('cus_big')
+
+    assert len(result['cancelled']) == 45
+    assert result['cancelled'] == [f'sub_{i}' for i in range(45)]
+    assert stripe_utils.stripe.Subscription.modify.call_count == 45
+
+
+def test_uniform_error_shape_across_both_failure_paths():
+    """Caller (routers/users.py) only calls sanitize(str(...)) on errors —
+    both shapes must be uniform {'context': str, 'err': str}."""
+
+    def _list(status):
+        if status == 'trialing':
+            raise RuntimeError('list trialing failed')
+        return _FakeListing([_fake_sub('sub_x')])
+
+    def _modify(sub_id, cancel_at_period_end):
+        raise RuntimeError(f'modify {sub_id} failed')
+
+    _setup_stripe(list_side_effect=_list, modify_side_effect=_modify)
+
+    result = stripe_utils.cancel_all_active_subscriptions('cus_mixed')
+
+    assert result['cancelled'] == []
+    for entry in result['errors']:
+        assert set(entry.keys()) == {'context', 'err'}
+        assert isinstance(entry['context'], str)
+        assert isinstance(entry['err'], str)
+
+    contexts = sorted(e['context'] for e in result['errors'])
+    assert contexts == ['list:trialing', 'sub_x']

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -101,7 +101,10 @@ def cancel_all_active_subscriptions(customer_id: str) -> dict:
     partial Stripe outage doesn't abort the surrounding deletion flow.
 
     Returns: {'cancelled': [sub_id, ...], 'skipped': [sub_id, ...],
-              'errors': [{'sub_id'/'status', 'err'}, ...]}.
+              'errors': [{'context': str, 'err': str}, ...]}.
+    `context` is the subscription id for per-sub modify failures and
+    `list:<status>` for list-call failures, so callers can iterate without
+    branching on which key is present.
     """
     cancelled: list[str] = []
     skipped: list[str] = []
@@ -118,9 +121,9 @@ def cancel_all_active_subscriptions(customer_id: str) -> dict:
                     stripe.Subscription.modify(sub.id, cancel_at_period_end=True)
                     cancelled.append(sub.id)
                 except Exception as e:
-                    errors.append({'sub_id': sub.id, 'err': str(e)})
+                    errors.append({'context': sub.id, 'err': str(e)})
         except Exception as e:
-            errors.append({'status': status, 'err': str(e)})
+            errors.append({'context': f'list:{status}', 'err': str(e)})
 
     return {'cancelled': cancelled, 'skipped': skipped, 'errors': errors}
 

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -90,6 +90,41 @@ def cancel_subscription(subscription_id: str):
         return None
 
 
+def cancel_all_active_subscriptions(customer_id: str) -> dict:
+    """Mark every active or trialing Stripe subscription for a customer as
+    cancel_at_period_end. Used by account deletion so the user stops being
+    billed once they no longer have an account to manage the subscription
+    from.
+
+    Idempotent: subscriptions already scheduled for cancellation are skipped,
+    and any per-subscription error is captured rather than raised so a
+    partial Stripe outage doesn't abort the surrounding deletion flow.
+
+    Returns: {'cancelled': [sub_id, ...], 'skipped': [sub_id, ...],
+              'errors': [{'sub_id'/'status', 'err'}, ...]}.
+    """
+    cancelled: list[str] = []
+    skipped: list[str] = []
+    errors: list[dict] = []
+
+    for status in ('active', 'trialing'):
+        try:
+            subs = stripe.Subscription.list(customer=customer_id, status=status, limit=20)
+            for sub in subs.auto_paging_iter():
+                if getattr(sub, 'cancel_at_period_end', False):
+                    skipped.append(sub.id)
+                    continue
+                try:
+                    stripe.Subscription.modify(sub.id, cancel_at_period_end=True)
+                    cancelled.append(sub.id)
+                except Exception as e:
+                    errors.append({'sub_id': sub.id, 'err': str(e)})
+        except Exception as e:
+            errors.append({'status': status, 'err': str(e)})
+
+    return {'cancelled': cancelled, 'skipped': skipped, 'errors': errors}
+
+
 def find_app_subscription_by_customer_id(customer_id: str, app_id: str, uid: str, status_filter: str = 'all'):
     """Find app subscription using customer ID (fast path)."""
     try:


### PR DESCRIPTION
Closes the Stripe gap in the account-deletion flow flagged in #6750.

Today `DELETE /v1/users/delete-account` revokes Firebase auth and wipes Firestore but leaves any Stripe subscription active. The deleted user keeps being charged with no remaining identity to access invoices or self-service the cancellation. PR #6669 (the recent delete-account redesign) explicitly noted *Pinecone + GCS intentionally untouched pending their own cleanup pass* — Stripe is not mentioned, which made it look like a real omission rather than a deferred item.

This PR:
1. Adds `cancel_all_active_subscriptions(customer_id)` to `utils/stripe.py`. It enumerates `active` + `trialing` subscriptions and marks each as `cancel_at_period_end=True`. Idempotent on retry (subs already scheduled for cancellation are skipped) and tolerant of partial Stripe outages (per-sub errors captured rather than raised).
2. Calls the helper from `delete_account` between the Firebase auth revoke and the Firestore wipe trigger. Wrapped in `try/except` so a Stripe outage cannot block the deletion the user already requested — the error is logged via `sanitize()` and reconciliation can happen via the existing Stripe webhook path.

### Choice of period-end vs immediate cancel
Period-end cancel matches the existing `cancel_subscription` helper used elsewhere in this module. If compliance prefers no-grace-period, swap the modify call (or the helper's flag) to `stripe.Subscription.delete(sub.id)` for immediate termination. Happy to update either way.

### Out of scope
Pinecone and GCS cleanup remain deferred per #6669's notes. The Cloud Tasks / Pub-Sub migration for retry + DLQ is tracked in #6750. This PR is the in-place Stripe fix only.