### PR TITLE
desktop: vertically center dashboard Tasks/Goals rows

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Center dashboard Tasks/Goals rows vertically when one card is shorter than the other"
+  ],
   "releases": [
     {
       "version": "0.11.345",

--- a/desktop/Desktop/Sources/MainWindow/Components/GoalsWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/GoalsWidget.swift
@@ -38,45 +38,59 @@ struct GoalsWidget: View {
 
             if goals.isEmpty {
                 // Empty state — header already has a + button, so just offer
-                // the AI generation action below.
-                Button(action: { triggerGoalGeneration() }) {
-                    HStack(spacing: 6) {
-                        if isGeneratingGoal {
-                            ProgressView()
-                                .scaleEffect(0.6)
-                                .frame(width: 12, height: 12)
-                        } else {
-                            Image(systemName: "sparkles")
-                                .scaledFont(size: 12)
-                        }
-                        Text(isGeneratingGoal ? "Generating..." : "Generate AI Goal")
-                            .scaledFont(size: 13, weight: .medium)
-                    }
-                    .foregroundColor(OmiColors.purplePrimary)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 9)
-                    .omiControlSurface(fill: OmiColors.purplePrimary.opacity(0.12), radius: OmiChrome.chipRadius)
-                }
-                .buttonStyle(.plain)
-                .disabled(isGeneratingGoal)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-            } else {
-                // Goals list
-                VStack(spacing: 14) {
-                    ForEach(Array(goals.enumerated()), id: \.element.id) { index, goal in
-                        GoalRowView(
-                            goal: goal,
-                            index: index,
-                            onTap: { editingGoal = goal },
-                            onUpdateProgress: { value in onUpdateProgress(goal, value) },
-                            onDelete: { onDeleteGoal(goal) },
-                            onGetInsight: {
-                                selectedGoalForInsight = goal
+                // the AI generation action centered in the empty area.
+                VStack(spacing: 0) {
+                    Spacer(minLength: 0)
+
+                    Button(action: { triggerGoalGeneration() }) {
+                        HStack(spacing: 6) {
+                            if isGeneratingGoal {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(width: 12, height: 12)
+                            } else {
+                                Image(systemName: "sparkles")
+                                    .scaledFont(size: 12)
                             }
-                        )
+                            Text(isGeneratingGoal ? "Generating..." : "Generate AI Goal")
+                                .scaledFont(size: 13, weight: .medium)
+                        }
+                        .foregroundColor(OmiColors.purplePrimary)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 9)
+                        .omiControlSurface(fill: OmiColors.purplePrimary.opacity(0.12), radius: OmiChrome.chipRadius)
                     }
+                    .buttonStyle(.plain)
+                    .disabled(isGeneratingGoal)
+
+                    Spacer(minLength: 0)
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                // Goals list — centered vertically in remaining cell height
+                // so a shorter Goals list floats to the middle when the
+                // Tasks card determines the row's intrinsic height.
+                VStack(spacing: 0) {
+                    Spacer(minLength: 0)
+
+                    VStack(spacing: 14) {
+                        ForEach(Array(goals.enumerated()), id: \.element.id) { index, goal in
+                            GoalRowView(
+                                goal: goal,
+                                index: index,
+                                onTap: { editingGoal = goal },
+                                onUpdateProgress: { value in onUpdateProgress(goal, value) },
+                                onDelete: { onDeleteGoal(goal) },
+                                onGetInsight: {
+                                    selectedGoalForInsight = goal
+                                }
+                            )
+                        }
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .padding(22)

--- a/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
@@ -30,48 +30,63 @@ struct TasksWidget: View {
             }
 
             if totalTaskCount == 0 {
-                // Empty state
-                VStack(spacing: 8) {
-                    Image(systemName: "checkmark.circle")
-                        .scaledFont(size: 28)
-                        .foregroundColor(OmiColors.textQuaternary)
-                    Text("No incomplete tasks")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
+                // Empty state — vertically centered in the cell
+                VStack(spacing: 0) {
+                    Spacer(minLength: 0)
+
+                    VStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle")
+                            .scaledFont(size: 28)
+                            .foregroundColor(OmiColors.textQuaternary)
+                        Text("No incomplete tasks")
+                            .scaledFont(size: 13)
+                            .foregroundColor(OmiColors.textTertiary)
+                    }
+
+                    Spacer(minLength: 0)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 let allTasks = (combinedTodayTasks + recentTasks).prefix(3)
 
-                VStack(spacing: 10) {
-                    ForEach(Array(allTasks)) { task in
-                        TaskRowView(
-                            task: task,
-                            onToggle: { onToggleCompletion(task) }
-                        )
-                    }
-                }
+                // Task rows + "View all" centered vertically in remaining
+                // cell height — when the Goals card is taller, the row
+                // group floats to the middle instead of pinning to the top.
+                VStack(spacing: 0) {
+                    Spacer(minLength: 0)
 
-                Button(action: {
-                    NotificationCenter.default.post(
-                        name: .navigateToTasks,
-                        object: nil
-                    )
-                }) {
-                    HStack {
-                        Spacer()
-                        Text("View all tasks")
-                            .scaledFont(size: 12, weight: .semibold)
-                            .foregroundColor(OmiColors.textSecondary)
-                        Image(systemName: "chevron.right")
-                            .scaledFont(size: 10)
-                            .foregroundColor(OmiColors.textSecondary)
-                        Spacer()
+                    VStack(spacing: 10) {
+                        ForEach(Array(allTasks)) { task in
+                            TaskRowView(
+                                task: task,
+                                onToggle: { onToggleCompletion(task) }
+                            )
+                        }
                     }
+
+                    Button(action: {
+                        NotificationCenter.default.post(
+                            name: .navigateToTasks,
+                            object: nil
+                        )
+                    }) {
+                        HStack {
+                            Spacer()
+                            Text("View all tasks")
+                                .scaledFont(size: 12, weight: .semibold)
+                                .foregroundColor(OmiColors.textSecondary)
+                            Image(systemName: "chevron.right")
+                                .scaledFont(size: 10)
+                                .foregroundColor(OmiColors.textSecondary)
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 8)
+
+                    Spacer(minLength: 0)
                 }
-                .buttonStyle(.plain)
-                .padding(.top, 4)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .padding(22)


### PR DESCRIPTION
## Summary
Follow-up to #6903. With the cards now equalized to the taller intrinsic height, the shorter card's rows pinned to the top, leaving a visible gap below. This PR centers the rows vertically inside each card so they float to the middle when the sibling card is taller.

Wraps the existing row VStack in `VStack(spacing: 0) { Spacer(minLength: 0); … ; Spacer(minLength: 0) }.frame(maxHeight: .infinity)` for both empty and non-empty branches in `TasksWidget` and `GoalsWidget`.

## Test plan
- [ ] Dashboard with 2 tasks and 4 goals — Tasks rows centered vertically; Goals fills.
- [ ] Dashboard with 4 tasks and 1 goal — Goals row centered; Tasks fills.
- [ ] Empty state on either side — empty content stays centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)