### PR TITLE
fix(desktop): remove ElevenLabs API key from backend responses (#6827)

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -72,7 +72,6 @@ jobs:
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
             AGENT_GCS_BUCKET=based-hardware-agent
-            DISABLE_ELEVENLABS_KEY_RESPONSE=false
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
@@ -139,7 +138,6 @@ jobs:
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
             AGENT_GCS_BUCKET=based-hardware-agent
-            DISABLE_ELEVENLABS_KEY_RESPONSE=false
           secrets: |
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             GEMINI_API_KEY=DESKTOP_GEMINI_API_KEY:latest

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -61,7 +61,6 @@ jobs:
           env_vars: |
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
-            DISABLE_ELEVENLABS_KEY_RESPONSE=false
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -69,13 +69,10 @@ pub struct Config {
     pub deepgram_api_key: Option<String>,
     /// Anthropic API key for chat (served to desktop clients)
     pub anthropic_api_key: Option<String>,
-    /// ElevenLabs API key for floating bar voice answers (served to desktop clients)
+    /// ElevenLabs API key for TTS proxy (used server-side by /v1/tts/synthesize, never served to clients)
     pub elevenlabs_api_key: Option<String>,
     /// Google Calendar API key (served to desktop clients)
     pub google_calendar_api_key: Option<String>,
-    /// When true, omit ElevenLabs API key from /v1/config/api-keys response.
-    /// Set this after all clients have updated to use the TTS proxy (issue #6622).
-    pub disable_elevenlabs_key_response: bool,
 }
 
 impl Config {
@@ -137,9 +134,6 @@ impl Config {
             anthropic_api_key: env::var("ANTHROPIC_API_KEY").ok(),
             elevenlabs_api_key: env::var("ELEVENLABS_API_KEY").ok(),
             google_calendar_api_key: env::var("GOOGLE_CALENDAR_API_KEY").ok(),
-            disable_elevenlabs_key_response: env::var("DISABLE_ELEVENLABS_KEY_RESPONSE")
-                .map(|v| v == "true" || v == "1")
-                .unwrap_or(false),
         }
     }
 

--- a/desktop/Backend-Rust/src/routes/config.rs
+++ b/desktop/Backend-Rust/src/routes/config.rs
@@ -1,12 +1,9 @@
 // Client configuration routes
 // Serves API keys to authenticated desktop clients so keys are not bundled in the app binary.
 //
-// Deepgram and Gemini keys are NO LONGER served here — they are proxied server-side
-// via /v1/proxy/deepgram/* and /v1/proxy/gemini/* (see proxy.rs, issue #5861).
-//
-// ElevenLabs key: new clients use the TTS proxy at /v1/tts/synthesize (issue #6622),
-// but the key is still served here for backward compatibility with older app versions.
-// Set DISABLE_ELEVENLABS_KEY_RESPONSE=true to stop serving it once all clients have updated.
+// Deepgram, Gemini, and ElevenLabs keys are NO LONGER served here — they are proxied
+// server-side via /v1/proxy/deepgram/*, /v1/proxy/gemini/*, and /v1/tts/synthesize
+// (see proxy.rs, tts.rs; issues #5861, #6622).
 
 use axum::{extract::State, routing::get, Json, Router};
 use serde::Serialize;
@@ -22,25 +19,16 @@ struct ApiKeysResponse {
     firebase_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     google_calendar_api_key: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    elevenlabs_api_key: Option<String>,
 }
 
 /// GET /v1/config/api-keys — return API keys for the authenticated user
 /// NOTE: Deepgram, Gemini keys removed — proxied server-side (issue #5861)
-/// NOTE: ElevenLabs key gated by DISABLE_ELEVENLABS_KEY_RESPONSE (issue #6622)
+/// NOTE: ElevenLabs key removed — proxied via /v1/tts/synthesize (issue #6622, #6827)
 async fn get_api_keys(State(state): State<AppState>, _user: AuthUser) -> Json<ApiKeysResponse> {
-    let elevenlabs_key = if state.config.disable_elevenlabs_key_response {
-        None
-    } else {
-        state.config.elevenlabs_api_key.clone()
-    };
-
     Json(ApiKeysResponse {
         anthropic_api_key: state.config.anthropic_api_key.clone(),
         firebase_api_key: state.config.firebase_api_key.clone(),
         google_calendar_api_key: state.config.google_calendar_api_key.clone(),
-        elevenlabs_api_key: elevenlabs_key,
     })
 }
 


### PR DESCRIPTION
## Summary
- Remove `elevenlabs_api_key` from the `/v1/config/api-keys` response — the key is no longer served to any client
- Remove the transitional `DISABLE_ELEVENLABS_KEY_RESPONSE` flag from backend config and all CI/CD workflows
- `ELEVENLABS_API_KEY` secret is **kept** in deployments — still used server-side by the TTS proxy (`/v1/tts/synthesize`)

## Context
PR #6623 migrated desktop TTS to a server-side proxy so the ElevenLabs API key never leaves the backend. The `DISABLE_ELEVENLABS_KEY_RESPONSE` flag was added as a transitional kill-switch, currently set to `false` in all environments — meaning the key was still being served. This PR completes the migration by permanently removing the key from API responses.

## Files changed
| File | Change |
|------|--------|
| `desktop/Backend-Rust/src/routes/config.rs` | Remove `elevenlabs_api_key` from `ApiKeysResponse` struct and conditional logic |
| `desktop/Backend-Rust/src/config.rs` | Remove `disable_elevenlabs_key_response` field and env var loading |
| `.github/workflows/desktop_auto_release.yml` | Remove `DISABLE_ELEVENLABS_KEY_RESPONSE=false` from dev and prod deploy steps |
| `.github/workflows/desktop_backend_auto_dev.yml` | Remove `DISABLE_ELEVENLABS_KEY_RESPONSE=false` from dev deploy step |

## Risk assessment
- **Low risk**: Desktop client (`APIKeyService.swift`) already does NOT decode `elevenlabs_api_key` from the response
- **No breakage**: TTS proxy continues to work — `ELEVENLABS_API_KEY` env var and secret are unchanged
- **Old clients**: Pre-proxy desktop versions would lose the key, but all shipped versions already use the proxy

## Test plan
- [x] `cargo check` passes — no compilation errors
- [x] Verified TTS proxy route (`tts.rs`) still reads `config.elevenlabs_api_key` server-side
- [x] Verified desktop `ApiKeysResponse` Swift struct does not reference `elevenlabs_api_key`
- [ ] Deploy to dev and verify `/v1/config/api-keys` no longer includes ElevenLabs key
- [ ] Verify TTS voice playback still works via proxy

Closes #6827
Follows up on #6622, #6623

_by AI for @beastoin_