### PR TITLE
fix preference tool missing uid and scoring fields so saved memories appear in tab

### DIFF
--- a/backend/utils/retrieval/tools/preference_tools.py
+++ b/backend/utils/retrieval/tools/preference_tools.py
@@ -12,6 +12,7 @@ from langchain_core.runnables import RunnableConfig
 import database.memories as memory_db
 import database.vector_db as vector_db
 import logging
+from models.memories import CATEGORY_BOOSTS
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +70,11 @@ def save_user_preference_tool(preference: str, config: RunnableConfig = None) ->
 
     now = datetime.now(timezone.utc)
     memory_id = str(uuid.uuid4())
+    cat_boost = 999 - CATEGORY_BOOSTS.get('system', 0)
+    scoring = "{:02d}_{:02d}_{:010d}".format(0, cat_boost, int(now.timestamp()))
     memory_data = {
         'id': memory_id,
+        'uid': uid,
         'content': preference,
         'category': 'system',
         'manually_added': False,
@@ -79,6 +83,7 @@ def save_user_preference_tool(preference: str, config: RunnableConfig = None) ->
         'reviewed': False,
         'visibility': 'private',
         'tags': ['agent-learned'],
+        'scoring': scoring,
     }
 
     try:

--- a/backend/utils/retrieval/tools/preference_tools.py
+++ b/backend/utils/retrieval/tools/preference_tools.py
@@ -12,7 +12,7 @@ from langchain_core.runnables import RunnableConfig
 import database.memories as memory_db
 import database.vector_db as vector_db
 import logging
-from models.memories import CATEGORY_BOOSTS
+from models.memories import MemoryDB
 
 logger = logging.getLogger(__name__)
 
@@ -70,8 +70,6 @@ def save_user_preference_tool(preference: str, config: RunnableConfig = None) ->
 
     now = datetime.now(timezone.utc)
     memory_id = str(uuid.uuid4())
-    cat_boost = 999 - CATEGORY_BOOSTS.get('system', 0)
-    scoring = "{:02d}_{:02d}_{:010d}".format(0, cat_boost, int(now.timestamp()))
     memory_data = {
         'id': memory_id,
         'uid': uid,
@@ -83,8 +81,8 @@ def save_user_preference_tool(preference: str, config: RunnableConfig = None) ->
         'reviewed': False,
         'visibility': 'private',
         'tags': ['agent-learned'],
-        'scoring': scoring,
     }
+    memory_data['scoring'] = MemoryDB.calculate_score(MemoryDB.model_validate(memory_data))
 
     try:
         memory_db.create_memory(uid, memory_data)


### PR DESCRIPTION
When saving a preference from chat, the memory was written to Firestore without `uid` or `scoring` fields. Firestore excludes documents missing an `order_by` field, so memories never appeared in the tab. The `uid` omission then caused `MemoryDB.model_validate` to skip the document even after it was found.

**Fix:** add `uid` and compute `scoring` (matching `MemoryDB.calculate_score` format) before writing.

## Demo
https://github.com/user-attachments/assets/98f0b764-ed8e-4b44-880c-2235314bb6eb

Closes #6815

🤖 Generated with [Claude Code](https://claude.com/claude-code)