### PR TITLE
Preserve mobile voice recordings after transcription failures

### DIFF
--- a/app/ios/Flutter/devDebug.xcconfig
+++ b/app/ios/Flutter/devDebug.xcconfig
@@ -1,4 +1,4 @@
-#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-dev.xcconfig"
 #include "Generated.xcconfig"
 #include "Base.xcconfig"
 #include "Custom.xcconfig"
@@ -6,3 +6,5 @@
 ASSET_PREFIX=dev
 BUNDLE_NAME=Omi Dev
 BUNDLE_DISPLAY_NAME=Omi Dev
+APP_BUNDLE_IDENTIFIER=com.friend-app-with-wearable.ios12.development
+GOOGLE_REVERSE_CLIENT_ID=com.googleusercontent.apps.1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -153,6 +153,8 @@ PODS:
   - flutter_sound_core (9.25.1)
   - flutter_timezone (0.0.1):
     - Flutter
+  - flutter_tts (0.0.1):
+    - Flutter
   - frame_sdk (0.0.2):
     - Flutter
   - geolocator_apple (1.2.0):
@@ -301,6 +303,7 @@ DEPENDENCIES:
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_sound (from `.symlinks/plugins/flutter_sound/ios`)
   - flutter_timezone (from `.symlinks/plugins/flutter_timezone/ios`)
+  - flutter_tts (from `.symlinks/plugins/flutter_tts/ios`)
   - frame_sdk (from `.symlinks/plugins/frame_sdk/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
@@ -410,6 +413,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_sound/ios"
   flutter_timezone:
     :path: ".symlinks/plugins/flutter_timezone/ios"
+  flutter_tts:
+    :path: ".symlinks/plugins/flutter_tts/ios"
   frame_sdk:
     :path: ".symlinks/plugins/frame_sdk/ios"
   geolocator_apple:
@@ -499,6 +504,7 @@ SPEC CHECKSUMS:
   flutter_sound: 69343c1dd74d2cc5a7fe6693f20369b63ea2e249
   flutter_sound_core: 065aca7698f13a934d8cb8156a2865efd282b1e8
   flutter_timezone: ee50ce7786b5fde27e2fe5375bbc8c9661ffc13f
+  flutter_tts: 35ac3c7d42412733e795ea96ad2d7e05d0a75113
   frame_sdk: 4d4df786d828557bf57e05f6f1856613896cc9db
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   google_sign_in_ios: 39f46834c156be9a4dfef914258e0145b7117725

--- a/app/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
+++ b/app/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug-dev"

--- a/app/lib/backend/http/api/messages.dart
+++ b/app/lib/backend/http/api/messages.dart
@@ -213,5 +213,9 @@ Future<String> transcribeVoiceMessage(List<File> audioFiles, {String? language})
     }
   }
 
-  return transcripts.join(' ');
+  final transcript = transcripts.join(' ').trim();
+  if (transcript.isEmpty) {
+    throw Exception('Voice message transcription returned empty transcript');
+  }
+  return transcript;
 }

--- a/app/lib/pages/chat/widgets/voice_recorder_widget.dart
+++ b/app/lib/pages/chat/widgets/voice_recorder_widget.dart
@@ -153,7 +153,7 @@ class _VoiceRecorderWidgetState extends State<VoiceRecorderWidget> with SingleTi
                   Row(
                     children: [
                       GestureDetector(
-                        onTap: provider.retry,
+                        onTap: () => provider.retry(),
                         child: Container(
                           padding: const EdgeInsets.all(4),
                           margin: const EdgeInsets.only(left: 10, right: 0, top: 10, bottom: 10),
@@ -194,8 +194,7 @@ class AudioWavePainter extends CustomPainter {
 
     final paint = Paint()
       ..color = Colors.white
-      ..strokeWidth =
-          4 // Slightly thicker for better visibility
+      ..strokeWidth = 4 // Slightly thicker for better visibility
       ..strokeCap = StrokeCap.round;
 
     final width = size.width;

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -92,6 +92,8 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   // Track WAL processing progress
   int _totalWalsToProcess = 0;
   int _walsProcessedCount = 0;
+  Timer? _autoUploadTimer;
+  bool _isDisposed = false;
 
   // Computed properties for backward compatibility
   List<Wal> get missingWals => _allWals.where((w) => w.status == WalStatus.miss).toList();
@@ -144,15 +146,24 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   void _initializeProvider() async {
     await refreshWals();
-    _autoUploadPendingPhoneFiles();
+    if (_isDisposed) return;
+    _scheduleAutoUploadPendingPhoneFiles();
   }
 
   bool _isAutoUploading = false;
 
   /// Auto-upload phone WALs to cloud on app open when device is not connected
   /// and no sync is already in progress.
+  void _scheduleAutoUploadPendingPhoneFiles() {
+    _autoUploadTimer?.cancel();
+    _autoUploadTimer = Timer(const Duration(seconds: 3), () {
+      _autoUploadTimer = null;
+      _autoUploadPendingPhoneFiles();
+    });
+  }
+
   void _autoUploadPendingPhoneFiles() async {
-    await Future.delayed(const Duration(seconds: 3));
+    if (_isDisposed) return;
     if (_syncState.isProcessing) return;
     if (_walService.getSyncs().isStorageSyncing || _walService.getSyncs().isSdCardSyncing) return;
     final phoneWals = _allWals
@@ -431,22 +442,27 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   }
 
   @override
-  void onWalSyncedProgress(double percentage,
-      {double? speedKBps,
-      SyncPhase? phase,
-      int? currentFile,
-      int? totalFiles,
-      int? uploadedBytes,
-      int? totalBytesToUpload}) {
+  void onWalSyncedProgress(
+    double percentage, {
+    double? speedKBps,
+    SyncPhase? phase,
+    int? currentFile,
+    int? totalFiles,
+    int? uploadedBytes,
+    int? totalBytesToUpload,
+  }) {
     if (_syncState.isSyncing) {
-      _updateSyncState(_syncState.toSyncing(
+      _updateSyncState(
+        _syncState.toSyncing(
           progress: percentage,
           speedKBps: speedKBps,
           phase: phase,
           currentFile: currentFile,
           totalFiles: totalFiles,
           uploadedBytes: uploadedBytes,
-          totalBytesToUpload: totalBytesToUpload));
+          totalBytesToUpload: totalBytesToUpload,
+        ),
+      );
     }
   }
 
@@ -508,6 +524,9 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   @override
   void dispose() {
+    _isDisposed = true;
+    _autoUploadTimer?.cancel();
+    _autoUploadTimer = null;
     _audioPlayerUtils.removeListener(_onAudioPlayerStateChanged);
     WaveformUtils.clearCache();
     _walService.unsubscribe(this);

--- a/app/lib/providers/voice_recorder_provider.dart
+++ b/app/lib/providers/voice_recorder_provider.dart
@@ -20,6 +20,8 @@ import 'package:omi/utils/l10n_extensions.dart';
 
 enum VoiceRecorderState { idle, recording, transcribing, transcribeSuccess, transcribeFailed, pendingRecovery }
 
+typedef VoiceMessageTranscriber = Future<String> Function(List<File> audioFiles);
+
 class VoiceRecorderProvider extends ChangeNotifier {
   static const _wavPathKey = 'voice_recorder_pending_wav_path';
 
@@ -46,6 +48,11 @@ class VoiceRecorderProvider extends ChangeNotifier {
   // Callbacks for UI integration
   Function(String transcript)? _onTranscriptReady;
   VoidCallback? _onClose;
+
+  final VoiceMessageTranscriber _transcribeVoiceMessage;
+
+  VoiceRecorderProvider({VoiceMessageTranscriber? transcriber})
+      : _transcribeVoiceMessage = transcriber ?? transcribeVoiceMessage;
 
   VoiceRecorderState get state => _state;
   String get transcript => _transcript;
@@ -94,9 +101,9 @@ class VoiceRecorderProvider extends ChangeNotifier {
     // Clean up any previous WAV file
     await _cleanupWavFile();
 
-    // Create temp PCM file for streaming audio to disk
-    final tempDir = await getTemporaryDirectory();
-    _pcmFile = File('${tempDir.path}/voice_recording_${DateTime.now().millisecondsSinceEpoch}.pcm');
+    // Create a persisted PCM file for streaming audio to disk.
+    final recordingsDir = await _recordingsDirectory();
+    _pcmFile = File('${recordingsDir.path}/voice_recording_${DateTime.now().millisecondsSinceEpoch}.pcm');
     _pcmSink = _pcmFile!.openWrite();
 
     // Reset audio levels
@@ -217,18 +224,17 @@ class VoiceRecorderProvider extends ChangeNotifier {
       // Split into chunks if the WAV is large, then transcribe
       final chunks = await splitWavFileIfNeeded(_wavFile!, 16000, 1);
       try {
-        final transcript = await transcribeVoiceMessage(chunks);
-        _transcript = transcript;
-        _state = VoiceRecorderState.transcribeSuccess;
-        _isProcessing = false;
-        notifyListeners();
-
-        if (transcript.isNotEmpty) {
+        final transcript = await _transcribeVoiceMessage(chunks);
+        if (transcript.trim().isNotEmpty) {
+          _transcript = transcript;
+          _state = VoiceRecorderState.transcribeSuccess;
+          _isProcessing = false;
+          notifyListeners();
           _onTranscriptReady?.call(transcript);
           close();
         } else {
-          Logger.debug('Empty transcript received, closing without error');
-          close();
+          Logger.debug('Empty transcript received; preserving recording for retry');
+          _markTranscriptionFailed();
         }
       } finally {
         _cleanupChunkFiles(chunks);
@@ -243,21 +249,19 @@ class VoiceRecorderProvider extends ChangeNotifier {
       _state = VoiceRecorderState.transcribeFailed;
       _isProcessing = false;
       notifyListeners();
-      AppSnackbar.showSnackbarError(
-        globalNavigatorKey.currentContext?.l10n.voiceFailedToTranscribe ?? 'Failed to transcribe audio',
-      );
+      _showTranscriptionFailedSnackbar();
     }
   }
 
-  void retry() {
+  Future<void> retry() async {
     if (_wavFile != null && _wavFile!.existsSync()) {
       // Retry transcription with existing WAV file on disk (no re-encoding needed)
-      _retryTranscription();
+      await _retryTranscription();
     } else if (_pcmFile != null && _pcmFile!.existsSync()) {
       // WAV conversion failed but PCM survived — retry from PCM
-      processRecording();
+      await processRecording();
     } else {
-      startRecording();
+      await startRecording();
     }
   }
 
@@ -271,18 +275,17 @@ class VoiceRecorderProvider extends ChangeNotifier {
     try {
       final chunks = await splitWavFileIfNeeded(_wavFile!, 16000, 1);
       try {
-        final transcript = await transcribeVoiceMessage(chunks);
-        _transcript = transcript;
-        _state = VoiceRecorderState.transcribeSuccess;
-        _isProcessing = false;
-        notifyListeners();
-
-        if (transcript.isNotEmpty) {
+        final transcript = await _transcribeVoiceMessage(chunks);
+        if (transcript.trim().isNotEmpty) {
+          _transcript = transcript;
+          _state = VoiceRecorderState.transcribeSuccess;
+          _isProcessing = false;
+          notifyListeners();
           _onTranscriptReady?.call(transcript);
           close();
         } else {
-          Logger.debug('Empty transcript received on retry, closing without error');
-          close();
+          Logger.debug('Empty transcript received on retry; preserving recording for retry');
+          _markTranscriptionFailed();
         }
       } finally {
         _cleanupChunkFiles(chunks);
@@ -292,10 +295,17 @@ class VoiceRecorderProvider extends ChangeNotifier {
       _state = VoiceRecorderState.transcribeFailed;
       _isProcessing = false;
       notifyListeners();
-      AppSnackbar.showSnackbarError(
-        globalNavigatorKey.currentContext?.l10n.voiceFailedToTranscribe ?? 'Failed to transcribe audio',
-      );
+      _showTranscriptionFailedSnackbar();
     }
+  }
+
+  static Future<Directory> _recordingsDirectory() async {
+    final supportDir = await getApplicationSupportDirectory();
+    final directory = Directory('${supportDir.path}/voice_recordings');
+    if (!directory.existsSync()) {
+      await directory.create(recursive: true);
+    }
+    return directory;
   }
 
   /// Convert a PCM file on disk to a WAV file on disk.
@@ -304,8 +314,8 @@ class VoiceRecorderProvider extends ChangeNotifier {
     final pcmLength = await pcmFile.length();
     final wavHeader = WavBytesUtil.getWavHeader(pcmLength, sampleRate, channelCount: channels);
 
-    final tempDir = await getTemporaryDirectory();
-    final wavPath = '${tempDir.path}/voice_recording_${DateTime.now().millisecondsSinceEpoch}.wav';
+    final recordingsDir = await _recordingsDirectory();
+    final wavPath = '${recordingsDir.path}/voice_recording_${DateTime.now().millisecondsSinceEpoch}.wav';
     final wavFile = File(wavPath);
     final sink = wavFile.openWrite();
 
@@ -423,6 +433,19 @@ class VoiceRecorderProvider extends ChangeNotifier {
         }
       }
     }
+  }
+
+  void _markTranscriptionFailed() {
+    _state = VoiceRecorderState.transcribeFailed;
+    _isProcessing = false;
+    notifyListeners();
+    _showTranscriptionFailedSnackbar();
+  }
+
+  void _showTranscriptionFailedSnackbar() {
+    final context = globalNavigatorKey.currentContext;
+    if (context == null) return;
+    AppSnackbar.showSnackbarError(context.l10n.voiceFailedToTranscribe);
   }
 
   void close() {

--- a/app/test/unit/voice_recorder_test.dart
+++ b/app/test/unit/voice_recorder_test.dart
@@ -433,6 +433,17 @@ void main() {
       }
     });
 
+    Future<File> createPendingWav(String name) async {
+      final wavFile = File(path.join(tempDir.path, name));
+      final sink = wavFile.openWrite();
+      sink.add(WavBytesUtil.getWavHeader(32000, 16000));
+      sink.add(Uint8List(32000));
+      await sink.flush();
+      await sink.close();
+      await SharedPreferencesUtil().saveString('voice_recorder_pending_wav_path', wavFile.path);
+      return wavFile;
+    }
+
     test('transitions to pendingRecovery when WAV file exists', () async {
       // Create a WAV file and persist its path
       final wavFile = File(path.join(tempDir.path, 'pending.wav'));
@@ -475,6 +486,51 @@ void main() {
 
       expect(provider.state, equals(VoiceRecorderState.idle));
       expect(provider.hasPendingRecording, isFalse);
+    });
+
+    test('retry preserves pending WAV when transcription returns empty text', () async {
+      final wavFile = await createPendingWav('empty_retry.wav');
+      var transcriptCallbackCalled = false;
+
+      final provider = VoiceRecorderProvider(transcriber: (_) async => '');
+      provider.setCallbacks(onTranscriptReady: (_) => transcriptCallbackCalled = true);
+      await provider.checkPendingRecording();
+
+      await provider.retry();
+
+      expect(provider.state, equals(VoiceRecorderState.transcribeFailed));
+      expect(provider.isActive, isTrue);
+      expect(transcriptCallbackCalled, isFalse);
+      expect(wavFile.existsSync(), isTrue);
+      expect(SharedPreferencesUtil().getString('voice_recorder_pending_wav_path'), equals(wavFile.path));
+    });
+
+    test('retry preserves pending WAV when transcription throws', () async {
+      final wavFile = await createPendingWav('failed_retry.wav');
+
+      final provider = VoiceRecorderProvider(transcriber: (_) async => throw Exception('transcription failed'));
+      await provider.checkPendingRecording();
+
+      await provider.retry();
+
+      expect(provider.state, equals(VoiceRecorderState.transcribeFailed));
+      expect(provider.isActive, isTrue);
+      expect(wavFile.existsSync(), isTrue);
+      expect(SharedPreferencesUtil().getString('voice_recorder_pending_wav_path'), equals(wavFile.path));
+    });
+
+    test('close discards failed pending WAV only after explicit user removal', () async {
+      final wavFile = await createPendingWav('discard_retry.wav');
+      final provider = VoiceRecorderProvider(transcriber: (_) async => '');
+      await provider.checkPendingRecording();
+      await provider.retry();
+
+      provider.close();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(provider.state, equals(VoiceRecorderState.idle));
+      expect(wavFile.existsSync(), isFalse);
+      expect(SharedPreferencesUtil().getString('voice_recorder_pending_wav_path'), isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary
- preserve recorded voice-message audio across empty/failed transcription retries until the user explicitly closes it
- treat empty transcription responses as failures instead of sending/deleting the recording
- make the dev iOS simulator scheme build and auth with the development bundle ID
- cancel SyncProvider auto-upload timer on dispose to keep full app tests clean

## Verification
- Mac mini: `app/test.sh` passed, 419 tests
- Local MacBook: built, installed, and launched dev iOS simulator app as `com.friend-app-with-wearable.ios12.development` on iPhone 16 Pro

Not merged.