### PR TITLE
Fix #6940: rate limit all memories endpoints + error handling

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -57,11 +57,12 @@ async def create_memory(
     memory.category = MemoryCategory.manual
     memory_db = MemoryDB.from_memory(memory, uid, None, True)
 
-    def _persist():
-        memories_db.create_memory(uid, memory_db.dict())
+    # Build payload outside try so serialization bugs aren't misreported as
+    # transient 503s — only the Firestore write should be retryable.
+    payload = memory_db.dict()
 
     try:
-        await asyncio.to_thread(_persist)
+        await asyncio.to_thread(memories_db.create_memory, uid, payload)
     except Exception:
         logger.exception("Firestore create_memory failed uid=%s", uid)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -50,15 +50,31 @@ def _validate_memory(uid: str, memory_id: str) -> dict:
 
 
 @router.post('/v3/memories', tags=['memories'], response_model=MemoryDB)
-def create_memory(memory: Memory, uid: str = Depends(auth.get_current_user_uid)):
+async def create_memory(
+    memory: Memory,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:create")),
+):
     memory.category = MemoryCategory.manual
     memory_db = MemoryDB.from_memory(memory, uid, None, True)
-    memories_db.create_memory(uid, memory_db.dict())
 
-    upsert_memory_vector(uid, memory_db.id, memory_db.content, memory_db.category.value)
+    def _persist():
+        memories_db.create_memory(uid, memory_db.dict())
+
+    try:
+        await asyncio.to_thread(_persist)
+    except Exception:
+        logger.exception("Firestore create_memory failed uid=%s", uid)
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+
+    try:
+        await asyncio.to_thread(upsert_memory_vector, uid, memory_db.id, memory_db.content, memory_db.category.value)
+    except Exception:
+        logger.exception("Vector upsert failed uid=%s memory_id=%s (memory saved, vector missing)", uid, memory_db.id)
 
     if memory.visibility == 'public':
-        critical_executor.submit(update_personas_async, uid)
+        loop = asyncio.get_running_loop()
+        loop.run_in_executor(critical_executor, update_personas_async, uid)
+
     return memory_db
 
 
@@ -146,40 +162,55 @@ def get_memories(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_
 
 
 @router.delete('/v3/memories/{memory_id}', tags=['memories'])
-def delete_memory(memory_id: str, uid: str = Depends(auth.get_current_user_uid)):
+def delete_memory(
+    memory_id: str,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:delete")),
+):
     _validate_memory(uid, memory_id)
     memories_db.delete_memory(uid, memory_id)
-    delete_memory_vector(uid, memory_id)
+    try:
+        delete_memory_vector(uid, memory_id)
+    except Exception:
+        logger.exception("Vector delete failed uid=%s memory_id=%s (Firestore deleted)", uid, memory_id)
     return {'status': 'ok'}
 
 
 @router.delete('/v3/memories', tags=['memories'])
-def delete_memories(uid: str = Depends(auth.get_current_user_uid)):
+def delete_memories(
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:delete_all")),
+):
     memories_db.delete_all_memories(uid)
     return {'status': 'ok'}
 
 
 @router.post('/v3/memories/{memory_id}/review', tags=['memories'])
-def review_memory(memory_id: str, value: bool, uid: str = Depends(auth.get_current_user_uid)):
+def review_memory(
+    memory_id: str,
+    value: bool,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:modify")),
+):
     _validate_memory(uid, memory_id)
     memories_db.review_memory(uid, memory_id, value)
     return {'status': 'ok'}
 
 
 @router.patch('/v3/memories/{memory_id}', tags=['memories'])
-def edit_memory(memory_id: str, value: str, uid: str = Depends(auth.get_current_user_uid)):
+def edit_memory(
+    memory_id: str,
+    value: str,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:modify")),
+):
     _validate_memory(uid, memory_id)
-    # first_word = value.split(' ')[0]
-    # user_name = get_user_name(uid, use_default=False)
-    # if user_name == first_word:
-    #     value = value[len(first_word):].strip()
-
     memories_db.edit_memory(uid, memory_id, value)
     return {'status': 'ok'}
 
 
 @router.patch('/v3/memories/{memory_id}/visibility', tags=['memories'])
-def update_memory_visibility(memory_id: str, value: str, uid: str = Depends(auth.get_current_user_uid)):
+def update_memory_visibility(
+    memory_id: str,
+    value: str,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:modify")),
+):
     _validate_memory(uid, memory_id)
     if value not in ['public', 'private']:
         raise HTTPException(status_code=400, detail='Invalid visibility value')

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -79,6 +79,7 @@ pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_rate_limiting.py -v
 pytest tests/unit/test_memories_batch.py -v
+pytest tests/unit/test_memories_create.py -v
 pytest tests/unit/test_sync_v2.py -v
 pytest tests/unit/test_sync_transcription_prefs.py -v
 pytest tests/unit/test_vision_stream_async.py -v

--- a/backend/tests/unit/test_memories_create.py
+++ b/backend/tests/unit/test_memories_create.py
@@ -115,13 +115,28 @@ class TestCreateMemoryErrorHandling:
         source = _read_router()
         assert re.search(r'async def create_memory\(', source), "create_memory must be async def"
 
-    def test_create_memory_uses_to_thread(self):
-        """Blocking work must be offloaded via asyncio.to_thread."""
+    def test_create_memory_uses_to_thread_for_firestore(self):
+        """Firestore write in create_memory must use asyncio.to_thread."""
         source = _read_router()
-        # Must have at least 2 to_thread calls (Firestore + vector)
-        to_thread_calls = re.findall(r'asyncio\.to_thread\(', source)
-        # At least 3: batch's _persist, create's Firestore, create's vector
-        assert len(to_thread_calls) >= 3, f"Expected >=3 asyncio.to_thread calls, got {len(to_thread_calls)}"
+        # Extract the create_memory function body (between its def and the next @router)
+        match = re.search(
+            r'(async def create_memory\(.+?)(?=\n@router\.)', source, re.DOTALL
+        )
+        assert match, "create_memory function not found"
+        fn_body = match.group(1)
+        assert 'asyncio.to_thread(memories_db.create_memory' in fn_body, \
+            "create_memory must offload Firestore write via asyncio.to_thread"
+
+    def test_create_memory_uses_to_thread_for_vector(self):
+        """Vector upsert in create_memory must use asyncio.to_thread."""
+        source = _read_router()
+        match = re.search(
+            r'(async def create_memory\(.+?)(?=\n@router\.)', source, re.DOTALL
+        )
+        assert match, "create_memory function not found"
+        fn_body = match.group(1)
+        assert 'asyncio.to_thread' in fn_body and 'upsert_memory_vector' in fn_body, \
+            "create_memory must offload vector upsert via asyncio.to_thread"
 
     def test_firestore_write_has_error_handling(self):
         """Firestore write in create_memory must be wrapped in try/except."""
@@ -157,9 +172,39 @@ class TestCreateMemoryErrorHandling:
 # ---------------------------------------------------------------------------
 
 
-class TestDeleteAllRateLimit:
+class TestPolicyBoundaries:
+    """Verify rate limit policy values are safe and reasonable."""
+
     def test_delete_all_limit_is_tight(self):
         """delete_all is extremely destructive — must have very tight limits."""
         max_req, window = RATE_POLICIES["memories:delete_all"]
         assert max_req <= 5, f"delete_all limit too high: {max_req}"
         assert window >= 3600, f"delete_all window too short: {window}"
+
+    def test_modify_limit_higher_than_create(self):
+        """Modify (lightweight Firestore writes) should allow more than create (OpenAI+Pinecone)."""
+        create_max, _ = RATE_POLICIES["memories:create"]
+        modify_max, _ = RATE_POLICIES["memories:modify"]
+        assert modify_max > create_max, \
+            f"modify ({modify_max}) should be higher than create ({create_max})"
+
+    def test_delete_limit_matches_create(self):
+        """Single delete should match create rate (same Firestore+Pinecone cost)."""
+        create_max, create_window = RATE_POLICIES["memories:create"]
+        delete_max, delete_window = RATE_POLICIES["memories:delete"]
+        assert delete_max == create_max
+        assert delete_window == create_window
+
+    def test_delete_all_much_tighter_than_single_delete(self):
+        """Bulk delete must be much tighter than single delete."""
+        delete_max, _ = RATE_POLICIES["memories:delete"]
+        delete_all_max, _ = RATE_POLICIES["memories:delete_all"]
+        assert delete_all_max < delete_max / 10, \
+            f"delete_all ({delete_all_max}) should be <<< delete ({delete_max})"
+
+    def test_all_memory_policies_use_1h_window(self):
+        """All memory policies should use consistent 1-hour windows."""
+        for name in ["memories:create", "memories:batch", "memories:modify",
+                      "memories:delete", "memories:delete_all"]:
+            _, window = RATE_POLICIES[name]
+            assert window == 3600, f"{name} window is {window}, expected 3600"

--- a/backend/tests/unit/test_memories_create.py
+++ b/backend/tests/unit/test_memories_create.py
@@ -1,0 +1,165 @@
+"""
+Tests for POST /v3/memories error handling and rate limit wiring.
+
+Regression goal (#6940): POST /v3/memories must
+  (a) have memories:create rate limit applied,
+  (b) return 503 on Firestore failure (not unhandled 500),
+  (c) survive vector upsert failure without 500 (memory still returned),
+  (d) not attempt vector upsert when Firestore write fails,
+  (e) run blocking work off the event loop via asyncio.to_thread.
+
+The router import chain (database.memories → encryption → cryptography)
+requires production env vars, so behavior tests use source-level verification
+matching the repo pattern in test_rate_limiting.py.
+"""
+
+import os
+import re
+
+import pytest
+
+from utils.rate_limit_config import RATE_POLICIES
+
+ROUTER_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'memories.py')
+
+
+def _read_router():
+    with open(ROUTER_PATH) as f:
+        return f.read()
+
+
+def _grep_router(pattern: str) -> list[str]:
+    """Return lines matching pattern in the memories router."""
+    matches = []
+    with open(ROUTER_PATH) as f:
+        for line in f:
+            if re.search(pattern, line):
+                matches.append(line.strip())
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Policy existence tests
+# ---------------------------------------------------------------------------
+
+
+class TestMemoriesRateLimitPolicies:
+    def test_memories_create_policy_exists(self):
+        assert "memories:create" in RATE_POLICIES
+        max_req, window = RATE_POLICIES["memories:create"]
+        assert max_req == 60
+        assert window == 3600
+
+    def test_memories_modify_policy_exists(self):
+        assert "memories:modify" in RATE_POLICIES
+        max_req, window = RATE_POLICIES["memories:modify"]
+        assert max_req == 120
+        assert window == 3600
+
+    def test_memories_delete_policy_exists(self):
+        assert "memories:delete" in RATE_POLICIES
+        max_req, window = RATE_POLICIES["memories:delete"]
+        assert max_req == 60
+        assert window == 3600
+
+    def test_memories_delete_all_policy_exists(self):
+        assert "memories:delete_all" in RATE_POLICIES
+        max_req, window = RATE_POLICIES["memories:delete_all"]
+        assert max_req == 2
+        assert window == 3600
+
+
+# ---------------------------------------------------------------------------
+# Rate limit wiring tests (source-level grep)
+# ---------------------------------------------------------------------------
+
+
+class TestMemoriesRateLimitWiring:
+    def test_create_endpoint_has_rate_limit(self):
+        matches = _grep_router(r"with_rate_limit.*memories:create")
+        assert len(matches) == 1, f"POST /v3/memories must have memories:create, found: {matches}"
+
+    def test_batch_endpoint_has_rate_limit(self):
+        matches = _grep_router(r"with_rate_limit.*memories:batch")
+        assert len(matches) == 1, f"POST /v3/memories/batch must have memories:batch, found: {matches}"
+
+    def test_delete_endpoint_has_rate_limit(self):
+        matches = _grep_router(r"with_rate_limit.*memories:delete[^_]")
+        assert len(matches) == 1, f"DELETE /v3/memories/{{id}} must have memories:delete, found: {matches}"
+
+    def test_delete_all_endpoint_has_rate_limit(self):
+        matches = _grep_router(r"with_rate_limit.*memories:delete_all")
+        assert len(matches) == 1, f"DELETE /v3/memories must have memories:delete_all, found: {matches}"
+
+    def test_review_endpoint_has_rate_limit(self):
+        matches = _grep_router(r"with_rate_limit.*memories:modify")
+        assert len(matches) >= 1, f"Review/edit/visibility must have memories:modify, found: {matches}"
+
+    def test_all_write_endpoints_rate_limited(self):
+        """Every write endpoint in memories.py must use with_rate_limit."""
+        matches = _grep_router(r"with_rate_limit.*memories:")
+        # create, batch, delete, delete_all, modify(review), modify(edit), modify(visibility) = 7
+        assert len(matches) == 7, f"Expected 7 rate-limited endpoints, got {len(matches)}: {matches}"
+
+
+# ---------------------------------------------------------------------------
+# Error handling tests (source-level verification)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMemoryErrorHandling:
+    """Verify error handling structure in create_memory source code."""
+
+    def test_create_memory_is_async(self):
+        """create_memory must be async def (prevents threadpool exhaustion)."""
+        source = _read_router()
+        assert re.search(r'async def create_memory\(', source), "create_memory must be async def"
+
+    def test_create_memory_uses_to_thread(self):
+        """Blocking work must be offloaded via asyncio.to_thread."""
+        source = _read_router()
+        # Must have at least 2 to_thread calls (Firestore + vector)
+        to_thread_calls = re.findall(r'asyncio\.to_thread\(', source)
+        # At least 3: batch's _persist, create's Firestore, create's vector
+        assert len(to_thread_calls) >= 3, f"Expected >=3 asyncio.to_thread calls, got {len(to_thread_calls)}"
+
+    def test_firestore_write_has_error_handling(self):
+        """Firestore write in create_memory must be wrapped in try/except."""
+        source = _read_router()
+        # The pattern: try + to_thread(_persist) + except -> 503
+        assert 'HTTPException(status_code=503' in source, "Firestore failure must return 503"
+
+    def test_vector_upsert_has_error_handling(self):
+        """Vector upsert failure must be caught and logged (not 500)."""
+        source = _read_router()
+        assert 'Vector upsert failed' in source, "Vector upsert failure must be logged"
+
+    def test_vector_delete_has_error_handling(self):
+        """Vector delete in delete_memory must be caught (not 500)."""
+        source = _read_router()
+        assert 'Vector delete failed' in source, "Vector delete failure must be logged"
+
+    def test_firestore_failure_blocks_vector_upsert(self):
+        """If Firestore fails (raises), vector upsert must not execute.
+
+        Verified by structural ordering: Firestore try/except with raise
+        appears before vector try/except in the create_memory function.
+        """
+        source = _read_router()
+        # Find positions of both error-handling blocks
+        firestore_pos = source.find('HTTPException(status_code=503')
+        vector_pos = source.find('Vector upsert failed')
+        assert firestore_pos < vector_pos, "Firestore error handling must come before vector upsert"
+
+
+# ---------------------------------------------------------------------------
+# Delete-all safety tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAllRateLimit:
+    def test_delete_all_limit_is_tight(self):
+        """delete_all is extremely destructive — must have very tight limits."""
+        max_req, window = RATE_POLICIES["memories:delete_all"]
+        assert max_req <= 5, f"delete_all limit too high: {max_req}"
+        assert window >= 3600, f"delete_all window too short: {window}"

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -332,6 +332,10 @@ class TestRouterPolicyMapping(unittest.TestCase):
             "agent:execute_tool",
             "mcp:sse",
             "memories:create",
+            "memories:modify",
+            "memories:delete",
+            "memories:delete_all",
+            "memories:batch",
             "goals:suggest",
             "goals:advice",
             "goals:extract",
@@ -424,6 +428,19 @@ class TestRouterWiring(unittest.TestCase):
     def test_agent_tools_wired(self):
         matches = self._grep_file("routers/agent_tools.py", r"with_rate_limit.*agent:")
         self.assertGreaterEqual(len(matches), 1, "agent_tools.py missing rate limit wiring")
+
+    def test_memories_router_has_rate_limits(self):
+        matches = self._grep_file("routers/memories.py", r"with_rate_limit.*memories:")
+        # create, batch, delete, delete_all, modify(review), modify(edit), modify(visibility) = 7
+        self.assertEqual(len(matches), 7, f"memories.py expected 7 rate limits, got {len(matches)}")
+
+    def test_memories_create_endpoint_rate_limited(self):
+        matches = self._grep_file("routers/memories.py", r"with_rate_limit.*memories:create")
+        self.assertEqual(len(matches), 1, "POST /v3/memories must have memories:create rate limit")
+
+    def test_memories_delete_all_endpoint_rate_limited(self):
+        matches = self._grep_file("routers/memories.py", r"with_rate_limit.*memories:delete_all")
+        self.assertEqual(len(matches), 1, "DELETE /v3/memories must have memories:delete_all rate limit")
 
 
 class TestRealCheckRateLimit(unittest.TestCase):

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -58,6 +58,12 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # Memory batch writes — each request can create up to 100 memories, so the
     # per-request cap is intentionally tighter than memories:create.
     "memories:batch": (30, 3600),
+    # Memory mutations — lightweight Firestore writes
+    "memories:modify": (120, 3600),
+    # Memory deletes — destructive operations
+    "memories:delete": (60, 3600),
+    # Delete-all is extremely destructive; tight cap with one retry cushion
+    "memories:delete_all": (2, 3600),
     # Goals — single LLM call
     "goals:suggest": (30, 3600),
     "goals:advice": (30, 3600),


### PR DESCRIPTION
## Summary

Fixes #6940 — POST /v3/memories returned unhandled 500s on Firestore/vector failures and had no per-endpoint rate limits for delete, modify, or delete-all operations.

### Changes

**Rate limiting (3 new policies):**
- `memories:modify` (120/hr) — review, edit, visibility endpoints
- `memories:delete` (60/hr) — single memory delete
- `memories:delete_all` (2/hr) — bulk delete (extremely destructive)
- All 7 write endpoints now use `with_rate_limit()` wrapper

**Error handling (POST /v3/memories):**
- Firestore write failure → 503 (not unhandled 500)
- Vector upsert failure → caught + logged (memory still returned)
- Firestore failure blocks vector upsert (fail-closed ordering)
- `create_memory` converted to `async def` + `asyncio.to_thread` for both Firestore and vector calls
- Payload serialization moved outside try/except to avoid misreporting serialization bugs as transient 503s

**Delete endpoint hardening:**
- Vector delete failure caught + logged (Firestore delete still succeeds)

### Tests (22 tests, 5 classes)

- `TestMemoriesRateLimitPolicies` (4) — policy existence + values
- `TestMemoriesRateLimitWiring` (6) — source-level grep for with_rate_limit on all 7 endpoints
- `TestCreateMemoryErrorHandling` (7) — async check, function-specific to_thread for Firestore and vector, error handling patterns, ordering
- `TestPolicyBoundaries` (5) — modify > create, delete = create, delete_all <<< delete, 1h windows
- Uses source-level grep pattern (import chain requires GCP credentials for behavioral tests)

### Evidence

```
22 passed in 0.07s
```

### Risks

- Rate limit values may need tuning based on production traffic patterns
- Source-level tests are brittle to refactors (but match existing repo pattern in test_rate_limiting.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)