### PR TITLE
fix(backend): handle Google Calendar OAuth token failures with retry and structured errors

### DIFF
--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -724,10 +724,7 @@ async def get_calendar_events_tool(
         return result.strip()
     except Exception as e:
         logger.error(f"❌ Unexpected error in get_calendar_events_tool: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return f"Unexpected error fetching calendar events: {str(e)}"
+        return f"Unexpected error fetching calendar events: {e}"
 
 
 @tool
@@ -917,10 +914,7 @@ async def create_calendar_event_tool(
 
     except Exception as e:
         logger.error(f"❌ Unexpected error in create_calendar_event_tool: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return f"Unexpected error creating calendar event: {str(e)}"
+        return f"Unexpected error creating calendar event: {e}"
 
 
 @tool

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -19,7 +19,7 @@ from utils.retrieval.tools.integration_base import (
     parse_iso_with_tz,
     prepare_access,
 )
-from utils.retrieval.tools.google_utils import google_api_request
+from utils.retrieval.tools.google_utils import google_api_request, GoogleAPIError
 
 # Import shared Google utilities
 from utils.retrieval.tools.google_utils import refresh_google_token
@@ -632,15 +632,10 @@ async def get_calendar_events_tool(
                     max_results=max_results,
                     search_query=search_query,
                 )
-        except Exception as e:
-            error_msg = str(e)
-            logger.error(f"❌ Error fetching calendar events: {error_msg}")
-            import traceback
+        except GoogleAPIError as e:
+            logger.error(f"❌ Google API error fetching calendar events: status={e.status_code}, msg={e.message}")
 
-            traceback.print_exc()
-
-            # Try to refresh token if authentication failed
-            if "Authentication failed" in error_msg or "401" in error_msg:
+            if e.is_auth_error:
                 logger.info(f"🔄 Attempting to refresh Google Calendar token...")
                 new_token = await refresh_google_token(uid, integration)
                 if new_token:
@@ -653,19 +648,23 @@ async def get_calendar_events_tool(
                             search_query=search_query,
                         )
                     except Exception as retry_error:
-                        logger.error(f"❌ Error after token refresh: {str(retry_error)}")
-                        import traceback
-
-                        traceback.print_exc()
-                        return f"Error fetching calendar events: {str(retry_error)}"
+                        logger.error(f"❌ Error after token refresh: {retry_error}")
+                        return f"Error fetching calendar events: {retry_error}"
                 else:
                     logger.error(f"❌ Token refresh failed")
                     return (
                         "Google Calendar authentication expired. Please reconnect your Google Calendar from settings."
                     )
+            elif e.is_permission_error:
+                return "Google Calendar access denied. Please reconnect your Google Calendar from settings with proper permissions."
             else:
-                logger.error(f"❌ Non-auth error: {error_msg}")
-                return f"Error fetching calendar events: {error_msg}"
+                return f"Error fetching calendar events: {e.message}"
+        except (httpx.TimeoutException, httpx.ConnectError) as e:
+            logger.error(f"❌ Network error fetching calendar events: {e}")
+            return "Unable to reach Google Calendar right now. Please try again in a moment."
+        except Exception as e:
+            logger.error(f"❌ Unexpected error fetching calendar events: {e}")
+            return f"Error fetching calendar events: {e}"
 
         events_count = len(events) if events else 0
 
@@ -865,15 +864,10 @@ async def create_calendar_event_tool(
 
             return result.strip()
 
-        except Exception as e:
-            error_msg = str(e)
-            logger.error(f"❌ Error creating calendar event: {error_msg}")
-            import traceback
+        except GoogleAPIError as e:
+            logger.error(f"❌ Google API error creating calendar event: status={e.status_code}, msg={e.message}")
 
-            traceback.print_exc()
-
-            # Try to refresh token if authentication failed
-            if "Authentication failed" in error_msg or "401" in error_msg:
+            if e.is_auth_error:
                 logger.info(f"🔄 Attempting to refresh Google Calendar token...")
                 new_token = await refresh_google_token(uid, integration)
                 if new_token:
@@ -906,20 +900,20 @@ async def create_calendar_event_tool(
 
                         return result.strip()
                     except Exception as retry_error:
-                        logger.error(f"❌ Error after token refresh: {str(retry_error)}")
-                        import traceback
-
-                        traceback.print_exc()
-                        return f"Error creating calendar event: {str(retry_error)}"
+                        logger.error(f"❌ Error after token refresh: {retry_error}")
+                        return f"Error creating calendar event: {retry_error}"
                 else:
                     logger.error(f"❌ Token refresh failed")
                     return (
                         "Google Calendar authentication expired. Please reconnect your Google Calendar from settings."
                     )
-            elif "Insufficient permissions" in error_msg or "403" in error_msg:
+            elif e.is_permission_error:
                 return "Google Calendar write access is not available. Please reconnect your Google Calendar from settings with proper permissions."
             else:
-                return f"Error creating calendar event: {error_msg}"
+                return f"Error creating calendar event: {e.message}"
+        except (httpx.TimeoutException, httpx.ConnectError) as e:
+            logger.error(f"❌ Network error creating calendar event: {e}")
+            return "Unable to reach Google Calendar right now. Please try again in a moment."
 
     except Exception as e:
         logger.error(f"❌ Unexpected error in create_calendar_event_tool: {e}")
@@ -989,12 +983,10 @@ async def delete_calendar_event_tool(
             try:
                 await delete_google_calendar_event(access_token, event_id)
                 return f"✅ Successfully deleted calendar event (ID: {event_id})"
-            except Exception as e:
-                error_msg = str(e)
-                logger.error(f"❌ Error deleting event by ID: {error_msg}")
+            except GoogleAPIError as e:
+                logger.error(f"❌ Google API error deleting event by ID: status={e.status_code}, msg={e.message}")
 
-                # Try to refresh token if authentication failed
-                if "Authentication failed" in error_msg or "401" in error_msg:
+                if e.is_auth_error:
                     logger.info(f"🔄 Attempting to refresh Google Calendar token...")
                     new_token = await refresh_google_token(uid, integration)
                     if new_token:
@@ -1002,11 +994,19 @@ async def delete_calendar_event_tool(
                             await delete_google_calendar_event(new_token, event_id)
                             return f"✅ Successfully deleted calendar event (ID: {event_id})"
                         except Exception as retry_error:
-                            return f"Error deleting calendar event: {str(retry_error)}"
+                            return f"Error deleting calendar event: {retry_error}"
                     else:
                         return "Google Calendar authentication expired. Please reconnect your Google Calendar from settings."
+                elif e.is_permission_error:
+                    return "Google Calendar write access is not available. Please reconnect your Google Calendar from settings with proper permissions."
                 else:
-                    return f"Error deleting calendar event: {error_msg}"
+                    return f"Error deleting calendar event: {e.message}"
+            except (httpx.TimeoutException, httpx.ConnectError) as e:
+                logger.error(f"❌ Network error deleting event by ID: {e}")
+                return "Unable to reach Google Calendar right now. Please try again in a moment."
+            except Exception as e:
+                logger.error(f"❌ Unexpected error deleting event by ID: {e}")
+                return f"Error deleting calendar event: {e}"
 
         # Otherwise, search for events matching criteria
         if not event_title and not start_date:
@@ -1125,15 +1125,10 @@ async def delete_calendar_event_tool(
                 else:
                     return "No events were deleted."
 
-        except Exception as e:
-            error_msg = str(e)
-            logger.error(f"❌ Error searching for events to delete: {error_msg}")
-            import traceback
+        except GoogleAPIError as e:
+            logger.error(f"❌ Google API error searching events to delete: status={e.status_code}, msg={e.message}")
 
-            traceback.print_exc()
-
-            # Try to refresh token if authentication failed
-            if "Authentication failed" in error_msg or "401" in error_msg:
+            if e.is_auth_error:
                 logger.info(f"🔄 Attempting to refresh Google Calendar token...")
                 new_token = await refresh_google_token(uid, integration)
                 if new_token:
@@ -1169,7 +1164,7 @@ async def delete_calendar_event_tool(
                                 try:
                                     await delete_google_calendar_event(new_token, event_id)
                                     deleted_count += 1
-                                except:
+                                except Exception:
                                     pass
 
                         if deleted_count > 0:
@@ -1177,20 +1172,25 @@ async def delete_calendar_event_tool(
                         else:
                             return "No events were deleted."
                     except Exception as retry_error:
-                        return f"Error deleting calendar events: {str(retry_error)}"
+                        return f"Error deleting calendar events: {retry_error}"
                 else:
                     return (
                         "Google Calendar authentication expired. Please reconnect your Google Calendar from settings."
                     )
+            elif e.is_permission_error:
+                return "Google Calendar write access is not available. Please reconnect your Google Calendar from settings with proper permissions."
             else:
-                return f"Error searching for calendar events: {error_msg}"
+                return f"Error searching for calendar events: {e.message}"
+        except (httpx.TimeoutException, httpx.ConnectError) as e:
+            logger.error(f"❌ Network error searching events to delete: {e}")
+            return "Unable to reach Google Calendar right now. Please try again in a moment."
+        except Exception as e:
+            logger.error(f"❌ Unexpected error searching events to delete: {e}")
+            return f"Error searching for calendar events: {e}"
 
     except Exception as e:
         logger.error(f"❌ Unexpected error in delete_calendar_event_tool: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return f"Unexpected error deleting calendar events: {str(e)}"
+        return f"Unexpected error deleting calendar events: {e}"
 
 
 @tool
@@ -1317,12 +1317,10 @@ async def update_calendar_event_tool(
         # Get current event to preserve existing data
         try:
             current_event = await get_google_calendar_event(access_token, target_event_id)
-        except Exception as e:
-            error_msg = str(e)
-            logger.error(f"❌ Error getting event: {error_msg}")
+        except GoogleAPIError as e:
+            logger.error(f"❌ Google API error getting event: status={e.status_code}, msg={e.message}")
 
-            # Try to refresh token if authentication failed
-            if "Authentication failed" in error_msg or "401" in error_msg:
+            if e.is_auth_error:
                 logger.info(f"🔄 Attempting to refresh Google Calendar token...")
                 new_token = await refresh_google_token(uid, integration)
                 if new_token:
@@ -1330,13 +1328,21 @@ async def update_calendar_event_tool(
                         current_event = await get_google_calendar_event(new_token, target_event_id)
                         access_token = new_token
                     except Exception as retry_error:
-                        return f"Error getting calendar event: {str(retry_error)}"
+                        return f"Error getting calendar event: {retry_error}"
                 else:
                     return (
                         "Google Calendar authentication expired. Please reconnect your Google Calendar from settings."
                     )
+            elif e.is_permission_error:
+                return "Google Calendar access denied. Please reconnect your Google Calendar from settings with proper permissions."
             else:
-                return f"Error getting calendar event: {error_msg}"
+                return f"Error getting calendar event: {e.message}"
+        except (httpx.TimeoutException, httpx.ConnectError) as e:
+            logger.error(f"❌ Network error getting event: {e}")
+            return "Unable to reach Google Calendar right now. Please try again in a moment."
+        except Exception as e:
+            logger.error(f"❌ Unexpected error getting event: {e}")
+            return f"Error getting calendar event: {e}"
 
         # Prepare update fields
         update_summary = title if title is not None else None
@@ -1424,15 +1430,10 @@ async def update_calendar_event_tool(
 
             return result.strip()
 
-        except Exception as e:
-            error_msg = str(e)
-            logger.error(f"❌ Error updating calendar event: {error_msg}")
-            import traceback
+        except GoogleAPIError as e:
+            logger.error(f"❌ Google API error updating calendar event: status={e.status_code}, msg={e.message}")
 
-            traceback.print_exc()
-
-            # Try to refresh token if authentication failed
-            if "Authentication failed" in error_msg or "401" in error_msg:
+            if e.is_auth_error:
                 logger.info(f"🔄 Attempting to refresh Google Calendar token...")
                 new_token = await refresh_google_token(uid, integration)
                 if new_token:
@@ -1451,17 +1452,19 @@ async def update_calendar_event_tool(
                             result += f"   Attendees: {', '.join(update_attendees)}\n"
                         return result.strip()
                     except Exception as retry_error:
-                        return f"Error updating calendar event: {str(retry_error)}"
+                        return f"Error updating calendar event: {retry_error}"
                 else:
                     return (
                         "Google Calendar authentication expired. Please reconnect your Google Calendar from settings."
                     )
+            elif e.is_permission_error:
+                return "Google Calendar write access is not available. Please reconnect your Google Calendar from settings with proper permissions."
             else:
-                return f"Error updating calendar event: {error_msg}"
+                return f"Error updating calendar event: {e.message}"
+        except (httpx.TimeoutException, httpx.ConnectError) as e:
+            logger.error(f"❌ Network error updating calendar event: {e}")
+            return "Unable to reach Google Calendar right now. Please try again in a moment."
 
     except Exception as e:
         logger.error(f"❌ Unexpected error in update_calendar_event_tool: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return f"Unexpected error updating calendar event: {str(e)}"
+        return f"Unexpected error updating calendar event: {e}"

--- a/backend/utils/retrieval/tools/google_utils.py
+++ b/backend/utils/retrieval/tools/google_utils.py
@@ -2,6 +2,7 @@
 Shared utilities for Google OAuth integrations (Calendar, Gmail, etc.).
 """
 
+import asyncio
 import os
 from typing import Optional
 
@@ -9,9 +10,41 @@ import httpx
 
 import database.users as users_db
 from utils.http_client import get_auth_client
+from utils.log_sanitizer import sanitize
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Transient HTTP status codes that should be retried
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+# Max retries for transient failures
+_MAX_RETRIES = 3
+
+
+class GoogleAPIError(Exception):
+    """Structured exception for Google API failures."""
+
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"Google API error {status_code}: {message}")
+
+    @property
+    def is_auth_error(self) -> bool:
+        return self.status_code == 401 or 'invalid_grant' in self.message.lower()
+
+    @property
+    def is_rate_limit(self) -> bool:
+        return self.status_code == 429
+
+    @property
+    def is_permission_error(self) -> bool:
+        return self.status_code == 403
+
+    @property
+    def is_retryable(self) -> bool:
+        return self.status_code in _RETRYABLE_STATUS_CODES
 
 
 async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
@@ -28,12 +61,14 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
     """
     refresh_token = integration.get('refresh_token')
     if not refresh_token:
+        logger.warning(f"🔄 No refresh_token stored for uid={uid}, cannot refresh")
         return None
 
     client_id = os.getenv('GOOGLE_CLIENT_ID')
     client_secret = os.getenv('GOOGLE_CLIENT_SECRET')
 
     if not all([client_id, client_secret]):
+        logger.error("🔄 Missing GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET env vars")
         return None
 
     try:
@@ -56,9 +91,26 @@ async def refresh_google_token(uid: str, integration: dict) -> Optional[str]:
                 # Update stored token
                 integration['access_token'] = new_access_token
                 users_db.set_integration(uid, 'google_calendar', integration)
+                logger.info(f"🔄 Successfully refreshed Google token for uid={uid}")
                 return new_access_token
+
+        # Detect token revocation (invalid_grant) — user revoked access in Google settings
+        error_body = sanitize(response.text[:200]) if response.text else "No error body"
+        if response.status_code == 400 and 'invalid_grant' in (response.text or '').lower():
+            logger.error(
+                f"🔄 Google refresh token revoked for uid={uid} (invalid_grant). "
+                f"User needs to reconnect. Response: {error_body}"
+            )
+        else:
+            logger.error(
+                f"🔄 Google token refresh failed for uid={uid}: " f"status={response.status_code}, body={error_body}"
+            )
+    except httpx.TimeoutException:
+        logger.error(f"🔄 Timeout refreshing Google token for uid={uid}")
+    except httpx.ConnectError:
+        logger.error(f"🔄 Network error refreshing Google token for uid={uid}")
     except Exception as e:
-        logger.error(f"Error refreshing Google token: {e}")
+        logger.error(f"🔄 Unexpected error refreshing Google token for uid={uid}: {e}")
 
     return None
 
@@ -71,24 +123,70 @@ async def google_api_request(
     body: dict | None = None,
     allow_204: bool = False,
 ):
+    """
+    Make a Google API request with automatic retry for transient failures.
+
+    Retries on 429 (rate limit) and 5xx (server errors) with exponential backoff.
+    Raises GoogleAPIError with status_code for structured error handling upstream.
+    Raises httpx.TimeoutException / httpx.ConnectError for network failures.
+    """
     logger.info(f"🌐 Google API {method.upper()} {url}")
 
     client = get_auth_client()
-    r = await client.request(
-        method=method,
-        url=url,
-        headers={"Authorization": f"Bearer {access_token}"},
-        json=body,
-        params=params,
-    )
+    last_error = None
 
-    logger.info(f"🔎 Status {r.status_code}")
+    for attempt in range(_MAX_RETRIES):
+        try:
+            r = await client.request(
+                method=method,
+                url=url,
+                headers={"Authorization": f"Bearer {access_token}"},
+                json=body,
+                params=params,
+            )
+        except httpx.TimeoutException:
+            logger.warning(f"🌐 Timeout on attempt {attempt + 1}/{_MAX_RETRIES} for {method.upper()} {url}")
+            last_error = httpx.TimeoutException(f"Timeout calling {url}")
+            if attempt < _MAX_RETRIES - 1:
+                await asyncio.sleep(2**attempt)
+            continue
+        except httpx.ConnectError as e:
+            logger.warning(f"🌐 Network error on attempt {attempt + 1}/{_MAX_RETRIES} for {method.upper()} {url}: {e}")
+            last_error = e
+            if attempt < _MAX_RETRIES - 1:
+                await asyncio.sleep(2**attempt)
+            continue
 
-    if allow_204 and r.status_code == 204:
-        return None
+        logger.info(f"🔎 Status {r.status_code}")
 
-    if r.status_code != 200:
-        snippet = r.text[:200] if r.text else "No error body"
-        raise Exception(f"Google API error {r.status_code}: {snippet}")
+        if allow_204 and r.status_code == 204:
+            return None
 
-    return r.json()
+        if r.status_code == 200:
+            return r.json()
+
+        snippet = sanitize(r.text[:200]) if r.text else "No error body"
+
+        # Retry on transient errors with exponential backoff
+        if r.status_code in _RETRYABLE_STATUS_CODES and attempt < _MAX_RETRIES - 1:
+            delay = 2**attempt
+            if r.status_code == 429:
+                # Respect Retry-After header if present
+                retry_after = r.headers.get('Retry-After')
+                if retry_after and retry_after.isdigit():
+                    delay = max(delay, int(retry_after))
+                logger.warning(f"🌐 Rate limited (429), retrying in {delay}s (attempt {attempt + 1}/{_MAX_RETRIES})")
+            else:
+                logger.warning(
+                    f"�� Server error {r.status_code}, retrying in {delay}s (attempt {attempt + 1}/{_MAX_RETRIES})"
+                )
+            await asyncio.sleep(delay)
+            continue
+
+        # Non-retryable error — raise immediately
+        raise GoogleAPIError(r.status_code, snippet)
+
+    # All retries exhausted
+    if last_error and isinstance(last_error, (httpx.TimeoutException, httpx.ConnectError)):
+        raise last_error
+    raise GoogleAPIError(r.status_code, sanitize(r.text[:200]) if r.text else "No error body")

--- a/backend/utils/retrieval/tools/google_utils.py
+++ b/backend/utils/retrieval/tools/google_utils.py
@@ -178,7 +178,7 @@ async def google_api_request(
                 logger.warning(f"🌐 Rate limited (429), retrying in {delay}s (attempt {attempt + 1}/{_MAX_RETRIES})")
             else:
                 logger.warning(
-                    f"�� Server error {r.status_code}, retrying in {delay}s (attempt {attempt + 1}/{_MAX_RETRIES})"
+                    f"🌐 Server error {r.status_code}, retrying in {delay}s (attempt {attempt + 1}/{_MAX_RETRIES})"
                 )
             await asyncio.sleep(delay)
             continue
@@ -189,4 +189,5 @@ async def google_api_request(
     # All retries exhausted
     if last_error and isinstance(last_error, (httpx.TimeoutException, httpx.ConnectError)):
         raise last_error
-    raise GoogleAPIError(r.status_code, sanitize(r.text[:200]) if r.text else "No error body")
+    # Unreachable with _MAX_RETRIES >= 1, but kept as a safety net
+    raise GoogleAPIError(0, "All retries exhausted with no response")


### PR DESCRIPTION
## Summary

Addresses **issue #6556** — chronic Google Calendar integration failures (58 errors/week since Dec 2025).

### Root cause
The error handling in `calendar_tools.py` relied on fragile string matching (`"Authentication failed" in error_msg or "401" in error_msg`), missing:
- Token revocation with non-401 codes (`invalid_grant`)
- Rate limits (429)
- Network errors / timeouts
- Server errors (5xx)

### Changes

**`google_utils.py`:**
- Added `GoogleAPIError` exception class with `status_code` property and helpers (`is_auth_error`, `is_rate_limit`, `is_permission_error`, `is_retryable`)
- Added automatic retry with exponential backoff for transient failures (429, 5xx, network timeouts)
- Respects `Retry-After` header on 429 responses
- `refresh_google_token()` now detects `invalid_grant` in refresh response body (token revoked by user in Google account settings)
- Added specific error logging with `sanitize()` per repo logging rules

**`calendar_tools.py`:**
- Replaced all 5 string-matching error handlers (`get`, `create`, `delete-by-id`, `delete-search`, `update`) with structured `GoogleAPIError` catching
- Added explicit `httpx.TimeoutException` / `httpx.ConnectError` handling with user-friendly messages
- Added `403` permission error handling consistently across all tools

### Impact
- Transient failures (rate limits, server hiccups) are automatically retried instead of immediately failing
- Token revocation is properly detected regardless of HTTP status code
- Users get actionable error messages ("Please reconnect your Google Calendar") instead of generic errors
- Error logging includes status codes for easier debugging in GCP Error Reporting

## Test plan
- [ ] Verify existing calendar tool tests still pass (`bash test.sh`)
- [ ] Confirm `GoogleAPIError` correctly classifies 401, 403, 429, 5xx status codes
- [ ] Verify retry logic respects `_MAX_RETRIES` and exponential backoff
- [ ] Confirm `refresh_google_token` detects `invalid_grant` in response body
- [ ] Manual test: calendar operations work normally on the happy path

Fixes #6556