### PR TITLE
Overage billing for every paid plan (Neo + Architect join Operator)

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -321,6 +321,7 @@ class OverageInfoResponse(BaseModel):
     plan_type: str
     is_overage_plan: bool
     included_questions: Optional[int] = None
+    included_cost_usd: Optional[float] = None
     used_questions: int = 0
     excess_questions: int = 0
     real_cost_usd: float = 0.0
@@ -351,6 +352,7 @@ def get_overage_info_endpoint(uid: str = Depends(auth.get_current_user_uid_no_by
         plan_type=plan.value,
         is_overage_plan=is_overage_plan(plan),
         included_questions=snapshot['included_questions'],
+        included_cost_usd=snapshot.get('included_cost_usd'),
         used_questions=snapshot['used_questions'],
         excess_questions=snapshot['excess_questions'],
         real_cost_usd=snapshot['real_cost_usd'],

--- a/backend/utils/overage.py
+++ b/backend/utils/overage.py
@@ -1,20 +1,23 @@
-"""Usage-based overage billing for chat when users exceed their plan's included
-question cap.
+"""Usage-based overage billing for chat.
 
-Experiment shape (backend-only):
-  - Operator (PlanType.operator, desktop) has 500 included chat questions per month.
-  - Past 500, the user is NOT blocked — calls go through and we accrue an
-    overage charge equal to the true provider cost of the excess usage,
-    marked up by ``OVERAGE_MARKUP_MULTIPLIER`` (default 15 %).
-  - Neo (mobile) keeps its hard cap — no overage on mobile.
-  - Architect stays on its monthly cost cap (hard-blocked past $400/mo).
-  - Free users still get hard-capped (they have no payment method on file).
-  - BYOK users bypass everything — handled by the existing BYOK check in
-    ``utils.subscription.enforce_chat_quota``.
+Every paid plan participates — we never ask a paying user to upgrade, we bill
+the excess.
 
-True costs are already tracked on every chat call via
+  - Operator (500 included chat questions / mo): overage on questions past cap.
+  - Neo / Unlimited (200 included): overage on questions past cap.
+  - Architect ($400 included AI compute / mo): overage on cost past cap.
+  - Free users still hard-capped (no payment method on file).
+  - BYOK users bypass everything (handled in ``utils.subscription.enforce_chat_quota``).
+
+True costs are tracked on every chat call via
 ``database.llm_usage.record_llm_usage_bucket`` → ``desktop_chat.cost_usd``.
 This module reads those numbers rather than maintaining a parallel counter.
+
+**Billing attribution**
+  - Question-based plans (Operator, Neo): cost is attributed proportionally —
+    ``overage = (excess_q / total_q) × total_real_cost × markup``. Approximate
+    (a user who does cheap Qs then expensive Qs underbills), but fair enough.
+  - Cost-based plans (Architect): exact. ``overage = (real_cost - cap) × markup``.
 """
 
 import os
@@ -22,7 +25,11 @@ from typing import Optional
 
 from database import user_usage as user_usage_db
 from models.users import PlanType
-from utils.subscription import OPERATOR_CHAT_QUESTIONS_PER_MONTH
+from utils.subscription import (
+    ARCHITECT_CHAT_COST_USD_PER_MONTH,
+    NEO_CHAT_QUESTIONS_PER_MONTH,
+    OPERATOR_CHAT_QUESTIONS_PER_MONTH,
+)
 
 # Markup applied to raw provider cost before charging the user.
 # 1.15 = 15 % on top of true cost (covers variance + infra).
@@ -45,75 +52,83 @@ PROVIDER_REFERENCE_RATES = {
 OVERAGE_EXPLAINER_TITLE = "What happens past your monthly limit?"
 
 OVERAGE_EXPLAINER_BODY = (
-    "Your plan includes {included_questions} chat questions per month. "
-    "If you go over, Omi doesn't cut you off — you stay fully functional and we "
-    "charge only for the extra usage, billed to the card on file at the end of your cycle.\n\n"
+    "Your paid plan includes a monthly AI-usage allowance. If you go over, Omi "
+    "doesn't cut you off — you stay fully functional and we charge only for "
+    "the extra usage, billed to the card on file at the end of your cycle.\n\n"
     "How the charge is computed:\n"
-    "  • We add up the real provider cost (Claude, Gemini, Deepgram, etc.) of the "
-    "questions you asked past {included_questions}.\n"
+    "  • We sum the real provider cost (Claude, Gemini, Deepgram, etc.) of the "
+    "usage past your included allowance.\n"
     "  • We add a {markup_pct:.0f}% buffer on top to cover infra and pricing variance.\n"
     "  • That's it — no surge pricing, no hidden fees.\n\n"
-    "A typical chat question costs roughly $0.01–$0.05 of real compute. "
-    "Heavy RAG questions with lots of tool use cost a bit more.\n\n"
-    "Prefer predictable billing? You can always bring your own API keys in "
-    "Settings → Developer API Keys and pay providers directly. When BYOK is "
-    "active, Omi is free."
+    "A typical chat question costs roughly $0.01–$0.05 of real compute. Heavy "
+    "RAG or agentic questions cost a bit more.\n\n"
+    "Prefer predictable billing? Bring your own API keys in Settings → Developer "
+    "API Keys and pay providers directly — Omi is free when BYOK is active."
 )
 
 
 def build_explainer_text() -> str:
     return OVERAGE_EXPLAINER_BODY.format(
-        included_questions=OPERATOR_CHAT_QUESTIONS_PER_MONTH,
         markup_pct=(OVERAGE_MARKUP_MULTIPLIER - 1.0) * 100.0,
     )
 
 
 def _plan_included_questions(plan: PlanType) -> Optional[int]:
-    """Number of chat questions included in the monthly fee for plans that
-    participate in overage billing. Returns None if the plan is not eligible.
-
-    Only Operator (the desktop mid-tier) participates in overage billing.
-    Neo is hard-capped on mobile; Architect uses a monthly cost cap instead."""
+    """Included chat questions for question-based overage plans."""
     if plan == PlanType.operator:
         return OPERATOR_CHAT_QUESTIONS_PER_MONTH
+    if plan == PlanType.unlimited:
+        return NEO_CHAT_QUESTIONS_PER_MONTH
+    return None
+
+
+def _plan_included_cost_usd(plan: PlanType) -> Optional[float]:
+    """Included monthly AI-compute dollars for cost-based overage plans."""
+    if plan == PlanType.architect:
+        return ARCHITECT_CHAT_COST_USD_PER_MONTH
     return None
 
 
 def is_overage_plan(plan: PlanType) -> bool:
-    """True if this plan uses overage billing past its included question count."""
-    return _plan_included_questions(plan) is not None
+    """True if this plan bills overage past its included allowance."""
+    return _plan_included_questions(plan) is not None or _plan_included_cost_usd(plan) is not None
 
 
 def get_user_overage(uid: str, plan: PlanType) -> dict:
-    """Compute the current-month overage snapshot for *uid* on *plan*.
+    """Current-month overage snapshot for *uid* on *plan*.
 
     Returns a dict with:
-      - included_questions: plan's included count (or None)
+      - included_questions: plan's question allowance (or None)
+      - included_cost_usd:  plan's compute-dollar allowance (or None)
       - used_questions:     questions used this month
-      - excess_questions:   max(0, used - included)
+      - excess_questions:   max(0, used_q - included_q) for question plans
       - real_cost_usd:      provider cost for entire month (from tracked data)
       - overage_usd:        accrued overage charge with markup (0 if under cap)
       - markup_multiplier:  the multiplier applied
       - reset_at:           unix ts when the monthly bucket rolls over
     """
-    included = _plan_included_questions(plan)
+    included_q = _plan_included_questions(plan)
+    included_cost = _plan_included_cost_usd(plan)
     usage = user_usage_db.get_monthly_chat_usage(uid)
-    used = int(usage.get('questions', 0))
+    used_q = int(usage.get('questions', 0))
     real_cost = float(usage.get('cost_usd', 0.0))
     reset_at = usage.get('reset_at')
 
     overage_usd = 0.0
-    excess = 0
-    if included is not None and used > included and used > 0:
-        excess = used - included
-        # Attribute cost proportionally: the excess share of this month's real
-        # cost is (excess / used) × total real cost, then apply markup.
-        overage_usd = round((excess / used) * real_cost * OVERAGE_MARKUP_MULTIPLIER, 4)
+    excess_q = 0
+    if included_q is not None and used_q > included_q and used_q > 0:
+        # Question-based: attribute cost proportionally.
+        excess_q = used_q - included_q
+        overage_usd = round((excess_q / used_q) * real_cost * OVERAGE_MARKUP_MULTIPLIER, 4)
+    elif included_cost is not None and real_cost > included_cost:
+        # Cost-based: exact excess × markup.
+        overage_usd = round((real_cost - included_cost) * OVERAGE_MARKUP_MULTIPLIER, 4)
 
     return {
-        'included_questions': included,
-        'used_questions': used,
-        'excess_questions': excess,
+        'included_questions': included_q,
+        'included_cost_usd': included_cost,
+        'used_questions': used_q,
+        'excess_questions': excess_q,
         'real_cost_usd': round(real_cost, 4),
         'overage_usd': overage_usd,
         'markup_multiplier': OVERAGE_MARKUP_MULTIPLIER,

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -294,23 +294,20 @@ def get_chat_quota_snapshot(uid: str) -> dict:
 
 
 # Plans that enter usage-based overage billing instead of hard-blocking when
-# they exceed their included chat question count. For these plans, going over
-# is a soft event: the call is served and the excess is billed at end of cycle
-# against the card on file.
-#
-# Only Operator (desktop mid-tier) uses overage. Neo is hard-capped on mobile;
-# Architect uses a monthly cost cap.
-OVERAGE_ENABLED_PLANS = {PlanType.operator}
+# they exceed their included allowance. Paying users are never asked to
+# "upgrade past their plan" — the excess is billed at end of cycle against
+# the card on file. Free stays hard-capped (no payment method on file).
+OVERAGE_ENABLED_PLANS = {PlanType.operator, PlanType.unlimited, PlanType.architect}
 
 
 def enforce_chat_quota(uid: str) -> None:
     """Block or allow a chat request based on the user's plan + usage.
 
     - BYOK users with an LLM key attached: always allowed, no Omi-side cost.
-    - Free plan past its cap: blocked (no card on file). 402.
-    - Neo (unlimited) / overage-enabled plans past their cap: ALLOWED — we
-      serve the call and accrue an overage charge. See ``utils.overage``.
-    - Architect (cost-capped): still blocked when monthly cost cap is hit.
+    - Paid plans past their cap: ALLOWED — the call is served and the excess
+      accrues an overage charge. See ``utils.overage``.
+    - Free plan past its cap: blocked (no card on file) → 402, which the
+      chat endpoint converts into a canned AI reply for mobile UX.
     """
     # BYOK users pay their own LLM provider — no Omi-side cost to cap.
     # Require an LLM provider key on this request (not just any BYOK header)
@@ -325,9 +322,10 @@ def enforce_chat_quota(uid: str) -> None:
 
     plan = snapshot['plan']
 
-    # Overage-enabled plans never hard-block on chat question count — the
-    # excess becomes a billable overage at end of cycle.
-    if plan in OVERAGE_ENABLED_PLANS and snapshot['unit'] == 'questions':
+    # Every paying plan goes into overage mode past its cap, regardless of
+    # whether the cap is expressed in questions or dollars. Only Free
+    # (PlanType.basic) falls through to the 402 below.
+    if plan in OVERAGE_ENABLED_PLANS:
         return
 
     raise HTTPException(


### PR DESCRIPTION
## Summary
Paying users shouldn't see an "upgrade your plan" message when they cross their included allowance — they already pay. Extend overage billing to all paid plans:

- **Operator** (500 included chat questions) — already overage-billed.
- **Neo / Unlimited** (200 included chat questions) — now overage-billed.
- **Architect** (\$400 included AI compute) — now overage-billed on cost.
- **Free** — still hard-capped (no payment method on file); graceful 402→AI-message flow unchanged.

## Attribution
- Question-based plans: proportional — `(excess_q / total_q) × total_real_cost × 1.15`.
- Cost-based plans (Architect): exact — `(real_cost - cap) × 1.15`.

Both use the already-tracked `desktop_chat.cost_usd` snapshot. No new usage plumbing.

## Same known limitation as before
Overage is computed + exposed via \`/v1/payments/overage-info\` but not yet wired into Stripe invoice items. So in the interim, paying users who go over get free usage — matching the experiment Operator already had. Wire Stripe billing before publicizing.

## Test plan
- [x] Syntax clean on all three files
- [ ] Manual: Neo user past 200 Q → chat keeps responding, `/v1/payments/overage-info` reflects non-zero overage_usd
- [ ] Manual: Architect user past \$400 → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)