### PR TITLE
fix(onboarding): make speech-profile Skip button always responsive

### DIFF
--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -485,9 +485,12 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
                           ),
 
                           TextButton(
-                            onPressed: () => provider.skipCurrentQuestion(),
+                            onPressed: () {
+                              provider.close();
+                              widget.onSkip();
+                            },
                             child: Text(
-                              context.l10n.skipThisQuestion,
+                              context.l10n.skipForNow,
                               style: const TextStyle(color: Colors.grey, fontSize: 14, fontFamily: 'Manrope'),
                             ),
                           ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.533+829
+version: 1.0.533+830
 
 
 environment:


### PR DESCRIPTION
## Summary

- Replaces "Skip this question" with "Skip for now" on the onboarding speech-profile screen and changes its handler so the button always does something visible.
- Previously tapped the handler called `SpeechProfileProvider.skipCurrentQuestion()`, which sends a `{"type": "skip_question"}` frame over the websocket — but silently no-ops if the socket is not connected. When users hit a transient socket failure (mic permission hang, network flake, backend drop) the button appeared dead.
- New handler closes the provider (cancels streams, stops mic, tears down the socket) and calls `widget.onSkip()`, which is already wired in [onboarding/wrapper.dart](app/lib/pages/onboarding/wrapper.dart) to advance to the Knowledge Graph step.
- `skipForNow` l10n key already exists in all 33 locales — no ARB changes needed.

## Scope

- Only touches the onboarding flow (`app/lib/pages/onboarding/speech_profile_widget.dart`).
- The re-enrollment flow in `app/lib/pages/speech_profile/page.dart` is left untouched.

## Test plan

- [ ] Fresh install on iOS, sign in, tap "Get Started" on the speech-profile screen, immediately tap "Skip for now" → should advance past speech profile to the Knowledge Graph step, with no dialog, no hang.
- [ ] Same flow with airplane mode on (socket never connects) → "Skip for now" still works.
- [ ] Same flow with a healthy recording midway → "Skip for now" cleanly stops the mic + socket and advances.
- [ ] iPad: same paths.
- [ ] Android regression: onboarding still completes normally when the user does record + finishes the profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)