### PR TITLE
admin: add Releases page (crash rate + AI stability rating)

### DIFF
--- a/web/admin/app/(protected)/dashboard/releases/page.tsx
+++ b/web/admin/app/(protected)/dashboard/releases/page.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import useSWR from "swr";
+import { Loader2, AlertTriangle, ExternalLink } from "lucide-react";
+import { useAuthToken, authenticatedFetcher } from "@/hooks/useAuthToken";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+interface ReleaseRow {
+  version: string;
+  tag: string;
+  published_at: string;
+  html_url: string;
+  crash_rate: number | null;
+  crash_count: number | null;
+  session_count: number | null;
+  feedback_count: number | null;
+  broken_count: number | null;
+  rating: number | null;
+  summary: string | null;
+}
+
+interface ReleasesResponse {
+  releases: ReleaseRow[];
+  github_error: string | null;
+  posthog_error: string | null;
+  partial: boolean;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "—";
+  }
+}
+
+function CrashRateCell({ row }: { row: ReleaseRow }) {
+  if (row.crash_rate === null || row.session_count === null) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+  const pct = row.crash_rate * 100;
+  const color =
+    pct >= 2 ? "text-red-500" : pct >= 0.5 ? "text-amber-500" : "text-emerald-500";
+  return (
+    <div className="flex flex-col">
+      <span className={cn("font-mono font-semibold", color)}>
+        {pct.toFixed(2)}%
+      </span>
+      <span className="text-[11px] text-muted-foreground font-mono">
+        {row.crash_count?.toLocaleString()} / {row.session_count?.toLocaleString()} sessions
+      </span>
+    </div>
+  );
+}
+
+function RatingBadge({ rating }: { rating: number | null }) {
+  if (rating === null) return <span className="text-muted-foreground">—</span>;
+  const color =
+    rating >= 4
+      ? "bg-emerald-500/15 text-emerald-500 border-emerald-500/30"
+      : rating >= 2.5
+        ? "bg-amber-500/15 text-amber-500 border-amber-500/30"
+        : "bg-red-500/15 text-red-500 border-red-500/30";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center rounded-md border px-2.5 py-1 font-mono font-bold text-base",
+        color
+      )}
+    >
+      {rating.toFixed(1)}
+    </span>
+  );
+}
+
+function FeedbackCell({ row }: { row: ReleaseRow }) {
+  const fb = row.feedback_count ?? 0;
+  const broken = row.broken_count ?? 0;
+  if (fb === 0 && broken === 0) {
+    return <span className="text-muted-foreground text-xs">none</span>;
+  }
+  return (
+    <div className="flex flex-col gap-0.5">
+      {fb > 0 && (
+        <span className="text-xs">
+          <span className="font-semibold">{fb}</span>{" "}
+          <span className="text-muted-foreground">feedback{fb !== 1 ? "s" : ""}</span>
+        </span>
+      )}
+      {broken > 0 && (
+        <span className="text-xs">
+          <span className="font-semibold">{broken}</span>{" "}
+          <span className="text-muted-foreground">capture failures</span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function ReleasesPage() {
+  const { token } = useAuthToken();
+  const { data, error, isLoading } = useSWR<ReleasesResponse>(
+    token ? ["/api/omi/releases", token] : null,
+    authenticatedFetcher,
+    { revalidateOnFocus: false, refreshInterval: 5 * 60 * 1000 }
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 gap-2">
+        <AlertTriangle className="h-8 w-8 text-red-500" />
+        <p className="text-sm text-muted-foreground">
+          Failed to load releases: {String(error?.message || error)}
+        </p>
+      </div>
+    );
+  }
+
+  const releases = data?.releases ?? [];
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold tracking-tight">Desktop Releases</h1>
+
+      {data?.partial && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-500">
+          <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+          <span>
+            {data.posthog_error
+              ? `PostHog unavailable: ${data.posthog_error}`
+              : "Some metrics may be incomplete."}
+          </span>
+        </div>
+      )}
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[100px]">Version</TableHead>
+              <TableHead className="w-[140px]">Released</TableHead>
+              <TableHead className="w-[140px]">Crash Rate</TableHead>
+              <TableHead className="w-[120px]">Issues</TableHead>
+              <TableHead className="w-[60px] text-center">Rating</TableHead>
+              <TableHead>Summary</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {releases.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-center py-8 text-muted-foreground"
+                >
+                  No releases found.
+                </TableCell>
+              </TableRow>
+            )}
+            {releases.map((r) => (
+              <TableRow key={r.tag}>
+                <TableCell className="font-mono text-sm">
+                  <a
+                    href={r.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 hover:underline"
+                  >
+                    {r.version}
+                    <ExternalLink className="h-3 w-3 opacity-40" />
+                  </a>
+                </TableCell>
+                <TableCell className="text-muted-foreground text-xs">
+                  {formatDate(r.published_at)}
+                </TableCell>
+                <TableCell>
+                  <CrashRateCell row={r} />
+                </TableCell>
+                <TableCell>
+                  <FeedbackCell row={r} />
+                </TableCell>
+                <TableCell className="text-center">
+                  <RatingBadge rating={r.rating} />
+                </TableCell>
+                <TableCell className="text-sm max-w-sm">
+                  {r.summary || <span className="text-muted-foreground">—</span>}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/web/admin/app/api/omi/releases/route.ts
+++ b/web/admin/app/api/omi/releases/route.ts
@@ -1,0 +1,263 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyAdmin } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const GITHUB_REPO = 'BasedHardware/omi';
+const RELEASE_TAG_SUFFIX = '-macos';
+const RELEASE_LIMIT = 30;
+
+const POSTHOG_API_KEY = process.env.POSTHOG_PERSONAL_API_KEY;
+const POSTHOG_PROJECT_ID = process.env.POSTHOG_PROJECT_ID || '302298';
+const POSTHOG_BASE = 'https://us.posthog.com';
+
+// --- Types ---
+
+interface ReleaseRow {
+  version: string;
+  tag: string;
+  published_at: string;
+  html_url: string;
+  crash_rate: number | null;
+  crash_count: number | null;
+  session_count: number | null;
+  feedback_count: number | null;
+  broken_count: number | null;
+  rating: number | null;
+  summary: string | null;
+}
+
+// --- GitHub ---
+
+async function fetchGithubReleases(): Promise<any[]> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const res = await fetch(
+    `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100`,
+    { headers, cache: 'no-store' }
+  );
+  if (!res.ok) throw new Error(`GitHub ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+function parseVersion(tag: string): string | null {
+  const m = tag.match(/^v(\d+\.\d+\.\d+)\+\d+-macos$/);
+  return m ? m[1] : null;
+}
+
+// --- PostHog ---
+
+async function posthogQuery(query: string): Promise<any> {
+  if (!POSTHOG_API_KEY) return null;
+  const res = await fetch(`${POSTHOG_BASE}/api/projects/${POSTHOG_PROJECT_ID}/query/`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${POSTHOG_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query } }),
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`PostHog query error ${res.status}: ${text}`);
+    return null;
+  }
+  return res.json();
+}
+
+interface VersionMetrics {
+  crashes: number;
+  launches: number;
+  feedbacks: number;
+  brokens: number;
+  resets: number;
+}
+
+async function fetchPostHogMetrics(
+  versions: string[]
+): Promise<Map<string, VersionMetrics>> {
+  const results = new Map<string, VersionMetrics>();
+  if (!POSTHOG_API_KEY || versions.length === 0) return results;
+
+  // Initialize all versions
+  for (const v of versions) {
+    results.set(v, { crashes: 0, launches: 0, feedbacks: 0, brokens: 0, resets: 0 });
+  }
+
+  // Single query: counts per event per version, last 60 days
+  const data = await posthogQuery(`
+    SELECT
+      properties.$app_version AS version,
+      event,
+      count() AS cnt,
+      count(DISTINCT distinct_id) AS users
+    FROM events
+    WHERE event IN (
+      'App Crash Detected',
+      'App Launched',
+      'Feedback Submitted',
+      'Screen Capture Broken Detected',
+      'Screen Capture Reset Clicked'
+    )
+    AND timestamp >= now() - INTERVAL 60 DAY
+    AND properties.$app_version IS NOT NULL
+    GROUP BY version, event
+  `);
+
+  if (!data?.results) return results;
+
+  for (const row of data.results) {
+    const [version, event, count] = row;
+    if (!version || !results.has(version)) continue;
+    const m = results.get(version)!;
+    switch (event) {
+      case 'App Crash Detected': m.crashes = count; break;
+      case 'App Launched': m.launches = count; break;
+      case 'Feedback Submitted': m.feedbacks = count; break;
+      case 'Screen Capture Broken Detected': m.brokens = count; break;
+      case 'Screen Capture Reset Clicked': m.resets = count; break;
+    }
+  }
+
+  return results;
+}
+
+// --- Rating + Summary ---
+
+function computeRatingAndSummary(
+  m: VersionMetrics
+): { rating: number; summary: string } {
+  const crashRate = m.launches > 0 ? m.crashes / m.launches : 0;
+  const issues: string[] = [];
+  let score = 5.0;
+
+  // Crash rate scoring
+  if (crashRate >= 0.05) {
+    score -= 2.5;
+    issues.push(`high crash rate (${(crashRate * 100).toFixed(1)}%)`);
+  } else if (crashRate >= 0.02) {
+    score -= 1.5;
+    issues.push(`elevated crash rate (${(crashRate * 100).toFixed(1)}%)`);
+  } else if (crashRate >= 0.005) {
+    score -= 0.5;
+    issues.push(`minor crash rate (${(crashRate * 100).toFixed(1)}%)`);
+  }
+
+  // Screen capture broken scoring
+  if (m.brokens > 100) {
+    score -= 1.5;
+    issues.push(`${m.brokens} screen capture failures`);
+  } else if (m.brokens > 20) {
+    score -= 0.75;
+    issues.push(`${m.brokens} screen capture failures`);
+  } else if (m.brokens > 5) {
+    score -= 0.25;
+    issues.push(`${m.brokens} screen capture failures`);
+  }
+
+  // Feedback scoring
+  if (m.feedbacks > 10) {
+    score -= 1.0;
+    issues.push(`${m.feedbacks} user complaints`);
+  } else if (m.feedbacks > 3) {
+    score -= 0.5;
+    issues.push(`${m.feedbacks} user complaints`);
+  } else if (m.feedbacks > 0) {
+    score -= 0.25;
+    issues.push(`${m.feedbacks} user complaint${m.feedbacks === 1 ? '' : 's'}`);
+  }
+
+  // Reset clicks
+  if (m.resets > 5) {
+    score -= 0.5;
+    issues.push(`${m.resets} permission reset clicks`);
+  }
+
+  score = Math.max(0, Math.min(5, Math.round(score * 10) / 10));
+
+  let summary: string;
+  if (m.launches === 0) {
+    summary = 'No usage data yet';
+    score = 0;
+  } else if (issues.length === 0) {
+    summary = `Clean release — ${m.launches} sessions, no significant issues`;
+  } else {
+    summary = issues.join(', ');
+    // Capitalize first letter
+    summary = summary.charAt(0).toUpperCase() + summary.slice(1);
+  }
+
+  return { rating: score, summary };
+}
+
+// --- Handler ---
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  let github_error: string | null = null;
+  let posthog_error: string | null = null;
+
+  // 1. GitHub releases
+  let githubReleases: any[] = [];
+  try {
+    githubReleases = await fetchGithubReleases();
+  } catch (err: any) {
+    github_error = err?.message || String(err);
+    return NextResponse.json(
+      { releases: [], github_error, posthog_error: null, partial: true },
+      { status: 502 }
+    );
+  }
+
+  const desktopReleases = githubReleases
+    .filter((r) => typeof r.tag_name === 'string' && r.tag_name.endsWith(RELEASE_TAG_SUFFIX))
+    .filter((r) => parseVersion(r.tag_name) !== null)
+    .slice(0, RELEASE_LIMIT);
+
+  const versions = desktopReleases.map((r) => parseVersion(r.tag_name)!);
+
+  // 2. PostHog metrics
+  let metricsMap = new Map<string, VersionMetrics>();
+  try {
+    metricsMap = await fetchPostHogMetrics(versions);
+  } catch (err: any) {
+    posthog_error = err?.message || String(err);
+  }
+
+  // 3. Compose rows
+  const rows: ReleaseRow[] = desktopReleases.map((r) => {
+    const version = parseVersion(r.tag_name)!;
+    const m = metricsMap.get(version);
+    const crashRate = m && m.launches > 0 ? m.crashes / m.launches : null;
+    const { rating, summary } = m ? computeRatingAndSummary(m) : { rating: null, summary: null };
+
+    return {
+      version,
+      tag: r.tag_name,
+      published_at: r.published_at,
+      html_url: r.html_url,
+      crash_rate: crashRate,
+      crash_count: m?.crashes ?? null,
+      session_count: m?.launches ?? null,
+      feedback_count: m?.feedbacks ?? null,
+      broken_count: m?.brokens ?? null,
+      rating,
+      summary,
+    };
+  });
+
+  return NextResponse.json({
+    releases: rows,
+    github_error: null,
+    posthog_error,
+    partial: posthog_error !== null,
+  });
+}

--- a/web/admin/components/dashboard/sidebar.tsx
+++ b/web/admin/components/dashboard/sidebar.tsx
@@ -21,6 +21,7 @@ import {
   BarChart3,
   ShieldAlert,
   FlaskConical,
+  Rocket,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -101,6 +102,11 @@ export function DashboardSidebar() {
       title: "Analytics",
       href: "/dashboard/analytics",
       icon: BarChart3,
+    },
+    {
+      title: "Releases",
+      href: "/dashboard/releases",
+      icon: Rocket,
     },
     {
       title: "Chat Lab",


### PR DESCRIPTION
## Summary
- New `/dashboard/releases` page — single table listing desktop releases
- Pulls GitHub releases (macOS tags), aggregates PostHog events (crashes, launches, feedbacks, screen capture failures) over 60 days
- Computes a 0-5 stability rating + summary per release
- Sidebar nav entry added with Rocket icon

Originally scaffolded in a prior session (2026-04-15) but never committed — files were sitting untracked in an abandoned worktree. This PR picks them up with the sidebar entry added.

## Files
- `web/admin/app/api/omi/releases/route.ts` — new API route (verifyAdmin + GitHub + PostHog)
- `web/admin/app/(protected)/dashboard/releases/page.tsx` — new SWR-driven page
- `web/admin/components/dashboard/sidebar.tsx` — Releases nav entry

## Required env (already on prod)
`POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID` — already configured in `gcp_admin.yml` secrets. `GITHUB_TOKEN` optional (higher rate limit).

## Test plan
- [ ] `/dashboard/releases` renders the latest ~30 macOS releases
- [ ] Crash rate column shows color-coded %
- [ ] Rating shows 0-5 with green/amber/red color
- [ ] Amber banner appears if PostHog query fails
- [ ] Hard-refresh may be required post-deploy (CDN cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)