### PR TITLE
fix(app) prevent Bad state: No element crash in SD card WAL sync

### DIFF
--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -854,7 +854,11 @@ class SDCardWalSyncImpl implements SDCardWalSync {
     IWalSyncProgressListener? progress,
     IWifiConnectionListener? connectionListener,
   }) async {
-    var walToSync = _wals.where((w) => w == wal).toList().first;
+    var walToSync = _wals.where((w) => w == wal).firstOrNull;
+    if (walToSync == null) {
+      Logger.debug("SDCardWalSync: WAL not found in _wals, skipping sync");
+      return null;
+    }
 
     _resetSyncState();
     _isSyncing = true;


### PR DESCRIPTION
Fixes #6656

`_wals.where((w) => w == wal).toList().first` throws `Bad state: No element` when the WAL is no longer present in `_wals` (race condition). Replaced with `.firstOrNull` + early return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)