### PR TITLE
chore: instruct agents to sync main before creating a worktree/branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,7 @@ Always format code after making changes. The pre-commit hook handles this automa
 - Never merge directly from a local branch. Land changes through a PR only.
 - When a change should go remote, create or use a feature branch, commit there, open/update a PR, and merge via the PR.
 - Always work in a git worktree for code changes. Use `EnterWorktree` at the start of a task to isolate your work.
+- Before creating a worktree or branch, run `git fetch origin && git pull --ff-only` on `main` — don't branch off stale local state.
 
 ## Documentation Maintenance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ Files ending in `.gen.dart` or `.g.dart` are auto-generated — don't format man
 - If push fails (remote ahead): `git pull --rebase && git push`.
 - Never push or create PRs unless explicitly asked — commit locally by default.
 - Always work in a git worktree for code changes. Use `EnterWorktree` to isolate work.
+- Before creating a worktree or branch, run `git fetch origin && git pull --ff-only` on `main` — don't branch off stale local state.
 
 ### RELEASE Command
 Create branch from `main`, individual commits per file, push/create PR, merge without squash, switch back to `main` and pull.


### PR DESCRIPTION
## Summary
- A 16-day-old local \`main\` in one of my clones produced a feature branch that built and shipped without 64 \`origin/main\` commits — a stale-base bug, not visible at merge time because git only diffs my changes.
- Adds one line to \`CLAUDE.md\` and \`AGENTS.md\` (synced) under the existing Git → Rules section so future Claude / Codex sessions sync \`main\` before branching:
  > Before creating a worktree or branch, run \`git fetch origin && git pull --ff-only\` on \`main\` — don't branch off stale local state.
- The same line was also added to \`~/.claude/CLAUDE.md\` and \`~/.codex/AGENTS.md\` locally so the rule applies on every project, not just this repo.

## Test plan
- [x] Diff is two single-line additions, no other changes.
- [x] Wording matches the rest of the Git → Rules bullets in style and length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)