### PR TITLE
Phone calls: free-tier monthly quota with server-driven config

### DIFF
--- a/app/lib/models/subscription.dart
+++ b/app/lib/models/subscription.dart
@@ -90,6 +90,34 @@ class SubscriptionPlan {
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
+class PhoneCallQuota {
+  final bool hasAccess;
+  final bool isPaid;
+  final int? monthlyLimit;
+  @JsonKey(defaultValue: 0)
+  final int monthlyUsed;
+  final int? remaining;
+  final int? maxDurationSeconds;
+  @JsonKey(defaultValue: [])
+  final List<String> allowedCountries;
+  final int? resetAt;
+
+  PhoneCallQuota({
+    required this.hasAccess,
+    required this.isPaid,
+    this.monthlyLimit,
+    this.monthlyUsed = 0,
+    this.remaining,
+    this.maxDurationSeconds,
+    this.allowedCountries = const [],
+    this.resetAt,
+  });
+
+  factory PhoneCallQuota.fromJson(Map<String, dynamic> json) => _$PhoneCallQuotaFromJson(json);
+  Map<String, dynamic> toJson() => _$PhoneCallQuotaToJson(this);
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
 class UserSubscriptionResponse {
   final Subscription subscription;
   final int transcriptionSecondsUsed;
@@ -113,6 +141,7 @@ class UserSubscriptionResponse {
   @JsonKey(defaultValue: true)
   final bool chatQuotaAllowed;
   final int? chatQuotaResetAt;
+  final PhoneCallQuota? phoneCallQuota;
 
   UserSubscriptionResponse({
     required this.subscription,
@@ -131,6 +160,7 @@ class UserSubscriptionResponse {
     this.chatQuotaPercent = 0.0,
     this.chatQuotaAllowed = true,
     this.chatQuotaResetAt,
+    this.phoneCallQuota,
   });
 
   factory UserSubscriptionResponse.fromJson(Map<String, dynamic> json) => _$UserSubscriptionResponseFromJson(json);

--- a/app/lib/models/subscription.g.dart
+++ b/app/lib/models/subscription.g.dart
@@ -109,6 +109,33 @@ Map<String, dynamic> _$SubscriptionPlanToJson(SubscriptionPlan instance) =>
       'prices': instance.prices,
     };
 
+PhoneCallQuota _$PhoneCallQuotaFromJson(Map<String, dynamic> json) =>
+    PhoneCallQuota(
+      hasAccess: json['has_access'] as bool,
+      isPaid: json['is_paid'] as bool,
+      monthlyLimit: (json['monthly_limit'] as num?)?.toInt(),
+      monthlyUsed: (json['monthly_used'] as num?)?.toInt() ?? 0,
+      remaining: (json['remaining'] as num?)?.toInt(),
+      maxDurationSeconds: (json['max_duration_seconds'] as num?)?.toInt(),
+      allowedCountries: (json['allowed_countries'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+      resetAt: (json['reset_at'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$PhoneCallQuotaToJson(PhoneCallQuota instance) =>
+    <String, dynamic>{
+      'has_access': instance.hasAccess,
+      'is_paid': instance.isPaid,
+      'monthly_limit': instance.monthlyLimit,
+      'monthly_used': instance.monthlyUsed,
+      'remaining': instance.remaining,
+      'max_duration_seconds': instance.maxDurationSeconds,
+      'allowed_countries': instance.allowedCountries,
+      'reset_at': instance.resetAt,
+    };
+
 UserSubscriptionResponse _$UserSubscriptionResponseFromJson(
         Map<String, dynamic> json) =>
     UserSubscriptionResponse(
@@ -134,6 +161,10 @@ UserSubscriptionResponse _$UserSubscriptionResponseFromJson(
       chatQuotaPercent: (json['chat_quota_percent'] as num?)?.toDouble() ?? 0.0,
       chatQuotaAllowed: json['chat_quota_allowed'] as bool? ?? true,
       chatQuotaResetAt: (json['chat_quota_reset_at'] as num?)?.toInt(),
+      phoneCallQuota: json['phone_call_quota'] == null
+          ? null
+          : PhoneCallQuota.fromJson(
+              json['phone_call_quota'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$UserSubscriptionResponseToJson(
@@ -155,4 +186,5 @@ Map<String, dynamic> _$UserSubscriptionResponseToJson(
       'chat_quota_percent': instance.chatQuotaPercent,
       'chat_quota_allowed': instance.chatQuotaAllowed,
       'chat_quota_reset_at': instance.chatQuotaResetAt,
+      'phone_call_quota': instance.phoneCallQuota,
     };

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -35,7 +35,6 @@ import 'package:omi/pages/memories/page.dart';
 import 'package:omi/pages/phone_calls/active_call_banner.dart';
 import 'package:omi/pages/phone_calls/phone_calls_page.dart';
 import 'package:omi/pages/phone_calls/phone_calls_upsell_sheet.dart';
-import 'package:omi/models/subscription.dart';
 import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/pages/settings/daily_summary_detail_page.dart';
 import 'package:omi/pages/settings/data_privacy_page.dart';
@@ -681,7 +680,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                 },
                               ),
                               // Phone calls button - bottom left.
-                              if (home.selectedIndex == 0 && context.watch<UsageProvider>().showSubscriptionUI)
+                              if (home.selectedIndex == 0 && context.watch<UsageProvider>().shouldShowPhoneCallsEntry)
                                 Positioned(
                                   left: 20,
                                   bottom: 100,
@@ -693,10 +692,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                       if (usageProvider.subscription == null) {
                                         await usageProvider.fetchSubscription();
                                       }
-                                      final p = usageProvider.subscription?.subscription.plan;
-                                      var isUnlimited =
-                                          p == PlanType.unlimited || p == PlanType.operator || p == PlanType.architect;
-                                      if (!isUnlimited) {
+                                      if (!usageProvider.canAccessPhoneCalls) {
+                                        // Quota exhausted or feature disabled. Only surface the
+                                        // upsell when the paywall is allowed to appear; on
+                                        // hidden-paywall builds we silently swallow the tap.
+                                        if (!usageProvider.showSubscriptionUI) return;
                                         MixpanelManager().phoneCallUpsellShown(source: 'home');
                                         if (!context.mounted) return;
                                         showPhoneCallsUpsell(context);
@@ -838,8 +838,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurple.withValues(alpha: 0.2)
                               : hasPendingOnDevice
-                              ? Colors.orange.withValues(alpha: 0.15)
-                              : const Color(0xFF1F1F25),
+                                  ? Colors.orange.withValues(alpha: 0.15)
+                                  : const Color(0xFF1F1F25),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -848,8 +848,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurpleAccent
                               : hasPendingOnDevice
-                              ? Colors.orangeAccent
-                              : Colors.white70,
+                                  ? Colors.orangeAccent
+                                  : Colors.white70,
                         ),
                       ),
                     );

--- a/app/lib/pages/phone_calls/phone_calls_page.dart
+++ b/app/lib/pages/phone_calls/phone_calls_page.dart
@@ -9,6 +9,7 @@ import 'package:omi/backend/schema/phone_call.dart';
 import 'package:omi/pages/phone_calls/active_call_page.dart';
 import 'package:omi/pages/phone_calls/phone_setup_intro_page.dart';
 import 'package:omi/providers/phone_call_provider.dart';
+import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
@@ -174,7 +175,14 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
           ],
         ),
       ),
-      body: TabBarView(controller: _tabController, children: [_buildContactsTab(), _buildKeypadTab()]),
+      body: Column(
+        children: [
+          const _FreeQuotaBanner(),
+          Expanded(
+            child: TabBarView(controller: _tabController, children: [_buildContactsTab(), _buildKeypadTab()]),
+          ),
+        ],
+      ),
     );
   }
 
@@ -460,6 +468,44 @@ class _ContactRow extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _FreeQuotaBanner extends StatelessWidget {
+  const _FreeQuotaBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<UsageProvider>(
+      builder: (context, usage, _) {
+        final quota = usage.phoneCallQuota;
+        if (quota == null || quota.isPaid) return const SizedBox.shrink();
+        final limit = quota.monthlyLimit;
+        if (limit == null || limit <= 0) return const SizedBox.shrink();
+        final remaining = quota.remaining ?? (limit - quota.monthlyUsed);
+        final maxMinutes = (quota.maxDurationSeconds ?? 0) ~/ 60;
+        final durationSuffix = maxMinutes > 0 ? ' · up to $maxMinutes min each' : '';
+        return Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          color: const Color(0xFF1F1F25),
+          child: Row(
+            children: [
+              Icon(Icons.info_outline, size: 16, color: Colors.grey[500]),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  remaining > 0
+                      ? '$remaining of $limit free calls remaining this month$durationSuffix'
+                      : 'Monthly free call limit reached — resets next month',
+                  style: TextStyle(color: Colors.grey[300], fontSize: 12),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -338,9 +338,8 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                   title: context.l10n.offlineSync,
                   icon: const FaIcon(FontAwesomeIcons.solidCloud, color: Color(0xFF8E8E93), size: 20),
                   onTap: () {
-                    final page = SharedPreferencesUtil().deviceSupportsMultiFileSync
-                        ? const AutoSyncPage()
-                        : const SyncPage();
+                    final page =
+                        SharedPreferencesUtil().deviceSupportsMultiFileSync ? const AutoSyncPage() : const SyncPage();
                     Navigator.of(context).push(MaterialPageRoute(builder: (context) => page));
                   },
                 ),
@@ -374,10 +373,7 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                 ),
                 Consumer<UsageProvider>(
                   builder: (context, usageProvider, child) {
-                    final sp2 = usageProvider.subscription?.subscription.plan;
-                    final isUnlimited =
-                        sp2 == PlanType.unlimited || sp2 == PlanType.operator || sp2 == PlanType.architect;
-                    if (!isUnlimited) return const SizedBox.shrink();
+                    if (!usageProvider.shouldShowPhoneCallsEntry) return const SizedBox.shrink();
                     return Column(
                       children: [
                         const Divider(height: 1, color: Color(0xFF3C3C43)),

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -54,6 +54,34 @@ class UsageProvider with ChangeNotifier {
   double get chatQuotaPercent => _subscription?.chatQuotaPercent ?? 0.0;
   bool get chatQuotaAllowed => _subscription?.chatQuotaAllowed ?? true;
 
+  // Phone call feature — derived from subscription response. Only consult
+  // the server-driven quota when the user is on the free tier or the
+  // subscription UI is hidden; paid users with the paywall visible skip
+  // straight to the existing unlimited behavior.
+  PhoneCallQuota? get phoneCallQuota => _subscription?.phoneCallQuota;
+
+  bool get _isPaidPlan {
+    final plan = _subscription?.subscription.plan;
+    return plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.architect;
+  }
+
+  bool get canAccessPhoneCalls {
+    if (_isPaidPlan) return true;
+    final quota = phoneCallQuota;
+    if (quota == null) return false;
+    return quota.hasAccess;
+  }
+
+  bool get shouldShowPhoneCallsEntry {
+    if (_isPaidPlan) return true;
+    final quota = phoneCallQuota;
+    final freeTierEnabled = quota != null && (quota.monthlyLimit ?? 0) > 0;
+    if (freeTierEnabled) return true;
+    // Free tier disabled → only surface the entry for real users who can still
+    // see the paywall. Hidden-paywall builds (App Review) keep it off-screen.
+    return showSubscriptionUI;
+  }
+
   // Payment-related state
   Map<String, dynamic>? _availablePlans;
   Map<String, dynamic>? get availablePlans => _availablePlans;

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.533+827
+version: 1.0.533+828
 
 
 environment:

--- a/backend/database/phone_call_config.py
+++ b/backend/database/phone_call_config.py
@@ -51,11 +51,18 @@ def _get_config() -> dict:
 
 
 def _merge_defaults(override: Optional[dict], defaults: dict) -> dict:
+    """Overlay a Firestore override onto the hardcoded defaults.
+
+    An explicit ``None`` in the override is preserved (so ops can set
+    ``max_duration_seconds: null`` in Firestore to clear the default cap).
+    Only keys known to ``defaults`` are honored — unknown override keys are
+    ignored so a typo in Firestore can't silently change behavior.
+    """
     merged = dict(defaults)
     if isinstance(override, dict):
-        for k, v in override.items():
-            if v is not None:
-                merged[k] = v
+        for k in defaults.keys():
+            if k in override:
+                merged[k] = override[k]
     return merged
 
 

--- a/backend/database/phone_call_config.py
+++ b/backend/database/phone_call_config.py
@@ -1,0 +1,71 @@
+"""
+Server-driven config for phone-call free-tier quotas.
+
+Stored in Firestore so limits can be tuned without a redeploy:
+
+  Collection: phone_call_config
+  Document ID: default
+  Fields:
+    free_plan: {
+      monthly_call_limit: int,        # 0 = feature disabled for free users
+      max_duration_seconds: int,      # per-call ceiling (None/0 = no cap)
+      allowed_countries: list[str],   # ISO-2 codes; empty/missing = no restriction
+    }
+    paid_plan: {                      # optional; defaults to unlimited if missing
+      monthly_call_limit: int | None,
+      max_duration_seconds: int | None,
+      allowed_countries: list[str],
+    }
+
+Setting `free_plan.monthly_call_limit` to 0 makes the feature behave as
+paid-only (same as before this config existed).
+"""
+
+from typing import Optional
+
+from database._client import db
+from database.cache import get_memory_cache
+
+_CACHE_KEY = "phone_call_config:default"
+_CACHE_TTL_SECONDS = 60  # short so flag flips propagate within a minute
+
+_DEFAULT_FREE_PLAN = {
+    "monthly_call_limit": 0,
+    "max_duration_seconds": 300,
+    "allowed_countries": [],
+}
+_DEFAULT_PAID_PLAN = {
+    "monthly_call_limit": None,
+    "max_duration_seconds": None,
+    "allowed_countries": [],
+}
+
+
+def _fetch_config() -> dict:
+    doc = db.collection("phone_call_config").document("default").get()
+    return doc.to_dict() if doc.exists else {}
+
+
+def _get_config() -> dict:
+    return get_memory_cache().get_or_fetch(_CACHE_KEY, _fetch_config, ttl=_CACHE_TTL_SECONDS) or {}
+
+
+def _merge_defaults(override: Optional[dict], defaults: dict) -> dict:
+    merged = dict(defaults)
+    if isinstance(override, dict):
+        for k, v in override.items():
+            if v is not None:
+                merged[k] = v
+    return merged
+
+
+def get_free_plan_config() -> dict:
+    return _merge_defaults(_get_config().get("free_plan"), _DEFAULT_FREE_PLAN)
+
+
+def get_paid_plan_config() -> dict:
+    return _merge_defaults(_get_config().get("paid_plan"), _DEFAULT_PAID_PLAN)
+
+
+def get_config_for_plan(is_paid: bool) -> dict:
+    return get_paid_plan_config() if is_paid else get_free_plan_config()

--- a/backend/database/phone_call_usage.py
+++ b/backend/database/phone_call_usage.py
@@ -1,0 +1,62 @@
+"""
+Phone call usage counters for free-tier quota enforcement.
+
+Counters live in Redis (fail-open, auto-expiring) rather than Firestore because
+the free-tier quota exists only to limit App-Review bypass and abuse; we never
+need historical usage data. Keys roll over at month boundaries:
+
+  Key:    phone_call_usage:{uid}:{YYYY-MM}
+  Value:  integer call count (INCR)
+  TTL:    ~40 days so the previous month expires naturally after rollover
+
+If Redis is unavailable the read returns 0 (allow) and the increment silently
+skips — same fail-open posture as the rest of ``database/redis_db.py``.
+"""
+
+from datetime import datetime, timezone
+from typing import Tuple
+
+from database.redis_db import r, try_catch_decorator
+
+_TTL_SECONDS = 40 * 24 * 3600  # 40 days — comfortably past any month rollover
+
+
+def _period_id(now: datetime) -> str:
+    return f"{now.year}-{now.month:02d}"
+
+
+def _period_reset_epoch(now: datetime) -> int:
+    """Epoch seconds at which the current monthly bucket rolls over."""
+    if now.month == 12:
+        next_month = datetime(now.year + 1, 1, 1, tzinfo=timezone.utc)
+    else:
+        next_month = datetime(now.year, now.month + 1, 1, tzinfo=timezone.utc)
+    return int(next_month.timestamp())
+
+
+def _key(uid: str, period_id: str) -> str:
+    return f"phone_call_usage:{uid}:{period_id}"
+
+
+@try_catch_decorator
+def _read_count(uid: str, period_id: str) -> int:
+    raw = r.get(_key(uid, period_id))
+    return int(raw) if raw else 0
+
+
+def get_current_month_count(uid: str) -> Tuple[int, int]:
+    """Return (calls_initiated, reset_at_epoch) for the current monthly bucket."""
+    now = datetime.now(timezone.utc)
+    count = _read_count(uid, _period_id(now)) or 0
+    return count, _period_reset_epoch(now)
+
+
+@try_catch_decorator
+def increment_current_month(uid: str) -> None:
+    """Atomically bump the current month's call counter by 1."""
+    now = datetime.now(timezone.utc)
+    key = _key(uid, _period_id(now))
+    pipe = r.pipeline()
+    pipe.incr(key, 1)
+    pipe.expire(key, _TTL_SECONDS)
+    pipe.execute()

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -89,6 +89,19 @@ class SubscriptionPlan(BaseModel):
     legacy: bool = False
 
 
+class PhoneCallQuota(BaseModel):
+    """Phone call feature access + remaining-quota snapshot for the client."""
+
+    has_access: bool
+    is_paid: bool
+    monthly_limit: Optional[int] = None  # None = unlimited (paid), 0 = disabled
+    monthly_used: int = 0
+    remaining: Optional[int] = None  # None = unlimited
+    max_duration_seconds: Optional[int] = None
+    allowed_countries: List[str] = []
+    reset_at: Optional[int] = None  # unix seconds — start of next month UTC
+
+
 class UserSubscriptionResponse(BaseModel):
     subscription: Subscription
     transcription_seconds_used: int
@@ -107,3 +120,6 @@ class UserSubscriptionResponse(BaseModel):
     chat_quota_percent: float = 0.0
     chat_quota_allowed: bool = True
     chat_quota_reset_at: Optional[int] = None
+    # Phone call feature access snapshot — null means the client hasn't been
+    # given a quota read (older servers or disabled endpoints).
+    phone_call_quota: Optional[PhoneCallQuota] = None

--- a/backend/routers/phone_calls.py
+++ b/backend/routers/phone_calls.py
@@ -12,8 +12,8 @@ from twilio.base.exceptions import TwilioRestException
 from twilio.twiml.voice_response import VoiceResponse, Dial
 
 import database.phone_calls as phone_calls_db
-import database.users as users_db
-from utils.subscription import is_paid_plan
+import database.phone_call_usage as phone_call_usage_db
+from utils.phone_calls import check_call_access, check_destination_allowed, get_quota_snapshot
 from utils.other import endpoints as auth
 from utils.other.endpoints import rate_limit_dependency
 from utils.twilio_service import (
@@ -33,13 +33,6 @@ def _redact_phone(number: str) -> str:
     if len(number) > 4:
         return number[:2] + '***' + number[-4:]
     return '***'
-
-
-def _require_unlimited_plan(uid: str):
-    """Raise 403 if the user is not on a paid plan."""
-    subscription = users_db.get_user_valid_subscription(uid)
-    if not subscription or not is_paid_plan(subscription.plan):
-        raise HTTPException(status_code=403, detail="Phone calls require a paid subscription")
 
 
 router = APIRouter()
@@ -95,7 +88,7 @@ def verify_phone_number(
     _: None = Depends(rate_limit_dependency(endpoint="phone_verify", requests_per_window=5, window_seconds=3600)),
 ):
     """Initiate phone number verification via Twilio caller ID validation."""
-    _require_unlimited_plan(uid)
+    check_call_access(uid)
     phone_number = request.phone_number.strip()
     if not E164_PATTERN.match(phone_number):
         raise HTTPException(status_code=400, detail="Phone number must be in E.164 format (e.g., +15551234567)")
@@ -142,7 +135,7 @@ def check_phone_verification(
     ),
 ):
     """Check if a phone number has been verified. Poll this endpoint every 2s (60s timeout)."""
-    _require_unlimited_plan(uid)
+    check_call_access(uid)
     phone_number = request.phone_number.strip()
 
     # Check if already stored locally (avoid duplicates from repeated polling)
@@ -181,7 +174,7 @@ def check_phone_verification(
 @router.get("/v1/phone/numbers", tags=['phone-calls'])
 def list_phone_numbers(uid: str = Depends(auth.get_current_user_uid)):
     """List all verified phone numbers for the user."""
-    _require_unlimited_plan(uid)
+    check_call_access(uid)
     numbers = phone_calls_db.get_phone_numbers(uid)
     return {'numbers': numbers}
 
@@ -189,7 +182,7 @@ def list_phone_numbers(uid: str = Depends(auth.get_current_user_uid)):
 @router.delete("/v1/phone/numbers/{phone_number_id}", tags=['phone-calls'])
 def remove_phone_number(phone_number_id: str, uid: str = Depends(auth.get_current_user_uid)):
     """Remove a verified phone number."""
-    _require_unlimited_plan(uid)
+    check_call_access(uid)
     phone_number = phone_calls_db.get_phone_number(uid, phone_number_id)
     if not phone_number:
         raise HTTPException(status_code=404, detail="Phone number not found")
@@ -211,7 +204,7 @@ def remove_phone_number(phone_number_id: str, uid: str = Depends(auth.get_curren
 @router.post("/v1/phone/token", response_model=TokenResponse, tags=['phone-calls'])
 def get_phone_token(uid: str = Depends(auth.get_current_user_uid)):
     """Generate a Twilio access token for making VoIP calls."""
-    _require_unlimited_plan(uid)
+    check_call_access(uid)
     # Verify user has at least one verified number
     primary = phone_calls_db.get_primary_phone_number(uid)
     if not primary:
@@ -288,6 +281,19 @@ async def twiml_voice_webhook(request: Request):
         response.say('Invalid destination number format. Goodbye.')
         return Response(content=str(response), media_type='text/xml')
 
+    # Final quota + destination check before placing the call. Free-tier users
+    # on exhausted monthly buckets or disallowed destinations are turned away
+    # here so Twilio never actually dials; we then refuse to count the attempt.
+    snapshot = get_quota_snapshot(uid)
+    if not snapshot.has_access:
+        response.say('Monthly phone call limit reached. Goodbye.')
+        return Response(content=str(response), media_type='text/xml')
+    try:
+        check_destination_allowed(snapshot, to_number)
+    except HTTPException:
+        response.say('This destination is not available on your plan. Goodbye.')
+        return Response(content=str(response), media_type='text/xml')
+
     # Verify the number is still a valid outgoing caller ID in Twilio
     is_verified = check_caller_id_verified(caller_number)
     print(
@@ -299,7 +305,19 @@ async def twiml_voice_webhook(request: Request):
         response.say('Your caller ID is not verified. Please re-verify your phone number.')
         return Response(content=str(response), media_type='text/xml')
 
-    dial = Dial(caller_id=caller_number)
+    # Count the call against the free-tier bucket before handing Twilio the
+    # dial instructions. We increment only after all guards pass so rejected
+    # attempts don't eat the user's quota.
+    try:
+        if not snapshot.is_paid:
+            phone_call_usage_db.increment_current_month(uid)
+    except Exception:
+        traceback.print_exc()
+
+    dial_kwargs = {'caller_id': caller_number}
+    if snapshot.max_duration_seconds and snapshot.max_duration_seconds > 0:
+        dial_kwargs['time_limit'] = int(snapshot.max_duration_seconds)
+    dial = Dial(**dial_kwargs)
     dial.number(to_number)
     response.append(dial)
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -60,7 +60,9 @@ from models.users import (
     SubscriptionStatus,
     PlanType,
     PricingOption,
+    PhoneCallQuota,
 )
+from utils.phone_calls import get_quota_snapshot as get_phone_call_quota_snapshot
 from utils.apps import get_available_app_by_id
 from utils.subscription import (
     get_chat_quota_snapshot,
@@ -832,6 +834,10 @@ def get_user_subscription_endpoint(
     # BYOK free plan: user supplies their own OpenAI/Anthropic/Gemini/Deepgram keys.
     # Only return unlimited when the request actually carries BYOK headers (desktop).
     # Mobile (no BYOK headers) should see the real subscription even if BYOK is active.
+    # Synthetic paid-tier quota for BYOK / marketplace-reviewer overrides so
+    # these users aren't surprised by a disabled phone-call feature.
+    unlimited_phone_quota = PhoneCallQuota(has_access=True, is_paid=True)
+
     if users_db.is_byok_active(uid) and has_byok_keys():
         return UserSubscriptionResponse(
             subscription=_byok_unlimited_subscription(),
@@ -845,6 +851,7 @@ def get_user_subscription_endpoint(
             memories_created_limit=0,
             available_plans=[],
             show_subscription_ui=False,
+            phone_call_quota=unlimited_phone_quota,
         )
 
     marketplace_reviewers = os.getenv('MARKETPLACE_APP_REVIEWERS', '').split(',')
@@ -871,6 +878,7 @@ def get_user_subscription_endpoint(
             memories_created_limit=0,
             available_plans=[],
             show_subscription_ui=False,
+            phone_call_quota=unlimited_phone_quota,
         )
     # First, reconcile any "basic but actually unlimited" inconsistencies against Stripe once.
     raw_subscription = get_user_subscription(uid)
@@ -996,6 +1004,9 @@ def get_user_subscription_endpoint(
 
     show_subscription_ui = not should_hide_subscription_ui(uid, x_app_platform, x_app_version)
 
+    # Phone-call feature access + monthly free-tier usage snapshot.
+    phone_call_quota = PhoneCallQuota(**get_phone_call_quota_snapshot(uid).to_client_dict())
+
     # Chat quota — reuse the shared snapshot helper
     chat_snapshot = get_chat_quota_snapshot(uid)
     chat_percent = 0.0
@@ -1020,6 +1031,7 @@ def get_user_subscription_endpoint(
         chat_quota_percent=chat_percent,
         chat_quota_allowed=chat_allowed,
         chat_quota_reset_at=chat_snapshot['reset_at'],
+        phone_call_quota=phone_call_quota,
     )
 
 

--- a/backend/utils/phone_calls.py
+++ b/backend/utils/phone_calls.py
@@ -1,0 +1,175 @@
+"""
+Phone call quota resolution + gate.
+
+Paid-plan users always pass. Free-plan users are metered against
+``phone_call_config``'s ``free_plan`` block and their monthly usage counter
+in ``phone_call_usage``.
+
+Setting ``free_plan.monthly_call_limit`` to 0 makes the feature paid-only
+again (same behavior as before this module existed); the quota snapshot
+returned to the client in that case reports ``has_access = False``.
+"""
+
+from typing import Optional
+
+from fastapi import HTTPException
+
+import database.phone_call_usage as phone_call_usage_db
+import database.users as users_db
+from database.phone_call_config import get_config_for_plan
+from utils.subscription import is_paid_plan
+
+# Minimal E.164 prefix → ISO-2 mapping. Intentionally covers the cheap/common
+# destinations; anything not on the list falls through to
+# ``None`` and is treated as "unknown country" — the allowlist check then
+# rejects it (fail-safe against toll-fraud on high-cost international routes).
+_E164_PREFIX_TO_ISO2 = [
+    ('+1', 'US'),  # US + CA share +1; Twilio bills similarly
+    ('+44', 'GB'),
+    ('+61', 'AU'),
+    ('+64', 'NZ'),
+    ('+33', 'FR'),
+    ('+49', 'DE'),
+    ('+34', 'ES'),
+    ('+39', 'IT'),
+    ('+31', 'NL'),
+    ('+46', 'SE'),
+    ('+47', 'NO'),
+    ('+45', 'DK'),
+    ('+358', 'FI'),
+    ('+353', 'IE'),
+    ('+41', 'CH'),
+    ('+43', 'AT'),
+    ('+32', 'BE'),
+    ('+351', 'PT'),
+    ('+81', 'JP'),
+    ('+82', 'KR'),
+]
+
+
+def country_from_e164(number: str) -> Optional[str]:
+    """Best-effort ISO-2 lookup from an E.164 number. Returns None if unknown."""
+    if not number or not number.startswith('+'):
+        return None
+    for prefix, iso in _E164_PREFIX_TO_ISO2:
+        if number.startswith(prefix):
+            return iso
+    return None
+
+
+class QuotaSnapshot:
+    __slots__ = (
+        'plan',
+        'is_paid',
+        'monthly_limit',
+        'monthly_used',
+        'max_duration_seconds',
+        'allowed_countries',
+        'reset_at',
+    )
+
+    def __init__(
+        self,
+        plan,
+        is_paid: bool,
+        monthly_limit: Optional[int],
+        monthly_used: int,
+        max_duration_seconds: Optional[int],
+        allowed_countries: list,
+        reset_at: int,
+    ):
+        self.plan = plan
+        self.is_paid = is_paid
+        self.monthly_limit = monthly_limit
+        self.monthly_used = monthly_used
+        self.max_duration_seconds = max_duration_seconds
+        self.allowed_countries = allowed_countries or []
+        self.reset_at = reset_at
+
+    @property
+    def has_access(self) -> bool:
+        """True iff the user can currently place a call under this plan."""
+        if self.is_paid:
+            return True
+        if self.monthly_limit is None:
+            return True
+        if self.monthly_limit <= 0:
+            return False
+        return self.monthly_used < self.monthly_limit
+
+    @property
+    def remaining(self) -> Optional[int]:
+        if self.is_paid or self.monthly_limit is None:
+            return None
+        return max(0, self.monthly_limit - self.monthly_used)
+
+    def to_client_dict(self) -> dict:
+        return {
+            'has_access': self.has_access,
+            'is_paid': self.is_paid,
+            'monthly_limit': self.monthly_limit,
+            'monthly_used': self.monthly_used,
+            'remaining': self.remaining,
+            'max_duration_seconds': self.max_duration_seconds,
+            'allowed_countries': self.allowed_countries,
+            'reset_at': self.reset_at,
+        }
+
+
+def get_quota_snapshot(uid: str) -> QuotaSnapshot:
+    """Resolve the user's plan + config + current usage into a snapshot."""
+    subscription = users_db.get_user_valid_subscription(uid)
+    plan = subscription.plan if subscription else None
+    paid = bool(subscription and is_paid_plan(subscription.plan))
+    config = get_config_for_plan(paid)
+    used, reset_at = phone_call_usage_db.get_current_month_count(uid)
+    return QuotaSnapshot(
+        plan=plan,
+        is_paid=paid,
+        monthly_limit=config.get('monthly_call_limit'),
+        monthly_used=used,
+        max_duration_seconds=config.get('max_duration_seconds'),
+        allowed_countries=config.get('allowed_countries') or [],
+        reset_at=reset_at,
+    )
+
+
+def check_call_access(uid: str) -> QuotaSnapshot:
+    """Raise 402/403 if the user cannot access the phone call feature.
+
+    Returns the snapshot so callers can reuse it (e.g. for max-duration
+    enforcement on the TwiML response).
+    """
+    snapshot = get_quota_snapshot(uid)
+    if snapshot.has_access:
+        return snapshot
+
+    if not snapshot.is_paid and (snapshot.monthly_limit or 0) <= 0:
+        # Feature disabled for the free tier.
+        raise HTTPException(status_code=403, detail="Phone calls require a paid subscription")
+    # Free tier enabled but quota exhausted.
+    raise HTTPException(
+        status_code=402,
+        detail={
+            'error': 'phone_call_quota_exceeded',
+            'monthly_limit': snapshot.monthly_limit,
+            'monthly_used': snapshot.monthly_used,
+            'reset_at': snapshot.reset_at,
+        },
+    )
+
+
+def check_destination_allowed(snapshot: QuotaSnapshot, to_number: str) -> None:
+    """Reject destinations outside the allowlist. No-op if allowlist is empty
+    or the caller is on a paid plan."""
+    if snapshot.is_paid:
+        return
+    allowed = snapshot.allowed_countries
+    if not allowed:
+        return
+    iso = country_from_e164(to_number)
+    if iso is None or iso not in allowed:
+        raise HTTPException(
+            status_code=403,
+            detail="This destination is not available on the free plan",
+        )

--- a/backend/utils/phone_calls.py
+++ b/backend/utils/phone_calls.py
@@ -10,7 +10,7 @@ again (same behavior as before this module existed); the quota snapshot
 returned to the client in that case reports ``has_access = False``.
 """
 
-from typing import Optional
+from typing import FrozenSet, Optional
 
 from fastapi import HTTPException
 
@@ -20,41 +20,67 @@ from database.phone_call_config import get_config_for_plan
 from utils.subscription import is_paid_plan
 
 # Minimal E.164 prefix → ISO-2 mapping. Intentionally covers the cheap/common
-# destinations; anything not on the list falls through to
-# ``None`` and is treated as "unknown country" — the allowlist check then
-# rejects it (fail-safe against toll-fraud on high-cost international routes).
-_E164_PREFIX_TO_ISO2 = [
-    ('+1', 'US'),  # US + CA share +1; Twilio bills similarly
-    ('+44', 'GB'),
-    ('+61', 'AU'),
-    ('+64', 'NZ'),
-    ('+33', 'FR'),
-    ('+49', 'DE'),
-    ('+34', 'ES'),
-    ('+39', 'IT'),
-    ('+31', 'NL'),
-    ('+46', 'SE'),
-    ('+47', 'NO'),
-    ('+45', 'DK'),
-    ('+358', 'FI'),
-    ('+353', 'IE'),
-    ('+41', 'CH'),
-    ('+43', 'AT'),
-    ('+32', 'BE'),
-    ('+351', 'PT'),
-    ('+81', 'JP'),
-    ('+82', 'KR'),
+# destinations; anything not on the list falls through to an empty match and
+# is treated as "unknown country" — the allowlist check then rejects it
+# (fail-safe against toll-fraud on high-cost international routes).
+#
+# A prefix maps to one-or-more ISO codes because the NANP pool (+1) is shared
+# by US and Canada (plus other territories we intentionally don't allowlist).
+# Without a proper libphonenumber parse we can't distinguish US from CA by
+# area code here, so the allowlist check treats +1 as matching if *either*
+# code is allowed. Ops who want to separate US and CA should run the check
+# outside this module.
+_E164_PREFIX_TO_ISO2: list[tuple[str, FrozenSet[str]]] = [
+    ('+1', frozenset({'US', 'CA'})),  # NANP: US and CA share +1
+    ('+44', frozenset({'GB'})),
+    ('+61', frozenset({'AU'})),
+    ('+64', frozenset({'NZ'})),
+    ('+33', frozenset({'FR'})),
+    ('+49', frozenset({'DE'})),
+    ('+34', frozenset({'ES'})),
+    ('+39', frozenset({'IT'})),
+    ('+31', frozenset({'NL'})),
+    ('+46', frozenset({'SE'})),
+    ('+47', frozenset({'NO'})),
+    ('+45', frozenset({'DK'})),
+    ('+358', frozenset({'FI'})),
+    ('+353', frozenset({'IE'})),
+    ('+41', frozenset({'CH'})),
+    ('+43', frozenset({'AT'})),
+    ('+32', frozenset({'BE'})),
+    ('+351', frozenset({'PT'})),
+    ('+81', frozenset({'JP'})),
+    ('+82', frozenset({'KR'})),
 ]
 
 
-def country_from_e164(number: str) -> Optional[str]:
-    """Best-effort ISO-2 lookup from an E.164 number. Returns None if unknown."""
+def countries_from_e164(number: str) -> FrozenSet[str]:
+    """Best-effort ISO-2 lookup from an E.164 number.
+
+    Returns the set of ISO-2 codes that share the matched dial prefix. The
+    number passes an allowlist check if any element of that set is allowed.
+    Empty set means "unknown" — fail-safe, always blocked when an allowlist
+    is configured.
+    """
     if not number or not number.startswith('+'):
-        return None
-    for prefix, iso in _E164_PREFIX_TO_ISO2:
+        return frozenset()
+    for prefix, iso_codes in _E164_PREFIX_TO_ISO2:
         if number.startswith(prefix):
-            return iso
-    return None
+            return iso_codes
+    return frozenset()
+
+
+def country_from_e164(number: str) -> Optional[str]:
+    """Back-compat: return a representative ISO-2 for ``number`` if known.
+
+    Prefer ``countries_from_e164`` when checking allowlists — it returns the
+    full set so shared dial prefixes (notably +1 for US + CA) don't silently
+    pick one country over another.
+    """
+    matches = countries_from_e164(number)
+    if not matches:
+        return None
+    return next(iter(matches))
 
 
 class QuotaSnapshot:
@@ -167,8 +193,9 @@ def check_destination_allowed(snapshot: QuotaSnapshot, to_number: str) -> None:
     allowed = snapshot.allowed_countries
     if not allowed:
         return
-    iso = country_from_e164(to_number)
-    if iso is None or iso not in allowed:
+    allowed_set = {c.upper() for c in allowed}
+    matches = countries_from_e164(to_number)
+    if not matches or matches.isdisjoint(allowed_set):
         raise HTTPException(
             status_code=403,
             detail="This destination is not available on the free plan",


### PR DESCRIPTION
## Summary

- Adds an optional free-tier quota for the VoIP phone-call feature so free users can try it within a server-configured monthly limit (previously paid-only).
- Ships a Firestore-driven config (`phone_call_config/default`) so ops can tune the free call limit, per-call duration cap, and destination country allowlist without a redeploy. Default ships with `monthly_call_limit: 0` — current paid-only behavior is preserved until the flag is raised.
- Tracks monthly usage in Redis (fail-open, 40-day TTL) — no persistent per-user data for this feature.

## Behavior

**Entry visibility (home phone button + settings row):**
- Paid user → always shown
- Free user with `monthly_call_limit > 0` → shown with remaining-calls badge
- Free user with `monthly_call_limit == 0` → shown only when `show_subscription_ui` is true (preserves existing upsell path)

**On tap:**
- Paid → open Phone Calls page
- Free with quota remaining → open Phone Calls page
- Free with quota exhausted → existing upsell sheet fires when paywall UI is enabled

**Server-side guards:**
- All `/v1/phone/*` endpoints route through `check_call_access(uid)` — 403 when free tier disabled, 402 when quota exhausted
- TwiML webhook re-checks quota + destination, increments the Redis counter only after all guards pass, and passes `max_duration_seconds` into `<Dial time_limit=...>` so Twilio hangs up at the cap
- Small E.164→ISO-2 prefix map fails safe on unknown prefixes so high-cost international routes can be blocked by default when an allowlist is configured

## Configuration

Firestore `phone_call_config/default`:

```yaml
free_plan:
  monthly_call_limit: 3
  max_duration_seconds: 300
  allowed_countries: ["US", "CA", "GB"]  # optional; [] = no restriction
```

Set `monthly_call_limit: 0` at any time to restore paid-only gating with no deploy.

## Test plan

- [ ] Backend: `bash test-preflight.sh && bash test.sh`
- [ ] Backend: with `monthly_call_limit: 0`, confirm `/v1/phone/token` returns 403 for free user (existing behavior preserved)
- [ ] Backend: with `monthly_call_limit: 3`, free user can hit the token endpoint 3× per month; 4th returns 402
- [ ] Backend: TwiML `<Dial>` carries `timeLimit=300` for free user; absent for paid
- [ ] Backend: call to non-allowlisted country returns 403 for free user when allowlist is set
- [ ] App: free user with quota > 0 sees Phone Calls row + banner shows remaining count
- [ ] App: free user after quota exhaustion with `show_subscription_ui=true` → upsell fires
- [ ] App: free user with `monthly_call_limit=0` and `show_subscription_ui=false` → entry is hidden, no upsell ever shown
- [ ] App: paid user sees Phone Calls row with no banner
- [ ] iOS: place a real Twilio call; CallKit UI shows; call ends at the configured duration cap for free user

🤖 Generated with [Claude Code](https://claude.com/claude-code)