### PR TITLE
Issue-6894:Fix from-segments endpoint 500 CreateConversation missing text_source

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -938,7 +938,7 @@ def create_conversation_from_segments(
     language_code = request.language or 'en'
 
     # Source defaults
-    source = request.source or ConversationSource.external_integration
+    source = request.source or ConversationSource.omi
 
     # Create conversation object with transcript segments
     create_conversation_obj = CreateConversation(

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -94,7 +94,7 @@ def _get_structured(
         if (
             conversation.source == ConversationSource.workflow
             or conversation.source == ConversationSource.external_integration
-        ):
+        ) and isinstance(conversation, ExternalIntegrationCreateConversation):
             if conversation.text_source == ExternalIntegrationConversationSource.audio:
                 structured = get_transcript_structure(
                     conversation.text,


### PR DESCRIPTION
The /v1/dev/user/conversations/from-segments endpoint creates a CreateConversation object (which has transcript_segments but no text_source attribute) and defaults source to external_integration. In _get_structured(), the code checks source == external_integration then immediately accesses conversation.text_source, causing an AttributeError caught as a generic 500.

Fix: add isinstance check so the text_source branch only runs for ExternalIntegrationCreateConversation objects, and change the from-segments endpoint to default to ConversationSource.omi since it provides transcript segments, not external text.

Fixes #6894