### PR TITLE
docs(helm): document intentional pusher activeConnectionsPerPod=30 vs backend-listen=22

### DIFF
--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -341,6 +341,10 @@ autoscaling:
       selectPolicy: Max
   # targetCPUUtilizationPercentage: 60
   # targetMemoryUtilizationPercentage: 60
+  # Intentionally higher than backend-listen (22) — pusher's WebSocket
+  # handling profile can absorb 30 concurrent connections per pod, while
+  # backend-listen cannot (see #6752, PR #6732 rollback). Both values are
+  # tuned continuously as the async request pipeline evolves.
   activeConnectionsPerPod: 30
 
 podDisruptionBudget:


### PR DESCRIPTION
## What

Adds a one-line YAML comment to `backend/charts/pusher/prod_omi_pusher_values.yaml` documenting that the asymmetry between `pusher.activeConnectionsPerPod=30` and `backend-listen.activeConnectionsPerPod=22` is intentional, not a missed-rollback bug from PR #6732.

## Why

Issue #6752 was filed to confirm intent. @thainguyensunya confirmed in [#6752 comment](https://github.com/BasedHardware/omi/issues/6752#issuecomment-4267157273):

> The `activeConnectionsPerPod` value of 30 for pusher is intentional. The logic to handle WebSocket traffic of pusher and backend-listen are different. As my observation, backend-listen can't handle 30 `activeConnectionsPerPod` but pusher can. That's why I only rollback the change for backend-listen. Currently there are some changes introduced in **backend-listen** and **pusher** to optimize async requests handling, I believe `activeConnectionsPerPod` will need to be adjusted continuously to optimize the number of backend-listen and pusher pods.

This PR captures that context at the call site so future readers don't have to re-discover it from PR history.

Closes #6752