### PR TITLE
chore(app): bump build to 823

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.532+821
+version: 1.0.532+823
 
 
 environment:


### PR DESCRIPTION
## Summary
Bump build number to 823 to trigger Codemagic mobile release for subscription restructure (PR #6744 + #6771).

🤖 Generated with [Claude Code](https://claude.com/claude-code)