### PR TITLE
fix(ble): force reconnect on CDM appear (android) + kick stuck .connecting on foreground (ios)

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -84,8 +84,16 @@ class OmiBleForegroundService : Service() {
 
             val inst = instance
             if (inst != null) {
-                Log.d(TAG, "startService($caller): service already running, managing $deviceAddress directly")
-                inst.manageDevice(deviceAddress, requiresBond)
+                // When the OS's CDM fires EVENT_BLE_APPEARED, the device is definitely
+                // visible right now — a stuck autoConnect=true passive scan may have
+                // missed it. Abandon any pending/stuck attempt and try a fresh connect.
+                if (caller.startsWith("CompanionSvc")) {
+                    Log.d(TAG, "startService($caller): service running, forcing reconnect for $deviceAddress")
+                    inst.forceReconnect(deviceAddress, requiresBond, caller)
+                } else {
+                    Log.d(TAG, "startService($caller): service already running, managing $deviceAddress directly")
+                    inst.manageDevice(deviceAddress, requiresBond)
+                }
                 return
             }
 
@@ -342,6 +350,37 @@ class OmiBleForegroundService : Service() {
         managed.pendingReconnect?.let { handler.removeCallbacks(it) }
         managed.pendingReconnect = null
         managed.retryCount = 0
+        connectToDevice(addr, source)
+    }
+
+    /**
+     * Called from startService() when CompanionDeviceManager fires EVENT_BLE_APPEARED.
+     * The OS has confirmed the device is in range right now, so abandon any stuck
+     * autoConnect=true passive scan and force a fresh connection attempt.
+     */
+    fun forceReconnect(address: String, requiresBond: Boolean, source: String) {
+        val addr = address.uppercase()
+        if (bleManager.isPeripheralConnected(addr)) return
+
+        synchronized(syncLock) {
+            val managed = managedDevices[addr] ?: run {
+                // No managed state yet — fall through to normal manage flow
+                managedDevices[addr] = ManagedDevice(address = addr, requiresBond = requiresBond)
+                null
+            }
+            if (managed != null) {
+                if (requiresBond && !managed.requiresBond) managed.requiresBond = true
+                // Cancel any pending retry so it doesn't race with the fresh attempt
+                managed.pendingReconnect?.let { handler.removeCallbacks(it) }
+                managed.pendingReconnect = null
+                managed.retryCount = 0
+                // Close the stuck GATT so connectToDevice opens a fresh one
+                if (bleManager.connectedGatts.containsKey(addr)) {
+                    bleManager.closeGatt(addr)
+                }
+                managed.currentGattHash = null
+            }
+        }
         connectToDevice(addr, source)
     }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -84,16 +84,11 @@ class OmiBleForegroundService : Service() {
 
             val inst = instance
             if (inst != null) {
-                // When the OS's CDM fires EVENT_BLE_APPEARED, the device is definitely
-                // visible right now — a stuck autoConnect=true passive scan may have
-                // missed it. Abandon any pending/stuck attempt and try a fresh connect.
-                if (caller.startsWith("CompanionSvc")) {
-                    Log.d(TAG, "startService($caller): service running, forcing reconnect for $deviceAddress")
-                    inst.forceReconnect(deviceAddress, requiresBond, caller)
-                } else {
-                    Log.d(TAG, "startService($caller): service already running, managing $deviceAddress directly")
-                    inst.manageDevice(deviceAddress, requiresBond)
-                }
+                // Service already running — any startService call is effectively a
+                // "please (re)connect this device" signal. Always force a fresh attempt
+                // so a stuck autoConnect=true passive scan doesn't silently swallow it.
+                Log.d(TAG, "startService($caller): service running, forcing reconnect for $deviceAddress")
+                inst.forceReconnect(deviceAddress, requiresBond, caller)
                 return
             }
 

--- a/app/ios/Runner/OmiBleManager.swift
+++ b/app/ios/Runner/OmiBleManager.swift
@@ -173,14 +173,13 @@ final class OmiBleManager: NSObject {
         for (uuid, peripheral) in peripherals {
             guard everConnected.contains(uuid) else { continue }
             if manuallyDisconnected.contains(uuid) { continue }
-            switch peripheral.state {
-            case .connected, .connecting:
-                continue
-            default:
-                NSLog("[OmiBle] Re-issuing connect on foreground for \(uuid), state=\(peripheral.state.rawValue)")
-                peripheral.delegate = self
-                centralManager.connect(peripheral, options: nil)
-            }
+            // Only skip if already connected. For peripherals in .connecting state,
+            // re-issue connect() to kick CoreBluetooth — the pending attempt may be
+            // silently waiting in congested RF. connect() is idempotent on iOS.
+            if peripheral.state == .connected { continue }
+            NSLog("[OmiBle] Re-issuing connect on foreground for \(uuid), state=\(peripheral.state.rawValue)")
+            peripheral.delegate = self
+            centralManager.connect(peripheral, options: nil)
         }
     }
 


### PR DESCRIPTION
## Problem

In congested RF environments (events, venues with heavy BLE/WiFi traffic), when the device disconnects and the app retries, the pending reconnection attempt can sit indefinitely waiting for advertising packets. Users had to bring the phone within 1-2 inches of the device for it to finally reconnect.

Happens on both Android and iOS — different underlying mechanisms but same user experience.

## Android root cause

1. Device disconnects → \`handleRetryLogic\` schedules retry
2. Retry fires → \`connectGatt(autoConnect=true)\` → \`currentGattHash\` set, GATT sits on passive background scan
3. \`CompanionDeviceManager\` fires \`EVENT_BLE_APPEARED\` (the OS's more aggressive scan did find the device)
4. \`BleCompanionService.handleDeviceAppeared\` → \`startService(\"CompanionSvc.deviceAppeared\")\`
5. Service already running → \`manageDevice(addr)\`
6. \`manageDevice\` sees \`existing.currentGattHash != null\` → **returns without doing anything**

The most reliable \"device is here\" signal the OS gives us was being silently dropped.

### Android fix

Mirror Fieldy's pattern: when CDM triggers \`startService\`, bypass \`manageDevice\`'s guards and route to a new \`forceReconnect\` method that cancels the pending retry, closes the stuck GATT, and starts a fresh \`connectToDevice\`. Non-CompanionSvc callers (Dart \`manageDevice\`, BT toggle handler) still go through \`manageDevice\` as before. Rate limiting (15s) preserved.

## iOS root cause

\`OmiBleManager.reconnectStalePeripherals()\` is called on \`applicationWillEnterForeground\` and re-issues \`centralManager.connect(peripheral, options: nil)\` on previously-connected peripherals that aren't currently connected. But it skipped peripherals in \`.connecting\` state:

\`\`\`swift
switch peripheral.state {
case .connected, .connecting:
    continue   // <-- skip both
\`\`\`

A peripheral stuck in \`.connecting\` (iOS equivalent of Android's stuck \`autoConnect=true\`) got no kick on foreground.

### iOS fix

Match Fieldy's \`handleWillEnterForeground\`: re-issue \`connect()\` for any non-\`.connected\` peripheral. iOS's \`connect()\` is idempotent — safe for already-connecting peripherals, and it nudges CoreBluetooth to retry for truly stuck ones.

## Files

- \`app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt\` — new \`forceReconnect\` method, CDM-aware branch in \`startService\`
- \`app/ios/Runner/OmiBleManager.swift\` — removed \`.connecting\` skip in \`reconnectStalePeripherals\`

## Test plan

- [ ] Normal connect / BT toggle / device off-on — no regression (both platforms)
- [ ] Congested RF environment (event/venue) — verify reconnection without bringing phone close to device
- [ ] Android: logcat shows \`OmiBle.FgService\` \`startService(CompanionSvc...): service running, forcing reconnect\` on reconnection
- [ ] iOS: NSLog shows \`[OmiBle] Re-issuing connect on foreground for <uuid>, state=1\` (1 = \`.connecting\`) when foregrounding with a stuck connect