### PR TITLE
Add charging status indicator to mobile app

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "اسحب للتحديث",
     "copiedToClipboard": "تم نسخ {title} إلى الحافظة",
     "batteryLevel": "مستوى البطارية",
+    "charging": "شحن",
     "productUpdate": "تحديث المنتج",
     "offline": "غير متصل",
     "available": "متاح",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "Узровень батарэі",
+    "charging": "Зарадка",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Плъзнете за актуализация",
     "copiedToClipboard": "{title} копирано в клипборда",
     "batteryLevel": "Ниво на батерията",
+    "charging": "Зареждане",
     "productUpdate": "Актуализация на продукта",
     "offline": "Офлайн",
     "available": "Наличен",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "ব্যাটারি স্তর",
+    "charging": "চার্জ হচ্ছে",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "Nivo baterije",
+    "charging": "Punjenje",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Llisca per actualitzar",
     "copiedToClipboard": "{title} copiat al portapapers",
     "batteryLevel": "Nivell de bateria",
+    "charging": "Carregant",
     "productUpdate": "Actualització del producte",
     "offline": "Fora de línia",
     "available": "Disponible",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Přejeďte pro aktualizaci",
     "copiedToClipboard": "{title} zkopírováno do schránky",
     "batteryLevel": "Stav baterie",
+    "charging": "Nabíjení",
     "productUpdate": "Aktualizace produktu",
     "offline": "Offline",
     "available": "K dispozici",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Glid for at opdatere",
     "copiedToClipboard": "{title} kopieret til udklipsholder",
     "batteryLevel": "Batteriniveau",
+    "charging": "Oplader",
     "productUpdate": "Produktopdatering",
     "offline": "Offline",
     "available": "Tilgængelig",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -733,6 +733,7 @@
     "slideToUpdate": "Zum Aktualisieren wischen",
     "copiedToClipboard": "{title} in Zwischenablage kopiert",
     "batteryLevel": "Batteriestand",
+    "charging": "Wird geladen",
     "productUpdate": "Produktaktualisierung",
     "offline": "Offline",
     "available": "Verfügbar",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Σύρετε για ενημέρωση",
     "copiedToClipboard": "{title} αντιγράφηκε στο πρόχειρο",
     "batteryLevel": "Επίπεδο μπαταρίας",
+    "charging": "Φόρτιση",
     "productUpdate": "Ενημέρωση προϊόντος",
     "offline": "Εκτός σύνδεσης",
     "available": "Διαθέσιμο",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -2515,6 +2515,7 @@
     "@batteryLevel": {
         "description": "Battery level label"
     },
+    "charging": "Charging",
     "productUpdate": "Product Update",
     "@productUpdate": {
         "description": "Menu item for product/firmware update"

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -733,6 +733,7 @@
     "slideToUpdate": "Desliza para actualizar",
     "copiedToClipboard": "{title} copiado al portapapeles",
     "batteryLevel": "Nivel de batería",
+    "charging": "Cargando",
     "productUpdate": "Actualización del producto",
     "offline": "Sin conexión",
     "available": "Disponible",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Värskendamiseks libistage",
     "copiedToClipboard": "{title} kopeeritud lõikelauale",
     "batteryLevel": "Aku tase",
+    "charging": "Laadimine",
     "productUpdate": "Toote värskendus",
     "offline": "Ühenduseta",
     "available": "Saadaval",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "سطح باتری",
+    "charging": "در حال شارژ",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Liu'uta päivittääksesi",
     "copiedToClipboard": "{title} kopioitu leikepöydälle",
     "batteryLevel": "Akun taso",
+    "charging": "Lataa",
     "productUpdate": "Tuotepäivitys",
     "offline": "Offline-tilassa",
     "available": "Saatavilla",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Glisser pour mettre à jour",
     "copiedToClipboard": "{title} copié dans le presse-papiers",
     "batteryLevel": "Niveau de batterie",
+    "charging": "En charge",
     "productUpdate": "Mise à jour du produit",
     "offline": "Hors ligne",
     "available": "Disponible",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "רמת הסוללה",
+    "charging": "טוען",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -733,6 +733,7 @@
     "slideToUpdate": "अपडेट के लिए स्लाइड करें",
     "copiedToClipboard": "{title} क्लिपबोर्ड में कॉपी किया गया",
     "batteryLevel": "बैटरी स्तर",
+    "charging": "चार्ज हो रहा है",
     "productUpdate": "उत्पाद अपडेट",
     "offline": "ऑफ़लाइन",
     "available": "उपलब्ध",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "Razina baterije",
+    "charging": "Punjenje",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Csúsztassa a frissítéshez",
     "copiedToClipboard": "{title} a vágólapra másolva",
     "batteryLevel": "Akkumulátor szint",
+    "charging": "Töltés",
     "productUpdate": "Termékfrissítés",
     "offline": "Offline",
     "available": "Elérhető",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Geser untuk memperbarui",
     "copiedToClipboard": "{title} disalin ke papan klip",
     "batteryLevel": "Level Baterai",
+    "charging": "Mengisi daya",
     "productUpdate": "Pembaruan Produk",
     "offline": "Luring",
     "available": "Tersedia",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Scorri per aggiornare",
     "copiedToClipboard": "{title} copiato negli appunti",
     "batteryLevel": "Livello batteria",
+    "charging": "In carica",
     "productUpdate": "Aggiornamento prodotto",
     "offline": "Non in linea",
     "available": "Disponibile",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -733,6 +733,7 @@
     "slideToUpdate": "スライドして更新",
     "copiedToClipboard": "{title}をクリップボードにコピーしました",
     "batteryLevel": "バッテリー残量",
+    "charging": "充電中",
     "productUpdate": "製品アップデート",
     "offline": "オフライン",
     "available": "利用可能",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "ಬ್ಯಾಟರಿ ಸ್ತರ",
+    "charging": "ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "업데이트하려면 밀기",
     "copiedToClipboard": "{title}이(가) 클립보드에 복사되었습니다",
     "batteryLevel": "배터리 수준",
+    "charging": "충전 중",
     "productUpdate": "제품 업데이트",
     "offline": "오프라인",
     "available": "사용 가능",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -4581,6 +4581,12 @@ abstract class AppLocalizations {
   /// **'Battery Level'**
   String get batteryLevel;
 
+  /// No description provided for @charging.
+  ///
+  /// In en, this message translates to:
+  /// **'Charging'**
+  String get charging;
+
   /// Menu item for product/firmware update
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -2352,6 +2352,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get batteryLevel => 'مستوى البطارية';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'تحديث المنتج';
 
   @override

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -2352,7 +2352,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get batteryLevel => 'مستوى البطارية';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'شحن';
 
   @override
   String get productUpdate => 'تحديث المنتج';

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -2379,6 +2379,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get batteryLevel => 'Узровень батарэі';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Абнаўленне прадукту';
 
   @override

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -2379,7 +2379,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get batteryLevel => 'Узровень батарэі';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Зарадка';
 
   @override
   String get productUpdate => 'Абнаўленне прадукту';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -2373,6 +2373,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get batteryLevel => 'Ниво на батерията';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Актуализация на продукта';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -2373,7 +2373,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get batteryLevel => 'Ниво на батерията';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Зареждане';
 
   @override
   String get productUpdate => 'Актуализация на продукта';

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -2375,6 +2375,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get batteryLevel => 'ব্যাটারি স্তর';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'পণ্য আপডেট';
 
   @override

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -2375,7 +2375,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get batteryLevel => 'ব্যাটারি স্তর';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'চার্জ হচ্ছে';
 
   @override
   String get productUpdate => 'পণ্য আপডেট';

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -2377,6 +2377,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get batteryLevel => 'Nivo baterije';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Ažuriranje proizvoda';
 
   @override

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -2377,7 +2377,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get batteryLevel => 'Nivo baterije';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Punjenje';
 
   @override
   String get productUpdate => 'Ažuriranje proizvoda';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -2381,6 +2381,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get batteryLevel => 'Nivell de bateria';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Actualització del producte';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -2381,7 +2381,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get batteryLevel => 'Nivell de bateria';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Carregant';
 
   @override
   String get productUpdate => 'Actualització del producte';

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -2371,6 +2371,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get batteryLevel => 'Stav baterie';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Aktualizace produktu';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -2371,7 +2371,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get batteryLevel => 'Stav baterie';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Nabíjení';
 
   @override
   String get productUpdate => 'Aktualizace produktu';

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -2350,6 +2350,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get batteryLevel => 'Batteriniveau';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Produktopdatering';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -2350,7 +2350,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get batteryLevel => 'Batteriniveau';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Oplader';
 
   @override
   String get productUpdate => 'Produktopdatering';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -2389,6 +2389,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get batteryLevel => 'Batteriestand';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Produktaktualisierung';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -2389,7 +2389,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get batteryLevel => 'Batteriestand';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Wird geladen';
 
   @override
   String get productUpdate => 'Produktaktualisierung';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -2387,6 +2387,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get batteryLevel => 'Επίπεδο μπαταρίας';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Ενημέρωση προϊόντος';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -2387,7 +2387,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get batteryLevel => 'Επίπεδο μπαταρίας';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Φόρτιση';
 
   @override
   String get productUpdate => 'Ενημέρωση προϊόντος';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -2373,6 +2373,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get batteryLevel => 'Battery Level';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Product Update';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -2351,6 +2351,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get batteryLevel => 'Nivel de batería';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Actualización del producto';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -2351,7 +2351,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get batteryLevel => 'Nivel de batería';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Cargando';
 
   @override
   String get productUpdate => 'Actualización del producto';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -2369,6 +2369,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get batteryLevel => 'Aku tase';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Toote värskendus';
 
   @override

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -2369,7 +2369,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get batteryLevel => 'Aku tase';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Laadimine';
 
   @override
   String get productUpdate => 'Toote värskendus';

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -2374,6 +2374,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get batteryLevel => 'سطح باتری';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'بروزرسانی محصول';
 
   @override

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -2374,7 +2374,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get batteryLevel => 'سطح باتری';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'در حال شارژ';
 
   @override
   String get productUpdate => 'بروزرسانی محصول';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -2367,6 +2367,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get batteryLevel => 'Akun taso';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Tuotepäivitys';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -2367,7 +2367,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get batteryLevel => 'Akun taso';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Lataa';
 
   @override
   String get productUpdate => 'Tuotepäivitys';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -2388,6 +2388,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get batteryLevel => 'Niveau de batterie';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Mise à jour du produit';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -2388,7 +2388,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get batteryLevel => 'Niveau de batterie';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'En charge';
 
   @override
   String get productUpdate => 'Mise à jour du produit';

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -2357,6 +2357,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get batteryLevel => 'רמת הסוללה';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'עדכון מוצר';
 
   @override

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -2357,7 +2357,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get batteryLevel => 'רמת הסוללה';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'טוען';
 
   @override
   String get productUpdate => 'עדכון מוצר';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -2342,6 +2342,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get batteryLevel => 'बैटरी स्तर';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'उत्पाद अपडेट';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -2342,7 +2342,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get batteryLevel => 'बैटरी स्तर';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'चार्ज हो रहा है';
 
   @override
   String get productUpdate => 'उत्पाद अपडेट';

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -2378,6 +2378,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get batteryLevel => 'Razina baterije';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Ažuriranje proizvoda';
 
   @override

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -2378,7 +2378,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get batteryLevel => 'Razina baterije';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Punjenje';
 
   @override
   String get productUpdate => 'Ažuriranje proizvoda';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -2383,6 +2383,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get batteryLevel => 'Akkumulátor szint';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Termékfrissítés';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -2383,7 +2383,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get batteryLevel => 'Akkumulátor szint';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Töltés';
 
   @override
   String get productUpdate => 'Termékfrissítés';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -2375,6 +2375,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get batteryLevel => 'Level Baterai';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Pembaruan Produk';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -2375,7 +2375,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get batteryLevel => 'Level Baterai';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Mengisi daya';
 
   @override
   String get productUpdate => 'Pembaruan Produk';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -2378,6 +2378,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get batteryLevel => 'Livello batteria';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Aggiornamento prodotto';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -2378,7 +2378,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get batteryLevel => 'Livello batteria';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'In carica';
 
   @override
   String get productUpdate => 'Aggiornamento prodotto';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -2327,6 +2327,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get batteryLevel => 'バッテリー残量';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => '製品アップデート';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -2327,7 +2327,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get batteryLevel => 'バッテリー残量';
 
   @override
-  String get charging => 'Charging';
+  String get charging => '充電中';
 
   @override
   String get productUpdate => '製品アップデート';

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -2381,6 +2381,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get batteryLevel => 'ಬ್ಯಾಟರಿ ಸ್ತರ';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'ಉತ್ಪನ್ನ ನವೀಕರಣ';
 
   @override

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -2381,7 +2381,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get batteryLevel => 'ಬ್ಯಾಟರಿ ಸ್ತರ';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'ಚಾರ್ಜ್ ಆಗುತ್ತಿದೆ';
 
   @override
   String get productUpdate => 'ಉತ್ಪನ್ನ ನವೀಕರಣ';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -2327,6 +2327,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get batteryLevel => '배터리 수준';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => '제품 업데이트';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -2327,7 +2327,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get batteryLevel => '배터리 수준';
 
   @override
-  String get charging => 'Charging';
+  String get charging => '충전 중';
 
   @override
   String get productUpdate => '제품 업데이트';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -2368,6 +2368,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get batteryLevel => 'Baterijos lygis';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Produkto atnaujinimas';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -2368,7 +2368,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get batteryLevel => 'Baterijos lygis';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Kraunama';
 
   @override
   String get productUpdate => 'Produkto atnaujinimas';

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -2374,6 +2374,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get batteryLevel => 'Akumulatora līmenis';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Produkta atjauninājums';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -2374,7 +2374,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get batteryLevel => 'Akumulatora līmenis';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Uzlāde';
 
   @override
   String get productUpdate => 'Produkta atjauninājums';

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -2384,6 +2384,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get batteryLevel => 'Ниво на батерија';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Ажурирање на производ';
 
   @override

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -2384,7 +2384,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get batteryLevel => 'Ниво на батерија';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Полнење';
 
   @override
   String get productUpdate => 'Ажурирање на производ';

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -2377,6 +2377,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get batteryLevel => 'बॅटरी स्तर';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'उत्पादन अपडेट';
 
   @override

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -2377,7 +2377,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get batteryLevel => 'बॅटरी स्तर';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'चार्ज होत आहे';
 
   @override
   String get productUpdate => 'उत्पादन अपडेट';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -2377,6 +2377,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get batteryLevel => 'Tahap Bateri';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Kemas Kini Produk';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -2377,7 +2377,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get batteryLevel => 'Tahap Bateri';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Mengecas';
 
   @override
   String get productUpdate => 'Kemas Kini Produk';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -2376,6 +2376,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get batteryLevel => 'Batterijniveau';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Productupdate';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -2376,7 +2376,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get batteryLevel => 'Batterijniveau';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Opladen';
 
   @override
   String get productUpdate => 'Productupdate';

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -2367,6 +2367,9 @@ class AppLocalizationsNo extends AppLocalizations {
   String get batteryLevel => 'Batterinivå';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Produktoppdatering';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -2367,7 +2367,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get batteryLevel => 'Batterinivå';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Lader';
 
   @override
   String get productUpdate => 'Produktoppdatering';

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -2372,6 +2372,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get batteryLevel => 'Poziom baterii';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Aktualizacja produktu';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -2372,7 +2372,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get batteryLevel => 'Poziom baterii';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Ładowanie';
 
   @override
   String get productUpdate => 'Aktualizacja produktu';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -2343,6 +2343,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get batteryLevel => 'Nível da Bateria';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Atualização do Produto';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -2343,7 +2343,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get batteryLevel => 'Nível da Bateria';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Carregando';
 
   @override
   String get productUpdate => 'Atualização do Produto';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -2380,6 +2380,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get batteryLevel => 'Nivel baterie';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Actualizare produs';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -2380,7 +2380,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get batteryLevel => 'Nivel baterie';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Se încarcă';
 
   @override
   String get productUpdate => 'Actualizare produs';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -2376,6 +2376,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get batteryLevel => 'Уровень заряда';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Обновление продукта';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -2376,7 +2376,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get batteryLevel => 'Уровень заряда';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Зарядка';
 
   @override
   String get productUpdate => 'Обновление продукта';

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -2374,6 +2374,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get batteryLevel => 'Úroveň batérie';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Aktualizácia produktu';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -2374,7 +2374,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get batteryLevel => 'Úroveň batérie';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Nabíjanie';
 
   @override
   String get productUpdate => 'Aktualizácia produktu';

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -2377,6 +2377,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get batteryLevel => 'Raven baterije';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Posodobitev proizvoda';
 
   @override

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -2377,7 +2377,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get batteryLevel => 'Raven baterije';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Polnjenje';
 
   @override
   String get productUpdate => 'Posodobitev proizvoda';

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -2376,6 +2376,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get batteryLevel => 'Ниво батерије';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Ажурирање производа';
 
   @override

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -2376,7 +2376,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get batteryLevel => 'Ниво батерије';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Пуњење';
 
   @override
   String get productUpdate => 'Ажурирање производа';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -2371,6 +2371,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get batteryLevel => 'Batterinivå';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Produktuppdatering';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -2371,7 +2371,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get batteryLevel => 'Batterinivå';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Laddar';
 
   @override
   String get productUpdate => 'Produktuppdatering';

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -2388,6 +2388,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get batteryLevel => 'பேட்டரி நிலை';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'பொருள் புதுப்பிப்பு';
 
   @override

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -2388,7 +2388,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get batteryLevel => 'பேட்டரி நிலை';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'சார்ஜ் ஆகிறது';
 
   @override
   String get productUpdate => 'பொருள் புதுப்பிப்பு';

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -2385,6 +2385,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get batteryLevel => 'బ్యాటరీ స్థాయి';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'ఉత్పత్తి అపడేట్';
 
   @override

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -2385,7 +2385,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get batteryLevel => 'బ్యాటరీ స్థాయి';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'ఛార్జ్ అవుతోంది';
 
   @override
   String get productUpdate => 'ఉత్పత్తి అపడేట్';

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -2356,6 +2356,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get batteryLevel => 'ระดับแบตเตอรี่';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'การอัปเดตผลิตภัณฑ์';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -2356,7 +2356,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get batteryLevel => 'ระดับแบตเตอรี่';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'กำลังชาร์จ';
 
   @override
   String get productUpdate => 'การอัปเดตผลิตภัณฑ์';

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -2389,6 +2389,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get batteryLevel => 'Antas ng Baterya';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Product Update';
 
   @override

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -2389,7 +2389,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get batteryLevel => 'Antas ng Baterya';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Nagcha-charge';
 
   @override
   String get productUpdate => 'Product Update';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -2375,6 +2375,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get batteryLevel => 'Pil Seviyesi';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Ürün Güncellemesi';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -2375,7 +2375,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get batteryLevel => 'Pil Seviyesi';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Şarj oluyor';
 
   @override
   String get productUpdate => 'Ürün Güncellemesi';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -2373,6 +2373,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get batteryLevel => 'Рівень заряду';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Оновлення продукту';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -2373,7 +2373,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get batteryLevel => 'Рівень заряду';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Заряджається';
 
   @override
   String get productUpdate => 'Оновлення продукту';

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -2375,6 +2375,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get batteryLevel => 'بیٹری کی سطح';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'مصنوع کی اپ ڈیٹ';
 
   @override

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -2375,7 +2375,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get batteryLevel => 'بیٹری کی سطح';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'چارج ہو رہا ہے';
 
   @override
   String get productUpdate => 'مصنوع کی اپ ڈیٹ';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -2372,6 +2372,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get batteryLevel => 'Mức Pin';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => 'Cập Nhật Sản Phẩm';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -2372,7 +2372,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get batteryLevel => 'Mức Pin';
 
   @override
-  String get charging => 'Charging';
+  String get charging => 'Đang sạc';
 
   @override
   String get productUpdate => 'Cập Nhật Sản Phẩm';

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -2323,6 +2323,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get batteryLevel => '电池电量';
 
   @override
+  String get charging => 'Charging';
+
+  @override
   String get productUpdate => '产品更新';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -2323,7 +2323,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get batteryLevel => '电池电量';
 
   @override
-  String get charging => 'Charging';
+  String get charging => '充电中';
 
   @override
   String get productUpdate => '产品更新';

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -296,6 +296,7 @@
     "basicPlanDescription": "1 200 premium minučių + neribota įrenginyje",
     "batteryDrainSignificantly": "Baterijos išsikrovimas žymiai padidės.",
     "batteryLevel": "Baterijos lygis",
+    "charging": "Kraunama",
     "batteryUsageHigher": "Baterijos naudojimas bus didesnis nei debesies transkripcijos.",
     "beforeUpdateMakeSure": "Prieš atnaujinant įsitikinkite:",
     "bestInClassTranscription": "Geriausia klasės transkripcija be jokio nustatymo",

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Bīdiet, lai atjauninātu",
     "copiedToClipboard": "{title} nokopēts starpliktuvē",
     "batteryLevel": "Akumulatora līmenis",
+    "charging": "Uzlāde",
     "productUpdate": "Produkta atjauninājums",
     "offline": "Bezsaistē",
     "available": "Pieejams",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "Ниво на батерија",
+    "charging": "Полнење",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "बॅटरी स्तर",
+    "charging": "चार्ज होत आहे",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Luncurkan untuk kemas kini",
     "copiedToClipboard": "{title} disalin ke papan keratan",
     "batteryLevel": "Tahap Bateri",
+    "charging": "Mengecas",
     "productUpdate": "Kemas Kini Produk",
     "offline": "Luar Talian",
     "available": "Tersedia",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Schuif om bij te werken",
     "copiedToClipboard": "{title} gekopieerd naar klembord",
     "batteryLevel": "Batterijniveau",
+    "charging": "Opladen",
     "productUpdate": "Productupdate",
     "offline": "Offline",
     "available": "Beschikbaar",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Gli for å oppdatere",
     "copiedToClipboard": "{title} kopiert til utklippstavlen",
     "batteryLevel": "Batterinivå",
+    "charging": "Lader",
     "productUpdate": "Produktoppdatering",
     "offline": "Frakoblet",
     "available": "Tilgjengelig",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Przesuń, aby zaktualizować",
     "copiedToClipboard": "{title} skopiowano do schowka",
     "batteryLevel": "Poziom baterii",
+    "charging": "Ładowanie",
     "productUpdate": "Aktualizacja produktu",
     "offline": "Offline",
     "available": "Dostępne",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -733,6 +733,7 @@
     "slideToUpdate": "Deslize para atualizar",
     "copiedToClipboard": "{title} copiado para a área de transferência",
     "batteryLevel": "Nível da Bateria",
+    "charging": "Carregando",
     "productUpdate": "Atualização do Produto",
     "offline": "Offline",
     "available": "Disponível",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Glisați pentru a actualiza",
     "copiedToClipboard": "{title} copiat în clipboard",
     "batteryLevel": "Nivel baterie",
+    "charging": "Se încarcă",
     "productUpdate": "Actualizare produs",
     "offline": "Offline",
     "available": "Disponibil",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Проведите для обновления",
     "copiedToClipboard": "{title} скопировано в буфер обмена",
     "batteryLevel": "Уровень заряда",
+    "charging": "Зарядка",
     "productUpdate": "Обновление продукта",
     "offline": "Не в сети",
     "available": "Доступно",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Posuňte pre aktualizáciu",
     "copiedToClipboard": "{title} skopírované do schránky",
     "batteryLevel": "Úroveň batérie",
+    "charging": "Nabíjanie",
     "productUpdate": "Aktualizácia produktu",
     "offline": "Offline",
     "available": "Dostupné",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "Raven baterije",
+    "charging": "Polnjenje",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "Ниво батерије",
+    "charging": "Пуњење",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Dra för att uppdatera",
     "copiedToClipboard": "{title} kopierat till urklipp",
     "batteryLevel": "Batterinivå",
+    "charging": "Laddar",
     "productUpdate": "Produktuppdatering",
     "offline": "Offline",
     "available": "Tillgänglig",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "பேட்டரி நிலை",
+    "charging": "சார்ஜ் ஆகிறது",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "బ్యాటరీ స్థాయి",
+    "charging": "ఛార్జ్ అవుతోంది",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "เลื่อนเพื่ออัปเดต",
     "copiedToClipboard": "คัดลอก {title} ไปยังคลิปบอร์ดแล้ว",
     "batteryLevel": "ระดับแบตเตอรี่",
+    "charging": "กำลังชาร์จ",
     "productUpdate": "การอัปเดตผลิตภัณฑ์",
     "offline": "ออฟไลน์",
     "available": "พร้อมใช้งาน",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "Antas ng Baterya",
+    "charging": "Nagcha-charge",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Güncellemek için kaydırın",
     "copiedToClipboard": "{title} panoya kopyalandı",
     "batteryLevel": "Pil Seviyesi",
+    "charging": "Şarj oluyor",
     "productUpdate": "Ürün Güncellemesi",
     "offline": "Çevrimdışı",
     "available": "Mevcut",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Проведіть для оновлення",
     "copiedToClipboard": "{title} скопійовано в буфер обміну",
     "batteryLevel": "Рівень заряду",
+    "charging": "Заряджається",
     "productUpdate": "Оновлення продукту",
     "offline": "Не в мережі",
     "available": "Доступно",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -2512,6 +2512,7 @@
         }
     },
     "batteryLevel": "بیٹری کی سطح",
+    "charging": "چارج ہو رہا ہے",
     "@batteryLevel": {
         "description": "Battery level label"
     },

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -732,6 +732,7 @@
     "slideToUpdate": "Vuốt để cập nhật",
     "copiedToClipboard": "Đã sao chép {title} vào khay nhớ tạm",
     "batteryLevel": "Mức Pin",
+    "charging": "Đang sạc",
     "productUpdate": "Cập Nhật Sản Phẩm",
     "offline": "Ngoại tuyến",
     "available": "Có sẵn",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -733,6 +733,7 @@
     "slideToUpdate": "滑动以更新",
     "copiedToClipboard": "{title}已复制到剪贴板",
     "batteryLevel": "电池电量",
+    "charging": "充电中",
     "productUpdate": "产品更新",
     "offline": "离线",
     "available": "可用",

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -161,6 +161,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
   }
 
   Widget _buildBatterySection(DeviceProvider provider) {
+    final charging = provider.isCharging;
     return Container(
       decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(20)),
       child: Padding(
@@ -172,11 +173,13 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               height: 24,
               child: Padding(
                 padding: const EdgeInsets.only(left: 2, top: 1),
-                child: FaIcon(
-                  _getBatteryIcon(provider.batteryLevel),
-                  color: _getBatteryColor(provider.batteryLevel),
-                  size: 20,
-                ),
+                child: charging
+                    ? const Icon(Icons.bolt, color: Color.fromARGB(255, 0, 255, 8), size: 22)
+                    : FaIcon(
+                        _getBatteryIcon(provider.batteryLevel),
+                        color: _getBatteryColor(provider.batteryLevel),
+                        size: 20,
+                      ),
               ),
             ),
             const SizedBox(width: 16),
@@ -190,7 +193,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(color: const Color(0xFF2A2A2E), borderRadius: BorderRadius.circular(100)),
               child: Text(
-                '${provider.batteryLevel}%',
+                charging ? context.l10n.charging : '${provider.batteryLevel}%',
                 style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w500),
               ),
             ),

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -185,7 +185,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
             const SizedBox(width: 16),
             Expanded(
               child: Text(
-                context.l10n.batteryLevel,
+                charging ? context.l10n.charging : context.l10n.batteryLevel,
                 style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w400),
               ),
             ),
@@ -193,7 +193,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(color: const Color(0xFF2A2A2E), borderRadius: BorderRadius.circular(100)),
               child: Text(
-                charging ? context.l10n.charging : '${provider.batteryLevel}%',
+                '${provider.batteryLevel}%',
                 style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w500),
               ),
             ),

--- a/app/lib/pages/home/widgets/battery_info_widget.dart
+++ b/app/lib/pages/home/widgets/battery_info_widget.dart
@@ -24,11 +24,16 @@ class BatteryInfoWidget extends StatelessWidget {
       builder: (context, isMemoriesPage, child) {
         // Use Selector to only rebuild when battery level, connected device, or connecting state changes
         // This reduces battery drain by avoiding unnecessary rebuilds during other provider updates
-        return Selector<DeviceProvider, (int, BtDevice?, BtDevice?, bool)>(
-          selector: (_, provider) =>
-              (provider.batteryLevel, provider.connectedDevice, provider.pairedDevice, provider.isConnecting),
+        return Selector<DeviceProvider, (int, BtDevice?, BtDevice?, bool, bool)>(
+          selector: (_, provider) => (
+            provider.batteryLevel,
+            provider.connectedDevice,
+            provider.pairedDevice,
+            provider.isConnecting,
+            provider.isCharging
+          ),
           builder: (context, data, child) {
-            final (batteryLevel, connectedDevice, pairedDevice, isConnecting) = data;
+            final (batteryLevel, connectedDevice, pairedDevice, isConnecting, isCharging) = data;
             if (connectedDevice != null) {
               return GestureDetector(
                 onTap: () {
@@ -59,19 +64,22 @@ class BatteryInfoWidget extends StatelessWidget {
                       // Only show battery indicator and percentage when battery level is valid (> 0)
                       if (batteryLevel > 0) ...[
                         const SizedBox(width: 6.0),
-                        Container(
-                          width: 8,
-                          height: 8,
-                          decoration: BoxDecoration(
-                            color: batteryLevel > 75
-                                ? const Color.fromARGB(255, 0, 255, 8)
-                                : batteryLevel > 20
-                                    ? Colors.yellow.shade700
-                                    : Colors.red,
-                            shape: BoxShape.circle,
+                        if (isCharging)
+                          const Icon(Icons.bolt, color: Color.fromARGB(255, 0, 255, 8), size: 14)
+                        else
+                          Container(
+                            width: 8,
+                            height: 8,
+                            decoration: BoxDecoration(
+                              color: batteryLevel > 75
+                                  ? const Color.fromARGB(255, 0, 255, 8)
+                                  : batteryLevel > 20
+                                      ? Colors.yellow.shade700
+                                      : Colors.red,
+                              shape: BoxShape.circle,
+                            ),
                           ),
-                        ),
-                        const SizedBox(width: 6.0),
+                        const SizedBox(width: 4.0),
                         Text(
                           '$batteryLevel%',
                           style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.bold),

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -14,6 +14,7 @@ import 'package:omi/pages/home/firmware_update.dart';
 import 'package:omi/pages/home/omiglass_ota_update.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/services/devices.dart';
+import 'package:omi/services/devices/omi_connection.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/battery_widget_service.dart';
@@ -34,7 +35,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   BtDevice? connectedDevice;
   BtDevice? pairedDevice;
   StreamSubscription<List<int>>? _bleBatteryLevelListener;
+  StreamSubscription? _bleChargingStatusListener;
   int batteryLevel = -1;
+  bool isCharging = false;
   int _lastNotifiedBatteryLevel = -1;
   DateTime? _lastBatteryNotifyTime;
   bool _hasLowBatteryAlerted = false;
@@ -193,6 +196,24 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     notifyListeners();
   }
 
+  Future<void> initiateChargingStatusListener() async {
+    if (connectedDevice == null) return;
+    _bleChargingStatusListener?.cancel();
+
+    var connection = await ServiceManager.instance().device.ensureConnection(connectedDevice!.id);
+    if (connection == null) return;
+    if (connection is! OmiDeviceConnection) return;
+
+    _bleChargingStatusListener = await connection.getChargingStatusListener(
+      onChargingStatusChange: (bool charging) {
+        if (isCharging != charging) {
+          isCharging = charging;
+          notifyListeners();
+        }
+      },
+    );
+  }
+
   /// Updates battery level with throttling logic. Returns true if notifyListeners was called.
   /// This method is exposed for testing the throttling behavior.
   @visibleForTesting
@@ -203,9 +224,8 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Throttle notifyListeners to reduce battery drain from excessive UI rebuilds
     // Only notify when: first reading, >=5% change, 15min elapsed, or crosses 20% threshold
     final delta = (_lastNotifiedBatteryLevel - value).abs();
-    final elapsed = _lastBatteryNotifyTime == null
-        ? const Duration(minutes: 999)
-        : currentTime.difference(_lastBatteryNotifyTime!);
+    final elapsed =
+        _lastBatteryNotifyTime == null ? const Duration(minutes: 999) : currentTime.difference(_lastBatteryNotifyTime!);
     final crossedLowBatteryThreshold =
         (value < 20 && _lastNotifiedBatteryLevel >= 20) || (value >= 20 && _lastNotifiedBatteryLevel < 20);
     final shouldNotify =
@@ -320,6 +340,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   @override
   void dispose() {
     _bleBatteryLevelListener?.cancel();
+    _bleChargingStatusListener?.cancel();
     _discoveryTimer?.cancel();
     _disconnectDebouncer.cancel();
     _connectDebouncer.cancel();
@@ -331,6 +352,8 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     Logger.debug('onDisconnected inside: $connectedDevice');
     _havingNewFirmware = false;
     _isFirmwareDialogShowing = false;
+    _bleChargingStatusListener?.cancel();
+    isCharging = false;
     setConnectedDevice(null);
     setisDeviceStorageSupport();
     setIsConnected(false);
@@ -414,8 +437,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       );
     }
 
-    // Then set up listener for battery changes
+    // Then set up listeners for battery changes and charging status
     await initiateBleBatteryListener();
+    await initiateChargingStatusListener();
     if (batteryLevel != -1 && batteryLevel < 20) {
       _hasLowBatteryAlerted = false;
     }

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -204,6 +204,12 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     if (connection == null) return;
     if (connection is! OmiDeviceConnection) return;
 
+    final currentStatus = await connection.readChargingStatus();
+    if (isCharging != currentStatus) {
+      isCharging = currentStatus;
+      notifyListeners();
+    }
+
     _bleChargingStatusListener = await connection.getChargingStatusListener(
       onChargingStatusChange: (bool charging) {
         if (isCharging != charging) {

--- a/app/lib/services/devices/omi_connection.dart
+++ b/app/lib/services/devices/omi_connection.dart
@@ -18,6 +18,7 @@ class OmiDeviceConnection extends DeviceConnection {
   static const String settingsServiceUuid = '19b10010-e8f2-537e-4f6c-d104768a1214';
   static const String settingsDimRatioCharacteristicUuid = '19b10011-e8f2-537e-4f6c-d104768a1214';
   static const String settingsMicGainCharacteristicUuid = '19b10012-e8f2-537e-4f6c-d104768a1214';
+  static const String settingsChargingStatusCharacteristicUuid = '19b10013-e8f2-537e-4f6c-d104768a1214';
   static const String featuresServiceUuid = '19b10020-e8f2-537e-4f6c-d104768a1214';
   static const String featuresCharacteristicUuid = '19b10021-e8f2-537e-4f6c-d104768a1214';
 
@@ -725,6 +726,25 @@ class OmiDeviceConnection extends DeviceConnection {
       return null;
     } catch (e) {
       Logger.debug('OmiDeviceConnection: Error getting mic gain: $e');
+      return null;
+    }
+  }
+
+  Future<StreamSubscription?> getChargingStatusListener({
+    required void Function(bool isCharging) onChargingStatusChange,
+  }) async {
+    try {
+      final stream = transport.getCharacteristicStream(
+        settingsServiceUuid,
+        settingsChargingStatusCharacteristicUuid,
+      );
+      return stream.listen((value) {
+        if (value.isNotEmpty) {
+          onChargingStatusChange(value[0] == 1);
+        }
+      });
+    } catch (e) {
+      Logger.debug('OmiDeviceConnection: Error setting up charging status listener: $e');
       return null;
     }
   }

--- a/app/lib/services/devices/omi_connection.dart
+++ b/app/lib/services/devices/omi_connection.dart
@@ -730,6 +730,19 @@ class OmiDeviceConnection extends DeviceConnection {
     }
   }
 
+  Future<bool> readChargingStatus() async {
+    try {
+      final value = await transport.readCharacteristic(
+        settingsServiceUuid,
+        settingsChargingStatusCharacteristicUuid,
+      );
+      return value.isNotEmpty && value[0] == 1;
+    } catch (e) {
+      Logger.debug('OmiDeviceConnection: Error reading charging status: $e');
+      return false;
+    }
+  }
+
   Future<StreamSubscription?> getChargingStatusListener({
     required void Function(bool isCharging) onChargingStatusChange,
   }) async {

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.533+828
+version: 1.0.533+829
 
 
 environment:


### PR DESCRIPTION
## Summary
- Subscribes to new firmware BLE characteristic `0x19B10013` (Settings Service, added in PR #6976) to detect charging state
- Home screen: bolt icon replaces the colored dot next to battery percentage when charging
- Device detail page: bolt icon replaces battery icon, badge shows "Charging" instead of percentage
- Gracefully degrades on pre-3.0.18 firmware (characteristic doesn't exist, `isCharging` stays false)

## Test plan
- [ ] Connect to device with firmware >= 3.0.18, plug in charger, verify bolt icon appears on home screen
- [ ] Verify device detail page shows bolt icon + "Charging" text while charging
- [ ] Unplug charger, verify indicators revert to normal battery display
- [ ] Connect to device with older firmware, verify normal battery indicator (no crash, no glitch)
- [ ] Disconnect device, verify `isCharging` resets (no stale charging indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)