### PR TITLE
Improve PTT transcription with screen context

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -71,6 +71,26 @@ _WS_IDLE_TIMEOUT_S = 60
 _MAX_PCM_BODY_BYTES = 200_000_000
 
 
+def _parse_context_keywords(raw: Optional[str]) -> List[str]:
+    if not raw:
+        return []
+
+    keywords = []
+    seen = set()
+    for item in raw.split(','):
+        keyword = item.strip()
+        if len(keyword) < 2 or len(keyword) > 80:
+            continue
+        key = keyword.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        keywords.append(keyword)
+        if len(keywords) >= 100:
+            break
+    return keywords
+
+
 def filter_messages(messages, app_id):
     logger.info(f'filter_messages {len(messages)} {app_id}')
     collected = []
@@ -501,6 +521,7 @@ async def transcribe_voice_message(
             raise HTTPException(status_code=413, detail=f'Body too large (max {_MAX_PCM_BODY_BYTES} bytes)')
 
         language = request.query_params.get("language")
+        context_keywords = _parse_context_keywords(request.query_params.get("keywords"))
         encoding = request.query_params.get("encoding", "linear16")
         try:
             sample_rate = int(request.query_params.get("sample_rate", "16000"))
@@ -529,6 +550,7 @@ async def transcribe_voice_message(
                 encoding=encoding,
                 sample_rate=sample_rate,
                 channels=channels,
+                keywords=context_keywords,
             )
         except RuntimeError as e:
             logger.error(f'PCM transcription failed: {e}')
@@ -660,6 +682,7 @@ async def transcribe_voice_message_stream(
     sample_rate: int = 16000,
     codec: str = 'linear16',
     channels: int = 1,
+    keywords: Optional[str] = None,
 ):
     """WebSocket endpoint for PTT live mode transcription-only streaming.
 
@@ -672,6 +695,7 @@ async def transcribe_voice_message_stream(
         sample_rate: Audio sample rate in Hz (default 16000)
         codec: Audio codec, must be 'linear16' (default 'linear16')
         channels: Number of audio channels (default 1)
+        keywords: Comma-separated context terms to boost recognition
 
     Client sends:
         - binary frames: audio data (PCM 16-bit)
@@ -729,6 +753,7 @@ async def transcribe_voice_message_stream(
     # PTT transcribe-stream always uses Deepgram (lightweight, no conversation lifecycle).
     # get_stt_service_for_language resolves the language/model for the DG call.
     _, stt_language, stt_model = get_stt_service_for_language(language)
+    context_keywords = _parse_context_keywords(keywords)
 
     loop = asyncio.get_running_loop()
 
@@ -763,6 +788,7 @@ async def transcribe_voice_message_stream(
             sample_rate=sample_rate,
             channels=channels,
             model=stt_model,
+            keywords=context_keywords,
             is_active=lambda: websocket_active,
         )
 

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -560,7 +560,7 @@ class TestVoiceMessageTranscribeEndpoint:
         client, module, saved = _make_chat_client()
         try:
             resp = client.post(
-                '/v2/voice-message/transcribe',
+                '/v2/voice-message/transcribe?keywords=Aarav,Ansh,Aarav',
                 content=b'\x00' * 3200,
                 headers={'Content-Type': 'application/octet-stream'},
             )
@@ -568,6 +568,7 @@ class TestVoiceMessageTranscribeEndpoint:
             data = resp.json()
             assert data['transcript'] == 'Hello world'
             assert data['language'] == 'en'
+            assert mock_transcribe.call_args.kwargs['keywords'] == ['Aarav', 'Ansh']
         finally:
             _cleanup_chat_client(saved)
 

--- a/backend/utils/chat.py
+++ b/backend/utils/chat.py
@@ -115,6 +115,7 @@ def transcribe_pcm_bytes(
     encoding: str = 'linear16',
     sample_rate: int = 16000,
     channels: int = 1,
+    keywords: Optional[List[str]] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """Transcribe raw PCM audio bytes directly via Deepgram pre-recorded API.
 
@@ -138,6 +139,7 @@ def transcribe_pcm_bytes(
             language=stt_language,
             model=stt_model,
             return_language=True,
+            keywords=keywords,
         )
         words, detected_language = result
     else:
@@ -149,6 +151,7 @@ def transcribe_pcm_bytes(
             channels=channels,
             language=stt_language,
             model=stt_model,
+            keywords=keywords,
         )
         detected_language = stt_language
 

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -262,6 +262,7 @@ def deepgram_prerecorded_from_bytes(
     language: Optional[str] = None,
     model: str = "nova-3",
     return_language: bool = False,
+    keywords: Optional[Sequence[str]] = None,
 ) -> Union[List[dict], Tuple[List[dict], str]]:
     """
     Transcribe audio bytes using Deepgram's pre-recorded API.
@@ -280,6 +281,7 @@ def deepgram_prerecorded_from_bytes(
         language: Language code for transcription, or None for auto-detect
         model: Deepgram model name (default 'nova-3')
         return_language: If True, returns (words, language) tuple
+        keywords: Custom vocabulary words to boost transcription accuracy
 
     Returns:
         List of word dicts with format: {'timestamp': [start, end], 'speaker': 'SPEAKER_XX', 'text': 'word'}
@@ -302,6 +304,12 @@ def deepgram_prerecorded_from_bytes(
         }
         if language and not is_multi:
             options["language"] = language
+
+        if keywords:
+            if str(model).startswith("nova-3"):
+                options["keyterm"] = list(keywords)
+            else:
+                options["keywords"] = list(keywords)
 
         # For raw PCM, Deepgram needs encoding + sample_rate to interpret the bytes
         if encoding:
@@ -361,7 +369,16 @@ def deepgram_prerecorded_from_bytes(
         logger.error(f'Deepgram prerecorded from bytes error: {e}')
         if attempts < 2:
             return deepgram_prerecorded_from_bytes(
-                audio_bytes, sample_rate, diarize, attempts + 1, encoding, channels, language, model, return_language
+                audio_bytes,
+                sample_rate,
+                diarize,
+                attempts + 1,
+                encoding,
+                channels,
+                language,
+                model,
+                return_language,
+                keywords,
             )
         raise RuntimeError(f'Deepgram transcription failed after {attempts + 1} attempts: {e}')
 

--- a/desktop/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift
@@ -1,0 +1,562 @@
+import CoreGraphics
+import Foundation
+
+struct PTTContextSnapshot {
+  let capturedAt: Date
+  let keywords: [String]
+  let sourceCount: Int
+}
+
+enum PTTContextVocabularyProvider {
+  private static let maxKeywords = 100
+  private static let maxTextLengthPerScreenshot = 3_000
+  private static let maxImmediateOCRLength = 2_000
+  private static let lookbackSeconds: TimeInterval = 120
+
+  static func capture(at date: Date = Date(), preOverlayImage: CGImage? = nil) async -> PTTContextSnapshot {
+    async let immediateOCRText = captureImmediateScreenText(preferredImage: preOverlayImage)
+    let screenshots = await loadContextScreenshots(around: date)
+    let settingsVocabulary = await MainActor.run {
+      AssistantSettings.shared.effectiveVocabulary
+    }
+
+    var collector = KeywordCollector(limit: maxKeywords)
+    for term in settingsVocabulary {
+      collector.add(term)
+    }
+
+    let visibleText = await immediateOCRText
+    if let visibleText, !visibleText.isEmpty {
+      let clippedText = String(visibleText.prefix(maxImmediateOCRLength))
+      collector.addExtractedTerms(from: clippedText, priority: true)
+      collector.addVisibleTerms(from: clippedText)
+    }
+
+    for screenshot in screenshots {
+      collector.add(screenshot.appName)
+      if let title = screenshot.windowTitle {
+        collector.add(title)
+        collector.addExtractedTerms(from: title, priority: true)
+      }
+      if let ocrText = screenshot.ocrText, !ocrText.isEmpty {
+        collector.addExtractedTerms(from: String(ocrText.prefix(maxTextLengthPerScreenshot)), priority: false)
+      }
+    }
+
+    let keywords = collector.values
+    let sample = keywords.prefix(12).joined(separator: ", ")
+    let immediateSourceCount = (visibleText?.isEmpty == false) ? 1 : 0
+    log("PTTContextVocabulary: captured \(keywords.count) keywords from \(screenshots.count) screenshots + \(immediateSourceCount) immediate OCR source(s); sample=[\(sample)]")
+    return PTTContextSnapshot(
+      capturedAt: date,
+      keywords: keywords,
+      sourceCount: screenshots.count + immediateSourceCount
+    )
+  }
+
+  private static func loadContextScreenshots(around date: Date) async -> [Screenshot] {
+    do {
+      let startDate = date.addingTimeInterval(-lookbackSeconds)
+      let screenshots = try await RewindDatabase.shared.getScreenshots(
+        from: startDate,
+        to: date.addingTimeInterval(2),
+        limit: 12
+      )
+      if !screenshots.isEmpty {
+        return screenshots
+      }
+      return try await RewindDatabase.shared.getRecentScreenshots(limit: 8)
+    } catch {
+      logError("PTTContextVocabulary: failed to load screenshot context", error: error)
+      return []
+    }
+  }
+
+  private static func captureImmediateScreenText(preferredImage: CGImage?) async -> String? {
+    if let preferredImage,
+       let text = await extractVisibleText(from: preferredImage) {
+      log("PTTContextVocabulary: immediate OCR used pre-overlay display image")
+      return text
+    }
+
+    let screenCaptureService = ScreenCaptureService()
+    let activeWindowInfo = await ScreenCaptureService.getActiveWindowInfoAsync()
+    let activeAppName = activeWindowInfo.appName?.lowercased() ?? ""
+    let shouldCaptureActiveWindow = !isOmiApp(activeAppName)
+    let activeWindowImage: CGImage?
+    if shouldCaptureActiveWindow, let windowID = activeWindowInfo.windowID {
+      switch await screenCaptureService.captureWindowCGImage(windowID: windowID) {
+      case .success(let image):
+        activeWindowImage = image
+      case .windowGone, .failed:
+        activeWindowImage = nil
+      }
+    } else {
+      activeWindowImage = nil
+      if !activeAppName.isEmpty {
+        log("PTTContextVocabulary: skipped active-window OCR for Omi window (\(activeAppName))")
+      }
+    }
+
+    let image: CGImage?
+    if let activeWindowImage {
+      image = activeWindowImage
+    } else {
+      image = await MainActor.run(resultType: CGImage?.self, body: {
+        ScreenCaptureManager.captureScreenImage()
+      })
+    }
+
+    guard let image else {
+      return nil
+    }
+
+    return await extractVisibleText(from: image)
+  }
+
+  private static func extractVisibleText(from image: CGImage) async -> String? {
+    do {
+      let text = try await RewindOCRService.shared.extractText(from: image)
+      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmed.isEmpty {
+        log("PTTContextVocabulary: immediate OCR found no visible text")
+        return nil
+      }
+      return trimmed
+    } catch {
+      logError("PTTContextVocabulary: immediate OCR failed", error: error)
+      return nil
+    }
+  }
+
+  private static func isOmiApp(_ appName: String) -> Bool {
+    appName.contains("omi") || appName.contains("floating-agent")
+  }
+}
+
+enum PTTTranscriptContextualCorrector {
+  static func correct(_ transcript: String, keywords: [String]) -> String {
+    let phraseCorrected = correctCommonPTTPhrases(in: transcript)
+    let brandCorrected = correctOmiBrand(in: phraseCorrected)
+    let terms = keywords
+      .map { canonicalNameTerm($0) }
+      .compactMap { $0 }
+      .filter { $0.count >= 3 && $0.count <= 32 }
+
+    guard !terms.isEmpty else { return brandCorrected }
+
+    var corrected = brandCorrected
+    var replacements: [(String, String)] = []
+
+    let directedNameCorrected = correctDirectedNameObject(in: corrected, terms: terms)
+    if directedNameCorrected != corrected {
+      replacements.append((corrected, directedNameCorrected))
+      corrected = directedNameCorrected
+    }
+
+    let greetingCorrected = correctGreetingTarget(in: corrected, terms: terms)
+    if greetingCorrected != corrected {
+      replacements.append((corrected, greetingCorrected))
+      corrected = greetingCorrected
+    }
+
+    if corrected != transcript {
+      log("PTTTranscriptCorrector: applied \(replacements.count) context correction(s)")
+    }
+
+    return corrected
+  }
+
+  private static func correctGreetingTarget(in text: String, terms: [String]) -> String {
+    let patterns = [
+      #"(?i)^\s*(?:hey|hi|hello|yo|lol|help|ok|okay)(?:\s+|[,.;:!?-]+\s*)([A-Za-z][A-Za-z'\-]{1,31})"#,
+      #"(?i)^([A-Za-z][A-Za-z'\-]{1,31})(?=(?:[,.;:!?-]+\s*|\s+)(?:how|what|are|is|you)\b|[,.;:!?-])"#
+    ]
+
+    for pattern in patterns {
+      guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+      let nsText = text as NSString
+      guard let match = regex.firstMatch(in: text, range: NSRange(location: 0, length: nsText.length)),
+            match.numberOfRanges > 1 else { continue }
+
+      let candidate = nsText.substring(with: match.range(at: 1))
+      guard !KeywordCollector.stopWords.contains(candidate.lowercased()),
+            let replacement = bestGreetingTargetReplacement(for: candidate, terms: terms),
+            replacement.caseInsensitiveCompare(candidate) != .orderedSame,
+            let range = Range(match.range(at: 1), in: text)
+      else { continue }
+
+      var updated = text
+      updated.replaceSubrange(range, with: replacement)
+      log("PTTTranscriptCorrector: greeting target '\(candidate)' -> '\(replacement)'")
+      return updated
+    }
+
+    return text
+  }
+
+  private static func correctDirectedNameObject(in text: String, terms: [String]) -> String {
+    let patterns = [
+      #"(?i)\b(?:say|tell|send)\s+(?:hi|hello|hey)\s+(?:to|two|too)\s+([A-Za-z][A-Za-z'\-]{1,31})\b"#,
+      #"(?i)\b(?:say|tell|send)\s+([A-Za-z][A-Za-z'\-]{1,31})\s+(?:hi|hello|hey)\b"#
+    ]
+
+    for pattern in patterns {
+      guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+      let nsText = text as NSString
+      guard let match = regex.firstMatch(in: text, range: NSRange(location: 0, length: nsText.length)),
+            match.numberOfRanges > 1 else { continue }
+
+      let candidate = nsText.substring(with: match.range(at: 1))
+      guard !KeywordCollector.stopWords.contains(candidate.lowercased()),
+            let replacement = bestGreetingTargetReplacement(for: candidate, terms: terms),
+            replacement.caseInsensitiveCompare(candidate) != .orderedSame,
+            let range = Range(match.range(at: 1), in: text)
+      else { continue }
+
+      var updated = text
+      updated.replaceSubrange(range, with: replacement)
+      log("PTTTranscriptCorrector: directed name '\(candidate)' -> '\(replacement)'")
+      return updated
+    }
+
+    return text
+  }
+
+  private static func bestGreetingTargetReplacement(for candidate: String, terms: [String]) -> String? {
+    let lowerCandidate = candidate.lowercased()
+    var best: (term: String, score: Int)?
+
+    for term in terms {
+      let canonical = canonicalNameTerm(term)
+      guard let canonical else { continue }
+      let lowerTerm = canonical.lowercased()
+      guard lowerTerm != lowerCandidate else { continue }
+
+      let score = greetingTargetScore(candidate: lowerCandidate, term: lowerTerm)
+      guard score > 0 else { continue }
+      if best == nil || score > best!.score {
+        best = (canonical, score)
+      }
+    }
+
+    return best?.term
+  }
+
+  private static func greetingTargetScore(candidate: String, term: String) -> Int {
+    let collapsedCandidate = collapseRepeatedLetters(candidate)
+    let collapsedTerm = collapseRepeatedLetters(term)
+    if collapsedCandidate == collapsedTerm {
+      return 124
+    }
+
+    if candidate.first == term.first {
+      if candidate.count >= 3, candidate.count < term.count {
+        let prefix = String(term.prefix(candidate.count))
+        let prefixDistance = levenshtein(candidate, prefix)
+        if prefixDistance == 0 { return 120 }
+        if prefixDistance == 1 { return 112 }
+      }
+
+      let distance = levenshtein(candidate, term)
+      if distance <= 2 { return 100 - distance }
+      if distance <= 3 && min(candidate.count, term.count) >= 5 { return 80 - distance }
+
+      let collapsedDistance = levenshtein(collapsedCandidate, collapsedTerm)
+      if collapsedDistance <= 1 { return 98 - collapsedDistance }
+    }
+
+    if candidate.count > term.count {
+      let maxSuffixLength = min(candidate.count, term.count + 3)
+      for length in term.count...maxSuffixLength {
+        let suffix = String(candidate.suffix(length))
+        let distance = levenshtein(suffix, term)
+        if distance <= 1 { return 118 - distance }
+        if distance <= 2 && term.count >= 4 { return 96 - distance }
+      }
+    }
+
+    if sharedSuffixLength(candidate, term) >= 3 {
+      return 72
+    }
+
+    if phoneticTail(candidate) == phoneticTail(term), phoneticTail(candidate).count >= 2 {
+      return 68
+    }
+
+    return 0
+  }
+
+  private static func collapseRepeatedLetters(_ value: String) -> String {
+    var output = ""
+    var previous: Character?
+    for character in value.lowercased() {
+      guard character >= "a", character <= "z" else { continue }
+      if character != previous {
+        output.append(character)
+      }
+      previous = character
+    }
+    return output
+  }
+
+  private static func sharedSuffixLength(_ lhs: String, _ rhs: String) -> Int {
+    let left = Array(lhs.reversed())
+    let right = Array(rhs.reversed())
+    var count = 0
+    for index in 0..<min(left.count, right.count) {
+      guard left[index] == right[index] else { break }
+      count += 1
+    }
+    return count
+  }
+
+  private static func phoneticTail(_ value: String) -> String {
+    value.lowercased()
+      .replacingOccurrences(of: #"[^a-z]"#, with: "", options: .regularExpression)
+      .replacingOccurrences(of: #"[aeiouy]"#, with: "", options: .regularExpression)
+      .replacingOccurrences(of: #"([a-z])\1+"#, with: "$1", options: .regularExpression)
+  }
+
+  private static func correctOmiBrand(in text: String) -> String {
+    let pattern = #"\b(?:omi|omni|omie|omy|ohmi|oh me)\b"#
+    guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+      return text
+    }
+    return regex.stringByReplacingMatches(
+      in: text,
+      range: NSRange(location: 0, length: (text as NSString).length),
+      withTemplate: "Omi"
+    )
+  }
+
+  private static func correctCommonPTTPhrases(in text: String) -> String {
+    let replacements: [(pattern: String, template: String)] = [
+      (#"\bHome are you\b"#, "How are you")
+    ]
+
+    var updated = text
+    for replacement in replacements {
+      guard let regex = try? NSRegularExpression(pattern: replacement.pattern, options: [.caseInsensitive]) else {
+        continue
+      }
+      updated = regex.stringByReplacingMatches(
+        in: updated,
+        range: NSRange(location: 0, length: (updated as NSString).length),
+        withTemplate: replacement.template
+      )
+    }
+    return updated
+  }
+
+  private static func canonicalNameTerm(_ raw: String) -> String? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+      .trimmingCharacters(in: CharacterSet(charactersIn: ".,;:()[]{}<>\"'"))
+    guard !trimmed.isEmpty else { return nil }
+    guard trimmed.range(of: #"^[A-Za-z][A-Za-z'\-]{2,31}$"#, options: .regularExpression) != nil else { return nil }
+    guard !KeywordCollector.stopWords.contains(trimmed.lowercased()) else { return nil }
+    if trimmed == trimmed.uppercased(),
+       trimmed.count <= 4,
+       trimmed.caseInsensitiveCompare("Omi") != .orderedSame {
+      return nil
+    }
+    return trimmed
+  }
+
+  private static func levenshtein(_ lhs: String, _ rhs: String) -> Int {
+    let left = Array(lhs)
+    let right = Array(rhs)
+    guard !left.isEmpty else { return right.count }
+    guard !right.isEmpty else { return left.count }
+
+    var previous = Array(0...right.count)
+    for (i, leftChar) in left.enumerated() {
+      var current = [i + 1]
+      for (j, rightChar) in right.enumerated() {
+        if leftChar == rightChar {
+          current.append(previous[j])
+        } else {
+          current.append(min(previous[j], previous[j + 1], current[j]) + 1)
+        }
+      }
+      previous = current
+    }
+    return previous[right.count]
+  }
+}
+
+actor PTTTranscriptCleanupService {
+  static let shared = PTTTranscriptCleanupService()
+
+  private let maxContextTerms = 40
+
+  func cleanup(_ transcript: String, keywords: [String]) async -> String {
+    let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.count >= 4, trimmed.count <= 500 else { return transcript }
+
+    let context = contextTerms(from: keywords)
+    let contextText = context.isEmpty ? "None" : context.joined(separator: ", ")
+    let prompt = """
+      Raw ASR transcript:
+      \(trimmed)
+
+      Visible/context terms:
+      \(contextText)
+
+      Correct the transcript for obvious speech-to-text errors. Use visible/context terms only to fix proper nouns and product/company names.
+
+      Rules:
+      - Return only the corrected transcript, no quotes or explanation.
+      - Preserve the user's meaning and wording as much as possible.
+      - Do not answer the question.
+      - Do not add facts not implied by the raw transcript.
+      - Prefer Omi for the company/product name.
+      - If uncertain, leave the phrase unchanged.
+      """
+
+    do {
+      let response = try await withTimeout(seconds: 2) {
+        let client = try GeminiClient(model: ModelQoS.Gemini.proactive)
+        return try await client.sendTextRequest(
+          prompt: prompt,
+          systemPrompt: "You clean up short voice ASR transcripts. Return only the corrected transcript.",
+          maxRetries: 0,
+          timeout: 2
+        )
+      }
+      let cleaned = sanitize(response)
+      guard shouldUse(cleaned: cleaned, original: trimmed) else { return transcript }
+      if cleaned != trimmed {
+        log("PTTTranscriptCleanup: '\(trimmed)' -> '\(cleaned)'")
+      }
+      return cleaned
+    } catch {
+      logError("PTTTranscriptCleanup: failed", error: error)
+      return transcript
+    }
+  }
+
+  private func contextTerms(from keywords: [String]) -> [String] {
+    var seen = Set<String>()
+    var terms: [String] = []
+    let pattern = #"\b[A-Za-z][A-Za-z'\-]{1,31}\b"#
+
+    for keyword in keywords {
+      let normalized = keyword
+        .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+      let nsText = normalized as NSString
+      for match in regex.matches(in: normalized, range: NSRange(location: 0, length: nsText.length)) {
+        let term = nsText.substring(with: match.range)
+        let key = term.lowercased()
+        guard !KeywordCollector.stopWords.contains(key), !seen.contains(key) else { continue }
+        seen.insert(key)
+        terms.append(term)
+        if terms.count >= maxContextTerms {
+          return terms
+        }
+      }
+    }
+
+    return terms
+  }
+
+  private func sanitize(_ raw: String) -> String {
+    raw.trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: #"^["'`]+|["'`]+$"#, with: "", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func shouldUse(cleaned: String, original: String) -> Bool {
+    guard !cleaned.isEmpty else { return false }
+    guard cleaned.count <= max(original.count * 3, original.count + 80) else { return false }
+    guard cleaned.range(of: "\n") == nil else { return false }
+    return true
+  }
+
+  private func withTimeout<T: Sendable>(
+    seconds: UInt64,
+    operation: @escaping @Sendable () async throws -> T
+  ) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+      group.addTask {
+        try await operation()
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+        throw CancellationError()
+      }
+      guard let result = try await group.next() else {
+        throw CancellationError()
+      }
+      group.cancelAll()
+      return result
+    }
+  }
+}
+
+private struct KeywordCollector {
+  static let stopWords: Set<String> = [
+    "about", "after", "again", "all", "also", "and", "app", "are", "ask", "back", "browser", "but", "can",
+    "chat", "code", "done", "each", "for", "from", "has", "have", "here", "into", "just", "like", "more",
+    "hello", "hi", "next", "not", "now", "okay", "open", "orange", "question", "reply", "running", "said",
+    "say", "send", "sent", "show", "some", "task", "tell", "test", "text", "that", "the", "this", "thread",
+    "time", "to", "too", "two", "use", "user", "voice", "was", "what", "when", "with", "you", "your"
+  ]
+
+  private let limit: Int
+  private var seen = Set<String>()
+  private(set) var values: [String] = []
+
+  init(limit: Int) {
+    self.limit = limit
+  }
+
+  mutating func add(_ raw: String) {
+    guard values.count < limit else { return }
+    let term = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+      .trimmingCharacters(in: CharacterSet(charactersIn: ".,;:()[]{}<>\"'"))
+    guard term.count >= 2 && term.count <= 80 else { return }
+    guard term.rangeOfCharacter(from: .letters) != nil else { return }
+    let key = term.lowercased()
+    guard !Self.stopWords.contains(key), !seen.contains(key) else { return }
+    seen.insert(key)
+    values.append(term)
+  }
+
+  mutating func addExtractedTerms(from text: String, priority: Bool) {
+    let patterns = [
+      #"\b[A-Z][A-Za-z'\-]{2,}(?:\s+[A-Z][A-Za-z'\-]{2,}){1,2}\b"#,
+      #"\b[A-Z][A-Za-z'\-]{2,}\b"#,
+      #"\b[A-Z]{2,8}\b"#
+    ]
+
+    for pattern in patterns {
+      guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+      let nsText = text as NSString
+      let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+      for match in matches {
+        let term = nsText.substring(with: match.range)
+        if priority {
+          add(term)
+        } else if values.count < limit {
+          add(term)
+        }
+      }
+    }
+  }
+
+  mutating func addVisibleTerms(from text: String) {
+    let pattern = #"\b[A-Za-z][A-Za-z'\-]{1,31}\b"#
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+
+    let nsText = text as NSString
+    let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+
+    for match in matches {
+      add(nsText.substring(with: match.range))
+      guard values.count < limit else { return }
+    }
+  }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -45,6 +45,8 @@ class PushToTalkManager: ObservableObject {
   private var finalizeWorkItem: DispatchWorkItem?
   private var hasMicPermission: Bool = false
   private var isCurrentSessionFollowUp = false
+  private var currentContextSnapshot: PTTContextSnapshot?
+  private var contextCaptureTask: Task<Void, Never>?
 
   // Batch mode: accumulate raw audio for post-recording transcription
   private var batchAudioBuffer = Data()
@@ -217,6 +219,7 @@ class PushToTalkManager: ObservableObject {
     isCurrentSessionFollowUp = barState?.showingAIResponse == true
     transcriptSegments = []
     lastInterimText = ""
+    currentContextSnapshot = nil
     finalizeWorkItem?.cancel()
     finalizeWorkItem = nil
 
@@ -229,10 +232,10 @@ class PushToTalkManager: ObservableObject {
 
     let isFollowUp = isCurrentSessionFollowUp
     AnalyticsManager.shared.floatingBarPTTStarted(mode: isFollowUp ? "follow_up_hold" : "hold")
+    let preOverlayImage = ScreenCaptureManager.captureScreenImage()
     updateBarState()
 
-
-    startAudioTranscription()
+    captureContextAndStartAudio(preOverlayImage: preOverlayImage)
     log("PushToTalkManager: started listening (hold mode, followUp=\(isFollowUp))")
   }
 
@@ -258,9 +261,9 @@ class PushToTalkManager: ObservableObject {
     if transcriptionService == nil {
       transcriptSegments = []
       lastInterimText = ""
-
-
-      startAudioTranscription()
+      currentContextSnapshot = nil
+      let preOverlayImage = ScreenCaptureManager.captureScreenImage()
+      captureContextAndStartAudio(preOverlayImage: preOverlayImage)
     }
 
     updateBarState()
@@ -289,10 +292,13 @@ class PushToTalkManager: ObservableObject {
     finalizeWorkItem = nil
     liveFinalizationTimeout?.cancel()
     liveFinalizationTimeout = nil
+    contextCaptureTask?.cancel()
+    contextCaptureTask = nil
     stopAudioTranscription()
     state = .idle
     transcriptSegments = []
     lastInterimText = ""
+    currentContextSnapshot = nil
     batchAudioLock.lock()
     batchAudioBuffer = Data()
     batchAudioLock.unlock()
@@ -352,27 +358,23 @@ class PushToTalkManager: ObservableObject {
 
       Task {
         do {
-          let language = AssistantSettings.shared.effectiveTranscriptionLanguage
+          await self.contextCaptureTask?.value
+          let language = self.pttBatchTranscriptionLanguage()
           let audioSeconds = Double(audioData.count) / (16000.0 * 2.0)
-          log("PushToTalkManager: batch audio \(audioData.count) bytes (\(String(format: "%.1f", audioSeconds))s), language=\(language)")
+          log("PushToTalkManager: batch audio \(audioData.count) bytes (\(String(format: "%.1f", audioSeconds))s), pttLanguage=\(language), selectedLanguage=\(AssistantSettings.shared.transcriptionLanguage), autoDetect=\(AssistantSettings.shared.transcriptionAutoDetect)")
 
-          // First attempt with the user's effective language (usually "multi")
           var transcript = try await TranscriptionService.batchTranscribe(
             audioData: audioData,
-            language: language
+            language: language,
+            contextKeywords: self.currentContextSnapshot?.keywords ?? []
           )
 
-          // If multi-language detection returned empty on short audio (<5s),
-          // retry with the user's explicit language — Deepgram's language
-          // detection needs more context and often fails on short clips.
-          if (transcript == nil || transcript?.isEmpty == true)
-              && language == "multi" && audioSeconds < 5.0 {
-            let fallback = AssistantSettings.shared.transcriptionLanguage
-            let retryLang = (fallback.isEmpty || fallback == "multi") ? "en" : fallback
-            log("PushToTalkManager: multi returned empty on short audio, retrying with '\(retryLang)'")
+          if (transcript == nil || transcript?.isEmpty == true) && language != "en" && audioSeconds < 5.0 {
+            log("PushToTalkManager: selected language returned empty on short audio, retrying with 'en'")
             transcript = try await TranscriptionService.batchTranscribe(
               audioData: audioData,
-              language: retryLang
+              language: "en",
+              contextKeywords: self.currentContextSnapshot?.keywords ?? []
             )
           }
 
@@ -408,6 +410,15 @@ class PushToTalkManager: ObservableObject {
     }
   }
 
+  private func pttBatchTranscriptionLanguage() -> String {
+    let selected = AssistantSettings.shared.transcriptionLanguage
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    if selected.isEmpty || selected == "multi" || selected == "auto" {
+      return "en"
+    }
+    return selected
+  }
+
   private func sendTranscript() {
     stopAudioTranscription()
 
@@ -416,6 +427,10 @@ class PushToTalkManager: ObservableObject {
       in: .whitespacesAndNewlines)
     if query.isEmpty {
       query = lastInterimText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    let contextKeywords = currentContextSnapshot?.keywords ?? []
+    if !query.isEmpty {
+      query = PTTTranscriptContextualCorrector.correct(query, keywords: contextKeywords)
     }
     let hasQuery = !query.isEmpty
     let wasFollowUp = isCurrentSessionFollowUp
@@ -434,6 +449,7 @@ class PushToTalkManager: ObservableObject {
     state = .idle
     transcriptSegments = []
     lastInterimText = ""
+    currentContextSnapshot = nil
     updateBarState(skipResize: hasQuery || wasFollowUp)
 
     guard hasQuery else {
@@ -441,6 +457,15 @@ class PushToTalkManager: ObservableObject {
       return
     }
 
+    Task { [weak self, query, contextKeywords, wasFollowUp] in
+      let cleanedQuery = await PTTTranscriptCleanupService.shared.cleanup(query, keywords: contextKeywords)
+      await MainActor.run {
+        self?.sendQuery(cleanedQuery, wasFollowUp: wasFollowUp)
+      }
+    }
+  }
+
+  private func sendQuery(_ query: String, wasFollowUp: Bool) {
     if wasFollowUp {
       log("PushToTalkManager: sending follow-up query (\(query.count) chars): \(query)")
       FloatingControlBarManager.shared.sendFollowUpQuery(query, fromVoice: true)
@@ -451,6 +476,20 @@ class PushToTalkManager: ObservableObject {
   }
 
   // MARK: - Audio Transcription (Dedicated Session)
+
+  private func captureContextAndStartAudio(preOverlayImage: CGImage? = nil) {
+    contextCaptureTask?.cancel()
+    startAudioTranscription()
+    let captureStartedAt = Date()
+    contextCaptureTask = Task { [weak self] in
+      let snapshot = await PTTContextVocabularyProvider.capture(at: captureStartedAt, preOverlayImage: preOverlayImage)
+      await MainActor.run {
+        guard let self, !Task.isCancelled else { return }
+        guard self.state == .listening || self.state == .lockedListening || self.state == .finalizing else { return }
+        self.currentContextSnapshot = snapshot
+      }
+    }
+  }
 
   private func startAudioTranscription() {
     // Always re-check permission (it can be granted at any time via System Settings)
@@ -486,7 +525,11 @@ class PushToTalkManager: ObservableObject {
 
       do {
         let language = AssistantSettings.shared.effectiveTranscriptionLanguage
-        let service = try TranscriptionService(language: language, channels: 1)
+        let service = try TranscriptionService(
+          language: language,
+          channels: 1,
+          contextKeywords: currentContextSnapshot?.keywords ?? []
+        )
         transcriptionService = service
 
         service.start(
@@ -592,14 +635,6 @@ class PushToTalkManager: ObservableObject {
       transcriptSegments.append(segment.text)
     }
     lastInterimText = ""
-
-    if state == .listening || state == .lockedListening {
-      let liveText = transcriptSegments.joined(separator: " ")
-      barState?.voiceTranscript = liveText
-      if isCurrentSessionFollowUp {
-        barState?.voiceFollowUpTranscript = liveText
-      }
-    }
 
     // In finalizing state, segments mean backend is done — send immediately
     if state == .finalizing {

--- a/desktop/Desktop/Sources/FloatingControlBar/ScreenCaptureManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ScreenCaptureManager.swift
@@ -2,30 +2,26 @@ import AppKit
 import CWebP
 
 class ScreenCaptureManager {
-    /// Returns WebP data for the screen under the mouse cursor at full Retina
-    /// resolution, compressed in memory via libwebp. No disk I/O.
-    static func captureScreenData() -> Data? {
+    /// Returns a CGImage for the screen under the mouse cursor.
+    static func captureScreenImage() -> CGImage? {
         guard CGPreflightScreenCaptureAccess() else {
             log("ScreenCaptureManager: Screen recording permission not granted, skipping capture")
             return nil
         }
 
-        // Capture the screen where the mouse cursor is, not just the primary display
-        let displayID: CGDirectDisplayID = {
-            let mouseLocation = NSEvent.mouseLocation
-            for screen in NSScreen.screens {
-                if screen.frame.contains(mouseLocation),
-                   let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID {
-                    return screenNumber
-                }
-            }
-            return CGMainDisplayID()
-        }()
-
+        let displayID = displayIDUnderMouse()
         guard let image = CGDisplayCreateImage(displayID) else {
             log("ScreenCaptureManager: Could not capture screen (display \(displayID))")
             return nil
         }
+
+        return image
+    }
+
+    /// Returns WebP data for the screen under the mouse cursor at full Retina
+    /// resolution, compressed in memory via libwebp. No disk I/O.
+    static func captureScreenData() -> Data? {
+        guard let image = captureScreenImage() else { return nil }
 
         let width = image.width
         let height = image.height
@@ -65,6 +61,17 @@ class ScreenCaptureManager {
 
         log("ScreenCaptureManager: Screenshot captured \(width)x\(height), WebP \(data.count / 1024) KB")
         return data
+    }
+
+    private static func displayIDUnderMouse() -> CGDirectDisplayID {
+        let mouseLocation = NSEvent.mouseLocation
+        for screen in NSScreen.screens {
+            if screen.frame.contains(mouseLocation),
+               let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID {
+                return screenNumber
+            }
+        }
+        return CGMainDisplayID()
     }
 
     /// Legacy file-based capture (kept for callers that need a URL).

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -475,7 +475,7 @@ class ShortcutSettings: ObservableObject {
            let mode = PTTTranscriptionMode(rawValue: saved) {
             self.pttTranscriptionMode = mode
         } else {
-            self.pttTranscriptionMode = .live
+            self.pttTranscriptionMode = .batch
         }
         self.draggableBarEnabled = UserDefaults.standard.object(forKey: "shortcut_draggableBarEnabled") as? Bool ?? false
         self.floatingBarVoiceAnswersEnabled = UserDefaults.standard.object(forKey: "shortcut_floatingBarVoiceAnswersEnabled") as? Bool ?? true

--- a/desktop/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -167,7 +167,7 @@ actor GeminiClient {
     if let cString = getenv("OMI_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty {
       return url.hasSuffix("/") ? url : url + "/"
     }
-    return ""
+    return "https://api.omi.me/"
   }
 
   enum GeminiClientError: LocalizedError {
@@ -229,7 +229,8 @@ actor GeminiClient {
   init(apiKey: String? = nil, model: String = ModelQoS.Gemini.proactive) throws {
     // BREAKING CHANGE (issue #5861): apiKey parameter is ignored.
     // All Gemini requests now route through the backend proxy which supplies
-    // the key server-side. Requires OMI_API_URL to be set (standard dev flow via run.sh).
+    // the key server-side. Defaults to production when OMI_API_URL is absent
+    // so installed test bundles launched from Finder still have AI features.
     guard !Self.proxyBaseURL.isEmpty else {
       throw GeminiClientError.missingAPIKey
     }
@@ -414,9 +415,10 @@ actor GeminiClient {
   /// - Returns: The text response from the model
   func sendTextRequest(
     prompt: String,
-    systemPrompt: String
+    systemPrompt: String,
+    maxRetries: Int = 2,
+    timeout: TimeInterval = 300
   ) async throws -> String {
-    let maxRetries = 2
     var lastError: Error?
 
     for attempt in 0...maxRetries {
@@ -438,7 +440,7 @@ actor GeminiClient {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue(try await authHeader(), forHTTPHeaderField: "Authorization")
-        urlRequest.timeoutInterval = 300
+        urlRequest.timeoutInterval = timeout
         urlRequest.httpBody = try JSONEncoder().encode(request)
 
         let (data, urlResponse) = try await URLSession.shared.data(for: urlRequest)

--- a/desktop/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/Desktop/Sources/TranscriptionService.swift
@@ -97,12 +97,48 @@ class TranscriptionService {
     private let encoding = "linear16"
     private let channels = 1  // Always mono for Python backend streaming
     private let streamingMode: StreamingMode
+    private let contextKeywords: [String]
 
     /// Python backend base URL for transcription endpoints.
     /// Resolution order: beta release channel → OMI_PYTHON_API_URL → https://api.omi.me/
     /// NOTE: Do NOT fall back to OMI_API_URL — that points to the Rust desktop-backend
     /// (Cloud Run), which does not have /v2/voice-message/* or /v4/listen endpoints.
     private static let pythonBackendBaseURL: String = DesktopBackendEnvironment.pythonBaseURL()
+
+    private static func sanitizedContextKeywords(_ keywords: [String]) -> [String] {
+        let stopWords: Set<String> = [
+            "about", "after", "again", "all", "also", "and", "app", "are", "ask", "back", "browser", "but", "can",
+            "chat", "code", "done", "each", "for", "from", "get", "has", "have", "help", "here", "home", "how",
+            "into", "just", "like", "means", "more", "next", "not", "now", "open", "question", "read", "right",
+            "said", "screen", "sent", "show", "some", "task", "test", "text", "that", "the", "this", "time",
+            "use", "user", "voice", "was", "what", "when", "window", "with", "you", "your"
+        ]
+        var seen = Set<String>()
+        var result: [String] = []
+        for keyword in ["Omi", "OMI"] + keywords {
+            let normalized = keyword
+                .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let pattern = #"\b[A-Za-z][A-Za-z'\-]{1,31}\b"#
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let nsText = normalized as NSString
+            let matches = regex.matches(in: normalized, range: NSRange(location: 0, length: nsText.length))
+
+            for match in matches {
+                let term = nsText.substring(with: match.range)
+                let key = term.lowercased()
+                guard term.count >= 2 && term.count <= 32 else { continue }
+                guard !stopWords.contains(key), !seen.contains(key) else { continue }
+                seen.insert(key)
+                result.append(term)
+                if result.count >= 40 {
+                    return result
+                }
+            }
+        }
+        return result
+    }
 
     // Reconnection (internal for @testable import)
     var reconnectAttempts = 0
@@ -126,11 +162,12 @@ class TranscriptionService {
     /// - Parameters:
     ///   - language: Language code for transcription (e.g., "en", "uk", "ru", "multi" for auto-detect)
     ///   - mode: Streaming mode — `.conversation` for `/v4/listen` (default), `.ptt` for `/v2/voice-message/transcribe-stream`
-    init(language: String = "en", mode: StreamingMode = .conversation) throws {
+    init(language: String = "en", mode: StreamingMode = .conversation, contextKeywords: [String] = []) throws {
         self.apiKey = ""  // Not needed — Python backend uses Firebase auth
         self.language = language
         self.streamingMode = mode
-        log("TranscriptionService: Initialized for \(mode == .conversation ? "/v4/listen" : "/v2/voice-message/transcribe-stream"), language=\(language)")
+        self.contextKeywords = Self.sanitizedContextKeywords(contextKeywords)
+        log("TranscriptionService: Initialized for \(mode == .conversation ? "/v4/listen" : "/v2/voice-message/transcribe-stream"), language=\(language), contextKeywords=\(self.contextKeywords.count)")
     }
 
     /// Initialize for batch (PTT) mode only — uses Python backend `/v2/voice-message/transcribe`
@@ -146,6 +183,7 @@ class TranscriptionService {
         self.apiKey = ""
         self.language = language
         self.streamingMode = .ptt  // Batch doesn't stream, but PTT is the correct context
+        self.contextKeywords = []
         log("TranscriptionService: Initialized for batch (PTT) mode via Python backend")
     }
 
@@ -153,8 +191,8 @@ class TranscriptionService {
 
     /// Legacy init with channels parameter — used by PushToTalkManager for PTT live mode.
     /// Routes to `/v2/voice-message/transcribe-stream` (PTT-only transcription).
-    convenience init(language: String = "en", channels: Int) throws {
-        try self.init(language: language, mode: .ptt)
+    convenience init(language: String = "en", channels: Int, contextKeywords: [String] = []) throws {
+        try self.init(language: language, mode: .ptt, contextKeywords: contextKeywords)
     }
 
     /// Flush remaining audio and (for PTT mode) tell the backend to finalize transcription.
@@ -303,12 +341,16 @@ class TranscriptionService {
         case .ptt:
             // PTT-only transcription — no conversation lifecycle
             path = "/v2/voice-message/transcribe-stream"
-            queryItems = [
+            var items = [
                 URLQueryItem(name: "language", value: language),
                 URLQueryItem(name: "sample_rate", value: String(sampleRate)),
                 URLQueryItem(name: "codec", value: encoding),
                 URLQueryItem(name: "channels", value: String(channels)),
             ]
+            if !contextKeywords.isEmpty {
+                items.append(URLQueryItem(name: "keywords", value: contextKeywords.joined(separator: ",")))
+            }
+            queryItems = items
         }
 
         guard var components = URLComponents(string: "\(wsBase)\(path)") else {
@@ -536,7 +578,8 @@ extension TranscriptionService {
     static func batchTranscribe(
         audioData: Data,
         language: String = "en",
-        apiKey: String? = nil
+        apiKey: String? = nil,
+        contextKeywords: [String] = []
     ) async throws -> String? {
         // Always use Firebase auth + Python backend
         let authService = await MainActor.run { AuthService.shared }
@@ -546,12 +589,17 @@ extension TranscriptionService {
         guard var components = URLComponents(string: baseURLString) else {
             throw TranscriptionError.connectionFailed(NSError(domain: "Invalid backend URL", code: -1))
         }
-        components.queryItems = [
+        let sanitizedKeywords = sanitizedContextKeywords(contextKeywords)
+        var queryItems = [
             URLQueryItem(name: "language", value: language),
             URLQueryItem(name: "sample_rate", value: "16000"),
             URLQueryItem(name: "encoding", value: "linear16"),
             URLQueryItem(name: "channels", value: "1"),
         ]
+        if !sanitizedKeywords.isEmpty {
+            queryItems.append(URLQueryItem(name: "keywords", value: sanitizedKeywords.joined(separator: ",")))
+        }
+        components.queryItems = queryItems
 
         guard let url = components.url else {
             throw TranscriptionError.connectionFailed(NSError(domain: "Invalid URL", code: -1))
@@ -566,7 +614,7 @@ extension TranscriptionService {
         }
         request.httpBody = audioData
 
-        log("TranscriptionService: Batch transcribing \(audioData.count) bytes via Python backend")
+        log("TranscriptionService: Batch transcribing \(audioData.count) bytes via Python backend, contextKeywords=\(sanitizedKeywords.count)")
 
         let (data, response) = try await URLSession.shared.data(for: request)
 


### PR DESCRIPTION
## Summary
- Capture screen OCR/user vocabulary at PTT start and pass context keywords into batch/live transcription.
- Default PTT to batch transcription, remove live partial transcript display, and apply fast contextual cleanup for names/company terms like Omi.
- Add backend keyword/keyterm plumbing for Deepgram prerecorded and streaming transcription endpoints.

## Verification
- Mac mini: `cd desktop && PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/Users/kodjimini/local/homebrew/bin xcrun swift build -c debug --package-path Desktop`
- Mac mini: `python3 -m py_compile backend/routers/chat.py backend/utils/chat.py backend/utils/stt/pre_recorded.py backend/tests/unit/test_desktop_transcribe.py`
- Focused pytest not run on Mac mini: `pytest` is not installed there.
- Focused pytest not run locally: local env is missing `google.cloud.storage`.

## Scope
Only STT/PTT context and word-accuracy changes from today are included. Agent Pills/floating-agent UI changes from the older branch are intentionally excluded.