### PR TITLE
fix external app errors leaking into user chat

### DIFF
--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -143,8 +143,13 @@ def send_app_notification_to_user(request: Request, data: dict, authorization: O
     target = 'app'
     if app.external_integration and app.external_integration.chat_messages_enabled:
         target = app.external_integration.chat_messages_target
-        chat_app_id = None if target == 'main' else app.id
-        add_integration_chat_message(data['message'], chat_app_id, uid)
+        if target == 'main':
+            # Prefix app name so users can identify which integration sent the message,
+            # especially useful when an external app's error appears in the main chat.
+            prefixed = f"[{app.name}]: {data['message']}"
+            add_integration_chat_message(prefixed, None, uid)
+        else:
+            add_integration_chat_message(data['message'], app.id, uid)
 
     # Always send push notification
     send_app_notification(uid, app.name, app.id, data['message'], target=target)

--- a/backend/utils/retrieval/tools/app_tools.py
+++ b/backend/utils/retrieval/tools/app_tools.py
@@ -238,6 +238,15 @@ async def _call_tool_endpoint(kwargs: dict, config: Optional[RunnableConfig], ap
                 except ValueError:
                     return response.text
             else:
+                # Auth errors (401/403) almost always mean the app's API key or
+                # credentials are misconfigured on the app developer's side.
+                # Return a clean message so Claude doesn't echo raw API key errors
+                # (like "Invalid API key · Fix external API key") back to the user.
+                if response.status_code in (401, 403):
+                    return (
+                        f"The {app_tool.name} tool is temporarily unavailable due to a "
+                        f"configuration issue on the app's side. Please try again later "
+                    )
                 error_msg = f"Error calling {app_tool.name}: HTTP {response.status_code}"
                 try:
                     error_detail = response.json()


### PR DESCRIPTION
## Problem

Third-party apps can push messages into a user's Omi chat via `/v1/integrations/notification`. When an external app's backend has a broken API key (or any auth failure), it forwards the raw error — e.g. `"Invalid API key · Fix external API key"` — directly into the user's chat. The message appeared with no attribution, making it look like Omi itself was broken.

Two code paths caused this:

1. **Notification → main chat**: External app pushes error string to the user's main Omi chat with no indication of which app sent it.
2. **Chat tool → Claude**: An app's tool endpoint returns HTTP 401/403 with a raw error body. That string goes back to Claude as a tool result, and Claude echoes it word-for-word to the user.

## Fix

**`notifications.py`** — When an app routes a message to `target='main'`, prefix the app name:
```
Before: "Invalid API key · Fix external API key"
After:  "[TaskApp]: Invalid API key · Fix external API key"
```
Users can now identify which app caused the problem.

**`app_tools.py`** — When a tool endpoint returns 401 or 403, return a clean generic message to Claude instead of the raw error body. Claude then responds helpfully rather than echoing `"Invalid API key"` to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)