### PR TITLE
fix: handle VM deleted in GCP while Firestore record still exists (#6891)

### DIFF
--- a/desktop/Backend-Rust/src/routes/agent.rs
+++ b/desktop/Backend-Rust/src/routes/agent.rs
@@ -264,6 +264,14 @@ async fn get_agent_status(
                             last_query_at: vm.last_query_at,
                         })));
                     }
+                    Ok(gce_status) if gce_status == "NOT_FOUND" => {
+                        tracing::warn!(
+                            "VM {} no longer exists in GCP — clearing Firestore record",
+                            vm.vm_name
+                        );
+                        let _ = state.firestore.delete_agent_vm(&user.uid).await;
+                        return Ok(Json(None));
+                    }
                     Ok(gce_status) if gce_status == "RUNNING"
                         && (vm.status == AgentVmStatus::Error
                             || vm.status == AgentVmStatus::Stopped) =>
@@ -372,6 +380,10 @@ async fn check_gce_instance_status(
         .await?
         .send()
         .await?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok("NOT_FOUND".to_string());
+    }
 
     let instance: serde_json::Value = resp.json().await?;
     let status = instance["status"]

--- a/desktop/Backend-Rust/src/services/firestore.rs
+++ b/desktop/Backend-Rust/src/services/firestore.rs
@@ -9658,6 +9658,17 @@ impl FirestoreService {
         self.update_user_fields(uid, fields, &["agentVm"]).await
     }
 
+    /// Delete the agentVm field from a user's document.
+    /// Used when the GCE VM no longer exists in GCP.
+    pub async fn delete_agent_vm(
+        &self,
+        uid: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Omitting agentVm from the body while including it in the update mask
+        // causes Firestore to delete the field.
+        self.update_user_fields(uid, json!({}), &["agentVm"]).await
+    }
+
     // =========================================================================
     // SCREEN ACTIVITY
     // =========================================================================


### PR DESCRIPTION
Fix: handle VM deleted in GCP while Firestore record still exists (#6891)

- Add `delete_agent_vm` to FirestoreService to clear the agentVm field
- Return "NOT_FOUND" from `check_gce_instance_status` on HTTP 404 instead of silently falling through as "UNKNOWN"
- Add NOT_FOUND match arm in `get_agent_status` to delete stale Firestore record and return null, allowing client to re-provision