### PR TITLE
Update CHANGELOG.json for v0.11.339 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,9 +1,14 @@
 {
-  "unreleased": [
-    "Added a Skip button to the onboarding goal step and made it resilient to transient 429 errors",
-    "Added a Skip button to the onboarding exports step (Put your memories where you work)"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.339",
+      "date": "2026-04-19",
+      "changes": [
+        "Added a Skip button to the onboarding goal step and made it resilient to transient 429 errors",
+        "Added a Skip button to the onboarding exports step (Put your memories where you work)"
+      ]
+    },
     {
       "version": "0.11.337",
       "date": "2026-04-19",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.339 and clears the unreleased array.