### PR TITLE
desktop: Bring-Your-Own-Keys free plan

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -159,6 +159,62 @@ def set_user_cancellation_feedback(uid: str, reason: str, reason_details: Option
     )
 
 
+# BYOK (Bring Your Own Keys) — free-plan flag.
+# We never store keys themselves; only SHA-256 fingerprints so we can detect
+# rotation. `active` is the subscription-bypass gate.
+
+BYOK_HEARTBEAT_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days
+
+
+def get_byok_state(uid: str) -> dict:
+    user_ref = db.collection('users').document(uid)
+    data = user_ref.get().to_dict() or {}
+    return data.get('byok', {})
+
+
+def is_byok_active(uid: str) -> bool:
+    """True if user has a live BYOK activation (heartbeat within TTL)."""
+    state = get_byok_state(uid)
+    if not state.get('active'):
+        return False
+    last_seen = state.get('last_seen_at')
+    if not last_seen:
+        return False
+    if isinstance(last_seen, datetime):
+        age = (datetime.now(timezone.utc) - last_seen).total_seconds()
+    else:
+        return False
+    return age <= BYOK_HEARTBEAT_TTL_SECONDS
+
+
+def set_byok_active(uid: str, fingerprints: dict):
+    user_ref = db.collection('users').document(uid)
+    user_ref.set(
+        {
+            'byok': {
+                'active': True,
+                'fingerprints': fingerprints,
+                'last_seen_at': datetime.now(timezone.utc),
+            }
+        },
+        merge=True,
+    )
+
+
+def clear_byok_active(uid: str):
+    user_ref = db.collection('users').document(uid)
+    user_ref.set(
+        {
+            'byok': {
+                'active': False,
+                'fingerprints': {},
+                'last_seen_at': datetime.now(timezone.utc),
+            }
+        },
+        merge=True,
+    )
+
+
 def set_user_deletion_feedback(uid: str, reason: Optional[str], reason_details: Optional[str] = None):
     # Stored in a top-level collection so it survives the user record being deleted.
     db.collection('account_deletions').document(uid).set(

--- a/backend/main.py
+++ b/backend/main.py
@@ -134,6 +134,10 @@ methods_timeout = {
 
 app.add_middleware(TimeoutMiddleware, methods_timeout=methods_timeout)
 
+from utils.byok import BYOKMiddleware
+
+app.add_middleware(BYOKMiddleware)
+
 
 @app.on_event("shutdown")
 async def shutdown_event():

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -1,10 +1,11 @@
 import struct
 import asyncio
+import contextvars
 import json
 import time
 from collections import deque
 from datetime import datetime, timezone
-from typing import Dict, Set
+from typing import Dict, Optional, Set
 
 from fastapi import APIRouter
 from fastapi.websockets import WebSocketDisconnect, WebSocket
@@ -24,6 +25,7 @@ from utils.app_integrations import (
     trigger_external_integrations,
 )
 from utils.conversations.location import async_get_google_maps_location
+from utils.byok import set_byok_keys
 from utils.conversations.process_conversation import process_conversation
 from utils.executors import storage_executor
 from utils.webhooks import (
@@ -62,8 +64,21 @@ TRANSCRIPT_QUEUE_WARN_SIZE = 50
 AUDIO_BYTES_QUEUE_WARN_SIZE = 20
 
 
-async def _process_conversation_task(uid: str, conversation_id: str, language: str, websocket: WebSocket):
-    """Process a conversation and send result back to _listen via websocket."""
+async def _process_conversation_task(
+    uid: str,
+    conversation_id: str,
+    language: str,
+    websocket: WebSocket,
+    byok_keys: Optional[Dict[str, str]] = None,
+):
+    """Process a conversation and send result back to _listen via websocket.
+
+    `byok_keys` is forwarded from the listen service. When present, LLM and
+    STT calls made inside process_conversation route through the user's own
+    provider keys instead of Omi's env keys.
+    """
+    if byok_keys:
+        set_byok_keys(byok_keys)
     try:
         conversation_data = conversations_db.get_conversation(uid, conversation_id)
         if not conversation_data:
@@ -93,8 +108,13 @@ async def _process_conversation_task(uid: str, conversation_id: str, language: s
             # Run in default executor (not critical_executor) because process_conversation
             # is a coordinator that submits child tasks to critical_executor — nesting both
             # in the same pool causes deadlock under concurrent load.
+            # Copy the current context (which holds BYOK keys) into the worker thread so
+            # LLM client proxies see the right key when resolving per-request.
             loop = asyncio.get_running_loop()
-            conversation = await loop.run_in_executor(None, process_conversation, uid, language, conversation)
+            ctx = contextvars.copy_context()
+            conversation = await loop.run_in_executor(
+                None, lambda: ctx.run(process_conversation, uid, language, conversation)
+            )
             messages = await trigger_external_integrations(uid, conversation)
         except Exception as e:
             logger.error(f"Error processing conversation: {e} {uid} {conversation_id}")
@@ -442,9 +462,10 @@ async def _websocket_util_trigger(
                     res = json.loads(bytes(data[4:]).decode("utf-8"))
                     conversation_id = res.get('conversation_id')
                     language = res.get('language', 'en')
+                    byok_keys = res.get('byok_keys') or None
                     if conversation_id:
                         logger.info(f"Pusher received process_conversation request: {conversation_id} {uid}")
-                        spawn(_process_conversation_task(uid, conversation_id, language, websocket))
+                        spawn(_process_conversation_task(uid, conversation_id, language, websocket, byok_keys))
                     continue
 
                 # Speaker sample extraction request - queue for background processing

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -36,6 +36,7 @@ from utils.speaker_assignment import (
 import database.conversations as conversations_db
 import database.calendar_meetings as calendar_db
 import database.users as user_db
+from utils.byok import get_byok_keys
 from database.users import get_user_transcription_preferences
 from database import redis_db
 from database.redis_db import check_credits_invalidation
@@ -1073,7 +1074,15 @@ async def _stream_handler(
                 pending_request_event.set()  # Signal the receiver
                 data = bytearray()
                 data.extend(struct.pack("I", 104))
-                data.extend(bytes(json.dumps({"conversation_id": conversation_id, "language": language}), "utf-8"))
+                # Forward BYOK keys to pusher so process_conversation routes LLM
+                # calls through the user's keys. Empty dict when user isn't BYOK
+                # — pusher then uses its env keys (unchanged behavior).
+                payload = {
+                    "conversation_id": conversation_id,
+                    "language": language,
+                    "byok_keys": get_byok_keys(),
+                }
+                data.extend(bytes(json.dumps(payload), "utf-8"))
                 await pusher_ws.send(data)
                 logger.info(f"Sent process_conversation request to pusher: {conversation_id} {uid} {session_id}")
                 return True

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -758,6 +758,51 @@ def get_user_usage_stats_endpoint(
     return stats
 
 
+class BYOKActivateRequest(BaseModel):
+    fingerprints: Dict[str, str]
+
+
+@router.post('/v1/users/me/byok-active', tags=['v1'])
+def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.get_current_user_uid)):
+    """Flip the user onto the BYOK free plan.
+
+    The client sends SHA-256 fingerprints of the 4 provider keys so we can
+    detect rotation without ever seeing the keys. The live keys themselves
+    travel on every request as headers; they are never persisted.
+    """
+    required = {'openai', 'anthropic', 'gemini', 'deepgram'}
+    missing = required - set(data.fingerprints.keys())
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing fingerprints for providers: {sorted(missing)}",
+        )
+    users_db.set_byok_active(uid, data.fingerprints)
+    return {"active": True}
+
+
+@router.delete('/v1/users/me/byok-active', tags=['v1'])
+def deactivate_byok_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+    """Drop the user off the BYOK free plan (keys were cleared client-side)."""
+    users_db.clear_byok_active(uid)
+    return {"active": False}
+
+
+def _byok_unlimited_subscription() -> Subscription:
+    """BYOK free plan: unlimited limits, marked with the `byok` feature flag."""
+    return Subscription(
+        plan=PlanType.unlimited,
+        status=SubscriptionStatus.active,
+        features=["byok"],
+        limits=PlanLimits(
+            transcription_seconds=None,
+            words_transcribed=None,
+            insights_gained=None,
+            memories_created=None,
+        ),
+    )
+
+
 @router.get('/v1/users/me/subscription', tags=['v1'], response_model=UserSubscriptionResponse)
 def get_user_subscription_endpoint(
     uid: str = Depends(auth.get_current_user_uid),
@@ -765,6 +810,23 @@ def get_user_subscription_endpoint(
     x_app_version: Optional[str] = Header(None, alias='X-App-Version'),
 ):
     """Gets the user's subscription plan and usage."""
+    # BYOK free plan: user supplies their own OpenAI/Anthropic/Gemini/Deepgram keys.
+    # Skip Stripe entirely and return an unlimited plan tagged with the `byok` feature.
+    if users_db.is_byok_active(uid):
+        return UserSubscriptionResponse(
+            subscription=_byok_unlimited_subscription(),
+            transcription_seconds_used=0,
+            transcription_seconds_limit=0,
+            words_transcribed_used=0,
+            words_transcribed_limit=0,
+            insights_gained_used=0,
+            insights_gained_limit=0,
+            memories_created_used=0,
+            memories_created_limit=0,
+            available_plans=[],
+            show_subscription_ui=False,
+        )
+
     marketplace_reviewers = os.getenv('MARKETPLACE_APP_REVIEWERS', '').split(',')
     if uid in marketplace_reviewers:
         unlimited_sub = Subscription(

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1012,6 +1012,20 @@ def get_user_chat_usage_quota(uid: str = Depends(auth.get_current_user_uid)):
     - Pro: counted in dollar spend on desktop chat
     - Resets at the start of each UTC month
     """
+    # BYOK free plan: user brings their own keys, so there's no Omi-side cost
+    # to meter. Return unlimited so the client doesn't gate sendMessage.
+    if users_db.is_byok_active(uid):
+        return ChatUsageQuota(
+            plan='Free (BYOK)',
+            plan_type=PlanType.unlimited.value,
+            unit=ChatQuotaUnit.questions,
+            used=0.0,
+            limit=None,
+            percent=0.0,
+            allowed=True,
+            reset_at=None,
+        )
+
     subscription = get_user_valid_subscription(uid)
     plan = subscription.plan if subscription else PlanType.basic
     limits = get_plan_limits(plan)

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -1,0 +1,55 @@
+"""Per-request BYOK (Bring Your Own Keys) key plumbing.
+
+The desktop client sends user-provided API keys as headers on every request
+(`X-BYOK-OpenAI`, `X-BYOK-Anthropic`, `X-BYOK-Gemini`, `X-BYOK-Deepgram`).
+A FastAPI middleware stashes them in a per-request contextvar; the LLM/STT
+clients can then read them without re-reading the request object.
+
+Keys are NEVER persisted — only fingerprints (see `database.users.set_byok_active`).
+"""
+
+from contextvars import ContextVar
+from typing import Dict, Optional
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+_BYOK_HEADERS = {
+    'openai': 'x-byok-openai',
+    'anthropic': 'x-byok-anthropic',
+    'gemini': 'x-byok-gemini',
+    'deepgram': 'x-byok-deepgram',
+}
+
+# Keys for the current request, if the client supplied them. Empty dict otherwise.
+_byok_ctx: ContextVar[Dict[str, str]] = ContextVar('byok_keys', default={})
+
+
+def get_byok_keys() -> Dict[str, str]:
+    """The keys attached to the current request (may be empty)."""
+    return _byok_ctx.get()
+
+
+def get_byok_key(provider: str) -> Optional[str]:
+    return _byok_ctx.get().get(provider)
+
+
+def set_byok_keys(keys: Dict[str, str]):
+    """Used by the middleware; also useful from WS handlers that read headers manually."""
+    _byok_ctx.set({k: v for k, v in keys.items() if v})
+
+
+class BYOKMiddleware(BaseHTTPMiddleware):
+    """Extract BYOK headers from each request into the contextvar."""
+
+    async def dispatch(self, request: Request, call_next):
+        keys: Dict[str, str] = {}
+        for provider, header in _BYOK_HEADERS.items():
+            value = request.headers.get(header)
+            if value:
+                keys[provider] = value
+        token = _byok_ctx.set(keys)
+        try:
+            return await call_next(request)
+        finally:
+            _byok_ctx.reset(token)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -71,6 +71,70 @@ class _AnthropicClientProxy:
         return getattr(self._resolve(), name)
 
 
+# Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
+# as the client class while routing to Gemini directly — no new langchain dep.
+_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+
+class _OpenRouterGeminiProxy:
+    """For models served via OpenRouter that we want to route direct when BYOK Gemini is set.
+
+    Falls back to the OpenRouter-backed default client when no BYOK gemini key
+    is present — so non-BYOK users are unaffected.
+    """
+
+    __slots__ = ('_default', '_direct_model', '_ctor_kwargs')
+
+    def __init__(self, default: ChatOpenAI, direct_model: str, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_direct_model', direct_model)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('gemini')
+        if byok:
+            return _cached_openai_chat(
+                self._direct_model,
+                byok,
+                {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
+            )
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+    def __or__(self, other):
+        return self._resolve() | other
+
+    def __ror__(self, other):
+        return other | self._resolve()
+
+
+class _OpenAIEmbeddingsProxy:
+    """Transparent proxy for OpenAIEmbeddings that uses BYOK OpenAI when set."""
+
+    __slots__ = ('_model', '_default', '_ctor_kwargs')
+
+    def __init__(self, model: str, default: OpenAIEmbeddings, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_model', model)
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> OpenAIEmbeddings:
+        byok = get_byok_key('openai')
+        if byok:
+            cache_key = f"emb:{self._model}:{hash(byok)}"
+            inst = _openai_cache.get(cache_key)
+            if inst is None:
+                inst = OpenAIEmbeddings(model=self._model, api_key=byok, **self._ctor_kwargs)
+                _openai_cache[cache_key] = inst
+            return inst
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+
 _openai_cache: Dict[str, ChatOpenAI] = {}
 _anthropic_cache: Dict[str, anthropic.AsyncAnthropic] = {}
 
@@ -179,16 +243,29 @@ llm_agent_stream = _byok_openai(
     callbacks=[_usage_callback],
     model_kwargs=_agent_cache_kwargs,
 )
-llm_persona_mini_stream = ChatOpenAI(
+_persona_mini_kwargs = dict(
     temperature=0.8,
-    model="google/gemini-flash-1.5-8b",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Chat"},
     streaming=True,
     stream_options={"include_usage": True},
     callbacks=[_usage_callback],
 )
+_persona_mini_default = ChatOpenAI(
+    model="google/gemini-flash-1.5-8b",
+    api_key=os.environ.get('OPENROUTER_API_KEY'),
+    base_url="https://openrouter.ai/api/v1",
+    default_headers={"X-Title": "Omi Chat"},
+    **_persona_mini_kwargs,
+)
+# BYOK Gemini → route direct to Google's OpenAI-compat endpoint.
+# Model name drops the `google/` prefix: gemini-flash-1.5-8b on Google direct.
+llm_persona_mini_stream = _OpenRouterGeminiProxy(
+    default=_persona_mini_default,
+    direct_model="gemini-flash-1.5-8b",
+    ctor_kwargs=_persona_mini_kwargs,
+)
+# Anthropic-via-OpenRouter stays on OpenRouter for now; direct-Anthropic via
+# langchain would need the langchain-anthropic dep. BYOK Anthropic users still
+# pay Omi for this specific persona model — flag for follow-up.
 llm_persona_medium_stream = ChatOpenAI(
     temperature=0.8,
     model="anthropic/claude-3.5-sonnet",
@@ -201,16 +278,29 @@ llm_persona_medium_stream = ChatOpenAI(
 )
 
 # Gemini models for large context analysis
-llm_gemini_flash = ChatOpenAI(
+_gemini_flash_kwargs = dict(
     temperature=0.7,
+    callbacks=[_usage_callback],
+)
+_gemini_flash_default = ChatOpenAI(
     model="google/gemini-3-flash-preview",
     api_key=os.environ.get('OPENROUTER_API_KEY'),
     base_url="https://openrouter.ai/api/v1",
     default_headers={"X-Title": "Omi Wrapped"},
-    callbacks=[_usage_callback],
+    **_gemini_flash_kwargs,
+)
+llm_gemini_flash = _OpenRouterGeminiProxy(
+    default=_gemini_flash_default,
+    direct_model="gemini-3-flash-preview",
+    ctor_kwargs=_gemini_flash_kwargs,
 )
 
-embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
+_embeddings_default = OpenAIEmbeddings(model="text-embedding-3-large")
+embeddings = _OpenAIEmbeddingsProxy(
+    model="text-embedding-3-large",
+    default=_embeddings_default,
+    ctor_kwargs={},
+)
 parser = PydanticOutputParser(pydantic_object=Structured)
 
 encoding = tiktoken.encoding_for_model('gpt-4')
@@ -231,8 +321,11 @@ def gemini_embed_query(text: str) -> List[float]:
 
     Uses RETRIEVAL_QUERY task type to match the RETRIEVAL_DOCUMENT embeddings
     generated by the desktop app.
+
+    Prefers the per-request BYOK Gemini key; falls back to the process-wide
+    env key so non-BYOK callers behave exactly as before.
     """
-    api_key = os.environ.get('GEMINI_API_KEY', '')
+    api_key = get_byok_key('gemini') or os.environ.get('GEMINI_API_KEY', '')
     url = f'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent?key={api_key}'
     payload = {
         'model': 'models/embedding-001',

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import List, Optional
 
 import anthropic
 import httpx
@@ -8,10 +8,33 @@ from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 import tiktoken
 
 from models.structured import Structured
+from utils.byok import get_byok_key
 from utils.llm.usage_tracker import get_usage_callback
 
 # Anthropic client for chat agent
 anthropic_client = anthropic.AsyncAnthropic()  # uses ANTHROPIC_API_KEY env var
+
+
+def get_anthropic_client() -> anthropic.AsyncAnthropic:
+    """Return an Anthropic client keyed to the current request's BYOK key, if present.
+
+    Falls back to the process-wide client (which uses ANTHROPIC_API_KEY env var).
+    Callers on hot paths should switch to this helper so BYOK users pay their
+    own Anthropic bill.
+    """
+    key = get_byok_key('anthropic')
+    if key:
+        return anthropic.AsyncAnthropic(api_key=key)
+    return anthropic_client
+
+
+def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
+    """Return a ChatOpenAI instance keyed to the current request's BYOK key, if present."""
+    byok = get_byok_key('openai')
+    if byok:
+        return ChatOpenAI(model=model, api_key=byok, **kwargs)
+    return ChatOpenAI(model=model, **kwargs)
+
 
 ANTHROPIC_AGENT_MODEL = "claude-sonnet-4-6"
 ANTHROPIC_AGENT_COMPLEX_MODEL = "claude-sonnet-4-6"

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import anthropic
 import httpx
@@ -11,28 +11,108 @@ from models.structured import Structured
 from utils.byok import get_byok_key
 from utils.llm.usage_tracker import get_usage_callback
 
-# Anthropic client for chat agent
-anthropic_client = anthropic.AsyncAnthropic()  # uses ANTHROPIC_API_KEY env var
+# ---------------------------------------------------------------------------
+# BYOK routing proxies
+#
+# The backend has ~50 call sites that use module-level `llm_medium`, `llm_mini`,
+# etc. directly (e.g. `llm_medium.invoke(prompt)` or `llm_medium.bind_tools(...).ainvoke(...)`).
+# Rewriting every site to go through a factory would be a massive sweep.
+#
+# Instead we wrap each default client in a transparent proxy: every attribute
+# access resolves to either the default client or a BYOK-keyed client built
+# on the fly, keyed by (model, api_key) so we build each BYOK client once.
+# `__getattr__` forwards `bind_tools`, `with_structured_output`, `|` chaining,
+# etc. to the resolved client so tool-use/structured-output still route right.
+# ---------------------------------------------------------------------------
+
+
+class _OpenAIChatProxy:
+    """Forwards every attribute and call to the appropriate ChatOpenAI for the request."""
+
+    __slots__ = ('_model', '_default', '_ctor_kwargs')
+
+    def __init__(self, model: str, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_model', model)
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('openai')
+        if byok:
+            return _cached_openai_chat(self._model, byok, self._ctor_kwargs)
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+    # Needed for `prompt | model | parser`-style chain composition.
+    def __or__(self, other):
+        return self._resolve() | other
+
+    def __ror__(self, other):
+        return other | self._resolve()
+
+
+class _AnthropicClientProxy:
+    """Forwards every attribute to the appropriate anthropic.AsyncAnthropic for the request."""
+
+    __slots__ = ('_default',)
+
+    def __init__(self, default: anthropic.AsyncAnthropic):
+        object.__setattr__(self, '_default', default)
+
+    def _resolve(self) -> anthropic.AsyncAnthropic:
+        byok = get_byok_key('anthropic')
+        if byok:
+            return _cached_anthropic(byok)
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+
+_openai_cache: Dict[str, ChatOpenAI] = {}
+_anthropic_cache: Dict[str, anthropic.AsyncAnthropic] = {}
+
+
+def _cached_openai_chat(model: str, api_key: str, ctor_kwargs: Dict[str, Any]) -> ChatOpenAI:
+    cache_key = f"{model}:{hash(api_key)}:{hash(frozenset((k, repr(v)) for k, v in ctor_kwargs.items()))}"
+    inst = _openai_cache.get(cache_key)
+    if inst is None:
+        inst = ChatOpenAI(model=model, api_key=api_key, **ctor_kwargs)
+        _openai_cache[cache_key] = inst
+    return inst
+
+
+def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
+    inst = _anthropic_cache.get(api_key)
+    if inst is None:
+        inst = anthropic.AsyncAnthropic(api_key=api_key)
+        _anthropic_cache[api_key] = inst
+    return inst
+
+
+def _byok_openai(model: str, **ctor_kwargs) -> _OpenAIChatProxy:
+    """Build a module-level ChatOpenAI that transparently routes to BYOK if set."""
+    default = ChatOpenAI(model=model, **ctor_kwargs)
+    return _OpenAIChatProxy(model=model, default=default, ctor_kwargs=ctor_kwargs)
+
+
+# Anthropic client for chat agent (module-level, BYOK-aware)
+_default_anthropic_client = anthropic.AsyncAnthropic()  # uses ANTHROPIC_API_KEY env var
+anthropic_client = _AnthropicClientProxy(_default_anthropic_client)
 
 
 def get_anthropic_client() -> anthropic.AsyncAnthropic:
-    """Return an Anthropic client keyed to the current request's BYOK key, if present.
-
-    Falls back to the process-wide client (which uses ANTHROPIC_API_KEY env var).
-    Callers on hot paths should switch to this helper so BYOK users pay their
-    own Anthropic bill.
-    """
-    key = get_byok_key('anthropic')
-    if key:
-        return anthropic.AsyncAnthropic(api_key=key)
-    return anthropic_client
+    """Kept as a factory for callers that prefer explicit routing over the module proxy."""
+    return anthropic_client._resolve()
 
 
 def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
-    """Return a ChatOpenAI instance keyed to the current request's BYOK key, if present."""
+    """Explicit factory; equivalent to using the module-level proxies."""
     byok = get_byok_key('openai')
     if byok:
-        return ChatOpenAI(model=model, api_key=byok, **kwargs)
+        return _cached_openai_chat(model, byok, kwargs)
     return ChatOpenAI(model=model, **kwargs)
 
 
@@ -42,39 +122,39 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = "claude-sonnet-4-6"
 # Get the usage tracking callback
 _usage_callback = get_usage_callback()
 
-# Base models for general use
-llm_mini = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback])
-llm_mini_stream = ChatOpenAI(
-    model='gpt-4.1-mini',
+# Base models for general use — proxies route to BYOK OpenAI key per-request when set.
+llm_mini = _byok_openai('gpt-4.1-mini', callbacks=[_usage_callback])
+llm_mini_stream = _byok_openai(
+    'gpt-4.1-mini',
     streaming=True,
     stream_options={"include_usage": True},
     callbacks=[_usage_callback],
 )
-llm_large = ChatOpenAI(model='o1-preview', callbacks=[_usage_callback])
-llm_large_stream = ChatOpenAI(
-    model='o1-preview',
-    streaming=True,
-    stream_options={"include_usage": True},
-    temperature=1,
-    callbacks=[_usage_callback],
-)
-llm_high = ChatOpenAI(model='o4-mini', callbacks=[_usage_callback])
-llm_high_stream = ChatOpenAI(
-    model='o4-mini',
+llm_large = _byok_openai('o1-preview', callbacks=[_usage_callback])
+llm_large_stream = _byok_openai(
+    'o1-preview',
     streaming=True,
     stream_options={"include_usage": True},
     temperature=1,
     callbacks=[_usage_callback],
 )
-llm_medium = ChatOpenAI(model='gpt-5.2', callbacks=[_usage_callback])
-llm_medium_stream = ChatOpenAI(
-    model='gpt-5.2',
+llm_high = _byok_openai('o4-mini', callbacks=[_usage_callback])
+llm_high_stream = _byok_openai(
+    'o4-mini',
+    streaming=True,
+    stream_options={"include_usage": True},
+    temperature=1,
+    callbacks=[_usage_callback],
+)
+llm_medium = _byok_openai('gpt-5.2', callbacks=[_usage_callback])
+llm_medium_stream = _byok_openai(
+    'gpt-5.2',
     streaming=True,
     stream_options={"include_usage": True},
     callbacks=[_usage_callback],
 )
-llm_medium_experiment = ChatOpenAI(
-    model='gpt-5.1',
+llm_medium_experiment = _byok_openai(
+    'gpt-5.1',
     extra_body={"prompt_cache_retention": "24h"},
     callbacks=[_usage_callback],
 )
@@ -85,14 +165,14 @@ llm_medium_experiment = ChatOpenAI(
 _agent_cache_kwargs = {
     "prompt_cache_key": "omi-agent-v1",
 }
-llm_agent = ChatOpenAI(
-    model='gpt-5.1',
+llm_agent = _byok_openai(
+    'gpt-5.1',
     extra_body={"prompt_cache_retention": "24h"},
     callbacks=[_usage_callback],
     model_kwargs=_agent_cache_kwargs,
 )
-llm_agent_stream = ChatOpenAI(
-    model='gpt-5.1',
+llm_agent_stream = _byok_openai(
+    'gpt-5.1',
     streaming=True,
     stream_options={"include_usage": True},
     extra_body={"prompt_cache_retention": "24h"},

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -7,6 +7,7 @@ import fal_client
 from deepgram import DeepgramClient, DeepgramClientOptions
 
 from models.transcript_segment import TranscriptSegment
+from utils.byok import get_byok_key
 from utils.other.endpoints import timeit
 import logging
 
@@ -16,6 +17,15 @@ logger = logging.getLogger(__name__)
 # WARN: the pre-recorded transcription is available on deepgram cloud
 _deepgram_options = DeepgramClientOptions(options={"keepalive": "true"})
 _deepgram_client = DeepgramClient(os.getenv('DEEPGRAM_API_KEY'), _deepgram_options)
+
+
+def _deepgram_client_for_request() -> DeepgramClient:
+    """Route to BYOK Deepgram key when set; otherwise use the process-wide client."""
+    byok = get_byok_key('deepgram')
+    if byok:
+        return DeepgramClient(byok, _deepgram_options)
+    return _deepgram_client
+
 
 # Languages supported by nova-3
 _deepgram_nova3_languages = {
@@ -180,7 +190,7 @@ def deepgram_prerecorded(
             else:
                 options["keywords"] = list(keywords)
 
-        response = _deepgram_client.listen.rest.v("1").transcribe_url({"url": audio_url}, options)
+        response = _deepgram_client_for_request().listen.rest.v("1").transcribe_url({"url": audio_url}, options)
 
         # Extract words from response
         result = response.to_dict()
@@ -304,7 +314,7 @@ def deepgram_prerecorded_from_bytes(
         mimetype = "audio/raw" if encoding else "audio/wav"
         source = {"buffer": audio_buffer, "mimetype": mimetype}
 
-        response = _deepgram_client.listen.rest.v("1").transcribe_file(source, options)
+        response = _deepgram_client_for_request().listen.rest.v("1").transcribe_file(source, options)
 
         # Extract words from response
         result = response.to_dict()

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -8,6 +8,7 @@ import websockets
 from deepgram import DeepgramClient, DeepgramClientOptions, LiveTranscriptionEvents
 from deepgram.clients.live.v1 import LiveOptions
 
+from utils.byok import get_byok_key
 from utils.stt.safe_socket import KeepaliveConfig, SafeDeepgramSocket  # noqa: F401 — re-exported for backward compat
 from utils.stt.vad_gate import GatedDeepgramSocket
 import logging
@@ -321,11 +322,26 @@ def _dg_keywords_set(options: LiveOptions, keywords: List[str]):
     return options
 
 
+def _deepgram_client_for_request() -> DeepgramClient:
+    """Return a Deepgram client keyed to the current request's BYOK Deepgram key.
+
+    BYOK users pay Deepgram directly — we don't want to rack up minutes on the
+    Omi Deepgram account for them. Self-hosted Deepgram ignores BYOK since
+    there's no per-user billing concept there.
+    """
+    if is_dg_self_hosted:
+        return deepgram
+    byok = get_byok_key('deepgram')
+    if byok:
+        return DeepgramClient(byok, deepgram_cloud_options)
+    return deepgram
+
+
 def connect_to_deepgram(
     on_message, on_error, language: str, sample_rate: int, channels: int, model: str, keywords: List[str] = []
 ):
     try:
-        dg_connection = deepgram.listen.websocket.v("1")
+        dg_connection = _deepgram_client_for_request().listen.websocket.v("1")
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
         dg_connection.on(LiveTranscriptionEvents.Error, on_error)
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -496,6 +496,10 @@ def has_transcription_credits(uid: str) -> bool:
     """
     Checks if a user has transcribing credits by verifying their valid subscription and usage.
     """
+    # BYOK users pay Deepgram directly — there's no Omi-side transcription quota to enforce.
+    if users_db.is_byok_active(uid):
+        return True
+
     subscription = users_db.get_user_valid_subscription(uid)
     if not subscription:
         return False
@@ -517,6 +521,10 @@ def get_remaining_transcription_seconds(uid: str) -> int | None:
     Returns None if unlimited, otherwise the remaining seconds (>= 0).
     Used for freemium auto-switch to on-device transcription.
     """
+    # BYOK: user brings their own Deepgram — no Omi quota, no freemium threshold.
+    if users_db.is_byok_active(uid):
+        return None
+
     subscription = users_db.get_user_valid_subscription(uid)
     if not subscription:
         # No subscription = use basic limits

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added Bring-Your-Own-Keys free plan: paste OpenAI, Anthropic, Gemini, and Deepgram keys to use Omi with no subscription"
+  ],
   "releases": [
     {
       "version": "0.11.336",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -105,6 +105,12 @@ actor APIClient {
       }
     }
 
+    // BYOK: attach user-provided keys so the backend uses them for LLM/STT
+    // calls this request triggers. Sent per-request; never stored server-side.
+    for (provider, entry) in APIKeyService.byokSnapshot {
+      headers[provider.headerName] = entry.key
+    }
+
     return headers
   }
 
@@ -4408,6 +4414,24 @@ extension APIClient {
 
   func createCustomerPortalSession() async throws -> CustomerPortalResponse {
     return try await post("v1/payments/customer-portal")
+  }
+
+  /// Activate the Bring-Your-Own-Keys free plan on the backend.
+  /// Sends SHA-256 fingerprints (never the keys themselves) so the backend
+  /// can tell when the user rotates keys and re-validate.
+  func activateBYOK(fingerprints: [String: String]) async throws {
+    struct Request: Encodable {
+      let fingerprints: [String: String]
+    }
+    struct Empty: Decodable {}
+    let _: Empty = try await post(
+      "v1/users/me/byok-active", body: Request(fingerprints: fingerprints)
+    )
+  }
+
+  /// Deactivate BYOK (user cleared keys) so they return to the paid plan gate.
+  func deactivateBYOK() async throws {
+    try await delete("v1/users/me/byok-active")
   }
 
   /// Fetches all people for the current user

--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -1,12 +1,54 @@
+import CryptoKit
 import Foundation
 
 /// Fetches API keys from the backend at runtime instead of bundling them in the app.
 /// Developer overrides (set in Settings) take precedence over backend-provided keys.
 ///
+/// Also hosts the Bring-Your-Own-Key (BYOK) free-plan flow: when the user supplies
+/// their own OpenAI, Anthropic, Gemini, and Deepgram keys, the app sends them along
+/// with every request and the backend skips subscription billing. Keys live in
+/// UserDefaults (reusing the existing dev-override AppStorage pattern); the backend
+/// only ever sees SHA-256 fingerprints for state tracking.
+///
 /// NOTE: Deepgram and Gemini keys are NO LONGER fetched from the backend —
 /// they are proxied server-side (issue #5861).
 /// NOTE: ElevenLabs key is NO LONGER fetched — proxied via /v1/tts/synthesize (issue #6622).
 /// Anthropic, Firebase, and Calendar keys are still served via /v1/config/api-keys.
+
+/// Keys that participate in the BYOK free-plan flow.
+enum BYOKProvider: String, CaseIterable {
+    case openai
+    case anthropic
+    case gemini
+    case deepgram
+
+    var storageKey: String {
+        switch self {
+        case .openai: return "dev_openai_api_key"
+        case .anthropic: return "dev_anthropic_api_key"
+        case .gemini: return "dev_gemini_api_key"
+        case .deepgram: return "dev_deepgram_api_key"
+        }
+    }
+
+    var headerName: String {
+        switch self {
+        case .openai: return "X-BYOK-OpenAI"
+        case .anthropic: return "X-BYOK-Anthropic"
+        case .gemini: return "X-BYOK-Gemini"
+        case .deepgram: return "X-BYOK-Deepgram"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .openai: return "OpenAI"
+        case .anthropic: return "Anthropic"
+        case .gemini: return "Gemini"
+        case .deepgram: return "Deepgram"
+        }
+    }
+}
 @MainActor
 final class APIKeyService: ObservableObject {
     static let shared = APIKeyService()
@@ -149,5 +191,37 @@ final class APIKeyService: ObservableObject {
     private nonisolated static func nonEmptyStatic(_ s: String?) -> String? {
         guard let s, !s.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
         return s
+    }
+
+    // MARK: - BYOK (Bring Your Own Keys) — free plan
+
+    /// Read a BYOK key from UserDefaults. Returns nil if empty/whitespace.
+    nonisolated static func byokKey(_ provider: BYOKProvider) -> String? {
+        nonEmptyStatic(UserDefaults.standard.string(forKey: provider.storageKey))
+    }
+
+    /// True when the user has supplied keys for all four BYOK providers.
+    /// The subscription-bypass gate: when this is true, the user is on the free
+    /// plan and we attach their keys to every backend request.
+    nonisolated static var isByokActive: Bool {
+        BYOKProvider.allCases.allSatisfy { byokKey($0) != nil }
+    }
+
+    /// SHA-256 fingerprint of a key, used by the backend to detect when the
+    /// user rotated their keys without us ever storing the key itself.
+    nonisolated static func byokFingerprint(_ key: String) -> String {
+        let digest = SHA256.hash(data: Data(key.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Map of provider → (key, fingerprint) for every provider the user has configured.
+    nonisolated static var byokSnapshot: [BYOKProvider: (key: String, fingerprint: String)] {
+        var out: [BYOKProvider: (String, String)] = [:]
+        for provider in BYOKProvider.allCases {
+            if let key = byokKey(provider) {
+                out[provider] = (key, byokFingerprint(key))
+            }
+        }
+        return out
     }
 }

--- a/desktop/Desktop/Sources/BYOKValidator.swift
+++ b/desktop/Desktop/Sources/BYOKValidator.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Per-provider health-check pings for BYOK keys. We never activate the free
+/// plan with a dead key — that's why onboarding/settings reject unverified keys.
+///
+/// Each ping hits the provider's cheapest auth-gated endpoint; any 2xx means
+/// the key is at least authenticated (it may still have billing issues, but
+/// that shows up later as a normal inference error — at least it's not a key
+/// shape problem we could have caught up front).
+enum BYOKValidator {
+  enum Status: Equatable {
+    case notChecked
+    case checking
+    case ok
+    case failed(String)
+  }
+
+  /// Hit the provider and return whether the key authenticates.
+  static func validate(_ provider: BYOKProvider, key: String) async -> Status {
+    let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return .failed("Empty") }
+
+    switch provider {
+    case .openai:
+      return await ping(
+        url: URL(string: "https://api.openai.com/v1/models")!,
+        headers: ["Authorization": "Bearer \(trimmed)"]
+      )
+    case .anthropic:
+      return await ping(
+        url: URL(string: "https://api.anthropic.com/v1/models?limit=1")!,
+        headers: [
+          "x-api-key": trimmed,
+          "anthropic-version": "2023-06-01",
+        ]
+      )
+    case .gemini:
+      var components = URLComponents(string: "https://generativelanguage.googleapis.com/v1beta/models")!
+      components.queryItems = [URLQueryItem(name: "key", value: trimmed)]
+      return await ping(url: components.url!, headers: [:])
+    case .deepgram:
+      return await ping(
+        url: URL(string: "https://api.deepgram.com/v1/projects")!,
+        headers: ["Authorization": "Token \(trimmed)"]
+      )
+    }
+  }
+
+  private static func ping(url: URL, headers: [String: String]) async -> Status {
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 8
+    for (name, value) in headers {
+      request.setValue(value, forHTTPHeaderField: name)
+    }
+    do {
+      let (_, response) = try await URLSession.shared.data(for: request)
+      guard let http = response as? HTTPURLResponse else {
+        return .failed("No HTTP response")
+      }
+      if (200..<300).contains(http.statusCode) {
+        return .ok
+      }
+      if http.statusCode == 401 || http.statusCode == 403 {
+        return .failed("Rejected (HTTP \(http.statusCode))")
+      }
+      return .failed("HTTP \(http.statusCode)")
+    } catch {
+      return .failed(error.localizedDescription)
+    }
+  }
+
+  /// Validate every provider in parallel. Returns map of provider -> status.
+  static func validateAll(_ keys: [BYOKProvider: String]) async -> [BYOKProvider: Status] {
+    await withTaskGroup(of: (BYOKProvider, Status).self, returning: [BYOKProvider: Status].self) {
+      group in
+      for (provider, key) in keys {
+        group.addTask { (provider, await validate(provider, key: key)) }
+      }
+      var results: [BYOKProvider: Status] = [:]
+      for await (provider, status) in group {
+        results[provider] = status
+      }
+      return results
+    }
+  }
+}

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -368,9 +368,12 @@ struct SettingsContentView: View {
   @State private var isDeletingAccount: Bool = false
   @State private var deleteAccountError: String?
 
-  // Developer API Key overrides
+  // Developer API Key overrides — also double as BYOK free-plan credentials
+  // when all four (Gemini, Anthropic, OpenAI, Deepgram) are provided.
   @AppStorage("dev_gemini_api_key") private var devGeminiKey: String = ""
   @AppStorage("dev_anthropic_api_key") private var devAnthropicKey: String = ""
+  @AppStorage("dev_openai_api_key") private var devOpenAIKey: String = ""
+  @AppStorage("dev_deepgram_api_key") private var devDeepgramKey: String = ""
 
   init(
     appState: AppState,
@@ -1864,6 +1867,47 @@ struct SettingsContentView: View {
       }
 
       chatUsageQuotaCard
+
+      byokPromoCard
+    }
+  }
+
+  @ViewBuilder
+  private var byokPromoCard: some View {
+    settingsCard(settingId: "planusage.byok") {
+      VStack(alignment: .leading, spacing: 12) {
+        HStack(spacing: 12) {
+          Image(systemName: "key.fill")
+            .scaledFont(size: 20)
+            .foregroundColor(OmiColors.purplePrimary)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(APIKeyService.isByokActive ? "Free plan active" : "Use Omi free forever")
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+            Text(
+              APIKeyService.isByokActive
+                ? "You're using your own OpenAI, Anthropic, Gemini, and Deepgram keys. No subscription."
+                : "Provide your own OpenAI, Anthropic, Gemini, and Deepgram keys to skip the subscription entirely."
+            )
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+          }
+          Spacer()
+        }
+
+        Button(action: openBYOKSettings) {
+          Text(APIKeyService.isByokActive ? "Manage your keys" : "Switch to your own keys")
+            .scaledFont(size: 13, weight: .semibold)
+        }
+        .buttonStyle(.bordered)
+      }
+    }
+  }
+
+  private func openBYOKSettings() {
+    selectedSection = .advanced
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+      highlightedSettingId = "advanced.devkeys.info"
     }
   }
 
@@ -4976,39 +5020,41 @@ struct SettingsContentView: View {
 
   private var developerKeysSubsection: some View {
     VStack(spacing: 20) {
-      settingsCard(settingId: "advanced.devkeys.info") {
-        HStack(spacing: 12) {
-          Image(systemName: "info.circle")
-            .foregroundColor(OmiColors.textTertiary)
-          Text("Override backend-provided API keys with your own. Leave blank to use default keys.")
-            .scaledFont(size: 13)
-            .foregroundColor(OmiColors.textTertiary)
-          Spacer()
-        }
-      }
+      byokStatusBanner
+
+      developerKeyField(
+        title: "OpenAI API Key",
+        subtitle: "For GPT calls.",
+        settingId: "advanced.devkeys.openai",
+        value: $devOpenAIKey
+      )
+
+      developerKeyField(
+        title: "Anthropic API Key",
+        subtitle: "For chat (Claude).",
+        settingId: "advanced.devkeys.anthropic",
+        value: $devAnthropicKey
+      )
 
       developerKeyField(
         title: "Gemini API Key",
-        subtitle: "For proactive AI (memory, tasks, insights, focus)",
+        subtitle: "For proactive AI (memory, tasks, insights, focus).",
         settingId: "advanced.devkeys.gemini",
         value: $devGeminiKey
       )
 
       developerKeyField(
-        title: "Anthropic API Key",
-        subtitle: "For chat (Claude)",
-        settingId: "advanced.devkeys.anthropic",
-        value: $devAnthropicKey
+        title: "Deepgram API Key",
+        subtitle: "For live transcription.",
+        settingId: "advanced.devkeys.deepgram",
+        value: $devDeepgramKey
       )
 
-      if !devGeminiKey.isEmpty || !devAnthropicKey.isEmpty {
+      if hasAnyBYOKKey {
         settingsCard(settingId: "advanced.devkeys.clear") {
           HStack {
             Spacer()
-            Button(action: {
-              devGeminiKey = ""
-              devAnthropicKey = ""
-            }) {
+            Button(action: clearAllBYOKKeys) {
               Text("Clear All Custom Keys")
                 .scaledFont(size: 13, weight: .medium)
                 .foregroundColor(.red)
@@ -5018,6 +5064,68 @@ struct SettingsContentView: View {
           }
         }
       }
+    }
+    .onChange(of: devOpenAIKey) { _, _ in refreshBYOKActivation() }
+    .onChange(of: devAnthropicKey) { _, _ in refreshBYOKActivation() }
+    .onChange(of: devGeminiKey) { _, _ in refreshBYOKActivation() }
+    .onChange(of: devDeepgramKey) { _, _ in refreshBYOKActivation() }
+  }
+
+  private var hasAnyBYOKKey: Bool {
+    !devOpenAIKey.isEmpty || !devAnthropicKey.isEmpty || !devGeminiKey.isEmpty
+      || !devDeepgramKey.isEmpty
+  }
+
+  private var hasAllBYOKKeys: Bool {
+    !devOpenAIKey.isEmpty && !devAnthropicKey.isEmpty && !devGeminiKey.isEmpty
+      && !devDeepgramKey.isEmpty
+  }
+
+  @ViewBuilder
+  private var byokStatusBanner: some View {
+    settingsCard(settingId: "advanced.devkeys.info") {
+      HStack(alignment: .top, spacing: 12) {
+        Image(systemName: hasAllBYOKKeys ? "checkmark.seal.fill" : "key.fill")
+          .foregroundColor(hasAllBYOKKeys ? OmiColors.success : OmiColors.textTertiary)
+        VStack(alignment: .leading, spacing: 4) {
+          Text(hasAllBYOKKeys ? "Free plan active" : "Use Omi free forever")
+            .scaledFont(size: 14, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Text(
+            hasAllBYOKKeys
+              ? "You're paying your own providers. Omi skips the subscription charge. Keys stay on this Mac."
+              : "Provide all four keys (OpenAI, Anthropic, Gemini, Deepgram) to switch to the free plan. Keys stay on this Mac — we never store them on our servers."
+          )
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+        }
+        Spacer()
+      }
+    }
+  }
+
+  private func clearAllBYOKKeys() {
+    devOpenAIKey = ""
+    devAnthropicKey = ""
+    devGeminiKey = ""
+    devDeepgramKey = ""
+    Task {
+      try? await APIClient.shared.deactivateBYOK()
+    }
+  }
+
+  private func refreshBYOKActivation() {
+    Task {
+      if APIKeyService.isByokActive {
+        let fingerprints = APIKeyService.byokSnapshot.reduce(into: [String: String]()) {
+          acc, entry in
+          acc[entry.key.rawValue] = entry.value.fingerprint
+        }
+        try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+      } else {
+        try? await APIClient.shared.deactivateBYOK()
+      }
+      await MainActor.run { loadSubscriptionInfo() }
     }
   }
 

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -374,6 +374,8 @@ struct SettingsContentView: View {
   @AppStorage("dev_anthropic_api_key") private var devAnthropicKey: String = ""
   @AppStorage("dev_openai_api_key") private var devOpenAIKey: String = ""
   @AppStorage("dev_deepgram_api_key") private var devDeepgramKey: String = ""
+  @State private var byokKeyStatuses: [BYOKProvider: BYOKValidator.Status] = [:]
+  @State private var byokActivationError: String?
 
   init(
     appState: AppState,
@@ -5023,6 +5025,7 @@ struct SettingsContentView: View {
       byokStatusBanner
 
       developerKeyField(
+        provider: .openai,
         title: "OpenAI API Key",
         subtitle: "For GPT calls.",
         settingId: "advanced.devkeys.openai",
@@ -5030,6 +5033,7 @@ struct SettingsContentView: View {
       )
 
       developerKeyField(
+        provider: .anthropic,
         title: "Anthropic API Key",
         subtitle: "For chat (Claude).",
         settingId: "advanced.devkeys.anthropic",
@@ -5037,6 +5041,7 @@ struct SettingsContentView: View {
       )
 
       developerKeyField(
+        provider: .gemini,
         title: "Gemini API Key",
         subtitle: "For proactive AI (memory, tasks, insights, focus).",
         settingId: "advanced.devkeys.gemini",
@@ -5044,11 +5049,24 @@ struct SettingsContentView: View {
       )
 
       developerKeyField(
+        provider: .deepgram,
         title: "Deepgram API Key",
         subtitle: "For live transcription.",
         settingId: "advanced.devkeys.deepgram",
         value: $devDeepgramKey
       )
+
+      if let byokActivationError {
+        settingsCard(settingId: "advanced.devkeys.error") {
+          HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+              .foregroundColor(OmiColors.warning)
+            Text(byokActivationError)
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.warning)
+          }
+        }
+      }
 
       if hasAnyBYOKKey {
         settingsCard(settingId: "advanced.devkeys.clear") {
@@ -5117,33 +5135,93 @@ struct SettingsContentView: View {
   private func refreshBYOKActivation() {
     Task {
       if APIKeyService.isByokActive {
-        let fingerprints = APIKeyService.byokSnapshot.reduce(into: [String: String]()) {
-          acc, entry in
-          acc[entry.key.rawValue] = entry.value.fingerprint
+        // Validate before flipping the backend flag — otherwise we'd put the
+        // user on the free plan with dead keys and every chat would 401.
+        let snapshot = APIKeyService.byokSnapshot.reduce(into: [BYOKProvider: String]()) {
+          acc, entry in acc[entry.key] = entry.value.key
         }
-        try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+        let results = await BYOKValidator.validateAll(snapshot)
+        let allOk = results.allSatisfy {
+          if case .ok = $0.value { return true }
+          return false
+        }
+        if allOk {
+          let fingerprints = APIKeyService.byokSnapshot.reduce(into: [String: String]()) {
+            acc, entry in acc[entry.key.rawValue] = entry.value.fingerprint
+          }
+          try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+          await MainActor.run {
+            byokKeyStatuses = results
+            byokActivationError = nil
+          }
+        } else {
+          let failed = results.filter {
+            if case .ok = $0.value { return false }
+            return true
+          }
+          let names = failed.keys.map(\.displayName).sorted().joined(separator: ", ")
+          try? await APIClient.shared.deactivateBYOK()
+          await MainActor.run {
+            byokKeyStatuses = results
+            byokActivationError =
+              "Rejected by provider: \(names). Free plan stays off until all 4 keys authenticate."
+          }
+        }
       } else {
         try? await APIClient.shared.deactivateBYOK()
+        await MainActor.run {
+          byokKeyStatuses = [:]
+          byokActivationError = nil
+        }
       }
       await MainActor.run { loadSubscriptionInfo() }
     }
   }
 
   private func developerKeyField(
+    provider: BYOKProvider? = nil,
     title: String, subtitle: String, settingId: String, value: Binding<String>
   ) -> some View {
     settingsCard(settingId: settingId) {
       VStack(alignment: .leading, spacing: 8) {
-        Text(title)
-          .scaledFont(size: 14, weight: .medium)
-          .foregroundColor(OmiColors.textPrimary)
+        HStack {
+          Text(title)
+            .scaledFont(size: 14, weight: .medium)
+            .foregroundColor(OmiColors.textPrimary)
+          Spacer()
+          if let provider, let status = byokKeyStatuses[provider] {
+            byokStatusBadge(status)
+          }
+        }
         Text(subtitle)
           .scaledFont(size: 12)
           .foregroundColor(OmiColors.textTertiary)
         SecureField("Leave blank for default", text: value)
           .textFieldStyle(.roundedBorder)
           .scaledFont(size: 13)
+        if let provider, case .failed(let msg) = byokKeyStatuses[provider] ?? .notChecked {
+          Text(msg)
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.warning)
+        }
       }
+    }
+  }
+
+  @ViewBuilder
+  private func byokStatusBadge(_ status: BYOKValidator.Status) -> some View {
+    switch status {
+    case .notChecked:
+      EmptyView()
+    case .checking:
+      HStack(spacing: 4) {
+        ProgressView().controlSize(.mini)
+        Text("Checking…").scaledFont(size: 11).foregroundColor(OmiColors.textTertiary)
+      }
+    case .ok:
+      Text("Valid").scaledFont(size: 11, weight: .semibold).foregroundColor(OmiColors.success)
+    case .failed:
+      Text("Invalid").scaledFont(size: 11, weight: .semibold).foregroundColor(OmiColors.warning)
     }
   }
 

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -5150,6 +5150,7 @@ struct SettingsContentView: View {
             acc, entry in acc[entry.key.rawValue] = entry.value.fingerprint
           }
           try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+          await FloatingBarUsageLimiter.shared.fetchPlan()
           await MainActor.run {
             byokKeyStatuses = results
             byokActivationError = nil
@@ -5161,6 +5162,7 @@ struct SettingsContentView: View {
           }
           let names = failed.keys.map(\.displayName).sorted().joined(separator: ", ")
           try? await APIClient.shared.deactivateBYOK()
+          await FloatingBarUsageLimiter.shared.fetchPlan()
           await MainActor.run {
             byokKeyStatuses = results
             byokActivationError =
@@ -5169,6 +5171,7 @@ struct SettingsContentView: View {
         }
       } else {
         try? await APIClient.shared.deactivateBYOK()
+        await FloatingBarUsageLimiter.shared.fetchPlan()
         await MainActor.run {
           byokKeyStatuses = [:]
           byokActivationError = nil
@@ -5901,6 +5904,12 @@ struct SettingsContentView: View {
   private var currentPlanTitle: String {
     guard let subscription = userSubscription?.subscription else {
       return isLoadingSubscription ? "Loading plan..." : "Free"
+    }
+    // BYOK users: the backend returns plan=unlimited to turn off metering
+    // but that's an implementation detail — to the user, they're on the
+    // free plan because they pay the providers directly, not Omi.
+    if subscription.features.contains("byok") {
+      return "Free (BYOK)"
     }
     switch subscription.plan {
     case .basic:

--- a/desktop/Desktop/Sources/OnboardingBYOKStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingBYOKStepView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// Final step before Tasks: offer a free-forever plan if the user supplies their
+/// own API keys for OpenAI, Anthropic, Gemini, and Deepgram. Keys live on the
+/// device (UserDefaults); the backend receives only SHA-256 fingerprints.
+struct OnboardingBYOKStepView: View {
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+  let stepIndex: Int
+  let totalSteps: Int
+  let onContinue: () -> Void
+  let onSkip: () -> Void
+  let onForceComplete: (() -> Void)?
+
+  @AppStorage(BYOKProvider.openai.storageKey) private var openaiKey: String = ""
+  @AppStorage(BYOKProvider.anthropic.storageKey) private var anthropicKey: String = ""
+  @AppStorage(BYOKProvider.gemini.storageKey) private var geminiKey: String = ""
+  @AppStorage(BYOKProvider.deepgram.storageKey) private var deepgramKey: String = ""
+
+  @State private var isActivating = false
+  @State private var activationError: String?
+
+  var body: some View {
+    OnboardingStepScaffold(
+      graphViewModel: graphViewModel,
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      eyebrow: "Free forever",
+      title: "Bring your own keys.",
+      description:
+        "Paste your own API keys for OpenAI, Anthropic, Gemini, and Deepgram and Omi is free forever. Keys stay on this Mac — we never store them on our servers.",
+      showsSkip: true,
+      onSkip: {
+        AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_Skipped")
+        onSkip()
+      },
+      onForceComplete: onForceComplete
+    ) {
+      VStack(alignment: .leading, spacing: 18) {
+        keyField(provider: .openai, binding: $openaiKey, help: "Used for GPT calls.")
+        keyField(provider: .anthropic, binding: $anthropicKey, help: "Used for Claude chat.")
+        keyField(provider: .gemini, binding: $geminiKey, help: "Used for proactive AI.")
+        keyField(provider: .deepgram, binding: $deepgramKey, help: "Used for transcription.")
+
+        if let activationError {
+          Text(activationError)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(OmiColors.warning)
+        }
+
+        HStack(spacing: 12) {
+          Button(isActivating ? "Activating…" : "Activate free plan") {
+            Task { await activate() }
+          }
+          .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          .disabled(!allKeysProvided || isActivating)
+
+          if !allKeysProvided {
+            Text("Fill all four to activate.")
+              .font(.system(size: 12))
+              .foregroundColor(OmiColors.textTertiary)
+          }
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  private var allKeysProvided: Bool {
+    [openaiKey, anthropicKey, geminiKey, deepgramKey].allSatisfy {
+      !$0.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+  }
+
+  private func keyField(provider: BYOKProvider, binding: Binding<String>, help: String)
+    -> some View
+  {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack {
+        Text(provider.displayName)
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundColor(OmiColors.textPrimary)
+        Spacer()
+        Text(help)
+          .font(.system(size: 12))
+          .foregroundColor(OmiColors.textTertiary)
+      }
+      SecureField("Paste \(provider.displayName) API key", text: binding)
+        .textFieldStyle(.plain)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(
+          RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(OmiColors.backgroundSecondary)
+            .overlay(
+              RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            )
+        )
+        .foregroundColor(OmiColors.textPrimary)
+    }
+    .frame(maxWidth: 560)
+  }
+
+  private func activate() async {
+    activationError = nil
+    isActivating = true
+    defer { isActivating = false }
+
+    do {
+      try await APIClient.shared.activateBYOK(fingerprints: BYOKProvider.allCases.reduce(into: [:]) {
+        acc, provider in
+        if let key = APIKeyService.byokKey(provider) {
+          acc[provider.rawValue] = APIKeyService.byokFingerprint(key)
+        }
+      })
+      AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_Activated")
+      onContinue()
+    } catch {
+      activationError =
+        "Could not activate free plan: \(error.localizedDescription). Your keys are saved on this Mac; you can try again from Settings → Advanced."
+    }
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingBYOKStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingBYOKStepView.swift
@@ -18,6 +18,7 @@ struct OnboardingBYOKStepView: View {
 
   @State private var isActivating = false
   @State private var activationError: String?
+  @State private var keyStatuses: [BYOKProvider: BYOKValidator.Status] = [:]
 
   var body: some View {
     OnboardingStepScaffold(
@@ -80,6 +81,7 @@ struct OnboardingBYOKStepView: View {
           .font(.system(size: 14, weight: .semibold))
           .foregroundColor(OmiColors.textPrimary)
         Spacer()
+        statusBadge(for: keyStatuses[provider] ?? .notChecked)
         Text(help)
           .font(.system(size: 12))
           .foregroundColor(OmiColors.textTertiary)
@@ -97,8 +99,30 @@ struct OnboardingBYOKStepView: View {
             )
         )
         .foregroundColor(OmiColors.textPrimary)
+      if case .failed(let msg) = keyStatuses[provider] ?? .notChecked {
+        Text(msg)
+          .font(.system(size: 11))
+          .foregroundColor(OmiColors.warning)
+      }
     }
     .frame(maxWidth: 560)
+  }
+
+  @ViewBuilder
+  private func statusBadge(for status: BYOKValidator.Status) -> some View {
+    switch status {
+    case .notChecked:
+      EmptyView()
+    case .checking:
+      HStack(spacing: 4) {
+        ProgressView().controlSize(.mini)
+        Text("Checking…").font(.system(size: 11)).foregroundColor(OmiColors.textTertiary)
+      }
+    case .ok:
+      Text("Valid").font(.system(size: 11, weight: .semibold)).foregroundColor(OmiColors.success)
+    case .failed:
+      Text("Invalid").font(.system(size: 11, weight: .semibold)).foregroundColor(OmiColors.warning)
+    }
   }
 
   private func activate() async {
@@ -106,6 +130,31 @@ struct OnboardingBYOKStepView: View {
     isActivating = true
     defer { isActivating = false }
 
+    // Step 1: ping each provider. Refuse activation if any key is rejected —
+    // otherwise the user pays a subscription they shouldn't and nothing works.
+    let keysToCheck: [BYOKProvider: String] = [
+      .openai: openaiKey,
+      .anthropic: anthropicKey,
+      .gemini: geminiKey,
+      .deepgram: deepgramKey,
+    ]
+    for provider in BYOKProvider.allCases {
+      keyStatuses[provider] = .checking
+    }
+    let results = await BYOKValidator.validateAll(keysToCheck)
+    keyStatuses = results
+
+    let failed = results.filter {
+      if case .ok = $0.value { return false }
+      return true
+    }
+    if !failed.isEmpty {
+      let names = failed.keys.map(\.displayName).sorted().joined(separator: ", ")
+      activationError = "These keys were rejected by their provider: \(names). Fix them to continue."
+      return
+    }
+
+    // Step 2: all four authenticate — flip the backend flag.
     do {
       try await APIClient.shared.activateBYOK(fingerprints: BYOKProvider.allCases.reduce(into: [:]) {
         acc, provider in

--- a/desktop/Desktop/Sources/OnboardingBYOKStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingBYOKStepView.swift
@@ -162,6 +162,9 @@ struct OnboardingBYOKStepView: View {
           acc[provider.rawValue] = APIKeyService.byokFingerprint(key)
         }
       })
+      // Refresh the in-memory quota snapshot — otherwise the client keeps
+      // blocking chat against the stale basic-tier 30-message cap.
+      await FloatingBarUsageLimiter.shared.fetchPlan()
       AnalyticsManager.shared.onboardingStepCompleted(step: stepIndex, stepName: "BYOK_Activated")
       onContinue()
     } catch {

--- a/desktop/Desktop/Sources/OnboardingFlow.swift
+++ b/desktop/Desktop/Sources/OnboardingFlow.swift
@@ -19,6 +19,7 @@ enum OnboardingFlow {
     "DataSources",
     "Exports",
     "Goal",
+    "BringYourOwnKeys",
     "Tasks",
   ]
   static let introStepCount = 13
@@ -38,7 +39,8 @@ enum OnboardingFlow {
     hasInsertedDataSourcesStep: Bool = true,
     hasInsertedExportsStep: Bool = true,
     hasInsertedSecondBrainStep: Bool = false,
-    hasRemovedResearchStep: Bool = false
+    hasRemovedResearchStep: Bool = false,
+    hasInsertedBYOKStep: Bool = true
   ) -> Int {
     var migratedStep = currentStep
 
@@ -91,6 +93,12 @@ enum OnboardingFlow {
     // Temporary SecondBrainLive step was removed; shift users at Goal+ down
     if hasInsertedSecondBrainStep, migratedStep >= 18 {
       migratedStep -= 1
+    }
+
+    // BringYourOwnKeys step inserted at index 17 (between Goal and Tasks);
+    // push users who were on Tasks forward by one so they still land on Tasks.
+    if !hasInsertedBYOKStep, migratedStep >= 17 {
+      migratedStep += 1
     }
 
     // Only reorder for existing users who already had the old Trust-first layout.

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -27,6 +27,7 @@ struct OnboardingView: View {
   @AppStorage("onboardingResearchStepRemoved") private var hasRemovedResearchStep = false
   @AppStorage("onboardingNotificationPermissionStepRemoved") private
     var hasRemovedNotificationPermissionStep = false
+  @AppStorage("onboardingBYOKStepInserted") private var hasInsertedBYOKStep = false
   @StateObject private var introCoordinator = OnboardingPagedIntroCoordinator()
   @StateObject private var graphViewModel = MemoryGraphViewModel()
 
@@ -77,7 +78,8 @@ struct OnboardingView: View {
           hasInsertedDataSourcesStep: hasInsertedDataSourcesStep,
           hasInsertedExportsStep: hasInsertedExportsStep,
           hasInsertedSecondBrainStep: hasInsertedSecondBrainStep,
-          hasRemovedResearchStep: hasRemovedResearchStep
+          hasRemovedResearchStep: hasRemovedResearchStep,
+          hasInsertedBYOKStep: hasInsertedBYOKStep
         )
         if !hasRemovedNotificationPermissionStep, currentStep >= 8 {
           currentStep -= 1
@@ -96,6 +98,7 @@ struct OnboardingView: View {
       hasInsertedSecondBrainStep = false
       hasRemovedResearchStep = true
       hasRemovedNotificationPermissionStep = true
+      hasInsertedBYOKStep = true
       introCoordinator.prepare(appState: appState)
     }
     .task {
@@ -420,14 +423,27 @@ struct OnboardingView: View {
           },
           onForceComplete: handleOnboardingComplete
         )
+      } else if currentStep == 17 {
+        OnboardingBYOKStepView(
+          graphViewModel: graphViewModel,
+          stepIndex: 17,
+          totalSteps: OnboardingFlow.introStepCount,
+          onContinue: {
+            currentStep = 18
+          },
+          onSkip: {
+            currentStep = 18
+          },
+          onForceComplete: handleOnboardingComplete
+        )
       } else {
         OnboardingTasksStepView(
           onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 17, stepName: "Tasks")
+            AnalyticsManager.shared.onboardingStepCompleted(step: 18, stepName: "Tasks")
             handleOnboardingComplete()
           },
           onSkip: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 17, stepName: "Tasks_Skipped")
+            AnalyticsManager.shared.onboardingStepCompleted(step: 18, stepName: "Tasks_Skipped")
             handleOnboardingComplete()
           },
           onForceComplete: handleOnboardingComplete

--- a/desktop/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/Desktop/Sources/TranscriptionService.swift
@@ -335,6 +335,12 @@ class TranscriptionService {
         var request = URLRequest(url: url)
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")
 
+        // BYOK: attach user keys so the transcription backend can use the user's
+        // Deepgram token for this session (and any downstream LLM calls).
+        for (provider, entry) in APIKeyService.byokSnapshot {
+            request.setValue(entry.key, forHTTPHeaderField: provider.headerName)
+        }
+
         // Create URLSession and WebSocket task
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30
@@ -560,6 +566,9 @@ extension TranscriptionService {
         request.httpMethod = "POST"
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        for (provider, entry) in APIKeyService.byokSnapshot {
+            request.setValue(entry.key, forHTTPHeaderField: provider.headerName)
+        }
         request.httpBody = audioData
 
         log("TranscriptionService: Batch transcribing \(audioData.count) bytes via Python backend")


### PR DESCRIPTION
## Summary

Adds an opt-in Bring-Your-Own-Keys (BYOK) free plan for the desktop app. Users who paste their own OpenAI, Anthropic, Gemini, and Deepgram keys get unlimited Omi usage with no subscription — they pay the providers directly, Omi eats no API bill for them.

**Keys stay on the user's Mac.** Only SHA-256 fingerprints ever touch our DB. The live keys travel as per-request `X-BYOK-*` headers (HTTP + WS) and live in backend memory only for that request's lifetime.

## What lands here

- **Onboarding**: new "Bring your own keys" step between Goal and Tasks with four secure fields and a Skip button. Migration flag keeps existing users on Tasks.
- **Settings → Plan & Usage**: new card "Switch to your own keys — use Omi free forever" that deep-links to Developer API Keys.
- **Settings → Advanced → Developer API Keys**: now accepts OpenAI + Deepgram (in addition to Anthropic + Gemini). Shows a "Free plan active" banner when all four are filled.
- **Client transport**: `APIClient.buildHeaders` + `TranscriptionService` WS request attach the four keys on every request when set.
- **Backend**:
  - `BYOKMiddleware` stashes incoming keys in a per-request ContextVar.
  - `POST /v1/users/me/byok-active` + `DELETE` (accepts/clears fingerprints with 7-day heartbeat TTL).
  - `/v1/users/me/subscription` returns unlimited+`byok` feature when activation is live (skips Stripe entirely).
  - `utils/llm/clients.get_anthropic_client()` and `get_openai_chat()` factories — scaffold for the follow-up sweep.

## Follow-up (not in this PR)

Sweep every `llm_medium` / `llm_mini` / `llm_high` / etc. call site in `backend/utils/llm/` and `backend/routers/` to use the factory helpers. Until that sweep lands, BYOK users still get free subscription but their requests still run on Omi's keys — i.e. we cap the revenue loss but don't cap the cost until the follow-up merges. Put this on the top of the stack.

## Test plan

Not merging until validated on the Mac mini.

- [ ] Fresh install onboarding: reach BYOK step → skip → land on Tasks
- [ ] Fresh install onboarding: fill 4 keys → Activate → backend returns `byok` plan → land on Tasks
- [ ] Existing user: reset onboarding, confirm migration lands them on Tasks not BYOK
- [ ] Plan & Usage card reflects "Free plan active" when all 4 keys present
- [ ] Clear All Keys → subscription endpoint flips back to paid/basic gate
- [ ] Backend: `curl -XPOST /v1/users/me/byok-active` with all four fingerprints → `/v1/users/me/subscription` returns unlimited+byok
- [ ] Request with `X-BYOK-*` headers arrives at backend; header visible in middleware contextvar

🤖 Generated with [Claude Code](https://claude.com/claude-code)