### PR TITLE
fix: sign-out crash from disposed drawer context

### DIFF
--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -486,10 +486,6 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                   title: context.l10n.signOut,
                   icon: const FaIcon(FontAwesomeIcons.signOutAlt, color: Color(0xFF8E8E93), size: 20),
                   onTap: () async {
-                    final navigator = Navigator.of(context);
-
-                    navigator.pop(); // Close the settings drawer
-
                     await showDialog(
                       context: context,
                       builder: (ctx) {
@@ -497,7 +493,8 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                           ctx,
                           () => Navigator.of(ctx).pop(),
                           () async {
-                            Navigator.of(ctx).pop();
+                            Navigator.of(ctx).pop(); // close dialog
+                            Navigator.of(context).pop(); // close drawer
                             await SharedPreferencesUtil().clear();
                             await AuthService.instance.signOut();
                             if (context.mounted) {


### PR DESCRIPTION
## Summary
  - The sign-out handler called `navigator.pop()` to close the drawer
  **before** `showDialog`, disposing the drawer's `context`
  - `showDialog` then used the dead context, causing either a silent failure or crash
  - Fix: show the confirmation dialog while the drawer is still mounted, pop both dialog and drawer on confirm

Closes #5652

_I am not a flutter developer so this could be totally wrong but I was exploring this cool project and thought, ah lets try fix something minor, excuse and close if this is just noise._
