### PR TITLE
fix(backend): correct legacy client filter for renamed plan IDs

### DIFF
--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -132,19 +132,16 @@ def adapt_plans_for_legacy_client(definitions: list[dict]) -> list[dict]:
     so older clients (mobile, stable desktop) keep showing the old plan titles
     and don't see desktop-only plans.
 
-    Hides Operator and Architect (pro) entirely — both are desktop-only.
-    Drops the legacy suffix + flag from Unlimited so pre-rollout clients
-    still see it as "Omi Unlimited".
+    Hides Operator and Architect entirely — both are desktop-only.
+    Keeps only Unlimited (Neo) as "Omi Unlimited" for legacy mobile clients.
     """
     out: list[dict] = []
     for d in definitions:
-        if d['plan_id'] in ('operator', 'pro'):
+        if d['plan_id'] in ('operator', 'architect'):
             continue
         adapted = dict(d)
-        if d['plan_id'] == 'architect':
-            adapted['title'] = 'Omi Pro'
-        elif d['plan_id'] == 'unlimited':
-            adapted['title'] = 'Unlimited Plan'
+        if d['plan_id'] == 'unlimited':
+            adapted['title'] = 'Omi Unlimited'
             adapted['legacy'] = False
         out.append(adapted)
     return out


### PR DESCRIPTION
## Summary
- Follow-up to #6766 — the subscription restructure (#6734) renamed `plan_id` from `'pro'` to `'architect'`, so the old filter `('operator', 'pro')` no longer catches Architect
- Mobile clients were again seeing Architect plans (and possibly Operator) instead of just Omi Unlimited
- Updates `adapt_plans_for_legacy_client()` to filter `('operator', 'architect')` and rename Unlimited to "Omi Unlimited"

## Test plan
- [ ] Verify `/v1/payments/available-plans` returns only Omi Unlimited plans for mobile (no X-App-Platform or ios/android)
- [ ] Verify desktop (macOS) still sees Neo + Operator + Architect plans
- [ ] Confirm mobile app shows "Omi Unlimited Annual" and "Omi Unlimited Monthly" only

🤖 Generated with [Claude Code](https://claude.com/claude-code)