### PR TITLE
Update CHANGELOG.json for v0.11.354 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Removed Anthropic API key from client, added Omi AI branding in Settings, improved harness switching"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.354",
+      "date": "2026-04-23",
+      "changes": [
+        "Removed Anthropic API key from client, added Omi AI branding in Settings, improved harness switching"
+      ]
+    },
     {
       "version": "0.11.353",
       "date": "2026-04-23",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.354 and clears the unreleased array.