### PR TITLE
desktop: skip + 429 retry on onboarding goal step

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added a Skip button to the onboarding goal step and made it resilient to transient 429 errors"
+  ],
   "releases": [
     {
       "version": "0.11.336",

--- a/desktop/Desktop/Sources/OnboardingGoalStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingGoalStepView.swift
@@ -7,6 +7,7 @@ struct OnboardingGoalStepView: View {
   let stepIndex: Int
   let totalSteps: Int
   let onContinue: () -> Void
+  let onSkip: () -> Void
   let onForceComplete: (() -> Void)?
 
   @State private var customGoalSelected = false
@@ -22,6 +23,8 @@ struct OnboardingGoalStepView: View {
       title: "Pick one goal.",
       description:
         "Selecting a correct and detailed goal is very important - Omi will optimize all advice to achieve that goal. Make sure your goal contains a number to measure progress.",
+      showsSkip: true,
+      onSkip: onSkip,
       onForceComplete: onForceComplete
     ) {
       VStack(alignment: .leading, spacing: 18) {

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -1155,14 +1155,12 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
       ?? fallbackGoalConfig(from: title)
 
     do {
-      let goal = try await APIClient.shared.createGoal(
+      let goal = try await createGoalWithRetry(
         title: title,
         description: "Added from onboarding",
         goalType: config.goalType,
         targetValue: config.targetValue,
-        currentValue: 0,
-        unit: config.unit,
-        source: "onboarding_step_flow"
+        unit: config.unit
       )
       _ = try? await GoalStorage.shared.syncServerGoal(goal)
 
@@ -1178,10 +1176,51 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
           ["source_id": "user", "target_id": "goal_\(slug(title))", "label": "prioritizes"]
         ]
       )
+    } catch APIError.httpError(let statusCode) where statusCode == 429 {
+      logError(
+        "OnboardingPagedIntroCoordinator: Goal save rate-limited (429)",
+        error: APIError.httpError(statusCode: 429))
+      lastActionError =
+        "Too many requests right now. Skip this step or try again in a moment."
     } catch {
       logError("OnboardingPagedIntroCoordinator: Failed to save onboarding goal", error: error)
       lastActionError = error.localizedDescription
     }
+  }
+
+  /// Create a goal with retry/backoff for transient 429s. The onboarding flow can saturate
+  /// Cloud Armor's per-Authorization limit through the local-file memory batch import that
+  /// runs in parallel; this gives the limiter time to drain before failing the user.
+  private func createGoalWithRetry(
+    title: String,
+    description: String,
+    goalType: GoalType,
+    targetValue: Double,
+    unit: String?
+  ) async throws -> Goal {
+    let backoffsSec: [UInt64] = [1, 3, 6]
+    var lastError: Error?
+    for attempt in 0...backoffsSec.count {
+      do {
+        return try await APIClient.shared.createGoal(
+          title: title,
+          description: description,
+          goalType: goalType,
+          targetValue: targetValue,
+          currentValue: 0,
+          unit: unit,
+          source: "onboarding_step_flow"
+        )
+      } catch APIError.httpError(let statusCode) where statusCode == 429 {
+        lastError = APIError.httpError(statusCode: 429)
+        guard attempt < backoffsSec.count else { break }
+        log(
+          "OnboardingPagedIntroCoordinator: createGoal 429, retrying in \(backoffsSec[attempt])s "
+            + "(attempt \(attempt + 2)/\(backoffsSec.count + 1))")
+        try? await Task.sleep(nanoseconds: backoffsSec[attempt] * 1_000_000_000)
+      }
+    }
+    throw lastError ?? APIError.httpError(statusCode: 429)
   }
 
   func completeIntro(appState: AppState) async -> Bool {

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -418,6 +418,14 @@ struct OnboardingView: View {
             }
             currentStep = 17
           },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 16, stepName: "Goal_Skipped")
+            if !ProactiveAssistantsPlugin.shared.isMonitoring {
+              ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
+            }
+            currentStep = 17
+          },
           onForceComplete: handleOnboardingComplete
         )
       } else {


### PR DESCRIPTION
## Summary
- Adds a Skip button to the onboarding goal step (step 16), matching the `OnboardingStepScaffold(showsSkip:onSkip:)` pattern used by other onboarding steps. Skipping advances to the Tasks step and starts proactive monitoring the same way Continue does.
- Wraps the onboarding `createGoal` POST in a 1s/3s/6s exponential backoff (3 retries) so a transient 429 — typically a Cloud Armor per-Authorization rate-limit hit by the parallel local-file memory batch import earlier in onboarding — no longer hard-fails the step.
- Replaces the raw `"HTTP error: 429"` error string with a friendlier message ("Too many requests right now. Skip this step or try again in a moment."), paired with the new Skip button so the user always has a way forward.

## Test plan
- [ ] Walk through onboarding to step 16 — confirm a Skip button appears in the top-right (same affordance as other steps).
- [ ] Tap Skip on the Goal step — onboarding advances to the Tasks step without saving a goal.
- [ ] Enter a goal and tap Continue — goal saves normally (happy path unchanged).
- [ ] Force a 429 (e.g. spam memory batches) and re-try Continue — observe retry log lines and the new error copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)