### PR TITLE
feat(app): add Multi-language (Auto-detect) option to language picker

### DIFF
--- a/app/lib/providers/home_provider.dart
+++ b/app/lib/providers/home_provider.dart
@@ -52,6 +52,8 @@ class HomeProvider extends ChangeNotifier {
 
   // Available languages ordered by popularity
   final Map<String, String> availableLanguages = {
+    // Multi-language mode (auto-detect via Soniox)
+    'Multi-language (Auto-detect)': 'multi',
     // Top languages first
     'English': 'en',
     'English (US)': 'en-US',


### PR DESCRIPTION
## Summary

Adds the missing **Multi-language (Auto-detect)** option to the mobile app's language picker. The Omi backend already supports `'multi'` for automatic multi-language transcription via Soniox, but this option was not exposed in the mobile app's `availableLanguages` map.

This is a 2-line change (1 comment + 1 map entry) that closes the UI gap for users who need mid-conversation language switching.

## Motivation

Closes #4742 (partially — addresses the missing UI exposure on mobile).

Multi-language conversations are common in:
- International / immigrant households
- Academic and research environments
- Multinational workplaces
- Language learners

For example, my daily conversations as a PhD student in Japan involve Chinese (with my partner), Japanese (with advisors and lab members), and English (for technical terms). Currently, no single-language option in the app can handle this — picking any one language causes the others to be silently dropped.

The macOS desktop app already exposes a "Multilingual" option, but iOS / Android users have no equivalent.

## Backend Support (Already Exists)

The backend already routes `'multi'` correctly. Key references:

- `backend/utils/stt/pre_recorded.py:131` — `if language == 'multi':` branch
- `backend/utils/stt/streaming.py:142` — `get_stt_service_for_language()` handles multi mode
- `backend/routers/transcribe.py:308-324` — converts `'auto'` to `'multi'` for consistency
- Test coverage: `test_streaming_deepgram_backoff.py`, `test_voice_message_language.py`, `test_desktop_transcribe.py`

Backend documentation: https://docs.omi.me/doc/developer/backend/transcription

## Changes

**File:** `app/lib/providers/home_provider.dart`

```dart
final Map<String, String> availableLanguages = {
    // Multi-language mode (auto-detect via Soniox)
    'Multi-language (Auto-detect)': 'multi',
    // Top languages first
    'English': 'en',
    ...
};
```

The new entry is placed at the top of the map so it appears first in the picker (most visible position for the most useful new option).

## Risk Assessment

**Zero regression risk:**
- Pure additive change — no existing language options modified
- Map insertion — does not alter any function signatures
- Backend already validates and handles `'multi'`
- Users who don't select Multi see exactly the same behavior as before

## Testing

- ✅ Code review: change is logically equivalent to adding any other language option to the map
- ✅ Backend support verified via existing tests (see references above)
- ⚠️ Local Simulator testing not completed due to missing watchOS 26.4 Simulator runtime in my dev environment — happy to defer to CI
- ⚠️ Real-device testing pending — would appreciate maintainer verification with a paired pendant

## Related

- Closes / partially addresses #4742
- Aligns mobile parity with macOS desktop app (which already exposes Multilingual)