### PR TITLE
fix voice playback speaker mode — first chunk skipped + infinite repeat

### DIFF
--- a/app/lib/services/voice_playback/omi_voice_playback_service.dart
+++ b/app/lib/services/voice_playback/omi_voice_playback_service.dart
@@ -307,6 +307,7 @@ class OmiVoicePlaybackService {
       final session = await AudioSession.instance;
       await session.setActive(true);
     } catch (e) {
+      _sessionActive = false;
       Logger.debug('OmiVoicePlaybackService: setActive(true) failed: $e');
     }
   }

--- a/app/lib/services/voice_playback/omi_voice_playback_service.dart
+++ b/app/lib/services/voice_playback/omi_voice_playback_service.dart
@@ -72,7 +72,6 @@ class OmiVoicePlaybackService {
 
     _player.playerStateStream.listen((state) {
       if (state.processingState == ProcessingState.completed) {
-        _player.seek(Duration.zero);
         _playNextFromQueue();
       }
     });
@@ -304,9 +303,12 @@ class OmiVoicePlaybackService {
   Future<void> _activateSession() async {
     if (_sessionActive) return;
     _sessionActive = true;
-    // AudioSession (configured with AudioSessionConfiguration.speech()) plus
-    // just_audio handles the AVAudioSession / AudioFocus lifecycle across iOS
-    // and Android. Nothing further to do here.
+    try {
+      final session = await AudioSession.instance;
+      await session.setActive(true);
+    } catch (e) {
+      Logger.debug('OmiVoicePlaybackService: setActive(true) failed: $e');
+    }
   }
 
   Future<void> _deactivateSession() async {


### PR DESCRIPTION
## Summary

Fixes two bugs in `OmiVoicePlaybackService` that only affected **speaker mode** (Always setting) from PR #6986.

- **First chunk skipped**: `_activateSession()` set an internal flag but never called `session.setActive(true)`. Headphones mode worked because `_hasHeadphonesConnected()` → `session.getDevices()` implicitly warmed up the iOS `AVAudioSession` as a side effect. Speaker mode had no such warm-up, so `_player.play()` failed on the first chunk, the error handler skipped it, and only the tail ("Anything else?") was heard.
- **Infinite repetition**: `_player.seek(Duration.zero)` was called on every `completed` event. The native player (AVPlayer/ExoPlayer) sought back to position 0 while its internal playback rate was still non-zero, causing it to restart immediately and fire another `completed` event — an infinite seek → replay loop.

## Changes

- `_activateSession()`: call `session.setActive(true)` so the audio session is active before the first chunk plays (headphones mode is unaffected)
- Remove `_player.seek(Duration.zero)` from the `playerStateStream` completion listener — it was unnecessary (the next `_playNextFromQueue` call sets a new source) and caused the replay loop

## Test plan

- [ ] Speaker mode (Always): hold Omi button, ask a question → full response spoken, no repetition
- [ ] Headphones mode: verify still works as before
- [ ] Off mode: verify no audio plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)