### PR TITLE
Fix pi-mono path resolution for app bundles with spaces

### DIFF
--- a/desktop/agent/src/adapters/pi-mono.ts
+++ b/desktop/agent/src/adapters/pi-mono.ts
@@ -124,13 +124,15 @@ function resolveBundledPi(): string {
   // this file compiles to agent/dist/adapters/pi-mono.js
   // Prefer the direct package path — .bin/pi is a symlink that ditto resolves
   // into a flat copy, breaking its relative import of ./main.js
-  const direct = new URL(
+  // Note: URL.pathname percent-encodes spaces (%20) which breaks existsSync
+  // for app bundles with spaces in their name (e.g. "Omi Beta.app").
+  const direct = decodeURIComponent(new URL(
     "../../node_modules/@mariozechner/pi-coding-agent/dist/cli.js",
     import.meta.url
-  ).pathname;
+  ).pathname);
   if (existsSync(direct)) return direct;
-  const binFallback = new URL("../../node_modules/.bin/pi", import.meta.url)
-    .pathname;
+  const binFallback = decodeURIComponent(new URL("../../node_modules/.bin/pi", import.meta.url)
+    .pathname);
   if (existsSync(binFallback)) return binFallback;
   return "pi";
 }
@@ -141,10 +143,10 @@ function resolveBundledPi(): string {
  *  Shipped: <App>.app/Contents/Resources/agent/dist/adapters/../../.. → <App>.app/Contents/Resources/pi-mono-extension/index.ts
  */
 function resolveBundledExtension(): string {
-  return new URL(
+  return decodeURIComponent(new URL(
     "../../../pi-mono-extension/index.ts",
     import.meta.url
-  ).pathname;
+  ).pathname);
 }
 
 export class PiMonoAdapter implements HarnessAdapter {


### PR DESCRIPTION
## Summary
- Fix `spawn pi ENOENT` crash on released Omi Beta/Omi Dev builds
- `URL.pathname` percent-encodes spaces (`%20`) which breaks `existsSync` for app bundles with spaces in their names (e.g. "Omi Beta.app", "Omi Dev.app")
- Apply `decodeURIComponent()` to all `import.meta.url`-based path resolutions in the pi-mono adapter
- Affects both `resolveBundledPi()` and `resolveBundledExtension()`

## Root Cause
The pi binary IS correctly bundled inside the app at:
```
Omi Beta.app/Contents/Resources/agent/node_modules/@mariozechner/pi-coding-agent/dist/cli.js
```
But `new URL(..., import.meta.url).pathname` returns:
```
/Applications/Omi%20Beta.app/Contents/Resources/agent/node_modules/...
```
`existsSync("/Applications/Omi%20Beta.app/...")` → `false` because the filesystem has a literal space, not `%20`.

## Test plan
- [x] TypeScript compiles (`npm run build`)
- [x] Swift app compiles (`xcrun swift build`)
- [ ] Build named test bundle with spaces and verify pi-mono resolves correctly
- [ ] Verify chat works end-to-end in released build after update

Closes: discovered during live testing of PR #6930 (issue #6594)

🤖 Generated with [Claude Code](https://claude.com/claude-code)