### PR TITLE
docs(cli): add CLI tab to Mintlify navigation

### DIFF
--- a/docs/doc/developer/cli/agents.mdx
+++ b/docs/doc/developer/cli/agents.mdx
@@ -75,8 +75,12 @@ backoff strategies.
 ```python
 import json
 import subprocess
-import time
+from datetime import datetime, timedelta, timezone
 from typing import Any
+
+
+class OmiCliError(RuntimeError):
+    pass
 
 
 def omi(*args: str) -> Any:
@@ -98,12 +102,7 @@ def omi(*args: str) -> Any:
     raise OmiCliError(err)
 
 
-class OmiCliError(RuntimeError):
-    pass
-
-
 # Read all open action items and mark anything older than 30 days complete.
-from datetime import datetime, timedelta, timezone
 cutoff = datetime.now(timezone.utc) - timedelta(days=30)
 
 items = omi("action-item", "list", "--open") or []
@@ -116,15 +115,22 @@ for item in items:
 ## Handling rate limits in your harness
 
 ```python
-import json, subprocess, time, re
+import json
+import re
+import subprocess
+import time
 
 
-def omi_with_backoff(*args, max_attempts=3):
-    for attempt in range(max_attempts):
-        result = subprocess.run(["omi", "--json", *args], capture_output=True, text=True)
+def omi_with_backoff(*args: str, max_attempts: int = 3) -> object:
+    for _ in range(max_attempts):
+        result = subprocess.run(
+            ["omi", "--json", *args],
+            capture_output=True,
+            text=True,
+        )
         if result.returncode == 0:
             return json.loads(result.stdout) if result.stdout.strip() else None
-        if result.returncode != 4:        # not a rate-limit error
+        if result.returncode != 4:  # not a rate-limit error
             raise RuntimeError(result.stderr)
         # Pull "Retry in Ns" out of the detail message.
         match = re.search(r"Retry in (\d+)s", result.stderr)

--- a/docs/doc/developer/cli/agents.mdx
+++ b/docs/doc/developer/cli/agents.mdx
@@ -1,0 +1,146 @@
+---
+title: "For agents"
+icon: "robot"
+description: "Stable agent contract — JSON output, exit codes, retry semantics."
+---
+
+`omi-cli` is built so an LLM-driven harness can drive it without a wrapper
+layer. This page documents the stable contract.
+
+## The JSON contract
+
+Pass `--json` (a **global** flag, before the subcommand) and the CLI behaves
+like a strict tool:
+
+- **stdout** receives a single JSON document and *only* a JSON document.
+  No spinners, no progress messages, no decorative output.
+- **stderr** receives any error as a JSON object: `{"error": "...", "detail": "..."}`.
+- **exit code** signals what happened.
+
+```bash
+omi --json memory list --limit 25 | jq '.[] | {id, content, category}'
+```
+
+## Exit codes
+
+| Code | Meaning                                                                 |
+| ---- | ----------------------------------------------------------------------- |
+| `0`  | Success.                                                                |
+| `1`  | Usage error — bad flag, missing arg, validation rejection.              |
+| `2`  | Auth error — no creds, expired token, insufficient scope.               |
+| `3`  | Server error — 5xx after retries exhausted, or connection failure.      |
+| `4`  | Rate limited — 429 after retries exhausted. `detail` includes the wait. |
+| `5`  | Not found — 404, or client-side scan came up empty.                     |
+
+These codes are **part of the contract** — they won't shift between minor
+versions. Branch on them in your harness without parsing English errors.
+
+## Authentication
+
+For agents, prefer the env-var path:
+
+```bash
+export OMI_API_KEY=omi_dev_...
+```
+
+The on-disk config file is great for humans on a laptop but a footgun in
+shared CI runners. The env var injection runs the same prefix validation as
+`omi auth login` so a malformed value still fails fast with exit `1`.
+
+## Retry behavior
+
+Transient failures are retried automatically before the CLI surfaces an error:
+
+- **5xx** — exponential backoff with jitter (initial 0.5s, cap 8s).
+- **429** — honors the server's `Retry-After` header when present (capped at
+  60s so a misconfigured upstream can't pin your agent forever); falls back to
+  jitter otherwise. The `Retry-After` cap means a 429 with a one-hour hint
+  becomes a one-minute wait — your agent gets exit `4` quickly enough to
+  decide whether to back off itself.
+- **Transport errors** (DNS failures, dropped TCP) — retried up to 4 attempts.
+
+After retries are exhausted, the CLI surfaces a structured error and the
+appropriate exit code. The `detail` field for rate-limit errors looks like:
+
+```json
+{"error": "Rate limited: dev:conversations (25/hr)", "detail": "Retry in 12s. ..."}
+```
+
+The policy name (`dev:conversations`, `dev:memories`, `dev:memories_batch`)
+matches the backend's rate-limit policy IDs so you can map them to your own
+backoff strategies.
+
+## Worked example: Python harness
+
+```python
+import json
+import subprocess
+import time
+from typing import Any
+
+
+def omi(*args: str) -> Any:
+    """Invoke the omi CLI in JSON mode, raising on non-success exit codes."""
+    result = subprocess.run(
+        ["omi", "--json", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return json.loads(result.stdout) if result.stdout.strip() else None
+    # Errors come back as JSON on stderr in JSON mode.
+    try:
+        err = json.loads(result.stderr)
+    except json.JSONDecodeError:
+        err = {"error": result.stderr.strip()}
+    err["exit_code"] = result.returncode
+    raise OmiCliError(err)
+
+
+class OmiCliError(RuntimeError):
+    pass
+
+
+# Read all open action items and mark anything older than 30 days complete.
+from datetime import datetime, timedelta, timezone
+cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+
+items = omi("action-item", "list", "--open") or []
+for item in items:
+    created = datetime.fromisoformat(item["created_at"].replace("Z", "+00:00"))
+    if created < cutoff:
+        omi("action-item", "complete", item["id"])
+```
+
+## Handling rate limits in your harness
+
+```python
+import json, subprocess, time, re
+
+
+def omi_with_backoff(*args, max_attempts=3):
+    for attempt in range(max_attempts):
+        result = subprocess.run(["omi", "--json", *args], capture_output=True, text=True)
+        if result.returncode == 0:
+            return json.loads(result.stdout) if result.stdout.strip() else None
+        if result.returncode != 4:        # not a rate-limit error
+            raise RuntimeError(result.stderr)
+        # Pull "Retry in Ns" out of the detail message.
+        match = re.search(r"Retry in (\d+)s", result.stderr)
+        wait_s = int(match.group(1)) if match else 60
+        time.sleep(wait_s)
+    raise RuntimeError("rate-limited after retries")
+```
+
+## Tips
+
+- **One JSON document per invocation.** Don't try to stream — the CLI doesn't
+  emit incremental output. Run it again for the next page.
+- **Use `--profile` to isolate environments.** A staging profile + a prod
+  profile saves you from accidentally writing to prod with a test script.
+- **Use `--api-base http://localhost:8080`** for local backend testing.
+- **`--verbose` is safe in JSON mode.** Debug output goes to stderr, stdout
+  stays valid JSON.
+- **Pipe stdin with `--text -`** for `omi conversation create` — handy when
+  the content is generated by another tool and you don't want to shell-escape it.

--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -1,0 +1,130 @@
+---
+title: "Command reference"
+icon: "book"
+description: "Every verb, every flag."
+---
+
+The full command tree (run `omi --help` for the live version):
+
+```text
+omi
+├── auth          login [--browser] [--api-key KEY] | logout | status | whoami | refresh
+├── config        show | set <k> <v> | path | profile {list, use <name>, delete <name>}
+├── memory        list | get | create | update | delete
+├── conversation  list | get | create | from-segments | update | delete
+├── action-item   list | get | create | update | complete | delete
+└── goal          list | get | create | update | progress | history | delete
+```
+
+## Global flags
+
+```text
+--json                 Emit JSON to stdout (machine-readable, agent-friendly).
+--profile, -p NAME     Use a specific profile from ~/.omi/config.toml.
+--api-base URL         Override the API base URL.
+--verbose, -v          Log HTTP traffic to stderr.
+--no-color             Disable colored output (also honors $NO_COLOR).
+--version              Print the version.
+--help                 Show contextual help.
+```
+
+<Note>
+  Global flags must come **before** the subcommand
+  (`omi --json memory list`, not `omi memory list --json`). This is a Click
+  framework constraint; you'll get a friendly usage message if you put them
+  in the wrong place.
+</Note>
+
+---
+
+## `omi auth`
+
+| Command                       | Notes                                                           |
+| ----------------------------- | --------------------------------------------------------------- |
+| `omi auth login`              | Hidden-input prompt for a dev API key.                          |
+| `omi auth login --api-key K`  | Headless. Exposes the key in `ps`/history — prefer the prompt.  |
+| `omi auth login --browser`    | OAuth browser flow. **Coming in v0.2.0.**                       |
+| `omi auth logout`             | Clear the active profile's credentials.                         |
+| `omi auth status`             | Show profile + masked credential + API base.                    |
+| `omi auth whoami`             | Round-trip to the API to verify the credential is valid.        |
+| `omi auth refresh`            | OAuth-only (no-op with API keys).                               |
+
+## `omi config`
+
+| Command                            | Notes                                                |
+| ---------------------------------- | ---------------------------------------------------- |
+| `omi config show`                  | Print all profiles + masked credentials.             |
+| `omi config path`                  | Print the on-disk config file path.                  |
+| `omi config set api_base URL`      | Override the API base for the active profile.        |
+| `omi config profile list`          | Tabular list of profiles.                            |
+| `omi config profile use NAME`      | Switch the active profile. Creates it if missing.    |
+| `omi config profile delete NAME`   | Wipe a profile (prompts unless `--yes`).             |
+
+## `omi memory`
+
+| Command                                        | Endpoint                                              |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| `omi memory list [--limit N --offset N --categories CSV]` | `GET /v1/dev/user/memories`                |
+| `omi memory get ID`                            | client-side scan (no direct GET in the dev API)       |
+| `omi memory create CONTENT [--category C --visibility V --tag T...]` | `POST /v1/dev/user/memories`                |
+| `omi memory update ID [--content ... --category ... --visibility ... --tag ...]` | `PATCH /v1/dev/user/memories/{id}` |
+| `omi memory delete ID [-y]`                    | `DELETE /v1/dev/user/memories/{id}`                   |
+
+Categories: `core`, `hobbies`, `lifestyle`, `interests`, `habits`, `work`,
+`skills`, `learnings`, `other`, `system`.
+Visibility: `public` or `private`.
+
+## `omi conversation`
+
+| Command                                       | Endpoint                                                       |
+| --------------------------------------------- | -------------------------------------------------------------- |
+| `omi conversation list [...filters]`          | `GET /v1/dev/user/conversations`                               |
+| `omi conversation get ID [--include-transcript]` | `GET /v1/dev/user/conversations/{id}`                       |
+| `omi conversation create --text ... [...]`    | `POST /v1/dev/user/conversations`                              |
+| `omi conversation from-segments FILE.json [--source ...]` | `POST /v1/dev/user/conversations/from-segments`    |
+| `omi conversation update ID [--title ... --discarded/--no-discarded]` | `PATCH /v1/dev/user/conversations/{id}` |
+| `omi conversation delete ID [-y]`             | `DELETE /v1/dev/user/conversations/{id}`                       |
+
+The `--text` flag accepts `-` to read from stdin:
+
+```bash
+cat meeting_notes.md | omi conversation create --text - --text-source message
+```
+
+## `omi action-item`
+
+| Command                                       | Endpoint                                                    |
+| --------------------------------------------- | ----------------------------------------------------------- |
+| `omi action-item list [--completed/--open ...]` | `GET /v1/dev/user/action-items`                           |
+| `omi action-item get ID`                      | client-side scan                                            |
+| `omi action-item create DESC [--due-at ISO]`  | `POST /v1/dev/user/action-items`                            |
+| `omi action-item update ID [--description ... --completed/--open --due-at ...]` | `PATCH /v1/dev/user/action-items/{id}` |
+| `omi action-item complete ID`                 | shortcut for `update --completed`                           |
+| `omi action-item delete ID [-y]`              | `DELETE /v1/dev/user/action-items/{id}`                     |
+
+## `omi goal`
+
+| Command                                                | Endpoint                                                |
+| ------------------------------------------------------ | ------------------------------------------------------- |
+| `omi goal list [--limit N --include-inactive]`         | `GET /v1/dev/user/goals`                                |
+| `omi goal get ID`                                      | `GET /v1/dev/user/goals/{id}`                           |
+| `omi goal create TITLE --target N [--type ...] [...]`  | `POST /v1/dev/user/goals`                               |
+| `omi goal update ID [...]`                             | `PATCH /v1/dev/user/goals/{id}`                         |
+| `omi goal progress ID VALUE`                           | `PATCH /v1/dev/user/goals/{id}/progress`                |
+| `omi goal history ID [--days N]`                       | `GET /v1/dev/user/goals/{id}/history`                   |
+| `omi goal delete ID [-y]`                              | `DELETE /v1/dev/user/goals/{id}`                        |
+
+Goal types: `boolean`, `scale`, `numeric`. Up to **3 active goals per user**;
+the oldest is deactivated automatically when you create a fourth.
+
+---
+
+## Environment variables
+
+| Variable          | Effect                                                                                  |
+| ----------------- | --------------------------------------------------------------------------------------- |
+| `OMI_API_KEY`     | Use this dev API key without persisting anything to disk. Validated against the prefix. |
+| `OMI_API_BASE`    | Override the API base URL (handy for staging or local backends).                        |
+| `OMI_PROFILE`     | Default profile name when `--profile` is not passed.                                    |
+| `OMI_CONFIG`      | Path to the config file (default `~/.omi/config.toml`).                                 |
+| `NO_COLOR`        | Disable color output (standard, see [no-color.org](https://no-color.org)).              |

--- a/docs/doc/developer/cli/install.mdx
+++ b/docs/doc/developer/cli/install.mdx
@@ -1,0 +1,73 @@
+---
+title: "Install"
+icon: "download"
+description: "Install omi-cli and confirm the binary is on your PATH."
+---
+
+## Install
+
+<Tabs>
+  <Tab title="pipx (recommended)">
+    ```bash
+    pipx install omi-cli
+    ```
+
+    `pipx` keeps `omi-cli` in its own isolated virtualenv so it can't conflict
+    with anything else on your system. If you don't have pipx yet:
+
+    ```bash
+    brew install pipx        # macOS
+    apt install pipx         # Debian/Ubuntu
+    pipx ensurepath
+    ```
+  </Tab>
+  <Tab title="pip">
+    ```bash
+    pip install omi-cli
+    ```
+
+    Suitable if you're already inside a virtualenv or you want the package
+    available alongside the rest of your project's deps.
+  </Tab>
+  <Tab title="From source">
+    ```bash
+    git clone https://github.com/BasedHardware/omi
+    cd omi/sdks/python-cli
+    pip install -e ".[dev]"
+    ```
+
+    Useful if you want to hack on the CLI itself. The `[dev]` extra brings in
+    `pytest`, `respx`, `black`, `mypy`, `isort`, and the build tooling.
+  </Tab>
+</Tabs>
+
+<Note>
+  The PyPI distribution name is `omi-cli` because the bare `omi` slot belongs
+  to an unrelated package. The console command is **`omi`** regardless.
+</Note>
+
+## Verify
+
+```bash
+omi --version
+# omi-cli 0.1.0
+
+omi --help
+```
+
+You should see the full command tree (`auth`, `config`, `memory`,
+`conversation`, `action-item`, `goal`).
+
+## Requirements
+
+- **Python 3.10+** — the package is tested on 3.10, 3.11, and 3.12.
+- **A network path to `https://api.omi.me`** — overridable via `--api-base` or
+  `$OMI_API_BASE` for staging or local environments.
+- **A developer API key** — see the [Quickstart](/doc/developer/cli/quickstart)
+  for how to generate one.
+
+## Where state lives
+
+`omi-cli` stores its config and credentials at `~/.omi/config.toml` (file
+permissions `0600`, parent dir `0700`). You can override the location with the
+`OMI_CONFIG` environment variable.

--- a/docs/doc/developer/cli/introduction.mdx
+++ b/docs/doc/developer/cli/introduction.mdx
@@ -1,0 +1,90 @@
+---
+title: "Introduction"
+icon: "terminal"
+description: "Talk to Omi from your terminal. Designed for humans and agents alike."
+---
+
+`omi-cli` is the command-line interface to the Omi developer API. It exposes
+scoped, JSON-friendly verbs for the four primary nouns Omi maintains about you,
+so you can drive Omi from shell pipelines, CI jobs, AI agent harnesses, or your
+own personal scripts.
+
+<CardGroup cols={2}>
+  <Card title="Memories" icon="brain">
+    Facts and learnings the system knows about you.
+  </Card>
+  <Card title="Conversations" icon="comments">
+    Captured & processed audio/text exchanges.
+  </Card>
+  <Card title="Action items" icon="list-check">
+    Tasks and follow-ups extracted from your captures.
+  </Card>
+  <Card title="Goals" icon="bullseye">
+    Tracked progress metrics over time.
+  </Card>
+</CardGroup>
+
+---
+
+## Why a CLI?
+
+Omi already ships:
+
+- a **Python SDK** ([`omi-sdk`](/doc/developer/sdk/python)) for Bluetooth and audio capture,
+- a **Flutter mobile app**, **macOS desktop app**, and
+- an **MCP server** ([`MCP`](/doc/developer/mcp/introduction)) for Claude Desktop and similar tools.
+
+What was missing was a **terminal-native, scriptable, JSON-emitting** interface
+to the data plane — the thing every modern dev tool ships (`gh`, `stripe`,
+`vercel`, `linear`) and the thing AI agents reach for first.
+
+`omi-cli` fills that gap. The same binary works equally well for a human
+reading their inbox of action items at the terminal and for an LLM agent
+piping `--json` output through `jq`.
+
+## What you can do with it
+
+```bash
+# Read your memories with a category filter, just the IDs and content as JSON:
+omi --json memory list --categories work,skills | jq '.[] | {id, content}'
+
+# Pipe the transcript of a meeting into a new conversation:
+cat meeting_notes.md | omi conversation create --text - --text-source message
+
+# Mark every action item older than 30 days as complete:
+omi --json action-item list --open \
+  | jq -r '.[] | select(.created_at < (now - 30*86400 | todate)) | .id' \
+  | xargs -I{} omi action-item complete {}
+
+# Track progress on a daily goal in a cron job:
+omi goal progress g_xyz "$(get_today_progress)"
+```
+
+## How it relates to MCP
+
+The two are complementary, not competing:
+
+- **MCP** is the right surface for AI assistants embedded in apps that speak
+  the Model Context Protocol (Claude Desktop, Cursor). It's invisible to you —
+  the LLM calls tools directly.
+- **CLI** is the right surface when you want a stable command line your
+  scripts, agents, and shell pipelines can drive — anywhere a process can run.
+
+Both hit the same Omi API and respect the same scopes.
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="Install" icon="download" href="/doc/developer/cli/install">
+    `pipx install omi-cli` and you're done.
+  </Card>
+  <Card title="Quickstart" icon="rocket" href="/doc/developer/cli/quickstart">
+    Your first five commands, end to end.
+  </Card>
+  <Card title="Command reference" icon="book" href="/doc/developer/cli/commands">
+    Every verb, every flag.
+  </Card>
+  <Card title="For agents" icon="robot" href="/doc/developer/cli/agents">
+    Agent contract, exit codes, JSON shape.
+  </Card>
+</CardGroup>

--- a/docs/doc/developer/cli/quickstart.mdx
+++ b/docs/doc/developer/cli/quickstart.mdx
@@ -1,0 +1,121 @@
+---
+title: "Quickstart"
+icon: "rocket"
+description: "Get from zero to a memory list in three commands."
+---
+
+This guide assumes you've already [installed `omi-cli`](/doc/developer/cli/install).
+
+## 1. Get a developer API key
+
+<Steps>
+  <Step title="Open the Omi web app">
+    Go to [`https://app.omi.me`](https://app.omi.me) and sign in.
+  </Step>
+  <Step title="Create a key">
+    Navigate to **Developer → API Keys** and click **Create key**.
+  </Step>
+  <Step title="Pick scopes">
+    Select the scopes you want this key to have. For a first-pass exploration,
+    grant all `:read` scopes; add `:write` as you need them. The CLI checks
+    the prefix of the key client-side so you'll fail fast on a typo.
+  </Step>
+  <Step title="Copy the key">
+    The key is shown **once** — copy it now. It looks like
+    `omi_dev_<32 hex chars>`.
+  </Step>
+</Steps>
+
+## 2. Log in
+
+<Tabs>
+  <Tab title="Interactive (preferred)">
+    ```bash
+    omi auth login
+    ```
+
+    The CLI prompts for the key with hidden input — your token never ends up
+    in shell history.
+  </Tab>
+  <Tab title="Headless / CI">
+    ```bash
+    export OMI_API_KEY=omi_dev_...
+    ```
+
+    The env var takes effect immediately; no on-disk config needed. The same
+    prefix validation runs, so a malformed value fails with a clear error
+    rather than a cryptic 401.
+  </Tab>
+  <Tab title="Stdin (also nice for CI)">
+    ```bash
+    omi auth login < /path/to/key.txt
+    ```
+
+    Useful when the key already lives in a secret manager and you can pipe it
+    in without ever displaying it.
+  </Tab>
+</Tabs>
+
+Confirm:
+
+```bash
+omi auth status
+```
+
+```text
+          omi auth status
+ profile        default
+ authenticated  ✓
+ auth_method    api_key
+ api_base       https://api.omi.me
+ credential     omi_de…a385
+```
+
+## 3. Read your data
+
+```bash
+omi memory list
+omi conversation list --limit 5
+omi action-item list --open
+omi goal list
+```
+
+Add `--json` (as a global flag, before the verb) for machine-readable output:
+
+```bash
+omi --json memory list --limit 25 | jq '.[] | {id, content, category}'
+```
+
+## 4. Make a change
+
+```bash
+# Create a memory:
+omi memory create "Prefers async over sync meetings" --category work --tag preferences
+
+# Mark an action item complete:
+omi action-item complete a1b2c3d4
+
+# Update goal progress:
+omi goal progress g_xyz 7
+```
+
+## Profiles
+
+Got more than one Omi account (e.g. personal + work)? Use named profiles:
+
+```bash
+omi config profile use work
+omi auth login                      # logs in the active profile
+omi --profile personal memory list  # one-off override
+```
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Command reference" icon="book" href="/doc/developer/cli/commands">
+    Every verb, every flag.
+  </Card>
+  <Card title="For agents" icon="robot" href="/doc/developer/cli/agents">
+    Stable JSON contract + exit codes for LLM use.
+  </Card>
+</CardGroup>

--- a/docs/doc/developer/cli/quickstart.mdx
+++ b/docs/doc/developer/cli/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Quickstart"
 icon: "rocket"
-description: "Get from zero to a memory list in three commands."
+description: "Get from zero to your data in four steps: get a key, log in, read, write."
 ---
 
 This guide assumes you've already [installed `omi-cli`](/doc/developer/cli/install).

--- a/docs/doc/developer/cli/troubleshooting.mdx
+++ b/docs/doc/developer/cli/troubleshooting.mdx
@@ -1,0 +1,128 @@
+---
+title: "Troubleshooting"
+icon: "wrench"
+description: "Common failure modes and how to fix them."
+---
+
+## "Not authenticated" (exit 2)
+
+```text
+✗ Not authenticated
+  Run `omi auth login` and paste your dev API key. (See `omi auth login --help`.)
+```
+
+The active profile has no credentials. Either:
+
+- Run `omi auth login` and paste a dev key, or
+- `export OMI_API_KEY=omi_dev_...` in the current shell.
+
+Confirm with `omi auth status`.
+
+## "That doesn't look like an Omi developer key" (exit 1)
+
+The CLI validates the key's prefix client-side before ever calling the API.
+Real dev keys start with `omi_dev_` and are at least ~24 characters long.
+
+If you see this from `OMI_API_KEY`, double-check that you pasted the whole
+token and didn't accidentally include `Bearer ` or wrap it in quotes that
+made it into the env value.
+
+## "Insufficient permissions" (exit 2)
+
+```text
+✗ Insufficient permissions
+  Your API key does not have the required scope for this operation.
+```
+
+The dev key was minted without the scope you're trying to exercise. For
+example, `omi memory create` requires `memories:write` but a read-only key
+only has `memories:read`.
+
+Generate a new key in the Omi web app under **Developer → API Keys** with the
+scope you need, then `omi auth login` to swap it in.
+
+## "Rate limited" (exit 4)
+
+```text
+✗ Rate limited: dev:conversations (25/hr)
+  Retry in 12s. Slow down and retry shortly.
+```
+
+The dev API enforces hourly limits per policy:
+
+| Policy                | Limit      |
+| --------------------- | ---------- |
+| `dev:conversations`   | 25 / hour  |
+| `dev:memories`        | 120 / hour |
+| `dev:memories_batch`  | 15 / hour  |
+
+The CLI retries automatically up to 4 attempts with backoff before raising. If
+you're seeing the error code from a script, sleep for the `Retry in Ns` value
+and try again — see [For agents](/doc/developer/cli/agents) for a worked
+backoff example.
+
+## "Server error" (exit 3)
+
+```text
+✗ Server error (502)
+  The Omi API returned an error. Try again, then check status.omi.me.
+```
+
+A `5xx` response from the API after retries exhausted. The CLI already retried
+4 times with backoff, so the issue is server-side. Try again in a minute; if
+the problem persists, check the Omi status page or report it.
+
+## "No such option: --json" with the flag after the verb
+
+```bash
+omi memory list --json   # ❌ wrong
+omi --json memory list   # ✅ right
+```
+
+Global flags must come **before** the subcommand. This is a Click framework
+constraint.
+
+## Token rolled back after a failed login verification
+
+If `omi auth login` succeeds but the verification round-trip returns 401, the
+CLI clears the just-stored credential — better to be unauthenticated than
+silently broken. The fix: regenerate the key in the Omi web app and try
+again. Network errors don't trigger the rollback (the credential is kept and
+the CLI just warns).
+
+## Where state lives
+
+```bash
+omi config path
+# /Users/you/.omi/config.toml
+```
+
+Permissions are owner-only (`0600` for the file, `0700` for the parent dir).
+If you ever see permissions other than these, something modified the file
+outside of `omi-cli` — fix with `chmod 600 ~/.omi/config.toml`.
+
+To wipe everything:
+
+```bash
+omi auth logout
+# or, nuclear option:
+rm -rf ~/.omi/
+```
+
+## Verbose mode for debugging
+
+```bash
+omi -v memory list
+# [debug] GET /v1/dev/user/memories → 200 (0.42s)
+```
+
+Debug output goes to stderr; stdout stays clean for piping. Combine with
+`--json` if your script expects JSON.
+
+## Still stuck?
+
+- Check the [Command reference](/doc/developer/cli/commands) for the exact
+  expected flags.
+- File an issue at
+  [github.com/BasedHardware/omi](https://github.com/BasedHardware/omi/issues)
+  with the failing command, the full stderr, and the `omi --version` output.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -234,6 +234,33 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "CLI",
+        "icon": "terminal",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "doc/developer/cli/introduction",
+              "doc/developer/cli/install",
+              "doc/developer/cli/quickstart"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "doc/developer/cli/commands"
+            ]
+          },
+          {
+            "group": "Resources",
+            "pages": [
+              "doc/developer/cli/agents",
+              "doc/developer/cli/troubleshooting"
+            ]
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## ⚠️ Do not merge yet — please review first

Adds a new top-level **CLI** tab to the Mintlify navigation, alongside Documentation / API Reference / Build Apps / Hardware / MCP. Follow-up to PR #7027 which shipped the `omi-cli` package.

## Summary

New tab: **CLI** (icon: `terminal`).
New section in nav: \`doc/developer/cli/\` with 6 MDX pages.

| Page | Group | Purpose |
|------|-------|---------|
| introduction | Getting Started | What `omi-cli` is, why it exists, how it relates to the SDK and MCP |
| install | Getting Started | pipx / pip / from-source install paths + verify |
| quickstart | Getting Started | Get-a-key-to-real-data in 4 steps |
| commands | Reference | Full verb tree, every flag, env vars, link to endpoints |
| agents | Resources | Stable JSON contract, exit codes, retry semantics, worked Python harness |
| troubleshooting | Resources | Common errors mapped to exit codes and fixes |

## Why this and not just the package README?

The README in \`sdks/python-cli/\` is for someone who's already at the source.
Mintlify is the front door for users who haven't installed anything yet —
they're searching, browsing, and comparing the CLI to MCP and the SDK. A
top-level tab puts the CLI on equal footing with those entry points (which is
the right shape: agents in particular reach for whichever surface their
harness supports).

## Where the content came from

- **introduction / install / quickstart / commands** are the same shape as the
  MCP tab, populated from the package's own README + first-hand verification
  against \`api.omi.me\` post-merge of #7027.
- **agents** ports the worked Python example from \`examples/agent_quickstart.md\`
  and adds the rate-limit policy mapping that's only documented inside the
  backend (see \`backend/utils/rate_limit_config.py:82-84\`).
- **troubleshooting** maps the stable exit codes from \`omi_cli/errors.py\` to
  user-friendly fixes, including the \`mix_stderr\` and \`--json\` flag-position
  gotchas surfaced during the launch test.

## Quality gates

- \`docs/docs.json\` validated as JSON.
- Internal links use the canonical \`/doc/developer/cli/...\` paths.
- No external links to URLs that don't exist (e.g. dev keys page is referenced
  by description, not deep-linked, since the marketing route may move).

## Test plan

- [ ] \`pnpm dev\` (or whatever the docs preview command is) renders the new
      tab without errors.
- [ ] Click through every page in the new tab; verify all internal links
      resolve.
- [ ] \`docs/docs.json\` schema check passes (Mintlify build).
- [ ] Compare the new pages against the merged \`sdks/python-cli/README.md\` for
      drift (commands, env vars, exit codes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)