### PR TITLE
chore(agent-vm): reduce boot disk from 50 GB pd-ssd to 30 GB pd-balanced

### DIFF
--- a/desktop/Backend-Rust/src/routes/agent.rs
+++ b/desktop/Backend-Rust/src/routes/agent.rs
@@ -487,8 +487,8 @@ async fn create_gce_vm(
             "autoDelete": true,
             "initializeParams": {
                 "sourceImage": source_image,
-                "diskSizeGb": "50",
-                "diskType": format!("zones/{}/diskTypes/pd-ssd", zone)
+                "diskSizeGb": "30",
+                "diskType": format!("zones/{}/diskTypes/pd-balanced", zone)
             }
         }],
         "networkInterfaces": [{


### PR DESCRIPTION
This enhancement is for #6611 
<p><strong>Summary</strong></p>
<p>Reduces the GCE boot disk spec for every provisioned agent VM from a 50 GB <code>pd-ssd</code> to a 30 GB <code>pd-balanced</code>. No change to machine type, network, startup script, or application behaviour.</p>
<p><strong>Changes</strong></p>
<ul>
<li>desktop/Backend-Rust/src/routes/agent.rs — <code>diskSizeGb</code>: <code>&quot;50&quot;</code> → <code>&quot;30&quot;</code>, <code>diskType</code>: <code>pd-ssd</code> → <code>pd-balanced</code></li>
</ul>
<p><strong>Cost impact</strong></p>

Metric | Before | After | Saving
-- | -- | -- | --
Disk type | pd-ssd | pd-balanced | —
Disk size | 50 GB | 30 GB | —
Cost per VM/month | $8.50 | $3.00 | −$5.50 (−65%)


<p>At current scale this saves ~$5.50 per active agent VM per month. Scales linearly with the number of provisioned VMs.</p>
<p><strong>Why pd-balanced is sufficient</strong></p>
<p><code>pd-balanced</code> delivers up to 80 MB/s throughput and 6 000 IOPS at 30 GB — well above what an idle or lightly-used agent VM requires. <code>pd-ssd</code> (160 MB/s, 15 000+ IOPS) is over-provisioned for this workload.</p>
<p><strong>Why 30 GB is sufficient</strong></p>
<p>The OS image + agent process fits comfortably under 20 GB based on current usage. 30 GB leaves a 10 GB buffer for logs, model weights, and temporary files.</p>
<p><strong>Testing</strong></p>
<ul>
<li>[ ]  Provision a new agent VM in staging, verify boot succeeds.</li>
<li>[ ]  Confirm <code>agent-flutter</code> / <code>agent-swift</code> flow works end-to-end.</li>
<li>[ ]  Verify GCE console shows <code>pd-balanced, 30 GB</code> for the new VM.</li>
</ul>
<!-- notionvc: e0a2737a-fff0-4266-9326-d5d7ffc0d2b0 -->