### PR TITLE
Desktop: add ModelQoS tier system for AI model cost optimization

### DIFF
--- a/desktop/Backend-Rust/src/llm/client.rs
+++ b/desktop/Backend-Rust/src/llm/client.rs
@@ -221,7 +221,6 @@ impl LlmClient {
     }
 
     /// Set the model to use
-    #[allow(dead_code)]
     pub fn with_model(mut self, model: &str) -> Self {
         self.model = model.to_string();
         self

--- a/desktop/Backend-Rust/src/llm/client.rs
+++ b/desktop/Backend-Rust/src/llm/client.rs
@@ -1183,7 +1183,7 @@ mod tests {
     fn with_model_extraction_uses_extraction_accessor() {
         let client = LlmClient::new("test-key".to_string())
             .with_model(super::super::model_qos::gemini_extraction());
-        // In test env (standard tier), extraction == default == flash
+        // In test env (premium tier), extraction == default == flash
         assert_eq!(client.model, "gemini-3-flash-preview");
     }
 }

--- a/desktop/Backend-Rust/src/llm/client.rs
+++ b/desktop/Backend-Rust/src/llm/client.rs
@@ -211,12 +211,12 @@ struct GeminiPartResponse {
 }
 
 impl LlmClient {
-    /// Create a new Gemini client
+    /// Create a new Gemini client with the QoS-configured default model.
     pub fn new(api_key: String) -> Self {
         Self {
             client: Client::new(),
             api_key,
-            model: "gemini-3-flash-preview".to_string(),
+            model: super::model_qos::gemini_default().to_string(),
         }
     }
 

--- a/desktop/Backend-Rust/src/llm/client.rs
+++ b/desktop/Backend-Rust/src/llm/client.rs
@@ -1161,3 +1161,29 @@ Return relationships as source -> relationship -> target triples."#,
         Ok(result)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_uses_qos_default_model() {
+        let client = LlmClient::new("test-key".to_string());
+        assert_eq!(client.model, super::super::model_qos::gemini_default());
+    }
+
+    #[test]
+    fn with_model_overrides_default() {
+        let client = LlmClient::new("test-key".to_string())
+            .with_model("gemini-pro-latest");
+        assert_eq!(client.model, "gemini-pro-latest");
+    }
+
+    #[test]
+    fn with_model_extraction_uses_extraction_accessor() {
+        let client = LlmClient::new("test-key".to_string())
+            .with_model(super::super::model_qos::gemini_extraction());
+        // In test env (standard tier), extraction == default == flash
+        assert_eq!(client.model, "gemini-3-flash-preview");
+    }
+}

--- a/desktop/Backend-Rust/src/llm/mod.rs
+++ b/desktop/Backend-Rust/src/llm/mod.rs
@@ -1,6 +1,7 @@
 // LLM module
 
 pub mod client;
+pub mod model_qos;
 pub mod persona;
 pub mod prompts;
 

--- a/desktop/Backend-Rust/src/llm/model_qos.rs
+++ b/desktop/Backend-Rust/src/llm/model_qos.rs
@@ -94,11 +94,8 @@ pub fn daily_hard_limit() -> u32 {
     daily_hard_limit_for(active_tier())
 }
 
-fn daily_hard_limit_for(tier: ModelTier) -> u32 {
-    match tier {
-        ModelTier::Standard => 500,
-        ModelTier::Premium => 1500,
-    }
+fn daily_hard_limit_for(_tier: ModelTier) -> u32 {
+    1500
 }
 
 /// Tier description for logging.
@@ -212,12 +209,8 @@ mod tests {
     }
 
     #[test]
-    fn daily_hard_limit_standard() {
-        assert_eq!(daily_hard_limit_for(ModelTier::Standard), 500);
-    }
-
-    #[test]
-    fn daily_hard_limit_premium() {
+    fn daily_hard_limit_same_for_both_tiers() {
+        assert_eq!(daily_hard_limit_for(ModelTier::Standard), 1500);
         assert_eq!(daily_hard_limit_for(ModelTier::Premium), 1500);
     }
 

--- a/desktop/Backend-Rust/src/llm/model_qos.rs
+++ b/desktop/Backend-Rust/src/llm/model_qos.rs
@@ -3,7 +3,7 @@
 // Central model configuration with switchable tiers, mirroring the Swift ModelQoS.
 // All LlmClient call sites should use these accessors instead of hardcoded model strings.
 //
-// Tier is read from OMI_MODEL_TIER env var at startup (default: "standard").
+// Tier is read from OMI_MODEL_TIER env var at startup (default: "premium").
 
 use std::sync::OnceLock;
 
@@ -13,16 +13,16 @@ static ACTIVE_TIER: OnceLock<ModelTier> = OnceLock::new();
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ModelTier {
     /// Cost-optimized: Flash for all Gemini workloads
-    Standard,
-    /// Quality-optimized: Pro for structured extraction, Flash for simple tasks
     Premium,
+    /// Quality-optimized: Pro for structured extraction, Flash for simple tasks
+    Max,
 }
 
 impl ModelTier {
     fn from_env() -> Self {
         match std::env::var("OMI_MODEL_TIER").as_deref() {
-            Ok("premium") => ModelTier::Premium,
-            _ => ModelTier::Standard,
+            Ok("max") => ModelTier::Max,
+            _ => ModelTier::Premium,
         }
     }
 }
@@ -41,8 +41,8 @@ pub fn gemini_default() -> &'static str {
 
 fn gemini_default_for(tier: ModelTier) -> &'static str {
     match tier {
-        ModelTier::Standard => "gemini-3-flash-preview",
         ModelTier::Premium => "gemini-3-flash-preview",
+        ModelTier::Max => "gemini-3-flash-preview",
     }
 }
 
@@ -53,8 +53,8 @@ pub fn gemini_extraction() -> &'static str {
 
 fn gemini_extraction_for(tier: ModelTier) -> &'static str {
     match tier {
-        ModelTier::Standard => "gemini-3-flash-preview",
-        ModelTier::Premium => "gemini-pro-latest",
+        ModelTier::Premium => "gemini-3-flash-preview",
+        ModelTier::Max => "gemini-pro-latest",
     }
 }
 
@@ -76,16 +76,16 @@ pub fn gemini_degrade_target() -> &'static str {
 // MARK: - Rate Limit Thresholds (tier-aware)
 
 /// Daily soft limit — at or above this, Pro requests degrade to Flash.
-/// Standard: aggressive (30) since standard already sends Flash.
-/// Premium: generous (300) to allow Pro usage.
+/// Premium: aggressive (30) since premium already sends Flash.
+/// Max: generous (300) to allow Pro usage.
 pub fn daily_soft_limit() -> u32 {
     daily_soft_limit_for(active_tier())
 }
 
 fn daily_soft_limit_for(tier: ModelTier) -> u32 {
     match tier {
-        ModelTier::Standard => 30,
-        ModelTier::Premium => 300,
+        ModelTier::Premium => 30,
+        ModelTier::Max => 300,
     }
 }
 
@@ -105,8 +105,8 @@ pub fn tier_description() -> &'static str {
 
 fn tier_description_for(tier: ModelTier) -> &'static str {
     match tier {
-        ModelTier::Standard => "Standard (cost-optimized)",
-        ModelTier::Premium => "Premium (quality-optimized)",
+        ModelTier::Premium => "Premium (cost-optimized)",
+        ModelTier::Max => "Max (quality-optimized)",
     }
 }
 
@@ -115,7 +115,7 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    /// Serialize env-var–mutating tests to avoid races under parallel execution.
+    /// Serialize env-var-mutating tests to avoid races under parallel execution.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // --- ModelTier::from_env (serialized — shares process env) ---
@@ -124,21 +124,21 @@ mod tests {
     fn from_env_all_cases() {
         let _guard = ENV_LOCK.lock().unwrap();
 
-        // Default (unset) → Standard
+        // Default (unset) → Premium
         std::env::remove_var("OMI_MODEL_TIER");
-        assert_eq!(ModelTier::from_env(), ModelTier::Standard);
-
-        // Explicit premium → Premium
-        std::env::set_var("OMI_MODEL_TIER", "premium");
         assert_eq!(ModelTier::from_env(), ModelTier::Premium);
 
-        // Invalid value → Standard fallback
-        std::env::set_var("OMI_MODEL_TIER", "garbage");
-        assert_eq!(ModelTier::from_env(), ModelTier::Standard);
+        // Explicit max → Max
+        std::env::set_var("OMI_MODEL_TIER", "max");
+        assert_eq!(ModelTier::from_env(), ModelTier::Max);
 
-        // Empty string → Standard fallback
+        // Invalid value → Premium fallback
+        std::env::set_var("OMI_MODEL_TIER", "garbage");
+        assert_eq!(ModelTier::from_env(), ModelTier::Premium);
+
+        // Empty string → Premium fallback
         std::env::set_var("OMI_MODEL_TIER", "");
-        assert_eq!(ModelTier::from_env(), ModelTier::Standard);
+        assert_eq!(ModelTier::from_env(), ModelTier::Premium);
 
         std::env::remove_var("OMI_MODEL_TIER");
     }
@@ -146,38 +146,38 @@ mod tests {
     // --- gemini_default_for (both tiers) ---
 
     #[test]
-    fn gemini_default_standard_is_flash() {
-        assert_eq!(gemini_default_for(ModelTier::Standard), "gemini-3-flash-preview");
+    fn gemini_default_premium_is_flash() {
+        assert_eq!(gemini_default_for(ModelTier::Premium), "gemini-3-flash-preview");
     }
 
     #[test]
-    fn gemini_default_premium_is_flash() {
+    fn gemini_default_max_is_flash() {
         // Default model is Flash for both tiers (cheap baseline)
-        assert_eq!(gemini_default_for(ModelTier::Premium), "gemini-3-flash-preview");
+        assert_eq!(gemini_default_for(ModelTier::Max), "gemini-3-flash-preview");
     }
 
     // --- gemini_extraction_for (the tier-dependent branch) ---
 
     #[test]
-    fn gemini_extraction_standard_is_flash() {
-        assert_eq!(gemini_extraction_for(ModelTier::Standard), "gemini-3-flash-preview");
+    fn gemini_extraction_premium_is_flash() {
+        assert_eq!(gemini_extraction_for(ModelTier::Premium), "gemini-3-flash-preview");
     }
 
     #[test]
-    fn gemini_extraction_premium_is_pro() {
-        assert_eq!(gemini_extraction_for(ModelTier::Premium), "gemini-pro-latest");
+    fn gemini_extraction_max_is_pro() {
+        assert_eq!(gemini_extraction_for(ModelTier::Max), "gemini-pro-latest");
     }
 
     // --- tier_description_for ---
 
     #[test]
-    fn tier_description_standard() {
-        assert!(tier_description_for(ModelTier::Standard).contains("Standard"));
+    fn tier_description_premium() {
+        assert!(tier_description_for(ModelTier::Premium).contains("Premium"));
     }
 
     #[test]
-    fn tier_description_premium() {
-        assert!(tier_description_for(ModelTier::Premium).contains("Premium"));
+    fn tier_description_max() {
+        assert!(tier_description_for(ModelTier::Max).contains("Max"));
     }
 
     // --- Static accessors (pinned models) ---
@@ -199,24 +199,24 @@ mod tests {
     // --- Rate limit thresholds ---
 
     #[test]
-    fn daily_soft_limit_standard_is_lower() {
-        assert_eq!(daily_soft_limit_for(ModelTier::Standard), 30);
+    fn daily_soft_limit_premium_is_lower() {
+        assert_eq!(daily_soft_limit_for(ModelTier::Premium), 30);
     }
 
     #[test]
-    fn daily_soft_limit_premium_is_higher() {
-        assert_eq!(daily_soft_limit_for(ModelTier::Premium), 300);
+    fn daily_soft_limit_max_is_higher() {
+        assert_eq!(daily_soft_limit_for(ModelTier::Max), 300);
     }
 
     #[test]
     fn daily_hard_limit_same_for_both_tiers() {
-        assert_eq!(daily_hard_limit_for(ModelTier::Standard), 1500);
         assert_eq!(daily_hard_limit_for(ModelTier::Premium), 1500);
+        assert_eq!(daily_hard_limit_for(ModelTier::Max), 1500);
     }
 
     #[test]
     fn soft_limit_always_below_hard_limit() {
-        for tier in [ModelTier::Standard, ModelTier::Premium] {
+        for tier in [ModelTier::Premium, ModelTier::Max] {
             assert!(daily_soft_limit_for(tier) < daily_hard_limit_for(tier));
         }
     }

--- a/desktop/Backend-Rust/src/llm/model_qos.rs
+++ b/desktop/Backend-Rust/src/llm/model_qos.rs
@@ -1,0 +1,108 @@
+// Model QoS Tier System for Rust Backend
+//
+// Central model configuration with switchable tiers, mirroring the Swift ModelQoS.
+// All LlmClient call sites should use these accessors instead of hardcoded model strings.
+//
+// Tier is read from OMI_MODEL_TIER env var at startup (default: "standard").
+
+use std::sync::OnceLock;
+
+/// Active tier, resolved once from OMI_MODEL_TIER env var.
+static ACTIVE_TIER: OnceLock<ModelTier> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ModelTier {
+    /// Cost-optimized: Flash for all Gemini workloads
+    Standard,
+    /// Quality-optimized: Pro for structured extraction, Flash for simple tasks
+    Premium,
+}
+
+impl ModelTier {
+    fn from_env() -> Self {
+        match std::env::var("OMI_MODEL_TIER").as_deref() {
+            Ok("premium") => ModelTier::Premium,
+            _ => ModelTier::Standard,
+        }
+    }
+}
+
+/// Get the active model tier (resolved once from env).
+pub fn active_tier() -> ModelTier {
+    *ACTIVE_TIER.get_or_init(ModelTier::from_env)
+}
+
+// MARK: - Gemini Models
+
+/// Default model for LlmClient (used by chat, conversations, personas, knowledge graph).
+pub fn gemini_default() -> &'static str {
+    match active_tier() {
+        ModelTier::Standard => "gemini-3-flash-preview",
+        ModelTier::Premium => "gemini-3-flash-preview",
+    }
+}
+
+/// Model for structured extraction tasks (conversations, knowledge graph).
+pub fn gemini_extraction() -> &'static str {
+    match active_tier() {
+        ModelTier::Standard => "gemini-3-flash-preview",
+        ModelTier::Premium => "gemini-pro-latest",
+    }
+}
+
+/// Allowed models for the Gemini proxy (passthrough from Swift app).
+/// These are the models the desktop app is allowed to request.
+pub fn gemini_proxy_allowed() -> &'static [&'static str] {
+    &[
+        "gemini-3-flash-preview",
+        "gemini-pro-latest",
+        "gemini-embedding-001",
+    ]
+}
+
+/// Model that rate-limited Pro requests degrade to.
+pub fn gemini_degrade_target() -> &'static str {
+    "gemini-3-flash-preview"
+}
+
+/// Tier description for logging.
+pub fn tier_description() -> &'static str {
+    match active_tier() {
+        ModelTier::Standard => "Standard (cost-optimized)",
+        ModelTier::Premium => "Premium (quality-optimized)",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_tier_is_standard() {
+        // Without OMI_MODEL_TIER set, should default to standard
+        // (OnceLock may already be initialized, so test the from_env logic directly)
+        let tier = ModelTier::from_env();
+        // In test environment without the env var, this should be Standard
+        assert_eq!(tier, ModelTier::Standard);
+    }
+
+    #[test]
+    fn test_gemini_default_returns_flash() {
+        // Standard tier always uses flash
+        assert_eq!(gemini_default(), "gemini-3-flash-preview");
+    }
+
+    #[test]
+    fn test_proxy_allowed_contains_expected_models() {
+        let allowed = gemini_proxy_allowed();
+        assert!(allowed.contains(&"gemini-3-flash-preview"));
+        assert!(allowed.contains(&"gemini-pro-latest"));
+        assert!(allowed.contains(&"gemini-embedding-001"));
+        assert!(!allowed.contains(&"gemini-ultra"));
+    }
+
+    #[test]
+    fn test_degrade_target_is_flash() {
+        assert_eq!(gemini_degrade_target(), "gemini-3-flash-preview");
+    }
+}

--- a/desktop/Backend-Rust/src/llm/model_qos.rs
+++ b/desktop/Backend-Rust/src/llm/model_qos.rs
@@ -36,7 +36,11 @@ pub fn active_tier() -> ModelTier {
 
 /// Default model for LlmClient (used by chat, conversations, personas, knowledge graph).
 pub fn gemini_default() -> &'static str {
-    match active_tier() {
+    gemini_default_for(active_tier())
+}
+
+fn gemini_default_for(tier: ModelTier) -> &'static str {
+    match tier {
         ModelTier::Standard => "gemini-3-flash-preview",
         ModelTier::Premium => "gemini-3-flash-preview",
     }
@@ -44,7 +48,11 @@ pub fn gemini_default() -> &'static str {
 
 /// Model for structured extraction tasks (conversations, knowledge graph).
 pub fn gemini_extraction() -> &'static str {
-    match active_tier() {
+    gemini_extraction_for(active_tier())
+}
+
+fn gemini_extraction_for(tier: ModelTier) -> &'static str {
+    match tier {
         ModelTier::Standard => "gemini-3-flash-preview",
         ModelTier::Premium => "gemini-pro-latest",
     }
@@ -67,7 +75,11 @@ pub fn gemini_degrade_target() -> &'static str {
 
 /// Tier description for logging.
 pub fn tier_description() -> &'static str {
-    match active_tier() {
+    tier_description_for(active_tier())
+}
+
+fn tier_description_for(tier: ModelTier) -> &'static str {
+    match tier {
         ModelTier::Standard => "Standard (cost-optimized)",
         ModelTier::Premium => "Premium (quality-optimized)",
     }
@@ -77,23 +89,76 @@ pub fn tier_description() -> &'static str {
 mod tests {
     use super::*;
 
+    // --- ModelTier::from_env ---
+
     #[test]
-    fn test_default_tier_is_standard() {
-        // Without OMI_MODEL_TIER set, should default to standard
-        // (OnceLock may already be initialized, so test the from_env logic directly)
-        let tier = ModelTier::from_env();
-        // In test environment without the env var, this should be Standard
-        assert_eq!(tier, ModelTier::Standard);
+    fn from_env_defaults_to_standard() {
+        std::env::remove_var("OMI_MODEL_TIER");
+        assert_eq!(ModelTier::from_env(), ModelTier::Standard);
     }
 
     #[test]
-    fn test_gemini_default_returns_flash() {
-        // Standard tier always uses flash
-        assert_eq!(gemini_default(), "gemini-3-flash-preview");
+    fn from_env_premium() {
+        std::env::set_var("OMI_MODEL_TIER", "premium");
+        assert_eq!(ModelTier::from_env(), ModelTier::Premium);
+        std::env::remove_var("OMI_MODEL_TIER");
     }
 
     #[test]
-    fn test_proxy_allowed_contains_expected_models() {
+    fn from_env_invalid_falls_back_to_standard() {
+        std::env::set_var("OMI_MODEL_TIER", "garbage");
+        assert_eq!(ModelTier::from_env(), ModelTier::Standard);
+        std::env::remove_var("OMI_MODEL_TIER");
+    }
+
+    #[test]
+    fn from_env_empty_falls_back_to_standard() {
+        std::env::set_var("OMI_MODEL_TIER", "");
+        assert_eq!(ModelTier::from_env(), ModelTier::Standard);
+        std::env::remove_var("OMI_MODEL_TIER");
+    }
+
+    // --- gemini_default_for (both tiers) ---
+
+    #[test]
+    fn gemini_default_standard_is_flash() {
+        assert_eq!(gemini_default_for(ModelTier::Standard), "gemini-3-flash-preview");
+    }
+
+    #[test]
+    fn gemini_default_premium_is_flash() {
+        // Default model is Flash for both tiers (cheap baseline)
+        assert_eq!(gemini_default_for(ModelTier::Premium), "gemini-3-flash-preview");
+    }
+
+    // --- gemini_extraction_for (the tier-dependent branch) ---
+
+    #[test]
+    fn gemini_extraction_standard_is_flash() {
+        assert_eq!(gemini_extraction_for(ModelTier::Standard), "gemini-3-flash-preview");
+    }
+
+    #[test]
+    fn gemini_extraction_premium_is_pro() {
+        assert_eq!(gemini_extraction_for(ModelTier::Premium), "gemini-pro-latest");
+    }
+
+    // --- tier_description_for ---
+
+    #[test]
+    fn tier_description_standard() {
+        assert!(tier_description_for(ModelTier::Standard).contains("Standard"));
+    }
+
+    #[test]
+    fn tier_description_premium() {
+        assert!(tier_description_for(ModelTier::Premium).contains("Premium"));
+    }
+
+    // --- Static accessors (pinned models) ---
+
+    #[test]
+    fn proxy_allowed_contains_expected_models() {
         let allowed = gemini_proxy_allowed();
         assert!(allowed.contains(&"gemini-3-flash-preview"));
         assert!(allowed.contains(&"gemini-pro-latest"));
@@ -102,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_degrade_target_is_flash() {
+    fn degrade_target_is_flash() {
         assert_eq!(gemini_degrade_target(), "gemini-3-flash-preview");
     }
 }

--- a/desktop/Backend-Rust/src/llm/model_qos.rs
+++ b/desktop/Backend-Rust/src/llm/model_qos.rs
@@ -88,33 +88,33 @@ fn tier_description_for(tier: ModelTier) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
-    // --- ModelTier::from_env ---
+    /// Serialize env-var–mutating tests to avoid races under parallel execution.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // --- ModelTier::from_env (serialized — shares process env) ---
 
     #[test]
-    fn from_env_defaults_to_standard() {
+    fn from_env_all_cases() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        // Default (unset) → Standard
         std::env::remove_var("OMI_MODEL_TIER");
         assert_eq!(ModelTier::from_env(), ModelTier::Standard);
-    }
 
-    #[test]
-    fn from_env_premium() {
+        // Explicit premium → Premium
         std::env::set_var("OMI_MODEL_TIER", "premium");
         assert_eq!(ModelTier::from_env(), ModelTier::Premium);
-        std::env::remove_var("OMI_MODEL_TIER");
-    }
 
-    #[test]
-    fn from_env_invalid_falls_back_to_standard() {
+        // Invalid value → Standard fallback
         std::env::set_var("OMI_MODEL_TIER", "garbage");
         assert_eq!(ModelTier::from_env(), ModelTier::Standard);
-        std::env::remove_var("OMI_MODEL_TIER");
-    }
 
-    #[test]
-    fn from_env_empty_falls_back_to_standard() {
+        // Empty string → Standard fallback
         std::env::set_var("OMI_MODEL_TIER", "");
         assert_eq!(ModelTier::from_env(), ModelTier::Standard);
+
         std::env::remove_var("OMI_MODEL_TIER");
     }
 

--- a/desktop/Backend-Rust/src/llm/model_qos.rs
+++ b/desktop/Backend-Rust/src/llm/model_qos.rs
@@ -12,9 +12,9 @@ static ACTIVE_TIER: OnceLock<ModelTier> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ModelTier {
-    /// Cost-optimized: Flash for all Gemini workloads
+    /// Cost-optimized: Flash for all Gemini workloads, lower rate limits
     Premium,
-    /// Quality-optimized: Pro for structured extraction, Flash for simple tasks
+    /// Quality-optimized: same models, higher rate limits
     Max,
 }
 
@@ -51,11 +51,8 @@ pub fn gemini_extraction() -> &'static str {
     gemini_extraction_for(active_tier())
 }
 
-fn gemini_extraction_for(tier: ModelTier) -> &'static str {
-    match tier {
-        ModelTier::Premium => "gemini-3-flash-preview",
-        ModelTier::Max => "gemini-pro-latest",
-    }
+fn gemini_extraction_for(_tier: ModelTier) -> &'static str {
+    "gemini-3-flash-preview"
 }
 
 /// Allowed models for the Gemini proxy (passthrough from Swift app).
@@ -63,7 +60,6 @@ fn gemini_extraction_for(tier: ModelTier) -> &'static str {
 pub fn gemini_proxy_allowed() -> &'static [&'static str] {
     &[
         "gemini-3-flash-preview",
-        "gemini-pro-latest",
         "gemini-embedding-001",
     ]
 }
@@ -159,13 +155,9 @@ mod tests {
     // --- gemini_extraction_for (the tier-dependent branch) ---
 
     #[test]
-    fn gemini_extraction_premium_is_flash() {
+    fn gemini_extraction_is_flash_for_both_tiers() {
         assert_eq!(gemini_extraction_for(ModelTier::Premium), "gemini-3-flash-preview");
-    }
-
-    #[test]
-    fn gemini_extraction_max_is_pro() {
-        assert_eq!(gemini_extraction_for(ModelTier::Max), "gemini-pro-latest");
+        assert_eq!(gemini_extraction_for(ModelTier::Max), "gemini-3-flash-preview");
     }
 
     // --- tier_description_for ---
@@ -186,8 +178,8 @@ mod tests {
     fn proxy_allowed_contains_expected_models() {
         let allowed = gemini_proxy_allowed();
         assert!(allowed.contains(&"gemini-3-flash-preview"));
-        assert!(allowed.contains(&"gemini-pro-latest"));
         assert!(allowed.contains(&"gemini-embedding-001"));
+        assert!(!allowed.contains(&"gemini-pro-latest"), "pro removed from allowlist");
         assert!(!allowed.contains(&"gemini-ultra"));
     }
 

--- a/desktop/Backend-Rust/src/llm/model_qos.rs
+++ b/desktop/Backend-Rust/src/llm/model_qos.rs
@@ -73,6 +73,34 @@ pub fn gemini_degrade_target() -> &'static str {
     "gemini-3-flash-preview"
 }
 
+// MARK: - Rate Limit Thresholds (tier-aware)
+
+/// Daily soft limit — at or above this, Pro requests degrade to Flash.
+/// Standard: aggressive (30) since standard already sends Flash.
+/// Premium: generous (300) to allow Pro usage.
+pub fn daily_soft_limit() -> u32 {
+    daily_soft_limit_for(active_tier())
+}
+
+fn daily_soft_limit_for(tier: ModelTier) -> u32 {
+    match tier {
+        ModelTier::Standard => 30,
+        ModelTier::Premium => 300,
+    }
+}
+
+/// Daily hard limit — at or above this, all requests are rejected (429).
+pub fn daily_hard_limit() -> u32 {
+    daily_hard_limit_for(active_tier())
+}
+
+fn daily_hard_limit_for(tier: ModelTier) -> u32 {
+    match tier {
+        ModelTier::Standard => 500,
+        ModelTier::Premium => 1500,
+    }
+}
+
 /// Tier description for logging.
 pub fn tier_description() -> &'static str {
     tier_description_for(active_tier())
@@ -169,5 +197,34 @@ mod tests {
     #[test]
     fn degrade_target_is_flash() {
         assert_eq!(gemini_degrade_target(), "gemini-3-flash-preview");
+    }
+
+    // --- Rate limit thresholds ---
+
+    #[test]
+    fn daily_soft_limit_standard_is_lower() {
+        assert_eq!(daily_soft_limit_for(ModelTier::Standard), 30);
+    }
+
+    #[test]
+    fn daily_soft_limit_premium_is_higher() {
+        assert_eq!(daily_soft_limit_for(ModelTier::Premium), 300);
+    }
+
+    #[test]
+    fn daily_hard_limit_standard() {
+        assert_eq!(daily_hard_limit_for(ModelTier::Standard), 500);
+    }
+
+    #[test]
+    fn daily_hard_limit_premium() {
+        assert_eq!(daily_hard_limit_for(ModelTier::Premium), 1500);
+    }
+
+    #[test]
+    fn soft_limit_always_below_hard_limit() {
+        for tier in [ModelTier::Standard, ModelTier::Premium] {
+            assert!(daily_soft_limit_for(tier) < daily_hard_limit_for(tier));
+        }
     }
 }

--- a/desktop/Backend-Rust/src/main.rs
+++ b/desktop/Backend-Rust/src/main.rs
@@ -90,7 +90,11 @@ async fn main() {
     dotenvy::dotenv().ok();
 
     // Log active QoS tier
-    tracing::info!("Model QoS tier: {}", llm::model_qos::tier_description());
+    tracing::info!("Model QoS tier: {} | rate limits: soft={}, hard={}",
+        llm::model_qos::tier_description(),
+        llm::model_qos::daily_soft_limit(),
+        llm::model_qos::daily_hard_limit(),
+    );
 
     // Load and validate config
     let config = Config::from_env();

--- a/desktop/Backend-Rust/src/main.rs
+++ b/desktop/Backend-Rust/src/main.rs
@@ -89,6 +89,9 @@ async fn main() {
     // Load environment variables
     dotenvy::dotenv().ok();
 
+    // Log active QoS tier
+    tracing::info!("Model QoS tier: {}", llm::model_qos::tier_description());
+
     // Load and validate config
     let config = Config::from_env();
     if let Err(e) = config.validate() {

--- a/desktop/Backend-Rust/src/routes/conversations.rs
+++ b/desktop/Backend-Rust/src/routes/conversations.rs
@@ -843,7 +843,8 @@ async fn merge_conversations(
     // If reprocessing is requested and we have an LLM client, process the merged conversation
     if request.reprocess {
         if let Some(api_key) = &state.config.gemini_api_key {
-            let llm = LlmClient::new(api_key.clone());
+            let llm = LlmClient::new(api_key.clone())
+                .with_model(crate::llm::model_qos::gemini_extraction());
 
             // Get existing data for deduplication
             let existing_memories = state

--- a/desktop/Backend-Rust/src/routes/conversations.rs
+++ b/desktop/Backend-Rust/src/routes/conversations.rs
@@ -191,6 +191,7 @@ async fn create_conversation_from_segments(
         // Get LLM client (Gemini)
         let llm_client = if let Some(api_key) = &state.config.gemini_api_key {
             LlmClient::new(api_key.clone())
+                .with_model(crate::llm::model_qos::gemini_extraction())
         } else {
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -441,6 +442,7 @@ async fn reprocess_conversation(
     // Get LLM client (Gemini)
     let llm_client = if let Some(api_key) = &state.config.gemini_api_key {
         LlmClient::new(api_key.clone())
+            .with_model(crate::llm::model_qos::gemini_extraction())
     } else {
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/desktop/Backend-Rust/src/routes/knowledge_graph.rs
+++ b/desktop/Backend-Rust/src/routes/knowledge_graph.rs
@@ -94,7 +94,8 @@ async fn rebuild_knowledge_graph(
     tracing::info!("Processing {} memories for knowledge graph", memories.len());
 
     // Create LLM client
-    let llm = LlmClient::new(api_key);
+    let llm = LlmClient::new(api_key)
+        .with_model(crate::llm::model_qos::gemini_extraction());
 
     // Track nodes by lowercase label for deduplication
     let mut node_map: HashMap<String, KnowledgeGraphNode> = HashMap::new();

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -27,14 +27,9 @@ const GEMINI_ALLOWED_ACTIONS: &[&str] = &[
     "batchEmbedContents",
 ];
 
-// Allowed Gemini models — only these can be requested through the proxy.
+// Allowed Gemini models — driven by model_qos (issue #6834).
 // Desktop app uses: gemini-3-flash-preview (default), gemini-pro-latest (tasks/insights),
 // gemini-embedding-001 (embeddings). Rate limiting may rewrite pro → flash.
-const GEMINI_ALLOWED_MODELS: &[&str] = &[
-    "gemini-3-flash-preview",
-    "gemini-pro-latest",
-    "gemini-embedding-001",
-];
 
 /// Maximum request body size for Gemini proxy routes (5 MB).
 /// Normal app payloads are 300-600 KB (base64 JPEG + prompt); 5 MB gives ~8x headroom.
@@ -458,9 +453,9 @@ fn is_gemini_action_allowed(action: &str) -> bool {
     GEMINI_ALLOWED_ACTIONS.contains(&action)
 }
 
-/// Check if a Gemini model is in the allowlist (issue #6624)
+/// Check if a Gemini model is in the allowlist (issue #6624, #6834)
 fn is_gemini_model_allowed(model: &str) -> bool {
-    GEMINI_ALLOWED_MODELS.contains(&model)
+    crate::llm::model_qos::gemini_proxy_allowed().contains(&model)
 }
 
 /// Sanitize a Gemini request body (issue #6624).

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -28,8 +28,8 @@ const GEMINI_ALLOWED_ACTIONS: &[&str] = &[
 ];
 
 // Allowed Gemini models — driven by model_qos (issue #6834).
-// Desktop app uses: gemini-3-flash-preview (default), gemini-pro-latest (tasks/insights),
-// gemini-embedding-001 (embeddings). Rate limiting may rewrite pro → flash.
+// Desktop app uses: gemini-3-flash-preview (all features), gemini-embedding-001 (embeddings).
+// Rate limiting may degrade requests above soft limit.
 
 /// Maximum request body size for Gemini proxy routes (5 MB).
 /// Normal app payloads are 300-600 KB (base64 JPEG + prompt); 5 MB gives ~8x headroom.
@@ -717,12 +717,12 @@ mod tests {
     #[test]
     fn model_allowlist_permits_valid_models() {
         assert!(is_gemini_model_allowed("gemini-3-flash-preview"));
-        assert!(is_gemini_model_allowed("gemini-pro-latest"));
         assert!(is_gemini_model_allowed("gemini-embedding-001"));
     }
 
     #[test]
     fn model_allowlist_blocks_unknown() {
+        assert!(!is_gemini_model_allowed("gemini-pro-latest"), "pro removed from allowlist");
         assert!(!is_gemini_model_allowed("gemini-2.5-pro"));
         assert!(!is_gemini_model_allowed("gemini-1.5-pro"));
         assert!(!is_gemini_model_allowed("gemini-ultra"));

--- a/desktop/Backend-Rust/src/routes/rate_limit.rs
+++ b/desktop/Backend-Rust/src/routes/rate_limit.rs
@@ -197,7 +197,7 @@ pub fn maybe_rewrite_model_path(path: &str, decision: &RateDecision, action: &st
         return path.to_string();
     }
     if let Some(rest) = path.strip_prefix("models/gemini-pro-latest:") {
-        return format!("models/gemini-3-flash-preview:{}", rest);
+        return format!("models/{}:{}", crate::llm::model_qos::gemini_degrade_target(), rest);
     }
     path.to_string()
 }

--- a/desktop/Backend-Rust/src/routes/rate_limit.rs
+++ b/desktop/Backend-Rust/src/routes/rate_limit.rs
@@ -23,11 +23,8 @@ use tokio::sync::Mutex;
 
 use crate::services::RedisService;
 
-/// Daily soft limit — at or above this, Pro requests are degraded to Flash.
-const DAILY_SOFT_LIMIT: u32 = 300;
-
-/// Daily hard limit — at or above this, all requests are rejected with 429.
-const DAILY_HARD_LIMIT: u32 = 1500;
+// Daily soft/hard limits are tier-aware — see crate::llm::model_qos.
+use crate::llm::model_qos;
 
 /// Burst cap — max requests per rolling 60-second window.
 const BURST_PER_MINUTE: usize = 30;
@@ -60,9 +57,9 @@ impl RateSnapshot {
     fn to_decision(&self) -> RateDecision {
         if self.burst_count > BURST_PER_MINUTE {
             RateDecision::Reject
-        } else if self.daily_count >= DAILY_HARD_LIMIT {
+        } else if self.daily_count >= model_qos::daily_hard_limit() {
             RateDecision::Reject
-        } else if self.daily_count >= DAILY_SOFT_LIMIT {
+        } else if self.daily_count >= model_qos::daily_soft_limit() {
             RateDecision::DegradeToFlash
         } else {
             RateDecision::Allow
@@ -218,23 +215,25 @@ pub fn rate_limit_error_json(message: &str) -> String {
 mod tests {
     use super::*;
 
-    // --- Decision from snapshot ---
+    // --- Decision from snapshot (uses QoS tier — Standard in test env: soft=30, hard=500) ---
 
     #[test]
     fn snapshot_allow() {
-        let s = RateSnapshot { daily_count: 100, burst_count: 5 };
+        let s = RateSnapshot { daily_count: 10, burst_count: 5 };
         assert_eq!(s.to_decision(), RateDecision::Allow);
     }
 
     #[test]
     fn snapshot_degrade_at_soft_limit() {
-        let s = RateSnapshot { daily_count: 300, burst_count: 5 };
+        let soft = model_qos::daily_soft_limit();
+        let s = RateSnapshot { daily_count: soft, burst_count: 5 };
         assert_eq!(s.to_decision(), RateDecision::DegradeToFlash);
     }
 
     #[test]
     fn snapshot_reject_at_hard_limit() {
-        let s = RateSnapshot { daily_count: 1500, burst_count: 5 };
+        let hard = model_qos::daily_hard_limit();
+        let s = RateSnapshot { daily_count: hard, burst_count: 5 };
         assert_eq!(s.to_decision(), RateDecision::Reject);
     }
 

--- a/desktop/Backend-Rust/src/routes/rate_limit.rs
+++ b/desktop/Backend-Rust/src/routes/rate_limit.rs
@@ -250,6 +250,22 @@ mod tests {
         assert_eq!(s.to_decision(), RateDecision::Allow);
     }
 
+    // --- Boundary: just below thresholds ---
+
+    #[test]
+    fn snapshot_allow_just_below_soft_limit() {
+        let soft = model_qos::daily_soft_limit();
+        let s = RateSnapshot { daily_count: soft - 1, burst_count: 5 };
+        assert_eq!(s.to_decision(), RateDecision::Allow);
+    }
+
+    #[test]
+    fn snapshot_degrade_just_below_hard_limit() {
+        let hard = model_qos::daily_hard_limit();
+        let s = RateSnapshot { daily_count: hard - 1, burst_count: 5 };
+        assert_eq!(s.to_decision(), RateDecision::DegradeToFlash);
+    }
+
     // --- No Redis → unmetered (cache bypassed entirely) ---
 
     #[tokio::test]

--- a/desktop/Backend-Rust/src/routes/rate_limit.rs
+++ b/desktop/Backend-Rust/src/routes/rate_limit.rs
@@ -215,7 +215,7 @@ pub fn rate_limit_error_json(message: &str) -> String {
 mod tests {
     use super::*;
 
-    // --- Decision from snapshot (uses QoS tier — Standard in test env: soft=30, hard=500) ---
+    // --- Decision from snapshot (uses QoS tier — Premium in test env: soft=30, hard=1500) ---
 
     #[test]
     fn snapshot_allow() {

--- a/desktop/Desktop/Sources/AppleNotesReaderService.swift
+++ b/desktop/Desktop/Sources/AppleNotesReaderService.swift
@@ -142,7 +142,7 @@ actor AppleNotesReaderService {
         prompt: synthesisPrompt,
         systemPrompt:
           "You extract high-signal user facts from Apple Notes. Output only valid JSON.",
-        model: "claude-opus-4-6",
+        model: ModelQoS.Claude.synthesis,
         onTextDelta: { @Sendable _ in },
         onToolCall: { @Sendable _, _, _ in "" },
         onToolActivity: { @Sendable _, _, _, _ in }

--- a/desktop/Desktop/Sources/CalendarReaderService.swift
+++ b/desktop/Desktop/Sources/CalendarReaderService.swift
@@ -191,7 +191,7 @@ actor CalendarReaderService {
         prompt: synthesisPrompt,
         systemPrompt:
           "You are a profile extraction assistant. Analyze calendar events and output structured JSON. Be concise and factual.",
-        model: "claude-opus-4-6",
+        model: ModelQoS.Claude.synthesis,
         onTextDelta: { @Sendable _ in },
         onToolCall: { @Sendable _, _, _ in return "" },
         onToolActivity: { @Sendable _, _, _, _ in }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -103,13 +103,10 @@ class FloatingControlBarState: NSObject, ObservableObject {
     @Published var currentQueryFromVoice: Bool = false
 
     // Model selection
-    @Published var selectedModel: String = "claude-sonnet-4-6"
+    @Published var selectedModel: String = ModelQoS.Claude.defaultSelection
 
-    /// Available models for the floating bar picker
-    static let availableModels: [(id: String, label: String)] = [
-        ("claude-sonnet-4-6", "Sonnet"),
-        ("claude-opus-4-6", "Opus"),
-    ]
+    /// Available models for the floating bar picker (driven by QoS tier)
+    static var availableModels: [(id: String, label: String)] { ModelQoS.Claude.availableModels }
 
     var isShowingNotification: Bool {
         currentNotification != nil

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1549,7 +1549,7 @@ class FloatingControlBarManager {
             }
 
         let floatingModel = ShortcutSettings.shared.selectedModel.isEmpty
-            ? "claude-sonnet-4-6"
+            ? ModelQoS.Claude.defaultSelection
             : ShortcutSettings.shared.selectedModel
         let notificationContextSuffix = notificationContextSuffixIfNeeded(for: message)
         await provider.sendMessage(

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -324,11 +324,8 @@ class ShortcutSettings: ObservableObject {
         didSet { UserDefaults.standard.set(selectedModel, forKey: "shortcut_selectedModel") }
     }
 
-    /// Available models for Ask Omi.
-    static let availableModels: [(id: String, label: String)] = [
-        ("claude-sonnet-4-6", "Sonnet"),
-        ("claude-opus-4-6", "Opus"),
-    ]
+    /// Available models for Ask Omi (driven by QoS tier).
+    static var availableModels: [(id: String, label: String)] { ModelQoS.Claude.availableModels }
 
     /// Push-to-talk transcription mode.
     enum PTTTranscriptionMode: String, CaseIterable {
@@ -471,7 +468,7 @@ class ShortcutSettings: ObservableObject {
         self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
         self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false
         self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
-        self.selectedModel = UserDefaults.standard.string(forKey: "shortcut_selectedModel") ?? "claude-sonnet-4-6"
+        self.selectedModel = UserDefaults.standard.string(forKey: "shortcut_selectedModel") ?? ModelQoS.Claude.defaultSelection
         if let saved = UserDefaults.standard.string(forKey: "shortcut_pttTranscriptionMode"),
            let mode = PTTTranscriptionMode(rawValue: saved) {
             self.pttTranscriptionMode = mode

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -487,6 +487,11 @@ class ShortcutSettings: ObservableObject {
             ? storedVoiceID
             : Self.defaultVoiceID
         self.selectedVoiceID = validVoiceID
+
+        NotificationCenter.default.addObserver(forName: .modelTierDidChange, object: nil, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            self.selectedModel = ModelQoS.Claude.sanitizedSelection(self.selectedModel)
+        }
     }
 
     private func persistShortcut(_ shortcut: KeyboardShortcut, forKey key: String) {

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -468,7 +468,9 @@ class ShortcutSettings: ObservableObject {
         self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
         self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false
         self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
-        self.selectedModel = UserDefaults.standard.string(forKey: "shortcut_selectedModel") ?? ModelQoS.Claude.defaultSelection
+        let savedModel = UserDefaults.standard.string(forKey: "shortcut_selectedModel") ?? ModelQoS.Claude.defaultSelection
+        let allowedIDs = ModelQoS.Claude.availableModels.map(\.id)
+        self.selectedModel = allowedIDs.contains(savedModel) ? savedModel : ModelQoS.Claude.defaultSelection
         if let saved = UserDefaults.standard.string(forKey: "shortcut_pttTranscriptionMode"),
            let mode = PTTTranscriptionMode(rawValue: saved) {
             self.pttTranscriptionMode = mode

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -468,9 +468,9 @@ class ShortcutSettings: ObservableObject {
         self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
         self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false
         self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
-        let savedModel = UserDefaults.standard.string(forKey: "shortcut_selectedModel") ?? ModelQoS.Claude.defaultSelection
-        let allowedIDs = ModelQoS.Claude.availableModels.map(\.id)
-        self.selectedModel = allowedIDs.contains(savedModel) ? savedModel : ModelQoS.Claude.defaultSelection
+        self.selectedModel = ModelQoS.Claude.sanitizedSelection(
+            UserDefaults.standard.string(forKey: "shortcut_selectedModel")
+        )
         if let saved = UserDefaults.standard.string(forKey: "shortcut_pttTranscriptionMode"),
            let mode = PTTTranscriptionMode(rawValue: saved) {
             self.pttTranscriptionMode = mode

--- a/desktop/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/Desktop/Sources/GmailReaderService.swift
@@ -267,7 +267,7 @@ actor GmailReaderService {
         prompt: synthesisPrompt,
         systemPrompt:
           "You are a profile extraction assistant. Output ONLY valid JSON. No markdown, no code fences, no explanation.",
-        model: "claude-opus-4-6",
+        model: ModelQoS.Claude.synthesis,
         onTextDelta: { @Sendable _ in },
         onToolCall: { @Sendable _, _, _ in return "" },
         onToolActivity: { @Sendable _, _, _, _ in }

--- a/desktop/Desktop/Sources/MainWindow/Pages/ChatLabView.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/ChatLabView.swift
@@ -436,7 +436,7 @@ class ChatLabViewModel: ObservableObject {
             request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
 
             let body: [String: Any] = [
-                "model": "claude-sonnet-4-20250514",
+                "model": ModelQoS.Claude.chatLabQuery,
                 "max_tokens": 1024,
                 "system": systemPrompt.prefix(50000),
                 "messages": [["role": "user", "content": userMessage]],
@@ -481,7 +481,7 @@ class ChatLabViewModel: ObservableObject {
             """
 
             let body: [String: Any] = [
-                "model": "claude-haiku-4-5-20251001",
+                "model": ModelQoS.Claude.chatLabGrade,
                 "max_tokens": 200,
                 "messages": [["role": "user", "content": gradePrompt]],
             ]

--- a/desktop/Desktop/Sources/ModelQoS.swift
+++ b/desktop/Desktop/Sources/ModelQoS.swift
@@ -7,8 +7,8 @@ import Foundation
 // Individual workloads can also override their tier.
 
 enum ModelTier: String, CaseIterable {
-    case standard   // Cost-optimized: Sonnet for Claude, Flash for Gemini
-    case premium    // Quality-optimized: Opus for Claude, Pro for Gemini
+    case premium    // Cost-optimized: Sonnet for Claude, Flash for Gemini
+    case max        // Quality-optimized: Opus for Claude, Pro for Gemini
 }
 
 struct ModelQoS {
@@ -20,7 +20,7 @@ struct ModelQoS {
         get {
             guard let raw = UserDefaults.standard.string(forKey: tierKey),
                   let tier = ModelTier(rawValue: raw) else {
-                return .standard
+                return .premium
             }
             return tier
         }
@@ -33,13 +33,13 @@ struct ModelQoS {
 
     struct Claude {
         /// Main chat session model
-        static var chat: String { model(standard: "claude-sonnet-4-6", premium: "claude-opus-4-6") }
+        static var chat: String { model(premium: "claude-sonnet-4-6", max: "claude-opus-4-6") }
 
         /// Floating bar responses
-        static var floatingBar: String { model(standard: "claude-sonnet-4-6", premium: "claude-sonnet-4-6") }
+        static var floatingBar: String { model(premium: "claude-sonnet-4-6", max: "claude-sonnet-4-6") }
 
         /// Synthesis tasks (calendar, gmail, notes, onboarding)
-        static var synthesis: String { model(standard: "claude-sonnet-4-6", premium: "claude-opus-4-6") }
+        static var synthesis: String { model(premium: "claude-sonnet-4-6", max: "claude-opus-4-6") }
 
         /// ChatLab test queries
         static var chatLabQuery: String { "claude-sonnet-4-20250514" }
@@ -50,9 +50,9 @@ struct ModelQoS {
         /// Available models shown in the UI picker
         static var availableModels: [(id: String, label: String)] {
             switch activeTier {
-            case .standard:
-                return [("claude-sonnet-4-6", "Sonnet")]
             case .premium:
+                return [("claude-sonnet-4-6", "Sonnet")]
+            case .max:
                 return [
                     ("claude-sonnet-4-6", "Sonnet"),
                     ("claude-opus-4-6", "Opus"),
@@ -71,8 +71,8 @@ struct ModelQoS {
             return allowedIDs.contains(model) ? model : defaultSelection
         }
 
-        private static func model(standard: String, premium: String) -> String {
-            activeTier == .standard ? standard : premium
+        private static func model(premium: String, max: String) -> String {
+            activeTier == .premium ? premium : max
         }
     }
 
@@ -80,19 +80,19 @@ struct ModelQoS {
 
     struct Gemini {
         /// Proactive assistants (screenshot analysis, context detection)
-        static var proactive: String { model(standard: "gemini-3-flash-preview", premium: "gemini-3-flash-preview") }
+        static var proactive: String { model(premium: "gemini-3-flash-preview", max: "gemini-3-flash-preview") }
 
         /// Task extraction
-        static var taskExtraction: String { model(standard: "gemini-3-flash-preview", premium: "gemini-pro-latest") }
+        static var taskExtraction: String { model(premium: "gemini-3-flash-preview", max: "gemini-pro-latest") }
 
         /// Insight generation
-        static var insight: String { model(standard: "gemini-3-flash-preview", premium: "gemini-pro-latest") }
+        static var insight: String { model(premium: "gemini-3-flash-preview", max: "gemini-pro-latest") }
 
         /// Embeddings (not tier-dependent, kept separate)
         static var embedding: String { "gemini-embedding-001" }
 
-        private static func model(standard: String, premium: String) -> String {
-            activeTier == .standard ? standard : premium
+        private static func model(premium: String, max: String) -> String {
+            activeTier == .premium ? premium : max
         }
     }
 
@@ -100,8 +100,8 @@ struct ModelQoS {
 
     static var tierDescription: String {
         switch activeTier {
-        case .standard: return "Standard (cost-optimized)"
-        case .premium: return "Premium (quality-optimized)"
+        case .premium: return "Premium (cost-optimized)"
+        case .max: return "Max (quality-optimized)"
         }
     }
 }

--- a/desktop/Desktop/Sources/ModelQoS.swift
+++ b/desktop/Desktop/Sources/ModelQoS.swift
@@ -26,6 +26,7 @@ struct ModelQoS {
         }
         set {
             UserDefaults.standard.set(newValue.rawValue, forKey: tierKey)
+            NotificationCenter.default.post(name: .modelTierDidChange, object: nil)
         }
     }
 
@@ -104,4 +105,8 @@ struct ModelQoS {
         case .max: return "Max (quality-optimized)"
         }
     }
+}
+
+extension Notification.Name {
+    static let modelTierDidChange = Notification.Name("modelTierDidChange")
 }

--- a/desktop/Desktop/Sources/ModelQoS.swift
+++ b/desktop/Desktop/Sources/ModelQoS.swift
@@ -7,8 +7,8 @@ import Foundation
 // Individual workloads can also override their tier.
 
 enum ModelTier: String, CaseIterable {
-    case premium    // Cost-optimized: Sonnet for Claude, Flash for Gemini
-    case max        // Quality-optimized: Opus for Claude, Pro for Gemini
+    case premium    // Cost-optimized: Sonnet + Haiku for Claude, Flash for Gemini
+    case max        // Quality-optimized: higher rate limits, same models
 }
 
 struct ModelQoS {
@@ -33,14 +33,14 @@ struct ModelQoS {
     // MARK: - Claude Models
 
     struct Claude {
-        /// Main chat session model
-        static var chat: String { model(premium: "claude-sonnet-4-6", max: "claude-opus-4-6") }
+        /// Main chat session model (user-facing conversations)
+        static var chat: String { "claude-sonnet-4-6" }
 
         /// Floating bar responses
-        static var floatingBar: String { model(premium: "claude-sonnet-4-6", max: "claude-sonnet-4-6") }
+        static var floatingBar: String { "claude-sonnet-4-6" }
 
-        /// Synthesis tasks (calendar, gmail, notes, onboarding)
-        static var synthesis: String { model(premium: "claude-sonnet-4-6", max: "claude-opus-4-6") }
+        /// Synthesis extraction tasks (calendar, gmail, notes, memory import)
+        static var synthesis: String { "claude-haiku-4-5-20251001" }
 
         /// ChatLab test queries
         static var chatLabQuery: String { "claude-sonnet-4-20250514" }
@@ -50,15 +50,7 @@ struct ModelQoS {
 
         /// Available models shown in the UI picker
         static var availableModels: [(id: String, label: String)] {
-            switch activeTier {
-            case .premium:
-                return [("claude-sonnet-4-6", "Sonnet")]
-            case .max:
-                return [
-                    ("claude-sonnet-4-6", "Sonnet"),
-                    ("claude-opus-4-6", "Opus"),
-                ]
-            }
+            [("claude-sonnet-4-6", "Sonnet")]
         }
 
         /// Default model for user selection (floating bar / shortcut picker)
@@ -71,30 +63,22 @@ struct ModelQoS {
             let allowedIDs = availableModels.map(\.id)
             return allowedIDs.contains(model) ? model : defaultSelection
         }
-
-        private static func model(premium: String, max: String) -> String {
-            activeTier == .premium ? premium : max
-        }
     }
 
     // MARK: - Gemini Models
 
     struct Gemini {
         /// Proactive assistants (screenshot analysis, context detection)
-        static var proactive: String { model(premium: "gemini-3-flash-preview", max: "gemini-3-flash-preview") }
+        static var proactive: String { "gemini-3-flash-preview" }
 
         /// Task extraction
-        static var taskExtraction: String { model(premium: "gemini-3-flash-preview", max: "gemini-pro-latest") }
+        static var taskExtraction: String { "gemini-3-flash-preview" }
 
         /// Insight generation
-        static var insight: String { model(premium: "gemini-3-flash-preview", max: "gemini-pro-latest") }
+        static var insight: String { "gemini-3-flash-preview" }
 
         /// Embeddings (not tier-dependent, kept separate)
         static var embedding: String { "gemini-embedding-001" }
-
-        private static func model(premium: String, max: String) -> String {
-            activeTier == .premium ? premium : max
-        }
     }
 
     // MARK: - Tier Info (for UI / debugging)

--- a/desktop/Desktop/Sources/ModelQoS.swift
+++ b/desktop/Desktop/Sources/ModelQoS.swift
@@ -63,6 +63,14 @@ struct ModelQoS {
         /// Default model for user selection (floating bar / shortcut picker)
         static var defaultSelection: String { "claude-sonnet-4-6" }
 
+        /// Sanitize a persisted model ID against the current tier's allowed list.
+        /// Returns the saved model if it's still available, otherwise falls back to defaultSelection.
+        static func sanitizedSelection(_ savedModel: String?) -> String {
+            let model = savedModel ?? defaultSelection
+            let allowedIDs = availableModels.map(\.id)
+            return allowedIDs.contains(model) ? model : defaultSelection
+        }
+
         private static func model(standard: String, premium: String) -> String {
             activeTier == .standard ? standard : premium
         }

--- a/desktop/Desktop/Sources/ModelQoS.swift
+++ b/desktop/Desktop/Sources/ModelQoS.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+// MARK: - Model QoS Tier System
+//
+// Central model configuration with switchable tiers.
+// Change `activeTier` to switch all models at once.
+// Individual workloads can also override their tier.
+
+enum ModelTier: String, CaseIterable {
+    case standard   // Cost-optimized: Sonnet for Claude, Flash for Gemini
+    case premium    // Quality-optimized: Opus for Claude, Pro for Gemini
+}
+
+struct ModelQoS {
+    // MARK: - Active Tier (single switch)
+
+    private static let tierKey = "modelQoS_activeTier"
+
+    static var activeTier: ModelTier {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: tierKey),
+                  let tier = ModelTier(rawValue: raw) else {
+                return .standard
+            }
+            return tier
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: tierKey)
+        }
+    }
+
+    // MARK: - Claude Models
+
+    struct Claude {
+        /// Main chat session model
+        static var chat: String { model(standard: "claude-sonnet-4-6", premium: "claude-opus-4-6") }
+
+        /// Floating bar responses
+        static var floatingBar: String { model(standard: "claude-sonnet-4-6", premium: "claude-sonnet-4-6") }
+
+        /// Synthesis tasks (calendar, gmail, notes, onboarding)
+        static var synthesis: String { model(standard: "claude-sonnet-4-6", premium: "claude-opus-4-6") }
+
+        /// ChatLab test queries
+        static var chatLabQuery: String { "claude-sonnet-4-20250514" }
+
+        /// ChatLab grading (always cheap)
+        static var chatLabGrade: String { "claude-haiku-4-5-20251001" }
+
+        /// Available models shown in the UI picker
+        static var availableModels: [(id: String, label: String)] {
+            switch activeTier {
+            case .standard:
+                return [("claude-sonnet-4-6", "Sonnet")]
+            case .premium:
+                return [
+                    ("claude-sonnet-4-6", "Sonnet"),
+                    ("claude-opus-4-6", "Opus"),
+                ]
+            }
+        }
+
+        /// Default model for user selection (floating bar / shortcut picker)
+        static var defaultSelection: String { "claude-sonnet-4-6" }
+
+        private static func model(standard: String, premium: String) -> String {
+            activeTier == .standard ? standard : premium
+        }
+    }
+
+    // MARK: - Gemini Models
+
+    struct Gemini {
+        /// Proactive assistants (screenshot analysis, context detection)
+        static var proactive: String { model(standard: "gemini-3-flash-preview", premium: "gemini-3-flash-preview") }
+
+        /// Task extraction
+        static var taskExtraction: String { model(standard: "gemini-3-flash-preview", premium: "gemini-pro-latest") }
+
+        /// Insight generation
+        static var insight: String { model(standard: "gemini-3-flash-preview", premium: "gemini-pro-latest") }
+
+        /// Embeddings (not tier-dependent, kept separate)
+        static var embedding: String { "gemini-embedding-001" }
+
+        private static func model(standard: String, premium: String) -> String {
+            activeTier == .standard ? standard : premium
+        }
+    }
+
+    // MARK: - Tier Info (for UI / debugging)
+
+    static var tierDescription: String {
+        switch activeTier {
+        case .standard: return "Standard (cost-optimized)"
+        case .premium: return "Premium (quality-optimized)"
+        }
+    }
+}

--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -1383,7 +1383,7 @@ struct OnboardingChatView: View {
           prompt:
             "Begin exploration. \(fileCount) files have been indexed in the indexed_files table.",
           systemPrompt: systemPrompt,
-          model: "claude-opus-4-6",
+          model: ModelQoS.Claude.synthesis,
           onTextDelta: { @Sendable delta in
             Task { @MainActor in
               explorationText += delta

--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -1383,7 +1383,7 @@ struct OnboardingChatView: View {
           prompt:
             "Begin exploration. \(fileCount) files have been indexed in the indexed_files table.",
           systemPrompt: systemPrompt,
-          model: ModelQoS.Claude.synthesis,
+          model: ModelQoS.Claude.chat,
           onTextDelta: { @Sendable delta in
             Task { @MainActor in
               explorationText += delta

--- a/desktop/Desktop/Sources/OnboardingMemoryLogImportService.swift
+++ b/desktop/Desktop/Sources/OnboardingMemoryLogImportService.swift
@@ -93,7 +93,7 @@ actor OnboardingMemoryLogImportService {
         prompt: importPrompt,
         systemPrompt:
           "You convert memory-log exports into concise durable user memories. Output only valid JSON.",
-        model: "claude-opus-4-6",
+        model: ModelQoS.Claude.synthesis,
         onTextDelta: { @Sendable _ in },
         onToolCall: { @Sendable _, _, _ in "" },
         onToolActivity: { @Sendable _, _, _, _ in }

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -996,7 +996,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         prompt: prompt,
         systemPrompt:
           "You are a structured onboarding research assistant. Output only valid JSON.",
-        model: ModelQoS.Claude.synthesis,
+        model: ModelQoS.Claude.chat,
         onTextDelta: { @Sendable _ in },
         onToolCall: { @Sendable _, _, _ in return "" },
         onToolActivity: { @Sendable _, _, _, _ in }

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -996,7 +996,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
         prompt: prompt,
         systemPrompt:
           "You are a structured onboarding research assistant. Output only valid JSON.",
-        model: "claude-opus-4-6",
+        model: ModelQoS.Claude.synthesis,
         onTextDelta: { @Sendable _ in },
         onToolCall: { @Sendable _, _, _ in return "" },
         onToolActivity: { @Sendable _, _, _, _ in }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -63,8 +63,7 @@ actor InsightAssistant: ProactiveAssistant {
     // MARK: - Initialization
 
     init(apiKey: String? = nil) throws {
-        // Use Gemini 3.1 Pro for better insight quality (3-pro-preview retires March 9, 2026)
-        self.geminiClient = try GeminiClient(apiKey: apiKey, model: "gemini-pro-latest")
+        self.geminiClient = try GeminiClient(apiKey: apiKey, model: ModelQoS.Gemini.insight)
 
         let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
         self.frameSignal = stream

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -144,8 +144,7 @@ actor TaskAssistant: ProactiveAssistant {
     // MARK: - Initialization
 
     init(apiKey: String? = nil) throws {
-        // Use Gemini 3 Pro for better task extraction quality
-        self.geminiClient = try GeminiClient(apiKey: apiKey, model: "gemini-pro-latest")
+        self.geminiClient = try GeminiClient(apiKey: apiKey, model: ModelQoS.Gemini.taskExtraction)
 
         let (stream, continuation) = AsyncStream.makeStream(of: TriggerEvent.self, bufferingPolicy: .bufferingNewest(1))
         self.triggerStream = stream

--- a/desktop/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -226,7 +226,7 @@ actor GeminiClient {
     }
   }
 
-  init(apiKey: String? = nil, model: String = "gemini-3-flash-preview") throws {
+  init(apiKey: String? = nil, model: String = ModelQoS.Gemini.proactive) throws {
     // BREAKING CHANGE (issue #5861): apiKey parameter is ignored.
     // All Gemini requests now route through the backend proxy which supplies
     // the key server-side. Requires OMI_API_URL to be set (standard dev flow via run.sh).

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/EmbeddingService.swift
@@ -7,7 +7,7 @@ actor EmbeddingService {
 
   /// Gemini embedding-001 outputs 3072 dimensions by default
   static let embeddingDimension = 3072
-  static let modelName = "gemini-embedding-001"
+  static var modelName: String { ModelQoS.Gemini.embedding }
 
   /// In-memory index: action_item.id -> normalized embedding
   private var index: [Int64: [Float]] = [:]

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -772,11 +772,11 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             let mainSystemPrompt = buildSystemPrompt(contextString: formatMemoriesSection())
             let floatingSystemPrompt = Self.floatingBarSystemPromptPrefix + "\n\n" + mainSystemPrompt
             let floatingModel = ShortcutSettings.shared.selectedModel.isEmpty
-                ? "claude-sonnet-4-6"
+                ? ModelQoS.Claude.defaultSelection
                 : ShortcutSettings.shared.selectedModel
             cachedMainSystemPrompt = mainSystemPrompt
             await acpBridge.warmupSession(cwd: workingDirectory, sessions: [
-                .init(key: "main", model: "claude-opus-4-6", systemPrompt: mainSystemPrompt),
+                .init(key: "main", model: ModelQoS.Claude.chat, systemPrompt: mainSystemPrompt),
                 .init(key: "floating", model: floatingModel, systemPrompt: floatingSystemPrompt)
             ])
             return true
@@ -1619,7 +1619,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 prompt: question,
                 systemPrompt: systemPrompt,
                 sessionKey: sessionKey,
-                model: "claude-sonnet-4-20250514",
+                model: ModelQoS.Claude.chatLabQuery,
                 onTextDelta: { _ in },
                 onToolCall: { callId, name, input in
                     let toolCall = ToolCall(name: name, arguments: input, thoughtSignature: nil)

--- a/desktop/Desktop/Tests/ModelQoSTests.swift
+++ b/desktop/Desktop/Tests/ModelQoSTests.swift
@@ -35,72 +35,50 @@ final class ModelQoSTests: XCTestCase {
         XCTAssertEqual(ModelQoS.activeTier, .premium)
     }
 
-    // MARK: - Claude models: premium tier
+    // MARK: - Claude models are tier-independent
 
-    func testClaudeModelsPremiumTier() {
-        ModelQoS.activeTier = .premium
-        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
-        XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
-        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-sonnet-4-6")
-    }
-
-    // MARK: - Claude models: max tier
-
-    func testClaudeModelsMaxTier() {
-        ModelQoS.activeTier = .max
-        XCTAssertEqual(ModelQoS.Claude.chat, "claude-opus-4-6")
-        XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
-        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-opus-4-6")
-    }
-
-    // MARK: - Claude pinned models (tier-independent)
-
-    func testClaudePinnedModelsIgnoreTier() {
+    func testClaudeModelsIdenticalAcrossTiers() {
         for tier in ModelTier.allCases {
             ModelQoS.activeTier = tier
+            XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
+            XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
+            XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-haiku-4-5-20251001")
             XCTAssertEqual(ModelQoS.Claude.chatLabQuery, "claude-sonnet-4-20250514")
             XCTAssertEqual(ModelQoS.Claude.chatLabGrade, "claude-haiku-4-5-20251001")
             XCTAssertEqual(ModelQoS.Claude.defaultSelection, "claude-sonnet-4-6")
         }
     }
 
-    // MARK: - Available models reflect tier
+    // MARK: - Synthesis uses Haiku (extraction workloads)
 
-    func testAvailableModelsPremiumTier() {
-        ModelQoS.activeTier = .premium
-        let ids = ModelQoS.Claude.availableModels.map(\.id)
-        XCTAssertEqual(ids, ["claude-sonnet-4-6"])
+    func testSynthesisUsesHaiku() {
+        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-haiku-4-5-20251001")
     }
 
-    func testAvailableModelsMaxTier() {
-        ModelQoS.activeTier = .max
-        let ids = ModelQoS.Claude.availableModels.map(\.id)
-        XCTAssertEqual(ids, ["claude-sonnet-4-6", "claude-opus-4-6"])
+    // MARK: - Chat uses Sonnet (user-facing)
+
+    func testChatUsesSonnet() {
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
     }
 
-    // MARK: - Gemini models: premium tier
+    // MARK: - Available models (Sonnet only, both tiers)
 
-    func testGeminiModelsPremiumTier() {
-        ModelQoS.activeTier = .premium
-        XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-3-flash-preview")
-        XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-3-flash-preview")
-        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
-    }
-
-    // MARK: - Gemini models: max tier
-
-    func testGeminiModelsMaxTier() {
-        ModelQoS.activeTier = .max
-        XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-3-flash-preview")
-        XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-pro-latest")
-        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-pro-latest")
-    }
-
-    // MARK: - Gemini pinned models (tier-independent)
-
-    func testGeminiEmbeddingIgnoresTier() {
+    func testAvailableModelsSonnetOnlyBothTiers() {
         for tier in ModelTier.allCases {
             ModelQoS.activeTier = tier
+            let ids = ModelQoS.Claude.availableModels.map(\.id)
+            XCTAssertEqual(ids, ["claude-sonnet-4-6"])
+        }
+    }
+
+    // MARK: - Gemini models are tier-independent
+
+    func testGeminiModelsIdenticalAcrossTiers() {
+        for tier in ModelTier.allCases {
+            ModelQoS.activeTier = tier
+            XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-3-flash-preview")
+            XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-3-flash-preview")
+            XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
             XCTAssertEqual(ModelQoS.Gemini.embedding, "gemini-embedding-001")
         }
     }
@@ -115,49 +93,21 @@ final class ModelQoSTests: XCTestCase {
         XCTAssertEqual(ModelQoS.tierDescription, "Max (quality-optimized)")
     }
 
-    // MARK: - Tier switch dynamically changes accessors
-
-    func testTierSwitchChangesModelsAtRuntime() {
-        ModelQoS.activeTier = .premium
-        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
-        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
-
-        ModelQoS.activeTier = .max
-        XCTAssertEqual(ModelQoS.Claude.chat, "claude-opus-4-6")
-        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-pro-latest")
-
-        ModelQoS.activeTier = .premium
-        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
-        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
-    }
-
-    // MARK: - Sanitized selection (stale model regression)
+    // MARK: - Sanitized selection
 
     func testSanitizedSelectionAllowsValidModel() {
-        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-sonnet-4-6"), "claude-sonnet-4-6")
-
-        ModelQoS.activeTier = .max
-        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-opus-4-6")
     }
 
-    func testSanitizedSelectionFallsBackForStaleModel() {
-        // User previously selected Opus while on max tier
-        ModelQoS.activeTier = .max
-        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-opus-4-6")
-
-        // Tier drops to premium — Opus is no longer available
-        ModelQoS.activeTier = .premium
+    func testSanitizedSelectionFallsBackForUnknownModel() {
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-sonnet-4-6")
     }
 
     func testSanitizedSelectionHandlesNil() {
-        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection(nil), "claude-sonnet-4-6")
     }
 
     func testSanitizedSelectionHandlesUnknownModel() {
-        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("gpt-4o"), "claude-sonnet-4-6")
     }
 
@@ -167,5 +117,23 @@ final class ModelQoSTests: XCTestCase {
         let expectation = expectation(forNotification: .modelTierDidChange, object: nil)
         ModelQoS.activeTier = .max
         wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Model count (5 unique model IDs)
+
+    func testOnlyFiveUniqueModelIDs() {
+        let allModels: Set<String> = [
+            ModelQoS.Claude.chat,
+            ModelQoS.Claude.floatingBar,
+            ModelQoS.Claude.synthesis,
+            ModelQoS.Claude.chatLabQuery,
+            ModelQoS.Claude.chatLabGrade,
+            ModelQoS.Claude.defaultSelection,
+            ModelQoS.Gemini.proactive,
+            ModelQoS.Gemini.taskExtraction,
+            ModelQoS.Gemini.insight,
+            ModelQoS.Gemini.embedding,
+        ]
+        XCTAssertEqual(allModels.count, 5, "Expected exactly 5 unique model IDs: \(allModels)")
     }
 }

--- a/desktop/Desktop/Tests/ModelQoSTests.swift
+++ b/desktop/Desktop/Tests/ModelQoSTests.swift
@@ -16,38 +16,38 @@ final class ModelQoSTests: XCTestCase {
 
     // MARK: - Default tier
 
-    func testDefaultTierIsStandard() {
-        XCTAssertEqual(ModelQoS.activeTier, .standard)
+    func testDefaultTierIsPremium() {
+        XCTAssertEqual(ModelQoS.activeTier, .premium)
     }
 
     // MARK: - Tier persistence
 
     func testSetTierPersistsToUserDefaults() {
+        ModelQoS.activeTier = .max
+        XCTAssertEqual(UserDefaults.standard.string(forKey: tierKey), "max")
+
         ModelQoS.activeTier = .premium
         XCTAssertEqual(UserDefaults.standard.string(forKey: tierKey), "premium")
-
-        ModelQoS.activeTier = .standard
-        XCTAssertEqual(UserDefaults.standard.string(forKey: tierKey), "standard")
     }
 
-    func testInvalidUserDefaultsFallsBackToStandard() {
+    func testInvalidUserDefaultsFallsBackToPremium() {
         UserDefaults.standard.set("invalid_tier", forKey: tierKey)
-        XCTAssertEqual(ModelQoS.activeTier, .standard)
-    }
-
-    // MARK: - Claude models: standard tier
-
-    func testClaudeModelsStandardTier() {
-        ModelQoS.activeTier = .standard
-        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
-        XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
-        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.activeTier, .premium)
     }
 
     // MARK: - Claude models: premium tier
 
     func testClaudeModelsPremiumTier() {
         ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-sonnet-4-6")
+    }
+
+    // MARK: - Claude models: max tier
+
+    func testClaudeModelsMaxTier() {
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.chat, "claude-opus-4-6")
         XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
         XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-opus-4-6")
@@ -66,31 +66,31 @@ final class ModelQoSTests: XCTestCase {
 
     // MARK: - Available models reflect tier
 
-    func testAvailableModelsStandardTier() {
-        ModelQoS.activeTier = .standard
+    func testAvailableModelsPremiumTier() {
+        ModelQoS.activeTier = .premium
         let ids = ModelQoS.Claude.availableModels.map(\.id)
         XCTAssertEqual(ids, ["claude-sonnet-4-6"])
     }
 
-    func testAvailableModelsPremiumTier() {
-        ModelQoS.activeTier = .premium
+    func testAvailableModelsMaxTier() {
+        ModelQoS.activeTier = .max
         let ids = ModelQoS.Claude.availableModels.map(\.id)
         XCTAssertEqual(ids, ["claude-sonnet-4-6", "claude-opus-4-6"])
-    }
-
-    // MARK: - Gemini models: standard tier
-
-    func testGeminiModelsStandardTier() {
-        ModelQoS.activeTier = .standard
-        XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-3-flash-preview")
-        XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-3-flash-preview")
-        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
     }
 
     // MARK: - Gemini models: premium tier
 
     func testGeminiModelsPremiumTier() {
         ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-3-flash-preview")
+        XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-3-flash-preview")
+        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
+    }
+
+    // MARK: - Gemini models: max tier
+
+    func testGeminiModelsMaxTier() {
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-3-flash-preview")
         XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-pro-latest")
         XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-pro-latest")
@@ -108,25 +108,25 @@ final class ModelQoSTests: XCTestCase {
     // MARK: - Tier description
 
     func testTierDescription() {
-        ModelQoS.activeTier = .standard
-        XCTAssertEqual(ModelQoS.tierDescription, "Standard (cost-optimized)")
-
         ModelQoS.activeTier = .premium
-        XCTAssertEqual(ModelQoS.tierDescription, "Premium (quality-optimized)")
+        XCTAssertEqual(ModelQoS.tierDescription, "Premium (cost-optimized)")
+
+        ModelQoS.activeTier = .max
+        XCTAssertEqual(ModelQoS.tierDescription, "Max (quality-optimized)")
     }
 
     // MARK: - Tier switch dynamically changes accessors
 
     func testTierSwitchChangesModelsAtRuntime() {
-        ModelQoS.activeTier = .standard
+        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
         XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
 
-        ModelQoS.activeTier = .premium
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.chat, "claude-opus-4-6")
         XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-pro-latest")
 
-        ModelQoS.activeTier = .standard
+        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
         XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
     }
@@ -134,30 +134,30 @@ final class ModelQoSTests: XCTestCase {
     // MARK: - Sanitized selection (stale model regression)
 
     func testSanitizedSelectionAllowsValidModel() {
-        ModelQoS.activeTier = .standard
+        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-sonnet-4-6"), "claude-sonnet-4-6")
 
-        ModelQoS.activeTier = .premium
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-opus-4-6")
     }
 
     func testSanitizedSelectionFallsBackForStaleModel() {
-        // User previously selected Opus while on premium tier
-        ModelQoS.activeTier = .premium
+        // User previously selected Opus while on max tier
+        ModelQoS.activeTier = .max
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-opus-4-6")
 
-        // Tier drops to standard — Opus is no longer available
-        ModelQoS.activeTier = .standard
+        // Tier drops to premium — Opus is no longer available
+        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-sonnet-4-6")
     }
 
     func testSanitizedSelectionHandlesNil() {
-        ModelQoS.activeTier = .standard
+        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection(nil), "claude-sonnet-4-6")
     }
 
     func testSanitizedSelectionHandlesUnknownModel() {
-        ModelQoS.activeTier = .standard
+        ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("gpt-4o"), "claude-sonnet-4-6")
     }
 }

--- a/desktop/Desktop/Tests/ModelQoSTests.swift
+++ b/desktop/Desktop/Tests/ModelQoSTests.swift
@@ -130,4 +130,34 @@ final class ModelQoSTests: XCTestCase {
         XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
         XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
     }
+
+    // MARK: - Sanitized selection (stale model regression)
+
+    func testSanitizedSelectionAllowsValidModel() {
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-sonnet-4-6"), "claude-sonnet-4-6")
+
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-opus-4-6")
+    }
+
+    func testSanitizedSelectionFallsBackForStaleModel() {
+        // User previously selected Opus while on premium tier
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-opus-4-6")
+
+        // Tier drops to standard — Opus is no longer available
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("claude-opus-4-6"), "claude-sonnet-4-6")
+    }
+
+    func testSanitizedSelectionHandlesNil() {
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection(nil), "claude-sonnet-4-6")
+    }
+
+    func testSanitizedSelectionHandlesUnknownModel() {
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("gpt-4o"), "claude-sonnet-4-6")
+    }
 }

--- a/desktop/Desktop/Tests/ModelQoSTests.swift
+++ b/desktop/Desktop/Tests/ModelQoSTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import Omi_Computer
+
+final class ModelQoSTests: XCTestCase {
+    private let tierKey = "modelQoS_activeTier"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: tierKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: tierKey)
+        super.tearDown()
+    }
+
+    // MARK: - Default tier
+
+    func testDefaultTierIsStandard() {
+        XCTAssertEqual(ModelQoS.activeTier, .standard)
+    }
+
+    // MARK: - Tier persistence
+
+    func testSetTierPersistsToUserDefaults() {
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(UserDefaults.standard.string(forKey: tierKey), "premium")
+
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(UserDefaults.standard.string(forKey: tierKey), "standard")
+    }
+
+    func testInvalidUserDefaultsFallsBackToStandard() {
+        UserDefaults.standard.set("invalid_tier", forKey: tierKey)
+        XCTAssertEqual(ModelQoS.activeTier, .standard)
+    }
+
+    // MARK: - Claude models: standard tier
+
+    func testClaudeModelsStandardTier() {
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-sonnet-4-6")
+    }
+
+    // MARK: - Claude models: premium tier
+
+    func testClaudeModelsPremiumTier() {
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-opus-4-6")
+        XCTAssertEqual(ModelQoS.Claude.floatingBar, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Claude.synthesis, "claude-opus-4-6")
+    }
+
+    // MARK: - Claude pinned models (tier-independent)
+
+    func testClaudePinnedModelsIgnoreTier() {
+        for tier in ModelTier.allCases {
+            ModelQoS.activeTier = tier
+            XCTAssertEqual(ModelQoS.Claude.chatLabQuery, "claude-sonnet-4-20250514")
+            XCTAssertEqual(ModelQoS.Claude.chatLabGrade, "claude-haiku-4-5-20251001")
+            XCTAssertEqual(ModelQoS.Claude.defaultSelection, "claude-sonnet-4-6")
+        }
+    }
+
+    // MARK: - Available models reflect tier
+
+    func testAvailableModelsStandardTier() {
+        ModelQoS.activeTier = .standard
+        let ids = ModelQoS.Claude.availableModels.map(\.id)
+        XCTAssertEqual(ids, ["claude-sonnet-4-6"])
+    }
+
+    func testAvailableModelsPremiumTier() {
+        ModelQoS.activeTier = .premium
+        let ids = ModelQoS.Claude.availableModels.map(\.id)
+        XCTAssertEqual(ids, ["claude-sonnet-4-6", "claude-opus-4-6"])
+    }
+
+    // MARK: - Gemini models: standard tier
+
+    func testGeminiModelsStandardTier() {
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-3-flash-preview")
+        XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-3-flash-preview")
+        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
+    }
+
+    // MARK: - Gemini models: premium tier
+
+    func testGeminiModelsPremiumTier() {
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Gemini.proactive, "gemini-3-flash-preview")
+        XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-pro-latest")
+        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-pro-latest")
+    }
+
+    // MARK: - Gemini pinned models (tier-independent)
+
+    func testGeminiEmbeddingIgnoresTier() {
+        for tier in ModelTier.allCases {
+            ModelQoS.activeTier = tier
+            XCTAssertEqual(ModelQoS.Gemini.embedding, "gemini-embedding-001")
+        }
+    }
+
+    // MARK: - Tier description
+
+    func testTierDescription() {
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.tierDescription, "Standard (cost-optimized)")
+
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.tierDescription, "Premium (quality-optimized)")
+    }
+
+    // MARK: - Tier switch dynamically changes accessors
+
+    func testTierSwitchChangesModelsAtRuntime() {
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
+
+        ModelQoS.activeTier = .premium
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-opus-4-6")
+        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-pro-latest")
+
+        ModelQoS.activeTier = .standard
+        XCTAssertEqual(ModelQoS.Claude.chat, "claude-sonnet-4-6")
+        XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-3-flash-preview")
+    }
+}

--- a/desktop/Desktop/Tests/ModelQoSTests.swift
+++ b/desktop/Desktop/Tests/ModelQoSTests.swift
@@ -160,4 +160,12 @@ final class ModelQoSTests: XCTestCase {
         ModelQoS.activeTier = .premium
         XCTAssertEqual(ModelQoS.Claude.sanitizedSelection("gpt-4o"), "claude-sonnet-4-6")
     }
+
+    // MARK: - Tier change notification
+
+    func testTierChangePostsNotification() {
+        let expectation = expectation(forNotification: .modelTierDidChange, object: nil)
+        ModelQoS.activeTier = .max
+        wait(for: [expectation], timeout: 1.0)
+    }
 }


### PR DESCRIPTION
## Summary

Implements a Model QoS tier system for the desktop app (Swift + Rust backend) that centralizes all AI model configuration with switchable cost/quality tiers.

**Optimized model palette (7 → 5 unique model IDs, ~55-65% cost savings on max tier):**

| Model ID | Cost (in/out per 1M) | Used For |
|----------|---------------------|----------|
| `claude-sonnet-4-6` | $3/$15 | Chat, floating bar, onboarding (user-facing) |
| `claude-haiku-4-5-20251001` | $1/$5 | Gmail/Calendar/Notes extraction + ChatLab grading |
| `gemini-3-flash-preview` | $0.50/$3 | All Gemini features (proactive, tasks, insight) |
| `claude-sonnet-4-20250514` | $3/$15 | ChatLab queries (pinned for reproducibility) |
| `gemini-embedding-001` | — | Embeddings (pinned, can't swap without re-index) |

**Key changes:**
- Synthesis extraction (Gmail, Calendar, Notes, Memory import) → Haiku (80% cheaper than Opus)
- Onboarding chat → uses chat model (Sonnet) since it's user-facing, not extraction
- Gemini: all features use Flash (removed gemini-pro-latest entirely)
- Tiers differentiated via rate limits (premium: soft=30, max: soft=300, hard=1500 both)
- Runtime re-sanitization: `ShortcutSettings` observes `.modelTierDidChange` notification
- `sanitizedSelection()` prevents stale model IDs from persisting across tier changes

**Files changed:**
- `ModelQoS.swift` — Central Swift config (5 model IDs, tier-independent)
- `OnboardingChatView.swift` — Uses chat model instead of synthesis
- `OnboardingPagedIntroCoordinator.swift` — Uses chat model instead of synthesis
- `model_qos.rs` — Rust backend config (Flash for all Gemini, simplified proxy allowlist)
- `proxy.rs` — Removed gemini-pro-latest from allowlist
- `rate_limit.rs` — Tier-aware rate limiting (boundary tests)
- `client.rs` — LlmClient wired to model_qos
- `ShortcutSettings.swift` — Re-sanitization observer on tier change

## Test plan

- [x] 123 Rust tests pass (model_qos, proxy allowlist, rate limit boundaries)
- [x] Swift builds clean with 14 test cases (tier independence, 5-model-count invariant)
- [x] L2: Local Rust backend + named macOS app bundle, full sign-in → chat → Gemini proxy
- [x] Gemini proxy: Flash→200, blocked model→403
- [x] Walkthrough video + screenshots uploaded to GCS

Closes #6834

🤖 Generated with [Claude Code](https://claude.com/claude-code)