### PR TITLE
feat: QoS architecture refactor + Gemini direct provider migration #6873

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -79,6 +79,8 @@ ingress:
   #      - chart-example.local
 
 env:
+  - name: USE_VERTEX_AI
+    value: "true"
   - name: GEMINI_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -79,6 +79,8 @@ ingress:
   #      - chart-example.local
 
 env:
+  - name: USE_VERTEX_AI
+    value: "true"
   - name: GEMINI_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -80,7 +80,7 @@ ingress:
 
 env:
   - name: USE_VERTEX_AI
-    value: "true"
+    value: "false"
   - name: GEMINI_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -80,7 +80,7 @@ ingress:
 
 env:
   - name: USE_VERTEX_AI
-    value: "false"
+    value: "true"
   - name: GEMINI_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -43,6 +43,7 @@ fal_client==0.4.1
 fastapi==0.112.0
 fastapi-cli==0.0.5
 fastapi-utilities==0.2.0
+filetype==1.2.0
 filelock==3.15.4
 firebase-admin==6.5.0
 flatbuffers==24.3.25
@@ -51,6 +52,7 @@ frozenlist==1.4.1
 fsspec==2024.6.1
 gitdb==4.0.11
 GitPython==3.1.43
+google-ai-generativelanguage==0.11.0
 google-api-core==2.19.1
 google-api-python-client==2.139.0
 google-auth==2.32.0
@@ -93,6 +95,7 @@ kiwisolver==1.4.5
 langchain==0.3.27
 langchain-community==0.3.31
 langchain-core==0.3.79
+langchain-google-genai==2.1.12
 langchain-openai==0.3.35
 langchain-pinecone==0.2.12
 pinecone==7.3.0

--- a/backend/tests/integration/test_qos_all_features_l1.py
+++ b/backend/tests/integration/test_qos_all_features_l1.py
@@ -1,0 +1,143 @@
+"""
+L1 Integration Test — Real LLM calls for ALL features in premium profile.
+
+Tests every feature path with a real API call to find compatibility flaws.
+For get_llm() features: invoke() with a simple prompt.
+For Anthropic/Perplexity: uses their native clients.
+
+Run: cd backend && python3 -m pytest tests/integration/test_qos_all_features_l1.py -v -s
+"""
+
+import os
+import sys
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), '..', '..', '.env'))
+
+from utils.llm.clients import (
+    MODEL_QOS_PROFILES,
+    get_model,
+    get_llm,
+    get_provider,
+    _active_profile_name,
+    anthropic_client,
+)
+
+SIMPLE_PROMPT = "Reply with exactly one word: hello"
+
+# Features that can't use get_llm() — need their own client
+_ANTHROPIC_FEATURES = {'chat_agent'}
+_PERPLEXITY_FEATURES = {'web_search'}
+_SKIP_GET_LLM = _ANTHROPIC_FEATURES | _PERPLEXITY_FEATURES
+
+
+def call_perplexity(model: str, prompt: str) -> str:
+    url = "https://api.perplexity.ai/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {os.environ['PERPLEXITY_API_KEY']}",
+        "Content-Type": "application/json",
+    }
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 50,
+    }
+    resp = httpx.post(url, json=body, headers=headers, timeout=30)
+    resp.raise_for_status()
+    return resp.json()["choices"][0]["message"]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Premium profile — all features
+# ---------------------------------------------------------------------------
+class TestPremiumAllFeatures:
+    """Test every feature in the premium profile with real LLM calls."""
+
+    ALL_FEATURES = sorted(MODEL_QOS_PROFILES['premium'].keys())
+    GET_LLM_FEATURES = [f for f in ALL_FEATURES if f not in _SKIP_GET_LLM]
+
+    @pytest.mark.parametrize("feature", GET_LLM_FEATURES)
+    def test_premium_get_llm_feature(self, feature):
+        """Test that get_llm() features in premium profile respond to real prompts."""
+        if _active_profile_name != 'premium':
+            pytest.skip("MODEL_QOS is not premium")
+        model = get_model(feature)
+        provider = get_provider(feature)
+        llm = get_llm(feature)
+        response = llm.invoke(SIMPLE_PROMPT)
+        text = response.content.strip() if hasattr(response, 'content') else str(response).strip()
+        assert text, f"FAIL {feature} ({model}/{provider}) returned empty"
+        print(f"  PASS {feature}: {model} [{provider}] -> {text[:60]}")
+
+    @pytest.mark.asyncio
+    async def test_premium_chat_agent(self):
+        """Test chat_agent via Anthropic client."""
+        if _active_profile_name != 'premium':
+            pytest.skip("MODEL_QOS is not premium")
+        model = get_model('chat_agent')
+        response = await anthropic_client.messages.create(
+            model=model,
+            max_tokens=50,
+            messages=[{"role": "user", "content": SIMPLE_PROMPT}],
+        )
+        text = response.content[0].text.strip()
+        assert text, f"FAIL chat_agent ({model}) returned empty"
+        print(f"  PASS chat_agent: {model} [anthropic] -> {text[:60]}")
+
+    def test_premium_web_search(self):
+        """Test web_search via Perplexity."""
+        if _active_profile_name != 'premium':
+            pytest.skip("MODEL_QOS is not premium")
+        model = get_model('web_search')
+        text = call_perplexity(model, "What is 2+2? Reply in one word.")
+        assert text.strip(), f"FAIL web_search ({model}) returned empty"
+        print(f"  PASS web_search: {model} [perplexity] -> {text.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# Premium profile — streaming variants
+# ---------------------------------------------------------------------------
+class TestPremiumStreaming:
+    """Test streaming works for key features in premium profile."""
+
+    STREAMING_FEATURES = ['chat_responses', 'wrapped_analysis']
+
+    @pytest.mark.parametrize("feature", STREAMING_FEATURES)
+    def test_premium_streaming(self, feature):
+        if _active_profile_name != 'premium':
+            pytest.skip("MODEL_QOS is not premium")
+        model = get_model(feature)
+        provider = get_provider(feature)
+        llm = get_llm(feature, streaming=True)
+        response = llm.invoke(SIMPLE_PROMPT)
+        text = response.content.strip() if hasattr(response, 'content') else str(response).strip()
+        assert text, f"FAIL streaming {feature} ({model}/{provider}) returned empty"
+        print(f"  PASS streaming {feature}: {model} [{provider}] -> {text[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# Cross-profile comparison — verify feature parity
+# ---------------------------------------------------------------------------
+class TestProfileFeatureParity:
+    """Verify all profiles have the same feature set."""
+
+    def test_same_features_as_max(self):
+        premium_features = set(MODEL_QOS_PROFILES['premium'].keys())
+        max_features = set(MODEL_QOS_PROFILES['max'].keys())
+        missing_in_max = premium_features - max_features
+        extra_in_max = max_features - premium_features
+        assert not missing_in_max, f"Features in premium but missing in max: {missing_in_max}"
+        assert not extra_in_max, f"Features in max but missing in premium: {extra_in_max}"
+
+    def test_same_features_as_byok(self):
+        premium_features = set(MODEL_QOS_PROFILES['premium'].keys())
+        byok_features = set(MODEL_QOS_PROFILES['byok'].keys())
+        missing_in_byok = premium_features - byok_features
+        extra_in_byok = byok_features - premium_features
+        assert not missing_in_byok, f"Features in premium but missing in byok: {missing_in_byok}"
+        assert not extra_in_byok, f"Features in byok but missing in premium: {extra_in_byok}"

--- a/backend/tests/integration/test_qos_live_cp9.py
+++ b/backend/tests/integration/test_qos_live_cp9.py
@@ -107,9 +107,9 @@ class TestP2_ModelProviderResolution:
             assert model == _active_profile[feature][0]
             assert provider == _active_profile[feature][1]
 
-    def test_four_profiles_exist(self):
-        assert len(MODEL_QOS_PROFILES) == 4
-        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'max', 'max_0424', 'byok'}
+    def test_three_profiles_exist(self):
+        assert len(MODEL_QOS_PROFILES) == 3
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'max', 'byok'}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_qos_live_cp9.py
+++ b/backend/tests/integration/test_qos_live_cp9.py
@@ -6,7 +6,7 @@ Tests every code path changed in the QoS profile refactor:
   P2: get_model()/get_provider() resolution across all 6 profiles
   P3: _create_byok_client() factory (mocked key, real client construction)
   P4: _effective_byok_provider() mapping
-  P5: BYOK profile auto-mapping (_BYOK_PROFILE_MAP)
+  P5: BYOK profile hardcoded to byok_high
   P6: Structured output compatibility on OpenAI (real .with_structured_output() call)
   P7: Prompt caching (cache_key binding for gpt-5.4-mini)
   P8: Streaming client construction and invocation
@@ -38,7 +38,6 @@ load_dotenv(os.path.join(os.path.dirname(__file__), '..', '..', '.env'))
 
 from utils.llm.clients import (
     MODEL_QOS_PROFILES,
-    _BYOK_PROFILE_MAP,
     _CACHE_KEY_MODELS,
     _GEMINI_OPENAI_BASE_URL,
     _STRUCTURED_OUTPUT_FEATURES,
@@ -171,26 +170,35 @@ class TestP4_EffectiveBYOKProvider:
 
 
 # ---------------------------------------------------------------------------
-# P5: BYOK profile auto-mapping
+# P5: BYOK profile hardcoded to byok_high
 # ---------------------------------------------------------------------------
-class TestP5_BYOKAutoMapping:
-    """P5: _BYOK_PROFILE_MAP auto-derives BYOK profile from active profile."""
+class TestP5_BYOKProfileFixed:
+    """P5: BYOK profile is always hardcoded to byok_high regardless of active profile."""
 
-    def test_all_profiles_mapped(self):
-        for name in MODEL_QOS_PROFILES:
-            assert name in _BYOK_PROFILE_MAP, f'{name} missing from _BYOK_PROFILE_MAP'
+    def test_byok_profile_is_byok_high(self):
+        assert _byok_profile_name == 'byok_high'
 
-    def test_premium_maps_to_byok_high(self):
-        assert _BYOK_PROFILE_MAP['premium'] == 'byok_high'
-        assert _BYOK_PROFILE_MAP['premium1'] == 'byok_high'
-
-    def test_max_maps_to_byok_max(self):
-        assert _BYOK_PROFILE_MAP['max'] == 'byok_max'
-        assert _BYOK_PROFILE_MAP['max1'] == 'byok_max'
-
-    def test_active_has_byok_mapping(self):
-        assert _byok_profile_name is not None
+    def test_byok_profile_exists(self):
         assert _byok_profile is not None
+        assert _byok_profile is MODEL_QOS_PROFILES['byok_high']
+
+    def test_byok_profile_independent_of_active(self):
+        """BYOK profile should always be byok_high regardless of MODEL_QOS setting."""
+        assert _byok_profile_name == 'byok_high'
+        assert _active_profile_name in MODEL_QOS_PROFILES
+        # Even if active is 'max', BYOK stays byok_high
+        assert _byok_profile_name != _active_profile_name or _active_profile_name == 'byok_high'
+
+    def test_byok_high_mostly_openai(self):
+        """byok_high profile should use OpenAI for most features (chat_agent/web_search are exceptions)."""
+        exceptions = {'chat_agent': 'anthropic', 'web_search': 'perplexity', 'wrapped_analysis': 'openrouter'}
+        for feature, (model, provider) in MODEL_QOS_PROFILES['byok_high'].items():
+            if feature in exceptions:
+                assert (
+                    provider == exceptions[feature]
+                ), f'byok_high {feature} expected {exceptions[feature]}, got {provider}'
+            else:
+                assert provider == 'openai', f'byok_high feature {feature} uses {provider}, expected openai'
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_qos_live_cp9.py
+++ b/backend/tests/integration/test_qos_live_cp9.py
@@ -13,7 +13,7 @@ Tests every code path changed in the QoS profile refactor:
   P9: OpenRouter vendor prefix and temperature config
   P10: Anthropic client via get_model() + anthropic_client
   P11: Perplexity via get_model() + HTTP client
-  P12: _get_or_create_gemini_llm() client factory (construction only, no GEMINI_API_KEY needed)
+  P12: _get_or_create_gemini_llm() client factory (native SDK, ChatGoogleGenerativeAI)
   P13: get_qos_info() debugging helper
 
 Requires: OPENAI_API_KEY, OPENROUTER_API_KEY, ANTHROPIC_API_KEY, PERPLEXITY_API_KEY in .env
@@ -39,7 +39,6 @@ load_dotenv(os.path.join(os.path.dirname(__file__), '..', '..', '.env'))
 from utils.llm.clients import (
     MODEL_QOS_PROFILES,
     _CACHE_KEY_MODELS,
-    _GEMINI_OPENAI_BASE_URL,
     _STRUCTURED_OUTPUT_FEATURES,
     _active_profile,
     _active_profile_name,
@@ -368,11 +367,13 @@ class TestP11_Perplexity:
 # P12: Gemini client factory (construction — no key needed for factory test)
 # ---------------------------------------------------------------------------
 class TestP12_GeminiFactory:
-    """P12: _get_or_create_gemini_llm constructs valid ChatOpenAI pointing to Gemini endpoint."""
+    """P12: _get_or_create_gemini_llm constructs valid ChatGoogleGenerativeAI using native SDK."""
 
-    def test_gemini_factory_base_url(self):
+    def test_gemini_factory_is_native_sdk(self):
+        from langchain_google_genai import ChatGoogleGenerativeAI
+
         llm = _get_or_create_gemini_llm('gemini-2.5-flash')
-        assert llm.openai_api_base == _GEMINI_OPENAI_BASE_URL
+        assert isinstance(llm, ChatGoogleGenerativeAI)
 
     def test_gemini_factory_cached(self):
         llm1 = _get_or_create_gemini_llm('gemini-2.5-flash')
@@ -386,7 +387,7 @@ class TestP12_GeminiFactory:
 
     @pytest.mark.skipif(not HAS_GEMINI_KEY, reason="GEMINI_API_KEY not set")
     def test_gemini_real_invocation(self):
-        """Real Gemini API call via OpenAI-compat endpoint."""
+        """Real Gemini API call via native SDK (not OpenAI-compat)."""
         llm = _get_or_create_gemini_llm('gemini-2.5-flash-lite')
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip()

--- a/backend/tests/integration/test_qos_live_cp9.py
+++ b/backend/tests/integration/test_qos_live_cp9.py
@@ -6,7 +6,7 @@ Tests every code path changed in the QoS profile refactor:
   P2: get_model()/get_provider() resolution across all 6 profiles
   P3: _create_byok_client() factory (mocked key, real client construction)
   P4: _effective_byok_provider() mapping
-  P5: BYOK profile hardcoded to byok_high
+  P5: BYOK profile hardcoded to byok
   P6: Structured output compatibility on OpenAI (real .with_structured_output() call)
   P7: Prompt caching (cache_key binding for gpt-5.4-mini)
   P8: Streaming client construction and invocation
@@ -108,9 +108,9 @@ class TestP2_ModelProviderResolution:
             assert model == _active_profile[feature][0]
             assert provider == _active_profile[feature][1]
 
-    def test_six_profiles_exist(self):
-        assert len(MODEL_QOS_PROFILES) == 6
-        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium1', 'max', 'max1', 'byok_high', 'byok_max'}
+    def test_five_profiles_exist(self):
+        assert len(MODEL_QOS_PROFILES) == 5
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium_0424', 'max', 'max_0424', 'byok'}
 
 
 # ---------------------------------------------------------------------------
@@ -170,35 +170,33 @@ class TestP4_EffectiveBYOKProvider:
 
 
 # ---------------------------------------------------------------------------
-# P5: BYOK profile hardcoded to byok_high
+# P5: BYOK profile hardcoded to byok
 # ---------------------------------------------------------------------------
 class TestP5_BYOKProfileFixed:
-    """P5: BYOK profile is always hardcoded to byok_high regardless of active profile."""
+    """P5: BYOK profile is always hardcoded to 'byok' regardless of active profile."""
 
-    def test_byok_profile_is_byok_high(self):
-        assert _byok_profile_name == 'byok_high'
+    def test_byok_profile_is_byok(self):
+        assert _byok_profile_name == 'byok'
 
     def test_byok_profile_exists(self):
         assert _byok_profile is not None
-        assert _byok_profile is MODEL_QOS_PROFILES['byok_high']
+        assert _byok_profile is MODEL_QOS_PROFILES['byok']
 
     def test_byok_profile_independent_of_active(self):
-        """BYOK profile should always be byok_high regardless of MODEL_QOS setting."""
-        assert _byok_profile_name == 'byok_high'
+        """BYOK profile should always be 'byok' regardless of MODEL_QOS setting."""
+        assert _byok_profile_name == 'byok'
         assert _active_profile_name in MODEL_QOS_PROFILES
-        # Even if active is 'max', BYOK stays byok_high
-        assert _byok_profile_name != _active_profile_name or _active_profile_name == 'byok_high'
+        # Even if active is 'max', BYOK stays 'byok'
+        assert _byok_profile_name != _active_profile_name or _active_profile_name == 'byok'
 
-    def test_byok_high_mostly_openai(self):
-        """byok_high profile should use OpenAI for most features (chat_agent/web_search are exceptions)."""
+    def test_byok_mostly_openai(self):
+        """byok profile should use OpenAI for most features (chat_agent/web_search are exceptions)."""
         exceptions = {'chat_agent': 'anthropic', 'web_search': 'perplexity', 'wrapped_analysis': 'openrouter'}
-        for feature, (model, provider) in MODEL_QOS_PROFILES['byok_high'].items():
+        for feature, (model, provider) in MODEL_QOS_PROFILES['byok'].items():
             if feature in exceptions:
-                assert (
-                    provider == exceptions[feature]
-                ), f'byok_high {feature} expected {exceptions[feature]}, got {provider}'
+                assert provider == exceptions[feature], f'byok {feature} expected {exceptions[feature]}, got {provider}'
             else:
-                assert provider == 'openai', f'byok_high feature {feature} uses {provider}, expected openai'
+                assert provider == 'openai', f'byok feature {feature} uses {provider}, expected openai'
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_qos_live_cp9.py
+++ b/backend/tests/integration/test_qos_live_cp9.py
@@ -107,9 +107,9 @@ class TestP2_ModelProviderResolution:
             assert model == _active_profile[feature][0]
             assert provider == _active_profile[feature][1]
 
-    def test_five_profiles_exist(self):
-        assert len(MODEL_QOS_PROFILES) == 5
-        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium_0424', 'max', 'max_0424', 'byok'}
+    def test_four_profiles_exist(self):
+        assert len(MODEL_QOS_PROFILES) == 4
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'max', 'max_0424', 'byok'}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_qos_live_cp9.py
+++ b/backend/tests/integration/test_qos_live_cp9.py
@@ -1,0 +1,407 @@
+"""
+CP9 Live Integration Test — Real LLM API calls covering ALL changed paths in PR #6942.
+
+Tests every code path changed in the QoS profile refactor:
+  P1: get_llm() routing for all features in premium profile
+  P2: get_model()/get_provider() resolution across all 6 profiles
+  P3: _create_byok_client() factory (mocked key, real client construction)
+  P4: _effective_byok_provider() mapping
+  P5: BYOK profile auto-mapping (_BYOK_PROFILE_MAP)
+  P6: Structured output compatibility on OpenAI (real .with_structured_output() call)
+  P7: Prompt caching (cache_key binding for gpt-5.4-mini)
+  P8: Streaming client construction and invocation
+  P9: OpenRouter vendor prefix and temperature config
+  P10: Anthropic client via get_model() + anthropic_client
+  P11: Perplexity via get_model() + HTTP client
+  P12: _get_or_create_gemini_llm() client factory (construction only, no GEMINI_API_KEY needed)
+  P13: get_qos_info() debugging helper
+
+Requires: OPENAI_API_KEY, OPENROUTER_API_KEY, ANTHROPIC_API_KEY, PERPLEXITY_API_KEY in .env
+Optional: GEMINI_API_KEY (skips Gemini live tests if missing)
+
+Run: cd backend && python3 -m pytest tests/integration/test_qos_live_cp9.py -v -s
+"""
+
+import os
+import sys
+
+import httpx
+import pytest
+from pydantic import BaseModel, Field
+
+# Add backend to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), '..', '..', '.env'))
+
+from utils.llm.clients import (
+    MODEL_QOS_PROFILES,
+    _BYOK_PROFILE_MAP,
+    _CACHE_KEY_MODELS,
+    _GEMINI_OPENAI_BASE_URL,
+    _STRUCTURED_OUTPUT_FEATURES,
+    _active_profile,
+    _active_profile_name,
+    _byok_profile,
+    _byok_profile_name,
+    _create_byok_client,
+    _effective_byok_provider,
+    _get_or_create_gemini_llm,
+    _get_or_create_openai_llm,
+    _get_or_create_openrouter_llm,
+    anthropic_client,
+    get_llm,
+    get_model,
+    get_provider,
+    get_qos_info,
+)
+
+SIMPLE_PROMPT = "Reply with exactly one word: hello"
+HAS_GEMINI_KEY = bool(os.environ.get('GEMINI_API_KEY', ''))
+
+
+# ---------------------------------------------------------------------------
+# P1: get_llm() routing — real invocations for every premium OpenAI feature
+# ---------------------------------------------------------------------------
+class TestP1_GetLlmRouting:
+    """P1: Every feature in premium profile that routes to OpenAI responds to real prompts."""
+
+    OPENAI_FEATURES = [f for f, (m, p) in MODEL_QOS_PROFILES['premium'].items() if p == 'openai']
+
+    @pytest.mark.parametrize("feature", OPENAI_FEATURES)
+    def test_openai_feature_responds(self, feature):
+        llm = get_llm(feature)
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip(), f"{feature} returned empty response"
+        print(f"  P1 {feature} ({get_model(feature)}): {response.content.strip()[:60]}")
+
+    @pytest.mark.skipif(not HAS_GEMINI_KEY, reason="GEMINI_API_KEY not set")
+    def test_gemini_features_respond(self):
+        """Gemini features in premium profile (flash-lite) respond to real prompts."""
+        gemini_features = [f for f, (m, p) in MODEL_QOS_PROFILES['premium'].items() if p == 'gemini']
+        for feature in gemini_features:
+            llm = get_llm(feature)
+            response = llm.invoke(SIMPLE_PROMPT)
+            assert response.content.strip(), f"{feature} returned empty"
+            print(f"  P1 gemini {feature} ({get_model(feature)}): {response.content.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# P2: get_model()/get_provider() resolution across all 6 profiles
+# ---------------------------------------------------------------------------
+class TestP2_ModelProviderResolution:
+    """P2: get_model/get_provider resolve correctly for all features in all profiles."""
+
+    def test_all_profiles_resolve(self):
+        for profile_name, profile in MODEL_QOS_PROFILES.items():
+            for feature, (expected_model, expected_provider) in profile.items():
+                # get_model/get_provider only check active profile, so verify data structure
+                assert isinstance(expected_model, str) and len(expected_model) > 0
+                assert expected_provider in {'openai', 'gemini', 'openrouter', 'anthropic', 'perplexity'}
+        print(f"  P2: All {len(MODEL_QOS_PROFILES)} profiles validated")
+
+    def test_active_profile_get_model(self):
+        for feature in _active_profile:
+            model = get_model(feature)
+            provider = get_provider(feature)
+            assert model == _active_profile[feature][0]
+            assert provider == _active_profile[feature][1]
+
+    def test_six_profiles_exist(self):
+        assert len(MODEL_QOS_PROFILES) == 6
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium1', 'max', 'max1', 'byok_high', 'byok_max'}
+
+
+# ---------------------------------------------------------------------------
+# P3: _create_byok_client() factory — constructs real ChatOpenAI with test key
+# ---------------------------------------------------------------------------
+class TestP3_CreateByokClient:
+    """P3: _create_byok_client creates valid ChatOpenAI instances."""
+
+    def test_openai_byok_client(self):
+        client = _create_byok_client('gpt-4.1-mini', 'openai', os.environ['OPENAI_API_KEY'])
+        assert client is not None
+        response = client.invoke(SIMPLE_PROMPT)
+        assert response.content.strip(), "BYOK OpenAI client returned empty"
+        print(f"  P3 BYOK openai: {response.content.strip()[:60]}")
+
+    def test_openrouter_gemini_byok_reroute(self):
+        """OpenRouter + gemini model → reroutes to Gemini direct (needs GEMINI_API_KEY)."""
+        if not HAS_GEMINI_KEY:
+            pytest.skip("GEMINI_API_KEY not set")
+        client = _create_byok_client(
+            'gemini-3-flash-preview', 'openrouter', os.environ['GEMINI_API_KEY'], feature='wrapped_analysis'
+        )
+        assert client is not None
+        response = client.invoke(SIMPLE_PROMPT)
+        assert response.content.strip()
+        print(f"  P3 BYOK openrouter→gemini: {response.content.strip()[:60]}")
+
+    def test_unsupported_provider_returns_none(self):
+        client = _create_byok_client('sonar-pro', 'perplexity', 'fake-key')
+        assert client is None
+
+    def test_streaming_byok_client(self):
+        client = _create_byok_client('gpt-4.1-mini', 'openai', os.environ['OPENAI_API_KEY'], streaming=True)
+        assert client is not None
+        response = client.invoke(SIMPLE_PROMPT)
+        assert response.content.strip()
+        print(f"  P3 BYOK streaming: {response.content.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# P4: _effective_byok_provider() mapping
+# ---------------------------------------------------------------------------
+class TestP4_EffectiveBYOKProvider:
+    """P4: Provider mapping for BYOK key type resolution."""
+
+    def test_openai(self):
+        assert _effective_byok_provider('gpt-4.1-mini', 'openai') == 'openai'
+
+    def test_gemini(self):
+        assert _effective_byok_provider('gemini-2.5-flash', 'gemini') == 'gemini'
+
+    def test_openrouter_gemini(self):
+        assert _effective_byok_provider('gemini-3-flash-preview', 'openrouter') == 'gemini'
+
+    def test_openrouter_non_gemini(self):
+        assert _effective_byok_provider('anthropic/claude', 'openrouter') == 'openrouter'
+
+
+# ---------------------------------------------------------------------------
+# P5: BYOK profile auto-mapping
+# ---------------------------------------------------------------------------
+class TestP5_BYOKAutoMapping:
+    """P5: _BYOK_PROFILE_MAP auto-derives BYOK profile from active profile."""
+
+    def test_all_profiles_mapped(self):
+        for name in MODEL_QOS_PROFILES:
+            assert name in _BYOK_PROFILE_MAP, f'{name} missing from _BYOK_PROFILE_MAP'
+
+    def test_premium_maps_to_byok_high(self):
+        assert _BYOK_PROFILE_MAP['premium'] == 'byok_high'
+        assert _BYOK_PROFILE_MAP['premium1'] == 'byok_high'
+
+    def test_max_maps_to_byok_max(self):
+        assert _BYOK_PROFILE_MAP['max'] == 'byok_max'
+        assert _BYOK_PROFILE_MAP['max1'] == 'byok_max'
+
+    def test_active_has_byok_mapping(self):
+        assert _byok_profile_name is not None
+        assert _byok_profile is not None
+
+
+# ---------------------------------------------------------------------------
+# P6: Structured output compatibility — real .with_structured_output() call
+# ---------------------------------------------------------------------------
+class TestP6_StructuredOutput:
+    """P6: .with_structured_output() works with real API call on OpenAI features."""
+
+    class SimpleOutput(BaseModel):
+        word: str = Field(description="A single word greeting")
+
+    def test_structured_output_chat_extraction(self):
+        """chat_extraction (OpenAI in premium) works with with_structured_output."""
+        llm = get_llm('chat_extraction')
+        structured = llm.with_structured_output(self.SimpleOutput)
+        result = structured.invoke("Reply with a JSON object containing a single word: hello")
+        assert isinstance(result, self.SimpleOutput)
+        assert len(result.word) > 0
+        print(f"  P6 structured chat_extraction: {result.word}")
+
+    def test_structured_output_proactive_notification(self):
+        llm = get_llm('proactive_notification')
+        structured = llm.with_structured_output(self.SimpleOutput)
+        result = structured.invoke("Reply with a JSON object containing a single word: hello")
+        assert isinstance(result, self.SimpleOutput)
+        print(f"  P6 structured proactive_notification: {result.word}")
+
+    def test_structured_output_conv_app_select(self):
+        llm = get_llm('conv_app_select')
+        structured = llm.with_structured_output(self.SimpleOutput)
+        result = structured.invoke("Reply with a JSON object containing a single word: hello")
+        assert isinstance(result, self.SimpleOutput)
+        print(f"  P6 structured conv_app_select: {result.word}")
+
+    def test_structured_output_external_structure(self):
+        llm = get_llm('external_structure')
+        structured = llm.with_structured_output(self.SimpleOutput)
+        result = structured.invoke("Reply with a JSON object containing a single word: hello")
+        assert isinstance(result, self.SimpleOutput)
+        print(f"  P6 structured external_structure: {result.word}")
+
+    @pytest.mark.skipif(not HAS_GEMINI_KEY, reason="GEMINI_API_KEY not set — trends is on Gemini in premium")
+    def test_structured_output_trends_gemini(self):
+        """trends is on gemini-2.5-flash-lite in premium — test SO on Gemini."""
+        llm = get_llm('trends')
+        structured = llm.with_structured_output(self.SimpleOutput)
+        result = structured.invoke("Reply with a JSON object containing a single word: hello")
+        assert isinstance(result, self.SimpleOutput)
+        print(f"  P6 structured trends (gemini): {result.word}")
+
+    def test_structured_output_features_set(self):
+        assert _STRUCTURED_OUTPUT_FEATURES == {
+            'chat_extraction',
+            'proactive_notification',
+            'conv_app_select',
+            'external_structure',
+            'trends',
+        }
+
+
+# ---------------------------------------------------------------------------
+# P7: Prompt caching — cache_key binding
+# ---------------------------------------------------------------------------
+class TestP7_PromptCaching:
+    """P7: cache_key binding works and produces valid responses."""
+
+    def test_cache_key_with_cacheable_model(self):
+        """conv_structure uses gpt-5.4-mini (in _CACHE_KEY_MODELS) — cache_key should bind."""
+        llm = get_llm('conv_structure', cache_key='omi-test-cp9')
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip()
+        print(f"  P7 cache_key bound: {response.content.strip()[:60]}")
+
+    def test_cache_key_ignored_for_non_cacheable(self):
+        """memories uses gpt-4.1-mini (not in _CACHE_KEY_MODELS) — cache_key is no-op."""
+        llm_with = get_llm('memories', cache_key='omi-test-cp9')
+        llm_without = get_llm('memories')
+        assert llm_with is llm_without  # same instance, cache_key was a no-op
+
+    def test_cache_key_models_set(self):
+        assert _CACHE_KEY_MODELS == {'gpt-5.4', 'gpt-5.4-mini'}
+
+
+# ---------------------------------------------------------------------------
+# P8: Streaming client invocation
+# ---------------------------------------------------------------------------
+class TestP8_Streaming:
+    """P8: Streaming clients respond to real prompts."""
+
+    def test_streaming_openai(self):
+        llm = get_llm('chat_responses', streaming=True)
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip()
+        print(f"  P8 streaming openai: {response.content.strip()[:60]}")
+
+    def test_streaming_openrouter(self):
+        llm = get_llm('wrapped_analysis', streaming=True)
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip()
+        print(f"  P8 streaming openrouter: {response.content.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# P9: OpenRouter vendor prefix and temperature
+# ---------------------------------------------------------------------------
+class TestP9_OpenRouterConfig:
+    """P9: OpenRouter adds google/ prefix and applies temperature config."""
+
+    def test_wrapped_analysis_responds(self):
+        llm = get_llm('wrapped_analysis')
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip()
+        print(f"  P9 openrouter: {response.content.strip()[:60]}")
+
+    def test_vendor_prefix(self):
+        llm = get_llm('wrapped_analysis')
+        assert llm.model_name.startswith('google/'), f"Expected google/ prefix, got {llm.model_name}"
+
+    def test_temperature_applied(self):
+        llm = get_llm('wrapped_analysis')
+        assert llm.temperature == 0.7
+
+
+# ---------------------------------------------------------------------------
+# P10: Anthropic via get_model() + anthropic_client
+# ---------------------------------------------------------------------------
+class TestP10_Anthropic:
+    """P10: chat_agent via Anthropic client with real API call."""
+
+    @pytest.mark.asyncio
+    async def test_chat_agent(self):
+        model = get_model('chat_agent')
+        assert 'claude' in model
+        response = await anthropic_client.messages.create(
+            model=model, max_tokens=50, messages=[{"role": "user", "content": SIMPLE_PROMPT}]
+        )
+        text = response.content[0].text.strip()
+        assert text, "Anthropic returned empty"
+        print(f"  P10 anthropic {model}: {text[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# P11: Perplexity via get_model() + HTTP client
+# ---------------------------------------------------------------------------
+class TestP11_Perplexity:
+    """P11: web_search via Perplexity HTTP with real API call."""
+
+    def test_web_search(self):
+        model = get_model('web_search')
+        assert model == 'sonar-pro'
+        url = "https://api.perplexity.ai/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {os.environ['PERPLEXITY_API_KEY']}",
+            "Content-Type": "application/json",
+        }
+        body = {
+            "model": model,
+            "messages": [{"role": "user", "content": "What is 2+2? Reply in one word."}],
+            "max_tokens": 50,
+        }
+        resp = httpx.post(url, json=body, headers=headers, timeout=30)
+        resp.raise_for_status()
+        text = resp.json()["choices"][0]["message"]["content"].strip()
+        assert text
+        print(f"  P11 perplexity {model}: {text[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# P12: Gemini client factory (construction — no key needed for factory test)
+# ---------------------------------------------------------------------------
+class TestP12_GeminiFactory:
+    """P12: _get_or_create_gemini_llm constructs valid ChatOpenAI pointing to Gemini endpoint."""
+
+    def test_gemini_factory_base_url(self):
+        llm = _get_or_create_gemini_llm('gemini-2.5-flash')
+        assert llm.openai_api_base == _GEMINI_OPENAI_BASE_URL
+
+    def test_gemini_factory_cached(self):
+        llm1 = _get_or_create_gemini_llm('gemini-2.5-flash')
+        llm2 = _get_or_create_gemini_llm('gemini-2.5-flash')
+        assert llm1 is llm2
+
+    def test_gemini_streaming_factory(self):
+        llm = _get_or_create_gemini_llm('gemini-2.5-flash', streaming=True)
+        llm_no_stream = _get_or_create_gemini_llm('gemini-2.5-flash')
+        assert llm is not llm_no_stream
+
+    @pytest.mark.skipif(not HAS_GEMINI_KEY, reason="GEMINI_API_KEY not set")
+    def test_gemini_real_invocation(self):
+        """Real Gemini API call via OpenAI-compat endpoint."""
+        llm = _get_or_create_gemini_llm('gemini-2.5-flash-lite')
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip()
+        print(f"  P12 gemini real: {response.content.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# P13: get_qos_info() debugging helper
+# ---------------------------------------------------------------------------
+class TestP13_QosInfo:
+    """P13: get_qos_info returns complete, correct data."""
+
+    def test_all_features_present(self):
+        info = get_qos_info()
+        for feature in _active_profile:
+            assert feature in info
+            assert info[feature]['model'] == _active_profile[feature][0]
+            assert info[feature]['provider'] == _active_profile[feature][1]
+            assert info[feature]['profile'] == _active_profile_name
+
+    def test_pinned_features_included(self):
+        info = get_qos_info()
+        assert 'fair_use' in info
+        assert info['fair_use']['model'] == 'gpt-5.1'

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -254,6 +254,14 @@ class TestProfileRouting:
         distinct = {model for model, _provider in MODEL_QOS_PROFILES['max'].values()}
         assert len(distinct) == 9, f"Expected 9 variants in max, got {len(distinct)}: {distinct}"
 
+    def test_premium1_profile_has_expected_variant_count(self):
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['premium1'].values()}
+        assert len(distinct) == 6, f"Expected 6 variants in premium1, got {len(distinct)}: {distinct}"
+
+    def test_max1_profile_has_expected_variant_count(self):
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['max1'].values()}
+        assert len(distinct) == 7, f"Expected 7 variants in max1, got {len(distinct)}: {distinct}"
+
 
 # ---------------------------------------------------------------------------
 # Streaming support — verify streaming clients work

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -262,6 +262,14 @@ class TestProfileRouting:
         distinct = {model for model, _provider in MODEL_QOS_PROFILES['max1'].values()}
         assert len(distinct) == 7, f"Expected 7 variants in max1, got {len(distinct)}: {distinct}"
 
+    def test_byok_high_profile_has_expected_variant_count(self):
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['byok_high'].values()}
+        assert len(distinct) == 6, f"Expected 6 variants in byok_high, got {len(distinct)}: {distinct}"
+
+    def test_byok_max_profile_has_expected_variant_count(self):
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['byok_max'].values()}
+        assert len(distinct) == 7, f"Expected 7 variants in byok_max, got {len(distinct)}: {distinct}"
+
 
 # ---------------------------------------------------------------------------
 # Streaming support — verify streaming clients work

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -124,14 +124,7 @@ class TestPremiumNano:
         'conv_app_select',
         'conv_folder',
         'conv_discard',
-        'daily_summary_simple',
-        'memory_category',
-        'session_titles',
-        'followup',
         'smart_glasses',
-        'onboarding',
-        'app_integration',
-        'trends',
         'persona_chat',
     ]
 
@@ -139,6 +132,47 @@ class TestPremiumNano:
     def test_nano_feature_responds(self, feature):
         model = get_model(feature)
         assert model == 'gpt-4.1-nano', f"{feature} should be gpt-4.1-nano in premium, got {model}"
+        llm = get_llm(feature)
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip(), f"{feature} ({model}) returned empty response"
+        print(f"  {feature} ({model}): {response.content.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# Premium profile — gpt-4.1-mini features (vision/openglass)
+# ---------------------------------------------------------------------------
+class TestPremiumVision:
+    """Test gpt-4.1-mini vision-capable features in premium profile."""
+
+    def test_openglass_feature_responds(self):
+        model = get_model('openglass')
+        assert model == 'gpt-4.1-mini', f"openglass should be gpt-4.1-mini, got {model}"
+        llm = get_llm('openglass')
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip(), f"openglass ({model}) returned empty response"
+        print(f"  openglass ({model}): {response.content.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# Premium profile — gemini-2.5-flash-lite features (free-text cost optimization)
+# ---------------------------------------------------------------------------
+class TestPremiumGemini:
+    """Test gemini-2.5-flash-lite features in premium profile respond to real prompts."""
+
+    GEMINI_FEATURES = [
+        'daily_summary_simple',
+        'memory_category',
+        'session_titles',
+        'followup',
+        'onboarding',
+        'app_integration',
+        'trends',
+    ]
+
+    @pytest.mark.parametrize("feature", GEMINI_FEATURES)
+    def test_gemini_feature_responds(self, feature):
+        model = get_model(feature)
+        assert model == 'gemini-2.5-flash-lite', f"{feature} should be gemini-2.5-flash-lite in premium, got {model}"
         llm = get_llm(feature)
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), f"{feature} ({model}) returned empty response"
@@ -204,7 +238,7 @@ class TestProfileRouting:
 
     def test_all_features_have_valid_provider(self):
         info = get_qos_info()
-        valid_providers = {'openai', 'anthropic', 'openrouter', 'perplexity'}
+        valid_providers = {'openai', 'anthropic', 'openrouter', 'perplexity', 'gemini'}
         for feature, details in info.items():
             assert details['provider'] in valid_providers, f"{feature}: invalid provider {details['provider']}"
             print(f"  {feature}: {details['model']} ({details['provider']})")
@@ -214,7 +248,7 @@ class TestProfileRouting:
 
     def test_premium_profile_has_expected_variant_count(self):
         distinct = set(MODEL_QOS_PROFILES['premium'].values())
-        assert len(distinct) == 6, f"Expected 6 variants in premium, got {len(distinct)}: {distinct}"
+        assert len(distinct) == 7, f"Expected 7 variants in premium, got {len(distinct)}: {distinct}"
 
     def test_max_profile_has_expected_variant_count(self):
         distinct = set(MODEL_QOS_PROFILES['max'].values())

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -256,10 +256,6 @@ class TestProfileRouting:
         distinct = {model for model, _provider in MODEL_QOS_PROFILES['max'].values()}
         assert len(distinct) == 9, f"Expected 9 variants in max, got {len(distinct)}: {distinct}"
 
-    def test_premium_0424_profile_has_expected_variant_count(self):
-        distinct = {model for model, _provider in MODEL_QOS_PROFILES['premium_0424'].values()}
-        assert len(distinct) == 6, f"Expected 6 variants in premium_0424, got {len(distinct)}: {distinct}"
-
     def test_max_0424_profile_has_expected_variant_count(self):
         distinct = {model for model, _provider in MODEL_QOS_PROFILES['max_0424'].values()}
         assert len(distinct) == 7, f"Expected 7 variants in max_0424, got {len(distinct)}: {distinct}"

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -30,7 +30,6 @@ from utils.llm.clients import (
     get_llm,
     get_provider,
     get_qos_info,
-    _classify_provider,
     _active_profile_name,
     anthropic_client,
     ANTHROPIC_AGENT_MODEL,

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -256,21 +256,17 @@ class TestProfileRouting:
         distinct = {model for model, _provider in MODEL_QOS_PROFILES['max'].values()}
         assert len(distinct) == 9, f"Expected 9 variants in max, got {len(distinct)}: {distinct}"
 
-    def test_premium1_profile_has_expected_variant_count(self):
-        distinct = {model for model, _provider in MODEL_QOS_PROFILES['premium1'].values()}
-        assert len(distinct) == 6, f"Expected 6 variants in premium1, got {len(distinct)}: {distinct}"
+    def test_premium_0424_profile_has_expected_variant_count(self):
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['premium_0424'].values()}
+        assert len(distinct) == 6, f"Expected 6 variants in premium_0424, got {len(distinct)}: {distinct}"
 
-    def test_max1_profile_has_expected_variant_count(self):
-        distinct = {model for model, _provider in MODEL_QOS_PROFILES['max1'].values()}
-        assert len(distinct) == 7, f"Expected 7 variants in max1, got {len(distinct)}: {distinct}"
+    def test_max_0424_profile_has_expected_variant_count(self):
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['max_0424'].values()}
+        assert len(distinct) == 7, f"Expected 7 variants in max_0424, got {len(distinct)}: {distinct}"
 
-    def test_byok_high_profile_has_expected_variant_count(self):
-        distinct = {model for model, _provider in MODEL_QOS_PROFILES['byok_high'].values()}
-        assert len(distinct) == 6, f"Expected 6 variants in byok_high, got {len(distinct)}: {distinct}"
-
-    def test_byok_max_profile_has_expected_variant_count(self):
-        distinct = {model for model, _provider in MODEL_QOS_PROFILES['byok_max'].values()}
-        assert len(distinct) == 7, f"Expected 7 variants in byok_max, got {len(distinct)}: {distinct}"
+    def test_byok_profile_has_expected_variant_count(self):
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['byok'].values()}
+        assert len(distinct) == 7, f"Expected 7 variants in byok, got {len(distinct)}: {distinct}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -28,6 +28,7 @@ from utils.llm.clients import (
     MODEL_QOS_PROFILES,
     get_model,
     get_llm,
+    get_provider,
     get_qos_info,
     _classify_provider,
     _active_profile_name,
@@ -187,7 +188,7 @@ class TestPremiumOpenRouter:
 
     def test_wrapped_analysis(self):
         model = get_model('wrapped_analysis')
-        assert model == 'google/gemini-3-flash-preview'
+        assert model == 'gemini-3-flash-preview'
         llm = get_llm('wrapped_analysis')
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), f"wrapped_analysis ({model}) returned empty response"
@@ -247,11 +248,11 @@ class TestProfileRouting:
         assert _active_profile_name == 'premium'
 
     def test_premium_profile_has_expected_variant_count(self):
-        distinct = set(MODEL_QOS_PROFILES['premium'].values())
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['premium'].values()}
         assert len(distinct) == 7, f"Expected 7 variants in premium, got {len(distinct)}: {distinct}"
 
     def test_max_profile_has_expected_variant_count(self):
-        distinct = set(MODEL_QOS_PROFILES['max'].values())
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['max'].values()}
         assert len(distinct) == 9, f"Expected 9 variants in max, got {len(distinct)}: {distinct}"
 
 

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -256,10 +256,6 @@ class TestProfileRouting:
         distinct = {model for model, _provider in MODEL_QOS_PROFILES['max'].values()}
         assert len(distinct) == 9, f"Expected 9 variants in max, got {len(distinct)}: {distinct}"
 
-    def test_max_0424_profile_has_expected_variant_count(self):
-        distinct = {model for model, _provider in MODEL_QOS_PROFILES['max_0424'].values()}
-        assert len(distinct) == 7, f"Expected 7 variants in max_0424, got {len(distinct)}: {distinct}"
-
     def test_byok_profile_has_expected_variant_count(self):
         distinct = {model for model, _provider in MODEL_QOS_PROFILES['byok'].values()}
         assert len(distinct) == 7, f"Expected 7 variants in byok, got {len(distinct)}: {distinct}"

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -36,6 +36,7 @@ from utils.llm.clients import (
 )
 
 SIMPLE_PROMPT = "Reply with exactly one word: hello"
+HAS_GEMINI_KEY = bool(os.environ.get('GEMINI_API_KEY', ''))
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +170,7 @@ class TestPremiumGemini:
         'trends',
     ]
 
+    @pytest.mark.skipif(not HAS_GEMINI_KEY, reason="GEMINI_API_KEY not set")
     @pytest.mark.parametrize("feature", GEMINI_FEATURES)
     def test_gemini_feature_responds(self, feature):
         model = get_model(feature)

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -127,6 +127,8 @@ class TestPremiumNano:
         'conv_discard',
         'smart_glasses',
         'persona_chat',
+        'daily_summary_simple',
+        'memory_category',
     ]
 
     @pytest.mark.parametrize("feature", NANO_FEATURES)
@@ -161,8 +163,6 @@ class TestPremiumGemini:
     """Test gemini-2.5-flash-lite features in premium profile respond to real prompts."""
 
     GEMINI_FEATURES = [
-        'daily_summary_simple',
-        'memory_category',
         'session_titles',
         'followup',
         'onboarding',

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -7,7 +7,7 @@ a non-empty response.
 
 Default profile is premium. Set MODEL_QOS=max to test max profile.
 
-Requires: OPENAI_API_KEY, OPENROUTER_API_KEY, ANTHROPIC_API_KEY, PERPLEXITY_API_KEY in .env.
+Requires: OPENAI_API_KEY, OPENROUTER_API_KEY, ANTHROPIC_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY in .env.
 Run: cd backend && python3 -m pytest tests/integration/test_qos_real_llm.py -v -s
 """
 

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -258,7 +258,7 @@ class TestProfileRouting:
 
     def test_byok_profile_has_expected_variant_count(self):
         distinct = {model for model, _provider in MODEL_QOS_PROFILES['byok'].values()}
-        assert len(distinct) == 7, f"Expected 7 variants in byok, got {len(distinct)}: {distinct}"
+        assert len(distinct) == 9, f"Expected 9 variants in byok, got {len(distinct)}: {distinct}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -33,6 +33,8 @@ sys.modules.setdefault('utils.other.storage', MagicMock())
 
 import warnings
 
+from langchain_openai import ChatOpenAI
+
 warnings.filterwarnings('ignore', message='.*stream_options.*')
 
 
@@ -592,65 +594,37 @@ class TestCacheRouting:
         inst2 = _cached_anthropic(api_key)
         assert inst1 is inst2
 
-    def test_gemini_wrapper_routes_to_byok(self):
-        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL, _wrap_byok
+    def test_gemini_byok_routes_to_gemini_endpoint(self):
+        from utils.llm.clients import _create_byok_client, _GEMINI_OPENAI_BASE_URL
 
-        mock_default = MagicMock()
-        wrapper = _wrap_byok(mock_default, 'gemini-2.5-flash-lite', 'gemini', {})
-        assert isinstance(wrapper, _BYOKChatWrapper)
-        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
-            resolved = wrapper._resolve()
-        assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
+        client = _create_byok_client('gemini-2.5-flash-lite', 'gemini', 'AIza-byok-key')
+        assert isinstance(client, ChatOpenAI)
+        assert client.openai_api_base == _GEMINI_OPENAI_BASE_URL
 
-    def test_gemini_wrapper_falls_back_to_default(self):
-        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
+    def test_openai_byok_creates_client(self):
+        from utils.llm.clients import _create_byok_client
 
-        mock_default = MagicMock()
-        wrapper = _wrap_byok(mock_default, 'gemini-2.5-flash-lite', 'gemini', {})
-        assert isinstance(wrapper, _BYOKChatWrapper)
-        with patch('utils.llm.clients.get_byok_key', return_value=None):
-            resolved = wrapper._resolve()
-        assert resolved is mock_default
+        client = _create_byok_client('gpt-4.1-mini', 'openai', 'sk-byok-test-key')
+        assert isinstance(client, ChatOpenAI)
+        assert client.model_name == 'gpt-4.1-mini'
 
-    def test_openrouter_wrapper_byok_routes_to_gemini_direct(self):
-        """OpenRouter BYOK wraps to Gemini direct — must not forward OpenRouter api_key."""
-        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL, _wrap_byok
+    def test_openrouter_gemini_byok_routes_to_gemini_direct(self):
+        """OpenRouter BYOK for Gemini models reroutes to Gemini direct endpoint."""
+        from utils.llm.clients import _create_byok_client, _GEMINI_OPENAI_BASE_URL
 
-        mock_default = MagicMock()
-        or_kwargs = {
-            'api_key': 'sk-or-openrouter-key',
-            'base_url': 'https://openrouter.ai/api/v1',
-            'callbacks': [],
-        }
-        wrapper = _wrap_byok(mock_default, 'google/gemini-3-flash-preview', 'openrouter', or_kwargs)
-        assert isinstance(wrapper, _BYOKChatWrapper)
-        assert wrapper._provider == 'gemini'  # OpenRouter BYOK resolves via Gemini
-
-        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
-            resolved = wrapper._resolve()
+        client = _create_byok_client('gemini-3-flash-preview', 'openrouter', 'AIza-byok-key')
+        assert isinstance(client, ChatOpenAI)
         # Must use Gemini base URL, not OpenRouter
-        assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
-        # Must not contain the OpenRouter api_key
-        assert resolved.openai_api_key != 'sk-or-openrouter-key'
+        assert client.openai_api_base == _GEMINI_OPENAI_BASE_URL
+        # Must use the bare model name for Gemini direct API
+        assert client.model_name == 'gemini-3-flash-preview'
 
-    def test_openrouter_wrapper_strips_vendor_prefix(self):
-        """OpenRouter BYOK must strip google/ prefix for Gemini direct API."""
-        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
+    def test_non_gemini_openrouter_returns_none(self):
+        """Non-Gemini OpenRouter models have no BYOK support — returns None."""
+        from utils.llm.clients import _create_byok_client
 
-        mock_default = MagicMock()
-        wrapper = _wrap_byok(mock_default, 'google/gemini-3-flash-preview', 'openrouter', {'api_key': 'sk-or-key'})
-        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
-            resolved = wrapper._resolve()
-        assert resolved.model_name == 'gemini-3-flash-preview'
-
-    def test_non_gemini_openrouter_returns_default_directly(self):
-        """Non-Gemini OpenRouter models have no BYOK support — returns default client unchanged."""
-        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
-
-        mock_default = MagicMock()
-        result = _wrap_byok(mock_default, 'anthropic/claude-3.5-sonnet', 'openrouter', {'api_key': 'sk-or-key'})
-        assert result is mock_default  # No wrapper, returns default directly
-        assert not isinstance(result, _BYOKChatWrapper)
+        result = _create_byok_client('anthropic/claude-3.5-sonnet', 'openrouter', 'sk-or-key')
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -592,20 +592,20 @@ class TestCacheRouting:
         inst2 = _cached_anthropic(api_key)
         assert inst1 is inst2
 
-    def test_anthropic_proxy_routes_to_byok(self):
-        from utils.llm.clients import _AnthropicViaOpenAIProxy, _ANTHROPIC_OPENAI_BASE_URL
+    def test_gemini_proxy_routes_to_byok(self):
+        from utils.llm.clients import _GeminiChatProxy, _GEMINI_OPENAI_BASE_URL
 
         mock_default = MagicMock()
-        proxy = _AnthropicViaOpenAIProxy(default=mock_default, ctor_kwargs={})
-        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'sk-ant-byok' if p == 'anthropic' else None):
+        proxy = _GeminiChatProxy(model='gemini-2.5-flash-lite', default=mock_default, ctor_kwargs={})
+        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
             resolved = proxy._resolve()
-        assert resolved.openai_api_base == _ANTHROPIC_OPENAI_BASE_URL
+        assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
 
-    def test_anthropic_proxy_falls_back_to_default(self):
-        from utils.llm.clients import _AnthropicViaOpenAIProxy
+    def test_gemini_proxy_falls_back_to_default(self):
+        from utils.llm.clients import _GeminiChatProxy
 
         mock_default = MagicMock()
-        proxy = _AnthropicViaOpenAIProxy(default=mock_default, ctor_kwargs={})
+        proxy = _GeminiChatProxy(model='gemini-2.5-flash-lite', default=mock_default, ctor_kwargs={})
         with patch('utils.llm.clients.get_byok_key', return_value=None):
             resolved = proxy._resolve()
         assert resolved is mock_default

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -612,6 +612,37 @@ class TestCacheRouting:
             resolved = wrapper._resolve()
         assert resolved is mock_default
 
+    def test_openrouter_wrapper_byok_routes_to_gemini_direct(self):
+        """OpenRouter BYOK wraps to Gemini direct — must not forward OpenRouter api_key."""
+        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL, _wrap_byok
+
+        mock_default = MagicMock()
+        or_kwargs = {
+            'api_key': 'sk-or-openrouter-key',
+            'base_url': 'https://openrouter.ai/api/v1',
+            'callbacks': [],
+        }
+        wrapper = _wrap_byok(mock_default, 'google/gemini-3-flash-preview', 'openrouter', or_kwargs)
+        assert isinstance(wrapper, _BYOKChatWrapper)
+        assert wrapper._provider == 'gemini'  # OpenRouter BYOK resolves via Gemini
+
+        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
+            resolved = wrapper._resolve()
+        # Must use Gemini base URL, not OpenRouter
+        assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
+        # Must not contain the OpenRouter api_key
+        assert resolved.openai_api_key != 'sk-or-openrouter-key'
+
+    def test_openrouter_wrapper_strips_vendor_prefix(self):
+        """OpenRouter BYOK must strip google/ prefix for Gemini direct API."""
+        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
+
+        mock_default = MagicMock()
+        wrapper = _wrap_byok(mock_default, 'google/gemini-3-flash-preview', 'openrouter', {'api_key': 'sk-or-key'})
+        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
+            resolved = wrapper._resolve()
+        assert resolved.model_name == 'gemini-3-flash-preview'
+
 
 # ---------------------------------------------------------------------------
 # 12. Middleware dispatch: context isolation between requests

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -592,22 +592,24 @@ class TestCacheRouting:
         inst2 = _cached_anthropic(api_key)
         assert inst1 is inst2
 
-    def test_gemini_proxy_routes_to_byok(self):
-        from utils.llm.clients import _GeminiChatProxy, _GEMINI_OPENAI_BASE_URL
+    def test_gemini_wrapper_routes_to_byok(self):
+        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL, _wrap_byok
 
         mock_default = MagicMock()
-        proxy = _GeminiChatProxy(model='gemini-2.5-flash-lite', default=mock_default, ctor_kwargs={})
+        wrapper = _wrap_byok(mock_default, 'gemini-2.5-flash-lite', 'gemini', {})
+        assert isinstance(wrapper, _BYOKChatWrapper)
         with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
-            resolved = proxy._resolve()
+            resolved = wrapper._resolve()
         assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
 
-    def test_gemini_proxy_falls_back_to_default(self):
-        from utils.llm.clients import _GeminiChatProxy
+    def test_gemini_wrapper_falls_back_to_default(self):
+        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
 
         mock_default = MagicMock()
-        proxy = _GeminiChatProxy(model='gemini-2.5-flash-lite', default=mock_default, ctor_kwargs={})
+        wrapper = _wrap_byok(mock_default, 'gemini-2.5-flash-lite', 'gemini', {})
+        assert isinstance(wrapper, _BYOKChatWrapper)
         with patch('utils.llm.clients.get_byok_key', return_value=None):
-            resolved = proxy._resolve()
+            resolved = wrapper._resolve()
         assert resolved is mock_default
 
 

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -643,6 +643,15 @@ class TestCacheRouting:
             resolved = wrapper._resolve()
         assert resolved.model_name == 'gemini-3-flash-preview'
 
+    def test_non_gemini_openrouter_wrapper_stays_on_openrouter(self):
+        """Non-Gemini OpenRouter models must NOT reroute to Gemini direct."""
+        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
+
+        mock_default = MagicMock()
+        wrapper = _wrap_byok(mock_default, 'anthropic/claude-3.5-sonnet', 'openrouter', {'api_key': 'sk-or-key'})
+        assert isinstance(wrapper, _BYOKChatWrapper)
+        assert wrapper._provider == 'openrouter'  # NOT 'gemini'
+
 
 # ---------------------------------------------------------------------------
 # 12. Middleware dispatch: context isolation between requests

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -643,14 +643,14 @@ class TestCacheRouting:
             resolved = wrapper._resolve()
         assert resolved.model_name == 'gemini-3-flash-preview'
 
-    def test_non_gemini_openrouter_wrapper_stays_on_openrouter(self):
-        """Non-Gemini OpenRouter models must NOT reroute to Gemini direct."""
+    def test_non_gemini_openrouter_returns_default_directly(self):
+        """Non-Gemini OpenRouter models have no BYOK support — returns default client unchanged."""
         from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
 
         mock_default = MagicMock()
-        wrapper = _wrap_byok(mock_default, 'anthropic/claude-3.5-sonnet', 'openrouter', {'api_key': 'sk-or-key'})
-        assert isinstance(wrapper, _BYOKChatWrapper)
-        assert wrapper._provider == 'openrouter'  # NOT 'gemini'
+        result = _wrap_byok(mock_default, 'anthropic/claude-3.5-sonnet', 'openrouter', {'api_key': 'sk-or-key'})
+        assert result is mock_default  # No wrapper, returns default directly
+        assert not isinstance(result, _BYOKChatWrapper)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -817,67 +817,9 @@ class TestBYOKWrapperArchitecture:
 class TestBYOKProfile:
     """Verify BYOK QoS profile structure and model selections."""
 
-    def test_byok_all_openai_except_special(self):
-        """byok routes all features to OpenAI except chat_agent/web_search/wrapped_analysis."""
-        bk = MODEL_QOS_PROFILES['byok']
-        for feature, (model, provider) in bk.items():
-            if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
-                continue
-            assert provider == 'openai', f'byok {feature} should be openai, got {provider}'
-
-    def test_byok_uses_gpt54_flagship(self):
-        """byok uses gpt-5.4 for flagship features."""
-        bk = MODEL_QOS_PROFILES['byok']
-        for feature in [
-            'conv_action_items',
-            'conv_structure',
-            'conv_app_result',
-            'daily_summary',
-            'chat_responses',
-            'goals_advice',
-            'app_generator',
-            'persona_clone',
-            'persona_chat_premium',
-            'notifications',
-            'chat_graph',
-        ]:
-            assert bk[feature][0] == 'gpt-5.4', f'byok {feature} should be gpt-5.4, got {bk[feature][0]}'
-
-    def test_byok_uses_gpt54_mini_quality(self):
-        """byok upgrades quality tier to gpt-5.4-mini."""
-        bk = MODEL_QOS_PROFILES['byok']
-        for feature in [
-            'external_structure',
-            'memories',
-            'memory_conflict',
-            'knowledge_graph',
-            'chat_extraction',
-            'goals',
-            'proactive_notification',
-            'openglass',
-            'smart_glasses',
-        ]:
-            assert bk[feature][0] == 'gpt-5.4-mini', f'byok {feature} should be gpt-5.4-mini, got {bk[feature][0]}'
-
-    def test_byok_keeps_o4_mini_for_learnings(self):
-        """byok keeps o4-mini for learnings (reasoning model)."""
-        bk = MODEL_QOS_PROFILES['byok']
-        assert bk['learnings'] == ('o4-mini', 'openai')
-
-    def test_byok_model_variants(self):
-        """byok uses expected distinct model IDs."""
-        bk = MODEL_QOS_PROFILES['byok']
-        distinct = {model for model, _p in bk.values()}
-        expected = {
-            'gpt-5.4',
-            'gpt-5.4-mini',
-            'gpt-4.1-mini',
-            'o4-mini',
-            'claude-sonnet-4-6',
-            'gemini-3-flash-preview',
-            'sonar-pro',
-        }
-        assert distinct == expected
+    def test_byok_is_exact_copy_of_max(self):
+        """byok must be an exact copy of max (BYOK users pay their own costs)."""
+        assert MODEL_QOS_PROFILES['byok'] == MODEL_QOS_PROFILES['max']
 
     def test_byok_has_same_features_as_premium(self):
         """BYOK profile must cover the same feature set as premium."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -796,13 +796,18 @@ class TestRuntimeProviderRouting:
         base_url = getattr(llm, 'openai_api_base', None) or ''
         assert 'openrouter' not in base_url
 
-    def test_gemini_feature_routes_to_gemini_endpoint(self):
-        """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL
-
+    def test_gemini_feature_routes_correctly(self):
+        """Free-text features on gemini-2.5-flash-lite should route to Gemini (native SDK or fallback)."""
         llm = get_llm('followup')
-        # get_llm() eagerly resolves BYOK; result is a ChatOpenAI routed to Gemini
-        assert llm.openai_api_base == _GEMINI_OPENAI_BASE_URL, 'followup must use Gemini base URL'
+        if os.environ.get('GEMINI_API_KEY'):
+            from langchain_google_genai import ChatGoogleGenerativeAI
+
+            assert isinstance(
+                llm, ChatGoogleGenerativeAI
+            ), f'followup should be ChatGoogleGenerativeAI, got {type(llm)}'
+        else:
+            # No key — falls back to ChatOpenAI placeholder pointing at Gemini endpoint
+            assert hasattr(llm, 'invoke')
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""
@@ -831,19 +836,20 @@ class TestRuntimeProviderRouting:
 class TestBYOKWrapperArchitecture:
     """Verify get_llm() eagerly resolves BYOK and returns proper ChatOpenAI instances."""
 
-    def test_get_llm_returns_chat_openai(self):
-        """get_llm() must eagerly resolve BYOK and return a ChatOpenAI (Runnable), not a wrapper."""
+    def test_get_llm_returns_base_chat_model(self):
+        """get_llm() must eagerly resolve BYOK and return a BaseChatModel (Runnable), not a wrapper."""
+        from langchain_core.language_models import BaseChatModel
         from langchain_openai import ChatOpenAI
 
-        # OpenAI feature
+        # OpenAI feature — always ChatOpenAI
         llm_openai = get_llm('conv_structure')
-        assert isinstance(llm_openai, ChatOpenAI), 'get_llm must return ChatOpenAI, not wrapper'
+        assert isinstance(llm_openai, ChatOpenAI), 'OpenAI get_llm must return ChatOpenAI'
 
-        # Gemini feature (uses OpenAI-compat endpoint)
+        # Gemini feature — ChatGoogleGenerativeAI (with key) or ChatOpenAI fallback (no key)
         llm_gemini = get_llm('followup')
-        assert isinstance(llm_gemini, ChatOpenAI), 'Gemini get_llm must return ChatOpenAI'
+        assert isinstance(llm_gemini, BaseChatModel), 'Gemini get_llm must return BaseChatModel'
 
-        # OpenRouter feature
+        # OpenRouter feature — always ChatOpenAI
         llm_or = get_llm('wrapped_analysis')
         assert isinstance(llm_or, ChatOpenAI), 'OpenRouter get_llm must return ChatOpenAI'
 

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -572,10 +572,16 @@ class TestRollbackScenario:
         assert get_provider('persona_chat') == 'anthropic'
 
     def test_invalid_provider_in_override_falls_back(self, monkeypatch):
-        """Explicit override with invalid provider falls back to profile provider."""
+        """Explicit override with invalid provider falls back to inferred provider."""
         monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus_provider')
         assert get_model('conv_action_items') == 'gpt-5.1'
-        assert get_provider('conv_action_items') == 'openai'  # profile provider
+        assert get_provider('conv_action_items') == 'openai'  # inferred from model name
+
+    def test_mismatched_model_provider_uses_inferred(self, monkeypatch):
+        """Explicit override with mismatched model/provider uses inferred provider."""
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gpt-5.1:anthropic')
+        assert get_model('persona_chat') == 'gpt-5.1'
+        assert get_provider('persona_chat') == 'openai'  # inferred, not explicit anthropic
 
     def test_model_only_override_infers_provider(self, monkeypatch):
         """Model-only override infers provider from model name."""
@@ -849,6 +855,17 @@ class TestOverrideWarningLog:
             'invalid provider' in r.message for r in caplog.records
         ), "No warning expected for model-only override"
 
+    def test_warns_on_mismatched_model_provider(self, monkeypatch, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
+            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:anthropic')
+            result = get_model('conv_action_items')
+            assert result == 'gpt-5.1'
+        assert any(
+            'does not match model' in r.message for r in caplog.records
+        ), "Expected model/provider mismatch warning"
+
 
 class TestRuntimeProviderRouting:
     """Verify get_llm() routes to correct client factory based on resolved model."""
@@ -876,23 +893,28 @@ class TestRuntimeProviderRouting:
         assert llm._provider == 'openai'
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
-        """If an override sets an OpenRouter model:provider, get_llm should route via OpenRouter."""
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gemini-flash-1.5-8b:openrouter')
+        """If an override sets an OpenRouter model (vendor/model format), get_llm should route via OpenRouter."""
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b:openrouter')
         llm = get_llm('persona_chat')
-        # The wrapper's default client should be OpenRouter-configured
-        base_url = getattr(llm._default, 'openai_api_base', None) or ''
+        # OpenRouter Gemini models get BYOK-wrapped with Gemini direct fallback
+        base_url = (
+            getattr(llm, 'openai_api_base', None)
+            or getattr(getattr(llm, '_default', None), 'openai_api_base', None)
+            or ''
+        )
         assert 'openrouter' in base_url
 
     def test_openrouter_temperature_applied_via_get_llm(self, monkeypatch):
         """When get_llm routes to OpenRouter, _OPENROUTER_TEMPERATURES config is applied."""
         from utils.llm.clients import _OPENROUTER_TEMPERATURES
 
-        # Override persona_chat to an OpenRouter model to test temperature routing
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gemini-flash-1.5-8b:openrouter')
+        # Override persona_chat to an OpenRouter model (vendor/model format)
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b:openrouter')
         llm = get_llm('persona_chat')
         expected_temp = _OPENROUTER_TEMPERATURES.get('persona_chat')
         assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
-        assert llm._default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+        default = getattr(llm, '_default', llm)
+        assert default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
 
 
 class TestBYOKWrapperArchitecture:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -878,21 +878,19 @@ class TestRuntimeProviderRouting:
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
         """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL
+        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL
 
         llm = get_llm('followup')
-        assert isinstance(llm, _BYOKChatWrapper), 'followup should be wrapped with _BYOKChatWrapper'
-        assert llm._provider == 'gemini', 'followup wrapper should have gemini provider'
-        # Default client must use Gemini base URL
-        assert llm._default.openai_api_base == _GEMINI_OPENAI_BASE_URL, 'followup default must use Gemini base URL'
+        # get_llm() eagerly resolves BYOK; result is a ChatOpenAI routed to Gemini
+        assert llm.openai_api_base == _GEMINI_OPENAI_BASE_URL, 'followup must use Gemini base URL'
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""
-        from utils.llm.clients import _BYOKChatWrapper
-
         llm = get_llm('openglass')
-        assert isinstance(llm, _BYOKChatWrapper)
-        assert llm._provider == 'openai'
+        # get_llm() eagerly resolves; result is a ChatOpenAI routed to OpenAI
+        base_url = getattr(llm, 'openai_api_base', None) or ''
+        assert 'openrouter' not in base_url
+        assert 'generativelanguage.googleapis.com' not in base_url
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
         """If an override sets an OpenRouter model (vendor/model format), get_llm should route via OpenRouter."""
@@ -933,26 +931,23 @@ class TestRuntimeProviderRouting:
 
 
 class TestBYOKWrapperArchitecture:
-    """Verify BYOK wrapper is used consistently across providers."""
+    """Verify get_llm() eagerly resolves BYOK and returns proper ChatOpenAI instances."""
 
-    def test_all_providers_use_byok_wrapper(self):
-        from utils.llm.clients import _BYOKChatWrapper
+    def test_get_llm_returns_chat_openai(self):
+        """get_llm() must eagerly resolve BYOK and return a ChatOpenAI (Runnable), not a wrapper."""
+        from langchain_openai import ChatOpenAI
 
         # OpenAI feature
         llm_openai = get_llm('conv_structure')
-        assert isinstance(llm_openai, _BYOKChatWrapper)
-        assert llm_openai._provider == 'openai'
+        assert isinstance(llm_openai, ChatOpenAI), 'get_llm must return ChatOpenAI, not wrapper'
 
-        # Gemini feature
+        # Gemini feature (uses OpenAI-compat endpoint)
         llm_gemini = get_llm('followup')
-        assert isinstance(llm_gemini, _BYOKChatWrapper)
-        assert llm_gemini._provider == 'gemini'
+        assert isinstance(llm_gemini, ChatOpenAI), 'Gemini get_llm must return ChatOpenAI'
 
         # OpenRouter feature
         llm_or = get_llm('wrapped_analysis')
-        assert isinstance(llm_or, _BYOKChatWrapper)
-        # OpenRouter Gemini models use 'gemini' as BYOK provider (routes to Google direct)
-        assert llm_or._provider == 'gemini'
+        assert isinstance(llm_or, ChatOpenAI), 'OpenRouter get_llm must return ChatOpenAI'
 
     def test_no_legacy_llm_medium_or_llm_large(self):
         """Dead legacy instances must not exist in clients module."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -58,8 +58,8 @@ from utils.llm.clients import (
 class TestModelQosProfiles:
     """Verify profile structure and completeness."""
 
-    def test_four_profiles_exist(self):
-        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'max', 'max_0424', 'byok'}
+    def test_three_profiles_exist(self):
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'max', 'byok'}
 
     def test_all_profiles_have_same_features(self):
         feature_sets = {name: set(profile.keys()) for name, profile in MODEL_QOS_PROFILES.items()}
@@ -81,10 +81,9 @@ class TestModelQosProfiles:
         for name in ('premium', 'max', 'byok'):
             providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
             assert 'openai' in providers, f'{name} missing OpenAI models'
-        # Gemini-optimized profiles must have Gemini provider
-        for name in ('premium', 'max_0424'):
-            providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
-            assert 'gemini' in providers, f'{name} should have Gemini direct models'
+        # Premium profile must have Gemini provider
+        providers = {p for _m, p in MODEL_QOS_PROFILES['premium'].values()}
+        assert 'gemini' in providers, 'premium should have Gemini direct models'
 
     def test_premium_profile_models(self):
         """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gemini for free-text."""
@@ -164,33 +163,6 @@ class TestModelQosProfiles:
             'sonar-pro',
         }
         assert distinct_models == expected
-
-    def test_max_0424_keeps_o4_mini_for_learnings(self):
-        """max_0424 keeps o4-mini for learnings (reasoning model, no Gemini equivalent)."""
-        m1 = MODEL_QOS_PROFILES['max_0424']
-        assert m1['learnings'] == ('o4-mini', 'openai')
-
-    def test_max_0424_model_variants(self):
-        """max_0424 uses 7 distinct model IDs."""
-        m1 = MODEL_QOS_PROFILES['max_0424']
-        distinct = {model for model, _p in m1.values()}
-        expected = {
-            'gemini-2.5-pro',
-            'gemini-2.5-flash',
-            'gemini-2.5-flash-lite',
-            'o4-mini',
-            'claude-sonnet-4-6',
-            'gemini-3-flash-preview',
-            'sonar-pro',
-        }
-        assert distinct == expected
-
-    def test_max_0424_uses_flash_not_flashlite_for_quality(self):
-        """max_0424 uses gemini-2.5-flash (not lite) for quality-sensitive features."""
-        m1 = MODEL_QOS_PROFILES['max_0424']
-        assert m1['memories'] == ('gemini-2.5-flash', 'gemini')
-        assert m1['daily_summary_simple'] == ('gemini-2.5-flash', 'gemini')
-        assert m1['memory_category'] == ('gemini-2.5-flash', 'gemini')
 
     def test_new_features_present(self):
         """Verify newly added features exist in both profiles."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -36,7 +36,6 @@ from utils.llm.clients import (
     _PINNED_FEATURES,
     _active_profile,
     _active_profile_name,
-    _classify_provider,
     _get_or_create_gemini_llm,
     _get_or_create_openai_llm,
     _get_or_create_openrouter_llm,
@@ -181,26 +180,10 @@ class TestGetModel:
     def test_returns_profile_default(self):
         assert get_model('conv_action_items') == MODEL_QOS_PROFILES[_active_profile_name]['conv_action_items'][0]
 
-    def test_env_override_takes_precedence(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1')
-        assert get_model('conv_action_items') == 'gpt-5.1'
-
-    def test_env_override_with_anthropic_model(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CHAT_AGENT', 'claude-haiku-3.5')
-        assert get_model('chat_agent') == 'claude-haiku-3.5'
-
-    def test_empty_env_override_falls_back_to_profile(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', '')
-        assert get_model('conv_action_items') == _active_profile['conv_action_items'][0]
-
     def test_unknown_feature_falls_back_to_gpt41_mini(self):
         assert get_model('totally_unknown_feature') == 'gpt-4.1-mini'
 
     def test_pinned_feature_ignores_profile(self):
-        assert get_model('fair_use') == 'gpt-5.1'
-
-    def test_pinned_feature_ignores_env_override(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_FAIR_USE', 'gpt-4.1-nano')
         assert get_model('fair_use') == 'gpt-5.1'
 
     def test_anthropic_feature_returns_model_string(self):
@@ -257,17 +240,10 @@ class TestGetLlm:
         assert llm_with_key is not llm_without_key
         assert hasattr(llm_with_key, 'invoke')
 
-    def test_cache_key_ignored_for_non_cacheable_model(self, monkeypatch):
-        # Override to a model not in _CACHE_KEY_MODELS
-        monkeypatch.setenv('MODEL_QOS_MEMORIES', 'gpt-4.1-nano')
+    def test_cache_key_ignored_for_non_cacheable_model(self):
+        # memories uses gpt-4.1-mini which is not in _CACHE_KEY_MODELS
         llm_with_key = get_llm('memories', cache_key='omi-test-key')
         llm_without_key = get_llm('memories')
-        assert llm_with_key is llm_without_key
-
-    def test_cache_key_ignored_after_override_to_non_cacheable(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_STRUCTURE', 'gpt-4.1-mini')
-        llm_with_key = get_llm('conv_structure', cache_key='omi-test-key')
-        llm_without_key = get_llm('conv_structure')
         assert llm_with_key is llm_without_key
 
     def test_new_features_return_clients(self):
@@ -448,11 +424,6 @@ class TestGetQosInfo:
         assert get_provider('wrapped_analysis') == 'openrouter'
         assert get_provider('followup') == 'gemini'
 
-    def test_reflects_env_override(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'o4-mini')
-        info = get_qos_info()
-        assert info['conv_action_items']['model'] == 'o4-mini'
-
 
 class TestPinnedFeatures:
     """Verify pinned features are immutable."""
@@ -466,30 +437,7 @@ class TestPinnedFeatures:
 
 
 class TestProviderClassification:
-    """Verify provider detection from model name and feature routing."""
-
-    def test_classify_provider_openai(self):
-        assert _classify_provider('gpt-5.4') == 'openai'
-        assert _classify_provider('gpt-5.4-mini') == 'openai'
-        assert _classify_provider('gpt-4.1-nano') == 'openai'
-        assert _classify_provider('o4-mini') == 'openai'
-
-    def test_classify_provider_anthropic(self):
-        assert _classify_provider('claude-sonnet-4-6') == 'anthropic'
-        assert _classify_provider('claude-haiku-3.5') == 'anthropic'
-
-    def test_classify_provider_openrouter(self):
-        assert _classify_provider('google/gemini-flash-1.5-8b') == 'openrouter'
-        assert _classify_provider('anthropic/claude-3.5-sonnet') == 'openrouter'
-
-    def test_classify_provider_gemini(self):
-        assert _classify_provider('gemini-2.5-flash-lite') == 'gemini'
-        assert _classify_provider('gemini-2.5-pro') == 'gemini'
-        assert _classify_provider('gemini-2.5-flash') == 'gemini'
-
-    def test_classify_provider_perplexity(self):
-        assert _classify_provider('sonar-pro') == 'perplexity'
-        assert _classify_provider('sonar') == 'perplexity'
+    """Verify provider routing from profile entries."""
 
     def test_chat_agent_is_anthropic_only(self):
         assert 'chat_agent' in _ANTHROPIC_ONLY_FEATURES
@@ -527,18 +475,6 @@ class TestProviderSafetyGuard:
         with pytest.raises(ValueError, match='Perplexity'):
             get_llm('web_search')
 
-    def test_get_llm_rejects_claude_model_override(self, monkeypatch):
-        """Env override to a claude model is rejected — can't serve via ChatOpenAI."""
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'claude-haiku-3.5')
-        with pytest.raises(ValueError, match='Anthropic'):
-            get_llm('conv_action_items')
-
-    def test_get_llm_rejects_sonar_model_override(self, monkeypatch):
-        """Env override to a sonar model is rejected — can't serve via ChatOpenAI."""
-        monkeypatch.setenv('MODEL_QOS_CONV_STRUCTURE', 'sonar-pro')
-        with pytest.raises(ValueError, match='Perplexity'):
-            get_llm('conv_structure')
-
 
 class TestAnthropicModelExports:
     """Verify ANTHROPIC_AGENT_MODEL is backed by profile."""
@@ -553,41 +489,6 @@ class TestAnthropicModelExports:
 
         assert isinstance(ANTHROPIC_AGENT_MODEL, str)
         assert len(ANTHROPIC_AGENT_MODEL) > 0
-
-
-class TestRollbackScenario:
-    """Verify model can be switched via env var for rollback."""
-
-    def test_override_conv_action_items_to_gpt51(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1')
-        assert get_model('conv_action_items') == 'gpt-5.1'
-
-    def test_override_chat_agent_to_haiku(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CHAT_AGENT', 'claude-haiku-3.5')
-        assert get_model('chat_agent') == 'claude-haiku-3.5'
-
-    def test_override_persona_to_different_model(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'claude-3.5-sonnet:anthropic')
-        assert get_model('persona_chat') == 'claude-3.5-sonnet'
-        assert get_provider('persona_chat') == 'anthropic'
-
-    def test_invalid_provider_in_override_falls_back(self, monkeypatch):
-        """Explicit override with invalid provider falls back to inferred provider."""
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus_provider')
-        assert get_model('conv_action_items') == 'gpt-5.1'
-        assert get_provider('conv_action_items') == 'openai'  # inferred from model name
-
-    def test_mismatched_model_provider_uses_inferred(self, monkeypatch):
-        """Explicit override with mismatched model/provider uses inferred provider."""
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gpt-5.1:anthropic')
-        assert get_model('persona_chat') == 'gpt-5.1'
-        assert get_provider('persona_chat') == 'openai'  # inferred, not explicit anthropic
-
-    def test_model_only_override_infers_provider(self, monkeypatch):
-        """Model-only override infers provider from model name."""
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gemini-2.5-flash')
-        assert get_model('conv_action_items') == 'gemini-2.5-flash'
-        assert get_provider('conv_action_items') == 'gemini'  # inferred from model name
 
 
 class TestProfileSelectionAtImportTime:
@@ -821,52 +722,6 @@ class TestExpandedCallsiteCoverage:
             assert 'llm_high.invoke' not in source, f"{path} still uses llm_high.invoke"
 
 
-class TestOverrideWarningLog:
-    """Verify override warnings fire for invalid explicit provider."""
-
-    def test_warns_on_invalid_explicit_provider(self, monkeypatch, caplog):
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus')
-            result = get_model('conv_action_items')
-            assert result == 'gpt-5.1'
-        assert any('invalid provider' in r.message for r in caplog.records), "Expected invalid provider warning"
-
-    def test_no_warning_on_valid_explicit_provider(self, monkeypatch, caplog):
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini:openai')
-            result = get_model('conv_action_items')
-            assert result == 'gpt-4.1-mini'
-        assert not any(
-            'invalid provider' in r.message for r in caplog.records
-        ), "No warning expected for valid explicit provider"
-
-    def test_no_warning_on_model_only_override(self, monkeypatch, caplog):
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini')
-            result = get_model('conv_action_items')
-            assert result == 'gpt-4.1-mini'
-        assert not any(
-            'invalid provider' in r.message for r in caplog.records
-        ), "No warning expected for model-only override"
-
-    def test_warns_on_mismatched_model_provider(self, monkeypatch, caplog):
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:anthropic')
-            result = get_model('conv_action_items')
-            assert result == 'gpt-5.1'
-        assert any(
-            'does not match model' in r.message for r in caplog.records
-        ), "Expected model/provider mismatch warning"
-
-
 class TestRuntimeProviderRouting:
     """Verify get_llm() routes to correct client factory based on resolved model."""
 
@@ -892,42 +747,20 @@ class TestRuntimeProviderRouting:
         assert 'openrouter' not in base_url
         assert 'generativelanguage.googleapis.com' not in base_url
 
-    def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
-        """If an override sets an OpenRouter model (vendor/model format), get_llm should route via OpenRouter."""
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b:openrouter')
-        llm = get_llm('persona_chat')
-        # OpenRouter Gemini models get BYOK-wrapped with Gemini direct fallback
-        base_url = (
-            getattr(llm, 'openai_api_base', None)
-            or getattr(getattr(llm, '_default', None), 'openai_api_base', None)
-            or ''
-        )
-        assert 'openrouter' in base_url
-
-    def test_openrouter_temperature_applied_via_get_llm(self, monkeypatch):
+    def test_openrouter_temperature_applied_via_get_llm(self):
         """When get_llm routes to OpenRouter, _OPENROUTER_TEMPERATURES config is applied."""
         from utils.llm.clients import _OPENROUTER_TEMPERATURES
 
-        # Override persona_chat to an OpenRouter model (vendor/model format)
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b:openrouter')
-        llm = get_llm('persona_chat')
-        expected_temp = _OPENROUTER_TEMPERATURES.get('persona_chat')
-        assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
-        default = getattr(llm, '_default', llm)
-        assert default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+        llm = get_llm('wrapped_analysis')
+        expected_temp = _OPENROUTER_TEMPERATURES.get('wrapped_analysis')
+        assert expected_temp == 0.7, "wrapped_analysis should have temp 0.7 in config"
+        assert llm.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
 
     def test_openrouter_adds_vendor_prefix_for_gemini_models(self):
         """Profile stores bare model name; OpenRouter factory must add google/ prefix for API calls."""
         llm = get_llm('wrapped_analysis')
         default = getattr(llm, '_default', llm)
         assert default.model_name.startswith('google/'), f"Expected google/ prefix, got {default.model_name}"
-
-    def test_empty_provider_suffix_in_override(self, monkeypatch):
-        """MODEL_QOS_X=model: (empty provider after colon) should use inferred provider."""
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini:')
-        assert get_model('conv_action_items') == 'gpt-4.1-mini'
-        # Empty string is not in _VALID_PROVIDERS, so falls back to inferred
-        assert get_provider('conv_action_items') == 'openai'
 
 
 class TestBYOKWrapperArchitecture:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -54,13 +54,14 @@ from utils.llm.clients import (
 class TestModelQosProfiles:
     """Verify profile structure and completeness."""
 
-    def test_two_profiles_exist(self):
-        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'max'}
+    def test_four_profiles_exist(self):
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium1', 'max', 'max1'}
 
     def test_all_profiles_have_same_features(self):
-        premium_features = set(MODEL_QOS_PROFILES['premium'].keys())
-        max_features = set(MODEL_QOS_PROFILES['max'].keys())
-        assert premium_features == max_features
+        feature_sets = {name: set(profile.keys()) for name, profile in MODEL_QOS_PROFILES.items()}
+        reference = feature_sets['premium']
+        for name, features in feature_sets.items():
+            assert features == reference, f'{name} features differ from premium: {features ^ reference}'
 
     def test_premium_profile_is_default(self):
         assert _active_profile_name == 'premium'
@@ -69,16 +70,17 @@ class TestModelQosProfiles:
         """Each profile should have features across expected providers."""
         for profile_name, profile in MODEL_QOS_PROFILES.items():
             providers = {provider for _model, provider in profile.values()}
-            assert 'openai' in providers, f'{profile_name} missing OpenAI models'
             assert 'anthropic' in providers, f'{profile_name} missing Anthropic models'
             assert 'perplexity' in providers, f'{profile_name} missing Perplexity models'
-        # Both profiles keep OpenRouter for wrapped_analysis
-        for profile_name in MODEL_QOS_PROFILES:
-            providers = {provider for _m, provider in MODEL_QOS_PROFILES[profile_name].values()}
             assert 'openrouter' in providers, f'{profile_name} should have OpenRouter (wrapped_analysis)'
-        # Premium profile uses Gemini direct for free-text features
-        premium_providers = {provider for _m, provider in MODEL_QOS_PROFILES['premium'].values()}
-        assert 'gemini' in premium_providers, 'premium should have Gemini direct models'
+        # OpenAI-based profiles must have OpenAI provider
+        for name in ('premium', 'max'):
+            providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
+            assert 'openai' in providers, f'{name} missing OpenAI models'
+        # Gemini-optimized profiles must have Gemini provider
+        for name in ('premium', 'premium1', 'max1'):
+            providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
+            assert 'gemini' in providers, f'{name} should have Gemini direct models'
 
     def test_premium_profile_models(self):
         """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gemini for free-text."""
@@ -157,6 +159,65 @@ class TestModelQosProfiles:
             'sonar-pro',
         }
         assert distinct_models == expected
+
+    def test_premium1_all_gemini_except_special(self):
+        """premium1 should route everything to Gemini except chat_agent/web_search/wrapped_analysis."""
+        p1 = MODEL_QOS_PROFILES['premium1']
+        for feature, (model, provider) in p1.items():
+            if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
+                continue
+            assert provider == 'gemini', f'premium1 {feature} should be gemini, got {provider}'
+
+    def test_premium1_model_tiers(self):
+        """premium1 uses 3 Gemini tiers: pro (flagship), flash (quality), flash-lite (simple)."""
+        p1 = MODEL_QOS_PROFILES['premium1']
+        assert p1['conv_action_items'] == ('gemini-2.5-pro', 'gemini')
+        assert p1['chat_responses'] == ('gemini-2.5-pro', 'gemini')
+        assert p1['memories'] == ('gemini-2.5-flash', 'gemini')
+        assert p1['chat_extraction'] == ('gemini-2.5-flash', 'gemini')
+        assert p1['conv_folder'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert p1['session_titles'] == ('gemini-2.5-flash-lite', 'gemini')
+
+    def test_premium1_model_variants(self):
+        """premium1 uses 6 distinct model IDs."""
+        p1 = MODEL_QOS_PROFILES['premium1']
+        distinct = {model for model, _p in p1.values()}
+        expected = {
+            'gemini-2.5-pro',
+            'gemini-2.5-flash',
+            'gemini-2.5-flash-lite',
+            'claude-sonnet-4-6',
+            'gemini-3-flash-preview',
+            'sonar-pro',
+        }
+        assert distinct == expected
+
+    def test_max1_keeps_o4_mini_for_learnings(self):
+        """max1 keeps o4-mini for learnings (reasoning model, no Gemini equivalent)."""
+        m1 = MODEL_QOS_PROFILES['max1']
+        assert m1['learnings'] == ('o4-mini', 'openai')
+
+    def test_max1_model_variants(self):
+        """max1 uses 7 distinct model IDs."""
+        m1 = MODEL_QOS_PROFILES['max1']
+        distinct = {model for model, _p in m1.values()}
+        expected = {
+            'gemini-2.5-pro',
+            'gemini-2.5-flash',
+            'gemini-2.5-flash-lite',
+            'o4-mini',
+            'claude-sonnet-4-6',
+            'gemini-3-flash-preview',
+            'sonar-pro',
+        }
+        assert distinct == expected
+
+    def test_max1_uses_flash_not_flashlite_for_quality(self):
+        """max1 uses gemini-2.5-flash (not lite) for quality-sensitive features."""
+        m1 = MODEL_QOS_PROFILES['max1']
+        assert m1['memories'] == ('gemini-2.5-flash', 'gemini')
+        assert m1['daily_summary_simple'] == ('gemini-2.5-flash', 'gemini')
+        assert m1['memory_category'] == ('gemini-2.5-flash', 'gemini')
 
     def test_new_features_present(self):
         """Verify newly added features exist in both profiles."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -58,8 +58,8 @@ from utils.llm.clients import (
 class TestModelQosProfiles:
     """Verify profile structure and completeness."""
 
-    def test_six_profiles_exist(self):
-        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium1', 'max', 'max1', 'byok_high', 'byok_max'}
+    def test_five_profiles_exist(self):
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium_0424', 'max', 'max_0424', 'byok'}
 
     def test_all_profiles_have_same_features(self):
         feature_sets = {name: set(profile.keys()) for name, profile in MODEL_QOS_PROFILES.items()}
@@ -78,11 +78,11 @@ class TestModelQosProfiles:
             assert 'perplexity' in providers, f'{profile_name} missing Perplexity models'
             assert 'openrouter' in providers, f'{profile_name} should have OpenRouter (wrapped_analysis)'
         # OpenAI-based profiles must have OpenAI provider
-        for name in ('premium', 'max', 'byok_high', 'byok_max'):
+        for name in ('premium', 'max', 'byok'):
             providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
             assert 'openai' in providers, f'{name} missing OpenAI models'
         # Gemini-optimized profiles must have Gemini provider
-        for name in ('premium', 'premium1', 'max1'):
+        for name in ('premium', 'premium_0424', 'max_0424'):
             providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
             assert 'gemini' in providers, f'{name} should have Gemini direct models'
 
@@ -164,17 +164,17 @@ class TestModelQosProfiles:
         }
         assert distinct_models == expected
 
-    def test_premium1_all_gemini_except_special(self):
-        """premium1 should route everything to Gemini except chat_agent/web_search/wrapped_analysis."""
-        p1 = MODEL_QOS_PROFILES['premium1']
+    def test_premium_0424_all_gemini_except_special(self):
+        """premium_0424 should route everything to Gemini except chat_agent/web_search/wrapped_analysis."""
+        p1 = MODEL_QOS_PROFILES['premium_0424']
         for feature, (model, provider) in p1.items():
             if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
                 continue
-            assert provider == 'gemini', f'premium1 {feature} should be gemini, got {provider}'
+            assert provider == 'gemini', f'premium_0424 {feature} should be gemini, got {provider}'
 
-    def test_premium1_model_tiers(self):
-        """premium1 uses 3 Gemini tiers: pro (flagship), flash (quality), flash-lite (simple)."""
-        p1 = MODEL_QOS_PROFILES['premium1']
+    def test_premium_0424_model_tiers(self):
+        """premium_0424 uses 3 Gemini tiers: pro (flagship), flash (quality), flash-lite (simple)."""
+        p1 = MODEL_QOS_PROFILES['premium_0424']
         assert p1['conv_action_items'] == ('gemini-2.5-pro', 'gemini')
         assert p1['chat_responses'] == ('gemini-2.5-pro', 'gemini')
         assert p1['memories'] == ('gemini-2.5-flash', 'gemini')
@@ -182,9 +182,9 @@ class TestModelQosProfiles:
         assert p1['conv_folder'] == ('gemini-2.5-flash-lite', 'gemini')
         assert p1['session_titles'] == ('gemini-2.5-flash-lite', 'gemini')
 
-    def test_premium1_model_variants(self):
-        """premium1 uses 6 distinct model IDs."""
-        p1 = MODEL_QOS_PROFILES['premium1']
+    def test_premium_0424_model_variants(self):
+        """premium_0424 uses 6 distinct model IDs."""
+        p1 = MODEL_QOS_PROFILES['premium_0424']
         distinct = {model for model, _p in p1.values()}
         expected = {
             'gemini-2.5-pro',
@@ -196,14 +196,14 @@ class TestModelQosProfiles:
         }
         assert distinct == expected
 
-    def test_max1_keeps_o4_mini_for_learnings(self):
-        """max1 keeps o4-mini for learnings (reasoning model, no Gemini equivalent)."""
-        m1 = MODEL_QOS_PROFILES['max1']
+    def test_max_0424_keeps_o4_mini_for_learnings(self):
+        """max_0424 keeps o4-mini for learnings (reasoning model, no Gemini equivalent)."""
+        m1 = MODEL_QOS_PROFILES['max_0424']
         assert m1['learnings'] == ('o4-mini', 'openai')
 
-    def test_max1_model_variants(self):
-        """max1 uses 7 distinct model IDs."""
-        m1 = MODEL_QOS_PROFILES['max1']
+    def test_max_0424_model_variants(self):
+        """max_0424 uses 7 distinct model IDs."""
+        m1 = MODEL_QOS_PROFILES['max_0424']
         distinct = {model for model, _p in m1.values()}
         expected = {
             'gemini-2.5-pro',
@@ -216,9 +216,9 @@ class TestModelQosProfiles:
         }
         assert distinct == expected
 
-    def test_max1_uses_flash_not_flashlite_for_quality(self):
-        """max1 uses gemini-2.5-flash (not lite) for quality-sensitive features."""
-        m1 = MODEL_QOS_PROFILES['max1']
+    def test_max_0424_uses_flash_not_flashlite_for_quality(self):
+        """max_0424 uses gemini-2.5-flash (not lite) for quality-sensitive features."""
+        m1 = MODEL_QOS_PROFILES['max_0424']
         assert m1['memories'] == ('gemini-2.5-flash', 'gemini')
         assert m1['daily_summary_simple'] == ('gemini-2.5-flash', 'gemini')
         assert m1['memory_category'] == ('gemini-2.5-flash', 'gemini')
@@ -867,50 +867,20 @@ class TestBYOKWrapperArchitecture:
             assert not hasattr(mod, name), f'{name} should have been removed from clients.py'
 
 
-class TestBYOKProfiles:
-    """Verify BYOK QoS profiles structure and model selections."""
+class TestBYOKProfile:
+    """Verify BYOK QoS profile structure and model selections."""
 
-    def test_byok_high_all_openai_except_special(self):
-        """byok_high routes all features to OpenAI except chat_agent/web_search/wrapped_analysis."""
-        bh = MODEL_QOS_PROFILES['byok_high']
-        for feature, (model, provider) in bh.items():
+    def test_byok_all_openai_except_special(self):
+        """byok routes all features to OpenAI except chat_agent/web_search/wrapped_analysis."""
+        bk = MODEL_QOS_PROFILES['byok']
+        for feature, (model, provider) in bk.items():
             if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
                 continue
-            assert provider == 'openai', f'byok_high {feature} should be openai, got {provider}'
+            assert provider == 'openai', f'byok {feature} should be openai, got {provider}'
 
-    def test_byok_max_all_openai_except_special(self):
-        """byok_max routes all features to OpenAI except chat_agent/web_search/wrapped_analysis."""
-        bm = MODEL_QOS_PROFILES['byok_max']
-        for feature, (model, provider) in bm.items():
-            if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
-                continue
-            assert provider == 'openai', f'byok_max {feature} should be openai, got {provider}'
-
-    def test_byok_high_upgrades_quality_tier(self):
-        """byok_high upgrades gpt-4.1-mini quality features to gpt-4.1."""
-        bh = MODEL_QOS_PROFILES['byok_high']
-        for feature in [
-            'external_structure',
-            'memories',
-            'memory_conflict',
-            'knowledge_graph',
-            'chat_extraction',
-            'chat_graph',
-            'goals',
-            'proactive_notification',
-            'openglass',
-        ]:
-            assert bh[feature][0] == 'gpt-4.1', f'byok_high {feature} should be gpt-4.1, got {bh[feature][0]}'
-
-    def test_byok_high_upgrades_simple_tier(self):
-        """byok_high upgrades gpt-4.1-nano simple features to gpt-4.1-mini."""
-        bh = MODEL_QOS_PROFILES['byok_high']
-        for feature in ['conv_app_select', 'conv_folder', 'conv_discard', 'smart_glasses', 'persona_chat']:
-            assert bh[feature][0] == 'gpt-4.1-mini', f'byok_high {feature} should be gpt-4.1-mini, got {bh[feature][0]}'
-
-    def test_byok_max_uses_gpt54_flagship(self):
-        """byok_max uses gpt-5.4 for flagship features."""
-        bm = MODEL_QOS_PROFILES['byok_max']
+    def test_byok_uses_gpt54_flagship(self):
+        """byok uses gpt-5.4 for flagship features."""
+        bk = MODEL_QOS_PROFILES['byok']
         for feature in [
             'conv_action_items',
             'conv_structure',
@@ -924,11 +894,11 @@ class TestBYOKProfiles:
             'notifications',
             'chat_graph',
         ]:
-            assert bm[feature][0] == 'gpt-5.4', f'byok_max {feature} should be gpt-5.4, got {bm[feature][0]}'
+            assert bk[feature][0] == 'gpt-5.4', f'byok {feature} should be gpt-5.4, got {bk[feature][0]}'
 
-    def test_byok_max_uses_gpt54_mini_quality(self):
-        """byok_max upgrades quality tier to gpt-5.4-mini."""
-        bm = MODEL_QOS_PROFILES['byok_max']
+    def test_byok_uses_gpt54_mini_quality(self):
+        """byok upgrades quality tier to gpt-5.4-mini."""
+        bk = MODEL_QOS_PROFILES['byok']
         for feature in [
             'external_structure',
             'memories',
@@ -940,31 +910,17 @@ class TestBYOKProfiles:
             'openglass',
             'smart_glasses',
         ]:
-            assert bm[feature][0] == 'gpt-5.4-mini', f'byok_max {feature} should be gpt-5.4-mini, got {bm[feature][0]}'
+            assert bk[feature][0] == 'gpt-5.4-mini', f'byok {feature} should be gpt-5.4-mini, got {bk[feature][0]}'
 
-    def test_byok_max_keeps_o4_mini_for_learnings(self):
-        """byok_max keeps o4-mini for learnings (reasoning model)."""
-        bm = MODEL_QOS_PROFILES['byok_max']
-        assert bm['learnings'] == ('o4-mini', 'openai')
+    def test_byok_keeps_o4_mini_for_learnings(self):
+        """byok keeps o4-mini for learnings (reasoning model)."""
+        bk = MODEL_QOS_PROFILES['byok']
+        assert bk['learnings'] == ('o4-mini', 'openai')
 
-    def test_byok_high_model_variants(self):
-        """byok_high uses expected distinct model IDs."""
-        bh = MODEL_QOS_PROFILES['byok_high']
-        distinct = {model for model, _p in bh.values()}
-        expected = {
-            'gpt-5.4-mini',
-            'gpt-4.1',
-            'gpt-4.1-mini',
-            'claude-sonnet-4-6',
-            'gemini-3-flash-preview',
-            'sonar-pro',
-        }
-        assert distinct == expected
-
-    def test_byok_max_model_variants(self):
-        """byok_max uses expected distinct model IDs."""
-        bm = MODEL_QOS_PROFILES['byok_max']
-        distinct = {model for model, _p in bm.values()}
+    def test_byok_model_variants(self):
+        """byok uses expected distinct model IDs."""
+        bk = MODEL_QOS_PROFILES['byok']
+        distinct = {model for model, _p in bk.values()}
         expected = {
             'gpt-5.4',
             'gpt-5.4-mini',
@@ -976,26 +932,25 @@ class TestBYOKProfiles:
         }
         assert distinct == expected
 
-    def test_byok_profiles_have_same_features_as_premium(self):
-        """BYOK profiles must cover the same feature set as premium."""
+    def test_byok_has_same_features_as_premium(self):
+        """BYOK profile must cover the same feature set as premium."""
         premium_features = set(MODEL_QOS_PROFILES['premium'].keys())
-        for name in ('byok_high', 'byok_max'):
-            byok_features = set(MODEL_QOS_PROFILES[name].keys())
-            assert byok_features == premium_features, f'{name} features differ: {byok_features ^ premium_features}'
+        byok_features = set(MODEL_QOS_PROFILES['byok'].keys())
+        assert byok_features == premium_features, f'byok features differ: {byok_features ^ premium_features}'
 
 
 class TestBYOKProfileFixed:
-    """Verify BYOK QoS profile is always byok_high."""
+    """Verify BYOK QoS profile is always 'byok'."""
 
-    def test_byok_profile_is_byok_high(self):
-        assert _byok_profile_name == 'byok_high'
+    def test_byok_profile_is_byok(self):
+        assert _byok_profile_name == 'byok'
 
     def test_byok_profile_exists(self):
         assert _byok_profile is not None
-        assert _byok_profile is MODEL_QOS_PROFILES['byok_high']
+        assert _byok_profile is MODEL_QOS_PROFILES['byok']
 
     def test_byok_profile_via_subprocess(self):
-        """Verify byok_high is set regardless of MODEL_QOS value."""
+        """Verify byok is set regardless of MODEL_QOS value."""
         import subprocess
 
         result = subprocess.run(
@@ -1012,7 +967,7 @@ class TestBYOKProfileFixed:
                     "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
                     "os.environ['MODEL_QOS']='max'; "
                     "from utils.llm.clients import _byok_profile_name, _byok_profile; "
-                    "assert _byok_profile_name == 'byok_high', f'Expected byok_high, got {_byok_profile_name}'; "
+                    "assert _byok_profile_name == 'byok', f'Expected byok, got {_byok_profile_name}'; "
                     "assert _byok_profile is not None"
                 ),
             ],
@@ -1063,15 +1018,14 @@ class TestStructuredOutputFeatureTracking:
         gemini_so = {f for f in _STRUCTURED_OUTPUT_FEATURES if premium[f][1] == 'gemini'}
         assert gemini_so == {'trends'}, f'Expected only trends on Gemini SO in premium, got {gemini_so}'
 
-    def test_premium1_gemini_structured_output(self):
-        """In premium1 profile, all structured output features are on Gemini."""
-        p1 = MODEL_QOS_PROFILES['premium1']
+    def test_premium_0424_gemini_structured_output(self):
+        """In premium_0424 profile, all structured output features are on Gemini."""
+        p1 = MODEL_QOS_PROFILES['premium_0424']
         gemini_so = {f for f in _STRUCTURED_OUTPUT_FEATURES if p1[f][1] == 'gemini'}
         assert gemini_so == _STRUCTURED_OUTPUT_FEATURES
 
-    def test_byok_profiles_no_gemini_structured_output(self):
-        """BYOK profiles route all structured output features to OpenAI (no Gemini compat risk)."""
-        for name in ('byok_high', 'byok_max'):
-            profile = MODEL_QOS_PROFILES[name]
-            for feature in _STRUCTURED_OUTPUT_FEATURES:
-                assert profile[feature][1] == 'openai', f'{name} {feature} should be openai, got {profile[feature][1]}'
+    def test_byok_no_gemini_structured_output(self):
+        """BYOK profile routes all structured output features to OpenAI (no Gemini compat risk)."""
+        profile = MODEL_QOS_PROFILES['byok']
+        for feature in _STRUCTURED_OUTPUT_FEATURES:
+            assert profile[feature][1] == 'openai', f'byok {feature} should be openai, got {profile[feature][1]}'

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -37,6 +37,7 @@ from utils.llm.clients import (
     _active_profile,
     _active_profile_name,
     _classify_provider,
+    _get_or_create_gemini_llm,
     _get_or_create_openai_llm,
     _get_or_create_openrouter_llm,
     _llm_cache,
@@ -75,9 +76,12 @@ class TestModelQosProfiles:
         for profile_name in MODEL_QOS_PROFILES:
             providers = {_classify_provider(m) for m in MODEL_QOS_PROFILES[profile_name].values()}
             assert 'openrouter' in providers, f'{profile_name} should have OpenRouter (wrapped_analysis)'
+        # Premium profile uses Gemini direct for free-text features
+        premium_providers = {_classify_provider(m) for m in MODEL_QOS_PROFILES['premium'].values()}
+        assert 'gemini' in premium_providers, 'premium should have Gemini direct models'
 
     def test_premium_profile_models(self):
-        """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gpt-4.1-nano for simple."""
+        """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gemini for free-text."""
         premium = MODEL_QOS_PROFILES['premium']
         # Flagship features use gpt-5.4-mini
         assert premium['conv_structure'] == 'gpt-5.4-mini'
@@ -94,8 +98,14 @@ class TestModelQosProfiles:
         assert premium['proactive_notification'] == 'gpt-4.1-mini'
         # Simple features use gpt-4.1-nano
         assert premium['conv_app_select'] == 'gpt-4.1-nano'
-        assert premium['session_titles'] == 'gpt-4.1-nano'
-        assert premium['followup'] == 'gpt-4.1-nano'
+        # Free-text features migrated to Gemini 2.5 Flash-Lite
+        assert premium['session_titles'] == 'gemini-2.5-flash-lite'
+        assert premium['followup'] == 'gemini-2.5-flash-lite'
+        assert premium['onboarding'] == 'gemini-2.5-flash-lite'
+        assert premium['memory_category'] == 'gemini-2.5-flash-lite'
+        assert premium['daily_summary_simple'] == 'gemini-2.5-flash-lite'
+        assert premium['app_integration'] == 'gemini-2.5-flash-lite'
+        assert premium['trends'] == 'gemini-2.5-flash-lite'
         # Unchanged
         assert premium['chat_agent'] == 'claude-sonnet-4-6'
         assert premium['web_search'] == 'sonar-pro'
@@ -459,6 +469,11 @@ class TestProviderClassification:
         assert _classify_provider('google/gemini-flash-1.5-8b') == 'openrouter'
         assert _classify_provider('anthropic/claude-3.5-sonnet') == 'openrouter'
 
+    def test_classify_provider_gemini(self):
+        assert _classify_provider('gemini-2.5-flash-lite') == 'gemini'
+        assert _classify_provider('gemini-2.5-pro') == 'gemini'
+        assert _classify_provider('gemini-2.5-flash') == 'gemini'
+
     def test_classify_provider_perplexity(self):
         assert _classify_provider('sonar-pro') == 'perplexity'
         assert _classify_provider('sonar') == 'perplexity'
@@ -806,6 +821,13 @@ class TestRuntimeProviderRouting:
         llm = get_llm('persona_chat')
         base_url = getattr(llm, 'openai_api_base', None) or ''
         assert 'openrouter' not in base_url
+
+    def test_gemini_feature_routes_to_gemini_endpoint(self):
+        """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
+        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL, _GeminiChatProxy
+
+        llm = get_llm('followup')
+        assert isinstance(llm, _GeminiChatProxy), 'followup should route through _GeminiChatProxy'
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
         """If an override sets an OpenRouter model, get_llm should route via OpenRouter."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -817,9 +817,30 @@ class TestBYOKWrapperArchitecture:
 class TestBYOKProfile:
     """Verify BYOK QoS profile structure and model selections."""
 
-    def test_byok_is_exact_copy_of_max(self):
-        """byok must be an exact copy of max (BYOK users pay their own costs)."""
-        assert MODEL_QOS_PROFILES['byok'] == MODEL_QOS_PROFILES['max']
+    def test_byok_all_openai_except_special(self):
+        """byok routes all features to OpenAI except chat_agent/web_search/wrapped_analysis."""
+        bk = MODEL_QOS_PROFILES['byok']
+        for feature, (model, provider) in bk.items():
+            if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
+                continue
+            assert provider == 'openai', f'byok {feature} should be openai, got {provider}'
+
+    def test_byok_model_variants(self):
+        """byok uses same 9 distinct models as max."""
+        bk = MODEL_QOS_PROFILES['byok']
+        distinct = {model for model, _p in bk.values()}
+        expected = {
+            'gpt-5.4',
+            'gpt-5.4-mini',
+            'gpt-4.1',
+            'gpt-4.1-mini',
+            'gpt-4.1-nano',
+            'o4-mini',
+            'claude-sonnet-4-6',
+            'gemini-3-flash-preview',
+            'sonar-pro',
+        }
+        assert distinct == expected
 
     def test_byok_has_same_features_as_premium(self):
         """BYOK profile must cover the same feature set as premium."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -571,6 +571,18 @@ class TestRollbackScenario:
         assert get_model('persona_chat') == 'claude-3.5-sonnet'
         assert get_provider('persona_chat') == 'anthropic'
 
+    def test_invalid_provider_in_override_falls_back(self, monkeypatch):
+        """Explicit override with invalid provider falls back to profile provider."""
+        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus_provider')
+        assert get_model('conv_action_items') == 'gpt-5.1'
+        assert get_provider('conv_action_items') == 'openai'  # profile provider
+
+    def test_model_only_override_infers_provider(self, monkeypatch):
+        """Model-only override infers provider from model name."""
+        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gemini-2.5-flash')
+        assert get_model('conv_action_items') == 'gemini-2.5-flash'
+        assert get_provider('conv_action_items') == 'gemini'  # inferred from model name
+
 
 class TestProfileSelectionAtImportTime:
     """Verify MODEL_QOS env var selects the correct profile at module load time."""
@@ -804,20 +816,29 @@ class TestExpandedCallsiteCoverage:
 
 
 class TestOverrideWarningLog:
-    """Verify override warnings fire when provider doesn't match."""
+    """Verify override warnings fire for invalid explicit provider."""
 
-    def test_warns_on_cross_provider_override(self, monkeypatch, caplog):
+    def test_warns_on_invalid_explicit_provider(self, monkeypatch, caplog):
         import logging
 
         with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gemini-2.5-flash')
+            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus')
             result = get_model('conv_action_items')
-            assert result == 'gemini-2.5-flash'
-        assert any(
-            'differs from profile provider' in r.message for r in caplog.records
-        ), "Expected cross-provider override warning"
+            assert result == 'gpt-5.1'
+        assert any('invalid provider' in r.message for r in caplog.records), "Expected invalid provider warning"
 
-    def test_no_warning_on_same_provider_override(self, monkeypatch, caplog):
+    def test_no_warning_on_valid_explicit_provider(self, monkeypatch, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
+            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini:openai')
+            result = get_model('conv_action_items')
+            assert result == 'gpt-4.1-mini'
+        assert not any(
+            'invalid provider' in r.message for r in caplog.records
+        ), "No warning expected for valid explicit provider"
+
+    def test_no_warning_on_model_only_override(self, monkeypatch, caplog):
         import logging
 
         with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
@@ -825,8 +846,8 @@ class TestOverrideWarningLog:
             result = get_model('conv_action_items')
             assert result == 'gpt-4.1-mini'
         assert not any(
-            'may be invalid' in r.message for r in caplog.records
-        ), "No warning expected for same-provider override"
+            'invalid provider' in r.message for r in caplog.records
+        ), "No warning expected for model-only override"
 
 
 class TestRuntimeProviderRouting:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -878,11 +878,13 @@ class TestRuntimeProviderRouting:
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
         """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _BYOKChatWrapper
+        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL
 
         llm = get_llm('followup')
         assert isinstance(llm, _BYOKChatWrapper), 'followup should be wrapped with _BYOKChatWrapper'
         assert llm._provider == 'gemini', 'followup wrapper should have gemini provider'
+        # Default client must use Gemini base URL
+        assert llm._default.openai_api_base == _GEMINI_OPENAI_BASE_URL, 'followup default must use Gemini base URL'
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""
@@ -915,6 +917,19 @@ class TestRuntimeProviderRouting:
         assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
         default = getattr(llm, '_default', llm)
         assert default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+
+    def test_openrouter_adds_vendor_prefix_for_gemini_models(self):
+        """Profile stores bare model name; OpenRouter factory must add google/ prefix for API calls."""
+        llm = get_llm('wrapped_analysis')
+        default = getattr(llm, '_default', llm)
+        assert default.model_name.startswith('google/'), f"Expected google/ prefix, got {default.model_name}"
+
+    def test_empty_provider_suffix_in_override(self, monkeypatch):
+        """MODEL_QOS_X=model: (empty provider after colon) should use inferred provider."""
+        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini:')
+        assert get_model('conv_action_items') == 'gpt-4.1-mini'
+        # Empty string is not in _VALID_PROVIDERS, so falls back to inferred
+        assert get_provider('conv_action_items') == 'openai'
 
 
 class TestBYOKWrapperArchitecture:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -31,7 +31,6 @@ os.environ.setdefault('ANTHROPIC_API_KEY', 'sk-ant-test-fake-key')
 from utils.llm.clients import (
     MODEL_QOS_PROFILES,
     _ANTHROPIC_ONLY_FEATURES,
-    _BYOK_PROFILE_MAP,
     _CACHE_KEY_MODELS,
     _PERPLEXITY_ONLY_FEATURES,
     _PINNED_FEATURES,
@@ -985,38 +984,18 @@ class TestBYOKProfiles:
             assert byok_features == premium_features, f'{name} features differ: {byok_features ^ premium_features}'
 
 
-class TestBYOKProfileAutoMapping:
-    """Verify BYOK QoS profile is auto-derived from active profile (no env var)."""
+class TestBYOKProfileFixed:
+    """Verify BYOK QoS profile is always byok_high."""
 
-    def test_byok_map_covers_all_profiles(self):
-        """Every profile in MODEL_QOS_PROFILES must have a BYOK mapping."""
-        for profile_name in MODEL_QOS_PROFILES:
-            assert profile_name in _BYOK_PROFILE_MAP, f'{profile_name} missing from _BYOK_PROFILE_MAP'
+    def test_byok_profile_is_byok_high(self):
+        assert _byok_profile_name == 'byok_high'
 
-    def test_byok_map_targets_exist(self):
-        """Every BYOK mapping target must exist in MODEL_QOS_PROFILES."""
-        for target in set(_BYOK_PROFILE_MAP.values()):
-            assert target in MODEL_QOS_PROFILES, f'BYOK target {target} not in MODEL_QOS_PROFILES'
-
-    def test_premium_maps_to_byok_high(self):
-        assert _BYOK_PROFILE_MAP['premium'] == 'byok_high'
-
-    def test_premium1_maps_to_byok_high(self):
-        assert _BYOK_PROFILE_MAP['premium1'] == 'byok_high'
-
-    def test_max_maps_to_byok_max(self):
-        assert _BYOK_PROFILE_MAP['max'] == 'byok_max'
-
-    def test_max1_maps_to_byok_max(self):
-        assert _BYOK_PROFILE_MAP['max1'] == 'byok_max'
-
-    def test_active_profile_has_byok_mapping(self):
-        """The current active profile must have a BYOK mapping resolved."""
-        assert _byok_profile_name is not None
+    def test_byok_profile_exists(self):
         assert _byok_profile is not None
+        assert _byok_profile is MODEL_QOS_PROFILES['byok_high']
 
-    def test_auto_mapping_via_subprocess(self):
-        """Verify auto-mapping works in a fresh process (premium → byok_high)."""
+    def test_byok_profile_via_subprocess(self):
+        """Verify byok_high is set regardless of MODEL_QOS value."""
         import subprocess
 
         result = subprocess.run(
@@ -1031,7 +1010,7 @@ class TestBYOKProfileAutoMapping:
                     "'database','database._client','database.llm_usage']]; "
                     "import os; os.environ['OPENAI_API_KEY']='sk-test'; "
                     "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
-                    "os.environ['MODEL_QOS']='premium'; "
+                    "os.environ['MODEL_QOS']='max'; "
                     "from utils.llm.clients import _byok_profile_name, _byok_profile; "
                     "assert _byok_profile_name == 'byok_high', f'Expected byok_high, got {_byok_profile_name}'; "
                     "assert _byok_profile is not None"
@@ -1041,7 +1020,7 @@ class TestBYOKProfileAutoMapping:
             text=True,
             cwd=str(os.path.join(os.path.dirname(__file__), '..', '..')),
         )
-        assert result.returncode == 0, f"auto-mapping test failed: {result.stderr}"
+        assert result.returncode == 0, f"byok profile test failed: {result.stderr}"
 
 
 class TestEffectiveBYOKProvider:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -31,6 +31,7 @@ os.environ.setdefault('ANTHROPIC_API_KEY', 'sk-ant-test-fake-key')
 from utils.llm.clients import (
     MODEL_QOS_PROFILES,
     _ANTHROPIC_ONLY_FEATURES,
+    _BYOK_PROFILE_MAP,
     _CACHE_KEY_MODELS,
     _PERPLEXITY_ONLY_FEATURES,
     _PINNED_FEATURES,
@@ -984,15 +985,38 @@ class TestBYOKProfiles:
             assert byok_features == premium_features, f'{name} features differ: {byok_features ^ premium_features}'
 
 
-class TestBYOKProfileResolution:
-    """Verify BYOK QoS profile selection at startup."""
+class TestBYOKProfileAutoMapping:
+    """Verify BYOK QoS profile is auto-derived from active profile (no env var)."""
 
-    def test_byok_profile_default_is_none(self):
-        """Without BYOK_QOS env var, _byok_profile should be None."""
-        assert _byok_profile is None or _byok_profile_name is not None
+    def test_byok_map_covers_all_profiles(self):
+        """Every profile in MODEL_QOS_PROFILES must have a BYOK mapping."""
+        for profile_name in MODEL_QOS_PROFILES:
+            assert profile_name in _BYOK_PROFILE_MAP, f'{profile_name} missing from _BYOK_PROFILE_MAP'
 
-    def test_byok_profile_selection_via_env(self):
-        """BYOK_QOS=byok_high should select the byok_high profile."""
+    def test_byok_map_targets_exist(self):
+        """Every BYOK mapping target must exist in MODEL_QOS_PROFILES."""
+        for target in set(_BYOK_PROFILE_MAP.values()):
+            assert target in MODEL_QOS_PROFILES, f'BYOK target {target} not in MODEL_QOS_PROFILES'
+
+    def test_premium_maps_to_byok_high(self):
+        assert _BYOK_PROFILE_MAP['premium'] == 'byok_high'
+
+    def test_premium1_maps_to_byok_high(self):
+        assert _BYOK_PROFILE_MAP['premium1'] == 'byok_high'
+
+    def test_max_maps_to_byok_max(self):
+        assert _BYOK_PROFILE_MAP['max'] == 'byok_max'
+
+    def test_max1_maps_to_byok_max(self):
+        assert _BYOK_PROFILE_MAP['max1'] == 'byok_max'
+
+    def test_active_profile_has_byok_mapping(self):
+        """The current active profile must have a BYOK mapping resolved."""
+        assert _byok_profile_name is not None
+        assert _byok_profile is not None
+
+    def test_auto_mapping_via_subprocess(self):
+        """Verify auto-mapping works in a fresh process (premium → byok_high)."""
         import subprocess
 
         result = subprocess.run(
@@ -1007,45 +1031,17 @@ class TestBYOKProfileResolution:
                     "'database','database._client','database.llm_usage']]; "
                     "import os; os.environ['OPENAI_API_KEY']='sk-test'; "
                     "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
-                    "os.environ['BYOK_QOS']='byok_high'; "
+                    "os.environ['MODEL_QOS']='premium'; "
                     "from utils.llm.clients import _byok_profile_name, _byok_profile; "
                     "assert _byok_profile_name == 'byok_high', f'Expected byok_high, got {_byok_profile_name}'; "
-                    "assert _byok_profile is not None, 'byok_profile should not be None'"
+                    "assert _byok_profile is not None"
                 ),
             ],
             capture_output=True,
             text=True,
             cwd=str(os.path.join(os.path.dirname(__file__), '..', '..')),
         )
-        assert result.returncode == 0, f"byok profile test failed: {result.stderr}"
-
-    def test_invalid_byok_profile_disabled(self):
-        """BYOK_QOS=bogus should disable BYOK profile (set to None)."""
-        import subprocess
-
-        result = subprocess.run(
-            [
-                'python3',
-                '-c',
-                (
-                    "import sys; from unittest.mock import MagicMock; "
-                    "[sys.modules.setdefault(m, MagicMock()) for m in "
-                    "['firebase_admin','firebase_admin.firestore','google.cloud.firestore',"
-                    "'google.cloud.firestore_v1','google.cloud.firestore_v1.base_query',"
-                    "'database','database._client','database.llm_usage']]; "
-                    "import os; os.environ['OPENAI_API_KEY']='sk-test'; "
-                    "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
-                    "os.environ['BYOK_QOS']='bogus'; "
-                    "from utils.llm.clients import _byok_profile_name, _byok_profile; "
-                    "assert _byok_profile_name is None, f'Expected None, got {_byok_profile_name}'; "
-                    "assert _byok_profile is None, 'byok_profile should be None for invalid profile'"
-                ),
-            ],
-            capture_output=True,
-            text=True,
-            cwd=str(os.path.join(os.path.dirname(__file__), '..', '..')),
-        )
-        assert result.returncode == 0, f"invalid byok profile test failed: {result.stderr}"
+        assert result.returncode == 0, f"auto-mapping test failed: {result.stderr}"
 
 
 class TestEffectiveBYOKProvider:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -98,6 +98,8 @@ class TestModelQosProfiles:
         assert premium['proactive_notification'] == 'gpt-4.1-mini'
         # Simple features use gpt-4.1-nano
         assert premium['conv_app_select'] == 'gpt-4.1-nano'
+        # Vision features use gpt-4.1-mini
+        assert premium['openglass'] == 'gpt-4.1-mini'
         # Free-text features migrated to Gemini 2.5 Flash-Lite
         assert premium['session_titles'] == 'gemini-2.5-flash-lite'
         assert premium['followup'] == 'gemini-2.5-flash-lite'
@@ -824,10 +826,18 @@ class TestRuntimeProviderRouting:
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
         """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL, _GeminiChatProxy
+        from utils.llm.clients import _BYOKChatProxy, _GeminiChatProxy
 
         llm = get_llm('followup')
         assert isinstance(llm, _GeminiChatProxy), 'followup should route through _GeminiChatProxy'
+        assert isinstance(llm, _BYOKChatProxy), 'all chat proxies inherit from _BYOKChatProxy'
+
+    def test_openglass_routes_to_openai(self):
+        """openglass (vision) should route to OpenAI gpt-4.1-mini."""
+        from utils.llm.clients import _OpenAIChatProxy
+
+        llm = get_llm('openglass')
+        assert isinstance(llm, _OpenAIChatProxy)
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
         """If an override sets an OpenRouter model, get_llm should route via OpenRouter."""
@@ -846,3 +856,33 @@ class TestRuntimeProviderRouting:
         expected_temp = _OPENROUTER_TEMPERATURES.get('persona_chat')
         assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
         assert llm.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+
+
+class TestProxyHierarchy:
+    """Verify all ChatOpenAI proxies share _BYOKChatProxy base."""
+
+    def test_all_chat_proxies_inherit_from_base(self):
+        from utils.llm.clients import _BYOKChatProxy, _GeminiChatProxy, _OpenAIChatProxy, _OpenRouterGeminiProxy
+
+        assert issubclass(_OpenAIChatProxy, _BYOKChatProxy)
+        assert issubclass(_GeminiChatProxy, _BYOKChatProxy)
+        assert issubclass(_OpenRouterGeminiProxy, _BYOKChatProxy)
+
+    def test_no_legacy_llm_medium_or_llm_large(self):
+        """Dead legacy instances must not exist in clients module."""
+        import utils.llm.clients as mod
+
+        for name in [
+            'llm_medium',
+            'llm_large',
+            'llm_high',
+            'llm_agent',
+            'llm_gemini_flash',
+            'llm_mini_stream',
+            'llm_medium_stream',
+            'llm_large_stream',
+            'llm_high_stream',
+            'llm_agent_stream',
+            'llm_medium_experiment',
+        ]:
+            assert not hasattr(mod, name), f'{name} should have been removed from clients.py'

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -43,6 +43,7 @@ from utils.llm.clients import (
     _llm_cache,
     get_llm,
     get_model,
+    get_provider,
     get_qos_info,
 )
 
@@ -68,83 +69,83 @@ class TestModelQosProfiles:
     def test_profiles_cover_expected_providers(self):
         """Each profile should have features across expected providers."""
         for profile_name, profile in MODEL_QOS_PROFILES.items():
-            providers = {_classify_provider(model) for model in profile.values()}
+            providers = {provider for _model, provider in profile.values()}
             assert 'openai' in providers, f'{profile_name} missing OpenAI models'
             assert 'anthropic' in providers, f'{profile_name} missing Anthropic models'
             assert 'perplexity' in providers, f'{profile_name} missing Perplexity models'
         # Both profiles keep OpenRouter for wrapped_analysis
         for profile_name in MODEL_QOS_PROFILES:
-            providers = {_classify_provider(m) for m in MODEL_QOS_PROFILES[profile_name].values()}
+            providers = {provider for _m, provider in MODEL_QOS_PROFILES[profile_name].values()}
             assert 'openrouter' in providers, f'{profile_name} should have OpenRouter (wrapped_analysis)'
         # Premium profile uses Gemini direct for free-text features
-        premium_providers = {_classify_provider(m) for m in MODEL_QOS_PROFILES['premium'].values()}
+        premium_providers = {provider for _m, provider in MODEL_QOS_PROFILES['premium'].values()}
         assert 'gemini' in premium_providers, 'premium should have Gemini direct models'
 
     def test_premium_profile_models(self):
         """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gemini for free-text."""
         premium = MODEL_QOS_PROFILES['premium']
-        # Flagship features use gpt-5.4-mini
-        assert premium['conv_structure'] == 'gpt-5.4-mini'
-        assert premium['chat_responses'] == 'gpt-5.4-mini'
-        assert premium['goals_advice'] == 'gpt-5.4-mini'
-        # Quality-sensitive features use gpt-4.1-mini
-        assert premium['memories'] == 'gpt-4.1-mini'
-        assert premium['chat_extraction'] == 'gpt-4.1-mini'
-        assert premium['chat_graph'] == 'gpt-4.1-mini'
-        assert premium['external_structure'] == 'gpt-4.1-mini'
-        assert premium['memory_conflict'] == 'gpt-4.1-mini'
-        assert premium['knowledge_graph'] == 'gpt-4.1-mini'
-        assert premium['goals'] == 'gpt-4.1-mini'
-        assert premium['proactive_notification'] == 'gpt-4.1-mini'
-        # Simple features use gpt-4.1-nano
-        assert premium['conv_app_select'] == 'gpt-4.1-nano'
-        # Vision features use gpt-4.1-mini
-        assert premium['openglass'] == 'gpt-4.1-mini'
-        # Free-text features migrated to Gemini 2.5 Flash-Lite
-        assert premium['session_titles'] == 'gemini-2.5-flash-lite'
-        assert premium['followup'] == 'gemini-2.5-flash-lite'
-        assert premium['onboarding'] == 'gemini-2.5-flash-lite'
-        assert premium['memory_category'] == 'gemini-2.5-flash-lite'
-        assert premium['daily_summary_simple'] == 'gemini-2.5-flash-lite'
-        assert premium['app_integration'] == 'gemini-2.5-flash-lite'
-        assert premium['trends'] == 'gemini-2.5-flash-lite'
-        # Unchanged
-        assert premium['chat_agent'] == 'claude-sonnet-4-6'
-        assert premium['web_search'] == 'sonar-pro'
+        # Flagship features use gpt-5.4-mini on openai
+        assert premium['conv_structure'] == ('gpt-5.4-mini', 'openai')
+        assert premium['chat_responses'] == ('gpt-5.4-mini', 'openai')
+        assert premium['goals_advice'] == ('gpt-5.4-mini', 'openai')
+        # Quality-sensitive features use gpt-4.1-mini on openai
+        assert premium['memories'] == ('gpt-4.1-mini', 'openai')
+        assert premium['chat_extraction'] == ('gpt-4.1-mini', 'openai')
+        assert premium['chat_graph'] == ('gpt-4.1-mini', 'openai')
+        assert premium['external_structure'] == ('gpt-4.1-mini', 'openai')
+        assert premium['memory_conflict'] == ('gpt-4.1-mini', 'openai')
+        assert premium['knowledge_graph'] == ('gpt-4.1-mini', 'openai')
+        assert premium['goals'] == ('gpt-4.1-mini', 'openai')
+        assert premium['proactive_notification'] == ('gpt-4.1-mini', 'openai')
+        # Simple features use gpt-4.1-nano on openai
+        assert premium['conv_app_select'] == ('gpt-4.1-nano', 'openai')
+        # Vision features use gpt-4.1-mini on openai
+        assert premium['openglass'] == ('gpt-4.1-mini', 'openai')
+        # Free-text features migrated to Gemini 2.5 Flash-Lite on gemini provider
+        assert premium['session_titles'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['followup'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['onboarding'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['memory_category'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['daily_summary_simple'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['app_integration'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['trends'] == ('gemini-2.5-flash-lite', 'gemini')
+        # Anthropic & Perplexity with explicit provider
+        assert premium['chat_agent'] == ('claude-sonnet-4-6', 'anthropic')
+        assert premium['web_search'] == ('sonar-pro', 'perplexity')
         # Persona uses direct OpenAI API
-        assert premium['persona_chat'] == 'gpt-4.1-nano'
-        assert premium['persona_chat_premium'] == 'gpt-5.4-mini'
+        assert premium['persona_chat'] == ('gpt-4.1-nano', 'openai')
+        assert premium['persona_chat_premium'] == ('gpt-5.4-mini', 'openai')
 
     def test_max_profile_models(self):
         """Max uses gpt-5.4 flagship, gpt-4.1-mini for cheap tasks, production-grade models."""
         max_prof = MODEL_QOS_PROFILES['max']
-        # Flagship uses gpt-5.4
-        assert max_prof['chat_responses'] == 'gpt-5.4'
-        assert max_prof['goals_advice'] == 'gpt-5.4'
-        assert max_prof['app_generator'] == 'gpt-5.4'
-        assert max_prof['conv_action_items'] == 'gpt-5.4'
-        assert max_prof['conv_structure'] == 'gpt-5.4'
-        assert max_prof['daily_summary'] == 'gpt-5.4'
-        assert max_prof['persona_clone'] == 'gpt-5.4'
-        assert max_prof['notifications'] == 'gpt-5.4'
-        # Cheap tasks use gpt-4.1-mini
-        assert max_prof['conv_app_select'] == 'gpt-4.1-mini'
-        assert max_prof['memories'] == 'gpt-4.1-mini'
-        assert max_prof['learnings'] == 'o4-mini'
-        assert max_prof['chat_graph'] == 'gpt-4.1'
+        # Flagship uses gpt-5.4 on openai
+        assert max_prof['chat_responses'] == ('gpt-5.4', 'openai')
+        assert max_prof['goals_advice'] == ('gpt-5.4', 'openai')
+        assert max_prof['app_generator'] == ('gpt-5.4', 'openai')
+        assert max_prof['conv_action_items'] == ('gpt-5.4', 'openai')
+        assert max_prof['conv_structure'] == ('gpt-5.4', 'openai')
+        assert max_prof['daily_summary'] == ('gpt-5.4', 'openai')
+        assert max_prof['persona_clone'] == ('gpt-5.4', 'openai')
+        assert max_prof['notifications'] == ('gpt-5.4', 'openai')
+        # Cheap tasks use gpt-4.1-mini on openai
+        assert max_prof['conv_app_select'] == ('gpt-4.1-mini', 'openai')
+        assert max_prof['memories'] == ('gpt-4.1-mini', 'openai')
+        assert max_prof['learnings'] == ('o4-mini', 'openai')
+        assert max_prof['chat_graph'] == ('gpt-4.1', 'openai')
         # Persona uses direct OpenAI API
-        assert max_prof['persona_chat'] == 'gpt-4.1-nano'
-        assert max_prof['persona_chat_premium'] == 'gpt-5.4-mini'
-        # OpenRouter for wrapped_analysis only
-        assert max_prof['wrapped_analysis'] == 'google/gemini-3-flash-preview'
-        # Anthropic & Perplexity unchanged
-        assert max_prof['chat_agent'] == 'claude-sonnet-4-6'
-        assert max_prof['web_search'] == 'sonar-pro'
+        assert max_prof['persona_chat'] == ('gpt-4.1-nano', 'openai')
+        assert max_prof['persona_chat_premium'] == ('gpt-5.4-mini', 'openai')
+        # OpenRouter for wrapped_analysis with explicit provider
+        assert max_prof['wrapped_analysis'] == ('gemini-3-flash-preview', 'openrouter')
+        # Anthropic & Perplexity with explicit provider
+        assert max_prof['chat_agent'] == ('claude-sonnet-4-6', 'anthropic')
+        assert max_prof['web_search'] == ('sonar-pro', 'perplexity')
 
     def test_max_profile_model_variants(self):
         """Max profile uses 9 distinct model IDs."""
         max_prof = MODEL_QOS_PROFILES['max']
-        distinct_models = set(max_prof.values())
+        distinct_models = {model for model, _provider in max_prof.values()}
         expected = {
             'gpt-5.4',
             'gpt-4.1-mini',
@@ -153,7 +154,7 @@ class TestModelQosProfiles:
             'gpt-4.1-nano',
             'gpt-5.4-mini',
             'claude-sonnet-4-6',
-            'google/gemini-3-flash-preview',
+            'gemini-3-flash-preview',
             'sonar-pro',
         }
         assert distinct_models == expected
@@ -178,7 +179,7 @@ class TestGetModel:
     """Verify get_model() resolution: pinned > env override > profile > fallback."""
 
     def test_returns_profile_default(self):
-        assert get_model('conv_action_items') == MODEL_QOS_PROFILES[_active_profile_name]['conv_action_items']
+        assert get_model('conv_action_items') == MODEL_QOS_PROFILES[_active_profile_name]['conv_action_items'][0]
 
     def test_env_override_takes_precedence(self, monkeypatch):
         monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1')
@@ -190,7 +191,7 @@ class TestGetModel:
 
     def test_empty_env_override_falls_back_to_profile(self, monkeypatch):
         monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', '')
-        assert get_model('conv_action_items') == _active_profile['conv_action_items']
+        assert get_model('conv_action_items') == _active_profile['conv_action_items'][0]
 
     def test_unknown_feature_falls_back_to_gpt41_mini(self):
         assert get_model('totally_unknown_feature') == 'gpt-4.1-mini'
@@ -436,6 +437,16 @@ class TestGetQosInfo:
         assert info['persona_chat']['provider'] == 'openai'
         # wrapped_analysis uses OpenRouter in both profiles
         assert info['wrapped_analysis']['provider'] == 'openrouter'
+        # Gemini features use gemini provider
+        assert info['followup']['provider'] == 'gemini'
+
+    def test_get_provider_matches_profile(self):
+        """get_provider() returns the explicit provider from the profile."""
+        assert get_provider('conv_action_items') == 'openai'
+        assert get_provider('chat_agent') == 'anthropic'
+        assert get_provider('web_search') == 'perplexity'
+        assert get_provider('wrapped_analysis') == 'openrouter'
+        assert get_provider('followup') == 'gemini'
 
     def test_reflects_env_override(self, monkeypatch):
         monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'o4-mini')
@@ -447,7 +458,7 @@ class TestPinnedFeatures:
     """Verify pinned features are immutable."""
 
     def test_fair_use_pinned_to_gpt51(self):
-        assert _PINNED_FEATURES['fair_use'] == 'gpt-5.1'
+        assert _PINNED_FEATURES['fair_use'] == ('gpt-5.1', 'openai')
 
     def test_pinned_survives_profile_switch(self):
         # Even if profile doesn't list fair_use, it should resolve to pinned value
@@ -490,19 +501,19 @@ class TestProviderClassification:
         """Persona chat features use direct OpenAI API in both profiles."""
         for profile_name in ['max', 'premium']:
             prof = MODEL_QOS_PROFILES[profile_name]
-            assert _classify_provider(prof['persona_chat']) == 'openai', f'{profile_name} persona_chat'
-            assert _classify_provider(prof['persona_chat_premium']) == 'openai', f'{profile_name} persona_chat_premium'
+            assert prof['persona_chat'][1] == 'openai', f'{profile_name} persona_chat'
+            assert prof['persona_chat_premium'][1] == 'openai', f'{profile_name} persona_chat_premium'
 
     def test_wrapped_analysis_uses_openrouter_in_both_profiles(self):
         """wrapped_analysis uses OpenRouter (gemini-3-flash-preview) in both profiles."""
         for profile_name in ['max', 'premium']:
             prof = MODEL_QOS_PROFILES[profile_name]
-            assert _classify_provider(prof['wrapped_analysis']) == 'openrouter', f'{profile_name} wrapped_analysis'
+            assert prof['wrapped_analysis'][1] == 'openrouter', f'{profile_name} wrapped_analysis'
 
     def test_conv_features_are_openai(self):
         max_prof = MODEL_QOS_PROFILES['max']
         for feature in ['conv_action_items', 'conv_structure', 'conv_app_result', 'conv_app_select']:
-            assert _classify_provider(max_prof[feature]) == 'openai'
+            assert max_prof[feature][1] == 'openai'
 
 
 class TestProviderSafetyGuard:
@@ -556,8 +567,9 @@ class TestRollbackScenario:
         assert get_model('chat_agent') == 'claude-haiku-3.5'
 
     def test_override_persona_to_different_model(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'anthropic/claude-3.5-sonnet')
-        assert get_model('persona_chat') == 'anthropic/claude-3.5-sonnet'
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'claude-3.5-sonnet:anthropic')
+        assert get_model('persona_chat') == 'claude-3.5-sonnet'
+        assert get_provider('persona_chat') == 'anthropic'
 
 
 class TestProfileSelectionAtImportTime:
@@ -798,10 +810,12 @@ class TestOverrideWarningLog:
         import logging
 
         with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'google/gemini-flash-1.5-8b')
+            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gemini-2.5-flash')
             result = get_model('conv_action_items')
-            assert result == 'google/gemini-flash-1.5-8b'
-        assert any('may be invalid' in r.message for r in caplog.records), "Expected cross-provider override warning"
+            assert result == 'gemini-2.5-flash'
+        assert any(
+            'differs from profile provider' in r.message for r in caplog.records
+        ), "Expected cross-provider override warning"
 
     def test_no_warning_on_same_provider_override(self, monkeypatch, caplog):
         import logging
@@ -826,24 +840,26 @@ class TestRuntimeProviderRouting:
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
         """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _BYOKChatProxy, _GeminiChatProxy
+        from utils.llm.clients import _BYOKChatWrapper
 
         llm = get_llm('followup')
-        assert isinstance(llm, _GeminiChatProxy), 'followup should route through _GeminiChatProxy'
-        assert isinstance(llm, _BYOKChatProxy), 'all chat proxies inherit from _BYOKChatProxy'
+        assert isinstance(llm, _BYOKChatWrapper), 'followup should be wrapped with _BYOKChatWrapper'
+        assert llm._provider == 'gemini', 'followup wrapper should have gemini provider'
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""
-        from utils.llm.clients import _OpenAIChatProxy
+        from utils.llm.clients import _BYOKChatWrapper
 
         llm = get_llm('openglass')
-        assert isinstance(llm, _OpenAIChatProxy)
+        assert isinstance(llm, _BYOKChatWrapper)
+        assert llm._provider == 'openai'
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
-        """If an override sets an OpenRouter model, get_llm should route via OpenRouter."""
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b')
+        """If an override sets an OpenRouter model:provider, get_llm should route via OpenRouter."""
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gemini-flash-1.5-8b:openrouter')
         llm = get_llm('persona_chat')
-        base_url = getattr(llm, 'openai_api_base', None) or ''
+        # The wrapper's default client should be OpenRouter-configured
+        base_url = getattr(llm._default, 'openai_api_base', None) or ''
         assert 'openrouter' in base_url
 
     def test_openrouter_temperature_applied_via_get_llm(self, monkeypatch):
@@ -851,22 +867,34 @@ class TestRuntimeProviderRouting:
         from utils.llm.clients import _OPENROUTER_TEMPERATURES
 
         # Override persona_chat to an OpenRouter model to test temperature routing
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b')
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gemini-flash-1.5-8b:openrouter')
         llm = get_llm('persona_chat')
         expected_temp = _OPENROUTER_TEMPERATURES.get('persona_chat')
         assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
-        assert llm.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+        assert llm._default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
 
 
-class TestProxyHierarchy:
-    """Verify all ChatOpenAI proxies share _BYOKChatProxy base."""
+class TestBYOKWrapperArchitecture:
+    """Verify BYOK wrapper is used consistently across providers."""
 
-    def test_all_chat_proxies_inherit_from_base(self):
-        from utils.llm.clients import _BYOKChatProxy, _GeminiChatProxy, _OpenAIChatProxy, _OpenRouterGeminiProxy
+    def test_all_providers_use_byok_wrapper(self):
+        from utils.llm.clients import _BYOKChatWrapper
 
-        assert issubclass(_OpenAIChatProxy, _BYOKChatProxy)
-        assert issubclass(_GeminiChatProxy, _BYOKChatProxy)
-        assert issubclass(_OpenRouterGeminiProxy, _BYOKChatProxy)
+        # OpenAI feature
+        llm_openai = get_llm('conv_structure')
+        assert isinstance(llm_openai, _BYOKChatWrapper)
+        assert llm_openai._provider == 'openai'
+
+        # Gemini feature
+        llm_gemini = get_llm('followup')
+        assert isinstance(llm_gemini, _BYOKChatWrapper)
+        assert llm_gemini._provider == 'gemini'
+
+        # OpenRouter feature
+        llm_or = get_llm('wrapped_analysis')
+        assert isinstance(llm_or, _BYOKChatWrapper)
+        # OpenRouter Gemini models use 'gemini' as BYOK provider (routes to Google direct)
+        assert llm_or._provider == 'gemini'
 
     def test_no_legacy_llm_medium_or_llm_large(self):
         """Dead legacy instances must not exist in clients module."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -34,8 +34,12 @@ from utils.llm.clients import (
     _CACHE_KEY_MODELS,
     _PERPLEXITY_ONLY_FEATURES,
     _PINNED_FEATURES,
+    _STRUCTURED_OUTPUT_FEATURES,
     _active_profile,
     _active_profile_name,
+    _byok_profile,
+    _byok_profile_name,
+    _effective_byok_provider,
     _get_or_create_gemini_llm,
     _get_or_create_openai_llm,
     _get_or_create_openrouter_llm,
@@ -54,8 +58,8 @@ from utils.llm.clients import (
 class TestModelQosProfiles:
     """Verify profile structure and completeness."""
 
-    def test_four_profiles_exist(self):
-        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium1', 'max', 'max1'}
+    def test_six_profiles_exist(self):
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium1', 'max', 'max1', 'byok_high', 'byok_max'}
 
     def test_all_profiles_have_same_features(self):
         feature_sets = {name: set(profile.keys()) for name, profile in MODEL_QOS_PROFILES.items()}
@@ -74,7 +78,7 @@ class TestModelQosProfiles:
             assert 'perplexity' in providers, f'{profile_name} missing Perplexity models'
             assert 'openrouter' in providers, f'{profile_name} should have OpenRouter (wrapped_analysis)'
         # OpenAI-based profiles must have OpenAI provider
-        for name in ('premium', 'max'):
+        for name in ('premium', 'max', 'byok_high', 'byok_max'):
             providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
             assert 'openai' in providers, f'{name} missing OpenAI models'
         # Gemini-optimized profiles must have Gemini provider
@@ -861,3 +865,238 @@ class TestBYOKWrapperArchitecture:
             'llm_medium_experiment',
         ]:
             assert not hasattr(mod, name), f'{name} should have been removed from clients.py'
+
+
+class TestBYOKProfiles:
+    """Verify BYOK QoS profiles structure and model selections."""
+
+    def test_byok_high_all_openai_except_special(self):
+        """byok_high routes all features to OpenAI except chat_agent/web_search/wrapped_analysis."""
+        bh = MODEL_QOS_PROFILES['byok_high']
+        for feature, (model, provider) in bh.items():
+            if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
+                continue
+            assert provider == 'openai', f'byok_high {feature} should be openai, got {provider}'
+
+    def test_byok_max_all_openai_except_special(self):
+        """byok_max routes all features to OpenAI except chat_agent/web_search/wrapped_analysis."""
+        bm = MODEL_QOS_PROFILES['byok_max']
+        for feature, (model, provider) in bm.items():
+            if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
+                continue
+            assert provider == 'openai', f'byok_max {feature} should be openai, got {provider}'
+
+    def test_byok_high_upgrades_quality_tier(self):
+        """byok_high upgrades gpt-4.1-mini quality features to gpt-4.1."""
+        bh = MODEL_QOS_PROFILES['byok_high']
+        for feature in [
+            'external_structure',
+            'memories',
+            'memory_conflict',
+            'knowledge_graph',
+            'chat_extraction',
+            'chat_graph',
+            'goals',
+            'proactive_notification',
+            'openglass',
+        ]:
+            assert bh[feature][0] == 'gpt-4.1', f'byok_high {feature} should be gpt-4.1, got {bh[feature][0]}'
+
+    def test_byok_high_upgrades_simple_tier(self):
+        """byok_high upgrades gpt-4.1-nano simple features to gpt-4.1-mini."""
+        bh = MODEL_QOS_PROFILES['byok_high']
+        for feature in ['conv_app_select', 'conv_folder', 'conv_discard', 'smart_glasses', 'persona_chat']:
+            assert bh[feature][0] == 'gpt-4.1-mini', f'byok_high {feature} should be gpt-4.1-mini, got {bh[feature][0]}'
+
+    def test_byok_max_uses_gpt54_flagship(self):
+        """byok_max uses gpt-5.4 for flagship features."""
+        bm = MODEL_QOS_PROFILES['byok_max']
+        for feature in [
+            'conv_action_items',
+            'conv_structure',
+            'conv_app_result',
+            'daily_summary',
+            'chat_responses',
+            'goals_advice',
+            'app_generator',
+            'persona_clone',
+            'persona_chat_premium',
+            'notifications',
+            'chat_graph',
+        ]:
+            assert bm[feature][0] == 'gpt-5.4', f'byok_max {feature} should be gpt-5.4, got {bm[feature][0]}'
+
+    def test_byok_max_uses_gpt54_mini_quality(self):
+        """byok_max upgrades quality tier to gpt-5.4-mini."""
+        bm = MODEL_QOS_PROFILES['byok_max']
+        for feature in [
+            'external_structure',
+            'memories',
+            'memory_conflict',
+            'knowledge_graph',
+            'chat_extraction',
+            'goals',
+            'proactive_notification',
+            'openglass',
+            'smart_glasses',
+        ]:
+            assert bm[feature][0] == 'gpt-5.4-mini', f'byok_max {feature} should be gpt-5.4-mini, got {bm[feature][0]}'
+
+    def test_byok_max_keeps_o4_mini_for_learnings(self):
+        """byok_max keeps o4-mini for learnings (reasoning model)."""
+        bm = MODEL_QOS_PROFILES['byok_max']
+        assert bm['learnings'] == ('o4-mini', 'openai')
+
+    def test_byok_high_model_variants(self):
+        """byok_high uses expected distinct model IDs."""
+        bh = MODEL_QOS_PROFILES['byok_high']
+        distinct = {model for model, _p in bh.values()}
+        expected = {
+            'gpt-5.4-mini',
+            'gpt-4.1',
+            'gpt-4.1-mini',
+            'claude-sonnet-4-6',
+            'gemini-3-flash-preview',
+            'sonar-pro',
+        }
+        assert distinct == expected
+
+    def test_byok_max_model_variants(self):
+        """byok_max uses expected distinct model IDs."""
+        bm = MODEL_QOS_PROFILES['byok_max']
+        distinct = {model for model, _p in bm.values()}
+        expected = {
+            'gpt-5.4',
+            'gpt-5.4-mini',
+            'gpt-4.1-mini',
+            'o4-mini',
+            'claude-sonnet-4-6',
+            'gemini-3-flash-preview',
+            'sonar-pro',
+        }
+        assert distinct == expected
+
+    def test_byok_profiles_have_same_features_as_premium(self):
+        """BYOK profiles must cover the same feature set as premium."""
+        premium_features = set(MODEL_QOS_PROFILES['premium'].keys())
+        for name in ('byok_high', 'byok_max'):
+            byok_features = set(MODEL_QOS_PROFILES[name].keys())
+            assert byok_features == premium_features, f'{name} features differ: {byok_features ^ premium_features}'
+
+
+class TestBYOKProfileResolution:
+    """Verify BYOK QoS profile selection at startup."""
+
+    def test_byok_profile_default_is_none(self):
+        """Without BYOK_QOS env var, _byok_profile should be None."""
+        assert _byok_profile is None or _byok_profile_name is not None
+
+    def test_byok_profile_selection_via_env(self):
+        """BYOK_QOS=byok_high should select the byok_high profile."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                'python3',
+                '-c',
+                (
+                    "import sys; from unittest.mock import MagicMock; "
+                    "[sys.modules.setdefault(m, MagicMock()) for m in "
+                    "['firebase_admin','firebase_admin.firestore','google.cloud.firestore',"
+                    "'google.cloud.firestore_v1','google.cloud.firestore_v1.base_query',"
+                    "'database','database._client','database.llm_usage']]; "
+                    "import os; os.environ['OPENAI_API_KEY']='sk-test'; "
+                    "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
+                    "os.environ['BYOK_QOS']='byok_high'; "
+                    "from utils.llm.clients import _byok_profile_name, _byok_profile; "
+                    "assert _byok_profile_name == 'byok_high', f'Expected byok_high, got {_byok_profile_name}'; "
+                    "assert _byok_profile is not None, 'byok_profile should not be None'"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(os.path.join(os.path.dirname(__file__), '..', '..')),
+        )
+        assert result.returncode == 0, f"byok profile test failed: {result.stderr}"
+
+    def test_invalid_byok_profile_disabled(self):
+        """BYOK_QOS=bogus should disable BYOK profile (set to None)."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                'python3',
+                '-c',
+                (
+                    "import sys; from unittest.mock import MagicMock; "
+                    "[sys.modules.setdefault(m, MagicMock()) for m in "
+                    "['firebase_admin','firebase_admin.firestore','google.cloud.firestore',"
+                    "'google.cloud.firestore_v1','google.cloud.firestore_v1.base_query',"
+                    "'database','database._client','database.llm_usage']]; "
+                    "import os; os.environ['OPENAI_API_KEY']='sk-test'; "
+                    "os.environ['ANTHROPIC_API_KEY']='sk-ant-test'; "
+                    "os.environ['BYOK_QOS']='bogus'; "
+                    "from utils.llm.clients import _byok_profile_name, _byok_profile; "
+                    "assert _byok_profile_name is None, f'Expected None, got {_byok_profile_name}'; "
+                    "assert _byok_profile is None, 'byok_profile should be None for invalid profile'"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(os.path.join(os.path.dirname(__file__), '..', '..')),
+        )
+        assert result.returncode == 0, f"invalid byok profile test failed: {result.stderr}"
+
+
+class TestEffectiveBYOKProvider:
+    """Verify _effective_byok_provider maps providers correctly."""
+
+    def test_openai_passthrough(self):
+        assert _effective_byok_provider('gpt-4.1-mini', 'openai') == 'openai'
+
+    def test_gemini_passthrough(self):
+        assert _effective_byok_provider('gemini-2.5-flash', 'gemini') == 'gemini'
+
+    def test_openrouter_gemini_maps_to_gemini(self):
+        assert _effective_byok_provider('gemini-3-flash-preview', 'openrouter') == 'gemini'
+
+    def test_openrouter_non_gemini_stays_openrouter(self):
+        assert _effective_byok_provider('anthropic/claude-3.5-sonnet', 'openrouter') == 'openrouter'
+
+    def test_anthropic_passthrough(self):
+        assert _effective_byok_provider('claude-sonnet-4-6', 'anthropic') == 'anthropic'
+
+    def test_perplexity_passthrough(self):
+        assert _effective_byok_provider('sonar-pro', 'perplexity') == 'perplexity'
+
+
+class TestStructuredOutputFeatureTracking:
+    """Verify structured output feature set matches actual usage."""
+
+    def test_expected_features_tracked(self):
+        expected = {'chat_extraction', 'proactive_notification', 'conv_app_select', 'external_structure', 'trends'}
+        assert _STRUCTURED_OUTPUT_FEATURES == expected
+
+    def test_tracked_features_exist_in_all_profiles(self):
+        for feature in _STRUCTURED_OUTPUT_FEATURES:
+            for profile_name, profile in MODEL_QOS_PROFILES.items():
+                assert feature in profile, f'{feature} missing from {profile_name}'
+
+    def test_premium_gemini_structured_output(self):
+        """In premium profile, only 'trends' uses structured_output on Gemini."""
+        premium = MODEL_QOS_PROFILES['premium']
+        gemini_so = {f for f in _STRUCTURED_OUTPUT_FEATURES if premium[f][1] == 'gemini'}
+        assert gemini_so == {'trends'}, f'Expected only trends on Gemini SO in premium, got {gemini_so}'
+
+    def test_premium1_gemini_structured_output(self):
+        """In premium1 profile, all structured output features are on Gemini."""
+        p1 = MODEL_QOS_PROFILES['premium1']
+        gemini_so = {f for f in _STRUCTURED_OUTPUT_FEATURES if p1[f][1] == 'gemini'}
+        assert gemini_so == _STRUCTURED_OUTPUT_FEATURES
+
+    def test_byok_profiles_no_gemini_structured_output(self):
+        """BYOK profiles route all structured output features to OpenAI (no Gemini compat risk)."""
+        for name in ('byok_high', 'byok_max'):
+            profile = MODEL_QOS_PROFILES[name]
+            for feature in _STRUCTURED_OUTPUT_FEATURES:
+                assert profile[feature][1] == 'openai', f'{name} {feature} should be openai, got {profile[feature][1]}'

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -58,8 +58,8 @@ from utils.llm.clients import (
 class TestModelQosProfiles:
     """Verify profile structure and completeness."""
 
-    def test_five_profiles_exist(self):
-        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'premium_0424', 'max', 'max_0424', 'byok'}
+    def test_four_profiles_exist(self):
+        assert set(MODEL_QOS_PROFILES.keys()) == {'premium', 'max', 'max_0424', 'byok'}
 
     def test_all_profiles_have_same_features(self):
         feature_sets = {name: set(profile.keys()) for name, profile in MODEL_QOS_PROFILES.items()}
@@ -82,7 +82,7 @@ class TestModelQosProfiles:
             providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
             assert 'openai' in providers, f'{name} missing OpenAI models'
         # Gemini-optimized profiles must have Gemini provider
-        for name in ('premium', 'premium_0424', 'max_0424'):
+        for name in ('premium', 'max_0424'):
             providers = {p for _m, p in MODEL_QOS_PROFILES[name].values()}
             assert 'gemini' in providers, f'{name} should have Gemini direct models'
 
@@ -106,12 +106,13 @@ class TestModelQosProfiles:
         assert premium['conv_app_select'] == ('gpt-4.1-nano', 'openai')
         # Vision features use gpt-4.1-mini on openai
         assert premium['openglass'] == ('gpt-4.1-mini', 'openai')
-        # Free-text features migrated to Gemini 2.5 Flash-Lite on gemini provider
+        # Free-text features use Gemini 2.5 Flash-Lite on gemini provider
         assert premium['session_titles'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['followup'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['onboarding'] == ('gemini-2.5-flash-lite', 'gemini')
-        assert premium['memory_category'] == ('gemini-2.5-flash-lite', 'gemini')
-        assert premium['daily_summary_simple'] == ('gemini-2.5-flash-lite', 'gemini')
+        # Simple classification uses gpt-4.1-nano on openai
+        assert premium['memory_category'] == ('gpt-4.1-nano', 'openai')
+        assert premium['daily_summary_simple'] == ('gpt-4.1-nano', 'openai')
         assert premium['app_integration'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['trends'] == ('gemini-2.5-flash-lite', 'gemini')
         # Anthropic & Perplexity with explicit provider
@@ -163,38 +164,6 @@ class TestModelQosProfiles:
             'sonar-pro',
         }
         assert distinct_models == expected
-
-    def test_premium_0424_all_gemini_except_special(self):
-        """premium_0424 should route everything to Gemini except chat_agent/web_search/wrapped_analysis."""
-        p1 = MODEL_QOS_PROFILES['premium_0424']
-        for feature, (model, provider) in p1.items():
-            if feature in ('chat_agent', 'web_search', 'wrapped_analysis'):
-                continue
-            assert provider == 'gemini', f'premium_0424 {feature} should be gemini, got {provider}'
-
-    def test_premium_0424_model_tiers(self):
-        """premium_0424 uses 3 Gemini tiers: pro (flagship), flash (quality), flash-lite (simple)."""
-        p1 = MODEL_QOS_PROFILES['premium_0424']
-        assert p1['conv_action_items'] == ('gemini-2.5-pro', 'gemini')
-        assert p1['chat_responses'] == ('gemini-2.5-pro', 'gemini')
-        assert p1['memories'] == ('gemini-2.5-flash', 'gemini')
-        assert p1['chat_extraction'] == ('gemini-2.5-flash', 'gemini')
-        assert p1['conv_folder'] == ('gemini-2.5-flash-lite', 'gemini')
-        assert p1['session_titles'] == ('gemini-2.5-flash-lite', 'gemini')
-
-    def test_premium_0424_model_variants(self):
-        """premium_0424 uses 6 distinct model IDs."""
-        p1 = MODEL_QOS_PROFILES['premium_0424']
-        distinct = {model for model, _p in p1.values()}
-        expected = {
-            'gemini-2.5-pro',
-            'gemini-2.5-flash',
-            'gemini-2.5-flash-lite',
-            'claude-sonnet-4-6',
-            'gemini-3-flash-preview',
-            'sonar-pro',
-        }
-        assert distinct == expected
 
     def test_max_0424_keeps_o4_mini_for_learnings(self):
         """max_0424 keeps o4-mini for learnings (reasoning model, no Gemini equivalent)."""
@@ -1023,12 +992,6 @@ class TestStructuredOutputFeatureTracking:
         premium = MODEL_QOS_PROFILES['premium']
         gemini_so = {f for f in _STRUCTURED_OUTPUT_FEATURES if premium[f][1] == 'gemini'}
         assert gemini_so == {'trends'}, f'Expected only trends on Gemini SO in premium, got {gemini_so}'
-
-    def test_premium_0424_gemini_structured_output(self):
-        """In premium_0424 profile, all structured output features are on Gemini."""
-        p1 = MODEL_QOS_PROFILES['premium_0424']
-        gemini_so = {f for f in _STRUCTURED_OUTPUT_FEATURES if p1[f][1] == 'gemini'}
-        assert gemini_so == _STRUCTURED_OUTPUT_FEATURES
 
     def test_byok_no_gemini_structured_output(self):
         """BYOK profile routes all structured output features to OpenAI (no Gemini compat risk)."""

--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -259,16 +259,15 @@ class TestPromptCacheRetention:
         clients_path = Path(__file__).resolve().parent.parent.parent / "utils" / "llm" / "clients.py"
         return clients_path.read_text()
 
-    def test_llm_medium_experiment_has_cache_retention(self):
-        """llm_medium_experiment must have extra_body with prompt_cache_retention=24h."""
+    def test_qos_gpt51_has_cache_retention(self):
+        """QoS _get_or_create_openai_llm must set prompt_cache_retention=24h for gpt-5.1."""
         source = self._read_clients_source()
-        # Find the llm_medium_experiment definition block and check extra_body
         match = re.search(
-            r'llm_medium_experiment\s*=.*?extra_body\s*=\s*\{[^}]*"prompt_cache_retention"\s*:\s*"24h"',
+            r"_get_or_create_openai_llm.*?gpt-5\.1.*?prompt_cache_retention.*?24h",
             source,
             re.DOTALL,
         )
-        assert match, "llm_medium_experiment missing extra_body with prompt_cache_retention='24h'"
+        assert match, "_get_or_create_openai_llm should set prompt_cache_retention='24h' for gpt-5.1"
 
     def test_qos_tier_medium_gets_cache_retention(self):
         """Omi QoS tier medium (gpt-5.1) must set prompt_cache_retention=24h via _get_or_create_openai_llm."""

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -170,7 +170,6 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 # Profiles:
 #   premium  — maximize cost savings while preserving 80% of max quality
 #   max      — 100% quality, best models available, no cost optimization
-#   max_0424 — preserve 100% quality on Gemini models for cost savings
 #   byok     — BYOK users get max quality (they pay their own API costs)
 # ---------------------------------------------------------------------------
 
@@ -274,54 +273,6 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         # OpenRouter
         'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         # Perplexity
-        'web_search': ('sonar-pro', 'perplexity'),
-    },
-    # -----------------------------------------------------------------------
-    # max_0424 — preserve 100% quality on Gemini for cost savings.
-    # Release April 24 2026. Uses gemini-2.5-pro for flagship,
-    # gemini-2.5-flash (not flash-lite) for quality tier to match max quality,
-    # keeps o4-mini for reasoning (no Gemini equivalent).
-    # -----------------------------------------------------------------------
-    'max_0424': {
-        # Gemini 2.5 Pro — flagship tier (replaces gpt-5.4)
-        'conv_action_items': ('gemini-2.5-pro', 'gemini'),
-        'conv_structure': ('gemini-2.5-pro', 'gemini'),
-        'conv_app_result': ('gemini-2.5-pro', 'gemini'),
-        'daily_summary': ('gemini-2.5-pro', 'gemini'),
-        'chat_responses': ('gemini-2.5-pro', 'gemini'),
-        'goals_advice': ('gemini-2.5-pro', 'gemini'),
-        'app_generator': ('gemini-2.5-pro', 'gemini'),
-        'persona_clone': ('gemini-2.5-pro', 'gemini'),
-        'persona_chat_premium': ('gemini-2.5-pro', 'gemini'),
-        'chat_graph': ('gemini-2.5-pro', 'gemini'),  # was gpt-4.1 in max
-        # Gemini 2.5 Flash — quality-sensitive (replaces gpt-4.1-mini)
-        'external_structure': ('gemini-2.5-flash', 'gemini'),  # [SO]
-        'memories': ('gemini-2.5-flash', 'gemini'),
-        'memory_conflict': ('gemini-2.5-flash', 'gemini'),
-        'memory_category': ('gemini-2.5-flash', 'gemini'),
-        'knowledge_graph': ('gemini-2.5-flash', 'gemini'),
-        'chat_extraction': ('gemini-2.5-flash', 'gemini'),  # [SO]
-        'daily_summary_simple': ('gemini-2.5-flash', 'gemini'),
-        'goals': ('gemini-2.5-flash', 'gemini'),
-        'proactive_notification': ('gemini-2.5-flash', 'gemini'),  # [SO]
-        'notifications': ('gemini-2.5-flash', 'gemini'),
-        'openglass': ('gemini-2.5-flash', 'gemini'),
-        'smart_glasses': ('gemini-2.5-flash', 'gemini'),
-        'session_titles': ('gemini-2.5-flash', 'gemini'),
-        'followup': ('gemini-2.5-flash', 'gemini'),
-        'onboarding': ('gemini-2.5-flash', 'gemini'),
-        'app_integration': ('gemini-2.5-flash', 'gemini'),
-        # OpenAI reasoning (no Gemini equivalent for chain-of-thought)
-        'learnings': ('o4-mini', 'openai'),
-        # Gemini 2.5 Flash-Lite — simple tasks (replaces gpt-4.1-nano)
-        'conv_app_select': ('gemini-2.5-flash-lite', 'gemini'),  # [SO]
-        'conv_folder': ('gemini-2.5-flash-lite', 'gemini'),
-        'conv_discard': ('gemini-2.5-flash-lite', 'gemini'),
-        'trends': ('gemini-2.5-flash-lite', 'gemini'),  # [SO]
-        'persona_chat': ('gemini-2.5-flash-lite', 'gemini'),
-        # Keep on original provider
-        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
-        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -146,24 +146,16 @@ def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict
             return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
     elif provider == 'openrouter':
-        # Only reroute to Gemini direct if the model is actually Gemini-based
+        # Only Gemini-based OpenRouter models support BYOK reroute to Gemini direct
         bare_model = model.split('/', 1)[1] if '/' in model else model
-        is_gemini_model = bare_model.startswith('gemini')
-
-        if is_gemini_model:
+        if bare_model.startswith('gemini'):
 
             def _factory(byok_key: str) -> ChatOpenAI:
                 return _cached_openai_chat(bare_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
             return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
-        else:
-            # Non-Gemini OpenRouter model: BYOK stays on OpenRouter
-            def _factory(byok_key: str) -> ChatOpenAI:
-                return _cached_openai_chat(
-                    model, byok_key, {**clean_kwargs, 'base_url': 'https://openrouter.ai/api/v1'}
-                )
-
-            return _BYOKChatWrapper(default=default, provider='openrouter', byok_factory=_factory)
+        # Non-Gemini OpenRouter: no BYOK support, always use Omi's key
+        return default
     else:
         # OpenAI and any future OpenAI-compatible provider
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import anthropic
 import httpx
@@ -19,54 +19,47 @@ logger = logging.getLogger(__name__)
 _usage_callback = get_usage_callback()
 
 # ---------------------------------------------------------------------------
-# BYOK routing proxies
+# BYOK wrappers — generic, provider-agnostic
 #
-# All LLM features are routed through get_llm(feature) / get_model(feature).
-# Each proxy wraps a default client and transparently resolves to either
-# the default or a BYOK-keyed client at call time. `__getattr__` forwards
-# `bind_tools`, `with_structured_output`, `|` chaining, etc. to the resolved
-# client so tool-use/structured-output still route correctly.
+# BYOK is a per-request feature that substitutes the user's own API key.
+# Wrappers sit on top of the QoS routing layer — they are not the base.
+# The QoS layer creates a plain client, then optionally wraps it with BYOK.
 # ---------------------------------------------------------------------------
 
+# Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
+# as the client class while routing to Gemini directly — no new langchain dep.
+_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
-class _BYOKChatProxy:
-    """Base class for transparent BYOK-aware ChatOpenAI proxies.
 
-    Subclasses only need to implement _resolve() — all attribute forwarding
-    and LangChain pipe composition is handled here.
+class _BYOKChatWrapper:
+    """Wraps any ChatOpenAI client with per-request BYOK key substitution.
+
+    NOT a base class. A decorator/wrapper applied by get_llm() on top of
+    provider-specific clients. The provider tag determines which BYOK key
+    pool to check. The byok_factory constructs a BYOK-keyed client when needed.
     """
 
-    __slots__ = ('_model', '_default', '_ctor_kwargs')
+    __slots__ = ('_default', '_provider', '_byok_factory')
 
-    def __init__(self, model: str, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
-        object.__setattr__(self, '_model', model)
+    def __init__(self, default: ChatOpenAI, provider: str, byok_factory: Callable[[str], ChatOpenAI]):
         object.__setattr__(self, '_default', default)
-        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+        object.__setattr__(self, '_provider', provider)
+        object.__setattr__(self, '_byok_factory', byok_factory)
 
     def _resolve(self) -> ChatOpenAI:
-        raise NotImplementedError
+        byok = get_byok_key(self._provider)
+        if byok:
+            return self._byok_factory(byok)
+        return self._default
 
     def __getattr__(self, name: str):
         return getattr(self._resolve(), name)
 
-    # Needed for `prompt | model | parser`-style chain composition.
     def __or__(self, other):
         return self._resolve() | other
 
     def __ror__(self, other):
         return other | self._resolve()
-
-
-class _OpenAIChatProxy(_BYOKChatProxy):
-    """Routes to BYOK OpenAI when set, otherwise uses default OpenAI client."""
-
-    __slots__ = ()
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('openai')
-        if byok:
-            return _cached_openai_chat(self._model, byok, self._ctor_kwargs)
-        return self._default
 
 
 class _AnthropicClientProxy:
@@ -85,35 +78,6 @@ class _AnthropicClientProxy:
 
     def __getattr__(self, name: str):
         return getattr(self._resolve(), name)
-
-
-# Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
-# as the client class while routing to Gemini directly — no new langchain dep.
-_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
-
-
-class _OpenRouterGeminiProxy(_BYOKChatProxy):
-    """Routes OpenRouter Gemini models to Google direct when BYOK Gemini is set.
-
-    Falls back to the OpenRouter-backed default client when no BYOK gemini key
-    is present — so non-BYOK users are unaffected.
-    """
-
-    __slots__ = ('_direct_model',)
-
-    def __init__(self, default: ChatOpenAI, direct_model: str, ctor_kwargs: Dict[str, Any]):
-        super().__init__(model=direct_model, default=default, ctor_kwargs=ctor_kwargs)
-        object.__setattr__(self, '_direct_model', direct_model)
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('gemini')
-        if byok:
-            return _cached_openai_chat(
-                self._direct_model,
-                byok,
-                {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
-            )
-        return self._default
 
 
 class _OpenAIEmbeddingsProxy:
@@ -171,10 +135,28 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
     return inst
 
 
-def _byok_openai(model: str, **ctor_kwargs) -> _OpenAIChatProxy:
-    """Build a module-level ChatOpenAI that transparently routes to BYOK if set."""
-    default = ChatOpenAI(model=model, **ctor_kwargs)
-    return _OpenAIChatProxy(model=model, default=default, ctor_kwargs=ctor_kwargs)
+def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict[str, Any]) -> _BYOKChatWrapper:
+    """Wrap a ChatOpenAI client with BYOK resolution for the given provider."""
+    if provider == 'gemini':
+
+        def _factory(byok_key: str) -> ChatOpenAI:
+            return _cached_openai_chat(model, byok_key, {**ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+
+    elif provider == 'openrouter':
+        # OpenRouter Gemini models: BYOK gemini key routes to Google direct
+        direct_model = model.split('/', 1)[1] if '/' in model else model
+
+        def _factory(byok_key: str) -> ChatOpenAI:
+            return _cached_openai_chat(direct_model, byok_key, {**ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+
+        return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
+    else:
+        # OpenAI and any future OpenAI-compatible provider
+
+        def _factory(byok_key: str) -> ChatOpenAI:
+            return _cached_openai_chat(model, byok_key, ctor_kwargs)
+
+    return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory)
 
 
 # Anthropic client for chat agent (module-level, BYOK-aware)
@@ -198,131 +180,138 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 # ---------------------------------------------------------------------------
 # Model QoS Profile System
 #
-# Each profile maps every feature to a specific model. Features span multiple
-# providers (OpenAI, Anthropic, OpenRouter, Perplexity). Within a profile,
-# each feature gets the model appropriate for that cost/quality level.
+# Each profile maps every feature to a (model, provider) tuple.
+# The profile is the SINGLE SOURCE OF TRUTH for both model and provider.
+# Provider is never inferred from model name — it is declared explicitly.
+#
+# This means the same model can be hosted by different providers:
+#   feature_a: ('gemini-2.5-flash', 'gemini')      → Google direct
+#   feature_b: ('gemini-2.5-flash', 'openrouter')   → OpenRouter
 #
 # Global switch:     MODEL_QOS=premium        (selects entire profile)
-# Per-feature:       MODEL_QOS_CHAT_AGENT=claude-haiku-3.5  (overrides one feature)
+# Per-feature:       MODEL_QOS_FOLLOWUP=gpt-4.1-nano:openai  (model:provider)
+#                    MODEL_QOS_FOLLOWUP=gpt-4.1-nano          (model only, inherits provider)
 #
 # Two profiles:
 #   premium — cost-effective default (80% of max quality)
 #   max     — maximum quality, latest flagship models
 # ---------------------------------------------------------------------------
 
-MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
+MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
     'premium': {
         # OpenAI — conversation processing
-        'conv_action_items': 'gpt-5.4-mini',
-        'conv_structure': 'gpt-5.4-mini',
-        'conv_app_result': 'gpt-5.4-mini',
-        'conv_app_select': 'gpt-4.1-nano',
-        'conv_folder': 'gpt-4.1-nano',
-        'conv_discard': 'gpt-4.1-nano',
-        'daily_summary': 'gpt-5.4-mini',
-        'daily_summary_simple': 'gemini-2.5-flash-lite',  # free-text stats → Gemini (75% savings vs mini)
-        'external_structure': 'gpt-4.1-mini',  # quality-sensitive: structuring external data
+        'conv_action_items': ('gpt-5.4-mini', 'openai'),
+        'conv_structure': ('gpt-5.4-mini', 'openai'),
+        'conv_app_result': ('gpt-5.4-mini', 'openai'),
+        'conv_app_select': ('gpt-4.1-nano', 'openai'),
+        'conv_folder': ('gpt-4.1-nano', 'openai'),
+        'conv_discard': ('gpt-4.1-nano', 'openai'),
+        'daily_summary': ('gpt-5.4-mini', 'openai'),
+        'daily_summary_simple': ('gemini-2.5-flash-lite', 'gemini'),
+        'external_structure': ('gpt-4.1-mini', 'openai'),
         # OpenAI — memories & knowledge
-        'memories': 'gpt-4.1-mini',  # quality-sensitive: memory extraction
-        'learnings': 'gpt-5.4-mini',
-        'memory_conflict': 'gpt-4.1-mini',  # quality-sensitive: conflict detection
-        'memory_category': 'gemini-2.5-flash-lite',  # text enum classification → Gemini (75% savings vs mini)
-        'knowledge_graph': 'gpt-4.1-mini',  # quality-sensitive: entity/relationship extraction
+        'memories': ('gpt-4.1-mini', 'openai'),
+        'learnings': ('gpt-5.4-mini', 'openai'),
+        'memory_conflict': ('gpt-4.1-mini', 'openai'),
+        'memory_category': ('gemini-2.5-flash-lite', 'gemini'),
+        'knowledge_graph': ('gpt-4.1-mini', 'openai'),
         # OpenAI — chat
-        'chat_responses': 'gpt-5.4-mini',
-        'chat_extraction': 'gpt-4.1-mini',  # quality-sensitive: structured data extraction
-        'chat_graph': 'gpt-4.1-mini',  # quality-sensitive: graph queries
-        'session_titles': 'gemini-2.5-flash-lite',  # free text title → Gemini (75% savings vs mini)
-        # OpenAI — features
-        'goals': 'gpt-4.1-mini',  # quality-sensitive: goal analysis
-        'goals_advice': 'gpt-5.4-mini',
-        'notifications': 'gpt-5.4-mini',
-        'proactive_notification': 'gpt-4.1-mini',  # quality-sensitive: notification decisions
-        'followup': 'gemini-2.5-flash-lite',  # free text question → Gemini (75% savings vs mini)
-        'smart_glasses': 'gpt-4.1-nano',
-        'openglass': 'gpt-4.1-mini',  # vision: image description from smart glasses
-        'onboarding': 'gemini-2.5-flash-lite',  # boolean yes/no check → Gemini (75% savings vs mini)
-        'app_generator': 'gpt-5.4-mini',
-        'app_integration': 'gemini-2.5-flash-lite',  # simple routing → Gemini (75% savings vs mini)
-        'persona_clone': 'gpt-5.4-mini',
-        'trends': 'gemini-2.5-flash-lite',  # simple pattern analysis → Gemini (75% savings vs mini)
-        # Anthropic (chat_agent — used via get_model() + anthropic_client)
-        'chat_agent': 'claude-sonnet-4-6',
-        # OpenAI — persona
-        'persona_chat': 'gpt-4.1-nano',
-        'persona_chat_premium': 'gpt-5.4-mini',
-        # OpenRouter — wrapped_analysis only (gemini-3-flash-preview still active)
-        'wrapped_analysis': 'google/gemini-3-flash-preview',
+        'chat_responses': ('gpt-5.4-mini', 'openai'),
+        'chat_extraction': ('gpt-4.1-mini', 'openai'),
+        'chat_graph': ('gpt-4.1-mini', 'openai'),
+        'session_titles': ('gemini-2.5-flash-lite', 'gemini'),
+        # Features
+        'goals': ('gpt-4.1-mini', 'openai'),
+        'goals_advice': ('gpt-5.4-mini', 'openai'),
+        'notifications': ('gpt-5.4-mini', 'openai'),
+        'proactive_notification': ('gpt-4.1-mini', 'openai'),
+        'followup': ('gemini-2.5-flash-lite', 'gemini'),
+        'smart_glasses': ('gpt-4.1-nano', 'openai'),
+        'openglass': ('gpt-4.1-mini', 'openai'),
+        'onboarding': ('gemini-2.5-flash-lite', 'gemini'),
+        'app_generator': ('gpt-5.4-mini', 'openai'),
+        'app_integration': ('gemini-2.5-flash-lite', 'gemini'),
+        'persona_clone': ('gpt-5.4-mini', 'openai'),
+        'trends': ('gemini-2.5-flash-lite', 'gemini'),
+        # Anthropic (used via get_model() + anthropic_client)
+        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        # Persona
+        'persona_chat': ('gpt-4.1-nano', 'openai'),
+        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
+        # OpenRouter
+        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         # Perplexity
-        'web_search': 'sonar-pro',
+        'web_search': ('sonar-pro', 'perplexity'),
     },
     'max': {
-        # OpenAI — conversation processing (gpt-5.4 replaces gpt-5.1/5.2, rest unchanged)
-        'conv_action_items': 'gpt-5.4',
-        'conv_structure': 'gpt-5.4',
-        'conv_app_result': 'gpt-5.4',
-        'conv_app_select': 'gpt-4.1-mini',
-        'conv_folder': 'gpt-4.1-mini',
-        'conv_discard': 'gpt-4.1-mini',
-        'daily_summary': 'gpt-5.4',
-        'daily_summary_simple': 'gpt-4.1-mini',
-        'external_structure': 'gpt-4.1-mini',
-        # OpenAI — memories & knowledge (unchanged from production)
-        'memories': 'gpt-4.1-mini',
-        'learnings': 'o4-mini',
-        'memory_conflict': 'gpt-4.1-mini',
-        'memory_category': 'gpt-4.1-mini',
-        'knowledge_graph': 'gpt-4.1-mini',
-        # OpenAI — chat (gpt-5.4 replaces gpt-5.2, rest unchanged)
-        'chat_responses': 'gpt-5.4',
-        'chat_extraction': 'gpt-4.1-mini',
-        'chat_graph': 'gpt-4.1',
-        'session_titles': 'gpt-4.1-mini',
-        # OpenAI — features (gpt-5.4 replaces gpt-5.2/5.1, rest unchanged)
-        'goals': 'gpt-4.1-mini',
-        'goals_advice': 'gpt-5.4',
-        'notifications': 'gpt-5.4',
-        'proactive_notification': 'gpt-4.1-mini',
-        'followup': 'gpt-4.1-mini',
-        'smart_glasses': 'gpt-4.1-mini',
-        'openglass': 'gpt-4.1-mini',  # vision: image description from smart glasses
-        'onboarding': 'gpt-4.1-mini',
-        'app_generator': 'gpt-5.4',
-        'app_integration': 'gpt-4.1-mini',
-        'persona_clone': 'gpt-5.4',
-        'trends': 'gpt-4.1-mini',
-        # Anthropic (unchanged)
-        'chat_agent': 'claude-sonnet-4-6',
-        # OpenAI — persona (moved from deprecated OpenRouter models to direct API)
-        'persona_chat': 'gpt-4.1-nano',
-        'persona_chat_premium': 'gpt-5.4-mini',
-        # OpenRouter — wrapped_analysis only (gemini-3-flash-preview still active)
-        'wrapped_analysis': 'google/gemini-3-flash-preview',
-        # Perplexity (unchanged)
-        'web_search': 'sonar-pro',
+        # OpenAI — conversation processing
+        'conv_action_items': ('gpt-5.4', 'openai'),
+        'conv_structure': ('gpt-5.4', 'openai'),
+        'conv_app_result': ('gpt-5.4', 'openai'),
+        'conv_app_select': ('gpt-4.1-mini', 'openai'),
+        'conv_folder': ('gpt-4.1-mini', 'openai'),
+        'conv_discard': ('gpt-4.1-mini', 'openai'),
+        'daily_summary': ('gpt-5.4', 'openai'),
+        'daily_summary_simple': ('gpt-4.1-mini', 'openai'),
+        'external_structure': ('gpt-4.1-mini', 'openai'),
+        # OpenAI — memories & knowledge
+        'memories': ('gpt-4.1-mini', 'openai'),
+        'learnings': ('o4-mini', 'openai'),
+        'memory_conflict': ('gpt-4.1-mini', 'openai'),
+        'memory_category': ('gpt-4.1-mini', 'openai'),
+        'knowledge_graph': ('gpt-4.1-mini', 'openai'),
+        # OpenAI — chat
+        'chat_responses': ('gpt-5.4', 'openai'),
+        'chat_extraction': ('gpt-4.1-mini', 'openai'),
+        'chat_graph': ('gpt-4.1', 'openai'),
+        'session_titles': ('gpt-4.1-mini', 'openai'),
+        # Features
+        'goals': ('gpt-4.1-mini', 'openai'),
+        'goals_advice': ('gpt-5.4', 'openai'),
+        'notifications': ('gpt-5.4', 'openai'),
+        'proactive_notification': ('gpt-4.1-mini', 'openai'),
+        'followup': ('gpt-4.1-mini', 'openai'),
+        'smart_glasses': ('gpt-4.1-mini', 'openai'),
+        'openglass': ('gpt-4.1-mini', 'openai'),
+        'onboarding': ('gpt-4.1-mini', 'openai'),
+        'app_generator': ('gpt-5.4', 'openai'),
+        'app_integration': ('gpt-4.1-mini', 'openai'),
+        'persona_clone': ('gpt-5.4', 'openai'),
+        'trends': ('gpt-4.1-mini', 'openai'),
+        # Anthropic
+        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        # Persona
+        'persona_chat': ('gpt-4.1-nano', 'openai'),
+        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
+        # OpenRouter
+        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
+        # Perplexity
+        'web_search': ('sonar-pro', 'perplexity'),
     },
 }
 
-# Pinned features — model is fixed regardless of profile or env override.
-_PINNED_FEATURES: Dict[str, str] = {
-    'fair_use': 'gpt-5.1',
+# Pinned features — (model, provider) fixed regardless of profile or env override.
+_PINNED_FEATURES: Dict[str, Tuple[str, str]] = {
+    'fair_use': ('gpt-5.1', 'openai'),
 }
 
-# Resolve active profile once at startup (kai: OnceLock/singleton pattern).
+# Resolve active profile once at startup.
 _active_profile_name = os.environ.get('MODEL_QOS', 'premium').strip().lower()
 if _active_profile_name not in MODEL_QOS_PROFILES:
     logger.warning('MODEL_QOS=%s is not a valid profile, falling back to premium', _active_profile_name)
     _active_profile_name = 'premium'
 _active_profile = MODEL_QOS_PROFILES[_active_profile_name]
 
-# Provider detection from model name — provider depends on profile, not feature.
-# A feature like persona_chat may be OpenRouter in premium but OpenAI in max.
-_ANTHROPIC_ONLY_FEATURES = {'chat_agent'}  # always Anthropic, used via get_model() + anthropic_client
-_PERPLEXITY_ONLY_FEATURES = {'web_search'}  # always Perplexity, used via get_model() + HTTP client
+# Features that can't go through get_llm() (non-ChatOpenAI providers).
+_ANTHROPIC_ONLY_FEATURES = {'chat_agent'}
+_PERPLEXITY_ONLY_FEATURES = {'web_search'}
 
 
 def _classify_provider(model: str) -> str:
-    """Classify provider from model name. Provider follows the model, not the feature."""
+    """Infer provider from model name. Used ONLY as fallback for env overrides
+    that don't specify an explicit provider (e.g. MODEL_QOS_X=gpt-4.1-mini).
+    Profile entries always have explicit provider — this is never used for them.
+    """
     if '/' in model:
         return 'openrouter'
     if model.startswith('claude'):
@@ -345,6 +334,45 @@ _OPENROUTER_TEMPERATURES: Dict[str, float] = {
 # Models that support OpenAI prompt caching (prompt_cache_key routing).
 _CACHE_KEY_MODELS = {'gpt-5.4', 'gpt-5.4-mini'}
 
+_DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
+
+
+def _get_model_config(feature: str) -> Tuple[str, str]:
+    """Get the (model, provider) tuple for a feature. Internal — used by get_llm/get_model/get_provider.
+
+    Resolution order: pinned > per-feature env override > active profile > fallback.
+    Env override format: MODEL_QOS_X=model:provider  or  MODEL_QOS_X=model (inherits profile provider).
+    """
+    if feature in _PINNED_FEATURES:
+        return _PINNED_FEATURES[feature]
+    env_key = f'MODEL_QOS_{feature.upper()}'
+    override = os.environ.get(env_key, '').strip()
+    if override:
+        # Parse model:provider format
+        if ':' in override:
+            parts = override.rsplit(':', 1)
+            override_model, override_provider = parts[0], parts[1]
+        else:
+            override_model = override
+            # Inherit provider from profile if not specified, fall back to inference
+            profile_entry = _active_profile.get(feature, _DEFAULT_CONFIG)
+            profile_provider = profile_entry[1]
+            override_provider = _classify_provider(override_model)
+            if override_provider != profile_provider:
+                logger.warning(
+                    'QoS override %s=%s (inferred provider: %s) differs from profile provider %s — '
+                    'use %s=%s:%s to be explicit',
+                    env_key,
+                    override,
+                    override_provider,
+                    profile_provider,
+                    env_key,
+                    override,
+                    override_provider,
+                )
+        return (override_model, override_provider)
+    return _active_profile.get(feature, _DEFAULT_CONFIG)
+
 
 def get_model(feature: str) -> str:
     """Get the model name for a feature from the active Model QoS profile.
@@ -358,41 +386,31 @@ def get_model(feature: str) -> str:
         Model name string (e.g. 'gpt-4.1-mini', 'claude-sonnet-4-6').
 
     Override via env var:
-        MODEL_QOS_CHAT_AGENT=claude-haiku-3.5
+        MODEL_QOS_CHAT_AGENT=claude-haiku-3.5:anthropic
         MODEL_QOS_CONV_STRUCTURE=gpt-5.1
     """
-    if feature in _PINNED_FEATURES:
-        return _PINNED_FEATURES[feature]
-    env_key = f'MODEL_QOS_{feature.upper()}'
-    override = os.environ.get(env_key, '').strip()
-    if override:
-        # Warn if override model doesn't match the feature's expected provider
-        profile_model = _active_profile.get(feature, 'gpt-4.1-mini')
-        expected_provider = _classify_provider(profile_model)
-        override_provider = _classify_provider(override)
-        if expected_provider != override_provider:
-            logger.warning(
-                'QoS override %s=%s (provider: %s) may be invalid — feature %s expects %s',
-                env_key,
-                override,
-                override_provider,
-                feature,
-                expected_provider,
-            )
-        return override
-    return _active_profile.get(feature, 'gpt-4.1-mini')
+    return _get_model_config(feature)[0]
+
+
+def get_provider(feature: str) -> str:
+    """Get the provider for a feature from the active Model QoS profile.
+
+    Returns:
+        Provider string: 'openai', 'gemini', 'openrouter', 'anthropic', 'perplexity'.
+    """
+    return _get_model_config(feature)[1]
 
 
 # ---------------------------------------------------------------------------
 # Client factories — provider-specific, cached per (model, streaming, provider)
-# QoS clients are BYOK-aware via _byok_openai / _OpenRouterGeminiProxy.
+# Each factory creates a plain ChatOpenAI, then wraps it with _BYOKChatWrapper.
 # ---------------------------------------------------------------------------
 
 _llm_cache: Dict[tuple, Any] = {}
 
 
-def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _OpenAIChatProxy:
-    """Get or create a BYOK-aware ChatOpenAI proxy for an OpenAI model."""
+def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _BYOKChatWrapper:
+    """Get or create a BYOK-wrapped ChatOpenAI for an OpenAI model."""
     key = (model_name, streaming, 'openai')
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
@@ -401,14 +419,21 @@ def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _Open
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        _llm_cache[key] = _byok_openai(model_name, **kwargs)
+        default = ChatOpenAI(model=model_name, **kwargs)
+        _llm_cache[key] = _wrap_byok(default, model_name, 'openai', kwargs)
     return _llm_cache[key]
 
 
 def _get_or_create_openrouter_llm(
     model_name: str, streaming: bool = False, temperature: Optional[float] = None
-) -> ChatOpenAI:
-    """Get or create a ChatOpenAI instance for an OpenRouter model."""
+) -> _BYOKChatWrapper:
+    """Get or create a BYOK-wrapped ChatOpenAI for an OpenRouter model.
+
+    Model names in the profile are bare (e.g. 'gemini-3-flash-preview').
+    OpenRouter API requires vendor prefix (e.g. 'google/gemini-3-flash-preview').
+    """
+    # OpenRouter requires vendor-prefixed model names for Google models.
+    api_model = f'google/{model_name}' if model_name.startswith('gemini') else model_name
     key = (model_name, streaming, 'openrouter', temperature)
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {
@@ -422,34 +447,13 @@ def _get_or_create_openrouter_llm(
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        # For Gemini models on OpenRouter, use proxy for BYOK Gemini routing
-        if model_name.startswith('google/gemini'):
-            direct_model = model_name.split('/', 1)[1]
-            default = ChatOpenAI(model=model_name, **kwargs)
-            _llm_cache[key] = _OpenRouterGeminiProxy(default=default, direct_model=direct_model, ctor_kwargs=kwargs)
-        else:
-            _llm_cache[key] = ChatOpenAI(model=model_name, **kwargs)
+        default = ChatOpenAI(model=api_model, **kwargs)
+        _llm_cache[key] = _wrap_byok(default, model_name, 'openrouter', kwargs)
     return _llm_cache[key]
 
 
-class _GeminiChatProxy(_BYOKChatProxy):
-    """Routes to BYOK Gemini when set, otherwise uses default Google OpenAI-compatible endpoint."""
-
-    __slots__ = ()
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('gemini')
-        if byok:
-            return _cached_openai_chat(
-                self._model,
-                byok,
-                {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
-            )
-        return self._default
-
-
-def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _GeminiChatProxy:
-    """Get or create a BYOK-aware ChatOpenAI proxy for a Gemini model via Google's OpenAI-compat endpoint."""
+def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOKChatWrapper:
+    """Get or create a BYOK-wrapped ChatOpenAI for a Gemini model via Google's OpenAI-compat endpoint."""
     key = (model_name, streaming, 'gemini')
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
@@ -462,20 +466,20 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _Gemi
             base_url=_GEMINI_OPENAI_BASE_URL,
             **kwargs,
         )
-        _llm_cache[key] = _GeminiChatProxy(model=model_name, default=default, ctor_kwargs=kwargs)
+        _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)
     return _llm_cache[key]
 
 
 def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> ChatOpenAI:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
-    Works for OpenAI, Gemini, and OpenRouter features (returns ChatOpenAI or BYOK proxy).
+    Works for OpenAI, Gemini, and OpenRouter features (returns ChatOpenAI or BYOK wrapper).
     For Anthropic/Perplexity, use get_model(feature) to get the model string.
 
     Args:
         feature: Feature name (e.g. 'conv_action_items', 'persona_chat').
         streaming: Whether to return a streaming-enabled client.
-        cache_key: Optional prompt cache routing key (OpenAI gpt-5.1 only).
+        cache_key: Optional prompt cache routing key (OpenAI gpt-5.4/5.4-mini only).
 
     Usage:
         llm = get_llm('conv_action_items', cache_key='omi-extract-actions')
@@ -493,10 +497,8 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
             f"Feature '{feature}' is Perplexity — use get_model('{feature}') with the Perplexity HTTP client instead of get_llm()"
         )
 
-    model = get_model(feature)
-    provider = _classify_provider(model)
+    model, provider = _get_model_config(feature)
 
-    # Reject models that can't be served via ChatOpenAI (Anthropic direct, Perplexity)
     if provider == 'anthropic':
         raise ValueError(
             f"Feature '{feature}' resolved to Anthropic model '{model}' — use get_model() with anthropic_client"
@@ -513,6 +515,7 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
     if provider == 'gemini':
         return _get_or_create_gemini_llm(model, streaming)
 
+    # Default: OpenAI
     llm = _get_or_create_openai_llm(model, streaming)
     if cache_key and model in _CACHE_KEY_MODELS:
         return llm.bind(prompt_cache_key=cache_key)
@@ -520,27 +523,27 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
 
 
 def get_qos_info() -> Dict[str, Dict[str, str]]:
-    """Return full feature→model mapping for the active profile (debugging/monitoring)."""
+    """Return full feature→(model, provider) mapping for the active profile (debugging/monitoring)."""
     info: Dict[str, Dict[str, str]] = {}
     all_features = set(_active_profile.keys()) | set(_PINNED_FEATURES.keys())
     for feature in sorted(all_features):
-        model = get_model(feature)
+        model, provider = _get_model_config(feature)
         info[feature] = {
             'model': model,
             'profile': _active_profile_name,
-            'provider': _classify_provider(model),
+            'provider': provider,
         }
     return info
 
 
-# Startup logging (kai: log active profile so cost issues are traceable).
+# Startup logging — log active profile so cost issues are traceable.
 logger.info('Model QoS profile=%s (%d features)', _active_profile_name, len(_active_profile))
-for _feat, _model in sorted(_active_profile.items()):
-    _resolved = get_model(_feat)
-    if _resolved != _model:
-        logger.info('  QoS %s: %s (override, profile default: %s)', _feat, _resolved, _model)
+for _feat, (_model, _provider) in sorted(_active_profile.items()):
+    _resolved_model = get_model(_feat)
+    if _resolved_model != _model:
+        logger.info('  QoS %s: %s [%s] (override, profile default: %s)', _feat, _resolved_model, _provider, _model)
     else:
-        logger.info('  QoS %s: %s', _feat, _resolved)
+        logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
 
 
 # ---------------------------------------------------------------------------
@@ -554,7 +557,8 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = get_model('chat_agent')
 # Legacy module-level alias (kept for test compatibility).
 # Production code should use get_llm(feature) exclusively.
 # ---------------------------------------------------------------------------
-llm_mini = _byok_openai('gpt-4.1-mini', callbacks=[_usage_callback])
+_llm_mini_default = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback])
+llm_mini = _wrap_byok(_llm_mini_default, 'gpt-4.1-mini', 'openai', {'callbacks': [_usage_callback]})
 
 # ---------------------------------------------------------------------------
 # Embeddings, parser, utilities

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -168,19 +168,18 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 # Global switch:     MODEL_QOS=premium        (selects entire profile)
 #
 # Profiles:
-#   premium      — maximize cost savings while preserving 80% of max quality
-#   premium_0424 — same 80% quality preservation as premium, migrated to Gemini for deeper savings
-#   max          — 100% quality, best models available, no cost optimization
-#   max_0424     — preserve 100% quality on Gemini models for cost savings
-#   byok         — BYOK users get max quality (they pay their own API costs)
+#   premium  — maximize cost savings while preserving 80% of max quality
+#   max      — 100% quality, best models available, no cost optimization
+#   max_0424 — preserve 100% quality on Gemini models for cost savings
+#   byok     — BYOK users get max quality (they pay their own API costs)
 # ---------------------------------------------------------------------------
 
 MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
     # -----------------------------------------------------------------------
     # premium — maximize cost savings while preserving 80% of max quality.
     # Uses gpt-5.4-mini (not gpt-5.4) for core features, gpt-4.1-mini (not gpt-4.1)
-    # for quality-sensitive tasks, gpt-4.1-nano for simple routing, and Gemini
-    # flash-lite for low-complexity text (summaries, categories, titles).
+    # for quality-sensitive tasks, gpt-4.1-nano for simple routing/classification,
+    # and Gemini flash-lite for low-complexity free-text (titles, followups, onboarding).
     # -----------------------------------------------------------------------
     'premium': {
         # OpenAI — conversation processing
@@ -191,13 +190,13 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'conv_folder': ('gpt-4.1-nano', 'openai'),
         'conv_discard': ('gpt-4.1-nano', 'openai'),
         'daily_summary': ('gpt-5.4-mini', 'openai'),
-        'daily_summary_simple': ('gemini-2.5-flash-lite', 'gemini'),
+        'daily_summary_simple': ('gpt-4.1-nano', 'openai'),
         'external_structure': ('gpt-4.1-mini', 'openai'),
         # OpenAI — memories & knowledge
         'memories': ('gpt-4.1-mini', 'openai'),
         'learnings': ('gpt-5.4-mini', 'openai'),
         'memory_conflict': ('gpt-4.1-mini', 'openai'),
-        'memory_category': ('gemini-2.5-flash-lite', 'gemini'),
+        'memory_category': ('gpt-4.1-nano', 'openai'),
         'knowledge_graph': ('gpt-4.1-mini', 'openai'),
         # OpenAI — chat
         'chat_responses': ('gpt-5.4-mini', 'openai'),
@@ -225,55 +224,6 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         # OpenRouter
         'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         # Perplexity
-        'web_search': ('sonar-pro', 'perplexity'),
-    },
-    # -----------------------------------------------------------------------
-    # premium_0424 — same 80% quality preservation as premium, migrated to Gemini
-    # for deeper cost savings. Release April 24 2026.
-    # gpt-5.4-mini→gemini-2.5-pro, gpt-4.1-mini→flash, gpt-4.1-nano→flash-lite.
-    #
-    # ⚠️  Features marked [SO] use with_structured_output(method="json_schema")
-    #     which may need method="function_calling" fallback on Gemini.
-    # -----------------------------------------------------------------------
-    'premium_0424': {
-        # Gemini 2.5 Pro — flagship tier (Phase 1+4: replaces gpt-5.4-mini)
-        'conv_action_items': ('gemini-2.5-pro', 'gemini'),  # PydanticOutputParser — safe
-        'conv_structure': ('gemini-2.5-pro', 'gemini'),  # PydanticOutputParser — safe
-        'conv_app_result': ('gemini-2.5-pro', 'gemini'),  # free-text
-        'daily_summary': ('gemini-2.5-pro', 'gemini'),  # free-text
-        'learnings': ('gemini-2.5-pro', 'gemini'),  # PydanticOutputParser — safe
-        'chat_responses': ('gemini-2.5-pro', 'gemini'),  # free-text streaming
-        'goals_advice': ('gemini-2.5-pro', 'gemini'),  # free-text
-        'app_generator': ('gemini-2.5-pro', 'gemini'),  # free-text
-        'persona_clone': ('gemini-2.5-pro', 'gemini'),  # free-text
-        'persona_chat_premium': ('gemini-2.5-pro', 'gemini'),  # free-text
-        # Gemini 2.5 Flash — quality-sensitive (Phase 3+4: replaces gpt-4.1-mini)
-        'external_structure': ('gemini-2.5-flash', 'gemini'),  # [SO] with_structured_output
-        'memories': ('gemini-2.5-flash', 'gemini'),  # PydanticOutputParser — safe
-        'memory_conflict': ('gemini-2.5-flash', 'gemini'),  # PydanticOutputParser — safe
-        'knowledge_graph': ('gemini-2.5-flash', 'gemini'),  # free-text
-        'chat_extraction': ('gemini-2.5-flash', 'gemini'),  # [SO] with_structured_output (10+ schemas)
-        'chat_graph': ('gemini-2.5-flash', 'gemini'),  # free-text
-        'goals': ('gemini-2.5-flash', 'gemini'),  # free-text
-        'proactive_notification': ('gemini-2.5-flash', 'gemini'),  # [SO] with_structured_output
-        'notifications': ('gemini-2.5-flash', 'gemini'),  # free-text
-        'openglass': ('gemini-2.5-flash', 'gemini'),  # free-text (vision)
-        'smart_glasses': ('gemini-2.5-flash', 'gemini'),  # free-text (vision/multimodal)
-        # Gemini 2.5 Flash-Lite — simple tasks (Phase 2+3: replaces gpt-4.1-nano)
-        'conv_app_select': ('gemini-2.5-flash-lite', 'gemini'),  # [SO] with_structured_output
-        'conv_folder': ('gemini-2.5-flash-lite', 'gemini'),  # PydanticOutputParser chain — safe
-        'conv_discard': ('gemini-2.5-flash-lite', 'gemini'),  # PydanticOutputParser chain — safe
-        'daily_summary_simple': ('gemini-2.5-flash-lite', 'gemini'),
-        'memory_category': ('gemini-2.5-flash-lite', 'gemini'),
-        'session_titles': ('gemini-2.5-flash-lite', 'gemini'),
-        'followup': ('gemini-2.5-flash-lite', 'gemini'),
-        'onboarding': ('gemini-2.5-flash-lite', 'gemini'),
-        'app_integration': ('gemini-2.5-flash-lite', 'gemini'),
-        'trends': ('gemini-2.5-flash-lite', 'gemini'),  # [SO] with_structured_output
-        'persona_chat': ('gemini-2.5-flash-lite', 'gemini'),
-        # Keep on original provider (no Gemini equivalent)
-        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
-        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -526,16 +526,22 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
 
     if provider == 'openrouter':
         temp = _OPENROUTER_TEMPERATURES.get(feature)
-        return _get_or_create_openrouter_llm(model, streaming, temp)
+        result = _get_or_create_openrouter_llm(model, streaming, temp)
+    elif provider == 'gemini':
+        result = _get_or_create_gemini_llm(model, streaming)
+    else:
+        # Default: OpenAI
+        result = _get_or_create_openai_llm(model, streaming)
 
-    if provider == 'gemini':
-        return _get_or_create_gemini_llm(model, streaming)
+    # Eagerly resolve BYOK wrapper so callers always get a proper Runnable.
+    # This is safe because get_llm() is called within the request handler
+    # where the BYOK contextvar is already set by the middleware.
+    if isinstance(result, _BYOKChatWrapper):
+        result = result._resolve()
 
-    # Default: OpenAI
-    llm = _get_or_create_openai_llm(model, streaming)
     if cache_key and model in _CACHE_KEY_MODELS:
-        return llm.bind(prompt_cache_key=cache_key)
-    return llm
+        return result.bind(prompt_cache_key=cache_key)
+    return result
 
 
 def get_qos_info() -> Dict[str, Dict[str, str]]:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -364,18 +364,27 @@ def _get_model_config(feature: str) -> Tuple[str, str]:
         if ':' in override:
             parts = override.rsplit(':', 1)
             override_model, override_provider = parts[0], parts[1]
+            inferred = _classify_provider(override_model)
             if override_provider not in _VALID_PROVIDERS:
                 logger.warning(
-                    'QoS override %s=%s has invalid provider %r — falling back to profile provider %s',
+                    'QoS override %s=%s has invalid provider %r — using inferred provider %s',
                     env_key,
                     override,
                     override_provider,
-                    profile_entry[1],
+                    inferred,
                 )
-                override_provider = profile_entry[1]
+                override_provider = inferred
+            elif override_provider != inferred:
+                logger.warning(
+                    'QoS override %s=%s: explicit provider %r does not match model (inferred %s) — using inferred',
+                    env_key,
+                    override,
+                    override_provider,
+                    inferred,
+                )
+                override_provider = inferred
         else:
             override_model = override
-            # Model-only override: infer provider from model name to maintain safety guards
             override_provider = _classify_provider(override_model)
         return (override_model, override_provider)
     return _active_profile.get(feature, _DEFAULT_CONFIG)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -363,6 +363,98 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         'web_search': ('sonar-pro', 'perplexity'),
     },
+    # -----------------------------------------------------------------------
+    # byok_high — quality-optimized for BYOK users (all OpenAI, upgraded tiers)
+    # BYOK users pay their own API costs, so we upgrade mid-tier models.
+    # Flagship: gpt-5.4-mini, Quality: gpt-4.1 (up from 4.1-mini), Simple: gpt-4.1-mini (up from nano)
+    # -----------------------------------------------------------------------
+    'byok_high': {
+        # gpt-5.4-mini — flagship (same quality as premium)
+        'conv_action_items': ('gpt-5.4-mini', 'openai'),
+        'conv_structure': ('gpt-5.4-mini', 'openai'),
+        'conv_app_result': ('gpt-5.4-mini', 'openai'),
+        'daily_summary': ('gpt-5.4-mini', 'openai'),
+        'learnings': ('gpt-5.4-mini', 'openai'),
+        'chat_responses': ('gpt-5.4-mini', 'openai'),
+        'goals_advice': ('gpt-5.4-mini', 'openai'),
+        'app_generator': ('gpt-5.4-mini', 'openai'),
+        'persona_clone': ('gpt-5.4-mini', 'openai'),
+        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
+        'notifications': ('gpt-5.4-mini', 'openai'),
+        # gpt-4.1 — quality tier (upgraded from gpt-4.1-mini)
+        'external_structure': ('gpt-4.1', 'openai'),
+        'memories': ('gpt-4.1', 'openai'),
+        'memory_conflict': ('gpt-4.1', 'openai'),
+        'knowledge_graph': ('gpt-4.1', 'openai'),
+        'chat_extraction': ('gpt-4.1', 'openai'),
+        'chat_graph': ('gpt-4.1', 'openai'),
+        'goals': ('gpt-4.1', 'openai'),
+        'proactive_notification': ('gpt-4.1', 'openai'),
+        'openglass': ('gpt-4.1', 'openai'),
+        # gpt-4.1-mini — simple tasks (upgraded from gpt-4.1-nano)
+        'conv_app_select': ('gpt-4.1-mini', 'openai'),
+        'conv_folder': ('gpt-4.1-mini', 'openai'),
+        'conv_discard': ('gpt-4.1-mini', 'openai'),
+        'smart_glasses': ('gpt-4.1-mini', 'openai'),
+        'persona_chat': ('gpt-4.1-mini', 'openai'),
+        'daily_summary_simple': ('gpt-4.1-mini', 'openai'),
+        'memory_category': ('gpt-4.1-mini', 'openai'),
+        'session_titles': ('gpt-4.1-mini', 'openai'),
+        'followup': ('gpt-4.1-mini', 'openai'),
+        'onboarding': ('gpt-4.1-mini', 'openai'),
+        'app_integration': ('gpt-4.1-mini', 'openai'),
+        'trends': ('gpt-4.1-mini', 'openai'),
+        # Keep on original provider
+        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
+        'web_search': ('sonar-pro', 'perplexity'),
+    },
+    # -----------------------------------------------------------------------
+    # byok_max — maximum quality for BYOK users (all OpenAI, top-tier models)
+    # gpt-5.4 flagship, gpt-5.4-mini quality, o4-mini reasoning, gpt-4.1-mini simple
+    # -----------------------------------------------------------------------
+    'byok_max': {
+        # gpt-5.4 — top-tier flagship
+        'conv_action_items': ('gpt-5.4', 'openai'),
+        'conv_structure': ('gpt-5.4', 'openai'),
+        'conv_app_result': ('gpt-5.4', 'openai'),
+        'daily_summary': ('gpt-5.4', 'openai'),
+        'chat_responses': ('gpt-5.4', 'openai'),
+        'goals_advice': ('gpt-5.4', 'openai'),
+        'app_generator': ('gpt-5.4', 'openai'),
+        'persona_clone': ('gpt-5.4', 'openai'),
+        'persona_chat_premium': ('gpt-5.4', 'openai'),
+        'notifications': ('gpt-5.4', 'openai'),
+        'chat_graph': ('gpt-5.4', 'openai'),
+        # o4-mini — reasoning tier
+        'learnings': ('o4-mini', 'openai'),
+        # gpt-5.4-mini — quality tier (upgraded from gpt-4.1-mini)
+        'external_structure': ('gpt-5.4-mini', 'openai'),
+        'memories': ('gpt-5.4-mini', 'openai'),
+        'memory_conflict': ('gpt-5.4-mini', 'openai'),
+        'knowledge_graph': ('gpt-5.4-mini', 'openai'),
+        'chat_extraction': ('gpt-5.4-mini', 'openai'),
+        'goals': ('gpt-5.4-mini', 'openai'),
+        'proactive_notification': ('gpt-5.4-mini', 'openai'),
+        'openglass': ('gpt-5.4-mini', 'openai'),
+        'smart_glasses': ('gpt-5.4-mini', 'openai'),
+        # gpt-4.1-mini — simple tasks (upgraded from gpt-4.1-nano)
+        'conv_app_select': ('gpt-4.1-mini', 'openai'),
+        'conv_folder': ('gpt-4.1-mini', 'openai'),
+        'conv_discard': ('gpt-4.1-mini', 'openai'),
+        'persona_chat': ('gpt-4.1-mini', 'openai'),
+        'daily_summary_simple': ('gpt-4.1-mini', 'openai'),
+        'memory_category': ('gpt-4.1-mini', 'openai'),
+        'session_titles': ('gpt-4.1-mini', 'openai'),
+        'followup': ('gpt-4.1-mini', 'openai'),
+        'onboarding': ('gpt-4.1-mini', 'openai'),
+        'app_integration': ('gpt-4.1-mini', 'openai'),
+        'trends': ('gpt-4.1-mini', 'openai'),
+        # Keep on original provider
+        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
+        'web_search': ('sonar-pro', 'perplexity'),
+    },
 }
 
 # Pinned features — (model, provider) fixed regardless of profile or env override.
@@ -376,6 +468,14 @@ if _active_profile_name not in MODEL_QOS_PROFILES:
     logger.warning('MODEL_QOS=%s is not a valid profile, falling back to premium', _active_profile_name)
     _active_profile_name = 'premium'
 _active_profile = MODEL_QOS_PROFILES[_active_profile_name]
+
+# BYOK QoS profile — when set, BYOK users get upgraded model routing.
+# Set BYOK_QOS=byok_high or BYOK_QOS=byok_max to enable.
+_byok_profile_name = os.environ.get('BYOK_QOS', '').strip().lower() or None
+if _byok_profile_name and _byok_profile_name not in MODEL_QOS_PROFILES:
+    logger.warning('BYOK_QOS=%s is not a valid profile, BYOK profile disabled', _byok_profile_name)
+    _byok_profile_name = None
+_byok_profile = MODEL_QOS_PROFILES.get(_byok_profile_name) if _byok_profile_name else None
 
 # Features that can't go through get_llm() (non-ChatOpenAI providers).
 _ANTHROPIC_ONLY_FEATURES = {'chat_agent'}
@@ -392,6 +492,15 @@ _OPENROUTER_TEMPERATURES: Dict[str, float] = {
 
 # Models that support OpenAI prompt caching (prompt_cache_key routing).
 _CACHE_KEY_MODELS = {'gpt-5.4', 'gpt-5.4-mini'}
+
+# Features that call .with_structured_output() — logged when resolving to Gemini for compat monitoring.
+_STRUCTURED_OUTPUT_FEATURES = {
+    'chat_extraction',
+    'proactive_notification',
+    'conv_app_select',
+    'external_structure',
+    'trends',
+}
 
 _DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
 
@@ -506,6 +615,13 @@ def _get_default_client(model: str, provider: str, streaming: bool, feature: str
     return _get_or_create_openai_llm(model, streaming)
 
 
+def _effective_byok_provider(model: str, provider: str) -> str:
+    """Map provider to the actual BYOK key type needed (Gemini-based OpenRouter → Gemini key)."""
+    if provider == 'openrouter' and model.startswith('gemini'):
+        return 'gemini'
+    return provider
+
+
 def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> ChatOpenAI:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
@@ -544,18 +660,30 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
             f"Feature '{feature}' resolved to Perplexity model '{model}' — use get_model() with Perplexity HTTP client"
         )
 
-    # Check for BYOK key — if the user provided their own key, create a
-    # per-request client instead of using the cached default.
-    # Safe because get_llm() runs within the request handler where the
-    # BYOK contextvar is already set by the middleware.
-    byok_provider = 'gemini' if provider == 'openrouter' and model.startswith('gemini') else provider
+    # Log structured output compatibility when feature resolves to Gemini
+    if feature in _STRUCTURED_OUTPUT_FEATURES and provider == 'gemini':
+        logger.debug(
+            'QoS structured_output on gemini: feature=%s model=%s profile=%s', feature, model, _active_profile_name
+        )
+
+    # BYOK resolution — if the user provided their own key, create a per-request client.
+    # When a BYOK QoS profile is configured, upgrade model selection for BYOK users.
+    byok_provider = _effective_byok_provider(model, provider)
     byok_key = get_byok_key(byok_provider)
+
+    if byok_key and _byok_profile:
+        # Try upgrading to BYOK profile's model selection
+        byok_model, byok_prov = _byok_profile.get(feature, (model, provider))
+        byok_prov_eff = _effective_byok_provider(byok_model, byok_prov)
+        byok_key_for_profile = get_byok_key(byok_prov_eff)
+        if byok_key_for_profile:
+            logger.debug('BYOK QoS upgrade: feature=%s %s/%s→%s/%s', feature, model, provider, byok_model, byok_prov)
+            model, provider = byok_model, byok_prov
+            byok_key = byok_key_for_profile
+
     if byok_key:
         byok_client = _create_byok_client(model, provider, byok_key, streaming, feature)
-        if byok_client is not None:
-            result = byok_client
-        else:
-            result = _get_default_client(model, provider, streaming, feature)
+        result = byok_client if byok_client is not None else _get_default_client(model, provider, streaming, feature)
     else:
         result = _get_default_client(model, provider, streaming, feature)
 
@@ -582,6 +710,15 @@ def get_qos_info() -> Dict[str, Dict[str, str]]:
 logger.info('Model QoS profile=%s (%d features)', _active_profile_name, len(_active_profile))
 for _feat, (_model, _provider) in sorted(_active_profile.items()):
     logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
+if _byok_profile_name:
+    logger.info('BYOK QoS profile=%s (%d features)', _byok_profile_name, len(_byok_profile))
+else:
+    logger.info('BYOK QoS profile=none (BYOK users use server profile)')
+
+# Log structured output features on Gemini for compatibility monitoring
+_so_gemini = {f for f in _STRUCTURED_OUTPUT_FEATURES if _active_profile.get(f, _DEFAULT_CONFIG)[1] == 'gemini'}
+if _so_gemini:
+    logger.info('Structured output features on Gemini: %s', ', '.join(sorted(_so_gemini)))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -21,20 +21,20 @@ _usage_callback = get_usage_callback()
 # ---------------------------------------------------------------------------
 # BYOK routing proxies
 #
-# The backend has ~50 call sites that use module-level `llm_medium`, `llm_mini`,
-# etc. directly (e.g. `llm_medium.invoke(prompt)` or `llm_medium.bind_tools(...).ainvoke(...)`).
-# Rewriting every site to go through a factory would be a massive sweep.
-#
-# Instead we wrap each default client in a transparent proxy: every attribute
-# access resolves to either the default client or a BYOK-keyed client built
-# on the fly, keyed by (model, api_key) so we build each BYOK client once.
-# `__getattr__` forwards `bind_tools`, `with_structured_output`, `|` chaining,
-# etc. to the resolved client so tool-use/structured-output still route right.
+# All LLM features are routed through get_llm(feature) / get_model(feature).
+# Each proxy wraps a default client and transparently resolves to either
+# the default or a BYOK-keyed client at call time. `__getattr__` forwards
+# `bind_tools`, `with_structured_output`, `|` chaining, etc. to the resolved
+# client so tool-use/structured-output still route correctly.
 # ---------------------------------------------------------------------------
 
 
-class _OpenAIChatProxy:
-    """Forwards every attribute and call to the appropriate ChatOpenAI for the request."""
+class _BYOKChatProxy:
+    """Base class for transparent BYOK-aware ChatOpenAI proxies.
+
+    Subclasses only need to implement _resolve() — all attribute forwarding
+    and LangChain pipe composition is handled here.
+    """
 
     __slots__ = ('_model', '_default', '_ctor_kwargs')
 
@@ -44,10 +44,7 @@ class _OpenAIChatProxy:
         object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
 
     def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('openai')
-        if byok:
-            return _cached_openai_chat(self._model, byok, self._ctor_kwargs)
-        return self._default
+        raise NotImplementedError
 
     def __getattr__(self, name: str):
         return getattr(self._resolve(), name)
@@ -58,6 +55,18 @@ class _OpenAIChatProxy:
 
     def __ror__(self, other):
         return other | self._resolve()
+
+
+class _OpenAIChatProxy(_BYOKChatProxy):
+    """Routes to BYOK OpenAI when set, otherwise uses default OpenAI client."""
+
+    __slots__ = ()
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('openai')
+        if byok:
+            return _cached_openai_chat(self._model, byok, self._ctor_kwargs)
+        return self._default
 
 
 class _AnthropicClientProxy:
@@ -83,19 +92,18 @@ class _AnthropicClientProxy:
 _GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 
-class _OpenRouterGeminiProxy:
-    """For models served via OpenRouter that we want to route direct when BYOK Gemini is set.
+class _OpenRouterGeminiProxy(_BYOKChatProxy):
+    """Routes OpenRouter Gemini models to Google direct when BYOK Gemini is set.
 
     Falls back to the OpenRouter-backed default client when no BYOK gemini key
     is present — so non-BYOK users are unaffected.
     """
 
-    __slots__ = ('_default', '_direct_model', '_ctor_kwargs')
+    __slots__ = ('_direct_model',)
 
     def __init__(self, default: ChatOpenAI, direct_model: str, ctor_kwargs: Dict[str, Any]):
-        object.__setattr__(self, '_default', default)
+        super().__init__(model=direct_model, default=default, ctor_kwargs=ctor_kwargs)
         object.__setattr__(self, '_direct_model', direct_model)
-        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
 
     def _resolve(self) -> ChatOpenAI:
         byok = get_byok_key('gemini')
@@ -106,15 +114,6 @@ class _OpenRouterGeminiProxy:
                 {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
             )
         return self._default
-
-    def __getattr__(self, name: str):
-        return getattr(self._resolve(), name)
-
-    def __or__(self, other):
-        return self._resolve() | other
-
-    def __ror__(self, other):
-        return other | self._resolve()
 
 
 class _OpenAIEmbeddingsProxy:
@@ -241,6 +240,7 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
         'proactive_notification': 'gpt-4.1-mini',  # quality-sensitive: notification decisions
         'followup': 'gemini-2.5-flash-lite',  # free text question → Gemini (75% savings vs mini)
         'smart_glasses': 'gpt-4.1-nano',
+        'openglass': 'gpt-4.1-mini',  # vision: image description from smart glasses
         'onboarding': 'gemini-2.5-flash-lite',  # boolean yes/no check → Gemini (75% savings vs mini)
         'app_generator': 'gpt-5.4-mini',
         'app_integration': 'gemini-2.5-flash-lite',  # simple routing → Gemini (75% savings vs mini)
@@ -285,6 +285,7 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
         'proactive_notification': 'gpt-4.1-mini',
         'followup': 'gpt-4.1-mini',
         'smart_glasses': 'gpt-4.1-mini',
+        'openglass': 'gpt-4.1-mini',  # vision: image description from smart glasses
         'onboarding': 'gpt-4.1-mini',
         'app_generator': 'gpt-5.4',
         'app_integration': 'gpt-4.1-mini',
@@ -431,15 +432,10 @@ def _get_or_create_openrouter_llm(
     return _llm_cache[key]
 
 
-class _GeminiChatProxy:
-    """Transparent BYOK-aware proxy for Gemini models via Google's OpenAI-compatible endpoint."""
+class _GeminiChatProxy(_BYOKChatProxy):
+    """Routes to BYOK Gemini when set, otherwise uses default Google OpenAI-compatible endpoint."""
 
-    __slots__ = ('_model', '_default', '_ctor_kwargs')
-
-    def __init__(self, model: str, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
-        object.__setattr__(self, '_model', model)
-        object.__setattr__(self, '_default', default)
-        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+    __slots__ = ()
 
     def _resolve(self) -> ChatOpenAI:
         byok = get_byok_key('gemini')
@@ -450,15 +446,6 @@ class _GeminiChatProxy:
                 {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
             )
         return self._default
-
-    def __getattr__(self, name: str):
-        return getattr(self._resolve(), name)
-
-    def __or__(self, other):
-        return self._resolve() | other
-
-    def __ror__(self, other):
-        return other | self._resolve()
 
 
 def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _GeminiChatProxy:
@@ -564,84 +551,10 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = get_model('chat_agent')
 
 
 # ---------------------------------------------------------------------------
-# Legacy model instances (for callsites not yet wired through get_llm)
-#
-# These are kept for backward compatibility with BYOK routing.
-# New code should use get_llm(feature) or get_model(feature) instead.
+# Legacy module-level alias (kept for test compatibility).
+# Production code should use get_llm(feature) exclusively.
 # ---------------------------------------------------------------------------
 llm_mini = _byok_openai('gpt-4.1-mini', callbacks=[_usage_callback])
-llm_mini_stream = _byok_openai(
-    'gpt-4.1-mini',
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-llm_large = _byok_openai('o1-preview', callbacks=[_usage_callback])
-llm_large_stream = _byok_openai(
-    'o1-preview',
-    streaming=True,
-    stream_options={"include_usage": True},
-    temperature=1,
-    callbacks=[_usage_callback],
-)
-llm_high = _byok_openai('o4-mini', callbacks=[_usage_callback])
-llm_high_stream = _byok_openai(
-    'o4-mini',
-    streaming=True,
-    stream_options={"include_usage": True},
-    temperature=1,
-    callbacks=[_usage_callback],
-)
-llm_medium = _byok_openai('gpt-5.2', callbacks=[_usage_callback])
-llm_medium_stream = _byok_openai(
-    'gpt-5.2',
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-llm_medium_experiment = _byok_openai(
-    'gpt-5.1',
-    extra_body={"prompt_cache_retention": "24h"},
-    callbacks=[_usage_callback],
-)
-
-# Specialized models for agentic workflows
-# prompt_cache_key ensures consistent routing to the same cache machine
-# for better prompt prefix cache hit rates.
-_agent_cache_kwargs = {
-    "prompt_cache_key": "omi-agent-v1",
-}
-llm_agent = _byok_openai(
-    'gpt-5.1',
-    extra_body={"prompt_cache_retention": "24h"},
-    callbacks=[_usage_callback],
-    model_kwargs=_agent_cache_kwargs,
-)
-llm_agent_stream = _byok_openai(
-    'gpt-5.1',
-    streaming=True,
-    stream_options={"include_usage": True},
-    extra_body={"prompt_cache_retention": "24h"},
-    callbacks=[_usage_callback],
-    model_kwargs=_agent_cache_kwargs,
-)
-# Gemini models for large context analysis
-_gemini_flash_kwargs = dict(
-    temperature=0.7,
-    callbacks=[_usage_callback],
-)
-_gemini_flash_default = ChatOpenAI(
-    model="google/gemini-3-flash-preview",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Wrapped"},
-    **_gemini_flash_kwargs,
-)
-llm_gemini_flash = _OpenRouterGeminiProxy(
-    default=_gemini_flash_default,
-    direct_model="gemini-3-flash-preview",
-    ctor_kwargs=_gemini_flash_kwargs,
-)
 
 # ---------------------------------------------------------------------------
 # Embeddings, parser, utilities

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -170,7 +170,7 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 # Profiles:
 #   premium  — maximize cost savings while preserving 80% of max quality
 #   max      — 100% quality, best models available, no cost optimization
-#   byok     — BYOK users get max quality (they pay their own API costs)
+#   byok     — exact copy of max (BYOK users pay their own API costs)
 # ---------------------------------------------------------------------------
 
 MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
@@ -276,50 +276,52 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # byok — BYOK users get max quality (they pay their own API costs).
-    # All-OpenAI: gpt-5.4 flagship, gpt-5.4-mini quality, o4-mini reasoning,
-    # gpt-4.1-mini simple. No Gemini — BYOK keys are OpenAI keys.
+    # byok — exact copy of max. BYOK users pay their own API costs so they
+    # get the same best-quality routing as max subscribers.
     # -----------------------------------------------------------------------
     'byok': {
-        # gpt-5.4 — top-tier flagship
+        # OpenAI — conversation processing
         'conv_action_items': ('gpt-5.4', 'openai'),
         'conv_structure': ('gpt-5.4', 'openai'),
         'conv_app_result': ('gpt-5.4', 'openai'),
-        'daily_summary': ('gpt-5.4', 'openai'),
-        'chat_responses': ('gpt-5.4', 'openai'),
-        'goals_advice': ('gpt-5.4', 'openai'),
-        'app_generator': ('gpt-5.4', 'openai'),
-        'persona_clone': ('gpt-5.4', 'openai'),
-        'persona_chat_premium': ('gpt-5.4', 'openai'),
-        'notifications': ('gpt-5.4', 'openai'),
-        'chat_graph': ('gpt-5.4', 'openai'),
-        # o4-mini — reasoning tier
-        'learnings': ('o4-mini', 'openai'),
-        # gpt-5.4-mini — quality tier (upgraded from gpt-4.1-mini)
-        'external_structure': ('gpt-5.4-mini', 'openai'),
-        'memories': ('gpt-5.4-mini', 'openai'),
-        'memory_conflict': ('gpt-5.4-mini', 'openai'),
-        'knowledge_graph': ('gpt-5.4-mini', 'openai'),
-        'chat_extraction': ('gpt-5.4-mini', 'openai'),
-        'goals': ('gpt-5.4-mini', 'openai'),
-        'proactive_notification': ('gpt-5.4-mini', 'openai'),
-        'openglass': ('gpt-5.4-mini', 'openai'),
-        'smart_glasses': ('gpt-5.4-mini', 'openai'),
-        # gpt-4.1-mini — simple tasks (upgraded from gpt-4.1-nano)
         'conv_app_select': ('gpt-4.1-mini', 'openai'),
         'conv_folder': ('gpt-4.1-mini', 'openai'),
         'conv_discard': ('gpt-4.1-mini', 'openai'),
-        'persona_chat': ('gpt-4.1-mini', 'openai'),
+        'daily_summary': ('gpt-5.4', 'openai'),
         'daily_summary_simple': ('gpt-4.1-mini', 'openai'),
+        'external_structure': ('gpt-4.1-mini', 'openai'),
+        # OpenAI — memories & knowledge
+        'memories': ('gpt-4.1-mini', 'openai'),
+        'learnings': ('o4-mini', 'openai'),
+        'memory_conflict': ('gpt-4.1-mini', 'openai'),
         'memory_category': ('gpt-4.1-mini', 'openai'),
+        'knowledge_graph': ('gpt-4.1-mini', 'openai'),
+        # OpenAI — chat
+        'chat_responses': ('gpt-5.4', 'openai'),
+        'chat_extraction': ('gpt-4.1-mini', 'openai'),
+        'chat_graph': ('gpt-4.1', 'openai'),
         'session_titles': ('gpt-4.1-mini', 'openai'),
+        # Features
+        'goals': ('gpt-4.1-mini', 'openai'),
+        'goals_advice': ('gpt-5.4', 'openai'),
+        'notifications': ('gpt-5.4', 'openai'),
+        'proactive_notification': ('gpt-4.1-mini', 'openai'),
         'followup': ('gpt-4.1-mini', 'openai'),
+        'smart_glasses': ('gpt-4.1-mini', 'openai'),
+        'openglass': ('gpt-4.1-mini', 'openai'),
         'onboarding': ('gpt-4.1-mini', 'openai'),
+        'app_generator': ('gpt-5.4', 'openai'),
         'app_integration': ('gpt-4.1-mini', 'openai'),
+        'persona_clone': ('gpt-5.4', 'openai'),
         'trends': ('gpt-4.1-mini', 'openai'),
-        # Keep on original provider
+        # Anthropic
         'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        # Persona
+        'persona_chat': ('gpt-4.1-nano', 'openai'),
+        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
+        # OpenRouter
         'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
+        # Perplexity
         'web_search': ('sonar-pro', 'perplexity'),
     },
 }

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -146,13 +146,24 @@ def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict
             return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
     elif provider == 'openrouter':
-        # OpenRouter Gemini models: BYOK gemini key routes to Google direct
-        direct_model = model.split('/', 1)[1] if '/' in model else model
+        # Only reroute to Gemini direct if the model is actually Gemini-based
+        bare_model = model.split('/', 1)[1] if '/' in model else model
+        is_gemini_model = bare_model.startswith('gemini')
 
-        def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(direct_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+        if is_gemini_model:
 
-        return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
+            def _factory(byok_key: str) -> ChatOpenAI:
+                return _cached_openai_chat(bare_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+
+            return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
+        else:
+            # Non-Gemini OpenRouter model: BYOK stays on OpenRouter
+            def _factory(byok_key: str) -> ChatOpenAI:
+                return _cached_openai_chat(
+                    model, byok_key, {**clean_kwargs, 'base_url': 'https://openrouter.ai/api/v1'}
+                )
+
+            return _BYOKChatWrapper(default=default, provider='openrouter', byok_factory=_factory)
     else:
         # OpenAI and any future OpenAI-compatible provider
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -469,19 +469,10 @@ if _active_profile_name not in MODEL_QOS_PROFILES:
     _active_profile_name = 'premium'
 _active_profile = MODEL_QOS_PROFILES[_active_profile_name]
 
-# BYOK QoS mapping — automatic profile upgrade when a BYOK key is active.
-# BYOK users pay their own API costs, so we route them to higher-quality models.
-# Source of truth: this dict. No env var needed.
-_BYOK_PROFILE_MAP: Dict[str, str] = {
-    'premium': 'byok_high',
-    'premium1': 'byok_high',
-    'max': 'byok_max',
-    'max1': 'byok_max',
-    'byok_high': 'byok_high',
-    'byok_max': 'byok_max',
-}
-_byok_profile_name = _BYOK_PROFILE_MAP.get(_active_profile_name)
-_byok_profile = MODEL_QOS_PROFILES.get(_byok_profile_name) if _byok_profile_name else None
+# BYOK QoS — all BYOK users get routed to byok_high (quality upgrade, all-OpenAI).
+# BYOK users pay their own API costs, so we give them higher-quality models.
+_byok_profile_name = 'byok_high'
+_byok_profile = MODEL_QOS_PROFILES[_byok_profile_name]
 
 # Features that can't go through get_llm() (non-ChatOpenAI providers).
 _ANTHROPIC_ONLY_FEATURES = {'chat_agent'}
@@ -716,7 +707,7 @@ def get_qos_info() -> Dict[str, Dict[str, str]]:
 logger.info('Model QoS profile=%s (%d features)', _active_profile_name, len(_active_profile))
 for _feat, (_model, _provider) in sorted(_active_profile.items()):
     logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
-logger.info('BYOK QoS profile=%s (auto-mapped from %s)', _byok_profile_name, _active_profile_name)
+logger.info('BYOK QoS profile=%s', _byok_profile_name)
 
 # Log structured output features on Gemini for compatibility monitoring
 _so_gemini = {f for f in _STRUCTURED_OUTPUT_FEATURES if _active_profile.get(f, _DEFAULT_CONFIG)[1] == 'gemini'}

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import anthropic
 import httpx
@@ -19,47 +19,17 @@ logger = logging.getLogger(__name__)
 _usage_callback = get_usage_callback()
 
 # ---------------------------------------------------------------------------
-# BYOK wrappers — generic, provider-agnostic
+# BYOK (Bring Your Own Key)
 #
-# BYOK is a per-request feature that substitutes the user's own API key.
-# Wrappers sit on top of the QoS routing layer — they are not the base.
-# The QoS layer creates a plain client, then optionally wraps it with BYOK.
+# Per-request feature that substitutes the user's own API key.
+# For get_llm() callers: resolved inline — no wrapper class needed.
+# For module-level singletons (anthropic_client, embeddings): proxy classes
+# provide lazy resolution since there's no request context at import time.
 # ---------------------------------------------------------------------------
 
 # Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
 # as the client class while routing to Gemini directly — no new langchain dep.
 _GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
-
-
-class _BYOKChatWrapper:
-    """Wraps any ChatOpenAI client with per-request BYOK key substitution.
-
-    NOT a base class. A decorator/wrapper applied by get_llm() on top of
-    provider-specific clients. The provider tag determines which BYOK key
-    pool to check. The byok_factory constructs a BYOK-keyed client when needed.
-    """
-
-    __slots__ = ('_default', '_provider', '_byok_factory')
-
-    def __init__(self, default: ChatOpenAI, provider: str, byok_factory: Callable[[str], ChatOpenAI]):
-        object.__setattr__(self, '_default', default)
-        object.__setattr__(self, '_provider', provider)
-        object.__setattr__(self, '_byok_factory', byok_factory)
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key(self._provider)
-        if byok:
-            return self._byok_factory(byok)
-        return self._default
-
-    def __getattr__(self, name: str):
-        return getattr(self._resolve(), name)
-
-    def __or__(self, other):
-        return self._resolve() | other
-
-    def __ror__(self, other):
-        return other | self._resolve()
 
 
 class _AnthropicClientProxy:
@@ -135,34 +105,33 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
     return inst
 
 
-def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict[str, Any]) -> _BYOKChatWrapper:
-    """Wrap a ChatOpenAI client with BYOK resolution for the given provider."""
-    # Strip api_key/base_url from kwargs — BYOK factory supplies its own
-    clean_kwargs = {k: v for k, v in ctor_kwargs.items() if k not in ('api_key', 'base_url')}
+def _create_byok_client(
+    model: str, provider: str, byok_key: str, streaming: bool = False, feature: str = ''
+) -> Optional[ChatOpenAI]:
+    """Create a ChatOpenAI using the user's BYOK key. Returns None if BYOK not supported for this provider."""
+    kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
+    if model == 'gpt-5.1':
+        kwargs['extra_body'] = {"prompt_cache_retention": "24h"}
+    if streaming:
+        kwargs['streaming'] = True
+        kwargs['stream_options'] = {"include_usage": True}
+
+    if provider == 'openai':
+        return _cached_openai_chat(model, byok_key, kwargs)
 
     if provider == 'gemini':
+        return _cached_openai_chat(model, byok_key, {**kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
-        def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+    if provider == 'openrouter':
+        # Gemini-based OpenRouter models reroute to Gemini direct via BYOK
+        if model.startswith('gemini'):
+            temp = _OPENROUTER_TEMPERATURES.get(feature)
+            if temp is not None:
+                kwargs['temperature'] = temp
+            return _cached_openai_chat(model, byok_key, {**kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+        return None  # Non-Gemini OpenRouter: no BYOK support
 
-    elif provider == 'openrouter':
-        # Only Gemini-based OpenRouter models support BYOK reroute to Gemini direct
-        bare_model = model.split('/', 1)[1] if '/' in model else model
-        if bare_model.startswith('gemini'):
-
-            def _factory(byok_key: str) -> ChatOpenAI:
-                return _cached_openai_chat(bare_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
-
-            return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
-        # Non-Gemini OpenRouter: no BYOK support, always use Omi's key
-        return default
-    else:
-        # OpenAI and any future OpenAI-compatible provider
-
-        def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(model, byok_key, clean_kwargs)
-
-    return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory)
+    return None
 
 
 # Anthropic client for chat agent (module-level, BYOK-aware)
@@ -360,14 +329,15 @@ def get_provider(feature: str) -> str:
 
 # ---------------------------------------------------------------------------
 # Client factories — provider-specific, cached per (model, streaming, provider)
-# Each factory creates a plain ChatOpenAI, then wraps it with _BYOKChatWrapper.
+# Each factory creates and caches a plain ChatOpenAI using Omi's default keys.
+# BYOK resolution happens inline in get_llm() at request time.
 # ---------------------------------------------------------------------------
 
 _llm_cache: Dict[tuple, Any] = {}
 
 
-def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _BYOKChatWrapper:
-    """Get or create a BYOK-wrapped ChatOpenAI for an OpenAI model."""
+def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> ChatOpenAI:
+    """Get or create a cached ChatOpenAI for an OpenAI model."""
     key = (model_name, streaming, 'openai')
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
@@ -376,15 +346,14 @@ def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _BYOK
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        default = ChatOpenAI(model=model_name, **kwargs)
-        _llm_cache[key] = _wrap_byok(default, model_name, 'openai', kwargs)
+        _llm_cache[key] = ChatOpenAI(model=model_name, **kwargs)
     return _llm_cache[key]
 
 
 def _get_or_create_openrouter_llm(
     model_name: str, streaming: bool = False, temperature: Optional[float] = None
-) -> _BYOKChatWrapper:
-    """Get or create a BYOK-wrapped ChatOpenAI for an OpenRouter model.
+) -> ChatOpenAI:
+    """Get or create a cached ChatOpenAI for an OpenRouter model.
 
     Model names in the profile are bare (e.g. 'gemini-3-flash-preview').
     OpenRouter API requires vendor prefix (e.g. 'google/gemini-3-flash-preview').
@@ -404,33 +373,41 @@ def _get_or_create_openrouter_llm(
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        default = ChatOpenAI(model=api_model, **kwargs)
-        _llm_cache[key] = _wrap_byok(default, model_name, 'openrouter', kwargs)
+        _llm_cache[key] = ChatOpenAI(model=api_model, **kwargs)
     return _llm_cache[key]
 
 
-def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOKChatWrapper:
-    """Get or create a BYOK-wrapped ChatOpenAI for a Gemini model via Google's OpenAI-compat endpoint."""
+def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> ChatOpenAI:
+    """Get or create a cached ChatOpenAI for a Gemini model via Google's OpenAI-compat endpoint."""
     key = (model_name, streaming, 'gemini')
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        default = ChatOpenAI(
+        _llm_cache[key] = ChatOpenAI(
             model=model_name,
             api_key=os.environ.get('GEMINI_API_KEY', ''),
             base_url=_GEMINI_OPENAI_BASE_URL,
             **kwargs,
         )
-        _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)
     return _llm_cache[key]
+
+
+def _get_default_client(model: str, provider: str, streaming: bool, feature: str) -> ChatOpenAI:
+    """Get the cached default client for a model/provider combo."""
+    if provider == 'openrouter':
+        temp = _OPENROUTER_TEMPERATURES.get(feature)
+        return _get_or_create_openrouter_llm(model, streaming, temp)
+    if provider == 'gemini':
+        return _get_or_create_gemini_llm(model, streaming)
+    return _get_or_create_openai_llm(model, streaming)
 
 
 def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> ChatOpenAI:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
-    Works for OpenAI, Gemini, and OpenRouter features (returns ChatOpenAI or BYOK wrapper).
+    Works for OpenAI, Gemini, and OpenRouter features. Always returns a ChatOpenAI.
     For Anthropic/Perplexity, use get_model(feature) to get the model string.
 
     Args:
@@ -465,20 +442,20 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
             f"Feature '{feature}' resolved to Perplexity model '{model}' — use get_model() with Perplexity HTTP client"
         )
 
-    if provider == 'openrouter':
-        temp = _OPENROUTER_TEMPERATURES.get(feature)
-        result = _get_or_create_openrouter_llm(model, streaming, temp)
-    elif provider == 'gemini':
-        result = _get_or_create_gemini_llm(model, streaming)
+    # Check for BYOK key — if the user provided their own key, create a
+    # per-request client instead of using the cached default.
+    # Safe because get_llm() runs within the request handler where the
+    # BYOK contextvar is already set by the middleware.
+    byok_provider = 'gemini' if provider == 'openrouter' and model.startswith('gemini') else provider
+    byok_key = get_byok_key(byok_provider)
+    if byok_key:
+        byok_client = _create_byok_client(model, provider, byok_key, streaming, feature)
+        if byok_client is not None:
+            result = byok_client
+        else:
+            result = _get_default_client(model, provider, streaming, feature)
     else:
-        # Default: OpenAI
-        result = _get_or_create_openai_llm(model, streaming)
-
-    # Eagerly resolve BYOK wrapper so callers always get a proper Runnable.
-    # This is safe because get_llm() is called within the request handler
-    # where the BYOK contextvar is already set by the middleware.
-    if isinstance(result, _BYOKChatWrapper):
-        result = result._resolve()
+        result = _get_default_client(model, provider, streaming, feature)
 
     if cache_key and model in _CACHE_KEY_MODELS:
         return result.bind(prompt_cache_key=cache_key)
@@ -516,8 +493,7 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = get_model('chat_agent')
 # Legacy module-level alias (kept for test compatibility).
 # Production code should use get_llm(feature) exclusively.
 # ---------------------------------------------------------------------------
-_llm_mini_default = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback])
-llm_mini = _wrap_byok(_llm_mini_default, 'gpt-4.1-mini', 'openai', {'callbacks': [_usage_callback]})
+llm_mini = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback])
 
 # ---------------------------------------------------------------------------
 # Embeddings, parser, utilities

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -195,8 +195,6 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 #   feature_b: ('gemini-2.5-flash', 'openrouter')   → OpenRouter
 #
 # Global switch:     MODEL_QOS=premium        (selects entire profile)
-# Per-feature:       MODEL_QOS_FOLLOWUP=gpt-4.1-nano:openai  (model:provider)
-#                    MODEL_QOS_FOLLOWUP=gpt-4.1-nano          (model only, inherits provider)
 #
 # Two profiles:
 #   premium — cost-effective default (80% of max quality)
@@ -313,22 +311,6 @@ _ANTHROPIC_ONLY_FEATURES = {'chat_agent'}
 _PERPLEXITY_ONLY_FEATURES = {'web_search'}
 
 
-def _classify_provider(model: str) -> str:
-    """Infer provider from model name. Used ONLY as fallback for env overrides
-    that don't specify an explicit provider (e.g. MODEL_QOS_X=gpt-4.1-mini).
-    Profile entries always have explicit provider — this is never used for them.
-    """
-    if '/' in model:
-        return 'openrouter'
-    if model.startswith('claude'):
-        return 'anthropic'
-    if model.startswith('sonar'):
-        return 'perplexity'
-    if model.startswith('gemini-'):
-        return 'gemini'
-    return 'openai'
-
-
 # Feature-specific client config (temperature, headers — orthogonal to model choice).
 # Only applied when a feature resolves to an OpenRouter model.
 _OPENROUTER_TEMPERATURES: Dict[str, float] = {
@@ -343,67 +325,26 @@ _CACHE_KEY_MODELS = {'gpt-5.4', 'gpt-5.4-mini'}
 _DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
 
 
-_VALID_PROVIDERS = {'openai', 'gemini', 'openrouter', 'anthropic', 'perplexity'}
-
-
 def _get_model_config(feature: str) -> Tuple[str, str]:
     """Get the (model, provider) tuple for a feature. Internal — used by get_llm/get_model/get_provider.
 
-    Resolution order: pinned > per-feature env override > active profile > fallback.
-
-    Env override formats:
-      MODEL_QOS_X=model:provider  — explicit model and provider (validated)
-      MODEL_QOS_X=model           — provider inferred from model name via _classify_provider()
+    Resolution order: pinned > active profile > fallback.
     """
     if feature in _PINNED_FEATURES:
         return _PINNED_FEATURES[feature]
-    env_key = f'MODEL_QOS_{feature.upper()}'
-    override = os.environ.get(env_key, '').strip()
-    if override:
-        profile_entry = _active_profile.get(feature, _DEFAULT_CONFIG)
-        if ':' in override:
-            parts = override.rsplit(':', 1)
-            override_model, override_provider = parts[0], parts[1]
-            inferred = _classify_provider(override_model)
-            if override_provider not in _VALID_PROVIDERS:
-                logger.warning(
-                    'QoS override %s=%s has invalid provider %r — using inferred provider %s',
-                    env_key,
-                    override,
-                    override_provider,
-                    inferred,
-                )
-                override_provider = inferred
-            elif override_provider != inferred:
-                logger.warning(
-                    'QoS override %s=%s: explicit provider %r does not match model (inferred %s) — using inferred',
-                    env_key,
-                    override,
-                    override_provider,
-                    inferred,
-                )
-                override_provider = inferred
-        else:
-            override_model = override
-            override_provider = _classify_provider(override_model)
-        return (override_model, override_provider)
     return _active_profile.get(feature, _DEFAULT_CONFIG)
 
 
 def get_model(feature: str) -> str:
     """Get the model name for a feature from the active Model QoS profile.
 
-    Resolution order: pinned > per-feature env override > active profile > fallback.
+    Resolution order: pinned > active profile > fallback.
 
     Args:
         feature: Feature name (e.g. 'conv_action_items', 'chat_agent').
 
     Returns:
         Model name string (e.g. 'gpt-4.1-mini', 'claude-sonnet-4-6').
-
-    Override via env var:
-        MODEL_QOS_CHAT_AGENT=claude-haiku-3.5:anthropic
-        MODEL_QOS_CONV_STRUCTURE=gpt-5.1
     """
     return _get_model_config(feature)[0]
 
@@ -561,11 +502,7 @@ def get_qos_info() -> Dict[str, Dict[str, str]]:
 # Startup logging — log active profile so cost issues are traceable.
 logger.info('Model QoS profile=%s (%d features)', _active_profile_name, len(_active_profile))
 for _feat, (_model, _provider) in sorted(_active_profile.items()):
-    _resolved_model = get_model(_feat)
-    if _resolved_model != _model:
-        logger.info('  QoS %s: %s [%s] (override, profile default: %s)', _feat, _resolved_model, _provider, _model)
-    else:
-        logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
+    logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -6,7 +6,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import anthropic
 import httpx
 from cachetools import TTLCache
+from langchain_core.language_models import BaseChatModel
 from langchain_core.output_parsers import PydanticOutputParser
+from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 import tiktoken
 
@@ -27,8 +29,8 @@ _usage_callback = get_usage_callback()
 # provide lazy resolution since there's no request context at import time.
 # ---------------------------------------------------------------------------
 
-# Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
-# as the client class while routing to Gemini directly — no new langchain dep.
+# Google's OpenAI-compatible endpoint — used only for BYOK users who bring their
+# own AI Studio API key. Platform calls use ChatGoogleGenerativeAI (native SDK).
 _GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 
@@ -549,24 +551,44 @@ def _get_or_create_openrouter_llm(
     return _llm_cache[key]
 
 
-def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> ChatOpenAI:
-    """Get or create a cached ChatOpenAI for a Gemini model via Google's OpenAI-compat endpoint."""
+def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> BaseChatModel:
+    """Get or create a cached ChatGoogleGenerativeAI for a Gemini model via native SDK.
+
+    Routing priority:
+      1. GOOGLE_CLOUD_PROJECT set → Vertex AI (uses ADC / google-credentials.json, paid quota)
+      2. GEMINI_API_KEY set → AI Studio (paid-tier key, no OpenAI-compat rate limits)
+      3. Neither → placeholder that fails at invoke time (unit tests)
+
+    BYOK users still go through the OpenAI-compat endpoint via _create_byok_client().
+    """
     key = (model_name, streaming, 'gemini')
     if key not in _llm_cache:
+        gcp_project = os.environ.get('GOOGLE_CLOUD_PROJECT', '')
+        gemini_key = os.environ.get('GEMINI_API_KEY', '')
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
         if streaming:
             kwargs['streaming'] = True
-            kwargs['stream_options'] = {"include_usage": True}
-        _llm_cache[key] = ChatOpenAI(
-            model=model_name,
-            api_key=os.environ.get('GEMINI_API_KEY', ''),
-            base_url=_GEMINI_OPENAI_BASE_URL,
-            **kwargs,
-        )
+
+        if gcp_project:
+            # Vertex AI — uses ADC (GOOGLE_APPLICATION_CREDENTIALS), project-level paid quota
+            gcp_location = os.environ.get('GCP_LOCATION', 'us-central1')
+            _llm_cache[key] = ChatGoogleGenerativeAI(
+                model=model_name, project=gcp_project, location=gcp_location, **kwargs
+            )
+        elif gemini_key:
+            # AI Studio — uses API key, paid-tier quota
+            kwargs['google_api_key'] = gemini_key
+            _llm_cache[key] = ChatGoogleGenerativeAI(model=model_name, **kwargs)
+        else:
+            # No credentials — constructable placeholder, fails at invoke time
+            logger.warning('No GOOGLE_CLOUD_PROJECT or GEMINI_API_KEY — Gemini calls will fail at invoke time')
+            _llm_cache[key] = ChatOpenAI(
+                model=model_name, api_key='not-set', base_url=_GEMINI_OPENAI_BASE_URL, **kwargs
+            )
     return _llm_cache[key]
 
 
-def _get_default_client(model: str, provider: str, streaming: bool, feature: str) -> ChatOpenAI:
+def _get_default_client(model: str, provider: str, streaming: bool, feature: str) -> BaseChatModel:
     """Get the cached default client for a model/provider combo."""
     if provider == 'openrouter':
         temp = _OPENROUTER_TEMPERATURES.get(feature)
@@ -583,10 +605,12 @@ def _effective_byok_provider(model: str, provider: str) -> str:
     return provider
 
 
-def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> ChatOpenAI:
+def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> BaseChatModel:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
-    Works for OpenAI, Gemini, and OpenRouter features. Always returns a ChatOpenAI.
+    Works for OpenAI, Gemini, and OpenRouter features. Returns a BaseChatModel
+    (ChatOpenAI for OpenAI/OpenRouter, ChatGoogleGenerativeAI for Gemini).
+    All share the same interface: .invoke(), .ainvoke(), .stream(), .with_structured_output().
     For Anthropic/Perplexity, use get_model(feature) to get the model string.
 
     Args:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -456,22 +456,26 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> BaseC
     """Get or create a cached ChatGoogleGenerativeAI for a Gemini model via native SDK.
 
     Routing priority:
-      1. GOOGLE_CLOUD_PROJECT set → Vertex AI (uses ADC / google-credentials.json, paid quota)
+      1. USE_VERTEX_AI=true + GOOGLE_CLOUD_PROJECT → Vertex AI (ADC, paid quota, ~34% savings with EDP)
       2. GEMINI_API_KEY set → AI Studio (paid-tier key, no OpenAI-compat rate limits)
       3. Neither → placeholder that fails at invoke time (unit tests)
+
+    Vertex AI requires explicit opt-in via USE_VERTEX_AI=true because GOOGLE_CLOUD_PROJECT
+    is already set for Firestore and the service account may lack Vertex AI permissions.
 
     BYOK users still go through the OpenAI-compat endpoint via _create_byok_client().
     """
     key = (model_name, streaming, 'gemini')
     if key not in _llm_cache:
-        gcp_project = os.environ.get('GOOGLE_CLOUD_PROJECT', '')
+        use_vertex = os.environ.get('USE_VERTEX_AI', '').lower() == 'true'
+        gcp_project = os.environ.get('GOOGLE_CLOUD_PROJECT', '') if use_vertex else ''
         gemini_key = os.environ.get('GEMINI_API_KEY', '')
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
         if streaming:
             kwargs['streaming'] = True
 
         if gcp_project:
-            # Vertex AI — uses ADC (GOOGLE_APPLICATION_CREDENTIALS), project-level paid quota
+            # Vertex AI — explicit opt-in, uses ADC (GOOGLE_APPLICATION_CREDENTIALS)
             gcp_location = os.environ.get('GCP_LOCATION', 'us-central1')
             _llm_cache[key] = ChatGoogleGenerativeAI(
                 model=model_name, project=gcp_project, location=gcp_location, **kwargs
@@ -482,7 +486,7 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> BaseC
             _llm_cache[key] = ChatGoogleGenerativeAI(model=model_name, **kwargs)
         else:
             # No credentials — constructable placeholder, fails at invoke time
-            logger.warning('No GOOGLE_CLOUD_PROJECT or GEMINI_API_KEY — Gemini calls will fail at invoke time')
+            logger.warning('No USE_VERTEX_AI or GEMINI_API_KEY — Gemini calls will fail at invoke time')
             _llm_cache[key] = ChatOpenAI(
                 model=model_name, api_key='not-set', base_url=_GEMINI_OPENAI_BASE_URL, **kwargs
             )

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -221,34 +221,34 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
         'conv_folder': 'gpt-4.1-nano',
         'conv_discard': 'gpt-4.1-nano',
         'daily_summary': 'gpt-5.4-mini',
-        'daily_summary_simple': 'gpt-4.1-nano',
+        'daily_summary_simple': 'gemini-2.5-flash-lite',  # free-text stats → Gemini (75% savings vs mini)
         'external_structure': 'gpt-4.1-mini',  # quality-sensitive: structuring external data
         # OpenAI — memories & knowledge
         'memories': 'gpt-4.1-mini',  # quality-sensitive: memory extraction
         'learnings': 'gpt-5.4-mini',
         'memory_conflict': 'gpt-4.1-mini',  # quality-sensitive: conflict detection
-        'memory_category': 'gpt-4.1-nano',
+        'memory_category': 'gemini-2.5-flash-lite',  # text enum classification → Gemini (75% savings vs mini)
         'knowledge_graph': 'gpt-4.1-mini',  # quality-sensitive: entity/relationship extraction
         # OpenAI — chat
         'chat_responses': 'gpt-5.4-mini',
         'chat_extraction': 'gpt-4.1-mini',  # quality-sensitive: structured data extraction
         'chat_graph': 'gpt-4.1-mini',  # quality-sensitive: graph queries
-        'session_titles': 'gpt-4.1-nano',
+        'session_titles': 'gemini-2.5-flash-lite',  # free text title → Gemini (75% savings vs mini)
         # OpenAI — features
         'goals': 'gpt-4.1-mini',  # quality-sensitive: goal analysis
         'goals_advice': 'gpt-5.4-mini',
         'notifications': 'gpt-5.4-mini',
         'proactive_notification': 'gpt-4.1-mini',  # quality-sensitive: notification decisions
-        'followup': 'gpt-4.1-nano',
+        'followup': 'gemini-2.5-flash-lite',  # free text question → Gemini (75% savings vs mini)
         'smart_glasses': 'gpt-4.1-nano',
-        'onboarding': 'gpt-4.1-nano',
+        'onboarding': 'gemini-2.5-flash-lite',  # boolean yes/no check → Gemini (75% savings vs mini)
         'app_generator': 'gpt-5.4-mini',
-        'app_integration': 'gpt-4.1-nano',
+        'app_integration': 'gemini-2.5-flash-lite',  # simple routing → Gemini (75% savings vs mini)
         'persona_clone': 'gpt-5.4-mini',
-        'trends': 'gpt-4.1-nano',
+        'trends': 'gemini-2.5-flash-lite',  # simple pattern analysis → Gemini (75% savings vs mini)
         # Anthropic (chat_agent — used via get_model() + anthropic_client)
         'chat_agent': 'claude-sonnet-4-6',
-        # OpenAI — persona (moved from deprecated OpenRouter models to direct API)
+        # OpenAI — persona
         'persona_chat': 'gpt-4.1-nano',
         'persona_chat_premium': 'gpt-5.4-mini',
         # OpenRouter — wrapped_analysis only (gemini-3-flash-preview still active)
@@ -328,6 +328,8 @@ def _classify_provider(model: str) -> str:
         return 'anthropic'
     if model.startswith('sonar'):
         return 'perplexity'
+    if model.startswith('gemini-'):
+        return 'gemini'
     return 'openai'
 
 
@@ -429,10 +431,58 @@ def _get_or_create_openrouter_llm(
     return _llm_cache[key]
 
 
+class _GeminiChatProxy:
+    """Transparent BYOK-aware proxy for Gemini models via Google's OpenAI-compatible endpoint."""
+
+    __slots__ = ('_model', '_default', '_ctor_kwargs')
+
+    def __init__(self, model: str, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_model', model)
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('gemini')
+        if byok:
+            return _cached_openai_chat(
+                self._model,
+                byok,
+                {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
+            )
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+    def __or__(self, other):
+        return self._resolve() | other
+
+    def __ror__(self, other):
+        return other | self._resolve()
+
+
+def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _GeminiChatProxy:
+    """Get or create a BYOK-aware ChatOpenAI proxy for a Gemini model via Google's OpenAI-compat endpoint."""
+    key = (model_name, streaming, 'gemini')
+    if key not in _llm_cache:
+        kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
+        if streaming:
+            kwargs['streaming'] = True
+            kwargs['stream_options'] = {"include_usage": True}
+        default = ChatOpenAI(
+            model=model_name,
+            api_key=os.environ.get('GEMINI_API_KEY', ''),
+            base_url=_GEMINI_OPENAI_BASE_URL,
+            **kwargs,
+        )
+        _llm_cache[key] = _GeminiChatProxy(model=model_name, default=default, ctor_kwargs=kwargs)
+    return _llm_cache[key]
+
+
 def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> ChatOpenAI:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
-    Works for OpenAI and OpenRouter features (returns ChatOpenAI or BYOK proxy).
+    Works for OpenAI, Gemini, and OpenRouter features (returns ChatOpenAI or BYOK proxy).
     For Anthropic/Perplexity, use get_model(feature) to get the model string.
 
     Args:
@@ -472,6 +522,9 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
     if provider == 'openrouter':
         temp = _OPENROUTER_TEMPERATURES.get(feature)
         return _get_or_create_openrouter_llm(model, streaming, temp)
+
+    if provider == 'gemini':
+        return _get_or_create_gemini_llm(model, streaming)
 
     llm = _get_or_create_openai_llm(model, streaming)
     if cache_key and model in _CACHE_KEY_MODELS:
@@ -572,78 +625,6 @@ llm_agent_stream = _byok_openai(
     callbacks=[_usage_callback],
     model_kwargs=_agent_cache_kwargs,
 )
-_persona_mini_kwargs = dict(
-    temperature=0.8,
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-_persona_mini_default = ChatOpenAI(
-    model="google/gemini-flash-1.5-8b",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Chat"},
-    **_persona_mini_kwargs,
-)
-# BYOK Gemini → route direct to Google's OpenAI-compat endpoint.
-# Model name drops the `google/` prefix: gemini-flash-1.5-8b on Google direct.
-llm_persona_mini_stream = _OpenRouterGeminiProxy(
-    default=_persona_mini_default,
-    direct_model="gemini-flash-1.5-8b",
-    ctor_kwargs=_persona_mini_kwargs,
-)
-# Anthropic-via-OpenRouter. BYOK Anthropic users route to Anthropic's
-# OpenAI-compat endpoint directly, avoiding Omi's OpenRouter bill.
-_ANTHROPIC_OPENAI_BASE_URL = "https://api.anthropic.com/v1/"
-_persona_medium_kwargs = dict(
-    temperature=0.8,
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-_persona_medium_default = ChatOpenAI(
-    model="anthropic/claude-3.5-sonnet",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Chat"},
-    **_persona_medium_kwargs,
-)
-
-
-class _AnthropicViaOpenAIProxy:
-    """Route to Anthropic's OpenAI-compat endpoint when BYOK Anthropic key is set."""
-
-    __slots__ = ('_default', '_ctor_kwargs')
-
-    def __init__(self, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
-        object.__setattr__(self, '_default', default)
-        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('anthropic')
-        if byok:
-            return _cached_openai_chat(
-                'claude-sonnet-4-20250514',
-                byok,
-                {**self._ctor_kwargs, 'base_url': _ANTHROPIC_OPENAI_BASE_URL},
-            )
-        return self._default
-
-    def __getattr__(self, name: str):
-        return getattr(self._resolve(), name)
-
-    def __or__(self, other):
-        return self._resolve() | other
-
-    def __ror__(self, other):
-        return other | self._resolve()
-
-
-llm_persona_medium_stream = _AnthropicViaOpenAIProxy(
-    default=_persona_medium_default,
-    ctor_kwargs=_persona_medium_kwargs,
-)
-
 # Gemini models for large context analysis
 _gemini_flash_kwargs = dict(
     temperature=0.7,

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -469,12 +469,18 @@ if _active_profile_name not in MODEL_QOS_PROFILES:
     _active_profile_name = 'premium'
 _active_profile = MODEL_QOS_PROFILES[_active_profile_name]
 
-# BYOK QoS profile — when set, BYOK users get upgraded model routing.
-# Set BYOK_QOS=byok_high or BYOK_QOS=byok_max to enable.
-_byok_profile_name = os.environ.get('BYOK_QOS', '').strip().lower() or None
-if _byok_profile_name and _byok_profile_name not in MODEL_QOS_PROFILES:
-    logger.warning('BYOK_QOS=%s is not a valid profile, BYOK profile disabled', _byok_profile_name)
-    _byok_profile_name = None
+# BYOK QoS mapping — automatic profile upgrade when a BYOK key is active.
+# BYOK users pay their own API costs, so we route them to higher-quality models.
+# Source of truth: this dict. No env var needed.
+_BYOK_PROFILE_MAP: Dict[str, str] = {
+    'premium': 'byok_high',
+    'premium1': 'byok_high',
+    'max': 'byok_max',
+    'max1': 'byok_max',
+    'byok_high': 'byok_high',
+    'byok_max': 'byok_max',
+}
+_byok_profile_name = _BYOK_PROFILE_MAP.get(_active_profile_name)
 _byok_profile = MODEL_QOS_PROFILES.get(_byok_profile_name) if _byok_profile_name else None
 
 # Features that can't go through get_llm() (non-ChatOpenAI providers).
@@ -710,10 +716,7 @@ def get_qos_info() -> Dict[str, Dict[str, str]]:
 logger.info('Model QoS profile=%s (%d features)', _active_profile_name, len(_active_profile))
 for _feat, (_model, _provider) in sorted(_active_profile.items()):
     logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
-if _byok_profile_name:
-    logger.info('BYOK QoS profile=%s (%d features)', _byok_profile_name, len(_byok_profile))
-else:
-    logger.info('BYOK QoS profile=none (BYOK users use server profile)')
+logger.info('BYOK QoS profile=%s (auto-mapped from %s)', _byok_profile_name, _active_profile_name)
 
 # Log structured output features on Gemini for compatibility monitoring
 _so_gemini = {f for f in _STRUCTURED_OUTPUT_FEATURES if _active_profile.get(f, _DEFAULT_CONFIG)[1] == 'gemini'}

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -171,6 +171,9 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 # ---------------------------------------------------------------------------
 
 MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
+    # -----------------------------------------------------------------------
+    # premium — cost-effective default (OpenAI + some Gemini for simple tasks)
+    # -----------------------------------------------------------------------
     'premium': {
         # OpenAI — conversation processing
         'conv_action_items': ('gpt-5.4-mini', 'openai'),
@@ -216,6 +219,58 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         # Perplexity
         'web_search': ('sonar-pro', 'perplexity'),
     },
+    # -----------------------------------------------------------------------
+    # premium1 — full Gemini migration (40-60% OpenAI savings)
+    # All 5 phases from issue #6873: gpt-5.4-mini→Pro, gpt-4.1-mini→Flash,
+    # gpt-4.1-nano→Flash-Lite. Only chat_agent/web_search/wrapped stay.
+    #
+    # ⚠️  Features marked [SO] use with_structured_output(method="json_schema")
+    #     which may need method="function_calling" fallback on Gemini.
+    # -----------------------------------------------------------------------
+    'premium1': {
+        # Gemini 2.5 Pro — flagship tier (Phase 1+4: replaces gpt-5.4-mini)
+        'conv_action_items': ('gemini-2.5-pro', 'gemini'),  # PydanticOutputParser — safe
+        'conv_structure': ('gemini-2.5-pro', 'gemini'),  # PydanticOutputParser — safe
+        'conv_app_result': ('gemini-2.5-pro', 'gemini'),  # free-text
+        'daily_summary': ('gemini-2.5-pro', 'gemini'),  # free-text
+        'learnings': ('gemini-2.5-pro', 'gemini'),  # PydanticOutputParser — safe
+        'chat_responses': ('gemini-2.5-pro', 'gemini'),  # free-text streaming
+        'goals_advice': ('gemini-2.5-pro', 'gemini'),  # free-text
+        'app_generator': ('gemini-2.5-pro', 'gemini'),  # free-text
+        'persona_clone': ('gemini-2.5-pro', 'gemini'),  # free-text
+        'persona_chat_premium': ('gemini-2.5-pro', 'gemini'),  # free-text
+        # Gemini 2.5 Flash — quality-sensitive (Phase 3+4: replaces gpt-4.1-mini)
+        'external_structure': ('gemini-2.5-flash', 'gemini'),  # [SO] with_structured_output
+        'memories': ('gemini-2.5-flash', 'gemini'),  # PydanticOutputParser — safe
+        'memory_conflict': ('gemini-2.5-flash', 'gemini'),  # PydanticOutputParser — safe
+        'knowledge_graph': ('gemini-2.5-flash', 'gemini'),  # free-text
+        'chat_extraction': ('gemini-2.5-flash', 'gemini'),  # [SO] with_structured_output (10+ schemas)
+        'chat_graph': ('gemini-2.5-flash', 'gemini'),  # free-text
+        'goals': ('gemini-2.5-flash', 'gemini'),  # free-text
+        'proactive_notification': ('gemini-2.5-flash', 'gemini'),  # [SO] with_structured_output
+        'notifications': ('gemini-2.5-flash', 'gemini'),  # free-text
+        'openglass': ('gemini-2.5-flash', 'gemini'),  # free-text (vision)
+        'smart_glasses': ('gemini-2.5-flash', 'gemini'),  # free-text (vision/multimodal)
+        # Gemini 2.5 Flash-Lite — simple tasks (Phase 2+3: replaces gpt-4.1-nano)
+        'conv_app_select': ('gemini-2.5-flash-lite', 'gemini'),  # [SO] with_structured_output
+        'conv_folder': ('gemini-2.5-flash-lite', 'gemini'),  # PydanticOutputParser chain — safe
+        'conv_discard': ('gemini-2.5-flash-lite', 'gemini'),  # PydanticOutputParser chain — safe
+        'daily_summary_simple': ('gemini-2.5-flash-lite', 'gemini'),
+        'memory_category': ('gemini-2.5-flash-lite', 'gemini'),
+        'session_titles': ('gemini-2.5-flash-lite', 'gemini'),
+        'followup': ('gemini-2.5-flash-lite', 'gemini'),
+        'onboarding': ('gemini-2.5-flash-lite', 'gemini'),
+        'app_integration': ('gemini-2.5-flash-lite', 'gemini'),
+        'trends': ('gemini-2.5-flash-lite', 'gemini'),  # [SO] with_structured_output
+        'persona_chat': ('gemini-2.5-flash-lite', 'gemini'),
+        # Keep on original provider (no Gemini equivalent)
+        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
+        'web_search': ('sonar-pro', 'perplexity'),
+    },
+    # -----------------------------------------------------------------------
+    # max — maximum quality, flagship OpenAI models
+    # -----------------------------------------------------------------------
     'max': {
         # OpenAI — conversation processing
         'conv_action_items': ('gpt-5.4', 'openai'),
@@ -259,6 +314,53 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         # OpenRouter
         'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         # Perplexity
+        'web_search': ('sonar-pro', 'perplexity'),
+    },
+    # -----------------------------------------------------------------------
+    # max1 — max quality with Gemini optimization
+    # Same migration as premium1 but keeps o4-mini for learnings (reasoning).
+    # Upgrades gpt-4.1-mini tier to gemini-2.5-flash (not flash-lite).
+    # -----------------------------------------------------------------------
+    'max1': {
+        # Gemini 2.5 Pro — flagship tier (replaces gpt-5.4)
+        'conv_action_items': ('gemini-2.5-pro', 'gemini'),
+        'conv_structure': ('gemini-2.5-pro', 'gemini'),
+        'conv_app_result': ('gemini-2.5-pro', 'gemini'),
+        'daily_summary': ('gemini-2.5-pro', 'gemini'),
+        'chat_responses': ('gemini-2.5-pro', 'gemini'),
+        'goals_advice': ('gemini-2.5-pro', 'gemini'),
+        'app_generator': ('gemini-2.5-pro', 'gemini'),
+        'persona_clone': ('gemini-2.5-pro', 'gemini'),
+        'persona_chat_premium': ('gemini-2.5-pro', 'gemini'),
+        'chat_graph': ('gemini-2.5-pro', 'gemini'),  # was gpt-4.1 in max
+        # Gemini 2.5 Flash — quality-sensitive (replaces gpt-4.1-mini)
+        'external_structure': ('gemini-2.5-flash', 'gemini'),  # [SO]
+        'memories': ('gemini-2.5-flash', 'gemini'),
+        'memory_conflict': ('gemini-2.5-flash', 'gemini'),
+        'memory_category': ('gemini-2.5-flash', 'gemini'),
+        'knowledge_graph': ('gemini-2.5-flash', 'gemini'),
+        'chat_extraction': ('gemini-2.5-flash', 'gemini'),  # [SO]
+        'daily_summary_simple': ('gemini-2.5-flash', 'gemini'),
+        'goals': ('gemini-2.5-flash', 'gemini'),
+        'proactive_notification': ('gemini-2.5-flash', 'gemini'),  # [SO]
+        'notifications': ('gemini-2.5-flash', 'gemini'),
+        'openglass': ('gemini-2.5-flash', 'gemini'),
+        'smart_glasses': ('gemini-2.5-flash', 'gemini'),
+        'session_titles': ('gemini-2.5-flash', 'gemini'),
+        'followup': ('gemini-2.5-flash', 'gemini'),
+        'onboarding': ('gemini-2.5-flash', 'gemini'),
+        'app_integration': ('gemini-2.5-flash', 'gemini'),
+        # OpenAI reasoning (no Gemini equivalent for chain-of-thought)
+        'learnings': ('o4-mini', 'openai'),
+        # Gemini 2.5 Flash-Lite — simple tasks (replaces gpt-4.1-nano)
+        'conv_app_select': ('gemini-2.5-flash-lite', 'gemini'),  # [SO]
+        'conv_folder': ('gemini-2.5-flash-lite', 'gemini'),
+        'conv_discard': ('gemini-2.5-flash-lite', 'gemini'),
+        'trends': ('gemini-2.5-flash-lite', 'gemini'),  # [SO]
+        'persona_chat': ('gemini-2.5-flash-lite', 'gemini'),
+        # Keep on original provider
+        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         'web_search': ('sonar-pro', 'perplexity'),
     },
 }

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -166,19 +166,19 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 # Global switch:     MODEL_QOS=premium        (selects entire profile)
 #
 # Profiles:
-#   premium      — cost-effective default, ~80% of max quality (OpenAI + Gemini cost savings)
-#   premium_0424 — full Gemini migration of premium, same quality target, ~40-60% cheaper
-#   max          — maximum quality, 100% flagship OpenAI, no cost optimization
-#   max_0424     — full Gemini migration of max, same quality target + o4-mini reasoning
-#   byok         — BYOK users, top-tier all-OpenAI (users pay their own API costs)
+#   premium      — maximize cost savings while preserving 80% of max quality
+#   premium_0424 — same 80% quality preservation as premium, migrated to Gemini for deeper savings
+#   max          — 100% quality, best models available, no cost optimization
+#   max_0424     — preserve 100% quality on Gemini models for cost savings
+#   byok         — BYOK users get max quality (they pay their own API costs)
 # ---------------------------------------------------------------------------
 
 MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
     # -----------------------------------------------------------------------
-    # premium — cost-effective default, ~80% of max quality.
-    # Uses OpenAI flagship (gpt-5.4-mini) for core features, mid-tier (gpt-4.1-mini)
-    # for quality-sensitive tasks, nano for simple routing, and Gemini flash-lite
-    # for low-complexity text tasks (summaries, categories, titles) to save cost.
+    # premium — maximize cost savings while preserving 80% of max quality.
+    # Uses gpt-5.4-mini (not gpt-5.4) for core features, gpt-4.1-mini (not gpt-4.1)
+    # for quality-sensitive tasks, gpt-4.1-nano for simple routing, and Gemini
+    # flash-lite for low-complexity text (summaries, categories, titles).
     # -----------------------------------------------------------------------
     'premium': {
         # OpenAI — conversation processing
@@ -226,10 +226,9 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # premium_0424 — full Gemini migration, release April 24 2026.
-    # Replaces all OpenAI models with Gemini equivalents for ~40-60% cost savings.
-    # Quality target: same as premium (80% of max) but on Gemini models.
-    # gpt-5.4-mini→Pro, gpt-4.1-mini→Flash, gpt-4.1-nano→Flash-Lite.
+    # premium_0424 — same 80% quality preservation as premium, migrated to Gemini
+    # for deeper cost savings. Release April 24 2026.
+    # gpt-5.4-mini→gemini-2.5-pro, gpt-4.1-mini→flash, gpt-4.1-nano→flash-lite.
     #
     # ⚠️  Features marked [SO] use with_structured_output(method="json_schema")
     #     which may need method="function_calling" fallback on Gemini.
@@ -276,10 +275,9 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # max — maximum quality, 100% flagship OpenAI models.
+    # max — 100% quality, best models available, no cost optimization.
     # Uses gpt-5.4 for all core features, o4-mini for reasoning (learnings),
-    # gpt-4.1 for chat graph. No Gemini — pure OpenAI for best quality.
-    # Reserved for users who need the highest accuracy regardless of cost.
+    # gpt-4.1 for chat graph. Pure OpenAI for highest accuracy.
     # -----------------------------------------------------------------------
     'max': {
         # OpenAI — conversation processing
@@ -327,10 +325,10 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # max_0424 — max quality with Gemini optimization, release April 24 2026.
-    # Same migration as premium_0424 but targets 100% quality on Gemini.
-    # Uses gemini-2.5-pro for flagship, gemini-2.5-flash for quality tier
-    # (not flash-lite), and keeps o4-mini for reasoning (learnings).
+    # max_0424 — preserve 100% quality on Gemini for cost savings.
+    # Release April 24 2026. Uses gemini-2.5-pro for flagship,
+    # gemini-2.5-flash (not flash-lite) for quality tier to match max quality,
+    # keeps o4-mini for reasoning (no Gemini equivalent).
     # -----------------------------------------------------------------------
     'max_0424': {
         # Gemini 2.5 Pro — flagship tier (replaces gpt-5.4)
@@ -375,9 +373,8 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # byok — BYOK (Bring Your Own Key) users, maximum quality on all-OpenAI.
-    # BYOK users pay their own API costs, so we give them top-tier models.
-    # Uses gpt-5.4 flagship, gpt-5.4-mini quality, o4-mini reasoning,
+    # byok — BYOK users get max quality (they pay their own API costs).
+    # All-OpenAI: gpt-5.4 flagship, gpt-5.4-mini quality, o4-mini reasoning,
     # gpt-4.1-mini simple. No Gemini — BYOK keys are OpenAI keys.
     # -----------------------------------------------------------------------
     'byok': {

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -137,24 +137,27 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
 
 def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict[str, Any]) -> _BYOKChatWrapper:
     """Wrap a ChatOpenAI client with BYOK resolution for the given provider."""
+    # Strip api_key/base_url from kwargs — BYOK factory supplies its own
+    clean_kwargs = {k: v for k, v in ctor_kwargs.items() if k not in ('api_key', 'base_url')}
+
     if provider == 'gemini':
 
         def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(model, byok_key, {**ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+            return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
     elif provider == 'openrouter':
         # OpenRouter Gemini models: BYOK gemini key routes to Google direct
         direct_model = model.split('/', 1)[1] if '/' in model else model
 
         def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(direct_model, byok_key, {**ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+            return _cached_openai_chat(direct_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
         return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
     else:
         # OpenAI and any future OpenAI-compatible provider
 
         def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(model, byok_key, ctor_kwargs)
+            return _cached_openai_chat(model, byok_key, clean_kwargs)
 
     return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory)
 
@@ -337,39 +340,40 @@ _CACHE_KEY_MODELS = {'gpt-5.4', 'gpt-5.4-mini'}
 _DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
 
 
+_VALID_PROVIDERS = {'openai', 'gemini', 'openrouter', 'anthropic', 'perplexity'}
+
+
 def _get_model_config(feature: str) -> Tuple[str, str]:
     """Get the (model, provider) tuple for a feature. Internal — used by get_llm/get_model/get_provider.
 
     Resolution order: pinned > per-feature env override > active profile > fallback.
-    Env override format: MODEL_QOS_X=model:provider  or  MODEL_QOS_X=model (inherits profile provider).
+
+    Env override formats:
+      MODEL_QOS_X=model:provider  — explicit model and provider (validated)
+      MODEL_QOS_X=model           — provider inferred from model name via _classify_provider()
     """
     if feature in _PINNED_FEATURES:
         return _PINNED_FEATURES[feature]
     env_key = f'MODEL_QOS_{feature.upper()}'
     override = os.environ.get(env_key, '').strip()
     if override:
-        # Parse model:provider format
+        profile_entry = _active_profile.get(feature, _DEFAULT_CONFIG)
         if ':' in override:
             parts = override.rsplit(':', 1)
             override_model, override_provider = parts[0], parts[1]
+            if override_provider not in _VALID_PROVIDERS:
+                logger.warning(
+                    'QoS override %s=%s has invalid provider %r — falling back to profile provider %s',
+                    env_key,
+                    override,
+                    override_provider,
+                    profile_entry[1],
+                )
+                override_provider = profile_entry[1]
         else:
             override_model = override
-            # Inherit provider from profile if not specified, fall back to inference
-            profile_entry = _active_profile.get(feature, _DEFAULT_CONFIG)
-            profile_provider = profile_entry[1]
+            # Model-only override: infer provider from model name to maintain safety guards
             override_provider = _classify_provider(override_model)
-            if override_provider != profile_provider:
-                logger.warning(
-                    'QoS override %s=%s (inferred provider: %s) differs from profile provider %s — '
-                    'use %s=%s:%s to be explicit',
-                    env_key,
-                    override,
-                    override_provider,
-                    profile_provider,
-                    env_key,
-                    override,
-                    override_provider,
-                )
         return (override_model, override_provider)
     return _active_profile.get(feature, _DEFAULT_CONFIG)
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -165,14 +165,20 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 #
 # Global switch:     MODEL_QOS=premium        (selects entire profile)
 #
-# Two profiles:
-#   premium — cost-effective default (80% of max quality)
-#   max     — maximum quality, latest flagship models
+# Profiles:
+#   premium      — cost-effective default, ~80% of max quality (OpenAI + Gemini cost savings)
+#   premium_0424 — full Gemini migration of premium, same quality target, ~40-60% cheaper
+#   max          — maximum quality, 100% flagship OpenAI, no cost optimization
+#   max_0424     — full Gemini migration of max, same quality target + o4-mini reasoning
+#   byok         — BYOK users, top-tier all-OpenAI (users pay their own API costs)
 # ---------------------------------------------------------------------------
 
 MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
     # -----------------------------------------------------------------------
-    # premium — cost-effective default (OpenAI + some Gemini for simple tasks)
+    # premium — cost-effective default, ~80% of max quality.
+    # Uses OpenAI flagship (gpt-5.4-mini) for core features, mid-tier (gpt-4.1-mini)
+    # for quality-sensitive tasks, nano for simple routing, and Gemini flash-lite
+    # for low-complexity text tasks (summaries, categories, titles) to save cost.
     # -----------------------------------------------------------------------
     'premium': {
         # OpenAI — conversation processing
@@ -220,14 +226,15 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # premium1 — full Gemini migration (40-60% OpenAI savings)
-    # All 5 phases from issue #6873: gpt-5.4-mini→Pro, gpt-4.1-mini→Flash,
-    # gpt-4.1-nano→Flash-Lite. Only chat_agent/web_search/wrapped stay.
+    # premium_0424 — full Gemini migration, release April 24 2026.
+    # Replaces all OpenAI models with Gemini equivalents for ~40-60% cost savings.
+    # Quality target: same as premium (80% of max) but on Gemini models.
+    # gpt-5.4-mini→Pro, gpt-4.1-mini→Flash, gpt-4.1-nano→Flash-Lite.
     #
     # ⚠️  Features marked [SO] use with_structured_output(method="json_schema")
     #     which may need method="function_calling" fallback on Gemini.
     # -----------------------------------------------------------------------
-    'premium1': {
+    'premium_0424': {
         # Gemini 2.5 Pro — flagship tier (Phase 1+4: replaces gpt-5.4-mini)
         'conv_action_items': ('gemini-2.5-pro', 'gemini'),  # PydanticOutputParser — safe
         'conv_structure': ('gemini-2.5-pro', 'gemini'),  # PydanticOutputParser — safe
@@ -269,7 +276,10 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # max — maximum quality, flagship OpenAI models
+    # max — maximum quality, 100% flagship OpenAI models.
+    # Uses gpt-5.4 for all core features, o4-mini for reasoning (learnings),
+    # gpt-4.1 for chat graph. No Gemini — pure OpenAI for best quality.
+    # Reserved for users who need the highest accuracy regardless of cost.
     # -----------------------------------------------------------------------
     'max': {
         # OpenAI — conversation processing
@@ -317,11 +327,12 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # max1 — max quality with Gemini optimization
-    # Same migration as premium1 but keeps o4-mini for learnings (reasoning).
-    # Upgrades gpt-4.1-mini tier to gemini-2.5-flash (not flash-lite).
+    # max_0424 — max quality with Gemini optimization, release April 24 2026.
+    # Same migration as premium_0424 but targets 100% quality on Gemini.
+    # Uses gemini-2.5-pro for flagship, gemini-2.5-flash for quality tier
+    # (not flash-lite), and keeps o4-mini for reasoning (learnings).
     # -----------------------------------------------------------------------
-    'max1': {
+    'max_0424': {
         # Gemini 2.5 Pro — flagship tier (replaces gpt-5.4)
         'conv_action_items': ('gemini-2.5-pro', 'gemini'),
         'conv_structure': ('gemini-2.5-pro', 'gemini'),
@@ -364,56 +375,12 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # byok_high — quality-optimized for BYOK users (all OpenAI, upgraded tiers)
-    # BYOK users pay their own API costs, so we upgrade mid-tier models.
-    # Flagship: gpt-5.4-mini, Quality: gpt-4.1 (up from 4.1-mini), Simple: gpt-4.1-mini (up from nano)
+    # byok — BYOK (Bring Your Own Key) users, maximum quality on all-OpenAI.
+    # BYOK users pay their own API costs, so we give them top-tier models.
+    # Uses gpt-5.4 flagship, gpt-5.4-mini quality, o4-mini reasoning,
+    # gpt-4.1-mini simple. No Gemini — BYOK keys are OpenAI keys.
     # -----------------------------------------------------------------------
-    'byok_high': {
-        # gpt-5.4-mini — flagship (same quality as premium)
-        'conv_action_items': ('gpt-5.4-mini', 'openai'),
-        'conv_structure': ('gpt-5.4-mini', 'openai'),
-        'conv_app_result': ('gpt-5.4-mini', 'openai'),
-        'daily_summary': ('gpt-5.4-mini', 'openai'),
-        'learnings': ('gpt-5.4-mini', 'openai'),
-        'chat_responses': ('gpt-5.4-mini', 'openai'),
-        'goals_advice': ('gpt-5.4-mini', 'openai'),
-        'app_generator': ('gpt-5.4-mini', 'openai'),
-        'persona_clone': ('gpt-5.4-mini', 'openai'),
-        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
-        'notifications': ('gpt-5.4-mini', 'openai'),
-        # gpt-4.1 — quality tier (upgraded from gpt-4.1-mini)
-        'external_structure': ('gpt-4.1', 'openai'),
-        'memories': ('gpt-4.1', 'openai'),
-        'memory_conflict': ('gpt-4.1', 'openai'),
-        'knowledge_graph': ('gpt-4.1', 'openai'),
-        'chat_extraction': ('gpt-4.1', 'openai'),
-        'chat_graph': ('gpt-4.1', 'openai'),
-        'goals': ('gpt-4.1', 'openai'),
-        'proactive_notification': ('gpt-4.1', 'openai'),
-        'openglass': ('gpt-4.1', 'openai'),
-        # gpt-4.1-mini — simple tasks (upgraded from gpt-4.1-nano)
-        'conv_app_select': ('gpt-4.1-mini', 'openai'),
-        'conv_folder': ('gpt-4.1-mini', 'openai'),
-        'conv_discard': ('gpt-4.1-mini', 'openai'),
-        'smart_glasses': ('gpt-4.1-mini', 'openai'),
-        'persona_chat': ('gpt-4.1-mini', 'openai'),
-        'daily_summary_simple': ('gpt-4.1-mini', 'openai'),
-        'memory_category': ('gpt-4.1-mini', 'openai'),
-        'session_titles': ('gpt-4.1-mini', 'openai'),
-        'followup': ('gpt-4.1-mini', 'openai'),
-        'onboarding': ('gpt-4.1-mini', 'openai'),
-        'app_integration': ('gpt-4.1-mini', 'openai'),
-        'trends': ('gpt-4.1-mini', 'openai'),
-        # Keep on original provider
-        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
-        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
-        'web_search': ('sonar-pro', 'perplexity'),
-    },
-    # -----------------------------------------------------------------------
-    # byok_max — maximum quality for BYOK users (all OpenAI, top-tier models)
-    # gpt-5.4 flagship, gpt-5.4-mini quality, o4-mini reasoning, gpt-4.1-mini simple
-    # -----------------------------------------------------------------------
-    'byok_max': {
+    'byok': {
         # gpt-5.4 — top-tier flagship
         'conv_action_items': ('gpt-5.4', 'openai'),
         'conv_structure': ('gpt-5.4', 'openai'),
@@ -469,9 +436,9 @@ if _active_profile_name not in MODEL_QOS_PROFILES:
     _active_profile_name = 'premium'
 _active_profile = MODEL_QOS_PROFILES[_active_profile_name]
 
-# BYOK QoS — all BYOK users get routed to byok_high (quality upgrade, all-OpenAI).
-# BYOK users pay their own API costs, so we give them higher-quality models.
-_byok_profile_name = 'byok_high'
+# BYOK QoS — all BYOK users get routed to 'byok' profile (top-tier all-OpenAI).
+# BYOK users pay their own API costs, so we give them maximum quality models.
+_byok_profile_name = 'byok'
 _byok_profile = MODEL_QOS_PROFILES[_byok_profile_name]
 
 # Features that can't go through get_llm() (non-ChatOpenAI providers).

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -170,7 +170,7 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 # Profiles:
 #   premium  — maximize cost savings while preserving 80% of max quality
 #   max      — 100% quality, best models available, no cost optimization
-#   byok     — exact copy of max (BYOK users pay their own API costs)
+#   byok     — same models as max (BYOK users pay their own API costs)
 # ---------------------------------------------------------------------------
 
 MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
@@ -276,7 +276,7 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
         'web_search': ('sonar-pro', 'perplexity'),
     },
     # -----------------------------------------------------------------------
-    # byok — exact copy of max. BYOK users pay their own API costs so they
+    # byok — same models as max. BYOK users pay their own API costs so they
     # get the same best-quality routing as max subscribers.
     # -----------------------------------------------------------------------
     'byok': {

--- a/backend/utils/llm/openglass.py
+++ b/backend/utils/llm/openglass.py
@@ -2,7 +2,7 @@ from typing import List
 
 from models.conversation_photo import ConversationPhoto
 from models.structured import Structured
-from utils.llm.clients import llm_mini
+from utils.llm.clients import get_llm
 from utils.llm.usage_tracker import track_usage, Features
 
 
@@ -28,6 +28,6 @@ async def describe_image(uid: str, base64_data: str) -> str:
     }
 
     with track_usage(uid, Features.OPENGLASS):
-        response = await llm_mini.ainvoke([message], config={"max_tokens": 150})
+        response = await get_llm('openglass').ainvoke([message], config={"max_tokens": 150})
     description = response.content
     return description.strip() if description is not None and description != '""' else ""


### PR DESCRIPTION
## Summary

Optimize LLM costs via QoS profile system with native Gemini SDK support and multi-provider routing.

### Changes
- **Native Gemini SDK**: Switch from OpenAI-compatible proxy to `ChatGoogleGenerativeAI` with 3-tier routing (Vertex AI → AI Studio → placeholder)
- **3 QoS profiles**: premium (default), max, byok — each mapping 28 features to optimal model/provider combos
- **Premium profile** (80% quality, cost-optimized):
  - gpt-5.4-mini for flagship features (conv processing, chat, daily summaries)
  - gpt-4.1-mini for quality-sensitive features (memories, knowledge graph, extraction)
  - gpt-4.1-nano for simple routing/classification (app select, folders, discard, persona, memory category, daily summary simple)
  - gemini-2.5-flash-lite for free-text features (session titles, followup, onboarding, app integration, trends)
  - claude-sonnet-4-6 for chat agent, sonar-pro for web search, gemini-3-flash-preview for wrapped analysis
- **Max profile**: 100% quality, best models (gpt-5.4 flagship, gpt-4.1-mini quality, gpt-4.1 chat_graph, o4-mini learnings)
- **BYOK profile**: Same models as max (separate dict, can diverge later). BYOK users pay their own costs.
- **Removed premium_0424 and max_0424**: Pricing research proved Gemini migration was NOT cost-effective (gemini-2.5-flash output $2.50/M > gpt-4.1-mini $1.60/M)
- **Provider-agnostic architecture**: `get_llm()` returns `BaseChatModel`, all callers work unchanged
- **USE_VERTEX_AI flag**: Explicit opt-in for Vertex AI (not auto-detected from GOOGLE_CLOUD_PROJECT). Dev=true, prod=false initially.
- **BYOK OpenRouter redirect**: Redirects OpenRouter Gemini models to native Gemini SDK for user-key scenarios
- **Comprehensive tests**: 89 unit tests + 145 integration test cases covering all profiles and providers

### Key files
- `backend/utils/llm/clients.py` — Core QoS routing, profile definitions, provider factories
- `backend/tests/unit/test_omi_qos_tiers.py` — Unit tests for all profiles and routing logic
- `backend/tests/integration/test_qos_*.py` — Integration tests with real LLM calls
- `backend/charts/backend-listen/*_values.yaml` — Helm chart env vars (USE_VERTEX_AI)

---

## Test Results (2026-04-26)

### L1: Unit tests (`test_omi_qos_tiers.py`)
**89 passed, 0 failed** (7.4s)

### L1: Real LLM calls (`test_qos_real_llm.py`)
**38 passed, 0 failed** (30s, Gemini tests deselected due to free-tier rate limits)

| Test Class | Model | Count | Result |
|---|---|---|---|
| TestPremiumFlagship | gpt-5.4-mini | 11 | PASS |
| TestPremiumMini | gpt-4.1-mini | 8 | PASS |
| TestPremiumNano | gpt-4.1-nano | 7 | PASS |
| TestPremiumVision | gpt-4.1-mini | 1 | PASS |
| TestPremiumAnthropic | claude-sonnet-4-6 | 1 | PASS |
| TestPremiumPerplexity | sonar-pro | 1 | PASS |
| TestPremiumOpenRouter | gemini-3-flash-preview | 1 | PASS |
| TestProfileRouting | all profiles | 4 | PASS |
| TestStreamingClients | openai + openrouter | 2 | PASS |
| TestCacheKeyReal | gpt-5.4-mini | 1 | PASS |

### L1: All features live (`test_qos_all_features_l1.py`)
**39 passed, 0 failed** (35.7s)
- All 33 `get_llm` features invoke successfully
- Anthropic + Perplexity specialty providers verified
- Streaming verified for openai + openrouter
- Profile feature parity: premium = max = byok (same 28 features each)

### L2: CP9 live (`test_qos_live_cp9.py`)
**65 passed, 0 failed** (43.5s)
- P1: 28 OpenAI + Gemini routing tests
- P3-P5: BYOK client creation + provider mapping + profile independence
- P6: Structured output (chat_extraction, proactive_notification, conv_app_select, external_structure, trends)
- P7: Prompt caching with cache keys
- P8-P9: Streaming + OpenRouter config
- P10-P11: Anthropic + Perplexity specialty providers
- P12: Gemini native SDK factory, caching, streaming, real invocation
- P13: QoS info completeness

**Total: 231 tests passed, 0 failed across 4 test suites**

---

## Deployment Plan (consulted with mon)

### Phase 1: Merge + Deploy to Dev
1. Merge PR to main
2. Deploy backend-listen to dev: `gh workflow run gcp_backend.yml -f environment=dev -f branch=main`
3. Verify in dev:
   - USE_VERTEX_AI=true is active in dev pods
   - Gemini features (session_titles, followup, onboarding, app_integration, trends) route through Vertex AI
   - Verify dev GKE service account has `roles/aiplatform.user` IAM permission
   - Check us-central1 Vertex AI quota for gemini-2.5-flash-lite
4. Soak 24-48h on dev

### Phase 2: Deploy to Prod
1. Flip `USE_VERTEX_AI=false` → `true` in prod Helm chart (separate commit)
2. Verify prod GKE SA has `aiplatform.endpoints.predict` permission
3. Deploy backend-listen to prod
4. Monitor Gemini call latency + error rates

### Pre-deployment Checklist
- [ ] Dev GKE SA has `roles/aiplatform.user`
- [ ] Prod GKE SA has `roles/aiplatform.user`
- [ ] us-central1 Vertex AI quota sufficient for gemini-2.5-flash-lite
- [ ] GOOGLE_CLOUD_PROJECT env var populated in GKE pods

### Rollback Plan
- **Quick (config-only, ~3min)**: Set `USE_VERTEX_AI=false` in Helm values → redeploy. Falls back to GEMINI_API_KEY (AI Studio).
- **Full**: Revert the PR. Check if any subsequent PRs depend on `BaseChatModel` return type before reverting.
- **Safety net**: Keep GEMINI_API_KEY configured in prod even after enabling Vertex AI, so the AI Studio fallback stays warm.

---

---

## L1 Live Test Evidence (2026-04-29)

### Backend Boot
- Backend starts successfully on PR branch with `langchain-google-genai==2.1.12`
- All 35 QoS features load correctly, health endpoint returns `{"status":"ok"}`

### QoS Routing Verification
- `get_llm()` returns correct `BaseChatModel` for all LangChain providers:
  - `conv_structure` (openai) → `ChatOpenAI` ✓
  - `session_titles` (gemini) → `ChatGoogleGenerativeAI` ✓
  - `wrapped_analysis` (openrouter) → `ChatOpenAI` ✓
  - `goals` (openai) → `ChatOpenAI` ✓
  - `persona_chat` (openai) → `ChatOpenAI` ✓
- `get_model()` returns correct model names for non-LangChain providers:
  - `chat_agent` (anthropic) → `claude-sonnet-4-6` ✓
  - `web_search` (perplexity) → `sonar-pro` ✓
- Profile switching works (premium → max → byok)

### Real API Calls
- OpenAI (goals, gpt-4.1-mini): Response received ✓
- Gemini via Vertex AI (gemini-2.5-flash, based-hardware-dev): Response received ✓

### Critical Fix: Missing Dependency
- `langchain-google-genai` was NOT in `requirements.txt` — would crash backend on deploy
- Fixed in commit `5ed1d68ff`: added `langchain-google-genai==2.1.12` + transitive deps

## Vertex AI IAM Verification (Concern #4)

### Dev Project (based-hardware-dev)
- Vertex AI API: enabled ✓
- Service agent: provisioned ✓
- Joan SA (`local-development-joan@`): Vertex AI calls succeed (tested live with gemini-2.5-flash) ✓

### Prod Project (based-hardware)
- Vertex AI API: enabled ✓
- Service agent: provisioned (`service-208440318997@gcp-sa-aiplatform.iam.gserviceaccount.com`) ✓
- `GOOGLE_APPLICATION_CREDENTIALS=google-credentials.json` → no volume mount → ADC fallback → GKE node SA (default compute)
- Default compute SA has `roles/editor` with 444 aiplatform permissions including `aiplatform.endpoints.predict` ✓
- `USE_VERTEX_AI=false` in prod (safe) — Vertex AI will not be invoked until explicitly flipped
- **When flipped**: `roles/editor` on default compute SA covers all required Vertex AI permissions

### Pre-deployment Checklist Update
- [x] Vertex AI API enabled on both dev and prod ✓
- [x] Service agents provisioned on both projects ✓
- [x] Dev IAM verified (live call succeeded) ✓
- [x] Prod IAM verified (`roles/editor` includes aiplatform permissions) ✓
- [x] `langchain-google-genai` added to requirements.txt ✓
- [ ] us-central1 Vertex AI quota sufficient for gemini-2.5-flash-lite

Closes #6873

_by AI for @beastoin_