### PR TITLE
Fix runbook drift in docs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -75,6 +75,6 @@ Complete index of all documentation in the Omi codebase.
 
 ## Related Files
 
-- Architecture: `.cursor/ARCHITECTURE.md`
-- API Reference: `.cursor/API_REFERENCE.md`
-- Data Flow: `.cursor/DATA_FLOW.md`
+- Cursor hooks: `.cursor/hooks.json`
+- Cursor MCP config: `.cursor/mcp.json`
+- Cursor rules: `.cursor/rules/`

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -24,5 +24,7 @@
 
 ### Desktop App (macOS) — GitHub Actions + Codemagic
 - **Trigger**: push to `main` with `desktop/**` changes
-- **Step 1**: GitHub Actions `desktop_auto_release.yml` auto-increments version, pushes `v*-macos` tag
+- **Step 1**: GitHub Actions `desktop_auto_release.yml` deploys the desktop backend to development
+  and production Cloud Run, then computes the next desktop version, pushes the `v*-macos` tag, and
+  syncs `desktop/CHANGELOG.json` back to `main`
 - **Step 2**: Codemagic `omi-desktop-swift-release` builds, signs, notarizes, publishes

--- a/docs/runbooks/logging.md
+++ b/docs/runbooks/logging.md
@@ -1,19 +1,22 @@
 ## Logs
 
 ### Flutter (iOS Simulator)
-App logs go to `/tmp/flutter-run.log`. Use `print()` (not `Logger.debug`) for logs that must appear there. Grep with `[TagName]` prefixes:
+Flutter logs are whatever file you redirect `flutter run` stdout into. The repo uses both
+`/tmp/flutter-run.log` and `/tmp/omi-flutter.log` in different workflows, so treat the path below
+as an example command convention rather than a fixed app log sink. Use `print()` (not
+`Logger.debug`) for logs that must appear there. Grep with `[TagName]` prefixes:
 ```bash
 grep -E "\[AgentChat\]|\[HomePage\]" /tmp/flutter-run.log | tail -20
 ```
 
-### Backend (Cloud Run)
+### Backend-listen (GKE, namespace `prod-omi-backend`)
 ```bash
-gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="backend-listen"' --project=based-hardware --limit=30 --freshness=5m --format=json
+kubectl logs -n prod-omi-backend -l app.kubernetes.io/instance=prod-omi-backend-listen --timestamps --since=10m | grep "<uid>"
 ```
 
 ### Agent-proxy (GKE, namespace `prod-omi-backend`)
 ```bash
-kubectl logs -n prod-omi-backend -l app=agent-proxy --timestamps --since=10m | grep "<uid>"
+kubectl logs -n prod-omi-backend -l app.kubernetes.io/instance=prod-omi-agent-proxy --timestamps --since=10m | grep "<uid>"
 ```
 
 ### Agent VM

--- a/docs/runbooks/simulator.md
+++ b/docs/runbooks/simulator.md
@@ -2,9 +2,12 @@
 
 ```bash
 xcrun simctl list devices | grep Booted  # get device ID
-cd app && flutter run -d <device-id> --flavor dev   # dev backend (api.omiapi.com)
-cd app && flutter run -d <device-id> --flavor prod   # prod backend (api.omi.me)
+cd app && flutter run -d <device-id> --flavor dev    # dev flavor (loads .dev.env)
+cd app && flutter run -d <device-id> --flavor prod   # prod flavor (loads .env)
 ```
+
+The actual backend host comes from `API_BASE_URL` in those env files, not from the flavor flag
+alone. Start from `app/.env.template` when creating local env files.
 
 See `/local-dev mobile` skill for full setup details, env file configuration, and troubleshooting.
 


### PR DESCRIPTION
## Summary
- fix the simulator runbook so flavors are described in terms of `.dev.env` / `.env` rather than hard-coded hosts
- update the logging runbook to match the current Kubernetes workloads and label selectors for `backend-listen` and `agent-proxy`
- align the deploy runbook and docs index with the current desktop auto-release workflow and the actual `.cursor/` files in the repo

## Verification
- Verified the simulator flavor docs against `app/lib/env/dev_env.dart`, `app/lib/env/prod_env.dart`, and `app/.env.template`
- Verified the log commands against `backend/charts/backend-listen/templates/_helpers.tpl`, `backend/charts/agent-proxy/templates/_helpers.tpl`, and the GKE deploy workflows
- Verified the desktop release description against `.github/workflows/desktop_auto_release.yml`
- Reviewed the rendered markdown diff with `git diff`

Partial follow-up for #6698
