### PR TITLE
Update CHANGELOG.json for v0.11.364 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,9 +1,14 @@
 {
-  "unreleased": [
-    "Added agent pills: action-y Ask Omi requests (typed or voice) now spawn small floating-bar agents that run in parallel; hover any pill to see live progress and open in chat",
-    "Added Execute button on floating-bar notification cards and task rows \u2014 one click spawns an agent that handles the item end-to-end"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.364",
+      "date": "2026-04-26",
+      "changes": [
+        "Added agent pills: action-y Ask Omi requests (typed or voice) now spawn small floating-bar agents that run in parallel; hover any pill to see live progress and open in chat",
+        "Added Execute button on floating-bar notification cards and task rows \u2014 one click spawns an agent that handles the item end-to-end"
+      ]
+    },
     {
       "version": "0.11.363",
       "date": "2026-04-26",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.364 and clears the unreleased array.