### PR TITLE
fix(pusher): add jemalloc to eliminate glibc malloc fragmentation OOM

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -39,7 +39,12 @@ WORKDIR /app
 ENV PATH="/opt/venv/bin:$PATH"
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-RUN apt-get update && apt-get -y install ffmpeg curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install ffmpeg curl libjemalloc2 && rm -rf /var/lib/apt/lists/*
+
+# jemalloc eliminates glibc malloc fragmentation that causes RSS to grow linearly
+# under high-churn bytearray allocations from WebSocket audio streams (#6938)
+# Use soname-only form so ld.so resolves via standard search paths (arch-portable)
+ENV LD_PRELOAD=libjemalloc.so.2
 
 # Copy compiled liblc3 library from builder staging dir
 COPY --from=builder /opt/liblc3/ /usr/local/lib/

--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -43,7 +43,8 @@ RUN apt-get update && apt-get -y install ffmpeg curl libjemalloc2 && rm -rf /var
 
 # jemalloc eliminates glibc malloc fragmentation that causes RSS to grow linearly
 # under high-churn bytearray allocations from WebSocket audio streams (#6938)
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+# Use soname-only form so ld.so resolves via standard search paths (arch-portable)
+ENV LD_PRELOAD=libjemalloc.so.2
 
 # Copy compiled liblc3 library from builder staging dir
 COPY --from=builder /opt/liblc3/ /usr/local/lib/

--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -39,7 +39,11 @@ WORKDIR /app
 ENV PATH="/opt/venv/bin:$PATH"
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-RUN apt-get update && apt-get -y install ffmpeg curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install ffmpeg curl libjemalloc2 && rm -rf /var/lib/apt/lists/*
+
+# jemalloc eliminates glibc malloc fragmentation that causes RSS to grow linearly
+# under high-churn bytearray allocations from WebSocket audio streams (#6938)
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 # Copy compiled liblc3 library from builder staging dir
 COPY --from=builder /opt/liblc3/ /usr/local/lib/


### PR DESCRIPTION
## Summary
- **Root cause**: glibc `malloc` arena fragmentation under high-churn `bytearray` allocations from WebSocket audio streams. Live profiling confirmed ~580MB arena with only ~270MB in use — **53% trapped in fragmented chunks** glibc can't return to OS. `malloc_trim(0)` only reclaims ~6MB.
- **Fix**: `LD_PRELOAD=libjemalloc.so.2` — jemalloc's thread-local caches + size-class slabs eliminate the fragmentation pattern entirely. Industry standard fix used by Redis (default since 2.4), Firefox, and most long-running high-churn servers.
- **Implementation**: 2 lines per Dockerfile — `apt-get install libjemalloc2` + `ENV LD_PRELOAD`. No code changes needed.

## Changes
| File | Change |
|------|--------|
| `backend/pusher/Dockerfile` | Add `libjemalloc2` to runtime apt-get, set `LD_PRELOAD=libjemalloc.so.2` |
| `backend/Dockerfile` | Same — backend + backend-listen share this image, both handle audio bytearray streams |

## Why both Dockerfiles
- **Pusher**: receives audio via binary WebSocket, buffers/batches/uploads — primary OOM victim (173 kills/24h)
- **Backend / Backend-listen** (`transcribe.py`): decodes audio (opus/aac/lc3), copies to bytes, forwards to pusher — same alloc/copy/free pattern, same fragmentation risk
- Backend-listen uses the same Docker image as backend (`gcr.io/based-hardware/backend`), so one Dockerfile change covers both

## Expected impact
- RSS stays flat near actual in-use (~300MB) instead of growing linearly at ~1.9 GB/hour
- Eliminates the malloc fragmentation that was the remaining OOM driver after deque fix (#6762)

## Live test results — all 3 services with jemalloc

Ran all 3 services locally with `LD_PRELOAD=libjemalloc.so.2`, verified with curl and wscat:

| Service | Port | Health (curl) | jemalloc loaded | WS handshake + send | RSS |
|---------|------|---------------|-----------------|----------------------|-----|
| Pusher | 10240 | PASS — `{"status":"healthy"}` | PASS — 5 mappings | PASS — `/v1/trigger/listen` | 334 MB |
| Backend | 10241 | PASS — `{"status":"ok"}` | PASS — 5 mappings | PASS — `/v4/listen` (auth) | 410 MB |
| Backend-listen | 10242 | PASS — `{"status":"ok"}` | PASS — 5 mappings | PASS — `/v4/listen` (auth) | 460 MB |

### Evidence

**jemalloc confirmed loaded in all 3 processes:**
```
$ cat /proc/<PID>/maps | grep jemalloc
7b59a0600000-7b59a06cb000  /usr/lib/x86_64-linux-gnu/libjemalloc.so.2

$ cat /proc/<PID>/environ | tr '\0' '\n' | grep LD_PRELOAD
LD_PRELOAD=libjemalloc.so.2
```

**jemalloc is the active allocator:**
```
jemalloc loaded: libjemalloc.so.2
mallctl found — jemalloc is the active allocator
```

**Pusher WebSocket:**
```
WS connected: True → sent 100 bytes → connection handled → PASS
```

**Backend + Backend-listen WebSocket** (`/v4/listen` with ADMIN_KEY auth):
```
WS connected: True → sent 320 bytes (20ms PCM) → received "ping" → PASS
```

**Note**: glibc fragmentation builds over hours of sustained load (1.9 GB/hr with 30+ concurrent WS connections). Short synthetic tests don't reproduce it. Post-deploy 24h RSS monitoring will confirm the fix.

## Verification plan (post-deploy)
```
kubectl exec <pod> -- python3 -c "
import ctypes; print(ctypes.CDLL('libjemalloc.so.2')._name)
with open('/proc/self/status') as f:
    for l in f:
        if 'VmRSS' in l: print(l.strip())
"
```

## Test plan
- [x] Dockerfile syntax valid (programmatic check, both files)
- [x] `libjemalloc2` available in `python:3.11-slim` (Debian Bookworm) via apt
- [x] `LD_PRELOAD` uses arch-portable soname-only form (`libjemalloc.so.2`)
- [x] CI builds amd64 only (confirmed via CI workflows — plain `docker build`)
- [x] All 3 services run with jemalloc — health, WS, allocator verified
- [x] Backend-listen confirmed to share `backend/Dockerfile` image

## Deploy plan
1. Merge PR
2. `gcp_backend_pusher.yml` (prod, main) — pusher GKE pods
3. `gcp_backend.yml` (prod, main) — backend Cloud Run + backend-listen GKE
4. Post-deploy: verify jemalloc loaded + RSS monitoring at T+1h/6h/24h

## Review cycle
- Round 1: Reviewer flagged hardcoded amd64 path → fixed to soname-only form
- Round 2: PR_APPROVED_LGTM
- Tester: TESTS_APPROVED
- L1/L2: All 3 services tested locally with jemalloc — health, WS, allocator all verified

Closes #6938

_by AI for @beastoin_