### PR TITLE
Support macOS platform in app_review_config

### DIFF
--- a/backend/database/app_review_config.py
+++ b/backend/database/app_review_config.py
@@ -5,7 +5,7 @@ platform and app version.
 Stored in Firestore so the flag can be flipped without a redeploy:
 
   Collection: app_review_config
-  Document ID: ios | android
+  Document ID: ios | android | macos
   Fields:
     hidden_versions: list[str]   # e.g. ["1.0.531", "1.0.531+607"]
     reviewer_uids:   list[str]   # specific UIDs to always hide for
@@ -36,12 +36,16 @@ def get_review_config(platform: str) -> dict:
     return get_memory_cache().get_or_fetch(cache_key, lambda: _fetch_review_config(platform), ttl=_CACHE_TTL_SECONDS)
 
 
+_SUPPORTED_PLATFORMS = {"ios", "macos"}
+
+
 def should_hide_subscription_ui(uid: str, platform: Optional[str], app_version: Optional[str]) -> bool:
     """True when subscription surfaces should be hidden for this caller."""
-    if not platform or platform.lower() != "ios":
+    normalized = (platform or "").lower()
+    if normalized not in _SUPPORTED_PLATFORMS:
         return False
 
-    cfg = get_review_config("ios") or {}
+    cfg = get_review_config(normalized) or {}
 
     if uid and uid in (cfg.get("reviewer_uids") or []):
         return True


### PR DESCRIPTION
## Summary

- Generalize `should_hide_subscription_ui` to support `macos` platform alongside `ios`
- Replace hardcoded `platform == "ios"` check with a `_SUPPORTED_PLATFORMS` set
- Enables server-side deprecation control for the macOS TestFlight app via the existing `app_review_config` Firestore collection

Manager creates a `macos` document in `app_review_config` with `hidden_versions: ["1.0.80"]` to trigger the deprecation dialog on the macOS TestFlight build.

## Test plan

- [ ] Existing iOS behavior unchanged — `app_review_config/ios` doc still gates `show_subscription_ui` for iOS
- [ ] macOS app sending `X-App-Platform: macos` + `X-App-Version: 1.0.80` gets `show_subscription_ui: false` when `1.0.80` is in `app_review_config/macos.hidden_versions`
- [ ] Unknown platforms (e.g., `android`, `windows`) still return `show_subscription_ui: true` (not in `_SUPPORTED_PLATFORMS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)