### PR TITLE
refactor(backend): migrate Gemini from AI Studio to Vertex AI (#6935)

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -79,11 +79,10 @@ ingress:
   #      - chart-example.local
 
 env:
-  - name: GEMINI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: dev-omi-backend-secrets
-        key: GEMINI_API_KEY
+  - name: GCP_LOCATION
+    value: "global"
+  - name: GCP_EMBEDDING_LOCATION
+    value: "us-central1"
   - name: DEEPGRAM_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -79,11 +79,10 @@ ingress:
   #      - chart-example.local
 
 env:
-  - name: GEMINI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: prod-omi-backend-secrets
-        key: GEMINI_API_KEY
+  - name: GCP_LOCATION
+    value: "global"
+  - name: GCP_EMBEDDING_LOCATION
+    value: "us-central1"
   - name: BUCKET_SPEECH_PROFILES
     value: "speech-profiles"
   - name: GITHUB_TOKEN

--- a/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
@@ -56,8 +56,6 @@ externalSecret:
       remoteKey: ENCRYPTION_SECRET
     - secretKey: SERVICE_ACCOUNT_JSON
       remoteKey: SERVICE_ACCOUNT_JSON
-    - secretKey: GEMINI_API_KEY
-      remoteKey: GEMINI_API_KEY
     - secretKey: TWILIO_ACCOUNT_SID
       remoteKey: TWILIO_ACCOUNT_SID
     - secretKey: TWILIO_AUTH_TOKEN

--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -64,8 +64,6 @@ externalSecret:
       remoteKey: STT_SERVICE_MODELS
     - secretKey: ENCRYPTION_SECRET
       remoteKey: ENCRYPTION_SECRET
-    - secretKey: GEMINI_API_KEY
-      remoteKey: GEMINI_API_KEY
     - secretKey: TWILIO_ACCOUNT_SID
       remoteKey: TWILIO_ACCOUNT_SID
     - secretKey: TWILIO_AUTH_TOKEN

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -93,6 +93,7 @@ kiwisolver==1.4.5
 langchain==0.3.27
 langchain-community==0.3.31
 langchain-core==0.3.79
+langchain-google-genai==4.2.2
 langchain-openai==0.3.35
 langchain-pinecone==0.2.12
 pinecone==7.3.0

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -103,6 +103,7 @@ pytest tests/unit/test_async_http_infrastructure.py -v
 pytest tests/unit/test_clean_sweep_migrations.py -v
 pytest tests/unit/test_omi_qos_tiers.py -v
 pytest tests/unit/test_byok_security.py -v
+pytest tests/unit/test_vertex_ai_migration.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -124,14 +124,7 @@ class TestPremiumNano:
         'conv_app_select',
         'conv_folder',
         'conv_discard',
-        'daily_summary_simple',
-        'memory_category',
-        'session_titles',
-        'followup',
         'smart_glasses',
-        'onboarding',
-        'app_integration',
-        'trends',
         'persona_chat',
     ]
 
@@ -139,6 +132,47 @@ class TestPremiumNano:
     def test_nano_feature_responds(self, feature):
         model = get_model(feature)
         assert model == 'gpt-4.1-nano', f"{feature} should be gpt-4.1-nano in premium, got {model}"
+        llm = get_llm(feature)
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip(), f"{feature} ({model}) returned empty response"
+        print(f"  {feature} ({model}): {response.content.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# Premium profile — gpt-4.1-mini features (vision/openglass)
+# ---------------------------------------------------------------------------
+class TestPremiumVision:
+    """Test gpt-4.1-mini vision-capable features in premium profile."""
+
+    def test_openglass_feature_responds(self):
+        model = get_model('openglass')
+        assert model == 'gpt-4.1-mini', f"openglass should be gpt-4.1-mini, got {model}"
+        llm = get_llm('openglass')
+        response = llm.invoke(SIMPLE_PROMPT)
+        assert response.content.strip(), f"openglass ({model}) returned empty response"
+        print(f"  openglass ({model}): {response.content.strip()[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# Premium profile — gemini-2.5-flash-lite features (free-text cost optimization)
+# ---------------------------------------------------------------------------
+class TestPremiumGemini:
+    """Test gemini-2.5-flash-lite features in premium profile respond to real prompts."""
+
+    GEMINI_FEATURES = [
+        'daily_summary_simple',
+        'memory_category',
+        'session_titles',
+        'followup',
+        'onboarding',
+        'app_integration',
+        'trends',
+    ]
+
+    @pytest.mark.parametrize("feature", GEMINI_FEATURES)
+    def test_gemini_feature_responds(self, feature):
+        model = get_model(feature)
+        assert model == 'gemini-2.5-flash-lite', f"{feature} should be gemini-2.5-flash-lite in premium, got {model}"
         llm = get_llm(feature)
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), f"{feature} ({model}) returned empty response"
@@ -204,7 +238,7 @@ class TestProfileRouting:
 
     def test_all_features_have_valid_provider(self):
         info = get_qos_info()
-        valid_providers = {'openai', 'anthropic', 'openrouter', 'perplexity'}
+        valid_providers = {'openai', 'anthropic', 'openrouter', 'perplexity', 'gemini'}
         for feature, details in info.items():
             assert details['provider'] in valid_providers, f"{feature}: invalid provider {details['provider']}"
             print(f"  {feature}: {details['model']} ({details['provider']})")
@@ -214,7 +248,7 @@ class TestProfileRouting:
 
     def test_premium_profile_has_expected_variant_count(self):
         distinct = set(MODEL_QOS_PROFILES['premium'].values())
-        assert len(distinct) == 6, f"Expected 6 variants in premium, got {len(distinct)}: {distinct}"
+        assert len(distinct) == 7, f"Expected 7 variants in premium, got {len(distinct)}: {distinct}"
 
     def test_max_profile_has_expected_variant_count(self):
         distinct = set(MODEL_QOS_PROFILES['max'].values())

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -30,7 +30,6 @@ from utils.llm.clients import (
     get_llm,
     get_provider,
     get_qos_info,
-    _classify_provider,
     _active_profile_name,
     anthropic_client,
     ANTHROPIC_AGENT_MODEL,

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -28,6 +28,7 @@ from utils.llm.clients import (
     MODEL_QOS_PROFILES,
     get_model,
     get_llm,
+    get_provider,
     get_qos_info,
     _classify_provider,
     _active_profile_name,
@@ -187,7 +188,7 @@ class TestPremiumOpenRouter:
 
     def test_wrapped_analysis(self):
         model = get_model('wrapped_analysis')
-        assert model == 'google/gemini-3-flash-preview'
+        assert model == 'gemini-3-flash-preview'
         llm = get_llm('wrapped_analysis')
         response = llm.invoke(SIMPLE_PROMPT)
         assert response.content.strip(), f"wrapped_analysis ({model}) returned empty response"
@@ -247,11 +248,11 @@ class TestProfileRouting:
         assert _active_profile_name == 'premium'
 
     def test_premium_profile_has_expected_variant_count(self):
-        distinct = set(MODEL_QOS_PROFILES['premium'].values())
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['premium'].values()}
         assert len(distinct) == 7, f"Expected 7 variants in premium, got {len(distinct)}: {distinct}"
 
     def test_max_profile_has_expected_variant_count(self):
-        distinct = set(MODEL_QOS_PROFILES['max'].values())
+        distinct = {model for model, _provider in MODEL_QOS_PROFILES['max'].values()}
         assert len(distinct) == 9, f"Expected 9 variants in max, got {len(distinct)}: {distinct}"
 
 

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -7,7 +7,7 @@ a non-empty response.
 
 Default profile is premium. Set MODEL_QOS=max to test max profile.
 
-Requires: OPENAI_API_KEY, OPENROUTER_API_KEY, ANTHROPIC_API_KEY, PERPLEXITY_API_KEY in .env.
+Requires: OPENAI_API_KEY, OPENROUTER_API_KEY, ANTHROPIC_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY in .env.
 Run: cd backend && python3 -m pytest tests/integration/test_qos_real_llm.py -v -s
 """
 

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -592,20 +592,20 @@ class TestCacheRouting:
         inst2 = _cached_anthropic(api_key)
         assert inst1 is inst2
 
-    def test_anthropic_proxy_routes_to_byok(self):
-        from utils.llm.clients import _AnthropicViaOpenAIProxy, _ANTHROPIC_OPENAI_BASE_URL
+    def test_gemini_proxy_routes_to_byok(self):
+        from utils.llm.clients import _GeminiChatProxy, _GEMINI_OPENAI_BASE_URL
 
         mock_default = MagicMock()
-        proxy = _AnthropicViaOpenAIProxy(default=mock_default, ctor_kwargs={})
-        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'sk-ant-byok' if p == 'anthropic' else None):
+        proxy = _GeminiChatProxy(model='gemini-2.5-flash-lite', default=mock_default, ctor_kwargs={})
+        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
             resolved = proxy._resolve()
-        assert resolved.openai_api_base == _ANTHROPIC_OPENAI_BASE_URL
+        assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
 
-    def test_anthropic_proxy_falls_back_to_default(self):
-        from utils.llm.clients import _AnthropicViaOpenAIProxy
+    def test_gemini_proxy_falls_back_to_default(self):
+        from utils.llm.clients import _GeminiChatProxy
 
         mock_default = MagicMock()
-        proxy = _AnthropicViaOpenAIProxy(default=mock_default, ctor_kwargs={})
+        proxy = _GeminiChatProxy(model='gemini-2.5-flash-lite', default=mock_default, ctor_kwargs={})
         with patch('utils.llm.clients.get_byok_key', return_value=None):
             resolved = proxy._resolve()
         assert resolved is mock_default

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -612,6 +612,37 @@ class TestCacheRouting:
             resolved = wrapper._resolve()
         assert resolved is mock_default
 
+    def test_openrouter_wrapper_byok_routes_to_gemini_direct(self):
+        """OpenRouter BYOK wraps to Gemini direct — must not forward OpenRouter api_key."""
+        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL, _wrap_byok
+
+        mock_default = MagicMock()
+        or_kwargs = {
+            'api_key': 'sk-or-openrouter-key',
+            'base_url': 'https://openrouter.ai/api/v1',
+            'callbacks': [],
+        }
+        wrapper = _wrap_byok(mock_default, 'google/gemini-3-flash-preview', 'openrouter', or_kwargs)
+        assert isinstance(wrapper, _BYOKChatWrapper)
+        assert wrapper._provider == 'gemini'  # OpenRouter BYOK resolves via Gemini
+
+        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
+            resolved = wrapper._resolve()
+        # Must use Gemini base URL, not OpenRouter
+        assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
+        # Must not contain the OpenRouter api_key
+        assert resolved.openai_api_key != 'sk-or-openrouter-key'
+
+    def test_openrouter_wrapper_strips_vendor_prefix(self):
+        """OpenRouter BYOK must strip google/ prefix for Gemini direct API."""
+        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
+
+        mock_default = MagicMock()
+        wrapper = _wrap_byok(mock_default, 'google/gemini-3-flash-preview', 'openrouter', {'api_key': 'sk-or-key'})
+        with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
+            resolved = wrapper._resolve()
+        assert resolved.model_name == 'gemini-3-flash-preview'
+
 
 # ---------------------------------------------------------------------------
 # 12. Middleware dispatch: context isolation between requests

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -592,22 +592,24 @@ class TestCacheRouting:
         inst2 = _cached_anthropic(api_key)
         assert inst1 is inst2
 
-    def test_gemini_proxy_routes_to_byok(self):
-        from utils.llm.clients import _GeminiChatProxy, _GEMINI_OPENAI_BASE_URL
+    def test_gemini_wrapper_routes_to_byok(self):
+        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL, _wrap_byok
 
         mock_default = MagicMock()
-        proxy = _GeminiChatProxy(model='gemini-2.5-flash-lite', default=mock_default, ctor_kwargs={})
+        wrapper = _wrap_byok(mock_default, 'gemini-2.5-flash-lite', 'gemini', {})
+        assert isinstance(wrapper, _BYOKChatWrapper)
         with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
-            resolved = proxy._resolve()
+            resolved = wrapper._resolve()
         assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
 
-    def test_gemini_proxy_falls_back_to_default(self):
-        from utils.llm.clients import _GeminiChatProxy
+    def test_gemini_wrapper_falls_back_to_default(self):
+        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
 
         mock_default = MagicMock()
-        proxy = _GeminiChatProxy(model='gemini-2.5-flash-lite', default=mock_default, ctor_kwargs={})
+        wrapper = _wrap_byok(mock_default, 'gemini-2.5-flash-lite', 'gemini', {})
+        assert isinstance(wrapper, _BYOKChatWrapper)
         with patch('utils.llm.clients.get_byok_key', return_value=None):
-            resolved = proxy._resolve()
+            resolved = wrapper._resolve()
         assert resolved is mock_default
 
 

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -643,6 +643,15 @@ class TestCacheRouting:
             resolved = wrapper._resolve()
         assert resolved.model_name == 'gemini-3-flash-preview'
 
+    def test_non_gemini_openrouter_wrapper_stays_on_openrouter(self):
+        """Non-Gemini OpenRouter models must NOT reroute to Gemini direct."""
+        from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
+
+        mock_default = MagicMock()
+        wrapper = _wrap_byok(mock_default, 'anthropic/claude-3.5-sonnet', 'openrouter', {'api_key': 'sk-or-key'})
+        assert isinstance(wrapper, _BYOKChatWrapper)
+        assert wrapper._provider == 'openrouter'  # NOT 'gemini'
+
 
 # ---------------------------------------------------------------------------
 # 12. Middleware dispatch: context isolation between requests

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -643,14 +643,14 @@ class TestCacheRouting:
             resolved = wrapper._resolve()
         assert resolved.model_name == 'gemini-3-flash-preview'
 
-    def test_non_gemini_openrouter_wrapper_stays_on_openrouter(self):
-        """Non-Gemini OpenRouter models must NOT reroute to Gemini direct."""
+    def test_non_gemini_openrouter_returns_default_directly(self):
+        """Non-Gemini OpenRouter models have no BYOK support — returns default client unchanged."""
         from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
 
         mock_default = MagicMock()
-        wrapper = _wrap_byok(mock_default, 'anthropic/claude-3.5-sonnet', 'openrouter', {'api_key': 'sk-or-key'})
-        assert isinstance(wrapper, _BYOKChatWrapper)
-        assert wrapper._provider == 'openrouter'  # NOT 'gemini'
+        result = _wrap_byok(mock_default, 'anthropic/claude-3.5-sonnet', 'openrouter', {'api_key': 'sk-or-key'})
+        assert result is mock_default  # No wrapper, returns default directly
+        assert not isinstance(result, _BYOKChatWrapper)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -234,17 +234,15 @@ class TestCacheKeyHashing:
 
 
 class TestGeminiKeyNotInUrl:
-    @patch('utils.llm.clients.httpx.post')
-    @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-test-token')
+    @patch('utils.llm.clients._get_vertex_embed_client')
     @patch('utils.llm.clients.get_byok_key', return_value=None)
-    def test_gemini_embed_vertex_uses_bearer_auth(self, mock_byok, mock_vertex_token, mock_post):
-        """Platform calls (no BYOK) route to Vertex AI with Bearer token."""
+    def test_gemini_embed_vertex_uses_sdk(self, mock_byok, mock_client):
+        """Platform calls (no BYOK) route to Vertex AI via google-genai SDK (no raw keys in URLs)."""
         import utils.llm.clients as mod
 
-        mock_response = MagicMock()
-        mock_response.json.return_value = {'embedding': {'values': [0.1, 0.2]}}
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
+        mock_embed_result = MagicMock()
+        mock_embed_result.embeddings = [MagicMock(values=[0.1, 0.2])]
+        mock_client.return_value.models.embed_content.return_value = mock_embed_result
 
         orig_project = mod._GCP_PROJECT
         try:
@@ -253,13 +251,9 @@ class TestGeminiKeyNotInUrl:
         finally:
             mod._GCP_PROJECT = orig_project
 
-        call_args = mock_post.call_args
-        url = call_args[0][0] if call_args[0] else call_args[1].get('url', '')
-        assert 'aiplatform.googleapis.com' in url
-        assert '?key=' not in url
-        headers = call_args[1].get('headers', {})
-        assert headers.get('Authorization') == 'Bearer vertex-test-token'
-        assert 'x-goog-api-key' not in headers
+        # SDK handles auth internally — no raw tokens in headers or URLs
+        mock_client.assert_called_once_with('us-central1')
+        mock_client.return_value.models.embed_content.assert_called_once()
 
     @patch('utils.llm.clients.httpx.post')
     @patch('utils.llm.clients.get_byok_key', return_value='user-gemini-key-secret')

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -235,27 +235,36 @@ class TestCacheKeyHashing:
 
 class TestGeminiKeyNotInUrl:
     @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-test-token')
     @patch('utils.llm.clients.get_byok_key', return_value=None)
-    def test_gemini_embed_uses_header_not_url_param(self, mock_byok, mock_post):
+    def test_gemini_embed_vertex_uses_bearer_auth(self, mock_byok, mock_vertex_token, mock_post):
+        """Platform calls (no BYOK) route to Vertex AI with Bearer token."""
+        import utils.llm.clients as mod
+
         mock_response = MagicMock()
         mock_response.json.return_value = {'embedding': {'values': [0.1, 0.2]}}
         mock_response.raise_for_status = MagicMock()
         mock_post.return_value = mock_response
 
-        from utils.llm.clients import gemini_embed_query
-
-        gemini_embed_query('test query')
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod.gemini_embed_query('test query')
+        finally:
+            mod._GCP_PROJECT = orig_project
 
         call_args = mock_post.call_args
         url = call_args[0][0] if call_args[0] else call_args[1].get('url', '')
+        assert 'aiplatform.googleapis.com' in url
         assert '?key=' not in url
-        assert 'key=' not in url
         headers = call_args[1].get('headers', {})
-        assert 'x-goog-api-key' in headers
+        assert headers.get('Authorization') == 'Bearer vertex-test-token'
+        assert 'x-goog-api-key' not in headers
 
     @patch('utils.llm.clients.httpx.post')
     @patch('utils.llm.clients.get_byok_key', return_value='user-gemini-key-secret')
-    def test_byok_gemini_key_not_in_url(self, mock_byok, mock_post):
+    def test_byok_gemini_uses_ai_studio(self, mock_byok, mock_post):
+        """BYOK users route to AI Studio with their own API key in header."""
         mock_response = MagicMock()
         mock_response.json.return_value = {'embedding': {'values': [0.1, 0.2]}}
         mock_response.raise_for_status = MagicMock()
@@ -267,6 +276,7 @@ class TestGeminiKeyNotInUrl:
 
         call_args = mock_post.call_args
         url = call_args[0][0] if call_args[0] else call_args[1].get('url', '')
+        assert 'generativelanguage.googleapis.com' in url
         assert 'user-gemini-key-secret' not in url
         headers = call_args[1].get('headers', {})
         assert headers.get('x-goog-api-key') == 'user-gemini-key-secret'
@@ -593,14 +603,14 @@ class TestCacheRouting:
         assert inst1 is inst2
 
     def test_gemini_wrapper_routes_to_byok(self):
-        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL, _wrap_byok
+        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_AI_STUDIO_BASE_URL, _wrap_byok
 
         mock_default = MagicMock()
         wrapper = _wrap_byok(mock_default, 'gemini-2.5-flash-lite', 'gemini', {})
         assert isinstance(wrapper, _BYOKChatWrapper)
         with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
             resolved = wrapper._resolve()
-        assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
+        assert resolved.openai_api_base == _GEMINI_AI_STUDIO_BASE_URL
 
     def test_gemini_wrapper_falls_back_to_default(self):
         from utils.llm.clients import _BYOKChatWrapper, _wrap_byok
@@ -614,7 +624,7 @@ class TestCacheRouting:
 
     def test_openrouter_wrapper_byok_routes_to_gemini_direct(self):
         """OpenRouter BYOK wraps to Gemini direct — must not forward OpenRouter api_key."""
-        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL, _wrap_byok
+        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_AI_STUDIO_BASE_URL, _wrap_byok
 
         mock_default = MagicMock()
         or_kwargs = {
@@ -629,7 +639,7 @@ class TestCacheRouting:
         with patch('utils.llm.clients.get_byok_key', side_effect=lambda p: 'AIza-byok-key' if p == 'gemini' else None):
             resolved = wrapper._resolve()
         # Must use Gemini base URL, not OpenRouter
-        assert resolved.openai_api_base == _GEMINI_OPENAI_BASE_URL
+        assert resolved.openai_api_base == _GEMINI_AI_STUDIO_BASE_URL
         # Must not contain the OpenRouter api_key
         assert resolved.openai_api_key != 'sk-or-openrouter-key'
 

--- a/backend/tests/unit/test_llm_usage_tracker.py
+++ b/backend/tests/unit/test_llm_usage_tracker.py
@@ -419,3 +419,36 @@ def test_usage_context_is_frozen():
         assert False, "Should have raised FrozenInstanceError"
     except AttributeError:
         pass  # Expected - frozen dataclass
+
+
+def test_gemini_usage_metadata_fallback():
+    """ChatGoogleGenerativeAI puts token counts on message.usage_metadata, not llm_output.
+
+    Regression test: without the fallback, Gemini platform calls record 0 tokens.
+    """
+    from langchain_core.messages import AIMessage
+    from langchain_core.outputs import ChatGeneration
+
+    usage_tracker.get_and_clear_buffer()
+    callback = usage_tracker.LLMUsageCallback()
+    token = usage_tracker.set_usage_context("user-gemini", usage_tracker.Features.FOLLOWUP)
+    try:
+        msg = AIMessage(
+            content="response text",
+            usage_metadata={"input_tokens": 42, "output_tokens": 17, "total_tokens": 59},
+            response_metadata={"model_name": "gemini-2.5-flash-lite"},
+        )
+        gen = ChatGeneration(message=msg)
+        result = LLMResult(
+            generations=[[gen]],
+            llm_output={},
+        )
+        callback.on_llm_end(result)
+    finally:
+        usage_tracker.reset_usage_context(token)
+
+    buffered = usage_tracker.get_and_clear_buffer()
+    assert "user-gemini:followup:gemini-2.5-flash-lite" in buffered
+    record = buffered["user-gemini:followup:gemini-2.5-flash-lite"]
+    assert record["input_tokens"] == 42
+    assert record["output_tokens"] == 17

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -572,10 +572,16 @@ class TestRollbackScenario:
         assert get_provider('persona_chat') == 'anthropic'
 
     def test_invalid_provider_in_override_falls_back(self, monkeypatch):
-        """Explicit override with invalid provider falls back to profile provider."""
+        """Explicit override with invalid provider falls back to inferred provider."""
         monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus_provider')
         assert get_model('conv_action_items') == 'gpt-5.1'
-        assert get_provider('conv_action_items') == 'openai'  # profile provider
+        assert get_provider('conv_action_items') == 'openai'  # inferred from model name
+
+    def test_mismatched_model_provider_uses_inferred(self, monkeypatch):
+        """Explicit override with mismatched model/provider uses inferred provider."""
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gpt-5.1:anthropic')
+        assert get_model('persona_chat') == 'gpt-5.1'
+        assert get_provider('persona_chat') == 'openai'  # inferred, not explicit anthropic
 
     def test_model_only_override_infers_provider(self, monkeypatch):
         """Model-only override infers provider from model name."""
@@ -849,6 +855,17 @@ class TestOverrideWarningLog:
             'invalid provider' in r.message for r in caplog.records
         ), "No warning expected for model-only override"
 
+    def test_warns_on_mismatched_model_provider(self, monkeypatch, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
+            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:anthropic')
+            result = get_model('conv_action_items')
+            assert result == 'gpt-5.1'
+        assert any(
+            'does not match model' in r.message for r in caplog.records
+        ), "Expected model/provider mismatch warning"
+
 
 class TestRuntimeProviderRouting:
     """Verify get_llm() routes to correct client factory based on resolved model."""
@@ -876,23 +893,28 @@ class TestRuntimeProviderRouting:
         assert llm._provider == 'openai'
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
-        """If an override sets an OpenRouter model:provider, get_llm should route via OpenRouter."""
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gemini-flash-1.5-8b:openrouter')
+        """If an override sets an OpenRouter model (vendor/model format), get_llm should route via OpenRouter."""
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b:openrouter')
         llm = get_llm('persona_chat')
-        # The wrapper's default client should be OpenRouter-configured
-        base_url = getattr(llm._default, 'openai_api_base', None) or ''
+        # OpenRouter Gemini models get BYOK-wrapped with Gemini direct fallback
+        base_url = (
+            getattr(llm, 'openai_api_base', None)
+            or getattr(getattr(llm, '_default', None), 'openai_api_base', None)
+            or ''
+        )
         assert 'openrouter' in base_url
 
     def test_openrouter_temperature_applied_via_get_llm(self, monkeypatch):
         """When get_llm routes to OpenRouter, _OPENROUTER_TEMPERATURES config is applied."""
         from utils.llm.clients import _OPENROUTER_TEMPERATURES
 
-        # Override persona_chat to an OpenRouter model to test temperature routing
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gemini-flash-1.5-8b:openrouter')
+        # Override persona_chat to an OpenRouter model (vendor/model format)
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b:openrouter')
         llm = get_llm('persona_chat')
         expected_temp = _OPENROUTER_TEMPERATURES.get('persona_chat')
         assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
-        assert llm._default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+        default = getattr(llm, '_default', llm)
+        assert default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
 
 
 class TestBYOKWrapperArchitecture:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -878,21 +878,19 @@ class TestRuntimeProviderRouting:
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
         """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL
+        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL
 
         llm = get_llm('followup')
-        assert isinstance(llm, _BYOKChatWrapper), 'followup should be wrapped with _BYOKChatWrapper'
-        assert llm._provider == 'gemini', 'followup wrapper should have gemini provider'
-        # Default client must use Gemini base URL
-        assert llm._default.openai_api_base == _GEMINI_OPENAI_BASE_URL, 'followup default must use Gemini base URL'
+        # get_llm() eagerly resolves BYOK; result is a ChatOpenAI routed to Gemini
+        assert llm.openai_api_base == _GEMINI_OPENAI_BASE_URL, 'followup must use Gemini base URL'
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""
-        from utils.llm.clients import _BYOKChatWrapper
-
         llm = get_llm('openglass')
-        assert isinstance(llm, _BYOKChatWrapper)
-        assert llm._provider == 'openai'
+        # get_llm() eagerly resolves; result is a ChatOpenAI routed to OpenAI
+        base_url = getattr(llm, 'openai_api_base', None) or ''
+        assert 'openrouter' not in base_url
+        assert 'generativelanguage.googleapis.com' not in base_url
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
         """If an override sets an OpenRouter model (vendor/model format), get_llm should route via OpenRouter."""
@@ -933,26 +931,23 @@ class TestRuntimeProviderRouting:
 
 
 class TestBYOKWrapperArchitecture:
-    """Verify BYOK wrapper is used consistently across providers."""
+    """Verify get_llm() eagerly resolves BYOK and returns proper ChatOpenAI instances."""
 
-    def test_all_providers_use_byok_wrapper(self):
-        from utils.llm.clients import _BYOKChatWrapper
+    def test_get_llm_returns_chat_openai(self):
+        """get_llm() must eagerly resolve BYOK and return a ChatOpenAI (Runnable), not a wrapper."""
+        from langchain_openai import ChatOpenAI
 
         # OpenAI feature
         llm_openai = get_llm('conv_structure')
-        assert isinstance(llm_openai, _BYOKChatWrapper)
-        assert llm_openai._provider == 'openai'
+        assert isinstance(llm_openai, ChatOpenAI), 'get_llm must return ChatOpenAI, not wrapper'
 
-        # Gemini feature
+        # Gemini feature (uses OpenAI-compat endpoint)
         llm_gemini = get_llm('followup')
-        assert isinstance(llm_gemini, _BYOKChatWrapper)
-        assert llm_gemini._provider == 'gemini'
+        assert isinstance(llm_gemini, ChatOpenAI), 'Gemini get_llm must return ChatOpenAI'
 
         # OpenRouter feature
         llm_or = get_llm('wrapped_analysis')
-        assert isinstance(llm_or, _BYOKChatWrapper)
-        # OpenRouter Gemini models use 'gemini' as BYOK provider (routes to Google direct)
-        assert llm_or._provider == 'gemini'
+        assert isinstance(llm_or, ChatOpenAI), 'OpenRouter get_llm must return ChatOpenAI'
 
     def test_no_legacy_llm_medium_or_llm_large(self):
         """Dead legacy instances must not exist in clients module."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -36,7 +36,6 @@ from utils.llm.clients import (
     _PINNED_FEATURES,
     _active_profile,
     _active_profile_name,
-    _classify_provider,
     _get_or_create_gemini_llm,
     _get_or_create_openai_llm,
     _get_or_create_openrouter_llm,
@@ -181,26 +180,10 @@ class TestGetModel:
     def test_returns_profile_default(self):
         assert get_model('conv_action_items') == MODEL_QOS_PROFILES[_active_profile_name]['conv_action_items'][0]
 
-    def test_env_override_takes_precedence(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1')
-        assert get_model('conv_action_items') == 'gpt-5.1'
-
-    def test_env_override_with_anthropic_model(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CHAT_AGENT', 'claude-haiku-3.5')
-        assert get_model('chat_agent') == 'claude-haiku-3.5'
-
-    def test_empty_env_override_falls_back_to_profile(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', '')
-        assert get_model('conv_action_items') == _active_profile['conv_action_items'][0]
-
     def test_unknown_feature_falls_back_to_gpt41_mini(self):
         assert get_model('totally_unknown_feature') == 'gpt-4.1-mini'
 
     def test_pinned_feature_ignores_profile(self):
-        assert get_model('fair_use') == 'gpt-5.1'
-
-    def test_pinned_feature_ignores_env_override(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_FAIR_USE', 'gpt-4.1-nano')
         assert get_model('fair_use') == 'gpt-5.1'
 
     def test_anthropic_feature_returns_model_string(self):
@@ -257,17 +240,10 @@ class TestGetLlm:
         assert llm_with_key is not llm_without_key
         assert hasattr(llm_with_key, 'invoke')
 
-    def test_cache_key_ignored_for_non_cacheable_model(self, monkeypatch):
-        # Override to a model not in _CACHE_KEY_MODELS
-        monkeypatch.setenv('MODEL_QOS_MEMORIES', 'gpt-4.1-nano')
+    def test_cache_key_ignored_for_non_cacheable_model(self):
+        # memories uses gpt-4.1-mini which is not in _CACHE_KEY_MODELS
         llm_with_key = get_llm('memories', cache_key='omi-test-key')
         llm_without_key = get_llm('memories')
-        assert llm_with_key is llm_without_key
-
-    def test_cache_key_ignored_after_override_to_non_cacheable(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_STRUCTURE', 'gpt-4.1-mini')
-        llm_with_key = get_llm('conv_structure', cache_key='omi-test-key')
-        llm_without_key = get_llm('conv_structure')
         assert llm_with_key is llm_without_key
 
     def test_new_features_return_clients(self):
@@ -448,11 +424,6 @@ class TestGetQosInfo:
         assert get_provider('wrapped_analysis') == 'openrouter'
         assert get_provider('followup') == 'gemini'
 
-    def test_reflects_env_override(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'o4-mini')
-        info = get_qos_info()
-        assert info['conv_action_items']['model'] == 'o4-mini'
-
 
 class TestPinnedFeatures:
     """Verify pinned features are immutable."""
@@ -466,30 +437,7 @@ class TestPinnedFeatures:
 
 
 class TestProviderClassification:
-    """Verify provider detection from model name and feature routing."""
-
-    def test_classify_provider_openai(self):
-        assert _classify_provider('gpt-5.4') == 'openai'
-        assert _classify_provider('gpt-5.4-mini') == 'openai'
-        assert _classify_provider('gpt-4.1-nano') == 'openai'
-        assert _classify_provider('o4-mini') == 'openai'
-
-    def test_classify_provider_anthropic(self):
-        assert _classify_provider('claude-sonnet-4-6') == 'anthropic'
-        assert _classify_provider('claude-haiku-3.5') == 'anthropic'
-
-    def test_classify_provider_openrouter(self):
-        assert _classify_provider('google/gemini-flash-1.5-8b') == 'openrouter'
-        assert _classify_provider('anthropic/claude-3.5-sonnet') == 'openrouter'
-
-    def test_classify_provider_gemini(self):
-        assert _classify_provider('gemini-2.5-flash-lite') == 'gemini'
-        assert _classify_provider('gemini-2.5-pro') == 'gemini'
-        assert _classify_provider('gemini-2.5-flash') == 'gemini'
-
-    def test_classify_provider_perplexity(self):
-        assert _classify_provider('sonar-pro') == 'perplexity'
-        assert _classify_provider('sonar') == 'perplexity'
+    """Verify provider routing from profile entries."""
 
     def test_chat_agent_is_anthropic_only(self):
         assert 'chat_agent' in _ANTHROPIC_ONLY_FEATURES
@@ -527,18 +475,6 @@ class TestProviderSafetyGuard:
         with pytest.raises(ValueError, match='Perplexity'):
             get_llm('web_search')
 
-    def test_get_llm_rejects_claude_model_override(self, monkeypatch):
-        """Env override to a claude model is rejected — can't serve via ChatOpenAI."""
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'claude-haiku-3.5')
-        with pytest.raises(ValueError, match='Anthropic'):
-            get_llm('conv_action_items')
-
-    def test_get_llm_rejects_sonar_model_override(self, monkeypatch):
-        """Env override to a sonar model is rejected — can't serve via ChatOpenAI."""
-        monkeypatch.setenv('MODEL_QOS_CONV_STRUCTURE', 'sonar-pro')
-        with pytest.raises(ValueError, match='Perplexity'):
-            get_llm('conv_structure')
-
 
 class TestAnthropicModelExports:
     """Verify ANTHROPIC_AGENT_MODEL is backed by profile."""
@@ -553,41 +489,6 @@ class TestAnthropicModelExports:
 
         assert isinstance(ANTHROPIC_AGENT_MODEL, str)
         assert len(ANTHROPIC_AGENT_MODEL) > 0
-
-
-class TestRollbackScenario:
-    """Verify model can be switched via env var for rollback."""
-
-    def test_override_conv_action_items_to_gpt51(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1')
-        assert get_model('conv_action_items') == 'gpt-5.1'
-
-    def test_override_chat_agent_to_haiku(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_CHAT_AGENT', 'claude-haiku-3.5')
-        assert get_model('chat_agent') == 'claude-haiku-3.5'
-
-    def test_override_persona_to_different_model(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'claude-3.5-sonnet:anthropic')
-        assert get_model('persona_chat') == 'claude-3.5-sonnet'
-        assert get_provider('persona_chat') == 'anthropic'
-
-    def test_invalid_provider_in_override_falls_back(self, monkeypatch):
-        """Explicit override with invalid provider falls back to inferred provider."""
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus_provider')
-        assert get_model('conv_action_items') == 'gpt-5.1'
-        assert get_provider('conv_action_items') == 'openai'  # inferred from model name
-
-    def test_mismatched_model_provider_uses_inferred(self, monkeypatch):
-        """Explicit override with mismatched model/provider uses inferred provider."""
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gpt-5.1:anthropic')
-        assert get_model('persona_chat') == 'gpt-5.1'
-        assert get_provider('persona_chat') == 'openai'  # inferred, not explicit anthropic
-
-    def test_model_only_override_infers_provider(self, monkeypatch):
-        """Model-only override infers provider from model name."""
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gemini-2.5-flash')
-        assert get_model('conv_action_items') == 'gemini-2.5-flash'
-        assert get_provider('conv_action_items') == 'gemini'  # inferred from model name
 
 
 class TestProfileSelectionAtImportTime:
@@ -821,52 +722,6 @@ class TestExpandedCallsiteCoverage:
             assert 'llm_high.invoke' not in source, f"{path} still uses llm_high.invoke"
 
 
-class TestOverrideWarningLog:
-    """Verify override warnings fire for invalid explicit provider."""
-
-    def test_warns_on_invalid_explicit_provider(self, monkeypatch, caplog):
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus')
-            result = get_model('conv_action_items')
-            assert result == 'gpt-5.1'
-        assert any('invalid provider' in r.message for r in caplog.records), "Expected invalid provider warning"
-
-    def test_no_warning_on_valid_explicit_provider(self, monkeypatch, caplog):
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini:openai')
-            result = get_model('conv_action_items')
-            assert result == 'gpt-4.1-mini'
-        assert not any(
-            'invalid provider' in r.message for r in caplog.records
-        ), "No warning expected for valid explicit provider"
-
-    def test_no_warning_on_model_only_override(self, monkeypatch, caplog):
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini')
-            result = get_model('conv_action_items')
-            assert result == 'gpt-4.1-mini'
-        assert not any(
-            'invalid provider' in r.message for r in caplog.records
-        ), "No warning expected for model-only override"
-
-    def test_warns_on_mismatched_model_provider(self, monkeypatch, caplog):
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:anthropic')
-            result = get_model('conv_action_items')
-            assert result == 'gpt-5.1'
-        assert any(
-            'does not match model' in r.message for r in caplog.records
-        ), "Expected model/provider mismatch warning"
-
-
 class TestRuntimeProviderRouting:
     """Verify get_llm() routes to correct client factory based on resolved model."""
 
@@ -892,42 +747,20 @@ class TestRuntimeProviderRouting:
         assert 'openrouter' not in base_url
         assert 'generativelanguage.googleapis.com' not in base_url
 
-    def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
-        """If an override sets an OpenRouter model (vendor/model format), get_llm should route via OpenRouter."""
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b:openrouter')
-        llm = get_llm('persona_chat')
-        # OpenRouter Gemini models get BYOK-wrapped with Gemini direct fallback
-        base_url = (
-            getattr(llm, 'openai_api_base', None)
-            or getattr(getattr(llm, '_default', None), 'openai_api_base', None)
-            or ''
-        )
-        assert 'openrouter' in base_url
-
-    def test_openrouter_temperature_applied_via_get_llm(self, monkeypatch):
+    def test_openrouter_temperature_applied_via_get_llm(self):
         """When get_llm routes to OpenRouter, _OPENROUTER_TEMPERATURES config is applied."""
         from utils.llm.clients import _OPENROUTER_TEMPERATURES
 
-        # Override persona_chat to an OpenRouter model (vendor/model format)
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b:openrouter')
-        llm = get_llm('persona_chat')
-        expected_temp = _OPENROUTER_TEMPERATURES.get('persona_chat')
-        assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
-        default = getattr(llm, '_default', llm)
-        assert default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+        llm = get_llm('wrapped_analysis')
+        expected_temp = _OPENROUTER_TEMPERATURES.get('wrapped_analysis')
+        assert expected_temp == 0.7, "wrapped_analysis should have temp 0.7 in config"
+        assert llm.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
 
     def test_openrouter_adds_vendor_prefix_for_gemini_models(self):
         """Profile stores bare model name; OpenRouter factory must add google/ prefix for API calls."""
         llm = get_llm('wrapped_analysis')
         default = getattr(llm, '_default', llm)
         assert default.model_name.startswith('google/'), f"Expected google/ prefix, got {default.model_name}"
-
-    def test_empty_provider_suffix_in_override(self, monkeypatch):
-        """MODEL_QOS_X=model: (empty provider after colon) should use inferred provider."""
-        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini:')
-        assert get_model('conv_action_items') == 'gpt-4.1-mini'
-        # Empty string is not in _VALID_PROVIDERS, so falls back to inferred
-        assert get_provider('conv_action_items') == 'openai'
 
 
 class TestBYOKWrapperArchitecture:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -37,6 +37,7 @@ from utils.llm.clients import (
     _active_profile,
     _active_profile_name,
     _classify_provider,
+    _get_or_create_gemini_llm,
     _get_or_create_openai_llm,
     _get_or_create_openrouter_llm,
     _llm_cache,
@@ -75,9 +76,12 @@ class TestModelQosProfiles:
         for profile_name in MODEL_QOS_PROFILES:
             providers = {_classify_provider(m) for m in MODEL_QOS_PROFILES[profile_name].values()}
             assert 'openrouter' in providers, f'{profile_name} should have OpenRouter (wrapped_analysis)'
+        # Premium profile uses Gemini direct for free-text features
+        premium_providers = {_classify_provider(m) for m in MODEL_QOS_PROFILES['premium'].values()}
+        assert 'gemini' in premium_providers, 'premium should have Gemini direct models'
 
     def test_premium_profile_models(self):
-        """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gpt-4.1-nano for simple."""
+        """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gemini for free-text."""
         premium = MODEL_QOS_PROFILES['premium']
         # Flagship features use gpt-5.4-mini
         assert premium['conv_structure'] == 'gpt-5.4-mini'
@@ -94,8 +98,14 @@ class TestModelQosProfiles:
         assert premium['proactive_notification'] == 'gpt-4.1-mini'
         # Simple features use gpt-4.1-nano
         assert premium['conv_app_select'] == 'gpt-4.1-nano'
-        assert premium['session_titles'] == 'gpt-4.1-nano'
-        assert premium['followup'] == 'gpt-4.1-nano'
+        # Free-text features migrated to Gemini 2.5 Flash-Lite
+        assert premium['session_titles'] == 'gemini-2.5-flash-lite'
+        assert premium['followup'] == 'gemini-2.5-flash-lite'
+        assert premium['onboarding'] == 'gemini-2.5-flash-lite'
+        assert premium['memory_category'] == 'gemini-2.5-flash-lite'
+        assert premium['daily_summary_simple'] == 'gemini-2.5-flash-lite'
+        assert premium['app_integration'] == 'gemini-2.5-flash-lite'
+        assert premium['trends'] == 'gemini-2.5-flash-lite'
         # Unchanged
         assert premium['chat_agent'] == 'claude-sonnet-4-6'
         assert premium['web_search'] == 'sonar-pro'
@@ -459,6 +469,11 @@ class TestProviderClassification:
         assert _classify_provider('google/gemini-flash-1.5-8b') == 'openrouter'
         assert _classify_provider('anthropic/claude-3.5-sonnet') == 'openrouter'
 
+    def test_classify_provider_gemini(self):
+        assert _classify_provider('gemini-2.5-flash-lite') == 'gemini'
+        assert _classify_provider('gemini-2.5-pro') == 'gemini'
+        assert _classify_provider('gemini-2.5-flash') == 'gemini'
+
     def test_classify_provider_perplexity(self):
         assert _classify_provider('sonar-pro') == 'perplexity'
         assert _classify_provider('sonar') == 'perplexity'
@@ -806,6 +821,13 @@ class TestRuntimeProviderRouting:
         llm = get_llm('persona_chat')
         base_url = getattr(llm, 'openai_api_base', None) or ''
         assert 'openrouter' not in base_url
+
+    def test_gemini_feature_routes_to_gemini_endpoint(self):
+        """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
+        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL, _GeminiChatProxy
+
+        llm = get_llm('followup')
+        assert isinstance(llm, _GeminiChatProxy), 'followup should route through _GeminiChatProxy'
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
         """If an override sets an OpenRouter model, get_llm should route via OpenRouter."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -571,6 +571,18 @@ class TestRollbackScenario:
         assert get_model('persona_chat') == 'claude-3.5-sonnet'
         assert get_provider('persona_chat') == 'anthropic'
 
+    def test_invalid_provider_in_override_falls_back(self, monkeypatch):
+        """Explicit override with invalid provider falls back to profile provider."""
+        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus_provider')
+        assert get_model('conv_action_items') == 'gpt-5.1'
+        assert get_provider('conv_action_items') == 'openai'  # profile provider
+
+    def test_model_only_override_infers_provider(self, monkeypatch):
+        """Model-only override infers provider from model name."""
+        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gemini-2.5-flash')
+        assert get_model('conv_action_items') == 'gemini-2.5-flash'
+        assert get_provider('conv_action_items') == 'gemini'  # inferred from model name
+
 
 class TestProfileSelectionAtImportTime:
     """Verify MODEL_QOS env var selects the correct profile at module load time."""
@@ -804,20 +816,29 @@ class TestExpandedCallsiteCoverage:
 
 
 class TestOverrideWarningLog:
-    """Verify override warnings fire when provider doesn't match."""
+    """Verify override warnings fire for invalid explicit provider."""
 
-    def test_warns_on_cross_provider_override(self, monkeypatch, caplog):
+    def test_warns_on_invalid_explicit_provider(self, monkeypatch, caplog):
         import logging
 
         with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gemini-2.5-flash')
+            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1:bogus')
             result = get_model('conv_action_items')
-            assert result == 'gemini-2.5-flash'
-        assert any(
-            'differs from profile provider' in r.message for r in caplog.records
-        ), "Expected cross-provider override warning"
+            assert result == 'gpt-5.1'
+        assert any('invalid provider' in r.message for r in caplog.records), "Expected invalid provider warning"
 
-    def test_no_warning_on_same_provider_override(self, monkeypatch, caplog):
+    def test_no_warning_on_valid_explicit_provider(self, monkeypatch, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
+            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini:openai')
+            result = get_model('conv_action_items')
+            assert result == 'gpt-4.1-mini'
+        assert not any(
+            'invalid provider' in r.message for r in caplog.records
+        ), "No warning expected for valid explicit provider"
+
+    def test_no_warning_on_model_only_override(self, monkeypatch, caplog):
         import logging
 
         with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
@@ -825,8 +846,8 @@ class TestOverrideWarningLog:
             result = get_model('conv_action_items')
             assert result == 'gpt-4.1-mini'
         assert not any(
-            'may be invalid' in r.message for r in caplog.records
-        ), "No warning expected for same-provider override"
+            'invalid provider' in r.message for r in caplog.records
+        ), "No warning expected for model-only override"
 
 
 class TestRuntimeProviderRouting:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -878,11 +878,13 @@ class TestRuntimeProviderRouting:
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
         """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _BYOKChatWrapper
+        from utils.llm.clients import _BYOKChatWrapper, _GEMINI_OPENAI_BASE_URL
 
         llm = get_llm('followup')
         assert isinstance(llm, _BYOKChatWrapper), 'followup should be wrapped with _BYOKChatWrapper'
         assert llm._provider == 'gemini', 'followup wrapper should have gemini provider'
+        # Default client must use Gemini base URL
+        assert llm._default.openai_api_base == _GEMINI_OPENAI_BASE_URL, 'followup default must use Gemini base URL'
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""
@@ -915,6 +917,19 @@ class TestRuntimeProviderRouting:
         assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
         default = getattr(llm, '_default', llm)
         assert default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+
+    def test_openrouter_adds_vendor_prefix_for_gemini_models(self):
+        """Profile stores bare model name; OpenRouter factory must add google/ prefix for API calls."""
+        llm = get_llm('wrapped_analysis')
+        default = getattr(llm, '_default', llm)
+        assert default.model_name.startswith('google/'), f"Expected google/ prefix, got {default.model_name}"
+
+    def test_empty_provider_suffix_in_override(self, monkeypatch):
+        """MODEL_QOS_X=model: (empty provider after colon) should use inferred provider."""
+        monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-4.1-mini:')
+        assert get_model('conv_action_items') == 'gpt-4.1-mini'
+        # Empty string is not in _VALID_PROVIDERS, so falls back to inferred
+        assert get_provider('conv_action_items') == 'openai'
 
 
 class TestBYOKWrapperArchitecture:

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -98,6 +98,8 @@ class TestModelQosProfiles:
         assert premium['proactive_notification'] == 'gpt-4.1-mini'
         # Simple features use gpt-4.1-nano
         assert premium['conv_app_select'] == 'gpt-4.1-nano'
+        # Vision features use gpt-4.1-mini
+        assert premium['openglass'] == 'gpt-4.1-mini'
         # Free-text features migrated to Gemini 2.5 Flash-Lite
         assert premium['session_titles'] == 'gemini-2.5-flash-lite'
         assert premium['followup'] == 'gemini-2.5-flash-lite'
@@ -824,10 +826,18 @@ class TestRuntimeProviderRouting:
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
         """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL, _GeminiChatProxy
+        from utils.llm.clients import _BYOKChatProxy, _GeminiChatProxy
 
         llm = get_llm('followup')
         assert isinstance(llm, _GeminiChatProxy), 'followup should route through _GeminiChatProxy'
+        assert isinstance(llm, _BYOKChatProxy), 'all chat proxies inherit from _BYOKChatProxy'
+
+    def test_openglass_routes_to_openai(self):
+        """openglass (vision) should route to OpenAI gpt-4.1-mini."""
+        from utils.llm.clients import _OpenAIChatProxy
+
+        llm = get_llm('openglass')
+        assert isinstance(llm, _OpenAIChatProxy)
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
         """If an override sets an OpenRouter model, get_llm should route via OpenRouter."""
@@ -846,3 +856,33 @@ class TestRuntimeProviderRouting:
         expected_temp = _OPENROUTER_TEMPERATURES.get('persona_chat')
         assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
         assert llm.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+
+
+class TestProxyHierarchy:
+    """Verify all ChatOpenAI proxies share _BYOKChatProxy base."""
+
+    def test_all_chat_proxies_inherit_from_base(self):
+        from utils.llm.clients import _BYOKChatProxy, _GeminiChatProxy, _OpenAIChatProxy, _OpenRouterGeminiProxy
+
+        assert issubclass(_OpenAIChatProxy, _BYOKChatProxy)
+        assert issubclass(_GeminiChatProxy, _BYOKChatProxy)
+        assert issubclass(_OpenRouterGeminiProxy, _BYOKChatProxy)
+
+    def test_no_legacy_llm_medium_or_llm_large(self):
+        """Dead legacy instances must not exist in clients module."""
+        import utils.llm.clients as mod
+
+        for name in [
+            'llm_medium',
+            'llm_large',
+            'llm_high',
+            'llm_agent',
+            'llm_gemini_flash',
+            'llm_mini_stream',
+            'llm_medium_stream',
+            'llm_large_stream',
+            'llm_high_stream',
+            'llm_agent_stream',
+            'llm_medium_experiment',
+        ]:
+            assert not hasattr(mod, name), f'{name} should have been removed from clients.py'

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -43,6 +43,7 @@ from utils.llm.clients import (
     _llm_cache,
     get_llm,
     get_model,
+    get_provider,
     get_qos_info,
 )
 
@@ -68,83 +69,83 @@ class TestModelQosProfiles:
     def test_profiles_cover_expected_providers(self):
         """Each profile should have features across expected providers."""
         for profile_name, profile in MODEL_QOS_PROFILES.items():
-            providers = {_classify_provider(model) for model in profile.values()}
+            providers = {provider for _model, provider in profile.values()}
             assert 'openai' in providers, f'{profile_name} missing OpenAI models'
             assert 'anthropic' in providers, f'{profile_name} missing Anthropic models'
             assert 'perplexity' in providers, f'{profile_name} missing Perplexity models'
         # Both profiles keep OpenRouter for wrapped_analysis
         for profile_name in MODEL_QOS_PROFILES:
-            providers = {_classify_provider(m) for m in MODEL_QOS_PROFILES[profile_name].values()}
+            providers = {provider for _m, provider in MODEL_QOS_PROFILES[profile_name].values()}
             assert 'openrouter' in providers, f'{profile_name} should have OpenRouter (wrapped_analysis)'
         # Premium profile uses Gemini direct for free-text features
-        premium_providers = {_classify_provider(m) for m in MODEL_QOS_PROFILES['premium'].values()}
+        premium_providers = {provider for _m, provider in MODEL_QOS_PROFILES['premium'].values()}
         assert 'gemini' in premium_providers, 'premium should have Gemini direct models'
 
     def test_premium_profile_models(self):
         """Premium uses gpt-5.4-mini for flagship, gpt-4.1-mini for quality-sensitive, gemini for free-text."""
         premium = MODEL_QOS_PROFILES['premium']
-        # Flagship features use gpt-5.4-mini
-        assert premium['conv_structure'] == 'gpt-5.4-mini'
-        assert premium['chat_responses'] == 'gpt-5.4-mini'
-        assert premium['goals_advice'] == 'gpt-5.4-mini'
-        # Quality-sensitive features use gpt-4.1-mini
-        assert premium['memories'] == 'gpt-4.1-mini'
-        assert premium['chat_extraction'] == 'gpt-4.1-mini'
-        assert premium['chat_graph'] == 'gpt-4.1-mini'
-        assert premium['external_structure'] == 'gpt-4.1-mini'
-        assert premium['memory_conflict'] == 'gpt-4.1-mini'
-        assert premium['knowledge_graph'] == 'gpt-4.1-mini'
-        assert premium['goals'] == 'gpt-4.1-mini'
-        assert premium['proactive_notification'] == 'gpt-4.1-mini'
-        # Simple features use gpt-4.1-nano
-        assert premium['conv_app_select'] == 'gpt-4.1-nano'
-        # Vision features use gpt-4.1-mini
-        assert premium['openglass'] == 'gpt-4.1-mini'
-        # Free-text features migrated to Gemini 2.5 Flash-Lite
-        assert premium['session_titles'] == 'gemini-2.5-flash-lite'
-        assert premium['followup'] == 'gemini-2.5-flash-lite'
-        assert premium['onboarding'] == 'gemini-2.5-flash-lite'
-        assert premium['memory_category'] == 'gemini-2.5-flash-lite'
-        assert premium['daily_summary_simple'] == 'gemini-2.5-flash-lite'
-        assert premium['app_integration'] == 'gemini-2.5-flash-lite'
-        assert premium['trends'] == 'gemini-2.5-flash-lite'
-        # Unchanged
-        assert premium['chat_agent'] == 'claude-sonnet-4-6'
-        assert premium['web_search'] == 'sonar-pro'
+        # Flagship features use gpt-5.4-mini on openai
+        assert premium['conv_structure'] == ('gpt-5.4-mini', 'openai')
+        assert premium['chat_responses'] == ('gpt-5.4-mini', 'openai')
+        assert premium['goals_advice'] == ('gpt-5.4-mini', 'openai')
+        # Quality-sensitive features use gpt-4.1-mini on openai
+        assert premium['memories'] == ('gpt-4.1-mini', 'openai')
+        assert premium['chat_extraction'] == ('gpt-4.1-mini', 'openai')
+        assert premium['chat_graph'] == ('gpt-4.1-mini', 'openai')
+        assert premium['external_structure'] == ('gpt-4.1-mini', 'openai')
+        assert premium['memory_conflict'] == ('gpt-4.1-mini', 'openai')
+        assert premium['knowledge_graph'] == ('gpt-4.1-mini', 'openai')
+        assert premium['goals'] == ('gpt-4.1-mini', 'openai')
+        assert premium['proactive_notification'] == ('gpt-4.1-mini', 'openai')
+        # Simple features use gpt-4.1-nano on openai
+        assert premium['conv_app_select'] == ('gpt-4.1-nano', 'openai')
+        # Vision features use gpt-4.1-mini on openai
+        assert premium['openglass'] == ('gpt-4.1-mini', 'openai')
+        # Free-text features migrated to Gemini 2.5 Flash-Lite on gemini provider
+        assert premium['session_titles'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['followup'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['onboarding'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['memory_category'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['daily_summary_simple'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['app_integration'] == ('gemini-2.5-flash-lite', 'gemini')
+        assert premium['trends'] == ('gemini-2.5-flash-lite', 'gemini')
+        # Anthropic & Perplexity with explicit provider
+        assert premium['chat_agent'] == ('claude-sonnet-4-6', 'anthropic')
+        assert premium['web_search'] == ('sonar-pro', 'perplexity')
         # Persona uses direct OpenAI API
-        assert premium['persona_chat'] == 'gpt-4.1-nano'
-        assert premium['persona_chat_premium'] == 'gpt-5.4-mini'
+        assert premium['persona_chat'] == ('gpt-4.1-nano', 'openai')
+        assert premium['persona_chat_premium'] == ('gpt-5.4-mini', 'openai')
 
     def test_max_profile_models(self):
         """Max uses gpt-5.4 flagship, gpt-4.1-mini for cheap tasks, production-grade models."""
         max_prof = MODEL_QOS_PROFILES['max']
-        # Flagship uses gpt-5.4
-        assert max_prof['chat_responses'] == 'gpt-5.4'
-        assert max_prof['goals_advice'] == 'gpt-5.4'
-        assert max_prof['app_generator'] == 'gpt-5.4'
-        assert max_prof['conv_action_items'] == 'gpt-5.4'
-        assert max_prof['conv_structure'] == 'gpt-5.4'
-        assert max_prof['daily_summary'] == 'gpt-5.4'
-        assert max_prof['persona_clone'] == 'gpt-5.4'
-        assert max_prof['notifications'] == 'gpt-5.4'
-        # Cheap tasks use gpt-4.1-mini
-        assert max_prof['conv_app_select'] == 'gpt-4.1-mini'
-        assert max_prof['memories'] == 'gpt-4.1-mini'
-        assert max_prof['learnings'] == 'o4-mini'
-        assert max_prof['chat_graph'] == 'gpt-4.1'
+        # Flagship uses gpt-5.4 on openai
+        assert max_prof['chat_responses'] == ('gpt-5.4', 'openai')
+        assert max_prof['goals_advice'] == ('gpt-5.4', 'openai')
+        assert max_prof['app_generator'] == ('gpt-5.4', 'openai')
+        assert max_prof['conv_action_items'] == ('gpt-5.4', 'openai')
+        assert max_prof['conv_structure'] == ('gpt-5.4', 'openai')
+        assert max_prof['daily_summary'] == ('gpt-5.4', 'openai')
+        assert max_prof['persona_clone'] == ('gpt-5.4', 'openai')
+        assert max_prof['notifications'] == ('gpt-5.4', 'openai')
+        # Cheap tasks use gpt-4.1-mini on openai
+        assert max_prof['conv_app_select'] == ('gpt-4.1-mini', 'openai')
+        assert max_prof['memories'] == ('gpt-4.1-mini', 'openai')
+        assert max_prof['learnings'] == ('o4-mini', 'openai')
+        assert max_prof['chat_graph'] == ('gpt-4.1', 'openai')
         # Persona uses direct OpenAI API
-        assert max_prof['persona_chat'] == 'gpt-4.1-nano'
-        assert max_prof['persona_chat_premium'] == 'gpt-5.4-mini'
-        # OpenRouter for wrapped_analysis only
-        assert max_prof['wrapped_analysis'] == 'google/gemini-3-flash-preview'
-        # Anthropic & Perplexity unchanged
-        assert max_prof['chat_agent'] == 'claude-sonnet-4-6'
-        assert max_prof['web_search'] == 'sonar-pro'
+        assert max_prof['persona_chat'] == ('gpt-4.1-nano', 'openai')
+        assert max_prof['persona_chat_premium'] == ('gpt-5.4-mini', 'openai')
+        # OpenRouter for wrapped_analysis with explicit provider
+        assert max_prof['wrapped_analysis'] == ('gemini-3-flash-preview', 'openrouter')
+        # Anthropic & Perplexity with explicit provider
+        assert max_prof['chat_agent'] == ('claude-sonnet-4-6', 'anthropic')
+        assert max_prof['web_search'] == ('sonar-pro', 'perplexity')
 
     def test_max_profile_model_variants(self):
         """Max profile uses 9 distinct model IDs."""
         max_prof = MODEL_QOS_PROFILES['max']
-        distinct_models = set(max_prof.values())
+        distinct_models = {model for model, _provider in max_prof.values()}
         expected = {
             'gpt-5.4',
             'gpt-4.1-mini',
@@ -153,7 +154,7 @@ class TestModelQosProfiles:
             'gpt-4.1-nano',
             'gpt-5.4-mini',
             'claude-sonnet-4-6',
-            'google/gemini-3-flash-preview',
+            'gemini-3-flash-preview',
             'sonar-pro',
         }
         assert distinct_models == expected
@@ -178,7 +179,7 @@ class TestGetModel:
     """Verify get_model() resolution: pinned > env override > profile > fallback."""
 
     def test_returns_profile_default(self):
-        assert get_model('conv_action_items') == MODEL_QOS_PROFILES[_active_profile_name]['conv_action_items']
+        assert get_model('conv_action_items') == MODEL_QOS_PROFILES[_active_profile_name]['conv_action_items'][0]
 
     def test_env_override_takes_precedence(self, monkeypatch):
         monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gpt-5.1')
@@ -190,7 +191,7 @@ class TestGetModel:
 
     def test_empty_env_override_falls_back_to_profile(self, monkeypatch):
         monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', '')
-        assert get_model('conv_action_items') == _active_profile['conv_action_items']
+        assert get_model('conv_action_items') == _active_profile['conv_action_items'][0]
 
     def test_unknown_feature_falls_back_to_gpt41_mini(self):
         assert get_model('totally_unknown_feature') == 'gpt-4.1-mini'
@@ -436,6 +437,16 @@ class TestGetQosInfo:
         assert info['persona_chat']['provider'] == 'openai'
         # wrapped_analysis uses OpenRouter in both profiles
         assert info['wrapped_analysis']['provider'] == 'openrouter'
+        # Gemini features use gemini provider
+        assert info['followup']['provider'] == 'gemini'
+
+    def test_get_provider_matches_profile(self):
+        """get_provider() returns the explicit provider from the profile."""
+        assert get_provider('conv_action_items') == 'openai'
+        assert get_provider('chat_agent') == 'anthropic'
+        assert get_provider('web_search') == 'perplexity'
+        assert get_provider('wrapped_analysis') == 'openrouter'
+        assert get_provider('followup') == 'gemini'
 
     def test_reflects_env_override(self, monkeypatch):
         monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'o4-mini')
@@ -447,7 +458,7 @@ class TestPinnedFeatures:
     """Verify pinned features are immutable."""
 
     def test_fair_use_pinned_to_gpt51(self):
-        assert _PINNED_FEATURES['fair_use'] == 'gpt-5.1'
+        assert _PINNED_FEATURES['fair_use'] == ('gpt-5.1', 'openai')
 
     def test_pinned_survives_profile_switch(self):
         # Even if profile doesn't list fair_use, it should resolve to pinned value
@@ -490,19 +501,19 @@ class TestProviderClassification:
         """Persona chat features use direct OpenAI API in both profiles."""
         for profile_name in ['max', 'premium']:
             prof = MODEL_QOS_PROFILES[profile_name]
-            assert _classify_provider(prof['persona_chat']) == 'openai', f'{profile_name} persona_chat'
-            assert _classify_provider(prof['persona_chat_premium']) == 'openai', f'{profile_name} persona_chat_premium'
+            assert prof['persona_chat'][1] == 'openai', f'{profile_name} persona_chat'
+            assert prof['persona_chat_premium'][1] == 'openai', f'{profile_name} persona_chat_premium'
 
     def test_wrapped_analysis_uses_openrouter_in_both_profiles(self):
         """wrapped_analysis uses OpenRouter (gemini-3-flash-preview) in both profiles."""
         for profile_name in ['max', 'premium']:
             prof = MODEL_QOS_PROFILES[profile_name]
-            assert _classify_provider(prof['wrapped_analysis']) == 'openrouter', f'{profile_name} wrapped_analysis'
+            assert prof['wrapped_analysis'][1] == 'openrouter', f'{profile_name} wrapped_analysis'
 
     def test_conv_features_are_openai(self):
         max_prof = MODEL_QOS_PROFILES['max']
         for feature in ['conv_action_items', 'conv_structure', 'conv_app_result', 'conv_app_select']:
-            assert _classify_provider(max_prof[feature]) == 'openai'
+            assert max_prof[feature][1] == 'openai'
 
 
 class TestProviderSafetyGuard:
@@ -556,8 +567,9 @@ class TestRollbackScenario:
         assert get_model('chat_agent') == 'claude-haiku-3.5'
 
     def test_override_persona_to_different_model(self, monkeypatch):
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'anthropic/claude-3.5-sonnet')
-        assert get_model('persona_chat') == 'anthropic/claude-3.5-sonnet'
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'claude-3.5-sonnet:anthropic')
+        assert get_model('persona_chat') == 'claude-3.5-sonnet'
+        assert get_provider('persona_chat') == 'anthropic'
 
 
 class TestProfileSelectionAtImportTime:
@@ -798,10 +810,12 @@ class TestOverrideWarningLog:
         import logging
 
         with caplog.at_level(logging.WARNING, logger='utils.llm.clients'):
-            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'google/gemini-flash-1.5-8b')
+            monkeypatch.setenv('MODEL_QOS_CONV_ACTION_ITEMS', 'gemini-2.5-flash')
             result = get_model('conv_action_items')
-            assert result == 'google/gemini-flash-1.5-8b'
-        assert any('may be invalid' in r.message for r in caplog.records), "Expected cross-provider override warning"
+            assert result == 'gemini-2.5-flash'
+        assert any(
+            'differs from profile provider' in r.message for r in caplog.records
+        ), "Expected cross-provider override warning"
 
     def test_no_warning_on_same_provider_override(self, monkeypatch, caplog):
         import logging
@@ -826,24 +840,26 @@ class TestRuntimeProviderRouting:
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
         """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _BYOKChatProxy, _GeminiChatProxy
+        from utils.llm.clients import _BYOKChatWrapper
 
         llm = get_llm('followup')
-        assert isinstance(llm, _GeminiChatProxy), 'followup should route through _GeminiChatProxy'
-        assert isinstance(llm, _BYOKChatProxy), 'all chat proxies inherit from _BYOKChatProxy'
+        assert isinstance(llm, _BYOKChatWrapper), 'followup should be wrapped with _BYOKChatWrapper'
+        assert llm._provider == 'gemini', 'followup wrapper should have gemini provider'
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""
-        from utils.llm.clients import _OpenAIChatProxy
+        from utils.llm.clients import _BYOKChatWrapper
 
         llm = get_llm('openglass')
-        assert isinstance(llm, _OpenAIChatProxy)
+        assert isinstance(llm, _BYOKChatWrapper)
+        assert llm._provider == 'openai'
 
     def test_override_to_openrouter_model_routes_to_openrouter(self, monkeypatch):
-        """If an override sets an OpenRouter model, get_llm should route via OpenRouter."""
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b')
+        """If an override sets an OpenRouter model:provider, get_llm should route via OpenRouter."""
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gemini-flash-1.5-8b:openrouter')
         llm = get_llm('persona_chat')
-        base_url = getattr(llm, 'openai_api_base', None) or ''
+        # The wrapper's default client should be OpenRouter-configured
+        base_url = getattr(llm._default, 'openai_api_base', None) or ''
         assert 'openrouter' in base_url
 
     def test_openrouter_temperature_applied_via_get_llm(self, monkeypatch):
@@ -851,22 +867,34 @@ class TestRuntimeProviderRouting:
         from utils.llm.clients import _OPENROUTER_TEMPERATURES
 
         # Override persona_chat to an OpenRouter model to test temperature routing
-        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'google/gemini-flash-1.5-8b')
+        monkeypatch.setenv('MODEL_QOS_PERSONA_CHAT', 'gemini-flash-1.5-8b:openrouter')
         llm = get_llm('persona_chat')
         expected_temp = _OPENROUTER_TEMPERATURES.get('persona_chat')
         assert expected_temp == 0.8, "persona_chat should have temp 0.8 in config"
-        assert llm.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
+        assert llm._default.temperature == expected_temp, "get_llm should apply _OPENROUTER_TEMPERATURES"
 
 
-class TestProxyHierarchy:
-    """Verify all ChatOpenAI proxies share _BYOKChatProxy base."""
+class TestBYOKWrapperArchitecture:
+    """Verify BYOK wrapper is used consistently across providers."""
 
-    def test_all_chat_proxies_inherit_from_base(self):
-        from utils.llm.clients import _BYOKChatProxy, _GeminiChatProxy, _OpenAIChatProxy, _OpenRouterGeminiProxy
+    def test_all_providers_use_byok_wrapper(self):
+        from utils.llm.clients import _BYOKChatWrapper
 
-        assert issubclass(_OpenAIChatProxy, _BYOKChatProxy)
-        assert issubclass(_GeminiChatProxy, _BYOKChatProxy)
-        assert issubclass(_OpenRouterGeminiProxy, _BYOKChatProxy)
+        # OpenAI feature
+        llm_openai = get_llm('conv_structure')
+        assert isinstance(llm_openai, _BYOKChatWrapper)
+        assert llm_openai._provider == 'openai'
+
+        # Gemini feature
+        llm_gemini = get_llm('followup')
+        assert isinstance(llm_gemini, _BYOKChatWrapper)
+        assert llm_gemini._provider == 'gemini'
+
+        # OpenRouter feature
+        llm_or = get_llm('wrapped_analysis')
+        assert isinstance(llm_or, _BYOKChatWrapper)
+        # OpenRouter Gemini models use 'gemini' as BYOK provider (routes to Google direct)
+        assert llm_or._provider == 'gemini'
 
     def test_no_legacy_llm_medium_or_llm_large(self):
         """Dead legacy instances must not exist in clients module."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -731,13 +731,24 @@ class TestRuntimeProviderRouting:
         base_url = getattr(llm, 'openai_api_base', None) or ''
         assert 'openrouter' not in base_url
 
-    def test_gemini_feature_routes_to_gemini_endpoint(self):
-        """Free-text features on gemini-2.5-flash-lite should route via Gemini (Vertex AI or AI Studio)."""
-        llm = get_llm('followup')
-        # get_llm() eagerly resolves BYOK; result is a ChatOpenAI routed to Gemini
-        base_url = llm.openai_api_base
-        is_gemini = 'generativelanguage.googleapis.com' in base_url or 'aiplatform.googleapis.com' in base_url
-        assert is_gemini, f'followup must use Gemini base URL, got: {base_url}'
+    @patch.dict(os.environ, {'GEMINI_API_KEY': 'test-gemini-key'})
+    def test_gemini_feature_routes_to_gemini_sdk(self):
+        """Free-text features on gemini-2.5-flash-lite should route via ChatGoogleGenerativeAI SDK."""
+        from langchain_google_genai import ChatGoogleGenerativeAI
+
+        import utils.llm.clients as mod
+
+        orig_cache = dict(mod._llm_cache)
+        try:
+            mod._llm_cache.clear()
+            llm = get_llm('followup')
+            # get_llm() eagerly resolves BYOK; result is ChatGoogleGenerativeAI (Vertex or AI Studio)
+            assert isinstance(
+                llm, ChatGoogleGenerativeAI
+            ), f'followup must use ChatGoogleGenerativeAI, got: {type(llm)}'
+        finally:
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -732,12 +732,12 @@ class TestRuntimeProviderRouting:
         assert 'openrouter' not in base_url
 
     def test_gemini_feature_routes_to_gemini_endpoint(self):
-        """Free-text features on gemini-2.5-flash-lite should route via Google's OpenAI-compat endpoint."""
-        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL
-
+        """Free-text features on gemini-2.5-flash-lite should route via Gemini (Vertex AI or AI Studio)."""
         llm = get_llm('followup')
         # get_llm() eagerly resolves BYOK; result is a ChatOpenAI routed to Gemini
-        assert llm.openai_api_base == _GEMINI_OPENAI_BASE_URL, 'followup must use Gemini base URL'
+        base_url = llm.openai_api_base
+        is_gemini = 'generativelanguage.googleapis.com' in base_url or 'aiplatform.googleapis.com' in base_url
+        assert is_gemini, f'followup must use Gemini base URL, got: {base_url}'
 
     def test_openglass_routes_to_openai(self):
         """openglass (vision) should route to OpenAI gpt-4.1-mini."""

--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -259,16 +259,15 @@ class TestPromptCacheRetention:
         clients_path = Path(__file__).resolve().parent.parent.parent / "utils" / "llm" / "clients.py"
         return clients_path.read_text()
 
-    def test_llm_medium_experiment_has_cache_retention(self):
-        """llm_medium_experiment must have extra_body with prompt_cache_retention=24h."""
+    def test_qos_gpt51_has_cache_retention(self):
+        """QoS _get_or_create_openai_llm must set prompt_cache_retention=24h for gpt-5.1."""
         source = self._read_clients_source()
-        # Find the llm_medium_experiment definition block and check extra_body
         match = re.search(
-            r'llm_medium_experiment\s*=.*?extra_body\s*=\s*\{[^}]*"prompt_cache_retention"\s*:\s*"24h"',
+            r"_get_or_create_openai_llm.*?gpt-5\.1.*?prompt_cache_retention.*?24h",
             source,
             re.DOTALL,
         )
-        assert match, "llm_medium_experiment missing extra_body with prompt_cache_retention='24h'"
+        assert match, "_get_or_create_openai_llm should set prompt_cache_retention='24h' for gpt-5.1"
 
     def test_qos_tier_medium_gets_cache_retention(self):
         """Omi QoS tier medium (gpt-5.1) must set prompt_cache_retention=24h via _get_or_create_openai_llm."""

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -311,6 +311,26 @@ class TestHelmGeminiKeyRemoved:
                 content = f.read()
             assert 'GEMINI_API_KEY' not in content
 
+    def test_gcp_location_in_backend_listen_dev(self):
+        """GCP_LOCATION env var must be set in dev Helm chart."""
+        chart_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'charts', 'backend-listen', 'dev_omi_backend_listen_values.yaml'
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GCP_LOCATION' in content
+
+    def test_gcp_location_in_backend_listen_prod(self):
+        """GCP_LOCATION env var must be set in prod Helm chart."""
+        chart_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'charts', 'backend-listen', 'prod_omi_backend_listen_values.yaml'
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GCP_LOCATION' in content
+
 
 # ---------------------------------------------------------------------------
 # 5. AI Studio URL preserved for BYOK

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -372,31 +372,88 @@ class TestAIStudioUrlPreserved:
 
 class TestBoundaryBehavior:
     def test_concurrent_token_refresh_serialized(self):
-        """Concurrent calls to _get_vertex_access_token serialize through _vertex_lock."""
+        """Concurrent calls to _get_vertex_access_token serialize through _vertex_lock.
+
+        Verifies that the lock prevents redundant refreshes: after the first
+        thread refreshes (setting valid=True), subsequent threads see the
+        valid token and skip refresh.
+        """
+        import concurrent.futures
+        import threading
+
         import utils.llm.clients as mod
 
         mock_creds = MagicMock()
         mock_creds.valid = False
         refresh_count = {'n': 0}
+        barrier = threading.Barrier(4, timeout=5)
 
-        def counting_refresh(request):
+        def slow_refresh(request):
+            """Simulate refresh: mark valid after first call so others skip."""
             refresh_count['n'] += 1
+            mock_creds.valid = True
 
-        mock_creds.refresh = counting_refresh
+        mock_creds.refresh = slow_refresh
         mock_creds.token = 'refreshed-tok'
 
         orig_creds = mod._vertex_credentials
         try:
             mod._vertex_credentials = mock_creds
-            import concurrent.futures
+
+            def _get_token_after_barrier():
+                barrier.wait()
+                return mod._get_vertex_access_token()
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-                futures = [pool.submit(mod._get_vertex_access_token) for _ in range(4)]
+                futures = [pool.submit(_get_token_after_barrier) for _ in range(4)]
                 results = [f.result() for f in futures]
             assert all(r == 'refreshed-tok' for r in results)
-            assert refresh_count['n'] >= 1
+            # Lock serializes: first thread refreshes and sets valid=True,
+            # remaining threads see valid=True and skip refresh.
+            assert refresh_count['n'] == 1
         finally:
             mod._vertex_credentials = orig_creds
+
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='ttl-test-token')
+    def test_ttl_cache_evicts_vertex_client_after_expiry(self, mock_token):
+        """Vertex clients cached in _openai_cache are evicted after TTL expires."""
+        from cachetools import TTLCache
+
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = mod._openai_cache
+        orig_llm_cache = dict(mod._llm_cache)
+        # Use a very short TTL to test eviction without sleeping
+        short_ttl_cache = TTLCache(maxsize=256, ttl=0.1)
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._openai_cache = short_ttl_cache
+            mod._llm_cache.clear()
+
+            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            client_a = llm._default_factory()
+            assert len(short_ttl_cache) == 1
+
+            # Same token before TTL expires — cached
+            client_a2 = llm._default_factory()
+            assert client_a2 is client_a
+
+            # Wait for TTL to expire
+            import time
+
+            time.sleep(0.15)
+
+            # Cache entry evicted — new client created even with same token
+            assert len(short_ttl_cache) == 0
+            client_b = llm._default_factory()
+            assert client_b is not client_a
+            assert len(short_ttl_cache) == 1
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._openai_cache = orig_cache
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_llm_cache)
 
     @patch('utils.llm.clients.httpx.post')
     @patch('utils.llm.clients._get_vertex_access_token', return_value='vx-token')

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -73,6 +73,27 @@ class TestGeminiLlmFactory:
             mod._llm_cache.clear()
             mod._llm_cache.update(orig_cache)
 
+    @patch.dict(os.environ, {'GEMINI_API_KEY': ''}, clear=False)
+    def test_no_project_no_key_falls_back_to_chatopen_ai(self):
+        """Without GCP project or GEMINI_API_KEY, factory returns ChatOpenAI placeholder."""
+        from langchain_openai import ChatOpenAI
+
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._llm_cache)
+        try:
+            mod._GCP_PROJECT = ''
+            mod._llm_cache.clear()
+            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            default = llm._default
+            assert isinstance(default, ChatOpenAI)
+            assert 'generativelanguage.googleapis.com' in default.openai_api_base
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
+
     def test_byok_resolves_to_chatopen_ai_with_ai_studio(self):
         """BYOK users get ChatOpenAI routed to AI Studio, not the Vertex SDK client."""
         from langchain_openai import ChatOpenAI

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -130,9 +130,11 @@ class TestGeminiLlmFactory:
             mod._GCP_PROJECT = 'test-project'
             mod._llm_cache.clear()
             llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
-            # The wrapper's default should use Vertex base URL
+            # The wrapper's initial default should use Vertex base URL
             default = llm._default
             assert 'aiplatform.googleapis.com' in default.openai_api_base
+            # default_factory must be set for per-request token refresh
+            assert llm._default_factory is not None
         finally:
             mod._GCP_PROJECT = orig_project
             mod._llm_cache.clear()
@@ -168,10 +170,47 @@ class TestGeminiLlmFactory:
             llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
             default = llm._default
             assert 'generativelanguage.googleapis.com' in default.openai_api_base
+            # No default_factory for AI Studio (static API key)
+            assert llm._default_factory is None
         finally:
             mod._GCP_PROJECT = orig_project
             mod._llm_cache.clear()
             mod._llm_cache.update(orig_cache)
+
+    @patch('utils.llm.clients._get_vertex_access_token')
+    def test_vertex_token_refresh_creates_new_client(self, mock_token):
+        """When Vertex AI token changes, default_factory returns a new client with fresh token."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._llm_cache)
+        orig_openai_cache = dict(mod._openai_cache)
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._llm_cache.clear()
+            mod._openai_cache.clear()
+
+            # First call — token A
+            mock_token.return_value = 'token-aaa'
+            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            client_a = llm._default_factory()
+            assert 'aiplatform.googleapis.com' in client_a.openai_api_base
+
+            # Second call — same token, should return cached client
+            client_a2 = llm._default_factory()
+            assert client_a2 is client_a
+
+            # Third call — token refreshed (simulates ~1 hour later)
+            mock_token.return_value = 'token-bbb'
+            client_b = llm._default_factory()
+            assert client_b is not client_a  # new client with fresh token
+            assert 'aiplatform.googleapis.com' in client_b.openai_api_base
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
+            mod._openai_cache.clear()
+            mod._openai_cache.update(orig_openai_cache)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -1,0 +1,375 @@
+"""Tests for Gemini AI Studio → Vertex AI migration (issue #6935).
+
+Covers:
+  - Vertex auth helper caches and refreshes tokens
+  - _get_or_create_gemini_llm routes platform to Vertex AI, falls back to AI Studio
+  - gemini_embed_query routing (BYOK vs Vertex)
+  - GCP project resolution
+  - Helm chart GEMINI_API_KEY removal
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-for-unit-tests')
+os.environ.setdefault('DEEPGRAM_API_KEY', 'dg-test-fake-for-unit-tests')
+os.environ.setdefault('ANTHROPIC_API_KEY', 'ant-test-fake-for-unit-tests')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+sys.modules.setdefault('database._client', MagicMock())
+sys.modules.setdefault('database.redis_db', MagicMock())
+sys.modules.setdefault('database.users', MagicMock())
+sys.modules.setdefault('database.user_usage', MagicMock())
+sys.modules.setdefault('database.llm_usage', MagicMock())
+sys.modules.setdefault('database.announcements', MagicMock())
+sys.modules.setdefault('utils.other.storage', MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# 1. Vertex access token helper
+# ---------------------------------------------------------------------------
+
+
+class TestVertexAccessToken:
+    def test_returns_token_when_creds_valid(self):
+        """When credentials are valid, return cached token without refresh."""
+        import utils.llm.clients as mod
+
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.token = 'cached-token-abc'
+
+        orig_creds = mod._vertex_credentials
+        try:
+            mod._vertex_credentials = mock_creds
+            token = mod._get_vertex_access_token()
+            assert token == 'cached-token-abc'
+            mock_creds.refresh.assert_not_called()
+        finally:
+            mod._vertex_credentials = orig_creds
+
+    def test_refreshes_expired_token(self):
+        """When credentials are expired, refresh and return new token."""
+        import utils.llm.clients as mod
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.token = 'refreshed-token-xyz'
+
+        orig_creds = mod._vertex_credentials
+        try:
+            mod._vertex_credentials = mock_creds
+            token = mod._get_vertex_access_token()
+            assert token == 'refreshed-token-xyz'
+            mock_creds.refresh.assert_called_once()
+        finally:
+            mod._vertex_credentials = orig_creds
+
+    def test_raises_when_no_credentials(self):
+        """When no ADC credentials available, raise RuntimeError."""
+        import utils.llm.clients as mod
+
+        orig_creds = mod._vertex_credentials
+        try:
+            mod._vertex_credentials = None
+            with pytest.raises(RuntimeError, match='Vertex AI credentials not available'):
+                mod._get_vertex_access_token()
+        finally:
+            mod._vertex_credentials = orig_creds
+
+
+# ---------------------------------------------------------------------------
+# 2. Vertex OpenAI base URL construction
+# ---------------------------------------------------------------------------
+
+
+class TestVertexBaseUrl:
+    def test_default_location(self):
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project-123'
+            url = mod._vertex_openai_base_url()
+            assert 'aiplatform.googleapis.com' in url
+            assert 'test-project-123' in url
+            assert '/endpoints/openapi' in url
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+    def test_custom_location(self):
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project-456'
+            url = mod._vertex_openai_base_url(location='us-east1')
+            assert 'us-east1' in url
+            assert 'test-project-456' in url
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+
+# ---------------------------------------------------------------------------
+# 3. Gemini LLM factory routing (Vertex AI vs AI Studio fallback)
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiLlmFactory:
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-tok')
+    def test_platform_routes_to_vertex_when_project_set(self, mock_token):
+        """When GCP project is set, default Gemini client uses Vertex AI base URL."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._llm_cache)
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._llm_cache.clear()
+            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            # The wrapper's default should use Vertex base URL
+            default = llm._default
+            assert 'aiplatform.googleapis.com' in default.openai_api_base
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
+
+    @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('ADC broken'))
+    def test_vertex_creds_failure_falls_back_to_ai_studio(self, mock_token):
+        """When GCP project is set but ADC fails, falls back to GEMINI_API_KEY."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._llm_cache)
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._llm_cache.clear()
+            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            default = llm._default
+            assert 'generativelanguage.googleapis.com' in default.openai_api_base
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
+
+    def test_no_project_uses_ai_studio(self):
+        """Without GCP project, Gemini client uses AI Studio (GEMINI_API_KEY)."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._llm_cache)
+        try:
+            mod._GCP_PROJECT = ''
+            mod._llm_cache.clear()
+            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            default = llm._default
+            assert 'generativelanguage.googleapis.com' in default.openai_api_base
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
+
+
+# ---------------------------------------------------------------------------
+# 4. gemini_embed_query routing
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiEmbedRouting:
+    @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vx-token')
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_platform_embed_uses_vertex_endpoint(self, mock_byok, mock_token, mock_post):
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mock_response = MagicMock()
+            mock_response.json.return_value = {'embedding': {'values': [0.1] * 3072}}
+            mock_response.raise_for_status = MagicMock()
+            mock_post.return_value = mock_response
+
+            result = mod.gemini_embed_query('test query')
+
+            call_args = mock_post.call_args
+            url = call_args[0][0]
+            assert 'aiplatform.googleapis.com' in url
+            assert 'gemini-embedding-001' in url
+            headers = call_args[1].get('headers', {})
+            assert headers.get('Authorization') == 'Bearer vx-token'
+            assert 'x-goog-api-key' not in headers
+            assert len(result) == 3072
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+    @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients.get_byok_key', return_value='byok-gem-key')
+    def test_byok_embed_uses_ai_studio_endpoint(self, mock_byok, mock_post):
+        from utils.llm.clients import gemini_embed_query
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'embedding': {'values': [0.2] * 3072}}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        result = gemini_embed_query('test query')
+
+        call_args = mock_post.call_args
+        url = call_args[0][0]
+        assert 'generativelanguage.googleapis.com' in url
+        assert 'aiplatform.googleapis.com' not in url
+        headers = call_args[1].get('headers', {})
+        assert headers.get('x-goog-api-key') == 'byok-gem-key'
+        assert len(result) == 3072
+
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_embed_no_project_raises_clear_error(self, mock_byok):
+        """Without BYOK or GCP project, embedding raises RuntimeError."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = ''
+            with pytest.raises(RuntimeError, match='BYOK key or GCP project'):
+                mod.gemini_embed_query('test query')
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+
+# ---------------------------------------------------------------------------
+# 5. Helm config: GEMINI_API_KEY removed
+# ---------------------------------------------------------------------------
+
+
+class TestHelmGeminiKeyRemoved:
+    """Verify GEMINI_API_KEY is no longer referenced in backend Helm charts."""
+
+    def test_no_gemini_api_key_in_backend_listen_dev(self):
+        chart_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'charts', 'backend-listen', 'dev_omi_backend_listen_values.yaml'
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GEMINI_API_KEY' not in content
+
+    def test_no_gemini_api_key_in_backend_listen_prod(self):
+        chart_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'charts', 'backend-listen', 'prod_omi_backend_listen_values.yaml'
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GEMINI_API_KEY' not in content
+
+    def test_no_gemini_api_key_in_backend_secrets_dev(self):
+        chart_path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'charts', 'backend-secrets', 'dev_omi_backend_secrets_values.yaml'
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GEMINI_API_KEY' not in content
+
+    def test_no_gemini_api_key_in_backend_secrets_prod(self):
+        chart_path = os.path.join(
+            os.path.dirname(__file__),
+            '..',
+            '..',
+            'charts',
+            'backend-secrets',
+            'prod_omi_backend_secrets_values.yaml',
+        )
+        if os.path.exists(chart_path):
+            with open(chart_path) as f:
+                content = f.read()
+            assert 'GEMINI_API_KEY' not in content
+
+
+# ---------------------------------------------------------------------------
+# 6. AI Studio URL preserved for BYOK
+# ---------------------------------------------------------------------------
+
+
+class TestAIStudioUrlPreserved:
+    def test_ai_studio_base_url_constant_exists(self):
+        from utils.llm.clients import _GEMINI_AI_STUDIO_BASE_URL
+
+        assert 'generativelanguage.googleapis.com' in _GEMINI_AI_STUDIO_BASE_URL
+
+
+# ---------------------------------------------------------------------------
+# 7. Boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryBehavior:
+    def test_concurrent_token_refresh_serialized(self):
+        """Concurrent calls to _get_vertex_access_token serialize through _vertex_lock."""
+        import utils.llm.clients as mod
+
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        refresh_count = {'n': 0}
+
+        def counting_refresh(request):
+            refresh_count['n'] += 1
+
+        mock_creds.refresh = counting_refresh
+        mock_creds.token = 'refreshed-tok'
+
+        orig_creds = mod._vertex_credentials
+        try:
+            mod._vertex_credentials = mock_creds
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+                futures = [pool.submit(mod._get_vertex_access_token) for _ in range(4)]
+                results = [f.result() for f in futures]
+            assert all(r == 'refreshed-tok' for r in results)
+            assert refresh_count['n'] >= 1
+        finally:
+            mod._vertex_credentials = orig_creds
+
+    @patch('utils.llm.clients.httpx.post')
+    @patch('utils.llm.clients._get_vertex_access_token', return_value='vx-token')
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_embedding_location_override(self, mock_byok, mock_token, mock_post):
+        """GCP_EMBEDDING_LOCATION env var overrides default us-central1."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mock_response = MagicMock()
+            mock_response.json.return_value = {'embedding': {'values': [0.1] * 3072}}
+            mock_response.raise_for_status = MagicMock()
+            mock_post.return_value = mock_response
+
+            with patch.dict(os.environ, {'GCP_EMBEDDING_LOCATION': 'europe-west4'}):
+                mod.gemini_embed_query('test query')
+
+            url = mock_post.call_args[0][0]
+            assert 'europe-west4' in url
+            assert 'us-central1' not in url
+        finally:
+            mod._GCP_PROJECT = orig_project
+
+    @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('token refresh failed'))
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_embed_token_refresh_failure_raises(self, mock_byok, mock_token):
+        """Embedding with GCP project set but token refresh failure raises."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            with pytest.raises(RuntimeError, match='token refresh failed'):
+                mod.gemini_embed_query('test query')
+        finally:
+            mod._GCP_PROJECT = orig_project

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -140,9 +140,10 @@ class TestGeminiLlmFactory:
             mod._llm_cache.clear()
             mod._llm_cache.update(orig_cache)
 
+    @patch.dict(os.environ, {'GEMINI_API_KEY': 'test-fallback-key'})
     @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('ADC broken'))
     def test_vertex_creds_failure_falls_back_to_ai_studio(self, mock_token):
-        """When GCP project is set but ADC fails, falls back to GEMINI_API_KEY."""
+        """When GCP project is set but ADC fails and GEMINI_API_KEY is present, falls back to AI Studio."""
         import utils.llm.clients as mod
 
         orig_project = mod._GCP_PROJECT
@@ -157,6 +158,28 @@ class TestGeminiLlmFactory:
             mod._GCP_PROJECT = orig_project
             mod._llm_cache.clear()
             mod._llm_cache.update(orig_cache)
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('ADC broken'))
+    def test_vertex_creds_failure_no_gemini_key_fails_fast(self, mock_token):
+        """Production scenario: GCP project set, Vertex fails, no GEMINI_API_KEY → raise immediately."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._llm_cache)
+        # Ensure GEMINI_API_KEY is absent
+        orig_key = os.environ.pop('GEMINI_API_KEY', None)
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._llm_cache.clear()
+            with pytest.raises(RuntimeError, match='ADC broken'):
+                mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
+            if orig_key is not None:
+                os.environ['GEMINI_API_KEY'] = orig_key
 
     def test_no_project_uses_ai_studio(self):
         """Without GCP project, Gemini client uses AI Studio (GEMINI_API_KEY)."""

--- a/backend/tests/unit/test_vertex_ai_migration.py
+++ b/backend/tests/unit/test_vertex_ai_migration.py
@@ -1,9 +1,8 @@
 """Tests for Gemini AI Studio → Vertex AI migration (issue #6935).
 
 Covers:
-  - Vertex auth helper caches and refreshes tokens
-  - _get_or_create_gemini_llm routes platform to Vertex AI, falls back to AI Studio
-  - gemini_embed_query routing (BYOK vs Vertex)
+  - _get_or_create_gemini_llm routes to ChatGoogleGenerativeAI (SDK) vs AI Studio
+  - gemini_embed_query routing (BYOK via httpx vs Vertex via google-genai SDK)
   - GCP project resolution
   - Helm chart GEMINI_API_KEY removal
 """
@@ -29,121 +28,15 @@ sys.modules.setdefault('utils.other.storage', MagicMock())
 
 
 # ---------------------------------------------------------------------------
-# 1. Vertex access token helper
-# ---------------------------------------------------------------------------
-
-
-class TestVertexAccessToken:
-    def test_returns_token_when_creds_valid(self):
-        """When credentials are valid, return cached token without refresh."""
-        import utils.llm.clients as mod
-
-        mock_creds = MagicMock()
-        mock_creds.valid = True
-        mock_creds.token = 'cached-token-abc'
-
-        orig_creds = mod._vertex_credentials
-        try:
-            mod._vertex_credentials = mock_creds
-            token = mod._get_vertex_access_token()
-            assert token == 'cached-token-abc'
-            mock_creds.refresh.assert_not_called()
-        finally:
-            mod._vertex_credentials = orig_creds
-
-    def test_refreshes_expired_token(self):
-        """When credentials are expired, refresh and return new token."""
-        import utils.llm.clients as mod
-
-        mock_creds = MagicMock()
-        mock_creds.valid = False
-        mock_creds.token = 'refreshed-token-xyz'
-
-        orig_creds = mod._vertex_credentials
-        try:
-            mod._vertex_credentials = mock_creds
-            token = mod._get_vertex_access_token()
-            assert token == 'refreshed-token-xyz'
-            mock_creds.refresh.assert_called_once()
-        finally:
-            mod._vertex_credentials = orig_creds
-
-    def test_raises_when_no_credentials(self):
-        """When no ADC credentials available, raise RuntimeError."""
-        import utils.llm.clients as mod
-
-        orig_creds = mod._vertex_credentials
-        try:
-            mod._vertex_credentials = None
-            with pytest.raises(RuntimeError, match='Vertex AI credentials not available'):
-                mod._get_vertex_access_token()
-        finally:
-            mod._vertex_credentials = orig_creds
-
-
-# ---------------------------------------------------------------------------
-# 2. Vertex OpenAI base URL construction
-# ---------------------------------------------------------------------------
-
-
-class TestVertexBaseUrl:
-    def test_default_location(self):
-        import utils.llm.clients as mod
-
-        orig_project = mod._GCP_PROJECT
-        try:
-            mod._GCP_PROJECT = 'test-project-123'
-            url = mod._vertex_openai_base_url()
-            assert 'aiplatform.googleapis.com' in url
-            assert 'test-project-123' in url
-            assert '/endpoints/openapi' in url
-        finally:
-            mod._GCP_PROJECT = orig_project
-
-    def test_custom_location(self):
-        import utils.llm.clients as mod
-
-        orig_project = mod._GCP_PROJECT
-        try:
-            mod._GCP_PROJECT = 'test-project-456'
-            url = mod._vertex_openai_base_url(location='us-east1')
-            assert 'us-east1' in url
-            assert 'test-project-456' in url
-        finally:
-            mod._GCP_PROJECT = orig_project
-
-
-# ---------------------------------------------------------------------------
-# 3. Gemini LLM factory routing (Vertex AI vs AI Studio fallback)
+# 1. Gemini LLM factory routing (Vertex AI SDK vs AI Studio)
 # ---------------------------------------------------------------------------
 
 
 class TestGeminiLlmFactory:
-    @patch('utils.llm.clients._get_vertex_access_token', return_value='vertex-tok')
-    def test_platform_routes_to_vertex_when_project_set(self, mock_token):
-        """When GCP project is set, default Gemini client uses Vertex AI base URL."""
-        import utils.llm.clients as mod
+    def test_platform_routes_to_vertex_sdk_when_project_set(self):
+        """When GCP project is set, default Gemini client is ChatGoogleGenerativeAI with Vertex config."""
+        from langchain_google_genai import ChatGoogleGenerativeAI
 
-        orig_project = mod._GCP_PROJECT
-        orig_cache = dict(mod._llm_cache)
-        try:
-            mod._GCP_PROJECT = 'test-project'
-            mod._llm_cache.clear()
-            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
-            # The wrapper's initial default should use Vertex base URL
-            default = llm._default
-            assert 'aiplatform.googleapis.com' in default.openai_api_base
-            # default_factory must be set for per-request token refresh
-            assert llm._default_factory is not None
-        finally:
-            mod._GCP_PROJECT = orig_project
-            mod._llm_cache.clear()
-            mod._llm_cache.update(orig_cache)
-
-    @patch.dict(os.environ, {'GEMINI_API_KEY': 'test-fallback-key'})
-    @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('ADC broken'))
-    def test_vertex_creds_failure_falls_back_to_ai_studio(self, mock_token):
-        """When GCP project is set but ADC fails and GEMINI_API_KEY is present, falls back to AI Studio."""
         import utils.llm.clients as mod
 
         orig_project = mod._GCP_PROJECT
@@ -153,36 +46,18 @@ class TestGeminiLlmFactory:
             mod._llm_cache.clear()
             llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
             default = llm._default
-            assert 'generativelanguage.googleapis.com' in default.openai_api_base
+            # SDK client should be ChatGoogleGenerativeAI, not ChatOpenAI
+            assert isinstance(default, ChatGoogleGenerativeAI)
         finally:
             mod._GCP_PROJECT = orig_project
             mod._llm_cache.clear()
             mod._llm_cache.update(orig_cache)
 
-    @patch.dict(os.environ, {}, clear=False)
-    @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('ADC broken'))
-    def test_vertex_creds_failure_no_gemini_key_fails_fast(self, mock_token):
-        """Production scenario: GCP project set, Vertex fails, no GEMINI_API_KEY → raise immediately."""
-        import utils.llm.clients as mod
+    @patch.dict(os.environ, {'GEMINI_API_KEY': 'test-ai-studio-key'})
+    def test_no_project_uses_ai_studio_sdk(self):
+        """Without GCP project, Gemini client uses AI Studio via SDK (api_key mode)."""
+        from langchain_google_genai import ChatGoogleGenerativeAI
 
-        orig_project = mod._GCP_PROJECT
-        orig_cache = dict(mod._llm_cache)
-        # Ensure GEMINI_API_KEY is absent
-        orig_key = os.environ.pop('GEMINI_API_KEY', None)
-        try:
-            mod._GCP_PROJECT = 'test-project'
-            mod._llm_cache.clear()
-            with pytest.raises(RuntimeError, match='ADC broken'):
-                mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
-        finally:
-            mod._GCP_PROJECT = orig_project
-            mod._llm_cache.clear()
-            mod._llm_cache.update(orig_cache)
-            if orig_key is not None:
-                os.environ['GEMINI_API_KEY'] = orig_key
-
-    def test_no_project_uses_ai_studio(self):
-        """Without GCP project, Gemini client uses AI Studio (GEMINI_API_KEY)."""
         import utils.llm.clients as mod
 
         orig_project = mod._GCP_PROJECT
@@ -192,79 +67,93 @@ class TestGeminiLlmFactory:
             mod._llm_cache.clear()
             llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
             default = llm._default
-            assert 'generativelanguage.googleapis.com' in default.openai_api_base
-            # No default_factory for AI Studio (static API key)
-            assert llm._default_factory is None
+            assert isinstance(default, ChatGoogleGenerativeAI)
         finally:
             mod._GCP_PROJECT = orig_project
             mod._llm_cache.clear()
             mod._llm_cache.update(orig_cache)
 
-    @patch('utils.llm.clients._get_vertex_access_token')
-    def test_vertex_token_refresh_creates_new_client(self, mock_token):
-        """When Vertex AI token changes, default_factory returns a new client with fresh token."""
+    def test_byok_resolves_to_chatopen_ai_with_ai_studio(self):
+        """BYOK users get ChatOpenAI routed to AI Studio, not the Vertex SDK client."""
+        from langchain_openai import ChatOpenAI
+
         import utils.llm.clients as mod
 
         orig_project = mod._GCP_PROJECT
         orig_cache = dict(mod._llm_cache)
-        orig_openai_cache = dict(mod._openai_cache)
         try:
             mod._GCP_PROJECT = 'test-project'
             mod._llm_cache.clear()
-            mod._openai_cache.clear()
-
-            # First call — token A
-            mock_token.return_value = 'token-aaa'
             llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
-            client_a = llm._default_factory()
-            assert 'aiplatform.googleapis.com' in client_a.openai_api_base
-
-            # Second call — same token, should return cached client
-            client_a2 = llm._default_factory()
-            assert client_a2 is client_a
-
-            # Third call — token refreshed (simulates ~1 hour later)
-            mock_token.return_value = 'token-bbb'
-            client_b = llm._default_factory()
-            assert client_b is not client_a  # new client with fresh token
-            assert 'aiplatform.googleapis.com' in client_b.openai_api_base
+            # Simulate BYOK resolution
+            byok_client = llm._byok_factory('user-gemini-key')
+            assert isinstance(byok_client, ChatOpenAI)
+            assert 'generativelanguage.googleapis.com' in byok_client.openai_api_base
         finally:
             mod._GCP_PROJECT = orig_project
             mod._llm_cache.clear()
             mod._llm_cache.update(orig_cache)
-            mod._openai_cache.clear()
-            mod._openai_cache.update(orig_openai_cache)
+
+    def test_wrapper_has_no_default_factory(self):
+        """SDK handles token refresh internally — no default_factory needed on wrapper."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._llm_cache)
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._llm_cache.clear()
+            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            assert not hasattr(llm, '_default_factory')
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
+
+    def test_cached_across_calls(self):
+        """Same (model, streaming, provider) key returns cached wrapper."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        orig_cache = dict(mod._llm_cache)
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._llm_cache.clear()
+            llm1 = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            llm2 = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
+            assert llm1 is llm2
+        finally:
+            mod._GCP_PROJECT = orig_project
+            mod._llm_cache.clear()
+            mod._llm_cache.update(orig_cache)
 
 
 # ---------------------------------------------------------------------------
-# 4. gemini_embed_query routing
+# 2. gemini_embed_query routing
 # ---------------------------------------------------------------------------
 
 
 class TestGeminiEmbedRouting:
-    @patch('utils.llm.clients.httpx.post')
-    @patch('utils.llm.clients._get_vertex_access_token', return_value='vx-token')
+    @patch('utils.llm.clients._get_vertex_embed_client')
     @patch('utils.llm.clients.get_byok_key', return_value=None)
-    def test_platform_embed_uses_vertex_endpoint(self, mock_byok, mock_token, mock_post):
+    def test_platform_embed_uses_vertex_sdk(self, mock_byok, mock_client):
+        """Platform embedding uses google-genai SDK client."""
         import utils.llm.clients as mod
 
         orig_project = mod._GCP_PROJECT
         try:
             mod._GCP_PROJECT = 'test-project'
-            mock_response = MagicMock()
-            mock_response.json.return_value = {'embedding': {'values': [0.1] * 3072}}
-            mock_response.raise_for_status = MagicMock()
-            mock_post.return_value = mock_response
+            mock_embed_result = MagicMock()
+            mock_embed_result.embeddings = [MagicMock(values=[0.1] * 3072)]
+            mock_client.return_value.models.embed_content.return_value = mock_embed_result
 
             result = mod.gemini_embed_query('test query')
 
-            call_args = mock_post.call_args
-            url = call_args[0][0]
-            assert 'aiplatform.googleapis.com' in url
-            assert 'gemini-embedding-001' in url
-            headers = call_args[1].get('headers', {})
-            assert headers.get('Authorization') == 'Bearer vx-token'
-            assert 'x-goog-api-key' not in headers
+            mock_client.assert_called_once_with('us-central1')
+            mock_client.return_value.models.embed_content.assert_called_once()
+            call_kwargs = mock_client.return_value.models.embed_content.call_args
+            assert call_kwargs[1]['model'] == 'gemini-embedding-001'
+            assert call_kwargs[1]['contents'] == 'test query'
             assert len(result) == 3072
         finally:
             mod._GCP_PROJECT = orig_project
@@ -272,6 +161,7 @@ class TestGeminiEmbedRouting:
     @patch('utils.llm.clients.httpx.post')
     @patch('utils.llm.clients.get_byok_key', return_value='byok-gem-key')
     def test_byok_embed_uses_ai_studio_endpoint(self, mock_byok, mock_post):
+        """BYOK users get AI Studio embedding via httpx (not the Vertex SDK)."""
         from utils.llm.clients import gemini_embed_query
 
         mock_response = MagicMock()
@@ -302,9 +192,57 @@ class TestGeminiEmbedRouting:
         finally:
             mod._GCP_PROJECT = orig_project
 
+    @patch('utils.llm.clients._get_vertex_embed_client')
+    @patch('utils.llm.clients.get_byok_key', return_value=None)
+    def test_embedding_location_override(self, mock_byok, mock_client):
+        """GCP_EMBEDDING_LOCATION env var overrides default us-central1."""
+        import utils.llm.clients as mod
+
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mock_embed_result = MagicMock()
+            mock_embed_result.embeddings = [MagicMock(values=[0.1] * 3072)]
+            mock_client.return_value.models.embed_content.return_value = mock_embed_result
+
+            with patch.dict(os.environ, {'GCP_EMBEDDING_LOCATION': 'europe-west4'}):
+                mod.gemini_embed_query('test query')
+
+            mock_client.assert_called_once_with('europe-west4')
+        finally:
+            mod._GCP_PROJECT = orig_project
+
 
 # ---------------------------------------------------------------------------
-# 5. Helm config: GEMINI_API_KEY removed
+# 3. Vertex embed client caching
+# ---------------------------------------------------------------------------
+
+
+class TestVertexEmbedClient:
+    def test_client_cached_per_location(self):
+        """_get_vertex_embed_client caches clients per location."""
+        import utils.llm.clients as mod
+
+        orig_clients = dict(mod._vertex_embed_clients)
+        orig_project = mod._GCP_PROJECT
+        try:
+            mod._GCP_PROJECT = 'test-project'
+            mod._vertex_embed_clients.clear()
+
+            client_a = mod._get_vertex_embed_client('us-central1')
+            client_b = mod._get_vertex_embed_client('us-central1')
+            assert client_a is client_b  # same location → cached
+
+            client_c = mod._get_vertex_embed_client('europe-west4')
+            assert client_c is not client_a  # different location → new client
+        finally:
+            mod._vertex_embed_clients.clear()
+            mod._vertex_embed_clients.update(orig_clients)
+            mod._GCP_PROJECT = orig_project
+
+
+# ---------------------------------------------------------------------------
+# 4. Helm config: GEMINI_API_KEY removed
 # ---------------------------------------------------------------------------
 
 
@@ -354,7 +292,7 @@ class TestHelmGeminiKeyRemoved:
 
 
 # ---------------------------------------------------------------------------
-# 6. AI Studio URL preserved for BYOK
+# 5. AI Studio URL preserved for BYOK
 # ---------------------------------------------------------------------------
 
 
@@ -366,129 +304,26 @@ class TestAIStudioUrlPreserved:
 
 
 # ---------------------------------------------------------------------------
-# 7. Boundary tests
+# 6. SDK dependency
 # ---------------------------------------------------------------------------
 
 
-class TestBoundaryBehavior:
-    def test_concurrent_token_refresh_serialized(self):
-        """Concurrent calls to _get_vertex_access_token serialize through _vertex_lock.
+class TestSDKAvailable:
+    def test_langchain_google_genai_importable(self):
+        """langchain-google-genai SDK must be importable."""
+        from langchain_google_genai import ChatGoogleGenerativeAI
 
-        Verifies that the lock prevents redundant refreshes: after the first
-        thread refreshes (setting valid=True), subsequent threads see the
-        valid token and skip refresh.
-        """
-        import concurrent.futures
-        import threading
+        assert ChatGoogleGenerativeAI is not None
 
-        import utils.llm.clients as mod
+    def test_google_genai_importable(self):
+        """google-genai SDK must be importable (used for embeddings)."""
+        from google import genai
 
-        mock_creds = MagicMock()
-        mock_creds.valid = False
-        refresh_count = {'n': 0}
-        barrier = threading.Barrier(4, timeout=5)
+        assert genai.Client is not None
 
-        def slow_refresh(request):
-            """Simulate refresh: mark valid after first call so others skip."""
-            refresh_count['n'] += 1
-            mock_creds.valid = True
-
-        mock_creds.refresh = slow_refresh
-        mock_creds.token = 'refreshed-tok'
-
-        orig_creds = mod._vertex_credentials
-        try:
-            mod._vertex_credentials = mock_creds
-
-            def _get_token_after_barrier():
-                barrier.wait()
-                return mod._get_vertex_access_token()
-
-            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-                futures = [pool.submit(_get_token_after_barrier) for _ in range(4)]
-                results = [f.result() for f in futures]
-            assert all(r == 'refreshed-tok' for r in results)
-            # Lock serializes: first thread refreshes and sets valid=True,
-            # remaining threads see valid=True and skip refresh.
-            assert refresh_count['n'] == 1
-        finally:
-            mod._vertex_credentials = orig_creds
-
-    @patch('utils.llm.clients._get_vertex_access_token', return_value='ttl-test-token')
-    def test_ttl_cache_evicts_vertex_client_after_expiry(self, mock_token):
-        """Vertex clients cached in _openai_cache are evicted after TTL expires."""
-        from cachetools import TTLCache
-
-        import utils.llm.clients as mod
-
-        orig_project = mod._GCP_PROJECT
-        orig_cache = mod._openai_cache
-        orig_llm_cache = dict(mod._llm_cache)
-        # Use a very short TTL to test eviction without sleeping
-        short_ttl_cache = TTLCache(maxsize=256, ttl=0.1)
-        try:
-            mod._GCP_PROJECT = 'test-project'
-            mod._openai_cache = short_ttl_cache
-            mod._llm_cache.clear()
-
-            llm = mod._get_or_create_gemini_llm('gemini-2.5-flash-lite')
-            client_a = llm._default_factory()
-            assert len(short_ttl_cache) == 1
-
-            # Same token before TTL expires — cached
-            client_a2 = llm._default_factory()
-            assert client_a2 is client_a
-
-            # Wait for TTL to expire
-            import time
-
-            time.sleep(0.15)
-
-            # Cache entry evicted — new client created even with same token
-            assert len(short_ttl_cache) == 0
-            client_b = llm._default_factory()
-            assert client_b is not client_a
-            assert len(short_ttl_cache) == 1
-        finally:
-            mod._GCP_PROJECT = orig_project
-            mod._openai_cache = orig_cache
-            mod._llm_cache.clear()
-            mod._llm_cache.update(orig_llm_cache)
-
-    @patch('utils.llm.clients.httpx.post')
-    @patch('utils.llm.clients._get_vertex_access_token', return_value='vx-token')
-    @patch('utils.llm.clients.get_byok_key', return_value=None)
-    def test_embedding_location_override(self, mock_byok, mock_token, mock_post):
-        """GCP_EMBEDDING_LOCATION env var overrides default us-central1."""
-        import utils.llm.clients as mod
-
-        orig_project = mod._GCP_PROJECT
-        try:
-            mod._GCP_PROJECT = 'test-project'
-            mock_response = MagicMock()
-            mock_response.json.return_value = {'embedding': {'values': [0.1] * 3072}}
-            mock_response.raise_for_status = MagicMock()
-            mock_post.return_value = mock_response
-
-            with patch.dict(os.environ, {'GCP_EMBEDDING_LOCATION': 'europe-west4'}):
-                mod.gemini_embed_query('test query')
-
-            url = mock_post.call_args[0][0]
-            assert 'europe-west4' in url
-            assert 'us-central1' not in url
-        finally:
-            mod._GCP_PROJECT = orig_project
-
-    @patch('utils.llm.clients._get_vertex_access_token', side_effect=RuntimeError('token refresh failed'))
-    @patch('utils.llm.clients.get_byok_key', return_value=None)
-    def test_embed_token_refresh_failure_raises(self, mock_byok, mock_token):
-        """Embedding with GCP project set but token refresh failure raises."""
-        import utils.llm.clients as mod
-
-        orig_project = mod._GCP_PROJECT
-        try:
-            mod._GCP_PROJECT = 'test-project'
-            with pytest.raises(RuntimeError, match='token refresh failed'):
-                mod.gemini_embed_query('test query')
-        finally:
-            mod._GCP_PROJECT = orig_project
+    def test_requirements_includes_sdk(self):
+        """requirements.txt includes langchain-google-genai."""
+        req_path = os.path.join(os.path.dirname(__file__), '..', '..', 'requirements.txt')
+        with open(req_path) as f:
+            content = f.read()
+        assert 'langchain-google-genai' in content

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -146,24 +146,16 @@ def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict
             return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
     elif provider == 'openrouter':
-        # Only reroute to Gemini direct if the model is actually Gemini-based
+        # Only Gemini-based OpenRouter models support BYOK reroute to Gemini direct
         bare_model = model.split('/', 1)[1] if '/' in model else model
-        is_gemini_model = bare_model.startswith('gemini')
-
-        if is_gemini_model:
+        if bare_model.startswith('gemini'):
 
             def _factory(byok_key: str) -> ChatOpenAI:
                 return _cached_openai_chat(bare_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
             return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
-        else:
-            # Non-Gemini OpenRouter model: BYOK stays on OpenRouter
-            def _factory(byok_key: str) -> ChatOpenAI:
-                return _cached_openai_chat(
-                    model, byok_key, {**clean_kwargs, 'base_url': 'https://openrouter.ai/api/v1'}
-                )
-
-            return _BYOKChatWrapper(default=default, provider='openrouter', byok_factory=_factory)
+        # Non-Gemini OpenRouter: no BYOK support, always use Omi's key
+        return default
     else:
         # OpenAI and any future OpenAI-compatible provider
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import anthropic
 import httpx
@@ -19,54 +19,47 @@ logger = logging.getLogger(__name__)
 _usage_callback = get_usage_callback()
 
 # ---------------------------------------------------------------------------
-# BYOK routing proxies
+# BYOK wrappers — generic, provider-agnostic
 #
-# All LLM features are routed through get_llm(feature) / get_model(feature).
-# Each proxy wraps a default client and transparently resolves to either
-# the default or a BYOK-keyed client at call time. `__getattr__` forwards
-# `bind_tools`, `with_structured_output`, `|` chaining, etc. to the resolved
-# client so tool-use/structured-output still route correctly.
+# BYOK is a per-request feature that substitutes the user's own API key.
+# Wrappers sit on top of the QoS routing layer — they are not the base.
+# The QoS layer creates a plain client, then optionally wraps it with BYOK.
 # ---------------------------------------------------------------------------
 
+# Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
+# as the client class while routing to Gemini directly — no new langchain dep.
+_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
-class _BYOKChatProxy:
-    """Base class for transparent BYOK-aware ChatOpenAI proxies.
 
-    Subclasses only need to implement _resolve() — all attribute forwarding
-    and LangChain pipe composition is handled here.
+class _BYOKChatWrapper:
+    """Wraps any ChatOpenAI client with per-request BYOK key substitution.
+
+    NOT a base class. A decorator/wrapper applied by get_llm() on top of
+    provider-specific clients. The provider tag determines which BYOK key
+    pool to check. The byok_factory constructs a BYOK-keyed client when needed.
     """
 
-    __slots__ = ('_model', '_default', '_ctor_kwargs')
+    __slots__ = ('_default', '_provider', '_byok_factory')
 
-    def __init__(self, model: str, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
-        object.__setattr__(self, '_model', model)
+    def __init__(self, default: ChatOpenAI, provider: str, byok_factory: Callable[[str], ChatOpenAI]):
         object.__setattr__(self, '_default', default)
-        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+        object.__setattr__(self, '_provider', provider)
+        object.__setattr__(self, '_byok_factory', byok_factory)
 
     def _resolve(self) -> ChatOpenAI:
-        raise NotImplementedError
+        byok = get_byok_key(self._provider)
+        if byok:
+            return self._byok_factory(byok)
+        return self._default
 
     def __getattr__(self, name: str):
         return getattr(self._resolve(), name)
 
-    # Needed for `prompt | model | parser`-style chain composition.
     def __or__(self, other):
         return self._resolve() | other
 
     def __ror__(self, other):
         return other | self._resolve()
-
-
-class _OpenAIChatProxy(_BYOKChatProxy):
-    """Routes to BYOK OpenAI when set, otherwise uses default OpenAI client."""
-
-    __slots__ = ()
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('openai')
-        if byok:
-            return _cached_openai_chat(self._model, byok, self._ctor_kwargs)
-        return self._default
 
 
 class _AnthropicClientProxy:
@@ -85,35 +78,6 @@ class _AnthropicClientProxy:
 
     def __getattr__(self, name: str):
         return getattr(self._resolve(), name)
-
-
-# Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
-# as the client class while routing to Gemini directly — no new langchain dep.
-_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
-
-
-class _OpenRouterGeminiProxy(_BYOKChatProxy):
-    """Routes OpenRouter Gemini models to Google direct when BYOK Gemini is set.
-
-    Falls back to the OpenRouter-backed default client when no BYOK gemini key
-    is present — so non-BYOK users are unaffected.
-    """
-
-    __slots__ = ('_direct_model',)
-
-    def __init__(self, default: ChatOpenAI, direct_model: str, ctor_kwargs: Dict[str, Any]):
-        super().__init__(model=direct_model, default=default, ctor_kwargs=ctor_kwargs)
-        object.__setattr__(self, '_direct_model', direct_model)
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('gemini')
-        if byok:
-            return _cached_openai_chat(
-                self._direct_model,
-                byok,
-                {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
-            )
-        return self._default
 
 
 class _OpenAIEmbeddingsProxy:
@@ -171,10 +135,28 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
     return inst
 
 
-def _byok_openai(model: str, **ctor_kwargs) -> _OpenAIChatProxy:
-    """Build a module-level ChatOpenAI that transparently routes to BYOK if set."""
-    default = ChatOpenAI(model=model, **ctor_kwargs)
-    return _OpenAIChatProxy(model=model, default=default, ctor_kwargs=ctor_kwargs)
+def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict[str, Any]) -> _BYOKChatWrapper:
+    """Wrap a ChatOpenAI client with BYOK resolution for the given provider."""
+    if provider == 'gemini':
+
+        def _factory(byok_key: str) -> ChatOpenAI:
+            return _cached_openai_chat(model, byok_key, {**ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+
+    elif provider == 'openrouter':
+        # OpenRouter Gemini models: BYOK gemini key routes to Google direct
+        direct_model = model.split('/', 1)[1] if '/' in model else model
+
+        def _factory(byok_key: str) -> ChatOpenAI:
+            return _cached_openai_chat(direct_model, byok_key, {**ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+
+        return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
+    else:
+        # OpenAI and any future OpenAI-compatible provider
+
+        def _factory(byok_key: str) -> ChatOpenAI:
+            return _cached_openai_chat(model, byok_key, ctor_kwargs)
+
+    return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory)
 
 
 # Anthropic client for chat agent (module-level, BYOK-aware)
@@ -198,131 +180,138 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 # ---------------------------------------------------------------------------
 # Model QoS Profile System
 #
-# Each profile maps every feature to a specific model. Features span multiple
-# providers (OpenAI, Anthropic, OpenRouter, Perplexity). Within a profile,
-# each feature gets the model appropriate for that cost/quality level.
+# Each profile maps every feature to a (model, provider) tuple.
+# The profile is the SINGLE SOURCE OF TRUTH for both model and provider.
+# Provider is never inferred from model name — it is declared explicitly.
+#
+# This means the same model can be hosted by different providers:
+#   feature_a: ('gemini-2.5-flash', 'gemini')      → Google direct
+#   feature_b: ('gemini-2.5-flash', 'openrouter')   → OpenRouter
 #
 # Global switch:     MODEL_QOS=premium        (selects entire profile)
-# Per-feature:       MODEL_QOS_CHAT_AGENT=claude-haiku-3.5  (overrides one feature)
+# Per-feature:       MODEL_QOS_FOLLOWUP=gpt-4.1-nano:openai  (model:provider)
+#                    MODEL_QOS_FOLLOWUP=gpt-4.1-nano          (model only, inherits provider)
 #
 # Two profiles:
 #   premium — cost-effective default (80% of max quality)
 #   max     — maximum quality, latest flagship models
 # ---------------------------------------------------------------------------
 
-MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
+MODEL_QOS_PROFILES: Dict[str, Dict[str, Tuple[str, str]]] = {
     'premium': {
         # OpenAI — conversation processing
-        'conv_action_items': 'gpt-5.4-mini',
-        'conv_structure': 'gpt-5.4-mini',
-        'conv_app_result': 'gpt-5.4-mini',
-        'conv_app_select': 'gpt-4.1-nano',
-        'conv_folder': 'gpt-4.1-nano',
-        'conv_discard': 'gpt-4.1-nano',
-        'daily_summary': 'gpt-5.4-mini',
-        'daily_summary_simple': 'gemini-2.5-flash-lite',  # free-text stats → Gemini (75% savings vs mini)
-        'external_structure': 'gpt-4.1-mini',  # quality-sensitive: structuring external data
+        'conv_action_items': ('gpt-5.4-mini', 'openai'),
+        'conv_structure': ('gpt-5.4-mini', 'openai'),
+        'conv_app_result': ('gpt-5.4-mini', 'openai'),
+        'conv_app_select': ('gpt-4.1-nano', 'openai'),
+        'conv_folder': ('gpt-4.1-nano', 'openai'),
+        'conv_discard': ('gpt-4.1-nano', 'openai'),
+        'daily_summary': ('gpt-5.4-mini', 'openai'),
+        'daily_summary_simple': ('gemini-2.5-flash-lite', 'gemini'),
+        'external_structure': ('gpt-4.1-mini', 'openai'),
         # OpenAI — memories & knowledge
-        'memories': 'gpt-4.1-mini',  # quality-sensitive: memory extraction
-        'learnings': 'gpt-5.4-mini',
-        'memory_conflict': 'gpt-4.1-mini',  # quality-sensitive: conflict detection
-        'memory_category': 'gemini-2.5-flash-lite',  # text enum classification → Gemini (75% savings vs mini)
-        'knowledge_graph': 'gpt-4.1-mini',  # quality-sensitive: entity/relationship extraction
+        'memories': ('gpt-4.1-mini', 'openai'),
+        'learnings': ('gpt-5.4-mini', 'openai'),
+        'memory_conflict': ('gpt-4.1-mini', 'openai'),
+        'memory_category': ('gemini-2.5-flash-lite', 'gemini'),
+        'knowledge_graph': ('gpt-4.1-mini', 'openai'),
         # OpenAI — chat
-        'chat_responses': 'gpt-5.4-mini',
-        'chat_extraction': 'gpt-4.1-mini',  # quality-sensitive: structured data extraction
-        'chat_graph': 'gpt-4.1-mini',  # quality-sensitive: graph queries
-        'session_titles': 'gemini-2.5-flash-lite',  # free text title → Gemini (75% savings vs mini)
-        # OpenAI — features
-        'goals': 'gpt-4.1-mini',  # quality-sensitive: goal analysis
-        'goals_advice': 'gpt-5.4-mini',
-        'notifications': 'gpt-5.4-mini',
-        'proactive_notification': 'gpt-4.1-mini',  # quality-sensitive: notification decisions
-        'followup': 'gemini-2.5-flash-lite',  # free text question → Gemini (75% savings vs mini)
-        'smart_glasses': 'gpt-4.1-nano',
-        'openglass': 'gpt-4.1-mini',  # vision: image description from smart glasses
-        'onboarding': 'gemini-2.5-flash-lite',  # boolean yes/no check → Gemini (75% savings vs mini)
-        'app_generator': 'gpt-5.4-mini',
-        'app_integration': 'gemini-2.5-flash-lite',  # simple routing → Gemini (75% savings vs mini)
-        'persona_clone': 'gpt-5.4-mini',
-        'trends': 'gemini-2.5-flash-lite',  # simple pattern analysis → Gemini (75% savings vs mini)
-        # Anthropic (chat_agent — used via get_model() + anthropic_client)
-        'chat_agent': 'claude-sonnet-4-6',
-        # OpenAI — persona
-        'persona_chat': 'gpt-4.1-nano',
-        'persona_chat_premium': 'gpt-5.4-mini',
-        # OpenRouter — wrapped_analysis only (gemini-3-flash-preview still active)
-        'wrapped_analysis': 'google/gemini-3-flash-preview',
+        'chat_responses': ('gpt-5.4-mini', 'openai'),
+        'chat_extraction': ('gpt-4.1-mini', 'openai'),
+        'chat_graph': ('gpt-4.1-mini', 'openai'),
+        'session_titles': ('gemini-2.5-flash-lite', 'gemini'),
+        # Features
+        'goals': ('gpt-4.1-mini', 'openai'),
+        'goals_advice': ('gpt-5.4-mini', 'openai'),
+        'notifications': ('gpt-5.4-mini', 'openai'),
+        'proactive_notification': ('gpt-4.1-mini', 'openai'),
+        'followup': ('gemini-2.5-flash-lite', 'gemini'),
+        'smart_glasses': ('gpt-4.1-nano', 'openai'),
+        'openglass': ('gpt-4.1-mini', 'openai'),
+        'onboarding': ('gemini-2.5-flash-lite', 'gemini'),
+        'app_generator': ('gpt-5.4-mini', 'openai'),
+        'app_integration': ('gemini-2.5-flash-lite', 'gemini'),
+        'persona_clone': ('gpt-5.4-mini', 'openai'),
+        'trends': ('gemini-2.5-flash-lite', 'gemini'),
+        # Anthropic (used via get_model() + anthropic_client)
+        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        # Persona
+        'persona_chat': ('gpt-4.1-nano', 'openai'),
+        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
+        # OpenRouter
+        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
         # Perplexity
-        'web_search': 'sonar-pro',
+        'web_search': ('sonar-pro', 'perplexity'),
     },
     'max': {
-        # OpenAI — conversation processing (gpt-5.4 replaces gpt-5.1/5.2, rest unchanged)
-        'conv_action_items': 'gpt-5.4',
-        'conv_structure': 'gpt-5.4',
-        'conv_app_result': 'gpt-5.4',
-        'conv_app_select': 'gpt-4.1-mini',
-        'conv_folder': 'gpt-4.1-mini',
-        'conv_discard': 'gpt-4.1-mini',
-        'daily_summary': 'gpt-5.4',
-        'daily_summary_simple': 'gpt-4.1-mini',
-        'external_structure': 'gpt-4.1-mini',
-        # OpenAI — memories & knowledge (unchanged from production)
-        'memories': 'gpt-4.1-mini',
-        'learnings': 'o4-mini',
-        'memory_conflict': 'gpt-4.1-mini',
-        'memory_category': 'gpt-4.1-mini',
-        'knowledge_graph': 'gpt-4.1-mini',
-        # OpenAI — chat (gpt-5.4 replaces gpt-5.2, rest unchanged)
-        'chat_responses': 'gpt-5.4',
-        'chat_extraction': 'gpt-4.1-mini',
-        'chat_graph': 'gpt-4.1',
-        'session_titles': 'gpt-4.1-mini',
-        # OpenAI — features (gpt-5.4 replaces gpt-5.2/5.1, rest unchanged)
-        'goals': 'gpt-4.1-mini',
-        'goals_advice': 'gpt-5.4',
-        'notifications': 'gpt-5.4',
-        'proactive_notification': 'gpt-4.1-mini',
-        'followup': 'gpt-4.1-mini',
-        'smart_glasses': 'gpt-4.1-mini',
-        'openglass': 'gpt-4.1-mini',  # vision: image description from smart glasses
-        'onboarding': 'gpt-4.1-mini',
-        'app_generator': 'gpt-5.4',
-        'app_integration': 'gpt-4.1-mini',
-        'persona_clone': 'gpt-5.4',
-        'trends': 'gpt-4.1-mini',
-        # Anthropic (unchanged)
-        'chat_agent': 'claude-sonnet-4-6',
-        # OpenAI — persona (moved from deprecated OpenRouter models to direct API)
-        'persona_chat': 'gpt-4.1-nano',
-        'persona_chat_premium': 'gpt-5.4-mini',
-        # OpenRouter — wrapped_analysis only (gemini-3-flash-preview still active)
-        'wrapped_analysis': 'google/gemini-3-flash-preview',
-        # Perplexity (unchanged)
-        'web_search': 'sonar-pro',
+        # OpenAI — conversation processing
+        'conv_action_items': ('gpt-5.4', 'openai'),
+        'conv_structure': ('gpt-5.4', 'openai'),
+        'conv_app_result': ('gpt-5.4', 'openai'),
+        'conv_app_select': ('gpt-4.1-mini', 'openai'),
+        'conv_folder': ('gpt-4.1-mini', 'openai'),
+        'conv_discard': ('gpt-4.1-mini', 'openai'),
+        'daily_summary': ('gpt-5.4', 'openai'),
+        'daily_summary_simple': ('gpt-4.1-mini', 'openai'),
+        'external_structure': ('gpt-4.1-mini', 'openai'),
+        # OpenAI — memories & knowledge
+        'memories': ('gpt-4.1-mini', 'openai'),
+        'learnings': ('o4-mini', 'openai'),
+        'memory_conflict': ('gpt-4.1-mini', 'openai'),
+        'memory_category': ('gpt-4.1-mini', 'openai'),
+        'knowledge_graph': ('gpt-4.1-mini', 'openai'),
+        # OpenAI — chat
+        'chat_responses': ('gpt-5.4', 'openai'),
+        'chat_extraction': ('gpt-4.1-mini', 'openai'),
+        'chat_graph': ('gpt-4.1', 'openai'),
+        'session_titles': ('gpt-4.1-mini', 'openai'),
+        # Features
+        'goals': ('gpt-4.1-mini', 'openai'),
+        'goals_advice': ('gpt-5.4', 'openai'),
+        'notifications': ('gpt-5.4', 'openai'),
+        'proactive_notification': ('gpt-4.1-mini', 'openai'),
+        'followup': ('gpt-4.1-mini', 'openai'),
+        'smart_glasses': ('gpt-4.1-mini', 'openai'),
+        'openglass': ('gpt-4.1-mini', 'openai'),
+        'onboarding': ('gpt-4.1-mini', 'openai'),
+        'app_generator': ('gpt-5.4', 'openai'),
+        'app_integration': ('gpt-4.1-mini', 'openai'),
+        'persona_clone': ('gpt-5.4', 'openai'),
+        'trends': ('gpt-4.1-mini', 'openai'),
+        # Anthropic
+        'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
+        # Persona
+        'persona_chat': ('gpt-4.1-nano', 'openai'),
+        'persona_chat_premium': ('gpt-5.4-mini', 'openai'),
+        # OpenRouter
+        'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
+        # Perplexity
+        'web_search': ('sonar-pro', 'perplexity'),
     },
 }
 
-# Pinned features — model is fixed regardless of profile or env override.
-_PINNED_FEATURES: Dict[str, str] = {
-    'fair_use': 'gpt-5.1',
+# Pinned features — (model, provider) fixed regardless of profile or env override.
+_PINNED_FEATURES: Dict[str, Tuple[str, str]] = {
+    'fair_use': ('gpt-5.1', 'openai'),
 }
 
-# Resolve active profile once at startup (kai: OnceLock/singleton pattern).
+# Resolve active profile once at startup.
 _active_profile_name = os.environ.get('MODEL_QOS', 'premium').strip().lower()
 if _active_profile_name not in MODEL_QOS_PROFILES:
     logger.warning('MODEL_QOS=%s is not a valid profile, falling back to premium', _active_profile_name)
     _active_profile_name = 'premium'
 _active_profile = MODEL_QOS_PROFILES[_active_profile_name]
 
-# Provider detection from model name — provider depends on profile, not feature.
-# A feature like persona_chat may be OpenRouter in premium but OpenAI in max.
-_ANTHROPIC_ONLY_FEATURES = {'chat_agent'}  # always Anthropic, used via get_model() + anthropic_client
-_PERPLEXITY_ONLY_FEATURES = {'web_search'}  # always Perplexity, used via get_model() + HTTP client
+# Features that can't go through get_llm() (non-ChatOpenAI providers).
+_ANTHROPIC_ONLY_FEATURES = {'chat_agent'}
+_PERPLEXITY_ONLY_FEATURES = {'web_search'}
 
 
 def _classify_provider(model: str) -> str:
-    """Classify provider from model name. Provider follows the model, not the feature."""
+    """Infer provider from model name. Used ONLY as fallback for env overrides
+    that don't specify an explicit provider (e.g. MODEL_QOS_X=gpt-4.1-mini).
+    Profile entries always have explicit provider — this is never used for them.
+    """
     if '/' in model:
         return 'openrouter'
     if model.startswith('claude'):
@@ -345,6 +334,45 @@ _OPENROUTER_TEMPERATURES: Dict[str, float] = {
 # Models that support OpenAI prompt caching (prompt_cache_key routing).
 _CACHE_KEY_MODELS = {'gpt-5.4', 'gpt-5.4-mini'}
 
+_DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
+
+
+def _get_model_config(feature: str) -> Tuple[str, str]:
+    """Get the (model, provider) tuple for a feature. Internal — used by get_llm/get_model/get_provider.
+
+    Resolution order: pinned > per-feature env override > active profile > fallback.
+    Env override format: MODEL_QOS_X=model:provider  or  MODEL_QOS_X=model (inherits profile provider).
+    """
+    if feature in _PINNED_FEATURES:
+        return _PINNED_FEATURES[feature]
+    env_key = f'MODEL_QOS_{feature.upper()}'
+    override = os.environ.get(env_key, '').strip()
+    if override:
+        # Parse model:provider format
+        if ':' in override:
+            parts = override.rsplit(':', 1)
+            override_model, override_provider = parts[0], parts[1]
+        else:
+            override_model = override
+            # Inherit provider from profile if not specified, fall back to inference
+            profile_entry = _active_profile.get(feature, _DEFAULT_CONFIG)
+            profile_provider = profile_entry[1]
+            override_provider = _classify_provider(override_model)
+            if override_provider != profile_provider:
+                logger.warning(
+                    'QoS override %s=%s (inferred provider: %s) differs from profile provider %s — '
+                    'use %s=%s:%s to be explicit',
+                    env_key,
+                    override,
+                    override_provider,
+                    profile_provider,
+                    env_key,
+                    override,
+                    override_provider,
+                )
+        return (override_model, override_provider)
+    return _active_profile.get(feature, _DEFAULT_CONFIG)
+
 
 def get_model(feature: str) -> str:
     """Get the model name for a feature from the active Model QoS profile.
@@ -358,41 +386,31 @@ def get_model(feature: str) -> str:
         Model name string (e.g. 'gpt-4.1-mini', 'claude-sonnet-4-6').
 
     Override via env var:
-        MODEL_QOS_CHAT_AGENT=claude-haiku-3.5
+        MODEL_QOS_CHAT_AGENT=claude-haiku-3.5:anthropic
         MODEL_QOS_CONV_STRUCTURE=gpt-5.1
     """
-    if feature in _PINNED_FEATURES:
-        return _PINNED_FEATURES[feature]
-    env_key = f'MODEL_QOS_{feature.upper()}'
-    override = os.environ.get(env_key, '').strip()
-    if override:
-        # Warn if override model doesn't match the feature's expected provider
-        profile_model = _active_profile.get(feature, 'gpt-4.1-mini')
-        expected_provider = _classify_provider(profile_model)
-        override_provider = _classify_provider(override)
-        if expected_provider != override_provider:
-            logger.warning(
-                'QoS override %s=%s (provider: %s) may be invalid — feature %s expects %s',
-                env_key,
-                override,
-                override_provider,
-                feature,
-                expected_provider,
-            )
-        return override
-    return _active_profile.get(feature, 'gpt-4.1-mini')
+    return _get_model_config(feature)[0]
+
+
+def get_provider(feature: str) -> str:
+    """Get the provider for a feature from the active Model QoS profile.
+
+    Returns:
+        Provider string: 'openai', 'gemini', 'openrouter', 'anthropic', 'perplexity'.
+    """
+    return _get_model_config(feature)[1]
 
 
 # ---------------------------------------------------------------------------
 # Client factories — provider-specific, cached per (model, streaming, provider)
-# QoS clients are BYOK-aware via _byok_openai / _OpenRouterGeminiProxy.
+# Each factory creates a plain ChatOpenAI, then wraps it with _BYOKChatWrapper.
 # ---------------------------------------------------------------------------
 
 _llm_cache: Dict[tuple, Any] = {}
 
 
-def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _OpenAIChatProxy:
-    """Get or create a BYOK-aware ChatOpenAI proxy for an OpenAI model."""
+def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _BYOKChatWrapper:
+    """Get or create a BYOK-wrapped ChatOpenAI for an OpenAI model."""
     key = (model_name, streaming, 'openai')
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
@@ -401,14 +419,21 @@ def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _Open
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        _llm_cache[key] = _byok_openai(model_name, **kwargs)
+        default = ChatOpenAI(model=model_name, **kwargs)
+        _llm_cache[key] = _wrap_byok(default, model_name, 'openai', kwargs)
     return _llm_cache[key]
 
 
 def _get_or_create_openrouter_llm(
     model_name: str, streaming: bool = False, temperature: Optional[float] = None
-) -> ChatOpenAI:
-    """Get or create a ChatOpenAI instance for an OpenRouter model."""
+) -> _BYOKChatWrapper:
+    """Get or create a BYOK-wrapped ChatOpenAI for an OpenRouter model.
+
+    Model names in the profile are bare (e.g. 'gemini-3-flash-preview').
+    OpenRouter API requires vendor prefix (e.g. 'google/gemini-3-flash-preview').
+    """
+    # OpenRouter requires vendor-prefixed model names for Google models.
+    api_model = f'google/{model_name}' if model_name.startswith('gemini') else model_name
     key = (model_name, streaming, 'openrouter', temperature)
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {
@@ -422,34 +447,13 @@ def _get_or_create_openrouter_llm(
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        # For Gemini models on OpenRouter, use proxy for BYOK Gemini routing
-        if model_name.startswith('google/gemini'):
-            direct_model = model_name.split('/', 1)[1]
-            default = ChatOpenAI(model=model_name, **kwargs)
-            _llm_cache[key] = _OpenRouterGeminiProxy(default=default, direct_model=direct_model, ctor_kwargs=kwargs)
-        else:
-            _llm_cache[key] = ChatOpenAI(model=model_name, **kwargs)
+        default = ChatOpenAI(model=api_model, **kwargs)
+        _llm_cache[key] = _wrap_byok(default, model_name, 'openrouter', kwargs)
     return _llm_cache[key]
 
 
-class _GeminiChatProxy(_BYOKChatProxy):
-    """Routes to BYOK Gemini when set, otherwise uses default Google OpenAI-compatible endpoint."""
-
-    __slots__ = ()
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('gemini')
-        if byok:
-            return _cached_openai_chat(
-                self._model,
-                byok,
-                {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
-            )
-        return self._default
-
-
-def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _GeminiChatProxy:
-    """Get or create a BYOK-aware ChatOpenAI proxy for a Gemini model via Google's OpenAI-compat endpoint."""
+def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOKChatWrapper:
+    """Get or create a BYOK-wrapped ChatOpenAI for a Gemini model via Google's OpenAI-compat endpoint."""
     key = (model_name, streaming, 'gemini')
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
@@ -462,20 +466,20 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _Gemi
             base_url=_GEMINI_OPENAI_BASE_URL,
             **kwargs,
         )
-        _llm_cache[key] = _GeminiChatProxy(model=model_name, default=default, ctor_kwargs=kwargs)
+        _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)
     return _llm_cache[key]
 
 
 def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> ChatOpenAI:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
-    Works for OpenAI, Gemini, and OpenRouter features (returns ChatOpenAI or BYOK proxy).
+    Works for OpenAI, Gemini, and OpenRouter features (returns ChatOpenAI or BYOK wrapper).
     For Anthropic/Perplexity, use get_model(feature) to get the model string.
 
     Args:
         feature: Feature name (e.g. 'conv_action_items', 'persona_chat').
         streaming: Whether to return a streaming-enabled client.
-        cache_key: Optional prompt cache routing key (OpenAI gpt-5.1 only).
+        cache_key: Optional prompt cache routing key (OpenAI gpt-5.4/5.4-mini only).
 
     Usage:
         llm = get_llm('conv_action_items', cache_key='omi-extract-actions')
@@ -493,10 +497,8 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
             f"Feature '{feature}' is Perplexity — use get_model('{feature}') with the Perplexity HTTP client instead of get_llm()"
         )
 
-    model = get_model(feature)
-    provider = _classify_provider(model)
+    model, provider = _get_model_config(feature)
 
-    # Reject models that can't be served via ChatOpenAI (Anthropic direct, Perplexity)
     if provider == 'anthropic':
         raise ValueError(
             f"Feature '{feature}' resolved to Anthropic model '{model}' — use get_model() with anthropic_client"
@@ -513,6 +515,7 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
     if provider == 'gemini':
         return _get_or_create_gemini_llm(model, streaming)
 
+    # Default: OpenAI
     llm = _get_or_create_openai_llm(model, streaming)
     if cache_key and model in _CACHE_KEY_MODELS:
         return llm.bind(prompt_cache_key=cache_key)
@@ -520,27 +523,27 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
 
 
 def get_qos_info() -> Dict[str, Dict[str, str]]:
-    """Return full feature→model mapping for the active profile (debugging/monitoring)."""
+    """Return full feature→(model, provider) mapping for the active profile (debugging/monitoring)."""
     info: Dict[str, Dict[str, str]] = {}
     all_features = set(_active_profile.keys()) | set(_PINNED_FEATURES.keys())
     for feature in sorted(all_features):
-        model = get_model(feature)
+        model, provider = _get_model_config(feature)
         info[feature] = {
             'model': model,
             'profile': _active_profile_name,
-            'provider': _classify_provider(model),
+            'provider': provider,
         }
     return info
 
 
-# Startup logging (kai: log active profile so cost issues are traceable).
+# Startup logging — log active profile so cost issues are traceable.
 logger.info('Model QoS profile=%s (%d features)', _active_profile_name, len(_active_profile))
-for _feat, _model in sorted(_active_profile.items()):
-    _resolved = get_model(_feat)
-    if _resolved != _model:
-        logger.info('  QoS %s: %s (override, profile default: %s)', _feat, _resolved, _model)
+for _feat, (_model, _provider) in sorted(_active_profile.items()):
+    _resolved_model = get_model(_feat)
+    if _resolved_model != _model:
+        logger.info('  QoS %s: %s [%s] (override, profile default: %s)', _feat, _resolved_model, _provider, _model)
     else:
-        logger.info('  QoS %s: %s', _feat, _resolved)
+        logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
 
 
 # ---------------------------------------------------------------------------
@@ -554,7 +557,8 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = get_model('chat_agent')
 # Legacy module-level alias (kept for test compatibility).
 # Production code should use get_llm(feature) exclusively.
 # ---------------------------------------------------------------------------
-llm_mini = _byok_openai('gpt-4.1-mini', callbacks=[_usage_callback])
+_llm_mini_default = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback])
+llm_mini = _wrap_byok(_llm_mini_default, 'gpt-4.1-mini', 'openai', {'callbacks': [_usage_callback]})
 
 # ---------------------------------------------------------------------------
 # Embeddings, parser, utilities

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -526,16 +526,22 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
 
     if provider == 'openrouter':
         temp = _OPENROUTER_TEMPERATURES.get(feature)
-        return _get_or_create_openrouter_llm(model, streaming, temp)
+        result = _get_or_create_openrouter_llm(model, streaming, temp)
+    elif provider == 'gemini':
+        result = _get_or_create_gemini_llm(model, streaming)
+    else:
+        # Default: OpenAI
+        result = _get_or_create_openai_llm(model, streaming)
 
-    if provider == 'gemini':
-        return _get_or_create_gemini_llm(model, streaming)
+    # Eagerly resolve BYOK wrapper so callers always get a proper Runnable.
+    # This is safe because get_llm() is called within the request handler
+    # where the BYOK contextvar is already set by the middleware.
+    if isinstance(result, _BYOKChatWrapper):
+        result = result._resolve()
 
-    # Default: OpenAI
-    llm = _get_or_create_openai_llm(model, streaming)
     if cache_key and model in _CACHE_KEY_MODELS:
-        return llm.bind(prompt_cache_key=cache_key)
-    return llm
+        return result.bind(prompt_cache_key=cache_key)
+    return result
 
 
 def get_qos_info() -> Dict[str, Dict[str, str]]:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -364,18 +364,27 @@ def _get_model_config(feature: str) -> Tuple[str, str]:
         if ':' in override:
             parts = override.rsplit(':', 1)
             override_model, override_provider = parts[0], parts[1]
+            inferred = _classify_provider(override_model)
             if override_provider not in _VALID_PROVIDERS:
                 logger.warning(
-                    'QoS override %s=%s has invalid provider %r — falling back to profile provider %s',
+                    'QoS override %s=%s has invalid provider %r — using inferred provider %s',
                     env_key,
                     override,
                     override_provider,
-                    profile_entry[1],
+                    inferred,
                 )
-                override_provider = profile_entry[1]
+                override_provider = inferred
+            elif override_provider != inferred:
+                logger.warning(
+                    'QoS override %s=%s: explicit provider %r does not match model (inferred %s) — using inferred',
+                    env_key,
+                    override,
+                    override_provider,
+                    inferred,
+                )
+                override_provider = inferred
         else:
             override_model = override
-            # Model-only override: infer provider from model name to maintain safety guards
             override_provider = _classify_provider(override_model)
         return (override_model, override_provider)
     return _active_profile.get(feature, _DEFAULT_CONFIG)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -21,20 +21,20 @@ _usage_callback = get_usage_callback()
 # ---------------------------------------------------------------------------
 # BYOK routing proxies
 #
-# The backend has ~50 call sites that use module-level `llm_medium`, `llm_mini`,
-# etc. directly (e.g. `llm_medium.invoke(prompt)` or `llm_medium.bind_tools(...).ainvoke(...)`).
-# Rewriting every site to go through a factory would be a massive sweep.
-#
-# Instead we wrap each default client in a transparent proxy: every attribute
-# access resolves to either the default client or a BYOK-keyed client built
-# on the fly, keyed by (model, api_key) so we build each BYOK client once.
-# `__getattr__` forwards `bind_tools`, `with_structured_output`, `|` chaining,
-# etc. to the resolved client so tool-use/structured-output still route right.
+# All LLM features are routed through get_llm(feature) / get_model(feature).
+# Each proxy wraps a default client and transparently resolves to either
+# the default or a BYOK-keyed client at call time. `__getattr__` forwards
+# `bind_tools`, `with_structured_output`, `|` chaining, etc. to the resolved
+# client so tool-use/structured-output still route correctly.
 # ---------------------------------------------------------------------------
 
 
-class _OpenAIChatProxy:
-    """Forwards every attribute and call to the appropriate ChatOpenAI for the request."""
+class _BYOKChatProxy:
+    """Base class for transparent BYOK-aware ChatOpenAI proxies.
+
+    Subclasses only need to implement _resolve() — all attribute forwarding
+    and LangChain pipe composition is handled here.
+    """
 
     __slots__ = ('_model', '_default', '_ctor_kwargs')
 
@@ -44,10 +44,7 @@ class _OpenAIChatProxy:
         object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
 
     def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('openai')
-        if byok:
-            return _cached_openai_chat(self._model, byok, self._ctor_kwargs)
-        return self._default
+        raise NotImplementedError
 
     def __getattr__(self, name: str):
         return getattr(self._resolve(), name)
@@ -58,6 +55,18 @@ class _OpenAIChatProxy:
 
     def __ror__(self, other):
         return other | self._resolve()
+
+
+class _OpenAIChatProxy(_BYOKChatProxy):
+    """Routes to BYOK OpenAI when set, otherwise uses default OpenAI client."""
+
+    __slots__ = ()
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('openai')
+        if byok:
+            return _cached_openai_chat(self._model, byok, self._ctor_kwargs)
+        return self._default
 
 
 class _AnthropicClientProxy:
@@ -83,19 +92,18 @@ class _AnthropicClientProxy:
 _GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 
-class _OpenRouterGeminiProxy:
-    """For models served via OpenRouter that we want to route direct when BYOK Gemini is set.
+class _OpenRouterGeminiProxy(_BYOKChatProxy):
+    """Routes OpenRouter Gemini models to Google direct when BYOK Gemini is set.
 
     Falls back to the OpenRouter-backed default client when no BYOK gemini key
     is present — so non-BYOK users are unaffected.
     """
 
-    __slots__ = ('_default', '_direct_model', '_ctor_kwargs')
+    __slots__ = ('_direct_model',)
 
     def __init__(self, default: ChatOpenAI, direct_model: str, ctor_kwargs: Dict[str, Any]):
-        object.__setattr__(self, '_default', default)
+        super().__init__(model=direct_model, default=default, ctor_kwargs=ctor_kwargs)
         object.__setattr__(self, '_direct_model', direct_model)
-        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
 
     def _resolve(self) -> ChatOpenAI:
         byok = get_byok_key('gemini')
@@ -106,15 +114,6 @@ class _OpenRouterGeminiProxy:
                 {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
             )
         return self._default
-
-    def __getattr__(self, name: str):
-        return getattr(self._resolve(), name)
-
-    def __or__(self, other):
-        return self._resolve() | other
-
-    def __ror__(self, other):
-        return other | self._resolve()
 
 
 class _OpenAIEmbeddingsProxy:
@@ -241,6 +240,7 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
         'proactive_notification': 'gpt-4.1-mini',  # quality-sensitive: notification decisions
         'followup': 'gemini-2.5-flash-lite',  # free text question → Gemini (75% savings vs mini)
         'smart_glasses': 'gpt-4.1-nano',
+        'openglass': 'gpt-4.1-mini',  # vision: image description from smart glasses
         'onboarding': 'gemini-2.5-flash-lite',  # boolean yes/no check → Gemini (75% savings vs mini)
         'app_generator': 'gpt-5.4-mini',
         'app_integration': 'gemini-2.5-flash-lite',  # simple routing → Gemini (75% savings vs mini)
@@ -285,6 +285,7 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
         'proactive_notification': 'gpt-4.1-mini',
         'followup': 'gpt-4.1-mini',
         'smart_glasses': 'gpt-4.1-mini',
+        'openglass': 'gpt-4.1-mini',  # vision: image description from smart glasses
         'onboarding': 'gpt-4.1-mini',
         'app_generator': 'gpt-5.4',
         'app_integration': 'gpt-4.1-mini',
@@ -431,15 +432,10 @@ def _get_or_create_openrouter_llm(
     return _llm_cache[key]
 
 
-class _GeminiChatProxy:
-    """Transparent BYOK-aware proxy for Gemini models via Google's OpenAI-compatible endpoint."""
+class _GeminiChatProxy(_BYOKChatProxy):
+    """Routes to BYOK Gemini when set, otherwise uses default Google OpenAI-compatible endpoint."""
 
-    __slots__ = ('_model', '_default', '_ctor_kwargs')
-
-    def __init__(self, model: str, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
-        object.__setattr__(self, '_model', model)
-        object.__setattr__(self, '_default', default)
-        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+    __slots__ = ()
 
     def _resolve(self) -> ChatOpenAI:
         byok = get_byok_key('gemini')
@@ -450,15 +446,6 @@ class _GeminiChatProxy:
                 {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
             )
         return self._default
-
-    def __getattr__(self, name: str):
-        return getattr(self._resolve(), name)
-
-    def __or__(self, other):
-        return self._resolve() | other
-
-    def __ror__(self, other):
-        return other | self._resolve()
 
 
 def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _GeminiChatProxy:
@@ -564,84 +551,10 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = get_model('chat_agent')
 
 
 # ---------------------------------------------------------------------------
-# Legacy model instances (for callsites not yet wired through get_llm)
-#
-# These are kept for backward compatibility with BYOK routing.
-# New code should use get_llm(feature) or get_model(feature) instead.
+# Legacy module-level alias (kept for test compatibility).
+# Production code should use get_llm(feature) exclusively.
 # ---------------------------------------------------------------------------
 llm_mini = _byok_openai('gpt-4.1-mini', callbacks=[_usage_callback])
-llm_mini_stream = _byok_openai(
-    'gpt-4.1-mini',
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-llm_large = _byok_openai('o1-preview', callbacks=[_usage_callback])
-llm_large_stream = _byok_openai(
-    'o1-preview',
-    streaming=True,
-    stream_options={"include_usage": True},
-    temperature=1,
-    callbacks=[_usage_callback],
-)
-llm_high = _byok_openai('o4-mini', callbacks=[_usage_callback])
-llm_high_stream = _byok_openai(
-    'o4-mini',
-    streaming=True,
-    stream_options={"include_usage": True},
-    temperature=1,
-    callbacks=[_usage_callback],
-)
-llm_medium = _byok_openai('gpt-5.2', callbacks=[_usage_callback])
-llm_medium_stream = _byok_openai(
-    'gpt-5.2',
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-llm_medium_experiment = _byok_openai(
-    'gpt-5.1',
-    extra_body={"prompt_cache_retention": "24h"},
-    callbacks=[_usage_callback],
-)
-
-# Specialized models for agentic workflows
-# prompt_cache_key ensures consistent routing to the same cache machine
-# for better prompt prefix cache hit rates.
-_agent_cache_kwargs = {
-    "prompt_cache_key": "omi-agent-v1",
-}
-llm_agent = _byok_openai(
-    'gpt-5.1',
-    extra_body={"prompt_cache_retention": "24h"},
-    callbacks=[_usage_callback],
-    model_kwargs=_agent_cache_kwargs,
-)
-llm_agent_stream = _byok_openai(
-    'gpt-5.1',
-    streaming=True,
-    stream_options={"include_usage": True},
-    extra_body={"prompt_cache_retention": "24h"},
-    callbacks=[_usage_callback],
-    model_kwargs=_agent_cache_kwargs,
-)
-# Gemini models for large context analysis
-_gemini_flash_kwargs = dict(
-    temperature=0.7,
-    callbacks=[_usage_callback],
-)
-_gemini_flash_default = ChatOpenAI(
-    model="google/gemini-3-flash-preview",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Wrapped"},
-    **_gemini_flash_kwargs,
-)
-llm_gemini_flash = _OpenRouterGeminiProxy(
-    default=_gemini_flash_default,
-    direct_model="gemini-3-flash-preview",
-    ctor_kwargs=_gemini_flash_kwargs,
-)
 
 # ---------------------------------------------------------------------------
 # Embeddings, parser, utilities

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -146,13 +146,24 @@ def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict
             return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
     elif provider == 'openrouter':
-        # OpenRouter Gemini models: BYOK gemini key routes to Google direct
-        direct_model = model.split('/', 1)[1] if '/' in model else model
+        # Only reroute to Gemini direct if the model is actually Gemini-based
+        bare_model = model.split('/', 1)[1] if '/' in model else model
+        is_gemini_model = bare_model.startswith('gemini')
 
-        def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(direct_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+        if is_gemini_model:
 
-        return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
+            def _factory(byok_key: str) -> ChatOpenAI:
+                return _cached_openai_chat(bare_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+
+            return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
+        else:
+            # Non-Gemini OpenRouter model: BYOK stays on OpenRouter
+            def _factory(byok_key: str) -> ChatOpenAI:
+                return _cached_openai_chat(
+                    model, byok_key, {**clean_kwargs, 'base_url': 'https://openrouter.ai/api/v1'}
+                )
+
+            return _BYOKChatWrapper(default=default, provider='openrouter', byok_factory=_factory)
     else:
         # OpenAI and any future OpenAI-compatible provider
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,9 +1,12 @@
 import hashlib
 import logging
 import os
+import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import anthropic
+import google.auth
+import google.auth.transport.requests
 import httpx
 from cachetools import TTLCache
 from langchain_core.output_parsers import PydanticOutputParser
@@ -19,6 +22,41 @@ logger = logging.getLogger(__name__)
 _usage_callback = get_usage_callback()
 
 # ---------------------------------------------------------------------------
+# Vertex AI configuration — ADC auth for cost savings (EDP + Provisioned Throughput)
+# Platform Gemini calls route here; BYOK users stay on AI Studio.
+# ---------------------------------------------------------------------------
+
+try:
+    _vertex_credentials, _vertex_project = google.auth.default(
+        scopes=['https://www.googleapis.com/auth/cloud-platform'],
+    )
+except google.auth.exceptions.DefaultCredentialsError:
+    logger.info('No ADC found — Vertex AI Gemini calls will fall back to GEMINI_API_KEY')
+    _vertex_credentials = None
+    _vertex_project = None
+
+_GCP_PROJECT = os.environ.get('GOOGLE_CLOUD_PROJECT', '') or (_vertex_project or '')
+_GCP_LOCATION = os.environ.get('GCP_LOCATION', 'global')
+_vertex_lock = threading.Lock()
+
+
+def _get_vertex_access_token() -> str:
+    """Return a valid Vertex AI access token, refreshing if needed (thread-safe)."""
+    if _vertex_credentials is None:
+        raise RuntimeError('Vertex AI credentials not available — check ADC configuration')
+    with _vertex_lock:
+        if not _vertex_credentials.valid:
+            _vertex_credentials.refresh(google.auth.transport.requests.Request())
+        return _vertex_credentials.token
+
+
+def _vertex_openai_base_url(location: Optional[str] = None) -> str:
+    """Build the Vertex AI OpenAI-compatible endpoint URL."""
+    loc = location or _GCP_LOCATION
+    return f'https://aiplatform.googleapis.com/v1/projects/{_GCP_PROJECT}/locations/{loc}/endpoints/openapi'
+
+
+# ---------------------------------------------------------------------------
 # BYOK wrappers — generic, provider-agnostic
 #
 # BYOK is a per-request feature that substitutes the user's own API key.
@@ -28,7 +66,7 @@ _usage_callback = get_usage_callback()
 
 # Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
 # as the client class while routing to Gemini directly — no new langchain dep.
-_GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+_GEMINI_AI_STUDIO_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 
 class _BYOKChatWrapper:
@@ -143,7 +181,7 @@ def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict
     if provider == 'gemini':
 
         def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+            return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_AI_STUDIO_BASE_URL})
 
     elif provider == 'openrouter':
         # Only Gemini-based OpenRouter models support BYOK reroute to Gemini direct
@@ -151,7 +189,9 @@ def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict
         if bare_model.startswith('gemini'):
 
             def _factory(byok_key: str) -> ChatOpenAI:
-                return _cached_openai_chat(bare_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+                return _cached_openai_chat(
+                    bare_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_AI_STUDIO_BASE_URL}
+                )
 
             return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
         # Non-Gemini OpenRouter: no BYOK support, always use Omi's key
@@ -410,19 +450,43 @@ def _get_or_create_openrouter_llm(
 
 
 def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOKChatWrapper:
-    """Get or create a BYOK-wrapped ChatOpenAI for a Gemini model via Google's OpenAI-compat endpoint."""
+    """Get or create a BYOK-wrapped ChatOpenAI for a Gemini model.
+
+    Platform calls route to Vertex AI (ADC auth, EDP/PT discounts).
+    Falls back to GEMINI_API_KEY (AI Studio) when Vertex is unavailable.
+    BYOK users always route to AI Studio via the _BYOKChatWrapper.
+    """
     key = (model_name, streaming, 'gemini')
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        default = ChatOpenAI(
-            model=model_name,
-            api_key=os.environ.get('GEMINI_API_KEY', ''),
-            base_url=_GEMINI_OPENAI_BASE_URL,
-            **kwargs,
-        )
+        # Try Vertex AI first (ADC), fall back to AI Studio (GEMINI_API_KEY)
+        if _GCP_PROJECT:
+            try:
+                token = _get_vertex_access_token()
+                default = ChatOpenAI(
+                    model=model_name,
+                    api_key=token,
+                    base_url=_vertex_openai_base_url(),
+                    **kwargs,
+                )
+            except Exception:
+                logger.warning('Vertex AI credentials unavailable, falling back to GEMINI_API_KEY')
+                default = ChatOpenAI(
+                    model=model_name,
+                    api_key=os.environ.get('GEMINI_API_KEY', ''),
+                    base_url=_GEMINI_AI_STUDIO_BASE_URL,
+                    **kwargs,
+                )
+        else:
+            default = ChatOpenAI(
+                model=model_name,
+                api_key=os.environ.get('GEMINI_API_KEY', ''),
+                base_url=_GEMINI_AI_STUDIO_BASE_URL,
+                **kwargs,
+            )
         _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)
     return _llm_cache[key]
 
@@ -549,17 +613,38 @@ def gemini_embed_query(text: str) -> List[float]:
     Uses RETRIEVAL_QUERY task type to match the RETRIEVAL_DOCUMENT embeddings
     generated by the desktop app.
 
-    Prefers the per-request BYOK Gemini key; falls back to the process-wide
-    env key so non-BYOK callers behave exactly as before.
+    Routing:
+      - BYOK Gemini key present → AI Studio (user's own key, unchanged)
+      - No BYOK key → Vertex AI via ADC (EDP/PT cost savings)
     """
-    api_key = get_byok_key('gemini') or os.environ.get('GEMINI_API_KEY', '')
-    url = 'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent'
+    byok_key = get_byok_key('gemini')
+    if byok_key:
+        # BYOK users: AI Studio endpoint with their own API key
+        url = 'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent'
+        payload = {
+            'model': 'models/embedding-001',
+            'content': {'parts': [{'text': text}]},
+            'taskType': 'RETRIEVAL_QUERY',
+        }
+        headers = {'x-goog-api-key': byok_key, 'Content-Type': 'application/json'}
+        resp = httpx.post(url, json=payload, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return resp.json()['embedding']['values']
+
+    # Platform calls: Vertex AI endpoint with ADC token
+    if not _GCP_PROJECT:
+        raise RuntimeError('Gemini embedding requires either a BYOK key or GCP project configuration')
+    loc = os.environ.get('GCP_EMBEDDING_LOCATION', 'us-central1')
+    url = (
+        f'https://aiplatform.googleapis.com/v1beta1/projects/{_GCP_PROJECT}'
+        f'/locations/{loc}/publishers/google/models/gemini-embedding-001:embedContent'
+    )
     payload = {
-        'model': 'models/embedding-001',
         'content': {'parts': [{'text': text}]},
         'taskType': 'RETRIEVAL_QUERY',
     }
-    headers = {'x-goog-api-key': api_key, 'Content-Type': 'application/json'}
+    token = _get_vertex_access_token()
+    headers = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
     resp = httpx.post(url, json=payload, headers=headers, timeout=10)
     resp.raise_for_status()
     return resp.json()['embedding']['values']

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -195,8 +195,6 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 #   feature_b: ('gemini-2.5-flash', 'openrouter')   → OpenRouter
 #
 # Global switch:     MODEL_QOS=premium        (selects entire profile)
-# Per-feature:       MODEL_QOS_FOLLOWUP=gpt-4.1-nano:openai  (model:provider)
-#                    MODEL_QOS_FOLLOWUP=gpt-4.1-nano          (model only, inherits provider)
 #
 # Two profiles:
 #   premium — cost-effective default (80% of max quality)
@@ -313,22 +311,6 @@ _ANTHROPIC_ONLY_FEATURES = {'chat_agent'}
 _PERPLEXITY_ONLY_FEATURES = {'web_search'}
 
 
-def _classify_provider(model: str) -> str:
-    """Infer provider from model name. Used ONLY as fallback for env overrides
-    that don't specify an explicit provider (e.g. MODEL_QOS_X=gpt-4.1-mini).
-    Profile entries always have explicit provider — this is never used for them.
-    """
-    if '/' in model:
-        return 'openrouter'
-    if model.startswith('claude'):
-        return 'anthropic'
-    if model.startswith('sonar'):
-        return 'perplexity'
-    if model.startswith('gemini-'):
-        return 'gemini'
-    return 'openai'
-
-
 # Feature-specific client config (temperature, headers — orthogonal to model choice).
 # Only applied when a feature resolves to an OpenRouter model.
 _OPENROUTER_TEMPERATURES: Dict[str, float] = {
@@ -343,67 +325,26 @@ _CACHE_KEY_MODELS = {'gpt-5.4', 'gpt-5.4-mini'}
 _DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
 
 
-_VALID_PROVIDERS = {'openai', 'gemini', 'openrouter', 'anthropic', 'perplexity'}
-
-
 def _get_model_config(feature: str) -> Tuple[str, str]:
     """Get the (model, provider) tuple for a feature. Internal — used by get_llm/get_model/get_provider.
 
-    Resolution order: pinned > per-feature env override > active profile > fallback.
-
-    Env override formats:
-      MODEL_QOS_X=model:provider  — explicit model and provider (validated)
-      MODEL_QOS_X=model           — provider inferred from model name via _classify_provider()
+    Resolution order: pinned > active profile > fallback.
     """
     if feature in _PINNED_FEATURES:
         return _PINNED_FEATURES[feature]
-    env_key = f'MODEL_QOS_{feature.upper()}'
-    override = os.environ.get(env_key, '').strip()
-    if override:
-        profile_entry = _active_profile.get(feature, _DEFAULT_CONFIG)
-        if ':' in override:
-            parts = override.rsplit(':', 1)
-            override_model, override_provider = parts[0], parts[1]
-            inferred = _classify_provider(override_model)
-            if override_provider not in _VALID_PROVIDERS:
-                logger.warning(
-                    'QoS override %s=%s has invalid provider %r — using inferred provider %s',
-                    env_key,
-                    override,
-                    override_provider,
-                    inferred,
-                )
-                override_provider = inferred
-            elif override_provider != inferred:
-                logger.warning(
-                    'QoS override %s=%s: explicit provider %r does not match model (inferred %s) — using inferred',
-                    env_key,
-                    override,
-                    override_provider,
-                    inferred,
-                )
-                override_provider = inferred
-        else:
-            override_model = override
-            override_provider = _classify_provider(override_model)
-        return (override_model, override_provider)
     return _active_profile.get(feature, _DEFAULT_CONFIG)
 
 
 def get_model(feature: str) -> str:
     """Get the model name for a feature from the active Model QoS profile.
 
-    Resolution order: pinned > per-feature env override > active profile > fallback.
+    Resolution order: pinned > active profile > fallback.
 
     Args:
         feature: Feature name (e.g. 'conv_action_items', 'chat_agent').
 
     Returns:
         Model name string (e.g. 'gpt-4.1-mini', 'claude-sonnet-4-6').
-
-    Override via env var:
-        MODEL_QOS_CHAT_AGENT=claude-haiku-3.5:anthropic
-        MODEL_QOS_CONV_STRUCTURE=gpt-5.1
     """
     return _get_model_config(feature)[0]
 
@@ -561,11 +502,7 @@ def get_qos_info() -> Dict[str, Dict[str, str]]:
 # Startup logging — log active profile so cost issues are traceable.
 logger.info('Model QoS profile=%s (%d features)', _active_profile_name, len(_active_profile))
 for _feat, (_model, _provider) in sorted(_active_profile.items()):
-    _resolved_model = get_model(_feat)
-    if _resolved_model != _model:
-        logger.info('  QoS %s: %s [%s] (override, profile default: %s)', _feat, _resolved_model, _provider, _model)
-    else:
-        logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
+    logger.info('  QoS %s: %s [%s]', _feat, _model, _provider)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -221,34 +221,34 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
         'conv_folder': 'gpt-4.1-nano',
         'conv_discard': 'gpt-4.1-nano',
         'daily_summary': 'gpt-5.4-mini',
-        'daily_summary_simple': 'gpt-4.1-nano',
+        'daily_summary_simple': 'gemini-2.5-flash-lite',  # free-text stats → Gemini (75% savings vs mini)
         'external_structure': 'gpt-4.1-mini',  # quality-sensitive: structuring external data
         # OpenAI — memories & knowledge
         'memories': 'gpt-4.1-mini',  # quality-sensitive: memory extraction
         'learnings': 'gpt-5.4-mini',
         'memory_conflict': 'gpt-4.1-mini',  # quality-sensitive: conflict detection
-        'memory_category': 'gpt-4.1-nano',
+        'memory_category': 'gemini-2.5-flash-lite',  # text enum classification → Gemini (75% savings vs mini)
         'knowledge_graph': 'gpt-4.1-mini',  # quality-sensitive: entity/relationship extraction
         # OpenAI — chat
         'chat_responses': 'gpt-5.4-mini',
         'chat_extraction': 'gpt-4.1-mini',  # quality-sensitive: structured data extraction
         'chat_graph': 'gpt-4.1-mini',  # quality-sensitive: graph queries
-        'session_titles': 'gpt-4.1-nano',
+        'session_titles': 'gemini-2.5-flash-lite',  # free text title → Gemini (75% savings vs mini)
         # OpenAI — features
         'goals': 'gpt-4.1-mini',  # quality-sensitive: goal analysis
         'goals_advice': 'gpt-5.4-mini',
         'notifications': 'gpt-5.4-mini',
         'proactive_notification': 'gpt-4.1-mini',  # quality-sensitive: notification decisions
-        'followup': 'gpt-4.1-nano',
+        'followup': 'gemini-2.5-flash-lite',  # free text question → Gemini (75% savings vs mini)
         'smart_glasses': 'gpt-4.1-nano',
-        'onboarding': 'gpt-4.1-nano',
+        'onboarding': 'gemini-2.5-flash-lite',  # boolean yes/no check → Gemini (75% savings vs mini)
         'app_generator': 'gpt-5.4-mini',
-        'app_integration': 'gpt-4.1-nano',
+        'app_integration': 'gemini-2.5-flash-lite',  # simple routing → Gemini (75% savings vs mini)
         'persona_clone': 'gpt-5.4-mini',
-        'trends': 'gpt-4.1-nano',
+        'trends': 'gemini-2.5-flash-lite',  # simple pattern analysis → Gemini (75% savings vs mini)
         # Anthropic (chat_agent — used via get_model() + anthropic_client)
         'chat_agent': 'claude-sonnet-4-6',
-        # OpenAI — persona (moved from deprecated OpenRouter models to direct API)
+        # OpenAI — persona
         'persona_chat': 'gpt-4.1-nano',
         'persona_chat_premium': 'gpt-5.4-mini',
         # OpenRouter — wrapped_analysis only (gemini-3-flash-preview still active)
@@ -328,6 +328,8 @@ def _classify_provider(model: str) -> str:
         return 'anthropic'
     if model.startswith('sonar'):
         return 'perplexity'
+    if model.startswith('gemini-'):
+        return 'gemini'
     return 'openai'
 
 
@@ -429,10 +431,58 @@ def _get_or_create_openrouter_llm(
     return _llm_cache[key]
 
 
+class _GeminiChatProxy:
+    """Transparent BYOK-aware proxy for Gemini models via Google's OpenAI-compatible endpoint."""
+
+    __slots__ = ('_model', '_default', '_ctor_kwargs')
+
+    def __init__(self, model: str, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_model', model)
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('gemini')
+        if byok:
+            return _cached_openai_chat(
+                self._model,
+                byok,
+                {**self._ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL},
+            )
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+    def __or__(self, other):
+        return self._resolve() | other
+
+    def __ror__(self, other):
+        return other | self._resolve()
+
+
+def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _GeminiChatProxy:
+    """Get or create a BYOK-aware ChatOpenAI proxy for a Gemini model via Google's OpenAI-compat endpoint."""
+    key = (model_name, streaming, 'gemini')
+    if key not in _llm_cache:
+        kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
+        if streaming:
+            kwargs['streaming'] = True
+            kwargs['stream_options'] = {"include_usage": True}
+        default = ChatOpenAI(
+            model=model_name,
+            api_key=os.environ.get('GEMINI_API_KEY', ''),
+            base_url=_GEMINI_OPENAI_BASE_URL,
+            **kwargs,
+        )
+        _llm_cache[key] = _GeminiChatProxy(model=model_name, default=default, ctor_kwargs=kwargs)
+    return _llm_cache[key]
+
+
 def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> ChatOpenAI:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
-    Works for OpenAI and OpenRouter features (returns ChatOpenAI or BYOK proxy).
+    Works for OpenAI, Gemini, and OpenRouter features (returns ChatOpenAI or BYOK proxy).
     For Anthropic/Perplexity, use get_model(feature) to get the model string.
 
     Args:
@@ -472,6 +522,9 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
     if provider == 'openrouter':
         temp = _OPENROUTER_TEMPERATURES.get(feature)
         return _get_or_create_openrouter_llm(model, streaming, temp)
+
+    if provider == 'gemini':
+        return _get_or_create_gemini_llm(model, streaming)
 
     llm = _get_or_create_openai_llm(model, streaming)
     if cache_key and model in _CACHE_KEY_MODELS:
@@ -572,78 +625,6 @@ llm_agent_stream = _byok_openai(
     callbacks=[_usage_callback],
     model_kwargs=_agent_cache_kwargs,
 )
-_persona_mini_kwargs = dict(
-    temperature=0.8,
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-_persona_mini_default = ChatOpenAI(
-    model="google/gemini-flash-1.5-8b",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Chat"},
-    **_persona_mini_kwargs,
-)
-# BYOK Gemini → route direct to Google's OpenAI-compat endpoint.
-# Model name drops the `google/` prefix: gemini-flash-1.5-8b on Google direct.
-llm_persona_mini_stream = _OpenRouterGeminiProxy(
-    default=_persona_mini_default,
-    direct_model="gemini-flash-1.5-8b",
-    ctor_kwargs=_persona_mini_kwargs,
-)
-# Anthropic-via-OpenRouter. BYOK Anthropic users route to Anthropic's
-# OpenAI-compat endpoint directly, avoiding Omi's OpenRouter bill.
-_ANTHROPIC_OPENAI_BASE_URL = "https://api.anthropic.com/v1/"
-_persona_medium_kwargs = dict(
-    temperature=0.8,
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-_persona_medium_default = ChatOpenAI(
-    model="anthropic/claude-3.5-sonnet",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Chat"},
-    **_persona_medium_kwargs,
-)
-
-
-class _AnthropicViaOpenAIProxy:
-    """Route to Anthropic's OpenAI-compat endpoint when BYOK Anthropic key is set."""
-
-    __slots__ = ('_default', '_ctor_kwargs')
-
-    def __init__(self, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
-        object.__setattr__(self, '_default', default)
-        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
-
-    def _resolve(self) -> ChatOpenAI:
-        byok = get_byok_key('anthropic')
-        if byok:
-            return _cached_openai_chat(
-                'claude-sonnet-4-20250514',
-                byok,
-                {**self._ctor_kwargs, 'base_url': _ANTHROPIC_OPENAI_BASE_URL},
-            )
-        return self._default
-
-    def __getattr__(self, name: str):
-        return getattr(self._resolve(), name)
-
-    def __or__(self, other):
-        return self._resolve() | other
-
-    def __ror__(self, other):
-        return other | self._resolve()
-
-
-llm_persona_medium_stream = _AnthropicViaOpenAIProxy(
-    default=_persona_medium_default,
-    ctor_kwargs=_persona_medium_kwargs,
-)
-
 # Gemini models for large context analysis
 _gemini_flash_kwargs = dict(
     temperature=0.7,

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -137,24 +137,27 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
 
 def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict[str, Any]) -> _BYOKChatWrapper:
     """Wrap a ChatOpenAI client with BYOK resolution for the given provider."""
+    # Strip api_key/base_url from kwargs — BYOK factory supplies its own
+    clean_kwargs = {k: v for k, v in ctor_kwargs.items() if k not in ('api_key', 'base_url')}
+
     if provider == 'gemini':
 
         def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(model, byok_key, {**ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+            return _cached_openai_chat(model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
     elif provider == 'openrouter':
         # OpenRouter Gemini models: BYOK gemini key routes to Google direct
         direct_model = model.split('/', 1)[1] if '/' in model else model
 
         def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(direct_model, byok_key, {**ctor_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
+            return _cached_openai_chat(direct_model, byok_key, {**clean_kwargs, 'base_url': _GEMINI_OPENAI_BASE_URL})
 
         return _BYOKChatWrapper(default=default, provider='gemini', byok_factory=_factory)
     else:
         # OpenAI and any future OpenAI-compatible provider
 
         def _factory(byok_key: str) -> ChatOpenAI:
-            return _cached_openai_chat(model, byok_key, ctor_kwargs)
+            return _cached_openai_chat(model, byok_key, clean_kwargs)
 
     return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory)
 
@@ -337,39 +340,40 @@ _CACHE_KEY_MODELS = {'gpt-5.4', 'gpt-5.4-mini'}
 _DEFAULT_CONFIG: Tuple[str, str] = ('gpt-4.1-mini', 'openai')
 
 
+_VALID_PROVIDERS = {'openai', 'gemini', 'openrouter', 'anthropic', 'perplexity'}
+
+
 def _get_model_config(feature: str) -> Tuple[str, str]:
     """Get the (model, provider) tuple for a feature. Internal — used by get_llm/get_model/get_provider.
 
     Resolution order: pinned > per-feature env override > active profile > fallback.
-    Env override format: MODEL_QOS_X=model:provider  or  MODEL_QOS_X=model (inherits profile provider).
+
+    Env override formats:
+      MODEL_QOS_X=model:provider  — explicit model and provider (validated)
+      MODEL_QOS_X=model           — provider inferred from model name via _classify_provider()
     """
     if feature in _PINNED_FEATURES:
         return _PINNED_FEATURES[feature]
     env_key = f'MODEL_QOS_{feature.upper()}'
     override = os.environ.get(env_key, '').strip()
     if override:
-        # Parse model:provider format
+        profile_entry = _active_profile.get(feature, _DEFAULT_CONFIG)
         if ':' in override:
             parts = override.rsplit(':', 1)
             override_model, override_provider = parts[0], parts[1]
+            if override_provider not in _VALID_PROVIDERS:
+                logger.warning(
+                    'QoS override %s=%s has invalid provider %r — falling back to profile provider %s',
+                    env_key,
+                    override,
+                    override_provider,
+                    profile_entry[1],
+                )
+                override_provider = profile_entry[1]
         else:
             override_model = override
-            # Inherit provider from profile if not specified, fall back to inference
-            profile_entry = _active_profile.get(feature, _DEFAULT_CONFIG)
-            profile_provider = profile_entry[1]
+            # Model-only override: infer provider from model name to maintain safety guards
             override_provider = _classify_provider(override_model)
-            if override_provider != profile_provider:
-                logger.warning(
-                    'QoS override %s=%s (inferred provider: %s) differs from profile provider %s — '
-                    'use %s=%s:%s to be explicit',
-                    env_key,
-                    override,
-                    override_provider,
-                    profile_provider,
-                    env_key,
-                    override,
-                    override_provider,
-                )
         return (override_model, override_provider)
     return _active_profile.get(feature, _DEFAULT_CONFIG)
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -75,19 +75,33 @@ class _BYOKChatWrapper:
     NOT a base class. A decorator/wrapper applied by get_llm() on top of
     provider-specific clients. The provider tag determines which BYOK key
     pool to check. The byok_factory constructs a BYOK-keyed client when needed.
+
+    For providers with expiring credentials (e.g. Vertex AI OAuth2 tokens),
+    default_factory resolves a fresh default client per-request instead of
+    returning the static _default. This keeps token refresh aligned with
+    the QoS caching pattern.
     """
 
-    __slots__ = ('_default', '_provider', '_byok_factory')
+    __slots__ = ('_default', '_provider', '_byok_factory', '_default_factory')
 
-    def __init__(self, default: ChatOpenAI, provider: str, byok_factory: Callable[[str], ChatOpenAI]):
+    def __init__(
+        self,
+        default: ChatOpenAI,
+        provider: str,
+        byok_factory: Callable[[str], ChatOpenAI],
+        default_factory: Optional[Callable[[], ChatOpenAI]] = None,
+    ):
         object.__setattr__(self, '_default', default)
         object.__setattr__(self, '_provider', provider)
         object.__setattr__(self, '_byok_factory', byok_factory)
+        object.__setattr__(self, '_default_factory', default_factory)
 
     def _resolve(self) -> ChatOpenAI:
         byok = get_byok_key(self._provider)
         if byok:
             return self._byok_factory(byok)
+        if self._default_factory is not None:
+            return self._default_factory()
         return self._default
 
     def __getattr__(self, name: str):
@@ -173,8 +187,19 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
     return inst
 
 
-def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict[str, Any]) -> _BYOKChatWrapper:
-    """Wrap a ChatOpenAI client with BYOK resolution for the given provider."""
+def _wrap_byok(
+    default: ChatOpenAI,
+    model: str,
+    provider: str,
+    ctor_kwargs: Dict[str, Any],
+    default_factory: Optional[Callable[[], ChatOpenAI]] = None,
+) -> _BYOKChatWrapper:
+    """Wrap a ChatOpenAI client with BYOK resolution for the given provider.
+
+    Args:
+        default_factory: Optional callable that returns a fresh default client
+            per-request. Used for providers with expiring credentials (Vertex AI).
+    """
     # Strip api_key/base_url from kwargs — BYOK factory supplies its own
     clean_kwargs = {k: v for k, v in ctor_kwargs.items() if k not in ('api_key', 'base_url')}
 
@@ -202,7 +227,7 @@ def _wrap_byok(default: ChatOpenAI, model: str, provider: str, ctor_kwargs: Dict
         def _factory(byok_key: str) -> ChatOpenAI:
             return _cached_openai_chat(model, byok_key, clean_kwargs)
 
-    return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory)
+    return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory, default_factory=default_factory)
 
 
 # Anthropic client for chat agent (module-level, BYOK-aware)
@@ -455,6 +480,12 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOK
     Platform calls route to Vertex AI (ADC auth, EDP/PT discounts).
     Falls back to GEMINI_API_KEY (AI Studio) when Vertex is unavailable.
     BYOK users always route to AI Studio via the _BYOKChatWrapper.
+
+    Vertex AI uses OAuth2 tokens that expire after ~1 hour. Rather than
+    baking a static token into a cached client, we use a default_factory
+    that resolves a fresh token per-request via _BYOKChatWrapper._resolve().
+    Clients are cached in _openai_cache (TTLCache, 1h) keyed by token hash
+    so the same client is reused while the token is valid.
     """
     key = (model_name, streaming, 'gemini')
     if key not in _llm_cache:
@@ -462,24 +493,28 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOK
         if streaming:
             kwargs['streaming'] = True
             kwargs['stream_options'] = {"include_usage": True}
-        # Try Vertex AI first (ADC), fall back to AI Studio (GEMINI_API_KEY)
+
         if _GCP_PROJECT:
-            try:
-                token = _get_vertex_access_token()
-                default = ChatOpenAI(
-                    model=model_name,
-                    api_key=token,
-                    base_url=_vertex_openai_base_url(),
-                    **kwargs,
-                )
-            except Exception:
-                logger.warning('Vertex AI credentials unavailable, falling back to GEMINI_API_KEY')
-                default = ChatOpenAI(
-                    model=model_name,
-                    api_key=os.environ.get('GEMINI_API_KEY', ''),
-                    base_url=_GEMINI_AI_STUDIO_BASE_URL,
-                    **kwargs,
-                )
+            vertex_base_url = _vertex_openai_base_url()
+            vertex_kwargs = {**kwargs, 'base_url': vertex_base_url}
+
+            def _vertex_client_factory() -> ChatOpenAI:
+                """Resolve a Vertex AI client with a fresh token (cached by token hash)."""
+                try:
+                    token = _get_vertex_access_token()
+                    return _cached_openai_chat(model_name, token, vertex_kwargs)
+                except Exception:
+                    logger.warning('Vertex AI credentials unavailable, falling back to GEMINI_API_KEY')
+                    return ChatOpenAI(
+                        model=model_name,
+                        api_key=os.environ.get('GEMINI_API_KEY', ''),
+                        base_url=_GEMINI_AI_STUDIO_BASE_URL,
+                        **kwargs,
+                    )
+
+            # Eagerly resolve initial default for introspection / test compatibility
+            default = _vertex_client_factory()
+            _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs, default_factory=_vertex_client_factory)
         else:
             default = ChatOpenAI(
                 model=model_name,
@@ -487,7 +522,7 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOK
                 base_url=_GEMINI_AI_STUDIO_BASE_URL,
                 **kwargs,
             )
-        _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)
+            _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)
     return _llm_cache[key]
 
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,15 +1,14 @@
 import hashlib
 import logging
 import os
-import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import anthropic
-import google.auth
-import google.auth.transport.requests
 import httpx
 from cachetools import TTLCache
+from google import genai
 from langchain_core.output_parsers import PydanticOutputParser
+from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 import tiktoken
 
@@ -24,36 +23,20 @@ _usage_callback = get_usage_callback()
 # ---------------------------------------------------------------------------
 # Vertex AI configuration — ADC auth for cost savings (EDP + Provisioned Throughput)
 # Platform Gemini calls route here; BYOK users stay on AI Studio.
+# The langchain-google-genai SDK handles token refresh automatically.
 # ---------------------------------------------------------------------------
 
-try:
-    _vertex_credentials, _vertex_project = google.auth.default(
-        scopes=['https://www.googleapis.com/auth/cloud-platform'],
-    )
-except google.auth.exceptions.DefaultCredentialsError:
-    logger.info('No ADC found — Vertex AI Gemini calls will fall back to GEMINI_API_KEY')
-    _vertex_credentials = None
-    _vertex_project = None
-
-_GCP_PROJECT = os.environ.get('GOOGLE_CLOUD_PROJECT', '') or (_vertex_project or '')
+_GCP_PROJECT = os.environ.get('GOOGLE_CLOUD_PROJECT', '')
 _GCP_LOCATION = os.environ.get('GCP_LOCATION', 'global')
-_vertex_lock = threading.Lock()
+
+_vertex_embed_clients: Dict[str, genai.Client] = {}
 
 
-def _get_vertex_access_token() -> str:
-    """Return a valid Vertex AI access token, refreshing if needed (thread-safe)."""
-    if _vertex_credentials is None:
-        raise RuntimeError('Vertex AI credentials not available — check ADC configuration')
-    with _vertex_lock:
-        if not _vertex_credentials.valid:
-            _vertex_credentials.refresh(google.auth.transport.requests.Request())
-        return _vertex_credentials.token
-
-
-def _vertex_openai_base_url(location: Optional[str] = None) -> str:
-    """Build the Vertex AI OpenAI-compatible endpoint URL."""
-    loc = location or _GCP_LOCATION
-    return f'https://aiplatform.googleapis.com/v1/projects/{_GCP_PROJECT}/locations/{loc}/endpoints/openapi'
+def _get_vertex_embed_client(location: str) -> genai.Client:
+    """Get or create a google-genai Client for Vertex AI embeddings (cached per location)."""
+    if location not in _vertex_embed_clients:
+        _vertex_embed_clients[location] = genai.Client(project=_GCP_PROJECT, location=location, vertexai=True)
+    return _vertex_embed_clients[location]
 
 
 # ---------------------------------------------------------------------------
@@ -64,44 +47,29 @@ def _vertex_openai_base_url(location: Optional[str] = None) -> str:
 # The QoS layer creates a plain client, then optionally wraps it with BYOK.
 # ---------------------------------------------------------------------------
 
-# Google's OpenAI-compatible endpoint lets us keep langchain_openai.ChatOpenAI
-# as the client class while routing to Gemini directly — no new langchain dep.
+# AI Studio base URL for BYOK Gemini users (ChatOpenAI + Google's OpenAI-compat endpoint).
 _GEMINI_AI_STUDIO_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 
 class _BYOKChatWrapper:
-    """Wraps any ChatOpenAI client with per-request BYOK key substitution.
+    """Wraps any BaseChatModel client with per-request BYOK key substitution.
 
     NOT a base class. A decorator/wrapper applied by get_llm() on top of
     provider-specific clients. The provider tag determines which BYOK key
     pool to check. The byok_factory constructs a BYOK-keyed client when needed.
-
-    For providers with expiring credentials (e.g. Vertex AI OAuth2 tokens),
-    default_factory resolves a fresh default client per-request instead of
-    returning the static _default. This keeps token refresh aligned with
-    the QoS caching pattern.
     """
 
-    __slots__ = ('_default', '_provider', '_byok_factory', '_default_factory')
+    __slots__ = ('_default', '_provider', '_byok_factory')
 
-    def __init__(
-        self,
-        default: ChatOpenAI,
-        provider: str,
-        byok_factory: Callable[[str], ChatOpenAI],
-        default_factory: Optional[Callable[[], ChatOpenAI]] = None,
-    ):
+    def __init__(self, default, provider: str, byok_factory: Callable[[str], ChatOpenAI]):
         object.__setattr__(self, '_default', default)
         object.__setattr__(self, '_provider', provider)
         object.__setattr__(self, '_byok_factory', byok_factory)
-        object.__setattr__(self, '_default_factory', default_factory)
 
-    def _resolve(self) -> ChatOpenAI:
+    def _resolve(self):
         byok = get_byok_key(self._provider)
         if byok:
             return self._byok_factory(byok)
-        if self._default_factory is not None:
-            return self._default_factory()
         return self._default
 
     def __getattr__(self, name: str):
@@ -187,19 +155,8 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
     return inst
 
 
-def _wrap_byok(
-    default: ChatOpenAI,
-    model: str,
-    provider: str,
-    ctor_kwargs: Dict[str, Any],
-    default_factory: Optional[Callable[[], ChatOpenAI]] = None,
-) -> _BYOKChatWrapper:
-    """Wrap a ChatOpenAI client with BYOK resolution for the given provider.
-
-    Args:
-        default_factory: Optional callable that returns a fresh default client
-            per-request. Used for providers with expiring credentials (Vertex AI).
-    """
+def _wrap_byok(default, model: str, provider: str, ctor_kwargs: Dict[str, Any]) -> _BYOKChatWrapper:
+    """Wrap a BaseChatModel client with BYOK resolution for the given provider."""
     # Strip api_key/base_url from kwargs — BYOK factory supplies its own
     clean_kwargs = {k: v for k, v in ctor_kwargs.items() if k not in ('api_key', 'base_url')}
 
@@ -227,7 +184,7 @@ def _wrap_byok(
         def _factory(byok_key: str) -> ChatOpenAI:
             return _cached_openai_chat(model, byok_key, clean_kwargs)
 
-    return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory, default_factory=default_factory)
+    return _BYOKChatWrapper(default=default, provider=provider, byok_factory=_factory)
 
 
 # Anthropic client for chat agent (module-level, BYOK-aware)
@@ -475,60 +432,35 @@ def _get_or_create_openrouter_llm(
 
 
 def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOKChatWrapper:
-    """Get or create a BYOK-wrapped ChatOpenAI for a Gemini model.
+    """Get or create a BYOK-wrapped Gemini client.
 
-    Platform calls route to Vertex AI (ADC auth, EDP/PT discounts).
-    Falls back to GEMINI_API_KEY (AI Studio) when Vertex is unavailable.
+    Platform calls route to Vertex AI via the langchain-google-genai SDK,
+    which handles ADC auth and token refresh automatically.
+    Falls back to AI Studio (GEMINI_API_KEY) when no GCP project is configured.
     BYOK users always route to AI Studio via the _BYOKChatWrapper.
-
-    Vertex AI uses OAuth2 tokens that expire after ~1 hour. Rather than
-    baking a static token into a cached client, we use a default_factory
-    that resolves a fresh token per-request via _BYOKChatWrapper._resolve().
-    Clients are cached in _openai_cache (TTLCache, 1h) keyed by token hash
-    so the same client is reused while the token is valid.
     """
     key = (model_name, streaming, 'gemini')
     if key not in _llm_cache:
         kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
         if streaming:
             kwargs['streaming'] = True
-            kwargs['stream_options'] = {"include_usage": True}
 
         if _GCP_PROJECT:
-            vertex_base_url = _vertex_openai_base_url()
-            vertex_kwargs = {**kwargs, 'base_url': vertex_base_url}
-
-            def _vertex_client_factory() -> ChatOpenAI:
-                """Resolve a Vertex AI client with a fresh token (cached by token hash)."""
-                try:
-                    token = _get_vertex_access_token()
-                    return _cached_openai_chat(model_name, token, vertex_kwargs)
-                except Exception:
-                    # Only fall back to AI Studio if GEMINI_API_KEY is actually available.
-                    # In production Helm config, the key is removed — fail fast instead
-                    # of creating an unauthenticated client that errors downstream.
-                    gemini_key = os.environ.get('GEMINI_API_KEY', '')
-                    if not gemini_key:
-                        raise
-                    logger.warning('Vertex AI credentials unavailable, falling back to GEMINI_API_KEY')
-                    return ChatOpenAI(
-                        model=model_name,
-                        api_key=gemini_key,
-                        base_url=_GEMINI_AI_STUDIO_BASE_URL,
-                        **kwargs,
-                    )
-
-            # Eagerly resolve initial default for introspection / test compatibility
-            default = _vertex_client_factory()
-            _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs, default_factory=_vertex_client_factory)
-        else:
-            default = ChatOpenAI(
+            # Vertex AI via SDK — handles ADC token refresh automatically
+            default = ChatGoogleGenerativeAI(
                 model=model_name,
-                api_key=os.environ.get('GEMINI_API_KEY', ''),
-                base_url=_GEMINI_AI_STUDIO_BASE_URL,
+                project=_GCP_PROJECT,
+                location=_GCP_LOCATION,
                 **kwargs,
             )
-            _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)
+        else:
+            # No GCP project — use AI Studio with GEMINI_API_KEY
+            default = ChatGoogleGenerativeAI(
+                model=model_name,
+                api_key=os.environ.get('GEMINI_API_KEY', ''),
+                **kwargs,
+            )
+        _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)
     return _llm_cache[key]
 
 
@@ -655,8 +587,8 @@ def gemini_embed_query(text: str) -> List[float]:
     generated by the desktop app.
 
     Routing:
-      - BYOK Gemini key present → AI Studio (user's own key, unchanged)
-      - No BYOK key → Vertex AI via ADC (EDP/PT cost savings)
+      - BYOK Gemini key present → AI Studio (user's own key)
+      - No BYOK key → Vertex AI via google-genai SDK (ADC, token refresh automatic)
     """
     byok_key = get_byok_key('gemini')
     if byok_key:
@@ -672,20 +604,13 @@ def gemini_embed_query(text: str) -> List[float]:
         resp.raise_for_status()
         return resp.json()['embedding']['values']
 
-    # Platform calls: Vertex AI endpoint with ADC token
+    # Platform calls: Vertex AI via google-genai SDK (handles ADC token refresh)
     if not _GCP_PROJECT:
         raise RuntimeError('Gemini embedding requires either a BYOK key or GCP project configuration')
     loc = os.environ.get('GCP_EMBEDDING_LOCATION', 'us-central1')
-    url = (
-        f'https://aiplatform.googleapis.com/v1beta1/projects/{_GCP_PROJECT}'
-        f'/locations/{loc}/publishers/google/models/gemini-embedding-001:embedContent'
+    result = _get_vertex_embed_client(loc).models.embed_content(
+        model='gemini-embedding-001',
+        contents=text,
+        config={'task_type': 'RETRIEVAL_QUERY'},
     )
-    payload = {
-        'content': {'parts': [{'text': text}]},
-        'taskType': 'RETRIEVAL_QUERY',
-    }
-    token = _get_vertex_access_token()
-    headers = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
-    resp = httpx.post(url, json=payload, headers=headers, timeout=10)
-    resp.raise_for_status()
-    return resp.json()['embedding']['values']
+    return list(result.embeddings[0].values)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -445,6 +445,7 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOK
         if streaming:
             kwargs['streaming'] = True
 
+        gemini_api_key = os.environ.get('GEMINI_API_KEY', '')
         if _GCP_PROJECT:
             # Vertex AI via SDK — handles ADC token refresh automatically
             default = ChatGoogleGenerativeAI(
@@ -453,11 +454,20 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOK
                 location=_GCP_LOCATION,
                 **kwargs,
             )
-        else:
-            # No GCP project — use AI Studio with GEMINI_API_KEY
+        elif gemini_api_key:
+            # No GCP project — use AI Studio with GEMINI_API_KEY via SDK
             default = ChatGoogleGenerativeAI(
                 model=model_name,
-                api_key=os.environ.get('GEMINI_API_KEY', ''),
+                api_key=gemini_api_key,
+                **kwargs,
+            )
+        else:
+            # No GCP project and no API key — fall back to ChatOpenAI pointed at AI Studio
+            # This preserves constructability without credentials (will fail at invoke time)
+            default = ChatOpenAI(
+                model=model_name,
+                openai_api_key='placeholder',
+                openai_api_base=_GEMINI_AI_STUDIO_BASE_URL,
                 **kwargs,
             )
         _llm_cache[key] = _wrap_byok(default, model_name, 'gemini', kwargs)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -504,10 +504,16 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> _BYOK
                     token = _get_vertex_access_token()
                     return _cached_openai_chat(model_name, token, vertex_kwargs)
                 except Exception:
+                    # Only fall back to AI Studio if GEMINI_API_KEY is actually available.
+                    # In production Helm config, the key is removed — fail fast instead
+                    # of creating an unauthenticated client that errors downstream.
+                    gemini_key = os.environ.get('GEMINI_API_KEY', '')
+                    if not gemini_key:
+                        raise
                     logger.warning('Vertex AI credentials unavailable, falling back to GEMINI_API_KEY')
                     return ChatOpenAI(
                         model=model_name,
-                        api_key=os.environ.get('GEMINI_API_KEY', ''),
+                        api_key=gemini_key,
                         base_url=_GEMINI_AI_STUDIO_BASE_URL,
                         **kwargs,
                     )

--- a/backend/utils/llm/openglass.py
+++ b/backend/utils/llm/openglass.py
@@ -2,7 +2,7 @@ from typing import List
 
 from models.conversation_photo import ConversationPhoto
 from models.structured import Structured
-from utils.llm.clients import llm_mini
+from utils.llm.clients import get_llm
 from utils.llm.usage_tracker import track_usage, Features
 
 
@@ -28,6 +28,6 @@ async def describe_image(uid: str, base64_data: str) -> str:
     }
 
     with track_usage(uid, Features.OPENGLASS):
-        response = await llm_mini.ainvoke([message], config={"max_tokens": 150})
+        response = await get_llm('openglass').ainvoke([message], config={"max_tokens": 150})
     description = response.content
     return description.strip() if description is not None and description != '""' else ""

--- a/backend/utils/llm/usage_tracker.py
+++ b/backend/utils/llm/usage_tracker.py
@@ -77,6 +77,33 @@ class LLMUsageCallback(BaseCallbackHandler):
         input_tokens = token_usage.get("prompt_tokens", 0)
         output_tokens = token_usage.get("completion_tokens", 0)
 
+        # Fallback: ChatGoogleGenerativeAI puts token counts on message.usage_metadata
+        # instead of llm_output["token_usage"]. Extract from there if primary path yields 0.
+        if input_tokens == 0 and output_tokens == 0 and response.generations:
+            for gen_list in response.generations:
+                for gen in gen_list:
+                    msg = getattr(gen, "message", None)
+                    if msg is None:
+                        continue
+                    usage = getattr(msg, "usage_metadata", None)
+                    if usage:
+                        input_tokens = (
+                            getattr(usage, "input_tokens", 0) or usage.get("input_tokens", 0)
+                            if isinstance(usage, dict)
+                            else getattr(usage, "input_tokens", 0)
+                        )
+                        output_tokens = (
+                            getattr(usage, "output_tokens", 0) or usage.get("output_tokens", 0)
+                            if isinstance(usage, dict)
+                            else getattr(usage, "output_tokens", 0)
+                        )
+                        if model == "unknown":
+                            resp_meta = getattr(msg, "response_metadata", {})
+                            model = resp_meta.get("model_name", model) if isinstance(resp_meta, dict) else model
+                        break
+                if input_tokens > 0 or output_tokens > 0:
+                    break
+
         # Also try to get model from response metadata
         if model == "unknown" and response.generations:
             for gen_list in response.generations:


### PR DESCRIPTION
## Summary
- Migrates Gemini API calls from AI Studio to **Vertex AI** using Google's official SDKs for ~34% cost savings (EDP + Provisioned Throughput)
- Uses `langchain-google-genai` (`ChatGoogleGenerativeAI`) for LLM calls — SDK handles ADC/OAuth2 token refresh automatically
- Uses `google-genai` (`genai.Client`) for embeddings via Vertex AI — automatic credential management
- BYOK users continue using AI Studio via `ChatOpenAI` (no change for them)
- Removes all manual OAuth2 token refresh machinery (threading, google.auth, credential caching)
- Removes `GEMINI_API_KEY` from Helm charts (replaced with `GCP_LOCATION`)
- Fixes usage tracking: `LLMUsageCallback` now extracts token counts from Gemini's `usage_metadata` (not just `llm_output["token_usage"]`)

## Architecture
- **Platform LLM calls**: `ChatGoogleGenerativeAI` with `project` + `location` params → Vertex AI (SDK handles auth)
- **Platform embeddings**: `genai.Client(vertexai=True)` → Vertex AI embedding endpoint
- **BYOK LLM calls**: `ChatOpenAI` → AI Studio `generativelanguage.googleapis.com` (unchanged)
- **BYOK embeddings**: `httpx.post` → AI Studio embedding endpoint (unchanged)
- **No credentials fallback**: `ChatOpenAI` placeholder (constructable, fails at invoke time)

## Testing
- 21 vertex AI migration tests (LLM factory routing, embed routing, client caching, Helm cleanup, GCP_LOCATION, SDK availability)
- 19 usage tracker tests (including Gemini usage_metadata regression test)
- 73 QoS tier tests (routing verification)
- 11 BYOK security tests (updated SDK mocking)
- All 113+ tests pass

## Review Cycle Summary
- **Round 1**: Fixed usage tracking regression (usage_metadata fallback) and eager API key validation (3-way fallback)
- **Round 2**: Added regression test for no-project no-key ChatOpenAI fallback
- **Round 3**: Added Helm GCP_LOCATION verification tests
- **Approved**: PR_APPROVED_LGTM + TESTS_APPROVED

## Risks / Edge Cases
- `GOOGLE_CLOUD_PROJECT` env var must be set in production for Vertex AI routing
- If GCP project is empty and no `GEMINI_API_KEY`, embedding raises `RuntimeError` (fail-fast)
- `GCP_LOCATION` defaults to `global` for LLM, `us-central1` for embeddings (overridable via env)

Closes #6935

_by AI for @beastoin_