### PR TITLE
Vector-based dedup for action item extraction

### DIFF
--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -492,13 +492,23 @@ def find_similar_action_items(uid: str, query: str, threshold: float = 0.6, limi
             namespace=ACTION_ITEMS_NAMESPACE,
         )
         matches = xc.get('matches', [])
-        kept = [m for m in matches if m.get('score', 0.0) >= threshold]
+        kept = []
+        dropped_no_id = 0
+        for m in matches:
+            if m.get('score', 0.0) < threshold:
+                continue
+            aid = m.get('metadata', {}).get('action_item_id')
+            if not aid:
+                dropped_no_id += 1
+                continue
+            kept.append({'action_item_id': aid, 'score': m.get('score', 0.0)})
         top_score = matches[0]['score'] if matches else None
         logger.info(
             f'find_similar_action_items uid={uid} matches={len(matches)} '
-            f'kept={len(kept)} top_score={top_score} threshold={threshold}'
+            f'kept={len(kept)} dropped_no_id={dropped_no_id} '
+            f'top_score={top_score} threshold={threshold}'
         )
-        return [{'action_item_id': m['metadata'].get('action_item_id'), 'score': m.get('score', 0.0)} for m in kept]
+        return kept
     except Exception as e:
         logger.exception(f'find_similar_action_items failed uid={uid}: {e}')
         return []

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -467,6 +467,43 @@ def search_action_items_by_vector(uid: str, query: str, limit: int = 10, min_sco
     return [m['metadata'].get('action_item_id') for m in kept]
 
 
+def find_similar_action_items(uid: str, query: str, threshold: float = 0.6, limit: int = 10) -> List[dict]:
+    """
+    Find action items semantically similar to the given query text. Used to
+    feed the conversation extraction prompt with potentially-duplicate open
+    tasks so the LLM can suppress true duplicates.
+
+    Returns matches at or above the threshold. Each result is
+    `{'action_item_id': str, 'score': float}` ordered by Pinecone relevance.
+    Pinecone or embedding failures degrade silently to an empty list — the
+    caller treats "no candidates" as "user has nothing relevant," which is
+    the same behavior as a brand-new user.
+    """
+    if index is None:
+        return []
+
+    try:
+        vector = embeddings.embed_query(query)
+        xc = index.query(
+            vector=vector,
+            top_k=limit,
+            include_metadata=True,
+            filter={'uid': uid},
+            namespace=ACTION_ITEMS_NAMESPACE,
+        )
+        matches = xc.get('matches', [])
+        kept = [m for m in matches if m.get('score', 0.0) >= threshold]
+        top_score = matches[0]['score'] if matches else None
+        logger.info(
+            f'find_similar_action_items uid={uid} matches={len(matches)} '
+            f'kept={len(kept)} top_score={top_score} threshold={threshold}'
+        )
+        return [{'action_item_id': m['metadata'].get('action_item_id'), 'score': m.get('score', 0.0)} for m in kept]
+    except Exception as e:
+        logger.exception(f'find_similar_action_items failed uid={uid}: {e}')
+        return []
+
+
 def delete_action_item_vector(uid: str, action_item_id: str):
     if index is None:
         logger.warning('Pinecone index not initialized, skipping action item vector delete')

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -58,6 +58,7 @@ pytest tests/unit/test_ws_auth_handshake.py -v
 pytest tests/unit/test_streaming_deepgram_backoff.py -v
 pytest tests/unit/test_batch_upload_storage.py -v
 pytest tests/unit/test_action_item_date_validation.py -v
+pytest tests/unit/test_action_item_dedup.py -v
 pytest tests/unit/test_tools_router.py -v
 pytest tests/unit/test_kg_user_type_mismatch.py -v
 pytest tests/unit/test_kg_edge_id_sanitization.py -v

--- a/backend/tests/unit/test_action_item_dedup.py
+++ b/backend/tests/unit/test_action_item_dedup.py
@@ -165,3 +165,23 @@ class TestFindSimilarActionItems:
         result = vector_db.find_similar_action_items('uid-abc', 'something')
 
         assert [r['action_item_id'] for r in result] == ['first', 'second', 'third']
+
+    def test_drops_matches_with_missing_action_item_id(self, monkeypatch):
+        """A malformed Pinecone match (missing/empty action_item_id metadata) must be
+        dropped per-match, not poison the whole dedup context. Returning None as an id
+        would crash get_action_items_by_ids downstream."""
+        response = {
+            'matches': [
+                {'metadata': {'action_item_id': 'good-1'}, 'score': 0.90},
+                {'metadata': {}, 'score': 0.85},  # missing action_item_id
+                {'metadata': {'action_item_id': None}, 'score': 0.80},  # explicit None
+                {'metadata': {'action_item_id': ''}, 'score': 0.75},  # empty string
+                {'metadata': {'action_item_id': 'good-2'}, 'score': 0.70},
+            ]
+        }
+        _setup_mocks(monkeypatch, query_response=response)
+
+        result = vector_db.find_similar_action_items('uid-abc', 'q')
+
+        assert [r['action_item_id'] for r in result] == ['good-1', 'good-2']
+        assert all(r['action_item_id'] for r in result)

--- a/backend/tests/unit/test_action_item_dedup.py
+++ b/backend/tests/unit/test_action_item_dedup.py
@@ -1,0 +1,167 @@
+"""
+Tests for find_similar_action_items — the helper that powers semantic dedup
+during conversation extraction.
+
+Critical contract: the helper must (a) return [] when Pinecone isn't
+configured, (b) filter matches below the threshold, (c) swallow Pinecone
+exceptions and return [] (so a Pinecone outage degrades to "no dedup
+context" rather than failing the whole conversation pipeline), and
+(d) preserve match order from Pinecone (most-similar first).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Stub heavy deps before importing vector_db. Same pattern as test_memories_batch.
+for mod_name in [
+    'pinecone',
+    'firebase_admin',
+    'firebase_admin.auth',
+    'google',
+    'google.cloud',
+    'google.cloud.firestore',
+]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+sys.modules['pinecone'].Pinecone = MagicMock
+
+
+class _FakeFirestoreClient:
+    def collection(self, *a, **kw):
+        return MagicMock()
+
+    def batch(self):
+        return MagicMock()
+
+
+sys.modules['google.cloud.firestore'].Client = _FakeFirestoreClient
+sys.modules['google.cloud.firestore'].ArrayUnion = MagicMock
+sys.modules['google.cloud.firestore'].ArrayRemove = MagicMock
+sys.modules['google.cloud.firestore'].Increment = MagicMock
+sys.modules['google.cloud.firestore'].SERVER_TIMESTAMP = object()
+sys.modules['google.cloud.firestore'].DELETE_FIELD = object()
+sys.modules['google.cloud.firestore'].FieldFilter = MagicMock
+sys.modules['google.cloud.firestore'].Query = MagicMock
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+if 'utils.llm.clients' not in sys.modules:
+    clients_stub = types.ModuleType('utils.llm.clients')
+    clients_stub.embeddings = MagicMock()
+    sys.modules['utils.llm.clients'] = clients_stub
+
+
+from database import vector_db  # noqa: E402
+
+
+def _setup_mocks(monkeypatch, *, index_none=False, query_response=None, embed_raises=None, query_raises=None):
+    fake_index = MagicMock()
+    if query_raises is not None:
+        fake_index.query = MagicMock(side_effect=query_raises)
+    else:
+        fake_index.query = MagicMock(return_value=query_response or {'matches': []})
+    monkeypatch.setattr(vector_db, 'index', None if index_none else fake_index)
+
+    fake_embeddings = MagicMock()
+    if embed_raises is not None:
+        fake_embeddings.embed_query = MagicMock(side_effect=embed_raises)
+    else:
+        fake_embeddings.embed_query = MagicMock(return_value=[0.1, 0.2, 0.3])
+    monkeypatch.setattr(vector_db, 'embeddings', fake_embeddings)
+    return fake_index, fake_embeddings
+
+
+class TestFindSimilarActionItems:
+    def test_returns_empty_when_pinecone_not_configured(self, monkeypatch):
+        """No-op cleanly when Pinecone isn't initialized (tests, local dev, env-var-missing)."""
+        _, fake_embeddings = _setup_mocks(monkeypatch, index_none=True)
+
+        result = vector_db.find_similar_action_items('uid-abc', 'buy milk')
+
+        assert result == []
+        # Embedding call must not happen — no point spending OpenAI tokens if Pinecone is down.
+        fake_embeddings.embed_query.assert_not_called()
+
+    def test_filters_below_threshold(self, monkeypatch):
+        """Threshold defines what counts as a candidate; everything below is dropped."""
+        response = {
+            'matches': [
+                {'metadata': {'action_item_id': 'a1'}, 'score': 0.92},
+                {'metadata': {'action_item_id': 'a2'}, 'score': 0.71},
+                {'metadata': {'action_item_id': 'a3'}, 'score': 0.45},  # below default 0.6
+                {'metadata': {'action_item_id': 'a4'}, 'score': 0.10},  # below default 0.6
+            ]
+        }
+        _setup_mocks(monkeypatch, query_response=response)
+
+        result = vector_db.find_similar_action_items('uid-abc', 'buy milk')
+
+        assert [r['action_item_id'] for r in result] == ['a1', 'a2']
+        assert [r['score'] for r in result] == [0.92, 0.71]
+
+    def test_threshold_param_is_respected(self, monkeypatch):
+        """Caller can tighten or loosen by passing threshold."""
+        response = {
+            'matches': [
+                {'metadata': {'action_item_id': 'a1'}, 'score': 0.92},
+                {'metadata': {'action_item_id': 'a2'}, 'score': 0.71},
+                {'metadata': {'action_item_id': 'a3'}, 'score': 0.45},
+            ]
+        }
+        _setup_mocks(monkeypatch, query_response=response)
+
+        result = vector_db.find_similar_action_items('uid-abc', 'buy milk', threshold=0.85)
+
+        assert [r['action_item_id'] for r in result] == ['a1']
+
+    def test_limit_param_passed_to_pinecone(self, monkeypatch):
+        """limit drives top_k on the Pinecone query."""
+        fake_index, _ = _setup_mocks(monkeypatch, query_response={'matches': []})
+
+        vector_db.find_similar_action_items('uid-abc', 'buy milk', limit=25)
+
+        kwargs = fake_index.query.call_args.kwargs
+        assert kwargs['top_k'] == 25
+        assert kwargs['namespace'] == vector_db.ACTION_ITEMS_NAMESPACE
+        assert kwargs['filter'] == {'uid': 'uid-abc'}
+
+    def test_pinecone_exception_returns_empty(self, monkeypatch):
+        """A Pinecone outage must not fail the conversation pipeline."""
+        _setup_mocks(monkeypatch, query_raises=RuntimeError('pinecone is down'))
+
+        result = vector_db.find_similar_action_items('uid-abc', 'buy milk')
+
+        assert result == []
+
+    def test_embedding_exception_returns_empty(self, monkeypatch):
+        """An OpenAI embeddings outage must not fail the conversation pipeline."""
+        _setup_mocks(monkeypatch, embed_raises=RuntimeError('openai is down'))
+
+        result = vector_db.find_similar_action_items('uid-abc', 'buy milk')
+
+        assert result == []
+
+    def test_empty_query_still_calls_pinecone(self, monkeypatch):
+        """The helper itself doesn't gate on empty query — that's the caller's concern.
+        Embedding an empty string is harmless; Pinecone returns no matches; helper returns []."""
+        _setup_mocks(monkeypatch, query_response={'matches': []})
+
+        result = vector_db.find_similar_action_items('uid-abc', '')
+
+        assert result == []
+
+    def test_preserves_pinecone_match_order(self, monkeypatch):
+        """Pinecone returns matches sorted by relevance; we must not re-order."""
+        response = {
+            'matches': [
+                {'metadata': {'action_item_id': 'first'}, 'score': 0.95},
+                {'metadata': {'action_item_id': 'second'}, 'score': 0.85},
+                {'metadata': {'action_item_id': 'third'}, 'score': 0.70},
+            ]
+        }
+        _setup_mocks(monkeypatch, query_response=response)
+
+        result = vector_db.find_similar_action_items('uid-abc', 'something')
+
+        assert [r['action_item_id'] for r in result] == ['first', 'second', 'third']

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -26,6 +26,7 @@ from database.vector_db import (
     delete_memory_vector,
     upsert_action_item_vectors_batch,
     delete_action_item_vectors_batch,
+    find_similar_action_items,
 )
 from utils.llm.memories import resolve_memory_conflict
 from database.apps import record_app_usage, get_omi_personas_by_uid_db, get_app_by_id_db
@@ -83,6 +84,44 @@ from utils.other.storage import precache_conversation_audio
 logger = logging.getLogger(__name__)
 
 
+def _fetch_dedup_candidates(uid: str, structured: Structured) -> List[dict]:
+    """
+    Fetch open action items semantically related to this conversation, active
+    in the past week, for the LLM extraction prompt to consider as potential
+    duplicates. Replaces the older time-windowed fetch (past 2 days, limit
+    50). Returns [] if Pinecone is down or there's no overview to query —
+    extraction then proceeds with no dedup context, same as for a new user.
+    """
+    if not structured or not structured.overview:
+        return []
+
+    try:
+        similar = find_similar_action_items(uid, structured.overview, threshold=0.6, limit=10)
+        if not similar:
+            return []
+
+        items = action_items_db.get_action_items_by_ids(uid, [s['action_item_id'] for s in similar])
+        cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+
+        eligible = []
+        for item in items:
+            if item.get('completed', False):
+                continue
+            last_active = item.get('updated_at') or item.get('created_at')
+            if last_active is None or last_active < cutoff:
+                continue
+            eligible.append(item)
+
+        logger.info(
+            f'dedup_candidates uid={uid} similar={len(similar)} '
+            f'eligible={len(eligible)} top_score={similar[0]["score"]}'
+        )
+        return eligible
+    except Exception as e:
+        logger.exception(f'_fetch_dedup_candidates failed uid={uid}: {e}')
+        return []
+
+
 def _get_structured(
     uid: str,
     language_code: str,
@@ -93,14 +132,6 @@ def _get_structured(
     try:
         tz = notification_db.get_user_time_zone(uid)
         user_language = users_db.get_user_language_preference(uid) or language_code
-
-        # Fetch existing action items from past 2 days for deduplication
-        existing_action_items = None
-        try:
-            two_days_ago = datetime.now(timezone.utc) - timedelta(days=2)
-            existing_action_items = action_items_db.get_action_items(uid=uid, start_date=two_days_ago, limit=50)
-        except Exception as e:
-            logger.error(f"Error fetching existing action items for deduplication: {e}")
 
         # Extract calendar context from external_data
         calendar_context = None
@@ -129,7 +160,7 @@ def _get_structured(
                         conversation.started_at,
                         language_code,
                         tz,
-                        existing_action_items=existing_action_items,
+                        existing_action_items=_fetch_dedup_candidates(uid, structured),
                         calendar_meeting_context=calendar_context,
                         output_language_code=user_language,
                     )
@@ -177,7 +208,7 @@ def _get_structured(
                     language_code,
                     tz,
                     photos=conversation.photos,
-                    existing_action_items=existing_action_items,
+                    existing_action_items=_fetch_dedup_candidates(uid, structured),
                     output_language_code=user_language,
                 )
             return structured, False
@@ -211,7 +242,7 @@ def _get_structured(
                 language_code,
                 tz,
                 photos=conversation.photos,
-                existing_action_items=existing_action_items,
+                existing_action_items=_fetch_dedup_candidates(uid, structured),
                 calendar_meeting_context=calendar_context,
                 output_language_code=user_language,
             )

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -317,7 +317,10 @@ def extract_action_items(
         language_code: Language code for the conversation
         tz: User's timezone
         photos: Optional conversation photos
-        existing_action_items: Recent action items for deduplication (from past 2 days)
+        existing_action_items: Open action items semantically related to this
+            conversation (top vector matches, recently active). Caller is
+            expected to pre-filter to open items only; this function defends
+            in depth by skipping any item that arrives marked completed.
 
     Returns:
         List of extracted ActionItem objects
@@ -330,16 +333,21 @@ def extract_action_items(
     if existing_action_items:
         items_list = []
         for item in existing_action_items:
+            # Defensive: the rendered section is "OPEN TASKS"; a completed item
+            # leaking through (e.g. a future caller that doesn't pre-filter)
+            # would mislead the LLM into suppressing valid new tasks.
+            if item.get('completed', False):
+                continue
             desc = item.get('description', '')
             due = item.get('due_at')
             due_str = due.strftime('%Y-%m-%d %H:%M UTC') if due else 'No due date'
-            completed = '✓ Completed' if item.get('completed', False) else 'Pending'
-            items_list.append(f"  • {desc} (Due: {due_str}) [{completed}]")
+            items_list.append(f"  • {desc} (Due: {due_str})")
 
-        existing_items_context = (
-            f"\n\nPOTENTIALLY RELATED OPEN TASKS — recently active, semantically similar ({len(items_list)} items):\n"
-            + "\n".join(items_list)
-        )
+        if items_list:
+            existing_items_context = (
+                f"\n\nPOTENTIALLY RELATED OPEN TASKS — recently active, semantically similar ({len(items_list)} items):\n"
+                + "\n".join(items_list)
+            )
 
     # First system message: task-specific instructions (static prefix enables cross-conversation caching)
     # NOTE: {language_code} is in the context message, not here, to keep this prefix fully static across all languages.

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -336,8 +336,9 @@ def extract_action_items(
             completed = '✓ Completed' if item.get('completed', False) else 'Pending'
             items_list.append(f"  • {desc} (Due: {due_str}) [{completed}]")
 
-        existing_items_context = f"\n\nEXISTING ACTION ITEMS FROM PAST 2 DAYS ({len(items_list)} items):\n" + "\n".join(
-            items_list
+        existing_items_context = (
+            f"\n\nPOTENTIALLY RELATED OPEN TASKS — recently active, semantically similar ({len(items_list)} items):\n"
+            + "\n".join(items_list)
         )
 
     # First system message: task-specific instructions (static prefix enables cross-conversation caching)
@@ -353,21 +354,23 @@ def extract_action_items(
     - Consider the scheduled meeting time and duration when extracting due dates
     - If you cannot confidently match a speaker to a name, use the action description without speaker references
 
-    CRITICAL DEDUPLICATION RULES (Check BEFORE extracting):
-    • DO NOT extract action items that are >95% similar to existing ones in the content
-    • Check both the description AND the due date/timeframe
-    • Consider semantic similarity, not just exact word matches
-    • Examples of what counts as DUPLICATES (DO NOT extract):
-      - "Call John" vs "Phone John" → DUPLICATE
-      - "Finish report by Friday" (existing) vs "Complete report by end of week" → DUPLICATE
-      - "Buy milk" (existing) vs "Get milk from store" → DUPLICATE
-      - "Email Sarah about meeting" (existing) vs "Send email to Sarah regarding the meeting" → DUPLICATE
-    • Examples of what is NOT duplicate (OK to extract):
-      - "Buy groceries" (existing) vs "Buy milk" → NOT duplicate (different scope)
-      - "Call dentist" (existing) vs "Call plumber" → NOT duplicate (different person/service)
-      - "Submit report by March 1st" (existing) vs "Submit report by March 15th" → NOT duplicate (different deadlines)
-    • If you're unsure whether something is a duplicate, err on the side of treating it as a duplicate (DON'T extract)
-    • SINGLE-TOPIC LIMIT: If a conversation discusses one topic, extract AT MOST 1 action item for it — not one per variation, option, or detail mentioned in the discussion.
+    DEDUPLICATION RULES — be conservative about suppressing:
+    • The "POTENTIALLY RELATED OPEN TASKS" section lists open items recently active in the user's task list, semantically similar to this conversation. They may or may not be true duplicates.
+    • Only suppress a candidate if you are 100% confident the existing task captures this EXACT intent and the user is just re-mentioning it (not re-doing it).
+    • EXTRACT (do not suppress) when the user signals re-occurrence or distinct scope:
+      - Re-occurrence cues: "again", "another", "still need to", "I forgot to", "more", "one more"
+      - Different person, scope, or deadline ("Submit report by March 1" vs "Submit report by April 15" — different deadlines, both valid)
+      - Existing item describes a one-off task that's already in progress; user is starting a new instance
+    • If user says "I did X" / "I just X'd" / "X is done" / "X is taken care of": DO NOT extract a new item AND do not modify the existing one — just leave it (auto-completion of existing tasks is out of scope here).
+    • Examples of true DUPLICATES (suppress):
+      - "Call John" said today, existing open "Call John" from this morning, no new context → DUPLICATE
+      - "Email Sarah about meeting" said today, existing "Email Sarah about meeting" still open → DUPLICATE (same intent re-mentioned)
+    • Examples of NOT duplicates (extract anyway):
+      - Existing: "Buy milk" (open). User says "I need to buy more milk" → EXTRACT (re-occurrence cue)
+      - Existing: "Submit report by March 1" (open). User says "Submit report by April 15" → EXTRACT (different deadline)
+      - Existing: "Call dentist" (open). User says "Call plumber" → EXTRACT (different scope)
+    • When unsure → EXTRACT. A duplicate the user can delete is recoverable; a silently-suppressed real task is not.
+    • SINGLE-TOPIC LIMIT: Within THIS conversation, extract AT MOST 1 action item per topic — not one per variation, option, or detail. (This rule applies within the current transcript, not across conversations.)
 
     WORKFLOW:
     1. FIRST: Read the ENTIRE conversation carefully to understand the full context


### PR DESCRIPTION
## Summary

- Replaces the time-windowed (past 2 days, limit 50) Firestore fetch for dedup candidates with semantic retrieval against the action item vector index (`ns4`). An open task from 3+ weeks ago that the user re-mentions today is now visible to the LLM extraction prompt — previously invisible, would have created a duplicate.
- Tightens the eligibility filter to **open items active in the past 7 days**. Completed items don't suppress new mentions (re-occurrence after completion is valid). Stale items (no activity in a week) drop out.
- Flips the prompt dedup rule from "err toward duplicate (DON'T extract)" to "err toward extracting" — protects against silently dropping legitimate re-occurrences (chores, recurring intent, "I forgot to" mentions, different deadlines/scope).
- No auto-update, no auto-complete, no cross-conversation merge, no CRUD-path dedup. Those are explicit out-of-scope decisions tracked as future work.

## Background

`ns4` was populated for all 1.68M production action items via the recently-shipped backfill, but the conversation extraction pipeline was still doing time-windowed Firestore reads. This PR consumes the index for its primary intended purpose.

Plan doc with rationale, alternatives considered (multi-phase reconcile pipeline, auto-update, auto-complete) and why they're out of scope: see commit messages.

## Test plan

- [x] Unit tests for `find_similar_action_items` (8 cases): Pinecone unconfigured → `[]`; threshold filters; limit param wired; embedding failure → `[]`; Pinecone failure → `[]`; preserves match order; threshold param respected; empty query handled.
- [x] Existing `test_action_item_date_validation.py` (21 cases) still passes.
- [ ] Smoke against staging/dev backend: `POST /v1/dev/user/conversations` with text that mentions an existing open task; grep logs for `dedup_candidates uid=... similar=N eligible=M top_score=...`; confirm LLM either suppresses (true match) or extracts with awareness (re-occurrence / different scope).
- [ ] First-week prod observability: tail logs for `dedup_candidates` line, plot `top_score` distribution, validate that 0.6 cosine threshold is the right cut. Adjust constant in `find_similar_action_items` if the data says otherwise.
- [ ] Spot-check 20 random conversations pre/post-deploy for extraction quality regression (suppressing real duplicates ✓, preserving valid re-occurrences ✓).

## Notes for reviewer

- Three commits, each independently revertable: helper + tests / wire-in / prompt rewrite.
- The prompt rewrite **busts the OpenAI prompt cache once on deploy** (it lives in `instructions_text`, the cached prefix). One-time cost; cache rebuilds within the first hour. The rendered candidates list lives in the dynamic `context_message` (second system message), so per-conversation churn doesn't bust cache.
- Pinecone or embedding failures degrade to `[]` (no dedup context) — same path as a brand-new user. Conversation pipeline never fails on dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)