### PR TITLE
fix(desktop): disable beta→dev backend routing — creating ghost Firebase accounts

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed beta build creating empty Firebase accounts on sign-in by routing back to production backend"
+  ],
   "releases": [
     {
       "version": "0.11.365",

--- a/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -16,8 +16,12 @@ enum DesktopBackendEnvironment {
     bundleIdentifier: String,
     updateChannel: String
   ) -> Bool {
-    bundleIdentifier == AppBuild.productionBundleIdentifier
-      && normalizedChannel(updateChannel) == "beta"
+    // Beta-to-dev routing disabled: signed-in users were landing in fresh empty
+    // Firebase accounts (e.g. caLCFj7… instead of viUv7Gtdo… for kodjima33),
+    // because the dev backend's auth path mints custom tokens for new UIDs
+    // instead of linking to the existing prod user. Keep beta on prod backends
+    // until the auth flow is fixed.
+    return false
   }
 
   static func pythonBaseURL(

--- a/desktop/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/Desktop/Tests/APIClientRoutingTests.swift
@@ -154,12 +154,13 @@ final class APIClientRoutingTests: XCTestCase {
         XCTAssertEqual(url, "https://desktop-backend-hhibjajaja-uc.a.run.app/")
     }
 
-    func testDevelopmentBackendSelectionOnlyAppliesToProductionBundleBetaChannel() {
-        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+    func testDevelopmentBackendRoutingDisabled() {
+        // Beta-to-dev routing disabled — see DesktopBackendEnvironment for context.
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "beta"
         ))
-        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "staging"
         ))


### PR DESCRIPTION
## Problem

Production-bundle macOS users on the `beta` update channel are landing in **fresh empty Firebase accounts** after sign-in. Concrete repro: signing in as `kodjima33@gmail.com` on build `0.11.365` creates new Firebase user `caLCFj7IisV85UX9XrrV1aVf3pk1` (no email, no providers, created today) instead of returning the existing `viUv7GtdoHXbK1UBCDlPuTDuPgJ2` that owns all of kodjima33's data. Reported as widespread across beta users.

Both UIDs are in the same `based-hardware` Firebase project (`aud: based-hardware`, `iss: https://securetoken.google.com/based-hardware`), so it's not a project mismatch — the dev auth flow is minting tokens for new UIDs instead of linking to existing ones.

## Cause

PR #7014 (`60046c19f`) routed `com.omi.computer-macos` clients on the `beta` channel to:
- Python: `https://api.omiapi.com/`
- Rust: `https://desktop-backend-dt5lrfkkoa-uc.a.run.app/`

The `OMI_AUTH_URL` is unchanged (still prod `omi-desktop-auth`), but downstream calls through the dev Python backend during sign-in result in a different uid being returned to the client. The empty user record on the new uid (no email, no providers) indicates the path goes through `signInWithCustomToken` for a freshly-generated uid rather than `signInWithIdp` linking by email.

## Fix

Surgical: `shouldUseDevelopmentBackends` now always returns `false`, so prod-beta clients keep talking to prod backends. The routing scaffolding (`DesktopBackendEnvironment`, env-var override paths, `applyReleaseChannelDefaults`) is left in place for when the auth-side issue is properly diagnosed and fixed — at that point this can be reverted.

A full `git revert` of #7014 conflicts with newer changes to `TranscriptionService.swift` and others; this 1-line approach gets the same effect with no merge surgery.

## Verification

- [ ] Codemagic build succeeds
- [ ] Mac mini smoke test: sign in as kodjima33 on the new build, confirm uid = `viUv7GtdoHXbK1UBCDlPuTDuPgJ2` and data loads
- [ ] Confirm `APIClient.baseURL` resolves to `https://api.omi.me/` for prod-beta
- [ ] Confirm `rustBackendURL` resolves to the prod `desktop-backend-hhibjajaja-uc.a.run.app` (or the env-var override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)