### PR TITLE
desktop: equalize dashboard card heights

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Dashboard Tasks/Goals cards now shrink to fit content instead of stretching to fill the screen"
+    "Dashboard Tasks/Goals cards now shrink to fit content instead of stretching to fill the screen",
+    "Dashboard Tasks/Goals cards now match heights even when shrunk to fit content"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/MainWindow/Components/GoalsWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/GoalsWidget.swift
@@ -80,7 +80,7 @@ struct GoalsWidget: View {
             }
         }
         .padding(22)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .omiPanel(fill: OmiColors.backgroundSecondary)
         .sheet(isPresented: $showingCreateSheet) {
             GoalEditSheet(

--- a/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
@@ -75,7 +75,7 @@ struct TasksWidget: View {
             }
         }
         .padding(22)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .omiPanel(fill: OmiColors.backgroundSecondary)
     }
 }

--- a/desktop/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -458,6 +458,10 @@ struct DashboardPage: View {
     }
 
     private var expandedWidgets: some View {
+        // fixedSize(vertical:) constrains the Grid to its row's intrinsic
+        // height so Tasks/Goals stop competing with ChatMessagesView for
+        // vertical space; each cell still fills the row, so the two cards
+        // remain visually equal-height (matching the taller intrinsic).
         Grid(horizontalSpacing: 20, verticalSpacing: 20) {
             GridRow {
                 TasksWidget(
@@ -508,6 +512,7 @@ struct DashboardPage: View {
                 .frame(minWidth: 0, maxWidth: .infinity)
             }
         }
+        .fixedSize(horizontal: false, vertical: true)
         .transition(.opacity.combined(with: .move(edge: .top)))
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #6902. The shrink-to-fit fix landed but the two cards no longer matched heights — the shorter card's panel left a visible gap because Grid cells don't auto-stretch to row height when the cell views are intrinsic-sized.

This PR:
- Restores `.frame(maxHeight: .infinity, alignment: .topLeading)` on each widget root so each card fills its grid cell.
- Adds `.fixedSize(horizontal: false, vertical: true)` on the Grid in `DashboardPage.expandedWidgets` so the Grid itself reports only the row's intrinsic height instead of competing with `ChatMessagesView` for vertical space.

Net effect: cards size to the taller of the two intrinsic heights (matching), and the rest of the dashboard goes to the chat view as before.

## Test plan
- [ ] Dashboard with mismatched content (e.g. 3 tasks, 1 goal) — both cards' panels are the same height (taller intrinsic wins).
- [ ] Dashboard with similar content (3 tasks, 3 goals) — same height, both compact.
- [ ] Empty state on either card — both still equal-height with reasonable padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)