### PR TITLE
Update CHANGELOG.json for v0.11.366 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed beta build creating empty Firebase accounts on sign-in by routing back to production backend"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.366",
+      "date": "2026-04-26",
+      "changes": [
+        "Fixed beta build creating empty Firebase accounts on sign-in by routing back to production backend"
+      ]
+    },
     {
       "version": "0.11.365",
       "date": "2026-04-26",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.366 and clears the unreleased array.