### PR TITLE
feat(ptt): screen-context keyterm bias + drop live-transcript flicker

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -70,6 +70,38 @@ _WS_IDLE_TIMEOUT_S = 60
 # Prevents memory exhaustion from oversized payloads regardless of budget.
 _MAX_PCM_BODY_BYTES = 200_000_000
 
+# Limits for the optional client-supplied keyterm bias on /v2/voice-message/transcribe[-stream].
+# Deepgram caps keyterm count and individual lengths; we trim well below those
+# to stay safe and to keep the per-request bias focused.
+_MAX_TRANSCRIBE_KEYWORDS = 80
+_MAX_TRANSCRIBE_KEYWORD_LEN = 32
+
+
+def _parse_transcribe_keywords(raw: Optional[str]) -> List[str]:
+    """Parse comma-separated keyterm hints from a query param.
+
+    Strips whitespace, drops empties, dedupes case-insensitively, caps length
+    and total count. Returns an empty list when the param is missing or junk.
+    """
+    if not raw:
+        return []
+    seen: set = set()
+    result: List[str] = []
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if len(token) > _MAX_TRANSCRIBE_KEYWORD_LEN:
+            continue
+        key = token.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(token)
+        if len(result) >= _MAX_TRANSCRIBE_KEYWORDS:
+            break
+    return result
+
 
 def filter_messages(messages, app_id):
     logger.info(f'filter_messages {len(messages)} {app_id}')
@@ -520,6 +552,10 @@ async def transcribe_voice_message(
             del audio_bytes
             raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
 
+        # Optional comma-separated keyterm bias (desktop PTT sends OCR-extracted
+        # tokens from the user's screen so names/jargon survive STT).
+        keywords = _parse_transcribe_keywords(request.query_params.get("keywords"))
+
         resolved_language = resolve_voice_message_language(uid, language)
         try:
             transcript, detected_language = transcribe_pcm_bytes(
@@ -529,6 +565,7 @@ async def transcribe_voice_message(
                 encoding=encoding,
                 sample_rate=sample_rate,
                 channels=channels,
+                keywords=keywords,
             )
         except RuntimeError as e:
             logger.error(f'PCM transcription failed: {e}')
@@ -660,6 +697,7 @@ async def transcribe_voice_message_stream(
     sample_rate: int = 16000,
     codec: str = 'linear16',
     channels: int = 1,
+    keywords: Optional[str] = None,
 ):
     """WebSocket endpoint for PTT live mode transcription-only streaming.
 
@@ -756,6 +794,8 @@ async def transcribe_voice_message_stream(
                 websocket_active = False
                 break
 
+    parsed_keywords = _parse_transcribe_keywords(keywords)
+
     try:
         dg_socket = await process_audio_dg(
             stream_transcript,
@@ -763,6 +803,7 @@ async def transcribe_voice_message_stream(
             sample_rate=sample_rate,
             channels=channels,
             model=stt_model,
+            keywords=parsed_keywords,
             is_active=lambda: websocket_active,
         )
 

--- a/backend/utils/chat.py
+++ b/backend/utils/chat.py
@@ -2,7 +2,7 @@ import time
 import base64
 import uuid
 from datetime import datetime, timezone
-from typing import AsyncGenerator, List, Optional, Tuple
+from typing import AsyncGenerator, List, Optional, Sequence, Tuple
 
 from utils.executors import storage_executor
 
@@ -115,6 +115,7 @@ def transcribe_pcm_bytes(
     encoding: str = 'linear16',
     sample_rate: int = 16000,
     channels: int = 1,
+    keywords: Optional[Sequence[str]] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """Transcribe raw PCM audio bytes directly via Deepgram pre-recorded API.
 
@@ -138,6 +139,7 @@ def transcribe_pcm_bytes(
             language=stt_language,
             model=stt_model,
             return_language=True,
+            keywords=keywords,
         )
         words, detected_language = result
     else:
@@ -149,6 +151,7 @@ def transcribe_pcm_bytes(
             channels=channels,
             language=stt_language,
             model=stt_model,
+            keywords=keywords,
         )
         detected_language = stt_language
 

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -262,6 +262,7 @@ def deepgram_prerecorded_from_bytes(
     language: Optional[str] = None,
     model: str = "nova-3",
     return_language: bool = False,
+    keywords: Optional[Sequence[str]] = None,
 ) -> Union[List[dict], Tuple[List[dict], str]]:
     """
     Transcribe audio bytes using Deepgram's pre-recorded API.
@@ -308,6 +309,13 @@ def deepgram_prerecorded_from_bytes(
             options["encoding"] = encoding
             options["sample_rate"] = sample_rate
             options["channels"] = channels
+
+        # Optional keyterm bias — same wiring as the URL variant.
+        if keywords:
+            if model in ('nova-3',):
+                options["keyterm"] = list(keywords)
+            else:
+                options["keywords"] = list(keywords)
 
         # Wrap bytes in BytesIO for Deepgram client
         audio_buffer = BytesIO(audio_bytes)
@@ -361,7 +369,16 @@ def deepgram_prerecorded_from_bytes(
         logger.error(f'Deepgram prerecorded from bytes error: {e}')
         if attempts < 2:
             return deepgram_prerecorded_from_bytes(
-                audio_bytes, sample_rate, diarize, attempts + 1, encoding, channels, language, model, return_language
+                audio_bytes,
+                sample_rate,
+                diarize,
+                attempts + 1,
+                encoding,
+                channels,
+                language,
+                model,
+                return_language,
+                keywords,
             )
         raise RuntimeError(f'Deepgram transcription failed after {attempts + 1} attempts: {e}')
 

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -53,6 +53,12 @@ class PushToTalkManager: ObservableObject {
   // Live mode: timeout for waiting on final transcript after CloseStream
   private var liveFinalizationTimeout: DispatchWorkItem?
 
+  // Screen-context OCR for keyterm biasing.
+  // Captured at startListening, awaited at finalize, fed to the transcribe call.
+  // Wispr Flow does the same trick (axParsedWords + ocrParsedWords) — they get
+  // names right because the STT sees what's on the user's screen at PTT time.
+  private var screenContextTask: Task<[String], Never>?
+
   private init() {}
 
   // MARK: - Setup / Teardown
@@ -233,6 +239,7 @@ class PushToTalkManager: ObservableObject {
 
 
     startAudioTranscription()
+    captureScreenContextForBias()
     log("PushToTalkManager: started listening (hold mode, followUp=\(isFollowUp))")
   }
 
@@ -261,6 +268,7 @@ class PushToTalkManager: ObservableObject {
 
 
       startAudioTranscription()
+      captureScreenContextForBias()
     }
 
     updateBarState()
@@ -289,6 +297,8 @@ class PushToTalkManager: ObservableObject {
     finalizeWorkItem = nil
     liveFinalizationTimeout?.cancel()
     liveFinalizationTimeout = nil
+    screenContextTask?.cancel()
+    screenContextTask = nil
     stopAudioTranscription()
     state = .idle
     transcriptSegments = []
@@ -348,18 +358,21 @@ class PushToTalkManager: ObservableObject {
         return
       }
 
+      // Status-only string ("Transcribing…") — not the live transcript text.
       barState?.voiceTranscript = "Transcribing..."
 
       Task {
         do {
           let language = AssistantSettings.shared.effectiveTranscriptionLanguage
           let audioSeconds = Double(audioData.count) / (16000.0 * 2.0)
-          log("PushToTalkManager: batch audio \(audioData.count) bytes (\(String(format: "%.1f", audioSeconds))s), language=\(language)")
+          let keyterms = await self.awaitScreenContextKeyterms()
+          log("PushToTalkManager: batch audio \(audioData.count) bytes (\(String(format: "%.1f", audioSeconds))s), language=\(language), keyterms=\(keyterms.count)")
 
           // First attempt with the user's effective language (usually "multi")
           var transcript = try await TranscriptionService.batchTranscribe(
             audioData: audioData,
-            language: language
+            language: language,
+            keywords: keyterms
           )
 
           // If multi-language detection returned empty on short audio (<5s),
@@ -372,7 +385,8 @@ class PushToTalkManager: ObservableObject {
             log("PushToTalkManager: multi returned empty on short audio, retrying with '\(retryLang)'")
             transcript = try await TranscriptionService.batchTranscribe(
               audioData: audioData,
-              language: retryLang
+              language: retryLang,
+              keywords: keyterms
             )
           }
 
@@ -481,13 +495,27 @@ class PushToTalkManager: ObservableObject {
       startMicCapture(batchMode: true)
       log("PushToTalkManager: started audio capture (batch mode)")
     } else {
-      // Live mode: start mic capture and stream to Deepgram
+      // Live mode: start mic capture and stream to Deepgram.
+      // We start mic immediately so the user doesn't lose the first words
+      // while we wait for OCR; keyterms are attached to the WS handshake
+      // (best-effort — capped at 600ms in awaitScreenContextKeyterms).
       startMicCapture()
 
       do {
         let language = AssistantSettings.shared.effectiveTranscriptionLanguage
         let service = try TranscriptionService(language: language, channels: 1)
         transcriptionService = service
+
+        // Attach screen-context keyterms to the WS connection. We do this in
+        // a Task so the live mic doesn't block; the WS connect will pick up
+        // keywords whenever they land (or stay empty if OCR misses the
+        // window).
+        Task { [weak service] in
+          let keyterms = await self.awaitScreenContextKeyterms()
+          await MainActor.run {
+            service?.setKeywords(keyterms)
+          }
+        }
 
         service.start(
           onSegments: { [weak self] segments in
@@ -593,13 +621,12 @@ class PushToTalkManager: ObservableObject {
     }
     lastInterimText = ""
 
-    if state == .listening || state == .lockedListening {
-      let liveText = transcriptSegments.joined(separator: " ")
-      barState?.voiceTranscript = liveText
-      if isCurrentSessionFollowUp {
-        barState?.voiceFollowUpTranscript = liveText
-      }
-    }
+    // We deliberately do NOT push interim text into voiceTranscript /
+    // voiceFollowUpTranscript here. Live word-by-word display flickers and
+    // shows pre-correction tokens (mis-heard names, dropped words) that the
+    // final pass will fix. The hint label ("Release ⌥ to send" / "Listening…")
+    // stays visible while we listen, and the final transcript shows up in the
+    // input via sendTranscript → openAIInputWithQuery.
 
     // In finalizing state, segments mean backend is done — send immediately
     if state == .finalizing {
@@ -609,6 +636,134 @@ class PushToTalkManager: ObservableObject {
       sendTranscript()
     }
   }
+
+  // MARK: - Screen-context OCR for keyterm biasing
+
+  /// Capture the current screen and OCR it on a background task. Result is
+  /// fed to the transcribe call as keyterm bias so names/jargon visible on
+  /// screen survive the STT pass. Mirrors what Wispr Flow does with its
+  /// axParsedWords + ocrParsedWords pipeline.
+  private func captureScreenContextForBias() {
+    screenContextTask?.cancel()
+    let captureStart = Date()
+    screenContextTask = Task.detached(priority: .userInitiated) {
+      // Always include the product-name keyterms even if OCR fails or returns
+      // nothing — Deepgram should never mishear "Omi" as "homie".
+      let baseline = Self.alwaysOnKeyterms
+      guard let screenshotData = ScreenCaptureManager.captureScreenData() else {
+        return baseline
+      }
+      do {
+        let text = try await RewindOCRService.shared.extractText(from: screenshotData)
+        let ocrWords = Self.extractKeytermsFromOCR(text)
+        let elapsed = Int(Date().timeIntervalSince(captureStart) * 1000)
+        let merged = Self.mergeKeyterms(baseline: baseline, ocrTokens: ocrWords)
+        log("PushToTalkManager: screen OCR yielded \(ocrWords.count) tokens, \(merged.count) total keyterms (with baseline) in \(elapsed)ms")
+        return merged
+      } catch {
+        logError("PushToTalkManager: screen OCR failed", error: error)
+        return baseline
+      }
+    }
+  }
+
+  /// Merge baseline always-on keyterms with screen-derived ones, preserving
+  /// baseline priority (they appear first in the list). Dedupes case-insensitively.
+  nonisolated static func mergeKeyterms(baseline: [String], ocrTokens: [String]) -> [String] {
+    var seen = Set<String>()
+    var out: [String] = []
+    for token in baseline + ocrTokens {
+      let key = token.lowercased()
+      if seen.contains(key) { continue }
+      seen.insert(key)
+      out.append(token)
+    }
+    return out
+  }
+
+  /// Wait briefly for screen OCR to land before firing transcribe. Capped at
+  /// `timeoutMs` so PTT never feels laggy if OCR stalls. Falls back to the
+  /// always-on baseline so "Omi" still gets biased even when OCR is missing.
+  private func awaitScreenContextKeyterms(timeoutMs: Int = 600) async -> [String] {
+    guard let task = screenContextTask else { return Self.alwaysOnKeyterms }
+    let timeoutNs = UInt64(timeoutMs) * 1_000_000
+    let waiter = Task<[String], Never> { await task.value }
+    let result = await withTaskGroup(of: [String]?.self) { group -> [String] in
+      group.addTask { await waiter.value }
+      group.addTask {
+        try? await Task.sleep(nanoseconds: timeoutNs)
+        return nil
+      }
+      for await value in group {
+        if let value = value {
+          group.cancelAll()
+          return value
+        } else {
+          // Timeout fired first — bail with the baseline so "Omi" is still biased.
+          group.cancelAll()
+          return Self.alwaysOnKeyterms
+        }
+      }
+      return Self.alwaysOnKeyterms
+    }
+    return result
+  }
+
+  /// Pull useful keyterm tokens out of OCR text. We drop short tokens, common
+  /// English stop words, and pure-punctuation noise; we keep capitalized
+  /// words, mixed-case / camelCase identifiers, and anything that looks like
+  /// a proper noun. Caps total tokens to avoid overflowing Deepgram limits.
+  ///
+  /// Marked `nonisolated` so it can run inside a `Task.detached` block —
+  /// the function is pure and has no main-actor state.
+  nonisolated static func extractKeytermsFromOCR(_ text: String, maxTokens: Int = 80) -> [String] {
+    guard !text.isEmpty else { return [] }
+    let separators = CharacterSet.alphanumerics.inverted
+    let raw = text.components(separatedBy: separators)
+    var seen = Set<String>()
+    var keep: [String] = []
+    for token in raw {
+      let t = token.trimmingCharacters(in: .whitespaces)
+      if t.count < 3 || t.count > 32 { continue }
+      // skip pure-numeric runs
+      if t.allSatisfy({ $0.isNumber }) { continue }
+      // dedupe case-insensitively so we don't ship "Slack" and "slack" both
+      let key = t.lowercased()
+      if Self.ocrStopWords.contains(key) { continue }
+      if seen.contains(key) { continue }
+      // Prefer tokens that look like proper nouns / identifiers — capitalized
+      // first letter, or any uppercase letter past index 0 (camelCase),
+      // or contain digits (model names like "GPT4o", "M4").
+      let firstIsUpper = t.first?.isUppercase == true
+      let hasInnerUpper = t.dropFirst().contains(where: { $0.isUppercase })
+      let hasDigit = t.contains(where: { $0.isNumber })
+      guard firstIsUpper || hasInnerUpper || hasDigit else { continue }
+      seen.insert(key)
+      keep.append(t)
+      if keep.count >= maxTokens { break }
+    }
+    return keep
+  }
+
+  /// Always-on keyterm bias. Names of our own product and adjacent terms that
+  /// the STT mishears constantly ("Omi" → "Only", "Omi" → "homie", etc.).
+  /// Kept short — these are merged with screen-OCR keyterms before send.
+  nonisolated static let alwaysOnKeyterms: [String] = [
+    "Omi", "OMI", "Omi AI",
+  ]
+
+  /// English stop words we never want to ship as keyterms even if capitalized
+  /// (sentence-initial). Kept tight on purpose — biasing on real common words
+  /// hurts recognition of unrelated content.
+  nonisolated private static let ocrStopWords: Set<String> = [
+    "the", "and", "for", "you", "your", "with", "this", "that", "from", "have",
+    "are", "was", "were", "but", "not", "all", "can", "will", "would", "could",
+    "should", "into", "out", "about", "more", "less", "what", "when", "where",
+    "why", "how", "who", "which", "they", "them", "their", "there", "here",
+    "yes", "no", "ok", "okay", "new", "old", "open", "close", "save", "edit",
+    "view", "file", "menu", "search", "settings", "preferences", "help",
+    "show", "hide", "next", "back", "done", "cancel", "submit", "send",
+  ]
 
   // MARK: - Bar State Sync
 

--- a/desktop/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/Desktop/Sources/TranscriptionService.swift
@@ -125,6 +125,11 @@ class TranscriptionService {
     private let audioBufferSize = 3200  // ~100ms of 16kHz 16-bit audio (16000 * 2 * 0.1)
     private let audioBufferLock = NSLock()
 
+    // Screen-context keyterm bias. Set before connect() to be picked up at
+    // WS handshake; setting after the socket is up is a no-op (Deepgram
+    // keyterm/keywords are a connect-time option).
+    private var pendingKeywords: [String] = []
+
     // MARK: - Initialization
 
     /// Initialize the transcription service for streaming.
@@ -160,6 +165,13 @@ class TranscriptionService {
     /// Routes to `/v2/voice-message/transcribe-stream` (PTT-only transcription).
     convenience init(language: String = "en", channels: Int) throws {
         try self.init(language: language, mode: .ptt)
+    }
+
+    /// Attach screen-context keyterms before WS connect. Effective on the
+    /// initial handshake only — Deepgram doesn't accept keyterm updates on
+    /// an open stream. Safe to call from any thread.
+    func setKeywords(_ keywords: [String]) {
+        pendingKeywords = keywords
     }
 
     /// Flush remaining audio and (for PTT mode) tell the backend to finalize transcription.
@@ -308,12 +320,17 @@ class TranscriptionService {
         case .ptt:
             // PTT-only transcription — no conversation lifecycle
             path = "/v2/voice-message/transcribe-stream"
-            queryItems = [
+            var items: [URLQueryItem] = [
                 URLQueryItem(name: "language", value: language),
                 URLQueryItem(name: "sample_rate", value: String(sampleRate)),
                 URLQueryItem(name: "codec", value: encoding),
                 URLQueryItem(name: "channels", value: String(channels)),
             ]
+            if !pendingKeywords.isEmpty {
+                // Comma-joined; backend splits and forwards to Deepgram.
+                items.append(URLQueryItem(name: "keywords", value: pendingKeywords.joined(separator: ",")))
+            }
+            queryItems = items
         }
 
         guard var components = URLComponents(string: "\(wsBase)\(path)") else {
@@ -541,7 +558,8 @@ extension TranscriptionService {
     static func batchTranscribe(
         audioData: Data,
         language: String = "en",
-        apiKey: String? = nil
+        apiKey: String? = nil,
+        keywords: [String] = []
     ) async throws -> String? {
         // Always use Firebase auth + Python backend
         let authService = await MainActor.run { AuthService.shared }
@@ -551,12 +569,16 @@ extension TranscriptionService {
         guard var components = URLComponents(string: baseURLString) else {
             throw TranscriptionError.connectionFailed(NSError(domain: "Invalid backend URL", code: -1))
         }
-        components.queryItems = [
+        var items: [URLQueryItem] = [
             URLQueryItem(name: "language", value: language),
             URLQueryItem(name: "sample_rate", value: "16000"),
             URLQueryItem(name: "encoding", value: "linear16"),
             URLQueryItem(name: "channels", value: "1"),
         ]
+        if !keywords.isEmpty {
+            items.append(URLQueryItem(name: "keywords", value: keywords.joined(separator: ",")))
+        }
+        components.queryItems = items
 
         guard let url = components.url else {
             throw TranscriptionError.connectionFailed(NSError(domain: "Invalid URL", code: -1))


### PR DESCRIPTION
## What

Two changes to the desktop PTT \"Ask\" flow:

1. **Stop the flickering interim transcript.** The live word-by-word display in the floating bar showed pre-correction Deepgram tokens that the final pass routinely fixes (mis-heard names, dropped words). The hint label (\"Release ⌥ to send\" / \"Listening…\") now stays visible while we listen; the final, verified transcript still lands in the input via \`openAIInputWithQuery\` once the backend confirms.

2. **Bias Deepgram with screen-context keyterms** so names / jargon visible on the user's screen at PTT-press time survive transcription. At \`startListening\`, capture a screenshot via \`ScreenCaptureManager\` and OCR it with the existing \`RewindOCRService\` on a detached Task. Filter to proper-noun-shaped tokens (capitalized, camelCase, or with digits), drop common English stop words, dedupe case-insensitively, cap at 80 tokens. Always merge an \`Omi / OMI / \"Omi AI\"\` baseline so our own product name never comes back as \"homie\" / \"Only\". Pass the result as the \`keywords\` query param to \`/v2/voice-message/transcribe[-stream]\`; backend forwards as \`keyterm\` (nova-3) or \`keywords\` (older models).

## Why

User reports: \"Aarav\", \"Ansh\", and even \"Omi\" itself frequently get mis-transcribed or dropped on the desktop PTT path. Wispr Flow nails the same names because they bundle screen-derived bias context (\`axParsedWords\` + \`ocrParsedWords\`) with every dictation request. Omi already takes a screenshot a moment later for the chat attachment — reusing that capture point is free, no separate AX pipeline needed.

## How it's wired

- Desktop:
  - \`PushToTalkManager.captureScreenContextForBias()\` fires OCR async at press-time.
  - \`awaitScreenContextKeyterms(timeoutMs: 600)\` waits before transcribe with a hard cap; falls back to baseline.
  - Live mode: \`TranscriptionService.setKeywords()\` before WS handshake.
  - Batch mode: \`batchTranscribe(..., keywords:)\` query param.
- Backend:
  - \`/v2/voice-message/transcribe\` (REST) and \`/v2/voice-message/transcribe-stream\` (WS) accept \`keywords\` query param.
  - \`_parse_transcribe_keywords\` dedupes / caps at 80 tokens, ≤32 chars each.
  - \`transcribe_pcm_bytes\` and \`deepgram_prerecorded_from_bytes\` plumb \`keywords\` through to Deepgram (\`keyterm\` for nova-3, \`keywords\` otherwise).

## Test plan

- [x] \`xcrun swift build -c debug --package-path Desktop\` clean
- [x] Python files parse clean
- [ ] Local launch with \`omi-ptt-context\` named bundle: PTT \"Ask Aarav about the deploy\" with the literal text \"Aarav\" visible on the screen → transcript should contain \"Aarav\", not \"a rough\" / \"Arab\".
- [ ] PTT no longer shows interim text mid-listen — only the final transcript appears in the input.
- [ ] Backend deploy needs to land before client-side bias actually biases STT — this PR ships both halves together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)