### PR TITLE
Fix BYOK bypass for /v4/listen + offer BYOK on usage-limit popup

### DIFF
--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -1017,32 +1017,35 @@ class TestWSAuthDependencyBYOK:
     @patch('utils.other.endpoints.validate_byok_websocket', return_value=None)
     @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
     def test_ws_listen_with_byok_headers_validates(self, _mock_auth, mock_validate):
+        import asyncio
         from utils.other.endpoints import get_current_user_uid_ws_listen
 
         ws = self._make_ws({'x-byok-openai': 'sk-test'})
-        uid = get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok')
+        uid = asyncio.run(get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok'))
         assert uid == 'ws-uid'
         mock_validate.assert_called_once_with('ws-uid')
 
     @patch('utils.other.endpoints.validate_byok_websocket', return_value=None)
     @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
     def test_ws_listen_no_headers_passes(self, _mock_auth, mock_validate):
+        import asyncio
         from utils.other.endpoints import get_current_user_uid_ws_listen
 
         ws = self._make_ws({})
-        uid = get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok')
+        uid = asyncio.run(get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok'))
         assert uid == 'ws-uid'
         mock_validate.assert_called_once()
 
     @patch('utils.other.endpoints.validate_byok_websocket', return_value='fingerprint mismatch')
     @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
     def test_ws_listen_validation_failure_raises_4003(self, _mock_auth, _mock_validate):
+        import asyncio
         from fastapi import WebSocketException
         from utils.other.endpoints import get_current_user_uid_ws_listen
 
         ws = self._make_ws({'x-byok-openai': 'wrong-key'})
         with pytest.raises(WebSocketException) as exc_info:
-            get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok')
+            asyncio.run(get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok'))
         assert exc_info.value.code == 4003
 
 

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import time
@@ -142,7 +143,7 @@ def _verify_ws_auth(authorization: str) -> str:
         raise WebSocketException(code=1008, reason="Auth error")
 
 
-def get_current_user_uid_ws_listen(
+async def get_current_user_uid_ws_listen(
     websocket: WebSocket = None,
     authorization: str = Header(None),
 ):
@@ -154,15 +155,23 @@ def get_current_user_uid_ws_listen(
     Also extracts BYOK headers from the WS upgrade request and validates
     them against Firestore enrollment (BaseHTTPMiddleware doesn't fire for
     WebSocket scope, so this is the shared entry point for WS BYOK).
+
+    **Why async:** Starlette runs sync WS deps in a worker thread via
+    ``anyio.to_thread.run_sync``, which copies the context. ContextVar
+    mutations inside the sync dep (``set_byok_keys``) are discarded when
+    control returns to the async handler, so ``get_byok_key('deepgram')``
+    would return None downstream. Running the dep on the event loop keeps
+    the mutation in the handler's context; the blocking Firebase and
+    Firestore calls are offloaded via ``asyncio.to_thread``.
     """
-    uid = _verify_ws_auth(authorization)
+    uid = await asyncio.to_thread(_verify_ws_auth, authorization)
 
     # Extract BYOK headers from the WS upgrade request and validate.
     if websocket is not None:
         byok_keys = extract_byok_from_websocket(websocket)
         if byok_keys:
             set_byok_keys(byok_keys)
-        error = validate_byok_websocket(uid)
+        error = await asyncio.to_thread(validate_byok_websocket, uid)
         if error:
             raise WebSocketException(code=4003, reason=error)
 

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -115,6 +115,13 @@ struct DesktopHomeView: View {
                   },
                   onDismiss: {
                     appState.showUsageLimitPopup = false
+                  },
+                  onBringYourOwnKeys: {
+                    appState.showUsageLimitPopup = false
+                    selectedSettingsSection = .advanced
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                      selectedIndex = SidebarNavItem.settings.rawValue
+                    }
                   }
                 )
               }

--- a/desktop/Desktop/Sources/UsageLimitPopupView.swift
+++ b/desktop/Desktop/Sources/UsageLimitPopupView.swift
@@ -10,6 +10,7 @@ struct UsageLimitPopupView: View {
   let reason: String
   let onUpgrade: () -> Void
   let onDismiss: () -> Void
+  let onBringYourOwnKeys: () -> Void
 
   private var headline: String {
     "You've hit your monthly limit"
@@ -89,10 +90,10 @@ struct UsageLimitPopupView: View {
             }
             .buttonStyle(.plain)
 
-            Button(action: onDismiss) {
-              Text("Not now")
+            Button(action: onBringYourOwnKeys) {
+              Text("Bring your own keys")
                 .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textTertiary)
+                .foregroundColor(OmiColors.purplePrimary)
                 .frame(maxWidth: .infinity)
                 .frame(height: 32)
             }
@@ -121,7 +122,8 @@ struct UsageLimitPopupView: View {
   UsageLimitPopupView(
     reason: "transcription",
     onUpgrade: {},
-    onDismiss: {}
+    onDismiss: {},
+    onBringYourOwnKeys: {}
   )
   .frame(width: 900, height: 600)
 }


### PR DESCRIPTION
## Summary
- **Backend**: `get_current_user_uid_ws_listen` is now `async`. The previous sync dep ran in an `anyio` threadpool with a copied context, so `set_byok_keys()` mutations were discarded before the async `/v4/listen` handler read them. Result: BYOK users kept hitting the freemium transcription threshold (`freemium_threshold_reached`) even with all four keys configured. Blocking Firebase/Firestore calls inside the dep are offloaded via `asyncio.to_thread` so the event loop stays unblocked.
- **Desktop**: usage-limit popup secondary action is now **"Bring your own keys"** instead of "Not now" — navigates to Settings → Advanced where the user can wire their own keys and use Omi free. Dismiss-via-X is unchanged.

## Test plan
- [x] `backend/tests/unit/test_byok_security.py` (direct-call tests) — updated to `asyncio.run` the now-async dep.
- [x] `backend/tests/unit/test_ws_auth_handshake.py` (TestClient-based) — unchanged, FastAPI handles async deps natively.
- [ ] Manual: sign in on a BYOK-configured build, connect `/v4/listen`, run past 20 h of transcription → no freemium popup.
- [ ] Manual: force-trigger popup on non-BYOK user → confirm "Bring your own keys" text routes to Advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)