### PR TITLE
Add missing env var placeholders to dev backend-listen chart

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -319,6 +319,16 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: METRICS_SECRET
+  - name: GROQ_API_KEY
+    value: "PLACEHOLDER_GROQ_API_KEY"
+  - name: OPENROUTER_API_KEY
+    value: "PLACEHOLDER_OPENROUTER_API_KEY"
+  - name: RAPID_API_HOST
+    value: "PLACEHOLDER_RAPID_API_HOST"
+  - name: RAPID_API_KEY
+    value: "PLACEHOLDER_RAPID_API_KEY"
+  - name: CONVERSATION_SUMMARIZED_APP_IDS
+    value: "PLACEHOLDER_CONVERSATION_SUMMARIZED_APP_IDS"
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -320,15 +320,30 @@ env:
         name: dev-omi-backend-secrets
         key: METRICS_SECRET
   - name: GROQ_API_KEY
-    value: "PLACEHOLDER_GROQ_API_KEY"
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: GROQ_API_KEY
   - name: OPENROUTER_API_KEY
-    value: "PLACEHOLDER_OPENROUTER_API_KEY"
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: OPENROUTER_API_KEY
   - name: RAPID_API_HOST
-    value: "PLACEHOLDER_RAPID_API_HOST"
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: RAPID_API_HOST
   - name: RAPID_API_KEY
-    value: "PLACEHOLDER_RAPID_API_KEY"
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: RAPID_API_KEY
   - name: CONVERSATION_SUMMARIZED_APP_IDS
-    value: "PLACEHOLDER_CONVERSATION_SUMMARIZED_APP_IDS"
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: CONVERSATION_SUMMARIZED_APP_IDS
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
@@ -70,3 +70,13 @@ externalSecret:
       remoteKey: TWILIO_TWIML_APP_SID
     - secretKey: METRICS_SECRET
       remoteKey: METRICS_SECRET
+    - secretKey: GROQ_API_KEY
+      remoteKey: GROQ_API_KEY
+    - secretKey: OPENROUTER_API_KEY
+      remoteKey: OPENROUTER_API_KEY
+    - secretKey: RAPID_API_HOST
+      remoteKey: RAPID_API_HOST
+    - secretKey: RAPID_API_KEY
+      remoteKey: RAPID_API_KEY
+    - secretKey: CONVERSATION_SUMMARIZED_APP_IDS
+      remoteKey: CONVERSATION_SUMMARIZED_APP_IDS


### PR DESCRIPTION
## Summary
- Add 5 env vars present in prod but missing from dev backend-listen
- Variables: `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `RAPID_API_HOST`, `RAPID_API_KEY`, `CONVERSATION_SUMMARIZED_APP_IDS`
- Add secret key mappings to ExternalSecret values (backend-secrets chart) for GCP SM → K8s sync
- Use `secretKeyRef` pattern in backend-listen chart (consistent with existing secret refs)

## GCP Secret Manager status (based-hardware-dev)
| Secret | Status |
|--------|--------|
| GROQ_API_KEY | Created with `PLACEHOLDER_GROQ_API_KEY` value |
| OPENROUTER_API_KEY | Already existed (real value, 73 chars) |
| RAPID_API_HOST | Already existed (real value, 28 chars) |
| RAPID_API_KEY | Already existed (real value, 50 chars) |
| CONVERSATION_SUMMARIZED_APP_IDS | Created with `PLACEHOLDER_CONVERSATION_SUMMARIZED_APP_IDS` value |

## Context
Beta users are routed to dev backends (PR #7014). Env var audit found these 5 vars exist in prod backend-listen but are absent in dev GKE deployment.

## Test plan
- [ ] Deploy backend-secrets chart first (syncs new keys to K8s secret)
- [ ] Deploy backend-listen chart (pods pick up new env vars)
- [ ] Verify pods start without CrashLoopBackOff
- [ ] Replace 2 placeholder values (GROQ_API_KEY, CONVERSATION_SUMMARIZED_APP_IDS) with real values when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)