### PR TITLE
desktop: agent pills + Execute buttons (notifications & tasks)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added agent pills: action-y Ask Omi requests (typed or voice) now spawn small floating-bar agents that run in parallel; hover any pill to see live progress and open in chat",
+    "Added Execute button on floating-bar notification cards and task rows \u2014 one click spawns an agent that handles the item end-to-end"
+  ],
   "releases": [
     {
       "version": "0.11.363",

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -122,10 +122,15 @@ final class AgentPillsManager: ObservableObject {
 
     /// Parse phrases like "spawn 3 agents", "5 tasks", "two agents working in
     /// parallel" out of a user query. Returns 1 if no count is mentioned.
+    /// Handles "3 test agents" — words between the number and the noun are
+    /// allowed (up to 5 tokens) so demo phrasing doesn't fall through.
     static func parseAgentCount(from text: String) -> Int {
         let lower = text.lowercased()
-        // Numeric form: "3 agents", "spawn 5", "do 2 things"
-        let numericPattern = #"\b(\d+)\s+(?:agents?|tasks?|pills?|things?|background\s+(?:agents?|tasks?))\b"#
+        let nounGroup = "(?:agents?|tasks?|pills?|things?)"
+        // Numeric: "3 agents", "spawn 5 in parallel", "3 test agents",
+        // "spawn 3 of these", but NOT "in 30 seconds".
+        // Allow up to ~5 short words between the number and the noun.
+        let numericPattern = #"\b(\d+)(?:\s+\S+){0,5}\s+\#(nounGroup)\b"#
         if let regex = try? NSRegularExpression(pattern: numericPattern),
             let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower)),
             match.numberOfRanges > 1,
@@ -135,11 +140,11 @@ final class AgentPillsManager: ObservableObject {
         {
             return min(n, 8)
         }
-        // Word form: "two agents", "three tasks"
+        // Word form: "two agents", "three tasks", "five test agents"
         let wordToNumber: [String: Int] = [
             "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8,
         ]
-        let wordPattern = #"\b(two|three|four|five|six|seven|eight)\s+(?:agents?|tasks?|pills?|things?)\b"#
+        let wordPattern = #"\b(two|three|four|five|six|seven|eight)(?:\s+\S+){0,5}\s+\#(nounGroup)\b"#
         if let regex = try? NSRegularExpression(pattern: wordPattern),
             let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower)),
             match.numberOfRanges > 1,
@@ -386,14 +391,31 @@ final class AgentPillsManager: ObservableObject {
     }
 
     fileprivate static func generateTitleAndAck(for query: String) async -> (title: String, ack: String)? {
-        guard let apiKey = APIKeyService.currentAnthropicKey, !apiKey.isEmpty else { return nil }
-        let url = URL(string: "https://api.anthropic.com/v1/messages")!
+        // Route through the desktop-backend's OpenAI-compatible proxy at
+        // /v2/chat/completions instead of hitting api.anthropic.com directly.
+        // This way we don't need a BYOK key (no partial-BYOK 403 risk), and
+        // the request goes through the user's existing Firebase auth + plan.
+        let baseURL = await APIClient.shared.rustBackendURL
+        guard !baseURL.isEmpty else {
+            log("AgentPill: title gen skipped — rustBackendURL empty")
+            return nil
+        }
+        let normalized = baseURL.hasSuffix("/") ? baseURL : baseURL + "/"
+        guard let url = URL(string: normalized + "v2/chat/completions") else {
+            log("AgentPill: title gen failed — bad URL")
+            return nil
+        }
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 8
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        do {
+            let headers = try await APIClient.shared.buildHeaders(requireAuth: true)
+            for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
+        } catch {
+            log("AgentPill: title gen skipped — auth header unavailable (\(error.localizedDescription))")
+            return nil
+        }
 
         let prompt = """
         The user just kicked off a background agent with this request:
@@ -404,28 +426,49 @@ final class AgentPillsManager: ObservableObject {
         {"title":"<3-5 word imperative title in Title Case, no trailing punctuation>","ack":"<one short spoken acknowledgement, max 7 words, friendly tone, e.g. 'Got it, building Mario now.'>"}
         """
 
+        // OpenAI-compatible body. The backend translates to Anthropic upstream.
         let body: [String: Any] = [
             "model": "claude-haiku-4-5-20251001",
             "max_tokens": 120,
             "messages": [["role": "user", "content": prompt]],
+            "stream": false,
         ]
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return nil }
+            guard let http = response as? HTTPURLResponse else {
+                log("AgentPill: title gen failed — no HTTP response")
+                return nil
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                let body = String(data: data.prefix(200), encoding: .utf8) ?? "<binary>"
+                log("AgentPill: title gen HTTP \(http.statusCode) — \(body)")
+                return nil
+            }
+            // OpenAI shape: { choices: [{ message: { content: "..." } }] }
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                let content = json["content"] as? [[String: Any]],
-                let text = content.first?["text"] as? String
-            else { return nil }
+                let choices = json["choices"] as? [[String: Any]],
+                let firstChoice = choices.first,
+                let message = firstChoice["message"] as? [String: Any],
+                let text = message["content"] as? String
+            else {
+                log("AgentPill: title gen response shape unexpected")
+                return nil
+            }
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard let payloadData = trimmed.data(using: .utf8),
                 let payload = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
                 let title = (payload["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
                 let ack = (payload["ack"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
                 !title.isEmpty, !ack.isEmpty
-            else { return nil }
+            else {
+                log("AgentPill: title gen JSON parse failed — raw: \(String(trimmed.prefix(200)))")
+                return nil
+            }
+            log("AgentPill: title gen ok — title=\"\(title)\" ack=\"\(ack)\"")
             return (title: String(title.prefix(40)), ack: String(ack.prefix(120)))
         } catch {
+            log("AgentPill: title gen threw — \(error.localizedDescription)")
             return nil
         }
     }

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -8,6 +8,7 @@ import SwiftUI
 @MainActor
 final class AgentPill: ObservableObject, Identifiable {
     enum Status: Equatable {
+        case queued
         case starting
         case running
         case done
@@ -15,6 +16,7 @@ final class AgentPill: ObservableObject, Identifiable {
 
         var displayLabel: String {
             switch self {
+            case .queued: return "Queued"
             case .starting, .running: return "Running"
             case .done: return "Done"
             case .failed: return "Failed"
@@ -24,12 +26,12 @@ final class AgentPill: ObservableObject, Identifiable {
 
     let id = UUID()
     let query: String
-    let title: String
     let createdAt: Date
     let model: String
 
-    @Published var status: Status = .starting
-    @Published var latestActivity: String = "Starting…"
+    @Published var title: String
+    @Published var status: Status = .queued
+    @Published var latestActivity: String = "Queued…"
     @Published var transcript: [String] = []
     @Published var aiMessage: ChatMessage?
     @Published var completedAt: Date?
@@ -76,8 +78,16 @@ final class AgentPillsManager: ObservableObject {
     /// Configurable soft cap so the row never grows past a reasonable width.
     private let maxPills: Int = 8
 
-    private var providers: [UUID: ChatProvider] = [:]
-    private var cancellables: [UUID: AnyCancellable] = [:]
+    /// One ChatProvider (and therefore one ACP node subprocess) per pill so
+    /// pills can truly run in parallel — each provider has its own bridge,
+    /// `isSending` flag, and interrupt scope. Bridges are heavy to boot, so we
+    /// stagger their startup via `bootChain` to avoid the race we saw the first
+    /// time around. After boot completes, every pill's `sendMessage` runs in
+    /// parallel with the others.
+    private var providersByPill: [UUID: ChatProvider] = [:]
+    private var streamsByPill: [UUID: AnyCancellable] = [:]
+    private var messageCountByPill: [UUID: Int] = [:]
+    private var bootChain: Task<Void, Never> = Task {}
 
     private init() {}
 
@@ -88,16 +98,21 @@ final class AgentPillsManager: ObservableObject {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         guard !lower.isEmpty else { return false }
+        // Anything containing "agent", "pill", or "background" is intentional
+        // demo invocation — always promote.
+        let demoSignals = ["agent", "pill", "background", "in parallel"]
+        if demoSignals.contains(where: { lower.contains($0) }) { return true }
         let actionPrefixes = [
             "open ", "do ", "go ", "send ", "make ", "find ", "search ",
             "build ", "fix ", "create ", "click ", "buy ", "book ",
             "schedule ", "draft ", "write ", "reply ", "compose ", "start ",
+            "spawn ", "kick off ", "kickoff ", "launch ", "trigger ", "queue ",
             "deploy ", "merge ", "push ", "pull ", "checkout ", "commit ",
             "close ", "delete ", "remove ", "add ", "install ", "update ",
             "edit ", "rename ", "move ", "copy ", "show me ", "help me ",
             "can you ", "please ", "summarize ", "summarise ", "research ",
             "look up ", "look at ", "fill ", "submit ", "post ", "tweet ",
-            "dm ", "email ", "call ", "navigate ", "visit ",
+            "dm ", "email ", "call ", "navigate ", "visit ", "test ",
         ]
         if actionPrefixes.contains(where: { lower.hasPrefix($0) }) { return true }
         // Long, detailed instructions are almost always actions.
@@ -105,15 +120,68 @@ final class AgentPillsManager: ObservableObject {
         return false
     }
 
-    /// Spawn a new agent pill for the given user query.
+    /// Parse phrases like "spawn 3 agents", "5 tasks", "two agents working in
+    /// parallel" out of a user query. Returns 1 if no count is mentioned.
+    static func parseAgentCount(from text: String) -> Int {
+        let lower = text.lowercased()
+        // Numeric form: "3 agents", "spawn 5", "do 2 things"
+        let numericPattern = #"\b(\d+)\s+(?:agents?|tasks?|pills?|things?|background\s+(?:agents?|tasks?))\b"#
+        if let regex = try? NSRegularExpression(pattern: numericPattern),
+            let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower)),
+            match.numberOfRanges > 1,
+            let range = Range(match.range(at: 1), in: lower),
+            let n = Int(lower[range]),
+            n > 0
+        {
+            return min(n, 8)
+        }
+        // Word form: "two agents", "three tasks"
+        let wordToNumber: [String: Int] = [
+            "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8,
+        ]
+        let wordPattern = #"\b(two|three|four|five|six|seven|eight)\s+(?:agents?|tasks?|pills?|things?)\b"#
+        if let regex = try? NSRegularExpression(pattern: wordPattern),
+            let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower)),
+            match.numberOfRanges > 1,
+            let range = Range(match.range(at: 1), in: lower),
+            let n = wordToNumber[String(lower[range])]
+        {
+            return min(n, 8)
+        }
+        return 1
+    }
+
+    /// Spawn one or more pills for a user query. If the query says "spawn 3
+    /// agents" we create 3 pills (each runs the same task on the shared
+    /// queue). Returns the first pill so callers can inspect it.
     @discardableResult
-    func spawn(query: String, model: String) -> AgentPill {
+    func spawnFromUserQuery(_ query: String, model: String, fromVoice: Bool = false) -> AgentPill {
+        let count = AgentPillsManager.parseAgentCount(from: query)
+        if count <= 1 {
+            return spawn(query: query, model: model, fromVoice: fromVoice)
+        }
+        var first: AgentPill?
+        for i in 1...count {
+            let labelled = "[\(i)/\(count)] \(query)"
+            // Only the first pill speaks the acknowledgement when N > 1,
+            // otherwise we'd hear N overlapping voices.
+            let pill = spawn(query: labelled, model: model, fromVoice: fromVoice && first == nil)
+            if first == nil { first = pill }
+        }
+        return first ?? spawn(query: query, model: model, fromVoice: fromVoice)
+    }
+
+    /// Spawn a new agent pill. Each pill gets its own ChatProvider so the
+    /// pills truly run in parallel. Bridge boots are staggered through
+    /// `bootChain` so we never race ACP startup; once a pill's bridge is
+    /// warmed it sends concurrently with everything else.
+    @discardableResult
+    func spawn(query: String, model: String, fromVoice: Bool = false) -> AgentPill {
         let pill = AgentPill(query: query, model: model)
 
-        // Trim if we're at the cap — drop the oldest non-running pill first,
-        // otherwise drop the oldest pill regardless of status.
+        // Trim if we're at the cap — drop the oldest finished pill first.
         if pills.count >= maxPills {
-            if let idx = pills.firstIndex(where: { $0.status != .running && $0.status != .starting }) {
+            if let idx = pills.firstIndex(where: { isFinished($0.status) }) {
                 cleanup(pillID: pills[idx].id)
             } else {
                 cleanup(pillID: pills[0].id)
@@ -123,60 +191,96 @@ final class AgentPillsManager: ObservableObject {
         pills.append(pill)
 
         let provider = ChatProvider()
-        // Inherit the working directory from the floating bar's provider so
-        // shell-based agents land in the user's expected cwd.
-        if let floatingProvider = FloatingControlBarManager.shared.sharedFloatingProvider {
-            provider.workingDirectory = floatingProvider.workingDirectory
-            provider.modelOverride = floatingProvider.modelOverride
+        if let floating = FloatingControlBarManager.shared.sharedFloatingProvider {
+            provider.workingDirectory = floating.workingDirectory
+            provider.modelOverride = floating.modelOverride
         }
-        providers[pill.id] = provider
+        providersByPill[pill.id] = provider
 
         let messageCountBefore = provider.messages.count
-        cancellables[pill.id] = provider.$messages
+        messageCountByPill[pill.id] = messageCountBefore
+        streamsByPill[pill.id] = provider.$messages
             .receive(on: DispatchQueue.main)
             .sink { [weak self, weak pill] messages in
                 guard let self, let pill else { return }
                 self.handle(messages: messages, since: messageCountBefore, for: pill)
             }
 
-        Task { @MainActor [weak self] in
+        // Stagger bridge boots: chain this pill's warmup after the previous
+        // pill's. Once warmed, the actual sendMessage runs in parallel with
+        // every other warmed pill.
+        let previousBoot = bootChain
+        let myBoot = Task { [weak provider] in
+            await previousBoot.value
+            await provider?.warmupBridge()
+        }
+        bootChain = myBoot
+
+        pill.status = .starting
+        pill.latestActivity = "Warming up…"
+
+        // For voice queries, speak an instant deterministic acknowledgement
+        // BEFORE waiting for any API call so the user always gets audible
+        // feedback that we heard them. The smart title is fetched in parallel
+        // and updates the pill silently when it arrives.
+        if fromVoice {
+            FloatingBarVoicePlaybackService.shared.speakOneShot(AgentPillsManager.randomAck())
+        }
+
+        Task { [weak pill] in
+            guard let pill else { return }
+            guard let result = await AgentPillsManager.generateTitleAndAck(for: pill.query) else { return }
+            await MainActor.run {
+                pill.title = result.title
+                if pill.latestActivity == "Warming up…" || pill.latestActivity == "Starting…" {
+                    pill.latestActivity = result.ack
+                }
+            }
+        }
+
+        Task { [weak self, weak pill, weak provider] in
+            await myBoot.value
+            guard let self, let pill, let provider else { return }
+            // Bridge is up; flip to running and fire the prompt. Concurrent
+            // with any other pill that's already past this point.
+            pill.status = .running
             await provider.sendMessage(
-                query,
-                model: model,
+                pill.query,
+                model: pill.model,
                 systemPromptPrefix: ChatProvider.floatingBarSystemPromptPrefix,
                 sessionKey: "agent-\(pill.id.uuidString)"
             )
-            self?.complete(pill: pill, provider: provider)
+            self.complete(pill: pill, provider: provider)
         }
 
         return pill
     }
 
-    /// Force-dismiss a pill and free its provider.
+    /// Force-dismiss a pill.
     func dismiss(pillID: UUID) {
         cleanup(pillID: pillID)
         if hoveredPillID == pillID { hoveredPillID = nil }
         if pinnedPillID == pillID { pinnedPillID = nil }
     }
 
-    /// Remove all completed (done or failed) pills.
-    func clearCompleted() {
-        let toRemove = pills.filter {
-            switch $0.status {
-            case .done, .failed: return true
-            default: return false
-            }
-        }
-        for pill in toRemove {
-            cleanup(pillID: pill.id)
-        }
+    private func cleanup(pillID: UUID) {
+        streamsByPill[pillID]?.cancel()
+        streamsByPill[pillID] = nil
+        providersByPill[pillID] = nil
+        messageCountByPill[pillID] = nil
+        pills.removeAll { $0.id == pillID }
     }
 
-    private func cleanup(pillID: UUID) {
-        cancellables[pillID]?.cancel()
-        cancellables[pillID] = nil
-        providers[pillID] = nil
-        pills.removeAll { $0.id == pillID }
+    /// Remove all completed (done or failed) pills.
+    func clearCompleted() {
+        pills.removeAll { isFinished($0.status) }
+    }
+
+    private func isFinished(_ status: AgentPill.Status) -> Bool {
+        switch status {
+        case .done, .failed: return true
+        default: return false
+        }
     }
 
     private func handle(messages: [ChatMessage], since: Int, for pill: AgentPill) {
@@ -236,10 +340,17 @@ final class AgentPillsManager: ObservableObject {
         }
         pill.completedAt = Date()
         pill.suggestedFollowUps = AgentPillsManager.deriveFollowUps(for: pill)
+        // Tear down this pill's stream so we stop holding the provider — the
+        // node bridge process will deinit when no Swift references remain.
+        streamsByPill[pill.id]?.cancel()
+        streamsByPill[pill.id] = nil
+        providersByPill[pill.id] = nil
+        messageCountByPill[pill.id] = nil
     }
 
     /// Tiny heuristic to suggest 1–2 follow-ups based on the original query.
-    /// Real implementation would ask the model — kept simple for the demo.
+    /// "Open chat" is intentionally omitted — the popover already has a
+    /// dedicated "Open in chat" button, so adding it as a chip would duplicate.
     private static func deriveFollowUps(for pill: AgentPill) -> [String] {
         let lower = pill.query.lowercased()
         if lower.contains("email") || lower.contains("reply") {
@@ -251,6 +362,71 @@ final class AgentPillsManager: ObservableObject {
         if lower.contains("schedule") || lower.contains("book") || lower.contains("calendar") {
             return ["Open calendar", "Add reminder"]
         }
-        return ["Open chat", "Run again"]
+        return ["Run again"]
+    }
+
+    /// Ask Claude Haiku for a short title (3–5 words, present participle) and
+    /// a one-sentence acknowledgement we can speak aloud. Returns nil if the
+    /// API key isn't available or the call fails — the caller keeps the
+    /// existing heuristic title in that case.
+    /// Short, instant acknowledgements spoken the moment a voice query spawns
+    /// a pill. Random pick so consecutive PTT queries don't sound identical.
+    private static let instantAcks: [String] = [
+        "On it.",
+        "Got it.",
+        "Sure thing.",
+        "Working on it.",
+        "Alright, doing that now.",
+        "Let me get that started.",
+        "Okay, on it.",
+    ]
+
+    fileprivate static func randomAck() -> String {
+        instantAcks.randomElement() ?? "On it."
+    }
+
+    fileprivate static func generateTitleAndAck(for query: String) async -> (title: String, ack: String)? {
+        guard let apiKey = APIKeyService.currentAnthropicKey, !apiKey.isEmpty else { return nil }
+        let url = URL(string: "https://api.anthropic.com/v1/messages")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 8
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+
+        let prompt = """
+        The user just kicked off a background agent with this request:
+
+        "\(query)"
+
+        Reply with a JSON object on a single line, no prose, no markdown:
+        {"title":"<3-5 word imperative title in Title Case, no trailing punctuation>","ack":"<one short spoken acknowledgement, max 7 words, friendly tone, e.g. 'Got it, building Mario now.'>"}
+        """
+
+        let body: [String: Any] = [
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 120,
+            "messages": [["role": "user", "content": prompt]],
+        ]
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return nil }
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let content = json["content"] as? [[String: Any]],
+                let text = content.first?["text"] as? String
+            else { return nil }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let payloadData = trimmed.data(using: .utf8),
+                let payload = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+                let title = (payload["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                let ack = (payload["ack"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                !title.isEmpty, !ack.isEmpty
+            else { return nil }
+            return (title: String(title.prefix(40)), ack: String(ack.prefix(120)))
+        } catch {
+            return nil
+        }
     }
 }

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -1,0 +1,256 @@
+import Combine
+import Foundation
+import SwiftUI
+
+/// A running or finished background "agent" launched from the Ask Omi floating
+/// bar. Each pill owns its own `ChatProvider` so multiple agents can execute in
+/// parallel without sharing message state.
+@MainActor
+final class AgentPill: ObservableObject, Identifiable {
+    enum Status: Equatable {
+        case starting
+        case running
+        case done
+        case failed(String)
+
+        var displayLabel: String {
+            switch self {
+            case .starting, .running: return "Running"
+            case .done: return "Done"
+            case .failed: return "Failed"
+            }
+        }
+    }
+
+    let id = UUID()
+    let query: String
+    let title: String
+    let createdAt: Date
+    let model: String
+
+    @Published var status: Status = .starting
+    @Published var latestActivity: String = "Starting…"
+    @Published var transcript: [String] = []
+    @Published var aiMessage: ChatMessage?
+    @Published var completedAt: Date?
+    @Published var suggestedFollowUps: [String] = []
+
+    /// Convenience: how long the agent has been running (or ran).
+    var elapsed: TimeInterval {
+        (completedAt ?? Date()).timeIntervalSince(createdAt)
+    }
+
+    init(query: String, model: String) {
+        self.query = query
+        self.model = model
+        self.title = AgentPill.deriveTitle(from: query)
+        self.createdAt = Date()
+    }
+
+    /// Pull a short uppercase title out of the query for the pill popover header.
+    /// "open google.com and find vegan ramen" → "OPEN GOOGLE.COM"
+    private static func deriveTitle(from query: String) -> String {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let words = trimmed
+            .split(separator: " ", maxSplits: 4, omittingEmptySubsequences: true)
+            .prefix(3)
+            .map(String.init)
+        let joined = words.joined(separator: " ").uppercased()
+        if joined.count > 32 {
+            return String(joined.prefix(32)) + "…"
+        }
+        return joined.isEmpty ? "AGENT" : joined
+    }
+}
+
+/// Singleton that owns the running `AgentPill`s. Spawning a pill creates a new
+/// `ChatProvider` and observes its message stream until the agent finishes.
+@MainActor
+final class AgentPillsManager: ObservableObject {
+    static let shared = AgentPillsManager()
+
+    @Published private(set) var pills: [AgentPill] = []
+    @Published var hoveredPillID: UUID?
+    @Published var pinnedPillID: UUID?
+
+    /// Configurable soft cap so the row never grows past a reasonable width.
+    private let maxPills: Int = 8
+
+    private var providers: [UUID: ChatProvider] = [:]
+    private var cancellables: [UUID: AnyCancellable] = [:]
+
+    private init() {}
+
+    /// Whether a piece of user input looks like an "action" the agent should
+    /// execute, vs. a quick conversational question.
+    static func looksLikeAction(_ text: String) -> Bool {
+        let lower = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard !lower.isEmpty else { return false }
+        let actionPrefixes = [
+            "open ", "do ", "go ", "send ", "make ", "find ", "search ",
+            "build ", "fix ", "create ", "click ", "buy ", "book ",
+            "schedule ", "draft ", "write ", "reply ", "compose ", "start ",
+            "deploy ", "merge ", "push ", "pull ", "checkout ", "commit ",
+            "close ", "delete ", "remove ", "add ", "install ", "update ",
+            "edit ", "rename ", "move ", "copy ", "show me ", "help me ",
+            "can you ", "please ", "summarize ", "summarise ", "research ",
+            "look up ", "look at ", "fill ", "submit ", "post ", "tweet ",
+            "dm ", "email ", "call ", "navigate ", "visit ",
+        ]
+        if actionPrefixes.contains(where: { lower.hasPrefix($0) }) { return true }
+        // Long, detailed instructions are almost always actions.
+        if lower.count >= 70 { return true }
+        return false
+    }
+
+    /// Spawn a new agent pill for the given user query.
+    @discardableResult
+    func spawn(query: String, model: String) -> AgentPill {
+        let pill = AgentPill(query: query, model: model)
+
+        // Trim if we're at the cap — drop the oldest non-running pill first,
+        // otherwise drop the oldest pill regardless of status.
+        if pills.count >= maxPills {
+            if let idx = pills.firstIndex(where: { $0.status != .running && $0.status != .starting }) {
+                cleanup(pillID: pills[idx].id)
+            } else {
+                cleanup(pillID: pills[0].id)
+            }
+        }
+
+        pills.append(pill)
+
+        let provider = ChatProvider()
+        // Inherit the working directory from the floating bar's provider so
+        // shell-based agents land in the user's expected cwd.
+        if let floatingProvider = FloatingControlBarManager.shared.sharedFloatingProvider {
+            provider.workingDirectory = floatingProvider.workingDirectory
+            provider.modelOverride = floatingProvider.modelOverride
+        }
+        providers[pill.id] = provider
+
+        let messageCountBefore = provider.messages.count
+        cancellables[pill.id] = provider.$messages
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak pill] messages in
+                guard let self, let pill else { return }
+                self.handle(messages: messages, since: messageCountBefore, for: pill)
+            }
+
+        Task { @MainActor [weak self] in
+            await provider.sendMessage(
+                query,
+                model: model,
+                systemPromptPrefix: ChatProvider.floatingBarSystemPromptPrefix,
+                sessionKey: "agent-\(pill.id.uuidString)"
+            )
+            self?.complete(pill: pill, provider: provider)
+        }
+
+        return pill
+    }
+
+    /// Force-dismiss a pill and free its provider.
+    func dismiss(pillID: UUID) {
+        cleanup(pillID: pillID)
+        if hoveredPillID == pillID { hoveredPillID = nil }
+        if pinnedPillID == pillID { pinnedPillID = nil }
+    }
+
+    /// Remove all completed (done or failed) pills.
+    func clearCompleted() {
+        let toRemove = pills.filter {
+            switch $0.status {
+            case .done, .failed: return true
+            default: return false
+            }
+        }
+        for pill in toRemove {
+            cleanup(pillID: pill.id)
+        }
+    }
+
+    private func cleanup(pillID: UUID) {
+        cancellables[pillID]?.cancel()
+        cancellables[pillID] = nil
+        providers[pillID] = nil
+        pills.removeAll { $0.id == pillID }
+    }
+
+    private func handle(messages: [ChatMessage], since: Int, for pill: AgentPill) {
+        guard messages.count > since else { return }
+        let recent = Array(messages.suffix(from: since))
+        guard let aiMessage = recent.last(where: { $0.sender == .ai }) else { return }
+        pill.aiMessage = aiMessage
+
+        if pill.status == .starting {
+            pill.status = .running
+        }
+
+        let activity = describeActivity(for: aiMessage)
+        if !activity.isEmpty && activity != pill.latestActivity {
+            pill.latestActivity = activity
+            pill.transcript.append(activity)
+        }
+    }
+
+    private func describeActivity(for message: ChatMessage) -> String {
+        for block in message.contentBlocks.reversed() {
+            switch block {
+            case .toolCall(_, let name, _, _, let input, _):
+                let display = ChatContentBlock.displayName(for: name)
+                if let input, !input.summary.isEmpty {
+                    return "\(display) — \(input.summary)"
+                }
+                return display
+            case .text(_, let text):
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    return String(trimmed.prefix(110))
+                }
+            case .thinking, .discoveryCard:
+                continue
+            }
+        }
+        let trimmedFallback = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedFallback.isEmpty {
+            return String(trimmedFallback.prefix(110))
+        }
+        return "Working…"
+    }
+
+    private func complete(pill: AgentPill, provider: ChatProvider) {
+        if let errorText = provider.errorMessage, !errorText.isEmpty {
+            pill.status = .failed(errorText)
+            pill.latestActivity = errorText
+        } else {
+            pill.status = .done
+            if let last = pill.aiMessage, !last.text.isEmpty {
+                let trimmed = last.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                pill.latestActivity = String(trimmed.prefix(140))
+            } else {
+                pill.latestActivity = "Done"
+            }
+        }
+        pill.completedAt = Date()
+        pill.suggestedFollowUps = AgentPillsManager.deriveFollowUps(for: pill)
+    }
+
+    /// Tiny heuristic to suggest 1–2 follow-ups based on the original query.
+    /// Real implementation would ask the model — kept simple for the demo.
+    private static func deriveFollowUps(for pill: AgentPill) -> [String] {
+        let lower = pill.query.lowercased()
+        if lower.contains("email") || lower.contains("reply") {
+            return ["Open thread", "Check for replies"]
+        }
+        if lower.contains("search") || lower.contains("find") || lower.contains("look") {
+            return ["Open results", "Refine search"]
+        }
+        if lower.contains("schedule") || lower.contains("book") || lower.contains("calendar") {
+            return ["Open calendar", "Add reminder"]
+        }
+        return ["Open chat", "Run again"]
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPillsView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPillsView.swift
@@ -1,0 +1,463 @@
+import AppKit
+import SwiftUI
+
+/// Horizontal row of agent pill icons rendered just below the floating bar.
+/// Each pill is a small rounded square containing the Omi logo + a status dot.
+struct AgentPillsRowView: View {
+    @ObservedObject var manager: AgentPillsManager
+
+    var body: some View {
+        HStack(spacing: AgentPillsLayout.pillSpacing) {
+            ForEach(manager.pills) { pill in
+                AgentPillView(pill: pill, manager: manager)
+            }
+        }
+        .padding(.horizontal, AgentPillsLayout.rowHorizontalPadding)
+        .padding(.vertical, AgentPillsLayout.rowVerticalPadding)
+        .frame(minHeight: AgentPillsLayout.rowHeight, alignment: .top)
+    }
+}
+
+enum AgentPillsLayout {
+    static let pillSize: CGFloat = 38
+    static let pillSpacing: CGFloat = 8
+    static let rowHorizontalPadding: CGFloat = 6
+    static let rowVerticalPadding: CGFloat = 4
+    /// Total row height including padding (used by the overlay window for sizing).
+    static let rowHeight: CGFloat = pillSize + rowVerticalPadding * 2
+    /// Max popover width when hovering a pill.
+    static let popoverWidth: CGFloat = 320
+}
+
+/// One agent pill: rounded square + circular Omi logo + status dot. Slowly
+/// rotates the logo while running, settles when done.
+struct AgentPillView: View {
+    @ObservedObject var pill: AgentPill
+    @ObservedObject var manager: AgentPillsManager
+    @State private var rotationAngle: Double = 0
+    @State private var pulse: Bool = false
+    @State private var isHovering: Bool = false
+    @State private var rotationTimer: Timer?
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            roundedSquare
+                .overlay(omiBadge)
+                .overlay(statusDot, alignment: .topTrailing)
+                .scaleEffect(isHovering ? 1.06 : 1.0)
+                .animation(.spring(response: 0.32, dampingFraction: 0.72), value: isHovering)
+        }
+        .frame(width: AgentPillsLayout.pillSize, height: AgentPillsLayout.pillSize)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            isHovering = hovering
+            if hovering {
+                manager.hoveredPillID = pill.id
+            } else if manager.hoveredPillID == pill.id {
+                manager.hoveredPillID = nil
+            }
+        }
+        .onAppear { startRotationIfRunning() }
+        .onChange(of: pill.status) { startRotationIfRunning() }
+        .onDisappear {
+            rotationTimer?.invalidate()
+            rotationTimer = nil
+        }
+        .accessibilityLabel("\(pill.title) — \(pill.status.displayLabel)")
+    }
+
+    private var roundedSquare: some View {
+        RoundedRectangle(cornerRadius: 9, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        Color(nsColor: NSColor(white: 0.18, alpha: 0.95)),
+                        Color(nsColor: NSColor(white: 0.08, alpha: 0.95)),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.10), lineWidth: 0.6)
+            )
+            .shadow(color: Color.black.opacity(0.45), radius: 6, x: 0, y: 3)
+    }
+
+    private var omiBadge: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.95, green: 0.95, blue: 0.97),
+                            Color(red: 0.78, green: 0.78, blue: 0.82),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: AgentPillsLayout.pillSize - 14, height: AgentPillsLayout.pillSize - 14)
+                .overlay(
+                    Circle().strokeBorder(Color.black.opacity(0.25), lineWidth: 0.5)
+                )
+
+            if let logo = AgentPillView.omiLogo {
+                Image(nsImage: logo)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: AgentPillsLayout.pillSize - 18, height: AgentPillsLayout.pillSize - 18)
+                    .clipShape(Circle())
+            } else {
+                // Fallback: solid disc with a subtle highlight
+                Circle()
+                    .fill(Color(nsColor: NSColor(white: 0.05, alpha: 1.0)))
+                    .frame(width: AgentPillsLayout.pillSize - 18, height: AgentPillsLayout.pillSize - 18)
+            }
+        }
+        .rotationEffect(.degrees(rotationAngle))
+        .animation(.easeInOut(duration: 1.2), value: rotationAngle)
+    }
+
+    @ViewBuilder
+    private var statusDot: some View {
+        ZStack {
+            Circle()
+                .fill(Color(nsColor: NSColor(white: 0.05, alpha: 1.0)))
+                .frame(width: 9, height: 9)
+            Circle()
+                .fill(statusColor)
+                .frame(width: 7, height: 7)
+                .scaleEffect(shouldPulse && pulse ? 1.18 : 1.0)
+                .opacity(shouldPulse && pulse ? 0.65 : 1.0)
+                .animation(
+                    shouldPulse
+                        ? .easeInOut(duration: 1.0).repeatForever(autoreverses: true)
+                        : .default,
+                    value: pulse
+                )
+                .onAppear {
+                    if shouldPulse { pulse = true }
+                }
+                .onChange(of: pill.status) {
+                    pulse = shouldPulse ? true : false
+                }
+        }
+        .offset(x: 3, y: -3)
+    }
+
+    private var shouldPulse: Bool {
+        switch pill.status {
+        case .running, .starting: return true
+        default: return false
+        }
+    }
+
+    private var statusColor: Color {
+        switch pill.status {
+        case .starting, .running: return Color(red: 0.27, green: 0.92, blue: 0.46)
+        case .done: return Color(red: 0.45, green: 0.85, blue: 1.0)
+        case .failed: return Color(red: 1.0, green: 0.42, blue: 0.42)
+        }
+    }
+
+    private func startRotationIfRunning() {
+        rotationTimer?.invalidate()
+        rotationTimer = nil
+        switch pill.status {
+        case .starting, .running:
+            // Subtle: a single 360° rotation every ~3s with easing — not annoying.
+            rotationAngle = 0
+            let timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
+                Task { @MainActor in
+                    withAnimation(.easeInOut(duration: 1.2)) {
+                        rotationAngle += 360
+                    }
+                }
+            }
+            timer.fire()
+            rotationTimer = timer
+        default:
+            // Settle to upright on completion.
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
+                rotationAngle = 0
+            }
+        }
+    }
+
+    /// Cached Omi logo image, loaded once from the resource bundle.
+    private static let omiLogo: NSImage? = {
+        if let url = Bundle.resourceBundle.url(forResource: "omi_app_icon", withExtension: "png"),
+            let img = NSImage(contentsOf: url) {
+            return img
+        }
+        if let url = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
+            let img = NSImage(contentsOf: url) {
+            return img
+        }
+        return nil
+    }()
+}
+
+/// Popover panel that appears under the hovered pill. Shows what the agent is
+/// doing right now (Clicky-style), and on completion suggested follow-ups.
+struct AgentPillPopover: View {
+    @ObservedObject var pill: AgentPill
+    var onDismiss: () -> Void
+    var onOpenInChat: () -> Void
+    var onSendFollowUp: (String) -> Void
+
+    @State private var followUpText: String = ""
+    @FocusState private var followUpFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+            activityRow
+            if !isFinished {
+                progressBar
+            }
+            if case .failed(let message) = pill.status {
+                Text(message)
+                    .scaledFont(size: 11)
+                    .foregroundColor(Color(red: 1.0, green: 0.55, blue: 0.55))
+                    .lineLimit(3)
+            }
+            if isFinished {
+                followUpSection
+            }
+        }
+        .padding(14)
+        .frame(width: AgentPillsLayout.popoverWidth, alignment: .leading)
+        .floatingBackground(cornerRadius: 14)
+    }
+
+    private var isFinished: Bool {
+        switch pill.status {
+        case .done, .failed: return true
+        default: return false
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Text(pill.title)
+                .scaledFont(size: 12, weight: .bold)
+                .foregroundColor(.white)
+                .lineLimit(1)
+
+            Spacer(minLength: 6)
+
+            Text(pill.status.displayLabel)
+                .scaledFont(size: 10, weight: .semibold)
+                .foregroundColor(statusBadgeForeground)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(statusBadgeBackground)
+                .clipShape(Capsule())
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(.white.opacity(0.6))
+                    .frame(width: 18, height: 18)
+                    .background(Color.white.opacity(0.08))
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss agent")
+        }
+    }
+
+    private var statusBadgeForeground: Color {
+        switch pill.status {
+        case .starting, .running: return Color(red: 0.18, green: 0.10, blue: 0.0)
+        case .done: return Color(red: 0.07, green: 0.18, blue: 0.10)
+        case .failed: return .white
+        }
+    }
+
+    private var statusBadgeBackground: Color {
+        switch pill.status {
+        case .starting, .running: return Color(red: 1.0, green: 0.78, blue: 0.30)
+        case .done: return Color(red: 0.45, green: 0.92, blue: 0.55)
+        case .failed: return Color(red: 0.78, green: 0.32, blue: 0.32)
+        }
+    }
+
+    private var activityRow: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: activityIcon)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.white.opacity(0.7))
+                .frame(width: 16, height: 16, alignment: .center)
+                .background(Color.white.opacity(0.06))
+                .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+
+            Text(pill.latestActivity)
+                .scaledFont(size: 12)
+                .foregroundColor(.white.opacity(0.86))
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var activityIcon: String {
+        let lower = pill.latestActivity.lowercased()
+        if lower.contains("running command") || lower.hasPrefix("bash") { return "terminal" }
+        if lower.contains("reading file") || lower.contains("editing file") { return "doc.text" }
+        if lower.contains("searching") { return "magnifyingglass" }
+        if lower.contains("fetching page") || lower.contains("web") { return "globe" }
+        return "sparkles"
+    }
+
+    private var progressBar: some View {
+        IndeterminateProgressBar()
+            .frame(height: 3)
+            .clipShape(RoundedRectangle(cornerRadius: 1.5))
+    }
+
+    private var followUpSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if !pill.suggestedFollowUps.isEmpty {
+                Text("Suggested next:")
+                    .scaledFont(size: 10, weight: .medium)
+                    .foregroundColor(.white.opacity(0.5))
+
+                AgentFollowUpFlowLayout(spacing: 6) {
+                    ForEach(pill.suggestedFollowUps, id: \.self) { suggestion in
+                        Button {
+                            onSendFollowUp(suggestion)
+                        } label: {
+                            Text(suggestion)
+                                .scaledFont(size: 11, weight: .medium)
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 5)
+                                .background(Color.white.opacity(0.10))
+                                .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+
+            HStack(spacing: 6) {
+                TextField("Follow up", text: $followUpText)
+                    .textFieldStyle(.plain)
+                    .scaledFont(size: 12)
+                    .foregroundColor(.white)
+                    .focused($followUpFocused)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color.white.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .onSubmit { submitFollowUp() }
+
+                Button {
+                    submitFollowUp()
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundColor(followUpText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .white.opacity(0.35) : .white)
+                }
+                .buttonStyle(.plain)
+                .disabled(followUpText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                Button(action: onOpenInChat) {
+                    Image(systemName: "bubble.left.and.bubble.right.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(.white.opacity(0.7))
+                        .frame(width: 26, height: 26)
+                        .background(Color.white.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .help("Open in chat")
+            }
+        }
+    }
+
+    private func submitFollowUp() {
+        let trimmed = followUpText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        onSendFollowUp(trimmed)
+        followUpText = ""
+    }
+}
+
+/// Soft, infinitely-running progress bar shown while the agent runs.
+private struct IndeterminateProgressBar: View {
+    @State private var phase: CGFloat = 0
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            ZStack(alignment: .leading) {
+                Color.white.opacity(0.08)
+                LinearGradient(
+                    colors: [
+                        Color.white.opacity(0.02),
+                        Color.white.opacity(0.65),
+                        Color.white.opacity(0.02),
+                    ],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: width * 0.35)
+                .offset(x: -width * 0.35 + (width + width * 0.35) * phase)
+            }
+            .clipped()
+            .onAppear {
+                withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) {
+                    phase = 1
+                }
+            }
+        }
+    }
+}
+
+/// Minimal flow layout for follow-up chips so they wrap if too wide.
+private struct AgentFollowUpFlowLayout: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if rowWidth + size.width > maxWidth {
+                totalHeight += rowHeight + spacing
+                rowWidth = size.width + spacing
+                rowHeight = size.height
+            } else {
+                rowWidth += size.width + spacing
+                rowHeight = max(rowHeight, size.height)
+            }
+        }
+        totalHeight += rowHeight
+        return CGSize(width: maxWidth.isFinite ? maxWidth : rowWidth, height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            view.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPillsView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPillsView.swift
@@ -36,6 +36,7 @@ struct AgentPillView: View {
     @ObservedObject var manager: AgentPillsManager
     @State private var rotationAngle: Double = 0
     @State private var isHovering: Bool = false
+    @State private var rotationTask: Task<Void, Never>?
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -57,6 +58,10 @@ struct AgentPillView: View {
         }
         .onAppear { startRotationIfRunning() }
         .onChange(of: pill.status) { startRotationIfRunning() }
+        .onDisappear {
+            rotationTask?.cancel()
+            rotationTask = nil
+        }
         .accessibilityLabel("\(pill.title) — \(pill.status.displayLabel)")
     }
 
@@ -112,7 +117,6 @@ struct AgentPillView: View {
             }
         }
         .rotationEffect(.degrees(rotationAngle))
-        .animation(isRotating ? .linear(duration: 4.0).repeatForever(autoreverses: false) : .default, value: rotationAngle)
     }
 
     @ViewBuilder
@@ -152,31 +156,35 @@ struct AgentPillView: View {
         }
     }
 
-    private var isRotating: Bool {
-        switch pill.status {
-        case .starting, .running: return true
-        default: return false
-        }
-    }
-
     private func startRotationIfRunning() {
         switch pill.status {
         case .starting, .running:
-            // Continuous slow rotation — set a single faraway target and let
-            // SwiftUI's repeatForever animation drive it. Avoids the timer
-            // wakeups and the "pause between revolutions" feel of the old
-            // implementation.
-            rotationAngle = 0
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                withAnimation(.linear(duration: 4.0).repeatForever(autoreverses: false)) {
-                    rotationAngle = 360
+            // Continuous slow rotation. We use a Task instead of repeatForever
+            // because repeatForever can't be cancelled cleanly from outside —
+            // explicit Task.cancel() lets us actually halt rotation when the
+            // agent finishes (otherwise the spinner kept going past Done).
+            rotationTask?.cancel()
+            rotationTask = Task { @MainActor in
+                while !Task.isCancelled {
+                    let target = rotationAngle + 360
+                    withAnimation(.linear(duration: 4.0)) {
+                        rotationAngle = target
+                    }
+                    do {
+                        try await Task.sleep(nanoseconds: 4_000_000_000)
+                    } catch {
+                        break
+                    }
                 }
             }
         default:
-            // Stop where we are — no snap-back, that would feel jerky after
-            // a long-running task.
-            withAnimation(.easeOut(duration: 0.4)) {
-                rotationAngle = floor(rotationAngle / 360) * 360
+            // Cancel the task and snap to the nearest full revolution with a
+            // gentle settle.
+            rotationTask?.cancel()
+            rotationTask = nil
+            let settled = (rotationAngle / 360.0).rounded() * 360.0
+            withAnimation(.easeOut(duration: 0.35)) {
+                rotationAngle = settled
             }
         }
     }

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPillsView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPillsView.swift
@@ -35,9 +35,7 @@ struct AgentPillView: View {
     @ObservedObject var pill: AgentPill
     @ObservedObject var manager: AgentPillsManager
     @State private var rotationAngle: Double = 0
-    @State private var pulse: Bool = false
     @State private var isHovering: Bool = false
-    @State private var rotationTimer: Timer?
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -59,10 +57,6 @@ struct AgentPillView: View {
         }
         .onAppear { startRotationIfRunning() }
         .onChange(of: pill.status) { startRotationIfRunning() }
-        .onDisappear {
-            rotationTimer?.invalidate()
-            rotationTimer = nil
-        }
         .accessibilityLabel("\(pill.title) — \(pill.status.displayLabel)")
     }
 
@@ -118,71 +112,71 @@ struct AgentPillView: View {
             }
         }
         .rotationEffect(.degrees(rotationAngle))
-        .animation(.easeInOut(duration: 1.2), value: rotationAngle)
+        .animation(isRotating ? .linear(duration: 4.0).repeatForever(autoreverses: false) : .default, value: rotationAngle)
     }
 
     @ViewBuilder
     private var statusDot: some View {
-        ZStack {
-            Circle()
-                .fill(Color(nsColor: NSColor(white: 0.05, alpha: 1.0)))
-                .frame(width: 9, height: 9)
-            Circle()
-                .fill(statusColor)
-                .frame(width: 7, height: 7)
-                .scaleEffect(shouldPulse && pulse ? 1.18 : 1.0)
-                .opacity(shouldPulse && pulse ? 0.65 : 1.0)
-                .animation(
-                    shouldPulse
-                        ? .easeInOut(duration: 1.0).repeatForever(autoreverses: true)
-                        : .default,
-                    value: pulse
-                )
-                .onAppear {
-                    if shouldPulse { pulse = true }
-                }
-                .onChange(of: pill.status) {
-                    pulse = shouldPulse ? true : false
-                }
+        // Only render a status dot when the agent has finished. While running
+        // the rotating logo itself signals activity — the dot would be
+        // redundant noise on top of that.
+        if showStatusDot {
+            ZStack {
+                Circle()
+                    .fill(Color(nsColor: NSColor(white: 0.05, alpha: 1.0)))
+                    .frame(width: 10, height: 10)
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 8, height: 8)
+            }
+            .offset(x: 3, y: -3)
+            .transition(.scale.combined(with: .opacity))
         }
-        .offset(x: 3, y: -3)
     }
 
-    private var shouldPulse: Bool {
+    /// Show the dot only on terminal states. While running we rely on the
+    /// rotating logo as the activity signal.
+    private var showStatusDot: Bool {
         switch pill.status {
-        case .running, .starting: return true
+        case .done, .failed: return true
         default: return false
         }
     }
 
     private var statusColor: Color {
         switch pill.status {
+        case .queued: return Color(red: 0.85, green: 0.78, blue: 0.30)
         case .starting, .running: return Color(red: 0.27, green: 0.92, blue: 0.46)
-        case .done: return Color(red: 0.45, green: 0.85, blue: 1.0)
+        case .done: return Color(red: 0.27, green: 0.92, blue: 0.46)  // green
         case .failed: return Color(red: 1.0, green: 0.42, blue: 0.42)
         }
     }
 
+    private var isRotating: Bool {
+        switch pill.status {
+        case .starting, .running: return true
+        default: return false
+        }
+    }
+
     private func startRotationIfRunning() {
-        rotationTimer?.invalidate()
-        rotationTimer = nil
         switch pill.status {
         case .starting, .running:
-            // Subtle: a single 360° rotation every ~3s with easing — not annoying.
+            // Continuous slow rotation — set a single faraway target and let
+            // SwiftUI's repeatForever animation drive it. Avoids the timer
+            // wakeups and the "pause between revolutions" feel of the old
+            // implementation.
             rotationAngle = 0
-            let timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
-                Task { @MainActor in
-                    withAnimation(.easeInOut(duration: 1.2)) {
-                        rotationAngle += 360
-                    }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                withAnimation(.linear(duration: 4.0).repeatForever(autoreverses: false)) {
+                    rotationAngle = 360
                 }
             }
-            timer.fire()
-            rotationTimer = timer
         default:
-            // Settle to upright on completion.
-            withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
-                rotationAngle = 0
+            // Stop where we are — no snap-back, that would feel jerky after
+            // a long-running task.
+            withAnimation(.easeOut(duration: 0.4)) {
+                rotationAngle = floor(rotationAngle / 360) * 360
             }
         }
     }
@@ -208,9 +202,6 @@ struct AgentPillPopover: View {
     var onDismiss: () -> Void
     var onOpenInChat: () -> Void
     var onSendFollowUp: (String) -> Void
-
-    @State private var followUpText: String = ""
-    @FocusState private var followUpFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -273,6 +264,7 @@ struct AgentPillPopover: View {
 
     private var statusBadgeForeground: Color {
         switch pill.status {
+        case .queued: return Color(red: 0.0, green: 0.0, blue: 0.0)
         case .starting, .running: return Color(red: 0.18, green: 0.10, blue: 0.0)
         case .done: return Color(red: 0.07, green: 0.18, blue: 0.10)
         case .failed: return .white
@@ -281,6 +273,7 @@ struct AgentPillPopover: View {
 
     private var statusBadgeBackground: Color {
         switch pill.status {
+        case .queued: return Color(red: 0.85, green: 0.85, blue: 0.85)
         case .starting, .running: return Color(red: 1.0, green: 0.78, blue: 0.30)
         case .done: return Color(red: 0.45, green: 0.92, blue: 0.55)
         case .failed: return Color(red: 0.78, green: 0.32, blue: 0.32)
@@ -345,47 +338,22 @@ struct AgentPillPopover: View {
                 }
             }
 
-            HStack(spacing: 6) {
-                TextField("Follow up", text: $followUpText)
-                    .textFieldStyle(.plain)
-                    .scaledFont(size: 12)
-                    .foregroundColor(.white)
-                    .focused($followUpFocused)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 6)
-                    .background(Color.white.opacity(0.06))
-                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-                    .onSubmit { submitFollowUp() }
-
-                Button {
-                    submitFollowUp()
-                } label: {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundColor(followUpText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .white.opacity(0.35) : .white)
-                }
-                .buttonStyle(.plain)
-                .disabled(followUpText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-                Button(action: onOpenInChat) {
+            Button(action: onOpenInChat) {
+                HStack(spacing: 6) {
                     Image(systemName: "bubble.left.and.bubble.right.fill")
-                        .font(.system(size: 12))
-                        .foregroundColor(.white.opacity(0.7))
-                        .frame(width: 26, height: 26)
-                        .background(Color.white.opacity(0.08))
-                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                        .font(.system(size: 11))
+                    Text("Open in chat")
+                        .scaledFont(size: 11, weight: .medium)
                 }
-                .buttonStyle(.plain)
-                .help("Open in chat")
+                .foregroundColor(.white)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .frame(maxWidth: .infinity)
+                .background(Color.white.opacity(0.10))
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             }
+            .buttonStyle(.plain)
         }
-    }
-
-    private func submitFollowUp() {
-        let trimmed = followUpText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        onSendFollowUp(trimmed)
-        followUpText = ""
     }
 }
 

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPillsWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPillsWindow.swift
@@ -1,0 +1,230 @@
+import AppKit
+import Combine
+import SwiftUI
+
+/// Borderless overlay window that displays the agent pills row and the hover
+/// popover directly below the floating control bar. Kept separate from the
+/// main floating bar window so it doesn't fight the bar's tightly-managed
+/// resize logic.
+@MainActor
+final class AgentPillsWindow: NSPanel, NSWindowDelegate {
+    /// Vertical gap between the floating bar's bottom edge and the pills row.
+    static let gapBelowBar: CGFloat = 8
+
+    private let manager = AgentPillsManager.shared
+    private var hostingView: NSHostingView<AnyView>?
+    private var pillsCancellable: AnyCancellable?
+    private var hoverCancellable: AnyCancellable?
+    private weak var anchorWindow: NSWindow?
+
+    init() {
+        super.init(
+            contentRect: NSRect(origin: .zero, size: NSSize(width: 200, height: AgentPillsLayout.rowHeight)),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        self.appearance = NSAppearance(named: .vibrantDark)
+        self.isOpaque = false
+        self.backgroundColor = .clear
+        self.hasShadow = false
+        self.level = .floating
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+        self.isMovableByWindowBackground = false
+        self.isReleasedWhenClosed = false
+        self.delegate = self
+        self.ignoresMouseEvents = false
+        self.becomesKeyOnlyIfNeeded = true
+
+        setupHostingView()
+        observeManager()
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    /// Anchor the pills window to the floating bar's window frame.
+    func attach(to barWindow: NSWindow) {
+        self.anchorWindow = barWindow
+        repositionToAnchor()
+        // Reposition whenever the bar moves or resizes.
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(anchorMoved(_:)),
+            name: NSWindow.didMoveNotification, object: barWindow
+        )
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(anchorMoved(_:)),
+            name: NSWindow.didResizeNotification, object: barWindow
+        )
+    }
+
+    @objc private func anchorMoved(_ note: Notification) {
+        repositionToAnchor()
+    }
+
+    private func setupHostingView() {
+        let root = AgentPillsContainerView(
+            manager: manager,
+            onSendFollowUp: { [weak self] pill, text in
+                self?.spawnFollowUp(from: pill, text: text)
+            },
+            onOpenInChat: { [weak self] pill in
+                self?.openPillInChat(pill)
+            }
+        )
+
+        let view = AnyView(root.preferredColorScheme(.dark).withFontScaling())
+        let hosting = NSHostingView(rootView: view)
+        hosting.appearance = NSAppearance(named: .vibrantDark)
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        hostingView = hosting
+
+        let container = NSView()
+        self.contentView = container
+        container.addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: container.topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+    }
+
+    private func observeManager() {
+        pillsCancellable = manager.$pills
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] pills in
+                self?.updateVisibility(pillCount: pills.count)
+                self?.repositionToAnchor()
+            }
+        hoverCancellable = manager.$hoveredPillID
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.repositionToAnchor()
+            }
+    }
+
+    private func updateVisibility(pillCount: Int) {
+        if pillCount == 0 {
+            self.orderOut(nil)
+        } else if !self.isVisible, let anchor = anchorWindow, anchor.isVisible {
+            self.orderFront(nil)
+        }
+    }
+
+    /// Recompute frame size and position based on the anchor window and the
+    /// current pill count + hover state.
+    private func repositionToAnchor() {
+        guard let anchor = anchorWindow else { return }
+
+        let pillCount = manager.pills.count
+        guard pillCount > 0 else {
+            self.orderOut(nil)
+            return
+        }
+
+        let rowWidth = computeRowWidth(pillCount: pillCount)
+        let popoverHeight: CGFloat = manager.hoveredPillID != nil ? popoverEstimatedHeight() : 0
+        let totalHeight = AgentPillsLayout.rowHeight + (popoverHeight > 0 ? popoverHeight + 6 : 0)
+
+        let anchorFrame = anchor.frame
+        // Center the row horizontally on the anchor, position right below it.
+        let centerX = anchorFrame.midX
+        let topY = anchorFrame.minY - AgentPillsWindow.gapBelowBar
+        let originX = centerX - max(rowWidth, AgentPillsLayout.popoverWidth) / 2
+        let originY = topY - totalHeight
+
+        let frame = NSRect(
+            x: originX,
+            y: originY,
+            width: max(rowWidth, AgentPillsLayout.popoverWidth),
+            height: totalHeight
+        )
+        self.setFrame(frame, display: true, animate: false)
+
+        // Make sure we're above the floating bar and visible on the same screen.
+        if let anchorScreen = anchor.screen, anchorScreen != self.screen {
+            self.setFrameOrigin(frame.origin)
+        }
+
+        if !self.isVisible, let anchor = anchorWindow, anchor.isVisible {
+            self.orderFront(nil)
+        }
+    }
+
+    private func computeRowWidth(pillCount: Int) -> CGFloat {
+        let pillsWidth = CGFloat(pillCount) * AgentPillsLayout.pillSize
+            + CGFloat(max(0, pillCount - 1)) * AgentPillsLayout.pillSpacing
+        return pillsWidth + AgentPillsLayout.rowHorizontalPadding * 2
+    }
+
+    private func popoverEstimatedHeight() -> CGFloat {
+        // Generous estimate that fits header + activity + (progress bar OR follow-ups).
+        guard let id = manager.hoveredPillID,
+            let pill = manager.pills.first(where: { $0.id == id })
+        else { return 0 }
+        switch pill.status {
+        case .done, .failed: return 170
+        default: return 110
+        }
+    }
+
+    private func spawnFollowUp(from pill: AgentPill, text: String) {
+        manager.spawn(query: text, model: pill.model)
+    }
+
+    private func openPillInChat(_ pill: AgentPill) {
+        // For the demo: bring the floating bar to front, open Ask Omi conversation
+        // pre-populated with the pill's query so the user can continue inline.
+        anchorWindow?.makeKeyAndOrderFront(nil)
+        NotificationCenter.default.post(
+            name: .agentPillRequestedChat,
+            object: nil,
+            userInfo: ["query": pill.query]
+        )
+    }
+}
+
+extension Notification.Name {
+    static let agentPillRequestedChat = Notification.Name("agentPillRequestedChat")
+}
+
+/// SwiftUI container that draws the pills row plus a hover popover anchored
+/// below it. The popover is rendered inside the same window so hovering the
+/// pill smoothly transitions into hovering the popover.
+struct AgentPillsContainerView: View {
+    @ObservedObject var manager: AgentPillsManager
+    var onSendFollowUp: (AgentPill, String) -> Void
+    var onOpenInChat: (AgentPill) -> Void
+
+    var body: some View {
+        VStack(spacing: 6) {
+            AgentPillsRowView(manager: manager)
+                .floatingBackground(cornerRadius: 14)
+                .fixedSize(horizontal: true, vertical: true)
+                .frame(height: AgentPillsLayout.rowHeight)
+
+            if let hoveredID = manager.hoveredPillID,
+                let pill = manager.pills.first(where: { $0.id == hoveredID }) {
+                AgentPillPopover(
+                    pill: pill,
+                    onDismiss: { manager.dismiss(pillID: pill.id) },
+                    onOpenInChat: { onOpenInChat(pill) },
+                    onSendFollowUp: { text in onSendFollowUp(pill, text) }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .onHover { hovering in
+                    // Keep the popover open while the user is interacting with it.
+                    if hovering {
+                        manager.hoveredPillID = pill.id
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+        .animation(.spring(response: 0.32, dampingFraction: 0.85), value: manager.hoveredPillID)
+        .animation(.spring(response: 0.32, dampingFraction: 0.85), value: manager.pills.count)
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPillsWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPillsWindow.swift
@@ -170,7 +170,7 @@ final class AgentPillsWindow: NSPanel, NSWindowDelegate {
     }
 
     private func spawnFollowUp(from pill: AgentPill, text: String) {
-        manager.spawn(query: text, model: pill.model)
+        manager.spawnFromUserQuery(text, model: pill.model)
     }
 
     private func openPillInChat(_ pill: AgentPill) {

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -271,6 +271,34 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     }
   }
 
+  /// Synthesize and play a single short phrase via ElevenLabs (or fall back to
+  /// the system voice). Used by agent pills to speak a short acknowledgement
+  /// like "On it" before the agent kicks off.
+  func speakOneShot(_ text: String) {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    let mode = currentMode ?? resolvePlaybackMode()
+    currentMode = mode
+    switch mode {
+    case .elevenLabs(let voiceID):
+      Task { [weak self] in
+        do {
+          let audio = try await Self.synthesizeSpeech(text: trimmed, voiceID: voiceID)
+          await MainActor.run {
+            self?.startPlayback(audio)
+          }
+        } catch {
+          // Network/API error — fall back to system voice on the main thread.
+          await MainActor.run {
+            self?.enqueueSystemSpeech(trimmed)
+          }
+        }
+      }
+    case .systemFallback:
+      enqueueSystemSpeech(trimmed)
+    }
+  }
+
   func interruptCurrentResponse() {
     if let currentResponseID {
       interruptedResponseID = currentResponseID

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -201,8 +201,8 @@ struct FloatingControlBarView: View {
 
                 Spacer(minLength: 0)
 
-                // Reserve space so text never runs under the overlaid X button.
-                Color.clear.frame(width: 18, height: 18)
+                // Reserve space so text never runs under the overlaid action buttons.
+                Color.clear.frame(width: 90, height: 18)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 12)
@@ -211,17 +211,44 @@ struct FloatingControlBarView: View {
         }
         .buttonStyle(.plain)
         .overlay(alignment: .topTrailing) {
-            Button {
-                FloatingControlBarManager.shared.dismissCurrentNotification()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundColor(.white.opacity(0.62))
-                    .frame(width: 18, height: 18)
-                    .background(Color.white.opacity(0.08))
-                    .clipShape(Circle())
+            HStack(spacing: 6) {
+                // Spawn an agent pill that handles whatever the notification is
+                // about — reuses the same parallel-pill bridge flow.
+                Button {
+                    let model = ShortcutSettings.shared.selectedModel.isEmpty
+                        ? "claude-sonnet-4-6"
+                        : ShortcutSettings.shared.selectedModel
+                    let query = "Handle this notification: \(notification.title). \(notification.message)"
+                    AgentPillsManager.shared.spawn(query: query, model: model)
+                    FloatingControlBarManager.shared.dismissCurrentNotification()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 9, weight: .bold))
+                        Text("Execute")
+                            .scaledFont(size: 10, weight: .semibold)
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.white.opacity(0.18))
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .help("Spawn an agent to handle this")
+
+                Button {
+                    FloatingControlBarManager.shared.dismissCurrentNotification()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.white.opacity(0.62))
+                        .frame(width: 18, height: 18)
+                        .background(Color.white.opacity(0.08))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
             .padding(.horizontal, 12)
             .padding(.vertical, 12)
         }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -996,7 +996,7 @@ class FloatingControlBarManager {
                 let model = ShortcutSettings.shared.selectedModel.isEmpty
                     ? "claude-sonnet-4-6"
                     : ShortcutSettings.shared.selectedModel
-                _ = AgentPillsManager.shared.spawn(query: message, model: model)
+                _ = AgentPillsManager.shared.spawnFromUserQuery(message, model: model)
                 // Collapse the input so the pill is the only visible result.
                 barWindow.state.aiInputText = ""
                 barWindow.closeAIConversation()
@@ -1292,7 +1292,7 @@ class FloatingControlBarManager {
                 let model = ShortcutSettings.shared.selectedModel.isEmpty
                     ? "claude-sonnet-4-6"
                     : ShortcutSettings.shared.selectedModel
-                _ = AgentPillsManager.shared.spawn(query: message, model: model)
+                _ = AgentPillsManager.shared.spawnFromUserQuery(message, model: model)
                 window.state.aiInputText = ""
                 window.closeAIConversation()
                 return
@@ -1322,7 +1322,17 @@ class FloatingControlBarManager {
         window.state.currentQueryFromVoice = fromVoice
         window.orderFrontRegardless()
 
-        // Auto-send the query
+        // Auto-send the query. PTT bypasses the typed onSendQuery closure, so
+        // we need to apply the same pill-routing rule here ourselves.
+        if AgentPillsManager.looksLikeAction(query) {
+            let model = ShortcutSettings.shared.selectedModel.isEmpty
+                ? "claude-sonnet-4-6"
+                : ShortcutSettings.shared.selectedModel
+            _ = AgentPillsManager.shared.spawnFromUserQuery(query, model: model, fromVoice: fromVoice)
+            window.state.aiInputText = ""
+            window.closeAIConversation()
+            return
+        }
         Task { @MainActor in
             await self.sendAIQuery(query, barWindow: window, provider: provider)
         }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -849,11 +849,16 @@ class FloatingControlBarManager {
 
     private var window: FloatingControlBarWindow?
     private var snoozeTimer: Timer?
+    private var pillsWindow: AgentPillsWindow?
     private var recordingCancellable: AnyCancellable?
     private var durationCancellable: AnyCancellable?
     private var chatCancellable: AnyCancellable?
     private var historyChatProvider: ChatProvider?
     private var floatingChatProvider: ChatProvider?
+
+    /// Public read-only access to the floating bar's chat provider so the
+    /// agent pills manager can inherit the working directory / model.
+    var sharedFloatingProvider: ChatProvider? { floatingChatProvider }
     private var pendingNotifications: [FloatingBarNotification] = []
     private var notificationDismissWorkItem: DispatchWorkItem?
     private var notificationWasTemporarilyShown = false
@@ -985,6 +990,18 @@ class FloatingControlBarManager {
 
         barWindow.onSendQuery = { [weak self, weak barWindow, weak floatingProvider] message in
             guard let self = self, let barWindow = barWindow, let provider = floatingProvider else { return }
+            // Route action-like queries to an agent pill (no inline chat). Quick
+            // questions still flow through the inline conversation.
+            if AgentPillsManager.looksLikeAction(message) {
+                let model = ShortcutSettings.shared.selectedModel.isEmpty
+                    ? "claude-sonnet-4-6"
+                    : ShortcutSettings.shared.selectedModel
+                _ = AgentPillsManager.shared.spawn(query: message, model: model)
+                // Collapse the input so the pill is the only visible result.
+                barWindow.state.aiInputText = ""
+                barWindow.closeAIConversation()
+                return
+            }
             Task { @MainActor in
                 await self.sendAIQuery(message, barWindow: barWindow, provider: provider)
             }
@@ -1061,6 +1078,26 @@ class FloatingControlBarManager {
             scheduleSnoozeTimer()
         } else if snoozedUntil != nil {
             snoozedUntil = nil
+        }
+
+        // Create the agent pills overlay window and anchor it under the bar.
+        let pills = AgentPillsWindow()
+        pills.attach(to: barWindow)
+        self.pillsWindow = pills
+
+        // Listen for "open in chat" requests from a pill so the user can
+        // continue an agent's task inline if they want.
+        NotificationCenter.default.addObserver(
+            forName: .agentPillRequestedChat, object: nil, queue: .main
+        ) { [weak barWindow] note in
+            guard let barWindow = barWindow else { return }
+            Task { @MainActor in
+                let query = (note.userInfo?["query"] as? String) ?? ""
+                barWindow.showAIConversation()
+                if !query.isEmpty {
+                    barWindow.state.aiInputText = query
+                }
+            }
         }
     }
 
@@ -1251,6 +1288,15 @@ class FloatingControlBarManager {
         // Re-wire the onSendQuery to use the isolated floating-bar provider
         window.onSendQuery = { [weak self, weak window, weak provider] message in
             guard let self = self, let window = window, let provider = provider else { return }
+            if AgentPillsManager.looksLikeAction(message) {
+                let model = ShortcutSettings.shared.selectedModel.isEmpty
+                    ? "claude-sonnet-4-6"
+                    : ShortcutSettings.shared.selectedModel
+                _ = AgentPillsManager.shared.spawn(query: message, model: model)
+                window.state.aiInputText = ""
+                window.closeAIConversation()
+                return
+            }
             Task { @MainActor in
                 await self.sendAIQuery(message, barWindow: window, provider: provider)
             }

--- a/desktop/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -4258,6 +4258,30 @@ struct TaskRow: View {
             // Hover actions overlaid on trailing edge (no layout shift)
             if (isHovering || showPriorityPicker) && !isMultiSelectMode && !isDeletedTask && !isTextFieldFocused {
                 HStack(spacing: 4) {
+                    // Execute: spawn an agent pill that handles this task end-to-end.
+                    if !task.completed {
+                        Button {
+                            let model = ShortcutSettings.shared.selectedModel.isEmpty
+                                ? "claude-sonnet-4-6"
+                                : ShortcutSettings.shared.selectedModel
+                            AgentPillsManager.shared.spawn(query: task.description, model: model)
+                        } label: {
+                            HStack(spacing: 3) {
+                                Image(systemName: "sparkles")
+                                    .font(.system(size: 9, weight: .bold))
+                                Text("Execute")
+                                    .scaledFont(size: 10, weight: .semibold)
+                            }
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.white.opacity(0.18))
+                            .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                        .help("Spawn an agent to do this")
+                    }
+
                     // Add date button (shown on hover when no due date)
                     if task.dueAt == nil && !task.completed {
                         Button {


### PR DESCRIPTION
## Summary
- New floating-bar **agent pills**: action-y Ask Omi requests (typed *or* voice via PTT) spawn small rounded-square pills below the bar that run in parallel — each gets its own ChatProvider/bridge so they truly execute concurrently. Hover any pill to see live activity, status badge (Queued/Running/Done/Failed), and an "Open in chat" button.
- Smart pill titles via Claude Haiku through the desktop-backend's `/v2/chat/completions` proxy (no BYOK needed). Voice spawns get an instant ElevenLabs ack ("On it.") before the agent kicks off so the user always hears confirmation.
- "spawn 3 agents" / "make 5 things" parses the count and spawns N pills with one user message.
- **Execute button** on floating-bar notification cards (✦ next to the X dismiss) — click to spawn an agent that handles the notification end-to-end.
- **Execute button** on Tasks page rows (revealed on hover) — spawns an agent for the task description through the same flow.

## Architecture
- `AgentPill.swift` — model + `AgentPillsManager` singleton, per-pill `ChatProvider`, staggered bridge boots via `bootChain`, `looksLikeAction()` heuristic, `parseAgentCount()`, `generateTitleAndAck()` via backend proxy, instant `randomAck()` for voice.
- `AgentPillsView.swift` — pill row UI, continuous Task-driven rotation that actually halts on done, green status dot only on terminal states, hover popover with suggested-next chips and Open-in-chat button.
- `AgentPillsWindow.swift` — borderless `NSPanel` overlay anchored under the floating bar.
- `FloatingControlBarWindow.swift` — typed and PTT send paths route action queries to a pill instead of inline chat; `.agentPillRequestedChat` notification reopens inline chat from a pill.
- `FloatingBarVoicePlaybackService.speakOneShot()` — fire-and-forget ElevenLabs (or system fallback) for the instant ack.
- `FloatingControlBarView.swift` — Execute capsule on notification cards.
- `TasksPage.swift` — Execute capsule in the hover-actions row.

## Test plan
- [ ] Type \`make a snake game\` in the floating bar → pill spawns, title becomes \`Building Snake Game\` (Haiku), spinner runs, settles with green dot
- [ ] Type \`spawn 3 test agents\` → 3 pills line up; hover each to see independent activity
- [ ] PTT a query like \`open google.com and find vegan ramen\` → voice ack ("On it.") plays, pill spawns
- [ ] Trigger a notification (or wait for a real one) → click ✦ Execute → notification dismisses, pill spawns
- [ ] Hover a row in the Tasks page → ✦ Execute capsule appears → click → pill spawns running the task description
- [ ] Hover a pill → popover shows live tool calls; agent finishes, popover updates with Suggested next + Open in chat
- [ ] Click \"Open in chat\" → floating-bar inline chat opens pre-populated with the original query

🤖 Generated with [Claude Code](https://claude.com/claude-code)