### PR TITLE
[security] fix(apps): redact MCP OAuth tokens from app responses

### DIFF
--- a/backend/models/app.py
+++ b/backend/models/app.py
@@ -21,6 +21,21 @@ APP_REDUCE_EXCLUDE_FIELDS = {
     'usage_count',
 }
 
+SENSITIVE_EXTERNAL_INTEGRATION_FIELDS = {
+    'mcp_oauth_tokens',
+}
+
+
+def redact_external_integration_secrets(external_integration: Optional[dict]) -> Optional[dict]:
+    """Remove secret-bearing integration fields from user-facing responses."""
+    if not external_integration or not isinstance(external_integration, dict):
+        return external_integration
+
+    redacted = dict(external_integration)
+    for field in SENSITIVE_EXTERNAL_INTEGRATION_FIELDS:
+        redacted.pop(field, None)
+    return redacted
+
 
 class AppReview(BaseModel):
     uid: str
@@ -218,7 +233,15 @@ class App(AppBaseModel):
         Excludes large/redundant fields that are not needed in app list displays.
         Uses APP_REDUCE_EXCLUDE_FIELDS constant for consistency with cache reduction.
         """
-        return self.model_dump(mode='json', exclude=APP_REDUCE_EXCLUDE_FIELDS)
+        data = self.model_dump(mode='json', exclude=APP_REDUCE_EXCLUDE_FIELDS)
+        data['external_integration'] = redact_external_integration_secrets(data.get('external_integration'))
+        return data
+
+    def to_safe_response_dict(self) -> dict:
+        """Serialize for user-facing detail responses with sensitive fields redacted."""
+        data = self.model_dump(mode='json')
+        data['external_integration'] = redact_external_integration_secrets(data.get('external_integration'))
+        return data
 
     @staticmethod
     def reduce_dict(app_dict: dict) -> dict:
@@ -226,7 +249,9 @@ class App(AppBaseModel):
 
         Use this for reducing dicts before caching. For App instances, use to_reduced_dict().
         """
-        return {k: v for k, v in app_dict.items() if k not in APP_REDUCE_EXCLUDE_FIELDS}
+        reduced = {k: v for k, v in app_dict.items() if k not in APP_REDUCE_EXCLUDE_FIELDS}
+        reduced['external_integration'] = redact_external_integration_secrets(reduced.get('external_integration'))
+        return reduced
 
 
 class AppCreate(BaseModel):

--- a/backend/models/app.py
+++ b/backend/models/app.py
@@ -250,7 +250,8 @@ class App(AppBaseModel):
         Use this for reducing dicts before caching. For App instances, use to_reduced_dict().
         """
         reduced = {k: v for k, v in app_dict.items() if k not in APP_REDUCE_EXCLUDE_FIELDS}
-        reduced['external_integration'] = redact_external_integration_secrets(reduced.get('external_integration'))
+        if 'external_integration' in reduced:
+            reduced['external_integration'] = redact_external_integration_secrets(reduced.get('external_integration'))
         return reduced
 
 

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -647,7 +647,7 @@ def get_persona_details(uid: str = Depends(auth.get_current_user_uid)):
         if app.private and app.uid != uid:
             raise HTTPException(status_code=403, detail='You are not authorized to view this Persona')
 
-    return app
+    return app.to_safe_response_dict()
 
 
 @router.post('/v1/user/persona', tags=['v1'])
@@ -859,7 +859,7 @@ def get_app_details(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
     if app.thumbnails:
         app.thumbnail_urls = [get_app_thumbnail_url(thumbnail_id) for thumbnail_id in app.thumbnails]
 
-    return app
+    return app.to_safe_response_dict()
 
 
 @router.get('/v1/app-categories', tags=['v1'])

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -689,7 +689,7 @@ def get_conversation_suggested_apps(conversation_id: str, uid: str = Depends(aut
 
             suggested_apps.append(app)
 
-    return {"suggested_apps": [app.dict() for app in suggested_apps], "conversation_id": conversation_id}
+    return {"suggested_apps": [app.to_safe_response_dict() for app in suggested_apps], "conversation_id": conversation_id}
 
 
 @router.post("/v1/conversations/{conversation_id}/test-prompt", response_model=dict, tags=['conversations'])

--- a/backend/tests/unit/test_mcp_oauth_token_redaction.py
+++ b/backend/tests/unit/test_mcp_oauth_token_redaction.py
@@ -58,3 +58,23 @@ def test_reduce_dict_redacts_mcp_oauth_tokens_from_cached_dicts():
     assert 'external_integration' in reduced
     assert reduced['external_integration']['mcp_server_url'] == 'https://mcp.example.com'
     assert 'mcp_oauth_tokens' not in reduced['external_integration']
+
+
+def test_reduce_dict_does_not_inject_external_integration_when_missing():
+    raw = {
+        'id': 'app2',
+        'name': 'plain-app',
+        'uid': 'owner',
+        'private': False,
+        'approved': True,
+        'status': 'approved',
+        'category': 'utilities-and-tools',
+        'author': 'owner',
+        'description': 'demo',
+        'image': 'img',
+        'capabilities': ['chat'],
+    }
+
+    reduced = App.reduce_dict(raw)
+
+    assert 'external_integration' not in reduced

--- a/backend/tests/unit/test_mcp_oauth_token_redaction.py
+++ b/backend/tests/unit/test_mcp_oauth_token_redaction.py
@@ -1,0 +1,60 @@
+from models.app import App
+
+
+def _sample_app() -> App:
+    return App(
+        id='app1',
+        name='demo',
+        uid='owner',
+        private=False,
+        approved=True,
+        status='approved',
+        category='utilities-and-tools',
+        author='owner',
+        description='demo',
+        image='img',
+        capabilities={'chat'},
+        external_integration={
+            'mcp_server_url': 'https://mcp.example.com',
+            'mcp_oauth_tokens': {
+                'client_id': 'cid',
+                'client_secret': 'csecret',
+                'access_token': 'atoken',
+                'refresh_token': 'rtoken',
+                'code_verifier': 'pkce',
+                'token_endpoint': 'https://oauth.example/token',
+                'redirect_uri': 'https://api.omi.me/v1/apps/mcp/callback',
+                'expires_at': 12345,
+            },
+        },
+    )
+
+
+def test_to_reduced_dict_redacts_mcp_oauth_tokens():
+    app = _sample_app()
+
+    reduced = app.to_reduced_dict()
+
+    assert 'external_integration' in reduced
+    assert reduced['external_integration']['mcp_server_url'] == 'https://mcp.example.com'
+    assert 'mcp_oauth_tokens' not in reduced['external_integration']
+
+
+def test_to_safe_response_dict_redacts_mcp_oauth_tokens():
+    app = _sample_app()
+
+    safe = app.to_safe_response_dict()
+
+    assert 'external_integration' in safe
+    assert safe['external_integration']['mcp_server_url'] == 'https://mcp.example.com'
+    assert 'mcp_oauth_tokens' not in safe['external_integration']
+
+
+def test_reduce_dict_redacts_mcp_oauth_tokens_from_cached_dicts():
+    raw = _sample_app().model_dump(mode='json')
+
+    reduced = App.reduce_dict(raw)
+
+    assert 'external_integration' in reduced
+    assert reduced['external_integration']['mcp_server_url'] == 'https://mcp.example.com'
+    assert 'mcp_oauth_tokens' not in reduced['external_integration']

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -67,7 +67,7 @@ from database.redis_db import (
     set_persona_update_timestamp,
 )
 from database.users import get_stripe_connect_account_id
-from models.app import App, UsageHistoryItem, UsageHistoryType
+from models.app import App, UsageHistoryItem, UsageHistoryType, redact_external_integration_secrets
 from utils.conversations.factory import deserialize_conversations
 from utils.conversations.render import conversations_to_string
 from utils import stripe
@@ -81,6 +81,19 @@ logger = logging.getLogger(__name__)
 MarketplaceAppReviewUIDs = (
     os.getenv('MARKETPLACE_APP_REVIEWERS').split(',') if os.getenv('MARKETPLACE_APP_REVIEWERS') else []
 )
+
+
+def _redact_cached_app_dict(app_dict: dict) -> dict:
+    """Defensively redact secret-bearing integration fields from cached app dicts."""
+    sanitized = dict(app_dict)
+    if 'external_integration' in sanitized:
+        sanitized['external_integration'] = redact_external_integration_secrets(sanitized.get('external_integration'))
+    return sanitized
+
+
+def _redact_cached_apps(apps: List[dict]) -> List[dict]:
+    """Defensively redact secret-bearing integration fields from cached app lists."""
+    return [_redact_cached_app_dict(app) for app in apps]
 
 
 # ********************************
@@ -183,7 +196,7 @@ def get_popular_apps() -> List[App]:
         # Check Redis cache
         if cached_apps := get_generic_cache(cache_key):
             logger.info('get_popular_apps from Redis cache')
-            popular_apps = cached_apps
+            popular_apps = _redact_cached_apps(cached_apps)
         else:
             # Database query
             logger.info('get_popular_apps from db')
@@ -226,7 +239,7 @@ def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
         """Fetch from Redis or DB (called only once with singleflight)."""
         if data := get_generic_cache(cache_key):
             logger.info('get_public_approved_apps_data from Redis cache')
-            return data
+            return _redact_cached_apps(data)
         logger.info('get_public_approved_apps_data from db')
         data = get_public_approved_apps_db()
         # Reduce cache size by excluding large fields
@@ -282,6 +295,7 @@ def get_available_app_by_id(app_id: str, uid: str | None) -> dict | None:
     cached_app = get_app_cache_by_id(app_id)
     if cached_app:
         logger.info('get_app_cache_by_id from cache')
+        cached_app = _redact_cached_app_dict(cached_app)
         if cached_app['private'] and cached_app.get('uid') != uid and not (uid and is_tester(uid)):
             return None
         return cached_app
@@ -368,7 +382,7 @@ def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
         # Check Redis cache
         if cached_apps := get_generic_cache(redis_cache_key):
             logger.info('get_public_approved_apps_data from Redis cache')
-            all_apps = cached_apps
+            all_apps = _redact_cached_apps(cached_apps)
         else:
             # Database query
             logger.info('get_public_approved_apps_data from db')


### PR DESCRIPTION
## Summary

This PR fixes a stored secret disclosure issue in MCP-backed app serialization.

- OAuth-backed MCP apps store secret-bearing data under `external_integration.mcp_oauth_tokens`
- public and user-facing app serialization paths were returning `external_integration` without stripping `mcp_oauth_tokens`
- if an MCP app was later made public, public app responses could disclose stored OAuth material
- this patch redacts `mcp_oauth_tokens` from reduced app lists, detail responses, cache-reduced app dicts, and suggested app responses
- adds targeted regression coverage for the redaction helpers

## Security issue covered

| issue | impact | severity |
| --- | --- | --- |
| Stored MCP OAuth token disclosure via app serialization | Public or user-facing app responses could expose secret-bearing MCP OAuth state such as `client_secret`, `access_token`, `refresh_token`, and PKCE verifier material | High |

## Before this PR

- MCP OAuth secrets were stored in app records under `external_integration.mcp_oauth_tokens`
- `AppBaseModel` and reduced app serialization still included `external_integration`
- `App.to_reduced_dict()` and `App.reduce_dict()` did not strip `mcp_oauth_tokens`
- app detail responses and suggested app responses could serialize the full secret-bearing structure

## After this PR

- user-facing app serialization now redacts `external_integration.mcp_oauth_tokens`
- reduced app dicts used for public caches also redact the secret-bearing field
- app detail responses and suggested app responses now use the safe redacted serialization path
- storage paths remain unchanged: the fix is scoped to response serialization, not persistence

## Why this matters

This was a trust-boundary failure between secret storage and marketplace/public presentation.

The backend correctly stores MCP OAuth material so Omi can call remote MCP servers, but that same secret-bearing structure should never appear in user-facing app responses. Without redaction, publishing an MCP app could turn app metadata endpoints into a credential disclosure surface.

## Attack flow

```text
owner creates OAuth-backed MCP app
    -> backend stores external_integration.mcp_oauth_tokens
        -> owner changes app visibility to public
            -> public/user-facing app serialization returns external_integration
                -> stored MCP OAuth secrets leak in app response payloads
```

## Affected code

| file | role |
| --- | --- |
| `backend/routers/apps.py` | MCP OAuth token storage and app detail serialization |
| `backend/routers/conversations.py` | suggested app serialization path |
| `backend/models/app.py` | reduced/detail app serialization helpers |
| `backend/tests/unit/test_mcp_oauth_token_redaction.py` | regression coverage for redaction |

## Root cause

- direct cause: secret-bearing `mcp_oauth_tokens` was stored inside the same nested object that was later serialized into app responses
- trust-boundary failure: public/user-facing app metadata reused internal integration state without a redaction layer

## CVSS assessment

| issue | CVSS v3.1 | vector |
| --- | --- | --- |
| MCP OAuth token disclosure in app responses | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N` |

Rationale:
- exploitation requires a normal authenticated app owner to create/connect the MCP app and change visibility
- once public, other users can receive the leaked secret-bearing metadata through ordinary app response paths
- impact is primarily confidentiality loss of stored third-party OAuth credentials/tokens

## Safe reproduction steps

1. Create an MCP app through:
   - `POST /v1/apps/mcp`
2. Complete the OAuth flow so `external_integration.mcp_oauth_tokens` is populated
3. Change visibility to public:
   - `PATCH /v1/apps/{app_id}/change-visibility?private=false`
4. Fetch the app through a user-facing response path such as:
   - `GET /v1/approved-apps`
   - `GET /v2/apps`
   - `GET /v1/apps/{app_id}`
   - `GET /v1/conversations/{conversation_id}/suggested-apps` when applicable
5. Observe pre-fix behavior:
   - `external_integration.mcp_oauth_tokens` is present in the response
6. Observe fixed behavior:
   - `external_integration` remains available where needed, but `mcp_oauth_tokens` is redacted from the response payload

## Expected vulnerable behavior

Before this PR, user-facing app responses could include fields such as:
- `client_secret`
- `access_token`
- `refresh_token`
- `code_verifier`
- token endpoint metadata

inside `external_integration.mcp_oauth_tokens`.

## Changes in this PR

- add a dedicated redaction helper for secret-bearing external integration fields
- redact `mcp_oauth_tokens` in `App.to_reduced_dict()`
- redact `mcp_oauth_tokens` in `App.reduce_dict()` used for cached reduced app data
- add `App.to_safe_response_dict()` for detail/user-facing responses
- switch app detail and persona detail responses to the safe serialization path
- switch suggested app responses to the safe serialization path
- add regression tests covering reduced dict, safe detail dict, and reduced cached dict behavior

## Files changed

| category | files | change |
| --- | --- | --- |
| fix | `backend/models/app.py` | add redaction helper and safe serialization methods |
| fix | `backend/routers/apps.py` | use safe response serialization for detail endpoints |
| fix | `backend/routers/conversations.py` | use safe response serialization for suggested apps |
| tests | `backend/tests/unit/test_mcp_oauth_token_redaction.py` | add regression coverage for MCP OAuth token redaction |

## Maintainer impact

- narrow patch surface focused on serialization only
- no schema, migration, or OAuth flow changes
- no change to MCP token storage behavior needed for server-side operation
- safer default for any endpoint that uses the new redacted app serialization helpers

## Fix rationale

The safest fix is to keep secret-bearing MCP OAuth state in storage but remove it at every user-facing serialization boundary.

That avoids breaking MCP runtime behavior while ensuring marketplace/detail responses never expose token material.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix
- [x] Tests added/updated
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation-only change

## Test plan

- [x] Added targeted regression tests for MCP OAuth token redaction
- [x] Ran targeted unit test file successfully
- [x] Checked diff formatting with `git diff --check`

Executed:

```bash
cd backend
/Users/lennon/.hermes/hermes-agent/venv/bin/python3.11 -m pytest tests/unit/test_mcp_oauth_token_redaction.py -q
```

Observed result:

```text
3 passed in 0.04s
```

## Disclosure notes

- this PR is intentionally scoped to the verified MCP OAuth token disclosure path in user-facing app serialization
- persistence of `mcp_oauth_tokens` is unchanged and remains required for MCP server operation
- no unrelated auth, webhook, or payment logic was modified
