### PR TITLE
macOS TestFlight: deprecation dialog (DO NOT MERGE)

### DIFF
--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -23,6 +23,7 @@ import 'package:omi/services/clickup_service.dart';
 import 'package:omi/services/google_tasks_service.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/services/todoist_service.dart';
+import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 
@@ -231,77 +232,86 @@ class _AppShellState extends State<AppShell> {
     }
   }
 
-  void _showDeprecationDialog() {
+  Future<void> _checkDeprecation() async {
     if (!Platform.isMacOS) return;
+    if (!context.read<AuthenticationProvider>().isSignedIn()) return;
+
+    try {
+      final sub = await getUserSubscription();
+      if (sub == null || sub.showSubscriptionUi) return;
+      if (!mounted) return;
+      _showDeprecationDialog();
+    } catch (_) {}
+  }
+
+  void _showDeprecationDialog() {
     const downloadUrl = 'https://macos.omi.me';
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      showDialog(
-        context: context,
-        barrierDismissible: false,
-        builder: (context) {
-          var showUrl = false;
-          return StatefulBuilder(
-            builder: (context, setState) => PopScope(
-              canPop: false,
-              child: AlertDialog(
-                backgroundColor: const Color(0xFF1A1A2E),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                title: const Text(
-                  'App No Longer Maintained',
-                  style: TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.w600),
-                  textAlign: TextAlign.center,
-                ),
-                content: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Text(
-                      'This version is no longer maintained. Please uninstall this app and download the latest version directly from our website.',
-                      style: TextStyle(color: Colors.white70, fontSize: 15, height: 1.5),
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        var showUrl = false;
+        return StatefulBuilder(
+          builder: (context, setState) => PopScope(
+            canPop: false,
+            child: AlertDialog(
+              backgroundColor: const Color(0xFF1A1A2E),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+              title: const Text(
+                'App No Longer Maintained',
+                style: TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.w600),
+                textAlign: TextAlign.center,
+              ),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text(
+                    'This version is no longer maintained. Please uninstall this app and download the latest version directly from our website.',
+                    style: TextStyle(color: Colors.white70, fontSize: 15, height: 1.5),
+                    textAlign: TextAlign.center,
+                  ),
+                  if (showUrl) ...[
+                    const SizedBox(height: 16),
+                    SelectableText(
+                      downloadUrl,
+                      style: const TextStyle(color: Colors.deepPurpleAccent, fontSize: 14),
                       textAlign: TextAlign.center,
                     ),
-                    if (showUrl) ...[
-                      const SizedBox(height: 16),
-                      SelectableText(
-                        downloadUrl,
-                        style: const TextStyle(color: Colors.deepPurpleAccent, fontSize: 14),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
                   ],
-                ),
-                actionsAlignment: MainAxisAlignment.center,
-                actions: [
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.deepPurple,
-                        foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(vertical: 14),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      ),
-                      onPressed: () async {
-                        final ok = await launchUrl(Uri.parse(downloadUrl));
-                        if (!ok) setState(() => showUrl = true);
-                      },
-                      child: const Text('Download', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
-                    ),
-                  ),
                 ],
               ),
+              actionsAlignment: MainAxisAlignment.center,
+              actions: [
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.deepPurple,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    ),
+                    onPressed: () async {
+                      final ok = await launchUrl(Uri.parse(downloadUrl));
+                      if (!ok) setState(() => showUrl = true);
+                    },
+                    child: const Text('Download', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+                  ),
+                ),
+              ],
             ),
-          );
-        },
-      );
-    });
+          ),
+        );
+      },
+    );
   }
 
   @override
   void initState() {
     initDeepLinks();
-    _showDeprecationDialog();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      _checkDeprecation();
       if (context.read<AuthenticationProvider>().isSignedIn()) {
         context.read<HomeProvider>().setupHasSpeakerProfile();
         context.read<HomeProvider>().setupUserPrimaryLanguage();

--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:omi/mobile/mobile_app.dart';
 import 'package:omi/desktop/desktop_app.dart';
 import 'package:omi/backend/preferences.dart';
@@ -229,9 +231,53 @@ class _AppShellState extends State<AppShell> {
     }
   }
 
+  void _showDeprecationDialog() {
+    if (!Platform.isMacOS) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => PopScope(
+          canPop: false,
+          child: AlertDialog(
+            backgroundColor: const Color(0xFF1A1A2E),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            title: const Text(
+              'App No Longer Maintained',
+              style: TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.w600),
+              textAlign: TextAlign.center,
+            ),
+            content: const Text(
+              'This version is no longer maintained. Please uninstall this app and download the latest version directly from our website.',
+              style: TextStyle(color: Colors.white70, fontSize: 15, height: 1.5),
+              textAlign: TextAlign.center,
+            ),
+            actionsAlignment: MainAxisAlignment.center,
+            actions: [
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.deepPurple,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                  onPressed: () => launchUrl(Uri.parse('https://macos.omi.me')),
+                  child: const Text('Download', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    });
+  }
+
   @override
   void initState() {
     initDeepLinks();
+    _showDeprecationDialog();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (context.read<AuthenticationProvider>().isSignedIn()) {

--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -233,43 +233,65 @@ class _AppShellState extends State<AppShell> {
 
   void _showDeprecationDialog() {
     if (!Platform.isMacOS) return;
+    const downloadUrl = 'https://macos.omi.me';
     WidgetsBinding.instance.addPostFrameCallback((_) {
       showDialog(
         context: context,
         barrierDismissible: false,
-        builder: (context) => PopScope(
-          canPop: false,
-          child: AlertDialog(
-            backgroundColor: const Color(0xFF1A1A2E),
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-            title: const Text(
-              'App No Longer Maintained',
-              style: TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.w600),
-              textAlign: TextAlign.center,
-            ),
-            content: const Text(
-              'This version is no longer maintained. Please uninstall this app and download the latest version directly from our website.',
-              style: TextStyle(color: Colors.white70, fontSize: 15, height: 1.5),
-              textAlign: TextAlign.center,
-            ),
-            actionsAlignment: MainAxisAlignment.center,
-            actions: [
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.deepPurple,
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  ),
-                  onPressed: () => launchUrl(Uri.parse('https://macos.omi.me')),
-                  child: const Text('Download', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+        builder: (context) {
+          var showUrl = false;
+          return StatefulBuilder(
+            builder: (context, setState) => PopScope(
+              canPop: false,
+              child: AlertDialog(
+                backgroundColor: const Color(0xFF1A1A2E),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                title: const Text(
+                  'App No Longer Maintained',
+                  style: TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.w600),
+                  textAlign: TextAlign.center,
                 ),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Text(
+                      'This version is no longer maintained. Please uninstall this app and download the latest version directly from our website.',
+                      style: TextStyle(color: Colors.white70, fontSize: 15, height: 1.5),
+                      textAlign: TextAlign.center,
+                    ),
+                    if (showUrl) ...[
+                      const SizedBox(height: 16),
+                      SelectableText(
+                        downloadUrl,
+                        style: const TextStyle(color: Colors.deepPurpleAccent, fontSize: 14),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ],
+                ),
+                actionsAlignment: MainAxisAlignment.center,
+                actions: [
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.deepPurple,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      ),
+                      onPressed: () async {
+                        final ok = await launchUrl(Uri.parse(downloadUrl));
+                        if (!ok) setState(() => showUrl = true);
+                      },
+                      child: const Text('Download', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
-        ),
+            ),
+          );
+        },
       );
     });
   }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.74+436
+version: 1.0.80+500
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.80+500
+version: 1.0.80+501
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -313,7 +313,7 @@ workflows:
           flutter build macos \
             --release \
             --build-name=1.0.80 \
-            --build-number=500 \
+            --build-number=501 \
             --flavor prod
 
       - name: Package application for App Store

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -310,13 +310,10 @@ workflows:
 
       - name: Flutter build macOS
         script: |
-          # Build
-          BUILD_NAME=$(echo $CM_TAG | sed 's/^v\(.*\)+\(.*\)-desktop-cm$/\1/')
-          BUILD_NUMBER=$(echo $CM_TAG | sed 's/^v\(.*\)+\(.*\)-desktop-cm$/\2/')
           flutter build macos \
             --release \
-            --build-name=$BUILD_NAME \
-            --build-number=$BUILD_NUMBER \
+            --build-name=1.0.80 \
+            --build-number=500 \
             --flavor prod
 
       - name: Package application for App Store


### PR DESCRIPTION
> **⚠️ DO NOT MERGE THIS PR INTO MAIN.**
> This branch exists solely to trigger a Codemagic macOS TestFlight build. It is based on `a72e76b76` (Nov 6, 2025) — the last stable state of the Flutter macOS app. Merging would reintroduce deleted macOS code and a stale `codemagic.yaml` workflow.

## Summary

- Adds a non-dismissable deprecation dialog on macOS app launch
- Dialog blocks all app usage — no X, no back, no tap-outside dismiss
- Text: "This version is no longer maintained. Please uninstall this app and download the latest version directly from our website."
- "Download" button opens https://macos.omi.me
- macOS-only guard (`Platform.isMacOS`) — no effect on iOS/Android

## How to build

Either push a tag matching `v*-desktop-cm` on this branch, or start a manual build in the Codemagic dashboard selecting `macos-testflight-release` branch + `macos-prod-testflight` workflow.

## Test plan

- [ ] Codemagic build succeeds for `macos-prod-testflight` workflow
- [ ] macOS app launches and immediately shows the deprecation dialog
- [ ] Dialog cannot be dismissed (no close button, back button, or outside tap)
- [ ] "Download" button opens https://macos.omi.me

🤖 Generated with [Claude Code](https://claude.com/claude-code)