### PR TITLE
Desktop: defer auto-update when a conversation is active

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Auto-updates no longer install during an active conversation \u2014 the app waits for 2 minutes of silence before restarting"
+  ],
   "releases": [
     {
       "version": "0.11.348",

--- a/desktop/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/Desktop/Sources/UpdaterViewModel.swift
@@ -224,10 +224,24 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
       return false
     }
 
+    if let lastSpeech = VADGateService.lastSpeechAt {
+      let secondsSinceSpeech = Date().timeIntervalSince(lastSpeech)
+      if secondsSinceSpeech < UpdaterDelegate.activeCallSilenceWindow {
+        logSync(
+          "Sparkle: Deferring update v\(version) — speech detected \(Int(secondsSinceSpeech))s ago (active recording)"
+        )
+        return false
+      }
+    }
+
     logSync("Sparkle: Triggering immediate installation for v\(version)")
     installationBlock()
     return true
   }
+
+  /// Minimum seconds of VAD silence required before an auto-install is allowed.
+  /// Matches the typical pause threshold at which a real conversation has wound down.
+  fileprivate static let activeCallSilenceWindow: TimeInterval = 120
 }
 
 /// View model for managing Sparkle auto-updates

--- a/desktop/Desktop/Sources/VADGateService.swift
+++ b/desktop/Desktop/Sources/VADGateService.swift
@@ -280,6 +280,21 @@ final class VADGateService {
     // Fail-open flag
     let modelAvailable: Bool
 
+    // Shared wall-clock timestamp of the most recent frame classified as speech.
+    // Used by the Sparkle updater gate to defer restarts during active conversations.
+    private static let lastSpeechLock = NSLock()
+    private static var _lastSpeechAt: Date?
+    static var lastSpeechAt: Date? {
+        lastSpeechLock.lock()
+        defer { lastSpeechLock.unlock() }
+        return _lastSpeechAt
+    }
+    fileprivate static func markSpeechDetected(at date: Date = Date()) {
+        lastSpeechLock.lock()
+        _lastSpeechAt = date
+        lastSpeechLock.unlock()
+    }
+
     init() {
         let mic = SileroVADModel()
         let sys = SileroVADModel()
@@ -376,6 +391,7 @@ final class VADGateService {
 
         if isSpeech {
             lastSpeechMs = audioCursorMs
+            VADGateService.markSpeechDetected()
         }
 
         if isSpeech {
@@ -613,7 +629,10 @@ final class VADGateService {
             // .hold — maintain previous state to avoid cutting mid-speech
             isSpeech = (batchState == .speech || batchState == .hangover)
         }
-        if isSpeech { batchLastSpeechMs = batchAudioCursorMs }
+        if isSpeech {
+            batchLastSpeechMs = batchAudioCursorMs
+            VADGateService.markSpeechDetected()
+        }
 
         // Batch state machine
         switch batchState {


### PR DESCRIPTION
## Summary
- Users reported the desktop app auto-updating/restarting during live calls, dropping the in-progress recording
- The Sparkle `willInstallUpdateOnQuit` delegate now returns `false` if the on-device VAD detected speech within the last 120s, deferring the install until the next natural quit
- Exposes a thread-safe `VADGateService.lastSpeechAt` timestamp (set from both streaming and batch VAD paths) so the update gate can read the signal without extra plumbing

## Test plan
- [ ] Build on Mac mini; no compile errors
- [ ] Launch the app, start recording, speak briefly, trigger a Sparkle check while still recording → log shows "Deferring update … speech detected Xs ago"
- [ ] Stop recording, wait ≥120s, trigger a check → log shows "Triggering immediate installation" and the app updates+relaunches as before
- [ ] Dev build still follows the existing "leave scheduled for quit" path