### PR TITLE
fix(app): show plan management on usage page when no activity

### DIFF
--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -325,6 +325,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
           if (provider.error != null && !hasAnyData) {
             return Column(
               children: [
+                _buildSubscriptionInfo(context, provider),
                 _buildFairUseBanner(),
                 Expanded(
                   child: Center(
@@ -345,6 +346,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
           if (!provider.isLoading && !hasAnyData && provider.error == null) {
             return Column(
               children: [
+                _buildSubscriptionInfo(context, provider),
                 _buildFairUseBanner(),
                 Expanded(child: _buildEmptyState()),
               ],


### PR DESCRIPTION
## Summary
The subscription/plan management section on "Your Omi Insights" was only visible when usage data existed. Users with no activity saw "No Activity Yet" but couldn't access plan management from this page.

Adds `_buildSubscriptionInfo()` to both the empty state and error state views so the plan upgrade/manage section is always visible.

## Test plan
- [ ] Open Your Omi Insights with no activity — plan info should now appear above "No Activity Yet"
- [ ] Open with activity — plan info still shows (no regression)
- [ ] Open with error state — plan info shows above error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)