### PR TITLE
fix navigator pop crash on device disconnect

### DIFF
--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -368,7 +368,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                 context.read<DeviceProvider>().updateConnectingStatus(false);
               }
 
-              if (mounted) {
+              if (mounted && Navigator.of(context).canPop()) {
                 Navigator.of(context).pop();
               }
               MixpanelManager().disconnectFriendClicked();


### PR DESCRIPTION
Guard `Navigator.of(context).pop()` with `canPop()` to prevent the `Bad state: No element` crash when the device page is the root route or the stack has already been popped.

Closes #6763

🤖 Generated with [Claude Code](https://claude.com/claude-code)