### PR TITLE
fix(macos): pin VNRecognizeTextRequest to Revision 2 to avoid macOS 26 crash

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed crash on macOS 26 in OCR screen indexing — Vision TextRecognition no longer asserts on empty array when processing certain screen captures"
+  ],
   "releases": [
     {
       "version": "0.11.352",

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,6 @@
 {
   "unreleased": [
-    "Fixed crash on macOS 26 in OCR screen indexing — Vision TextRecognition no longer asserts on empty array when processing certain screen captures"
+    "Fixed crash on macOS 26 in OCR screen indexing — pinned Vision TextRecognition to Revision 2 to work around an Apple-internal EXC_BREAKPOINT regression in VNRecognizeTextRequestRevision3"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -213,24 +213,21 @@ actor RewindOCRService {
 
             request.recognitionLevel = recognitionLevel
             request.usesLanguageCorrection = false
-            // Use automatic language detection instead of a fixed ["en-US"] list.
-            // On macOS 26, TextRecognition's internal Swift concurrency tasks access the
-            // recognitionLanguages array via ObjC bridge; when restricted to a single
-            // language and the image content triggers an empty-candidates path, the
-            // framework asserts on objectAtSubscript:0 of an empty __SwiftNativeNSArray
-            // (EXC_BREAKPOINT / _assertionFailure). Letting Vision auto-detect avoids
-            // that code path. (Refs: issue #6944, #5891)
-            request.automaticallyDetectsLanguage = true
+            request.recognitionLanguages = ["en-US"]
+            // Pin to Revision 2 to avoid an EXC_BREAKPOINT crash in TextRecognition
+            // Revision 3 on macOS 26. The crash happens in a cooperative thread spawned
+            // internally by VNRecognizeTextRequestRevision3 — no Omi code appears in the
+            // faulting thread's stack — confirming this is an Apple regression in that
+            // revision's Swift concurrency usage. Revision 2 avoids that code path while
+            // retaining acceptable OCR quality on the macOS 14+ deployment target.
+            // (Refs: issue #6944, crash queue com.apple.VNRecognizeTextRequestRevision3)
+            request.revision = VNRecognizeTextRequestRevision2
 
-            // autoreleasepool ensures Vision/TextRecognition ObjC objects are released
-            // promptly and don't outlive the handler's cooperative tasks on macOS 26.
-            autoreleasepool {
-                let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-                do {
-                    try handler.perform([request])
-                } catch {
-                    continuation.resume(throwing: RewindError.ocrFailed(error.localizedDescription))
-                }
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            do {
+                try handler.perform([request])
+            } catch {
+                continuation.resume(throwing: RewindError.ocrFailed(error.localizedDescription))
             }
         }
     }

--- a/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -215,13 +215,13 @@ actor RewindOCRService {
             request.usesLanguageCorrection = false
             request.recognitionLanguages = ["en-US"]
             // Pin to Revision 2 to avoid an EXC_BREAKPOINT crash in TextRecognition
-            // Revision 3 on macOS 26. The crash happens in a cooperative thread spawned
-            // internally by VNRecognizeTextRequestRevision3 — no Omi code appears in the
-            // faulting thread's stack — confirming this is an Apple regression in that
-            // revision's Swift concurrency usage. Revision 2 avoids that code path while
-            // retaining acceptable OCR quality on the macOS 14+ deployment target.
-            // (Refs: issue #6944, crash queue com.apple.VNRecognizeTextRequestRevision3)
-            // TODO: Remove once Apple fixes Revision 3 on macOS 26.
+            // Revision 3 (confirmed on macOS 15.4.1 and macOS 26). Revision 3 internally
+            // calls into a Swift array via ObjC bridge and hits an assertion failure in
+            // __EmptyArrayStorage._objectAt — no Omi code appears in the faulting thread,
+            // confirming this is an Apple regression in VNRecognizeTextRequestRevision3.
+            // Revision 2 avoids that code path with acceptable OCR quality on macOS 14+.
+            // (Refs: issue #6944, crash thread libswiftCore _assertionFailure)
+            // TODO: Remove once Apple fixes VNRecognizeTextRequestRevision3.
             request.revision = VNRecognizeTextRequestRevision2
 
             let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])

--- a/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -213,14 +213,24 @@ actor RewindOCRService {
 
             request.recognitionLevel = recognitionLevel
             request.usesLanguageCorrection = false
-            request.recognitionLanguages = ["en-US"]
+            // Use automatic language detection instead of a fixed ["en-US"] list.
+            // On macOS 26, TextRecognition's internal Swift concurrency tasks access the
+            // recognitionLanguages array via ObjC bridge; when restricted to a single
+            // language and the image content triggers an empty-candidates path, the
+            // framework asserts on objectAtSubscript:0 of an empty __SwiftNativeNSArray
+            // (EXC_BREAKPOINT / _assertionFailure). Letting Vision auto-detect avoids
+            // that code path. (Refs: issue #6944, #5891)
+            request.automaticallyDetectsLanguage = true
 
-            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-
-            do {
-                try handler.perform([request])
-            } catch {
-                continuation.resume(throwing: RewindError.ocrFailed(error.localizedDescription))
+            // autoreleasepool ensures Vision/TextRecognition ObjC objects are released
+            // promptly and don't outlive the handler's cooperative tasks on macOS 26.
+            autoreleasepool {
+                let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+                do {
+                    try handler.perform([request])
+                } catch {
+                    continuation.resume(throwing: RewindError.ocrFailed(error.localizedDescription))
+                }
             }
         }
     }

--- a/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -221,6 +221,7 @@ actor RewindOCRService {
             // revision's Swift concurrency usage. Revision 2 avoids that code path while
             // retaining acceptable OCR quality on the macOS 14+ deployment target.
             // (Refs: issue #6944, crash queue com.apple.VNRecognizeTextRequestRevision3)
+            // TODO: Remove once Apple fixes Revision 3 on macOS 26.
             request.revision = VNRecognizeTextRequestRevision2
 
             let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])


### PR DESCRIPTION
## Summary

- `VNRecognizeTextRequestRevision3` crashes internally with `EXC_BREAKPOINT` (`_assertionFailure`) — confirmed on **macOS 15.4.1** and **macOS 26**, so this is a bug in Revision 3 itself, not a macOS 26-specific regression
- The crash happens in `__EmptyArrayStorage._objectAt` via ObjC bridge — no app code appears in the faulting thread's stack, confirming this is an Apple regression in VNRecognizeTextRequestRevision3
- Fix: pin `VNRecognizeTextRequest.revision` to `VNRecognizeTextRequestRevision2`, which avoids the broken code path while retaining acceptable OCR quality on our macOS 14+ deployment target

Fixes #6944

## Crash details

**Faulting thread (no app frames — pure Apple internal crash):**
```
_assertionFailure(_:_:file:line:flags:)
__EmptyArrayStorage._objectAt(_:)
@objc __SwiftNativeNSArrayWithContiguousStorage.objectAtSubscript(_:)
TextRecognition (internal frames)
-[VNRecognizeTextRequest internalPerformRevision:inContext:error:]
```

**App code (waiting for Vision to finish):**
```
VNImageRequestHandler.performRequests(...)
closure #2 in RewindOCRService.extractTextWithBounds(from:)
RewindIndexer.processFrame(...)
```

## Test plan

- [ ] Build and run on macOS 15 or macOS 26 — app should stay running past the previous crash window
- [ ] Confirm OCR screen indexing still works (search for recently viewed text in Rewind)
- [ ] Verify no regression (Revision 2 is available since macOS 10.15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)