### PR TITLE
feat(memories): add batch delete API to fix 429 rate limit on bulk selection

### DIFF
--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -254,6 +254,15 @@ def delete_memory(uid: str, memory_id: str):
     memory_ref.delete()
 
 
+def delete_memories_batch(uid: str, memory_ids: List[str]):
+    user_ref = db.collection(users_collection).document(uid)
+    memories_ref = user_ref.collection(memories_collection)
+    batch = db.batch()
+    for memory_id in memory_ids:
+        batch.delete(memories_ref.document(memory_id))
+    batch.commit()
+
+
 def delete_all_memories(uid: str):
     user_ref = db.collection(users_collection).document(uid)
     memories_ref = user_ref.collection(memories_collection)

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -289,6 +289,17 @@ def delete_memory_vector(uid: str, memory_id: str):
     logger.info(f'delete_memory_vector {vector_id} {result}')
 
 
+def delete_memory_vectors_batch(uid: str, memory_ids: List[str]):
+    if index is None:
+        logger.warning('Pinecone index not initialized, skipping memory vector batch delete')
+        return
+    if not memory_ids:
+        return
+    vector_ids = [f'{uid}-{mid}' for mid in memory_ids]
+    index.delete(ids=vector_ids, namespace=MEMORIES_NAMESPACE)
+    logger.info(f'delete_memory_vectors_batch uid={uid} count={len(vector_ids)}')
+
+
 # ==========================================
 # Screen Activity Vector Functions
 # For screenshot embeddings (Gemini embedding-001, 3072-dim)

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -175,17 +175,22 @@ def delete_memories_batch(
     data: BatchDeleteMemoriesRequest,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:delete_batch")),
 ):
-    if not data.memory_ids:
+    # Deduplicate to avoid double-counting and redundant Firestore ops
+    unique_ids = list(dict.fromkeys(data.memory_ids))
+    if not unique_ids:
         return {'status': 'ok', 'deleted_count': 0}
-    # Validate ownership of all memories before deleting any
-    for memory_id in data.memory_ids:
-        _validate_memory(uid, memory_id)
-    memories_db.delete_memories_batch(uid, data.memory_ids)
+    # Validate ownership with a single Firestore batch-get instead of N serial reads
+    fetched = memories_db.get_memories_by_ids(uid, unique_ids)
+    fetched_ids = {m['id'] for m in fetched}
+    missing = [mid for mid in unique_ids if mid not in fetched_ids]
+    if missing:
+        raise HTTPException(status_code=404, detail=f"Memories not found or not owned: {missing}")
+    memories_db.delete_memories_batch(uid, unique_ids)
     try:
-        delete_memory_vectors_batch(uid, data.memory_ids)
+        delete_memory_vectors_batch(uid, unique_ids)
     except Exception:
-        logger.exception("Vector batch delete failed uid=%s count=%d (Firestore deleted)", uid, len(data.memory_ids))
-    return {'status': 'ok', 'deleted_count': len(data.memory_ids)}
+        logger.exception("Vector batch delete failed uid=%s count=%d (Firestore deleted)", uid, len(unique_ids))
+    return {'status': 'ok', 'deleted_count': len(unique_ids)}
 
 
 @router.delete('/v3/memories/{memory_id}', tags=['memories'])

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, ValidationError
 import database.memories as memories_db
 from database.vector_db import (
     delete_memory_vector,
+    delete_memory_vectors_batch,
     upsert_memory_vector,
     upsert_memory_vectors_batch,
 )
@@ -36,6 +37,13 @@ class BatchMemoriesRequest(BaseModel):
 class BatchMemoriesResponse(BaseModel):
     memories: List[MemoryDB]
     created_count: int
+
+
+class BatchDeleteMemoriesRequest(BaseModel):
+    memory_ids: List[str] = Field(
+        description="List of memory IDs to delete",
+        max_length=MEMORIES_BATCH_MAX,
+    )
 
 
 def _validate_memory(uid: str, memory_id: str) -> dict:
@@ -160,6 +168,24 @@ def get_memories(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_
             )
             continue
     return valid_memories
+
+
+@router.delete('/v3/memories/batch', tags=['memories'])
+def delete_memories_batch(
+    data: BatchDeleteMemoriesRequest,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:delete_batch")),
+):
+    if not data.memory_ids:
+        return {'status': 'ok', 'deleted_count': 0}
+    # Validate ownership of all memories before deleting any
+    for memory_id in data.memory_ids:
+        _validate_memory(uid, memory_id)
+    memories_db.delete_memories_batch(uid, data.memory_ids)
+    try:
+        delete_memory_vectors_batch(uid, data.memory_ids)
+    except Exception:
+        logger.exception("Vector batch delete failed uid=%s count=%d (Firestore deleted)", uid, len(data.memory_ids))
+    return {'status': 'ok', 'deleted_count': len(data.memory_ids)}
 
 
 @router.delete('/v3/memories/{memory_id}', tags=['memories'])

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -62,6 +62,8 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "memories:modify": (120, 3600),
     # Memory deletes — destructive operations
     "memories:delete": (60, 3600),
+    # Batch delete — each request can remove up to 100 memories
+    "memories:delete_batch": (10, 3600),
     # Delete-all is extremely destructive; tight cap with one retry cushion
     "memories:delete_all": (2, 3600),
     # Goals — single LLM call

--- a/web/app/src/app/api/proxy/[...path]/route.ts
+++ b/web/app/src/app/api/proxy/[...path]/route.ts
@@ -72,7 +72,7 @@ async function handleRequest(
       headers['X-Device-Id-Hash'] = deviceIdHash;
     }
 
-    if (!isMultipart && request.method !== 'GET' && request.method !== 'DELETE') {
+    if (!isMultipart && request.method !== 'GET') {
       headers['Content-Type'] = 'application/json';
     }
 
@@ -81,8 +81,8 @@ async function handleRequest(
       headers,
     };
 
-    // Include body for POST/PATCH requests
-    if (request.method === 'POST' || request.method === 'PATCH') {
+    // Include body for POST/PATCH/DELETE requests
+    if (request.method === 'POST' || request.method === 'PATCH' || request.method === 'DELETE') {
       if (isMultipart) {
         // For multipart, forward the FormData directly
         const formData = await request.formData();

--- a/web/app/src/components/memories/MemoriesPage.tsx
+++ b/web/app/src/components/memories/MemoriesPage.tsx
@@ -53,6 +53,7 @@ export function MemoriesPage() {
     addMemory,
     editMemory,
     removeMemory,
+    removeMemories,
     toggleVisibility,
     acceptMemory,
     rejectMemory,
@@ -299,16 +300,14 @@ export function MemoriesPage() {
   const executeBulkDelete = useCallback(async () => {
     setIsDeleting(true);
     try {
-      // Delete each selected memory
-      const deletePromises = selectedIds.map((id) => removeMemory(id));
-      await Promise.all(deletePromises);
+      await removeMemories(selectedIds);
       setSelectedIds([]);
       setIsSelectMode(false);
       setShowDeleteConfirm(false);
     } finally {
       setIsDeleting(false);
     }
-  }, [selectedIds, removeMemory]);
+  }, [selectedIds, removeMemories]);
 
   // Handle copy to clipboard
   const handleCopy = useCallback(async () => {

--- a/web/app/src/components/memories/MemoriesPage.tsx
+++ b/web/app/src/components/memories/MemoriesPage.tsx
@@ -300,10 +300,12 @@ export function MemoriesPage() {
   const executeBulkDelete = useCallback(async () => {
     setIsDeleting(true);
     try {
-      await removeMemories(selectedIds);
-      setSelectedIds([]);
-      setIsSelectMode(false);
-      setShowDeleteConfirm(false);
+      const success = await removeMemories(selectedIds);
+      if (success) {
+        setSelectedIds([]);
+        setIsSelectMode(false);
+        setShowDeleteConfirm(false);
+      }
     } finally {
       setIsDeleting(false);
     }

--- a/web/app/src/hooks/useMemories.ts
+++ b/web/app/src/hooks/useMemories.ts
@@ -398,13 +398,16 @@ export function useMemories(options: UseMemoriesOptions = {}): UseMemoriesReturn
     }
   }, [activeCategories]);
 
-  // Remove multiple memories via batch API
+  // Remove multiple memories via batch API (chunks of 100 to respect server limit)
   const removeMemories = useCallback(async (ids: string[]): Promise<boolean> => {
     if (ids.length === 0) return true;
     const key = getCacheKey(activeCategories);
+    const CHUNK_SIZE = 100;
     try {
       const idSet = new Set(ids);
-      await deleteMemoriesBatch(ids);
+      for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+        await deleteMemoriesBatch(ids.slice(i, i + CHUNK_SIZE));
+      }
       const updater = (prev: Memory[]) => prev.filter((m) => !idSet.has(m.id));
       setMemories(updater);
       updateCacheMemories(key, updater);

--- a/web/app/src/hooks/useMemories.ts
+++ b/web/app/src/hooks/useMemories.ts
@@ -8,6 +8,7 @@ import {
   updateMemoryContent,
   updateMemoryVisibility,
   deleteMemory,
+  deleteMemoriesBatch,
   reviewMemory,
 } from '@/lib/api';
 import {
@@ -36,6 +37,7 @@ export interface UseMemoriesReturn {
   addMemory: (content: string, visibility?: MemoryVisibility) => Promise<Memory | null>;
   editMemory: (id: string, content: string) => Promise<boolean>;
   removeMemory: (id: string) => Promise<boolean>;
+  removeMemories: (ids: string[]) => Promise<boolean>;
   toggleVisibility: (id: string, visibility: MemoryVisibility) => Promise<boolean>;
   acceptMemory: (id: string) => Promise<boolean>;
   rejectMemory: (id: string) => Promise<boolean>;
@@ -396,6 +398,23 @@ export function useMemories(options: UseMemoriesOptions = {}): UseMemoriesReturn
     }
   }, [activeCategories]);
 
+  // Remove multiple memories via batch API
+  const removeMemories = useCallback(async (ids: string[]): Promise<boolean> => {
+    if (ids.length === 0) return true;
+    const key = getCacheKey(activeCategories);
+    try {
+      const idSet = new Set(ids);
+      await deleteMemoriesBatch(ids);
+      const updater = (prev: Memory[]) => prev.filter((m) => !idSet.has(m.id));
+      setMemories(updater);
+      updateCacheMemories(key, updater);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete memories');
+      return false;
+    }
+  }, [activeCategories]);
+
   // Toggle visibility
   const toggleVisibility = useCallback(async (
     id: string,
@@ -466,6 +485,7 @@ export function useMemories(options: UseMemoriesOptions = {}): UseMemoriesReturn
     addMemory,
     editMemory,
     removeMemory,
+    removeMemories,
     toggleVisibility,
     acceptMemory,
     rejectMemory,

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -477,6 +477,18 @@ export async function deleteMemory(id: string): Promise<void> {
 }
 
 /**
+ * Delete multiple memories in a single batch request
+ */
+export async function deleteMemoriesBatch(ids: string[]): Promise<void> {
+  await fetchWithAuth(`/v3/memories/batch`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ memory_ids: ids }),
+  });
+  invalidateCache(invalidationPatterns.memories);
+}
+
+/**
  * Review a memory (accept or reject)
  */
 export async function reviewMemory(id: string, accept: boolean): Promise<void> {


### PR DESCRIPTION
## Summary

When selecting multiple memories in the web UI and clicking Delete, the frontend was sending individual `DELETE /v3/memories/{id}` requests concurrently via `Promise.all()`. With 50+ memories selected this immediately hits the rate limiter and returns 429 errors.

This PR introduces a batch delete API and updates the web frontend to use it.

- **Backend**: new `DELETE /v3/memories/batch` endpoint — accepts up to 100 memory IDs, validates ownership of all IDs, deletes from Firestore in a single batch write, removes Pinecone vectors in one batch call
- **Frontend**: new `deleteMemoriesBatch()` API helper, `removeMemories()` hook method, and `executeBulkDelete` updated to issue a single request instead of N concurrent ones

## Changes

| File | Change |
|------|--------|
| `backend/database/vector_db.py` | `delete_memory_vectors_batch()` — single Pinecone batch delete |
| `backend/database/memories.py` | `delete_memories_batch()` — Firestore batch write |
| `backend/utils/rate_limit_config.py` | `memories:delete_batch` policy (10 req / hour) |
| `backend/routers/memories.py` | `DELETE /v3/memories/batch` endpoint + `BatchDeleteMemoriesRequest` model |
| `web/app/src/lib/api.ts` | `deleteMemoriesBatch(ids)` |
| `web/app/src/hooks/useMemories.ts` | `removeMemories(ids)` with optimistic UI update |
| `web/app/src/components/memories/MemoriesPage.tsx` | `executeBulkDelete` uses single batch call |

## Test plan

- [ ] Select 50+ memories in the web UI → click Delete → confirm no 429 error
- [ ] Verify deleted memories disappear from the list immediately (optimistic update)
- [ ] Verify deleted memories are removed from Firestore and Pinecone
- [ ] Single memory delete (from card menu) still works via existing `DELETE /v3/memories/{id}`
- [ ] Rate limit: confirm `memories:delete_batch` policy is applied (10 req / hour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)