### PR TITLE
fix(ble): stop Omi connect/bond/disconnect loop on Android

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -293,15 +293,14 @@ class OmiBleManager private constructor(private val application: Application) {
             completion(Result.failure(Exception("Device not connected")))
             return
         }
-        if (device.bondState == BluetoothDevice.BOND_BONDED) {
+        val state = device.bondState
+        if (state == BluetoothDevice.BOND_BONDED) {
             Log.i(TAG, "requestBond: $addr already bonded")
             completion(Result.success(true))
             return
         }
-        Log.i(TAG, "requestBond: $addr initiating bond")
         bondingAddress = addr
         bondCompletionCallback = { bonded -> completion(Result.success(bonded)) }
-        device.createBond()
         val timeoutRunnable = Runnable {
             bondTimeoutRunnable = null
             bondingAddress = null
@@ -311,6 +310,14 @@ class OmiBleManager private constructor(private val application: Application) {
         }
         bondTimeoutRunnable = timeoutRunnable
         mainHandler.postDelayed(timeoutRunnable, BOND_TIMEOUT_MS)
+        if (state == BluetoothDevice.BOND_BONDING) {
+            // Peripheral already initiated SMP (firmware's bt_conn_set_security).
+            // Don't call createBond() again — it can spawn a second pair dialog or restart SMP.
+            Log.i(TAG, "requestBond: $addr already bonding, awaiting completion")
+            return
+        }
+        Log.i(TAG, "requestBond: $addr initiating bond")
+        device.createBond()
     }
 
     // ── Characteristic operations ──

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -68,7 +68,7 @@ class DeviceConnectionFactory {
       case TransportKind.bluetooth:
         final deviceId = locator.bluetoothId;
         if (deviceId == null) return null;
-        final needsBond = device.type == DeviceType.limitless;
+        final needsBond = device.type == DeviceType.limitless || device.type == DeviceType.omi;
         transport = NativeBleTransport(deviceId, requiresBond: needsBond);
         break;
 

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -64,11 +64,20 @@ class DeviceConnectionFactory {
     final locator = device.locator;
     if (locator == null) return null;
 
+    // Use name-based detection as fallback for OmiGlass devices (some advertise as DeviceType.omi).
+    final deviceName = device.name.toLowerCase();
+    final isOmiGlass = device.type == DeviceType.openglass ||
+        deviceName.contains('openglass') ||
+        deviceName.contains('omiglass') ||
+        deviceName.contains('glass');
+
     switch (locator.kind) {
       case TransportKind.bluetooth:
         final deviceId = locator.bluetoothId;
         if (deviceId == null) return null;
-        final needsBond = device.type == DeviceType.limitless || device.type == DeviceType.omi;
+        // OmiGlass firmware does not have CONFIG_BT_SMP — exclude it from the bonded set
+        // even if it advertised as DeviceType.omi.
+        final needsBond = device.type == DeviceType.limitless || (device.type == DeviceType.omi && !isOmiGlass);
         transport = NativeBleTransport(deviceId, requiresBond: needsBond);
         break;
 
@@ -79,14 +88,6 @@ class DeviceConnectionFactory {
       default:
         return null;
     }
-
-    // Create device connection with transport
-    // Use name-based detection as fallback for OmiGlass devices
-    final deviceName = device.name.toLowerCase();
-    final isOmiGlass = device.type == DeviceType.openglass ||
-        deviceName.contains('openglass') ||
-        deviceName.contains('omiglass') ||
-        deviceName.contains('glass');
 
     switch (device.type) {
       case DeviceType.omi:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.533+832
+version: 1.0.534+833
 
 
 environment:


### PR DESCRIPTION
## Summary
- Tell the Android native BLE layer that Omi devices now require bonding, so it waits for `BOND_BONDED` before issuing MTU/notification GATT ops (firmware started requesting `BT_SECURITY_L2` on connect in #6822).
- In `OmiBleManager.requestBond`, also short-circuit on `BOND_BONDING` instead of only `BOND_BONDED` — otherwise we call `createBond()` a second time when the firmware initiated SMP first, spawning a duplicate "Pair & connect" dialog.

## Background
After the bonding-persistence firmware change, Android entered a connect → bond fail → `status=22` disconnect → reconnect loop. Bond state went `BOND_BONDING → BOND_NONE`, then the local host terminated the link ~3s later. Root cause: the Dart/Native layer treated Omi as a no-bond device (`requiresBond=false`), so MTU/notification setup raced with the peripheral-initiated SMP procedure. Switching the Omi flag to `requiresBond=true` makes the existing `OmiBleForegroundService` bond branch wait for `BOND_BONDED` before continuing the GATT pipeline.

The second commit fixes the "had to tap Pair & Connect twice" symptom that surfaced once the loop was gone — `requestBond` was kicking off a second `createBond()` because the firmware-initiated SMP had already moved the device into `BOND_BONDING` by the time `onGattServicesDiscovered` fired.

## Test plan
- [ ] First-time pair on a fresh Android device: single "Pair & Connect" dialog, bond completes, MTU=498 negotiates, audio streams.
- [ ] Reconnect after BT toggle: link re-encrypts silently with persisted keys, no dialog.
- [ ] Reconnect after app cold start: same — no dialog.
- [ ] Reconnect after device power cycle: bond keys persisted on firmware, no dialog.
- [ ] Existing users with stale half-bond: `Settings → Bluetooth → Omi → Forget`, then re-pair completes in one tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)