### PR TITLE
Fix BYOK security flaws: ContextVar, cache, Gemini, WebSocket, validation

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -43,6 +43,7 @@ from utils.llm.goals import extract_and_update_goal_progress
 from database.redis_db import try_acquire_goal_extraction_lock, check_rate_limit, store_chat_share, get_chat_share
 from database.users import set_chat_message_rating_score
 from utils.rate_limit_config import get_effective_limit, RATE_LIMIT_SHADOW
+from utils.byok import validate_byok_request
 from utils.subscription import enforce_chat_quota
 from utils.other import endpoints as auth, storage
 from utils.other.chat_file import FileChatTool
@@ -97,6 +98,11 @@ def send_message(
     app_id: Optional[str] = None,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "chat:send_message")),
 ):
+    # Validate BYOK keys against Firestore enrollment BEFORE quota check.
+    # For BYOK-active users: headers must be present and match fingerprints.
+    # For non-BYOK users: any BYOK headers are silently cleared.
+    validate_byok_request(uid)
+
     # Hard cap: Free/Plus by question count, Pro by cost_usd. Raises 402 with a
     # structured body the client can use to render the upgrade modal.
     enforce_chat_quota(uid)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -43,7 +43,6 @@ from utils.llm.goals import extract_and_update_goal_progress
 from database.redis_db import try_acquire_goal_extraction_lock, check_rate_limit, store_chat_share, get_chat_share
 from database.users import set_chat_message_rating_score
 from utils.rate_limit_config import get_effective_limit, RATE_LIMIT_SHADOW
-from utils.byok import validate_byok_request
 from utils.subscription import enforce_chat_quota
 from utils.other import endpoints as auth, storage
 from utils.other.chat_file import FileChatTool
@@ -98,13 +97,9 @@ def send_message(
     app_id: Optional[str] = None,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "chat:send_message")),
 ):
-    # Validate BYOK keys against Firestore enrollment BEFORE quota check.
-    # For BYOK-active users: headers must be present and match fingerprints.
-    # For non-BYOK users: any BYOK headers are silently cleared.
-    validate_byok_request(uid)
-
     # Hard cap: Free/Plus by question count, Pro by cost_usd. Raises 402 with a
     # structured body the client can use to render the upgrade modal.
+    # (BYOK validation already ran in get_current_user_uid dependency.)
     enforce_chat_quota(uid)
 
     compat_app_id = app_id or plugin_id

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -36,7 +36,7 @@ from utils.speaker_assignment import (
 import database.conversations as conversations_db
 import database.calendar_meetings as calendar_db
 import database.users as user_db
-from utils.byok import get_byok_keys, extract_byok_from_websocket, set_byok_keys, validate_byok_websocket
+from utils.byok import get_byok_keys
 from database.users import get_user_transcription_preferences
 from database import redis_db
 from database.redis_db import check_credits_invalidation
@@ -235,24 +235,6 @@ async def _stream_handler(
     logger.info(
         f'_stream_handler {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode}'
     )
-
-    # BaseHTTPMiddleware skips WebSocket scope, so extract BYOK headers manually.
-    # This ensures Deepgram streaming and pusher-forwarded LLM calls use the
-    # user's own keys when set.
-    byok_ws_keys = extract_byok_from_websocket(websocket)
-    if byok_ws_keys:
-        set_byok_keys(byok_ws_keys)
-
-    # Validate BYOK keys against Firestore enrollment.
-    # BYOK-active users MUST send keys matching their enrolled fingerprints.
-    # Non-BYOK users' headers are silently cleared.
-    byok_error = validate_byok_websocket(uid)
-    if byok_error:
-        logger.warning(f'_stream_handler BYOK validation failed {uid}: {byok_error}')
-        await websocket.send_json({'error': byok_error})
-        await websocket.close(code=4003)
-        BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
-        return
 
     use_custom_stt = custom_stt_mode == CustomSttMode.enabled
     is_multi_channel = channels >= 2

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -36,7 +36,7 @@ from utils.speaker_assignment import (
 import database.conversations as conversations_db
 import database.calendar_meetings as calendar_db
 import database.users as user_db
-from utils.byok import get_byok_keys
+from utils.byok import get_byok_keys, extract_byok_from_websocket, set_byok_keys
 from database.users import get_user_transcription_preferences
 from database import redis_db
 from database.redis_db import check_credits_invalidation
@@ -235,6 +235,13 @@ async def _stream_handler(
     logger.info(
         f'_stream_handler {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode}'
     )
+
+    # BaseHTTPMiddleware skips WebSocket scope, so extract BYOK headers manually.
+    # This ensures Deepgram streaming and pusher-forwarded LLM calls use the
+    # user's own keys when set.
+    byok_ws_keys = extract_byok_from_websocket(websocket)
+    if byok_ws_keys:
+        set_byok_keys(byok_ws_keys)
 
     use_custom_stt = custom_stt_mode == CustomSttMode.enabled
     is_multi_channel = channels >= 2

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -36,7 +36,7 @@ from utils.speaker_assignment import (
 import database.conversations as conversations_db
 import database.calendar_meetings as calendar_db
 import database.users as user_db
-from utils.byok import get_byok_keys, extract_byok_from_websocket, set_byok_keys
+from utils.byok import get_byok_keys, extract_byok_from_websocket, set_byok_keys, validate_byok_websocket
 from database.users import get_user_transcription_preferences
 from database import redis_db
 from database.redis_db import check_credits_invalidation
@@ -242,6 +242,17 @@ async def _stream_handler(
     byok_ws_keys = extract_byok_from_websocket(websocket)
     if byok_ws_keys:
         set_byok_keys(byok_ws_keys)
+
+    # Validate BYOK keys against Firestore enrollment.
+    # BYOK-active users MUST send keys matching their enrolled fingerprints.
+    # Non-BYOK users' headers are silently cleared.
+    byok_error = validate_byok_websocket(uid)
+    if byok_error:
+        logger.warning(f'_stream_handler BYOK validation failed {uid}: {byok_error}')
+        await websocket.send_json({'error': byok_error})
+        await websocket.close(code=4003)
+        BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
+        return
 
     use_custom_stt = custom_stt_mode == CustomSttMode.enabled
     is_multi_channel = channels >= 2

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -91,6 +91,7 @@ from utils.other.storage import (
 )
 from utils.webhooks import webhook_first_time_setup
 from database.action_items import get_action_items as get_standalone_action_items
+from utils.byok import has_byok_keys, invalidate_byok_state_cache
 import logging
 
 logger = logging.getLogger(__name__)
@@ -792,8 +793,6 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
                 status_code=400, detail=f"Invalid fingerprint for {provider}: expected lowercase hex SHA-256 (64 chars)"
             )
     users_db.set_byok_active(uid, data.fingerprints)
-    from utils.byok import invalidate_byok_state_cache
-
     invalidate_byok_state_cache(uid)
     return {"active": True}
 
@@ -802,8 +801,6 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
 def deactivate_byok_endpoint(uid: str = Depends(auth.get_current_user_uid)):
     """Drop the user off the BYOK free plan (keys were cleared client-side)."""
     users_db.clear_byok_active(uid)
-    from utils.byok import invalidate_byok_state_cache
-
     invalidate_byok_state_cache(uid)
     return {"active": False}
 
@@ -833,8 +830,6 @@ def get_user_subscription_endpoint(
     # BYOK free plan: user supplies their own OpenAI/Anthropic/Gemini/Deepgram keys.
     # Only return unlimited when the request actually carries BYOK headers (desktop).
     # Mobile (no BYOK headers) should see the real subscription even if BYOK is active.
-    from utils.byok import has_byok_keys
-
     if users_db.is_byok_active(uid) and has_byok_keys():
         return UserSubscriptionResponse(
             subscription=_byok_unlimited_subscription(),

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1,4 +1,5 @@
 import json
+import re
 import threading
 import uuid
 from typing import List, Dict, Any, Union, Optional
@@ -759,6 +760,10 @@ def get_user_usage_stats_endpoint(
     return stats
 
 
+_SHA256_HEX_RE = re.compile(r'^[a-f0-9]{64}$')
+_BYOK_REQUIRED_PROVIDERS = {'openai', 'anthropic', 'gemini', 'deepgram'}
+
+
 class BYOKActivateRequest(BaseModel):
     fingerprints: Dict[str, str]
 
@@ -771,13 +776,19 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
     detect rotation without ever seeing the keys. The live keys themselves
     travel on every request as headers; they are never persisted.
     """
-    required = {'openai', 'anthropic', 'gemini', 'deepgram'}
-    missing = required - set(data.fingerprints.keys())
+    missing = _BYOK_REQUIRED_PROVIDERS - set(data.fingerprints.keys())
     if missing:
         raise HTTPException(
             status_code=400,
             detail=f"Missing fingerprints for providers: {sorted(missing)}",
         )
+    for provider, fp in data.fingerprints.items():
+        if provider not in _BYOK_REQUIRED_PROVIDERS:
+            raise HTTPException(status_code=400, detail=f"Unknown provider: {provider}")
+        if not _SHA256_HEX_RE.match(fp):
+            raise HTTPException(
+                status_code=400, detail=f"Invalid fingerprint for {provider}: expected lowercase hex SHA-256 (64 chars)"
+            )
     users_db.set_byok_active(uid, data.fingerprints)
     return {"active": True}
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -792,6 +792,9 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
                 status_code=400, detail=f"Invalid fingerprint for {provider}: expected lowercase hex SHA-256 (64 chars)"
             )
     users_db.set_byok_active(uid, data.fingerprints)
+    from utils.byok import invalidate_byok_state_cache
+
+    invalidate_byok_state_cache(uid)
     return {"active": True}
 
 
@@ -799,6 +802,9 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
 def deactivate_byok_endpoint(uid: str = Depends(auth.get_current_user_uid)):
     """Drop the user off the BYOK free plan (keys were cleared client-side)."""
     users_db.clear_byok_active(uid)
+    from utils.byok import invalidate_byok_state_cache
+
+    invalidate_byok_state_cache(uid)
     return {"active": False}
 
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -55,7 +55,9 @@ from models.users import (
     ChatQuotaUnit,
     WebhookType,
     UserSubscriptionResponse,
+    Subscription,
     SubscriptionPlan,
+    SubscriptionStatus,
     PlanType,
     PricingOption,
 )

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -772,7 +772,7 @@ class BYOKActivateRequest(BaseModel):
 
 
 @router.post('/v1/users/me/byok-active', tags=['v1'])
-def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.get_current_user_uid)):
+def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.get_current_user_uid_no_byok_validation)):
     """Flip the user onto the BYOK free plan.
 
     The client sends SHA-256 fingerprints of the 4 provider keys so we can
@@ -798,7 +798,7 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
 
 
 @router.delete('/v1/users/me/byok-active', tags=['v1'])
-def deactivate_byok_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def deactivate_byok_endpoint(uid: str = Depends(auth.get_current_user_uid_no_byok_validation)):
     """Drop the user off the BYOK free plan (keys were cleared client-side)."""
     users_db.clear_byok_active(uid)
     invalidate_byok_state_cache(uid)

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -831,8 +831,11 @@ def get_user_subscription_endpoint(
 ):
     """Gets the user's subscription plan and usage."""
     # BYOK free plan: user supplies their own OpenAI/Anthropic/Gemini/Deepgram keys.
-    # Skip Stripe entirely and return an unlimited plan tagged with the `byok` feature.
-    if users_db.is_byok_active(uid):
+    # Only return unlimited when the request actually carries BYOK headers (desktop).
+    # Mobile (no BYOK headers) should see the real subscription even if BYOK is active.
+    from utils.byok import has_byok_keys
+
+    if users_db.is_byok_active(uid) and has_byok_keys():
         return UserSubscriptionResponse(
             subscription=_byok_unlimited_subscription(),
             transcription_seconds_used=0,
@@ -1038,6 +1041,21 @@ def get_user_chat_usage_quota(uid: str = Depends(auth.get_current_user_uid)):
 
     Used by the desktop app. Mobile uses the subscription endpoint instead.
     """
+    # BYOK free plan: user brings their own keys, so there's no Omi-side cost
+    # to meter. Only return unlimited when BYOK headers are on the request (desktop).
+    # Mobile (no headers) should see real quota.
+    if users_db.is_byok_active(uid) and has_byok_keys():
+        return ChatUsageQuota(
+            plan='Free (BYOK)',
+            plan_type=PlanType.unlimited.value,
+            unit=ChatQuotaUnit.questions,
+            used=0.0,
+            limit=None,
+            percent=0.0,
+            allowed=True,
+            reset_at=None,
+        )
+
     snapshot = get_chat_quota_snapshot(uid)
     plan = snapshot['plan']
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -102,6 +102,7 @@ pytest tests/unit/test_thread_join_elimination.py -v
 pytest tests/unit/test_async_http_infrastructure.py -v
 pytest tests/unit/test_clean_sweep_migrations.py -v
 pytest tests/unit/test_omi_qos_tiers.py -v
+pytest tests/unit/test_byok_security.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -447,3 +447,231 @@ class TestBoundedCache:
 
         assert hasattr(_anthropic_cache, 'ttl')
         assert _anthropic_cache.ttl > 0
+
+
+# ---------------------------------------------------------------------------
+# 10. BYOK activation endpoint validation
+# ---------------------------------------------------------------------------
+
+
+class TestBYOKActivationValidation:
+    """Test the validation logic used by activate_byok_endpoint.
+
+    The endpoint module (routers.users) triggers GCS storage.Client() on import,
+    which requires GCP credentials. Instead of mocking the entire import chain,
+    we test the validation functions directly: the regex, the provider set, and
+    the boundary cases are the same constants the endpoint uses.
+    """
+
+    _REQUIRED_PROVIDERS = {'openai', 'anthropic', 'gemini', 'deepgram'}
+
+    def _valid_fingerprints(self) -> Dict[str, str]:
+        return {
+            'openai': hashlib.sha256(b'sk-openai').hexdigest(),
+            'anthropic': hashlib.sha256(b'sk-anthropic').hexdigest(),
+            'gemini': hashlib.sha256(b'sk-gemini').hexdigest(),
+            'deepgram': hashlib.sha256(b'sk-deepgram').hexdigest(),
+        }
+
+    def _validate(self, fingerprints: Dict[str, str]) -> str | None:
+        """Replicate the validation logic from activate_byok_endpoint."""
+        missing = self._REQUIRED_PROVIDERS - set(fingerprints.keys())
+        if missing:
+            return f"Missing fingerprints for providers: {sorted(missing)}"
+        for provider, fp in fingerprints.items():
+            if provider not in self._REQUIRED_PROVIDERS:
+                return f"Unknown provider: {provider}"
+            if not _SHA256_HEX_RE.match(fp):
+                return f"Invalid fingerprint for {provider}"
+        return None
+
+    def test_valid_fingerprints_pass(self):
+        assert self._validate(self._valid_fingerprints()) is None
+
+    def test_missing_provider_rejects(self):
+        fps = self._valid_fingerprints()
+        del fps['deepgram']
+        err = self._validate(fps)
+        assert err is not None
+        assert 'deepgram' in err
+
+    def test_unknown_provider_rejects(self):
+        fps = self._valid_fingerprints()
+        fps['unknown_provider'] = hashlib.sha256(b'x').hexdigest()
+        err = self._validate(fps)
+        assert err is not None
+        assert 'Unknown provider' in err
+
+    def test_63_char_fingerprint_rejects(self):
+        fps = self._valid_fingerprints()
+        fps['openai'] = 'a' * 63
+        err = self._validate(fps)
+        assert err is not None
+        assert 'Invalid fingerprint' in err
+
+    def test_64_char_valid_hex_passes(self):
+        fps = self._valid_fingerprints()
+        fps['openai'] = 'a' * 64  # valid: 64 hex chars
+        assert self._validate(fps) is None
+
+    def test_65_char_fingerprint_rejects(self):
+        fps = self._valid_fingerprints()
+        fps['openai'] = 'a' * 65
+        err = self._validate(fps)
+        assert err is not None
+        assert 'Invalid fingerprint' in err
+
+    def test_empty_fingerprints_rejects(self):
+        err = self._validate({})
+        assert err is not None
+        assert 'Missing fingerprints' in err
+
+
+# ---------------------------------------------------------------------------
+# 11. Cache routing: raw keys never in cache keys
+# ---------------------------------------------------------------------------
+
+
+class TestCacheRouting:
+    def test_cached_openai_chat_no_raw_key_in_cache(self):
+        from utils.llm.clients import _cached_openai_chat, _openai_cache
+
+        api_key = 'sk-secret-openai-key-for-cache-test'
+        _cached_openai_chat('gpt-4.1-mini', api_key, {})
+        for k in _openai_cache.keys():
+            assert api_key not in k, f"Raw API key found in cache key: {k}"
+
+    def test_cached_openai_chat_returns_same_instance(self):
+        from utils.llm.clients import _cached_openai_chat
+
+        api_key = 'sk-deterministic-test-key'
+        inst1 = _cached_openai_chat('gpt-4.1-mini', api_key, {})
+        inst2 = _cached_openai_chat('gpt-4.1-mini', api_key, {})
+        assert inst1 is inst2
+
+    def test_cached_anthropic_no_raw_key_in_cache(self):
+        from utils.llm.clients import _anthropic_cache, _cached_anthropic
+
+        api_key = 'sk-ant-secret-key-for-cache-test'
+        _cached_anthropic(api_key)
+        for k in _anthropic_cache.keys():
+            assert api_key not in k, f"Raw API key found in cache key: {k}"
+
+    def test_cached_anthropic_returns_same_instance(self):
+        from utils.llm.clients import _cached_anthropic
+
+        api_key = 'sk-ant-deterministic-key'
+        inst1 = _cached_anthropic(api_key)
+        inst2 = _cached_anthropic(api_key)
+        assert inst1 is inst2
+
+    def test_anthropic_proxy_routes_to_byok(self):
+        from utils.llm.clients import _AnthropicViaOpenAIProxy, _ANTHROPIC_OPENAI_BASE_URL
+
+        mock_default = MagicMock()
+        proxy = _AnthropicViaOpenAIProxy(default=mock_default, ctor_kwargs={})
+        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'sk-ant-byok' if p == 'anthropic' else None):
+            resolved = proxy._resolve()
+        assert resolved.openai_api_base == _ANTHROPIC_OPENAI_BASE_URL
+
+    def test_anthropic_proxy_falls_back_to_default(self):
+        from utils.llm.clients import _AnthropicViaOpenAIProxy
+
+        mock_default = MagicMock()
+        proxy = _AnthropicViaOpenAIProxy(default=mock_default, ctor_kwargs={})
+        with patch('utils.llm.clients.get_byok_key', return_value=None):
+            resolved = proxy._resolve()
+        assert resolved is mock_default
+
+
+# ---------------------------------------------------------------------------
+# 12. Middleware dispatch: context isolation between requests
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareIsolation:
+    def test_two_contexts_isolated(self):
+        """Keys set in one context must not bleed into another."""
+        from utils.byok import get_byok_keys, set_byok_keys
+
+        ctx1 = copy_context()
+        ctx2 = copy_context()
+
+        ctx1.run(set_byok_keys, {'openai': 'key-a'})
+        result2 = ctx2.run(get_byok_keys)
+        assert result2 == {}, "Context 2 should not see keys from context 1"
+
+    def test_context_reset_clears_keys(self):
+        """After ContextVar.reset(), keys from previous set are gone."""
+        from utils.byok import _byok_ctx, get_byok_keys
+
+        ctx = copy_context()
+
+        def _run():
+            token = _byok_ctx.set({'openai': 'temp-key'})
+            assert get_byok_keys() == {'openai': 'temp-key'}
+            _byok_ctx.reset(token)
+            assert get_byok_keys() == {}
+
+        ctx.run(_run)
+
+
+# ---------------------------------------------------------------------------
+# 13. Quota boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestQuotaBoundaryTests:
+    @patch('utils.byok.get_byok_key')
+    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
+    @patch('utils.subscription.users_db')
+    def test_chat_quota_bypasses_with_anthropic_key_only(self, mock_users_db, mock_get_key):
+        """Anthropic-only BYOK should also bypass chat quota."""
+        mock_users_db.is_byok_active.return_value = True
+        mock_get_key.side_effect = lambda p: 'sk-ant-byok' if p == 'anthropic' else None
+        from utils.subscription import enforce_chat_quota
+
+        enforce_chat_quota('anthropic-byok-uid')  # Should not raise
+
+    @patch('utils.byok.get_byok_key', return_value=None)
+    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
+    @patch('utils.subscription.users_db')
+    @patch('utils.subscription.get_chat_quota_snapshot')
+    def test_chat_quota_at_exact_limit(self, mock_snapshot, mock_users_db, _mock_get_key):
+        """Usage exactly at limit should be rejected."""
+        from models.users import PlanType
+
+        mock_users_db.is_byok_active.return_value = False
+        mock_snapshot.return_value = {
+            'plan': PlanType.basic,
+            'unit': 'questions',
+            'used': 30,
+            'limit': 30,
+            'allowed': False,
+            'reset_at': '2026-05-01',
+        }
+        from fastapi import HTTPException
+        from utils.subscription import enforce_chat_quota
+
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_chat_quota('at-limit-uid')
+        assert exc_info.value.status_code == 402
+
+    @patch('utils.byok.get_byok_key', return_value=None)
+    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
+    @patch('utils.subscription.users_db')
+    @patch('utils.subscription.get_chat_quota_snapshot')
+    def test_chat_quota_just_below_limit(self, mock_snapshot, mock_users_db, _mock_get_key):
+        """Usage below limit should pass."""
+        mock_users_db.is_byok_active.return_value = False
+        mock_snapshot.return_value = {
+            'plan': 'basic',
+            'unit': 'questions',
+            'used': 29,
+            'limit': 30,
+            'allowed': True,
+            'reset_at': '2026-05-01',
+        }
+        from utils.subscription import enforce_chat_quota
+
+        enforce_chat_quota('below-limit-uid')  # Should not raise

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -1,0 +1,384 @@
+"""Tests for BYOK security fixes (issue #6880).
+
+Covers: fingerprint validation, ContextVar safety, WebSocket extraction,
+cache key hashing, Gemini URL key removal, quota bypass consistency.
+"""
+
+import hashlib
+import os
+import re
+import sys
+from contextvars import copy_context
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level stubs: prevent Firestore/Redis init on import
+# ---------------------------------------------------------------------------
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-for-unit-tests')
+os.environ.setdefault('DEEPGRAM_API_KEY', 'dg-test-fake-for-unit-tests')
+os.environ.setdefault('GOOGLE_API_KEY', 'goog-test-fake-for-unit-tests')
+os.environ.setdefault('ANTHROPIC_API_KEY', 'ant-test-fake-for-unit-tests')
+
+sys.modules.setdefault('database._client', MagicMock())
+sys.modules.setdefault('database.redis_db', MagicMock())
+sys.modules.setdefault('database.users', MagicMock())
+sys.modules.setdefault('database.user_usage', MagicMock())
+sys.modules.setdefault('database.llm_usage', MagicMock())
+sys.modules.setdefault('database.announcements', MagicMock())
+
+import warnings
+
+warnings.filterwarnings('ignore', message='.*stream_options.*')
+
+
+# ---------------------------------------------------------------------------
+# 1. ContextVar safety: default is None, not a shared mutable dict
+# ---------------------------------------------------------------------------
+
+
+class TestContextVarSafety:
+    def test_default_is_none(self):
+        from utils.byok import _byok_ctx
+
+        assert _byok_ctx.get() is None
+
+    def test_get_byok_keys_returns_empty_dict_by_default(self):
+        from utils.byok import get_byok_keys
+
+        ctx = copy_context()
+        result = ctx.run(get_byok_keys)
+        assert result == {}
+
+    def test_get_byok_key_returns_none_by_default(self):
+        from utils.byok import get_byok_key
+
+        ctx = copy_context()
+        result = ctx.run(get_byok_key, 'openai')
+        assert result is None
+
+    def test_set_and_get_keys(self):
+        from utils.byok import get_byok_keys, set_byok_keys
+
+        ctx = copy_context()
+
+        def _run():
+            set_byok_keys({'openai': 'sk-test', 'deepgram': 'dg-test'})
+            keys = get_byok_keys()
+            assert keys == {'openai': 'sk-test', 'deepgram': 'dg-test'}
+
+        ctx.run(_run)
+
+    def test_set_filters_empty_values(self):
+        from utils.byok import get_byok_keys, set_byok_keys
+
+        ctx = copy_context()
+
+        def _run():
+            set_byok_keys({'openai': 'sk-test', 'anthropic': '', 'gemini': None})
+            keys = get_byok_keys()
+            assert 'openai' in keys
+            assert 'anthropic' not in keys
+            assert 'gemini' not in keys
+
+        ctx.run(_run)
+
+    def test_has_byok_keys(self):
+        from utils.byok import has_byok_keys, set_byok_keys
+
+        ctx = copy_context()
+
+        def _run():
+            assert not has_byok_keys()
+            set_byok_keys({'openai': 'sk-test'})
+            assert has_byok_keys()
+
+        ctx.run(_run)
+
+
+# ---------------------------------------------------------------------------
+# 2. WebSocket BYOK extraction
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketExtraction:
+    def _make_ws(self, headers: Dict[str, str]) -> MagicMock:
+        ws = MagicMock()
+        ws.headers = headers
+        return ws
+
+    def test_extracts_all_four_headers(self):
+        from utils.byok import extract_byok_from_websocket
+
+        ws = self._make_ws(
+            {
+                'x-byok-openai': 'sk-o',
+                'x-byok-anthropic': 'sk-a',
+                'x-byok-gemini': 'sk-g',
+                'x-byok-deepgram': 'sk-d',
+            }
+        )
+        keys = extract_byok_from_websocket(ws)
+        assert keys == {'openai': 'sk-o', 'anthropic': 'sk-a', 'gemini': 'sk-g', 'deepgram': 'sk-d'}
+
+    def test_returns_empty_when_no_headers(self):
+        from utils.byok import extract_byok_from_websocket
+
+        ws = self._make_ws({})
+        keys = extract_byok_from_websocket(ws)
+        assert keys == {}
+
+    def test_partial_headers(self):
+        from utils.byok import extract_byok_from_websocket
+
+        ws = self._make_ws({'x-byok-deepgram': 'dg-key'})
+        keys = extract_byok_from_websocket(ws)
+        assert keys == {'deepgram': 'dg-key'}
+
+    def test_ignores_unknown_headers(self):
+        from utils.byok import extract_byok_from_websocket
+
+        ws = self._make_ws({'x-byok-unknown': 'val', 'x-byok-openai': 'sk-o'})
+        keys = extract_byok_from_websocket(ws)
+        assert keys == {'openai': 'sk-o'}
+
+
+# ---------------------------------------------------------------------------
+# 3. Fingerprint validation
+# ---------------------------------------------------------------------------
+
+_SHA256_HEX_RE = re.compile(r'^[a-f0-9]{64}$')
+
+
+class TestFingerprintValidation:
+    def _valid_fingerprints(self) -> Dict[str, str]:
+        return {
+            'openai': hashlib.sha256(b'sk-test-openai').hexdigest(),
+            'anthropic': hashlib.sha256(b'sk-test-anthropic').hexdigest(),
+            'gemini': hashlib.sha256(b'sk-test-gemini').hexdigest(),
+            'deepgram': hashlib.sha256(b'sk-test-deepgram').hexdigest(),
+        }
+
+    def test_valid_fingerprints_match_regex(self):
+        for provider, fp in self._valid_fingerprints().items():
+            assert _SHA256_HEX_RE.match(fp), f"Valid fingerprint for {provider} should match"
+
+    def test_empty_string_rejected(self):
+        assert not _SHA256_HEX_RE.match('')
+
+    def test_short_hex_rejected(self):
+        assert not _SHA256_HEX_RE.match('abcdef0123456789')
+
+    def test_uppercase_rejected(self):
+        fp = hashlib.sha256(b'test').hexdigest().upper()
+        assert not _SHA256_HEX_RE.match(fp)
+
+    def test_non_hex_rejected(self):
+        assert not _SHA256_HEX_RE.match('g' * 64)
+
+    def test_arbitrary_string_rejected(self):
+        assert not _SHA256_HEX_RE.match('x')
+        assert not _SHA256_HEX_RE.match('fake-fingerprint')
+
+
+# ---------------------------------------------------------------------------
+# 4. Cache key hashing
+# ---------------------------------------------------------------------------
+
+
+class TestCacheKeyHashing:
+    def test_hash_key_returns_sha256(self):
+        from utils.llm.clients import _hash_key
+
+        key = 'sk-test-key-12345'
+        result = _hash_key(key)
+        expected = hashlib.sha256(key.encode()).hexdigest()
+        assert result == expected
+
+    def test_hash_key_is_deterministic(self):
+        from utils.llm.clients import _hash_key
+
+        assert _hash_key('abc') == _hash_key('abc')
+
+    def test_hash_key_differs_for_different_inputs(self):
+        from utils.llm.clients import _hash_key
+
+        assert _hash_key('key-a') != _hash_key('key-b')
+
+    def test_openai_cache_uses_hashed_key(self):
+        """Verify the cache key format uses _hash_key, not raw api_key or hash()."""
+        from utils.llm.clients import _hash_key
+
+        api_key = 'sk-secret-key'
+        hashed = _hash_key(api_key)
+        cache_key_fragment = f"gpt-4.1-mini:{hashed}:"
+        assert hashed in cache_key_fragment
+        assert api_key not in cache_key_fragment
+
+    def test_anthropic_cache_does_not_store_raw_key(self):
+        """Verify _cached_anthropic uses _hash_key for cache lookup."""
+        from utils.llm.clients import _anthropic_cache, _hash_key
+
+        api_key = 'sk-ant-test-key-for-cache-test'
+        hashed = _hash_key(api_key)
+        assert api_key not in _anthropic_cache
+
+
+# ---------------------------------------------------------------------------
+# 5. Gemini embed: key not in URL
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiKeyNotInUrl:
+    @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_gemini_embed_uses_header_not_url_param(self, mock_byok, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'embedding': {'values': [0.1, 0.2]}}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        from utils.llm.clients import gemini_embed_query
+
+        gemini_embed_query('test query')
+
+        call_args = mock_post.call_args
+        url = call_args[0][0] if call_args[0] else call_args[1].get('url', '')
+        assert '?key=' not in url
+        assert 'key=' not in url
+        headers = call_args[1].get('headers', {})
+        assert 'x-goog-api-key' in headers
+
+    @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients.get_byok_key', return_value='user-gemini-key-secret')
+    def test_byok_gemini_key_not_in_url(self, mock_byok, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'embedding': {'values': [0.1, 0.2]}}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        from utils.llm.clients import gemini_embed_query
+
+        gemini_embed_query('test query')
+
+        call_args = mock_post.call_args
+        url = call_args[0][0] if call_args[0] else call_args[1].get('url', '')
+        assert 'user-gemini-key-secret' not in url
+        headers = call_args[1].get('headers', {})
+        assert headers.get('x-goog-api-key') == 'user-gemini-key-secret'
+
+
+# ---------------------------------------------------------------------------
+# 6. Chat quota BYOK bypass
+# ---------------------------------------------------------------------------
+
+
+class TestChatQuotaBYOKBypass:
+    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
+    @patch('utils.subscription.users_db')
+    def test_enforce_chat_quota_bypasses_for_byok(self, mock_users_db):
+        mock_users_db.is_byok_active.return_value = True
+        from utils.subscription import enforce_chat_quota
+
+        enforce_chat_quota('byok-user-uid')
+        mock_users_db.is_byok_active.assert_called_once_with('byok-user-uid')
+
+    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
+    @patch('utils.subscription.users_db')
+    @patch('utils.subscription.get_chat_quota_snapshot')
+    def test_enforce_chat_quota_still_enforces_for_non_byok(self, mock_snapshot, mock_users_db):
+        from models.users import PlanType
+
+        mock_users_db.is_byok_active.return_value = False
+        mock_snapshot.return_value = {
+            'plan': PlanType.basic,
+            'unit': 'questions',
+            'used': 31,
+            'limit': 30,
+            'allowed': False,
+            'reset_at': '2026-05-01',
+        }
+        from fastapi import HTTPException
+        from utils.subscription import enforce_chat_quota
+
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_chat_quota('non-byok-uid')
+        assert exc_info.value.status_code == 402
+
+
+# ---------------------------------------------------------------------------
+# 7. Transcription credit BYOK bypass
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptionCreditBYOKBypass:
+    @patch('utils.subscription.users_db')
+    def test_has_transcription_credits_bypasses_for_byok(self, mock_users_db):
+        mock_users_db.is_byok_active.return_value = True
+        from utils.subscription import has_transcription_credits
+
+        assert has_transcription_credits('byok-uid') is True
+
+    @patch('utils.subscription.users_db')
+    def test_remaining_seconds_is_none_for_byok(self, mock_users_db):
+        mock_users_db.is_byok_active.return_value = True
+        from utils.subscription import get_remaining_transcription_seconds
+
+        assert get_remaining_transcription_seconds('byok-uid') is None
+
+
+# ---------------------------------------------------------------------------
+# 8. BYOK headers constant is public and correct
+# ---------------------------------------------------------------------------
+
+
+class TestBYOKHeadersConstant:
+    def test_headers_has_all_four_providers(self):
+        from utils.byok import BYOK_HEADERS
+
+        assert set(BYOK_HEADERS.keys()) == {'openai', 'anthropic', 'gemini', 'deepgram'}
+
+    def test_headers_are_lowercase(self):
+        from utils.byok import BYOK_HEADERS
+
+        for header in BYOK_HEADERS.values():
+            assert header == header.lower()
+
+    def test_headers_start_with_x_byok(self):
+        from utils.byok import BYOK_HEADERS
+
+        for header in BYOK_HEADERS.values():
+            assert header.startswith('x-byok-')
+
+
+# ---------------------------------------------------------------------------
+# 9. Bounded cache behavior
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedCache:
+    def test_openai_cache_has_maxsize(self):
+        from utils.llm.clients import _openai_cache
+
+        assert hasattr(_openai_cache, 'maxsize')
+        assert _openai_cache.maxsize > 0
+
+    def test_anthropic_cache_has_maxsize(self):
+        from utils.llm.clients import _anthropic_cache
+
+        assert hasattr(_anthropic_cache, 'maxsize')
+        assert _anthropic_cache.maxsize > 0
+
+    def test_openai_cache_has_ttl(self):
+        from utils.llm.clients import _openai_cache
+
+        assert hasattr(_openai_cache, 'ttl')
+        assert _openai_cache.ttl > 0
+
+    def test_anthropic_cache_has_ttl(self):
+        from utils.llm.clients import _anthropic_cache
+
+        assert hasattr(_anthropic_cache, 'ttl')
+        assert _anthropic_cache.ttl > 0

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -21,6 +21,7 @@ os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-for-unit-tests')
 os.environ.setdefault('DEEPGRAM_API_KEY', 'dg-test-fake-for-unit-tests')
 os.environ.setdefault('GOOGLE_API_KEY', 'goog-test-fake-for-unit-tests')
 os.environ.setdefault('ANTHROPIC_API_KEY', 'ant-test-fake-for-unit-tests')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
 sys.modules.setdefault('database._client', MagicMock())
 sys.modules.setdefault('database.redis_db', MagicMock())
@@ -28,6 +29,7 @@ sys.modules.setdefault('database.users', MagicMock())
 sys.modules.setdefault('database.user_usage', MagicMock())
 sys.modules.setdefault('database.llm_usage', MagicMock())
 sys.modules.setdefault('database.announcements', MagicMock())
+sys.modules.setdefault('utils.other.storage', MagicMock())
 
 import warnings
 
@@ -455,15 +457,7 @@ class TestBoundedCache:
 
 
 class TestBYOKActivationValidation:
-    """Test the validation logic used by activate_byok_endpoint.
-
-    The endpoint module (routers.users) triggers GCS storage.Client() on import,
-    which requires GCP credentials. Instead of mocking the entire import chain,
-    we test the validation functions directly: the regex, the provider set, and
-    the boundary cases are the same constants the endpoint uses.
-    """
-
-    _REQUIRED_PROVIDERS = {'openai', 'anthropic', 'gemini', 'deepgram'}
+    """Test the actual activate_byok_endpoint and its production constants."""
 
     def _valid_fingerprints(self) -> Dict[str, str]:
         return {
@@ -473,58 +467,95 @@ class TestBYOKActivationValidation:
             'deepgram': hashlib.sha256(b'sk-deepgram').hexdigest(),
         }
 
-    def _validate(self, fingerprints: Dict[str, str]) -> str | None:
-        """Replicate the validation logic from activate_byok_endpoint."""
-        missing = self._REQUIRED_PROVIDERS - set(fingerprints.keys())
-        if missing:
-            return f"Missing fingerprints for providers: {sorted(missing)}"
-        for provider, fp in fingerprints.items():
-            if provider not in self._REQUIRED_PROVIDERS:
-                return f"Unknown provider: {provider}"
-            if not _SHA256_HEX_RE.match(fp):
-                return f"Invalid fingerprint for {provider}"
-        return None
+    @patch('routers.users.users_db')
+    def test_valid_activation_persists_fingerprints(self, mock_users_db):
+        from routers.users import BYOKActivateRequest, activate_byok_endpoint
 
-    def test_valid_fingerprints_pass(self):
-        assert self._validate(self._valid_fingerprints()) is None
+        fps = self._valid_fingerprints()
+        data = BYOKActivateRequest(fingerprints=fps)
+        result = activate_byok_endpoint(data, uid='test-uid')
+        assert result == {"active": True}
+        mock_users_db.set_byok_active.assert_called_once_with('test-uid', fps)
 
     def test_missing_provider_rejects(self):
+        from fastapi import HTTPException
+        from routers.users import BYOKActivateRequest, activate_byok_endpoint
+
         fps = self._valid_fingerprints()
         del fps['deepgram']
-        err = self._validate(fps)
-        assert err is not None
-        assert 'deepgram' in err
+        data = BYOKActivateRequest(fingerprints=fps)
+        with pytest.raises(HTTPException) as exc_info:
+            activate_byok_endpoint(data, uid='test-uid')
+        assert exc_info.value.status_code == 400
+        assert 'deepgram' in str(exc_info.value.detail)
 
     def test_unknown_provider_rejects(self):
+        from fastapi import HTTPException
+        from routers.users import BYOKActivateRequest, activate_byok_endpoint
+
         fps = self._valid_fingerprints()
         fps['unknown_provider'] = hashlib.sha256(b'x').hexdigest()
-        err = self._validate(fps)
-        assert err is not None
-        assert 'Unknown provider' in err
+        data = BYOKActivateRequest(fingerprints=fps)
+        with pytest.raises(HTTPException) as exc_info:
+            activate_byok_endpoint(data, uid='test-uid')
+        assert exc_info.value.status_code == 400
+        assert 'Unknown provider' in str(exc_info.value.detail)
 
     def test_63_char_fingerprint_rejects(self):
+        from fastapi import HTTPException
+        from routers.users import BYOKActivateRequest, activate_byok_endpoint
+
         fps = self._valid_fingerprints()
         fps['openai'] = 'a' * 63
-        err = self._validate(fps)
-        assert err is not None
-        assert 'Invalid fingerprint' in err
+        data = BYOKActivateRequest(fingerprints=fps)
+        with pytest.raises(HTTPException) as exc_info:
+            activate_byok_endpoint(data, uid='test-uid')
+        assert exc_info.value.status_code == 400
 
-    def test_64_char_valid_hex_passes(self):
+    @patch('routers.users.users_db')
+    def test_64_char_valid_hex_passes(self, mock_users_db):
+        from routers.users import BYOKActivateRequest, activate_byok_endpoint
+
         fps = self._valid_fingerprints()
-        fps['openai'] = 'a' * 64  # valid: 64 hex chars
-        assert self._validate(fps) is None
+        fps['openai'] = 'a' * 64
+        data = BYOKActivateRequest(fingerprints=fps)
+        result = activate_byok_endpoint(data, uid='test-uid')
+        assert result == {"active": True}
 
     def test_65_char_fingerprint_rejects(self):
+        from fastapi import HTTPException
+        from routers.users import BYOKActivateRequest, activate_byok_endpoint
+
         fps = self._valid_fingerprints()
         fps['openai'] = 'a' * 65
-        err = self._validate(fps)
-        assert err is not None
-        assert 'Invalid fingerprint' in err
+        data = BYOKActivateRequest(fingerprints=fps)
+        with pytest.raises(HTTPException) as exc_info:
+            activate_byok_endpoint(data, uid='test-uid')
+        assert exc_info.value.status_code == 400
 
     def test_empty_fingerprints_rejects(self):
-        err = self._validate({})
-        assert err is not None
-        assert 'Missing fingerprints' in err
+        from fastapi import HTTPException
+        from routers.users import BYOKActivateRequest, activate_byok_endpoint
+
+        data = BYOKActivateRequest(fingerprints={})
+        with pytest.raises(HTTPException) as exc_info:
+            activate_byok_endpoint(data, uid='test-uid')
+        assert exc_info.value.status_code == 400
+
+    @patch('routers.users.users_db')
+    def test_deactivation_calls_clear(self, mock_users_db):
+        from routers.users import deactivate_byok_endpoint
+
+        result = deactivate_byok_endpoint(uid='test-uid')
+        assert result == {"active": False}
+        mock_users_db.clear_byok_active.assert_called_once_with('test-uid')
+
+    def test_production_constants_match(self):
+        """Verify the test regex matches the production regex."""
+        from routers.users import _SHA256_HEX_RE as prod_re, _BYOK_REQUIRED_PROVIDERS as prod_providers
+
+        assert prod_re.pattern == _SHA256_HEX_RE.pattern
+        assert prod_providers == {'openai', 'anthropic', 'gemini', 'deepgram'}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -276,24 +276,25 @@ class TestGeminiKeyNotInUrl:
 
 
 class TestChatQuotaBYOKBypass:
-    @patch('utils.byok.has_byok_keys', return_value=True)
+    @patch('utils.byok.get_byok_key')
     @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
-    def test_enforce_chat_quota_bypasses_for_byok(self, mock_users_db, _mock_has_keys):
+    def test_enforce_chat_quota_bypasses_for_byok_with_openai_key(self, mock_users_db, mock_get_key):
         mock_users_db.is_byok_active.return_value = True
+        mock_get_key.side_effect = lambda p: 'sk-openai' if p == 'openai' else None
         from utils.subscription import enforce_chat_quota
 
         enforce_chat_quota('byok-user-uid')
         mock_users_db.is_byok_active.assert_called_once_with('byok-user-uid')
 
-    @patch('utils.byok.has_byok_keys', return_value=False)
+    @patch('utils.byok.get_byok_key', return_value=None)
     @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
     @patch('utils.subscription.get_chat_quota_snapshot')
-    def test_enforce_chat_quota_enforces_when_byok_active_but_no_headers(
-        self, mock_snapshot, mock_users_db, _mock_has_keys
+    def test_enforce_chat_quota_enforces_when_byok_active_but_no_llm_headers(
+        self, mock_snapshot, mock_users_db, _mock_get_key
     ):
-        """Abuse case: user activated BYOK with fake fingerprints but sends no BYOK headers."""
+        """Abuse case: user activated BYOK but sends no LLM provider headers."""
         from models.users import PlanType
 
         mock_users_db.is_byok_active.return_value = True
@@ -310,6 +311,31 @@ class TestChatQuotaBYOKBypass:
 
         with pytest.raises(HTTPException) as exc_info:
             enforce_chat_quota('fake-byok-uid')
+        assert exc_info.value.status_code == 402
+
+    @patch('utils.byok.get_byok_key')
+    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
+    @patch('utils.subscription.users_db')
+    @patch('utils.subscription.get_chat_quota_snapshot')
+    def test_enforce_chat_quota_enforces_when_only_deepgram_header(self, mock_snapshot, mock_users_db, mock_get_key):
+        """Partial-header abuse: only x-byok-deepgram sent, chat uses Omi's OpenAI key."""
+        from models.users import PlanType
+
+        mock_users_db.is_byok_active.return_value = True
+        mock_get_key.side_effect = lambda p: 'dg-key' if p == 'deepgram' else None
+        mock_snapshot.return_value = {
+            'plan': PlanType.basic,
+            'unit': 'questions',
+            'used': 31,
+            'limit': 30,
+            'allowed': False,
+            'reset_at': '2026-05-01',
+        }
+        from fastapi import HTTPException
+        from utils.subscription import enforce_chat_quota
+
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_chat_quota('partial-byok-uid')
         assert exc_info.value.status_code == 402
 
     @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
@@ -341,19 +367,31 @@ class TestChatQuotaBYOKBypass:
 
 
 class TestTranscriptionCreditBYOKBypass:
+    @patch('utils.byok.get_byok_key', return_value='dg-user-key')
     @patch('utils.subscription.users_db')
-    def test_has_transcription_credits_bypasses_for_byok(self, mock_users_db):
+    def test_has_transcription_credits_bypasses_for_byok(self, mock_users_db, _mock_get_key):
         mock_users_db.is_byok_active.return_value = True
         from utils.subscription import has_transcription_credits
 
         assert has_transcription_credits('byok-uid') is True
 
+    @patch('utils.byok.get_byok_key', return_value='dg-user-key')
     @patch('utils.subscription.users_db')
-    def test_remaining_seconds_is_none_for_byok(self, mock_users_db):
+    def test_remaining_seconds_is_none_for_byok(self, mock_users_db, _mock_get_key):
         mock_users_db.is_byok_active.return_value = True
         from utils.subscription import get_remaining_transcription_seconds
 
         assert get_remaining_transcription_seconds('byok-uid') is None
+
+    @patch('utils.byok.get_byok_key', return_value=None)
+    @patch('utils.subscription.users_db')
+    def test_transcription_not_bypassed_when_no_deepgram_header(self, mock_users_db, _mock_get_key):
+        """BYOK active but no x-byok-deepgram header — should NOT bypass."""
+        mock_users_db.is_byok_active.return_value = True
+        mock_users_db.get_user_valid_subscription.return_value = None
+        from utils.subscription import has_transcription_credits
+
+        assert has_transcription_credits('fake-byok-uid') is False
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -892,3 +892,61 @@ class TestBYOKFingerprintValidation:
             assert error is None
         finally:
             _byok_ctx.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# 15. BYOK state cache
+# ---------------------------------------------------------------------------
+
+
+class TestBYOKStateCache:
+    """In-memory TTL cache avoids redundant Firestore reads per request."""
+
+    def setup_method(self):
+        from utils.byok import _byok_state_cache, _byok_state_cache_lock
+
+        with _byok_state_cache_lock:
+            _byok_state_cache.clear()
+
+    def test_cache_avoids_repeated_firestore_reads(self):
+        """Second call for same uid should hit cache, not Firestore."""
+        from utils.byok import get_cached_byok_state, _byok_state_cache, _byok_state_cache_lock
+
+        fake_state = {'active': True, 'fingerprints': {'openai': 'abc'}}
+        with patch('database.users.get_byok_state', return_value=fake_state) as mock_fs:
+            result1 = get_cached_byok_state('uid-1')
+            result2 = get_cached_byok_state('uid-1')
+            assert result1 == fake_state
+            assert result2 == fake_state
+            assert mock_fs.call_count == 1  # Only one Firestore read
+
+    def test_different_uids_get_separate_entries(self):
+        """Each uid gets its own cache entry."""
+        from utils.byok import get_cached_byok_state
+
+        state_a = {'active': True, 'fingerprints': {'openai': 'aaa'}}
+        state_b = {'active': False, 'fingerprints': {}}
+
+        with patch('database.users.get_byok_state', side_effect=[state_a, state_b]) as mock_fs:
+            assert get_cached_byok_state('uid-a') == state_a
+            assert get_cached_byok_state('uid-b') == state_b
+            assert mock_fs.call_count == 2
+
+    def test_invalidate_busts_cache(self):
+        """invalidate_byok_state_cache forces next call to read Firestore."""
+        from utils.byok import get_cached_byok_state, invalidate_byok_state_cache
+
+        state_old = {'active': True, 'fingerprints': {'openai': 'old'}}
+        state_new = {'active': True, 'fingerprints': {'openai': 'new'}}
+
+        with patch('database.users.get_byok_state', side_effect=[state_old, state_new]) as mock_fs:
+            assert get_cached_byok_state('uid-1') == state_old
+            invalidate_byok_state_cache('uid-1')
+            assert get_cached_byok_state('uid-1') == state_new
+            assert mock_fs.call_count == 2
+
+    def test_cache_is_bounded(self):
+        """Cache respects maxsize — evicts oldest entries."""
+        from utils.byok import _byok_state_cache, _BYOK_STATE_CACHE_MAX
+
+        assert _BYOK_STATE_CACHE_MAX == 1024  # Verify constant

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -974,3 +974,102 @@ class TestBYOKStateCache:
         from utils.byok import _byok_state_cache, _BYOK_STATE_CACHE_MAX
 
         assert _BYOK_STATE_CACHE_MAX == 1024  # Verify constant
+
+
+# ---------------------------------------------------------------------------
+# 17. Auth dependency integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuthDependencyBYOKIntegration:
+    """Verify shared auth dependencies call (or skip) BYOK validation."""
+
+    @patch('utils.other.endpoints.validate_byok_request')
+    @patch('utils.other.endpoints.record_user_platform')
+    @patch('utils.other.endpoints.verify_token', return_value='uid-123')
+    def test_get_current_user_uid_calls_byok_validation(self, _mock_verify, _mock_platform, mock_validate):
+        from utils.other.endpoints import get_current_user_uid
+
+        uid = get_current_user_uid(authorization='Bearer fake-token')
+        assert uid == 'uid-123'
+        mock_validate.assert_called_once_with('uid-123')
+
+    @patch('utils.other.endpoints.record_user_platform')
+    @patch('utils.other.endpoints.verify_token', return_value='uid-456')
+    def test_no_byok_validation_skips_validate(self, _mock_verify, _mock_platform):
+        """get_current_user_uid_no_byok_validation must NOT call validate_byok_request."""
+        from utils.other.endpoints import get_current_user_uid_no_byok_validation
+
+        with patch('utils.other.endpoints.validate_byok_request') as mock_validate:
+            uid = get_current_user_uid_no_byok_validation(authorization='Bearer fake-token')
+            assert uid == 'uid-456'
+            mock_validate.assert_not_called()
+
+
+class TestWSAuthDependencyBYOK:
+    """Verify get_current_user_uid_ws_listen extracts BYOK and validates."""
+
+    def _make_ws(self, headers: dict):
+        ws = MagicMock()
+        ws.headers = headers
+        return ws
+
+    @patch('utils.other.endpoints.validate_byok_websocket', return_value=None)
+    @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
+    def test_ws_listen_with_byok_headers_validates(self, _mock_auth, mock_validate):
+        from utils.other.endpoints import get_current_user_uid_ws_listen
+
+        ws = self._make_ws({'x-byok-openai': 'sk-test'})
+        uid = get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok')
+        assert uid == 'ws-uid'
+        mock_validate.assert_called_once_with('ws-uid')
+
+    @patch('utils.other.endpoints.validate_byok_websocket', return_value=None)
+    @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
+    def test_ws_listen_no_headers_passes(self, _mock_auth, mock_validate):
+        from utils.other.endpoints import get_current_user_uid_ws_listen
+
+        ws = self._make_ws({})
+        uid = get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok')
+        assert uid == 'ws-uid'
+        mock_validate.assert_called_once()
+
+    @patch('utils.other.endpoints.validate_byok_websocket', return_value='fingerprint mismatch')
+    @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
+    def test_ws_listen_validation_failure_raises_4003(self, _mock_auth, _mock_validate):
+        from fastapi import WebSocketException
+        from utils.other.endpoints import get_current_user_uid_ws_listen
+
+        ws = self._make_ws({'x-byok-openai': 'wrong-key'})
+        with pytest.raises(WebSocketException) as exc_info:
+            get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok')
+        assert exc_info.value.code == 4003
+
+
+class TestActivationCacheInvalidation:
+    """Verify activate/deactivate endpoints invalidate BYOK state cache."""
+
+    @patch('routers.users.invalidate_byok_state_cache')
+    @patch('routers.users.users_db')
+    def test_activate_invalidates_cache(self, mock_users_db, mock_invalidate):
+        from routers.users import activate_byok_endpoint, BYOKActivateRequest
+
+        fingerprints = {
+            'openai': hashlib.sha256(b'sk-o').hexdigest(),
+            'anthropic': hashlib.sha256(b'sk-a').hexdigest(),
+            'gemini': hashlib.sha256(b'sk-g').hexdigest(),
+            'deepgram': hashlib.sha256(b'sk-d').hexdigest(),
+        }
+        data = BYOKActivateRequest(fingerprints=fingerprints)
+        result = activate_byok_endpoint(data=data, uid='uid-act')
+        assert result == {'active': True}
+        mock_invalidate.assert_called_once_with('uid-act')
+
+    @patch('routers.users.invalidate_byok_state_cache')
+    @patch('routers.users.users_db')
+    def test_deactivate_invalidates_cache(self, mock_users_db, mock_invalidate):
+        from routers.users import deactivate_byok_endpoint
+
+        result = deactivate_byok_endpoint(uid='uid-deact')
+        assert result == {'active': False}
+        mock_invalidate.assert_called_once_with('uid-deact')

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -276,14 +276,41 @@ class TestGeminiKeyNotInUrl:
 
 
 class TestChatQuotaBYOKBypass:
+    @patch('utils.byok.has_byok_keys', return_value=True)
     @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
-    def test_enforce_chat_quota_bypasses_for_byok(self, mock_users_db):
+    def test_enforce_chat_quota_bypasses_for_byok(self, mock_users_db, _mock_has_keys):
         mock_users_db.is_byok_active.return_value = True
         from utils.subscription import enforce_chat_quota
 
         enforce_chat_quota('byok-user-uid')
         mock_users_db.is_byok_active.assert_called_once_with('byok-user-uid')
+
+    @patch('utils.byok.has_byok_keys', return_value=False)
+    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
+    @patch('utils.subscription.users_db')
+    @patch('utils.subscription.get_chat_quota_snapshot')
+    def test_enforce_chat_quota_enforces_when_byok_active_but_no_headers(
+        self, mock_snapshot, mock_users_db, _mock_has_keys
+    ):
+        """Abuse case: user activated BYOK with fake fingerprints but sends no BYOK headers."""
+        from models.users import PlanType
+
+        mock_users_db.is_byok_active.return_value = True
+        mock_snapshot.return_value = {
+            'plan': PlanType.basic,
+            'unit': 'questions',
+            'used': 31,
+            'limit': 30,
+            'allowed': False,
+            'reset_at': '2026-05-01',
+        }
+        from fastapi import HTTPException
+        from utils.subscription import enforce_chat_quota
+
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_chat_quota('fake-byok-uid')
+        assert exc_info.value.status_code == 402
 
     @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -279,7 +279,6 @@ class TestGeminiKeyNotInUrl:
 
 class TestChatQuotaBYOKBypass:
     @patch('utils.byok.get_byok_key')
-    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
     def test_enforce_chat_quota_bypasses_for_byok_with_openai_key(self, mock_users_db, mock_get_key):
         mock_users_db.is_byok_active.return_value = True
@@ -290,7 +289,6 @@ class TestChatQuotaBYOKBypass:
         mock_users_db.is_byok_active.assert_called_once_with('byok-user-uid')
 
     @patch('utils.byok.get_byok_key', return_value=None)
-    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
     @patch('utils.subscription.get_chat_quota_snapshot')
     def test_enforce_chat_quota_enforces_when_byok_active_but_no_llm_headers(
@@ -316,7 +314,6 @@ class TestChatQuotaBYOKBypass:
         assert exc_info.value.status_code == 402
 
     @patch('utils.byok.get_byok_key')
-    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
     @patch('utils.subscription.get_chat_quota_snapshot')
     def test_enforce_chat_quota_enforces_when_only_deepgram_header(self, mock_snapshot, mock_users_db, mock_get_key):
@@ -340,7 +337,6 @@ class TestChatQuotaBYOKBypass:
             enforce_chat_quota('partial-byok-uid')
         assert exc_info.value.status_code == 402
 
-    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
     @patch('utils.subscription.get_chat_quota_snapshot')
     def test_enforce_chat_quota_still_enforces_for_non_byok(self, mock_snapshot, mock_users_db):
@@ -654,7 +650,6 @@ class TestMiddlewareIsolation:
 
 class TestQuotaBoundaryTests:
     @patch('utils.byok.get_byok_key')
-    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
     def test_chat_quota_bypasses_with_anthropic_key_only(self, mock_users_db, mock_get_key):
         """Anthropic-only BYOK should also bypass chat quota."""
@@ -665,7 +660,6 @@ class TestQuotaBoundaryTests:
         enforce_chat_quota('anthropic-byok-uid')  # Should not raise
 
     @patch('utils.byok.get_byok_key', return_value=None)
-    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
     @patch('utils.subscription.get_chat_quota_snapshot')
     def test_chat_quota_at_exact_limit(self, mock_snapshot, mock_users_db, _mock_get_key):
@@ -689,7 +683,6 @@ class TestQuotaBoundaryTests:
         assert exc_info.value.status_code == 402
 
     @patch('utils.byok.get_byok_key', return_value=None)
-    @patch('utils.subscription.CHAT_CAP_ENFORCEMENT_ENABLED', True)
     @patch('utils.subscription.users_db')
     @patch('utils.subscription.get_chat_quota_snapshot')
     def test_chat_quota_just_below_limit(self, mock_snapshot, mock_users_db, _mock_get_key):

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -706,3 +706,189 @@ class TestQuotaBoundaryTests:
         from utils.subscription import enforce_chat_quota
 
         enforce_chat_quota('below-limit-uid')  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# 14. Per-request fingerprint validation against Firestore enrollment
+# ---------------------------------------------------------------------------
+
+
+class TestBYOKFingerprintValidation:
+    """Firestore BYOK state is the source of truth.
+
+    - BYOK-active users MUST send keys whose SHA-256 matches enrolled fingerprints.
+    - Non-BYOK users' headers are silently cleared.
+    """
+
+    _FAKE_KEY_OPENAI = 'sk-test-openai-key-12345'
+    _FAKE_KEY_ANTHROPIC = 'sk-ant-test-key-67890'
+    _FAKE_KEY_GEMINI = 'AIzaSy-test-gemini-key'
+    _FAKE_KEY_DEEPGRAM = 'dg-test-deepgram-key'
+
+    @property
+    def _enrolled_fingerprints(self):
+        return {
+            'openai': hashlib.sha256(self._FAKE_KEY_OPENAI.encode()).hexdigest(),
+            'anthropic': hashlib.sha256(self._FAKE_KEY_ANTHROPIC.encode()).hexdigest(),
+            'gemini': hashlib.sha256(self._FAKE_KEY_GEMINI.encode()).hexdigest(),
+            'deepgram': hashlib.sha256(self._FAKE_KEY_DEEPGRAM.encode()).hexdigest(),
+        }
+
+    @property
+    def _valid_request_keys(self):
+        return {
+            'openai': self._FAKE_KEY_OPENAI,
+            'anthropic': self._FAKE_KEY_ANTHROPIC,
+            'gemini': self._FAKE_KEY_GEMINI,
+            'deepgram': self._FAKE_KEY_DEEPGRAM,
+        }
+
+    def _mock_byok_state(self, active=True, fingerprints=None):
+        from datetime import datetime, timezone
+
+        return {
+            'active': active,
+            'fingerprints': fingerprints if fingerprints is not None else self._enrolled_fingerprints,
+            'last_seen_at': datetime.now(timezone.utc),
+        }
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_valid_keys_pass_validation(self, mock_get_state):
+        """BYOK-active user with matching keys passes validation."""
+        from utils.byok import _byok_ctx, validate_byok_request
+
+        mock_get_state.return_value = self._mock_byok_state()
+        token = _byok_ctx.set(self._valid_request_keys)
+        try:
+            validate_byok_request('byok-uid')  # Should not raise
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_missing_header_raises_403(self, mock_get_state):
+        """BYOK-active user missing a required provider header → 403."""
+        from fastapi import HTTPException
+        from utils.byok import _byok_ctx, validate_byok_request
+
+        mock_get_state.return_value = self._mock_byok_state()
+        # Only send openai key, missing anthropic/gemini/deepgram
+        token = _byok_ctx.set({'openai': self._FAKE_KEY_OPENAI})
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                validate_byok_request('byok-uid')
+            assert exc_info.value.status_code == 403
+            assert 'missing key header' in exc_info.value.detail
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_wrong_key_raises_403(self, mock_get_state):
+        """BYOK-active user with a key that doesn't match fingerprint → 403."""
+        from fastapi import HTTPException
+        from utils.byok import _byok_ctx, validate_byok_request
+
+        mock_get_state.return_value = self._mock_byok_state()
+        bad_keys = dict(self._valid_request_keys)
+        bad_keys['openai'] = 'sk-WRONG-key-does-not-match'
+        token = _byok_ctx.set(bad_keys)
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                validate_byok_request('byok-uid')
+            assert exc_info.value.status_code == 403
+            assert 'mismatch' in exc_info.value.detail
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_no_headers_when_byok_active_raises_403(self, mock_get_state):
+        """BYOK-active user sending zero BYOK headers → 403."""
+        from fastapi import HTTPException
+        from utils.byok import _byok_ctx, validate_byok_request
+
+        mock_get_state.return_value = self._mock_byok_state()
+        token = _byok_ctx.set({})
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                validate_byok_request('byok-uid')
+            assert exc_info.value.status_code == 403
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_non_byok_user_headers_are_cleared(self, mock_get_state):
+        """Non-BYOK user sending BYOK headers → headers silently cleared."""
+        from utils.byok import _byok_ctx, validate_byok_request, get_byok_keys
+
+        mock_get_state.return_value = self._mock_byok_state(active=False)
+        token = _byok_ctx.set({'openai': 'sk-sneaky-key'})
+        try:
+            validate_byok_request('non-byok-uid')  # Should not raise
+            # Headers must have been cleared
+            assert get_byok_keys() == {}
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_non_byok_user_no_headers_passes(self, mock_get_state):
+        """Non-BYOK user with no BYOK headers → normal flow, no error."""
+        from utils.byok import _byok_ctx, validate_byok_request
+
+        mock_get_state.return_value = self._mock_byok_state(active=False)
+        token = _byok_ctx.set(None)
+        try:
+            validate_byok_request('normal-uid')  # Should not raise
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_expired_byok_headers_cleared(self, mock_get_state):
+        """BYOK activation expired (>7 days) → headers silently cleared."""
+        from datetime import datetime as dt, timezone as tz
+        from utils.byok import _byok_ctx, validate_byok_request, get_byok_keys
+
+        expired_state = self._mock_byok_state()
+        expired_state['last_seen_at'] = dt(2020, 1, 1, tzinfo=tz.utc)
+        mock_get_state.return_value = expired_state
+
+        token = _byok_ctx.set(self._valid_request_keys)
+        try:
+            validate_byok_request('expired-uid')  # Should not raise
+            assert get_byok_keys() == {}  # Headers cleared
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_websocket_validation_returns_error_string(self, mock_get_state):
+        """WebSocket validation returns error string instead of raising."""
+        from utils.byok import _byok_ctx, validate_byok_websocket
+
+        mock_get_state.return_value = self._mock_byok_state()
+        token = _byok_ctx.set({})  # Missing all keys
+        try:
+            error = validate_byok_websocket('byok-uid')
+            assert error is not None
+            assert 'missing key header' in error
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_websocket_validation_returns_none_on_success(self, mock_get_state):
+        """WebSocket validation returns None when keys are valid."""
+        from utils.byok import _byok_ctx, validate_byok_websocket
+
+        mock_get_state.return_value = self._mock_byok_state()
+        token = _byok_ctx.set(self._valid_request_keys)
+        try:
+            error = validate_byok_websocket('byok-uid')
+            assert error is None
+        finally:
+            _byok_ctx.reset(token)

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -768,18 +768,18 @@ class TestBYOKFingerprintValidation:
     @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
     @patch('database.users.get_byok_state')
     def test_missing_header_raises_403(self, mock_get_state):
-        """BYOK-active user missing a required provider header → 403."""
+        """BYOK-active user sends some headers but missing a provider → 403."""
         from fastapi import HTTPException
         from utils.byok import _byok_ctx, validate_byok_request
 
         mock_get_state.return_value = self._mock_byok_state()
-        # Only send openai key, missing anthropic/gemini/deepgram
+        # Send only openai key — this is a broken BYOK attempt (partial headers)
         token = _byok_ctx.set({'openai': self._FAKE_KEY_OPENAI})
         try:
             with pytest.raises(HTTPException) as exc_info:
                 validate_byok_request('byok-uid')
             assert exc_info.value.status_code == 403
-            assert 'missing key header' in exc_info.value.detail
+            assert 'missing' in exc_info.value.detail
         finally:
             _byok_ctx.reset(token)
 
@@ -804,13 +804,28 @@ class TestBYOKFingerprintValidation:
 
     @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
     @patch('database.users.get_byok_state')
-    def test_no_headers_when_byok_active_raises_403(self, mock_get_state):
-        """BYOK-active user sending zero BYOK headers → 403."""
+    def test_no_headers_when_byok_active_falls_through(self, mock_get_state):
+        """BYOK-active user sending zero BYOK headers (e.g. mobile) → no error, falls through to Omi keys."""
+        from utils.byok import _byok_ctx, validate_byok_request, get_byok_keys
+
+        mock_get_state.return_value = self._mock_byok_state()
+        token = _byok_ctx.set({})
+        try:
+            validate_byok_request('byok-uid')  # Should NOT raise
+            assert get_byok_keys() == {}  # Context cleared, will use Omi keys
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_partial_headers_when_byok_active_raises_403(self, mock_get_state):
+        """BYOK-active user sending SOME but not all headers → 403 (incomplete BYOK attempt)."""
         from fastapi import HTTPException
         from utils.byok import _byok_ctx, validate_byok_request
 
         mock_get_state.return_value = self._mock_byok_state()
-        token = _byok_ctx.set({})
+        # Send only openai key, missing the rest — this is a broken BYOK attempt, not mobile
+        token = _byok_ctx.set({'openai': self._FAKE_KEY_OPENAI})
         try:
             with pytest.raises(HTTPException) as exc_info:
                 validate_byok_request('byok-uid')
@@ -866,16 +881,32 @@ class TestBYOKFingerprintValidation:
 
     @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
     @patch('database.users.get_byok_state')
-    def test_websocket_validation_returns_error_string(self, mock_get_state):
-        """WebSocket validation returns error string instead of raising."""
+    def test_websocket_no_headers_falls_through(self, mock_get_state):
+        """BYOK-active user on WS with no headers (mobile) → falls through, no error."""
+        from utils.byok import _byok_ctx, validate_byok_websocket, get_byok_keys
+
+        mock_get_state.return_value = self._mock_byok_state()
+        token = _byok_ctx.set({})  # No BYOK headers (mobile app)
+        try:
+            error = validate_byok_websocket('byok-uid')
+            assert error is None  # No error — mobile falls through
+            assert get_byok_keys() == {}  # Context cleared
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_websocket_partial_headers_returns_error(self, mock_get_state):
+        """BYOK-active user on WS with partial headers → error string."""
         from utils.byok import _byok_ctx, validate_byok_websocket
 
         mock_get_state.return_value = self._mock_byok_state()
-        token = _byok_ctx.set({})  # Missing all keys
+        # Send only one key — broken BYOK attempt
+        token = _byok_ctx.set({'openai': self._FAKE_KEY_OPENAI})
         try:
             error = validate_byok_websocket('byok-uid')
             assert error is not None
-            assert 'missing key header' in error
+            assert 'missing' in error
         finally:
             _byok_ctx.reset(token)
 

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -15,15 +15,53 @@ validated against enrolled fingerprints so that:
 
 import hashlib
 import logging
+import threading
+import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
+from cachetools import TTLCache
 from fastapi import HTTPException, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.websockets import WebSocket
 
 logger = logging.getLogger('byok')
+
+# ---------------------------------------------------------------------------
+# In-memory TTL cache for Firestore BYOK state lookups.
+#
+# Without this, get_byok_state(uid) triggers a Firestore read 2-3 times per
+# request (once in validate_byok_request, again in is_byok_active inside
+# subscription code).  A short TTL (30 s) keeps reads fresh enough for key
+# rotation detection while cutting redundant Firestore traffic.
+# ---------------------------------------------------------------------------
+_BYOK_STATE_CACHE_MAX = 1024
+_BYOK_STATE_CACHE_TTL = 30  # seconds
+_byok_state_cache: TTLCache = TTLCache(maxsize=_BYOK_STATE_CACHE_MAX, ttl=_BYOK_STATE_CACHE_TTL)
+_byok_state_cache_lock = threading.Lock()
+
+
+def get_cached_byok_state(uid: str) -> dict:
+    """Return BYOK state for *uid*, hitting Firestore at most once per TTL window."""
+    with _byok_state_cache_lock:
+        cached = _byok_state_cache.get(uid)
+    if cached is not None:
+        return cached
+
+    import database.users as users_db
+
+    state = users_db.get_byok_state(uid)
+    with _byok_state_cache_lock:
+        _byok_state_cache[uid] = state
+    return state
+
+
+def invalidate_byok_state_cache(uid: str) -> None:
+    """Call after activation/deactivation to bust the cache immediately."""
+    with _byok_state_cache_lock:
+        _byok_state_cache.pop(uid, None)
+
 
 BYOK_HEADERS = {
     'openai': 'x-byok-openai',
@@ -114,7 +152,7 @@ def _check_byok_validity(uid: str) -> Optional[str]:
     """
     import database.users as users_db
 
-    state = users_db.get_byok_state(uid)
+    state = get_cached_byok_state(uid)
 
     # Replicate is_byok_active logic on the already-fetched state to avoid a
     # second Firestore read.

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -6,14 +6,24 @@ A FastAPI middleware stashes them in a per-request contextvar; the LLM/STT
 clients can then read them without re-reading the request object.
 
 Keys are NEVER persisted — only fingerprints (see `database.users.set_byok_active`).
+
+Firestore BYOK state is the **source of truth**.  Per-request headers are
+validated against enrolled fingerprints so that:
+  - BYOK-active users MUST send keys that match their enrolled fingerprints.
+  - Non-BYOK users' headers are silently ignored (Omi keys are used).
 """
 
+import hashlib
+import logging
 from contextvars import ContextVar
+from datetime import datetime, timezone
 from typing import Dict, Optional
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.websockets import WebSocket
+
+logger = logging.getLogger('byok')
 
 BYOK_HEADERS = {
     'openai': 'x-byok-openai',
@@ -83,3 +93,80 @@ class BYOKMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         finally:
             _byok_ctx.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Per-request fingerprint validation against Firestore enrollment
+# ---------------------------------------------------------------------------
+
+
+def _check_byok_validity(uid: str) -> Optional[str]:
+    """Core validation: Firestore BYOK state is source of truth.
+
+    Returns an error message string on failure, or ``None`` on success.
+
+    Behaviour:
+    - If user is NOT BYOK-active → clears any BYOK headers from the context
+      (so they are never used) and returns None.
+    - If user IS BYOK-active → every enrolled provider fingerprint must be
+      matched by a header whose SHA-256 equals the stored fingerprint.
+      Missing or mismatched headers → returns an error string.
+    """
+    import database.users as users_db
+
+    state = users_db.get_byok_state(uid)
+
+    # Replicate is_byok_active logic on the already-fetched state to avoid a
+    # second Firestore read.
+    is_active = False
+    if state.get('active'):
+        last_seen = state.get('last_seen_at')
+        if isinstance(last_seen, datetime):
+            age = (datetime.now(timezone.utc) - last_seen).total_seconds()
+            is_active = age <= users_db.BYOK_HEARTBEAT_TTL_SECONDS
+
+    if not is_active:
+        # Non-enrolled user — silently discard any BYOK headers so downstream
+        # code always uses Omi's own keys.
+        if _byok_ctx.get():
+            _byok_ctx.set(None)
+        return None
+
+    # BYOK-active: validate every enrolled provider.
+    stored_fingerprints = state.get('fingerprints', {})
+    request_keys = _byok_ctx.get() or {}
+
+    for provider, stored_fp in stored_fingerprints.items():
+        raw_key = request_keys.get(provider)
+        if not raw_key:
+            return f"BYOK active but missing key header for provider: {provider}"
+        request_fp = hashlib.sha256(raw_key.encode()).hexdigest()
+        if request_fp != stored_fp:
+            return f"BYOK key fingerprint mismatch for provider: {provider}"
+
+    return None
+
+
+def validate_byok_request(uid: str) -> None:
+    """Validate BYOK keys for HTTP endpoints (chat, etc.).
+
+    Raises ``HTTPException(403)`` when the user is BYOK-active but the
+    request headers are missing or don't match enrolled fingerprints.
+    """
+    error = _check_byok_validity(uid)
+    if error:
+        logger.warning('BYOK validation failed uid=%s: %s', uid, error)
+        raise HTTPException(status_code=403, detail=error)
+
+
+def validate_byok_websocket(uid: str) -> Optional[str]:
+    """Validate BYOK keys for WebSocket endpoints (listen, etc.).
+
+    Returns an error message string on failure, or ``None`` on success.
+    The caller is responsible for closing the WebSocket with an appropriate
+    error when a non-None value is returned.
+    """
+    error = _check_byok_validity(uid)
+    if error:
+        logger.warning('BYOK WS validation failed uid=%s: %s', uid, error)
+    return error

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -144,15 +144,20 @@ def _check_byok_validity(uid: str) -> Optional[str]:
     Returns an error message string on failure, or ``None`` on success.
 
     Behaviour:
-    - If user is NOT BYOK-active → clears any BYOK headers from the context
-      (so they are never used) and returns None.
+    - If NO BYOK headers on this request → returns None immediately without
+      touching Firestore.  This is the fast path for mobile and non-BYOK users.
+    - If user is NOT BYOK-active but sends headers → clears headers from the
+      context (so they are never used) and returns None.
     - If user IS BYOK-active **and sends BYOK headers** → every header key's
       SHA-256 must match the enrolled fingerprint.  Mismatch → error string.
-    - If user IS BYOK-active **but sends NO BYOK headers** (e.g. mobile app
-      which has no BYOK support) → clears context and falls through to normal
-      Omi keys + normal subscription enforcement.  The user can still use the
-      service on the platform that doesn't support BYOK.
     """
+    # Fast path: no BYOK headers on this request → nothing to validate.
+    # Avoids hitting Firestore/cache for the vast majority of requests
+    # (mobile, non-BYOK desktop).
+    request_keys = _byok_ctx.get() or {}
+    if not request_keys:
+        return None
+
     import database.users as users_db
 
     state = get_cached_byok_state(uid)
@@ -173,17 +178,8 @@ def _check_byok_validity(uid: str) -> Optional[str]:
             _byok_ctx.set(None)
         return None
 
-    # BYOK-active user.
-    request_keys = _byok_ctx.get() or {}
-
-    if not request_keys:
-        # BYOK-active but NO headers at all (e.g. mobile app).
-        # Fall through to normal Omi keys + normal subscription enforcement.
-        # Don't block — the user just isn't using BYOK on this platform.
-        _byok_ctx.set(None)
-        return None
-
-    # Headers present — validate every enrolled provider fingerprint.
+    # BYOK-active user with headers present — validate every enrolled
+    # provider fingerprint.
     stored_fingerprints = state.get('fingerprints', {})
 
     for provider, stored_fp in stored_fingerprints.items():

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -146,9 +146,12 @@ def _check_byok_validity(uid: str) -> Optional[str]:
     Behaviour:
     - If user is NOT BYOK-active → clears any BYOK headers from the context
       (so they are never used) and returns None.
-    - If user IS BYOK-active → every enrolled provider fingerprint must be
-      matched by a header whose SHA-256 equals the stored fingerprint.
-      Missing or mismatched headers → returns an error string.
+    - If user IS BYOK-active **and sends BYOK headers** → every header key's
+      SHA-256 must match the enrolled fingerprint.  Mismatch → error string.
+    - If user IS BYOK-active **but sends NO BYOK headers** (e.g. mobile app
+      which has no BYOK support) → clears context and falls through to normal
+      Omi keys + normal subscription enforcement.  The user can still use the
+      service on the platform that doesn't support BYOK.
     """
     import database.users as users_db
 
@@ -170,14 +173,23 @@ def _check_byok_validity(uid: str) -> Optional[str]:
             _byok_ctx.set(None)
         return None
 
-    # BYOK-active: validate every enrolled provider.
-    stored_fingerprints = state.get('fingerprints', {})
+    # BYOK-active user.
     request_keys = _byok_ctx.get() or {}
+
+    if not request_keys:
+        # BYOK-active but NO headers at all (e.g. mobile app).
+        # Fall through to normal Omi keys + normal subscription enforcement.
+        # Don't block — the user just isn't using BYOK on this platform.
+        _byok_ctx.set(None)
+        return None
+
+    # Headers present — validate every enrolled provider fingerprint.
+    stored_fingerprints = state.get('fingerprints', {})
 
     for provider, stored_fp in stored_fingerprints.items():
         raw_key = request_keys.get(provider)
         if not raw_key:
-            return f"BYOK active but missing key header for provider: {provider}"
+            return f"BYOK key header missing for enrolled provider: {provider}"
         request_fp = hashlib.sha256(raw_key.encode()).hexdigest()
         if request_fp != stored_fp:
             return f"BYOK key fingerprint mismatch for provider: {provider}"

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -13,25 +13,36 @@ from typing import Dict, Optional
 
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.websockets import WebSocket
 
-_BYOK_HEADERS = {
+BYOK_HEADERS = {
     'openai': 'x-byok-openai',
     'anthropic': 'x-byok-anthropic',
     'gemini': 'x-byok-gemini',
     'deepgram': 'x-byok-deepgram',
 }
 
-# Keys for the current request, if the client supplied them. Empty dict otherwise.
-_byok_ctx: ContextVar[Dict[str, str]] = ContextVar('byok_keys', default={})
+# Keys for the current request, if the client supplied them.
+# Default is None (not {}) to avoid sharing a mutable object across contexts.
+_byok_ctx: ContextVar[Optional[Dict[str, str]]] = ContextVar('byok_keys', default=None)
 
 
 def get_byok_keys() -> Dict[str, str]:
     """The keys attached to the current request (may be empty)."""
-    return _byok_ctx.get()
+    return _byok_ctx.get() or {}
 
 
 def get_byok_key(provider: str) -> Optional[str]:
-    return _byok_ctx.get().get(provider)
+    keys = _byok_ctx.get()
+    if keys is None:
+        return None
+    return keys.get(provider)
+
+
+def has_byok_keys() -> bool:
+    """True if the current request carries at least one BYOK header."""
+    keys = _byok_ctx.get()
+    return bool(keys)
 
 
 def set_byok_keys(keys: Dict[str, str]):
@@ -39,12 +50,31 @@ def set_byok_keys(keys: Dict[str, str]):
     _byok_ctx.set({k: v for k, v in keys.items() if v})
 
 
+def extract_byok_from_websocket(websocket: WebSocket) -> Dict[str, str]:
+    """Read BYOK headers from a WebSocket's initial upgrade request.
+
+    BaseHTTPMiddleware only fires for HTTP scope, so WebSocket handlers must
+    call this manually and then pass the result to ``set_byok_keys``.
+    """
+    keys: Dict[str, str] = {}
+    for provider, header in BYOK_HEADERS.items():
+        value = websocket.headers.get(header)
+        if value:
+            keys[provider] = value
+    return keys
+
+
 class BYOKMiddleware(BaseHTTPMiddleware):
-    """Extract BYOK headers from each request into the contextvar."""
+    """Extract BYOK headers from each HTTP request into the contextvar.
+
+    NOTE: BaseHTTPMiddleware does NOT fire for WebSocket connections
+    (scope["type"] == "websocket"). WebSocket handlers must call
+    ``extract_byok_from_websocket`` + ``set_byok_keys`` manually.
+    """
 
     async def dispatch(self, request: Request, call_next):
         keys: Dict[str, str] = {}
-        for provider, header in _BYOK_HEADERS.items():
+        for provider, header in BYOK_HEADERS.items():
             value = request.headers.get(header)
             if value:
                 keys[provider] = value

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -623,7 +623,7 @@ class _AnthropicViaOpenAIProxy:
         byok = get_byok_key('anthropic')
         if byok:
             return _cached_openai_chat(
-                'claude-3-5-sonnet-20241022',
+                'claude-sonnet-4-20250514',
                 byok,
                 {**self._ctor_kwargs, 'base_url': _ANTHROPIC_OPENAI_BASE_URL},
             )

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,9 +1,11 @@
+import hashlib
 import logging
 import os
 from typing import Any, Dict, List, Optional
 
 import anthropic
 import httpx
+from cachetools import TTLCache
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 import tiktoken
@@ -140,12 +142,20 @@ class _OpenAIEmbeddingsProxy:
         return getattr(self._resolve(), name)
 
 
-_openai_cache: Dict[str, ChatOpenAI] = {}
-_anthropic_cache: Dict[str, anthropic.AsyncAnthropic] = {}
+_BYOK_CACHE_MAX_SIZE = 256
+_BYOK_CACHE_TTL_SECONDS = 3600  # 1 hour
+
+_openai_cache: TTLCache = TTLCache(maxsize=_BYOK_CACHE_MAX_SIZE, ttl=_BYOK_CACHE_TTL_SECONDS)
+_anthropic_cache: TTLCache = TTLCache(maxsize=_BYOK_CACHE_MAX_SIZE, ttl=_BYOK_CACHE_TTL_SECONDS)
+
+
+def _hash_key(api_key: str) -> str:
+    """Derive a safe cache key from an API key. Never store raw keys in memory."""
+    return hashlib.sha256(api_key.encode()).hexdigest()
 
 
 def _cached_openai_chat(model: str, api_key: str, ctor_kwargs: Dict[str, Any]) -> ChatOpenAI:
-    cache_key = f"{model}:{hash(api_key)}:{hash(frozenset((k, repr(v)) for k, v in ctor_kwargs.items()))}"
+    cache_key = f"{model}:{_hash_key(api_key)}:{hash(frozenset((k, repr(v)) for k, v in ctor_kwargs.items()))}"
     inst = _openai_cache.get(cache_key)
     if inst is None:
         inst = ChatOpenAI(model=model, api_key=api_key, **ctor_kwargs)
@@ -154,10 +164,11 @@ def _cached_openai_chat(model: str, api_key: str, ctor_kwargs: Dict[str, Any]) -
 
 
 def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
-    inst = _anthropic_cache.get(api_key)
+    cache_key = _hash_key(api_key)
+    inst = _anthropic_cache.get(cache_key)
     if inst is None:
         inst = anthropic.AsyncAnthropic(api_key=api_key)
-        _anthropic_cache[api_key] = inst
+        _anthropic_cache[cache_key] = inst
     return inst
 
 
@@ -581,18 +592,56 @@ llm_persona_mini_stream = _OpenRouterGeminiProxy(
     direct_model="gemini-flash-1.5-8b",
     ctor_kwargs=_persona_mini_kwargs,
 )
-# Anthropic-via-OpenRouter stays on OpenRouter for now; direct-Anthropic via
-# langchain would need the langchain-anthropic dep. BYOK Anthropic users still
-# pay Omi for this specific persona model — flag for follow-up.
-llm_persona_medium_stream = ChatOpenAI(
+# Anthropic-via-OpenRouter. BYOK Anthropic users route to Anthropic's
+# OpenAI-compat endpoint directly, avoiding Omi's OpenRouter bill.
+_ANTHROPIC_OPENAI_BASE_URL = "https://api.anthropic.com/v1/"
+_persona_medium_kwargs = dict(
     temperature=0.8,
+    streaming=True,
+    stream_options={"include_usage": True},
+    callbacks=[_usage_callback],
+)
+_persona_medium_default = ChatOpenAI(
     model="anthropic/claude-3.5-sonnet",
     api_key=os.environ.get('OPENROUTER_API_KEY'),
     base_url="https://openrouter.ai/api/v1",
     default_headers={"X-Title": "Omi Chat"},
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
+    **_persona_medium_kwargs,
+)
+
+
+class _AnthropicViaOpenAIProxy:
+    """Route to Anthropic's OpenAI-compat endpoint when BYOK Anthropic key is set."""
+
+    __slots__ = ('_default', '_ctor_kwargs')
+
+    def __init__(self, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('anthropic')
+        if byok:
+            return _cached_openai_chat(
+                'claude-3-5-sonnet-20241022',
+                byok,
+                {**self._ctor_kwargs, 'base_url': _ANTHROPIC_OPENAI_BASE_URL},
+            )
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+    def __or__(self, other):
+        return self._resolve() | other
+
+    def __ror__(self, other):
+        return other | self._resolve()
+
+
+llm_persona_medium_stream = _AnthropicViaOpenAIProxy(
+    default=_persona_medium_default,
+    ctor_kwargs=_persona_medium_kwargs,
 )
 
 # Gemini models for large context analysis
@@ -647,12 +696,13 @@ def gemini_embed_query(text: str) -> List[float]:
     env key so non-BYOK callers behave exactly as before.
     """
     api_key = get_byok_key('gemini') or os.environ.get('GEMINI_API_KEY', '')
-    url = f'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent?key={api_key}'
+    url = 'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent'
     payload = {
         'model': 'models/embedding-001',
         'content': {'parts': [{'text': text}]},
         'taskType': 'RETRIEVAL_QUERY',
     }
-    resp = httpx.post(url, json=payload, timeout=10)
+    headers = {'x-goog-api-key': api_key, 'Content-Type': 'application/json'}
+    resp = httpx.post(url, json=payload, headers=headers, timeout=10)
     resp.raise_for_status()
     return resp.json()['embedding']['values']

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -130,7 +130,7 @@ class _OpenAIEmbeddingsProxy:
     def _resolve(self) -> OpenAIEmbeddings:
         byok = get_byok_key('openai')
         if byok:
-            cache_key = f"emb:{self._model}:{hash(byok)}"
+            cache_key = f"emb:{self._model}:{_hash_key(byok)}"
             inst = _openai_cache.get(cache_key)
             if inst is None:
                 inst = OpenAIEmbeddings(model=self._model, api_key=byok, **self._ctor_kwargs)

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -59,6 +59,8 @@ def get_current_user_uid(
     `record_user_platform`, which is throttled via Redis to one Firestore
     write per (uid, platform) every 10 minutes. Failures here never fail the
     request — it's telemetry, not auth.
+
+    Also validates BYOK headers against Firestore enrollment (if applicable).
     """
     if not authorization:
         raise HTTPException(status_code=401, detail="Authorization header not found")
@@ -76,6 +78,14 @@ def get_current_user_uid(
         record_user_platform(uid, x_app_platform)
     except Exception as e:  # noqa: BLE001 — telemetry must never fail the request
         logger.debug("record_user_platform swallowed error for uid=%s: %s", uid, e)
+
+    # Validate BYOK keys against Firestore enrollment for ALL authenticated
+    # HTTP endpoints.  Runs after auth so we have the uid.  Lightweight: uses
+    # a 30-second TTL cache for Firestore state, and is a no-op when no BYOK
+    # headers are present.
+    from utils.byok import validate_byok_request
+
+    validate_byok_request(uid)
 
     return uid
 
@@ -107,6 +117,9 @@ def get_current_user_uid_ws_listen(authorization: str = Header(None)):
 
     Mobile apps reconnect legitimately on network switch / backgrounding,
     so the per-UID rate limiter must not block them.
+
+    BYOK validation is done inside _stream_handler after header extraction
+    (BaseHTTPMiddleware doesn't fire for WebSocket scope).
     """
     return _verify_ws_auth(authorization)
 

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -4,6 +4,7 @@ import time
 
 from fastapi import Depends, Header, HTTPException, WebSocketException
 from fastapi import Request
+from starlette.websockets import WebSocket
 from firebase_admin import auth
 from firebase_admin.auth import InvalidIdTokenError
 import logging
@@ -11,6 +12,7 @@ import redis as redis_pkg
 
 from database.redis_db import check_rate_limit, try_acquire_listen_lock
 from database.users import record_user_platform
+from utils.byok import extract_byok_from_websocket, set_byok_keys, validate_byok_request, validate_byok_websocket
 from utils.rate_limit_config import RATE_POLICIES, RATE_LIMIT_SHADOW, get_effective_limit
 
 logger = logging.getLogger(__name__)
@@ -83,8 +85,6 @@ def get_current_user_uid(
     # HTTP endpoints.  Runs after auth so we have the uid.  Lightweight: uses
     # a 30-second TTL cache for Firestore state, and is a no-op when no BYOK
     # headers are present.
-    from utils.byok import validate_byok_request
-
     validate_byok_request(uid)
 
     return uid
@@ -112,16 +112,31 @@ def _verify_ws_auth(authorization: str) -> str:
         raise WebSocketException(code=1008, reason="Auth error")
 
 
-def get_current_user_uid_ws_listen(authorization: str = Header(None)):
+def get_current_user_uid_ws_listen(
+    websocket: WebSocket = None,
+    authorization: str = Header(None),
+):
     """WebSocket auth for /v4/listen — NO rate limiting.
 
     Mobile apps reconnect legitimately on network switch / backgrounding,
     so the per-UID rate limiter must not block them.
 
-    BYOK validation is done inside _stream_handler after header extraction
-    (BaseHTTPMiddleware doesn't fire for WebSocket scope).
+    Also extracts BYOK headers from the WS upgrade request and validates
+    them against Firestore enrollment (BaseHTTPMiddleware doesn't fire for
+    WebSocket scope, so this is the shared entry point for WS BYOK).
     """
-    return _verify_ws_auth(authorization)
+    uid = _verify_ws_auth(authorization)
+
+    # Extract BYOK headers from the WS upgrade request and validate.
+    if websocket is not None:
+        byok_keys = extract_byok_from_websocket(websocket)
+        if byok_keys:
+            set_byok_keys(byok_keys)
+        error = validate_byok_websocket(uid)
+        if error:
+            raise WebSocketException(code=4003, reason=error)
+
+    return uid
 
 
 def get_current_user_uid_ws(authorization: str = Header(None)):

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -90,6 +90,36 @@ def get_current_user_uid(
     return uid
 
 
+def get_current_user_uid_no_byok_validation(
+    authorization: str = Header(None),
+    x_app_platform: str = Header(None, alias='X-App-Platform'),
+):
+    """Auth dependency that skips BYOK fingerprint validation.
+
+    Used ONLY by the BYOK activation/deactivation endpoints — those need to
+    update Firestore fingerprints, so validating the old fingerprints first
+    would deadlock key rotation.
+    """
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header not found")
+    elif len(str(authorization).split(' ')) != 2:
+        raise HTTPException(status_code=401, detail="Invalid authorization token")
+
+    try:
+        token = authorization.split(' ')[1]
+        uid = verify_token(token)
+    except InvalidIdTokenError as e:
+        logger.error(e)
+        raise HTTPException(status_code=401, detail="Invalid authorization token")
+
+    try:
+        record_user_platform(uid, x_app_platform)
+    except Exception as e:  # noqa: BLE001 — telemetry must never fail the request
+        logger.debug("record_user_platform swallowed error for uid=%s: %s", uid, e)
+
+    return uid
+
+
 def _verify_ws_auth(authorization: str) -> str:
     """Common WebSocket auth — verifies token, returns uid.
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -6,7 +6,9 @@ import stripe
 import database.users as users_db
 import database.user_usage as user_usage_db
 from database.announcements import _compare_versions
+from fastapi import HTTPException
 from models.users import PlanType, SubscriptionStatus, Subscription, PlanLimits
+from utils.byok import get_byok_key
 from utils.log_sanitizer import sanitize
 import logging
 
@@ -268,7 +270,12 @@ def get_chat_quota_snapshot(uid: str) -> dict:
 
 def enforce_chat_quota(uid: str) -> None:
     """Raise HTTPException(402) if the user is past their monthly chat cap."""
-    from fastapi import HTTPException
+    # BYOK users pay their own LLM provider — no Omi-side cost to cap.
+    # Require an LLM provider key on this request (not just any BYOK header)
+    # so a user can't activate with fake fingerprints or send only x-byok-deepgram
+    # to bypass chat quota while chat falls back to Omi's OpenAI/Anthropic keys.
+    if users_db.is_byok_active(uid) and (get_byok_key('openai') or get_byok_key('anthropic')):
+        return
 
     snapshot = get_chat_quota_snapshot(uid)
     if snapshot['allowed']:
@@ -505,7 +512,9 @@ def has_transcription_credits(uid: str) -> bool:
     Checks if a user has transcribing credits by verifying their valid subscription and usage.
     """
     # BYOK users pay Deepgram directly — there's no Omi-side transcription quota to enforce.
-    if users_db.is_byok_active(uid):
+    # Require the Deepgram header on this request so a user can't activate BYOK
+    # with fake fingerprints then omit x-byok-deepgram to ride Omi's key.
+    if users_db.is_byok_active(uid) and get_byok_key('deepgram'):
         return True
 
     subscription = users_db.get_user_valid_subscription(uid)
@@ -530,7 +539,8 @@ def get_remaining_transcription_seconds(uid: str) -> int | None:
     Used for freemium auto-switch to on-device transcription.
     """
     # BYOK: user brings their own Deepgram — no Omi quota, no freemium threshold.
-    if users_db.is_byok_active(uid):
+    # Require the Deepgram header to prevent fake-fingerprint abuse.
+    if users_db.is_byok_active(uid) and get_byok_key('deepgram'):
         return None
 
     subscription = users_db.get_user_valid_subscription(uid)


### PR DESCRIPTION
## Summary

Fixes BYOK security flaws (#6880) and adds per-request fingerprint validation with Firestore as source of truth, applied to **all** endpoints via shared auth dependencies.

### Security fixes (from #6880)
- **ContextVar default**: Changed from mutable `{}` to `None` — prevents cross-request key leakage
- **TTLCache for LLM clients**: Replaced unbounded dicts with `TTLCache(maxsize=256, ttl=3600)`
- **Cache key hashing**: `hashlib.sha256` instead of Python's randomized `hash()`
- **Gemini header auth**: API key via `x-goog-api-key` header, never in URL
- **Fingerprint validation on activation**: SHA-256 hex format, all 4 providers, strict regex
- **Import fix**: Added missing `Subscription`/`SubscriptionStatus` imports in `routers/users.py`

### Per-request fingerprint validation (shared dependency — all endpoints)
- **Firestore = source of truth**: BYOK-active users MUST send keys matching enrolled SHA-256 fingerprints
- **HTTP (all endpoints)**: Validation in `get_current_user_uid()` shared auth dependency — every HTTP endpoint automatically covered
- **WebSocket (`/v4/listen`)**: Validation in `get_current_user_uid_ws_listen()` — extracts BYOK headers from WS upgrade request, validates against Firestore
- **Missing/mismatched → 403** (HTTP) or **close 4003** (WebSocket)
- **Mobile fallthrough**: BYOK-active users on mobile (no BYOK headers) fall through to Omi keys — NOT blocked
- **Non-BYOK users' headers silently cleared**: Prevents unauthorized BYOK usage
- **Expired BYOK (>7 days)**: Treated as non-BYOK, headers cleared
- **No per-endpoint validation code**: All validation centralized in `utils/other/endpoints.py`

### Firestore state TTL cache (performance)
- `TTLCache(maxsize=1024, ttl=30s)` for `get_byok_state()` results
- Reduces Firestore reads from 2-3x per request to ~1 per 30s per user
- Thread-safe with lock
- Activation/deactivation immediately invalidates cached entry

### Subscription bypass protection
- Bypass code kept pending full BYOK redesign (#6886)
- `/subscription` and `/usage-quota`: bypass only triggers when BYOK headers are actually present on the request (desktop), not just when Firestore says BYOK-active
- Mobile users always see their real subscription plan

### Import rule compliance
- All `from utils.byok import` moved to module top level per CLAUDE.md rule
- Applied to: `users.py`, `endpoints.py`, `subscription.py`

## Test plan
- **72 unit tests** across 16 test classes
- Covers: ContextVar safety, WebSocket extraction, fingerprint format, cache hashing, Gemini URL, quota bypass, activation validation, cache routing, middleware isolation, quota boundaries, per-request fingerprint validation (11 scenarios incl. mobile fallthrough + WS), state cache (4 tests)

## Related
- Fixes #6880
- Follow-up redesign: #6886

_by AI for @beastoin_