### PR TITLE
fix: return 422 instead of 500 when BYOK key lacks embedding model access

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from typing import List, Optional
 
+import openai
 from utils.executors import critical_executor
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -49,13 +50,24 @@ def _validate_memory(uid: str, memory_id: str) -> dict:
     return memory
 
 
+_BYOK_EMBEDDING_ERROR = (
+    "Your OpenAI API key does not have access to the 'text-embedding-3-large' model. "
+    "Grant embedding model access in your OpenAI project settings, or use a key from "
+    "a project with this access enabled."
+)
+
+
 @router.post('/v3/memories', tags=['memories'], response_model=MemoryDB)
 def create_memory(memory: Memory, uid: str = Depends(auth.get_current_user_uid)):
     memory.category = MemoryCategory.manual
     memory_db = MemoryDB.from_memory(memory, uid, None, True)
     memories_db.create_memory(uid, memory_db.dict())
 
-    upsert_memory_vector(uid, memory_db.id, memory_db.content, memory_db.category.value)
+    try:
+        upsert_memory_vector(uid, memory_db.id, memory_db.content, memory_db.category.value)
+    except openai.PermissionDeniedError:
+        logger.warning('BYOK embedding permission denied uid=%s', uid)
+        raise HTTPException(status_code=422, detail=_BYOK_EMBEDDING_ERROR)
 
     if memory.visibility == 'public':
         critical_executor.submit(update_personas_async, uid)
@@ -112,7 +124,11 @@ async def create_memories_batch(
             ],
         )
 
-    await asyncio.to_thread(_persist)
+    try:
+        await asyncio.to_thread(_persist)
+    except openai.PermissionDeniedError:
+        logger.warning('BYOK embedding permission denied uid=%s', uid)
+        raise HTTPException(status_code=422, detail=_BYOK_EMBEDDING_ERROR)
 
     if has_public:
         loop = asyncio.get_running_loop()

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -66,7 +66,8 @@ def create_memory(memory: Memory, uid: str = Depends(auth.get_current_user_uid))
     try:
         upsert_memory_vector(uid, memory_db.id, memory_db.content, memory_db.category.value)
     except openai.PermissionDeniedError:
-        logger.warning('BYOK embedding permission denied uid=%s', uid)
+        memories_db.delete_memory(uid, memory_db.id)
+        logger.warning('BYOK embedding permission denied uid=%s, rolled back memory %s', uid, memory_db.id)
         raise HTTPException(status_code=422, detail=_BYOK_EMBEDDING_ERROR)
 
     if memory.visibility == 'public':
@@ -112,22 +113,27 @@ async def create_memories_batch(
     # slow embeddings/Pinecone call can't starve the FastAPI sync threadpool.
     def _persist():
         memories_db.save_memories(uid, [m.dict() for m in memory_dbs])
-        upsert_memory_vectors_batch(
-            uid,
-            [
-                {
-                    "memory_id": m.id,
-                    "content": m.content,
-                    "category": m.category.value,
-                }
-                for m in memory_dbs
-            ],
-        )
+        try:
+            upsert_memory_vectors_batch(
+                uid,
+                [
+                    {
+                        "memory_id": m.id,
+                        "content": m.content,
+                        "category": m.category.value,
+                    }
+                    for m in memory_dbs
+                ],
+            )
+        except openai.PermissionDeniedError:
+            for m in memory_dbs:
+                memories_db.delete_memory(uid, m.id)
+            raise
 
     try:
         await asyncio.to_thread(_persist)
     except openai.PermissionDeniedError:
-        logger.warning('BYOK embedding permission denied uid=%s', uid)
+        logger.warning('BYOK embedding permission denied uid=%s, rolled back %d memories', uid, len(memory_dbs))
         raise HTTPException(status_code=422, detail=_BYOK_EMBEDDING_ERROR)
 
     if has_public:


### PR DESCRIPTION
## Summary
  - BYOK users whose OpenAI project lacks `text-embedding-3-large` access were                       
    getting an unhandled PermissionDeniedError (403 from OpenAI) that propagated
    as a 500 ~37 occurrences/hour in production                               
  - Catch openai.PermissionDeniedError in both POST /v3/memories and                                   
    POST /v3/memories/batch, return 422 with a clear actionable message
                                                                                                       
  ## Changes
  backend/routers/memories.py only, no other files touched.                                           
  - import openai at module top level                       
  - try/except around upsert_memory_vector in create_memory → HTTPException(422)                       
  - try/except around asyncio.to_thread(_persist) in create_memories_batch → same
  - Single _BYOK_EMBEDDING_ERROR constant with user-readable message                                   
                                                                    
  ## Test plan                                                                                         
  - [ ] BYOK user with key lacking text-embedding-3-large → POST /v3/memories returns 422 (not 500)
  - [ ] Same for POST /v3/memories/batch                                                               
  - [ ] Non-BYOK users unaffected, happy path unchanged                                               
  - [ ] Error logged at WARNING level with uid for observability    