### PR TITLE
Update CHANGELOG.json for v0.11.346 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Center dashboard Tasks/Goals rows vertically when one card is shorter than the other"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.346",
+      "date": "2026-04-21",
+      "changes": [
+        "Center dashboard Tasks/Goals rows vertically when one card is shorter than the other"
+      ]
+    },
     {
       "version": "0.11.345",
       "date": "2026-04-20",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.346 and clears the unreleased array.