### PR TITLE
refactor(backend): migrate Gemini from AI Studio to Vertex AI

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -79,11 +79,10 @@ ingress:
   #      - chart-example.local
 
 env:
-  - name: GEMINI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: dev-omi-backend-secrets
-        key: GEMINI_API_KEY
+  - name: GCP_LOCATION
+    value: "global"
+  - name: GCP_EMBEDDING_LOCATION
+    value: "us-central1"
   - name: DEEPGRAM_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -79,11 +79,10 @@ ingress:
   #      - chart-example.local
 
 env:
-  - name: GEMINI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: prod-omi-backend-secrets
-        key: GEMINI_API_KEY
+  - name: GCP_LOCATION
+    value: "global"
+  - name: GCP_EMBEDDING_LOCATION
+    value: "us-central1"
   - name: BUCKET_SPEECH_PROFILES
     value: "speech-profiles"
   - name: GITHUB_TOKEN

--- a/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
@@ -56,8 +56,6 @@ externalSecret:
       remoteKey: ENCRYPTION_SECRET
     - secretKey: SERVICE_ACCOUNT_JSON
       remoteKey: SERVICE_ACCOUNT_JSON
-    - secretKey: GEMINI_API_KEY
-      remoteKey: GEMINI_API_KEY
     - secretKey: TWILIO_ACCOUNT_SID
       remoteKey: TWILIO_ACCOUNT_SID
     - secretKey: TWILIO_AUTH_TOKEN

--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -64,8 +64,6 @@ externalSecret:
       remoteKey: STT_SERVICE_MODELS
     - secretKey: ENCRYPTION_SECRET
       remoteKey: ENCRYPTION_SECRET
-    - secretKey: GEMINI_API_KEY
-      remoteKey: GEMINI_API_KEY
     - secretKey: TWILIO_ACCOUNT_SID
       remoteKey: TWILIO_ACCOUNT_SID
     - secretKey: TWILIO_AUTH_TOKEN

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -103,6 +103,7 @@ pytest tests/unit/test_async_http_infrastructure.py -v
 pytest tests/unit/test_clean_sweep_migrations.py -v
 pytest tests/unit/test_omi_qos_tiers.py -v
 pytest tests/unit/test_byok_security.py -v
+pytest tests/unit/test_vertex_ai_migration.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -239,14 +239,19 @@ class TestGeminiKeyNotInUrl:
     @patch('utils.llm.clients.get_byok_key', return_value=None)
     def test_gemini_embed_vertex_uses_bearer_auth(self, mock_byok, mock_vertex_token, mock_post):
         """Platform calls (no BYOK) route to Vertex AI with Bearer token."""
+        import utils.llm.clients as mod
+
         mock_response = MagicMock()
         mock_response.json.return_value = {'embedding': {'values': [0.1, 0.2]}}
         mock_response.raise_for_status = MagicMock()
         mock_post.return_value = mock_response
 
-        from utils.llm.clients import gemini_embed_query
-
-        gemini_embed_query('test query')
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod.gemini_embed_query('test query')
+        finally:
+            mod._GCP_PROJECT = orig_project
 
         call_args = mock_post.call_args
         url = call_args[0][0] if call_args[0] else call_args[1].get('url', '')

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -235,8 +235,10 @@ class TestCacheKeyHashing:
 
 class TestGeminiKeyNotInUrl:
     @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-test-token')
     @patch('utils.llm.clients.get_byok_key', return_value=None)
-    def test_gemini_embed_uses_header_not_url_param(self, mock_byok, mock_post):
+    def test_gemini_embed_vertex_uses_bearer_auth(self, mock_byok, mock_vertex_token, mock_post):
+        """Platform calls (no BYOK) route to Vertex AI with Bearer token."""
         mock_response = MagicMock()
         mock_response.json.return_value = {'embedding': {'values': [0.1, 0.2]}}
         mock_response.raise_for_status = MagicMock()
@@ -248,14 +250,17 @@ class TestGeminiKeyNotInUrl:
 
         call_args = mock_post.call_args
         url = call_args[0][0] if call_args[0] else call_args[1].get('url', '')
+        assert 'aiplatform.googleapis.com' in url
+        assert 'generativelanguage.googleapis.com' not in url
         assert '?key=' not in url
-        assert 'key=' not in url
         headers = call_args[1].get('headers', {})
-        assert 'x-goog-api-key' in headers
+        assert headers.get('Authorization') == 'Bearer vertex-test-token'
+        assert 'x-goog-api-key' not in headers
 
     @patch('utils.llm.clients.httpx.post')
     @patch('utils.llm.clients.get_byok_key', return_value='user-gemini-key-secret')
-    def test_byok_gemini_key_not_in_url(self, mock_byok, mock_post):
+    def test_byok_gemini_uses_ai_studio(self, mock_byok, mock_post):
+        """BYOK users route to AI Studio with their own API key in header."""
         mock_response = MagicMock()
         mock_response.json.return_value = {'embedding': {'values': [0.1, 0.2]}}
         mock_response.raise_for_status = MagicMock()
@@ -267,6 +272,7 @@ class TestGeminiKeyNotInUrl:
 
         call_args = mock_post.call_args
         url = call_args[0][0] if call_args[0] else call_args[1].get('url', '')
+        assert 'generativelanguage.googleapis.com' in url
         assert 'user-gemini-key-secret' not in url
         headers = call_args[1].get('headers', {})
         assert headers.get('x-goog-api-key') == 'user-gemini-key-secret'

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -181,6 +181,26 @@ class TestVertexGeminiProxy:
         finally:
             mod._GCP_PROJECT = orig_project
 
+    @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('ADC broken'))
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_vertex_creds_failure_falls_back_to_openrouter(self, mock_byok, mock_token):
+        """When GCP project is set but ADC/refresh fails, proxy falls back to OpenRouter."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mock_default = MagicMock()
+            proxy = mod._VertexGeminiProxy(
+                default=mock_default,
+                direct_model='gemini-3-flash-preview',
+                ctor_kwargs={'callbacks': []},
+            )
+            resolved = proxy._resolve()
+            assert resolved is mock_default
+        finally:
+            mod._GCP_PROJECT = orig_project
+
     @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-tok')
     @patch('utils.llm.clients.get_byok_key', return_value=None)
     def test_vertex_client_strips_openrouter_kwargs(self, mock_byok, mock_token):
@@ -278,6 +298,19 @@ class TestGeminiEmbedRouting:
         headers = call_args[1].get('headers', {})
         assert headers.get('x-goog-api-key') == 'byok-gem-key'
         assert len(result) == 3072
+
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_embed_no_project_raises_clear_error(self, mock_byok):
+        """Without BYOK or GCP project, embedding raises RuntimeError."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = ''
+            with pytest.raises(RuntimeError, match='BYOK key or GCP project'):
+                mod.gemini_embed_query('test query')
+        finally:
+            mod._GCP_PROJECT = orig_project
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -124,43 +124,73 @@ class TestVertexGeminiProxy:
     @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-tok')
     @patch('utils.llm.clients.get_byok_key', return_value=None)
     def test_platform_routes_to_vertex(self, mock_byok, mock_token):
-        """Without BYOK key, proxy should route to Vertex AI."""
+        """Without BYOK key, proxy should route to Vertex AI with correct base URL."""
         import utils.llm.clients as mod
 
         orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._openai_cache)
         try:
             mod._GCP_PROJECT = 'test-project'
-            mock_default = MagicMock()
-            proxy = mod._VertexGeminiProxy(
-                default=mock_default,
-                direct_model='gemini-3-flash-preview',
-                ctor_kwargs={
-                    'api_key': 'openrouter-key',
-                    'base_url': 'https://openrouter.ai/api/v1',
-                    'default_headers': {'X-Title': 'Omi Chat'},
-                    'callbacks': [],
-                },
-            )
-            resolved = proxy._resolve()
-            # Should NOT be the OpenRouter default
-            assert resolved is not mock_default
+            mod._openai_cache.clear()
+
+            captured = {}
+
+            def capturing_cached_openai_chat(model, api_key, ctor_kwargs):
+                captured['api_key'] = api_key
+                captured['base_url'] = ctor_kwargs.get('base_url', '')
+                return MagicMock()
+
+            with patch.object(mod, '_cached_openai_chat', capturing_cached_openai_chat):
+                mock_default = MagicMock()
+                proxy = mod._VertexGeminiProxy(
+                    default=mock_default,
+                    direct_model='gemini-3-flash-preview',
+                    ctor_kwargs={
+                        'api_key': 'openrouter-key',
+                        'base_url': 'https://openrouter.ai/api/v1',
+                        'default_headers': {'X-Title': 'Omi Chat'},
+                        'callbacks': [],
+                    },
+                )
+                resolved = proxy._resolve()
+                assert resolved is not mock_default
+                assert 'aiplatform.googleapis.com' in captured['base_url']
+                assert captured['api_key'] == 'vertex-tok'
         finally:
             mod._GCP_PROJECT = orig_project
+            mod._openai_cache.clear()
+            mod._openai_cache.update(orig_cache)
 
     @patch('utils.llm.clients.get_byok_key', return_value='user-gemini-key')
     def test_byok_routes_to_ai_studio(self, mock_byok):
-        """With BYOK key, proxy should route to AI Studio."""
+        """With BYOK key, proxy should route to AI Studio with BYOK key."""
         import utils.llm.clients as mod
 
-        mock_default = MagicMock()
-        proxy = mod._VertexGeminiProxy(
-            default=mock_default,
-            direct_model='gemini-3-flash-preview',
-            ctor_kwargs={'callbacks': []},
-        )
-        resolved = proxy._resolve()
-        # Should NOT be the OpenRouter default (it's a cached AI Studio client)
-        assert resolved is not mock_default
+        orig_cache = dict(mod._openai_cache)
+        try:
+            mod._openai_cache.clear()
+
+            captured = {}
+
+            def capturing_cached_openai_chat(model, api_key, ctor_kwargs):
+                captured['api_key'] = api_key
+                captured['base_url'] = ctor_kwargs.get('base_url', '')
+                return MagicMock()
+
+            with patch.object(mod, '_cached_openai_chat', capturing_cached_openai_chat):
+                mock_default = MagicMock()
+                proxy = mod._VertexGeminiProxy(
+                    default=mock_default,
+                    direct_model='gemini-3-flash-preview',
+                    ctor_kwargs={'callbacks': []},
+                )
+                resolved = proxy._resolve()
+                assert resolved is not mock_default
+                assert 'generativelanguage.googleapis.com' in captured['base_url']
+                assert captured['api_key'] == 'user-gemini-key'
+        finally:
+            mod._openai_cache.clear()
+            mod._openai_cache.update(orig_cache)
 
     @patch('utils.llm.clients.get_byok_key', return_value=None)
     def test_no_vertex_config_falls_back_to_openrouter(self, mock_byok):
@@ -373,3 +403,77 @@ class TestAIStudioUrlPreserved:
         from utils.llm.clients import _GEMINI_AI_STUDIO_BASE_URL
 
         assert 'generativelanguage.googleapis.com' in _GEMINI_AI_STUDIO_BASE_URL
+
+
+# ---------------------------------------------------------------------------
+# 7. Boundary tests: concurrent refresh, embedding location override, token failure
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryBehavior:
+    def test_concurrent_token_refresh_serialized(self):
+        """Concurrent calls to _get_vertex_access_token serialize through _vertex_lock."""
+        import utils.llm.clients as mod
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        refresh_count = {'n': 0}
+
+        def counting_refresh(request):
+            refresh_count['n'] += 1
+
+        mock_creds.refresh = counting_refresh
+        mock_creds.token = 'refreshed-tok'
+
+        orig_creds = mod._vertex_credentials
+        try:
+            mod._vertex_credentials = mock_creds
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+                futures = [pool.submit(mod._get_vertex_access_token) for _ in range(4)]
+                results = [f.result() for f in futures]
+            # All should get the token
+            assert all(r == 'refreshed-tok' for r in results)
+            # Refresh was called (at least once, serialized by lock)
+            assert refresh_count['n'] >= 1
+        finally:
+            mod._vertex_credentials = orig_creds
+
+    @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vx-token')
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_embedding_location_override(self, mock_byok, mock_token, mock_post):
+        """GCP_EMBEDDING_LOCATION env var overrides default us-central1."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mock_response = MagicMock()
+            mock_response.json.return_value = {'embedding': {'values': [0.1] * 3072}}
+            mock_response.raise_for_status = MagicMock()
+            mock_post.return_value = mock_response
+
+            with patch.dict(os.environ, {'GCP_EMBEDDING_LOCATION': 'europe-west4'}):
+                mod.gemini_embed_query('test query')
+
+            url = mock_post.call_args[0][0]
+            assert 'europe-west4' in url
+            assert 'us-central1' not in url
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+    @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('token refresh failed'))
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_embed_token_refresh_failure_raises(self, mock_byok, mock_token):
+        """Embedding with GCP project set but token refresh failure raises."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            with pytest.raises(RuntimeError, match='token refresh failed'):
+                mod.gemini_embed_query('test query')
+        finally:
+            mod._GCP_PROJECT = orig_project

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -1,0 +1,342 @@
+"""Tests for Gemini AI Studio → Vertex AI migration (issue #6935).
+
+Covers:
+  - Vertex auth helper caches and refreshes tokens
+  - _VertexGeminiProxy routes BYOK to AI Studio, platform to Vertex AI
+  - gemini_embed_query routing (BYOK vs Vertex)
+  - OpenRouter kwargs stripped for Vertex clients
+  - GCP project resolution
+  - Helm chart GEMINI_API_KEY removal
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-for-unit-tests')
+os.environ.setdefault('DEEPGRAM_API_KEY', 'dg-test-fake-for-unit-tests')
+os.environ.setdefault('ANTHROPIC_API_KEY', 'ant-test-fake-for-unit-tests')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+sys.modules.setdefault('database._client', MagicMock())
+sys.modules.setdefault('database.redis_db', MagicMock())
+sys.modules.setdefault('database.users', MagicMock())
+sys.modules.setdefault('database.user_usage', MagicMock())
+sys.modules.setdefault('database.llm_usage', MagicMock())
+sys.modules.setdefault('database.announcements', MagicMock())
+sys.modules.setdefault('utils.other.storage', MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# 1. Vertex access token helper
+# ---------------------------------------------------------------------------
+
+
+class TestVertexAccessToken:
+    def test_returns_token_when_creds_valid(self):
+        """When credentials are valid, return cached token without refresh."""
+        import utils.llm.clients as mod
+
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.token = 'cached-token-abc'
+
+        orig_creds = mod._vertex_credentials
+        try:
+            mod._vertex_credentials = mock_creds
+            token = mod._get_vertex_access_token()
+            assert token == 'cached-token-abc'
+            mock_creds.refresh.assert_not_called()
+        finally:
+            mod._vertex_credentials = orig_creds
+
+    def test_refreshes_expired_token(self):
+        """When credentials are expired, refresh and return new token."""
+        import utils.llm.clients as mod
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.token = 'refreshed-token-xyz'
+
+        orig_creds = mod._vertex_credentials
+        try:
+            mod._vertex_credentials = mock_creds
+            token = mod._get_vertex_access_token()
+            assert token == 'refreshed-token-xyz'
+            mock_creds.refresh.assert_called_once()
+        finally:
+            mod._vertex_credentials = orig_creds
+
+    def test_raises_when_no_credentials(self):
+        """When no ADC credentials available, raise RuntimeError."""
+        import utils.llm.clients as mod
+
+        orig_creds = mod._vertex_credentials
+        try:
+            mod._vertex_credentials = None
+            with pytest.raises(RuntimeError, match='Vertex AI credentials not available'):
+                mod._get_vertex_access_token()
+        finally:
+            mod._vertex_credentials = orig_creds
+
+
+# ---------------------------------------------------------------------------
+# 2. Vertex OpenAI base URL construction
+# ---------------------------------------------------------------------------
+
+
+class TestVertexBaseUrl:
+    def test_default_location(self):
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project-123'
+            url = mod._vertex_openai_base_url()
+            assert 'aiplatform.googleapis.com' in url
+            assert 'test-project-123' in url
+            assert '/endpoints/openapi' in url
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+    def test_custom_location(self):
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project-456'
+            url = mod._vertex_openai_base_url(location='us-east1')
+            assert 'us-east1' in url
+            assert 'test-project-456' in url
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+
+# ---------------------------------------------------------------------------
+# 3. _VertexGeminiProxy routing
+# ---------------------------------------------------------------------------
+
+
+class TestVertexGeminiProxy:
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-tok')
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_platform_routes_to_vertex(self, mock_byok, mock_token):
+        """Without BYOK key, proxy should route to Vertex AI."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mock_default = MagicMock()
+            proxy = mod._VertexGeminiProxy(
+                default=mock_default,
+                direct_model='gemini-3-flash-preview',
+                ctor_kwargs={
+                    'api_key': 'openrouter-key',
+                    'base_url': 'https://openrouter.ai/api/v1',
+                    'default_headers': {'X-Title': 'Omi Chat'},
+                    'callbacks': [],
+                },
+            )
+            resolved = proxy._resolve()
+            # Should NOT be the OpenRouter default
+            assert resolved is not mock_default
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+    @patch('utils.llm.clients.get_byok_key', return_value='user-gemini-key')
+    def test_byok_routes_to_ai_studio(self, mock_byok):
+        """With BYOK key, proxy should route to AI Studio."""
+        import utils.llm.clients as mod
+
+        mock_default = MagicMock()
+        proxy = mod._VertexGeminiProxy(
+            default=mock_default,
+            direct_model='gemini-3-flash-preview',
+            ctor_kwargs={'callbacks': []},
+        )
+        resolved = proxy._resolve()
+        # Should NOT be the OpenRouter default (it's a cached AI Studio client)
+        assert resolved is not mock_default
+
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_no_vertex_config_falls_back_to_openrouter(self, mock_byok):
+        """Without GCP project, proxy falls back to OpenRouter default."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = ''
+            mock_default = MagicMock()
+            proxy = mod._VertexGeminiProxy(
+                default=mock_default,
+                direct_model='gemini-3-flash-preview',
+                ctor_kwargs={'callbacks': []},
+            )
+            resolved = proxy._resolve()
+            assert resolved is mock_default
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-tok')
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_vertex_client_strips_openrouter_kwargs(self, mock_byok, mock_token):
+        """Verify OpenRouter-specific kwargs (api_key, default_headers) are NOT passed to Vertex client."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._openai_cache)
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._openai_cache.clear()
+
+            captured = {}
+            orig_cached_fn = mod._cached_openai_chat
+
+            def capturing_cached_openai_chat(model, api_key, ctor_kwargs):
+                captured['model'] = model
+                captured['api_key'] = api_key
+                captured['ctor_kwargs'] = ctor_kwargs
+                return MagicMock()
+
+            with patch.object(mod, '_cached_openai_chat', capturing_cached_openai_chat):
+                proxy = mod._VertexGeminiProxy(
+                    default=MagicMock(),
+                    direct_model='gemini-3-flash-preview',
+                    ctor_kwargs={
+                        'api_key': 'openrouter-key-LEAKED',
+                        'base_url': 'https://openrouter.ai/api/v1',
+                        'default_headers': {'X-Title': 'Omi Chat'},
+                        'callbacks': ['cb1'],
+                        'temperature': 0.7,
+                    },
+                )
+                proxy._resolve()
+
+            assert 'openrouter-key-LEAKED' not in str(captured.get('ctor_kwargs', {}))
+            assert captured['ctor_kwargs'].get('callbacks') == ['cb1']
+            assert captured['ctor_kwargs'].get('temperature') == 0.7
+            assert 'aiplatform.googleapis.com' in captured['ctor_kwargs']['base_url']
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._openai_cache.clear()
+            mod._openai_cache.update(orig_cache)
+
+
+# ---------------------------------------------------------------------------
+# 4. gemini_embed_query routing
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiEmbedRouting:
+    @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vx-token')
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_platform_embed_uses_vertex_endpoint(self, mock_byok, mock_token, mock_post):
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mock_response = MagicMock()
+            mock_response.json.return_value = {'embedding': {'values': [0.1] * 3072}}
+            mock_response.raise_for_status = MagicMock()
+            mock_post.return_value = mock_response
+
+            result = mod.gemini_embed_query('test query')
+
+            call_args = mock_post.call_args
+            url = call_args[0][0]
+            assert 'aiplatform.googleapis.com' in url
+            assert 'gemini-embedding-001' in url
+            headers = call_args[1].get('headers', {})
+            assert headers.get('Authorization') == 'Bearer vx-token'
+            assert 'x-goog-api-key' not in headers
+            assert len(result) == 3072
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+    @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients.get_byok_key', return_value='byok-gem-key')
+    def test_byok_embed_uses_ai_studio_endpoint(self, mock_byok, mock_post):
+        from utils.llm.clients import gemini_embed_query
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'embedding': {'values': [0.2] * 3072}}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        result = gemini_embed_query('test query')
+
+        call_args = mock_post.call_args
+        url = call_args[0][0]
+        assert 'generativelanguage.googleapis.com' in url
+        assert 'aiplatform.googleapis.com' not in url
+        headers = call_args[1].get('headers', {})
+        assert headers.get('x-goog-api-key') == 'byok-gem-key'
+        assert len(result) == 3072
+
+
+# ---------------------------------------------------------------------------
+# 5. Helm config: GEMINI_API_KEY removed
+# ---------------------------------------------------------------------------
+
+
+class TestHelmGeminiKeyRemoved:
+    """Verify GEMINI_API_KEY is no longer referenced in backend Helm charts."""
+
+    def test_no_gemini_api_key_in_backend_listen_dev(self):
+        chart_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'charts', 'backend-listen', 'dev_omi_backend_listen_values.yaml'
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GEMINI_API_KEY' not in content
+
+    def test_no_gemini_api_key_in_backend_listen_prod(self):
+        chart_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'charts', 'backend-listen', 'prod_omi_backend_listen_values.yaml'
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GEMINI_API_KEY' not in content
+
+    def test_no_gemini_api_key_in_backend_secrets_dev(self):
+        chart_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'charts', 'backend-secrets', 'dev_omi_backend_secrets_values.yaml'
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GEMINI_API_KEY' not in content
+
+    def test_no_gemini_api_key_in_backend_secrets_prod(self):
+        chart_path = os.path.join(
+            os.path.dirname(__file__),
+            '..',
+            '..',
+            'charts',
+            'backend-secrets',
+            'prod_omi_backend_secrets_values.yaml',
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GEMINI_API_KEY' not in content
+
+
+# ---------------------------------------------------------------------------
+# 6. AI Studio URL preserved for BYOK
+# ---------------------------------------------------------------------------
+
+
+class TestAIStudioUrlPreserved:
+    def test_ai_studio_base_url_constant_exists(self):
+        from utils.llm.clients import _GEMINI_AI_STUDIO_BASE_URL
+
+        assert 'generativelanguage.googleapis.com' in _GEMINI_AI_STUDIO_BASE_URL

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,9 +1,12 @@
 import hashlib
 import logging
 import os
+import threading
 from typing import Any, Dict, List, Optional
 
 import anthropic
+import google.auth
+import google.auth.transport.requests
 import httpx
 from cachetools import TTLCache
 from langchain_core.output_parsers import PydanticOutputParser
@@ -17,6 +20,53 @@ from utils.llm.usage_tracker import get_usage_callback
 logger = logging.getLogger(__name__)
 
 _usage_callback = get_usage_callback()
+
+# ---------------------------------------------------------------------------
+# Vertex AI configuration (replaces Google AI Studio for platform-owned calls)
+#
+# Auth uses Application Default Credentials (ADC) / Workload Identity — no API
+# key needed.  BYOK users still route to AI Studio with their own key.
+#
+# Env vars:
+#   GCP_LOCATION — Vertex AI region (default: global, needed for Gemini 3)
+#   GOOGLE_CLOUD_PROJECT — GCP project ID (fallback if ADC doesn't return one)
+# ---------------------------------------------------------------------------
+
+_GCP_LOCATION = os.environ.get('GCP_LOCATION', 'global')
+
+# Resolve GCP project once at startup via ADC, with env fallback.
+# ADC may not be available in dev/test environments — fail gracefully.
+try:
+    _vertex_credentials, _vertex_project = google.auth.default(
+        scopes=['https://www.googleapis.com/auth/cloud-platform'],
+    )
+except google.auth.exceptions.DefaultCredentialsError:
+    logger.info('No ADC found — Vertex AI Gemini calls will fall back to OpenRouter')
+    _vertex_credentials = None
+    _vertex_project = None
+
+_GCP_PROJECT = _vertex_project or os.environ.get('GOOGLE_CLOUD_PROJECT', '')
+if not _GCP_PROJECT:
+    logger.info('No GCP project resolved — Vertex AI Gemini calls will fall back to OpenRouter')
+
+_vertex_lock = threading.Lock()
+
+
+def _get_vertex_access_token() -> str:
+    """Return a valid OAuth2 access token for Vertex AI, refreshing if needed."""
+    if _vertex_credentials is None:
+        raise RuntimeError('Vertex AI credentials not available — check ADC configuration')
+    with _vertex_lock:
+        if not _vertex_credentials.valid:
+            _vertex_credentials.refresh(google.auth.transport.requests.Request())
+        return _vertex_credentials.token
+
+
+def _vertex_openai_base_url(location: Optional[str] = None) -> str:
+    """Build the Vertex AI OpenAI-compatible base URL."""
+    loc = location or _GCP_LOCATION
+    return f'https://aiplatform.googleapis.com/v1/projects/{_GCP_PROJECT}/locations/{loc}/endpoints/openapi'
+
 
 # ---------------------------------------------------------------------------
 # BYOK routing proxies
@@ -78,16 +128,17 @@ class _AnthropicClientProxy:
         return getattr(self._resolve(), name)
 
 
-# Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
-# as the client class while routing to Gemini directly — no new langchain dep.
-_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+# Google AI Studio OpenAI-compatible endpoint — kept for BYOK Gemini users only.
+_GEMINI_AI_STUDIO_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 
-class _OpenRouterGeminiProxy:
-    """For models served via OpenRouter that we want to route direct when BYOK Gemini is set.
+class _VertexGeminiProxy:
+    """Routes platform Gemini calls to Vertex AI; BYOK Gemini stays on AI Studio.
 
-    Falls back to the OpenRouter-backed default client when no BYOK gemini key
-    is present — so non-BYOK users are unaffected.
+    Resolution order:
+    1. BYOK Gemini key present → route to AI Studio (user's own key, unchanged)
+    2. No BYOK key → route to Vertex AI via ADC token (saves 34% via EDP/PT)
+    3. Vertex AI not configured → fall back to OpenRouter (graceful degradation)
     """
 
     __slots__ = ('_default', '_direct_model', '_ctor_kwargs')
@@ -100,11 +151,25 @@ class _OpenRouterGeminiProxy:
     def _resolve(self) -> ChatOpenAI:
         byok = get_byok_key('gemini')
         if byok:
+            # BYOK users keep using AI Studio with their own API key
             return _cached_openai_chat(
                 self._direct_model,
                 byok,
-                {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
+                {**self._ctor_kwargs, 'base_url': _GEMINI_AI_STUDIO_BASE_URL},
             )
+        # Platform calls → Vertex AI (ADC auth, EDP/PT discounts)
+        if _GCP_PROJECT:
+            token = _get_vertex_access_token()
+            # Strip OpenRouter-specific kwargs before building Vertex client
+            vertex_kwargs = {
+                k: v for k, v in self._ctor_kwargs.items() if k not in ('api_key', 'base_url', 'default_headers')
+            }
+            return _cached_openai_chat(
+                self._direct_model,
+                token,
+                {**vertex_kwargs, 'base_url': _vertex_openai_base_url()},
+            )
+        # Fallback: no Vertex config, use OpenRouter default
         return self._default
 
     def __getattr__(self, name: str):
@@ -382,7 +447,7 @@ def get_model(feature: str) -> str:
 
 # ---------------------------------------------------------------------------
 # Client factories — provider-specific, cached per (model, streaming, provider)
-# QoS clients are BYOK-aware via _byok_openai / _OpenRouterGeminiProxy.
+# QoS clients are BYOK-aware via _byok_openai / _VertexGeminiProxy.
 # ---------------------------------------------------------------------------
 
 _llm_cache: Dict[tuple, Any] = {}
@@ -423,7 +488,7 @@ def _get_or_create_openrouter_llm(
         if model_name.startswith('google/gemini'):
             direct_model = model_name.split('/', 1)[1]
             default = ChatOpenAI(model=model_name, **kwargs)
-            _llm_cache[key] = _OpenRouterGeminiProxy(default=default, direct_model=direct_model, ctor_kwargs=kwargs)
+            _llm_cache[key] = _VertexGeminiProxy(default=default, direct_model=direct_model, ctor_kwargs=kwargs)
         else:
             _llm_cache[key] = ChatOpenAI(model=model_name, **kwargs)
     return _llm_cache[key]
@@ -587,7 +652,7 @@ _persona_mini_default = ChatOpenAI(
 )
 # BYOK Gemini → route direct to Google's OpenAI-compat endpoint.
 # Model name drops the `google/` prefix: gemini-flash-1.5-8b on Google direct.
-llm_persona_mini_stream = _OpenRouterGeminiProxy(
+llm_persona_mini_stream = _VertexGeminiProxy(
     default=_persona_mini_default,
     direct_model="gemini-flash-1.5-8b",
     ctor_kwargs=_persona_mini_kwargs,
@@ -656,7 +721,7 @@ _gemini_flash_default = ChatOpenAI(
     default_headers={"X-Title": "Omi Wrapped"},
     **_gemini_flash_kwargs,
 )
-llm_gemini_flash = _OpenRouterGeminiProxy(
+llm_gemini_flash = _VertexGeminiProxy(
     default=_gemini_flash_default,
     direct_model="gemini-3-flash-preview",
     ctor_kwargs=_gemini_flash_kwargs,
@@ -692,17 +757,37 @@ def gemini_embed_query(text: str) -> List[float]:
     Uses RETRIEVAL_QUERY task type to match the RETRIEVAL_DOCUMENT embeddings
     generated by the desktop app.
 
-    Prefers the per-request BYOK Gemini key; falls back to the process-wide
-    env key so non-BYOK callers behave exactly as before.
+    Routing:
+      - BYOK Gemini key present → AI Studio (user's own key, unchanged)
+      - No BYOK key → Vertex AI via ADC (EDP/PT cost savings)
     """
-    api_key = get_byok_key('gemini') or os.environ.get('GEMINI_API_KEY', '')
-    url = 'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent'
+    byok_key = get_byok_key('gemini')
+    if byok_key:
+        # BYOK users: AI Studio endpoint with their own API key
+        url = 'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent'
+        payload = {
+            'model': 'models/embedding-001',
+            'content': {'parts': [{'text': text}]},
+            'taskType': 'RETRIEVAL_QUERY',
+        }
+        headers = {'x-goog-api-key': byok_key, 'Content-Type': 'application/json'}
+        resp = httpx.post(url, json=payload, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return resp.json()['embedding']['values']
+
+    # Platform calls: Vertex AI endpoint with ADC token
+    loc = os.environ.get('GCP_EMBEDDING_LOCATION', 'us-central1')
+    url = (
+        f'https://aiplatform.googleapis.com/v1beta1/projects/{_GCP_PROJECT}'
+        f'/locations/{loc}/publishers/google/models/gemini-embedding-001:embedContent'
+    )
     payload = {
-        'model': 'models/embedding-001',
+        'model': f'projects/{_GCP_PROJECT}/locations/{loc}/publishers/google/models/gemini-embedding-001',
         'content': {'parts': [{'text': text}]},
         'taskType': 'RETRIEVAL_QUERY',
     }
-    headers = {'x-goog-api-key': api_key, 'Content-Type': 'application/json'}
+    token = _get_vertex_access_token()
+    headers = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
     resp = httpx.post(url, json=payload, headers=headers, timeout=10)
     resp.raise_for_status()
     return resp.json()['embedding']['values']

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -788,7 +788,6 @@ def gemini_embed_query(text: str) -> List[float]:
         f'/locations/{loc}/publishers/google/models/gemini-embedding-001:embedContent'
     )
     payload = {
-        'model': f'projects/{_GCP_PROJECT}/locations/{loc}/publishers/google/models/gemini-embedding-001',
         'content': {'parts': [{'text': text}]},
         'taskType': 'RETRIEVAL_QUERY',
     }

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -159,7 +159,11 @@ class _VertexGeminiProxy:
             )
         # Platform calls → Vertex AI (ADC auth, EDP/PT discounts)
         if _GCP_PROJECT:
-            token = _get_vertex_access_token()
+            try:
+                token = _get_vertex_access_token()
+            except Exception:
+                logger.warning('Vertex AI credentials unavailable, falling back to OpenRouter')
+                return self._default
             # Strip OpenRouter-specific kwargs before building Vertex client
             vertex_kwargs = {
                 k: v for k, v in self._ctor_kwargs.items() if k not in ('api_key', 'base_url', 'default_headers')
@@ -776,6 +780,8 @@ def gemini_embed_query(text: str) -> List[float]:
         return resp.json()['embedding']['values']
 
     # Platform calls: Vertex AI endpoint with ADC token
+    if not _GCP_PROJECT:
+        raise RuntimeError('Gemini embedding requires either a BYOK key or GCP project configuration')
     loc = os.environ.get('GCP_EMBEDDING_LOCATION', 'us-central1')
     url = (
         f'https://aiplatform.googleapis.com/v1beta1/projects/{_GCP_PROJECT}'


### PR DESCRIPTION
## Summary

Migrates all Gemini API calls from Google AI Studio (`generativelanguage.googleapis.com`) to Vertex AI (`aiplatform.googleapis.com`) for **34% cost savings** via EDP + Provisioned Throughput discounts.

**Resolves #6935**

### What changed

- **`backend/utils/llm/clients.py`** — Core migration:
  - Added Vertex AI auth via Application Default Credentials (ADC) with thread-safe token refresh
  - Renamed `_OpenRouterGeminiProxy` → `_VertexGeminiProxy` with 3-tier routing:
    1. **BYOK** → AI Studio (user's own key, unchanged)
    2. **Platform** → Vertex AI (ADC Bearer token, OpenRouter kwargs stripped)
    3. **No GCP config** → OpenRouter fallback (graceful degradation)
  - Updated `gemini_embed_query()` to route platform calls to Vertex embedding endpoint
  - **Graceful fallback**: proxy catches ADC/refresh errors and falls back to OpenRouter
  - Explicit RuntimeError for embeddings when neither BYOK nor GCP project configured

- **Helm charts** (4 files):
  - Removed `GEMINI_API_KEY` from secrets charts (dev + prod)
  - Added `GCP_LOCATION=global` and `GCP_EMBEDDING_LOCATION=us-central1` to listen charts

### Review cycle changes
- **Cycle 1**: Added try/except in `_resolve()` for graceful OpenRouter fallback when ADC fails
- **Cycle 2**: Strengthened test assertions (verify actual base URLs/keys), added boundary tests
- **L2 live testing**: Found and fixed embedding payload bug (redundant `model` field caused 400 on Vertex AI)

## Tests

- **21 tests** in `test_vertex_ai_migration.py` covering all routing paths, boundary conditions, and Helm changes
- **79 tests** in `test_byok_security.py` (2 updated for Vertex/AI Studio split)
- **All 100 tests passing**

## Live test evidence

- **L1**: Module loads, all 7 code paths verified standalone (token, URL, routing, fallback, embedding)
- **L2**: Real GCP credentials on dev project — Vertex AI token acquired (`ya29.c...`), LLM proxy resolves to `ChatOpenAI(gemini-3-flash-preview)` via Vertex, embedding payload bug caught and fixed

## Risks / Edge cases

- **ADC must be available in GKE** — pods need Workload Identity. If unavailable, LLM calls fall back to OpenRouter. Embeddings fail with clear error.
- **Vertex AI API must be enabled** on the GCP project (confirmed on prod `based-hardware` project)
- **`global` location for Gemini 3 Flash** — configurable via `GCP_LOCATION` env var

_by AI for @beastoin_