### PR TITLE
admin: public /users page with total user count

### DIFF
--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -101,6 +101,7 @@ interface RetentionData {
 interface DailyNewUsersData {
   data: { date: string; users: number; cumulative: number }[];
   totalUsers: number;
+  windowUsers: number;
   days: number;
 }
 
@@ -600,6 +601,11 @@ export default function AnalyticsPage() {
         <div className="flex items-start justify-between mb-1">
           <div>
             <h2 className="text-lg font-semibold">Cumulative Users</h2>
+            {dailyNewUsers?.totalUsers != null && (
+              <div className="text-3xl font-bold mt-1">
+                {dailyNewUsers.totalUsers.toLocaleString()}
+              </div>
+            )}
             <p className="text-sm text-muted-foreground">Total users across all platforms</p>
           </div>
           <div className="flex rounded-md border border-input overflow-hidden">
@@ -1449,15 +1455,22 @@ export default function AnalyticsPage() {
 
       {/* Daily New Users + Rolling Avg */}
       <Card className="p-6">
-        <div className="flex items-center justify-between mb-1">
-          <h2 className="text-lg font-semibold">Daily New Users</h2>
+        <div className="flex items-start justify-between mb-1">
+          <div>
+            <h2 className="text-lg font-semibold">Daily New Users</h2>
+            {dailyNewUsers?.totalUsers != null && (
+              <div className="text-3xl font-bold mt-1">
+                {dailyNewUsers.totalUsers.toLocaleString()}
+              </div>
+            )}
+            <p className="text-sm text-muted-foreground">First-time sign-ins with 7-day rolling average</p>
+          </div>
           {dailyWithRollingAvg.length > 0 && (
             <span className="text-sm text-muted-foreground">
               {dailyWithRollingAvg.reduce((s, p) => s + p.users, 0).toLocaleString()} in last 30d
             </span>
           )}
         </div>
-        <p className="text-sm text-muted-foreground mb-4">First-time sign-ins with 7-day rolling average</p>
         <div className="h-[350px]">
           {dailyNewUsersLoading ? (
             <div className="flex items-center justify-center h-full">

--- a/web/admin/app/api/omi/stats/daily-new-users/route.ts
+++ b/web/admin/app/api/omi/stats/daily-new-users/route.ts
@@ -1,124 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAdminAuth } from "@/lib/firebase/admin";
 import { verifyAdmin } from "@/lib/auth";
-import { getJsonCache, setJsonCache } from "@/lib/redis";
+import { getUserGrowthSeries, sliceSeries } from "@/lib/services/user-growth";
 
 export const dynamic = "force-dynamic";
-
-// The Firestore `users` collection has a `created_at` field that was
-// backfilled for ~63K existing users on a single day in late 2024, so it
-// can't be used to derive signup history. Firebase Auth's
-// `metadata.creationTime` is set by the Auth service on account creation
-// and is the authoritative signup timestamp.
-//
-// Scanning every user via `listUsers()` pages 1000 at a time (112K ≈ 25s)
-// and keeping UserRecord objects live is enough to OOM a 512Mi Cloud Run
-// container. The fix is threefold:
-//   1. Persist the computed series to Redis so only one instance pays
-//      the scan cost per TTL window, even across cold starts.
-//   2. Keep an in-memory shadow of the Redis value so warm instances
-//      skip the round-trip.
-//   3. Iterate pages one at a time, only retaining the date bucket map
-//      (~700 string keys + ints) and dropping each UserRecord batch to
-//      GC as soon as the loop moves on.
-
-type DailyPoint = { date: string; users: number; cumulative: number };
-type CachedSeries = {
-  data: DailyPoint[];
-  totalUsers: number;
-  generatedAt: number;
-};
-
-const REDIS_KEY = "admin:stats:daily-new-users:v1";
-const REDIS_TTL_SECONDS = 30 * 60; // 30 min — matches the in-memory shadow
-const LOCAL_TTL_MS = 30 * 60 * 1000;
-
-let cachedSeries: CachedSeries | null = null;
-let pendingBuild: Promise<CachedSeries> | null = null;
-
-async function buildDailySeries(): Promise<CachedSeries> {
-  const auth = getAdminAuth();
-  const countsByDate: Record<string, number> = {};
-  let pageToken: string | undefined = undefined;
-  let total = 0;
-  let earliest: Date | null = null;
-  let latest: Date | null = null;
-
-  do {
-    const page = await auth.listUsers(1000, pageToken);
-    for (const user of page.users) {
-      const rawCt = user.metadata?.creationTime;
-      if (!rawCt) continue;
-      const ct = new Date(rawCt);
-      if (Number.isNaN(ct.getTime())) continue;
-      const key = ct.toISOString().slice(0, 10);
-      countsByDate[key] = (countsByDate[key] || 0) + 1;
-      if (!earliest || ct < earliest) earliest = ct;
-      if (!latest || ct > latest) latest = ct;
-      total++;
-    }
-    pageToken = page.pageToken || undefined;
-    // Yield to the event loop between pages so V8 can collect the
-    // previous page's UserRecord objects before we request the next.
-    await new Promise((r) => setImmediate(r));
-  } while (pageToken);
-
-  if (!earliest || !latest) {
-    return { data: [], totalUsers: 0, generatedAt: Date.now() };
-  }
-
-  // Fill every day from the earliest signup to today so the curve is
-  // continuous (no gaps) and ends on the current date.
-  const endDate = new Date();
-  endDate.setUTCHours(0, 0, 0, 0);
-  const startDate = new Date(
-    Date.UTC(earliest.getUTCFullYear(), earliest.getUTCMonth(), earliest.getUTCDate()),
-  );
-
-  const data: DailyPoint[] = [];
-  let running = 0;
-  for (
-    const d = new Date(startDate);
-    d <= endDate;
-    d.setUTCDate(d.getUTCDate() + 1)
-  ) {
-    const key = d.toISOString().slice(0, 10);
-    const users = countsByDate[key] || 0;
-    running += users;
-    data.push({ date: key, users, cumulative: running });
-  }
-
-  return { data, totalUsers: total, generatedAt: Date.now() };
-}
-
-async function getSeries(): Promise<CachedSeries> {
-  const now = Date.now();
-
-  // 1. Warm in-memory shadow.
-  if (cachedSeries && now - cachedSeries.generatedAt < LOCAL_TTL_MS) {
-    return cachedSeries;
-  }
-
-  // 2. Shared Redis cache — survives cold starts and cross-instance.
-  const fromRedis = await getJsonCache<CachedSeries>(REDIS_KEY);
-  if (fromRedis && now - fromRedis.generatedAt < LOCAL_TTL_MS) {
-    cachedSeries = fromRedis;
-    return fromRedis;
-  }
-
-  // 3. De-duplicate concurrent rebuilds inside the same instance.
-  if (pendingBuild) return pendingBuild;
-  pendingBuild = buildDailySeries()
-    .then(async (series) => {
-      cachedSeries = series;
-      await setJsonCache(REDIS_KEY, series, REDIS_TTL_SECONDS);
-      return series;
-    })
-    .finally(() => {
-      pendingBuild = null;
-    });
-  return pendingBuild;
-}
 
 export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request);
@@ -126,27 +10,8 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const daysParam = searchParams.get("days");
-    const wantsAll =
-      !daysParam || daysParam === "all" || daysParam === "0";
-    const days = wantsAll ? null : Math.max(1, parseInt(daysParam!, 10));
-
-    const series = await getSeries();
-
-    let data = series.data;
-    if (days != null) {
-      const start = new Date();
-      start.setUTCDate(start.getUTCDate() - days);
-      const startKey = start.toISOString().slice(0, 10);
-      data = series.data.filter((p) => p.date >= startKey);
-    }
-
-    return NextResponse.json({
-      data,
-      totalUsers: series.totalUsers,
-      days: days ?? series.data.length,
-      generatedAt: series.generatedAt,
-    });
+    const series = await getUserGrowthSeries();
+    return NextResponse.json(sliceSeries(series, searchParams.get("days")));
   } catch (error: any) {
     console.error("Daily new users error:", error);
     return NextResponse.json(

--- a/web/admin/app/api/public/user-growth/route.ts
+++ b/web/admin/app/api/public/user-growth/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserGrowthSeries, sliceSeries } from "@/lib/services/user-growth";
+
+export const dynamic = "force-dynamic";
+
+// Public, unauthenticated endpoint. Returns only aggregate counts —
+// no UIDs, emails, or any other user-level data.
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const series = await getUserGrowthSeries();
+    const body = sliceSeries(series, searchParams.get("days"));
+    return NextResponse.json(body, {
+      headers: {
+        "Cache-Control": "public, max-age=300, s-maxage=300",
+      },
+    });
+  } catch (error: any) {
+    console.error("Public user-growth error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch user growth" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/admin/app/users/page.tsx
+++ b/web/admin/app/users/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import useSWR from "swr";
+import { Users } from "lucide-react";
+
+type UserGrowthResponse = {
+  totalUsers: number;
+  generatedAt: number;
+};
+
+const fetcher = async (url: string): Promise<UserGrowthResponse> => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json();
+};
+
+export default function PublicUsersPage() {
+  useEffect(() => {
+    document.title = "Omi — Users";
+  }, []);
+
+  const { data, error, isLoading } = useSWR<UserGrowthResponse>(
+    "/api/public/user-growth?days=1",
+    fetcher,
+    { revalidateOnFocus: false },
+  );
+
+  const totalUsers = data?.totalUsers;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex items-center justify-center px-4">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <div className="rounded-full bg-primary/10 p-3">
+          <Users className="h-6 w-6 text-primary" />
+        </div>
+        <div className="text-sm uppercase tracking-wide text-muted-foreground">
+          Omi users
+        </div>
+        <div className="text-7xl font-bold tracking-tight tabular-nums">
+          {error
+            ? "—"
+            : isLoading || totalUsers == null
+              ? "…"
+              : totalUsers.toLocaleString()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/admin/lib/services/user-growth.ts
+++ b/web/admin/lib/services/user-growth.ts
@@ -1,0 +1,140 @@
+import { getAdminAuth } from "@/lib/firebase/admin";
+import { getJsonCache, setJsonCache } from "@/lib/redis";
+
+// The Firestore `users` collection has a `created_at` field that was
+// backfilled for ~63K existing users on a single day in late 2024, so it
+// can't be used to derive signup history. Firebase Auth's
+// `metadata.creationTime` is set by the Auth service on account creation
+// and is the authoritative signup timestamp.
+
+export type DailyPoint = { date: string; users: number; cumulative: number };
+
+export type UserGrowthSeries = {
+  data: DailyPoint[];
+  totalUsers: number;
+  generatedAt: number;
+};
+
+export type UserGrowthResponse = {
+  data: DailyPoint[];
+  totalUsers: number;
+  windowUsers: number;
+  days: number;
+  generatedAt: number;
+};
+
+const REDIS_KEY = "admin:stats:daily-new-users:v1";
+const REDIS_TTL_SECONDS = 30 * 60;
+const LOCAL_TTL_MS = 30 * 60 * 1000;
+
+let cachedSeries: UserGrowthSeries | null = null;
+let pendingBuild: Promise<UserGrowthSeries> | null = null;
+
+async function buildDailySeries(): Promise<UserGrowthSeries> {
+  const auth = getAdminAuth();
+  const countsByDate: Record<string, number> = {};
+  let pageToken: string | undefined = undefined;
+  let total = 0;
+  let earliest: Date | null = null;
+  let latest: Date | null = null;
+
+  do {
+    const page = await auth.listUsers(1000, pageToken);
+    for (const user of page.users) {
+      const rawCt = user.metadata?.creationTime;
+      if (!rawCt) continue;
+      const ct = new Date(rawCt);
+      if (Number.isNaN(ct.getTime())) continue;
+      const key = ct.toISOString().slice(0, 10);
+      countsByDate[key] = (countsByDate[key] || 0) + 1;
+      if (!earliest || ct < earliest) earliest = ct;
+      if (!latest || ct > latest) latest = ct;
+      total++;
+    }
+    pageToken = page.pageToken || undefined;
+    // Yield to the event loop between pages so V8 can collect the
+    // previous page's UserRecord objects before we request the next.
+    await new Promise((r) => setImmediate(r));
+  } while (pageToken);
+
+  if (!earliest || !latest) {
+    return { data: [], totalUsers: 0, generatedAt: Date.now() };
+  }
+
+  const endDate = new Date();
+  endDate.setUTCHours(0, 0, 0, 0);
+  const startDate = new Date(
+    Date.UTC(
+      earliest.getUTCFullYear(),
+      earliest.getUTCMonth(),
+      earliest.getUTCDate(),
+    ),
+  );
+
+  const data: DailyPoint[] = [];
+  let running = 0;
+  for (
+    const d = new Date(startDate);
+    d <= endDate;
+    d.setUTCDate(d.getUTCDate() + 1)
+  ) {
+    const key = d.toISOString().slice(0, 10);
+    const users = countsByDate[key] || 0;
+    running += users;
+    data.push({ date: key, users, cumulative: running });
+  }
+
+  return { data, totalUsers: total, generatedAt: Date.now() };
+}
+
+export async function getUserGrowthSeries(): Promise<UserGrowthSeries> {
+  const now = Date.now();
+
+  if (cachedSeries && now - cachedSeries.generatedAt < LOCAL_TTL_MS) {
+    return cachedSeries;
+  }
+
+  const fromRedis = await getJsonCache<UserGrowthSeries>(REDIS_KEY);
+  if (fromRedis && now - fromRedis.generatedAt < LOCAL_TTL_MS) {
+    cachedSeries = fromRedis;
+    return fromRedis;
+  }
+
+  if (pendingBuild) return pendingBuild;
+  pendingBuild = buildDailySeries()
+    .then(async (series) => {
+      cachedSeries = series;
+      await setJsonCache(REDIS_KEY, series, REDIS_TTL_SECONDS);
+      return series;
+    })
+    .finally(() => {
+      pendingBuild = null;
+    });
+  return pendingBuild;
+}
+
+export function sliceSeries(
+  series: UserGrowthSeries,
+  daysParam: string | null | undefined,
+): UserGrowthResponse {
+  const wantsAll = !daysParam || daysParam === "all" || daysParam === "0";
+  const days = wantsAll ? null : Math.max(1, parseInt(daysParam, 10));
+
+  let data = series.data;
+  if (days != null) {
+    const start = new Date();
+    start.setUTCDate(start.getUTCDate() - days);
+    const startKey = start.toISOString().slice(0, 10);
+    data = series.data.filter((p) => p.date >= startKey);
+  }
+
+  const windowUsers = data.reduce((sum, p) => sum + p.users, 0);
+
+  return {
+    data,
+    totalUsers: series.totalUsers,
+    windowUsers,
+    days: days ?? series.data.length,
+    generatedAt: series.generatedAt,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a public `/users` page at `admin.omi.me/users` showing just the total user count — shareable with anyone, no admin login required.
- Adds a companion public API at `/api/public/user-growth` returning only aggregate counts (daily new users, running cumulative, all-time total). No UIDs, emails, or PII.
- Shows the total user count as a large number in the top-left of both the Cumulative Users and Daily New Users charts on the admin analytics page.

## Implementation

- Extracted the existing Firebase Auth scan + Redis cache out of `app/api/omi/stats/daily-new-users/route.ts` into `lib/services/user-growth.ts`, so the admin and public routes share the same 30-minute cached build (no extra listUsers cost).
- Public `/users` page lives outside the `(protected)` route group, so the admin auth gate never runs. It renders a plain number — no navigation, no links into the admin dashboard.
- Public API sets `Cache-Control: public, s-maxage=300`.
- Admin routes and `/login` are unchanged — hitting `/api/omi/stats/daily-new-users` without a token still returns 401.

## Test plan

- [ ] Open https://admin.omi.me/users in an incognito window; verify the total count renders without any login prompt.
- [ ] Hit `/api/public/user-growth?days=30` unauthenticated — confirm it returns aggregate data only (no UIDs or emails).
- [ ] Hit `/api/omi/stats/daily-new-users` unauthenticated — confirm it still returns 401.
- [ ] Load the admin analytics page logged in as an admin — confirm both user charts now show the all-time total as a big number in the top-left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)