### PR TITLE
[security] fix(apps): require source-account proof for owner migration

### DIFF
--- a/app/lib/backend/http/api/apps.dart
+++ b/app/lib/backend/http/api/apps.dart
@@ -65,7 +65,7 @@ Future<({List<App> apps, Map<String, dynamic> pagination, Map<String, dynamic>? 
 }
 
 Future<({List<Map<String, dynamic>> groups, Map<String, dynamic>? capability, int totalApps})>
-retrieveCapabilityAppsGroupedByCategory({required String capability, bool includeReviews = true}) async {
+    retrieveCapabilityAppsGroupedByCategory({required String capability, bool includeReviews = true}) async {
   final url = '${Env.apiBaseUrl}v2/apps/capability/$capability/grouped?include_reviews=$includeReviews';
   final response = await makeApiCall(url: url, headers: {}, body: '', method: 'GET');
   try {

--- a/app/lib/backend/http/api/apps.dart
+++ b/app/lib/backend/http/api/apps.dart
@@ -608,10 +608,10 @@ Future<bool> deleteApiKeyServer(String appId, String keyId) async {
   }
 }
 
-Future<bool> migrateAppOwnerId(String oldId) async {
+Future<bool> migrateAppOwnerId(String oldId, String oldAuthToken) async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/apps/migrate-owner?old_id=$oldId',
-    headers: {},
+    headers: {'X-Old-Authorization': 'Bearer $oldAuthToken'},
     body: '',
     method: 'POST',
   );

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -217,13 +217,22 @@ class AuthenticationProvider extends BaseProvider {
       }
     } catch (e) {
       if (e is FirebaseAuthException && e.code == 'credential-already-in-use') {
+        final existingCred = e.credential;
         final oldUserId = FirebaseAuth.instance.currentUser?.uid;
         final oldAuthToken = await FirebaseAuth.instance.currentUser?.getIdToken();
-        if (oldUserId != null) {
-          final newUserId = FirebaseAuth.instance.currentUser?.uid;
-          if (newUserId != null && oldAuthToken != null && oldAuthToken.isNotEmpty) {
-            await migrateAppOwnerId(oldUserId, oldAuthToken);
-          }
+
+        await FirebaseAuth.instance.signOut();
+        await FirebaseAuth.instance.signInWithCredential(existingCred!);
+        final newUserId = FirebaseAuth.instance.currentUser?.uid;
+        await AuthService.instance.getIdToken();
+
+        SharedPreferencesUtil().onboardingCompleted = false;
+        SharedPreferencesUtil().uid = newUserId ?? '';
+        SharedPreferencesUtil().email = FirebaseAuth.instance.currentUser?.email ?? '';
+        SharedPreferencesUtil().givenName = FirebaseAuth.instance.currentUser?.displayName?.split(' ')[0] ?? '';
+
+        if (oldUserId != null && newUserId != null && oldAuthToken != null && oldAuthToken.isNotEmpty) {
+          await migrateAppOwnerId(oldUserId, oldAuthToken);
         }
         return;
       }

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -218,10 +218,11 @@ class AuthenticationProvider extends BaseProvider {
     } catch (e) {
       if (e is FirebaseAuthException && e.code == 'credential-already-in-use') {
         final oldUserId = FirebaseAuth.instance.currentUser?.uid;
+        final oldAuthToken = await FirebaseAuth.instance.currentUser?.getIdToken();
         if (oldUserId != null) {
           final newUserId = FirebaseAuth.instance.currentUser?.uid;
-          if (newUserId != null) {
-            await migrateAppOwnerId(oldUserId);
+          if (newUserId != null && oldAuthToken != null && oldAuthToken.isNotEmpty) {
+            await migrateAppOwnerId(oldUserId, oldAuthToken);
           }
         }
         return;
@@ -247,6 +248,7 @@ class AuthenticationProvider extends BaseProvider {
           // Get existing user credentials
           final existingCred = e.credential;
           final oldUserId = FirebaseAuth.instance.currentUser?.uid;
+          final oldAuthToken = await FirebaseAuth.instance.currentUser?.getIdToken();
 
           // Sign out current anonymous user
           await FirebaseAuth.instance.signOut();
@@ -260,8 +262,8 @@ class AuthenticationProvider extends BaseProvider {
           SharedPreferencesUtil().uid = newUserId ?? '';
           SharedPreferencesUtil().email = FirebaseAuth.instance.currentUser?.email ?? '';
           SharedPreferencesUtil().givenName = FirebaseAuth.instance.currentUser?.displayName?.split(' ')[0] ?? '';
-          if (oldUserId != null && newUserId != null) {
-            await migrateAppOwnerId(oldUserId);
+          if (oldUserId != null && newUserId != null && oldAuthToken != null && oldAuthToken.isNotEmpty) {
+            await migrateAppOwnerId(oldUserId, oldAuthToken);
           }
           return;
         }
@@ -282,7 +284,7 @@ class AuthenticationProvider extends BaseProvider {
     }
   }
 
-  Future<bool> migrateAppOwnerId(String oldId) async {
-    return await apps_api.migrateAppOwnerId(oldId);
+  Future<bool> migrateAppOwnerId(String oldId, String oldAuthToken) async {
+    return await apps_api.migrateAppOwnerId(oldId, oldAuthToken);
   }
 }

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -217,24 +217,33 @@ class AuthenticationProvider extends BaseProvider {
       }
     } catch (e) {
       if (e is FirebaseAuthException && e.code == 'credential-already-in-use') {
-        final existingCred = e.credential;
-        final oldUserId = FirebaseAuth.instance.currentUser?.uid;
-        final oldAuthToken = await FirebaseAuth.instance.currentUser?.getIdToken();
+        try {
+          final existingCred = e.credential;
+          final oldUserId = FirebaseAuth.instance.currentUser?.uid;
+          final oldAuthToken = await FirebaseAuth.instance.currentUser?.getIdToken();
 
-        await FirebaseAuth.instance.signOut();
-        await FirebaseAuth.instance.signInWithCredential(existingCred!);
-        final newUserId = FirebaseAuth.instance.currentUser?.uid;
-        await AuthService.instance.getIdToken();
+          await FirebaseAuth.instance.signOut();
+          await FirebaseAuth.instance.signInWithCredential(existingCred!);
+          final newUserId = FirebaseAuth.instance.currentUser?.uid;
+          await AuthService.instance.getIdToken();
 
-        SharedPreferencesUtil().onboardingCompleted = false;
-        SharedPreferencesUtil().uid = newUserId ?? '';
-        SharedPreferencesUtil().email = FirebaseAuth.instance.currentUser?.email ?? '';
-        SharedPreferencesUtil().givenName = FirebaseAuth.instance.currentUser?.displayName?.split(' ')[0] ?? '';
+          SharedPreferencesUtil().onboardingCompleted = false;
+          SharedPreferencesUtil().uid = newUserId ?? '';
+          SharedPreferencesUtil().email = FirebaseAuth.instance.currentUser?.email ?? '';
+          SharedPreferencesUtil().givenName = FirebaseAuth.instance.currentUser?.displayName?.split(' ')[0] ?? '';
 
-        if (oldUserId != null && newUserId != null && oldAuthToken != null && oldAuthToken.isNotEmpty) {
-          await migrateAppOwnerId(oldUserId, oldAuthToken);
+          if (oldUserId != null && newUserId != null && oldAuthToken != null && oldAuthToken.isNotEmpty) {
+            await migrateAppOwnerId(oldUserId, oldAuthToken);
+          }
+          return;
+        } catch (linkError) {
+          Logger.debug('Error linking with existing Google credential: $linkError');
+          AppSnackbar.showSnackbarError(
+            globalNavigatorKey.currentContext?.l10n.authFailedToLinkGoogle ??
+                'Failed to link with Google, please try again.',
+          );
+          rethrow;
         }
-        return;
       }
       AppSnackbar.showSnackbarError(
         globalNavigatorKey.currentContext?.l10n.authFailedToLinkGoogle ??

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1377,11 +1377,12 @@ async def migrate_app_owner(
     # Security boundary: callers must prove control of the source legacy
     # account before the backend migrates its apps or memories into the
     # authenticated destination account.
-    if not old_authorization or len(str(old_authorization).split(' ')) != 2:
+    scheme, _, token = old_authorization.partition(' ')
+    if scheme != 'Bearer' or not token:
         raise HTTPException(status_code=403, detail='You are not authorized to migrate this owner ID')
 
     try:
-        old_uid = auth.verify_token(old_authorization.split(' ')[1])
+        old_uid = auth.verify_token(token)
     except Exception:
         raise HTTPException(status_code=403, detail='You are not authorized to migrate this owner ID')
 

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1369,7 +1369,25 @@ async def get_twitter_initial_message(username: str, uid: str = Depends(auth.get
 
 
 @router.post('/v1/apps/migrate-owner', tags=['v1'])
-async def migrate_app_owner(old_id, uid: str = Depends(auth.get_current_user_uid)):
+async def migrate_app_owner(
+    old_id: str,
+    old_authorization: str = Header(..., alias='X-Old-Authorization'),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    # Security boundary: callers must prove control of the source legacy
+    # account before the backend migrates its apps or memories into the
+    # authenticated destination account.
+    if not old_authorization or len(str(old_authorization).split(' ')) != 2:
+        raise HTTPException(status_code=403, detail='You are not authorized to migrate this owner ID')
+
+    try:
+        old_uid = auth.verify_token(old_authorization.split(' ')[1])
+    except Exception:
+        raise HTTPException(status_code=403, detail='You are not authorized to migrate this owner ID')
+
+    if old_uid != old_id:
+        raise HTTPException(status_code=403, detail='You are not authorized to migrate a different owner ID')
+
     # Migrate app ownership in the database
     migrate_app_owner_id_db(uid, old_id)
 

--- a/backend/tests/unit/test_migrate_owner_authz.py
+++ b/backend/tests/unit/test_migrate_owner_authz.py
@@ -1,0 +1,94 @@
+import ast
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+
+def _load_migrate_app_owner(verified_old_uid='legacy-user', verify_raises=None):
+    path = Path('/tmp/omi-audit/backend/routers/apps.py')
+    source = path.read_text()
+    module = ast.parse(source)
+    fn = next(node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == 'migrate_app_owner')
+    mod = ast.Module(body=[fn], type_ignores=[])
+    ast.fix_missing_locations(mod)
+
+    calls = []
+    tasks = []
+
+    class FakeRouter:
+        def post(self, *args, **kwargs):
+            def deco(f):
+                return f
+            return deco
+
+    class FakeAsyncioModule:
+        def create_task(self, coro):
+            tasks.append(coro)
+            return f'task-{len(tasks)}'
+
+    async def fake_migrate_memories(old_id, uid):
+        calls.append(('migrate_memories', old_id, uid))
+        return 'ok'
+
+    async def fake_update(uid):
+        calls.append(('update_omi_persona_connected_accounts', uid))
+        return 'ok'
+
+    def fake_migrate_app_owner_id_db(uid, old_id):
+        calls.append(('migrate_app_owner_id_db', uid, old_id))
+
+    def fake_verify_token(token):
+        calls.append(('verify_token', token))
+        if verify_raises:
+            raise verify_raises
+        return verified_old_uid
+
+    ns = {
+        'router': FakeRouter(),
+        'asyncio': FakeAsyncioModule(),
+        'migrate_app_owner_id_db': fake_migrate_app_owner_id_db,
+        'migrate_memories': fake_migrate_memories,
+        'update_omi_persona_connected_accounts': fake_update,
+        'auth': type('A', (), {'get_current_user_uid': object(), 'verify_token': staticmethod(fake_verify_token)})(),
+        'Depends': lambda x: x,
+        'Header': lambda *args, **kwargs: None,
+        'HTTPException': HTTPException,
+    }
+    exec(compile(mod, str(path), 'exec'), ns)
+    return ns['migrate_app_owner'], calls, tasks
+
+
+@pytest.mark.asyncio
+async def test_migrate_owner_rejects_when_old_auth_token_does_not_match_old_id():
+    migrate_app_owner, calls, tasks = _load_migrate_app_owner(verified_old_uid='different-legacy-user')
+
+    with pytest.raises(HTTPException, match='not authorized'):
+        await migrate_app_owner('victim-old-uid', old_authorization='Bearer proof-token', uid='attacker-uid')
+
+    assert calls == [('verify_token', 'proof-token')]
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_migrate_owner_allows_proven_legacy_account_migration_only():
+    migrate_app_owner, calls, tasks = _load_migrate_app_owner(verified_old_uid='legacy-user')
+
+    result = await migrate_app_owner('legacy-user', old_authorization='Bearer proof-token', uid='new-user')
+
+    assert result == {'status': 'ok', 'message': 'Migration started'}
+    assert calls == [
+        ('verify_token', 'proof-token'),
+        ('migrate_app_owner_id_db', 'new-user', 'legacy-user'),
+    ]
+    assert len(tasks) == 2
+
+    for task in tasks:
+        await task
+
+    assert calls == [
+        ('verify_token', 'proof-token'),
+        ('migrate_app_owner_id_db', 'new-user', 'legacy-user'),
+        ('migrate_memories', 'legacy-user', 'new-user'),
+        ('update_omi_persona_connected_accounts', 'new-user'),
+    ]

--- a/backend/tests/unit/test_migrate_owner_authz.py
+++ b/backend/tests/unit/test_migrate_owner_authz.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 
 
 def _load_migrate_app_owner(verified_old_uid='legacy-user', verify_raises=None):
-    path = Path('/tmp/omi-audit/backend/routers/apps.py')
+    path = Path(__file__).resolve().parents[2] / 'routers' / 'apps.py'
     source = path.read_text()
     module = ast.parse(source)
     fn = next(node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == 'migrate_app_owner')


### PR DESCRIPTION
## Summary
- harden `/v1/apps/migrate-owner` so callers must prove control of the source account before the backend migrates apps or memories into the authenticated destination account
- reject arbitrary `old_id` migration attempts that previously let any authenticated user target another user’s legacy UID
- update the app linking flow to send a verified old-user token during the legitimate anonymous-to-existing-account migration path
- add focused regression coverage for both the reject and allow cases

## Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| Missing source-account proof in `/v1/apps/migrate-owner` | Authenticated cross-account app ownership reassignment and memory migration | High |

## Before this PR
- `/v1/apps/migrate-owner` trusted the caller-supplied `old_id` query parameter
- the backend immediately executed `migrate_app_owner_id_db(uid, old_id)`
- the backend also scheduled `migrate_memories(old_id, uid)` with no proof that the caller controlled `old_id`
- the mobile app only sent `old_id`, so the backend had no cryptographic continuity check between the old account and the new authenticated account

## After this PR
- `/v1/apps/migrate-owner` requires `X-Old-Authorization: Bearer <old_id_token>`
- the backend verifies that token and requires the verified source UID to match the supplied `old_id`
- cross-account migration attempts without proof now fail with 403 before any ownership or memory migration occurs
- the app now captures the old anonymous user token before sign-out and sends it only during the legitimate account-link migration flow
- regression tests lock in both the reject path and the valid legacy-account migration path

## Why this matters
The vulnerable route crossed a hard ownership boundary:

```text
attacker-chosen old_id
    -> /v1/apps/migrate-owner
        -> migrate_app_owner_id_db(uid, old_id)
        -> migrate_memories(old_id, uid)
            -> victim apps reassigned and victim memories copied into attacker account
```

Without proof of control for the source account, any authenticated user who knew or guessed another user’s legacy UID could attempt to migrate that data into their own account.

## Affected code

| Area | Files |
| --- | --- |
| backend migration guard | `backend/routers/apps.py` |
| regression tests | `backend/tests/unit/test_migrate_owner_authz.py` |
| app migration request wiring | `app/lib/backend/http/api/apps.dart` |
| app auth-link flow | `app/lib/providers/auth_provider.dart` |

## Root cause
- the route trusted a client-controlled legacy source UID without verifying that the caller controlled that source account
- the migration sinks (`migrate_app_owner_id_db` and `migrate_memories`) correctly performed writes for the supplied source/destination pair, but the route failed to enforce the ownership boundary before invoking them

## Safe reproduction steps
1. Authenticate as a normal user.
2. Send `POST /v1/apps/migrate-owner?old_id=<victim_legacy_uid>`.
3. Before this PR, the route immediately invoked app-owner reassignment and scheduled memory migration into the attacker account.
4. After this PR, the request must also include `X-Old-Authorization: Bearer <old_source_token>`.
5. If the verified source UID does not match `old_id`, the route returns 403 and performs no migration.

## Changes in this PR
- require `X-Old-Authorization` on `/v1/apps/migrate-owner`
- verify the supplied old-user token with the existing auth verifier
- require the verified old UID to match the requested `old_id`
- keep the successful migration flow intact once source-account proof is present
- update the app account-link flow to capture the old anonymous token before sign-out and submit it during migration
- add regression tests for:
  - mismatched old token -> 403, no migration side effects
  - valid old token for the source UID -> migration proceeds

## Adjacent public context
An earlier public PR, #1889 (`Fix migrate owner`), touched this same route but only corrected the connected-accounts/persona handling around the migration flow.

This PR is adjacent to #1889, not a reimplementation of that fix:
- #1889 addressed route behavior in the same area
- this PR fixes the remaining source-account authorization gap that still allowed attacker-controlled `old_id` migration on current code

## Type of change
- [x] Security bug fix
- [x] Regression test coverage
- [ ] New feature
- [ ] Breaking API change

## Test plan
- [x] `python -m pytest backend/tests/unit/test_migrate_owner_authz.py -q`
- [x] `python -m py_compile backend/routers/apps.py backend/tests/unit/test_migrate_owner_authz.py`
- [ ] Full backend test suite not run in this patch round
- [ ] Flutter/Dart formatter not run here (`dart` not available in this environment)

## Disclosure notes
- this patch is intentionally narrow: it hardens the migration trust boundary without changing unrelated app/persona flows
- the adjacent public route fix in #1889 is called out above so maintainers can review the full route history in one place
