### PR TITLE
[security] fix(apps,mcp): reject private MCP server targets

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -16,14 +16,15 @@ from utils.http_client import get_webhook_client
 from utils.mcp_client import (
     discover_oauth_metadata,
     register_oauth_client,
+    generate_pkce_pair,
     build_authorization_url,
+    generate_state_token,
+    parse_state_token,
     exchange_oauth_code,
     refresh_oauth_token,
     discover_mcp_tools,
     fetch_brandfetch_logo,
-    generate_state_token,
-    parse_state_token,
-    generate_pkce_pair,
+    validate_mcp_server_url,
 )
 
 from database.apps import (
@@ -1447,6 +1448,10 @@ async def add_mcp_server(data: McpServerRequest, uid: str = Depends(auth.get_cur
         raise HTTPException(status_code=422, detail='App name is required')
     if not server_url:
         raise HTTPException(status_code=422, detail='MCP server URL is required')
+    try:
+        validate_mcp_server_url(server_url)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=f'MCP server URL rejected: {str(e)}')
 
     # Extract domain for logo
     parsed = urlparse(server_url)

--- a/backend/tests/unit/test_mcp_ssrf_guard.py
+++ b/backend/tests/unit/test_mcp_ssrf_guard.py
@@ -1,0 +1,58 @@
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Stub optional/heavy deps before importing target module
+sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault('firebase_admin.auth', MagicMock())
+sys.modules.setdefault('firebase_admin.firestore', MagicMock())
+sys.modules.setdefault('firebase_admin.messaging', MagicMock())
+sys.modules.setdefault('google.cloud', MagicMock())
+sys.modules.setdefault('google.cloud.firestore', MagicMock())
+sys.modules.setdefault('google.cloud.firestore_v1', MagicMock())
+sys.modules.setdefault('google.auth', MagicMock())
+sys.modules.setdefault('google.auth.transport.requests', MagicMock())
+sys.modules.setdefault('httpx', MagicMock())
+
+from utils import mcp_client
+
+
+class TestMcpServerUrlValidation:
+    def test_rejects_link_local_metadata_ip(self):
+        with pytest.raises(ValueError, match='not allowed'):
+            mcp_client.validate_mcp_server_url('http://169.254.169.254/latest/meta-data')
+
+    def test_rejects_loopback(self):
+        with pytest.raises(ValueError, match='not allowed'):
+            mcp_client.validate_mcp_server_url('http://127.0.0.1:8080/mcp')
+
+    def test_rejects_private_rfc1918(self):
+        with pytest.raises(ValueError, match='not allowed'):
+            mcp_client.validate_mcp_server_url('http://10.0.0.5/mcp')
+
+
+class TestOutboundValidation:
+    def test_discover_oauth_metadata_blocks_private_target_before_request(self):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('utils.mcp_client.httpx.AsyncClient', return_value=mock_client):
+            with pytest.raises(ValueError, match='not allowed'):
+                import asyncio
+                asyncio.run(mcp_client.discover_oauth_metadata('http://169.254.169.254/latest/meta-data'))
+
+        mock_client.get.assert_not_called()
+
+    def test_discover_mcp_tools_blocks_private_target_before_request(self):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('utils.mcp_client.httpx.AsyncClient', return_value=mock_client):
+            with pytest.raises(Exception, match='not allowed'):
+                import asyncio
+                asyncio.run(mcp_client.discover_mcp_tools('http://169.254.169.254/latest/meta-data'))
+
+        mock_client.post.assert_not_called()

--- a/backend/tests/unit/test_mcp_ssrf_guard.py
+++ b/backend/tests/unit/test_mcp_ssrf_guard.py
@@ -1,6 +1,9 @@
+import importlib
 import sys
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 # Stub optional/heavy deps before importing target module
@@ -13,46 +16,117 @@ sys.modules.setdefault('google.cloud.firestore', MagicMock())
 sys.modules.setdefault('google.cloud.firestore_v1', MagicMock())
 sys.modules.setdefault('google.auth', MagicMock())
 sys.modules.setdefault('google.auth.transport.requests', MagicMock())
-sys.modules.setdefault('httpx', MagicMock())
 
-from utils import mcp_client
+mcp_client = importlib.import_module('utils.mcp_client')
+
+
+def _addrinfo_for(*ips: str):
+    return [
+        (
+            0,
+            0,
+            0,
+            '',
+            (ip, 443),
+        )
+        for ip in ips
+    ]
 
 
 class TestMcpServerUrlValidation:
     def test_rejects_link_local_metadata_ip(self):
-        with pytest.raises(ValueError, match='not allowed'):
-            mcp_client.validate_mcp_server_url('http://169.254.169.254/latest/meta-data')
+        with patch('utils.mcp_client.socket.getaddrinfo', return_value=_addrinfo_for('169.254.169.254')):
+            with pytest.raises(ValueError, match='not allowed'):
+                mcp_client.validate_mcp_server_url('http://169.254.169.254/latest/meta-data')
 
     def test_rejects_loopback(self):
-        with pytest.raises(ValueError, match='not allowed'):
-            mcp_client.validate_mcp_server_url('http://127.0.0.1:8080/mcp')
+        with patch('utils.mcp_client.socket.getaddrinfo', return_value=_addrinfo_for('127.0.0.1')):
+            with pytest.raises(ValueError, match='not allowed'):
+                mcp_client.validate_mcp_server_url('http://127.0.0.1:8080/mcp')
 
     def test_rejects_private_rfc1918(self):
-        with pytest.raises(ValueError, match='not allowed'):
-            mcp_client.validate_mcp_server_url('http://10.0.0.5/mcp')
+        with patch('utils.mcp_client.socket.getaddrinfo', return_value=_addrinfo_for('10.0.0.5')):
+            with pytest.raises(ValueError, match='not allowed'):
+                mcp_client.validate_mcp_server_url('http://10.0.0.5/mcp')
 
 
 class TestOutboundValidation:
     def test_discover_oauth_metadata_blocks_private_target_before_request(self):
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch('utils.mcp_client.httpx.AsyncClient', return_value=mock_client):
-            with pytest.raises(ValueError, match='not allowed'):
+        with patch('utils.mcp_client.socket.getaddrinfo', return_value=_addrinfo_for('169.254.169.254')):
+            with patch('utils.mcp_client.httpx.AsyncClient') as mock_client_cls:
                 import asyncio
-                asyncio.run(mcp_client.discover_oauth_metadata('http://169.254.169.254/latest/meta-data'))
 
-        mock_client.get.assert_not_called()
+                with pytest.raises(ValueError, match='not allowed'):
+                    asyncio.run(mcp_client.discover_oauth_metadata('http://169.254.169.254/latest/meta-data'))
+
+        mock_client_cls.assert_not_called()
 
     def test_discover_mcp_tools_blocks_private_target_before_request(self):
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch('utils.mcp_client.httpx.AsyncClient', return_value=mock_client):
-            with pytest.raises(Exception, match='not allowed'):
+        with patch('utils.mcp_client.socket.getaddrinfo', return_value=_addrinfo_for('169.254.169.254')):
+            with patch('utils.mcp_client.httpx.AsyncClient') as mock_client_cls:
                 import asyncio
-                asyncio.run(mcp_client.discover_mcp_tools('http://169.254.169.254/latest/meta-data'))
 
-        mock_client.post.assert_not_called()
+                with pytest.raises(Exception, match='not allowed'):
+                    asyncio.run(mcp_client.discover_mcp_tools('http://169.254.169.254/latest/meta-data'))
+
+        mock_client_cls.assert_not_called()
+
+
+class _FakeStream:
+    def __init__(self, chunks):
+        self.status_code = 200
+        self._request = httpx.Request('GET', 'https://public.example/sse')
+        self._chunks = chunks
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def aiter_text(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aread(self):
+        return b''
+
+
+class _FakeClient:
+    def __init__(self, chunks):
+        self._stream = _FakeStream(chunks)
+        self.post = AsyncMock(return_value=httpx.Response(202, request=httpx.Request('POST', 'https://public.example/post')))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def stream(self, *args, **kwargs):
+        return self._stream
+
+
+class TestSseTransport:
+    def test_sse_event_lines_are_processed_inside_chunk_loop(self):
+        fake_client = _FakeClient(
+            [
+                'event: endpoint\ndata: /post\n\n',
+                'event: message\ndata: {"id": 1, "result": {"tools": []}}\n\n',
+            ]
+        )
+
+        @asynccontextmanager
+        async def fake_safe_client(url, timeout):
+            yield fake_client
+
+        with patch('utils.mcp_client._safe_async_client', fake_safe_client):
+            with patch('utils.mcp_client.validate_mcp_server_url'):
+                import asyncio
+
+                responses = asyncio.run(
+                    mcp_client._sse_send_and_receive_inner('https://public.example/sse', [{'id': 1}], None)
+                )
+
+        fake_client.post.assert_awaited_once()
+        assert responses == [{'id': 1, 'result': {'tools': []}}]

--- a/backend/utils/mcp_client.py
+++ b/backend/utils/mcp_client.py
@@ -16,11 +16,12 @@ import json
 import secrets
 import socket
 import time
+from contextlib import asynccontextmanager
 from typing import Optional
-from unittest.mock import patch
 from urllib.parse import urlencode, urljoin, urlparse
 
 import httpx
+import httpcore
 
 from models.app import ChatTool
 from utils.log_sanitizer import sanitize
@@ -45,7 +46,7 @@ def _is_forbidden_ip(ip_str: str) -> bool:
     )
 
 
-def validate_mcp_server_url(server_url: str) -> str:
+def validate_mcp_server_url(server_url: str) -> None:
     """Validate outbound MCP/OAuth URLs against SSRF-prone destinations."""
     parsed = urlparse(server_url)
     if parsed.scheme not in ("http", "https"):
@@ -58,7 +59,6 @@ def validate_mcp_server_url(server_url: str) -> str:
     host = parsed.hostname
     port = parsed.port or (443 if parsed.scheme == 'https' else 80)
     _resolve_public_addresses(host, port)
-    return server_url
 
 
 def _resolve_public_addresses(host: str, port: int):
@@ -78,16 +78,68 @@ def _resolve_public_addresses(host: str, port: int):
     return infos
 
 
-def _patch_resolution(host: str, port: int):
-    resolved_infos = _resolve_public_addresses(host, port)
-    original_getaddrinfo = socket.getaddrinfo
+class _PinnedAsyncNetworkBackend(httpcore.AsyncNetworkBackend):
+    """Per-client network backend that pins hostname resolution to validated IPs."""
 
-    def _pinned_getaddrinfo(query_host, query_port, *args, **kwargs):
-        if query_host == host and int(query_port or port) == int(port):
-            return resolved_infos
-        return original_getaddrinfo(query_host, query_port, *args, **kwargs)
+    def __init__(self, pinned_hosts: dict[tuple[str, int], list[str]]):
+        self._backend = httpcore.AnyIOBackend()
+        self._pinned_hosts = pinned_hosts
 
-    return patch('socket.getaddrinfo', side_effect=_pinned_getaddrinfo)
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options=None,
+    ):
+        pinned_addresses = self._pinned_hosts.get((host, int(port)))
+        if not pinned_addresses:
+            return await self._backend.connect_tcp(host, port, timeout, local_address, socket_options)
+
+        last_error = None
+        for pinned_ip in pinned_addresses:
+            try:
+                return await self._backend.connect_tcp(
+                    pinned_ip,
+                    port,
+                    timeout,
+                    local_address,
+                    socket_options,
+                )
+            except Exception as exc:
+                last_error = exc
+
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError(f"No validated addresses available for {host}:{port}")
+
+    async def connect_unix_socket(self, path: str, timeout: float | None = None, socket_options=None):
+        return await self._backend.connect_unix_socket(path, timeout, socket_options)
+
+    async def sleep(self, seconds: float) -> None:
+        await self._backend.sleep(seconds)
+
+
+def _validated_host_config(server_url: str) -> tuple[str, int, list[str]]:
+    validate_mcp_server_url(server_url)
+    parsed = urlparse(server_url)
+    host = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    infos = _resolve_public_addresses(host, port)
+    pinned_ips = list(dict.fromkeys(info[4][0] for info in infos))
+    return host, port, pinned_ips
+
+
+@asynccontextmanager
+async def _safe_async_client(server_url: str, timeout):
+    host, port, pinned_ips = _validated_host_config(server_url)
+    transport = httpx.AsyncHTTPTransport()
+    transport._pool._network_backend = _PinnedAsyncNetworkBackend({(host, port): pinned_ips})
+
+    async with transport:
+        async with httpx.AsyncClient(timeout=timeout, transport=transport) as client:
+            yield client
 
 
 # ---------------------------------------------------------------------------
@@ -101,16 +153,15 @@ async def discover_oauth_metadata(server_url: str) -> Optional[dict]:
     Checks /.well-known/oauth-authorization-server relative to the server origin.
     Returns metadata dict or None if the server does not require OAuth.
     """
-    validated_server_url = validate_mcp_server_url(server_url)
-    parsed = urlparse(validated_server_url)
+    validate_mcp_server_url(server_url)
+    parsed = urlparse(server_url)
     origin = f"{parsed.scheme}://{parsed.netloc}"
     metadata_url = urljoin(origin, "/.well-known/oauth-authorization-server")
     validate_mcp_server_url(metadata_url)
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
+    async with _safe_async_client(metadata_url, timeout=15.0) as client:
         try:
-            with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
-                resp = await client.get(metadata_url, follow_redirects=False)
+            resp = await client.get(metadata_url, follow_redirects=False)
             if resp.status_code == 200:
                 data = resp.json()
                 return {
@@ -140,10 +191,8 @@ async def register_oauth_client(registration_endpoint: str, redirect_uri: str, s
     if scopes:
         payload["scope"] = " ".join(scopes)
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        parsed = urlparse(registration_endpoint)
-        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
-            resp = await client.post(registration_endpoint, json=payload, follow_redirects=False)
+    async with _safe_async_client(registration_endpoint, timeout=15.0) as client:
+        resp = await client.post(registration_endpoint, json=payload, follow_redirects=False)
         resp.raise_for_status()
         data = resp.json()
         logger.info(f"[MCP OAuth] Registration response: {sanitize(data)}")
@@ -208,10 +257,8 @@ async def exchange_oauth_code(
     if code_verifier:
         payload["code_verifier"] = code_verifier
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        parsed = urlparse(token_endpoint)
-        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
-            resp = await client.post(token_endpoint, data=payload, follow_redirects=False)
+    async with _safe_async_client(token_endpoint, timeout=15.0) as client:
+        resp = await client.post(token_endpoint, data=payload, follow_redirects=False)
         resp.raise_for_status()
         data = resp.json()
         token_type = data.get("token_type", "Bearer")
@@ -245,10 +292,8 @@ async def refresh_oauth_token(
     if client_secret:
         payload["client_secret"] = client_secret
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        parsed = urlparse(token_endpoint)
-        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
-            resp = await client.post(token_endpoint, data=payload, follow_redirects=False)
+    async with _safe_async_client(token_endpoint, timeout=15.0) as client:
+        resp = await client.post(token_endpoint, data=payload, follow_redirects=False)
         resp.raise_for_status()
         data = resp.json()
         return {
@@ -314,10 +359,8 @@ async def _mcp_post(
     if session_id:
         headers["Mcp-Session-Id"] = session_id
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
-        parsed = urlparse(server_url)
-        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
-            resp = await client.post(server_url, json=payload, headers=headers, follow_redirects=False)
+    async with _safe_async_client(server_url, timeout=httpx.Timeout(30.0, connect=10.0)) as client:
+        resp = await client.post(server_url, json=payload, headers=headers, follow_redirects=False)
 
         if resp.status_code == 401:
             raise PermissionError("MCP server returned 401 Unauthorized")
@@ -401,29 +444,28 @@ async def _sse_send_and_receive_inner(
     responses: list[dict] = []
     post_endpoint = None
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
-        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
-            async with client.stream("GET", sse_url, headers=headers, follow_redirects=False) as stream:
-                if stream.status_code == 401:
-                    raise PermissionError("MCP server returned 401 Unauthorized")
-                if stream.status_code >= 400:
-                    await stream.aread()
-                    raise httpx.HTTPStatusError(
-                        f"SSE connection failed with {stream.status_code}",
-                        request=stream._request,
-                        response=httpx.Response(stream.status_code),
-                    )
+    async with _safe_async_client(sse_url, timeout=httpx.Timeout(30.0, connect=10.0)) as client:
+        async with client.stream("GET", sse_url, headers=headers, follow_redirects=False) as stream:
+            if stream.status_code == 401:
+                raise PermissionError("MCP server returned 401 Unauthorized")
+            if stream.status_code >= 400:
+                await stream.aread()
+                raise httpx.HTTPStatusError(
+                    f"SSE connection failed with {stream.status_code}",
+                    request=stream._request,
+                    response=httpx.Response(stream.status_code),
+                )
 
-                logger.info(f"[MCP SSE] Connected to {sse_url}, status={stream.status_code}")
-                buf = ""
-                event_type = ""
-                event_data_lines: list[str] = []
+            logger.info(f"[MCP SSE] Connected to {sse_url}, status={stream.status_code}")
+            buf = ""
+            event_type = ""
+            event_data_lines: list[str] = []
 
-                async for raw_chunk in stream.aiter_text():
-                    buf += raw_chunk
-                    while "\n" in buf:
-                        line, buf = buf.split("\n", 1)
-                        line = line.rstrip("\r")
+            async for raw_chunk in stream.aiter_text():
+                buf += raw_chunk
+                while "\n" in buf:
+                    line, buf = buf.split("\n", 1)
+                    line = line.rstrip("\r")
 
                     if line.startswith("event:"):
                         event_type = line[6:].strip()
@@ -447,13 +489,9 @@ async def _sse_send_and_receive_inner(
                             post_headers = {"Content-Type": "application/json"}
                             if access_token:
                                 post_headers["Authorization"] = f"Bearer {access_token}"
-                            post_parsed = urlparse(post_endpoint)
-                            with _patch_resolution(
-                                post_parsed.hostname,
-                                post_parsed.port or (443 if post_parsed.scheme == 'https' else 80),
-                            ):
+                            async with _safe_async_client(post_endpoint, timeout=httpx.Timeout(30.0, connect=10.0)) as post_client:
                                 for payload in payloads:
-                                    await client.post(
+                                    await post_client.post(
                                         post_endpoint,
                                         json=payload,
                                         headers=post_headers,

--- a/backend/utils/mcp_client.py
+++ b/backend/utils/mcp_client.py
@@ -11,10 +11,13 @@ Handles:
 import asyncio
 import base64
 import hashlib
+import ipaddress
 import json
 import secrets
+import socket
 import time
 from typing import Optional
+from unittest.mock import patch
 from urllib.parse import urlencode, urljoin, urlparse
 
 import httpx
@@ -30,6 +33,63 @@ MCP_CLIENT_VERSION = "1.0.0"
 MCP_PROTOCOL_VERSION = "2025-03-26"
 
 
+def _is_forbidden_ip(ip_str: str) -> bool:
+    ip = ipaddress.ip_address(ip_str)
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def validate_mcp_server_url(server_url: str) -> str:
+    """Validate outbound MCP/OAuth URLs against SSRF-prone destinations."""
+    parsed = urlparse(server_url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("URL scheme is not allowed")
+    if not parsed.hostname:
+        raise ValueError("URL host is required")
+    if parsed.username or parsed.password:
+        raise ValueError("URL credentials are not allowed")
+
+    host = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    _resolve_public_addresses(host, port)
+    return server_url
+
+
+def _resolve_public_addresses(host: str, port: int):
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise ValueError(f"Unable to resolve host: {host}") from e
+
+    if not infos:
+        raise ValueError(f"Unable to resolve host: {host}")
+
+    for info in infos:
+        ip_str = info[4][0]
+        if _is_forbidden_ip(ip_str):
+            raise ValueError("URL host is not allowed")
+
+    return infos
+
+
+def _patch_resolution(host: str, port: int):
+    resolved_infos = _resolve_public_addresses(host, port)
+    original_getaddrinfo = socket.getaddrinfo
+
+    def _pinned_getaddrinfo(query_host, query_port, *args, **kwargs):
+        if query_host == host and int(query_port or port) == int(port):
+            return resolved_infos
+        return original_getaddrinfo(query_host, query_port, *args, **kwargs)
+
+    return patch('socket.getaddrinfo', side_effect=_pinned_getaddrinfo)
+
+
 # ---------------------------------------------------------------------------
 # OAuth helpers
 # ---------------------------------------------------------------------------
@@ -41,13 +101,16 @@ async def discover_oauth_metadata(server_url: str) -> Optional[dict]:
     Checks /.well-known/oauth-authorization-server relative to the server origin.
     Returns metadata dict or None if the server does not require OAuth.
     """
-    parsed = urlparse(server_url)
+    validated_server_url = validate_mcp_server_url(server_url)
+    parsed = urlparse(validated_server_url)
     origin = f"{parsed.scheme}://{parsed.netloc}"
     metadata_url = urljoin(origin, "/.well-known/oauth-authorization-server")
+    validate_mcp_server_url(metadata_url)
 
     async with httpx.AsyncClient(timeout=15.0) as client:
         try:
-            resp = await client.get(metadata_url, follow_redirects=True)
+            with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
+                resp = await client.get(metadata_url, follow_redirects=False)
             if resp.status_code == 200:
                 data = resp.json()
                 return {
@@ -66,6 +129,7 @@ async def register_oauth_client(registration_endpoint: str, redirect_uri: str, s
 
     Returns dict with client_id and optionally client_secret.
     """
+    validate_mcp_server_url(registration_endpoint)
     payload = {
         "client_name": MCP_CLIENT_NAME,
         "redirect_uris": [redirect_uri],
@@ -77,7 +141,9 @@ async def register_oauth_client(registration_endpoint: str, redirect_uri: str, s
         payload["scope"] = " ".join(scopes)
 
     async with httpx.AsyncClient(timeout=15.0) as client:
-        resp = await client.post(registration_endpoint, json=payload)
+        parsed = urlparse(registration_endpoint)
+        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
+            resp = await client.post(registration_endpoint, json=payload, follow_redirects=False)
         resp.raise_for_status()
         data = resp.json()
         logger.info(f"[MCP OAuth] Registration response: {sanitize(data)}")
@@ -130,6 +196,7 @@ async def exchange_oauth_code(
     code_verifier: Optional[str] = None,
 ) -> dict:
     """Exchange an authorization code for access + refresh tokens."""
+    validate_mcp_server_url(token_endpoint)
     payload = {
         "grant_type": "authorization_code",
         "code": code,
@@ -142,7 +209,9 @@ async def exchange_oauth_code(
         payload["code_verifier"] = code_verifier
 
     async with httpx.AsyncClient(timeout=15.0) as client:
-        resp = await client.post(token_endpoint, data=payload)
+        parsed = urlparse(token_endpoint)
+        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
+            resp = await client.post(token_endpoint, data=payload, follow_redirects=False)
         resp.raise_for_status()
         data = resp.json()
         token_type = data.get("token_type", "Bearer")
@@ -167,6 +236,7 @@ async def refresh_oauth_token(
     client_secret: Optional[str] = None,
 ) -> dict:
     """Refresh an expired access token."""
+    validate_mcp_server_url(token_endpoint)
     payload = {
         "grant_type": "refresh_token",
         "refresh_token": refresh_token,
@@ -176,7 +246,9 @@ async def refresh_oauth_token(
         payload["client_secret"] = client_secret
 
     async with httpx.AsyncClient(timeout=15.0) as client:
-        resp = await client.post(token_endpoint, data=payload)
+        parsed = urlparse(token_endpoint)
+        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
+            resp = await client.post(token_endpoint, data=payload, follow_redirects=False)
         resp.raise_for_status()
         data = resp.json()
         return {
@@ -232,6 +304,7 @@ async def _mcp_post(
     Returns (response_dict, session_id). The session_id may be updated from the
     Mcp-Session-Id response header and should be passed to subsequent requests.
     """
+    validate_mcp_server_url(server_url)
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
@@ -242,7 +315,9 @@ async def _mcp_post(
         headers["Mcp-Session-Id"] = session_id
 
     async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
-        resp = await client.post(server_url, json=payload, headers=headers, follow_redirects=True)
+        parsed = urlparse(server_url)
+        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
+            resp = await client.post(server_url, json=payload, headers=headers, follow_redirects=False)
 
         if resp.status_code == 401:
             raise PermissionError("MCP server returned 401 Unauthorized")
@@ -302,6 +377,7 @@ async def _sse_send_and_receive(
 
     Returns a list of JSON-RPC response dicts (one per payload that has an id).
     """
+    validate_mcp_server_url(sse_url)
     return await asyncio.wait_for(
         _sse_send_and_receive_inner(sse_url, payloads, access_token),
         timeout=timeout_seconds,
@@ -326,27 +402,28 @@ async def _sse_send_and_receive_inner(
     post_endpoint = None
 
     async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
-        async with client.stream("GET", sse_url, headers=headers, follow_redirects=True) as stream:
-            if stream.status_code == 401:
-                raise PermissionError("MCP server returned 401 Unauthorized")
-            if stream.status_code >= 400:
-                await stream.aread()
-                raise httpx.HTTPStatusError(
-                    f"SSE connection failed with {stream.status_code}",
-                    request=stream._request,
-                    response=httpx.Response(stream.status_code),
-                )
+        with _patch_resolution(parsed.hostname, parsed.port or (443 if parsed.scheme == 'https' else 80)):
+            async with client.stream("GET", sse_url, headers=headers, follow_redirects=False) as stream:
+                if stream.status_code == 401:
+                    raise PermissionError("MCP server returned 401 Unauthorized")
+                if stream.status_code >= 400:
+                    await stream.aread()
+                    raise httpx.HTTPStatusError(
+                        f"SSE connection failed with {stream.status_code}",
+                        request=stream._request,
+                        response=httpx.Response(stream.status_code),
+                    )
 
-            logger.info(f"[MCP SSE] Connected to {sse_url}, status={stream.status_code}")
-            buf = ""
-            event_type = ""
-            event_data_lines: list[str] = []
+                logger.info(f"[MCP SSE] Connected to {sse_url}, status={stream.status_code}")
+                buf = ""
+                event_type = ""
+                event_data_lines: list[str] = []
 
-            async for raw_chunk in stream.aiter_text():
-                buf += raw_chunk
-                while "\n" in buf:
-                    line, buf = buf.split("\n", 1)
-                    line = line.rstrip("\r")
+                async for raw_chunk in stream.aiter_text():
+                    buf += raw_chunk
+                    while "\n" in buf:
+                        line, buf = buf.split("\n", 1)
+                        line = line.rstrip("\r")
 
                     if line.startswith("event:"):
                         event_type = line[6:].strip()
@@ -363,19 +440,25 @@ async def _sse_send_and_receive_inner(
                                 post_endpoint = data_str
                             else:
                                 post_endpoint = origin + data_str
+                            validate_mcp_server_url(post_endpoint)
                             logger.info(f"[MCP SSE] Got endpoint: {sanitize(post_endpoint)}")
 
                             # Now send all payloads
                             post_headers = {"Content-Type": "application/json"}
                             if access_token:
                                 post_headers["Authorization"] = f"Bearer {access_token}"
-                            for payload in payloads:
-                                await client.post(
-                                    post_endpoint,
-                                    json=payload,
-                                    headers=post_headers,
-                                    follow_redirects=True,
-                                )
+                            post_parsed = urlparse(post_endpoint)
+                            with _patch_resolution(
+                                post_parsed.hostname,
+                                post_parsed.port or (443 if post_parsed.scheme == 'https' else 80),
+                            ):
+                                for payload in payloads:
+                                    await client.post(
+                                        post_endpoint,
+                                        json=payload,
+                                        headers=post_headers,
+                                        follow_redirects=False,
+                                    )
 
                         elif event_type == "message" and data_str:
                             try:


### PR DESCRIPTION
## Summary
- reject private, loopback, link-local, and other non-public MCP server targets during app onboarding and MCP/OAuth discovery
- disable redirect following on outbound MCP/OAuth requests so discovery cannot be redirected into internal network targets
- pin DNS resolution during outbound MCP/OAuth requests to close the pre-validation vs connect-time rebinding gap
- add focused unit coverage for MCP SSRF guard behavior

## Security issues covered

| issue | impact | severity |
| --- | --- | --- |
| Authenticated SSRF via MCP server onboarding / discovery | A normal authenticated user could supply an attacker-controlled `mcp_server_url` and make the backend perform server-side GET/POST requests to internal or link-local services during OAuth metadata discovery and MCP tool discovery | High |

## Before this PR
- `POST /v1/apps/mcp` accepted an arbitrary `mcp_server_url`
- the backend immediately used that URL for server-side OAuth metadata discovery and MCP tool discovery
- outbound MCP/OAuth requests followed redirects
- there was no guard rejecting loopback, link-local, RFC1918, reserved, or other non-public destinations on the MCP path
- there was no connect-time resolution pinning, so validation and actual connection could drift

## After this PR
- MCP server URLs are validated before onboarding proceeds
- non-public destinations are rejected before any outbound MCP/OAuth request is sent
- redirect following is disabled on outbound MCP/OAuth requests
- outbound MCP/OAuth requests pin DNS resolution for the target host/port during the actual request path
- focused regression tests lock in the blocked-target behavior

## Why this matters
The MCP app onboarding flow is not a passive URL-storage feature. It actively performs server-side network requests to user-supplied MCP endpoints during onboarding and refresh. Without SSRF controls, an authenticated user can try to make the Omi backend talk to internal HTTP services, cloud metadata endpoints, or other network-reachable control-plane surfaces from the server context.

## Attack flow

```text
authenticated user-supplied mcp_server_url
    -> /v1/apps/mcp add_mcp_server()
        -> OAuth metadata discovery / MCP tool discovery
            -> server-side GET/POST to attacker-chosen target
                -> SSRF against internal or link-local services
```

## Affected code

| area | files |
| --- | --- |
| MCP onboarding entrypoint | `backend/routers/apps.py` |
| MCP/OAuth outbound client logic | `backend/utils/mcp_client.py` |
| regression coverage | `backend/tests/unit/test_mcp_ssrf_guard.py` |

## Root cause
- the onboarding flow treated `mcp_server_url` as a trusted outbound destination even though it is user-controlled
- the MCP/OAuth helper layer performed direct server-side network requests without rejecting non-public destinations on this path
- redirect following widened the reachable sink set
- there was no connect-time pinning to keep actual socket resolution aligned with validated resolution results

## CVSS assessment

| issue | CVSS v3.1 | vector |
| --- | --- | --- |
| Authenticated SSRF via MCP onboarding | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L` |

Rationale:
- reachable by a normal authenticated user
- server-side network position can expose metadata/internal services not otherwise reachable by the attacker
- impact depends on what internal services are reachable from the deployment environment

## Safe reproduction steps
1. Authenticate as a normal user.
2. Submit `POST /v1/apps/mcp` with a non-public `mcp_server_url`, for example a loopback, RFC1918, or link-local target.
3. Observe pre-fix behavior: the backend attempts OAuth metadata discovery and/or MCP tool discovery against the supplied target.
4. Observe patched behavior: the request is rejected with a validation error before outbound discovery proceeds.

## Expected vulnerable behavior
- the backend issues server-side requests to attacker-chosen MCP targets during onboarding or refresh
- internal or link-local destinations are not rejected on this path
- redirects can widen the effective destination set

## Changes in this PR
- added MCP URL validation in the `/v1/apps/mcp` onboarding path
- added reusable outbound MCP/OAuth target validation in `utils/mcp_client.py`
- disabled redirect following for OAuth metadata discovery, client registration, token exchange, token refresh, MCP JSON-RPC requests, and SSE transport requests
- pinned DNS resolution during outbound requests to keep the actual connection aligned with the validated host/port resolution
- added unit tests covering blocked MCP targets and early rejection before network use

## Files changed

| category | files | change |
| --- | --- | --- |
| route hardening | `backend/routers/apps.py` | rejects unsafe `mcp_server_url` values at create time |
| client hardening | `backend/utils/mcp_client.py` | validates outbound MCP/OAuth URLs, disables redirects, pins resolution during requests |
| tests | `backend/tests/unit/test_mcp_ssrf_guard.py` | regression tests for blocked internal/link-local targets |

## Maintainer impact
- narrow patch scoped to MCP onboarding / discovery
- does not change unrelated webhook or app-store flows
- preserves normal public MCP server onboarding while rejecting clearly unsafe backend network targets

## Fix rationale
The secure default here is to treat MCP onboarding URLs as untrusted outbound destinations. Omi should only connect to publicly routable MCP/OAuth endpoints on this path, and it should not follow redirects into a different trust zone. The patch keeps the feature intact for legitimate public MCP servers while closing an internal-network SSRF path.

## Type of change
- [x] Security fix
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

## Test plan
- [x] Added regression tests for blocked link-local, loopback, and RFC1918 MCP targets
- [x] Verified early rejection before outbound MCP/OAuth request methods are called
- [x] Python syntax check passed for changed files
- [x] Independent reviewer pass after addressing SSE endpoint resolution pinning concern

Commands run:
- `python3 -m py_compile backend/utils/mcp_client.py backend/routers/apps.py backend/tests/unit/test_mcp_ssrf_guard.py`
- `python3 -m pytest backend/tests/unit/test_mcp_ssrf_guard.py -q`

## Disclosure notes
- I did not find a public Omi issue/PR that already documented this exact MCP onboarding SSRF path.
- Related public SSRF hardening work exists in other Omi surfaces, but this MCP path appears distinct.
