### PR TITLE
desktop: shrink dashboard Tasks/Goals cards to fit content

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Dashboard Tasks/Goals cards now shrink to fit content instead of stretching to fill the screen"
+  ],
   "releases": [
     {
       "version": "0.11.343",

--- a/desktop/Desktop/Sources/MainWindow/Components/GoalsWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/GoalsWidget.swift
@@ -38,34 +38,29 @@ struct GoalsWidget: View {
 
             if goals.isEmpty {
                 // Empty state — header already has a + button, so just offer
-                // the AI generation action centered in the empty area.
-                VStack {
-                    Spacer(minLength: 0)
-
-                    Button(action: { triggerGoalGeneration() }) {
-                        HStack(spacing: 6) {
-                            if isGeneratingGoal {
-                                ProgressView()
-                                    .scaleEffect(0.6)
-                                    .frame(width: 12, height: 12)
-                            } else {
-                                Image(systemName: "sparkles")
-                                    .scaledFont(size: 12)
-                            }
-                            Text(isGeneratingGoal ? "Generating..." : "Generate AI Goal")
-                                .scaledFont(size: 13, weight: .medium)
+                // the AI generation action below.
+                Button(action: { triggerGoalGeneration() }) {
+                    HStack(spacing: 6) {
+                        if isGeneratingGoal {
+                            ProgressView()
+                                .scaleEffect(0.6)
+                                .frame(width: 12, height: 12)
+                        } else {
+                            Image(systemName: "sparkles")
+                                .scaledFont(size: 12)
                         }
-                        .foregroundColor(OmiColors.purplePrimary)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 9)
-                        .omiControlSurface(fill: OmiColors.purplePrimary.opacity(0.12), radius: OmiChrome.chipRadius)
+                        Text(isGeneratingGoal ? "Generating..." : "Generate AI Goal")
+                            .scaledFont(size: 13, weight: .medium)
                     }
-                    .buttonStyle(.plain)
-                    .disabled(isGeneratingGoal)
-
-                    Spacer(minLength: 0)
+                    .foregroundColor(OmiColors.purplePrimary)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 9)
+                    .omiControlSurface(fill: OmiColors.purplePrimary.opacity(0.12), radius: OmiChrome.chipRadius)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .buttonStyle(.plain)
+                .disabled(isGeneratingGoal)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
             } else {
                 // Goals list
                 VStack(spacing: 14) {
@@ -85,7 +80,7 @@ struct GoalsWidget: View {
             }
         }
         .padding(22)
-        .frame(maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .omiPanel(fill: OmiColors.backgroundSecondary)
         .sheet(isPresented: $showingCreateSheet) {
             GoalEditSheet(

--- a/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
@@ -31,64 +31,51 @@ struct TasksWidget: View {
 
             if totalTaskCount == 0 {
                 // Empty state
-                VStack {
-                    Spacer(minLength: 0)
-
-                    VStack(spacing: 8) {
-                        Image(systemName: "checkmark.circle")
-                            .scaledFont(size: 28)
-                            .foregroundColor(OmiColors.textQuaternary)
-                        Text("No incomplete tasks")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Spacer(minLength: 0)
+                VStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle")
+                        .scaledFont(size: 28)
+                        .foregroundColor(OmiColors.textQuaternary)
+                    Text("No incomplete tasks")
+                        .scaledFont(size: 13)
+                        .foregroundColor(OmiColors.textTertiary)
                 }
                 .frame(maxWidth: .infinity)
-                .frame(maxHeight: .infinity)
+                .padding(.vertical, 12)
             } else {
                 let allTasks = (combinedTodayTasks + recentTasks).prefix(3)
 
-                VStack(spacing: 0) {
-                    Spacer(minLength: 0)
-
-                    VStack(spacing: 10) {
-                        ForEach(Array(allTasks)) { task in
-                            TaskRowView(
-                                task: task,
-                                onToggle: { onToggleCompletion(task) }
-                            )
-                        }
-                    }
-
-                    Button(action: {
-                        NotificationCenter.default.post(
-                            name: .navigateToTasks,
-                            object: nil
+                VStack(spacing: 10) {
+                    ForEach(Array(allTasks)) { task in
+                        TaskRowView(
+                            task: task,
+                            onToggle: { onToggleCompletion(task) }
                         )
-                    }) {
-                        HStack {
-                            Spacer()
-                            Text("View all tasks")
-                                .scaledFont(size: 12, weight: .semibold)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Image(systemName: "chevron.right")
-                                .scaledFont(size: 10)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Spacer()
-                        }
                     }
-                    .buttonStyle(.plain)
-                    .padding(.top, 8)
-
-                    Spacer(minLength: 0)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                Button(action: {
+                    NotificationCenter.default.post(
+                        name: .navigateToTasks,
+                        object: nil
+                    )
+                }) {
+                    HStack {
+                        Spacer()
+                        Text("View all tasks")
+                            .scaledFont(size: 12, weight: .semibold)
+                            .foregroundColor(OmiColors.textSecondary)
+                        Image(systemName: "chevron.right")
+                            .scaledFont(size: 10)
+                            .foregroundColor(OmiColors.textSecondary)
+                        Spacer()
+                    }
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 4)
             }
         }
         .padding(22)
-        .frame(maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .omiPanel(fill: OmiColors.backgroundSecondary)
     }
 }


### PR DESCRIPTION
## Summary
Both `TasksWidget` and `GoalsWidget` had `.frame(maxHeight: .infinity, alignment: .topLeading)` at their root. With `ChatMessagesView` below them (also `maxHeight: .infinity`), the two siblings competed for vertical space and each grabbed roughly half the dashboard — even when the Tasks card had 2–3 rows and the Goals card had 1–2 goals.

This PR removes the maxHeight infinity from both widget roots and the inner Spacers in the non-empty branches, so the cards size to their content. The Grid in `DashboardPage.expandedWidgets` still equalizes the row to the taller of the two intrinsic heights.

## Test plan
- [ ] Open the dashboard with a small number of tasks (≤3) and goals (≤2) — both cards should hug their content; chat should fill the rest.
- [ ] Scale up tasks to ~10 — Tasks card grows to fit 3 rows + "View all" footer (`prefix(3)` is unchanged); Goals card matches its height.
- [ ] Empty state for both — cards display their empty-state content with reasonable padding instead of large empty centered area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)