### PR TITLE
Reply gracefully in chat when monthly quota is exceeded

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -90,6 +90,63 @@ def acquire_chat_session(uid: str, app_id: Optional[str] = None):
     return chat_session
 
 
+def _build_quota_exceeded_reply(
+    uid: str, data: SendMessageRequest, compat_app_id: Optional[str], detail: dict
+) -> ResponseMessage:
+    """Persist the user's question + a canned AI reply and return it.
+
+    Mobile clients render the reply as a normal AI message, so users on
+    older builds without structured 402 handling at least see *why* nothing
+    happened instead of a silent failure. Desktop never reaches this path —
+    its client-side quota pre-check in ACPBridge throws BridgeError.quotaExceeded
+    before the request fires.
+    """
+    now = datetime.now(timezone.utc)
+    user_msg = Message(
+        id=str(uuid.uuid4()),
+        text=data.text,
+        created_at=now,
+        sender='human',
+        type='text',
+        app_id=compat_app_id,
+    )
+    chat_db.add_message(uid, user_msg.dict())
+
+    plan = detail.get('plan') or 'Free'
+    unit = detail.get('unit')
+    limit = detail.get('limit')
+    reset_at = detail.get('reset_at')
+    if unit == 'cost_usd' and isinstance(limit, (int, float)):
+        limit_phrase = f"your ${int(limit)} monthly AI compute budget"
+    elif isinstance(limit, (int, float)):
+        limit_phrase = f"your {int(limit)} monthly chat question limit"
+    else:
+        limit_phrase = "your monthly chat limit"
+    reset_phrase = ''
+    if reset_at:
+        try:
+            reset_dt = datetime.fromtimestamp(int(reset_at), tz=timezone.utc)
+            reset_phrase = f' Your limit resets on {reset_dt.strftime("%B %-d")}.'
+        except (TypeError, ValueError):
+            pass
+
+    canned = (
+        f"You've reached {limit_phrase} on the {plan} plan.{reset_phrase}\n\n"
+        "Upgrade your plan to keep chatting, or bring your own API keys in Settings "
+        "to use Omi free."
+    )
+    ai_msg = Message(
+        id=str(uuid.uuid4()),
+        text=canned,
+        created_at=datetime.now(timezone.utc),
+        sender='ai',
+        type='text',
+        app_id=compat_app_id,
+    )
+    chat_db.add_message(uid, ai_msg.dict())
+    return ResponseMessage(**ai_msg.dict(), ask_for_nps=False)
+
+
 @router.post('/v2/messages', tags=['chat'], response_model=ResponseMessage)
 def send_message(
     data: SendMessageRequest,
@@ -97,10 +154,22 @@ def send_message(
     app_id: Optional[str] = None,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "chat:send_message")),
 ):
-    # Hard cap: Free/Plus by question count, Pro by cost_usd. Raises 402 with a
-    # structured body the client can use to render the upgrade modal.
-    # (BYOK validation already ran in get_current_user_uid dependency.)
-    enforce_chat_quota(uid)
+    # Hard cap: Free by question count, Architect by cost_usd. Operator enters
+    # overage mode silently. If exceeded, instead of raising 402 (which older
+    # mobile clients swallow as a generic error), save a canned AI reply so
+    # the user sees why they're blocked. Desktop pre-checks via
+    # /v1/users/me/usage-quota and never reaches here when over.
+    try:
+        enforce_chat_quota(uid)
+    except HTTPException as exc:
+        if exc.status_code != 402 or not isinstance(exc.detail, dict):
+            raise
+        if exc.detail.get('error') != 'quota_exceeded':
+            raise
+        _compat_id = app_id or plugin_id
+        if _compat_id in ['null', '']:
+            _compat_id = None
+        return _build_quota_exceeded_reply(uid, data, _compat_id, exc.detail)
 
     compat_app_id = app_id or plugin_id
     logger.info(f'send_message {data.text} {compat_app_id} {uid}')


### PR DESCRIPTION
## Summary
Older mobile builds don't render the structured 402 body from `enforce_chat_quota` — the request just fails silently and the user has no idea their plan is capped.

Catch the `HTTPException` inside `POST /v2/messages`, save a canned AI reply into the user's chat, and return it like any other response. User sees something like:
> You've reached your 30 monthly chat question limit on the Free plan. Your limit resets on May 1.
> 
> Upgrade your plan to keep chatting, or bring your own API keys in Settings to use Omi free.

## Why this is safe
- **Desktop unaffected**: ACPBridge pre-checks `/v1/users/me/usage-quota` and throws `BridgeError.quotaExceeded` before the request is made. Never reaches the new path.
- **Voice messages (`/v2/voice-messages`) still 402**: streaming path is harder to inject copy into and mobile exposes a separate voice flow.
- **Only triggers on `quota_exceeded`**: all other 402s still propagate normally.

## Test plan
- [x] Syntax compiles
- [ ] Manual: set `FREE_CHAT_QUESTIONS_PER_MONTH=0` locally, POST /v2/messages, confirm the canned reply is saved + returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)