### PR TITLE
Update CHANGELOG.json for v0.11.359 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,9 +1,14 @@
 {
-  "unreleased": [
-    "Proactive notifications now only appear in the floating bar, not as macOS system banners",
-    "Made the entire floating bar notification clickable (previously only the text opened the chat)"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.359",
+      "date": "2026-04-24",
+      "changes": [
+        "Proactive notifications now only appear in the floating bar, not as macOS system banners",
+        "Made the entire floating bar notification clickable (previously only the text opened the chat)"
+      ]
+    },
     {
       "version": "0.11.358",
       "date": "2026-04-23",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.359 and clears the unreleased array.