### PR TITLE
Don't 403 plan pages on BYOK drift + show Operator/Neo in desktop catalog

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -182,7 +182,10 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
 
 @router.get('/v1/payments/available-plans', response_model=AvailablePlansResponse)
 def get_available_plans_endpoint(
-    uid: str = Depends(auth.get_current_user_uid),
+    # Payment / plan surfaces must stay reachable even if BYOK fingerprints
+    # drift (e.g. user rotated a key locally without re-activating). Otherwise
+    # a broken-BYOK user can't see or change their plan to recover.
+    uid: str = Depends(auth.get_current_user_uid_no_byok_validation),
     x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
     x_app_version: Optional[str] = Header(None, alias='X-App-Version'),
 ):
@@ -332,7 +335,7 @@ class OverageInfoResponse(BaseModel):
 
 
 @router.get('/v1/payments/overage-info', response_model=OverageInfoResponse)
-def get_overage_info_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_overage_info_endpoint(uid: str = Depends(auth.get_current_user_uid_no_byok_validation)):
     """Explain overage billing + return the user's current accrued charge.
 
     Powers the clickable "What happens past the limit?" text on the plan page.

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -822,7 +822,9 @@ def _byok_unlimited_subscription() -> Subscription:
 
 @router.get('/v1/users/me/subscription', tags=['v1'], response_model=UserSubscriptionResponse)
 def get_user_subscription_endpoint(
-    uid: str = Depends(auth.get_current_user_uid),
+    # Keep reachable even when BYOK fingerprints drift — broken-BYOK users
+    # must still see their plan so they can recover.
+    uid: str = Depends(auth.get_current_user_uid_no_byok_validation),
     x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
     x_app_version: Optional[str] = Header(None, alias='X-App-Version'),
 ):

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -6250,8 +6250,14 @@ struct SettingsContentView: View {
 
   private func normalizedPlanId(from title: String) -> String? {
     let normalized = title.lowercased()
-    if normalized.contains("unlimited") {
+    // Match the three plan families by title keyword. Neo is the post-rename
+    // display name for the legacy "unlimited" plan and still maps to that id
+    // because Stripe/backend PlanType enum is unchanged.
+    if normalized.contains("unlimited") || normalized.contains("neo") {
       return "unlimited"
+    }
+    if normalized.contains("operator") {
+      return "operator"
     }
     if normalized.contains("architect") || normalized.contains("pro") {
       return "architect"
@@ -6270,7 +6276,9 @@ struct SettingsContentView: View {
       let title: String
       switch planId {
       case "unlimited":
-        title = "Plus"
+        title = "Neo"
+      case "operator":
+        title = "Operator"
       case "architect":
         title = "Architect"
       default:


### PR DESCRIPTION
## Summary
Fixes three separate issues that surfaced testing with a real BYOK user on prod:

### 1. BYOK fingerprint drift 403s every plan/subscription endpoint
If a BYOK user rotates a provider key locally without re-activating, `validate_byok_request` raises 403 on *every* endpoint that uses `get_current_user_uid`. That locks them out of Plan & Usage — they can't see or change their plan to recover. Switch `/v1/payments/available-plans`, `/v1/payments/overage-info`, and `/v1/users/me/subscription` to `get_current_user_uid_no_byok_validation`. Chat and listen continue to validate strictly — a mismatched key there is a real problem worth catching.

### 2. `normalizedPlanId` dropped Neo and Operator
Desktop's `planCatalog(from:)` groups plans by `normalizedPlanId(from: price.title)`. The matcher only recognised "unlimited", "architect", "pro" — so "Neo Monthly" and "Operator Monthly" both collapsed to `"unknown"` and got filtered out. For BYOK users the primary catalog (`userSubscription.availablePlans`) is empty, so the fallback from `/v1/payments/available-plans` is the only source — which means Operator disappeared from the picker entirely. Fix adds explicit "neo" and "operator" matches.

### 3. Proper fallback titles
Fallback catalog titled Neo as "Plus" and left Operator with the raw price-title ("Operator Monthly"). Swap to clean display names.

## What this does NOT fix
Per-key validation in Settings (no UI warning when the locally-stored key hash diverges from the enrolled fingerprint). That's a separate follow-up — the current PR just keeps the plans page reachable when drift happens.

## Test plan
- [x] `GET /v1/payments/available-plans` returns normally for a user whose local key hash doesn't match their Firestore fingerprint
- [x] Fallback plan catalog parses "Neo Monthly", "Operator Monthly", "Architect Monthly" correctly
- [ ] Manual: on Omi Beta with mismatched BYOK key, Plan & Usage page loads all three plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)