### PR TITLE
feat(omi-cli + auth): browser OAuth flow + interactive auth picker (v0.2.0)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -5,7 +5,7 @@ import hashlib
 import time
 import jwt
 from typing import Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from cryptography.hazmat.primitives import serialization
 from jwt.algorithms import RSAAlgorithm
 from fastapi import APIRouter, Request, HTTPException, Form
@@ -30,6 +30,47 @@ templates_path = pathlib.Path(__file__).parent.parent / "templates"
 templates = Jinja2Templates(directory=str(templates_path))
 
 
+# Loopback hosts permitted for CLI/native-app OAuth flows per RFC 8252
+# (Native Apps). The mobile app uses ``omi://`` which is allowed separately.
+# Anything else is rejected so an attacker cannot route the auth code to a
+# host they control.
+_LOOPBACK_HOSTNAMES = {"localhost", "127.0.0.1", "::1"}
+_DEFAULT_MOBILE_REDIRECT = "omi://auth/callback"
+
+
+def _validate_redirect_uri(redirect_uri: str) -> None:
+    """Reject everything except the mobile deep link and HTTP loopback URIs.
+
+    Security note: the auth ``code`` (a one-time secret) is delivered to the
+    ``redirect_uri`` the original requester provided. If we accepted arbitrary
+    URLs, a malicious actor who got a user to start a flow could harvest the
+    code at their own host. Restricting to the mobile scheme + loopback
+    addresses is the standard mitigation (RFC 8252 §7).
+    """
+    if not redirect_uri:
+        raise HTTPException(status_code=400, detail="redirect_uri is required")
+
+    if redirect_uri.startswith("omi://"):
+        # Allow any path under the mobile deep-link scheme.
+        return
+
+    parsed = urlparse(redirect_uri)
+    if parsed.scheme != "http":
+        raise HTTPException(
+            status_code=400,
+            detail="redirect_uri must use the omi:// scheme or http loopback (http://localhost:PORT)",
+        )
+
+    hostname = (parsed.hostname or "").strip().lower()
+    if hostname not in _LOOPBACK_HOSTNAMES:
+        raise HTTPException(
+            status_code=400,
+            detail="HTTP redirect_uri must point at loopback (localhost, 127.0.0.1, or ::1)",
+        )
+
+    return
+
+
 @router.get("/authorize")
 async def auth_authorize(
     request: Request,
@@ -43,6 +84,9 @@ async def auth_authorize(
     """
     if provider not in ['google', 'apple']:
         raise HTTPException(status_code=400, detail="Unsupported provider")
+
+    # Strict allowlist on where we'll deliver the auth code post-callback.
+    _validate_redirect_uri(redirect_uri)
 
     # Store session for auth flow
     session_id = str(uuid.uuid4())
@@ -88,14 +132,16 @@ async def auth_callback_google(
     auth_code = str(uuid.uuid4())
     set_auth_code(auth_code, oauth_credentials, 300)
 
-    # Redirect to HTML page that will handle custom scheme redirect
-    # This avoids browser security issues with backend->custom scheme redirects
+    # Redirect to HTML page that will handle the eventual scheme/loopback redirect.
+    # The original ``redirect_uri`` was validated by ``_validate_redirect_uri`` at
+    # ``/authorize`` time and cannot be overridden by the caller here.
     return templates.TemplateResponse(
         "auth_callback.html",
         {
             "request": request,
             "code": auth_code,
             "state": session_data['state'] or '',
+            "redirect_uri": session_data.get('redirect_uri') or _DEFAULT_MOBILE_REDIRECT,
         },
     )
 
@@ -126,14 +172,16 @@ async def auth_callback_apple_post(
     auth_code = str(uuid.uuid4())
     set_auth_code(auth_code, oauth_credentials, 300)
 
-    # Redirect to HTML page that will handle custom scheme redirect
-    # This avoids browser security issues with backend->custom scheme redirects
+    # Redirect to HTML page that will handle the eventual scheme/loopback redirect.
+    # The original ``redirect_uri`` was validated by ``_validate_redirect_uri`` at
+    # ``/authorize`` time and cannot be overridden by the caller here.
     return templates.TemplateResponse(
         "auth_callback.html",
         {
             "request": request,
             "code": auth_code,
             "state": session_data['state'] or '',
+            "redirect_uri": session_data.get('redirect_uri') or _DEFAULT_MOBILE_REDIRECT,
         },
     )
 

--- a/backend/templates/auth_callback.html
+++ b/backend/templates/auth_callback.html
@@ -92,15 +92,32 @@
     </div>
 
     <script>
-        // Get values from template variables (passed from backend)
+        // Get values from template variables (passed from backend).
+        // ``baseRedirect`` was validated server-side at /authorize time; here
+        // we still re-check the scheme/host before navigating, as defense in
+        // depth against a misconfigured upstream.
         const code = "{{ code }}";
         const state = "{{ state }}";
         const error = "{{ error if error is defined else '' }}";
+        const baseRedirect = "{{ redirect_uri | default('omi://auth/callback') }}";
 
         const errorElement = document.getElementById('error');
         const messageElement = document.getElementById('message');
         const spinnerElement = document.getElementById('spinner');
         const manualLinkElement = document.getElementById('manualLink');
+
+        function isAllowedRedirect(uri) {
+            if (!uri) return false;
+            if (uri.indexOf('omi://') === 0) return true;
+            try {
+                const u = new URL(uri);
+                if (u.protocol !== 'http:') return false;
+                const host = u.hostname.toLowerCase();
+                return host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+            } catch (_) {
+                return false;
+            }
+        }
 
         if (error) {
             // Handle OAuth error
@@ -108,32 +125,58 @@
             spinnerElement.style.display = 'none';
             messageElement.textContent = 'Please close this window and try again.';
         } else if (code) {
-            // Build the custom scheme redirect URL
-            let redirectUrl = 'omi://auth/callback?code=' + encodeURIComponent(code);
-            if (state) {
-                redirectUrl += '&state=' + encodeURIComponent(state);
-            }
+            if (!isAllowedRedirect(baseRedirect)) {
+                errorElement.textContent = 'Invalid redirect target. Please close this window.';
+                spinnerElement.style.display = 'none';
+                messageElement.textContent = '';
+            } else {
+                // Append code + state preserving any existing query params.
+                const sep = baseRedirect.indexOf('?') === -1 ? '?' : '&';
+                let redirectUrl = baseRedirect + sep + 'code=' + encodeURIComponent(code);
+                if (state) {
+                    redirectUrl += '&state=' + encodeURIComponent(state);
+                }
+                const isLoopback = redirectUrl.indexOf('http://') === 0;
 
-            // Set up manual link
-            manualLinkElement.href = redirectUrl;
+                // Loopback users (CLI / desktop apps) get a "you can close this tab" hint —
+                // their localhost server picks up the code automatically. Mobile users get
+                // the existing manual-link fallback in case the deep link doesn't fire.
+                if (isLoopback) {
+                    messageElement.textContent = 'Returning to your terminal — you can close this tab.';
+                } else {
+                    messageElement.textContent = 'Redirecting you back to the app...';
+                }
 
-            // Attempt automatic redirect
-            try {
-                console.log('Redirecting to:', redirectUrl);
-                window.location.href = redirectUrl;
+                // Set up manual link
+                manualLinkElement.href = redirectUrl;
+                if (isLoopback) {
+                    manualLinkElement.textContent = 'Open Manually';
+                }
 
-                // Show manual link after 3 seconds if automatic redirect doesn't work
-                setTimeout(() => {
-                    messageElement.textContent = 'If the app doesn\'t open automatically, click below:';
+                // Attempt automatic redirect
+                try {
+                    console.log('Redirecting to:', redirectUrl);
+                    window.location.href = redirectUrl;
+
+                    // Show manual link after 3 seconds if automatic redirect doesn't work
+                    setTimeout(() => {
+                        if (isLoopback) {
+                            messageElement.textContent = 'If your terminal didn\'t pick it up, click below:';
+                        } else {
+                            messageElement.textContent = 'If the app doesn\'t open automatically, click below:';
+                        }
+                        spinnerElement.style.display = 'none';
+                        manualLinkElement.style.display = 'inline-block';
+                    }, 3000);
+                } catch (e) {
+                    console.error('Redirect error:', e);
+                    errorElement.textContent = isLoopback
+                        ? 'Could not automatically redirect to your local CLI.'
+                        : 'Could not automatically redirect to the app.';
+                    messageElement.textContent = 'Please click below to continue:';
                     spinnerElement.style.display = 'none';
                     manualLinkElement.style.display = 'inline-block';
-                }, 3000);
-            } catch (e) {
-                console.error('Redirect error:', e);
-                errorElement.textContent = 'Could not automatically redirect to the app.';
-                messageElement.textContent = 'Please click below to continue:';
-                spinnerElement.style.display = 'none';
-                manualLinkElement.style.display = 'inline-block';
+                }
             }
         } else {
             // No code or error in URL

--- a/backend/templates/auth_callback.html
+++ b/backend/templates/auth_callback.html
@@ -112,8 +112,10 @@
             try {
                 const u = new URL(uri);
                 if (u.protocol !== 'http:') return false;
+                // URL.hostname returns the bracketless form for IPv6 — compare
+                // against the bare ``::1`` rather than ``[::1]``.
                 const host = u.hostname.toLowerCase();
-                return host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+                return host === 'localhost' || host === '127.0.0.1' || host === '::1';
             } catch (_) {
                 return false;
             }

--- a/docs/doc/developer/cli/agents.mdx
+++ b/docs/doc/developer/cli/agents.mdx
@@ -35,16 +35,28 @@ omi --json memory list --limit 25 | jq '.[] | {id, content, category}'
 These codes are **part of the contract** — they won't shift between minor
 versions. Branch on them in your harness without parsing English errors.
 
-## Authentication
+## Authentication: API key vs browser OAuth
 
-For agents, prefer the env-var path:
+The CLI supports both — but for **agents** specifically, the API-key path is
+almost always the right call:
+
+| Need                                | Use this                  |
+| ----------------------------------- | ------------------------- |
+| Headless / CI / container runtime   | `OMI_API_KEY` env var     |
+| Long-running unattended automation  | API key                   |
+| Scoped permissions                  | API key (granular scopes) |
+| Interactive use by a human          | `omi auth login --browser`|
+
+API keys are long-lived, scoped, and don't need a browser — perfect for
+agents. The browser OAuth flow exists for humans on a laptop and uses
+short-lived Firebase ID tokens that auto-refresh between calls.
 
 ```bash
 export OMI_API_KEY=omi_dev_...
 ```
 
-The on-disk config file is great for humans on a laptop but a footgun in
-shared CI runners. The env var injection runs the same prefix validation as
+The on-disk config file is great for humans but a footgun in shared CI
+runners. The env var injection runs the same prefix validation as
 `omi auth login` so a malformed value still fails fast with exit `1`.
 
 ## Retry behavior

--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -39,15 +39,20 @@ omi
 
 ## `omi auth`
 
-| Command                       | Notes                                                           |
-| ----------------------------- | --------------------------------------------------------------- |
-| `omi auth login`              | Hidden-input prompt for a dev API key.                          |
-| `omi auth login --api-key K`  | Headless. Exposes the key in `ps`/history — prefer the prompt.  |
-| `omi auth login --browser`    | OAuth browser flow. **Coming in v0.2.0.**                       |
-| `omi auth logout`             | Clear the active profile's credentials.                         |
-| `omi auth status`             | Show profile + masked credential + API base.                    |
-| `omi auth whoami`             | Round-trip to the API to verify the credential is valid.        |
-| `omi auth refresh`            | OAuth-only (no-op with API keys).                               |
+| Command                                | Notes                                                                            |
+| -------------------------------------- | -------------------------------------------------------------------------------- |
+| `omi auth login`                       | Interactive prompt: pick browser OAuth or paste an API key.                      |
+| `omi auth login --browser`             | Force the Firebase OAuth browser flow (default provider: Google).                |
+| `omi auth login --browser --provider apple` | Same flow, Apple Sign-In.                                                   |
+| `omi auth login --api-key K`           | Force the API-key path. Exposes the key in `ps`/history — prefer the prompt.    |
+| `omi auth logout`                      | Clear the active profile's credentials.                                          |
+| `omi auth status`                      | Show profile + masked credential + API base. OAuth profiles also show expiry.    |
+| `omi auth whoami`                      | Round-trip to the API to verify the credential is valid.                         |
+| `omi auth refresh`                     | Force-refresh the OAuth ID token. No-op for API-key profiles.                    |
+
+OAuth ID tokens are auto-refreshed before each request when the cached token
+is past (or near) its expiry — you should rarely need to call `refresh` by
+hand. The refresh token rotates if Firebase decides to.
 
 ## `omi config`
 

--- a/docs/doc/developer/cli/install.mdx
+++ b/docs/doc/developer/cli/install.mdx
@@ -4,6 +4,9 @@ icon: "download"
 description: "Install omi-cli and confirm the binary is on your PATH."
 ---
 
+`omi-cli` is published on PyPI: [pypi.org/project/omi-cli](https://pypi.org/project/omi-cli/).
+Source lives in the [Omi monorepo](https://github.com/BasedHardware/omi/tree/main/sdks/python-cli).
+
 ## Install
 
 <Tabs>
@@ -50,7 +53,7 @@ description: "Install omi-cli and confirm the binary is on your PATH."
 
 ```bash
 omi --version
-# omi-cli 0.1.0
+# omi-cli 0.2.0
 
 omi --help
 ```
@@ -63,8 +66,9 @@ You should see the full command tree (`auth`, `config`, `memory`,
 - **Python 3.10+** — the package is tested on 3.10, 3.11, and 3.12.
 - **A network path to `https://api.omi.me`** — overridable via `--api-base` or
   `$OMI_API_BASE` for staging or local environments.
-- **A developer API key** — see the [Quickstart](/doc/developer/cli/quickstart)
-  for how to generate one.
+- **A way to authenticate** — either a Google/Apple account (browser OAuth)
+  or a developer API key from the Omi web app. The
+  [Quickstart](/doc/developer/cli/quickstart) walks through both.
 
 ## Where state lives
 

--- a/docs/doc/developer/cli/introduction.mdx
+++ b/docs/doc/developer/cli/introduction.mdx
@@ -9,6 +9,10 @@ scoped, JSON-friendly verbs for the four primary nouns Omi maintains about you,
 so you can drive Omi from shell pipelines, CI jobs, AI agent harnesses, or your
 own personal scripts.
 
+* **PyPI:** [pypi.org/project/omi-cli](https://pypi.org/project/omi-cli/)
+* **Source:** [github.com/BasedHardware/omi/tree/main/sdks/python-cli](https://github.com/BasedHardware/omi/tree/main/sdks/python-cli)
+* **Install:** `pipx install omi-cli`
+
 <CardGroup cols={2}>
   <Card title="Memories" icon="brain">
     Facts and learnings the system knows about you.

--- a/docs/doc/developer/cli/quickstart.mdx
+++ b/docs/doc/developer/cli/quickstart.mdx
@@ -1,41 +1,56 @@
 ---
 title: "Quickstart"
 icon: "rocket"
-description: "Get from zero to your data in four steps: get a key, log in, read, write."
+description: "Get from zero to your data — pick browser OAuth or paste a dev API key."
 ---
 
 This guide assumes you've already [installed `omi-cli`](/doc/developer/cli/install).
 
-## 1. Get a developer API key
+## 1. Log in
 
-<Steps>
-  <Step title="Open the Omi web app">
-    Go to [`https://app.omi.me`](https://app.omi.me) and sign in.
-  </Step>
-  <Step title="Create a key">
-    Navigate to **Developer → API Keys** and click **Create key**.
-  </Step>
-  <Step title="Pick scopes">
-    Select the scopes you want this key to have. For a first-pass exploration,
-    grant all `:read` scopes; add `:write` as you need them. The CLI checks
-    the prefix of the key client-side so you'll fail fast on a typo.
-  </Step>
-  <Step title="Copy the key">
-    The key is shown **once** — copy it now. It looks like
-    `omi_dev_<32 hex chars>`.
-  </Step>
-</Steps>
+`omi auth login` (with no flags) asks how you'd like to authenticate:
 
-## 2. Log in
+```text
+$ omi auth login
+How would you like to log in?
+  1) Browser  — sign in with Google or Apple via OAuth (recommended for humans)
+  2) API key  — paste a developer key from app.omi.me (recommended for agents/CI)
+Choose 1 or 2 [1]: _
+```
 
 <Tabs>
-  <Tab title="Interactive (preferred)">
+  <Tab title="Browser (humans)">
     ```bash
-    omi auth login
+    omi auth login            # pick option 1
+    # or skip the prompt:
+    omi auth login --browser
     ```
 
-    The CLI prompts for the key with hidden input — your token never ends up
-    in shell history.
+    The CLI starts a localhost callback server on an ephemeral port, opens
+    your default browser to Omi's auth page, and waits for the callback.
+    Sign in with Google (or `--provider apple`) and you're back at the
+    terminal — no copying tokens around.
+
+    Tokens are stored at `~/.omi/config.toml` (file mode `0600`). The
+    short-lived Firebase ID token is auto-refreshed before each request
+    using the long-lived refresh token.
+  </Tab>
+  <Tab title="API key (agents, CI)">
+    ```bash
+    omi auth login --api-key omi_dev_...
+    ```
+
+    Or interactively (input is hidden — your token never lands in shell
+    history):
+
+    ```bash
+    omi auth login            # pick option 2
+    ```
+
+    Generate a dev API key in the Omi web app under **Developer → API Keys**.
+    Choose the scopes you want — `memories:read`, `memories:write`,
+    `conversations:read`, etc. The CLI validates the `omi_dev_` prefix
+    client-side so you fail fast on a typo.
   </Tab>
   <Tab title="Headless / CI">
     ```bash
@@ -44,15 +59,17 @@ This guide assumes you've already [installed `omi-cli`](/doc/developer/cli/insta
 
     The env var takes effect immediately; no on-disk config needed. The same
     prefix validation runs, so a malformed value fails with a clear error
-    rather than a cryptic 401.
+    rather than a cryptic 401. Pair with `--api-base` if you're targeting a
+    staging backend.
   </Tab>
-  <Tab title="Stdin (also nice for CI)">
+  <Tab title="Stdin">
     ```bash
     omi auth login < /path/to/key.txt
     ```
 
-    Useful when the key already lives in a secret manager and you can pipe it
-    in without ever displaying it.
+    Useful when the key lives in a secret manager and you can pipe it in
+    without ever displaying it. (Browser flow doesn't work over stdin —
+    the CLI assumes piped input is an API key.)
   </Tab>
 </Tabs>
 
@@ -64,14 +81,15 @@ omi auth status
 
 ```text
           omi auth status
- profile        default
- authenticated  ✓
- auth_method    api_key
- api_base       https://api.omi.me
- credential     omi_de…a385
+ profile               default
+ authenticated         ✓
+ auth_method           oauth
+ api_base              https://api.omi.me
+ credential            eyJhbG…1234
+ id_token_expires_at   1714142400.0
 ```
 
-## 3. Read your data
+## 2. Read your data
 
 ```bash
 omi memory list
@@ -86,7 +104,7 @@ Add `--json` (as a global flag, before the verb) for machine-readable output:
 omi --json memory list --limit 25 | jq '.[] | {id, content, category}'
 ```
 
-## 4. Make a change
+## 3. Make a change
 
 ```bash
 # Create a memory:
@@ -108,6 +126,9 @@ omi config profile use work
 omi auth login                      # logs in the active profile
 omi --profile personal memory list  # one-off override
 ```
+
+Each profile has its own auth method, credential, and API base. You can mix
+browser-OAuth in your personal profile with an API-key in a CI profile.
 
 ## Where to go next
 

--- a/docs/doc/developer/cli/troubleshooting.mdx
+++ b/docs/doc/developer/cli/troubleshooting.mdx
@@ -90,6 +90,53 @@ silently broken. The fix: regenerate the key in the Omi web app and try
 again. Network errors don't trigger the rollback (the credential is kept and
 the CLI just warns).
 
+## OAuth: "OAuth flow timed out"
+
+```text
+✗ OAuth flow timed out
+  No callback received within 5 minutes. Try again, or use `omi auth login --api-key` instead.
+```
+
+The CLI started a localhost server, opened your browser, and waited 5
+minutes for the callback. Possible causes:
+
+- Browser didn't open. Visit the URL the CLI printed manually.
+- A firewall blocked the loopback redirect. Try `--api-key` instead.
+- You closed the browser tab before the redirect fired.
+
+The CLI cleans up after itself; just rerun `omi auth login --browser`.
+
+## OAuth: "OAuth state mismatch"
+
+```text
+✗ OAuth state mismatch
+  The browser callback did not match the original session token. Possible CSRF — aborting.
+```
+
+The CSRF protection caught a mismatch — the `state` token in the callback
+URL didn't match what the CLI generated. This shouldn't happen in practice;
+if it does, run `omi auth login --browser` again. Don't paste random URLs.
+
+## OAuth: "Firebase refresh failed"
+
+```text
+✗ Firebase refresh failed (401)
+  Re-run `omi auth login --browser` to get fresh credentials.
+```
+
+The stored refresh token is no longer valid (revoked, signed out elsewhere,
+or rotated and the rotation didn't persist). Run `omi auth login --browser`
+to mint a fresh pair. Your data is safe; only the local credentials are
+stale.
+
+## OAuth: which provider?
+
+By default, `omi auth login --browser` uses Google. To use Apple Sign-In:
+
+```bash
+omi auth login --browser --provider apple
+```
+
 ## Where state lives
 
 ```bash

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -15,6 +15,10 @@ It's intentionally small, scriptable, and JSON-first — everything you need to
 plug Omi into shell pipelines, CI jobs, agent harnesses, or just your own
 personal automation.
 
+* **PyPI:** [pypi.org/project/omi-cli](https://pypi.org/project/omi-cli/)
+* **Docs:** [docs.omi.me/doc/developer/cli/introduction](https://docs.omi.me/doc/developer/cli/introduction)
+* **Source:** [github.com/BasedHardware/omi/tree/main/sdks/python-cli](https://github.com/BasedHardware/omi/tree/main/sdks/python-cli)
+
 ## Install
 
 ```bash
@@ -36,46 +40,48 @@ omi --help
 ## Quickstart
 
 ```bash
-# 1. Generate a developer API key in the Omi web app:
-#    https://app.omi.me   →   Developer   →   API Keys
-#    Choose the scopes you want this CLI to be able to exercise.
-
-# 2. Log in (the prompt is hidden — your key never lands in shell history):
+# 1. Log in. With no flags, omi-cli asks how you want to authenticate:
 omi auth login
+# → 1) Browser — sign in with Google or Apple (recommended for humans)
+# → 2) API key — paste a developer key from app.omi.me (recommended for agents/CI)
 
-# 3. Start using it:
+# 2. Start using it:
 omi memory list
 omi conversation list --limit 5
 omi action-item list --open
 omi goal list
 ```
 
-Pass `--json` to any command to get machine-readable output, ready for `jq`,
-agent harnesses, or whatever else:
+Pass `--json` to any command (as a global flag, before the verb) to get
+machine-readable output, ready for `jq`, agent harnesses, or whatever else:
 
 ```bash
-omi memory list --json | jq '.[] | {id, content}'
+omi --json memory list | jq '.[] | {id, content}'
 ```
 
 ## Auth
 
-Two auth methods are wired:
+Two auth methods, both fully wired:
 
-| Method                      | Status   | Use it for                    |
-| --------------------------- | -------- | ----------------------------- |
-| Dev API key (`omi_dev_*`)   | ✅ v0.1.0 | Agents, CI, headless, default |
-| Firebase OAuth (`--browser`) | 🚧 v0.2.0 | Humans on a laptop            |
+| Method                       | Best for                                 | How to use                                |
+| ---------------------------- | ---------------------------------------- | ----------------------------------------- |
+| Dev API key (`omi_dev_*`)    | Agents, CI, headless, scoped permissions | `omi auth login --api-key ...` or env var |
+| Firebase OAuth (Google/Apple) | Humans on a laptop                       | `omi auth login --browser`                |
 
-The browser flow is currently stubbed with a clear message; for now generate a
-dev key in the Omi web app and paste it into `omi auth login`. API keys are
-the right choice for agents anyway — they're long-lived, scoped, and don't
-need a browser.
+The browser flow opens your default browser for OAuth, captures the code on a
+localhost callback, and stores a Firebase ID token + refresh token. The ID
+token is auto-refreshed before each request when it's near expiry — you
+shouldn't need to think about it.
 
 ```bash
-omi auth login                  # interactive paste, hidden input
-omi auth login < key.txt        # piped, useful in CI
-omi auth status                 # show profile + masked credential
+omi auth login                  # interactive picker (browser or key)
+omi auth login --browser        # force OAuth (default provider: google)
+omi auth login --browser --provider apple
+omi auth login --api-key K      # force API-key path
+omi auth login < key.txt        # piped key, useful in CI
+omi auth status                 # show profile + masked credential + expiry
 omi auth whoami                 # round-trip to verify the credential works
+omi auth refresh                # force a Firebase refresh (no-op for API keys)
 omi auth logout                 # wipe the credential
 ```
 

--- a/sdks/python-cli/omi_cli/__init__.py
+++ b/sdks/python-cli/omi_cli/__init__.py
@@ -4,5 +4,5 @@ Provides scoped access to memories, conversations, action items, and goals via
 the developer API surface (`/v1/dev/*`). Designed for agents and humans alike.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["__version__"]

--- a/sdks/python-cli/omi_cli/auth/__init__.py
+++ b/sdks/python-cli/omi_cli/auth/__init__.py
@@ -3,19 +3,23 @@
 Two flows are wired through this package:
 
 * :mod:`omi_cli.auth.api_key` — paste-in dev API key (``omi_dev_*``). Primary
-  flow, suitable for agents, CI, and any headless context.
-* :mod:`omi_cli.auth.oauth` — Firebase OAuth browser flow. Stubbed in v0.1.0
-  pending backend work to support a localhost callback redirect; the stub
-  surfaces a clear error and points users at the API-key flow.
+  flow for agents, CI, and any headless context. Long-lived, scoped.
+* :mod:`omi_cli.auth.oauth` — Firebase OAuth browser flow. Spins up a
+  localhost callback server, opens the browser, exchanges the resulting code
+  for a Firebase ID token + refresh token. Best for humans on a laptop.
 
 Common token persistence lives in :mod:`omi_cli.auth.store`.
 """
 
 from omi_cli.auth.api_key import login_with_api_key, validate_api_key_format
+from omi_cli.auth.oauth import login_with_browser, needs_refresh, refresh_id_token
 from omi_cli.auth.store import clear_credentials
 
 __all__ = [
-    "login_with_api_key",
-    "validate_api_key_format",
     "clear_credentials",
+    "login_with_api_key",
+    "login_with_browser",
+    "needs_refresh",
+    "refresh_id_token",
+    "validate_api_key_format",
 ]

--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -20,6 +20,7 @@ opportunistically by the HTTP client just before each request.
 
 from __future__ import annotations
 
+import html
 import http.server
 import secrets
 import socketserver
@@ -326,12 +327,15 @@ def _make_callback_handler(
                     "</body></html>"
                 )
             else:
+                # ``html.escape`` is the right tool for inlining untrusted text
+                # into HTML — ``urllib.parse.quote`` is a URL-percent-encoder
+                # and would let through characters HTML treats specially.
                 err = received.get("error") or "missing code"
                 body = (
                     "<!DOCTYPE html><html><body style=\"font-family: -apple-system, sans-serif; "
                     "padding: 48px; max-width: 480px; margin: 0 auto; text-align: center;\">"
                     "<h1>Authentication failed</h1>"
-                    f"<p>{urllib.parse.quote(err)}</p>"
+                    f"<p>{html.escape(err)}</p>"
                     "<p>Close this tab and run <code>omi auth login --browser</code> again.</p>"
                     "</body></html>"
                 )

--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -1,40 +1,351 @@
-"""Firebase OAuth browser-flow stub for omi-cli.
+"""Browser-based Firebase OAuth flow for omi-cli.
 
-**Status: not implemented in v0.1.0.** Tracking in v0.2.0.
+Flow (RFC 8252 native-app pattern with CSRF state token):
 
-The existing Omi auth pipeline (``backend/routers/auth.py``) is built around the
-mobile app's deep-link redirect (``omi://auth/callback``) — the
-``auth_callback.html`` template does not honor an arbitrary ``redirect_uri``,
-so a localhost loopback redirect for the CLI cannot be wired up without a
-backend change. Rather than ship a fragile bypass (e.g. PKCE direct against
-Google with hardcoded client IDs that may not be configured for desktop usage),
-we land an honest stub here. The CLI surface is wired so that adding the real
-flow in v0.2.0 is purely additive — no command-line changes required.
+1. Spin up an HTTP server bound to ``127.0.0.1`` on an ephemeral port.
+2. Open the user's default browser at
+   ``{api_base}/v1/auth/authorize?provider=...&redirect_uri=http://127.0.0.1:PORT/callback&state=<csrf>``.
+3. The user signs in via Google (or Apple). The Omi backend's
+   ``auth_callback.html`` template navigates the browser back to the
+   loopback URL with ``?code=...&state=...``.
+4. The localhost handler captures the code and validates the state token.
+5. The CLI exchanges the code via ``POST /v1/auth/token`` to get a Firebase
+   custom token, then calls Firebase's ``signInWithCustomToken`` REST endpoint
+   to mint a long-lived refresh token + a short-lived ID token.
+6. Tokens are persisted to the user's profile.
 
-For now, ``omi auth login --browser`` returns a clear, actionable error
-pointing the user at the API-key flow.
+Refresh is implemented separately in :func:`refresh_id_token` and called
+opportunistically by the HTTP client just before each request.
 """
 
 from __future__ import annotations
 
-from omi_cli.errors import UsageError
+import http.server
+import secrets
+import socketserver
+import threading
+import time
+import urllib.parse
+import webbrowser
+from typing import Any, Optional
+
+import httpx
+
+from omi_cli import config as cfg
+from omi_cli.auth.store import store_oauth_tokens, update_oauth_id_token
+from omi_cli.config import Profile
+from omi_cli.errors import AuthError, UsageError
+
+# Public Firebase Web API key for the ``based-hardware`` Firebase project.
+# Firebase API keys are *not* secrets — they identify which project a
+# REST request targets and are embedded in every public web/mobile build.
+# See https://firebase.google.com/docs/projects/api-keys.
+_FIREBASE_API_KEY = "AIzaSyAqRWo5RN8YhlzNzBEWJ3GxG3S_1SJlxx4"
+_FIREBASE_SIGNIN_URL = (
+    "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken" f"?key={_FIREBASE_API_KEY}"
+)
+_FIREBASE_REFRESH_URL = f"https://securetoken.googleapis.com/v1/token?key={_FIREBASE_API_KEY}"
+
+_CALLBACK_PATH = "/callback"
+_BROWSER_TIMEOUT_SECONDS = 300  # five minutes from "open browser" to "code in hand"
+_HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+# Refresh slightly before the server-quoted expiry to absorb clock skew + the
+# round-trip time of the upcoming API call.
+_REFRESH_MARGIN_SECONDS = 60
 
 
-def login_with_browser(profile_name: str) -> None:  # noqa: ARG001 — kept for forward-compat signature
-    """Stub: surface a clear error. Real implementation tracked in v0.2.0."""
-    raise UsageError(
-        message="Browser OAuth login is coming in omi-cli v0.2.0",
-        detail=(
-            "For now, generate a developer API key at https://app.omi.me (Developer → API Keys), "
-            "then run `omi auth login` and paste the key. Agents and CI users should prefer the "
-            "API-key flow regardless — it works headlessly and supports scoped permissions."
-        ),
+# --- Browser flow ----------------------------------------------------------
+
+
+def login_with_browser(
+    profile_name: str,
+    *,
+    api_base: str,
+    provider: str = "google",
+    open_browser: bool = True,
+) -> Profile:
+    """Run the Firebase OAuth browser flow and persist the resulting tokens.
+
+    Returns the updated :class:`Profile`.
+
+    ``open_browser=False`` is useful in headless tests; the caller is then
+    responsible for actually visiting the printed URL.
+    """
+    if provider not in {"google", "apple"}:
+        raise UsageError(
+            message=f"Unknown OAuth provider: {provider}",
+            detail="Supported: google, apple.",
+        )
+
+    state = secrets.token_urlsafe(32)
+    received: dict[str, Optional[str]] = {}
+    received_event = threading.Event()
+
+    handler_class = _make_callback_handler(received, received_event)
+
+    # Bind to 127.0.0.1 explicitly (not "localhost" — some systems resolve that
+    # to ::1 first, and we want the IPv4 loopback to be the canonical one we
+    # tell the backend about).
+    with _OneShotHTTPServer(("127.0.0.1", 0), handler_class) as server:
+        port = server.server_address[1]
+        redirect_uri = f"http://127.0.0.1:{port}{_CALLBACK_PATH}"
+        auth_url = (
+            f"{api_base.rstrip('/')}/v1/auth/authorize?"
+            f"provider={urllib.parse.quote(provider)}&"
+            f"redirect_uri={urllib.parse.quote(redirect_uri, safe='')}&"
+            f"state={urllib.parse.quote(state)}"
+        )
+
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        try:
+            print(f"Opening browser for {provider} sign-in...")
+            print(f"If your browser does not open, visit:\n  {auth_url}")
+            if open_browser:
+                # webbrowser.open returns False on failure but is otherwise
+                # silent; we always print the URL above as a fallback.
+                webbrowser.open(auth_url, new=2)
+
+            if not received_event.wait(timeout=_BROWSER_TIMEOUT_SECONDS):
+                raise AuthError(
+                    message="OAuth flow timed out",
+                    detail=(
+                        f"No callback received within {_BROWSER_TIMEOUT_SECONDS // 60} minutes. "
+                        "Try again, or use `omi auth login --api-key` instead."
+                    ),
+                )
+        finally:
+            server.shutdown()
+            thread.join(timeout=2)
+
+    if received.get("error"):
+        raise AuthError(
+            message="OAuth provider returned an error",
+            detail=str(received["error"]),
+        )
+
+    if received.get("state") != state:
+        # CSRF guard — refuse if the callback's state token doesn't match the
+        # one we generated. A mismatch means either a buggy backend or someone
+        # injected a different flow into our session.
+        raise AuthError(
+            message="OAuth state mismatch",
+            detail="The browser callback did not match the original session token. Possible CSRF — aborting.",
+        )
+
+    code = received.get("code")
+    if not code:
+        raise AuthError(
+            message="OAuth callback missing authorization code",
+            detail="The browser callback URL did not include a `code` parameter.",
+        )
+
+    custom_token = _exchange_code_for_custom_token(api_base, code, redirect_uri)
+    id_token, refresh_token, expires_in = _firebase_signin_with_custom_token(custom_token)
+
+    return store_oauth_tokens(
+        profile_name,
+        id_token=id_token,
+        refresh_token=refresh_token,
+        expires_at=time.time() + expires_in - _REFRESH_MARGIN_SECONDS,
+        api_base=api_base,
     )
 
 
-def refresh_id_token(profile_name: str) -> None:  # noqa: ARG001
-    """Stub for the upcoming OAuth refresh flow."""
-    raise UsageError(
-        message="OAuth refresh is not available in v0.1.0",
-        detail="This profile is using API-key auth — there is no token to refresh.",
-    )
+# --- Refresh ---------------------------------------------------------------
+
+
+def refresh_id_token(profile_name: str) -> str:
+    """Mint a fresh Firebase ID token using the stored refresh token.
+
+    Persists the new token + expiry to the profile and returns the new ID
+    token so callers can use it immediately without re-loading config.
+    """
+    config = cfg.load()
+    profile = config.get_profile(profile_name)
+
+    if profile.auth_method != "oauth" or not profile.refresh_token:
+        raise UsageError(
+            message="Nothing to refresh",
+            detail=(
+                f"Profile '{profile_name}' is not configured for OAuth. "
+                "API keys are long-lived and don't need refreshing."
+            ),
+        )
+
+    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        resp = client.post(
+            _FIREBASE_REFRESH_URL,
+            data={"grant_type": "refresh_token", "refresh_token": profile.refresh_token},
+        )
+    if resp.status_code != 200:
+        raise AuthError(
+            message=f"Firebase refresh failed ({resp.status_code})",
+            detail="Re-run `omi auth login --browser` to get fresh credentials.",
+        )
+
+    data = resp.json()
+    new_id_token = data.get("id_token")
+    new_refresh_token = data.get("refresh_token")
+    expires_in = int(data.get("expires_in", 3600) or 3600)
+
+    if not new_id_token:
+        raise AuthError(
+            message="Firebase refresh response was missing id_token",
+            detail=f"Received keys: {sorted(data.keys())}",
+        )
+
+    expires_at = time.time() + expires_in - _REFRESH_MARGIN_SECONDS
+
+    # If Firebase rotated the refresh token, persist the new one too. Otherwise
+    # we just bump the ID token + expiry in place.
+    if new_refresh_token and new_refresh_token != profile.refresh_token:
+        store_oauth_tokens(
+            profile_name,
+            id_token=new_id_token,
+            refresh_token=new_refresh_token,
+            expires_at=expires_at,
+            api_base=profile.api_base,
+        )
+    else:
+        update_oauth_id_token(
+            profile_name,
+            id_token=new_id_token,
+            expires_at=expires_at,
+        )
+
+    return str(new_id_token)
+
+
+def needs_refresh(profile: Profile, now: Optional[float] = None) -> bool:
+    """Return True if the stored OAuth ID token is past (or near) its expiry."""
+    if profile.auth_method != "oauth":
+        return False
+    if not profile.id_token_expires_at:
+        # Token of unknown age — be safe and refresh.
+        return True
+    return (now or time.time()) >= profile.id_token_expires_at
+
+
+# --- Internals -------------------------------------------------------------
+
+
+def _exchange_code_for_custom_token(api_base: str, code: str, redirect_uri: str) -> str:
+    """Hit ``POST /v1/auth/token`` and pull the Firebase custom token out of the response."""
+    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        resp = client.post(
+            f"{api_base.rstrip('/')}/v1/auth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "use_custom_token": "true",
+            },
+        )
+    if resp.status_code != 200:
+        raise AuthError(
+            message=f"Token exchange failed ({resp.status_code})",
+            detail="The Omi auth server rejected the OAuth code. Try `omi auth login --browser` again.",
+        )
+
+    body = resp.json()
+    custom_token = body.get("custom_token")
+    if not custom_token:
+        raise AuthError(
+            message="Server did not return a Firebase custom token",
+            detail="The backend may not have FIREBASE_API_KEY configured.",
+        )
+    return str(custom_token)
+
+
+def _firebase_signin_with_custom_token(custom_token: str) -> tuple[str, str, int]:
+    """Sign into Firebase with the custom token and return ``(id_token, refresh_token, expires_in)``."""
+    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        resp = client.post(
+            _FIREBASE_SIGNIN_URL,
+            json={"token": custom_token, "returnSecureToken": True},
+        )
+    if resp.status_code != 200:
+        raise AuthError(
+            message=f"Firebase signInWithCustomToken failed ({resp.status_code})",
+            detail="Verify the public Firebase API key matches the project this backend issues custom tokens for.",
+        )
+    data = resp.json()
+    id_token = data.get("idToken")
+    refresh_token = data.get("refreshToken")
+    expires_in = int(data.get("expiresIn", 3600) or 3600)
+
+    if not id_token or not refresh_token:
+        raise AuthError(
+            message="Firebase signin response missing tokens",
+            detail=f"Received keys: {sorted(data.keys())}",
+        )
+    return id_token, refresh_token, expires_in
+
+
+def _first(values: Optional[list[str]]) -> Optional[str]:
+    """Return the first element of a list-or-None, or None if absent/empty."""
+    if not values:
+        return None
+    return values[0]
+
+
+def _make_callback_handler(
+    received: dict[str, Optional[str]],
+    received_event: threading.Event,
+) -> type[http.server.BaseHTTPRequestHandler]:
+    """Build a handler class that captures ``code`` / ``state`` / ``error`` from the callback URL."""
+
+    class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 — http.server uses do_VERB
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != _CALLBACK_PATH:
+                # Browsers love to fetch ``/favicon.ico`` etc. Treat anything
+                # other than the callback path as a 404 and keep waiting.
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            params = urllib.parse.parse_qs(parsed.query)
+            received["code"] = _first(params.get("code"))
+            received["state"] = _first(params.get("state"))
+            received["error"] = _first(params.get("error"))
+
+            ok = received.get("code") is not None and received.get("error") is None
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            if ok:
+                body = (
+                    "<!DOCTYPE html><html><body style=\"font-family: -apple-system, sans-serif; "
+                    "padding: 48px; max-width: 480px; margin: 0 auto; text-align: center;\">"
+                    "<h1>✓ Logged in</h1>"
+                    "<p>Authentication complete. You can close this tab and return to your terminal.</p>"
+                    "</body></html>"
+                )
+            else:
+                err = received.get("error") or "missing code"
+                body = (
+                    "<!DOCTYPE html><html><body style=\"font-family: -apple-system, sans-serif; "
+                    "padding: 48px; max-width: 480px; margin: 0 auto; text-align: center;\">"
+                    "<h1>Authentication failed</h1>"
+                    f"<p>{urllib.parse.quote(err)}</p>"
+                    "<p>Close this tab and run <code>omi auth login --browser</code> again.</p>"
+                    "</body></html>"
+                )
+            self.wfile.write(body.encode("utf-8"))
+            received_event.set()
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002 — stdlib signature
+            # Silence the default access-log noise. The CLI manages its own UX.
+            return
+
+    return _CallbackHandler
+
+
+class _OneShotHTTPServer(socketserver.TCPServer):
+    """``TCPServer`` with port-reuse so a previous botched login can't block this one."""
+
+    allow_reuse_address = True

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -55,6 +55,21 @@ class OmiClient:
     """Thin wrapper around :class:`httpx.Client`. One per CLI invocation."""
 
     def __init__(self, profile: Profile, *, timeout: Optional[httpx.Timeout] = None, verbose: bool = False) -> None:
+        # Pre-flight: if this is an OAuth profile and the cached Firebase ID
+        # token is expired (or close to it), refresh before we build the bearer
+        # header so the very first request goes out with a fresh token.
+        # ``omi_cli.auth.oauth`` is imported lazily because it pulls in
+        # ``http.server`` / ``socketserver`` which we don't need for the more
+        # common API-key path.
+        if profile.auth_method == "oauth":
+            from omi_cli.auth import oauth as oauth_auth  # local to avoid import cost on api_key path
+
+            if oauth_auth.needs_refresh(profile):
+                new_id_token = oauth_auth.refresh_id_token(profile.name)
+                # Mutate the in-memory profile so _build_headers picks up the
+                # new token without re-reading the config file.
+                profile.id_token = new_id_token
+
         self._profile = profile
         self._verbose = verbose
         self._http = httpx.Client(

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -1,4 +1,4 @@
-"""``omi auth`` — login, logout, status."""
+"""``omi auth`` — login (browser or API key), logout, status, refresh."""
 
 from __future__ import annotations
 
@@ -29,54 +29,120 @@ def _ctx(typer_ctx: typer.Context) -> "AppContext":
     return obj  # type: ignore[no-any-return]
 
 
-@app.command("login", help="Authenticate this profile with an Omi developer API key.")
+@app.command("login", help="Authenticate this profile. Prompts for browser or API key if no flag is given.")
 def login(
     typer_ctx: typer.Context,
     api_key_arg: Optional[str] = typer.Option(
         None,
         "--api-key",
-        help="API key. If omitted, you will be prompted interactively (preferred — keeps the key out of shell history).",
+        help="API key (skips the prompt). Visible in shell history — prefer the interactive paste.",
     ),
     browser: bool = typer.Option(
         False,
         "--browser",
-        help="Use the Firebase OAuth browser flow (coming in v0.2.0).",
+        help="Force the Firebase OAuth browser flow.",
+    ),
+    provider: str = typer.Option(
+        "google",
+        "--provider",
+        help="OAuth provider for --browser: google or apple.",
     ),
 ) -> None:
     ctx = _ctx(typer_ctx)
     renderer = ctx.renderer
 
+    if browser and api_key_arg:
+        raise UsageError(
+            message="Pick one auth method",
+            detail="`--browser` and `--api-key` are mutually exclusive.",
+        )
+
+    # Explicit flags win over the picker.
     if browser:
-        # Surface the v0.2.0 stub message — clean, expected error path.
-        oauth_auth.login_with_browser(ctx.profile_name)
-        return  # unreachable; the stub raises
+        return _do_browser_login(ctx, provider=provider)
 
-    if api_key_arg is None:
-        # Read from stdin if not a TTY (handy for piping `omi auth login < key.txt`).
-        if not sys.stdin.isatty():
-            api_key_arg = sys.stdin.read().strip()
-        else:
-            api_key_arg = typer.prompt("Paste your Omi developer API key", hide_input=True).strip()
+    if api_key_arg is not None:
+        return _do_api_key_login(ctx, api_key_arg)
 
-    profile = api_key_auth.login_with_api_key(ctx.profile_name, api_key_arg, api_base=ctx.api_base_override)
+    # Headless / piped contexts: read API key from stdin (e.g. `omi auth login < key.txt`).
+    if not sys.stdin.isatty():
+        piped = sys.stdin.read().strip()
+        if not piped:
+            raise UsageError(
+                message="No input on stdin",
+                detail="Pipe an API key in, or run `omi auth login` interactively.",
+            )
+        return _do_api_key_login(ctx, piped)
 
-    # Optional sanity check: reach out and confirm the key works. We do this on
-    # a tolerant endpoint (memories list with limit=1) so a missing scope on the
-    # primary domain doesn't make login appear to fail.
+    # Interactive picker — the new default UX.
+    if not ctx.renderer.json_mode:
+        renderer.info("How would you like to log in?")
+        renderer.info("  [bold]1[/bold]) Browser  — sign in with Google or Apple via OAuth (recommended for humans)")
+        renderer.info("  [bold]2[/bold]) API key  — paste a developer key from app.omi.me (recommended for agents/CI)")
+    choice = typer.prompt("Choose 1 or 2", default="1").strip()
+
+    if choice in {"1", "browser", "b"}:
+        return _do_browser_login(ctx, provider=provider)
+    if choice in {"2", "api-key", "key", "k"}:
+        api_key_input = typer.prompt("Paste your Omi developer API key", hide_input=True).strip()
+        return _do_api_key_login(ctx, api_key_input)
+    raise UsageError(
+        message=f"Unrecognized choice: {choice!r}",
+        detail="Enter 1 (browser) or 2 (API key).",
+    )
+
+
+def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
+    """Run the OAuth browser flow + verify the resulting Firebase token works."""
+    api_base = ctx.api_base_override or ctx.get_profile().api_base
+    profile = oauth_auth.login_with_browser(ctx.profile_name, api_base=api_base, provider=provider)
+
+    # Verify the freshly-minted Firebase ID token actually authenticates against
+    # the Omi API. If it doesn't, roll back so the user isn't left holding a
+    # half-broken OAuth profile.
     try:
         with OmiClient(profile, verbose=ctx.verbose) as client:
             client.get("/v1/dev/user/memories", params={"limit": 1})
     except AuthError as exc:
-        # Roll back the bad credential so the user isn't stuck with a broken profile.
         clear_credentials(ctx.profile_name)
         raise exc
     except CliError as exc:
-        # Network / rate-limit / non-auth issues: don't roll back, but warn.
-        renderer.warn(f"Could not verify the key right now ({exc.message}). It is stored — try again shortly.")
+        # Insufficient scope / 403 also bubbles as AuthError above. Anything
+        # else is a transient network blip — keep the credential, just warn.
+        ctx.renderer.warn(
+            f"Could not verify the new token right now ({exc.message}). It is stored — try again shortly."
+        )
 
-    renderer.success(f"Logged in as profile [bold]{profile.name}[/bold] ({profile.masked_credential()}).")
+    ctx.renderer.success(f"Logged in via [bold]{provider}[/bold] OAuth as profile [bold]{profile.name}[/bold].")
     if ctx.renderer.json_mode:
-        renderer.emit({"profile": profile.name, "auth_method": profile.auth_method, "api_base": profile.api_base})
+        ctx.renderer.emit(
+            {
+                "profile": profile.name,
+                "auth_method": profile.auth_method,
+                "api_base": profile.api_base,
+                "provider": provider,
+            }
+        )
+
+
+def _do_api_key_login(ctx: "AppContext", api_key: str) -> None:
+    """Validate, persist, and verify a dev API key."""
+    profile = api_key_auth.login_with_api_key(ctx.profile_name, api_key, api_base=ctx.api_base_override)
+
+    # Sanity check on a tolerant endpoint — see the original launch PR's
+    # rationale. AuthError → roll back; other CliError → warn and keep.
+    try:
+        with OmiClient(profile, verbose=ctx.verbose) as client:
+            client.get("/v1/dev/user/memories", params={"limit": 1})
+    except AuthError as exc:
+        clear_credentials(ctx.profile_name)
+        raise exc
+    except CliError as exc:
+        ctx.renderer.warn(f"Could not verify the key right now ({exc.message}). It is stored — try again shortly.")
+
+    ctx.renderer.success(f"Logged in as profile [bold]{profile.name}[/bold] ({profile.masked_credential()}).")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit({"profile": profile.name, "auth_method": profile.auth_method, "api_base": profile.api_base})
 
 
 @app.command("logout", help="Clear credentials for the active profile.")
@@ -95,13 +161,16 @@ def logout(typer_ctx: typer.Context) -> None:
 def status(typer_ctx: typer.Context) -> None:
     ctx = _ctx(typer_ctx)
     profile = ctx.get_profile()
-    payload = {
+    payload: dict[str, object] = {
         "profile": profile.name,
         "authenticated": profile.is_authenticated(),
         "auth_method": profile.auth_method,
         "api_base": profile.api_base,
         "credential": profile.masked_credential(),
     }
+    if profile.auth_method == "oauth" and profile.id_token_expires_at:
+        # Surface expiry so users can tell if the auto-refresh has been keeping up.
+        payload["id_token_expires_at"] = profile.id_token_expires_at
     ctx.renderer.emit(payload, title="omi auth status")
 
 
@@ -109,21 +178,21 @@ def status(typer_ctx: typer.Context) -> None:
 def whoami(typer_ctx: typer.Context) -> None:
     ctx = _ctx(typer_ctx)
     # The public dev surface doesn't expose a /me endpoint, but a memories list
-    # round-trip with the credential confirms the key is alive and identifies
-    # the user implicitly (the count belongs to *this* user). This keeps the
-    # command useful without inventing new backend routes.
+    # round-trip with the credential confirms the credential is alive and
+    # identifies the user implicitly (the count belongs to *this* user).
     with ctx.make_client() as client:
         memories = client.get("/v1/dev/user/memories", params={"limit": 1})
     payload = {
         "profile": ctx.profile_name,
         "credential": ctx.get_profile().masked_credential(),
+        "auth_method": ctx.get_profile().auth_method,
         "api_base": ctx.get_profile().api_base,
         "owns_memories": isinstance(memories, list),
     }
     ctx.renderer.emit(payload, title="omi whoami")
 
 
-@app.command("refresh", help="Refresh the OAuth ID token (no-op for API-key profiles).")
+@app.command("refresh", help="Force-refresh the OAuth ID token (no-op for API-key profiles).")
 def refresh(typer_ctx: typer.Context) -> None:
     ctx = _ctx(typer_ctx)
     profile = ctx.get_profile()
@@ -132,10 +201,11 @@ def refresh(typer_ctx: typer.Context) -> None:
             message="Nothing to refresh",
             detail=(
                 f"Profile '{profile.name}' uses API-key auth — there is no token to refresh. "
-                "API keys are long-lived; rotate them in the Omi web app if needed."
+                "Rotate keys in the Omi web app if needed."
             ),
         )
     oauth_auth.refresh_id_token(profile.name)
+    ctx.renderer.success(f"Refreshed Firebase ID token for profile [bold]{profile.name}[/bold].")
 
 
 def _ensure_authenticated(profile: cfg.Profile) -> None:  # pragma: no cover — utility for sibling commands

--- a/sdks/python-cli/pyproject.toml
+++ b/sdks/python-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omi-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Command-line interface for Omi — talk to memories, conversations, action items, and goals from your terminal."
 readme = "README.md"
 license = { text = "MIT" }

--- a/sdks/python-cli/tests/test_auth_oauth.py
+++ b/sdks/python-cli/tests/test_auth_oauth.py
@@ -1,21 +1,217 @@
-"""Tests for the OAuth stub (v0.1.0)."""
+"""Tests for the OAuth browser flow + refresh logic."""
 
 from __future__ import annotations
 
+import time
+
+import httpx
 import pytest
 
+from omi_cli import config as cfg
 from omi_cli.auth import oauth
-from omi_cli.errors import UsageError
+from omi_cli.auth.store import store_oauth_tokens
+from omi_cli.errors import AuthError, UsageError
+
+# ---- needs_refresh ---------------------------------------------------------
 
 
-def test_login_with_browser_raises_v0_2_message() -> None:
-    with pytest.raises(UsageError) as info:
-        oauth.login_with_browser("default")
-    msg = str(info.value).lower()
-    assert "v0.2.0" in msg or "0.2.0" in msg
-    assert "api key" in msg or "api-key" in msg
+def test_needs_refresh_returns_false_for_api_key_profile(config_path) -> None:
+    profile = cfg.Profile(name="default", auth_method="api_key", api_key="omi_dev_xxx")
+    assert oauth.needs_refresh(profile) is False
 
 
-def test_refresh_id_token_raises_for_v0_1() -> None:
+def test_needs_refresh_true_when_no_expiry(config_path) -> None:
+    profile = cfg.Profile(name="default", auth_method="oauth", id_token="t", refresh_token="r")
+    assert oauth.needs_refresh(profile) is True
+
+
+def test_needs_refresh_true_when_expired(config_path) -> None:
+    profile = cfg.Profile(
+        name="default",
+        auth_method="oauth",
+        id_token="t",
+        refresh_token="r",
+        id_token_expires_at=time.time() - 5,
+    )
+    assert oauth.needs_refresh(profile) is True
+
+
+def test_needs_refresh_false_when_far_from_expiry(config_path) -> None:
+    profile = cfg.Profile(
+        name="default",
+        auth_method="oauth",
+        id_token="t",
+        refresh_token="r",
+        id_token_expires_at=time.time() + 3000,
+    )
+    assert oauth.needs_refresh(profile) is False
+
+
+# ---- refresh_id_token ------------------------------------------------------
+
+
+def test_refresh_rejects_non_oauth_profile(config_path) -> None:
+    config = cfg.load()
+    profile = config.get_profile("default")
+    profile.auth_method = "api_key"
+    profile.api_key = "omi_dev_x"
+    config.set_profile(profile)
+    cfg.save(config)
     with pytest.raises(UsageError):
         oauth.refresh_id_token("default")
+
+
+def test_refresh_persists_new_id_token(config_path, monkeypatch) -> None:
+    store_oauth_tokens(
+        "default",
+        id_token="old_id",
+        refresh_token="refr_1",
+        expires_at=time.time() - 10,
+        api_base="https://api.test.omi.local",
+    )
+
+    captured: dict = {}
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        captured["url"] = url
+        captured["data"] = kwargs.get("data")
+        return httpx.Response(
+            200,
+            json={"id_token": "new_id_token", "refresh_token": "refr_1", "expires_in": "3600"},
+        )
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+
+    new = oauth.refresh_id_token("default")
+    assert new == "new_id_token"
+    assert captured["data"] == {"grant_type": "refresh_token", "refresh_token": "refr_1"}
+
+    reloaded = cfg.load().get_profile("default")
+    assert reloaded.id_token == "new_id_token"
+    assert reloaded.refresh_token == "refr_1"
+    # Expiry should be roughly now + 3600 - margin (60).
+    assert abs((reloaded.id_token_expires_at or 0) - (time.time() + 3540)) < 5
+
+
+def test_refresh_persists_rotated_refresh_token(config_path, monkeypatch) -> None:
+    store_oauth_tokens(
+        "default",
+        id_token="old_id",
+        refresh_token="refr_old",
+        expires_at=time.time() - 10,
+        api_base="https://api.test.omi.local",
+    )
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(
+            200,
+            json={"id_token": "new_id", "refresh_token": "refr_new_rotated", "expires_in": "3600"},
+        )
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    oauth.refresh_id_token("default")
+
+    reloaded = cfg.load().get_profile("default")
+    assert reloaded.id_token == "new_id"
+    assert reloaded.refresh_token == "refr_new_rotated"
+
+
+def test_refresh_surfaces_firebase_error(config_path, monkeypatch) -> None:
+    store_oauth_tokens(
+        "default",
+        id_token="old_id",
+        refresh_token="refr_bad",
+        expires_at=time.time() - 10,
+        api_base="https://api.test.omi.local",
+    )
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(401, json={"error": {"message": "INVALID_REFRESH_TOKEN"}})
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    with pytest.raises(AuthError) as info:
+        oauth.refresh_id_token("default")
+    assert "401" in str(info.value)
+
+
+# ---- login_with_browser surface ------------------------------------------
+
+
+def test_login_with_browser_rejects_unknown_provider(config_path) -> None:
+    with pytest.raises(UsageError):
+        oauth.login_with_browser(
+            "default",
+            api_base="https://api.test.omi.local",
+            provider="microsoft",  # unsupported
+            open_browser=False,
+        )
+
+
+# ---- code-exchange wiring -------------------------------------------------
+
+
+def test_exchange_code_for_custom_token_happy_path(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        captured["url"] = url
+        captured["data"] = kwargs.get("data")
+        return httpx.Response(200, json={"custom_token": "ct_abc", "id_token": "google_id"})
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    token = oauth._exchange_code_for_custom_token(
+        "https://api.test.omi.local",
+        code="auth_code",
+        redirect_uri="http://127.0.0.1:5555/callback",
+    )
+    assert token == "ct_abc"
+    assert captured["url"] == "https://api.test.omi.local/v1/auth/token"
+    assert captured["data"]["grant_type"] == "authorization_code"
+    assert captured["data"]["use_custom_token"] == "true"
+
+
+def test_exchange_code_raises_on_non_200(monkeypatch) -> None:
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(400, json={"detail": "Invalid or expired code"})
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    with pytest.raises(AuthError):
+        oauth._exchange_code_for_custom_token(
+            "https://api.test.omi.local", code="bad", redirect_uri="http://127.0.0.1:5555/callback"
+        )
+
+
+def test_exchange_code_raises_when_custom_token_missing(monkeypatch) -> None:
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(200, json={"id_token": "google_only", "access_token": "g"})
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    with pytest.raises(AuthError) as info:
+        oauth._exchange_code_for_custom_token(
+            "https://api.test.omi.local", code="ok", redirect_uri="http://127.0.0.1:5555/callback"
+        )
+    assert "custom token" in str(info.value).lower()
+
+
+def test_firebase_signin_with_custom_token_returns_tokens(monkeypatch) -> None:
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        assert "signInWithCustomToken" in url
+        return httpx.Response(
+            200,
+            json={"idToken": "fb_id", "refreshToken": "fb_refr", "expiresIn": "3600"},
+        )
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    id_token, refresh_token, expires_in = oauth._firebase_signin_with_custom_token("ct")
+    assert id_token == "fb_id"
+    assert refresh_token == "fb_refr"
+    assert expires_in == 3600
+
+
+def test_firebase_signin_raises_on_missing_tokens(monkeypatch) -> None:
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(200, json={"idToken": "fb_id"})  # missing refreshToken
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    with pytest.raises(AuthError):
+        oauth._firebase_signin_with_custom_token("ct")

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -1,11 +1,15 @@
-"""Tests for the HTTP client: auth headers, retry logic, error mapping."""
+"""Tests for the HTTP client: auth headers, retry logic, error mapping, OAuth refresh."""
 
 from __future__ import annotations
+
+import time
 
 import httpx
 import pytest
 
 from omi_cli import __version__
+from omi_cli import config as cfg
+from omi_cli.auth.store import store_oauth_tokens
 from omi_cli.client import USER_AGENT, OmiClient
 from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, ServerError
 
@@ -13,6 +17,60 @@ from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, S
 def test_user_agent_contains_version_and_repo() -> None:
     assert __version__ in USER_AGENT
     assert "omi-cli" in USER_AGENT
+
+
+def test_oauth_pre_flight_refresh_when_token_expired(config_path, monkeypatch) -> None:
+    """Constructing an OmiClient on an OAuth profile with an expired ID token
+    must trigger a Firebase refresh before the bearer header is built."""
+    # Seed the profile with an expired token.
+    store_oauth_tokens(
+        "default",
+        id_token="stale_token",
+        refresh_token="refr_x",
+        expires_at=time.time() - 60,
+        api_base="https://api.test.omi.local",
+    )
+
+    refreshed_calls: dict = {}
+
+    def fake_refresh(profile_name: str) -> str:
+        refreshed_calls["called"] = profile_name
+        return "fresh_token_after_refresh"
+
+    monkeypatch.setattr("omi_cli.auth.oauth.refresh_id_token", fake_refresh)
+
+    profile = cfg.load().get_profile("default")
+    with OmiClient(profile) as client:
+        # Inspect the Authorization header the client computed.
+        sent_token = client._http.headers["Authorization"]
+    assert refreshed_calls.get("called") == "default"
+    assert sent_token == "Bearer fresh_token_after_refresh"
+
+
+def test_oauth_pre_flight_skipped_when_token_fresh(config_path, monkeypatch) -> None:
+    """A still-valid OAuth ID token should NOT trigger a refresh — that would
+    waste a Firebase round-trip on every CLI invocation."""
+    store_oauth_tokens(
+        "default",
+        id_token="fresh_token",
+        refresh_token="refr_x",
+        expires_at=time.time() + 1800,  # 30 min remaining
+        api_base="https://api.test.omi.local",
+    )
+
+    refresh_count = {"n": 0}
+
+    def fake_refresh(profile_name: str) -> str:
+        refresh_count["n"] += 1
+        return "should_not_be_used"
+
+    monkeypatch.setattr("omi_cli.auth.oauth.refresh_id_token", fake_refresh)
+
+    profile = cfg.load().get_profile("default")
+    with OmiClient(profile) as client:
+        sent_token = client._http.headers["Authorization"]
+    assert refresh_count["n"] == 0
+    assert sent_token == "Bearer fresh_token"
 
 
 def test_get_injects_bearer_and_returns_json(authed_profile, respx_mock) -> None:


### PR DESCRIPTION
## Summary

Ships **browser-based Firebase OAuth login** for \`omi-cli\` v0.2.0, plus the small backend tweak that makes it possible. \`omi auth login\` (with no flags) now asks how the user wants to authenticate; both paths are fully wired.

\`\`\`text
\$ omi auth login
How would you like to log in?
  1) Browser  — sign in with Google or Apple via OAuth (recommended for humans)
  2) API key  — paste a developer key from app.omi.me (recommended for agents/CI)
Choose 1 or 2 [1]: _
\`\`\`

## What changed

### Backend (2 files)
- **\`backend/routers/auth.py\`** — adds \`_validate_redirect_uri\`: strict allowlist for \`omi://\` (mobile) and \`http://\` loopback (\`localhost\`, \`127.0.0.1\`, \`::1\`) per **RFC 8252 §7**. Anything else is rejected, so the auth code can never be delivered to a non-loopback host. Both Google and Apple callback handlers now pass the validated session \`redirect_uri\` through to the template.
- **\`backend/templates/auth_callback.html\`** — uses \`{{ redirect_uri }}\` (default \`omi://auth/callback\`) instead of a hardcoded value, with a JS-side allowlist as defense in depth. Loopback redirects get a "returning to your terminal — you can close this tab" UX; the existing mobile manual-link fallback is preserved.

**Mobile behavior is unchanged** — the mobile app passes \`omi://auth/callback\` as it always has, which still hits the same template path with the same redirect.

### CLI (8 files, version bump → **0.2.0**)
- **\`omi_cli/auth/oauth.py\`** — replaces the v0.1.0 stub with the real flow:
  - ephemeral-port \`socketserver.TCPServer\` bound to \`127.0.0.1\`
  - state-token CSRF guard
  - browser open via \`webbrowser.open\` (with the URL printed as fallback)
  - 5-minute timeout, clean shutdown
  - \`POST /v1/auth/token\` for the code-to-custom-token exchange
  - \`POST identitytoolkit.googleapis.com .../signInWithCustomToken\` to mint Firebase tokens
  - \`POST securetoken.googleapis.com .../v1/token\` for refresh, with refresh-token rotation handled
- **\`omi_cli/client.py\`** — pre-flight refresh: when the active profile is OAuth and the cached \`id_token\` is past (or near, with 60s margin) its expiry, refresh before building the bearer header. Costs nothing for API-key profiles (the \`oauth\` import is local).
- **\`omi_cli/commands/auth.py\`** — interactive picker (option 1 = browser, option 2 = API key). \`--browser\` and \`--api-key\` force a path; \`--provider apple\` for Apple Sign-In. Stdin-piped login still does API key. Both paths roll back the credential if the post-login verification round-trip returns 401.
- **\`omi_cli/auth/__init__.py\`** — re-exports \`login_with_browser\`, \`needs_refresh\`, \`refresh_id_token\`.
- Tests: 92 total (up from 78), covering the OAuth flow + refresh + pre-flight client behavior.

### Docs (6 files)
- New PyPI link prominently surfaced on \`introduction.mdx\` and \`install.mdx\` (per user request).
- \`quickstart.mdx\` rewritten around the new picker and four auth tabs (browser / API-key / env-var / stdin).
- \`commands.mdx\` drops the "coming in v0.2.0" stub note, documents \`--browser\` and \`--provider\`.
- \`agents.mdx\` adds an explicit "API-key vs browser OAuth" decision table — agents should still prefer API keys.
- \`troubleshooting.mdx\` gains five OAuth-specific entries (timeout, state mismatch, refresh failure, provider switching).

## Quality gates (all green)

| Check                            | Result                                  |
| -------------------------------- | --------------------------------------- |
| pytest                           | **92 tests pass** (up from 78)          |
| black --check (line 120)         | clean                                   |
| isort --check (black profile)    | clean                                   |
| mypy --strict                    | clean (19 source files)                 |
| \`omi --version\`                  | \`omi-cli 0.2.0\`                         |
| \`omi auth login --help\`          | renders the new \`--browser\`/\`--provider\` flags |

## Test plan

- [ ] Smoke the picker:
  \`\`\`bash
  pip install -e sdks/python-cli
  omi auth login         # picker shows; choose 1 → browser opens
  \`\`\`
- [ ] Browser flow against staging or local backend:
  \`\`\`bash
  omi --api-base https://api.omi.me auth login --browser
  # Sign in with Google → terminal shows "Logged in via google OAuth"
  omi memory list        # uses the freshly-minted Firebase ID token
  \`\`\`
- [ ] Auto-refresh (advance the clock or wait an hour):
  \`\`\`bash
  omi auth status       # id_token_expires_at in the past
  omi memory list       # silently refreshes; succeeds
  omi auth status       # id_token_expires_at bumped forward
  \`\`\`
- [ ] Force-refresh: \`omi auth refresh\` rotates the ID token in-place.
- [ ] API-key path still works: \`omi auth login --api-key omi_dev_...\` then \`omi memory list\`.
- [ ] Backend redirect_uri validation: \`curl -i 'https://api.omi.me/v1/auth/authorize?provider=google&redirect_uri=https://evil.example.com/cb&state=x'\` returns 400.

## Release posture

- Branch \`worktree-omi-cli-oauth\`, 17 commits (one file per commit per repo CLAUDE.md).
- Version bumped to **0.2.0** in \`pyproject.toml\` and \`__version__\`.
- After merge: I will rebuild the dist artifacts, then you can \`twine upload\` for the PyPI 0.2.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)