### PR TITLE
Update CHANGELOG.json for v0.11.338 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Added a Skip button to the onboarding goal step and made it resilient to transient 429 errors"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.338",
+      "date": "2026-04-19",
+      "changes": [
+        "Added a Skip button to the onboarding goal step and made it resilient to transient 429 errors"
+      ]
+    },
     {
       "version": "0.11.337",
       "date": "2026-04-19",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.338 and clears the unreleased array.