### PR TITLE
Route macOS beta to development backends

### DIFF
--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -2,15 +2,10 @@ import Foundation
 
 actor APIClient {
   static let shared = APIClient()
-  // Primary data backend URL — Python backend (api.omi.me) is the single source of truth for all data CRUD.
-  // Override via OMI_PYTHON_API_URL for local dev.
+  // Primary data backend URL — Python backend is the single source of truth for all data CRUD.
+  // Beta release channel uses the dev service; stable uses production or explicit local env.
   var baseURL: String {
-    if let cString = getenv("OMI_PYTHON_API_URL"), let url = String(validatingUTF8: cString),
-      !url.isEmpty
-    {
-      return url.hasSuffix("/") ? url : url + "/"
-    }
-    return "https://api.omi.me/"
+    DesktopBackendEnvironment.pythonBaseURL()
   }
 
   // Rust desktop backend URL — used only for: agent VM provisioning/status,
@@ -18,17 +13,9 @@ actor APIClient {
   // chat AI, and title generation are on Python.
   // Set via OMI_API_URL env var (in .env).
   var rustBackendURL: String {
-    // First check getenv() for values set by setenv() in loadEnvironment()
-    if let cString = getenv("OMI_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty
-    {
-      let normalized = url.hasSuffix("/") ? url : url + "/"
-      return normalized
-    }
-    // Fallback to ProcessInfo (launch-time snapshot)
-    if let envURL = ProcessInfo.processInfo.environment["OMI_API_URL"], !envURL.isEmpty {
-      let normalized = envURL.hasSuffix("/") ? envURL : envURL + "/"
-      return normalized
-    }
+    let resolved = DesktopBackendEnvironment.rustBackendURL()
+    if !resolved.isEmpty { return resolved }
+
     NSLog("OMI API: OMI_API_URL not set — Rust backend calls will fail")
     return ""
   }

--- a/desktop/Desktop/Sources/AppBuild.swift
+++ b/desktop/Desktop/Sources/AppBuild.swift
@@ -15,6 +15,10 @@ enum AppBuild {
     bundleIdentifier.hasPrefix("com.omi.") && bundleIdentifier != productionBundleIdentifier
   }
 
+  static var isProductionBundle: Bool {
+    bundleIdentifier == productionBundleIdentifier
+  }
+
   static var displayName: String {
     if let displayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String,
       !displayName.isEmpty
@@ -74,6 +78,15 @@ enum AppBuild {
     let resolved = resolveFreshInstallUpdateChannelSynchronously()
     if resolved == "beta" {
       UserDefaults.standard.set("beta", forKey: updateChannelDefaultsKey)
+    }
+  }
+
+  static func prepareUpdateChannelForBackendRouting() {
+    guard isProductionBundle else { return }
+
+    migrateBetaChannelOverwrite()
+    if UserDefaults.standard.string(forKey: updateChannelDefaultsKey) == nil {
+      syncUpdateChannelOnFirstLaunch()
     }
   }
 

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -230,6 +230,9 @@ class AppState: ObservableObject {
     // Register as the current instance so background services can check recording state
     AppState.current = self
 
+    // Resolve beta/stable before loading backend URLs so beta releases use dev services.
+    AppBuild.prepareUpdateChannelForBackendRouting()
+
     // Load API key from environment or .env file
     loadEnvironment()
 
@@ -482,6 +485,8 @@ class AppState: ObservableObject {
         // Don't break - load all .env files to merge keys
       }
     }
+
+    DesktopBackendEnvironment.applyReleaseChannelDefaults()
 
     log("Environment loaded (API keys will be fetched from backend after auth)")
   }

--- a/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+enum DesktopBackendEnvironment {
+  static let productionPythonAPIURL = "https://api.omi.me/"
+  static let developmentPythonAPIURL = "https://api.omiapi.com/"
+  static let developmentRustBackendURL = "https://desktop-backend-dt5lrfkkoa-uc.a.run.app/"
+
+  static var shouldUseDevelopmentBackends: Bool {
+    shouldUseDevelopmentBackends(
+      bundleIdentifier: AppBuild.bundleIdentifier,
+      updateChannel: AppBuild.currentUpdateChannel
+    )
+  }
+
+  static func shouldUseDevelopmentBackends(
+    bundleIdentifier: String,
+    updateChannel: String
+  ) -> Bool {
+    bundleIdentifier == AppBuild.productionBundleIdentifier
+      && normalizedChannel(updateChannel) == "beta"
+  }
+
+  static func pythonBaseURL(
+    environmentValue: String? = currentEnvironmentValue("OMI_PYTHON_API_URL")
+  ) -> String {
+    pythonBaseURL(
+      useDevelopmentBackends: shouldUseDevelopmentBackends,
+      environmentValue: environmentValue
+    )
+  }
+
+  static func pythonBaseURL(useDevelopmentBackends: Bool, environmentValue: String?) -> String {
+    if useDevelopmentBackends {
+      return developmentPythonAPIURL
+    }
+
+    if let url = normalizedURL(environmentValue) {
+      return url
+    }
+
+    return productionPythonAPIURL
+  }
+
+  static func rustBackendURL(
+    environmentValue: String? = currentEnvironmentValue("OMI_API_URL"),
+    launchEnvironmentValue: String? = ProcessInfo.processInfo.environment["OMI_API_URL"]
+  ) -> String {
+    rustBackendURL(
+      useDevelopmentBackends: shouldUseDevelopmentBackends,
+      environmentValue: environmentValue,
+      launchEnvironmentValue: launchEnvironmentValue
+    )
+  }
+
+  static func rustBackendURL(
+    useDevelopmentBackends: Bool,
+    environmentValue: String?,
+    launchEnvironmentValue: String?
+  ) -> String {
+    if useDevelopmentBackends {
+      return developmentRustBackendURL
+    }
+
+    if let url = normalizedURL(environmentValue) {
+      return url
+    }
+
+    if let url = normalizedURL(launchEnvironmentValue) {
+      return url
+    }
+
+    return ""
+  }
+
+  static func applyReleaseChannelDefaults() {
+    guard shouldUseDevelopmentBackends else { return }
+
+    setenv("OMI_PYTHON_API_URL", developmentPythonAPIURL, 1)
+    setenv("OMI_API_URL", developmentRustBackendURL, 1)
+    log("BackendEnvironment: beta channel using development backends with production data stores")
+  }
+
+  private static func normalizedChannel(_ channel: String) -> String {
+    let normalized = channel.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return normalized == "staging" ? "beta" : normalized
+  }
+
+  private static func normalizedURL(_ raw: String?) -> String? {
+    guard let raw else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return trimmed.hasSuffix("/") ? trimmed : trimmed + "/"
+  }
+
+  private static func currentEnvironmentValue(_ key: String) -> String? {
+    guard let value = getenv(key), let string = String(validatingUTF8: value) else {
+      return nil
+    }
+    return string
+  }
+}

--- a/desktop/Desktop/Sources/MainWindow/Pages/ChatLabView.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/ChatLabView.swift
@@ -250,7 +250,8 @@ class ChatLabViewModel: ObservableObject {
             let authHeader = try await AuthService.shared.getAuthHeader()
 
             // Fetch messages with ratings from the last 60 days
-            let url = URL(string: "https://api.omi.me/v2/messages?limit=500")!
+            let baseURL = await APIClient.shared.baseURL
+            let url = URL(string: "\(baseURL)v2/messages?limit=500")!
             var request = URLRequest(url: url)
             request.setValue(authHeader, forHTTPHeaderField: "Authorization")
 

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -197,6 +197,8 @@ public class ProactiveAssistantsPlugin: NSObject {
                 break
             }
         }
+
+        DesktopBackendEnvironment.applyReleaseChannelDefaults()
     }
 
 

--- a/desktop/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/Desktop/Sources/TranscriptionService.swift
@@ -99,15 +99,10 @@ class TranscriptionService {
     private let streamingMode: StreamingMode
 
     /// Python backend base URL for transcription endpoints.
-    /// Resolution order: OMI_PYTHON_API_URL → https://api.omi.me/
+    /// Resolution order: beta release channel → OMI_PYTHON_API_URL → https://api.omi.me/
     /// NOTE: Do NOT fall back to OMI_API_URL — that points to the Rust desktop-backend
     /// (Cloud Run), which does not have /v2/voice-message/* or /v4/listen endpoints.
-    private static let pythonBackendBaseURL: String = {
-        if let cString = getenv("OMI_PYTHON_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty {
-            return url.hasSuffix("/") ? url : url + "/"
-        }
-        return "https://api.omi.me/"
-    }()
+    private static let pythonBackendBaseURL: String = DesktopBackendEnvironment.pythonBaseURL()
 
     // Reconnection (internal for @testable import)
     var reconnectAttempts = 0

--- a/desktop/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/Desktop/Tests/APIClientRoutingTests.swift
@@ -35,6 +35,37 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
         lock.unlock()
     }
 
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let readCount = stream.read(buffer, maxLength: bufferSize)
+            if readCount > 0 {
+                data.append(buffer, count: readCount)
+            } else if readCount < 0 {
+                return nil
+            } else {
+                break
+            }
+        }
+
+        return data.isEmpty ? nil : data
+    }
+
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
@@ -44,7 +75,7 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
                 url: url,
                 method: request.httpMethod ?? "GET",
                 headers: request.allHTTPHeaderFields ?? [:],
-                body: request.httpBody
+                body: Self.bodyData(from: request)
             ))
         }
         let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
@@ -87,6 +118,59 @@ final class APIClientRoutingTests: XCTestCase {
         let client = APIClient()
         let url = await client.baseURL
         XCTAssertEqual(url, "https://api.omi.me/")
+    }
+
+    func testBetaProductionBundleUsesDevelopmentPythonBackend() {
+        let url = DesktopBackendEnvironment.pythonBaseURL(
+            useDevelopmentBackends: true,
+            environmentValue: "https://api.omi.me"
+        )
+        XCTAssertEqual(url, "https://api.omiapi.com/")
+    }
+
+    func testStableProductionBundleKeepsProductionPythonBackend() {
+        let url = DesktopBackendEnvironment.pythonBaseURL(
+            useDevelopmentBackends: false,
+            environmentValue: "https://api.omi.me"
+        )
+        XCTAssertEqual(url, "https://api.omi.me/")
+    }
+
+    func testBetaProductionBundleUsesDevelopmentRustBackend() {
+        let url = DesktopBackendEnvironment.rustBackendURL(
+            useDevelopmentBackends: true,
+            environmentValue: "https://desktop-backend-hhibjajaja-uc.a.run.app",
+            launchEnvironmentValue: nil
+        )
+        XCTAssertEqual(url, "https://desktop-backend-dt5lrfkkoa-uc.a.run.app/")
+    }
+
+    func testStableProductionBundleKeepsConfiguredRustBackend() {
+        let url = DesktopBackendEnvironment.rustBackendURL(
+            useDevelopmentBackends: false,
+            environmentValue: "https://desktop-backend-hhibjajaja-uc.a.run.app",
+            launchEnvironmentValue: nil
+        )
+        XCTAssertEqual(url, "https://desktop-backend-hhibjajaja-uc.a.run.app/")
+    }
+
+    func testDevelopmentBackendSelectionOnlyAppliesToProductionBundleBetaChannel() {
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.computer-macos",
+            updateChannel: "beta"
+        ))
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.computer-macos",
+            updateChannel: "staging"
+        ))
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.computer-macos",
+            updateChannel: "stable"
+        ))
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.desktop-dev",
+            updateChannel: "beta"
+        ))
     }
 
     func testBaseURLReadsFromPythonEnvVar() async {


### PR DESCRIPTION
## Summary
- route production-bundle macOS beta/staging channel to dev Python and Rust backends
- preserve stable production routing and local/dev env override behavior
- make Chat Lab ratings use APIClient baseURL instead of hardcoded prod URL
- add routing coverage for beta/stable backend selection and request body capture

## Verification
- Mac mini: `swift test --filter APIClientRoutingTests` (43 tests, 0 failures)
- `git diff --check`
- `swift format lint desktop/Desktop/Sources/DesktopBackendEnvironment.swift`

## Data stores
Dev backend deployments already point at production data stores: `GOOGLE_CLOUD_PROJECT=based-hardware` for Python and `FIREBASE_PROJECT_ID=based-hardware` for Rust.