### PR TITLE
app: disable Omi disconnected notifications

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -387,15 +387,15 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       return;
     }
 
-    // Show a notification if still disconnected after 30 seconds.
-    _disconnectNotificationTimer?.cancel();
-    _disconnectNotificationTimer = Timer(const Duration(seconds: 30), () {
-      final ctx = globalNavigatorKey.currentContext;
-      NotificationService.instance.createNotification(
-        title: ctx?.l10n.deviceDisconnectedNotificationTitle ?? 'Your Omi Device Disconnected',
-        body: ctx?.l10n.deviceDisconnectedNotificationBody ?? 'Please reconnect to continue using your Omi.',
-      );
-    });
+    // Disabled: "Omi disconnected" notifications were too noisy.
+    // _disconnectNotificationTimer?.cancel();
+    // _disconnectNotificationTimer = Timer(const Duration(seconds: 30), () {
+    //   final ctx = globalNavigatorKey.currentContext;
+    //   NotificationService.instance.createNotification(
+    //     title: ctx?.l10n.deviceDisconnectedNotificationTitle ?? 'Your Omi Device Disconnected',
+    //     body: ctx?.l10n.deviceDisconnectedNotificationBody ?? 'Please reconnect to continue using your Omi.',
+    //   );
+    // });
   }
 
   Future<(String, bool, String, Map)> shouldUpdateFirmware() async {

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -611,11 +611,12 @@ abstract class DeviceConnection {
   }
 
   void _showDeviceDisconnectedNotification() {
-    final ctx = globalNavigatorKey.currentContext;
-    final deviceName = device.name;
-    NotificationService.instance.createNotification(
-      title: ctx?.l10n.deviceDisconnectedTitle(deviceName) ?? '$deviceName Disconnected',
-      body: ctx?.l10n.deviceDisconnectedBody(deviceName) ?? 'Please reconnect to continue using your $deviceName.',
-    );
+    // Disabled: "Omi disconnected" notifications were too noisy.
+    // final ctx = globalNavigatorKey.currentContext;
+    // final deviceName = device.name;
+    // NotificationService.instance.createNotification(
+    //   title: ctx?.l10n.deviceDisconnectedTitle(deviceName) ?? '$deviceName Disconnected',
+    //   body: ctx?.l10n.deviceDisconnectedBody(deviceName) ?? 'Please reconnect to continue using your $deviceName.',
+    // );
   }
 }


### PR DESCRIPTION
## Summary
- Comment out `_showDeviceDisconnectedNotification` body in `device_connection.dart` — it was being called from ~17 BLE/audio disconnect paths.
- Comment out the 30-second post-disconnect notification timer in `device_provider.dart`.
- Reason: too noisy. Easy to revert when we want them back.

## Test plan
- [ ] BLE disconnect no longer surfaces a system notification.
- [ ] App still functions normally when device disconnects (state still updates, UI reflects disconnect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)