### PR TITLE
admin: align infra-cost projections with team-beasts 7-day run-rate

### DIFF
--- a/web/admin/app/api/omi/stats/infra-costs/route.ts
+++ b/web/admin/app/api/omi/stats/infra-costs/route.ts
@@ -92,12 +92,15 @@ const DEFAULT_SERVICE_COSTS: ServiceCostEntry[] = [
   { service: 'Networking', mtd: 495, projection: 1350, desktopWeight: 0.27, mobileWeight: 0.73 },
   { service: 'Cloud Logging', mtd: 326, projection: 890, desktopWeight: 0.27, mobileWeight: 0.73 },
   { service: 'Others', mtd: 638, projection: 1741, desktopWeight: 0.27, mobileWeight: 0.73 },
-  // External LLM bills, not in the GCP table — added so the total matches
-  // the team-report weekly trend (~$4.6K/day). Anthropic is almost
-  // entirely desktop (Claude-Opus floating bar); OpenAI splits 50/50.
-  { service: 'Anthropic', mtd: 7163, projection: 16710, desktopWeight: 0.9, mobileWeight: 0.1 },
-  { service: 'OpenAI', mtd: 7442, projection: 17365, desktopWeight: 0.5, mobileWeight: 0.5 },
-  { service: 'Deepgram', mtd: 5290, projection: 12343, desktopWeight: 0.2, mobileWeight: 0.8 },
+  // External LLM bills, not in the GCP table. Projections are the team-
+  // beasts daily-report 7-day totals extrapolated to 30 days
+  // (weekly × 30/7) so the dashboard matches the reported ~$4.6K/day run
+  // rate instead of undershooting at the older MTD-based estimates.
+  // Anthropic is almost entirely desktop (Claude-Opus floating bar);
+  // OpenAI splits 50/50.
+  { service: 'Anthropic', mtd: 7163, projection: 30699, desktopWeight: 0.9, mobileWeight: 0.1 },
+  { service: 'OpenAI', mtd: 7442, projection: 31895, desktopWeight: 0.5, mobileWeight: 0.5 },
+  { service: 'Deepgram', mtd: 5290, projection: 22672, desktopWeight: 0.2, mobileWeight: 0.8 },
 ];
 
 function loadServiceCosts(): ServiceCostEntry[] {
@@ -139,7 +142,7 @@ function computeMonthlyOverheadByPlatform(services: ServiceCostEntry[]): { deskt
   return { desktop, mobile, total };
 }
 
-const CACHE_PREFIX = "admin:stats:infra-costs:v1";
+const CACHE_PREFIX = "admin:stats:infra-costs:v2";
 const CACHE_TTL_SECONDS = 30 * 60;
 
 // User-provided April projection. Override with ADMIN_INFRA_OVERHEAD_MONTHLY

--- a/web/admin/components/swr-provider.tsx
+++ b/web/admin/components/swr-provider.tsx
@@ -11,7 +11,7 @@ import { ReactNode, useMemo } from 'react';
 //
 // We cap each entry at ~1MB and the total payload at ~5MB, because the
 // iOS/desktop webkit localStorage quota is 5MB per origin.
-const STORAGE_KEY = 'omi-admin-swr-cache-v3';
+const STORAGE_KEY = 'omi-admin-swr-cache-v4';
 const MAX_ENTRY_BYTES = 1_000_000;
 const MAX_TOTAL_BYTES = 5_000_000;
 


### PR DESCRIPTION
## Summary
- External-LLM projections in the Profitability ➜ Monthly infra cost by service breakdown were undershooting the reported spend ($104K/mo in dashboard vs ~$138K/mo on the team-beasts daily report).
- Bumped Anthropic / OpenAI / Deepgram to the 7-day report × 30/7. GCP rows were already accurate and are unchanged.
- Bumped `CACHE_PREFIX` → v2 (server Redis) and SWR `STORAGE_KEY` → v4 (client localStorage) so open sessions refetch instead of showing the stale cached payload.

## Test plan
- [ ] Hard-refresh `/dashboard/analytics`
- [ ] Profitability → **Monthly infra cost by service** table: Anthropic ≈ $30.7K, OpenAI ≈ $31.9K, Deepgram ≈ $22.7K in "Apr projection" column
- [ ] **Total infra cost / day**: daily desktop + mobile ≈ $4.6K/day; 30d total ≈ $138K
- [ ] **Cost / user / day**: mobile line is non-zero, desktop line stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)