### PR TITLE
feat: empty-state polish across home, conversations, tasks

### DIFF
--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -531,7 +531,10 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
                           : _buildTasksList(categorizedItems, provider),
                 ),
               ),
-              _buildFab(),
+              // Hide the purple corner FAB when the empty-state already
+              // shows its own "Create Action Item" pill — otherwise we
+              // render two competing add buttons on top of each other.
+              if (!categorizedItems.values.every((l) => l.isEmpty)) _buildFab(),
             ],
           ),
         );

--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -129,6 +129,88 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
     );
   }
 
+  int _nonDiscardedConversationCount(ConversationProvider provider) {
+    return provider.conversations.where((c) => !c.discarded).length;
+  }
+
+  Widget _buildNoConversationsHero(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(32, 0, 32, 120),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Layered icon: soft purple aura behind a tactile glassy tile.
+          Stack(
+            alignment: Alignment.center,
+            children: [
+              Container(
+                width: 160,
+                height: 160,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: RadialGradient(
+                    colors: [
+                      Colors.deepPurple.withValues(alpha: 0.35),
+                      Colors.deepPurple.withValues(alpha: 0.0),
+                    ],
+                    stops: const [0.0, 1.0],
+                  ),
+                ),
+              ),
+              Container(
+                width: 88,
+                height: 88,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(26),
+                  gradient: const LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [Color(0xFF7B5CFF), Color(0xFF5733E0)],
+                  ),
+                  border: Border.all(color: Colors.white.withValues(alpha: 0.08), width: 1),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.deepPurple.withValues(alpha: 0.45),
+                      blurRadius: 30,
+                      spreadRadius: 2,
+                      offset: const Offset(0, 12),
+                    ),
+                  ],
+                ),
+                child: const Icon(Icons.forum_rounded, size: 42, color: Colors.white),
+              ),
+            ],
+          ),
+          const SizedBox(height: 28),
+          const Text(
+            'No conversations yet',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 22,
+              fontWeight: FontWeight.w700,
+              letterSpacing: -0.3,
+            ),
+          ),
+          const SizedBox(height: 10),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 280),
+            child: Text(
+              'Conversations you record show up here. Tap a tile on the home tab to start your first one.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.white.withValues(alpha: 0.55),
+                fontSize: 15,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildLoadingShimmer() {
     return SliverList(
       delegate: SliverChildBuilderDelegate(
@@ -220,27 +302,32 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                 },
               ),
 
-              // Section header - show "Daily Recaps" or "Conversations" with optional recording pill
-              SliverToBoxAdapter(
-                child: Builder(
-                  builder: (context) => Padding(
-                    padding: const EdgeInsets.only(left: 24, right: 16, top: 16, bottom: 8),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Text(
-                          convoProvider.showDailySummaries ? context.l10n.dailyRecaps : context.l10n.conversations,
-                          style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
-                        ),
-                      ],
+              // Section header - show "Daily Recaps" or "Conversations" with optional recording pill.
+              // Hidden entirely when the user has fewer than 3 non-discarded
+              // conversations (and isn't on the Daily Recaps view) — those
+              // users get the empty-state hero below instead.
+              if (convoProvider.showDailySummaries || _nonDiscardedConversationCount(convoProvider) >= 3)
+                SliverToBoxAdapter(
+                  child: Builder(
+                    builder: (context) => Padding(
+                      padding: const EdgeInsets.only(left: 24, right: 16, top: 16, bottom: 8),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Text(
+                            convoProvider.showDailySummaries ? context.l10n.dailyRecaps : context.l10n.conversations,
+                            style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
-              ),
 
-              // Folder tabs - hide when showing daily recaps
-              if (!convoProvider.showDailySummaries)
+              // Folder tabs - hide when showing daily recaps OR when the user
+              // hasn't built up enough conversations yet (matches the title).
+              if (!convoProvider.showDailySummaries && _nonDiscardedConversationCount(convoProvider) >= 3)
                 Consumer2<FolderProvider, ConversationProvider>(
                   builder: (context, folderProvider, convoProvider, _) {
                     return SliverToBoxAdapter(
@@ -262,6 +349,17 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
               // Show daily summaries list or conversations based on filter
               if (convoProvider.showDailySummaries)
                 const DailySummariesList()
+              else if (_nonDiscardedConversationCount(convoProvider) < 3 &&
+                  !convoProvider.isLoadingConversations &&
+                  !convoProvider.isFetchingConversations &&
+                  !convoProvider.showStarredOnly &&
+                  convoProvider.selectedFolderId == null)
+                // Friendly hero for users who haven't built up enough
+                // conversations yet — matches the polished Tasks empty state.
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Center(child: _buildNoConversationsHero(context)),
+                )
               else if (convoProvider.groupedConversations.isEmpty &&
                   !convoProvider.isLoadingConversations &&
                   !convoProvider.isFetchingConversations)

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -126,24 +126,35 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
                   ),
                 ),
                 _buildConversationsPreview(convoProvider),
-              ] else
-                SliverToBoxAdapter(child: _buildGetStartedOptions(context)),
 
-              // Mind Map section
-              SliverToBoxAdapter(
-                child: _buildSectionHeader(
-                  context,
-                  context.l10n.mindMap,
-                  onViewAll: () => Navigator.push(
+                // Mind Map section — only shown for users with enough activity.
+                SliverToBoxAdapter(
+                  child: _buildSectionHeader(
                     context,
-                    MaterialPageRoute(builder: (context) => const MemoryGraphPage(trackOpenEvent: false)),
+                    context.l10n.mindMap,
+                    onViewAll: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => const MemoryGraphPage(trackOpenEvent: false)),
+                    ),
                   ),
                 ),
-              ),
-              SliverToBoxAdapter(child: _buildMindMapPreview(context)),
+                SliverToBoxAdapter(child: _buildMindMapPreview(context)),
 
-              // Bottom padding so content isn't hidden behind chat bar + nav
-              const SliverToBoxAdapter(child: SizedBox(height: 160)),
+                // Bottom padding so content isn't hidden behind chat bar + nav
+                const SliverToBoxAdapter(child: SizedBox(height: 160)),
+              ] else
+                // For new users (< 3 non-discarded convos): hide the conversations
+                // preview AND the mind map. The 3 "get started" tiles fill the
+                // remaining vertical space and sit centered between Today/Daily
+                // Recaps above and the floating chat bar below.
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Padding(
+                    // Bottom padding leaves room for the floating chat bar.
+                    padding: const EdgeInsets.only(bottom: 160),
+                    child: Center(child: _buildGetStartedOptions(context)),
+                  ),
+                ),
             ],
           ),
         );

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -8,10 +8,13 @@ import 'package:provider/provider.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/daily_summary.dart';
+import 'package:omi/pages/conversation_capturing/page.dart';
 import 'package:omi/pages/conversations/widgets/conversation_list_item.dart';
 import 'package:omi/pages/conversations/widgets/processing_capture.dart';
 import 'package:omi/pages/conversations/widgets/today_tasks_widget.dart';
 import 'package:omi/pages/memories/widgets/memory_graph_page.dart';
+import 'package:omi/pages/onboarding/device_selection.dart';
+import 'package:omi/pages/phone_calls/phone_calls_page.dart';
 import 'package:omi/pages/settings/daily_summary_detail_page.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/home_provider.dart';
@@ -102,21 +105,29 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
                 SliverToBoxAdapter(child: _buildDailyRecapsPreview(context)),
               ],
 
-              // Conversations section
-              SliverToBoxAdapter(
-                child: _buildSectionHeader(
-                  context,
-                  context.l10n.conversations,
-                  onViewAll: () {
-                    // Reset the daily-summaries flag so the conversations tab
-                    // actually shows conversations (it persists from Daily
-                    // Recaps' View All otherwise).
-                    if (convoProvider.showDailySummaries) convoProvider.toggleDailySummaries();
-                    context.read<HomeProvider>().setIndex(1);
-                  },
+              // Conversations section.
+              //
+              // If the user has fewer than 3 non-discarded conversations,
+              // we replace the recent-conversations preview with three
+              // big "get started" options so the home page doesn't feel
+              // empty for new users.
+              if (_nonDiscardedConversationCount(convoProvider) >= 3) ...[
+                SliverToBoxAdapter(
+                  child: _buildSectionHeader(
+                    context,
+                    context.l10n.conversations,
+                    onViewAll: () {
+                      // Reset the daily-summaries flag so the conversations tab
+                      // actually shows conversations (it persists from Daily
+                      // Recaps' View All otherwise).
+                      if (convoProvider.showDailySummaries) convoProvider.toggleDailySummaries();
+                      context.read<HomeProvider>().setIndex(1);
+                    },
+                  ),
                 ),
-              ),
-              _buildConversationsPreview(convoProvider),
+                _buildConversationsPreview(convoProvider),
+              ] else
+                SliverToBoxAdapter(child: _buildGetStartedOptions(context)),
 
               // Mind Map section
               SliverToBoxAdapter(
@@ -137,6 +148,116 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
           ),
         );
       },
+    );
+  }
+
+  int _nonDiscardedConversationCount(ConversationProvider provider) {
+    return provider.conversations.where((c) => !c.discarded).length;
+  }
+
+  Widget _buildGetStartedOptions(BuildContext context) {
+    Widget option({
+      required IconData icon,
+      required String label,
+      required VoidCallback onTap,
+    }) {
+      return GestureDetector(
+        onTap: () {
+          HapticFeedback.lightImpact();
+          onTap();
+        },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 88,
+              height: 88,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: const LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [Color(0xFF7B5CFF), Color(0xFF5733E0)],
+                ),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.08), width: 1),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.deepPurple.withValues(alpha: 0.45),
+                    blurRadius: 28,
+                    spreadRadius: 1,
+                    offset: const Offset(0, 10),
+                  ),
+                ],
+              ),
+              child: Icon(icon, color: Colors.white, size: 32),
+            ),
+            const SizedBox(height: 10),
+            SizedBox(
+              width: 96,
+              child: Text(
+                label,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  height: 1.2,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final phoneOption = option(
+      icon: Icons.mic_rounded,
+      label: 'Record with Phone',
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const ConversationCapturingPage()),
+        );
+      },
+    );
+    final callOption = option(
+      icon: Icons.phone_in_talk_rounded,
+      label: 'Record Call',
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const PhoneCallsPage()),
+        );
+      },
+    );
+    final deviceOption = option(
+      icon: Icons.bluetooth_searching_rounded,
+      label: 'Connect Device',
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const DeviceSelectionPage()),
+        );
+      },
+    );
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 28, 16, 24),
+      child: Column(
+        children: [
+          // Top of the triangle: Record with Phone (the simplest path).
+          phoneOption,
+          const SizedBox(height: 22),
+          // Bottom of the triangle: the other two side by side.
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              callOption,
+              deviceOption,
+            ],
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- **Tasks empty state:** hide the corner purple FAB so it doesn't overlap the new "Create Action Item" pill.
- **Home page:** when the user has fewer than 3 non-discarded conversations, replace the recent-conversations preview with a triangle of three big purple gradient tiles (Record with Phone, Record Call, Connect Device).
- **Conversations page:** in the same < 3 case, hide the "Conversations" title and folder tabs, and show a polished hero empty state matching the Tasks one.

## Test plan
- [ ] Fresh install / account with no conversations → home shows the 3 tiles, conversations tab shows the hero, tasks tab still works.
- [ ] Tap each tile (Record with Phone / Record Call / Connect Device) → routes to the corresponding page.
- [ ] After capturing 3+ conversations, home reverts to recent-conversations preview and conversations tab shows folders + title again.
- [ ] Tasks empty state: only the "Create Action Item" pill is visible (no second corner FAB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)