### PR TITLE
chore(app): bump build to 822

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.532+821
+version: 1.0.532+822
 
 
 environment:


### PR DESCRIPTION
## Summary
Trigger Codemagic mobile release — previous build for subscription restructure PR #6744 was canceled when PR #6771 pushed right after.

Build 821 app changes (subscription restructure) were never released to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)