### PR TITLE
fix(app/voice): preserve audio recording on transcription failure

### DIFF
--- a/app/lib/backend/http/api/messages.dart
+++ b/app/lib/backend/http/api/messages.dart
@@ -186,32 +186,71 @@ Future reportMessageServer(String messageId) async {
 /// Cloud Run's 32 MB request-body limit.  Transcripts are concatenated
 /// client-side with a space separator — same behaviour as the backend's
 /// multi-file mode but without a single oversized upload.
-Future<String> transcribeVoiceMessage(List<File> audioFiles, {String? language}) async {
-  final transcripts = <String>[];
+///
+/// Per-chunk retry: each chunk is attempted up to 3 times with 1s/3s backoff
+/// before bubbling the failure. A single transient blip on chunk N no longer
+/// invalidates the chunks before it.
+///
+/// Resume support: pass [existingTranscripts] (length must equal [audioFiles])
+/// to skip chunks that already produced a transcript on a prior attempt. The
+/// optional [onChunkSuccess] callback fires after each chunk completes so the
+/// caller can persist partial progress to disk.
+Future<String> transcribeVoiceMessage(
+  List<File> audioFiles, {
+  String? language,
+  List<String?>? existingTranscripts,
+  void Function(int index, String transcript)? onChunkSuccess,
+}) async {
+  final results = existingTranscripts != null && existingTranscripts.length == audioFiles.length
+      ? List<String?>.from(existingTranscripts)
+      : List<String?>.filled(audioFiles.length, null);
 
-  for (final file in audioFiles) {
-    try {
-      var response = await makeMultipartApiCallUnpooled(
-        url: '${Env.apiBaseUrl}v2/voice-message/transcribe',
-        files: [file],
-        fields: language != null ? {'language': language} : {},
-      );
-
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body);
-        final transcript = data['transcript'] ?? '';
-        if (transcript.isNotEmpty) {
-          transcripts.add(transcript);
-        }
-      } else {
-        Logger.debug('Failed to transcribe voice message chunk: ${response.statusCode} ${response.body}');
-        throw Exception('Failed to transcribe voice message');
-      }
-    } catch (e) {
-      Logger.debug('Error transcribing voice message chunk: $e');
-      throw Exception('Error transcribing voice message: $e');
+  for (int i = 0; i < audioFiles.length; i++) {
+    if (results[i] != null) {
+      // Already transcribed on a prior attempt; skip the upload.
+      continue;
     }
+
+    final file = audioFiles[i];
+    String? transcript;
+    Object? lastError;
+
+    for (int attempt = 0; attempt < 3; attempt++) {
+      try {
+        final response = await makeMultipartApiCallUnpooled(
+          url: '${Env.apiBaseUrl}v2/voice-message/transcribe',
+          files: [file],
+          fields: language != null ? {'language': language} : {},
+        );
+
+        if (response.statusCode == 200) {
+          final data = jsonDecode(response.body);
+          transcript = (data['transcript'] ?? '') as String;
+          break;
+        }
+
+        lastError = 'status ${response.statusCode}';
+        Logger.debug(
+          'Transcribe chunk $i attempt ${attempt + 1} failed: ${response.statusCode} ${response.body}',
+        );
+      } catch (e) {
+        lastError = e;
+        Logger.debug('Transcribe chunk $i attempt ${attempt + 1} threw: $e');
+      }
+
+      if (attempt < 2) {
+        // Backoff: 1s, then 3s.
+        await Future.delayed(Duration(seconds: attempt == 0 ? 1 : 3));
+      }
+    }
+
+    if (transcript == null) {
+      throw Exception('Failed to transcribe voice message chunk $i: $lastError');
+    }
+
+    results[i] = transcript;
+    onChunkSuccess?.call(i, transcript);
   }
 
-  return transcripts.join(' ');
+  return results.whereType<String>().where((t) => t.isNotEmpty).join(' ');
 }

--- a/app/lib/providers/voice_recorder_provider.dart
+++ b/app/lib/providers/voice_recorder_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 import 'dart:typed_data';
@@ -22,6 +23,7 @@ enum VoiceRecorderState { idle, recording, transcribing, transcribeSuccess, tran
 
 class VoiceRecorderProvider extends ChangeNotifier {
   static const _wavPathKey = 'voice_recorder_pending_wav_path';
+  static const _chunkTranscriptsKey = 'voice_recorder_pending_chunk_transcripts';
 
   /// Maximum WAV chunk size in bytes (10 MB of PCM data per chunk).
   /// Each chunk gets its own 44-byte WAV header so the backend can decode it independently.
@@ -38,6 +40,12 @@ class VoiceRecorderProvider extends ChangeNotifier {
 
   // Persisted WAV file for retry (kept until transcription succeeds or user closes)
   File? _wavFile;
+
+  // Per-chunk transcripts cache. Index aligns with the chunks emitted by
+  // splitWavFileIfNeeded for the current WAV. A non-null entry means that
+  // chunk was already transcribed successfully on a prior attempt and should
+  // be skipped on retry. Persisted to SharedPreferences alongside the WAV.
+  List<String?>? _chunkTranscripts;
 
   // Audio visualization
   final List<double> _audioLevels = List.generate(20, (_) => 0.1);
@@ -64,12 +72,40 @@ class VoiceRecorderProvider extends ChangeNotifier {
     final file = File(path);
     if (file.existsSync()) {
       _wavFile = file;
+      _chunkTranscripts = _loadChunkTranscriptsFromPrefs();
       _state = VoiceRecorderState.pendingRecovery;
       notifyListeners();
     } else {
       // File was cleaned up externally — clear the stale preference
       await SharedPreferencesUtil().remove(_wavPathKey);
+      await SharedPreferencesUtil().remove(_chunkTranscriptsKey);
     }
+  }
+
+  List<String?>? _loadChunkTranscriptsFromPrefs() {
+    final raw = SharedPreferencesUtil().getString(_chunkTranscriptsKey);
+    if (raw.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return null;
+      return decoded.map<String?>((e) => e is String ? e : null).toList();
+    } catch (e) {
+      Logger.debug('Failed to decode chunk transcripts: $e');
+      return null;
+    }
+  }
+
+  Future<void> _persistChunkTranscripts(List<String?> transcripts) async {
+    _chunkTranscripts = List<String?>.from(transcripts);
+    await SharedPreferencesUtil().saveString(
+      _chunkTranscriptsKey,
+      jsonEncode(transcripts),
+    );
+  }
+
+  Future<void> _clearChunkTranscripts() async {
+    _chunkTranscripts = null;
+    await SharedPreferencesUtil().remove(_chunkTranscriptsKey);
   }
 
   void setCallbacks({Function(String transcript)? onTranscriptReady, VoidCallback? onClose}) {
@@ -217,19 +253,7 @@ class VoiceRecorderProvider extends ChangeNotifier {
       // Split into chunks if the WAV is large, then transcribe
       final chunks = await splitWavFileIfNeeded(_wavFile!, 16000, 1);
       try {
-        final transcript = await transcribeVoiceMessage(chunks);
-        _transcript = transcript;
-        _state = VoiceRecorderState.transcribeSuccess;
-        _isProcessing = false;
-        notifyListeners();
-
-        if (transcript.isNotEmpty) {
-          _onTranscriptReady?.call(transcript);
-          close();
-        } else {
-          Logger.debug('Empty transcript received, closing without error');
-          close();
-        }
+        await _runTranscription(chunks);
       } finally {
         _cleanupChunkFiles(chunks);
       }
@@ -271,24 +295,59 @@ class VoiceRecorderProvider extends ChangeNotifier {
     try {
       final chunks = await splitWavFileIfNeeded(_wavFile!, 16000, 1);
       try {
-        final transcript = await transcribeVoiceMessage(chunks);
-        _transcript = transcript;
-        _state = VoiceRecorderState.transcribeSuccess;
-        _isProcessing = false;
-        notifyListeners();
-
-        if (transcript.isNotEmpty) {
-          _onTranscriptReady?.call(transcript);
-          close();
-        } else {
-          Logger.debug('Empty transcript received on retry, closing without error');
-          close();
-        }
+        await _runTranscription(chunks);
       } finally {
         _cleanupChunkFiles(chunks);
       }
     } catch (e) {
       Logger.debug('Error retrying transcription: $e');
+      _state = VoiceRecorderState.transcribeFailed;
+      _isProcessing = false;
+      notifyListeners();
+      AppSnackbar.showSnackbarError(
+        globalNavigatorKey.currentContext?.l10n.voiceFailedToTranscribe ?? 'Failed to transcribe audio',
+      );
+    }
+  }
+
+  /// Shared upload + result handling for [processRecording] and
+  /// [_retryTranscription]. Resumes from any per-chunk transcripts persisted
+  /// on a prior attempt and persists progress as each chunk completes.
+  ///
+  /// On non-empty transcript: closes the recorder (audio is consumed by the
+  /// caller via [_onTranscriptReady]). On empty transcript: treats it as a
+  /// failure, clears the chunk cache, and keeps the WAV so the user can
+  /// retry or dismiss.
+  ///
+  /// Errors propagate to the caller's catch block.
+  Future<void> _runTranscription(List<File> chunks) async {
+    final cache = _chunkTranscripts != null && _chunkTranscripts!.length == chunks.length
+        ? List<String?>.from(_chunkTranscripts!)
+        : List<String?>.filled(chunks.length, null);
+
+    final transcript = await transcribeVoiceMessage(
+      chunks,
+      existingTranscripts: cache,
+      onChunkSuccess: (i, t) async {
+        cache[i] = t;
+        await _persistChunkTranscripts(cache);
+      },
+    );
+
+    _transcript = transcript;
+
+    if (transcript.isNotEmpty) {
+      _state = VoiceRecorderState.transcribeSuccess;
+      _isProcessing = false;
+      notifyListeners();
+      _onTranscriptReady?.call(transcript);
+      close();
+    } else {
+      // All chunks uploaded but produced no speech. Treat as failure so the
+      // user sees feedback and can dismiss or re-record. Reset the chunk
+      // cache so the next refresh actually re-uploads.
+      Logger.debug('Empty transcript received, treating as failure');
+      await _clearChunkTranscripts();
       _state = VoiceRecorderState.transcribeFailed;
       _isProcessing = false;
       notifyListeners();
@@ -347,6 +406,7 @@ class VoiceRecorderProvider extends ChangeNotifier {
     }
     _wavFile = null;
     await SharedPreferencesUtil().remove(_wavPathKey);
+    await _clearChunkTranscripts();
   }
 
   /// Split a WAV file into multiple chunk files if it exceeds [maxChunkPcmBytes].


### PR DESCRIPTION
## Summary

When recording a voice message in chat, a transcription failure no longer destroys the audio. Three fixes:

- **Per-chunk retry** in `transcribeVoiceMessage`: each chunk is attempted up to 3× with 1s / 3s backoff before bubbling the error. A single transient upload error on chunk N no longer kills the whole transcription for a long recording.
- **Resume on retry** in `VoiceRecorderProvider`: per-chunk transcripts are cached in SharedPreferences alongside the WAV path. Tapping refresh only re-uploads chunks that haven't returned a transcript yet — successful chunks aren't redone.
- **Empty transcript = failure** (the disappearance bug): a 200 response with `{"transcript": ""}` previously called `close()` silently, which deleted the WAV and hid the bubble with no UI feedback. Now it sets `transcribeFailed`, shows the snackbar, clears the chunk cache so the next refresh actually re-uploads, and keeps the WAV on disk so the user can retry or dismiss with the X.

## Why

User reported recording a 10+ minute voice message in chat: transcription failed once, refresh "made it just disappear." That was the empty-transcript silent close. The retry/resume changes also harden long recordings against single-chunk hiccups, which were the most likely cause of the original failure (no 5xx in `/v2/voice-message/transcribe` Cloud Run logs over the prior 48h).

## Test plan

- [x] `flutter analyze` clean on changed files
- [x] `flutter test test/unit/voice_recorder_test.dart` — 21 tests pass
- [ ] Manual: iOS simulator on Mac mini — record 10+ second voice message in chat, confirm:
  - [ ] Successful path transcribes and the text lands in the chat input
  - [ ] On simulated failure, the audio bubble stays visible with refresh + close
  - [ ] After refresh, only un-transcribed chunks are re-uploaded
  - [ ] Empty transcript shows the error snackbar and keeps the bubble (does not silently disappear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)