### PR TITLE
Fix screenshot WebP mime type detection in ACP bridge

### DIFF
--- a/desktop/acp-bridge/src/index.ts
+++ b/desktop/acp-bridge/src/index.ts
@@ -45,6 +45,7 @@ import type {
 } from "./protocol.js";
 import { startOAuthFlow, type OAuthFlowHandle } from "./oauth-flow.js";
 import type { PromptBlock } from "./adapters/interface.js";
+import { detectImageMimeType } from "./mime-detect.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -72,24 +73,6 @@ function send(msg: OutboundMessage): void {
 
 function logErr(msg: string): void {
   process.stderr.write(`[acp-bridge] ${msg}\n`);
-}
-
-/**
- * Detect image MIME type from base64-encoded data by inspecting header bytes.
- * Exported for testability.
- */
-export function detectImageMimeType(base64Data: string): string {
-  const header = Buffer.from(base64Data.slice(0, 24), "base64");
-  // WebP: starts with RIFF....WEBP
-  if (header.length >= 12 && header.slice(0, 4).toString("ascii") === "RIFF" && header.slice(8, 12).toString("ascii") === "WEBP") {
-    return "image/webp";
-  }
-  // PNG: starts with 0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
-  if (header.length >= 8 && header[0] === 0x89 && header[1] === 0x50 && header[2] === 0x4e && header[3] === 0x47 && header[4] === 0x0d && header[5] === 0x0a && header[6] === 0x1a && header[7] === 0x0a) {
-    return "image/png";
-  }
-  // Default: JPEG
-  return "image/jpeg";
 }
 
 // --- OMI tools relay via Unix socket ---

--- a/desktop/acp-bridge/src/index.ts
+++ b/desktop/acp-bridge/src/index.ts
@@ -768,7 +768,14 @@ async function handleQuery(msg: QueryMessage): Promise<void> {
     const sendPrompt = async (): Promise<void> => {
       const promptBlocks: Array<Record<string, unknown>> = [];
       if (msg.imageBase64) {
-        promptBlocks.push({ type: "image", data: msg.imageBase64, mimeType: "image/webp" });
+        const hdr = Buffer.from(msg.imageBase64.slice(0, 24), "base64");
+        let imgMime = "image/jpeg";
+        if (hdr.length >= 12 && hdr.slice(0, 4).toString("ascii") === "RIFF" && hdr.slice(8, 12).toString("ascii") === "WEBP") {
+          imgMime = "image/webp";
+        } else if (hdr.length >= 4 && hdr[0] === 0x89 && hdr[1] === 0x50) {
+          imgMime = "image/png";
+        }
+        promptBlocks.push({ type: "image", data: msg.imageBase64, mimeType: imgMime });
       }
       promptBlocks.push({ type: "text", text: fullPrompt });
 
@@ -1258,8 +1265,16 @@ async function runPiMonoMode(): Promise<void> {
           // Build prompt blocks — include screenshot if available
           const promptBlocks: PromptBlock[] = [];
           if (qm.imageBase64) {
-            promptBlocks.push({ type: "image" as const, data: qm.imageBase64, mimeType: "image/jpeg" });
-            logErr("Pi-mono: including screenshot image in prompt");
+            // Detect image format from base64-decoded header bytes
+            const header = Buffer.from(qm.imageBase64.slice(0, 24), "base64");
+            let mimeType = "image/jpeg";
+            if (header.length >= 12 && header.slice(0, 4).toString("ascii") === "RIFF" && header.slice(8, 12).toString("ascii") === "WEBP") {
+              mimeType = "image/webp";
+            } else if (header.length >= 4 && header[0] === 0x89 && header[1] === 0x50) {
+              mimeType = "image/png";
+            }
+            promptBlocks.push({ type: "image" as const, data: qm.imageBase64, mimeType });
+            logErr(`Pi-mono: including screenshot image in prompt (${mimeType})`);
           }
           promptBlocks.push({ type: "text" as const, text: qm.prompt });
 

--- a/desktop/acp-bridge/src/index.ts
+++ b/desktop/acp-bridge/src/index.ts
@@ -74,6 +74,24 @@ function logErr(msg: string): void {
   process.stderr.write(`[acp-bridge] ${msg}\n`);
 }
 
+/**
+ * Detect image MIME type from base64-encoded data by inspecting header bytes.
+ * Exported for testability.
+ */
+export function detectImageMimeType(base64Data: string): string {
+  const header = Buffer.from(base64Data.slice(0, 24), "base64");
+  // WebP: starts with RIFF....WEBP
+  if (header.length >= 12 && header.slice(0, 4).toString("ascii") === "RIFF" && header.slice(8, 12).toString("ascii") === "WEBP") {
+    return "image/webp";
+  }
+  // PNG: starts with 0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
+  if (header.length >= 8 && header[0] === 0x89 && header[1] === 0x50 && header[2] === 0x4e && header[3] === 0x47 && header[4] === 0x0d && header[5] === 0x0a && header[6] === 0x1a && header[7] === 0x0a) {
+    return "image/png";
+  }
+  // Default: JPEG
+  return "image/jpeg";
+}
+
 // --- OMI tools relay via Unix socket ---
 
 let omiToolsPipePath = "";
@@ -768,13 +786,7 @@ async function handleQuery(msg: QueryMessage): Promise<void> {
     const sendPrompt = async (): Promise<void> => {
       const promptBlocks: Array<Record<string, unknown>> = [];
       if (msg.imageBase64) {
-        const hdr = Buffer.from(msg.imageBase64.slice(0, 24), "base64");
-        let imgMime = "image/jpeg";
-        if (hdr.length >= 12 && hdr.slice(0, 4).toString("ascii") === "RIFF" && hdr.slice(8, 12).toString("ascii") === "WEBP") {
-          imgMime = "image/webp";
-        } else if (hdr.length >= 4 && hdr[0] === 0x89 && hdr[1] === 0x50) {
-          imgMime = "image/png";
-        }
+        const imgMime = detectImageMimeType(msg.imageBase64);
         promptBlocks.push({ type: "image", data: msg.imageBase64, mimeType: imgMime });
       }
       promptBlocks.push({ type: "text", text: fullPrompt });
@@ -1265,14 +1277,7 @@ async function runPiMonoMode(): Promise<void> {
           // Build prompt blocks — include screenshot if available
           const promptBlocks: PromptBlock[] = [];
           if (qm.imageBase64) {
-            // Detect image format from base64-decoded header bytes
-            const header = Buffer.from(qm.imageBase64.slice(0, 24), "base64");
-            let mimeType = "image/jpeg";
-            if (header.length >= 12 && header.slice(0, 4).toString("ascii") === "RIFF" && header.slice(8, 12).toString("ascii") === "WEBP") {
-              mimeType = "image/webp";
-            } else if (header.length >= 4 && header[0] === 0x89 && header[1] === 0x50) {
-              mimeType = "image/png";
-            }
+            const mimeType = detectImageMimeType(qm.imageBase64);
             promptBlocks.push({ type: "image" as const, data: qm.imageBase64, mimeType });
             logErr(`Pi-mono: including screenshot image in prompt (${mimeType})`);
           }

--- a/desktop/acp-bridge/src/mime-detect.ts
+++ b/desktop/acp-bridge/src/mime-detect.ts
@@ -1,0 +1,17 @@
+/**
+ * Detect image MIME type from base64-encoded data by inspecting header bytes.
+ * Extracted to a separate module to avoid importing index.ts side effects in tests.
+ */
+export function detectImageMimeType(base64Data: string): string {
+  const header = Buffer.from(base64Data.slice(0, 24), "base64");
+  // WebP: starts with RIFF....WEBP
+  if (header.length >= 12 && header.slice(0, 4).toString("ascii") === "RIFF" && header.slice(8, 12).toString("ascii") === "WEBP") {
+    return "image/webp";
+  }
+  // PNG: starts with 0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
+  if (header.length >= 8 && header[0] === 0x89 && header[1] === 0x50 && header[2] === 0x4e && header[3] === 0x47 && header[4] === 0x0d && header[5] === 0x0a && header[6] === 0x1a && header[7] === 0x0a) {
+    return "image/png";
+  }
+  // Default: JPEG
+  return "image/jpeg";
+}

--- a/desktop/acp-bridge/tests/mime-detection.test.ts
+++ b/desktop/acp-bridge/tests/mime-detection.test.ts
@@ -60,6 +60,11 @@ describe("detectImageMimeType", () => {
     expect(detectImageMimeType(bytesToBase64(partialPng))).toBe("image/jpeg");
   });
 
+  it("falls back to JPEG for malformed non-base64 input", () => {
+    // Garbage string that isn't valid base64
+    expect(detectImageMimeType("not-base64-at-all!!!")).toBe("image/jpeg");
+  });
+
   it("does not misidentify RIFF without WEBP marker", () => {
     // RIFF header but with AVI instead of WEBP
     const aviHeader = [

--- a/desktop/acp-bridge/tests/mime-detection.test.ts
+++ b/desktop/acp-bridge/tests/mime-detection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectImageMimeType } from "../src/index.js";
+import { detectImageMimeType } from "../src/mime-detect.js";
 
 /**
  * Unit tests for detectImageMimeType — verifies that base64-encoded images

--- a/desktop/acp-bridge/tests/mime-detection.test.ts
+++ b/desktop/acp-bridge/tests/mime-detection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { detectImageMimeType } from "../src/index.js";
+
+/**
+ * Unit tests for detectImageMimeType — verifies that base64-encoded images
+ * are correctly identified by their header bytes.
+ *
+ * This was extracted after PR #6633 shipped with hardcoded "image/jpeg" for
+ * screenshots that ScreenCaptureManager actually encodes as WebP, causing
+ * Anthropic API 400: "image was specified using image/jpeg media type, but
+ * the image appears to be a image/webp image".
+ */
+
+// Helper: encode raw bytes to base64
+function bytesToBase64(bytes: number[]): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+describe("detectImageMimeType", () => {
+  it("detects WebP from RIFF....WEBP header", () => {
+    // Real WebP header: RIFF + 4-byte size + WEBP
+    const webpHeader = [
+      0x52, 0x49, 0x46, 0x46, // RIFF
+      0x00, 0x00, 0x10, 0x00, // file size (arbitrary)
+      0x57, 0x45, 0x42, 0x50, // WEBP
+      0x56, 0x50, 0x38, 0x20, // VP8 chunk (padding)
+    ];
+    expect(detectImageMimeType(bytesToBase64(webpHeader))).toBe("image/webp");
+  });
+
+  it("detects PNG from full 8-byte magic", () => {
+    // PNG magic: 89 50 4E 47 0D 0A 1A 0A
+    const pngHeader = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d];
+    expect(detectImageMimeType(bytesToBase64(pngHeader))).toBe("image/png");
+  });
+
+  it("falls back to JPEG for JPEG SOI header", () => {
+    // JPEG starts with FF D8 FF
+    const jpegHeader = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01];
+    expect(detectImageMimeType(bytesToBase64(jpegHeader))).toBe("image/jpeg");
+  });
+
+  it("falls back to JPEG for unknown/arbitrary bytes", () => {
+    const randomBytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b];
+    expect(detectImageMimeType(bytesToBase64(randomBytes))).toBe("image/jpeg");
+  });
+
+  it("falls back to JPEG for empty string", () => {
+    expect(detectImageMimeType("")).toBe("image/jpeg");
+  });
+
+  it("falls back to JPEG for very short base64", () => {
+    // Only 1 byte decoded — too short for any signature
+    expect(detectImageMimeType("AA==")).toBe("image/jpeg");
+  });
+
+  it("does not misidentify partial PNG (only 0x89 0x50, not full 8 bytes)", () => {
+    // Only first 2 bytes match PNG but rest doesn't — should NOT be PNG
+    const partialPng = [0x89, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    expect(detectImageMimeType(bytesToBase64(partialPng))).toBe("image/jpeg");
+  });
+
+  it("does not misidentify RIFF without WEBP marker", () => {
+    // RIFF header but with AVI instead of WEBP
+    const aviHeader = [
+      0x52, 0x49, 0x46, 0x46, // RIFF
+      0x00, 0x00, 0x10, 0x00, // size
+      0x41, 0x56, 0x49, 0x20, // AVI (not WEBP)
+    ];
+    expect(detectImageMimeType(bytesToBase64(aviHeader))).toBe("image/jpeg");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix hardcoded JPEG/WebP mime types in ACP bridge screenshot handling — detect actual format from base64 header bytes
- Fixes Anthropic API 400 error: `image was specified using image/jpeg media type, but the image appears to be a image/webp image`

## Problem
`ScreenCaptureManager` encodes screenshots as WebP via libwebp, but the ACP bridge had hardcoded mime types:
- **Pi-mono path** (line 1261): hardcoded `image/jpeg` — always wrong
- **Legacy path** (line 771): hardcoded `image/webp` — correct today but brittle

When Anthropic's API receives a base64 image with mismatched mime type, it returns HTTP 400.

## Fix
New `mime-detect.ts` module with exported `detectImageMimeType(base64Data)` helper:
- `RIFF....WEBP` (12-byte check) → `image/webp`
- Full 8-byte PNG magic (`89 50 4E 47 0D 0A 1A 0A`) → `image/png`
- Otherwise → `image/jpeg` (default)

Both pi-mono and legacy code paths in `index.ts` import and call this single helper.

### Files changed
| File | Change |
|------|--------|
| `desktop/acp-bridge/src/mime-detect.ts` | New module — `detectImageMimeType()` helper |
| `desktop/acp-bridge/src/index.ts` | Import helper, replace inline detection in both paths |
| `desktop/acp-bridge/tests/mime-detection.test.ts` | 8 unit tests for the helper |

## Test evidence

### Unit tests — 73/73 pass (8 new)
```
Test Files  5 passed (5)
     Tests  73 passed (73)
```

`mime-detection.test.ts` covers:
- WebP header detection (RIFF + WEBP marker)
- PNG full 8-byte magic detection
- JPEG SOI header fallback
- Unknown/arbitrary bytes fallback
- Empty string fallback
- Truncated base64 fallback
- Partial PNG (only 2-byte match) — correctly falls back to JPEG
- RIFF-AVI (not WEBP) — correctly falls back to JPEG

### Build
```
npm run build — compiles clean
```

## Review cycle
- **R1**: CODEx flagged (1) test importing index.ts triggers main() side effects, (2) JPEG fallback for unknown formats
- **Fix**: Extracted helper to `mime-detect.ts`; test imports from there (no side effects). JPEG fallback is intentional — the only image source is ScreenCaptureManager (always WebP); returning undefined would break the prompt.

## Risks
- **Low**: JPEG fallback for unrecognized formats. If ScreenCaptureManager switches to GIF/AVIF in the future, the helper would need a new branch. Current source always produces WebP.

_by AI for @beastoin_