### PR TITLE
feat(sdks): launch omi-cli — terminal-native interface to the Omi developer API

### DIFF
--- a/sdks/python-cli/.gitignore
+++ b/sdks/python-cli/.gitignore
@@ -1,0 +1,59 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+test_env/
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+.venv/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Testing
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/sdks/python-cli/LICENSE
+++ b/sdks/python-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Based Hardware / Omi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -1,0 +1,234 @@
+# omi-cli
+
+> Talk to Omi from your terminal. Designed for humans **and** agents.
+
+`omi-cli` is the command-line interface to the [Omi](https://omi.me) developer
+API. It exposes scoped, agent-friendly verbs for the four primary nouns Omi
+maintains about you:
+
+* **memories** — facts and learnings the system knows about you
+* **conversations** — captured & processed audio/text exchanges
+* **action items** — tasks and follow-ups
+* **goals** — tracked progress metrics
+
+It's intentionally small, scriptable, and JSON-first — everything you need to
+plug Omi into shell pipelines, CI jobs, agent harnesses, or just your own
+personal automation.
+
+## Install
+
+```bash
+pipx install omi-cli            # recommended — isolated install
+# or
+pip install omi-cli
+```
+
+After install, the binary on your `$PATH` is named `omi`:
+
+```bash
+omi --version
+omi --help
+```
+
+> The PyPI distribution name is `omi-cli` (the bare `omi` slot belongs to an
+> unrelated package). The console command is `omi` regardless.
+
+## Quickstart
+
+```bash
+# 1. Generate a developer API key in the Omi web app:
+#    https://app.omi.me   →   Developer   →   API Keys
+#    Choose the scopes you want this CLI to be able to exercise.
+
+# 2. Log in (the prompt is hidden — your key never lands in shell history):
+omi auth login
+
+# 3. Start using it:
+omi memory list
+omi conversation list --limit 5
+omi action-item list --open
+omi goal list
+```
+
+Pass `--json` to any command to get machine-readable output, ready for `jq`,
+agent harnesses, or whatever else:
+
+```bash
+omi memory list --json | jq '.[] | {id, content}'
+```
+
+## Auth
+
+Two auth methods are wired:
+
+| Method                      | Status   | Use it for                    |
+| --------------------------- | -------- | ----------------------------- |
+| Dev API key (`omi_dev_*`)   | ✅ v0.1.0 | Agents, CI, headless, default |
+| Firebase OAuth (`--browser`) | 🚧 v0.2.0 | Humans on a laptop            |
+
+The browser flow is currently stubbed with a clear message; for now generate a
+dev key in the Omi web app and paste it into `omi auth login`. API keys are
+the right choice for agents anyway — they're long-lived, scoped, and don't
+need a browser.
+
+```bash
+omi auth login                  # interactive paste, hidden input
+omi auth login < key.txt        # piped, useful in CI
+omi auth status                 # show profile + masked credential
+omi auth whoami                 # round-trip to verify the credential works
+omi auth logout                 # wipe the credential
+```
+
+You can also set `OMI_API_KEY` in the environment to bypass on-disk config
+entirely — handy in containers and CI:
+
+```bash
+export OMI_API_KEY=omi_dev_...
+omi memory list
+```
+
+## Profiles
+
+State lives at `~/.omi/config.toml` (overridable via `$OMI_CONFIG`). The file
+holds one or more named profiles, each with its own auth method and API base.
+Switch between them with `--profile`:
+
+```bash
+omi config profile use work
+omi auth login                  # logs in the active profile (work)
+omi --profile personal memory list
+```
+
+Common config:
+
+```bash
+omi config show
+omi config path
+omi config set api_base https://api.staging.omi.me
+omi config profile list
+omi config profile delete old-account --yes
+```
+
+## Command surface
+
+The full tree (run `omi --help` for the live version):
+
+```text
+omi
+├── auth
+│   ├── login [--browser] [--api-key KEY]
+│   ├── logout
+│   ├── status
+│   ├── whoami
+│   └── refresh
+├── config
+│   ├── show
+│   ├── path
+│   ├── set <key> <value>
+│   └── profile
+│       ├── list
+│       ├── use <name>
+│       └── delete <name>
+├── memory
+│   ├── list [--limit N] [--offset N] [--categories ...]
+│   ├── get <id>
+│   ├── create <content> [--category ...] [--visibility ...] [--tag ...]
+│   ├── update <id> [--content ...] [--category ...] [--visibility ...] [--tag ...]
+│   └── delete <id> [-y]
+├── conversation
+│   ├── list [--limit N] [--start-date ...] [--end-date ...] [--include-transcript]
+│   ├── get <id> [--include-transcript]
+│   ├── create [--text ...] [--text-source ...] [...]
+│   ├── from-segments <file.json> [--source ...]
+│   ├── update <id> [--title ...] [--discarded/--no-discarded]
+│   └── delete <id> [-y]
+├── action-item
+│   ├── list [--completed/--open] [--conversation-id ...] [...]
+│   ├── get <id>
+│   ├── create <description> [--due-at ...]
+│   ├── update <id> [--description ...] [--completed/--open] [--due-at ...]
+│   ├── complete <id>
+│   └── delete <id> [-y]
+└── goal
+    ├── list [--limit N] [--include-inactive]
+    ├── get <id>
+    ├── create <title> --target N [--type ...] [--current N] [--unit ...]
+    ├── update <id> [...]
+    ├── progress <id> <value>
+    ├── history <id> [--days N]
+    └── delete <id> [-y]
+```
+
+## Global flags
+
+```text
+--json                 Emit JSON to stdout (machine-readable, agent-friendly).
+--profile, -p NAME     Use a specific profile.
+--api-base URL         Override the API base URL.
+--verbose, -v          Log HTTP traffic to stderr.
+--no-color             Disable colored output (also honors $NO_COLOR).
+--version              Print the version.
+--help                 Show contextual help.
+```
+
+## Exit codes (stable contract)
+
+```text
+0  success
+1  usage error (bad flags, missing args, validation)
+2  auth error (no creds, expired token, insufficient scope)
+3  server error (5xx, connection failure)
+4  rate limited (429) — retry recommended
+5  not found (404)
+```
+
+## For agents
+
+The CLI is built so an LLM can use it without a wrapper:
+
+* `--json` returns valid JSON to stdout. Nothing else writes to stdout in JSON
+  mode (errors go to stderr as `{"error": "...", "detail": "..."}`).
+* Stable exit codes (above) let an agent disambiguate retryable vs terminal
+  errors.
+* Rate-limit errors include a `Retry-After` window in the message and surface
+  the policy name (`dev:conversations`, etc.) so an agent can back off
+  intelligently.
+* `OMI_API_KEY` and `OMI_API_BASE` env vars work without any prior `auth login`.
+
+See [`examples/agent_quickstart.md`](examples/agent_quickstart.md) for a worked
+example.
+
+## Rate limits
+
+The dev API enforces per-policy hourly limits:
+
+| Policy                | Limit       |
+| --------------------- | ----------- |
+| `dev:conversations`   | 25/hour     |
+| `dev:memories`        | 120/hour    |
+| `dev:memories_batch`  | 15/hour     |
+
+The CLI retries `429` automatically with exponential backoff and honors the
+server's `Retry-After` hint where present. After all retries are exhausted you
+get exit code `4` plus a message telling you how long to wait.
+
+## Development
+
+```bash
+# Editable install with dev extras
+pip install -e .[dev]
+
+# Run the test suite
+pytest -q
+
+# Lint
+black --check --line-length 120 --skip-string-normalization sdks/python-cli/
+mypy omi_cli
+
+# Build a wheel + sdist (no upload, no tag)
+bash release.sh --build-only
+```
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).

--- a/sdks/python-cli/examples/README.md
+++ b/sdks/python-cli/examples/README.md
@@ -1,0 +1,6 @@
+# omi-cli examples
+
+* [`agent_quickstart.md`](agent_quickstart.md) — how an LLM/agent should drive
+  the CLI.
+* [`shell_examples.sh`](shell_examples.sh) — runnable shell snippets covering
+  the most common verbs.

--- a/sdks/python-cli/examples/agent_quickstart.md
+++ b/sdks/python-cli/examples/agent_quickstart.md
@@ -1,0 +1,121 @@
+# omi-cli for agents
+
+> Practical guide for LLM-driven harnesses (Claude Code, Cursor, your own bots).
+
+## Why the CLI is agent-friendly
+
+* **Stable JSON contract.** `--json` emits a valid JSON document to stdout and
+  *only* a JSON document — no progress messages, no spinners. Errors go to
+  stderr as `{"error": "...", "detail": "..."}`.
+* **Stable exit codes.** `0` ok / `1` usage / `2` auth / `3` server / `4` rate
+  limited / `5` not found. Agents can branch on these without parsing
+  natural-language errors.
+* **No interactive prompts in headless contexts.** Pass `--yes` (or `-y`) to
+  destructive commands; pass `--api-key` or set `OMI_API_KEY` to skip
+  interactive login.
+* **Forgiving retry behavior.** `429` and `5xx` are retried with backoff
+  before surfacing.
+
+## Auth (one-time, by the human)
+
+The user gets a dev API key from the Omi web app
+(`https://app.omi.me` → Developer → API Keys) and either:
+
+```bash
+omi auth login                          # interactive paste; key not in shell history
+# or
+export OMI_API_KEY=omi_dev_...          # ephemeral, container-friendly
+```
+
+## The five things agents do most
+
+### 1. Read memories
+
+```bash
+omi memory list --json --limit 50 | jq '.[] | {id, content, category}'
+```
+
+### 2. Create a memory
+
+```bash
+omi memory create --json "User prefers dark mode" --category lifestyle
+```
+
+### 3. Read conversations
+
+```bash
+omi conversation list --json --limit 5 \
+  | jq '.[] | {id, title: .structured.title, started_at}'
+```
+
+### 4. Read open action items
+
+```bash
+omi action-item list --json --open
+```
+
+### 5. Mark an action item done
+
+```bash
+omi action-item complete --json a1b2c3d4
+```
+
+## Worked example: Python agent loop
+
+```python
+import json
+import subprocess
+from typing import Any
+
+def omi(*args: str) -> Any:
+    """Invoke the omi CLI in JSON mode, raising on non-success exit codes."""
+    result = subprocess.run(
+        ["omi", "--json", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # The CLI prints structured errors to stderr in JSON mode:
+        # {"error": "...", "detail": "..."}
+        try:
+            err = json.loads(result.stderr)
+        except json.JSONDecodeError:
+            err = {"error": result.stderr.strip()}
+        raise RuntimeError(f"omi exited {result.returncode}: {err}")
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+# Read all open action items and mark anything older than 30 days complete.
+from datetime import datetime, timedelta, timezone
+
+cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+items = omi("action-item", "list", "--open")
+for item in items or []:
+    created = datetime.fromisoformat(item["created_at"].replace("Z", "+00:00"))
+    if created < cutoff:
+        omi("action-item", "complete", item["id"])
+```
+
+## Handling rate limits
+
+Memories: 120/hr. Conversations: 25/hr. Batch creates: 15/hr.
+
+```python
+result = subprocess.run(["omi", "--json", "memory", "create", text], capture_output=True, text=True)
+if result.returncode == 4:                             # rate limited
+    err = json.loads(result.stderr)
+    # err["detail"] looks like: "Retry in 12s. ..."
+    time.sleep(parse_retry_window(err["detail"]) or 60)
+```
+
+## Tips
+
+* Use `--profile <name>` if your agent juggles multiple Omi accounts. Each
+  profile has its own credential and API base.
+* Use `--api-base http://localhost:8080` for local backend testing.
+* Use `--verbose` for debugging — it logs `METHOD path → status (Ns)` to stderr
+  without affecting stdout, so JSON mode stays valid.
+* For piping content into a conversation, use `--text -`:
+  ```bash
+  cat meeting_notes.md | omi conversation create --text - --text-source other_text
+  ```

--- a/sdks/python-cli/examples/shell_examples.sh
+++ b/sdks/python-cli/examples/shell_examples.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# omi-cli — runnable example snippets.
+# Each block is self-contained. Pick what you need.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+# Interactive login (recommended — input is hidden, never lands in history):
+#   omi auth login
+
+# Headless / CI:
+#   export OMI_API_KEY=omi_dev_...
+#   omi auth status
+
+# ---------------------------------------------------------------------------
+# Memories
+# ---------------------------------------------------------------------------
+
+# List the 10 most recent:
+omi memory list --limit 10
+
+# Get just the IDs and content as JSON for further processing:
+omi memory list --json --limit 50 | jq '.[] | {id, content}'
+
+# Create a memory with a category and tags:
+omi memory create "Wakes up at 6am most days" --category habits --tag morning --tag routine
+
+# Update a memory's content:
+omi memory update m_xyz --content "Wakes up at 6:30am most days"
+
+# Delete (skipping the confirm prompt):
+omi memory delete m_xyz --yes
+
+# ---------------------------------------------------------------------------
+# Conversations
+# ---------------------------------------------------------------------------
+
+# List with full transcripts:
+omi conversation list --limit 5 --include-transcript
+
+# Time-bounded query:
+omi conversation list \
+    --start-date 2026-04-01T00:00:00Z \
+    --end-date 2026-04-26T00:00:00Z \
+    --json | jq 'length'
+
+# Create from raw text (stdin form):
+echo "We agreed to ship the CLI on Friday." | omi conversation create --text - --text-source message
+
+# Create from structured segments (file with {transcript_segments: [...]}):
+omi conversation from-segments ./meeting_segments.json --source phone
+
+# Mark discarded:
+omi conversation update c_abc --discarded
+
+# ---------------------------------------------------------------------------
+# Action items
+# ---------------------------------------------------------------------------
+
+# All open items:
+omi action-item list --open
+
+# Filtered by date:
+omi action-item list --open --start-date 2026-04-01T00:00:00Z
+
+# Create with a due date:
+omi action-item create "Renew domain" --due-at 2026-05-01T00:00:00Z
+
+# Mark complete:
+omi action-item complete a_xyz
+
+# ---------------------------------------------------------------------------
+# Goals
+# ---------------------------------------------------------------------------
+
+# Active goals (default):
+omi goal list
+
+# Including inactive:
+omi goal list --include-inactive
+
+# Create a numeric goal:
+omi goal create "Drink 2L of water daily" --type numeric --target 2 --unit liters
+
+# Update progress (shortcut):
+omi goal progress g_xyz 1.5
+
+# History over the last week:
+omi goal history g_xyz --days 7

--- a/sdks/python-cli/omi_cli/__init__.py
+++ b/sdks/python-cli/omi_cli/__init__.py
@@ -1,0 +1,8 @@
+"""omi-cli — terminal-native interface to the Omi API.
+
+Provides scoped access to memories, conversations, action items, and goals via
+the developer API surface (`/v1/dev/*`). Designed for agents and humans alike.
+"""
+
+__version__ = "0.1.0"
+__all__ = ["__version__"]

--- a/sdks/python-cli/omi_cli/__main__.py
+++ b/sdks/python-cli/omi_cli/__main__.py
@@ -1,0 +1,11 @@
+"""Allow `python -m omi_cli` as an alternative entry point to the `omi` console script."""
+
+from omi_cli.main import app
+
+
+def _main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    _main()

--- a/sdks/python-cli/omi_cli/auth/__init__.py
+++ b/sdks/python-cli/omi_cli/auth/__init__.py
@@ -1,0 +1,21 @@
+"""Authentication primitives for omi-cli.
+
+Two flows are wired through this package:
+
+* :mod:`omi_cli.auth.api_key` — paste-in dev API key (``omi_dev_*``). Primary
+  flow, suitable for agents, CI, and any headless context.
+* :mod:`omi_cli.auth.oauth` — Firebase OAuth browser flow. Stubbed in v0.1.0
+  pending backend work to support a localhost callback redirect; the stub
+  surfaces a clear error and points users at the API-key flow.
+
+Common token persistence lives in :mod:`omi_cli.auth.store`.
+"""
+
+from omi_cli.auth.api_key import login_with_api_key, validate_api_key_format
+from omi_cli.auth.store import clear_credentials
+
+__all__ = [
+    "login_with_api_key",
+    "validate_api_key_format",
+    "clear_credentials",
+]

--- a/sdks/python-cli/omi_cli/auth/api_key.py
+++ b/sdks/python-cli/omi_cli/auth/api_key.py
@@ -1,0 +1,59 @@
+"""Developer API key auth flow.
+
+Usage:
+
+* User generates a key in the Omi web app under Developer → API Keys, choosing
+  the scopes the CLI should be allowed to exercise.
+* User runs ``omi auth login`` and pastes the key. We validate the prefix
+  client-side, then issue one round-trip to the API to confirm the key actually
+  works (and to surface scope info in ``omi auth status``).
+
+The actual *server-side* validation happens on the first authenticated call —
+we don't need a special "check token" endpoint because the dev keys are stateless
+bearer tokens.
+"""
+
+from __future__ import annotations
+
+from omi_cli.auth.store import store_api_key
+from omi_cli.config import Profile
+from omi_cli.errors import UsageError
+
+# Dev API keys are issued with this prefix by the backend (see
+# ``backend/database/dev_api_key.py``). Validating the prefix client-side gives
+# users a fast, helpful error when they paste the wrong kind of token (e.g. a
+# Firebase ID token or an MCP key, ``omi_mcp_*``).
+DEV_API_KEY_PREFIX = "omi_dev_"
+
+
+def validate_api_key_format(api_key: str) -> str:
+    """Return the trimmed key if the format looks plausible. Raise UsageError otherwise."""
+    if api_key is None:
+        raise UsageError(message="No API key provided")
+
+    cleaned = api_key.strip()
+    if not cleaned:
+        raise UsageError(message="API key cannot be empty")
+
+    if not cleaned.startswith(DEV_API_KEY_PREFIX):
+        raise UsageError(
+            message="That doesn't look like an Omi developer key",
+            detail=(
+                f"Expected a token starting with '{DEV_API_KEY_PREFIX}'. "
+                "Generate one in the Omi web app under Developer → API Keys."
+            ),
+        )
+
+    if len(cleaned) < len(DEV_API_KEY_PREFIX) + 16:
+        raise UsageError(
+            message="API key looks too short",
+            detail="Real dev keys are at least ~24 characters. Check that you pasted the whole token.",
+        )
+
+    return cleaned
+
+
+def login_with_api_key(profile_name: str, api_key: str, *, api_base: str | None = None) -> Profile:
+    """Validate and persist a dev API key. Returns the updated profile."""
+    cleaned = validate_api_key_format(api_key)
+    return store_api_key(profile_name, cleaned, api_base=api_base)

--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -1,0 +1,40 @@
+"""Firebase OAuth browser-flow stub for omi-cli.
+
+**Status: not implemented in v0.1.0.** Tracking in v0.2.0.
+
+The existing Omi auth pipeline (``backend/routers/auth.py``) is built around the
+mobile app's deep-link redirect (``omi://auth/callback``) — the
+``auth_callback.html`` template does not honor an arbitrary ``redirect_uri``,
+so a localhost loopback redirect for the CLI cannot be wired up without a
+backend change. Rather than ship a fragile bypass (e.g. PKCE direct against
+Google with hardcoded client IDs that may not be configured for desktop usage),
+we land an honest stub here. The CLI surface is wired so that adding the real
+flow in v0.2.0 is purely additive — no command-line changes required.
+
+For now, ``omi auth login --browser`` returns a clear, actionable error
+pointing the user at the API-key flow.
+"""
+
+from __future__ import annotations
+
+from omi_cli.errors import UsageError
+
+
+def login_with_browser(profile_name: str) -> None:  # noqa: ARG001 — kept for forward-compat signature
+    """Stub: surface a clear error. Real implementation tracked in v0.2.0."""
+    raise UsageError(
+        message="Browser OAuth login is coming in omi-cli v0.2.0",
+        detail=(
+            "For now, generate a developer API key at https://app.omi.me (Developer → API Keys), "
+            "then run `omi auth login` and paste the key. Agents and CI users should prefer the "
+            "API-key flow regardless — it works headlessly and supports scoped permissions."
+        ),
+    )
+
+
+def refresh_id_token(profile_name: str) -> None:  # noqa: ARG001
+    """Stub for the upcoming OAuth refresh flow."""
+    raise UsageError(
+        message="OAuth refresh is not available in v0.1.0",
+        detail="This profile is using API-key auth — there is no token to refresh.",
+    )

--- a/sdks/python-cli/omi_cli/auth/store.py
+++ b/sdks/python-cli/omi_cli/auth/store.py
@@ -1,0 +1,84 @@
+"""Persistent storage for auth credentials inside :class:`omi_cli.config.Profile`.
+
+This module is intentionally thin — the actual TOML I/O lives in
+:mod:`omi_cli.config` so the on-disk layout is centralized. We provide
+convenience helpers that the auth flows and command handlers call into.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from omi_cli import config as cfg
+
+
+def store_api_key(profile_name: str, api_key: str, *, api_base: Optional[str] = None) -> cfg.Profile:
+    """Persist an API key to the named profile and return the updated Profile."""
+    config = cfg.load()
+    profile = config.get_profile(profile_name)
+    profile.auth_method = "api_key"
+    profile.api_key = api_key
+    profile.id_token = None
+    profile.refresh_token = None
+    profile.id_token_expires_at = None
+    if api_base:
+        profile.api_base = api_base
+    config.set_profile(profile)
+    config.active_profile = profile_name
+    cfg.save(config)
+    return profile
+
+
+def store_oauth_tokens(
+    profile_name: str,
+    *,
+    id_token: str,
+    refresh_token: str,
+    expires_at: float,
+    api_base: Optional[str] = None,
+) -> cfg.Profile:
+    """Persist OAuth tokens to the named profile and return the updated Profile."""
+    config = cfg.load()
+    profile = config.get_profile(profile_name)
+    profile.auth_method = "oauth"
+    profile.api_key = None
+    profile.id_token = id_token
+    profile.refresh_token = refresh_token
+    profile.id_token_expires_at = expires_at
+    if api_base:
+        profile.api_base = api_base
+    config.set_profile(profile)
+    config.active_profile = profile_name
+    cfg.save(config)
+    return profile
+
+
+def update_oauth_id_token(profile_name: str, *, id_token: str, expires_at: float) -> cfg.Profile:
+    """Update only the short-lived ID token after a refresh round-trip."""
+    config = cfg.load()
+    profile = config.get_profile(profile_name)
+    if profile.auth_method != "oauth":
+        # Refresh on a non-oauth profile is a programming error; raise loudly.
+        raise RuntimeError(f"Profile '{profile_name}' is not configured for OAuth")
+    profile.id_token = id_token
+    profile.id_token_expires_at = expires_at
+    config.set_profile(profile)
+    cfg.save(config)
+    return profile
+
+
+def clear_credentials(profile_name: str) -> bool:
+    """Wipe credentials from the named profile. Returns True if anything was cleared."""
+    config = cfg.load()
+    if profile_name not in config.profiles:
+        return False
+    profile = config.profiles[profile_name]
+    had_creds = profile.is_authenticated()
+    profile.auth_method = None
+    profile.api_key = None
+    profile.id_token = None
+    profile.refresh_token = None
+    profile.id_token_expires_at = None
+    config.set_profile(profile)
+    cfg.save(config)
+    return had_creds

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -23,6 +23,7 @@ from typing import Any, Iterator, Mapping, Optional
 
 import httpx
 from tenacity import (
+    RetryCallState,
     Retrying,
     retry_if_exception_type,
     stop_after_attempt,
@@ -36,6 +37,10 @@ from omi_cli.errors import CliError, RateLimitError, ServerError, from_status
 USER_AGENT = f"omi-cli/{__version__} (+https://github.com/BasedHardware/omi)"
 DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 MAX_RETRY_ATTEMPTS = 4
+# Cap on how long we'll honor a server-supplied Retry-After hint. Without this,
+# a misconfigured upstream could pin the CLI for hours; agents will get a
+# RateLimitError they can act on much sooner.
+MAX_RETRY_AFTER_SECONDS = 60.0
 
 # Backend rate-limit policies surfaced to users on 429 (see
 # ``backend/utils/rate_limit_config.py``).
@@ -114,7 +119,9 @@ class OmiClient:
         retrying = Retrying(
             reraise=True,
             stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
-            wait=wait_exponential_jitter(initial=0.5, max=8.0),
+            # Honor server-supplied Retry-After when present, otherwise fall
+            # back to exponential jitter. See ``_retry_wait`` for the logic.
+            wait=_retry_wait,
             retry=retry_if_exception_type((httpx.TransportError, _RetryableHttp)),
         )
 
@@ -124,11 +131,14 @@ class OmiClient:
                     response = self._http.request(method, path, params=cleaned_params, json=json_body)
                     self._maybe_log(method, path, response)
                     if response.status_code >= 500:
-                        raise _RetryableHttp(response)
+                        raise _RetryableHttp(response, retry_after=None)
                     if response.status_code == 429:
                         # Surface the structured RateLimitError so callers can show
                         # a useful message; tenacity treats this as retryable.
-                        raise _RetryableHttp(response)
+                        raise _RetryableHttp(
+                            response,
+                            retry_after=_parse_retry_after(response.headers.get("Retry-After")),
+                        )
                     return self._handle_response(response)
         except _RetryableHttp as exc:
             # We exhausted retries — convert to the proper CliError now.
@@ -202,11 +212,37 @@ class OmiClient:
 
 
 class _RetryableHttp(Exception):
-    """Internal sentinel: a retryable HTTP response (5xx or 429)."""
+    """Internal sentinel: a retryable HTTP response (5xx or 429).
 
-    def __init__(self, response: httpx.Response) -> None:
+    ``retry_after`` is populated for 429s when the server sent a ``Retry-After``
+    header — the wait function reads it to honor the server's hint.
+    """
+
+    def __init__(self, response: httpx.Response, *, retry_after: Optional[float] = None) -> None:
         super().__init__(f"retryable HTTP {response.status_code}")
         self.response = response
+        self.retry_after = retry_after
+
+
+# Module-level wait function so tenacity's introspection (and tests) can find it.
+_jittered_backoff = wait_exponential_jitter(initial=0.5, max=8.0)
+
+
+def _retry_wait(retry_state: RetryCallState) -> float:
+    """Wait strategy: server-supplied Retry-After when available, jitter otherwise.
+
+    A 429 that includes ``Retry-After`` ends up here as a ``_RetryableHttp``
+    with ``retry_after`` populated. We honor it but cap to
+    :data:`MAX_RETRY_AFTER_SECONDS` so a pathological upstream can't pin the
+    CLI for an unbounded time. For 5xx (no ``Retry-After`` from this backend)
+    and transport errors we fall back to exponential jitter — same behavior
+    the client had before this fix.
+    """
+    outcome = retry_state.outcome
+    exc = outcome.exception() if outcome is not None and outcome.failed else None
+    if isinstance(exc, _RetryableHttp) and exc.retry_after is not None and exc.retry_after > 0:
+        return min(exc.retry_after, MAX_RETRY_AFTER_SECONDS)
+    return float(_jittered_backoff(retry_state))
 
 
 def _safe_parse_json(response: httpx.Response) -> Any:

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -1,0 +1,294 @@
+"""HTTP client for the Omi developer API.
+
+This is the single surface every command goes through. It owns:
+
+* Bearer-token injection from the active :class:`omi_cli.config.Profile`.
+* Retry/backoff for ``429`` and ``5xx`` responses, honoring ``Retry-After`` when
+  the server provides one.
+* Translating non-2xx responses into the :mod:`omi_cli.errors` hierarchy so the
+  call sites just see a clean exception.
+* Sniffing the rate-limit policy from the response body so the user gets a
+  useful message instead of a bare ``429``.
+
+The client is sync (httpx ``Client``, not ``AsyncClient``) — Typer commands run
+synchronously and the I/O is one request at a time. The complexity of an event
+loop here would buy nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Iterator, Mapping, Optional
+
+import httpx
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+from omi_cli import __version__
+from omi_cli.config import Profile
+from omi_cli.errors import CliError, RateLimitError, ServerError, from_status
+
+USER_AGENT = f"omi-cli/{__version__} (+https://github.com/BasedHardware/omi)"
+DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+MAX_RETRY_ATTEMPTS = 4
+
+# Backend rate-limit policies surfaced to users on 429 (see
+# ``backend/utils/rate_limit_config.py``).
+KNOWN_RATE_LIMIT_POLICIES = {
+    "dev:conversations": "25/hr",
+    "dev:memories": "120/hr",
+    "dev:memories_batch": "15/hr",
+}
+
+
+class OmiClient:
+    """Thin wrapper around :class:`httpx.Client`. One per CLI invocation."""
+
+    def __init__(self, profile: Profile, *, timeout: Optional[httpx.Timeout] = None, verbose: bool = False) -> None:
+        self._profile = profile
+        self._verbose = verbose
+        self._http = httpx.Client(
+            base_url=profile.api_base.rstrip("/"),
+            headers=self._build_headers(profile),
+            timeout=timeout or DEFAULT_TIMEOUT,
+            follow_redirects=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> "OmiClient":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Verb shims
+    # ------------------------------------------------------------------
+
+    def get(self, path: str, *, params: Optional[Mapping[str, Any]] = None) -> Any:
+        return self._request("GET", path, params=params)
+
+    def post(self, path: str, *, json_body: Optional[Mapping[str, Any]] = None) -> Any:
+        return self._request("POST", path, json_body=json_body)
+
+    def patch(
+        self,
+        path: str,
+        *,
+        json_body: Optional[Mapping[str, Any]] = None,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Any:
+        return self._request("PATCH", path, json_body=json_body, params=params)
+
+    def delete(self, path: str) -> Any:
+        return self._request("DELETE", path)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Mapping[str, Any]] = None,
+        json_body: Optional[Mapping[str, Any]] = None,
+    ) -> Any:
+        """Execute an HTTP request with retry, returning the parsed JSON body (or None for 204)."""
+        # Filter ``None`` out of params so callers can pass optional fields
+        # without sentinel checks.
+        cleaned_params = {k: v for k, v in (params or {}).items() if v is not None} or None
+
+        retrying = Retrying(
+            reraise=True,
+            stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+            wait=wait_exponential_jitter(initial=0.5, max=8.0),
+            retry=retry_if_exception_type((httpx.TransportError, _RetryableHttp)),
+        )
+
+        try:
+            for attempt in retrying:
+                with attempt:
+                    response = self._http.request(method, path, params=cleaned_params, json=json_body)
+                    self._maybe_log(method, path, response)
+                    if response.status_code >= 500:
+                        raise _RetryableHttp(response)
+                    if response.status_code == 429:
+                        # Surface the structured RateLimitError so callers can show
+                        # a useful message; tenacity treats this as retryable.
+                        raise _RetryableHttp(response)
+                    return self._handle_response(response)
+        except _RetryableHttp as exc:
+            # We exhausted retries — convert to the proper CliError now.
+            raise self._error_from_response(exc.response)
+        # Unreachable — Retrying always either returns or raises — but the type
+        # checker doesn't know that.
+        raise RuntimeError("unreachable")
+
+    def _handle_response(self, response: httpx.Response) -> Any:
+        if response.status_code == 204 or not response.content:
+            return None
+        if 200 <= response.status_code < 300:
+            return _safe_parse_json(response)
+        raise self._error_from_response(response)
+
+    def _error_from_response(self, response: httpx.Response) -> CliError:
+        detail = _extract_detail(response)
+        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+        policy = _detect_rate_limit_policy(detail)
+        # Server errors and rate limit errors get the richer formatters below.
+        if response.status_code == 429:
+            policy_label = KNOWN_RATE_LIMIT_POLICIES.get(policy, policy) if policy else None
+            label = f"{policy} ({policy_label})" if policy_label else policy
+            return RateLimitError(
+                message="Rate limited" if not label else f"Rate limited: {label}",
+                detail=_format_rate_limit_detail(retry_after, detail),
+                retry_after_seconds=retry_after,
+                policy=policy,
+            )
+        if 500 <= response.status_code < 600:
+            return ServerError(
+                message=f"Server error ({response.status_code})",
+                detail=detail or "The Omi API returned an error. Try again, then check status.omi.me.",
+            )
+        return from_status(response.status_code, detail=detail, retry_after=retry_after, policy=policy)
+
+    def _maybe_log(self, method: str, path: str, response: httpx.Response) -> None:
+        if not self._verbose:
+            return
+        # Use stderr via direct sys.stderr.write to avoid pulling Renderer in here.
+        import sys
+
+        sys.stderr.write(
+            f"[debug] {method} {path} → {response.status_code} ({response.elapsed.total_seconds():.2f}s)\n"
+        )
+
+    @staticmethod
+    def _build_headers(profile: Profile) -> dict[str, str]:
+        if not profile.is_authenticated():
+            raise CliError(
+                message="Not authenticated",
+                detail="Run `omi auth login` and paste your dev API key. (See `omi auth login --help`.)",
+                exit_code=2,
+            )
+        if profile.auth_method == "api_key":
+            assert profile.api_key  # narrowed by is_authenticated
+            token = profile.api_key
+        else:
+            assert profile.id_token
+            token = profile.id_token
+        return {
+            "Authorization": f"Bearer {token}",
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RetryableHttp(Exception):
+    """Internal sentinel: a retryable HTTP response (5xx or 429)."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        super().__init__(f"retryable HTTP {response.status_code}")
+        self.response = response
+
+
+def _safe_parse_json(response: httpx.Response) -> Any:
+    """Parse JSON, falling back to raw text if the body isn't valid JSON.
+
+    This handles edge cases where the backend returns a plain-text error body
+    despite a 2xx status (rare, but real for some endpoints).
+    """
+    try:
+        return response.json()
+    except (json.JSONDecodeError, ValueError):
+        return response.text
+
+
+def _extract_detail(response: httpx.Response) -> Optional[str]:
+    """Pull a human-readable error string out of a response body.
+
+    FastAPI conventionally returns ``{"detail": "..."}`` — handle that, while
+    tolerating arbitrary body shapes.
+    """
+    try:
+        body = response.json()
+    except (json.JSONDecodeError, ValueError):
+        text = response.text.strip()
+        return text[:500] if text else None
+    if isinstance(body, dict):
+        detail = body.get("detail")
+        if isinstance(detail, str):
+            return detail
+        if isinstance(detail, list):
+            # FastAPI validation errors come back as a list of dicts.
+            return "; ".join(_format_validation_error(e) for e in detail)
+        if detail is not None:
+            return json.dumps(detail)
+        msg = body.get("message")
+        if isinstance(msg, str):
+            return msg
+    return None
+
+
+def _format_validation_error(entry: Any) -> str:
+    if not isinstance(entry, dict):
+        return str(entry)
+    loc = entry.get("loc")
+    msg = entry.get("msg") or entry.get("message")
+    if loc and msg:
+        return f"{'.'.join(str(p) for p in loc)}: {msg}"
+    return str(msg or entry)
+
+
+def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Parse the Retry-After header. Supports the seconds form only — that's what FastAPI emits."""
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value.strip()))
+    except ValueError:
+        return None
+
+
+_POLICY_RE = re.compile(r"(dev:[a-zA-Z_]+)")
+
+
+def _detect_rate_limit_policy(detail: Optional[str]) -> Optional[str]:
+    if not detail:
+        return None
+    match = _POLICY_RE.search(detail)
+    return match.group(1) if match else None
+
+
+def _format_rate_limit_detail(retry_after: Optional[float], detail: Optional[str]) -> str:
+    parts = []
+    if retry_after is not None and retry_after > 0:
+        parts.append(f"Retry in {retry_after:.0f}s.")
+    if detail:
+        parts.append(detail)
+    return " ".join(parts) if parts else "Slow down and retry shortly."
+
+
+def chunked(seq: list[Any], size: int) -> Iterator[list[Any]]:
+    """Yield successive chunks of ``size`` items from ``seq``. Used by batch commands."""
+    if size <= 0:
+        raise ValueError("size must be positive")
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]

--- a/sdks/python-cli/omi_cli/commands/__init__.py
+++ b/sdks/python-cli/omi_cli/commands/__init__.py
@@ -1,0 +1,5 @@
+"""Sub-command modules for omi-cli.
+
+Each module exposes a Typer app named ``app``; the root in :mod:`omi_cli.main`
+registers them under their respective verb prefix.
+"""

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -1,0 +1,160 @@
+"""``omi action-item`` — tasks and follow-ups."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+import typer
+
+from omi_cli.errors import UsageError
+from omi_cli.output import shorten
+
+if TYPE_CHECKING:
+    from omi_cli.main import AppContext
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _ctx(typer_ctx: typer.Context) -> "AppContext":
+    obj = typer_ctx.obj
+    if obj is None:  # pragma: no cover
+        raise RuntimeError("AppContext not initialized")
+    return obj  # type: ignore[no-any-return]
+
+
+_LIST_COLUMNS = ["id", "completed", "description", "due_at", "created_at"]
+
+
+@app.command("list", help="List action items.")
+def list_action_items(
+    typer_ctx: typer.Context,
+    completed: Optional[bool] = typer.Option(None, "--completed/--open", help="Filter by completion."),
+    conversation_id: Optional[str] = typer.Option(None, "--conversation-id"),
+    start_date: Optional[datetime] = typer.Option(None, "--start-date"),
+    end_date: Optional[datetime] = typer.Option(None, "--end-date"),
+    limit: int = typer.Option(100, "--limit", min=1, max=500),
+    offset: int = typer.Option(0, "--offset", min=0),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    params: dict[str, object] = {"limit": limit, "offset": offset}
+    if completed is not None:
+        params["completed"] = completed
+    if conversation_id is not None:
+        params["conversation_id"] = conversation_id
+    if start_date is not None:
+        params["start_date"] = start_date.isoformat()
+    if end_date is not None:
+        params["end_date"] = end_date.isoformat()
+
+    with ctx.make_client() as client:
+        items = client.get("/v1/dev/user/action-items", params=params)
+
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(items)
+        return
+    rows = []
+    for it in items or []:
+        rows.append(
+            {
+                "id": shorten(it.get("id"), 14),
+                "completed": it.get("completed"),
+                "description": shorten(it.get("description"), 60),
+                "due_at": it.get("due_at"),
+                "created_at": it.get("created_at"),
+            }
+        )
+    ctx.renderer.emit(rows, columns=_LIST_COLUMNS, title=f"action items (limit={limit})")
+
+
+@app.command("get", help="Fetch a single action item by ID. (Not directly exposed by the dev API; uses list scan.)")
+def get_action_item(
+    typer_ctx: typer.Context,
+    action_item_id: str = typer.Argument(..., help="Action item ID."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        # Like memories, the dev API has no single-resource GET for action items.
+        # Page through up to 5 pages of 200 to find it; beyond that the user
+        # probably wants `omi action-item list` directly.
+        for offset in range(0, 1000, 200):
+            page = client.get("/v1/dev/user/action-items", params={"limit": 200, "offset": offset})
+            if not page:
+                break
+            for item in page:
+                if item.get("id") == action_item_id:
+                    ctx.renderer.emit(item, title="action item")
+                    return
+            if len(page) < 200:
+                break
+    raise UsageError(message=f"Action item not found: {action_item_id}")
+
+
+@app.command("create", help="Create a new action item.")
+def create_action_item(
+    typer_ctx: typer.Context,
+    description: str = typer.Argument(..., help="Action item description (1-500 chars)."),
+    completed: bool = typer.Option(False, "--completed/--open"),
+    due_at: Optional[datetime] = typer.Option(None, "--due-at", help="ISO datetime."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    body: dict[str, object] = {"description": description, "completed": completed}
+    if due_at is not None:
+        body["due_at"] = due_at.isoformat()
+    with ctx.make_client() as client:
+        result = client.post("/v1/dev/user/action-items", json_body=body)
+    ctx.renderer.success(f"Action item created: [bold]{result.get('id')}[/bold]")
+    ctx.renderer.emit(result)
+
+
+@app.command("update", help="Update an existing action item.")
+def update_action_item(
+    typer_ctx: typer.Context,
+    action_item_id: str = typer.Argument(..., help="Action item ID."),
+    description: Optional[str] = typer.Option(None, "--description"),
+    completed: Optional[bool] = typer.Option(None, "--completed/--open"),
+    due_at: Optional[datetime] = typer.Option(None, "--due-at"),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    body: dict[str, object] = {}
+    if description is not None:
+        body["description"] = description
+    if completed is not None:
+        body["completed"] = completed
+    if due_at is not None:
+        body["due_at"] = due_at.isoformat()
+    if not body:
+        raise UsageError(
+            message="No fields to update", detail="Provide --description, --completed/--open, or --due-at."
+        )
+    with ctx.make_client() as client:
+        result = client.patch(f"/v1/dev/user/action-items/{action_item_id}", json_body=body)
+    ctx.renderer.success(f"Updated action item [bold]{action_item_id}[/bold].")
+    ctx.renderer.emit(result)
+
+
+@app.command("complete", help="Mark an action item as completed (shortcut for `update --completed`).")
+def complete_action_item(
+    typer_ctx: typer.Context,
+    action_item_id: str = typer.Argument(..., help="Action item ID."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        result = client.patch(f"/v1/dev/user/action-items/{action_item_id}", json_body={"completed": True})
+    ctx.renderer.success(f"Completed action item [bold]{action_item_id}[/bold].")
+    ctx.renderer.emit(result)
+
+
+@app.command("delete", help="Delete an action item by ID.")
+def delete_action_item(
+    typer_ctx: typer.Context,
+    action_item_id: str = typer.Argument(..., help="Action item ID."),
+    confirm: bool = typer.Option(False, "--yes", "-y"),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if not confirm:
+        typer.confirm(f"Delete action item {action_item_id}?", abort=True)
+    with ctx.make_client() as client:
+        client.delete(f"/v1/dev/user/action-items/{action_item_id}")
+    ctx.renderer.success(f"Deleted action item [bold]{action_item_id}[/bold].")

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 import typer
 
-from omi_cli.errors import UsageError
+from omi_cli.errors import NotFoundError, UsageError
 from omi_cli.output import shorten
 
 if TYPE_CHECKING:
@@ -88,7 +88,9 @@ def get_action_item(
                     return
             if len(page) < 200:
                 break
-    raise UsageError(message=f"Action item not found: {action_item_id}")
+    # Exit code 5 (NotFoundError) — same contract as a server-side 404,
+    # whether or not the dev API exposed a direct GET for this noun.
+    raise NotFoundError(message=f"Action item not found: {action_item_id}")
 
 
 @app.command("create", help="Create a new action item.")

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -1,0 +1,146 @@
+"""``omi auth`` — login, logout, status."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Optional
+
+import typer
+
+from omi_cli import config as cfg
+from omi_cli.auth import api_key as api_key_auth
+from omi_cli.auth import oauth as oauth_auth
+from omi_cli.auth.store import clear_credentials
+from omi_cli.client import OmiClient
+from omi_cli.errors import AuthError, CliError, UsageError
+
+if TYPE_CHECKING:
+    from omi_cli.main import AppContext
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _ctx(typer_ctx: typer.Context) -> "AppContext":
+    """Type-narrowing accessor for the Typer context object."""
+    obj = typer_ctx.obj
+    if obj is None:  # pragma: no cover — defensive; root callback always sets it
+        raise RuntimeError("AppContext not initialized")
+    return obj  # type: ignore[no-any-return]
+
+
+@app.command("login", help="Authenticate this profile with an Omi developer API key.")
+def login(
+    typer_ctx: typer.Context,
+    api_key_arg: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help="API key. If omitted, you will be prompted interactively (preferred — keeps the key out of shell history).",
+    ),
+    browser: bool = typer.Option(
+        False,
+        "--browser",
+        help="Use the Firebase OAuth browser flow (coming in v0.2.0).",
+    ),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    renderer = ctx.renderer
+
+    if browser:
+        # Surface the v0.2.0 stub message — clean, expected error path.
+        oauth_auth.login_with_browser(ctx.profile_name)
+        return  # unreachable; the stub raises
+
+    if api_key_arg is None:
+        # Read from stdin if not a TTY (handy for piping `omi auth login < key.txt`).
+        if not sys.stdin.isatty():
+            api_key_arg = sys.stdin.read().strip()
+        else:
+            api_key_arg = typer.prompt("Paste your Omi developer API key", hide_input=True).strip()
+
+    profile = api_key_auth.login_with_api_key(ctx.profile_name, api_key_arg, api_base=ctx.api_base_override)
+
+    # Optional sanity check: reach out and confirm the key works. We do this on
+    # a tolerant endpoint (memories list with limit=1) so a missing scope on the
+    # primary domain doesn't make login appear to fail.
+    try:
+        with OmiClient(profile, verbose=ctx.verbose) as client:
+            client.get("/v1/dev/user/memories", params={"limit": 1})
+    except AuthError as exc:
+        # Roll back the bad credential so the user isn't stuck with a broken profile.
+        clear_credentials(ctx.profile_name)
+        raise exc
+    except CliError as exc:
+        # Network / rate-limit / non-auth issues: don't roll back, but warn.
+        renderer.warn(f"Could not verify the key right now ({exc.message}). It is stored — try again shortly.")
+
+    renderer.success(f"Logged in as profile [bold]{profile.name}[/bold] ({profile.masked_credential()}).")
+    if ctx.renderer.json_mode:
+        renderer.emit({"profile": profile.name, "auth_method": profile.auth_method, "api_base": profile.api_base})
+
+
+@app.command("logout", help="Clear credentials for the active profile.")
+def logout(typer_ctx: typer.Context) -> None:
+    ctx = _ctx(typer_ctx)
+    cleared = clear_credentials(ctx.profile_name)
+    if cleared:
+        ctx.renderer.success(f"Cleared credentials for profile [bold]{ctx.profile_name}[/bold].")
+    else:
+        ctx.renderer.warn(f"Profile [bold]{ctx.profile_name}[/bold] was not authenticated.")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit({"profile": ctx.profile_name, "logged_out": cleared})
+
+
+@app.command("status", help="Show the auth state of the active profile.")
+def status(typer_ctx: typer.Context) -> None:
+    ctx = _ctx(typer_ctx)
+    profile = ctx.get_profile()
+    payload = {
+        "profile": profile.name,
+        "authenticated": profile.is_authenticated(),
+        "auth_method": profile.auth_method,
+        "api_base": profile.api_base,
+        "credential": profile.masked_credential(),
+    }
+    ctx.renderer.emit(payload, title="omi auth status")
+
+
+@app.command("whoami", help="Resolve the current credential against the API and display identity info.")
+def whoami(typer_ctx: typer.Context) -> None:
+    ctx = _ctx(typer_ctx)
+    # The public dev surface doesn't expose a /me endpoint, but a memories list
+    # round-trip with the credential confirms the key is alive and identifies
+    # the user implicitly (the count belongs to *this* user). This keeps the
+    # command useful without inventing new backend routes.
+    with ctx.make_client() as client:
+        memories = client.get("/v1/dev/user/memories", params={"limit": 1})
+    payload = {
+        "profile": ctx.profile_name,
+        "credential": ctx.get_profile().masked_credential(),
+        "api_base": ctx.get_profile().api_base,
+        "owns_memories": isinstance(memories, list),
+    }
+    ctx.renderer.emit(payload, title="omi whoami")
+
+
+@app.command("refresh", help="Refresh the OAuth ID token (no-op for API-key profiles).")
+def refresh(typer_ctx: typer.Context) -> None:
+    ctx = _ctx(typer_ctx)
+    profile = ctx.get_profile()
+    if profile.auth_method != "oauth":
+        raise UsageError(
+            message="Nothing to refresh",
+            detail=(
+                f"Profile '{profile.name}' uses API-key auth — there is no token to refresh. "
+                "API keys are long-lived; rotate them in the Omi web app if needed."
+            ),
+        )
+    oauth_auth.refresh_id_token(profile.name)
+
+
+def _ensure_authenticated(profile: cfg.Profile) -> None:  # pragma: no cover — utility for sibling commands
+    if not profile.is_authenticated():
+        raise UsageError(
+            message="Not authenticated",
+            detail=f"Profile '{profile.name}' has no credentials. Run `omi auth login`.",
+        )

--- a/sdks/python-cli/omi_cli/commands/config.py
+++ b/sdks/python-cli/omi_cli/commands/config.py
@@ -1,0 +1,134 @@
+"""``omi config`` — view and edit configuration / profiles."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typer
+
+from omi_cli import config as cfg
+from omi_cli.errors import UsageError
+
+if TYPE_CHECKING:
+    from omi_cli.main import AppContext
+
+
+app = typer.Typer(no_args_is_help=True)
+profile_app = typer.Typer(no_args_is_help=True, help="Manage named profiles.")
+app.add_typer(profile_app, name="profile")
+
+
+def _ctx(typer_ctx: typer.Context) -> "AppContext":
+    obj = typer_ctx.obj
+    if obj is None:  # pragma: no cover
+        raise RuntimeError("AppContext not initialized")
+    return obj  # type: ignore[no-any-return]
+
+
+@app.command("show", help="Print the resolved configuration (credentials masked).")
+def show(typer_ctx: typer.Context) -> None:
+    ctx = _ctx(typer_ctx)
+    config = ctx.load_config()
+    profiles = []
+    for name, profile in sorted(config.profiles.items()):
+        profiles.append(
+            {
+                "name": name,
+                "active": name == config.active_profile,
+                "auth_method": profile.auth_method,
+                "api_base": profile.api_base,
+                "credential": profile.masked_credential(),
+            }
+        )
+    payload = {
+        "config_path": str(config.path),
+        "active_profile": config.active_profile,
+        "profiles": profiles,
+    }
+    ctx.renderer.emit(payload, title="omi config show")
+
+
+@app.command("path", help="Print the on-disk config path.")
+def path(typer_ctx: typer.Context) -> None:
+    ctx = _ctx(typer_ctx)
+    config = ctx.load_config()
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit({"path": str(config.path)})
+    else:
+        typer.echo(str(config.path))
+
+
+_SETTABLE_KEYS = {"api_base"}
+
+
+@app.command("set", help="Set a per-profile config value. Keys: api_base.")
+def set_value(
+    typer_ctx: typer.Context,
+    key: str = typer.Argument(..., help=f"Config key to set. One of: {sorted(_SETTABLE_KEYS)}"),
+    value: str = typer.Argument(..., help="New value."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if key not in _SETTABLE_KEYS:
+        raise UsageError(
+            message=f"Unknown config key '{key}'",
+            detail=f"Settable keys: {sorted(_SETTABLE_KEYS)}",
+        )
+    config = ctx.load_config()
+    profile = config.get_profile(ctx.profile_name)
+    if key == "api_base":
+        profile.api_base = value.rstrip("/")
+    config.set_profile(profile)
+    cfg.save(config)
+    ctx.renderer.success(f"Set [bold]{key}[/bold] = {value} on profile [bold]{profile.name}[/bold].")
+
+
+@profile_app.command("list", help="List all configured profiles.")
+def profile_list(typer_ctx: typer.Context) -> None:
+    ctx = _ctx(typer_ctx)
+    config = ctx.load_config()
+    rows = []
+    for name in config.list_profiles() or [config.active_profile]:
+        profile = config.get_profile(name)
+        rows.append(
+            {
+                "name": name,
+                "active": name == config.active_profile,
+                "auth_method": profile.auth_method or "(none)",
+                "api_base": profile.api_base,
+                "credential": profile.masked_credential(),
+            }
+        )
+    ctx.renderer.emit(rows, columns=["name", "active", "auth_method", "api_base", "credential"], title="profiles")
+
+
+@profile_app.command("use", help="Switch the active profile.")
+def profile_use(
+    typer_ctx: typer.Context,
+    name: str = typer.Argument(..., help="Profile name to make active."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    config = ctx.load_config()
+    if name not in config.profiles:
+        # Allow switching to a brand-new (yet-unconfigured) profile so users can
+        # bootstrap a fresh context: `omi config profile use work && omi auth login`
+        config.profiles[name] = cfg.Profile(name=name)
+    config.active_profile = name
+    cfg.save(config)
+    ctx.renderer.success(f"Active profile: [bold]{name}[/bold].")
+
+
+@profile_app.command("delete", help="Delete a profile and its credentials.")
+def profile_delete(
+    typer_ctx: typer.Context,
+    name: str = typer.Argument(..., help="Profile name to delete."),
+    confirm: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    config = ctx.load_config()
+    if name not in config.profiles:
+        raise UsageError(message=f"No such profile: '{name}'")
+    if not confirm:
+        typer.confirm(f"Delete profile '{name}'?", abort=True)
+    config.delete_profile(name)
+    cfg.save(config)
+    ctx.renderer.success(f"Deleted profile [bold]{name}[/bold].")

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -1,0 +1,202 @@
+"""``omi conversation`` — captured & processed audio/text conversations."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+import typer
+
+from omi_cli.errors import UsageError
+from omi_cli.models import ConversationTextSource
+from omi_cli.output import shorten
+
+if TYPE_CHECKING:
+    from omi_cli.main import AppContext
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _ctx(typer_ctx: typer.Context) -> "AppContext":
+    obj = typer_ctx.obj
+    if obj is None:  # pragma: no cover
+        raise RuntimeError("AppContext not initialized")
+    return obj  # type: ignore[no-any-return]
+
+
+_LIST_COLUMNS = ["id", "title", "category", "started_at", "source"]
+
+
+@app.command("list", help="List conversations.")
+def list_conversations(
+    typer_ctx: typer.Context,
+    limit: int = typer.Option(25, "--limit", min=1, max=200),
+    offset: int = typer.Option(0, "--offset", min=0),
+    start_date: Optional[datetime] = typer.Option(None, "--start-date", help="ISO datetime lower bound."),
+    end_date: Optional[datetime] = typer.Option(None, "--end-date", help="ISO datetime upper bound."),
+    categories: Optional[str] = typer.Option(None, "--categories", help="Comma-separated category filter."),
+    include_transcript: bool = typer.Option(False, "--include-transcript", help="Include transcript_segments."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        items = client.get(
+            "/v1/dev/user/conversations",
+            params={
+                "limit": limit,
+                "offset": offset,
+                "start_date": start_date.isoformat() if start_date else None,
+                "end_date": end_date.isoformat() if end_date else None,
+                "categories": categories,
+                "include_transcript": include_transcript,
+            },
+        )
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(items)
+        return
+    rows = []
+    for c in items or []:
+        structured = c.get("structured") or {}
+        rows.append(
+            {
+                "id": shorten(c.get("id"), 14),
+                "title": shorten(structured.get("title"), 50),
+                "category": structured.get("category"),
+                "started_at": c.get("started_at"),
+                "source": c.get("source"),
+            }
+        )
+    ctx.renderer.emit(rows, columns=_LIST_COLUMNS, title=f"conversations (limit={limit})")
+
+
+@app.command("get", help="Fetch a single conversation by ID.")
+def get_conversation(
+    typer_ctx: typer.Context,
+    conversation_id: str = typer.Argument(..., help="Conversation ID."),
+    include_transcript: bool = typer.Option(False, "--include-transcript"),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        result = client.get(
+            f"/v1/dev/user/conversations/{conversation_id}",
+            params={"include_transcript": include_transcript},
+        )
+    ctx.renderer.emit(result, title="conversation")
+
+
+@app.command("create", help="Create a conversation from raw text.")
+def create_conversation(
+    typer_ctx: typer.Context,
+    text: Optional[str] = typer.Option(None, "--text", help="Text body. Use '-' to read from stdin."),
+    text_source: ConversationTextSource = typer.Option(
+        ConversationTextSource.other_text,
+        "--text-source",
+        help="Source type. One of audio_transcript, message, other_text.",
+    ),
+    text_source_spec: Optional[str] = typer.Option(None, "--text-source-spec", help="e.g. 'email', 'slack'."),
+    started_at: Optional[datetime] = typer.Option(None, "--started-at", help="ISO datetime."),
+    finished_at: Optional[datetime] = typer.Option(None, "--finished-at", help="ISO datetime."),
+    language: str = typer.Option("en", "--language", help="ISO 639-1 code."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+
+    if text is None or text == "-":
+        if sys.stdin.isatty():
+            raise UsageError(
+                message="No --text provided",
+                detail="Pass --text 'your text' or pipe content via stdin and use --text -.",
+            )
+        text = sys.stdin.read()
+
+    body: dict[str, object] = {
+        "text": text,
+        "text_source": text_source.value,
+        "language": language,
+    }
+    if text_source_spec is not None:
+        body["text_source_spec"] = text_source_spec
+    if started_at is not None:
+        body["started_at"] = started_at.isoformat()
+    if finished_at is not None:
+        body["finished_at"] = finished_at.isoformat()
+
+    with ctx.make_client() as client:
+        result = client.post("/v1/dev/user/conversations", json_body=body)
+    ctx.renderer.success(f"Conversation queued: [bold]{result.get('id')}[/bold] (status={result.get('status')})")
+    ctx.renderer.emit(result)
+
+
+@app.command("from-segments", help="Create a conversation from structured transcript segments (JSON file).")
+def from_segments(
+    typer_ctx: typer.Context,
+    segments_file: Path = typer.Argument(..., help="Path to a JSON file containing 'transcript_segments'."),
+    source: Optional[str] = typer.Option(None, "--source", help="Conversation source (e.g. omi, friend, phone)."),
+    started_at: Optional[datetime] = typer.Option(None, "--started-at"),
+    finished_at: Optional[datetime] = typer.Option(None, "--finished-at"),
+    language: str = typer.Option("en", "--language"),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if not segments_file.exists():
+        raise UsageError(message=f"File not found: {segments_file}")
+    try:
+        payload = json.loads(segments_file.read_text())
+    except json.JSONDecodeError as exc:
+        raise UsageError(message=f"Invalid JSON in {segments_file}", detail=str(exc))
+
+    segments = payload.get("transcript_segments") if isinstance(payload, dict) else payload
+    if not isinstance(segments, list):
+        raise UsageError(
+            message="JSON must be a list, or an object with 'transcript_segments' key",
+            detail="Each segment needs at least 'text', 'start', 'end'.",
+        )
+
+    body: dict[str, object] = {"transcript_segments": segments, "language": language}
+    if source is not None:
+        body["source"] = source
+    if started_at is not None:
+        body["started_at"] = started_at.isoformat()
+    if finished_at is not None:
+        body["finished_at"] = finished_at.isoformat()
+
+    with ctx.make_client() as client:
+        result = client.post("/v1/dev/user/conversations/from-segments", json_body=body)
+    ctx.renderer.success(f"Conversation queued: [bold]{result.get('id')}[/bold]")
+    ctx.renderer.emit(result)
+
+
+@app.command("update", help="Update conversation title or discard status.")
+def update_conversation(
+    typer_ctx: typer.Context,
+    conversation_id: str = typer.Argument(..., help="Conversation ID."),
+    title: Optional[str] = typer.Option(None, "--title"),
+    discarded: Optional[bool] = typer.Option(None, "--discarded/--no-discarded"),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    body: dict[str, object] = {}
+    if title is not None:
+        body["title"] = title
+    if discarded is not None:
+        body["discarded"] = discarded
+    if not body:
+        raise UsageError(message="No fields to update", detail="Provide --title or --discarded/--no-discarded.")
+    with ctx.make_client() as client:
+        result = client.patch(f"/v1/dev/user/conversations/{conversation_id}", json_body=body)
+    ctx.renderer.success(f"Updated conversation [bold]{conversation_id}[/bold].")
+    ctx.renderer.emit(result)
+
+
+@app.command("delete", help="Delete a conversation by ID.")
+def delete_conversation(
+    typer_ctx: typer.Context,
+    conversation_id: str = typer.Argument(..., help="Conversation ID."),
+    confirm: bool = typer.Option(False, "--yes", "-y"),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if not confirm:
+        typer.confirm(f"Delete conversation {conversation_id}?", abort=True)
+    with ctx.make_client() as client:
+        client.delete(f"/v1/dev/user/conversations/{conversation_id}")
+    ctx.renderer.success(f"Deleted conversation [bold]{conversation_id}[/bold].")

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -1,0 +1,172 @@
+"""``omi goal`` — tracked progress metrics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import typer
+
+from omi_cli.errors import UsageError
+from omi_cli.models import GoalType
+from omi_cli.output import shorten
+
+if TYPE_CHECKING:
+    from omi_cli.main import AppContext
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _ctx(typer_ctx: typer.Context) -> "AppContext":
+    obj = typer_ctx.obj
+    if obj is None:  # pragma: no cover
+        raise RuntimeError("AppContext not initialized")
+    return obj  # type: ignore[no-any-return]
+
+
+_LIST_COLUMNS = ["id", "title", "goal_type", "current_value", "target_value", "unit", "is_active"]
+
+
+@app.command("list", help="List goals.")
+def list_goals(
+    typer_ctx: typer.Context,
+    limit: int = typer.Option(10, "--limit", min=1, max=100),
+    include_inactive: bool = typer.Option(False, "--include-inactive", help="Include inactive/completed goals."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        items = client.get(
+            "/v1/dev/user/goals",
+            params={"limit": limit, "include_inactive": include_inactive},
+        )
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(items)
+        return
+    rows = []
+    for g in items or []:
+        rows.append(
+            {
+                "id": shorten(g.get("id"), 14),
+                "title": shorten(g.get("title"), 40),
+                "goal_type": g.get("goal_type"),
+                "current_value": g.get("current_value"),
+                "target_value": g.get("target_value"),
+                "unit": g.get("unit"),
+                "is_active": g.get("is_active"),
+            }
+        )
+    ctx.renderer.emit(rows, columns=_LIST_COLUMNS, title="goals")
+
+
+@app.command("get", help="Fetch a single goal by ID.")
+def get_goal(
+    typer_ctx: typer.Context,
+    goal_id: str = typer.Argument(..., help="Goal ID."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        result = client.get(f"/v1/dev/user/goals/{goal_id}")
+    ctx.renderer.emit(result, title="goal")
+
+
+@app.command("create", help="Create a new goal. Up to 3 active goals per user.")
+def create_goal(
+    typer_ctx: typer.Context,
+    title: str = typer.Argument(..., help="Goal title (1-500 chars)."),
+    target_value: float = typer.Option(..., "--target", help="Target value to achieve."),
+    goal_type: GoalType = typer.Option(GoalType.scale, "--type", help="boolean, scale, or numeric."),
+    current_value: float = typer.Option(0, "--current", help="Current progress value."),
+    min_value: float = typer.Option(0, "--min", help="Minimum scale value."),
+    max_value: float = typer.Option(10, "--max", help="Maximum scale value."),
+    unit: Optional[str] = typer.Option(None, "--unit", help="Unit label (e.g. 'users', 'points')."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    body: dict[str, object] = {
+        "title": title,
+        "goal_type": goal_type.value,
+        "target_value": target_value,
+        "current_value": current_value,
+        "min_value": min_value,
+        "max_value": max_value,
+    }
+    if unit is not None:
+        body["unit"] = unit
+    with ctx.make_client() as client:
+        result = client.post("/v1/dev/user/goals", json_body=body)
+    ctx.renderer.success(f"Goal created: [bold]{result.get('id')}[/bold]")
+    ctx.renderer.emit(result)
+
+
+@app.command("update", help="Update a goal's metadata.")
+def update_goal(
+    typer_ctx: typer.Context,
+    goal_id: str = typer.Argument(..., help="Goal ID."),
+    title: Optional[str] = typer.Option(None, "--title"),
+    target_value: Optional[float] = typer.Option(None, "--target"),
+    current_value: Optional[float] = typer.Option(None, "--current"),
+    min_value: Optional[float] = typer.Option(None, "--min"),
+    max_value: Optional[float] = typer.Option(None, "--max"),
+    unit: Optional[str] = typer.Option(None, "--unit"),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    body: dict[str, object] = {}
+    if title is not None:
+        body["title"] = title
+    if target_value is not None:
+        body["target_value"] = target_value
+    if current_value is not None:
+        body["current_value"] = current_value
+    if min_value is not None:
+        body["min_value"] = min_value
+    if max_value is not None:
+        body["max_value"] = max_value
+    if unit is not None:
+        body["unit"] = unit
+    if not body:
+        raise UsageError(
+            message="No fields to update", detail="Provide one of --title/--target/--current/--min/--max/--unit."
+        )
+    with ctx.make_client() as client:
+        result = client.patch(f"/v1/dev/user/goals/{goal_id}", json_body=body)
+    ctx.renderer.success(f"Updated goal [bold]{goal_id}[/bold].")
+    ctx.renderer.emit(result)
+
+
+@app.command("progress", help="Update only the current_value of a goal (shortcut).")
+def update_progress(
+    typer_ctx: typer.Context,
+    goal_id: str = typer.Argument(..., help="Goal ID."),
+    current_value: float = typer.Argument(..., help="New progress value."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        # The progress endpoint takes current_value as a query param.
+        result = client.patch(f"/v1/dev/user/goals/{goal_id}/progress", params={"current_value": current_value})
+    ctx.renderer.success(f"Updated progress on [bold]{goal_id}[/bold] → {current_value}.")
+    ctx.renderer.emit(result)
+
+
+@app.command("history", help="Fetch progress history for a goal.")
+def goal_history(
+    typer_ctx: typer.Context,
+    goal_id: str = typer.Argument(..., help="Goal ID."),
+    days: int = typer.Option(30, "--days", min=1, max=365),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        result = client.get(f"/v1/dev/user/goals/{goal_id}/history", params={"days": days})
+    ctx.renderer.emit(result, title=f"goal history (last {days}d)")
+
+
+@app.command("delete", help="Delete a goal by ID.")
+def delete_goal(
+    typer_ctx: typer.Context,
+    goal_id: str = typer.Argument(..., help="Goal ID."),
+    confirm: bool = typer.Option(False, "--yes", "-y"),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if not confirm:
+        typer.confirm(f"Delete goal {goal_id}?", abort=True)
+    with ctx.make_client() as client:
+        client.delete(f"/v1/dev/user/goals/{goal_id}")
+    ctx.renderer.success(f"Deleted goal [bold]{goal_id}[/bold].")

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional
 
 import typer
 
-from omi_cli.errors import UsageError
+from omi_cli.errors import NotFoundError, UsageError
 from omi_cli.models import MemoryCategory, MemoryVisibility
 from omi_cli.output import shorten
 
@@ -77,13 +77,16 @@ def get_memory(
         while True:
             page = client.get("/v1/dev/user/memories", params={"limit": page_size, "offset": offset})
             if not page:
-                raise UsageError(message=f"Memory not found: {memory_id}", detail=None)
+                # Exit code 5 — preserves the documented "not found" agent contract
+                # whether the resource is missing server-side (HTTP 404) or absent
+                # from the client-side scan we do here.
+                raise NotFoundError(message=f"Memory not found: {memory_id}")
             for item in page:
                 if item.get("id") == memory_id:
                     ctx.renderer.emit(item, title="memory")
                     return
             if len(page) < page_size:
-                raise UsageError(message=f"Memory not found: {memory_id}")
+                raise NotFoundError(message=f"Memory not found: {memory_id}")
             offset += page_size
 
 

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -1,0 +1,148 @@
+"""``omi memory`` — facts and learnings about the user."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import typer
+
+from omi_cli.errors import UsageError
+from omi_cli.models import MemoryCategory, MemoryVisibility
+from omi_cli.output import shorten
+
+if TYPE_CHECKING:
+    from omi_cli.main import AppContext
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _ctx(typer_ctx: typer.Context) -> "AppContext":
+    obj = typer_ctx.obj
+    if obj is None:  # pragma: no cover
+        raise RuntimeError("AppContext not initialized")
+    return obj  # type: ignore[no-any-return]
+
+
+_LIST_COLUMNS = ["id", "category", "visibility", "content", "tags", "created_at"]
+
+
+@app.command("list", help="List memories.")
+def list_memories(
+    typer_ctx: typer.Context,
+    limit: int = typer.Option(25, "--limit", min=1, max=200, help="Max items to return."),
+    offset: int = typer.Option(0, "--offset", min=0, help="Pagination offset."),
+    categories: Optional[str] = typer.Option(
+        None,
+        "--categories",
+        help="Comma-separated category filter (e.g. 'work,skills').",
+    ),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        items = client.get(
+            "/v1/dev/user/memories",
+            params={"limit": limit, "offset": offset, "categories": categories},
+        )
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(items)
+        return
+    rows = []
+    for m in items or []:
+        rows.append(
+            {
+                "id": shorten(m.get("id"), 14),
+                "category": m.get("category"),
+                "visibility": m.get("visibility"),
+                "content": shorten(m.get("content"), 60),
+                "tags": ", ".join(m.get("tags") or []),
+                "created_at": m.get("created_at"),
+            }
+        )
+    ctx.renderer.emit(rows, columns=_LIST_COLUMNS, title=f"memories (limit={limit})")
+
+
+@app.command("get", help="Fetch a single memory by ID.")
+def get_memory(
+    typer_ctx: typer.Context,
+    memory_id: str = typer.Argument(..., help="Memory ID."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        # The dev API exposes list+search but no single-resource read for memories;
+        # implement get-by-id by listing with a filter and matching client-side.
+        # We page in chunks until we find it or exhaust the user's memories.
+        page_size = 100
+        offset = 0
+        while True:
+            page = client.get("/v1/dev/user/memories", params={"limit": page_size, "offset": offset})
+            if not page:
+                raise UsageError(message=f"Memory not found: {memory_id}", detail=None)
+            for item in page:
+                if item.get("id") == memory_id:
+                    ctx.renderer.emit(item, title="memory")
+                    return
+            if len(page) < page_size:
+                raise UsageError(message=f"Memory not found: {memory_id}")
+            offset += page_size
+
+
+@app.command("create", help="Create a new memory.")
+def create_memory(
+    typer_ctx: typer.Context,
+    content: str = typer.Argument(..., help="Memory content (1-500 chars)."),
+    category: Optional[MemoryCategory] = typer.Option(None, "--category", help="Category. Auto-detected if omitted."),
+    visibility: MemoryVisibility = typer.Option(MemoryVisibility.private, "--visibility", help="public or private."),
+    tag: list[str] = typer.Option([], "--tag", help="Tag (repeat for multiple)."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    body: dict[str, object] = {"content": content, "visibility": visibility.value, "tags": tag}
+    if category is not None:
+        body["category"] = category.value
+    with ctx.make_client() as client:
+        result = client.post("/v1/dev/user/memories", json_body=body)
+    ctx.renderer.success(f"Memory created: [bold]{result.get('id')}[/bold]")
+    ctx.renderer.emit(result, title="memory")
+
+
+@app.command("update", help="Update an existing memory.")
+def update_memory(
+    typer_ctx: typer.Context,
+    memory_id: str = typer.Argument(..., help="Memory ID."),
+    content: Optional[str] = typer.Option(None, "--content", help="New content."),
+    category: Optional[MemoryCategory] = typer.Option(None, "--category", help="New category."),
+    visibility: Optional[MemoryVisibility] = typer.Option(None, "--visibility", help="public or private."),
+    tag: Optional[list[str]] = typer.Option(None, "--tag", help="Replace tags (repeat for multiple)."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    body: dict[str, object] = {}
+    if content is not None:
+        body["content"] = content
+    if category is not None:
+        body["category"] = category.value
+    if visibility is not None:
+        body["visibility"] = visibility.value
+    if tag is not None:
+        body["tags"] = list(tag)
+    if not body:
+        raise UsageError(
+            message="No fields to update", detail="Provide at least one of --content/--category/--visibility/--tag."
+        )
+    with ctx.make_client() as client:
+        result = client.patch(f"/v1/dev/user/memories/{memory_id}", json_body=body)
+    ctx.renderer.success(f"Memory updated: [bold]{memory_id}[/bold]")
+    ctx.renderer.emit(result, title="memory")
+
+
+@app.command("delete", help="Delete a memory by ID.")
+def delete_memory(
+    typer_ctx: typer.Context,
+    memory_id: str = typer.Argument(..., help="Memory ID."),
+    confirm: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if not confirm:
+        typer.confirm(f"Delete memory {memory_id}?", abort=True)
+    with ctx.make_client() as client:
+        client.delete(f"/v1/dev/user/memories/{memory_id}")
+    ctx.renderer.success(f"Deleted memory [bold]{memory_id}[/bold].")

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -156,21 +156,53 @@ def load(path: Optional[Path] = None) -> Config:
 
 
 def save(config: Config) -> None:
-    """Persist the config to disk with secure (owner-only) permissions."""
+    """Persist the config to disk with secure (owner-only) permissions.
+
+    The temp file is **created** with mode ``0o600`` via :func:`os.open`, not
+    chmodded after the fact — this closes a TOCTOU window where another local
+    user could read bearer credentials between file creation (default umask,
+    typically ``0o644``) and the chmod call. We also temporarily clamp the
+    process umask to ``0o077`` so any platform that ANDs the requested mode
+    against the umask still ends up with owner-only perms.
+    """
     config.path.parent.mkdir(parents=True, exist_ok=True)
+    # Tighten parent dir perms too — credentials live underneath. Best-effort:
+    # don't fail if the user has a custom mode they want to keep.
+    try:
+        os.chmod(config.path.parent, 0o700)
+    except OSError:
+        pass
 
     payload: dict[str, Any] = {
         "active_profile": config.active_profile,
         "profiles": {name: p.to_toml_dict() for name, p in config.profiles.items()},
     }
 
-    # Write atomically: write to a temp file in the same dir, chmod, then rename.
     tmp_path = config.path.with_suffix(config.path.suffix + ".tmp")
-    with tmp_path.open("wb") as fh:
-        tomli_w.dump(payload, fh)
+    # Belt-and-suspenders: clamp umask AND pass an explicit 0o600 mode to os.open.
+    old_umask = os.umask(0o077)
+    try:
+        # O_EXCL guards against following an attacker-planted symlink at this path.
+        try:
+            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            # Stale temp from a previous interrupted save — remove and retry once.
+            os.unlink(tmp_path)
+            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                tomli_w.dump(payload, fh)
+        except Exception:
+            # Best-effort cleanup if the dump itself failed mid-write.
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+    finally:
+        os.umask(old_umask)
 
-    # Owner read/write only — credentials are inside.
-    os.chmod(tmp_path, 0o600)
+    # Atomic rename. The destination inherits the temp's 0o600 mode.
     os.replace(tmp_path, config.path)
 
 

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -1,0 +1,194 @@
+"""Configuration store for omi-cli.
+
+State lives at ``~/.omi/config.toml`` (overridable via ``$OMI_CONFIG``). The file
+holds one or more named profiles; each profile carries one auth method (api_key
+or oauth) plus an API base URL.
+
+The schema is intentionally small and forward-compatible: unknown keys are
+preserved on round-trip so future versions can add fields without breaking
+older installs.
+
+Permissions: the config file is created with mode ``0600`` (owner-only) since it
+holds bearer credentials.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import tomli_w
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover — exercised only on 3.10
+    import tomli as tomllib  # noqa: F401
+
+
+DEFAULT_API_BASE = "https://api.omi.me"
+DEFAULT_PROFILE_NAME = "default"
+ENV_CONFIG_PATH = "OMI_CONFIG"
+ENV_API_KEY = "OMI_API_KEY"
+ENV_API_BASE = "OMI_API_BASE"
+ENV_PROFILE = "OMI_PROFILE"
+
+
+def default_config_path() -> Path:
+    """Return the resolved config path, honoring ``$OMI_CONFIG``."""
+    override = os.environ.get(ENV_CONFIG_PATH)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".omi" / "config.toml"
+
+
+@dataclass
+class Profile:
+    """One auth context. A user may have several (e.g. personal vs work)."""
+
+    name: str
+    auth_method: Optional[str] = None  # "api_key" | "oauth" | None (unconfigured)
+    api_key: Optional[str] = None
+    id_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    id_token_expires_at: Optional[float] = None  # unix epoch seconds
+    api_base: str = DEFAULT_API_BASE
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def is_authenticated(self) -> bool:
+        if self.auth_method == "api_key":
+            return bool(self.api_key)
+        if self.auth_method == "oauth":
+            return bool(self.id_token) or bool(self.refresh_token)
+        return False
+
+    def to_toml_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"api_base": self.api_base}
+        if self.auth_method:
+            out["auth_method"] = self.auth_method
+        if self.api_key:
+            out["api_key"] = self.api_key
+        if self.id_token:
+            out["id_token"] = self.id_token
+        if self.refresh_token:
+            out["refresh_token"] = self.refresh_token
+        if self.id_token_expires_at is not None:
+            out["id_token_expires_at"] = self.id_token_expires_at
+        # Round-trip preserve unknown keys for forward compatibility.
+        for k, v in self.extra.items():
+            if k not in out:
+                out[k] = v
+        return out
+
+    @classmethod
+    def from_toml_dict(cls, name: str, data: dict[str, Any]) -> "Profile":
+        known = {
+            "auth_method",
+            "api_key",
+            "id_token",
+            "refresh_token",
+            "id_token_expires_at",
+            "api_base",
+        }
+        extra = {k: v for k, v in data.items() if k not in known}
+        return cls(
+            name=name,
+            auth_method=data.get("auth_method"),
+            api_key=data.get("api_key"),
+            id_token=data.get("id_token"),
+            refresh_token=data.get("refresh_token"),
+            id_token_expires_at=data.get("id_token_expires_at"),
+            api_base=data.get("api_base", DEFAULT_API_BASE),
+            extra=extra,
+        )
+
+    def masked_credential(self) -> str:
+        """Return a redacted form of the active credential, for status displays."""
+        if self.auth_method == "api_key" and self.api_key:
+            return _mask_token(self.api_key)
+        if self.auth_method == "oauth" and self.id_token:
+            return _mask_token(self.id_token)
+        return "(none)"
+
+
+@dataclass
+class Config:
+    """In-memory representation of the on-disk config file."""
+
+    path: Path
+    active_profile: str = DEFAULT_PROFILE_NAME
+    profiles: dict[str, Profile] = field(default_factory=dict)
+
+    def get_profile(self, name: Optional[str] = None) -> Profile:
+        target = name or self.active_profile
+        if target not in self.profiles:
+            self.profiles[target] = Profile(name=target)
+        return self.profiles[target]
+
+    def set_profile(self, profile: Profile) -> None:
+        self.profiles[profile.name] = profile
+
+    def delete_profile(self, name: str) -> None:
+        self.profiles.pop(name, None)
+        if self.active_profile == name:
+            self.active_profile = DEFAULT_PROFILE_NAME
+
+    def list_profiles(self) -> list[str]:
+        return sorted(self.profiles.keys())
+
+
+def load(path: Optional[Path] = None) -> Config:
+    """Load the config from disk, returning an empty Config if the file is missing."""
+    p = path or default_config_path()
+    if not p.exists():
+        return Config(path=p, active_profile=DEFAULT_PROFILE_NAME, profiles={})
+
+    with p.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    active = data.get("active_profile", DEFAULT_PROFILE_NAME)
+    profiles_data = data.get("profiles", {})
+    profiles = {name: Profile.from_toml_dict(name, raw) for name, raw in profiles_data.items()}
+
+    return Config(path=p, active_profile=active, profiles=profiles)
+
+
+def save(config: Config) -> None:
+    """Persist the config to disk with secure (owner-only) permissions."""
+    config.path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict[str, Any] = {
+        "active_profile": config.active_profile,
+        "profiles": {name: p.to_toml_dict() for name, p in config.profiles.items()},
+    }
+
+    # Write atomically: write to a temp file in the same dir, chmod, then rename.
+    tmp_path = config.path.with_suffix(config.path.suffix + ".tmp")
+    with tmp_path.open("wb") as fh:
+        tomli_w.dump(payload, fh)
+
+    # Owner read/write only — credentials are inside.
+    os.chmod(tmp_path, 0o600)
+    os.replace(tmp_path, config.path)
+
+
+def resolve_profile_name(cli_flag: Optional[str], config: Config) -> str:
+    """Resolve which profile to use given the precedence: CLI flag > env > config default."""
+    if cli_flag:
+        return cli_flag
+    env = os.environ.get(ENV_PROFILE)
+    if env:
+        return env
+    return config.active_profile
+
+
+def _mask_token(token: str) -> str:
+    """Render a token as ``prefix…suffix`` (4+4 chars) for safe display."""
+    if not token:
+        return ""
+    if len(token) <= 12:
+        # Short token — show only the first 2 and last 2 chars.
+        return f"{token[:2]}…{token[-2:]}"
+    return f"{token[:6]}…{token[-4:]}"

--- a/sdks/python-cli/omi_cli/errors.py
+++ b/sdks/python-cli/omi_cli/errors.py
@@ -1,0 +1,152 @@
+"""Exception hierarchy and exit-code mapping for omi-cli.
+
+Exit code contract (stable for agent use):
+
+    0  success
+    1  usage error (bad flags, missing args, validation)
+    2  auth error (no creds, expired token, insufficient scope)
+    3  server error (5xx, connection failure)
+    4  rate limited (429)
+    5  not found (404)
+
+Implementation note: :class:`CliError` extends :class:`click.ClickException` so
+Click's runner (and Typer's CliRunner used in tests) handles propagation of the
+custom ``exit_code`` natively. Subclasses override :meth:`show` to render via
+the active :class:`omi_cli.output.Renderer` when one is reachable on the
+current Click context — falling back to plain stderr otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+import click
+
+# Exit codes — stable contract for scripts and agents.
+EXIT_OK = 0
+EXIT_USAGE = 1
+EXIT_AUTH = 2
+EXIT_SERVER = 3
+EXIT_RATE_LIMITED = 4
+EXIT_NOT_FOUND = 5
+
+
+class CliError(click.ClickException):
+    """Base error raised by omi-cli. Maps to a stable exit code.
+
+    Subclasses set ``exit_code`` to one of the EXIT_* constants. Click's
+    runtime reads ``exit_code`` natively when bubbling an exception out of a
+    command — no extra wiring needed.
+    """
+
+    exit_code: int = EXIT_USAGE
+
+    def __init__(
+        self,
+        message: str,
+        exit_code: Optional[int] = None,
+        detail: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        if exit_code is not None:
+            self.exit_code = exit_code
+        self.detail = detail
+
+    # ``self.message`` is set by ClickException.__init__ — we don't override it
+    # because ClickException assigns to ``self.message`` directly.
+
+    def show(self, file: Optional[object] = None) -> None:
+        """Render via the AppContext's Renderer when available; else plain stderr."""
+        ctx = click.get_current_context(silent=True)
+        renderer = getattr(ctx.obj, "renderer", None) if ctx is not None and ctx.obj is not None else None
+        if renderer is not None:
+            renderer.error(self.message, detail=self.detail)
+            return
+        # Fallback path — covers the rare case where the error fires before the
+        # root callback finished initializing the Renderer.
+        target = file if file is not None else sys.stderr
+        line = f"omi: {self.message}\n"
+        if self.detail:
+            line += f"  {self.detail}\n"
+        target.write(line)  # type: ignore[union-attr]
+
+    def __str__(self) -> str:
+        if self.detail:
+            return f"{self.message}: {self.detail}"
+        return self.message
+
+
+class UsageError(CliError):
+    exit_code = EXIT_USAGE
+
+
+class AuthError(CliError):
+    exit_code = EXIT_AUTH
+
+
+class ServerError(CliError):
+    exit_code = EXIT_SERVER
+
+
+class NotFoundError(CliError):
+    exit_code = EXIT_NOT_FOUND
+
+
+class RateLimitError(CliError):
+    exit_code = EXIT_RATE_LIMITED
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        detail: Optional[str] = None,
+        retry_after_seconds: Optional[float] = None,
+        policy: Optional[str] = None,
+    ) -> None:
+        super().__init__(message=message, detail=detail)
+        self.retry_after_seconds = retry_after_seconds
+        self.policy = policy
+
+
+def from_status(
+    status: int,
+    *,
+    detail: Optional[str] = None,
+    retry_after: Optional[float] = None,
+    policy: Optional[str] = None,
+) -> CliError:
+    """Map an HTTP status code to the appropriate CliError subclass.
+
+    ``detail`` is the server's error message (already extracted from the response
+    body). ``retry_after`` and ``policy`` are populated for 429s to give users a
+    useful "wait Ns" message.
+    """
+    if status == 401:
+        return AuthError(
+            "Authentication failed",
+            detail=detail or "Token rejected. Run `omi auth login` to re-authenticate.",
+        )
+    if status == 403:
+        return AuthError(
+            "Insufficient permissions",
+            detail=detail or "Your API key does not have the required scope for this operation.",
+        )
+    if status == 404:
+        return NotFoundError("Not found", detail=detail)
+    if status == 429:
+        msg = "Rate limited"
+        if policy:
+            msg = f"Rate limited ({policy})"
+        return RateLimitError(
+            msg,
+            detail=detail or "Slow down and retry shortly.",
+            retry_after_seconds=retry_after,
+            policy=policy,
+        )
+    if 500 <= status < 600:
+        return ServerError(
+            f"Server error ({status})",
+            detail=detail or "The Omi API returned an error. Try again or check status.omi.me.",
+        )
+    return CliError(f"HTTP {status}", detail=detail, exit_code=EXIT_USAGE)

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -1,0 +1,180 @@
+"""Typer entry point for omi-cli.
+
+This is the root app — sub-commands are registered from :mod:`omi_cli.commands`.
+The root callback parses global flags and stashes a request-scoped object on
+``ctx.obj`` for sub-commands to consume.
+
+Global flags:
+
+* ``--json``         Emit machine-readable JSON to stdout. The agent contract.
+* ``--profile NAME`` Use a specific profile from ``~/.omi/config.toml``.
+* ``--api-base URL`` Override the API base URL (handy for staging/local).
+* ``-v/--verbose``   Log HTTP traffic to stderr.
+* ``--no-color``     Disable colored output (also honors ``NO_COLOR`` env var).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+import typer
+
+from omi_cli import __version__
+from omi_cli import config as cfg
+from omi_cli.client import OmiClient
+from omi_cli.commands import action_item as action_item_cmd
+from omi_cli.commands import auth as auth_cmd
+from omi_cli.commands import config as config_cmd
+from omi_cli.commands import conversation as conversation_cmd
+from omi_cli.commands import goal as goal_cmd
+from omi_cli.commands import memory as memory_cmd
+from omi_cli.errors import CliError
+from omi_cli.output import Renderer
+
+app = typer.Typer(
+    name="omi",
+    help=(
+        "Omi command-line interface — talk to memories, conversations, "
+        "action items, and goals from your terminal. Designed for humans and "
+        "agents alike. See https://github.com/BasedHardware/omi for the source."
+    ),
+    no_args_is_help=True,
+    add_completion=True,
+    rich_markup_mode="rich",
+)
+
+
+@dataclass
+class AppContext:
+    """Per-invocation state attached to the Typer context (``ctx.obj``)."""
+
+    profile_name: str
+    api_base_override: Optional[str]
+    renderer: Renderer
+    verbose: bool
+    _config: Optional[cfg.Config] = field(default=None, init=False)
+
+    def load_config(self) -> cfg.Config:
+        if self._config is None:
+            self._config = cfg.load()
+        return self._config
+
+    def reload_config(self) -> cfg.Config:
+        self._config = cfg.load()
+        return self._config
+
+    def get_profile(self) -> cfg.Profile:
+        config = self.load_config()
+        profile = config.get_profile(self.profile_name)
+        if self.api_base_override:
+            profile.api_base = self.api_base_override
+        # Allow OMI_API_KEY to take effect even if the on-disk profile has no key.
+        env_key = os.environ.get(cfg.ENV_API_KEY)
+        if env_key and not profile.api_key:
+            profile.auth_method = "api_key"
+            profile.api_key = env_key
+        env_base = os.environ.get(cfg.ENV_API_BASE)
+        if env_base and not self.api_base_override:
+            profile.api_base = env_base
+        return profile
+
+    def make_client(self) -> OmiClient:
+        return OmiClient(self.get_profile(), verbose=self.verbose)
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"omi-cli {__version__}")
+        raise typer.Exit(code=0)
+
+
+@app.callback()
+def _root(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON to stdout (machine-readable, agent-friendly)."),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        "-p",
+        help="Profile to use from ~/.omi/config.toml. Falls back to $OMI_PROFILE then 'default'.",
+    ),
+    api_base: Optional[str] = typer.Option(
+        None,
+        "--api-base",
+        help="Override the API base URL (default: https://api.omi.me).",
+        envvar=cfg.ENV_API_BASE,
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Log HTTP traffic to stderr."),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable color output (also honors $NO_COLOR)."),
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show omi-cli version and exit.",
+    ),
+) -> None:
+    """Root callback: parse global flags, build per-invocation context."""
+    config = cfg.load()
+    profile_name = cfg.resolve_profile_name(profile, config)
+
+    renderer = Renderer(json_mode=json_output, no_color=no_color, verbose=verbose)
+    ctx.obj = AppContext(
+        profile_name=profile_name,
+        api_base_override=api_base,
+        renderer=renderer,
+        verbose=verbose,
+    )
+
+
+@app.command(help="Print the omi-cli version.")
+def version() -> None:
+    typer.echo(f"omi-cli {__version__}")
+
+
+# ---------------------------------------------------------------------------
+# Sub-command registration
+# ---------------------------------------------------------------------------
+
+app.add_typer(auth_cmd.app, name="auth", help="Manage authentication: login, logout, status.")
+app.add_typer(config_cmd.app, name="config", help="View and modify CLI configuration / profiles.")
+app.add_typer(memory_cmd.app, name="memory", help="Memories — facts and learnings about the user.")
+app.add_typer(conversation_cmd.app, name="conversation", help="Conversations — captured & processed audio + text.")
+app.add_typer(action_item_cmd.app, name="action-item", help="Action items — tasks and follow-ups.")
+app.add_typer(goal_cmd.app, name="goal", help="Goals — tracked progress metrics.")
+
+
+# ---------------------------------------------------------------------------
+# Top-level error handler
+# ---------------------------------------------------------------------------
+
+
+def _exit_with_cli_error(error: CliError, renderer: Renderer) -> int:
+    renderer.error(error.message, detail=error.detail)
+    return error.exit_code
+
+
+def main() -> None:
+    """Module-level entry point that converts CliError into stable exit codes."""
+    try:
+        app(standalone_mode=False)
+    except CliError as exc:
+        # If the error happens before the root callback ran, ``ctx.obj`` might
+        # not exist — fall back to a default Renderer reading the env.
+        renderer = Renderer(json_mode=False)
+        sys.exit(_exit_with_cli_error(exc, renderer))
+    except typer.Exit as exc:
+        sys.exit(exc.exit_code)
+    except (KeyboardInterrupt, EOFError):
+        sys.stderr.write("\nAborted.\n")
+        sys.exit(130)
+    except Exception as exc:  # noqa: BLE001 — last-chance handler
+        sys.stderr.write(f"omi: unexpected error: {exc}\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -20,10 +20,12 @@ import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
+import click
 import typer
 
 from omi_cli import __version__
 from omi_cli import config as cfg
+from omi_cli.auth.api_key import validate_api_key_format
 from omi_cli.client import OmiClient
 from omi_cli.commands import action_item as action_item_cmd
 from omi_cli.commands import auth as auth_cmd
@@ -72,10 +74,13 @@ class AppContext:
         if self.api_base_override:
             profile.api_base = self.api_base_override
         # Allow OMI_API_KEY to take effect even if the on-disk profile has no key.
+        # Validate the prefix here so an obviously-bad env value fails fast with the
+        # same friendly UsageError the paste flow uses, instead of bouncing off the
+        # API as a cryptic 401.
         env_key = os.environ.get(cfg.ENV_API_KEY)
         if env_key and not profile.api_key:
             profile.auth_method = "api_key"
-            profile.api_key = env_key
+            profile.api_key = validate_api_key_format(env_key)
         env_base = os.environ.get(cfg.ENV_API_BASE)
         if env_base and not self.api_base_override:
             profile.api_base = env_base
@@ -158,7 +163,22 @@ def _exit_with_cli_error(error: CliError, renderer: Renderer) -> int:
 
 
 def main() -> None:
-    """Module-level entry point that converts CliError into stable exit codes."""
+    """Module-level entry point that converts CliError into stable exit codes.
+
+    We run Click in non-standalone mode so we can shape the exit codes ourselves.
+    The exception ladder, in order of specificity:
+
+    * :class:`CliError` (our own, subclass of ClickException) — already knows how
+      to render via the active Renderer; just call ``show()`` and exit with its
+      ``exit_code``.
+    * Other :class:`click.ClickException` (e.g. ``NoSuchOption`` for a typo'd
+      flag) — let Click's default ``show()`` print the friendly usage message,
+      then exit with its built-in ``exit_code`` (typically 2 for Click usage).
+    * :class:`typer.Exit` — Typer's "clean exit at this code", e.g. from
+      ``--version``. Pass through.
+    * KeyboardInterrupt / EOFError — Ctrl-C / Ctrl-D. Conventional 130.
+    * Anything else — last-chance handler. Print a clean line, exit 1.
+    """
     try:
         app(standalone_mode=False)
     except CliError as exc:
@@ -166,6 +186,11 @@ def main() -> None:
         # not exist — fall back to a default Renderer reading the env.
         renderer = Renderer(json_mode=False)
         sys.exit(_exit_with_cli_error(exc, renderer))
+    except click.ClickException as exc:
+        # Click's own usage errors (unknown flag, missing argument, etc.).
+        # Let Click format it the way users expect; honor its exit_code.
+        exc.show()
+        sys.exit(exc.exit_code)
     except typer.Exit as exc:
         sys.exit(exc.exit_code)
     except (KeyboardInterrupt, EOFError):

--- a/sdks/python-cli/omi_cli/models.py
+++ b/sdks/python-cli/omi_cli/models.py
@@ -1,0 +1,213 @@
+"""Pydantic shapes for omi-cli requests/responses.
+
+Mirrors the subset of `backend/routers/developer.py` that the CLI exercises. We
+hand-write these instead of codegen-from-OpenAPI because the spec at
+``docs/api-reference/openapi.json`` is stale (last touched 2025-03-28, missing
+goals entirely).
+
+Where the backend has stricter validation (e.g. content min/max length), we
+mirror the constraints so the CLI fails fast before hitting the API.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ---------------------------------------------------------------------------
+# Memories
+# ---------------------------------------------------------------------------
+
+
+class MemoryCategory(str, Enum):
+    """Mirrors backend ``MemoryCategory`` — the universe of valid category values."""
+
+    core = "core"
+    hobbies = "hobbies"
+    lifestyle = "lifestyle"
+    interests = "interests"
+    habits = "habits"
+    work = "work"
+    skills = "skills"
+    learnings = "learnings"
+    other = "other"
+    system = "system"
+
+
+class MemoryVisibility(str, Enum):
+    public = "public"
+    private = "private"
+
+
+class Memory(BaseModel):
+    model_config = ConfigDict(extra="allow")  # tolerate fields the backend may add
+
+    id: str
+    content: str
+    category: str  # accept any string so unknown categories don't crash the CLI
+    visibility: Optional[str] = "private"
+    tags: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+    manually_added: bool = False
+    reviewed: bool = False
+    edited: bool = False
+
+
+class MemoryCreate(BaseModel):
+    content: str = Field(min_length=1, max_length=500)
+    category: Optional[MemoryCategory] = None
+    visibility: MemoryVisibility = MemoryVisibility.private
+    tags: list[str] = Field(default_factory=list)
+
+
+class MemoryUpdate(BaseModel):
+    content: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    category: Optional[MemoryCategory] = None
+    visibility: Optional[MemoryVisibility] = None
+    tags: Optional[list[str]] = None
+
+
+# ---------------------------------------------------------------------------
+# Action items
+# ---------------------------------------------------------------------------
+
+
+class ActionItem(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    description: str
+    completed: bool = False
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    due_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    conversation_id: Optional[str] = None
+
+
+class ActionItemCreate(BaseModel):
+    description: str = Field(min_length=1, max_length=500)
+    completed: bool = False
+    due_at: Optional[datetime] = None
+
+
+class ActionItemUpdate(BaseModel):
+    description: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    completed: Optional[bool] = None
+    due_at: Optional[datetime] = None
+
+
+# ---------------------------------------------------------------------------
+# Conversations
+# ---------------------------------------------------------------------------
+
+
+class ConversationTextSource(str, Enum):
+    audio_transcript = "audio_transcript"
+    message = "message"
+    other_text = "other_text"
+
+
+class Conversation(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    created_at: Optional[datetime] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    structured: Optional[dict[str, Any]] = None
+    language: Optional[str] = None
+    source: Optional[str] = None
+    folder_id: Optional[str] = None
+    folder_name: Optional[str] = None
+
+
+class ConversationSummary(BaseModel):
+    """Trimmed view used in list output to keep tables narrow."""
+
+    id: str
+    title: str = ""
+    category: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    source: Optional[str] = None
+
+
+class ConversationCreate(BaseModel):
+    text: str = Field(min_length=1, max_length=100000)
+    text_source: ConversationTextSource = ConversationTextSource.other_text
+    text_source_spec: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    language: str = "en"
+
+
+class ConversationUpdate(BaseModel):
+    title: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    discarded: Optional[bool] = None
+
+
+# ---------------------------------------------------------------------------
+# Goals
+# ---------------------------------------------------------------------------
+
+
+class GoalType(str, Enum):
+    boolean = "boolean"
+    scale = "scale"
+    numeric = "numeric"
+
+
+class Goal(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    title: str
+    goal_type: str
+    target_value: float
+    current_value: float
+    min_value: float
+    max_value: float
+    unit: Optional[str] = None
+    is_active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class GoalCreate(BaseModel):
+    title: str = Field(min_length=1, max_length=500)
+    goal_type: GoalType = GoalType.scale
+    target_value: float
+    current_value: float = 0
+    min_value: float = 0
+    max_value: float = 10
+    unit: Optional[str] = None
+
+
+class GoalUpdate(BaseModel):
+    title: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    target_value: Optional[float] = None
+    current_value: Optional[float] = None
+    min_value: Optional[float] = None
+    max_value: Optional[float] = None
+    unit: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+class DevApiKey(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+    key_prefix: Optional[str] = None
+    created_at: Optional[datetime] = None
+    last_used_at: Optional[datetime] = None
+    scopes: Optional[list[str]] = None

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -1,0 +1,199 @@
+"""Output rendering for omi-cli.
+
+Two modes:
+
+* **Pretty (default):** Rich tables on a TTY; respects ``NO_COLOR`` env var and
+  ``--no-color`` flag. Errors go to stderr.
+* **JSON (`--json`):** machine-readable JSON to stdout. Nothing else writes to
+  stdout in JSON mode — this is the agent contract.
+
+The :class:`Renderer` carries the active mode through the call tree.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+from rich.console import Console
+from rich.table import Table
+
+
+def _no_color_env() -> bool:
+    """Return True if NO_COLOR or NOMI_NO_COLOR is set in the environment.
+
+    Standard ``NO_COLOR`` (https://no-color.org) takes precedence; the
+    ``OMI_NO_COLOR`` form is provided as an Omi-specific override.
+    """
+    if os.environ.get("NO_COLOR"):
+        return True
+    if os.environ.get("OMI_NO_COLOR"):
+        return True
+    return False
+
+
+@dataclass
+class Renderer:
+    """Stateful output sink. One instance per CLI invocation, attached to the Typer context."""
+
+    json_mode: bool = False
+    no_color: bool = False
+    verbose: bool = False
+
+    def __post_init__(self) -> None:
+        # stderr console for messages and errors. In JSON mode, this is the only console
+        # we ever write to (stdout is reserved for the JSON payload).
+        force_terminal = None if not self.no_color else False
+        self._stderr = Console(
+            stderr=True,
+            no_color=self.no_color or _no_color_env(),
+            force_terminal=force_terminal,
+            highlight=False,
+        )
+        self._stdout = Console(
+            no_color=self.no_color or _no_color_env(),
+            force_terminal=force_terminal,
+            highlight=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Stdout (data path)
+    # ------------------------------------------------------------------
+
+    def emit(self, data: Any, *, columns: Optional[Sequence[str]] = None, title: Optional[str] = None) -> None:
+        """Render an API result. JSON mode → JSON to stdout. Pretty mode → Rich table."""
+        if self.json_mode:
+            self._emit_json(data)
+            return
+
+        if isinstance(data, list):
+            self._emit_table(data, columns=columns, title=title)
+        elif isinstance(data, Mapping):
+            self._emit_mapping(data, title=title)
+        else:
+            # Scalars or anything else — just print.
+            self._stdout.print(data)
+
+    def _emit_json(self, data: Any) -> None:
+        # Use sys.stdout directly to avoid Rich coloring/wrapping the JSON.
+        sys.stdout.write(json.dumps(data, default=_json_default, indent=2, sort_keys=False))
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+    def _emit_table(
+        self,
+        rows: Sequence[Mapping[str, Any]],
+        *,
+        columns: Optional[Sequence[str]],
+        title: Optional[str],
+    ) -> None:
+        if not rows:
+            self._stdout.print("[dim](no results)[/dim]")
+            return
+
+        # Pick columns. Caller-supplied wins; otherwise use the keys of the first row.
+        cols = list(columns) if columns else list(rows[0].keys())
+
+        table = Table(title=title, show_lines=False, header_style="bold")
+        for col in cols:
+            table.add_column(col)
+        for row in rows:
+            table.add_row(*[_stringify(row.get(c)) for c in cols])
+        self._stdout.print(table)
+
+    def _emit_mapping(self, mapping: Mapping[str, Any], *, title: Optional[str]) -> None:
+        table = Table(title=title, show_header=False, show_lines=False, box=None)
+        table.add_column("field", style="bold")
+        table.add_column("value")
+        for k, v in mapping.items():
+            table.add_row(k, _stringify(v))
+        self._stdout.print(table)
+
+    # ------------------------------------------------------------------
+    # Stderr (status/messages)
+    # ------------------------------------------------------------------
+
+    def info(self, message: str) -> None:
+        if self.json_mode:
+            return  # silence in JSON mode — keep stderr clean for piping
+        self._stderr.print(message)
+
+    def success(self, message: str) -> None:
+        if self.json_mode:
+            return
+        self._stderr.print(f"[green]✓[/green] {message}")
+
+    def warn(self, message: str) -> None:
+        if self.json_mode:
+            return
+        self._stderr.print(f"[yellow]![/yellow] {message}")
+
+    def error(self, message: str, *, detail: Optional[str] = None) -> None:
+        # Errors are emitted in BOTH modes — JSON mode keeps stdout pristine,
+        # but error messages still need to reach the user via stderr.
+        if self.json_mode:
+            payload: dict[str, Any] = {"error": message}
+            if detail:
+                payload["detail"] = detail
+            self._stderr.print(json.dumps(payload))
+        else:
+            line = f"[red]✗[/red] {message}"
+            if detail:
+                line += f"\n  [dim]{detail}[/dim]"
+            self._stderr.print(line)
+
+    def debug(self, message: str) -> None:
+        if not self.verbose:
+            return
+        self._stderr.print(f"[dim][debug][/dim] {message}")
+
+
+def _stringify(v: Any) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, bool):
+        return "✓" if v else "✗"
+    if isinstance(v, (datetime,)):
+        return v.isoformat()
+    if isinstance(v, (list, tuple)):
+        return ", ".join(_stringify(x) for x in v)
+    if isinstance(v, Mapping):
+        return json.dumps(v, default=_json_default, sort_keys=False)
+    return str(v)
+
+
+def _json_default(v: Any) -> Any:
+    if isinstance(v, datetime):
+        return v.isoformat()
+    if hasattr(v, "model_dump"):  # pydantic v2
+        return v.model_dump()
+    if hasattr(v, "dict"):  # pydantic v1 fallback
+        return v.dict()
+    raise TypeError(f"Object of type {type(v).__name__} is not JSON serializable")
+
+
+def shorten(value: Optional[str], width: int = 60) -> str:
+    """Truncate a string to ``width`` chars with an ellipsis. Used for table cells."""
+    if not value:
+        return ""
+    s = str(value)
+    if len(s) <= width:
+        return s
+    return s[: max(width - 1, 1)] + "…"
+
+
+def coalesce_rows(items: Iterable[Any]) -> list[dict[str, Any]]:
+    """Coerce a list of pydantic models or dicts into a list of dicts. Convenience for renderers."""
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if hasattr(item, "model_dump"):
+            out.append(item.model_dump())
+        elif isinstance(item, Mapping):
+            out.append(dict(item))
+        else:
+            out.append({"value": item})
+    return out

--- a/sdks/python-cli/pyproject.toml
+++ b/sdks/python-cli/pyproject.toml
@@ -1,0 +1,95 @@
+[build-system]
+requires = ["setuptools>=64.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "omi-cli"
+version = "0.1.0"
+description = "Command-line interface for Omi — talk to memories, conversations, action items, and goals from your terminal."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+authors = [
+    { name = "Omi Community", email = "support@omi.me" },
+]
+keywords = [
+    "omi",
+    "cli",
+    "agent",
+    "memory",
+    "wearable",
+    "ai",
+    "conversational-ai",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Utilities",
+]
+dependencies = [
+    "typer>=0.12,<1.0",
+    "rich>=13.7,<15.0",
+    "httpx>=0.27,<1.0",
+    "tenacity>=8.2,<10.0",
+    "pydantic>=2.5,<3.0",
+    "tomli>=2.0; python_version < '3.11'",
+    "tomli-w>=1.0,<2.0",
+]
+
+[project.urls]
+Homepage = "https://www.omi.me/"
+Repository = "https://github.com/BasedHardware/omi"
+Documentation = "https://docs.omi.me"
+Issues = "https://github.com/BasedHardware/omi/issues"
+
+[project.scripts]
+omi = "omi_cli.main:app"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0,<9.0",
+    "pytest-cov>=5.0,<7.0",
+    "respx>=0.21,<1.0",
+    "black>=24.0,<26.0",
+    "isort>=5.13,<7.0",
+    "mypy>=1.8,<2.0",
+    "build>=1.0,<2.0",
+    "twine>=5.0,<7.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["omi_cli*"]
+
+[tool.setuptools.package-data]
+omi_cli = ["py.typed"]
+
+[tool.black]
+line-length = 120
+skip-string-normalization = true
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+line_length = 120
+multi_line_output = 3
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+addopts = "-q --strict-markers"

--- a/sdks/python-cli/pyproject.toml
+++ b/sdks/python-cli/pyproject.toml
@@ -51,7 +51,11 @@ Documentation = "https://docs.omi.me"
 Issues = "https://github.com/BasedHardware/omi/issues"
 
 [project.scripts]
-omi = "omi_cli.main:app"
+# Wire the console script through ``main()`` (not the bare Typer ``app``) so
+# the SIGINT/EOF + last-resort exception handlers in main.py run for every
+# invocation. Going through ``app`` directly would leak raw tracebacks on
+# unexpected errors and emit Click's default Ctrl-C string.
+omi = "omi_cli.main:main"
 
 [project.optional-dependencies]
 dev = [

--- a/sdks/python-cli/release.sh
+++ b/sdks/python-cli/release.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# omi-cli release script
+# Builds the omi-cli package and (optionally) uploads to PyPI.
+#
+# Usage:
+#   ./release.sh                    # interactive: build, twine check, prompt before upload
+#   ./release.sh --build-only       # build + twine check only, no upload, no tag prompt
+#
+# Tag scheme: omi-cli-vX.Y.Z (does NOT collide with the omi-sdk's vX.Y.Z scheme).
+
+set -e
+
+BUILD_ONLY=0
+for arg in "$@"; do
+    case "$arg" in
+        --build-only)
+            BUILD_ONLY=1
+            ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "❌ Unknown argument: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+echo "🚀 Starting omi-cli release process..."
+
+if [ ! -f "pyproject.toml" ]; then
+    echo "❌ Error: pyproject.toml not found. Run from sdks/python-cli/."
+    exit 1
+fi
+
+if ! command -v python &> /dev/null; then
+    echo "❌ Error: python not found"
+    exit 1
+fi
+
+if ! python -m pip show build &> /dev/null; then
+    echo "📦 Installing build tools..."
+    python -m pip install --quiet build twine
+fi
+
+CURRENT_VERSION=$(python -c "
+import sys
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])
+")
+echo "📋 Current version: ${CURRENT_VERSION}"
+
+echo "🔍 Checking if version exists on PyPI..."
+if pip index versions omi-cli 2>/dev/null | grep -q "${CURRENT_VERSION}"; then
+    echo "❌ Error: Version ${CURRENT_VERSION} already exists on PyPI."
+    echo "💡 Bump the version in pyproject.toml first."
+    exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+    echo "⚠️  Warning: uncommitted changes present."
+    if [ "$BUILD_ONLY" -eq 0 ]; then
+        read -p "🤔 Continue anyway? (y/N): " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "❌ Release cancelled."
+            exit 1
+        fi
+    fi
+fi
+
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+echo "🌿 Branch: ${CURRENT_BRANCH}"
+
+echo "🧹 Cleaning previous builds..."
+rm -rf dist/ build/ *.egg-info/
+
+echo "📦 Building package..."
+python -m build
+
+echo "🔍 Verifying package metadata..."
+python -m twine check dist/*
+
+echo "📋 Built artifacts:"
+ls -la dist/
+
+echo
+echo "🎯 Release Summary"
+echo "   Package: omi-cli"
+echo "   Version: ${CURRENT_VERSION}"
+echo "   Branch:  ${CURRENT_BRANCH}"
+echo
+
+if [ "$BUILD_ONLY" -eq 1 ]; then
+    echo "✅ Build complete (build-only mode — no upload, no tag)."
+    echo "💡 To upload manually: python -m twine upload dist/*"
+    echo "💡 To tag: git tag omi-cli-v${CURRENT_VERSION}"
+    exit 0
+fi
+
+read -p "🤔 Upload to PyPI? (y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "⬆️  Uploading to PyPI..."
+    python -m twine upload dist/*
+    echo "✅ Uploaded."
+
+    read -p "🏷️  Create git tag omi-cli-v${CURRENT_VERSION}? (Y/n): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+        git tag "omi-cli-v${CURRENT_VERSION}"
+        echo "✅ Tag created locally. Push with: git push origin omi-cli-v${CURRENT_VERSION}"
+    fi
+
+    echo "🎉 omi-cli v${CURRENT_VERSION} released!"
+    echo "📦 https://pypi.org/project/omi-cli/${CURRENT_VERSION}/"
+else
+    echo "❌ Upload cancelled."
+    echo "💡 To upload later: python -m twine upload dist/*"
+fi
+
+echo "🧹 Cleaning intermediate build dirs..."
+rm -rf build/ *.egg-info/

--- a/sdks/python-cli/tests/conftest.py
+++ b/sdks/python-cli/tests/conftest.py
@@ -1,0 +1,69 @@
+"""Pytest fixtures for the omi-cli test suite.
+
+Each test gets:
+
+* An isolated config dir under a temp path (via the ``OMI_CONFIG`` env var).
+* A pre-seeded "default" profile with a fake API key.
+* A respx mock router pointing at the fake API base URL so HTTP calls are
+  intercepted and asserted against, rather than going to the real Omi API.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from omi_cli import config as cfg
+from omi_cli.auth.store import store_api_key
+
+FAKE_API_BASE = "https://api.test.omi.local"
+FAKE_API_KEY = "omi_dev_" + ("x" * 32)
+
+
+@pytest.fixture
+def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolate the config file to ``tmp_path`` for each test."""
+    target = tmp_path / "config.toml"
+    monkeypatch.setenv(cfg.ENV_CONFIG_PATH, str(target))
+    # Clean up any inherited credentials from the user's real env.
+    for var in (cfg.ENV_API_KEY, cfg.ENV_API_BASE, cfg.ENV_PROFILE):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("OMI_NO_COLOR", raising=False)
+    return target
+
+
+@pytest.fixture
+def authed_profile(config_path: Path) -> cfg.Profile:
+    """Create a default profile pre-loaded with a fake API key + custom api_base."""
+    return store_api_key("default", FAKE_API_KEY, api_base=FAKE_API_BASE)
+
+
+@pytest.fixture
+def respx_mock() -> Iterator[respx.MockRouter]:
+    """A respx router scoped to the fake API base URL."""
+    with respx.mock(base_url=FAKE_API_BASE, assert_all_called=False) as router:
+        yield router
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Typer's CliRunner — used to invoke the root ``app`` in tests.
+
+    Click 8.2+ separates stderr from stdout by default (the old ``mix_stderr``
+    argument was removed). Tests can read ``result.stderr`` directly to assert
+    the JSON-mode agent contract.
+    """
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_typer_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop Typer/Rich from picking up the real terminal width during tests."""
+    monkeypatch.setenv("TERM", "dumb")
+    monkeypatch.setenv("COLUMNS", "200")

--- a/sdks/python-cli/tests/test_action_item.py
+++ b/sdks/python-cli/tests/test_action_item.py
@@ -48,3 +48,11 @@ def test_action_item_delete(authed_profile, respx_mock, cli_runner) -> None:
     respx_mock.delete("/v1/dev/user/action-items/a1").respond(json={"success": True})
     result = cli_runner.invoke(app, ["action-item", "delete", "a1", "-y"])
     assert result.exit_code == 0
+
+
+def test_action_item_get_missing_returns_not_found_exit_code(authed_profile, respx_mock, cli_runner) -> None:
+    """Same agent contract as memory get — client-side miss is exit 5, not 1."""
+    respx_mock.get("/v1/dev/user/action-items").respond(json=[])
+    result = cli_runner.invoke(app, ["action-item", "get", "missing"])
+    assert result.exit_code == 5  # EXIT_NOT_FOUND
+    assert "not found" in result.stderr.lower()

--- a/sdks/python-cli/tests/test_action_item.py
+++ b/sdks/python-cli/tests/test_action_item.py
@@ -1,0 +1,50 @@
+"""Tests for ``omi action-item`` commands."""
+
+from __future__ import annotations
+
+import json
+
+from omi_cli.main import app
+
+
+def test_action_item_list(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/action-items").respond(
+        json=[{"id": "a1", "description": "ship it", "completed": False}]
+    )
+    result = cli_runner.invoke(app, ["--json", "action-item", "list"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload[0]["id"] == "a1"
+
+
+def test_action_item_create(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/action-items").respond(
+        json={"id": "a1", "description": "buy milk", "completed": False}
+    )
+    result = cli_runner.invoke(app, ["--json", "action-item", "create", "buy milk"])
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert body["description"] == "buy milk"
+
+
+def test_action_item_complete_uses_patch(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.patch("/v1/dev/user/action-items/a1").respond(
+        json={"id": "a1", "description": "ship", "completed": True}
+    )
+    result = cli_runner.invoke(app, ["--json", "action-item", "complete", "a1"])
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"completed": True}
+
+
+def test_action_item_filter_completed(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.get("/v1/dev/user/action-items").respond(json=[])
+    cli_runner.invoke(app, ["action-item", "list", "--completed"])
+    request = route.calls.last.request
+    assert request.url.params["completed"] == "true"
+
+
+def test_action_item_delete(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.delete("/v1/dev/user/action-items/a1").respond(json={"success": True})
+    result = cli_runner.invoke(app, ["action-item", "delete", "a1", "-y"])
+    assert result.exit_code == 0

--- a/sdks/python-cli/tests/test_auth_api_key.py
+++ b/sdks/python-cli/tests/test_auth_api_key.py
@@ -1,0 +1,63 @@
+"""Tests for the API-key auth flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from omi_cli import config as cfg
+from omi_cli.auth import api_key as api_key_auth
+from omi_cli.auth.store import clear_credentials, store_api_key
+from omi_cli.errors import UsageError
+
+
+def test_validate_rejects_empty_key() -> None:
+    with pytest.raises(UsageError):
+        api_key_auth.validate_api_key_format("")
+
+
+def test_validate_rejects_whitespace_only() -> None:
+    with pytest.raises(UsageError):
+        api_key_auth.validate_api_key_format("   ")
+
+
+def test_validate_rejects_non_dev_prefix() -> None:
+    with pytest.raises(UsageError) as info:
+        api_key_auth.validate_api_key_format("omi_mcp_" + "x" * 32)
+    assert "developer key" in str(info.value).lower()
+
+
+def test_validate_rejects_truncated_dev_key() -> None:
+    with pytest.raises(UsageError):
+        api_key_auth.validate_api_key_format("omi_dev_short")
+
+
+def test_validate_strips_whitespace() -> None:
+    key = "omi_dev_" + "x" * 32
+    result = api_key_auth.validate_api_key_format(f"  {key}\n")
+    assert result == key
+
+
+def test_login_persists_to_disk(config_path) -> None:
+    key = "omi_dev_" + "y" * 40
+    profile = api_key_auth.login_with_api_key("default", key, api_base="https://api.staging.omi.me")
+    assert profile.api_key == key
+    assert profile.api_base == "https://api.staging.omi.me"
+
+    # Re-load from disk to confirm persistence.
+    reloaded = cfg.load().get_profile("default")
+    assert reloaded.api_key == key
+
+
+def test_store_and_clear_round_trip(config_path) -> None:
+    key = "omi_dev_" + "z" * 40
+    store_api_key("default", key)
+    assert cfg.load().get_profile("default").api_key == key
+
+    cleared = clear_credentials("default")
+    assert cleared is True
+    assert cfg.load().get_profile("default").api_key is None
+    assert cfg.load().get_profile("default").auth_method is None
+
+
+def test_clear_credentials_returns_false_for_unconfigured_profile(config_path) -> None:
+    assert clear_credentials("nonexistent") is False

--- a/sdks/python-cli/tests/test_auth_oauth.py
+++ b/sdks/python-cli/tests/test_auth_oauth.py
@@ -1,0 +1,21 @@
+"""Tests for the OAuth stub (v0.1.0)."""
+
+from __future__ import annotations
+
+import pytest
+
+from omi_cli.auth import oauth
+from omi_cli.errors import UsageError
+
+
+def test_login_with_browser_raises_v0_2_message() -> None:
+    with pytest.raises(UsageError) as info:
+        oauth.login_with_browser("default")
+    msg = str(info.value).lower()
+    assert "v0.2.0" in msg or "0.2.0" in msg
+    assert "api key" in msg or "api-key" in msg
+
+
+def test_refresh_id_token_raises_for_v0_1() -> None:
+    with pytest.raises(UsageError):
+        oauth.refresh_id_token("default")

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -115,6 +115,55 @@ def test_param_filtering_drops_none(authed_profile, respx_mock) -> None:
     assert request.url.params["limit"] == "25"
 
 
+def test_429_with_retry_after_waits_at_least_that_long(authed_profile, respx_mock, monkeypatch) -> None:
+    """Greptile P2: the retry wait must honor a server-supplied Retry-After
+    header rather than blindly using exponential jitter."""
+    import time
+
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    # tenacity sleeps via time.sleep — capture and short-circuit.
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "3"}, json={"detail": "slow down"}),
+            httpx.Response(200, json=[]),
+        ]
+    )
+    with OmiClient(authed_profile) as client:
+        result = client.get("/v1/dev/user/memories")
+    assert result == []
+    # Exactly one inter-attempt wait happened, and it honored the Retry-After
+    # value (3 seconds), not the jitter window (which caps at ~0.5s on attempt 1).
+    assert len(sleeps) == 1
+    assert sleeps[0] == 3.0
+
+
+def test_429_retry_after_is_capped(authed_profile, respx_mock, monkeypatch) -> None:
+    """A pathologically large Retry-After value must be capped so the CLI
+    doesn't pin for hours on a misbehaving upstream."""
+    import time
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+
+    from omi_cli import client as client_module
+
+    respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "99999"}, json={"detail": "wait"}),
+            httpx.Response(200, json=[]),
+        ]
+    )
+    with OmiClient(authed_profile) as cli:
+        cli.get("/v1/dev/user/memories")
+    assert sleeps[0] == client_module.MAX_RETRY_AFTER_SECONDS
+
+
 def test_validation_error_detail_string_is_formatted(authed_profile, respx_mock) -> None:
     respx_mock.post("/v1/dev/user/memories").respond(
         422,

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -1,0 +1,133 @@
+"""Tests for the HTTP client: auth headers, retry logic, error mapping."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from omi_cli import __version__
+from omi_cli.client import USER_AGENT, OmiClient
+from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, ServerError
+
+
+def test_user_agent_contains_version_and_repo() -> None:
+    assert __version__ in USER_AGENT
+    assert "omi-cli" in USER_AGENT
+
+
+def test_get_injects_bearer_and_returns_json(authed_profile, respx_mock) -> None:
+    route = respx_mock.get("/v1/dev/user/memories").respond(json=[{"id": "m1", "content": "hi"}])
+    with OmiClient(authed_profile) as client:
+        result = client.get("/v1/dev/user/memories")
+    assert result == [{"id": "m1", "content": "hi"}]
+    request = route.calls.last.request
+    assert request.headers["Authorization"].startswith("Bearer omi_dev_")
+    assert request.headers["User-Agent"] == USER_AGENT
+
+
+def test_unauthenticated_profile_raises(authed_profile) -> None:
+    profile = authed_profile
+    profile.api_key = None
+    profile.auth_method = None
+    with pytest.raises(CliError) as info:
+        OmiClient(profile)
+    assert info.value.exit_code == 2  # EXIT_AUTH
+
+
+def test_404_maps_to_not_found(authed_profile, respx_mock) -> None:
+    respx_mock.get("/v1/dev/user/memories").respond(404, json={"detail": "missing"})
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(NotFoundError):
+            client.get("/v1/dev/user/memories")
+
+
+def test_401_maps_to_auth_error(authed_profile, respx_mock) -> None:
+    respx_mock.get("/v1/dev/user/memories").respond(401, json={"detail": "Invalid API Key"})
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(AuthError):
+            client.get("/v1/dev/user/memories")
+
+
+def test_403_maps_to_auth_error(authed_profile, respx_mock) -> None:
+    respx_mock.post("/v1/dev/user/memories").respond(
+        403, json={"detail": "Insufficient permissions. Required scope: memories:write"}
+    )
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(AuthError) as info:
+            client.post("/v1/dev/user/memories", json_body={"content": "x"})
+    assert "permission" in str(info.value).lower() or "scope" in str(info.value).lower()
+
+
+def test_500_retries_and_then_surfaces_server_error(authed_profile, respx_mock) -> None:
+    route = respx_mock.get("/v1/dev/user/goals").mock(side_effect=[httpx.Response(500, json={"detail": "boom"})] * 4)
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(ServerError):
+            client.get("/v1/dev/user/goals")
+    # 4 attempts should have been made before giving up.
+    assert route.call_count == 4
+
+
+def test_500_then_200_succeeds_after_retry(authed_profile, respx_mock) -> None:
+    respx_mock.get("/v1/dev/user/goals").mock(
+        side_effect=[
+            httpx.Response(500, json={"detail": "boom"}),
+            httpx.Response(200, json=[]),
+        ]
+    )
+    with OmiClient(authed_profile) as client:
+        result = client.get("/v1/dev/user/goals")
+    assert result == []
+
+
+def test_429_surfaces_rate_limit_with_policy(authed_profile, respx_mock) -> None:
+    respx_mock.post("/v1/dev/user/conversations").mock(
+        side_effect=[
+            httpx.Response(
+                429,
+                headers={"Retry-After": "12"},
+                json={"detail": "Rate limit exceeded for policy dev:conversations"},
+            ),
+        ]
+        * 4
+    )
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(RateLimitError) as info:
+            client.post("/v1/dev/user/conversations", json_body={"text": "x"})
+    err = info.value
+    assert err.policy == "dev:conversations"
+    assert err.retry_after_seconds == 12.0
+    assert "12s" in (err.detail or "")
+
+
+def test_204_returns_none(authed_profile, respx_mock) -> None:
+    respx_mock.delete("/v1/dev/user/memories/abc").respond(204)
+    with OmiClient(authed_profile) as client:
+        result = client.delete("/v1/dev/user/memories/abc")
+    assert result is None
+
+
+def test_param_filtering_drops_none(authed_profile, respx_mock) -> None:
+    route = respx_mock.get("/v1/dev/user/memories").respond(json=[])
+    with OmiClient(authed_profile) as client:
+        client.get("/v1/dev/user/memories", params={"limit": 25, "offset": 0, "categories": None})
+    request = route.calls.last.request
+    assert "categories" not in request.url.params
+    assert request.url.params["limit"] == "25"
+
+
+def test_validation_error_detail_string_is_formatted(authed_profile, respx_mock) -> None:
+    respx_mock.post("/v1/dev/user/memories").respond(
+        422,
+        json={
+            "detail": [
+                {"loc": ["body", "content"], "msg": "field required"},
+                {"loc": ["body", "tags"], "msg": "must be a list"},
+            ]
+        },
+    )
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(CliError) as info:
+            client.post("/v1/dev/user/memories", json_body={})
+    detail = info.value.detail or ""
+    assert "body.content" in detail
+    assert "body.tags" in detail

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -1,0 +1,110 @@
+"""Tests for ``omi_cli.config``."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from omi_cli import config as cfg
+
+
+def test_default_config_path_honors_env(monkeypatch, tmp_path: Path) -> None:
+    custom = tmp_path / "custom.toml"
+    monkeypatch.setenv(cfg.ENV_CONFIG_PATH, str(custom))
+    assert cfg.default_config_path() == custom
+
+
+def test_load_missing_file_returns_empty_config(config_path: Path) -> None:
+    config = cfg.load()
+    assert config.path == config_path
+    assert config.active_profile == cfg.DEFAULT_PROFILE_NAME
+    assert config.profiles == {}
+
+
+def test_save_and_round_trip_preserves_unknown_keys(config_path: Path) -> None:
+    config = cfg.load()
+    profile = config.get_profile("work")
+    profile.auth_method = "api_key"
+    profile.api_key = "omi_dev_abc"
+    profile.api_base = "https://api.staging.omi.me"
+    profile.extra = {"future_setting": True}
+    config.set_profile(profile)
+    config.active_profile = "work"
+    cfg.save(config)
+
+    reloaded = cfg.load()
+    assert reloaded.active_profile == "work"
+    assert "work" in reloaded.profiles
+    p2 = reloaded.profiles["work"]
+    assert p2.api_key == "omi_dev_abc"
+    assert p2.api_base == "https://api.staging.omi.me"
+    assert p2.extra.get("future_setting") is True
+
+
+def test_save_creates_file_with_secure_perms(config_path: Path) -> None:
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.auth_method = "api_key"
+    profile.api_key = "omi_dev_secret"
+    config.set_profile(profile)
+    cfg.save(config)
+
+    mode = stat.S_IMODE(os.stat(config_path).st_mode)
+    # Owner read/write only — credentials are inside.
+    assert mode == 0o600
+
+
+def test_masked_credential_for_api_key(config_path: Path) -> None:
+    profile = cfg.Profile(name="default", auth_method="api_key", api_key="omi_dev_abcdefghij1234")
+    masked = profile.masked_credential()
+    assert "omi_dev_abcdefghij1234" not in masked
+    assert "…" in masked
+    assert masked.startswith("omi_de")
+
+
+def test_masked_credential_short_token_still_redacts() -> None:
+    profile = cfg.Profile(name="default", auth_method="api_key", api_key="abc12")
+    assert "…" in profile.masked_credential()
+
+
+def test_masked_credential_empty_when_no_auth() -> None:
+    profile = cfg.Profile(name="default")
+    assert profile.masked_credential() == "(none)"
+
+
+def test_resolve_profile_name_precedence(config_path: Path, monkeypatch) -> None:
+    config = cfg.load()
+    config.active_profile = "work"
+    cfg.save(config)
+    reloaded = cfg.load()
+    assert cfg.resolve_profile_name(None, reloaded) == "work"  # config default
+
+    monkeypatch.setenv(cfg.ENV_PROFILE, "personal")
+    assert cfg.resolve_profile_name(None, reloaded) == "personal"  # env beats config
+
+    assert cfg.resolve_profile_name("flag-profile", reloaded) == "flag-profile"  # flag beats env
+
+
+def test_delete_profile_resets_active_when_deleting_active(config_path: Path) -> None:
+    config = cfg.load()
+    config.get_profile("work")
+    config.active_profile = "work"
+    config.delete_profile("work")
+    assert config.active_profile == cfg.DEFAULT_PROFILE_NAME
+    assert "work" not in config.profiles
+
+
+def test_is_authenticated_states() -> None:
+    p = cfg.Profile(name="x")
+    assert not p.is_authenticated()
+    p.auth_method = "api_key"
+    p.api_key = "omi_dev_xxx"
+    assert p.is_authenticated()
+    p.auth_method = "oauth"
+    p.api_key = None
+    p.id_token = "id..."
+    assert p.is_authenticated()
+    p.id_token = None
+    p.refresh_token = "refr..."
+    assert p.is_authenticated()

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -55,6 +55,57 @@ def test_save_creates_file_with_secure_perms(config_path: Path) -> None:
     assert mode == 0o600
 
 
+def test_save_does_not_leave_world_readable_window(monkeypatch, config_path: Path) -> None:
+    """TOCTOU regression test (Greptile P1).
+
+    Force a permissive umask, save the config, and assert that *neither* the
+    final file nor any leftover temp file is world-readable. Earlier versions
+    of ``save()`` created the temp with default umask perms (~0o644) before
+    chmodding to 0o600 — that left a window where another local user could
+    read bearer credentials.
+    """
+    # Force a permissive umask. If save() relied on umask alone, the file would
+    # be created at 0o666 by default and the test would fail.
+    old_umask = os.umask(0o000)
+    try:
+        config = cfg.load()
+        profile = config.get_profile()
+        profile.auth_method = "api_key"
+        profile.api_key = "omi_dev_secret"
+        config.set_profile(profile)
+        cfg.save(config)
+    finally:
+        os.umask(old_umask)
+
+    # Final file is owner-only.
+    mode = stat.S_IMODE(os.stat(config_path).st_mode)
+    assert mode == 0o600
+
+    # No leftover temp file with relaxed perms.
+    tmp = config_path.with_suffix(config_path.suffix + ".tmp")
+    assert not tmp.exists()
+
+
+def test_save_overwrites_stale_temp_file(config_path: Path) -> None:
+    """If a previous save() crashed mid-write, a stale .tmp may remain.
+    save() should detect this and recover instead of erroring on O_EXCL."""
+    tmp = config_path.with_suffix(config_path.suffix + ".tmp")
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp.write_text("stale leftover")
+    assert tmp.exists()
+
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.auth_method = "api_key"
+    profile.api_key = "omi_dev_recovered"
+    config.set_profile(profile)
+    cfg.save(config)
+
+    assert not tmp.exists()
+    reloaded = cfg.load().get_profile()
+    assert reloaded.api_key == "omi_dev_recovered"
+
+
 def test_masked_credential_for_api_key(config_path: Path) -> None:
     profile = cfg.Profile(name="default", auth_method="api_key", api_key="omi_dev_abcdefghij1234")
     masked = profile.masked_credential()

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -1,0 +1,78 @@
+"""Tests for ``omi conversation`` commands."""
+
+from __future__ import annotations
+
+import json
+
+from omi_cli.main import app
+
+
+def test_conversation_list_renders(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/conversations").respond(
+        json=[
+            {
+                "id": "c1",
+                "structured": {"title": "hello", "category": "personal"},
+                "started_at": "2026-04-01T00:00:00Z",
+                "source": "phone",
+            }
+        ]
+    )
+    result = cli_runner.invoke(app, ["--json", "conversation", "list"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload[0]["id"] == "c1"
+
+
+def test_conversation_create_posts_text(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/conversations").respond(
+        json={"id": "c1", "status": "completed", "discarded": False}
+    )
+    result = cli_runner.invoke(
+        app, ["--json", "conversation", "create", "--text", "the weather today is fine", "--language", "en"]
+    )
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert body["text"].startswith("the weather")
+    assert body["language"] == "en"
+
+
+def test_conversation_get_includes_transcript_param(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "structured": {"title": "x"}, "transcript_segments": []}
+    )
+    result = cli_runner.invoke(app, ["--json", "conversation", "get", "c1", "--include-transcript"])
+    assert result.exit_code == 0
+    request = route.calls.last.request
+    assert request.url.params["include_transcript"] == "true"
+
+
+def test_conversation_update_requires_field(authed_profile, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["conversation", "update", "c1"])
+    assert result.exit_code == 1
+    assert "no fields to update" in result.stderr.lower()
+
+
+def test_conversation_delete_with_yes(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.delete("/v1/dev/user/conversations/c1").respond(json={"success": True})
+    result = cli_runner.invoke(app, ["conversation", "delete", "c1", "--yes"])
+    assert result.exit_code == 0
+
+
+def test_conversation_from_segments_reads_file(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    f = tmp_path / "segments.json"
+    segments = {
+        "transcript_segments": [
+            {"text": "hi", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_00"},
+            {"text": "hello", "start": 1.5, "end": 2.5, "speaker": "SPEAKER_01"},
+        ]
+    }
+    f.write_text(json.dumps(segments))
+    route = respx_mock.post("/v1/dev/user/conversations/from-segments").respond(
+        json={"id": "c1", "status": "completed", "discarded": False}
+    )
+    result = cli_runner.invoke(app, ["--json", "conversation", "from-segments", str(f), "--source", "phone"])
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert len(body["transcript_segments"]) == 2
+    assert body["source"] == "phone"

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -1,0 +1,98 @@
+"""Tests for ``omi goal`` commands."""
+
+from __future__ import annotations
+
+import json
+
+from omi_cli.main import app
+
+
+def test_goal_list(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/goals").respond(
+        json=[
+            {
+                "id": "g1",
+                "title": "ship cli",
+                "goal_type": "scale",
+                "target_value": 10,
+                "current_value": 3,
+                "min_value": 0,
+                "max_value": 10,
+                "is_active": True,
+            }
+        ]
+    )
+    result = cli_runner.invoke(app, ["--json", "goal", "list"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload[0]["id"] == "g1"
+
+
+def test_goal_create_posts(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/goals").respond(
+        json={
+            "id": "g1",
+            "title": "drink water",
+            "goal_type": "numeric",
+            "target_value": 2.0,
+            "current_value": 0,
+            "min_value": 0,
+            "max_value": 10,
+            "unit": "liters",
+            "is_active": True,
+        }
+    )
+    result = cli_runner.invoke(
+        app,
+        [
+            "--json",
+            "goal",
+            "create",
+            "drink water",
+            "--target",
+            "2",
+            "--type",
+            "numeric",
+            "--unit",
+            "liters",
+        ],
+    )
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert body["target_value"] == 2.0
+    assert body["goal_type"] == "numeric"
+    assert body["unit"] == "liters"
+
+
+def test_goal_progress_uses_query_param(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.patch("/v1/dev/user/goals/g1/progress").respond(
+        json={
+            "id": "g1",
+            "title": "x",
+            "goal_type": "scale",
+            "target_value": 10,
+            "current_value": 7,
+            "min_value": 0,
+            "max_value": 10,
+            "is_active": True,
+        }
+    )
+    result = cli_runner.invoke(app, ["--json", "goal", "progress", "g1", "7"])
+    assert result.exit_code == 0
+    request = route.calls.last.request
+    # httpx serializes Python floats with the trailing ``.0`` — accept either form.
+    assert request.url.params["current_value"] in ("7", "7.0")
+
+
+def test_goal_history(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/goals/g1/history").respond(json=[{"recorded_at": "2026-04-25T00:00:00Z", "value": 3}])
+    result = cli_runner.invoke(app, ["--json", "goal", "history", "g1", "--days", "7"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload[0]["value"] == 3
+
+
+def test_goal_delete(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.delete("/v1/dev/user/goals/g1").respond(json={"success": True})
+    result = cli_runner.invoke(app, ["goal", "delete", "g1", "-y"])
+    assert result.exit_code == 0

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -1,0 +1,35 @@
+"""Tests for the Typer root: --version, --help, global-flag plumbing."""
+
+from __future__ import annotations
+
+import json
+
+from omi_cli import __version__
+from omi_cli.main import app
+
+
+def test_version_flag(cli_runner) -> None:
+    result = cli_runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+
+
+def test_version_subcommand(cli_runner) -> None:
+    result = cli_runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+
+
+def test_help_lists_all_top_level_commands(cli_runner) -> None:
+    result = cli_runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for cmd in ("auth", "config", "memory", "conversation", "action-item", "goal", "version"):
+        assert cmd in result.stdout
+
+
+def test_auth_status_unauthenticated_in_json(config_path, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["--json", "auth", "status"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["authenticated"] is False
+    assert payload["auth_method"] is None

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -33,3 +33,25 @@ def test_auth_status_unauthenticated_in_json(config_path, cli_runner) -> None:
     payload = json.loads(result.stdout)
     assert payload["authenticated"] is False
     assert payload["auth_method"] is None
+
+
+def test_omi_api_key_env_var_is_validated(config_path, cli_runner, monkeypatch) -> None:
+    """Greptile P2: an obviously-bad OMI_API_KEY env value must surface as a
+    UsageError (exit 1) before the CLI tries to call the API and bounces off
+    a 401."""
+    monkeypatch.setenv("OMI_API_KEY", "not-a-real-key")
+    result = cli_runner.invoke(app, ["memory", "list"])
+    assert result.exit_code == 1  # EXIT_USAGE — same shape as the paste flow's bad-format error
+    assert "developer key" in result.stderr.lower() or "omi_dev_" in result.stderr.lower()
+
+
+def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runner, monkeypatch, respx_mock) -> None:
+    """A well-formed env-var key should reach the API exactly like the on-disk path."""
+    from tests.conftest import FAKE_API_BASE
+
+    monkeypatch.setenv("OMI_API_KEY", "omi_dev_" + ("a" * 32))
+    monkeypatch.setenv("OMI_API_BASE", FAKE_API_BASE)
+    respx_mock.get("/v1/dev/user/memories").respond(json=[])
+    result = cli_runner.invoke(app, ["--json", "memory", "list"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "[]"

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -1,0 +1,103 @@
+"""Tests for ``omi memory`` commands via CliRunner."""
+
+from __future__ import annotations
+
+import json
+
+from omi_cli.main import app
+
+
+def test_memory_list_json(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/memories").respond(
+        json=[{"id": "m1", "content": "hello world", "category": "core", "visibility": "private", "tags": []}]
+    )
+    result = cli_runner.invoke(app, ["--json", "memory", "list"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload[0]["id"] == "m1"
+
+
+def test_memory_list_pretty_renders_table(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/memories").respond(
+        json=[
+            {
+                "id": "m1",
+                "content": "hello",
+                "category": "core",
+                "visibility": "private",
+                "tags": ["a"],
+                "created_at": "2026-04-01T00:00:00Z",
+            }
+        ]
+    )
+    result = cli_runner.invoke(app, ["--no-color", "memory", "list"])
+    assert result.exit_code == 0
+    assert "m1" in result.stdout
+    assert "hello" in result.stdout
+
+
+def test_memory_create_posts_body(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/memories").respond(
+        json={"id": "m99", "content": "from cli", "category": "core", "visibility": "private", "tags": []}
+    )
+    result = cli_runner.invoke(app, ["--json", "memory", "create", "from cli"])
+    assert result.exit_code == 0
+    request = route.calls.last.request
+    body = json.loads(request.content)
+    assert body["content"] == "from cli"
+    assert body["visibility"] == "private"
+
+
+def test_memory_create_with_category_and_tags(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/memories").respond(
+        json={"id": "m1", "content": "x", "category": "work", "visibility": "public", "tags": ["a", "b"]}
+    )
+    result = cli_runner.invoke(
+        app,
+        ["--json", "memory", "create", "x", "--category", "work", "--visibility", "public", "--tag", "a", "--tag", "b"],
+    )
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert body["category"] == "work"
+    assert body["visibility"] == "public"
+    assert body["tags"] == ["a", "b"]
+
+
+def test_memory_delete_skips_prompt_with_yes(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.delete("/v1/dev/user/memories/m1").respond(204)
+    result = cli_runner.invoke(app, ["memory", "delete", "m1", "--yes"])
+    assert result.exit_code == 0
+
+
+def test_memory_update_requires_at_least_one_field(authed_profile, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["memory", "update", "m1"])
+    # exit 1 = usage error
+    assert result.exit_code == 1
+    assert "no fields to update" in result.stderr.lower()
+
+
+def test_memory_update_patches_body(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.patch("/v1/dev/user/memories/m1").respond(
+        json={
+            "id": "m1",
+            "content": "new",
+            "category": "core",
+            "visibility": "private",
+            "tags": [],
+            "created_at": "2026-04-01T00:00:00Z",
+            "updated_at": "2026-04-26T00:00:00Z",
+            "manually_added": True,
+            "reviewed": False,
+            "edited": True,
+        }
+    )
+    result = cli_runner.invoke(app, ["--json", "memory", "update", "m1", "--content", "new"])
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"content": "new"}
+
+
+def test_memory_unauthenticated_is_clear(config_path, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["memory", "list"])
+    assert result.exit_code == 2  # EXIT_AUTH
+    assert "auth login" in result.stderr.lower() or "not authenticated" in result.stderr.lower()

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -101,3 +101,27 @@ def test_memory_unauthenticated_is_clear(config_path, cli_runner) -> None:
     result = cli_runner.invoke(app, ["memory", "list"])
     assert result.exit_code == 2  # EXIT_AUTH
     assert "auth login" in result.stderr.lower() or "not authenticated" in result.stderr.lower()
+
+
+def test_memory_get_missing_returns_not_found_exit_code(authed_profile, respx_mock, cli_runner) -> None:
+    """Client-side scan for a missing memory must surface as exit 5 (NotFoundError),
+    matching the documented agent contract — not exit 1 (UsageError)."""
+    respx_mock.get("/v1/dev/user/memories").respond(json=[])
+    result = cli_runner.invoke(app, ["memory", "get", "does-not-exist"])
+    assert result.exit_code == 5  # EXIT_NOT_FOUND
+    assert "not found" in result.stderr.lower()
+
+
+def test_memory_get_found_in_later_page(authed_profile, respx_mock, cli_runner) -> None:
+    """Confirm the paging loop still finds an item past the first page."""
+    page1 = [
+        {"id": f"m{i}", "content": "x", "category": "core", "visibility": "private", "tags": []} for i in range(100)
+    ]
+    page2 = [{"id": "target", "content": "found me", "category": "core", "visibility": "private", "tags": []}]
+    import httpx
+
+    respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=[httpx.Response(200, json=page1), httpx.Response(200, json=page2)]
+    )
+    result = cli_runner.invoke(app, ["--json", "memory", "get", "target"])
+    assert result.exit_code == 0

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -1,0 +1,91 @@
+"""Tests for the Renderer (Rich + JSON output paths)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from omi_cli.output import Renderer, coalesce_rows, shorten
+
+
+def test_json_mode_emits_valid_json_to_stdout(capsys) -> None:
+    renderer = Renderer(json_mode=True)
+    renderer.emit({"id": "m1", "content": "hi"})
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed == {"id": "m1", "content": "hi"}
+    # Stderr should be quiet for emit() in JSON mode.
+    assert captured.err == ""
+
+
+def test_json_mode_silences_info_and_success(capsys) -> None:
+    renderer = Renderer(json_mode=True)
+    renderer.info("hello")
+    renderer.success("yay")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_json_mode_emits_errors_as_json_to_stderr(capsys) -> None:
+    renderer = Renderer(json_mode=True)
+    renderer.error("bad", detail="reason")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    parsed = json.loads(captured.err)
+    assert parsed == {"error": "bad", "detail": "reason"}
+
+
+def test_json_mode_serializes_datetime() -> None:
+    import sys
+    from io import StringIO
+
+    renderer = Renderer(json_mode=True)
+    buffer = StringIO()
+    sys.stdout, original = buffer, sys.stdout
+    try:
+        renderer.emit({"created_at": datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)})
+    finally:
+        sys.stdout = original
+    parsed = json.loads(buffer.getvalue())
+    assert parsed["created_at"].startswith("2026-04-26T12:00:00")
+
+
+def test_pretty_mode_renders_table_for_list(capsys) -> None:
+    renderer = Renderer(json_mode=False, no_color=True)
+    renderer.emit([{"id": "m1", "content": "hello"}], columns=["id", "content"], title="memories")
+    captured = capsys.readouterr()
+    assert "m1" in captured.out
+    assert "hello" in captured.out
+
+
+def test_pretty_mode_renders_no_results_for_empty_list(capsys) -> None:
+    renderer = Renderer(json_mode=False, no_color=True)
+    renderer.emit([])
+    captured = capsys.readouterr()
+    assert "no results" in captured.out
+
+
+def test_shorten_basic() -> None:
+    assert shorten("abcdef", 3) == "ab…"
+    assert shorten("abcdef", 10) == "abcdef"
+    assert shorten(None) == ""
+    assert shorten("") == ""
+
+
+def test_coalesce_rows_handles_dicts_and_models() -> None:
+    class Fake:
+        def model_dump(self) -> dict:
+            return {"x": 1}
+
+    rows = coalesce_rows([{"a": 1}, Fake()])
+    assert rows == [{"a": 1}, {"x": 1}]
+
+
+def test_no_color_env_disables_color(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    renderer = Renderer(json_mode=False)
+    renderer.success("done")
+    captured = capsys.readouterr()
+    # No ANSI codes when NO_COLOR is set.
+    assert "\x1b[" not in captured.err


### PR DESCRIPTION
## ⚠️ Do not merge yet — awaiting human review

Opening this PR to gather feedback. Build artifacts and a local tag have been produced; **PyPI upload is intentionally deferred** until this PR is approved.

## Summary

Ships a new package, **\`omi-cli\`** (PyPI \`omi-cli\` → console binary \`omi\`), at \`sdks/python-cli/\`. It exposes the Omi developer API surface (\`/v1/dev/*\`) as scoped, agent-friendly verbs.

Why: Omi has a Python SDK (\`omi-sdk\`) for Bluetooth/audio capture but no terminal-native, scriptable, JSON-emitting interface for the data plane that agents actually want — memories, conversations, action items, goals. The MCP server covers four tools and is Claude-Desktop-native; the Flutter app talks to the API directly. \`omi-cli\` fills the gap for shell pipelines, CI jobs, agent harnesses, and personal automation.

Why a separate package (rather than extending \`omi-sdk\`): the SDK pulls heavy deps (\`bleak\`, \`deepgram-sdk\`, \`aiohttp\`, \`websockets\`) for Bluetooth/audio that 100% of CLI users don't need. Two thin packages with clear purposes beats one bloated package.

## Command surface (v0.1.0)

\`\`\`text
omi
├── auth          login [--browser stub] | logout | status | whoami | refresh
├── config        show | set | path | profile {list, use, delete}
├── memory        list | get | create | update | delete
├── conversation  list | get | create | from-segments | update | delete
├── action-item   list | get | create | update | complete | delete
└── goal          list | get | create | update | progress | history | delete
\`\`\`

Global flags: \`--json\`, \`--profile\`, \`--api-base\`, \`-v/--verbose\`, \`--no-color\`, \`--version\`.

## Auth

- ✅ **Dev API key paste flow** (\`omi auth login\`) — primary, agent-friendly, headless. Hidden prompt; \`OMI_API_KEY\` env var also works.
- 🚧 **Firebase OAuth browser flow** (\`omi auth login --browser\`) — stubbed in v0.1.0. The existing \`/v1/auth/*\` flow's HTML callback hardcodes redirect to \`omi://auth/callback\` (mobile deep link), so a localhost-loopback redirect for the CLI needs a backend tweak. Tracked for **v0.2.0** rather than shipping a fragile bypass.

Tokens persist at \`~/.omi/config.toml\` (\`OMI_CONFIG\` overrides), 0600 perms, named-profile support.

## Agent contract

- \`--json\` emits valid JSON to stdout and **only** that — nothing else writes to stdout in JSON mode (errors go to stderr as \`{\"error\": ..., \"detail\": ...}\`).
- Stable exit codes: \`0\` ok / \`1\` usage / \`2\` auth / \`3\` server / \`4\` rate-limited / \`5\` not-found.
- 429s carry \`Retry-After\` window + the policy name (\`dev:conversations\`, etc.) so an agent can back off intelligently.
- See [\`examples/agent_quickstart.md\`](sdks/python-cli/examples/agent_quickstart.md) for a worked Python-driven example.

## What's _not_ in v1

- WebSocket \`/v4/listen\` streaming (audio capture is out of scope — that's what the SDK handles).
- Apps marketplace install / payments / third-party integrations OAuth (require Firebase ID token; need OAuth flow first).
- Dev-key creation (also Firebase-gated; users still generate keys in the web app).

## Quality gates (all green)

| Check                               | Result                          |
| ----------------------------------- | ------------------------------- |
| pytest                              | **69 tests pass**               |
| black --check (line-length 120)     | clean                           |
| isort --check-only (black profile)  | clean                           |
| mypy --strict                       | clean (19 source files)         |
| \`omi --help\` smoke test            | renders full command tree       |

## Test plan

- [ ] Generate a dev API key under \`https://app.omi.me\` → Developer → API Keys
- [ ] \`pipx install --editable sdks/python-cli\` (or \`pip install -e sdks/python-cli\`)
- [ ] \`omi auth login\` → paste key → \`omi auth status\` shows scopes + masked credential
- [ ] \`omi memory list --json | jq '.[0]'\` returns a memory
- [ ] \`omi memory create \"test from cli launch\"\` → echoes id
- [ ] \`omi memory delete <id> -y\` → 204
- [ ] \`omi conversation list --limit 5\`
- [ ] \`omi action-item list --open\`
- [ ] \`omi goal list\`
- [ ] Loop 30 conversation reads → CLI surfaces friendly 429 with retry hint, exit code 4

## Release posture (per repo CLAUDE.md)

- Branch: \`worktree-omi-cli-launch\` (worktree at \`.claude/worktrees/omi-cli-launch\`).
- 40 commits, **one file per commit**.
- Build artifacts produced via \`bash sdks/python-cli/release.sh --build-only\` (wheel + sdist, \`twine check\` passes).
- Local git tag \`omi-cli-v0.1.0\` created (not pushed).
- **\`twine upload\` not run.** PR not auto-merged. Tag not pushed. All three are deliberate.

To publish after review:
\`\`\`bash
cd sdks/python-cli && python -m twine upload dist/*
git push origin omi-cli-v0.1.0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)