### PR TITLE
fix(security): prevent path traversal in file upload endpoints

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -826,28 +826,31 @@ def upload_file_chat(
     thumbs_name = []
     files_chat = []
     for file in files:
-        temp_file = Path(f"{file.filename}")
-        with temp_file.open("wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
+        # Use a UUID-based temp file name to prevent path traversal via user-controlled filename
+        safe_suffix = Path(file.filename).name  # strip any directory components
+        temp_file = Path(f"{uuid.uuid4().hex}_{safe_suffix}")
+        try:
+            with temp_file.open("wb") as buffer:
+                shutil.copyfileobj(file.file, buffer)
 
-        result = FileChatTool.upload(temp_file)
+            result = FileChatTool.upload(temp_file)
 
-        thumb_name = result.get("thumbnail_name", "")
-        if thumb_name != "":
-            thumbs_name.append(thumb_name)
+            thumb_name = result.get("thumbnail_name", "")
+            if thumb_name != "":
+                thumbs_name.append(thumb_name)
 
-        filechat = FileChat(
-            id=str(uuid.uuid4()),
-            name=result.get("file_name", ""),
-            mime_type=result.get("mime_type", ""),
-            openai_file_id=result.get("file_id", ""),
-            created_at=datetime.now(timezone.utc),
-            thumb_name=thumb_name,
-        )
-        files_chat.append(filechat)
-
-        # cleanup temp_file
-        temp_file.unlink()
+            filechat = FileChat(
+                id=str(uuid.uuid4()),
+                name=result.get("file_name", ""),
+                mime_type=result.get("mime_type", ""),
+                openai_file_id=result.get("file_id", ""),
+                created_at=datetime.now(timezone.utc),
+                thumb_name=thumb_name,
+            )
+            files_chat.append(filechat)
+        finally:
+            if temp_file.exists():
+                temp_file.unlink()
 
     if len(thumbs_name) > 0:
         thumbs_path = storage.upload_multi_chat_files(thumbs_name, uid)
@@ -882,28 +885,31 @@ def upload_file_chat(
     thumbs_name = []
     files_chat = []
     for file in files:
-        temp_file = Path(f"{file.filename}")
-        with temp_file.open("wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
+        # Use a UUID-based temp file name to prevent path traversal via user-controlled filename
+        safe_suffix = Path(file.filename).name  # strip any directory components
+        temp_file = Path(f"{uuid.uuid4().hex}_{safe_suffix}")
+        try:
+            with temp_file.open("wb") as buffer:
+                shutil.copyfileobj(file.file, buffer)
 
-        result = FileChatTool.upload(temp_file)
+            result = FileChatTool.upload(temp_file)
 
-        thumb_name = result.get("thumbnail_name", "")
-        if thumb_name != "":
-            thumbs_name.append(thumb_name)
+            thumb_name = result.get("thumbnail_name", "")
+            if thumb_name != "":
+                thumbs_name.append(thumb_name)
 
-        filechat = FileChat(
-            id=str(uuid.uuid4()),
-            name=result.get("file_name", ""),
-            mime_type=result.get("mime_type", ""),
-            openai_file_id=result.get("file_id", ""),
-            created_at=datetime.now(timezone.utc),
-            thumb_name=thumb_name,
-        )
-        files_chat.append(filechat)
-
-        # cleanup temp_file
-        temp_file.unlink()
+            filechat = FileChat(
+                id=str(uuid.uuid4()),
+                name=result.get("file_name", ""),
+                mime_type=result.get("mime_type", ""),
+                openai_file_id=result.get("file_id", ""),
+                created_at=datetime.now(timezone.utc),
+                thumb_name=thumb_name,
+            )
+            files_chat.append(filechat)
+        finally:
+            if temp_file.exists():
+                temp_file.unlink()
 
     if len(thumbs_name) > 0:
         thumbs_path = storage.upload_multi_chat_files(thumbs_name, uid)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import tempfile
 import uuid
 import re
 import base64
@@ -827,8 +828,8 @@ def upload_file_chat(
     files_chat = []
     for file in files:
         # Use a UUID-based temp file name to prevent path traversal via user-controlled filename
-        safe_suffix = Path(file.filename).name  # strip any directory components
-        temp_file = Path(f"{uuid.uuid4().hex}_{safe_suffix}")
+        safe_suffix = Path(file.filename).name if file.filename else "upload"
+        temp_file = Path(tempfile.gettempdir()) / f"{uuid.uuid4().hex}_{safe_suffix}"
         try:
             with temp_file.open("wb") as buffer:
                 shutil.copyfileobj(file.file, buffer)
@@ -886,8 +887,8 @@ def upload_file_chat(
     files_chat = []
     for file in files:
         # Use a UUID-based temp file name to prevent path traversal via user-controlled filename
-        safe_suffix = Path(file.filename).name  # strip any directory components
-        temp_file = Path(f"{uuid.uuid4().hex}_{safe_suffix}")
+        safe_suffix = Path(file.filename).name if file.filename else "upload"
+        temp_file = Path(tempfile.gettempdir()) / f"{uuid.uuid4().hex}_{safe_suffix}"
         try:
             with temp_file.open("wb") as buffer:
                 shutil.copyfileobj(file.file, buffer)

--- a/backend/tests/unit/test_file_upload_endpoint_security.py
+++ b/backend/tests/unit/test_file_upload_endpoint_security.py
@@ -1,0 +1,212 @@
+"""Endpoint-level integration tests for file upload security.
+
+Tests the upload logic as closely as possible to the real endpoint behavior,
+without requiring the full FastAPI import chain. Verifies the complete
+path-traversal fix across both /v1/files and /v2/files upload paths.
+
+Covers: BasedHardware/omi#6804
+"""
+
+import shutil
+import tempfile
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class UploadFile:
+    """Simulates FastAPI's UploadFile for testing."""
+    def __init__(self, filename, content=b"test content"):
+        self.filename = filename
+        self.content = content
+        self.file = MagicMock()
+        # Make copyfileobj read from our content
+        self.file.read = MagicMock(side_effect=[content, b""])
+
+    def read(self):
+        return self.content
+
+
+def simulate_upload_endpoint(files, upload_fn):
+    """Simulate the upload endpoint logic from backend/routers/chat.py.
+
+    This is the actual code path from both /v1/files and /v2/files:
+    - safe_suffix = Path(file.filename).name if file.filename else "upload"
+    - temp_file = Path(tempfile.gettempdir()) / f"{uuid.uuid4().hex}_{safe_suffix}"
+    - try: write + upload
+    - finally: cleanup
+    """
+    results = []
+    temp_files = []
+
+    for file in files:
+        # --- Exact code from chat.py lines 831-854 (v2) / 890-913 (v1) ---
+        safe_suffix = Path(file.filename).name if file.filename else "upload"
+        temp_file = Path(tempfile.gettempdir()) / f"{uuid.uuid4().hex}_{safe_suffix}"
+        temp_files.append(temp_file)
+
+        try:
+            with temp_file.open("wb") as buffer:
+                shutil.copyfileobj(file.file, buffer)
+
+            result = upload_fn(temp_file)
+            results.append(result)
+        finally:
+            if temp_file.exists():
+                temp_file.unlink()
+
+    return results, temp_files
+
+
+@pytest.fixture
+def uploaded_paths():
+    """Track paths that were passed to the upload function."""
+    paths = []
+
+    def upload(file_path):
+        paths.append(str(file_path))
+        return {
+            'file_name': Path(file_path).name,
+            'mime_type': 'text/plain',
+            'file_id': f'test-{uuid.uuid4().hex[:8]}',
+            'thumbnail_name': '',
+        }
+
+    upload.paths = paths
+    return upload
+
+
+class TestPathTraversalV2:
+    """Test /v2/files path traversal fix at endpoint logic level."""
+
+    def test_traversal_stripped_to_basename(self, uploaded_paths):
+        """../../etc/passwd → only 'passwd' in temp file path."""
+        simulate_upload_endpoint([UploadFile("../../etc/passwd")], uploaded_paths)
+        assert "passwd" in uploaded_paths.paths[0]
+        assert "../" not in uploaded_paths.paths[0]
+        assert "etc" not in uploaded_paths.paths[0]
+
+    def test_absolute_path_stripped(self, uploaded_paths):
+        """/etc/shadow → only 'shadow' in temp file path."""
+        simulate_upload_endpoint([UploadFile("/etc/shadow")], uploaded_paths)
+        assert uploaded_paths.paths[0].endswith("shadow")
+        assert "/etc/" not in uploaded_paths.paths[0]
+
+    def test_nested_traversal_stripped(self, uploaded_paths):
+        """Deep nesting fully stripped."""
+        simulate_upload_endpoint(
+            [UploadFile("../../../tmp/../../etc/hosts")], uploaded_paths
+        )
+        assert "hosts" in uploaded_paths.paths[0]
+        assert "../" not in uploaded_paths.paths[0]
+
+    def test_normal_filename_preserved(self, uploaded_paths):
+        """Normal filenames pass through unchanged."""
+        simulate_upload_endpoint([UploadFile("report.pdf")], uploaded_paths)
+        assert "report.pdf" in uploaded_paths.paths[0]
+
+
+class TestNoneFilenameV2:
+    """Test P1 fix: None filename handling."""
+
+    def test_none_filename_no_crash(self, uploaded_paths):
+        """filename=None should use 'upload' default, not crash."""
+        simulate_upload_endpoint([UploadFile(None)], uploaded_paths)
+        assert "upload" in uploaded_paths.paths[0]
+
+    def test_none_filename_file_created_and_cleaned(self, uploaded_paths):
+        """File should be created in temp dir and cleaned up."""
+        _, temp_files = simulate_upload_endpoint(
+            [UploadFile(None)], uploaded_paths
+        )
+        for tf in temp_files:
+            assert not tf.exists()
+
+
+class TestTempFileLocationV2:
+    """Test P2 fix: temp files in system temp dir."""
+
+    def test_in_system_temp_dir(self, uploaded_paths):
+        """Temp file must be inside tempfile.gettempdir()."""
+        simulate_upload_endpoint([UploadFile("test.txt")], uploaded_paths)
+        assert uploaded_paths.paths[0].startswith(tempfile.gettempdir())
+
+    def test_absolute_path(self, uploaded_paths):
+        """Temp file path must be absolute."""
+        simulate_upload_endpoint([UploadFile("test.txt")], uploaded_paths)
+        assert Path(uploaded_paths.paths[0]).is_absolute()
+
+    def test_not_in_cwd(self, uploaded_paths):
+        """Temp file must not be in current working directory."""
+        import os
+        simulate_upload_endpoint([UploadFile("test.txt")], uploaded_paths)
+        cwd = os.getcwd()
+        assert not uploaded_paths.paths[0].startswith(cwd + os.sep)
+
+
+class TestCleanupV2:
+    """Test temp file cleanup in all scenarios."""
+
+    def test_cleanup_on_success(self):
+        """Temp file removed after successful upload."""
+        def success_upload(fp):
+            return {'file_name': 'test.txt', 'mime_type': 'text/plain',
+                    'file_id': 'f1', 'thumbnail_name': ''}
+
+        _, temp_files = simulate_upload_endpoint(
+            [UploadFile("test.txt")], success_upload
+        )
+        for tf in temp_files:
+            assert not tf.exists()
+
+    def test_cleanup_on_upload_failure(self):
+        """Temp file removed even when upload raises exception."""
+        def failing_upload(fp):
+            raise RuntimeError("upload service unavailable")
+
+        with pytest.raises(RuntimeError):
+            simulate_upload_endpoint([UploadFile("test.txt")], failing_upload)
+
+        import glob
+        # No orphan temp files with our UUID pattern
+        leftovers = glob.glob(f"{tempfile.gettempdir()}/test_*")
+        assert len(leftovers) == 0
+
+    def test_multiple_files_all_cleaned(self):
+        """Multiple file uploads — all temp files cleaned."""
+        def success_upload(fp):
+            return {'file_name': 'test', 'mime_type': 'text/plain',
+                    'file_id': 'f1', 'thumbnail_name': ''}
+
+        _, temp_files = simulate_upload_endpoint(
+            [UploadFile("a.txt"), UploadFile("b.pdf"), UploadFile("c.png")],
+            success_upload,
+        )
+        for tf in temp_files:
+            assert not tf.exists()
+
+
+class TestBothEndpoints:
+    """Verify both /v1 and /v2 upload paths share the same secure logic."""
+
+    def test_same_logic_v1_v2(self, uploaded_paths):
+        """The secure filename logic is identical for both endpoints."""
+        # Both endpoints use the exact same code:
+        #   safe_suffix = Path(file.filename).name if file.filename else "upload"
+        #   temp_file = Path(tempfile.gettempdir()) / f"{uuid.uuid4().hex}_{safe_suffix}"
+        # This test verifies the logic function handles all cases correctly.
+        cases = [
+            (None, "upload"),
+            ("normal.txt", "normal.txt"),
+            ("../../etc/passwd", "passwd"),
+            ("/etc/shadow", "shadow"),
+        ]
+        for filename, expected_suffix in cases:
+            safe_suffix = Path(filename).name if filename else "upload"
+            assert safe_suffix == expected_suffix, f"Failed for {filename!r}"
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/backend/tests/unit/test_file_upload_security.py
+++ b/backend/tests/unit/test_file_upload_security.py
@@ -1,0 +1,145 @@
+"""Unit tests for path traversal and security fixes in file upload endpoints.
+
+Covers: BasedHardware/omi#6804
+- P1: None filename handling (UploadFile.filename is Optional[str])
+- P2: Temp files written to system temp dir, not CWD
+- Path traversal: directory components stripped from filename
+- Cleanup: temp files removed even on upload failure
+
+These tests verify the security logic extracted from the endpoints in
+backend/routers/chat.py (both /v1/files and /v2/files handlers).
+"""
+
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def safe_filename_logic(filename):
+    """Extract the security-relevant logic from the upload endpoints.
+
+    Mirrors the code in backend/routers/chat.py lines 831-832 and 890-891:
+        safe_suffix = Path(file.filename).name if file.filename else "upload"
+        temp_file = Path(tempfile.gettempdir()) / f"{uuid.uuid4().hex}_{safe_suffix}"
+    """
+    safe_suffix = Path(filename).name if filename else "upload"
+    temp_file = Path(tempfile.gettempdir()) / f"{uuid.uuid4().hex}_{safe_suffix}"
+    return safe_suffix, temp_file
+
+
+class TestFileUploadPathTraversal(unittest.TestCase):
+    """Test path traversal prevention in file upload filename handling."""
+
+    def test_none_filename_uses_default(self):
+        """P1 fix: filename=None should not raise TypeError, uses 'upload'."""
+        safe_suffix, temp_file = safe_filename_logic(None)
+        self.assertEqual(safe_suffix, "upload")
+        self.assertTrue(temp_file.name.endswith("_upload"))
+
+    def test_normal_filename_unchanged(self):
+        """Normal filenames pass through unchanged."""
+        safe_suffix, temp_file = safe_filename_logic("document.pdf")
+        self.assertEqual(safe_suffix, "document.pdf")
+        self.assertTrue(temp_file.name.endswith("_document.pdf"))
+
+    def test_unix_path_traversal_stripped(self):
+        """../../etc/passwd is stripped to just 'passwd'."""
+        safe_suffix, _ = safe_filename_logic("../../etc/passwd")
+        self.assertEqual(safe_suffix, "passwd")
+
+    def test_absolute_path_stripped(self):
+        """/etc/shadow is stripped to just 'shadow'."""
+        safe_suffix, _ = safe_filename_logic("/etc/shadow")
+        self.assertEqual(safe_suffix, "shadow")
+
+    def test_windows_path_traversal_stripped(self):
+        """Windows-style path traversal: on Linux, Path() doesn't split on backslash,
+        so the caller should normalize. Test that Unix-style traversal is covered."""
+        # On Linux, Path() doesn't strip backslash-separated paths.
+        # The fix in chat.py uses Path().name which handles Unix paths correctly.
+        # Windows-style paths are a defense-in-depth concern, not the primary fix.
+        safe_suffix, _ = safe_filename_logic("..\\..\\secret.txt")
+        # On Linux this won't strip — that's expected; the server runs on Linux
+        # where backslash is a valid filename char. Path traversal via / is covered.
+        self.assertIsInstance(safe_suffix, str)
+
+    def test_nested_traversal_stripped(self):
+        """Deeply nested traversal is fully stripped."""
+        safe_suffix, _ = safe_filename_logic("../../../tmp/../../../etc/hosts")
+        self.assertEqual(safe_suffix, "hosts")
+
+    def test_empty_string_filename(self):
+        """Empty string is falsy, so falls through to 'upload' default."""
+        safe_suffix, temp_file = safe_filename_logic("")
+        self.assertEqual(safe_suffix, "upload")
+
+
+class TestTempFileLocation(unittest.TestCase):
+    """Test P2 fix: temp files go to system temp dir, not CWD."""
+
+    def test_temp_file_in_system_temp_dir(self):
+        """Temp file path must be inside system temp directory."""
+        _, temp_file = safe_filename_logic("test.txt")
+        self.assertTrue(str(temp_file).startswith(tempfile.gettempdir()))
+
+    def test_temp_file_is_absolute(self):
+        """Temp file path must be absolute, not relative."""
+        _, temp_file = safe_filename_logic("test.txt")
+        self.assertTrue(temp_file.is_absolute())
+
+    def test_temp_file_not_in_cwd(self):
+        """Temp file must not be in the current working directory."""
+        import os
+        _, temp_file = safe_filename_logic("test.txt")
+        cwd = os.getcwd()
+        self.assertFalse(str(temp_file).startswith(cwd))
+
+
+class TestTempFileCleanup(unittest.TestCase):
+    """Test that temp files are cleaned up even on upload failure."""
+
+    def test_cleanup_on_success(self):
+        """Temp file removed after successful upload."""
+        _, temp_file = safe_filename_logic("test.txt")
+        temp_file.write_bytes(b"content")
+        self.assertTrue(temp_file.exists())
+
+        # Simulate successful upload + cleanup (finally block)
+        try:
+            pass  # upload succeeds
+        finally:
+            if temp_file.exists():
+                temp_file.unlink()
+
+        self.assertFalse(temp_file.exists())
+
+    def test_cleanup_on_failure(self):
+        """Temp file removed even when upload raises exception."""
+        _, temp_file = safe_filename_logic("test.txt")
+        temp_file.write_bytes(b"content")
+        self.assertTrue(temp_file.exists())
+
+        # Simulate upload failure + cleanup (finally block)
+        try:
+            raise RuntimeError("upload failed")
+        except RuntimeError:
+            pass
+        finally:
+            if temp_file.exists():
+                temp_file.unlink()
+
+        self.assertFalse(temp_file.exists())
+
+    def test_cleanup_idempotent(self):
+        """Cleanup should not fail if temp file already removed."""
+        _, temp_file = safe_filename_logic("test.txt")
+        # File never created — unlink should not raise
+        if temp_file.exists():
+            temp_file.unlink()
+        # No assertion needed: reaching here means no exception
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Both `/v1/files` and `/v2/files` used the user-provided `filename` directly as the local file path:

```python
temp_file = Path(f"{file.filename}")
```

This allows path traversal — a crafted filename like `../../tmp/malicious` or an absolute path like `/etc/cron.d/x` would write to arbitrary locations on the server. The file is normally cleaned up by `unlink()`, but if `FileChatTool.upload()` throws, the temp file persists on disk indefinitely.

## Changes

1. **Sanitize filename**: `Path(file.filename).name` strips directory components, then prepend UUID for uniqueness
2. **Guaranteed cleanup**: Wrap upload logic in `try/finally` so temp files are always deleted

## Before
```python
temp_file = Path(f"{file.filename}")  # user-controlled path
with temp_file.open("wb") as buffer:
    shutil.copyfileobj(file.file, buffer)
result = FileChatTool.upload(temp_file)
# ...
temp_file.unlink()  # never reached if upload() raises
```

## After
```python
safe_suffix = Path(file.filename).name
temp_file = Path(f"{uuid.uuid4().hex}_{safe_suffix}")
try:
    with temp_file.open("wb") as buffer:
        shutil.copyfileobj(file.file, buffer)
    result = FileChatTool.upload(temp_file)
    # ...
finally:
    if temp_file.exists():
        temp_file.unlink()
```

Applies to both `/v1/files` and `/v2/files` endpoints.