### PR TITLE
fix(app): guard getAuthHeader against missing token (#6142)

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -22,6 +22,14 @@ class ApiClient {
   }
 }
 
+class AuthTokenUnavailableException implements Exception {
+  final String message;
+  AuthTokenUnavailableException([this.message = 'No auth token found']);
+
+  @override
+  String toString() => 'AuthTokenUnavailableException: $message';
+}
+
 Future<String> getAuthHeader() async {
   DateTime? expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
   bool hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
@@ -42,7 +50,7 @@ Future<String> getAuthHeader() async {
     if (AuthService.instance.isSignedIn()) {
       // should only throw if the user is signed in but the token is not found
       // if the user is not signed in, the token will always be empty
-      throw Exception('No auth token found');
+      throw AuthTokenUnavailableException('No auth token found');
     }
   }
   return 'Bearer ${SharedPreferencesUtil().authToken}';
@@ -64,7 +72,18 @@ Future<Map<String, String>> buildHeaders({
   };
 
   if (requireAuthCheck) {
-    headers['Authorization'] = await getAuthHeader();
+    try {
+      headers['Authorization'] = await getAuthHeader();
+    } on AuthTokenUnavailableException {
+      // Signed-in user has no usable token (refresh returned null for a
+      // transient or degraded reason). Proceed without Authorization; the
+      // downstream HTTP 401 path in makeApiCall already calls
+      // AuthService.signOut(), so recovery runs where it was already wired.
+      // We avoid forcing sign-out here because getIdToken() treats generic
+      // failures as transient (e.g. offline / platform hiccups) and leaves
+      // currentUser intact.
+      Logger.debug('No auth token available for request, proceeding without Authorization header');
+    }
   }
 
   return headers;

--- a/app/test/unit/backend/http/shared_test.dart
+++ b/app/test/unit/backend/http/shared_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/http/shared.dart';
+
+Future<String> simulateGetAuthHeader({required bool isSignedIn, required String token}) async {
+  if (token.isEmpty && isSignedIn) {
+    throw AuthTokenUnavailableException('No auth token found');
+  }
+  return 'Bearer $token';
+}
+
+Future<Map<String, String>> simulateBuildHeaders({required Future<String> Function() getAuthHeader}) async {
+  final headers = <String, String>{};
+  try {
+    headers['Authorization'] = await getAuthHeader();
+  } on AuthTokenUnavailableException {
+    // Mirrors buildHeaders() behavior in shared.dart: continue without auth header.
+  }
+  return headers;
+}
+
+void main() {
+  group('auth header guards', () {
+    test('throws AuthTokenUnavailableException when signed in and token missing', () async {
+      expect(() => simulateGetAuthHeader(isSignedIn: true, token: ''), throwsA(isA<AuthTokenUnavailableException>()));
+    });
+
+    test('caller guard catches AuthTokenUnavailableException and omits Authorization header', () async {
+      final headers = await simulateBuildHeaders(
+        getAuthHeader: () => simulateGetAuthHeader(isSignedIn: true, token: ''),
+      );
+
+      expect(headers.containsKey('Authorization'), isFalse);
+    });
+
+    test('includes Authorization header on happy path', () async {
+      final headers = await simulateBuildHeaders(
+        getAuthHeader: () => simulateGetAuthHeader(isSignedIn: true, token: 'fresh-token'),
+      );
+
+      expect(headers['Authorization'], equals('Bearer fresh-token'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

On v1.0.526, `getAuthHeader()` in `app/lib/backend/http/shared.dart` throws a plain `Exception('No auth token found')` when the user appears signed-in but `SharedPreferencesUtil` has no cached token. The exception propagates through the async header-builder as an unhandled error and crashes the app. Crashlytics recorded ~3,400 fatals across ~83 users between Mar 22-27, 2026.

This PR converts the throw into a typed `AuthTokenUnavailableException` and catches it at the sole in-file caller (`buildHeaders`), logging the condition and letting the request proceed without an Authorization header.

## Why this matters

`getAuthHeader()` sits on every authenticated HTTP path in the app. A raw `throw Exception(...)` is not something most async callers guard against, so a single user in this bad state generates hundreds of crash reports. The crash count is high (3,400) despite the user count being modest (83), which confirms the exception fires repeatedly as the app retries work.

## Changes

Introduce `AuthTokenUnavailableException` at the top of `shared.dart` and replace the generic throw with this typed variant. The check logic itself is unchanged: we only throw when the token is empty AND `AuthService.isSignedIn()` is true, so the semantics that "signed-in-but-no-token is a signal worth surfacing" are preserved - we just stop representing that signal as an unhandled crash.

At the sole in-file caller (`buildHeaders` around the `requireAuthCheck` branch), the `await getAuthHeader()` is wrapped in a `try/on AuthTokenUnavailableException` that logs via `Logger.debug` and proceeds without the Authorization header. The downstream HTTP 401 path in `makeApiCall` already calls `AuthService.signOut()`, so recovery still happens where it was already wired - we're not adding a new sign-out path, we're just removing the crash that was preventing the 401 path from being reached.

The four other sites that already guard `getIdToken() ?? ''` (lines 121, 256, 328, 448) are unchanged - they were never at risk because they already handle the null case.

## Testing

A small unit test at `app/test/unit/backend/http/shared_test.dart` covers the typed exception and the caller-guard pattern: exception raises on signed-in-empty-token, caller catches it and omits `Authorization`, happy path still attaches `Bearer <token>`. Tests use `flutter_test` and don't require Firebase/SharedPreferences mocks because they exercise the exception shape directly.

I did not run `flutter test` locally (flutter SDK not installed in this environment). `dart format --line-length 120` clean on both files.

## Limitations

- WebSocket handshake paths (`PureSocket.connect`, `PhoneCallProvider._connectTranscriptionSocket`) use `buildHeaders(requireAuthCheck: true)` but won't see a 401, so a signed-in-no-token user could see socket connections fail silently instead of a crash. Still a net improvement, and the existing HTTP paths will trigger re-auth.
- No change to `AuthService`. If the token is persistently missing despite `getIdTokenResult(true)` returning non-null, that's an underlying auth-state bug worth its own issue.

Fixes #6142

This contribution was developed with AI assistance (Codex).
