### PR TITLE
Update CHANGELOG.json for v0.11.351 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Added Pi-Mono as an alternative AI provider with server-side cost tracking via Omi API"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.351",
+      "date": "2026-04-21",
+      "changes": [
+        "Added Pi-Mono as an alternative AI provider with server-side cost tracking via Omi API"
+      ]
+    },
     {
       "version": "0.11.350",
       "date": "2026-04-21",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.351 and clears the unreleased array.