### PR TITLE
fix(desktop): architect rename + hide current plan from plan picker

### DIFF
--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -3871,7 +3871,8 @@ struct NotificationSettingsResponse: Codable {
 enum SubscriptionPlanType: String, Codable {
   case basic      // display "Free"
   case unlimited  // legacy — display "Unlimited (legacy)"
-  case pro        // display "Architect" — same Stripe IDs, pure rename
+  case architect  // display "Architect" ($400/mo, cost_usd quota)
+  case pro        // backward compat: old Firestore docs may still say "pro"
   case `operator` // new — display "Operator"
 }
 
@@ -4933,7 +4934,7 @@ extension APIClient {
   /// endpoint `/v1/users/me/usage-quota` which reads `users/{uid}/llm_usage/*`.
   struct ChatUsageQuota: Decodable {
     let plan: String       // display name: "Free" | "Plus" | "Pro"
-    let planType: String   // internal id: "basic" | "unlimited" | "pro"
+    let planType: String   // internal id: "basic" | "unlimited" | "architect"
     let unit: String       // "questions" | "cost_usd"
     let used: Double
     let limit: Double?     // nil means unlimited

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -5692,7 +5692,7 @@ struct SettingsContentView: View {
   private var subscriptionPlansForDisplay: [SubscriptionPlanOption] {
     // Oracle (mass-market, green) on the left, Architect/Pro (premium, purple)
     // on the right, legacy Unlimited last if the user is still on it.
-    let order = ["operator": 0, "pro": 1, "unlimited": 2]
+    let order = ["operator": 0, "architect": 1, "unlimited": 2]
     return mergedPlanCatalog.sorted { lhs, rhs in
       let lhsOrder = order[lhs.id, default: Int.max]
       let rhsOrder = order[rhs.id, default: Int.max]
@@ -5719,7 +5719,7 @@ struct SettingsContentView: View {
         return "Operator"
       }
       return "Unlimited (legacy)"
-    case .pro:
+    case .architect, .pro:
       return "Architect"
     case .operator:
       return "Operator"
@@ -5787,7 +5787,7 @@ struct SettingsContentView: View {
     switch planId {
     case "operator", "unlimited":
       return "500 questions per month"
-    case "pro":
+    case "architect":
       return "Power-user AI — thousands of chats + agentic automations"
     default:
       return nil
@@ -5795,9 +5795,9 @@ struct SettingsContentView: View {
   }
 
   private func planAccentColor(for planId: String) -> Color {
-    // Architect (pro) is the premium/purple tier; Oracle + legacy Unlimited
+    // Architect is the premium/purple tier; Operator + legacy Unlimited
     // are the mass-market green tier.
-    planId == "pro" ? OmiColors.purplePrimary : OmiColors.success
+    planId == "architect" ? OmiColors.purplePrimary : OmiColors.success
   }
 
   private func planSummaryText(for plan: SubscriptionPlanOption) -> String {
@@ -5820,7 +5820,7 @@ struct SettingsContentView: View {
     switch planId {
     case "operator", "unlimited":
       return "Most popular"
-    case "pro":
+    case "architect":
       return "Automation + coding"
     default:
       return "Plan"
@@ -5831,7 +5831,7 @@ struct SettingsContentView: View {
     switch planId {
     case "operator", "unlimited":
       return "500 chat questions per month. Shared with mobile and web."
-    case "pro":
+    case "architect":
       return "Power-user AI for heavy agentic workflows and vibe coding."
     default:
       return ""
@@ -5869,7 +5869,7 @@ struct SettingsContentView: View {
 
   private func fallbackFeatures(for planId: String) -> [String] {
     switch planId {
-    case "pro":
+    case "architect":
       return [
         "Automations and vibe coding",
         "Unlimited listening, memories, and insights",
@@ -5893,8 +5893,8 @@ struct SettingsContentView: View {
     if normalized.contains("unlimited") {
       return "unlimited"
     }
-    if normalized.contains("pro") {
-      return "pro"
+    if normalized.contains("architect") || normalized.contains("pro") {
+      return "architect"
     }
     return nil
   }
@@ -5911,8 +5911,8 @@ struct SettingsContentView: View {
       switch planId {
       case "unlimited":
         title = "Plus"
-      case "pro":
-        title = "Omi Pro"
+      case "architect":
+        title = "Architect"
       default:
         title = options.first?.title ?? "Plan"
       }
@@ -5940,8 +5940,10 @@ struct SettingsContentView: View {
     let isSelected = selectedPlanIdForCheckout == plan.id
     let accent = planAccentColor(for: plan.id)
     let isCurrentPlan = isCurrentSubscriptionPlan(plan)
-    let isProUser = userSubscription?.subscription.plan == .pro
-    let isDowngrade = isProUser && plan.id == "unlimited"
+    let isArchitectUser =
+      userSubscription?.subscription.plan == .architect
+      || userSubscription?.subscription.plan == .pro
+    let isDowngrade = isArchitectUser && plan.id == "unlimited"
     let canPurchase = !isCurrentPlan && !isDowngrade
 
     VStack(alignment: .leading, spacing: 16) {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -5690,17 +5690,19 @@ struct SettingsContentView: View {
   }
 
   private var subscriptionPlansForDisplay: [SubscriptionPlanOption] {
-    // Oracle (mass-market, green) on the left, Architect/Pro (premium, purple)
-    // on the right, legacy Unlimited last if the user is still on it.
+    // Operator (mass-market, green) on the left, Architect (premium, purple)
+    // on the right. Hide the user's current plan — they already see it above.
     let order = ["operator": 0, "architect": 1, "unlimited": 2]
-    return mergedPlanCatalog.sorted { lhs, rhs in
-      let lhsOrder = order[lhs.id, default: Int.max]
-      let rhsOrder = order[rhs.id, default: Int.max]
-      if lhsOrder != rhsOrder {
-        return lhsOrder < rhsOrder
+    return mergedPlanCatalog
+      .filter { !isCurrentSubscriptionPlan($0) }
+      .sorted { lhs, rhs in
+        let lhsOrder = order[lhs.id, default: Int.max]
+        let rhsOrder = order[rhs.id, default: Int.max]
+        if lhsOrder != rhsOrder {
+          return lhsOrder < rhsOrder
+        }
+        return lhs.title < rhs.title
       }
-      return lhs.title < rhs.title
-    }
   }
 
   private var currentPlanTitle: String {

--- a/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -157,15 +157,15 @@ struct SettingsSearchItem: Identifiable {
     // Plan and Usage
     SettingsSearchItem(
       name: "Plan and Usage", subtitle: "Subscription status and usage limits",
-      keywords: ["subscription", "billing", "plan", "usage", "stripe", "pro", "unlimited"],
+      keywords: ["subscription", "billing", "plan", "usage", "stripe", "architect", "unlimited"],
       section: .planUsage, icon: "creditcard", settingId: "planusage.overview"),
     SettingsSearchItem(
       name: "Current Plan", subtitle: "See your current subscription and renewal status",
       keywords: ["current plan", "renewal", "billing"], section: .planUsage, icon: "creditcard",
       settingId: "planusage.current"),
     SettingsSearchItem(
-      name: "Upgrade Plan", subtitle: "Buy Plus or Omi Pro",
-      keywords: ["upgrade", "buy", "pricing", "checkout", "pro", "plus", "unlimited"], section: .planUsage,
+      name: "Upgrade Plan", subtitle: "Buy Operator or Architect",
+      keywords: ["upgrade", "buy", "pricing", "checkout", "architect", "operator", "unlimited"], section: .planUsage,
       icon: "creditcard", settingId: "planusage.purchase"),
 
     // About

--- a/desktop/Desktop/Tests/SubscriptionInfoDecoderTests.swift
+++ b/desktop/Desktop/Tests/SubscriptionInfoDecoderTests.swift
@@ -108,14 +108,14 @@ final class SubscriptionInfoDecoderTests: XCTestCase {
     XCTAssertNil(info.deprecationMessage)
   }
 
-  func testDecodeProPlan() throws {
+  func testDecodeArchitectPlan() throws {
     let json = """
       {
-        "plan": "pro",
+        "plan": "architect",
         "status": "active",
         "current_period_end": 1700000000,
-        "stripe_subscription_id": "sub_pro",
-        "current_price_id": "price_pro",
+        "stripe_subscription_id": "sub_architect",
+        "current_price_id": "price_architect",
         "features": ["automations"],
         "cancel_at_period_end": true,
         "limits": {
@@ -127,8 +127,30 @@ final class SubscriptionInfoDecoderTests: XCTestCase {
       }
       """
     let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
-    XCTAssertEqual(info.plan, .pro)
+    XCTAssertEqual(info.plan, .architect)
     XCTAssertTrue(info.cancelAtPeriodEnd)
     XCTAssertNil(info.deprecated)
+  }
+
+  func testDecodeProPlanBackwardCompat() throws {
+    let json = """
+      {
+        "plan": "pro",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_pro",
+        "current_price_id": "price_pro",
+        "features": ["automations"],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        }
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .pro)
   }
 }

--- a/desktop/Desktop/Tests/SubscriptionPlanCatalogMergerTests.swift
+++ b/desktop/Desktop/Tests/SubscriptionPlanCatalogMergerTests.swift
@@ -7,8 +7,8 @@ final class SubscriptionPlanCatalogMergerTests: XCTestCase {
   func testMergeDeduplicatesDuplicatePriceIDsWithoutCrashing() {
     let fallback = [
       SubscriptionPlanOption(
-        id: "pro",
-        title: "Omi Pro",
+        id: "architect",
+        title: "Architect",
         features: ["Fallback Feature"],
         prices: [
           SubscriptionPriceOption(
@@ -29,8 +29,8 @@ final class SubscriptionPlanCatalogMergerTests: XCTestCase {
 
     let primary = [
       SubscriptionPlanOption(
-        id: "pro",
-        title: "Omi Pro",
+        id: "architect",
+        title: "Architect",
         features: ["Primary Feature"],
         prices: [
           SubscriptionPriceOption(


### PR DESCRIPTION
## Summary

Follow-up to PR #6744 (merged). These 6 desktop commits were pushed to the branch after it was merged and need to land separately:

- **Rename PlanType.pro → PlanType.architect** across APIClient, SettingsPage, SettingsSidebar, and tests — matches backend rename
- **Hide current plan from "Choose a plan"** — Unlimited subscribers no longer see their own plan repeated in the plan picker (manager feedback)

## Changes

- `APIClient.swift`: Add `case architect` to `SubscriptionPlanType`, keep `case pro` for backward compat
- `SettingsPage.swift`: Rename 12 "pro" references to "architect" (plan ordering, titles, colors, eyebrows, features, normalization), filter current plan from `subscriptionPlansForDisplay`
- `SettingsSidebar.swift`: Update sidebar keywords and subtitle
- `SubscriptionInfoDecoderTests.swift`: Add architect + pro backward compat tests
- `SubscriptionPlanCatalogMergerTests.swift`: Update plan IDs from "pro" to "architect"

## Test plan

- [x] Desktop builds and runs with correct plan display
- [x] Unlimited subscriber sees only Operator ($49) + Architect ($400) — no duplicate current plan
- [x] Deprecation banner shows for `deprecated=true`
- [x] PlanType.pro still decodes (backward compat)

## Evidence

![Desktop Plan & Usage](https://storage.googleapis.com/omi-pr-assets/pr-6744/desktop-fixed-no-dup.png)

Closes #6734 (desktop scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)