### PR TITLE
Update CHANGELOG.json for v0.11.358 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed AI provider switch not restarting the agent bridge session"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.358",
+      "date": "2026-04-23",
+      "changes": [
+        "Fixed AI provider switch not restarting the agent bridge session"
+      ]
+    },
     {
       "version": "0.11.357",
       "date": "2026-04-23",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.358 and clears the unreleased array.