### PR TITLE
desktop: add Skip button to onboarding exports step

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Added a Skip button to the onboarding goal step and made it resilient to transient 429 errors"
+    "Added a Skip button to the onboarding goal step and made it resilient to transient 429 errors",
+    "Added a Skip button to the onboarding exports step (Put your memories where you work)"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/OnboardingExportsStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingExportsStepView.swift
@@ -6,6 +6,7 @@ struct OnboardingExportsStepView: View {
   let totalSteps: Int
   let summaryText: String
   let onContinue: () -> Void
+  let onSkip: () -> Void
   let onForceComplete: (() -> Void)?
 
   @State private var statuses: [MemoryExportDestination: MemoryExportStatus] = [:]
@@ -20,6 +21,8 @@ struct OnboardingExportsStepView: View {
       title: "Put your memories where you work.",
       description: "Connect the tools where you want Omi context to live.",
       rightPaneFooterText: summaryText,
+      showsSkip: true,
+      onSkip: onSkip,
       onForceComplete: onForceComplete
     ) {
       VStack(alignment: .leading, spacing: 18) {

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -402,6 +402,11 @@ struct OnboardingView: View {
             AnalyticsManager.shared.onboardingStepCompleted(step: 15, stepName: "Exports")
             currentStep = 16
           },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 15, stepName: "Exports_Skipped")
+            currentStep = 16
+          },
           onForceComplete: handleOnboardingComplete
         )
       } else if currentStep == 16 {


### PR DESCRIPTION
## Summary
- Adds a Skip button to the onboarding "Put your memories where you work" step (step 15), matching the `OnboardingStepScaffold(showsSkip:onSkip:)` pattern.
- Skipping advances to the Goal step.

## Test plan
- [ ] Walk through onboarding to step 15 — confirm Skip button appears in the top-right.
- [ ] Tap Skip — onboarding advances to the Goal step without configuring any export destination.
- [ ] Tap Continue (after configuring an export) — happy path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)