### PR TITLE
[security] fix(payment): enforce ownership on Stripe account refresh

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -769,10 +769,18 @@ async def refresh_account_link_endpoint(
     request: Request, account_id: str, uid: str = Depends(auth.get_current_user_uid)
 ):
     """
-    Generate a fresh account link if the previous one expired
+    Generate a fresh account link if the previous one expired.
+
+    Only the authenticated user's own connected account may be refreshed.
     """
+    expected_account_id = get_stripe_connect_account_id(uid)
+    if not expected_account_id:
+        raise HTTPException(status_code=404, detail="Connect account not found")
+    if account_id != expected_account_id:
+        raise HTTPException(status_code=403, detail="You are not authorized to refresh this account")
+
     try:
-        account = refresh_connect_account_link(account_id)
+        account = refresh_connect_account_link(expected_account_id)
         return account
     except stripe.error.StripeError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/tests/unit/test_stripe_connect_account_refresh_authz.py
+++ b/backend/tests/unit/test_stripe_connect_account_refresh_authz.py
@@ -8,11 +8,11 @@ import asyncio
 import os
 import sys
 import types
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
-    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+    "test_fake_encryption_secret_not_used_in_production",
 )
 
 # --- Stub heavy infrastructure before importing project modules ---
@@ -120,54 +120,56 @@ class DummyRequest:
 
 def test_refresh_account_link_rejects_other_users_account_id():
     """Authenticated callers must not refresh a Stripe link for another account id."""
-    payment_router.get_stripe_connect_account_id = MagicMock(return_value="acct_attacker")
-    payment_router.refresh_connect_account_link = MagicMock()
-
-    with pytest_raises_http_exception(403) as exc:
-        asyncio.run(
-            payment_router.refresh_account_link_endpoint(
-                DummyRequest(), account_id="acct_victim", uid="attacker_uid"
+    with patch.object(
+        payment_router, "get_stripe_connect_account_id", return_value="acct_attacker"
+    ) as mock_get_account_id, patch.object(payment_router, "refresh_connect_account_link") as mock_refresh:
+        with pytest_raises_http_exception(403) as exc:
+            asyncio.run(
+                payment_router.refresh_account_link_endpoint(
+                    DummyRequest(), account_id="acct_victim", uid="attacker_uid"
+                )
             )
-        )
 
     assert "not authorized" in exc.detail.lower()
-    payment_router.get_stripe_connect_account_id.assert_called_once_with("attacker_uid")
-    payment_router.refresh_connect_account_link.assert_not_called()
+    mock_get_account_id.assert_called_once_with("attacker_uid")
+    mock_refresh.assert_not_called()
 
 
 def test_refresh_account_link_allows_own_account_id():
     """Authenticated callers may refresh the Stripe link for their own account id."""
-    payment_router.get_stripe_connect_account_id = MagicMock(return_value="acct_attacker")
-    payment_router.refresh_connect_account_link = MagicMock(
-        return_value={"account_id": "acct_attacker", "url": "https://example.test/onboard"}
-    )
-
-    result = asyncio.run(
-        payment_router.refresh_account_link_endpoint(
-            DummyRequest(), account_id="acct_attacker", uid="attacker_uid"
+    with patch.object(
+        payment_router, "get_stripe_connect_account_id", return_value="acct_attacker"
+    ) as mock_get_account_id, patch.object(
+        payment_router,
+        "refresh_connect_account_link",
+        return_value={"account_id": "acct_attacker", "url": "https://example.test/onboard"},
+    ) as mock_refresh:
+        result = asyncio.run(
+            payment_router.refresh_account_link_endpoint(
+                DummyRequest(), account_id="acct_attacker", uid="attacker_uid"
+            )
         )
-    )
 
     assert result["account_id"] == "acct_attacker"
-    payment_router.get_stripe_connect_account_id.assert_called_once_with("attacker_uid")
-    payment_router.refresh_connect_account_link.assert_called_once_with("acct_attacker")
+    mock_get_account_id.assert_called_once_with("attacker_uid")
+    mock_refresh.assert_called_once_with("acct_attacker")
 
 
 def test_refresh_account_link_requires_existing_connected_account():
     """Users without a stored Stripe Connect account should get a not-found error."""
-    payment_router.get_stripe_connect_account_id = MagicMock(return_value=None)
-    payment_router.refresh_connect_account_link = MagicMock()
-
-    with pytest_raises_http_exception(404) as exc:
-        asyncio.run(
-            payment_router.refresh_account_link_endpoint(
-                DummyRequest(), account_id="acct_missing", uid="attacker_uid"
+    with patch.object(payment_router, "get_stripe_connect_account_id", return_value=None) as mock_get_account_id, patch.object(
+        payment_router, "refresh_connect_account_link"
+    ) as mock_refresh:
+        with pytest_raises_http_exception(404) as exc:
+            asyncio.run(
+                payment_router.refresh_account_link_endpoint(
+                    DummyRequest(), account_id="acct_missing", uid="attacker_uid"
+                )
             )
-        )
 
     assert "connect account not found" in exc.detail.lower()
-    payment_router.get_stripe_connect_account_id.assert_called_once_with("attacker_uid")
-    payment_router.refresh_connect_account_link.assert_not_called()
+    mock_get_account_id.assert_called_once_with("attacker_uid")
+    mock_refresh.assert_not_called()
 
 
 class pytest_raises_http_exception:

--- a/backend/tests/unit/test_stripe_connect_account_refresh_authz.py
+++ b/backend/tests/unit/test_stripe_connect_account_refresh_authz.py
@@ -1,0 +1,191 @@
+"""Regression tests for Stripe Connect account-link refresh authorization.
+
+These tests keep the fix narrow: an authenticated user may only refresh the
+account link for the Stripe Connect account stored on their own user record.
+"""
+
+import asyncio
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+# --- Stub heavy infrastructure before importing project modules ---
+_mock_client = types.ModuleType("database._client")
+_mock_client.db = MagicMock()
+sys.modules["database._client"] = _mock_client
+
+_fb_admin = types.ModuleType("firebase_admin")
+_fb_admin.auth = MagicMock()
+sys.modules["firebase_admin"] = _fb_admin
+sys.modules["firebase_admin.auth"] = _fb_admin.auth
+
+_db_mod = types.ModuleType("database")
+sys.modules.setdefault("database", _db_mod)
+
+for _name in [
+    "database.users",
+    "database.notifications",
+    "database.conversations",
+    "database.memories",
+    "database.action_items",
+    "database.redis_db",
+    "database.user_usage",
+    "database.cache",
+    "database.announcements",
+]:
+    _m = types.ModuleType(_name)
+    sys.modules[_name] = _m
+    setattr(_db_mod, _name.split(".")[-1], _m)
+
+_users_mod = sys.modules["database.users"]
+for _attr in [
+    "get_user_subscription",
+    "get_user_valid_subscription",
+    "update_user_subscription",
+    "get_stripe_connect_account_id",
+    "set_stripe_connect_account_id",
+    "set_paypal_payment_details",
+    "get_default_payment_method",
+    "set_default_payment_method",
+    "get_paypal_payment_details",
+]:
+    setattr(_users_mod, _attr, MagicMock())
+
+_redis_mod = sys.modules["database.redis_db"]
+_redis_mod.set_credits_invalidation_signal = MagicMock()
+_redis_mod.mark_event_processed_once = MagicMock(return_value=True)
+_redis_mod.r = MagicMock()
+
+for _name in [
+    "utils.fair_use",
+    "utils.notifications",
+    "utils.apps",
+    "utils.stripe",
+    "utils.other",
+    "utils.other.endpoints",
+    "utils.other.storage",
+    "utils.subscription",
+    "utils.log_sanitizer",
+]:
+    _m = types.ModuleType(_name)
+    sys.modules[_name] = _m
+
+sys.modules["utils.fair_use"].clear_fair_use_on_upgrade = MagicMock()
+
+_notif_mod = sys.modules["utils.notifications"]
+_notif_mod.send_notification = MagicMock()
+_notif_mod.send_subscription_paid_personalized_notification = MagicMock()
+
+_apps_mod = sys.modules["utils.apps"]
+for _attr in ["find_app_subscription", "get_is_user_paid_app", "paid_app", "set_user_app_sub_customer_id"]:
+    setattr(_apps_mod, _attr, MagicMock())
+
+_stripe_utils = sys.modules["utils.stripe"]
+_stripe_utils.base_url = "http://test"
+_stripe_utils.create_connect_account = MagicMock()
+_stripe_utils.refresh_connect_account_link = MagicMock()
+_stripe_utils.is_onboarding_complete = MagicMock()
+_stripe_utils.create_subscription_checkout_session = MagicMock()
+
+_endpoints_mod = sys.modules["utils.other.endpoints"]
+_endpoints_mod.get_current_user_uid = lambda: "test-user"
+sys.modules["utils.other"].endpoints = _endpoints_mod
+
+_subscription_mod = sys.modules["utils.subscription"]
+for _attr in [
+    "get_basic_plan_limits",
+    "get_paid_plan_definitions",
+    "get_plan_type_from_price_id",
+    "get_plan_limits",
+    "is_paid_plan",
+]:
+    setattr(_subscription_mod, _attr, MagicMock())
+
+sys.modules["utils.log_sanitizer"].sanitize = lambda x: x
+
+import stripe
+from fastapi import HTTPException
+from routers import payment as payment_router
+
+
+class DummyRequest:
+    pass
+
+
+def test_refresh_account_link_rejects_other_users_account_id():
+    """Authenticated callers must not refresh a Stripe link for another account id."""
+    payment_router.get_stripe_connect_account_id = MagicMock(return_value="acct_attacker")
+    payment_router.refresh_connect_account_link = MagicMock()
+
+    with pytest_raises_http_exception(403) as exc:
+        asyncio.run(
+            payment_router.refresh_account_link_endpoint(
+                DummyRequest(), account_id="acct_victim", uid="attacker_uid"
+            )
+        )
+
+    assert "not authorized" in exc.detail.lower()
+    payment_router.get_stripe_connect_account_id.assert_called_once_with("attacker_uid")
+    payment_router.refresh_connect_account_link.assert_not_called()
+
+
+def test_refresh_account_link_allows_own_account_id():
+    """Authenticated callers may refresh the Stripe link for their own account id."""
+    payment_router.get_stripe_connect_account_id = MagicMock(return_value="acct_attacker")
+    payment_router.refresh_connect_account_link = MagicMock(
+        return_value={"account_id": "acct_attacker", "url": "https://example.test/onboard"}
+    )
+
+    result = asyncio.run(
+        payment_router.refresh_account_link_endpoint(
+            DummyRequest(), account_id="acct_attacker", uid="attacker_uid"
+        )
+    )
+
+    assert result["account_id"] == "acct_attacker"
+    payment_router.get_stripe_connect_account_id.assert_called_once_with("attacker_uid")
+    payment_router.refresh_connect_account_link.assert_called_once_with("acct_attacker")
+
+
+def test_refresh_account_link_requires_existing_connected_account():
+    """Users without a stored Stripe Connect account should get a not-found error."""
+    payment_router.get_stripe_connect_account_id = MagicMock(return_value=None)
+    payment_router.refresh_connect_account_link = MagicMock()
+
+    with pytest_raises_http_exception(404) as exc:
+        asyncio.run(
+            payment_router.refresh_account_link_endpoint(
+                DummyRequest(), account_id="acct_missing", uid="attacker_uid"
+            )
+        )
+
+    assert "connect account not found" in exc.detail.lower()
+    payment_router.get_stripe_connect_account_id.assert_called_once_with("attacker_uid")
+    payment_router.refresh_connect_account_link.assert_not_called()
+
+
+class pytest_raises_http_exception:
+    """Tiny context manager so this test stays runnable without importing pytest helpers here."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.detail = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if exc is None:
+            raise AssertionError(f"Expected HTTPException({self.status_code})")
+        if not isinstance(exc, HTTPException):
+            raise AssertionError(f"Expected HTTPException, got {type(exc)!r}")
+        if exc.status_code != self.status_code:
+            raise AssertionError(f"Expected status {self.status_code}, got {exc.status_code}")
+        self.detail = exc.detail
+        return True


### PR DESCRIPTION
## Summary

This PR fixes an authenticated authorization flaw in the Stripe Connect account-link refresh flow.

- `/v1/stripe/refresh/{account_id}` previously accepted any path-supplied Stripe Connect account id after user authentication
- the endpoint did not verify that the supplied `account_id` belonged to the authenticated user
- this patch now derives the expected Stripe account from the caller's own user record and rejects missing or mismatched ownership before creating a fresh Stripe account link
- adds targeted regression coverage for the allow, deny, and missing-account cases

## Security issue covered

| issue | impact | severity |
| --- | --- | --- |
| Authenticated IDOR on Stripe Connect account-link refresh | An authenticated user who knows another creator's Stripe Connect account id could mint a fresh onboarding/account link for that victim account | High |

## Before this PR

- `POST /v1/stripe/refresh/{account_id}` trusted the caller-supplied `account_id`
- after authentication, the handler directly called `refresh_connect_account_link(account_id)`
- no ownership check tied the requested Stripe account to the authenticated `uid`

## After this PR

- the handler loads the caller's stored Stripe Connect account id with `get_stripe_connect_account_id(uid)`
- requests with no stored Stripe account now fail closed with `404`
- requests for a different account id now fail closed with `403`
- the Stripe refresh call now uses the server-derived account id instead of the path parameter
- regression tests lock in the ownership boundary

## Why this matters

The vulnerable route was a broken object-level authorization path in a payment control plane.

A normal authenticated user should only ever be able to refresh the onboarding link for the Stripe Connect account attached to their own user record. Before this patch, the route accepted an arbitrary path account id and created a fresh Stripe account link for it.

## Attack flow

```text
authenticated attacker request
    -> POST /v1/stripe/refresh/{victim_account_id}
        -> backend trusted path-supplied Stripe account id
            -> fresh Stripe onboarding/account link for victim account
```

## Affected code

| file | role |
| --- | --- |
| `backend/routers/payment.py` | vulnerable refresh route and fix |
| `backend/database/users.py` | canonical per-user Stripe account lookup used for authorization |
| `backend/tests/unit/test_stripe_connect_account_refresh_authz.py` | regression coverage for ownership enforcement |

## Root cause

- direct cause: the route authenticated the caller but never enforced ownership of the requested Stripe account id
- trust-boundary failure: a path parameter was treated as authority for a payment control-plane action instead of deriving the target object from server-side user state

## CVSS assessment

| issue | CVSS v3.1 | vector |
| --- | --- | --- |
| Stripe Connect account-link refresh IDOR | 6.5 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N` |

Rationale:
- requires a normal authenticated user
- no user interaction is required after the attacker submits the request
- impact is primarily unauthorized access to another user's Stripe onboarding/control-plane flow rather than full platform compromise

## Safe reproduction steps

1. Create or use two users:
   - attacker user A
   - victim user B with a stored Stripe Connect account id
2. Authenticate as user A
3. Send a request to:
   - `POST /v1/stripe/refresh/{victim_account_id}`
4. Observe pre-fix behavior:
   - the backend returns a fresh link for the victim account
5. Observe fixed behavior:
   - the backend compares `{victim_account_id}` to `get_stripe_connect_account_id(attacker_uid)`
   - the request is rejected with `403`

## Expected vulnerable behavior

Before this PR, the route would accept a caller-supplied Stripe Connect account id and return:

- `account_id: <victim account id>`
- `url: <fresh Stripe account link>`

without verifying that the account belonged to the authenticated caller.

## Changes in this PR

- add server-side ownership lookup in `refresh_account_link_endpoint`
- reject callers without a stored Stripe Connect account
- reject mismatched account ids with `403`
- pass only the server-derived account id into `refresh_connect_account_link`
- add regression tests for:
  - mismatched account id rejection
  - successful refresh for the caller's own account id
  - missing stored account rejection

## Files changed

| category | files | change |
| --- | --- | --- |
| fix | `backend/routers/payment.py` | enforce ownership before refreshing Stripe account link |
| tests | `backend/tests/unit/test_stripe_connect_account_refresh_authz.py` | add regression coverage for the authz boundary |

## Maintainer impact

- narrow patch surface limited to the Stripe Connect refresh route
- no change to the existing happy path for refreshing the authenticated user's own account link
- no schema or migration changes
- no change to webhook or subscription logic

## Fix rationale

The backend already has a canonical ownership source for Stripe Connect accounts: `get_stripe_connect_account_id(uid)`.

The safest pattern is to treat that server-side value as authoritative and fail closed on any mismatch, rather than trusting a client-controlled path parameter for a payment control-plane action.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix
- [x] Tests added/updated
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation-only change

## Test plan

- [x] Added targeted regression tests for ownership enforcement
- [x] Ran targeted test file successfully
- [x] Checked diff formatting with `git diff --check`

Executed:

```bash
cd backend
/Users/lennon/.hermes/hermes-agent/venv/bin/python3.11 -m pytest tests/unit/test_stripe_connect_account_refresh_authz.py -q
```

Observed result:

```text
3 passed in 0.10s
```

## Disclosure notes

- this PR is intentionally scoped to the verified authorization flaw in the Stripe Connect refresh route
- no unrelated backend routes were changed
- the issue was reproduced as a direct current-head code-path proof before preparing this patch
