### PR TITLE
Issue-6575:Fix filler-word stripping breaking non-English words in multi-language

### DIFF
--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -448,7 +448,7 @@ def connect_to_deepgram(
             smart_format=True,
             profanity_filter=False,
             diarize=True,
-            filler_words=False,
+            filler_words=(language == 'multi'),
             channels=channels,
             multichannel=channels > 1,
             model=model,


### PR DESCRIPTION
…e mode

Deepgram's filler_words=False strips tokens like "um/uh" which are valid words in other languages (e.g. Portuguese "um" = "a/one"). Only disable filler word stripping in multi-language mode so real words are preserved. English-only mode keeps filler stripping on.

Fixes #6575