### PR TITLE
Remove device disconnected notifications from the mobile app

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -63,9 +63,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   Map<String, dynamic> _latestOmiGlassFirmwareDetails = {};
   Map<String, dynamic> get latestOmiGlassFirmwareDetails => _latestOmiGlassFirmwareDetails;
 
-  Timer? _disconnectNotificationTimer;
   Timer? _discoveryTimer;
-  bool _manualDisconnect = false;
   final Debouncer _disconnectDebouncer = Debouncer(delay: const Duration(milliseconds: 500));
   final Debouncer _connectDebouncer = Debouncer(delay: const Duration(milliseconds: 100));
 
@@ -109,7 +107,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   Future _bleDisconnectDevice(BtDevice btDevice) async {
-    _manualDisconnect = true;
     await ServiceManager.instance().device.disconnectDevice();
   }
 
@@ -380,22 +377,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       deviceType: 'omi',
       isConnected: false,
     );
-
-    if (_manualDisconnect) {
-      _manualDisconnect = false;
-      _disconnectNotificationTimer?.cancel();
-      return;
-    }
-
-    // Disabled: "Omi disconnected" notifications were too noisy.
-    // _disconnectNotificationTimer?.cancel();
-    // _disconnectNotificationTimer = Timer(const Duration(seconds: 30), () {
-    //   final ctx = globalNavigatorKey.currentContext;
-    //   NotificationService.instance.createNotification(
-    //     title: ctx?.l10n.deviceDisconnectedNotificationTitle ?? 'Your Omi Device Disconnected',
-    //     body: ctx?.l10n.deviceDisconnectedNotificationBody ?? 'Please reconnect to continue using your Omi.',
-    //   );
-    // });
   }
 
   Future<(String, bool, String, Map)> shouldUpdateFirmware() async {
@@ -420,8 +401,6 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   void _onDeviceConnected(BtDevice device) async {
     Logger.debug('_onConnected inside: $connectedDevice');
-    _disconnectNotificationTimer?.cancel();
-    NotificationService.instance.clearNotification(1);
     setConnectedDevice(device);
 
     if (captureProvider != null) {

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -19,9 +19,6 @@ import 'package:omi/services/devices/omi_connection.dart';
 import 'package:omi/services/devices/omiglass_connection.dart';
 import 'package:omi/services/devices/plaud_connection.dart';
 import 'package:omi/services/devices/wifi_sync_error.dart';
-import 'package:omi/app_globals.dart';
-import 'package:omi/services/notifications.dart';
-import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/services/devices/transports/device_transport.dart';
 import 'package:omi/services/devices/transports/ble_transport.dart';
 import 'package:omi/services/devices/transports/native_ble_transport.dart';
@@ -234,7 +231,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performRetrieveBatteryLevel();
     }
-    _showDeviceDisconnectedNotification();
     return -1;
   }
 
@@ -244,7 +240,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetBleBatteryLevelListener(onBatteryLevelChange: onBatteryLevelChange);
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -263,7 +258,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetBleAudioBytesListener(onAudioBytesReceived: onAudioBytesReceived);
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -301,7 +295,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetAudioCodec();
     }
-    _showDeviceDisconnectedNotification();
     return BleAudioCodec.pcm8;
   }
 
@@ -389,7 +382,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetStorageList();
     }
-    _showDeviceDisconnectedNotification();
     return Future.value(<int>[]);
   }
 
@@ -419,7 +411,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performWriteToStorage(numFile, command, offset);
     }
-    _showDeviceDisconnectedNotification();
     return Future.value(false);
   }
 
@@ -429,7 +420,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetBleStorageBytesListener(onStorageBytesReceived: onStorageBytesReceived);
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -441,7 +431,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performCameraStartPhotoController();
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -451,7 +440,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performCameraStopPhotoController();
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -461,7 +449,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performHasPhotoStreamingCharacteristic();
     }
-    _showDeviceDisconnectedNotification();
     return false;
   }
 
@@ -473,7 +460,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetImageListener(onImageReceived: onImageReceived);
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -485,7 +471,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetAccelListener(onAccelChange: onAccelChange);
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -497,7 +482,6 @@ abstract class DeviceConnection {
       _features = await performGetFeatures();
       return _features!;
     }
-    _showDeviceDisconnectedNotification();
     return 0;
   }
 
@@ -507,7 +491,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performSetLedDimRatio(ratio);
     }
-    _showDeviceDisconnectedNotification();
   }
 
   Future<void> performSetLedDimRatio(int ratio);
@@ -516,7 +499,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetLedDimRatio();
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -526,7 +508,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performSetMicGain(gain);
     }
-    _showDeviceDisconnectedNotification();
   }
 
   Future<void> performSetMicGain(int gain);
@@ -535,7 +516,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performGetMicGain();
     }
-    _showDeviceDisconnectedNotification();
     return null;
   }
 
@@ -577,7 +557,6 @@ abstract class DeviceConnection {
       return result;
     }
     debugPrint('DeviceConnection: startWifiSync - device disconnected, showing notification');
-    _showDeviceDisconnectedNotification();
     return false;
   }
 
@@ -589,7 +568,6 @@ abstract class DeviceConnection {
     if (await isConnected()) {
       return await performStopWifiSync();
     }
-    _showDeviceDisconnectedNotification();
     return false;
   }
 
@@ -610,13 +588,4 @@ abstract class DeviceConnection {
     return null;
   }
 
-  void _showDeviceDisconnectedNotification() {
-    // Disabled: "Omi disconnected" notifications were too noisy.
-    // final ctx = globalNavigatorKey.currentContext;
-    // final deviceName = device.name;
-    // NotificationService.instance.createNotification(
-    //   title: ctx?.l10n.deviceDisconnectedTitle(deviceName) ?? '$deviceName Disconnected',
-    //   body: ctx?.l10n.deviceDisconnectedBody(deviceName) ?? 'Please reconnect to continue using your $deviceName.',
-    // );
-  }
 }

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -587,5 +587,4 @@ abstract class DeviceConnection {
   }) async {
     return null;
   }
-
 }

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -4,7 +4,6 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:awesome_notifications/awesome_notifications.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -25,7 +24,6 @@ import 'package:omi/utils/logger.dart';
 class _FCMNotificationService implements NotificationInterface {
   _FCMNotificationService._();
 
-  MethodChannel platform = const MethodChannel('com.friend.ios/notifyOnKill');
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
 
   final channel = NotificationChannel(
@@ -118,16 +116,7 @@ class _FCMNotificationService implements NotificationInterface {
   }
 
   @override
-  Future<void> register() async {
-    try {
-      await platform.invokeMethod('setNotificationOnKillService', {
-        'title': "Your Omi Device Disconnected",
-        'description': "Please keep your app opened to continue using your Omi.",
-      });
-    } catch (e) {
-      Logger.debug('NotifOnKill error: $e');
-    }
-  }
+  Future<void> register() async {}
 
   @override
   Future<String> getTimeZone() async {


### PR DESCRIPTION
## Summary
- Drops the local notification scheduled 30s after BLE disconnect (`device_provider.dart`) and its `_disconnectNotificationTimer` / `_manualDisconnect` bookkeeping
- Drops `_showDeviceDisconnectedNotification()` and its 18 call sites across BLE retrieve/listener/codec/storage paths in `device_connection.dart`, plus the imports that became dead
- Empties FCM `register()` so the native `setNotificationOnKillService` channel is no longer invoked with the "Your Omi Device Disconnected" payload

Low-battery notification (<20%, fires once per drop-below-threshold, resets above 20% or on reconnect) is unchanged.

## Test plan
- [ ] Pair Omi, walk out of range → no "Omi Disconnected" notification appears (foreground or background)
- [ ] Kill the app while Omi is connected → no kill-time disconnect notification
- [ ] Force a BLE op while disconnected (e.g., battery read) → silent `-1` return, no notification
- [ ] Drop battery below 20% → low-battery notification still fires (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)