### PR TITLE
feat(ios) add home screen quick actions menu

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2958,5 +2958,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "إضافة مهمة",
+  "quickActionAskOmiAnything": "اسأل أومي أي شيء",
+  "quickActionVoiceMode": "الوضع الصوتي",
+  "quickActionMute": "كتم الصوت",
+  "quickActionUnmute": "إلغاء كتم الصوت",
+  "quickActionConnectDevice": "ربط الجهاز",
+  "quickActionDeviceSettings": "إعدادات الجهاز"
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Дадаць заданне",
+  "quickActionAskOmiAnything": "Спытайце ў Омі што заўгодна",
+  "quickActionVoiceMode": "Галасавы рэжым",
+  "quickActionMute": "Адключыць гук",
+  "quickActionUnmute": "Уключыць гук",
+  "quickActionConnectDevice": "Падключыць прыладу",
+  "quickActionDeviceSettings": "Налады прылады"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2960,5 +2960,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Добавяне на задача",
+  "quickActionAskOmiAnything": "Питайте Оми всичко",
+  "quickActionVoiceMode": "Гласов режим",
+  "quickActionMute": "Заглуши",
+  "quickActionUnmute": "Включи звука",
+  "quickActionConnectDevice": "Свържи устройство",
+  "quickActionDeviceSettings": "Настройки на устройство"
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "কাজ যোগ করুন",
+  "quickActionAskOmiAnything": "Omi কে যেকোনো কিছু জিজ্ঞেস করুন",
+  "quickActionVoiceMode": "ভয়েস মোড",
+  "quickActionMute": "নিঃশব্দ",
+  "quickActionUnmute": "শব্দ চালু করুন",
+  "quickActionConnectDevice": "ডিভাইস সংযুক্ত করুন",
+  "quickActionDeviceSettings": "ডিভাইস সেটিংস"
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Dodaj zadatak",
+  "quickActionAskOmiAnything": "Pitajte Omi bilo šta",
+  "quickActionVoiceMode": "Glasovni način",
+  "quickActionMute": "Isključi zvuk",
+  "quickActionUnmute": "Uključi zvuk",
+  "quickActionConnectDevice": "Poveži uređaj",
+  "quickActionDeviceSettings": "Postavke uređaja"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2960,5 +2960,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Afegir tasca",
+  "quickActionAskOmiAnything": "Pregunta-li qualsevol cosa a l'Omi",
+  "quickActionVoiceMode": "Mode de veu",
+  "quickActionMute": "Silenciar",
+  "quickActionUnmute": "Activar so",
+  "quickActionConnectDevice": "Connectar dispositiu",
+  "quickActionDeviceSettings": "Configuració del dispositiu"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2960,5 +2960,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Přidat úkol",
+  "quickActionAskOmiAnything": "Zeptejte se Omi na cokoli",
+  "quickActionVoiceMode": "Hlasový režim",
+  "quickActionMute": "Ztlumit",
+  "quickActionUnmute": "Zapnout zvuk",
+  "quickActionConnectDevice": "Připojit zařízení",
+  "quickActionDeviceSettings": "Nastavení zařízení"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3000,5 +3000,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Tilføj opgave",
+  "quickActionAskOmiAnything": "Spørg Omi om hvad som helst",
+  "quickActionVoiceMode": "Stemmétilstand",
+  "quickActionMute": "Slå lyd fra",
+  "quickActionUnmute": "Slå lyd til",
+  "quickActionConnectDevice": "Tilslut enhed",
+  "quickActionDeviceSettings": "Enhedsindstillinger"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2959,5 +2959,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Aufgabe hinzufügen",
+  "quickActionAskOmiAnything": "Frag Omi alles",
+  "quickActionVoiceMode": "Sprachmodus",
+  "quickActionMute": "Stummschalten",
+  "quickActionUnmute": "Stummschaltung aufheben",
+  "quickActionConnectDevice": "Gerät verbinden",
+  "quickActionDeviceSettings": "Geräteeinstellungen"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Προσθήκη εργασίας",
+  "quickActionAskOmiAnything": "Ρωτήστε τον Omi οτιδήποτε",
+  "quickActionVoiceMode": "Λειτουργία φωνής",
+  "quickActionMute": "Σίγαση",
+  "quickActionUnmute": "Αναίρεση σίγασης",
+  "quickActionConnectDevice": "Σύνδεση συσκευής",
+  "quickActionDeviceSettings": "Ρυθμίσεις συσκευής"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10900,5 +10900,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Add Task",
+  "quickActionAskOmiAnything": "Ask Omi Anything",
+  "quickActionVoiceMode": "Voice Mode",
+  "quickActionMute": "Mute",
+  "quickActionUnmute": "Unmute",
+  "quickActionConnectDevice": "Connect Device",
+  "quickActionDeviceSettings": "Device Settings"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2992,5 +2992,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Agregar tarea",
+  "quickActionAskOmiAnything": "Pregúntale cualquier cosa a Omi",
+  "quickActionVoiceMode": "Modo de voz",
+  "quickActionMute": "Silenciar",
+  "quickActionUnmute": "Activar sonido",
+  "quickActionConnectDevice": "Conectar dispositivo",
+  "quickActionDeviceSettings": "Configuración del dispositivo"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Lisa ülesanne",
+  "quickActionAskOmiAnything": "Küsi Omilt ükskõik mida",
+  "quickActionVoiceMode": "Häälerežiim",
+  "quickActionMute": "Vaigista",
+  "quickActionUnmute": "Tühista vaigistus",
+  "quickActionConnectDevice": "Ühenda seade",
+  "quickActionDeviceSettings": "Seadme sätted"
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "افزودن وظیفه",
+  "quickActionAskOmiAnything": "هر چیزی از اُمی بپرسید",
+  "quickActionVoiceMode": "حالت صوتی",
+  "quickActionMute": "بی‌صدا",
+  "quickActionUnmute": "لغو بی‌صدا",
+  "quickActionConnectDevice": "اتصال دستگاه",
+  "quickActionDeviceSettings": "تنظیمات دستگاه"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Lisää tehtävä",
+  "quickActionAskOmiAnything": "Kysy Omilta mitä tahansa",
+  "quickActionVoiceMode": "Äänitila",
+  "quickActionMute": "Mykistä",
+  "quickActionUnmute": "Poista mykistys",
+  "quickActionConnectDevice": "Yhdistä laite",
+  "quickActionDeviceSettings": "Laiteasetukset"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3026,5 +3026,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Ajouter une tâche",
+  "quickActionAskOmiAnything": "Demandez n'importe quoi à Omi",
+  "quickActionVoiceMode": "Mode vocal",
+  "quickActionMute": "Couper le son",
+  "quickActionUnmute": "Activer le son",
+  "quickActionConnectDevice": "Connecter l'appareil",
+  "quickActionDeviceSettings": "Paramètres de l'appareil"
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "הוסף משימה",
+  "quickActionAskOmiAnything": "שאל את Omi כל דבר",
+  "quickActionVoiceMode": "מצב קול",
+  "quickActionMute": "השתק",
+  "quickActionUnmute": "בטל השתקה",
+  "quickActionConnectDevice": "חבר מכשיר",
+  "quickActionDeviceSettings": "הגדרות מכשיר"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2992,5 +2992,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "कार्य जोड़ें",
+  "quickActionAskOmiAnything": "Omi से कुछ भी पूछें",
+  "quickActionVoiceMode": "वॉयस मोड",
+  "quickActionMute": "म्यूट करें",
+  "quickActionUnmute": "म्यूट हटाएं",
+  "quickActionConnectDevice": "डिवाइस कनेक्ट करें",
+  "quickActionDeviceSettings": "डिवाइस सेटिंग्स"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Dodaj zadatak",
+  "quickActionAskOmiAnything": "Pitajte Omi bilo što",
+  "quickActionVoiceMode": "Glasovni način rada",
+  "quickActionMute": "Isključi zvuk",
+  "quickActionUnmute": "Uključi zvuk",
+  "quickActionConnectDevice": "Poveži uređaj",
+  "quickActionDeviceSettings": "Postavke uređaja"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3087,5 +3087,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Feladat hozzáadása",
+  "quickActionAskOmiAnything": "Kérdezz bármit Omitól",
+  "quickActionVoiceMode": "Hangmód",
+  "quickActionMute": "Némítás",
+  "quickActionUnmute": "Némítás feloldása",
+  "quickActionConnectDevice": "Eszköz csatlakoztatása",
+  "quickActionDeviceSettings": "Eszközbeállítások"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3033,5 +3033,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Tambah Tugas",
+  "quickActionAskOmiAnything": "Tanyakan apa saja kepada Omi",
+  "quickActionVoiceMode": "Mode Suara",
+  "quickActionMute": "Bisukan",
+  "quickActionUnmute": "Aktifkan Suara",
+  "quickActionConnectDevice": "Hubungkan Perangkat",
+  "quickActionDeviceSettings": "Pengaturan Perangkat"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Aggiungi attività",
+  "quickActionAskOmiAnything": "Chiedi qualsiasi cosa a Omi",
+  "quickActionVoiceMode": "Modalità voce",
+  "quickActionMute": "Silenzia",
+  "quickActionUnmute": "Riattiva audio",
+  "quickActionConnectDevice": "Connetti dispositivo",
+  "quickActionDeviceSettings": "Impostazioni dispositivo"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2992,5 +2992,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "タスクを追加",
+  "quickActionAskOmiAnything": "Omiに何でも聞く",
+  "quickActionVoiceMode": "音声モード",
+  "quickActionMute": "ミュート",
+  "quickActionUnmute": "ミュート解除",
+  "quickActionConnectDevice": "デバイスを接続",
+  "quickActionDeviceSettings": "デバイス設定"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "ಕಾರ್ಯ ಸೇರಿಸಿ",
+  "quickActionAskOmiAnything": "Omi ಗೆ ಯಾವುದನ್ನಾದರೂ ಕೇಳಿ",
+  "quickActionVoiceMode": "ಧ್ವನಿ ಮೋಡ್",
+  "quickActionMute": "ಮ್ಯೂಟ್",
+  "quickActionUnmute": "ಅನ್‌ಮ್ಯೂಟ್",
+  "quickActionConnectDevice": "ಸಾಧನ ಸಂಪರ್ಕಿಸಿ",
+  "quickActionDeviceSettings": "ಸಾಧನ ಸೆಟ್ಟಿಂಗ್‌ಗಳು"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "작업 추가",
+  "quickActionAskOmiAnything": "Omi에게 무엇이든 물어보세요",
+  "quickActionVoiceMode": "음성 모드",
+  "quickActionMute": "음소거",
+  "quickActionUnmute": "음소거 해제",
+  "quickActionConnectDevice": "기기 연결",
+  "quickActionDeviceSettings": "기기 설정"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17102,6 +17102,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Mind Map'**
   String get mindMap;
+
+  /// No description provided for @quickActionAddTask.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Task'**
+  String get quickActionAddTask;
+
+  /// No description provided for @quickActionAskOmiAnything.
+  ///
+  /// In en, this message translates to:
+  /// **'Ask Omi Anything'**
+  String get quickActionAskOmiAnything;
+
+  /// No description provided for @quickActionVoiceMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Voice Mode'**
+  String get quickActionVoiceMode;
+
+  /// No description provided for @quickActionMute.
+  ///
+  /// In en, this message translates to:
+  /// **'Mute'**
+  String get quickActionMute;
+
+  /// No description provided for @quickActionUnmute.
+  ///
+  /// In en, this message translates to:
+  /// **'Unmute'**
+  String get quickActionUnmute;
+
+  /// No description provided for @quickActionConnectDevice.
+  ///
+  /// In en, this message translates to:
+  /// **'Connect Device'**
+  String get quickActionConnectDevice;
+
+  /// No description provided for @quickActionDeviceSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Device Settings'**
+  String get quickActionDeviceSettings;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
@@ -17113,167 +17155,72 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>[
-        'ar',
-        'be',
-        'bg',
-        'bn',
-        'bs',
-        'ca',
-        'cs',
-        'da',
-        'de',
-        'el',
-        'en',
-        'es',
-        'et',
-        'fa',
-        'fi',
-        'fr',
-        'he',
-        'hi',
-        'hr',
-        'hu',
-        'id',
-        'it',
-        'ja',
-        'kn',
-        'ko',
-        'lt',
-        'lv',
-        'mk',
-        'mr',
-        'ms',
-        'nl',
-        'no',
-        'pl',
-        'pt',
-        'ro',
-        'ru',
-        'sk',
-        'sl',
-        'sr',
-        'sv',
-        'ta',
-        'te',
-        'th',
-        'tl',
-        'tr',
-        'uk',
-        'ur',
-        'vi',
-        'zh'
-      ].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['ar', 'be', 'bg', 'bn', 'bs', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'et', 'fa', 'fi', 'fr', 'he', 'hi', 'hr', 'hu', 'id', 'it', 'ja', 'kn', 'ko', 'lt', 'lv', 'mk', 'mr', 'ms', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'vi', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'ar':
-      return AppLocalizationsAr();
-    case 'be':
-      return AppLocalizationsBe();
-    case 'bg':
-      return AppLocalizationsBg();
-    case 'bn':
-      return AppLocalizationsBn();
-    case 'bs':
-      return AppLocalizationsBs();
-    case 'ca':
-      return AppLocalizationsCa();
-    case 'cs':
-      return AppLocalizationsCs();
-    case 'da':
-      return AppLocalizationsDa();
-    case 'de':
-      return AppLocalizationsDe();
-    case 'el':
-      return AppLocalizationsEl();
-    case 'en':
-      return AppLocalizationsEn();
-    case 'es':
-      return AppLocalizationsEs();
-    case 'et':
-      return AppLocalizationsEt();
-    case 'fa':
-      return AppLocalizationsFa();
-    case 'fi':
-      return AppLocalizationsFi();
-    case 'fr':
-      return AppLocalizationsFr();
-    case 'he':
-      return AppLocalizationsHe();
-    case 'hi':
-      return AppLocalizationsHi();
-    case 'hr':
-      return AppLocalizationsHr();
-    case 'hu':
-      return AppLocalizationsHu();
-    case 'id':
-      return AppLocalizationsId();
-    case 'it':
-      return AppLocalizationsIt();
-    case 'ja':
-      return AppLocalizationsJa();
-    case 'kn':
-      return AppLocalizationsKn();
-    case 'ko':
-      return AppLocalizationsKo();
-    case 'lt':
-      return AppLocalizationsLt();
-    case 'lv':
-      return AppLocalizationsLv();
-    case 'mk':
-      return AppLocalizationsMk();
-    case 'mr':
-      return AppLocalizationsMr();
-    case 'ms':
-      return AppLocalizationsMs();
-    case 'nl':
-      return AppLocalizationsNl();
-    case 'no':
-      return AppLocalizationsNo();
-    case 'pl':
-      return AppLocalizationsPl();
-    case 'pt':
-      return AppLocalizationsPt();
-    case 'ro':
-      return AppLocalizationsRo();
-    case 'ru':
-      return AppLocalizationsRu();
-    case 'sk':
-      return AppLocalizationsSk();
-    case 'sl':
-      return AppLocalizationsSl();
-    case 'sr':
-      return AppLocalizationsSr();
-    case 'sv':
-      return AppLocalizationsSv();
-    case 'ta':
-      return AppLocalizationsTa();
-    case 'te':
-      return AppLocalizationsTe();
-    case 'th':
-      return AppLocalizationsTh();
-    case 'tl':
-      return AppLocalizationsTl();
-    case 'tr':
-      return AppLocalizationsTr();
-    case 'uk':
-      return AppLocalizationsUk();
-    case 'ur':
-      return AppLocalizationsUr();
-    case 'vi':
-      return AppLocalizationsVi();
-    case 'zh':
-      return AppLocalizationsZh();
+    case 'ar': return AppLocalizationsAr();
+    case 'be': return AppLocalizationsBe();
+    case 'bg': return AppLocalizationsBg();
+    case 'bn': return AppLocalizationsBn();
+    case 'bs': return AppLocalizationsBs();
+    case 'ca': return AppLocalizationsCa();
+    case 'cs': return AppLocalizationsCs();
+    case 'da': return AppLocalizationsDa();
+    case 'de': return AppLocalizationsDe();
+    case 'el': return AppLocalizationsEl();
+    case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
+    case 'et': return AppLocalizationsEt();
+    case 'fa': return AppLocalizationsFa();
+    case 'fi': return AppLocalizationsFi();
+    case 'fr': return AppLocalizationsFr();
+    case 'he': return AppLocalizationsHe();
+    case 'hi': return AppLocalizationsHi();
+    case 'hr': return AppLocalizationsHr();
+    case 'hu': return AppLocalizationsHu();
+    case 'id': return AppLocalizationsId();
+    case 'it': return AppLocalizationsIt();
+    case 'ja': return AppLocalizationsJa();
+    case 'kn': return AppLocalizationsKn();
+    case 'ko': return AppLocalizationsKo();
+    case 'lt': return AppLocalizationsLt();
+    case 'lv': return AppLocalizationsLv();
+    case 'mk': return AppLocalizationsMk();
+    case 'mr': return AppLocalizationsMr();
+    case 'ms': return AppLocalizationsMs();
+    case 'nl': return AppLocalizationsNl();
+    case 'no': return AppLocalizationsNo();
+    case 'pl': return AppLocalizationsPl();
+    case 'pt': return AppLocalizationsPt();
+    case 'ro': return AppLocalizationsRo();
+    case 'ru': return AppLocalizationsRu();
+    case 'sk': return AppLocalizationsSk();
+    case 'sl': return AppLocalizationsSl();
+    case 'sr': return AppLocalizationsSr();
+    case 'sv': return AppLocalizationsSv();
+    case 'ta': return AppLocalizationsTa();
+    case 'te': return AppLocalizationsTe();
+    case 'th': return AppLocalizationsTh();
+    case 'tl': return AppLocalizationsTl();
+    case 'tr': return AppLocalizationsTr();
+    case 'uk': return AppLocalizationsUk();
+    case 'ur': return AppLocalizationsUr();
+    case 'vi': return AppLocalizationsVi();
+    case 'zh': return AppLocalizationsZh();
   }
 
-  throw FlutterError('AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -24,8 +24,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deleteConversationTitle => 'حذف المحادثة؟';
 
   @override
-  String get deleteConversationMessage =>
-      'سيؤدي هذا أيضًا إلى حذف الذكريات والمهام وملفات الصوت المرتبطة. لا يمكن التراجع عن هذا الإجراء.';
+  String get deleteConversationMessage => 'سيؤدي هذا أيضًا إلى حذف الذكريات والمهام وملفات الصوت المرتبطة. لا يمكن التراجع عن هذا الإجراء.';
 
   @override
   String get confirm => 'تأكيد';
@@ -357,15 +356,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get exportBeforeDelete => 'يمكنك تصدير بياناتك قبل حذف حسابك، ولكن بمجرد الحذف، لا يمكن استردادها.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'أدرك أن حذف حسابي دائم وأن جميع البيانات، بما في ذلك الذكريات والمحادثات، ستُفقد ولا يمكن استردادها.';
+  String get deleteAccountCheckbox => 'أدرك أن حذف حسابي دائم وأن جميع البيانات، بما في ذلك الذكريات والمحادثات، ستُفقد ولا يمكن استردادها.';
 
   @override
   String get areYouSure => 'هل أنت متأكد؟';
 
   @override
-  String get deleteAccountFinal =>
-      'هذا الإجراء لا رجعة فيه وسيحذف حسابك وجميع البيانات المرتبطة به نهائياً. هل أنت متأكد من رغبتك في المتابعة؟';
+  String get deleteAccountFinal => 'هذا الإجراء لا رجعة فيه وسيحذف حسابك وجميع البيانات المرتبطة به نهائياً. هل أنت متأكد من رغبتك في المتابعة؟';
 
   @override
   String get deleteNow => 'احذف الآن';
@@ -452,8 +449,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get yourPrivacyYourControl => 'خصوصيتك، تحكمك';
 
   @override
-  String get privacyIntro =>
-      'في Omi، نحن ملتزمون بحماية خصوصيتك. تتيح لك هذه الصفحة التحكم في كيفية تخزين بياناتك واستخدامها.';
+  String get privacyIntro => 'في Omi، نحن ملتزمون بحماية خصوصيتك. تتيح لك هذه الصفحة التحكم في كيفية تخزين بياناتك واستخدامها.';
 
   @override
   String get learnMore => 'اعرف المزيد...';
@@ -462,8 +458,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dataProtectionLevel => 'مستوى حماية البيانات';
 
   @override
-  String get dataProtectionDesc =>
-      'بياناتك محمية افتراضياً بتشفير قوي. راجع إعداداتك وخيارات الخصوصية المستقبلية أدناه.';
+  String get dataProtectionDesc => 'بياناتك محمية افتراضياً بتشفير قوي. راجع إعداداتك وخيارات الخصوصية المستقبلية أدناه.';
 
   @override
   String get appAccess => 'وصول التطبيقات';
@@ -526,15 +521,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deviceDisconnectedMessage => 'تم قطع اتصال Omi الخاص بك 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'تم إلغاء إقران الجهاز. انتقل إلى الإعدادات > البلوتوث وانسَ الجهاز لإكمال إلغاء الإقران.';
+  String get deviceUnpairedMessage => 'تم إلغاء إقران الجهاز. انتقل إلى الإعدادات > البلوتوث وانسَ الجهاز لإكمال إلغاء الإقران.';
 
   @override
   String get unpairDialogTitle => 'إلغاء إقران الجهاز';
 
   @override
-  String get unpairDialogMessage =>
-      'سيؤدي هذا إلى إلغاء إقران الجهاز بحيث يمكن توصيله بهاتف آخر. ستحتاج إلى الذهاب إلى الإعدادات > البلوتوث ونسيان الجهاز لإكمال العملية.';
+  String get unpairDialogMessage => 'سيؤدي هذا إلى إلغاء إقران الجهاز بحيث يمكن توصيله بهاتف آخر. ستحتاج إلى الذهاب إلى الإعدادات > البلوتوث ونسيان الجهاز لإكمال العملية.';
 
   @override
   String get deviceNotConnected => 'الجهاز غير متصل';
@@ -829,8 +822,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'حذف الرسم البياني للمعرفة؟';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'سيؤدي هذا إلى حذف جميع بيانات الرسم البياني للمعرفة المشتقة (العقد والاتصالات). ستبقى ذكرياتك الأصلية آمنة. سيتم إعادة بناء الرسم البياني بمرور الوقت أو عند الطلب التالي.';
+  String get deleteKnowledgeGraphMessage => 'سيؤدي هذا إلى حذف جميع بيانات الرسم البياني للمعرفة المشتقة (العقد والاتصالات). ستبقى ذكرياتك الأصلية آمنة. سيتم إعادة بناء الرسم البياني بمرور الوقت أو عند الطلب التالي.';
 
   @override
   String get knowledgeGraphDeleted => 'تم حذف الرسم البياني المعرفي';
@@ -1097,8 +1089,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get enhanceTranscriptAccuracyDesc => 'مع تحسن نموذجنا، يمكننا توفير نتائج نسخ أفضل لتسجيلاتك.';
 
   @override
-  String get legalNotice =>
-      'إشعار قانوني: قد تختلف قانونية تسجيل وتخزين البيانات الصوتية اعتماداً على موقعك وكيفية استخدامك لهذه الميزة. من مسؤوليتك ضمان الامتثال للقوانين واللوائح المحلية.';
+  String get legalNotice => 'إشعار قانوني: قد تختلف قانونية تسجيل وتخزين البيانات الصوتية اعتماداً على موقعك وكيفية استخدامك لهذه الميزة. من مسؤوليتك ضمان الامتثال للقوانين واللوائح المحلية.';
 
   @override
   String get alreadyAuthorized => 'تم التفويض بالفعل';
@@ -1344,8 +1335,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get defaultRepository => 'المستودع الافتراضي';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'حدد مستودعاً افتراضياً لإنشاء المشكلات. لا يزال بإمكانك تحديد مستودع مختلف عند إنشاء المشكلات.';
+  String get selectDefaultRepoDesc => 'حدد مستودعاً افتراضياً لإنشاء المشكلات. لا يزال بإمكانك تحديد مستودع مختلف عند إنشاء المشكلات.';
 
   @override
   String get noReposFound => 'لم يتم العثور على مستودعات';
@@ -1720,8 +1710,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get enableBluetooth => 'تمكين البلوتوث';
 
   @override
-  String get bluetoothNeeded =>
-      'يحتاج Omi إلى البلوتوث للاتصال بجهازك القابل للارتداء. يرجى تمكين البلوتوث والمحاولة مرة أخرى.';
+  String get bluetoothNeeded => 'يحتاج Omi إلى البلوتوث للاتصال بجهازك القابل للارتداء. يرجى تمكين البلوتوث والمحاولة مرة أخرى.';
 
   @override
   String get contactSupport => 'الاتصال بالدعم؟';
@@ -1754,8 +1743,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get locationServiceDisabled => 'خدمة الموقع معطلة';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'خدمة الموقع معطلة. يرجى الذهاب إلى الإعدادات > الخصوصية والأمان > خدمات الموقع وتمكينها';
+  String get locationServiceDisabledDesc => 'خدمة الموقع معطلة. يرجى الذهاب إلى الإعدادات > الخصوصية والأمان > خدمات الموقع وتمكينها';
 
   @override
   String get backgroundLocationDenied => 'تم رفض الوصول إلى الموقع في الخلفية';
@@ -1767,12 +1755,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get lovingOmi => 'تحب Omi؟';
 
   @override
-  String get leaveReviewIos =>
-      'ساعدنا في الوصول إلى المزيد من الأشخاص من خلال ترك تقييم في App Store. ملاحظاتك تعني لنا الكثير!';
+  String get leaveReviewIos => 'ساعدنا في الوصول إلى المزيد من الأشخاص من خلال ترك تقييم في App Store. ملاحظاتك تعني لنا الكثير!';
 
   @override
-  String get leaveReviewAndroid =>
-      'ساعدنا في الوصول إلى المزيد من الأشخاص من خلال ترك تقييم في Google Play Store. ملاحظاتك تعني لنا الكثير!';
+  String get leaveReviewAndroid => 'ساعدنا في الوصول إلى المزيد من الأشخاص من خلال ترك تقييم في Google Play Store. ملاحظاتك تعني لنا الكثير!';
 
   @override
   String get rateOnAppStore => 'التقييم على App Store';
@@ -1811,8 +1797,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get invalidRecordingMultipleSpeakers => 'تم اكتشاف تسجيل غير صالح';
 
   @override
-  String get multipleSpeakersDesc =>
-      'يبدو أن هناك عدة متحدثين في التسجيل. يرجى التأكد من أنك في موقع هادئ والمحاولة مرة أخرى.';
+  String get multipleSpeakersDesc => 'يبدو أن هناك عدة متحدثين في التسجيل. يرجى التأكد من أنك في موقع هادئ والمحاولة مرة أخرى.';
 
   @override
   String get tooShortDesc => 'لا يوجد كلام كافٍ مكتشف. يرجى التحدث أكثر والمحاولة مرة أخرى.';
@@ -1824,8 +1809,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get areYouThere => 'هل أنت هناك؟';
 
   @override
-  String get noSpeechDesc =>
-      'لم نتمكن من اكتشاف أي كلام. يرجى التأكد من التحدث لمدة 10 ثوانٍ على الأقل وليس أكثر من 3 دقائق.';
+  String get noSpeechDesc => 'لم نتمكن من اكتشاف أي كلام. يرجى التأكد من التحدث لمدة 10 ثوانٍ على الأقل وليس أكثر من 3 دقائق.';
 
   @override
   String get connectionLost => 'فُقد الاتصال';
@@ -1846,8 +1830,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get permissionsRequired => 'الأذونات مطلوبة';
 
   @override
-  String get permissionsRequiredDesc =>
-      'يحتاج هذا التطبيق إلى أذونات البلوتوث والموقع للعمل بشكل صحيح. يرجى تمكينها في الإعدادات.';
+  String get permissionsRequiredDesc => 'يحتاج هذا التطبيق إلى أذونات البلوتوث والموقع للعمل بشكل صحيح. يرجى تمكينها في الإعدادات.';
 
   @override
   String get openSettings => 'فتح الإعدادات';
@@ -1877,8 +1860,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – رفيقك الذكي';
 
   @override
-  String get captureEveryMoment =>
-      'احتفظ بكل لحظة. احصل على ملخصات مدعومة بالذكاء الاصطناعي.\nلا تدون ملاحظات بعد الآن.';
+  String get captureEveryMoment => 'احتفظ بكل لحظة. احصل على ملخصات مدعومة بالذكاء الاصطناعي.\nلا تدون ملاحظات بعد الآن.';
 
   @override
   String get appleWatchSetup => 'إعداد Apple Watch';
@@ -1893,8 +1875,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get permissionGrantedNow => 'تم منح الإذن! الآن:\n\nافتح تطبيق Omi على ساعتك واضغط على \"متابعة\" أدناه';
 
   @override
-  String get needMicrophonePermission =>
-      'نحتاج إذن الميكروفون.\n\n1. اضغط على \"منح الإذن\"\n2. اسمح على iPhone الخاص بك\n3. سيُغلق تطبيق الساعة\n4. أعد فتحه واضغط على \"متابعة\"';
+  String get needMicrophonePermission => 'نحتاج إذن الميكروفون.\n\n1. اضغط على \"منح الإذن\"\n2. اسمح على iPhone الخاص بك\n3. سيُغلق تطبيق الساعة\n4. أعد فتحه واضغط على \"متابعة\"';
 
   @override
   String get grantPermissionButton => 'منح الإذن';
@@ -1903,15 +1884,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get needHelp => 'تحتاج مساعدة؟';
 
   @override
-  String get troubleshootingSteps =>
-      'استكشاف الأخطاء وإصلاحها:\n\n1. تأكد من تثبيت Omi على ساعتك\n2. افتح تطبيق Omi على ساعتك\n3. ابحث عن نافذة الإذن المنبثقة\n4. اضغط على \"السماح\" عند المطالبة\n5. سيغلق التطبيق على ساعتك - أعد فتحه\n6. ارجع واضغط على \"متابعة\" على iPhone الخاص بك';
+  String get troubleshootingSteps => 'استكشاف الأخطاء وإصلاحها:\n\n1. تأكد من تثبيت Omi على ساعتك\n2. افتح تطبيق Omi على ساعتك\n3. ابحث عن نافذة الإذن المنبثقة\n4. اضغط على \"السماح\" عند المطالبة\n5. سيغلق التطبيق على ساعتك - أعد فتحه\n6. ارجع واضغط على \"متابعة\" على iPhone الخاص بك';
 
   @override
   String get recordingStartedSuccessfully => 'بدأ التسجيل بنجاح!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'لم يتم منح الإذن بعد. يرجى التأكد من أنك سمحت بالوصول إلى الميكروفون وأعدت فتح التطبيق على ساعتك.';
+  String get permissionNotGrantedYet => 'لم يتم منح الإذن بعد. يرجى التأكد من أنك سمحت بالوصول إلى الميكروفون وأعدت فتح التطبيق على ساعتك.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2008,8 +1987,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get welcomeActionItemsTitle => 'جاهز للمهام';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'سيستخرج الذكاء الاصطناعي الخاص بك المهام والأعمال تلقائياً من محادثاتك. ستظهر هنا عند إنشائها.';
+  String get welcomeActionItemsDescription => 'سيستخرج الذكاء الاصطناعي الخاص بك المهام والأعمال تلقائياً من محادثاتك. ستظهر هنا عند إنشائها.';
 
   @override
   String get autoExtractionFeature => 'يتم استخراجها تلقائياً من المحادثات';
@@ -2211,8 +2189,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get translationNotice => 'إشعار الترجمة';
 
   @override
-  String get translationNoticeMessage =>
-      'يترجم Omi المحادثات إلى لغتك الأساسية. يمكنك تحديثها في أي وقت في الإعدادات → الملفات الشخصية.';
+  String get translationNoticeMessage => 'يترجم Omi المحادثات إلى لغتك الأساسية. يمكنك تحديثها في أي وقت في الإعدادات → الملفات الشخصية.';
 
   @override
   String get pleaseCheckInternetConnection => 'يرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى';
@@ -2367,8 +2344,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'إلغاء إقران الجهاز';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'سيؤدي هذا إلى إلغاء إقران الجهاز حتى يمكن توصيله بهاتف آخر. ستحتاج إلى الانتقال إلى الإعدادات > البلوتوث ونسيان الجهاز لإكمال العملية.';
+  String get unpairDeviceDialogMessage => 'سيؤدي هذا إلى إلغاء إقران الجهاز حتى يمكن توصيله بهاتف آخر. ستحتاج إلى الانتقال إلى الإعدادات > البلوتوث ونسيان الجهاز لإكمال العملية.';
 
   @override
   String get unpair => 'إلغاء الإقران';
@@ -2850,12 +2826,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get submitAppQuestion => 'إرسال التطبيق؟';
 
   @override
-  String get submitAppPublicDescription =>
-      'سيتم مراجعة تطبيقك ونشره للعامة. يمكنك البدء في استخدامه فورًا، حتى أثناء المراجعة!';
+  String get submitAppPublicDescription => 'سيتم مراجعة تطبيقك ونشره للعامة. يمكنك البدء في استخدامه فورًا، حتى أثناء المراجعة!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'سيتم مراجعة تطبيقك وإتاحته لك بشكل خاص. يمكنك البدء في استخدامه فورًا، حتى أثناء المراجعة!';
+  String get submitAppPrivateDescription => 'سيتم مراجعة تطبيقك وإتاحته لك بشكل خاص. يمكنك البدء في استخدامه فورًا، حتى أثناء المراجعة!';
 
   @override
   String get startEarning => 'ابدأ الكسب! 💰';
@@ -2879,15 +2853,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dataAccessNotice => 'إشعار الوصول إلى البيانات';
 
   @override
-  String get dataAccessWarning =>
-      'سيصل هذا التطبيق إلى بياناتك. Omi AI غير مسؤول عن كيفية استخدام بياناتك أو تعديلها أو حذفها بواسطة هذا التطبيق';
+  String get dataAccessWarning => 'سيصل هذا التطبيق إلى بياناتك. Omi AI غير مسؤول عن كيفية استخدام بياناتك أو تعديلها أو حذفها بواسطة هذا التطبيق';
 
   @override
   String get installApp => 'تثبيت التطبيق';
 
   @override
-  String get betaTesterNotice =>
-      'أنت مختبر تجريبي لهذا التطبيق. إنه غير عام حتى الآن. سيكون عامًا بمجرد الموافقة عليه.';
+  String get betaTesterNotice => 'أنت مختبر تجريبي لهذا التطبيق. إنه غير عام حتى الآن. سيكون عامًا بمجرد الموافقة عليه.';
 
   @override
   String get appUnderReviewOwner => 'تطبيقك قيد المراجعة ومرئي لك فقط. سيكون عامًا بمجرد الموافقة عليه.';
@@ -3107,8 +3079,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get microphonePermissionRequired => 'إذن الميكروفون مطلوب لإجراء المكالمات';
 
   @override
-  String get microphonePermissionDenied =>
-      'تم رفض إذن الميكروفون. يرجى منح الإذن في تفضيلات النظام > الخصوصية والأمان > الميكروفون.';
+  String get microphonePermissionDenied => 'تم رفض إذن الميكروفون. يرجى منح الإذن في تفضيلات النظام > الخصوصية والأمان > الميكروفون.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3341,8 +3312,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get whatWeCollect => 'ما نجمعه';
 
   @override
-  String get dataCollectionMessage =>
-      'بالمتابعة، سيتم تخزين محادثاتك وتسجيلاتك ومعلوماتك الشخصية بشكل آمن على خوادمنا لتوفير رؤى مدعومة بالذكاء الاصطناعي وتمكين جميع ميزات التطبيق.';
+  String get dataCollectionMessage => 'بالمتابعة، سيتم تخزين محادثاتك وتسجيلاتك ومعلوماتك الشخصية بشكل آمن على خوادمنا لتوفير رؤى مدعومة بالذكاء الاصطناعي وتمكين جميع ميزات التطبيق.';
 
   @override
   String get dataProtection => 'حماية البيانات';
@@ -3392,8 +3362,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get recordAudioConversations => 'تسجيل المحادثات الصوتية';
 
   @override
-  String get microphoneAccessDescription =>
-      'يحتاج Omi إلى الوصول إلى الميكروفون لتسجيل محادثاتك وتوفير النصوص المكتوبة.';
+  String get microphoneAccessDescription => 'يحتاج Omi إلى الوصول إلى الميكروفون لتسجيل محادثاتك وتوفير النصوص المكتوبة.';
 
   @override
   String get screenRecording => 'تسجيل الشاشة';
@@ -3402,8 +3371,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'التقاط صوت النظام من الاجتماعات';
 
   @override
-  String get screenRecordingDescription =>
-      'يحتاج Omi إلى إذن تسجيل الشاشة للتقاط صوت النظام من اجتماعات المتصفح الخاصة بك.';
+  String get screenRecordingDescription => 'يحتاج Omi إلى إذن تسجيل الشاشة للتقاط صوت النظام من اجتماعات المتصفح الخاصة بك.';
 
   @override
   String get accessibility => 'إمكانية الوصول';
@@ -3412,8 +3380,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'اكتشاف الاجتماعات عبر المتصفح';
 
   @override
-  String get accessibilityDescription =>
-      'يحتاج Omi إلى إذن إمكانية الوصول لاكتشاف متى تنضم إلى اجتماعات Zoom أو Meet أو Teams في متصفحك.';
+  String get accessibilityDescription => 'يحتاج Omi إلى إذن إمكانية الوصول لاكتشاف متى تنضم إلى اجتماعات Zoom أو Meet أو Teams في متصفحك.';
 
   @override
   String get pleaseWait => 'يرجى الانتظار...';
@@ -3485,8 +3452,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get conversationsExportStarted => 'بدأ تصدير المحادثات. قد يستغرق هذا بضع ثوانٍ، يرجى الانتظار.';
 
   @override
-  String get mcpDescription =>
-      'للاتصال بـ Omi مع التطبيقات الأخرى لقراءة وبحث وإدارة ذكرياتك ومحادثاتك. قم بإنشاء مفتاح للبدء.';
+  String get mcpDescription => 'للاتصال بـ Omi مع التطبيقات الأخرى لقراءة وبحث وإدارة ذكرياتك ومحادثاتك. قم بإنشاء مفتاح للبدء.';
 
   @override
   String get apiKeys => 'مفاتيح API';
@@ -3642,8 +3608,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get preparingSystemAudioCapture => 'جارٍ تحضير التقاط الصوت النظام';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'انقر على الزر لالتقاط الصوت للحصول على نصوص مباشرة ورؤى الذكاء الاصطناعي والحفظ التلقائي.';
+  String get clickTheButtonToCaptureAudio => 'انقر على الزر لالتقاط الصوت للحصول على نصوص مباشرة ورؤى الذكاء الاصطناعي والحفظ التلقائي.';
 
   @override
   String get reconnecting => 'جارٍ إعادة الاتصال...';
@@ -3870,8 +3835,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'حذف رسم المعرفة؟';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'سيؤدي هذا إلى حذف جميع بيانات رسم المعرفة المشتقة. تظل ذكرياتك الأصلية آمنة.';
+  String get deleteKnowledgeGraphWarning => 'سيؤدي هذا إلى حذف جميع بيانات رسم المعرفة المشتقة. تظل ذكرياتك الأصلية آمنة.';
 
   @override
   String get connectOmiWithAI => 'ربط Omi بمساعدي الذكاء الاصطناعي';
@@ -3928,8 +3892,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get updateAppQuestion => 'تحديث التطبيق؟';
 
   @override
-  String get updateAppConfirmation =>
-      'هل أنت متأكد من رغبتك في تحديث تطبيقك؟ ستظهر التغييرات بعد مراجعتها من قبل فريقنا.';
+  String get updateAppConfirmation => 'هل أنت متأكد من رغبتك في تحديث تطبيقك؟ ستظهر التغييرات بعد مراجعتها من قبل فريقنا.';
 
   @override
   String get updateApp => 'تحديث التطبيق';
@@ -3995,8 +3958,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'إلغاء الاشتراك؟';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'هل أنت متأكد من رغبتك في إلغاء اشتراكك؟ سيستمر وصولك حتى نهاية فترة الفوترة الحالية.';
+  String get cancelSubscriptionConfirmation => 'هل أنت متأكد من رغبتك في إلغاء اشتراكك؟ سيستمر وصولك حتى نهاية فترة الفوترة الحالية.';
 
   @override
   String get cancelSubscriptionButton => 'إلغاء الاشتراك';
@@ -4065,8 +4027,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get issueActivatingApp => 'حدثت مشكلة في تفعيل هذا التطبيق. يرجى المحاولة مرة أخرى.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'سيصل هذا التطبيق إلى بياناتك. Omi AI ليس مسؤولاً عن كيفية استخدام بياناتك أو تعديلها أو حذفها بواسطة هذا التطبيق';
+  String get dataAccessNoticeDescription => 'سيصل هذا التطبيق إلى بياناتك. Omi AI ليس مسؤولاً عن كيفية استخدام بياناتك أو تعديلها أو حذفها بواسطة هذا التطبيق';
 
   @override
   String get copyUrl => 'نسخ الرابط';
@@ -4154,8 +4115,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get omiApiKeys => 'مفاتيح Omi API';
 
   @override
-  String get apiKeysDescription =>
-      'تُستخدم مفاتيح API للمصادقة عندما يتواصل تطبيقك مع خادم OMI. تسمح لتطبيقك بإنشاء ذكريات والوصول إلى خدمات OMI الأخرى بأمان.';
+  String get apiKeysDescription => 'تُستخدم مفاتيح API للمصادقة عندما يتواصل تطبيقك مع خادم OMI. تسمح لتطبيقك بإنشاء ذكريات والوصول إلى خدمات OMI الأخرى بأمان.';
 
   @override
   String get aboutOmiApiKeys => 'حول مفاتيح Omi API';
@@ -4179,8 +4139,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get revokeApiKeyQuestion => 'إلغاء مفتاح API؟';
 
   @override
-  String get revokeApiKeyWarning =>
-      'لا يمكن التراجع عن هذا الإجراء. لن تتمكن أي تطبيقات تستخدم هذا المفتاح من الوصول إلى API بعد الآن.';
+  String get revokeApiKeyWarning => 'لا يمكن التراجع عن هذا الإجراء. لن تتمكن أي تطبيقات تستخدم هذا المفتاح من الوصول إلى API بعد الآن.';
 
   @override
   String get revoke => 'إلغاء';
@@ -4278,8 +4237,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get externalAppAccess => 'وصول التطبيقات الخارجية';
 
   @override
-  String get externalAppAccessDescription =>
-      'التطبيقات المثبتة التالية لديها تكاملات خارجية ويمكنها الوصول إلى بياناتك، مثل المحادثات والذكريات.';
+  String get externalAppAccessDescription => 'التطبيقات المثبتة التالية لديها تكاملات خارجية ويمكنها الوصول إلى بياناتك، مثل المحادثات والذكريات.';
 
   @override
   String get noExternalAppsHaveAccess => 'لا توجد تطبيقات خارجية لديها وصول إلى بياناتك.';
@@ -4288,8 +4246,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get maximumSecurityE2ee => 'الأمان الأقصى (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'التشفير من طرف إلى طرف هو المعيار الذهبي للخصوصية. عند تفعيله، يتم تشفير بياناتك على جهازك قبل إرسالها إلى خوادمنا. هذا يعني أنه لا أحد، ولا حتى Omi، يمكنه الوصول إلى محتواك.';
+  String get e2eeDescription => 'التشفير من طرف إلى طرف هو المعيار الذهبي للخصوصية. عند تفعيله، يتم تشفير بياناتك على جهازك قبل إرسالها إلى خوادمنا. هذا يعني أنه لا أحد، ولا حتى Omi، يمكنه الوصول إلى محتواك.';
 
   @override
   String get importantTradeoffs => 'المقايضات المهمة:';
@@ -4323,15 +4280,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get secureEncryption => 'تشفير آمن';
 
   @override
-  String get secureEncryptionDescription =>
-      'يتم تشفير بياناتك بمفتاح فريد لك على خوادمنا المستضافة على Google Cloud. هذا يعني أن محتواك الأصلي غير متاح لأي شخص، بما في ذلك موظفي Omi أو Google، مباشرة من قاعدة البيانات.';
+  String get secureEncryptionDescription => 'يتم تشفير بياناتك بمفتاح فريد لك على خوادمنا المستضافة على Google Cloud. هذا يعني أن محتواك الأصلي غير متاح لأي شخص، بما في ذلك موظفي Omi أو Google، مباشرة من قاعدة البيانات.';
 
   @override
   String get endToEndEncryption => 'التشفير من طرف إلى طرف';
 
   @override
-  String get e2eeCardDescription =>
-      'قم بالتفعيل لأقصى درجات الأمان حيث يمكنك أنت فقط الوصول إلى بياناتك. انقر لمعرفة المزيد.';
+  String get e2eeCardDescription => 'قم بالتفعيل لأقصى درجات الأمان حيث يمكنك أنت فقط الوصول إلى بياناتك. انقر لمعرفة المزيد.';
 
   @override
   String get dataAlwaysEncrypted => 'بغض النظر عن المستوى، يتم تشفير بياناتك دائمًا أثناء التخزين وأثناء النقل.';
@@ -4399,12 +4354,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get trainingDataProgram => 'برنامج بيانات التدريب';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'احصل على Omi غير محدود مجاناً من خلال المساهمة ببياناتك لتدريب نماذج الذكاء الاصطناعي.';
+  String get getOmiUnlimitedFree => 'احصل على Omi غير محدود مجاناً من خلال المساهمة ببياناتك لتدريب نماذج الذكاء الاصطناعي.';
 
   @override
-  String get trainingDataBullets =>
-      '• بياناتك تساعد في تحسين نماذج الذكاء الاصطناعي\n• يتم مشاركة البيانات غير الحساسة فقط\n• عملية شفافة بالكامل';
+  String get trainingDataBullets => '• بياناتك تساعد في تحسين نماذج الذكاء الاصطناعي\n• يتم مشاركة البيانات غير الحساسة فقط\n• عملية شفافة بالكامل';
 
   @override
   String get learnMoreAtOmiTraining => 'تعرف على المزيد في omi.me/training';
@@ -4564,8 +4517,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'خصوصيتك تهمنا';
 
   @override
-  String get privacyIntroText =>
-      'في Omi، نأخذ خصوصيتك على محمل الجد. نريد أن نكون شفافين بشأن البيانات التي نجمعها وكيف نستخدمها لتحسين منتجنا لك. إليك ما تحتاج معرفته:';
+  String get privacyIntroText => 'في Omi، نأخذ خصوصيتك على محمل الجد. نريد أن نكون شفافين بشأن البيانات التي نجمعها وكيف نستخدمها لتحسين منتجنا لك. إليك ما تحتاج معرفته:';
 
   @override
   String get whatWeTrack => 'ما نتتبعه';
@@ -4580,12 +4532,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get ourCommitment => 'التزامنا';
 
   @override
-  String get commitmentText =>
-      'نحن ملتزمون باستخدام البيانات التي نجمعها فقط لجعل Omi منتجًا أفضل لك. خصوصيتك وثقتك في غاية الأهمية لنا.';
+  String get commitmentText => 'نحن ملتزمون باستخدام البيانات التي نجمعها فقط لجعل Omi منتجًا أفضل لك. خصوصيتك وثقتك في غاية الأهمية لنا.';
 
   @override
-  String get thankYouText =>
-      'شكرًا لك لكونك مستخدمًا قيمًا لـ Omi. إذا كانت لديك أي أسئلة أو مخاوف، فلا تتردد في التواصل معنا على team@basedhardware.com.';
+  String get thankYouText => 'شكرًا لك لكونك مستخدمًا قيمًا لـ Omi. إذا كانت لديك أي أسئلة أو مخاوف، فلا تتردد في التواصل معنا على team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'إعدادات مزامنة WiFi';
@@ -4594,8 +4544,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get enterHotspotCredentials => 'أدخل بيانات اعتماد نقطة اتصال هاتفك';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'تستخدم مزامنة WiFi هاتفك كنقطة اتصال. ابحث عن اسم وكلمة مرور نقطة الاتصال في الإعدادات > نقطة اتصال شخصية.';
+  String get wifiSyncUsesHotspot => 'تستخدم مزامنة WiFi هاتفك كنقطة اتصال. ابحث عن اسم وكلمة مرور نقطة الاتصال في الإعدادات > نقطة اتصال شخصية.';
 
   @override
   String get hotspotNameSsid => 'اسم نقطة الاتصال (SSID)';
@@ -4660,8 +4609,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'بدأ التصدير. قد يستغرق هذا بضع ثوانٍ...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'سيؤدي هذا إلى حذف جميع بيانات الرسم البياني المعرفي المشتقة (العقد والاتصالات). ستبقى ذكرياتك الأصلية آمنة. سيتم إعادة بناء الرسم البياني بمرور الوقت أو عند الطلب التالي.';
+  String get knowledgeGraphDeleteDescription => 'سيؤدي هذا إلى حذف جميع بيانات الرسم البياني المعرفي المشتقة (العقد والاتصالات). ستبقى ذكرياتك الأصلية آمنة. سيتم إعادة بناء الرسم البياني بمرور الوقت أو عند الطلب التالي.';
 
   @override
   String get configureDailySummaryDigest => 'قم بتكوين ملخص مهامك اليومية';
@@ -4731,8 +4679,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'حذف جميع محادثات Limitless؟';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'سيؤدي هذا إلى حذف جميع المحادثات المستوردة من Limitless نهائيًا. لا يمكن التراجع عن هذا الإجراء.';
+  String get deleteAllLimitlessWarning => 'سيؤدي هذا إلى حذف جميع المحادثات المستوردة من Limitless نهائيًا. لا يمكن التراجع عن هذا الإجراء.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4788,8 +4735,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get howItWorksTitle => 'كيف يعمل؟';
 
   @override
-  String get howPeopleWorks =>
-      'بمجرد إنشاء شخص، يمكنك الذهاب إلى نص المحادثة وتعيين الأجزاء المقابلة لهم، وبهذه الطريقة سيتمكن Omi من التعرف على كلامهم أيضًا!';
+  String get howPeopleWorks => 'بمجرد إنشاء شخص، يمكنك الذهاب إلى نص المحادثة وتعيين الأجزاء المقابلة لهم، وبهذه الطريقة سيتمكن Omi من التعرف على كلامهم أيضًا!';
 
   @override
   String get tapToDelete => 'اضغط للحذف';
@@ -4815,8 +4761,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get privacyNotice => 'إشعار الخصوصية';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'قد تلتقط التسجيلات أصوات الآخرين. تأكد من الحصول على موافقة جميع المشاركين قبل التفعيل.';
+  String get recordingsMayCaptureOthers => 'قد تلتقط التسجيلات أصوات الآخرين. تأكد من الحصول على موافقة جميع المشاركين قبل التفعيل.';
 
   @override
   String get enable => 'تفعيل';
@@ -4828,8 +4773,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get on => 'تشغيل';
 
   @override
-  String get storeAudioDescription =>
-      'احتفظ بجميع التسجيلات الصوتية مخزنة محليًا على هاتفك. عند التعطيل، يتم الاحتفاظ فقط بالتحميلات الفاشلة لتوفير مساحة التخزين.';
+  String get storeAudioDescription => 'احتفظ بجميع التسجيلات الصوتية مخزنة محليًا على هاتفك. عند التعطيل، يتم الاحتفاظ فقط بالتحميلات الفاشلة لتوفير مساحة التخزين.';
 
   @override
   String get enableLocalStorage => 'تفعيل التخزين المحلي';
@@ -4850,8 +4794,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get cloudStorageDialogMessage => 'سيتم تخزين تسجيلاتك في الوقت الفعلي في التخزين السحابي الخاص أثناء التحدث.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'قم بتخزين تسجيلاتك في الوقت الفعلي في التخزين السحابي الخاص أثناء التحدث. يتم التقاط الصوت وحفظه بشكل آمن في الوقت الفعلي.';
+  String get storeAudioCloudDescription => 'قم بتخزين تسجيلاتك في الوقت الفعلي في التخزين السحابي الخاص أثناء التحدث. يتم التقاط الصوت وحفظه بشكل آمن في الوقت الفعلي.';
 
   @override
   String get downloadingFirmware => 'جارٍ تنزيل البرنامج الثابت';
@@ -4958,8 +4901,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get connectingYourStripeAccount => 'جاري توصيل حساب Stripe الخاص بك';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'يرجى إكمال عملية تسجيل Stripe في متصفحك. ستتحدث هذه الصفحة تلقائيًا عند الانتهاء.';
+  String get stripeOnboardingInstructions => 'يرجى إكمال عملية تسجيل Stripe في متصفحك. ستتحدث هذه الصفحة تلقائيًا عند الانتهاء.';
 
   @override
   String get failedTryAgain => 'فشل؟ حاول مرة أخرى';
@@ -4971,8 +4913,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get successfullyConnected => 'تم الاتصال بنجاح!';
 
   @override
-  String get stripeReadyForPayments =>
-      'حساب Stripe الخاص بك جاهز الآن لاستقبال المدفوعات. يمكنك البدء في الكسب من مبيعات تطبيقك على الفور.';
+  String get stripeReadyForPayments => 'حساب Stripe الخاص بك جاهز الآن لاستقبال المدفوعات. يمكنك البدء في الكسب من مبيعات تطبيقك على الفور.';
 
   @override
   String get updateStripeDetails => 'تحديث تفاصيل Stripe';
@@ -4999,8 +4940,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get paypalMeLink => 'رابط PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'إذا كان Stripe متاحًا في بلدك، نوصي بشدة باستخدامه للحصول على مدفوعات أسرع وأسهل.';
+  String get stripeRecommendation => 'إذا كان Stripe متاحًا في بلدك، نوصي بشدة باستخدامه للحصول على مدفوعات أسرع وأسهل.';
 
   @override
   String get updatePayPalDetails => 'تحديث تفاصيل PayPal';
@@ -5052,8 +4992,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'تمت إزالة عينة الكلام الإضافية';
 
   @override
-  String get consentDataMessage =>
-      'بالمتابعة، سيتم تخزين محادثاتك وتسجيلاتك ومعلوماتك الشخصية بشكل آمن على خوادمنا. تتم معالجة تسجيلاتك الصوتية ونصوصك بواسطة خدمات ذكاء اصطناعي تابعة لجهات خارجية (بما في ذلك Deepgram للنسخ و OpenAI للتحليل) لتزويدك برؤى مدعومة بالذكاء الاصطناعي وتمكين جميع ميزات التطبيق.';
+  String get consentDataMessage => 'بالمتابعة، سيتم تخزين محادثاتك وتسجيلاتك ومعلوماتك الشخصية بشكل آمن على خوادمنا. تتم معالجة تسجيلاتك الصوتية ونصوصك بواسطة خدمات ذكاء اصطناعي تابعة لجهات خارجية (بما في ذلك Deepgram للنسخ و OpenAI للتحليل) لتزويدك برؤى مدعومة بالذكاء الاصطناعي وتمكين جميع ميزات التطبيق.';
 
   @override
   String get tasksEmptyStateMessage => 'ستظهر المهام من محادثاتك هنا.\nاضغط على + لإنشاء مهمة يدويًا.';
@@ -5092,15 +5031,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get installOmiOnAppleWatch => 'قم بتثبيت Omi على\nApple Watch الخاص بك';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'لاستخدام Apple Watch مع Omi، تحتاج أولاً إلى تثبيت تطبيق Omi على ساعتك.';
+  String get installOmiOnAppleWatchDescription => 'لاستخدام Apple Watch مع Omi، تحتاج أولاً إلى تثبيت تطبيق Omi على ساعتك.';
 
   @override
   String get openOmiOnAppleWatch => 'افتح Omi على\nApple Watch الخاص بك';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'تم تثبيت تطبيق Omi على Apple Watch الخاص بك. افتحه واضغط على بدء للبدء.';
+  String get openOmiOnAppleWatchDescription => 'تم تثبيت تطبيق Omi على Apple Watch الخاص بك. افتحه واضغط على بدء للبدء.';
 
   @override
   String get openWatchApp => 'افتح تطبيق الساعة';
@@ -5109,15 +5046,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'لقد قمت بتثبيت وفتح التطبيق';
 
   @override
-  String get unableToOpenWatchApp =>
-      'تعذر فتح تطبيق Apple Watch. يرجى فتح تطبيق Watch يدويًا على Apple Watch وتثبيت Omi من قسم \"التطبيقات المتاحة\".';
+  String get unableToOpenWatchApp => 'تعذر فتح تطبيق Apple Watch. يرجى فتح تطبيق Watch يدويًا على Apple Watch وتثبيت Omi من قسم \"التطبيقات المتاحة\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'تم توصيل Apple Watch بنجاح!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch لا يزال غير قابل للوصول. يرجى التأكد من أن تطبيق Omi مفتوح على ساعتك.';
+  String get appleWatchNotReachable => 'Apple Watch لا يزال غير قابل للوصول. يرجى التأكد من أن تطبيق Omi مفتوح على ساعتك.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5545,8 +5480,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get multipleSpeakersDetected => 'تم اكتشاف عدة متحدثين';
 
   @override
-  String get multipleSpeakersDescription =>
-      'يبدو أن هناك عدة متحدثين في التسجيل. يرجى التأكد من أنك في مكان هادئ والمحاولة مرة أخرى.';
+  String get multipleSpeakersDescription => 'يبدو أن هناك عدة متحدثين في التسجيل. يرجى التأكد من أنك في مكان هادئ والمحاولة مرة أخرى.';
 
   @override
   String get invalidRecordingDetected => 'تم اكتشاف تسجيل غير صالح';
@@ -5564,8 +5498,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get howToTakeGoodSample => 'كيف تأخذ عينة جيدة؟';
 
   @override
-  String get goodSampleInstructions =>
-      '1. تأكد من أنك في مكان هادئ.\n2. تحدث بوضوح وطبيعية.\n3. تأكد من أن جهازك في وضعه الطبيعي على رقبتك.\n\nبمجرد إنشائه، يمكنك دائمًا تحسينه أو القيام به مرة أخرى.';
+  String get goodSampleInstructions => '1. تأكد من أنك في مكان هادئ.\n2. تحدث بوضوح وطبيعية.\n3. تأكد من أن جهازك في وضعه الطبيعي على رقبتك.\n\nبمجرد إنشائه، يمكنك دائمًا تحسينه أو القيام به مرة أخرى.';
 
   @override
   String get noDeviceConnectedUseMic => 'لا يوجد جهاز متصل. سيتم استخدام ميكروفون الهاتف.';
@@ -6020,8 +5953,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get performanceWarning => 'تحذير الأداء';
 
   @override
-  String get largeModelWarning =>
-      'هذا النموذج كبير وقد يتسبب في تعطل التطبيق أو بطئه الشديد.\n\nيُنصح باستخدام \"small\" أو \"base\".';
+  String get largeModelWarning => 'هذا النموذج كبير وقد يتسبب في تعطل التطبيق أو بطئه الشديد.\n\nيُنصح باستخدام \"small\" أو \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'استخدام التعرف على الكلام الأصلي لـ iOS';
@@ -6087,8 +6019,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get premiumMinutesMonth => '1,200 دقيقة مميزة/شهر. علامة التبويب على الجهاز توفر نسخاً مجانياً غير محدود. ';
 
   @override
-  String get audioProcessedLocally =>
-      'تتم معالجة الصوت محلياً. يعمل بدون اتصال، أكثر خصوصية، لكنه يستهلك المزيد من البطارية.';
+  String get audioProcessedLocally => 'تتم معالجة الصوت محلياً. يعمل بدون اتصال، أكثر خصوصية، لكنه يستهلك المزيد من البطارية.';
 
   @override
   String get languageLabel => 'اللغة';
@@ -6097,8 +6028,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get modelLabel => 'النموذج';
 
   @override
-  String get modelTooLargeWarning =>
-      'هذا النموذج كبير وقد يتسبب في تعطل التطبيق أو تشغيله ببطء شديد على الأجهزة المحمولة.\n\nيُوصى باستخدام small أو base.';
+  String get modelTooLargeWarning => 'هذا النموذج كبير وقد يتسبب في تعطل التطبيق أو تشغيله ببطء شديد على الأجهزة المحمولة.\n\nيُوصى باستخدام small أو base.';
 
   @override
   String get nativeEngineNoDownload => 'سيتم استخدام محرك الكلام الأصلي لجهازك. لا يلزم تنزيل نموذج.';
@@ -6137,8 +6067,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'النسخ المباشر المدمج في Omi مُحسّن للمحادثات في الوقت الفعلي مع الكشف التلقائي عن المتحدثين والفصل بينهم.';
+  String get omiTranscriptionOptimized => 'النسخ المباشر المدمج في Omi مُحسّن للمحادثات في الوقت الفعلي مع الكشف التلقائي عن المتحدثين والفصل بينهم.';
 
   @override
   String get reset => 'إعادة تعيين';
@@ -6681,8 +6610,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shareRecording => 'مشاركة التسجيل';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'هل أنت متأكد من رغبتك في حذف هذا التسجيل نهائياً؟ لا يمكن التراجع عن هذا الإجراء.';
+  String get deleteRecordingConfirmation => 'هل أنت متأكد من رغبتك في حذف هذا التسجيل نهائياً؟ لا يمكن التراجع عن هذا الإجراء.';
 
   @override
   String get recordingIdLabel => 'معرّف التسجيل';
@@ -6741,8 +6669,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get enableFastTransfer => 'تفعيل النقل السريع';
 
   @override
-  String get fastTransferDescription =>
-      'يستخدم النقل السريع شبكة WiFi للحصول على سرعات أسرع بـ 5 مرات. سيتصل هاتفك مؤقتًا بشبكة WiFi الخاصة بجهاز Omi أثناء النقل.';
+  String get fastTransferDescription => 'يستخدم النقل السريع شبكة WiFi للحصول على سرعات أسرع بـ 5 مرات. سيتصل هاتفك مؤقتًا بشبكة WiFi الخاصة بجهاز Omi أثناء النقل.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'يتم إيقاف الوصول إلى الإنترنت أثناء النقل';
@@ -6757,8 +6684,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get fiveTimesFaster => 'أسرع 5 مرات';
 
   @override
-  String get fastTransferMethodDescription =>
-      'ينشئ اتصال WiFi مباشر بجهاز Omi. يتم فصل هاتفك مؤقتًا عن شبكة WiFi العادية أثناء النقل.';
+  String get fastTransferMethodDescription => 'ينشئ اتصال WiFi مباشر بجهاز Omi. يتم فصل هاتفك مؤقتًا عن شبكة WiFi العادية أثناء النقل.';
 
   @override
   String get bluetooth => 'بلوتوث';
@@ -6767,8 +6693,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get bleSpeed => '~30 كيلوبايت/ثانية عبر BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'يستخدم اتصال Bluetooth منخفض الطاقة القياسي. أبطأ لكنه لا يؤثر على اتصال WiFi.';
+  String get bluetoothMethodDescription => 'يستخدم اتصال Bluetooth منخفض الطاقة القياسي. أبطأ لكنه لا يؤثر على اتصال WiFi.';
 
   @override
   String get selected => 'محدد';
@@ -6809,8 +6734,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get appVisibilityChangedSuccessfully => 'تم تغيير إعدادات الرؤية للتطبيق بنجاح. قد يستغرق الأمر بضع دقائق.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'حدث خطأ أثناء تفعيل التطبيق. إذا كان تطبيق تكامل، تأكد من اكتمال الإعداد.';
+  String get errorActivatingAppIntegration => 'حدث خطأ أثناء تفعيل التطبيق. إذا كان تطبيق تكامل، تأكد من اكتمال الإعداد.';
 
   @override
   String get errorUpdatingAppStatus => 'حدث خطأ أثناء تحديث حالة التطبيق.';
@@ -6890,8 +6814,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'يجب أن يكون الاسم 3 أحرف على الأقل';
 
   @override
-  String get conversationPromptHint =>
-      'مثال: استخراج عناصر الإجراءات والقرارات المتخذة والنقاط الرئيسية من المحادثة المقدمة.';
+  String get conversationPromptHint => 'مثال: استخراج عناصر الإجراءات والقرارات المتخذة والنقاط الرئيسية من المحادثة المقدمة.';
 
   @override
   String get pleaseEnterAppPrompt => 'يرجى إدخال موجه لتطبيقك';
@@ -7084,8 +7007,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get couldNotSchedulePlanChange => 'تعذر جدولة تغيير الخطة. يرجى المحاولة مرة أخرى.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'تم إعادة تفعيل اشتراكك! لا توجد رسوم الآن - ستستمر في الاستمتاع بالميزات المميزة.';
+  String get subscriptionReactivatedDefault => 'تم إعادة تفعيل اشتراكك! لا توجد رسوم الآن - ستستمر في الاستمتاع بالميزات المميزة.';
 
   @override
   String get subscriptionSuccessfulCharged => 'تم الاشتراك بنجاح! تم خصم المبلغ لفترة الفوترة الجديدة.';
@@ -7253,8 +7175,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authFailedToRetrieveToken => 'فشل استرداد رمز Firebase، يرجى المحاولة مرة أخرى.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'خطأ غير متوقع أثناء تسجيل الدخول، خطأ في Firebase، يرجى المحاولة مرة أخرى.';
+  String get authUnexpectedErrorFirebase => 'خطأ غير متوقع أثناء تسجيل الدخول، خطأ في Firebase، يرجى المحاولة مرة أخرى.';
 
   @override
   String get authUnexpectedError => 'خطأ غير متوقع أثناء تسجيل الدخول، يرجى المحاولة مرة أخرى';
@@ -7285,8 +7206,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get onboardingNotificationDeniedSystemPrefs => 'تم رفض إذن الإشعارات. يرجى منح الإذن في تفضيلات النظام.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'تم رفض إذن الإشعارات. يرجى منح الإذن في تفضيلات النظام > الإشعارات.';
+  String get onboardingNotificationDeniedNotifications => 'تم رفض إذن الإشعارات. يرجى منح الإذن في تفضيلات النظام > الإشعارات.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7305,8 +7225,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get onboardingMicrophoneRequired => 'يتطلب إذن الميكروفون للتسجيل.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'تم رفض إذن الميكروفون. يرجى منح الإذن في تفضيلات النظام > الخصوصية والأمان > الميكروفون.';
+  String get onboardingMicrophoneDenied => 'تم رفض إذن الميكروفون. يرجى منح الإذن في تفضيلات النظام > الخصوصية والأمان > الميكروفون.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7322,8 +7241,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'يتطلب إذن التقاط الشاشة لتسجيل صوت النظام.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'تم رفض إذن التقاط الشاشة. يرجى منح الإذن في تفضيلات النظام > الخصوصية والأمان > تسجيل الشاشة.';
+  String get onboardingScreenCaptureDenied => 'تم رفض إذن التقاط الشاشة. يرجى منح الإذن في تفضيلات النظام > الخصوصية والأمان > تسجيل الشاشة.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7448,8 +7366,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get locationPermissionRequired => 'إذن الموقع مطلوب';
 
   @override
-  String get locationPermissionContent =>
-      'يتطلب النقل السريع إذن الموقع للتحقق من اتصال WiFi. يرجى منح إذن الموقع للمتابعة.';
+  String get locationPermissionContent => 'يتطلب النقل السريع إذن الموقع للتحقق من اتصال WiFi. يرجى منح إذن الموقع للمتابعة.';
 
   @override
   String get pdfTranscriptExport => 'تصدير النص';
@@ -7920,8 +7837,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get pairingTitlePlaudNote => 'ضع Plaud Note في وضع الإقران';
 
   @override
-  String get pairingDescPlaudNote =>
-      'اضغط مع الاستمرار على الزر الجانبي لمدة ثانيتين. سيومض مؤشر LED الأحمر عندما يكون جاهزًا للإقران.';
+  String get pairingDescPlaudNote => 'اضغط مع الاستمرار على الزر الجانبي لمدة ثانيتين. سيومض مؤشر LED الأحمر عندما يكون جاهزًا للإقران.';
 
   @override
   String get pairingTitleBee => 'ضع Bee في وضع الإقران';
@@ -7933,8 +7849,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get pairingTitleLimitless => 'ضع Limitless في وضع الإقران';
 
   @override
-  String get pairingDescLimitless =>
-      'عندما يكون أي ضوء مرئيًا، اضغط مرة واحدة ثم اضغط مع الاستمرار حتى يظهر الجهاز ضوءًا ورديًا، ثم حرر.';
+  String get pairingDescLimitless => 'عندما يكون أي ضوء مرئيًا، اضغط مرة واحدة ثم اضغط مع الاستمرار حتى يظهر الجهاز ضوءًا ورديًا، ثم حرر.';
 
   @override
   String get pairingTitleFriendPendant => 'ضع Friend Pendant في وضع الإقران';
@@ -7952,8 +7867,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get pairingTitleAppleWatch => 'توصيل Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'قم بتثبيت وفتح تطبيق Omi على Apple Watch الخاص بك، ثم اضغط على اتصال في التطبيق.';
+  String get pairingDescAppleWatch => 'قم بتثبيت وفتح تطبيق Omi على Apple Watch الخاص بك، ثم اضغط على اتصال في التطبيق.';
 
   @override
   String get pairingTitleNeoOne => 'ضع Neo One في وضع الإقران';
@@ -8076,8 +7990,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get switchAndRestart => 'تبديل';
 
   @override
-  String get stagingDisclaimer =>
-      'قد تكون البيئة التجريبية غير مستقرة وذات أداء متقلب، وقد تُفقد البيانات. للاختبار فقط.';
+  String get stagingDisclaimer => 'قد تكون البيئة التجريبية غير مستقرة وذات أداء متقلب، وقد تُفقد البيانات. للاختبار فقط.';
 
   @override
   String get apiEnvSavedRestartRequired => 'تم الحفظ. أغلق التطبيق وأعد فتحه لتطبيق التغييرات.';
@@ -8306,8 +8219,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'مكالمات هاتفية عبر Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'قم بإجراء مكالمات عبر Omi واحصل على نسخ نصي فوري وملخصات تلقائية والمزيد. متاح حصرياً لمشتركي خطة غير محدود.';
+  String get phoneCallsUpsellSubtitle => 'قم بإجراء مكالمات عبر Omi واحصل على نسخ نصي فوري وملخصات تلقائية والمزيد. متاح حصرياً لمشتركي خطة غير محدود.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'نسخ نصي فوري لكل مكالمة';
@@ -8346,8 +8258,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deletePendingFiles => 'حذف التسجيلات المعلقة';
 
   @override
-  String get deletePendingFilesWarning =>
-      'لم تتم مزامنة هذه التسجيلات مع هاتفك وستفقد نهائياً. لا يمكن التراجع عن هذا.';
+  String get deletePendingFilesWarning => 'لم تتم مزامنة هذه التسجيلات مع هاتفك وستفقد نهائياً. لا يمكن التراجع عن هذا.';
 
   @override
   String get pendingFilesDeleted => 'تم حذف التسجيلات المعلقة';
@@ -8359,8 +8270,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deleteAll => 'حذف الكل';
 
   @override
-  String get deleteAllFilesWarning =>
-      'سيؤدي هذا إلى حذف التسجيلات المتزامنة والمعلقة. التسجيلات المعلقة لم تتم مزامنتها وستفقد نهائياً. لا يمكن التراجع عن هذا.';
+  String get deleteAllFilesWarning => 'سيؤدي هذا إلى حذف التسجيلات المتزامنة والمعلقة. التسجيلات المعلقة لم تتم مزامنتها وستفقد نهائياً. لا يمكن التراجع عن هذا.';
 
   @override
   String get allFilesDeleted => 'تم حذف جميع التسجيلات';
@@ -8425,8 +8335,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get fairUseAboutTitle => 'حول الاستخدام العادل';
 
   @override
-  String get fairUseAboutBody =>
-      'تم تصميم Omi للمحادثات الشخصية والاجتماعات والتفاعلات المباشرة. يُقاس الاستخدام بوقت الكلام الفعلي المكتشف وليس بوقت الاتصال. إذا تجاوز الاستخدام بشكل كبير الأنماط الطبيعية لمحتوى غير شخصي، فقد يتم تطبيق تعديلات.';
+  String get fairUseAboutBody => 'تم تصميم Omi للمحادثات الشخصية والاجتماعات والتفاعلات المباشرة. يُقاس الاستخدام بوقت الكلام الفعلي المكتشف وليس بوقت الاتصال. إذا تجاوز الاستخدام بشكل كبير الأنماط الطبيعية لمحتوى غير شخصي، فقد يتم تطبيق تعديلات.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8464,8 +8373,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get improveConnectionTitle => 'تحسين الاتصال';
 
   @override
-  String get improveConnectionContent =>
-      'لقد حسّنا طريقة بقاء Omi متصلاً بجهازك. لتفعيل ذلك، يرجى الانتقال إلى صفحة معلومات الجهاز، والضغط على \"فصل الجهاز\"، ثم إعادة إقران جهازك.';
+  String get improveConnectionContent => 'لقد حسّنا طريقة بقاء Omi متصلاً بجهازك. لتفعيل ذلك، يرجى الانتقال إلى صفحة معلومات الجهاز، والضغط على \"فصل الجهاز\"، ثم إعادة إقران جهازك.';
 
   @override
   String get improveConnectionAction => 'فهمت';
@@ -8520,12 +8428,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get cancelSyncQuestion => 'إلغاء المزامنة؟';
 
   @override
-  String get omisStorageDesc =>
-      'عندما لا يكون Omi متصلاً بهاتفك، يخزن الصوت محليًا في ذاكرته المدمجة. لن تفقد أي تسجيل أبدًا.';
+  String get omisStorageDesc => 'عندما لا يكون Omi متصلاً بهاتفك، يخزن الصوت محليًا في ذاكرته المدمجة. لن تفقد أي تسجيل أبدًا.';
 
   @override
-  String get phoneStorageDesc =>
-      'عند إعادة اتصال Omi، يتم نقل التسجيلات تلقائيًا إلى هاتفك كمنطقة تخزين مؤقتة قبل الرفع.';
+  String get phoneStorageDesc => 'عند إعادة اتصال Omi، يتم نقل التسجيلات تلقائيًا إلى هاتفك كمنطقة تخزين مؤقتة قبل الرفع.';
 
   @override
   String get cloudStorageDesc => 'بمجرد الرفع، تتم معالجة تسجيلاتك ونسخها. ستكون المحادثات متاحة في غضون دقيقة.';
@@ -8552,8 +8458,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get permissionEnable => 'تفعيل';
 
   @override
-  String get permissionsPageDescription =>
-      'هذه الأذونات ضرورية لعمل Omi. فهي تتيح ميزات أساسية مثل الإشعارات وتجارب الموقع والتقاط الصوت.';
+  String get permissionsPageDescription => 'هذه الأذونات ضرورية لعمل Omi. فهي تتيح ميزات أساسية مثل الإشعارات وتجارب الموقع والتقاط الصوت.';
 
   @override
   String get permissionsRequiredDescription => 'يحتاج Omi إلى بعض الأذونات ليعمل بشكل صحيح. يرجى منحها للمتابعة.';
@@ -8833,8 +8738,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get firmwareWarningTitle => 'مهم: اقرأ قبل التحديث';
 
   @override
-  String get firmwareFormatWarning =>
-      'سيقوم هذا التحديث بتهيئة بطاقة SD. يرجى التأكد من مزامنة جميع البيانات غير المتصلة قبل الترقية.\n\nإذا رأيت ضوءاً أحمر يومض بعد تثبيت هذا الإصدار، لا تقلق. ما عليك سوى توصيل الجهاز بالتطبيق وسيتحول إلى اللون الأزرق. الضوء الأحمر يعني أن ساعة الجهاز لم تتم مزامنتها بعد.';
+  String get firmwareFormatWarning => 'سيقوم هذا التحديث بتهيئة بطاقة SD. يرجى التأكد من مزامنة جميع البيانات غير المتصلة قبل الترقية.\n\nإذا رأيت ضوءاً أحمر يومض بعد تثبيت هذا الإصدار، لا تقلق. ما عليك سوى توصيل الجهاز بالتطبيق وسيتحول إلى اللون الأزرق. الضوء الأحمر يعني أن ساعة الجهاز لم تتم مزامنتها بعد.';
 
   @override
   String get continueAnyway => 'متابعة';
@@ -8854,8 +8758,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get tasksMarkComplete => 'تم وضع علامة مكتمل';
 
   @override
-  String get appleHealthManageNote =>
-      'يصل Omi إلى Apple Health عبر إطار عمل HealthKit من Apple. يمكنك إلغاء الوصول في أي وقت من إعدادات iOS.';
+  String get appleHealthManageNote => 'يصل Omi إلى Apple Health عبر إطار عمل HealthKit من Apple. يمكنك إلغاء الوصول في أي وقت من إعدادات iOS.';
 
   @override
   String get appleHealthConnectCta => 'الاتصال بـ Apple Health';
@@ -8888,8 +8791,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get appleHealthDeniedTitle => 'تم رفض الوصول إلى Apple Health';
 
   @override
-  String get appleHealthDeniedBody =>
-      'ليس لدى Omi إذن لقراءة بيانات Apple Health الخاصة بك. فعّل ذلك من إعدادات iOS ← الخصوصية والأمان ← Health ← Omi.';
+  String get appleHealthDeniedBody => 'ليس لدى Omi إذن لقراءة بيانات Apple Health الخاصة بك. فعّل ذلك من إعدادات iOS ← الخصوصية والأمان ← Health ← Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'لماذا ترحل؟';
@@ -8958,8 +8860,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get planUpdate => 'تحديث الخطة';
 
   @override
-  String get planDeprecationMessage =>
-      'يتم إيقاف خطة Unlimited الخاصة بك. انتقل إلى خطة Operator — نفس الميزات الرائعة بسعر \$49/شهريًا. ستستمر خطتك الحالية في العمل في هذه الأثناء.';
+  String get planDeprecationMessage => 'يتم إيقاف خطة Unlimited الخاصة بك. انتقل إلى خطة Operator — نفس الميزات الرائعة بسعر \$49/شهريًا. ستستمر خطتك الحالية في العمل في هذه الأثناء.';
 
   @override
   String get upgradeYourPlan => 'قم بترقية خطتك';
@@ -9101,4 +9002,25 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'إضافة مهمة';
+
+  @override
+  String get quickActionAskOmiAnything => 'اسأل أومي أي شيء';
+
+  @override
+  String get quickActionVoiceMode => 'الوضع الصوتي';
+
+  @override
+  String get quickActionMute => 'كتم الصوت';
+
+  @override
+  String get quickActionUnmute => 'إلغاء كتم الصوت';
+
+  @override
+  String get quickActionConnectDevice => 'ربط الجهاز';
+
+  @override
+  String get quickActionDeviceSettings => 'إعدادات الجهاز';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -24,8 +24,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deleteConversationTitle => 'Выдаліць размову?';
 
   @override
-  String get deleteConversationMessage =>
-      'Гэта таксама выдаліць звязаныя ўспаміны, задачы і аўдыёфайлы. Гэта дзеянне нельга адмяніць.';
+  String get deleteConversationMessage => 'Гэта таксама выдаліць звязаныя ўспаміны, задачы і аўдыёфайлы. Гэта дзеянне нельга адмяніць.';
 
   @override
   String get confirm => 'Пацвердзіць';
@@ -318,8 +317,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get installedApps => 'Усталяваныя дадатыі';
 
   @override
-  String get unableToFetchApps =>
-      'Не атрымалася загрузіць дадатыі :(\n\nПрацяніце вашае падключэнне да інтэрнету і спрабуйце яшчэ раз.';
+  String get unableToFetchApps => 'Не атрымалася загрузіць дадатыі :(\n\nПрацяніце вашае падключэнне да інтэрнету і спрабуйце яшчэ раз.';
 
   @override
   String get aboutOmi => 'Пра Omi';
@@ -355,19 +353,16 @@ class AppLocalizationsBe extends AppLocalizations {
   String get appsDisconnected => 'Вашы дадатыі і інтэграцыі будуць адключаны адразу.';
 
   @override
-  String get exportBeforeDelete =>
-      'Вы можаце экспартаваць вашы дадзеныя да выдалення рахунка, але пасля выдалення ўспаміны нельга будзе адноўіць.';
+  String get exportBeforeDelete => 'Вы можаце экспартаваць вашы дадзеныя да выдалення рахунка, але пасля выдалення ўспаміны нельга будзе адноўіць.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Я разумею, што выданне мага рахунка перманентна і ўсе дадзеныя, уключаючы ўспаміны і размовы, будуць страчаны і не могуць быць адноўлены.';
+  String get deleteAccountCheckbox => 'Я разумею, што выданне мага рахунка перманентна і ўсе дадзеныя, уключаючы ўспаміны і размовы, будуць страчаны і не могуць быць адноўлены.';
 
   @override
   String get areYouSure => 'Вы ўпэўнены?';
 
   @override
-  String get deleteAccountFinal =>
-      'Гэта дзеянне незаўратна і безвяртана выдаліць ваш рахунак і ўсе звязаныя дадзеныя. Вы ўпэўнены, што хочаце перайсці да гэтага?';
+  String get deleteAccountFinal => 'Гэта дзеянне незаўратна і безвяртана выдаліць ваш рахунак і ўсе звязаныя дадзеныя. Вы ўпэўнены, што хочаце перайсці да гэтага?';
 
   @override
   String get deleteNow => 'Выдаліць зараз';
@@ -376,8 +371,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get goBack => 'Вярніцца';
 
   @override
-  String get checkBoxToConfirm =>
-      'Адзначце поле, каб пацвердзіць, што вы разумееце, што выданне вашага рахунка перманентна і незаўратна.';
+  String get checkBoxToConfirm => 'Адзначце поле, каб пацвердзіць, што вы разумееце, што выданне вашага рахунка перманентна і незаўратна.';
 
   @override
   String get profile => 'Профіль';
@@ -455,8 +449,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get yourPrivacyYourControl => 'Ваша прыватнасць, ваша кантроль';
 
   @override
-  String get privacyIntro =>
-      'У Omi мы адданы абаронцы вашай прыватнасці. Гэта старонка дазваляе вам кантраляваць, як вашы дадзеныя захоўваюцца і выкарыстоўваюцца.';
+  String get privacyIntro => 'У Omi мы адданы абаронцы вашай прыватнасці. Гэта старонка дазваляе вам кантраляваць, як вашы дадзеныя захоўваюцца і выкарыстоўваюцца.';
 
   @override
   String get learnMore => 'Даведацца больш...';
@@ -465,15 +458,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get dataProtectionLevel => 'Ўзровень абароны дадзеных';
 
   @override
-  String get dataProtectionDesc =>
-      'Вашы дадзеныя абаронены па змаўчанні сільным шыфраваннем. Прагледзьце ваш параметры і адносныя вариянты прыватнасці ніжэй.';
+  String get dataProtectionDesc => 'Вашы дадзеныя абаронены па змаўчанні сільным шыфраваннем. Прагледзьце ваш параметры і адносныя вариянты прыватнасці ніжэй.';
 
   @override
   String get appAccess => 'Доступ дадатка';
 
   @override
-  String get appAccessDesc =>
-      'Наступныя дадатыі могуць атрымаць доступ да вашых дадзеных. Націсніце на дадатак, каб кантраляваць яго дазволы.';
+  String get appAccessDesc => 'Наступныя дадатыі могуць атрымаць доступ да вашых дадзеных. Націсніце на дадатак, каб кантраляваць яго дазволы.';
 
   @override
   String get noAppsExternalAccess => 'Ні адзін з установленых дадатаў не мае зовнішняга доступу да вашых дадзеных.';
@@ -530,22 +521,19 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Ваш Omi быў адключаны 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Прылада адключана ад пары. Перайдзіце ў Параметры > Bluetooth і забудзьцеся прыладе, каб завяршыць адключэнне ад пары.';
+  String get deviceUnpairedMessage => 'Прылада адключана ад пары. Перайдзіце ў Параметры > Bluetooth і забудзьцеся прыладе, каб завяршыць адключэнне ад пары.';
 
   @override
   String get unpairDialogTitle => 'Адключыць прыладу ад пары';
 
   @override
-  String get unpairDialogMessage =>
-      'Гэта адключыць прыладу ад пары, каб яе можна было падключыць да іншага тэлефона. Вы павінны будзеце перайсці ў Параметры > Bluetooth і забыць прыладу, каб завяршыць працэс.';
+  String get unpairDialogMessage => 'Гэта адключыць прыладу ад пары, каб яе можна было падключыць да іншага тэлефона. Вы павінны будзеце перайсці ў Параметры > Bluetooth і забыць прыладу, каб завяршыць працэс.';
 
   @override
   String get deviceNotConnected => 'Прылада не падключана';
 
   @override
-  String get connectDeviceMessage =>
-      'Падключыце вашу прыладу Omi, каб атрымаць доступ\nдаа параметраў прылады і персанолізацыі';
+  String get connectDeviceMessage => 'Падключыце вашу прыладу Omi, каб атрымаць доступ\nдаа параметраў прылады і персанолізацыі';
 
   @override
   String get deviceInfoSection => 'Інфармацыя пра прыладу';
@@ -560,8 +548,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get v2Undetected => 'V2 не знойдзена';
 
   @override
-  String get v2UndetectedMessage =>
-      'Мы бачым, што ў вас ёсць V1 прылада або ваша прылада не падключана. Функцыянальнасць SD карты даступна толькі для V2 прыладаў.';
+  String get v2UndetectedMessage => 'Мы бачым, што ў вас ёсць V1 прылада або ваша прылада не падключана. Функцыянальнасць SD карты даступна толькі для V2 прыладаў.';
 
   @override
   String get endConversation => 'Завяршыць размову';
@@ -693,8 +680,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get noActivityYet => 'Пакі няма дзеяння';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Пачніце размову з Omi\nкаб убачыць вашыя ўсвідомленні выкарыстання тут.';
+  String get startConversationToSeeInsights => 'Пачніце размову з Omi\nкаб убачыць вашыя ўсвідомленні выкарыстання тут.';
 
   @override
   String get listening => 'Слуханне';
@@ -836,8 +822,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Выдаліць граф ведаў?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Гэта выдаліць усе вывераныя дадзеныя графа ведаў (вузлы і звязкі). Вашы арыгінальныя ўспаміны заставаюцца бяспечныя. Граф будзе перабудаваны з часам або пры наступным запыце.';
+  String get deleteKnowledgeGraphMessage => 'Гэта выдаліць усе вывераныя дадзеныя графа ведаў (вузлы і звязкі). Вашы арыгінальныя ўспаміны заставаюцца бяспечныя. Граф будзе перабудаваны з часам або пры наступным запыце.';
 
   @override
   String get knowledgeGraphDeleted => 'Граф ведаў выдалены';
@@ -985,8 +970,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get shortConversationThreshold => 'Парог коротка размоў';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Размовы, карацейшыя за гэта, будуць схованы, хіба што ўключаны вышэй';
+  String get shortConversationThresholdSubtitle => 'Размовы, карацейшыя за гэта, будуць схованы, хіба што ўключаны вышэй';
 
   @override
   String get durationThreshold => 'Парог тычаса';
@@ -1081,8 +1065,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get needYourPermission => 'Нам трэба ваша разрешэнне';
 
   @override
-  String get alreadyGavePermission =>
-      'Вы ўжо даў нам разрешэнне захаваць вашыя голасныя запісы. Вось напоміненне, чаму нам гэта трэба:';
+  String get alreadyGavePermission => 'Вы ўжо даў нам разрешэнне захаваць вашыя голасныя запісы. Вось напоміненне, чаму нам гэта трэба:';
 
   @override
   String get wouldLikePermission => 'Мы хацелі б вашы разрешэнне захаваць вашыя голасныя запісы. Вось чаму:';
@@ -1091,26 +1074,22 @@ class AppLocalizationsBe extends AppLocalizations {
   String get improveSpeechProfile => 'Палепшыць ваш профіль голасу';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Мы выкарыстоўваем запісы, каб больш тренаваць і зацацаниць ваш персанальны профіль голасу.';
+  String get improveSpeechProfileDesc => 'Мы выкарыстоўваем запісы, каб больш тренаваць і зацацаниць ваш персанальны профіль голасу.';
 
   @override
   String get trainFamilyProfiles => 'Тренаваць профілі для сяброў і сямей';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Вашы запісы дапамаглі нам распазнаваць і стварыць профілі для вашых сяброў і сямей.';
+  String get trainFamilyProfilesDesc => 'Вашы запісы дапамаглі нам распазнаваць і стварыць профілі для вашых сяброў і сямей.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Палепшыць дакладнасць транскрыпцыі';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Па меры палепшэння нашай мадэлі, мы можам забяспечыць лепшыя вынікі транскрыпцыі для вашых запісаў.';
+  String get enhanceTranscriptAccuracyDesc => 'Па меры палепшэння нашай мадэлі, мы можам забяспечыць лепшыя вынікі транскрыпцыі для вашых запісаў.';
 
   @override
-  String get legalNotice =>
-      'Юридычнае ўведамленне: Легальнасць запісу і захаванне голасных дадзеных можа варыяваць ў залежнасці ад вашага месцазнаходжання і вашага выкарыстання гэтай функцыі. Вы адказаны за захаванне адпаведнасці месцавым законам і рэгуляцыям.';
+  String get legalNotice => 'Юридычнае ўведамленне: Легальнасць запісу і захаванне голасных дадзеных можа варыяваць ў залежнасці ад вашага месцазнаходжання і вашага выкарыстання гэтай функцыі. Вы адказаны за захаванне адпаведнасці месцавым законам і рэгуляцыям.';
 
   @override
   String get alreadyAuthorized => 'Ужо аўтарызавана';
@@ -1188,8 +1167,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get showEventsNoParticipants => 'Паказваць палітыі без удзельнікаў';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Калі ўключана, Coming Up паказвае палітыі без удзельнікаў ці ссылкі на відэа.';
+  String get showEventsNoParticipantsDesc => 'Калі ўключана, Coming Up паказвае палітыі без удзельнікаў ці ссылкі на відэа.';
 
   @override
   String get yourMeetings => 'Ваша сустрэчы';
@@ -1274,8 +1252,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Скажыце нам вашу асноўную мову';
 
   @override
-  String get languageForTranscription =>
-      'Устаноўце вашу мову для больш складаных расшифровак і персаналізаванага вопыту.';
+  String get languageForTranscription => 'Устаноўце вашу мову для больш складаных расшифровак і персаналізаванага вопыту.';
 
   @override
   String get singleLanguageModeInfo => 'Адзінмоўны рэжым уключаны. Пераклад адключаны для больш высокай дакладнасці.';
@@ -1358,8 +1335,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get defaultRepository => 'Сховішча па змаўчанні';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Выберыце сховішча па змаўчанні для стварэння задач. Вы ўсё адно можаце вызначыць іншае сховішча пры стварэнні задач.';
+  String get selectDefaultRepoDesc => 'Выберыце сховішча па змаўчанні для стварэння задач. Вы ўсё адно можаце вызначыць іншае сховішча пры стварэнні задач.';
 
   @override
   String get noReposFound => 'Сховішча не знойдзены';
@@ -1406,8 +1382,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get configureSettings => 'Канфігураваць налады';
 
   @override
-  String get completeAuthBrowser =>
-      'Калі ласка, завяршыце аўтэнтыфікацыю ў вашым браўзеры. Пасля гэтага вярніцеся ў прыкладанне.';
+  String get completeAuthBrowser => 'Калі ласка, завяршыце аўтэнтыфікацыю ў вашым браўзеры. Пасля гэтага вярніцеся ў прыкладанне.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1735,8 +1710,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get enableBluetooth => 'Уключыць Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi трэба Bluetooth для падлучэння да вашага нашпігальнага прыстроя. Калі ласка, уключыце Bluetooth і спробуйце яшчэ раз.';
+  String get bluetoothNeeded => 'Omi трэба Bluetooth для падлучэння да вашага нашпігальнага прыстроя. Калі ласка, уключыце Bluetooth і спробуйце яшчэ раз.';
 
   @override
   String get contactSupport => 'Звярнуцца ў тэхподтрымку?';
@@ -1769,26 +1743,22 @@ class AppLocalizationsBe extends AppLocalizations {
   String get locationServiceDisabled => 'Сервіс месцазнаходжання адключаны';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Сервіс месцазнаходжання адключаны. Калі ласка, перайдзіце ў Налады > Прыватнасць і безпека > Сервісы месцазнаходжання і уключыце яго';
+  String get locationServiceDisabledDesc => 'Сервіс месцазнаходжання адключаны. Калі ласка, перайдзіце ў Налады > Прыватнасць і безпека > Сервісы месцазнаходжання і уключыце яго';
 
   @override
   String get backgroundLocationDenied => 'Доступ да фонавога месцазнаходжання адказаны';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Калі ласка, перайдзіце ў налады прыстроя і ўстаноўце дазвол месцазнаходжання на \"Всегда разрешить\"';
+  String get backgroundLocationDeniedDesc => 'Калі ласка, перайдзіце ў налады прыстроя і ўстаноўце дазвол месцазнаходжання на \"Всегда разрешить\"';
 
   @override
   String get lovingOmi => 'Нравіцца вам Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Дапамажыце нам дасягнуць больш людзей, пакідаючы водгук ў App Store. Ваш водгук значыць шмат для нас!';
+  String get leaveReviewIos => 'Дапамажыце нам дасягнуць больш людзей, пакідаючы водгук ў App Store. Ваш водгук значыць шмат для нас!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Дапамажыце нам дасягнуць больш людзей, пакідаючы водгук ў Google Play Store. Ваш водгук значыць шмат для нас!';
+  String get leaveReviewAndroid => 'Дапамажыце нам дасягнуць больш людзей, пакідаючы водгук ў Google Play Store. Ваш водгук значыць шмат для нас!';
 
   @override
   String get rateOnAppStore => 'Агранізавіць ў App Store';
@@ -1821,15 +1791,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get connectionError => 'Памылка злучэння';
 
   @override
-  String get connectionErrorDesc =>
-      'Не вдалося злучыцца з сервером. Калі ласка, праверыце вашу інтэрнэт-злучэнне і спробуйце яшчэ раз.';
+  String get connectionErrorDesc => 'Не вдалося злучыцца з сервером. Калі ласка, праверыце вашу інтэрнэт-злучэнне і спробуйце яшчэ раз.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Невалідны запіс выяўлены';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Здаецца, ў запісе больш адной дыктара. Калі ласка, пераканайцеся, што вы ў спакойным месцы, і спробуйце яшчэ раз.';
+  String get multipleSpeakersDesc => 'Здаецца, ў запісе больш адной дыктара. Калі ласка, пераканайцеся, што вы ў спакойным месцы, і спробуйце яшчэ раз.';
 
   @override
   String get tooShortDesc => 'Выяўлена недастаткова маў. Калі ласка, гаварыце больш і спробуйце яшчэ раз.';
@@ -1841,15 +1809,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get areYouThere => 'Вы там?';
 
   @override
-  String get noSpeechDesc =>
-      'Мы не можам выявіць маў. Калі ласка, пераканайцеся, што вы гаварыце мінімум 10 секунд і не больш за 3 хвіліны.';
+  String get noSpeechDesc => 'Мы не можам выявіць маў. Калі ласка, пераканайцеся, што вы гаварыце мінімум 10 секунд і не больш за 3 хвіліны.';
 
   @override
   String get connectionLost => 'Злучэнне страчана';
 
   @override
-  String get connectionLostDesc =>
-      'Злучэнне было перарвана. Калі ласка, праверыце вашу інтэрнэт-злучэнне і спробуйце яшчэ раз.';
+  String get connectionLostDesc => 'Злучэнне было перарвана. Калі ласка, праверыце вашу інтэрнэт-злучэнне і спробуйце яшчэ раз.';
 
   @override
   String get tryAgain => 'Спробуйце яшчэ раз';
@@ -1864,8 +1830,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get permissionsRequired => 'Дазволы абавязаны';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Гэтаму прыкладанню трэба дазволы Bluetooth і месцазнаходжання для правільнай работы. Калі ласка, уключыце іх у наладах.';
+  String get permissionsRequiredDesc => 'Гэтаму прыкладанню трэба дазволы Bluetooth і месцазнаходжання для правільнай работы. Калі ласка, уключыце іх у наладах.';
 
   @override
   String get openSettings => 'Адкрыць налады';
@@ -1907,12 +1872,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get microphonePermission => 'Дазвол мікрафона';
 
   @override
-  String get permissionGrantedNow =>
-      'Дазвол дадзены! Зараз:\n\nАдкрыйце прыкладанне Omi на вашым гадзінніку і дакніце \"Прадоўжыць\" ніжэй';
+  String get permissionGrantedNow => 'Дазвол дадзены! Зараз:\n\nАдкрыйце прыкладанне Omi на вашым гадзінніку і дакніце \"Прадоўжыць\" ніжэй';
 
   @override
-  String get needMicrophonePermission =>
-      'Нам трэба дазвол мікрафона.\n\n1. Дакніце \"Дайце дазвол\"\n2. Дазвольце на вашым iPhone\n3. Прыкладанне на гадзінніку затворыцца\n4. Адкрыйце яго і дакніце \"Прадоўжыць\"';
+  String get needMicrophonePermission => 'Нам трэба дазвол мікрафона.\n\n1. Дакніце \"Дайце дазвол\"\n2. Дазвольце на вашым iPhone\n3. Прыкладанне на гадзінніку затворыцца\n4. Адкрыйце яго і дакніце \"Прадоўжыць\"';
 
   @override
   String get grantPermissionButton => 'Дайце дазвол';
@@ -1921,15 +1884,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get needHelp => 'Потрэбна помоч?';
 
   @override
-  String get troubleshootingSteps =>
-      'Развязанне праблем:\n\n1. Пераканайцеся, што Omi ўстаноўлена на вашым гадзінніку\n2. Адкрыйце прыкладанне Omi на вашым гадзінніку\n3. Поўкайце спливаючае акно дазвола\n4. Дакніце \"Дазволіць\" пры запыте\n5. Прыкладанне на гадзінніку затворыцца - адкрыйце яго\n6. Вярніцеся і дакніце \"Прадоўжыць\" на вашым iPhone';
+  String get troubleshootingSteps => 'Развязанне праблем:\n\n1. Пераканайцеся, што Omi ўстаноўлена на вашым гадзінніку\n2. Адкрыйце прыкладанне Omi на вашым гадзінніку\n3. Поўкайце спливаючае акно дазвола\n4. Дакніце \"Дазволіць\" пры запыте\n5. Прыкладанне на гадзінніку затворыцца - адкрыйце яго\n6. Вярніцеся і дакніце \"Прадоўжыць\" на вашым iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Запіс пачаўся паспяхова!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Дазвол яшчэ не дадзены. Калі ласка, пераканайцеся, што вы дадзілі доступ мікрафона і адкрылі прыкладанне на вашым гадзінніку.';
+  String get permissionNotGrantedYet => 'Дазвол яшчэ не дадзены. Калі ласка, пераканайцеся, што вы дадзілі доступ мікрафона і адкрылі прыкладанне на вашым гадзінніку.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2026,8 +1987,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Готовы да дзеяння';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Ваш AI аўтаматычна выцягне задачы і да-зробы з вашых разговораў. Яны будуць адлюстравацца тут пры стварэнні.';
+  String get welcomeActionItemsDescription => 'Ваш AI аўтаматычна выцягне задачы і да-зробы з вашых разговораў. Яны будуць адлюстравацца тут пры стварэнні.';
 
   @override
   String get autoExtractionFeature => 'Аўтаматычна выцягнута з разговораў';
@@ -2223,15 +2183,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'МОВ І РАСШЫФРОЎКА';
 
   @override
-  String get languageSettingsHelperText =>
-      'Мова прыкладання змяняе меню і кнопкі. Мова маўлення влывае на тое, як вашы запісы расшыфроўваюцца.';
+  String get languageSettingsHelperText => 'Мова прыкладання змяняе меню і кнопкі. Мова маўлення влывае на тое, як вашы запісы расшыфроўваюцца.';
 
   @override
   String get translationNotice => 'Паведамленне аб перакладе';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi перакладае разговоры на вашу асноўную мову. Абнавіце яе ў любы час у Наладах → Профілі.';
+  String get translationNoticeMessage => 'Omi перакладае разговоры на вашу асноўную мову. Абнавіце яе ў любы час у Наладах → Профілі.';
 
   @override
   String get pleaseCheckInternetConnection => 'Калі ласка, праверыце вашу інтэрнэт-злучэнне і спробуйце яшчэ раз';
@@ -2251,8 +2209,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Гэты разговор не можа быць аб\'ёдзінаны (заблакаваны ці ўжо аб\'ёдноўваецца)';
+  String get conversationCannotBeMerged => 'Гэты разговор не можа быць аб\'ёдзінаны (заблакаваны ці ўжо аб\'ёдноўваецца)';
 
   @override
   String get pleaseEnterFolderName => 'Калі ласка, уведзіце назву папкі';
@@ -2394,8 +2351,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Адлучыць прыбор';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Гэта адлучыць прыбор, каб яго можна было падлучыць да іншага тэлефона. Вам трэба перайсці ў Параметры > Bluetooth і забыць прыбор, каб завяршыць працэс.';
+  String get unpairDeviceDialogMessage => 'Гэта адлучыць прыбор, каб яго можна было падлучыць да іншага тэлефона. Вам трэба перайсці ў Параметры > Bluetooth і забыць прыбор, каб завяршыць працэс.';
 
   @override
   String get unpair => 'Адлучыць';
@@ -2576,8 +2532,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get youreAllSet => 'Вы рэды!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Вітаем у Omi! Ваш AI асістэнт готаў дапамагаць вам з разнамовамі, задачамі і многім іншым.';
+  String get welcomeToOmiDescription => 'Вітаем у Omi! Ваш AI асістэнт готаў дапамагаць вам з разнамовамі, задачамі і многім іншым.';
 
   @override
   String get startUsingOmi => 'Пачаць выкарыстоўваць Omi';
@@ -2656,8 +2611,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get reviewAndManageConversations => 'Рэвью і кіруйце вашымі перехоплены разнамовамі';
 
   @override
-  String get startCapturingConversations =>
-      'Пачніце перахоплівацьразнамовы з вашым прыбором Omi, каб яны паяўіліся здесь.';
+  String get startCapturingConversations => 'Пачніце перахоплівацьразнамовы з вашым прыбором Omi, каб яны паяўіліся здесь.';
 
   @override
   String get useMobileAppToCapture => 'Выкарыстоўвайце мабільны прыбор для перахоплівання аўдыё';
@@ -2714,8 +2668,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get noTasksYet => 'Задач яшчэ няма';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Задачы з вашых разнамоў паявяцца здесь.\nЦукніце Ствараць, каб дадаць адну ручна.';
+  String get tasksFromConversationsWillAppear => 'Задачы з вашых разнамоў паявяцца здесь.\nЦукніце Ствараць, каб дадаць адну ручна.';
 
   @override
   String get monthJan => 'Сцяніч';
@@ -2772,8 +2725,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deleteActionItem => 'Выдаліць пункт дзеяння';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Вы ўпэўнены, што хочаце выдаліць гэты пункт дзеяння? Гэта дзеянне невозможна адмяніць.';
+  String get deleteActionItemConfirmation => 'Вы ўпэўнены, што хочаце выдаліць гэты пункт дзеяння? Гэта дзеянне невозможна адмяніць.';
 
   @override
   String get enterActionItemDescription => 'Увядзіце апісанне пункту дзеяння...';
@@ -2848,8 +2800,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get chatPrompt => 'Чат падказка';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Вы чудасны прыбор, ваша праца - адказаць на пытанні карыстальніка і заставіць яго адчуць сябе добра...';
+  String get chatPromptPlaceholder => 'Вы чудасны прыбор, ваша праца - адказаць на пытанні карыстальніка і заставіць яго адчуць сябе добра...';
 
   @override
   String get conversationPrompt => 'Падказка разнамовы';
@@ -2867,8 +2818,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get makeMyAppPublic => 'Ўчыніць мой прыбор публічным';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Адпраўляючы гэты прыбор, я пагаджаюся з Тэрмінамі абслугоўвання Omi AI і Палітыкай прыватнасці';
+  String get submitAppTermsAgreement => 'Адпраўляючы гэты прыбор, я пагаджаюся з Тэрмінамі абслугоўвання Omi AI і Палітыкай прыватнасці';
 
   @override
   String get submitApp => 'Адправіць прыбор';
@@ -2883,12 +2833,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get submitAppQuestion => 'Адправіць прыбор?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Ваш прыбор будзе рэвюявацца і зрабленаў публічным. Вы можаце пачаць выкарыстоўваць яго танічна, нават падчас рэвю!';
+  String get submitAppPublicDescription => 'Ваш прыбор будзе рэвюявацца і зрабленаў публічным. Вы можаце пачаць выкарыстоўваць яго танічна, нават падчас рэвю!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Ваш прыбор будзе рэвюявацца і зроблены даступны вам прыватна. Вы можаце пачаць выкарыстоўваць яго танічна, нават падчас рэвю!';
+  String get submitAppPrivateDescription => 'Ваш прыбор будзе рэвюявацца і зроблены даступны вам прыватна. Вы можаце пачаць выкарыстоўваць яго танічна, нават падчас рэвю!';
 
   @override
   String get startEarning => 'Пачніце зарабляць! 💰';
@@ -2912,15 +2860,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get dataAccessNotice => 'Паведамленне аб доступе да дадзеных';
 
   @override
-  String get dataAccessWarning =>
-      'Гэты прыбор будзе мець доступ да вашых дадзеных. Omi AI не адказны за тое, як вашыя дадзеныя выкарыстоўваюцца, змяняюцца ці выдаляюцца гэтым прыбором';
+  String get dataAccessWarning => 'Гэты прыбор будзе мець доступ да вашых дадзеных. Omi AI не адказны за тое, як вашыя дадзеныя выкарыстоўваюцца, змяняюцца ці выдаляюцца гэтым прыбором';
 
   @override
   String get installApp => 'Ўстанавіць прыбор';
 
   @override
-  String get betaTesterNotice =>
-      'Вы бета-тэстер гэтага прыбора. Ён яшчэ не публічны. Ён будзе публічным пасля ўхвалення.';
+  String get betaTesterNotice => 'Вы бета-тэстер гэтага прыбора. Ён яшчэ не публічны. Ён будзе публічным пасля ўхвалення.';
 
   @override
   String get appUnderReviewOwner => 'Ваш прыбор на рэвю і відны толькі вам. Ён будзе публічным пасля ўхвалення.';
@@ -2988,8 +2934,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get descriptionLabel => 'Апісанне';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Мой дзівосны прыбор - гэта чудасны прыбор, які робіць дзівосныя рэчы. Гэта лепшы прыбор ў свеце!';
+  String get appDescriptionPlaceholder => 'Мой дзівосны прыбор - гэта чудасны прыбор, які робіць дзівосныя рэчы. Гэта лепшы прыбор ў свеце!';
 
   @override
   String get pleaseProvideValidDescription => 'Будь ласка, падайце сапраўднае апісанне';
@@ -3141,8 +3086,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get microphonePermissionRequired => 'Дазвол мікрафона патрэбны для рабібаць звонкаў';
 
   @override
-  String get microphonePermissionDenied =>
-      'Дазвол мікрафона адхінуты. Будь ласка, дайце дазвол у Сістэмных параметрах > Прыватнасць & Бяспека > Мікрафон.';
+  String get microphonePermissionDenied => 'Дазвол мікрафона адхінуты. Будь ласка, дайце дазвол у Сістэмных параметрах > Прыватнасць & Бяспека > Мікрафон.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3301,8 +3245,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get createMemory => 'Ствараць памяць';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Вы ўпэўнены, што хочаце выдаліць гэту памяць? Гэта дзеянне невозможна адмяніць.';
+  String get deleteMemoryConfirmation => 'Вы ўпэўнены, што хочаце выдаліць гэту памяць? Гэта дзеянне невозможна адмяніць.';
 
   @override
   String get makePrivate => 'Ўчыніць прыватнай';
@@ -3376,8 +3319,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get whatWeCollect => 'Што мы збіраем';
 
   @override
-  String get dataCollectionMessage =>
-      'Продолжаючы, вашы размовы, запісы і персаналь­ная інфармацыя будуць бяспечна захоўваны на нашых серверах для прадастаўлення выснаваў на базе ШІ і ўключэння ўсіх функцый прыкладання.';
+  String get dataCollectionMessage => 'Продолжаючы, вашы размовы, запісы і персаналь­ная інфармацыя будуць бяспечна захоўваны на нашых серверах для прадастаўлення выснаваў на базе ШІ і ўключэння ўсіх функцый прыкладання.';
 
   @override
   String get dataProtection => 'Абарона даных';
@@ -3410,8 +3352,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Імя павінна быць не менш за 2 сімвалы';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Скажыце нам, як вас завяць. Гэта дапамагае персаналізаваць ваш вопыт Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Скажыце нам, як вас завяць. Гэта дапамагае персаналізаваць ваш вопыт Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3428,8 +3369,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get recordAudioConversations => 'Запісваць аўдыёразмовы';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi патрабуе доступ да мікрофона для запісу вашых размаў і прадастаўлення транскрыпцый.';
+  String get microphoneAccessDescription => 'Omi патрабуе доступ да мікрофона для запісу вашых размаў і прадастаўлення транскрыпцый.';
 
   @override
   String get screenRecording => 'Запіс экрана';
@@ -3438,8 +3378,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Захопіць сістэмны аўдыё з сустрэч';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi патрабуе дазвол на запіс экрана для захопу сістэмнага аўдыё з вашых веб-сустрэч.';
+  String get screenRecordingDescription => 'Omi патрабуе дазвол на запіс экрана для захопу сістэмнага аўдыё з вашых веб-сустрэч.';
 
   @override
   String get accessibility => 'Доступнасць';
@@ -3448,8 +3387,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Выявіць веб-сустрэчы';
 
   @override
-  String get accessibilityDescription =>
-      'Omi патрабуе дазвол на доступнасць для выявлення, калі вы ўдзельнічаеце ў сустрэчах Zoom, Meet або Teams у вашым браўзеры.';
+  String get accessibilityDescription => 'Omi патрабуе дазвол на доступнасць для выявлення, калі вы ўдзельнічаеце ў сустрэчах Zoom, Meet або Teams у вашым браўзеры.';
 
   @override
   String get pleaseWait => 'Пачакайце...';
@@ -3521,8 +3459,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get conversationsExportStarted => 'Экспарт размаў пачаўся. Гэта можа заняць некалькі секунд, пачакайце.';
 
   @override
-  String get mcpDescription =>
-      'Для злучэння Omi з іншымі прыкладаннямі для чытання, пошуку і кіравання вашымі спогадамі і размовамі. Создайте ключ для пачатку.';
+  String get mcpDescription => 'Для злучэння Omi з іншымі прыкладаннямі для чытання, пошуку і кіравання вашымі спогадамі і размовамі. Создайте ключ для пачатку.';
 
   @override
   String get apiKeys => 'API ключы';
@@ -3593,8 +3530,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get auto => 'Аўта';
 
   @override
-  String get noSummaryForApp =>
-      'Зводка не даступна для гэтага прыкладання. Спрабуйце іншае прыкладанне для лепшых результатаў.';
+  String get noSummaryForApp => 'Зводка не даступна для гэтага прыкладання. Спрабуйце іншае прыкладанне для лепшых результатаў.';
 
   @override
   String get tryAnotherApp => 'Спрабуйце іншае прыкладанне';
@@ -3631,8 +3567,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Дозвольце Omi выбраць най­лепшае прыкладанне аўтаматычна';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Вы сапраўды хочаце выдаліць гэтую размову? Гэта дзеянне не можна адмяніць.';
+  String get deleteConversationConfirmation => 'Вы сапраўды хочаце выдаліць гэтую размову? Гэта дзеянне не можна адмяніць.';
 
   @override
   String get conversationDeleted => 'Размова выдалена';
@@ -3680,8 +3615,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Падрыхтоўка захопу сістэмнага аўдыё';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Клацніце кнопку для захопу аўдыё для жывых транскрыпцый, выснаваў ШІ і аўтаматычнага захавання.';
+  String get clickTheButtonToCaptureAudio => 'Клацніце кнопку для захопу аўдыё для жывых транскрыпцый, выснаваў ШІ і аўтаматычнага захавання.';
 
   @override
   String get reconnecting => 'Перападключэнне...';
@@ -3839,8 +3773,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get dailySummaryTitle => 'Щодзённая зводка';
 
   @override
-  String get dailySummaryDescription =>
-      'Атрымайце персаналізаваную зводку размаў вашага дня, дастаўленую як паведамленне.';
+  String get dailySummaryDescription => 'Атрымайце персаналізаваную зводку размаў вашага дня, дастаўленую як паведамленне.';
 
   @override
   String get deliveryTime => 'Час дастаўкі';
@@ -3909,8 +3842,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Выдаліць граф ведаў?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Гэта выдаліць ўсе вывядзеныя даныя графа ведаў. Вашы асноўныя спогады застаюцца бяспечны.';
+  String get deleteKnowledgeGraphWarning => 'Гэта выдаліць ўсе вывядзеныя даныя графа ведаў. Вашы асноўныя спогады застаюцца бяспечны.';
 
   @override
   String get connectOmiWithAI => 'Злучыце Omi з помацнікамі ШІ';
@@ -3967,8 +3899,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get updateAppQuestion => 'Абнавіць прыкладанне?';
 
   @override
-  String get updateAppConfirmation =>
-      'Вы сапраўды хочаце абнавіць вашае прыкладанне? Змяненні будуць адлюстраны пасля рэцэнзіі нашай каманды.';
+  String get updateAppConfirmation => 'Вы сапраўды хочаце абнавіць вашае прыкладанне? Змяненні будуць адлюстраны пасля рэцэнзіі нашай каманды.';
 
   @override
   String get updateApp => 'Абнавіць прыкладанне';
@@ -3998,8 +3929,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get no => 'Не';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Подпіска скасована паспяхова. Она застанецца актыўнай да канца цякучага біллінгавога перыяду.';
+  String get subscriptionCancelledSuccessfully => 'Подпіска скасована паспяхова. Она застанецца актыўнай да канца цякучага біллінгавога перыяду.';
 
   @override
   String get failedToCancelSubscription => 'Не ўдалася скасаваць падпіску. Спрабуйце яшчэ раз.';
@@ -4035,8 +3965,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Скасаваць падпіску?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Вы сапраўды хочаце скасаваць вашу падпіску? Вы будзеце мець доступ да конца цякучага біллінгавога перыяду.';
+  String get cancelSubscriptionConfirmation => 'Вы сапраўды хочаце скасаваць вашу падпіску? Вы будзеце мець доступ да конца цякучага біллінгавога перыяду.';
 
   @override
   String get cancelSubscriptionButton => 'Скасаваць падпіску';
@@ -4045,16 +3974,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get cancelling => 'Скасаванне...';
 
   @override
-  String get betaTesterMessage =>
-      'Вы бета-тэстар гэтага прыкладання. Яно яшчэ не публічнае. Яно будзе публічным пасля адобрення.';
+  String get betaTesterMessage => 'Вы бета-тэстар гэтага прыкладання. Яно яшчэ не публічнае. Яно будзе публічным пасля адобрення.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Вашае прыкладанне перагледаецца і адлюстраецца толькі вам. Яно будзе публічным пасля адобрення.';
+  String get appUnderReviewMessage => 'Вашае прыкладанне перагледаецца і адлюстраецца толькі вам. Яно будзе публічным пасля адобрення.';
 
   @override
-  String get appRejectedMessage =>
-      'Ваша прыкладанне адхілена. Пакалуйста, абнавіце дэталі прыкладання і адправце яго заноў для перагляду.';
+  String get appRejectedMessage => 'Ваша прыкладанне адхілена. Пакалуйста, абнавіце дэталі прыкладання і адправце яго заноў для перагляду.';
 
   @override
   String get invalidIntegrationUrl => 'Недапусцімы URL інтэграцыі';
@@ -4108,8 +4034,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get issueActivatingApp => 'Была праблема пры ўключэнні гэтага прыкладання. Спрабуйце яшчэ раз.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Гэта прыкладанне будзе мець доступ да вашых даных. Omi AI не адказвае за тое, як ваша прыкладанне выкарыстоўвае, змяняе або выдаляе вашы даныя';
+  String get dataAccessNoticeDescription => 'Гэта прыкладанне будзе мець доступ да вашых даных. Omi AI не адказвае за тое, як ваша прыкладанне выкарыстоўвае, змяняе або выдаляе вашы даныя';
 
   @override
   String get copyUrl => 'Скапіяваць URL';
@@ -4197,8 +4122,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get omiApiKeys => 'API ключы Omi';
 
   @override
-  String get apiKeysDescription =>
-      'API ключы выкарыстоўваюцца для аўтэнтыфікацыі, калі ваша прыкладанне зносіцца з сервером OMI. Яны дазваляюць вашаму прыкладанню стварыць спогады і бяспечна атрымаць доступ да іншых сервісаў OMI.';
+  String get apiKeysDescription => 'API ключы выкарыстоўваюцца для аўтэнтыфікацыі, калі ваша прыкладанне зносіцца з сервером OMI. Яны дазваляюць вашаму прыкладанню стварыць спогады і бяспечна атрымаць доступ да іншых сервісаў OMI.';
 
   @override
   String get aboutOmiApiKeys => 'Аб API ключах Omi';
@@ -4222,8 +4146,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Адкліклаць API ключ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Гэта дзеянне не можна адмяніць. Любыя прыкладанні, якія выкарыстоўваюць гэты ключ, больш не зможуць мець доступ да API.';
+  String get revokeApiKeyWarning => 'Гэта дзеянне не можна адмяніць. Любыя прыкладанні, якія выкарыстоўваюць гэты ключ, больш не зможуць мець доступ да API.';
 
   @override
   String get revoke => 'Адкліклаць';
@@ -4312,8 +4235,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get keyCreated => 'Ключ створен';
 
   @override
-  String get keyCreatedMessage =>
-      'Ваш новы ключ створен. Пакалуйста, скапіюйце яго зараз. Вы не зможаце убачыць яго зноў.';
+  String get keyCreatedMessage => 'Ваш новы ключ створен. Пакалуйста, скапіюйце яго зараз. Вы не зможаце убачыць яго зноў.';
 
   @override
   String get keyWord => 'Ключ';
@@ -4322,8 +4244,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get externalAppAccess => 'Доступ зовнішняй прыкладання';
 
   @override
-  String get externalAppAccessDescription =>
-      'Наступныя ўсталяваныя прыкладанні маюць вонкавыя інтэграцыі і могуць мець доступ да вашых даных, такія як размовы і спогады.';
+  String get externalAppAccessDescription => 'Наступныя ўсталяваныя прыкладанні маюць вонкавыя інтэграцыі і могуць мець доступ да вашых даных, такія як размовы і спогады.';
 
   @override
   String get noExternalAppsHaveAccess => 'Ніякія зовнішнія прыкладанні не маюць доступу да вашых даных.';
@@ -4332,8 +4253,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get maximumSecurityE2ee => 'Максімальная бяспека (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Шыфраванне ад канца да канца - гэта золаты стандарт для прыватнасці. Калі ўключана, вашы даныя шыфруюцца на вашым прыладзе да адпраўкі на нашы серверы. Гэта азначае, што ніхто, нават Omi, не можа атрымаць доступ да вашага змесціва.';
+  String get e2eeDescription => 'Шыфраванне ад канца да канца - гэта золаты стандарт для прыватнасці. Калі ўключана, вашы даныя шыфруюцца на вашым прыладзе да адпраўкі на нашы серверы. Гэта азначае, што ніхто, нават Omi, не можа атрымаць доступ да вашага змесціва.';
 
   @override
   String get importantTradeoffs => 'Важныя кампраміс:';
@@ -4348,8 +4268,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get featureComingSoon => 'Гэта функцыя скора адойдзе!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Міграцыя ў працэсе. Вы не можаце змяніць узровень абароны, пакуль яна не завершыцца.';
+  String get migrationInProgressMessage => 'Міграцыя ў працэсе. Вы не можаце змяніць узровень абароны, пакуль яна не завершыцца.';
 
   @override
   String get migrationFailed => 'Міграцыя не ўдалася';
@@ -4368,19 +4287,16 @@ class AppLocalizationsBe extends AppLocalizations {
   String get secureEncryption => 'Бяспечнае шыфраванне';
 
   @override
-  String get secureEncryptionDescription =>
-      'Вашы даныя шыфруюцца з ключом, адзінкавым для вас на нашых серверах, размешчаны на Google Cloud. Гэта азначае, што ваше сыра змесціва недаступна ніхто, уключаючы персонал Omi або Google, непасрэдна з базы даных.';
+  String get secureEncryptionDescription => 'Вашы даныя шыфруюцца з ключом, адзінкавым для вас на нашых серверах, размешчаны на Google Cloud. Гэта азначае, што ваше сыра змесціва недаступна ніхто, уключаючы персонал Omi або Google, непасрэдна з базы даных.';
 
   @override
   String get endToEndEncryption => 'Шыфраванне ад канца да канца';
 
   @override
-  String get e2eeCardDescription =>
-      'Ўключыце для максімальнай бяспекі, дзе толькі вы можаце мець доступ да вашых даных. Клацніце для больш дэталяў.';
+  String get e2eeCardDescription => 'Ўключыце для максімальнай бяспекі, дзе толькі вы можаце мець доступ да вашых даных. Клацніце для больш дэталяў.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Незалежна ад узроўня, вашы даныя заўсёды шыфруюцца ў спокойнаму стане і ў транзіце.';
+  String get dataAlwaysEncrypted => 'Незалежна ад узроўня, вашы даныя заўсёды шыфруюцца ў спокойнаму стане і ў транзіце.';
 
   @override
   String get readOnlyScope => 'Толькі чытанне';
@@ -4445,12 +4361,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get trainingDataProgram => 'Праграма даных навучання';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Атрымайце Omi Unlimited бясплатна, удзельнічаючы ў даных для навучання мадэляў ШІ.';
+  String get getOmiUnlimitedFree => 'Атрымайце Omi Unlimited бясплатна, удзельнічаючы ў даных для навучання мадэляў ШІ.';
 
   @override
-  String get trainingDataBullets =>
-      '• Ваша даныя дапамагаюць палепшыць мадэлі ШІ\n• Толькі нечуллівыя даныя дзяляцца\n• Цалкам прозрыста процес';
+  String get trainingDataBullets => '• Ваша даныя дапамагаюць палепшыць мадэлі ШІ\n• Толькі нечуллівыя даныя дзяляцца\n• Цалкам прозрыста процес';
 
   @override
   String get learnMoreAtOmiTraining => 'Больш дзеянняў на omi.me/training';
@@ -4500,8 +4414,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get monthlyPlanContinues => 'Ваш бягучы штомесячны план будзе працягваць да канца перыяду выстаўлення сметы';
 
   @override
-  String get paymentMethodCharged =>
-      'Ваш існуючы спосаб плацежу будзе аўтаматычна дэбетаваны, калі ваш штомесячны план скончыцца';
+  String get paymentMethodCharged => 'Ваш існуючы спосаб плацежу будзе аўтаматычна дэбетаваны, калі ваш штомесячны план скончыцца';
 
   @override
   String get annualSubscriptionStarts => 'Ваша 12-месячная гадавая подпіска пачнецца аўтаматычна пасля спісання';
@@ -4544,8 +4457,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Ваш гадавы план пачнецца аўтаматычна, калі скончыцца ваш штомесячны план.';
+  String get annualPlanStartsAutomatically => 'Ваш гадавы план пачнецца аўтаматычна, калі скончыцца ваш штомесячны план.';
 
   @override
   String planRenewsOn(String date) {
@@ -4612,8 +4524,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Ваша Прыватнасць Важлівая для Нас';
 
   @override
-  String get privacyIntroText =>
-      'У Omi мы вельмі цэнім вашу прыватнасць. Мы хочам быць прозрыстымі адносна дадзеных, якія мы збіраем, і як мы іх выкарыстоўваем для палепшэння нашага прадукту для вас. Вось што вам трэба ведаць:';
+  String get privacyIntroText => 'У Omi мы вельмі цэнім вашу прыватнасць. Мы хочам быць прозрыстымі адносна дадзеных, якія мы збіраем, і як мы іх выкарыстоўваем для палепшэння нашага прадукту для вас. Вось што вам трэба ведаць:';
 
   @override
   String get whatWeTrack => 'Што мы адсочваем';
@@ -4628,12 +4539,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get ourCommitment => 'Наша Адзвяртанне';
 
   @override
-  String get commitmentText =>
-      'Мы зацвёрджаны выкарыстоўваць дадзеныя, якія мы збіраем, толькі для палепшэння Omi. Ваша прыватнасць і даверыгу нам вельмі важныя.';
+  String get commitmentText => 'Мы зацвёрджаны выкарыстоўваць дадзеныя, якія мы збіраем, толькі для палепшэння Omi. Ваша прыватнасць і даверыгу нам вельмі важныя.';
 
   @override
-  String get thankYouText =>
-      'Дзякуем, што вы каристальнік Omi. Калі ў вас ёсць якія-либо пытанні або ўзнікаюць праблемы, не вагайцеся звяртацца да нас team@basedhardware.com.';
+  String get thankYouText => 'Дзякуем, што вы каристальнік Omi. Калі ў вас ёсць якія-либо пытанні або ўзнікаюць праблемы, не вагайцеся звяртацца да нас team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Параметры Сінхранізацыі WiFi';
@@ -4642,8 +4551,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get enterHotspotCredentials => 'Уведзіце меркаванні гарячай тачкі вашага тэлефона';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'Сінхранізацыя WiFi выкарыстоўвае ваш тэлефон як гарячую тачку. Знайдзіце імя гарячай тачкі і пароль у Параметрах > Персанальная гарячая тачка.';
+  String get wifiSyncUsesHotspot => 'Сінхранізацыя WiFi выкарыстоўвае ваш тэлефон як гарячую тачку. Знайдзіце імя гарячай тачкі і пароль у Параметрах > Персанальная гарячая тачка.';
 
   @override
   String get hotspotNameSsid => 'Імя Гарячай Тачкі (SSID)';
@@ -4678,8 +4586,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Не ўдалося сгенерыраваць рэзюмэ. Пераканайцеся, што ў вас ёсць разговоры за той дзень.';
+  String get failedToGenerateSummaryCheckConversations => 'Не ўдалося сгенерыраваць рэзюмэ. Пераканайцеся, што ў вас ёсць разговоры за той дзень.';
 
   @override
   String get summaryNotFound => 'Рэзюмэ не знойдзена';
@@ -4709,8 +4616,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Экспорт пачаўся. Гэта можа заняць некалькі секунд...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Гэта удаліт усе дадзеныя дэрыванага графа ведаў (вузлы і злучэнні). Ваша арыгінальная память застанецца ў безпеце. Граф будзе адбудаваны з часам або пры наступным запыце.';
+  String get knowledgeGraphDeleteDescription => 'Гэта удаліт усе дадзеныя дэрыванага графа ведаў (вузлы і злучэнні). Ваша арыгінальная память застанецца ў безпеце. Граф будзе адбудаваны з часам або пры наступным запыце.';
 
   @override
   String get configureDailySummaryDigest => 'Канфігураваць ваш дзённы дайджэст элементаў дзеяння';
@@ -4780,8 +4686,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Удаліць Усе Разговоры Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Гэта перманентна удаліт усе разговоры, імпартаваныя з Limitless. Гэта дзеяннне нельга адмяніць.';
+  String get deleteAllLimitlessWarning => 'Гэта перманентна удаліт усе разговоры, імпартаваныя з Limitless. Гэта дзеяннне нельга адмяніць.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4837,8 +4742,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get howItWorksTitle => 'Як гэта працуе?';
 
   @override
-  String get howPeopleWorks =>
-      'Як толькі чалавек створаны, вы можаце перайсці да транскрыпцыі разговора і прызначыць яму іх адпаведныя сегменты, гэта дозваліт Omi распазнаваць іх мову!';
+  String get howPeopleWorks => 'Як толькі чалавек створаны, вы можаце перайсці да транскрыпцыі разговора і прызначыць яму іх адпаведныя сегменты, гэта дозваліт Omi распазнаваць іх мову!';
 
   @override
   String get tapToDelete => 'Тапніце для удалення';
@@ -4864,8 +4768,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get privacyNotice => 'Адведамленне аб Прыватнасці';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Запісы могуць захопіць голасы іншых. Пераканайцеся, што вы маеце согласія ў усіх удзельнікаў перад уключэннем.';
+  String get recordingsMayCaptureOthers => 'Запісы могуць захопіць голасы іншых. Пераканайцеся, што вы маеце согласія ў усіх удзельнікаў перад уключэннем.';
 
   @override
   String get enable => 'Уключыць';
@@ -4877,8 +4780,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get on => 'Ўкл.';
 
   @override
-  String get storeAudioDescription =>
-      'Сахавайце ўсе аўдыё запісы мясцова на вашым тэлефоне. Калі выключана, захавліваюцца толькі не ўдалыя загрузкі для экономіі месца на сховіщы.';
+  String get storeAudioDescription => 'Сахавайце ўсе аўдыё запісы мясцова на вашым тэлефоне. Калі выключана, захавліваюцца толькі не ўдалыя загрузкі для экономіі месца на сховіщы.';
 
   @override
   String get enableLocalStorage => 'Уключыць Мясцовае Сховіще';
@@ -4896,12 +4798,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get storeAudioOnCloud => 'Захоўваць Аўдыё ў Облаку';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Ваша запісы ў рэжыме рэальнага часу будуць захаваны ў прыватным облачным сховіщы па мене, як вы гавараеце.';
+  String get cloudStorageDialogMessage => 'Ваша запісы ў рэжыме рэальнага часу будуць захаваны ў прыватным облачным сховіщы па мене, як вы гавараеце.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Захавайце свае запісы ў рэжыме рэальнага часу ў прыватным облачным сховіщы па мене, як вы гавараеце. Аўдыё захоплівается і безбяспечна захавліваецца ў рэжыме рэальнага часу.';
+  String get storeAudioCloudDescription => 'Захавайце свае запісы ў рэжыме рэальнага часу ў прыватным облачным сховіщы па мене, як вы гавараеце. Аўдыё захоплівается і безбяспечна захавліваецца ў рэжыме рэальнага часу.';
 
   @override
   String get downloadingFirmware => 'Загрузка Прашыўкі';
@@ -4954,8 +4854,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get payments => 'Плацежы';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Прыстаўце спосаб плацежу ніжэй, каб пачаць атрымліваць выплаты за вашыя прыложэнні.';
+  String get connectPaymentMethodInfo => 'Прыстаўце спосаб плацежу ніжэй, каб пачаць атрымліваць выплаты за вашыя прыложэнні.';
 
   @override
   String get selectedPaymentMethod => 'Выбраны Спосаб Плацежу';
@@ -4982,8 +4881,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get monthlyPayouts => 'Штомесячныя Выплаты';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Атрымліваць штомесячныя плацежы непасрэдна на ваш рахунак, калі вы дасягнеце \$10 у заробку';
+  String get monthlyPayoutsDescription => 'Атрымліваць штомесячныя плацежы непасрэдна на ваш рахунак, калі вы дасягнеце \$10 у заробку';
 
   @override
   String get secureAndReliable => 'Бяспечна і Надзейна';
@@ -5010,8 +4908,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get connectingYourStripeAccount => 'Падлучэнне вашага рахунку Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Калі ласка, завяршыце працэс ўбудовання Stripe ў вашы браўзеры. Гэта старонка аўтаматычна абнавіцца пасля завяршэння.';
+  String get stripeOnboardingInstructions => 'Калі ласка, завяршыце працэс ўбудовання Stripe ў вашы браўзеры. Гэта старонка аўтаматычна абнавіцца пасля завяршэння.';
 
   @override
   String get failedTryAgain => 'Не ўдалось? Спробуйце Яшчэ Раз';
@@ -5023,8 +4920,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get successfullyConnected => 'Успешна Падлучана!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Ваш рахунак Stripe цяпер гатаў атрымліваць плацежы. Вы можаце пачаць заробляць з вашых прыложэнняў адразу.';
+  String get stripeReadyForPayments => 'Ваш рахунак Stripe цяпер гатаў атрымліваць плацежы. Вы можаце пачаць заробляць з вашых прыложэнняў адразу.';
 
   @override
   String get updateStripeDetails => 'Абнавіць Дадзеныя Stripe';
@@ -5042,8 +4938,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Абнавіць дадзеныя вашага рахунку PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Прыстаўце ваш рахунак PayPal, каб пачаць атрымліваць плацежы за вашыя прыложэнні';
+  String get connectPayPalToReceivePayments => 'Прыстаўце ваш рахунак PayPal, каб пачаць атрымліваць плацежы за вашыя прыложэнні';
 
   @override
   String get paypalEmail => 'Электронная Пошта PayPal';
@@ -5052,8 +4947,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me Спасылка';
 
   @override
-  String get stripeRecommendation =>
-      'Калі Stripe даступна ў вашай краіне, мы вельмі рэкамендуем яе выкарыстоўваць для хутчэйшых і лягчэйшых выплат.';
+  String get stripeRecommendation => 'Калі Stripe даступна ў вашай краіне, мы вельмі рэкамендуем яе выкарыстоўваць для хутчэйшых і лягчэйшых выплат.';
 
   @override
   String get updatePayPalDetails => 'Абнавіць Дадзеныя PayPal';
@@ -5105,12 +4999,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Дадатковы Ўзор Мовы Выдалены';
 
   @override
-  String get consentDataMessage =>
-      'Працягваючы, вашы размовы, запісы і асабістая інфармацыя будуць надзейна захоўвацца на нашых серверах. Вашы аўдыязапісы і транскрыпцыі апрацоўваюцца староннімі сэрвісамі ШІ (уключаючы Deepgram для транскрыпцыі і OpenAI для аналізу), каб забяспечыць вас аналітыкай на аснове ШІ і ўключыць усе функцыі праграмы.';
+  String get consentDataMessage => 'Працягваючы, вашы размовы, запісы і асабістая інфармацыя будуць надзейна захоўвацца на нашых серверах. Вашы аўдыязапісы і транскрыпцыі апрацоўваюцца староннімі сэрвісамі ШІ (уключаючы Deepgram для транскрыпцыі і OpenAI для аналізу), каб забяспечыць вас аналітыкай на аснове ШІ і ўключыць усе функцыі праграмы.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Задачы з вашых разговораў пояўляцца тут.\nТапніце + каб стварыць адну ручнічна.';
+  String get tasksEmptyStateMessage => 'Задачы з вашых разговораў пояўляцца тут.\nТапніце + каб стварыць адну ручнічна.';
 
   @override
   String get clearChatAction => 'Очыстіць Чат';
@@ -5146,15 +5038,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Ўстаноўьце Omi на ваш\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Каб выкарыстоўваць ваш Apple Watch з Omi, вам трэба спачатку ўсталяваць прыложэнне Omi на вашы гадзінкі.';
+  String get installOmiOnAppleWatchDescription => 'Каб выкарыстоўваць ваш Apple Watch з Omi, вам трэба спачатку ўсталяваць прыложэнне Omi на вашы гадзінкі.';
 
   @override
   String get openOmiOnAppleWatch => 'Адкрыйце Omi на ваш\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Прыложэнне Omi ўстаноўлена на вашым Apple Watch. Адкрыйце яго і тапніце Пачаць, каб пачаць.';
+  String get openOmiOnAppleWatchDescription => 'Прыложэнне Omi ўстаноўлена на вашым Apple Watch. Адкрыйце яго і тапніце Пачаць, каб пачаць.';
 
   @override
   String get openWatchApp => 'Адкрыць Прыложэнне Watch';
@@ -5163,15 +5053,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Я Ўсталявам і Адкрыў Прыложэнне';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Не ўдалося адкрыць прыложэнне Apple Watch. Калі ласка, ручнічна адкрыйце прыложэнне Watch на вашым Apple Watch і ўсталяйце Omi з секкіі \"Даступныя Прыложэнні\".';
+  String get unableToOpenWatchApp => 'Не ўдалося адкрыць прыложэнне Apple Watch. Калі ласка, ручнічна адкрыйце прыложэнне Watch на вашым Apple Watch і ўсталяйце Omi з секкіі \"Даступныя Прыложэнні\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch Успешна Падлучана!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch яшчэ недаступна. Калі ласка, пераканайцеся, што прыложэнне Omi адкрыто на вашых гадзінках.';
+  String get appleWatchNotReachable => 'Apple Watch яшчэ недаступна. Калі ласка, пераканайцеся, што прыложэнне Omi адкрыто на вашых гадзінках.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5599,8 +5487,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get multipleSpeakersDetected => 'Выяўлена Некалькі Спікераў';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Здаецца, ў запісе ёсць некалькі спікераў. Калі ласка, пераканайцеся, што вы знаходзіцеся ў спакойным месцы і спробуйце яшчэ раз.';
+  String get multipleSpeakersDescription => 'Здаецца, ў запісе ёсць некалькі спікераў. Калі ласка, пераканайцеся, што вы знаходзіцеся ў спакойным месцы і спробуйце яшчэ раз.';
 
   @override
   String get invalidRecordingDetected => 'Выяўлена Неправільны Запіс';
@@ -5609,19 +5496,16 @@ class AppLocalizationsBe extends AppLocalizations {
   String get notEnoughSpeechDescription => 'Нема дастаткова мовы. Калі ласка, гавараеце больш і спробуйце яшчэ раз.';
 
   @override
-  String get speechDurationDescription =>
-      'Пожалуйста, переконайцеся, што вы гавораце не менш за 5 секунд і не больш за 90.';
+  String get speechDurationDescription => 'Пожалуйста, переконайцеся, што вы гавораце не менш за 5 секунд і не больш за 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Сувязь была перарвана. Пожалуйста, праверце сувязь з інтэрнэтам і паспрабуйце яшчэ раз.';
+  String get connectionLostDescription => 'Сувязь была перарвана. Пожалуйста, праверце сувязь з інтэрнэтам і паспрабуйце яшчэ раз.';
 
   @override
   String get howToTakeGoodSample => 'Як зрабіць добрую выбарку?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Переконайцеся, што вы ў цішкім месцы.\n2. Гавораце ясна і натуральна.\n3. Переконайцеся, што ваш прыбор у натуральным становішчы, на вашай шыі.\n\nПасля стварэння вы заўсёды можаце яго палепшыць або зрабіць яшчэ раз.';
+  String get goodSampleInstructions => '1. Переконайцеся, што вы ў цішкім месцы.\n2. Гавораце ясна і натуральна.\n3. Переконайцеся, што ваш прыбор у натуральным становішчы, на вашай шыі.\n\nПасля стварэння вы заўсёды можаце яго палепшыць або зрабіць яшчэ раз.';
 
   @override
   String get noDeviceConnectedUseMic => 'Прыбор не падключаны. Будзе выкарыстаны мікрафон тэлефона.';
@@ -5684,12 +5568,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get howItWorks => 'Як гэта працуе';
 
   @override
-  String get dailyScoreExplanation =>
-      'Ваш дзённы бал базуецца на выкананні задач. Выканайце свае задачы, каб палепшыць ваш бал!';
+  String get dailyScoreExplanation => 'Ваш дзённы бал базуецца на выкананні задач. Выканайце свае задачы, каб палепшыць ваш бал!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Кантраліруйце, як часта Omi адпраўляе вам прааактыўныя апавяшчэнні і напамінаўі.';
+  String get notificationFrequencyDescription => 'Кантраліруйце, як часта Omi адпраўляе вам прааактыўныя апавяшчэнні і напамінаўі.';
 
   @override
   String get sliderOff => 'Выкл.';
@@ -5703,8 +5585,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Не удалося стварыць рэзюмэ. Переконайцеся, што у вас ёсць разговоры для гэтага дня.';
+  String get failedToGenerateSummary => 'Не удалося стварыць рэзюмэ. Переконайцеся, што у вас ёсць разговоры для гэтага дня.';
 
   @override
   String get recap => 'Адно воку';
@@ -5783,8 +5664,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get selectApp => 'Абраць прыкладанне';
 
   @override
-  String get noChatAppsEnabled =>
-      'Няма ўключаных прыкладанняў чата.\nНатісніце \"Ўключыць прыкладанні\", каб дадаць яшчэ.';
+  String get noChatAppsEnabled => 'Няма ўключаных прыкладанняў чата.\nНатісніце \"Ўключыць прыкладанні\", каб дадаць яшчэ.';
 
   @override
   String get disable => 'Выключыць';
@@ -5936,8 +5816,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get recordings => 'Запісы';
 
   @override
-  String get enableRemindersAccess =>
-      'Пожалуйста, ўключыце доступ да напамінаўяў ў налладах, каб выкарыстоўваць Apple Reminders';
+  String get enableRemindersAccess => 'Пожалуйста, ўключыце доступ да напамінаўяў ў налладах, каб выкарыстоўваць Apple Reminders';
 
   @override
   String todayAtTime(String time) {
@@ -5992,8 +5871,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get webhookUrlNotSet => 'URL webhook не ўстаўлены';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Пожалуйста, ўстаўце URL webhook ў налады разработчыка, каб выкарыстоўваць гэтую функцыю.';
+  String get setWebhookUrlInSettings => 'Пожалуйста, ўстаўце URL webhook ў налады разработчыка, каб выкарыстоўваць гэтую функцыю.';
 
   @override
   String get sendWebUrl => 'Адправіць URL вэба';
@@ -6067,15 +5945,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get cloudProvider => 'Облачны пастаўшчык';
 
   @override
-  String get premiumMinutesInfo =>
-      '1200 премыум хвілін/месяц. Вкладка На прыборы прапанавае неабмежаваную бясплатную транскрыпцыю.';
+  String get premiumMinutesInfo => '1200 премыум хвілін/месяц. Вкладка На прыборы прапанавае неабмежаваную бясплатную транскрыпцыю.';
 
   @override
   String get viewUsage => 'Прагляд выкарыстання';
 
   @override
-  String get localProcessingInfo =>
-      'Аудыё апрацоўваецца лакальна. Працуе аўтаномна, больш прыватна, але выкарыстоўвае больш батарэі.';
+  String get localProcessingInfo => 'Аудыё апрацоўваецца лакальна. Працуе аўтаномна, больш прыватна, але выкарыстоўвае больш батарэі.';
 
   @override
   String get model => 'Мадэль';
@@ -6084,15 +5960,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get performanceWarning => 'Папярэджаны аб прадуктыўнасці';
 
   @override
-  String get largeModelWarning =>
-      'Гэтая мадэль вельмі воладзьма і можа прывесці да краху прыкладання або працаваць вельмі павольна на мабільных прыборах.\n\nРакамендаваны \"small\" ці \"base\".';
+  String get largeModelWarning => 'Гэтая мадэль вельмі воладзьма і можа прывесці да краху прыкладання або працаваць вельмі павольна на мабільных прыборах.\n\nРакамендаваны \"small\" ці \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Выкарыстанне родзімага распазнавання маўлення iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Будзе выкарыстаны родзім рухавік маўлення вашага прыбора. Загрузка мадэлі не патрэбна.';
+  String get noModelDownloadRequired => 'Будзе выкарыстаны родзім рухавік маўлення вашага прыбора. Загрузка мадэлі не патрэбна.';
 
   @override
   String get modelReady => 'Мадэль готавая';
@@ -6149,12 +6023,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get batteryDrainSignificantly => 'Дранаж батарэі значна павеліцца.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 премыум хвілін/месяц. Вкладка На прыборы прапанавае неабмежаваную бясплатную транскрыпцыю. ';
+  String get premiumMinutesMonth => '1200 премыум хвілін/месяц. Вкладка На прыборы прапанавае неабмежаваную бясплатную транскрыпцыю. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Аудыё апрацоўваецца лакальна. Працуе аўтаномна, больш прыватна, але выкарыстоўвае больш батарэі.';
+  String get audioProcessedLocally => 'Аудыё апрацоўваецца лакальна. Працуе аўтаномна, больш прыватна, але выкарыстоўвае больш батарэі.';
 
   @override
   String get languageLabel => 'Мова';
@@ -6163,12 +6035,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get modelLabel => 'Мадэль';
 
   @override
-  String get modelTooLargeWarning =>
-      'Гэтая мадэль вельмі воладзьма і можа прывесці да краху прыкладання або працаваць вельмі павольна на мабільных прыборах.\n\nРакамендаваны \"small\" ці \"base\".';
+  String get modelTooLargeWarning => 'Гэтая мадэль вельмі воладзьма і можа прывесці да краху прыкладання або працаваць вельмі павольна на мабільных прыборах.\n\nРакамендаваны \"small\" ці \"base\".';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Будзе выкарыстаны родзім рухавік маўлення вашага прыбора. Загрузка мадэлі не патрэбна.';
+  String get nativeEngineNoDownload => 'Будзе выкарыстаны родзім рухавік маўлення вашага прыбора. Загрузка мадэлі не патрэбна.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6204,8 +6074,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Убудаваная жывая транскрыпцыя Omi аптымізавана для разговораў у рэальным часе з аўтаматычным распазнаваннем дыктарыў і дыяризацыяй.';
+  String get omiTranscriptionOptimized => 'Убудаваная жывая транскрыпцыя Omi аптымізавана для разговораў у рэальным часе з аўтаматычным распазнаваннем дыктарыў і дыяризацыяй.';
 
   @override
   String get reset => 'Скінуць';
@@ -6425,8 +6294,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Пабудова графіка ведаў з памяці...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Ваш графік ведаў будзе пабудаваны аўтаматычна, калі вы стварыце новыя памяці.';
+  String get knowledgeGraphWillBuildAutomatically => 'Ваш графік ведаў будзе пабудаваны аўтаматычна, калі вы стварыце новыя памяці.';
 
   @override
   String get buildGraphButton => 'Пабудаваць графік';
@@ -6662,8 +6530,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get failedToLoadContacts => 'Не вышло загрузіць контакты';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Не вышло падрыхтаваць разговор для дзяління. Пожалуйста, паспрабуйце яшчэ раз.';
+  String get failedToPrepareConversationForSharing => 'Не вышло падрыхтаваць разговор для дзяління. Пожалуйста, паспрабуйце яшчэ раз.';
 
   @override
   String get couldNotOpenSmsApp => 'Не вышло адкрыць прыкладанне SMS. Пожалуйста, паспрабуйце яшчэ раз.';
@@ -6729,8 +6596,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Загрузка аудыё з SD картка вашага прыбора';
 
   @override
-  String get transferRequiredDescription =>
-      'Гэты запіс сахаваны на SD картка вашага прыбора. Перамясціце яго на ваш тэлефон, каб слухаць ці дзелініцца.';
+  String get transferRequiredDescription => 'Гэты запіс сахаваны на SD картка вашага прыбора. Перамясціце яго на ваш тэлефон, каб слухаць ці дзелініцца.';
 
   @override
   String get cancelTransfer => 'Скасаваць пераноса';
@@ -6751,8 +6617,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get shareRecording => 'Абагуліць запіс';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Вы ўпэўнены, што хочаце назаўсёды выдаліць гэты запіс? Гэта не можна адмяніць.';
+  String get deleteRecordingConfirmation => 'Вы ўпэўнены, што хочаце назаўсёды выдаліць гэты запіс? Гэта не можна адмяніць.';
 
   @override
   String get recordingIdLabel => 'ID запісу';
@@ -6811,15 +6676,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get enableFastTransfer => 'Ўключыць хуткую пераноску';
 
   @override
-  String get fastTransferDescription =>
-      'Хутка пераноска выкарыстоўвае WiFi для ~5х больш хуткага хуткасці. Ваш тэлефон часова падключыцца да сеткі WiFi вашага прыстасавання Omi падчас пераносы.';
+  String get fastTransferDescription => 'Хутка пераноска выкарыстоўвае WiFi для ~5х больш хуткага хуткасці. Ваш тэлефон часова падключыцца да сеткі WiFi вашага прыстасавання Omi падчас пераносы.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Доступ у інтэрнет паставлены на паўзу падчас пераносы';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Выберыце спосаб пераносы запісаў з вашага прыстасавання Omi на ваш тэлефон.';
+  String get chooseTransferMethodDescription => 'Выберыце спосаб пераносы запісаў з вашага прыстасавання Omi на ваш тэлефон.';
 
   @override
   String get wifiSpeed => '~150 KB/s праз WiFi';
@@ -6828,8 +6691,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get fiveTimesFaster => '5X ХУТЧЭЙ';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Стварае прамую злучэнне WiFi з вашым прыстасаваннем Omi. Ваш тэлефон часова адключаецца ад звычайнай сеткі WiFi падчас пераносы.';
+  String get fastTransferMethodDescription => 'Стварае прамую злучэнне WiFi з вашым прыстасаваннем Omi. Ваш тэлефон часова адключаецца ад звычайнай сеткі WiFi падчас пераносы.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6838,8 +6700,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get bleSpeed => '~30 KB/s праз BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Выкарыстоўвае стандартнае Bluetooth Low Energy злучэнне. Павольней, але не ўплывае на ваше WiFi злучэнне.';
+  String get bluetoothMethodDescription => 'Выкарыстоўвае стандартнае Bluetooth Low Energy злучэнне. Павольней, але не ўплывае на ваше WiFi злучэнне.';
 
   @override
   String get selected => 'Выбрана';
@@ -6880,8 +6741,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get appVisibilityChangedSuccessfully => 'Відимасць дадатка змененая ўдала. Гэта можа заняць некалькі хвілін.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Памылка пры актывізацыі дадатка. Калі гэта дадатак інтэграцыі, заканчыце наладку.';
+  String get errorActivatingAppIntegration => 'Памылка пры актывізацыі дадатка. Калі гэта дадатак інтэграцыі, заканчыце наладку.';
 
   @override
   String get errorUpdatingAppStatus => 'Адбылася памылка пры абнаўленні стану дадатка.';
@@ -6949,8 +6809,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get importantConversationTitle => 'Важная разма';
 
   @override
-  String get importantConversationBody =>
-      'Вы толькі што мелі важную размову. Націсніце, каб абагуліць рэзюмэ з іншымі.';
+  String get importantConversationBody => 'Вы толькі што мелі важную размову. Націсніце, каб абагуліць рэзюмэ з іншымі.';
 
   @override
   String get templateName => 'Назва шаблёна';
@@ -6962,8 +6821,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Назва павінна быць не менш за 3 сімвалы';
 
   @override
-  String get conversationPromptHint =>
-      'напрыклад, Выняць элементы дзеяння, рашэнні, прынятыя і ключавыя моменты з прадстаўленай размовы.';
+  String get conversationPromptHint => 'напрыклад, Выняць элементы дзеяння, рашэнні, прынятыя і ключавыя моменты з прадстаўленай размовы.';
 
   @override
   String get pleaseEnterAppPrompt => 'Калі ласка, введзіце запіт да вашага дадатка';
@@ -7045,8 +6903,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'Дозвол на фотаграфіі адмоўлены. Калі ласка, разрэшыце доступ да фотаграфій, каб выбраць выяву';
+  String get addAppPhotosPermissionDenied => 'Дозвол на фотаграфіі адмоўлены. Калі ласка, разрэшыце доступ да фотаграфій, каб выбраць выяву';
 
   @override
   String get addAppErrorSelectingImageRetry => 'Памылка пры выбары выявы. Спрабуйце яшчэ раз.';
@@ -7151,15 +7008,13 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Паўпшасцэнне заплянавана! Ваш штомесячны план працягваецца да канца вашага біліцейнага перыёда, затым аўтаматычна мяняецца на річны.';
+  String get planUpgradeScheduledMessage => 'Паўпшасцэнне заплянавана! Ваш штомесячны план працягваецца да канца вашага біліцейнага перыёда, затым аўтаматычна мяняецца на річны.';
 
   @override
   String get couldNotSchedulePlanChange => 'Не вдалося заплянаваць смену плана. Спрабуйце яшчэ раз.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Ваша подпіска была перазапушчана! Без плацежа зараз - вы будзеце выставлены рахунак у канцы вашага цяперашняга перыёда.';
+  String get subscriptionReactivatedDefault => 'Ваша подпіска была перазапушчана! Без плацежа зараз - вы будзеце выставлены рахунак у канцы вашага цяперашняга перыёда.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Подпіска ўспяшнай! Вам вылічаны плата за новы біліцейны перыёд.';
@@ -7342,8 +7197,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Дозвол Bluetooth патрэбны для падключэння да вашага прыстасавання.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Дозвол Bluetooth адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Дозвол Bluetooth адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7356,12 +7210,10 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Дозвол на ведаміяць адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Дозвол на ведаміяць адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Дозвол на ведаміяць адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы > Ведаміяці.';
+  String get onboardingNotificationDeniedNotifications => 'Дозвол на ведаміяць адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы > Ведаміяці.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7374,15 +7226,13 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Калі ласка, разрэшыце дозвол на месцазнаходжанне ў Параметрах > Прыватнасць і бяспека > Сервісы месцазнаходжання';
+  String get onboardingLocationGrantInSettings => 'Калі ласка, разрэшыце дозвол на месцазнаходжанне ў Параметрах > Прыватнасць і бяспека > Сервісы месцазнаходжання';
 
   @override
   String get onboardingMicrophoneRequired => 'Дозвол мікрофона патрэбны для запісу.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Дозвол мікрофона адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы > Прыватнасць і бяспека > Мікрофон.';
+  String get onboardingMicrophoneDenied => 'Дозвол мікрофона адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы > Прыватнасць і бяспека > Мікрофон.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7398,8 +7248,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Дозвол на захоп экрана патрэбны для запісу сістэмнага аўдыё.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Дозвол на захоп экрана адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы > Прыватнасць і бяспека > Запіс экрана.';
+  String get onboardingScreenCaptureDenied => 'Дозвол на захоп экрана адмоўлены. Калі ласка, разрэшыце дозвол у Параметрах системы > Прыватнасць і бяспека > Запіс экрана.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7452,8 +7301,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Дозвол на фотаграфіі адмоўлены. Калі ласка, разрэшыце доступ да фотаграфій, каб выбраць выявы';
+  String get msgPhotosPermissionDenied => 'Дозвол на фотаграфіі адмоўлены. Калі ласка, разрэшыце доступ да фотаграфій, каб выбраць выявы';
 
   @override
   String get msgSelectImagesGenericError => 'Памылка пры выбары выяў. Спрабуйце яшчэ раз.';
@@ -7507,8 +7355,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get devModeInvalidAudioBytesWebhookUrl => 'Недапушчальны URL-адрас вэбхука байтаў аўдыё';
 
   @override
-  String get devModeInvalidRealtimeTranscriptWebhookUrl =>
-      'Недапушчальны URL-адрас вэбхука транскрыпцыі рэального часу';
+  String get devModeInvalidRealtimeTranscriptWebhookUrl => 'Недапушчальны URL-адрас вэбхука транскрыпцыі рэального часу';
 
   @override
   String get devModeInvalidConversationCreatedWebhookUrl => 'Недапушчальны URL-адрас вэбхука стварэння разьмовы';
@@ -7526,8 +7373,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get locationPermissionRequired => 'Дозвол на месцазнаходжанне патрэбны';
 
   @override
-  String get locationPermissionContent =>
-      'Хутка пераноска патрэбуе дозвол на месцазнаходжанне, каб прапаноўваць WiFi злучэнне. Калі ласка, разрэшыце дозвол на месцазнаходжанне, каб адкіць.';
+  String get locationPermissionContent => 'Хутка пераноска патрэбуе дозвол на месцазнаходжанне, каб прапаноўваць WiFi злучэнне. Калі ласка, разрэшыце дозвол на месцазнаходжанне, каб адкіць.';
 
   @override
   String get pdfTranscriptExport => 'Экспорт транскрыпцыі';
@@ -7690,8 +7536,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Прыстасаванне не падтрымлівае WiFi синхранізацыю, мяняем на Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Прыстасаванне не падтрымлівае WiFi синхранізацыю, мяняем на Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health недаступна на гэтым прыстасаванні';
@@ -7987,8 +7832,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Пакладзіце Omi DevKit у рэжым спарыпання';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Натысніце кнопку адзін раз для ўключэння. Калі рэжым спарыпання актыўны, LED мігацьме фіялетавым.';
+  String get pairingDescOmiDevkit => 'Натысніце кнопку адзін раз для ўключэння. Калі рэжым спарыпання актыўны, LED мігацьме фіялетавым.';
 
   @override
   String get pairingTitleOmiGlass => 'Уключыце Omi Glass';
@@ -8000,8 +7844,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Пакладзіце Plaud Note у рэжым спарыпання';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Прыціскайце і трымайце бакавую кнопку на 2 секунды. Чырвоны LED мігацьме, калі гатовы.';
+  String get pairingDescPlaudNote => 'Прыціскайце і трымайце бакавую кнопку на 2 секунды. Чырвоны LED мігацьме, калі гатовы.';
 
   @override
   String get pairingTitleBee => 'Пакладзіце Bee у рэжым спарыпання';
@@ -8013,15 +7856,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get pairingTitleLimitless => 'Пакладзіце Limitless у рэжым спарыпання';
 
   @override
-  String get pairingDescLimitless =>
-      'Калі любы індыкатар бачны, натысніце адзін раз, потым прыціскайце кнопку да ружоватага сцвятлення і адпусціце.';
+  String get pairingDescLimitless => 'Калі любы індыкатар бачны, натысніце адзін раз, потым прыціскайце кнопку да ружоватага сцвятлення і адпусціце.';
 
   @override
   String get pairingTitleFriendPendant => 'Пакладзіце Friend Pendant у рэжым спарыпання';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Натысніце кнопку на медальёне для ўключэння. Ён аўтаматычна ўвойде у рэжым спарыпання.';
+  String get pairingDescFriendPendant => 'Натысніце кнопку на медальёне для ўключэння. Ён аўтаматычна ўвойде у рэжым спарыпання.';
 
   @override
   String get pairingTitleFieldy => 'Пакладзіце Fieldy у рэжым спарыпання';
@@ -8033,15 +7874,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Падключыце Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Устанавіце і адкрыйце прыкладанне Omi на сваім Apple Watch, потым натысніце Connect у прыкладанні.';
+  String get pairingDescAppleWatch => 'Устанавіце і адкрыйце прыкладанне Omi на сваім Apple Watch, потым натысніце Connect у прыкладанні.';
 
   @override
   String get pairingTitleNeoOne => 'Пакладзіце Neo One у рэжым спарыпання';
 
   @override
-  String get pairingDescNeoOne =>
-      'Прыціскайце і трымайце кнопку ўключэння, пакуль LED не пачне мігаць. Прыстасаванне будзе адкрыта.';
+  String get pairingDescNeoOne => 'Прыціскайце і трымайце кнопку ўключэння, пакуль LED не пачне мігаць. Прыстасаванне будзе адкрыта.';
 
   @override
   String get downloadingFromDevice => 'Загрузка з прыстасавання';
@@ -8111,8 +7950,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get wifiConfiguration => 'Канфігурацыя WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Уведзіце свае ўліку дадаткі WiFi, каб дазволіць прыстасаванню загруліцца прошыўку.';
+  String get wifiConfigurationSubtitle => 'Уведзіце свае ўліку дадаткі WiFi, каб дазволіць прыстасаванню загруліцца прошыўку.';
 
   @override
   String get networkNameSsid => 'Назва сеткі (SSID)';
@@ -8159,8 +7997,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get switchAndRestart => 'Пераключыцца';
 
   @override
-  String get stagingDisclaimer =>
-      'Этап можа мець ошыбкі, непаслядоўную прадукцыйнасць і стрататы дадзеных. Ужывайце толькі для тэставання.';
+  String get stagingDisclaimer => 'Этап можа мець ошыбкі, непаслядоўную прадукцыйнасць і стрататы дадзеных. Ужывайце толькі для тэставання.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Захавана. Закрыйце і перападкрыйце прыкладанне.';
@@ -8389,8 +8226,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Тэлефонныя вызовы праз Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Звяжэцца праз Omi і атрымайце трансляцыю у рэжыме рэальнага часу, аўтаматычныя аніяцыі і іншае. Даступна толькі для падпісчыкаў плана Unlimited.';
+  String get phoneCallsUpsellSubtitle => 'Звяжэцца праз Omi і атрымайце трансляцыю у рэжыме рэальнага часу, аўтаматычныя аніяцыі і іншае. Даступна толькі для падпісчыкаў плана Unlimited.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Трансляцыя кожнага вызова у рэжыме рэальнага часу';
@@ -8429,8 +8265,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deletePendingFiles => 'Выдаліць чакаючыя запісы';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Гэтыя запісы НЕ сінхранізаваны з вашым тэлефонам і будуць назаўсёды страчаны. Гэта нельга адмяніць.';
+  String get deletePendingFilesWarning => 'Гэтыя запісы НЕ сінхранізаваны з вашым тэлефонам і будуць назаўсёды страчаны. Гэта нельга адмяніць.';
 
   @override
   String get pendingFilesDeleted => 'Чакаючыя запісы выдаленыя';
@@ -8442,8 +8277,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deleteAll => 'Выдаліць ўсё';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Гэта выдаліць як сінхранізаваныя, так і чакаючыя запісы. Чакаючыя запісы НЕ сінхранізаваны і будуць назаўсёды страчаны. Гэта нельга адмяніць.';
+  String get deleteAllFilesWarning => 'Гэта выдаліць як сінхранізаваныя, так і чакаючыя запісы. Чакаючыя запісы НЕ сінхранізаваны і будуць назаўсёды страчаны. Гэта нельга адмяніць.';
 
   @override
   String get allFilesDeleted => 'Усе запісы выдаленыя';
@@ -8508,8 +8342,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get fairUseAboutTitle => 'Аб справядлівым ўжыванні';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi прызначаны для асобных размоў, сустрэч і жывых узаёмадзеянняў. Ужыванне вымяраецца рэальным часом мовы, а не часам злучэння. Калі ўжыванне значна перавышае нармальныя мадэлі для ненасобнага контэнта, могуць быць зробленыя карэкцыі.';
+  String get fairUseAboutBody => 'Omi прызначаны для асобных размоў, сустрэч і жывых узаёмадзеянняў. Ужыванне вымяраецца рэальным часом мовы, а не часам злучэння. Калі ўжыванне значна перавышае нармальныя мадэлі для ненасобнага контэнта, могуць быць зробленыя карэкцыі.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8547,8 +8380,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get improveConnectionTitle => 'Палепшыць злучэнне';
 
   @override
-  String get improveConnectionContent =>
-      'Мы палепшылі, як Omi астается злучаным з вашым прыстасаваннем. Каб актывіраваць гэта, перайдзіце на старонку Device Info, натысніце \"Адключыць прыстасаванне\", а потым яшчэ раз спарыце свая прыстасаванне.';
+  String get improveConnectionContent => 'Мы палепшылі, як Omi астается злучаным з вашым прыстасаваннем. Каб актывіраваць гэта, перайдзіце на старонку Device Info, натысніце \"Адключыць прыстасаванне\", а потым яшчэ раз спарыце свая прыстасаванне.';
 
   @override
   String get improveConnectionAction => 'Зразумелі';
@@ -8603,16 +8435,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get cancelSyncQuestion => 'Адмяніць сінхранізацыю?';
 
   @override
-  String get omisStorageDesc =>
-      'Калі вашы Omi не злучаны з вашым тэлефонам, ён захоўвае аўдыё адзінаў у абрана пам\'яці прыстасавання. Вы ніколі не страчаеце запіс.';
+  String get omisStorageDesc => 'Калі вашы Omi не злучаны з вашым тэлефонам, ён захоўвае аўдыё адзінаў у абрана пам\'яці прыстасавання. Вы ніколі не страчаеце запіс.';
 
   @override
-  String get phoneStorageDesc =>
-      'Калі Omi яшчэ раз злучаюцца, запісы аўтаматычна переносяцца на вашы тэлефон як часовае адзінаў да загрузкі.';
+  String get phoneStorageDesc => 'Калі Omi яшчэ раз злучаюцца, запісы аўтаматычна переносяцца на вашы тэлефон як часовае адзінаў да загрузкі.';
 
   @override
-  String get cloudStorageDesc =>
-      'Пасля загрузкі ваш запісы апрацоўваюцца і трансляцуюцца. Размовы будуць даступны у велічыні хвіліны.';
+  String get cloudStorageDesc => 'Пасля загрузкі ваш запісы апрацоўваюцца і трансляцуюцца. Размовы будуць даступны у велічыні хвіліны.';
 
   @override
   String get tipKeepPhoneNearby => 'Трымайце тэлефон побач для хутшыбшай сінхранізацыі';
@@ -8636,12 +8465,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get permissionEnable => 'Уключыць';
 
   @override
-  String get permissionsPageDescription =>
-      'Гэтыя дазволы важны для таго, как працуе Omi. Яны дазваляюць ключавыя функцыі, такія як апавяшчэнні, месцазнаходжанні і захоп аўдыё.';
+  String get permissionsPageDescription => 'Гэтыя дазволы важны для таго, как працуе Omi. Яны дазваляюць ключавыя функцыі, такія як апавяшчэнні, месцазнаходжанні і захоп аўдыё.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi патрабуе некалькі дазволаў для нармальнай работы. Калі ласка, дайце іх, каб прадолжыць.';
+  String get permissionsRequiredDescription => 'Omi патрабуе некалькі дазволаў для нармальнай работы. Калі ласка, дайце іх, каб прадолжыць.';
 
   @override
   String get permissionsSetupTitle => 'Атрымайце найлепшыя адносіны';
@@ -8897,8 +8724,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get enableLocationTitle => 'Уключыць месцазнаходжанне';
 
   @override
-  String get enableLocationDescription =>
-      'Дазвол на месцазнаходжанне патрэбны, каб знайсці pobliski Bluetooth-прыстасаванні.';
+  String get enableLocationDescription => 'Дазвол на месцазнаходжанне патрэбны, каб знайсці pobliski Bluetooth-прыстасаванні.';
 
   @override
   String get voiceRecordingFound => 'Запіс знойдзены';
@@ -8919,8 +8745,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get firmwareWarningTitle => 'Важна: Прачытайце перад абнаўленнем';
 
   @override
-  String get firmwareFormatWarning =>
-      'Гэта прашыўка адфарматуе SD-карту. Калі ласка, пераканайцеся, што ўсе афлайн-даныя сінхранізаваны перад абнаўленнем.\n\nКалі пасля ўстаноўкі гэтай версіі вы ўбачыце мігатлівы чырвоны індыкатар, не хвалюйцеся. Проста падключыце прыладу да праграмы, і яна павінна стаць сіняй. Чырвоны індыкатар азначае, што гадзіннік прылады яшчэ не сінхранізаваны.';
+  String get firmwareFormatWarning => 'Гэта прашыўка адфарматуе SD-карту. Калі ласка, пераканайцеся, што ўсе афлайн-даныя сінхранізаваны перад абнаўленнем.\n\nКалі пасля ўстаноўкі гэтай версіі вы ўбачыце мігатлівы чырвоны індыкатар, не хвалюйцеся. Проста падключыце прыладу да праграмы, і яна павінна стаць сіняй. Чырвоны індыкатар азначае, што гадзіннік прылады яшчэ не сінхранізаваны.';
 
   @override
   String get continueAnyway => 'Працягнуць';
@@ -8940,8 +8765,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get tasksMarkComplete => 'Адзначана як выкананае';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi атрымлівае доступ да Apple Health праз фрэймворк HealthKit ад Apple. Вы можаце адклікаць доступ у любы час у Наладах iOS.';
+  String get appleHealthManageNote => 'Omi атрымлівае доступ да Apple Health праз фрэймворк HealthKit ад Apple. Вы можаце адклікаць доступ у любы час у Наладах iOS.';
 
   @override
   String get appleHealthConnectCta => 'Падключыць Apple Health';
@@ -8974,8 +8798,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Доступ да Apple Health адхілены';
 
   @override
-  String get appleHealthDeniedBody =>
-      'У Omi няма дазволу на чытанне даных Apple Health. Уключыце яго ў Налады iOS → Прыватнасць і бяспека → Health → Omi.';
+  String get appleHealthDeniedBody => 'У Omi няма дазволу на чытанне даных Apple Health. Уключыце яго ў Налады iOS → Прыватнасць і бяспека → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Чаму вы сыходзіце?';
@@ -9044,8 +8867,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get planUpdate => 'Абнаўленне плана';
 
   @override
-  String get planDeprecationMessage =>
-      'Ваш план Unlimited спыняецца. Пераключыцеся на план Operator — тыя ж выдатныя магчымасці за \$49/мес. Ваш бягучы план будзе працягваць працаваць тым часам.';
+  String get planDeprecationMessage => 'Ваш план Unlimited спыняецца. Пераключыцеся на план Operator — тыя ж выдатныя магчымасці за \$49/мес. Ваш бягучы план будзе працягваць працаваць тым часам.';
 
   @override
   String get upgradeYourPlan => 'Палепшыце свой план';
@@ -9156,8 +8978,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Вы дасягнулі свайго месячнага ліміту. Абнавіце, каб працягваць размаўляць з Omi без абмежаванняў.';
+  String get chatQuotaExceededReply => 'Вы дасягнулі свайго месячнага ліміту. Абнавіце, каб працягваць размаўляць з Omi без абмежаванняў.';
 
   @override
   String get voiceResponseAudio => 'Чытаць адказ Omi уголас';
@@ -9188,4 +9009,25 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Дадаць заданне';
+
+  @override
+  String get quickActionAskOmiAnything => 'Спытайце ў Омі што заўгодна';
+
+  @override
+  String get quickActionVoiceMode => 'Галасавы рэжым';
+
+  @override
+  String get quickActionMute => 'Адключыць гук';
+
+  @override
+  String get quickActionUnmute => 'Уключыць гук';
+
+  @override
+  String get quickActionConnectDevice => 'Падключыць прыладу';
+
+  @override
+  String get quickActionDeviceSettings => 'Налады прылады';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -24,8 +24,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteConversationTitle => 'Изтриване на разговор?';
 
   @override
-  String get deleteConversationMessage =>
-      'Това ще изтрие и свързаните спомени, задачи и аудио файлове. Това действие не може да бъде отменено.';
+  String get deleteConversationMessage => 'Това ще изтрие и свързаните спомени, задачи и аудио файлове. Това действие не може да бъде отменено.';
 
   @override
   String get confirm => 'Потвърди';
@@ -146,8 +145,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleting => 'Изтриване...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
+  String get pleaseCompleteAuthentication => 'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
 
   @override
   String get failedToStartAuthentication => 'Неуспешно стартиране на удостоверяване';
@@ -228,8 +226,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noStarredConversations => 'Няма отбелязани разговори';
 
   @override
-  String get starConversationHint =>
-      'За да отбележите разговор, отворете го и натиснете иконката със звезда в заглавието.';
+  String get starConversationHint => 'За да отбележите разговор, отворете го и натиснете иконката със звезда в заглавието.';
 
   @override
   String get searchConversations => 'Търсене на разговори...';
@@ -320,8 +317,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get installedApps => 'Инсталирани приложения';
 
   @override
-  String get unableToFetchApps =>
-      'Не могат да се заредят приложенията :(\n\nМоля, проверете интернет връзката си и опитайте отново.';
+  String get unableToFetchApps => 'Не могат да се заредят приложенията :(\n\nМоля, проверете интернет връзката си и опитайте отново.';
 
   @override
   String get aboutOmi => 'За Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get appsDisconnected => 'Вашите приложения и интеграции ще бъдат прекратени незабавно.';
 
   @override
-  String get exportBeforeDelete =>
-      'Можете да експортирате данните си преди да изтриете акаунта си, но след като бъде изтрит, не може да бъде възстановен.';
+  String get exportBeforeDelete => 'Можете да експортирате данните си преди да изтриете акаунта си, но след като бъде изтрит, не може да бъде възстановен.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Разбирам, че изтриването на акаунта ми е постоянно и всички данни, включително спомени и разговори, ще бъдат загубени и не могат да бъдат възстановени.';
+  String get deleteAccountCheckbox => 'Разбирам, че изтриването на акаунта ми е постоянно и всички данни, включително спомени и разговори, ще бъдат загубени и не могат да бъдат възстановени.';
 
   @override
   String get areYouSure => 'Сигурни ли сте?';
 
   @override
-  String get deleteAccountFinal =>
-      'Това действие е необратимо и ще изтрие завинаги вашия акаунт и всички свързани данни. Сигурни ли сте, че искате да продължите?';
+  String get deleteAccountFinal => 'Това действие е необратимо и ще изтрие завинаги вашия акаунт и всички свързани данни. Сигурни ли сте, че искате да продължите?';
 
   @override
   String get deleteNow => 'Изтрий сега';
@@ -378,8 +371,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get goBack => 'Назад';
 
   @override
-  String get checkBoxToConfirm =>
-      'Отметнете квадратчето, за да потвърдите, че разбирате, че изтриването на акаунта ви е постоянно и необратимо.';
+  String get checkBoxToConfirm => 'Отметнете квадратчето, за да потвърдите, че разбирате, че изтриването на акаунта ви е постоянно и необратимо.';
 
   @override
   String get profile => 'Профил';
@@ -457,8 +449,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get yourPrivacyYourControl => 'Вашата поверителност, вашият контрол';
 
   @override
-  String get privacyIntro =>
-      'В Omi сме ангажирани със защитата на вашата поверителност. Тази страница ви позволява да контролирате как вашите данни се съхраняват и използват.';
+  String get privacyIntro => 'В Omi сме ангажирани със защитата на вашата поверителност. Тази страница ви позволява да контролирате как вашите данни се съхраняват и използват.';
 
   @override
   String get learnMore => 'Научете повече...';
@@ -467,15 +458,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dataProtectionLevel => 'Ниво на защита на данните';
 
   @override
-  String get dataProtectionDesc =>
-      'Вашите данни са защитени по подразбиране със силно криптиране. Прегледайте настройките си и бъдещите опции за поверителност по-долу.';
+  String get dataProtectionDesc => 'Вашите данни са защитени по подразбиране със силно криптиране. Прегледайте настройките си и бъдещите опции за поверителност по-долу.';
 
   @override
   String get appAccess => 'Достъп до приложение';
 
   @override
-  String get appAccessDesc =>
-      'Следните приложения могат да имат достъп до вашите данни. Докоснете приложение, за да управлявате неговите разрешения.';
+  String get appAccessDesc => 'Следните приложения могат да имат достъп до вашите данни. Докоснете приложение, за да управлявате неговите разрешения.';
 
   @override
   String get noAppsExternalAccess => 'Няма инсталирани приложения с външен достъп до вашите данни.';
@@ -532,22 +521,19 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Вашият Omi беше прекъснат 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Устройството е разкачено. Отидете в Настройки > Bluetooth и забравете устройството, за да завършите разкачването.';
+  String get deviceUnpairedMessage => 'Устройството е разкачено. Отидете в Настройки > Bluetooth и забравете устройството, за да завършите разкачването.';
 
   @override
   String get unpairDialogTitle => 'Разедини устройство';
 
   @override
-  String get unpairDialogMessage =>
-      'Това ще разедини устройството, така че да може да бъде свързано с друг телефон. Ще трябва да отидете в Настройки > Bluetooth и да забравите устройството, за да завършите процеса.';
+  String get unpairDialogMessage => 'Това ще разедини устройството, така че да може да бъде свързано с друг телефон. Ще трябва да отидете в Настройки > Bluetooth и да забравите устройството, за да завършите процеса.';
 
   @override
   String get deviceNotConnected => 'Устройството не е свързано';
 
   @override
-  String get connectDeviceMessage =>
-      'Свържете вашето Omi устройство за достъп\nдо настройките на устройството и персонализация';
+  String get connectDeviceMessage => 'Свържете вашето Omi устройство за достъп\nдо настройките на устройството и персонализация';
 
   @override
   String get deviceInfoSection => 'Информация за устройството';
@@ -562,8 +548,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get v2Undetected => 'V2 не е открит';
 
   @override
-  String get v2UndetectedMessage =>
-      'Виждаме, че имате V1 устройство или устройството ви не е свързано. Функционалността на SD картата е налична само за V2 устройства.';
+  String get v2UndetectedMessage => 'Виждаме, че имате V1 устройство или устройството ви не е свързано. Функционалността на SD картата е налична само за V2 устройства.';
 
   @override
   String get endConversation => 'Край на разговор';
@@ -695,8 +680,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noActivityYet => 'Все още няма дейност';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Започнете разговор с Omi,\nза да видите прозренията си за използване тук.';
+  String get startConversationToSeeInsights => 'Започнете разговор с Omi,\nза да видите прозренията си за използване тук.';
 
   @override
   String get listening => 'Слушане';
@@ -838,8 +822,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Изтриване на граф на знанията?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Това ще изтрие всички производни данни от графа на знанията (възли и връзки). Вашите оригинални спомени ще останат в безопасност. Графът ще бъде възстановен с течение на времето или при следващо запитване.';
+  String get deleteKnowledgeGraphMessage => 'Това ще изтрие всички производни данни от графа на знанията (възли и връзки). Вашите оригинални спомени ще останат в безопасност. Графът ще бъде възстановен с течение на времето или при следващо запитване.';
 
   @override
   String get knowledgeGraphDeleted => 'Графът на знанията е изтрит';
@@ -987,8 +970,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shortConversationThreshold => 'Праг за кратък разговор';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Разговорите по-къси от това ще бъдат скрити, освен ако не са активирани по-горе';
+  String get shortConversationThresholdSubtitle => 'Разговорите по-къси от това ще бъдат скрити, освен ако не са активирани по-горе';
 
   @override
   String get durationThreshold => 'Праг на продължителност';
@@ -1023,8 +1005,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get integrationsFooter => 'Свържете вашите приложения, за да виждате данни и метрики в чата.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
+  String get completeAuthInBrowser => 'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1084,8 +1065,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get needYourPermission => 'Нуждаем се от вашето разрешение';
 
   @override
-  String get alreadyGavePermission =>
-      'Вече сте ни дали разрешение да запазваме вашите записи. Ето напомняне защо го нуждаем:';
+  String get alreadyGavePermission => 'Вече сте ни дали разрешение да запазваме вашите записи. Ето напомняне защо го нуждаем:';
 
   @override
   String get wouldLikePermission => 'Бихме искали вашето разрешение да запазваме вашите гласови записи. Ето защо:';
@@ -1100,19 +1080,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get trainFamilyProfiles => 'Обучете профили за приятели и семейство';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Вашите записи ни помагат да разпознаем и създадем профили за вашите приятели и семейство.';
+  String get trainFamilyProfilesDesc => 'Вашите записи ни помагат да разпознаем и създадем профили за вашите приятели и семейство.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Подобрете точността на транскрипта';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'С подобряването на нашия модел, можем да предоставим по-добри резултати от транскрипцията за вашите записи.';
+  String get enhanceTranscriptAccuracyDesc => 'С подобряването на нашия модел, можем да предоставим по-добри резултати от транскрипцията за вашите записи.';
 
   @override
-  String get legalNotice =>
-      'Юридическо уведомление: Законността на записването и съхраняването на гласови данни може да варира в зависимост от вашето местоположение и как използвате тази функция. Вие сте отговорни за спазването на местните закони и разпоредби.';
+  String get legalNotice => 'Юридическо уведомление: Законността на записването и съхраняването на гласови данни може да варира в зависимост от вашето местоположение и как използвате тази функция. Вие сте отговорни за спазването на местните закони и разпоредби.';
 
   @override
   String get alreadyAuthorized => 'Вече разрешено';
@@ -1231,8 +1208,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noProjectsInWorkspace => 'Няма намерени проекти в това работно пространство';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Изберете колко дълго да се чака в тишина преди автоматично приключване на разговор:';
+  String get conversationTimeoutDesc => 'Изберете колко дълго да се чака в тишина преди автоматично приключване на разговор:';
 
   @override
   String get timeout2Minutes => '2 минути';
@@ -1359,8 +1335,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get defaultRepository => 'Хранилище по подразбиране';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Изберете хранилище по подразбиране за създаване на проблеми. Все още можете да посочите различно хранилище при създаване на проблеми.';
+  String get selectDefaultRepoDesc => 'Изберете хранилище по подразбиране за създаване на проблеми. Все още можете да посочите различно хранилище при създаване на проблеми.';
 
   @override
   String get noReposFound => 'Не са намерени хранилища';
@@ -1407,8 +1382,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get configureSettings => 'Конфигурирай настройки';
 
   @override
-  String get completeAuthBrowser =>
-      'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
+  String get completeAuthBrowser => 'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1577,8 +1551,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get logsCopied => 'Дневниците са копирани';
 
   @override
-  String get noLogsYet =>
-      'Все още няма дневници. Започнете записване, за да видите активността на персонализирания STT.';
+  String get noLogsYet => 'Все още няма дневници. Започнете записване, за да видите активността на персонализирания STT.';
 
   @override
   String deviceUsesCodec(String device, String reason) {
@@ -1737,8 +1710,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get enableBluetooth => 'Активирай Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi се нуждае от Bluetooth, за да се свърже с вашето носимо устройство. Моля, активирайте Bluetooth и опитайте отново.';
+  String get bluetoothNeeded => 'Omi се нуждае от Bluetooth, за да се свърже с вашето носимо устройство. Моля, активирайте Bluetooth и опитайте отново.';
 
   @override
   String get contactSupport => 'Свържете се с поддръжката?';
@@ -1771,26 +1743,22 @@ class AppLocalizationsBg extends AppLocalizations {
   String get locationServiceDisabled => 'Услугата за местоположение е деактивирана';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Услугата за местоположение е деактивирана. Моля, отидете в Настройки > Поверителност и сигурност > Услуги за местоположение и я активирайте';
+  String get locationServiceDisabledDesc => 'Услугата за местоположение е деактивирана. Моля, отидете в Настройки > Поверителност и сигурност > Услуги за местоположение и я активирайте';
 
   @override
   String get backgroundLocationDenied => 'Отказан достъп до фоново местоположение';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Моля, отидете в настройките на устройството и задайте разрешението за местоположение на \"Винаги разрешавай\"';
+  String get backgroundLocationDeniedDesc => 'Моля, отидете в настройките на устройството и задайте разрешението за местоположение на \"Винаги разрешавай\"';
 
   @override
   String get lovingOmi => 'Обичате ли Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Помогнете ни да достигнем до повече хора, като оставите отзив в App Store. Вашата обратна връзка е много важна за нас!';
+  String get leaveReviewIos => 'Помогнете ни да достигнем до повече хора, като оставите отзив в App Store. Вашата обратна връзка е много важна за нас!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Помогнете ни да достигнем до повече хора, като оставите отзив в Google Play Store. Вашата обратна връзка е много важна за нас!';
+  String get leaveReviewAndroid => 'Помогнете ни да достигнем до повече хора, като оставите отзив в Google Play Store. Вашата обратна връзка е много важна за нас!';
 
   @override
   String get rateOnAppStore => 'Оценете в App Store';
@@ -1823,15 +1791,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get connectionError => 'Грешка в връзката';
 
   @override
-  String get connectionErrorDesc =>
-      'Неуспешна връзка със сървъра. Моля, проверете интернет връзката си и опитайте отново.';
+  String get connectionErrorDesc => 'Неуспешна връзка със сървъра. Моля, проверете интернет връзката си и опитайте отново.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Открит е невалиден запис';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Изглежда има множество говорители в записа. Моля, уверете се, че сте на тихо място и опитайте отново.';
+  String get multipleSpeakersDesc => 'Изглежда има множество говорители в записа. Моля, уверете се, че сте на тихо място и опитайте отново.';
 
   @override
   String get tooShortDesc => 'Не е открита достатъчно реч. Моля, говорете повече и опитайте отново.';
@@ -1843,8 +1809,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get areYouThere => 'Там ли сте?';
 
   @override
-  String get noSpeechDesc =>
-      'Не можахме да открием реч. Моля, уверете се, че говорите поне 10 секунди и не повече от 3 минути.';
+  String get noSpeechDesc => 'Не можахме да открием реч. Моля, уверете се, че говорите поне 10 секунди и не повече от 3 минути.';
 
   @override
   String get connectionLost => 'Връзката е изгубена';
@@ -1865,8 +1830,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get permissionsRequired => 'Необходими разрешения';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Това приложение се нуждае от разрешения за Bluetooth и местоположение, за да функционира правилно. Моля, активирайте ги в настройките.';
+  String get permissionsRequiredDesc => 'Това приложение се нуждае от разрешения за Bluetooth и местоположение, за да функционира правилно. Моля, активирайте ги в настройките.';
 
   @override
   String get openSettings => 'Отвори настройки';
@@ -1908,12 +1872,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get microphonePermission => 'Разрешение за микрофон';
 
   @override
-  String get permissionGrantedNow =>
-      'Разрешението е дадено! Сега:\n\nОтворете приложението Omi на часовника си и натиснете \"Продължи\" по-долу';
+  String get permissionGrantedNow => 'Разрешението е дадено! Сега:\n\nОтворете приложението Omi на часовника си и натиснете \"Продължи\" по-долу';
 
   @override
-  String get needMicrophonePermission =>
-      'Нуждаем се от разрешение за микрофон.\n\n1. Натиснете \"Дайте разрешение\"\n2. Разрешете на вашия iPhone\n3. Приложението на часовника ще се затвори\n4. Отворете отново и натиснете \"Продължи\"';
+  String get needMicrophonePermission => 'Нуждаем се от разрешение за микрофон.\n\n1. Натиснете \"Дайте разрешение\"\n2. Разрешете на вашия iPhone\n3. Приложението на часовника ще се затвори\n4. Отворете отново и натиснете \"Продължи\"';
 
   @override
   String get grantPermissionButton => 'Дайте разрешение';
@@ -1922,15 +1884,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get needHelp => 'Нужда от помощ?';
 
   @override
-  String get troubleshootingSteps =>
-      'Отстраняване на проблеми:\n\n1. Уверете се, че Omi е инсталиран на часовника ви\n2. Отворете приложението Omi на часовника си\n3. Потърсете изскачащия прозорец за разрешение\n4. Натиснете \"Разреши\" когато бъдете подканени\n5. Приложението на часовника ще се затвори - отворете го отново\n6. Върнете се и натиснете \"Продължи\" на вашия iPhone';
+  String get troubleshootingSteps => 'Отстраняване на проблеми:\n\n1. Уверете се, че Omi е инсталиран на часовника ви\n2. Отворете приложението Omi на часовника си\n3. Потърсете изскачащия прозорец за разрешение\n4. Натиснете \"Разреши\" когато бъдете подканени\n5. Приложението на часовника ще се затвори - отворете го отново\n6. Върнете се и натиснете \"Продължи\" на вашия iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Записването започна успешно!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Разрешението все още не е дадено. Моля, уверете се, че сте разрешили достъп до микрофона и сте отворили отново приложението на часовника си.';
+  String get permissionNotGrantedYet => 'Разрешението все още не е дадено. Моля, уверете се, че сте разрешили достъп до микрофона и сте отворили отново приложението на часовника си.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2027,8 +1987,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Готови за задачи';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Вашият AI автоматично ще извлича задачи и дейности от вашите разговори. Те ще се появят тук, когато бъдат създадени.';
+  String get welcomeActionItemsDescription => 'Вашият AI автоматично ще извлича задачи и дейности от вашите разговори. Те ще се появят тук, когато бъдат създадени.';
 
   @override
   String get autoExtractionFeature => 'Автоматично извлечени от разговори';
@@ -2078,8 +2037,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get clearMemoryTitle => 'Изчистване на паметта на Omi';
 
   @override
-  String get clearMemoryMessage =>
-      'Сигурни ли сте, че искате да изчистите паметта на Omi? Това действие не може да бъде отменено.';
+  String get clearMemoryMessage => 'Сигурни ли сте, че искате да изчистите паметта на Omi? Това действие не може да бъде отменено.';
 
   @override
   String get clearMemoryButton => 'Изчисти паметта';
@@ -2225,15 +2183,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'РЕЧ И ТРАНСКРИПЦИЯ';
 
   @override
-  String get languageSettingsHelperText =>
-      'Езикът на приложението променя менютата и бутоните. Езикът на речта влияе на начина, по който се транскрибират вашите записи.';
+  String get languageSettingsHelperText => 'Езикът на приложението променя менютата и бутоните. Езикът на речта влияе на начина, по който се транскрибират вашите записи.';
 
   @override
   String get translationNotice => 'Известие за превод';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi превежда разговори на вашия основен език. Актуализирайте го по всяко време в Настройки → Профили.';
+  String get translationNoticeMessage => 'Omi превежда разговори на вашия основен език. Актуализирайте го по всяко време в Настройки → Профили.';
 
   @override
   String get pleaseCheckInternetConnection => 'Моля, проверете интернет връзката си и опитайте отново';
@@ -2388,8 +2344,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Разкачи устройството';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Това ще разкачи устройството, за да може да бъде свързано с друг телефон. Ще трябва да отидете в Настройки > Bluetooth и да забравите устройството, за да завършите процеса.';
+  String get unpairDeviceDialogMessage => 'Това ще разкачи устройството, за да може да бъде свързано с друг телефон. Ще трябва да отидете в Настройки > Bluetooth и да забравите устройството, за да завършите процеса.';
 
   @override
   String get unpair => 'Разкачи';
@@ -2570,8 +2525,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get youreAllSet => 'Готови сте!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Добре дошли в Omi! Вашият AI спътник е готов да ви помогне с разговори, задачи и още.';
+  String get welcomeToOmiDescription => 'Добре дошли в Omi! Вашият AI спътник е готов да ви помогне с разговори, задачи и още.';
 
   @override
   String get startUsingOmi => 'Започнете да използвате Omi';
@@ -2650,8 +2604,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get reviewAndManageConversations => 'Прегледайте и управлявайте записаните си разговори';
 
   @override
-  String get startCapturingConversations =>
-      'Започнете да записвате разговори с вашето устройство Omi, за да ги видите тук.';
+  String get startCapturingConversations => 'Започнете да записвате разговори с вашето устройство Omi, за да ги видите тук.';
 
   @override
   String get useMobileAppToCapture => 'Използвайте мобилното приложение за записване на аудио';
@@ -2708,8 +2661,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noTasksYet => 'Все още няма задачи';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Задачите от вашите разговори ще се показват тук.\nЩракнете върху Създаване, за да добавите една ръчно.';
+  String get tasksFromConversationsWillAppear => 'Задачите от вашите разговори ще се показват тук.\nЩракнете върху Създаване, за да добавите една ръчно.';
 
   @override
   String get monthJan => 'Ян';
@@ -2766,8 +2718,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteActionItem => 'Изтриване на задача';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Сигурни ли сте, че искате да изтриете тази задача? Това действие не може да бъде отменено.';
+  String get deleteActionItemConfirmation => 'Сигурни ли сте, че искате да изтриете тази задача? Това действие не може да бъде отменено.';
 
   @override
   String get enterActionItemDescription => 'Въведете описание на задачата...';
@@ -2842,15 +2793,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get chatPrompt => 'Подсказка за чат';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Вие сте страхотно приложение, вашата задача е да отговаряте на потребителските запитвания и да ги карате да се чувстват добре...';
+  String get chatPromptPlaceholder => 'Вие сте страхотно приложение, вашата задача е да отговаряте на потребителските запитвания и да ги карате да се чувстват добре...';
 
   @override
   String get conversationPrompt => 'Подканване за разговор';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Вие сте страхотно приложение, ще ви бъде даден транскрипт и резюме на разговор...';
+  String get conversationPromptPlaceholder => 'Вие сте страхотно приложение, ще ви бъде даден транскрипт и резюме на разговор...';
 
   @override
   String get notificationScopes => 'Обхват на известията';
@@ -2862,8 +2811,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get makeMyAppPublic => 'Направи приложението ми публично';
 
   @override
-  String get submitAppTermsAgreement =>
-      'С изпращането на това приложение приемам Условията за ползване и Политиката за поверителност на Omi AI';
+  String get submitAppTermsAgreement => 'С изпращането на това приложение приемам Условията за ползване и Политиката за поверителност на Omi AI';
 
   @override
   String get submitApp => 'Изпрати приложението';
@@ -2878,12 +2826,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get submitAppQuestion => 'Изпрати приложението?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Вашето приложение ще бъде прегледано и направено публично. Можете да започнете да го използвате веднага, дори по време на прегледа!';
+  String get submitAppPublicDescription => 'Вашето приложение ще бъде прегледано и направено публично. Можете да започнете да го използвате веднага, дори по време на прегледа!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Вашето приложение ще бъде прегледано и направено достъпно за вас лично. Можете да започнете да го използвате веднага, дори по време на прегледа!';
+  String get submitAppPrivateDescription => 'Вашето приложение ще бъде прегледано и направено достъпно за вас лично. Можете да започнете да го използвате веднага, дори по време на прегледа!';
 
   @override
   String get startEarning => 'Започнете да печелите! 💰';
@@ -2907,23 +2853,19 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dataAccessNotice => 'Уведомление за достъп до данни';
 
   @override
-  String get dataAccessWarning =>
-      'Това приложение ще има достъп до вашите данни. Omi AI не носи отговорност за това как вашите данни се използват, модифицират или изтриват от това приложение';
+  String get dataAccessWarning => 'Това приложение ще има достъп до вашите данни. Omi AI не носи отговорност за това как вашите данни се използват, модифицират или изтриват от това приложение';
 
   @override
   String get installApp => 'Инсталиране на приложението';
 
   @override
-  String get betaTesterNotice =>
-      'Вие сте бета тестер за това приложение. То все още не е публично. Ще стане публично след одобрение.';
+  String get betaTesterNotice => 'Вие сте бета тестер за това приложение. То все още не е публично. Ще стане публично след одобрение.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Вашето приложение е в процес на преглед и е видимо само за вас. Ще стане публично след одобрение.';
+  String get appUnderReviewOwner => 'Вашето приложение е в процес на преглед и е видимо само за вас. Ще стане публично след одобрение.';
 
   @override
-  String get appRejectedNotice =>
-      'Вашето приложение е отхвърлено. Моля, актуализирайте детайлите на приложението и го подайте отново за преглед.';
+  String get appRejectedNotice => 'Вашето приложение е отхвърлено. Моля, актуализирайте детайлите на приложението и го подайте отново за преглед.';
 
   @override
   String get setupSteps => 'Стъпки за настройка';
@@ -2985,8 +2927,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get descriptionLabel => 'Описание';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Моето страхотно приложение е страхотно приложение, което прави невероятни неща. То е най-доброто приложение!';
+  String get appDescriptionPlaceholder => 'Моето страхотно приложение е страхотно приложение, което прави невероятни неща. То е най-доброто приложение!';
 
   @override
   String get pleaseProvideValidDescription => 'Моля, предоставете валидно описание';
@@ -3138,8 +3079,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get microphonePermissionRequired => 'Разрешение за микрофон е необходимо за обаждания';
 
   @override
-  String get microphonePermissionDenied =>
-      'Разрешението за микрофон е отказано. Моля, предоставете разрешение в Системни настройки > Поверителност и сигурност > Микрофон.';
+  String get microphonePermissionDenied => 'Разрешението за микрофон е отказано. Моля, предоставете разрешение в Системни настройки > Поверителност и сигурност > Микрофон.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3298,8 +3238,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get createMemory => 'Създай спомен';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Сигурни ли сте, че искате да изтриете този спомен? Това действие не може да бъде отменено.';
+  String get deleteMemoryConfirmation => 'Сигурни ли сте, че искате да изтриете този спомен? Това действие не може да бъде отменено.';
 
   @override
   String get makePrivate => 'Направи частна';
@@ -3373,8 +3312,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get whatWeCollect => 'Какво събираме';
 
   @override
-  String get dataCollectionMessage =>
-      'Продължавайки, вашите разговори, записи и лична информация ще бъдат съхранявани сигурно на нашите сървъри, за да предоставим прозрения, задвижвани от AI, и да активираме всички функции на приложението.';
+  String get dataCollectionMessage => 'Продължавайки, вашите разговори, записи и лична информация ще бъдат съхранявани сигурно на нашите сървъри, за да предоставим прозрения, задвижвани от AI, и да активираме всички функции на приложението.';
 
   @override
   String get dataProtection => 'Защита на данните';
@@ -3407,8 +3345,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Името трябва да съдържа поне 2 знака';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Кажете ни как бихте искали да се обръщаме към вас. Това помага за персонализиране на вашето Omi изживяване.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Кажете ни как бихте искали да се обръщаме към вас. Това помага за персонализиране на вашето Omi изживяване.';
 
   @override
   String charactersCount(int count) {
@@ -3416,8 +3353,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Активирайте функции за най-доброто Omi изживяване на вашето устройство.';
+  String get enableFeaturesForBestExperience => 'Активирайте функции за най-доброто Omi изживяване на вашето устройство.';
 
   @override
   String get microphoneAccess => 'Достъп до микрофон';
@@ -3426,8 +3362,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get recordAudioConversations => 'Записване на аудио разговори';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi се нуждае от достъп до микрофона, за да записва вашите разговори и да предоставя транскрипции.';
+  String get microphoneAccessDescription => 'Omi се нуждае от достъп до микрофона, за да записва вашите разговори и да предоставя транскрипции.';
 
   @override
   String get screenRecording => 'Запис на екрана';
@@ -3436,8 +3371,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Заснемане на системен звук от срещи';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi се нуждае от разрешение за запис на екрана, за да заснема системен звук от вашите срещи в браузъра.';
+  String get screenRecordingDescription => 'Omi се нуждае от разрешение за запис на екрана, за да заснема системен звук от вашите срещи в браузъра.';
 
   @override
   String get accessibility => 'Достъпност';
@@ -3446,8 +3380,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Откриване на срещи в браузъра';
 
   @override
-  String get accessibilityDescription =>
-      'Omi се нуждае от разрешение за достъпност, за да открива кога се присъединявате към срещи в Zoom, Meet или Teams във вашия браузър.';
+  String get accessibilityDescription => 'Omi се нуждае от разрешение за достъпност, за да открива кога се присъединявате към срещи в Zoom, Meet или Teams във вашия браузър.';
 
   @override
   String get pleaseWait => 'Моля, изчакайте...';
@@ -3495,8 +3428,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get preferences => 'Предпочитания';
 
   @override
-  String get helpImproveOmiBySharing =>
-      'Помогнете за подобряването на Omi чрез споделяне на анонимизирани данни за анализ';
+  String get helpImproveOmiBySharing => 'Помогнете за подобряването на Omi чрез споделяне на анонимизирани данни за анализ';
 
   @override
   String get deleteAccount => 'Изтриване на Акаунт';
@@ -3517,12 +3449,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get exportAllConversationsToJson => 'Експортирайте всички свои разговори в JSON файл.';
 
   @override
-  String get conversationsExportStarted =>
-      'Експортирането на разговори започна. Това може да отнеме няколко секунди, моля, изчакайте.';
+  String get conversationsExportStarted => 'Експортирането на разговори започна. Това може да отнеме няколко секунди, моля, изчакайте.';
 
   @override
-  String get mcpDescription =>
-      'За свързване на Omi с други приложения за четене, търсене и управление на вашите спомени и разговори. Създайте ключ, за да започнете.';
+  String get mcpDescription => 'За свързване на Omi с други приложения за четене, търсене и управление на вашите спомени и разговори. Създайте ключ, за да започнете.';
 
   @override
   String get apiKeys => 'API ключове';
@@ -3563,8 +3493,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Диагностично състояние на услугата за транскрипция';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Активирайте подробни диагностични съобщения от услугата за транскрипция';
+  String get enableDetailedDiagnosticMessages => 'Активирайте подробни диагностични съобщения от услугата за транскрипция';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Автоматично създаване и маркиране на нови говорители';
@@ -3594,8 +3523,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get auto => 'Автоматично';
 
   @override
-  String get noSummaryForApp =>
-      'Няма налично обобщение за това приложение. Опитайте друго приложение за по-добри резултати.';
+  String get noSummaryForApp => 'Няма налично обобщение за това приложение. Опитайте друго приложение за по-добри резултати.';
 
   @override
   String get tryAnotherApp => 'Опитайте друго приложение';
@@ -3632,8 +3560,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Нека Omi избере най-доброто приложение автоматично';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Сигурни ли сте, че искате да изтриете този разговор? Това действие не може да бъде отменено.';
+  String get deleteConversationConfirmation => 'Сигурни ли сте, че искате да изтриете този разговор? Това действие не може да бъде отменено.';
 
   @override
   String get conversationDeleted => 'Разговорът е изтрит';
@@ -3681,8 +3608,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Подготовка на системното аудио заснемане';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Щракнете върху бутона, за да заснемете аудио за реални транскрипции, AI прозрения и автоматично запазване.';
+  String get clickTheButtonToCaptureAudio => 'Щракнете върху бутона, за да заснемете аудио за реални транскрипции, AI прозрения и автоматично запазване.';
 
   @override
   String get reconnecting => 'Повторно свързване...';
@@ -3840,8 +3766,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dailySummaryTitle => 'Дневно Резюме';
 
   @override
-  String get dailySummaryDescription =>
-      'Получавайте персонализирано обобщение на разговорите ви за деня като известие.';
+  String get dailySummaryDescription => 'Получавайте персонализирано обобщение на разговорите ви за деня като известие.';
 
   @override
   String get deliveryTime => 'Час на доставка';
@@ -3886,8 +3811,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shortcuts => 'Клавишни комбинации';
 
   @override
-  String get shortcutChangeInstruction =>
-      'Щракнете върху пряк път, за да го промените. Натиснете Escape, за да отмените.';
+  String get shortcutChangeInstruction => 'Щракнете върху пряк път, за да го промените. Натиснете Escape, за да отмените.';
 
   @override
   String get configureSTTProvider => 'Конфигуриране на доставчик на STT';
@@ -3911,8 +3835,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Изтриване на графа на знанието?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Това ще изтрие всички производни данни от графа на знанието. Вашите оригинални спомени остават в безопасност.';
+  String get deleteKnowledgeGraphWarning => 'Това ще изтрие всички производни данни от графа на знанието. Вашите оригинални спомени остават в безопасност.';
 
   @override
   String get connectOmiWithAI => 'Свържете Omi с AI асистенти';
@@ -3969,8 +3892,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get updateAppQuestion => 'Актуализиране на приложението?';
 
   @override
-  String get updateAppConfirmation =>
-      'Сигурни ли сте, че искате да актуализирате приложението си? Промените ще бъдат отразени след преглед от нашия екип.';
+  String get updateAppConfirmation => 'Сигурни ли сте, че искате да актуализирате приложението си? Промените ще бъдат отразени след преглед от нашия екип.';
 
   @override
   String get updateApp => 'Актуализиране на приложението';
@@ -4000,8 +3922,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get no => 'Не';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Абонаментът е отменен успешно. Той ще остане активен до края на текущия период на фактуриране.';
+  String get subscriptionCancelledSuccessfully => 'Абонаментът е отменен успешно. Той ще остане активен до края на текущия период на фактуриране.';
 
   @override
   String get failedToCancelSubscription => 'Неуспешно отменяне на абонамента. Моля, опитайте отново.';
@@ -4037,8 +3958,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Отмяна на абонамента?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Сигурни ли сте, че искате да отмените абонамента си? Ще имате достъп до края на текущия период на фактуриране.';
+  String get cancelSubscriptionConfirmation => 'Сигурни ли сте, че искате да отмените абонамента си? Ще имате достъп до края на текущия период на фактуриране.';
 
   @override
   String get cancelSubscriptionButton => 'Отмяна на абонамента';
@@ -4047,16 +3967,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get cancelling => 'Отменяне...';
 
   @override
-  String get betaTesterMessage =>
-      'Вие сте бета тестер за това приложение. То все още не е публично. Ще стане публично след одобрение.';
+  String get betaTesterMessage => 'Вие сте бета тестер за това приложение. То все още не е публично. Ще стане публично след одобрение.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Вашето приложение е в процес на преглед и е видимо само за вас. Ще стане публично след одобрение.';
+  String get appUnderReviewMessage => 'Вашето приложение е в процес на преглед и е видимо само за вас. Ще стане публично след одобрение.';
 
   @override
-  String get appRejectedMessage =>
-      'Вашето приложение беше отхвърлено. Моля, актуализирайте детайлите и изпратете отново за преглед.';
+  String get appRejectedMessage => 'Вашето приложение беше отхвърлено. Моля, актуализирайте детайлите и изпратете отново за преглед.';
 
   @override
   String get invalidIntegrationUrl => 'Невалиден URL за интеграция';
@@ -4110,8 +4027,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get issueActivatingApp => 'Възникна проблем при активирането на това приложение. Моля, опитайте отново.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Това приложение ще има достъп до вашите данни. Omi AI не носи отговорност за начина, по който вашите данни се използват, променят или изтриват от това приложение';
+  String get dataAccessNoticeDescription => 'Това приложение ще има достъп до вашите данни. Omi AI не носи отговорност за начина, по който вашите данни се използват, променят или изтриват от това приложение';
 
   @override
   String get copyUrl => 'Копиране на URL';
@@ -4199,8 +4115,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get omiApiKeys => 'Omi API ключове';
 
   @override
-  String get apiKeysDescription =>
-      'API ключовете се използват за удостоверяване, когато приложението ви комуникира със сървъра на OMI. Те позволяват на приложението ви да създава спомени и да получава достъп до други услуги на OMI по сигурен начин.';
+  String get apiKeysDescription => 'API ключовете се използват за удостоверяване, когато приложението ви комуникира със сървъра на OMI. Те позволяват на приложението ви да създава спомени и да получава достъп до други услуги на OMI по сигурен начин.';
 
   @override
   String get aboutOmiApiKeys => 'Относно Omi API ключове';
@@ -4224,8 +4139,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Отмяна на API ключ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Това действие не може да бъде отменено. Всички приложения, използващи този ключ, вече няма да имат достъп до API.';
+  String get revokeApiKeyWarning => 'Това действие не може да бъде отменено. Всички приложения, използващи този ключ, вече няма да имат достъп до API.';
 
   @override
   String get revoke => 'Отмяна';
@@ -4314,8 +4228,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get keyCreated => 'Ключът е създаден';
 
   @override
-  String get keyCreatedMessage =>
-      'Вашият нов ключ е създаден. Моля, копирайте го сега. Няма да можете да го видите отново.';
+  String get keyCreatedMessage => 'Вашият нов ключ е създаден. Моля, копирайте го сега. Няма да можете да го видите отново.';
 
   @override
   String get keyWord => 'Ключ';
@@ -4324,8 +4237,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get externalAppAccess => 'Достъп на външни приложения';
 
   @override
-  String get externalAppAccessDescription =>
-      'Следните инсталирани приложения имат външни интеграции и могат да достъпват данните ви, като разговори и спомени.';
+  String get externalAppAccessDescription => 'Следните инсталирани приложения имат външни интеграции и могат да достъпват данните ви, като разговори и спомени.';
 
   @override
   String get noExternalAppsHaveAccess => 'Няма външни приложения с достъп до вашите данни.';
@@ -4334,8 +4246,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get maximumSecurityE2ee => 'Максимална сигурност (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Криптирането от край до край е златният стандарт за поверителност. Когато е активирано, вашите данни се криптират на вашето устройство, преди да бъдат изпратени до нашите сървъри. Това означава, че никой, дори Omi, не може да получи достъп до вашето съдържание.';
+  String get e2eeDescription => 'Криптирането от край до край е златният стандарт за поверителност. Когато е активирано, вашите данни се криптират на вашето устройство, преди да бъдат изпратени до нашите сървъри. Това означава, че никой, дори Omi, не може да получи достъп до вашето съдържание.';
 
   @override
   String get importantTradeoffs => 'Важни компромиси:';
@@ -4350,8 +4261,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get featureComingSoon => 'Тази функция идва скоро!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Миграцията е в ход. Не можете да промените нивото на защита, докато не приключи.';
+  String get migrationInProgressMessage => 'Миграцията е в ход. Не можете да промените нивото на защита, докато не приключи.';
 
   @override
   String get migrationFailed => 'Миграцията неуспешна';
@@ -4370,15 +4280,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get secureEncryption => 'Сигурно криптиране';
 
   @override
-  String get secureEncryptionDescription =>
-      'Вашите данни са криптирани с ключ, уникален за вас, на нашите сървъри, хоствани в Google Cloud. Това означава, че вашето сурово съдържание е недостъпно за никого, включително персонала на Omi или Google, директно от базата данни.';
+  String get secureEncryptionDescription => 'Вашите данни са криптирани с ключ, уникален за вас, на нашите сървъри, хоствани в Google Cloud. Това означава, че вашето сурово съдържание е недостъпно за никого, включително персонала на Omi или Google, директно от базата данни.';
 
   @override
   String get endToEndEncryption => 'Криптиране от край до край';
 
   @override
-  String get e2eeCardDescription =>
-      'Активирайте за максимална сигурност, при която само вие имате достъп до данните си. Докоснете, за да научите повече.';
+  String get e2eeCardDescription => 'Активирайте за максимална сигурност, при която само вие имате достъп до данните си. Докоснете, за да научите повече.';
 
   @override
   String get dataAlwaysEncrypted => 'Независимо от нивото, вашите данни винаги са криптирани в покой и при пренос.';
@@ -4446,12 +4354,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get trainingDataProgram => 'Програма за данни за обучение';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Получете Omi Unlimited безплатно, като допринесете данните си за обучение на AI модели.';
+  String get getOmiUnlimitedFree => 'Получете Omi Unlimited безплатно, като допринесете данните си за обучение на AI модели.';
 
   @override
-  String get trainingDataBullets =>
-      '• Вашите данни помагат за подобряване на AI модели\n• Споделят се само нечувствителни данни\n• Напълно прозрачен процес';
+  String get trainingDataBullets => '• Вашите данни помагат за подобряване на AI модели\n• Споделят се само нечувствителни данни\n• Напълно прозрачен процес';
 
   @override
   String get learnMoreAtOmiTraining => 'Научете повече на omi.me/training';
@@ -4501,8 +4407,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get monthlyPlanContinues => 'Текущият ви месечен план ще продължи до края на периода на фактуриране';
 
   @override
-  String get paymentMethodCharged =>
-      'Съществуващият ви метод на плащане ще бъде таксуван автоматично, когато месечният ви план приключи';
+  String get paymentMethodCharged => 'Съществуващият ви метод на плащане ще бъде таксуван автоматично, когато месечният ви план приключи';
 
   @override
   String get annualSubscriptionStarts => 'Вашият 12-месечен годишен абонамент ще започне автоматично след таксуването';
@@ -4545,8 +4450,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Годишният ви план ще започне автоматично, когато месечният ви план приключи.';
+  String get annualPlanStartsAutomatically => 'Годишният ви план ще започне автоматично, когато месечният ви план приключи.';
 
   @override
   String planRenewsOn(String date) {
@@ -4613,8 +4517,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Вашата поверителност е важна за нас';
 
   @override
-  String get privacyIntroText =>
-      'В Omi приемаме поверителността ви много сериозно. Искаме да бъдем прозрачни относно данните, които събираме и как ги използваме за подобряване на продукта. Ето какво трябва да знаете:';
+  String get privacyIntroText => 'В Omi приемаме поверителността ви много сериозно. Искаме да бъдем прозрачни относно данните, които събираме и как ги използваме за подобряване на продукта. Ето какво трябва да знаете:';
 
   @override
   String get whatWeTrack => 'Какво проследяваме';
@@ -4629,12 +4532,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get ourCommitment => 'Нашият ангажимент';
 
   @override
-  String get commitmentText =>
-      'Ние сме ангажирани да използваме събраните данни само за да направим Omi по-добър продукт за вас. Вашата поверителност и доверие са от първостепенно значение за нас.';
+  String get commitmentText => 'Ние сме ангажирани да използваме събраните данни само за да направим Omi по-добър продукт за вас. Вашата поверителност и доверие са от първостепенно значение за нас.';
 
   @override
-  String get thankYouText =>
-      'Благодарим ви, че сте ценен потребител на Omi. Ако имате въпроси или притеснения, не се колебайте да се свържете с нас на team@basedhardware.com.';
+  String get thankYouText => 'Благодарим ви, че сте ценен потребител на Omi. Ако имате въпроси или притеснения, не се колебайте да се свържете с нас на team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Настройки за WiFi синхронизация';
@@ -4643,8 +4544,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get enterHotspotCredentials => 'Въведете данните за гореща точка на телефона';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi синхронизацията използва телефона ви като гореща точка. Намерете името и паролата в Настройки > Лична гореща точка.';
+  String get wifiSyncUsesHotspot => 'WiFi синхронизацията използва телефона ви като гореща точка. Намерете името и паролата в Настройки > Лична гореща точка.';
 
   @override
   String get hotspotNameSsid => 'Име на гореща точка (SSID)';
@@ -4679,8 +4579,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Неуспешно генериране на резюме. Уверете се, че имате разговори за този ден.';
+  String get failedToGenerateSummaryCheckConversations => 'Неуспешно генериране на резюме. Уверете се, че имате разговори за този ден.';
 
   @override
   String get summaryNotFound => 'Резюмето не е намерено';
@@ -4710,8 +4609,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Експортирането започна. Това може да отнеме няколко секунди...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Това ще изтрие всички производни данни от графа на знанията (възли и връзки). Оригиналните ви спомени ще останат в безопасност. Графът ще бъде възстановен с времето или при следваща заявка.';
+  String get knowledgeGraphDeleteDescription => 'Това ще изтрие всички производни данни от графа на знанията (възли и връзки). Оригиналните ви спомени ще останат в безопасност. Графът ще бъде възстановен с времето или при следваща заявка.';
 
   @override
   String get configureDailySummaryDigest => 'Конфигурирайте вашия дневен дайджест на задачите';
@@ -4781,8 +4679,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Изтриване на всички разговори от Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Това ще изтрие завинаги всички разговори, импортирани от Limitless. Това действие не може да бъде отменено.';
+  String get deleteAllLimitlessWarning => 'Това ще изтрие завинаги всички разговори, импортирани от Limitless. Това действие не може да бъде отменено.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4838,8 +4735,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get howItWorksTitle => 'Как работи?';
 
   @override
-  String get howPeopleWorks =>
-      'След като създадете човек, можете да отидете в транскрипция на разговор и да му зададете съответните сегменти, така Omi ще може да разпознава и неговата реч!';
+  String get howPeopleWorks => 'След като създадете човек, можете да отидете в транскрипция на разговор и да му зададете съответните сегменти, така Omi ще може да разпознава и неговата реч!';
 
   @override
   String get tapToDelete => 'Докоснете за изтриване';
@@ -4865,8 +4761,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get privacyNotice => 'Известие за поверителност';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Записите могат да уловят гласовете на други хора. Уверете се, че имате съгласието на всички участници преди активиране.';
+  String get recordingsMayCaptureOthers => 'Записите могат да уловят гласовете на други хора. Уверете се, че имате съгласието на всички участници преди активиране.';
 
   @override
   String get enable => 'Активиране';
@@ -4878,8 +4773,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get on => 'Вкл';
 
   @override
-  String get storeAudioDescription =>
-      'Съхранявайте всички аудио записи локално на телефона си. Когато е деактивирано, само неуспешните качвания се запазват, за да се спести място.';
+  String get storeAudioDescription => 'Съхранявайте всички аудио записи локално на телефона си. Когато е деактивирано, само неуспешните качвания се запазват, за да се спести място.';
 
   @override
   String get enableLocalStorage => 'Активиране на локално хранилище';
@@ -4897,12 +4791,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get storeAudioOnCloud => 'Съхранявай аудио в облака';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Вашите записи в реално време ще се съхраняват в частно облачно хранилище, докато говорите.';
+  String get cloudStorageDialogMessage => 'Вашите записи в реално време ще се съхраняват в частно облачно хранилище, докато говорите.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Съхранявайте записите си в реално време в частно облачно хранилище, докато говорите. Аудиото се улавя и запазва сигурно в реално време.';
+  String get storeAudioCloudDescription => 'Съхранявайте записите си в реално време в частно облачно хранилище, докато говорите. Аудиото се улавя и запазва сигурно в реално време.';
 
   @override
   String get downloadingFirmware => 'Изтегляне на фърмуер';
@@ -4911,8 +4803,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get installingFirmware => 'Инсталиране на фърмуер';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Не затваряйте приложението и не изключвайте устройството. Това може да повреди устройството ви.';
+  String get firmwareUpdateWarning => 'Не затваряйте приложението и не изключвайте устройството. Това може да повреди устройството ви.';
 
   @override
   String get firmwareUpdated => 'Фърмуерът е актуализиран';
@@ -4956,8 +4847,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get payments => 'Плащания';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Свържете метод на плащане по-долу, за да започнете да получавате плащания за вашите приложения.';
+  String get connectPaymentMethodInfo => 'Свържете метод на плащане по-долу, за да започнете да получавате плащания за вашите приложения.';
 
   @override
   String get selectedPaymentMethod => 'Избран метод на плащане';
@@ -4984,15 +4874,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get monthlyPayouts => 'Месечни плащания';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Получавайте месечни плащания директно в сметката си, когато достигнете \$10 печалби';
+  String get monthlyPayoutsDescription => 'Получавайте месечни плащания директно в сметката си, когато достигнете \$10 печалби';
 
   @override
   String get secureAndReliable => 'Сигурно и надеждно';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe осигурява безопасни и навременни преводи на приходите от вашето приложение';
+  String get stripeSecureDescription => 'Stripe осигурява безопасни и навременни преводи на приходите от вашето приложение';
 
   @override
   String get selectYourCountry => 'Изберете вашата държава';
@@ -5013,8 +4901,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get connectingYourStripeAccount => 'Свързване на вашия Stripe акаунт';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Моля, завършете процеса на регистрация в Stripe във вашия браузър. Тази страница ще се актуализира автоматично след завършване.';
+  String get stripeOnboardingInstructions => 'Моля, завършете процеса на регистрация в Stripe във вашия браузър. Тази страница ще се актуализира автоматично след завършване.';
 
   @override
   String get failedTryAgain => 'Неуспешно? Опитайте отново';
@@ -5026,15 +4913,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get successfullyConnected => 'Успешно свързано!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Вашият Stripe акаунт вече е готов да получава плащания. Можете да започнете да печелите от продажбите на приложението си веднага.';
+  String get stripeReadyForPayments => 'Вашият Stripe акаунт вече е готов да получава плащания. Можете да започнете да печелите от продажбите на приложението си веднага.';
 
   @override
   String get updateStripeDetails => 'Актуализиране на детайлите на Stripe';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Грешка при актуализиране на детайлите на Stripe! Моля, опитайте отново по-късно.';
+  String get errorUpdatingStripeDetails => 'Грешка при актуализиране на детайлите на Stripe! Моля, опитайте отново по-късно.';
 
   @override
   String get updatePayPal => 'Актуализиране на PayPal';
@@ -5046,8 +4931,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Актуализирайте данните на вашия PayPal акаунт';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Свържете вашия PayPal акаунт, за да започнете да получавате плащания за вашите приложения';
+  String get connectPayPalToReceivePayments => 'Свържете вашия PayPal акаунт, за да започнете да получавате плащания за вашите приложения';
 
   @override
   String get paypalEmail => 'PayPal имейл';
@@ -5056,8 +4940,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me връзка';
 
   @override
-  String get stripeRecommendation =>
-      'Ако Stripe е наличен във вашата държава, силно препоръчваме да го използвате за по-бързи и лесни плащания.';
+  String get stripeRecommendation => 'Ако Stripe е наличен във вашата държава, силно препоръчваме да го използвате за по-бързи и лесни плащания.';
 
   @override
   String get updatePayPalDetails => 'Актуализиране на детайлите на PayPal';
@@ -5109,12 +4992,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Допълнителната гласова проба е премахната';
 
   @override
-  String get consentDataMessage =>
-      'С продължаването вашите разговори, записи и лична информация ще бъдат сигурно съхранени на нашите сървъри. Вашите аудиозаписи и транскрипции се обработват от AI услуги на трети страни (включително Deepgram за транскрипция и OpenAI за анализ), за да ви предоставят прозрения, базирани на AI, и да активират всички функции на приложението.';
+  String get consentDataMessage => 'С продължаването вашите разговори, записи и лична информация ще бъдат сигурно съхранени на нашите сървъри. Вашите аудиозаписи и транскрипции се обработват от AI услуги на трети страни (включително Deepgram за транскрипция и OpenAI за анализ), за да ви предоставят прозрения, базирани на AI, и да активират всички функции на приложението.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Задачите от вашите разговори ще се появят тук.\nДокоснете + за ръчно създаване.';
+  String get tasksEmptyStateMessage => 'Задачите от вашите разговори ще се появят тук.\nДокоснете + за ръчно създаване.';
 
   @override
   String get clearChatAction => 'Изчисти чата';
@@ -5150,15 +5031,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Инсталирайте Omi на вашия\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'За да използвате Apple Watch с Omi, първо трябва да инсталирате приложението Omi на часовника си.';
+  String get installOmiOnAppleWatchDescription => 'За да използвате Apple Watch с Omi, първо трябва да инсталирате приложението Omi на часовника си.';
 
   @override
   String get openOmiOnAppleWatch => 'Отворете Omi на вашия\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Приложението Omi е инсталирано на вашия Apple Watch. Отворете го и натиснете Старт, за да започнете.';
+  String get openOmiOnAppleWatchDescription => 'Приложението Omi е инсталирано на вашия Apple Watch. Отворете го и натиснете Старт, за да започнете.';
 
   @override
   String get openWatchApp => 'Отворете приложението Watch';
@@ -5167,15 +5046,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Инсталирах и отворих приложението';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Не може да се отвори приложението Apple Watch. Моля, отворете ръчно приложението Watch на вашия Apple Watch и инсталирайте Omi от секцията \"Налични приложения\".';
+  String get unableToOpenWatchApp => 'Не може да се отвори приложението Apple Watch. Моля, отворете ръчно приложението Watch на вашия Apple Watch и инсталирайте Omi от секцията \"Налични приложения\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch е свързан успешно!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch все още не е достъпен. Моля, уверете се, че приложението Omi е отворено на часовника ви.';
+  String get appleWatchNotReachable => 'Apple Watch все още не е достъпен. Моля, уверете се, че приложението Omi е отворено на часовника ви.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5603,8 +5480,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get multipleSpeakersDetected => 'Открити са множество говорители';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Изглежда, че в записа има множество говорители. Моля, уверете се, че сте на тихо място и опитайте отново.';
+  String get multipleSpeakersDescription => 'Изглежда, че в записа има множество говорители. Моля, уверете се, че сте на тихо място и опитайте отново.';
 
   @override
   String get invalidRecordingDetected => 'Открит е невалиден запис';
@@ -5616,15 +5492,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get speechDurationDescription => 'Моля, уверете се, че говорите поне 5 секунди и не повече от 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Връзката беше прекъсната. Моля, проверете интернет връзката си и опитайте отново.';
+  String get connectionLostDescription => 'Връзката беше прекъсната. Моля, проверете интернет връзката си и опитайте отново.';
 
   @override
   String get howToTakeGoodSample => 'Как да направите добра проба?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Уверете се, че сте на тихо място.\n2. Говорете ясно и естествено.\n3. Уверете се, че устройството ви е в естествена позиция на врата ви.\n\nСлед като бъде създаден, винаги можете да го подобрите или направите отново.';
+  String get goodSampleInstructions => '1. Уверете се, че сте на тихо място.\n2. Говорете ясно и естествено.\n3. Уверете се, че устройството ви е в естествена позиция на врата ви.\n\nСлед като бъде създаден, винаги можете да го подобрите или направите отново.';
 
   @override
   String get noDeviceConnectedUseMic => 'Няма свързано устройство. Ще се използва микрофонът на телефона.';
@@ -5687,12 +5561,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get howItWorks => 'Как работи';
 
   @override
-  String get dailyScoreExplanation =>
-      'Дневният ви резултат се базира на завършените задачи. Завършете задачите си, за да подобрите резултата!';
+  String get dailyScoreExplanation => 'Дневният ви резултат се базира на завършените задачи. Завършете задачите си, за да подобрите резултата!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Контролирайте колко често Omi ви изпраща проактивни известия и напомняния.';
+  String get notificationFrequencyDescription => 'Контролирайте колко често Omi ви изпраща проактивни известия и напомняния.';
 
   @override
   String get sliderOff => 'Изкл.';
@@ -5706,8 +5578,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Неуспешно генериране на обобщение. Уверете се, че имате разговори за този ден.';
+  String get failedToGenerateSummary => 'Неуспешно генериране на обобщение. Уверете се, че имате разговори за този ден.';
 
   @override
   String get recap => 'Резюме';
@@ -5786,8 +5657,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get selectApp => 'Избери приложение';
 
   @override
-  String get noChatAppsEnabled =>
-      'Няма активирани чат приложения.\nДокоснете \"Активиране на приложения\" за добавяне.';
+  String get noChatAppsEnabled => 'Няма активирани чат приложения.\nДокоснете \"Активиране на приложения\" за добавяне.';
 
   @override
   String get disable => 'Деактивирай';
@@ -5939,8 +5809,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get recordings => 'Записи';
 
   @override
-  String get enableRemindersAccess =>
-      'Моля, активирайте достъпа до Напомняния в Настройки, за да използвате Apple Напомняния';
+  String get enableRemindersAccess => 'Моля, активирайте достъпа до Напомняния в Настройки, за да използвате Apple Напомняния';
 
   @override
   String todayAtTime(String time) {
@@ -5995,8 +5864,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL не е зададен';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Моля, задайте Webhook URL в настройките за разработчици, за да използвате тази функция.';
+  String get setWebhookUrlInSettings => 'Моля, задайте Webhook URL в настройките за разработчици, за да използвате тази функция.';
 
   @override
   String get sendWebUrl => 'Изпрати уеб връзка';
@@ -6070,15 +5938,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get cloudProvider => 'Облачен доставчик';
 
   @override
-  String get premiumMinutesInfo =>
-      '1200 премиум минути/месец. Разделът На устройството предлага неограничена безплатна транскрипция.';
+  String get premiumMinutesInfo => '1200 премиум минути/месец. Разделът На устройството предлага неограничена безплатна транскрипция.';
 
   @override
   String get viewUsage => 'Преглед на използването';
 
   @override
-  String get localProcessingInfo =>
-      'Аудиото се обработва локално. Работи офлайн, по-поверително, но използва повече батерия.';
+  String get localProcessingInfo => 'Аудиото се обработва локално. Работи офлайн, по-поверително, но използва повече батерия.';
 
   @override
   String get model => 'Модел';
@@ -6087,15 +5953,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get performanceWarning => 'Предупреждение за производителност';
 
   @override
-  String get largeModelWarning =>
-      'Този модел е голям и може да срине приложението или да работи много бавно.\n\nПрепоръчва се \"small\" или \"base\".';
+  String get largeModelWarning => 'Този модел е голям и може да срине приложението или да работи много бавно.\n\nПрепоръчва се \"small\" или \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Използване на вградено iOS разпознаване на реч';
 
   @override
-  String get noModelDownloadRequired =>
-      'Ще се използва вграденият речеви двигател на устройството. Не е необходимо изтегляне на модел.';
+  String get noModelDownloadRequired => 'Ще се използва вграденият речеви двигател на устройството. Не е необходимо изтегляне на модел.';
 
   @override
   String get modelReady => 'Моделът е готов';
@@ -6140,8 +6004,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Устройството не е съвместимо';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'Вашето устройство не отговаря на изискванията за транскрипция на устройството.';
+  String get deviceNotMeetRequirements => 'Вашето устройство не отговаря на изискванията за транскрипция на устройството.';
 
   @override
   String get transcriptionSlowerOnDevice => 'Транскрипцията на устройството може да бъде по-бавна на това устройство.';
@@ -6153,12 +6016,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get batteryDrainSignificantly => 'Изтощаването на батерията ще се увеличи значително.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 премиум минути/месец. Разделът На устройството предлага неограничена безплатна транскрипция. ';
+  String get premiumMinutesMonth => '1200 премиум минути/месец. Разделът На устройството предлага неограничена безплатна транскрипция. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Аудиото се обработва локално. Работи офлайн, по-поверително, но консумира повече батерия.';
+  String get audioProcessedLocally => 'Аудиото се обработва локално. Работи офлайн, по-поверително, но консумира повече батерия.';
 
   @override
   String get languageLabel => 'Език';
@@ -6167,12 +6028,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get modelLabel => 'Модел';
 
   @override
-  String get modelTooLargeWarning =>
-      'Този модел е голям и може да причини срив на приложението или много бавна работа на мобилни устройства.\n\nПрепоръчва се small или base.';
+  String get modelTooLargeWarning => 'Този модел е голям и може да причини срив на приложението или много бавна работа на мобилни устройства.\n\nПрепоръчва се small или base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Ще се използва вграденият речеви механизъм на устройството. Не е необходимо изтегляне на модел.';
+  String get nativeEngineNoDownload => 'Ще се използва вграденият речеви механизъм на устройството. Не е необходимо изтегляне на модел.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6208,8 +6067,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Вградената транскрипция на живо на Omi е оптимизирана за разговори в реално време с автоматично разпознаване и разделяне на говорителите.';
+  String get omiTranscriptionOptimized => 'Вградената транскрипция на живо на Omi е оптимизирана за разговори в реално време с автоматично разпознаване и разделяне на говорителите.';
 
   @override
   String get reset => 'Нулиране';
@@ -6429,8 +6287,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Изграждане на графа на знанията от спомени...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Графът на знанията ще се изгради автоматично, когато създавате нови спомени.';
+  String get knowledgeGraphWillBuildAutomatically => 'Графът на знанията ще се изгради автоматично, когато създавате нови спомени.';
 
   @override
   String get buildGraphButton => 'Изграждане на граф';
@@ -6666,8 +6523,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get failedToLoadContacts => 'Неуспешно зареждане на контакти';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Неуспешна подготовка на разговора за споделяне. Моля, опитайте отново.';
+  String get failedToPrepareConversationForSharing => 'Неуспешна подготовка на разговора за споделяне. Моля, опитайте отново.';
 
   @override
   String get couldNotOpenSmsApp => 'Не можа да се отвори SMS приложението. Моля, опитайте отново.';
@@ -6733,8 +6589,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Изтегляне на аудио от SD картата на устройството ви';
 
   @override
-  String get transferRequiredDescription =>
-      'Този запис се съхранява на SD картата на вашето устройство. Прехвърлете го на телефона си, за да го слушате или споделите.';
+  String get transferRequiredDescription => 'Този запис се съхранява на SD картата на вашето устройство. Прехвърлете го на телефона си, за да го слушате или споделите.';
 
   @override
   String get cancelTransfer => 'Отмени прехвърлянето';
@@ -6755,8 +6610,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shareRecording => 'Сподели записа';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Сигурни ли сте, че искате да изтриете окончателно този запис? Това не може да бъде отменено.';
+  String get deleteRecordingConfirmation => 'Сигурни ли сте, че искате да изтриете окончателно този запис? Това не може да бъде отменено.';
 
   @override
   String get recordingIdLabel => 'ID на записа';
@@ -6815,15 +6669,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get enableFastTransfer => 'Активиране на бърз трансфер';
 
   @override
-  String get fastTransferDescription =>
-      'Бързият трансфер използва WiFi за ~5 пъти по-бързи скорости. Телефонът ви временно ще се свърже с WiFi мрежата на вашето Omi устройство по време на трансфер.';
+  String get fastTransferDescription => 'Бързият трансфер използва WiFi за ~5 пъти по-бързи скорости. Телефонът ви временно ще се свърже с WiFi мрежата на вашето Omi устройство по време на трансфер.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Достъпът до интернет е на пауза по време на трансфер';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Изберете как записите да се прехвърлят от вашето Omi устройство на телефона.';
+  String get chooseTransferMethodDescription => 'Изберете как записите да се прехвърлят от вашето Omi устройство на телефона.';
 
   @override
   String get wifiSpeed => '~150 KB/s чрез WiFi';
@@ -6832,8 +6684,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get fiveTimesFaster => '5 ПЪТИ ПО-БЪРЗО';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Създава директна WiFi връзка с вашето Omi устройство. Телефонът ви временно се изключва от обичайната WiFi мрежа по време на трансфер.';
+  String get fastTransferMethodDescription => 'Създава директна WiFi връзка с вашето Omi устройство. Телефонът ви временно се изключва от обичайната WiFi мрежа по време на трансфер.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6842,8 +6693,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get bleSpeed => '~30 KB/s чрез BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Използва стандартна Bluetooth Low Energy връзка. По-бавно, но не засяга WiFi връзката ви.';
+  String get bluetoothMethodDescription => 'Използва стандартна Bluetooth Low Energy връзка. По-бавно, но не засяга WiFi връзката ви.';
 
   @override
   String get selected => 'Избрано';
@@ -6881,12 +6731,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get appDeleteFailed => 'Неуспешно изтриване на приложението. Моля, опитайте отново по-късно.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Видимостта на приложението е променена успешно. Може да отнеме няколко минути.';
+  String get appVisibilityChangedSuccessfully => 'Видимостта на приложението е променена успешно. Може да отнеме няколко минути.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Грешка при активиране на приложението. Ако е интеграционно приложение, уверете се, че настройката е завършена.';
+  String get errorActivatingAppIntegration => 'Грешка при активиране на приложението. Ако е интеграционно приложение, уверете се, че настройката е завършена.';
 
   @override
   String get errorUpdatingAppStatus => 'Възникна грешка при актуализиране на състоянието на приложението.';
@@ -6954,8 +6802,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get importantConversationTitle => 'Важен разговор';
 
   @override
-  String get importantConversationBody =>
-      'Току-що проведохте важен разговор. Докоснете, за да споделите резюмето с други.';
+  String get importantConversationBody => 'Току-що проведохте важен разговор. Докоснете, за да споделите резюмето с други.';
 
   @override
   String get templateName => 'Име на шаблон';
@@ -6967,8 +6814,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Името трябва да е поне 3 символа';
 
   @override
-  String get conversationPromptHint =>
-      'напр. Извлечете действия, взети решения и ключови изводи от предоставения разговор.';
+  String get conversationPromptHint => 'напр. Извлечете действия, взети решения и ключови изводи от предоставения разговор.';
 
   @override
   String get pleaseEnterAppPrompt => 'Моля, въведете подсказка за вашето приложение';
@@ -7155,15 +7001,13 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Надграждането е планирано! Вашият месечен план продължава до края на периода за фактуриране, след което автоматично преминава към годишен.';
+  String get planUpgradeScheduledMessage => 'Надграждането е планирано! Вашият месечен план продължава до края на периода за фактуриране, след което автоматично преминава към годишен.';
 
   @override
   String get couldNotSchedulePlanChange => 'Не можахме да планираме промяна на плана. Моля, опитайте отново.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Вашият абонамент е активиран отново! Без такса сега - ще бъдете таксувани в края на текущия период.';
+  String get subscriptionReactivatedDefault => 'Вашият абонамент е активиран отново! Без такса сега - ще бъдете таксувани в края на текущия период.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Абонаментът е успешен! Таксувани сте за новия период на фактуриране.';
@@ -7346,8 +7190,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get onboardingBluetoothRequired => 'За свързване с вашето устройство е необходимо разрешение за Bluetooth.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Разрешението за Bluetooth е отказано. Моля, дайте разрешение в Системни настройки.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Разрешението за Bluetooth е отказано. Моля, дайте разрешение в Системни настройки.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7360,12 +7203,10 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Разрешението за известия е отказано. Моля, дайте разрешение в Системни настройки.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Разрешението за известия е отказано. Моля, дайте разрешение в Системни настройки.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Разрешението за известия е отказано. Моля, дайте разрешение в Системни настройки > Известия.';
+  String get onboardingNotificationDeniedNotifications => 'Разрешението за известия е отказано. Моля, дайте разрешение в Системни настройки > Известия.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7378,15 +7219,13 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Моля, дайте разрешение за местоположение в Настройки > Поверителност и сигурност > Услуги за местоположение';
+  String get onboardingLocationGrantInSettings => 'Моля, дайте разрешение за местоположение в Настройки > Поверителност и сигурност > Услуги за местоположение';
 
   @override
   String get onboardingMicrophoneRequired => 'За запис е необходимо разрешение за микрофон.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Разрешението за микрофон е отказано. Моля, дайте разрешение в Системни настройки > Поверителност и сигурност > Микрофон.';
+  String get onboardingMicrophoneDenied => 'Разрешението за микрофон е отказано. Моля, дайте разрешение в Системни настройки > Поверителност и сигурност > Микрофон.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7399,12 +7238,10 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'За запис на системен звук е необходимо разрешение за заснемане на екран.';
+  String get onboardingScreenCaptureRequired => 'За запис на системен звук е необходимо разрешение за заснемане на екран.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Разрешението за заснемане на екран е отказано. Моля, дайте разрешение в Системни настройки > Поверителност и сигурност > Запис на екран.';
+  String get onboardingScreenCaptureDenied => 'Разрешението за заснемане на екран е отказано. Моля, дайте разрешение в Системни настройки > Поверителност и сигурност > Запис на екран.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7417,8 +7254,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'За откриване на срещи в браузъра е необходимо разрешение за достъпност.';
+  String get onboardingAccessibilityRequired => 'За откриване на срещи в браузъра е необходимо разрешение за достъпност.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7458,8 +7294,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Достъпът до снимки е отказан. Моля, разрешете достъп до снимки, за да изберете изображения';
+  String get msgPhotosPermissionDenied => 'Достъпът до снимки е отказан. Моля, разрешете достъп до снимки, за да изберете изображения';
 
   @override
   String get msgSelectImagesGenericError => 'Грешка при избиране на изображения. Моля, опитайте отново.';
@@ -7513,8 +7348,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get devModeInvalidAudioBytesWebhookUrl => 'Невалиден URL адрес на уебхук за аудио байтове';
 
   @override
-  String get devModeInvalidRealtimeTranscriptWebhookUrl =>
-      'Невалиден URL адрес на уебхук за транскрипция в реално време';
+  String get devModeInvalidRealtimeTranscriptWebhookUrl => 'Невалиден URL адрес на уебхук за транскрипция в реално време';
 
   @override
   String get devModeInvalidConversationCreatedWebhookUrl => 'Невалиден URL адрес на уебхук за създаден разговор';
@@ -7532,8 +7366,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get locationPermissionRequired => 'Необходимо е разрешение за местоположение';
 
   @override
-  String get locationPermissionContent =>
-      'Разрешението за местоположение е необходимо, за да съхранявате местоположението на вашите разговори в приложението.';
+  String get locationPermissionContent => 'Разрешението за местоположение е необходимо, за да съхранявате местоположението на вашите разговори в приложението.';
 
   @override
   String get pdfTranscriptExport => 'Експорт на транскрипт';
@@ -7696,8 +7529,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Устройството не поддържа WiFi синхронизация, превключване към Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Устройството не поддържа WiFi синхронизация, превключване към Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health не е налично на това устройство';
@@ -7993,8 +7825,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Поставете Omi DevKit в режим на сдвояване';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Натиснете бутона веднъж, за да включите. Светодиодът ще мига в лилаво в режим на сдвояване.';
+  String get pairingDescOmiDevkit => 'Натиснете бутона веднъж, за да включите. Светодиодът ще мига в лилаво в режим на сдвояване.';
 
   @override
   String get pairingTitleOmiGlass => 'Включете Omi Glass';
@@ -8006,29 +7837,25 @@ class AppLocalizationsBg extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Поставете Plaud Note в режим на сдвояване';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Натиснете и задръжте страничния бутон за 2 секунди. Червеният светодиод ще мига, когато е готов за сдвояване.';
+  String get pairingDescPlaudNote => 'Натиснете и задръжте страничния бутон за 2 секунди. Червеният светодиод ще мига, когато е готов за сдвояване.';
 
   @override
   String get pairingTitleBee => 'Поставете Bee в режим на сдвояване';
 
   @override
-  String get pairingDescBee =>
-      'Натиснете бутона 5 пъти последователно. Светлината ще започне да мига в синьо и зелено.';
+  String get pairingDescBee => 'Натиснете бутона 5 пъти последователно. Светлината ще започне да мига в синьо и зелено.';
 
   @override
   String get pairingTitleLimitless => 'Поставете Limitless в режим на сдвояване';
 
   @override
-  String get pairingDescLimitless =>
-      'Когато свети индикатор, натиснете веднъж, след това натиснете и задръжте, докато устройството покаже розова светлина, след което отпуснете.';
+  String get pairingDescLimitless => 'Когато свети индикатор, натиснете веднъж, след това натиснете и задръжте, докато устройството покаже розова светлина, след което отпуснете.';
 
   @override
   String get pairingTitleFriendPendant => 'Поставете Friend Pendant в режим на сдвояване';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Натиснете бутона на медальона, за да го включите. Той ще влезе в режим на сдвояване автоматично.';
+  String get pairingDescFriendPendant => 'Натиснете бутона на медальона, за да го включите. Той ще влезе в режим на сдвояване автоматично.';
 
   @override
   String get pairingTitleFieldy => 'Поставете Fieldy в режим на сдвояване';
@@ -8040,15 +7867,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Свържете Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Инсталирайте и отворете приложението Omi на вашия Apple Watch, след което натиснете Свързване в приложението.';
+  String get pairingDescAppleWatch => 'Инсталирайте и отворете приложението Omi на вашия Apple Watch, след което натиснете Свързване в приложението.';
 
   @override
   String get pairingTitleNeoOne => 'Поставете Neo One в режим на сдвояване';
 
   @override
-  String get pairingDescNeoOne =>
-      'Натиснете и задръжте бутона за захранване, докато светодиодът мигне. Устройството ще бъде видимо.';
+  String get pairingDescNeoOne => 'Натиснете и задръжте бутона за захранване, докато светодиодът мигне. Устройството ще бъде видимо.';
 
   @override
   String get downloadingFromDevice => 'Изтегляне от устройството';
@@ -8165,12 +7990,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get switchAndRestart => 'Превключи';
 
   @override
-  String get stagingDisclaimer =>
-      'Тестовата среда може да е нестабилна, с непостоянна производителност и данните могат да бъдат загубени. Само за тестване.';
+  String get stagingDisclaimer => 'Тестовата среда може да е нестабилна, с непостоянна производителност и данните могат да бъдат загубени. Само за тестване.';
 
   @override
-  String get apiEnvSavedRestartRequired =>
-      'Запазено. Затворете и отворете отново приложението, за да приложите промените.';
+  String get apiEnvSavedRestartRequired => 'Запазено. Затворете и отворете отново приложението, за да приложите промените.';
 
   @override
   String get shared => 'Споделено';
@@ -8218,8 +8041,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get phoneGetStarted => 'Започнете';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'Записването на обаждания може да изисква съгласие във вашата юрисдикция';
+  String get callRecordingConsentDisclaimer => 'Записването на обаждания може да изисква съгласие във вашата юрисдикция';
 
   @override
   String get enterYourNumber => 'Въведете номера си';
@@ -8397,8 +8219,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Телефонни обаждания чрез Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Правете обаждания чрез Omi и получавайте транскрипция в реално време, автоматични резюмета и още. Достъпно само за абонати на план Неограничен.';
+  String get phoneCallsUpsellSubtitle => 'Правете обаждания чрез Omi и получавайте транскрипция в реално време, автоматични резюмета и още. Достъпно само за абонати на план Неограничен.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Транскрипция в реално време на всяко обаждане';
@@ -8425,8 +8246,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteSyncedFiles => 'Изтрий синхронизираните записи';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Тези записи вече са синхронизирани с телефона ви. Това не може да бъде отменено.';
+  String get deleteSyncedFilesMessage => 'Тези записи вече са синхронизирани с телефона ви. Това не може да бъде отменено.';
 
   @override
   String get syncedFilesDeleted => 'Синхронизираните записи са изтрити';
@@ -8438,8 +8258,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deletePendingFiles => 'Изтрий чакащите записи';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Тези записи НЕ са синхронизирани с телефона ви и ще бъдат загубени завинаги. Това не може да бъде отменено.';
+  String get deletePendingFilesWarning => 'Тези записи НЕ са синхронизирани с телефона ви и ще бъдат загубени завинаги. Това не може да бъде отменено.';
 
   @override
   String get pendingFilesDeleted => 'Чакащите записи са изтрити';
@@ -8451,8 +8270,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deleteAll => 'Изтриване на всички';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Това ще изтрие синхронизираните и чакащите записи. Чакащите записи НЕ са синхронизирани и ще бъдат загубени завинаги.';
+  String get deleteAllFilesWarning => 'Това ще изтрие синхронизираните и чакащите записи. Чакащите записи НЕ са синхронизирани и ще бъдат загубени завинаги.';
 
   @override
   String get allFilesDeleted => 'Всички записи са изтрити';
@@ -8517,8 +8335,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get fairUseAboutTitle => 'Относно честната употреба';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi е проектиран за лични разговори, срещи и взаимодействия на живо. Употребата се измерва по реалното открито време на реч, а не по времето на връзка. Ако употребата значително надвишава нормалните модели за неличностно съдържание, може да се приложат корекции.';
+  String get fairUseAboutBody => 'Omi е проектиран за лични разговори, срещи и взаимодействия на живо. Употребата се измерва по реалното открито време на реч, а не по времето на връзка. Ако употребата значително надвишава нормалните модели за неличностно съдържание, може да се приложат корекции.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8556,8 +8373,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get improveConnectionTitle => 'Подобряване на връзката';
 
   @override
-  String get improveConnectionContent =>
-      'Подобрихме начина, по който Omi остава свързан с вашето устройство. За да активирате това, моля, отидете на страницата с информация за устройството, натиснете \"Изключване на устройството\" и сдвоете устройството си отново.';
+  String get improveConnectionContent => 'Подобрихме начина, по който Omi остава свързан с вашето устройство. За да активирате това, моля, отидете на страницата с информация за устройството, натиснете \"Изключване на устройството\" и сдвоете устройството си отново.';
 
   @override
   String get improveConnectionAction => 'Разбрах';
@@ -8612,16 +8428,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get cancelSyncQuestion => 'Отмяна на синхронизацията?';
 
   @override
-  String get omisStorageDesc =>
-      'Когато Omi не е свързан с телефона ви, той съхранява аудиото локално във вградената си памет. Никога няма да загубите запис.';
+  String get omisStorageDesc => 'Когато Omi не е свързан с телефона ви, той съхранява аудиото локално във вградената си памет. Никога няма да загубите запис.';
 
   @override
-  String get phoneStorageDesc =>
-      'Когато Omi се свърже отново, записите автоматично се прехвърлят на телефона ви като временно хранилище преди качване.';
+  String get phoneStorageDesc => 'Когато Omi се свърже отново, записите автоматично се прехвърлят на телефона ви като временно хранилище преди качване.';
 
   @override
-  String get cloudStorageDesc =>
-      'След качване, записите ви се обработват и транскрибират. Разговорите ще бъдат налични в рамките на минута.';
+  String get cloudStorageDesc => 'След качване, записите ви се обработват и транскрибират. Разговорите ще бъдат налични в рамките на минута.';
 
   @override
   String get tipKeepPhoneNearby => 'Дръжте телефона наблизо за по-бърза синхронизация';
@@ -8645,12 +8458,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get permissionEnable => 'Активиране';
 
   @override
-  String get permissionsPageDescription =>
-      'Тези разрешения са основни за работата на Omi. Те позволяват ключови функции като известия, базирани на местоположение изживявания и аудио запис.';
+  String get permissionsPageDescription => 'Тези разрешения са основни за работата на Omi. Те позволяват ключови функции като известия, базирани на местоположение изживявания и аудио запис.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi се нуждае от няколко разрешения, за да работи правилно. Моля, предоставете ги, за да продължите.';
+  String get permissionsRequiredDescription => 'Omi се нуждае от няколко разрешения, за да работи правилно. Моля, предоставете ги, за да продължите.';
 
   @override
   String get permissionsSetupTitle => 'Получете най-доброто изживяване';
@@ -8906,8 +8717,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get enableLocationTitle => 'Активиране на местоположение';
 
   @override
-  String get enableLocationDescription =>
-      'Разрешението за местоположение е необходимо за намиране на близки Bluetooth устройства.';
+  String get enableLocationDescription => 'Разрешението за местоположение е необходимо за намиране на близки Bluetooth устройства.';
 
   @override
   String get voiceRecordingFound => 'Намерен запис';
@@ -8928,8 +8738,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get firmwareWarningTitle => 'Важно: Прочетете преди актуализация';
 
   @override
-  String get firmwareFormatWarning =>
-      'Този фърмуер ще форматира SD картата. Моля, уверете се, че всички офлайн данни са синхронизирани преди обновяване.\n\nАко видите мигаща червена светлина след инсталирането на тази версия, не се притеснявайте. Просто свържете устройството с приложението и то трябва да стане синьо. Червената светлина означава, че часовникът на устройството все още не е синхронизиран.';
+  String get firmwareFormatWarning => 'Този фърмуер ще форматира SD картата. Моля, уверете се, че всички офлайн данни са синхронизирани преди обновяване.\n\nАко видите мигаща червена светлина след инсталирането на тази версия, не се притеснявайте. Просто свържете устройството с приложението и то трябва да стане синьо. Червената светлина означава, че часовникът на устройството все още не е синхронизиран.';
 
   @override
   String get continueAnyway => 'Продължи';
@@ -8949,8 +8758,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get tasksMarkComplete => 'Отбелязано като завършено';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi осъществява достъп до Apple Health чрез рамката HealthKit на Apple. Можете да отмените достъпа по всяко време от Настройките на iOS.';
+  String get appleHealthManageNote => 'Omi осъществява достъп до Apple Health чрез рамката HealthKit на Apple. Можете да отмените достъпа по всяко време от Настройките на iOS.';
 
   @override
   String get appleHealthConnectCta => 'Свързване с Apple Health';
@@ -8983,8 +8791,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Достъпът до Apple Health е отказан';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi няма разрешение да чете данните ви от Apple Health. Активирайте го в Настройки на iOS → Поверителност и сигурност → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi няма разрешение да чете данните ви от Apple Health. Активирайте го в Настройки на iOS → Поверителност и сигурност → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Защо си тръгвате?';
@@ -9053,8 +8860,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get planUpdate => 'Актуализация на плана';
 
   @override
-  String get planDeprecationMessage =>
-      'Вашият план Unlimited се прекратява. Преминете към план Operator — същите страхотни функции за \$49/мес. Текущият ви план ще продължи да работи междувременно.';
+  String get planDeprecationMessage => 'Вашият план Unlimited се прекратява. Преминете към план Operator — същите страхотни функции за \$49/мес. Текущият ви план ще продължи да работи междувременно.';
 
   @override
   String get upgradeYourPlan => 'Надградете плана си';
@@ -9165,8 +8971,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Достигнахте месечния си лимит. Надградете, за да продължите да чатите с Omi без ограничения.';
+  String get chatQuotaExceededReply => 'Достигнахте месечния си лимит. Надградете, за да продължите да чатите с Omi без ограничения.';
 
   @override
   String get voiceResponseAudio => 'Прочитай отговора на Omi на глас';
@@ -9197,4 +9002,25 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Добавяне на задача';
+
+  @override
+  String get quickActionAskOmiAnything => 'Питайте Оми всичко';
+
+  @override
+  String get quickActionVoiceMode => 'Гласов режим';
+
+  @override
+  String get quickActionMute => 'Заглуши';
+
+  @override
+  String get quickActionUnmute => 'Включи звука';
+
+  @override
+  String get quickActionConnectDevice => 'Свържи устройство';
+
+  @override
+  String get quickActionDeviceSettings => 'Настройки на устройство';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -24,8 +24,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deleteConversationTitle => 'কথোপকথন মুছে ফেলুন?';
 
   @override
-  String get deleteConversationMessage =>
-      'এটি সম্পর্কিত স্মৃতি, কাজ এবং অডিও ফাইলগুলিও মুছে ফেলবে। এই পদক্ষেপটি আনডু করা যাবে না।';
+  String get deleteConversationMessage => 'এটি সম্পর্কিত স্মৃতি, কাজ এবং অডিও ফাইলগুলিও মুছে ফেলবে। এই পদক্ষেপটি আনডু করা যাবে না।';
 
   @override
   String get confirm => 'নিশ্চিত করুন';
@@ -318,8 +317,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get installedApps => 'ইনস্টল করা অ্যাপস';
 
   @override
-  String get unableToFetchApps =>
-      'অ্যাপস পেতে অক্ষম :(\n\nঅনুগ্রহ করে আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।';
+  String get unableToFetchApps => 'অ্যাপস পেতে অক্ষম :(\n\nঅনুগ্রহ করে আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।';
 
   @override
   String get aboutOmi => 'Omi সম্পর্কে';
@@ -355,19 +353,16 @@ class AppLocalizationsBn extends AppLocalizations {
   String get appsDisconnected => 'আপনার অ্যাপস এবং ইন্টিগ্রেশনগুলি তাৎক্ষণিকভাবে সংযোগ বিচ্ছিন্ন হবে।';
 
   @override
-  String get exportBeforeDelete =>
-      'আপনি আপনার অ্যাকাউন্ট মুছে ফেলার আগে আপনার ডেটা এক্সপোর্ট করতে পারেন, কিন্তু একবার মুছে গেলে, এটি পুনরুদ্ধার করা যাবে না।';
+  String get exportBeforeDelete => 'আপনি আপনার অ্যাকাউন্ট মুছে ফেলার আগে আপনার ডেটা এক্সপোর্ট করতে পারেন, কিন্তু একবার মুছে গেলে, এটি পুনরুদ্ধার করা যাবে না।';
 
   @override
-  String get deleteAccountCheckbox =>
-      'আমি বুঝি যে আমার অ্যাকাউন্ট মুছে ফেলা স্থায়ী এবং সমস্ত ডেটা, স্মৃতি এবং কথোপকথন সহ হারিয়ে যাবে এবং পুনরুদ্ধার করা যাবে না।';
+  String get deleteAccountCheckbox => 'আমি বুঝি যে আমার অ্যাকাউন্ট মুছে ফেলা স্থায়ী এবং সমস্ত ডেটা, স্মৃতি এবং কথোপকথন সহ হারিয়ে যাবে এবং পুনরুদ্ধার করা যাবে না।';
 
   @override
   String get areYouSure => 'আপনি নিশ্চিত?';
 
   @override
-  String get deleteAccountFinal =>
-      'এই পদক্ষেপটি অপ্রতিবর্তনীয় এবং আপনার অ্যাকাউন্ট এবং সমস্ত সম্পর্কিত ডেটা স্থায়ীভাবে মুছে ফেলবে। আপনি কি এগিয়ে যেতে চান?';
+  String get deleteAccountFinal => 'এই পদক্ষেপটি অপ্রতিবর্তনীয় এবং আপনার অ্যাকাউন্ট এবং সমস্ত সম্পর্কিত ডেটা স্থায়ীভাবে মুছে ফেলবে। আপনি কি এগিয়ে যেতে চান?';
 
   @override
   String get deleteNow => 'এখনই মুছুন';
@@ -376,8 +371,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get goBack => 'ফিরে যান';
 
   @override
-  String get checkBoxToConfirm =>
-      'নিশ্চিত করতে বক্স চেক করুন যে আপনি বুঝেন যে আপনার অ্যাকাউন্ট মুছে ফেলা স্থায়ী এবং অপ্রতিবর্তনীয়।';
+  String get checkBoxToConfirm => 'নিশ্চিত করতে বক্স চেক করুন যে আপনি বুঝেন যে আপনার অ্যাকাউন্ট মুছে ফেলা স্থায়ী এবং অপ্রতিবর্তনীয়।';
 
   @override
   String get profile => 'প্রোফাইল';
@@ -455,8 +449,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get yourPrivacyYourControl => 'আপনার গোপনীয়তা, আপনার নিয়ন্ত্রণ';
 
   @override
-  String get privacyIntro =>
-      'Omi তে, আমরা আপনার গোপনীয়তা রক্ষা করতে প্রতিশ্রুতিবদ্ধ। এই পৃষ্ঠাটি আপনাকে আপনার ডেটা কীভাবে সংরক্ষণ এবং ব্যবহার করা হয় তা নিয়ন্ত্রণ করতে দেয়।';
+  String get privacyIntro => 'Omi তে, আমরা আপনার গোপনীয়তা রক্ষা করতে প্রতিশ্রুতিবদ্ধ। এই পৃষ্ঠাটি আপনাকে আপনার ডেটা কীভাবে সংরক্ষণ এবং ব্যবহার করা হয় তা নিয়ন্ত্রণ করতে দেয়।';
 
   @override
   String get learnMore => 'আরও শিখুন...';
@@ -465,15 +458,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get dataProtectionLevel => 'ডেটা সুরক্ষা স্তর';
 
   @override
-  String get dataProtectionDesc =>
-      'আপনার ডেটা শক্তিশালী এনক্রিপশন দ্বারা ডিফল্টরূপে সুরক্ষিত। নীচে আপনার সেটিংস এবং ভবিষ্যত গোপনীয়তা বিকল্পগুলি পর্যালোচনা করুন।';
+  String get dataProtectionDesc => 'আপনার ডেটা শক্তিশালী এনক্রিপশন দ্বারা ডিফল্টরূপে সুরক্ষিত। নীচে আপনার সেটিংস এবং ভবিষ্যত গোপনীয়তা বিকল্পগুলি পর্যালোচনা করুন।';
 
   @override
   String get appAccess => 'অ্যাপ অ্যাক্সেস';
 
   @override
-  String get appAccessDesc =>
-      'নিম্নলিখিত অ্যাপগুলি আপনার ডেটা অ্যাক্সেস করতে পারে। একটি অ্যাপের অনুমতি পরিচালনা করতে এটিতে ট্যাপ করুন।';
+  String get appAccessDesc => 'নিম্নলিখিত অ্যাপগুলি আপনার ডেটা অ্যাক্সেস করতে পারে। একটি অ্যাপের অনুমতি পরিচালনা করতে এটিতে ট্যাপ করুন।';
 
   @override
   String get noAppsExternalAccess => 'কোনো ইনস্টল করা অ্যাপের আপনার ডেটায় বাহ্যিক অ্যাক্সেস নেই।';
@@ -530,15 +521,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deviceDisconnectedMessage => 'আপনার Omi সংযোগ বিচ্ছিন্ন হয়েছে 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'ডিভাইস আনপেয়ার করা হয়েছে। আনপেয়ারিং সম্পূর্ণ করতে সেটিংস > ব্লুটুথ যান এবং ডিভাইসটি ভুলে যান।';
+  String get deviceUnpairedMessage => 'ডিভাইস আনপেয়ার করা হয়েছে। আনপেয়ারিং সম্পূর্ণ করতে সেটিংস > ব্লুটুথ যান এবং ডিভাইসটি ভুলে যান।';
 
   @override
   String get unpairDialogTitle => 'ডিভাইস আনপেয়ার করুন';
 
   @override
-  String get unpairDialogMessage =>
-      'এটি ডিভাইসটি আনপেয়ার করবে যাতে এটি অন্য ফোনের সাথে সংযুক্ত হতে পারে। আপনাকে সেটিংস > ব্লুটুথ যেতে হবে এবং প্রক্রিয়াটি সম্পূর্ণ করতে ডিভাইসটি ভুলে যেতে হবে।';
+  String get unpairDialogMessage => 'এটি ডিভাইসটি আনপেয়ার করবে যাতে এটি অন্য ফোনের সাথে সংযুক্ত হতে পারে। আপনাকে সেটিংস > ব্লুটুথ যেতে হবে এবং প্রক্রিয়াটি সম্পূর্ণ করতে ডিভাইসটি ভুলে যেতে হবে।';
 
   @override
   String get deviceNotConnected => 'ডিভাইস সংযুক্ত নয়';
@@ -559,8 +548,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get v2Undetected => 'V2 সনাক্ত হয়নি';
 
   @override
-  String get v2UndetectedMessage =>
-      'আমরা দেখছি যে আপনার কাছে একটি V1 ডিভাইস রয়েছে বা আপনার ডিভাইস সংযুক্ত নয়। SD কার্ড কার্যকারিতা শুধুমাত্র V2 ডিভাইসের জন্য উপলব্ধ।';
+  String get v2UndetectedMessage => 'আমরা দেখছি যে আপনার কাছে একটি V1 ডিভাইস রয়েছে বা আপনার ডিভাইস সংযুক্ত নয়। SD কার্ড কার্যকারিতা শুধুমাত্র V2 ডিভাইসের জন্য উপলব্ধ।';
 
   @override
   String get endConversation => 'কথোপকথন শেষ করুন';
@@ -692,8 +680,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get noActivityYet => 'এখনো কোনো কার্যকলাপ নেই';
 
   @override
-  String get startConversationToSeeInsights =>
-      'এখানে আপনার ব্যবহার অন্তর্দৃষ্টি দেখতে Omi এর সাথে একটি কথোপকথন শুরু করুন।';
+  String get startConversationToSeeInsights => 'এখানে আপনার ব্যবহার অন্তর্দৃষ্টি দেখতে Omi এর সাথে একটি কথোপকথন শুরু করুন।';
 
   @override
   String get listening => 'শোনা';
@@ -835,8 +822,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'জ্ঞান গ্রাফ মুছুন?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'এটি সমস্ত উদ্ভূত জ্ঞান গ্রাফ ডেটা (নোড এবং সংযোগ) মুছে ফেলবে। আপনার মূল স্মৃতি নিরাপদ থাকবে। গ্রাফটি সময়ের সাথে বা পরবর্তী অনুরোধে পুনর্নির্মাণ করা হবে।';
+  String get deleteKnowledgeGraphMessage => 'এটি সমস্ত উদ্ভূত জ্ঞান গ্রাফ ডেটা (নোড এবং সংযোগ) মুছে ফেলবে। আপনার মূল স্মৃতি নিরাপদ থাকবে। গ্রাফটি সময়ের সাথে বা পরবর্তী অনুরোধে পুনর্নির্মাণ করা হবে।';
 
   @override
   String get knowledgeGraphDeleted => 'জ্ঞান গ্রাফ মুছে ফেলা হয়েছে';
@@ -1019,8 +1005,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get integrationsFooter => 'আপনার অ্যাপ সংযুক্ত করুন চ্যাটে ডেটা এবং মেট্রিক্স দেখতে।';
 
   @override
-  String get completeAuthInBrowser =>
-      'অনুগ্রহ করে আপনার ব্রাউজারে প্রমাণীকরণ সম্পূর্ণ করুন। সম্পন্ন হলে, অ্যাপে ফিরে আসুন।';
+  String get completeAuthInBrowser => 'অনুগ্রহ করে আপনার ব্রাউজারে প্রমাণীকরণ সম্পূর্ণ করুন। সম্পন্ন হলে, অ্যাপে ফিরে আসুন।';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1080,8 +1065,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get needYourPermission => 'আমাদের আপনার অনুমতি প্রয়োজন';
 
   @override
-  String get alreadyGavePermission =>
-      'আপনি ইতিমধ্যে আমাদের আপনার রেকর্ডিং সংরক্ষণ করার অনুমতি দিয়েছেন। এখানে আমাদের এটি প্রয়োজনের একটি অনুস্মারক রয়েছে:';
+  String get alreadyGavePermission => 'আপনি ইতিমধ্যে আমাদের আপনার রেকর্ডিং সংরক্ষণ করার অনুমতি দিয়েছেন। এখানে আমাদের এটি প্রয়োজনের একটি অনুস্মারক রয়েছে:';
 
   @override
   String get wouldLikePermission => 'আমরা আপনার কণ্ঠস্বর রেকর্ডিং সংরক্ষণ করার অনুমতি চাই। এখানে কেন রয়েছে:';
@@ -1090,26 +1074,22 @@ class AppLocalizationsBn extends AppLocalizations {
   String get improveSpeechProfile => 'আপনার কণ্ঠ প্রোফাইল উন্নত করুন';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'আমরা রেকর্ডিং ব্যবহার করে আপনার ব্যক্তিগত কণ্ঠ প্রোফাইলকে আরও প্রশিক্ষণ এবং উন্নত করি।';
+  String get improveSpeechProfileDesc => 'আমরা রেকর্ডিং ব্যবহার করে আপনার ব্যক্তিগত কণ্ঠ প্রোফাইলকে আরও প্রশিক্ষণ এবং উন্নত করি।';
 
   @override
   String get trainFamilyProfiles => 'বন্ধু এবং পরিবারের জন্য প্রোফাইল প্রশিক্ষণ করুন';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'আপনার রেকর্ডিং আমাদের আপনার বন্ধু এবং পরিবারকে চিনতে এবং প্রোফাইল তৈরি করতে সাহায্য করে।';
+  String get trainFamilyProfilesDesc => 'আপনার রেকর্ডিং আমাদের আপনার বন্ধু এবং পরিবারকে চিনতে এবং প্রোফাইল তৈরি করতে সাহায্য করে।';
 
   @override
   String get enhanceTranscriptAccuracy => 'ট্রান্সক্রিপ্ট নির্ভুলতা উন্নত করুন';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'আমাদের মডেল উন্নত হওয়ায়, আমরা আপনার রেকর্ডিংয়ের জন্য আরও ভাল ট্রান্সক্রিপশন ফলাফল প্রদান করতে পারি।';
+  String get enhanceTranscriptAccuracyDesc => 'আমাদের মডেল উন্নত হওয়ায়, আমরা আপনার রেকর্ডিংয়ের জন্য আরও ভাল ট্রান্সক্রিপশন ফলাফল প্রদান করতে পারি।';
 
   @override
-  String get legalNotice =>
-      'আইনি নোটিশ: ভয়েস ডেটা রেকর্ড এবং সংরক্ষণের আইনি বৈধতা আপনার অবস্থান এবং আপনি এই বৈশিষ্ট্যটি কীভাবে ব্যবহার করেন তার উপর নির্ভর করে পরিবর্তিত হতে পারে। স্থানীয় আইন এবং প্রবিধান মেনে চলা নিশ্চিত করা আপনার দায়িত্ব।';
+  String get legalNotice => 'আইনি নোটিশ: ভয়েস ডেটা রেকর্ড এবং সংরক্ষণের আইনি বৈধতা আপনার অবস্থান এবং আপনি এই বৈশিষ্ট্যটি কীভাবে ব্যবহার করেন তার উপর নির্ভর করে পরিবর্তিত হতে পারে। স্থানীয় আইন এবং প্রবিধান মেনে চলা নিশ্চিত করা আপনার দায়িত্ব।';
 
   @override
   String get alreadyAuthorized => 'ইতিমধ্যে অনুমোদিত';
@@ -1228,8 +1208,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get noProjectsInWorkspace => 'এই কর্মক্ষেত্রে কোনো প্রকল্প পাওয়া যায়নি';
 
   @override
-  String get conversationTimeoutDesc =>
-      'অটোম্যাটিকভাবে একটি কথোপকথন শেষ করার আগে নীরবতায় কতক্ষণ অপেক্ষা করবেন তা চয়ন করুন:';
+  String get conversationTimeoutDesc => 'অটোম্যাটিকভাবে একটি কথোপকথন শেষ করার আগে নীরবতায় কতক্ষণ অপেক্ষা করবেন তা চয়ন করুন:';
 
   @override
   String get timeout2Minutes => '2 মিনিট';
@@ -1356,8 +1335,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get defaultRepository => 'ডিফল্ট রিপোজিটরি';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'সমস্যা তৈরির জন্য একটি ডিফল্ট রিপোজিটরি নির্বাচন করুন। আপনি এখনও সমস্যা তৈরি করার সময় একটি ভিন্ন রিপোজিটরি নির্দিষ্ট করতে পারেন।';
+  String get selectDefaultRepoDesc => 'সমস্যা তৈরির জন্য একটি ডিফল্ট রিপোজিটরি নির্বাচন করুন। আপনি এখনও সমস্যা তৈরি করার সময় একটি ভিন্ন রিপোজিটরি নির্দিষ্ট করতে পারেন।';
 
   @override
   String get noReposFound => 'কোনো রিপোজিটরি পাওয়া যায়নি';
@@ -1453,8 +1431,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get bringYourOwn => 'নিজের নিয়ে আসুন';
 
   @override
-  String get payYourSttProvider =>
-      'Omi অবাধে ব্যবহার করুন। আপনি শুধুমাত্র আপনার STT প্রদানকারীকে সরাসরি অর্থ প্রদান করেন।';
+  String get payYourSttProvider => 'Omi অবাধে ব্যবহার করুন। আপনি শুধুমাত্র আপনার STT প্রদানকারীকে সরাসরি অর্থ প্রদান করেন।';
 
   @override
   String get freeMinutesMonth => 'প্রতি মাসে 1,200 বিনামূল্যে মিনিট অন্তর্ভুক্ত। সীমাহীন ';
@@ -1733,8 +1710,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth সক্ষম করুন';
 
   @override
-  String get bluetoothNeeded =>
-      'আপনার পরিধানযোগ্যের সাথে সংযোগ করতে Omi এর Bluetooth দরকার। Bluetooth সক্ষম করুন এবং আবার চেষ্টা করুন।';
+  String get bluetoothNeeded => 'আপনার পরিধানযোগ্যের সাথে সংযোগ করতে Omi এর Bluetooth দরকার। Bluetooth সক্ষম করুন এবং আবার চেষ্টা করুন।';
 
   @override
   String get contactSupport => 'সাপোর্টের সাথে যোগাযোগ করবেন?';
@@ -1767,8 +1743,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get locationServiceDisabled => 'অবস্থান সেবা অক্ষম করা হয়েছে';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'অবস্থান সেবা অক্ষম। সেটিংস > গোপনীয়তা ও সুরক্ষা > অবস্থান সেবায় যান এবং এটি সক্ষম করুন';
+  String get locationServiceDisabledDesc => 'অবস্থান সেবা অক্ষম। সেটিংস > গোপনীয়তা ও সুরক্ষা > অবস্থান সেবায় যান এবং এটি সক্ষম করুন';
 
   @override
   String get backgroundLocationDenied => 'পটভূমি অবস্থান অ্যাক্সেস অনুমোদিত নয়';
@@ -1780,12 +1755,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get lovingOmi => 'Omi ভালোবাসছেন?';
 
   @override
-  String get leaveReviewIos =>
-      'অ্যাপ স্টোরে পর্যালোচনা রেখে আমাদের আরও মানুষের কাছে পৌঁছাতে সাহায্য করুন। আপনার প্রতিক্রিয়া আমাদের কাছে বিশ্ব মানে!';
+  String get leaveReviewIos => 'অ্যাপ স্টোরে পর্যালোচনা রেখে আমাদের আরও মানুষের কাছে পৌঁছাতে সাহায্য করুন। আপনার প্রতিক্রিয়া আমাদের কাছে বিশ্ব মানে!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Google Play স্টোরে পর্যালোচনা রেখে আমাদের আরও মানুষের কাছে পৌঁছাতে সাহায্য করুন। আপনার প্রতিক্রিয়া আমাদের কাছে বিশ্ব মানে!';
+  String get leaveReviewAndroid => 'Google Play স্টোরে পর্যালোচনা রেখে আমাদের আরও মানুষের কাছে পৌঁছাতে সাহায্য করুন। আপনার প্রতিক্রিয়া আমাদের কাছে বিশ্ব মানে!';
 
   @override
   String get rateOnAppStore => 'অ্যাপ স্টোরে রেটিং দিন';
@@ -1818,15 +1791,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get connectionError => 'সংযোগ ত্রুটি';
 
   @override
-  String get connectionErrorDesc =>
-      'সার্ভারের সাথে সংযোগ করতে ব্যর্থ। আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।';
+  String get connectionErrorDesc => 'সার্ভারের সাথে সংযোগ করতে ব্যর্থ। আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'অবৈধ রেকর্ডিং সনাক্ত করা হয়েছে';
 
   @override
-  String get multipleSpeakersDesc =>
-      'এটি দেখে মনে হচ্ছে রেকর্ডিংয়ে একাধিক স্পিকার রয়েছে। নিশ্চিত করুন যে আপনি একটি শান্ত স্থানে আছেন এবং আবার চেষ্টা করুন।';
+  String get multipleSpeakersDesc => 'এটি দেখে মনে হচ্ছে রেকর্ডিংয়ে একাধিক স্পিকার রয়েছে। নিশ্চিত করুন যে আপনি একটি শান্ত স্থানে আছেন এবং আবার চেষ্টা করুন।';
 
   @override
   String get tooShortDesc => 'যথেষ্ট কথা সনাক্ত করা হয়নি। আরও কথা বলুন এবং আবার চেষ্টা করুন।';
@@ -1859,8 +1830,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get permissionsRequired => 'অনুমতি প্রয়োজন';
 
   @override
-  String get permissionsRequiredDesc =>
-      'এই অ্যাপটি সঠিকভাবে কাজ করার জন্য Bluetooth এবং অবস্থান অনুমতি প্রয়োজন। সেটিংসে সক্ষম করুন।';
+  String get permissionsRequiredDesc => 'এই অ্যাপটি সঠিকভাবে কাজ করার জন্য Bluetooth এবং অবস্থান অনুমতি প্রয়োজন। সেটিংসে সক্ষম করুন।';
 
   @override
   String get openSettings => 'সেটিংস খুলুন';
@@ -1902,12 +1872,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get microphonePermission => 'মাইক্রোফোন অনুমতি';
 
   @override
-  String get permissionGrantedNow =>
-      'অনুমতি প্রদান করা হয়েছে! এখন:\n\nআপনার ঘড়িতে Omi অ্যাপ খুলুন এবং নীচে \"চালিয়ে যান\" ট্যাপ করুন';
+  String get permissionGrantedNow => 'অনুমতি প্রদান করা হয়েছে! এখন:\n\nআপনার ঘড়িতে Omi অ্যাপ খুলুন এবং নীচে \"চালিয়ে যান\" ট্যাপ করুন';
 
   @override
-  String get needMicrophonePermission =>
-      'আমাদের মাইক্রোফোন অনুমতি প্রয়োজন।\n\n1. \"অনুমতি প্রদান করুন\" ট্যাপ করুন\n2. আপনার iPhone এ অনুমোদন করুন\n3. ঘড়ির অ্যাপ বন্ধ হবে\n4. পুনরায় খুলুন এবং \"চালিয়ে যান\" ট্যাপ করুন';
+  String get needMicrophonePermission => 'আমাদের মাইক্রোফোন অনুমতি প্রয়োজন।\n\n1. \"অনুমতি প্রদান করুন\" ট্যাপ করুন\n2. আপনার iPhone এ অনুমোদন করুন\n3. ঘড়ির অ্যাপ বন্ধ হবে\n4. পুনরায় খুলুন এবং \"চালিয়ে যান\" ট্যাপ করুন';
 
   @override
   String get grantPermissionButton => 'অনুমতি প্রদান করুন';
@@ -1916,15 +1884,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get needHelp => 'সাহায্যের প্রয়োজন?';
 
   @override
-  String get troubleshootingSteps =>
-      'সমস্যা সমাধান:\n\n1. নিশ্চিত করুন Omi আপনার ঘড়িতে ইনস্টল করা আছে\n2. আপনার ঘড়িতে Omi অ্যাপ খুলুন\n3. অনুমতি পপআপ খুঁজুন\n4. প্রম্পট দেখা গেলে \"অনুমোদন করুন\" ট্যাপ করুন\n5. আপনার ঘড়িতে অ্যাপ বন্ধ হবে - পুনরায় খুলুন\n6. ফিরে আসুন এবং আপনার iPhone এ \"চালিয়ে যান\" ট্যাপ করুন';
+  String get troubleshootingSteps => 'সমস্যা সমাধান:\n\n1. নিশ্চিত করুন Omi আপনার ঘড়িতে ইনস্টল করা আছে\n2. আপনার ঘড়িতে Omi অ্যাপ খুলুন\n3. অনুমতি পপআপ খুঁজুন\n4. প্রম্পট দেখা গেলে \"অনুমোদন করুন\" ট্যাপ করুন\n5. আপনার ঘড়িতে অ্যাপ বন্ধ হবে - পুনরায় খুলুন\n6. ফিরে আসুন এবং আপনার iPhone এ \"চালিয়ে যান\" ট্যাপ করুন';
 
   @override
   String get recordingStartedSuccessfully => 'রেকর্ডিং সফলভাবে শুরু হয়েছে!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'এখনও অনুমতি প্রদান করা হয়নি। নিশ্চিত করুন যে আপনি মাইক্রোফোন অ্যাক্সেস অনুমোদন করেছেন এবং আপনার ঘড়িতে অ্যাপ পুনরায় খুলেছেন।';
+  String get permissionNotGrantedYet => 'এখনও অনুমতি প্রদান করা হয়নি। নিশ্চিত করুন যে আপনি মাইক্রোফোন অ্যাক্সেস অনুমোদন করেছেন এবং আপনার ঘড়িতে অ্যাপ পুনরায় খুলেছেন।';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1955,8 +1921,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get actionItemsTitle => 'কাজ করার তালিকা';
 
   @override
-  String get actionItemsDescription =>
-      'সম্পাদন করতে ট্যাপ করুন • নির্বাচন করতে দীর্ঘ চাপুন • অ্যাকশনের জন্য স্যোয়াইপ করুন';
+  String get actionItemsDescription => 'সম্পাদন করতে ট্যাপ করুন • নির্বাচন করতে দীর্ঘ চাপুন • অ্যাকশনের জন্য স্যোয়াইপ করুন';
 
   @override
   String get tabToDo => 'করার কাজ';
@@ -2022,8 +1987,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get welcomeActionItemsTitle => 'অ্যাকশন আইটেমের জন্য প্রস্তুত';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'আপনার AI স্বয়ংক্রিয়ভাবে আপনার কথোপকথন থেকে কাজ এবং করার কাজ বের করবে। সেগুলি তৈরি হলে এখানে প্রদর্শিত হবে।';
+  String get welcomeActionItemsDescription => 'আপনার AI স্বয়ংক্রিয়ভাবে আপনার কথোপকথন থেকে কাজ এবং করার কাজ বের করবে। সেগুলি তৈরি হলে এখানে প্রদর্শিত হবে।';
 
   @override
   String get autoExtractionFeature => 'কথোপকথন থেকে স্বয়ংক্রিয়ভাবে বের করা';
@@ -2073,8 +2037,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get clearMemoryTitle => 'Omi এর স্মৃতি পরিষ্কার করুন';
 
   @override
-  String get clearMemoryMessage =>
-      'আপনি কি নিশ্চিত যে আপনি Omi এর স্মৃতি পরিষ্কার করতে চান? এই অ্যাকশনটি পূর্বাবস্থা করা যাবে না।';
+  String get clearMemoryMessage => 'আপনি কি নিশ্চিত যে আপনি Omi এর স্মৃতি পরিষ্কার করতে চান? এই অ্যাকশনটি পূর্বাবস্থা করা যাবে না।';
 
   @override
   String get clearMemoryButton => 'স্মৃতি পরিষ্কার করুন';
@@ -2220,15 +2183,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'কথা এবং ট্রান্সক্রিপশন';
 
   @override
-  String get languageSettingsHelperText =>
-      'অ্যাপ ভাষা মেনু এবং বোতামগুলি পরিবর্তন করে। কথার ভাষা আপনার রেকর্ডিংগুলি কীভাবে ট্রান্সক্রাইব করা হয় তা প্রভাবিত করে।';
+  String get languageSettingsHelperText => 'অ্যাপ ভাষা মেনু এবং বোতামগুলি পরিবর্তন করে। কথার ভাষা আপনার রেকর্ডিংগুলি কীভাবে ট্রান্সক্রাইব করা হয় তা প্রভাবিত করে।';
 
   @override
   String get translationNotice => 'অনুবাদ বিজ্ঞপ্তি';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi কথোপকথনগুলি আপনার প্রাথমিক ভাষায় অনুবাদ করে। সেটিংস → প্রোফাইলে যেকোনো সময় আপডেট করুন।';
+  String get translationNoticeMessage => 'Omi কথোপকথনগুলি আপনার প্রাথমিক ভাষায় অনুবাদ করে। সেটিংস → প্রোফাইলে যেকোনো সময় আপডেট করুন।';
 
   @override
   String get pleaseCheckInternetConnection => 'আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন';
@@ -2390,8 +2351,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'ডিভাইস আনপেয়ার করুন';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'এটি ডিভাইসটিকে আনপেয়ার করবে যাতে এটি অন্য ফোনের সাথে সংযুক্ত হতে পারে। প্রক্রিয়াটি সম্পূর্ণ করতে আপনাকে সেটিংস > ব্লুটুথ এ যেতে হবে এবং ডিভাইসটি ভুলে যেতে হবে।';
+  String get unpairDeviceDialogMessage => 'এটি ডিভাইসটিকে আনপেয়ার করবে যাতে এটি অন্য ফোনের সাথে সংযুক্ত হতে পারে। প্রক্রিয়াটি সম্পূর্ণ করতে আপনাকে সেটিংস > ব্লুটুথ এ যেতে হবে এবং ডিভাইসটি ভুলে যেতে হবে।';
 
   @override
   String get unpair => 'আনপেয়ার করুন';
@@ -2572,8 +2532,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get youreAllSet => 'আপনি সব প্রস্তুত!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Omi তে স্বাগতম! আপনার AI সহায়ক কথোপকথন, কাজ এবং আরও অনেক কিছুতে আপনাকে সাহায্য করতে প্রস্তুত।';
+  String get welcomeToOmiDescription => 'Omi তে স্বাগতম! আপনার AI সহায়ক কথোপকথন, কাজ এবং আরও অনেক কিছুতে আপনাকে সাহায্য করতে প্রস্তুত।';
 
   @override
   String get startUsingOmi => 'Omi ব্যবহার শুরু করুন';
@@ -2709,8 +2668,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get noTasksYet => 'এখনো কোনো কাজ নেই';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'আপনার কথোপকথন থেকে কাজ এখানে প্রদর্শিত হবে।\nএক্স ক্লিক করুন ম্যানুয়ালি একটি যোগ করতে।';
+  String get tasksFromConversationsWillAppear => 'আপনার কথোপকথন থেকে কাজ এখানে প্রদর্শিত হবে।\nএক্স ক্লিক করুন ম্যানুয়ালি একটি যোগ করতে।';
 
   @override
   String get monthJan => 'জানু';
@@ -2767,8 +2725,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deleteActionItem => 'কর্মপরিকল্পনা মুছুন';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'আপনি কি এই কর্মপরিকল্পনা মুছতে নিশ্চিত? এই পদক্ষেপ পূর্বাবস্থায় ফেরানো যাবে না।';
+  String get deleteActionItemConfirmation => 'আপনি কি এই কর্মপরিকল্পনা মুছতে নিশ্চিত? এই পদক্ষেপ পূর্বাবস্থায় ফেরানো যাবে না।';
 
   @override
   String get enterActionItemDescription => 'কর্মপরিকল্পনা বর্ণনা লিখুন...';
@@ -2843,15 +2800,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get chatPrompt => 'চ্যাট প্রম্পট';
 
   @override
-  String get chatPromptPlaceholder =>
-      'আপনি একটি দুর্দান্ত অ্যাপ, আপনার কাজ ব্যবহারকারীর প্রশ্নের উত্তর দেওয়া এবং তাদের ভালো অনুভব করান...';
+  String get chatPromptPlaceholder => 'আপনি একটি দুর্দান্ত অ্যাপ, আপনার কাজ ব্যবহারকারীর প্রশ্নের উত্তর দেওয়া এবং তাদের ভালো অনুভব করান...';
 
   @override
   String get conversationPrompt => 'কথোপকথন প্রম্পট';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'আপনি একটি দুর্দান্ত অ্যাপ, আপনাকে একটি কথোপকথনের ট্রান্সক্রিপ্ট এবং সারাংশ দেওয়া হবে...';
+  String get conversationPromptPlaceholder => 'আপনি একটি দুর্দান্ত অ্যাপ, আপনাকে একটি কথোপকথনের ট্রান্সক্রিপ্ট এবং সারাংশ দেওয়া হবে...';
 
   @override
   String get notificationScopes => 'বিজ্ঞপ্তি স্কোপ';
@@ -2878,12 +2833,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get submitAppQuestion => 'অ্যাপ জমা দিতে?';
 
   @override
-  String get submitAppPublicDescription =>
-      'আপনার অ্যাপ পর্যালোচনা করা হবে এবং জনসাধারণ উপলব্ধ করা হবে। পর্যালোচনার সময়ও আপনি এটি অবিলম্বে ব্যবহার শুরু করতে পারেন!';
+  String get submitAppPublicDescription => 'আপনার অ্যাপ পর্যালোচনা করা হবে এবং জনসাধারণ উপলব্ধ করা হবে। পর্যালোচনার সময়ও আপনি এটি অবিলম্বে ব্যবহার শুরু করতে পারেন!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'আপনার অ্যাপ পর্যালোচনা করা হবে এবং আপনার কাছে ব্যক্তিগতভাবে উপলব্ধ করা হবে। পর্যালোচনার সময়ও আপনি এটি অবিলম্বে ব্যবহার শুরু করতে পারেন!';
+  String get submitAppPrivateDescription => 'আপনার অ্যাপ পর্যালোচনা করা হবে এবং আপনার কাছে ব্যক্তিগতভাবে উপলব্ধ করা হবে। পর্যালোচনার সময়ও আপনি এটি অবিলম্বে ব্যবহার শুরু করতে পারেন!';
 
   @override
   String get startEarning => 'উপার্জন শুরু করুন! 💰';
@@ -2907,8 +2860,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get dataAccessNotice => 'ডেটা অ্যাক্সেস বিজ্ঞপ্তি';
 
   @override
-  String get dataAccessWarning =>
-      'এই অ্যাপ আপনার ডেটা অ্যাক্সেস করবে। Omi AI এই অ্যাপের দ্বারা আপনার ডেটা কীভাবে ব্যবহার, পরিবর্তন বা মুছে ফেলা হয় তার জন্য দায়বদ্ধ নয়';
+  String get dataAccessWarning => 'এই অ্যাপ আপনার ডেটা অ্যাক্সেস করবে। Omi AI এই অ্যাপের দ্বারা আপনার ডেটা কীভাবে ব্যবহার, পরিবর্তন বা মুছে ফেলা হয় তার জন্য দায়বদ্ধ নয়';
 
   @override
   String get installApp => 'অ্যাপ ইনস্টল করুন';
@@ -2917,12 +2869,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get betaTesterNotice => 'আপনি এই অ্যাপের বিটা পরীক্ষক। এটি এখনো জনসাধারণ নয়। এটি অনুমোদিত হলে জনসাধারণ হবে।';
 
   @override
-  String get appUnderReviewOwner =>
-      'আপনার অ্যাপ পর্যালোচনা অধীনে এবং শুধুমাত্র আপনার কাছে দৃশ্যমান। এটি অনুমোদিত হলে জনসাধারণ হবে।';
+  String get appUnderReviewOwner => 'আপনার অ্যাপ পর্যালোচনা অধীনে এবং শুধুমাত্র আপনার কাছে দৃশ্যমান। এটি অনুমোদিত হলে জনসাধারণ হবে।';
 
   @override
-  String get appRejectedNotice =>
-      'আপনার অ্যাপ প্রত্যাখ্যান করা হয়েছে। দয়া করে অ্যাপ বিবরণ আপডেট করুন এবং পুনর্মূল্যায়নের জন্য পুনরায় জমা দিন।';
+  String get appRejectedNotice => 'আপনার অ্যাপ প্রত্যাখ্যান করা হয়েছে। দয়া করে অ্যাপ বিবরণ আপডেট করুন এবং পুনর্মূল্যায়নের জন্য পুনরায় জমা দিন।';
 
   @override
   String get setupSteps => 'সেটআপ ধাপ';
@@ -2984,8 +2934,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get descriptionLabel => 'বর্ণনা';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'আমার দুর্দান্ত অ্যাপ একটি দুর্দান্ত অ্যাপ যা অসাধারণ কাজ করে। এটি সর্বোত্তম অ্যাপ!';
+  String get appDescriptionPlaceholder => 'আমার দুর্দান্ত অ্যাপ একটি দুর্দান্ত অ্যাপ যা অসাধারণ কাজ করে। এটি সর্বোত্তম অ্যাপ!';
 
   @override
   String get pleaseProvideValidDescription => 'দয়া করে একটি বৈধ বর্ণনা প্রদান করুন';
@@ -3137,8 +3086,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get microphonePermissionRequired => 'কল করার জন্য মাইক্রোফোন অনুমতি প্রয়োজন';
 
   @override
-  String get microphonePermissionDenied =>
-      'মাইক্রোফোন অনুমতি অস্বীকার করা হয়েছে। সিস্টেম পছন্দ > গোপনীয়তা এবং নিরাপত্তা > মাইক্রোফোন এ অনুমতি দিন।';
+  String get microphonePermissionDenied => 'মাইক্রোফোন অনুমতি অস্বীকার করা হয়েছে। সিস্টেম পছন্দ > গোপনীয়তা এবং নিরাপত্তা > মাইক্রোফোন এ অনুমতি দিন।';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3371,8 +3319,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get whatWeCollect => 'আমরা কী সংগ্রহ করি';
 
   @override
-  String get dataCollectionMessage =>
-      'চালিয়ে গিয়ে, আপনার কথোপকথন, রেকর্ডিং এবং ব্যক্তিগত তথ্য আমাদের সার্ভারে নিরাপদে সংরক্ষণ করা হবে যাতে AI-চালিত অন্তর্দৃষ্টি প্রদান করা যায় এবং সমস্ত অ্যাপ বৈশিষ্ট্য সক্ষম করা যায়।';
+  String get dataCollectionMessage => 'চালিয়ে গিয়ে, আপনার কথোপকথন, রেকর্ডিং এবং ব্যক্তিগত তথ্য আমাদের সার্ভারে নিরাপদে সংরক্ষণ করা হবে যাতে AI-চালিত অন্তর্দৃষ্টি প্রদান করা যায় এবং সমস্ত অ্যাপ বৈশিষ্ট্য সক্ষম করা যায়।';
 
   @override
   String get dataProtection => 'ডেটা সুরক্ষা';
@@ -3405,8 +3352,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'নাম কমপক্ষে ২ অক্ষরের হতে হবে';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'আমাদের বলুন আপনি কীভাবে সম্বোধিত হতে চান। এটি আপনার Omi অভিজ্ঞতা ব্যক্তিগতকৃত করতে সাহায্য করে।';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'আমাদের বলুন আপনি কীভাবে সম্বোধিত হতে চান। এটি আপনার Omi অভিজ্ঞতা ব্যক্তিগতকৃত করতে সাহায্য করে।';
 
   @override
   String charactersCount(int count) {
@@ -3423,8 +3369,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get recordAudioConversations => 'অডিও কথোপকথন রেকর্ড করুন';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi আপনার কথোপকথন রেকর্ড করতে এবং ট্রান্সক্রিপশন প্রদান করতে মাইক্রোফোন অ্যাক্সেসের প্রয়োজন।';
+  String get microphoneAccessDescription => 'Omi আপনার কথোপকথন রেকর্ড করতে এবং ট্রান্সক্রিপশন প্রদান করতে মাইক্রোফোন অ্যাক্সেসের প্রয়োজন।';
 
   @override
   String get screenRecording => 'স্ক্রিন রেকর্ডিং';
@@ -3433,8 +3378,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'মিটিং থেকে সিস্টেম অডিও ক্যাপচার করুন';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi আপনার ব্রাউজার-ভিত্তিক মিটিং থেকে সিস্টেম অডিও ক্যাপচার করতে স্ক্রিন রেকর্ডিং অনুমতির প্রয়োজন।';
+  String get screenRecordingDescription => 'Omi আপনার ব্রাউজার-ভিত্তিক মিটিং থেকে সিস্টেম অডিও ক্যাপচার করতে স্ক্রিন রেকর্ডিং অনুমতির প্রয়োজন।';
 
   @override
   String get accessibility => 'অ্যাক্সেসযোগ্যতা';
@@ -3443,8 +3387,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'ব্রাউজার-ভিত্তিক মিটিং সনাক্ত করুন';
 
   @override
-  String get accessibilityDescription =>
-      'Omi আপনার ব্রাউজারে Zoom, Meet বা Teams মিটিং যোগদানের সময় সনাক্ত করতে অ্যাক্সেসযোগ্যতা অনুমতির প্রয়োজন।';
+  String get accessibilityDescription => 'Omi আপনার ব্রাউজারে Zoom, Meet বা Teams মিটিং যোগদানের সময় সনাক্ত করতে অ্যাক্সেসযোগ্যতা অনুমতির প্রয়োজন।';
 
   @override
   String get pleaseWait => 'অনুগ্রহ করে অপেক্ষা করুন...';
@@ -3513,12 +3456,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get exportAllConversationsToJson => 'আপনার সমস্ত কথোপকথন একটি JSON ফাইলে রপ্তানি করুন।';
 
   @override
-  String get conversationsExportStarted =>
-      'কথোপকথন রপ্তানি শুরু হয়েছে। এটি কয়েক সেকেন্ড সময় নিতে পারে, অনুগ্রহ করে অপেক্ষা করুন।';
+  String get conversationsExportStarted => 'কথোপকথন রপ্তানি শুরু হয়েছে। এটি কয়েক সেকেন্ড সময় নিতে পারে, অনুগ্রহ করে অপেক্ষা করুন।';
 
   @override
-  String get mcpDescription =>
-      'Omi কে অন্যান্য অ্যাপ্লিকেশনের সাথে সংযুক্ত করতে আপনার স্মৃতি এবং কথোপকথন পড়তে, অনুসন্ধান করতে এবং পরিচালনা করতে। শুরু করতে একটি কী তৈরি করুন।';
+  String get mcpDescription => 'Omi কে অন্যান্য অ্যাপ্লিকেশনের সাথে সংযুক্ত করতে আপনার স্মৃতি এবং কথোপকথন পড়তে, অনুসন্ধান করতে এবং পরিচালনা করতে। শুরু করতে একটি কী তৈরি করুন।';
 
   @override
   String get apiKeys => 'API চাবি';
@@ -3565,8 +3506,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'নতুন স্পিকার স্বয়ংক্রিয়ভাবে তৈরি এবং ট্যাগ করুন';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'ট্রান্সক্রিপ্টে একটি নাম সনাক্ত হলে স্বয়ংক্রিয়ভাবে একটি নতুন ব্যক্তি তৈরি করুন।';
+  String get automaticallyCreateNewPerson => 'ট্রান্সক্রিপ্টে একটি নাম সনাক্ত হলে স্বয়ংক্রিয়ভাবে একটি নতুন ব্যক্তি তৈরি করুন।';
 
   @override
   String get pilotFeatures => 'পাইলট বৈশিষ্ট্য';
@@ -3675,8 +3615,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get preparingSystemAudioCapture => 'সিস্টেম অডিও ক্যাপচার প্রস্তুত করা হচ্ছে';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'লাইভ ট্রান্সক্রিপ্ট, AI অন্তর্দৃষ্টি এবং স্বয়ংক্রিয় সংরক্ষণের জন্য অডিও ক্যাপচার করতে বোতাম ক্লিক করুন।';
+  String get clickTheButtonToCaptureAudio => 'লাইভ ট্রান্সক্রিপ্ট, AI অন্তর্দৃষ্টি এবং স্বয়ংক্রিয় সংরক্ষণের জন্য অডিও ক্যাপচার করতে বোতাম ক্লিক করুন।';
 
   @override
   String get reconnecting => 'পুনরায় সংযোগ করা হচ্ছে...';
@@ -3903,8 +3842,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'জ্ঞান গ্রাফ মুছবেন?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'এটি সমস্ত উদ্ভূত জ্ঞান গ্রাফ ডেটা মুছে ফেলবে। আপনার মূল স্মৃতি নিরাপদ থাকে।';
+  String get deleteKnowledgeGraphWarning => 'এটি সমস্ত উদ্ভূত জ্ঞান গ্রাফ ডেটা মুছে ফেলবে। আপনার মূল স্মৃতি নিরাপদ থাকে।';
 
   @override
   String get connectOmiWithAI => 'Omi কে AI সহায়কদের সাথে সংযুক্ত করুন';
@@ -3961,8 +3899,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get updateAppQuestion => 'অ্যাপ আপডেট করবেন?';
 
   @override
-  String get updateAppConfirmation =>
-      'আপনি কি আপনার অ্যাপ আপডেট করতে চান? আমাদের দল দ্বারা পর্যালোচনা করার পরে পরিবর্তনগুলি প্রতিফলিত হবে।';
+  String get updateAppConfirmation => 'আপনি কি আপনার অ্যাপ আপডেট করতে চান? আমাদের দল দ্বারা পর্যালোচনা করার পরে পরিবর্তনগুলি প্রতিফলিত হবে।';
 
   @override
   String get updateApp => 'অ্যাপ আপডেট করুন';
@@ -3992,8 +3929,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get no => 'না';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'সাবস্ক্রিপশন সফলভাবে বাতিল করা হয়েছে। এটি বর্তমান বিলিং সময়ের শেষ পর্যন্ত সক্রিয় থাকবে।';
+  String get subscriptionCancelledSuccessfully => 'সাবস্ক্রিপশন সফলভাবে বাতিল করা হয়েছে। এটি বর্তমান বিলিং সময়ের শেষ পর্যন্ত সক্রিয় থাকবে।';
 
   @override
   String get failedToCancelSubscription => 'সাবস্ক্রিপশন বাতিল করতে ব্যর্থ। অনুগ্রহ করে আবার চেষ্টা করুন।';
@@ -4029,8 +3965,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'সাবস্ক্রিপশন বাতিল করবেন?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'আপনি কি আপনার সাবস্ক্রিপশন বাতিল করতে চান? আপনি আপনার বর্তমান বিলিং সময়ের শেষ পর্যন্ত অ্যাক্সেস চালিয়ে যাবেন।';
+  String get cancelSubscriptionConfirmation => 'আপনি কি আপনার সাবস্ক্রিপশন বাতিল করতে চান? আপনি আপনার বর্তমান বিলিং সময়ের শেষ পর্যন্ত অ্যাক্সেস চালিয়ে যাবেন।';
 
   @override
   String get cancelSubscriptionButton => 'সাবস্ক্রিপশন বাতিল করুন';
@@ -4039,16 +3974,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get cancelling => 'বাতিল করা হচ্ছে...';
 
   @override
-  String get betaTesterMessage =>
-      'আপনি এই অ্যাপের একজন বিটা পরীক্ষক। এটি এখনও জনসাধারণের জন্য নেই। অনুমোদিত হলে এটি জনসাধারণের জন্য থাকবে।';
+  String get betaTesterMessage => 'আপনি এই অ্যাপের একজন বিটা পরীক্ষক। এটি এখনও জনসাধারণের জন্য নেই। অনুমোদিত হলে এটি জনসাধারণের জন্য থাকবে।';
 
   @override
-  String get appUnderReviewMessage =>
-      'আপনার অ্যাপ পর্যালোচনার অধীন এবং শুধুমাত্র আপনার কাছে দৃশ্যমান। অনুমোদিত হলে এটি জনসাধারণের জন্য থাকবে।';
+  String get appUnderReviewMessage => 'আপনার অ্যাপ পর্যালোচনার অধীন এবং শুধুমাত্র আপনার কাছে দৃশ্যমান। অনুমোদিত হলে এটি জনসাধারণের জন্য থাকবে।';
 
   @override
-  String get appRejectedMessage =>
-      'আপনার অ্যাপ প্রত্যাখ্যান করা হয়েছে। অনুগ্রহ করে অ্যাপের বিবরণ আপডেট করুন এবং পর্যালোচনার জন্য পুনরায় জমা দিন।';
+  String get appRejectedMessage => 'আপনার অ্যাপ প্রত্যাখ্যান করা হয়েছে। অনুগ্রহ করে অ্যাপের বিবরণ আপডেট করুন এবং পর্যালোচনার জন্য পুনরায় জমা দিন।';
 
   @override
   String get invalidIntegrationUrl => 'অকার্যকর ইন্টিগ্রেশন URL';
@@ -4102,8 +4034,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get issueActivatingApp => 'এই অ্যাপ সক্রিয় করতে একটি সমস্যা হয়েছিল। অনুগ্রহ করে আবার চেষ্টা করুন।';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'এই অ্যাপ আপনার ডেটা অ্যাক্সেস করবে। Omi AI এই অ্যাপটি আপনার ডেটা কীভাবে ব্যবহার, সংশোধন বা মুছে ফেলে তার জন্য দায়বদ্ধ নয়';
+  String get dataAccessNoticeDescription => 'এই অ্যাপ আপনার ডেটা অ্যাক্সেস করবে। Omi AI এই অ্যাপটি আপনার ডেটা কীভাবে ব্যবহার, সংশোধন বা মুছে ফেলে তার জন্য দায়বদ্ধ নয়';
 
   @override
   String get copyUrl => 'URL কপি করুন';
@@ -4191,8 +4122,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get omiApiKeys => 'Omi API চাবি';
 
   @override
-  String get apiKeysDescription =>
-      'API চাবি ব্যবহার করা হয় যখন আপনার অ্যাপ OMI সার্ভারের সাথে যোগাযোগ করে প্রমাণীকরণের জন্য। তারা আপনার অ্যাপ্লিকেশনকে স্মৃতি তৈরি করতে এবং অন্যান্য OMI সেবা নিরাপদে অ্যাক্সেস করতে দেয়।';
+  String get apiKeysDescription => 'API চাবি ব্যবহার করা হয় যখন আপনার অ্যাপ OMI সার্ভারের সাথে যোগাযোগ করে প্রমাণীকরণের জন্য। তারা আপনার অ্যাপ্লিকেশনকে স্মৃতি তৈরি করতে এবং অন্যান্য OMI সেবা নিরাপদে অ্যাক্সেস করতে দেয়।';
 
   @override
   String get aboutOmiApiKeys => 'Omi API চাবি সম্পর্কে';
@@ -4216,8 +4146,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API চাবি প্রত্যাহার করবেন?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'এই পদক্ষেপ পূর্বাবস্থায় ফেরানো যায় না। এই চাবি ব্যবহার করে কোনো অ্যাপ্লিকেশন API অ্যাক্সেস করতে পারবে না।';
+  String get revokeApiKeyWarning => 'এই পদক্ষেপ পূর্বাবস্থায় ফেরানো যায় না। এই চাবি ব্যবহার করে কোনো অ্যাপ্লিকেশন API অ্যাক্সেস করতে পারবে না।';
 
   @override
   String get revoke => 'প্রত্যাহার করুন';
@@ -4306,8 +4235,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get keyCreated => 'চাবি তৈরি হয়েছে';
 
   @override
-  String get keyCreatedMessage =>
-      'আপনার নতুন চাবি তৈরি করা হয়েছে। অনুগ্রহ করে এখন এটি কপি করুন। আপনি এটি আর দেখতে পাবেন না।';
+  String get keyCreatedMessage => 'আপনার নতুন চাবি তৈরি করা হয়েছে। অনুগ্রহ করে এখন এটি কপি করুন। আপনি এটি আর দেখতে পাবেন না।';
 
   @override
   String get keyWord => 'চাবি';
@@ -4316,8 +4244,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get externalAppAccess => 'বাহ্যিক অ্যাপ অ্যাক্সেস';
 
   @override
-  String get externalAppAccessDescription =>
-      'নিম্নলিখিত ইনস্টল করা অ্যাপগুলির বাহ্যিক ইন্টিগ্রেশন রয়েছে এবং আপনার কথোপকথন এবং স্মৃতি সহ আপনার ডেটা অ্যাক্সেস করতে পারে।';
+  String get externalAppAccessDescription => 'নিম্নলিখিত ইনস্টল করা অ্যাপগুলির বাহ্যিক ইন্টিগ্রেশন রয়েছে এবং আপনার কথোপকথন এবং স্মৃতি সহ আপনার ডেটা অ্যাক্সেস করতে পারে।';
 
   @override
   String get noExternalAppsHaveAccess => 'কোনো বাহ্যিক অ্যাপের আপনার ডেটায় অ্যাক্সেস নেই।';
@@ -4326,8 +4253,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get maximumSecurityE2ee => 'সর্বোচ্চ নিরাপত্তা (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'এন্ড-টু-এন্ড এনক্রিপশন গোপনীয়তার স্বর্ণ মান। সক্ষম হলে, আপনার ডেটা আপনার ডিভাইসে এনক্রিপ্ট করা হয় তারপর আমাদের সার্ভারে পাঠানো হয়। এর মানে কেউ, এমনকি Omi ও, আপনার বিষয়বস্তু অ্যাক্সেস করতে পারে না।';
+  String get e2eeDescription => 'এন্ড-টু-এন্ড এনক্রিপশন গোপনীয়তার স্বর্ণ মান। সক্ষম হলে, আপনার ডেটা আপনার ডিভাইসে এনক্রিপ্ট করা হয় তারপর আমাদের সার্ভারে পাঠানো হয়। এর মানে কেউ, এমনকি Omi ও, আপনার বিষয়বস্তু অ্যাক্সেস করতে পারে না।';
 
   @override
   String get importantTradeoffs => 'গুরুত্বপূর্ণ পারস্পরিক সম্পর্ক:';
@@ -4342,8 +4268,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get featureComingSoon => 'এই বৈশিষ্ট্য শীঘ্রই আসছে!';
 
   @override
-  String get migrationInProgressMessage =>
-      'স্থানান্তর চলছে। এটি সম্পূর্ণ না হওয়া পর্যন্ত আপনি সুরক্ষা স্তর পরিবর্তন করতে পারবেন না।';
+  String get migrationInProgressMessage => 'স্থানান্তর চলছে। এটি সম্পূর্ণ না হওয়া পর্যন্ত আপনি সুরক্ষা স্তর পরিবর্তন করতে পারবেন না।';
 
   @override
   String get migrationFailed => 'স্থানান্তর ব্যর্থ';
@@ -4362,15 +4287,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get secureEncryption => 'নিরাপদ এনক্রিপশন';
 
   @override
-  String get secureEncryptionDescription =>
-      'আপনার ডেটা Google Cloud-এ হোস্ট করা আমাদের সার্ভারে আপনার জন্য অনন্য একটি চাবি দিয়ে এনক্রিপ্ট করা হয়। এর মানে আপনার কাঁচা বিষয়বস্তু কেউ নয়, এমনকি Omi কর্মীরা বা Google, ডাটাবেস থেকে সরাসরি অ্যাক্সেস করতে পারে না।';
+  String get secureEncryptionDescription => 'আপনার ডেটা Google Cloud-এ হোস্ট করা আমাদের সার্ভারে আপনার জন্য অনন্য একটি চাবি দিয়ে এনক্রিপ্ট করা হয়। এর মানে আপনার কাঁচা বিষয়বস্তু কেউ নয়, এমনকি Omi কর্মীরা বা Google, ডাটাবেস থেকে সরাসরি অ্যাক্সেস করতে পারে না।';
 
   @override
   String get endToEndEncryption => 'এন্ড-টু-এন্ড এনক্রিপশন';
 
   @override
-  String get e2eeCardDescription =>
-      'সর্বোচ্চ নিরাপত্তার জন্য সক্ষম করুন যেখানে শুধুমাত্র আপনি আপনার ডেটা অ্যাক্সেস করতে পারেন। আরও জানতে ট্যাপ করুন।';
+  String get e2eeCardDescription => 'সর্বোচ্চ নিরাপত্তার জন্য সক্ষম করুন যেখানে শুধুমাত্র আপনি আপনার ডেটা অ্যাক্সেস করতে পারেন। আরও জানতে ট্যাপ করুন।';
 
   @override
   String get dataAlwaysEncrypted => 'স্তর নির্বিশেষে, আপনার ডেটা সর্বদা বিশ্রামে এবং রূপান্তরে এনক্রিপ্ট করা হয়।';
@@ -4441,8 +4364,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get getOmiUnlimitedFree => 'AI মডেল প্রশিক্ষণের জন্য আপনার ডেটা অবদান রেখে বিনামূল্যে Omi Unlimited পান।';
 
   @override
-  String get trainingDataBullets =>
-      '• আপনার ডেটা AI মডেল উন্নত করতে সাহায্য করে\n• শুধুমাত্র অ-সংবেদনশীল ডেটা শেয়ার করা হয়\n• সম্পূর্ণ স্বচ্ছ প্রক্রিয়া';
+  String get trainingDataBullets => '• আপনার ডেটা AI মডেল উন্নত করতে সাহায্য করে\n• শুধুমাত্র অ-সংবেদনশীল ডেটা শেয়ার করা হয়\n• সম্পূর্ণ স্বচ্ছ প্রক্রিয়া';
 
   @override
   String get learnMoreAtOmiTraining => 'omi.me/training এ আরও জানুন';
@@ -4454,8 +4376,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get submitRequest => 'অনুরোধ জমা দিন';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'ধন্যবাদ! আপনার অনুরোধ পর্যালোচনার অধীন। অনুমোদিত হলে আমরা আপনাকে সূচিত করব।';
+  String get thankYouRequestUnderReview => 'ধন্যবাদ! আপনার অনুরোধ পর্যালোচনার অধীন। অনুমোদিত হলে আমরা আপনাকে সূচিত করব।';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4493,8 +4414,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get monthlyPlanContinues => 'আপনার বর্তমান মাসিক পরিকল্পনা আপনার বিলিং সময়কালের শেষ পর্যন্ত চলতে থাকবে';
 
   @override
-  String get paymentMethodCharged =>
-      'আপনার বিদ্যমান পেমেন্ট পদ্ধতি আপনার মাসিক পরিকল্পনা শেষ হলে স্বয়ংক্রিয়ভাবে চার্জ করা হবে';
+  String get paymentMethodCharged => 'আপনার বিদ্যমান পেমেন্ট পদ্ধতি আপনার মাসিক পরিকল্পনা শেষ হলে স্বয়ংক্রিয়ভাবে চার্জ করা হবে';
 
   @override
   String get annualSubscriptionStarts => 'চার্জের পরে আপনার ১২-মাসের বার্ষিক সাবস্ক্রিপশন স্বয়ংক্রিয়ভাবে শুরু হবে';
@@ -4537,8 +4457,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'আপনার মাসিক পরিকল্পনা শেষ হলে আপনার বার্ষিক পরিকল্পনা স্বয়ংক্রিয়ভাবে শুরু হবে।';
+  String get annualPlanStartsAutomatically => 'আপনার মাসিক পরিকল্পনা শেষ হলে আপনার বার্ষিক পরিকল্পনা স্বয়ংক্রিয়ভাবে শুরু হবে।';
 
   @override
   String planRenewsOn(String date) {
@@ -4605,8 +4524,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'আপনার গোপনীয়তা আমাদের কাছে গুরুত্বপূর্ণ';
 
   @override
-  String get privacyIntroText =>
-      'Omi-তে, আমরা আপনার গোপনীয়তাকে অত্যন্ত গুরুত্ব সহকারে নিই। আমরা আমরা যে ডেটা সংগ্রহ করি এবং কীভাবে এটি ব্যবহার করি সে সম্পর্কে স্বচ্ছ হতে চাই আপনার পণ্য উন্নত করতে। এখানে আপনার যা জানা দরকার:';
+  String get privacyIntroText => 'Omi-তে, আমরা আপনার গোপনীয়তাকে অত্যন্ত গুরুত্ব সহকারে নিই। আমরা আমরা যে ডেটা সংগ্রহ করি এবং কীভাবে এটি ব্যবহার করি সে সম্পর্কে স্বচ্ছ হতে চাই আপনার পণ্য উন্নত করতে। এখানে আপনার যা জানা দরকার:';
 
   @override
   String get whatWeTrack => 'আমরা কী ট্র্যাক করি';
@@ -4621,12 +4539,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get ourCommitment => 'আমাদের প্রতিশ্রুতি';
 
   @override
-  String get commitmentText =>
-      'আমরা আমরা যে ডেটা সংগ্রহ করি তা শুধুমাত্র Omi কে আপনার জন্য একটি ভাল পণ্য করতে ব্যবহার করতে প্রতিশ্রুতিবদ্ধ। আপনার গোপনীয়তা এবং বিশ্বাস আমাদের কাছে সর্বোচ্চ।';
+  String get commitmentText => 'আমরা আমরা যে ডেটা সংগ্রহ করি তা শুধুমাত্র Omi কে আপনার জন্য একটি ভাল পণ্য করতে ব্যবহার করতে প্রতিশ্রুতিবদ্ধ। আপনার গোপনীয়তা এবং বিশ্বাস আমাদের কাছে সর্বোচ্চ।';
 
   @override
-  String get thankYouText =>
-      'Omi এর একজন মূল্যবান ব্যবহারকারী হওয়ার জন্য ধন্যবাদ। যদি আপনার কোনো প্রশ্ন বা উদ্বেগ থাকে তবে আমাদের সাথে যোগাযোগ করুন team@basedhardware.com।';
+  String get thankYouText => 'Omi এর একজন মূল্যবান ব্যবহারকারী হওয়ার জন্য ধন্যবাদ। যদি আপনার কোনো প্রশ্ন বা উদ্বেগ থাকে তবে আমাদের সাথে যোগাযোগ করুন team@basedhardware.com।';
 
   @override
   String get wifiSyncSettings => 'WiFi সিঙ্ক সেটিংস';
@@ -4635,8 +4551,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get enterHotspotCredentials => 'আপনার ফোনের হটস্পট শংসাপত্র প্রবেশ করুন';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi সিঙ্ক আপনার ফোনকে হটস্পট হিসাবে ব্যবহার করে। আপনার হটস্পট নাম এবং পাসওয়ার্ড খুঁজুন সেটিংস > ব্যক্তিগত হটস্পট এ।';
+  String get wifiSyncUsesHotspot => 'WiFi সিঙ্ক আপনার ফোনকে হটস্পট হিসাবে ব্যবহার করে। আপনার হটস্পট নাম এবং পাসওয়ার্ড খুঁজুন সেটিংস > ব্যক্তিগত হটস্পট এ।';
 
   @override
   String get hotspotNameSsid => 'হটস্পট নাম (SSID)';
@@ -4671,8 +4586,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'সারাংশ তৈরি করতে ব্যর্থ। নিশ্চিত করুন যে সেই দিনের জন্য আপনার কথোপকথন আছে।';
+  String get failedToGenerateSummaryCheckConversations => 'সারাংশ তৈরি করতে ব্যর্থ। নিশ্চিত করুন যে সেই দিনের জন্য আপনার কথোপকথন আছে।';
 
   @override
   String get summaryNotFound => 'সারাংশ পাওয়া যায়নি';
@@ -4702,8 +4616,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'রপ্তানি শুরু হয়েছে। এটি কয়েক সেকেন্ড সময় নিতে পারে...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'এটি সমস্ত উদ্ভূত জ্ঞান গ্রাফ ডেটা (নোড এবং সংযোগ) মুছে ফেলবে। আপনার মূল স্মৃতি নিরাপদ থাকবে। গ্রাফ সময়ের সাথে বা পরবর্তী অনুরোধে পুনর্নির্মাণ করা হবে।';
+  String get knowledgeGraphDeleteDescription => 'এটি সমস্ত উদ্ভূত জ্ঞান গ্রাফ ডেটা (নোড এবং সংযোগ) মুছে ফেলবে। আপনার মূল স্মৃতি নিরাপদ থাকবে। গ্রাফ সময়ের সাথে বা পরবর্তী অনুরোধে পুনর্নির্মাণ করা হবে।';
 
   @override
   String get configureDailySummaryDigest => 'আপনার দৈনিক পদক্ষেপ আইটেম পাচন কনফিগার করুন';
@@ -4773,8 +4686,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'সমস্ত Limitless কথোপকথন মুছুন?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'এটি Limitless থেকে আমদানি করা সমস্ত কথোপকথন স্থায়ীভাবে মুছে ফেলবে। এই পদক্ষেপ পূর্বাবাস করা যায় না।';
+  String get deleteAllLimitlessWarning => 'এটি Limitless থেকে আমদানি করা সমস্ত কথোপকথন স্থায়ীভাবে মুছে ফেলবে। এই পদক্ষেপ পূর্বাবাস করা যায় না।';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4830,8 +4742,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get howItWorksTitle => 'এটি কীভাবে কাজ করে?';
 
   @override
-  String get howPeopleWorks =>
-      'একবার একজন ব্যক্তি তৈরি হলে, আপনি একটি কথোপকথন ট্রান্সক্রিপ্টে যেতে পারেন এবং তাদের সংশ্লিষ্ট সেগমেন্ট বরাদ্দ করতে পারেন, এইভাবে Omi তাদের বক্তৃতাও চিনতে সক্ষম হবে!';
+  String get howPeopleWorks => 'একবার একজন ব্যক্তি তৈরি হলে, আপনি একটি কথোপকথন ট্রান্সক্রিপ্টে যেতে পারেন এবং তাদের সংশ্লিষ্ট সেগমেন্ট বরাদ্দ করতে পারেন, এইভাবে Omi তাদের বক্তৃতাও চিনতে সক্ষম হবে!';
 
   @override
   String get tapToDelete => 'মুছতে ট্যাপ করুন';
@@ -4857,8 +4768,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get privacyNotice => 'গোপনীয়তা নোটিশ';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'রেকর্ডিংগুলি অন্যদের কণ্ঠস্বর ক্যাপচার করতে পারে। সক্ষম করার আগে সমস্ত অংশগ্রহণকারীদের কাছ থেকে সম্মতি নিশ্চিত করুন।';
+  String get recordingsMayCaptureOthers => 'রেকর্ডিংগুলি অন্যদের কণ্ঠস্বর ক্যাপচার করতে পারে। সক্ষম করার আগে সমস্ত অংশগ্রহণকারীদের কাছ থেকে সম্মতি নিশ্চিত করুন।';
 
   @override
   String get enable => 'সক্ষম করুন';
@@ -4870,8 +4780,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get on => 'চালু';
 
   @override
-  String get storeAudioDescription =>
-      'সমস্ত অডিও রেকর্ডিং আপনার ফোনে স্থানীয়ভাবে সংরক্ষণ করুন। নিষ্ক্রিয় হলে, শুধুমাত্র ব্যর্থ আপলোডগুলি স্টোরেজ স্থান সাশ্রয় করার জন্য রাখা হয়।';
+  String get storeAudioDescription => 'সমস্ত অডিও রেকর্ডিং আপনার ফোনে স্থানীয়ভাবে সংরক্ষণ করুন। নিষ্ক্রিয় হলে, শুধুমাত্র ব্যর্থ আপলোডগুলি স্টোরেজ স্থান সাশ্রয় করার জন্য রাখা হয়।';
 
   @override
   String get enableLocalStorage => 'স্থানীয় স্টোরেজ সক্ষম করুন';
@@ -4889,12 +4798,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get storeAudioOnCloud => 'ক্লাউডে অডিও সংরক্ষণ করুন';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'আপনার রিয়েল-টাইম রেকর্ডিংগুলি আপনি কথা বলার সাথে সাথে ব্যক্তিগত ক্লাউড স্টোরেজে সংরক্ষিত হবে।';
+  String get cloudStorageDialogMessage => 'আপনার রিয়েল-টাইম রেকর্ডিংগুলি আপনি কথা বলার সাথে সাথে ব্যক্তিগত ক্লাউড স্টোরেজে সংরক্ষিত হবে।';
 
   @override
-  String get storeAudioCloudDescription =>
-      'আপনার রিয়েল-টাইম রেকর্ডিংগুলি আপনি কথা বলার সাথে সাথে ব্যক্তিগত ক্লাউড স্টোরেজে সংরক্ষণ করুন। অডিও রিয়েল-টাইমে সুরক্ষিতভাবে ক্যাপচার এবং সংরক্ষিত হয়।';
+  String get storeAudioCloudDescription => 'আপনার রিয়েল-টাইম রেকর্ডিংগুলি আপনি কথা বলার সাথে সাথে ব্যক্তিগত ক্লাউড স্টোরেজে সংরক্ষণ করুন। অডিও রিয়েল-টাইমে সুরক্ষিতভাবে ক্যাপচার এবং সংরক্ষিত হয়।';
 
   @override
   String get downloadingFirmware => 'ফার্মওয়্যার ডাউনলোড করা হচ্ছে';
@@ -4903,8 +4810,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get installingFirmware => 'ফার্মওয়্যার ইনস্টল করা হচ্ছে';
 
   @override
-  String get firmwareUpdateWarning =>
-      'অ্যাপ বন্ধ করবেন না বা ডিভাইস বন্ধ করবেন না। এটি আপনার ডিভাইস ক্ষতিগ্রস্ত করতে পারে।';
+  String get firmwareUpdateWarning => 'অ্যাপ বন্ধ করবেন না বা ডিভাইস বন্ধ করবেন না। এটি আপনার ডিভাইস ক্ষতিগ্রস্ত করতে পারে।';
 
   @override
   String get firmwareUpdated => 'ফার্মওয়্যার আপডেট হয়েছে';
@@ -4948,8 +4854,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get payments => 'পেমেন্ট';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'আপনার অ্যাপের জন্য অর্থ প্রাপ্ত করা শুরু করতে নীচে একটি পেমেন্ট পদ্ধতি সংযোগ করুন।';
+  String get connectPaymentMethodInfo => 'আপনার অ্যাপের জন্য অর্থ প্রাপ্ত করা শুরু করতে নীচে একটি পেমেন্ট পদ্ধতি সংযোগ করুন।';
 
   @override
   String get selectedPaymentMethod => 'নির্বাচিত পেমেন্ট পদ্ধতি';
@@ -4976,8 +4881,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get monthlyPayouts => 'মাসিক পেআউট';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'যখন আপনি \$১০ এর উপার্জনে পৌঁছাবেন তখন আপনার অ্যাকাউন্টে সরাসরি মাসিক পেমেন্ট পান';
+  String get monthlyPayoutsDescription => 'যখন আপনি \$১০ এর উপার্জনে পৌঁছাবেন তখন আপনার অ্যাকাউন্টে সরাসরি মাসিক পেমেন্ট পান';
 
   @override
   String get secureAndReliable => 'নিরাপদ এবং নির্ভরযোগ্য';
@@ -5004,8 +4908,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get connectingYourStripeAccount => 'আপনার Stripe অ্যাকাউন্ট সংযোগ করা হচ্ছে';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'দয়া করে আপনার ব্রাউজারে Stripe অনবোর্ডিং প্রক্রিয়া সম্পন্ন করুন। এই পৃষ্ঠাটি সম্পন্ন হলে স্বয়ংক্রিয়ভাবে আপডেট হবে।';
+  String get stripeOnboardingInstructions => 'দয়া করে আপনার ব্রাউজারে Stripe অনবোর্ডিং প্রক্রিয়া সম্পন্ন করুন। এই পৃষ্ঠাটি সম্পন্ন হলে স্বয়ংক্রিয়ভাবে আপডেট হবে।';
 
   @override
   String get failedTryAgain => 'ব্যর্থ? আবার চেষ্টা করুন';
@@ -5017,8 +4920,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get successfullyConnected => 'সফলভাবে সংযুক্ত!';
 
   @override
-  String get stripeReadyForPayments =>
-      'আপনার Stripe অ্যাকাউন্ট এখন পেমেন্ট পেতে প্রস্তুত। আপনি আপনার অ্যাপ বিক্রয় থেকে অবিলম্বে উপার্জন শুরু করতে পারেন।';
+  String get stripeReadyForPayments => 'আপনার Stripe অ্যাকাউন্ট এখন পেমেন্ট পেতে প্রস্তুত। আপনি আপনার অ্যাপ বিক্রয় থেকে অবিলম্বে উপার্জন শুরু করতে পারেন।';
 
   @override
   String get updateStripeDetails => 'Stripe বিবরণ আপডেট করুন';
@@ -5045,8 +4947,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me লিঙ্ক';
 
   @override
-  String get stripeRecommendation =>
-      'যদি আপনার দেশে Stripe উপলব্ধ থাকে তবে আমরা দ্রুত এবং সহজ পেআউটের জন্য এটি ব্যবহার করার জন্য দৃঢ়ভাবে সুপারিশ করি।';
+  String get stripeRecommendation => 'যদি আপনার দেশে Stripe উপলব্ধ থাকে তবে আমরা দ্রুত এবং সহজ পেআউটের জন্য এটি ব্যবহার করার জন্য দৃঢ়ভাবে সুপারিশ করি।';
 
   @override
   String get updatePayPalDetails => 'PayPal বিবরণ আপডেট করুন';
@@ -5098,12 +4999,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'অতিরিক্ত বক্তৃতা নমুনা সরানো হয়েছে';
 
   @override
-  String get consentDataMessage =>
-      'চালিয়ে যাওয়ার মাধ্যমে, আপনার কথোপকথন, রেকর্ডিং এবং ব্যক্তিগত তথ্য আমাদের সার্ভারে নিরাপদে সংরক্ষণ করা হবে। আপনার অডিও রেকর্ডিং এবং ট্রান্সক্রিপ্ট তৃতীয় পক্ষের AI পরিষেবা দ্বারা প্রক্রিয়া করা হয় (ট্রান্সক্রিপশনের জন্য Deepgram এবং বিশ্লেষণের জন্য OpenAI সহ) যাতে আপনাকে AI-চালিত অন্তর্দৃষ্টি প্রদান করা যায় এবং সমস্ত অ্যাপ বৈশিষ্ট্য সক্ষম করা যায়।';
+  String get consentDataMessage => 'চালিয়ে যাওয়ার মাধ্যমে, আপনার কথোপকথন, রেকর্ডিং এবং ব্যক্তিগত তথ্য আমাদের সার্ভারে নিরাপদে সংরক্ষণ করা হবে। আপনার অডিও রেকর্ডিং এবং ট্রান্সক্রিপ্ট তৃতীয় পক্ষের AI পরিষেবা দ্বারা প্রক্রিয়া করা হয় (ট্রান্সক্রিপশনের জন্য Deepgram এবং বিশ্লেষণের জন্য OpenAI সহ) যাতে আপনাকে AI-চালিত অন্তর্দৃষ্টি প্রদান করা যায় এবং সমস্ত অ্যাপ বৈশিষ্ট্য সক্ষম করা যায়।';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'আপনার কথোপকথন থেকে কাজগুলি এখানে উপস্থিত হবে।\\nম্যানুয়ালি একটি তৈরি করতে + ট্যাপ করুন।';
+  String get tasksEmptyStateMessage => 'আপনার কথোপকথন থেকে কাজগুলি এখানে উপস্থিত হবে।\\nম্যানুয়ালি একটি তৈরি করতে + ট্যাপ করুন।';
 
   @override
   String get clearChatAction => 'চ্যাট সাফ করুন';
@@ -5139,15 +5038,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get installOmiOnAppleWatch => 'আপনার Apple Watch এ Omi ইনস্টল করুন';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'আপনার Apple Watch এর সাথে Omi ব্যবহার করতে, আপনাকে প্রথমে আপনার ঘড়িতে Omi অ্যাপ্লিকেশন ইনস্টল করতে হবে।';
+  String get installOmiOnAppleWatchDescription => 'আপনার Apple Watch এর সাথে Omi ব্যবহার করতে, আপনাকে প্রথমে আপনার ঘড়িতে Omi অ্যাপ্লিকেশন ইনস্টল করতে হবে।';
 
   @override
   String get openOmiOnAppleWatch => 'আপনার Apple Watch এ Omi খুলুন';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi অ্যাপ্লিকেশন আপনার Apple Watch এ ইনস্টল করা হয়েছে। এটি খুলুন এবং শুরু করতে শুরু ট্যাপ করুন।';
+  String get openOmiOnAppleWatchDescription => 'Omi অ্যাপ্লিকেশন আপনার Apple Watch এ ইনস্টল করা হয়েছে। এটি খুলুন এবং শুরু করতে শুরু ট্যাপ করুন।';
 
   @override
   String get openWatchApp => 'Watch অ্যাপ খুলুন';
@@ -5156,15 +5053,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'আমি অ্যাপ্লিকেশন ইনস্টল এবং খুলেছি';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch অ্যাপ খুলতে অক্ষম। দয়া করে আপনার Apple Watch এ Watch অ্যাপটি ম্যানুয়ালি খুলুন এবং \"উপলব্ধ অ্যাপ্লিকেশন\" বিভাগ থেকে Omi ইনস্টল করুন।';
+  String get unableToOpenWatchApp => 'Apple Watch অ্যাপ খুলতে অক্ষম। দয়া করে আপনার Apple Watch এ Watch অ্যাপটি ম্যানুয়ালি খুলুন এবং \"উপলব্ধ অ্যাপ্লিকেশন\" বিভাগ থেকে Omi ইনস্টল করুন।';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch সফলভাবে সংযুক্ত!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch এখনও পৌঁছানো যায় না। দয়া করে নিশ্চিত করুন যে Omi অ্যাপ্লিকেশন আপনার ঘড়িতে খোলা আছে।';
+  String get appleWatchNotReachable => 'Apple Watch এখনও পৌঁছানো যায় না। দয়া করে নিশ্চিত করুন যে Omi অ্যাপ্লিকেশন আপনার ঘড়িতে খোলা আছে।';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5181,8 +5076,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get finishedConversation => 'কথোপকথন শেষ?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'আপনি কি নিশ্চিত যে আপনি রেকর্ডিং বন্ধ করতে এবং এখনই কথোপকথন সংক্ষিপ্ত করতে চান?';
+  String get stopRecordingConfirmation => 'আপনি কি নিশ্চিত যে আপনি রেকর্ডিং বন্ধ করতে এবং এখনই কথোপকথন সংক্ষিপ্ত করতে চান?';
 
   @override
   String get conversationEndsManually => 'কথোপকথন শুধুমাত্র ম্যানুয়ালি শেষ হবে।';
@@ -5593,29 +5487,25 @@ class AppLocalizationsBn extends AppLocalizations {
   String get multipleSpeakersDetected => 'একাধিক স্পিকার সনাক্ত করা হয়েছে';
 
   @override
-  String get multipleSpeakersDescription =>
-      'মনে হয় রেকর্ডিংয়ে একাধিক স্পিকার রয়েছে। দয়া করে নিশ্চিত করুন যে আপনি একটি শান্ত জায়গায় আছেন এবং আবার চেষ্টা করুন।';
+  String get multipleSpeakersDescription => 'মনে হয় রেকর্ডিংয়ে একাধিক স্পিকার রয়েছে। দয়া করে নিশ্চিত করুন যে আপনি একটি শান্ত জায়গায় আছেন এবং আবার চেষ্টা করুন।';
 
   @override
   String get invalidRecordingDetected => 'অবৈধ রেকর্ডিং সনাক্ত করা হয়েছে';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'পর্যাপ্ত বক্তৃতা সনাক্ত করা হয়নি। দয়া করে আরও কথা বলুন এবং আবার চেষ্টা করুন।';
+  String get notEnoughSpeechDescription => 'পর্যাপ্ত বক্তৃতা সনাক্ত করা হয়নি। দয়া করে আরও কথা বলুন এবং আবার চেষ্টা করুন।';
 
   @override
   String get speechDurationDescription => 'নিশ্চিত করুন যে আপনি অন্তত ৫ সেকেন্ড এবং ৯০ সেকেন্ডের বেশি কথা বলছেন না।';
 
   @override
-  String get connectionLostDescription =>
-      'সংযোগ বাধাগ্রস্ত হয়েছে। আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।';
+  String get connectionLostDescription => 'সংযোগ বাধাগ্রস্ত হয়েছে। আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।';
 
   @override
   String get howToTakeGoodSample => 'একটি ভাল স্যাম্পল কীভাবে নিতে হয়?';
 
   @override
-  String get goodSampleInstructions =>
-      '১. নিশ্চিত করুন যে আপনি একটি শান্ত জায়গায় আছেন।\n২. স্পষ্টভাবে এবং স্বাভাবিকভাবে কথা বলুন।\n३. আপনার ডিভাইস আপনার গলায় প্রাকৃতিক অবস্থানে আছে তা নিশ্চিত করুন।\n\nএটি তৈরি করার পর, আপনি যেকোনো সময় এটি উন্নত করতে বা আবার করতে পারেন।';
+  String get goodSampleInstructions => '১. নিশ্চিত করুন যে আপনি একটি শান্ত জায়গায় আছেন।\n২. স্পষ্টভাবে এবং স্বাভাবিকভাবে কথা বলুন।\n३. আপনার ডিভাইস আপনার গলায় প্রাকৃতিক অবস্থানে আছে তা নিশ্চিত করুন।\n\nএটি তৈরি করার পর, আপনি যেকোনো সময় এটি উন্নত করতে বা আবার করতে পারেন।';
 
   @override
   String get noDeviceConnectedUseMic => 'কোন ডিভাইস সংযুক্ত নেই। ফোন মাইক্রোফোন ব্যবহার করা হবে।';
@@ -5678,8 +5568,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get howItWorks => 'এটি কীভাবে কাজ করে';
 
   @override
-  String get dailyScoreExplanation =>
-      'আপনার দৈনিক স্কোর কাজ সম্পূর্ণতার উপর ভিত্তি করে। আপনার স্কোর উন্নত করতে আপনার কাজগুলি সম্পূর্ণ করুন!';
+  String get dailyScoreExplanation => 'আপনার দৈনিক স্কোর কাজ সম্পূর্ণতার উপর ভিত্তি করে। আপনার স্কোর উন্নত করতে আপনার কাজগুলি সম্পূর্ণ করুন!';
 
   @override
   String get notificationFrequencyDescription => 'Omi কতবার সক্রিয় বিজ্ঞপ্তি এবং অনুস্মারক পাঠায় তা নিয়ন্ত্রণ করুন।';
@@ -6056,15 +5945,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get cloudProvider => 'ক্লাউড প্রদানকারী';
 
   @override
-  String get premiumMinutesInfo =>
-      'প্রতি মাসে ১,২০০ প্রিমিয়াম মিনিট। অন-ডিভাইস ট্যাব আনলিমিটেড ফ্রি ট্রান্সক্রিপশন অফার করে।';
+  String get premiumMinutesInfo => 'প্রতি মাসে ১,২০০ প্রিমিয়াম মিনিট। অন-ডিভাইস ট্যাব আনলিমিটেড ফ্রি ট্রান্সক্রিপশন অফার করে।';
 
   @override
   String get viewUsage => 'ব্যবহার দেখুন';
 
   @override
-  String get localProcessingInfo =>
-      'অডিও স্থানীয়ভাবে প্রক্রিয়া করা হয়। অফলাইনে কাজ করে, আরও ব্যক্তিগত, কিন্তু আরও ব্যাটারি ব্যবহার করে।';
+  String get localProcessingInfo => 'অডিও স্থানীয়ভাবে প্রক্রিয়া করা হয়। অফলাইনে কাজ করে, আরও ব্যক্তিগত, কিন্তু আরও ব্যাটারি ব্যবহার করে।';
 
   @override
   String get model => 'মডেল';
@@ -6073,15 +5960,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get performanceWarning => 'কর্মক্ষমতা সতর্কতা';
 
   @override
-  String get largeModelWarning =>
-      'এই মডেল বড় এবং মোবাইল ডিভাইসে অ্যাপটি ক্র্যাশ করতে বা খুবই ধীরে চলতে পারে।\n\n\"ছোট\" বা \"বেস\" সুপারিশ করা হয়।';
+  String get largeModelWarning => 'এই মডেল বড় এবং মোবাইল ডিভাইসে অ্যাপটি ক্র্যাশ করতে বা খুবই ধীরে চলতে পারে।\n\n\"ছোট\" বা \"বেস\" সুপারিশ করা হয়।';
 
   @override
   String get usingNativeIosSpeech => 'নেটিভ iOS স্পিচ রিকগনিশন ব্যবহার করা হচ্ছে';
 
   @override
-  String get noModelDownloadRequired =>
-      'আপনার ডিভাইসের নেটিভ স্পিচ ইঞ্জিন ব্যবহার করা হবে। কোন মডেল ডাউনলোড প্রয়োজন নেই।';
+  String get noModelDownloadRequired => 'আপনার ডিভাইসের নেটিভ স্পিচ ইঞ্জিন ব্যবহার করা হবে। কোন মডেল ডাউনলোড প্রয়োজন নেই।';
 
   @override
   String get modelReady => 'মডেল প্রস্তুত';
@@ -6138,12 +6023,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get batteryDrainSignificantly => 'ব্যাটারি ড্রেইন উল্লেখযোগ্যভাবে বৃদ্ধি পাবে।';
 
   @override
-  String get premiumMinutesMonth =>
-      'প্রতি মাসে ১,২০০ প্রিমিয়াম মিনিট। অন-ডিভাইস ট্যাব আনলিমিটেড ফ্রি ট্রান্সক্রিপশন অফার করে।';
+  String get premiumMinutesMonth => 'প্রতি মাসে ১,২০০ প্রিমিয়াম মিনিট। অন-ডিভাইস ট্যাব আনলিমিটেড ফ্রি ট্রান্সক্রিপশন অফার করে।';
 
   @override
-  String get audioProcessedLocally =>
-      'অডিও স্থানীয়ভাবে প্রক্রিয়া করা হয়। অফলাইনে কাজ করে, আরও ব্যক্তিগত, কিন্তু আরও ব্যাটারি ব্যবহার করে।';
+  String get audioProcessedLocally => 'অডিও স্থানীয়ভাবে প্রক্রিয়া করা হয়। অফলাইনে কাজ করে, আরও ব্যক্তিগত, কিন্তু আরও ব্যাটারি ব্যবহার করে।';
 
   @override
   String get languageLabel => 'ভাষা';
@@ -6152,12 +6035,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get modelLabel => 'মডেল';
 
   @override
-  String get modelTooLargeWarning =>
-      'এই মডেল বড় এবং মোবাইল ডিভাইসে অ্যাপটি ক্র্যাশ করতে বা খুবই ধীরে চলতে পারে।\n\n\"ছোট\" বা \"বেস\" সুপারিশ করা হয়।';
+  String get modelTooLargeWarning => 'এই মডেল বড় এবং মোবাইল ডিভাইসে অ্যাপটি ক্র্যাশ করতে বা খুবই ধীরে চলতে পারে।\n\n\"ছোট\" বা \"বেস\" সুপারিশ করা হয়।';
 
   @override
-  String get nativeEngineNoDownload =>
-      'আপনার ডিভাইসের নেটিভ স্পিচ ইঞ্জিন ব্যবহার করা হবে। কোন মডেল ডাউনলোড প্রয়োজন নেই।';
+  String get nativeEngineNoDownload => 'আপনার ডিভাইসের নেটিভ স্পিচ ইঞ্জিন ব্যবহার করা হবে। কোন মডেল ডাউনলোড প্রয়োজন নেই।';
 
   @override
   String modelReadyWithName(String model) {
@@ -6193,8 +6074,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi-এর বিল্ট-ইন লাইভ ট্রান্সক্রিপশন স্বয়ংক্রিয় স্পিকার সনাক্তকরণ এবং ডায়ারাইজেশন সহ রিয়েল-টাইম কথোপকথনের জন্য অপ্টিমাইজ করা হয়েছে।';
+  String get omiTranscriptionOptimized => 'Omi-এর বিল্ট-ইন লাইভ ট্রান্সক্রিপশন স্বয়ংক্রিয় স্পিকার সনাক্তকরণ এবং ডায়ারাইজেশন সহ রিয়েল-টাইম কথোপকথনের জন্য অপ্টিমাইজ করা হয়েছে।';
 
   @override
   String get reset => 'রিসেট';
@@ -6414,8 +6294,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'স্মৃতি থেকে আপনার জ্ঞান গ্রাফ তৈরি করা হচ্ছে...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'আপনার জ্ঞান গ্রাফ স্বয়ংক্রিয়ভাবে তৈরি হবে যখন আপনি নতুন স্মৃতি তৈরি করবেন।';
+  String get knowledgeGraphWillBuildAutomatically => 'আপনার জ্ঞান গ্রাফ স্বয়ংক্রিয়ভাবে তৈরি হবে যখন আপনি নতুন স্মৃতি তৈরি করবেন।';
 
   @override
   String get buildGraphButton => 'গ্রাফ তৈরি করুন';
@@ -6651,8 +6530,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get failedToLoadContacts => 'যোগাযোগ লোড করতে ব্যর্থ';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'শেয়ারিংয়ের জন্য কথোপকথন প্রস্তুত করতে ব্যর্থ। দয়া করে আবার চেষ্টা করুন।';
+  String get failedToPrepareConversationForSharing => 'শেয়ারিংয়ের জন্য কথোপকথন প্রস্তুত করতে ব্যর্থ। দয়া করে আবার চেষ্টা করুন।';
 
   @override
   String get couldNotOpenSmsApp => 'SMS অ্যাপ খুলতে পারেনি। দয়া করে আবার চেষ্টা করুন।';
@@ -6718,8 +6596,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'আপনার ডিভাইসের SD কার্ড থেকে অডিও ডাউনলোড করা হচ্ছে';
 
   @override
-  String get transferRequiredDescription =>
-      'এই রেকর্ডিং আপনার ডিভাইসের SD কার্ডে সংরক্ষিত। এটি প্লে বা শেয়ার করতে আপনার ফোনে স্থানান্তর করুন।';
+  String get transferRequiredDescription => 'এই রেকর্ডিং আপনার ডিভাইসের SD কার্ডে সংরক্ষিত। এটি প্লে বা শেয়ার করতে আপনার ফোনে স্থানান্তর করুন।';
 
   @override
   String get cancelTransfer => 'স্থানান্তর বাতিল করুন';
@@ -6740,8 +6617,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get shareRecording => 'রেকর্ডিং শেয়ার করুন';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'আপনি কি নিশ্চিত যে এই রেকর্ডিং স্থায়ীভাবে মুছে ফেলতে চান? এটি পূর্বাবস্থায় ফিরানো যাবে না।';
+  String get deleteRecordingConfirmation => 'আপনি কি নিশ্চিত যে এই রেকর্ডিং স্থায়ীভাবে মুছে ফেলতে চান? এটি পূর্বাবস্থায় ফিরানো যাবে না।';
 
   @override
   String get recordingIdLabel => 'রেকর্ডিং আইডি';
@@ -6800,15 +6676,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get enableFastTransfer => 'দ্রুত ট্রান্সফার সক্ষম করুন';
 
   @override
-  String get fastTransferDescription =>
-      'দ্রুত ট্রান্সফার WiFi ব্যবহার করে ~৫ গুণ দ্রুত গতি প্রদান করে। ট্রান্সফারের সময় আপনার ফোন আপনার Omi ডিভাইসের WiFi নেটওয়ার্কের সাথে সাময়িকভাবে সংযুক্ত হবে।';
+  String get fastTransferDescription => 'দ্রুত ট্রান্সফার WiFi ব্যবহার করে ~৫ গুণ দ্রুত গতি প্রদান করে। ট্রান্সফারের সময় আপনার ফোন আপনার Omi ডিভাইসের WiFi নেটওয়ার্কের সাথে সাময়িকভাবে সংযুক্ত হবে।';
 
   @override
   String get internetAccessPausedDuringTransfer => 'ট্রান্সফারের সময় ইন্টারনেট অ্যাক্সেস বন্ধ রয়েছে';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'আপনার Omi ডিভাইস থেকে আপনার ফোনে রেকর্ডিং কীভাবে স্থানান্তরিত হবে তা নির্বাচন করুন।';
+  String get chooseTransferMethodDescription => 'আপনার Omi ডিভাইস থেকে আপনার ফোনে রেকর্ডিং কীভাবে স্থানান্তরিত হবে তা নির্বাচন করুন।';
 
   @override
   String get wifiSpeed => 'WiFi এর মাধ্যমে ~১৫০ কেবি/সেক';
@@ -6817,8 +6691,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get fiveTimesFaster => '৫ গুণ দ্রুত';
 
   @override
-  String get fastTransferMethodDescription =>
-      'আপনার Omi ডিভাইসের সাথে সরাসরি WiFi সংযোগ তৈরি করে। ট্রান্সফারের সময় আপনার ফোন আপনার নিয়মিত WiFi থেকে সাময়িকভাবে সংযোগ বিচ্ছিন্ন হয়।';
+  String get fastTransferMethodDescription => 'আপনার Omi ডিভাইসের সাথে সরাসরি WiFi সংযোগ তৈরি করে। ট্রান্সফারের সময় আপনার ফোন আপনার নিয়মিত WiFi থেকে সাময়িকভাবে সংযোগ বিচ্ছিন্ন হয়।';
 
   @override
   String get bluetooth => 'ব্লুটুথ';
@@ -6827,8 +6700,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get bleSpeed => 'BLE এর মাধ্যমে ~৩০ কেবি/সেক';
 
   @override
-  String get bluetoothMethodDescription =>
-      'আদর্শ ব্লুটুথ লো এনার্জি সংযোগ ব্যবহার করে। ধীর কিন্তু আপনার WiFi সংযোগকে প্রভাবিত করে না।';
+  String get bluetoothMethodDescription => 'আদর্শ ব্লুটুথ লো এনার্জি সংযোগ ব্যবহার করে। ধীর কিন্তু আপনার WiFi সংযোগকে প্রভাবিত করে না।';
 
   @override
   String get selected => 'নির্বাচিত';
@@ -6866,12 +6738,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get appDeleteFailed => 'অ্যাপ মুছতে ব্যর্থ। দয়া করে পরে আবার চেষ্টা করুন।';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'অ্যাপের দৃশ্যমানতা সফলভাবে পরিবর্তিত হয়েছে। এটি প্রতিফলিত হতে কয়েক মিনিট সময় লাগতে পারে।';
+  String get appVisibilityChangedSuccessfully => 'অ্যাপের দৃশ্যমানতা সফলভাবে পরিবর্তিত হয়েছে। এটি প্রতিফলিত হতে কয়েক মিনিট সময় লাগতে পারে।';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'অ্যাপ সক্রিয়করণে ত্রুটি। যদি এটি একটি সংহতকরণ অ্যাপ হয় তবে সেটআপ সম্পূর্ণ হয়েছে তা নিশ্চিত করুন।';
+  String get errorActivatingAppIntegration => 'অ্যাপ সক্রিয়করণে ত্রুটি। যদি এটি একটি সংহতকরণ অ্যাপ হয় তবে সেটআপ সম্পূর্ণ হয়েছে তা নিশ্চিত করুন।';
 
   @override
   String get errorUpdatingAppStatus => 'অ্যাপের অবস্থা আপডেট করার সময় একটি ত্রুটি ঘটেছে।';
@@ -6939,8 +6809,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get importantConversationTitle => 'গুরুত্বপূর্ণ কথোপকথন';
 
   @override
-  String get importantConversationBody =>
-      'আপনি এইমাত্র একটি গুরুত্বপূর্ণ কথোপকথন করেছেন। সারসংক্ষেপ অন্যদের সাথে শেয়ার করতে ট্যাপ করুন।';
+  String get importantConversationBody => 'আপনি এইমাত্র একটি গুরুত্বপূর্ণ কথোপকথন করেছেন। সারসংক্ষেপ অন্যদের সাথে শেয়ার করতে ট্যাপ করুন।';
 
   @override
   String get templateName => 'টেমপ্লেটের নাম';
@@ -6952,8 +6821,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'নাম কমপক্ষে ৩টি অক্ষর হতে হবে';
 
   @override
-  String get conversationPromptHint =>
-      'যেমন, প্রদত্ত কথোপকথন থেকে কর্ম সামগ্রী, সিদ্ধান্ত এবং মূল টেকওভার গুলি বের করুন।';
+  String get conversationPromptHint => 'যেমন, প্রদত্ত কথোপকথন থেকে কর্ম সামগ্রী, সিদ্ধান্ত এবং মূল টেকওভার গুলি বের করুন।';
 
   @override
   String get pleaseEnterAppPrompt => 'অনুগ্রহ করে আপনার অ্যাপের জন্য একটি প্রম্পট লিখুন';
@@ -7140,15 +7008,13 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'আপগ্রেড নির্ধারিত হয়েছে! আপনার মাসিক পরিকল্পনা আপনার বিলিং সময়কালের শেষ পর্যন্ত চলতে থাকে, তারপর স্বয়ংক্রিয়ভাবে বার্ষিকতে স্যুইচ হয়।';
+  String get planUpgradeScheduledMessage => 'আপগ্রেড নির্ধারিত হয়েছে! আপনার মাসিক পরিকল্পনা আপনার বিলিং সময়কালের শেষ পর্যন্ত চলতে থাকে, তারপর স্বয়ংক্রিয়ভাবে বার্ষিকতে স্যুইচ হয়।';
 
   @override
   String get couldNotSchedulePlanChange => 'পরিকল্পনা পরিবর্তন নির্ধারণ করা যায়নি। দয়া করে আবার চেষ্টা করুন।';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'আপনার সাবস্ক্রিপশন পুনরায় সক্রিয় করা হয়েছে! এখন কোনো চার্জ নেই - আপনার বর্তমান সময়কালের শেষে বিলিং করা হবে।';
+  String get subscriptionReactivatedDefault => 'আপনার সাবস্ক্রিপশন পুনরায় সক্রিয় করা হয়েছে! এখন কোনো চার্জ নেই - আপনার বর্তমান সময়কালের শেষে বিলিং করা হবে।';
 
   @override
   String get subscriptionSuccessfulCharged => 'সাবস্ক্রিপশন সফল! নতুন বিলিং সময়কালের জন্য আপনাকে চার্জ করা হয়েছে।';
@@ -7316,8 +7182,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Firebase টোকেন পুনরুদ্ধার করতে ব্যর্থ, দয়া করে আবার চেষ্টা করুন।';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'সাইন ইন করতে অপ্রত্যাশিত ত্রুটি, Firebase ত্রুটি, দয়া করে আবার চেষ্টা করুন।';
+  String get authUnexpectedErrorFirebase => 'সাইন ইন করতে অপ্রত্যাশিত ত্রুটি, Firebase ত্রুটি, দয়া করে আবার চেষ্টা করুন।';
 
   @override
   String get authUnexpectedError => 'সাইন ইন করতে অপ্রত্যাশিত ত্রুটি, দয়া করে আবার চেষ্টা করুন';
@@ -7345,12 +7210,10 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'বিজ্ঞপ্তি অনুমতি প্রত্যাখ্যাত। সিস্টেম পছন্দগুলিতে অনুমতি দিন।';
+  String get onboardingNotificationDeniedSystemPrefs => 'বিজ্ঞপ্তি অনুমতি প্রত্যাখ্যাত। সিস্টেম পছন্দগুলিতে অনুমতি দিন।';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'বিজ্ঞপ্তি অনুমতি প্রত্যাখ্যাত। সিস্টেম পছন্দগুলি > বিজ্ঞপ্তিতে অনুমতি দিন।';
+  String get onboardingNotificationDeniedNotifications => 'বিজ্ঞপ্তি অনুমতি প্রত্যাখ্যাত। সিস্টেম পছন্দগুলি > বিজ্ঞপ্তিতে অনুমতি দিন।';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7369,8 +7232,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get onboardingMicrophoneRequired => 'রেকর্ডিংয়ের জন্য মাইক্রোফোন অনুমতি প্রয়োজন।';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'মাইক্রোফোন অনুমতি প্রত্যাখ্যাত। সিস্টেম পছন্দগুলি > গোপনীয়তা ও নিরাপত্তা > মাইক্রোফোনে অনুমতি দিন।';
+  String get onboardingMicrophoneDenied => 'মাইক্রোফোন অনুমতি প্রত্যাখ্যাত। সিস্টেম পছন্দগুলি > গোপনীয়তা ও নিরাপত্তা > মাইক্রোফোনে অনুমতি দিন।';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7386,8 +7248,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'সিস্টেম অডিও রেকর্ডিংয়ের জন্য স্ক্রীন ক্যাপচার অনুমতি প্রয়োজন।';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'স্ক্রীন ক্যাপচার অনুমতি প্রত্যাখ্যাত। সিস্টেম পছন্দগুলি > গোপনীয়তা ও নিরাপত্তা > স্ক্রীন রেকর্ডিংয়ে অনুমতি দিন।';
+  String get onboardingScreenCaptureDenied => 'স্ক্রীন ক্যাপচার অনুমতি প্রত্যাখ্যাত। সিস্টেম পছন্দগুলি > গোপনীয়তা ও নিরাপত্তা > স্ক্রীন রেকর্ডিংয়ে অনুমতি দিন।';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7512,8 +7373,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get locationPermissionRequired => 'অবস্থান অনুমতি প্রয়োজন';
 
   @override
-  String get locationPermissionContent =>
-      'দ্রুত ট্রান্সফার WiFi সংযোগ যাচাই করতে অবস্থান অনুমতি প্রয়োজন। এগিয়ে যেতে অবস্থান অনুমতি দিন।';
+  String get locationPermissionContent => 'দ্রুত ট্রান্সফার WiFi সংযোগ যাচাই করতে অবস্থান অনুমতি প্রয়োজন। এগিয়ে যেতে অবস্থান অনুমতি দিন।';
 
   @override
   String get pdfTranscriptExport => 'প্রতিলেখ রপ্তানি';
@@ -7984,8 +7844,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note পেয়ারিং মোডে রাখুন';
 
   @override
-  String get pairingDescPlaudNote =>
-      'পাশের বোতাম 2 সেকেন্ডের জন্য চাপ দিয়ে ধরুন। লাল LED পেয়ার করার জন্য প্রস্তুত হলে ঝলমলে করবে।';
+  String get pairingDescPlaudNote => 'পাশের বোতাম 2 সেকেন্ডের জন্য চাপ দিয়ে ধরুন। লাল LED পেয়ার করার জন্য প্রস্তুত হলে ঝলমলে করবে।';
 
   @override
   String get pairingTitleBee => 'Bee পেয়ারিং মোডে রাখুন';
@@ -7997,15 +7856,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get pairingTitleLimitless => 'Limitless পেয়ারিং মোডে রাখুন';
 
   @override
-  String get pairingDescLimitless =>
-      'যখন কোনো আলো দৃশ্যমান হয়, একবার চাপুন এবং তারপর ধরে রাখুন যতক্ষণ না ডিভাইসটি গোলাপি আলো দেখায়, তারপর ছেড়ে দিন।';
+  String get pairingDescLimitless => 'যখন কোনো আলো দৃশ্যমান হয়, একবার চাপুন এবং তারপর ধরে রাখুন যতক্ষণ না ডিভাইসটি গোলাপি আলো দেখায়, তারপর ছেড়ে দিন।';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant পেয়ারিং মোডে রাখুন';
 
   @override
-  String get pairingDescFriendPendant =>
-      'পেন্ডান্টে বোতাম চাপুন এটি চালু করতে। এটি স্বয়ংক্রিয়ভাবে পেয়ারিং মোডে প্রবেश করবে।';
+  String get pairingDescFriendPendant => 'পেন্ডান্টে বোতাম চাপুন এটি চালু করতে। এটি স্বয়ংক্রিয়ভাবে পেয়ারিং মোডে প্রবেश করবে।';
 
   @override
   String get pairingTitleFieldy => 'Fieldy পেয়ারিং মোডে রাখুন';
@@ -8017,8 +7874,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch সংযুক্ত করুন';
 
   @override
-  String get pairingDescAppleWatch =>
-      'আপনার Apple Watch-এ Omi অ্যাপ ইনস্টল এবং খুলুন, তারপর অ্যাপে সংযুক্ত ট্যাপ করুন।';
+  String get pairingDescAppleWatch => 'আপনার Apple Watch-এ Omi অ্যাপ ইনস্টল এবং খুলুন, তারপর অ্যাপে সংযুক্ত ট্যাপ করুন।';
 
   @override
   String get pairingTitleNeoOne => 'Neo One পেয়ারিং মোডে রাখুন';
@@ -8141,8 +7997,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get switchAndRestart => 'স্যুইচ করুন';
 
   @override
-  String get stagingDisclaimer =>
-      'স্টেজিং বাগযুক্ত হতে পারে, অসঙ্গত কর্মক্ষমতা থাকতে পারে, এবং ডেটা হারিয়ে যেতে পারে। শুধুমাত্র পরীক্ষার জন্য ব্যবহার করুন।';
+  String get stagingDisclaimer => 'স্টেজিং বাগযুক্ত হতে পারে, অসঙ্গত কর্মক্ষমতা থাকতে পারে, এবং ডেটা হারিয়ে যেতে পারে। শুধুমাত্র পরীক্ষার জন্য ব্যবহার করুন।';
 
   @override
   String get apiEnvSavedRestartRequired => 'সংরক্ষিত। প্রয়োগ করতে অ্যাপটি বন্ধ এবং পুনরায় খুলুন।';
@@ -8371,8 +8226,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Omi এর মাধ্যমে ফোন কল';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Omi এর মাধ্যমে কল করুন এবং রিয়েল-টাইম ট্রান্সক্রিপশন, স্বয়ংক্রিয় সারাংশ এবং আরও অনেক কিছু পান। এক্সক্লুসিভভাবে Unlimited প্ল্যান সাবস্ক্রাইবারদের জন্য উপলব্ধ।';
+  String get phoneCallsUpsellSubtitle => 'Omi এর মাধ্যমে কল করুন এবং রিয়েল-টাইম ট্রান্সক্রিপশন, স্বয়ংক্রিয় সারাংশ এবং আরও অনেক কিছু পান। এক্সক্লুসিভভাবে Unlimited প্ল্যান সাবস্ক্রাইবারদের জন্য উপলব্ধ।';
 
   @override
   String get phoneCallsUpsellFeature1 => 'প্রতিটি কলের রিয়েল-টাইম ট্রান্সক্রিপশন';
@@ -8399,8 +8253,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deleteSyncedFiles => 'সিঙ্ক করা রেকর্ডিং মুছুন';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'এই রেকর্ডিংগুলি ইতিমধ্যে আপনার ফোনে সিঙ্ক করা হয়েছে। এটি পূর্বাবাস করা যায় না।';
+  String get deleteSyncedFilesMessage => 'এই রেকর্ডিংগুলি ইতিমধ্যে আপনার ফোনে সিঙ্ক করা হয়েছে। এটি পূর্বাবাস করা যায় না।';
 
   @override
   String get syncedFilesDeleted => 'সিঙ্ক করা রেকর্ডিং মুছা হয়েছে';
@@ -8412,8 +8265,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deletePendingFiles => 'মুলতুবি রেকর্ডিং মুছুন';
 
   @override
-  String get deletePendingFilesWarning =>
-      'এই রেকর্ডিংগুলি আপনার ফোনে সিঙ্ক করা হয়নি এবং চিরকালের জন্য হারিয়ে যাবে। এটি পূর্বাবাস করা যায় না।';
+  String get deletePendingFilesWarning => 'এই রেকর্ডিংগুলি আপনার ফোনে সিঙ্ক করা হয়নি এবং চিরকালের জন্য হারিয়ে যাবে। এটি পূর্বাবাস করা যায় না।';
 
   @override
   String get pendingFilesDeleted => 'মুলতুবি রেকর্ডিং মুছা হয়েছে';
@@ -8425,8 +8277,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deleteAll => 'সব মুছুন';
 
   @override
-  String get deleteAllFilesWarning =>
-      'এটি সিঙ্ক করা এবং মুলতুবি উভয় রেকর্ডিং মুছে ফেলবে। মুলতুবি রেকর্ডিংগুলি সিঙ্ক করা হয়নি এবং চিরকালের জন্য হারিয়ে যাবে। এটি পূর্বাবাস করা যায় না।';
+  String get deleteAllFilesWarning => 'এটি সিঙ্ক করা এবং মুলতুবি উভয় রেকর্ডিং মুছে ফেলবে। মুলতুবি রেকর্ডিংগুলি সিঙ্ক করা হয়নি এবং চিরকালের জন্য হারিয়ে যাবে। এটি পূর্বাবাস করা যায় না।';
 
   @override
   String get allFilesDeleted => 'সমস্ত রেকর্ডিং মুছা হয়েছে';
@@ -8491,8 +8342,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get fairUseAboutTitle => 'ন্যায্য ব্যবহার সম্পর্কে';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi ব্যক্তিগত কথোপকথন, সভা এবং লাইভ ইন্টারঅ্যাকশনের জন্য ডিজাইন করা হয়েছে। ব্যবহার সংযোগ সময় দ্বারা নয়, সনাক্ত করা প্রকৃত কথা সময় দ্বারা পরিমাপ করা হয়। যদি ব্যবহার অ-ব্যক্তিগত সামগ্রীর জন্য সাধারণ নিদর্শন উল্লেখযোগ্যভাবে অতিক্রম করে, সমন্বয় প্রযোজ্য হতে পারে।';
+  String get fairUseAboutBody => 'Omi ব্যক্তিগত কথোপকথন, সভা এবং লাইভ ইন্টারঅ্যাকশনের জন্য ডিজাইন করা হয়েছে। ব্যবহার সংযোগ সময় দ্বারা নয়, সনাক্ত করা প্রকৃত কথা সময় দ্বারা পরিমাপ করা হয়। যদি ব্যবহার অ-ব্যক্তিগত সামগ্রীর জন্য সাধারণ নিদর্শন উল্লেখযোগ্যভাবে অতিক্রম করে, সমন্বয় প্রযোজ্য হতে পারে।';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8530,8 +8380,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get improveConnectionTitle => 'সংযোগ উন্নত করুন';
 
   @override
-  String get improveConnectionContent =>
-      'আমরা উন্নত করেছি কীভাবে Omi আপনার ডিভাইসে সংযুক্ত থাকে। এটি সক্রিয় করতে, ডিভাইস তথ্য পৃষ্ঠায় যান, \"ডিভাইস সংযোগ বিচ্ছিন্ন করুন\" ট্যাপ করুন, তারপর আপনার ডিভাইস পুনরায় পেয়ার করুন।';
+  String get improveConnectionContent => 'আমরা উন্নত করেছি কীভাবে Omi আপনার ডিভাইসে সংযুক্ত থাকে। এটি সক্রিয় করতে, ডিভাইস তথ্য পৃষ্ঠায় যান, \"ডিভাইস সংযোগ বিচ্ছিন্ন করুন\" ট্যাপ করুন, তারপর আপনার ডিভাইস পুনরায় পেয়ার করুন।';
 
   @override
   String get improveConnectionAction => 'বুঝেছি';
@@ -8586,16 +8435,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get cancelSyncQuestion => 'সিঙ্ক বাতিল করবেন?';
 
   @override
-  String get omisStorageDesc =>
-      'যখন আপনার Omi আপনার ফোনে সংযুক্ত নয়, এটি তার নির্মিত মেমরিতে অডিও স্থানীয়ভাবে সংরক্ষণ করে। আপনি কখনও একটি রেকর্ডিং হারাবেন না।';
+  String get omisStorageDesc => 'যখন আপনার Omi আপনার ফোনে সংযুক্ত নয়, এটি তার নির্মিত মেমরিতে অডিও স্থানীয়ভাবে সংরক্ষণ করে। আপনি কখনও একটি রেকর্ডিং হারাবেন না।';
 
   @override
-  String get phoneStorageDesc =>
-      'যখন Omi পুনরায় সংযুক্ত হয়, রেকর্ডিংগুলি স্বয়ংক্রিয়ভাবে আপনার ফোনে স্থানান্তরিত হয় আপলোড করার আগে অস্থায়ী ধারণ এলাকা হিসাবে।';
+  String get phoneStorageDesc => 'যখন Omi পুনরায় সংযুক্ত হয়, রেকর্ডিংগুলি স্বয়ংক্রিয়ভাবে আপনার ফোনে স্থানান্তরিত হয় আপলোড করার আগে অস্থায়ী ধারণ এলাকা হিসাবে।';
 
   @override
-  String get cloudStorageDesc =>
-      'একবার আপলোড করা হয়, আপনার রেকর্ডিংগুলি প্রক্রিয়াজাত এবং ট্রান্সক্রাইব করা হয়। কথোপকথনগুলি এক মিনিটের মধ্যে উপলব্ধ থাকবে।';
+  String get cloudStorageDesc => 'একবার আপলোড করা হয়, আপনার রেকর্ডিংগুলি প্রক্রিয়াজাত এবং ট্রান্সক্রাইব করা হয়। কথোপকথনগুলি এক মিনিটের মধ্যে উপলব্ধ থাকবে।';
 
   @override
   String get tipKeepPhoneNearby => 'দ্রুত সিঙ্কিংয়ের জন্য আপনার ফোন কাছাকাছি রাখুন';
@@ -8619,12 +8465,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get permissionEnable => 'সক্ষম করুন';
 
   @override
-  String get permissionsPageDescription =>
-      'এই অনুমতিগুলি Omi কীভাবে কাজ করে তার মূল। তারা বিজ্ঞপ্তি, অবস্থান-ভিত্তিক অভিজ্ঞতা এবং অডিও ক্যাপচার মত মূল বৈশিষ্ট্য সক্ষম।';
+  String get permissionsPageDescription => 'এই অনুমতিগুলি Omi কীভাবে কাজ করে তার মূল। তারা বিজ্ঞপ্তি, অবস্থান-ভিত্তিক অভিজ্ঞতা এবং অডিও ক্যাপচার মত মূল বৈশিষ্ট্য সক্ষম।';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi সঠিকভাবে কাজ করার জন্য কয়েকটি অনুমতি প্রয়োজন। অব্যাহত রাখতে অনুগ্রহ করে তাদের প্রদান করুন।';
+  String get permissionsRequiredDescription => 'Omi সঠিকভাবে কাজ করার জন্য কয়েকটি অনুমতি প্রয়োজন। অব্যাহত রাখতে অনুগ্রহ করে তাদের প্রদান করুন।';
 
   @override
   String get permissionsSetupTitle => 'সেরা অভিজ্ঞতা পান';
@@ -8678,8 +8522,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get justAMoment => 'শুধু একটি মুহূর্ত, অনুগ্রহ করে';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'আমরা অত্যন্ত সুপারিশ করি বাতিল করার পরিবর্তে আপনার অন্যান্য বিকল্প অন্বেষণ করুন।';
+  String get cancelConsequencesSubtitle => 'আমরা অত্যন্ত সুপারিশ করি বাতিল করার পরিবর্তে আপনার অন্যান্য বিকল্প অন্বেষণ করুন।';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8902,8 +8745,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get firmwareWarningTitle => 'গুরুত্বপূর্ণ: আপডেটের আগে পড়ুন';
 
   @override
-  String get firmwareFormatWarning =>
-      'এই ফার্মওয়্যার SD কার্ড ফরম্যাট করবে। আপগ্রেড করার আগে দয়া করে নিশ্চিত করুন যে সমস্ত অফলাইন ডেটা সিঙ্ক হয়েছে।\n\nএই সংস্করণ ইনস্টল করার পর যদি লাল আলো জ্বলতে দেখেন, চিন্তা করবেন না। শুধু ডিভাইসটি অ্যাপের সাথে সংযুক্ত করুন এবং এটি নীল হয়ে যাওয়া উচিত। লাল আলো মানে ডিভাইসের ঘড়ি এখনও সিঙ্ক হয়নি।';
+  String get firmwareFormatWarning => 'এই ফার্মওয়্যার SD কার্ড ফরম্যাট করবে। আপগ্রেড করার আগে দয়া করে নিশ্চিত করুন যে সমস্ত অফলাইন ডেটা সিঙ্ক হয়েছে।\n\nএই সংস্করণ ইনস্টল করার পর যদি লাল আলো জ্বলতে দেখেন, চিন্তা করবেন না। শুধু ডিভাইসটি অ্যাপের সাথে সংযুক্ত করুন এবং এটি নীল হয়ে যাওয়া উচিত। লাল আলো মানে ডিভাইসের ঘড়ি এখনও সিঙ্ক হয়নি।';
 
   @override
   String get continueAnyway => 'চালিয়ে যান';
@@ -8923,8 +8765,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get tasksMarkComplete => 'সম্পন্ন হিসেবে চিহ্নিত';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi অ্যাপলের HealthKit ফ্রেমওয়ার্কের মাধ্যমে Apple Health-এ অ্যাক্সেস করে। আপনি যেকোনো সময় iOS সেটিংস থেকে অ্যাক্সেস প্রত্যাহার করতে পারেন।';
+  String get appleHealthManageNote => 'Omi অ্যাপলের HealthKit ফ্রেমওয়ার্কের মাধ্যমে Apple Health-এ অ্যাক্সেস করে। আপনি যেকোনো সময় iOS সেটিংস থেকে অ্যাক্সেস প্রত্যাহার করতে পারেন।';
 
   @override
   String get appleHealthConnectCta => 'Apple Health-এ সংযুক্ত করুন';
@@ -8957,8 +8798,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health অ্যাক্সেস অস্বীকৃত';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi-র আপনার Apple Health ডেটা পড়ার অনুমতি নেই। iOS সেটিংস → Privacy & Security → Health → Omi-তে এটি সক্ষম করুন।';
+  String get appleHealthDeniedBody => 'Omi-র আপনার Apple Health ডেটা পড়ার অনুমতি নেই। iOS সেটিংস → Privacy & Security → Health → Omi-তে এটি সক্ষম করুন।';
 
   @override
   String get deleteFlowReasonTitle => 'আপনি কেন চলে যাচ্ছেন?';
@@ -9027,8 +8867,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get planUpdate => 'প্ল্যান আপডেট';
 
   @override
-  String get planDeprecationMessage =>
-      'আপনার Unlimited প্ল্যান বন্ধ হচ্ছে। Operator প্ল্যানে স্যুইচ করুন — একই দুর্দান্ত ফিচার \$49/মাসে। আপনার বর্তমান প্ল্যান এর মধ্যে কাজ করতে থাকবে।';
+  String get planDeprecationMessage => 'আপনার Unlimited প্ল্যান বন্ধ হচ্ছে। Operator প্ল্যানে স্যুইচ করুন — একই দুর্দান্ত ফিচার \$49/মাসে। আপনার বর্তমান প্ল্যান এর মধ্যে কাজ করতে থাকবে।';
 
   @override
   String get upgradeYourPlan => 'আপনার প্ল্যান আপগ্রেড করুন';
@@ -9139,8 +8978,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'আপনি আপনার মাসিক সীমায় পৌঁছেছেন। বিনা সীমাবদ্ধতায় Omi-এর সাথে চ্যাট চালিয়ে যেতে আপগ্রেড করুন।';
+  String get chatQuotaExceededReply => 'আপনি আপনার মাসিক সীমায় পৌঁছেছেন। বিনা সীমাবদ্ধতায় Omi-এর সাথে চ্যাট চালিয়ে যেতে আপগ্রেড করুন।';
 
   @override
   String get voiceResponseAudio => 'Omi-র উত্তর জোরে পড়ুন';
@@ -9171,4 +9009,25 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'কাজ যোগ করুন';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi কে যেকোনো কিছু জিজ্ঞেস করুন';
+
+  @override
+  String get quickActionVoiceMode => 'ভয়েস মোড';
+
+  @override
+  String get quickActionMute => 'নিঃশব্দ';
+
+  @override
+  String get quickActionUnmute => 'শব্দ চালু করুন';
+
+  @override
+  String get quickActionConnectDevice => 'ডিভাইস সংযুক্ত করুন';
+
+  @override
+  String get quickActionDeviceSettings => 'ডিভাইস সেটিংস';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -24,8 +24,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deleteConversationTitle => 'Izbrisati razgovor?';
 
   @override
-  String get deleteConversationMessage =>
-      'Ovo će takođe izbrisati povezane uspomene, zadatke i audio fajlove. Ova radnja se ne može opozvati.';
+  String get deleteConversationMessage => 'Ovo će takođe izbrisati povezane uspomene, zadatke i audio fajlove. Ova radnja se ne može opozvati.';
 
   @override
   String get confirm => 'Potvrdi';
@@ -146,8 +145,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deleting => 'Brisanje...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Molimo vas da završite autentifikaciju u vašem pregledniku. Kada završite, vratite se u aplikaciju.';
+  String get pleaseCompleteAuthentication => 'Molimo vas da završite autentifikaciju u vašem pregledniku. Kada završite, vratite se u aplikaciju.';
 
   @override
   String get failedToStartAuthentication => 'Neuspelo pokretanje autentifikacije';
@@ -319,8 +317,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get installedApps => 'Instalirane aplikacije';
 
   @override
-  String get unableToFetchApps =>
-      'Nije moguće preuzeti aplikacije :(\n\nMolimo proverite vašu internet konekciju i pokušajte ponovo.';
+  String get unableToFetchApps => 'Nije moguće preuzeti aplikacije :(\n\nMolimo proverite vašu internet konekciju i pokušajte ponovo.';
 
   @override
   String get aboutOmi => 'O Omiju';
@@ -356,19 +353,16 @@ class AppLocalizationsBs extends AppLocalizations {
   String get appsDisconnected => 'Vaše aplikacije i integracije će biti odmah prekopčane.';
 
   @override
-  String get exportBeforeDelete =>
-      'Možete izvesti svoje podatke pre nego što izbrisati nalog, ali kada je izbrisano, ne može biti vraćeno.';
+  String get exportBeforeDelete => 'Možete izvesti svoje podatke pre nego što izbrisati nalog, ali kada je izbrisano, ne može biti vraćeno.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Razumem da je brisanje mog naloga trajno i svi podaci, uključujući uspomene i razgovore, će biti izgubljeni i ne mogu biti vraćeni.';
+  String get deleteAccountCheckbox => 'Razumem da je brisanje mog naloga trajno i svi podaci, uključujući uspomene i razgovore, će biti izgubljeni i ne mogu biti vraćeni.';
 
   @override
   String get areYouSure => 'Jeste li sigurni?';
 
   @override
-  String get deleteAccountFinal =>
-      'Ova radnja je nepovratna i će zauvek izbrisati vaš nalog i sve povezane podatke. Jeste li sigurni da želite da nastavite?';
+  String get deleteAccountFinal => 'Ova radnja je nepovratna i će zauvek izbrisati vaš nalog i sve povezane podatke. Jeste li sigurni da želite da nastavite?';
 
   @override
   String get deleteNow => 'Izbriši sada';
@@ -377,8 +371,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get goBack => 'Nazad';
 
   @override
-  String get checkBoxToConfirm =>
-      'Označite polje da potvrdite da razumete da je brisanje vašeg naloga trajno i nepovratno.';
+  String get checkBoxToConfirm => 'Označite polje da potvrdite da razumete da je brisanje vašeg naloga trajno i nepovratno.';
 
   @override
   String get profile => 'Profil';
@@ -456,8 +449,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get yourPrivacyYourControl => 'Vaša privatnost, vaša kontrola';
 
   @override
-  String get privacyIntro =>
-      'U Omiju smo posvećeni zaštiti vaše privatnosti. Ova stranica vam omogućava da kontrolišete kako se vaši podaci čuvaju i koriste.';
+  String get privacyIntro => 'U Omiju smo posvećeni zaštiti vaše privatnosti. Ova stranica vam omogućava da kontrolišete kako se vaši podaci čuvaju i koriste.';
 
   @override
   String get learnMore => 'Saznajte više...';
@@ -466,15 +458,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get dataProtectionLevel => 'Nivo zaštite podataka';
 
   @override
-  String get dataProtectionDesc =>
-      'Vaši podaci su podrazumevano zaštićeni jakim šifrovanjem. Pregledajte vaše postavke i budućne opcije privatnosti ispod.';
+  String get dataProtectionDesc => 'Vaši podaci su podrazumevano zaštićeni jakim šifrovanjem. Pregledajte vaše postavke i budućne opcije privatnosti ispod.';
 
   @override
   String get appAccess => 'Pristup aplikacije';
 
   @override
-  String get appAccessDesc =>
-      'Sledeće aplikacije mogu pristupiti vašim podacima. Dodirnite aplikaciju da upravljate njenim dozvolama.';
+  String get appAccessDesc => 'Sledeće aplikacije mogu pristupiti vašim podacima. Dodirnite aplikaciju da upravljate njenim dozvolama.';
 
   @override
   String get noAppsExternalAccess => 'Nema instalirane aplikacije koje imaju spoljni pristup vašim podacima.';
@@ -531,15 +521,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Vaš Omi je iskopčan 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Uređaj je rozparen. Otite na Postavke > Bluetooth i zaboravite uređaj da završite rasparovanje.';
+  String get deviceUnpairedMessage => 'Uređaj je rozparen. Otite na Postavke > Bluetooth i zaboravite uređaj da završite rasparovanje.';
 
   @override
   String get unpairDialogTitle => 'Rozpari uređaj';
 
   @override
-  String get unpairDialogMessage =>
-      'Ovo će raspariti uređaj tako da može biti povezan sa drugim telefonom. Trebate otiti na Postavke > Bluetooth i zaboraviti uređaj da završite proces.';
+  String get unpairDialogMessage => 'Ovo će raspariti uređaj tako da može biti povezan sa drugim telefonom. Trebate otiti na Postavke > Bluetooth i zaboraviti uređaj da završite proces.';
 
   @override
   String get deviceNotConnected => 'Uređaj nije povezan';
@@ -560,8 +548,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get v2Undetected => 'V2 nije detektovano';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vidimo da imate V1 uređaj ili vaš uređaj nije povezan. Funkcionalnost SD kartice dostupna je samo za V2 uređaje.';
+  String get v2UndetectedMessage => 'Vidimo da imate V1 uređaj ili vaš uređaj nije povezan. Funkcionalnost SD kartice dostupna je samo za V2 uređaje.';
 
   @override
   String get endConversation => 'Završi razgovor';
@@ -835,8 +822,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Izbrisati grafikon znanja?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Ovo će izbrisati sve izvedene podatke grafikona znanja (čvorove i veze). Vaše originalne uspomene će ostati sigurne. Grafikon će biti ponovo izgrađen tokom vremena ili na sledeći zahtev.';
+  String get deleteKnowledgeGraphMessage => 'Ovo će izbrisati sve izvedene podatke grafikona znanja (čvorove i veze). Vaše originalne uspomene će ostati sigurne. Grafikon će biti ponovo izgrađen tokom vremena ili na sledeći zahtev.';
 
   @override
   String get knowledgeGraphDeleted => 'Grafikon znanja je obrisan';
@@ -984,8 +970,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get shortConversationThreshold => 'Prag kratkog razgovora';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Razgovori kraći od ovoga će biti skriveni osim ako su omogućeni iznad';
+  String get shortConversationThresholdSubtitle => 'Razgovori kraći od ovoga će biti skriveni osim ako su omogućeni iznad';
 
   @override
   String get durationThreshold => 'Prag trajanja';
@@ -1020,8 +1005,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get integrationsFooter => 'Povežite svoje aplikacije da vidite podatke i metrike u čatu.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Molimo vas da završite autentifikaciju u vašem pregledniku. Kada završite, vratite se u aplikaciju.';
+  String get completeAuthInBrowser => 'Molimo vas da završite autentifikaciju u vašem pregledniku. Kada završite, vratite se u aplikaciju.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1096,19 +1080,16 @@ class AppLocalizationsBs extends AppLocalizations {
   String get trainFamilyProfiles => 'Obučite profile za prijatelje i porodicu';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Vaši snimci nam pomažu da prepoznamo i kreiramo profile za vaše prijatelje i porodicu.';
+  String get trainFamilyProfilesDesc => 'Vaši snimci nam pomažu da prepoznamo i kreiramo profile za vaše prijatelje i porodicu.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Poboljšaj tačnost prepisa';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Kako se naš model poboljšava, možemo pružiti bolje rezultate transkripcije za vaše snimke.';
+  String get enhanceTranscriptAccuracyDesc => 'Kako se naš model poboljšava, možemo pružiti bolje rezultate transkripcije za vaše snimke.';
 
   @override
-  String get legalNotice =>
-      'Pravna napomena: Zakonitost snimanja i čuvanja podataka glasa može se razlikovati u zavisnosti od vaše lokacije i načina korišćenja ove funkcije. Vaša je odgovornost da osigurate poštovanje lokalnih zakona i propisa.';
+  String get legalNotice => 'Pravna napomena: Zakonitost snimanja i čuvanja podataka glasa može se razlikovati u zavisnosti od vaše lokacije i načina korišćenja ove funkcije. Vaša je odgovornost da osigurate poštovanje lokalnih zakona i propisa.';
 
   @override
   String get alreadyAuthorized => 'Već autorizovano';
@@ -1186,8 +1167,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get showEventsNoParticipants => 'Prikaži događaje bez učesnika';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Kada je omogućeno, Dolazak prikazuje događaje bez učesnika ili video linka.';
+  String get showEventsNoParticipantsDesc => 'Kada je omogućeno, Dolazak prikazuje događaje bez učesnika ili video linka.';
 
   @override
   String get yourMeetings => 'Vaši sastanci';
@@ -1228,8 +1208,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get noProjectsInWorkspace => 'Nema pronađenih projekata u ovoj radnoj oblasti';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Izaberite koliko dugo čekati u tišini pre nego što se razgovor automatski završi:';
+  String get conversationTimeoutDesc => 'Izaberite koliko dugo čekati u tišini pre nego što se razgovor automatski završi:';
 
   @override
   String get timeout2Minutes => '2 minuta';
@@ -1356,8 +1335,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get defaultRepository => 'Podrazumevani repozitorijum';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Izaberite podrazumevani repozitorijum za pravljenje problema. Možete i dalje naznačiti drugačiji repozitorijum pri pravljenju problema.';
+  String get selectDefaultRepoDesc => 'Izaberite podrazumevani repozitorijum za pravljenje problema. Možete i dalje naznačiti drugačiji repozitorijum pri pravljenju problema.';
 
   @override
   String get noReposFound => 'Nema pronađenih repozitorijuma';
@@ -1404,8 +1382,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get configureSettings => 'Konfigurišite postavke';
 
   @override
-  String get completeAuthBrowser =>
-      'Molimo dovršite autentifikaciju u vašem pregledniku. Kada završite, vratite se u aplikaciju.';
+  String get completeAuthBrowser => 'Molimo dovršite autentifikaciju u vašem pregledniku. Kada završite, vratite se u aplikaciju.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1733,8 +1710,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get enableBluetooth => 'Omogući Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi koristi Bluetooth da bi se povezao sa vašim nosivim uređajem. Molimo omogućite Bluetooth i pokušajte ponovo.';
+  String get bluetoothNeeded => 'Omi koristi Bluetooth da bi se povezao sa vašim nosivim uređajem. Molimo omogućite Bluetooth i pokušajte ponovo.';
 
   @override
   String get contactSupport => 'Kontaktiraj podršku?';
@@ -1767,26 +1743,22 @@ class AppLocalizationsBs extends AppLocalizations {
   String get locationServiceDisabled => 'Lokacijska usluga je onemogućena';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Lokacijska usluga je onemogućena. Molimo idite na Postavke > Privatnost i bezbednost > Usluge lokacije i omogućite je';
+  String get locationServiceDisabledDesc => 'Lokacijska usluga je onemogućena. Molimo idite na Postavke > Privatnost i bezbednost > Usluge lokacije i omogućite je';
 
   @override
   String get backgroundLocationDenied => 'Pristup lokalnosti u pozadini je odbijen';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Molimo idite na postavke uređaja i postavite dozvolu za lokaciju na \"Uvek dozvoli\"';
+  String get backgroundLocationDeniedDesc => 'Molimo idite na postavke uređaja i postavite dozvolu za lokaciju na \"Uvek dozvoli\"';
 
   @override
   String get lovingOmi => 'Vam se sviđa Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Pomozite nam da dosegnemo više ljudi ostavljanjem recenzije u App Store-u. Vaša povratna informacija znači nam sve!';
+  String get leaveReviewIos => 'Pomozite nam da dosegnemo više ljudi ostavljanjem recenzije u App Store-u. Vaša povratna informacija znači nam sve!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Pomozite nam da dosegnemo više ljudi ostavljanjem recenzije u Google Play Store-u. Vaša povratna informacija znači nam sve!';
+  String get leaveReviewAndroid => 'Pomozite nam da dosegnemo više ljudi ostavljanjem recenzije u Google Play Store-u. Vaša povratna informacija znači nam sve!';
 
   @override
   String get rateOnAppStore => 'Oceni u App Store-u';
@@ -1819,15 +1791,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get connectionError => 'Greška u konekciji';
 
   @override
-  String get connectionErrorDesc =>
-      'Nije uspelo povezivanje na server. Molimo proverite vašu internet konekciju i pokušajte ponovo.';
+  String get connectionErrorDesc => 'Nije uspelo povezivanje na server. Molimo proverite vašu internet konekciju i pokušajte ponovo.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Nevažeće snimanje detektovano';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Čini se da ima više govornika u snimanju. Molimo uverite se da ste u tihoj lokaciji i pokušajte ponovo.';
+  String get multipleSpeakersDesc => 'Čini se da ima više govornika u snimanju. Molimo uverite se da ste u tihoj lokaciji i pokušajte ponovo.';
 
   @override
   String get tooShortDesc => 'Nema dovoljno govora otkrivenog. Molimo govorite više i pokušajte ponovo.';
@@ -1839,8 +1809,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get areYouThere => 'Jeste li tu?';
 
   @override
-  String get noSpeechDesc =>
-      'Nismo mogli detektovati bilo kakav govor. Molimo govorite najmanje 10 sekundi i ne više od 3 minuta.';
+  String get noSpeechDesc => 'Nismo mogli detektovati bilo kakav govor. Molimo govorite najmanje 10 sekundi i ne više od 3 minuta.';
 
   @override
   String get connectionLost => 'Veza je prekinuta';
@@ -1861,8 +1830,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get permissionsRequired => 'Dozvole su obavezne';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Ova aplikacija koristi Bluetooth i dozvole lokacije za pravilno funkcionisanje. Molimo omogućite ih u postavkama.';
+  String get permissionsRequiredDesc => 'Ova aplikacija koristi Bluetooth i dozvole lokacije za pravilno funkcionisanje. Molimo omogućite ih u postavkama.';
 
   @override
   String get openSettings => 'Otvorite postavke';
@@ -1892,8 +1860,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Vaš AI pratilac';
 
   @override
-  String get captureEveryMoment =>
-      'Uhvatite svakog trenutka. Dobijte AI-powered\nrezimee. Nikada više ne pisati zabelešte.';
+  String get captureEveryMoment => 'Uhvatite svakog trenutka. Dobijte AI-powered\nrezimee. Nikada više ne pisati zabelešte.';
 
   @override
   String get appleWatchSetup => 'Apple Watch postavljanje';
@@ -1905,12 +1872,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get microphonePermission => 'Dozvola za mikrofon';
 
   @override
-  String get permissionGrantedNow =>
-      'Dozvola je data! Sada:\n\nOtvorite Omi aplikaciju na svom satu i dodirnite \"Nastavi\" ispod';
+  String get permissionGrantedNow => 'Dozvola je data! Sada:\n\nOtvorite Omi aplikaciju na svom satu i dodirnite \"Nastavi\" ispod';
 
   @override
-  String get needMicrophonePermission =>
-      'Trebamo dozvolu za mikrofon.\n\n1. Dodirnite \"Dodelite dozvolu\"\n2. Dozvolite na vašem iPhone-u\n3. Aplikacija na satu će se zatvoriti\n4. Ponovo otvorite i dodirnite \"Nastavi\"';
+  String get needMicrophonePermission => 'Trebamo dozvolu za mikrofon.\n\n1. Dodirnite \"Dodelite dozvolu\"\n2. Dozvolite na vašem iPhone-u\n3. Aplikacija na satu će se zatvoriti\n4. Ponovo otvorite i dodirnite \"Nastavi\"';
 
   @override
   String get grantPermissionButton => 'Dodelite dozvolu';
@@ -1919,15 +1884,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get needHelp => 'Trebate li pomoć?';
 
   @override
-  String get troubleshootingSteps =>
-      'Rešavanje problema:\n\n1. Uverite se da je Omi instaliran na vašem satu\n2. Otvorite Omi aplikaciju na svom satu\n3. Tražite skočni prozor dozvole\n4. Dodirnite \"Dozvoli\" kada se traži\n5. Aplikacija na vašem satu će se zatvoriti - ponovo je otvorite\n6. Vratite se i dodirnite \"Nastavi\" na vašem iPhone-u';
+  String get troubleshootingSteps => 'Rešavanje problema:\n\n1. Uverite se da je Omi instaliran na vašem satu\n2. Otvorite Omi aplikaciju na svom satu\n3. Tražite skočni prozor dozvole\n4. Dodirnite \"Dozvoli\" kada se traži\n5. Aplikacija na vašem satu će se zatvoriti - ponovo je otvorite\n6. Vratite se i dodirnite \"Nastavi\" na vašem iPhone-u';
 
   @override
   String get recordingStartedSuccessfully => 'Snimanje je uspešno počelo!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Dozvola još nije data. Molimo uverite se da ste dozvolili pristup mikrofonu i ponovo otvorili aplikaciju na vašem satu.';
+  String get permissionNotGrantedYet => 'Dozvola još nije data. Molimo uverite se da ste dozvolili pristup mikrofonu i ponovo otvorili aplikaciju na vašem satu.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2024,8 +1987,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Spremni za stavke akcije';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Vaš AI će automatski izvlačiti zadatke i stavke za akciju iz vaših razgovora. Pojaviće se ovde kada budu kreirane.';
+  String get welcomeActionItemsDescription => 'Vaš AI će automatski izvlačiti zadatke i stavke za akciju iz vaših razgovora. Pojaviće se ovde kada budu kreirane.';
 
   @override
   String get autoExtractionFeature => 'Automatski ekstrahuje iz razgovora';
@@ -2075,8 +2037,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get clearMemoryTitle => 'Obriši Omi-jevu memoriju';
 
   @override
-  String get clearMemoryMessage =>
-      'Ste li sigurni da želite da obrišete Omi-jevu memoriju? Ova akcija se ne može poništiti.';
+  String get clearMemoryMessage => 'Ste li sigurni da želite da obrišete Omi-jevu memoriju? Ova akcija se ne može poništiti.';
 
   @override
   String get clearMemoryButton => 'Obriši memoriju';
@@ -2222,15 +2183,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'GOVOR I TRANSKRIPCIJA';
 
   @override
-  String get languageSettingsHelperText =>
-      'Jezik aplikacije menja menije i dugmad. Jezik govora utiče na to kako se vaša snimanja transkribiraju.';
+  String get languageSettingsHelperText => 'Jezik aplikacije menja menije i dugmad. Jezik govora utiče na to kako se vaša snimanja transkribiraju.';
 
   @override
   String get translationNotice => 'Obaveštenje o prevodu';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi prevodi razgovore na vašem primarnom jeziku. Ažurirajte ga bilo kada u Postavke → Profili.';
+  String get translationNoticeMessage => 'Omi prevodi razgovore na vašem primarnom jeziku. Ažurirajte ga bilo kada u Postavke → Profili.';
 
   @override
   String get pleaseCheckInternetConnection => 'Molimo proverite vašu internet konekciju i pokušajte ponovo';
@@ -2392,8 +2351,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Ukloni sparivanje uređaja';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Ovo će ukloniti sparivanje uređaja kako bi se mogao spojiti na drugi telefon. Trebat ćeš otići u Postavke > Bluetooth i zaboraviti uređaj da završiš proces.';
+  String get unpairDeviceDialogMessage => 'Ovo će ukloniti sparivanje uređaja kako bi se mogao spojiti na drugi telefon. Trebat ćeš otići u Postavke > Bluetooth i zaboraviti uređaj da završiš proces.';
 
   @override
   String get unpair => 'Ukloni sparivanje';
@@ -2574,8 +2532,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get youreAllSet => 'Sve je spremno!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Dobrodošao u Omi! Tvoj AI asistent je spreman da ti pomogne sa razgovorima, zadacima i još mnogo toga.';
+  String get welcomeToOmiDescription => 'Dobrodošao u Omi! Tvoj AI asistent je spreman da ti pomogne sa razgovorima, zadacima i još mnogo toga.';
 
   @override
   String get startUsingOmi => 'Počni koristiti Omi';
@@ -2711,8 +2668,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get noTasksYet => 'Nema zadataka';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Zadaci iz tvojih razgovora će se pojaviti ovdje.\nKlikni Kreiraj da dodaš jedan ručno.';
+  String get tasksFromConversationsWillAppear => 'Zadaci iz tvojih razgovora će se pojaviti ovdje.\nKlikni Kreiraj da dodaš jedan ručno.';
 
   @override
   String get monthJan => 'Jan';
@@ -2769,8 +2725,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deleteActionItem => 'Obriši element akcije';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Jesi li siguran da želiš obrisati ovaj element akcije? Ova radnja se ne može opozvati.';
+  String get deleteActionItemConfirmation => 'Jesi li siguran da želiš obrisati ovaj element akcije? Ova radnja se ne može opozvati.';
 
   @override
   String get enterActionItemDescription => 'Uneesi opis elementa akcije...';
@@ -2845,8 +2800,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get chatPrompt => 'Chat upit';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ti si odličan aplikacija, tvoj posao je odgovoriti na upite korisnika i učiniti da se osjećaju dobro...';
+  String get chatPromptPlaceholder => 'Ti si odličan aplikacija, tvoj posao je odgovoriti na upite korisnika i učiniti da se osjećaju dobro...';
 
   @override
   String get conversationPrompt => 'Upit razgovora';
@@ -2864,8 +2818,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get makeMyAppPublic => 'Učini mojem aplikacijom javnom';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Slanjem ove aplikacije, slažem se sa Omi AI Uvjetima pružanja usluge i Politikom privatnosti';
+  String get submitAppTermsAgreement => 'Slanjem ove aplikacije, slažem se sa Omi AI Uvjetima pružanja usluge i Politikom privatnosti';
 
   @override
   String get submitApp => 'Pošalji aplikaciju';
@@ -2880,12 +2833,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get submitAppQuestion => 'Pošalji aplikaciju?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Tvoja aplikacija će biti pregledana i učinjena javnom. Možeš početi koristiti je odmah, čak i tijekom pregleda!';
+  String get submitAppPublicDescription => 'Tvoja aplikacija će biti pregledana i učinjena javnom. Možeš početi koristiti je odmah, čak i tijekom pregleda!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Tvoja aplikacija će biti pregledana i učinjena dostupnom tebi privatno. Možeš početi koristiti je odmah, čak i tijekom pregleda!';
+  String get submitAppPrivateDescription => 'Tvoja aplikacija će biti pregledana i učinjena dostupnom tebi privatno. Možeš početi koristiti je odmah, čak i tijekom pregleda!';
 
   @override
   String get startEarning => 'Počni zarada! 💰';
@@ -2909,23 +2860,19 @@ class AppLocalizationsBs extends AppLocalizations {
   String get dataAccessNotice => 'Obavijest o pristupu podacima';
 
   @override
-  String get dataAccessWarning =>
-      'Ova aplikacija će pristupiti tvojim podacima. Omi AI nije odgovoran za kako se tvoji podaci koriste, mijenjaju ili brišu ovom aplikacijom';
+  String get dataAccessWarning => 'Ova aplikacija će pristupiti tvojim podacima. Omi AI nije odgovoran za kako se tvoji podaci koriste, mijenjaju ili brišu ovom aplikacijom';
 
   @override
   String get installApp => 'Instaliraj aplikaciju';
 
   @override
-  String get betaTesterNotice =>
-      'Ti si beta tester za ovu aplikaciju. Još nije javna. Bit će javna nakon što bude odobrena.';
+  String get betaTesterNotice => 'Ti si beta tester za ovu aplikaciju. Još nije javna. Bit će javna nakon što bude odobrena.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Tvoja aplikacija se nalazi na pregledu i vidljiva je samo tebi. Bit će javna nakon što bude odobrena.';
+  String get appUnderReviewOwner => 'Tvoja aplikacija se nalazi na pregledu i vidljiva je samo tebi. Bit će javna nakon što bude odobrena.';
 
   @override
-  String get appRejectedNotice =>
-      'Tvoja aplikacija je odbijena. Molimo ažuriraj detalje aplikacije i ponovno pošalji na pregled.';
+  String get appRejectedNotice => 'Tvoja aplikacija je odbijena. Molimo ažuriraj detalje aplikacije i ponovno pošalji na pregled.';
 
   @override
   String get setupSteps => 'Koraci postavljanja';
@@ -2987,8 +2934,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get descriptionLabel => 'Opis';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Moja odličan aplikacija je odličan aplikacija koja radi nevjerojatne stvari. To je najbolja aplikacija ikad!';
+  String get appDescriptionPlaceholder => 'Moja odličan aplikacija je odličan aplikacija koja radi nevjerojatne stvari. To je najbolja aplikacija ikad!';
 
   @override
   String get pleaseProvideValidDescription => 'Molimo pruži važeći opis';
@@ -3140,8 +3086,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get microphonePermissionRequired => 'Dozvola za mikrofon je potrebna za pozivanje';
 
   @override
-  String get microphonePermissionDenied =>
-      'Dozvola za mikrofon je odbijena. Molimo dozvoli dozvolu u Sistemskim postavkama > Privatnost i sigurnost > Mikrofon.';
+  String get microphonePermissionDenied => 'Dozvola za mikrofon je odbijena. Molimo dozvoli dozvolu u Sistemskim postavkama > Privatnost i sigurnost > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3300,8 +3245,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get createMemory => 'Kreiraj uspomenu';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Jesi li siguran da želiš obrisati ovu uspomenu? Ova radnja se ne može opozvati.';
+  String get deleteMemoryConfirmation => 'Jesi li siguran da želiš obrisati ovu uspomenu? Ova radnja se ne može opozvati.';
 
   @override
   String get makePrivate => 'Učini privatnom';
@@ -3375,8 +3319,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get whatWeCollect => 'Što prikupljamo';
 
   @override
-  String get dataCollectionMessage =>
-      'Nastavljanjem, tvoje razgovore, snimke i osobne podatke sigurno ćemo pohraniti na naše poslužitelje kako bi pružili AI-pogonske uvide i omogućili sve značajke aplikacije.';
+  String get dataCollectionMessage => 'Nastavljanjem, tvoje razgovore, snimke i osobne podatke sigurno ćemo pohraniti na naše poslužitelje kako bi pružili AI-pogonske uvide i omogućili sve značajke aplikacije.';
 
   @override
   String get dataProtection => 'Zaštita podataka';
@@ -3409,8 +3352,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Ime mora sadržavati najmanje 2 znaka';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Reci nam kako bi se htio obraćati. To pomaže personalizirati tvoje Omi iskustvo.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Reci nam kako bi se htio obraćati. To pomaže personalizirati tvoje Omi iskustvo.';
 
   @override
   String charactersCount(int count) {
@@ -3427,8 +3369,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get recordAudioConversations => 'Snimi audio razgovore';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi trebam pristup mikrofonu kako bi snimi tvoje razgovore i pružio transkripcije.';
+  String get microphoneAccessDescription => 'Omi trebam pristup mikrofonu kako bi snimi tvoje razgovore i pružio transkripcije.';
 
   @override
   String get screenRecording => 'Snimanje zaslonom';
@@ -3437,8 +3378,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Snimaj sistemski audio sa sastanaka';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi trebam dozvolu za snimanje zaslona kako bi snimio sistemski audio s tvojih web-sastanaka.';
+  String get screenRecordingDescription => 'Omi trebam dozvolu za snimanje zaslona kako bi snimio sistemski audio s tvojih web-sastanaka.';
 
   @override
   String get accessibility => 'Dostupnost';
@@ -3447,8 +3387,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Otkrij web-sastanke';
 
   @override
-  String get accessibilityDescription =>
-      'Omi trebam dozvolu dostupnosti kako bi otkrio kad se priključiš Zoom, Meet ili Teams sastancima u svom pregledniku.';
+  String get accessibilityDescription => 'Omi trebam dozvolu dostupnosti kako bi otkrio kad se priključiš Zoom, Meet ili Teams sastancima u svom pregledniku.';
 
   @override
   String get pleaseWait => 'Molimo čekaj...';
@@ -3517,12 +3456,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get exportAllConversationsToJson => 'Izvezi sve svoje razgovore u JSON datoteku.';
 
   @override
-  String get conversationsExportStarted =>
-      'Izvoz razgovora je započeo. Ovo može potrajati nekoliko sekundi, molimo čekaj.';
+  String get conversationsExportStarted => 'Izvoz razgovora je započeo. Ovo može potrajati nekoliko sekundi, molimo čekaj.';
 
   @override
-  String get mcpDescription =>
-      'Kako bi povezao Omi s drugim aplikacijama za čitanje, pretragu i upravljanje tvojim uspomenama i razgovorima. Stvori ključ kako bi započeo.';
+  String get mcpDescription => 'Kako bi povezao Omi s drugim aplikacijama za čitanje, pretragu i upravljanje tvojim uspomenama i razgovorima. Stvori ključ kako bi započeo.';
 
   @override
   String get apiKeys => 'API ključevi';
@@ -3593,8 +3530,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get auto => 'Automatski';
 
   @override
-  String get noSummaryForApp =>
-      'Nema dostupnog sažetka za ovu aplikaciju. Pokušaj s drugom aplikacijom za bolje rezultate.';
+  String get noSummaryForApp => 'Nema dostupnog sažetka za ovu aplikaciju. Pokušaj s drugom aplikacijom za bolje rezultate.';
 
   @override
   String get tryAnotherApp => 'Pokušaj drugu aplikaciju';
@@ -3631,8 +3567,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Pusti Omi da automatski odabere najbolju aplikaciju';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Jesi li siguran da želiš obrisati ovaj razgovor? Ova se akcija ne može poništiti.';
+  String get deleteConversationConfirmation => 'Jesi li siguran da želiš obrisati ovaj razgovor? Ova se akcija ne može poništiti.';
 
   @override
   String get conversationDeleted => 'Razgovor je obrisan';
@@ -3680,8 +3615,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Priprema snimanja sistemskog zvuka';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klikni gumb da snimiš zvuk za direktnu transkripcionu, AI uvide i automatsko spremanje.';
+  String get clickTheButtonToCaptureAudio => 'Klikni gumb da snimiš zvuk za direktnu transkripcionu, AI uvide i automatsko spremanje.';
 
   @override
   String get reconnecting => 'Ponovno se povezujem...';
@@ -3908,8 +3842,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Obriši graf znanja?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Ovo će obrisati sve izvedene podatke grafa znanja. Tvoje originalne uspomene ostaju sigurne.';
+  String get deleteKnowledgeGraphWarning => 'Ovo će obrisati sve izvedene podatke grafa znanja. Tvoje originalne uspomene ostaju sigurne.';
 
   @override
   String get connectOmiWithAI => 'Poveži Omi s AI asistentima';
@@ -3966,8 +3899,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get updateAppQuestion => 'Ažurirati aplikaciju?';
 
   @override
-  String get updateAppConfirmation =>
-      'Jesi li siguran da želiš ažurirati svoju aplikaciju? Promjene će se odraziti kada ih odobri naš tim.';
+  String get updateAppConfirmation => 'Jesi li siguran da želiš ažurirati svoju aplikaciju? Promjene će se odraziti kada ih odobri naš tim.';
 
   @override
   String get updateApp => 'Ažurira aplikaciju';
@@ -3997,8 +3929,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get no => 'Ne';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Pretplata je uspješno otkazana. Ostaće aktivna do kraja trenutnog razdoblja naplate.';
+  String get subscriptionCancelledSuccessfully => 'Pretplata je uspješno otkazana. Ostaće aktivna do kraja trenutnog razdoblja naplate.';
 
   @override
   String get failedToCancelSubscription => 'Otkazivanje pretplate nije uspjelo. Molimo pokušaj ponovno.';
@@ -4034,8 +3965,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Otkazati pretplatu?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Jesi li siguran da želiš otkazati svoju pretplatu? Nastavit ćeš imati pristup do kraja svog trenutnog razdoblja naplate.';
+  String get cancelSubscriptionConfirmation => 'Jesi li siguran da želiš otkazati svoju pretplatu? Nastavit ćeš imati pristup do kraja svog trenutnog razdoblja naplate.';
 
   @override
   String get cancelSubscriptionButton => 'Otkaži pretplatu';
@@ -4047,12 +3977,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get betaTesterMessage => 'Jesi beta tester za ovu aplikaciju. Još nije javna. Biti će javna kada se odobri.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Tvoja aplikacija je u tijeku pregleda i vidljiva samo tebi. Biti će javna kada se odobri.';
+  String get appUnderReviewMessage => 'Tvoja aplikacija je u tijeku pregleda i vidljiva samo tebi. Biti će javna kada se odobri.';
 
   @override
-  String get appRejectedMessage =>
-      'Tvoja aplikacija je odbijena. Molimo ažuriraj detalje aplikacije i ponovno je podnesi na pregled.';
+  String get appRejectedMessage => 'Tvoja aplikacija je odbijena. Molimo ažuriraj detalje aplikacije i ponovno je podnesi na pregled.';
 
   @override
   String get invalidIntegrationUrl => 'Nevaljani URL integracije';
@@ -4106,8 +4034,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get issueActivatingApp => 'Došlo je do problema pri aktiviranju ove aplikacije. Molimo pokušaj ponovno.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Ova aplikacija će pristupiti tvojim podacima. Omi AI nije odgovorna za način na koji ova aplikacija koristi, mijenja ili briše tvoje podatke';
+  String get dataAccessNoticeDescription => 'Ova aplikacija će pristupiti tvojim podacima. Omi AI nije odgovorna za način na koji ova aplikacija koristi, mijenja ili briše tvoje podatke';
 
   @override
   String get copyUrl => 'Kopira URL';
@@ -4195,8 +4122,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get omiApiKeys => 'Omi API ključevi';
 
   @override
-  String get apiKeysDescription =>
-      'API ključevi se koriste za autentifikaciju kada se tvoja aplikacija komunicira s OMI poslužiteljem. Omogućuju tvojoj aplikaciji sigurno stvaranje uspomena i pristup ostalim OMI uslugama.';
+  String get apiKeysDescription => 'API ključevi se koriste za autentifikaciju kada se tvoja aplikacija komunicira s OMI poslužiteljem. Omogućuju tvojoj aplikaciji sigurno stvaranje uspomena i pristup ostalim OMI uslugama.';
 
   @override
   String get aboutOmiApiKeys => 'O Omi API ključevima';
@@ -4220,8 +4146,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Opozovi API ključ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Ova se akcija ne može poništiti. Sve aplikacije koje koriste ovaj ključ neće više moći pristupiti API-ju.';
+  String get revokeApiKeyWarning => 'Ova se akcija ne može poništiti. Sve aplikacije koje koriste ovaj ključ neće više moći pristupiti API-ju.';
 
   @override
   String get revoke => 'Opozovi';
@@ -4319,8 +4244,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get externalAppAccess => 'Pristup vanjske aplikacije';
 
   @override
-  String get externalAppAccessDescription =>
-      'Slijedeće instalirane aplikacije imaju vanjske integracije i mogu pristupiti tvojim podacima, kao što su razgovori i uspomene.';
+  String get externalAppAccessDescription => 'Slijedeće instalirane aplikacije imaju vanjske integracije i mogu pristupiti tvojim podacima, kao što su razgovori i uspomene.';
 
   @override
   String get noExternalAppsHaveAccess => 'Nema vanjskih aplikacija koje imaju pristup tvojim podacima.';
@@ -4329,8 +4253,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimalna sigurnost (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-end enkripcija je zlatni standard za privatnost. Kada je aktivirana, tvoji su podaci šifrirani na svom uređaju prije nego što se pošalju našim poslužiteljima. To znači da nitko, čak ni Omi, ne može pristupiti tvojoj sadržaju.';
+  String get e2eeDescription => 'End-to-end enkripcija je zlatni standard za privatnost. Kada je aktivirana, tvoji su podaci šifrirani na svom uređaju prije nego što se pošalju našim poslužiteljima. To znači da nitko, čak ni Omi, ne može pristupiti tvojoj sadržaju.';
 
   @override
   String get importantTradeoffs => 'Važni kompromisi:';
@@ -4345,8 +4268,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get featureComingSoon => 'Ova će se značajka uskoro pojaviti!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migracija je u tijeku. Ne možeš promijeniti razinu zaštite dok se ne dovrši.';
+  String get migrationInProgressMessage => 'Migracija je u tijeku. Ne možeš promijeniti razinu zaštite dok se ne dovrši.';
 
   @override
   String get migrationFailed => 'Migracija nije uspjela';
@@ -4365,15 +4287,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get secureEncryption => 'Sigurna enkripcija';
 
   @override
-  String get secureEncryptionDescription =>
-      'Tvoji su podaci šifrirani s ključem jedinstvenim za tebe na našim poslužiteljima, hostiranom na Google Cloud-u. To znači da je tvoj sirovi sadržaj nedostupan bilo kome, uključujući Omi personale ili Google, izravno iz baze podataka.';
+  String get secureEncryptionDescription => 'Tvoji su podaci šifrirani s ključem jedinstvenim za tebe na našim poslužiteljima, hostiranom na Google Cloud-u. To znači da je tvoj sirovi sadržaj nedostupan bilo kome, uključujući Omi personale ili Google, izravno iz baze podataka.';
 
   @override
   String get endToEndEncryption => 'End-to-End enkripcija';
 
   @override
-  String get e2eeCardDescription =>
-      'Aktivira za maksimalnu sigurnost gdje samo ti možeš pristupiti tvojim podacima. Dodirni kako bi saznao više.';
+  String get e2eeCardDescription => 'Aktivira za maksimalnu sigurnost gdje samo ti možeš pristupiti tvojim podacima. Dodirni kako bi saznao više.';
 
   @override
   String get dataAlwaysEncrypted => 'Bez obzira na razinu, tvoji su podaci uvijek šifrirani u mirovanju i u prijenosu.';
@@ -4441,12 +4361,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get trainingDataProgram => 'Program podataka za obuku';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Dobij Omi Unlimited besplatno doprinošenjem svojih podataka za treniranje AI modela.';
+  String get getOmiUnlimitedFree => 'Dobij Omi Unlimited besplatno doprinošenjem svojih podataka za treniranje AI modela.';
 
   @override
-  String get trainingDataBullets =>
-      '• Tvoji podaci pomažu poboljšati AI modele\n• Samo ne-osjetljivi podaci se dijele\n• Potpuno transparentan proces';
+  String get trainingDataBullets => '• Tvoji podaci pomažu poboljšati AI modele\n• Samo ne-osjetljivi podaci se dijele\n• Potpuno transparentan proces';
 
   @override
   String get learnMoreAtOmiTraining => 'Saznaj više na omi.me/training';
@@ -4458,8 +4376,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get submitRequest => 'Podnesi zahtjev';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Hvala! Tvoj zahtjev je u tijeku pregleda. Obavijestit ćemo te kada se odobri.';
+  String get thankYouRequestUnderReview => 'Hvala! Tvoj zahtjev je u tijeku pregleda. Obavijestit ćemo te kada se odobri.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4497,12 +4414,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get monthlyPlanContinues => 'Vaš trenutni mjesečni plan će nastaviti do kraja vašeg perioda naplate';
 
   @override
-  String get paymentMethodCharged =>
-      'Vaša postojeća metoda plaćanja će biti naplaćena automatski kada se vaš mjesečni plan završi';
+  String get paymentMethodCharged => 'Vaša postojeća metoda plaćanja će biti naplaćena automatski kada se vaš mjesečni plan završi';
 
   @override
-  String get annualSubscriptionStarts =>
-      'Vaša godišnja pretplata od 12 mjeseci će se pokrenuti automatski nakon naplate';
+  String get annualSubscriptionStarts => 'Vaša godišnja pretplata od 12 mjeseci će se pokrenuti automatski nakon naplate';
 
   @override
   String get thirteenMonthsCoverage => 'Dobit ćete 13 mjeseci pokrića ukupno (trenutni mjesec + 12 mjeseci godišnjeg)';
@@ -4542,8 +4457,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Vaš godišnji plan će se pokrenuti automatski kada se vaš mjesečni plan završi.';
+  String get annualPlanStartsAutomatically => 'Vaš godišnji plan će se pokrenuti automatski kada se vaš mjesečni plan završi.';
 
   @override
   String planRenewsOn(String date) {
@@ -4610,8 +4524,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Vaša privatnost nam je važna';
 
   @override
-  String get privacyIntroText =>
-      'U Omiju shvaćamo vašu privatnost vrlo ozbiljno. Želimo biti transparentni o podacima koje prikupljamo i kako ih koristimo da poboljšamo naš proizvod za vas. Evo što trebate znati:';
+  String get privacyIntroText => 'U Omiju shvaćamo vašu privatnost vrlo ozbiljno. Želimo biti transparentni o podacima koje prikupljamo i kako ih koristimo da poboljšamo naš proizvod za vas. Evo što trebate znati:';
 
   @override
   String get whatWeTrack => 'Što pratimo';
@@ -4626,12 +4539,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get ourCommitment => 'Naš zahtjev';
 
   @override
-  String get commitmentText =>
-      'Obavezani smo koristiti podatke koje prikupljamo samo kako bismo Omi učinili boljim proizvodom za vas. Vaša privatnost i povjerenje su nama od prvorazrednog značaja.';
+  String get commitmentText => 'Obavezani smo koristiti podatke koje prikupljamo samo kako bismo Omi učinili boljim proizvodom za vas. Vaša privatnost i povjerenje su nama od prvorazrednog značaja.';
 
   @override
-  String get thankYouText =>
-      'Hvala što ste dragocjeni korisnik Omija. Ako imate bilo kakvih pitanja ili zabrinutosti, slobodno nam se obratite na team@basedhardware.com.';
+  String get thankYouText => 'Hvala što ste dragocjeni korisnik Omija. Ako imate bilo kakvih pitanja ili zabrinutosti, slobodno nam se obratite na team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Postavke WiFi sinhronizacije';
@@ -4640,8 +4551,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get enterHotspotCredentials => 'Unesite vjerodajnice pristupne točke vašeg telefona';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi sinhronizacija koristi vaš telefon kao pristupnu točku. Pronađite naziv pristupne točke i lozinku u Postavkama > Osobna pristupna točka.';
+  String get wifiSyncUsesHotspot => 'WiFi sinhronizacija koristi vaš telefon kao pristupnu točku. Pronađite naziv pristupne točke i lozinku u Postavkama > Osobna pristupna točka.';
 
   @override
   String get hotspotNameSsid => 'Naziv pristupne točke (SSID)';
@@ -4676,8 +4586,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nije moguće napraviti sažetak. Provjerite jesu li razgovori za taj dan dostupni.';
+  String get failedToGenerateSummaryCheckConversations => 'Nije moguće napraviti sažetak. Provjerite jesu li razgovori za taj dan dostupni.';
 
   @override
   String get summaryNotFound => 'Sažetak nije pronađen';
@@ -4707,8 +4616,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Izvoz je započet. Ovo može potrajati nekoliko sekundi...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ovo će obrisati sve izvedene podatke grafa znanja (čvorove i veze). Vaše originalne uspomene će ostati sigurne. Grafikon će biti ponovno izgrađen tijekom vremena ili pri sljedećem zahtjevu.';
+  String get knowledgeGraphDeleteDescription => 'Ovo će obrisati sve izvedene podatke grafa znanja (čvorove i veze). Vaše originalne uspomene će ostati sigurne. Grafikon će biti ponovno izgrađen tijekom vremena ili pri sljedećem zahtjevu.';
 
   @override
   String get configureDailySummaryDigest => 'Konfiguriraj svoj dnevni sažetak stavki za akciju';
@@ -4778,8 +4686,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Obrisati sve razgovore bez ograničenja?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Ovo će trajno obrisati sve razgovore uvezene iz Limitless aplikacije. Ova akcija se ne može poništiti.';
+  String get deleteAllLimitlessWarning => 'Ovo će trajno obrisati sve razgovore uvezene iz Limitless aplikacije. Ova akcija se ne može poništiti.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4835,8 +4742,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get howItWorksTitle => 'Kako funkcionira?';
 
   @override
-  String get howPeopleWorks =>
-      'Kada se osoba kreira, možete prijeći na transkripciju razgovora i dodijeliti im odgovarajuće segmente, tako će Omi moći prepoznati njihov govor!';
+  String get howPeopleWorks => 'Kada se osoba kreira, možete prijeći na transkripciju razgovora i dodijeliti im odgovarajuće segmente, tako će Omi moći prepoznati njihov govor!';
 
   @override
   String get tapToDelete => 'Dodirnite za brisanje';
@@ -4862,8 +4768,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get privacyNotice => 'Obavijest o privatnosti';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Snimke mogu uhvatiti glasove drugih osoba. Pazite da imate pristanak svih sudionika prije nego što omogućite.';
+  String get recordingsMayCaptureOthers => 'Snimke mogu uhvatiti glasove drugih osoba. Pazite da imate pristanak svih sudionika prije nego što omogućite.';
 
   @override
   String get enable => 'Omogući';
@@ -4875,8 +4780,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get on => 'Uključeno';
 
   @override
-  String get storeAudioDescription =>
-      'Čuvajte sve audio snimke lokalno na vašem telefonu. Kada je onemogućeno, samo neuspješna učitavanja su čuvana kako bi se uštedilo prostor za pohranu.';
+  String get storeAudioDescription => 'Čuvajte sve audio snimke lokalno na vašem telefonu. Kada je onemogućeno, samo neuspješna učitavanja su čuvana kako bi se uštedilo prostor za pohranu.';
 
   @override
   String get enableLocalStorage => 'Omogući lokalnu pohranu';
@@ -4894,12 +4798,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get storeAudioOnCloud => 'Spremi audio u oblak';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Vaše snimke u stvarnom vremenu bit će pohranjene u privatnoj pohrani u oblaku dok govorite.';
+  String get cloudStorageDialogMessage => 'Vaše snimke u stvarnom vremenu bit će pohranjene u privatnoj pohrani u oblaku dok govorite.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Pohranite snimke u stvarnom vremenu u privatnoj pohrani u oblaku dok govorite. Audio se hvata i sigurno sprema u stvarnom vremenu.';
+  String get storeAudioCloudDescription => 'Pohranite snimke u stvarnom vremenu u privatnoj pohrani u oblaku dok govorite. Audio se hvata i sigurno sprema u stvarnom vremenu.';
 
   @override
   String get downloadingFirmware => 'Preuzimanje firmware-a';
@@ -4908,8 +4810,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get installingFirmware => 'Instalacija firmware-a';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Nemojte zatvarati aplikaciju niti isključiti uređaj. Ovo bi moglo oštetiti vaš uređaj.';
+  String get firmwareUpdateWarning => 'Nemojte zatvarati aplikaciju niti isključiti uređaj. Ovo bi moglo oštetiti vaš uređaj.';
 
   @override
   String get firmwareUpdated => 'Firmware je ažuriran';
@@ -4953,8 +4854,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get payments => 'Uplate';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Povežite metodu plaćanja ispod kako biste započeli primanje plaćanja za vaše aplikacije.';
+  String get connectPaymentMethodInfo => 'Povežite metodu plaćanja ispod kako biste započeli primanje plaćanja za vaše aplikacije.';
 
   @override
   String get selectedPaymentMethod => 'Odabrana metoda plaćanja';
@@ -4981,15 +4881,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get monthlyPayouts => 'Mjesečne isplate';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Primite mjesečne isplate izravno na svoj račun kada dosegnete 10 dolara prihoda';
+  String get monthlyPayoutsDescription => 'Primite mjesečne isplate izravno na svoj račun kada dosegnete 10 dolara prihoda';
 
   @override
   String get secureAndReliable => 'Sigurno i pouzdano';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe osigurava sigurne i pravovremene prosljeđivanja vašeg prihoda od aplikacije';
+  String get stripeSecureDescription => 'Stripe osigurava sigurne i pravovremene prosljeđivanja vašeg prihoda od aplikacije';
 
   @override
   String get selectYourCountry => 'Odaberite vašu zemlju';
@@ -5010,8 +4908,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get connectingYourStripeAccount => 'Povezivanje vašeg Stripe računa';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Molimo dovršite Stripe proces uključivanja u svom pregledniku. Ova se stranica će automatski ažurirati nakon što je dovršena.';
+  String get stripeOnboardingInstructions => 'Molimo dovršite Stripe proces uključivanja u svom pregledniku. Ova se stranica će automatski ažurirati nakon što je dovršena.';
 
   @override
   String get failedTryAgain => 'Nije uspjelo? Pokušaj ponovno';
@@ -5023,8 +4920,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get successfullyConnected => 'Uspješno povezano!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Vaš Stripe račun je sada spreman za primanje plaćanja. Možete odmah početi zarađivati od prodaje aplikacije.';
+  String get stripeReadyForPayments => 'Vaš Stripe račun je sada spreman za primanje plaćanja. Možete odmah početi zarađivati od prodaje aplikacije.';
 
   @override
   String get updateStripeDetails => 'Ažuriraj Stripe detalje';
@@ -5042,8 +4938,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Ažuriraj detalje svog PayPal računa';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Povežite vaš PayPal račun kako biste započeli primanje plaćanja za vaše aplikacije';
+  String get connectPayPalToReceivePayments => 'Povežite vaš PayPal račun kako biste započeli primanje plaćanja za vaše aplikacije';
 
   @override
   String get paypalEmail => 'PayPal e-mail';
@@ -5104,12 +4999,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Dodatni uzorak govora je uklonjen';
 
   @override
-  String get consentDataMessage =>
-      'Nastavljanjem, vaši razgovori, snimke i lični podaci bit će sigurno pohranjeni na našim serverima. Vaši audio zapisi i transkripti se obrađuju od strane AI usluga trećih strana (uključujući Deepgram za transkripciju i OpenAI za analizu) kako bi vam pružili uvide pokretane vještačkom inteligencijom i omogućili sve funkcije aplikacije.';
+  String get consentDataMessage => 'Nastavljanjem, vaši razgovori, snimke i lični podaci bit će sigurno pohranjeni na našim serverima. Vaši audio zapisi i transkripti se obrađuju od strane AI usluga trećih strana (uključujući Deepgram za transkripciju i OpenAI za analizu) kako bi vam pružili uvide pokretane vještačkom inteligencijom i omogućili sve funkcije aplikacije.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Zadaci iz vaših razgovora će se pojaviti ovdje.\\nDodirnite + da ga kreirate ručno.';
+  String get tasksEmptyStateMessage => 'Zadaci iz vaših razgovora će se pojaviti ovdje.\\nDodirnite + da ga kreirate ručno.';
 
   @override
   String get clearChatAction => 'Očisti razgovor';
@@ -5145,15 +5038,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Instalirajte Omi na vaš\\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Kako biste koristili Apple Watch s Omijom, trebate prvo instalirati Omi aplikaciju na svoj satnici.';
+  String get installOmiOnAppleWatchDescription => 'Kako biste koristili Apple Watch s Omijom, trebate prvo instalirati Omi aplikaciju na svoj satnici.';
 
   @override
   String get openOmiOnAppleWatch => 'Otvorite Omi na vaš\\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi aplikacija je instalirana na vašoj Apple Watch satnici. Otvorite je i dodirnite Počni kako biste započeli.';
+  String get openOmiOnAppleWatchDescription => 'Omi aplikacija je instalirana na vašoj Apple Watch satnici. Otvorite je i dodirnite Počni kako biste započeli.';
 
   @override
   String get openWatchApp => 'Otvori aplikaciju satnice';
@@ -5162,15 +5053,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Instalirao/a sam i otvorio/a aplikaciju';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Nije moguće otvoriti Apple Watch aplikaciju. Molimo ručno otvorite Watch aplikaciju na vašoj Apple Watch satnici i instalirajte Omi iz odjeljka \"Dostupne aplikacije\".';
+  String get unableToOpenWatchApp => 'Nije moguće otvoriti Apple Watch aplikaciju. Molimo ručno otvorite Watch aplikaciju na vašoj Apple Watch satnici i instalirajte Omi iz odjeljka \"Dostupne aplikacije\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch je uspješno povezan!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch još nije dostupan. Molimo provjerite je li Omi aplikacija otvorena na vašoj satnici.';
+  String get appleWatchNotReachable => 'Apple Watch još nije dostupan. Molimo provjerite je li Omi aplikacija otvorena na vašoj satnici.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5598,29 +5487,25 @@ class AppLocalizationsBs extends AppLocalizations {
   String get multipleSpeakersDetected => 'Detektirani su višestruki govornici';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Čini se da ima više govornika u snimci. Molimo provjerite da ste na tihoj lokaciji i pokušajte ponovno.';
+  String get multipleSpeakersDescription => 'Čini se da ima više govornika u snimci. Molimo provjerite da ste na tihoj lokaciji i pokušajte ponovno.';
 
   @override
   String get invalidRecordingDetected => 'Detektirana je nevaljana snimka';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Nema dovoljno detektiranog govora. Molimo govorite više i pokušajte ponovno.';
+  String get notEnoughSpeechDescription => 'Nema dovoljno detektiranog govora. Molimo govorite više i pokušajte ponovno.';
 
   @override
   String get speechDurationDescription => 'Molimo osigurajte da govorite najmanje 5 sekundi i ne više od 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Veza je prekinuta. Molimo proverite vašu internet konekciju i pokušajte ponovno.';
+  String get connectionLostDescription => 'Veza je prekinuta. Molimo proverite vašu internet konekciju i pokušajte ponovno.';
 
   @override
   String get howToTakeGoodSample => 'Kako napraviti dobar uzorak?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Osigurajte se da ste na mirnom mjestu.\n2. Govorite jasno i prirodno.\n3. Osigurajte se da je vaš uređaj u prirodnoj poziciji, na vašoj vratu.\n\nKada se napravi, uvijek ga možete poboljšati ili ponoviti.';
+  String get goodSampleInstructions => '1. Osigurajte se da ste na mirnom mjestu.\n2. Govorite jasno i prirodno.\n3. Osigurajte se da je vaš uređaj u prirodnoj poziciji, na vašoj vratu.\n\nKada se napravi, uvijek ga možete poboljšati ili ponoviti.';
 
   @override
   String get noDeviceConnectedUseMic => 'Nema priključenog uređaja. Koristit će se mikrofon telefona.';
@@ -5683,8 +5568,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get howItWorks => 'Kako funkcioniše';
 
   @override
-  String get dailyScoreExplanation =>
-      'Tvoj dnevni rezultat je zasnovan na završetku zadataka. Završi svoje zadatke da poboljšaš rezultat!';
+  String get dailyScoreExplanation => 'Tvoj dnevni rezultat je zasnovan na završetku zadataka. Završi svoje zadatke da poboljšaš rezultat!';
 
   @override
   String get notificationFrequencyDescription => 'Kontroliši kako često Omi šalje proaktivna obaveštenja i podsetnike.';
@@ -5932,8 +5816,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get recordings => 'Snimci';
 
   @override
-  String get enableRemindersAccess =>
-      'Molimo omogućite pristup podsjetnicima u postavkama da biste koristili Apple podsjetnike';
+  String get enableRemindersAccess => 'Molimo omogućite pristup podsjetnicima u postavkama da biste koristili Apple podsjetnike';
 
   @override
   String todayAtTime(String time) {
@@ -5988,8 +5871,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL nije postavljen';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Molimo postavite webhook URL u postavkama za razvojnjake da biste koristili ovu funkciju.';
+  String get setWebhookUrlInSettings => 'Molimo postavite webhook URL u postavkama za razvojnjake da biste koristili ovu funkciju.';
 
   @override
   String get sendWebUrl => 'Pošalji web url';
@@ -6063,15 +5945,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get cloudProvider => 'Pružalac usluga u oblaku';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 premium minuta/mjesec. Kartaca na uređaju nudi neограничenu besplatnu transkripciju.';
+  String get premiumMinutesInfo => '1.200 premium minuta/mjesec. Kartaca na uređaju nudi neограничenu besplatnu transkripciju.';
 
   @override
   String get viewUsage => 'Prikaži upotrebu';
 
   @override
-  String get localProcessingInfo =>
-      'Audio se obrađuje lokalno. Funkcioniše bez interneta, privatnije je, ali troši više baterije.';
+  String get localProcessingInfo => 'Audio se obrađuje lokalno. Funkcioniše bez interneta, privatnije je, ali troši više baterije.';
 
   @override
   String get model => 'Model';
@@ -6080,15 +5960,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get performanceWarning => 'Upozorenje o performansama';
 
   @override
-  String get largeModelWarning =>
-      'Ovaj model je velik i može uzrokovati pad aplikacije ili vrlo sporo pokretanje na mobilnim uređajima.\n\nPreporučuje se \"small\" ili \"base\".';
+  String get largeModelWarning => 'Ovaj model je velik i može uzrokovati pad aplikacije ili vrlo sporo pokretanje na mobilnim uređajima.\n\nPreporučuje se \"small\" ili \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Korištenje nativnog iOS prepoznavanja govora';
 
   @override
-  String get noModelDownloadRequired =>
-      'Koristiće se ugrađeni motor za govore vašeg uređaja. Preuzimanje modela nije potrebno.';
+  String get noModelDownloadRequired => 'Koristiće se ugrađeni motor za govore vašeg uređaja. Preuzimanje modela nije potrebno.';
 
   @override
   String get modelReady => 'Model je spreman';
@@ -6145,12 +6023,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get batteryDrainSignificantly => 'Drenaža baterije će se značajno povećati.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 premium minuta/mjesec. Kartaca na uređaju nudi neograničenu besplatnu transkripciju. ';
+  String get premiumMinutesMonth => '1.200 premium minuta/mjesec. Kartaca na uređaju nudi neograničenu besplatnu transkripciju. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Audio se obrađuje lokalno. Funkcioniše bez interneta, privatnije je, ali troši više baterije.';
+  String get audioProcessedLocally => 'Audio se obrađuje lokalno. Funkcioniše bez interneta, privatnije je, ali troši više baterije.';
 
   @override
   String get languageLabel => 'Jezik';
@@ -6159,12 +6035,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Ovaj model je velik i može uzrokovati pad aplikacije ili vrlo sporo pokretanje na mobilnim uređajima.\n\nPreporučuje se \"small\" ili \"base\".';
+  String get modelTooLargeWarning => 'Ovaj model je velik i može uzrokovati pad aplikacije ili vrlo sporo pokretanje na mobilnim uređajima.\n\nPreporučuje se \"small\" ili \"base\".';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Koristiće se ugrađeni motor za govore vašeg uređaja. Preuzimanje modela nije potrebno.';
+  String get nativeEngineNoDownload => 'Koristiće se ugrađeni motor za govore vašeg uređaja. Preuzimanje modela nije potrebno.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6200,8 +6074,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Ugrađena transkripcija u realnom vremenu tvrtke Omi je optimizovana za razgovore u realnom vremenu sa automatskim detektovanjem govornika i dijalizacijom.';
+  String get omiTranscriptionOptimized => 'Ugrađena transkripcija u realnom vremenu tvrtke Omi je optimizovana za razgovore u realnom vremenu sa automatskim detektovanjem govornika i dijalizacijom.';
 
   @override
   String get reset => 'Resetuj';
@@ -6421,8 +6294,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Gradim tvoj graf znanja iz uspomena...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Tvoj graf znanja će se graditi automatski dok kreijaš nove uspomene.';
+  String get knowledgeGraphWillBuildAutomatically => 'Tvoj graf znanja će se graditi automatski dok kreijaš nove uspomene.';
 
   @override
   String get buildGraphButton => 'Napravi graf';
@@ -6658,8 +6530,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get failedToLoadContacts => 'Neuspješno učitavanje kontakata';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Neuspješna priprema razgovora za dijeljenje. Molimo pokušajte ponovno.';
+  String get failedToPrepareConversationForSharing => 'Neuspješna priprema razgovora za dijeljenje. Molimo pokušajte ponovno.';
 
   @override
   String get couldNotOpenSmsApp => 'Nije moguće otvoriti SMS aplikaciju. Molimo pokušajte ponovno.';
@@ -6725,8 +6596,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Preuzimanje audija sa SD kartice vašeg uređaja';
 
   @override
-  String get transferRequiredDescription =>
-      'Ovaj snimak je sačuvan na SD kartici vašeg uređaja. Prenesi ga na svoj telefon da bi ga mogao reproducirati ili dijeliti.';
+  String get transferRequiredDescription => 'Ovaj snimak je sačuvan na SD kartici vašeg uređaja. Prenesi ga na svoj telefon da bi ga mogao reproducirati ili dijeliti.';
 
   @override
   String get cancelTransfer => 'Otkaži transfer';
@@ -6747,8 +6617,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get shareRecording => 'Dijeli snimak';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Jeste li sigurni da želite da trajno izbrišete ovaj snimak? Ovo se ne može poništiti.';
+  String get deleteRecordingConfirmation => 'Jeste li sigurni da želite da trajno izbrišete ovaj snimak? Ovo se ne može poništiti.';
 
   @override
   String get recordingIdLabel => 'ID snimka';
@@ -6807,8 +6676,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get enableFastTransfer => 'Omogući brzi prenos';
 
   @override
-  String get fastTransferDescription =>
-      'Brzi prenos koristi WiFi za ~5x brže brzine. Vaš telefon će se privremeno povezati na WiFi mrežu vašeg Omi uređaja tokom prenosa.';
+  String get fastTransferDescription => 'Brzi prenos koristi WiFi za ~5x brže brzine. Vaš telefon će se privremeno povezati na WiFi mrežu vašeg Omi uređaja tokom prenosa.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Pristup internetu je pauziran tokom prenosa';
@@ -6823,8 +6691,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get fiveTimesFaster => '5X BRŽE';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Kreira direktnu WiFi konekciju sa vašim Omi uređajem. Vaš telefon se privremeno odvaja od običnog WiFi-ja tokom prenosa.';
+  String get fastTransferMethodDescription => 'Kreira direktnu WiFi konekciju sa vašim Omi uređajem. Vaš telefon se privremeno odvaja od običnog WiFi-ja tokom prenosa.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6833,8 +6700,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get bleSpeed => '~30 KB/s preko BLE-a';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Koristi standardnu Bluetooth niskoenergijsku konekciju. Sporije, ali ne utiče na vašu WiFi konekciju.';
+  String get bluetoothMethodDescription => 'Koristi standardnu Bluetooth niskoenergijsku konekciju. Sporije, ali ne utiče na vašu WiFi konekciju.';
 
   @override
   String get selected => 'Odabrano';
@@ -6852,8 +6718,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'Vaš Omi uređaj se odvojio';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'Molimo da se ponovno povežete da biste nastavili sa korišćenjem vašeg Omi-ja.';
+  String get deviceDisconnectedNotificationBody => 'Molimo da se ponovno povežete da biste nastavili sa korišćenjem vašeg Omi-ja.';
 
   @override
   String get firmwareUpdateAvailable => 'Dostupna je ažuriranja firmvera';
@@ -6873,12 +6738,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get appDeleteFailed => 'Greška pri brisanju aplikacije. Molimo pokušajte ponovo kasnije.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Vidljivost aplikacije je uspješno promijenjena. Može trebati nekoliko minuta da se promjena odrazi.';
+  String get appVisibilityChangedSuccessfully => 'Vidljivost aplikacije je uspješno promijenjena. Može trebati nekoliko minuta da se promjena odrazi.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Greška pri aktiviranju aplikacije. Ako je ovo aplikacija za integraciju, pazite da je setup završen.';
+  String get errorActivatingAppIntegration => 'Greška pri aktiviranju aplikacije. Ako je ovo aplikacija za integraciju, pazite da je setup završen.';
 
   @override
   String get errorUpdatingAppStatus => 'Greška pri ažuriranju statusa aplikacije.';
@@ -6958,8 +6821,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Naziv mora biti najmanje 3 karaktera';
 
   @override
-  String get conversationPromptHint =>
-      'npr., Izvucite stavke za akciju, donešene odluke i ključne zaključke iz datog razgovora.';
+  String get conversationPromptHint => 'npr., Izvucite stavke za akciju, donešene odluke i ključne zaključke iz datog razgovora.';
 
   @override
   String get pleaseEnterAppPrompt => 'Molimo unesite prompt za vašu aplikaciju';
@@ -6992,8 +6854,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get failedToCreateApp => 'Greška pri pravljenju aplikacije. Molimo pokušajte ponovo.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'Molimo odaberite jednu više osnovnu mogućnost za vašu aplikaciju da nastavite';
+  String get addAppSelectCoreCapability => 'Molimo odaberite jednu više osnovnu mogućnost za vašu aplikaciju da nastavite';
 
   @override
   String get addAppSelectPaymentPlan => 'Molimo odaberite plan plaćanja i unesite cijenu za vašu aplikaciju';
@@ -7042,8 +6903,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'Dozvola za fotografije je odbijena. Molimo dozvolite pristup fotografijama da odaberete sliku';
+  String get addAppPhotosPermissionDenied => 'Dozvola za fotografije je odbijena. Molimo dozvolite pristup fotografijama da odaberete sliku';
 
   @override
   String get addAppErrorSelectingImageRetry => 'Greška pri odabiru slike. Molimo pokušajte ponovo.';
@@ -7063,12 +6923,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get addAppPersonaConflictWithCapabilities => 'Persona ne može biti odabrana sa ostalim mogućnostima';
 
   @override
-  String get paymentFailedToFetchCountries =>
-      'Greška pri učitavanju podržanih država. Molimo pokušajte ponovo kasnije.';
+  String get paymentFailedToFetchCountries => 'Greška pri učitavanju podržanih država. Molimo pokušajte ponovo kasnije.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Greška pri postavljanju zadane metode plaćanja. Molimo pokušajte ponovo kasnije.';
+  String get paymentFailedToSetDefault => 'Greška pri postavljanju zadane metode plaćanja. Molimo pokušajte ponovo kasnije.';
 
   @override
   String get paymentFailedToSavePaypal => 'Greška pri čuvanju PayPal detalja. Molimo pokušajte ponovo kasnije.';
@@ -7150,15 +7008,13 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Ažuriranja je zakazana! Vaš mjesečni plan se nastavlja do kraja vašeg perioda naplate, zatim se automatski prebacuje na godišnji.';
+  String get planUpgradeScheduledMessage => 'Ažuriranja je zakazana! Vaš mjesečni plan se nastavlja do kraja vašeg perioda naplate, zatim se automatski prebacuje na godišnji.';
 
   @override
   String get couldNotSchedulePlanChange => 'Nije moguće zakazati promenu plana. Molimo pokušajte ponovo.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Vaša pretplata je reaktivirana! Nema naknade sada - biće vam naplaćeno na kraju vašeg trenutnog perioda.';
+  String get subscriptionReactivatedDefault => 'Vaša pretplata je reaktivirana! Nema naknade sada - biće vam naplaćeno na kraju vašeg trenutnog perioda.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Pretplata je uspješna! Bačena vam je naplaćena za novi period naplate.';
@@ -7341,8 +7197,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Dozvola za Bluetooth je potrebna za povezivanje sa vašim uređajem.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Dozvola za Bluetooth je odbijena. Molimo dozvoli dozvolu u Postavkama sistema.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Dozvola za Bluetooth je odbijena. Molimo dozvoli dozvolu u Postavkama sistema.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7355,12 +7210,10 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Dozvola za obavijesti je odbijena. Molimo dozvoli dozvolu u Postavkama sistema.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Dozvola za obavijesti je odbijena. Molimo dozvoli dozvolu u Postavkama sistema.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Dozvola za obavijesti je odbijena. Molimo dozvoli dozvolu u Postavkama sistema > Obavijesti.';
+  String get onboardingNotificationDeniedNotifications => 'Dozvola za obavijesti je odbijena. Molimo dozvoli dozvolu u Postavkama sistema > Obavijesti.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7373,15 +7226,13 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Molimo dozvoli dozvolu za lokaciju u Postavkama > Privatnost i sigurnost > Lokacijske usluge';
+  String get onboardingLocationGrantInSettings => 'Molimo dozvoli dozvolu za lokaciju u Postavkama > Privatnost i sigurnost > Lokacijske usluge';
 
   @override
   String get onboardingMicrophoneRequired => 'Dozvola za mikrofon je potrebna za snimanje.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Dozvola za mikrofon je odbijena. Molimo dozvoli dozvolu u Postavkama sistema > Privatnost i sigurnost > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Dozvola za mikrofon je odbijena. Molimo dozvoli dozvolu u Postavkama sistema > Privatnost i sigurnost > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7397,8 +7248,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Dozvola za snimanje ekrana je potrebna za snimanje sistemskog zvuka.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Dozvola za snimanje ekrana je odbijena. Molimo dozvoli dozvolu u Postavkama sistema > Privatnost i sigurnost > Snimanje ekrana.';
+  String get onboardingScreenCaptureDenied => 'Dozvola za snimanje ekrana je odbijena. Molimo dozvoli dozvolu u Postavkama sistema > Privatnost i sigurnost > Snimanje ekrana.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7411,8 +7261,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Dozvola za pristupačnost je potrebna za detektovanje pregleda sa povezanog uređaja.';
+  String get onboardingAccessibilityRequired => 'Dozvola za pristupačnost je potrebna za detektovanje pregleda sa povezanog uređaja.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7452,8 +7301,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Dozvola za fotografije je odbijena. Molimo dozvoli pristup fotografijama da odaberete slike';
+  String get msgPhotosPermissionDenied => 'Dozvola za fotografije je odbijena. Molimo dozvoli pristup fotografijama da odaberete slike';
 
   @override
   String get msgSelectImagesGenericError => 'Greška pri odabiru slika. Molimo pokušajte ponovo.';
@@ -7525,8 +7373,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get locationPermissionRequired => 'Dozvola za lokaciju je potrebna';
 
   @override
-  String get locationPermissionContent =>
-      'Brzi prenos zahtijeva dozvolu za lokaciju da provjeri WiFi konekciju. Molimo dozvoli dozvolu za lokaciju da nastavite.';
+  String get locationPermissionContent => 'Brzi prenos zahtijeva dozvolu za lokaciju da provjeri WiFi konekciju. Molimo dozvoli dozvolu za lokaciju da nastavite.';
 
   @override
   String get pdfTranscriptExport => 'Izvoz transkripcije';
@@ -7689,8 +7536,7 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Uređaj ne podržava WiFi sinhronizaciju, prebacujem na Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Uređaj ne podržava WiFi sinhronizaciju, prebacujem na Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health nije dostupan na ovom uređaju';
@@ -7986,8 +7832,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Postavi Omi DevKit u režim uparivanja';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Pritisni dugme jednom da uključiš. LED će treperiti ljubičasto kada je u režimu uparivanja.';
+  String get pairingDescOmiDevkit => 'Pritisni dugme jednom da uključiš. LED će treperiti ljubičasto kada je u režimu uparivanja.';
 
   @override
   String get pairingTitleOmiGlass => 'Uključi Omi Glass';
@@ -7999,8 +7844,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Postavi Plaud Note u režim uparivanja';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Drži bočno dugme 2 sekunde. Crveni LED će treperiti kada je spreman za uparivanje.';
+  String get pairingDescPlaudNote => 'Drži bočno dugme 2 sekunde. Crveni LED će treperiti kada je spreman za uparivanje.';
 
   @override
   String get pairingTitleBee => 'Postavi Bee u režim uparivanja';
@@ -8012,15 +7856,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get pairingTitleLimitless => 'Postavi Limitless u režim uparivanja';
 
   @override
-  String get pairingDescLimitless =>
-      'Kada je neko svetlo vidljivo, pritisni jednom, a zatim drži dok uređaj ne prikaže ružičasto svetlo, zatim otpusti.';
+  String get pairingDescLimitless => 'Kada je neko svetlo vidljivo, pritisni jednom, a zatim drži dok uređaj ne prikaže ružičasto svetlo, zatim otpusti.';
 
   @override
   String get pairingTitleFriendPendant => 'Postavi Friend Pendant u režim uparivanja';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Pritisni dugme na privescu da ga uključiš. Automatski će ući u režim uparivanja.';
+  String get pairingDescFriendPendant => 'Pritisni dugme na privescu da ga uključiš. Automatski će ući u režim uparivanja.';
 
   @override
   String get pairingTitleFieldy => 'Postavi Fieldy u režim uparivanja';
@@ -8032,8 +7874,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Poveži Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Instaliraj i otvori Omi aplikaciju na Apple Watch-u, zatim dotakni Poveži u aplikaciji.';
+  String get pairingDescAppleWatch => 'Instaliraj i otvori Omi aplikaciju na Apple Watch-u, zatim dotakni Poveži u aplikaciji.';
 
   @override
   String get pairingTitleNeoOne => 'Postavi Neo One u režim uparivanja';
@@ -8156,8 +7997,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get switchAndRestart => 'Prebaci';
 
   @override
-  String get stagingDisclaimer =>
-      'Staging može biti buggy, imati neusaglašene performanse i podaci mogu biti izgubljeni. Koristite samo za testiranje.';
+  String get stagingDisclaimer => 'Staging može biti buggy, imati neusaglašene performanse i podaci mogu biti izgubljeni. Koristite samo za testiranje.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Sačuvano. Zatvorite i ponovo otvorite aplikaciju da se primene izmene.';
@@ -8386,8 +8226,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Pozivi preko Omi-a';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Pozivaj preko Omi-a i dobij transkribovanje u realnom vremenu, automatske rezime i još mnogo toga. Dostupno isključivo pretplatnicima Unlimited plana.';
+  String get phoneCallsUpsellSubtitle => 'Pozivaj preko Omi-a i dobij transkribovanje u realnom vremenu, automatske rezime i još mnogo toga. Dostupno isključivo pretplatnicima Unlimited plana.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transkribovanje u realnom vremenu svakog poziva';
@@ -8414,8 +8253,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deleteSyncedFiles => 'Obriši sinhronizovane snimke';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Ove snimke su već sinhronizovane sa tvojim telefonom. Ovo se ne može vratiti.';
+  String get deleteSyncedFilesMessage => 'Ove snimke su već sinhronizovane sa tvojim telefonom. Ovo se ne može vratiti.';
 
   @override
   String get syncedFilesDeleted => 'Sinhronizovane snimke su obrisane';
@@ -8427,8 +8265,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deletePendingFiles => 'Obriši snimke na čekanju';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Ove snimke NISU sinhronizovane sa tvojim telefonom i biće zauvek izgubljene. Ovo se ne može vratiti.';
+  String get deletePendingFilesWarning => 'Ove snimke NISU sinhronizovane sa tvojim telefonom i biće zauvek izgubljene. Ovo se ne može vratiti.';
 
   @override
   String get pendingFilesDeleted => 'Snimke na čekanju su obrisane';
@@ -8440,8 +8277,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deleteAll => 'Obriši sve';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Ovo će obrisati i sinhronizovane i snimke na čekanju. Snimke na čekanju NISU sinhronizovane i biće zauvek izgubljene. Ovo se ne može vratiti.';
+  String get deleteAllFilesWarning => 'Ovo će obrisati i sinhronizovane i snimke na čekanju. Snimke na čekanju NISU sinhronizovane i biće zauvek izgubljene. Ovo se ne može vratiti.';
 
   @override
   String get allFilesDeleted => 'Sve snimke su obrisane';
@@ -8506,8 +8342,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get fairUseAboutTitle => 'O fer upotrebi';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi je dizajniran za lične razgovore, sastanke i živu interakciju. Upotreba se meri vremenom stvarnog govora koji je detektovan, ne vremenom konekcije. Ako upotreba značajno prelazi normalne obrasce za ne-lični sadržaj, mogu se primeniti prilagođavanja.';
+  String get fairUseAboutBody => 'Omi je dizajniran za lične razgovore, sastanke i živu interakciju. Upotreba se meri vremenom stvarnog govora koji je detektovan, ne vremenom konekcije. Ako upotreba značajno prelazi normalne obrasce za ne-lični sadržaj, mogu se primeniti prilagođavanja.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8545,8 +8380,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get improveConnectionTitle => 'Poboljšaj konekciju';
 
   @override
-  String get improveConnectionContent =>
-      'Poboljšali smo kako Omi ostaje povezan sa vašim uređajem. Da biste ovo aktivirali, molim vas da idete na stranicu Informacije o uređaju, dodirnete \"Otkačite uređaj\", a zatim ponovo uparite vaš uređaj.';
+  String get improveConnectionContent => 'Poboljšali smo kako Omi ostaje povezan sa vašim uređajem. Da biste ovo aktivirali, molim vas da idete na stranicu Informacije o uređaju, dodirnete \"Otkačite uređaj\", a zatim ponovo uparite vaš uređaj.';
 
   @override
   String get improveConnectionAction => 'Shvaćeno';
@@ -8601,16 +8435,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get cancelSyncQuestion => 'Otkaži sinhronizovanje?';
 
   @override
-  String get omisStorageDesc =>
-      'Kada vaš Omi nije povezan sa vašim telefonom, čuva audio lokalno na svojoj ugrađenoj memoriji. Nikada ne gubite snimak.';
+  String get omisStorageDesc => 'Kada vaš Omi nije povezan sa vašim telefonom, čuva audio lokalno na svojoj ugrađenoj memoriji. Nikada ne gubite snimak.';
 
   @override
-  String get phoneStorageDesc =>
-      'Kada se Omi ponovo poveže, snimke se automatski prenose na vaš telefon kao privremena oblast čuvanja pre učitavanja.';
+  String get phoneStorageDesc => 'Kada se Omi ponovo poveže, snimke se automatski prenose na vaš telefon kao privremena oblast čuvanja pre učitavanja.';
 
   @override
-  String get cloudStorageDesc =>
-      'Nakon učitavanja, vaše snimke se obrađuju i transkribuju. Razgovori će biti dostupni u roku od minute.';
+  String get cloudStorageDesc => 'Nakon učitavanja, vaše snimke se obrađuju i transkribuju. Razgovori će biti dostupni u roku od minute.';
 
   @override
   String get tipKeepPhoneNearby => 'Čuvajte telefon blizu za brže sinhronizovanje';
@@ -8634,12 +8465,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get permissionEnable => 'Omogući';
 
   @override
-  String get permissionsPageDescription =>
-      'Ove dozvole su jezgro kako Omi funkcionira. One omogućavaju ključne funkcije poput obaveštenja, iskustava zasnovanih na lokaciji i hvatanja zvuka.';
+  String get permissionsPageDescription => 'Ove dozvole su jezgro kako Omi funkcionira. One omogućavaju ključne funkcije poput obaveštenja, iskustava zasnovanih na lokaciji i hvatanja zvuka.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi treba nekoliko dozvola da funkcionira pravilno. Molim vas da ih odobrite da biste nastavili.';
+  String get permissionsRequiredDescription => 'Omi treba nekoliko dozvola da funkcionira pravilno. Molim vas da ih odobrite da biste nastavili.';
 
   @override
   String get permissionsSetupTitle => 'Uži najbolje iskustvo';
@@ -8895,8 +8724,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get enableLocationTitle => 'Omogući lokaciju';
 
   @override
-  String get enableLocationDescription =>
-      'Dozvola za lokaciju je potrebna da se pronađe obližnjim Bluetooth uređajima.';
+  String get enableLocationDescription => 'Dozvola za lokaciju je potrebna da se pronađe obližnjim Bluetooth uređajima.';
 
   @override
   String get voiceRecordingFound => 'Snimak pronađen';
@@ -8917,8 +8745,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get firmwareWarningTitle => 'Važno: Pročitajte prije ažuriranja';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ovaj firmware će formatirati SD karticu. Molimo osigurajte da su svi offline podaci sinhronizovani prije nadogradnje.\n\nAko vidite trepćuće crveno svjetlo nakon instaliranja ove verzije, ne brinite. Jednostavno povežite uređaj s aplikacijom i trebao bi postati plav. Crveno svjetlo znači da sat uređaja još nije sinhronizovan.';
+  String get firmwareFormatWarning => 'Ovaj firmware će formatirati SD karticu. Molimo osigurajte da su svi offline podaci sinhronizovani prije nadogradnje.\n\nAko vidite trepćuće crveno svjetlo nakon instaliranja ove verzije, ne brinite. Jednostavno povežite uređaj s aplikacijom i trebao bi postati plav. Crveno svjetlo znači da sat uređaja još nije sinhronizovan.';
 
   @override
   String get continueAnyway => 'Nastavi';
@@ -8938,8 +8765,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get tasksMarkComplete => 'Označeno kao završeno';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi pristupa Apple Health-u preko Appleovog HealthKit okvira. Pristup možete opozvati u bilo kojem trenutku u iOS postavkama.';
+  String get appleHealthManageNote => 'Omi pristupa Apple Health-u preko Appleovog HealthKit okvira. Pristup možete opozvati u bilo kojem trenutku u iOS postavkama.';
 
   @override
   String get appleHealthConnectCta => 'Poveži s Apple Health';
@@ -8972,8 +8798,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Pristup Apple Health-u je odbijen';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi nema dozvolu za čitanje vaših Apple Health podataka. Omogućite ga u iOS Postavke → Privatnost i sigurnost → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi nema dozvolu za čitanje vaših Apple Health podataka. Omogućite ga u iOS Postavke → Privatnost i sigurnost → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Zašto odlazite?';
@@ -9042,8 +8867,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get planUpdate => 'Ažuriranje plana';
 
   @override
-  String get planDeprecationMessage =>
-      'Vaš Unlimited plan se ukida. Pređite na Operator plan — iste odlične funkcije za \$49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.';
+  String get planDeprecationMessage => 'Vaš Unlimited plan se ukida. Pređite na Operator plan — iste odlične funkcije za \$49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.';
 
   @override
   String get upgradeYourPlan => 'Nadogradite svoj plan';
@@ -9154,8 +8978,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Dosegli ste svoj mjesečni limit. Nadogradite da nastavite razgovarati s Omi bez ograničenja.';
+  String get chatQuotaExceededReply => 'Dosegli ste svoj mjesečni limit. Nadogradite da nastavite razgovarati s Omi bez ograničenja.';
 
   @override
   String get voiceResponseAudio => 'Pročitaj Omi odgovor naglas';
@@ -9186,4 +9009,25 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Dodaj zadatak';
+
+  @override
+  String get quickActionAskOmiAnything => 'Pitajte Omi bilo šta';
+
+  @override
+  String get quickActionVoiceMode => 'Glasovni način';
+
+  @override
+  String get quickActionMute => 'Isključi zvuk';
+
+  @override
+  String get quickActionUnmute => 'Uključi zvuk';
+
+  @override
+  String get quickActionConnectDevice => 'Poveži uređaj';
+
+  @override
+  String get quickActionDeviceSettings => 'Postavke uređaja';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -24,8 +24,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deleteConversationTitle => 'Eliminar conversa?';
 
   @override
-  String get deleteConversationMessage =>
-      'Això també eliminarà els records, tasques i fitxers d\'àudio associats. Aquesta acció no es pot desfer.';
+  String get deleteConversationMessage => 'Això també eliminarà els records, tasques i fitxers d\'àudio associats. Aquesta acció no es pot desfer.';
 
   @override
   String get confirm => 'Confirmar';
@@ -146,8 +145,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deleting => 'Eliminant...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Completeu l\'autenticació al vostre navegador. Un cop fet, torneu a l\'aplicació.';
+  String get pleaseCompleteAuthentication => 'Completeu l\'autenticació al vostre navegador. Un cop fet, torneu a l\'aplicació.';
 
   @override
   String get failedToStartAuthentication => 'No s\'ha pogut iniciar l\'autenticació';
@@ -228,8 +226,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get noStarredConversations => 'No hi ha converses destacades';
 
   @override
-  String get starConversationHint =>
-      'Per destacar una conversa, obriu-la i toqueu la icona d\'estrella a la capçalera.';
+  String get starConversationHint => 'Per destacar una conversa, obriu-la i toqueu la icona d\'estrella a la capçalera.';
 
   @override
   String get searchConversations => 'Cercar converses...';
@@ -320,8 +317,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get installedApps => 'Aplicacions instal·lades';
 
   @override
-  String get unableToFetchApps =>
-      'No s\'han pogut obtenir les aplicacions :(\n\nComproveu la vostra connexió a internet i torneu-ho a provar.';
+  String get unableToFetchApps => 'No s\'han pogut obtenir les aplicacions :(\n\nComproveu la vostra connexió a internet i torneu-ho a provar.';
 
   @override
   String get aboutOmi => 'Sobre Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsCa extends AppLocalizations {
   String get appsDisconnected => 'Les vostres aplicacions i integracions es desconnectaran immediatament.';
 
   @override
-  String get exportBeforeDelete =>
-      'Podeu exportar les vostres dades abans d\'eliminar el compte, però un cop eliminat, no es pot recuperar.';
+  String get exportBeforeDelete => 'Podeu exportar les vostres dades abans d\'eliminar el compte, però un cop eliminat, no es pot recuperar.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Entenc que eliminar el meu compte és permanent i totes les dades, incloent records i converses, es perdran i no es poden recuperar.';
+  String get deleteAccountCheckbox => 'Entenc que eliminar el meu compte és permanent i totes les dades, incloent records i converses, es perdran i no es poden recuperar.';
 
   @override
   String get areYouSure => 'Esteu segur?';
 
   @override
-  String get deleteAccountFinal =>
-      'Aquesta acció és irreversible i eliminarà permanentment el vostre compte i totes les dades associades. Esteu segur que voleu continuar?';
+  String get deleteAccountFinal => 'Aquesta acció és irreversible i eliminarà permanentment el vostre compte i totes les dades associades. Esteu segur que voleu continuar?';
 
   @override
   String get deleteNow => 'Eliminar ara';
@@ -378,8 +371,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get goBack => 'Tornar';
 
   @override
-  String get checkBoxToConfirm =>
-      'Marqueu la casella per confirmar que enteneu que eliminar el vostre compte és permanent i irreversible.';
+  String get checkBoxToConfirm => 'Marqueu la casella per confirmar que enteneu que eliminar el vostre compte és permanent i irreversible.';
 
   @override
   String get profile => 'Perfil';
@@ -457,8 +449,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get yourPrivacyYourControl => 'La vostra privadesa, el vostre control';
 
   @override
-  String get privacyIntro =>
-      'A Omi, estem compromesos a protegir la vostra privadesa. Aquesta pàgina us permet controlar com s\'emmagatzemen i utilitzen les vostres dades.';
+  String get privacyIntro => 'A Omi, estem compromesos a protegir la vostra privadesa. Aquesta pàgina us permet controlar com s\'emmagatzemen i utilitzen les vostres dades.';
 
   @override
   String get learnMore => 'Més informació...';
@@ -467,15 +458,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get dataProtectionLevel => 'Nivell de protecció de dades';
 
   @override
-  String get dataProtectionDesc =>
-      'Les vostres dades estan protegides per defecte amb un xifratge fort. Reviseu la vostra configuració i opcions futures de privadesa a continuació.';
+  String get dataProtectionDesc => 'Les vostres dades estan protegides per defecte amb un xifratge fort. Reviseu la vostra configuració i opcions futures de privadesa a continuació.';
 
   @override
   String get appAccess => 'Accés d\'aplicacions';
 
   @override
-  String get appAccessDesc =>
-      'Les següents aplicacions poden accedir a les vostres dades. Toqueu una aplicació per gestionar els seus permisos.';
+  String get appAccessDesc => 'Les següents aplicacions poden accedir a les vostres dades. Toqueu una aplicació per gestionar els seus permisos.';
 
   @override
   String get noAppsExternalAccess => 'Cap aplicació instal·lada té accés extern a les vostres dades.';
@@ -532,22 +521,19 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deviceDisconnectedMessage => 'El vostre Omi s\'ha desconnectat 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Dispositiu desvinculat. Vés a Configuració > Bluetooth i oblida el dispositiu per completar la desvinculació.';
+  String get deviceUnpairedMessage => 'Dispositiu desvinculat. Vés a Configuració > Bluetooth i oblida el dispositiu per completar la desvinculació.';
 
   @override
   String get unpairDialogTitle => 'Desvincular dispositiu';
 
   @override
-  String get unpairDialogMessage =>
-      'Això desvin cularà el dispositiu perquè es pugui connectar a un altre telèfon. Haureu d\'anar a Configuració > Bluetooth i oblidar el dispositiu per completar el procés.';
+  String get unpairDialogMessage => 'Això desvin cularà el dispositiu perquè es pugui connectar a un altre telèfon. Haureu d\'anar a Configuració > Bluetooth i oblidar el dispositiu per completar el procés.';
 
   @override
   String get deviceNotConnected => 'Dispositiu no connectat';
 
   @override
-  String get connectDeviceMessage =>
-      'Connecteu el vostre dispositiu Omi per accedir\na la configuració i personalització del dispositiu';
+  String get connectDeviceMessage => 'Connecteu el vostre dispositiu Omi per accedir\na la configuració i personalització del dispositiu';
 
   @override
   String get deviceInfoSection => 'Informació del dispositiu';
@@ -562,8 +548,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get v2Undetected => 'V2 no detectat';
 
   @override
-  String get v2UndetectedMessage =>
-      'Veiem que teniu un dispositiu V1 o que el vostre dispositiu no està connectat. La funcionalitat de targeta SD només està disponible per a dispositius V2.';
+  String get v2UndetectedMessage => 'Veiem que teniu un dispositiu V1 o que el vostre dispositiu no està connectat. La funcionalitat de targeta SD només està disponible per a dispositius V2.';
 
   @override
   String get endConversation => 'Finalitzar conversa';
@@ -695,8 +680,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get noActivityYet => 'Encara no hi ha activitat';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Comenceu una conversa amb Omi\nper veure les vostres estadístiques d\'ús aquí.';
+  String get startConversationToSeeInsights => 'Comenceu una conversa amb Omi\nper veure les vostres estadístiques d\'ús aquí.';
 
   @override
   String get listening => 'Escoltant';
@@ -758,8 +742,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get shareStatsMessage =>
-      'Compartint les meves estadístiques d\'Omi! (omi.me - el vostre assistent d\'IA sempre actiu)';
+  String get shareStatsMessage => 'Compartint les meves estadístiques d\'Omi! (omi.me - el vostre assistent d\'IA sempre actiu)';
 
   @override
   String get sharePeriodToday => 'Avui, omi ha:';
@@ -839,8 +822,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Eliminar graf de coneixement?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Això eliminarà totes les dades derivades del graf de coneixement (nodes i connexions). Els vostres records originals restaran segurs. El graf es reconstruirà amb el temps o a la propera sol·licitud.';
+  String get deleteKnowledgeGraphMessage => 'Això eliminarà totes les dades derivades del graf de coneixement (nodes i connexions). Els vostres records originals restaran segurs. El graf es reconstruirà amb el temps o a la propera sol·licitud.';
 
   @override
   String get knowledgeGraphDeleted => 'Graf de coneixement eliminat';
@@ -988,8 +970,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get shortConversationThreshold => 'Llindar de conversa curta';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Les converses més curtes que això s\'amagaran tret que s\'activi a dalt';
+  String get shortConversationThresholdSubtitle => 'Les converses més curtes que això s\'amagaran tret que s\'activi a dalt';
 
   @override
   String get durationThreshold => 'Llindar de durada';
@@ -1024,8 +1005,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get integrationsFooter => 'Connecteu les vostres aplicacions per veure dades i estadístiques al xat.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Completeu l\'autenticació al vostre navegador. Un cop fet, torneu a l\'aplicació.';
+  String get completeAuthInBrowser => 'Completeu l\'autenticació al vostre navegador. Un cop fet, torneu a l\'aplicació.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1085,37 +1065,31 @@ class AppLocalizationsCa extends AppLocalizations {
   String get needYourPermission => 'Necessitem el vostre permís';
 
   @override
-  String get alreadyGavePermission =>
-      'Ja ens heu donat permís per desar els vostres enregistraments. Aquí teniu un recordatori de per què ho necessitem:';
+  String get alreadyGavePermission => 'Ja ens heu donat permís per desar els vostres enregistraments. Aquí teniu un recordatori de per què ho necessitem:';
 
   @override
-  String get wouldLikePermission =>
-      'Ens agradaria el vostre permís per desar els vostres enregistraments de veu. Aquesta és la raó:';
+  String get wouldLikePermission => 'Ens agradaria el vostre permís per desar els vostres enregistraments de veu. Aquesta és la raó:';
 
   @override
   String get improveSpeechProfile => 'Millorar el vostre perfil de veu';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Utilitzem els enregistraments per entrenar i millorar el vostre perfil de veu personal.';
+  String get improveSpeechProfileDesc => 'Utilitzem els enregistraments per entrenar i millorar el vostre perfil de veu personal.';
 
   @override
   String get trainFamilyProfiles => 'Entrenar perfils d\'amics i família';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Els vostres enregistraments ens ajuden a reconèixer i crear perfils per als vostres amics i família.';
+  String get trainFamilyProfilesDesc => 'Els vostres enregistraments ens ajuden a reconèixer i crear perfils per als vostres amics i família.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Millorar la precisió de transcripció';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'A mesura que el nostre model millora, podem proporcionar millors resultats de transcripció per als vostres enregistraments.';
+  String get enhanceTranscriptAccuracyDesc => 'A mesura que el nostre model millora, podem proporcionar millors resultats de transcripció per als vostres enregistraments.';
 
   @override
-  String get legalNotice =>
-      'Avís legal: La legalitat d\'enregistrar i emmagatzemar dades de veu pot variar segons la vostra ubicació i com utilitzeu aquesta funció. És la vostra responsabilitat assegurar el compliment de les lleis i regulacions locals.';
+  String get legalNotice => 'Avís legal: La legalitat d\'enregistrar i emmagatzemar dades de veu pot variar segons la vostra ubicació i com utilitzeu aquesta funció. És la vostra responsabilitat assegurar el compliment de les lleis i regulacions locals.';
 
   @override
   String get alreadyAuthorized => 'Ja autoritzat';
@@ -1187,15 +1161,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get showMeetingsMenuBar => 'Mostrar reunions properes a la barra de menú';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Mostrar la vostra propera reunió i el temps fins que comenci a la barra de menú de macOS';
+  String get showMeetingsMenuBarDesc => 'Mostrar la vostra propera reunió i el temps fins que comenci a la barra de menú de macOS';
 
   @override
   String get showEventsNoParticipants => 'Mostrar esdeveniments sense participants';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Quan s\'activa, Properament mostra esdeveniments sense participants o enllaç de vídeo.';
+  String get showEventsNoParticipantsDesc => 'Quan s\'activa, Properament mostra esdeveniments sense participants o enllaç de vídeo.';
 
   @override
   String get yourMeetings => 'Les vostres reunions';
@@ -1236,8 +1208,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get noProjectsInWorkspace => 'No s\'han trobat projectes en aquest espai de treball';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Trieu quant temps esperar en silenci abans de finalitzar automàticament una conversa:';
+  String get conversationTimeoutDesc => 'Trieu quant temps esperar en silenci abans de finalitzar automàticament una conversa:';
 
   @override
   String get timeout2Minutes => '2 minuts';
@@ -1281,12 +1252,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Digueu-nos el vostre idioma principal';
 
   @override
-  String get languageForTranscription =>
-      'Establiu el vostre idioma per a transcripcions més precises i una experiència personalitzada.';
+  String get languageForTranscription => 'Establiu el vostre idioma per a transcripcions més precises i una experiència personalitzada.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'El mode d\'idioma únic està activat. La traducció està desactivada per a una major precisió.';
+  String get singleLanguageModeInfo => 'El mode d\'idioma únic està activat. La traducció està desactivada per a una major precisió.';
 
   @override
   String get searchLanguageHint => 'Cercar idioma per nom o codi';
@@ -1366,8 +1335,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get defaultRepository => 'Repositori per defecte';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Seleccioneu un repositori per defecte per crear incidències. Encara podeu especificar un repositori diferent quan creeu incidències.';
+  String get selectDefaultRepoDesc => 'Seleccioneu un repositori per defecte per crear incidències. Encara podeu especificar un repositori diferent quan creeu incidències.';
 
   @override
   String get noReposFound => 'No s\'han trobat repositoris';
@@ -1583,8 +1551,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get logsCopied => 'Registres copiats';
 
   @override
-  String get noLogsYet =>
-      'Encara no hi ha registres. Comenceu a enregistrar per veure l\'activitat STT personalitzada.';
+  String get noLogsYet => 'Encara no hi ha registres. Comenceu a enregistrar per veure l\'activitat STT personalitzada.';
 
   @override
   String deviceUsesCodec(String device, String reason) {
@@ -1743,8 +1710,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get enableBluetooth => 'Activar Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi necessita Bluetooth per connectar-se al vostre dispositiu portàtil. Activeu Bluetooth i torneu-ho a provar.';
+  String get bluetoothNeeded => 'Omi necessita Bluetooth per connectar-se al vostre dispositiu portàtil. Activeu Bluetooth i torneu-ho a provar.';
 
   @override
   String get contactSupport => 'Contactar amb suport?';
@@ -1777,26 +1743,22 @@ class AppLocalizationsCa extends AppLocalizations {
   String get locationServiceDisabled => 'Servei d\'ubicació desactivat';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'El servei d\'ubicació està desactivat. Aneu a Configuració > Privadesa i seguretat > Serveis d\'ubicació i activeu-lo';
+  String get locationServiceDisabledDesc => 'El servei d\'ubicació està desactivat. Aneu a Configuració > Privadesa i seguretat > Serveis d\'ubicació i activeu-lo';
 
   @override
   String get backgroundLocationDenied => 'Accés a la ubicació en segon pla denegat';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Aneu a la configuració del dispositiu i establiu el permís d\'ubicació a \"Permetre sempre\"';
+  String get backgroundLocationDeniedDesc => 'Aneu a la configuració del dispositiu i establiu el permís d\'ubicació a \"Permetre sempre\"';
 
   @override
   String get lovingOmi => 'T\'agrada Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Ajudeu-nos a arribar a més gent deixant una ressenya a l\'App Store. Els vostres comentaris són molt importants per a nosaltres!';
+  String get leaveReviewIos => 'Ajudeu-nos a arribar a més gent deixant una ressenya a l\'App Store. Els vostres comentaris són molt importants per a nosaltres!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Ajudeu-nos a arribar a més gent deixant una ressenya a Google Play Store. Els vostres comentaris són molt importants per a nosaltres!';
+  String get leaveReviewAndroid => 'Ajudeu-nos a arribar a més gent deixant una ressenya a Google Play Store. Els vostres comentaris són molt importants per a nosaltres!';
 
   @override
   String get rateOnAppStore => 'Valorar a l\'App Store';
@@ -1808,8 +1770,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get maybeLater => 'Potser més tard';
 
   @override
-  String get speechProfileIntro =>
-      'Omi necessita aprendre els vostres objectius i la vostra veu. Podreu modificar-ho més tard.';
+  String get speechProfileIntro => 'Omi necessita aprendre els vostres objectius i la vostra veu. Podreu modificar-ho més tard.';
 
   @override
   String get getStarted => 'Començar';
@@ -1830,15 +1791,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get connectionError => 'Error de connexió';
 
   @override
-  String get connectionErrorDesc =>
-      'No s\'ha pogut connectar amb el servidor. Comproveu la vostra connexió a internet i torneu-ho a provar.';
+  String get connectionErrorDesc => 'No s\'ha pogut connectar amb el servidor. Comproveu la vostra connexió a internet i torneu-ho a provar.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'S\'ha detectat un enregistrament no vàlid';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Sembla que hi ha diversos parlants a l\'enregistrament. Assegureu-vos que esteu en un lloc tranquil i torneu-ho a provar.';
+  String get multipleSpeakersDesc => 'Sembla que hi ha diversos parlants a l\'enregistrament. Assegureu-vos que esteu en un lloc tranquil i torneu-ho a provar.';
 
   @override
   String get tooShortDesc => 'No s\'ha detectat prou veu. Parleu més i torneu-ho a provar.';
@@ -1850,15 +1809,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get areYouThere => 'Hi sou?';
 
   @override
-  String get noSpeechDesc =>
-      'No hem pogut detectar cap veu. Assegureu-vos de parlar durant almenys 10 segons i no més de 3 minuts.';
+  String get noSpeechDesc => 'No hem pogut detectar cap veu. Assegureu-vos de parlar durant almenys 10 segons i no més de 3 minuts.';
 
   @override
   String get connectionLost => 'Connexió perduda';
 
   @override
-  String get connectionLostDesc =>
-      'La connexió s\'ha interromput. Comproveu la vostra connexió a internet i torneu-ho a provar.';
+  String get connectionLostDesc => 'La connexió s\'ha interromput. Comproveu la vostra connexió a internet i torneu-ho a provar.';
 
   @override
   String get tryAgain => 'Tornar a provar';
@@ -1873,8 +1830,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get permissionsRequired => 'Permisos necessaris';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Aquesta aplicació necessita permisos de Bluetooth i ubicació per funcionar correctament. Activeu-los a la configuració.';
+  String get permissionsRequiredDesc => 'Aquesta aplicació necessita permisos de Bluetooth i ubicació per funcionar correctament. Activeu-los a la configuració.';
 
   @override
   String get openSettings => 'Obrir configuració';
@@ -1916,12 +1872,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get microphonePermission => 'Permís del micròfon';
 
   @override
-  String get permissionGrantedNow =>
-      'Permís atorgat! Ara:\n\nObriu l\'aplicació Omi al vostre rellotge i toqueu \"Continuar\" a continuació';
+  String get permissionGrantedNow => 'Permís atorgat! Ara:\n\nObriu l\'aplicació Omi al vostre rellotge i toqueu \"Continuar\" a continuació';
 
   @override
-  String get needMicrophonePermission =>
-      'Necessitem permís del micròfon.\n\n1. Toqueu \"Atorgar permís\"\n2. Permeteu al vostre iPhone\n3. L\'aplicació del rellotge es tancarà\n4. Torneu a obrir-la i toqueu \"Continuar\"';
+  String get needMicrophonePermission => 'Necessitem permís del micròfon.\n\n1. Toqueu \"Atorgar permís\"\n2. Permeteu al vostre iPhone\n3. L\'aplicació del rellotge es tancarà\n4. Torneu a obrir-la i toqueu \"Continuar\"';
 
   @override
   String get grantPermissionButton => 'Atorgar permís';
@@ -1930,15 +1884,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get needHelp => 'Necessiteu ajuda?';
 
   @override
-  String get troubleshootingSteps =>
-      'Resolució de problemes:\n\n1. Assegureu-vos que Omi està instal·lat al vostre rellotge\n2. Obriu l\'aplicació Omi al vostre rellotge\n3. Busqueu la finestra emergent de permisos\n4. Toqueu \"Permetre\" quan se us demani\n5. L\'aplicació al vostre rellotge es tancarà - torneu a obrir-la\n6. Torneu i toqueu \"Continuar\" al vostre iPhone';
+  String get troubleshootingSteps => 'Resolució de problemes:\n\n1. Assegureu-vos que Omi està instal·lat al vostre rellotge\n2. Obriu l\'aplicació Omi al vostre rellotge\n3. Busqueu la finestra emergent de permisos\n4. Toqueu \"Permetre\" quan se us demani\n5. L\'aplicació al vostre rellotge es tancarà - torneu a obrir-la\n6. Torneu i toqueu \"Continuar\" al vostre iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Enregistrament iniciat correctament!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Permís encara no atorgat. Assegureu-vos que heu permès l\'accés al micròfon i heu tornat a obrir l\'aplicació al vostre rellotge.';
+  String get permissionNotGrantedYet => 'Permís encara no atorgat. Assegureu-vos que heu permès l\'accés al micròfon i heu tornat a obrir l\'aplicació al vostre rellotge.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1954,8 +1906,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get selectPrimaryLanguage => 'Seleccioneu el vostre idioma principal';
 
   @override
-  String get languageBenefits =>
-      'Establiu el vostre idioma per a transcripcions més precises i una experiència personalitzada';
+  String get languageBenefits => 'Establiu el vostre idioma per a transcripcions més precises i una experiència personalitzada';
 
   @override
   String get whatsYourPrimaryLanguage => 'Quin és el vostre idioma principal?';
@@ -2036,8 +1987,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Llest per a les tasques';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'La vostra IA extraurà automàticament tasques de les vostres converses. Apareixeran aquí quan es creïn.';
+  String get welcomeActionItemsDescription => 'La vostra IA extraurà automàticament tasques de les vostres converses. Apareixeran aquí quan es creïn.';
 
   @override
   String get autoExtractionFeature => 'Extret automàticament de converses';
@@ -2233,15 +2183,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'VEU I TRANSCRIPCIÓ';
 
   @override
-  String get languageSettingsHelperText =>
-      'L\'idioma de l\'aplicació canvia els menús i els botons. L\'idioma de la veu afecta com es transcriuen les teves gravacions.';
+  String get languageSettingsHelperText => 'L\'idioma de l\'aplicació canvia els menús i els botons. L\'idioma de la veu afecta com es transcriuen les teves gravacions.';
 
   @override
   String get translationNotice => 'Avís de traducció';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi tradueix les converses al teu idioma principal. Actualitza-ho en qualsevol moment a Configuració → Perfils.';
+  String get translationNoticeMessage => 'Omi tradueix les converses al teu idioma principal. Actualitza-ho en qualsevol moment a Configuració → Perfils.';
 
   @override
   String get pleaseCheckInternetConnection => 'Si us plau, comprova la teva connexió a Internet i torna-ho a intentar';
@@ -2396,8 +2344,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Desvincula el dispositiu';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Això desvinculará el dispositiu perquè pugui connectar-se a un altre telèfon. Hauràs d\'anar a Configuració > Bluetooth i oblidar el dispositiu per completar el procés.';
+  String get unpairDeviceDialogMessage => 'Això desvinculará el dispositiu perquè pugui connectar-se a un altre telèfon. Hauràs d\'anar a Configuració > Bluetooth i oblidar el dispositiu per completar el procés.';
 
   @override
   String get unpair => 'Desvincula';
@@ -2578,8 +2525,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get youreAllSet => 'Estàs a punt!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Benvingut a Omi! El teu company d\'IA està preparat per ajudar-te amb converses, tasques i molt més.';
+  String get welcomeToOmiDescription => 'Benvingut a Omi! El teu company d\'IA està preparat per ajudar-te amb converses, tasques i molt més.';
 
   @override
   String get startUsingOmi => 'Comença a utilitzar Omi';
@@ -2658,8 +2604,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get reviewAndManageConversations => 'Revisa i gestiona les teves converses capturades';
 
   @override
-  String get startCapturingConversations =>
-      'Comença a capturar converses amb el teu dispositiu Omi per veure-les aquí.';
+  String get startCapturingConversations => 'Comença a capturar converses amb el teu dispositiu Omi per veure-les aquí.';
 
   @override
   String get useMobileAppToCapture => 'Utilitza la teva aplicació mòbil per capturar àudio';
@@ -2716,8 +2661,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get noTasksYet => 'Encara no hi ha tasques';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Les tasques de les vostres converses apareixeran aquí.\nFeu clic a Crear per afegir-ne una manualment.';
+  String get tasksFromConversationsWillAppear => 'Les tasques de les vostres converses apareixeran aquí.\nFeu clic a Crear per afegir-ne una manualment.';
 
   @override
   String get monthJan => 'Gen';
@@ -2774,8 +2718,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deleteActionItem => 'Eliminar tasca';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Esteu segur que voleu eliminar aquesta tasca? Aquesta acció no es pot desfer.';
+  String get deleteActionItemConfirmation => 'Esteu segur que voleu eliminar aquesta tasca? Aquesta acció no es pot desfer.';
 
   @override
   String get enterActionItemDescription => 'Introduïu la descripció de la tasca...';
@@ -2817,8 +2760,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get checkBackLaterForNewApps => 'Torna més tard per veure aplicacions noves';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'Si us plau, comprova la connexió a Internet i torna-ho a provar';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'Si us plau, comprova la connexió a Internet i torna-ho a provar';
 
   @override
   String get createNewApp => 'Crear nova aplicació';
@@ -2851,15 +2793,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get chatPrompt => 'Indicació de xat';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ets una aplicació increïble, la teva feina és respondre a les consultes de l\'usuari i fer que se sentin bé...';
+  String get chatPromptPlaceholder => 'Ets una aplicació increïble, la teva feina és respondre a les consultes de l\'usuari i fer que se sentin bé...';
 
   @override
   String get conversationPrompt => 'Indicació de conversa';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Ets una aplicació increïble, rebràs una transcripció i resum d\'una conversa...';
+  String get conversationPromptPlaceholder => 'Ets una aplicació increïble, rebràs una transcripció i resum d\'una conversa...';
 
   @override
   String get notificationScopes => 'Àmbits de notificació';
@@ -2871,8 +2811,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get makeMyAppPublic => 'Fes pública la meva aplicació';
 
   @override
-  String get submitAppTermsAgreement =>
-      'En enviar aquesta aplicació, accepto les Condicions de Servei i la Política de Privadesa d\'Omi AI';
+  String get submitAppTermsAgreement => 'En enviar aquesta aplicació, accepto les Condicions de Servei i la Política de Privadesa d\'Omi AI';
 
   @override
   String get submitApp => 'Enviar aplicació';
@@ -2887,12 +2826,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get submitAppQuestion => 'Enviar aplicació?';
 
   @override
-  String get submitAppPublicDescription =>
-      'La teva aplicació serà revisada i feta pública. Pots començar a utilitzar-la immediatament, fins i tot durant la revisió!';
+  String get submitAppPublicDescription => 'La teva aplicació serà revisada i feta pública. Pots començar a utilitzar-la immediatament, fins i tot durant la revisió!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'La teva aplicació serà revisada i feta disponible per a tu de manera privada. Pots començar a utilitzar-la immediatament, fins i tot durant la revisió!';
+  String get submitAppPrivateDescription => 'La teva aplicació serà revisada i feta disponible per a tu de manera privada. Pots començar a utilitzar-la immediatament, fins i tot durant la revisió!';
 
   @override
   String get startEarning => 'Comença a guanyar! 💰';
@@ -2916,23 +2853,19 @@ class AppLocalizationsCa extends AppLocalizations {
   String get dataAccessNotice => 'Avís d\'accés a dades';
 
   @override
-  String get dataAccessWarning =>
-      'Aquesta aplicació accedirà a les teves dades. Omi AI no és responsable de com s\'utilitzen, modifiquen o eliminen les teves dades per aquesta aplicació';
+  String get dataAccessWarning => 'Aquesta aplicació accedirà a les teves dades. Omi AI no és responsable de com s\'utilitzen, modifiquen o eliminen les teves dades per aquesta aplicació';
 
   @override
   String get installApp => 'Instal·la l\'aplicació';
 
   @override
-  String get betaTesterNotice =>
-      'Ets provador beta d\'aquesta aplicació. Encara no és pública. Serà pública un cop aprovada.';
+  String get betaTesterNotice => 'Ets provador beta d\'aquesta aplicació. Encara no és pública. Serà pública un cop aprovada.';
 
   @override
-  String get appUnderReviewOwner =>
-      'La teva aplicació està en revisió i només visible per a tu. Serà pública un cop aprovada.';
+  String get appUnderReviewOwner => 'La teva aplicació està en revisió i només visible per a tu. Serà pública un cop aprovada.';
 
   @override
-  String get appRejectedNotice =>
-      'La teva aplicació ha estat rebutjada. Si us plau, actualitza els detalls de l\'aplicació i torna-la a enviar per a revisió.';
+  String get appRejectedNotice => 'La teva aplicació ha estat rebutjada. Si us plau, actualitza els detalls de l\'aplicació i torna-la a enviar per a revisió.';
 
   @override
   String get setupSteps => 'Passos de configuració';
@@ -2967,8 +2900,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get errorActivatingApp => 'Error en activar l\'aplicació';
 
   @override
-  String get integrationSetupRequired =>
-      'Si aquesta és una aplicació d\'integració, assegura\'t que la configuració està completada.';
+  String get integrationSetupRequired => 'Si aquesta és una aplicació d\'integració, assegura\'t que la configuració està completada.';
 
   @override
   String get installed => 'Instal·lat';
@@ -2995,8 +2927,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get descriptionLabel => 'Descripció';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'La meva aplicació fantàstica és una aplicació genial que fa coses increïbles. És la millor aplicació!';
+  String get appDescriptionPlaceholder => 'La meva aplicació fantàstica és una aplicació genial que fa coses increïbles. És la millor aplicació!';
 
   @override
   String get pleaseProvideValidDescription => 'Si us plau, proporcioneu una descripció vàlida';
@@ -3148,8 +3079,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get microphonePermissionRequired => 'Es requereix permís de micròfon per a l\'enregistrament de veu.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Permís de micròfon denegat. Si us plau, concediu permís a Preferències del Sistema > Privacitat i Seguretat > Micròfon.';
+  String get microphonePermissionDenied => 'Permís de micròfon denegat. Si us plau, concediu permís a Preferències del Sistema > Privacitat i Seguretat > Micròfon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3308,8 +3238,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get createMemory => 'Crear memòria';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Estàs segur que vols eliminar aquesta memòria? Aquesta acció no es pot desfer.';
+  String get deleteMemoryConfirmation => 'Estàs segur que vols eliminar aquesta memòria? Aquesta acció no es pot desfer.';
 
   @override
   String get makePrivate => 'Fer privat';
@@ -3383,8 +3312,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get whatWeCollect => 'Què recopilem';
 
   @override
-  String get dataCollectionMessage =>
-      'En continuar, les teves converses, enregistraments i informació personal s\'emmagatzemaran de manera segura als nostres servidors per proporcionar informació impulsada per IA i habilitar totes les funcions de l\'aplicació.';
+  String get dataCollectionMessage => 'En continuar, les teves converses, enregistraments i informació personal s\'emmagatzemaran de manera segura als nostres servidors per proporcionar informació impulsada per IA i habilitar totes les funcions de l\'aplicació.';
 
   @override
   String get dataProtection => 'Protecció de dades';
@@ -3399,8 +3327,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get chooseYourLanguage => 'Trieu el vostre idioma';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'Seleccioneu el vostre idioma preferit per a la millor experiència Omi';
+  String get selectPreferredLanguageForBestExperience => 'Seleccioneu el vostre idioma preferit per a la millor experiència Omi';
 
   @override
   String get searchLanguages => 'Cerca idiomes...';
@@ -3418,8 +3345,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'El nom ha de tenir almenys 2 caràcters';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Digueu-nos com us agradaria que us adrecem. Això ajuda a personalitzar la vostra experiència Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Digueu-nos com us agradaria que us adrecem. Això ajuda a personalitzar la vostra experiència Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3427,8 +3353,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Activeu les funcions per a la millor experiència Omi al vostre dispositiu.';
+  String get enableFeaturesForBestExperience => 'Activeu les funcions per a la millor experiència Omi al vostre dispositiu.';
 
   @override
   String get microphoneAccess => 'Accés al micròfon';
@@ -3437,8 +3362,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get recordAudioConversations => 'Enregistrar converses d\'àudio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi necessita accés al micròfon per enregistrar les vostres converses i proporcionar transcripcions.';
+  String get microphoneAccessDescription => 'Omi necessita accés al micròfon per enregistrar les vostres converses i proporcionar transcripcions.';
 
   @override
   String get screenRecording => 'Gravació de pantalla';
@@ -3447,8 +3371,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Capturar àudio del sistema de reunions';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi necessita permís de gravació de pantalla per capturar l\'àudio del sistema de les vostres reunions basades en el navegador.';
+  String get screenRecordingDescription => 'Omi necessita permís de gravació de pantalla per capturar l\'àudio del sistema de les vostres reunions basades en el navegador.';
 
   @override
   String get accessibility => 'Accessibilitat';
@@ -3457,8 +3380,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Detectar reunions basades en el navegador';
 
   @override
-  String get accessibilityDescription =>
-      'Omi necessita permís d\'accessibilitat per detectar quan us uniu a reunions de Zoom, Meet o Teams al vostre navegador.';
+  String get accessibilityDescription => 'Omi necessita permís d\'accessibilitat per detectar quan us uniu a reunions de Zoom, Meet o Teams al vostre navegador.';
 
   @override
   String get pleaseWait => 'Si us plau, espereu...';
@@ -3527,12 +3449,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get exportAllConversationsToJson => 'Exporteu totes les vostres converses a un fitxer JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'S\'ha iniciat l\'exportació de converses. Això pot trigar uns segons, espereu.';
+  String get conversationsExportStarted => 'S\'ha iniciat l\'exportació de converses. Això pot trigar uns segons, espereu.';
 
   @override
-  String get mcpDescription =>
-      'Per connectar Omi amb altres aplicacions per llegir, cercar i gestionar els vostres records i converses. Creeu una clau per començar.';
+  String get mcpDescription => 'Per connectar Omi amb altres aplicacions per llegir, cercar i gestionar els vostres records i converses. Creeu una clau per començar.';
 
   @override
   String get apiKeys => 'Claus API';
@@ -3579,8 +3499,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'Creació i etiquetatge automàtic de parlants nous';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Crear automàticament una persona nova quan es detecti un nom a la transcripció.';
+  String get automaticallyCreateNewPerson => 'Crear automàticament una persona nova quan es detecti un nom a la transcripció.';
 
   @override
   String get pilotFeatures => 'Funcions pilot';
@@ -3604,8 +3523,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get auto => 'Automàtic';
 
   @override
-  String get noSummaryForApp =>
-      'No hi ha resum disponible per a aquesta aplicació. Prova una altra aplicació per obtenir millors resultats.';
+  String get noSummaryForApp => 'No hi ha resum disponible per a aquesta aplicació. Prova una altra aplicació per obtenir millors resultats.';
 
   @override
   String get tryAnotherApp => 'Provar una altra aplicació';
@@ -3642,8 +3560,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Deixeu que Omi esculli automàticament la millor aplicació';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Esteu segur que voleu suprimir aquesta conversa? Aquesta acció no es pot desfer.';
+  String get deleteConversationConfirmation => 'Esteu segur que voleu suprimir aquesta conversa? Aquesta acció no es pot desfer.';
 
   @override
   String get conversationDeleted => 'Conversa suprimida';
@@ -3691,8 +3608,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Preparant la captura d\'àudio del sistema';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Feu clic al botó per capturar àudio per a transcripcions en directe, informació d\'IA i desament automàtic.';
+  String get clickTheButtonToCaptureAudio => 'Feu clic al botó per capturar àudio per a transcripcions en directe, informació d\'IA i desament automàtic.';
 
   @override
   String get reconnecting => 'Reconnectant...';
@@ -3919,8 +3835,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Eliminar Gràfic de Coneixement?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Això eliminarà totes les dades derivades del gràfic de coneixement. Els teus records originals romanen segurs.';
+  String get deleteKnowledgeGraphWarning => 'Això eliminarà totes les dades derivades del gràfic de coneixement. Els teus records originals romanen segurs.';
 
   @override
   String get connectOmiWithAI => 'Connecta Omi amb assistents d\'IA';
@@ -3962,8 +3877,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Termes i Política de Privacitat';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Ajuda a diagnosticar problemes. S\'elimina automàticament després de 3 dies.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Ajuda a diagnosticar problemes. S\'elimina automàticament després de 3 dies.';
 
   @override
   String get manageYourApp => 'Gestiona la teva aplicació';
@@ -3978,8 +3892,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get updateAppQuestion => 'Actualitzar l\'aplicació?';
 
   @override
-  String get updateAppConfirmation =>
-      'Estàs segur que vols actualitzar la teva aplicació? Els canvis es reflectiran un cop revisats pel nostre equip.';
+  String get updateAppConfirmation => 'Estàs segur que vols actualitzar la teva aplicació? Els canvis es reflectiran un cop revisats pel nostre equip.';
 
   @override
   String get updateApp => 'Actualitzar aplicació';
@@ -4009,8 +3922,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get no => 'No';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Subscripció cancel·lada amb èxit. Romandrà activa fins al final del període de facturació actual.';
+  String get subscriptionCancelledSuccessfully => 'Subscripció cancel·lada amb èxit. Romandrà activa fins al final del període de facturació actual.';
 
   @override
   String get failedToCancelSubscription => 'No s\'ha pogut cancel·lar la subscripció. Torna-ho a provar.';
@@ -4046,8 +3958,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Cancel·lar subscripció?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Estàs segur que vols cancel·lar la subscripció? Continuaràs tenint accés fins al final del període de facturació actual.';
+  String get cancelSubscriptionConfirmation => 'Estàs segur que vols cancel·lar la subscripció? Continuaràs tenint accés fins al final del període de facturació actual.';
 
   @override
   String get cancelSubscriptionButton => 'Cancel·lar subscripció';
@@ -4056,16 +3967,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get cancelling => 'Cancel·lant...';
 
   @override
-  String get betaTesterMessage =>
-      'Ets un provador beta d\'aquesta aplicació. Encara no és pública. Serà pública un cop aprovada.';
+  String get betaTesterMessage => 'Ets un provador beta d\'aquesta aplicació. Encara no és pública. Serà pública un cop aprovada.';
 
   @override
-  String get appUnderReviewMessage =>
-      'La teva aplicació està en revisió i només és visible per a tu. Serà pública un cop aprovada.';
+  String get appUnderReviewMessage => 'La teva aplicació està en revisió i només és visible per a tu. Serà pública un cop aprovada.';
 
   @override
-  String get appRejectedMessage =>
-      'La teva aplicació ha estat rebutjada. Actualitza els detalls i torna a enviar-la per a revisió.';
+  String get appRejectedMessage => 'La teva aplicació ha estat rebutjada. Actualitza els detalls i torna a enviar-la per a revisió.';
 
   @override
   String get invalidIntegrationUrl => 'URL d\'integració no vàlida';
@@ -4119,8 +4027,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get issueActivatingApp => 'Hi ha hagut un problema en activar aquesta aplicació. Torna-ho a provar.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Aquesta aplicació accedirà a les teves dades. Omi AI no és responsable de com s\'utilitzen les teves dades.';
+  String get dataAccessNoticeDescription => 'Aquesta aplicació accedirà a les teves dades. Omi AI no és responsable de com s\'utilitzen les teves dades.';
 
   @override
   String get copyUrl => 'Copia l\'URL';
@@ -4208,8 +4115,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get omiApiKeys => 'Claus API d\'Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Les claus API s\'utilitzen per a l\'autenticació quan la teva aplicació es comunica amb el servidor OMI. Permeten que la teva aplicació creï records i accedeixi a altres serveis d\'OMI de manera segura.';
+  String get apiKeysDescription => 'Les claus API s\'utilitzen per a l\'autenticació quan la teva aplicació es comunica amb el servidor OMI. Permeten que la teva aplicació creï records i accedeixi a altres serveis d\'OMI de manera segura.';
 
   @override
   String get aboutOmiApiKeys => 'Sobre les claus API d\'Omi';
@@ -4233,8 +4139,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Revocar clau API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Aquesta acció no es pot desfer. Les aplicacions que utilitzin aquesta clau ja no podran accedir a l\'API.';
+  String get revokeApiKeyWarning => 'Aquesta acció no es pot desfer. Les aplicacions que utilitzin aquesta clau ja no podran accedir a l\'API.';
 
   @override
   String get revoke => 'Revocar';
@@ -4323,8 +4228,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get keyCreated => 'Clau creada';
 
   @override
-  String get keyCreatedMessage =>
-      'La teva nova clau ha estat creada. Si us plau, copia-la ara. No la podràs veure de nou.';
+  String get keyCreatedMessage => 'La teva nova clau ha estat creada. Si us plau, copia-la ara. No la podràs veure de nou.';
 
   @override
   String get keyWord => 'Clau';
@@ -4333,8 +4237,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get externalAppAccess => 'Accés d\'aplicacions externes';
 
   @override
-  String get externalAppAccessDescription =>
-      'Les següents aplicacions instal·lades tenen integracions externes i poden accedir a les teves dades, com ara converses i records.';
+  String get externalAppAccessDescription => 'Les següents aplicacions instal·lades tenen integracions externes i poden accedir a les teves dades, com ara converses i records.';
 
   @override
   String get noExternalAppsHaveAccess => 'Cap aplicació externa té accés a les teves dades.';
@@ -4343,15 +4246,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get maximumSecurityE2ee => 'Seguretat màxima (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'El xifratge d\'extrem a extrem és l\'estàndard d\'or per a la privacitat. Quan està activat, les teves dades es xifren al teu dispositiu abans d\'enviar-se als nostres servidors. Això significa que ningú, ni tan sols Omi, pot accedir al teu contingut.';
+  String get e2eeDescription => 'El xifratge d\'extrem a extrem és l\'estàndard d\'or per a la privacitat. Quan està activat, les teves dades es xifren al teu dispositiu abans d\'enviar-se als nostres servidors. Això significa que ningú, ni tan sols Omi, pot accedir al teu contingut.';
 
   @override
   String get importantTradeoffs => 'Compensacions importants:';
 
   @override
-  String get e2eeTradeoff1 =>
-      '• Algunes funcions com les integracions d\'aplicacions externes poden estar desactivades.';
+  String get e2eeTradeoff1 => '• Algunes funcions com les integracions d\'aplicacions externes poden estar desactivades.';
 
   @override
   String get e2eeTradeoff2 => '• Si perds la teva contrasenya, les teves dades no es poden recuperar.';
@@ -4360,8 +4261,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get featureComingSoon => 'Aquesta funció arribarà aviat!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migració en curs. No pots canviar el nivell de protecció fins que s\'hagi completat.';
+  String get migrationInProgressMessage => 'Migració en curs. No pots canviar el nivell de protecció fins que s\'hagi completat.';
 
   @override
   String get migrationFailed => 'La migració ha fallat';
@@ -4380,19 +4280,16 @@ class AppLocalizationsCa extends AppLocalizations {
   String get secureEncryption => 'Xifratge segur';
 
   @override
-  String get secureEncryptionDescription =>
-      'Les teves dades es xifren amb una clau única per a tu als nostres servidors, allotjats a Google Cloud. Això significa que el teu contingut en brut és inaccessible per a qualsevol, inclòs el personal d\'Omi o Google, directament des de la base de dades.';
+  String get secureEncryptionDescription => 'Les teves dades es xifren amb una clau única per a tu als nostres servidors, allotjats a Google Cloud. Això significa que el teu contingut en brut és inaccessible per a qualsevol, inclòs el personal d\'Omi o Google, directament des de la base de dades.';
 
   @override
   String get endToEndEncryption => 'Xifratge d\'extrem a extrem';
 
   @override
-  String get e2eeCardDescription =>
-      'Activa per a la màxima seguretat on només tu pots accedir a les teves dades. Toca per saber-ne més.';
+  String get e2eeCardDescription => 'Activa per a la màxima seguretat on només tu pots accedir a les teves dades. Toca per saber-ne més.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Independentment del nivell, les teves dades sempre estan xifrades en repòs i en trànsit.';
+  String get dataAlwaysEncrypted => 'Independentment del nivell, les teves dades sempre estan xifrades en repòs i en trànsit.';
 
   @override
   String get readOnlyScope => 'Només lectura';
@@ -4457,12 +4354,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get trainingDataProgram => 'Programa de dades d\'entrenament';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Obtén Omi Il·limitat gratis contribuint les teves dades per entrenar models d\'IA.';
+  String get getOmiUnlimitedFree => 'Obtén Omi Il·limitat gratis contribuint les teves dades per entrenar models d\'IA.';
 
   @override
-  String get trainingDataBullets =>
-      '• Les teves dades ajuden a millorar els models d\'IA\n• Només es comparteixen dades no sensibles\n• Procés totalment transparent';
+  String get trainingDataBullets => '• Les teves dades ajuden a millorar els models d\'IA\n• Només es comparteixen dades no sensibles\n• Procés totalment transparent';
 
   @override
   String get learnMoreAtOmiTraining => 'Aprèn més a omi.me/training';
@@ -4474,8 +4369,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get submitRequest => 'Enviar sol·licitud';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Gràcies! La teva sol·licitud està en revisió. T\'avisarem quan sigui aprovada.';
+  String get thankYouRequestUnderReview => 'Gràcies! La teva sol·licitud està en revisió. T\'avisarem quan sigui aprovada.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4513,12 +4407,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get monthlyPlanContinues => 'El teu pla mensual actual continuarà fins al final del període de facturació';
 
   @override
-  String get paymentMethodCharged =>
-      'El teu mètode de pagament existent es cobrarà automàticament quan acabi el teu pla mensual';
+  String get paymentMethodCharged => 'El teu mètode de pagament existent es cobrarà automàticament quan acabi el teu pla mensual';
 
   @override
-  String get annualSubscriptionStarts =>
-      'La teva subscripció anual de 12 mesos començarà automàticament després del cobrament';
+  String get annualSubscriptionStarts => 'La teva subscripció anual de 12 mesos començarà automàticament després del cobrament';
 
   @override
   String get thirteenMonthsCoverage => 'Obtindràs 13 mesos de cobertura en total (mes actual + 12 mesos anuals)';
@@ -4558,8 +4450,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'El teu pla anual començarà automàticament quan acabi el teu pla mensual.';
+  String get annualPlanStartsAutomatically => 'El teu pla anual començarà automàticament quan acabi el teu pla mensual.';
 
   @override
   String planRenewsOn(String date) {
@@ -4597,8 +4488,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get resubscribe => 'Tornar a subscriure';
 
   @override
-  String get couldNotOpenPaymentSettings =>
-      'No s\'han pogut obrir els ajustos de pagament. Si us plau, torna-ho a provar.';
+  String get couldNotOpenPaymentSettings => 'No s\'han pogut obrir els ajustos de pagament. Si us plau, torna-ho a provar.';
 
   @override
   String get managePaymentMethod => 'Gestionar mètode de pagament';
@@ -4627,8 +4517,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'La teva privadesa ens importa';
 
   @override
-  String get privacyIntroText =>
-      'A Omi, ens prenem molt seriosament la teva privadesa. Volem ser transparents sobre les dades que recollim i com les utilitzem per millorar el producte. Això és el que has de saber:';
+  String get privacyIntroText => 'A Omi, ens prenem molt seriosament la teva privadesa. Volem ser transparents sobre les dades que recollim i com les utilitzem per millorar el producte. Això és el que has de saber:';
 
   @override
   String get whatWeTrack => 'Què fem seguiment';
@@ -4643,12 +4532,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get ourCommitment => 'El nostre compromís';
 
   @override
-  String get commitmentText =>
-      'Estem compromesos a utilitzar les dades que recollim només per fer d\'Omi un producte millor per a tu. La teva privadesa i confiança són primordials per a nosaltres.';
+  String get commitmentText => 'Estem compromesos a utilitzar les dades que recollim només per fer d\'Omi un producte millor per a tu. La teva privadesa i confiança són primordials per a nosaltres.';
 
   @override
-  String get thankYouText =>
-      'Gràcies per ser un usuari valorat d\'Omi. Si tens alguna pregunta o preocupació, no dubtis a contactar-nos a team@basedhardware.com.';
+  String get thankYouText => 'Gràcies per ser un usuari valorat d\'Omi. Si tens alguna pregunta o preocupació, no dubtis a contactar-nos a team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Configuració de sincronització WiFi';
@@ -4657,8 +4544,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get enterHotspotCredentials => 'Introdueix les credencials del punt d\'accés del telèfon';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'La sincronització WiFi utilitza el telèfon com a punt d\'accés. Troba el nom i la contrasenya a Configuració > Punt d\'accés personal.';
+  String get wifiSyncUsesHotspot => 'La sincronització WiFi utilitza el telèfon com a punt d\'accés. Troba el nom i la contrasenya a Configuració > Punt d\'accés personal.';
 
   @override
   String get hotspotNameSsid => 'Nom del punt d\'accés (SSID)';
@@ -4693,8 +4579,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'No s\'ha pogut generar el resum. Assegura\'t que tens converses per a aquell dia.';
+  String get failedToGenerateSummaryCheckConversations => 'No s\'ha pogut generar el resum. Assegura\'t que tens converses per a aquell dia.';
 
   @override
   String get summaryNotFound => 'Resum no trobat';
@@ -4724,8 +4609,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Exportació iniciada. Això pot trigar uns segons...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Això eliminarà totes les dades derivades del graf de coneixement (nodes i connexions). Els teus records originals romandran segurs. El graf es reconstruirà amb el temps o a la propera sol·licitud.';
+  String get knowledgeGraphDeleteDescription => 'Això eliminarà totes les dades derivades del graf de coneixement (nodes i connexions). Els teus records originals romandran segurs. El graf es reconstruirà amb el temps o a la propera sol·licitud.';
 
   @override
   String get configureDailySummaryDigest => 'Configura el resum diari de les teves tasques';
@@ -4795,8 +4679,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Eliminar totes les converses de Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Això eliminarà permanentment totes les converses importades de Limitless. Aquesta acció no es pot desfer.';
+  String get deleteAllLimitlessWarning => 'Això eliminarà permanentment totes les converses importades de Limitless. Aquesta acció no es pot desfer.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4852,8 +4735,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get howItWorksTitle => 'Com funciona?';
 
   @override
-  String get howPeopleWorks =>
-      'Un cop creada una persona, pots anar a una transcripció de conversa i assignar-li els segments corresponents, així Omi també podrà reconèixer la seva parla!';
+  String get howPeopleWorks => 'Un cop creada una persona, pots anar a una transcripció de conversa i assignar-li els segments corresponents, així Omi també podrà reconèixer la seva parla!';
 
   @override
   String get tapToDelete => 'Toca per eliminar';
@@ -4879,8 +4761,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get privacyNotice => 'Avís de privacitat';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Les gravacions poden capturar les veus d\'altres persones. Assegureu-vos de tenir el consentiment de tots els participants abans d\'activar.';
+  String get recordingsMayCaptureOthers => 'Les gravacions poden capturar les veus d\'altres persones. Assegureu-vos de tenir el consentiment de tots els participants abans d\'activar.';
 
   @override
   String get enable => 'Activar';
@@ -4892,8 +4773,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Manteniu totes les gravacions d\'àudio emmagatzemades localment al telèfon. Quan estigui desactivat, només es conserven les càrregues fallides per estalviar espai.';
+  String get storeAudioDescription => 'Manteniu totes les gravacions d\'àudio emmagatzemades localment al telèfon. Quan estigui desactivat, només es conserven les càrregues fallides per estalviar espai.';
 
   @override
   String get enableLocalStorage => 'Activa l\'emmagatzematge local';
@@ -4911,12 +4791,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get storeAudioOnCloud => 'Emmagatzemar àudio al núvol';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Les vostres gravacions en temps real s\'emmagatzemaran a l\'emmagatzematge privat al núvol mentre parleu.';
+  String get cloudStorageDialogMessage => 'Les vostres gravacions en temps real s\'emmagatzemaran a l\'emmagatzematge privat al núvol mentre parleu.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Emmagatzemeu les vostres gravacions en temps real a l\'emmagatzematge privat al núvol mentre parleu. L\'àudio es captura i es desa de manera segura en temps real.';
+  String get storeAudioCloudDescription => 'Emmagatzemeu les vostres gravacions en temps real a l\'emmagatzematge privat al núvol mentre parleu. L\'àudio es captura i es desa de manera segura en temps real.';
 
   @override
   String get downloadingFirmware => 'Descarregant el firmware';
@@ -4925,8 +4803,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get installingFirmware => 'Instal·lant el firmware';
 
   @override
-  String get firmwareUpdateWarning =>
-      'No tanqueu l\'aplicació ni apagueu el dispositiu. Això podria danyar el dispositiu.';
+  String get firmwareUpdateWarning => 'No tanqueu l\'aplicació ni apagueu el dispositiu. Això podria danyar el dispositiu.';
 
   @override
   String get firmwareUpdated => 'Firmware actualitzat';
@@ -4970,8 +4847,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get payments => 'Pagaments';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Connecteu un mètode de pagament a continuació per començar a rebre pagaments per les vostres aplicacions.';
+  String get connectPaymentMethodInfo => 'Connecteu un mètode de pagament a continuació per començar a rebre pagaments per les vostres aplicacions.';
 
   @override
   String get selectedPaymentMethod => 'Mètode de pagament seleccionat';
@@ -4998,15 +4874,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get monthlyPayouts => 'Pagaments mensuals';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Rebeu pagaments mensuals directament al vostre compte quan arribeu als 10 \$ de guanys';
+  String get monthlyPayoutsDescription => 'Rebeu pagaments mensuals directament al vostre compte quan arribeu als 10 \$ de guanys';
 
   @override
   String get secureAndReliable => 'Segur i fiable';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe garanteix transferències segures i puntuals dels ingressos de la vostra aplicació';
+  String get stripeSecureDescription => 'Stripe garanteix transferències segures i puntuals dels ingressos de la vostra aplicació';
 
   @override
   String get selectYourCountry => 'Seleccioneu el vostre país';
@@ -5027,8 +4901,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get connectingYourStripeAccount => 'Connectant el vostre compte de Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Si us plau, completeu el procés d\'incorporació de Stripe al vostre navegador. Aquesta pàgina s\'actualitzarà automàticament un cop completat.';
+  String get stripeOnboardingInstructions => 'Si us plau, completeu el procés d\'incorporació de Stripe al vostre navegador. Aquesta pàgina s\'actualitzarà automàticament un cop completat.';
 
   @override
   String get failedTryAgain => 'Ha fallat? Torneu-ho a provar';
@@ -5040,15 +4913,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get successfullyConnected => 'Connectat amb èxit!';
 
   @override
-  String get stripeReadyForPayments =>
-      'El vostre compte de Stripe està ara preparat per rebre pagaments. Podeu començar a guanyar amb les vendes de les vostres aplicacions de seguida.';
+  String get stripeReadyForPayments => 'El vostre compte de Stripe està ara preparat per rebre pagaments. Podeu començar a guanyar amb les vendes de les vostres aplicacions de seguida.';
 
   @override
   String get updateStripeDetails => 'Actualitzar els detalls de Stripe';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Error en actualitzar els detalls de Stripe! Si us plau, torneu-ho a provar més tard.';
+  String get errorUpdatingStripeDetails => 'Error en actualitzar els detalls de Stripe! Si us plau, torneu-ho a provar més tard.';
 
   @override
   String get updatePayPal => 'Actualitzar PayPal';
@@ -5060,8 +4931,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Actualitzeu les dades del vostre compte de PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Connecteu el vostre compte de PayPal per començar a rebre pagaments per les vostres aplicacions';
+  String get connectPayPalToReceivePayments => 'Connecteu el vostre compte de PayPal per començar a rebre pagaments per les vostres aplicacions';
 
   @override
   String get paypalEmail => 'Correu electrònic de PayPal';
@@ -5070,8 +4940,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get paypalMeLink => 'Enllaç PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Si Stripe està disponible al vostre país, us recomanem molt utilitzar-lo per a pagaments més ràpids i fàcils.';
+  String get stripeRecommendation => 'Si Stripe està disponible al vostre país, us recomanem molt utilitzar-lo per a pagaments més ràpids i fàcils.';
 
   @override
   String get updatePayPalDetails => 'Actualitzar els detalls de PayPal';
@@ -5123,12 +4992,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'S\'ha eliminat la mostra de veu addicional';
 
   @override
-  String get consentDataMessage =>
-      'Continuant, les vostres converses, enregistraments i informació personal s\'emmagatzemaran de manera segura als nostres servidors. Els vostres enregistraments d\'àudio i transcripcions són processats per serveis d\'IA de tercers (incloent Deepgram per a la transcripció i OpenAI per a l\'anàlisi) per proporcionar-vos informació impulsada per IA i habilitar totes les funcions de l\'aplicació.';
+  String get consentDataMessage => 'Continuant, les vostres converses, enregistraments i informació personal s\'emmagatzemaran de manera segura als nostres servidors. Els vostres enregistraments d\'àudio i transcripcions són processats per serveis d\'IA de tercers (incloent Deepgram per a la transcripció i OpenAI per a l\'anàlisi) per proporcionar-vos informació impulsada per IA i habilitar totes les funcions de l\'aplicació.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Les tasques de les teves converses apareixeran aquí.\nToca + per crear-ne una manualment.';
+  String get tasksEmptyStateMessage => 'Les tasques de les teves converses apareixeran aquí.\nToca + per crear-ne una manualment.';
 
   @override
   String get clearChatAction => 'Esborrar el xat';
@@ -5164,15 +5031,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Instal·la Omi al teu\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Per utilitzar el teu Apple Watch amb Omi, primer has d\'instal·lar l\'aplicació Omi al teu rellotge.';
+  String get installOmiOnAppleWatchDescription => 'Per utilitzar el teu Apple Watch amb Omi, primer has d\'instal·lar l\'aplicació Omi al teu rellotge.';
 
   @override
   String get openOmiOnAppleWatch => 'Obre Omi al teu\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'L\'aplicació Omi està instal·lada al teu Apple Watch. Obre-la i toca Iniciar per començar.';
+  String get openOmiOnAppleWatchDescription => 'L\'aplicació Omi està instal·lada al teu Apple Watch. Obre-la i toca Iniciar per començar.';
 
   @override
   String get openWatchApp => 'Obre l\'aplicació Watch';
@@ -5181,15 +5046,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'He instal·lat i obert l\'aplicació';
 
   @override
-  String get unableToOpenWatchApp =>
-      'No s\'ha pogut obrir l\'aplicació Apple Watch. Obre manualment l\'aplicació Watch al teu Apple Watch i instal·la Omi des de la secció \"Aplicacions disponibles\".';
+  String get unableToOpenWatchApp => 'No s\'ha pogut obrir l\'aplicació Apple Watch. Obre manualment l\'aplicació Watch al teu Apple Watch i instal·la Omi des de la secció \"Aplicacions disponibles\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch connectat correctament!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch encara no és accessible. Assegura\'t que l\'aplicació Omi estigui oberta al teu rellotge.';
+  String get appleWatchNotReachable => 'Apple Watch encara no és accessible. Assegura\'t que l\'aplicació Omi estigui oberta al teu rellotge.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5617,8 +5480,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get multipleSpeakersDetected => 'Múltiples parlants detectats';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Sembla que hi ha múltiples parlants a la gravació. Assegureu-vos que esteu en un lloc tranquil i torneu-ho a provar.';
+  String get multipleSpeakersDescription => 'Sembla que hi ha múltiples parlants a la gravació. Assegureu-vos que esteu en un lloc tranquil i torneu-ho a provar.';
 
   @override
   String get invalidRecordingDetected => 'Gravació invàlida detectada';
@@ -5630,15 +5492,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get speechDurationDescription => 'Assegureu-vos de parlar almenys 5 segons i no més de 90.';
 
   @override
-  String get connectionLostDescription =>
-      'La connexió s\'ha interromput. Comproveu la connexió a Internet i torneu-ho a provar.';
+  String get connectionLostDescription => 'La connexió s\'ha interromput. Comproveu la connexió a Internet i torneu-ho a provar.';
 
   @override
   String get howToTakeGoodSample => 'Com fer una bona mostra?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Assegureu-vos que esteu en un lloc tranquil.\n2. Parleu clarament i naturalment.\n3. Assegureu-vos que el dispositiu estigui en la seva posició natural al coll.\n\nUn cop creat, sempre podeu millorar-lo o fer-ho de nou.';
+  String get goodSampleInstructions => '1. Assegureu-vos que esteu en un lloc tranquil.\n2. Parleu clarament i naturalment.\n3. Assegureu-vos que el dispositiu estigui en la seva posició natural al coll.\n\nUn cop creat, sempre podeu millorar-lo o fer-ho de nou.';
 
   @override
   String get noDeviceConnectedUseMic => 'Cap dispositiu connectat. S\'utilitzarà el micròfon del telèfon.';
@@ -5701,12 +5561,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get howItWorks => 'Com funciona';
 
   @override
-  String get dailyScoreExplanation =>
-      'La teva puntuació diària es basa en completar tasques. Completa les teves tasques per millorar la puntuació!';
+  String get dailyScoreExplanation => 'La teva puntuació diària es basa en completar tasques. Completa les teves tasques per millorar la puntuació!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Controla amb quina freqüència Omi t\'envia notificacions proactives i recordatoris.';
+  String get notificationFrequencyDescription => 'Controla amb quina freqüència Omi t\'envia notificacions proactives i recordatoris.';
 
   @override
   String get sliderOff => 'Apagat';
@@ -5720,8 +5578,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'No s\'ha pogut generar el resum. Assegura\'t que tens converses per a aquest dia.';
+  String get failedToGenerateSummary => 'No s\'ha pogut generar el resum. Assegura\'t que tens converses per a aquest dia.';
 
   @override
   String get recap => 'Recapitulació';
@@ -5880,8 +5737,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get wifiEnableFailed => 'No s\'ha pogut activar el WiFi al dispositiu. Si us plau, torna-ho a provar.';
 
   @override
-  String get deviceNoFastTransfer =>
-      'El teu dispositiu no suporta transferència ràpida. Utilitza Bluetooth en el seu lloc.';
+  String get deviceNoFastTransfer => 'El teu dispositiu no suporta transferència ràpida. Utilitza Bluetooth en el seu lloc.';
 
   @override
   String get enableHotspotMessage => 'Si us plau, activa el punt d\'accés del teu telèfon i torna-ho a provar.';
@@ -5953,8 +5809,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get recordings => 'Enregistraments';
 
   @override
-  String get enableRemindersAccess =>
-      'Si us plau, activeu l\'accés als Recordatoris a Configuració per utilitzar els Recordatoris d\'Apple';
+  String get enableRemindersAccess => 'Si us plau, activeu l\'accés als Recordatoris a Configuració per utilitzar els Recordatoris d\'Apple';
 
   @override
   String todayAtTime(String time) {
@@ -6009,8 +5864,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get webhookUrlNotSet => 'URL de Webhook no configurada';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Si us plau, configura l\'URL de Webhook a la configuració de desenvolupador per utilitzar aquesta funció.';
+  String get setWebhookUrlInSettings => 'Si us plau, configura l\'URL de Webhook a la configuració de desenvolupador per utilitzar aquesta funció.';
 
   @override
   String get sendWebUrl => 'Enviar URL web';
@@ -6084,15 +5938,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get cloudProvider => 'Proveïdor al núvol';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 minuts premium/mes. La pestanya Al dispositiu ofereix transcripció gratuïta il·limitada.';
+  String get premiumMinutesInfo => '1.200 minuts premium/mes. La pestanya Al dispositiu ofereix transcripció gratuïta il·limitada.';
 
   @override
   String get viewUsage => 'Veure ús';
 
   @override
-  String get localProcessingInfo =>
-      'L\'àudio es processa localment. Funciona sense connexió, més privat, però usa més bateria.';
+  String get localProcessingInfo => 'L\'àudio es processa localment. Funciona sense connexió, més privat, però usa més bateria.';
 
   @override
   String get model => 'Model';
@@ -6101,8 +5953,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get performanceWarning => 'Advertència de rendiment';
 
   @override
-  String get largeModelWarning =>
-      'Aquest model és gran i pot bloquejar l\'app o funcionar molt lentament.\n\nEs recomana \"small\" o \"base\".';
+  String get largeModelWarning => 'Aquest model és gran i pot bloquejar l\'app o funcionar molt lentament.\n\nEs recomana \"small\" o \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Utilitzant el reconeixement de veu natiu diOS';
@@ -6153,8 +6004,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Dispositiu no compatible';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'El teu dispositiu no compleix els requisits per a la transcripció al dispositiu.';
+  String get deviceNotMeetRequirements => 'El teu dispositiu no compleix els requisits per a la transcripció al dispositiu.';
 
   @override
   String get transcriptionSlowerOnDevice => 'La transcripció al dispositiu pot ser més lenta en aquest dispositiu.';
@@ -6166,12 +6016,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get batteryDrainSignificantly => 'El consum de bateria augmentarà significativament.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 minuts premium/mes. La pestanya Al dispositiu ofereix transcripció gratuïta il·limitada. ';
+  String get premiumMinutesMonth => '1.200 minuts premium/mes. La pestanya Al dispositiu ofereix transcripció gratuïta il·limitada. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Laudio es processa localment. Funciona sense connexió, més privat, però consumeix més bateria.';
+  String get audioProcessedLocally => 'Laudio es processa localment. Funciona sense connexió, més privat, però consumeix més bateria.';
 
   @override
   String get languageLabel => 'Idioma';
@@ -6180,12 +6028,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Aquest model és gran i pot fer que laplicació es bloquegi o funcioni molt lentament en dispositius mòbils.\n\nEs recomana small o base.';
+  String get modelTooLargeWarning => 'Aquest model és gran i pot fer que laplicació es bloquegi o funcioni molt lentament en dispositius mòbils.\n\nEs recomana small o base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Sutilitzarà el motor de veu natiu del teu dispositiu. No cal descarregar cap model.';
+  String get nativeEngineNoDownload => 'Sutilitzarà el motor de veu natiu del teu dispositiu. No cal descarregar cap model.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6221,8 +6067,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'La transcripció en directe integrada dOmi està optimitzada per a converses en temps real amb detecció automàtica de parlants i diarització.';
+  String get omiTranscriptionOptimized => 'La transcripció en directe integrada dOmi està optimitzada per a converses en temps real amb detecció automàtica de parlants i diarització.';
 
   @override
   String get reset => 'Restablir';
@@ -6442,8 +6287,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Construint el graf de coneixement a partir de records...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'El graf de coneixement es construirà automàticament quan creïs nous records.';
+  String get knowledgeGraphWillBuildAutomatically => 'El graf de coneixement es construirà automàticament quan creïs nous records.';
 
   @override
   String get buildGraphButton => 'Construir graf';
@@ -6679,8 +6523,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get failedToLoadContacts => 'Error en carregar els contactes';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Error en preparar la conversa per compartir. Si us plau, torna-ho a provar.';
+  String get failedToPrepareConversationForSharing => 'Error en preparar la conversa per compartir. Si us plau, torna-ho a provar.';
 
   @override
   String get couldNotOpenSmsApp => 'No s\'ha pogut obrir l\'aplicació de SMS. Si us plau, torna-ho a provar.';
@@ -6746,8 +6589,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Descarregant àudio de la targeta SD del teu dispositiu';
 
   @override
-  String get transferRequiredDescription =>
-      'Aquest enregistrament està emmagatzemat a la targeta SD del teu dispositiu. Transfereix-lo al teu telèfon per reproduir-lo.';
+  String get transferRequiredDescription => 'Aquest enregistrament està emmagatzemat a la targeta SD del teu dispositiu. Transfereix-lo al teu telèfon per reproduir-lo.';
 
   @override
   String get cancelTransfer => 'Cancel·lar transferència';
@@ -6768,8 +6610,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get shareRecording => 'Compartir enregistrament';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Estàs segur que vols eliminar permanentment aquest enregistrament? Això no es pot desfer.';
+  String get deleteRecordingConfirmation => 'Estàs segur que vols eliminar permanentment aquest enregistrament? Això no es pot desfer.';
 
   @override
   String get recordingIdLabel => 'ID de l\'enregistrament';
@@ -6828,15 +6669,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get enableFastTransfer => 'Activar transferència ràpida';
 
   @override
-  String get fastTransferDescription =>
-      'La transferència ràpida utilitza WiFi per velocitats ~5x més ràpides. El teu telèfon es connectarà temporalment a la xarxa WiFi del dispositiu Omi durant la transferència.';
+  String get fastTransferDescription => 'La transferència ràpida utilitza WiFi per velocitats ~5x més ràpides. El teu telèfon es connectarà temporalment a la xarxa WiFi del dispositiu Omi durant la transferència.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'L\'accés a internet es pausa durant la transferència';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Tria com es transfereixen les gravacions del dispositiu Omi al telèfon.';
+  String get chooseTransferMethodDescription => 'Tria com es transfereixen les gravacions del dispositiu Omi al telèfon.';
 
   @override
   String get wifiSpeed => '~150 KB/s via WiFi';
@@ -6845,8 +6684,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get fiveTimesFaster => '5X MÉS RÀPID';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Crea una connexió WiFi directa al dispositiu Omi. El telèfon es desconnecta temporalment del WiFi habitual durant la transferència.';
+  String get fastTransferMethodDescription => 'Crea una connexió WiFi directa al dispositiu Omi. El telèfon es desconnecta temporalment del WiFi habitual durant la transferència.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6855,8 +6693,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get bleSpeed => '~30 KB/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Utilitza connexió Bluetooth Low Energy estàndard. Més lent però no afecta la connexió WiFi.';
+  String get bluetoothMethodDescription => 'Utilitza connexió Bluetooth Low Energy estàndard. Més lent però no afecta la connexió WiFi.';
 
   @override
   String get selected => 'Seleccionat';
@@ -6894,12 +6731,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get appDeleteFailed => 'No s\'ha pogut eliminar l\'aplicació. Torneu-ho a provar més tard.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'La visibilitat de l\'aplicació s\'ha canviat amb èxit. Pot trigar uns minuts a reflectir-se.';
+  String get appVisibilityChangedSuccessfully => 'La visibilitat de l\'aplicació s\'ha canviat amb èxit. Pot trigar uns minuts a reflectir-se.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Error en activar l\'aplicació. Si és una aplicació d\'integració, assegureu-vos que la configuració estigui completa.';
+  String get errorActivatingAppIntegration => 'Error en activar l\'aplicació. Si és una aplicació d\'integració, assegureu-vos que la configuració estigui completa.';
 
   @override
   String get errorUpdatingAppStatus => 'S\'ha produït un error en actualitzar l\'estat de l\'aplicació.';
@@ -6979,8 +6814,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'El nom ha de tenir almenys 3 caràcters';
 
   @override
-  String get conversationPromptHint =>
-      'p. ex., Extreu elements d\'acció, decisions preses i punts clau de la conversa proporcionada.';
+  String get conversationPromptHint => 'p. ex., Extreu elements d\'acció, decisions preses i punts clau de la conversa proporcionada.';
 
   @override
   String get pleaseEnterAppPrompt => 'Si us plau, introduïu una indicació per a la vostra aplicació';
@@ -7085,8 +6919,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get paymentFailedToFetchCountries => 'Error en obtenir els països compatibles. Torneu-ho a provar més tard.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Error en establir el mètode de pagament predeterminat. Torneu-ho a provar més tard.';
+  String get paymentFailedToSetDefault => 'Error en establir el mètode de pagament predeterminat. Torneu-ho a provar més tard.';
 
   @override
   String get paymentFailedToSavePaypal => 'Error en desar les dades de PayPal. Torneu-ho a provar més tard.';
@@ -7168,15 +7001,13 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Actualització programada! El teu pla mensual continua fins al final del teu període de facturació.';
+  String get planUpgradeScheduledMessage => 'Actualització programada! El teu pla mensual continua fins al final del teu període de facturació.';
 
   @override
   String get couldNotSchedulePlanChange => 'No s\'ha pogut programar el canvi de pla. Si us plau, torna-ho a provar.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'La teva subscripció s\'ha reactivat! Sense càrrecs ara - se\'t facturarà al final del període.';
+  String get subscriptionReactivatedDefault => 'La teva subscripció s\'ha reactivat! Sense càrrecs ara - se\'t facturarà al final del període.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Subscripció correcta! Se t\'ha cobrat pel nou període de facturació.';
@@ -7185,8 +7016,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get couldNotProcessSubscription => 'No s\'ha pogut processar la subscripció. Si us plau, torna-ho a provar.';
 
   @override
-  String get couldNotLaunchUpgradePage =>
-      'No s\'ha pogut obrir la pàgina d\'actualització. Si us plau, torna-ho a provar.';
+  String get couldNotLaunchUpgradePage => 'No s\'ha pogut obrir la pàgina d\'actualització. Si us plau, torna-ho a provar.';
 
   @override
   String get transcriptionJsonPlaceholder => 'Enganxa la teva configuració JSON aquí...';
@@ -7300,8 +7130,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get successfullyConnectedGoogleTasks => 'Connectat correctament a Google Tasks!';
 
   @override
-  String get failedToConnectGoogleTasksRetry =>
-      'No s\'ha pogut connectar a Google Tasks. Si us plau, torna-ho a provar.';
+  String get failedToConnectGoogleTasksRetry => 'No s\'ha pogut connectar a Google Tasks. Si us plau, torna-ho a provar.';
 
   @override
   String get successfullyConnectedClickUp => 'Connectat correctament a ClickUp!';
@@ -7343,12 +7172,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get authFailedToSignInWithApple => 'No s\'ha pogut iniciar sessió amb Apple, si us plau torneu-ho a provar.';
 
   @override
-  String get authFailedToRetrieveToken =>
-      'No s\'ha pogut recuperar el token de Firebase, si us plau torneu-ho a provar.';
+  String get authFailedToRetrieveToken => 'No s\'ha pogut recuperar el token de Firebase, si us plau torneu-ho a provar.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Error inesperat en iniciar sessió, error de Firebase, si us plau torneu-ho a provar.';
+  String get authUnexpectedErrorFirebase => 'Error inesperat en iniciar sessió, error de Firebase, si us plau torneu-ho a provar.';
 
   @override
   String get authUnexpectedError => 'Error inesperat en iniciar sessió, si us plau torneu-ho a provar';
@@ -7363,8 +7190,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Es requereix permís de Bluetooth per connectar al dispositiu.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Permís de Bluetooth denegat. Si us plau, concediu permís a Preferències del Sistema.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Permís de Bluetooth denegat. Si us plau, concediu permís a Preferències del Sistema.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7377,12 +7203,10 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Permís de notificacions denegat. Si us plau, concediu permís a Preferències del Sistema.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Permís de notificacions denegat. Si us plau, concediu permís a Preferències del Sistema.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Permís de notificacions denegat. Si us plau, concediu permís a Preferències del Sistema > Notificacions.';
+  String get onboardingNotificationDeniedNotifications => 'Permís de notificacions denegat. Si us plau, concediu permís a Preferències del Sistema > Notificacions.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7395,15 +7219,13 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Si us plau, concediu permís d\'ubicació a Configuració > Privacitat i Seguretat > Serveis d\'ubicació';
+  String get onboardingLocationGrantInSettings => 'Si us plau, concediu permís d\'ubicació a Configuració > Privacitat i Seguretat > Serveis d\'ubicació';
 
   @override
   String get onboardingMicrophoneRequired => 'Es requereix permís de micròfon per gravar.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Permís de micròfon denegat. Si us plau, concediu permís a Preferències del Sistema > Privacitat i Seguretat > Micròfon.';
+  String get onboardingMicrophoneDenied => 'Permís de micròfon denegat. Si us plau, concediu permís a Preferències del Sistema > Privacitat i Seguretat > Micròfon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7416,12 +7238,10 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Es requereix permís de captura de pantalla per gravar àudio del sistema.';
+  String get onboardingScreenCaptureRequired => 'Es requereix permís de captura de pantalla per gravar àudio del sistema.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Permís de captura de pantalla denegat. Si us plau, concediu permís a Preferències del Sistema > Privacitat i Seguretat > Gravació de pantalla.';
+  String get onboardingScreenCaptureDenied => 'Permís de captura de pantalla denegat. Si us plau, concediu permís a Preferències del Sistema > Privacitat i Seguretat > Gravació de pantalla.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7434,8 +7254,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Es requereix permís d\'accessibilitat per detectar reunions del navegador.';
+  String get onboardingAccessibilityRequired => 'Es requereix permís d\'accessibilitat per detectar reunions del navegador.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7475,8 +7294,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Permís de fotos denegat. Si us plau, permeteu l\'accés a les fotos per seleccionar imatges';
+  String get msgPhotosPermissionDenied => 'Permís de fotos denegat. Si us plau, permeteu l\'accés a les fotos per seleccionar imatges';
 
   @override
   String get msgSelectImagesGenericError => 'Error en seleccionar imatges. Si us plau, torneu-ho a provar.';
@@ -7518,8 +7336,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Es requereix permís de micròfon';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Concediu el permís de micròfon a les Preferències del Sistema';
+  String get captureMicrophonePermissionInSystemPreferences => 'Concediu el permís de micròfon a les Preferències del Sistema';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Es requereix permís d\'enregistrament de pantalla';
@@ -7549,8 +7366,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get locationPermissionRequired => 'Es requereix permís d\'ubicació';
 
   @override
-  String get locationPermissionContent =>
-      'La transferència ràpida requereix permís d\'ubicació per verificar la connexió WiFi. Si us plau, concediu el permís d\'ubicació per continuar.';
+  String get locationPermissionContent => 'La transferència ràpida requereix permís d\'ubicació per verificar la connexió WiFi. Si us plau, concediu el permís d\'ubicació per continuar.';
 
   @override
   String get pdfTranscriptExport => 'Exportació de transcripció';
@@ -7713,8 +7529,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'El dispositiu no admet sincronització WiFi, canviant a Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'El dispositiu no admet sincronització WiFi, canviant a Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health no està disponible en aquest dispositiu';
@@ -8010,8 +7825,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Posa Omi DevKit en mode d\'aparellament';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Premeu el botó un cop per encendre. El LED parpellejarà en violeta en mode d\'aparellament.';
+  String get pairingDescOmiDevkit => 'Premeu el botó un cop per encendre. El LED parpellejarà en violeta en mode d\'aparellament.';
 
   @override
   String get pairingTitleOmiGlass => 'Enceneu Omi Glass';
@@ -8023,8 +7837,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Posa Plaud Note en mode d\'aparellament';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Manteniu premut el botó lateral durant 2 segons. El LED vermell parpellejarà quan estigui llest per aparellar.';
+  String get pairingDescPlaudNote => 'Manteniu premut el botó lateral durant 2 segons. El LED vermell parpellejarà quan estigui llest per aparellar.';
 
   @override
   String get pairingTitleBee => 'Posa Bee en mode d\'aparellament';
@@ -8036,15 +7849,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get pairingTitleLimitless => 'Posa Limitless en mode d\'aparellament';
 
   @override
-  String get pairingDescLimitless =>
-      'Quan qualsevol llum sigui visible, premeu un cop i després manteniu premut fins que el dispositiu mostri una llum rosa, després deixeu anar.';
+  String get pairingDescLimitless => 'Quan qualsevol llum sigui visible, premeu un cop i després manteniu premut fins que el dispositiu mostri una llum rosa, després deixeu anar.';
 
   @override
   String get pairingTitleFriendPendant => 'Posa Friend Pendant en mode d\'aparellament';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Premeu el botó del penjoll per encendre\'l. Entrarà en mode d\'aparellament automàticament.';
+  String get pairingDescFriendPendant => 'Premeu el botó del penjoll per encendre\'l. Entrarà en mode d\'aparellament automàticament.';
 
   @override
   String get pairingTitleFieldy => 'Posa Fieldy en mode d\'aparellament';
@@ -8056,15 +7867,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Connecteu Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Instal·leu i obriu l\'aplicació Omi al vostre Apple Watch, després toqueu Connectar a l\'aplicació.';
+  String get pairingDescAppleWatch => 'Instal·leu i obriu l\'aplicació Omi al vostre Apple Watch, després toqueu Connectar a l\'aplicació.';
 
   @override
   String get pairingTitleNeoOne => 'Posa Neo One en mode d\'aparellament';
 
   @override
-  String get pairingDescNeoOne =>
-      'Manteniu premut el botó d\'engegada fins que el LED parpellegi. El dispositiu serà detectable.';
+  String get pairingDescNeoOne => 'Manteniu premut el botó d\'engegada fins que el LED parpellegi. El dispositiu serà detectable.';
 
   @override
   String get downloadingFromDevice => 'Descarregant del dispositiu';
@@ -8134,8 +7943,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get wifiConfiguration => 'Configuració WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Introduïu les credencials WiFi per permetre al dispositiu descarregar el firmware.';
+  String get wifiConfigurationSubtitle => 'Introduïu les credencials WiFi per permetre al dispositiu descarregar el firmware.';
 
   @override
   String get networkNameSsid => 'Nom de la xarxa (SSID)';
@@ -8153,8 +7961,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'El que sé de tu';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Aquí tens un resum del que sé de tu basant-me en les nostres converses. Pots editar qualsevol cosa que no sigui correcta.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Aquí tens un resum del que sé de tu basant-me en les nostres converses. Pots editar qualsevol cosa que no sigui correcta.';
 
   @override
   String get apiEnvironment => 'Entorn de l\'API';
@@ -8183,8 +7990,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get switchAndRestart => 'Canvia';
 
   @override
-  String get stagingDisclaimer =>
-      'L\'entorn de staging pot ser inestable, tenir un rendiment inconsistent i es poden perdre dades. Utilitza\'l només per a proves.';
+  String get stagingDisclaimer => 'L\'entorn de staging pot ser inestable, tenir un rendiment inconsistent i es poden perdre dades. Utilitza\'l només per a proves.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Desat. Tanca i torna a obrir l\'aplicació per aplicar els canvis.';
@@ -8235,8 +8041,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get phoneGetStarted => 'Comenca';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'La gravacio de trucades pot requerir consentiment a la teva jurisdiccio';
+  String get callRecordingConsentDisclaimer => 'La gravacio de trucades pot requerir consentiment a la teva jurisdiccio';
 
   @override
   String get enterYourNumber => 'Introdueix el teu numero';
@@ -8414,8 +8219,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Trucades telefòniques via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Fes trucades a través d\'Omi i obtin transcripció en temps real, resums automàtics i més.';
+  String get phoneCallsUpsellSubtitle => 'Fes trucades a través d\'Omi i obtin transcripció en temps real, resums automàtics i més.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transcripció en temps real de cada trucada';
@@ -8442,8 +8246,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deleteSyncedFiles => 'Eliminar enregistraments sincronitzats';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Aquests enregistraments ja estan sincronitzats amb el vostre telèfon. Això no es pot desfer.';
+  String get deleteSyncedFilesMessage => 'Aquests enregistraments ja estan sincronitzats amb el vostre telèfon. Això no es pot desfer.';
 
   @override
   String get syncedFilesDeleted => 'Enregistraments sincronitzats eliminats';
@@ -8455,8 +8258,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deletePendingFiles => 'Eliminar enregistraments pendents';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Aquests enregistraments NO estan sincronitzats amb el vostre telèfon i es perdran permanentment. Això no es pot desfer.';
+  String get deletePendingFilesWarning => 'Aquests enregistraments NO estan sincronitzats amb el vostre telèfon i es perdran permanentment. Això no es pot desfer.';
 
   @override
   String get pendingFilesDeleted => 'Enregistraments pendents eliminats';
@@ -8468,8 +8270,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deleteAll => 'Eliminar tot';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Això eliminarà els enregistraments sincronitzats i pendents. Els enregistraments pendents NO estan sincronitzats i es perdran permanentment.';
+  String get deleteAllFilesWarning => 'Això eliminarà els enregistraments sincronitzats i pendents. Els enregistraments pendents NO estan sincronitzats i es perdran permanentment.';
 
   @override
   String get allFilesDeleted => 'Tots els enregistraments eliminats';
@@ -8534,8 +8335,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get fairUseAboutTitle => 'Sobre l\'ús raonable';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi està dissenyat per a converses personals, reunions i interaccions en directe. L\'ús es mesura pel temps real de parla detectat, no pel temps de connexió. Si l\'ús supera significativament els patrons normals per a contingut no personal, es podrien aplicar ajustos.';
+  String get fairUseAboutBody => 'Omi està dissenyat per a converses personals, reunions i interaccions en directe. L\'ús es mesura pel temps real de parla detectat, no pel temps de connexió. Si l\'ús supera significativament els patrons normals per a contingut no personal, es podrien aplicar ajustos.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8573,8 +8373,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get improveConnectionTitle => 'Millorar la connexió';
 
   @override
-  String get improveConnectionContent =>
-      'Hem millorat com Omi es manté connectat al teu dispositiu. Per activar-ho, ves a la pàgina d\'informació del dispositiu, toca \"Desconnectar dispositiu\" i torna a vincular el teu dispositiu.';
+  String get improveConnectionContent => 'Hem millorat com Omi es manté connectat al teu dispositiu. Per activar-ho, ves a la pàgina d\'informació del dispositiu, toca \"Desconnectar dispositiu\" i torna a vincular el teu dispositiu.';
 
   @override
   String get improveConnectionAction => 'Entesos';
@@ -8629,16 +8428,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get cancelSyncQuestion => 'Cancel·lar la sincronització?';
 
   @override
-  String get omisStorageDesc =>
-      'Quan el vostre Omi no està connectat al telèfon, emmagatzema l\'àudio localment a la seva memòria integrada. Mai perdreu cap enregistrament.';
+  String get omisStorageDesc => 'Quan el vostre Omi no està connectat al telèfon, emmagatzema l\'àudio localment a la seva memòria integrada. Mai perdreu cap enregistrament.';
 
   @override
-  String get phoneStorageDesc =>
-      'Quan l\'Omi es reconnecta, els enregistraments es transfereixen automàticament al telèfon com a àrea temporal abans de pujar-los.';
+  String get phoneStorageDesc => 'Quan l\'Omi es reconnecta, els enregistraments es transfereixen automàticament al telèfon com a àrea temporal abans de pujar-los.';
 
   @override
-  String get cloudStorageDesc =>
-      'Un cop pujats, els vostres enregistraments es processen i transcriuen. Les converses estaran disponibles en un minut.';
+  String get cloudStorageDesc => 'Un cop pujats, els vostres enregistraments es processen i transcriuen. Les converses estaran disponibles en un minut.';
 
   @override
   String get tipKeepPhoneNearby => 'Manteniu el telèfon a prop per a una sincronització més ràpida';
@@ -8662,12 +8458,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get permissionEnable => 'Activar';
 
   @override
-  String get permissionsPageDescription =>
-      'Aquests permisos són essencials per al funcionament d\'Omi. Habiliten funcions clau com notificacions, experiències basades en la ubicació i captura d\'àudio.';
+  String get permissionsPageDescription => 'Aquests permisos són essencials per al funcionament d\'Omi. Habiliten funcions clau com notificacions, experiències basades en la ubicació i captura d\'àudio.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi necessita alguns permisos per funcionar correctament. Si us plau, concediu-los per continuar.';
+  String get permissionsRequiredDescription => 'Omi necessita alguns permisos per funcionar correctament. Si us plau, concediu-los per continuar.';
 
   @override
   String get permissionsSetupTitle => 'Obteniu la millor experiència';
@@ -8923,8 +8717,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get enableLocationTitle => 'Activa la ubicació';
 
   @override
-  String get enableLocationDescription =>
-      'Es necessita el permís d\'ubicació per trobar dispositius Bluetooth propers.';
+  String get enableLocationDescription => 'Es necessita el permís d\'ubicació per trobar dispositius Bluetooth propers.';
 
   @override
   String get voiceRecordingFound => 'Gravació trobada';
@@ -8945,8 +8738,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get firmwareWarningTitle => 'Important: Llegiu abans d\'actualitzar';
 
   @override
-  String get firmwareFormatWarning =>
-      'Aquest firmware formatarà la targeta SD. Assegureu-vos que totes les dades fora de línia estiguin sincronitzades abans d\'actualitzar.\n\nSi veieu una llum vermella parpellejant després d\'instal·lar aquesta versió, no us preocupeu. Simplement connecteu el dispositiu a l\'aplicació i hauria de tornar-se blau. La llum vermella significa que el rellotge del dispositiu encara no s\'ha sincronitzat.';
+  String get firmwareFormatWarning => 'Aquest firmware formatarà la targeta SD. Assegureu-vos que totes les dades fora de línia estiguin sincronitzades abans d\'actualitzar.\n\nSi veieu una llum vermella parpellejant després d\'instal·lar aquesta versió, no us preocupeu. Simplement connecteu el dispositiu a l\'aplicació i hauria de tornar-se blau. La llum vermella significa que el rellotge del dispositiu encara no s\'ha sincronitzat.';
 
   @override
   String get continueAnyway => 'Continuar';
@@ -8966,8 +8758,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get tasksMarkComplete => 'Marcat com a completat';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi accedeix a Apple Health a través del framework HealthKit d\'Apple. Pots revocar l\'accés en qualsevol moment a la configuració d\'iOS.';
+  String get appleHealthManageNote => 'Omi accedeix a Apple Health a través del framework HealthKit d\'Apple. Pots revocar l\'accés en qualsevol moment a la configuració d\'iOS.';
 
   @override
   String get appleHealthConnectCta => 'Connectar a Apple Health';
@@ -8982,8 +8773,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get appleHealthFeatureChatTitle => 'Parla de la teva salut';
 
   @override
-  String get appleHealthFeatureChatDesc =>
-      'Pregunta a Omi sobre els teus passos, son, freqüència cardíaca i entrenaments.';
+  String get appleHealthFeatureChatDesc => 'Pregunta a Omi sobre els teus passos, son, freqüència cardíaca i entrenaments.';
 
   @override
   String get appleHealthFeatureReadOnlyTitle => 'Accés només de lectura';
@@ -8995,15 +8785,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get appleHealthFeatureSecureTitle => 'Sincronització segura';
 
   @override
-  String get appleHealthFeatureSecureDesc =>
-      'Les teves dades d\'Apple Health se sincronitzen de forma privada amb el teu compte d\'Omi.';
+  String get appleHealthFeatureSecureDesc => 'Les teves dades d\'Apple Health se sincronitzen de forma privada amb el teu compte d\'Omi.';
 
   @override
   String get appleHealthDeniedTitle => 'Accés a Apple Health denegat';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi no té permís per llegir les teves dades d\'Apple Health. Activa-ho a Configuració d\'iOS → Privadesa i seguretat → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi no té permís per llegir les teves dades d\'Apple Health. Activa-ho a Configuració d\'iOS → Privadesa i seguretat → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Per què te\'n vas?';
@@ -9072,8 +8860,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get planUpdate => 'Actualització del pla';
 
   @override
-  String get planDeprecationMessage =>
-      'El vostre pla Unlimited s\'està retirant. Canvieu al pla Operator — les mateixes funcions excel·lents a \$49/mes. El vostre pla actual continuarà funcionant mentrestant.';
+  String get planDeprecationMessage => 'El vostre pla Unlimited s\'està retirant. Canvieu al pla Operator — les mateixes funcions excel·lents a \$49/mes. El vostre pla actual continuarà funcionant mentrestant.';
 
   @override
   String get upgradeYourPlan => 'Actualitza el teu pla';
@@ -9184,8 +8971,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Has assolit el teu límit mensual. Actualitza per continuar xatejant amb Omi sense restriccions.';
+  String get chatQuotaExceededReply => 'Has assolit el teu límit mensual. Actualitza per continuar xatejant amb Omi sense restriccions.';
 
   @override
   String get voiceResponseAudio => 'Llegeix la resposta d\'Omi en veu alta';
@@ -9216,4 +9002,25 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Afegir tasca';
+
+  @override
+  String get quickActionAskOmiAnything => 'Pregunta-li qualsevol cosa a l\'Omi';
+
+  @override
+  String get quickActionVoiceMode => 'Mode de veu';
+
+  @override
+  String get quickActionMute => 'Silenciar';
+
+  @override
+  String get quickActionUnmute => 'Activar so';
+
+  @override
+  String get quickActionConnectDevice => 'Connectar dispositiu';
+
+  @override
+  String get quickActionDeviceSettings => 'Configuració del dispositiu';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -24,8 +24,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteConversationTitle => 'Smazat konverzaci?';
 
   @override
-  String get deleteConversationMessage =>
-      'Tím se také smažou související vzpomínky, úkoly a zvukové soubory. Tuto akci nelze vrátit zpět.';
+  String get deleteConversationMessage => 'Tím se také smažou související vzpomínky, úkoly a zvukové soubory. Tuto akci nelze vrátit zpět.';
 
   @override
   String get confirm => 'Potvrdit';
@@ -146,8 +145,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleting => 'Mazání...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
+  String get pleaseCompleteAuthentication => 'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
 
   @override
   String get failedToStartAuthentication => 'Nepodařilo se spustit ověření';
@@ -228,8 +226,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noStarredConversations => 'Žádné konverzace s hvězdičkou';
 
   @override
-  String get starConversationHint =>
-      'Chcete-li konverzaci označit hvězdičkou, otevřete ji a klepněte na ikonu hvězdičky v záhlaví.';
+  String get starConversationHint => 'Chcete-li konverzaci označit hvězdičkou, otevřete ji a klepněte na ikonu hvězdičky v záhlaví.';
 
   @override
   String get searchConversations => 'Hledat konverzace...';
@@ -320,8 +317,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get installedApps => 'Nainstalované aplikace';
 
   @override
-  String get unableToFetchApps =>
-      'Nelze načíst aplikace :(\n\nZkontrolujte prosím připojení k internetu a zkuste to znovu.';
+  String get unableToFetchApps => 'Nelze načíst aplikace :(\n\nZkontrolujte prosím připojení k internetu a zkuste to znovu.';
 
   @override
   String get aboutOmi => 'O Omi';
@@ -360,15 +356,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get exportBeforeDelete => 'Před smazáním účtu si můžete exportovat data, ale po smazání je nelze obnovit.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Rozumím tomu, že smazání mého účtu je trvalé a všechna data včetně vzpomínek a konverzací budou ztracena a nelze je obnovit.';
+  String get deleteAccountCheckbox => 'Rozumím tomu, že smazání mého účtu je trvalé a všechna data včetně vzpomínek a konverzací budou ztracena a nelze je obnovit.';
 
   @override
   String get areYouSure => 'Jste si jisti?';
 
   @override
-  String get deleteAccountFinal =>
-      'Tato akce je nevratná a trvale smaže váš účet a všechna související data. Opravdu chcete pokračovat?';
+  String get deleteAccountFinal => 'Tato akce je nevratná a trvale smaže váš účet a všechna související data. Opravdu chcete pokračovat?';
 
   @override
   String get deleteNow => 'Smazat nyní';
@@ -377,8 +371,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get goBack => 'Zpět';
 
   @override
-  String get checkBoxToConfirm =>
-      'Zaškrtněte políčko pro potvrzení, že rozumíte tomu, že smazání účtu je trvalé a nevratné.';
+  String get checkBoxToConfirm => 'Zaškrtněte políčko pro potvrzení, že rozumíte tomu, že smazání účtu je trvalé a nevratné.';
 
   @override
   String get profile => 'Profil';
@@ -456,8 +449,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get yourPrivacyYourControl => 'Vaše soukromí, vaše kontrola';
 
   @override
-  String get privacyIntro =>
-      'V Omi se zavazujeme chránit vaše soukromí. Tato stránka vám umožňuje kontrolovat, jak jsou vaše data ukládána a používána.';
+  String get privacyIntro => 'V Omi se zavazujeme chránit vaše soukromí. Tato stránka vám umožňuje kontrolovat, jak jsou vaše data ukládána a používána.';
 
   @override
   String get learnMore => 'Dozvědět se více...';
@@ -466,15 +458,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get dataProtectionLevel => 'Úroveň ochrany dat';
 
   @override
-  String get dataProtectionDesc =>
-      'Vaše data jsou standardně zabezpečena silným šifrováním. Níže si prohlédněte svá nastavení a budoucí možnosti ochrany soukromí.';
+  String get dataProtectionDesc => 'Vaše data jsou standardně zabezpečena silným šifrováním. Níže si prohlédněte svá nastavení a budoucí možnosti ochrany soukromí.';
 
   @override
   String get appAccess => 'Přístup aplikací';
 
   @override
-  String get appAccessDesc =>
-      'Následující aplikace mají přístup k vašim datům. Klepnutím na aplikaci spravujete její oprávnění.';
+  String get appAccessDesc => 'Následující aplikace mají přístup k vašim datům. Klepnutím na aplikaci spravujete její oprávnění.';
 
   @override
   String get noAppsExternalAccess => 'Žádné nainstalované aplikace nemají externí přístup k vašim datům.';
@@ -531,15 +521,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Vaše Omi bylo odpojeno 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Párování zařízení zrušeno. Přejděte do Nastavení > Bluetooth a zapomeňte zařízení pro dokončení zrušení párování.';
+  String get deviceUnpairedMessage => 'Párování zařízení zrušeno. Přejděte do Nastavení > Bluetooth a zapomeňte zařízení pro dokončení zrušení párování.';
 
   @override
   String get unpairDialogTitle => 'Zrušit párování zařízení';
 
   @override
-  String get unpairDialogMessage =>
-      'Tím se zruší párování zařízení, aby mohlo být připojeno k jinému telefonu. Budete muset přejít do Nastavení > Bluetooth a zapomenout zařízení pro dokončení procesu.';
+  String get unpairDialogMessage => 'Tím se zruší párování zařízení, aby mohlo být připojeno k jinému telefonu. Budete muset přejít do Nastavení > Bluetooth a zapomenout zařízení pro dokončení procesu.';
 
   @override
   String get deviceNotConnected => 'Zařízení není připojeno';
@@ -560,8 +548,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get v2Undetected => 'V2 nedetekováno';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vidíme, že máte buď zařízení V1, nebo vaše zařízení není připojeno. Funkce SD karty je dostupná pouze pro zařízení V2.';
+  String get v2UndetectedMessage => 'Vidíme, že máte buď zařízení V1, nebo vaše zařízení není připojeno. Funkce SD karty je dostupná pouze pro zařízení V2.';
 
   @override
   String get endConversation => 'Ukončit konverzaci';
@@ -835,8 +822,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Smazat graf znalostí?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Tím se smažou všechna odvozená data grafu znalostí (uzly a spojení). Vaše původní vzpomínky zůstanou v bezpečí. Graf bude v průběhu času znovu vytvořen nebo při dalším požadavku.';
+  String get deleteKnowledgeGraphMessage => 'Tím se smažou všechna odvozená data grafu znalostí (uzly a spojení). Vaše původní vzpomínky zůstanou v bezpečí. Graf bude v průběhu času znovu vytvořen nebo při dalším požadavku.';
 
   @override
   String get knowledgeGraphDeleted => 'Graf znalostí smazán';
@@ -984,8 +970,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get shortConversationThreshold => 'Prahová hodnota krátkých konverzací';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Konverzace kratší než tato hodnota budou skryty, pokud nejsou výše povoleny';
+  String get shortConversationThresholdSubtitle => 'Konverzace kratší než tato hodnota budou skryty, pokud nejsou výše povoleny';
 
   @override
   String get durationThreshold => 'Prahová hodnota trvání';
@@ -1020,8 +1005,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get integrationsFooter => 'Připojte své aplikace k zobrazení dat a metrik v chatu.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
+  String get completeAuthInBrowser => 'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1081,8 +1065,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get needYourPermission => 'Potřebujeme vaše povolení';
 
   @override
-  String get alreadyGavePermission =>
-      'Již jste nám dali povolení k ukládání vašich nahrávek. Zde je připomenutí, proč to potřebujeme:';
+  String get alreadyGavePermission => 'Již jste nám dali povolení k ukládání vašich nahrávek. Zde je připomenutí, proč to potřebujeme:';
 
   @override
   String get wouldLikePermission => 'Rádi bychom vaše povolení k ukládání vašich hlasových nahrávek. Zde je proč:';
@@ -1091,26 +1074,22 @@ class AppLocalizationsCs extends AppLocalizations {
   String get improveSpeechProfile => 'Vylepšit váš hlasový profil';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Nahrávky používáme k dalšímu trénování a vylepšování vašeho osobního hlasového profilu.';
+  String get improveSpeechProfileDesc => 'Nahrávky používáme k dalšímu trénování a vylepšování vašeho osobního hlasového profilu.';
 
   @override
   String get trainFamilyProfiles => 'Trénovat profily pro přátele a rodinu';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Vaše nahrávky nám pomáhají rozpoznat a vytvářet profily pro vaše přátele a rodinu.';
+  String get trainFamilyProfilesDesc => 'Vaše nahrávky nám pomáhají rozpoznat a vytvářet profily pro vaše přátele a rodinu.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Zvýšit přesnost přepisu';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'S vylepšením našeho modelu můžeme pro vaše nahrávky poskytovat lepší výsledky přepisu.';
+  String get enhanceTranscriptAccuracyDesc => 'S vylepšením našeho modelu můžeme pro vaše nahrávky poskytovat lepší výsledky přepisu.';
 
   @override
-  String get legalNotice =>
-      'Právní upozornění: Legálnost nahrávání a ukládání hlasových dat se může lišit v závislosti na vaší lokalitě a způsobu použití této funkce. Je vaší odpovědností zajistit dodržování místních zákonů a předpisů.';
+  String get legalNotice => 'Právní upozornění: Legálnost nahrávání a ukládání hlasových dat se může lišit v závislosti na vaší lokalitě a způsobu použití této funkce. Je vaší odpovědností zajistit dodržování místních zákonů a předpisů.';
 
   @override
   String get alreadyAuthorized => 'Již autorizováno';
@@ -1188,8 +1167,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showEventsNoParticipants => 'Zobrazit události bez účastníků';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Pokud je povoleno, Již brzy zobrazuje události bez účastníků nebo video odkazu.';
+  String get showEventsNoParticipantsDesc => 'Pokud je povoleno, Již brzy zobrazuje události bez účastníků nebo video odkazu.';
 
   @override
   String get yourMeetings => 'Vaše schůzky';
@@ -1357,8 +1335,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get defaultRepository => 'Výchozí repozitář';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Vyberte výchozí repozitář pro vytváření problémů. Při vytváření problémů můžete stále specifikovat jiný repozitář.';
+  String get selectDefaultRepoDesc => 'Vyberte výchozí repozitář pro vytváření problémů. Při vytváření problémů můžete stále specifikovat jiný repozitář.';
 
   @override
   String get noReposFound => 'Nenalezeny žádné repozitáře';
@@ -1405,8 +1382,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get configureSettings => 'Nakonfigurovat nastavení';
 
   @override
-  String get completeAuthBrowser =>
-      'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
+  String get completeAuthBrowser => 'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1734,8 +1710,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get enableBluetooth => 'Povolit Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi potřebuje Bluetooth pro připojení k vašemu nositelného zařízení. Povolte prosím Bluetooth a zkuste to znovu.';
+  String get bluetoothNeeded => 'Omi potřebuje Bluetooth pro připojení k vašemu nositelného zařízení. Povolte prosím Bluetooth a zkuste to znovu.';
 
   @override
   String get contactSupport => 'Kontaktovat podporu?';
@@ -1768,26 +1743,22 @@ class AppLocalizationsCs extends AppLocalizations {
   String get locationServiceDisabled => 'Služba určování polohy zakázána';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Služba určování polohy je zakázána. Přejděte do Nastavení > Soukromí a zabezpečení > Služby určování polohy a povolte ji';
+  String get locationServiceDisabledDesc => 'Služba určování polohy je zakázána. Přejděte do Nastavení > Soukromí a zabezpečení > Služby určování polohy a povolte ji';
 
   @override
   String get backgroundLocationDenied => 'Přístup k poloze na pozadí odepřen';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Přejděte do nastavení zařízení a nastavte oprávnění k poloze na \"Vždy povolit\"';
+  String get backgroundLocationDeniedDesc => 'Přejděte do nastavení zařízení a nastavte oprávnění k poloze na \"Vždy povolit\"';
 
   @override
   String get lovingOmi => 'Líbí se vám Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Pomozte nám oslovit více lidí tím, že zanecháte hodnocení v App Store. Vaše zpětná vazba pro nás hodně znamená!';
+  String get leaveReviewIos => 'Pomozte nám oslovit více lidí tím, že zanecháte hodnocení v App Store. Vaše zpětná vazba pro nás hodně znamená!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Pomozte nám oslovit více lidí tím, že zanecháte hodnocení v Obchodě Google Play. Vaše zpětná vazba pro nás hodně znamená!';
+  String get leaveReviewAndroid => 'Pomozte nám oslovit více lidí tím, že zanecháte hodnocení v Obchodě Google Play. Vaše zpětná vazba pro nás hodně znamená!';
 
   @override
   String get rateOnAppStore => 'Ohodnotit v App Store';
@@ -1820,15 +1791,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get connectionError => 'Chyba připojení';
 
   @override
-  String get connectionErrorDesc =>
-      'Nepodařilo se připojit k serveru. Zkontrolujte prosím připojení k internetu a zkuste to znovu.';
+  String get connectionErrorDesc => 'Nepodařilo se připojit k serveru. Zkontrolujte prosím připojení k internetu a zkuste to znovu.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Detekována neplatná nahrávka';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Zdá se, že v nahrávce je více mluvčích. Ujistěte se prosím, že jste na tichém místě, a zkuste to znovu.';
+  String get multipleSpeakersDesc => 'Zdá se, že v nahrávce je více mluvčích. Ujistěte se prosím, že jste na tichém místě, a zkuste to znovu.';
 
   @override
   String get tooShortDesc => 'Není detekován dostatek řeči. Mluvte prosím více a zkuste to znovu.';
@@ -1840,15 +1809,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get areYouThere => 'Jste tam?';
 
   @override
-  String get noSpeechDesc =>
-      'Nemohli jsme detekovat žádnou řeč. Ujistěte se prosím, že mluvíte alespoň 10 sekund a ne více než 3 minuty.';
+  String get noSpeechDesc => 'Nemohli jsme detekovat žádnou řeč. Ujistěte se prosím, že mluvíte alespoň 10 sekund a ne více než 3 minuty.';
 
   @override
   String get connectionLost => 'Spojení ztraceno';
 
   @override
-  String get connectionLostDesc =>
-      'Spojení bylo přerušeno. Zkontrolujte prosím připojení k internetu a zkuste to znovu.';
+  String get connectionLostDesc => 'Spojení bylo přerušeno. Zkontrolujte prosím připojení k internetu a zkuste to znovu.';
 
   @override
   String get tryAgain => 'Zkusit znovu';
@@ -1863,8 +1830,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get permissionsRequired => 'Vyžadována oprávnění';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Tato aplikace potřebuje oprávnění Bluetooth a Poloha, aby fungovala správně. Povolte je prosím v nastavení.';
+  String get permissionsRequiredDesc => 'Tato aplikace potřebuje oprávnění Bluetooth a Poloha, aby fungovala správně. Povolte je prosím v nastavení.';
 
   @override
   String get openSettings => 'Otevřít nastavení';
@@ -1894,8 +1860,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Váš AI společník';
 
   @override
-  String get captureEveryMoment =>
-      'Zachyťte každý okamžik. Získejte souhrny\npodporované AI. Už nikdy si nedělejte poznámky.';
+  String get captureEveryMoment => 'Zachyťte každý okamžik. Získejte souhrny\npodporované AI. Už nikdy si nedělejte poznámky.';
 
   @override
   String get appleWatchSetup => 'Nastavení Apple Watch';
@@ -1907,12 +1872,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get microphonePermission => 'Oprávnění k mikrofonu';
 
   @override
-  String get permissionGrantedNow =>
-      'Oprávnění uděleno! Nyní:\n\nOtevřete aplikaci Omi na hodinkách a klepněte níže na \"Pokračovat\"';
+  String get permissionGrantedNow => 'Oprávnění uděleno! Nyní:\n\nOtevřete aplikaci Omi na hodinkách a klepněte níže na \"Pokračovat\"';
 
   @override
-  String get needMicrophonePermission =>
-      'Potřebujeme oprávnění k mikrofonu.\n\n1. Klepněte na \"Udělit oprávnění\"\n2. Povolte na svém iPhone\n3. Aplikace na hodinkách se zavře\n4. Znovu otevřete a klepněte na \"Pokračovat\"';
+  String get needMicrophonePermission => 'Potřebujeme oprávnění k mikrofonu.\n\n1. Klepněte na \"Udělit oprávnění\"\n2. Povolte na svém iPhone\n3. Aplikace na hodinkách se zavře\n4. Znovu otevřete a klepněte na \"Pokračovat\"';
 
   @override
   String get grantPermissionButton => 'Udělit oprávnění';
@@ -1921,15 +1884,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get needHelp => 'Potřebujete pomoc?';
 
   @override
-  String get troubleshootingSteps =>
-      'Řešení problémů:\n\n1. Ujistěte se, že Omi je nainstalováno na vašich hodinkách\n2. Otevřete aplikaci Omi na hodinkách\n3. Hledejte vyskakovací okno s oprávněním\n4. Klepněte na \"Povolit\", když budete vyzváni\n5. Aplikace na hodinkách se zavře - znovu ji otevřete\n6. Vraťte se a klepněte na \"Pokračovat\" na svém iPhone';
+  String get troubleshootingSteps => 'Řešení problémů:\n\n1. Ujistěte se, že Omi je nainstalováno na vašich hodinkách\n2. Otevřete aplikaci Omi na hodinkách\n3. Hledejte vyskakovací okno s oprávněním\n4. Klepněte na \"Povolit\", když budete vyzváni\n5. Aplikace na hodinkách se zavře - znovu ji otevřete\n6. Vraťte se a klepněte na \"Pokračovat\" na svém iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Nahrávání úspěšně zahájeno!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Oprávnění ještě nebylo uděleno. Ujistěte se prosím, že jste povolili přístup k mikrofonu a znovu otevřeli aplikaci na hodinkách.';
+  String get permissionNotGrantedYet => 'Oprávnění ještě nebylo uděleno. Ujistěte se prosím, že jste povolili přístup k mikrofonu a znovu otevřeli aplikaci na hodinkách.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2026,8 +1987,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Připraveno na úkoly';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Vaše AI automaticky extrahuje úkoly a to-dos z vašich konverzací. Objeví se zde, když budou vytvořeny.';
+  String get welcomeActionItemsDescription => 'Vaše AI automaticky extrahuje úkoly a to-dos z vašich konverzací. Objeví se zde, když budou vytvořeny.';
 
   @override
   String get autoExtractionFeature => 'Automaticky extrahováno z konverzací';
@@ -2223,15 +2183,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'ŘEČ A PŘEPIS';
 
   @override
-  String get languageSettingsHelperText =>
-      'Jazyk aplikace mění nabídky a tlačítka. Jazyk řeči ovlivňuje, jak jsou vaše nahrávky přepisovány.';
+  String get languageSettingsHelperText => 'Jazyk aplikace mění nabídky a tlačítka. Jazyk řeči ovlivňuje, jak jsou vaše nahrávky přepisovány.';
 
   @override
   String get translationNotice => 'Oznámení o překladu';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi překládá konverzace do vašeho hlavního jazyka. Aktualizujte to kdykoli v Nastavení → Profily.';
+  String get translationNoticeMessage => 'Omi překládá konverzace do vašeho hlavního jazyka. Aktualizujte to kdykoli v Nastavení → Profily.';
 
   @override
   String get pleaseCheckInternetConnection => 'Zkontrolujte prosím připojení k internetu a zkuste to znovu';
@@ -2386,8 +2344,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Zrušit párování zařízení';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Tím se zruší párování zařízení, aby se mohlo připojit k jinému telefonu. Budete muset přejít do Nastavení > Bluetooth a zapomenout zařízení pro dokončení procesu.';
+  String get unpairDeviceDialogMessage => 'Tím se zruší párování zařízení, aby se mohlo připojit k jinému telefonu. Budete muset přejít do Nastavení > Bluetooth a zapomenout zařízení pro dokončení procesu.';
 
   @override
   String get unpair => 'Zrušit párování';
@@ -2568,8 +2525,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get youreAllSet => 'Vše je připraveno!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Vítejte v Omi! Váš AI společník je připraven vám pomoci s rozhovory, úkoly a mnoho dalšího.';
+  String get welcomeToOmiDescription => 'Vítejte v Omi! Váš AI společník je připraven vám pomoci s rozhovory, úkoly a mnoho dalšího.';
 
   @override
   String get startUsingOmi => 'Začít používat Omi';
@@ -2705,8 +2661,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noTasksYet => 'Zatím žádné úkoly';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Úkoly z vašich konverzací se zde zobrazí.\nKliknutím na Vytvořit přidáte jeden ručně.';
+  String get tasksFromConversationsWillAppear => 'Úkoly z vašich konverzací se zde zobrazí.\nKliknutím na Vytvořit přidáte jeden ručně.';
 
   @override
   String get monthJan => 'Led';
@@ -2838,8 +2793,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get chatPrompt => 'Výzva chatu';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Jste úžasná aplikace, vaším úkolem je reagovat na dotazy uživatelů a dát jim dobrý pocit...';
+  String get chatPromptPlaceholder => 'Jste úžasná aplikace, vaším úkolem je reagovat na dotazy uživatelů a dát jim dobrý pocit...';
 
   @override
   String get conversationPrompt => 'Výzva konverzace';
@@ -2857,8 +2811,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get makeMyAppPublic => 'Zveřejnit mou aplikaci';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Odesláním této aplikace souhlasím se Smluvními podmínkami a Zásadami ochrany osobních údajů Omi AI';
+  String get submitAppTermsAgreement => 'Odesláním této aplikace souhlasím se Smluvními podmínkami a Zásadami ochrany osobních údajů Omi AI';
 
   @override
   String get submitApp => 'Odeslat aplikaci';
@@ -2873,12 +2826,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get submitAppQuestion => 'Odeslat aplikaci?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Vaše aplikace bude zkontrolována a zveřejněna. Můžete ji začít používat okamžitě, i během kontroly!';
+  String get submitAppPublicDescription => 'Vaše aplikace bude zkontrolována a zveřejněna. Můžete ji začít používat okamžitě, i během kontroly!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Vaše aplikace bude zkontrolována a zpřístupněna vám soukromě. Můžete ji začít používat okamžitě, i během kontroly!';
+  String get submitAppPrivateDescription => 'Vaše aplikace bude zkontrolována a zpřístupněna vám soukromě. Můžete ji začít používat okamžitě, i během kontroly!';
 
   @override
   String get startEarning => 'Začněte vydělávat! 💰';
@@ -2902,8 +2853,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get dataAccessNotice => 'Upozornění na přístup k datům';
 
   @override
-  String get dataAccessWarning =>
-      'Tato aplikace bude mít přístup k vašim datům. Omi AI nenese odpovědnost za to, jak jsou vaše data touto aplikací používána, upravována nebo mazána';
+  String get dataAccessWarning => 'Tato aplikace bude mít přístup k vašim datům. Omi AI nenese odpovědnost za to, jak jsou vaše data touto aplikací používána, upravována nebo mazána';
 
   @override
   String get installApp => 'Nainstalovat aplikaci';
@@ -2912,12 +2862,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get betaTesterNotice => 'Jste beta tester této aplikace. Ještě není veřejná. Stane se veřejnou po schválení.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Vaše aplikace je v recenzi a viditelná pouze pro vás. Stane se veřejnou po schválení.';
+  String get appUnderReviewOwner => 'Vaše aplikace je v recenzi a viditelná pouze pro vás. Stane se veřejnou po schválení.';
 
   @override
-  String get appRejectedNotice =>
-      'Vaše aplikace byla zamítnuta. Aktualizujte prosím detaily aplikace a znovu ji odešlete k recenzi.';
+  String get appRejectedNotice => 'Vaše aplikace byla zamítnuta. Aktualizujte prosím detaily aplikace a znovu ji odešlete k recenzi.';
 
   @override
   String get setupSteps => 'Kroky nastavení';
@@ -2952,8 +2900,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get errorActivatingApp => 'Chyba při aktivaci aplikace';
 
   @override
-  String get integrationSetupRequired =>
-      'Pokud se jedná o integrační aplikaci, ujistěte se, že je nastavení dokončeno.';
+  String get integrationSetupRequired => 'Pokud se jedná o integrační aplikaci, ujistěte se, že je nastavení dokončeno.';
 
   @override
   String get installed => 'Nainstalováno';
@@ -2980,8 +2927,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get descriptionLabel => 'Popis';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Má úžasná aplikace je skvělá aplikace, která dělá úžasné věci. Je to nejlepší aplikace!';
+  String get appDescriptionPlaceholder => 'Má úžasná aplikace je skvělá aplikace, která dělá úžasné věci. Je to nejlepší aplikace!';
 
   @override
   String get pleaseProvideValidDescription => 'Zadejte prosím platný popis';
@@ -3133,8 +3079,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get microphonePermissionRequired => 'Pro hlasový záznam je vyžadováno oprávnění k mikrofonu.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Oprávnění k mikrofonu bylo zamítnuto. Udělte prosím oprávnění v Předvolby systému > Soukromí a zabezpečení > Mikrofon.';
+  String get microphonePermissionDenied => 'Oprávnění k mikrofonu bylo zamítnuto. Udělte prosím oprávnění v Předvolby systému > Soukromí a zabezpečení > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3367,8 +3312,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get whatWeCollect => 'Co sbíráme';
 
   @override
-  String get dataCollectionMessage =>
-      'Pokračováním budou vaše konverzace, nahrávky a osobní údaje bezpečně uloženy na našich serverech, aby poskytly přehledy založené na AI a umožnily všechny funkce aplikace.';
+  String get dataCollectionMessage => 'Pokračováním budou vaše konverzace, nahrávky a osobní údaje bezpečně uloženy na našich serverech, aby poskytly přehledy založené na AI a umožnily všechny funkce aplikace.';
 
   @override
   String get dataProtection => 'Ochrana dat';
@@ -3401,8 +3345,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Jméno musí mít alespoň 2 znaky';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Řekněte nám, jak byste chtěli být oslovováni. To pomáhá personalizovat váš Omi zážitek.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Řekněte nám, jak byste chtěli být oslovováni. To pomáhá personalizovat váš Omi zážitek.';
 
   @override
   String charactersCount(int count) {
@@ -3419,8 +3362,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get recordAudioConversations => 'Nahrávat audio konverzace';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi potřebuje přístup k mikrofonu pro nahrávání vašich konverzací a poskytování přepisů.';
+  String get microphoneAccessDescription => 'Omi potřebuje přístup k mikrofonu pro nahrávání vašich konverzací a poskytování přepisů.';
 
   @override
   String get screenRecording => 'Záznam obrazovky';
@@ -3429,8 +3371,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Zachytit systémový zvuk ze schůzek';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi potřebuje oprávnění k záznamu obrazovky pro zachycení systémového zvuku z vašich schůzek v prohlížeči.';
+  String get screenRecordingDescription => 'Omi potřebuje oprávnění k záznamu obrazovky pro zachycení systémového zvuku z vašich schůzek v prohlížeči.';
 
   @override
   String get accessibility => 'Přístupnost';
@@ -3439,8 +3380,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Detekovat schůzky v prohlížeči';
 
   @override
-  String get accessibilityDescription =>
-      'Omi potřebuje oprávnění k přístupnosti pro detekci, kdy se připojujete ke schůzkám Zoom, Meet nebo Teams ve vašem prohlížeči.';
+  String get accessibilityDescription => 'Omi potřebuje oprávnění k přístupnosti pro detekci, kdy se připojujete ke schůzkám Zoom, Meet nebo Teams ve vašem prohlížeči.';
 
   @override
   String get pleaseWait => 'Prosím čekejte...';
@@ -3512,8 +3452,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get conversationsExportStarted => 'Export konverzací zahájen. Může to trvat několik sekund, počkejte prosím.';
 
   @override
-  String get mcpDescription =>
-      'Pro připojení Omi k dalším aplikacím pro čtení, vyhledávání a správu vašich vzpomínek a konverzací. Začněte vytvořením klíče.';
+  String get mcpDescription => 'Pro připojení Omi k dalším aplikacím pro čtení, vyhledávání a správu vašich vzpomínek a konverzací. Začněte vytvořením klíče.';
 
   @override
   String get apiKeys => 'API klíče';
@@ -3669,8 +3608,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Příprava záznamu systémového zvuku';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klikněte na tlačítko pro záznam zvuku pro živé přepisy, poznatky AI a automatické ukládání.';
+  String get clickTheButtonToCaptureAudio => 'Klikněte na tlačítko pro záznam zvuku pro živé přepisy, poznatky AI a automatické ukládání.';
 
   @override
   String get reconnecting => 'Opětovné připojování...';
@@ -3897,8 +3835,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Smazat graf znalostí?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Tím se smažou všechna odvozená data grafu znalostí. Vaše původní vzpomínky zůstanou v bezpečí.';
+  String get deleteKnowledgeGraphWarning => 'Tím se smažou všechna odvozená data grafu znalostí. Vaše původní vzpomínky zůstanou v bezpečí.';
 
   @override
   String get connectOmiWithAI => 'Připojte Omi k AI asistentům';
@@ -3955,8 +3892,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get updateAppQuestion => 'Aktualizovat aplikaci?';
 
   @override
-  String get updateAppConfirmation =>
-      'Opravdu chcete aktualizovat svou aplikaci? Změny se projeví po kontrole naším týmem.';
+  String get updateAppConfirmation => 'Opravdu chcete aktualizovat svou aplikaci? Změny se projeví po kontrole naším týmem.';
 
   @override
   String get updateApp => 'Aktualizovat aplikaci';
@@ -3986,8 +3922,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get no => 'Ne';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Předplatné bylo úspěšně zrušeno. Zůstane aktivní do konce aktuálního fakturačního období.';
+  String get subscriptionCancelledSuccessfully => 'Předplatné bylo úspěšně zrušeno. Zůstane aktivní do konce aktuálního fakturačního období.';
 
   @override
   String get failedToCancelSubscription => 'Zrušení předplatného se nezdařilo. Zkuste to prosím znovu.';
@@ -4023,8 +3958,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Zrušit předplatné?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Opravdu chcete zrušit předplatné? Budete mít přístup do konce aktuálního fakturačního období.';
+  String get cancelSubscriptionConfirmation => 'Opravdu chcete zrušit předplatné? Budete mít přístup do konce aktuálního fakturačního období.';
 
   @override
   String get cancelSubscriptionButton => 'Zrušit předplatné';
@@ -4036,8 +3970,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get betaTesterMessage => 'Jste beta tester této aplikace. Zatím není veřejná. Bude veřejná po schválení.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Vaše aplikace je v procesu kontroly a viditelná pouze pro vás. Bude veřejná po schválení.';
+  String get appUnderReviewMessage => 'Vaše aplikace je v procesu kontroly a viditelná pouze pro vás. Bude veřejná po schválení.';
 
   @override
   String get appRejectedMessage => 'Vaše aplikace byla zamítnuta. Aktualizujte údaje a znovu odešlete ke kontrole.';
@@ -4094,8 +4027,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get issueActivatingApp => 'Při aktivaci této aplikace došlo k problému. Zkuste to prosím znovu.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Tato aplikace bude mít přístup k vašim datům. Omi AI nenese odpovědnost za to, jak jsou vaše data používána třetími stranami.';
+  String get dataAccessNoticeDescription => 'Tato aplikace bude mít přístup k vašim datům. Omi AI nenese odpovědnost za to, jak jsou vaše data používána třetími stranami.';
 
   @override
   String get copyUrl => 'Kopírovat URL';
@@ -4183,8 +4115,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get omiApiKeys => 'Omi API klíče';
 
   @override
-  String get apiKeysDescription =>
-      'API klíče se používají pro ověření, když vaše aplikace komunikuje se serverem OMI. Umožňují vaší aplikaci vytvářet vzpomínky a bezpečně přistupovat k dalším službám OMI.';
+  String get apiKeysDescription => 'API klíče se používají pro ověření, když vaše aplikace komunikuje se serverem OMI. Umožňují vaší aplikaci vytvářet vzpomínky a bezpečně přistupovat k dalším službám OMI.';
 
   @override
   String get aboutOmiApiKeys => 'O Omi API klíčích';
@@ -4208,8 +4139,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Odvolat API klíč?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Tuto akci nelze vrátit zpět. Všechny aplikace používající tento klíč již nebudou mít přístup k API.';
+  String get revokeApiKeyWarning => 'Tuto akci nelze vrátit zpět. Všechny aplikace používající tento klíč již nebudou mít přístup k API.';
 
   @override
   String get revoke => 'Odvolat';
@@ -4307,8 +4237,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get externalAppAccess => 'Přístup externích aplikací';
 
   @override
-  String get externalAppAccessDescription =>
-      'Následující nainstalované aplikace mají externí integrace a mohou přistupovat k vašim datům, jako jsou konverzace a vzpomínky.';
+  String get externalAppAccessDescription => 'Následující nainstalované aplikace mají externí integrace a mohou přistupovat k vašim datům, jako jsou konverzace a vzpomínky.';
 
   @override
   String get noExternalAppsHaveAccess => 'Žádné externí aplikace nemají přístup k vašim datům.';
@@ -4317,8 +4246,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maximální zabezpečení (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-end šifrování je zlatý standard ochrany soukromí. Když je povoleno, vaše data jsou šifrována na vašem zařízení před odesláním na naše servery. To znamená, že nikdo, ani Omi, nemůže přistupovat k vašemu obsahu.';
+  String get e2eeDescription => 'End-to-end šifrování je zlatý standard ochrany soukromí. Když je povoleno, vaše data jsou šifrována na vašem zařízení před odesláním na naše servery. To znamená, že nikdo, ani Omi, nemůže přistupovat k vašemu obsahu.';
 
   @override
   String get importantTradeoffs => 'Důležité kompromisy:';
@@ -4352,15 +4280,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get secureEncryption => 'Bezpečné šifrování';
 
   @override
-  String get secureEncryptionDescription =>
-      'Vaše data jsou šifrována klíčem jedinečným pro vás na našich serverech hostovaných v Google Cloud. To znamená, že váš surový obsah je nepřístupný nikomu, včetně zaměstnanců Omi nebo Google, přímo z databáze.';
+  String get secureEncryptionDescription => 'Vaše data jsou šifrována klíčem jedinečným pro vás na našich serverech hostovaných v Google Cloud. To znamená, že váš surový obsah je nepřístupný nikomu, včetně zaměstnanců Omi nebo Google, přímo z databáze.';
 
   @override
   String get endToEndEncryption => 'End-to-end šifrování';
 
   @override
-  String get e2eeCardDescription =>
-      'Povolte pro maximální zabezpečení, kde pouze vy máte přístup k vašim datům. Klepnutím se dozvíte více.';
+  String get e2eeCardDescription => 'Povolte pro maximální zabezpečení, kde pouze vy máte přístup k vašim datům. Klepnutím se dozvíte více.';
 
   @override
   String get dataAlwaysEncrypted => 'Bez ohledu na úroveň jsou vaše data vždy šifrována v klidu i při přenosu.';
@@ -4431,8 +4357,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Získejte Omi Unlimited zdarma přispěním vašich dat k trénování AI modelů.';
 
   @override
-  String get trainingDataBullets =>
-      '• Vaše data pomáhají vylepšovat AI modely\n• Sdílena jsou pouze necitlivá data\n• Plně transparentní proces';
+  String get trainingDataBullets => '• Vaše data pomáhají vylepšovat AI modely\n• Sdílena jsou pouze necitlivá data\n• Plně transparentní proces';
 
   @override
   String get learnMoreAtOmiTraining => 'Zjistěte více na omi.me/training';
@@ -4482,8 +4407,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get monthlyPlanContinues => 'Váš aktuální měsíční plán bude pokračovat do konce fakturačního období';
 
   @override
-  String get paymentMethodCharged =>
-      'Vaše stávající platební metoda bude automaticky účtována po skončení měsíčního plánu';
+  String get paymentMethodCharged => 'Vaše stávající platební metoda bude automaticky účtována po skončení měsíčního plánu';
 
   @override
   String get annualSubscriptionStarts => 'Vaše 12měsíční roční předplatné začne automaticky po zaúčtování';
@@ -4593,8 +4517,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Na vašem soukromí nám záleží';
 
   @override
-  String get privacyIntroText =>
-      'V Omi bereme vaše soukromí velmi vážně. Chceme být transparentní ohledně dat, která shromažďujeme a jak je používáme ke zlepšení produktu. Zde je to, co potřebujete vědět:';
+  String get privacyIntroText => 'V Omi bereme vaše soukromí velmi vážně. Chceme být transparentní ohledně dat, která shromažďujeme a jak je používáme ke zlepšení produktu. Zde je to, co potřebujete vědět:';
 
   @override
   String get whatWeTrack => 'Co sledujeme';
@@ -4609,12 +4532,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get ourCommitment => 'Náš závazek';
 
   @override
-  String get commitmentText =>
-      'Zavazujeme se používat shromážděná data pouze k tomu, abychom z Omi udělali lepší produkt. Vaše soukromí a důvěra jsou pro nás prvořadé.';
+  String get commitmentText => 'Zavazujeme se používat shromážděná data pouze k tomu, abychom z Omi udělali lepší produkt. Vaše soukromí a důvěra jsou pro nás prvořadé.';
 
   @override
-  String get thankYouText =>
-      'Děkujeme, že jste váženým uživatelem Omi. Máte-li jakékoli dotazy nebo obavy, neváhejte nás kontaktovat na team@basedhardware.com.';
+  String get thankYouText => 'Děkujeme, že jste váženým uživatelem Omi. Máte-li jakékoli dotazy nebo obavy, neváhejte nás kontaktovat na team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Nastavení WiFi synchronizace';
@@ -4623,8 +4544,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get enterHotspotCredentials => 'Zadejte přihlašovací údaje hotspotu telefonu';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi synchronizace používá váš telefon jako hotspot. Název a heslo najdete v Nastavení > Osobní hotspot.';
+  String get wifiSyncUsesHotspot => 'WiFi synchronizace používá váš telefon jako hotspot. Název a heslo najdete v Nastavení > Osobní hotspot.';
 
   @override
   String get hotspotNameSsid => 'Název hotspotu (SSID)';
@@ -4659,8 +4579,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nepodařilo se vygenerovat shrnutí. Ujistěte se, že máte konverzace pro daný den.';
+  String get failedToGenerateSummaryCheckConversations => 'Nepodařilo se vygenerovat shrnutí. Ujistěte se, že máte konverzace pro daný den.';
 
   @override
   String get summaryNotFound => 'Shrnutí nenalezeno';
@@ -4690,8 +4609,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Export zahájen. Může to trvat několik sekund...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Tímto se odstraní všechna odvozená data grafu znalostí (uzly a spojení). Vaše původní vzpomínky zůstanou v bezpečí. Graf bude postupně obnoven nebo při dalším požadavku.';
+  String get knowledgeGraphDeleteDescription => 'Tímto se odstraní všechna odvozená data grafu znalostí (uzly a spojení). Vaše původní vzpomínky zůstanou v bezpečí. Graf bude postupně obnoven nebo při dalším požadavku.';
 
   @override
   String get configureDailySummaryDigest => 'Nastavte si denní přehled úkolů';
@@ -4761,8 +4679,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Smazat všechny konverzace z Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Toto trvale smaže všechny konverzace importované z Limitless. Tuto akci nelze vrátit zpět.';
+  String get deleteAllLimitlessWarning => 'Toto trvale smaže všechny konverzace importované z Limitless. Tuto akci nelze vrátit zpět.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4818,8 +4735,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get howItWorksTitle => 'Jak to funguje?';
 
   @override
-  String get howPeopleWorks =>
-      'Jakmile je osoba vytvořena, můžete přejít k přepisu konverzace a přiřadit jim odpovídající segmenty, tak Omi bude moci rozpoznat i jejich řeč!';
+  String get howPeopleWorks => 'Jakmile je osoba vytvořena, můžete přejít k přepisu konverzace a přiřadit jim odpovídající segmenty, tak Omi bude moci rozpoznat i jejich řeč!';
 
   @override
   String get tapToDelete => 'Klepněte pro smazání';
@@ -4845,8 +4761,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get privacyNotice => 'Oznámení o ochraně soukromí';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Nahrávky mohou zachytit hlasy ostatních. Před povolením se ujistěte, že máte souhlas všech účastníků.';
+  String get recordingsMayCaptureOthers => 'Nahrávky mohou zachytit hlasy ostatních. Před povolením se ujistěte, že máte souhlas všech účastníků.';
 
   @override
   String get enable => 'Povolit';
@@ -4858,8 +4773,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get on => 'Zap';
 
   @override
-  String get storeAudioDescription =>
-      'Uchovávejte všechny zvukové nahrávky uložené místně v telefonu. Při vypnutí se ukládají pouze neúspěšné nahrávky pro úsporu místa.';
+  String get storeAudioDescription => 'Uchovávejte všechny zvukové nahrávky uložené místně v telefonu. Při vypnutí se ukládají pouze neúspěšné nahrávky pro úsporu místa.';
 
   @override
   String get enableLocalStorage => 'Povolit místní úložiště';
@@ -4877,12 +4791,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get storeAudioOnCloud => 'Ukládat zvuk do cloudu';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Vaše nahrávky v reálném čase budou ukládány do soukromého cloudového úložiště, zatímco mluvíte.';
+  String get cloudStorageDialogMessage => 'Vaše nahrávky v reálném čase budou ukládány do soukromého cloudového úložiště, zatímco mluvíte.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Ukládejte své nahrávky v reálném čase do soukromého cloudového úložiště, zatímco mluvíte. Zvuk je zachycen a bezpečně uložen v reálném čase.';
+  String get storeAudioCloudDescription => 'Ukládejte své nahrávky v reálném čase do soukromého cloudového úložiště, zatímco mluvíte. Zvuk je zachycen a bezpečně uložen v reálném čase.';
 
   @override
   String get downloadingFirmware => 'Stahování firmwaru';
@@ -4891,8 +4803,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get installingFirmware => 'Instalace firmwaru';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Nezavírejte aplikaci ani nevypínejte zařízení. Mohlo by to poškodit vaše zařízení.';
+  String get firmwareUpdateWarning => 'Nezavírejte aplikaci ani nevypínejte zařízení. Mohlo by to poškodit vaše zařízení.';
 
   @override
   String get firmwareUpdated => 'Firmware aktualizován';
@@ -4990,8 +4901,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get connectingYourStripeAccount => 'Připojování vašeho účtu Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Dokončete prosím proces registrace Stripe ve vašem prohlížeči. Tato stránka se automaticky aktualizuje po dokončení.';
+  String get stripeOnboardingInstructions => 'Dokončete prosím proces registrace Stripe ve vašem prohlížeči. Tato stránka se automaticky aktualizuje po dokončení.';
 
   @override
   String get failedTryAgain => 'Selhalo? Zkusit znovu';
@@ -5003,8 +4913,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get successfullyConnected => 'Úspěšně připojeno!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Váš účet Stripe je nyní připraven přijímat platby. Můžete začít vydělávat z prodeje aplikací ihned.';
+  String get stripeReadyForPayments => 'Váš účet Stripe je nyní připraven přijímat platby. Můžete začít vydělávat z prodeje aplikací ihned.';
 
   @override
   String get updateStripeDetails => 'Aktualizovat údaje Stripe';
@@ -5031,8 +4940,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get paypalMeLink => 'Odkaz PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Pokud je Stripe k dispozici ve vaší zemi, důrazně doporučujeme jej používat pro rychlejší a snadnější výplaty.';
+  String get stripeRecommendation => 'Pokud je Stripe k dispozici ve vaší zemi, důrazně doporučujeme jej používat pro rychlejší a snadnější výplaty.';
 
   @override
   String get updatePayPalDetails => 'Aktualizovat údaje PayPal';
@@ -5084,8 +4992,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Další hlasový vzorek byl odstraněn';
 
   @override
-  String get consentDataMessage =>
-      'Pokračováním budou vaše konverzace, nahrávky a osobní údaje bezpečně uloženy na našich serverech. Vaše audio nahrávky a přepisy jsou zpracovávány AI službami třetích stran (včetně Deepgram pro přepis a OpenAI pro analýzu), aby vám poskytly poznatky založené na AI a umožnily všechny funkce aplikace.';
+  String get consentDataMessage => 'Pokračováním budou vaše konverzace, nahrávky a osobní údaje bezpečně uloženy na našich serverech. Vaše audio nahrávky a přepisy jsou zpracovávány AI službami třetích stran (včetně Deepgram pro přepis a OpenAI pro analýzu), aby vám poskytly poznatky založené na AI a umožnily všechny funkce aplikace.';
 
   @override
   String get tasksEmptyStateMessage => 'Úkoly z vašich konverzací se zobrazí zde.\nKlepněte na + pro ruční vytvoření.';
@@ -5124,15 +5031,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Nainstalujte Omi na\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Chcete-li používat Apple Watch s Omi, musíte nejprve nainstalovat aplikaci Omi na hodinky.';
+  String get installOmiOnAppleWatchDescription => 'Chcete-li používat Apple Watch s Omi, musíte nejprve nainstalovat aplikaci Omi na hodinky.';
 
   @override
   String get openOmiOnAppleWatch => 'Otevřete Omi na\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Aplikace Omi je nainstalována na vašem Apple Watch. Otevřete ji a klepněte na Start.';
+  String get openOmiOnAppleWatchDescription => 'Aplikace Omi je nainstalována na vašem Apple Watch. Otevřete ji a klepněte na Start.';
 
   @override
   String get openWatchApp => 'Otevřít aplikaci Watch';
@@ -5141,15 +5046,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Nainstaloval(a) jsem a otevřel(a) aplikaci';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Nelze otevřít aplikaci Apple Watch. Ručně otevřete aplikaci Watch na Apple Watch a nainstalujte Omi ze sekce \"Dostupné aplikace\".';
+  String get unableToOpenWatchApp => 'Nelze otevřít aplikaci Apple Watch. Ručně otevřete aplikaci Watch na Apple Watch a nainstalujte Omi ze sekce \"Dostupné aplikace\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch úspěšně připojeny!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch stále není dostupné. Ujistěte se, že aplikace Omi je na hodinkách otevřená.';
+  String get appleWatchNotReachable => 'Apple Watch stále není dostupné. Ujistěte se, že aplikace Omi je na hodinkách otevřená.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5577,8 +5480,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get multipleSpeakersDetected => 'Bylo detekováno více mluvčích';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Zdá se, že v nahrávce je více mluvčích. Ujistěte se, že jste na tichém místě a zkuste to znovu.';
+  String get multipleSpeakersDescription => 'Zdá se, že v nahrávce je více mluvčích. Ujistěte se, že jste na tichém místě a zkuste to znovu.';
 
   @override
   String get invalidRecordingDetected => 'Byla detekována neplatná nahrávka';
@@ -5590,15 +5492,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get speechDurationDescription => 'Ujistěte se, že mluvíte alespoň 5 sekund a ne více než 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Připojení bylo přerušeno. Zkontrolujte své internetové připojení a zkuste to znovu.';
+  String get connectionLostDescription => 'Připojení bylo přerušeno. Zkontrolujte své internetové připojení a zkuste to znovu.';
 
   @override
   String get howToTakeGoodSample => 'Jak pořídit dobrý vzorek?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Ujistěte se, že jste na tichém místě.\n2. Mluvte jasně a přirozeně.\n3. Ujistěte se, že je vaše zařízení v přirozené poloze na krku.\n\nJakmile je vytvořen, můžete jej vždy vylepšit nebo udělat znovu.';
+  String get goodSampleInstructions => '1. Ujistěte se, že jste na tichém místě.\n2. Mluvte jasně a přirozeně.\n3. Ujistěte se, že je vaše zařízení v přirozené poloze na krku.\n\nJakmile je vytvořen, můžete jej vždy vylepšit nebo udělat znovu.';
 
   @override
   String get noDeviceConnectedUseMic => 'Žádné připojené zařízení. Bude použit mikrofon telefonu.';
@@ -5661,12 +5561,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get howItWorks => 'Jak to funguje';
 
   @override
-  String get dailyScoreExplanation =>
-      'Vaše denní skóre je založeno na plnění úkolů. Dokončete své úkoly pro zlepšení skóre!';
+  String get dailyScoreExplanation => 'Vaše denní skóre je založeno na plnění úkolů. Dokončete své úkoly pro zlepšení skóre!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Ovládejte, jak často vám Omi zasílá proaktivní oznámení a připomínky.';
+  String get notificationFrequencyDescription => 'Ovládejte, jak často vám Omi zasílá proaktivní oznámení a připomínky.';
 
   @override
   String get sliderOff => 'Vyp.';
@@ -5680,8 +5578,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Nepodařilo se vygenerovat shrnutí. Ujistěte se, že máte konverzace pro tento den.';
+  String get failedToGenerateSummary => 'Nepodařilo se vygenerovat shrnutí. Ujistěte se, že máte konverzace pro tento den.';
 
   @override
   String get recap => 'Rekapitulace';
@@ -6047,8 +5944,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get viewUsage => 'Zobrazit využití';
 
   @override
-  String get localProcessingInfo =>
-      'Zvuk je zpracováván lokálně. Funguje offline, je soukromější, ale spotřebovává více baterie.';
+  String get localProcessingInfo => 'Zvuk je zpracováván lokálně. Funguje offline, je soukromější, ale spotřebovává více baterie.';
 
   @override
   String get model => 'Model';
@@ -6057,8 +5953,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get performanceWarning => 'Varování o výkonu';
 
   @override
-  String get largeModelWarning =>
-      'Tento model je velký a může způsobit pád aplikace nebo velmi pomalý běh na mobilních zařízeních.\n\nDoporučuje se \"small\" nebo \"base\".';
+  String get largeModelWarning => 'Tento model je velký a může způsobit pád aplikace nebo velmi pomalý běh na mobilních zařízeních.\n\nDoporučuje se \"small\" nebo \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Používání nativního rozpoznávání řeči iOS';
@@ -6121,12 +6016,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get batteryDrainSignificantly => 'Vybíjení baterie se výrazně zvýší.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1 200 prémiových minut/měsíc. Karta Na zařízení nabízí neomezený bezplatný přepis. ';
+  String get premiumMinutesMonth => '1 200 prémiových minut/měsíc. Karta Na zařízení nabízí neomezený bezplatný přepis. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Zvuk je zpracováván lokálně. Funguje offline, je soukromější, ale spotřebovává více baterie.';
+  String get audioProcessedLocally => 'Zvuk je zpracováván lokálně. Funguje offline, je soukromější, ale spotřebovává více baterie.';
 
   @override
   String get languageLabel => 'Jazyk';
@@ -6135,8 +6028,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Tento model je velký a může způsobit pád aplikace nebo velmi pomalý běh na mobilních zařízeních.\n\nDoporučuje se small nebo base.';
+  String get modelTooLargeWarning => 'Tento model je velký a může způsobit pád aplikace nebo velmi pomalý běh na mobilních zařízeních.\n\nDoporučuje se small nebo base.';
 
   @override
   String get nativeEngineNoDownload => 'Bude použit nativní hlasový engine vašeho zařízení. Není nutné stahovat model.';
@@ -6175,8 +6067,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Vestavěný živý přepis Omi je optimalizován pro konverzace v reálném čase s automatickou detekcí mluvčích a diarizací.';
+  String get omiTranscriptionOptimized => 'Vestavěný živý přepis Omi je optimalizován pro konverzace v reálném čase s automatickou detekcí mluvčích a diarizací.';
 
   @override
   String get reset => 'Resetovat';
@@ -6396,8 +6287,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Vytváření znalostního grafu ze vzpomínek...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Váš znalostní graf se vytvoří automaticky, jakmile vytvoříte nové vzpomínky.';
+  String get knowledgeGraphWillBuildAutomatically => 'Váš znalostní graf se vytvoří automaticky, jakmile vytvoříte nové vzpomínky.';
 
   @override
   String get buildGraphButton => 'Vytvořit graf';
@@ -6633,8 +6523,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get failedToLoadContacts => 'Nepodařilo se načíst kontakty';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Nepodařilo se připravit konverzaci ke sdílení. Zkuste to prosím znovu.';
+  String get failedToPrepareConversationForSharing => 'Nepodařilo se připravit konverzaci ke sdílení. Zkuste to prosím znovu.';
 
   @override
   String get couldNotOpenSmsApp => 'Nepodařilo se otevřít aplikaci SMS. Zkuste to prosím znovu.';
@@ -6700,8 +6589,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Stahování zvuku z SD karty vašeho zařízení';
 
   @override
-  String get transferRequiredDescription =>
-      'Tato nahrávka je uložena na SD kartě vašeho zařízení. Přeneste ji do telefonu pro přehrání.';
+  String get transferRequiredDescription => 'Tato nahrávka je uložena na SD kartě vašeho zařízení. Přeneste ji do telefonu pro přehrání.';
 
   @override
   String get cancelTransfer => 'Zrušit přenos';
@@ -6781,8 +6669,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get enableFastTransfer => 'Povolit rychlý přenos';
 
   @override
-  String get fastTransferDescription =>
-      'Rychlý přenos používá WiFi pro ~5x rychlejší přenosy. Váš telefon se dočasně připojí k WiFi síti zařízení Omi během přenosu.';
+  String get fastTransferDescription => 'Rychlý přenos používá WiFi pro ~5x rychlejší přenosy. Váš telefon se dočasně připojí k WiFi síti zařízení Omi během přenosu.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Přístup k internetu je během přenosu pozastaven';
@@ -6797,8 +6684,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fiveTimesFaster => '5X RYCHLEJŠÍ';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Vytvoří přímé WiFi připojení k zařízení Omi. Telefon se dočasně odpojí od běžné WiFi během přenosu.';
+  String get fastTransferMethodDescription => 'Vytvoří přímé WiFi připojení k zařízení Omi. Telefon se dočasně odpojí od běžné WiFi během přenosu.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6807,8 +6693,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get bleSpeed => '~30 KB/s přes BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Používá standardní Bluetooth Low Energy připojení. Pomalejší, ale neovlivňuje WiFi připojení.';
+  String get bluetoothMethodDescription => 'Používá standardní Bluetooth Low Energy připojení. Pomalejší, ale neovlivňuje WiFi připojení.';
 
   @override
   String get selected => 'Vybráno';
@@ -6826,8 +6711,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'Vaše zařízení Omi bylo odpojeno';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'Prosím, znovu se připojte, abyste mohli pokračovat v používání Omi.';
+  String get deviceDisconnectedNotificationBody => 'Prosím, znovu se připojte, abyste mohli pokračovat v používání Omi.';
 
   @override
   String get firmwareUpdateAvailable => 'K dispozici je aktualizace firmwaru';
@@ -6847,12 +6731,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get appDeleteFailed => 'Nepodařilo se smazat aplikaci. Zkuste to prosím později.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Viditelnost aplikace byla úspěšně změněna. Může to trvat několik minut.';
+  String get appVisibilityChangedSuccessfully => 'Viditelnost aplikace byla úspěšně změněna. Může to trvat několik minut.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Chyba při aktivaci aplikace. Pokud jde o integrační aplikaci, ujistěte se, že je nastavení dokončeno.';
+  String get errorActivatingAppIntegration => 'Chyba při aktivaci aplikace. Pokud jde o integrační aplikaci, ujistěte se, že je nastavení dokončeno.';
 
   @override
   String get errorUpdatingAppStatus => 'Při aktualizaci stavu aplikace došlo k chybě.';
@@ -6932,8 +6814,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Název musí mít alespoň 3 znaky';
 
   @override
-  String get conversationPromptHint =>
-      'např. Extrahujte úkoly, přijatá rozhodnutí a klíčové poznatky z poskytnuté konverzace.';
+  String get conversationPromptHint => 'např. Extrahujte úkoly, přijatá rozhodnutí a klíčové poznatky z poskytnuté konverzace.';
 
   @override
   String get pleaseEnterAppPrompt => 'Zadejte prosím výzvu pro vaši aplikaci';
@@ -7120,15 +7001,13 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade naplánován! Váš měsíční plán pokračuje do konce fakturačního období.';
+  String get planUpgradeScheduledMessage => 'Upgrade naplánován! Váš měsíční plán pokračuje do konce fakturačního období.';
 
   @override
   String get couldNotSchedulePlanChange => 'Nepodařilo se naplánovat změnu plánu. Zkuste to prosím znovu.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Vaše předplatné bylo obnoveno! Nyní nebude účtován žádný poplatek - fakturováno bude na konci fakturačního období.';
+  String get subscriptionReactivatedDefault => 'Vaše předplatné bylo obnoveno! Nyní nebude účtován žádný poplatek - fakturováno bude na konci fakturačního období.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Předplatné úspěšné! Byli jste účtováni za nové fakturační období.';
@@ -7296,8 +7175,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Nepodařilo se získat Firebase token, zkuste to prosím znovu.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Neočekávaná chyba při přihlašování, chyba Firebase, zkuste to prosím znovu.';
+  String get authUnexpectedErrorFirebase => 'Neočekávaná chyba při přihlašování, chyba Firebase, zkuste to prosím znovu.';
 
   @override
   String get authUnexpectedError => 'Neočekávaná chyba při přihlašování, zkuste to prosím znovu';
@@ -7312,8 +7190,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get onboardingBluetoothRequired => 'K připojení k zařízení je vyžadováno oprávnění Bluetooth.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Oprávnění Bluetooth bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Oprávnění Bluetooth bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7326,12 +7203,10 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Oprávnění pro oznámení bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Oprávnění pro oznámení bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Oprávnění pro oznámení bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému > Oznámení.';
+  String get onboardingNotificationDeniedNotifications => 'Oprávnění pro oznámení bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému > Oznámení.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7344,15 +7219,13 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Udělte prosím oprávnění k poloze v Nastavení > Soukromí a zabezpečení > Polohové služby';
+  String get onboardingLocationGrantInSettings => 'Udělte prosím oprávnění k poloze v Nastavení > Soukromí a zabezpečení > Polohové služby';
 
   @override
   String get onboardingMicrophoneRequired => 'K nahrávání je vyžadováno oprávnění mikrofonu.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Oprávnění mikrofonu bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému > Soukromí a zabezpečení > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Oprávnění mikrofonu bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému > Soukromí a zabezpečení > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7365,12 +7238,10 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'K nahrávání systémového zvuku je vyžadováno oprávnění pro snímání obrazovky.';
+  String get onboardingScreenCaptureRequired => 'K nahrávání systémového zvuku je vyžadováno oprávnění pro snímání obrazovky.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Oprávnění pro snímání obrazovky bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému > Soukromí a zabezpečení > Nahrávání obrazovky.';
+  String get onboardingScreenCaptureDenied => 'Oprávnění pro snímání obrazovky bylo zamítnuto. Udělte prosím oprávnění v Předvolbách systému > Soukromí a zabezpečení > Nahrávání obrazovky.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7399,8 +7270,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get msgCameraNotAvailable => 'Snímání fotoaparátem není na této platformě k dispozici';
 
   @override
-  String get msgCameraPermissionDenied =>
-      'Oprávnění k fotoaparátu bylo zamítnuto. Povolte prosím přístup k fotoaparátu';
+  String get msgCameraPermissionDenied => 'Oprávnění k fotoaparátu bylo zamítnuto. Povolte prosím přístup k fotoaparátu';
 
   @override
   String msgCameraAccessError(String error) {
@@ -7424,8 +7294,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Oprávnění k fotografiím bylo zamítnuto. Povolte prosím přístup k fotografiím pro výběr obrázků';
+  String get msgPhotosPermissionDenied => 'Oprávnění k fotografiím bylo zamítnuto. Povolte prosím přístup k fotografiím pro výběr obrázků';
 
   @override
   String get msgSelectImagesGenericError => 'Chyba při výběru obrázků. Zkuste to prosím znovu.';
@@ -7497,8 +7366,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get locationPermissionRequired => 'Vyžadováno oprávnění k poloze';
 
   @override
-  String get locationPermissionContent =>
-      'Rychlý přenos vyžaduje oprávnění k poloze pro ověření WiFi připojení. Prosím, udělte oprávnění k poloze pro pokračování.';
+  String get locationPermissionContent => 'Rychlý přenos vyžaduje oprávnění k poloze pro ověření WiFi připojení. Prosím, udělte oprávnění k poloze pro pokračování.';
 
   @override
   String get pdfTranscriptExport => 'Export přepisu';
@@ -7661,8 +7529,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Zařízení nepodporuje WiFi synchronizaci, přepínání na Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Zařízení nepodporuje WiFi synchronizaci, přepínání na Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health není na tomto zařízení k dispozici';
@@ -7958,8 +7825,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Přepněte Omi DevKit do režimu párování';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Stiskněte tlačítko jednou pro zapnutí. LED bude blikat fialově v režimu párování.';
+  String get pairingDescOmiDevkit => 'Stiskněte tlačítko jednou pro zapnutí. LED bude blikat fialově v režimu párování.';
 
   @override
   String get pairingTitleOmiGlass => 'Zapněte Omi Glass';
@@ -7971,8 +7837,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Přepněte Plaud Note do režimu párování';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Stiskněte a podržte boční tlačítko po dobu 2 sekund. Červená LED bude blikat, když je připraveno k párování.';
+  String get pairingDescPlaudNote => 'Stiskněte a podržte boční tlačítko po dobu 2 sekund. Červená LED bude blikat, když je připraveno k párování.';
 
   @override
   String get pairingTitleBee => 'Přepněte Bee do režimu párování';
@@ -7984,15 +7849,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get pairingTitleLimitless => 'Přepněte Limitless do režimu párování';
 
   @override
-  String get pairingDescLimitless =>
-      'Když svítí jakýkoli indikátor, stiskněte jednou a poté stiskněte a podržte, dokud zařízení neukáže růžové světlo, poté uvolněte.';
+  String get pairingDescLimitless => 'Když svítí jakýkoli indikátor, stiskněte jednou a poté stiskněte a podržte, dokud zařízení neukáže růžové světlo, poté uvolněte.';
 
   @override
   String get pairingTitleFriendPendant => 'Přepněte Friend Pendant do režimu párování';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Stiskněte tlačítko na přívěsku pro zapnutí. Automaticky přejde do režimu párování.';
+  String get pairingDescFriendPendant => 'Stiskněte tlačítko na přívěsku pro zapnutí. Automaticky přejde do režimu párování.';
 
   @override
   String get pairingTitleFieldy => 'Přepněte Fieldy do režimu párování';
@@ -8004,15 +7867,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Připojte Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Nainstalujte a otevřete aplikaci Omi na Apple Watch, poté klepněte na Připojit v aplikaci.';
+  String get pairingDescAppleWatch => 'Nainstalujte a otevřete aplikaci Omi na Apple Watch, poté klepněte na Připojit v aplikaci.';
 
   @override
   String get pairingTitleNeoOne => 'Přepněte Neo One do režimu párování';
 
   @override
-  String get pairingDescNeoOne =>
-      'Stiskněte a podržte tlačítko napájení, dokud LED nezabliká. Zařízení bude viditelné.';
+  String get pairingDescNeoOne => 'Stiskněte a podržte tlačítko napájení, dokud LED nezabliká. Zařízení bude viditelné.';
 
   @override
   String get downloadingFromDevice => 'Stahování ze zařízení';
@@ -8129,8 +7990,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get switchAndRestart => 'Přepnout';
 
   @override
-  String get stagingDisclaimer =>
-      'Testovací prostředí může být nestabilní, mít nekonzistentní výkon a data mohou být ztracena. Pouze pro testování.';
+  String get stagingDisclaimer => 'Testovací prostředí může být nestabilní, mít nekonzistentní výkon a data mohou být ztracena. Pouze pro testování.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Uloženo. Zavřete a znovu otevřete aplikaci pro použití změn.';
@@ -8359,8 +8219,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonní hovory přes Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Volejte přes Omi a získejte přepis v reálném čase, automatické shrnutí a další.';
+  String get phoneCallsUpsellSubtitle => 'Volejte přes Omi a získejte přepis v reálném čase, automatické shrnutí a další.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Přepis každého hovoru v reálném čase';
@@ -8387,8 +8246,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteSyncedFiles => 'Smazat synchronizované nahrávky';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Tyto nahrávky jsou již synchronizovány s vaším telefonem. Toto nelze vrátit zpět.';
+  String get deleteSyncedFilesMessage => 'Tyto nahrávky jsou již synchronizovány s vaším telefonem. Toto nelze vrátit zpět.';
 
   @override
   String get syncedFilesDeleted => 'Synchronizované nahrávky smazány';
@@ -8400,8 +8258,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deletePendingFiles => 'Smazat čekající nahrávky';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Tyto nahrávky NEJSOU synchronizovány s vaším telefonem a budou trvale ztraceny. Toto nelze vrátit zpět.';
+  String get deletePendingFilesWarning => 'Tyto nahrávky NEJSOU synchronizovány s vaším telefonem a budou trvale ztraceny. Toto nelze vrátit zpět.';
 
   @override
   String get pendingFilesDeleted => 'Čekající nahrávky smazány';
@@ -8413,8 +8270,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deleteAll => 'Smazat vše';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Toto smaže synchronizované i čekající nahrávky. Čekající nahrávky NEJSOU synchronizovány a budou trvale ztraceny.';
+  String get deleteAllFilesWarning => 'Toto smaže synchronizované i čekající nahrávky. Čekající nahrávky NEJSOU synchronizovány a budou trvale ztraceny.';
 
   @override
   String get allFilesDeleted => 'Všechny nahrávky smazány';
@@ -8479,8 +8335,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fairUseAboutTitle => 'O spravedlivém používání';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi je navržen pro osobní konverzace, schůzky a živé interakce. Používání se měří skutečným detekovaným časem řeči, nikoli časem připojení. Pokud používání výrazně překročí běžné vzorce pro neosobní obsah, mohou být provedeny úpravy.';
+  String get fairUseAboutBody => 'Omi je navržen pro osobní konverzace, schůzky a živé interakce. Používání se měří skutečným detekovaným časem řeči, nikoli časem připojení. Pokud používání výrazně překročí běžné vzorce pro neosobní obsah, mohou být provedeny úpravy.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8518,8 +8373,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get improveConnectionTitle => 'Zlepšit připojení';
 
   @override
-  String get improveConnectionContent =>
-      'Vylepšili jsme způsob, jakým Omi zůstává připojeno k vašemu zařízení. Pro aktivaci přejděte na stránku Informace o zařízení, klepněte na \"Odpojit zařízení\" a poté zařízení znovu spárujte.';
+  String get improveConnectionContent => 'Vylepšili jsme způsob, jakým Omi zůstává připojeno k vašemu zařízení. Pro aktivaci přejděte na stránku Informace o zařízení, klepněte na \"Odpojit zařízení\" a poté zařízení znovu spárujte.';
 
   @override
   String get improveConnectionAction => 'Rozumím';
@@ -8574,16 +8428,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get cancelSyncQuestion => 'Zrušit synchronizaci?';
 
   @override
-  String get omisStorageDesc =>
-      'Když váš Omi není připojen k telefonu, ukládá zvuk lokálně ve své vestavěné paměti. Nikdy neztratíte nahrávku.';
+  String get omisStorageDesc => 'Když váš Omi není připojen k telefonu, ukládá zvuk lokálně ve své vestavěné paměti. Nikdy neztratíte nahrávku.';
 
   @override
-  String get phoneStorageDesc =>
-      'Když se Omi znovu připojí, nahrávky se automaticky přenesou do telefonu jako dočasné úložiště před nahráním.';
+  String get phoneStorageDesc => 'Když se Omi znovu připojí, nahrávky se automaticky přenesou do telefonu jako dočasné úložiště před nahráním.';
 
   @override
-  String get cloudStorageDesc =>
-      'Po nahrání jsou vaše nahrávky zpracovány a přepsány. Konverzace budou dostupné během minuty.';
+  String get cloudStorageDesc => 'Po nahrání jsou vaše nahrávky zpracovány a přepsány. Konverzace budou dostupné během minuty.';
 
   @override
   String get tipKeepPhoneNearby => 'Mějte telefon poblíž pro rychlejší synchronizaci';
@@ -8607,12 +8458,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get permissionEnable => 'Povolit';
 
   @override
-  String get permissionsPageDescription =>
-      'Tato oprávnění jsou klíčová pro fungování Omi. Umožňují klíčové funkce jako oznámení, služby založené na poloze a záznam zvuku.';
+  String get permissionsPageDescription => 'Tato oprávnění jsou klíčová pro fungování Omi. Umožňují klíčové funkce jako oznámení, služby založené na poloze a záznam zvuku.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi potřebuje několik oprávnění, aby správně fungoval. Prosím, udělte je pro pokračování.';
+  String get permissionsRequiredDescription => 'Omi potřebuje několik oprávnění, aby správně fungoval. Prosím, udělte je pro pokračování.';
 
   @override
   String get permissionsSetupTitle => 'Získejte nejlepší zážitek';
@@ -8889,8 +8738,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get firmwareWarningTitle => 'Důležité: Přečtěte si před aktualizací';
 
   @override
-  String get firmwareFormatWarning =>
-      'Tento firmware naformátuje SD kartu. Před aktualizací se prosím ujistěte, že jsou všechna offline data synchronizována.\n\nPokud po instalaci této verze uvidíte blikající červené světlo, nedělejte si starosti. Jednoduše připojte zařízení k aplikaci a mělo by se rozsvítit modře. Červené světlo znamená, že hodiny zařízení ještě nebyly synchronizovány.';
+  String get firmwareFormatWarning => 'Tento firmware naformátuje SD kartu. Před aktualizací se prosím ujistěte, že jsou všechna offline data synchronizována.\n\nPokud po instalaci této verze uvidíte blikající červené světlo, nedělejte si starosti. Jednoduše připojte zařízení k aplikaci a mělo by se rozsvítit modře. Červené světlo znamená, že hodiny zařízení ještě nebyly synchronizovány.';
 
   @override
   String get continueAnyway => 'Pokračovat';
@@ -8910,8 +8758,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get tasksMarkComplete => 'Označeno jako dokončené';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi přistupuje k Apple Health prostřednictvím frameworku HealthKit od Applu. Přístup můžete kdykoli odvolat v Nastavení iOS.';
+  String get appleHealthManageNote => 'Omi přistupuje k Apple Health prostřednictvím frameworku HealthKit od Applu. Přístup můžete kdykoli odvolat v Nastavení iOS.';
 
   @override
   String get appleHealthConnectCta => 'Připojit k Apple Health';
@@ -8944,8 +8791,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Přístup k Apple Health zamítnut';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi nemá oprávnění číst vaše data z Apple Health. Povolte ho v Nastavení iOS → Soukromí a zabezpečení → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi nemá oprávnění číst vaše data z Apple Health. Povolte ho v Nastavení iOS → Soukromí a zabezpečení → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Proč odcházíte?';
@@ -9014,8 +8860,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get planUpdate => 'Aktualizace plánu';
 
   @override
-  String get planDeprecationMessage =>
-      'Váš plán Unlimited je rušen. Přejděte na plán Operator — stejné skvělé funkce za \$49/měs. Váš stávající plán bude zatím nadále fungovat.';
+  String get planDeprecationMessage => 'Váš plán Unlimited je rušen. Přejděte na plán Operator — stejné skvělé funkce za \$49/měs. Váš stávající plán bude zatím nadále fungovat.';
 
   @override
   String get upgradeYourPlan => 'Upgradujte svůj plán';
@@ -9126,8 +8971,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Dosáhli jste svého měsíčního limitu. Upgradujte, abyste mohli pokračovat v chatu s Omi bez omezení.';
+  String get chatQuotaExceededReply => 'Dosáhli jste svého měsíčního limitu. Upgradujte, abyste mohli pokračovat v chatu s Omi bez omezení.';
 
   @override
   String get voiceResponseAudio => 'Přečíst odpověď Omi nahlas';
@@ -9158,4 +9002,25 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Přidat úkol';
+
+  @override
+  String get quickActionAskOmiAnything => 'Zeptejte se Omi na cokoli';
+
+  @override
+  String get quickActionVoiceMode => 'Hlasový režim';
+
+  @override
+  String get quickActionMute => 'Ztlumit';
+
+  @override
+  String get quickActionUnmute => 'Zapnout zvuk';
+
+  @override
+  String get quickActionConnectDevice => 'Připojit zařízení';
+
+  @override
+  String get quickActionDeviceSettings => 'Nastavení zařízení';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -24,8 +24,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteConversationTitle => 'Slet samtale?';
 
   @override
-  String get deleteConversationMessage =>
-      'Dette vil også slette tilknyttede minder, opgaver og lydfiler. Denne handling kan ikke fortrydes.';
+  String get deleteConversationMessage => 'Dette vil også slette tilknyttede minder, opgaver og lydfiler. Denne handling kan ikke fortrydes.';
 
   @override
   String get confirm => 'Bekræft';
@@ -146,8 +145,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleting => 'Sletter...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Fuldfør venligst godkendelse i din browser. Når det er færdigt, vend tilbage til appen.';
+  String get pleaseCompleteAuthentication => 'Fuldfør venligst godkendelse i din browser. Når det er færdigt, vend tilbage til appen.';
 
   @override
   String get failedToStartAuthentication => 'Kunne ikke starte godkendelse';
@@ -228,8 +226,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get noStarredConversations => 'Ingen stjernemarkerede samtaler';
 
   @override
-  String get starConversationHint =>
-      'For at stjernemarkere en samtale skal du åbne den og trykke på stjerneikonet i overskriften.';
+  String get starConversationHint => 'For at stjernemarkere en samtale skal du åbne den og trykke på stjerneikonet i overskriften.';
 
   @override
   String get searchConversations => 'Søg samtaler...';
@@ -356,19 +353,16 @@ class AppLocalizationsDa extends AppLocalizations {
   String get appsDisconnected => 'Dine apps og integrationer vil blive afbrudt øjeblikkeligt.';
 
   @override
-  String get exportBeforeDelete =>
-      'Du kan eksportere dine data før du sletter din konto, men når den er slettet, kan den ikke gendannes.';
+  String get exportBeforeDelete => 'Du kan eksportere dine data før du sletter din konto, men når den er slettet, kan den ikke gendannes.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Jeg forstår, at sletning af min konto er permanent, og at alle data, inklusive minder og samtaler, vil gå tabt og ikke kan gendannes.';
+  String get deleteAccountCheckbox => 'Jeg forstår, at sletning af min konto er permanent, og at alle data, inklusive minder og samtaler, vil gå tabt og ikke kan gendannes.';
 
   @override
   String get areYouSure => 'Er du sikker?';
 
   @override
-  String get deleteAccountFinal =>
-      'Denne handling er irreversibel og vil permanent slette din konto og alle tilknyttede data. Er du sikker på, at du vil fortsætte?';
+  String get deleteAccountFinal => 'Denne handling er irreversibel og vil permanent slette din konto og alle tilknyttede data. Er du sikker på, at du vil fortsætte?';
 
   @override
   String get deleteNow => 'Slet nu';
@@ -377,8 +371,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get goBack => 'Gå tilbage';
 
   @override
-  String get checkBoxToConfirm =>
-      'Marker afkrydsningsfeltet for at bekræfte, at du forstår, at sletning af din konto er permanent og irreversibel.';
+  String get checkBoxToConfirm => 'Marker afkrydsningsfeltet for at bekræfte, at du forstår, at sletning af din konto er permanent og irreversibel.';
 
   @override
   String get profile => 'Profil';
@@ -456,8 +449,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get yourPrivacyYourControl => 'Dit privatliv, din kontrol';
 
   @override
-  String get privacyIntro =>
-      'Hos Omi er vi forpligtede til at beskytte dit privatliv. Denne side giver dig mulighed for at styre, hvordan dine data gemmes og bruges.';
+  String get privacyIntro => 'Hos Omi er vi forpligtede til at beskytte dit privatliv. Denne side giver dig mulighed for at styre, hvordan dine data gemmes og bruges.';
 
   @override
   String get learnMore => 'Læs mere...';
@@ -466,15 +458,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get dataProtectionLevel => 'Databeskyttelsesniveau';
 
   @override
-  String get dataProtectionDesc =>
-      'Dine data er som standard sikret med stærk kryptering. Gennemgå dine indstillinger og fremtidige privatlivsindstillinger nedenfor.';
+  String get dataProtectionDesc => 'Dine data er som standard sikret med stærk kryptering. Gennemgå dine indstillinger og fremtidige privatlivsindstillinger nedenfor.';
 
   @override
   String get appAccess => 'App-adgang';
 
   @override
-  String get appAccessDesc =>
-      'Følgende apps kan få adgang til dine data. Tryk på en app for at administrere dens tilladelser.';
+  String get appAccessDesc => 'Følgende apps kan få adgang til dine data. Tryk på en app for at administrere dens tilladelser.';
 
   @override
   String get noAppsExternalAccess => 'Ingen installerede apps har ekstern adgang til dine data.';
@@ -531,15 +521,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Din Omi er blevet afbrudt 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Enhed afparret. Gå til Indstillinger > Bluetooth og glem enheden for at fuldføre afparringen.';
+  String get deviceUnpairedMessage => 'Enhed afparret. Gå til Indstillinger > Bluetooth og glem enheden for at fuldføre afparringen.';
 
   @override
   String get unpairDialogTitle => 'Afpar enhed';
 
   @override
-  String get unpairDialogMessage =>
-      'Dette vil afparre enheden, så den kan tilsluttes en anden telefon. Du skal gå til Indstillinger > Bluetooth og glemme enheden for at fuldføre processen.';
+  String get unpairDialogMessage => 'Dette vil afparre enheden, så den kan tilsluttes en anden telefon. Du skal gå til Indstillinger > Bluetooth og glemme enheden for at fuldføre processen.';
 
   @override
   String get deviceNotConnected => 'Enhed ikke tilsluttet';
@@ -560,8 +548,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get v2Undetected => 'V2 ikke opdaget';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vi kan se, at du enten har en V1-enhed, eller at din enhed ikke er tilsluttet. SD-kort-funktionalitet er kun tilgængelig for V2-enheder.';
+  String get v2UndetectedMessage => 'Vi kan se, at du enten har en V1-enhed, eller at din enhed ikke er tilsluttet. SD-kort-funktionalitet er kun tilgængelig for V2-enheder.';
 
   @override
   String get endConversation => 'Afslut samtale';
@@ -835,8 +822,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Slet videngraf?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Dette vil slette alle afledte videngraf-data (noder og forbindelser). Dine originale minder forbliver sikre. Grafen vil blive genopbygget over tid eller ved næste anmodning.';
+  String get deleteKnowledgeGraphMessage => 'Dette vil slette alle afledte videngraf-data (noder og forbindelser). Dine originale minder forbliver sikre. Grafen vil blive genopbygget over tid eller ved næste anmodning.';
 
   @override
   String get knowledgeGraphDeleted => 'Vidensgraf slettet';
@@ -984,8 +970,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get shortConversationThreshold => 'Kort samtale-tærskel';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Samtaler kortere end denne vil blive skjult, medmindre aktiveret ovenfor';
+  String get shortConversationThresholdSubtitle => 'Samtaler kortere end denne vil blive skjult, medmindre aktiveret ovenfor';
 
   @override
   String get durationThreshold => 'Varighedstærskel';
@@ -1020,8 +1005,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get integrationsFooter => 'Forbind dine apps for at se data og målinger i chat.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Fuldfør venligst godkendelse i din browser. Når det er færdigt, vend tilbage til appen.';
+  String get completeAuthInBrowser => 'Fuldfør venligst godkendelse i din browser. Når det er færdigt, vend tilbage til appen.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1081,37 +1065,31 @@ class AppLocalizationsDa extends AppLocalizations {
   String get needYourPermission => 'Vi har brug for din tilladelse';
 
   @override
-  String get alreadyGavePermission =>
-      'Du har allerede givet os tilladelse til at gemme dine optagelser. Her er en påmindelse om, hvorfor vi har brug for det:';
+  String get alreadyGavePermission => 'Du har allerede givet os tilladelse til at gemme dine optagelser. Her er en påmindelse om, hvorfor vi har brug for det:';
 
   @override
-  String get wouldLikePermission =>
-      'Vi vil gerne have din tilladelse til at gemme dine stemmeoptagelser. Her er hvorfor:';
+  String get wouldLikePermission => 'Vi vil gerne have din tilladelse til at gemme dine stemmeoptagelser. Her er hvorfor:';
 
   @override
   String get improveSpeechProfile => 'Forbedr din taleprofil';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Vi bruger optagelser til yderligere at træne og forbedre din personlige taleprofil.';
+  String get improveSpeechProfileDesc => 'Vi bruger optagelser til yderligere at træne og forbedre din personlige taleprofil.';
 
   @override
   String get trainFamilyProfiles => 'Træn profiler for venner og familie';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Dine optagelser hjælper os med at genkende og oprette profiler for dine venner og familie.';
+  String get trainFamilyProfilesDesc => 'Dine optagelser hjælper os med at genkende og oprette profiler for dine venner og familie.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Forbedr udskriftspræcision';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Efterhånden som vores model forbedres, kan vi levere bedre transskriptionsresultater for dine optagelser.';
+  String get enhanceTranscriptAccuracyDesc => 'Efterhånden som vores model forbedres, kan vi levere bedre transskriptionsresultater for dine optagelser.';
 
   @override
-  String get legalNotice =>
-      'Juridisk meddelelse: Lovligheden af at optage og gemme stemmedata kan variere afhængigt af din placering og hvordan du bruger denne funktion. Det er dit ansvar at sikre overholdelse af lokale love og regler.';
+  String get legalNotice => 'Juridisk meddelelse: Lovligheden af at optage og gemme stemmedata kan variere afhængigt af din placering og hvordan du bruger denne funktion. Det er dit ansvar at sikre overholdelse af lokale love og regler.';
 
   @override
   String get alreadyAuthorized => 'Allerede godkendt';
@@ -1189,8 +1167,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get showEventsNoParticipants => 'Vis begivenheder uden deltagere';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Når aktiveret, viser Kommende begivenheder uden deltagere eller videolink.';
+  String get showEventsNoParticipantsDesc => 'Når aktiveret, viser Kommende begivenheder uden deltagere eller videolink.';
 
   @override
   String get yourMeetings => 'Dine møder';
@@ -1231,8 +1208,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get noProjectsInWorkspace => 'Ingen projekter fundet i dette arbejdsområde';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Vælg hvor længe der skal ventes i stilhed før automatisk afslutning af samtale:';
+  String get conversationTimeoutDesc => 'Vælg hvor længe der skal ventes i stilhed før automatisk afslutning af samtale:';
 
   @override
   String get timeout2Minutes => '2 minutter';
@@ -1279,8 +1255,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get languageForTranscription => 'Indstil dit sprog for skarpere transskriptioner og en personlig oplevelse.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Enkeltsprogs-tilstand er aktiveret. Oversættelse er deaktiveret for højere nøjagtighed.';
+  String get singleLanguageModeInfo => 'Enkeltsprogs-tilstand er aktiveret. Oversættelse er deaktiveret for højere nøjagtighed.';
 
   @override
   String get searchLanguageHint => 'Søg sprog';
@@ -2202,15 +2177,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'TALE OG TRANSSKRIPTION';
 
   @override
-  String get languageSettingsHelperText =>
-      'App-sprog ændrer menuer og knapper. Talesprog påvirker, hvordan dine optagelser transskriberes.';
+  String get languageSettingsHelperText => 'App-sprog ændrer menuer og knapper. Talesprog påvirker, hvordan dine optagelser transskriberes.';
 
   @override
   String get translationNotice => 'Oversættelsesmeddelelse';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi oversætter samtaler til dit primære sprog. Opdater det når som helst i Indstillinger → Profiler.';
+  String get translationNoticeMessage => 'Omi oversætter samtaler til dit primære sprog. Opdater det når som helst i Indstillinger → Profiler.';
 
   @override
   String get pleaseCheckInternetConnection => 'Tjek venligst din internetforbindelse og prøv igen';
@@ -2365,8 +2338,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Afpar enhed';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Dette vil afparre enheden, så den kan forbindes til en anden telefon. Du skal gå til Indstillinger > Bluetooth og glemme enheden for at fuldføre processen.';
+  String get unpairDeviceDialogMessage => 'Dette vil afparre enheden, så den kan forbindes til en anden telefon. Du skal gå til Indstillinger > Bluetooth og glemme enheden for at fuldføre processen.';
 
   @override
   String get unpair => 'Afpar';
@@ -2547,8 +2519,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get youreAllSet => 'Du er klar!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Velkommen til Omi! Din AI-ledsager er klar til at hjælpe dig med samtaler, opgaver og meget mere.';
+  String get welcomeToOmiDescription => 'Velkommen til Omi! Din AI-ledsager er klar til at hjælpe dig med samtaler, opgaver og meget mere.';
 
   @override
   String get startUsingOmi => 'Begynd at bruge Omi';
@@ -2684,8 +2655,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get noTasksYet => 'Ingen opgaver endnu';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Opgaver fra dine samtaler vises her.\nKlik på Opret for at tilføje en manuelt.';
+  String get tasksFromConversationsWillAppear => 'Opgaver fra dine samtaler vises her.\nKlik på Opret for at tilføje en manuelt.';
 
   @override
   String get monthJan => 'Jan';
@@ -2742,8 +2712,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteActionItem => 'Slet opgave';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Er du sikker på, at du vil slette denne opgave? Denne handling kan ikke fortrydes.';
+  String get deleteActionItemConfirmation => 'Er du sikker på, at du vil slette denne opgave? Denne handling kan ikke fortrydes.';
 
   @override
   String get enterActionItemDescription => 'Indtast opgavebeskrivelse...';
@@ -2818,15 +2787,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get chatPrompt => 'Chat-prompt';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Du er en fantastisk app, dit job er at svare på brugerforespørgsler og få dem til at føle sig godt tilpas...';
+  String get chatPromptPlaceholder => 'Du er en fantastisk app, dit job er at svare på brugerforespørgsler og få dem til at føle sig godt tilpas...';
 
   @override
   String get conversationPrompt => 'Samtaleprompt';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Du er en fantastisk app, du vil få en transskription og opsummering af en samtale...';
+  String get conversationPromptPlaceholder => 'Du er en fantastisk app, du vil få en transskription og opsummering af en samtale...';
 
   @override
   String get notificationScopes => 'Notifikationsområder';
@@ -2838,8 +2805,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get makeMyAppPublic => 'Gør min app offentlig';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Ved at indsende denne app accepterer jeg Omi AI\'s servicevilkår og privatlivspolitik';
+  String get submitAppTermsAgreement => 'Ved at indsende denne app accepterer jeg Omi AI\'s servicevilkår og privatlivspolitik';
 
   @override
   String get submitApp => 'Indsend app';
@@ -2854,12 +2820,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get submitAppQuestion => 'Indsend app?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Din app vil blive gennemgået og gjort offentlig. Du kan begynde at bruge den med det samme, selv under gennemgangen!';
+  String get submitAppPublicDescription => 'Din app vil blive gennemgået og gjort offentlig. Du kan begynde at bruge den med det samme, selv under gennemgangen!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Din app vil blive gennemgået og gjort tilgængelig for dig privat. Du kan begynde at bruge den med det samme, selv under gennemgangen!';
+  String get submitAppPrivateDescription => 'Din app vil blive gennemgået og gjort tilgængelig for dig privat. Du kan begynde at bruge den med det samme, selv under gennemgangen!';
 
   @override
   String get startEarning => 'Begynd at tjene! 💰';
@@ -2883,23 +2847,19 @@ class AppLocalizationsDa extends AppLocalizations {
   String get dataAccessNotice => 'Meddelelse om dataadgang';
 
   @override
-  String get dataAccessWarning =>
-      'Denne app vil få adgang til dine data. Omi AI er ikke ansvarlig for, hvordan dine data bruges, ændres eller slettes af denne app';
+  String get dataAccessWarning => 'Denne app vil få adgang til dine data. Omi AI er ikke ansvarlig for, hvordan dine data bruges, ændres eller slettes af denne app';
 
   @override
   String get installApp => 'Installer app';
 
   @override
-  String get betaTesterNotice =>
-      'Du er betatester for denne app. Den er ikke offentlig endnu. Den bliver offentlig, når den er godkendt.';
+  String get betaTesterNotice => 'Du er betatester for denne app. Den er ikke offentlig endnu. Den bliver offentlig, når den er godkendt.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Din app er under gennemgang og kun synlig for dig. Den bliver offentlig, når den er godkendt.';
+  String get appUnderReviewOwner => 'Din app er under gennemgang og kun synlig for dig. Den bliver offentlig, når den er godkendt.';
 
   @override
-  String get appRejectedNotice =>
-      'Din app er blevet afvist. Opdater venligst app-detaljerne og indsend den igen til gennemgang.';
+  String get appRejectedNotice => 'Din app er blevet afvist. Opdater venligst app-detaljerne og indsend den igen til gennemgang.';
 
   @override
   String get setupSteps => 'Opsætningstrin';
@@ -2934,8 +2894,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get errorActivatingApp => 'Fejl ved aktivering af app';
 
   @override
-  String get integrationSetupRequired =>
-      'Hvis dette er en integrationsapp, skal du sørge for, at opsætningen er fuldført.';
+  String get integrationSetupRequired => 'Hvis dette er en integrationsapp, skal du sørge for, at opsætningen er fuldført.';
 
   @override
   String get installed => 'Installeret';
@@ -2962,8 +2921,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get descriptionLabel => 'Beskrivelse';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Min fantastiske app er en fantastisk app, der gør fantastiske ting. Det er den bedste app nogensinde!';
+  String get appDescriptionPlaceholder => 'Min fantastiske app er en fantastisk app, der gør fantastiske ting. Det er den bedste app nogensinde!';
 
   @override
   String get pleaseProvideValidDescription => 'Angiv venligst en gyldig beskrivelse';
@@ -3115,8 +3073,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get microphonePermissionRequired => 'Mikrofontilladelse er påkrævet til stemmeoptagelse.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofontilladelse nægtet. Giv venligst tilladelse i Systemindstillinger > Privatliv og sikkerhed > Mikrofon.';
+  String get microphonePermissionDenied => 'Mikrofontilladelse nægtet. Giv venligst tilladelse i Systemindstillinger > Privatliv og sikkerhed > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3275,8 +3232,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get createMemory => 'Opret hukommelse';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Er du sikker på, at du vil slette denne hukommelse? Denne handling kan ikke fortrydes.';
+  String get deleteMemoryConfirmation => 'Er du sikker på, at du vil slette denne hukommelse? Denne handling kan ikke fortrydes.';
 
   @override
   String get makePrivate => 'Gør privat';
@@ -3350,8 +3306,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get whatWeCollect => 'Hvad vi indsamler';
 
   @override
-  String get dataCollectionMessage =>
-      'Ved at fortsætte vil dine samtaler, optagelser og personlige oplysninger blive sikkert gemt på vores servere for at levere AI-drevne indsigter og aktivere alle app-funktioner.';
+  String get dataCollectionMessage => 'Ved at fortsætte vil dine samtaler, optagelser og personlige oplysninger blive sikkert gemt på vores servere for at levere AI-drevne indsigter og aktivere alle app-funktioner.';
 
   @override
   String get dataProtection => 'Databeskyttelse';
@@ -3384,8 +3339,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Navnet skal være mindst 2 tegn';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Fortæl os, hvordan du gerne vil tiltales. Dette hjælper med at personalisere din Omi-oplevelse.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Fortæl os, hvordan du gerne vil tiltales. Dette hjælper med at personalisere din Omi-oplevelse.';
 
   @override
   String charactersCount(int count) {
@@ -3402,8 +3356,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get recordAudioConversations => 'Optag lydsamtaler';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi har brug for mikrofonadgang for at optage dine samtaler og give transkriptioner.';
+  String get microphoneAccessDescription => 'Omi har brug for mikrofonadgang for at optage dine samtaler og give transkriptioner.';
 
   @override
   String get screenRecording => 'Skærmoptagelse';
@@ -3412,8 +3365,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Optag systemlyd fra møder';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi har brug for skærmoptagelsestilladelse for at optage systemlyd fra dine browserbaserede møder.';
+  String get screenRecordingDescription => 'Omi har brug for skærmoptagelsestilladelse for at optage systemlyd fra dine browserbaserede møder.';
 
   @override
   String get accessibility => 'Tilgængelighed';
@@ -3422,8 +3374,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Opdage browserbaserede møder';
 
   @override
-  String get accessibilityDescription =>
-      'Omi har brug for tilgængelighedstilladelse for at opdage, når du deltager i Zoom-, Meet- eller Teams-møder i din browser.';
+  String get accessibilityDescription => 'Omi har brug for tilgængelighedstilladelse for at opdage, når du deltager i Zoom-, Meet- eller Teams-møder i din browser.';
 
   @override
   String get pleaseWait => 'Vent venligst...';
@@ -3492,12 +3443,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get exportAllConversationsToJson => 'Eksporter alle dine samtaler til en JSON-fil.';
 
   @override
-  String get conversationsExportStarted =>
-      'Eksport af samtaler startet. Dette kan tage et par sekunder, vent venligst.';
+  String get conversationsExportStarted => 'Eksport af samtaler startet. Dette kan tage et par sekunder, vent venligst.';
 
   @override
-  String get mcpDescription =>
-      'For at forbinde Omi med andre applikationer for at læse, søge og administrere dine minder og samtaler. Opret en nøgle for at komme i gang.';
+  String get mcpDescription => 'For at forbinde Omi med andre applikationer for at læse, søge og administrere dine minder og samtaler. Opret en nøgle for at komme i gang.';
 
   @override
   String get apiKeys => 'API-nøgler';
@@ -3538,8 +3487,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Transskriptionstjenestens diagnostiske status';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Aktiver detaljerede diagnostiske meddelelser fra transskriptionstjenesten';
+  String get enableDetailedDiagnosticMessages => 'Aktiver detaljerede diagnostiske meddelelser fra transskriptionstjenesten';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Opret og tag nye talere automatisk';
@@ -3606,8 +3554,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Lad Omi automatisk vælge den bedste app';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Er du sikker på, at du vil slette denne samtale? Denne handling kan ikke fortrydes.';
+  String get deleteConversationConfirmation => 'Er du sikker på, at du vil slette denne samtale? Denne handling kan ikke fortrydes.';
 
   @override
   String get conversationDeleted => 'Samtale slettet';
@@ -3655,8 +3602,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Forbereder systemlydoptagelse';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klik på knappen for at optage lyd til direkte transkriptioner, AI-indsigt og automatisk lagring.';
+  String get clickTheButtonToCaptureAudio => 'Klik på knappen for at optage lyd til direkte transkriptioner, AI-indsigt og automatisk lagring.';
 
   @override
   String get reconnecting => 'Genopretter forbindelse...';
@@ -3883,8 +3829,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Slet vidensgraf?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Dette vil slette alle afledte vidensgrafsdata. Dine originale minder forbliver sikre.';
+  String get deleteKnowledgeGraphWarning => 'Dette vil slette alle afledte vidensgrafsdata. Dine originale minder forbliver sikre.';
 
   @override
   String get connectOmiWithAI => 'Forbind Omi med AI-assistenter';
@@ -3926,8 +3871,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Vilkår og Privatlivspolitik';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Hjælper med at diagnosticere problemer. Slettes automatisk efter 3 dage.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Hjælper med at diagnosticere problemer. Slettes automatisk efter 3 dage.';
 
   @override
   String get manageYourApp => 'Administrer din app';
@@ -3942,8 +3886,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get updateAppQuestion => 'Opdater app?';
 
   @override
-  String get updateAppConfirmation =>
-      'Er du sikker på, at du vil opdatere din app? Ændringerne vil blive synlige efter gennemgang af vores team.';
+  String get updateAppConfirmation => 'Er du sikker på, at du vil opdatere din app? Ændringerne vil blive synlige efter gennemgang af vores team.';
 
   @override
   String get updateApp => 'Opdater app';
@@ -3973,8 +3916,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get no => 'Nej';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abonnement annulleret. Det forbliver aktivt indtil slutningen af den aktuelle faktureringsperiode.';
+  String get subscriptionCancelledSuccessfully => 'Abonnement annulleret. Det forbliver aktivt indtil slutningen af den aktuelle faktureringsperiode.';
 
   @override
   String get failedToCancelSubscription => 'Kunne ikke annullere abonnement. Prøv venligst igen.';
@@ -4010,8 +3952,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Annuller abonnement?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Er du sikker på, at du vil annullere dit abonnement? Du vil fortsat have adgang indtil slutningen af din nuværende faktureringsperiode.';
+  String get cancelSubscriptionConfirmation => 'Er du sikker på, at du vil annullere dit abonnement? Du vil fortsat have adgang indtil slutningen af din nuværende faktureringsperiode.';
 
   @override
   String get cancelSubscriptionButton => 'Annuller abonnement';
@@ -4020,12 +3961,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get cancelling => 'Annullerer...';
 
   @override
-  String get betaTesterMessage =>
-      'Du er betatester for denne app. Den er ikke offentlig endnu. Den bliver offentlig efter godkendelse.';
+  String get betaTesterMessage => 'Du er betatester for denne app. Den er ikke offentlig endnu. Den bliver offentlig efter godkendelse.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Din app er under gennemgang og kun synlig for dig. Den bliver offentlig efter godkendelse.';
+  String get appUnderReviewMessage => 'Din app er under gennemgang og kun synlig for dig. Den bliver offentlig efter godkendelse.';
 
   @override
   String get appRejectedMessage => 'Din app er blevet afvist. Opdater appdetaljerne og indsend igen til gennemgang.';
@@ -4170,8 +4109,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get omiApiKeys => 'Omi API-nøgler';
 
   @override
-  String get apiKeysDescription =>
-      'API-nøgler bruges til godkendelse, når din app kommunikerer med OMI-serveren. De gør det muligt for din applikation at oprette minder og få sikker adgang til andre OMI-tjenester.';
+  String get apiKeysDescription => 'API-nøgler bruges til godkendelse, når din app kommunikerer med OMI-serveren. De gør det muligt for din applikation at oprette minder og få sikker adgang til andre OMI-tjenester.';
 
   @override
   String get aboutOmiApiKeys => 'Om Omi API-nøgler';
@@ -4195,8 +4133,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Tilbagekald API-nøgle?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Denne handling kan ikke fortrydes. Alle applikationer, der bruger denne nøgle, vil ikke længere kunne få adgang til API\'et.';
+  String get revokeApiKeyWarning => 'Denne handling kan ikke fortrydes. Alle applikationer, der bruger denne nøgle, vil ikke længere kunne få adgang til API\'et.';
 
   @override
   String get revoke => 'Tilbagekald';
@@ -4285,8 +4222,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get keyCreated => 'Nøgle oprettet';
 
   @override
-  String get keyCreatedMessage =>
-      'Din nye nøgle er blevet oprettet. Kopiér den venligst nu. Du vil ikke kunne se den igen.';
+  String get keyCreatedMessage => 'Din nye nøgle er blevet oprettet. Kopiér den venligst nu. Du vil ikke kunne se den igen.';
 
   @override
   String get keyWord => 'Nøgle';
@@ -4295,8 +4231,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get externalAppAccess => 'Ekstern app-adgang';
 
   @override
-  String get externalAppAccessDescription =>
-      'Følgende installerede apps har eksterne integrationer og kan få adgang til dine data, såsom samtaler og minder.';
+  String get externalAppAccessDescription => 'Følgende installerede apps har eksterne integrationer og kan få adgang til dine data, såsom samtaler og minder.';
 
   @override
   String get noExternalAppsHaveAccess => 'Ingen eksterne apps har adgang til dine data.';
@@ -4305,8 +4240,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimal sikkerhed (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-end-kryptering er guldstandarden for privatliv. Når det er aktiveret, krypteres dine data på din enhed, før de sendes til vores servere. Det betyder, at ingen, ikke engang Omi, kan få adgang til dit indhold.';
+  String get e2eeDescription => 'End-to-end-kryptering er guldstandarden for privatliv. Når det er aktiveret, krypteres dine data på din enhed, før de sendes til vores servere. Det betyder, at ingen, ikke engang Omi, kan få adgang til dit indhold.';
 
   @override
   String get importantTradeoffs => 'Vigtige kompromiser:';
@@ -4321,8 +4255,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get featureComingSoon => 'Denne funktion kommer snart!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migrering i gang. Du kan ikke ændre beskyttelsesniveauet, før det er fuldført.';
+  String get migrationInProgressMessage => 'Migrering i gang. Du kan ikke ændre beskyttelsesniveauet, før det er fuldført.';
 
   @override
   String get migrationFailed => 'Migrering mislykkedes';
@@ -4341,15 +4274,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get secureEncryption => 'Sikker kryptering';
 
   @override
-  String get secureEncryptionDescription =>
-      'Dine data er krypteret med en nøgle, der er unik for dig, på vores servere, der er hostet på Google Cloud. Det betyder, at dit rå indhold er utilgængeligt for alle, inklusive Omi-personale eller Google, direkte fra databasen.';
+  String get secureEncryptionDescription => 'Dine data er krypteret med en nøgle, der er unik for dig, på vores servere, der er hostet på Google Cloud. Det betyder, at dit rå indhold er utilgængeligt for alle, inklusive Omi-personale eller Google, direkte fra databasen.';
 
   @override
   String get endToEndEncryption => 'End-to-end-kryptering';
 
   @override
-  String get e2eeCardDescription =>
-      'Aktiver for maksimal sikkerhed, hvor kun du kan få adgang til dine data. Tryk for at lære mere.';
+  String get e2eeCardDescription => 'Aktiver for maksimal sikkerhed, hvor kun du kan få adgang til dine data. Tryk for at lære mere.';
 
   @override
   String get dataAlwaysEncrypted => 'Uanset niveau er dine data altid krypteret i hvile og under overførsel.';
@@ -4420,8 +4351,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Få Omi Unlimited gratis ved at bidrage med dine data til at træne AI-modeller.';
 
   @override
-  String get trainingDataBullets =>
-      '• Dine data hjælper med at forbedre AI-modeller\n• Kun ikke-følsomme data deles\n• Fuldstændig gennemsigtig proces';
+  String get trainingDataBullets => '• Dine data hjælper med at forbedre AI-modeller\n• Kun ikke-følsomme data deles\n• Fuldstændig gennemsigtig proces';
 
   @override
   String get learnMoreAtOmiTraining => 'Lær mere på omi.me/training';
@@ -4433,8 +4363,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get submitRequest => 'Send anmodning';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Tak! Din anmodning er under behandling. Vi giver dig besked, når den er godkendt.';
+  String get thankYouRequestUnderReview => 'Tak! Din anmodning er under behandling. Vi giver dig besked, når den er godkendt.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4469,12 +4398,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get importantBillingInfo => 'Vigtig faktureringsinformation:';
 
   @override
-  String get monthlyPlanContinues =>
-      'Dit nuværende månedlige abonnement fortsætter indtil udgangen af din faktureringsperiode';
+  String get monthlyPlanContinues => 'Dit nuværende månedlige abonnement fortsætter indtil udgangen af din faktureringsperiode';
 
   @override
-  String get paymentMethodCharged =>
-      'Din eksisterende betalingsmetode vil automatisk blive opkrævet, når dit månedlige abonnement udløber';
+  String get paymentMethodCharged => 'Din eksisterende betalingsmetode vil automatisk blive opkrævet, når dit månedlige abonnement udløber';
 
   @override
   String get annualSubscriptionStarts => 'Dit 12-måneders årlige abonnement starter automatisk efter opkrævningen';
@@ -4517,8 +4444,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Dit årlige abonnement starter automatisk, når dit månedlige abonnement slutter.';
+  String get annualPlanStartsAutomatically => 'Dit årlige abonnement starter automatisk, når dit månedlige abonnement slutter.';
 
   @override
   String planRenewsOn(String date) {
@@ -4585,8 +4511,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Dit privatliv er vigtigt for os';
 
   @override
-  String get privacyIntroText =>
-      'Hos Omi tager vi dit privatliv meget alvorligt. Vi ønsker at være transparente om de data, vi indsamler, og hvordan vi bruger dem til at forbedre vores produkt. Her er hvad du skal vide:';
+  String get privacyIntroText => 'Hos Omi tager vi dit privatliv meget alvorligt. Vi ønsker at være transparente om de data, vi indsamler, og hvordan vi bruger dem til at forbedre vores produkt. Her er hvad du skal vide:';
 
   @override
   String get whatWeTrack => 'Hvad vi sporer';
@@ -4601,12 +4526,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ourCommitment => 'Vores forpligtelse';
 
   @override
-  String get commitmentText =>
-      'Vi er forpligtet til kun at bruge de data, vi indsamler, til at gøre Omi til et bedre produkt for dig. Dit privatliv og din tillid er altafgørende for os.';
+  String get commitmentText => 'Vi er forpligtet til kun at bruge de data, vi indsamler, til at gøre Omi til et bedre produkt for dig. Dit privatliv og din tillid er altafgørende for os.';
 
   @override
-  String get thankYouText =>
-      'Tak fordi du er en værdsat bruger af Omi. Hvis du har spørgsmål eller bekymringer, er du velkommen til at kontakte os på team@basedhardware.com.';
+  String get thankYouText => 'Tak fordi du er en værdsat bruger af Omi. Hvis du har spørgsmål eller bekymringer, er du velkommen til at kontakte os på team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi-synkroniseringsindstillinger';
@@ -4615,8 +4538,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get enterHotspotCredentials => 'Indtast din telefons hotspot-legitimationsoplysninger';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi-synkronisering bruger din telefon som hotspot. Find dit hotspot-navn og adgangskode i Indstillinger > Personligt hotspot.';
+  String get wifiSyncUsesHotspot => 'WiFi-synkronisering bruger din telefon som hotspot. Find dit hotspot-navn og adgangskode i Indstillinger > Personligt hotspot.';
 
   @override
   String get hotspotNameSsid => 'Hotspot-navn (SSID)';
@@ -4651,8 +4573,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Kunne ikke generere resumé. Sørg for, at du har samtaler for den dag.';
+  String get failedToGenerateSummaryCheckConversations => 'Kunne ikke generere resumé. Sørg for, at du har samtaler for den dag.';
 
   @override
   String get summaryNotFound => 'Resumé ikke fundet';
@@ -4682,8 +4603,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Eksport startet. Dette kan tage et par sekunder...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Dette vil slette alle afledte videngrafdata (noder og forbindelser). Dine originale minder forbliver sikre. Grafen vil blive genopbygget over tid eller ved næste anmodning.';
+  String get knowledgeGraphDeleteDescription => 'Dette vil slette alle afledte videngrafdata (noder og forbindelser). Dine originale minder forbliver sikre. Grafen vil blive genopbygget over tid eller ved næste anmodning.';
 
   @override
   String get configureDailySummaryDigest => 'Konfigurer dit daglige opgaveoversigt';
@@ -4753,8 +4673,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Slet alle Limitless samtaler?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Dette vil permanent slette alle samtaler importeret fra Limitless. Denne handling kan ikke fortrydes.';
+  String get deleteAllLimitlessWarning => 'Dette vil permanent slette alle samtaler importeret fra Limitless. Denne handling kan ikke fortrydes.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4810,8 +4729,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get howItWorksTitle => 'Hvordan virker det?';
 
   @override
-  String get howPeopleWorks =>
-      'Når en person er oprettet, kan du gå til en samtaleudskrift og tildele dem deres tilsvarende segmenter, på den måde vil Omi også kunne genkende deres tale!';
+  String get howPeopleWorks => 'Når en person er oprettet, kan du gå til en samtaleudskrift og tildele dem deres tilsvarende segmenter, på den måde vil Omi også kunne genkende deres tale!';
 
   @override
   String get tapToDelete => 'Tryk for at slette';
@@ -4837,8 +4755,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get privacyNotice => 'Fortrolighedsmeddelelse';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Optagelser kan optage andres stemmer. Sørg for at have samtykke fra alle deltagere, før du aktiverer.';
+  String get recordingsMayCaptureOthers => 'Optagelser kan optage andres stemmer. Sørg for at have samtykke fra alle deltagere, før du aktiverer.';
 
   @override
   String get enable => 'Aktiver';
@@ -4850,8 +4767,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get on => 'Til';
 
   @override
-  String get storeAudioDescription =>
-      'Behold alle lydoptagelser gemt lokalt på din telefon. Når deaktiveret, gemmes kun mislykkede uploads for at spare lagerplads.';
+  String get storeAudioDescription => 'Behold alle lydoptagelser gemt lokalt på din telefon. Når deaktiveret, gemmes kun mislykkede uploads for at spare lagerplads.';
 
   @override
   String get enableLocalStorage => 'Aktiver lokal lagring';
@@ -4872,8 +4788,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get cloudStorageDialogMessage => 'Dine optagelser i realtid gemmes i privat cloud-lagring, mens du taler.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Gem dine optagelser i realtid i privat cloud-lagring, mens du taler. Lyd optages og gemmes sikkert i realtid.';
+  String get storeAudioCloudDescription => 'Gem dine optagelser i realtid i privat cloud-lagring, mens du taler. Lyd optages og gemmes sikkert i realtid.';
 
   @override
   String get downloadingFirmware => 'Downloader firmware';
@@ -4926,8 +4841,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get payments => 'Betalinger';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Tilslut en betalingsmetode nedenfor for at begynde at modtage udbetalinger for dine apps.';
+  String get connectPaymentMethodInfo => 'Tilslut en betalingsmetode nedenfor for at begynde at modtage udbetalinger for dine apps.';
 
   @override
   String get selectedPaymentMethod => 'Valgt betalingsmetode';
@@ -4954,8 +4868,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get monthlyPayouts => 'Månedlige udbetalinger';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Modtag månedlige betalinger direkte til din konto, når du når \$10 i indtjening';
+  String get monthlyPayoutsDescription => 'Modtag månedlige betalinger direkte til din konto, når du når \$10 i indtjening';
 
   @override
   String get secureAndReliable => 'Sikker og pålidelig';
@@ -4982,8 +4895,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get connectingYourStripeAccount => 'Tilslutter din Stripe-konto';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Fuldfør venligst Stripe-onboarding-processen i din browser. Denne side opdateres automatisk, når den er fuldført.';
+  String get stripeOnboardingInstructions => 'Fuldfør venligst Stripe-onboarding-processen i din browser. Denne side opdateres automatisk, når den er fuldført.';
 
   @override
   String get failedTryAgain => 'Mislykkedes? Prøv igen';
@@ -4995,8 +4907,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get successfullyConnected => 'Succesfuldt forbundet!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Din Stripe-konto er nu klar til at modtage betalinger. Du kan begynde at tjene på dine app-salg med det samme.';
+  String get stripeReadyForPayments => 'Din Stripe-konto er nu klar til at modtage betalinger. Du kan begynde at tjene på dine app-salg med det samme.';
 
   @override
   String get updateStripeDetails => 'Opdater Stripe-detaljer';
@@ -5014,8 +4925,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Opdater dine PayPal-kontooplysninger';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Tilslut din PayPal-konto for at begynde at modtage betalinger for dine apps';
+  String get connectPayPalToReceivePayments => 'Tilslut din PayPal-konto for at begynde at modtage betalinger for dine apps';
 
   @override
   String get paypalEmail => 'PayPal e-mail';
@@ -5024,8 +4934,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me link';
 
   @override
-  String get stripeRecommendation =>
-      'Hvis Stripe er tilgængelig i dit land, anbefaler vi stærkt at bruge det til hurtigere og nemmere udbetalinger.';
+  String get stripeRecommendation => 'Hvis Stripe er tilgængelig i dit land, anbefaler vi stærkt at bruge det til hurtigere og nemmere udbetalinger.';
 
   @override
   String get updatePayPalDetails => 'Opdater PayPal-detaljer';
@@ -5077,8 +4986,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Yderligere stemmeprøve fjernet';
 
   @override
-  String get consentDataMessage =>
-      'Ved at fortsætte vil dine samtaler, optagelser og personlige oplysninger blive sikkert gemt på vores servere. Dine lydoptagelser og udskrifter behandles af tredjeparts AI-tjenester (herunder Deepgram til transskription og OpenAI til analyse) for at give dig AI-drevne indsigter og aktivere alle appfunktioner.';
+  String get consentDataMessage => 'Ved at fortsætte vil dine samtaler, optagelser og personlige oplysninger blive sikkert gemt på vores servere. Dine lydoptagelser og udskrifter behandles af tredjeparts AI-tjenester (herunder Deepgram til transskription og OpenAI til analyse) for at give dig AI-drevne indsigter og aktivere alle appfunktioner.';
 
   @override
   String get tasksEmptyStateMessage => 'Opgaver fra dine samtaler vises her.\nTryk på + for at oprette en manuelt.';
@@ -5117,15 +5025,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Installer Omi på dit\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'For at bruge dit Apple Watch med Omi skal du først installere Omi-appen på dit ur.';
+  String get installOmiOnAppleWatchDescription => 'For at bruge dit Apple Watch med Omi skal du først installere Omi-appen på dit ur.';
 
   @override
   String get openOmiOnAppleWatch => 'Åbn Omi på dit\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi-appen er installeret på dit Apple Watch. Åbn den og tryk på Start for at begynde.';
+  String get openOmiOnAppleWatchDescription => 'Omi-appen er installeret på dit Apple Watch. Åbn den og tryk på Start for at begynde.';
 
   @override
   String get openWatchApp => 'Åbn Watch-appen';
@@ -5134,15 +5040,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Jeg har installeret og åbnet appen';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Kunne ikke åbne Apple Watch-appen. Åbn manuelt Watch-appen på dit Apple Watch og installer Omi fra sektionen \"Tilgængelige apps\".';
+  String get unableToOpenWatchApp => 'Kunne ikke åbne Apple Watch-appen. Åbn manuelt Watch-appen på dit Apple Watch og installer Omi fra sektionen \"Tilgængelige apps\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch tilsluttet!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch er stadig ikke tilgængeligt. Sørg for, at Omi-appen er åben på dit ur.';
+  String get appleWatchNotReachable => 'Apple Watch er stadig ikke tilgængeligt. Sørg for, at Omi-appen er åben på dit ur.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5570,8 +5474,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get multipleSpeakersDetected => 'Flere talere registreret';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Det ser ud til, at der er flere talere i optagelsen. Sørg for, at du er et roligt sted, og prøv igen.';
+  String get multipleSpeakersDescription => 'Det ser ud til, at der er flere talere i optagelsen. Sørg for, at du er et roligt sted, og prøv igen.';
 
   @override
   String get invalidRecordingDetected => 'Ugyldig optagelse registreret';
@@ -5589,8 +5492,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get howToTakeGoodSample => 'Hvordan tager man en god prøve?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Sørg for, at du er et roligt sted.\n2. Tal tydeligt og naturligt.\n3. Sørg for, at din enhed er i sin naturlige position på din hals.\n\nNår den er oprettet, kan du altid forbedre den eller gøre det igen.';
+  String get goodSampleInstructions => '1. Sørg for, at du er et roligt sted.\n2. Tal tydeligt og naturligt.\n3. Sørg for, at din enhed er i sin naturlige position på din hals.\n\nNår den er oprettet, kan du altid forbedre den eller gøre det igen.';
 
   @override
   String get noDeviceConnectedUseMic => 'Ingen enhed tilsluttet. Telefonens mikrofon bruges.';
@@ -5653,12 +5555,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get howItWorks => 'Sådan fungerer det';
 
   @override
-  String get dailyScoreExplanation =>
-      'Din daglige score er baseret på opgavefuldførelse. Fuldfør dine opgaver for at forbedre din score!';
+  String get dailyScoreExplanation => 'Din daglige score er baseret på opgavefuldførelse. Fuldfør dine opgaver for at forbedre din score!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontroller hvor ofte Omi sender dig proaktive notifikationer og påmindelser.';
+  String get notificationFrequencyDescription => 'Kontroller hvor ofte Omi sender dig proaktive notifikationer og påmindelser.';
 
   @override
   String get sliderOff => 'Fra';
@@ -5903,8 +5803,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get recordings => 'Optagelser';
 
   @override
-  String get enableRemindersAccess =>
-      'Aktivér venligst påmindelsesadgang i Indstillinger for at bruge Apple Påmindelser';
+  String get enableRemindersAccess => 'Aktivér venligst påmindelsesadgang i Indstillinger for at bruge Apple Påmindelser';
 
   @override
   String todayAtTime(String time) {
@@ -5959,8 +5858,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL ikke angivet';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Angiv venligst webhook URL i udviklerindstillinger for at bruge denne funktion.';
+  String get setWebhookUrlInSettings => 'Angiv venligst webhook URL i udviklerindstillinger for at bruge denne funktion.';
 
   @override
   String get sendWebUrl => 'Send web URL';
@@ -6034,8 +5932,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get cloudProvider => 'Cloud-udbyder';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 premium minutter/måned. Lokal-fanen tilbyder ubegrænset gratis transskription.';
+  String get premiumMinutesInfo => '1.200 premium minutter/måned. Lokal-fanen tilbyder ubegrænset gratis transskription.';
 
   @override
   String get viewUsage => 'Se forbrug';
@@ -6050,15 +5947,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get performanceWarning => 'Ydelsesadvarsel';
 
   @override
-  String get largeModelWarning =>
-      'Denne model er stor og kan få appen til at gå ned eller køre meget langsomt på mobile enheder.\n\n\"small\" eller \"base\" anbefales.';
+  String get largeModelWarning => 'Denne model er stor og kan få appen til at gå ned eller køre meget langsomt på mobile enheder.\n\n\"small\" eller \"base\" anbefales.';
 
   @override
   String get usingNativeIosSpeech => 'Bruger indbygget iOS-talegenkendelse';
 
   @override
-  String get noModelDownloadRequired =>
-      'Din enheds indbyggede talegenkendelse vil blive brugt. Ingen model-download påkrævet.';
+  String get noModelDownloadRequired => 'Din enheds indbyggede talegenkendelse vil blive brugt. Ingen model-download påkrævet.';
 
   @override
   String get modelReady => 'Model klar';
@@ -6115,8 +6010,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get batteryDrainSignificantly => 'Batteriforbrug vil øges betydeligt.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 premium minutter/måned. Fanen På enheden tilbyder ubegrænset gratis transskription. ';
+  String get premiumMinutesMonth => '1.200 premium minutter/måned. Fanen På enheden tilbyder ubegrænset gratis transskription. ';
 
   @override
   String get audioProcessedLocally => 'Lyd behandles lokalt. Fungerer offline, mere privat, men bruger mere batteri.';
@@ -6128,12 +6022,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Denne model er stor og kan få appen til at gå ned eller køre meget langsomt på mobile enheder.\n\nsmall eller base anbefales.';
+  String get modelTooLargeWarning => 'Denne model er stor og kan få appen til at gå ned eller køre meget langsomt på mobile enheder.\n\nsmall eller base anbefales.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Din enheds indbyggede talemotor vil blive brugt. Ingen model-download påkrævet.';
+  String get nativeEngineNoDownload => 'Din enheds indbyggede talemotor vil blive brugt. Ingen model-download påkrævet.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6169,8 +6061,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omis indbyggede live-transskription er optimeret til samtaler i realtid med automatisk talerdetektering og diarization.';
+  String get omiTranscriptionOptimized => 'Omis indbyggede live-transskription er optimeret til samtaler i realtid med automatisk talerdetektering og diarization.';
 
   @override
   String get reset => 'Nulstil';
@@ -6390,8 +6281,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Opbygger vidensgraf fra minder...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Din vidensgraf vil blive opbygget automatisk, når du opretter nye minder.';
+  String get knowledgeGraphWillBuildAutomatically => 'Din vidensgraf vil blive opbygget automatisk, når du opretter nye minder.';
 
   @override
   String get buildGraphButton => 'Opbyg graf';
@@ -6773,8 +6663,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get enableFastTransfer => 'Aktiver hurtig overførsel';
 
   @override
-  String get fastTransferDescription =>
-      'Hurtig overførsel bruger WiFi for ~5x hurtigere hastigheder. Din telefon vil midlertidigt forbinde til din Omi-enheds WiFi-netværk under overførsel.';
+  String get fastTransferDescription => 'Hurtig overførsel bruger WiFi for ~5x hurtigere hastigheder. Din telefon vil midlertidigt forbinde til din Omi-enheds WiFi-netværk under overførsel.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Internetadgang er sat på pause under overførsel';
@@ -6789,8 +6678,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fiveTimesFaster => '5X HURTIGERE';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Opretter en direkte WiFi-forbindelse til din Omi-enhed. Din telefon afbrydes midlertidigt fra dit normale WiFi under overførsel.';
+  String get fastTransferMethodDescription => 'Opretter en direkte WiFi-forbindelse til din Omi-enhed. Din telefon afbrydes midlertidigt fra dit normale WiFi under overførsel.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6799,8 +6687,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get bleSpeed => 'BLE-hastighed';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Bruger standard Bluetooth Low Energy forbindelse. Langsommere men påvirker ikke din WiFi-forbindelse.';
+  String get bluetoothMethodDescription => 'Bruger standard Bluetooth Low Energy forbindelse. Langsommere men påvirker ikke din WiFi-forbindelse.';
 
   @override
   String get selected => 'Valgt';
@@ -6838,12 +6725,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get appDeleteFailed => 'Kunne ikke slette app. Prøv venligst igen senere.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'App-synlighed ændret med succes. Det kan tage et par minutter at træde i kraft.';
+  String get appVisibilityChangedSuccessfully => 'App-synlighed ændret med succes. Det kan tage et par minutter at træde i kraft.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Fejl ved aktivering af app. Hvis det er en integrationsapp, skal du sikre dig, at opsætningen er fuldført.';
+  String get errorActivatingAppIntegration => 'Fejl ved aktivering af app. Hvis det er en integrationsapp, skal du sikre dig, at opsætningen er fuldført.';
 
   @override
   String get errorUpdatingAppStatus => 'Der opstod en fejl under opdatering af app-status.';
@@ -7110,15 +6995,13 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Din planopgradering er planlagt og træder i kraft ved udgangen af din nuværende faktureringsperiode.';
+  String get planUpgradeScheduledMessage => 'Din planopgradering er planlagt og træder i kraft ved udgangen af din nuværende faktureringsperiode.';
 
   @override
   String get couldNotSchedulePlanChange => 'Kunne ikke planlægge abonnementsændring. Prøv venligst igen.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Dit abonnement er blevet genaktiveret! Ingen opkrævning nu - du faktureres ved udgangen af din nuværende periode.';
+  String get subscriptionReactivatedDefault => 'Dit abonnement er blevet genaktiveret! Ingen opkrævning nu - du faktureres ved udgangen af din nuværende periode.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Abonnement opkrævet! Tak for din støtte.';
@@ -7298,12 +7181,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get authFailedToLinkApple => 'Kunne ikke forbinde med Apple, prøv venligst igen.';
 
   @override
-  String get onboardingBluetoothRequired =>
-      'Bluetooth-tilladelse er påkrævet for at oprette forbindelse til din enhed.';
+  String get onboardingBluetoothRequired => 'Bluetooth-tilladelse er påkrævet for at oprette forbindelse til din enhed.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth-tilladelse afvist. Giv venligst tilladelse i Systemindstillinger.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth-tilladelse afvist. Giv venligst tilladelse i Systemindstillinger.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7316,12 +7197,10 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Notifikationstilladelse afvist. Giv venligst tilladelse i Systemindstillinger.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Notifikationstilladelse afvist. Giv venligst tilladelse i Systemindstillinger.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Notifikationstilladelse afvist. Giv venligst tilladelse i Systemindstillinger > Notifikationer.';
+  String get onboardingNotificationDeniedNotifications => 'Notifikationstilladelse afvist. Giv venligst tilladelse i Systemindstillinger > Notifikationer.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7334,15 +7213,13 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Giv venligst placeringstilladelse i Indstillinger > Privatliv og sikkerhed > Placeringstjenester';
+  String get onboardingLocationGrantInSettings => 'Giv venligst placeringstilladelse i Indstillinger > Privatliv og sikkerhed > Placeringstjenester';
 
   @override
   String get onboardingMicrophoneRequired => 'Mikrofontilladelse er påkrævet for optagelse.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofontilladelse afvist. Giv venligst tilladelse i Systemindstillinger > Privatliv og sikkerhed > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Mikrofontilladelse afvist. Giv venligst tilladelse i Systemindstillinger > Privatliv og sikkerhed > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7358,8 +7235,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Skærmoptagelsestilladelse er påkrævet for systemlydoptagelse.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Skærmoptagelsestilladelse afvist. Giv venligst tilladelse i Systemindstillinger > Privatliv og sikkerhed > Skærmoptagelse.';
+  String get onboardingScreenCaptureDenied => 'Skærmoptagelsestilladelse afvist. Giv venligst tilladelse i Systemindstillinger > Privatliv og sikkerhed > Skærmoptagelse.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7412,8 +7288,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Fototilladelse nægtet. Tillad venligst adgang til fotos for at vælge billeder';
+  String get msgPhotosPermissionDenied => 'Fototilladelse nægtet. Tillad venligst adgang til fotos for at vælge billeder';
 
   @override
   String get msgSelectImagesGenericError => 'Fejl ved valg af billeder. Prøv venligst igen.';
@@ -7485,8 +7360,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get locationPermissionRequired => 'Placeringstilladelse påkrævet';
 
   @override
-  String get locationPermissionContent =>
-      'Hurtig overførsel kræver placeringstilladelse for at bekræfte WiFi-forbindelse. Giv venligst placeringstilladelse for at fortsætte.';
+  String get locationPermissionContent => 'Hurtig overførsel kræver placeringstilladelse for at bekræfte WiFi-forbindelse. Giv venligst placeringstilladelse for at fortsætte.';
 
   @override
   String get pdfTranscriptExport => 'Eksport af transskription';
@@ -7649,8 +7523,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Enheden understøtter ikke WiFi-synkronisering, skifter til Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Enheden understøtter ikke WiFi-synkronisering, skifter til Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health er ikke tilgængelig på denne enhed';
@@ -7958,8 +7831,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Sæt Plaud Note i parringstilstand';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Tryk og hold sideknappen i 2 sekunder. Den røde LED blinker, når den er klar til parring.';
+  String get pairingDescPlaudNote => 'Tryk og hold sideknappen i 2 sekunder. Den røde LED blinker, når den er klar til parring.';
 
   @override
   String get pairingTitleBee => 'Sæt Bee i parringstilstand';
@@ -7971,15 +7843,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get pairingTitleLimitless => 'Sæt Limitless i parringstilstand';
 
   @override
-  String get pairingDescLimitless =>
-      'Når et lys er synligt, tryk én gang og tryk derefter og hold, indtil enheden viser et pink lys, slip derefter.';
+  String get pairingDescLimitless => 'Når et lys er synligt, tryk én gang og tryk derefter og hold, indtil enheden viser et pink lys, slip derefter.';
 
   @override
   String get pairingTitleFriendPendant => 'Sæt Friend Pendant i parringstilstand';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Tryk på knappen på vedhænget for at tænde det. Det går automatisk i parringstilstand.';
+  String get pairingDescFriendPendant => 'Tryk på knappen på vedhænget for at tænde det. Det går automatisk i parringstilstand.';
 
   @override
   String get pairingTitleFieldy => 'Sæt Fieldy i parringstilstand';
@@ -7991,8 +7861,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Tilslut Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Installer og åbn Omi-appen på dit Apple Watch, tryk derefter på Tilslut i appen.';
+  String get pairingDescAppleWatch => 'Installer og åbn Omi-appen på dit Apple Watch, tryk derefter på Tilslut i appen.';
 
   @override
   String get pairingTitleNeoOne => 'Sæt Neo One i parringstilstand';
@@ -8086,8 +7955,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Her er hvad jeg ved om dig';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Dette kort opdateres, efterhånden som Omi lærer fra dine samtaler.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Dette kort opdateres, efterhånden som Omi lærer fra dine samtaler.';
 
   @override
   String get apiEnvironment => 'API-miljø';
@@ -8116,8 +7984,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get switchAndRestart => 'Skift';
 
   @override
-  String get stagingDisclaimer =>
-      'Testmiljøet kan være ustabilt, have inkonsistent ydeevne, og data kan gå tabt. Kun til test.';
+  String get stagingDisclaimer => 'Testmiljøet kan være ustabilt, have inkonsistent ydeevne, og data kan gå tabt. Kun til test.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Gemt. Luk og genåbn appen for at anvende ændringerne.';
@@ -8346,8 +8213,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonopkald via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Foretag opkald via Omi og få transskription i realtid, automatiske resuméer og mere.';
+  String get phoneCallsUpsellSubtitle => 'Foretag opkald via Omi og få transskription i realtid, automatiske resuméer og mere.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transskription i realtid af hvert opkald';
@@ -8374,8 +8240,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteSyncedFiles => 'Slet synkroniserede optagelser';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Disse optagelser er allerede synkroniseret med din telefon. Dette kan ikke fortrydes.';
+  String get deleteSyncedFilesMessage => 'Disse optagelser er allerede synkroniseret med din telefon. Dette kan ikke fortrydes.';
 
   @override
   String get syncedFilesDeleted => 'Synkroniserede optagelser slettet';
@@ -8387,8 +8252,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deletePendingFiles => 'Slet ventende optagelser';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Disse optagelser er IKKE synkroniseret med din telefon og vil gå permanent tabt. Dette kan ikke fortrydes.';
+  String get deletePendingFilesWarning => 'Disse optagelser er IKKE synkroniseret med din telefon og vil gå permanent tabt. Dette kan ikke fortrydes.';
 
   @override
   String get pendingFilesDeleted => 'Ventende optagelser slettet';
@@ -8400,8 +8264,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deleteAll => 'Slet alle';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Dette sletter synkroniserede og ventende optagelser. Ventende optagelser er IKKE synkroniseret og vil gå permanent tabt.';
+  String get deleteAllFilesWarning => 'Dette sletter synkroniserede og ventende optagelser. Ventende optagelser er IKKE synkroniseret og vil gå permanent tabt.';
 
   @override
   String get allFilesDeleted => 'Alle optagelser slettet';
@@ -8466,8 +8329,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fairUseAboutTitle => 'Om rimelig brug';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi er designet til personlige samtaler, møder og live-interaktioner. Forbruget måles ved den faktiske registrerede taletid, ikke forbindelsestid. Hvis forbruget væsentligt overstiger normale mønstre for ikke-personligt indhold, kan der foretages justeringer.';
+  String get fairUseAboutBody => 'Omi er designet til personlige samtaler, møder og live-interaktioner. Forbruget måles ved den faktiske registrerede taletid, ikke forbindelsestid. Hvis forbruget væsentligt overstiger normale mønstre for ikke-personligt indhold, kan der foretages justeringer.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8505,8 +8367,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get improveConnectionTitle => 'Forbedre forbindelsen';
 
   @override
-  String get improveConnectionContent =>
-      'Vi har forbedret, hvordan Omi forbliver forbundet til din enhed. For at aktivere dette, gå til enhedsinfosiden, tryk på \"Afbryd enhed\", og tilslut din enhed igen.';
+  String get improveConnectionContent => 'Vi har forbedret, hvordan Omi forbliver forbundet til din enhed. For at aktivere dette, gå til enhedsinfosiden, tryk på \"Afbryd enhed\", og tilslut din enhed igen.';
 
   @override
   String get improveConnectionAction => 'Forstået';
@@ -8561,16 +8422,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get cancelSyncQuestion => 'Annuller synkronisering?';
 
   @override
-  String get omisStorageDesc =>
-      'Når din Omi ikke er forbundet til din telefon, gemmer den lyd lokalt i sin indbyggede hukommelse. Du mister aldrig en optagelse.';
+  String get omisStorageDesc => 'Når din Omi ikke er forbundet til din telefon, gemmer den lyd lokalt i sin indbyggede hukommelse. Du mister aldrig en optagelse.';
 
   @override
-  String get phoneStorageDesc =>
-      'Når Omi genopretter forbindelsen, overføres optagelser automatisk til din telefon som midlertidig opbevaring før upload.';
+  String get phoneStorageDesc => 'Når Omi genopretter forbindelsen, overføres optagelser automatisk til din telefon som midlertidig opbevaring før upload.';
 
   @override
-  String get cloudStorageDesc =>
-      'Når de er uploadet, behandles og transskriberes dine optagelser. Samtaler vil være tilgængelige inden for et minut.';
+  String get cloudStorageDesc => 'Når de er uploadet, behandles og transskriberes dine optagelser. Samtaler vil være tilgængelige inden for et minut.';
 
   @override
   String get tipKeepPhoneNearby => 'Hold din telefon i nærheden for hurtigere synkronisering';
@@ -8594,12 +8452,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get permissionEnable => 'Aktivér';
 
   @override
-  String get permissionsPageDescription =>
-      'Disse tilladelser er centrale for Omis funktion. De aktiverer nøglefunktioner som notifikationer, placeringsbaserede oplevelser og lydoptagelse.';
+  String get permissionsPageDescription => 'Disse tilladelser er centrale for Omis funktion. De aktiverer nøglefunktioner som notifikationer, placeringsbaserede oplevelser og lydoptagelse.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi har brug for nogle tilladelser for at fungere korrekt. Giv dem venligst for at fortsætte.';
+  String get permissionsRequiredDescription => 'Omi har brug for nogle tilladelser for at fungere korrekt. Giv dem venligst for at fortsætte.';
 
   @override
   String get permissionsSetupTitle => 'Få den bedste oplevelse';
@@ -8653,8 +8509,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get justAMoment => 'Et øjeblik, tak';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Vi anbefaler stærkt at udforske dine andre muligheder i stedet for at annullere.';
+  String get cancelConsequencesSubtitle => 'Vi anbefaler stærkt at udforske dine andre muligheder i stedet for at annullere.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8665,8 +8520,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ifYouCancel => 'Hvis du annullerer:';
 
   @override
-  String get cancelConsequenceNoAccess =>
-      'Du vil ikke længere have ubegrænset adgang ved slutningen af din faktureringsperiode.';
+  String get cancelConsequenceNoAccess => 'Du vil ikke længere have ubegrænset adgang ved slutningen af din faktureringsperiode.';
 
   @override
   String get cancelConsequenceBattery => '7x mere batteriforbrug (behandling på enheden)';
@@ -8857,8 +8711,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get enableLocationTitle => 'Aktivér placering';
 
   @override
-  String get enableLocationDescription =>
-      'Placeringstilladelse er nødvendig for at finde Bluetooth-enheder i nærheden.';
+  String get enableLocationDescription => 'Placeringstilladelse er nødvendig for at finde Bluetooth-enheder i nærheden.';
 
   @override
   String get voiceRecordingFound => 'Optagelse fundet';
@@ -8879,8 +8732,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get firmwareWarningTitle => 'Vigtigt: Læs inden opdatering';
 
   @override
-  String get firmwareFormatWarning =>
-      'Denne firmware vil formatere SD-kortet. Sørg venligst for, at alle offline-data er synkroniseret inden opgradering.\n\nHvis du ser et blinkende rødt lys efter installation af denne version, skal du ikke bekymre dig. Tilslut blot enheden til appen, og den skulle blive blå. Det røde lys betyder, at enhedens ur endnu ikke er synkroniseret.';
+  String get firmwareFormatWarning => 'Denne firmware vil formatere SD-kortet. Sørg venligst for, at alle offline-data er synkroniseret inden opgradering.\n\nHvis du ser et blinkende rødt lys efter installation af denne version, skal du ikke bekymre dig. Tilslut blot enheden til appen, og den skulle blive blå. Det røde lys betyder, at enhedens ur endnu ikke er synkroniseret.';
 
   @override
   String get continueAnyway => 'Fortsæt';
@@ -8900,8 +8752,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get tasksMarkComplete => 'Markeret som fuldført';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi tilgår Apple Health via Apples HealthKit-framework. Du kan til enhver tid tilbagekalde adgangen i iOS-indstillingerne.';
+  String get appleHealthManageNote => 'Omi tilgår Apple Health via Apples HealthKit-framework. Du kan til enhver tid tilbagekalde adgangen i iOS-indstillingerne.';
 
   @override
   String get appleHealthConnectCta => 'Forbind til Apple Health';
@@ -8934,8 +8785,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Adgang til Apple Health nægtet';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi har ikke tilladelse til at læse dine Apple Health-data. Aktivér det i iOS-indstillinger → Anonymitet og sikkerhed → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi har ikke tilladelse til at læse dine Apple Health-data. Aktivér det i iOS-indstillinger → Anonymitet og sikkerhed → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Hvorfor forlader du os?';
@@ -9004,8 +8854,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get planUpdate => 'Planopdatering';
 
   @override
-  String get planDeprecationMessage =>
-      'Dit Unlimited-abonnement bliver udfaset. Skift til Operator-abonnementet — samme fantastiske funktioner til \$49/md. Dit nuværende abonnement vil fortsætte med at fungere i mellemtiden.';
+  String get planDeprecationMessage => 'Dit Unlimited-abonnement bliver udfaset. Skift til Operator-abonnementet — samme fantastiske funktioner til \$49/md. Dit nuværende abonnement vil fortsætte med at fungere i mellemtiden.';
 
   @override
   String get upgradeYourPlan => 'Opgrader din plan';
@@ -9116,8 +8965,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Du har nået din månedlige grænse. Opgrader for at fortsætte med at chatte med Omi uden begrænsninger.';
+  String get chatQuotaExceededReply => 'Du har nået din månedlige grænse. Opgrader for at fortsætte med at chatte med Omi uden begrænsninger.';
 
   @override
   String get voiceResponseAudio => 'Læs Omis svar højt';
@@ -9148,4 +8996,25 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Tilføj opgave';
+
+  @override
+  String get quickActionAskOmiAnything => 'Spørg Omi om hvad som helst';
+
+  @override
+  String get quickActionVoiceMode => 'Stemmétilstand';
+
+  @override
+  String get quickActionMute => 'Slå lyd fra';
+
+  @override
+  String get quickActionUnmute => 'Slå lyd til';
+
+  @override
+  String get quickActionConnectDevice => 'Tilslut enhed';
+
+  @override
+  String get quickActionDeviceSettings => 'Enhedsindstillinger';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -24,8 +24,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteConversationTitle => 'Unterhaltung löschen?';
 
   @override
-  String get deleteConversationMessage =>
-      'Dadurch werden auch zugehörige Erinnerungen, Aufgaben und Audiodateien gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get deleteConversationMessage => 'Dadurch werden auch zugehörige Erinnerungen, Aufgaben und Audiodateien gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get confirm => 'Bestätigen';
@@ -82,8 +81,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get conversationUrlNotShared => 'Unterhaltungs-URL konnte nicht geteilt werden.';
 
   @override
-  String get errorProcessingConversation =>
-      'Fehler beim Verarbeiten der Unterhaltung. Bitte versuchen Sie es später erneut.';
+  String get errorProcessingConversation => 'Fehler beim Verarbeiten der Unterhaltung. Bitte versuchen Sie es später erneut.';
 
   @override
   String get noInternetConnection => 'Keine Internetverbindung';
@@ -124,8 +122,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get editPerson => 'Person bearbeiten';
 
   @override
-  String get createPersonHint =>
-      'Erstellen Sie eine neue Person und trainieren Sie Omi, deren Stimme ebenfalls zu erkennen!';
+  String get createPersonHint => 'Erstellen Sie eine neue Person und trainieren Sie Omi, deren Stimme ebenfalls zu erkennen!';
 
   @override
   String get speechProfile => 'Sprachprofil';
@@ -148,8 +145,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleting => 'Löschen...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Bitte schließen Sie die Authentifizierung in Ihrem Browser ab. Kehren Sie danach zur App zurück.';
+  String get pleaseCompleteAuthentication => 'Bitte schließen Sie die Authentifizierung in Ihrem Browser ab. Kehren Sie danach zur App zurück.';
 
   @override
   String get failedToStartAuthentication => 'Authentifizierung konnte nicht gestartet werden';
@@ -230,8 +226,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noStarredConversations => 'Keine markierten Gespräche';
 
   @override
-  String get starConversationHint =>
-      'Um eine Unterhaltung zu favorisieren, öffnen Sie sie und tippen Sie auf das Sternsymbol im Kopfbereich.';
+  String get starConversationHint => 'Um eine Unterhaltung zu favorisieren, öffnen Sie sie und tippen Sie auf das Sternsymbol im Kopfbereich.';
 
   @override
   String get searchConversations => 'Konversationen durchsuchen...';
@@ -289,8 +284,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get clearChat => 'Chat löschen';
 
   @override
-  String get clearChatConfirm =>
-      'Sind Sie sicher, dass Sie den Chat löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get clearChatConfirm => 'Sind Sie sicher, dass Sie den Chat löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get maxFilesLimit => 'Sie können nur 4 Dateien gleichzeitig hochladen';
@@ -323,8 +317,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get installedApps => 'Installierte Apps';
 
   @override
-  String get unableToFetchApps =>
-      'Apps konnten nicht geladen werden :(\n\nBitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
+  String get unableToFetchApps => 'Apps konnten nicht geladen werden :(\n\nBitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
 
   @override
   String get aboutOmi => 'Über Omi';
@@ -360,19 +353,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appsDisconnected => 'Ihre Apps und Integrationen werden sofort getrennt.';
 
   @override
-  String get exportBeforeDelete =>
-      'Sie können Ihre Daten exportieren, bevor Sie Ihr Konto löschen. Einmal gelöscht, können sie nicht wiederhergestellt werden.';
+  String get exportBeforeDelete => 'Sie können Ihre Daten exportieren, bevor Sie Ihr Konto löschen. Einmal gelöscht, können sie nicht wiederhergestellt werden.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Ich verstehe, dass das Löschen meines Kontos dauerhaft ist und alle Daten, einschließlich Erinnerungen und Unterhaltungen, verloren gehen und nicht wiederhergestellt werden können.';
+  String get deleteAccountCheckbox => 'Ich verstehe, dass das Löschen meines Kontos dauerhaft ist und alle Daten, einschließlich Erinnerungen und Unterhaltungen, verloren gehen und nicht wiederhergestellt werden können.';
 
   @override
   String get areYouSure => 'Sind Sie sicher?';
 
   @override
-  String get deleteAccountFinal =>
-      'Diese Aktion ist unwiderruflich und wird Ihr Konto und alle zugehörigen Daten dauerhaft löschen. Sind Sie sicher, dass Sie fortfahren möchten?';
+  String get deleteAccountFinal => 'Diese Aktion ist unwiderruflich und wird Ihr Konto und alle zugehörigen Daten dauerhaft löschen. Sind Sie sicher, dass Sie fortfahren möchten?';
 
   @override
   String get deleteNow => 'Jetzt löschen';
@@ -381,8 +371,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get goBack => 'Zurück';
 
   @override
-  String get checkBoxToConfirm =>
-      'Aktivieren Sie das Kontrollkästchen, um zu bestätigen, dass Sie verstehen, dass das Löschen Ihres Kontos dauerhaft und unwiderruflich ist.';
+  String get checkBoxToConfirm => 'Aktivieren Sie das Kontrollkästchen, um zu bestätigen, dass Sie verstehen, dass das Löschen Ihres Kontos dauerhaft und unwiderruflich ist.';
 
   @override
   String get profile => 'Profil';
@@ -460,8 +449,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get yourPrivacyYourControl => 'Ihre Privatsphäre, Ihre Kontrolle';
 
   @override
-  String get privacyIntro =>
-      'Bei Omi verpflichten wir uns, Ihre Privatsphäre zu schützen. Auf dieser Seite können Sie steuern, wie Ihre Daten gespeichert und verwendet werden.';
+  String get privacyIntro => 'Bei Omi verpflichten wir uns, Ihre Privatsphäre zu schützen. Auf dieser Seite können Sie steuern, wie Ihre Daten gespeichert und verwendet werden.';
 
   @override
   String get learnMore => 'Mehr erfahren...';
@@ -470,15 +458,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dataProtectionLevel => 'Datenschutzniveau';
 
   @override
-  String get dataProtectionDesc =>
-      'Ihre Daten sind standardmäßig durch starke Verschlüsselung gesichert. Überprüfen Sie unten Ihre Einstellungen und zukünftigen Datenschutzoptionen.';
+  String get dataProtectionDesc => 'Ihre Daten sind standardmäßig durch starke Verschlüsselung gesichert. Überprüfen Sie unten Ihre Einstellungen und zukünftigen Datenschutzoptionen.';
 
   @override
   String get appAccess => 'App-Zugriff';
 
   @override
-  String get appAccessDesc =>
-      'Die folgenden Apps können auf Ihre Daten zugreifen. Tippen Sie auf eine App, um deren Berechtigungen zu verwalten.';
+  String get appAccessDesc => 'Die folgenden Apps können auf Ihre Daten zugreifen. Tippen Sie auf eine App, um deren Berechtigungen zu verwalten.';
 
   @override
   String get noAppsExternalAccess => 'Keine installierten Apps haben externen Zugriff auf Ihre Daten.';
@@ -535,22 +521,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Ihr Omi wurde getrennt 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Gerät entkoppelt. Gehen Sie zu Einstellungen > Bluetooth und vergessen Sie das Gerät, um die Entkopplung abzuschließen.';
+  String get deviceUnpairedMessage => 'Gerät entkoppelt. Gehen Sie zu Einstellungen > Bluetooth und vergessen Sie das Gerät, um die Entkopplung abzuschließen.';
 
   @override
   String get unpairDialogTitle => 'Gerät entkoppeln';
 
   @override
-  String get unpairDialogMessage =>
-      'Dies entkoppelt das Gerät, damit es mit einem anderen Telefon verbunden werden kann. Sie müssen zu Einstellungen > Bluetooth gehen und das Gerät vergessen, um den Vorgang abzuschließen.';
+  String get unpairDialogMessage => 'Dies entkoppelt das Gerät, damit es mit einem anderen Telefon verbunden werden kann. Sie müssen zu Einstellungen > Bluetooth gehen und das Gerät vergessen, um den Vorgang abzuschließen.';
 
   @override
   String get deviceNotConnected => 'Gerät nicht verbunden';
 
   @override
-  String get connectDeviceMessage =>
-      'Verbinden Sie Ihr Omi-Gerät, um auf Geräteeinstellungen und Anpassungen zuzugreifen';
+  String get connectDeviceMessage => 'Verbinden Sie Ihr Omi-Gerät, um auf Geräteeinstellungen und Anpassungen zuzugreifen';
 
   @override
   String get deviceInfoSection => 'Geräteinformationen';
@@ -565,8 +548,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get v2Undetected => 'V2 nicht erkannt';
 
   @override
-  String get v2UndetectedMessage =>
-      'Wir sehen, dass Sie entweder ein V1-Gerät haben oder Ihr Gerät nicht verbunden ist. Die SD-Karten-Funktionalität ist nur für V2-Geräte verfügbar.';
+  String get v2UndetectedMessage => 'Wir sehen, dass Sie entweder ein V1-Gerät haben oder Ihr Gerät nicht verbunden ist. Die SD-Karten-Funktionalität ist nur für V2-Geräte verfügbar.';
 
   @override
   String get endConversation => 'Unterhaltung beenden';
@@ -698,8 +680,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noActivityYet => 'Noch keine Aktivität';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Starten Sie eine Unterhaltung mit Omi,\num hier Ihre Nutzungserkenntnisse zu sehen.';
+  String get startConversationToSeeInsights => 'Starten Sie eine Unterhaltung mit Omi,\num hier Ihre Nutzungserkenntnisse zu sehen.';
 
   @override
   String get listening => 'Zuhören';
@@ -841,8 +822,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Wissensgraph löschen?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Dies löscht alle abgeleiteten Daten des Wissensgraphen (Knoten und Verbindungen). Ihre ursprünglichen Erinnerungen bleiben sicher. Der Graph wird mit der Zeit oder bei der nächsten Anfrage neu erstellt.';
+  String get deleteKnowledgeGraphMessage => 'Dies löscht alle abgeleiteten Daten des Wissensgraphen (Knoten und Verbindungen). Ihre ursprünglichen Erinnerungen bleiben sicher. Der Graph wird mit der Zeit oder bei der nächsten Anfrage neu erstellt.';
 
   @override
   String get knowledgeGraphDeleted => 'Wissensgraph gelöscht';
@@ -990,8 +970,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shortConversationThreshold => 'Schwellenwert für kurze Unterhaltungen';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Unterhaltungen, die kürzer als dies sind, werden ausgeblendet, sofern oben nicht aktiviert';
+  String get shortConversationThresholdSubtitle => 'Unterhaltungen, die kürzer als dies sind, werden ausgeblendet, sofern oben nicht aktiviert';
 
   @override
   String get durationThreshold => 'Dauerschwellenwert';
@@ -1026,8 +1005,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get integrationsFooter => 'Verbinden Sie Ihre Apps, um Daten und Metriken im Chat anzuzeigen.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Bitte schließen Sie die Authentifizierung in Ihrem Browser ab. Kehren Sie danach zur App zurück.';
+  String get completeAuthInBrowser => 'Bitte schließen Sie die Authentifizierung in Ihrem Browser ab. Kehren Sie danach zur App zurück.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1087,37 +1065,31 @@ class AppLocalizationsDe extends AppLocalizations {
   String get needYourPermission => 'Wir benötigen Ihre Erlaubnis';
 
   @override
-  String get alreadyGavePermission =>
-      'Sie haben uns bereits die Erlaubnis gegeben, Ihre Aufnahmen zu speichern. Hier ist eine Erinnerung, warum wir sie brauchen:';
+  String get alreadyGavePermission => 'Sie haben uns bereits die Erlaubnis gegeben, Ihre Aufnahmen zu speichern. Hier ist eine Erinnerung, warum wir sie brauchen:';
 
   @override
-  String get wouldLikePermission =>
-      'Wir möchten Ihre Erlaubnis, Ihre Sprachaufnahmen zu speichern. Hier ist der Grund:';
+  String get wouldLikePermission => 'Wir möchten Ihre Erlaubnis, Ihre Sprachaufnahmen zu speichern. Hier ist der Grund:';
 
   @override
   String get improveSpeechProfile => 'Ihr Sprachprofil verbessern';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Wir verwenden Aufnahmen, um Ihr persönliches Sprachprofil weiter zu trainieren und zu verbessern.';
+  String get improveSpeechProfileDesc => 'Wir verwenden Aufnahmen, um Ihr persönliches Sprachprofil weiter zu trainieren und zu verbessern.';
 
   @override
   String get trainFamilyProfiles => 'Profile für Freunde und Familie trainieren';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Ihre Aufnahmen helfen uns, Profile für Ihre Freunde und Familie zu erkennen und zu erstellen.';
+  String get trainFamilyProfilesDesc => 'Ihre Aufnahmen helfen uns, Profile für Ihre Freunde und Familie zu erkennen und zu erstellen.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Transkriptionsgenauigkeit verbessern';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Wenn unser Modell besser wird, können wir bessere Transkriptionsergebnisse für Ihre Aufnahmen liefern.';
+  String get enhanceTranscriptAccuracyDesc => 'Wenn unser Modell besser wird, können wir bessere Transkriptionsergebnisse für Ihre Aufnahmen liefern.';
 
   @override
-  String get legalNotice =>
-      'Rechtlicher Hinweis: Die Rechtmäßigkeit der Aufnahme und Speicherung von Sprachdaten kann je nach Ihrem Standort und der Art und Weise, wie Sie diese Funktion nutzen, variieren. Es liegt in Ihrer Verantwortung, die Einhaltung der örtlichen Gesetze und Vorschriften sicherzustellen.';
+  String get legalNotice => 'Rechtlicher Hinweis: Die Rechtmäßigkeit der Aufnahme und Speicherung von Sprachdaten kann je nach Ihrem Standort und der Art und Weise, wie Sie diese Funktion nutzen, variieren. Es liegt in Ihrer Verantwortung, die Einhaltung der örtlichen Gesetze und Vorschriften sicherzustellen.';
 
   @override
   String get alreadyAuthorized => 'Bereits autorisiert';
@@ -1189,15 +1161,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showMeetingsMenuBar => 'Anstehende Meetings in der Menüleiste anzeigen';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Anzeige Ihres nächsten Meetings und der Zeit bis zum Beginn in der macOS-Menüleiste';
+  String get showMeetingsMenuBarDesc => 'Anzeige Ihres nächsten Meetings und der Zeit bis zum Beginn in der macOS-Menüleiste';
 
   @override
   String get showEventsNoParticipants => 'Ereignisse ohne Teilnehmer anzeigen';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Wenn aktiviert, zeigt \'Demnächst\' Ereignisse ohne Teilnehmer oder Video-Link an.';
+  String get showEventsNoParticipantsDesc => 'Wenn aktiviert, zeigt \'Demnächst\' Ereignisse ohne Teilnehmer oder Video-Link an.';
 
   @override
   String get yourMeetings => 'Ihre Meetings';
@@ -1238,8 +1208,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noProjectsInWorkspace => 'Keine Projekte in diesem Arbeitsbereich gefunden';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Wählen Sie, wie lange bei Stille gewartet werden soll, bevor eine Unterhaltung automatisch beendet wird:';
+  String get conversationTimeoutDesc => 'Wählen Sie, wie lange bei Stille gewartet werden soll, bevor eine Unterhaltung automatisch beendet wird:';
 
   @override
   String get timeout2Minutes => '2 Minuten';
@@ -1283,12 +1252,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Sagen Sie uns Ihre primäre Sprache';
 
   @override
-  String get languageForTranscription =>
-      'Stellen Sie Ihre Sprache für schärfere Transkriptionen und ein personalisiertes Erlebnis ein.';
+  String get languageForTranscription => 'Stellen Sie Ihre Sprache für schärfere Transkriptionen und ein personalisiertes Erlebnis ein.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Einzel-Sprachmodus ist aktiviert. Übersetzung ist für höhere Genauigkeit deaktiviert.';
+  String get singleLanguageModeInfo => 'Einzel-Sprachmodus ist aktiviert. Übersetzung ist für höhere Genauigkeit deaktiviert.';
 
   @override
   String get searchLanguageHint => 'Sprache nach Name oder Code suchen';
@@ -1368,8 +1335,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get defaultRepository => 'Standard-Repository';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Wählen Sie ein Standard-Repository für das Erstellen von Issues. Sie können beim Erstellen von Issues immer noch ein anderes Repository angeben.';
+  String get selectDefaultRepoDesc => 'Wählen Sie ein Standard-Repository für das Erstellen von Issues. Sie können beim Erstellen von Issues immer noch ein anderes Repository angeben.';
 
   @override
   String get noReposFound => 'Keine Repositories gefunden';
@@ -1416,8 +1382,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get configureSettings => 'Einstellungen konfigurieren';
 
   @override
-  String get completeAuthBrowser =>
-      'Bitte schließen Sie die Authentifizierung in Ihrem Browser ab. Kehren Sie danach zur App zurück.';
+  String get completeAuthBrowser => 'Bitte schließen Sie die Authentifizierung in Ihrem Browser ab. Kehren Sie danach zur App zurück.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1586,8 +1551,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get logsCopied => 'Protokolle kopiert';
 
   @override
-  String get noLogsYet =>
-      'Noch keine Protokolle. Starten Sie die Aufnahme, um benutzerdefinierte STT-Aktivitäten zu sehen.';
+  String get noLogsYet => 'Noch keine Protokolle. Starten Sie die Aufnahme, um benutzerdefinierte STT-Aktivitäten zu sehen.';
 
   @override
   String deviceUsesCodec(String device, String reason) {
@@ -1746,8 +1710,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth aktivieren';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi benötigt Bluetooth, um sich mit Ihrem Wearable zu verbinden. Bitte aktivieren Sie Bluetooth und versuchen Sie es erneut.';
+  String get bluetoothNeeded => 'Omi benötigt Bluetooth, um sich mit Ihrem Wearable zu verbinden. Bitte aktivieren Sie Bluetooth und versuchen Sie es erneut.';
 
   @override
   String get contactSupport => 'Support kontaktieren?';
@@ -1780,26 +1743,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get locationServiceDisabled => 'Standortdienst deaktiviert';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Der Standortdienst ist deaktiviert. Bitte gehen Sie zu Einstellungen > Datenschutz & Sicherheit > Standortdienste und aktivieren Sie ihn';
+  String get locationServiceDisabledDesc => 'Der Standortdienst ist deaktiviert. Bitte gehen Sie zu Einstellungen > Datenschutz & Sicherheit > Standortdienste und aktivieren Sie ihn';
 
   @override
   String get backgroundLocationDenied => 'Hintergrundstandortzugriff verweigert';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Bitte gehen Sie zu den Geräteeinstellungen und setzen Sie die Standortberechtigung auf \'Immer zulassen\'';
+  String get backgroundLocationDeniedDesc => 'Bitte gehen Sie zu den Geräteeinstellungen und setzen Sie die Standortberechtigung auf \'Immer zulassen\'';
 
   @override
   String get lovingOmi => 'Gefällt Ihnen Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Helfen Sie uns, mehr Menschen zu erreichen, indem Sie eine Bewertung im App Store hinterlassen. Ihr Feedback bedeutet uns die Welt!';
+  String get leaveReviewIos => 'Helfen Sie uns, mehr Menschen zu erreichen, indem Sie eine Bewertung im App Store hinterlassen. Ihr Feedback bedeutet uns die Welt!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Helfen Sie uns, mehr Menschen zu erreichen, indem Sie eine Bewertung im Google Play Store hinterlassen. Ihr Feedback bedeutet uns die Welt!';
+  String get leaveReviewAndroid => 'Helfen Sie uns, mehr Menschen zu erreichen, indem Sie eine Bewertung im Google Play Store hinterlassen. Ihr Feedback bedeutet uns die Welt!';
 
   @override
   String get rateOnAppStore => 'Im App Store bewerten';
@@ -1832,37 +1791,31 @@ class AppLocalizationsDe extends AppLocalizations {
   String get connectionError => 'Verbindungsfehler';
 
   @override
-  String get connectionErrorDesc =>
-      'Verbindung zum Server fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
+  String get connectionErrorDesc => 'Verbindung zum Server fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Ungültige Aufnahme erkannt';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Es scheint, dass mehrere Sprecher in der Aufnahme sind. Bitte stellen Sie sicher, dass Sie sich an einem ruhigen Ort befinden, und versuchen Sie es erneut.';
+  String get multipleSpeakersDesc => 'Es scheint, dass mehrere Sprecher in der Aufnahme sind. Bitte stellen Sie sicher, dass Sie sich an einem ruhigen Ort befinden, und versuchen Sie es erneut.';
 
   @override
-  String get tooShortDesc =>
-      'Es wurde nicht genug Sprache erkannt. Bitte sprechen Sie mehr und versuchen Sie es erneut.';
+  String get tooShortDesc => 'Es wurde nicht genug Sprache erkannt. Bitte sprechen Sie mehr und versuchen Sie es erneut.';
 
   @override
-  String get invalidRecordingDesc =>
-      'Bitte stellen Sie sicher, dass Sie mindestens 5 Sekunden und nicht mehr als 90 Sekunden sprechen.';
+  String get invalidRecordingDesc => 'Bitte stellen Sie sicher, dass Sie mindestens 5 Sekunden und nicht mehr als 90 Sekunden sprechen.';
 
   @override
   String get areYouThere => 'Sind Sie da?';
 
   @override
-  String get noSpeechDesc =>
-      'Wir konnten keine Sprache erkennen. Bitte stellen Sie sicher, dass Sie mindestens 10 Sekunden und nicht mehr als 3 Minuten sprechen.';
+  String get noSpeechDesc => 'Wir konnten keine Sprache erkennen. Bitte stellen Sie sicher, dass Sie mindestens 10 Sekunden und nicht mehr als 3 Minuten sprechen.';
 
   @override
   String get connectionLost => 'Verbindung unterbrochen';
 
   @override
-  String get connectionLostDesc =>
-      'Die Verbindung wurde unterbrochen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
+  String get connectionLostDesc => 'Die Verbindung wurde unterbrochen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
 
   @override
   String get tryAgain => 'Erneut versuchen';
@@ -1877,8 +1830,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get permissionsRequired => 'Berechtigungen erforderlich';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Diese App benötigt Bluetooth- und Standortberechtigungen, um ordnungsgemäß zu funktionieren. Bitte aktivieren Sie diese in den Einstellungen.';
+  String get permissionsRequiredDesc => 'Diese App benötigt Bluetooth- und Standortberechtigungen, um ordnungsgemäß zu funktionieren. Bitte aktivieren Sie diese in den Einstellungen.';
 
   @override
   String get openSettings => 'Einstellungen öffnen';
@@ -1908,8 +1860,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Ihr KI-Begleiter';
 
   @override
-  String get captureEveryMoment =>
-      'Erfassen Sie jeden Moment. Erhalten Sie KI-gestützte Zusammenfassungen. Nie wieder Notizen machen.';
+  String get captureEveryMoment => 'Erfassen Sie jeden Moment. Erhalten Sie KI-gestützte Zusammenfassungen. Nie wieder Notizen machen.';
 
   @override
   String get appleWatchSetup => 'Apple Watch Einrichtung';
@@ -1921,12 +1872,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get microphonePermission => 'Mikrofonberechtigung';
 
   @override
-  String get permissionGrantedNow =>
-      'Berechtigung erteilt! Jetzt:\n\nÖffnen Sie die Omi-App auf Ihrer Uhr und tippen Sie unten auf \'Weiter\'';
+  String get permissionGrantedNow => 'Berechtigung erteilt! Jetzt:\n\nÖffnen Sie die Omi-App auf Ihrer Uhr und tippen Sie unten auf \'Weiter\'';
 
   @override
-  String get needMicrophonePermission =>
-      'Wir benötigen Mikrofonberechtigung.\n\n1. Tippen Sie auf \'Berechtigung erteilen\'\n2. Erlauben Sie auf Ihrem iPhone\n3. Uhr-App wird geschlossen\n4. Öffnen Sie sie erneut und tippen Sie auf \'Weiter\'';
+  String get needMicrophonePermission => 'Wir benötigen Mikrofonberechtigung.\n\n1. Tippen Sie auf \'Berechtigung erteilen\'\n2. Erlauben Sie auf Ihrem iPhone\n3. Uhr-App wird geschlossen\n4. Öffnen Sie sie erneut und tippen Sie auf \'Weiter\'';
 
   @override
   String get grantPermissionButton => 'Berechtigung erteilen';
@@ -1935,15 +1884,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get needHelp => 'Brauchen Sie Hilfe?';
 
   @override
-  String get troubleshootingSteps =>
-      'Fehlerbehebung:\n\n1. Stellen Sie sicher, dass Omi auf Ihrer Uhr installiert ist\n2. Öffnen Sie die Omi-App auf Ihrer Uhr\n3. Suchen Sie nach dem Berechtigungs-Popup\n4. Tippen Sie bei Aufforderung auf \'Zulassen\'\n5. App auf Ihrer Uhr wird geschlossen - öffnen Sie sie erneut\n6. Kommen Sie zurück und tippen Sie auf Ihrem iPhone auf \'Weiter\'';
+  String get troubleshootingSteps => 'Fehlerbehebung:\n\n1. Stellen Sie sicher, dass Omi auf Ihrer Uhr installiert ist\n2. Öffnen Sie die Omi-App auf Ihrer Uhr\n3. Suchen Sie nach dem Berechtigungs-Popup\n4. Tippen Sie bei Aufforderung auf \'Zulassen\'\n5. App auf Ihrer Uhr wird geschlossen - öffnen Sie sie erneut\n6. Kommen Sie zurück und tippen Sie auf Ihrem iPhone auf \'Weiter\'';
 
   @override
   String get recordingStartedSuccessfully => 'Aufnahme erfolgreich gestartet!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Berechtigung noch nicht erteilt. Bitte stellen Sie sicher, dass Sie den Mikrofonzugriff erlaubt und die App auf Ihrer Uhr erneut geöffnet haben.';
+  String get permissionNotGrantedYet => 'Berechtigung noch nicht erteilt. Bitte stellen Sie sicher, dass Sie den Mikrofonzugriff erlaubt und die App auf Ihrer Uhr erneut geöffnet haben.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1959,8 +1906,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get selectPrimaryLanguage => 'Wählen Sie Ihre primäre Sprache';
 
   @override
-  String get languageBenefits =>
-      'Stellen Sie Ihre Sprache für schärfere Transkriptionen und ein personalisiertes Erlebnis ein';
+  String get languageBenefits => 'Stellen Sie Ihre Sprache für schärfere Transkriptionen und ein personalisiertes Erlebnis ein';
 
   @override
   String get whatsYourPrimaryLanguage => 'Was ist Ihre primäre Sprache?';
@@ -2041,8 +1987,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Bereit für Aufgaben';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Ihre KI extrahiert automatisch Aufgaben und To-Dos aus Ihren Unterhaltungen. Sie erscheinen hier, wenn sie erstellt wurden.';
+  String get welcomeActionItemsDescription => 'Ihre KI extrahiert automatisch Aufgaben und To-Dos aus Ihren Unterhaltungen. Sie erscheinen hier, wenn sie erstellt wurden.';
 
   @override
   String get autoExtractionFeature => 'Automatisch aus Unterhaltungen extrahiert';
@@ -2092,8 +2037,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get clearMemoryTitle => 'Omis Gedächtnis löschen';
 
   @override
-  String get clearMemoryMessage =>
-      'Sind Sie sicher, dass Sie Omis Gedächtnis löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get clearMemoryMessage => 'Sind Sie sicher, dass Sie Omis Gedächtnis löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get clearMemoryButton => 'Erinnerung löschen';
@@ -2239,19 +2183,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'SPRACHE UND TRANSKRIPTION';
 
   @override
-  String get languageSettingsHelperText =>
-      'Die App-Sprache ändert Menüs und Schaltflächen. Die Sprachsprache beeinflusst, wie Ihre Aufnahmen transkribiert werden.';
+  String get languageSettingsHelperText => 'Die App-Sprache ändert Menüs und Schaltflächen. Die Sprachsprache beeinflusst, wie Ihre Aufnahmen transkribiert werden.';
 
   @override
   String get translationNotice => 'Übersetzungshinweis';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi übersetzt Unterhaltungen in Ihre Hauptsprache. Aktualisieren Sie diese jederzeit unter Einstellungen → Profile.';
+  String get translationNoticeMessage => 'Omi übersetzt Unterhaltungen in Ihre Hauptsprache. Aktualisieren Sie diese jederzeit unter Einstellungen → Profile.';
 
   @override
-  String get pleaseCheckInternetConnection =>
-      'Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut';
+  String get pleaseCheckInternetConnection => 'Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut';
 
   @override
   String get pleaseSelectReason => 'Bitte wählen Sie einen Grund aus';
@@ -2268,8 +2209,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Diese Unterhaltung kann nicht zusammengeführt werden (gesperrt oder wird bereits zusammengeführt)';
+  String get conversationCannotBeMerged => 'Diese Unterhaltung kann nicht zusammengeführt werden (gesperrt oder wird bereits zusammengeführt)';
 
   @override
   String get pleaseEnterFolderName => 'Bitte geben Sie einen Ordnernamen ein';
@@ -2404,8 +2344,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Gerät entkoppeln';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Dies entkoppelt das Gerät, damit es mit einem anderen Telefon verbunden werden kann. Sie müssen zu Einstellungen > Bluetooth gehen und das Gerät vergessen, um den Vorgang abzuschließen.';
+  String get unpairDeviceDialogMessage => 'Dies entkoppelt das Gerät, damit es mit einem anderen Telefon verbunden werden kann. Sie müssen zu Einstellungen > Bluetooth gehen und das Gerät vergessen, um den Vorgang abzuschließen.';
 
   @override
   String get unpair => 'Entkoppeln';
@@ -2571,8 +2510,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get howDoesItWork => 'Wie funktioniert es?';
 
   @override
-  String get sdCardSyncDescription =>
-      'SD-Karten-Synchronisierung importiert Ihre Erinnerungen von der SD-Karte in die App';
+  String get sdCardSyncDescription => 'SD-Karten-Synchronisierung importiert Ihre Erinnerungen von der SD-Karte in die App';
 
   @override
   String get checksForAudioFiles => 'Prüft auf Audiodateien auf der SD-Karte';
@@ -2587,8 +2525,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get youreAllSet => 'Alles bereit!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Willkommen bei Omi! Ihr KI-Begleiter ist bereit, Sie bei Gesprächen, Aufgaben und mehr zu unterstützen.';
+  String get welcomeToOmiDescription => 'Willkommen bei Omi! Ihr KI-Begleiter ist bereit, Sie bei Gesprächen, Aufgaben und mehr zu unterstützen.';
 
   @override
   String get startUsingOmi => 'Omi verwenden';
@@ -2667,8 +2604,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get reviewAndManageConversations => 'Überprüfe und verwalte deine aufgenommenen Unterhaltungen';
 
   @override
-  String get startCapturingConversations =>
-      'Beginne Unterhaltungen mit deinem Omi-Gerät aufzunehmen, um sie hier zu sehen.';
+  String get startCapturingConversations => 'Beginne Unterhaltungen mit deinem Omi-Gerät aufzunehmen, um sie hier zu sehen.';
 
   @override
   String get useMobileAppToCapture => 'Verwende deine mobile App, um Audio aufzunehmen';
@@ -2725,8 +2661,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noTasksYet => 'Noch keine Aufgaben';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Aufgaben aus Ihren Gesprächen werden hier angezeigt.\nKlicken Sie auf Erstellen, um eine manuell hinzuzufügen.';
+  String get tasksFromConversationsWillAppear => 'Aufgaben aus Ihren Gesprächen werden hier angezeigt.\nKlicken Sie auf Erstellen, um eine manuell hinzuzufügen.';
 
   @override
   String get monthJan => 'Jan';
@@ -2783,8 +2718,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteActionItem => 'Aufgabe löschen';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Möchten Sie diese Aufgabe wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get deleteActionItemConfirmation => 'Möchten Sie diese Aufgabe wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get enterActionItemDescription => 'Aufgabenbeschreibung eingeben...';
@@ -2826,8 +2760,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get checkBackLaterForNewApps => 'Schauen Sie später nach neuen Apps';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut';
 
   @override
   String get createNewApp => 'Neue App erstellen';
@@ -2860,15 +2793,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chatPrompt => 'Chat-Eingabeaufforderung';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Sie sind eine großartige App, Ihre Aufgabe ist es, auf Benutzeranfragen zu antworten und ihnen ein gutes Gefühl zu geben...';
+  String get chatPromptPlaceholder => 'Sie sind eine großartige App, Ihre Aufgabe ist es, auf Benutzeranfragen zu antworten und ihnen ein gutes Gefühl zu geben...';
 
   @override
   String get conversationPrompt => 'Gesprächsaufforderung';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Sie sind eine großartige App, Sie erhalten ein Transkript und eine Zusammenfassung eines Gesprächs...';
+  String get conversationPromptPlaceholder => 'Sie sind eine großartige App, Sie erhalten ein Transkript und eine Zusammenfassung eines Gesprächs...';
 
   @override
   String get notificationScopes => 'Benachrichtigungsbereiche';
@@ -2880,8 +2811,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get makeMyAppPublic => 'Meine App öffentlich machen';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Mit der Einreichung dieser App stimme ich den Nutzungsbedingungen und der Datenschutzrichtlinie von Omi AI zu';
+  String get submitAppTermsAgreement => 'Mit der Einreichung dieser App stimme ich den Nutzungsbedingungen und der Datenschutzrichtlinie von Omi AI zu';
 
   @override
   String get submitApp => 'App einreichen';
@@ -2896,12 +2826,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get submitAppQuestion => 'App einreichen?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Ihre App wird überprüft und veröffentlicht. Sie können sie sofort verwenden, auch während der Überprüfung!';
+  String get submitAppPublicDescription => 'Ihre App wird überprüft und veröffentlicht. Sie können sie sofort verwenden, auch während der Überprüfung!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Ihre App wird überprüft und Ihnen privat zur Verfügung gestellt. Sie können sie sofort verwenden, auch während der Überprüfung!';
+  String get submitAppPrivateDescription => 'Ihre App wird überprüft und Ihnen privat zur Verfügung gestellt. Sie können sie sofort verwenden, auch während der Überprüfung!';
 
   @override
   String get startEarning => 'Beginnen Sie zu verdienen! 💰';
@@ -2925,23 +2853,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dataAccessNotice => 'Datenzugriffshinweis';
 
   @override
-  String get dataAccessWarning =>
-      'Diese App greift auf Ihre Daten zu. Omi AI ist nicht verantwortlich dafür, wie Ihre Daten von dieser App verwendet, geändert oder gelöscht werden';
+  String get dataAccessWarning => 'Diese App greift auf Ihre Daten zu. Omi AI ist nicht verantwortlich dafür, wie Ihre Daten von dieser App verwendet, geändert oder gelöscht werden';
 
   @override
   String get installApp => 'App installieren';
 
   @override
-  String get betaTesterNotice =>
-      'Sie sind Beta-Tester für diese App. Sie ist noch nicht öffentlich. Sie wird öffentlich, sobald sie genehmigt wurde.';
+  String get betaTesterNotice => 'Sie sind Beta-Tester für diese App. Sie ist noch nicht öffentlich. Sie wird öffentlich, sobald sie genehmigt wurde.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Ihre App wird überprüft und ist nur für Sie sichtbar. Sie wird öffentlich, sobald sie genehmigt wurde.';
+  String get appUnderReviewOwner => 'Ihre App wird überprüft und ist nur für Sie sichtbar. Sie wird öffentlich, sobald sie genehmigt wurde.';
 
   @override
-  String get appRejectedNotice =>
-      'Ihre App wurde abgelehnt. Bitte aktualisieren Sie die App-Details und reichen Sie sie erneut zur Überprüfung ein.';
+  String get appRejectedNotice => 'Ihre App wurde abgelehnt. Bitte aktualisieren Sie die App-Details und reichen Sie sie erneut zur Überprüfung ein.';
 
   @override
   String get setupSteps => 'Einrichtungsschritte';
@@ -2976,8 +2900,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get errorActivatingApp => 'Fehler beim Aktivieren der App';
 
   @override
-  String get integrationSetupRequired =>
-      'Wenn dies eine Integrations-App ist, stellen Sie sicher, dass die Einrichtung abgeschlossen ist.';
+  String get integrationSetupRequired => 'Wenn dies eine Integrations-App ist, stellen Sie sicher, dass die Einrichtung abgeschlossen ist.';
 
   @override
   String get installed => 'Installiert';
@@ -3004,8 +2927,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get descriptionLabel => 'Beschreibung';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Meine fantastische App ist eine großartige App, die erstaunliche Dinge tut. Sie ist die beste App aller Zeiten!';
+  String get appDescriptionPlaceholder => 'Meine fantastische App ist eine großartige App, die erstaunliche Dinge tut. Sie ist die beste App aller Zeiten!';
 
   @override
   String get pleaseProvideValidDescription => 'Bitte geben Sie eine gültige Beschreibung an';
@@ -3142,8 +3064,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get clearChatTitle => 'Chat löschen?';
 
   @override
-  String get confirmClearChat =>
-      'Möchten Sie den Chat wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get confirmClearChat => 'Möchten Sie den Chat wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get copy => 'Kopieren';
@@ -3158,8 +3079,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get microphonePermissionRequired => 'Mikrofonberechtigung ist für Sprachaufnahmen erforderlich.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofonberechtigung verweigert. Bitte erteilen Sie die Berechtigung in Systemeinstellungen > Datenschutz & Sicherheit > Mikrofon.';
+  String get microphonePermissionDenied => 'Mikrofonberechtigung verweigert. Bitte erteilen Sie die Berechtigung in Systemeinstellungen > Datenschutz & Sicherheit > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3318,8 +3238,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get createMemory => 'Erinnerung erstellen';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Möchten Sie diese Erinnerung wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get deleteMemoryConfirmation => 'Möchten Sie diese Erinnerung wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get makePrivate => 'Privat machen';
@@ -3393,8 +3312,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get whatWeCollect => 'Was wir sammeln';
 
   @override
-  String get dataCollectionMessage =>
-      'Durch Fortfahren werden Ihre Gespräche, Aufnahmen und persönlichen Informationen sicher auf unseren Servern gespeichert, um KI-gestützte Einblicke zu bieten und alle App-Funktionen zu ermöglichen.';
+  String get dataCollectionMessage => 'Durch Fortfahren werden Ihre Gespräche, Aufnahmen und persönlichen Informationen sicher auf unseren Servern gespeichert, um KI-gestützte Einblicke zu bieten und alle App-Funktionen zu ermöglichen.';
 
   @override
   String get dataProtection => 'Datenschutz';
@@ -3409,8 +3327,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chooseYourLanguage => 'Wählen Sie Ihre Sprache';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'Wählen Sie Ihre bevorzugte Sprache für das beste Omi-Erlebnis';
+  String get selectPreferredLanguageForBestExperience => 'Wählen Sie Ihre bevorzugte Sprache für das beste Omi-Erlebnis';
 
   @override
   String get searchLanguages => 'Sprachen suchen...';
@@ -3428,8 +3345,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Der Name muss mindestens 2 Zeichen lang sein';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Sagen Sie uns, wie Sie angesprochen werden möchten. Dies hilft, Ihr Omi-Erlebnis zu personalisieren.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Sagen Sie uns, wie Sie angesprochen werden möchten. Dies hilft, Ihr Omi-Erlebnis zu personalisieren.';
 
   @override
   String charactersCount(int count) {
@@ -3446,8 +3362,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get recordAudioConversations => 'Audio-Gespräche aufzeichnen';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi benötigt Mikrofonzugriff, um Ihre Gespräche aufzuzeichnen und Transkriptionen bereitzustellen.';
+  String get microphoneAccessDescription => 'Omi benötigt Mikrofonzugriff, um Ihre Gespräche aufzuzeichnen und Transkriptionen bereitzustellen.';
 
   @override
   String get screenRecording => 'Bildschirmaufzeichnung';
@@ -3456,8 +3371,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'System-Audio von Besprechungen erfassen';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi benötigt die Berechtigung zur Bildschirmaufzeichnung, um System-Audio von Ihren browserbasierten Besprechungen zu erfassen.';
+  String get screenRecordingDescription => 'Omi benötigt die Berechtigung zur Bildschirmaufzeichnung, um System-Audio von Ihren browserbasierten Besprechungen zu erfassen.';
 
   @override
   String get accessibility => 'Barrierefreiheit';
@@ -3466,8 +3380,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Browserbasierte Besprechungen erkennen';
 
   @override
-  String get accessibilityDescription =>
-      'Omi benötigt die Berechtigung für Barrierefreiheit, um zu erkennen, wann Sie Zoom-, Meet- oder Teams-Besprechungen in Ihrem Browser beitreten.';
+  String get accessibilityDescription => 'Omi benötigt die Berechtigung für Barrierefreiheit, um zu erkennen, wann Sie Zoom-, Meet- oder Teams-Besprechungen in Ihrem Browser beitreten.';
 
   @override
   String get pleaseWait => 'Bitte warten...';
@@ -3536,12 +3449,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get exportAllConversationsToJson => 'Exportieren Sie alle Ihre Unterhaltungen in eine JSON-Datei.';
 
   @override
-  String get conversationsExportStarted =>
-      'Export der Unterhaltungen gestartet. Dies kann einige Sekunden dauern, bitte warten.';
+  String get conversationsExportStarted => 'Export der Unterhaltungen gestartet. Dies kann einige Sekunden dauern, bitte warten.';
 
   @override
-  String get mcpDescription =>
-      'Um Omi mit anderen Anwendungen zu verbinden, um Ihre Erinnerungen und Unterhaltungen zu lesen, zu durchsuchen und zu verwalten. Erstellen Sie einen Schlüssel, um loszulegen.';
+  String get mcpDescription => 'Um Omi mit anderen Anwendungen zu verbinden, um Ihre Erinnerungen und Unterhaltungen zu lesen, zu durchsuchen und zu verwalten. Erstellen Sie einen Schlüssel, um loszulegen.';
 
   @override
   String get apiKeys => 'API-Schlüssel';
@@ -3588,8 +3499,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'Neue Sprecher automatisch erstellen und kennzeichnen';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Automatisch eine neue Person erstellen, wenn ein Name im Transkript erkannt wird.';
+  String get automaticallyCreateNewPerson => 'Automatisch eine neue Person erstellen, wenn ein Name im Transkript erkannt wird.';
 
   @override
   String get pilotFeatures => 'Pilotfunktionen';
@@ -3613,8 +3523,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get auto => 'Automatisch';
 
   @override
-  String get noSummaryForApp =>
-      'Keine Zusammenfassung für diese App verfügbar. Probieren Sie eine andere App für bessere Ergebnisse.';
+  String get noSummaryForApp => 'Keine Zusammenfassung für diese App verfügbar. Probieren Sie eine andere App für bessere Ergebnisse.';
 
   @override
   String get tryAnotherApp => 'Andere App ausprobieren';
@@ -3651,8 +3560,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Lassen Sie Omi automatisch die beste App auswählen';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Möchten Sie dieses Gespräch wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get deleteConversationConfirmation => 'Möchten Sie dieses Gespräch wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get conversationDeleted => 'Gespräch gelöscht';
@@ -3700,8 +3608,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Systemtonaufnahme wird vorbereitet';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klicken Sie auf die Schaltfläche, um Audio für Live-Transkripte, KI-Einblicke und automatisches Speichern aufzunehmen.';
+  String get clickTheButtonToCaptureAudio => 'Klicken Sie auf die Schaltfläche, um Audio für Live-Transkripte, KI-Einblicke und automatisches Speichern aufzunehmen.';
 
   @override
   String get reconnecting => 'Verbindung wird wiederhergestellt...';
@@ -3859,8 +3766,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dailySummaryTitle => 'Tägliche Zusammenfassung';
 
   @override
-  String get dailySummaryDescription =>
-      'Erhalten Sie eine personalisierte Zusammenfassung Ihrer Tagesgespräche als Benachrichtigung.';
+  String get dailySummaryDescription => 'Erhalten Sie eine personalisierte Zusammenfassung Ihrer Tagesgespräche als Benachrichtigung.';
 
   @override
   String get deliveryTime => 'Lieferzeit';
@@ -3905,8 +3811,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shortcuts => 'Tastenkombinationen';
 
   @override
-  String get shortcutChangeInstruction =>
-      'Klicken Sie auf eine Tastenkombination, um sie zu ändern. Drücken Sie Escape, um abzubrechen.';
+  String get shortcutChangeInstruction => 'Klicken Sie auf eine Tastenkombination, um sie zu ändern. Drücken Sie Escape, um abzubrechen.';
 
   @override
   String get configureSTTProvider => 'STT-Anbieter konfigurieren';
@@ -3930,8 +3835,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Wissensgraph löschen?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Dadurch werden alle abgeleiteten Wissensgraph-Daten gelöscht. Ihre ursprünglichen Erinnerungen bleiben sicher.';
+  String get deleteKnowledgeGraphWarning => 'Dadurch werden alle abgeleiteten Wissensgraph-Daten gelöscht. Ihre ursprünglichen Erinnerungen bleiben sicher.';
 
   @override
   String get connectOmiWithAI => 'Verbinden Sie Omi mit KI-Assistenten';
@@ -3973,8 +3877,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Nutzungsbedingungen & Datenschutz';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Hilft bei der Diagnose von Problemen. Wird nach 3 Tagen automatisch gelöscht.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Hilft bei der Diagnose von Problemen. Wird nach 3 Tagen automatisch gelöscht.';
 
   @override
   String get manageYourApp => 'Verwalten Sie Ihre App';
@@ -3989,8 +3892,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get updateAppQuestion => 'App aktualisieren?';
 
   @override
-  String get updateAppConfirmation =>
-      'Sind Sie sicher, dass Sie Ihre App aktualisieren möchten? Die Änderungen werden nach Überprüfung durch unser Team übernommen.';
+  String get updateAppConfirmation => 'Sind Sie sicher, dass Sie Ihre App aktualisieren möchten? Die Änderungen werden nach Überprüfung durch unser Team übernommen.';
 
   @override
   String get updateApp => 'App aktualisieren';
@@ -4020,8 +3922,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get no => 'Nein';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abonnement erfolgreich gekündigt. Es bleibt bis zum Ende des aktuellen Abrechnungszeitraums aktiv.';
+  String get subscriptionCancelledSuccessfully => 'Abonnement erfolgreich gekündigt. Es bleibt bis zum Ende des aktuellen Abrechnungszeitraums aktiv.';
 
   @override
   String get failedToCancelSubscription => 'Kündigung des Abonnements fehlgeschlagen. Bitte versuchen Sie es erneut.';
@@ -4057,8 +3958,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Abonnement kündigen?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Sind Sie sicher, dass Sie Ihr Abonnement kündigen möchten? Sie haben weiterhin Zugang bis zum Ende Ihres aktuellen Abrechnungszeitraums.';
+  String get cancelSubscriptionConfirmation => 'Sind Sie sicher, dass Sie Ihr Abonnement kündigen möchten? Sie haben weiterhin Zugang bis zum Ende Ihres aktuellen Abrechnungszeitraums.';
 
   @override
   String get cancelSubscriptionButton => 'Abonnement kündigen';
@@ -4067,16 +3967,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cancelling => 'Wird gekündigt...';
 
   @override
-  String get betaTesterMessage =>
-      'Sie sind Beta-Tester für diese App. Sie ist noch nicht öffentlich. Sie wird nach Genehmigung öffentlich.';
+  String get betaTesterMessage => 'Sie sind Beta-Tester für diese App. Sie ist noch nicht öffentlich. Sie wird nach Genehmigung öffentlich.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Ihre App wird überprüft und ist nur für Sie sichtbar. Sie wird nach Genehmigung öffentlich.';
+  String get appUnderReviewMessage => 'Ihre App wird überprüft und ist nur für Sie sichtbar. Sie wird nach Genehmigung öffentlich.';
 
   @override
-  String get appRejectedMessage =>
-      'Ihre App wurde abgelehnt. Bitte aktualisieren Sie die App-Details und reichen Sie sie erneut ein.';
+  String get appRejectedMessage => 'Ihre App wurde abgelehnt. Bitte aktualisieren Sie die App-Details und reichen Sie sie erneut ein.';
 
   @override
   String get invalidIntegrationUrl => 'Ungültige Integrations-URL';
@@ -4127,12 +4024,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get anonymousUser => 'Anonymer Benutzer';
 
   @override
-  String get issueActivatingApp =>
-      'Bei der Aktivierung dieser App ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.';
+  String get issueActivatingApp => 'Bei der Aktivierung dieser App ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Diese App wird auf Ihre Daten zugreifen. Omi AI ist nicht verantwortlich für die Verwendung, Änderung oder Löschung Ihrer Daten durch diese App';
+  String get dataAccessNoticeDescription => 'Diese App wird auf Ihre Daten zugreifen. Omi AI ist nicht verantwortlich für die Verwendung, Änderung oder Löschung Ihrer Daten durch diese App';
 
   @override
   String get copyUrl => 'URL kopieren';
@@ -4220,8 +4115,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get omiApiKeys => 'Omi API-Schlüssel';
 
   @override
-  String get apiKeysDescription =>
-      'API-Schlüssel werden zur Authentifizierung verwendet, wenn Ihre App mit dem OMI-Server kommuniziert. Sie ermöglichen Ihrer Anwendung, Erinnerungen zu erstellen und sicher auf andere OMI-Dienste zuzugreifen.';
+  String get apiKeysDescription => 'API-Schlüssel werden zur Authentifizierung verwendet, wenn Ihre App mit dem OMI-Server kommuniziert. Sie ermöglichen Ihrer Anwendung, Erinnerungen zu erstellen und sicher auf andere OMI-Dienste zuzugreifen.';
 
   @override
   String get aboutOmiApiKeys => 'Über Omi API-Schlüssel';
@@ -4245,8 +4139,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API-Schlüssel widerrufen?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Diese Aktion kann nicht rückgängig gemacht werden. Alle Anwendungen, die diesen Schlüssel verwenden, können nicht mehr auf die API zugreifen.';
+  String get revokeApiKeyWarning => 'Diese Aktion kann nicht rückgängig gemacht werden. Alle Anwendungen, die diesen Schlüssel verwenden, können nicht mehr auf die API zugreifen.';
 
   @override
   String get revoke => 'Widerrufen';
@@ -4335,8 +4228,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get keyCreated => 'Schlüssel erstellt';
 
   @override
-  String get keyCreatedMessage =>
-      'Ihr neuer Schlüssel wurde erstellt. Bitte kopieren Sie ihn jetzt. Sie werden ihn nicht mehr sehen können.';
+  String get keyCreatedMessage => 'Ihr neuer Schlüssel wurde erstellt. Bitte kopieren Sie ihn jetzt. Sie werden ihn nicht mehr sehen können.';
 
   @override
   String get keyWord => 'Schlüssel';
@@ -4345,8 +4237,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get externalAppAccess => 'Externer App-Zugriff';
 
   @override
-  String get externalAppAccessDescription =>
-      'Die folgenden installierten Apps haben externe Integrationen und können auf Ihre Daten zugreifen, wie Gespräche und Erinnerungen.';
+  String get externalAppAccessDescription => 'Die folgenden installierten Apps haben externe Integrationen und können auf Ihre Daten zugreifen, wie Gespräche und Erinnerungen.';
 
   @override
   String get noExternalAppsHaveAccess => 'Keine externen Apps haben Zugriff auf Ihre Daten.';
@@ -4355,8 +4246,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maximale Sicherheit (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-End-Verschlüsselung ist der Goldstandard für Datenschutz. Wenn aktiviert, werden Ihre Daten auf Ihrem Gerät verschlüsselt, bevor sie an unsere Server gesendet werden. Das bedeutet, dass niemand, nicht einmal Omi, auf Ihre Inhalte zugreifen kann.';
+  String get e2eeDescription => 'End-to-End-Verschlüsselung ist der Goldstandard für Datenschutz. Wenn aktiviert, werden Ihre Daten auf Ihrem Gerät verschlüsselt, bevor sie an unsere Server gesendet werden. Das bedeutet, dass niemand, nicht einmal Omi, auf Ihre Inhalte zugreifen kann.';
 
   @override
   String get importantTradeoffs => 'Wichtige Kompromisse:';
@@ -4371,8 +4261,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get featureComingSoon => 'Diese Funktion kommt bald!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migration läuft. Sie können das Schutzniveau nicht ändern, bis sie abgeschlossen ist.';
+  String get migrationInProgressMessage => 'Migration läuft. Sie können das Schutzniveau nicht ändern, bis sie abgeschlossen ist.';
 
   @override
   String get migrationFailed => 'Migration fehlgeschlagen';
@@ -4391,19 +4280,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get secureEncryption => 'Sichere Verschlüsselung';
 
   @override
-  String get secureEncryptionDescription =>
-      'Ihre Daten werden mit einem für Sie einzigartigen Schlüssel auf unseren Servern verschlüsselt, die bei Google Cloud gehostet werden. Das bedeutet, dass Ihre Rohdaten für niemanden zugänglich sind, einschließlich Omi-Mitarbeiter oder Google, direkt aus der Datenbank.';
+  String get secureEncryptionDescription => 'Ihre Daten werden mit einem für Sie einzigartigen Schlüssel auf unseren Servern verschlüsselt, die bei Google Cloud gehostet werden. Das bedeutet, dass Ihre Rohdaten für niemanden zugänglich sind, einschließlich Omi-Mitarbeiter oder Google, direkt aus der Datenbank.';
 
   @override
   String get endToEndEncryption => 'End-to-End-Verschlüsselung';
 
   @override
-  String get e2eeCardDescription =>
-      'Aktivieren Sie für maximale Sicherheit, bei der nur Sie auf Ihre Daten zugreifen können. Tippen Sie, um mehr zu erfahren.';
+  String get e2eeCardDescription => 'Aktivieren Sie für maximale Sicherheit, bei der nur Sie auf Ihre Daten zugreifen können. Tippen Sie, um mehr zu erfahren.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Unabhängig vom Level sind Ihre Daten immer im Ruhezustand und während der Übertragung verschlüsselt.';
+  String get dataAlwaysEncrypted => 'Unabhängig vom Level sind Ihre Daten immer im Ruhezustand und während der Übertragung verschlüsselt.';
 
   @override
   String get readOnlyScope => 'Nur Lesen';
@@ -4468,12 +4354,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trainingDataProgram => 'Trainingsdatenprogramm';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Erhalten Sie Omi Unlimited kostenlos, indem Sie Ihre Daten zum Training von KI-Modellen beitragen.';
+  String get getOmiUnlimitedFree => 'Erhalten Sie Omi Unlimited kostenlos, indem Sie Ihre Daten zum Training von KI-Modellen beitragen.';
 
   @override
-  String get trainingDataBullets =>
-      '• Ihre Daten helfen, KI-Modelle zu verbessern\n• Nur nicht sensible Daten werden geteilt\n• Vollständig transparenter Prozess';
+  String get trainingDataBullets => '• Ihre Daten helfen, KI-Modelle zu verbessern\n• Nur nicht sensible Daten werden geteilt\n• Vollständig transparenter Prozess';
 
   @override
   String get learnMoreAtOmiTraining => 'Erfahren Sie mehr unter omi.me/training';
@@ -4485,8 +4369,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get submitRequest => 'Anfrage senden';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Vielen Dank! Ihre Anfrage wird geprüft. Wir benachrichtigen Sie nach der Genehmigung.';
+  String get thankYouRequestUnderReview => 'Vielen Dank! Ihre Anfrage wird geprüft. Wir benachrichtigen Sie nach der Genehmigung.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4524,15 +4407,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get monthlyPlanContinues => 'Ihr aktueller Monatsplan läuft bis zum Ende Ihres Abrechnungszeitraums weiter';
 
   @override
-  String get paymentMethodCharged =>
-      'Ihre bestehende Zahlungsmethode wird automatisch belastet, wenn Ihr Monatsplan endet';
+  String get paymentMethodCharged => 'Ihre bestehende Zahlungsmethode wird automatisch belastet, wenn Ihr Monatsplan endet';
 
   @override
   String get annualSubscriptionStarts => 'Ihr 12-monatiges Jahresabonnement beginnt automatisch nach der Abbuchung';
 
   @override
-  String get thirteenMonthsCoverage =>
-      'Sie erhalten insgesamt 13 Monate Abdeckung (aktueller Monat + 12 Monate jährlich)';
+  String get thirteenMonthsCoverage => 'Sie erhalten insgesamt 13 Monate Abdeckung (aktueller Monat + 12 Monate jährlich)';
 
   @override
   String get confirmUpgrade => 'Upgrade bestätigen';
@@ -4607,8 +4488,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get resubscribe => 'Erneut abonnieren';
 
   @override
-  String get couldNotOpenPaymentSettings =>
-      'Zahlungseinstellungen konnten nicht geöffnet werden. Bitte versuchen Sie es erneut.';
+  String get couldNotOpenPaymentSettings => 'Zahlungseinstellungen konnten nicht geöffnet werden. Bitte versuchen Sie es erneut.';
 
   @override
   String get managePaymentMethod => 'Zahlungsmethode verwalten';
@@ -4637,8 +4517,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Ihre Privatsphäre ist uns wichtig';
 
   @override
-  String get privacyIntroText =>
-      'Bei Omi nehmen wir Ihre Privatsphäre sehr ernst. Wir möchten transparent sein über die Daten, die wir sammeln und wie wir sie verwenden, um unser Produkt zu verbessern. Hier ist, was Sie wissen müssen:';
+  String get privacyIntroText => 'Bei Omi nehmen wir Ihre Privatsphäre sehr ernst. Wir möchten transparent sein über die Daten, die wir sammeln und wie wir sie verwenden, um unser Produkt zu verbessern. Hier ist, was Sie wissen müssen:';
 
   @override
   String get whatWeTrack => 'Was wir erfassen';
@@ -4653,12 +4532,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get ourCommitment => 'Unser Engagement';
 
   @override
-  String get commitmentText =>
-      'Wir verpflichten uns, die gesammelten Daten nur zu verwenden, um Omi zu einem besseren Produkt für Sie zu machen. Ihre Privatsphäre und Ihr Vertrauen sind uns sehr wichtig.';
+  String get commitmentText => 'Wir verpflichten uns, die gesammelten Daten nur zu verwenden, um Omi zu einem besseren Produkt für Sie zu machen. Ihre Privatsphäre und Ihr Vertrauen sind uns sehr wichtig.';
 
   @override
-  String get thankYouText =>
-      'Vielen Dank, dass Sie ein geschätzter Benutzer von Omi sind. Bei Fragen oder Bedenken können Sie uns gerne unter team@basedhardware.com kontaktieren.';
+  String get thankYouText => 'Vielen Dank, dass Sie ein geschätzter Benutzer von Omi sind. Bei Fragen oder Bedenken können Sie uns gerne unter team@basedhardware.com kontaktieren.';
 
   @override
   String get wifiSyncSettings => 'WLAN-Synchronisierungseinstellungen';
@@ -4667,8 +4544,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get enterHotspotCredentials => 'Geben Sie die Hotspot-Anmeldedaten Ihres Telefons ein';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WLAN-Sync nutzt Ihr Telefon als Hotspot. Finden Sie Name und Passwort unter Einstellungen > Persönlicher Hotspot.';
+  String get wifiSyncUsesHotspot => 'WLAN-Sync nutzt Ihr Telefon als Hotspot. Finden Sie Name und Passwort unter Einstellungen > Persönlicher Hotspot.';
 
   @override
   String get hotspotNameSsid => 'Hotspot-Name (SSID)';
@@ -4703,8 +4579,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Zusammenfassung konnte nicht erstellt werden. Stellen Sie sicher, dass Sie Gespräche für diesen Tag haben.';
+  String get failedToGenerateSummaryCheckConversations => 'Zusammenfassung konnte nicht erstellt werden. Stellen Sie sicher, dass Sie Gespräche für diesen Tag haben.';
 
   @override
   String get summaryNotFound => 'Zusammenfassung nicht gefunden';
@@ -4734,8 +4609,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Export gestartet. Dies kann einige Sekunden dauern...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Dies löscht alle abgeleiteten Wissensgraph-Daten (Knoten und Verbindungen). Ihre ursprünglichen Erinnerungen bleiben sicher. Der Graph wird im Laufe der Zeit oder bei der nächsten Anfrage neu erstellt.';
+  String get knowledgeGraphDeleteDescription => 'Dies löscht alle abgeleiteten Wissensgraph-Daten (Knoten und Verbindungen). Ihre ursprünglichen Erinnerungen bleiben sicher. Der Graph wird im Laufe der Zeit oder bei der nächsten Anfrage neu erstellt.';
 
   @override
   String get configureDailySummaryDigest => 'Konfigurieren Sie Ihre tägliche Aufgabenübersicht';
@@ -4805,8 +4679,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Alle Limitless-Gespräche löschen?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Dies löscht dauerhaft alle von Limitless importierten Gespräche. Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get deleteAllLimitlessWarning => 'Dies löscht dauerhaft alle von Limitless importierten Gespräche. Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4862,8 +4735,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get howItWorksTitle => 'Wie funktioniert es?';
 
   @override
-  String get howPeopleWorks =>
-      'Sobald eine Person erstellt wurde, können Sie zum Gesprächstranskript gehen und ihr die entsprechenden Segmente zuweisen, so kann Omi auch ihre Sprache erkennen!';
+  String get howPeopleWorks => 'Sobald eine Person erstellt wurde, können Sie zum Gesprächstranskript gehen und ihr die entsprechenden Segmente zuweisen, so kann Omi auch ihre Sprache erkennen!';
 
   @override
   String get tapToDelete => 'Tippen zum Löschen';
@@ -4889,8 +4761,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get privacyNotice => 'Datenschutzhinweis';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Aufnahmen können die Stimmen anderer erfassen. Stellen Sie sicher, dass Sie die Zustimmung aller Teilnehmer haben, bevor Sie aktivieren.';
+  String get recordingsMayCaptureOthers => 'Aufnahmen können die Stimmen anderer erfassen. Stellen Sie sicher, dass Sie die Zustimmung aller Teilnehmer haben, bevor Sie aktivieren.';
 
   @override
   String get enable => 'Aktivieren';
@@ -4902,8 +4773,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Bewahren Sie alle Audioaufnahmen lokal auf Ihrem Telefon auf. Bei Deaktivierung werden nur fehlgeschlagene Uploads gespeichert, um Speicherplatz zu sparen.';
+  String get storeAudioDescription => 'Bewahren Sie alle Audioaufnahmen lokal auf Ihrem Telefon auf. Bei Deaktivierung werden nur fehlgeschlagene Uploads gespeichert, um Speicherplatz zu sparen.';
 
   @override
   String get enableLocalStorage => 'Lokalen Speicher aktivieren';
@@ -4921,12 +4791,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get storeAudioOnCloud => 'Audio in der Cloud speichern';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Ihre Echtzeit-Aufnahmen werden während des Sprechens in einem privaten Cloud-Speicher gespeichert.';
+  String get cloudStorageDialogMessage => 'Ihre Echtzeit-Aufnahmen werden während des Sprechens in einem privaten Cloud-Speicher gespeichert.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Speichern Sie Ihre Echtzeit-Aufnahmen während des Sprechens in einem privaten Cloud-Speicher. Audio wird in Echtzeit erfasst und sicher gespeichert.';
+  String get storeAudioCloudDescription => 'Speichern Sie Ihre Echtzeit-Aufnahmen während des Sprechens in einem privaten Cloud-Speicher. Audio wird in Echtzeit erfasst und sicher gespeichert.';
 
   @override
   String get downloadingFirmware => 'Firmware wird heruntergeladen';
@@ -4935,8 +4803,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get installingFirmware => 'Firmware wird installiert';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Schließen Sie die App nicht und schalten Sie das Gerät nicht aus. Dies könnte Ihr Gerät beschädigen.';
+  String get firmwareUpdateWarning => 'Schließen Sie die App nicht und schalten Sie das Gerät nicht aus. Dies könnte Ihr Gerät beschädigen.';
 
   @override
   String get firmwareUpdated => 'Firmware aktualisiert';
@@ -4980,8 +4847,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get payments => 'Zahlungen';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Verbinden Sie unten eine Zahlungsmethode, um Auszahlungen für Ihre Apps zu erhalten.';
+  String get connectPaymentMethodInfo => 'Verbinden Sie unten eine Zahlungsmethode, um Auszahlungen für Ihre Apps zu erhalten.';
 
   @override
   String get selectedPaymentMethod => 'Ausgewählte Zahlungsmethode';
@@ -5008,8 +4874,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get monthlyPayouts => 'Monatliche Auszahlungen';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Erhalten Sie monatliche Zahlungen direkt auf Ihr Konto, wenn Sie 10 \$ Einnahmen erreichen';
+  String get monthlyPayoutsDescription => 'Erhalten Sie monatliche Zahlungen direkt auf Ihr Konto, wenn Sie 10 \$ Einnahmen erreichen';
 
   @override
   String get secureAndReliable => 'Sicher und zuverlässig';
@@ -5036,8 +4901,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get connectingYourStripeAccount => 'Verbindung Ihres Stripe-Kontos';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Bitte schließen Sie den Stripe-Onboarding-Prozess in Ihrem Browser ab. Diese Seite wird automatisch aktualisiert, sobald der Vorgang abgeschlossen ist.';
+  String get stripeOnboardingInstructions => 'Bitte schließen Sie den Stripe-Onboarding-Prozess in Ihrem Browser ab. Diese Seite wird automatisch aktualisiert, sobald der Vorgang abgeschlossen ist.';
 
   @override
   String get failedTryAgain => 'Fehlgeschlagen? Erneut versuchen';
@@ -5049,15 +4913,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get successfullyConnected => 'Erfolgreich verbunden!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Ihr Stripe-Konto ist jetzt bereit, Zahlungen zu empfangen. Sie können sofort mit dem Verdienen aus Ihren App-Verkäufen beginnen.';
+  String get stripeReadyForPayments => 'Ihr Stripe-Konto ist jetzt bereit, Zahlungen zu empfangen. Sie können sofort mit dem Verdienen aus Ihren App-Verkäufen beginnen.';
 
   @override
   String get updateStripeDetails => 'Stripe-Details aktualisieren';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Fehler beim Aktualisieren der Stripe-Details! Bitte versuchen Sie es später erneut.';
+  String get errorUpdatingStripeDetails => 'Fehler beim Aktualisieren der Stripe-Details! Bitte versuchen Sie es später erneut.';
 
   @override
   String get updatePayPal => 'PayPal aktualisieren';
@@ -5078,8 +4940,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me-Link';
 
   @override
-  String get stripeRecommendation =>
-      'Wenn Stripe in Ihrem Land verfügbar ist, empfehlen wir dringend, es für schnellere und einfachere Auszahlungen zu verwenden.';
+  String get stripeRecommendation => 'Wenn Stripe in Ihrem Land verfügbar ist, empfehlen wir dringend, es für schnellere und einfachere Auszahlungen zu verwenden.';
 
   @override
   String get updatePayPalDetails => 'PayPal-Details aktualisieren';
@@ -5131,12 +4992,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Zusätzliche Sprachprobe entfernt';
 
   @override
-  String get consentDataMessage =>
-      'Durch Fortfahren werden Ihre Gespräche, Aufnahmen und persönlichen Daten sicher auf unseren Servern gespeichert. Ihre Audioaufnahmen und Transkripte werden von KI-Diensten Dritter verarbeitet (einschließlich Deepgram für die Transkription und OpenAI für die Analyse), um Ihnen KI-gestützte Erkenntnisse zu liefern und alle App-Funktionen zu ermöglichen.';
+  String get consentDataMessage => 'Durch Fortfahren werden Ihre Gespräche, Aufnahmen und persönlichen Daten sicher auf unseren Servern gespeichert. Ihre Audioaufnahmen und Transkripte werden von KI-Diensten Dritter verarbeitet (einschließlich Deepgram für die Transkription und OpenAI für die Analyse), um Ihnen KI-gestützte Erkenntnisse zu liefern und alle App-Funktionen zu ermöglichen.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Aufgaben aus Ihren Gesprächen werden hier angezeigt.\nTippen Sie auf +, um eine manuell zu erstellen.';
+  String get tasksEmptyStateMessage => 'Aufgaben aus Ihren Gesprächen werden hier angezeigt.\nTippen Sie auf +, um eine manuell zu erstellen.';
 
   @override
   String get clearChatAction => 'Chat löschen';
@@ -5172,15 +5031,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Installiere Omi auf deiner\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Um deine Apple Watch mit Omi zu verwenden, musst du zuerst die Omi-App auf deiner Uhr installieren.';
+  String get installOmiOnAppleWatchDescription => 'Um deine Apple Watch mit Omi zu verwenden, musst du zuerst die Omi-App auf deiner Uhr installieren.';
 
   @override
   String get openOmiOnAppleWatch => 'Öffne Omi auf deiner\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Die Omi-App ist auf deiner Apple Watch installiert. Öffne sie und tippe auf Start.';
+  String get openOmiOnAppleWatchDescription => 'Die Omi-App ist auf deiner Apple Watch installiert. Öffne sie und tippe auf Start.';
 
   @override
   String get openWatchApp => 'Watch-App öffnen';
@@ -5189,15 +5046,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Ich habe die App installiert und geöffnet';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch-App konnte nicht geöffnet werden. Öffne die Watch-App manuell auf deiner Apple Watch und installiere Omi aus dem Bereich \"Verfügbare Apps\".';
+  String get unableToOpenWatchApp => 'Apple Watch-App konnte nicht geöffnet werden. Öffne die Watch-App manuell auf deiner Apple Watch und installiere Omi aus dem Bereich \"Verfügbare Apps\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch erfolgreich verbunden!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch ist noch nicht erreichbar. Stelle sicher, dass die Omi-App auf deiner Uhr geöffnet ist.';
+  String get appleWatchNotReachable => 'Apple Watch ist noch nicht erreichbar. Stelle sicher, dass die Omi-App auf deiner Uhr geöffnet ist.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5214,8 +5069,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get finishedConversation => 'Gespräch beendet?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Möchtest du die Aufnahme wirklich beenden und das Gespräch jetzt zusammenfassen?';
+  String get stopRecordingConfirmation => 'Möchtest du die Aufnahme wirklich beenden und das Gespräch jetzt zusammenfassen?';
 
   @override
   String get conversationEndsManually => 'Das Gespräch endet nur manuell.';
@@ -5626,30 +5480,25 @@ class AppLocalizationsDe extends AppLocalizations {
   String get multipleSpeakersDetected => 'Mehrere Sprecher erkannt';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Es scheint, dass mehrere Sprecher in der Aufnahme sind. Stellen Sie sicher, dass Sie an einem ruhigen Ort sind, und versuchen Sie es erneut.';
+  String get multipleSpeakersDescription => 'Es scheint, dass mehrere Sprecher in der Aufnahme sind. Stellen Sie sicher, dass Sie an einem ruhigen Ort sind, und versuchen Sie es erneut.';
 
   @override
   String get invalidRecordingDetected => 'Ungültige Aufnahme erkannt';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Es wurde nicht genug Sprache erkannt. Bitte sprechen Sie mehr und versuchen Sie es erneut.';
+  String get notEnoughSpeechDescription => 'Es wurde nicht genug Sprache erkannt. Bitte sprechen Sie mehr und versuchen Sie es erneut.';
 
   @override
-  String get speechDurationDescription =>
-      'Stellen Sie sicher, dass Sie mindestens 5 Sekunden und nicht mehr als 90 sprechen.';
+  String get speechDurationDescription => 'Stellen Sie sicher, dass Sie mindestens 5 Sekunden und nicht mehr als 90 sprechen.';
 
   @override
-  String get connectionLostDescription =>
-      'Die Verbindung wurde unterbrochen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
+  String get connectionLostDescription => 'Die Verbindung wurde unterbrochen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
 
   @override
   String get howToTakeGoodSample => 'Wie macht man eine gute Probe?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Stellen Sie sicher, dass Sie an einem ruhigen Ort sind.\n2. Sprechen Sie klar und natürlich.\n3. Stellen Sie sicher, dass Ihr Gerät in seiner natürlichen Position an Ihrem Hals ist.\n\nSobald es erstellt ist, können Sie es jederzeit verbessern oder erneut machen.';
+  String get goodSampleInstructions => '1. Stellen Sie sicher, dass Sie an einem ruhigen Ort sind.\n2. Sprechen Sie klar und natürlich.\n3. Stellen Sie sicher, dass Ihr Gerät in seiner natürlichen Position an Ihrem Hals ist.\n\nSobald es erstellt ist, können Sie es jederzeit verbessern oder erneut machen.';
 
   @override
   String get noDeviceConnectedUseMic => 'Kein Gerät verbunden. Das Telefonmikrofon wird verwendet.';
@@ -5712,12 +5561,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get howItWorks => 'So funktioniert es';
 
   @override
-  String get dailyScoreExplanation =>
-      'Ihr täglicher Score basiert auf der Aufgabenerledigung. Erledigen Sie Ihre Aufgaben, um Ihren Score zu verbessern!';
+  String get dailyScoreExplanation => 'Ihr täglicher Score basiert auf der Aufgabenerledigung. Erledigen Sie Ihre Aufgaben, um Ihren Score zu verbessern!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Steuern Sie, wie oft Omi Ihnen proaktive Benachrichtigungen und Erinnerungen sendet.';
+  String get notificationFrequencyDescription => 'Steuern Sie, wie oft Omi Ihnen proaktive Benachrichtigungen und Erinnerungen sendet.';
 
   @override
   String get sliderOff => 'Aus';
@@ -5731,8 +5578,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Zusammenfassung konnte nicht erstellt werden. Stellen Sie sicher, dass Sie Gespräche für diesen Tag haben.';
+  String get failedToGenerateSummary => 'Zusammenfassung konnte nicht erstellt werden. Stellen Sie sicher, dass Sie Gespräche für diesen Tag haben.';
 
   @override
   String get recap => 'Rückblick';
@@ -5811,8 +5657,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get selectApp => 'App auswählen';
 
   @override
-  String get noChatAppsEnabled =>
-      'Keine Chat-Apps aktiviert.\nTippen Sie auf \"Apps aktivieren\" um welche hinzuzufügen.';
+  String get noChatAppsEnabled => 'Keine Chat-Apps aktiviert.\nTippen Sie auf \"Apps aktivieren\" um welche hinzuzufügen.';
 
   @override
   String get disable => 'Deaktivieren';
@@ -5895,8 +5740,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deviceNoFastTransfer => 'Gerät unterstützt keine Schnellübertragung';
 
   @override
-  String get enableHotspotMessage =>
-      'Bitte aktiviere den WLAN-Hotspot auf deinem Telefon, damit sich das Omi-Gerät verbinden kann.';
+  String get enableHotspotMessage => 'Bitte aktiviere den WLAN-Hotspot auf deinem Telefon, damit sich das Omi-Gerät verbinden kann.';
 
   @override
   String get transferStartFailed => 'Übertragungsstart fehlgeschlagen';
@@ -5965,8 +5809,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get recordings => 'Aufnahmen';
 
   @override
-  String get enableRemindersAccess =>
-      'Bitte aktivieren Sie den Zugriff auf Erinnerungen in den Einstellungen, um Apple Erinnerungen zu verwenden';
+  String get enableRemindersAccess => 'Bitte aktivieren Sie den Zugriff auf Erinnerungen in den Einstellungen, um Apple Erinnerungen zu verwenden';
 
   @override
   String todayAtTime(String time) {
@@ -6000,8 +5843,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get summarizingConversation => 'Unterhaltung wird zusammengefasst...\nDies kann einige Sekunden dauern';
 
   @override
-  String get resummarizingConversation =>
-      'Unterhaltung wird erneut zusammengefasst...\nDies kann einige Sekunden dauern';
+  String get resummarizingConversation => 'Unterhaltung wird erneut zusammengefasst...\nDies kann einige Sekunden dauern';
 
   @override
   String get nothingInterestingRetry => 'Nichts Interessantes gefunden,\nmöchten Sie es erneut versuchen?';
@@ -6096,15 +5938,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cloudProvider => 'Cloud-Anbieter';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 Premium-Minuten/Monat. Der Tab Auf Gerät bietet unbegrenzte kostenlose Transkription.';
+  String get premiumMinutesInfo => '1.200 Premium-Minuten/Monat. Der Tab Auf Gerät bietet unbegrenzte kostenlose Transkription.';
 
   @override
   String get viewUsage => 'Nutzung anzeigen';
 
   @override
-  String get localProcessingInfo =>
-      'Audio wird lokal verarbeitet. Funktioniert offline, privater, verbraucht aber mehr Akku.';
+  String get localProcessingInfo => 'Audio wird lokal verarbeitet. Funktioniert offline, privater, verbraucht aber mehr Akku.';
 
   @override
   String get model => 'Modell';
@@ -6113,15 +5953,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get performanceWarning => 'Leistungswarnung';
 
   @override
-  String get largeModelWarning =>
-      'Dieses Modell ist groß und kann die App zum Absturz bringen oder sehr langsam laufen.\n\nsmall oder base wird empfohlen.';
+  String get largeModelWarning => 'Dieses Modell ist groß und kann die App zum Absturz bringen oder sehr langsam laufen.\n\nsmall oder base wird empfohlen.';
 
   @override
   String get usingNativeIosSpeech => 'Verwende native iOS-Spracherkennung';
 
   @override
-  String get noModelDownloadRequired =>
-      'Die native Sprach-Engine Ihres Geräts wird verwendet. Kein Modell-Download erforderlich.';
+  String get noModelDownloadRequired => 'Die native Sprach-Engine Ihres Geräts wird verwendet. Kein Modell-Download erforderlich.';
 
   @override
   String get modelReady => 'Modell bereit';
@@ -6166,8 +6004,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Gerät nicht kompatibel';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'Ihr Gerät erfüllt nicht die Anforderungen für die Transkription auf dem Gerät.';
+  String get deviceNotMeetRequirements => 'Ihr Gerät erfüllt nicht die Anforderungen für die Transkription auf dem Gerät.';
 
   @override
   String get transcriptionSlowerOnDevice => 'Die Transkription auf dem Gerät kann auf diesem Gerät langsamer sein.';
@@ -6179,12 +6016,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get batteryDrainSignificantly => 'Der Batterieverbrauch wird deutlich steigen.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 Premium-Minuten/Monat. Der Tab Auf Gerät bietet unbegrenzte kostenlose Transkription. ';
+  String get premiumMinutesMonth => '1.200 Premium-Minuten/Monat. Der Tab Auf Gerät bietet unbegrenzte kostenlose Transkription. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Audio wird lokal verarbeitet. Funktioniert offline, privater, verbraucht aber mehr Batterie.';
+  String get audioProcessedLocally => 'Audio wird lokal verarbeitet. Funktioniert offline, privater, verbraucht aber mehr Batterie.';
 
   @override
   String get languageLabel => 'Sprache';
@@ -6193,12 +6028,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get modelLabel => 'Modell';
 
   @override
-  String get modelTooLargeWarning =>
-      'Dieses Modell ist groß und kann zum Absturz der App führen oder sehr langsam auf mobilen Geräten laufen.\n\nsmall oder base wird empfohlen.';
+  String get modelTooLargeWarning => 'Dieses Modell ist groß und kann zum Absturz der App führen oder sehr langsam auf mobilen Geräten laufen.\n\nsmall oder base wird empfohlen.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Die native Sprach-Engine Ihres Geräts wird verwendet. Kein Modell-Download erforderlich.';
+  String get nativeEngineNoDownload => 'Die native Sprach-Engine Ihres Geräts wird verwendet. Kein Modell-Download erforderlich.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6234,8 +6067,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omis integrierte Live-Transkription ist für Echtzeitgespräche mit automatischer Sprechererkennung und Diarisierung optimiert.';
+  String get omiTranscriptionOptimized => 'Omis integrierte Live-Transkription ist für Echtzeitgespräche mit automatischer Sprechererkennung und Diarisierung optimiert.';
 
   @override
   String get reset => 'Zurücksetzen';
@@ -6455,8 +6287,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Wissensgraph wird aus Erinnerungen erstellt...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Ihr Wissensgraph wird automatisch erstellt, wenn Sie neue Erinnerungen anlegen.';
+  String get knowledgeGraphWillBuildAutomatically => 'Ihr Wissensgraph wird automatisch erstellt, wenn Sie neue Erinnerungen anlegen.';
 
   @override
   String get buildGraphButton => 'Graph erstellen';
@@ -6692,8 +6523,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get failedToLoadContacts => 'Kontakte konnten nicht geladen werden';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Gespräch konnte nicht zum Teilen vorbereitet werden. Bitte versuchen Sie es erneut.';
+  String get failedToPrepareConversationForSharing => 'Gespräch konnte nicht zum Teilen vorbereitet werden. Bitte versuchen Sie es erneut.';
 
   @override
   String get couldNotOpenSmsApp => 'SMS-App konnte nicht geöffnet werden. Bitte versuchen Sie es erneut.';
@@ -6759,8 +6589,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Audio von der SD-Karte deines Geräts wird heruntergeladen';
 
   @override
-  String get transferRequiredDescription =>
-      'Bitte übertrage die Dateien vom Gerät, um die SD-Karten-Einstellungen zu ändern.';
+  String get transferRequiredDescription => 'Bitte übertrage die Dateien vom Gerät, um die SD-Karten-Einstellungen zu ändern.';
 
   @override
   String get cancelTransfer => 'Übertragung abbrechen';
@@ -6840,15 +6669,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get enableFastTransfer => 'Schnelle Übertragung aktivieren';
 
   @override
-  String get fastTransferDescription =>
-      'Die schnelle Übertragung nutzt WLAN für ~5x schnellere Geschwindigkeiten. Ihr Telefon verbindet sich während der Übertragung vorübergehend mit dem WLAN-Netzwerk Ihres Omi-Geräts.';
+  String get fastTransferDescription => 'Die schnelle Übertragung nutzt WLAN für ~5x schnellere Geschwindigkeiten. Ihr Telefon verbindet sich während der Übertragung vorübergehend mit dem WLAN-Netzwerk Ihres Omi-Geräts.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Der Internetzugang wird während der Übertragung unterbrochen';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Wählen Sie, wie Aufnahmen von Ihrem Omi-Gerät auf Ihr Telefon übertragen werden.';
+  String get chooseTransferMethodDescription => 'Wählen Sie, wie Aufnahmen von Ihrem Omi-Gerät auf Ihr Telefon übertragen werden.';
 
   @override
   String get wifiSpeed => '~150 KB/s über WLAN';
@@ -6857,8 +6684,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fiveTimesFaster => '5X SCHNELLER';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Erstellt eine direkte WLAN-Verbindung zu Ihrem Omi-Gerät. Ihr Telefon trennt sich während der Übertragung vorübergehend von Ihrem normalen WLAN.';
+  String get fastTransferMethodDescription => 'Erstellt eine direkte WLAN-Verbindung zu Ihrem Omi-Gerät. Ihr Telefon trennt sich während der Übertragung vorübergehend von Ihrem normalen WLAN.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6867,8 +6693,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get bleSpeed => '~30 KB/s über BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Verwendet Standard-Bluetooth-Low-Energy-Verbindung. Langsamer, beeinträchtigt aber nicht Ihre WLAN-Verbindung.';
+  String get bluetoothMethodDescription => 'Verwendet Standard-Bluetooth-Low-Energy-Verbindung. Langsamer, beeinträchtigt aber nicht Ihre WLAN-Verbindung.';
 
   @override
   String get selected => 'Ausgewählt';
@@ -6906,12 +6731,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appDeleteFailed => 'App konnte nicht gelöscht werden. Bitte versuche es später erneut.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'App-Sichtbarkeit erfolgreich geändert. Es kann einige Minuten dauern, bis die Änderung wirksam wird.';
+  String get appVisibilityChangedSuccessfully => 'App-Sichtbarkeit erfolgreich geändert. Es kann einige Minuten dauern, bis die Änderung wirksam wird.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Fehler beim Aktivieren der App. Falls es sich um eine Integrations-App handelt, stelle sicher, dass die Einrichtung abgeschlossen ist.';
+  String get errorActivatingAppIntegration => 'Fehler beim Aktivieren der App. Falls es sich um eine Integrations-App handelt, stelle sicher, dass die Einrichtung abgeschlossen ist.';
 
   @override
   String get errorUpdatingAppStatus => 'Beim Aktualisieren des App-Status ist ein Fehler aufgetreten.';
@@ -6979,8 +6802,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get importantConversationTitle => 'Wichtiges Gespräch';
 
   @override
-  String get importantConversationBody =>
-      'Du hattest gerade ein wichtiges Gespräch. Tippe, um die Zusammenfassung zu teilen.';
+  String get importantConversationBody => 'Du hattest gerade ein wichtiges Gespräch. Tippe, um die Zusammenfassung zu teilen.';
 
   @override
   String get templateName => 'Vorlagenname';
@@ -6992,8 +6814,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Der Name muss mindestens 3 Zeichen haben';
 
   @override
-  String get conversationPromptHint =>
-      'z.B. Extrahieren Sie Aktionspunkte, getroffene Entscheidungen und wichtige Erkenntnisse aus dem Gespräch.';
+  String get conversationPromptHint => 'z.B. Extrahieren Sie Aktionspunkte, getroffene Entscheidungen und wichtige Erkenntnisse aus dem Gespräch.';
 
   @override
   String get pleaseEnterAppPrompt => 'Bitte geben Sie eine Aufforderung für Ihre App ein';
@@ -7026,12 +6847,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get failedToCreateApp => 'App konnte nicht erstellt werden. Bitte versuchen Sie es erneut.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'Bitte wählen Sie eine weitere Kernfähigkeit für Ihre App aus, um fortzufahren';
+  String get addAppSelectCoreCapability => 'Bitte wählen Sie eine weitere Kernfähigkeit für Ihre App aus, um fortzufahren';
 
   @override
-  String get addAppSelectPaymentPlan =>
-      'Bitte wählen Sie einen Zahlungsplan und geben Sie einen Preis für Ihre App ein';
+  String get addAppSelectPaymentPlan => 'Bitte wählen Sie einen Zahlungsplan und geben Sie einen Preis für Ihre App ein';
 
   @override
   String get addAppSelectCapability => 'Bitte wählen Sie mindestens eine Fähigkeit für Ihre App aus';
@@ -7097,16 +6916,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get addAppPersonaConflictWithCapabilities => 'Persona kann nicht mit anderen Fähigkeiten ausgewählt werden';
 
   @override
-  String get paymentFailedToFetchCountries =>
-      'Unterstützte Länder konnten nicht abgerufen werden. Bitte versuchen Sie es später erneut.';
+  String get paymentFailedToFetchCountries => 'Unterstützte Länder konnten nicht abgerufen werden. Bitte versuchen Sie es später erneut.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Standard-Zahlungsmethode konnte nicht festgelegt werden. Bitte versuchen Sie es später erneut.';
+  String get paymentFailedToSetDefault => 'Standard-Zahlungsmethode konnte nicht festgelegt werden. Bitte versuchen Sie es später erneut.';
 
   @override
-  String get paymentFailedToSavePaypal =>
-      'PayPal-Details konnten nicht gespeichert werden. Bitte versuchen Sie es später erneut.';
+  String get paymentFailedToSavePaypal => 'PayPal-Details konnten nicht gespeichert werden. Bitte versuchen Sie es später erneut.';
 
   @override
   String get paypalEmailHint => 'nik@example.com';
@@ -7185,8 +7001,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade geplant! Dein Monatsplan läuft bis zum Ende deines Abrechnungszeitraums weiter und wechselt dann automatisch zum Jahresplan.';
+  String get planUpgradeScheduledMessage => 'Upgrade geplant! Dein Monatsplan läuft bis zum Ende deines Abrechnungszeitraums weiter und wechselt dann automatisch zum Jahresplan.';
 
   @override
   String get couldNotSchedulePlanChange => 'Die Planänderung konnte nicht geplant werden. Bitte versuche es erneut.';
@@ -7315,8 +7130,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get successfullyConnectedGoogleTasks => 'Erfolgreich mit Google Tasks verbunden!';
 
   @override
-  String get failedToConnectGoogleTasksRetry =>
-      'Verbindung zu Google Tasks fehlgeschlagen. Bitte versuchen Sie es erneut.';
+  String get failedToConnectGoogleTasksRetry => 'Verbindung zu Google Tasks fehlgeschlagen. Bitte versuchen Sie es erneut.';
 
   @override
   String get successfullyConnectedClickUp => 'Erfolgreich mit ClickUp verbunden!';
@@ -7358,12 +7172,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authFailedToSignInWithApple => 'Anmeldung mit Apple fehlgeschlagen, bitte versuchen Sie es erneut.';
 
   @override
-  String get authFailedToRetrieveToken =>
-      'Firebase-Token konnte nicht abgerufen werden, bitte versuchen Sie es erneut.';
+  String get authFailedToRetrieveToken => 'Firebase-Token konnte nicht abgerufen werden, bitte versuchen Sie es erneut.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Unerwarteter Fehler bei der Anmeldung, Firebase-Fehler, bitte versuchen Sie es erneut.';
+  String get authUnexpectedErrorFirebase => 'Unerwarteter Fehler bei der Anmeldung, Firebase-Fehler, bitte versuchen Sie es erneut.';
 
   @override
   String get authUnexpectedError => 'Unerwarteter Fehler bei der Anmeldung, bitte versuchen Sie es erneut';
@@ -7375,12 +7187,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authFailedToLinkApple => 'Verknüpfung mit Apple fehlgeschlagen, bitte versuchen Sie es erneut.';
 
   @override
-  String get onboardingBluetoothRequired =>
-      'Bluetooth-Berechtigung ist erforderlich, um sich mit Ihrem Gerät zu verbinden.';
+  String get onboardingBluetoothRequired => 'Bluetooth-Berechtigung ist erforderlich, um sich mit Ihrem Gerät zu verbinden.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth-Berechtigung verweigert. Bitte erteilen Sie die Berechtigung in den Systemeinstellungen.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth-Berechtigung verweigert. Bitte erteilen Sie die Berechtigung in den Systemeinstellungen.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7393,12 +7203,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Benachrichtigungsberechtigung verweigert. Bitte erteilen Sie die Berechtigung in den Systemeinstellungen.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Benachrichtigungsberechtigung verweigert. Bitte erteilen Sie die Berechtigung in den Systemeinstellungen.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Benachrichtigungsberechtigung verweigert. Bitte erteilen Sie die Berechtigung in Systemeinstellungen > Mitteilungen.';
+  String get onboardingNotificationDeniedNotifications => 'Benachrichtigungsberechtigung verweigert. Bitte erteilen Sie die Berechtigung in Systemeinstellungen > Mitteilungen.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7411,15 +7219,13 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Bitte erteilen Sie die Standortberechtigung in Einstellungen > Datenschutz & Sicherheit > Ortungsdienste';
+  String get onboardingLocationGrantInSettings => 'Bitte erteilen Sie die Standortberechtigung in Einstellungen > Datenschutz & Sicherheit > Ortungsdienste';
 
   @override
   String get onboardingMicrophoneRequired => 'Mikrofonberechtigung ist für die Aufnahme erforderlich.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofonberechtigung verweigert. Bitte erteilen Sie die Berechtigung in Systemeinstellungen > Datenschutz & Sicherheit > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Mikrofonberechtigung verweigert. Bitte erteilen Sie die Berechtigung in Systemeinstellungen > Datenschutz & Sicherheit > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7432,12 +7238,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Bildschirmaufnahme-Berechtigung ist für die Systemtonaufnahme erforderlich.';
+  String get onboardingScreenCaptureRequired => 'Bildschirmaufnahme-Berechtigung ist für die Systemtonaufnahme erforderlich.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Bildschirmaufnahme-Berechtigung verweigert. Bitte erteilen Sie die Berechtigung in Systemeinstellungen > Datenschutz & Sicherheit > Bildschirmaufnahme.';
+  String get onboardingScreenCaptureDenied => 'Bildschirmaufnahme-Berechtigung verweigert. Bitte erteilen Sie die Berechtigung in Systemeinstellungen > Datenschutz & Sicherheit > Bildschirmaufnahme.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7450,8 +7254,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Bedienungshilfen-Berechtigung ist erforderlich, um Browser-Meetings zu erkennen.';
+  String get onboardingAccessibilityRequired => 'Bedienungshilfen-Berechtigung ist erforderlich, um Browser-Meetings zu erkennen.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7467,8 +7270,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get msgCameraNotAvailable => 'Kameraaufnahme ist auf dieser Plattform nicht verfügbar';
 
   @override
-  String get msgCameraPermissionDenied =>
-      'Kameraberechtigung verweigert. Bitte erlauben Sie den Zugriff auf die Kamera';
+  String get msgCameraPermissionDenied => 'Kameraberechtigung verweigert. Bitte erlauben Sie den Zugriff auf die Kamera';
 
   @override
   String msgCameraAccessError(String error) {
@@ -7492,8 +7294,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Fotos-Berechtigung verweigert. Bitte erlauben Sie den Zugriff auf Fotos, um Bilder auszuwählen';
+  String get msgPhotosPermissionDenied => 'Fotos-Berechtigung verweigert. Bitte erlauben Sie den Zugriff auf Fotos, um Bilder auszuwählen';
 
   @override
   String get msgSelectImagesGenericError => 'Fehler beim Auswählen von Bildern. Bitte versuchen Sie es erneut.';
@@ -7535,8 +7336,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Mikrofonberechtigung erforderlich';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Mikrofonberechtigung in den Systemeinstellungen erteilen';
+  String get captureMicrophonePermissionInSystemPreferences => 'Mikrofonberechtigung in den Systemeinstellungen erteilen';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Bildschirmaufnahme-Berechtigung erforderlich';
@@ -7566,8 +7366,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get locationPermissionRequired => 'Standortberechtigung erforderlich';
 
   @override
-  String get locationPermissionContent =>
-      'Schnelltransfer benötigt die Standortberechtigung, um die WLAN-Verbindung zu überprüfen. Bitte erteilen Sie die Standortberechtigung, um fortzufahren.';
+  String get locationPermissionContent => 'Schnelltransfer benötigt die Standortberechtigung, um die WLAN-Verbindung zu überprüfen. Bitte erteilen Sie die Standortberechtigung, um fortzufahren.';
 
   @override
   String get pdfTranscriptExport => 'Transkript-Export';
@@ -7730,8 +7529,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Gerät unterstützt keine WiFi-Synchronisierung, Wechsel zu Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Gerät unterstützt keine WiFi-Synchronisierung, Wechsel zu Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health ist auf diesem Gerät nicht verfügbar';
@@ -8000,8 +7798,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audioPlaybackUnavailable => 'Audiodatei ist nicht zur Wiedergabe verfügbar';
 
   @override
-  String get audioPlaybackFailed =>
-      'Audio kann nicht abgespielt werden. Die Datei ist möglicherweise beschädigt oder fehlt.';
+  String get audioPlaybackFailed => 'Audio kann nicht abgespielt werden. Die Datei ist möglicherweise beschädigt oder fehlt.';
 
   @override
   String get connectionGuide => 'Verbindungsanleitung';
@@ -8028,8 +7825,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Omi DevKit in den Kopplungsmodus versetzen';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Drücken Sie die Taste einmal zum Einschalten. Die LED blinkt lila im Kopplungsmodus.';
+  String get pairingDescOmiDevkit => 'Drücken Sie die Taste einmal zum Einschalten. Die LED blinkt lila im Kopplungsmodus.';
 
   @override
   String get pairingTitleOmiGlass => 'Omi Glass einschalten';
@@ -8041,8 +7837,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note in den Kopplungsmodus versetzen';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Halten Sie die Seitentaste 2 Sekunden gedrückt. Die rote LED blinkt, wenn das Gerät kopplungsbereit ist.';
+  String get pairingDescPlaudNote => 'Halten Sie die Seitentaste 2 Sekunden gedrückt. Die rote LED blinkt, wenn das Gerät kopplungsbereit ist.';
 
   @override
   String get pairingTitleBee => 'Bee in den Kopplungsmodus versetzen';
@@ -8054,15 +7849,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pairingTitleLimitless => 'Limitless in den Kopplungsmodus versetzen';
 
   @override
-  String get pairingDescLimitless =>
-      'Wenn ein Licht sichtbar ist, drücken Sie einmal und halten Sie dann gedrückt, bis das Gerät ein rosa Licht zeigt, dann loslassen.';
+  String get pairingDescLimitless => 'Wenn ein Licht sichtbar ist, drücken Sie einmal und halten Sie dann gedrückt, bis das Gerät ein rosa Licht zeigt, dann loslassen.';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant in den Kopplungsmodus versetzen';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Drücken Sie den Knopf am Anhänger, um ihn einzuschalten. Er wechselt automatisch in den Kopplungsmodus.';
+  String get pairingDescFriendPendant => 'Drücken Sie den Knopf am Anhänger, um ihn einzuschalten. Er wechselt automatisch in den Kopplungsmodus.';
 
   @override
   String get pairingTitleFieldy => 'Fieldy in den Kopplungsmodus versetzen';
@@ -8074,15 +7867,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch verbinden';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Installieren und öffnen Sie die Omi-App auf Ihrer Apple Watch und tippen Sie dann auf Verbinden in der App.';
+  String get pairingDescAppleWatch => 'Installieren und öffnen Sie die Omi-App auf Ihrer Apple Watch und tippen Sie dann auf Verbinden in der App.';
 
   @override
   String get pairingTitleNeoOne => 'Neo One in den Kopplungsmodus versetzen';
 
   @override
-  String get pairingDescNeoOne =>
-      'Halten Sie die Ein-/Aus-Taste gedrückt, bis die LED blinkt. Das Gerät wird erkennbar sein.';
+  String get pairingDescNeoOne => 'Halten Sie die Ein-/Aus-Taste gedrückt, bis die LED blinkt. Das Gerät wird erkennbar sein.';
 
   @override
   String get downloadingFromDevice => 'Wird vom Gerät heruntergeladen';
@@ -8152,8 +7943,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get wifiConfiguration => 'WLAN-Konfiguration';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Geben Sie Ihre WLAN-Zugangsdaten ein, damit das Gerät die Firmware herunterladen kann.';
+  String get wifiConfigurationSubtitle => 'Geben Sie Ihre WLAN-Zugangsdaten ein, damit das Gerät die Firmware herunterladen kann.';
 
   @override
   String get networkNameSsid => 'Netzwerkname (SSID)';
@@ -8171,8 +7961,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Das weiß ich über dich';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Diese Karte wird aktualisiert, wenn Omi aus Ihren Gesprächen lernt.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Diese Karte wird aktualisiert, wenn Omi aus Ihren Gesprächen lernt.';
 
   @override
   String get apiEnvironment => 'API-Umgebung';
@@ -8201,12 +7990,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get switchAndRestart => 'Wechseln';
 
   @override
-  String get stagingDisclaimer =>
-      'Die Testumgebung kann instabil sein, inkonsistente Leistung aufweisen und Daten können verloren gehen. Nur zum Testen.';
+  String get stagingDisclaimer => 'Die Testumgebung kann instabil sein, inkonsistente Leistung aufweisen und Daten können verloren gehen. Nur zum Testen.';
 
   @override
-  String get apiEnvSavedRestartRequired =>
-      'Gespeichert. Schließen und öffnen Sie die App erneut, um die Änderungen anzuwenden.';
+  String get apiEnvSavedRestartRequired => 'Gespeichert. Schließen und öffnen Sie die App erneut, um die Änderungen anzuwenden.';
 
   @override
   String get shared => 'Geteilt';
@@ -8254,8 +8041,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get phoneGetStarted => 'Loslegen';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'Anrufaufzeichnung kann in Ihrer Gerichtsbarkeit eine Einwilligung erfordern';
+  String get callRecordingConsentDisclaimer => 'Anrufaufzeichnung kann in Ihrer Gerichtsbarkeit eine Einwilligung erfordern';
 
   @override
   String get enterYourNumber => 'Geben Sie Ihre Nummer ein';
@@ -8433,8 +8219,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonanrufe über Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Telefoniere über Omi und erhalte Echtzeit-Transkription, automatische Zusammenfassungen und mehr.';
+  String get phoneCallsUpsellSubtitle => 'Telefoniere über Omi und erhalte Echtzeit-Transkription, automatische Zusammenfassungen und mehr.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Echtzeit-Transkription jedes Anrufs';
@@ -8461,8 +8246,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteSyncedFiles => 'Synchronisierte Aufnahmen löschen';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Diese Aufnahmen wurden bereits mit Ihrem Telefon synchronisiert. Dies kann nicht rückgängig gemacht werden.';
+  String get deleteSyncedFilesMessage => 'Diese Aufnahmen wurden bereits mit Ihrem Telefon synchronisiert. Dies kann nicht rückgängig gemacht werden.';
 
   @override
   String get syncedFilesDeleted => 'Synchronisierte Aufnahmen gelöscht';
@@ -8474,8 +8258,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deletePendingFiles => 'Ausstehende Aufnahmen löschen';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Diese Aufnahmen wurden NICHT mit Ihrem Telefon synchronisiert und gehen dauerhaft verloren. Dies kann nicht rückgängig gemacht werden.';
+  String get deletePendingFilesWarning => 'Diese Aufnahmen wurden NICHT mit Ihrem Telefon synchronisiert und gehen dauerhaft verloren. Dies kann nicht rückgängig gemacht werden.';
 
   @override
   String get pendingFilesDeleted => 'Ausstehende Aufnahmen gelöscht';
@@ -8487,8 +8270,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deleteAll => 'Alle löschen';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Dies löscht sowohl synchronisierte als auch ausstehende Aufnahmen. Ausstehende Aufnahmen wurden NICHT synchronisiert und gehen dauerhaft verloren.';
+  String get deleteAllFilesWarning => 'Dies löscht sowohl synchronisierte als auch ausstehende Aufnahmen. Ausstehende Aufnahmen wurden NICHT synchronisiert und gehen dauerhaft verloren.';
 
   @override
   String get allFilesDeleted => 'Alle Aufnahmen gelöscht';
@@ -8520,8 +8302,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fairUsePolicy => 'Faire Nutzung';
 
   @override
-  String get fairUseLoadError =>
-      'Der Status der fairen Nutzung konnte nicht geladen werden. Bitte versuchen Sie es erneut.';
+  String get fairUseLoadError => 'Der Status der fairen Nutzung konnte nicht geladen werden. Bitte versuchen Sie es erneut.';
 
   @override
   String get fairUseStatusNormal => 'Ihre Nutzung liegt im normalen Bereich.';
@@ -8554,8 +8335,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fairUseAboutTitle => 'Über faire Nutzung';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi ist für persönliche Gespräche, Meetings und Live-Interaktionen konzipiert. Die Nutzung wird an der tatsächlich erkannten Sprechzeit gemessen, nicht an der Verbindungszeit. Wenn die Nutzung die normalen Muster für nicht-persönliche Inhalte erheblich überschreitet, können Anpassungen vorgenommen werden.';
+  String get fairUseAboutBody => 'Omi ist für persönliche Gespräche, Meetings und Live-Interaktionen konzipiert. Die Nutzung wird an der tatsächlich erkannten Sprechzeit gemessen, nicht an der Verbindungszeit. Wenn die Nutzung die normalen Muster für nicht-persönliche Inhalte erheblich überschreitet, können Anpassungen vorgenommen werden.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8582,8 +8362,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get transcriptionPaused => 'Aufnahme läuft, verbinde neu';
 
   @override
-  String get transcriptionPausedReconnecting =>
-      'Nimmt weiterhin auf — Verbindung zur Transkription wird wiederhergestellt...';
+  String get transcriptionPausedReconnecting => 'Nimmt weiterhin auf — Verbindung zur Transkription wird wiederhergestellt...';
 
   @override
   String fairUseBannerStatus(String status) {
@@ -8594,8 +8373,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get improveConnectionTitle => 'Verbindung verbessern';
 
   @override
-  String get improveConnectionContent =>
-      'Wir haben verbessert, wie Omi mit deinem Gerät verbunden bleibt. Um dies zu aktivieren, gehe zur Geräteinfo-Seite, tippe auf \"Gerät trennen\" und verbinde dein Gerät erneut.';
+  String get improveConnectionContent => 'Wir haben verbessert, wie Omi mit deinem Gerät verbunden bleibt. Um dies zu aktivieren, gehe zur Geräteinfo-Seite, tippe auf \"Gerät trennen\" und verbinde dein Gerät erneut.';
 
   @override
   String get improveConnectionAction => 'Verstanden';
@@ -8624,8 +8402,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get recordingsSyncAutomatically => 'Aufnahmen werden automatisch synchronisiert — kein Handeln erforderlich.';
 
   @override
-  String get filesDownloadedUploadedNextTime =>
-      'Bereits heruntergeladene Dateien werden beim nächsten Mal hochgeladen.';
+  String get filesDownloadedUploadedNextTime => 'Bereits heruntergeladene Dateien werden beim nächsten Mal hochgeladen.';
 
   @override
   String nConversationsCreated(int count) {
@@ -8651,16 +8428,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cancelSyncQuestion => 'Synchronisierung abbrechen?';
 
   @override
-  String get omisStorageDesc =>
-      'Wenn Ihr Omi nicht mit Ihrem Telefon verbunden ist, speichert es Audio lokal im eingebauten Speicher. Sie verlieren nie eine Aufnahme.';
+  String get omisStorageDesc => 'Wenn Ihr Omi nicht mit Ihrem Telefon verbunden ist, speichert es Audio lokal im eingebauten Speicher. Sie verlieren nie eine Aufnahme.';
 
   @override
-  String get phoneStorageDesc =>
-      'Wenn Omi sich wieder verbindet, werden Aufnahmen automatisch auf Ihr Telefon übertragen, bevor sie hochgeladen werden.';
+  String get phoneStorageDesc => 'Wenn Omi sich wieder verbindet, werden Aufnahmen automatisch auf Ihr Telefon übertragen, bevor sie hochgeladen werden.';
 
   @override
-  String get cloudStorageDesc =>
-      'Nach dem Hochladen werden Ihre Aufnahmen verarbeitet und transkribiert. Gespräche sind innerhalb einer Minute verfügbar.';
+  String get cloudStorageDesc => 'Nach dem Hochladen werden Ihre Aufnahmen verarbeitet und transkribiert. Gespräche sind innerhalb einer Minute verfügbar.';
 
   @override
   String get tipKeepPhoneNearby => 'Halten Sie Ihr Telefon in der Nähe für schnellere Synchronisierung';
@@ -8684,12 +8458,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get permissionEnable => 'Aktivieren';
 
   @override
-  String get permissionsPageDescription =>
-      'Diese Berechtigungen sind zentral für die Funktionsweise von Omi. Sie ermöglichen wichtige Funktionen wie Benachrichtigungen, standortbasierte Erlebnisse und Audioaufnahme.';
+  String get permissionsPageDescription => 'Diese Berechtigungen sind zentral für die Funktionsweise von Omi. Sie ermöglichen wichtige Funktionen wie Benachrichtigungen, standortbasierte Erlebnisse und Audioaufnahme.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi benötigt einige Berechtigungen, um richtig zu funktionieren. Bitte erteile sie, um fortzufahren.';
+  String get permissionsRequiredDescription => 'Omi benötigt einige Berechtigungen, um richtig zu funktionieren. Bitte erteile sie, um fortzufahren.';
 
   @override
   String get permissionsSetupTitle => 'Hol dir das beste Erlebnis';
@@ -8743,8 +8515,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get justAMoment => 'Einen Moment bitte';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Wir empfehlen dringend, deine anderen Optionen zu erkunden, anstatt zu kündigen.';
+  String get cancelConsequencesSubtitle => 'Wir empfehlen dringend, deine anderen Optionen zu erkunden, anstatt zu kündigen.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8946,8 +8717,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get enableLocationTitle => 'Standort aktivieren';
 
   @override
-  String get enableLocationDescription =>
-      'Standortberechtigung wird benötigt, um Bluetooth-Geräte in der Nähe zu finden.';
+  String get enableLocationDescription => 'Standortberechtigung wird benötigt, um Bluetooth-Geräte in der Nähe zu finden.';
 
   @override
   String get voiceRecordingFound => 'Aufnahme gefunden';
@@ -8968,8 +8738,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get firmwareWarningTitle => 'Wichtig: Vor dem Update lesen';
 
   @override
-  String get firmwareFormatWarning =>
-      'Diese Firmware wird die SD-Karte formatieren. Bitte stellen Sie sicher, dass alle Offline-Daten vor dem Upgrade synchronisiert sind.\n\nWenn Sie nach der Installation dieser Version ein blinkendes rotes Licht sehen, machen Sie sich keine Sorgen. Verbinden Sie das Gerät einfach mit der App und es sollte blau werden. Das rote Licht bedeutet, dass die Uhr des Geräts noch nicht synchronisiert wurde.';
+  String get firmwareFormatWarning => 'Diese Firmware wird die SD-Karte formatieren. Bitte stellen Sie sicher, dass alle Offline-Daten vor dem Upgrade synchronisiert sind.\n\nWenn Sie nach der Installation dieser Version ein blinkendes rotes Licht sehen, machen Sie sich keine Sorgen. Verbinden Sie das Gerät einfach mit der App und es sollte blau werden. Das rote Licht bedeutet, dass die Uhr des Geräts noch nicht synchronisiert wurde.';
 
   @override
   String get continueAnyway => 'Fortfahren';
@@ -8989,8 +8758,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tasksMarkComplete => 'Als erledigt markiert';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi greift über Apples HealthKit-Framework auf Apple Health zu. Du kannst den Zugriff jederzeit in den iOS-Einstellungen widerrufen.';
+  String get appleHealthManageNote => 'Omi greift über Apples HealthKit-Framework auf Apple Health zu. Du kannst den Zugriff jederzeit in den iOS-Einstellungen widerrufen.';
 
   @override
   String get appleHealthConnectCta => 'Mit Apple Health verbinden';
@@ -9005,8 +8773,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appleHealthFeatureChatTitle => 'Chatte über deine Gesundheit';
 
   @override
-  String get appleHealthFeatureChatDesc =>
-      'Frage Omi nach deinen Schritten, deinem Schlaf, deiner Herzfrequenz und deinen Workouts.';
+  String get appleHealthFeatureChatDesc => 'Frage Omi nach deinen Schritten, deinem Schlaf, deiner Herzfrequenz und deinen Workouts.';
 
   @override
   String get appleHealthFeatureReadOnlyTitle => 'Nur Lesezugriff';
@@ -9018,15 +8785,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appleHealthFeatureSecureTitle => 'Sichere Synchronisierung';
 
   @override
-  String get appleHealthFeatureSecureDesc =>
-      'Deine Apple Health-Daten werden privat mit deinem Omi-Konto synchronisiert.';
+  String get appleHealthFeatureSecureDesc => 'Deine Apple Health-Daten werden privat mit deinem Omi-Konto synchronisiert.';
 
   @override
   String get appleHealthDeniedTitle => 'Apple Health-Zugriff verweigert';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi hat keine Berechtigung, deine Apple Health-Daten zu lesen. Aktiviere sie unter iOS Einstellungen → Datenschutz & Sicherheit → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi hat keine Berechtigung, deine Apple Health-Daten zu lesen. Aktiviere sie unter iOS Einstellungen → Datenschutz & Sicherheit → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Warum verlässt du uns?';
@@ -9095,8 +8860,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get planUpdate => 'Plan-Aktualisierung';
 
   @override
-  String get planDeprecationMessage =>
-      'Ihr Unlimited-Plan wird eingestellt. Wechseln Sie zum Operator-Plan — dieselben großartigen Funktionen für \$49/Monat. Ihr aktueller Plan funktioniert in der Zwischenzeit weiterhin.';
+  String get planDeprecationMessage => 'Ihr Unlimited-Plan wird eingestellt. Wechseln Sie zum Operator-Plan — dieselben großartigen Funktionen für \$49/Monat. Ihr aktueller Plan funktioniert in der Zwischenzeit weiterhin.';
 
   @override
   String get upgradeYourPlan => 'Upgrade deinen Plan';
@@ -9207,8 +8971,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Du hast dein monatliches Limit erreicht. Upgrade, um ohne Einschränkungen mit Omi weiterzuchatten.';
+  String get chatQuotaExceededReply => 'Du hast dein monatliches Limit erreicht. Upgrade, um ohne Einschränkungen mit Omi weiterzuchatten.';
 
   @override
   String get voiceResponseAudio => 'Omis Antwort laut vorlesen';
@@ -9239,4 +9002,25 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Aufgabe hinzufügen';
+
+  @override
+  String get quickActionAskOmiAnything => 'Frag Omi alles';
+
+  @override
+  String get quickActionVoiceMode => 'Sprachmodus';
+
+  @override
+  String get quickActionMute => 'Stummschalten';
+
+  @override
+  String get quickActionUnmute => 'Stummschaltung aufheben';
+
+  @override
+  String get quickActionConnectDevice => 'Gerät verbinden';
+
+  @override
+  String get quickActionDeviceSettings => 'Geräteeinstellungen';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -24,8 +24,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteConversationTitle => 'Διαγραφή Συνομιλίας;';
 
   @override
-  String get deleteConversationMessage =>
-      'Αυτό θα διαγράψει επίσης τις σχετικές αναμνήσεις, εργασίες και αρχεία ήχου. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get deleteConversationMessage => 'Αυτό θα διαγράψει επίσης τις σχετικές αναμνήσεις, εργασίες και αρχεία ήχου. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String get confirm => 'Επιβεβαίωση';
@@ -82,8 +81,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get conversationUrlNotShared => 'Δεν ήταν δυνατή η κοινοποίηση του URL της συνομιλίας.';
 
   @override
-  String get errorProcessingConversation =>
-      'Σφάλμα κατά την επεξεργασία της συνομιλίας. Παρακαλώ δοκιμάστε ξανά αργότερα.';
+  String get errorProcessingConversation => 'Σφάλμα κατά την επεξεργασία της συνομιλίας. Παρακαλώ δοκιμάστε ξανά αργότερα.';
 
   @override
   String get noInternetConnection => 'Χωρίς σύνδεση στο διαδίκτυο';
@@ -147,8 +145,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleting => 'Διαγραφή...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
+  String get pleaseCompleteAuthentication => 'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
 
   @override
   String get failedToStartAuthentication => 'Αποτυχία έναρξης πιστοποίησης';
@@ -229,8 +226,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noStarredConversations => 'Δεν υπάρχουν συνομιλίες με αστέρι';
 
   @override
-  String get starConversationHint =>
-      'Για να προσθέσετε μια συνομιλία στα αγαπημένα, ανοίξτε τη και πατήστε το εικονίδιο αστεριού στην κεφαλίδα.';
+  String get starConversationHint => 'Για να προσθέσετε μια συνομιλία στα αγαπημένα, ανοίξτε τη και πατήστε το εικονίδιο αστεριού στην κεφαλίδα.';
 
   @override
   String get searchConversations => 'Αναζήτηση συνομιλιών...';
@@ -288,8 +284,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get clearChat => 'Διαγραφή συνομιλίας';
 
   @override
-  String get clearChatConfirm =>
-      'Είστε βέβαιοι ότι θέλετε να εκκαθαρίσετε τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get clearChatConfirm => 'Είστε βέβαιοι ότι θέλετε να εκκαθαρίσετε τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String get maxFilesLimit => 'Μπορείτε να ανεβάσετε μόνο 4 αρχεία τη φορά';
@@ -322,8 +317,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get installedApps => 'Εγκατεστημένες εφαρμογές';
 
   @override
-  String get unableToFetchApps =>
-      'Αδυναμία λήψης εφαρμογών :(\n\nΠαρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
+  String get unableToFetchApps => 'Αδυναμία λήψης εφαρμογών :(\n\nΠαρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
 
   @override
   String get aboutOmi => 'Σχετικά με το Omi';
@@ -359,19 +353,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get appsDisconnected => 'Οι Εφαρμογές και οι Ενσωματώσεις σας θα αποσυνδεθούν αμέσως.';
 
   @override
-  String get exportBeforeDelete =>
-      'Μπορείτε να εξάγετε τα δεδομένα σας πριν διαγράψετε τον λογαριασμό σας, αλλά μόλις διαγραφεί, δεν μπορεί να ανακτηθεί.';
+  String get exportBeforeDelete => 'Μπορείτε να εξάγετε τα δεδομένα σας πριν διαγράψετε τον λογαριασμό σας, αλλά μόλις διαγραφεί, δεν μπορεί να ανακτηθεί.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Κατανοώ ότι η διαγραφή του λογαριασμού μου είναι μόνιμη και όλα τα δεδομένα, συμπεριλαμβανομένων των αναμνήσεων και των συνομιλιών, θα χαθούν και δεν μπορούν να ανακτηθούν.';
+  String get deleteAccountCheckbox => 'Κατανοώ ότι η διαγραφή του λογαριασμού μου είναι μόνιμη και όλα τα δεδομένα, συμπεριλαμβανομένων των αναμνήσεων και των συνομιλιών, θα χαθούν και δεν μπορούν να ανακτηθούν.';
 
   @override
   String get areYouSure => 'Είστε βέβαιοι;';
 
   @override
-  String get deleteAccountFinal =>
-      'Αυτή η ενέργεια είναι μη αναστρέψιμη και θα διαγράψει μόνιμα τον λογαριασμό σας και όλα τα σχετικά δεδομένα. Είστε βέβαιοι ότι θέλετε να συνεχίσετε;';
+  String get deleteAccountFinal => 'Αυτή η ενέργεια είναι μη αναστρέψιμη και θα διαγράψει μόνιμα τον λογαριασμό σας και όλα τα σχετικά δεδομένα. Είστε βέβαιοι ότι θέλετε να συνεχίσετε;';
 
   @override
   String get deleteNow => 'Διαγραφή Τώρα';
@@ -380,8 +371,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get goBack => 'Επιστροφή';
 
   @override
-  String get checkBoxToConfirm =>
-      'Επιλέξτε το πλαίσιο για να επιβεβαιώσετε ότι κατανοείτε ότι η διαγραφή του λογαριασμού σας είναι μόνιμη και μη αναστρέψιμη.';
+  String get checkBoxToConfirm => 'Επιλέξτε το πλαίσιο για να επιβεβαιώσετε ότι κατανοείτε ότι η διαγραφή του λογαριασμού σας είναι μόνιμη και μη αναστρέψιμη.';
 
   @override
   String get profile => 'Προφίλ';
@@ -459,8 +449,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get yourPrivacyYourControl => 'Το Απόρρητό σας, ο Έλεγχός σας';
 
   @override
-  String get privacyIntro =>
-      'Στο Omi, δεσμευόμαστε να προστατεύουμε το απόρρητό σας. Αυτή η σελίδα σας επιτρέπει να ελέγχετε πώς αποθηκεύονται και χρησιμοποιούνται τα δεδομένα σας.';
+  String get privacyIntro => 'Στο Omi, δεσμευόμαστε να προστατεύουμε το απόρρητό σας. Αυτή η σελίδα σας επιτρέπει να ελέγχετε πώς αποθηκεύονται και χρησιμοποιούνται τα δεδομένα σας.';
 
   @override
   String get learnMore => 'Μάθετε περισσότερα...';
@@ -469,15 +458,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get dataProtectionLevel => 'Επίπεδο Προστασίας Δεδομένων';
 
   @override
-  String get dataProtectionDesc =>
-      'Τα δεδομένα σας είναι ασφαλισμένα από προεπιλογή με ισχυρή κρυπτογράφηση. Ελέγξτε τις ρυθμίσεις σας και τις μελλοντικές επιλογές απορρήτου παρακάτω.';
+  String get dataProtectionDesc => 'Τα δεδομένα σας είναι ασφαλισμένα από προεπιλογή με ισχυρή κρυπτογράφηση. Ελέγξτε τις ρυθμίσεις σας και τις μελλοντικές επιλογές απορρήτου παρακάτω.';
 
   @override
   String get appAccess => 'Πρόσβαση Εφαρμογών';
 
   @override
-  String get appAccessDesc =>
-      'Οι παρακάτω εφαρμογές μπορούν να έχουν πρόσβαση στα δεδομένα σας. Πατήστε σε μια εφαρμογή για να διαχειριστείτε τα δικαιώματά της.';
+  String get appAccessDesc => 'Οι παρακάτω εφαρμογές μπορούν να έχουν πρόσβαση στα δεδομένα σας. Πατήστε σε μια εφαρμογή για να διαχειριστείτε τα δικαιώματά της.';
 
   @override
   String get noAppsExternalAccess => 'Καμία εγκατεστημένη εφαρμογή δεν έχει εξωτερική πρόσβαση στα δεδομένα σας.';
@@ -534,22 +521,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Το Omi σας έχει αποσυνδεθεί 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Η συσκευή αποσυζεύχθηκε. Μεταβείτε στις Ρυθμίσεις > Bluetooth και ξεχάστε τη συσκευή για να ολοκληρώσετε την αποσύζευξη.';
+  String get deviceUnpairedMessage => 'Η συσκευή αποσυζεύχθηκε. Μεταβείτε στις Ρυθμίσεις > Bluetooth και ξεχάστε τη συσκευή για να ολοκληρώσετε την αποσύζευξη.';
 
   @override
   String get unpairDialogTitle => 'Κατάργηση Σύζευξης Συσκευής';
 
   @override
-  String get unpairDialogMessage =>
-      'Αυτό θα καταργήσει τη σύζευξη της συσκευής ώστε να μπορεί να συνδεθεί σε άλλο τηλέφωνο. Θα χρειαστεί να μεταβείτε στις Ρυθμίσεις > Bluetooth και να διαγράψετε τη συσκευή για να ολοκληρώσετε τη διαδικασία.';
+  String get unpairDialogMessage => 'Αυτό θα καταργήσει τη σύζευξη της συσκευής ώστε να μπορεί να συνδεθεί σε άλλο τηλέφωνο. Θα χρειαστεί να μεταβείτε στις Ρυθμίσεις > Bluetooth και να διαγράψετε τη συσκευή για να ολοκληρώσετε τη διαδικασία.';
 
   @override
   String get deviceNotConnected => 'Η Συσκευή Δεν Είναι Συνδεδεμένη';
 
   @override
-  String get connectDeviceMessage =>
-      'Συνδέστε τη συσκευή Omi για να αποκτήσετε πρόσβαση\nστις ρυθμίσεις και την προσαρμογή της συσκευής';
+  String get connectDeviceMessage => 'Συνδέστε τη συσκευή Omi για να αποκτήσετε πρόσβαση\nστις ρυθμίσεις και την προσαρμογή της συσκευής';
 
   @override
   String get deviceInfoSection => 'Πληροφορίες Συσκευής';
@@ -564,8 +548,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get v2Undetected => 'Δεν ανιχνεύτηκε V2';
 
   @override
-  String get v2UndetectedMessage =>
-      'Βλέπουμε ότι είτε έχετε συσκευή V1 είτε η συσκευή σας δεν είναι συνδεδεμένη. Η λειτουργικότητα κάρτας SD είναι διαθέσιμη μόνο για συσκευές V2.';
+  String get v2UndetectedMessage => 'Βλέπουμε ότι είτε έχετε συσκευή V1 είτε η συσκευή σας δεν είναι συνδεδεμένη. Η λειτουργικότητα κάρτας SD είναι διαθέσιμη μόνο για συσκευές V2.';
 
   @override
   String get endConversation => 'Τερματισμός Συνομιλίας';
@@ -697,8 +680,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noActivityYet => 'Καμία Δραστηριότητα Ακόμα';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Ξεκινήστε μια συνομιλία με το Omi\nγια να δείτε τις πληροφορίες χρήσης σας εδώ.';
+  String get startConversationToSeeInsights => 'Ξεκινήστε μια συνομιλία με το Omi\nγια να δείτε τις πληροφορίες χρήσης σας εδώ.';
 
   @override
   String get listening => 'Ακρόαση';
@@ -840,8 +822,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Διαγραφή Γραφήματος Γνώσης;';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Αυτό θα διαγράψει όλα τα παράγωγα δεδομένα του γραφήματος γνώσης (κόμβοι και συνδέσεις). Οι αρχικές αναμνήσεις σας θα παραμείνουν ασφαλείς. Το γράφημα θα ξαναδημιουργηθεί με το χρόνο ή στο επόμενο αίτημα.';
+  String get deleteKnowledgeGraphMessage => 'Αυτό θα διαγράψει όλα τα παράγωγα δεδομένα του γραφήματος γνώσης (κόμβοι και συνδέσεις). Οι αρχικές αναμνήσεις σας θα παραμείνουν ασφαλείς. Το γράφημα θα ξαναδημιουργηθεί με το χρόνο ή στο επόμενο αίτημα.';
 
   @override
   String get knowledgeGraphDeleted => 'Γράφημα γνώσης διαγράφηκε';
@@ -989,8 +970,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get shortConversationThreshold => 'Όριο Σύντομης Συνομιλίας';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Οι συνομιλίες συντομότερες από αυτό θα αποκρύπτονται εκτός αν ενεργοποιηθούν παραπάνω';
+  String get shortConversationThresholdSubtitle => 'Οι συνομιλίες συντομότερες από αυτό θα αποκρύπτονται εκτός αν ενεργοποιηθούν παραπάνω';
 
   @override
   String get durationThreshold => 'Όριο Διάρκειας';
@@ -1025,8 +1005,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get integrationsFooter => 'Συνδέστε τις εφαρμογές σας για να δείτε δεδομένα και μετρήσεις στη συνομιλία.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
+  String get completeAuthInBrowser => 'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1086,37 +1065,31 @@ class AppLocalizationsEl extends AppLocalizations {
   String get needYourPermission => 'Χρειαζόμαστε την άδειά σας';
 
   @override
-  String get alreadyGavePermission =>
-      'Έχετε ήδη δώσει την άδειά σας για αποθήκευση των εγγραφών σας. Ορίστε μια υπενθύμιση γιατί το χρειαζόμαστε:';
+  String get alreadyGavePermission => 'Έχετε ήδη δώσει την άδειά σας για αποθήκευση των εγγραφών σας. Ορίστε μια υπενθύμιση γιατί το χρειαζόμαστε:';
 
   @override
-  String get wouldLikePermission =>
-      'Θα θέλαμε την άδειά σας για αποθήκευση των φωνητικών σας εγγραφών. Εδώ είναι γιατί:';
+  String get wouldLikePermission => 'Θα θέλαμε την άδειά σας για αποθήκευση των φωνητικών σας εγγραφών. Εδώ είναι γιατί:';
 
   @override
   String get improveSpeechProfile => 'Βελτίωση του Προφίλ Ομιλίας σας';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Χρησιμοποιούμε τις εγγραφές για περαιτέρω εκπαίδευση και βελτίωση του προσωπικού σας προφίλ ομιλίας.';
+  String get improveSpeechProfileDesc => 'Χρησιμοποιούμε τις εγγραφές για περαιτέρω εκπαίδευση και βελτίωση του προσωπικού σας προφίλ ομιλίας.';
 
   @override
   String get trainFamilyProfiles => 'Εκπαίδευση Προφίλ για Φίλους και Οικογένεια';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Οι εγγραφές σας μας βοηθούν να αναγνωρίζουμε και να δημιουργούμε προφίλ για τους φίλους και την οικογένειά σας.';
+  String get trainFamilyProfilesDesc => 'Οι εγγραφές σας μας βοηθούν να αναγνωρίζουμε και να δημιουργούμε προφίλ για τους φίλους και την οικογένειά σας.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Βελτίωση της Ακρίβειας Απομαγνητοφώνησης';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Καθώς το μοντέλο μας βελτιώνεται, μπορούμε να παρέχουμε καλύτερα αποτελέσματα απομαγνητοφώνησης για τις εγγραφές σας.';
+  String get enhanceTranscriptAccuracyDesc => 'Καθώς το μοντέλο μας βελτιώνεται, μπορούμε να παρέχουμε καλύτερα αποτελέσματα απομαγνητοφώνησης για τις εγγραφές σας.';
 
   @override
-  String get legalNotice =>
-      'Νομική Ειδοποίηση: Η νομιμότητα της εγγραφής και αποθήκευσης φωνητικών δεδομένων μπορεί να διαφέρει ανάλογα με την τοποθεσία σας και τον τρόπο χρήσης αυτής της λειτουργίας. Είναι δική σας ευθύνη να διασφαλίσετε τη συμμόρφωση με τους τοπικούς νόμους και κανονισμούς.';
+  String get legalNotice => 'Νομική Ειδοποίηση: Η νομιμότητα της εγγραφής και αποθήκευσης φωνητικών δεδομένων μπορεί να διαφέρει ανάλογα με την τοποθεσία σας και τον τρόπο χρήσης αυτής της λειτουργίας. Είναι δική σας ευθύνη να διασφαλίσετε τη συμμόρφωση με τους τοπικούς νόμους και κανονισμούς.';
 
   @override
   String get alreadyAuthorized => 'Ήδη Εξουσιοδοτημένο';
@@ -1188,15 +1161,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showMeetingsMenuBar => 'Εμφάνιση επερχόμενων συναντήσεων στη γραμμή μενού';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Εμφάνιση της επόμενης συνάντησής σας και του χρόνου μέχρι να ξεκινήσει στη γραμμή μενού του macOS';
+  String get showMeetingsMenuBarDesc => 'Εμφάνιση της επόμενης συνάντησής σας και του χρόνου μέχρι να ξεκινήσει στη γραμμή μενού του macOS';
 
   @override
   String get showEventsNoParticipants => 'Εμφάνιση συμβάντων χωρίς συμμετέχοντες';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Όταν είναι ενεργοποιημένο, το Coming Up εμφανίζει συμβάντα χωρίς συμμετέχοντες ή σύνδεσμο βίντεο.';
+  String get showEventsNoParticipantsDesc => 'Όταν είναι ενεργοποιημένο, το Coming Up εμφανίζει συμβάντα χωρίς συμμετέχοντες ή σύνδεσμο βίντεο.';
 
   @override
   String get yourMeetings => 'Οι Συναντήσεις σας';
@@ -1237,8 +1208,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noProjectsInWorkspace => 'Δεν βρέθηκαν έργα σε αυτόν τον χώρο εργασίας';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Επιλέξτε πόσο χρόνο να περιμένει σε σιωπή πριν τερματιστεί αυτόματα μια συνομιλία:';
+  String get conversationTimeoutDesc => 'Επιλέξτε πόσο χρόνο να περιμένει σε σιωπή πριν τερματιστεί αυτόματα μια συνομιλία:';
 
   @override
   String get timeout2Minutes => '2 λεπτά';
@@ -1282,12 +1252,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Πείτε μας την κύρια γλώσσα σας';
 
   @override
-  String get languageForTranscription =>
-      'Ορίστε τη γλώσσα σας για πιο ακριβείς απομαγνητοφωνήσεις και εξατομικευμένη εμπειρία.';
+  String get languageForTranscription => 'Ορίστε τη γλώσσα σας για πιο ακριβείς απομαγνητοφωνήσεις και εξατομικευμένη εμπειρία.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Η Λειτουργία Μονής Γλώσσας είναι ενεργοποιημένη. Η μετάφραση είναι απενεργοποιημένη για μεγαλύτερη ακρίβεια.';
+  String get singleLanguageModeInfo => 'Η Λειτουργία Μονής Γλώσσας είναι ενεργοποιημένη. Η μετάφραση είναι απενεργοποιημένη για μεγαλύτερη ακρίβεια.';
 
   @override
   String get searchLanguageHint => 'Αναζήτηση γλώσσας με όνομα ή κωδικό';
@@ -1367,8 +1335,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get defaultRepository => 'Προεπιλεγμένο Αποθετήριο';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Επιλέξτε ένα προεπιλεγμένο αποθετήριο για δημιουργία ζητημάτων. Μπορείτε ακόμα να καθορίσετε διαφορετικό αποθετήριο κατά τη δημιουργία ζητημάτων.';
+  String get selectDefaultRepoDesc => 'Επιλέξτε ένα προεπιλεγμένο αποθετήριο για δημιουργία ζητημάτων. Μπορείτε ακόμα να καθορίσετε διαφορετικό αποθετήριο κατά τη δημιουργία ζητημάτων.';
 
   @override
   String get noReposFound => 'Δεν βρέθηκαν αποθετήρια';
@@ -1415,8 +1382,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get configureSettings => 'Διαμόρφωση Ρυθμίσεων';
 
   @override
-  String get completeAuthBrowser =>
-      'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
+  String get completeAuthBrowser => 'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1585,8 +1551,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get logsCopied => 'Τα αρχεία καταγραφής αντιγράφηκαν';
 
   @override
-  String get noLogsYet =>
-      'Δεν υπάρχουν ακόμα αρχεία καταγραφής. Ξεκινήστε εγγραφή για να δείτε προσαρμοσμένη δραστηριότητα STT.';
+  String get noLogsYet => 'Δεν υπάρχουν ακόμα αρχεία καταγραφής. Ξεκινήστε εγγραφή για να δείτε προσαρμοσμένη δραστηριότητα STT.';
 
   @override
   String deviceUsesCodec(String device, String reason) {
@@ -1745,8 +1710,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get enableBluetooth => 'Ενεργοποίηση Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Το Omi χρειάζεται Bluetooth για σύνδεση με τη φορητή σας συσκευή. Παρακαλώ ενεργοποιήστε το Bluetooth και δοκιμάστε ξανά.';
+  String get bluetoothNeeded => 'Το Omi χρειάζεται Bluetooth για σύνδεση με τη φορητή σας συσκευή. Παρακαλώ ενεργοποιήστε το Bluetooth και δοκιμάστε ξανά.';
 
   @override
   String get contactSupport => 'Επικοινωνία με Υποστήριξη;';
@@ -1779,26 +1743,22 @@ class AppLocalizationsEl extends AppLocalizations {
   String get locationServiceDisabled => 'Η Υπηρεσία Τοποθεσίας είναι Απενεργοποιημένη';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Η Υπηρεσία Τοποθεσίας είναι Απενεργοποιημένη. Παρακαλώ μεταβείτε στις Ρυθμίσεις > Απόρρητο & Ασφάλεια > Υπηρεσίες Τοποθεσίας και ενεργοποιήστε την';
+  String get locationServiceDisabledDesc => 'Η Υπηρεσία Τοποθεσίας είναι Απενεργοποιημένη. Παρακαλώ μεταβείτε στις Ρυθμίσεις > Απόρρητο & Ασφάλεια > Υπηρεσίες Τοποθεσίας και ενεργοποιήστε την';
 
   @override
   String get backgroundLocationDenied => 'Απορρίφθηκε η Πρόσβαση Τοποθεσίας Παρασκηνίου';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Παρακαλώ μεταβείτε στις ρυθμίσεις της συσκευής και ορίστε την άδεια τοποθεσίας σε \"Πάντα Να Επιτρέπεται\"';
+  String get backgroundLocationDeniedDesc => 'Παρακαλώ μεταβείτε στις ρυθμίσεις της συσκευής και ορίστε την άδεια τοποθεσίας σε \"Πάντα Να Επιτρέπεται\"';
 
   @override
   String get lovingOmi => 'Αγαπάτε το Omi;';
 
   @override
-  String get leaveReviewIos =>
-      'Βοηθήστε μας να φτάσουμε σε περισσότερους ανθρώπους αφήνοντας μια κριτική στο App Store. Τα σχόλιά σας σημαίνουν τα πάντα για εμάς!';
+  String get leaveReviewIos => 'Βοηθήστε μας να φτάσουμε σε περισσότερους ανθρώπους αφήνοντας μια κριτική στο App Store. Τα σχόλιά σας σημαίνουν τα πάντα για εμάς!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Βοηθήστε μας να φτάσουμε σε περισσότερους ανθρώπους αφήνοντας μια κριτική στο Google Play Store. Τα σχόλιά σας σημαίνουν τα πάντα για εμάς!';
+  String get leaveReviewAndroid => 'Βοηθήστε μας να φτάσουμε σε περισσότερους ανθρώπους αφήνοντας μια κριτική στο Google Play Store. Τα σχόλιά σας σημαίνουν τα πάντα για εμάς!';
 
   @override
   String get rateOnAppStore => 'Αξιολόγηση στο App Store';
@@ -1810,8 +1770,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get maybeLater => 'Ίσως αργότερα';
 
   @override
-  String get speechProfileIntro =>
-      'Το Omi πρέπει να μάθει τους στόχους και τη φωνή σας. Θα μπορείτε να το τροποποιήσετε αργότερα.';
+  String get speechProfileIntro => 'Το Omi πρέπει να μάθει τους στόχους και τη φωνή σας. Θα μπορείτε να το τροποποιήσετε αργότερα.';
 
   @override
   String get getStarted => 'Ξεκινήστε';
@@ -1832,36 +1791,31 @@ class AppLocalizationsEl extends AppLocalizations {
   String get connectionError => 'Σφάλμα Σύνδεσης';
 
   @override
-  String get connectionErrorDesc =>
-      'Αποτυχία σύνδεσης με τον διακομιστή. Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
+  String get connectionErrorDesc => 'Αποτυχία σύνδεσης με τον διακομιστή. Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Ανιχνεύθηκε μη έγκυρη εγγραφή';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Φαίνεται ότι υπάρχουν πολλοί ομιλητές στην εγγραφή. Παρακαλώ βεβαιωθείτε ότι βρίσκεστε σε ήσυχο χώρο και δοκιμάστε ξανά.';
+  String get multipleSpeakersDesc => 'Φαίνεται ότι υπάρχουν πολλοί ομιλητές στην εγγραφή. Παρακαλώ βεβαιωθείτε ότι βρίσκεστε σε ήσυχο χώρο και δοκιμάστε ξανά.';
 
   @override
   String get tooShortDesc => 'Δεν ανιχνεύθηκε αρκετή ομιλία. Παρακαλώ μιλήστε περισσότερο και δοκιμάστε ξανά.';
 
   @override
-  String get invalidRecordingDesc =>
-      'Παρακαλώ βεβαιωθείτε ότι μιλάτε για τουλάχιστον 5 δευτερόλεπτα και όχι περισσότερο από 90.';
+  String get invalidRecordingDesc => 'Παρακαλώ βεβαιωθείτε ότι μιλάτε για τουλάχιστον 5 δευτερόλεπτα και όχι περισσότερο από 90.';
 
   @override
   String get areYouThere => 'Είστε εκεί;';
 
   @override
-  String get noSpeechDesc =>
-      'Δεν μπορέσαμε να ανιχνεύσουμε καμία ομιλία. Παρακαλώ βεβαιωθείτε ότι μιλάτε για τουλάχιστον 10 δευτερόλεπτα και όχι περισσότερο από 3 λεπτά.';
+  String get noSpeechDesc => 'Δεν μπορέσαμε να ανιχνεύσουμε καμία ομιλία. Παρακαλώ βεβαιωθείτε ότι μιλάτε για τουλάχιστον 10 δευτερόλεπτα και όχι περισσότερο από 3 λεπτά.';
 
   @override
   String get connectionLost => 'Η Σύνδεση Χάθηκε';
 
   @override
-  String get connectionLostDesc =>
-      'Η σύνδεση διακόπηκε. Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
+  String get connectionLostDesc => 'Η σύνδεση διακόπηκε. Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
 
   @override
   String get tryAgain => 'Δοκιμάστε Ξανά';
@@ -1876,8 +1830,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get permissionsRequired => 'Απαιτούνται δικαιώματα';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Αυτή η εφαρμογή χρειάζεται άδειες Bluetooth και Τοποθεσίας για να λειτουργήσει σωστά. Παρακαλώ ενεργοποιήστε τις στις ρυθμίσεις.';
+  String get permissionsRequiredDesc => 'Αυτή η εφαρμογή χρειάζεται άδειες Bluetooth και Τοποθεσίας για να λειτουργήσει σωστά. Παρακαλώ ενεργοποιήστε τις στις ρυθμίσεις.';
 
   @override
   String get openSettings => 'Άνοιγμα Ρυθμίσεων';
@@ -1907,8 +1860,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Ο Βοηθός AI σας';
 
   @override
-  String get captureEveryMoment =>
-      'Καταγράψτε κάθε στιγμή. Λάβετε περιλήψεις\nμε AI. Μην κρατάτε ποτέ ξανά σημειώσεις.';
+  String get captureEveryMoment => 'Καταγράψτε κάθε στιγμή. Λάβετε περιλήψεις\nμε AI. Μην κρατάτε ποτέ ξανά σημειώσεις.';
 
   @override
   String get appleWatchSetup => 'Ρύθμιση Apple Watch';
@@ -1920,12 +1872,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get microphonePermission => 'Άδεια Μικροφώνου';
 
   @override
-  String get permissionGrantedNow =>
-      'Η άδεια χορηγήθηκε! Τώρα:\n\nΑνοίξτε την εφαρμογή Omi στο ρολόι σας και πατήστε \"Συνέχεια\" παρακάτω';
+  String get permissionGrantedNow => 'Η άδεια χορηγήθηκε! Τώρα:\n\nΑνοίξτε την εφαρμογή Omi στο ρολόι σας και πατήστε \"Συνέχεια\" παρακάτω';
 
   @override
-  String get needMicrophonePermission =>
-      'Χρειαζόμαστε άδεια μικροφώνου.\n\n1. Πατήστε \"Χορήγηση Άδειας\"\n2. Επιτρέψτε στο iPhone σας\n3. Η εφαρμογή ρολογιού θα κλείσει\n4. Ανοίξτε ξανά και πατήστε \"Συνέχεια\"';
+  String get needMicrophonePermission => 'Χρειαζόμαστε άδεια μικροφώνου.\n\n1. Πατήστε \"Χορήγηση Άδειας\"\n2. Επιτρέψτε στο iPhone σας\n3. Η εφαρμογή ρολογιού θα κλείσει\n4. Ανοίξτε ξανά και πατήστε \"Συνέχεια\"';
 
   @override
   String get grantPermissionButton => 'Χορήγηση Άδειας';
@@ -1934,15 +1884,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get needHelp => 'Χρειάζεστε Βοήθεια;';
 
   @override
-  String get troubleshootingSteps =>
-      'Αντιμετώπιση προβλημάτων:\n\n1. Βεβαιωθείτε ότι το Omi είναι εγκατεστημένο στο ρολόι σας\n2. Ανοίξτε την εφαρμογή Omi στο ρολόι σας\n3. Αναζητήστε το αναδυόμενο παράθυρο άδειας\n4. Πατήστε \"Επιτρέπεται\" όταν σας ζητηθεί\n5. Η εφαρμογή στο ρολόι σας θα κλείσει - ανοίξτε την ξανά\n6. Επιστρέψτε και πατήστε \"Συνέχεια\" στο iPhone σας';
+  String get troubleshootingSteps => 'Αντιμετώπιση προβλημάτων:\n\n1. Βεβαιωθείτε ότι το Omi είναι εγκατεστημένο στο ρολόι σας\n2. Ανοίξτε την εφαρμογή Omi στο ρολόι σας\n3. Αναζητήστε το αναδυόμενο παράθυρο άδειας\n4. Πατήστε \"Επιτρέπεται\" όταν σας ζητηθεί\n5. Η εφαρμογή στο ρολόι σας θα κλείσει - ανοίξτε την ξανά\n6. Επιστρέψτε και πατήστε \"Συνέχεια\" στο iPhone σας';
 
   @override
   String get recordingStartedSuccessfully => 'Η εγγραφή ξεκίνησε επιτυχώς!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Η άδεια δεν έχει χορηγηθεί ακόμα. Παρακαλώ βεβαιωθείτε ότι επιτρέψατε την πρόσβαση στο μικρόφωνο και ανοίξατε ξανά την εφαρμογή στο ρολόι σας.';
+  String get permissionNotGrantedYet => 'Η άδεια δεν έχει χορηγηθεί ακόμα. Παρακαλώ βεβαιωθείτε ότι επιτρέψατε την πρόσβαση στο μικρόφωνο και ανοίξατε ξανά την εφαρμογή στο ρολόι σας.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1973,8 +1921,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get actionItemsTitle => 'Προς Εκτέλεση';
 
   @override
-  String get actionItemsDescription =>
-      'Πατήστε για επεξεργασία • Παρατεταμένο πάτημα για επιλογή • Σύρετε για ενέργειες';
+  String get actionItemsDescription => 'Πατήστε για επεξεργασία • Παρατεταμένο πάτημα για επιλογή • Σύρετε για ενέργειες';
 
   @override
   String get tabToDo => 'Προς Εκτέλεση';
@@ -2040,8 +1987,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Έτοιμοι για Ενέργειες';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Το AI σας θα εξάγει αυτόματα εργασίες και υποχρεώσεις από τις συνομιλίες σας. Θα εμφανιστούν εδώ όταν δημιουργηθούν.';
+  String get welcomeActionItemsDescription => 'Το AI σας θα εξάγει αυτόματα εργασίες και υποχρεώσεις από τις συνομιλίες σας. Θα εμφανιστούν εδώ όταν δημιουργηθούν.';
 
   @override
   String get autoExtractionFeature => 'Αυτόματη εξαγωγή από συνομιλίες';
@@ -2091,8 +2037,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get clearMemoryTitle => 'Εκκαθάριση Μνήμης του Omi';
 
   @override
-  String get clearMemoryMessage =>
-      'Είστε βέβαιοι ότι θέλετε να εκκαθαρίσετε τη μνήμη του Omi; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get clearMemoryMessage => 'Είστε βέβαιοι ότι θέλετε να εκκαθαρίσετε τη μνήμη του Omi; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String get clearMemoryButton => 'Εκκαθάριση μνήμης';
@@ -2238,15 +2183,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'ΟΜΙΛΊΑ ΚΑΙ ΜΕΤΑΓΡΑΦΉ';
 
   @override
-  String get languageSettingsHelperText =>
-      'Η γλώσσα της εφαρμογής αλλάζει τα μενού και τα κουμπιά. Η γλώσσα ομιλίας επηρεάζει τον τρόπο μεταγραφής των ηχογραφήσεών σας.';
+  String get languageSettingsHelperText => 'Η γλώσσα της εφαρμογής αλλάζει τα μενού και τα κουμπιά. Η γλώσσα ομιλίας επηρεάζει τον τρόπο μεταγραφής των ηχογραφήσεών σας.';
 
   @override
   String get translationNotice => 'Ειδοποίηση μετάφρασης';
 
   @override
-  String get translationNoticeMessage =>
-      'Το Omi μεταφράζει συνομιλίες στην κύρια γλώσσα σας. Ενημερώστε το ανά πάσα στιγμή στις Ρυθμίσεις → Προφίλ.';
+  String get translationNoticeMessage => 'Το Omi μεταφράζει συνομιλίες στην κύρια γλώσσα σας. Ενημερώστε το ανά πάσα στιγμή στις Ρυθμίσεις → Προφίλ.';
 
   @override
   String get pleaseCheckInternetConnection => 'Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά';
@@ -2266,8 +2209,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Αυτή η συνομιλία δεν μπορεί να συγχωνευτεί (κλειδωμένη ή ήδη σε συγχώνευση)';
+  String get conversationCannotBeMerged => 'Αυτή η συνομιλία δεν μπορεί να συγχωνευτεί (κλειδωμένη ή ήδη σε συγχώνευση)';
 
   @override
   String get pleaseEnterFolderName => 'Εισαγάγετε ένα όνομα φακέλου';
@@ -2402,8 +2344,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Αποσύζευξη συσκευής';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Αυτό θα αποσυζεύξει τη συσκευή ώστε να μπορεί να συνδεθεί σε άλλο τηλέφωνο. Θα πρέπει να μεταβείτε στις Ρυθμίσεις > Bluetooth και να ξεχάσετε τη συσκευή για να ολοκληρώσετε τη διαδικασία.';
+  String get unpairDeviceDialogMessage => 'Αυτό θα αποσυζεύξει τη συσκευή ώστε να μπορεί να συνδεθεί σε άλλο τηλέφωνο. Θα πρέπει να μεταβείτε στις Ρυθμίσεις > Bluetooth και να ξεχάσετε τη συσκευή για να ολοκληρώσετε τη διαδικασία.';
 
   @override
   String get unpair => 'Αποσύζευξη';
@@ -2569,8 +2510,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get howDoesItWork => 'Πώς λειτουργεί;';
 
   @override
-  String get sdCardSyncDescription =>
-      'Ο συγχρονισμός κάρτας SD θα εισαγάγει τις αναμνήσεις σας από την κάρτα SD στην εφαρμογή';
+  String get sdCardSyncDescription => 'Ο συγχρονισμός κάρτας SD θα εισαγάγει τις αναμνήσεις σας από την κάρτα SD στην εφαρμογή';
 
   @override
   String get checksForAudioFiles => 'Ελέγχει για αρχεία ήχου στην κάρτα SD';
@@ -2585,8 +2525,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get youreAllSet => 'Είστε έτοιμοι!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Καλώς ήρθατε στο Omi! Ο AI σύντροφός σας είναι έτοιμος να σας βοηθήσει με συνομιλίες, εργασίες και πολλά άλλα.';
+  String get welcomeToOmiDescription => 'Καλώς ήρθατε στο Omi! Ο AI σύντροφός σας είναι έτοιμος να σας βοηθήσει με συνομιλίες, εργασίες και πολλά άλλα.';
 
   @override
   String get startUsingOmi => 'Ξεκινήστε να χρησιμοποιείτε το Omi';
@@ -2665,8 +2604,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get reviewAndManageConversations => 'Ελέγξτε και διαχειριστείτε τις καταγεγραμμένες συνομιλίες σας';
 
   @override
-  String get startCapturingConversations =>
-      'Ξεκινήστε να καταγράφετε συνομιλίες με τη συσκευή Omi για να τις δείτε εδώ.';
+  String get startCapturingConversations => 'Ξεκινήστε να καταγράφετε συνομιλίες με τη συσκευή Omi για να τις δείτε εδώ.';
 
   @override
   String get useMobileAppToCapture => 'Χρησιμοποιήστε την εφαρμογή κινητού για να καταγράψετε ήχο';
@@ -2681,8 +2619,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showAll => 'Εμφάνιση όλων →';
 
   @override
-  String get noTasksForToday =>
-      'Δεν υπάρχουν εργασίες για σήμερα.\nΡωτήστε το Omi για περισσότερες εργασίες ή δημιουργήστε χειροκίνητα.';
+  String get noTasksForToday => 'Δεν υπάρχουν εργασίες για σήμερα.\nΡωτήστε το Omi για περισσότερες εργασίες ή δημιουργήστε χειροκίνητα.';
 
   @override
   String get dailyScore => 'ΗΜΕΡΗΣΙΟ ΣΚΟΡ';
@@ -2724,8 +2661,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noTasksYet => 'Δεν υπάρχουν εργασίες ακόμα';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Οι εργασίες από τις συνομιλίες σας θα εμφανιστούν εδώ.\nΚάντε κλικ στο Δημιουργία για να προσθέσετε μία μη αυτόματα.';
+  String get tasksFromConversationsWillAppear => 'Οι εργασίες από τις συνομιλίες σας θα εμφανιστούν εδώ.\nΚάντε κλικ στο Δημιουργία για να προσθέσετε μία μη αυτόματα.';
 
   @override
   String get monthJan => 'Ιαν';
@@ -2782,8 +2718,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteActionItem => 'Διαγραφή εργασίας';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτήν την εργασία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get deleteActionItemConfirmation => 'Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτήν την εργασία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String get enterActionItemDescription => 'Εισαγάγετε περιγραφή εργασίας...';
@@ -2858,15 +2793,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chatPrompt => 'Προτροπή συνομιλίας';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Είστε μια υπέροχη εφαρμογή, η δουλειά σας είναι να απαντάτε στα ερωτήματα των χρηστών και να τους κάνετε να αισθάνονται καλά...';
+  String get chatPromptPlaceholder => 'Είστε μια υπέροχη εφαρμογή, η δουλειά σας είναι να απαντάτε στα ερωτήματα των χρηστών και να τους κάνετε να αισθάνονται καλά...';
 
   @override
   String get conversationPrompt => 'Προτροπή συνομιλίας';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Είστε μια υπέροχη εφαρμογή, θα σας δοθεί απομαγνητοφώνηση και περίληψη μιας συζήτησης...';
+  String get conversationPromptPlaceholder => 'Είστε μια υπέροχη εφαρμογή, θα σας δοθεί απομαγνητοφώνηση και περίληψη μιας συζήτησης...';
 
   @override
   String get notificationScopes => 'Πεδία ειδοποιήσεων';
@@ -2878,8 +2811,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get makeMyAppPublic => 'Κάντε την εφαρμογή μου δημόσια';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Υποβάλλοντας αυτήν την εφαρμογή, συμφωνώ με τους Όρους Υπηρεσίας και την Πολιτική Απορρήτου του Omi AI';
+  String get submitAppTermsAgreement => 'Υποβάλλοντας αυτήν την εφαρμογή, συμφωνώ με τους Όρους Υπηρεσίας και την Πολιτική Απορρήτου του Omi AI';
 
   @override
   String get submitApp => 'Υποβολή εφαρμογής';
@@ -2894,12 +2826,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get submitAppQuestion => 'Υποβολή εφαρμογής;';
 
   @override
-  String get submitAppPublicDescription =>
-      'Η εφαρμογή σας θα αξιολογηθεί και θα γίνει δημόσια. Μπορείτε να αρχίσετε να τη χρησιμοποιείτε αμέσως, ακόμη και κατά τη διάρκεια της αξιολόγησης!';
+  String get submitAppPublicDescription => 'Η εφαρμογή σας θα αξιολογηθεί και θα γίνει δημόσια. Μπορείτε να αρχίσετε να τη χρησιμοποιείτε αμέσως, ακόμη και κατά τη διάρκεια της αξιολόγησης!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Η εφαρμογή σας θα αξιολογηθεί και θα διατεθεί σε εσάς ιδιωτικά. Μπορείτε να αρχίσετε να τη χρησιμοποιείτε αμέσως, ακόμη και κατά τη διάρκεια της αξιολόγησης!';
+  String get submitAppPrivateDescription => 'Η εφαρμογή σας θα αξιολογηθεί και θα διατεθεί σε εσάς ιδιωτικά. Μπορείτε να αρχίσετε να τη χρησιμοποιείτε αμέσως, ακόμη και κατά τη διάρκεια της αξιολόγησης!';
 
   @override
   String get startEarning => 'Ξεκινήστε να κερδίζετε! 💰';
@@ -2923,23 +2853,19 @@ class AppLocalizationsEl extends AppLocalizations {
   String get dataAccessNotice => 'Ειδοποίηση πρόσβασης δεδομένων';
 
   @override
-  String get dataAccessWarning =>
-      'Αυτή η εφαρμογή θα έχει πρόσβαση στα δεδομένα σας. Η Omi AI δεν είναι υπεύθυνη για τον τρόπο χρήσης, τροποποίησης ή διαγραφής των δεδομένων σας από αυτήν την εφαρμογή';
+  String get dataAccessWarning => 'Αυτή η εφαρμογή θα έχει πρόσβαση στα δεδομένα σας. Η Omi AI δεν είναι υπεύθυνη για τον τρόπο χρήσης, τροποποίησης ή διαγραφής των δεδομένων σας από αυτήν την εφαρμογή';
 
   @override
   String get installApp => 'Εγκατάσταση εφαρμογής';
 
   @override
-  String get betaTesterNotice =>
-      'Είστε δοκιμαστής beta για αυτήν την εφαρμογή. Δεν είναι ακόμα δημόσια. Θα γίνει δημόσια μόλις εγκριθεί.';
+  String get betaTesterNotice => 'Είστε δοκιμαστής beta για αυτήν την εφαρμογή. Δεν είναι ακόμα δημόσια. Θα γίνει δημόσια μόλις εγκριθεί.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Η εφαρμογή σας βρίσκεται υπό αναθεώρηση και είναι ορατή μόνο σε εσάς. Θα γίνει δημόσια μόλις εγκριθεί.';
+  String get appUnderReviewOwner => 'Η εφαρμογή σας βρίσκεται υπό αναθεώρηση και είναι ορατή μόνο σε εσάς. Θα γίνει δημόσια μόλις εγκριθεί.';
 
   @override
-  String get appRejectedNotice =>
-      'Η εφαρμογή σας απορρίφθηκε. Παρακαλούμε ενημερώστε τις λεπτομέρειες της εφαρμογής και υποβάλετε ξανά για αναθεώρηση.';
+  String get appRejectedNotice => 'Η εφαρμογή σας απορρίφθηκε. Παρακαλούμε ενημερώστε τις λεπτομέρειες της εφαρμογής και υποβάλετε ξανά για αναθεώρηση.';
 
   @override
   String get setupSteps => 'Βήματα εγκατάστασης';
@@ -2974,8 +2900,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get errorActivatingApp => 'Σφάλμα ενεργοποίησης εφαρμογής';
 
   @override
-  String get integrationSetupRequired =>
-      'Εάν αυτή είναι μια εφαρμογή ενσωμάτωσης, βεβαιωθείτε ότι η εγκατάσταση έχει ολοκληρωθεί.';
+  String get integrationSetupRequired => 'Εάν αυτή είναι μια εφαρμογή ενσωμάτωσης, βεβαιωθείτε ότι η εγκατάσταση έχει ολοκληρωθεί.';
 
   @override
   String get installed => 'Εγκατεστημένο';
@@ -3002,8 +2927,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get descriptionLabel => 'Περιγραφή';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Η υπέροχη εφαρμογή μου είναι μια υπέροχη εφαρμογή που κάνει καταπληκτικά πράγματα. Είναι η καλύτερη εφαρμογή!';
+  String get appDescriptionPlaceholder => 'Η υπέροχη εφαρμογή μου είναι μια υπέροχη εφαρμογή που κάνει καταπληκτικά πράγματα. Είναι η καλύτερη εφαρμογή!';
 
   @override
   String get pleaseProvideValidDescription => 'Παρακαλώ δώστε μια έγκυρη περιγραφή';
@@ -3140,8 +3064,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get clearChatTitle => 'Διαγραφή συνομιλίας;';
 
   @override
-  String get confirmClearChat =>
-      'Είστε βέβαιοι ότι θέλετε να διαγράψετε τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get confirmClearChat => 'Είστε βέβαιοι ότι θέλετε να διαγράψετε τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String get copy => 'Αντιγραφή';
@@ -3156,8 +3079,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get microphonePermissionRequired => 'Απαιτείται άδεια μικροφώνου για ηχογράφηση φωνής.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Άρνηση άδειας μικροφώνου. Παρακαλώ δώστε άδεια στις Προτιμήσεις Συστήματος > Απόρρητο & Ασφάλεια > Μικρόφωνο.';
+  String get microphonePermissionDenied => 'Άρνηση άδειας μικροφώνου. Παρακαλώ δώστε άδεια στις Προτιμήσεις Συστήματος > Απόρρητο & Ασφάλεια > Μικρόφωνο.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3316,8 +3238,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get createMemory => 'Δημιουργία μνήμης';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Είστε σίγουροι ότι θέλετε να διαγράψετε αυτήν τη μνήμη; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get deleteMemoryConfirmation => 'Είστε σίγουροι ότι θέλετε να διαγράψετε αυτήν τη μνήμη; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String get makePrivate => 'Κάντε ιδιωτική';
@@ -3391,8 +3312,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get whatWeCollect => 'Τι συλλέγουμε';
 
   @override
-  String get dataCollectionMessage =>
-      'Συνεχίζοντας, οι συνομιλίες, οι ηχογραφήσεις και οι προσωπικές σας πληροφορίες θα αποθηκευτούν με ασφάλεια στους διακομιστές μας για να παρέχουμε πληροφορίες που υποστηρίζονται από AI και να ενεργοποιήσουμε όλες τις λειτουργίες της εφαρμογής.';
+  String get dataCollectionMessage => 'Συνεχίζοντας, οι συνομιλίες, οι ηχογραφήσεις και οι προσωπικές σας πληροφορίες θα αποθηκευτούν με ασφάλεια στους διακομιστές μας για να παρέχουμε πληροφορίες που υποστηρίζονται από AI και να ενεργοποιήσουμε όλες τις λειτουργίες της εφαρμογής.';
 
   @override
   String get dataProtection => 'Προστασία Δεδομένων';
@@ -3407,8 +3327,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chooseYourLanguage => 'Επιλέξτε τη γλώσσα σας';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'Επιλέξτε την προτιμώμενη γλώσσα σας για την καλύτερη εμπειρία Omi';
+  String get selectPreferredLanguageForBestExperience => 'Επιλέξτε την προτιμώμενη γλώσσα σας για την καλύτερη εμπειρία Omi';
 
   @override
   String get searchLanguages => 'Αναζήτηση γλωσσών...';
@@ -3426,8 +3345,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Το όνομα πρέπει να έχει τουλάχιστον 2 χαρακτήρες';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Πείτε μας πώς θα θέλατε να σας αποκαλούμε. Αυτό βοηθά στην εξατομίκευση της εμπειρίας Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Πείτε μας πώς θα θέλατε να σας αποκαλούμε. Αυτό βοηθά στην εξατομίκευση της εμπειρίας Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3435,8 +3353,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Ενεργοποιήστε λειτουργίες για την καλύτερη εμπειρία Omi στη συσκευή σας.';
+  String get enableFeaturesForBestExperience => 'Ενεργοποιήστε λειτουργίες για την καλύτερη εμπειρία Omi στη συσκευή σας.';
 
   @override
   String get microphoneAccess => 'Πρόσβαση στο μικρόφωνο';
@@ -3445,8 +3362,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get recordAudioConversations => 'Εγγραφή ηχητικών συνομιλιών';
 
   @override
-  String get microphoneAccessDescription =>
-      'Το Omi χρειάζεται πρόσβαση στο μικρόφωνο για να εγγράφει τις συνομιλίες σας και να παρέχει μεταγραφές.';
+  String get microphoneAccessDescription => 'Το Omi χρειάζεται πρόσβαση στο μικρόφωνο για να εγγράφει τις συνομιλίες σας και να παρέχει μεταγραφές.';
 
   @override
   String get screenRecording => 'Εγγραφή οθόνης';
@@ -3455,8 +3371,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Καταγραφή ήχου συστήματος από συναντήσεις';
 
   @override
-  String get screenRecordingDescription =>
-      'Το Omi χρειάζεται άδεια εγγραφής οθόνης για να καταγράφει τον ήχο συστήματος από τις συναντήσεις σας που βασίζονται στον περιηγητή.';
+  String get screenRecordingDescription => 'Το Omi χρειάζεται άδεια εγγραφής οθόνης για να καταγράφει τον ήχο συστήματος από τις συναντήσεις σας που βασίζονται στον περιηγητή.';
 
   @override
   String get accessibility => 'Προσβασιμότητα';
@@ -3465,8 +3380,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Ανίχνευση συναντήσεων που βασίζονται στον περιηγητή';
 
   @override
-  String get accessibilityDescription =>
-      'Το Omi χρειάζεται άδεια προσβασιμότητας για να ανιχνεύει πότε συμμετέχετε σε συναντήσεις Zoom, Meet ή Teams στον περιηγητή σας.';
+  String get accessibilityDescription => 'Το Omi χρειάζεται άδεια προσβασιμότητας για να ανιχνεύει πότε συμμετέχετε σε συναντήσεις Zoom, Meet ή Teams στον περιηγητή σας.';
 
   @override
   String get pleaseWait => 'Παρακαλώ περιμένετε...';
@@ -3535,12 +3449,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get exportAllConversationsToJson => 'Εξάγετε όλες τις συνομιλίες σας σε αρχείο JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Η εξαγωγή συνομιλιών ξεκίνησε. Αυτό μπορεί να διαρκέσει μερικά δευτερόλεπτα, παρακαλώ περιμένετε.';
+  String get conversationsExportStarted => 'Η εξαγωγή συνομιλιών ξεκίνησε. Αυτό μπορεί να διαρκέσει μερικά δευτερόλεπτα, παρακαλώ περιμένετε.';
 
   @override
-  String get mcpDescription =>
-      'Για να συνδέσετε το Omi με άλλες εφαρμογές για να διαβάσετε, να αναζητήσετε και να διαχειριστείτε τις αναμνήσεις και τις συνομιλίες σας. Δημιουργήστε ένα κλειδί για να ξεκινήσετε.';
+  String get mcpDescription => 'Για να συνδέσετε το Omi με άλλες εφαρμογές για να διαβάσετε, να αναζητήσετε και να διαχειριστείτε τις αναμνήσεις και τις συνομιλίες σας. Δημιουργήστε ένα κλειδί για να ξεκινήσετε.';
 
   @override
   String get apiKeys => 'Κλειδιά API';
@@ -3581,8 +3493,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Κατάσταση διαγνωστικών υπηρεσίας μεταγραφής';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Ενεργοποίηση λεπτομερών διαγνωστικών μηνυμάτων από την υπηρεσία μεταγραφής';
+  String get enableDetailedDiagnosticMessages => 'Ενεργοποίηση λεπτομερών διαγνωστικών μηνυμάτων από την υπηρεσία μεταγραφής';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Αυτόματη δημιουργία και επισήμανση νέων ομιλητών';
@@ -3612,8 +3523,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get auto => 'Αυτόματα';
 
   @override
-  String get noSummaryForApp =>
-      'Δεν υπάρχει διαθέσιμη σύνοψη για αυτήν την εφαρμογή. Δοκιμάστε μια άλλη εφαρμογή για καλύτερα αποτελέσματα.';
+  String get noSummaryForApp => 'Δεν υπάρχει διαθέσιμη σύνοψη για αυτήν την εφαρμογή. Δοκιμάστε μια άλλη εφαρμογή για καλύτερα αποτελέσματα.';
 
   @override
   String get tryAnotherApp => 'Δοκιμάστε άλλη εφαρμογή';
@@ -3650,8 +3560,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Αφήστε το Omi να επιλέξει αυτόματα την καλύτερη εφαρμογή';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Είστε σίγουροι ότι θέλετε να διαγράψετε αυτή τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get deleteConversationConfirmation => 'Είστε σίγουροι ότι θέλετε να διαγράψετε αυτή τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String get conversationDeleted => 'Η συνομιλία διαγράφηκε';
@@ -3699,8 +3608,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Προετοιμασία καταγραφής ήχου συστήματος';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Κάντε κλικ στο κουμπί για να καταγράψετε ήχο για ζωντανές μεταγραφές, πληροφορίες AI και αυτόματη αποθήκευση.';
+  String get clickTheButtonToCaptureAudio => 'Κάντε κλικ στο κουμπί για να καταγράψετε ήχο για ζωντανές μεταγραφές, πληροφορίες AI και αυτόματη αποθήκευση.';
 
   @override
   String get reconnecting => 'Επανασύνδεση...';
@@ -3903,8 +3811,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get shortcuts => 'Συντομεύσεις';
 
   @override
-  String get shortcutChangeInstruction =>
-      'Κάντε κλικ σε μια συντόμευση για να την αλλάξετε. Πατήστε Escape για ακύρωση.';
+  String get shortcutChangeInstruction => 'Κάντε κλικ σε μια συντόμευση για να την αλλάξετε. Πατήστε Escape για ακύρωση.';
 
   @override
   String get configureSTTProvider => 'Διαμόρφωση παρόχου STT';
@@ -3928,8 +3835,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Διαγραφή γράφου γνώσης;';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Αυτό θα διαγράψει όλα τα παράγωγα δεδομένα γράφου γνώσης. Οι αρχικές σας αναμνήσεις παραμένουν ασφαλείς.';
+  String get deleteKnowledgeGraphWarning => 'Αυτό θα διαγράψει όλα τα παράγωγα δεδομένα γράφου γνώσης. Οι αρχικές σας αναμνήσεις παραμένουν ασφαλείς.';
 
   @override
   String get connectOmiWithAI => 'Συνδέστε το Omi με βοηθούς AI';
@@ -3971,8 +3877,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Όροι & Πολιτική Απορρήτου';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Βοηθά στη διάγνωση προβλημάτων. Διαγράφεται αυτόματα μετά από 3 ημέρες.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Βοηθά στη διάγνωση προβλημάτων. Διαγράφεται αυτόματα μετά από 3 ημέρες.';
 
   @override
   String get manageYourApp => 'Διαχείριση της εφαρμογής σας';
@@ -3987,8 +3892,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get updateAppQuestion => 'Ενημέρωση εφαρμογής;';
 
   @override
-  String get updateAppConfirmation =>
-      'Είστε σίγουροι ότι θέλετε να ενημερώσετε την εφαρμογή σας; Οι αλλαγές θα εμφανιστούν μετά τον έλεγχο από την ομάδα μας.';
+  String get updateAppConfirmation => 'Είστε σίγουροι ότι θέλετε να ενημερώσετε την εφαρμογή σας; Οι αλλαγές θα εμφανιστούν μετά τον έλεγχο από την ομάδα μας.';
 
   @override
   String get updateApp => 'Ενημέρωση εφαρμογής';
@@ -4018,8 +3922,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get no => 'Όχι';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Η συνδρομή ακυρώθηκε επιτυχώς. Θα παραμείνει ενεργή μέχρι το τέλος της τρέχουσας περιόδου χρέωσης.';
+  String get subscriptionCancelledSuccessfully => 'Η συνδρομή ακυρώθηκε επιτυχώς. Θα παραμείνει ενεργή μέχρι το τέλος της τρέχουσας περιόδου χρέωσης.';
 
   @override
   String get failedToCancelSubscription => 'Αποτυχία ακύρωσης συνδρομής. Παρακαλώ δοκιμάστε ξανά.';
@@ -4055,8 +3958,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Ακύρωση συνδρομής;';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Είστε σίγουροι ότι θέλετε να ακυρώσετε τη συνδρομή σας; Θα συνεχίσετε να έχετε πρόσβαση μέχρι το τέλος της τρέχουσας περιόδου χρέωσης.';
+  String get cancelSubscriptionConfirmation => 'Είστε σίγουροι ότι θέλετε να ακυρώσετε τη συνδρομή σας; Θα συνεχίσετε να έχετε πρόσβαση μέχρι το τέλος της τρέχουσας περιόδου χρέωσης.';
 
   @override
   String get cancelSubscriptionButton => 'Ακύρωση συνδρομής';
@@ -4065,16 +3967,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get cancelling => 'Ακύρωση...';
 
   @override
-  String get betaTesterMessage =>
-      'Είστε δοκιμαστής beta για αυτήν την εφαρμογή. Δεν είναι ακόμα δημόσια. Θα γίνει δημόσια μετά την έγκριση.';
+  String get betaTesterMessage => 'Είστε δοκιμαστής beta για αυτήν την εφαρμογή. Δεν είναι ακόμα δημόσια. Θα γίνει δημόσια μετά την έγκριση.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Η εφαρμογή σας είναι υπό αξιολόγηση και ορατή μόνο σε εσάς. Θα γίνει δημόσια μετά την έγκριση.';
+  String get appUnderReviewMessage => 'Η εφαρμογή σας είναι υπό αξιολόγηση και ορατή μόνο σε εσάς. Θα γίνει δημόσια μετά την έγκριση.';
 
   @override
-  String get appRejectedMessage =>
-      'Η εφαρμογή σας απορρίφθηκε. Ενημερώστε τα στοιχεία και υποβάλετε ξανά για αξιολόγηση.';
+  String get appRejectedMessage => 'Η εφαρμογή σας απορρίφθηκε. Ενημερώστε τα στοιχεία και υποβάλετε ξανά για αξιολόγηση.';
 
   @override
   String get invalidIntegrationUrl => 'Μη έγκυρη διεύθυνση URL ενσωμάτωσης';
@@ -4125,12 +4024,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get anonymousUser => 'Ανώνυμος χρήστης';
 
   @override
-  String get issueActivatingApp =>
-      'Υπήρξε πρόβλημα κατά την ενεργοποίηση αυτής της εφαρμογής. Παρακαλώ δοκιμάστε ξανά.';
+  String get issueActivatingApp => 'Υπήρξε πρόβλημα κατά την ενεργοποίηση αυτής της εφαρμογής. Παρακαλώ δοκιμάστε ξανά.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Αυτή η εφαρμογή θα έχει πρόσβαση στα δεδομένα σας. Η Omi AI δεν είναι υπεύθυνη για τον τρόπο χρήσης των δεδομένων σας από τρίτους.';
+  String get dataAccessNoticeDescription => 'Αυτή η εφαρμογή θα έχει πρόσβαση στα δεδομένα σας. Η Omi AI δεν είναι υπεύθυνη για τον τρόπο χρήσης των δεδομένων σας από τρίτους.';
 
   @override
   String get copyUrl => 'Αντιγραφή URL';
@@ -4218,8 +4115,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get omiApiKeys => 'Κλειδιά API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Τα κλειδιά API χρησιμοποιούνται για έλεγχο ταυτότητας όταν η εφαρμογή σας επικοινωνεί με τον διακομιστή OMI. Επιτρέπουν στην εφαρμογή σας να δημιουργεί αναμνήσεις και να έχει ασφαλή πρόσβαση σε άλλες υπηρεσίες OMI.';
+  String get apiKeysDescription => 'Τα κλειδιά API χρησιμοποιούνται για έλεγχο ταυτότητας όταν η εφαρμογή σας επικοινωνεί με τον διακομιστή OMI. Επιτρέπουν στην εφαρμογή σας να δημιουργεί αναμνήσεις και να έχει ασφαλή πρόσβαση σε άλλες υπηρεσίες OMI.';
 
   @override
   String get aboutOmiApiKeys => 'Σχετικά με τα κλειδιά API Omi';
@@ -4243,8 +4139,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Ανάκληση κλειδιού API;';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Αυτή η ενέργεια δεν μπορεί να αναιρεθεί. Οι εφαρμογές που χρησιμοποιούν αυτό το κλειδί δεν θα έχουν πλέον πρόσβαση στο API.';
+  String get revokeApiKeyWarning => 'Αυτή η ενέργεια δεν μπορεί να αναιρεθεί. Οι εφαρμογές που χρησιμοποιούν αυτό το κλειδί δεν θα έχουν πλέον πρόσβαση στο API.';
 
   @override
   String get revoke => 'Ανάκληση';
@@ -4333,8 +4228,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get keyCreated => 'Το κλειδί δημιουργήθηκε';
 
   @override
-  String get keyCreatedMessage =>
-      'Το νέο σας κλειδί δημιουργήθηκε. Παρακαλώ αντιγράψτε το τώρα. Δεν θα μπορείτε να το δείτε ξανά.';
+  String get keyCreatedMessage => 'Το νέο σας κλειδί δημιουργήθηκε. Παρακαλώ αντιγράψτε το τώρα. Δεν θα μπορείτε να το δείτε ξανά.';
 
   @override
   String get keyWord => 'Κλειδί';
@@ -4343,8 +4237,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get externalAppAccess => 'Πρόσβαση εξωτερικών εφαρμογών';
 
   @override
-  String get externalAppAccessDescription =>
-      'Οι παρακάτω εγκατεστημένες εφαρμογές έχουν εξωτερικές ενσωματώσεις και μπορούν να έχουν πρόσβαση στα δεδομένα σας, όπως συνομιλίες και αναμνήσεις.';
+  String get externalAppAccessDescription => 'Οι παρακάτω εγκατεστημένες εφαρμογές έχουν εξωτερικές ενσωματώσεις και μπορούν να έχουν πρόσβαση στα δεδομένα σας, όπως συνομιλίες και αναμνήσεις.';
 
   @override
   String get noExternalAppsHaveAccess => 'Καμία εξωτερική εφαρμογή δεν έχει πρόσβαση στα δεδομένα σας.';
@@ -4353,15 +4246,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get maximumSecurityE2ee => 'Μέγιστη ασφάλεια (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Η κρυπτογράφηση από άκρο σε άκρο είναι το χρυσό πρότυπο για την ιδιωτικότητα. Όταν είναι ενεργοποιημένη, τα δεδομένα σας κρυπτογραφούνται στη συσκευή σας πριν σταλούν στους διακομιστές μας. Αυτό σημαίνει ότι κανείς, ούτε καν η Omi, δεν μπορεί να έχει πρόσβαση στο περιεχόμενό σας.';
+  String get e2eeDescription => 'Η κρυπτογράφηση από άκρο σε άκρο είναι το χρυσό πρότυπο για την ιδιωτικότητα. Όταν είναι ενεργοποιημένη, τα δεδομένα σας κρυπτογραφούνται στη συσκευή σας πριν σταλούν στους διακομιστές μας. Αυτό σημαίνει ότι κανείς, ούτε καν η Omi, δεν μπορεί να έχει πρόσβαση στο περιεχόμενό σας.';
 
   @override
   String get importantTradeoffs => 'Σημαντικοί συμβιβασμοί:';
 
   @override
-  String get e2eeTradeoff1 =>
-      '• Ορισμένες λειτουργίες όπως οι ενσωματώσεις εξωτερικών εφαρμογών ενδέχεται να απενεργοποιηθούν.';
+  String get e2eeTradeoff1 => '• Ορισμένες λειτουργίες όπως οι ενσωματώσεις εξωτερικών εφαρμογών ενδέχεται να απενεργοποιηθούν.';
 
   @override
   String get e2eeTradeoff2 => '• Εάν χάσετε τον κωδικό πρόσβασής σας, τα δεδομένα σας δεν μπορούν να ανακτηθούν.';
@@ -4370,8 +4261,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get featureComingSoon => 'Αυτή η λειτουργία έρχεται σύντομα!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Μετανάστευση σε εξέλιξη. Δεν μπορείτε να αλλάξετε το επίπεδο προστασίας μέχρι να ολοκληρωθεί.';
+  String get migrationInProgressMessage => 'Μετανάστευση σε εξέλιξη. Δεν μπορείτε να αλλάξετε το επίπεδο προστασίας μέχρι να ολοκληρωθεί.';
 
   @override
   String get migrationFailed => 'Η μετανάστευση απέτυχε';
@@ -4390,19 +4280,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get secureEncryption => 'Ασφαλής κρυπτογράφηση';
 
   @override
-  String get secureEncryptionDescription =>
-      'Τα δεδομένα σας κρυπτογραφούνται με ένα μοναδικό κλειδί για εσάς στους διακομιστές μας, που φιλοξενούνται στο Google Cloud. Αυτό σημαίνει ότι το ακατέργαστο περιεχόμενό σας είναι απρόσιτο σε οποιονδήποτε, συμπεριλαμβανομένου του προσωπικού της Omi ή της Google, απευθείας από τη βάση δεδομένων.';
+  String get secureEncryptionDescription => 'Τα δεδομένα σας κρυπτογραφούνται με ένα μοναδικό κλειδί για εσάς στους διακομιστές μας, που φιλοξενούνται στο Google Cloud. Αυτό σημαίνει ότι το ακατέργαστο περιεχόμενό σας είναι απρόσιτο σε οποιονδήποτε, συμπεριλαμβανομένου του προσωπικού της Omi ή της Google, απευθείας από τη βάση δεδομένων.';
 
   @override
   String get endToEndEncryption => 'Κρυπτογράφηση από άκρο σε άκρο';
 
   @override
-  String get e2eeCardDescription =>
-      'Ενεργοποιήστε για μέγιστη ασφάλεια όπου μόνο εσείς έχετε πρόσβαση στα δεδομένα σας. Πατήστε για να μάθετε περισσότερα.';
+  String get e2eeCardDescription => 'Ενεργοποιήστε για μέγιστη ασφάλεια όπου μόνο εσείς έχετε πρόσβαση στα δεδομένα σας. Πατήστε για να μάθετε περισσότερα.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Ανεξάρτητα από το επίπεδο, τα δεδομένα σας είναι πάντα κρυπτογραφημένα σε κατάσταση ηρεμίας και κατά τη μεταφορά.';
+  String get dataAlwaysEncrypted => 'Ανεξάρτητα από το επίπεδο, τα δεδομένα σας είναι πάντα κρυπτογραφημένα σε κατάσταση ηρεμίας και κατά τη μεταφορά.';
 
   @override
   String get readOnlyScope => 'Μόνο ανάγνωση';
@@ -4467,12 +4354,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trainingDataProgram => 'Πρόγραμμα δεδομένων εκπαίδευσης';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Αποκτήστε το Omi Unlimited δωρεάν συνεισφέροντας τα δεδομένα σας για την εκπαίδευση μοντέλων AI.';
+  String get getOmiUnlimitedFree => 'Αποκτήστε το Omi Unlimited δωρεάν συνεισφέροντας τα δεδομένα σας για την εκπαίδευση μοντέλων AI.';
 
   @override
-  String get trainingDataBullets =>
-      '• Τα δεδομένα σας βοηθούν στη βελτίωση των μοντέλων AI\n• Μοιράζονται μόνο μη ευαίσθητα δεδομένα\n• Πλήρως διαφανής διαδικασία';
+  String get trainingDataBullets => '• Τα δεδομένα σας βοηθούν στη βελτίωση των μοντέλων AI\n• Μοιράζονται μόνο μη ευαίσθητα δεδομένα\n• Πλήρως διαφανής διαδικασία';
 
   @override
   String get learnMoreAtOmiTraining => 'Μάθετε περισσότερα στο omi.me/training';
@@ -4484,8 +4369,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get submitRequest => 'Υποβολή αιτήματος';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Ευχαριστούμε! Το αίτημά σας εξετάζεται. Θα σας ειδοποιήσουμε μόλις εγκριθεί.';
+  String get thankYouRequestUnderReview => 'Ευχαριστούμε! Το αίτημά σας εξετάζεται. Θα σας ειδοποιήσουμε μόλις εγκριθεί.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4520,12 +4404,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get importantBillingInfo => 'Σημαντικές πληροφορίες χρέωσης:';
 
   @override
-  String get monthlyPlanContinues =>
-      'Το τρέχον μηνιαίο σας πρόγραμμα θα συνεχιστεί μέχρι το τέλος της περιόδου χρέωσης';
+  String get monthlyPlanContinues => 'Το τρέχον μηνιαίο σας πρόγραμμα θα συνεχιστεί μέχρι το τέλος της περιόδου χρέωσης';
 
   @override
-  String get paymentMethodCharged =>
-      'Ο υπάρχων τρόπος πληρωμής σας θα χρεωθεί αυτόματα όταν λήξει το μηνιαίο σας πρόγραμμα';
+  String get paymentMethodCharged => 'Ο υπάρχων τρόπος πληρωμής σας θα χρεωθεί αυτόματα όταν λήξει το μηνιαίο σας πρόγραμμα';
 
   @override
   String get annualSubscriptionStarts => 'Η 12μηνη ετήσια συνδρομή σας θα ξεκινήσει αυτόματα μετά τη χρέωση';
@@ -4568,8 +4450,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Το ετήσιο πρόγραμμά σας θα ξεκινήσει αυτόματα όταν λήξει το μηνιαίο σας πρόγραμμα.';
+  String get annualPlanStartsAutomatically => 'Το ετήσιο πρόγραμμά σας θα ξεκινήσει αυτόματα όταν λήξει το μηνιαίο σας πρόγραμμα.';
 
   @override
   String planRenewsOn(String date) {
@@ -4607,8 +4488,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get resubscribe => 'Επανεγγραφή';
 
   @override
-  String get couldNotOpenPaymentSettings =>
-      'Δεν ήταν δυνατό το άνοιγμα των ρυθμίσεων πληρωμής. Παρακαλώ δοκιμάστε ξανά.';
+  String get couldNotOpenPaymentSettings => 'Δεν ήταν δυνατό το άνοιγμα των ρυθμίσεων πληρωμής. Παρακαλώ δοκιμάστε ξανά.';
 
   @override
   String get managePaymentMethod => 'Διαχείριση μεθόδου πληρωμής';
@@ -4637,8 +4517,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Το απόρρητό σας μας ενδιαφέρει';
 
   @override
-  String get privacyIntroText =>
-      'Στην Omi, λαμβάνουμε πολύ σοβαρά το απόρρητό σας. Θέλουμε να είμαστε διαφανείς σχετικά με τα δεδομένα που συλλέγουμε και πώς τα χρησιμοποιούμε. Ορίστε τι πρέπει να γνωρίζετε:';
+  String get privacyIntroText => 'Στην Omi, λαμβάνουμε πολύ σοβαρά το απόρρητό σας. Θέλουμε να είμαστε διαφανείς σχετικά με τα δεδομένα που συλλέγουμε και πώς τα χρησιμοποιούμε. Ορίστε τι πρέπει να γνωρίζετε:';
 
   @override
   String get whatWeTrack => 'Τι παρακολουθούμε';
@@ -4653,12 +4532,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get ourCommitment => 'Η δέσμευσή μας';
 
   @override
-  String get commitmentText =>
-      'Δεσμευόμαστε να χρησιμοποιούμε τα δεδομένα που συλλέγουμε μόνο για να κάνουμε το Omi καλύτερο προϊόν για εσάς. Το απόρρητο και η εμπιστοσύνη σας είναι υψίστης σημασίας για εμάς.';
+  String get commitmentText => 'Δεσμευόμαστε να χρησιμοποιούμε τα δεδομένα που συλλέγουμε μόνο για να κάνουμε το Omi καλύτερο προϊόν για εσάς. Το απόρρητο και η εμπιστοσύνη σας είναι υψίστης σημασίας για εμάς.';
 
   @override
-  String get thankYouText =>
-      'Σας ευχαριστούμε που είστε πολύτιμος χρήστης του Omi. Εάν έχετε ερωτήσεις ή ανησυχίες, μη διστάσετε να επικοινωνήσετε μαζί μας στο team@basedhardware.com.';
+  String get thankYouText => 'Σας ευχαριστούμε που είστε πολύτιμος χρήστης του Omi. Εάν έχετε ερωτήσεις ή ανησυχίες, μη διστάσετε να επικοινωνήσετε μαζί μας στο team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Ρυθμίσεις συγχρονισμού WiFi';
@@ -4667,8 +4544,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get enterHotspotCredentials => 'Εισάγετε τα διαπιστευτήρια hotspot του τηλεφώνου σας';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'Ο συγχρονισμός WiFi χρησιμοποιεί το τηλέφωνό σας ως hotspot. Βρείτε το όνομα και τον κωδικό στις Ρυθμίσεις > Προσωπικό Hotspot.';
+  String get wifiSyncUsesHotspot => 'Ο συγχρονισμός WiFi χρησιμοποιεί το τηλέφωνό σας ως hotspot. Βρείτε το όνομα και τον κωδικό στις Ρυθμίσεις > Προσωπικό Hotspot.';
 
   @override
   String get hotspotNameSsid => 'Όνομα Hotspot (SSID)';
@@ -4703,8 +4579,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Αποτυχία δημιουργίας σύνοψης. Βεβαιωθείτε ότι έχετε συνομιλίες για εκείνη την ημέρα.';
+  String get failedToGenerateSummaryCheckConversations => 'Αποτυχία δημιουργίας σύνοψης. Βεβαιωθείτε ότι έχετε συνομιλίες για εκείνη την ημέρα.';
 
   @override
   String get summaryNotFound => 'Η σύνοψη δεν βρέθηκε';
@@ -4734,8 +4609,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Η εξαγωγή ξεκίνησε. Αυτό μπορεί να διαρκέσει λίγα δευτερόλεπτα...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Αυτό θα διαγράψει όλα τα παράγωγα δεδομένα του γράφου γνώσεων (κόμβους και συνδέσεις). Οι αρχικές σας αναμνήσεις θα παραμείνουν ασφαλείς. Ο γράφος θα ανακατασκευαστεί σταδιακά ή κατόπιν αιτήματος.';
+  String get knowledgeGraphDeleteDescription => 'Αυτό θα διαγράψει όλα τα παράγωγα δεδομένα του γράφου γνώσεων (κόμβους και συνδέσεις). Οι αρχικές σας αναμνήσεις θα παραμείνουν ασφαλείς. Ο γράφος θα ανακατασκευαστεί σταδιακά ή κατόπιν αιτήματος.';
 
   @override
   String get configureDailySummaryDigest => 'Διαμορφώστε την καθημερινή σύνοψη εργασιών σας';
@@ -4805,8 +4679,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Διαγραφή όλων των συνομιλιών Limitless;';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Αυτό θα διαγράψει μόνιμα όλες τις συνομιλίες που εισήχθησαν από το Limitless. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get deleteAllLimitlessWarning => 'Αυτό θα διαγράψει μόνιμα όλες τις συνομιλίες που εισήχθησαν από το Limitless. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4862,8 +4735,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get howItWorksTitle => 'Πώς λειτουργεί;';
 
   @override
-  String get howPeopleWorks =>
-      'Μόλις δημιουργηθεί ένα άτομο, μπορείτε να μεταβείτε σε μια μεταγραφή συνομιλίας και να του αντιστοιχίσετε τα αντίστοιχα τμήματα, έτσι το Omi θα μπορεί να αναγνωρίζει και τη δική του ομιλία!';
+  String get howPeopleWorks => 'Μόλις δημιουργηθεί ένα άτομο, μπορείτε να μεταβείτε σε μια μεταγραφή συνομιλίας και να του αντιστοιχίσετε τα αντίστοιχα τμήματα, έτσι το Omi θα μπορεί να αναγνωρίζει και τη δική του ομιλία!';
 
   @override
   String get tapToDelete => 'Πατήστε για διαγραφή';
@@ -4889,8 +4761,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get privacyNotice => 'Ειδοποίηση απορρήτου';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Οι εγγραφές μπορεί να καταγράψουν φωνές άλλων. Βεβαιωθείτε ότι έχετε τη συγκατάθεση όλων των συμμετεχόντων πριν την ενεργοποίηση.';
+  String get recordingsMayCaptureOthers => 'Οι εγγραφές μπορεί να καταγράψουν φωνές άλλων. Βεβαιωθείτε ότι έχετε τη συγκατάθεση όλων των συμμετεχόντων πριν την ενεργοποίηση.';
 
   @override
   String get enable => 'Ενεργοποίηση';
@@ -4902,8 +4773,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Διατηρήστε όλες τις ηχογραφήσεις αποθηκευμένες τοπικά στο τηλέφωνό σας. Όταν είναι απενεργοποιημένο, διατηρούνται μόνο οι αποτυχημένες μεταφορτώσεις για εξοικονόμηση χώρου.';
+  String get storeAudioDescription => 'Διατηρήστε όλες τις ηχογραφήσεις αποθηκευμένες τοπικά στο τηλέφωνό σας. Όταν είναι απενεργοποιημένο, διατηρούνται μόνο οι αποτυχημένες μεταφορτώσεις για εξοικονόμηση χώρου.';
 
   @override
   String get enableLocalStorage => 'Ενεργοποίηση τοπικής αποθήκευσης';
@@ -4921,12 +4791,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get storeAudioOnCloud => 'Αποθήκευση ήχου στο Cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Οι εγγραφές σας σε πραγματικό χρόνο θα αποθηκεύονται σε ιδιωτικό χώρο αποθήκευσης cloud καθώς μιλάτε.';
+  String get cloudStorageDialogMessage => 'Οι εγγραφές σας σε πραγματικό χρόνο θα αποθηκεύονται σε ιδιωτικό χώρο αποθήκευσης cloud καθώς μιλάτε.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Αποθηκεύστε τις εγγραφές σας σε πραγματικό χρόνο σε ιδιωτικό χώρο αποθήκευσης cloud καθώς μιλάτε. Ο ήχος καταγράφεται και αποθηκεύεται με ασφάλεια σε πραγματικό χρόνο.';
+  String get storeAudioCloudDescription => 'Αποθηκεύστε τις εγγραφές σας σε πραγματικό χρόνο σε ιδιωτικό χώρο αποθήκευσης cloud καθώς μιλάτε. Ο ήχος καταγράφεται και αποθηκεύεται με ασφάλεια σε πραγματικό χρόνο.';
 
   @override
   String get downloadingFirmware => 'Λήψη υλικολογισμικού';
@@ -4935,8 +4803,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get installingFirmware => 'Εγκατάσταση υλικολογισμικού';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Μην κλείσετε την εφαρμογή ή απενεργοποιήσετε τη συσκευή. Αυτό μπορεί να καταστρέψει τη συσκευή σας.';
+  String get firmwareUpdateWarning => 'Μην κλείσετε την εφαρμογή ή απενεργοποιήσετε τη συσκευή. Αυτό μπορεί να καταστρέψει τη συσκευή σας.';
 
   @override
   String get firmwareUpdated => 'Το υλικολογισμικό ενημερώθηκε';
@@ -4980,8 +4847,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get payments => 'Πληρωμές';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Συνδέστε μια μέθοδο πληρωμής παρακάτω για να αρχίσετε να λαμβάνετε πληρωμές για τις εφαρμογές σας.';
+  String get connectPaymentMethodInfo => 'Συνδέστε μια μέθοδο πληρωμής παρακάτω για να αρχίσετε να λαμβάνετε πληρωμές για τις εφαρμογές σας.';
 
   @override
   String get selectedPaymentMethod => 'Επιλεγμένη μέθοδος πληρωμής';
@@ -5008,15 +4874,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get monthlyPayouts => 'Μηνιαίες πληρωμές';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Λάβετε μηνιαίες πληρωμές απευθείας στον λογαριασμό σας όταν φτάσετε τα \$10 σε κέρδη';
+  String get monthlyPayoutsDescription => 'Λάβετε μηνιαίες πληρωμές απευθείας στον λογαριασμό σας όταν φτάσετε τα \$10 σε κέρδη';
 
   @override
   String get secureAndReliable => 'Ασφαλές και αξιόπιστο';
 
   @override
-  String get stripeSecureDescription =>
-      'Το Stripe εξασφαλίζει ασφαλείς και έγκαιρες μεταφορές των εσόδων της εφαρμογής σας';
+  String get stripeSecureDescription => 'Το Stripe εξασφαλίζει ασφαλείς και έγκαιρες μεταφορές των εσόδων της εφαρμογής σας';
 
   @override
   String get selectYourCountry => 'Επιλέξτε τη χώρα σας';
@@ -5037,8 +4901,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get connectingYourStripeAccount => 'Σύνδεση του λογαριασμού Stripe σας';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Παρακαλώ ολοκληρώστε τη διαδικασία εγγραφής Stripe στον browser σας. Αυτή η σελίδα θα ενημερωθεί αυτόματα μετά την ολοκλήρωση.';
+  String get stripeOnboardingInstructions => 'Παρακαλώ ολοκληρώστε τη διαδικασία εγγραφής Stripe στον browser σας. Αυτή η σελίδα θα ενημερωθεί αυτόματα μετά την ολοκλήρωση.';
 
   @override
   String get failedTryAgain => 'Απέτυχε; Δοκιμάστε ξανά';
@@ -5050,8 +4913,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get successfullyConnected => 'Επιτυχής σύνδεση!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Ο λογαριασμός Stripe σας είναι τώρα έτοιμος να λαμβάνει πληρωμές. Μπορείτε να αρχίσετε να κερδίζετε από τις πωλήσεις των εφαρμογών σας αμέσως.';
+  String get stripeReadyForPayments => 'Ο λογαριασμός Stripe σας είναι τώρα έτοιμος να λαμβάνει πληρωμές. Μπορείτε να αρχίσετε να κερδίζετε από τις πωλήσεις των εφαρμογών σας αμέσως.';
 
   @override
   String get updateStripeDetails => 'Ενημέρωση στοιχείων Stripe';
@@ -5069,8 +4931,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Ενημερώστε τα στοιχεία του λογαριασμού PayPal σας';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Συνδέστε τον λογαριασμό PayPal σας για να αρχίσετε να λαμβάνετε πληρωμές για τις εφαρμογές σας';
+  String get connectPayPalToReceivePayments => 'Συνδέστε τον λογαριασμό PayPal σας για να αρχίσετε να λαμβάνετε πληρωμές για τις εφαρμογές σας';
 
   @override
   String get paypalEmail => 'Email PayPal';
@@ -5079,8 +4940,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get paypalMeLink => 'Σύνδεσμος PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Εάν το Stripe είναι διαθέσιμο στη χώρα σας, σας συνιστούμε ανεπιφύλακτα να το χρησιμοποιήσετε για ταχύτερες και ευκολότερες πληρωμές.';
+  String get stripeRecommendation => 'Εάν το Stripe είναι διαθέσιμο στη χώρα σας, σας συνιστούμε ανεπιφύλακτα να το χρησιμοποιήσετε για ταχύτερες και ευκολότερες πληρωμές.';
 
   @override
   String get updatePayPalDetails => 'Ενημέρωση στοιχείων PayPal';
@@ -5132,12 +4992,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Το πρόσθετο δείγμα ομιλίας αφαιρέθηκε';
 
   @override
-  String get consentDataMessage =>
-      'Συνεχίζοντας, οι συνομιλίες, οι εγγραφές και τα προσωπικά σας στοιχεία θα αποθηκευτούν με ασφάλεια στους διακομιστές μας. Οι ηχογραφήσεις και τα μεταγραφές σας επεξεργάζονται από υπηρεσίες τεχνητής νοημοσύνης τρίτων (συμπεριλαμβανομένων των Deepgram για μεταγραφή και OpenAI για ανάλυση) για να σας παρέχουν γνώσεις βασισμένες σε AI και να ενεργοποιήσουν όλες τις λειτουργίες της εφαρμογής.';
+  String get consentDataMessage => 'Συνεχίζοντας, οι συνομιλίες, οι εγγραφές και τα προσωπικά σας στοιχεία θα αποθηκευτούν με ασφάλεια στους διακομιστές μας. Οι ηχογραφήσεις και τα μεταγραφές σας επεξεργάζονται από υπηρεσίες τεχνητής νοημοσύνης τρίτων (συμπεριλαμβανομένων των Deepgram για μεταγραφή και OpenAI για ανάλυση) για να σας παρέχουν γνώσεις βασισμένες σε AI και να ενεργοποιήσουν όλες τις λειτουργίες της εφαρμογής.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Οι εργασίες από τις συνομιλίες σας θα εμφανιστούν εδώ.\nΠατήστε + για χειροκίνητη δημιουργία.';
+  String get tasksEmptyStateMessage => 'Οι εργασίες από τις συνομιλίες σας θα εμφανιστούν εδώ.\nΠατήστε + για χειροκίνητη δημιουργία.';
 
   @override
   String get clearChatAction => 'Διαγραφή συνομιλίας';
@@ -5173,15 +5031,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Εγκαταστήστε το Omi στο\nApple Watch σας';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Για να χρησιμοποιήσετε το Apple Watch με το Omi, πρέπει πρώτα να εγκαταστήσετε την εφαρμογή Omi στο ρολόι σας.';
+  String get installOmiOnAppleWatchDescription => 'Για να χρησιμοποιήσετε το Apple Watch με το Omi, πρέπει πρώτα να εγκαταστήσετε την εφαρμογή Omi στο ρολόι σας.';
 
   @override
   String get openOmiOnAppleWatch => 'Ανοίξτε το Omi στο\nApple Watch σας';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Η εφαρμογή Omi είναι εγκατεστημένη στο Apple Watch σας. Ανοίξτε την και πατήστε Έναρξη.';
+  String get openOmiOnAppleWatchDescription => 'Η εφαρμογή Omi είναι εγκατεστημένη στο Apple Watch σας. Ανοίξτε την και πατήστε Έναρξη.';
 
   @override
   String get openWatchApp => 'Άνοιγμα εφαρμογής Watch';
@@ -5190,15 +5046,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Έχω εγκαταστήσει και ανοίξει την εφαρμογή';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Δεν είναι δυνατό το άνοιγμα της εφαρμογής Apple Watch. Ανοίξτε χειροκίνητα την εφαρμογή Watch στο Apple Watch και εγκαταστήστε το Omi από την ενότητα \"Διαθέσιμες εφαρμογές\".';
+  String get unableToOpenWatchApp => 'Δεν είναι δυνατό το άνοιγμα της εφαρμογής Apple Watch. Ανοίξτε χειροκίνητα την εφαρμογή Watch στο Apple Watch και εγκαταστήστε το Omi από την ενότητα \"Διαθέσιμες εφαρμογές\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Το Apple Watch συνδέθηκε επιτυχώς!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Το Apple Watch δεν είναι ακόμα προσβάσιμο. Βεβαιωθείτε ότι η εφαρμογή Omi είναι ανοιχτή στο ρολόι σας.';
+  String get appleWatchNotReachable => 'Το Apple Watch δεν είναι ακόμα προσβάσιμο. Βεβαιωθείτε ότι η εφαρμογή Omi είναι ανοιχτή στο ρολόι σας.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5215,8 +5069,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get finishedConversation => 'Τελείωσε η συνομιλία;';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Είστε σίγουροι ότι θέλετε να σταματήσετε την εγγραφή και να συνοψίσετε τη συνομιλία τώρα;';
+  String get stopRecordingConfirmation => 'Είστε σίγουροι ότι θέλετε να σταματήσετε την εγγραφή και να συνοψίσετε τη συνομιλία τώρα;';
 
   @override
   String get conversationEndsManually => 'Η συνομιλία θα τελειώσει μόνο χειροκίνητα.';
@@ -5627,8 +5480,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get multipleSpeakersDetected => 'Εντοπίστηκαν πολλοί ομιλητές';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Φαίνεται ότι υπάρχουν πολλοί ομιλητές στην εγγραφή. Βεβαιωθείτε ότι βρίσκεστε σε ήσυχο μέρος και δοκιμάστε ξανά.';
+  String get multipleSpeakersDescription => 'Φαίνεται ότι υπάρχουν πολλοί ομιλητές στην εγγραφή. Βεβαιωθείτε ότι βρίσκεστε σε ήσυχο μέρος και δοκιμάστε ξανά.';
 
   @override
   String get invalidRecordingDetected => 'Εντοπίστηκε μη έγκυρη εγγραφή';
@@ -5637,19 +5489,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get notEnoughSpeechDescription => 'Δεν εντοπίστηκε αρκετή ομιλία. Μιλήστε περισσότερο και δοκιμάστε ξανά.';
 
   @override
-  String get speechDurationDescription =>
-      'Βεβαιωθείτε ότι μιλάτε τουλάχιστον 5 δευτερόλεπτα και όχι περισσότερο από 90.';
+  String get speechDurationDescription => 'Βεβαιωθείτε ότι μιλάτε τουλάχιστον 5 δευτερόλεπτα και όχι περισσότερο από 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Η σύνδεση διακόπηκε. Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
+  String get connectionLostDescription => 'Η σύνδεση διακόπηκε. Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
 
   @override
   String get howToTakeGoodSample => 'Πώς να πάρετε ένα καλό δείγμα;';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Βεβαιωθείτε ότι βρίσκεστε σε ήσυχο μέρος.\n2. Μιλήστε καθαρά και φυσικά.\n3. Βεβαιωθείτε ότι η συσκευή σας είναι στη φυσική της θέση στο λαιμό σας.\n\nΜόλις δημιουργηθεί, μπορείτε πάντα να το βελτιώσετε ή να το κάνετε ξανά.';
+  String get goodSampleInstructions => '1. Βεβαιωθείτε ότι βρίσκεστε σε ήσυχο μέρος.\n2. Μιλήστε καθαρά και φυσικά.\n3. Βεβαιωθείτε ότι η συσκευή σας είναι στη φυσική της θέση στο λαιμό σας.\n\nΜόλις δημιουργηθεί, μπορείτε πάντα να το βελτιώσετε ή να το κάνετε ξανά.';
 
   @override
   String get noDeviceConnectedUseMic => 'Δεν έχει συνδεθεί συσκευή. Θα χρησιμοποιηθεί το μικρόφωνο του τηλεφώνου.';
@@ -5712,12 +5561,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get howItWorks => 'Πώς λειτουργεί';
 
   @override
-  String get dailyScoreExplanation =>
-      'Το ημερήσιο σκορ σας βασίζεται στην ολοκλήρωση εργασιών. Ολοκληρώστε τις εργασίες σας για να βελτιώσετε το σκορ!';
+  String get dailyScoreExplanation => 'Το ημερήσιο σκορ σας βασίζεται στην ολοκλήρωση εργασιών. Ολοκληρώστε τις εργασίες σας για να βελτιώσετε το σκορ!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Ελέγξτε πόσο συχνά το Omi σας στέλνει προληπτικές ειδοποιήσεις και υπενθυμίσεις.';
+  String get notificationFrequencyDescription => 'Ελέγξτε πόσο συχνά το Omi σας στέλνει προληπτικές ειδοποιήσεις και υπενθυμίσεις.';
 
   @override
   String get sliderOff => 'Απεν.';
@@ -5731,8 +5578,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Αποτυχία δημιουργίας σύνοψης. Βεβαιωθείτε ότι έχετε συνομιλίες για εκείνη την ημέρα.';
+  String get failedToGenerateSummary => 'Αποτυχία δημιουργίας σύνοψης. Βεβαιωθείτε ότι έχετε συνομιλίες για εκείνη την ημέρα.';
 
   @override
   String get recap => 'Ανακεφαλαίωση';
@@ -5811,8 +5657,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get selectApp => 'Επιλογή εφαρμογής';
 
   @override
-  String get noChatAppsEnabled =>
-      'Δεν έχουν ενεργοποιηθεί εφαρμογές συνομιλίας.\nΠατήστε \"Ενεργοποίηση εφαρμογών\" για προσθήκη.';
+  String get noChatAppsEnabled => 'Δεν έχουν ενεργοποιηθεί εφαρμογές συνομιλίας.\nΠατήστε \"Ενεργοποίηση εφαρμογών\" για προσθήκη.';
 
   @override
   String get disable => 'Απενεργοποίηση';
@@ -5964,8 +5809,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get recordings => 'Εγγραφές';
 
   @override
-  String get enableRemindersAccess =>
-      'Παρακαλώ ενεργοποιήστε την πρόσβαση στις Υπενθυμίσεις στις Ρυθμίσεις για να χρησιμοποιήσετε τις Υπενθυμίσεις Apple';
+  String get enableRemindersAccess => 'Παρακαλώ ενεργοποιήστε την πρόσβαση στις Υπενθυμίσεις στις Ρυθμίσεις για να χρησιμοποιήσετε τις Υπενθυμίσεις Apple';
 
   @override
   String todayAtTime(String time) {
@@ -6094,15 +5938,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get cloudProvider => 'Πάροχος Cloud';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 premium λεπτά/μήνα. Η καρτέλα Στη Συσκευή προσφέρει απεριόριστη δωρεάν μεταγραφή.';
+  String get premiumMinutesInfo => '1.200 premium λεπτά/μήνα. Η καρτέλα Στη Συσκευή προσφέρει απεριόριστη δωρεάν μεταγραφή.';
 
   @override
   String get viewUsage => 'Προβολή χρήσης';
 
   @override
-  String get localProcessingInfo =>
-      'Ο ήχος επεξεργάζεται τοπικά. Λειτουργεί εκτός σύνδεσης, πιο ιδιωτικό, αλλά καταναλώνει περισσότερη μπαταρία.';
+  String get localProcessingInfo => 'Ο ήχος επεξεργάζεται τοπικά. Λειτουργεί εκτός σύνδεσης, πιο ιδιωτικό, αλλά καταναλώνει περισσότερη μπαταρία.';
 
   @override
   String get model => 'Μοντέλο';
@@ -6111,15 +5953,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get performanceWarning => 'Προειδοποίηση απόδοσης';
 
   @override
-  String get largeModelWarning =>
-      'Αυτό το μοντέλο είναι μεγάλο και μπορεί να προκαλέσει κατάρρευση της εφαρμογής ή να λειτουργεί πολύ αργά σε κινητές συσκευές.\n\nΣυνιστάται το \"small\" ή \"base\".';
+  String get largeModelWarning => 'Αυτό το μοντέλο είναι μεγάλο και μπορεί να προκαλέσει κατάρρευση της εφαρμογής ή να λειτουργεί πολύ αργά σε κινητές συσκευές.\n\nΣυνιστάται το \"small\" ή \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Χρήση εγγενούς αναγνώρισης ομιλίας iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Θα χρησιμοποιηθεί η εγγενής μηχανή ομιλίας της συσκευής σας. Δεν απαιτείται λήψη μοντέλου.';
+  String get noModelDownloadRequired => 'Θα χρησιμοποιηθεί η εγγενής μηχανή ομιλίας της συσκευής σας. Δεν απαιτείται λήψη μοντέλου.';
 
   @override
   String get modelReady => 'Μοντέλο Έτοιμο';
@@ -6176,12 +6016,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get batteryDrainSignificantly => 'Η κατανάλωση μπαταρίας θα αυξηθεί σημαντικά.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 premium λεπτά/μήνα. Η καρτέλα Στη συσκευή προσφέρει απεριόριστη δωρεάν μεταγραφή. ';
+  String get premiumMinutesMonth => '1.200 premium λεπτά/μήνα. Η καρτέλα Στη συσκευή προσφέρει απεριόριστη δωρεάν μεταγραφή. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Ο ήχος επεξεργάζεται τοπικά. Λειτουργεί εκτός σύνδεσης, πιο ιδιωτικό, αλλά καταναλώνει περισσότερη μπαταρία.';
+  String get audioProcessedLocally => 'Ο ήχος επεξεργάζεται τοπικά. Λειτουργεί εκτός σύνδεσης, πιο ιδιωτικό, αλλά καταναλώνει περισσότερη μπαταρία.';
 
   @override
   String get languageLabel => 'Γλώσσα';
@@ -6190,12 +6028,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get modelLabel => 'Μοντέλο';
 
   @override
-  String get modelTooLargeWarning =>
-      'Αυτό το μοντέλο είναι μεγάλο και μπορεί να προκαλέσει κατάρρευση της εφαρμογής ή πολύ αργή λειτουργία σε κινητές συσκευές.\n\nΣυνιστάται το small ή base.';
+  String get modelTooLargeWarning => 'Αυτό το μοντέλο είναι μεγάλο και μπορεί να προκαλέσει κατάρρευση της εφαρμογής ή πολύ αργή λειτουργία σε κινητές συσκευές.\n\nΣυνιστάται το small ή base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Θα χρησιμοποιηθεί η εγγενής μηχανή ομιλίας της συσκευής σας. Δεν απαιτείται λήψη μοντέλου.';
+  String get nativeEngineNoDownload => 'Θα χρησιμοποιηθεί η εγγενής μηχανή ομιλίας της συσκευής σας. Δεν απαιτείται λήψη μοντέλου.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6231,8 +6067,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Η ενσωματωμένη ζωντανή μεταγραφή του Omi είναι βελτιστοποιημένη για συνομιλίες σε πραγματικό χρόνο με αυτόματη ανίχνευση και διαχωρισμό ομιλητών.';
+  String get omiTranscriptionOptimized => 'Η ενσωματωμένη ζωντανή μεταγραφή του Omi είναι βελτιστοποιημένη για συνομιλίες σε πραγματικό χρόνο με αυτόματη ανίχνευση και διαχωρισμό ομιλητών.';
 
   @override
   String get reset => 'Επαναφορά';
@@ -6452,8 +6287,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Δημιουργία γραφήματος γνώσης από αναμνήσεις...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Το γράφημα γνώσης θα δημιουργηθεί αυτόματα καθώς δημιουργείτε νέες αναμνήσεις.';
+  String get knowledgeGraphWillBuildAutomatically => 'Το γράφημα γνώσης θα δημιουργηθεί αυτόματα καθώς δημιουργείτε νέες αναμνήσεις.';
 
   @override
   String get buildGraphButton => 'Δημιουργία γραφήματος';
@@ -6689,8 +6523,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get failedToLoadContacts => 'Αποτυχία φόρτωσης επαφών';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Αποτυχία προετοιμασίας συνομιλίας για κοινοποίηση. Παρακαλώ δοκιμάστε ξανά.';
+  String get failedToPrepareConversationForSharing => 'Αποτυχία προετοιμασίας συνομιλίας για κοινοποίηση. Παρακαλώ δοκιμάστε ξανά.';
 
   @override
   String get couldNotOpenSmsApp => 'Δεν ήταν δυνατό το άνοιγμα της εφαρμογής SMS. Παρακαλώ δοκιμάστε ξανά.';
@@ -6756,8 +6589,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Λήψη ήχου από την κάρτα SD της συσκευής σας';
 
   @override
-  String get transferRequiredDescription =>
-      'Αυτή η εγγραφή είναι αποθηκευμένη στην κάρτα SD της συσκευής σας. Μεταφέρετέ την στο τηλέφωνό σας για αναπαραγωγή.';
+  String get transferRequiredDescription => 'Αυτή η εγγραφή είναι αποθηκευμένη στην κάρτα SD της συσκευής σας. Μεταφέρετέ την στο τηλέφωνό σας για αναπαραγωγή.';
 
   @override
   String get cancelTransfer => 'Ακύρωση μεταφοράς';
@@ -6778,8 +6610,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get shareRecording => 'Κοινοποίηση εγγραφής';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Είστε βέβαιοι ότι θέλετε να διαγράψετε οριστικά αυτήν την εγγραφή; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+  String get deleteRecordingConfirmation => 'Είστε βέβαιοι ότι θέλετε να διαγράψετε οριστικά αυτήν την εγγραφή; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
 
   @override
   String get recordingIdLabel => 'Αναγνωριστικό εγγραφής';
@@ -6838,15 +6669,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get enableFastTransfer => 'Ενεργοποίηση γρήγορης μεταφοράς';
 
   @override
-  String get fastTransferDescription =>
-      'Η γρήγορη μεταφορά χρησιμοποιεί WiFi για ~5x ταχύτερες ταχύτητες. Το τηλέφωνό σας θα συνδεθεί προσωρινά στο δίκτυο WiFi της συσκευής Omi κατά τη μεταφορά.';
+  String get fastTransferDescription => 'Η γρήγορη μεταφορά χρησιμοποιεί WiFi για ~5x ταχύτερες ταχύτητες. Το τηλέφωνό σας θα συνδεθεί προσωρινά στο δίκτυο WiFi της συσκευής Omi κατά τη μεταφορά.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Η πρόσβαση στο διαδίκτυο διακόπτεται κατά τη μεταφορά';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Επιλέξτε πώς μεταφέρονται οι εγγραφές από τη συσκευή Omi στο τηλέφωνό σας.';
+  String get chooseTransferMethodDescription => 'Επιλέξτε πώς μεταφέρονται οι εγγραφές από τη συσκευή Omi στο τηλέφωνό σας.';
 
   @override
   String get wifiSpeed => '~150 KB/s μέσω WiFi';
@@ -6855,8 +6684,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fiveTimesFaster => '5X ΓΡΗΓΟΡΟΤΕΡΟ';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Δημιουργεί απευθείας σύνδεση WiFi με τη συσκευή Omi. Το τηλέφωνό σας αποσυνδέεται προσωρινά από το κανονικό WiFi κατά τη μεταφορά.';
+  String get fastTransferMethodDescription => 'Δημιουργεί απευθείας σύνδεση WiFi με τη συσκευή Omi. Το τηλέφωνό σας αποσυνδέεται προσωρινά από το κανονικό WiFi κατά τη μεταφορά.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6865,8 +6693,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get bleSpeed => '~30 KB/s μέσω BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Χρησιμοποιεί τυπική σύνδεση Bluetooth Low Energy. Πιο αργό αλλά δεν επηρεάζει τη σύνδεση WiFi.';
+  String get bluetoothMethodDescription => 'Χρησιμοποιεί τυπική σύνδεση Bluetooth Low Energy. Πιο αργό αλλά δεν επηρεάζει τη σύνδεση WiFi.';
 
   @override
   String get selected => 'Επιλεγμένο';
@@ -6884,8 +6711,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'Η συσκευή Omi σας αποσυνδέθηκε';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'Παρακαλώ επανασυνδεθείτε για να συνεχίσετε να χρησιμοποιείτε το Omi.';
+  String get deviceDisconnectedNotificationBody => 'Παρακαλώ επανασυνδεθείτε για να συνεχίσετε να χρησιμοποιείτε το Omi.';
 
   @override
   String get firmwareUpdateAvailable => 'Διαθέσιμη ενημέρωση υλικολογισμικού';
@@ -6905,12 +6731,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get appDeleteFailed => 'Αποτυχία διαγραφής εφαρμογής. Δοκιμάστε ξανά αργότερα.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Η ορατότητα της εφαρμογής άλλαξε επιτυχώς. Μπορεί να χρειαστούν μερικά λεπτά.';
+  String get appVisibilityChangedSuccessfully => 'Η ορατότητα της εφαρμογής άλλαξε επιτυχώς. Μπορεί να χρειαστούν μερικά λεπτά.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Σφάλμα κατά την ενεργοποίηση της εφαρμογής. Αν είναι εφαρμογή ενσωμάτωσης, βεβαιωθείτε ότι η ρύθμιση έχει ολοκληρωθεί.';
+  String get errorActivatingAppIntegration => 'Σφάλμα κατά την ενεργοποίηση της εφαρμογής. Αν είναι εφαρμογή ενσωμάτωσης, βεβαιωθείτε ότι η ρύθμιση έχει ολοκληρωθεί.';
 
   @override
   String get errorUpdatingAppStatus => 'Παρουσιάστηκε σφάλμα κατά την ενημέρωση της κατάστασης της εφαρμογής.';
@@ -7177,16 +7001,13 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Η αναβάθμιση προγραμματίστηκε! Το μηνιαίο πλάνο σας συνεχίζεται μέχρι το τέλος της περιόδου χρέωσης.';
+  String get planUpgradeScheduledMessage => 'Η αναβάθμιση προγραμματίστηκε! Το μηνιαίο πλάνο σας συνεχίζεται μέχρι το τέλος της περιόδου χρέωσης.';
 
   @override
-  String get couldNotSchedulePlanChange =>
-      'Δεν ήταν δυνατός ο προγραμματισμός αλλαγής πλάνου. Παρακαλώ δοκιμάστε ξανά.';
+  String get couldNotSchedulePlanChange => 'Δεν ήταν δυνατός ο προγραμματισμός αλλαγής πλάνου. Παρακαλώ δοκιμάστε ξανά.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Η συνδρομή σας επανενεργοποιήθηκε! Χωρίς χρέωση τώρα - θα χρεωθείτε στο τέλος της τρέχουσας περιόδου.';
+  String get subscriptionReactivatedDefault => 'Η συνδρομή σας επανενεργοποιήθηκε! Χωρίς χρέωση τώρα - θα χρεωθείτε στο τέλος της τρέχουσας περιόδου.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Επιτυχής συνδρομή! Χρεωθήκατε για τη νέα περίοδο χρέωσης.';
@@ -7195,8 +7016,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get couldNotProcessSubscription => 'Δεν ήταν δυνατή η επεξεργασία της συνδρομής. Παρακαλώ δοκιμάστε ξανά.';
 
   @override
-  String get couldNotLaunchUpgradePage =>
-      'Δεν ήταν δυνατή η εκκίνηση της σελίδας αναβάθμισης. Παρακαλώ δοκιμάστε ξανά.';
+  String get couldNotLaunchUpgradePage => 'Δεν ήταν δυνατή η εκκίνηση της σελίδας αναβάθμισης. Παρακαλώ δοκιμάστε ξανά.';
 
   @override
   String get transcriptionJsonPlaceholder => 'Επικολλήστε τη διαμόρφωση JSON εδώ...';
@@ -7355,8 +7175,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Αποτυχία ανάκτησης του Firebase token, παρακαλώ δοκιμάστε ξανά.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Απρόσμενο σφάλμα κατά τη σύνδεση, σφάλμα Firebase, παρακαλώ δοκιμάστε ξανά.';
+  String get authUnexpectedErrorFirebase => 'Απρόσμενο σφάλμα κατά τη σύνδεση, σφάλμα Firebase, παρακαλώ δοκιμάστε ξανά.';
 
   @override
   String get authUnexpectedError => 'Απρόσμενο σφάλμα κατά τη σύνδεση, παρακαλώ δοκιμάστε ξανά';
@@ -7371,8 +7190,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Απαιτείται άδεια Bluetooth για σύνδεση με τη συσκευή σας.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Η άδεια Bluetooth απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Η άδεια Bluetooth απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7385,12 +7203,10 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Η άδεια ειδοποιήσεων απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Η άδεια ειδοποιήσεων απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Η άδεια ειδοποιήσεων απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος > Ειδοποιήσεις.';
+  String get onboardingNotificationDeniedNotifications => 'Η άδεια ειδοποιήσεων απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος > Ειδοποιήσεις.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7403,15 +7219,13 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Παρακαλώ χορηγήστε άδεια τοποθεσίας στις Ρυθμίσεις > Απόρρητο και Ασφάλεια > Υπηρεσίες Τοποθεσίας';
+  String get onboardingLocationGrantInSettings => 'Παρακαλώ χορηγήστε άδεια τοποθεσίας στις Ρυθμίσεις > Απόρρητο και Ασφάλεια > Υπηρεσίες Τοποθεσίας';
 
   @override
   String get onboardingMicrophoneRequired => 'Απαιτείται άδεια μικροφώνου για εγγραφή.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Η άδεια μικροφώνου απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος > Απόρρητο και Ασφάλεια > Μικρόφωνο.';
+  String get onboardingMicrophoneDenied => 'Η άδεια μικροφώνου απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος > Απόρρητο και Ασφάλεια > Μικρόφωνο.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7427,8 +7241,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Απαιτείται άδεια καταγραφής οθόνης για εγγραφή ήχου συστήματος.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Η άδεια καταγραφής οθόνης απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος > Απόρρητο και Ασφάλεια > Εγγραφή Οθόνης.';
+  String get onboardingScreenCaptureDenied => 'Η άδεια καταγραφής οθόνης απορρίφθηκε. Παρακαλώ χορηγήστε άδεια στις Προτιμήσεις Συστήματος > Απόρρητο και Ασφάλεια > Εγγραφή Οθόνης.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7441,8 +7254,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Απαιτείται άδεια προσβασιμότητας για ανίχνευση συναντήσεων προγράμματος περιήγησης.';
+  String get onboardingAccessibilityRequired => 'Απαιτείται άδεια προσβασιμότητας για ανίχνευση συναντήσεων προγράμματος περιήγησης.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7482,8 +7294,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Η άδεια φωτογραφιών απορρίφθηκε. Παρακαλώ επιτρέψτε την πρόσβαση στις φωτογραφίες για να επιλέξετε εικόνες';
+  String get msgPhotosPermissionDenied => 'Η άδεια φωτογραφιών απορρίφθηκε. Παρακαλώ επιτρέψτε την πρόσβαση στις φωτογραφίες για να επιλέξετε εικόνες';
 
   @override
   String get msgSelectImagesGenericError => 'Σφάλμα επιλογής εικόνων. Παρακαλώ δοκιμάστε ξανά.';
@@ -7537,12 +7348,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get devModeInvalidAudioBytesWebhookUrl => 'Μη έγκυρη διεύθυνση URL webhook για bytes ήχου';
 
   @override
-  String get devModeInvalidRealtimeTranscriptWebhookUrl =>
-      'Μη έγκυρη διεύθυνση URL webhook για μεταγραφή σε πραγματικό χρόνο';
+  String get devModeInvalidRealtimeTranscriptWebhookUrl => 'Μη έγκυρη διεύθυνση URL webhook για μεταγραφή σε πραγματικό χρόνο';
 
   @override
-  String get devModeInvalidConversationCreatedWebhookUrl =>
-      'Μη έγκυρη διεύθυνση URL webhook για δημιουργημένη συνομιλία';
+  String get devModeInvalidConversationCreatedWebhookUrl => 'Μη έγκυρη διεύθυνση URL webhook για δημιουργημένη συνομιλία';
 
   @override
   String get devModeInvalidDaySummaryWebhookUrl => 'Μη έγκυρη διεύθυνση URL webhook για ημερήσια σύνοψη';
@@ -7557,8 +7366,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get locationPermissionRequired => 'Απαιτείται άδεια τοποθεσίας';
 
   @override
-  String get locationPermissionContent =>
-      'Η γρήγορη μεταφορά απαιτεί άδεια τοποθεσίας για να επαληθεύσει τη σύνδεση WiFi. Παρακαλώ δώστε άδεια τοποθεσίας για να συνεχίσετε.';
+  String get locationPermissionContent => 'Η γρήγορη μεταφορά απαιτεί άδεια τοποθεσίας για να επαληθεύσει τη σύνδεση WiFi. Παρακαλώ δώστε άδεια τοποθεσίας για να συνεχίσετε.';
 
   @override
   String get pdfTranscriptExport => 'Εξαγωγή μεταγραφής';
@@ -7721,8 +7529,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Η συσκευή δεν υποστηρίζει συγχρονισμό WiFi, μετάβαση σε Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Η συσκευή δεν υποστηρίζει συγχρονισμό WiFi, μετάβαση σε Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Το Apple Health δεν είναι διαθέσιμο σε αυτήν τη συσκευή';
@@ -7991,8 +7798,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get audioPlaybackUnavailable => 'Το αρχείο ήχου δεν είναι διαθέσιμο για αναπαραγωγή';
 
   @override
-  String get audioPlaybackFailed =>
-      'Δεν είναι δυνατή η αναπαραγωγή ήχου. Το αρχείο μπορεί να είναι κατεστραμμένο ή να λείπει.';
+  String get audioPlaybackFailed => 'Δεν είναι δυνατή η αναπαραγωγή ήχου. Το αρχείο μπορεί να είναι κατεστραμμένο ή να λείπει.';
 
   @override
   String get connectionGuide => 'Οδηγός σύνδεσης';
@@ -8019,8 +7825,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Θέστε το Omi DevKit σε λειτουργία σύζευξης';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Πατήστε το κουμπί μία φορά για ενεργοποίηση. Το LED θα αναβοσβήνει μωβ στη λειτουργία σύζευξης.';
+  String get pairingDescOmiDevkit => 'Πατήστε το κουμπί μία φορά για ενεργοποίηση. Το LED θα αναβοσβήνει μωβ στη λειτουργία σύζευξης.';
 
   @override
   String get pairingTitleOmiGlass => 'Ενεργοποιήστε το Omi Glass';
@@ -8032,50 +7837,43 @@ class AppLocalizationsEl extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Θέστε το Plaud Note σε λειτουργία σύζευξης';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Πατήστε παρατεταμένα το πλαϊνό κουμπί για 2 δευτερόλεπτα. Το κόκκινο LED θα αναβοσβήνει όταν είναι έτοιμο για σύζευξη.';
+  String get pairingDescPlaudNote => 'Πατήστε παρατεταμένα το πλαϊνό κουμπί για 2 δευτερόλεπτα. Το κόκκινο LED θα αναβοσβήνει όταν είναι έτοιμο για σύζευξη.';
 
   @override
   String get pairingTitleBee => 'Θέστε το Bee σε λειτουργία σύζευξης';
 
   @override
-  String get pairingDescBee =>
-      'Πατήστε το κουμπί 5 φορές συνεχόμενα. Το φως θα αρχίσει να αναβοσβήνει μπλε και πράσινο.';
+  String get pairingDescBee => 'Πατήστε το κουμπί 5 φορές συνεχόμενα. Το φως θα αρχίσει να αναβοσβήνει μπλε και πράσινο.';
 
   @override
   String get pairingTitleLimitless => 'Θέστε το Limitless σε λειτουργία σύζευξης';
 
   @override
-  String get pairingDescLimitless =>
-      'Όταν είναι ορατό οποιοδήποτε φως, πατήστε μία φορά και μετά πατήστε παρατεταμένα μέχρι η συσκευή να δείξει ροζ φως, μετά αφήστε.';
+  String get pairingDescLimitless => 'Όταν είναι ορατό οποιοδήποτε φως, πατήστε μία φορά και μετά πατήστε παρατεταμένα μέχρι η συσκευή να δείξει ροζ φως, μετά αφήστε.';
 
   @override
   String get pairingTitleFriendPendant => 'Θέστε το Friend Pendant σε λειτουργία σύζευξης';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Πατήστε το κουμπί στο μενταγιόν για να το ενεργοποιήσετε. Θα εισέλθει αυτόματα σε λειτουργία σύζευξης.';
+  String get pairingDescFriendPendant => 'Πατήστε το κουμπί στο μενταγιόν για να το ενεργοποιήσετε. Θα εισέλθει αυτόματα σε λειτουργία σύζευξης.';
 
   @override
   String get pairingTitleFieldy => 'Θέστε το Fieldy σε λειτουργία σύζευξης';
 
   @override
-  String get pairingDescFieldy =>
-      'Πατήστε παρατεταμένα τη συσκευή μέχρι να εμφανιστεί το φως για να την ενεργοποιήσετε.';
+  String get pairingDescFieldy => 'Πατήστε παρατεταμένα τη συσκευή μέχρι να εμφανιστεί το φως για να την ενεργοποιήσετε.';
 
   @override
   String get pairingTitleAppleWatch => 'Συνδέστε το Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Εγκαταστήστε και ανοίξτε την εφαρμογή Omi στο Apple Watch σας, μετά πατήστε Σύνδεση στην εφαρμογή.';
+  String get pairingDescAppleWatch => 'Εγκαταστήστε και ανοίξτε την εφαρμογή Omi στο Apple Watch σας, μετά πατήστε Σύνδεση στην εφαρμογή.';
 
   @override
   String get pairingTitleNeoOne => 'Θέστε το Neo One σε λειτουργία σύζευξης';
 
   @override
-  String get pairingDescNeoOne =>
-      'Πατήστε παρατεταμένα το κουμπί τροφοδοσίας μέχρι να αναβοσβήσει το LED. Η συσκευή θα είναι ανιχνεύσιμη.';
+  String get pairingDescNeoOne => 'Πατήστε παρατεταμένα το κουμπί τροφοδοσίας μέχρι να αναβοσβήσει το LED. Η συσκευή θα είναι ανιχνεύσιμη.';
 
   @override
   String get downloadingFromDevice => 'Λήψη από τη συσκευή';
@@ -8145,8 +7943,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get wifiConfiguration => 'Ρύθμιση WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Εισαγάγετε τα στοιχεία WiFi για να επιτρέψετε στη συσκευή να κατεβάσει το firmware.';
+  String get wifiConfigurationSubtitle => 'Εισαγάγετε τα στοιχεία WiFi για να επιτρέψετε στη συσκευή να κατεβάσει το firmware.';
 
   @override
   String get networkNameSsid => 'Όνομα δικτύου (SSID)';
@@ -8164,8 +7961,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Αυτά γνωρίζω για εσένα';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Αυτός ο χάρτης ενημερώνεται καθώς το Omi μαθαίνει από τις συνομιλίες σας.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Αυτός ο χάρτης ενημερώνεται καθώς το Omi μαθαίνει από τις συνομιλίες σας.';
 
   @override
   String get apiEnvironment => 'Περιβάλλον API';
@@ -8194,12 +7990,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get switchAndRestart => 'Εναλλαγή';
 
   @override
-  String get stagingDisclaimer =>
-      'Το δοκιμαστικό περιβάλλον μπορεί να είναι ασταθές, με ασυνεπή απόδοση και τα δεδομένα μπορεί να χαθούν. Μόνο για δοκιμές.';
+  String get stagingDisclaimer => 'Το δοκιμαστικό περιβάλλον μπορεί να είναι ασταθές, με ασυνεπή απόδοση και τα δεδομένα μπορεί να χαθούν. Μόνο για δοκιμές.';
 
   @override
-  String get apiEnvSavedRestartRequired =>
-      'Αποθηκεύτηκε. Κλείστε και ανοίξτε ξανά την εφαρμογή για να εφαρμοστούν οι αλλαγές.';
+  String get apiEnvSavedRestartRequired => 'Αποθηκεύτηκε. Κλείστε και ανοίξτε ξανά την εφαρμογή για να εφαρμοστούν οι αλλαγές.';
 
   @override
   String get shared => 'Κοινόχρηστο';
@@ -8425,8 +8219,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Τηλεφωνικές κλήσεις μέσω Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Κάντε κλήσεις μέσω Omi και λάβετε μεταγραφή σε πραγματικό χρόνο, αυτόματες περιλήψεις και πολλά άλλα.';
+  String get phoneCallsUpsellSubtitle => 'Κάντε κλήσεις μέσω Omi και λάβετε μεταγραφή σε πραγματικό χρόνο, αυτόματες περιλήψεις και πολλά άλλα.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Μεταγραφή σε πραγματικό χρόνο κάθε κλήσης';
@@ -8453,8 +8246,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteSyncedFiles => 'Διαγραφή συγχρονισμένων ηχογραφήσεων';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Αυτές οι ηχογραφήσεις έχουν ήδη συγχρονιστεί με το τηλέφωνό σας. Δεν μπορεί να αναιρεθεί.';
+  String get deleteSyncedFilesMessage => 'Αυτές οι ηχογραφήσεις έχουν ήδη συγχρονιστεί με το τηλέφωνό σας. Δεν μπορεί να αναιρεθεί.';
 
   @override
   String get syncedFilesDeleted => 'Οι συγχρονισμένες ηχογραφήσεις διαγράφηκαν';
@@ -8466,8 +8258,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deletePendingFiles => 'Διαγραφή εκκρεμών ηχογραφήσεων';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Αυτές οι ηχογραφήσεις ΔΕΝ έχουν συγχρονιστεί με το τηλέφωνό σας και θα χαθούν μόνιμα. Δεν μπορεί να αναιρεθεί.';
+  String get deletePendingFilesWarning => 'Αυτές οι ηχογραφήσεις ΔΕΝ έχουν συγχρονιστεί με το τηλέφωνό σας και θα χαθούν μόνιμα. Δεν μπορεί να αναιρεθεί.';
 
   @override
   String get pendingFilesDeleted => 'Οι εκκρεμείς ηχογραφήσεις διαγράφηκαν';
@@ -8479,8 +8270,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deleteAll => 'Διαγραφή όλων';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Αυτό θα διαγράψει συγχρονισμένες και εκκρεμείς ηχογραφήσεις. Οι εκκρεμείς ηχογραφήσεις ΔΕΝ έχουν συγχρονιστεί και θα χαθούν μόνιμα.';
+  String get deleteAllFilesWarning => 'Αυτό θα διαγράψει συγχρονισμένες και εκκρεμείς ηχογραφήσεις. Οι εκκρεμείς ηχογραφήσεις ΔΕΝ έχουν συγχρονιστεί και θα χαθούν μόνιμα.';
 
   @override
   String get allFilesDeleted => 'Όλες οι ηχογραφήσεις διαγράφηκαν';
@@ -8545,8 +8335,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fairUseAboutTitle => 'Σχετικά με τη δίκαιη χρήση';
 
   @override
-  String get fairUseAboutBody =>
-      'Το Omi είναι σχεδιασμένο για προσωπικές συνομιλίες, συναντήσεις και ζωντανές αλληλεπιδράσεις. Η χρήση μετράται βάσει του πραγματικού χρόνου ομιλίας που ανιχνεύεται, όχι του χρόνου σύνδεσης. Εάν η χρήση υπερβαίνει σημαντικά τα κανονικά πρότυπα για μη προσωπικό περιεχόμενο, ενδέχεται να εφαρμοστούν προσαρμογές.';
+  String get fairUseAboutBody => 'Το Omi είναι σχεδιασμένο για προσωπικές συνομιλίες, συναντήσεις και ζωντανές αλληλεπιδράσεις. Η χρήση μετράται βάσει του πραγματικού χρόνου ομιλίας που ανιχνεύεται, όχι του χρόνου σύνδεσης. Εάν η χρήση υπερβαίνει σημαντικά τα κανονικά πρότυπα για μη προσωπικό περιεχόμενο, ενδέχεται να εφαρμοστούν προσαρμογές.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8584,8 +8373,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get improveConnectionTitle => 'Βελτίωση σύνδεσης';
 
   @override
-  String get improveConnectionContent =>
-      'Βελτιώσαμε τον τρόπο που το Omi παραμένει συνδεδεμένο με τη συσκευή σας. Για να το ενεργοποιήσετε, μεταβείτε στη σελίδα Πληροφορίες συσκευής, πατήστε \"Αποσύνδεση συσκευής\" και συνδέστε ξανά τη συσκευή σας.';
+  String get improveConnectionContent => 'Βελτιώσαμε τον τρόπο που το Omi παραμένει συνδεδεμένο με τη συσκευή σας. Για να το ενεργοποιήσετε, μεταβείτε στη σελίδα Πληροφορίες συσκευής, πατήστε \"Αποσύνδεση συσκευής\" και συνδέστε ξανά τη συσκευή σας.';
 
   @override
   String get improveConnectionAction => 'Κατάλαβα';
@@ -8640,16 +8428,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get cancelSyncQuestion => 'Ακύρωση συγχρονισμού;';
 
   @override
-  String get omisStorageDesc =>
-      'Όταν το Omi σας δεν είναι συνδεδεμένο στο τηλέφωνό σας, αποθηκεύει ήχο τοπικά στην ενσωματωμένη μνήμη του. Δεν χάνετε ποτέ μια εγγραφή.';
+  String get omisStorageDesc => 'Όταν το Omi σας δεν είναι συνδεδεμένο στο τηλέφωνό σας, αποθηκεύει ήχο τοπικά στην ενσωματωμένη μνήμη του. Δεν χάνετε ποτέ μια εγγραφή.';
 
   @override
-  String get phoneStorageDesc =>
-      'Όταν το Omi επανασυνδεθεί, οι εγγραφές μεταφέρονται αυτόματα στο τηλέφωνό σας πριν τη μεταφόρτωση.';
+  String get phoneStorageDesc => 'Όταν το Omi επανασυνδεθεί, οι εγγραφές μεταφέρονται αυτόματα στο τηλέφωνό σας πριν τη μεταφόρτωση.';
 
   @override
-  String get cloudStorageDesc =>
-      'Μετά τη μεταφόρτωση, οι εγγραφές σας επεξεργάζονται και μεταγράφονται. Οι συνομιλίες θα είναι διαθέσιμες σε ένα λεπτό.';
+  String get cloudStorageDesc => 'Μετά τη μεταφόρτωση, οι εγγραφές σας επεξεργάζονται και μεταγράφονται. Οι συνομιλίες θα είναι διαθέσιμες σε ένα λεπτό.';
 
   @override
   String get tipKeepPhoneNearby => 'Κρατήστε το τηλέφωνό σας κοντά για ταχύτερο συγχρονισμό';
@@ -8673,12 +8458,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get permissionEnable => 'Ενεργοποίηση';
 
   @override
-  String get permissionsPageDescription =>
-      'Αυτές οι άδειες είναι βασικές για τη λειτουργία του Omi. Ενεργοποιούν βασικές λειτουργίες όπως ειδοποιήσεις, εμπειρίες βάσει τοποθεσίας και καταγραφή ήχου.';
+  String get permissionsPageDescription => 'Αυτές οι άδειες είναι βασικές για τη λειτουργία του Omi. Ενεργοποιούν βασικές λειτουργίες όπως ειδοποιήσεις, εμπειρίες βάσει τοποθεσίας και καταγραφή ήχου.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Το Omi χρειάζεται μερικά δικαιώματα για να λειτουργήσει σωστά. Παρακαλώ παραχωρήστε τα για να συνεχίσετε.';
+  String get permissionsRequiredDescription => 'Το Omi χρειάζεται μερικά δικαιώματα για να λειτουργήσει σωστά. Παρακαλώ παραχωρήστε τα για να συνεχίσετε.';
 
   @override
   String get permissionsSetupTitle => 'Αποκτήστε την καλύτερη εμπειρία';
@@ -8732,8 +8515,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get justAMoment => 'Μια στιγμή, παρακαλώ';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Συνιστούμε ανεπιφύλακτα να εξερευνήσετε τις άλλες επιλογές σας αντί να ακυρώσετε.';
+  String get cancelConsequencesSubtitle => 'Συνιστούμε ανεπιφύλακτα να εξερευνήσετε τις άλλες επιλογές σας αντί να ακυρώσετε.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8956,8 +8738,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get firmwareWarningTitle => 'Σημαντικό: Διαβάστε πριν την ενημέρωση';
 
   @override
-  String get firmwareFormatWarning =>
-      'Αυτό το firmware θα διαμορφώσει την κάρτα SD. Βεβαιωθείτε ότι όλα τα offline δεδομένα έχουν συγχρονιστεί πριν την αναβάθμιση.\n\nΑν δείτε ένα κόκκινο φως που αναβοσβήνει μετά την εγκατάσταση αυτής της έκδοσης, μην ανησυχείτε. Απλά συνδέστε τη συσκευή στην εφαρμογή και θα πρέπει να γίνει μπλε. Το κόκκινο φως σημαίνει ότι το ρολόι της συσκευής δεν έχει συγχρονιστεί ακόμα.';
+  String get firmwareFormatWarning => 'Αυτό το firmware θα διαμορφώσει την κάρτα SD. Βεβαιωθείτε ότι όλα τα offline δεδομένα έχουν συγχρονιστεί πριν την αναβάθμιση.\n\nΑν δείτε ένα κόκκινο φως που αναβοσβήνει μετά την εγκατάσταση αυτής της έκδοσης, μην ανησυχείτε. Απλά συνδέστε τη συσκευή στην εφαρμογή και θα πρέπει να γίνει μπλε. Το κόκκινο φως σημαίνει ότι το ρολόι της συσκευής δεν έχει συγχρονιστεί ακόμα.';
 
   @override
   String get continueAnyway => 'Συνέχεια';
@@ -8977,8 +8758,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get tasksMarkComplete => 'Επισημάνθηκε ως ολοκληρωμένο';
 
   @override
-  String get appleHealthManageNote =>
-      'Το Omi αποκτά πρόσβαση στο Apple Health μέσω του πλαισίου HealthKit της Apple. Μπορείτε να ανακαλέσετε την πρόσβαση ανά πάσα στιγμή από τις Ρυθμίσεις iOS.';
+  String get appleHealthManageNote => 'Το Omi αποκτά πρόσβαση στο Apple Health μέσω του πλαισίου HealthKit της Apple. Μπορείτε να ανακαλέσετε την πρόσβαση ανά πάσα στιγμή από τις Ρυθμίσεις iOS.';
 
   @override
   String get appleHealthConnectCta => 'Σύνδεση με το Apple Health';
@@ -8993,15 +8773,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get appleHealthFeatureChatTitle => 'Μιλήστε για την υγεία σας';
 
   @override
-  String get appleHealthFeatureChatDesc =>
-      'Ρωτήστε το Omi για τα βήματα, τον ύπνο, τον καρδιακό ρυθμό και τις προπονήσεις σας.';
+  String get appleHealthFeatureChatDesc => 'Ρωτήστε το Omi για τα βήματα, τον ύπνο, τον καρδιακό ρυθμό και τις προπονήσεις σας.';
 
   @override
   String get appleHealthFeatureReadOnlyTitle => 'Πρόσβαση μόνο για ανάγνωση';
 
   @override
-  String get appleHealthFeatureReadOnlyDesc =>
-      'Το Omi δεν γράφει ποτέ στο Apple Health και δεν τροποποιεί τα δεδομένα σας.';
+  String get appleHealthFeatureReadOnlyDesc => 'Το Omi δεν γράφει ποτέ στο Apple Health και δεν τροποποιεί τα δεδομένα σας.';
 
   @override
   String get appleHealthFeatureSecureTitle => 'Ασφαλής συγχρονισμός';
@@ -9013,8 +8791,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Απορρίφθηκε η πρόσβαση στο Apple Health';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Το Omi δεν έχει άδεια να διαβάσει τα δεδομένα σας Apple Health. Ενεργοποιήστε το στο Ρυθμίσεις iOS → Απόρρητο και ασφάλεια → Health → Omi.';
+  String get appleHealthDeniedBody => 'Το Omi δεν έχει άδεια να διαβάσει τα δεδομένα σας Apple Health. Ενεργοποιήστε το στο Ρυθμίσεις iOS → Απόρρητο και ασφάλεια → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Γιατί φεύγετε;';
@@ -9083,8 +8860,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get planUpdate => 'Ενημέρωση πλάνου';
 
   @override
-  String get planDeprecationMessage =>
-      'Το πλάνο Unlimited σας καταργείται. Μεταβείτε στο πλάνο Operator — ίδιες εξαιρετικές λειτουργίες στα \$49/μήνα. Το τρέχον πλάνο σας θα συνεχίσει να λειτουργεί στο μεταξύ.';
+  String get planDeprecationMessage => 'Το πλάνο Unlimited σας καταργείται. Μεταβείτε στο πλάνο Operator — ίδιες εξαιρετικές λειτουργίες στα \$49/μήνα. Το τρέχον πλάνο σας θα συνεχίσει να λειτουργεί στο μεταξύ.';
 
   @override
   String get upgradeYourPlan => 'Αναβαθμίστε το πλάνο σας';
@@ -9195,8 +8971,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Φτάσατε το μηνιαίο σας όριο. Αναβαθμίστε για να συνεχίσετε να συνομιλείτε με το Omi χωρίς περιορισμούς.';
+  String get chatQuotaExceededReply => 'Φτάσατε το μηνιαίο σας όριο. Αναβαθμίστε για να συνεχίσετε να συνομιλείτε με το Omi χωρίς περιορισμούς.';
 
   @override
   String get voiceResponseAudio => 'Ανάγνωση απάντησης Omi φωναχτά';
@@ -9227,4 +9002,25 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Προσθήκη εργασίας';
+
+  @override
+  String get quickActionAskOmiAnything => 'Ρωτήστε τον Omi οτιδήποτε';
+
+  @override
+  String get quickActionVoiceMode => 'Λειτουργία φωνής';
+
+  @override
+  String get quickActionMute => 'Σίγαση';
+
+  @override
+  String get quickActionUnmute => 'Αναίρεση σίγασης';
+
+  @override
+  String get quickActionConnectDevice => 'Σύνδεση συσκευής';
+
+  @override
+  String get quickActionDeviceSettings => 'Ρυθμίσεις συσκευής';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -24,8 +24,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteConversationTitle => 'Delete Conversation?';
 
   @override
-  String get deleteConversationMessage =>
-      'This will also delete associated memories, tasks, and audio files. This action cannot be undone.';
+  String get deleteConversationMessage => 'This will also delete associated memories, tasks, and audio files. This action cannot be undone.';
 
   @override
   String get confirm => 'Confirm';
@@ -146,8 +145,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleting => 'Deleting...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Please complete authentication in your browser. Once done, return to the app.';
+  String get pleaseCompleteAuthentication => 'Please complete authentication in your browser. Once done, return to the app.';
 
   @override
   String get failedToStartAuthentication => 'Failed to start authentication';
@@ -355,19 +353,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appsDisconnected => 'Your Apps and Integrations will be disconnected effectively immediately.';
 
   @override
-  String get exportBeforeDelete =>
-      'You can export your data before deleting your account, but once deleted, it cannot be recovered.';
+  String get exportBeforeDelete => 'You can export your data before deleting your account, but once deleted, it cannot be recovered.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'I understand that deleting my account is permanent and all data, including memories and conversations, will be lost and cannot be recovered.';
+  String get deleteAccountCheckbox => 'I understand that deleting my account is permanent and all data, including memories and conversations, will be lost and cannot be recovered.';
 
   @override
   String get areYouSure => 'Are you sure?';
 
   @override
-  String get deleteAccountFinal =>
-      'This action is irreversible and will permanently delete your account and all associated data. Are you sure you want to proceed?';
+  String get deleteAccountFinal => 'This action is irreversible and will permanently delete your account and all associated data. Are you sure you want to proceed?';
 
   @override
   String get deleteNow => 'Delete Now';
@@ -376,8 +371,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get goBack => 'Go Back';
 
   @override
-  String get checkBoxToConfirm =>
-      'Check the box to confirm you understand that deleting your account is permanent and irreversible.';
+  String get checkBoxToConfirm => 'Check the box to confirm you understand that deleting your account is permanent and irreversible.';
 
   @override
   String get profile => 'Profile';
@@ -455,8 +449,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get yourPrivacyYourControl => 'Your Privacy, Your Control';
 
   @override
-  String get privacyIntro =>
-      'At Omi, we are committed to protecting your privacy. This page allows you to control how your data is stored and used.';
+  String get privacyIntro => 'At Omi, we are committed to protecting your privacy. This page allows you to control how your data is stored and used.';
 
   @override
   String get learnMore => 'Learn more...';
@@ -465,8 +458,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dataProtectionLevel => 'Data Protection Level';
 
   @override
-  String get dataProtectionDesc =>
-      'Your data is secured by default with strong encryption. Review your settings and future privacy options below.';
+  String get dataProtectionDesc => 'Your data is secured by default with strong encryption. Review your settings and future privacy options below.';
 
   @override
   String get appAccess => 'App Access';
@@ -529,15 +521,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Your Omi has been disconnected 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Device unpaired. Go to Settings > Bluetooth and forget the device to complete unpairing.';
+  String get deviceUnpairedMessage => 'Device unpaired. Go to Settings > Bluetooth and forget the device to complete unpairing.';
 
   @override
   String get unpairDialogTitle => 'Unpair Device';
 
   @override
-  String get unpairDialogMessage =>
-      'This will unpair the device so it can be connected to another phone. You will need to go to Settings > Bluetooth and forget the device to complete the process.';
+  String get unpairDialogMessage => 'This will unpair the device so it can be connected to another phone. You will need to go to Settings > Bluetooth and forget the device to complete the process.';
 
   @override
   String get deviceNotConnected => 'Device Not Connected';
@@ -558,8 +548,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get v2Undetected => 'V2 undetected';
 
   @override
-  String get v2UndetectedMessage =>
-      'We see that you either have a V1 device or your device is not connected. SD Card functionality is available only for V2 devices.';
+  String get v2UndetectedMessage => 'We see that you either have a V1 device or your device is not connected. SD Card functionality is available only for V2 devices.';
 
   @override
   String get endConversation => 'End Conversation';
@@ -833,8 +822,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Delete Knowledge Graph?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'This will delete all derived knowledge graph data (nodes and connections). Your original memories will remain safe. The graph will be rebuilt over time or upon next request.';
+  String get deleteKnowledgeGraphMessage => 'This will delete all derived knowledge graph data (nodes and connections). Your original memories will remain safe. The graph will be rebuilt over time or upon next request.';
 
   @override
   String get knowledgeGraphDeleted => 'Knowledge Graph deleted';
@@ -982,8 +970,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shortConversationThreshold => 'Short Conversation Threshold';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Conversations shorter than this will be hidden unless enabled above';
+  String get shortConversationThresholdSubtitle => 'Conversations shorter than this will be hidden unless enabled above';
 
   @override
   String get durationThreshold => 'Duration Threshold';
@@ -1078,8 +1065,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get needYourPermission => 'We need your permission';
 
   @override
-  String get alreadyGavePermission =>
-      'You\'ve already given us permission to save your recordings. Here\'s a reminder of why we need it:';
+  String get alreadyGavePermission => 'You\'ve already given us permission to save your recordings. Here\'s a reminder of why we need it:';
 
   @override
   String get wouldLikePermission => 'We\'d like your permission to save your voice recordings. Here\'s why:';
@@ -1094,19 +1080,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trainFamilyProfiles => 'Train Profiles for Friends and Family';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Your recordings help us recognize and create profiles for your friends and family.';
+  String get trainFamilyProfilesDesc => 'Your recordings help us recognize and create profiles for your friends and family.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Enhance Transcript Accuracy';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'As our model improves, we can provide better transcription results for your recordings.';
+  String get enhanceTranscriptAccuracyDesc => 'As our model improves, we can provide better transcription results for your recordings.';
 
   @override
-  String get legalNotice =>
-      'Legal Notice: The legality of recording and storing voice data may vary depending on your location and how you use this feature. It\'s your responsibility to ensure compliance with local laws and regulations.';
+  String get legalNotice => 'Legal Notice: The legality of recording and storing voice data may vary depending on your location and how you use this feature. It\'s your responsibility to ensure compliance with local laws and regulations.';
 
   @override
   String get alreadyAuthorized => 'Already Authorized';
@@ -1184,8 +1167,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showEventsNoParticipants => 'Show events with no participants';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'When enabled, Coming Up shows events without participants or a video link.';
+  String get showEventsNoParticipantsDesc => 'When enabled, Coming Up shows events without participants or a video link.';
 
   @override
   String get yourMeetings => 'Your Meetings';
@@ -1226,8 +1208,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noProjectsInWorkspace => 'No projects found in this workspace';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Choose how long to wait in silence before automatically ending a conversation:';
+  String get conversationTimeoutDesc => 'Choose how long to wait in silence before automatically ending a conversation:';
 
   @override
   String get timeout2Minutes => '2 minutes';
@@ -1354,8 +1335,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get defaultRepository => 'Default Repository';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Select a default repository for creating issues. You can still specify a different repository when creating issues.';
+  String get selectDefaultRepoDesc => 'Select a default repository for creating issues. You can still specify a different repository when creating issues.';
 
   @override
   String get noReposFound => 'No repositories found';
@@ -1730,8 +1710,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get enableBluetooth => 'Enable Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi needs Bluetooth to connect to your wearable. Please enable Bluetooth and try again.';
+  String get bluetoothNeeded => 'Omi needs Bluetooth to connect to your wearable. Please enable Bluetooth and try again.';
 
   @override
   String get contactSupport => 'Contact Support?';
@@ -1764,26 +1743,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get locationServiceDisabled => 'Location Service Disabled';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Location Service is Disabled. Please go to Settings > Privacy & Security > Location Services and enable it';
+  String get locationServiceDisabledDesc => 'Location Service is Disabled. Please go to Settings > Privacy & Security > Location Services and enable it';
 
   @override
   String get backgroundLocationDenied => 'Background Location Access Denied';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Please go to device settings and set location permission to \"Always Allow\"';
+  String get backgroundLocationDeniedDesc => 'Please go to device settings and set location permission to \"Always Allow\"';
 
   @override
   String get lovingOmi => 'Loving Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Help us reach more people by leaving a review in the App Store. Your feedback means the world to us!';
+  String get leaveReviewIos => 'Help us reach more people by leaving a review in the App Store. Your feedback means the world to us!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Help us reach more people by leaving a review in the Google Play Store. Your feedback means the world to us!';
+  String get leaveReviewAndroid => 'Help us reach more people by leaving a review in the Google Play Store. Your feedback means the world to us!';
 
   @override
   String get rateOnAppStore => 'Rate on App Store';
@@ -1816,15 +1791,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get connectionError => 'Connection Error';
 
   @override
-  String get connectionErrorDesc =>
-      'Failed to connect to the server. Please check your internet connection and try again.';
+  String get connectionErrorDesc => 'Failed to connect to the server. Please check your internet connection and try again.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Invalid recording detected';
 
   @override
-  String get multipleSpeakersDesc =>
-      'It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.';
+  String get multipleSpeakersDesc => 'It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.';
 
   @override
   String get tooShortDesc => 'There is not enough speech detected. Please speak more and try again.';
@@ -1836,15 +1809,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get areYouThere => 'Are you there?';
 
   @override
-  String get noSpeechDesc =>
-      'We could not detect any speech. Please make sure to speak for at least 10 seconds and not more than 3 minutes.';
+  String get noSpeechDesc => 'We could not detect any speech. Please make sure to speak for at least 10 seconds and not more than 3 minutes.';
 
   @override
   String get connectionLost => 'Connection Lost';
 
   @override
-  String get connectionLostDesc =>
-      'The connection was interrupted. Please check your internet connection and try again.';
+  String get connectionLostDesc => 'The connection was interrupted. Please check your internet connection and try again.';
 
   @override
   String get tryAgain => 'Try Again';
@@ -1859,8 +1830,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get permissionsRequired => 'Permissions Required';
 
   @override
-  String get permissionsRequiredDesc =>
-      'This app needs Bluetooth and Location permissions to function properly. Please enable them in the settings.';
+  String get permissionsRequiredDesc => 'This app needs Bluetooth and Location permissions to function properly. Please enable them in the settings.';
 
   @override
   String get openSettings => 'Open Settings';
@@ -1902,12 +1872,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get microphonePermission => 'Microphone Permission';
 
   @override
-  String get permissionGrantedNow =>
-      'Permission granted! Now:\n\nOpen the Omi app on your watch and tap \"Continue\" below';
+  String get permissionGrantedNow => 'Permission granted! Now:\n\nOpen the Omi app on your watch and tap \"Continue\" below';
 
   @override
-  String get needMicrophonePermission =>
-      'We need microphone permission.\n\n1. Tap \"Grant Permission\"\n2. Allow on your iPhone\n3. Watch app will close\n4. Reopen and tap \"Continue\"';
+  String get needMicrophonePermission => 'We need microphone permission.\n\n1. Tap \"Grant Permission\"\n2. Allow on your iPhone\n3. Watch app will close\n4. Reopen and tap \"Continue\"';
 
   @override
   String get grantPermissionButton => 'Grant Permission';
@@ -1916,15 +1884,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get needHelp => 'Need Help?';
 
   @override
-  String get troubleshootingSteps =>
-      'Troubleshooting:\n\n1. Ensure Omi is installed on your watch\n2. Open the Omi app on your watch\n3. Look for the permission popup\n4. Tap \"Allow\" when prompted\n5. App on your watch will close - reopen it\n6. Come back and tap \"Continue\" on your iPhone';
+  String get troubleshootingSteps => 'Troubleshooting:\n\n1. Ensure Omi is installed on your watch\n2. Open the Omi app on your watch\n3. Look for the permission popup\n4. Tap \"Allow\" when prompted\n5. App on your watch will close - reopen it\n6. Come back and tap \"Continue\" on your iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Recording started successfully!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Permission not granted yet. Please make sure you allowed microphone access and reopened the app on your watch.';
+  String get permissionNotGrantedYet => 'Permission not granted yet. Please make sure you allowed microphone access and reopened the app on your watch.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2021,8 +1987,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Ready for Action Items';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Your AI will automatically extract tasks and to-dos from your conversations. They\'ll appear here when created.';
+  String get welcomeActionItemsDescription => 'Your AI will automatically extract tasks and to-dos from your conversations. They\'ll appear here when created.';
 
   @override
   String get autoExtractionFeature => 'Automatically extracted from conversations';
@@ -2218,15 +2183,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'SPEECH & TRANSCRIPTION';
 
   @override
-  String get languageSettingsHelperText =>
-      'App Language changes menus and buttons. Speech Language affects how your recordings are transcribed.';
+  String get languageSettingsHelperText => 'App Language changes menus and buttons. Speech Language affects how your recordings are transcribed.';
 
   @override
   String get translationNotice => 'Translation Notice';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi translates conversations into your primary language. Update it anytime in Settings → Profiles.';
+  String get translationNoticeMessage => 'Omi translates conversations into your primary language. Update it anytime in Settings → Profiles.';
 
   @override
   String get pleaseCheckInternetConnection => 'Please check your internet connection and try again';
@@ -2388,8 +2351,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Unpair Device';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'This will unpair the device so it can be connected to another phone. You will need to go to Settings > Bluetooth and forget the device to complete the process.';
+  String get unpairDeviceDialogMessage => 'This will unpair the device so it can be connected to another phone. You will need to go to Settings > Bluetooth and forget the device to complete the process.';
 
   @override
   String get unpair => 'Unpair';
@@ -2570,8 +2532,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get youreAllSet => 'You\'re all set!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Welcome to Omi! Your AI companion is ready to assist you with conversations, tasks, and more.';
+  String get welcomeToOmiDescription => 'Welcome to Omi! Your AI companion is ready to assist you with conversations, tasks, and more.';
 
   @override
   String get startUsingOmi => 'Start Using Omi';
@@ -2707,8 +2668,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noTasksYet => 'No Tasks Yet';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Tasks from your conversations will appear here.\nClick Create to add one manually.';
+  String get tasksFromConversationsWillAppear => 'Tasks from your conversations will appear here.\nClick Create to add one manually.';
 
   @override
   String get monthJan => 'Jan';
@@ -2765,8 +2725,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteActionItem => 'Delete Action Item';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Are you sure you want to delete this action item? This action cannot be undone.';
+  String get deleteActionItemConfirmation => 'Are you sure you want to delete this action item? This action cannot be undone.';
 
   @override
   String get enterActionItemDescription => 'Enter action item description...';
@@ -2841,15 +2800,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatPrompt => 'Chat Prompt';
 
   @override
-  String get chatPromptPlaceholder =>
-      'You are an awesome app, your job is to respond to the user queries and make them feel good...';
+  String get chatPromptPlaceholder => 'You are an awesome app, your job is to respond to the user queries and make them feel good...';
 
   @override
   String get conversationPrompt => 'Conversation Prompt';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'You are an awesome app, you will be given transcript and summary of a conversation...';
+  String get conversationPromptPlaceholder => 'You are an awesome app, you will be given transcript and summary of a conversation...';
 
   @override
   String get notificationScopes => 'Notification Scopes';
@@ -2861,8 +2818,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get makeMyAppPublic => 'Make my app public';
 
   @override
-  String get submitAppTermsAgreement =>
-      'By submitting this app, I agree to the Omi AI Terms of Service and Privacy Policy';
+  String get submitAppTermsAgreement => 'By submitting this app, I agree to the Omi AI Terms of Service and Privacy Policy';
 
   @override
   String get submitApp => 'Submit App';
@@ -2877,12 +2833,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get submitAppQuestion => 'Submit App?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Your app will be reviewed and made public. You can start using it immediately, even during the review!';
+  String get submitAppPublicDescription => 'Your app will be reviewed and made public. You can start using it immediately, even during the review!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Your app will be reviewed and made available to you privately. You can start using it immediately, even during the review!';
+  String get submitAppPrivateDescription => 'Your app will be reviewed and made available to you privately. You can start using it immediately, even during the review!';
 
   @override
   String get startEarning => 'Start Earning! 💰';
@@ -2906,19 +2860,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dataAccessNotice => 'Data Access Notice';
 
   @override
-  String get dataAccessWarning =>
-      'This app will access your data. Omi AI is not responsible for how your data is used, modified, or deleted by this app';
+  String get dataAccessWarning => 'This app will access your data. Omi AI is not responsible for how your data is used, modified, or deleted by this app';
 
   @override
   String get installApp => 'Install App';
 
   @override
-  String get betaTesterNotice =>
-      'You are a beta tester for this app. It is not public yet. It will be public once approved.';
+  String get betaTesterNotice => 'You are a beta tester for this app. It is not public yet. It will be public once approved.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Your app is under review and visible only to you. It will be public once approved.';
+  String get appUnderReviewOwner => 'Your app is under review and visible only to you. It will be public once approved.';
 
   @override
   String get appRejectedNotice => 'Your app has been rejected. Please update the app details and resubmit for review.';
@@ -2983,8 +2934,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get descriptionLabel => 'Description';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'My Awesome App is a great app that does amazing things. It is the best app ever!';
+  String get appDescriptionPlaceholder => 'My Awesome App is a great app that does amazing things. It is the best app ever!';
 
   @override
   String get pleaseProvideValidDescription => 'Please provide a valid description';
@@ -3136,8 +3086,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get microphonePermissionRequired => 'Microphone permission is required to make calls';
 
   @override
-  String get microphonePermissionDenied =>
-      'Microphone permission denied. Please grant permission in System Preferences > Privacy & Security > Microphone.';
+  String get microphonePermissionDenied => 'Microphone permission denied. Please grant permission in System Preferences > Privacy & Security > Microphone.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3370,8 +3319,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get whatWeCollect => 'What we collect';
 
   @override
-  String get dataCollectionMessage =>
-      'By continuing, your conversations, recordings, and personal information will be securely stored on our servers to provide AI-powered insights and enable all app features.';
+  String get dataCollectionMessage => 'By continuing, your conversations, recordings, and personal information will be securely stored on our servers to provide AI-powered insights and enable all app features.';
 
   @override
   String get dataProtection => 'Data Protection';
@@ -3404,8 +3352,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Name must be at least 2 characters';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Tell us how you\'d like to be addressed. This helps personalize your Omi experience.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Tell us how you\'d like to be addressed. This helps personalize your Omi experience.';
 
   @override
   String charactersCount(int count) {
@@ -3422,8 +3369,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get recordAudioConversations => 'Record audio conversations';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi needs microphone access to record your conversations and provide transcriptions.';
+  String get microphoneAccessDescription => 'Omi needs microphone access to record your conversations and provide transcriptions.';
 
   @override
   String get screenRecording => 'Screen Recording';
@@ -3432,8 +3378,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Capture system audio from meetings';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi needs screen recording permission to capture system audio from your browser-based meetings.';
+  String get screenRecordingDescription => 'Omi needs screen recording permission to capture system audio from your browser-based meetings.';
 
   @override
   String get accessibility => 'Accessibility';
@@ -3442,8 +3387,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Detect browser-based meetings';
 
   @override
-  String get accessibilityDescription =>
-      'Omi needs accessibility permission to detect when you join Zoom, Meet, or Teams meetings in your browser.';
+  String get accessibilityDescription => 'Omi needs accessibility permission to detect when you join Zoom, Meet, or Teams meetings in your browser.';
 
   @override
   String get pleaseWait => 'Please wait...';
@@ -3515,8 +3459,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get conversationsExportStarted => 'Conversations Export Started. This may take a few seconds, please wait.';
 
   @override
-  String get mcpDescription =>
-      'To connect Omi with other applications to read, search, and manage your memories and conversations. Create a key to get started.';
+  String get mcpDescription => 'To connect Omi with other applications to read, search, and manage your memories and conversations. Create a key to get started.';
 
   @override
   String get apiKeys => 'API Keys';
@@ -3563,8 +3506,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'Auto-create and tag new speakers';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Automatically create a new person when a name is detected in the transcript.';
+  String get automaticallyCreateNewPerson => 'Automatically create a new person when a name is detected in the transcript.';
 
   @override
   String get pilotFeatures => 'Pilot Features';
@@ -3625,8 +3567,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Let Omi choose the best app automatically';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Are you sure you want to delete this conversation? This action cannot be undone.';
+  String get deleteConversationConfirmation => 'Are you sure you want to delete this conversation? This action cannot be undone.';
 
   @override
   String get conversationDeleted => 'Conversation deleted';
@@ -3674,8 +3615,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Preparing system audio capture';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Click the button to capture audio for live transcripts, AI insights, and automatic saving.';
+  String get clickTheButtonToCaptureAudio => 'Click the button to capture audio for live transcripts, AI insights, and automatic saving.';
 
   @override
   String get reconnecting => 'Reconnecting...';
@@ -3833,8 +3773,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dailySummaryTitle => 'Daily Summary';
 
   @override
-  String get dailySummaryDescription =>
-      'Get a personalized summary of your day\'s conversations delivered as a notification.';
+  String get dailySummaryDescription => 'Get a personalized summary of your day\'s conversations delivered as a notification.';
 
   @override
   String get deliveryTime => 'Delivery Time';
@@ -3903,8 +3842,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Delete Knowledge Graph?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'This will delete all derived knowledge graph data. Your original memories remain safe.';
+  String get deleteKnowledgeGraphWarning => 'This will delete all derived knowledge graph data. Your original memories remain safe.';
 
   @override
   String get connectOmiWithAI => 'Connect Omi with AI assistants';
@@ -3961,8 +3899,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get updateAppQuestion => 'Update App?';
 
   @override
-  String get updateAppConfirmation =>
-      'Are you sure you want to update your app? The changes will reflect once reviewed by our team.';
+  String get updateAppConfirmation => 'Are you sure you want to update your app? The changes will reflect once reviewed by our team.';
 
   @override
   String get updateApp => 'Update App';
@@ -3992,8 +3929,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get no => 'No';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Subscription cancelled successfully. It will remain active until the end of the current billing period.';
+  String get subscriptionCancelledSuccessfully => 'Subscription cancelled successfully. It will remain active until the end of the current billing period.';
 
   @override
   String get failedToCancelSubscription => 'Failed to cancel subscription. Please try again.';
@@ -4029,8 +3965,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Cancel Subscription?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Are you sure you want to cancel your subscription? You will continue to have access until the end of your current billing period.';
+  String get cancelSubscriptionConfirmation => 'Are you sure you want to cancel your subscription? You will continue to have access until the end of your current billing period.';
 
   @override
   String get cancelSubscriptionButton => 'Cancel Subscription';
@@ -4039,12 +3974,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cancelling => 'Cancelling...';
 
   @override
-  String get betaTesterMessage =>
-      'You are a beta tester for this app. It is not public yet. It will be public once approved.';
+  String get betaTesterMessage => 'You are a beta tester for this app. It is not public yet. It will be public once approved.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Your app is under review and visible only to you. It will be public once approved.';
+  String get appUnderReviewMessage => 'Your app is under review and visible only to you. It will be public once approved.';
 
   @override
   String get appRejectedMessage => 'Your app has been rejected. Please update the app details and resubmit for review.';
@@ -4101,8 +4034,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get issueActivatingApp => 'There was an issue activating this app. Please try again.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'This app will access your data. Omi AI is not responsible for how your data is used, modified, or deleted by this app';
+  String get dataAccessNoticeDescription => 'This app will access your data. Omi AI is not responsible for how your data is used, modified, or deleted by this app';
 
   @override
   String get copyUrl => 'Copy URL';
@@ -4190,8 +4122,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get omiApiKeys => 'Omi API Keys';
 
   @override
-  String get apiKeysDescription =>
-      'API Keys are used for authentication when your app communicates with the OMI server. They allow your application to create memories and access other OMI services securely.';
+  String get apiKeysDescription => 'API Keys are used for authentication when your app communicates with the OMI server. They allow your application to create memories and access other OMI services securely.';
 
   @override
   String get aboutOmiApiKeys => 'About Omi API Keys';
@@ -4215,8 +4146,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Revoke API Key?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'This action cannot be undone. Any applications using this key will no longer be able to access the API.';
+  String get revokeApiKeyWarning => 'This action cannot be undone. Any applications using this key will no longer be able to access the API.';
 
   @override
   String get revoke => 'Revoke';
@@ -4305,8 +4235,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get keyCreated => 'Key Created';
 
   @override
-  String get keyCreatedMessage =>
-      'Your new key has been created. Please copy it now. You will not be able to see it again.';
+  String get keyCreatedMessage => 'Your new key has been created. Please copy it now. You will not be able to see it again.';
 
   @override
   String get keyWord => 'Key';
@@ -4315,8 +4244,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get externalAppAccess => 'External App Access';
 
   @override
-  String get externalAppAccessDescription =>
-      'The following installed apps have external integrations and can access your data, such as conversations and memories.';
+  String get externalAppAccessDescription => 'The following installed apps have external integrations and can access your data, such as conversations and memories.';
 
   @override
   String get noExternalAppsHaveAccess => 'No external apps have access to your data.';
@@ -4325,8 +4253,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maximum Security (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-end encryption is the gold standard for privacy. When enabled, your data is encrypted on your device before it\'s sent to our servers. This means no one, not even Omi, can access your content.';
+  String get e2eeDescription => 'End-to-end encryption is the gold standard for privacy. When enabled, your data is encrypted on your device before it\'s sent to our servers. This means no one, not even Omi, can access your content.';
 
   @override
   String get importantTradeoffs => 'Important Trade-offs:';
@@ -4341,8 +4268,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get featureComingSoon => 'This feature is coming soon!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migration in progress. You cannot change the protection level until it is complete.';
+  String get migrationInProgressMessage => 'Migration in progress. You cannot change the protection level until it is complete.';
 
   @override
   String get migrationFailed => 'Migration Failed';
@@ -4361,15 +4287,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get secureEncryption => 'Secure Encryption';
 
   @override
-  String get secureEncryptionDescription =>
-      'Your data is encrypted with a key unique to you on our servers, hosted on Google Cloud. This means your raw content is inaccessible to anyone, including Omi staff or Google, directly from the database.';
+  String get secureEncryptionDescription => 'Your data is encrypted with a key unique to you on our servers, hosted on Google Cloud. This means your raw content is inaccessible to anyone, including Omi staff or Google, directly from the database.';
 
   @override
   String get endToEndEncryption => 'End-to-End Encryption';
 
   @override
-  String get e2eeCardDescription =>
-      'Enable for maximum security where only you can access your data. Tap to learn more.';
+  String get e2eeCardDescription => 'Enable for maximum security where only you can access your data. Tap to learn more.';
 
   @override
   String get dataAlwaysEncrypted => 'Regardless of the level, your data is always encrypted at rest and in transit.';
@@ -4440,8 +4364,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Get Omi Unlimited for free by contributing your data to train AI models.';
 
   @override
-  String get trainingDataBullets =>
-      '• Your data helps improve AI models\n• Only non-sensitive data is shared\n• Fully transparent process';
+  String get trainingDataBullets => '• Your data helps improve AI models\n• Only non-sensitive data is shared\n• Fully transparent process';
 
   @override
   String get learnMoreAtOmiTraining => 'Learn more at omi.me/training';
@@ -4491,8 +4414,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get monthlyPlanContinues => 'Your current monthly plan will continue until the end of your billing period';
 
   @override
-  String get paymentMethodCharged =>
-      'Your existing payment method will be charged automatically when your monthly plan ends';
+  String get paymentMethodCharged => 'Your existing payment method will be charged automatically when your monthly plan ends';
 
   @override
   String get annualSubscriptionStarts => 'Your 12-month annual subscription will start automatically after the charge';
@@ -4602,8 +4524,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Your Privacy Matters to Us';
 
   @override
-  String get privacyIntroText =>
-      'At Omi, we take your privacy very seriously. We want to be transparent about the data we collect and how we use it to improve our product for you. Here\'s what you need to know:';
+  String get privacyIntroText => 'At Omi, we take your privacy very seriously. We want to be transparent about the data we collect and how we use it to improve our product for you. Here\'s what you need to know:';
 
   @override
   String get whatWeTrack => 'What We Track';
@@ -4618,12 +4539,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ourCommitment => 'Our Commitment';
 
   @override
-  String get commitmentText =>
-      'We are committed to using the data we collect only to make Omi a better product for you. Your privacy and trust are paramount to us.';
+  String get commitmentText => 'We are committed to using the data we collect only to make Omi a better product for you. Your privacy and trust are paramount to us.';
 
   @override
-  String get thankYouText =>
-      'Thank you for being a valued user of Omi. If you have any questions or concerns, feel free to reach out to us to team@basedhardware.com.';
+  String get thankYouText => 'Thank you for being a valued user of Omi. If you have any questions or concerns, feel free to reach out to us to team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi Sync Settings';
@@ -4632,8 +4551,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get enterHotspotCredentials => 'Enter your phone\'s hotspot credentials';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi sync uses your phone as a hotspot. Find your hotspot name and password in Settings > Personal Hotspot.';
+  String get wifiSyncUsesHotspot => 'WiFi sync uses your phone as a hotspot. Find your hotspot name and password in Settings > Personal Hotspot.';
 
   @override
   String get hotspotNameSsid => 'Hotspot Name (SSID)';
@@ -4668,8 +4586,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Failed to generate summary. Make sure you have conversations for that day.';
+  String get failedToGenerateSummaryCheckConversations => 'Failed to generate summary. Make sure you have conversations for that day.';
 
   @override
   String get summaryNotFound => 'Summary not found';
@@ -4699,8 +4616,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Export started. This may take a few seconds...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'This will delete all derived knowledge graph data (nodes and connections). Your original memories will remain safe. The graph will be rebuilt over time or upon next request.';
+  String get knowledgeGraphDeleteDescription => 'This will delete all derived knowledge graph data (nodes and connections). Your original memories will remain safe. The graph will be rebuilt over time or upon next request.';
 
   @override
   String get configureDailySummaryDigest => 'Configure your daily action items digest';
@@ -4770,8 +4686,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Delete All Limitless Conversations?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'This will permanently delete all conversations imported from Limitless. This action cannot be undone.';
+  String get deleteAllLimitlessWarning => 'This will permanently delete all conversations imported from Limitless. This action cannot be undone.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4827,8 +4742,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get howItWorksTitle => 'How it works?';
 
   @override
-  String get howPeopleWorks =>
-      'Once a person is created, you can go to a conversation transcript, and assign them their corresponding segments, that way Omi will be able to recognize their speech too!';
+  String get howPeopleWorks => 'Once a person is created, you can go to a conversation transcript, and assign them their corresponding segments, that way Omi will be able to recognize their speech too!';
 
   @override
   String get tapToDelete => 'Tap to delete';
@@ -4854,8 +4768,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get privacyNotice => 'Privacy Notice';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Recordings may capture others\' voices. Ensure you have consent from all participants before enabling.';
+  String get recordingsMayCaptureOthers => 'Recordings may capture others\' voices. Ensure you have consent from all participants before enabling.';
 
   @override
   String get enable => 'Enable';
@@ -4867,8 +4780,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Keep all audio recordings stored locally on your phone. When disabled, only failed uploads are kept to save storage space.';
+  String get storeAudioDescription => 'Keep all audio recordings stored locally on your phone. When disabled, only failed uploads are kept to save storage space.';
 
   @override
   String get enableLocalStorage => 'Enable Local Storage';
@@ -4886,12 +4798,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get storeAudioOnCloud => 'Store Audio on Cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Your real-time recordings will be stored in private cloud storage as you speak.';
+  String get cloudStorageDialogMessage => 'Your real-time recordings will be stored in private cloud storage as you speak.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Store your real-time recordings in private cloud storage as you speak. Audio is captured and saved securely in real-time.';
+  String get storeAudioCloudDescription => 'Store your real-time recordings in private cloud storage as you speak. Audio is captured and saved securely in real-time.';
 
   @override
   String get downloadingFirmware => 'Downloading Firmware';
@@ -4971,8 +4881,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get monthlyPayouts => 'Monthly payouts';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Receive monthly payments directly to your account when you reach \$10 in earnings';
+  String get monthlyPayoutsDescription => 'Receive monthly payments directly to your account when you reach \$10 in earnings';
 
   @override
   String get secureAndReliable => 'Secure and reliable';
@@ -4999,8 +4908,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get connectingYourStripeAccount => 'Connecting your Stripe account';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Please complete the Stripe onboarding process in your browser. This page will automatically update once completed.';
+  String get stripeOnboardingInstructions => 'Please complete the Stripe onboarding process in your browser. This page will automatically update once completed.';
 
   @override
   String get failedTryAgain => 'Failed? Try Again';
@@ -5012,8 +4920,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get successfullyConnected => 'Successfully Connected!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Your Stripe account is now ready to receive payments. You can start earning from your app sales right away.';
+  String get stripeReadyForPayments => 'Your Stripe account is now ready to receive payments. You can start earning from your app sales right away.';
 
   @override
   String get updateStripeDetails => 'Update Stripe Details';
@@ -5040,8 +4947,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me Link';
 
   @override
-  String get stripeRecommendation =>
-      'If Stripe is available in your country, we highly recommend using it for faster and easier payouts.';
+  String get stripeRecommendation => 'If Stripe is available in your country, we highly recommend using it for faster and easier payouts.';
 
   @override
   String get updatePayPalDetails => 'Update PayPal Details';
@@ -5093,8 +4999,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Additional Speech Sample Removed';
 
   @override
-  String get consentDataMessage =>
-      'By continuing, your conversations, recordings, and personal information will be securely stored on our servers. Your audio recordings and transcripts are processed by third-party AI services — Deepgram for transcription and OpenAI for analysis — to provide you with AI-powered insights and enable all app features.';
+  String get consentDataMessage => 'By continuing, your conversations, recordings, and personal information will be securely stored on our servers. Your audio recordings and transcripts are processed by third-party AI services — Deepgram for transcription and OpenAI for analysis — to provide you with AI-powered insights and enable all app features.';
 
   @override
   String get tasksEmptyStateMessage => 'Tasks from your conversations will appear here.\nTap + to create one manually.';
@@ -5133,15 +5038,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Install Omi on your\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'To use your Apple Watch with Omi, you need to install the Omi app on your watch first.';
+  String get installOmiOnAppleWatchDescription => 'To use your Apple Watch with Omi, you need to install the Omi app on your watch first.';
 
   @override
   String get openOmiOnAppleWatch => 'Open Omi on your\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'The Omi app is installed on your Apple Watch. Open it and tap Start to begin.';
+  String get openOmiOnAppleWatchDescription => 'The Omi app is installed on your Apple Watch. Open it and tap Start to begin.';
 
   @override
   String get openWatchApp => 'Open Watch App';
@@ -5150,15 +5053,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'I\'ve Installed & Opened the App';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Unable to open Apple Watch app. Please manually open the Watch app on your Apple Watch and install Omi from the \"Available Apps\" section.';
+  String get unableToOpenWatchApp => 'Unable to open Apple Watch app. Please manually open the Watch app on your Apple Watch and install Omi from the \"Available Apps\" section.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch connected successfully!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch still not reachable. Please make sure the Omi app is open on your watch.';
+  String get appleWatchNotReachable => 'Apple Watch still not reachable. Please make sure the Omi app is open on your watch.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5586,8 +5487,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get multipleSpeakersDetected => 'Multiple speakers detected';
 
   @override
-  String get multipleSpeakersDescription =>
-      'It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.';
+  String get multipleSpeakersDescription => 'It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.';
 
   @override
   String get invalidRecordingDetected => 'Invalid recording detected';
@@ -5599,15 +5499,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get speechDurationDescription => 'Please make sure you speak for at least 5 seconds and not more than 90.';
 
   @override
-  String get connectionLostDescription =>
-      'The connection was interrupted. Please check your internet connection and try again.';
+  String get connectionLostDescription => 'The connection was interrupted. Please check your internet connection and try again.';
 
   @override
   String get howToTakeGoodSample => 'How to take a good sample?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Make sure you are in a quiet place.\n2. Speak clearly and naturally.\n3. Make sure your device is in its natural position, on your neck.\n\nOnce it\'s created, you can always improve it or do it again.';
+  String get goodSampleInstructions => '1. Make sure you are in a quiet place.\n2. Speak clearly and naturally.\n3. Make sure your device is in its natural position, on your neck.\n\nOnce it\'s created, you can always improve it or do it again.';
 
   @override
   String get noDeviceConnectedUseMic => 'No device connected. Will use phone microphone.';
@@ -5670,12 +5568,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get howItWorks => 'How it works';
 
   @override
-  String get dailyScoreExplanation =>
-      'Your daily score is based on task completion. Complete your tasks to improve your score!';
+  String get dailyScoreExplanation => 'Your daily score is based on task completion. Complete your tasks to improve your score!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Control how often Omi sends you proactive notifications and reminders.';
+  String get notificationFrequencyDescription => 'Control how often Omi sends you proactive notifications and reminders.';
 
   @override
   String get sliderOff => 'Off';
@@ -6064,8 +5960,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get performanceWarning => 'Performance Warning';
 
   @override
-  String get largeModelWarning =>
-      'This model is large and may crash the app or run very slowly on mobile devices.\n\n\"small\" or \"base\" is recommended.';
+  String get largeModelWarning => 'This model is large and may crash the app or run very slowly on mobile devices.\n\n\"small\" or \"base\" is recommended.';
 
   @override
   String get usingNativeIosSpeech => 'Using Native iOS Speech Recognition';
@@ -6140,8 +6035,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'This model is large and may crash the app or run very slowly on mobile devices.\n\n\"small\" or \"base\" is recommended.';
+  String get modelTooLargeWarning => 'This model is large and may crash the app or run very slowly on mobile devices.\n\n\"small\" or \"base\" is recommended.';
 
   @override
   String get nativeEngineNoDownload => 'Your devices native speech engine will be used. No model download required.';
@@ -6180,8 +6074,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omis built-in live transcription is optimized for real-time conversations with automatic speaker detection and diarization.';
+  String get omiTranscriptionOptimized => 'Omis built-in live transcription is optimized for real-time conversations with automatic speaker detection and diarization.';
 
   @override
   String get reset => 'Reset';
@@ -6401,8 +6294,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Building your knowledge graph from memories...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Your knowledge graph will be built automatically as you create new memories.';
+  String get knowledgeGraphWillBuildAutomatically => 'Your knowledge graph will be built automatically as you create new memories.';
 
   @override
   String get buildGraphButton => 'Build Graph';
@@ -6704,8 +6596,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Downloading audio from your device\'s SD card';
 
   @override
-  String get transferRequiredDescription =>
-      'This recording is stored on your device\'s SD card. Transfer it to your phone to play or share.';
+  String get transferRequiredDescription => 'This recording is stored on your device\'s SD card. Transfer it to your phone to play or share.';
 
   @override
   String get cancelTransfer => 'Cancel Transfer';
@@ -6726,8 +6617,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareRecording => 'Share Recording';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Are you sure you want to permanently delete this recording? This can\'t be undone.';
+  String get deleteRecordingConfirmation => 'Are you sure you want to permanently delete this recording? This can\'t be undone.';
 
   @override
   String get recordingIdLabel => 'Recording ID';
@@ -6786,15 +6676,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get enableFastTransfer => 'Enable Fast Transfer';
 
   @override
-  String get fastTransferDescription =>
-      'Fast Transfer uses WiFi for ~5x faster speeds. Your phone will temporarily connect to your Omi device\'s WiFi network during transfer.';
+  String get fastTransferDescription => 'Fast Transfer uses WiFi for ~5x faster speeds. Your phone will temporarily connect to your Omi device\'s WiFi network during transfer.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Internet access is paused during transfer';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Choose how recordings are transferred from your Omi device to your phone.';
+  String get chooseTransferMethodDescription => 'Choose how recordings are transferred from your Omi device to your phone.';
 
   @override
   String get wifiSpeed => '~150 KB/s via WiFi';
@@ -6803,8 +6691,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fiveTimesFaster => '5X FASTER';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Creates a direct WiFi connection to your Omi device. Your phone temporarily disconnects from your regular WiFi during transfer.';
+  String get fastTransferMethodDescription => 'Creates a direct WiFi connection to your Omi device. Your phone temporarily disconnects from your regular WiFi during transfer.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6813,8 +6700,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get bleSpeed => '~30 KB/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Uses standard Bluetooth Low Energy connection. Slower but doesn\'t affect your WiFi connection.';
+  String get bluetoothMethodDescription => 'Uses standard Bluetooth Low Energy connection. Slower but doesn\'t affect your WiFi connection.';
 
   @override
   String get selected => 'Selected';
@@ -6852,12 +6738,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appDeleteFailed => 'Failed to delete app. Please try again later.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'App visibility changed successfully. It may take a few minutes to reflect.';
+  String get appVisibilityChangedSuccessfully => 'App visibility changed successfully. It may take a few minutes to reflect.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Error activating the app. If this is an integration app, make sure the setup is completed.';
+  String get errorActivatingAppIntegration => 'Error activating the app. If this is an integration app, make sure the setup is completed.';
 
   @override
   String get errorUpdatingAppStatus => 'An error occurred while updating the app status.';
@@ -6937,8 +6821,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Name must be at least 3 characters';
 
   @override
-  String get conversationPromptHint =>
-      'e.g., Extract action items, decisions made, and key takeaways from the provided conversation.';
+  String get conversationPromptHint => 'e.g., Extract action items, decisions made, and key takeaways from the provided conversation.';
 
   @override
   String get pleaseEnterAppPrompt => 'Please enter a prompt for your app';
@@ -7020,8 +6903,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'Photos permission denied. Please allow access to photos to select an image';
+  String get addAppPhotosPermissionDenied => 'Photos permission denied. Please allow access to photos to select an image';
 
   @override
   String get addAppErrorSelectingImageRetry => 'Error selecting image. Please try again.';
@@ -7126,19 +7008,16 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade scheduled! Your monthly plan continues until the end of your billing period, then automatically switches to annual.';
+  String get planUpgradeScheduledMessage => 'Upgrade scheduled! Your monthly plan continues until the end of your billing period, then automatically switches to annual.';
 
   @override
   String get couldNotSchedulePlanChange => 'Could not schedule plan change. Please try again.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Your subscription has been reactivated! No charge now - you\'ll be billed at the end of your current period.';
+  String get subscriptionReactivatedDefault => 'Your subscription has been reactivated! No charge now - you\'ll be billed at the end of your current period.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Subscription successful! You\'ve been charged for the new billing period.';
+  String get subscriptionSuccessfulCharged => 'Subscription successful! You\'ve been charged for the new billing period.';
 
   @override
   String get couldNotProcessSubscription => 'Could not process subscription. Please try again.';
@@ -7318,8 +7197,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Bluetooth permission is required to connect to your device.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth permission denied. Please grant permission in System Preferences.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth permission denied. Please grant permission in System Preferences.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7332,12 +7210,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Notification permission denied. Please grant permission in System Preferences.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Notification permission denied. Please grant permission in System Preferences.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Notification permission denied. Please grant permission in System Preferences > Notifications.';
+  String get onboardingNotificationDeniedNotifications => 'Notification permission denied. Please grant permission in System Preferences > Notifications.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7350,15 +7226,13 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Please grant location permission in Settings > Privacy & Security > Location Services';
+  String get onboardingLocationGrantInSettings => 'Please grant location permission in Settings > Privacy & Security > Location Services';
 
   @override
   String get onboardingMicrophoneRequired => 'Microphone permission is required for recording.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Microphone permission denied. Please grant permission in System Preferences > Privacy & Security > Microphone.';
+  String get onboardingMicrophoneDenied => 'Microphone permission denied. Please grant permission in System Preferences > Privacy & Security > Microphone.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7374,8 +7248,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Screen capture permission is required for system audio recording.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Screen capture permission denied. Please grant permission in System Preferences > Privacy & Security > Screen Recording.';
+  String get onboardingScreenCaptureDenied => 'Screen capture permission denied. Please grant permission in System Preferences > Privacy & Security > Screen Recording.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7500,8 +7373,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get locationPermissionRequired => 'Location Permission Required';
 
   @override
-  String get locationPermissionContent =>
-      'Fast Transfer requires location permission to verify WiFi connection. Please grant location permission to continue.';
+  String get locationPermissionContent => 'Fast Transfer requires location permission to verify WiFi connection. Please grant location permission to continue.';
 
   @override
   String get pdfTranscriptExport => 'Transcript Export';
@@ -7960,8 +7832,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Put Omi DevKit in Pairing Mode';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Press the button once to turn on. The LED will blink purple when in pairing mode.';
+  String get pairingDescOmiDevkit => 'Press the button once to turn on. The LED will blink purple when in pairing mode.';
 
   @override
   String get pairingTitleOmiGlass => 'Turn On Omi Glass';
@@ -7973,8 +7844,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Put Plaud Note in Pairing Mode';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Press and hold the side button for 2 seconds. The red LED will blink when ready to pair.';
+  String get pairingDescPlaudNote => 'Press and hold the side button for 2 seconds. The red LED will blink when ready to pair.';
 
   @override
   String get pairingTitleBee => 'Put Bee in Pairing Mode';
@@ -7986,15 +7856,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pairingTitleLimitless => 'Put Limitless in Pairing Mode';
 
   @override
-  String get pairingDescLimitless =>
-      'When any light is visible, press once and then press and hold until the device shows a pink light, then release.';
+  String get pairingDescLimitless => 'When any light is visible, press once and then press and hold until the device shows a pink light, then release.';
 
   @override
   String get pairingTitleFriendPendant => 'Put Friend Pendant in Pairing Mode';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Press the button on the pendant to turn it on. It will enter pairing mode automatically.';
+  String get pairingDescFriendPendant => 'Press the button on the pendant to turn it on. It will enter pairing mode automatically.';
 
   @override
   String get pairingTitleFieldy => 'Put Fieldy in Pairing Mode';
@@ -8012,8 +7880,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pairingTitleNeoOne => 'Put Neo One in Pairing Mode';
 
   @override
-  String get pairingDescNeoOne =>
-      'Press and hold the power button until the LED blinks. The device will be discoverable.';
+  String get pairingDescNeoOne => 'Press and hold the power button until the LED blinks. The device will be discoverable.';
 
   @override
   String get downloadingFromDevice => 'Downloading from device';
@@ -8130,8 +7997,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get switchAndRestart => 'Switch';
 
   @override
-  String get stagingDisclaimer =>
-      'Staging may be buggy, have inconsistent performance, and data might be lost. Use for testing only.';
+  String get stagingDisclaimer => 'Staging may be buggy, have inconsistent performance, and data might be lost. Use for testing only.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Saved. Close and reopen the app to apply.';
@@ -8360,8 +8226,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Phone Calls via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Make calls through Omi and get real-time transcription, automatic summaries, and more. Available exclusively for Unlimited plan subscribers.';
+  String get phoneCallsUpsellSubtitle => 'Make calls through Omi and get real-time transcription, automatic summaries, and more. Available exclusively for Unlimited plan subscribers.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Real-time transcription of every call';
@@ -8388,8 +8253,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteSyncedFiles => 'Delete Synced Recordings';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'These recordings have already been synced to your phone. This cannot be undone.';
+  String get deleteSyncedFilesMessage => 'These recordings have already been synced to your phone. This cannot be undone.';
 
   @override
   String get syncedFilesDeleted => 'Synced recordings deleted';
@@ -8401,8 +8265,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deletePendingFiles => 'Delete Pending Recordings';
 
   @override
-  String get deletePendingFilesWarning =>
-      'These recordings have NOT been synced to your phone and will be permanently lost. This cannot be undone.';
+  String get deletePendingFilesWarning => 'These recordings have NOT been synced to your phone and will be permanently lost. This cannot be undone.';
 
   @override
   String get pendingFilesDeleted => 'Pending recordings deleted';
@@ -8414,8 +8277,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteAll => 'Delete All';
 
   @override
-  String get deleteAllFilesWarning =>
-      'This will delete both synced and pending recordings. Pending recordings have NOT been synced and will be permanently lost. This cannot be undone.';
+  String get deleteAllFilesWarning => 'This will delete both synced and pending recordings. Pending recordings have NOT been synced and will be permanently lost. This cannot be undone.';
 
   @override
   String get allFilesDeleted => 'All recordings deleted';
@@ -8480,8 +8342,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fairUseAboutTitle => 'About Fair Use';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi is designed for personal conversations, meetings, and live interactions. Usage is measured by real speech time detected, not connection time. If usage significantly exceeds normal patterns for non-personal content, adjustments may apply.';
+  String get fairUseAboutBody => 'Omi is designed for personal conversations, meetings, and live interactions. Usage is measured by real speech time detected, not connection time. If usage significantly exceeds normal patterns for non-personal content, adjustments may apply.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8519,8 +8380,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get improveConnectionTitle => 'Improve Connection';
 
   @override
-  String get improveConnectionContent =>
-      'We\'ve improved how Omi stays connected to your device. To activate this, please go to the Device Info page, tap \"Disconnect Device\", and then pair your device again.';
+  String get improveConnectionContent => 'We\'ve improved how Omi stays connected to your device. To activate this, please go to the Device Info page, tap \"Disconnect Device\", and then pair your device again.';
 
   @override
   String get improveConnectionAction => 'Got it';
@@ -8575,16 +8435,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cancelSyncQuestion => 'Cancel sync?';
 
   @override
-  String get omisStorageDesc =>
-      'When your Omi is not connected to your phone, it stores audio locally on its built-in memory. You never lose a recording.';
+  String get omisStorageDesc => 'When your Omi is not connected to your phone, it stores audio locally on its built-in memory. You never lose a recording.';
 
   @override
-  String get phoneStorageDesc =>
-      'When Omi reconnects, recordings are automatically transferred to your phone as a temporary holding area before uploading.';
+  String get phoneStorageDesc => 'When Omi reconnects, recordings are automatically transferred to your phone as a temporary holding area before uploading.';
 
   @override
-  String get cloudStorageDesc =>
-      'Once uploaded, your recordings are processed and transcribed. Conversations will be available within a minute.';
+  String get cloudStorageDesc => 'Once uploaded, your recordings are processed and transcribed. Conversations will be available within a minute.';
 
   @override
   String get tipKeepPhoneNearby => 'Keep your phone nearby for faster syncing';
@@ -8608,12 +8465,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get permissionEnable => 'Enable';
 
   @override
-  String get permissionsPageDescription =>
-      'These permissions are core to how Omi works. They enable key features like notifications, location-based experiences, and audio capture.';
+  String get permissionsPageDescription => 'These permissions are core to how Omi works. They enable key features like notifications, location-based experiences, and audio capture.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi needs a few permissions to work properly. Please grant them to continue.';
+  String get permissionsRequiredDescription => 'Omi needs a few permissions to work properly. Please grant them to continue.';
 
   @override
   String get permissionsSetupTitle => 'Get the best experience';
@@ -8890,8 +8745,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get firmwareWarningTitle => 'Important: Read Before Updating';
 
   @override
-  String get firmwareFormatWarning =>
-      'This firmware will format the SD card. Please ensure all offline data is synced before upgrading.\n\nIf you see a flashing red light after flashing this version, do not worry. Simply connect the device to the app and it should turn blue. The red light means the device\'s clock hasn\'t been synced yet.';
+  String get firmwareFormatWarning => 'This firmware will format the SD card. Please ensure all offline data is synced before upgrading.\n\nIf you see a flashing red light after flashing this version, do not worry. Simply connect the device to the app and it should turn blue. The red light means the device\'s clock hasn\'t been synced yet.';
 
   @override
   String get continueAnyway => 'Continue';
@@ -8911,8 +8765,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tasksMarkComplete => 'Marked as complete';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi accesses Apple Health through Apple\'s HealthKit framework. You can revoke access anytime in iOS Settings.';
+  String get appleHealthManageNote => 'Omi accesses Apple Health through Apple\'s HealthKit framework. You can revoke access anytime in iOS Settings.';
 
   @override
   String get appleHealthConnectCta => 'Connect to Apple Health';
@@ -8945,8 +8798,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health access denied';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi doesn\'t have permission to read your Apple Health data. Enable it in iOS Settings → Privacy & Security → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi doesn\'t have permission to read your Apple Health data. Enable it in iOS Settings → Privacy & Security → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Why are you leaving?';
@@ -9015,8 +8867,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get planUpdate => 'Plan Update';
 
   @override
-  String get planDeprecationMessage =>
-      'Your Unlimited plan is being retired. Switch to the Operator plan — same great features at \$49/mo. Your current plan will continue to work in the meantime.';
+  String get planDeprecationMessage => 'Your Unlimited plan is being retired. Switch to the Operator plan — same great features at \$49/mo. Your current plan will continue to work in the meantime.';
 
   @override
   String get upgradeYourPlan => 'Upgrade Your Plan';
@@ -9127,8 +8978,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'You\'ve hit your monthly limit. Upgrade to keep chatting with Omi without restrictions.';
+  String get chatQuotaExceededReply => 'You\'ve hit your monthly limit. Upgrade to keep chatting with Omi without restrictions.';
 
   @override
   String get voiceResponseAudio => 'Speak Omi responses aloud';
@@ -9159,4 +9009,25 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Add Task';
+
+  @override
+  String get quickActionAskOmiAnything => 'Ask Omi Anything';
+
+  @override
+  String get quickActionVoiceMode => 'Voice Mode';
+
+  @override
+  String get quickActionMute => 'Mute';
+
+  @override
+  String get quickActionUnmute => 'Unmute';
+
+  @override
+  String get quickActionConnectDevice => 'Connect Device';
+
+  @override
+  String get quickActionDeviceSettings => 'Device Settings';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -24,8 +24,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteConversationTitle => '¿Borrar conversación?';
 
   @override
-  String get deleteConversationMessage =>
-      'Esto también eliminará los recuerdos, tareas y archivos de audio asociados. Esta acción no se puede deshacer.';
+  String get deleteConversationMessage => 'Esto también eliminará los recuerdos, tareas y archivos de audio asociados. Esta acción no se puede deshacer.';
 
   @override
   String get confirm => 'Confirmar';
@@ -146,8 +145,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleting => 'Borrando...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Por favor completa la autenticación en tu navegador. Regresa a la app cuando termines.';
+  String get pleaseCompleteAuthentication => 'Por favor completa la autenticación en tu navegador. Regresa a la app cuando termines.';
 
   @override
   String get failedToStartAuthentication => 'Error al iniciar autenticación';
@@ -228,8 +226,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noStarredConversations => 'No hay conversaciones destacadas';
 
   @override
-  String get starConversationHint =>
-      'Para marcar una conversación como favorita, ábrela y toca la estrella en la cabecera.';
+  String get starConversationHint => 'Para marcar una conversación como favorita, ábrela y toca la estrella en la cabecera.';
 
   @override
   String get searchConversations => 'Buscar conversaciones...';
@@ -356,19 +353,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appsDisconnected => 'Tus apps e integraciones se desconectarán inmediatamente.';
 
   @override
-  String get exportBeforeDelete =>
-      'Puedes exportar tus datos antes de borrar tu cuenta. Una vez borrados, no se pueden recuperar.';
+  String get exportBeforeDelete => 'Puedes exportar tus datos antes de borrar tu cuenta. Una vez borrados, no se pueden recuperar.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Entiendo que borrar mi cuenta es permanente y que todos los datos, incluyendo recuerdos y conversaciones, se perderán para siempre.';
+  String get deleteAccountCheckbox => 'Entiendo que borrar mi cuenta es permanente y que todos los datos, incluyendo recuerdos y conversaciones, se perderán para siempre.';
 
   @override
   String get areYouSure => '¿Estás seguro?';
 
   @override
-  String get deleteAccountFinal =>
-      'Esta acción es irreversible y borrará permanentemente tu cuenta y todos sus datos. ¿Deseas continuar?';
+  String get deleteAccountFinal => 'Esta acción es irreversible y borrará permanentemente tu cuenta y todos sus datos. ¿Deseas continuar?';
 
   @override
   String get deleteNow => 'Borrar ahora';
@@ -377,8 +371,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get goBack => 'Volver';
 
   @override
-  String get checkBoxToConfirm =>
-      'Marca la casilla para confirmar que entiendes que borrar tu cuenta es permanente e irreversible.';
+  String get checkBoxToConfirm => 'Marca la casilla para confirmar que entiendes que borrar tu cuenta es permanente e irreversible.';
 
   @override
   String get profile => 'Perfil';
@@ -456,8 +449,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get yourPrivacyYourControl => 'Tu privacidad, tu control';
 
   @override
-  String get privacyIntro =>
-      'En Omi, nos comprometemos a proteger tu privacidad. Esta página te permite controlar cómo se guardan y usan tus datos.';
+  String get privacyIntro => 'En Omi, nos comprometemos a proteger tu privacidad. Esta página te permite controlar cómo se guardan y usan tus datos.';
 
   @override
   String get learnMore => 'Saber más...';
@@ -472,8 +464,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appAccess => 'Acceso de apps';
 
   @override
-  String get appAccessDesc =>
-      'Las siguientes apps pueden acceder a tus datos. Toca una app para gestionar sus permisos.';
+  String get appAccessDesc => 'Las siguientes apps pueden acceder a tus datos. Toca una app para gestionar sus permisos.';
 
   @override
   String get noAppsExternalAccess => 'Ninguna app instalada tiene acceso externo a tus datos.';
@@ -530,15 +521,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Tu Omi se desconectó 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Dispositivo desvinculado. Ve a Configuración > Bluetooth y olvida el dispositivo para completar la desvinculación.';
+  String get deviceUnpairedMessage => 'Dispositivo desvinculado. Ve a Configuración > Bluetooth y olvida el dispositivo para completar la desvinculación.';
 
   @override
   String get unpairDialogTitle => 'Desvincular dispositivo';
 
   @override
-  String get unpairDialogMessage =>
-      'Esto desvinculará el dispositivo para que pueda usarse en otro teléfono. Debes ir a Ajustes > Bluetooth y olvidar el dispositivo para completar el proceso.';
+  String get unpairDialogMessage => 'Esto desvinculará el dispositivo para que pueda usarse en otro teléfono. Debes ir a Ajustes > Bluetooth y olvidar el dispositivo para completar el proceso.';
 
   @override
   String get deviceNotConnected => 'Dispositivo no conectado';
@@ -559,8 +548,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get v2Undetected => 'V2 no detectado';
 
   @override
-  String get v2UndetectedMessage =>
-      'Parece que tienes un dispositivo V1 o no está conectado. La funcionalidad de tarjeta SD es solo para dispositivos V2.';
+  String get v2UndetectedMessage => 'Parece que tienes un dispositivo V1 o no está conectado. La funcionalidad de tarjeta SD es solo para dispositivos V2.';
 
   @override
   String get endConversation => 'Terminar conversación';
@@ -834,8 +822,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => '¿Borrar Gráfico de Conocimiento?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Esto borrará todos los datos derivados del gráfico (nodos y conexiones). Tus recuerdos originales se mantienen seguros.';
+  String get deleteKnowledgeGraphMessage => 'Esto borrará todos los datos derivados del gráfico (nodos y conexiones). Tus recuerdos originales se mantienen seguros.';
 
   @override
   String get knowledgeGraphDeleted => 'Gráfico de conocimiento eliminado';
@@ -983,8 +970,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shortConversationThreshold => 'Umbral de conversación corta';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Conversaciones más cortas que esto se ocultan si no está activado arriba';
+  String get shortConversationThresholdSubtitle => 'Conversaciones más cortas que esto se ocultan si no está activado arriba';
 
   @override
   String get durationThreshold => 'Umbral de duración';
@@ -1079,8 +1065,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get needYourPermission => 'Necesitamos tu permiso';
 
   @override
-  String get alreadyGavePermission =>
-      'Ya nos diste permiso para guardar tus grabaciones. Aquí un recordatorio de por qué lo necesitamos:';
+  String get alreadyGavePermission => 'Ya nos diste permiso para guardar tus grabaciones. Aquí un recordatorio de por qué lo necesitamos:';
 
   @override
   String get wouldLikePermission => 'Nos gustaría tu permiso para guardar tus grabaciones de voz. Aquí está la razón:';
@@ -1095,15 +1080,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trainFamilyProfiles => 'Entrenar perfiles de amigos y familia';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Tus grabaciones ayudan a reconocer y crear perfiles para tus amigos y familiares.';
+  String get trainFamilyProfilesDesc => 'Tus grabaciones ayudan a reconocer y crear perfiles para tus amigos y familiares.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Mejorar precisión de transcripción';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'A medida que nuestro modelo mejora, podemos ofrecer mejores transcripciones.';
+  String get enhanceTranscriptAccuracyDesc => 'A medida que nuestro modelo mejora, podemos ofrecer mejores transcripciones.';
 
   @override
   String get legalNotice => 'Aviso legal: La legalidad de grabar puede variar según tu ubicación.';
@@ -1184,8 +1167,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showEventsNoParticipants => 'Mostrar eventos sin participantes';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Si activado, \'Próximamente\' mostrará eventos sin participantes o enlaces de video.';
+  String get showEventsNoParticipantsDesc => 'Si activado, \'Próximamente\' mostrará eventos sin participantes o enlaces de video.';
 
   @override
   String get yourMeetings => 'Tus reuniones';
@@ -1400,8 +1382,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get configureSettings => 'Configurar ajustes';
 
   @override
-  String get completeAuthBrowser =>
-      'Por favor completa la autenticación en tu navegador. Al terminar, vuelve a la app.';
+  String get completeAuthBrowser => 'Por favor completa la autenticación en tu navegador. Al terminar, vuelve a la app.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -2202,15 +2183,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'VOZ Y TRANSCRIPCIÓN';
 
   @override
-  String get languageSettingsHelperText =>
-      'El idioma de la aplicación cambia los menús y botones. El idioma de voz afecta cómo se transcriben tus grabaciones.';
+  String get languageSettingsHelperText => 'El idioma de la aplicación cambia los menús y botones. El idioma de voz afecta cómo se transcriben tus grabaciones.';
 
   @override
   String get translationNotice => 'Aviso de traducción';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi traduce las conversaciones a tu idioma principal. Actualízalo en cualquier momento en Ajustes → Perfiles.';
+  String get translationNoticeMessage => 'Omi traduce las conversaciones a tu idioma principal. Actualízalo en cualquier momento en Ajustes → Perfiles.';
 
   @override
   String get pleaseCheckInternetConnection => 'Por favor, verifica tu conexión a Internet e inténtalo de nuevo';
@@ -2230,8 +2209,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Esta conversación no se puede fusionar (bloqueada o ya en proceso de fusión)';
+  String get conversationCannotBeMerged => 'Esta conversación no se puede fusionar (bloqueada o ya en proceso de fusión)';
 
   @override
   String get pleaseEnterFolderName => 'Por favor, introduce un nombre de carpeta';
@@ -2366,8 +2344,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Desvincular dispositivo';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Esto desvinculará el dispositivo para que pueda conectarse a otro teléfono. Deberás ir a Configuración > Bluetooth y olvidar el dispositivo para completar el proceso.';
+  String get unpairDeviceDialogMessage => 'Esto desvinculará el dispositivo para que pueda conectarse a otro teléfono. Deberás ir a Configuración > Bluetooth y olvidar el dispositivo para completar el proceso.';
 
   @override
   String get unpair => 'Desvincular';
@@ -2533,8 +2510,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get howDoesItWork => '¿Cómo funciona?';
 
   @override
-  String get sdCardSyncDescription =>
-      'La sincronización de la tarjeta SD importará tus recuerdos de la tarjeta SD a la aplicación';
+  String get sdCardSyncDescription => 'La sincronización de la tarjeta SD importará tus recuerdos de la tarjeta SD a la aplicación';
 
   @override
   String get checksForAudioFiles => 'Comprueba archivos de audio en la tarjeta SD';
@@ -2549,8 +2525,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get youreAllSet => '¡Estás listo!';
 
   @override
-  String get welcomeToOmiDescription =>
-      '¡Bienvenido a Omi! Tu compañero de IA está listo para ayudarte con conversaciones, tareas y más.';
+  String get welcomeToOmiDescription => '¡Bienvenido a Omi! Tu compañero de IA está listo para ayudarte con conversaciones, tareas y más.';
 
   @override
   String get startUsingOmi => 'Comenzar a usar Omi';
@@ -2629,8 +2604,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get reviewAndManageConversations => 'Revisa y gestiona tus conversaciones capturadas';
 
   @override
-  String get startCapturingConversations =>
-      'Comienza a capturar conversaciones con tu dispositivo Omi para verlas aquí.';
+  String get startCapturingConversations => 'Comienza a capturar conversaciones con tu dispositivo Omi para verlas aquí.';
 
   @override
   String get useMobileAppToCapture => 'Usa tu aplicación móvil para capturar audio';
@@ -2687,8 +2661,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noTasksYet => 'Aún no hay tareas';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Las tareas de tus conversaciones aparecerán aquí.\nHaz clic en Crear para añadir una manualmente.';
+  String get tasksFromConversationsWillAppear => 'Las tareas de tus conversaciones aparecerán aquí.\nHaz clic en Crear para añadir una manualmente.';
 
   @override
   String get monthJan => 'Ene';
@@ -2745,8 +2718,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteActionItem => 'Eliminar tarea';
 
   @override
-  String get deleteActionItemConfirmation =>
-      '¿Estás seguro de que quieres eliminar esta tarea? Esta acción no se puede deshacer.';
+  String get deleteActionItemConfirmation => '¿Estás seguro de que quieres eliminar esta tarea? Esta acción no se puede deshacer.';
 
   @override
   String get enterActionItemDescription => 'Ingresa la descripción de la tarea...';
@@ -2788,8 +2760,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get checkBackLaterForNewApps => 'Vuelve más tarde para ver nuevas aplicaciones';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'Por favor, verifica tu conexión a Internet e inténtalo de nuevo';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'Por favor, verifica tu conexión a Internet e inténtalo de nuevo';
 
   @override
   String get createNewApp => 'Crear nueva aplicación';
@@ -2822,15 +2793,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chatPrompt => 'Indicación de chat';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Eres una aplicación increíble, tu trabajo es responder a las consultas de los usuarios y hacerlos sentir bien...';
+  String get chatPromptPlaceholder => 'Eres una aplicación increíble, tu trabajo es responder a las consultas de los usuarios y hacerlos sentir bien...';
 
   @override
   String get conversationPrompt => 'Indicación de conversación';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Eres una aplicación increíble, se te dará una transcripción y resumen de una conversación...';
+  String get conversationPromptPlaceholder => 'Eres una aplicación increíble, se te dará una transcripción y resumen de una conversación...';
 
   @override
   String get notificationScopes => 'Ámbitos de notificación';
@@ -2842,8 +2811,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get makeMyAppPublic => 'Hacer pública mi aplicación';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Al enviar esta aplicación, acepto los Términos de Servicio y la Política de Privacidad de Omi AI';
+  String get submitAppTermsAgreement => 'Al enviar esta aplicación, acepto los Términos de Servicio y la Política de Privacidad de Omi AI';
 
   @override
   String get submitApp => 'Enviar aplicación';
@@ -2858,12 +2826,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get submitAppQuestion => '¿Enviar aplicación?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Tu aplicación será revisada y publicada. Puedes comenzar a usarla inmediatamente, ¡incluso durante la revisión!';
+  String get submitAppPublicDescription => 'Tu aplicación será revisada y publicada. Puedes comenzar a usarla inmediatamente, ¡incluso durante la revisión!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Tu aplicación será revisada y estará disponible para ti de forma privada. Puedes comenzar a usarla inmediatamente, ¡incluso durante la revisión!';
+  String get submitAppPrivateDescription => 'Tu aplicación será revisada y estará disponible para ti de forma privada. Puedes comenzar a usarla inmediatamente, ¡incluso durante la revisión!';
 
   @override
   String get startEarning => '¡Comienza a ganar! 💰';
@@ -2887,23 +2853,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dataAccessNotice => 'Aviso de acceso a datos';
 
   @override
-  String get dataAccessWarning =>
-      'Esta aplicación accederá a sus datos. Omi AI no es responsable de cómo esta aplicación utiliza, modifica o elimina sus datos';
+  String get dataAccessWarning => 'Esta aplicación accederá a sus datos. Omi AI no es responsable de cómo esta aplicación utiliza, modifica o elimina sus datos';
 
   @override
   String get installApp => 'Instalar aplicación';
 
   @override
-  String get betaTesterNotice =>
-      'Eres un probador beta de esta aplicación. Aún no es pública. Será pública una vez aprobada.';
+  String get betaTesterNotice => 'Eres un probador beta de esta aplicación. Aún no es pública. Será pública una vez aprobada.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Tu aplicación está en revisión y solo visible para ti. Será pública una vez aprobada.';
+  String get appUnderReviewOwner => 'Tu aplicación está en revisión y solo visible para ti. Será pública una vez aprobada.';
 
   @override
-  String get appRejectedNotice =>
-      'Tu aplicación ha sido rechazada. Por favor actualiza los detalles de la aplicación y vuelve a enviarla para revisión.';
+  String get appRejectedNotice => 'Tu aplicación ha sido rechazada. Por favor actualiza los detalles de la aplicación y vuelve a enviarla para revisión.';
 
   @override
   String get setupSteps => 'Pasos de configuración';
@@ -2938,8 +2900,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get errorActivatingApp => 'Error al activar la aplicación';
 
   @override
-  String get integrationSetupRequired =>
-      'Si esta es una aplicación de integración, asegúrese de que la configuración esté completa.';
+  String get integrationSetupRequired => 'Si esta es una aplicación de integración, asegúrese de que la configuración esté completa.';
 
   @override
   String get installed => 'Instalado';
@@ -2966,8 +2927,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get descriptionLabel => 'Descripción';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Mi aplicación increíble es una aplicación genial que hace cosas asombrosas. ¡Es la mejor aplicación!';
+  String get appDescriptionPlaceholder => 'Mi aplicación increíble es una aplicación genial que hace cosas asombrosas. ¡Es la mejor aplicación!';
 
   @override
   String get pleaseProvideValidDescription => 'Por favor, proporcione una descripción válida';
@@ -3119,8 +3079,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get microphonePermissionRequired => 'Se requiere permiso de micrófono para la grabación de voz.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Permiso de micrófono denegado. Por favor, conceda permiso en Preferencias del Sistema > Privacidad y Seguridad > Micrófono.';
+  String get microphonePermissionDenied => 'Permiso de micrófono denegado. Por favor, conceda permiso en Preferencias del Sistema > Privacidad y Seguridad > Micrófono.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3279,8 +3238,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get createMemory => 'Crear memoria';
 
   @override
-  String get deleteMemoryConfirmation =>
-      '¿Estás seguro de que deseas eliminar esta memoria? Esta acción no se puede deshacer.';
+  String get deleteMemoryConfirmation => '¿Estás seguro de que deseas eliminar esta memoria? Esta acción no se puede deshacer.';
 
   @override
   String get makePrivate => 'Hacer privado';
@@ -3354,8 +3312,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get whatWeCollect => 'Qué recopilamos';
 
   @override
-  String get dataCollectionMessage =>
-      'Al continuar, tus conversaciones, grabaciones e información personal se almacenarán de forma segura en nuestros servidores para proporcionar información impulsada por IA y habilitar todas las funciones de la aplicación.';
+  String get dataCollectionMessage => 'Al continuar, tus conversaciones, grabaciones e información personal se almacenarán de forma segura en nuestros servidores para proporcionar información impulsada por IA y habilitar todas las funciones de la aplicación.';
 
   @override
   String get dataProtection => 'Protección de datos';
@@ -3388,8 +3345,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'El nombre debe tener al menos 2 caracteres';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Díganos cómo le gustaría que nos dirigiéramos a usted. Esto ayuda a personalizar su experiencia Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Díganos cómo le gustaría que nos dirigiéramos a usted. Esto ayuda a personalizar su experiencia Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3406,8 +3362,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get recordAudioConversations => 'Grabar conversaciones de audio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi necesita acceso al micrófono para grabar sus conversaciones y proporcionar transcripciones.';
+  String get microphoneAccessDescription => 'Omi necesita acceso al micrófono para grabar sus conversaciones y proporcionar transcripciones.';
 
   @override
   String get screenRecording => 'Grabación de pantalla';
@@ -3416,8 +3371,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Capturar audio del sistema de reuniones';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi necesita permiso de grabación de pantalla para capturar el audio del sistema de sus reuniones basadas en navegador.';
+  String get screenRecordingDescription => 'Omi necesita permiso de grabación de pantalla para capturar el audio del sistema de sus reuniones basadas en navegador.';
 
   @override
   String get accessibility => 'Accesibilidad';
@@ -3426,8 +3380,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Detectar reuniones basadas en navegador';
 
   @override
-  String get accessibilityDescription =>
-      'Omi necesita permiso de accesibilidad para detectar cuándo se une a reuniones de Zoom, Meet o Teams en su navegador.';
+  String get accessibilityDescription => 'Omi necesita permiso de accesibilidad para detectar cuándo se une a reuniones de Zoom, Meet o Teams en su navegador.';
 
   @override
   String get pleaseWait => 'Por favor, espere...';
@@ -3496,12 +3449,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get exportAllConversationsToJson => 'Exporte todas sus conversaciones a un archivo JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Exportación de conversaciones iniciada. Esto puede tardar unos segundos, por favor espere.';
+  String get conversationsExportStarted => 'Exportación de conversaciones iniciada. Esto puede tardar unos segundos, por favor espere.';
 
   @override
-  String get mcpDescription =>
-      'Para conectar Omi con otras aplicaciones para leer, buscar y administrar sus recuerdos y conversaciones. Cree una clave para comenzar.';
+  String get mcpDescription => 'Para conectar Omi con otras aplicaciones para leer, buscar y administrar sus recuerdos y conversaciones. Cree una clave para comenzar.';
 
   @override
   String get apiKeys => 'Claves API';
@@ -3542,15 +3493,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Estado de diagnóstico del servicio de transcripción';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Habilitar mensajes de diagnóstico detallados del servicio de transcripción';
+  String get enableDetailedDiagnosticMessages => 'Habilitar mensajes de diagnóstico detallados del servicio de transcripción';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Crear y etiquetar automáticamente nuevos hablantes';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Crear automáticamente una nueva persona cuando se detecta un nombre en la transcripción.';
+  String get automaticallyCreateNewPerson => 'Crear automáticamente una nueva persona cuando se detecta un nombre en la transcripción.';
 
   @override
   String get pilotFeatures => 'Funciones piloto';
@@ -3574,8 +3523,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get auto => 'Automático';
 
   @override
-  String get noSummaryForApp =>
-      'No hay resumen disponible para esta aplicación. Prueba otra aplicación para mejores resultados.';
+  String get noSummaryForApp => 'No hay resumen disponible para esta aplicación. Prueba otra aplicación para mejores resultados.';
 
   @override
   String get tryAnotherApp => 'Probar otra aplicación';
@@ -3612,8 +3560,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Deja que Omi elija automáticamente la mejor aplicación';
 
   @override
-  String get deleteConversationConfirmation =>
-      '¿Estás seguro de que quieres eliminar esta conversación? Esta acción no se puede deshacer.';
+  String get deleteConversationConfirmation => '¿Estás seguro de que quieres eliminar esta conversación? Esta acción no se puede deshacer.';
 
   @override
   String get conversationDeleted => 'Conversación eliminada';
@@ -3661,8 +3608,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Preparando captura de audio del sistema';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Haz clic en el botón para capturar audio para transcripciones en vivo, información de IA y guardado automático.';
+  String get clickTheButtonToCaptureAudio => 'Haz clic en el botón para capturar audio para transcripciones en vivo, información de IA y guardado automático.';
 
   @override
   String get reconnecting => 'Reconectando...';
@@ -3820,8 +3766,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dailySummaryTitle => 'Resumen Diario';
 
   @override
-  String get dailySummaryDescription =>
-      'Recibe un resumen personalizado de las conversaciones del día como notificación.';
+  String get dailySummaryDescription => 'Recibe un resumen personalizado de las conversaciones del día como notificación.';
 
   @override
   String get deliveryTime => 'Hora de entrega';
@@ -3890,8 +3835,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => '¿Eliminar Gráfico de Conocimiento?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Esto eliminará todos los datos del gráfico de conocimiento derivados. Tus recuerdos originales permanecen seguros.';
+  String get deleteKnowledgeGraphWarning => 'Esto eliminará todos los datos del gráfico de conocimiento derivados. Tus recuerdos originales permanecen seguros.';
 
   @override
   String get connectOmiWithAI => 'Conecta Omi con asistentes de IA';
@@ -3933,8 +3877,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Términos y Política de Privacidad';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Ayuda a diagnosticar problemas. Se elimina automáticamente después de 3 días.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Ayuda a diagnosticar problemas. Se elimina automáticamente después de 3 días.';
 
   @override
   String get manageYourApp => 'Gestiona tu aplicación';
@@ -3949,8 +3892,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get updateAppQuestion => '¿Actualizar aplicación?';
 
   @override
-  String get updateAppConfirmation =>
-      '¿Estás seguro de que quieres actualizar tu aplicación? Los cambios se reflejarán una vez revisados por nuestro equipo.';
+  String get updateAppConfirmation => '¿Estás seguro de que quieres actualizar tu aplicación? Los cambios se reflejarán una vez revisados por nuestro equipo.';
 
   @override
   String get updateApp => 'Actualizar aplicación';
@@ -3980,8 +3922,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get no => 'No';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Suscripción cancelada con éxito. Permanecerá activa hasta el final del período de facturación actual.';
+  String get subscriptionCancelledSuccessfully => 'Suscripción cancelada con éxito. Permanecerá activa hasta el final del período de facturación actual.';
 
   @override
   String get failedToCancelSubscription => 'Error al cancelar la suscripción. Por favor, inténtalo de nuevo.';
@@ -4017,8 +3958,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cancelSubscriptionQuestion => '¿Cancelar suscripción?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      '¿Estás seguro de que quieres cancelar tu suscripción? Seguirás teniendo acceso hasta el final de tu período de facturación actual.';
+  String get cancelSubscriptionConfirmation => '¿Estás seguro de que quieres cancelar tu suscripción? Seguirás teniendo acceso hasta el final de tu período de facturación actual.';
 
   @override
   String get cancelSubscriptionButton => 'Cancelar suscripción';
@@ -4027,16 +3967,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cancelling => 'Cancelando...';
 
   @override
-  String get betaTesterMessage =>
-      'Eres un probador beta de esta aplicación. Aún no es pública. Será pública una vez aprobada.';
+  String get betaTesterMessage => 'Eres un probador beta de esta aplicación. Aún no es pública. Será pública una vez aprobada.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Tu aplicación está en revisión y solo es visible para ti. Será pública una vez aprobada.';
+  String get appUnderReviewMessage => 'Tu aplicación está en revisión y solo es visible para ti. Será pública una vez aprobada.';
 
   @override
-  String get appRejectedMessage =>
-      'Tu aplicación ha sido rechazada. Actualiza los detalles y vuelve a enviarla para revisión.';
+  String get appRejectedMessage => 'Tu aplicación ha sido rechazada. Actualiza los detalles y vuelve a enviarla para revisión.';
 
   @override
   String get invalidIntegrationUrl => 'URL de integración no válida';
@@ -4090,8 +4027,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get issueActivatingApp => 'Hubo un problema al activar esta aplicación. Por favor, inténtalo de nuevo.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Esta aplicación accederá a tus datos. Omi AI no es responsable de cómo esta aplicación utiliza, modifica o elimina tus datos';
+  String get dataAccessNoticeDescription => 'Esta aplicación accederá a tus datos. Omi AI no es responsable de cómo esta aplicación utiliza, modifica o elimina tus datos';
 
   @override
   String get copyUrl => 'Copiar URL';
@@ -4179,8 +4115,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get omiApiKeys => 'Claves API de Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Las claves API se utilizan para la autenticación cuando tu aplicación se comunica con el servidor de OMI. Permiten que tu aplicación cree recuerdos y acceda a otros servicios de OMI de forma segura.';
+  String get apiKeysDescription => 'Las claves API se utilizan para la autenticación cuando tu aplicación se comunica con el servidor de OMI. Permiten que tu aplicación cree recuerdos y acceda a otros servicios de OMI de forma segura.';
 
   @override
   String get aboutOmiApiKeys => 'Acerca de las claves API de Omi';
@@ -4204,8 +4139,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get revokeApiKeyQuestion => '¿Revocar clave API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Esta acción no se puede deshacer. Las aplicaciones que usen esta clave ya no podrán acceder a la API.';
+  String get revokeApiKeyWarning => 'Esta acción no se puede deshacer. Las aplicaciones que usen esta clave ya no podrán acceder a la API.';
 
   @override
   String get revoke => 'Revocar';
@@ -4303,8 +4237,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get externalAppAccess => 'Acceso de aplicaciones externas';
 
   @override
-  String get externalAppAccessDescription =>
-      'Las siguientes aplicaciones instaladas tienen integraciones externas y pueden acceder a tus datos, como conversaciones y recuerdos.';
+  String get externalAppAccessDescription => 'Las siguientes aplicaciones instaladas tienen integraciones externas y pueden acceder a tus datos, como conversaciones y recuerdos.';
 
   @override
   String get noExternalAppsHaveAccess => 'Ninguna aplicación externa tiene acceso a tus datos.';
@@ -4313,15 +4246,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get maximumSecurityE2ee => 'Seguridad máxima (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'El cifrado de extremo a extremo es el estándar de oro para la privacidad. Cuando está habilitado, tus datos se cifran en tu dispositivo antes de enviarse a nuestros servidores. Esto significa que nadie, ni siquiera Omi, puede acceder a tu contenido.';
+  String get e2eeDescription => 'El cifrado de extremo a extremo es el estándar de oro para la privacidad. Cuando está habilitado, tus datos se cifran en tu dispositivo antes de enviarse a nuestros servidores. Esto significa que nadie, ni siquiera Omi, puede acceder a tu contenido.';
 
   @override
   String get importantTradeoffs => 'Compensaciones importantes:';
 
   @override
-  String get e2eeTradeoff1 =>
-      '• Algunas funciones como las integraciones de aplicaciones externas pueden estar deshabilitadas.';
+  String get e2eeTradeoff1 => '• Algunas funciones como las integraciones de aplicaciones externas pueden estar deshabilitadas.';
 
   @override
   String get e2eeTradeoff2 => '• Si pierdes tu contraseña, tus datos no se pueden recuperar.';
@@ -4330,8 +4261,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get featureComingSoon => '¡Esta función estará disponible pronto!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migración en progreso. No puedes cambiar el nivel de protección hasta que se complete.';
+  String get migrationInProgressMessage => 'Migración en progreso. No puedes cambiar el nivel de protección hasta que se complete.';
 
   @override
   String get migrationFailed => 'Migración fallida';
@@ -4350,19 +4280,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get secureEncryption => 'Cifrado seguro';
 
   @override
-  String get secureEncryptionDescription =>
-      'Tus datos se cifran con una clave única para ti en nuestros servidores, alojados en Google Cloud. Esto significa que tu contenido sin procesar es inaccesible para cualquier persona, incluido el personal de Omi o Google, directamente desde la base de datos.';
+  String get secureEncryptionDescription => 'Tus datos se cifran con una clave única para ti en nuestros servidores, alojados en Google Cloud. Esto significa que tu contenido sin procesar es inaccesible para cualquier persona, incluido el personal de Omi o Google, directamente desde la base de datos.';
 
   @override
   String get endToEndEncryption => 'Cifrado de extremo a extremo';
 
   @override
-  String get e2eeCardDescription =>
-      'Activa para máxima seguridad donde solo tú puedes acceder a tus datos. Toca para saber más.';
+  String get e2eeCardDescription => 'Activa para máxima seguridad donde solo tú puedes acceder a tus datos. Toca para saber más.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Independientemente del nivel, tus datos siempre están cifrados en reposo y en tránsito.';
+  String get dataAlwaysEncrypted => 'Independientemente del nivel, tus datos siempre están cifrados en reposo y en tránsito.';
 
   @override
   String get readOnlyScope => 'Solo lectura';
@@ -4430,8 +4357,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Obtén Omi Ilimitado gratis contribuyendo tus datos para entrenar modelos de IA.';
 
   @override
-  String get trainingDataBullets =>
-      '• Tus datos ayudan a mejorar los modelos de IA\n• Solo se comparten datos no sensibles\n• Proceso completamente transparente';
+  String get trainingDataBullets => '• Tus datos ayudan a mejorar los modelos de IA\n• Solo se comparten datos no sensibles\n• Proceso completamente transparente';
 
   @override
   String get learnMoreAtOmiTraining => 'Aprende más en omi.me/training';
@@ -4443,8 +4369,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get submitRequest => 'Enviar solicitud';
 
   @override
-  String get thankYouRequestUnderReview =>
-      '¡Gracias! Tu solicitud está en revisión. Te notificaremos cuando sea aprobada.';
+  String get thankYouRequestUnderReview => '¡Gracias! Tu solicitud está en revisión. Te notificaremos cuando sea aprobada.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4482,8 +4407,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get monthlyPlanContinues => 'Tu plan mensual actual continuará hasta el final de tu período de facturación';
 
   @override
-  String get paymentMethodCharged =>
-      'Tu método de pago existente se cobrará automáticamente cuando termine tu plan mensual';
+  String get paymentMethodCharged => 'Tu método de pago existente se cobrará automáticamente cuando termine tu plan mensual';
 
   @override
   String get annualSubscriptionStarts => 'Tu suscripción anual de 12 meses comenzará automáticamente después del cargo';
@@ -4593,8 +4517,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Tu privacidad nos importa';
 
   @override
-  String get privacyIntroText =>
-      'En Omi, nos tomamos tu privacidad muy en serio. Queremos ser transparentes sobre los datos que recopilamos y cómo los usamos para mejorar nuestro producto. Esto es lo que necesitas saber:';
+  String get privacyIntroText => 'En Omi, nos tomamos tu privacidad muy en serio. Queremos ser transparentes sobre los datos que recopilamos y cómo los usamos para mejorar nuestro producto. Esto es lo que necesitas saber:';
 
   @override
   String get whatWeTrack => 'Qué rastreamos';
@@ -4609,12 +4532,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get ourCommitment => 'Nuestro compromiso';
 
   @override
-  String get commitmentText =>
-      'Nos comprometemos a usar los datos que recopilamos solo para hacer de Omi un mejor producto para ti. Tu privacidad y confianza son primordiales para nosotros.';
+  String get commitmentText => 'Nos comprometemos a usar los datos que recopilamos solo para hacer de Omi un mejor producto para ti. Tu privacidad y confianza son primordiales para nosotros.';
 
   @override
-  String get thankYouText =>
-      'Gracias por ser un usuario valioso de Omi. Si tienes alguna pregunta o inquietud, no dudes en contactarnos en team@basedhardware.com.';
+  String get thankYouText => 'Gracias por ser un usuario valioso de Omi. Si tienes alguna pregunta o inquietud, no dudes en contactarnos en team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Configuración de sincronización WiFi';
@@ -4623,8 +4544,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get enterHotspotCredentials => 'Ingresa las credenciales del punto de acceso de tu teléfono';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'La sincronización WiFi usa tu teléfono como punto de acceso. Encuentra el nombre y contraseña en Ajustes > Punto de acceso personal.';
+  String get wifiSyncUsesHotspot => 'La sincronización WiFi usa tu teléfono como punto de acceso. Encuentra el nombre y contraseña en Ajustes > Punto de acceso personal.';
 
   @override
   String get hotspotNameSsid => 'Nombre del punto de acceso (SSID)';
@@ -4659,8 +4579,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Error al generar el resumen. Asegúrate de tener conversaciones para ese día.';
+  String get failedToGenerateSummaryCheckConversations => 'Error al generar el resumen. Asegúrate de tener conversaciones para ese día.';
 
   @override
   String get summaryNotFound => 'Resumen no encontrado';
@@ -4690,8 +4609,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Exportación iniciada. Esto puede tardar unos segundos...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Esto eliminará todos los datos derivados del grafo de conocimiento (nodos y conexiones). Tus recuerdos originales permanecerán seguros. El grafo se reconstruirá con el tiempo o en la próxima solicitud.';
+  String get knowledgeGraphDeleteDescription => 'Esto eliminará todos los datos derivados del grafo de conocimiento (nodos y conexiones). Tus recuerdos originales permanecerán seguros. El grafo se reconstruirá con el tiempo o en la próxima solicitud.';
 
   @override
   String get configureDailySummaryDigest => 'Configura tu resumen diario de tareas';
@@ -4761,8 +4679,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteAllLimitlessConversations => '¿Eliminar todas las conversaciones de Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Esto eliminará permanentemente todas las conversaciones importadas de Limitless. Esta acción no se puede deshacer.';
+  String get deleteAllLimitlessWarning => 'Esto eliminará permanentemente todas las conversaciones importadas de Limitless. Esta acción no se puede deshacer.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4818,8 +4735,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get howItWorksTitle => '¿Cómo funciona?';
 
   @override
-  String get howPeopleWorks =>
-      'Una vez creada una persona, puedes ir a la transcripción de una conversación y asignarle sus segmentos correspondientes, ¡así Omi también podrá reconocer su voz!';
+  String get howPeopleWorks => 'Una vez creada una persona, puedes ir a la transcripción de una conversación y asignarle sus segmentos correspondientes, ¡así Omi también podrá reconocer su voz!';
 
   @override
   String get tapToDelete => 'Toca para eliminar';
@@ -4845,8 +4761,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get privacyNotice => 'Aviso de privacidad';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Las grabaciones pueden capturar las voces de otros. Asegúrese de tener el consentimiento de todos los participantes antes de activar.';
+  String get recordingsMayCaptureOthers => 'Las grabaciones pueden capturar las voces de otros. Asegúrese de tener el consentimiento de todos los participantes antes de activar.';
 
   @override
   String get enable => 'Activar';
@@ -4858,8 +4773,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Mantenga todas las grabaciones de audio almacenadas localmente en su teléfono. Cuando está deshabilitado, solo se guardan las cargas fallidas para ahorrar espacio.';
+  String get storeAudioDescription => 'Mantenga todas las grabaciones de audio almacenadas localmente en su teléfono. Cuando está deshabilitado, solo se guardan las cargas fallidas para ahorrar espacio.';
 
   @override
   String get enableLocalStorage => 'Habilitar almacenamiento local';
@@ -4877,12 +4791,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get storeAudioOnCloud => 'Almacenar audio en la nube';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Sus grabaciones en tiempo real se almacenarán en almacenamiento privado en la nube mientras habla.';
+  String get cloudStorageDialogMessage => 'Sus grabaciones en tiempo real se almacenarán en almacenamiento privado en la nube mientras habla.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Almacene sus grabaciones en tiempo real en almacenamiento privado en la nube mientras habla. El audio se captura y guarda de forma segura en tiempo real.';
+  String get storeAudioCloudDescription => 'Almacene sus grabaciones en tiempo real en almacenamiento privado en la nube mientras habla. El audio se captura y guarda de forma segura en tiempo real.';
 
   @override
   String get downloadingFirmware => 'Descargando firmware';
@@ -4891,8 +4803,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get installingFirmware => 'Instalando firmware';
 
   @override
-  String get firmwareUpdateWarning =>
-      'No cierre la aplicación ni apague el dispositivo. Esto podría dañar su dispositivo.';
+  String get firmwareUpdateWarning => 'No cierre la aplicación ni apague el dispositivo. Esto podría dañar su dispositivo.';
 
   @override
   String get firmwareUpdated => 'Firmware actualizado';
@@ -4936,8 +4847,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get payments => 'Pagos';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Conecte un método de pago a continuación para comenzar a recibir pagos por sus aplicaciones.';
+  String get connectPaymentMethodInfo => 'Conecte un método de pago a continuación para comenzar a recibir pagos por sus aplicaciones.';
 
   @override
   String get selectedPaymentMethod => 'Método de pago seleccionado';
@@ -4964,15 +4874,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get monthlyPayouts => 'Pagos mensuales';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Reciba pagos mensuales directamente en su cuenta cuando alcance \$10 en ganancias';
+  String get monthlyPayoutsDescription => 'Reciba pagos mensuales directamente en su cuenta cuando alcance \$10 en ganancias';
 
   @override
   String get secureAndReliable => 'Seguro y confiable';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe garantiza transferencias seguras y oportunas de los ingresos de su aplicación';
+  String get stripeSecureDescription => 'Stripe garantiza transferencias seguras y oportunas de los ingresos de su aplicación';
 
   @override
   String get selectYourCountry => 'Seleccione su país';
@@ -4993,8 +4901,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get connectingYourStripeAccount => 'Conectando su cuenta de Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Complete el proceso de incorporación de Stripe en su navegador. Esta página se actualizará automáticamente una vez completado.';
+  String get stripeOnboardingInstructions => 'Complete el proceso de incorporación de Stripe en su navegador. Esta página se actualizará automáticamente una vez completado.';
 
   @override
   String get failedTryAgain => '¿Falló? Intentar de nuevo';
@@ -5006,15 +4913,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get successfullyConnected => '¡Conectado con éxito!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Su cuenta de Stripe está lista para recibir pagos. Puede comenzar a ganar con las ventas de sus aplicaciones de inmediato.';
+  String get stripeReadyForPayments => 'Su cuenta de Stripe está lista para recibir pagos. Puede comenzar a ganar con las ventas de sus aplicaciones de inmediato.';
 
   @override
   String get updateStripeDetails => 'Actualizar detalles de Stripe';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      '¡Error al actualizar los detalles de Stripe! Por favor, inténtelo de nuevo más tarde.';
+  String get errorUpdatingStripeDetails => '¡Error al actualizar los detalles de Stripe! Por favor, inténtelo de nuevo más tarde.';
 
   @override
   String get updatePayPal => 'Actualizar PayPal';
@@ -5026,8 +4931,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Actualice los datos de su cuenta de PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Conecte su cuenta de PayPal para comenzar a recibir pagos por sus aplicaciones';
+  String get connectPayPalToReceivePayments => 'Conecte su cuenta de PayPal para comenzar a recibir pagos por sus aplicaciones';
 
   @override
   String get paypalEmail => 'Correo electrónico de PayPal';
@@ -5036,8 +4940,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get paypalMeLink => 'Enlace PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Si Stripe está disponible en su país, le recomendamos encarecidamente usarlo para pagos más rápidos y fáciles.';
+  String get stripeRecommendation => 'Si Stripe está disponible en su país, le recomendamos encarecidamente usarlo para pagos más rápidos y fáciles.';
 
   @override
   String get updatePayPalDetails => 'Actualizar detalles de PayPal';
@@ -5089,12 +4992,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Muestra de voz adicional eliminada';
 
   @override
-  String get consentDataMessage =>
-      'Al continuar, tus conversaciones, grabaciones e información personal se almacenarán de forma segura en nuestros servidores. Tus grabaciones de audio y transcripciones son procesadas por servicios de IA de terceros (incluyendo Deepgram para transcripción y OpenAI para análisis) para proporcionarte información impulsada por IA y habilitar todas las funciones de la aplicación.';
+  String get consentDataMessage => 'Al continuar, tus conversaciones, grabaciones e información personal se almacenarán de forma segura en nuestros servidores. Tus grabaciones de audio y transcripciones son procesadas por servicios de IA de terceros (incluyendo Deepgram para transcripción y OpenAI para análisis) para proporcionarte información impulsada por IA y habilitar todas las funciones de la aplicación.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Las tareas de tus conversaciones aparecerán aquí.\nToca + para crear una manualmente.';
+  String get tasksEmptyStateMessage => 'Las tareas de tus conversaciones aparecerán aquí.\nToca + para crear una manualmente.';
 
   @override
   String get clearChatAction => 'Borrar chat';
@@ -5130,15 +5031,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Instala Omi en tu\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Para usar tu Apple Watch con Omi, primero debes instalar la aplicación Omi en tu reloj.';
+  String get installOmiOnAppleWatchDescription => 'Para usar tu Apple Watch con Omi, primero debes instalar la aplicación Omi en tu reloj.';
 
   @override
   String get openOmiOnAppleWatch => 'Abre Omi en tu\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'La aplicación Omi está instalada en tu Apple Watch. Ábrela y toca Iniciar para comenzar.';
+  String get openOmiOnAppleWatchDescription => 'La aplicación Omi está instalada en tu Apple Watch. Ábrela y toca Iniciar para comenzar.';
 
   @override
   String get openWatchApp => 'Abrir app Watch';
@@ -5147,15 +5046,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'He instalado y abierto la app';
 
   @override
-  String get unableToOpenWatchApp =>
-      'No se pudo abrir la app de Apple Watch. Abre manualmente la app Watch en tu Apple Watch e instala Omi desde la sección \"Apps disponibles\".';
+  String get unableToOpenWatchApp => 'No se pudo abrir la app de Apple Watch. Abre manualmente la app Watch en tu Apple Watch e instala Omi desde la sección \"Apps disponibles\".';
 
   @override
   String get appleWatchConnectedSuccessfully => '¡Apple Watch conectado correctamente!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch aún no está accesible. Asegúrate de que la app Omi esté abierta en tu reloj.';
+  String get appleWatchNotReachable => 'Apple Watch aún no está accesible. Asegúrate de que la app Omi esté abierta en tu reloj.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5172,8 +5069,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get finishedConversation => '¿Conversación terminada?';
 
   @override
-  String get stopRecordingConfirmation =>
-      '¿Estás seguro de que quieres detener la grabación y resumir la conversación ahora?';
+  String get stopRecordingConfirmation => '¿Estás seguro de que quieres detener la grabación y resumir la conversación ahora?';
 
   @override
   String get conversationEndsManually => 'La conversación solo terminará manualmente.';
@@ -5584,8 +5480,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get multipleSpeakersDetected => 'Múltiples hablantes detectados';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Parece que hay múltiples hablantes en la grabación. Asegúrate de estar en un lugar tranquilo e inténtalo de nuevo.';
+  String get multipleSpeakersDescription => 'Parece que hay múltiples hablantes en la grabación. Asegúrate de estar en un lugar tranquilo e inténtalo de nuevo.';
 
   @override
   String get invalidRecordingDetected => 'Grabación inválida detectada';
@@ -5597,15 +5492,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get speechDurationDescription => 'Asegúrate de hablar al menos 5 segundos y no más de 90.';
 
   @override
-  String get connectionLostDescription =>
-      'La conexión se interrumpió. Por favor, verifica tu conexión a internet e inténtalo de nuevo.';
+  String get connectionLostDescription => 'La conexión se interrumpió. Por favor, verifica tu conexión a internet e inténtalo de nuevo.';
 
   @override
   String get howToTakeGoodSample => '¿Cómo tomar una buena muestra?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Asegúrate de estar en un lugar tranquilo.\n2. Habla clara y naturalmente.\n3. Asegúrate de que tu dispositivo esté en su posición natural en tu cuello.\n\nUna vez creado, siempre puedes mejorarlo o hacerlo de nuevo.';
+  String get goodSampleInstructions => '1. Asegúrate de estar en un lugar tranquilo.\n2. Habla clara y naturalmente.\n3. Asegúrate de que tu dispositivo esté en su posición natural en tu cuello.\n\nUna vez creado, siempre puedes mejorarlo o hacerlo de nuevo.';
 
   @override
   String get noDeviceConnectedUseMic => 'Ningún dispositivo conectado. Se usará el micrófono del teléfono.';
@@ -5668,12 +5561,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get howItWorks => 'Cómo funciona';
 
   @override
-  String get dailyScoreExplanation =>
-      'Tu puntuación diaria se basa en completar tareas. ¡Completa tus tareas para mejorar tu puntuación!';
+  String get dailyScoreExplanation => 'Tu puntuación diaria se basa en completar tareas. ¡Completa tus tareas para mejorar tu puntuación!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Controla con qué frecuencia Omi te envía notificaciones proactivas y recordatorios.';
+  String get notificationFrequencyDescription => 'Controla con qué frecuencia Omi te envía notificaciones proactivas y recordatorios.';
 
   @override
   String get sliderOff => 'Apagado';
@@ -5918,8 +5809,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get recordings => 'Grabaciones';
 
   @override
-  String get enableRemindersAccess =>
-      'Por favor, habilite el acceso a Recordatorios en Ajustes para usar los Recordatorios de Apple';
+  String get enableRemindersAccess => 'Por favor, habilite el acceso a Recordatorios en Ajustes para usar los Recordatorios de Apple';
 
   @override
   String todayAtTime(String time) {
@@ -6006,8 +5896,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deviceNotCompatible => 'Tu dispositivo no es compatible con la transcripción en el dispositivo';
 
   @override
-  String get deviceRequirements =>
-      'Tu dispositivo no cumple con los requisitos para la transcripción en el dispositivo.';
+  String get deviceRequirements => 'Tu dispositivo no cumple con los requisitos para la transcripción en el dispositivo.';
 
   @override
   String get willLikelyCrash => 'Habilitar esto probablemente causará que la aplicación se bloquee o se congele.';
@@ -6049,15 +5938,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cloudProvider => 'Proveedor en la nube';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 minutos premium/mes. La pestaña En el dispositivo ofrece transcripción gratuita ilimitada.';
+  String get premiumMinutesInfo => '1.200 minutos premium/mes. La pestaña En el dispositivo ofrece transcripción gratuita ilimitada.';
 
   @override
   String get viewUsage => 'Ver uso';
 
   @override
-  String get localProcessingInfo =>
-      'El audio se procesa localmente. Funciona sin conexión, más privado, pero consume más batería.';
+  String get localProcessingInfo => 'El audio se procesa localmente. Funciona sin conexión, más privado, pero consume más batería.';
 
   @override
   String get model => 'Modelo';
@@ -6066,15 +5953,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get performanceWarning => 'Advertencia de rendimiento';
 
   @override
-  String get largeModelWarning =>
-      'Este modelo es grande y puede bloquear la aplicación o funcionar muy lento en dispositivos móviles.\n\nSe recomienda \"small\" o \"base\".';
+  String get largeModelWarning => 'Este modelo es grande y puede bloquear la aplicación o funcionar muy lento en dispositivos móviles.\n\nSe recomienda \"small\" o \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Usando reconocimiento de voz nativo de iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Se utilizará el motor de voz nativo de tu dispositivo. No se requiere descarga de modelo.';
+  String get noModelDownloadRequired => 'Se utilizará el motor de voz nativo de tu dispositivo. No se requiere descarga de modelo.';
 
   @override
   String get modelReady => 'Modelo listo';
@@ -6119,12 +6004,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Dispositivo no compatible';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'Tu dispositivo no cumple los requisitos para la transcripción en el dispositivo.';
+  String get deviceNotMeetRequirements => 'Tu dispositivo no cumple los requisitos para la transcripción en el dispositivo.';
 
   @override
-  String get transcriptionSlowerOnDevice =>
-      'La transcripción en el dispositivo puede ser más lenta en este dispositivo.';
+  String get transcriptionSlowerOnDevice => 'La transcripción en el dispositivo puede ser más lenta en este dispositivo.';
 
   @override
   String get computationallyIntensive => 'La transcripción en el dispositivo es computacionalmente intensiva.';
@@ -6133,12 +6016,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get batteryDrainSignificantly => 'El consumo de batería aumentará significativamente.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 minutos premium/mes. La pestaña En dispositivo ofrece transcripción gratuita ilimitada. ';
+  String get premiumMinutesMonth => '1.200 minutos premium/mes. La pestaña En dispositivo ofrece transcripción gratuita ilimitada. ';
 
   @override
-  String get audioProcessedLocally =>
-      'El audio se procesa localmente. Funciona sin conexión, más privado, pero usa más batería.';
+  String get audioProcessedLocally => 'El audio se procesa localmente. Funciona sin conexión, más privado, pero usa más batería.';
 
   @override
   String get languageLabel => 'Idioma';
@@ -6147,12 +6028,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get modelLabel => 'Modelo';
 
   @override
-  String get modelTooLargeWarning =>
-      'Este modelo es grande y puede causar que la aplicación se bloquee o funcione muy lentamente en dispositivos móviles.\n\nSe recomienda small o base.';
+  String get modelTooLargeWarning => 'Este modelo es grande y puede causar que la aplicación se bloquee o funcione muy lentamente en dispositivos móviles.\n\nSe recomienda small o base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Se usará el motor de voz nativo de tu dispositivo. No se requiere descarga de modelo.';
+  String get nativeEngineNoDownload => 'Se usará el motor de voz nativo de tu dispositivo. No se requiere descarga de modelo.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6188,8 +6067,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'La transcripción en vivo integrada de Omi está optimizada para conversaciones en tiempo real con detección automática de hablantes y diarización.';
+  String get omiTranscriptionOptimized => 'La transcripción en vivo integrada de Omi está optimizada para conversaciones en tiempo real con detección automática de hablantes y diarización.';
 
   @override
   String get reset => 'Restablecer';
@@ -6409,8 +6287,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Construyendo gráfico de conocimiento a partir de recuerdos...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Tu gráfico de conocimiento se construirá automáticamente cuando crees nuevos recuerdos.';
+  String get knowledgeGraphWillBuildAutomatically => 'Tu gráfico de conocimiento se construirá automáticamente cuando crees nuevos recuerdos.';
 
   @override
   String get buildGraphButton => 'Construir gráfico';
@@ -6646,8 +6523,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get failedToLoadContacts => 'Error al cargar los contactos';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Error al preparar la conversación para compartir. Por favor, inténtalo de nuevo.';
+  String get failedToPrepareConversationForSharing => 'Error al preparar la conversación para compartir. Por favor, inténtalo de nuevo.';
 
   @override
   String get couldNotOpenSmsApp => 'No se pudo abrir la aplicación de SMS. Por favor, inténtalo de nuevo.';
@@ -6713,8 +6589,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Descargando audio de la tarjeta SD de tu dispositivo';
 
   @override
-  String get transferRequiredDescription =>
-      'Esta grabación está almacenada en la tarjeta SD de tu dispositivo. Transfiérela a tu teléfono para reproducirla o compartirla.';
+  String get transferRequiredDescription => 'Esta grabación está almacenada en la tarjeta SD de tu dispositivo. Transfiérela a tu teléfono para reproducirla o compartirla.';
 
   @override
   String get cancelTransfer => 'Cancelar transferencia';
@@ -6735,8 +6610,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareRecording => 'Compartir grabación';
 
   @override
-  String get deleteRecordingConfirmation =>
-      '¿Estás seguro de que deseas eliminar permanentemente esta grabación? Esta acción no se puede deshacer.';
+  String get deleteRecordingConfirmation => '¿Estás seguro de que deseas eliminar permanentemente esta grabación? Esta acción no se puede deshacer.';
 
   @override
   String get recordingIdLabel => 'ID de grabación';
@@ -6795,15 +6669,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get enableFastTransfer => 'Habilitar transferencia rápida';
 
   @override
-  String get fastTransferDescription =>
-      'La transferencia rápida usa WiFi para velocidades ~5x más rápidas. Tu teléfono se conectará temporalmente a la red WiFi de tu dispositivo Omi durante la transferencia.';
+  String get fastTransferDescription => 'La transferencia rápida usa WiFi para velocidades ~5x más rápidas. Tu teléfono se conectará temporalmente a la red WiFi de tu dispositivo Omi durante la transferencia.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'El acceso a internet se pausa durante la transferencia';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Elige cómo se transfieren las grabaciones de tu dispositivo Omi a tu teléfono.';
+  String get chooseTransferMethodDescription => 'Elige cómo se transfieren las grabaciones de tu dispositivo Omi a tu teléfono.';
 
   @override
   String get wifiSpeed => '~150 KB/s vía WiFi';
@@ -6812,8 +6684,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fiveTimesFaster => '5X MÁS RÁPIDO';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Crea una conexión WiFi directa a tu dispositivo Omi. Tu teléfono se desconecta temporalmente de tu WiFi habitual durante la transferencia.';
+  String get fastTransferMethodDescription => 'Crea una conexión WiFi directa a tu dispositivo Omi. Tu teléfono se desconecta temporalmente de tu WiFi habitual durante la transferencia.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6822,8 +6693,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get bleSpeed => '~30 KB/s vía BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Usa conexión Bluetooth Low Energy estándar. Más lento pero no afecta tu conexión WiFi.';
+  String get bluetoothMethodDescription => 'Usa conexión Bluetooth Low Energy estándar. Más lento pero no afecta tu conexión WiFi.';
 
   @override
   String get selected => 'Seleccionado';
@@ -6861,12 +6731,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appDeleteFailed => 'Error al eliminar la app. Por favor, inténtalo de nuevo más tarde.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'La visibilidad de la app se cambió con éxito. Puede tardar unos minutos en reflejarse.';
+  String get appVisibilityChangedSuccessfully => 'La visibilidad de la app se cambió con éxito. Puede tardar unos minutos en reflejarse.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Error al activar la app. Si es una app de integración, asegúrate de que la configuración esté completa.';
+  String get errorActivatingAppIntegration => 'Error al activar la app. Si es una app de integración, asegúrate de que la configuración esté completa.';
 
   @override
   String get errorUpdatingAppStatus => 'Ocurrió un error al actualizar el estado de la app.';
@@ -6934,8 +6802,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get importantConversationTitle => 'Conversación importante';
 
   @override
-  String get importantConversationBody =>
-      'Acabas de tener una conversación importante. Toca para compartir el resumen.';
+  String get importantConversationBody => 'Acabas de tener una conversación importante. Toca para compartir el resumen.';
 
   @override
   String get templateName => 'Nombre de plantilla';
@@ -6947,8 +6814,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'El nombre debe tener al menos 3 caracteres';
 
   @override
-  String get conversationPromptHint =>
-      'ej., Extrae elementos de acción, decisiones tomadas y puntos clave de la conversación proporcionada.';
+  String get conversationPromptHint => 'ej., Extrae elementos de acción, decisiones tomadas y puntos clave de la conversación proporcionada.';
 
   @override
   String get pleaseEnterAppPrompt => 'Por favor, introduce una indicación para tu aplicación';
@@ -7053,8 +6919,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get paymentFailedToFetchCountries => 'Error al obtener países compatibles. Por favor intente más tarde.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Error al establecer método de pago predeterminado. Por favor intente más tarde.';
+  String get paymentFailedToSetDefault => 'Error al establecer método de pago predeterminado. Por favor intente más tarde.';
 
   @override
   String get paymentFailedToSavePaypal => 'Error al guardar detalles de PayPal. Por favor intente más tarde.';
@@ -7136,19 +7001,16 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      '¡Actualización programada! Tu plan mensual continúa hasta el final de tu período de facturación, luego cambia automáticamente a anual.';
+  String get planUpgradeScheduledMessage => '¡Actualización programada! Tu plan mensual continúa hasta el final de tu período de facturación, luego cambia automáticamente a anual.';
 
   @override
   String get couldNotSchedulePlanChange => 'No se pudo programar el cambio de plan. Por favor, inténtalo de nuevo.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      '¡Tu suscripción ha sido reactivada! Sin cargo ahora - se te facturará al final de tu período actual.';
+  String get subscriptionReactivatedDefault => '¡Tu suscripción ha sido reactivada! Sin cargo ahora - se te facturará al final de tu período actual.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      '¡Suscripción exitosa! Se te ha cobrado por el nuevo período de facturación.';
+  String get subscriptionSuccessfulCharged => '¡Suscripción exitosa! Se te ha cobrado por el nuevo período de facturación.';
 
   @override
   String get couldNotProcessSubscription => 'No se pudo procesar la suscripción. Por favor, inténtalo de nuevo.';
@@ -7313,8 +7175,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Error al recuperar el token de Firebase, por favor inténtalo de nuevo.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Error inesperado al iniciar sesión, error de Firebase, por favor inténtalo de nuevo.';
+  String get authUnexpectedErrorFirebase => 'Error inesperado al iniciar sesión, error de Firebase, por favor inténtalo de nuevo.';
 
   @override
   String get authUnexpectedError => 'Error inesperado al iniciar sesión, por favor inténtalo de nuevo';
@@ -7329,8 +7190,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Se requiere permiso de Bluetooth para conectarse a su dispositivo.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Permiso de Bluetooth denegado. Por favor, conceda el permiso en Preferencias del Sistema.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Permiso de Bluetooth denegado. Por favor, conceda el permiso en Preferencias del Sistema.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7343,12 +7203,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Permiso de notificaciones denegado. Por favor, conceda el permiso en Preferencias del Sistema.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Permiso de notificaciones denegado. Por favor, conceda el permiso en Preferencias del Sistema.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Permiso de notificaciones denegado. Por favor, conceda el permiso en Preferencias del Sistema > Notificaciones.';
+  String get onboardingNotificationDeniedNotifications => 'Permiso de notificaciones denegado. Por favor, conceda el permiso en Preferencias del Sistema > Notificaciones.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7361,15 +7219,13 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Por favor, conceda permiso de ubicación en Ajustes > Privacidad y Seguridad > Servicios de ubicación';
+  String get onboardingLocationGrantInSettings => 'Por favor, conceda permiso de ubicación en Ajustes > Privacidad y Seguridad > Servicios de ubicación';
 
   @override
   String get onboardingMicrophoneRequired => 'Se requiere permiso de micrófono para grabar.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Permiso de micrófono denegado. Por favor, conceda el permiso en Preferencias del Sistema > Privacidad y Seguridad > Micrófono.';
+  String get onboardingMicrophoneDenied => 'Permiso de micrófono denegado. Por favor, conceda el permiso en Preferencias del Sistema > Privacidad y Seguridad > Micrófono.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7382,12 +7238,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Se requiere permiso de captura de pantalla para grabar audio del sistema.';
+  String get onboardingScreenCaptureRequired => 'Se requiere permiso de captura de pantalla para grabar audio del sistema.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Permiso de captura de pantalla denegado. Por favor, conceda el permiso en Preferencias del Sistema > Privacidad y Seguridad > Grabación de pantalla.';
+  String get onboardingScreenCaptureDenied => 'Permiso de captura de pantalla denegado. Por favor, conceda el permiso en Preferencias del Sistema > Privacidad y Seguridad > Grabación de pantalla.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7400,8 +7254,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Se requiere permiso de accesibilidad para detectar reuniones del navegador.';
+  String get onboardingAccessibilityRequired => 'Se requiere permiso de accesibilidad para detectar reuniones del navegador.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7441,8 +7294,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Permiso de fotos denegado. Por favor, permita el acceso a las fotos para seleccionar imágenes';
+  String get msgPhotosPermissionDenied => 'Permiso de fotos denegado. Por favor, permita el acceso a las fotos para seleccionar imágenes';
 
   @override
   String get msgSelectImagesGenericError => 'Error al seleccionar imágenes. Por favor, inténtelo de nuevo.';
@@ -7484,8 +7336,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Se requiere permiso de micrófono';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Conceda permiso de micrófono en Preferencias del Sistema';
+  String get captureMicrophonePermissionInSystemPreferences => 'Conceda permiso de micrófono en Preferencias del Sistema';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Se requiere permiso de grabación de pantalla';
@@ -7515,8 +7366,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get locationPermissionRequired => 'Permiso de ubicación requerido';
 
   @override
-  String get locationPermissionContent =>
-      'La transferencia rápida requiere permiso de ubicación para verificar la conexión WiFi. Por favor, conceda el permiso de ubicación para continuar.';
+  String get locationPermissionContent => 'La transferencia rápida requiere permiso de ubicación para verificar la conexión WiFi. Por favor, conceda el permiso de ubicación para continuar.';
 
   @override
   String get pdfTranscriptExport => 'Exportar transcripción';
@@ -7679,8 +7529,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'El dispositivo no admite sincronización WiFi, cambiando a Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'El dispositivo no admite sincronización WiFi, cambiando a Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health no está disponible en este dispositivo';
@@ -7976,8 +7825,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Pon Omi DevKit en modo de emparejamiento';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Presiona el botón una vez para encender. El LED parpadeará en púrpura en modo de emparejamiento.';
+  String get pairingDescOmiDevkit => 'Presiona el botón una vez para encender. El LED parpadeará en púrpura en modo de emparejamiento.';
 
   @override
   String get pairingTitleOmiGlass => 'Enciende Omi Glass';
@@ -7989,8 +7837,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Pon Plaud Note en modo de emparejamiento';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Mantén presionado el botón lateral durante 2 segundos. El LED rojo parpadeará cuando esté listo para emparejar.';
+  String get pairingDescPlaudNote => 'Mantén presionado el botón lateral durante 2 segundos. El LED rojo parpadeará cuando esté listo para emparejar.';
 
   @override
   String get pairingTitleBee => 'Pon Bee en modo de emparejamiento';
@@ -8002,15 +7849,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pairingTitleLimitless => 'Pon Limitless en modo de emparejamiento';
 
   @override
-  String get pairingDescLimitless =>
-      'Cuando cualquier luz sea visible, presiona una vez y luego mantén presionado hasta que el dispositivo muestre una luz rosa, luego suelta.';
+  String get pairingDescLimitless => 'Cuando cualquier luz sea visible, presiona una vez y luego mantén presionado hasta que el dispositivo muestre una luz rosa, luego suelta.';
 
   @override
   String get pairingTitleFriendPendant => 'Pon Friend Pendant en modo de emparejamiento';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Presiona el botón del colgante para encenderlo. Entrará en modo de emparejamiento automáticamente.';
+  String get pairingDescFriendPendant => 'Presiona el botón del colgante para encenderlo. Entrará en modo de emparejamiento automáticamente.';
 
   @override
   String get pairingTitleFieldy => 'Pon Fieldy en modo de emparejamiento';
@@ -8022,15 +7867,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Conectar Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Instala y abre la aplicación Omi en tu Apple Watch, luego toca Conectar en la aplicación.';
+  String get pairingDescAppleWatch => 'Instala y abre la aplicación Omi en tu Apple Watch, luego toca Conectar en la aplicación.';
 
   @override
   String get pairingTitleNeoOne => 'Pon Neo One en modo de emparejamiento';
 
   @override
-  String get pairingDescNeoOne =>
-      'Mantén presionado el botón de encendido hasta que el LED parpadee. El dispositivo será visible.';
+  String get pairingDescNeoOne => 'Mantén presionado el botón de encendido hasta que el LED parpadee. El dispositivo será visible.';
 
   @override
   String get downloadingFromDevice => 'Descargando del dispositivo';
@@ -8100,8 +7943,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get wifiConfiguration => 'Configuración WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Ingrese sus credenciales WiFi para permitir que el dispositivo descargue el firmware.';
+  String get wifiConfigurationSubtitle => 'Ingrese sus credenciales WiFi para permitir que el dispositivo descargue el firmware.';
 
   @override
   String get networkNameSsid => 'Nombre de red (SSID)';
@@ -8119,8 +7961,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Esto es lo que sé sobre ti';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Este mapa se actualiza a medida que Omi aprende de tus conversaciones.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Este mapa se actualiza a medida que Omi aprende de tus conversaciones.';
 
   @override
   String get apiEnvironment => 'Entorno API';
@@ -8149,8 +7990,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get switchAndRestart => 'Cambiar';
 
   @override
-  String get stagingDisclaimer =>
-      'El entorno de pruebas puede ser inestable, tener un rendimiento inconsistente y los datos pueden perderse. Solo para pruebas.';
+  String get stagingDisclaimer => 'El entorno de pruebas puede ser inestable, tener un rendimiento inconsistente y los datos pueden perderse. Solo para pruebas.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Guardado. Cierra y vuelve a abrir la aplicación para aplicar los cambios.';
@@ -8201,8 +8041,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get phoneGetStarted => 'Comenzar';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'La grabacion de llamadas puede requerir consentimiento en tu jurisdiccion';
+  String get callRecordingConsentDisclaimer => 'La grabacion de llamadas puede requerir consentimiento en tu jurisdiccion';
 
   @override
   String get enterYourNumber => 'Ingresa tu numero';
@@ -8380,8 +8219,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Llamadas telefónicas vía Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Realiza llamadas a través de Omi y obtén transcripción en tiempo real, resúmenes automáticos y más.';
+  String get phoneCallsUpsellSubtitle => 'Realiza llamadas a través de Omi y obtén transcripción en tiempo real, resúmenes automáticos y más.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transcripción en tiempo real de cada llamada';
@@ -8408,8 +8246,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteSyncedFiles => 'Eliminar grabaciones sincronizadas';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Estas grabaciones ya se sincronizaron con tu teléfono. Esto no se puede deshacer.';
+  String get deleteSyncedFilesMessage => 'Estas grabaciones ya se sincronizaron con tu teléfono. Esto no se puede deshacer.';
 
   @override
   String get syncedFilesDeleted => 'Grabaciones sincronizadas eliminadas';
@@ -8421,8 +8258,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deletePendingFiles => 'Eliminar grabaciones pendientes';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Estas grabaciones NO se han sincronizado con tu teléfono y se perderán permanentemente. Esto no se puede deshacer.';
+  String get deletePendingFilesWarning => 'Estas grabaciones NO se han sincronizado con tu teléfono y se perderán permanentemente. Esto no se puede deshacer.';
 
   @override
   String get pendingFilesDeleted => 'Grabaciones pendientes eliminadas';
@@ -8434,8 +8270,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deleteAll => 'Eliminar todo';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Esto eliminará grabaciones sincronizadas y pendientes. Las grabaciones pendientes NO se han sincronizado y se perderán permanentemente.';
+  String get deleteAllFilesWarning => 'Esto eliminará grabaciones sincronizadas y pendientes. Las grabaciones pendientes NO se han sincronizado y se perderán permanentemente.';
 
   @override
   String get allFilesDeleted => 'Todas las grabaciones eliminadas';
@@ -8500,8 +8335,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fairUseAboutTitle => 'Sobre el uso razonable';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi está diseñado para conversaciones personales, reuniones e interacciones en vivo. El uso se mide por el tiempo real de habla detectado, no por el tiempo de conexión. Si el uso supera significativamente los patrones normales para contenido no personal, se pueden aplicar ajustes.';
+  String get fairUseAboutBody => 'Omi está diseñado para conversaciones personales, reuniones e interacciones en vivo. El uso se mide por el tiempo real de habla detectado, no por el tiempo de conexión. Si el uso supera significativamente los patrones normales para contenido no personal, se pueden aplicar ajustes.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8539,8 +8373,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get improveConnectionTitle => 'Mejorar conexión';
 
   @override
-  String get improveConnectionContent =>
-      'Hemos mejorado cómo Omi se mantiene conectado a tu dispositivo. Para activarlo, ve a la página de Información del dispositivo, toca \"Desconectar dispositivo\" y vuelve a vincular tu dispositivo.';
+  String get improveConnectionContent => 'Hemos mejorado cómo Omi se mantiene conectado a tu dispositivo. Para activarlo, ve a la página de Información del dispositivo, toca \"Desconectar dispositivo\" y vuelve a vincular tu dispositivo.';
 
   @override
   String get improveConnectionAction => 'Entendido';
@@ -8595,16 +8428,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cancelSyncQuestion => '¿Cancelar sincronización?';
 
   @override
-  String get omisStorageDesc =>
-      'Cuando tu Omi no está conectado a tu teléfono, almacena el audio localmente en su memoria integrada. Nunca perderás una grabación.';
+  String get omisStorageDesc => 'Cuando tu Omi no está conectado a tu teléfono, almacena el audio localmente en su memoria integrada. Nunca perderás una grabación.';
 
   @override
-  String get phoneStorageDesc =>
-      'Cuando Omi se reconecta, las grabaciones se transfieren automáticamente a tu teléfono antes de subirlas.';
+  String get phoneStorageDesc => 'Cuando Omi se reconecta, las grabaciones se transfieren automáticamente a tu teléfono antes de subirlas.';
 
   @override
-  String get cloudStorageDesc =>
-      'Una vez subidas, tus grabaciones se procesan y transcriben. Las conversaciones estarán disponibles en un minuto.';
+  String get cloudStorageDesc => 'Una vez subidas, tus grabaciones se procesan y transcriben. Las conversaciones estarán disponibles en un minuto.';
 
   @override
   String get tipKeepPhoneNearby => 'Mantén tu teléfono cerca para una sincronización más rápida';
@@ -8628,12 +8458,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get permissionEnable => 'Activar';
 
   @override
-  String get permissionsPageDescription =>
-      'Estos permisos son esenciales para el funcionamiento de Omi. Habilitan funciones clave como notificaciones, experiencias basadas en ubicación y captura de audio.';
+  String get permissionsPageDescription => 'Estos permisos son esenciales para el funcionamiento de Omi. Habilitan funciones clave como notificaciones, experiencias basadas en ubicación y captura de audio.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi necesita algunos permisos para funcionar correctamente. Por favor, concédelos para continuar.';
+  String get permissionsRequiredDescription => 'Omi necesita algunos permisos para funcionar correctamente. Por favor, concédelos para continuar.';
 
   @override
   String get permissionsSetupTitle => 'Obtén la mejor experiencia';
@@ -8687,8 +8515,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get justAMoment => 'Un momento, por favor';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Recomendamos encarecidamente explorar tus otras opciones en lugar de cancelar.';
+  String get cancelConsequencesSubtitle => 'Recomendamos encarecidamente explorar tus otras opciones en lugar de cancelar.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8890,8 +8717,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get enableLocationTitle => 'Activar ubicación';
 
   @override
-  String get enableLocationDescription =>
-      'Se necesita permiso de ubicación para encontrar dispositivos Bluetooth cercanos.';
+  String get enableLocationDescription => 'Se necesita permiso de ubicación para encontrar dispositivos Bluetooth cercanos.';
 
   @override
   String get voiceRecordingFound => 'Grabación encontrada';
@@ -8912,8 +8738,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get firmwareWarningTitle => 'Importante: Lea antes de actualizar';
 
   @override
-  String get firmwareFormatWarning =>
-      'Este firmware formateará la tarjeta SD. Asegúrese de que todos los datos sin conexión estén sincronizados antes de actualizar.\n\nSi ve una luz roja parpadeante después de instalar esta versión, no se preocupe. Simplemente conecte el dispositivo a la aplicación y debería ponerse azul. La luz roja significa que el reloj del dispositivo aún no se ha sincronizado.';
+  String get firmwareFormatWarning => 'Este firmware formateará la tarjeta SD. Asegúrese de que todos los datos sin conexión estén sincronizados antes de actualizar.\n\nSi ve una luz roja parpadeante después de instalar esta versión, no se preocupe. Simplemente conecte el dispositivo a la aplicación y debería ponerse azul. La luz roja significa que el reloj del dispositivo aún no se ha sincronizado.';
 
   @override
   String get continueAnyway => 'Continuar';
@@ -8933,8 +8758,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tasksMarkComplete => 'Marcado como completado';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi accede a Apple Health a través del framework HealthKit de Apple. Puedes revocar el acceso en cualquier momento desde los Ajustes de iOS.';
+  String get appleHealthManageNote => 'Omi accede a Apple Health a través del framework HealthKit de Apple. Puedes revocar el acceso en cualquier momento desde los Ajustes de iOS.';
 
   @override
   String get appleHealthConnectCta => 'Conectar con Apple Health';
@@ -8949,8 +8773,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appleHealthFeatureChatTitle => 'Conversa sobre tu salud';
 
   @override
-  String get appleHealthFeatureChatDesc =>
-      'Pregunta a Omi sobre tus pasos, sueño, frecuencia cardíaca y entrenamientos.';
+  String get appleHealthFeatureChatDesc => 'Pregunta a Omi sobre tus pasos, sueño, frecuencia cardíaca y entrenamientos.';
 
   @override
   String get appleHealthFeatureReadOnlyTitle => 'Acceso solo de lectura';
@@ -8962,15 +8785,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appleHealthFeatureSecureTitle => 'Sincronización segura';
 
   @override
-  String get appleHealthFeatureSecureDesc =>
-      'Tus datos de Apple Health se sincronizan de forma privada con tu cuenta de Omi.';
+  String get appleHealthFeatureSecureDesc => 'Tus datos de Apple Health se sincronizan de forma privada con tu cuenta de Omi.';
 
   @override
   String get appleHealthDeniedTitle => 'Acceso a Apple Health denegado';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi no tiene permiso para leer tus datos de Apple Health. Actívalo en Ajustes de iOS → Privacidad y seguridad → Salud → Omi.';
+  String get appleHealthDeniedBody => 'Omi no tiene permiso para leer tus datos de Apple Health. Actívalo en Ajustes de iOS → Privacidad y seguridad → Salud → Omi.';
 
   @override
   String get deleteFlowReasonTitle => '¿Por qué te vas?';
@@ -9039,8 +8860,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get planUpdate => 'Actualización del plan';
 
   @override
-  String get planDeprecationMessage =>
-      'Su plan Unlimited está siendo retirado. Cambie al plan Operator — las mismas excelentes funciones a \$49/mes. Su plan actual seguirá funcionando mientras tanto.';
+  String get planDeprecationMessage => 'Su plan Unlimited está siendo retirado. Cambie al plan Operator — las mismas excelentes funciones a \$49/mes. Su plan actual seguirá funcionando mientras tanto.';
 
   @override
   String get upgradeYourPlan => 'Mejora tu plan';
@@ -9151,8 +8971,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Has alcanzado tu límite mensual. Mejora tu plan para seguir chateando con Omi sin restricciones.';
+  String get chatQuotaExceededReply => 'Has alcanzado tu límite mensual. Mejora tu plan para seguir chateando con Omi sin restricciones.';
 
   @override
   String get voiceResponseAudio => 'Leer la respuesta de Omi en voz alta';
@@ -9183,4 +9002,25 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Agregar tarea';
+
+  @override
+  String get quickActionAskOmiAnything => 'Pregúntale cualquier cosa a Omi';
+
+  @override
+  String get quickActionVoiceMode => 'Modo de voz';
+
+  @override
+  String get quickActionMute => 'Silenciar';
+
+  @override
+  String get quickActionUnmute => 'Activar sonido';
+
+  @override
+  String get quickActionConnectDevice => 'Conectar dispositivo';
+
+  @override
+  String get quickActionDeviceSettings => 'Configuración del dispositivo';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -24,8 +24,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteConversationTitle => 'Kustuta vestlus?';
 
   @override
-  String get deleteConversationMessage =>
-      'See kustutab ka seotud mälestused, ülesanded ja helifailid. Seda toimingut ei saa tagasi võtta.';
+  String get deleteConversationMessage => 'See kustutab ka seotud mälestused, ülesanded ja helifailid. Seda toimingut ei saa tagasi võtta.';
 
   @override
   String get confirm => 'Kinnita';
@@ -146,8 +145,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleting => 'Kustutamine...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Palun lõpetage autentimine oma brauseris. Kui olete valmis, naasake rakendusse.';
+  String get pleaseCompleteAuthentication => 'Palun lõpetage autentimine oma brauseris. Kui olete valmis, naasake rakendusse.';
 
   @override
   String get failedToStartAuthentication => 'Autentimise alustamine ebaõnnestus';
@@ -286,8 +284,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get clearChat => 'Kustuta vestlus';
 
   @override
-  String get clearChatConfirm =>
-      'Kas olete kindel, et soovite vestluse tühjendada? Seda toimingut ei saa tagasi võtta.';
+  String get clearChatConfirm => 'Kas olete kindel, et soovite vestluse tühjendada? Seda toimingut ei saa tagasi võtta.';
 
   @override
   String get maxFilesLimit => 'Korraga saate üles laadida ainult 4 faili';
@@ -320,8 +317,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get installedApps => 'Paigaldatud rakendused';
 
   @override
-  String get unableToFetchApps =>
-      'Rakenduste laadimine ebaõnnestus :(\n\nPalun kontrollige oma internetiühendust ja proovige uuesti.';
+  String get unableToFetchApps => 'Rakenduste laadimine ebaõnnestus :(\n\nPalun kontrollige oma internetiühendust ja proovige uuesti.';
 
   @override
   String get aboutOmi => 'Omi kohta';
@@ -357,19 +353,16 @@ class AppLocalizationsEt extends AppLocalizations {
   String get appsDisconnected => 'Teie rakendused ja integratsioonid katkestatakse viivitamatult.';
 
   @override
-  String get exportBeforeDelete =>
-      'Saate oma andmed enne konto kustutamist eksportida, kuid pärast kustutamist ei saa neid taastada.';
+  String get exportBeforeDelete => 'Saate oma andmed enne konto kustutamist eksportida, kuid pärast kustutamist ei saa neid taastada.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Mõistan, et minu konto kustutamine on püsiv ja kõik andmed, sealhulgas mälestused ja vestlused, lähevad kaotsi ega ole taastatavad.';
+  String get deleteAccountCheckbox => 'Mõistan, et minu konto kustutamine on püsiv ja kõik andmed, sealhulgas mälestused ja vestlused, lähevad kaotsi ega ole taastatavad.';
 
   @override
   String get areYouSure => 'Kas olete kindel?';
 
   @override
-  String get deleteAccountFinal =>
-      'See toiming on pöördumatu ja kustutab jäädavalt teie konto ja kõik sellega seotud andmed. Kas olete kindel, et soovite jätkata?';
+  String get deleteAccountFinal => 'See toiming on pöördumatu ja kustutab jäädavalt teie konto ja kõik sellega seotud andmed. Kas olete kindel, et soovite jätkata?';
 
   @override
   String get deleteNow => 'Kustuta kohe';
@@ -378,8 +371,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get goBack => 'Mine tagasi';
 
   @override
-  String get checkBoxToConfirm =>
-      'Märkige ruut, et kinnitada, et mõistate, et teie konto kustutamine on püsiv ja pöördumatu.';
+  String get checkBoxToConfirm => 'Märkige ruut, et kinnitada, et mõistate, et teie konto kustutamine on püsiv ja pöördumatu.';
 
   @override
   String get profile => 'Profiil';
@@ -457,8 +449,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get yourPrivacyYourControl => 'Teie privaatsus, teie kontroll';
 
   @override
-  String get privacyIntro =>
-      'Omi-s oleme pühendunud teie privaatsuse kaitsmisele. See leht võimaldab teil kontrollida, kuidas teie andmeid säilitatakse ja kasutatakse.';
+  String get privacyIntro => 'Omi-s oleme pühendunud teie privaatsuse kaitsmisele. See leht võimaldab teil kontrollida, kuidas teie andmeid säilitatakse ja kasutatakse.';
 
   @override
   String get learnMore => 'Loe lähemalt...';
@@ -467,15 +458,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get dataProtectionLevel => 'Andmekaitse tase';
 
   @override
-  String get dataProtectionDesc =>
-      'Teie andmed on vaikimisi kaitstud tugeva krüpteerimisega. Vaadake allpool oma seadeid ja tulevasi privaatsusvalikuid.';
+  String get dataProtectionDesc => 'Teie andmed on vaikimisi kaitstud tugeva krüpteerimisega. Vaadake allpool oma seadeid ja tulevasi privaatsusvalikuid.';
 
   @override
   String get appAccess => 'Rakenduse juurdepääs';
 
   @override
-  String get appAccessDesc =>
-      'Järgmised rakendused pääsevad juurde teie andmetele. Puudutage rakendust selle õiguste haldamiseks.';
+  String get appAccessDesc => 'Järgmised rakendused pääsevad juurde teie andmetele. Puudutage rakendust selle õiguste haldamiseks.';
 
   @override
   String get noAppsExternalAccess => 'Ühelgi paigaldatud rakendusel pole välise juurdepääsu teie andmetele.';
@@ -532,15 +521,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Teie Omi on ühendus katkestatud 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Seadme sidumine tühistatud. Minge Seaded > Bluetooth ja unustage seade sidumise tühistamise lõpetamiseks.';
+  String get deviceUnpairedMessage => 'Seadme sidumine tühistatud. Minge Seaded > Bluetooth ja unustage seade sidumise tühistamise lõpetamiseks.';
 
   @override
   String get unpairDialogTitle => 'Tühista seadme sidumine';
 
   @override
-  String get unpairDialogMessage =>
-      'See tühistab seadme sidumise, et seda saaks ühendada teise telefoniga. Protsessi lõpetamiseks peate minema Seaded > Bluetooth ja unustama seadme.';
+  String get unpairDialogMessage => 'See tühistab seadme sidumise, et seda saaks ühendada teise telefoniga. Protsessi lõpetamiseks peate minema Seaded > Bluetooth ja unustama seadme.';
 
   @override
   String get deviceNotConnected => 'Seade pole ühendatud';
@@ -561,8 +548,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get v2Undetected => 'V2 tuvastamata';
 
   @override
-  String get v2UndetectedMessage =>
-      'Näeme, et teil on kas V1 seade või teie seade pole ühendatud. SD-kaardi funktsioon on saadaval ainult V2 seadmetele.';
+  String get v2UndetectedMessage => 'Näeme, et teil on kas V1 seade või teie seade pole ühendatud. SD-kaardi funktsioon on saadaval ainult V2 seadmetele.';
 
   @override
   String get endConversation => 'Lõpeta vestlus';
@@ -836,8 +822,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Kustuta teadmiste graaf?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'See kustutab kõik tuletatud teadmiste graafi andmed (sõlmed ja ühendused). Teie algsed mälestused jäävad turvaliseks. Graaf taastatakse aja jooksul või järgmise päringu korral.';
+  String get deleteKnowledgeGraphMessage => 'See kustutab kõik tuletatud teadmiste graafi andmed (sõlmed ja ühendused). Teie algsed mälestused jäävad turvaliseks. Graaf taastatakse aja jooksul või järgmise päringu korral.';
 
   @override
   String get knowledgeGraphDeleted => 'Teadmiste graaf kustutatud';
@@ -1080,8 +1065,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get needYourPermission => 'Vajame teie luba';
 
   @override
-  String get alreadyGavePermission =>
-      'Olete juba andnud meile loa teie salvestiste salvestamiseks. Siin on meeldetuletus, miks me seda vajame:';
+  String get alreadyGavePermission => 'Olete juba andnud meile loa teie salvestiste salvestamiseks. Siin on meeldetuletus, miks me seda vajame:';
 
   @override
   String get wouldLikePermission => 'Sooviksime teie luba teie helisalvestiste salvestamiseks. Siin on põhjus:';
@@ -1090,26 +1074,22 @@ class AppLocalizationsEt extends AppLocalizations {
   String get improveSpeechProfile => 'Parandage oma kõneprofiili';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Kasutame salvestisi, et edasi treenida ja parandada teie isiklikku kõneprofiili.';
+  String get improveSpeechProfileDesc => 'Kasutame salvestisi, et edasi treenida ja parandada teie isiklikku kõneprofiili.';
 
   @override
   String get trainFamilyProfiles => 'Treenige profiile sõprade ja pere jaoks';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Teie salvestised aitavad meil ära tunda ja luua profiile teie sõprade ja pere jaoks.';
+  String get trainFamilyProfilesDesc => 'Teie salvestised aitavad meil ära tunda ja luua profiile teie sõprade ja pere jaoks.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Parandage transkriptsiooni täpsust';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Kui meie mudel paraneb, saame pakkuda teie salvestiste jaoks paremaid transkriptsioone.';
+  String get enhanceTranscriptAccuracyDesc => 'Kui meie mudel paraneb, saame pakkuda teie salvestiste jaoks paremaid transkriptsioone.';
 
   @override
-  String get legalNotice =>
-      'Õiguslik teade: Häälsalvestuste salvestamise ja salvestamise seaduslikkus võib sõltuvalt teie asukohast ja selle funktsiooni kasutamisest erineda. Teie kohustus on tagada kohalike seaduste ja määruste järgimine.';
+  String get legalNotice => 'Õiguslik teade: Häälsalvestuste salvestamise ja salvestamise seaduslikkus võib sõltuvalt teie asukohast ja selle funktsiooni kasutamisest erineda. Teie kohustus on tagada kohalike seaduste ja määruste järgimine.';
 
   @override
   String get alreadyAuthorized => 'Juba autoriseeritud';
@@ -1272,8 +1252,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Öelge meile oma põhikeel';
 
   @override
-  String get languageForTranscription =>
-      'Määrake oma keel täpsemate transkriptsioonide ja isikupärastatud kogemuse saamiseks.';
+  String get languageForTranscription => 'Määrake oma keel täpsemate transkriptsioonide ja isikupärastatud kogemuse saamiseks.';
 
   @override
   String get singleLanguageModeInfo => 'Ühe keele režiim on lubatud. Tõlge on keelatud suurema täpsuse jaoks.';
@@ -1356,8 +1335,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get defaultRepository => 'Vaikimisi hoidla';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Valige vaikimisi hoidla probleemide loomiseks. Probleemide loomisel saate siiski määrata teise hoidla.';
+  String get selectDefaultRepoDesc => 'Valige vaikimisi hoidla probleemide loomiseks. Probleemide loomisel saate siiski määrata teise hoidla.';
 
   @override
   String get noReposFound => 'Hoidlaid ei leitud';
@@ -1732,8 +1710,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get enableBluetooth => 'Luba Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi vajab Bluetoothi, et ühenduda teie kantava seadmega. Palun lubage Bluetooth ja proovige uuesti.';
+  String get bluetoothNeeded => 'Omi vajab Bluetoothi, et ühenduda teie kantava seadmega. Palun lubage Bluetooth ja proovige uuesti.';
 
   @override
   String get contactSupport => 'Võta ühendust toega?';
@@ -1766,26 +1743,22 @@ class AppLocalizationsEt extends AppLocalizations {
   String get locationServiceDisabled => 'Asukohateenused keelatud';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Asukohateenused on keelatud. Palun minge Seaded > Privaatsus ja turvalisus > Asukohateenused ja lubage see';
+  String get locationServiceDisabledDesc => 'Asukohateenused on keelatud. Palun minge Seaded > Privaatsus ja turvalisus > Asukohateenused ja lubage see';
 
   @override
   String get backgroundLocationDenied => 'Tausta asukoha juurdepääs keelatud';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Palun minge seadme seadetesse ja määrake asukoha luba väärtusele \"Luba alati\"';
+  String get backgroundLocationDeniedDesc => 'Palun minge seadme seadetesse ja määrake asukoha luba väärtusele \"Luba alati\"';
 
   @override
   String get lovingOmi => 'Meeldib Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Aidake meil jõuda rohkemate inimesteni, jättes arvustuse App Store\'i. Teie tagasiside on meile ülimalt oluline!';
+  String get leaveReviewIos => 'Aidake meil jõuda rohkemate inimesteni, jättes arvustuse App Store\'i. Teie tagasiside on meile ülimalt oluline!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Aidake meil jõuda rohkemate inimesteni, jättes arvustuse Google Play poodi. Teie tagasiside on meile ülimalt oluline!';
+  String get leaveReviewAndroid => 'Aidake meil jõuda rohkemate inimesteni, jättes arvustuse Google Play poodi. Teie tagasiside on meile ülimalt oluline!';
 
   @override
   String get rateOnAppStore => 'Hinda App Store\'is';
@@ -1818,15 +1791,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get connectionError => 'Ühenduse viga';
 
   @override
-  String get connectionErrorDesc =>
-      'Serveriga ühendamine ebaõnnestus. Palun kontrollige oma internetiühendust ja proovige uuesti.';
+  String get connectionErrorDesc => 'Serveriga ühendamine ebaõnnestus. Palun kontrollige oma internetiühendust ja proovige uuesti.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Vigane salvestis tuvastatud';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Tundub, et salvestises on mitu kõnelejat. Palun veenduge, et olete vaikses kohas ja proovige uuesti.';
+  String get multipleSpeakersDesc => 'Tundub, et salvestises on mitu kõnelejat. Palun veenduge, et olete vaikses kohas ja proovige uuesti.';
 
   @override
   String get tooShortDesc => 'Kõnet ei tuvastatud piisavalt. Palun rääkige rohkem ja proovige uuesti.';
@@ -1838,8 +1809,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get areYouThere => 'Kas olete seal?';
 
   @override
-  String get noSpeechDesc =>
-      'Me ei suutnud kõnet tuvastada. Palun veenduge, et räägite vähemalt 10 sekundit ja mitte rohkem kui 3 minutit.';
+  String get noSpeechDesc => 'Me ei suutnud kõnet tuvastada. Palun veenduge, et räägite vähemalt 10 sekundit ja mitte rohkem kui 3 minutit.';
 
   @override
   String get connectionLost => 'Ühendus kadus';
@@ -1860,8 +1830,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get permissionsRequired => 'Õigused nõutavad';
 
   @override
-  String get permissionsRequiredDesc =>
-      'See rakendus vajab nõuetekohaseks toimimiseks Bluetoothi ja asukoha lube. Palun lubage need seadetes.';
+  String get permissionsRequiredDesc => 'See rakendus vajab nõuetekohaseks toimimiseks Bluetoothi ja asukoha lube. Palun lubage need seadetes.';
 
   @override
   String get openSettings => 'Ava seaded';
@@ -1891,8 +1860,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – teie AI kaaslane';
 
   @override
-  String get captureEveryMoment =>
-      'Jäädvustage iga hetk. Saage AI-põhiseid\nkokkuvõtteid. Ärge tehke enam kunagi märkmeid.';
+  String get captureEveryMoment => 'Jäädvustage iga hetk. Saage AI-põhiseid\nkokkuvõtteid. Ärge tehke enam kunagi märkmeid.';
 
   @override
   String get appleWatchSetup => 'Apple Watch\'i seadistamine';
@@ -1904,12 +1872,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get microphonePermission => 'Mikrofoni luba';
 
   @override
-  String get permissionGrantedNow =>
-      'Luba antud! Nüüd:\n\nAvage Omi rakendus oma kellal ja puudutage allpool \"Jätka\"';
+  String get permissionGrantedNow => 'Luba antud! Nüüd:\n\nAvage Omi rakendus oma kellal ja puudutage allpool \"Jätka\"';
 
   @override
-  String get needMicrophonePermission =>
-      'Vajame mikrofoni luba.\n\n1. Puudutage \"Anna luba\"\n2. Lubage oma iPhone\'is\n3. Kella rakendus sulgub\n4. Avage uuesti ja puudutage \"Jätka\"';
+  String get needMicrophonePermission => 'Vajame mikrofoni luba.\n\n1. Puudutage \"Anna luba\"\n2. Lubage oma iPhone\'is\n3. Kella rakendus sulgub\n4. Avage uuesti ja puudutage \"Jätka\"';
 
   @override
   String get grantPermissionButton => 'Anna luba';
@@ -1918,15 +1884,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get needHelp => 'Vajate abi?';
 
   @override
-  String get troubleshootingSteps =>
-      'Tõrkeotsing:\n\n1. Veenduge, et Omi on teie kellale installitud\n2. Avage Omi rakendus oma kellal\n3. Otsige loa hüpikakent\n4. Puudutage \"Luba\", kui küsitakse\n5. Rakendus teie kellal sulgub - avage see uuesti\n6. Tulge tagasi ja puudutage \"Jätka\" oma iPhone\'is';
+  String get troubleshootingSteps => 'Tõrkeotsing:\n\n1. Veenduge, et Omi on teie kellale installitud\n2. Avage Omi rakendus oma kellal\n3. Otsige loa hüpikakent\n4. Puudutage \"Luba\", kui küsitakse\n5. Rakendus teie kellal sulgub - avage see uuesti\n6. Tulge tagasi ja puudutage \"Jätka\" oma iPhone\'is';
 
   @override
   String get recordingStartedSuccessfully => 'Salvestamine algas edukalt!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Luba pole veel antud. Palun veenduge, et lubate mikrofoni juurdepääsu ja avasid rakenduse oma kellal uuesti.';
+  String get permissionNotGrantedYet => 'Luba pole veel antud. Palun veenduge, et lubate mikrofoni juurdepääsu ja avasid rakenduse oma kellal uuesti.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2023,8 +1987,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Valmis tegevuspunktide jaoks';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Teie AI eraldab automaatselt ülesanded ja tegevused teie vestlustest. Need ilmuvad siia, kui need luuakse.';
+  String get welcomeActionItemsDescription => 'Teie AI eraldab automaatselt ülesanded ja tegevused teie vestlustest. Need ilmuvad siia, kui need luuakse.';
 
   @override
   String get autoExtractionFeature => 'Automaatselt vestlustest eraldatud';
@@ -2074,8 +2037,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get clearMemoryTitle => 'Tühjenda Omi mälu';
 
   @override
-  String get clearMemoryMessage =>
-      'Kas olete kindel, et soovite Omi mälu tühjendada? Seda tegevust ei saa tagasi võtta.';
+  String get clearMemoryMessage => 'Kas olete kindel, et soovite Omi mälu tühjendada? Seda tegevust ei saa tagasi võtta.';
 
   @override
   String get clearMemoryButton => 'Tühjenda mälu';
@@ -2221,15 +2183,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'KÕNE JA TRANSKRIPTSIOON';
 
   @override
-  String get languageSettingsHelperText =>
-      'Rakenduse keel muudab menüüsid ja nuppe. Kõne keel mõjutab, kuidas teie salvestisi transkribeeritakse.';
+  String get languageSettingsHelperText => 'Rakenduse keel muudab menüüsid ja nuppe. Kõne keel mõjutab, kuidas teie salvestisi transkribeeritakse.';
 
   @override
   String get translationNotice => 'Tõlke teatis';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi tõlgib vestlused teie põhikeelde. Värskendage seda igal ajal jaotises Seaded → Profiilid.';
+  String get translationNoticeMessage => 'Omi tõlgib vestlused teie põhikeelde. Värskendage seda igal ajal jaotises Seaded → Profiilid.';
 
   @override
   String get pleaseCheckInternetConnection => 'Palun kontrollige oma internetiühendust ja proovige uuesti';
@@ -2384,8 +2344,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Tühista seadme sidumine';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'See tühistab seadme sidumise, et seda saaks ühendada teise telefoniga. Peate minema Seaded > Bluetooth ja unustama seadme protsessi lõpetamiseks.';
+  String get unpairDeviceDialogMessage => 'See tühistab seadme sidumise, et seda saaks ühendada teise telefoniga. Peate minema Seaded > Bluetooth ja unustama seadme protsessi lõpetamiseks.';
 
   @override
   String get unpair => 'Tühista sidumine';
@@ -2566,8 +2525,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get youreAllSet => 'Oled valmis!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Tere tulemast Omi juurde! Teie AI kaaslane on valmis aitama vestluste, ülesannete ja muuga.';
+  String get welcomeToOmiDescription => 'Tere tulemast Omi juurde! Teie AI kaaslane on valmis aitama vestluste, ülesannete ja muuga.';
 
   @override
   String get startUsingOmi => 'Alusta Omi kasutamist';
@@ -2703,8 +2661,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get noTasksYet => 'Ülesandeid pole veel';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Teie vestlustest pärit ülesanded ilmuvad siia.\nKlõpsake ülesande käsitsi lisamiseks nuppu Loo.';
+  String get tasksFromConversationsWillAppear => 'Teie vestlustest pärit ülesanded ilmuvad siia.\nKlõpsake ülesande käsitsi lisamiseks nuppu Loo.';
 
   @override
   String get monthJan => 'Jaan';
@@ -2761,8 +2718,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteActionItem => 'Kustuta ülesanne';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Kas olete kindel, et soovite selle ülesande kustutada? Seda tegevust ei saa tagasi võtta.';
+  String get deleteActionItemConfirmation => 'Kas olete kindel, et soovite selle ülesande kustutada? Seda tegevust ei saa tagasi võtta.';
 
   @override
   String get enterActionItemDescription => 'Sisesta ülesande kirjeldus...';
@@ -2837,15 +2793,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get chatPrompt => 'Vestluse viip';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Sa oled suurepärane rakendus, sinu töö on vastata kasutajate küsimustele ja panna nad end hästi tundma...';
+  String get chatPromptPlaceholder => 'Sa oled suurepärane rakendus, sinu töö on vastata kasutajate küsimustele ja panna nad end hästi tundma...';
 
   @override
   String get conversationPrompt => 'Vestluse viip';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Sa oled suurepärane rakendus, sulle antakse vestluse transkriptsioon ja kokkuvõte...';
+  String get conversationPromptPlaceholder => 'Sa oled suurepärane rakendus, sulle antakse vestluse transkriptsioon ja kokkuvõte...';
 
   @override
   String get notificationScopes => 'Teavituste ulatused';
@@ -2857,8 +2811,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get makeMyAppPublic => 'Tee minu rakendus avalikuks';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Selle rakenduse esitamisega nõustun Omi AI teenuse tingimuste ja privaatsuspoliitikaga';
+  String get submitAppTermsAgreement => 'Selle rakenduse esitamisega nõustun Omi AI teenuse tingimuste ja privaatsuspoliitikaga';
 
   @override
   String get submitApp => 'Esita rakendus';
@@ -2873,12 +2826,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get submitAppQuestion => 'Esita rakendus?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Sinu rakendust vaadatakse üle ja tehakse avalikuks. Võid seda kohe kasutada, isegi ülevaatuse ajal!';
+  String get submitAppPublicDescription => 'Sinu rakendust vaadatakse üle ja tehakse avalikuks. Võid seda kohe kasutada, isegi ülevaatuse ajal!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Sinu rakendust vaadatakse üle ja tehakse sulle privaatselt kättesaadavaks. Võid seda kohe kasutada, isegi ülevaatuse ajal!';
+  String get submitAppPrivateDescription => 'Sinu rakendust vaadatakse üle ja tehakse sulle privaatselt kättesaadavaks. Võid seda kohe kasutada, isegi ülevaatuse ajal!';
 
   @override
   String get startEarning => 'Alusta teenimist! 💰';
@@ -2902,23 +2853,19 @@ class AppLocalizationsEt extends AppLocalizations {
   String get dataAccessNotice => 'Andmetele juurdepääsu teatis';
 
   @override
-  String get dataAccessWarning =>
-      'See rakendus pääseb ligi teie andmetele. Omi AI ei vastuta selle eest, kuidas see rakendus teie andmeid kasutab, muudab või kustutab';
+  String get dataAccessWarning => 'See rakendus pääseb ligi teie andmetele. Omi AI ei vastuta selle eest, kuidas see rakendus teie andmeid kasutab, muudab või kustutab';
 
   @override
   String get installApp => 'Installi rakendus';
 
   @override
-  String get betaTesterNotice =>
-      'Olete selle rakenduse beeta-testija. See ei ole veel avalik. See muutub avalikuks pärast kinnitamist.';
+  String get betaTesterNotice => 'Olete selle rakenduse beeta-testija. See ei ole veel avalik. See muutub avalikuks pärast kinnitamist.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Teie rakendus on ülevaatamisel ja nähtav ainult teile. See muutub avalikuks pärast kinnitamist.';
+  String get appUnderReviewOwner => 'Teie rakendus on ülevaatamisel ja nähtav ainult teile. See muutub avalikuks pärast kinnitamist.';
 
   @override
-  String get appRejectedNotice =>
-      'Teie rakendus on tagasi lükatud. Palun värskendage rakenduse üksikasju ja esitage see uuesti ülevaatamiseks.';
+  String get appRejectedNotice => 'Teie rakendus on tagasi lükatud. Palun värskendage rakenduse üksikasju ja esitage see uuesti ülevaatamiseks.';
 
   @override
   String get setupSteps => 'Seadistamise sammud';
@@ -2980,8 +2927,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get descriptionLabel => 'Kirjeldus';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Minu suurepärane rakendus on suurepärane rakendus, mis teeb hämmastav asju. See on parim rakendus!';
+  String get appDescriptionPlaceholder => 'Minu suurepärane rakendus on suurepärane rakendus, mis teeb hämmastav asju. See on parim rakendus!';
 
   @override
   String get pleaseProvideValidDescription => 'Palun esitage kehtiv kirjeldus';
@@ -3133,8 +3079,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get microphonePermissionRequired => 'Helisalvestuse jaoks on vajalik mikrofoni luba.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofoni luba keelatud. Palun andke luba Süsteemieelistused > Privaatsus ja turvalisus > Mikrofon.';
+  String get microphonePermissionDenied => 'Mikrofoni luba keelatud. Palun andke luba Süsteemieelistused > Privaatsus ja turvalisus > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3293,8 +3238,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get createMemory => 'Loo mälestus';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Kas oled kindel, et soovid selle mälestuse kustutada? Seda toimingut ei saa tagasi võtta.';
+  String get deleteMemoryConfirmation => 'Kas oled kindel, et soovid selle mälestuse kustutada? Seda toimingut ei saa tagasi võtta.';
 
   @override
   String get makePrivate => 'Tee privaatseks';
@@ -3368,8 +3312,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get whatWeCollect => 'Mida me kogume';
 
   @override
-  String get dataCollectionMessage =>
-      'Jätkates salvestatakse teie vestlused, salvestused ja isikuandmed turvaliselt meie serveritesse, et pakkuda AI-põhiseid ülevaateid ja võimaldada kõiki rakenduse funktsioone.';
+  String get dataCollectionMessage => 'Jätkates salvestatakse teie vestlused, salvestused ja isikuandmed turvaliselt meie serveritesse, et pakkuda AI-põhiseid ülevaateid ja võimaldada kõiki rakenduse funktsioone.';
 
   @override
   String get dataProtection => 'Andmekaitse';
@@ -3402,8 +3345,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Nimi peab olema vähemalt 2 tähemärki';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Öelge meile, kuidas te soovite, et teid pöördutaks. See aitab isikupärastada teie Omi kogemust.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Öelge meile, kuidas te soovite, et teid pöördutaks. See aitab isikupärastada teie Omi kogemust.';
 
   @override
   String charactersCount(int count) {
@@ -3420,8 +3362,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get recordAudioConversations => 'Helisalvestiste salvestamine';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi vajab mikrofoni juurdepääsu, et salvestada teie vestlusi ja pakkuda transkriptsioone.';
+  String get microphoneAccessDescription => 'Omi vajab mikrofoni juurdepääsu, et salvestada teie vestlusi ja pakkuda transkriptsioone.';
 
   @override
   String get screenRecording => 'Ekraanisalvestus';
@@ -3430,8 +3371,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Süsteemiheli jäädvustamine koosolekutest';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi vajab ekraanisalvestuse luba, et jäädvustada süsteemiheli teie brauseripõhistest koosolekutest.';
+  String get screenRecordingDescription => 'Omi vajab ekraanisalvestuse luba, et jäädvustada süsteemiheli teie brauseripõhistest koosolekutest.';
 
   @override
   String get accessibility => 'Juurdepääsetavus';
@@ -3440,8 +3380,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Tuvastage brauseripõhised koosolekud';
 
   @override
-  String get accessibilityDescription =>
-      'Omi vajab juurdepääsetavuse luba, et tuvastada, millal te liitute Zoom, Meet või Teams koosolekutega oma brauseris.';
+  String get accessibilityDescription => 'Omi vajab juurdepääsetavuse luba, et tuvastada, millal te liitute Zoom, Meet või Teams koosolekutega oma brauseris.';
 
   @override
   String get pleaseWait => 'Palun oodake...';
@@ -3513,8 +3452,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get conversationsExportStarted => 'Vestluste eksport algas. See võib võtta mõned sekundid, palun oodake.';
 
   @override
-  String get mcpDescription =>
-      'Omi ühendamiseks teiste rakendustega, et lugeda, otsida ja hallata oma mälestusi ja vestlusi. Alustamiseks looge võti.';
+  String get mcpDescription => 'Omi ühendamiseks teiste rakendustega, et lugeda, otsida ja hallata oma mälestusi ja vestlusi. Alustamiseks looge võti.';
 
   @override
   String get apiKeys => 'API võtmed';
@@ -3585,8 +3523,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get auto => 'Automaatne';
 
   @override
-  String get noSummaryForApp =>
-      'Selle rakenduse jaoks pole kokkuvõtet saadaval. Proovi teist rakendust paremate tulemuste saamiseks.';
+  String get noSummaryForApp => 'Selle rakenduse jaoks pole kokkuvõtet saadaval. Proovi teist rakendust paremate tulemuste saamiseks.';
 
   @override
   String get tryAnotherApp => 'Proovi teist rakendust';
@@ -3623,8 +3560,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Lase Omil automaatselt parim rakendus valida';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Kas olete kindel, et soovite selle vestluse kustutada? Seda toimingut ei saa tagasi võtta.';
+  String get deleteConversationConfirmation => 'Kas olete kindel, et soovite selle vestluse kustutada? Seda toimingut ei saa tagasi võtta.';
 
   @override
   String get conversationDeleted => 'Vestlus kustutatud';
@@ -3672,8 +3608,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Süsteemiheli salvestamise ettevalmistamine';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klõpsake nupul, et salvestada heli reaalajas transkriptsioonide, AI-teadmiste ja automaatse salvestamise jaoks.';
+  String get clickTheButtonToCaptureAudio => 'Klõpsake nupul, et salvestada heli reaalajas transkriptsioonide, AI-teadmiste ja automaatse salvestamise jaoks.';
 
   @override
   String get reconnecting => 'Taasühendamine...';
@@ -3900,8 +3835,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Kustutada teadmiste graafik?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'See kustutab kõik tuletatud teadmiste graafiku andmed. Teie algse mälestused jäävad turvaliseks.';
+  String get deleteKnowledgeGraphWarning => 'See kustutab kõik tuletatud teadmiste graafiku andmed. Teie algse mälestused jäävad turvaliseks.';
 
   @override
   String get connectOmiWithAI => 'Ühenda Omi AI-assistentidega';
@@ -3958,8 +3892,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get updateAppQuestion => 'Värskenda rakendust?';
 
   @override
-  String get updateAppConfirmation =>
-      'Kas olete kindel, et soovite oma rakendust värskendada? Muudatused jõustuvad pärast meie meeskonna ülevaatust.';
+  String get updateAppConfirmation => 'Kas olete kindel, et soovite oma rakendust värskendada? Muudatused jõustuvad pärast meie meeskonna ülevaatust.';
 
   @override
   String get updateApp => 'Värskenda rakendust';
@@ -3989,8 +3922,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get no => 'Ei';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Tellimus tühistatud edukalt. See jääb aktiivseks kuni praeguse arveldusperioodi lõpuni.';
+  String get subscriptionCancelledSuccessfully => 'Tellimus tühistatud edukalt. See jääb aktiivseks kuni praeguse arveldusperioodi lõpuni.';
 
   @override
   String get failedToCancelSubscription => 'Tellimuse tühistamine ebaõnnestus. Palun proovi uuesti.';
@@ -4026,8 +3958,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Tühista tellimus?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Kas olete kindel, et soovite tellimuse tühistada? Teil on juurdepääs praeguse arveldusperioodi lõpuni.';
+  String get cancelSubscriptionConfirmation => 'Kas olete kindel, et soovite tellimuse tühistada? Teil on juurdepääs praeguse arveldusperioodi lõpuni.';
 
   @override
   String get cancelSubscriptionButton => 'Tühista tellimus';
@@ -4036,16 +3967,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get cancelling => 'Tühistamine...';
 
   @override
-  String get betaTesterMessage =>
-      'Olete selle rakenduse beetatestija. See ei ole veel avalik. See muutub avalikuks pärast heakskiitu.';
+  String get betaTesterMessage => 'Olete selle rakenduse beetatestija. See ei ole veel avalik. See muutub avalikuks pärast heakskiitu.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Teie rakendus on läbivaatamisel ja nähtav ainult teile. See muutub avalikuks pärast heakskiitu.';
+  String get appUnderReviewMessage => 'Teie rakendus on läbivaatamisel ja nähtav ainult teile. See muutub avalikuks pärast heakskiitu.';
 
   @override
-  String get appRejectedMessage =>
-      'Teie rakendus lükati tagasi. Palun uuendage andmeid ja esitage uuesti läbivaatamiseks.';
+  String get appRejectedMessage => 'Teie rakendus lükati tagasi. Palun uuendage andmeid ja esitage uuesti läbivaatamiseks.';
 
   @override
   String get invalidIntegrationUrl => 'Vigane integratsiooni URL';
@@ -4099,8 +4027,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get issueActivatingApp => 'Selle rakenduse aktiveerimisel tekkis probleem. Palun proovi uuesti.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'See rakendus pääseb ligi teie andmetele. Omi AI ei vastuta selle eest, kuidas teie andmeid kasutatakse.';
+  String get dataAccessNoticeDescription => 'See rakendus pääseb ligi teie andmetele. Omi AI ei vastuta selle eest, kuidas teie andmeid kasutatakse.';
 
   @override
   String get copyUrl => 'Kopeeri URL';
@@ -4188,8 +4115,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get omiApiKeys => 'Omi API võtmed';
 
   @override
-  String get apiKeysDescription =>
-      'API võtmeid kasutatakse autentimiseks, kui teie rakendus suhtleb OMI serveriga. Need võimaldavad teie rakendusel luua mälestusi ja turvaliselt juurde pääseda teistele OMI teenustele.';
+  String get apiKeysDescription => 'API võtmeid kasutatakse autentimiseks, kui teie rakendus suhtleb OMI serveriga. Need võimaldavad teie rakendusel luua mälestusi ja turvaliselt juurde pääseda teistele OMI teenustele.';
 
   @override
   String get aboutOmiApiKeys => 'Omi API võtmete kohta';
@@ -4213,8 +4139,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Tühistada API võti?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Seda toimingut ei saa tagasi võtta. Ükski rakendus, mis kasutab seda võtit, ei pääse enam API-le ligi.';
+  String get revokeApiKeyWarning => 'Seda toimingut ei saa tagasi võtta. Ükski rakendus, mis kasutab seda võtit, ei pääse enam API-le ligi.';
 
   @override
   String get revoke => 'Tühista';
@@ -4312,8 +4237,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get externalAppAccess => 'Väliste rakenduste juurdepääs';
 
   @override
-  String get externalAppAccessDescription =>
-      'Järgmistel installitud rakendustel on välised integratsioonid ja need saavad juurdepääsu teie andmetele, nagu vestlused ja mälestused.';
+  String get externalAppAccessDescription => 'Järgmistel installitud rakendustel on välised integratsioonid ja need saavad juurdepääsu teie andmetele, nagu vestlused ja mälestused.';
 
   @override
   String get noExternalAppsHaveAccess => 'Ühelgi välisel rakendusel pole juurdepääsu teie andmetele.';
@@ -4322,8 +4246,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimaalne turvalisus (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Otsast otsani krüpteerimine on privaatsuse kuldstandard. Kui see on lubatud, krüpteeritakse teie andmed teie seadmes enne nende saatmist meie serveritesse. See tähendab, et keegi, isegi mitte Omi, ei saa teie sisule juurde pääseda.';
+  String get e2eeDescription => 'Otsast otsani krüpteerimine on privaatsuse kuldstandard. Kui see on lubatud, krüpteeritakse teie andmed teie seadmes enne nende saatmist meie serveritesse. See tähendab, et keegi, isegi mitte Omi, ei saa teie sisule juurde pääseda.';
 
   @override
   String get importantTradeoffs => 'Olulised kompromissid:';
@@ -4357,15 +4280,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get secureEncryption => 'Turvaline krüpteerimine';
 
   @override
-  String get secureEncryptionDescription =>
-      'Teie andmed on krüpteeritud teile ainulaadse võtmega meie serverites, mis asuvad Google Cloudis. See tähendab, et teie toorandmed pole kellelegi kättesaadavad, sealhulgas Omi töötajatele või Google\'ile, otse andmebaasist.';
+  String get secureEncryptionDescription => 'Teie andmed on krüpteeritud teile ainulaadse võtmega meie serverites, mis asuvad Google Cloudis. See tähendab, et teie toorandmed pole kellelegi kättesaadavad, sealhulgas Omi töötajatele või Google\'ile, otse andmebaasist.';
 
   @override
   String get endToEndEncryption => 'Otsast otsani krüpteerimine';
 
   @override
-  String get e2eeCardDescription =>
-      'Lubab maksimaalse turvalisuse, kus ainult teie saate oma andmetele juurde pääseda. Puudutage, et rohkem teada saada.';
+  String get e2eeCardDescription => 'Lubab maksimaalse turvalisuse, kus ainult teie saate oma andmetele juurde pääseda. Puudutage, et rohkem teada saada.';
 
   @override
   String get dataAlwaysEncrypted => 'Olenemata tasemest on teie andmed alati krüpteeritud puhkeolekus ja edastamisel.';
@@ -4413,8 +4334,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get permissionsLabel => 'ÕIGUSED';
 
   @override
-  String get permissionsInfoNote =>
-      'R = Lugemine, W = Kirjutamine. Vaikimisi ainult lugemine, kui midagi pole valitud.';
+  String get permissionsInfoNote => 'R = Lugemine, W = Kirjutamine. Vaikimisi ainult lugemine, kui midagi pole valitud.';
 
   @override
   String get developerApi => 'Arendaja API';
@@ -4437,8 +4357,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Saage Omi Unlimited tasuta, panustades oma andmetega AI mudelite treenimisse.';
 
   @override
-  String get trainingDataBullets =>
-      '• Teie andmed aitavad parandada AI mudeleid\n• Jagatakse ainult mittetundlikke andmeid\n• Täiesti läbipaistev protsess';
+  String get trainingDataBullets => '• Teie andmed aitavad parandada AI mudeleid\n• Jagatakse ainult mittetundlikke andmeid\n• Täiesti läbipaistev protsess';
 
   @override
   String get learnMoreAtOmiTraining => 'Lisateave omi.me/training';
@@ -4598,8 +4517,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Teie privaatsus on meile oluline';
 
   @override
-  String get privacyIntroText =>
-      'Omis võtame teie privaatsust väga tõsiselt. Tahame olla läbipaistvad andmete osas, mida kogume ja kuidas neid kasutame. Siin on see, mida peate teadma:';
+  String get privacyIntroText => 'Omis võtame teie privaatsust väga tõsiselt. Tahame olla läbipaistvad andmete osas, mida kogume ja kuidas neid kasutame. Siin on see, mida peate teadma:';
 
   @override
   String get whatWeTrack => 'Mida jälgime';
@@ -4614,12 +4532,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get ourCommitment => 'Meie kohustus';
 
   @override
-  String get commitmentText =>
-      'Oleme pühendunud kasutama kogutud andmeid ainult Omi paremaks muutmiseks. Teie privaatsus ja usaldus on meile ülimalt olulised.';
+  String get commitmentText => 'Oleme pühendunud kasutama kogutud andmeid ainult Omi paremaks muutmiseks. Teie privaatsus ja usaldus on meile ülimalt olulised.';
 
   @override
-  String get thankYouText =>
-      'Täname, et olete Omi väärtuslik kasutaja. Kui teil on küsimusi või muresid, võtke meiega ühendust aadressil team@basedhardware.com.';
+  String get thankYouText => 'Täname, et olete Omi väärtuslik kasutaja. Kui teil on küsimusi või muresid, võtke meiega ühendust aadressil team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi sünkroonimise seaded';
@@ -4628,8 +4544,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get enterHotspotCredentials => 'Sisestage oma telefoni leviala mandaadid';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi sünkroonimine kasutab teie telefoni levialana. Leidke nimi ja parool menüüst Seaded > Isiklik leviala.';
+  String get wifiSyncUsesHotspot => 'WiFi sünkroonimine kasutab teie telefoni levialana. Leidke nimi ja parool menüüst Seaded > Isiklik leviala.';
 
   @override
   String get hotspotNameSsid => 'Leviala nimi (SSID)';
@@ -4664,8 +4579,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Kokkuvõtte loomine ebaõnnestus. Veenduge, et teil on selle päeva vestlusi.';
+  String get failedToGenerateSummaryCheckConversations => 'Kokkuvõtte loomine ebaõnnestus. Veenduge, et teil on selle päeva vestlusi.';
 
   @override
   String get summaryNotFound => 'Kokkuvõtet ei leitud';
@@ -4695,8 +4609,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Eksport alustatud. See võib võtta mõne sekundi...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'See kustutab kõik tuletatud teadmusgraafi andmed (sõlmed ja ühendused). Teie algsed mälestused jäävad turvaliseks. Graaf ehitatakse aja jooksul või järgmise päringu korral uuesti üles.';
+  String get knowledgeGraphDeleteDescription => 'See kustutab kõik tuletatud teadmusgraafi andmed (sõlmed ja ühendused). Teie algsed mälestused jäävad turvaliseks. Graaf ehitatakse aja jooksul või järgmise päringu korral uuesti üles.';
 
   @override
   String get configureDailySummaryDigest => 'Seadista oma igapäevane ülesannete kokkuvõte';
@@ -4766,8 +4679,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Kustuta kõik Limitless vestlused?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'See kustutab jäädavalt kõik Limitlessist imporditud vestlused. Seda toimingut ei saa tagasi võtta.';
+  String get deleteAllLimitlessWarning => 'See kustutab jäädavalt kõik Limitlessist imporditud vestlused. Seda toimingut ei saa tagasi võtta.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4823,8 +4735,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get howItWorksTitle => 'Kuidas see töötab?';
 
   @override
-  String get howPeopleWorks =>
-      'Kui inimene on loodud, võite minna vestluse transkriptsiooni juurde ja määrata talle vastavad segmendid, nii saab Omi ka tema kõnet tuvastada!';
+  String get howPeopleWorks => 'Kui inimene on loodud, võite minna vestluse transkriptsiooni juurde ja määrata talle vastavad segmendid, nii saab Omi ka tema kõnet tuvastada!';
 
   @override
   String get tapToDelete => 'Puuduta kustutamiseks';
@@ -4850,8 +4761,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get privacyNotice => 'Privaatsusteade';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Salvestised võivad jäädvustada teiste inimeste hääli. Enne lubamist veenduge, et teil on kõigi osalejate nõusolek.';
+  String get recordingsMayCaptureOthers => 'Salvestised võivad jäädvustada teiste inimeste hääli. Enne lubamist veenduge, et teil on kõigi osalejate nõusolek.';
 
   @override
   String get enable => 'Luba';
@@ -4863,8 +4773,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Hoidke kõik helisalvestised telefonis lokaalselt. Kui on keelatud, salvestatakse ainult ebaõnnestunud üleslaadimised ruumi säästmiseks.';
+  String get storeAudioDescription => 'Hoidke kõik helisalvestised telefonis lokaalselt. Kui on keelatud, salvestatakse ainult ebaõnnestunud üleslaadimised ruumi säästmiseks.';
 
   @override
   String get enableLocalStorage => 'Luba kohalik salvestus';
@@ -4882,12 +4791,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get storeAudioOnCloud => 'Salvesta heli pilve';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Teie reaalajas salvestised salvestatakse privaatsesse pilvesalvestusse, kui räägite.';
+  String get cloudStorageDialogMessage => 'Teie reaalajas salvestised salvestatakse privaatsesse pilvesalvestusse, kui räägite.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Salvestage oma reaalajas salvestised privaatsesse pilvesalvestusse, kui räägite. Heli salvestatakse turvaliselt reaalajas.';
+  String get storeAudioCloudDescription => 'Salvestage oma reaalajas salvestised privaatsesse pilvesalvestusse, kui räägite. Heli salvestatakse turvaliselt reaalajas.';
 
   @override
   String get downloadingFirmware => 'Püsivara allalaadimine';
@@ -4896,8 +4803,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get installingFirmware => 'Püsivara paigaldamine';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Ärge sulgege rakendust ega lülitage seadet välja. See võib teie seadet kahjustada.';
+  String get firmwareUpdateWarning => 'Ärge sulgege rakendust ega lülitage seadet välja. See võib teie seadet kahjustada.';
 
   @override
   String get firmwareUpdated => 'Püsivara uuendatud';
@@ -4941,8 +4847,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get payments => 'Maksed';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Ühendage allpool maksemeetod, et alustada oma rakenduste eest maksete saamist.';
+  String get connectPaymentMethodInfo => 'Ühendage allpool maksemeetod, et alustada oma rakenduste eest maksete saamist.';
 
   @override
   String get selectedPaymentMethod => 'Valitud maksemeetod';
@@ -4996,8 +4901,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get connectingYourStripeAccount => 'Teie Stripe konto ühendamine';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Palun viige Stripe\'i registreerimisprotsess lõpule oma brauseris. See leht värskendatakse automaatselt pärast lõpetamist.';
+  String get stripeOnboardingInstructions => 'Palun viige Stripe\'i registreerimisprotsess lõpule oma brauseris. See leht värskendatakse automaatselt pärast lõpetamist.';
 
   @override
   String get failedTryAgain => 'Ebaõnnestus? Proovi uuesti';
@@ -5009,8 +4913,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get successfullyConnected => 'Edukalt ühendatud!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Teie Stripe konto on nüüd valmis makseid vastu võtma. Saate kohe alustada oma rakenduste müügist teenimist.';
+  String get stripeReadyForPayments => 'Teie Stripe konto on nüüd valmis makseid vastu võtma. Saate kohe alustada oma rakenduste müügist teenimist.';
 
   @override
   String get updateStripeDetails => 'Värskenda Stripe andmeid';
@@ -5028,8 +4931,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Värskendage oma PayPali konto andmeid';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Ühendage oma PayPali konto, et alustada oma rakenduste eest maksete saamist';
+  String get connectPayPalToReceivePayments => 'Ühendage oma PayPali konto, et alustada oma rakenduste eest maksete saamist';
 
   @override
   String get paypalEmail => 'PayPali e-post';
@@ -5038,8 +4940,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me link';
 
   @override
-  String get stripeRecommendation =>
-      'Kui Stripe on teie riigis saadaval, soovitame tungivalt seda kasutada kiiremate ja lihtsamate väljamaksete jaoks.';
+  String get stripeRecommendation => 'Kui Stripe on teie riigis saadaval, soovitame tungivalt seda kasutada kiiremate ja lihtsamate väljamaksete jaoks.';
 
   @override
   String get updatePayPalDetails => 'Värskenda PayPali andmeid';
@@ -5091,8 +4992,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Lisakõnenäidis eemaldatud';
 
   @override
-  String get consentDataMessage =>
-      'Jätkates salvestatakse teie vestlused, salvestised ja isikuandmed turvaliselt meie serverites. Teie helisalvestisi ja transkriptsioone töötlevad kolmandate osapoolte AI-teenused (sealhulgas Deepgram transkriptsiooni ja OpenAI analüüsi jaoks), et pakkuda teile AI-põhiseid ülevaateid ja võimaldada kõiki rakenduse funktsioone.';
+  String get consentDataMessage => 'Jätkates salvestatakse teie vestlused, salvestised ja isikuandmed turvaliselt meie serverites. Teie helisalvestisi ja transkriptsioone töötlevad kolmandate osapoolte AI-teenused (sealhulgas Deepgram transkriptsiooni ja OpenAI analüüsi jaoks), et pakkuda teile AI-põhiseid ülevaateid ja võimaldada kõiki rakenduse funktsioone.';
 
   @override
   String get tasksEmptyStateMessage => 'Teie vestlustest pärit ülesanded ilmuvad siia.\nPuudutage + käsitsi loomiseks.';
@@ -5131,15 +5031,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Installige Omi oma\nApple Watchi';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Apple Watchi kasutamiseks Omiga peate esmalt installima Omi rakenduse oma kellale.';
+  String get installOmiOnAppleWatchDescription => 'Apple Watchi kasutamiseks Omiga peate esmalt installima Omi rakenduse oma kellale.';
 
   @override
   String get openOmiOnAppleWatch => 'Avage Omi oma\nApple Watchis';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi rakendus on teie Apple Watchile installitud. Avage see ja puudutage käivitamiseks Start.';
+  String get openOmiOnAppleWatchDescription => 'Omi rakendus on teie Apple Watchile installitud. Avage see ja puudutage käivitamiseks Start.';
 
   @override
   String get openWatchApp => 'Ava Watchi rakendus';
@@ -5148,15 +5046,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Olen rakenduse installinud ja avanud';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watchi rakendust ei saa avada. Avage Watchi rakendus käsitsi oma Apple Watchis ja installige Omi jaotisest \"Saadaolevad rakendused\".';
+  String get unableToOpenWatchApp => 'Apple Watchi rakendust ei saa avada. Avage Watchi rakendus käsitsi oma Apple Watchis ja installige Omi jaotisest \"Saadaolevad rakendused\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch ühendatud!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch pole veel kättesaadav. Veenduge, et Omi rakendus oleks teie kellas avatud.';
+  String get appleWatchNotReachable => 'Apple Watch pole veel kättesaadav. Veenduge, et Omi rakendus oleks teie kellas avatud.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5173,8 +5069,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get finishedConversation => 'Vestlus lõppenud?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Kas olete kindel, et soovite salvestamise peatada ja vestluse kohe kokku võtta?';
+  String get stopRecordingConfirmation => 'Kas olete kindel, et soovite salvestamise peatada ja vestluse kohe kokku võtta?';
 
   @override
   String get conversationEndsManually => 'Vestlus lõpeb ainult käsitsi.';
@@ -5585,8 +5480,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get multipleSpeakersDetected => 'Tuvastati mitu kõnelejat';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Tundub, et salvestises on mitu kõnelejat. Veenduge, et olete vaikses kohas ja proovige uuesti.';
+  String get multipleSpeakersDescription => 'Tundub, et salvestises on mitu kõnelejat. Veenduge, et olete vaikses kohas ja proovige uuesti.';
 
   @override
   String get invalidRecordingDetected => 'Tuvastati kehtetu salvestis';
@@ -5604,8 +5498,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get howToTakeGoodSample => 'Kuidas teha head proovi?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Veenduge, et olete vaikses kohas.\n2. Rääkige selgelt ja loomulikult.\n3. Veenduge, et teie seade on oma loomulikus asendis kaelal.\n\nKui see on loodud, saate seda alati parandada või uuesti teha.';
+  String get goodSampleInstructions => '1. Veenduge, et olete vaikses kohas.\n2. Rääkige selgelt ja loomulikult.\n3. Veenduge, et teie seade on oma loomulikus asendis kaelal.\n\nKui see on loodud, saate seda alati parandada või uuesti teha.';
 
   @override
   String get noDeviceConnectedUseMic => 'Ühendatud seadet pole. Kasutatakse telefoni mikrofoni.';
@@ -5668,12 +5561,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get howItWorks => 'Kuidas see töötab';
 
   @override
-  String get dailyScoreExplanation =>
-      'Teie päeva skoor põhineb ülesannete täitmisel. Täitke oma ülesanded skoori parandamiseks!';
+  String get dailyScoreExplanation => 'Teie päeva skoor põhineb ülesannete täitmisel. Täitke oma ülesanded skoori parandamiseks!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontrolli, kui sageli Omi saadab sulle proaktiivseid teavitusi ja meeldetuletusi.';
+  String get notificationFrequencyDescription => 'Kontrolli, kui sageli Omi saadab sulle proaktiivseid teavitusi ja meeldetuletusi.';
 
   @override
   String get sliderOff => 'Väljas';
@@ -5687,8 +5578,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Kokkuvõtte genereerimine ebaõnnestus. Veendu, et sul on vestlusi sellel päeval.';
+  String get failedToGenerateSummary => 'Kokkuvõtte genereerimine ebaõnnestus. Veendu, et sul on vestlusi sellel päeval.';
 
   @override
   String get recap => 'Kokkuvõte';
@@ -5767,8 +5657,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get selectApp => 'Vali rakendus';
 
   @override
-  String get noChatAppsEnabled =>
-      'Vestlusrakendusi pole lubatud.\nPuudutage rakenduste lisamiseks \"Luba rakendused\".';
+  String get noChatAppsEnabled => 'Vestlusrakendusi pole lubatud.\nPuudutage rakenduste lisamiseks \"Luba rakendused\".';
 
   @override
   String get disable => 'Keela';
@@ -6049,15 +5938,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get cloudProvider => 'Pilveteenuse pakkuja';
 
   @override
-  String get premiumMinutesInfo =>
-      '1200 premium minutit kuus. Seadmesisene vahekaart pakub piiramatut tasuta transkriptsiooni.';
+  String get premiumMinutesInfo => '1200 premium minutit kuus. Seadmesisene vahekaart pakub piiramatut tasuta transkriptsiooni.';
 
   @override
   String get viewUsage => 'Vaata kasutust';
 
   @override
-  String get localProcessingInfo =>
-      'Heli töödeldakse kohapeal. Töötab võrguühenduseta, on privaatsem, kuid kasutab rohkem akut.';
+  String get localProcessingInfo => 'Heli töödeldakse kohapeal. Töötab võrguühenduseta, on privaatsem, kuid kasutab rohkem akut.';
 
   @override
   String get model => 'Mudel';
@@ -6066,15 +5953,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get performanceWarning => 'Jõudluse hoiatus';
 
   @override
-  String get largeModelWarning =>
-      'See mudel on suur ja võib põhjustada rakenduse krahhi või väga aeglase töö mobiilseadmetes.\n\nSoovitatav on kasutada \"small\" või \"base\" mudelit.';
+  String get largeModelWarning => 'See mudel on suur ja võib põhjustada rakenduse krahhi või väga aeglase töö mobiilseadmetes.\n\nSoovitatav on kasutada \"small\" või \"base\" mudelit.';
 
   @override
   String get usingNativeIosSpeech => 'Kasutatakse iOS-i natiivset kõnetuvastust';
 
   @override
-  String get noModelDownloadRequired =>
-      'Kasutatakse teie seadme algset kõnemootorit. Mudeli allalaadimine pole vajalik.';
+  String get noModelDownloadRequired => 'Kasutatakse teie seadme algset kõnemootorit. Mudeli allalaadimine pole vajalik.';
 
   @override
   String get modelReady => 'Mudel on valmis';
@@ -6131,12 +6016,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get batteryDrainSignificantly => 'Aku tühjenemine suureneb märkimisväärselt.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 premium minutit/kuus. Seadmes vahekaart pakub piiramatut tasuta transkriptsiooni. ';
+  String get premiumMinutesMonth => '1200 premium minutit/kuus. Seadmes vahekaart pakub piiramatut tasuta transkriptsiooni. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Heli töödeldakse kohapeal. Töötab võrguühenduseta, privaatsem, kuid kasutab rohkem akut.';
+  String get audioProcessedLocally => 'Heli töödeldakse kohapeal. Töötab võrguühenduseta, privaatsem, kuid kasutab rohkem akut.';
 
   @override
   String get languageLabel => 'Keel';
@@ -6145,12 +6028,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get modelLabel => 'Mudel';
 
   @override
-  String get modelTooLargeWarning =>
-      'See mudel on suur ja võib põhjustada rakenduse krahhi või väga aeglase töö mobiilseadmetes.\n\nSoovitatav on small või base.';
+  String get modelTooLargeWarning => 'See mudel on suur ja võib põhjustada rakenduse krahhi või väga aeglase töö mobiilseadmetes.\n\nSoovitatav on small või base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Kasutatakse teie seadme natiivset kõnemootorit. Mudeli allalaadimine pole vajalik.';
+  String get nativeEngineNoDownload => 'Kasutatakse teie seadme natiivset kõnemootorit. Mudeli allalaadimine pole vajalik.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6186,8 +6067,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi sisseehitatud reaalajas transkriptsioon on optimeeritud reaalajas vestluste jaoks automaatse kõneleja tuvastamise ja diariseerimisega.';
+  String get omiTranscriptionOptimized => 'Omi sisseehitatud reaalajas transkriptsioon on optimeeritud reaalajas vestluste jaoks automaatse kõneleja tuvastamise ja diariseerimisega.';
 
   @override
   String get reset => 'Lähtesta';
@@ -6407,8 +6287,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Teadmisgraafiku loomine mälestustest...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Teie teadmisgraafik luuakse automaatselt, kui loote uusi mälestusi.';
+  String get knowledgeGraphWillBuildAutomatically => 'Teie teadmisgraafik luuakse automaatselt, kui loote uusi mälestusi.';
 
   @override
   String get buildGraphButton => 'Loo graafik';
@@ -6644,8 +6523,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get failedToLoadContacts => 'Kontaktide laadimine ebaõnnestus';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Vestluse jagamiseks ettevalmistamine ebaõnnestus. Palun proovige uuesti.';
+  String get failedToPrepareConversationForSharing => 'Vestluse jagamiseks ettevalmistamine ebaõnnestus. Palun proovige uuesti.';
 
   @override
   String get couldNotOpenSmsApp => 'SMS-i rakendust ei saanud avada. Palun proovige uuesti.';
@@ -6711,8 +6589,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Heli allalaadimine seadme SD-kaardilt';
 
   @override
-  String get transferRequiredDescription =>
-      'See salvestis on salvestatud teie seadme SD-kaardile. Kandke see oma telefoni, et seda esitada.';
+  String get transferRequiredDescription => 'See salvestis on salvestatud teie seadme SD-kaardile. Kandke see oma telefoni, et seda esitada.';
 
   @override
   String get cancelTransfer => 'Tühista ülekanne';
@@ -6733,8 +6610,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get shareRecording => 'Jaga salvestist';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Kas olete kindel, et soovite selle salvestise jäädavalt kustutada? Seda ei saa tagasi võtta.';
+  String get deleteRecordingConfirmation => 'Kas olete kindel, et soovite selle salvestise jäädavalt kustutada? Seda ei saa tagasi võtta.';
 
   @override
   String get recordingIdLabel => 'Salvestise ID';
@@ -6793,8 +6669,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get enableFastTransfer => 'Luba kiire edastus';
 
   @override
-  String get fastTransferDescription =>
-      'Kiire edastus kasutab WiFi-d ~5x kiiremate kiiruste jaoks. Teie telefon ühendub ajutiselt edastuse ajal Omi seadme WiFi-võrguga.';
+  String get fastTransferDescription => 'Kiire edastus kasutab WiFi-d ~5x kiiremate kiiruste jaoks. Teie telefon ühendub ajutiselt edastuse ajal Omi seadme WiFi-võrguga.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Interneti-juurdepääs on edastuse ajal peatatud';
@@ -6809,8 +6684,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get fiveTimesFaster => '5X KIIREM';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Loob otseühenduse WiFi kaudu Omi seadmega. Teie telefon katkestab ajutiselt ühenduse tavalise WiFi-ga edastuse ajal.';
+  String get fastTransferMethodDescription => 'Loob otseühenduse WiFi kaudu Omi seadmega. Teie telefon katkestab ajutiselt ühenduse tavalise WiFi-ga edastuse ajal.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6819,8 +6693,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get bleSpeed => '~30 KB/s BLE kaudu';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Kasutab standardset Bluetooth Low Energy ühendust. Aeglasem, kuid ei mõjuta WiFi-ühendust.';
+  String get bluetoothMethodDescription => 'Kasutab standardset Bluetooth Low Energy ühendust. Aeglasem, kuid ei mõjuta WiFi-ühendust.';
 
   @override
   String get selected => 'Valitud';
@@ -6858,12 +6731,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get appDeleteFailed => 'Rakenduse kustutamine ebaõnnestus. Palun proovi hiljem uuesti.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Rakenduse nähtavus muudeti edukalt. Muudatuse kajastumine võib võtta mõne minuti.';
+  String get appVisibilityChangedSuccessfully => 'Rakenduse nähtavus muudeti edukalt. Muudatuse kajastumine võib võtta mõne minuti.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Viga rakenduse aktiveerimisel. Kui see on integratsioonirakendus, veendu, et seadistus on lõpule viidud.';
+  String get errorActivatingAppIntegration => 'Viga rakenduse aktiveerimisel. Kui see on integratsioonirakendus, veendu, et seadistus on lõpule viidud.';
 
   @override
   String get errorUpdatingAppStatus => 'Rakenduse oleku uuendamisel ilmnes viga.';
@@ -7136,8 +7007,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get couldNotSchedulePlanChange => 'Paketi muutmist ei õnnestunud ajastada. Palun proovige uuesti.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Teie tellimus on taastatud! Praegu tasu ei võeta - arve esitatakse järgmisel arveldusperioodil.';
+  String get subscriptionReactivatedDefault => 'Teie tellimus on taastatud! Praegu tasu ei võeta - arve esitatakse järgmisel arveldusperioodil.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Tellimus õnnestus! Teilt on uue arveldusperioodi eest tasu võetud.';
@@ -7333,12 +7203,10 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Teavituste luba keelatud. Palun andke luba Süsteemieelistustes.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Teavituste luba keelatud. Palun andke luba Süsteemieelistustes.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Teavituste luba keelatud. Palun andke luba Süsteemieelistused > Teavitused.';
+  String get onboardingNotificationDeniedNotifications => 'Teavituste luba keelatud. Palun andke luba Süsteemieelistused > Teavitused.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7351,15 +7219,13 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Palun andke asukohaluba Seaded > Privaatsus ja turvalisus > Asukohateenused';
+  String get onboardingLocationGrantInSettings => 'Palun andke asukohaluba Seaded > Privaatsus ja turvalisus > Asukohateenused';
 
   @override
   String get onboardingMicrophoneRequired => 'Salvestamiseks on vajalik mikrofoni luba.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofoni luba keelatud. Palun andke luba Süsteemieelistused > Privaatsus ja turvalisus > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Mikrofoni luba keelatud. Palun andke luba Süsteemieelistused > Privaatsus ja turvalisus > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7375,8 +7241,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Süsteemiheli salvestamiseks on vajalik ekraanipildi luba.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Ekraanipildi luba keelatud. Palun andke luba Süsteemieelistused > Privaatsus ja turvalisus > Ekraani salvestamine.';
+  String get onboardingScreenCaptureDenied => 'Ekraanipildi luba keelatud. Palun andke luba Süsteemieelistused > Privaatsus ja turvalisus > Ekraani salvestamine.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7501,8 +7366,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get locationPermissionRequired => 'Asukoha luba nõutav';
 
   @override
-  String get locationPermissionContent =>
-      'Kiire edastus vajab asukoha luba WiFi-ühenduse kontrollimiseks. Jätkamiseks andke palun asukoha luba.';
+  String get locationPermissionContent => 'Kiire edastus vajab asukoha luba WiFi-ühenduse kontrollimiseks. Jätkamiseks andke palun asukoha luba.';
 
   @override
   String get pdfTranscriptExport => 'Transkriptsiooni eksport';
@@ -7973,8 +7837,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Lülitage Plaud Note sidumisrežiimi';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Vajutage ja hoidke külgnuppu 2 sekundit. Punane LED vilgub, kui seade on sidumiseks valmis.';
+  String get pairingDescPlaudNote => 'Vajutage ja hoidke külgnuppu 2 sekundit. Punane LED vilgub, kui seade on sidumiseks valmis.';
 
   @override
   String get pairingTitleBee => 'Lülitage Bee sidumisrežiimi';
@@ -7986,15 +7849,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get pairingTitleLimitless => 'Lülitage Limitless sidumisrežiimi';
 
   @override
-  String get pairingDescLimitless =>
-      'Kui mõni tuli põleb, vajutage üks kord ja seejärel vajutage ja hoidke all, kuni seade näitab roosat valgust, seejärel vabastage.';
+  String get pairingDescLimitless => 'Kui mõni tuli põleb, vajutage üks kord ja seejärel vajutage ja hoidke all, kuni seade näitab roosat valgust, seejärel vabastage.';
 
   @override
   String get pairingTitleFriendPendant => 'Lülitage Friend Pendant sidumisrežiimi';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Vajutage ripatsil olevat nuppu selle sisselülitamiseks. See lülitub automaatselt sidumisrežiimi.';
+  String get pairingDescFriendPendant => 'Vajutage ripatsil olevat nuppu selle sisselülitamiseks. See lülitub automaatselt sidumisrežiimi.';
 
   @override
   String get pairingTitleFieldy => 'Lülitage Fieldy sidumisrežiimi';
@@ -8006,8 +7867,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Ühendage Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Installige ja avage Omi rakendus oma Apple Watchis, seejärel puudutage rakenduses Ühenda.';
+  String get pairingDescAppleWatch => 'Installige ja avage Omi rakendus oma Apple Watchis, seejärel puudutage rakenduses Ühenda.';
 
   @override
   String get pairingTitleNeoOne => 'Lülitage Neo One sidumisrežiimi';
@@ -8130,8 +7990,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get switchAndRestart => 'Lülita';
 
   @override
-  String get stagingDisclaimer =>
-      'Testkeskkond võib olla ebastabiilne, ebaühtlase jõudlusega ja andmed võivad kaduda. Ainult testimiseks.';
+  String get stagingDisclaimer => 'Testkeskkond võib olla ebastabiilne, ebaühtlase jõudlusega ja andmed võivad kaduda. Ainult testimiseks.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Salvestatud. Sulgege ja avage rakendus uuesti, et muudatused rakenduks.';
@@ -8360,8 +8219,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonikõned Omi kaudu';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Tehke kõnesid Omi kaudu ja saage reaalajas transkriptsioon, automaatsed kokkuvõtted ja palju muud.';
+  String get phoneCallsUpsellSubtitle => 'Tehke kõnesid Omi kaudu ja saage reaalajas transkriptsioon, automaatsed kokkuvõtted ja palju muud.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Iga kõne reaalajas transkriptsioon';
@@ -8388,8 +8246,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteSyncedFiles => 'Kustuta sünkroniseeritud salvestised';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Need salvestised on juba teie telefoniga sünkroniseeritud. Seda ei saa tagasi võtta.';
+  String get deleteSyncedFilesMessage => 'Need salvestised on juba teie telefoniga sünkroniseeritud. Seda ei saa tagasi võtta.';
 
   @override
   String get syncedFilesDeleted => 'Sünkroniseeritud salvestised kustutatud';
@@ -8401,8 +8258,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deletePendingFiles => 'Kustuta ootel salvestised';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Neid salvestisi EI ole teie telefoniga sünkroniseeritud ja need lähevad jäädavalt kaotsi. Seda ei saa tagasi võtta.';
+  String get deletePendingFilesWarning => 'Neid salvestisi EI ole teie telefoniga sünkroniseeritud ja need lähevad jäädavalt kaotsi. Seda ei saa tagasi võtta.';
 
   @override
   String get pendingFilesDeleted => 'Ootel salvestised kustutatud';
@@ -8414,8 +8270,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deleteAll => 'Kustuta kõik';
 
   @override
-  String get deleteAllFilesWarning =>
-      'See kustutab sünkroniseeritud ja ootel salvestised. Ootel salvestisi EI ole sünkroniseeritud ja need lähevad jäädavalt kaotsi.';
+  String get deleteAllFilesWarning => 'See kustutab sünkroniseeritud ja ootel salvestised. Ootel salvestisi EI ole sünkroniseeritud ja need lähevad jäädavalt kaotsi.';
 
   @override
   String get allFilesDeleted => 'Kõik salvestised kustutatud';
@@ -8480,8 +8335,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get fairUseAboutTitle => 'Õiglase kasutuse kohta';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi on loodud isiklikeks vestlusteks, koosolekuteks ja reaalajas suhtluseks. Kasutust mõõdetakse tuvastatud tegeliku kõneaja, mitte ühenduse aja järgi. Kui kasutus ületab oluliselt tavapäraseid mustreid mitteisikliku sisu puhul, võidakse rakendada kohandusi.';
+  String get fairUseAboutBody => 'Omi on loodud isiklikeks vestlusteks, koosolekuteks ja reaalajas suhtluseks. Kasutust mõõdetakse tuvastatud tegeliku kõneaja, mitte ühenduse aja järgi. Kui kasutus ületab oluliselt tavapäraseid mustreid mitteisikliku sisu puhul, võidakse rakendada kohandusi.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8519,8 +8373,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get improveConnectionTitle => 'Ühenduse parandamine';
 
   @override
-  String get improveConnectionContent =>
-      'Oleme parandanud, kuidas Omi jääb teie seadmega ühendusse. Selle aktiveerimiseks minge seadme teabe lehele, puudutage \"Katkesta seadme ühendus\" ja ühendage seade uuesti.';
+  String get improveConnectionContent => 'Oleme parandanud, kuidas Omi jääb teie seadmega ühendusse. Selle aktiveerimiseks minge seadme teabe lehele, puudutage \"Katkesta seadme ühendus\" ja ühendage seade uuesti.';
 
   @override
   String get improveConnectionAction => 'Selge';
@@ -8575,16 +8428,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get cancelSyncQuestion => 'Tühista sünkroonimine?';
 
   @override
-  String get omisStorageDesc =>
-      'Kui teie Omi pole telefoniga ühendatud, salvestab see heli kohalikult sisseehitatud mällu. Te ei kaota kunagi salvestist.';
+  String get omisStorageDesc => 'Kui teie Omi pole telefoniga ühendatud, salvestab see heli kohalikult sisseehitatud mällu. Te ei kaota kunagi salvestist.';
 
   @override
-  String get phoneStorageDesc =>
-      'Kui Omi uuesti ühendub, kantakse salvestised automaatselt teie telefoni enne üleslaadimist.';
+  String get phoneStorageDesc => 'Kui Omi uuesti ühendub, kantakse salvestised automaatselt teie telefoni enne üleslaadimist.';
 
   @override
-  String get cloudStorageDesc =>
-      'Pärast üleslaadimist töödeldakse ja transkribeeritakse teie salvestised. Vestlused on saadaval minuti jooksul.';
+  String get cloudStorageDesc => 'Pärast üleslaadimist töödeldakse ja transkribeeritakse teie salvestised. Vestlused on saadaval minuti jooksul.';
 
   @override
   String get tipKeepPhoneNearby => 'Hoidke telefon lähedal kiiremaks sünkroonimiseks';
@@ -8608,12 +8458,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get permissionEnable => 'Luba';
 
   @override
-  String get permissionsPageDescription =>
-      'Need load on Omi toimimiseks olulised. Need võimaldavad põhifunktsioone nagu teavitused, asukohapõhised kogemused ja helisalvestus.';
+  String get permissionsPageDescription => 'Need load on Omi toimimiseks olulised. Need võimaldavad põhifunktsioone nagu teavitused, asukohapõhised kogemused ja helisalvestus.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi vajab mõningaid õigusi, et korralikult töötada. Palun anna need jätkamiseks.';
+  String get permissionsRequiredDescription => 'Omi vajab mõningaid õigusi, et korralikult töötada. Palun anna need jätkamiseks.';
 
   @override
   String get permissionsSetupTitle => 'Saage parim kogemus';
@@ -8890,8 +8738,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get firmwareWarningTitle => 'Oluline: Lugege enne uuendamist';
 
   @override
-  String get firmwareFormatWarning =>
-      'See püsivara vormindab SD-kaardi. Palun veenduge, et kõik võrguühenduseta andmed on enne uuendamist sünkroniseeritud.\n\nKui näete pärast selle versiooni installimist vilkuvat punast tuld, ärge muretsege. Ühendage seade lihtsalt rakendusega ja see peaks muutuma siniseks. Punane tuli tähendab, et seadme kell pole veel sünkroniseeritud.';
+  String get firmwareFormatWarning => 'See püsivara vormindab SD-kaardi. Palun veenduge, et kõik võrguühenduseta andmed on enne uuendamist sünkroniseeritud.\n\nKui näete pärast selle versiooni installimist vilkuvat punast tuld, ärge muretsege. Ühendage seade lihtsalt rakendusega ja see peaks muutuma siniseks. Punane tuli tähendab, et seadme kell pole veel sünkroniseeritud.';
 
   @override
   String get continueAnyway => 'Jätka';
@@ -8911,8 +8758,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get tasksMarkComplete => 'Märgitud lõpetatuks';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi kasutab Apple Health\'i juurdepääsuks Apple\'i HealthKit\'i raamistikku. Juurdepääsu saate igal ajal tühistada iOS\'i seadetes.';
+  String get appleHealthManageNote => 'Omi kasutab Apple Health\'i juurdepääsuks Apple\'i HealthKit\'i raamistikku. Juurdepääsu saate igal ajal tühistada iOS\'i seadetes.';
 
   @override
   String get appleHealthConnectCta => 'Ühenda Apple Health\'iga';
@@ -8945,8 +8791,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health\'i juurdepääs keelatud';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omil pole luba teie Apple Health\'i andmete lugemiseks. Lubage see: iOS Seaded → Privaatsus ja turvalisus → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omil pole luba teie Apple Health\'i andmete lugemiseks. Lubage see: iOS Seaded → Privaatsus ja turvalisus → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Miks sa lahkud?';
@@ -9015,8 +8860,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get planUpdate => 'Plaani uuendus';
 
   @override
-  String get planDeprecationMessage =>
-      'Teie Unlimited plaan lõpetatakse. Lülitage Operator plaanile — samad suurepärased funktsioonid hinnaga \$49/kuus. Teie praegune plaan jätkab vahepeal tööd.';
+  String get planDeprecationMessage => 'Teie Unlimited plaan lõpetatakse. Lülitage Operator plaanile — samad suurepärased funktsioonid hinnaga \$49/kuus. Teie praegune plaan jätkab vahepeal tööd.';
 
   @override
   String get upgradeYourPlan => 'Uuenda oma plaani';
@@ -9127,8 +8971,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Olete saavutanud oma igakuise limiidi. Uuendage, et jätkata Omiga piiranguteta vestlemist.';
+  String get chatQuotaExceededReply => 'Olete saavutanud oma igakuise limiidi. Uuendage, et jätkata Omiga piiranguteta vestlemist.';
 
   @override
   String get voiceResponseAudio => 'Loe Omi vastus ette';
@@ -9159,4 +9002,25 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Lisa ülesanne';
+
+  @override
+  String get quickActionAskOmiAnything => 'Küsi Omilt ükskõik mida';
+
+  @override
+  String get quickActionVoiceMode => 'Häälerežiim';
+
+  @override
+  String get quickActionMute => 'Vaigista';
+
+  @override
+  String get quickActionUnmute => 'Tühista vaigistus';
+
+  @override
+  String get quickActionConnectDevice => 'Ühenda seade';
+
+  @override
+  String get quickActionDeviceSettings => 'Seadme sätted';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -24,8 +24,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deleteConversationTitle => 'حذف گفتگو؟';
 
   @override
-  String get deleteConversationMessage =>
-      'این عمل باعث حذف یادداشت‌های، وظایف و فایل‌های صوتی مرتبط نیز می‌شود. این عمل قابل بازگشت نیست.';
+  String get deleteConversationMessage => 'این عمل باعث حذف یادداشت‌های، وظایف و فایل‌های صوتی مرتبط نیز می‌شود. این عمل قابل بازگشت نیست.';
 
   @override
   String get confirm => 'تایید';
@@ -146,8 +145,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deleting => 'درحال حذف...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'لطفاً احراز هویت را در مرورگر خود تکمیل کنید. پس از انجام، به اپلیکیشن بازگردید.';
+  String get pleaseCompleteAuthentication => 'لطفاً احراز هویت را در مرورگر خود تکمیل کنید. پس از انجام، به اپلیکیشن بازگردید.';
 
   @override
   String get failedToStartAuthentication => 'ناتوان در شروع احراز هویت';
@@ -319,8 +317,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get installedApps => 'اپلیکیشن‌های نصب‌شده';
 
   @override
-  String get unableToFetchApps =>
-      'ناتوان در دریافت اپلیکیشن‌ها :(\n\nلطفاً اتصال اینترنت خود را بررسی کنید و دوباره تلاش کنید.';
+  String get unableToFetchApps => 'ناتوان در دریافت اپلیکیشن‌ها :(\n\nلطفاً اتصال اینترنت خود را بررسی کنید و دوباره تلاش کنید.';
 
   @override
   String get aboutOmi => 'درباره Omi';
@@ -356,19 +353,16 @@ class AppLocalizationsFa extends AppLocalizations {
   String get appsDisconnected => 'اپلیکیشن‌ها و ادغام‌های شما بلافاصله قطع خواهند شد.';
 
   @override
-  String get exportBeforeDelete =>
-      'شما می‌توانید داده‌های خود را قبل از حذف حساب صادر کنید، اما پس از حذف، نمی‌توان آن را بازیابی کرد.';
+  String get exportBeforeDelete => 'شما می‌توانید داده‌های خود را قبل از حذف حساب صادر کنید، اما پس از حذف، نمی‌توان آن را بازیابی کرد.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'درک می‌کنم که حذف حساب من دائمی است و تمام داده‌ها، شامل یادداشت‌ها و گفتگوها، برای همیشه حذف خواهند شد و نمی‌توان آن‌ها را بازیابی کرد.';
+  String get deleteAccountCheckbox => 'درک می‌کنم که حذف حساب من دائمی است و تمام داده‌ها، شامل یادداشت‌ها و گفتگوها، برای همیشه حذف خواهند شد و نمی‌توان آن‌ها را بازیابی کرد.';
 
   @override
   String get areYouSure => 'آیا مطمئن هستید؟';
 
   @override
-  String get deleteAccountFinal =>
-      'این عمل برگشت‌ناپذیر است و حساب شما و تمام داده‌های مرتبط را برای همیشه حذف خواهد کرد. آیا مطمئن هستید که می‌خواهید ادامه دهید؟';
+  String get deleteAccountFinal => 'این عمل برگشت‌ناپذیر است و حساب شما و تمام داده‌های مرتبط را برای همیشه حذف خواهد کرد. آیا مطمئن هستید که می‌خواهید ادامه دهید؟';
 
   @override
   String get deleteNow => 'همین‌الان حذف کن';
@@ -377,8 +371,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get goBack => 'بازگشت';
 
   @override
-  String get checkBoxToConfirm =>
-      'جعبه را علامت‌گذاری کنید تا تایید کنید که درک می‌کنید حذف حساب دائمی و برگشت‌ناپذیر است.';
+  String get checkBoxToConfirm => 'جعبه را علامت‌گذاری کنید تا تایید کنید که درک می‌کنید حذف حساب دائمی و برگشت‌ناپذیر است.';
 
   @override
   String get profile => 'پروفایل';
@@ -456,8 +449,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get yourPrivacyYourControl => 'حریم خصوصی شما، کنترل شما';
 
   @override
-  String get privacyIntro =>
-      'در Omi، ما متعهد به حفاظت از حریم خصوصی شما هستیم. این صفحه به شما اجازه می‌دهد که کنترل کنید داده‌های شما چگونه ذخیره و استفاده می‌شوند.';
+  String get privacyIntro => 'در Omi، ما متعهد به حفاظت از حریم خصوصی شما هستیم. این صفحه به شما اجازه می‌دهد که کنترل کنید داده‌های شما چگونه ذخیره و استفاده می‌شوند.';
 
   @override
   String get learnMore => 'اطلاعات بیشتر...';
@@ -466,15 +458,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get dataProtectionLevel => 'سطح حفاظت داده‌ها';
 
   @override
-  String get dataProtectionDesc =>
-      'داده‌های شما به‌طور پیش‌فرض با رمزگذاری قوی ایمن هستند. تنظیمات و گزینه‌های حریم خصوصی آینده خود را مرور کنید.';
+  String get dataProtectionDesc => 'داده‌های شما به‌طور پیش‌فرض با رمزگذاری قوی ایمن هستند. تنظیمات و گزینه‌های حریم خصوصی آینده خود را مرور کنید.';
 
   @override
   String get appAccess => 'دسترسی اپلیکیشن';
 
   @override
-  String get appAccessDesc =>
-      'اپلیکیشن‌های زیر می‌توانند به داده‌های شما دسترسی داشته باشند. برای مدیریت اجازه‌های آن روی اپلیکیشن ضربه بزنید.';
+  String get appAccessDesc => 'اپلیکیشن‌های زیر می‌توانند به داده‌های شما دسترسی داشته باشند. برای مدیریت اجازه‌های آن روی اپلیکیشن ضربه بزنید.';
 
   @override
   String get noAppsExternalAccess => 'هیچ اپلیکیشن نصب‌شده‌ای دسترسی خارجی به داده‌های شما ندارد.';
@@ -531,22 +521,19 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Omi شما قطع شده است 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'دستگاه جدا شد. به تنظیمات > Bluetooth بروید و دستگاه را فراموش کنید تا جدایی تکمیل شود.';
+  String get deviceUnpairedMessage => 'دستگاه جدا شد. به تنظیمات > Bluetooth بروید و دستگاه را فراموش کنید تا جدایی تکمیل شود.';
 
   @override
   String get unpairDialogTitle => 'جدا کردن دستگاه';
 
   @override
-  String get unpairDialogMessage =>
-      'این دستگاه را جدا می‌کند تا بتوان آن را به تلفن دیگری متصل کرد. شما باید به تنظیمات > Bluetooth بروید و دستگاه را فراموش کنید تا فرایند تکمیل شود.';
+  String get unpairDialogMessage => 'این دستگاه را جدا می‌کند تا بتوان آن را به تلفن دیگری متصل کرد. شما باید به تنظیمات > Bluetooth بروید و دستگاه را فراموش کنید تا فرایند تکمیل شود.';
 
   @override
   String get deviceNotConnected => 'دستگاه متصل نیست';
 
   @override
-  String get connectDeviceMessage =>
-      'دستگاه Omi خود را متصل کنید تا\nبه تنظیمات و سفارشی‌سازی دستگاه دسترسی داشته باشید';
+  String get connectDeviceMessage => 'دستگاه Omi خود را متصل کنید تا\nبه تنظیمات و سفارشی‌سازی دستگاه دسترسی داشته باشید';
 
   @override
   String get deviceInfoSection => 'اطلاعات دستگاه';
@@ -561,8 +548,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get v2Undetected => 'V2 شناسایی نشد';
 
   @override
-  String get v2UndetectedMessage =>
-      'ما می‌بینیم که شما یک دستگاه V1 دارید یا دستگاه شما متصل نیست. عملکرد کارت SD فقط برای دستگاه‌های V2 دردسترس است.';
+  String get v2UndetectedMessage => 'ما می‌بینیم که شما یک دستگاه V1 دارید یا دستگاه شما متصل نیست. عملکرد کارت SD فقط برای دستگاه‌های V2 دردسترس است.';
 
   @override
   String get endConversation => 'پایان‌دادن به گفتگو';
@@ -836,8 +822,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'حذف گراف دانش؟';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'این کار تمام داده‌های گراف دانش مشتق‌شده (گره‌ها و اتصالات) را حذف خواهد کرد. یادداشت‌های اصلی شما امن باقی خواهند ماند. گراف در طول زمان یا در درخواست بعدی بازسازی خواهد شد.';
+  String get deleteKnowledgeGraphMessage => 'این کار تمام داده‌های گراف دانش مشتق‌شده (گره‌ها و اتصالات) را حذف خواهد کرد. یادداشت‌های اصلی شما امن باقی خواهند ماند. گراف در طول زمان یا در درخواست بعدی بازسازی خواهد شد.';
 
   @override
   String get knowledgeGraphDeleted => 'گراف دانش حذف شد';
@@ -1020,8 +1005,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get integrationsFooter => 'اپلیکیشن‌های خود را وصل کنید تا داده‌ها و معیارها را در چت مشاهده کنید.';
 
   @override
-  String get completeAuthInBrowser =>
-      'لطفاً احراز هویت را در مرورگر خود تکمیل کنید. پس از انجام، به اپلیکیشن بازگردید.';
+  String get completeAuthInBrowser => 'لطفاً احراز هویت را در مرورگر خود تکمیل کنید. پس از انجام، به اپلیکیشن بازگردید.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1081,8 +1065,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get needYourPermission => 'ما نیاز به اجازه شما داریم';
 
   @override
-  String get alreadyGavePermission =>
-      'شما قبلاً اجازه‌ای برای ذخیره ضبط‌های صوتی شما داده‌اید. اینجا یادآوری دلیل نیاز ما است:';
+  String get alreadyGavePermission => 'شما قبلاً اجازه‌ای برای ذخیره ضبط‌های صوتی شما داده‌اید. اینجا یادآوری دلیل نیاز ما است:';
 
   @override
   String get wouldLikePermission => 'ما می‌خواهیم اجازه شما را برای ذخیره ضبط‌های صوتی خود بگیریم. دلیل این است:';
@@ -1097,19 +1080,16 @@ class AppLocalizationsFa extends AppLocalizations {
   String get trainFamilyProfiles => 'آموزش پروفایل‌ها برای دوستان و خانواده';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'ضبط‌های شما کمک می‌کند ما دوستان و خانواده شما را شناسایی و پروفایل ایجاد کنیم.';
+  String get trainFamilyProfilesDesc => 'ضبط‌های شما کمک می‌کند ما دوستان و خانواده شما را شناسایی و پروفایل ایجاد کنیم.';
 
   @override
   String get enhanceTranscriptAccuracy => 'بهبود دقت رونویسی';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'هنگامی که مدل ما بهبود می‌یابد، می‌توانیم نتایج رونویسی بهتری برای ضبط‌های شما ارائه دهیم.';
+  String get enhanceTranscriptAccuracyDesc => 'هنگامی که مدل ما بهبود می‌یابد، می‌توانیم نتایج رونویسی بهتری برای ضبط‌های شما ارائه دهیم.';
 
   @override
-  String get legalNotice =>
-      'اخطار قانونی: قانونی بودن ضبط و ذخیره داده‌های صوتی ممکن است بسته به موقعیت مکانی شما و نحوه استفاده از این ویژگی متفاوت باشد. شما مسئول اطمینان از انطباق با قوانین و مقررات محلی هستید.';
+  String get legalNotice => 'اخطار قانونی: قانونی بودن ضبط و ذخیره داده‌های صوتی ممکن است بسته به موقعیت مکانی شما و نحوه استفاده از این ویژگی متفاوت باشد. شما مسئول اطمینان از انطباق با قوانین و مقررات محلی هستید.';
 
   @override
   String get alreadyAuthorized => 'قبلاً مجاز';
@@ -1187,8 +1167,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get showEventsNoParticipants => 'نمایش رویدادهایی بدون شرکت‌کننده';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'هنگام فعال‌سازی، Coming Up رویدادهایی بدون شرکت‌کننده یا پیوند ویدیویی را نمایش می‌دهد.';
+  String get showEventsNoParticipantsDesc => 'هنگام فعال‌سازی، Coming Up رویدادهایی بدون شرکت‌کننده یا پیوند ویدیویی را نمایش می‌دهد.';
 
   @override
   String get yourMeetings => 'جلسات شما';
@@ -1229,8 +1208,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get noProjectsInWorkspace => 'هیچ پروژه‌ای در این فضای کاری یافت نشد';
 
   @override
-  String get conversationTimeoutDesc =>
-      'انتخاب کنید که چقدر زمان در سکوت منتظر بمانید تا گفتگو به‌طور خودکار پایان یابد:';
+  String get conversationTimeoutDesc => 'انتخاب کنید که چقدر زمان در سکوت منتظر بمانید تا گفتگو به‌طور خودکار پایان یابد:';
 
   @override
   String get timeout2Minutes => '2 دقیقه';
@@ -1357,8 +1335,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get defaultRepository => 'مخزن پیش‌فرض';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'مخزنی پیش‌فرض برای ایجاد مسائل را انتخاب کنید. هنگام ایجاد مسائل، همچنان می‌توانید مخزن متفاوتی را مشخص کنید.';
+  String get selectDefaultRepoDesc => 'مخزنی پیش‌فرض برای ایجاد مسائل را انتخاب کنید. هنگام ایجاد مسائل، همچنان می‌توانید مخزن متفاوتی را مشخص کنید.';
 
   @override
   String get noReposFound => 'هیچ مخزنی یافت نشد';
@@ -1454,8 +1431,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get bringYourOwn => 'خود را بیاورید';
 
   @override
-  String get payYourSttProvider =>
-      'آزادانه از omi استفاده کنید. شما فقط مستقیماً ارائه‌دهنده STT خود را پرداخت می‌کنید.';
+  String get payYourSttProvider => 'آزادانه از omi استفاده کنید. شما فقط مستقیماً ارائه‌دهنده STT خود را پرداخت می‌کنید.';
 
   @override
   String get freeMinutesMonth => '1200 دقیقه رایگان/ماه شامل است. نامحدود با ';
@@ -1734,8 +1710,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get enableBluetooth => 'فعال‌سازی Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi نیاز به Bluetooth برای اتصال به دستگاه پوشیدنی دارد. لطفاً Bluetooth را فعال کنید و دوباره تلاش کنید.';
+  String get bluetoothNeeded => 'Omi نیاز به Bluetooth برای اتصال به دستگاه پوشیدنی دارد. لطفاً Bluetooth را فعال کنید و دوباره تلاش کنید.';
 
   @override
   String get contactSupport => 'تماس با پشتیبانی؟';
@@ -1768,26 +1743,22 @@ class AppLocalizationsFa extends AppLocalizations {
   String get locationServiceDisabled => 'سرویس مکان غیرفعال است';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'سرویس مکان غیرفعال است. لطفاً به Settings > Privacy & Security > Location Services بروید و آن را فعال کنید';
+  String get locationServiceDisabledDesc => 'سرویس مکان غیرفعال است. لطفاً به Settings > Privacy & Security > Location Services بروید و آن را فعال کنید';
 
   @override
   String get backgroundLocationDenied => 'دسترسی مکان پس‌زمینه رد شد';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'لطفاً به تنظیمات دستگاه بروید و مجوز مکان را روی \"Always Allow\" تنظیم کنید';
+  String get backgroundLocationDeniedDesc => 'لطفاً به تنظیمات دستگاه بروید و مجوز مکان را روی \"Always Allow\" تنظیم کنید';
 
   @override
   String get lovingOmi => 'Omi را دوست داشتید؟';
 
   @override
-  String get leaveReviewIos =>
-      'با گذاشتن نظری در App Store، کمک کنید ما به مردم بیشتری برسیم. بازخوردتان برای ما بسیار مهم است!';
+  String get leaveReviewIos => 'با گذاشتن نظری در App Store، کمک کنید ما به مردم بیشتری برسیم. بازخوردتان برای ما بسیار مهم است!';
 
   @override
-  String get leaveReviewAndroid =>
-      'با گذاشتن نظری در Google Play Store، کمک کنید ما به مردم بیشتری برسیم. بازخوردتان برای ما بسیار مهم است!';
+  String get leaveReviewAndroid => 'با گذاشتن نظری در Google Play Store، کمک کنید ما به مردم بیشتری برسیم. بازخوردتان برای ما بسیار مهم است!';
 
   @override
   String get rateOnAppStore => 'در App Store امتیاز دهید';
@@ -1826,8 +1797,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get invalidRecordingMultipleSpeakers => 'ضبط نامعتبر تشخیص داده شد';
 
   @override
-  String get multipleSpeakersDesc =>
-      'به نظر می‌رسد چندین سخنران در ضبط وجود دارند. لطفاً اطمینان حاصل کنید که در مکانی ساکت هستید و دوباره تلاش کنید.';
+  String get multipleSpeakersDesc => 'به نظر می‌رسد چندین سخنران در ضبط وجود دارند. لطفاً اطمینان حاصل کنید که در مکانی ساکت هستید و دوباره تلاش کنید.';
 
   @override
   String get tooShortDesc => 'سخن کافی تشخیص داده نشده است. لطفاً بیشتر صحبت کنید و دوباره تلاش کنید.';
@@ -1860,8 +1830,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get permissionsRequired => 'اجازات ضروری';
 
   @override
-  String get permissionsRequiredDesc =>
-      'این برنامه نیاز به اجازات Bluetooth و Location برای کارکرد صحیح دارد. لطفاً آنها را در تنظیمات فعال کنید.';
+  String get permissionsRequiredDesc => 'این برنامه نیاز به اجازات Bluetooth و Location برای کارکرد صحیح دارد. لطفاً آنها را در تنظیمات فعال کنید.';
 
   @override
   String get openSettings => 'باز کردن تنظیمات';
@@ -1903,12 +1872,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get microphonePermission => 'اجازه میکروفن';
 
   @override
-  String get permissionGrantedNow =>
-      'اجازه اعطا شد! اکنون:\n\nبرنامه Omi را روی ساعت خود باز کنید و روی \"Continue\" زیر ضربه بزنید';
+  String get permissionGrantedNow => 'اجازه اعطا شد! اکنون:\n\nبرنامه Omi را روی ساعت خود باز کنید و روی \"Continue\" زیر ضربه بزنید';
 
   @override
-  String get needMicrophonePermission =>
-      'ما به اجازه میکروفن نیاز داریم.\n\n1. روی \"اعطای اجازات\" ضربه بزنید\n2. در iPhone خود اجازه دهید\n3. برنامه ساعت بسته می‌شود\n4. دوباره باز کنید و روی \"Continue\" ضربه بزنید';
+  String get needMicrophonePermission => 'ما به اجازه میکروفن نیاز داریم.\n\n1. روی \"اعطای اجازات\" ضربه بزنید\n2. در iPhone خود اجازه دهید\n3. برنامه ساعت بسته می‌شود\n4. دوباره باز کنید و روی \"Continue\" ضربه بزنید';
 
   @override
   String get grantPermissionButton => 'اعطای اجازات';
@@ -1917,15 +1884,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get needHelp => 'کمک نیاز دارید؟';
 
   @override
-  String get troubleshootingSteps =>
-      'حل‌مسئله:\n\n1. مطمئن شوید که Omi روی ساعت شما نصب شده است\n2. برنامه Omi را روی ساعت خود باز کنید\n3. برای بالا رفتن اجازه به دنبال پنجره اجازات باشید\n4. هنگام درخواست، روی \"Allow\" ضربه بزنید\n5. برنامه روی ساعت شما بسته می‌شود - دوباره باز کنید\n6. به iPhone بازگردید و روی \"Continue\" ضربه بزنید';
+  String get troubleshootingSteps => 'حل‌مسئله:\n\n1. مطمئن شوید که Omi روی ساعت شما نصب شده است\n2. برنامه Omi را روی ساعت خود باز کنید\n3. برای بالا رفتن اجازه به دنبال پنجره اجازات باشید\n4. هنگام درخواست، روی \"Allow\" ضربه بزنید\n5. برنامه روی ساعت شما بسته می‌شود - دوباره باز کنید\n6. به iPhone بازگردید و روی \"Continue\" ضربه بزنید';
 
   @override
   String get recordingStartedSuccessfully => 'ضبط با موفقیت شروع شد!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'اجازه هنوز اعطا نشده است. لطفاً مطمئن شوید که دسترسی میکروفن را اجازه داده‌اید و برنامه را روی ساعت خود دوباره باز کرده‌اید.';
+  String get permissionNotGrantedYet => 'اجازه هنوز اعطا نشده است. لطفاً مطمئن شوید که دسترسی میکروفن را اجازه داده‌اید و برنامه را روی ساعت خود دوباره باز کرده‌اید.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2022,8 +1987,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get welcomeActionItemsTitle => 'آماده موارد اقدام';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'هوش مصنوعی شما به‌طور خودکار وظایف و کارهای انجام‌شده را از گفتگو‌های شما استخراج می‌کند. آنها در اینجا ظاهر می‌شوند.';
+  String get welcomeActionItemsDescription => 'هوش مصنوعی شما به‌طور خودکار وظایف و کارهای انجام‌شده را از گفتگو‌های شما استخراج می‌کند. آنها در اینجا ظاهر می‌شوند.';
 
   @override
   String get autoExtractionFeature => 'به‌طور خودکار از گفتگو‌ها استخراج شده';
@@ -2219,15 +2183,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'سخن و رونویسی';
 
   @override
-  String get languageSettingsHelperText =>
-      'زبان برنامه منوها و دکمه‌ها را تغییر می‌دهد. زبان سخن بر نحوه رونویسی ضبط‌های شما تأثیر می‌گذارد.';
+  String get languageSettingsHelperText => 'زبان برنامه منوها و دکمه‌ها را تغییر می‌دهد. زبان سخن بر نحوه رونویسی ضبط‌های شما تأثیر می‌گذارد.';
 
   @override
   String get translationNotice => 'اطلاع ترجمه';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi گفتگو‌های شما را به زبان اصلی شما ترجمه می‌کند. هر زمانی در Settings → Profiles آن را به‌روزرسانی کنید.';
+  String get translationNoticeMessage => 'Omi گفتگو‌های شما را به زبان اصلی شما ترجمه می‌کند. هر زمانی در Settings → Profiles آن را به‌روزرسانی کنید.';
 
   @override
   String get pleaseCheckInternetConnection => 'لطفاً اتصال اینترنت خود را بررسی کنید و دوباره تلاش کنید';
@@ -2389,8 +2351,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'جدا کردن دستگاه';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'این کار دستگاه را جدا می‌کند تا بتوان آن را به تلفن دیگری متصل کرد. برای تکمیل فرآیند، باید به تنظیمات > Bluetooth رفته و دستگاه را فراموش کنید.';
+  String get unpairDeviceDialogMessage => 'این کار دستگاه را جدا می‌کند تا بتوان آن را به تلفن دیگری متصل کرد. برای تکمیل فرآیند، باید به تنظیمات > Bluetooth رفته و دستگاه را فراموش کنید.';
 
   @override
   String get unpair => 'جدا کردن';
@@ -2571,8 +2532,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get youreAllSet => 'شما آماده‌اید!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'خوش‌آمدید به Omi! دستیار هوش مصنوعی شما آماده‌است تا در گفتگوها، وظایف و بسیاری مورد دیگر به شما کمک کند.';
+  String get welcomeToOmiDescription => 'خوش‌آمدید به Omi! دستیار هوش مصنوعی شما آماده‌است تا در گفتگوها، وظایف و بسیاری مورد دیگر به شما کمک کند.';
 
   @override
   String get startUsingOmi => 'شروع استفاده از Omi';
@@ -2708,8 +2668,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get noTasksYet => 'هیچ وظیفه‌ای وجود ندارد';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'وظایف از گفتگوهای شما در اینجا ظاهر می‌شوند.\nبرای افزودن دستی بر روی ایجاد کلیک کنید.';
+  String get tasksFromConversationsWillAppear => 'وظایف از گفتگوهای شما در اینجا ظاهر می‌شوند.\nبرای افزودن دستی بر روی ایجاد کلیک کنید.';
 
   @override
   String get monthJan => 'ژان';
@@ -2766,8 +2725,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deleteActionItem => 'حذف مورد اقدام';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'آیا مطمئن هستید که می‌خواهید این مورد اقدام را حذف کنید؟ این عمل قابل بازگشت نیست.';
+  String get deleteActionItemConfirmation => 'آیا مطمئن هستید که می‌خواهید این مورد اقدام را حذف کنید؟ این عمل قابل بازگشت نیست.';
 
   @override
   String get enterActionItemDescription => 'توضیح مورد اقدام را وارد کنید...';
@@ -2842,15 +2800,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get chatPrompt => 'دستورالعمل چت';
 
   @override
-  String get chatPromptPlaceholder =>
-      'شما یک برنامه عالی هستید، کار شما پاسخ‌دهی به سؤالات کاربر و خوب احساس کردن آنها است...';
+  String get chatPromptPlaceholder => 'شما یک برنامه عالی هستید، کار شما پاسخ‌دهی به سؤالات کاربر و خوب احساس کردن آنها است...';
 
   @override
   String get conversationPrompt => 'دستورالعمل گفتگو';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'شما یک برنامه عالی هستید، رونوشت و خلاصه یک گفتگو را دریافت خواهید کرد...';
+  String get conversationPromptPlaceholder => 'شما یک برنامه عالی هستید، رونوشت و خلاصه یک گفتگو را دریافت خواهید کرد...';
 
   @override
   String get notificationScopes => 'محدوده‌های اطلاع‌رسانی';
@@ -2862,8 +2818,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get makeMyAppPublic => 'برنامه خود را عمومی کنید';
 
   @override
-  String get submitAppTermsAgreement =>
-      'با ارسال این برنامه، من با شرایط خدمات و سیاست حریم خصوصی Omi AI موافقت می‌کنم';
+  String get submitAppTermsAgreement => 'با ارسال این برنامه، من با شرایط خدمات و سیاست حریم خصوصی Omi AI موافقت می‌کنم';
 
   @override
   String get submitApp => 'ارسال برنامه';
@@ -2878,12 +2833,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get submitAppQuestion => 'ارسال برنامه؟';
 
   @override
-  String get submitAppPublicDescription =>
-      'برنامه شما بررسی می‌شود و عمومی می‌شود. می‌توانید بلافاصله از آن استفاده کنید، حتی در حین بررسی!';
+  String get submitAppPublicDescription => 'برنامه شما بررسی می‌شود و عمومی می‌شود. می‌توانید بلافاصله از آن استفاده کنید، حتی در حین بررسی!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'برنامه شما بررسی می‌شود و به‌صورت خصوصی برای شما در دسترس قرار می‌گیرد. می‌توانید بلافاصله از آن استفاده کنید، حتی در حین بررسی!';
+  String get submitAppPrivateDescription => 'برنامه شما بررسی می‌شود و به‌صورت خصوصی برای شما در دسترس قرار می‌گیرد. می‌توانید بلافاصله از آن استفاده کنید، حتی در حین بررسی!';
 
   @override
   String get startEarning => 'شروع به درآمد! 💰';
@@ -2907,23 +2860,19 @@ class AppLocalizationsFa extends AppLocalizations {
   String get dataAccessNotice => 'اطلاع دسترسی به داده';
 
   @override
-  String get dataAccessWarning =>
-      'این برنامه به داده‌های شما دسترسی خواهد داشت. Omi AI مسئول نحوه استفاده، تغییر یا حذف داده‌های شما توسط این برنامه نیست';
+  String get dataAccessWarning => 'این برنامه به داده‌های شما دسترسی خواهد داشت. Omi AI مسئول نحوه استفاده، تغییر یا حذف داده‌های شما توسط این برنامه نیست';
 
   @override
   String get installApp => 'نصب برنامه';
 
   @override
-  String get betaTesterNotice =>
-      'شما یک آزمایشگر بتا برای این برنامه هستید. هنوز عمومی نیست. پس از تأیید عمومی می‌شود.';
+  String get betaTesterNotice => 'شما یک آزمایشگر بتا برای این برنامه هستید. هنوز عمومی نیست. پس از تأیید عمومی می‌شود.';
 
   @override
-  String get appUnderReviewOwner =>
-      'برنامه شما در حال بررسی است و تنها برای شما قابل مشاهده است. پس از تأیید عمومی می‌شود.';
+  String get appUnderReviewOwner => 'برنامه شما در حال بررسی است و تنها برای شما قابل مشاهده است. پس از تأیید عمومی می‌شود.';
 
   @override
-  String get appRejectedNotice =>
-      'برنامه شما رد شده است. لطفا جزئیات برنامه را به‌روز کنید و برای بررسی مجدد ارسال کنید.';
+  String get appRejectedNotice => 'برنامه شما رد شده است. لطفا جزئیات برنامه را به‌روز کنید و برای بررسی مجدد ارسال کنید.';
 
   @override
   String get setupSteps => 'مراحل راه‌اندازی';
@@ -2985,8 +2934,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get descriptionLabel => 'توضیح';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'برنامه فوق‌العاده من یک برنامه عالی است که کارهای فوق‌العاده انجام می‌دهد. این بهترین برنامه است!';
+  String get appDescriptionPlaceholder => 'برنامه فوق‌العاده من یک برنامه عالی است که کارهای فوق‌العاده انجام می‌دهد. این بهترین برنامه است!';
 
   @override
   String get pleaseProvideValidDescription => 'لطفا توضیح معتبری بدهید';
@@ -3138,8 +3086,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get microphonePermissionRequired => 'برای تماس، اجازه میکروفون لازم است';
 
   @override
-  String get microphonePermissionDenied =>
-      'اجازه میکروفون رد شد. لطفا اجازه را در تنظیمات سیستم > حریم خصوصی و امنیت > میکروفون بدهید.';
+  String get microphonePermissionDenied => 'اجازه میکروفون رد شد. لطفا اجازه را در تنظیمات سیستم > حریم خصوصی و امنیت > میکروفون بدهید.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3298,8 +3245,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get createMemory => 'ایجاد یادآوری';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'آیا مطمئن هستید که می‌خواهید این یادآوری را حذف کنید؟ این عمل قابل بازگشت نیست.';
+  String get deleteMemoryConfirmation => 'آیا مطمئن هستید که می‌خواهید این یادآوری را حذف کنید؟ این عمل قابل بازگشت نیست.';
 
   @override
   String get makePrivate => 'خصوصی کردن';
@@ -3373,8 +3319,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get whatWeCollect => 'آنچه ما جمع‌آوری می‌کنیم';
 
   @override
-  String get dataCollectionMessage =>
-      'با ادامه، گفتگوهای شما، ضبط‌ها و اطلاعات شخصی به‌طور ایمن در سرورهای ما ذخیره می‌شوند تا بینش‌های مبتنی بر هوش مصنوعی ارائه دهند و تمام ویژگی‌های برنامه را فعال کنند.';
+  String get dataCollectionMessage => 'با ادامه، گفتگوهای شما، ضبط‌ها و اطلاعات شخصی به‌طور ایمن در سرورهای ما ذخیره می‌شوند تا بینش‌های مبتنی بر هوش مصنوعی ارائه دهند و تمام ویژگی‌های برنامه را فعال کنند.';
 
   @override
   String get dataProtection => 'محافظت از داده‌ها';
@@ -3407,8 +3352,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'نام باید حداقل ۲ کاراکتر باشد';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'به ما بگویید چگونه می‌خواهید صدا زده شوید. این به شخصی‌سازی تجربه Omi شما کمک می‌کند.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'به ما بگویید چگونه می‌خواهید صدا زده شوید. این به شخصی‌سازی تجربه Omi شما کمک می‌کند.';
 
   @override
   String charactersCount(int count) {
@@ -3434,8 +3378,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'ثبت صوت سیستم از جلسات';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi برای ثبت صوت سیستم از جلسات مبتنی بر مرورگر شما به مجوز ضبط صفحه نیاز دارد.';
+  String get screenRecordingDescription => 'Omi برای ثبت صوت سیستم از جلسات مبتنی بر مرورگر شما به مجوز ضبط صفحه نیاز دارد.';
 
   @override
   String get accessibility => 'دسترسی‌پذیری';
@@ -3444,8 +3387,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'تشخیص جلسات مبتنی بر مرورگر';
 
   @override
-  String get accessibilityDescription =>
-      'Omi برای تشخیص زمانی که به جلسات Zoom، Meet یا Teams در مرورگر خود پیوند می‌زنید به مجوز دسترسی‌پذیری نیاز دارد.';
+  String get accessibilityDescription => 'Omi برای تشخیص زمانی که به جلسات Zoom، Meet یا Teams در مرورگر خود پیوند می‌زنید به مجوز دسترسی‌پذیری نیاز دارد.';
 
   @override
   String get pleaseWait => 'لطفاً منتظر بمانید...';
@@ -3514,12 +3456,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get exportAllConversationsToJson => 'تمام گفتگوهای خود را به یک فایل JSON صادر کنید.';
 
   @override
-  String get conversationsExportStarted =>
-      'صادرات گفتگوها آغاز شد. این ممکن است چند ثانیه طول بکشد، لطفاً منتظر بمانید.';
+  String get conversationsExportStarted => 'صادرات گفتگوها آغاز شد. این ممکن است چند ثانیه طول بکشد، لطفاً منتظر بمانید.';
 
   @override
-  String get mcpDescription =>
-      'برای اتصال Omi به برنامه‌های دیگر برای خواندن، جستجو و مدیریت خاطرات و گفتگوهای خود. یک کلید ایجاد کنید تا شروع کنید.';
+  String get mcpDescription => 'برای اتصال Omi به برنامه‌های دیگر برای خواندن، جستجو و مدیریت خاطرات و گفتگوهای خود. یک کلید ایجاد کنید تا شروع کنید.';
 
   @override
   String get apiKeys => 'کلیدهای API';
@@ -3627,8 +3567,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get letOmiChooseAutomatically => 'اجازه دهید Omi بهترین برنامه را به طور خودکار انتخاب کند';
 
   @override
-  String get deleteConversationConfirmation =>
-      'آیا مطمئنید که می‌خواهید این گفتگو را حذف کنید؟ این عمل قابل بازگشت نیست.';
+  String get deleteConversationConfirmation => 'آیا مطمئنید که می‌خواهید این گفتگو را حذف کنید؟ این عمل قابل بازگشت نیست.';
 
   @override
   String get conversationDeleted => 'گفتگو حذف شد';
@@ -3676,8 +3615,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get preparingSystemAudioCapture => 'در حال آماده‌سازی ثبت صوت سیستم';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'روی دکمه کلیک کنید تا صوت را برای رونوشت‌های زنده، بینش‌های هوش مصنوعی و ذخیره‌سازی خودکار ثبت کنید.';
+  String get clickTheButtonToCaptureAudio => 'روی دکمه کلیک کنید تا صوت را برای رونوشت‌های زنده، بینش‌های هوش مصنوعی و ذخیره‌سازی خودکار ثبت کنید.';
 
   @override
   String get reconnecting => 'در حال اتصال مجدد...';
@@ -3904,8 +3842,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'نمودار دانش را حذف کنید؟';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'این تمام داده‌های نمودار دانش مشتق‌شده را حذف می‌کند. خاطرات اصلی شما ایمن می‌مانند.';
+  String get deleteKnowledgeGraphWarning => 'این تمام داده‌های نمودار دانش مشتق‌شده را حذف می‌کند. خاطرات اصلی شما ایمن می‌مانند.';
 
   @override
   String get connectOmiWithAI => 'Omi را با دستیاران هوش مصنوعی متصل کنید';
@@ -3962,8 +3899,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get updateAppQuestion => 'برنامه را به‌روز کنید؟';
 
   @override
-  String get updateAppConfirmation =>
-      'آیا مطمئنید که می‌خواهید برنامه خود را به‌روز کنید؟ تغییرات زمانی‌که توسط تیم ما بررسی شوند منعکس می‌شوند.';
+  String get updateAppConfirmation => 'آیا مطمئنید که می‌خواهید برنامه خود را به‌روز کنید؟ تغییرات زمانی‌که توسط تیم ما بررسی شوند منعکس می‌شوند.';
 
   @override
   String get updateApp => 'به‌روزرسانی برنامه';
@@ -4029,8 +3965,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'اشتراک را لغو کنید؟';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'آیا مطمئنید که می‌خواهید اشتراک خود را لغو کنید؟ تا پایان دوره صورت‌حساب جاری دسترسی خواهید داشت.';
+  String get cancelSubscriptionConfirmation => 'آیا مطمئنید که می‌خواهید اشتراک خود را لغو کنید؟ تا پایان دوره صورت‌حساب جاری دسترسی خواهید داشت.';
 
   @override
   String get cancelSubscriptionButton => 'لغو اشتراک';
@@ -4039,16 +3974,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get cancelling => 'در حال لغو...';
 
   @override
-  String get betaTesterMessage =>
-      'شما یک آزمایشگر بتا برای این برنامه هستید. هنوز عمومی نیست. پس از تایید عمومی خواهد شد.';
+  String get betaTesterMessage => 'شما یک آزمایشگر بتا برای این برنامه هستید. هنوز عمومی نیست. پس از تایید عمومی خواهد شد.';
 
   @override
-  String get appUnderReviewMessage =>
-      'برنامه شما در حال بررسی است و فقط برای شما قابل مشاهده است. پس از تایید عمومی خواهد شد.';
+  String get appUnderReviewMessage => 'برنامه شما در حال بررسی است و فقط برای شما قابل مشاهده است. پس از تایید عمومی خواهد شد.';
 
   @override
-  String get appRejectedMessage =>
-      'برنامه شما رد شده است. لطفاً جزئیات برنامه را به‌روز کنید و دوباره برای بررسی تقدیم کنید.';
+  String get appRejectedMessage => 'برنامه شما رد شده است. لطفاً جزئیات برنامه را به‌روز کنید و دوباره برای بررسی تقدیم کنید.';
 
   @override
   String get invalidIntegrationUrl => 'URL یکپارچگی نامعتبر';
@@ -4102,8 +4034,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get issueActivatingApp => 'مشکلی در فعال‌سازی این برنامه وجود داشت. لطفاً دوباره تلاش کنید.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'این برنامه به داده‌های شما دسترسی خواهد داشت. Omi AI برای نحوه استفاده، تغییر یا حذف داده‌های شما توسط این برنامه مسئول نیست';
+  String get dataAccessNoticeDescription => 'این برنامه به داده‌های شما دسترسی خواهد داشت. Omi AI برای نحوه استفاده، تغییر یا حذف داده‌های شما توسط این برنامه مسئول نیست';
 
   @override
   String get copyUrl => 'کپی URL';
@@ -4191,8 +4122,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get omiApiKeys => 'کلیدهای API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'کلیدهای API برای احراز هویت زمانی که برنامه شما با سرور OMI ارتباط برقرار می‌کند استفاده می‌شوند. آنها به برنامه شما اجازه می‌دهند خاطرات ایجاد کنید و سایر سرویس‌های OMI را به طور ایمن دسترسی کنید.';
+  String get apiKeysDescription => 'کلیدهای API برای احراز هویت زمانی که برنامه شما با سرور OMI ارتباط برقرار می‌کند استفاده می‌شوند. آنها به برنامه شما اجازه می‌دهند خاطرات ایجاد کنید و سایر سرویس‌های OMI را به طور ایمن دسترسی کنید.';
 
   @override
   String get aboutOmiApiKeys => 'درباره کلیدهای API Omi';
@@ -4216,8 +4146,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get revokeApiKeyQuestion => 'کلید API را لغو کنید؟';
 
   @override
-  String get revokeApiKeyWarning =>
-      'این عمل قابل بازگشت نیست. هر برنامه‌ای که از این کلید استفاده می‌کند دیگر نخواهد توانست API را دسترسی کند.';
+  String get revokeApiKeyWarning => 'این عمل قابل بازگشت نیست. هر برنامه‌ای که از این کلید استفاده می‌کند دیگر نخواهد توانست API را دسترسی کند.';
 
   @override
   String get revoke => 'لغو';
@@ -4306,8 +4235,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get keyCreated => 'کلید ایجادشده';
 
   @override
-  String get keyCreatedMessage =>
-      'کلید جدید شما ایجاد شده است. لطفاً آن را اکنون کپی کنید. شما دیگر نخواهید توانست آن را ببینید.';
+  String get keyCreatedMessage => 'کلید جدید شما ایجاد شده است. لطفاً آن را اکنون کپی کنید. شما دیگر نخواهید توانست آن را ببینید.';
 
   @override
   String get keyWord => 'کلید';
@@ -4316,8 +4244,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get externalAppAccess => 'دسترسی برنامه خارجی';
 
   @override
-  String get externalAppAccessDescription =>
-      'برنامه‌های نصب‌شده زیر دارای یکپارچگی‌های خارجی هستند و می‌توانند داده‌های شما، مانند گفتگوها و خاطرات را دسترسی کنند.';
+  String get externalAppAccessDescription => 'برنامه‌های نصب‌شده زیر دارای یکپارچگی‌های خارجی هستند و می‌توانند داده‌های شما، مانند گفتگوها و خاطرات را دسترسی کنند.';
 
   @override
   String get noExternalAppsHaveAccess => 'هیچ برنامه خارجی به داده‌های شما دسترسی ندارد.';
@@ -4326,8 +4253,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get maximumSecurityE2ee => 'حداکثر امنیت (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'رمزگذاری از سر به سر استاندارد طلایی برای حریم‌خصوصی است. هنگامی که فعال باشد، داده‌های شما قبل از ارسال به سرورهای ما در دستگاه شما رمزگذاری می‌شوند. این بدان معناست که هیچ کس، حتی Omi، نمی‌تواند محتوای شما را دسترسی کند.';
+  String get e2eeDescription => 'رمزگذاری از سر به سر استاندارد طلایی برای حریم‌خصوصی است. هنگامی که فعال باشد، داده‌های شما قبل از ارسال به سرورهای ما در دستگاه شما رمزگذاری می‌شوند. این بدان معناست که هیچ کس، حتی Omi، نمی‌تواند محتوای شما را دسترسی کند.';
 
   @override
   String get importantTradeoffs => 'معامله‌های مهم:';
@@ -4342,8 +4268,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get featureComingSoon => 'این ویژگی به زودی می‌آید!';
 
   @override
-  String get migrationInProgressMessage =>
-      'مهاجرت در حال انجام است. تا زمانی که تکمیل نشود نمی‌توانید سطح حفاظت را تغییر دهید.';
+  String get migrationInProgressMessage => 'مهاجرت در حال انجام است. تا زمانی که تکمیل نشود نمی‌توانید سطح حفاظت را تغییر دهید.';
 
   @override
   String get migrationFailed => 'مهاجرت ناموفق';
@@ -4362,15 +4287,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get secureEncryption => 'رمزگذاری ایمن';
 
   @override
-  String get secureEncryptionDescription =>
-      'داده‌های شما با کلیدی منحصر به فرد برای شما در سرورهای ما، میزبان‌شده در Google Cloud، رمزگذاری می‌شوند. این بدان معناست که محتوای خام شما برای هیچ کس، از جمله کارکنان Omi یا Google، مستقیماً از پایگاه داده قابل دسترسی نیست.';
+  String get secureEncryptionDescription => 'داده‌های شما با کلیدی منحصر به فرد برای شما در سرورهای ما، میزبان‌شده در Google Cloud، رمزگذاری می‌شوند. این بدان معناست که محتوای خام شما برای هیچ کس، از جمله کارکنان Omi یا Google، مستقیماً از پایگاه داده قابل دسترسی نیست.';
 
   @override
   String get endToEndEncryption => 'رمزگذاری از سر به سر';
 
   @override
-  String get e2eeCardDescription =>
-      'برای حداکثر امنیت فعال کنید جایی که فقط شما می‌توانید داده‌های خود را دسترسی کنید. برای اطلاعات بیشتر لمس کنید.';
+  String get e2eeCardDescription => 'برای حداکثر امنیت فعال کنید جایی که فقط شما می‌توانید داده‌های خود را دسترسی کنید. برای اطلاعات بیشتر لمس کنید.';
 
   @override
   String get dataAlwaysEncrypted => 'صرف‌نظر از سطح، داده‌های شما همیشه در حالت سکون و در حین انتقال رمزگذاری شده است.';
@@ -4438,12 +4361,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get trainingDataProgram => 'برنامه داده‌های آموزشی';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Omi Unlimited را برای رایگان دریافت کنید با مشارکت داده‌های خود برای آموزش مدل‌های هوش مصنوعی.';
+  String get getOmiUnlimitedFree => 'Omi Unlimited را برای رایگان دریافت کنید با مشارکت داده‌های خود برای آموزش مدل‌های هوش مصنوعی.';
 
   @override
-  String get trainingDataBullets =>
-      '• داده‌های شما به بهبود مدل‌های هوش مصنوعی کمک می‌کند\n• فقط داده‌های غیر‌حساس اشتراک‌گذاری می‌شوند\n• فرآیند کاملاً شفاف';
+  String get trainingDataBullets => '• داده‌های شما به بهبود مدل‌های هوش مصنوعی کمک می‌کند\n• فقط داده‌های غیر‌حساس اشتراک‌گذاری می‌شوند\n• فرآیند کاملاً شفاف';
 
   @override
   String get learnMoreAtOmiTraining => 'اطلاعات بیشتر را در omi.me/training بیابید';
@@ -4603,8 +4524,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'حریم خصوصی شما برای ما مهم است';
 
   @override
-  String get privacyIntroText =>
-      'در Omi، ما حریم خصوصی شما را بسیار جدی می‌گیریم. ما می‌خواهیم در مورد داده‌هایی که جمع‌آوری می‌کنیم و نحوه استفاده از آن برای بهبود محصول خود برای شما شفاف باشیم. در اینجا آنچه باید بدانید:';
+  String get privacyIntroText => 'در Omi، ما حریم خصوصی شما را بسیار جدی می‌گیریم. ما می‌خواهیم در مورد داده‌هایی که جمع‌آوری می‌کنیم و نحوه استفاده از آن برای بهبود محصول خود برای شما شفاف باشیم. در اینجا آنچه باید بدانید:';
 
   @override
   String get whatWeTrack => 'آنچه ما ردیابی می‌کنیم';
@@ -4619,12 +4539,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get ourCommitment => 'تعهد ما';
 
   @override
-  String get commitmentText =>
-      'ما متعهد هستیم داده‌هایی که جمع‌آوری می‌کنیم را تنها برای بهتر کردن Omi برای شما استفاده کنیم. حریم خصوصی و اعتماد شما برای ما بسیار اهمیت دارند.';
+  String get commitmentText => 'ما متعهد هستیم داده‌هایی که جمع‌آوری می‌کنیم را تنها برای بهتر کردن Omi برای شما استفاده کنیم. حریم خصوصی و اعتماد شما برای ما بسیار اهمیت دارند.';
 
   @override
-  String get thankYouText =>
-      'از اینکه کاربر ارزشمندی از Omi هستید تشکر می‌کنیم. اگر سؤالات یا نگرانی‌ای دارید، لطفا با ما تماس بگیرید team@basedhardware.com.';
+  String get thankYouText => 'از اینکه کاربر ارزشمندی از Omi هستید تشکر می‌کنیم. اگر سؤالات یا نگرانی‌ای دارید، لطفا با ما تماس بگیرید team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'تنظیمات نقطه اتصال Wi-Fi';
@@ -4633,8 +4551,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get enterHotspotCredentials => 'اطلاعات اعتباری نقطه اتصال تلفن خود را وارد کنید';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'هم‌راه‌سازی Wi-Fi از تلفن شما به‌عنوان نقطه اتصال استفاده می‌کند. نام نقطه اتصال و رمز عبور خود را در تنظیمات > Personal Hotspot بیابید.';
+  String get wifiSyncUsesHotspot => 'هم‌راه‌سازی Wi-Fi از تلفن شما به‌عنوان نقطه اتصال استفاده می‌کند. نام نقطه اتصال و رمز عبور خود را در تنظیمات > Personal Hotspot بیابید.';
 
   @override
   String get hotspotNameSsid => 'نام نقطه اتصال (SSID)';
@@ -4669,8 +4586,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'نتوانستیم خلاصه را تولید کنیم. مطمئن شوید که برای آن روز مکالمات دارید.';
+  String get failedToGenerateSummaryCheckConversations => 'نتوانستیم خلاصه را تولید کنیم. مطمئن شوید که برای آن روز مکالمات دارید.';
 
   @override
   String get summaryNotFound => 'خلاصه یافت نشد';
@@ -4700,8 +4616,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'صادرات شروع شد. این ممکن است چند ثانیه طول بکشد...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'این تمام داده‌های نمودار دانش مشتق‌شده (گره‌ها و اتصالات) را حذف خواهد کرد. یادآوری‌های اصلی شما ایمن خواهند ماند. نمودار در طول زمان یا بعد از درخواست بعدی بازسازی خواهد شد.';
+  String get knowledgeGraphDeleteDescription => 'این تمام داده‌های نمودار دانش مشتق‌شده (گره‌ها و اتصالات) را حذف خواهد کرد. یادآوری‌های اصلی شما ایمن خواهند ماند. نمودار در طول زمان یا بعد از درخواست بعدی بازسازی خواهد شد.';
 
   @override
   String get configureDailySummaryDigest => 'تنظیم خلاصه اقدامات روزانه خود';
@@ -4771,8 +4686,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'تمام مکالمات Limitless حذف شود؟';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'این تمام مکالمات واردشده از Limitless را به‌طور دائم حذف خواهد کرد. این عمل برگشت‌پذیر نیست.';
+  String get deleteAllLimitlessWarning => 'این تمام مکالمات واردشده از Limitless را به‌طور دائم حذف خواهد کرد. این عمل برگشت‌پذیر نیست.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4828,8 +4742,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get howItWorksTitle => 'چگونه کار می‌کند؟';
 
   @override
-  String get howPeopleWorks =>
-      'بعد از اینکه یک فرد ایجاد شود، می‌توانید به رونویس مکالمه بروید و بخش‌های مرتبط با آن‌ها را تعیین کنید، به این ترتیب Omi می‌تواند صوت آن‌ها را نیز تشخیص دهد!';
+  String get howPeopleWorks => 'بعد از اینکه یک فرد ایجاد شود، می‌توانید به رونویس مکالمه بروید و بخش‌های مرتبط با آن‌ها را تعیین کنید، به این ترتیب Omi می‌تواند صوت آن‌ها را نیز تشخیص دهد!';
 
   @override
   String get tapToDelete => 'برای حذف ضربه بزنید';
@@ -4855,8 +4768,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get privacyNotice => 'اطلاعیه حریم خصوصی';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'ضبط‌ها ممکن است صدای دیگران را ضبط کنند. قبل از فعال‌سازی مطمئن شوید که رضایت تمام شرکت‌کنندگان را دارید.';
+  String get recordingsMayCaptureOthers => 'ضبط‌ها ممکن است صدای دیگران را ضبط کنند. قبل از فعال‌سازی مطمئن شوید که رضایت تمام شرکت‌کنندگان را دارید.';
 
   @override
   String get enable => 'فعال‌سازی';
@@ -4868,8 +4780,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get on => 'روشن';
 
   @override
-  String get storeAudioDescription =>
-      'تمام ضبط‌های صوتی را به‌طور محلی در تلفن خود ذخیره کنید. هنگام غیرفعال‌سازی، تنها آپلود‌های ناموفق ذخیره می‌شود تا فضای ذخیره‌سازی صرفه‌جویی شود.';
+  String get storeAudioDescription => 'تمام ضبط‌های صوتی را به‌طور محلی در تلفن خود ذخیره کنید. هنگام غیرفعال‌سازی، تنها آپلود‌های ناموفق ذخیره می‌شود تا فضای ذخیره‌سازی صرفه‌جویی شود.';
 
   @override
   String get enableLocalStorage => 'فعال‌سازی ذخیره‌سازی محلی';
@@ -4890,8 +4801,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get cloudStorageDialogMessage => 'ضبط‌های بلادرنگ شما در ذخیره‌سازی ابری خصوصی ذخیره خواهند شد.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'ضبط‌های بلادرنگ خود را در ذخیره‌سازی ابری خصوصی ذخیره کنید. صوت به‌طور بلادرنگ ضبط و به‌طور ایمن ذخیره می‌شود.';
+  String get storeAudioCloudDescription => 'ضبط‌های بلادرنگ خود را در ذخیره‌سازی ابری خصوصی ذخیره کنید. صوت به‌طور بلادرنگ ضبط و به‌طور ایمن ذخیره می‌شود.';
 
   @override
   String get downloadingFirmware => 'بارگیری نرم‌افزار';
@@ -4900,8 +4810,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get installingFirmware => 'نصب نرم‌افزار';
 
   @override
-  String get firmwareUpdateWarning =>
-      'برنامه را بسته نکنید یا دستگاه را خاموش نکنید. این می‌تواند دستگاه شما را خراب کند.';
+  String get firmwareUpdateWarning => 'برنامه را بسته نکنید یا دستگاه را خاموش نکنید. این می‌تواند دستگاه شما را خراب کند.';
 
   @override
   String get firmwareUpdated => 'نرم‌افزار به‌روزرسانی شد';
@@ -4945,8 +4854,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get payments => 'پرداخت‌ها';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'یک روش پرداخت در زیر متصل کنید تا برای برنامه‌های خود پرداخت‌های خود را دریافت کنید.';
+  String get connectPaymentMethodInfo => 'یک روش پرداخت در زیر متصل کنید تا برای برنامه‌های خود پرداخت‌های خود را دریافت کنید.';
 
   @override
   String get selectedPaymentMethod => 'روش پرداخت انتخاب‌شده';
@@ -5000,8 +4908,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get connectingYourStripeAccount => 'اتصال حساب Stripe شما';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'لطفا فرایند راه‌اندازی Stripe را در مرورگر خود تکمیل کنید. این صفحه به‌طور خودکار به‌روزرسانی خواهد شد.';
+  String get stripeOnboardingInstructions => 'لطفا فرایند راه‌اندازی Stripe را در مرورگر خود تکمیل کنید. این صفحه به‌طور خودکار به‌روزرسانی خواهد شد.';
 
   @override
   String get failedTryAgain => 'ناموفق؟ دوباره تلاش کنید';
@@ -5013,8 +4920,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get successfullyConnected => 'با موفقیت متصل!';
 
   @override
-  String get stripeReadyForPayments =>
-      'حساب Stripe شما اکنون برای دریافت پرداخت آماده است. می‌توانید بلافاصله از فروش برنامه شود درآمد کسب کنید.';
+  String get stripeReadyForPayments => 'حساب Stripe شما اکنون برای دریافت پرداخت آماده است. می‌توانید بلافاصله از فروش برنامه شود درآمد کسب کنید.';
 
   @override
   String get updateStripeDetails => 'به‌روزرسانی جزئیات Stripe';
@@ -5032,8 +4938,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get updatePayPalAccountDetails => 'به‌روزرسانی جزئیات حساب PayPal خود';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'حساب PayPal خود را متصل کنید تا برای برنامه‌های خود پرداخت‌های خود را دریافت کنید';
+  String get connectPayPalToReceivePayments => 'حساب PayPal خود را متصل کنید تا برای برنامه‌های خود پرداخت‌های خود را دریافت کنید';
 
   @override
   String get paypalEmail => 'رایانامه PayPal';
@@ -5042,8 +4947,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get paypalMeLink => 'پیوند PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'اگر Stripe در کشور شما موجود است، ما بسیار توصیه می‌کنیم که آن را برای پرداخت‌های سریع‌تر و آسان‌تر استفاده کنید.';
+  String get stripeRecommendation => 'اگر Stripe در کشور شما موجود است، ما بسیار توصیه می‌کنیم که آن را برای پرداخت‌های سریع‌تر و آسان‌تر استفاده کنید.';
 
   @override
   String get updatePayPalDetails => 'به‌روزرسانی جزئیات PayPal';
@@ -5095,12 +4999,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'نمونه صوتی اضافی حذف‌شد';
 
   @override
-  String get consentDataMessage =>
-      'با ادامه دادن، مکالمات، ضبط‌ها و اطلاعات شخصی شما به طور ایمن در سرورهای ما ذخیره می‌شود. ضبط‌های صوتی و رونوشت‌های شما توسط سرویس‌های هوش مصنوعی شخص ثالث (از جمله Deepgram برای رونویسی و OpenAI برای تحلیل) پردازش می‌شوند تا بینش‌های مبتنی بر هوش مصنوعی را به شما ارائه دهند و تمام ویژگی‌های برنامه را فعال کنند.';
+  String get consentDataMessage => 'با ادامه دادن، مکالمات، ضبط‌ها و اطلاعات شخصی شما به طور ایمن در سرورهای ما ذخیره می‌شود. ضبط‌های صوتی و رونوشت‌های شما توسط سرویس‌های هوش مصنوعی شخص ثالث (از جمله Deepgram برای رونویسی و OpenAI برای تحلیل) پردازش می‌شوند تا بینش‌های مبتنی بر هوش مصنوعی را به شما ارائه دهند و تمام ویژگی‌های برنامه را فعال کنند.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'وظایف از مکالمات شما اینجا ظاهر خواهند شد.\\n+ را ضربه بزنید تا یکی به‌صورت دستی ایجاد کنید.';
+  String get tasksEmptyStateMessage => 'وظایف از مکالمات شما اینجا ظاهر خواهند شد.\\n+ را ضربه بزنید تا یکی به‌صورت دستی ایجاد کنید.';
 
   @override
   String get clearChatAction => 'پاک‌کردن چت';
@@ -5136,15 +5038,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get installOmiOnAppleWatch => 'نصب Omi روی\\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'برای استفاده از Apple Watch با Omi، شما باید ابتدا برنامه Omi را روی ساعت نصب کنید.';
+  String get installOmiOnAppleWatchDescription => 'برای استفاده از Apple Watch با Omi، شما باید ابتدا برنامه Omi را روی ساعت نصب کنید.';
 
   @override
   String get openOmiOnAppleWatch => 'باز کردن Omi روی\\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'برنامه Omi روی Apple Watch نصب‌شده است. آن را باز کنید و Start را ضربه بزنید تا شروع کنید.';
+  String get openOmiOnAppleWatchDescription => 'برنامه Omi روی Apple Watch نصب‌شده است. آن را باز کنید و Start را ضربه بزنید تا شروع کنید.';
 
   @override
   String get openWatchApp => 'باز کردن برنامه ساعت';
@@ -5153,15 +5053,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'نصب و باز کردم برنامه را';
 
   @override
-  String get unableToOpenWatchApp =>
-      'نتوانستیم برنامه Apple Watch را باز کنیم. لطفا برنامه Watch را روی Apple Watch خود به‌صورت دستی باز کنید و Omi را از بخش \"برنامه‌های موجود\" نصب کنید.';
+  String get unableToOpenWatchApp => 'نتوانستیم برنامه Apple Watch را باز کنیم. لطفا برنامه Watch را روی Apple Watch خود به‌صورت دستی باز کنید و Omi را از بخش \"برنامه‌های موجود\" نصب کنید.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch با موفقیت متصل شد!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch هنوز در دسترس نیست. لطفا مطمئن شوید که برنامه Omi روی ساعت شما باز است.';
+  String get appleWatchNotReachable => 'Apple Watch هنوز در دسترس نیست. لطفا مطمئن شوید که برنامه Omi روی ساعت شما باز است.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5178,8 +5076,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get finishedConversation => 'مکالمه تکمیل شد؟';
 
   @override
-  String get stopRecordingConfirmation =>
-      'آیا مطمئن هستید که می‌خواهید ضبط را متوقف کنید و مکالمه را اکنون خلاصه کنید؟';
+  String get stopRecordingConfirmation => 'آیا مطمئن هستید که می‌خواهید ضبط را متوقف کنید و مکالمه را اکنون خلاصه کنید؟';
 
   @override
   String get conversationEndsManually => 'مکالمه تنها به‌صورت دستی پایان خواهد یافت.';
@@ -5590,8 +5487,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get multipleSpeakersDetected => 'چند گوینده تشخیص‌داده‌شد';
 
   @override
-  String get multipleSpeakersDescription =>
-      'به نظر می‌رسد که در ضبط چند گوینده وجود دارند. لطفا مطمئن شوید که در مکانی ساکت هستید و دوباره تلاش کنید.';
+  String get multipleSpeakersDescription => 'به نظر می‌رسد که در ضبط چند گوینده وجود دارند. لطفا مطمئن شوید که در مکانی ساکت هستید و دوباره تلاش کنید.';
 
   @override
   String get invalidRecordingDetected => 'ضبط نامعتبر تشخیص‌داده‌شد';
@@ -5609,8 +5505,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get howToTakeGoodSample => 'چگونه نمونه خوبی بگیریم؟';
 
   @override
-  String get goodSampleInstructions =>
-      '1. مطمئن شوید که در مکانی آرام قرار دارید.\n2. واضح و طبیعی صحبت کنید.\n3. مطمئن شوید که دستگاه شما در موضع طبیعی خود قرار دارد، روی گردن شما.\n\nپس از ایجاد، می توانید آن را بهبود بخشید یا دوباره انجام دهید.';
+  String get goodSampleInstructions => '1. مطمئن شوید که در مکانی آرام قرار دارید.\n2. واضح و طبیعی صحبت کنید.\n3. مطمئن شوید که دستگاه شما در موضع طبیعی خود قرار دارد، روی گردن شما.\n\nپس از ایجاد، می توانید آن را بهبود بخشید یا دوباره انجام دهید.';
 
   @override
   String get noDeviceConnectedUseMic => 'هیچ دستگاهی متصل نشده است. از میکروفن تلفن استفاده خواهد شد.';
@@ -5673,8 +5568,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get howItWorks => 'چگونه کار می کند';
 
   @override
-  String get dailyScoreExplanation =>
-      'امتیاز روزانه شما بر اساس تکمیل تکالیف است. تکالیف خود را تکمیل کنید تا امتیاز خود را بهبود بخشید!';
+  String get dailyScoreExplanation => 'امتیاز روزانه شما بر اساس تکمیل تکالیف است. تکالیف خود را تکمیل کنید تا امتیاز خود را بهبود بخشید!';
 
   @override
   String get notificationFrequencyDescription => 'کنترل کنید که Omi چند بار اعلانات پیشفعال و یادآوری ارسال می کند.';
@@ -5770,8 +5664,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get selectApp => 'انتخاب برنامه';
 
   @override
-  String get noChatAppsEnabled =>
-      'هیچ برنامه چت فعال نشده است.\nبرای افزودن برنامه ها \"برنامه های فعال کن\" را ضربه بزنید.';
+  String get noChatAppsEnabled => 'هیچ برنامه چت فعال نشده است.\nبرای افزودن برنامه ها \"برنامه های فعال کن\" را ضربه بزنید.';
 
   @override
   String get disable => 'غیرفعال کن';
@@ -5851,8 +5744,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get wifiEnableFailed => 'فعال کردن WiFi در دستگاه ناموفق بود. لطفاً دوباره تلاش کنید.';
 
   @override
-  String get deviceNoFastTransfer =>
-      'دستگاه شما از Fast Transfer پشتیبانی نمی کند. به جای آن از Bluetooth استفاده کنید.';
+  String get deviceNoFastTransfer => 'دستگاه شما از Fast Transfer پشتیبانی نمی کند. به جای آن از Bluetooth استفاده کنید.';
 
   @override
   String get enableHotspotMessage => 'لطفاً hotspot تلفن خود را فعال کنید و دوباره تلاش کنید.';
@@ -5924,8 +5816,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get recordings => 'ضبط ها';
 
   @override
-  String get enableRemindersAccess =>
-      'لطفاً دسترسی Reminders را در تنظیمات فعال کنید تا از Apple Reminders استفاده کنید';
+  String get enableRemindersAccess => 'لطفاً دسترسی Reminders را در تنظیمات فعال کنید تا از Apple Reminders استفاده کنید';
 
   @override
   String todayAtTime(String time) {
@@ -5980,8 +5871,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get webhookUrlNotSet => 'URL Webhook تنظیم نشده است';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'لطفاً برای استفاده از این ویژگی URL webhook را در تنظیمات توسعه دهنده تنظیم کنید.';
+  String get setWebhookUrlInSettings => 'لطفاً برای استفاده از این ویژگی URL webhook را در تنظیمات توسعه دهنده تنظیم کنید.';
 
   @override
   String get sendWebUrl => 'ارسال URL وب';
@@ -6061,8 +5951,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get viewUsage => 'مشاهده استفاده';
 
   @override
-  String get localProcessingInfo =>
-      'صوت به صورت محلی پردازش می شود. بدون اینترنت کار می کند، خصوصی تر است، اما باتری بیشتری مصرف می کند.';
+  String get localProcessingInfo => 'صوت به صورت محلی پردازش می شود. بدون اینترنت کار می کند، خصوصی تر است، اما باتری بیشتری مصرف می کند.';
 
   @override
   String get model => 'مدل';
@@ -6071,8 +5960,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get performanceWarning => 'هشدار عملکرد';
 
   @override
-  String get largeModelWarning =>
-      'این مدل بزرگ است و ممکن است برنامه را سقوط دهد یا بسیار آهسته اجرا شود.\n\n\"small\" یا \"base\" توصیه می شود.';
+  String get largeModelWarning => 'این مدل بزرگ است و ممکن است برنامه را سقوط دهد یا بسیار آهسته اجرا شود.\n\n\"small\" یا \"base\" توصیه می شود.';
 
   @override
   String get usingNativeIosSpeech => 'استفاده از شناخت گفتار بومی iOS';
@@ -6138,8 +6026,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get premiumMinutesMonth => '1,200 دقیقه premium/ماه. برگه On-Device رونویسی رایگان نامحدود را ارائه می دهد.';
 
   @override
-  String get audioProcessedLocally =>
-      'صوت به صورت محلی پردازش می شود. بدون اینترنت کار می کند، خصوصی تر است، اما باتری بیشتری مصرف می کند.';
+  String get audioProcessedLocally => 'صوت به صورت محلی پردازش می شود. بدون اینترنت کار می کند، خصوصی تر است، اما باتری بیشتری مصرف می کند.';
 
   @override
   String get languageLabel => 'زبان';
@@ -6148,8 +6035,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get modelLabel => 'مدل';
 
   @override
-  String get modelTooLargeWarning =>
-      'این مدل بزرگ است و ممکن است برنامه را سقوط دهد یا بسیار آهسته اجرا شود.\n\n\"small\" یا \"base\" توصیه می شود.';
+  String get modelTooLargeWarning => 'این مدل بزرگ است و ممکن است برنامه را سقوط دهد یا بسیار آهسته اجرا شود.\n\n\"small\" یا \"base\" توصیه می شود.';
 
   @override
   String get nativeEngineNoDownload => 'موتور گفتار بومی دستگاه شما استفاده خواهد شد. بدون دانلود مدل مورد نیاز.';
@@ -6188,8 +6074,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'رونویسی زنده تعبیه شده Omi برای مکالمات بلادرنگ با شناسایی و دیاریزاسیون گوینده خودکار بهینه شده است.';
+  String get omiTranscriptionOptimized => 'رونویسی زنده تعبیه شده Omi برای مکالمات بلادرنگ با شناسایی و دیاریزاسیون گوینده خودکار بهینه شده است.';
 
   @override
   String get reset => 'بازنشانی';
@@ -6409,8 +6294,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'ساخت نمودار دانش شما از خاطرات...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'نمودار دانش شما به طور خودکار با ایجاد خاطرات جدید ساخته خواهد شد.';
+  String get knowledgeGraphWillBuildAutomatically => 'نمودار دانش شما به طور خودکار با ایجاد خاطرات جدید ساخته خواهد شد.';
 
   @override
   String get buildGraphButton => 'ساخت نمودار';
@@ -6646,8 +6530,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get failedToLoadContacts => 'بارگذاری مخاطبین ناموفق بود';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'آماده سازی مکالمه برای اشتراک گذاری ناموفق بود. لطفاً دوباره تلاش کنید.';
+  String get failedToPrepareConversationForSharing => 'آماده سازی مکالمه برای اشتراک گذاری ناموفق بود. لطفاً دوباره تلاش کنید.';
 
   @override
   String get couldNotOpenSmsApp => 'نتوانستم برنامه SMS را باز کنم. لطفاً دوباره تلاش کنید.';
@@ -6713,8 +6596,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'دانلود صوت از کارت SD دستگاه';
 
   @override
-  String get transferRequiredDescription =>
-      'این ضبط روی کارت SD دستگاه شما ذخیره شده است. آن را به تلفن خود منتقل کنید تا بتوانید پخش یا اشتراک گذاری کنید.';
+  String get transferRequiredDescription => 'این ضبط روی کارت SD دستگاه شما ذخیره شده است. آن را به تلفن خود منتقل کنید تا بتوانید پخش یا اشتراک گذاری کنید.';
 
   @override
   String get cancelTransfer => 'لغو انتقال';
@@ -6735,8 +6617,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get shareRecording => 'اشتراک‌گذاری ضبط‌شده';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'آیا می‌خواهید این ضبط‌شده را برای همیشه حذف کنید؟ این کار قابل بازگشت نیست.';
+  String get deleteRecordingConfirmation => 'آیا می‌خواهید این ضبط‌شده را برای همیشه حذف کنید؟ این کار قابل بازگشت نیست.';
 
   @override
   String get recordingIdLabel => 'شناسه ضبط';
@@ -6795,8 +6676,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get enableFastTransfer => 'فعال‌کردن انتقال سریع';
 
   @override
-  String get fastTransferDescription =>
-      'انتقال سریع از Wi-Fi برای سرعت تقریباً 5 برابر سریع‌تر استفاده می‌کند. تلفن شما به‌طور موقت در طی انتقال به شبکه Wi-Fi دستگاه Omi متصل خواهد شد.';
+  String get fastTransferDescription => 'انتقال سریع از Wi-Fi برای سرعت تقریباً 5 برابر سریع‌تر استفاده می‌کند. تلفن شما به‌طور موقت در طی انتقال به شبکه Wi-Fi دستگاه Omi متصل خواهد شد.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'دسترسی به اینترنت در طی انتقال متوقف است';
@@ -6811,8 +6691,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get fiveTimesFaster => '5 برابر سریع‌تر';
 
   @override
-  String get fastTransferMethodDescription =>
-      'اتصال مستقیم Wi-Fi را به دستگاه Omi ایجاد می‌کند. تلفن شما به‌طور موقت از Wi-Fi معمولی خود در طی انتقال قطع می‌شود.';
+  String get fastTransferMethodDescription => 'اتصال مستقیم Wi-Fi را به دستگاه Omi ایجاد می‌کند. تلفن شما به‌طور موقت از Wi-Fi معمولی خود در طی انتقال قطع می‌شود.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6821,8 +6700,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get bleSpeed => 'تقریباً 30 کیلوبایت بر ثانیه از طریق BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'از اتصال استاندارد Bluetooth Low Energy استفاده می‌کند. کندتر اما اتصال Wi-Fi شما را تحت تأثیر قرار نمی‌دهد.';
+  String get bluetoothMethodDescription => 'از اتصال استاندارد Bluetooth Low Energy استفاده می‌کند. کندتر اما اتصال Wi-Fi شما را تحت تأثیر قرار نمی‌دهد.';
 
   @override
   String get selected => 'انتخاب‌شده';
@@ -6860,12 +6738,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get appDeleteFailed => 'حذف برنامه ناموفق بود. لطفاً بعداً دوباره تلاش کنید.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'دید برنامه با موفقیت تغییر کرد. ممکن است چند دقیقه طول بکشد تا منعکس شود.';
+  String get appVisibilityChangedSuccessfully => 'دید برنامه با موفقیت تغییر کرد. ممکن است چند دقیقه طول بکشد تا منعکس شود.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'خطا در فعال‌کردن برنامه. اگر این یک برنامه یکپارچگی است، مطمئن شوید که تنظیم تکمیل شده است.';
+  String get errorActivatingAppIntegration => 'خطا در فعال‌کردن برنامه. اگر این یک برنامه یکپارچگی است، مطمئن شوید که تنظیم تکمیل شده است.';
 
   @override
   String get errorUpdatingAppStatus => 'خطایی هنگام به‌روزرسانی وضعیت برنامه رخ داد.';
@@ -6945,8 +6821,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'نام باید حداقل 3 کاراکتر باشد';
 
   @override
-  String get conversationPromptHint =>
-      'برای مثال، اقلام اقدام، تصمیمات گرفته‌شده و نکات کلیدی را از گفتگوی ارائه‌شده استخراج کنید.';
+  String get conversationPromptHint => 'برای مثال، اقلام اقدام، تصمیمات گرفته‌شده و نکات کلیدی را از گفتگوی ارائه‌شده استخراج کنید.';
 
   @override
   String get pleaseEnterAppPrompt => 'لطفاً دستور برای برنامه خود را وارد کنید';
@@ -7028,8 +6903,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'اجازه عکس‌ها رد شد. لطفاً برای انتخاب تصویر دسترسی به عکس‌ها را مجاز کنید';
+  String get addAppPhotosPermissionDenied => 'اجازه عکس‌ها رد شد. لطفاً برای انتخاب تصویر دسترسی به عکس‌ها را مجاز کنید';
 
   @override
   String get addAppErrorSelectingImageRetry => 'خطا در انتخاب تصویر. لطفاً دوباره تلاش کنید.';
@@ -7134,15 +7008,13 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'ارتقا زمان‌بندی شد! نقشهِ ماهانهِ شما تا پایان دورهِ صورت‌حسابِ شما ادامه می‌یابد، سپس به‌طور خودکار به نقشهِ سالانه تغییر می‌کند.';
+  String get planUpgradeScheduledMessage => 'ارتقا زمان‌بندی شد! نقشهِ ماهانهِ شما تا پایان دورهِ صورت‌حسابِ شما ادامه می‌یابد، سپس به‌طور خودکار به نقشهِ سالانه تغییر می‌کند.';
 
   @override
   String get couldNotSchedulePlanChange => 'نتوانست تغییر نقشه را زمان‌بندی کند. لطفاً دوباره تلاش کنید.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'اشتراک شما دوباره فعال شد! هیچ شارژی در حال حاضر وجود ندارد - شما در پایان دورهِ فعلیِ خود شارژ شده‌اید.';
+  String get subscriptionReactivatedDefault => 'اشتراک شما دوباره فعال شد! هیچ شارژی در حال حاضر وجود ندارد - شما در پایان دورهِ فعلیِ خود شارژ شده‌اید.';
 
   @override
   String get subscriptionSuccessfulCharged => 'اشتراک موفق بود! برای دورهِ صورت‌حساب جدید شارژ شده‌اید.';
@@ -7325,8 +7197,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get onboardingBluetoothRequired => 'اجازهِ Bluetooth برای اتصال به دستگاه ضروری است.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'اجازهِ Bluetooth رد شد. لطفاً اجازه را در تنظیمات سیستم اعطا کنید.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'اجازهِ Bluetooth رد شد. لطفاً اجازه را در تنظیمات سیستم اعطا کنید.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7339,12 +7210,10 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'اجازهِ اطلاع رسانی رد شد. لطفاً اجازه را در تنظیمات سیستم اعطا کنید.';
+  String get onboardingNotificationDeniedSystemPrefs => 'اجازهِ اطلاع رسانی رد شد. لطفاً اجازه را در تنظیمات سیستم اعطا کنید.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'اجازهِ اطلاع رسانی رد شد. لطفاً اجازه را در تنظیمات سیستم > اطلاع رسانی اعطا کنید.';
+  String get onboardingNotificationDeniedNotifications => 'اجازهِ اطلاع رسانی رد شد. لطفاً اجازه را در تنظیمات سیستم > اطلاع رسانی اعطا کنید.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7357,15 +7226,13 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'لطفاً اجازهِ مکان را در تنظیمات > حریم خصوصی و امنیت > خدمات مکان اعطا کنید';
+  String get onboardingLocationGrantInSettings => 'لطفاً اجازهِ مکان را در تنظیمات > حریم خصوصی و امنیت > خدمات مکان اعطا کنید';
 
   @override
   String get onboardingMicrophoneRequired => 'اجازهِ میکروفن برای ضبط ضروری است.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'اجازهِ میکروفن رد شد. لطفاً اجازه را در تنظیمات سیستم > حریم خصوصی و امنیت > میکروفن اعطا کنید.';
+  String get onboardingMicrophoneDenied => 'اجازهِ میکروفن رد شد. لطفاً اجازه را در تنظیمات سیستم > حریم خصوصی و امنیت > میکروفن اعطا کنید.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7381,8 +7248,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'اجازهِ ضبطِ صفحهِ نمایش برای ضبط صدای سیستم ضروری است.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'اجازهِ ضبطِ صفحهِ نمایش رد شد. لطفاً اجازه را در تنظیمات سیستم > حریم خصوصی و امنیت > ضبط صفحه اعطا کنید.';
+  String get onboardingScreenCaptureDenied => 'اجازهِ ضبطِ صفحهِ نمایش رد شد. لطفاً اجازه را در تنظیمات سیستم > حریم خصوصی و امنیت > ضبط صفحه اعطا کنید.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7507,8 +7373,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get locationPermissionRequired => 'اجازهِ مکان مورد نیاز است';
 
   @override
-  String get locationPermissionContent =>
-      'انتقال سریع برای تأیید اتصال Wi-Fi به اجازهِ مکان نیاز دارد. لطفاً برای ادامه اجازهِ مکان را اعطا کنید.';
+  String get locationPermissionContent => 'انتقال سریع برای تأیید اتصال Wi-Fi به اجازهِ مکان نیاز دارد. لطفاً برای ادامه اجازهِ مکان را اعطا کنید.';
 
   @override
   String get pdfTranscriptExport => 'صادرات رونوشت';
@@ -7671,8 +7536,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'دستگاه از هماهنگ‌سازی Wi-Fi پشتیبانی نمی‌کند، تغییر به Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'دستگاه از هماهنگ‌سازی Wi-Fi پشتیبانی نمی‌کند، تغییر به Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health در این دستگاه در دسترس نیست';
@@ -7980,8 +7844,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get pairingTitlePlaudNote => 'قرار دادن Plaud Note در حالت جفت‌کردن';
 
   @override
-  String get pairingDescPlaudNote =>
-      'دکمه کناری را برای 2 ثانیه فشار دهید و نگاه دارید. LED قرمز هنگام آماده‌باش برای جفت‌کردن چشمک خواهد زد.';
+  String get pairingDescPlaudNote => 'دکمه کناری را برای 2 ثانیه فشار دهید و نگاه دارید. LED قرمز هنگام آماده‌باش برای جفت‌کردن چشمک خواهد زد.';
 
   @override
   String get pairingTitleBee => 'قرار دادن Bee در حالت جفت‌کردن';
@@ -7993,15 +7856,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get pairingTitleLimitless => 'قرار دادن Limitless در حالت جفت‌کردن';
 
   @override
-  String get pairingDescLimitless =>
-      'هنگامی که چراغی دیده شود، یک بار فشار دهید و سپس فشار دهید و نگاه دارید تا دستگاه نور صورتی نشان دهد، سپس رها کنید.';
+  String get pairingDescLimitless => 'هنگامی که چراغی دیده شود، یک بار فشار دهید و سپس فشار دهید و نگاه دارید تا دستگاه نور صورتی نشان دهد، سپس رها کنید.';
 
   @override
   String get pairingTitleFriendPendant => 'قرار دادن Friend Pendant در حالت جفت‌کردن';
 
   @override
-  String get pairingDescFriendPendant =>
-      'دکمه روی مدال را فشار دهید تا روشن شود. به‌طور خودکار وارد حالت جفت‌کردن خواهد شد.';
+  String get pairingDescFriendPendant => 'دکمه روی مدال را فشار دهید تا روشن شود. به‌طور خودکار وارد حالت جفت‌کردن خواهد شد.';
 
   @override
   String get pairingTitleFieldy => 'قرار دادن Fieldy در حالت جفت‌کردن';
@@ -8013,8 +7874,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get pairingTitleAppleWatch => 'اتصال Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'برنامه Omi را روی Apple Watch نصب و باز کنید، سپس در برنامه روی Connect ضربه بزنید.';
+  String get pairingDescAppleWatch => 'برنامه Omi را روی Apple Watch نصب و باز کنید، سپس در برنامه روی Connect ضربه بزنید.';
 
   @override
   String get pairingTitleNeoOne => 'قرار دادن Neo One در حالت جفت‌کردن';
@@ -8137,8 +7997,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get switchAndRestart => 'تغییر';
 
   @override
-  String get stagingDisclaimer =>
-      'انتقالی ممکن است دارای اشکال باشد، عملکرد نامتناسب داشته باشد و داده‌ها ممکن است از دست برود. فقط برای آزمایش استفاده کنید.';
+  String get stagingDisclaimer => 'انتقالی ممکن است دارای اشکال باشد، عملکرد نامتناسب داشته باشد و داده‌ها ممکن است از دست برود. فقط برای آزمایش استفاده کنید.';
 
   @override
   String get apiEnvSavedRestartRequired => 'ذخیره شد. برنامه را ببندید و دوباره باز کنید تا اعمال شود.';
@@ -8367,8 +8226,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'تماس‌های تلفنی از طریق Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'از طریق Omi تماس بگیرید و رونویسی زمان‌حقیقی، خلاصه‌های خودکار و موارد دیگر را دریافت کنید. منحصراً برای مشترکین نسخه Unlimited در دسترس است.';
+  String get phoneCallsUpsellSubtitle => 'از طریق Omi تماس بگیرید و رونویسی زمان‌حقیقی، خلاصه‌های خودکار و موارد دیگر را دریافت کنید. منحصراً برای مشترکین نسخه Unlimited در دسترس است.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'رونویسی زمان‌حقیقی هر تماس';
@@ -8407,8 +8265,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deletePendingFiles => 'حذف ضبط‌های در انتظار';
 
   @override
-  String get deletePendingFilesWarning =>
-      'این ضبط‌ها به تلفن شما همگام‌سازی نشده‌اند و برای همیشه از دست خواهند رفت. این قابل بازگشت نیست.';
+  String get deletePendingFilesWarning => 'این ضبط‌ها به تلفن شما همگام‌سازی نشده‌اند و برای همیشه از دست خواهند رفت. این قابل بازگشت نیست.';
 
   @override
   String get pendingFilesDeleted => 'ضبط‌های در انتظار حذف شدند';
@@ -8420,8 +8277,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deleteAll => 'حذف همه';
 
   @override
-  String get deleteAllFilesWarning =>
-      'این کار تمام ضبط‌های همگام‌سازی شده و در انتظار را حذف خواهد کرد. ضبط‌های در انتظار به تلفن شما همگام‌سازی نشده‌اند و برای همیشه از دست خواهند رفت. این قابل بازگشت نیست.';
+  String get deleteAllFilesWarning => 'این کار تمام ضبط‌های همگام‌سازی شده و در انتظار را حذف خواهد کرد. ضبط‌های در انتظار به تلفن شما همگام‌سازی نشده‌اند و برای همیشه از دست خواهند رفت. این قابل بازگشت نیست.';
 
   @override
   String get allFilesDeleted => 'تمام ضبط‌ها حذف شدند';
@@ -8486,8 +8342,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get fairUseAboutTitle => 'درباره استفاده منصفانه';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi برای گفتگوهای شخصی، جلسات و تعاملات زنده طراحی شده‌است. استفاده بر اساس زمان گفتار واقعی تشخیص‌داده‌شده، نه زمان اتصال اندازه‌گیری می‌شود. اگر استفاده به‌طور قابل‌توجهی از الگوهای معمول برای محتوای غیرشخصی تجاوز کند، تعدیل‌هایی اعمال قد می‌شود.';
+  String get fairUseAboutBody => 'Omi برای گفتگوهای شخصی، جلسات و تعاملات زنده طراحی شده‌است. استفاده بر اساس زمان گفتار واقعی تشخیص‌داده‌شده، نه زمان اتصال اندازه‌گیری می‌شود. اگر استفاده به‌طور قابل‌توجهی از الگوهای معمول برای محتوای غیرشخصی تجاوز کند، تعدیل‌هایی اعمال قد می‌شود.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8525,8 +8380,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get improveConnectionTitle => 'بهبود اتصال';
 
   @override
-  String get improveConnectionContent =>
-      'ما نحوه اتصال Omi به دستگاه شما را بهبود دادیم. برای فعال کردن آن، لطفا به صفحه اطلاعات دستگاه بروید، روی \"قطع دستگاه\" ضربه بزنید و سپس دستگاه خود را دوباره جفت کنید.';
+  String get improveConnectionContent => 'ما نحوه اتصال Omi به دستگاه شما را بهبود دادیم. برای فعال کردن آن، لطفا به صفحه اطلاعات دستگاه بروید، روی \"قطع دستگاه\" ضربه بزنید و سپس دستگاه خود را دوباره جفت کنید.';
 
   @override
   String get improveConnectionAction => 'فهمیدم';
@@ -8581,16 +8435,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get cancelSyncQuestion => 'همگام‌سازی را لغو کنید؟';
 
   @override
-  String get omisStorageDesc =>
-      'هنگامی که Omi به تلفن شما متصل نیست، صوت را به‌طور محلی روی حافظه داخلی‌اش ذخیره می‌کند. شما هرگز ضبط را از دست نمی‌دهید.';
+  String get omisStorageDesc => 'هنگامی که Omi به تلفن شما متصل نیست، صوت را به‌طور محلی روی حافظه داخلی‌اش ذخیره می‌کند. شما هرگز ضبط را از دست نمی‌دهید.';
 
   @override
-  String get phoneStorageDesc =>
-      'هنگامی که Omi دوباره متصل شود، ضبط‌ها به‌طور خودکار به تلفن شما به‌عنوان یک ناحیه نگهداری موقت قبل از بارگذاری منتقل می‌شوند.';
+  String get phoneStorageDesc => 'هنگامی که Omi دوباره متصل شود، ضبط‌ها به‌طور خودکار به تلفن شما به‌عنوان یک ناحیه نگهداری موقت قبل از بارگذاری منتقل می‌شوند.';
 
   @override
-  String get cloudStorageDesc =>
-      'پس از بارگذاری، ضبط‌های شما پردازش و رونویسی می‌شوند. گفتگوها در عرض یک دقیقه در دسترس خواهند بود.';
+  String get cloudStorageDesc => 'پس از بارگذاری، ضبط‌های شما پردازش و رونویسی می‌شوند. گفتگوها در عرض یک دقیقه در دسترس خواهند بود.';
 
   @override
   String get tipKeepPhoneNearby => 'تلفن خود را نزدیک نگاه دارید تا همگام‌سازی سریع‌تر شود';
@@ -8614,12 +8465,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get permissionEnable => 'فعال کردن';
 
   @override
-  String get permissionsPageDescription =>
-      'این مجوزها برای کار کردن Omi بسیار مهم‌اند. آن‌ها ویژگی‌های کلیدی مانند اطلاعات، تجربیات مبتنی بر مکان و ضبط صوت را فعال می‌کنند.';
+  String get permissionsPageDescription => 'این مجوزها برای کار کردن Omi بسیار مهم‌اند. آن‌ها ویژگی‌های کلیدی مانند اطلاعات، تجربیات مبتنی بر مکان و ضبط صوت را فعال می‌کنند.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi برای کار صحیح به چند مجوز نیاز دارد. برای ادامه لطفا آن‌ها را اعطا کنید.';
+  String get permissionsRequiredDescription => 'Omi برای کار صحیح به چند مجوز نیاز دارد. برای ادامه لطفا آن‌ها را اعطا کنید.';
 
   @override
   String get permissionsSetupTitle => 'بهترین تجربه را بدست آورید';
@@ -8896,8 +8745,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get firmwareWarningTitle => 'مهم: قبل از به‌روزرسانی بخوانید';
 
   @override
-  String get firmwareFormatWarning =>
-      'این فریمور کارت SD را فرمت می‌کند. لطفاً قبل از ارتقا مطمئن شوید که تمام داده‌های آفلاین همگام‌سازی شده‌اند.\n\nاگر بعد از نصب این نسخه چراغ قرمز چشمک‌زن دیدید، نگران نشوید. کافی است دستگاه را به برنامه متصل کنید و باید آبی شود. چراغ قرمز به این معنی است که ساعت دستگاه هنوز همگام‌سازی نشده است.';
+  String get firmwareFormatWarning => 'این فریمور کارت SD را فرمت می‌کند. لطفاً قبل از ارتقا مطمئن شوید که تمام داده‌های آفلاین همگام‌سازی شده‌اند.\n\nاگر بعد از نصب این نسخه چراغ قرمز چشمک‌زن دیدید، نگران نشوید. کافی است دستگاه را به برنامه متصل کنید و باید آبی شود. چراغ قرمز به این معنی است که ساعت دستگاه هنوز همگام‌سازی نشده است.';
 
   @override
   String get continueAnyway => 'ادامه';
@@ -8917,8 +8765,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get tasksMarkComplete => 'به عنوان تکمیل‌شده علامت‌گذاری شد';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi از طریق چارچوب HealthKit اپل به Apple Health دسترسی دارد. در هر زمان می‌توانید دسترسی را از تنظیمات iOS لغو کنید.';
+  String get appleHealthManageNote => 'Omi از طریق چارچوب HealthKit اپل به Apple Health دسترسی دارد. در هر زمان می‌توانید دسترسی را از تنظیمات iOS لغو کنید.';
 
   @override
   String get appleHealthConnectCta => 'اتصال به Apple Health';
@@ -8951,8 +8798,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get appleHealthDeniedTitle => 'دسترسی به Apple Health رد شد';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi مجوز خواندن داده‌های Apple Health شما را ندارد. آن را در تنظیمات iOS ← حریم خصوصی و امنیت ← Health ← Omi فعال کنید.';
+  String get appleHealthDeniedBody => 'Omi مجوز خواندن داده‌های Apple Health شما را ندارد. آن را در تنظیمات iOS ← حریم خصوصی و امنیت ← Health ← Omi فعال کنید.';
 
   @override
   String get deleteFlowReasonTitle => 'چرا می‌روید؟';
@@ -9021,8 +8867,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get planUpdate => 'به‌روزرسانی طرح';
 
   @override
-  String get planDeprecationMessage =>
-      'طرح Unlimited شما در حال بازنشسته شدن است. به طرح Operator تغییر دهید — همان ویژگی‌های عالی با \$49/ماه. طرح فعلی شما در این مدت به کار خود ادامه خواهد داد.';
+  String get planDeprecationMessage => 'طرح Unlimited شما در حال بازنشسته شدن است. به طرح Operator تغییر دهید — همان ویژگی‌های عالی با \$49/ماه. طرح فعلی شما در این مدت به کار خود ادامه خواهد داد.';
 
   @override
   String get upgradeYourPlan => 'طرح خود را ارتقا دهید';
@@ -9133,8 +8978,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'شما به حد ماهانه خود رسیده‌اید. برای ادامه گفتگو با Omi بدون محدودیت ارتقا دهید.';
+  String get chatQuotaExceededReply => 'شما به حد ماهانه خود رسیده‌اید. برای ادامه گفتگو با Omi بدون محدودیت ارتقا دهید.';
 
   @override
   String get voiceResponseAudio => 'خواندن پاسخ Omi با صدای بلند';
@@ -9165,4 +9009,25 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'افزودن وظیفه';
+
+  @override
+  String get quickActionAskOmiAnything => 'هر چیزی از اُمی بپرسید';
+
+  @override
+  String get quickActionVoiceMode => 'حالت صوتی';
+
+  @override
+  String get quickActionMute => 'بی‌صدا';
+
+  @override
+  String get quickActionUnmute => 'لغو بی‌صدا';
+
+  @override
+  String get quickActionConnectDevice => 'اتصال دستگاه';
+
+  @override
+  String get quickActionDeviceSettings => 'تنظیمات دستگاه';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -24,8 +24,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deleteConversationTitle => 'Poista keskustelu?';
 
   @override
-  String get deleteConversationMessage =>
-      'Tämä poistaa myös liittyvät muistot, tehtävät ja äänitiedostot. Tätä toimintoa ei voi kumota.';
+  String get deleteConversationMessage => 'Tämä poistaa myös liittyvät muistot, tehtävät ja äänitiedostot. Tätä toimintoa ei voi kumota.';
 
   @override
   String get confirm => 'Vahvista';
@@ -354,19 +353,16 @@ class AppLocalizationsFi extends AppLocalizations {
   String get appsDisconnected => 'Sovelluksesi ja integraatiot katkaistaan välittömästi.';
 
   @override
-  String get exportBeforeDelete =>
-      'Voit viedä tietosi ennen tilin poistamista, mutta poiston jälkeen niitä ei voi palauttaa.';
+  String get exportBeforeDelete => 'Voit viedä tietosi ennen tilin poistamista, mutta poiston jälkeen niitä ei voi palauttaa.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Ymmärrän, että tilini poistaminen on pysyvää ja kaikki tiedot, mukaan lukien muistot ja keskustelut, menetetään eikä niitä voi palauttaa.';
+  String get deleteAccountCheckbox => 'Ymmärrän, että tilini poistaminen on pysyvää ja kaikki tiedot, mukaan lukien muistot ja keskustelut, menetetään eikä niitä voi palauttaa.';
 
   @override
   String get areYouSure => 'Oletko varma?';
 
   @override
-  String get deleteAccountFinal =>
-      'Tämä toiminto on peruuttamaton ja poistaa tilisi ja kaikki siihen liittyvät tiedot pysyvästi. Haluatko varmasti jatkaa?';
+  String get deleteAccountFinal => 'Tämä toiminto on peruuttamaton ja poistaa tilisi ja kaikki siihen liittyvät tiedot pysyvästi. Haluatko varmasti jatkaa?';
 
   @override
   String get deleteNow => 'Poista nyt';
@@ -375,8 +371,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get goBack => 'Palaa takaisin';
 
   @override
-  String get checkBoxToConfirm =>
-      'Valitse ruutu vahvistaaksesi, että ymmärrät tilin poistamisen olevan pysyvää ja peruuttamatonta.';
+  String get checkBoxToConfirm => 'Valitse ruutu vahvistaaksesi, että ymmärrät tilin poistamisen olevan pysyvää ja peruuttamatonta.';
 
   @override
   String get profile => 'Profiili';
@@ -454,8 +449,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get yourPrivacyYourControl => 'Yksityisyytesi, sinun hallinnassasi';
 
   @override
-  String get privacyIntro =>
-      'Omissa olemme sitoutuneet suojaamaan yksityisyyttäsi. Tämä sivu antaa sinulle mahdollisuuden hallita, miten tietojasi tallennetaan ja käytetään.';
+  String get privacyIntro => 'Omissa olemme sitoutuneet suojaamaan yksityisyyttäsi. Tämä sivu antaa sinulle mahdollisuuden hallita, miten tietojasi tallennetaan ja käytetään.';
 
   @override
   String get learnMore => 'Lue lisää...';
@@ -464,15 +458,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get dataProtectionLevel => 'Tietosuojataso';
 
   @override
-  String get dataProtectionDesc =>
-      'Tietosi on oletuksena suojattu vahvalla salauksella. Tarkista asetuksesi ja tulevat yksityisyysvaihtoehdot alla.';
+  String get dataProtectionDesc => 'Tietosi on oletuksena suojattu vahvalla salauksella. Tarkista asetuksesi ja tulevat yksityisyysvaihtoehdot alla.';
 
   @override
   String get appAccess => 'Sovelluspääsy';
 
   @override
-  String get appAccessDesc =>
-      'Seuraavat sovellukset voivat käyttää tietojasi. Napauta sovellusta hallitaksesi sen käyttöoikeuksia.';
+  String get appAccessDesc => 'Seuraavat sovellukset voivat käyttää tietojasi. Napauta sovellusta hallitaksesi sen käyttöoikeuksia.';
 
   @override
   String get noAppsExternalAccess => 'Yhdelläkään asennetulla sovelluksella ei ole ulkoista pääsyä tietoihisi.';
@@ -529,15 +521,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Omin yhteys on katkaistu 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Laitteen pariliitos poistettu. Siirry Asetukset > Bluetooth ja unohda laite pariliitoksen poistamisen viimeistelemiseksi.';
+  String get deviceUnpairedMessage => 'Laitteen pariliitos poistettu. Siirry Asetukset > Bluetooth ja unohda laite pariliitoksen poistamisen viimeistelemiseksi.';
 
   @override
   String get unpairDialogTitle => 'Pura laitepari';
 
   @override
-  String get unpairDialogMessage =>
-      'Tämä purkaa laiteparin, jotta se voidaan yhdistää toiseen puhelimeen. Sinun on siirryttävä kohtaan Asetukset > Bluetooth ja unohdettava laite prosessin viimeistelemiseksi.';
+  String get unpairDialogMessage => 'Tämä purkaa laiteparin, jotta se voidaan yhdistää toiseen puhelimeen. Sinun on siirryttävä kohtaan Asetukset > Bluetooth ja unohdettava laite prosessin viimeistelemiseksi.';
 
   @override
   String get deviceNotConnected => 'Laitetta ei ole yhdistetty';
@@ -558,8 +548,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get v2Undetected => 'V2 ei havaittu';
 
   @override
-  String get v2UndetectedMessage =>
-      'Sinulla näyttää olevan V1-laite tai laitteesi ei ole yhdistetty. SD-korttitoiminto on saatavilla vain V2-laitteille.';
+  String get v2UndetectedMessage => 'Sinulla näyttää olevan V1-laite tai laitteesi ei ole yhdistetty. SD-korttitoiminto on saatavilla vain V2-laitteille.';
 
   @override
   String get endConversation => 'Lopeta keskustelu';
@@ -833,8 +822,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Poista tietograafi?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Tämä poistaa kaikki johdetut tietograafitiedot (solmut ja yhteydet). Alkuperäiset muistosi pysyvät turvassa. Graafi rakennetaan uudelleen ajan myötä tai seuraavan pyynnön yhteydessä.';
+  String get deleteKnowledgeGraphMessage => 'Tämä poistaa kaikki johdetut tietograafitiedot (solmut ja yhteydet). Alkuperäiset muistosi pysyvät turvassa. Graafi rakennetaan uudelleen ajan myötä tai seuraavan pyynnön yhteydessä.';
 
   @override
   String get knowledgeGraphDeleted => 'Tietämysgraafi poistettu';
@@ -982,8 +970,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get shortConversationThreshold => 'Lyhyen keskustelun kynnysarvo';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Tätä lyhyemmät keskustelut piilotetaan, ellei niitä ole otettu käyttöön yllä';
+  String get shortConversationThresholdSubtitle => 'Tätä lyhyemmät keskustelut piilotetaan, ellei niitä ole otettu käyttöön yllä';
 
   @override
   String get durationThreshold => 'Kestokynnys';
@@ -1078,8 +1065,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get needYourPermission => 'Tarvitsemme lupasi';
 
   @override
-  String get alreadyGavePermission =>
-      'Olet jo antanut meille luvan tallentaa nauhoituksiasi. Tässä muistutus siitä, miksi tarvitsemme sen:';
+  String get alreadyGavePermission => 'Olet jo antanut meille luvan tallentaa nauhoituksiasi. Tässä muistutus siitä, miksi tarvitsemme sen:';
 
   @override
   String get wouldLikePermission => 'Haluaisimme lupasi tallentaa ääninauhoituksesi. Tässä syy:';
@@ -1088,26 +1074,22 @@ class AppLocalizationsFi extends AppLocalizations {
   String get improveSpeechProfile => 'Paranna puheprofiiliasi';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Käytämme nauhoituksia henkilökohtaisen puheprofiilisi kouluttamiseen ja parantamiseen.';
+  String get improveSpeechProfileDesc => 'Käytämme nauhoituksia henkilökohtaisen puheprofiilisi kouluttamiseen ja parantamiseen.';
 
   @override
   String get trainFamilyProfiles => 'Kouluta profiileja ystäville ja perheelle';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Nauhoituksesi auttavat meitä tunnistamaan ja luomaan profiileja ystävillesi ja perheellesi.';
+  String get trainFamilyProfilesDesc => 'Nauhoituksesi auttavat meitä tunnistamaan ja luomaan profiileja ystävillesi ja perheellesi.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Paranna litterointitarkkuutta';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Kun mallimme paranee, voimme tarjota parempia litterointituloksia nauhoituksillesi.';
+  String get enhanceTranscriptAccuracyDesc => 'Kun mallimme paranee, voimme tarjota parempia litterointituloksia nauhoituksillesi.';
 
   @override
-  String get legalNotice =>
-      'Oikeudellinen huomautus: Äänidatan nauhoittamisen ja tallentamisen laillisuus voi vaihdella sijaintisi ja tämän ominaisuuden käyttötavan mukaan. Vastaat paikallisten lakien ja määräysten noudattamisesta.';
+  String get legalNotice => 'Oikeudellinen huomautus: Äänidatan nauhoittamisen ja tallentamisen laillisuus voi vaihdella sijaintisi ja tämän ominaisuuden käyttötavan mukaan. Vastaat paikallisten lakien ja määräysten noudattamisesta.';
 
   @override
   String get alreadyAuthorized => 'Jo valtuutettu';
@@ -1185,8 +1167,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showEventsNoParticipants => 'Näytä tapahtumat ilman osallistujia';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Kun käytössä, Tulossa näyttää tapahtumat ilman osallistujia tai videolinkkiä.';
+  String get showEventsNoParticipantsDesc => 'Kun käytössä, Tulossa näyttää tapahtumat ilman osallistujia tai videolinkkiä.';
 
   @override
   String get yourMeetings => 'Kokouksesi';
@@ -1227,8 +1208,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get noProjectsInWorkspace => 'Projekteja ei löytynyt tästä työtilasta';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Valitse kuinka kauan odotetaan hiljaisuutta ennen keskustelun automaattista päättämistä:';
+  String get conversationTimeoutDesc => 'Valitse kuinka kauan odotetaan hiljaisuutta ennen keskustelun automaattista päättämistä:';
 
   @override
   String get timeout2Minutes => '2 minuuttia';
@@ -1275,8 +1255,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get languageForTranscription => 'Aseta kielesi tarkempaa litterointia ja henkilökohtaista kokemusta varten.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Yhden kielen tila on käytössä. Käännös on poistettu käytöstä paremman tarkkuuden vuoksi.';
+  String get singleLanguageModeInfo => 'Yhden kielen tila on käytössä. Käännös on poistettu käytöstä paremman tarkkuuden vuoksi.';
 
   @override
   String get searchLanguageHint => 'Etsi kieltä nimen tai koodin perusteella';
@@ -1356,8 +1335,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get defaultRepository => 'Oletusrepositorio';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Valitse oletusrepositorio ongelmien luomiseen. Voit silti määrittää eri repositorion ongelmia luodessa.';
+  String get selectDefaultRepoDesc => 'Valitse oletusrepositorio ongelmien luomiseen. Voit silti määrittää eri repositorion ongelmia luodessa.';
 
   @override
   String get noReposFound => 'Repositorioita ei löytynyt';
@@ -1732,8 +1710,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get enableBluetooth => 'Ota Bluetooth käyttöön';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi tarvitsee Bluetoothin yhdistääkseen puettavaan laitteeseesi. Ota Bluetooth käyttöön ja yritä uudelleen.';
+  String get bluetoothNeeded => 'Omi tarvitsee Bluetoothin yhdistääkseen puettavaan laitteeseesi. Ota Bluetooth käyttöön ja yritä uudelleen.';
 
   @override
   String get contactSupport => 'Ota yhteyttä tukeen?';
@@ -1766,26 +1743,22 @@ class AppLocalizationsFi extends AppLocalizations {
   String get locationServiceDisabled => 'Sijaintipalvelu poistettu käytöstä';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Sijaintipalvelu on poistettu käytöstä. Siirry kohtaan Asetukset > Tietosuoja ja turvallisuus > Sijaintipalvelut ja ota se käyttöön';
+  String get locationServiceDisabledDesc => 'Sijaintipalvelu on poistettu käytöstä. Siirry kohtaan Asetukset > Tietosuoja ja turvallisuus > Sijaintipalvelut ja ota se käyttöön';
 
   @override
   String get backgroundLocationDenied => 'Taustasijaintipääsy evätty';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Siirry laitteen asetuksiin ja aseta sijaintioikeus asentoon \"Salli aina\"';
+  String get backgroundLocationDeniedDesc => 'Siirry laitteen asetuksiin ja aseta sijaintioikeus asentoon \"Salli aina\"';
 
   @override
   String get lovingOmi => 'Pidätkö Omista?';
 
   @override
-  String get leaveReviewIos =>
-      'Auta meitä tavoittamaan lisää ihmisiä jättämällä arvostelu App Storeen. Palautteesi on meille tärkeää!';
+  String get leaveReviewIos => 'Auta meitä tavoittamaan lisää ihmisiä jättämällä arvostelu App Storeen. Palautteesi on meille tärkeää!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Auta meitä tavoittamaan lisää ihmisiä jättämällä arvostelu Google Play -kauppaan. Palautteesi on meille tärkeää!';
+  String get leaveReviewAndroid => 'Auta meitä tavoittamaan lisää ihmisiä jättämällä arvostelu Google Play -kauppaan. Palautteesi on meille tärkeää!';
 
   @override
   String get rateOnAppStore => 'Arvostele App Storessa';
@@ -1824,8 +1797,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get invalidRecordingMultipleSpeakers => 'Virheellinen nauhoitus havaittu';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Näyttää siltä, että nauhoituksessa on useita puhujia. Varmista, että olet hiljaisessa paikassa ja yritä uudelleen.';
+  String get multipleSpeakersDesc => 'Näyttää siltä, että nauhoituksessa on useita puhujia. Varmista, että olet hiljaisessa paikassa ja yritä uudelleen.';
 
   @override
   String get tooShortDesc => 'Puhetta ei havaittu tarpeeksi. Puhu enemmän ja yritä uudelleen.';
@@ -1837,8 +1809,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get areYouThere => 'Oletko siellä?';
 
   @override
-  String get noSpeechDesc =>
-      'Emme voineet havaita mitään puhetta. Varmista, että puhut vähintään 10 sekuntia ja korkeintaan 3 minuuttia.';
+  String get noSpeechDesc => 'Emme voineet havaita mitään puhetta. Varmista, että puhut vähintään 10 sekuntia ja korkeintaan 3 minuuttia.';
 
   @override
   String get connectionLost => 'Yhteys katkesi';
@@ -1859,8 +1830,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get permissionsRequired => 'Käyttöoikeudet vaaditaan';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Tämä sovellus tarvitsee Bluetooth- ja sijaintioikeudet toimiakseen oikein. Ota ne käyttöön asetuksissa.';
+  String get permissionsRequiredDesc => 'Tämä sovellus tarvitsee Bluetooth- ja sijaintioikeudet toimiakseen oikein. Ota ne käyttöön asetuksissa.';
 
   @override
   String get openSettings => 'Avaa asetukset';
@@ -1890,8 +1860,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – tekoälykumppanisi';
 
   @override
-  String get captureEveryMoment =>
-      'Tallenna jokainen hetki. Saat tekoälyn\nluomat yhteenvedot. Älä enää tee muistiinpanoja.';
+  String get captureEveryMoment => 'Tallenna jokainen hetki. Saat tekoälyn\nluomat yhteenvedot. Älä enää tee muistiinpanoja.';
 
   @override
   String get appleWatchSetup => 'Apple Watch -asennus';
@@ -1903,12 +1872,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get microphonePermission => 'Mikrofonin käyttöoikeus';
 
   @override
-  String get permissionGrantedNow =>
-      'Käyttöoikeus myönnetty! Nyt:\n\nAvaa Omi-sovellus kellossasi ja napauta \"Jatka\" alla';
+  String get permissionGrantedNow => 'Käyttöoikeus myönnetty! Nyt:\n\nAvaa Omi-sovellus kellossasi ja napauta \"Jatka\" alla';
 
   @override
-  String get needMicrophonePermission =>
-      'Tarvitsemme mikrofonin käyttöoikeuden.\n\n1. Napauta \"Myönnä käyttöoikeus\"\n2. Salli iPhonessasi\n3. Kello-sovellus sulkeutuu\n4. Avaa uudelleen ja napauta \"Jatka\"';
+  String get needMicrophonePermission => 'Tarvitsemme mikrofonin käyttöoikeuden.\n\n1. Napauta \"Myönnä käyttöoikeus\"\n2. Salli iPhonessasi\n3. Kello-sovellus sulkeutuu\n4. Avaa uudelleen ja napauta \"Jatka\"';
 
   @override
   String get grantPermissionButton => 'Myönnä käyttöoikeus';
@@ -1917,15 +1884,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get needHelp => 'Tarvitsetko apua?';
 
   @override
-  String get troubleshootingSteps =>
-      'Vianmääritys:\n\n1. Varmista, että Omi on asennettu kelloosi\n2. Avaa Omi-sovellus kellossasi\n3. Etsi käyttöoikeuspyyntö\n4. Napauta \"Salli\" kehotettaessa\n5. Kello-sovellus sulkeutuu - avaa se uudelleen\n6. Palaa ja napauta \"Jatka\" iPhonessasi';
+  String get troubleshootingSteps => 'Vianmääritys:\n\n1. Varmista, että Omi on asennettu kelloosi\n2. Avaa Omi-sovellus kellossasi\n3. Etsi käyttöoikeuspyyntö\n4. Napauta \"Salli\" kehotettaessa\n5. Kello-sovellus sulkeutuu - avaa se uudelleen\n6. Palaa ja napauta \"Jatka\" iPhonessasi';
 
   @override
   String get recordingStartedSuccessfully => 'Nauhoitus aloitettu onnistuneesti!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Käyttöoikeutta ei ole vielä myönnetty. Varmista, että salloit mikrofonin käytön ja avasit sovelluksen kellossasi uudelleen.';
+  String get permissionNotGrantedYet => 'Käyttöoikeutta ei ole vielä myönnetty. Varmista, että salloit mikrofonin käytön ja avasit sovelluksen kellossasi uudelleen.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2022,8 +1987,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Valmis tehtäville';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Tekoälysi poimii automaattisesti tehtävät ja to-do-listat keskusteluistasi. Ne näkyvät täällä, kun ne on luotu.';
+  String get welcomeActionItemsDescription => 'Tekoälysi poimii automaattisesti tehtävät ja to-do-listat keskusteluistasi. Ne näkyvät täällä, kun ne on luotu.';
 
   @override
   String get autoExtractionFeature => 'Poimittu automaattisesti keskusteluista';
@@ -2219,15 +2183,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'PUHE JA LITTEROINTI';
 
   @override
-  String get languageSettingsHelperText =>
-      'Sovelluksen kieli muuttaa valikkoja ja painikkeita. Puheen kieli vaikuttaa siihen, miten tallenteet litteroidaan.';
+  String get languageSettingsHelperText => 'Sovelluksen kieli muuttaa valikkoja ja painikkeita. Puheen kieli vaikuttaa siihen, miten tallenteet litteroidaan.';
 
   @override
   String get translationNotice => 'Käännösilmoitus';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi kääntää keskustelut ensisijaiselle kielellesi. Päivitä se milloin tahansa kohdassa Asetukset → Profiilit.';
+  String get translationNoticeMessage => 'Omi kääntää keskustelut ensisijaiselle kielellesi. Päivitä se milloin tahansa kohdassa Asetukset → Profiilit.';
 
   @override
   String get pleaseCheckInternetConnection => 'Tarkista internet-yhteytesi ja yritä uudelleen';
@@ -2382,8 +2344,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Poista laitteen pariliitos';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Tämä poistaa laitteen pariliitoksen, jotta se voidaan yhdistää toiseen puhelimeen. Sinun on siirryttävä Asetukset > Bluetooth ja unohdettava laite prosessin viimeistelemiseksi.';
+  String get unpairDeviceDialogMessage => 'Tämä poistaa laitteen pariliitoksen, jotta se voidaan yhdistää toiseen puhelimeen. Sinun on siirryttävä Asetukset > Bluetooth ja unohdettava laite prosessin viimeistelemiseksi.';
 
   @override
   String get unpair => 'Poista pariliitos';
@@ -2564,8 +2525,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get youreAllSet => 'Olet valmis!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Tervetuloa Omiin! AI-kumppanisi on valmis auttamaan sinua keskusteluissa, tehtävissä ja muussa.';
+  String get welcomeToOmiDescription => 'Tervetuloa Omiin! AI-kumppanisi on valmis auttamaan sinua keskusteluissa, tehtävissä ja muussa.';
 
   @override
   String get startUsingOmi => 'Aloita Omin käyttö';
@@ -2701,8 +2661,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get noTasksYet => 'Ei tehtäviä vielä';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Keskusteluistasi tulevat tehtävät näkyvät tässä.\nNapsauta Luo lisätäksesi yhden manuaalisesti.';
+  String get tasksFromConversationsWillAppear => 'Keskusteluistasi tulevat tehtävät näkyvät tässä.\nNapsauta Luo lisätäksesi yhden manuaalisesti.';
 
   @override
   String get monthJan => 'Tammi';
@@ -2834,8 +2793,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get chatPrompt => 'Chat-kehote';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Olet mahtava sovellus, tehtäväsi on vastata käyttäjien kyselyihin ja saada heidät tuntemaan olonsa hyväksi...';
+  String get chatPromptPlaceholder => 'Olet mahtava sovellus, tehtäväsi on vastata käyttäjien kyselyihin ja saada heidät tuntemaan olonsa hyväksi...';
 
   @override
   String get conversationPrompt => 'Keskustelukehote';
@@ -2853,8 +2811,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get makeMyAppPublic => 'Tee sovelluksestani julkinen';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Lähettämällä tämän sovelluksen hyväksyn Omi AI:n käyttöehdot ja tietosuojakäytännön';
+  String get submitAppTermsAgreement => 'Lähettämällä tämän sovelluksen hyväksyn Omi AI:n käyttöehdot ja tietosuojakäytännön';
 
   @override
   String get submitApp => 'Lähetä sovellus';
@@ -2863,19 +2820,16 @@ class AppLocalizationsFi extends AppLocalizations {
   String get needHelpGettingStarted => 'Tarvitsetko apua aloittamiseen?';
 
   @override
-  String get clickHereForAppBuildingGuides =>
-      'Napsauta tästä sovelluksen rakentamisohjeiden ja dokumentaation saamiseksi';
+  String get clickHereForAppBuildingGuides => 'Napsauta tästä sovelluksen rakentamisohjeiden ja dokumentaation saamiseksi';
 
   @override
   String get submitAppQuestion => 'Lähetetäänkö sovellus?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Sovelluksesi tarkistetaan ja julkaistaan. Voit alkaa käyttää sitä heti, jopa tarkistuksen aikana!';
+  String get submitAppPublicDescription => 'Sovelluksesi tarkistetaan ja julkaistaan. Voit alkaa käyttää sitä heti, jopa tarkistuksen aikana!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Sovelluksesi tarkistetaan ja asetetaan saatavillesi yksityisesti. Voit alkaa käyttää sitä heti, jopa tarkistuksen aikana!';
+  String get submitAppPrivateDescription => 'Sovelluksesi tarkistetaan ja asetetaan saatavillesi yksityisesti. Voit alkaa käyttää sitä heti, jopa tarkistuksen aikana!';
 
   @override
   String get startEarning => 'Aloita ansaitseminen! 💰';
@@ -2899,23 +2853,19 @@ class AppLocalizationsFi extends AppLocalizations {
   String get dataAccessNotice => 'Tietojen käyttöilmoitus';
 
   @override
-  String get dataAccessWarning =>
-      'Tämä sovellus käyttää tietojasi. Omi AI ei ole vastuussa siitä, miten tietojasi käytetään, muokataan tai poistetaan tällä sovelluksella';
+  String get dataAccessWarning => 'Tämä sovellus käyttää tietojasi. Omi AI ei ole vastuussa siitä, miten tietojasi käytetään, muokataan tai poistetaan tällä sovelluksella';
 
   @override
   String get installApp => 'Asenna sovellus';
 
   @override
-  String get betaTesterNotice =>
-      'Olet tämän sovelluksen beta-testaaja. Se ei ole vielä julkinen. Se tulee julkiseksi hyväksynnän jälkeen.';
+  String get betaTesterNotice => 'Olet tämän sovelluksen beta-testaaja. Se ei ole vielä julkinen. Se tulee julkiseksi hyväksynnän jälkeen.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Sovelluksesi on tarkistettavana ja näkyvissä vain sinulle. Se tulee julkiseksi hyväksynnän jälkeen.';
+  String get appUnderReviewOwner => 'Sovelluksesi on tarkistettavana ja näkyvissä vain sinulle. Se tulee julkiseksi hyväksynnän jälkeen.';
 
   @override
-  String get appRejectedNotice =>
-      'Sovelluksesi on hylätty. Päivitä sovelluksen tiedot ja lähetä se uudelleen tarkistettavaksi.';
+  String get appRejectedNotice => 'Sovelluksesi on hylätty. Päivitä sovelluksen tiedot ja lähetä se uudelleen tarkistettavaksi.';
 
   @override
   String get setupSteps => 'Asennusvaiheet';
@@ -2977,8 +2927,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get descriptionLabel => 'Kuvaus';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Upea sovellukseni on loistava sovellus, joka tekee hämmästyttäviä asioita. Se on paras sovellus!';
+  String get appDescriptionPlaceholder => 'Upea sovellukseni on loistava sovellus, joka tekee hämmästyttäviä asioita. Se on paras sovellus!';
 
   @override
   String get pleaseProvideValidDescription => 'Anna kelvollinen kuvaus';
@@ -3130,8 +3079,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get microphonePermissionRequired => 'Mikrofonin lupa vaaditaan äänen tallennukseen.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofonin lupa evätty. Anna lupa kohdassa Järjestelmäasetukset > Tietosuoja ja turvallisuus > Mikrofoni.';
+  String get microphonePermissionDenied => 'Mikrofonin lupa evätty. Anna lupa kohdassa Järjestelmäasetukset > Tietosuoja ja turvallisuus > Mikrofoni.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3364,8 +3312,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get whatWeCollect => 'Mitä keräämme';
 
   @override
-  String get dataCollectionMessage =>
-      'Jatkamalla keskustelusi, tallenteet ja henkilötiedot tallennetaan turvallisesti palvelimillemme tarjotaksemme tekoälyavusteisia näkemyksiä ja mahdollistaaksemme kaikki sovelluksen ominaisuudet.';
+  String get dataCollectionMessage => 'Jatkamalla keskustelusi, tallenteet ja henkilötiedot tallennetaan turvallisesti palvelimillemme tarjotaksemme tekoälyavusteisia näkemyksiä ja mahdollistaaksemme kaikki sovelluksen ominaisuudet.';
 
   @override
   String get dataProtection => 'Tietosuoja';
@@ -3398,8 +3345,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Nimen on oltava vähintään 2 merkkiä';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Kerro meille, miten haluaisit, että sinut puhutellaan. Tämä auttaa personoimaan Omi-kokemuksesi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Kerro meille, miten haluaisit, että sinut puhutellaan. Tämä auttaa personoimaan Omi-kokemuksesi.';
 
   @override
   String charactersCount(int count) {
@@ -3407,8 +3353,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Ota käyttöön ominaisuudet parhaan Omi-kokemuksen saamiseksi laitteellasi.';
+  String get enableFeaturesForBestExperience => 'Ota käyttöön ominaisuudet parhaan Omi-kokemuksen saamiseksi laitteellasi.';
 
   @override
   String get microphoneAccess => 'Mikrofonin käyttöoikeus';
@@ -3417,8 +3362,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get recordAudioConversations => 'Tallenna äänikeskusteluja';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi tarvitsee mikrofonin käyttöoikeuden tallentaakseen keskustelusi ja tarjotakseen transkriptioita.';
+  String get microphoneAccessDescription => 'Omi tarvitsee mikrofonin käyttöoikeuden tallentaakseen keskustelusi ja tarjotakseen transkriptioita.';
 
   @override
   String get screenRecording => 'Näytön tallennus';
@@ -3427,8 +3371,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Tallenna järjestelmän ääntä kokouksista';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi tarvitsee näytön tallennusluvan tallentaakseen järjestelmän ääntä selainpohjaisista kokouksistasi.';
+  String get screenRecordingDescription => 'Omi tarvitsee näytön tallennusluvan tallentaakseen järjestelmän ääntä selainpohjaisista kokouksistasi.';
 
   @override
   String get accessibility => 'Esteettömyys';
@@ -3437,8 +3380,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Tunnista selainpohjaiset kokoukset';
 
   @override
-  String get accessibilityDescription =>
-      'Omi tarvitsee esteettömyysluvan tunnistaakseen, milloin liityt Zoom-, Meet- tai Teams-kokouksiin selaimessasi.';
+  String get accessibilityDescription => 'Omi tarvitsee esteettömyysluvan tunnistaakseen, milloin liityt Zoom-, Meet- tai Teams-kokouksiin selaimessasi.';
 
   @override
   String get pleaseWait => 'Odota...';
@@ -3510,8 +3452,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get conversationsExportStarted => 'Keskustelujen vienti aloitettu. Tämä voi kestää muutaman sekunnin, odota.';
 
   @override
-  String get mcpDescription =>
-      'Yhdistääksesi Omin muihin sovelluksiin lukeaksesi, etsiäksesi ja hallitaksesi muistojasi ja keskustelujasi. Luo avain aloittaaksesi.';
+  String get mcpDescription => 'Yhdistääksesi Omin muihin sovelluksiin lukeaksesi, etsiäksesi ja hallitaksesi muistojasi ja keskustelujasi. Luo avain aloittaaksesi.';
 
   @override
   String get apiKeys => 'API-avaimet';
@@ -3552,8 +3493,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Litterointipalvelun diagnostiikkatila';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Ota käyttöön yksityiskohtaiset diagnostiikkaviestit litterointipalvelusta';
+  String get enableDetailedDiagnosticMessages => 'Ota käyttöön yksityiskohtaiset diagnostiikkaviestit litterointipalvelusta';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Luo ja merkitse uudet puhujat automaattisesti';
@@ -3583,8 +3523,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get auto => 'Automaattinen';
 
   @override
-  String get noSummaryForApp =>
-      'Tälle sovellukselle ei ole tiivistelmää. Kokeile toista sovellusta parempien tulosten saamiseksi.';
+  String get noSummaryForApp => 'Tälle sovellukselle ei ole tiivistelmää. Kokeile toista sovellusta parempien tulosten saamiseksi.';
 
   @override
   String get tryAnotherApp => 'Kokeile toista sovellusta';
@@ -3621,8 +3560,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Anna Omin valita paras sovellus automaattisesti';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Haluatko varmasti poistaa tämän keskustelun? Tätä toimintoa ei voi kumota.';
+  String get deleteConversationConfirmation => 'Haluatko varmasti poistaa tämän keskustelun? Tätä toimintoa ei voi kumota.';
 
   @override
   String get conversationDeleted => 'Keskustelu poistettu';
@@ -3670,8 +3608,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Järjestelmän äänitallennus valmistellaan';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Napsauta painiketta tallentaaksesi ääntä live-transkriptioita, AI-oivalluksia ja automaattista tallennusta varten.';
+  String get clickTheButtonToCaptureAudio => 'Napsauta painiketta tallentaaksesi ääntä live-transkriptioita, AI-oivalluksia ja automaattista tallennusta varten.';
 
   @override
   String get reconnecting => 'Yhdistetään uudelleen...';
@@ -3898,8 +3835,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Poistetaanko tietograafi?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Tämä poistaa kaikki johdetut tietograafitiedot. Alkuperäiset muistosi pysyvät turvassa.';
+  String get deleteKnowledgeGraphWarning => 'Tämä poistaa kaikki johdetut tietograafitiedot. Alkuperäiset muistosi pysyvät turvassa.';
 
   @override
   String get connectOmiWithAI => 'Yhdistä Omi AI-avustajiin';
@@ -3941,8 +3877,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Ehdot ja Tietosuojakäytäntö';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Auttaa ongelmien diagnosoinnissa. Poistetaan automaattisesti 3 päivän kuluttua.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Auttaa ongelmien diagnosoinnissa. Poistetaan automaattisesti 3 päivän kuluttua.';
 
   @override
   String get manageYourApp => 'Hallinnoi sovellustasi';
@@ -3957,8 +3892,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get updateAppQuestion => 'Päivitä sovellus?';
 
   @override
-  String get updateAppConfirmation =>
-      'Haluatko varmasti päivittää sovelluksesi? Muutokset näkyvät tiimimme tarkistuksen jälkeen.';
+  String get updateAppConfirmation => 'Haluatko varmasti päivittää sovelluksesi? Muutokset näkyvät tiimimme tarkistuksen jälkeen.';
 
   @override
   String get updateApp => 'Päivitä sovellus';
@@ -3988,8 +3922,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get no => 'Ei';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Tilaus peruutettu onnistuneesti. Se pysyy aktiivisena nykyisen laskutuskauden loppuun.';
+  String get subscriptionCancelledSuccessfully => 'Tilaus peruutettu onnistuneesti. Se pysyy aktiivisena nykyisen laskutuskauden loppuun.';
 
   @override
   String get failedToCancelSubscription => 'Tilauksen peruuttaminen epäonnistui. Yritä uudelleen.';
@@ -4025,8 +3958,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Peruuta tilaus?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Haluatko varmasti peruuttaa tilauksesi? Sinulla on edelleen pääsy nykyisen laskutuskauden loppuun.';
+  String get cancelSubscriptionConfirmation => 'Haluatko varmasti peruuttaa tilauksesi? Sinulla on edelleen pääsy nykyisen laskutuskauden loppuun.';
 
   @override
   String get cancelSubscriptionButton => 'Peruuta tilaus';
@@ -4035,12 +3967,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get cancelling => 'Peruutetaan...';
 
   @override
-  String get betaTesterMessage =>
-      'Olet tämän sovelluksen beta-testaaja. Se ei ole vielä julkinen. Se julkaistaan hyväksynnän jälkeen.';
+  String get betaTesterMessage => 'Olet tämän sovelluksen beta-testaaja. Se ei ole vielä julkinen. Se julkaistaan hyväksynnän jälkeen.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Sovelluksesi on tarkistettavana ja näkyy vain sinulle. Se julkaistaan hyväksynnän jälkeen.';
+  String get appUnderReviewMessage => 'Sovelluksesi on tarkistettavana ja näkyy vain sinulle. Se julkaistaan hyväksynnän jälkeen.';
 
   @override
   String get appRejectedMessage => 'Sovelluksesi on hylätty. Päivitä tiedot ja lähetä uudelleen tarkistettavaksi.';
@@ -4097,8 +4027,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get issueActivatingApp => 'Sovelluksen aktivoinnissa ilmeni ongelma. Yritä uudelleen.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Tämä sovellus käyttää tietojasi. Omi AI ei ole vastuussa siitä, miten tietojasi käytetään, muokataan tai poistetaan tässä sovelluksessa';
+  String get dataAccessNoticeDescription => 'Tämä sovellus käyttää tietojasi. Omi AI ei ole vastuussa siitä, miten tietojasi käytetään, muokataan tai poistetaan tässä sovelluksessa';
 
   @override
   String get copyUrl => 'Kopioi URL';
@@ -4186,8 +4115,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get omiApiKeys => 'Omi API-avaimet';
 
   @override
-  String get apiKeysDescription =>
-      'API-avaimia käytetään todentamiseen, kun sovelluksesi kommunikoi OMI-palvelimen kanssa. Ne mahdollistavat sovelluksesi luoda muistoja ja käyttää muita OMI-palveluita turvallisesti.';
+  String get apiKeysDescription => 'API-avaimia käytetään todentamiseen, kun sovelluksesi kommunikoi OMI-palvelimen kanssa. Ne mahdollistavat sovelluksesi luoda muistoja ja käyttää muita OMI-palveluita turvallisesti.';
 
   @override
   String get aboutOmiApiKeys => 'Tietoja Omi API-avaimista';
@@ -4211,8 +4139,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Peruuta API-avain?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Tätä toimintoa ei voi kumota. Tätä avainta käyttävät sovellukset eivät enää pääse API:in.';
+  String get revokeApiKeyWarning => 'Tätä toimintoa ei voi kumota. Tätä avainta käyttävät sovellukset eivät enää pääse API:in.';
 
   @override
   String get revoke => 'Peruuta';
@@ -4310,8 +4237,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get externalAppAccess => 'Ulkoisten sovellusten käyttöoikeus';
 
   @override
-  String get externalAppAccessDescription =>
-      'Seuraavilla asennetuilla sovelluksilla on ulkoisia integraatioita ja ne voivat käyttää tietojasi, kuten keskusteluja ja muistoja.';
+  String get externalAppAccessDescription => 'Seuraavilla asennetuilla sovelluksilla on ulkoisia integraatioita ja ne voivat käyttää tietojasi, kuten keskusteluja ja muistoja.';
 
   @override
   String get noExternalAppsHaveAccess => 'Ulkoisilla sovelluksilla ei ole pääsyä tietoihisi.';
@@ -4320,15 +4246,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimaalinen turvallisuus (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Päästä päähän -salaus on yksityisyyden kultastandardi. Kun se on käytössä, tietosi salataan laitteellasi ennen kuin ne lähetetään palvelimillemme. Tämä tarkoittaa, että kukaan, ei edes Omi, pääse käsiksi sisältöösi.';
+  String get e2eeDescription => 'Päästä päähän -salaus on yksityisyyden kultastandardi. Kun se on käytössä, tietosi salataan laitteellasi ennen kuin ne lähetetään palvelimillemme. Tämä tarkoittaa, että kukaan, ei edes Omi, pääse käsiksi sisältöösi.';
 
   @override
   String get importantTradeoffs => 'Tärkeät kompromissit:';
 
   @override
-  String get e2eeTradeoff1 =>
-      '• Jotkin ominaisuudet, kuten ulkoisten sovellusten integraatiot, voivat olla pois käytöstä.';
+  String get e2eeTradeoff1 => '• Jotkin ominaisuudet, kuten ulkoisten sovellusten integraatiot, voivat olla pois käytöstä.';
 
   @override
   String get e2eeTradeoff2 => '• Jos kadotat salasanasi, tietojasi ei voi palauttaa.';
@@ -4356,15 +4280,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get secureEncryption => 'Turvallinen salaus';
 
   @override
-  String get secureEncryptionDescription =>
-      'Tietosi salataan sinulle yksilöllisellä avaimella palvelimillamme, jotka ovat Google Cloudissa. Tämä tarkoittaa, että raakatietosi eivät ole kenenkään, mukaan lukien Omin henkilöstön tai Googlen, saatavilla suoraan tietokannasta.';
+  String get secureEncryptionDescription => 'Tietosi salataan sinulle yksilöllisellä avaimella palvelimillamme, jotka ovat Google Cloudissa. Tämä tarkoittaa, että raakatietosi eivät ole kenenkään, mukaan lukien Omin henkilöstön tai Googlen, saatavilla suoraan tietokannasta.';
 
   @override
   String get endToEndEncryption => 'Päästä päähän -salaus';
 
   @override
-  String get e2eeCardDescription =>
-      'Ota käyttöön maksimaalinen turvallisuus, jossa vain sinä pääset käsiksi tietoihisi. Napauta saadaksesi lisätietoja.';
+  String get e2eeCardDescription => 'Ota käyttöön maksimaalinen turvallisuus, jossa vain sinä pääset käsiksi tietoihisi. Napauta saadaksesi lisätietoja.';
 
   @override
   String get dataAlwaysEncrypted => 'Tasosta riippumatta tietosi ovat aina salattuja levossa ja siirrettäessä.';
@@ -4432,12 +4354,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get trainingDataProgram => 'Koulutustietojen ohjelma';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Saat Omi Unlimited -tilauksen ilmaiseksi antamalla tietosi AI-mallien kouluttamiseen.';
+  String get getOmiUnlimitedFree => 'Saat Omi Unlimited -tilauksen ilmaiseksi antamalla tietosi AI-mallien kouluttamiseen.';
 
   @override
-  String get trainingDataBullets =>
-      '• Tietosi auttavat parantamaan AI-malleja\n• Vain ei-arkaluonteiset tiedot jaetaan\n• Täysin läpinäkyvä prosessi';
+  String get trainingDataBullets => '• Tietosi auttavat parantamaan AI-malleja\n• Vain ei-arkaluonteiset tiedot jaetaan\n• Täysin läpinäkyvä prosessi';
 
   @override
   String get learnMoreAtOmiTraining => 'Lue lisää osoitteessa omi.me/training';
@@ -4449,8 +4369,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get submitRequest => 'Lähetä pyyntö';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Kiitos! Pyyntösi on tarkistettavana. Ilmoitamme sinulle hyväksynnän jälkeen.';
+  String get thankYouRequestUnderReview => 'Kiitos! Pyyntösi on tarkistettavana. Ilmoitamme sinulle hyväksynnän jälkeen.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4494,8 +4413,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get annualSubscriptionStarts => '12 kuukauden vuositilauksesi alkaa automaattisesti veloituksen jälkeen';
 
   @override
-  String get thirteenMonthsCoverage =>
-      'Saat yhteensä 13 kuukauden kattavuuden (nykyinen kuukausi + 12 kuukautta vuosittain)';
+  String get thirteenMonthsCoverage => 'Saat yhteensä 13 kuukauden kattavuuden (nykyinen kuukausi + 12 kuukautta vuosittain)';
 
   @override
   String get confirmUpgrade => 'Vahvista päivitys';
@@ -4599,8 +4517,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Yksityisyytesi on meille tärkeä';
 
   @override
-  String get privacyIntroText =>
-      'Omissa otamme yksityisyytesi erittäin vakavasti. Haluamme olla läpinäkyviä keräämistämme tiedoista ja niiden käytöstä. Tässä on mitä sinun tulee tietää:';
+  String get privacyIntroText => 'Omissa otamme yksityisyytesi erittäin vakavasti. Haluamme olla läpinäkyviä keräämistämme tiedoista ja niiden käytöstä. Tässä on mitä sinun tulee tietää:';
 
   @override
   String get whatWeTrack => 'Mitä seuraamme';
@@ -4615,12 +4532,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get ourCommitment => 'Sitoumuksemme';
 
   @override
-  String get commitmentText =>
-      'Olemme sitoutuneet käyttämään keräämiämme tietoja vain Omin parantamiseen sinulle. Yksityisyytesi ja luottamuksesi ovat meille ensiarvoisen tärkeitä.';
+  String get commitmentText => 'Olemme sitoutuneet käyttämään keräämiämme tietoja vain Omin parantamiseen sinulle. Yksityisyytesi ja luottamuksesi ovat meille ensiarvoisen tärkeitä.';
 
   @override
-  String get thankYouText =>
-      'Kiitos, että olet arvokas Omin käyttäjä. Jos sinulla on kysyttävää tai huolenaiheita, ota rohkeasti yhteyttä osoitteeseen team@basedhardware.com.';
+  String get thankYouText => 'Kiitos, että olet arvokas Omin käyttäjä. Jos sinulla on kysyttävää tai huolenaiheita, ota rohkeasti yhteyttä osoitteeseen team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi-synkronointiasetukset';
@@ -4629,8 +4544,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get enterHotspotCredentials => 'Syötä puhelimesi hotspot-tunnukset';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi-synkronointi käyttää puhelintasi hotspotina. Löydä nimi ja salasana kohdasta Asetukset > Oma hotspot.';
+  String get wifiSyncUsesHotspot => 'WiFi-synkronointi käyttää puhelintasi hotspotina. Löydä nimi ja salasana kohdasta Asetukset > Oma hotspot.';
 
   @override
   String get hotspotNameSsid => 'Hotspotin nimi (SSID)';
@@ -4665,8 +4579,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Yhteenvedon luominen epäonnistui. Varmista, että sinulla on keskusteluja kyseiseltä päivältä.';
+  String get failedToGenerateSummaryCheckConversations => 'Yhteenvedon luominen epäonnistui. Varmista, että sinulla on keskusteluja kyseiseltä päivältä.';
 
   @override
   String get summaryNotFound => 'Yhteenvetoa ei löytynyt';
@@ -4696,8 +4609,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Vienti aloitettu. Tämä voi kestää muutaman sekunnin...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Tämä poistaa kaikki johdetut tietograafin tiedot (solmut ja yhteydet). Alkuperäiset muistosi säilyvät turvassa. Graafi rakennetaan uudelleen ajan myötä tai seuraavan pyynnön yhteydessä.';
+  String get knowledgeGraphDeleteDescription => 'Tämä poistaa kaikki johdetut tietograafin tiedot (solmut ja yhteydet). Alkuperäiset muistosi säilyvät turvassa. Graafi rakennetaan uudelleen ajan myötä tai seuraavan pyynnön yhteydessä.';
 
   @override
   String get configureDailySummaryDigest => 'Määritä päivittäinen tehtäväyhteenveto';
@@ -4767,8 +4679,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Poista kaikki Limitless-keskustelut?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Tämä poistaa pysyvästi kaikki Limitlessistä tuodut keskustelut. Tätä toimintoa ei voi kumota.';
+  String get deleteAllLimitlessWarning => 'Tämä poistaa pysyvästi kaikki Limitlessistä tuodut keskustelut. Tätä toimintoa ei voi kumota.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4824,8 +4735,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get howItWorksTitle => 'Miten se toimii?';
 
   @override
-  String get howPeopleWorks =>
-      'Kun henkilö on luotu, voit mennä keskustelun transkriptioon ja määrittää heille vastaavat segmentit, näin Omi voi tunnistaa myös heidän puheensa!';
+  String get howPeopleWorks => 'Kun henkilö on luotu, voit mennä keskustelun transkriptioon ja määrittää heille vastaavat segmentit, näin Omi voi tunnistaa myös heidän puheensa!';
 
   @override
   String get tapToDelete => 'Napauta poistaaksesi';
@@ -4851,8 +4761,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get privacyNotice => 'Tietosuojailmoitus';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Tallenteet voivat tallentaa muiden ääniä. Varmista, että sinulla on kaikkien osallistujien suostumus ennen käyttöönottoa.';
+  String get recordingsMayCaptureOthers => 'Tallenteet voivat tallentaa muiden ääniä. Varmista, että sinulla on kaikkien osallistujien suostumus ennen käyttöönottoa.';
 
   @override
   String get enable => 'Ota käyttöön';
@@ -4864,8 +4773,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Säilytä kaikki äänitallenteet paikallisesti puhelimessasi. Kun pois käytöstä, vain epäonnistuneet lataukset säilytetään tallennustilan säästämiseksi.';
+  String get storeAudioDescription => 'Säilytä kaikki äänitallenteet paikallisesti puhelimessasi. Kun pois käytöstä, vain epäonnistuneet lataukset säilytetään tallennustilan säästämiseksi.';
 
   @override
   String get enableLocalStorage => 'Ota paikallinen tallennustila käyttöön';
@@ -4883,12 +4791,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get storeAudioOnCloud => 'Tallenna ääni pilveen';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Reaaliaikaiset tallenteet tallennetaan yksityiseen pilvitallennustilaan puhuessasi.';
+  String get cloudStorageDialogMessage => 'Reaaliaikaiset tallenteet tallennetaan yksityiseen pilvitallennustilaan puhuessasi.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Tallenna reaaliaikaiset tallenteet yksityiseen pilvitallennustilaan puhuessasi. Ääni tallennetaan turvallisesti reaaliajassa.';
+  String get storeAudioCloudDescription => 'Tallenna reaaliaikaiset tallenteet yksityiseen pilvitallennustilaan puhuessasi. Ääni tallennetaan turvallisesti reaaliajassa.';
 
   @override
   String get downloadingFirmware => 'Ladataan laiteohjelmistoa';
@@ -4941,8 +4847,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get payments => 'Maksut';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Yhdistä maksutapa alla aloittaaksesi maksujen vastaanottamisen sovelluksistasi.';
+  String get connectPaymentMethodInfo => 'Yhdistä maksutapa alla aloittaaksesi maksujen vastaanottamisen sovelluksistasi.';
 
   @override
   String get selectedPaymentMethod => 'Valittu maksutapa';
@@ -4996,8 +4901,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get connectingYourStripeAccount => 'Stripe-tilisi yhdistäminen';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Suorita Stripe-käyttöönottoprosessi selaimessasi. Tämä sivu päivittyy automaattisesti, kun prosessi on valmis.';
+  String get stripeOnboardingInstructions => 'Suorita Stripe-käyttöönottoprosessi selaimessasi. Tämä sivu päivittyy automaattisesti, kun prosessi on valmis.';
 
   @override
   String get failedTryAgain => 'Epäonnistui? Yritä uudelleen';
@@ -5009,8 +4913,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get successfullyConnected => 'Yhdistetty onnistuneesti!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Stripe-tilisi on nyt valmis vastaanottamaan maksuja. Voit alkaa ansaita sovellustesi myynnistä heti.';
+  String get stripeReadyForPayments => 'Stripe-tilisi on nyt valmis vastaanottamaan maksuja. Voit alkaa ansaita sovellustesi myynnistä heti.';
 
   @override
   String get updateStripeDetails => 'Päivitä Stripe-tiedot';
@@ -5028,8 +4931,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Päivitä PayPal-tilisi tiedot';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Yhdistä PayPal-tilisi aloittaaksesi maksujen vastaanottamisen sovelluksistasi';
+  String get connectPayPalToReceivePayments => 'Yhdistä PayPal-tilisi aloittaaksesi maksujen vastaanottamisen sovelluksistasi';
 
   @override
   String get paypalEmail => 'PayPal-sähköposti';
@@ -5038,8 +4940,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me-linkki';
 
   @override
-  String get stripeRecommendation =>
-      'Jos Stripe on saatavilla maassasi, suosittelemme vahvasti sen käyttöä nopeampien ja helpompien maksujen saamiseksi.';
+  String get stripeRecommendation => 'Jos Stripe on saatavilla maassasi, suosittelemme vahvasti sen käyttöä nopeampien ja helpompien maksujen saamiseksi.';
 
   @override
   String get updatePayPalDetails => 'Päivitä PayPal-tiedot';
@@ -5091,12 +4992,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Lisäpuhenäyte poistettu';
 
   @override
-  String get consentDataMessage =>
-      'Jatkamalla keskustelusi, tallenteet ja henkilötietosi tallennetaan turvallisesti palvelimillemme. Äänitallenteitasi ja transkriptioitasi käsittelevät kolmannen osapuolen tekoälypalvelut (mukaan lukien Deepgram transkriptiota ja OpenAI analyysiä varten) tarjotaksemme sinulle tekoälypohjaisia oivalluksia ja mahdollistaaksemme kaikki sovelluksen ominaisuudet.';
+  String get consentDataMessage => 'Jatkamalla keskustelusi, tallenteet ja henkilötietosi tallennetaan turvallisesti palvelimillemme. Äänitallenteitasi ja transkriptioitasi käsittelevät kolmannen osapuolen tekoälypalvelut (mukaan lukien Deepgram transkriptiota ja OpenAI analyysiä varten) tarjotaksemme sinulle tekoälypohjaisia oivalluksia ja mahdollistaaksemme kaikki sovelluksen ominaisuudet.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Keskusteluistasi saadut tehtävät näkyvät täällä.\nNapauta + luodaksesi manuaalisesti.';
+  String get tasksEmptyStateMessage => 'Keskusteluistasi saadut tehtävät näkyvät täällä.\nNapauta + luodaksesi manuaalisesti.';
 
   @override
   String get clearChatAction => 'Tyhjennä keskustelu';
@@ -5132,15 +5031,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Asenna Omi\nApple Watchiin';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Käyttääksesi Apple Watchia Omin kanssa, sinun on ensin asennettava Omi-sovellus kelloosi.';
+  String get installOmiOnAppleWatchDescription => 'Käyttääksesi Apple Watchia Omin kanssa, sinun on ensin asennettava Omi-sovellus kelloosi.';
 
   @override
   String get openOmiOnAppleWatch => 'Avaa Omi\nApple Watchissa';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi-sovellus on asennettu Apple Watchiin. Avaa se ja napauta Aloita aloittaaksesi.';
+  String get openOmiOnAppleWatchDescription => 'Omi-sovellus on asennettu Apple Watchiin. Avaa se ja napauta Aloita aloittaaksesi.';
 
   @override
   String get openWatchApp => 'Avaa Watch-sovellus';
@@ -5149,15 +5046,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Olen asentanut ja avannut sovelluksen';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch -sovellusta ei voi avata. Avaa Watch-sovellus manuaalisesti Apple Watchissa ja asenna Omi \"Saatavilla olevat sovellukset\" -osiosta.';
+  String get unableToOpenWatchApp => 'Apple Watch -sovellusta ei voi avata. Avaa Watch-sovellus manuaalisesti Apple Watchissa ja asenna Omi \"Saatavilla olevat sovellukset\" -osiosta.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch yhdistetty!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch ei ole vielä tavoitettavissa. Varmista, että Omi-sovellus on auki kellossasi.';
+  String get appleWatchNotReachable => 'Apple Watch ei ole vielä tavoitettavissa. Varmista, että Omi-sovellus on auki kellossasi.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5174,8 +5069,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get finishedConversation => 'Keskustelu päättynyt?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Haluatko varmasti lopettaa nauhoituksen ja tehdä yhteenvedon keskustelusta nyt?';
+  String get stopRecordingConfirmation => 'Haluatko varmasti lopettaa nauhoituksen ja tehdä yhteenvedon keskustelusta nyt?';
 
   @override
   String get conversationEndsManually => 'Keskustelu päättyy vain manuaalisesti.';
@@ -5586,8 +5480,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get multipleSpeakersDetected => 'Useita puhujia havaittu';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Näyttää siltä, että nauhoituksessa on useita puhujia. Varmista, että olet hiljaisessa paikassa ja yritä uudelleen.';
+  String get multipleSpeakersDescription => 'Näyttää siltä, että nauhoituksessa on useita puhujia. Varmista, että olet hiljaisessa paikassa ja yritä uudelleen.';
 
   @override
   String get invalidRecordingDetected => 'Virheellinen nauhoitus havaittu';
@@ -5605,8 +5498,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get howToTakeGoodSample => 'Miten ottaa hyvä näyte?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Varmista, että olet hiljaisessa paikassa.\n2. Puhu selkeästi ja luonnollisesti.\n3. Varmista, että laitteesi on luonnollisessa asennossaan kaulallasi.\n\nKun se on luotu, voit aina parantaa sitä tai tehdä sen uudelleen.';
+  String get goodSampleInstructions => '1. Varmista, että olet hiljaisessa paikassa.\n2. Puhu selkeästi ja luonnollisesti.\n3. Varmista, että laitteesi on luonnollisessa asennossaan kaulallasi.\n\nKun se on luotu, voit aina parantaa sitä tai tehdä sen uudelleen.';
 
   @override
   String get noDeviceConnectedUseMic => 'Laitetta ei ole yhdistetty. Käytetään puhelimen mikrofonia.';
@@ -5669,12 +5561,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get howItWorks => 'Miten se toimii';
 
   @override
-  String get dailyScoreExplanation =>
-      'Päivittäinen pistemääräsi perustuu tehtävien suorittamiseen. Suorita tehtäväsi parantaaksesi pistemäärääsi!';
+  String get dailyScoreExplanation => 'Päivittäinen pistemääräsi perustuu tehtävien suorittamiseen. Suorita tehtäväsi parantaaksesi pistemäärääsi!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Hallitse kuinka usein Omi lähettää sinulle proaktiivisia ilmoituksia ja muistutuksia.';
+  String get notificationFrequencyDescription => 'Hallitse kuinka usein Omi lähettää sinulle proaktiivisia ilmoituksia ja muistutuksia.';
 
   @override
   String get sliderOff => 'Pois';
@@ -5688,8 +5578,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Yhteenvedon luominen epäonnistui. Varmista, että sinulla on keskusteluja kyseiseltä päivältä.';
+  String get failedToGenerateSummary => 'Yhteenvedon luominen epäonnistui. Varmista, että sinulla on keskusteluja kyseiseltä päivältä.';
 
   @override
   String get recap => 'Kertaus';
@@ -5920,8 +5809,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get recordings => 'Nauhoitukset';
 
   @override
-  String get enableRemindersAccess =>
-      'Ota käyttöön muistutusten käyttöoikeus asetuksissa käyttääksesi Apple Muistutuksia';
+  String get enableRemindersAccess => 'Ota käyttöön muistutusten käyttöoikeus asetuksissa käyttääksesi Apple Muistutuksia';
 
   @override
   String todayAtTime(String time) {
@@ -6050,15 +5938,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get cloudProvider => 'Pilvipalveluntarjoaja';
 
   @override
-  String get premiumMinutesInfo =>
-      '1 200 premium-minuuttia/kk. Laitteella-välilehti tarjoaa rajattoman ilmaisen puheentunnistuksen.';
+  String get premiumMinutesInfo => '1 200 premium-minuuttia/kk. Laitteella-välilehti tarjoaa rajattoman ilmaisen puheentunnistuksen.';
 
   @override
   String get viewUsage => 'Näytä käyttö';
 
   @override
-  String get localProcessingInfo =>
-      'Ääni käsitellään paikallisesti. Toimii offline-tilassa, yksityisempi, mutta kuluttaa enemmän akkua.';
+  String get localProcessingInfo => 'Ääni käsitellään paikallisesti. Toimii offline-tilassa, yksityisempi, mutta kuluttaa enemmän akkua.';
 
   @override
   String get model => 'Malli';
@@ -6067,15 +5953,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get performanceWarning => 'Suorituskykyvaroitus';
 
   @override
-  String get largeModelWarning =>
-      'Tämä malli on suuri ja saattaa kaataa sovelluksen tai toimia erittäin hitaasti mobiililaitteilla.\n\n\"small\" tai \"base\" on suositeltu.';
+  String get largeModelWarning => 'Tämä malli on suuri ja saattaa kaataa sovelluksen tai toimia erittäin hitaasti mobiililaitteilla.\n\n\"small\" tai \"base\" on suositeltu.';
 
   @override
   String get usingNativeIosSpeech => 'Käytetään iOS:n natiivia puheentunnistusta';
 
   @override
-  String get noModelDownloadRequired =>
-      'Laitteesi natiivi puheentunnistusmoottori on käytössä. Mallin lataus ei ole tarpeen.';
+  String get noModelDownloadRequired => 'Laitteesi natiivi puheentunnistusmoottori on käytössä. Mallin lataus ei ole tarpeen.';
 
   @override
   String get modelReady => 'Malli valmis';
@@ -6132,12 +6016,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get batteryDrainSignificantly => 'Akun kulutus kasvaa merkittävästi.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1 200 premium-minuuttia/kk. Laitteella-välilehti tarjoaa rajoittamattoman ilmaisen transkription. ';
+  String get premiumMinutesMonth => '1 200 premium-minuuttia/kk. Laitteella-välilehti tarjoaa rajoittamattoman ilmaisen transkription. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Ääni käsitellään paikallisesti. Toimii offline, yksityisempi, mutta kuluttaa enemmän akkua.';
+  String get audioProcessedLocally => 'Ääni käsitellään paikallisesti. Toimii offline, yksityisempi, mutta kuluttaa enemmän akkua.';
 
   @override
   String get languageLabel => 'Kieli';
@@ -6146,8 +6028,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get modelLabel => 'Malli';
 
   @override
-  String get modelTooLargeWarning =>
-      'Tämä malli on suuri ja voi aiheuttaa sovelluksen kaatumisen tai erittäin hitaan toiminnan mobiililaitteissa.\n\nSuositellaan small tai base.';
+  String get modelTooLargeWarning => 'Tämä malli on suuri ja voi aiheuttaa sovelluksen kaatumisen tai erittäin hitaan toiminnan mobiililaitteissa.\n\nSuositellaan small tai base.';
 
   @override
   String get nativeEngineNoDownload => 'Käytetään laitteesi natiivia puhe-moottoria. Mallin latausta ei tarvita.';
@@ -6186,8 +6067,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omin sisäänrakennettu live-transkriptio on optimoitu reaaliaikaisiin keskusteluihin automaattisella puhujan tunnistuksella ja diarisaatiolla.';
+  String get omiTranscriptionOptimized => 'Omin sisäänrakennettu live-transkriptio on optimoitu reaaliaikaisiin keskusteluihin automaattisella puhujan tunnistuksella ja diarisaatiolla.';
 
   @override
   String get reset => 'Nollaa';
@@ -6407,8 +6287,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Rakennetaan tietograafia muistoista...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Tietograafisi rakennetaan automaattisesti, kun luot uusia muistoja.';
+  String get knowledgeGraphWillBuildAutomatically => 'Tietograafisi rakennetaan automaattisesti, kun luot uusia muistoja.';
 
   @override
   String get buildGraphButton => 'Rakenna graafi';
@@ -6644,8 +6523,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get failedToLoadContacts => 'Yhteystietojen lataaminen epäonnistui';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Keskustelun valmistelu jakamista varten epäonnistui. Yritä uudelleen.';
+  String get failedToPrepareConversationForSharing => 'Keskustelun valmistelu jakamista varten epäonnistui. Yritä uudelleen.';
 
   @override
   String get couldNotOpenSmsApp => 'SMS-sovellusta ei voitu avata. Yritä uudelleen.';
@@ -6711,8 +6589,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Ladataan ääntä laitteesi SD-kortilta';
 
   @override
-  String get transferRequiredDescription =>
-      'Tämä nauhoitus on tallennettu laitteesi SD-kortille. Siirrä se puhelimeesi toistaaksesi tai jakaaksesi.';
+  String get transferRequiredDescription => 'Tämä nauhoitus on tallennettu laitteesi SD-kortille. Siirrä se puhelimeesi toistaaksesi tai jakaaksesi.';
 
   @override
   String get cancelTransfer => 'Peruuta siirto';
@@ -6733,8 +6610,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get shareRecording => 'Jaa nauhoitus';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Haluatko varmasti poistaa tämän nauhoituksen pysyvästi? Tätä ei voi perua.';
+  String get deleteRecordingConfirmation => 'Haluatko varmasti poistaa tämän nauhoituksen pysyvästi? Tätä ei voi perua.';
 
   @override
   String get recordingIdLabel => 'Nauhoituksen tunnus';
@@ -6793,8 +6669,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get enableFastTransfer => 'Ota nopea siirto käyttöön';
 
   @override
-  String get fastTransferDescription =>
-      'Nopea siirto käyttää WiFiä ~5x nopeampiin nopeuksiin. Puhelimesi yhdistää tilapäisesti Omi-laitteesi WiFi-verkkoon siirron aikana.';
+  String get fastTransferDescription => 'Nopea siirto käyttää WiFiä ~5x nopeampiin nopeuksiin. Puhelimesi yhdistää tilapäisesti Omi-laitteesi WiFi-verkkoon siirron aikana.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Internet-yhteys keskeytetään siirron ajaksi';
@@ -6809,8 +6684,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fiveTimesFaster => '5X NOPEAMPI';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Luo suoran WiFi-yhteyden Omi-laitteeseesi. Puhelimesi katkeaa tilapäisesti tavallisesta WiFistä siirron aikana.';
+  String get fastTransferMethodDescription => 'Luo suoran WiFi-yhteyden Omi-laitteeseesi. Puhelimesi katkeaa tilapäisesti tavallisesta WiFistä siirron aikana.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6819,8 +6693,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get bleSpeed => '~30 KB/s BLE:n kautta';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Käyttää tavallista Bluetooth Low Energy -yhteyttä. Hitaampi, mutta ei vaikuta WiFi-yhteyteen.';
+  String get bluetoothMethodDescription => 'Käyttää tavallista Bluetooth Low Energy -yhteyttä. Hitaampi, mutta ei vaikuta WiFi-yhteyteen.';
 
   @override
   String get selected => 'Valittu';
@@ -6858,12 +6731,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get appDeleteFailed => 'Sovelluksen poistaminen epäonnistui. Yritä myöhemmin uudelleen.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Sovelluksen näkyvyys muutettu onnistuneesti. Muutos voi näkyä muutaman minuutin kuluttua.';
+  String get appVisibilityChangedSuccessfully => 'Sovelluksen näkyvyys muutettu onnistuneesti. Muutos voi näkyä muutaman minuutin kuluttua.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Virhe sovelluksen aktivoinnissa. Jos kyseessä on integrointisovellus, varmista, että asennus on valmis.';
+  String get errorActivatingAppIntegration => 'Virhe sovelluksen aktivoinnissa. Jos kyseessä on integrointisovellus, varmista, että asennus on valmis.';
 
   @override
   String get errorUpdatingAppStatus => 'Sovelluksen tilan päivittämisessä tapahtui virhe.';
@@ -7130,15 +7001,13 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade scheduled! Your monthly plan continues until the end of your billing period, then automatically switches to annual.';
+  String get planUpgradeScheduledMessage => 'Upgrade scheduled! Your monthly plan continues until the end of your billing period, then automatically switches to annual.';
 
   @override
   String get couldNotSchedulePlanChange => 'Paketin vaihtoa ei voitu ajoittaa. Yritä uudelleen.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Tilauksesi on aktivoitu uudelleen! Ei veloitusta nyt - sinut laskutetaan nykyisen jakson lopussa.';
+  String get subscriptionReactivatedDefault => 'Tilauksesi on aktivoitu uudelleen! Ei veloitusta nyt - sinut laskutetaan nykyisen jakson lopussa.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Tilaus onnistui! Sinut on veloitettu uudesta laskutusjaksosta.';
@@ -7337,8 +7206,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get onboardingNotificationDeniedSystemPrefs => 'Ilmoituslupa evätty. Myönnä lupa Järjestelmäasetuksissa.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Ilmoituslupa evätty. Myönnä lupa kohdassa Järjestelmäasetukset > Ilmoitukset.';
+  String get onboardingNotificationDeniedNotifications => 'Ilmoituslupa evätty. Myönnä lupa kohdassa Järjestelmäasetukset > Ilmoitukset.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7351,15 +7219,13 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Myönnä sijaintilupa kohdassa Asetukset > Tietosuoja ja turvallisuus > Sijaintipalvelut';
+  String get onboardingLocationGrantInSettings => 'Myönnä sijaintilupa kohdassa Asetukset > Tietosuoja ja turvallisuus > Sijaintipalvelut';
 
   @override
   String get onboardingMicrophoneRequired => 'Mikrofonilupa vaaditaan tallennukseen.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofonilupa evätty. Myönnä lupa kohdassa Järjestelmäasetukset > Tietosuoja ja turvallisuus > Mikrofoni.';
+  String get onboardingMicrophoneDenied => 'Mikrofonilupa evätty. Myönnä lupa kohdassa Järjestelmäasetukset > Tietosuoja ja turvallisuus > Mikrofoni.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7375,8 +7241,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Näytönkaappauslupa vaaditaan järjestelmä-äänen tallennukseen.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Näytönkaappauslupa evätty. Myönnä lupa kohdassa Järjestelmäasetukset > Tietosuoja ja turvallisuus > Näytön tallennus.';
+  String get onboardingScreenCaptureDenied => 'Näytönkaappauslupa evätty. Myönnä lupa kohdassa Järjestelmäasetukset > Tietosuoja ja turvallisuus > Näytön tallennus.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7501,8 +7366,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get locationPermissionRequired => 'Sijaintilupa vaaditaan';
 
   @override
-  String get locationPermissionContent =>
-      'Nopea siirto vaatii sijaintiluvan WiFi-yhteyden tarkistamiseksi. Myönnä sijaintilupa jatkaaksesi.';
+  String get locationPermissionContent => 'Nopea siirto vaatii sijaintiluvan WiFi-yhteyden tarkistamiseksi. Myönnä sijaintilupa jatkaaksesi.';
 
   @override
   String get pdfTranscriptExport => 'Litteraation vienti';
@@ -7961,8 +7825,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Aseta Omi DevKit pariliitostilaan';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Paina painiketta kerran käynnistääksesi. LED vilkkuu violettina pariliitostilassa.';
+  String get pairingDescOmiDevkit => 'Paina painiketta kerran käynnistääksesi. LED vilkkuu violettina pariliitostilassa.';
 
   @override
   String get pairingTitleOmiGlass => 'Käynnistä Omi Glass';
@@ -7974,8 +7837,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Aseta Plaud Note pariliitostilaan';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Pidä sivupainiketta painettuna 2 sekuntia. Punainen LED vilkkuu, kun se on valmis pariliitokseen.';
+  String get pairingDescPlaudNote => 'Pidä sivupainiketta painettuna 2 sekuntia. Punainen LED vilkkuu, kun se on valmis pariliitokseen.';
 
   @override
   String get pairingTitleBee => 'Aseta Bee pariliitostilaan';
@@ -7987,15 +7849,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get pairingTitleLimitless => 'Aseta Limitless pariliitostilaan';
 
   @override
-  String get pairingDescLimitless =>
-      'Kun mikä tahansa valo on näkyvissä, paina kerran ja paina sitten pitkään, kunnes laite näyttää vaaleanpunaista valoa, vapauta sitten.';
+  String get pairingDescLimitless => 'Kun mikä tahansa valo on näkyvissä, paina kerran ja paina sitten pitkään, kunnes laite näyttää vaaleanpunaista valoa, vapauta sitten.';
 
   @override
   String get pairingTitleFriendPendant => 'Aseta Friend Pendant pariliitostilaan';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Paina riipuksen painiketta käynnistääksesi sen. Se siirtyy automaattisesti pariliitostilaan.';
+  String get pairingDescFriendPendant => 'Paina riipuksen painiketta käynnistääksesi sen. Se siirtyy automaattisesti pariliitostilaan.';
 
   @override
   String get pairingTitleFieldy => 'Aseta Fieldy pariliitostilaan';
@@ -8007,8 +7867,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Yhdistä Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Asenna ja avaa Omi-sovellus Apple Watchissasi, napauta sitten Yhdistä sovelluksessa.';
+  String get pairingDescAppleWatch => 'Asenna ja avaa Omi-sovellus Apple Watchissasi, napauta sitten Yhdistä sovelluksessa.';
 
   @override
   String get pairingTitleNeoOne => 'Aseta Neo One pariliitostilaan';
@@ -8131,12 +7990,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get switchAndRestart => 'Vaihda';
 
   @override
-  String get stagingDisclaimer =>
-      'Testiympäristö voi olla epävakaa, suorituskyky voi vaihdella ja tietoja voi kadota. Vain testausta varten.';
+  String get stagingDisclaimer => 'Testiympäristö voi olla epävakaa, suorituskyky voi vaihdella ja tietoja voi kadota. Vain testausta varten.';
 
   @override
-  String get apiEnvSavedRestartRequired =>
-      'Tallennettu. Sulje ja avaa sovellus uudelleen, jotta muutokset tulevat voimaan.';
+  String get apiEnvSavedRestartRequired => 'Tallennettu. Sulje ja avaa sovellus uudelleen, jotta muutokset tulevat voimaan.';
 
   @override
   String get shared => 'Jaettu';
@@ -8362,8 +8219,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Puhelut Omin kautta';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Soita puheluita Omin kautta ja saa reaaliaikainen litterointi, automaattiset yhteenvedot ja paljon muuta.';
+  String get phoneCallsUpsellSubtitle => 'Soita puheluita Omin kautta ja saa reaaliaikainen litterointi, automaattiset yhteenvedot ja paljon muuta.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Jokaisen puhelun reaaliaikainen litterointi';
@@ -8402,8 +8258,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deletePendingFiles => 'Poista odottavat tallenteet';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Näitä tallenteita EI ole synkronoitu puhelimeesi ja ne menetetään pysyvästi. Tätä ei voi kumota.';
+  String get deletePendingFilesWarning => 'Näitä tallenteita EI ole synkronoitu puhelimeesi ja ne menetetään pysyvästi. Tätä ei voi kumota.';
 
   @override
   String get pendingFilesDeleted => 'Odottavat tallenteet poistettu';
@@ -8415,8 +8270,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deleteAll => 'Poista kaikki';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Tämä poistaa synkronoidut ja odottavat tallenteet. Odottavia tallenteita EI ole synkronoitu ja ne menetetään pysyvästi.';
+  String get deleteAllFilesWarning => 'Tämä poistaa synkronoidut ja odottavat tallenteet. Odottavia tallenteita EI ole synkronoitu ja ne menetetään pysyvästi.';
 
   @override
   String get allFilesDeleted => 'Kaikki tallenteet poistettu';
@@ -8481,8 +8335,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fairUseAboutTitle => 'Tietoa kohtuullisesta käytöstä';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi on suunniteltu henkilökohtaisiin keskusteluihin, kokouksiin ja reaaliaikaiseen vuorovaikutukseen. Käyttöä mitataan havaitun todellisen puheajan, ei yhteysajan perusteella. Jos käyttö ylittää merkittävästi normaalit mallit ei-henkilökohtaisen sisällön osalta, säätöjä voidaan soveltaa.';
+  String get fairUseAboutBody => 'Omi on suunniteltu henkilökohtaisiin keskusteluihin, kokouksiin ja reaaliaikaiseen vuorovaikutukseen. Käyttöä mitataan havaitun todellisen puheajan, ei yhteysajan perusteella. Jos käyttö ylittää merkittävästi normaalit mallit ei-henkilökohtaisen sisällön osalta, säätöjä voidaan soveltaa.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8520,8 +8373,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get improveConnectionTitle => 'Paranna yhteyttä';
 
   @override
-  String get improveConnectionContent =>
-      'Olemme parantaneet Omin yhteydenpitoa laitteeseesi. Aktivoidaksesi tämän, siirry Laitteen tiedot -sivulle, napauta \"Katkaise laitteen yhteys\" ja yhdistä laitteesi uudelleen.';
+  String get improveConnectionContent => 'Olemme parantaneet Omin yhteydenpitoa laitteeseesi. Aktivoidaksesi tämän, siirry Laitteen tiedot -sivulle, napauta \"Katkaise laitteen yhteys\" ja yhdistä laitteesi uudelleen.';
 
   @override
   String get improveConnectionAction => 'Selvä';
@@ -8576,16 +8428,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get cancelSyncQuestion => 'Peruuta synkronointi?';
 
   @override
-  String get omisStorageDesc =>
-      'Kun Omi ei ole yhdistetty puhelimeesi, se tallentaa äänen paikallisesti sisäiseen muistiinsa. Et koskaan menetä nauhoitusta.';
+  String get omisStorageDesc => 'Kun Omi ei ole yhdistetty puhelimeesi, se tallentaa äänen paikallisesti sisäiseen muistiinsa. Et koskaan menetä nauhoitusta.';
 
   @override
-  String get phoneStorageDesc =>
-      'Kun Omi yhdistyy uudelleen, nauhoitukset siirretään automaattisesti puhelimeesi ennen palvelimelle lataamista.';
+  String get phoneStorageDesc => 'Kun Omi yhdistyy uudelleen, nauhoitukset siirretään automaattisesti puhelimeesi ennen palvelimelle lataamista.';
 
   @override
-  String get cloudStorageDesc =>
-      'Lataamisen jälkeen nauhoituksesi käsitellään ja litteroidaan. Keskustelut ovat saatavilla minuutin kuluessa.';
+  String get cloudStorageDesc => 'Lataamisen jälkeen nauhoituksesi käsitellään ja litteroidaan. Keskustelut ovat saatavilla minuutin kuluessa.';
 
   @override
   String get tipKeepPhoneNearby => 'Pidä puhelin lähellä nopeampaa synkronointia varten';
@@ -8609,12 +8458,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get permissionEnable => 'Ota käyttöön';
 
   @override
-  String get permissionsPageDescription =>
-      'Nämä käyttöoikeudet ovat keskeisiä Omin toiminnalle. Ne mahdollistavat keskeiset ominaisuudet kuten ilmoitukset, sijaintiin perustuvat kokemukset ja äänen tallennuksen.';
+  String get permissionsPageDescription => 'Nämä käyttöoikeudet ovat keskeisiä Omin toiminnalle. Ne mahdollistavat keskeiset ominaisuudet kuten ilmoitukset, sijaintiin perustuvat kokemukset ja äänen tallennuksen.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi tarvitsee muutamia käyttöoikeuksia toimiakseen oikein. Myönnä ne jatkaaksesi.';
+  String get permissionsRequiredDescription => 'Omi tarvitsee muutamia käyttöoikeuksia toimiakseen oikein. Myönnä ne jatkaaksesi.';
 
   @override
   String get permissionsSetupTitle => 'Saat parhaan kokemuksen';
@@ -8668,8 +8515,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get justAMoment => 'Hetkinen';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Suosittelemme vahvasti tutustumaan muihin vaihtoehtoihisi peruutuksen sijaan.';
+  String get cancelConsequencesSubtitle => 'Suosittelemme vahvasti tutustumaan muihin vaihtoehtoihisi peruutuksen sijaan.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8892,8 +8738,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get firmwareWarningTitle => 'Tärkeää: Lue ennen päivitystä';
 
   @override
-  String get firmwareFormatWarning =>
-      'Tämä laiteohjelmisto alustaa SD-kortin. Varmista, että kaikki offline-tiedot on synkronoitu ennen päivitystä.\n\nJos näet vilkkuvan punaisen valon tämän version asentamisen jälkeen, älä huoli. Yhdistä laite sovellukseen ja sen pitäisi muuttua siniseksi. Punainen valo tarkoittaa, että laitteen kelloa ei ole vielä synkronoitu.';
+  String get firmwareFormatWarning => 'Tämä laiteohjelmisto alustaa SD-kortin. Varmista, että kaikki offline-tiedot on synkronoitu ennen päivitystä.\n\nJos näet vilkkuvan punaisen valon tämän version asentamisen jälkeen, älä huoli. Yhdistä laite sovellukseen ja sen pitäisi muuttua siniseksi. Punainen valo tarkoittaa, että laitteen kelloa ei ole vielä synkronoitu.';
 
   @override
   String get continueAnyway => 'Jatka';
@@ -8913,8 +8758,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get tasksMarkComplete => 'Merkitty valmiiksi';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi käyttää Apple Healthia Applen HealthKit-kehyksen kautta. Voit perua käyttöoikeuden milloin tahansa iOS-asetuksista.';
+  String get appleHealthManageNote => 'Omi käyttää Apple Healthia Applen HealthKit-kehyksen kautta. Voit perua käyttöoikeuden milloin tahansa iOS-asetuksista.';
 
   @override
   String get appleHealthConnectCta => 'Yhdistä Apple Healthiin';
@@ -8947,8 +8791,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health -käyttöoikeus evätty';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omilla ei ole oikeutta lukea Apple Health -tietojasi. Ota se käyttöön: iOS-asetukset → Yksityisyys ja turvallisuus → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omilla ei ole oikeutta lukea Apple Health -tietojasi. Ota se käyttöön: iOS-asetukset → Yksityisyys ja turvallisuus → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Miksi lähdet?';
@@ -9017,8 +8860,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get planUpdate => 'Tilauksen päivitys';
 
   @override
-  String get planDeprecationMessage =>
-      'Unlimited-tilauksesi poistetaan käytöstä. Vaihda Operator-tilaukseen — samat loistavat ominaisuudet hintaan \$49/kk. Nykyinen tilauksesi jatkaa toimintaansa sillä välin.';
+  String get planDeprecationMessage => 'Unlimited-tilauksesi poistetaan käytöstä. Vaihda Operator-tilaukseen — samat loistavat ominaisuudet hintaan \$49/kk. Nykyinen tilauksesi jatkaa toimintaansa sillä välin.';
 
   @override
   String get upgradeYourPlan => 'Päivitä tilauksesi';
@@ -9129,8 +8971,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Olet saavuttanut kuukausittaisen rajasi. Päivitä jatkaaksesi keskustelua Omin kanssa ilman rajoituksia.';
+  String get chatQuotaExceededReply => 'Olet saavuttanut kuukausittaisen rajasi. Päivitä jatkaaksesi keskustelua Omin kanssa ilman rajoituksia.';
 
   @override
   String get voiceResponseAudio => 'Lue Omin vastaus ääneen';
@@ -9161,4 +9002,25 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Lisää tehtävä';
+
+  @override
+  String get quickActionAskOmiAnything => 'Kysy Omilta mitä tahansa';
+
+  @override
+  String get quickActionVoiceMode => 'Äänitila';
+
+  @override
+  String get quickActionMute => 'Mykistä';
+
+  @override
+  String get quickActionUnmute => 'Poista mykistys';
+
+  @override
+  String get quickActionConnectDevice => 'Yhdistä laite';
+
+  @override
+  String get quickActionDeviceSettings => 'Laiteasetukset';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -24,8 +24,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteConversationTitle => 'Supprimer la conversation ?';
 
   @override
-  String get deleteConversationMessage =>
-      'Cela supprimera également les souvenirs, tâches et fichiers audio associés. Cette action est irréversible.';
+  String get deleteConversationMessage => 'Cela supprimera également les souvenirs, tâches et fichiers audio associés. Cette action est irréversible.';
 
   @override
   String get confirm => 'Confirmer';
@@ -82,8 +81,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get conversationUrlNotShared => 'L\'URL de la conversation n\'a pas pu être partagée.';
 
   @override
-  String get errorProcessingConversation =>
-      'Erreur lors du traitement de la conversation. Veuillez réessayer plus tard.';
+  String get errorProcessingConversation => 'Erreur lors du traitement de la conversation. Veuillez réessayer plus tard.';
 
   @override
   String get noInternetConnection => 'Aucune connexion Internet';
@@ -147,8 +145,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleting => 'Suppression...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
+  String get pleaseCompleteAuthentication => 'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
 
   @override
   String get failedToStartAuthentication => 'Échec du démarrage de l\'authentification';
@@ -229,8 +226,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noStarredConversations => 'Aucune conversation favorite';
 
   @override
-  String get starConversationHint =>
-      'Pour marquer une conversation comme favorite, ouvrez-la et appuyez sur l\'icône étoile dans l\'en-tête.';
+  String get starConversationHint => 'Pour marquer une conversation comme favorite, ouvrez-la et appuyez sur l\'icône étoile dans l\'en-tête.';
 
   @override
   String get searchConversations => 'Rechercher des conversations...';
@@ -321,8 +317,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get installedApps => 'Applications installées';
 
   @override
-  String get unableToFetchApps =>
-      'Impossible de récupérer les applications :(\n\nVeuillez vérifier votre connexion internet et réessayer.';
+  String get unableToFetchApps => 'Impossible de récupérer les applications :(\n\nVeuillez vérifier votre connexion internet et réessayer.';
 
   @override
   String get aboutOmi => 'À propos d\'Omi';
@@ -358,19 +353,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appsDisconnected => 'Vos applications et intégrations seront déconnectées immédiatement.';
 
   @override
-  String get exportBeforeDelete =>
-      'Vous pouvez exporter vos données avant de supprimer votre compte, mais une fois supprimé, il ne pourra pas être récupéré.';
+  String get exportBeforeDelete => 'Vous pouvez exporter vos données avant de supprimer votre compte, mais une fois supprimé, il ne pourra pas être récupéré.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Je comprends que la suppression de mon compte est permanente et que toutes les données, y compris les mémoires et conversations, seront perdues et ne pourront pas être récupérées.';
+  String get deleteAccountCheckbox => 'Je comprends que la suppression de mon compte est permanente et que toutes les données, y compris les mémoires et conversations, seront perdues et ne pourront pas être récupérées.';
 
   @override
   String get areYouSure => 'Êtes-vous sûr ?';
 
   @override
-  String get deleteAccountFinal =>
-      'Cette action est irréversible et supprimera définitivement votre compte et toutes les données associées. Êtes-vous sûr de vouloir continuer ?';
+  String get deleteAccountFinal => 'Cette action est irréversible et supprimera définitivement votre compte et toutes les données associées. Êtes-vous sûr de vouloir continuer ?';
 
   @override
   String get deleteNow => 'Supprimer maintenant';
@@ -379,8 +371,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get goBack => 'Retour';
 
   @override
-  String get checkBoxToConfirm =>
-      'Cochez la case pour confirmer que vous comprenez que la suppression de votre compte est permanente et irréversible.';
+  String get checkBoxToConfirm => 'Cochez la case pour confirmer que vous comprenez que la suppression de votre compte est permanente et irréversible.';
 
   @override
   String get profile => 'Profil';
@@ -458,8 +449,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get yourPrivacyYourControl => 'Votre vie privée, votre contrôle';
 
   @override
-  String get privacyIntro =>
-      'Chez Omi, nous nous engageons à protéger votre vie privée. Cette page vous permet de contrôler la façon dont vos données sont stockées et utilisées.';
+  String get privacyIntro => 'Chez Omi, nous nous engageons à protéger votre vie privée. Cette page vous permet de contrôler la façon dont vos données sont stockées et utilisées.';
 
   @override
   String get learnMore => 'En savoir plus...';
@@ -468,15 +458,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dataProtectionLevel => 'Niveau de protection des données';
 
   @override
-  String get dataProtectionDesc =>
-      'Vos données sont sécurisées par défaut avec un cryptage fort. Vérifiez vos paramètres et les futures options de confidentialité ci-dessous.';
+  String get dataProtectionDesc => 'Vos données sont sécurisées par défaut avec un cryptage fort. Vérifiez vos paramètres et les futures options de confidentialité ci-dessous.';
 
   @override
   String get appAccess => 'Accès des applications';
 
   @override
-  String get appAccessDesc =>
-      'Les applications suivantes peuvent accéder à vos données. Appuyez sur une application pour gérer ses autorisations.';
+  String get appAccessDesc => 'Les applications suivantes peuvent accéder à vos données. Appuyez sur une application pour gérer ses autorisations.';
 
   @override
   String get noAppsExternalAccess => 'Aucune application installée n\'a d\'accès externe à vos données.';
@@ -533,22 +521,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Votre Omi a été déconnecté 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Appareil dissocié. Allez dans Paramètres > Bluetooth et oubliez l\'appareil pour terminer la dissociation.';
+  String get deviceUnpairedMessage => 'Appareil dissocié. Allez dans Paramètres > Bluetooth et oubliez l\'appareil pour terminer la dissociation.';
 
   @override
   String get unpairDialogTitle => 'Dissocier l\'appareil';
 
   @override
-  String get unpairDialogMessage =>
-      'Cela dissociera l\'appareil afin qu\'il puisse être connecté à un autre téléphone. Vous devrez aller dans Réglages > Bluetooth et oublier l\'appareil pour terminer le processus.';
+  String get unpairDialogMessage => 'Cela dissociera l\'appareil afin qu\'il puisse être connecté à un autre téléphone. Vous devrez aller dans Réglages > Bluetooth et oublier l\'appareil pour terminer le processus.';
 
   @override
   String get deviceNotConnected => 'Appareil non connecté';
 
   @override
-  String get connectDeviceMessage =>
-      'Connectez votre appareil Omi pour accéder aux\nparamètres et à la personnalisation de l\'appareil';
+  String get connectDeviceMessage => 'Connectez votre appareil Omi pour accéder aux\nparamètres et à la personnalisation de l\'appareil';
 
   @override
   String get deviceInfoSection => 'Informations sur l\'appareil';
@@ -563,8 +548,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get v2Undetected => 'V2 non détecté';
 
   @override
-  String get v2UndetectedMessage =>
-      'Nous voyons que vous avez soit un appareil V1, soit votre appareil n\'est pas connecté. La fonctionnalité carte SD n\'est disponible que pour les appareils V2.';
+  String get v2UndetectedMessage => 'Nous voyons que vous avez soit un appareil V1, soit votre appareil n\'est pas connecté. La fonctionnalité carte SD n\'est disponible que pour les appareils V2.';
 
   @override
   String get endConversation => 'Terminer la conversation';
@@ -696,8 +680,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noActivityYet => 'Pas encore d\'activité';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Commencez une conversation avec Omi\npour voir vos statistiques d\'utilisation ici.';
+  String get startConversationToSeeInsights => 'Commencez une conversation avec Omi\npour voir vos statistiques d\'utilisation ici.';
 
   @override
   String get listening => 'Écoute';
@@ -839,8 +822,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Supprimer le graphe de connaissances ?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Cela supprimera toutes les données du graphe de connaissances dérivées (nœuds et connexions). Vos mémoires originales resteront intactes. Le graphe sera reconstruit au fil du temps ou lors de la prochaine demande.';
+  String get deleteKnowledgeGraphMessage => 'Cela supprimera toutes les données du graphe de connaissances dérivées (nœuds et connexions). Vos mémoires originales resteront intactes. Le graphe sera reconstruit au fil du temps ou lors de la prochaine demande.';
 
   @override
   String get knowledgeGraphDeleted => 'Graphe de connaissances supprimé';
@@ -988,8 +970,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shortConversationThreshold => 'Seuil de conversation courte';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Les conversations plus courtes que cela seront masquées sauf si activé ci-dessus';
+  String get shortConversationThresholdSubtitle => 'Les conversations plus courtes que cela seront masquées sauf si activé ci-dessus';
 
   @override
   String get durationThreshold => 'Seuil de durée';
@@ -1021,12 +1002,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get comingSoon => 'Bientôt disponible';
 
   @override
-  String get integrationsFooter =>
-      'Connectez vos applications pour afficher les données et les métriques dans le chat.';
+  String get integrationsFooter => 'Connectez vos applications pour afficher les données et les métriques dans le chat.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
+  String get completeAuthInBrowser => 'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1086,37 +1065,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get needYourPermission => 'Nous avons besoin de votre permission';
 
   @override
-  String get alreadyGavePermission =>
-      'Vous nous avez déjà donné la permission d\'enregistrer vos enregistrements. Voici un rappel de pourquoi nous en avons besoin :';
+  String get alreadyGavePermission => 'Vous nous avez déjà donné la permission d\'enregistrer vos enregistrements. Voici un rappel de pourquoi nous en avons besoin :';
 
   @override
-  String get wouldLikePermission =>
-      'Nous aimerions avoir votre permission pour sauvegarder vos enregistrements vocaux. Voici pourquoi :';
+  String get wouldLikePermission => 'Nous aimerions avoir votre permission pour sauvegarder vos enregistrements vocaux. Voici pourquoi :';
 
   @override
   String get improveSpeechProfile => 'Améliorer votre profil vocal';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Nous utilisons les enregistrements pour entraîner et améliorer davantage votre profil vocal personnel.';
+  String get improveSpeechProfileDesc => 'Nous utilisons les enregistrements pour entraîner et améliorer davantage votre profil vocal personnel.';
 
   @override
   String get trainFamilyProfiles => 'Entraîner des profils pour les amis et la famille';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Vos enregistrements nous aident à reconnaître et créer des profils pour vos amis et votre famille.';
+  String get trainFamilyProfilesDesc => 'Vos enregistrements nous aident à reconnaître et créer des profils pour vos amis et votre famille.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Améliorer la précision de la transcription';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'À mesure que notre modèle s\'améliore, nous pouvons fournir de meilleurs résultats de transcription pour vos enregistrements.';
+  String get enhanceTranscriptAccuracyDesc => 'À mesure que notre modèle s\'améliore, nous pouvons fournir de meilleurs résultats de transcription pour vos enregistrements.';
 
   @override
-  String get legalNotice =>
-      'Avis juridique : La légalité de l\'enregistrement et du stockage des données vocales peut varier selon votre emplacement et la façon dont vous utilisez cette fonctionnalité. Il est de votre responsabilité de vous assurer de la conformité aux lois et réglementations locales.';
+  String get legalNotice => 'Avis juridique : La légalité de l\'enregistrement et du stockage des données vocales peut varier selon votre emplacement et la façon dont vous utilisez cette fonctionnalité. Il est de votre responsabilité de vous assurer de la conformité aux lois et réglementations locales.';
 
   @override
   String get alreadyAuthorized => 'Déjà autorisé';
@@ -1146,8 +1119,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get permissionRevokedTitle => 'Permission révoquée';
 
   @override
-  String get permissionRevokedMessage =>
-      'Voulez-vous que nous supprimions également tous vos enregistrements existants ?';
+  String get permissionRevokedMessage => 'Voulez-vous que nous supprimions également tous vos enregistrements existants ?';
 
   @override
   String get yes => 'Oui';
@@ -1189,15 +1161,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showMeetingsMenuBar => 'Afficher les réunions à venir dans la barre de menus';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Afficher votre prochaine réunion et le temps restant avant son début dans la barre de menus macOS';
+  String get showMeetingsMenuBarDesc => 'Afficher votre prochaine réunion et le temps restant avant son début dans la barre de menus macOS';
 
   @override
   String get showEventsNoParticipants => 'Afficher les événements sans participants';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Lorsque activé, À venir affiche les événements sans participants ou lien vidéo.';
+  String get showEventsNoParticipantsDesc => 'Lorsque activé, À venir affiche les événements sans participants ou lien vidéo.';
 
   @override
   String get yourMeetings => 'Vos réunions';
@@ -1238,8 +1208,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noProjectsInWorkspace => 'Aucun projet trouvé dans cet espace de travail';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Choisissez combien de temps attendre en silence avant de terminer automatiquement une conversation :';
+  String get conversationTimeoutDesc => 'Choisissez combien de temps attendre en silence avant de terminer automatiquement une conversation :';
 
   @override
   String get timeout2Minutes => '2 minutes';
@@ -1283,12 +1252,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Dites-nous votre langue principale';
 
   @override
-  String get languageForTranscription =>
-      'Définissez votre langue pour des transcriptions plus précises et une expérience personnalisée.';
+  String get languageForTranscription => 'Définissez votre langue pour des transcriptions plus précises et une expérience personnalisée.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Le mode langue unique est activé. La traduction est désactivée pour une meilleure précision.';
+  String get singleLanguageModeInfo => 'Le mode langue unique est activé. La traduction est désactivée pour une meilleure précision.';
 
   @override
   String get searchLanguageHint => 'Rechercher une langue par nom ou code';
@@ -1368,8 +1335,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get defaultRepository => 'Dépôt par défaut';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Sélectionnez un dépôt par défaut pour créer des issues. Vous pouvez toujours spécifier un autre dépôt lors de la création d\'issues.';
+  String get selectDefaultRepoDesc => 'Sélectionnez un dépôt par défaut pour créer des issues. Vous pouvez toujours spécifier un autre dépôt lors de la création d\'issues.';
 
   @override
   String get noReposFound => 'Aucun dépôt trouvé';
@@ -1416,8 +1382,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get configureSettings => 'Configurer les paramètres';
 
   @override
-  String get completeAuthBrowser =>
-      'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
+  String get completeAuthBrowser => 'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1745,8 +1710,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get enableBluetooth => 'Activer le Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi a besoin du Bluetooth pour se connecter à votre wearable. Veuillez activer le Bluetooth et réessayer.';
+  String get bluetoothNeeded => 'Omi a besoin du Bluetooth pour se connecter à votre wearable. Veuillez activer le Bluetooth et réessayer.';
 
   @override
   String get contactSupport => 'Contacter le support ?';
@@ -1779,26 +1743,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get locationServiceDisabled => 'Service de localisation désactivé';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Le service de localisation est désactivé. Veuillez aller dans Réglages > Confidentialité et sécurité > Services de localisation et l\'activer';
+  String get locationServiceDisabledDesc => 'Le service de localisation est désactivé. Veuillez aller dans Réglages > Confidentialité et sécurité > Services de localisation et l\'activer';
 
   @override
   String get backgroundLocationDenied => 'Accès à la localisation en arrière-plan refusé';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Veuillez aller dans les paramètres de l\'appareil et définir l\'autorisation de localisation sur « Toujours autoriser »';
+  String get backgroundLocationDeniedDesc => 'Veuillez aller dans les paramètres de l\'appareil et définir l\'autorisation de localisation sur « Toujours autoriser »';
 
   @override
   String get lovingOmi => 'Vous aimez Omi ?';
 
   @override
-  String get leaveReviewIos =>
-      'Aidez-nous à atteindre plus de personnes en laissant un avis sur l\'App Store. Votre retour compte énormément pour nous !';
+  String get leaveReviewIos => 'Aidez-nous à atteindre plus de personnes en laissant un avis sur l\'App Store. Votre retour compte énormément pour nous !';
 
   @override
-  String get leaveReviewAndroid =>
-      'Aidez-nous à atteindre plus de personnes en laissant un avis sur le Google Play Store. Votre retour compte énormément pour nous !';
+  String get leaveReviewAndroid => 'Aidez-nous à atteindre plus de personnes en laissant un avis sur le Google Play Store. Votre retour compte énormément pour nous !';
 
   @override
   String get rateOnAppStore => 'Noter sur l\'App Store';
@@ -1810,8 +1770,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get maybeLater => 'Peut-être plus tard';
 
   @override
-  String get speechProfileIntro =>
-      'Omi doit apprendre vos objectifs et votre voix. Vous pourrez le modifier plus tard.';
+  String get speechProfileIntro => 'Omi doit apprendre vos objectifs et votre voix. Vous pourrez le modifier plus tard.';
 
   @override
   String get getStarted => 'Commencer';
@@ -1832,15 +1791,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get connectionError => 'Erreur de connexion';
 
   @override
-  String get connectionErrorDesc =>
-      'Échec de la connexion au serveur. Veuillez vérifier votre connexion internet et réessayer.';
+  String get connectionErrorDesc => 'Échec de la connexion au serveur. Veuillez vérifier votre connexion internet et réessayer.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Enregistrement invalide détecté';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Il semble y avoir plusieurs locuteurs dans l\'enregistrement. Veuillez vous assurer d\'être dans un endroit calme et réessayer.';
+  String get multipleSpeakersDesc => 'Il semble y avoir plusieurs locuteurs dans l\'enregistrement. Veuillez vous assurer d\'être dans un endroit calme et réessayer.';
 
   @override
   String get tooShortDesc => 'Pas assez de parole détectée. Veuillez parler davantage et réessayer.';
@@ -1852,15 +1809,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get areYouThere => 'Êtes-vous là ?';
 
   @override
-  String get noSpeechDesc =>
-      'Nous n\'avons pas pu détecter de parole. Veuillez vous assurer de parler pendant au moins 10 secondes et pas plus de 3 minutes.';
+  String get noSpeechDesc => 'Nous n\'avons pas pu détecter de parole. Veuillez vous assurer de parler pendant au moins 10 secondes et pas plus de 3 minutes.';
 
   @override
   String get connectionLost => 'Connexion perdue';
 
   @override
-  String get connectionLostDesc =>
-      'La connexion a été interrompue. Veuillez vérifier votre connexion internet et réessayer.';
+  String get connectionLostDesc => 'La connexion a été interrompue. Veuillez vérifier votre connexion internet et réessayer.';
 
   @override
   String get tryAgain => 'Réessayer';
@@ -1875,8 +1830,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get permissionsRequired => 'Autorisations requises';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Cette application a besoin des autorisations Bluetooth et Localisation pour fonctionner correctement. Veuillez les activer dans les paramètres.';
+  String get permissionsRequiredDesc => 'Cette application a besoin des autorisations Bluetooth et Localisation pour fonctionner correctement. Veuillez les activer dans les paramètres.';
 
   @override
   String get openSettings => 'Ouvrir les paramètres';
@@ -1906,8 +1860,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Votre compagnon IA';
 
   @override
-  String get captureEveryMoment =>
-      'Capturez chaque moment. Obtenez des résumés\nalimentés par l\'IA. Ne prenez plus jamais de notes.';
+  String get captureEveryMoment => 'Capturez chaque moment. Obtenez des résumés\nalimentés par l\'IA. Ne prenez plus jamais de notes.';
 
   @override
   String get appleWatchSetup => 'Configuration Apple Watch';
@@ -1919,12 +1872,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get microphonePermission => 'Permission du microphone';
 
   @override
-  String get permissionGrantedNow =>
-      'Permission accordée ! Maintenant :\n\nOuvrez l\'application Omi sur votre montre et appuyez sur « Continuer » ci-dessous';
+  String get permissionGrantedNow => 'Permission accordée ! Maintenant :\n\nOuvrez l\'application Omi sur votre montre et appuyez sur « Continuer » ci-dessous';
 
   @override
-  String get needMicrophonePermission =>
-      'Nous avons besoin de la permission du microphone.\n\n1. Appuyez sur « Accorder la permission »\n2. Autorisez sur votre iPhone\n3. L\'application de la montre se fermera\n4. Rouvrez et appuyez sur « Continuer »';
+  String get needMicrophonePermission => 'Nous avons besoin de la permission du microphone.\n\n1. Appuyez sur « Accorder la permission »\n2. Autorisez sur votre iPhone\n3. L\'application de la montre se fermera\n4. Rouvrez et appuyez sur « Continuer »';
 
   @override
   String get grantPermissionButton => 'Accorder la permission';
@@ -1933,15 +1884,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get needHelp => 'Besoin d\'aide ?';
 
   @override
-  String get troubleshootingSteps =>
-      'Dépannage :\n\n1. Assurez-vous qu\'Omi est installé sur votre montre\n2. Ouvrez l\'application Omi sur votre montre\n3. Recherchez la fenêtre de permission\n4. Appuyez sur « Autoriser » lorsque demandé\n5. L\'application sur votre montre se fermera - rouvrez-la\n6. Revenez et appuyez sur « Continuer » sur votre iPhone';
+  String get troubleshootingSteps => 'Dépannage :\n\n1. Assurez-vous qu\'Omi est installé sur votre montre\n2. Ouvrez l\'application Omi sur votre montre\n3. Recherchez la fenêtre de permission\n4. Appuyez sur « Autoriser » lorsque demandé\n5. L\'application sur votre montre se fermera - rouvrez-la\n6. Revenez et appuyez sur « Continuer » sur votre iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Enregistrement démarré avec succès !';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Permission non encore accordée. Veuillez vous assurer d\'avoir autorisé l\'accès au microphone et rouvert l\'application sur votre montre.';
+  String get permissionNotGrantedYet => 'Permission non encore accordée. Veuillez vous assurer d\'avoir autorisé l\'accès au microphone et rouvert l\'application sur votre montre.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1957,8 +1906,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get selectPrimaryLanguage => 'Sélectionnez votre langue principale';
 
   @override
-  String get languageBenefits =>
-      'Définissez votre langue pour des transcriptions plus précises et une expérience personnalisée';
+  String get languageBenefits => 'Définissez votre langue pour des transcriptions plus précises et une expérience personnalisée';
 
   @override
   String get whatsYourPrimaryLanguage => 'Quelle est votre langue principale ?';
@@ -1967,15 +1915,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get selectYourLanguage => 'Sélectionnez votre langue';
 
   @override
-  String get personalGrowthJourney =>
-      'Votre parcours de croissance personnelle avec une IA qui écoute chacun de vos mots.';
+  String get personalGrowthJourney => 'Votre parcours de croissance personnelle avec une IA qui écoute chacun de vos mots.';
 
   @override
   String get actionItemsTitle => 'À faire';
 
   @override
-  String get actionItemsDescription =>
-      'Appuyez pour modifier • Appui long pour sélectionner • Glissez pour les actions';
+  String get actionItemsDescription => 'Appuyez pour modifier • Appui long pour sélectionner • Glissez pour les actions';
 
   @override
   String get tabToDo => 'À faire';
@@ -2041,8 +1987,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Prêt pour les actions';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Votre IA extraira automatiquement les tâches et les choses à faire de vos conversations. Elles apparaîtront ici une fois créées.';
+  String get welcomeActionItemsDescription => 'Votre IA extraira automatiquement les tâches et les choses à faire de vos conversations. Elles apparaîtront ici une fois créées.';
 
   @override
   String get autoExtractionFeature => 'Extraites automatiquement des conversations';
@@ -2092,8 +2037,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get clearMemoryTitle => 'Effacer la mémoire d\'Omi';
 
   @override
-  String get clearMemoryMessage =>
-      'Êtes-vous sûr de vouloir effacer la mémoire d\'Omi ? Cette action est irréversible.';
+  String get clearMemoryMessage => 'Êtes-vous sûr de vouloir effacer la mémoire d\'Omi ? Cette action est irréversible.';
 
   @override
   String get clearMemoryButton => 'Effacer la mémoire';
@@ -2239,15 +2183,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'VOIX ET TRANSCRIPTION';
 
   @override
-  String get languageSettingsHelperText =>
-      'La langue de l\'application modifie les menus et les boutons. La langue vocale affecte la transcription de vos enregistrements.';
+  String get languageSettingsHelperText => 'La langue de l\'application modifie les menus et les boutons. La langue vocale affecte la transcription de vos enregistrements.';
 
   @override
   String get translationNotice => 'Avis de traduction';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi traduit les conversations dans votre langue principale. Mettez-la à jour à tout moment dans Paramètres → Profils.';
+  String get translationNoticeMessage => 'Omi traduit les conversations dans votre langue principale. Mettez-la à jour à tout moment dans Paramètres → Profils.';
 
   @override
   String get pleaseCheckInternetConnection => 'Veuillez vérifier votre connexion Internet et réessayer';
@@ -2267,8 +2209,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Cette conversation ne peut pas être fusionnée (verrouillée ou déjà en cours de fusion)';
+  String get conversationCannotBeMerged => 'Cette conversation ne peut pas être fusionnée (verrouillée ou déjà en cours de fusion)';
 
   @override
   String get pleaseEnterFolderName => 'Veuillez saisir un nom de dossier';
@@ -2403,8 +2344,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Dissocier l\'appareil';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Cela dissociera l\'appareil pour qu\'il puisse être connecté à un autre téléphone. Vous devrez aller dans Paramètres > Bluetooth et oublier l\'appareil pour terminer le processus.';
+  String get unpairDeviceDialogMessage => 'Cela dissociera l\'appareil pour qu\'il puisse être connecté à un autre téléphone. Vous devrez aller dans Paramètres > Bluetooth et oublier l\'appareil pour terminer le processus.';
 
   @override
   String get unpair => 'Dissocier';
@@ -2570,8 +2510,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get howDoesItWork => 'Comment ça marche ?';
 
   @override
-  String get sdCardSyncDescription =>
-      'La synchronisation de la carte SD importera vos souvenirs de la carte SD vers l\'application';
+  String get sdCardSyncDescription => 'La synchronisation de la carte SD importera vos souvenirs de la carte SD vers l\'application';
 
   @override
   String get checksForAudioFiles => 'Vérifie les fichiers audio sur la carte SD';
@@ -2586,8 +2525,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get youreAllSet => 'Vous êtes prêt !';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Bienvenue sur Omi ! Votre compagnon IA est prêt à vous aider avec les conversations, les tâches et plus encore.';
+  String get welcomeToOmiDescription => 'Bienvenue sur Omi ! Votre compagnon IA est prêt à vous aider avec les conversations, les tâches et plus encore.';
 
   @override
   String get startUsingOmi => 'Commencer à utiliser Omi';
@@ -2666,8 +2604,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get reviewAndManageConversations => 'Consultez et gérez vos conversations capturées';
 
   @override
-  String get startCapturingConversations =>
-      'Commencez à capturer des conversations avec votre appareil Omi pour les voir ici.';
+  String get startCapturingConversations => 'Commencez à capturer des conversations avec votre appareil Omi pour les voir ici.';
 
   @override
   String get useMobileAppToCapture => 'Utilisez votre application mobile pour capturer de l\'audio';
@@ -2682,8 +2619,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showAll => 'Tout afficher →';
 
   @override
-  String get noTasksForToday =>
-      'Aucune tâche pour aujourd\'hui.\nDemandez à Omi plus de tâches ou créez-les manuellement.';
+  String get noTasksForToday => 'Aucune tâche pour aujourd\'hui.\nDemandez à Omi plus de tâches ou créez-les manuellement.';
 
   @override
   String get dailyScore => 'SCORE QUOTIDIEN';
@@ -2725,8 +2661,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noTasksYet => 'Aucune tâche pour l\'instant';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Les tâches de vos conversations apparaîtront ici.\nCliquez sur Créer pour en ajouter une manuellement.';
+  String get tasksFromConversationsWillAppear => 'Les tâches de vos conversations apparaîtront ici.\nCliquez sur Créer pour en ajouter une manuellement.';
 
   @override
   String get monthJan => 'Jan';
@@ -2783,8 +2718,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteActionItem => 'Supprimer la tâche';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Êtes-vous sûr de vouloir supprimer cette tâche ? Cette action ne peut pas être annulée.';
+  String get deleteActionItemConfirmation => 'Êtes-vous sûr de vouloir supprimer cette tâche ? Cette action ne peut pas être annulée.';
 
   @override
   String get enterActionItemDescription => 'Entrez la description de la tâche...';
@@ -2859,15 +2793,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chatPrompt => 'Invite de chat';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Vous êtes une application géniale, votre travail consiste à répondre aux questions des utilisateurs et à les faire se sentir bien...';
+  String get chatPromptPlaceholder => 'Vous êtes une application géniale, votre travail consiste à répondre aux questions des utilisateurs et à les faire se sentir bien...';
 
   @override
   String get conversationPrompt => 'Invite de conversation';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Vous êtes une application géniale, vous recevrez une transcription et un résumé d\'une conversation...';
+  String get conversationPromptPlaceholder => 'Vous êtes une application géniale, vous recevrez une transcription et un résumé d\'une conversation...';
 
   @override
   String get notificationScopes => 'Portées de notification';
@@ -2879,8 +2811,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get makeMyAppPublic => 'Rendre mon application publique';
 
   @override
-  String get submitAppTermsAgreement =>
-      'En soumettant cette application, j\'accepte les Conditions d\'utilisation et la Politique de confidentialité d\'Omi AI';
+  String get submitAppTermsAgreement => 'En soumettant cette application, j\'accepte les Conditions d\'utilisation et la Politique de confidentialité d\'Omi AI';
 
   @override
   String get submitApp => 'Soumettre l\'application';
@@ -2889,19 +2820,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get needHelpGettingStarted => 'Besoin d\'aide pour commencer ?';
 
   @override
-  String get clickHereForAppBuildingGuides =>
-      'Cliquez ici pour les guides de création d\'applications et la documentation';
+  String get clickHereForAppBuildingGuides => 'Cliquez ici pour les guides de création d\'applications et la documentation';
 
   @override
   String get submitAppQuestion => 'Soumettre l\'application ?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Votre application sera examinée et rendue publique. Vous pouvez commencer à l\'utiliser immédiatement, même pendant l\'examen !';
+  String get submitAppPublicDescription => 'Votre application sera examinée et rendue publique. Vous pouvez commencer à l\'utiliser immédiatement, même pendant l\'examen !';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Votre application sera examinée et mise à votre disposition en privé. Vous pouvez commencer à l\'utiliser immédiatement, même pendant l\'examen !';
+  String get submitAppPrivateDescription => 'Votre application sera examinée et mise à votre disposition en privé. Vous pouvez commencer à l\'utiliser immédiatement, même pendant l\'examen !';
 
   @override
   String get startEarning => 'Commencez à gagner ! 💰';
@@ -2925,23 +2853,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dataAccessNotice => 'Avis d\'accès aux données';
 
   @override
-  String get dataAccessWarning =>
-      'Cette application accédera à vos données. Omi AI n\'est pas responsable de la manière dont vos données sont utilisées, modifiées ou supprimées par cette application';
+  String get dataAccessWarning => 'Cette application accédera à vos données. Omi AI n\'est pas responsable de la manière dont vos données sont utilisées, modifiées ou supprimées par cette application';
 
   @override
   String get installApp => 'Installer l\'application';
 
   @override
-  String get betaTesterNotice =>
-      'Vous êtes un testeur bêta pour cette application. Elle n\'est pas encore publique. Elle sera publique une fois approuvée.';
+  String get betaTesterNotice => 'Vous êtes un testeur bêta pour cette application. Elle n\'est pas encore publique. Elle sera publique une fois approuvée.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Votre application est en cours de révision et visible uniquement pour vous. Elle sera publique une fois approuvée.';
+  String get appUnderReviewOwner => 'Votre application est en cours de révision et visible uniquement pour vous. Elle sera publique une fois approuvée.';
 
   @override
-  String get appRejectedNotice =>
-      'Votre application a été rejetée. Veuillez mettre à jour les détails de l\'application et la soumettre à nouveau pour révision.';
+  String get appRejectedNotice => 'Votre application a été rejetée. Veuillez mettre à jour les détails de l\'application et la soumettre à nouveau pour révision.';
 
   @override
   String get setupSteps => 'Étapes de configuration';
@@ -2976,8 +2900,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get errorActivatingApp => 'Erreur lors de l\'activation de l\'application';
 
   @override
-  String get integrationSetupRequired =>
-      'S\'il s\'agit d\'une application d\'intégration, assurez-vous que la configuration est terminée.';
+  String get integrationSetupRequired => 'S\'il s\'agit d\'une application d\'intégration, assurez-vous que la configuration est terminée.';
 
   @override
   String get installed => 'Installé';
@@ -3004,8 +2927,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get descriptionLabel => 'Description';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Mon application géniale est une application formidable qui fait des choses incroyables. C\'est la meilleure application !';
+  String get appDescriptionPlaceholder => 'Mon application géniale est une application formidable qui fait des choses incroyables. C\'est la meilleure application !';
 
   @override
   String get pleaseProvideValidDescription => 'Veuillez fournir une description valide';
@@ -3157,8 +3079,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get microphonePermissionRequired => 'L\'autorisation du microphone est requise pour l\'enregistrement vocal.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Autorisation du microphone refusée. Veuillez accorder l\'autorisation dans Préférences Système > Confidentialité et sécurité > Microphone.';
+  String get microphonePermissionDenied => 'Autorisation du microphone refusée. Veuillez accorder l\'autorisation dans Préférences Système > Confidentialité et sécurité > Microphone.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3240,8 +3161,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tryAdjustingSearchTerms => 'Essayez d\'ajuster vos termes de recherche';
 
   @override
-  String get starConversationsToFindQuickly =>
-      'Ajoutez des conversations aux favoris pour les retrouver rapidement ici';
+  String get starConversationsToFindQuickly => 'Ajoutez des conversations aux favoris pour les retrouver rapidement ici';
 
   @override
   String noConversationsOnDate(String date) {
@@ -3318,8 +3238,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get createMemory => 'Créer un souvenir';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Êtes-vous sûr de vouloir supprimer ce souvenir? Cette action ne peut pas être annulée.';
+  String get deleteMemoryConfirmation => 'Êtes-vous sûr de vouloir supprimer ce souvenir? Cette action ne peut pas être annulée.';
 
   @override
   String get makePrivate => 'Rendre privé';
@@ -3393,8 +3312,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get whatWeCollect => 'Ce que nous collectons';
 
   @override
-  String get dataCollectionMessage =>
-      'En continuant, vos conversations, enregistrements et informations personnelles seront stockés en toute sécurité sur nos serveurs pour fournir des informations alimentées par l\'IA et activer toutes les fonctionnalités de l\'application.';
+  String get dataCollectionMessage => 'En continuant, vos conversations, enregistrements et informations personnelles seront stockés en toute sécurité sur nos serveurs pour fournir des informations alimentées par l\'IA et activer toutes les fonctionnalités de l\'application.';
 
   @override
   String get dataProtection => 'Protection des données';
@@ -3409,8 +3327,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chooseYourLanguage => 'Choisissez votre langue';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'Sélectionnez votre langue préférée pour la meilleure expérience Omi';
+  String get selectPreferredLanguageForBestExperience => 'Sélectionnez votre langue préférée pour la meilleure expérience Omi';
 
   @override
   String get searchLanguages => 'Rechercher des langues...';
@@ -3428,8 +3345,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Le nom doit comporter au moins 2 caractères';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Dites-nous comment vous souhaitez être appelé. Cela aide à personnaliser votre expérience Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Dites-nous comment vous souhaitez être appelé. Cela aide à personnaliser votre expérience Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3437,8 +3353,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Activez les fonctionnalités pour la meilleure expérience Omi sur votre appareil.';
+  String get enableFeaturesForBestExperience => 'Activez les fonctionnalités pour la meilleure expérience Omi sur votre appareil.';
 
   @override
   String get microphoneAccess => 'Accès au microphone';
@@ -3447,8 +3362,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get recordAudioConversations => 'Enregistrer les conversations audio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi a besoin d\'un accès au microphone pour enregistrer vos conversations et fournir des transcriptions.';
+  String get microphoneAccessDescription => 'Omi a besoin d\'un accès au microphone pour enregistrer vos conversations et fournir des transcriptions.';
 
   @override
   String get screenRecording => 'Enregistrement d\'écran';
@@ -3457,8 +3371,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Capturer l\'audio système des réunions';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi a besoin de l\'autorisation d\'enregistrement d\'écran pour capturer l\'audio système de vos réunions basées sur le navigateur.';
+  String get screenRecordingDescription => 'Omi a besoin de l\'autorisation d\'enregistrement d\'écran pour capturer l\'audio système de vos réunions basées sur le navigateur.';
 
   @override
   String get accessibility => 'Accessibilité';
@@ -3467,8 +3380,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Détecter les réunions basées sur le navigateur';
 
   @override
-  String get accessibilityDescription =>
-      'Omi a besoin de l\'autorisation d\'accessibilité pour détecter quand vous rejoignez des réunions Zoom, Meet ou Teams dans votre navigateur.';
+  String get accessibilityDescription => 'Omi a besoin de l\'autorisation d\'accessibilité pour détecter quand vous rejoignez des réunions Zoom, Meet ou Teams dans votre navigateur.';
 
   @override
   String get pleaseWait => 'Veuillez patienter...';
@@ -3537,12 +3449,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get exportAllConversationsToJson => 'Exportez toutes vos conversations dans un fichier JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Exportation des conversations démarrée. Cela peut prendre quelques secondes, veuillez patienter.';
+  String get conversationsExportStarted => 'Exportation des conversations démarrée. Cela peut prendre quelques secondes, veuillez patienter.';
 
   @override
-  String get mcpDescription =>
-      'Pour connecter Omi à d\'autres applications pour lire, rechercher et gérer vos souvenirs et conversations. Créez une clé pour commencer.';
+  String get mcpDescription => 'Pour connecter Omi à d\'autres applications pour lire, rechercher et gérer vos souvenirs et conversations. Créez une clé pour commencer.';
 
   @override
   String get apiKeys => 'Clés API';
@@ -3583,15 +3493,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'État de diagnostic du service de transcription';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Activer les messages de diagnostic détaillés du service de transcription';
+  String get enableDetailedDiagnosticMessages => 'Activer les messages de diagnostic détaillés du service de transcription';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Créer et étiqueter automatiquement les nouveaux intervenants';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Créer automatiquement une nouvelle personne lorsqu\'un nom est détecté dans la transcription.';
+  String get automaticallyCreateNewPerson => 'Créer automatiquement une nouvelle personne lorsqu\'un nom est détecté dans la transcription.';
 
   @override
   String get pilotFeatures => 'Fonctionnalités pilotes';
@@ -3615,8 +3523,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get auto => 'Automatique';
 
   @override
-  String get noSummaryForApp =>
-      'Aucun résumé disponible pour cette application. Essayez une autre application pour de meilleurs résultats.';
+  String get noSummaryForApp => 'Aucun résumé disponible pour cette application. Essayez une autre application pour de meilleurs résultats.';
 
   @override
   String get tryAnotherApp => 'Essayer une autre application';
@@ -3653,8 +3560,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Laissez Omi choisir automatiquement la meilleure application';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Êtes-vous sûr de vouloir supprimer cette conversation ? Cette action ne peut pas être annulée.';
+  String get deleteConversationConfirmation => 'Êtes-vous sûr de vouloir supprimer cette conversation ? Cette action ne peut pas être annulée.';
 
   @override
   String get conversationDeleted => 'Conversation supprimée';
@@ -3669,8 +3575,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get conversationLinkCopiedToClipboard => 'Lien de la conversation copié dans le presse-papiers';
 
   @override
-  String get conversationTranscriptCopiedToClipboard =>
-      'Transcription de la conversation copiée dans le presse-papiers';
+  String get conversationTranscriptCopiedToClipboard => 'Transcription de la conversation copiée dans le presse-papiers';
 
   @override
   String get editConversationDialogTitle => 'Modifier la conversation';
@@ -3703,8 +3608,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Préparation de la capture audio système';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Cliquez sur le bouton pour capturer l\'audio pour les transcriptions en direct, les informations IA et l\'enregistrement automatique.';
+  String get clickTheButtonToCaptureAudio => 'Cliquez sur le bouton pour capturer l\'audio pour les transcriptions en direct, les informations IA et l\'enregistrement automatique.';
 
   @override
   String get reconnecting => 'Reconnexion...';
@@ -3862,8 +3766,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dailySummaryTitle => 'Résumé Quotidien';
 
   @override
-  String get dailySummaryDescription =>
-      'Recevez un résumé personnalisé des conversations de votre journée sous forme de notification.';
+  String get dailySummaryDescription => 'Recevez un résumé personnalisé des conversations de votre journée sous forme de notification.';
 
   @override
   String get deliveryTime => 'Heure de livraison';
@@ -3932,8 +3835,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Supprimer le graphe de connaissances ?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Cela supprimera toutes les données dérivées du graphe de connaissances. Vos souvenirs originaux restent en sécurité.';
+  String get deleteKnowledgeGraphWarning => 'Cela supprimera toutes les données dérivées du graphe de connaissances. Vos souvenirs originaux restent en sécurité.';
 
   @override
   String get connectOmiWithAI => 'Connectez Omi aux assistants IA';
@@ -3975,8 +3877,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Conditions et Politique de Confidentialité';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Aide à diagnostiquer les problèmes. Supprimé automatiquement après 3 jours.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Aide à diagnostiquer les problèmes. Supprimé automatiquement après 3 jours.';
 
   @override
   String get manageYourApp => 'Gérer votre application';
@@ -3991,8 +3892,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get updateAppQuestion => 'Mettre à jour l\'application ?';
 
   @override
-  String get updateAppConfirmation =>
-      'Êtes-vous sûr de vouloir mettre à jour votre application ? Les modifications seront appliquées après examen par notre équipe.';
+  String get updateAppConfirmation => 'Êtes-vous sûr de vouloir mettre à jour votre application ? Les modifications seront appliquées après examen par notre équipe.';
 
   @override
   String get updateApp => 'Mettre à jour l\'application';
@@ -4022,8 +3922,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get no => 'Non';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abonnement annulé avec succès. Il restera actif jusqu\'à la fin de la période de facturation en cours.';
+  String get subscriptionCancelledSuccessfully => 'Abonnement annulé avec succès. Il restera actif jusqu\'à la fin de la période de facturation en cours.';
 
   @override
   String get failedToCancelSubscription => 'Échec de l\'annulation de l\'abonnement. Veuillez réessayer.';
@@ -4059,8 +3958,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Annuler l\'abonnement ?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Êtes-vous sûr de vouloir annuler votre abonnement ? Vous continuerez à avoir accès jusqu\'à la fin de votre période de facturation actuelle.';
+  String get cancelSubscriptionConfirmation => 'Êtes-vous sûr de vouloir annuler votre abonnement ? Vous continuerez à avoir accès jusqu\'à la fin de votre période de facturation actuelle.';
 
   @override
   String get cancelSubscriptionButton => 'Annuler l\'abonnement';
@@ -4069,16 +3967,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cancelling => 'Annulation...';
 
   @override
-  String get betaTesterMessage =>
-      'Vous êtes un testeur bêta pour cette application. Elle n\'est pas encore publique. Elle sera publique une fois approuvée.';
+  String get betaTesterMessage => 'Vous êtes un testeur bêta pour cette application. Elle n\'est pas encore publique. Elle sera publique une fois approuvée.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Votre application est en cours d\'examen et visible uniquement par vous. Elle sera publique une fois approuvée.';
+  String get appUnderReviewMessage => 'Votre application est en cours d\'examen et visible uniquement par vous. Elle sera publique une fois approuvée.';
 
   @override
-  String get appRejectedMessage =>
-      'Votre application a été rejetée. Veuillez mettre à jour les détails et soumettre à nouveau.';
+  String get appRejectedMessage => 'Votre application a été rejetée. Veuillez mettre à jour les détails et soumettre à nouveau.';
 
   @override
   String get invalidIntegrationUrl => 'URL d\'intégration invalide';
@@ -4129,12 +4024,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get anonymousUser => 'Utilisateur anonyme';
 
   @override
-  String get issueActivatingApp =>
-      'Un problème est survenu lors de l\'activation de cette application. Veuillez réessayer.';
+  String get issueActivatingApp => 'Un problème est survenu lors de l\'activation de cette application. Veuillez réessayer.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Cette application accédera à vos données. Omi AI n\'est pas responsable de la façon dont vos données sont utilisées, modifiées ou supprimées par cette application';
+  String get dataAccessNoticeDescription => 'Cette application accédera à vos données. Omi AI n\'est pas responsable de la façon dont vos données sont utilisées, modifiées ou supprimées par cette application';
 
   @override
   String get copyUrl => 'Copier l\'URL';
@@ -4222,8 +4115,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get omiApiKeys => 'Clés API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Les clés API sont utilisées pour l\'authentification lorsque votre application communique avec le serveur OMI. Elles permettent à votre application de créer des souvenirs et d\'accéder à d\'autres services OMI en toute sécurité.';
+  String get apiKeysDescription => 'Les clés API sont utilisées pour l\'authentification lorsque votre application communique avec le serveur OMI. Elles permettent à votre application de créer des souvenirs et d\'accéder à d\'autres services OMI en toute sécurité.';
 
   @override
   String get aboutOmiApiKeys => 'À propos des clés API Omi';
@@ -4247,8 +4139,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Révoquer la clé API ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Cette action ne peut pas être annulée. Les applications utilisant cette clé ne pourront plus accéder à l\'API.';
+  String get revokeApiKeyWarning => 'Cette action ne peut pas être annulée. Les applications utilisant cette clé ne pourront plus accéder à l\'API.';
 
   @override
   String get revoke => 'Révoquer';
@@ -4337,8 +4228,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get keyCreated => 'Clé créée';
 
   @override
-  String get keyCreatedMessage =>
-      'Votre nouvelle clé a été créée. Veuillez la copier maintenant. Vous ne pourrez plus la voir.';
+  String get keyCreatedMessage => 'Votre nouvelle clé a été créée. Veuillez la copier maintenant. Vous ne pourrez plus la voir.';
 
   @override
   String get keyWord => 'Clé';
@@ -4347,8 +4237,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get externalAppAccess => 'Accès des applications externes';
 
   @override
-  String get externalAppAccessDescription =>
-      'Les applications installées suivantes ont des intégrations externes et peuvent accéder à vos données, telles que les conversations et les souvenirs.';
+  String get externalAppAccessDescription => 'Les applications installées suivantes ont des intégrations externes et peuvent accéder à vos données, telles que les conversations et les souvenirs.';
 
   @override
   String get noExternalAppsHaveAccess => 'Aucune application externe n\'a accès à vos données.';
@@ -4357,15 +4246,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get maximumSecurityE2ee => 'Sécurité maximale (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Le chiffrement de bout en bout est la référence en matière de confidentialité. Lorsqu\'il est activé, vos données sont chiffrées sur votre appareil avant d\'être envoyées à nos serveurs. Cela signifie que personne, pas même Omi, ne peut accéder à votre contenu.';
+  String get e2eeDescription => 'Le chiffrement de bout en bout est la référence en matière de confidentialité. Lorsqu\'il est activé, vos données sont chiffrées sur votre appareil avant d\'être envoyées à nos serveurs. Cela signifie que personne, pas même Omi, ne peut accéder à votre contenu.';
 
   @override
   String get importantTradeoffs => 'Compromis importants :';
 
   @override
-  String get e2eeTradeoff1 =>
-      '• Certaines fonctionnalités comme les intégrations d\'applications externes peuvent être désactivées.';
+  String get e2eeTradeoff1 => '• Certaines fonctionnalités comme les intégrations d\'applications externes peuvent être désactivées.';
 
   @override
   String get e2eeTradeoff2 => '• Si vous perdez votre mot de passe, vos données ne peuvent pas être récupérées.';
@@ -4374,8 +4261,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get featureComingSoon => 'Cette fonctionnalité arrive bientôt !';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migration en cours. Vous ne pouvez pas modifier le niveau de protection tant qu\'elle n\'est pas terminée.';
+  String get migrationInProgressMessage => 'Migration en cours. Vous ne pouvez pas modifier le niveau de protection tant qu\'elle n\'est pas terminée.';
 
   @override
   String get migrationFailed => 'Échec de la migration';
@@ -4394,19 +4280,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get secureEncryption => 'Chiffrement sécurisé';
 
   @override
-  String get secureEncryptionDescription =>
-      'Vos données sont chiffrées avec une clé unique sur nos serveurs, hébergés sur Google Cloud. Cela signifie que votre contenu brut est inaccessible à quiconque, y compris le personnel d\'Omi ou Google, directement depuis la base de données.';
+  String get secureEncryptionDescription => 'Vos données sont chiffrées avec une clé unique sur nos serveurs, hébergés sur Google Cloud. Cela signifie que votre contenu brut est inaccessible à quiconque, y compris le personnel d\'Omi ou Google, directement depuis la base de données.';
 
   @override
   String get endToEndEncryption => 'Chiffrement de bout en bout';
 
   @override
-  String get e2eeCardDescription =>
-      'Activez pour une sécurité maximale où seul vous pouvez accéder à vos données. Appuyez pour en savoir plus.';
+  String get e2eeCardDescription => 'Activez pour une sécurité maximale où seul vous pouvez accéder à vos données. Appuyez pour en savoir plus.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Quel que soit le niveau, vos données sont toujours chiffrées au repos et en transit.';
+  String get dataAlwaysEncrypted => 'Quel que soit le niveau, vos données sont toujours chiffrées au repos et en transit.';
 
   @override
   String get readOnlyScope => 'Lecture seule';
@@ -4471,26 +4354,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trainingDataProgram => 'Programme de données d\'entraînement';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Obtenez Omi Illimité gratuitement en contribuant vos données pour entraîner des modèles d\'IA.';
+  String get getOmiUnlimitedFree => 'Obtenez Omi Illimité gratuitement en contribuant vos données pour entraîner des modèles d\'IA.';
 
   @override
-  String get trainingDataBullets =>
-      '• Vos données aident à améliorer les modèles d\'IA\n• Seules les données non sensibles sont partagées\n• Processus entièrement transparent';
+  String get trainingDataBullets => '• Vos données aident à améliorer les modèles d\'IA\n• Seules les données non sensibles sont partagées\n• Processus entièrement transparent';
 
   @override
   String get learnMoreAtOmiTraining => 'En savoir plus sur omi.me/training';
 
   @override
-  String get agreeToContributeData =>
-      'Je comprends et j\'accepte de contribuer mes données pour l\'entraînement de l\'IA';
+  String get agreeToContributeData => 'Je comprends et j\'accepte de contribuer mes données pour l\'entraînement de l\'IA';
 
   @override
   String get submitRequest => 'Soumettre la demande';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Merci ! Votre demande est en cours d\'examen. Nous vous informerons une fois approuvée.';
+  String get thankYouRequestUnderReview => 'Merci ! Votre demande est en cours d\'examen. Nous vous informerons une fois approuvée.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4525,20 +4404,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get importantBillingInfo => 'Informations de facturation importantes :';
 
   @override
-  String get monthlyPlanContinues =>
-      'Votre forfait mensuel actuel continuera jusqu\'à la fin de votre période de facturation';
+  String get monthlyPlanContinues => 'Votre forfait mensuel actuel continuera jusqu\'à la fin de votre période de facturation';
 
   @override
-  String get paymentMethodCharged =>
-      'Votre méthode de paiement existante sera débitée automatiquement à la fin de votre forfait mensuel';
+  String get paymentMethodCharged => 'Votre méthode de paiement existante sera débitée automatiquement à la fin de votre forfait mensuel';
 
   @override
-  String get annualSubscriptionStarts =>
-      'Votre abonnement annuel de 12 mois débutera automatiquement après le prélèvement';
+  String get annualSubscriptionStarts => 'Votre abonnement annuel de 12 mois débutera automatiquement après le prélèvement';
 
   @override
-  String get thirteenMonthsCoverage =>
-      'Vous bénéficierez de 13 mois de couverture au total (mois en cours + 12 mois annuels)';
+  String get thirteenMonthsCoverage => 'Vous bénéficierez de 13 mois de couverture au total (mois en cours + 12 mois annuels)';
 
   @override
   String get confirmUpgrade => 'Confirmer la mise à niveau';
@@ -4575,8 +4450,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Votre forfait annuel débutera automatiquement à la fin de votre forfait mensuel.';
+  String get annualPlanStartsAutomatically => 'Votre forfait annuel débutera automatiquement à la fin de votre forfait mensuel.';
 
   @override
   String planRenewsOn(String date) {
@@ -4596,8 +4470,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get youreOnAnnualPlan => 'Vous êtes sur le forfait annuel';
 
   @override
-  String get alreadyBestValuePlan =>
-      'Vous avez déjà le forfait au meilleur rapport qualité-prix. Aucun changement nécessaire.';
+  String get alreadyBestValuePlan => 'Vous avez déjà le forfait au meilleur rapport qualité-prix. Aucun changement nécessaire.';
 
   @override
   String get unableToLoadPlans => 'Impossible de charger les forfaits';
@@ -4644,8 +4517,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Votre vie privée nous tient à cœur';
 
   @override
-  String get privacyIntroText =>
-      'Chez Omi, nous prenons votre vie privée très au sérieux. Nous voulons être transparents sur les données que nous collectons et comment nous les utilisons. Voici ce que vous devez savoir :';
+  String get privacyIntroText => 'Chez Omi, nous prenons votre vie privée très au sérieux. Nous voulons être transparents sur les données que nous collectons et comment nous les utilisons. Voici ce que vous devez savoir :';
 
   @override
   String get whatWeTrack => 'Ce que nous suivons';
@@ -4660,12 +4532,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get ourCommitment => 'Notre engagement';
 
   @override
-  String get commitmentText =>
-      'Nous nous engageons à n\'utiliser les données collectées que pour améliorer Omi pour vous. Votre vie privée et votre confiance sont primordiales pour nous.';
+  String get commitmentText => 'Nous nous engageons à n\'utiliser les données collectées que pour améliorer Omi pour vous. Votre vie privée et votre confiance sont primordiales pour nous.';
 
   @override
-  String get thankYouText =>
-      'Merci d\'être un utilisateur précieux d\'Omi. Si vous avez des questions ou des préoccupations, n\'hésitez pas à nous contacter à team@basedhardware.com.';
+  String get thankYouText => 'Merci d\'être un utilisateur précieux d\'Omi. Si vous avez des questions ou des préoccupations, n\'hésitez pas à nous contacter à team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Paramètres de synchronisation WiFi';
@@ -4674,8 +4544,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get enterHotspotCredentials => 'Entrez les identifiants du point d\'accès de votre téléphone';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'La synchronisation WiFi utilise votre téléphone comme point d\'accès. Trouvez le nom et le mot de passe dans Réglages > Partage de connexion.';
+  String get wifiSyncUsesHotspot => 'La synchronisation WiFi utilise votre téléphone comme point d\'accès. Trouvez le nom et le mot de passe dans Réglages > Partage de connexion.';
 
   @override
   String get hotspotNameSsid => 'Nom du point d\'accès (SSID)';
@@ -4710,8 +4579,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Échec de la génération du résumé. Assurez-vous d\'avoir des conversations pour ce jour.';
+  String get failedToGenerateSummaryCheckConversations => 'Échec de la génération du résumé. Assurez-vous d\'avoir des conversations pour ce jour.';
 
   @override
   String get summaryNotFound => 'Résumé non trouvé';
@@ -4741,8 +4609,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Exportation commencée. Cela peut prendre quelques secondes...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ceci supprimera toutes les données dérivées du graphe de connaissances (nœuds et connexions). Vos souvenirs originaux resteront en sécurité. Le graphe sera reconstruit au fil du temps ou à la prochaine demande.';
+  String get knowledgeGraphDeleteDescription => 'Ceci supprimera toutes les données dérivées du graphe de connaissances (nœuds et connexions). Vos souvenirs originaux resteront en sécurité. Le graphe sera reconstruit au fil du temps ou à la prochaine demande.';
 
   @override
   String get configureDailySummaryDigest => 'Configurez votre résumé quotidien des tâches';
@@ -4812,8 +4679,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Supprimer toutes les conversations Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Cela supprimera définitivement toutes les conversations importées de Limitless. Cette action ne peut pas être annulée.';
+  String get deleteAllLimitlessWarning => 'Cela supprimera définitivement toutes les conversations importées de Limitless. Cette action ne peut pas être annulée.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4869,8 +4735,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get howItWorksTitle => 'Comment ça marche?';
 
   @override
-  String get howPeopleWorks =>
-      'Une fois qu\'une personne est créée, vous pouvez aller dans la transcription d\'une conversation et lui attribuer les segments correspondants, ainsi Omi pourra également reconnaître sa voix!';
+  String get howPeopleWorks => 'Une fois qu\'une personne est créée, vous pouvez aller dans la transcription d\'une conversation et lui attribuer les segments correspondants, ainsi Omi pourra également reconnaître sa voix!';
 
   @override
   String get tapToDelete => 'Appuyez pour supprimer';
@@ -4896,8 +4761,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get privacyNotice => 'Avis de confidentialité';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Les enregistrements peuvent capturer les voix d\'autres personnes. Assurez-vous d\'avoir le consentement de tous les participants avant d\'activer.';
+  String get recordingsMayCaptureOthers => 'Les enregistrements peuvent capturer les voix d\'autres personnes. Assurez-vous d\'avoir le consentement de tous les participants avant d\'activer.';
 
   @override
   String get enable => 'Activer';
@@ -4909,8 +4773,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Conservez tous les enregistrements audio stockés localement sur votre téléphone. Lorsque désactivé, seuls les téléchargements échoués sont conservés pour économiser de l\'espace.';
+  String get storeAudioDescription => 'Conservez tous les enregistrements audio stockés localement sur votre téléphone. Lorsque désactivé, seuls les téléchargements échoués sont conservés pour économiser de l\'espace.';
 
   @override
   String get enableLocalStorage => 'Activer le stockage local';
@@ -4928,12 +4791,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get storeAudioOnCloud => 'Stocker l\'audio dans le cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Vos enregistrements en temps réel seront stockés dans un stockage cloud privé pendant que vous parlez.';
+  String get cloudStorageDialogMessage => 'Vos enregistrements en temps réel seront stockés dans un stockage cloud privé pendant que vous parlez.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Stockez vos enregistrements en temps réel dans un stockage cloud privé pendant que vous parlez. L\'audio est capturé et enregistré en toute sécurité en temps réel.';
+  String get storeAudioCloudDescription => 'Stockez vos enregistrements en temps réel dans un stockage cloud privé pendant que vous parlez. L\'audio est capturé et enregistré en toute sécurité en temps réel.';
 
   @override
   String get downloadingFirmware => 'Téléchargement du firmware';
@@ -4942,8 +4803,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get installingFirmware => 'Installation du firmware';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Ne fermez pas l\'application et n\'éteignez pas l\'appareil. Cela pourrait endommager votre appareil.';
+  String get firmwareUpdateWarning => 'Ne fermez pas l\'application et n\'éteignez pas l\'appareil. Cela pourrait endommager votre appareil.';
 
   @override
   String get firmwareUpdated => 'Firmware mis à jour';
@@ -4987,8 +4847,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get payments => 'Paiements';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Connectez un mode de paiement ci-dessous pour commencer à recevoir des paiements pour vos applications.';
+  String get connectPaymentMethodInfo => 'Connectez un mode de paiement ci-dessous pour commencer à recevoir des paiements pour vos applications.';
 
   @override
   String get selectedPaymentMethod => 'Mode de paiement sélectionné';
@@ -5015,22 +4874,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get monthlyPayouts => 'Paiements mensuels';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Recevez des paiements mensuels directement sur votre compte lorsque vous atteignez 10 \$ de gains';
+  String get monthlyPayoutsDescription => 'Recevez des paiements mensuels directement sur votre compte lorsque vous atteignez 10 \$ de gains';
 
   @override
   String get secureAndReliable => 'Sécurisé et fiable';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe assure des transferts sécurisés et ponctuels des revenus de votre application';
+  String get stripeSecureDescription => 'Stripe assure des transferts sécurisés et ponctuels des revenus de votre application';
 
   @override
   String get selectYourCountry => 'Sélectionnez votre pays';
 
   @override
-  String get countrySelectionPermanent =>
-      'Votre sélection de pays est permanente et ne peut pas être modifiée ultérieurement.';
+  String get countrySelectionPermanent => 'Votre sélection de pays est permanente et ne peut pas être modifiée ultérieurement.';
 
   @override
   String get byClickingConnectNow => 'En cliquant sur \"Connecter maintenant\", vous acceptez';
@@ -5045,8 +4901,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get connectingYourStripeAccount => 'Connexion de votre compte Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Veuillez compléter le processus d\'intégration Stripe dans votre navigateur. Cette page se mettra à jour automatiquement une fois terminé.';
+  String get stripeOnboardingInstructions => 'Veuillez compléter le processus d\'intégration Stripe dans votre navigateur. Cette page se mettra à jour automatiquement une fois terminé.';
 
   @override
   String get failedTryAgain => 'Échec ? Réessayer';
@@ -5058,15 +4913,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get successfullyConnected => 'Connexion réussie !';
 
   @override
-  String get stripeReadyForPayments =>
-      'Votre compte Stripe est maintenant prêt à recevoir des paiements. Vous pouvez commencer à gagner de l\'argent grâce aux ventes de vos applications dès maintenant.';
+  String get stripeReadyForPayments => 'Votre compte Stripe est maintenant prêt à recevoir des paiements. Vous pouvez commencer à gagner de l\'argent grâce aux ventes de vos applications dès maintenant.';
 
   @override
   String get updateStripeDetails => 'Mettre à jour les détails Stripe';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Erreur lors de la mise à jour des détails Stripe ! Veuillez réessayer plus tard.';
+  String get errorUpdatingStripeDetails => 'Erreur lors de la mise à jour des détails Stripe ! Veuillez réessayer plus tard.';
 
   @override
   String get updatePayPal => 'Mettre à jour PayPal';
@@ -5078,8 +4931,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Mettez à jour les détails de votre compte PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Connectez votre compte PayPal pour commencer à recevoir des paiements pour vos applications';
+  String get connectPayPalToReceivePayments => 'Connectez votre compte PayPal pour commencer à recevoir des paiements pour vos applications';
 
   @override
   String get paypalEmail => 'E-mail PayPal';
@@ -5088,8 +4940,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get paypalMeLink => 'Lien PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Si Stripe est disponible dans votre pays, nous vous recommandons fortement de l\'utiliser pour des paiements plus rapides et plus faciles.';
+  String get stripeRecommendation => 'Si Stripe est disponible dans votre pays, nous vous recommandons fortement de l\'utiliser pour des paiements plus rapides et plus faciles.';
 
   @override
   String get updatePayPalDetails => 'Mettre à jour les détails PayPal';
@@ -5141,12 +4992,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Échantillon vocal supplémentaire supprimé';
 
   @override
-  String get consentDataMessage =>
-      'En continuant, vos conversations, enregistrements et informations personnelles seront stockés en toute sécurité sur nos serveurs. Vos enregistrements audio et transcriptions sont traités par des services d\'IA tiers (notamment Deepgram pour la transcription et OpenAI pour l\'analyse) afin de vous fournir des informations alimentées par l\'IA et d\'activer toutes les fonctionnalités de l\'application.';
+  String get consentDataMessage => 'En continuant, vos conversations, enregistrements et informations personnelles seront stockés en toute sécurité sur nos serveurs. Vos enregistrements audio et transcriptions sont traités par des services d\'IA tiers (notamment Deepgram pour la transcription et OpenAI pour l\'analyse) afin de vous fournir des informations alimentées par l\'IA et d\'activer toutes les fonctionnalités de l\'application.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Les tâches de vos conversations apparaîtront ici.\nAppuyez sur + pour en créer une manuellement.';
+  String get tasksEmptyStateMessage => 'Les tâches de vos conversations apparaîtront ici.\nAppuyez sur + pour en créer une manuellement.';
 
   @override
   String get clearChatAction => 'Effacer le chat';
@@ -5182,15 +5031,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Installez Omi sur votre\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Pour utiliser votre Apple Watch avec Omi, vous devez d\'abord installer l\'application Omi sur votre montre.';
+  String get installOmiOnAppleWatchDescription => 'Pour utiliser votre Apple Watch avec Omi, vous devez d\'abord installer l\'application Omi sur votre montre.';
 
   @override
   String get openOmiOnAppleWatch => 'Ouvrez Omi sur votre\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'L\'application Omi est installée sur votre Apple Watch. Ouvrez-la et appuyez sur Démarrer.';
+  String get openOmiOnAppleWatchDescription => 'L\'application Omi est installée sur votre Apple Watch. Ouvrez-la et appuyez sur Démarrer.';
 
   @override
   String get openWatchApp => 'Ouvrir l\'app Watch';
@@ -5199,15 +5046,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'J\'ai installé et ouvert l\'application';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Impossible d\'ouvrir l\'app Apple Watch. Ouvrez manuellement l\'app Watch sur votre Apple Watch et installez Omi depuis la section \"Apps disponibles\".';
+  String get unableToOpenWatchApp => 'Impossible d\'ouvrir l\'app Apple Watch. Ouvrez manuellement l\'app Watch sur votre Apple Watch et installez Omi depuis la section \"Apps disponibles\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch connectée avec succès !';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch toujours inaccessible. Assurez-vous que l\'application Omi est ouverte sur votre montre.';
+  String get appleWatchNotReachable => 'Apple Watch toujours inaccessible. Assurez-vous que l\'application Omi est ouverte sur votre montre.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5224,8 +5069,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get finishedConversation => 'Conversation terminée ?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Voulez-vous vraiment arrêter l\'enregistrement et résumer la conversation maintenant ?';
+  String get stopRecordingConfirmation => 'Voulez-vous vraiment arrêter l\'enregistrement et résumer la conversation maintenant ?';
 
   @override
   String get conversationEndsManually => 'La conversation ne se terminera que manuellement.';
@@ -5636,8 +5480,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get multipleSpeakersDetected => 'Plusieurs interlocuteurs détectés';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Il semble qu\'il y ait plusieurs interlocuteurs dans l\'enregistrement. Assurez-vous d\'être dans un endroit calme et réessayez.';
+  String get multipleSpeakersDescription => 'Il semble qu\'il y ait plusieurs interlocuteurs dans l\'enregistrement. Assurez-vous d\'être dans un endroit calme et réessayez.';
 
   @override
   String get invalidRecordingDetected => 'Enregistrement invalide détecté';
@@ -5649,15 +5492,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get speechDurationDescription => 'Assurez-vous de parler au moins 5 secondes et pas plus de 90.';
 
   @override
-  String get connectionLostDescription =>
-      'La connexion a été interrompue. Veuillez vérifier votre connexion Internet et réessayer.';
+  String get connectionLostDescription => 'La connexion a été interrompue. Veuillez vérifier votre connexion Internet et réessayer.';
 
   @override
   String get howToTakeGoodSample => 'Comment faire un bon échantillon ?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Assurez-vous d\'être dans un endroit calme.\n2. Parlez clairement et naturellement.\n3. Assurez-vous que votre appareil est dans sa position naturelle sur votre cou.\n\nUne fois créé, vous pouvez toujours l\'améliorer ou le refaire.';
+  String get goodSampleInstructions => '1. Assurez-vous d\'être dans un endroit calme.\n2. Parlez clairement et naturellement.\n3. Assurez-vous que votre appareil est dans sa position naturelle sur votre cou.\n\nUne fois créé, vous pouvez toujours l\'améliorer ou le refaire.';
 
   @override
   String get noDeviceConnectedUseMic => 'Aucun appareil connecté. Le microphone du téléphone sera utilisé.';
@@ -5699,8 +5540,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get notificationFrequency => 'Fréquence des notifications';
 
   @override
-  String get controlNotificationFrequency =>
-      'Contrôlez la fréquence à laquelle Omi vous envoie des notifications proactives.';
+  String get controlNotificationFrequency => 'Contrôlez la fréquence à laquelle Omi vous envoie des notifications proactives.';
 
   @override
   String get yourScore => 'Votre score';
@@ -5721,12 +5561,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get howItWorks => 'Comment ça marche';
 
   @override
-  String get dailyScoreExplanation =>
-      'Votre score quotidien est basé sur l\'achèvement des tâches. Terminez vos tâches pour améliorer votre score!';
+  String get dailyScoreExplanation => 'Votre score quotidien est basé sur l\'achèvement des tâches. Terminez vos tâches pour améliorer votre score!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Contrôlez la fréquence à laquelle Omi vous envoie des notifications proactives et des rappels.';
+  String get notificationFrequencyDescription => 'Contrôlez la fréquence à laquelle Omi vous envoie des notifications proactives et des rappels.';
 
   @override
   String get sliderOff => 'Désactivé';
@@ -5740,8 +5578,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Échec de la génération du résumé. Assurez-vous d\'avoir des conversations pour ce jour.';
+  String get failedToGenerateSummary => 'Échec de la génération du résumé. Assurez-vous d\'avoir des conversations pour ce jour.';
 
   @override
   String get recap => 'Récap';
@@ -5820,8 +5657,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get selectApp => 'Sélectionner une application';
 
   @override
-  String get noChatAppsEnabled =>
-      'Aucune application de chat activée.\nAppuyez sur \"Activer les applications\" pour en ajouter.';
+  String get noChatAppsEnabled => 'Aucune application de chat activée.\nAppuyez sur \"Activer les applications\" pour en ajouter.';
 
   @override
   String get disable => 'Désactiver';
@@ -5901,8 +5737,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get wifiEnableFailed => 'Échec de l\'activation du WiFi sur l\'appareil. Veuillez réessayer.';
 
   @override
-  String get deviceNoFastTransfer =>
-      'Votre appareil ne prend pas en charge le transfert rapide. Utilisez le Bluetooth à la place.';
+  String get deviceNoFastTransfer => 'Votre appareil ne prend pas en charge le transfert rapide. Utilisez le Bluetooth à la place.';
 
   @override
   String get enableHotspotMessage => 'Veuillez activer le point d\'accès de votre téléphone et réessayer.';
@@ -5974,8 +5809,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get recordings => 'Enregistrements';
 
   @override
-  String get enableRemindersAccess =>
-      'Veuillez activer l\'accès aux Rappels dans les Réglages pour utiliser les Rappels Apple';
+  String get enableRemindersAccess => 'Veuillez activer l\'accès aux Rappels dans les Réglages pour utiliser les Rappels Apple';
 
   @override
   String todayAtTime(String time) {
@@ -6104,15 +5938,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cloudProvider => 'Fournisseur cloud';
 
   @override
-  String get premiumMinutesInfo =>
-      '1 200 minutes premium/mois. L\'onglet Sur l\'appareil offre une transcription gratuite illimitée.';
+  String get premiumMinutesInfo => '1 200 minutes premium/mois. L\'onglet Sur l\'appareil offre une transcription gratuite illimitée.';
 
   @override
   String get viewUsage => 'Voir lutilisation';
 
   @override
-  String get localProcessingInfo =>
-      'L\'audio est traité localement. Fonctionne hors ligne, plus privé, mais consomme plus de batterie.';
+  String get localProcessingInfo => 'L\'audio est traité localement. Fonctionne hors ligne, plus privé, mais consomme plus de batterie.';
 
   @override
   String get model => 'Modèle';
@@ -6121,15 +5953,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get performanceWarning => 'Avertissement de performance';
 
   @override
-  String get largeModelWarning =>
-      'Ce modèle est volumineux et peut faire planter l\'application ou fonctionner très lentement sur les appareils mobiles.\n\n« small » ou « base » est recommandé.';
+  String get largeModelWarning => 'Ce modèle est volumineux et peut faire planter l\'application ou fonctionner très lentement sur les appareils mobiles.\n\n« small » ou « base » est recommandé.';
 
   @override
   String get usingNativeIosSpeech => 'Utilisation de la reconnaissance vocale native iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Le moteur de reconnaissance vocale natif de votre appareil sera utilisé. Aucun téléchargement de modèle requis.';
+  String get noModelDownloadRequired => 'Le moteur de reconnaissance vocale natif de votre appareil sera utilisé. Aucun téléchargement de modèle requis.';
 
   @override
   String get modelReady => 'Modèle prêt';
@@ -6174,8 +6004,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Appareil non compatible';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'Votre appareil ne répond pas aux exigences pour la transcription sur appareil.';
+  String get deviceNotMeetRequirements => 'Votre appareil ne répond pas aux exigences pour la transcription sur appareil.';
 
   @override
   String get transcriptionSlowerOnDevice => 'La transcription sur appareil peut être plus lente sur cet appareil.';
@@ -6187,12 +6016,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get batteryDrainSignificantly => 'La consommation de batterie augmentera considérablement.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1 200 minutes premium/mois. Longlet Sur appareil offre une transcription gratuite illimitée. ';
+  String get premiumMinutesMonth => '1 200 minutes premium/mois. Longlet Sur appareil offre une transcription gratuite illimitée. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Laudio est traité localement. Fonctionne hors ligne, plus privé, mais consomme plus de batterie.';
+  String get audioProcessedLocally => 'Laudio est traité localement. Fonctionne hors ligne, plus privé, mais consomme plus de batterie.';
 
   @override
   String get languageLabel => 'Langue';
@@ -6201,12 +6028,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get modelLabel => 'Modèle';
 
   @override
-  String get modelTooLargeWarning =>
-      'Ce modèle est volumineux et peut provoquer le plantage de lapplication ou un fonctionnement très lent sur les appareils mobiles.\n\nsmall ou base est recommandé.';
+  String get modelTooLargeWarning => 'Ce modèle est volumineux et peut provoquer le plantage de lapplication ou un fonctionnement très lent sur les appareils mobiles.\n\nsmall ou base est recommandé.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Le moteur vocal natif de votre appareil sera utilisé. Aucun téléchargement de modèle requis.';
+  String get nativeEngineNoDownload => 'Le moteur vocal natif de votre appareil sera utilisé. Aucun téléchargement de modèle requis.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6242,8 +6067,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'La transcription en direct intégrée dOmi est optimisée pour les conversations en temps réel avec détection automatique des interlocuteurs et diarisation.';
+  String get omiTranscriptionOptimized => 'La transcription en direct intégrée dOmi est optimisée pour les conversations en temps réel avec détection automatique des interlocuteurs et diarisation.';
 
   @override
   String get reset => 'Réinitialiser';
@@ -6463,8 +6287,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Construction du graphe de connaissances à partir des souvenirs...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Votre graphe de connaissances sera construit automatiquement lorsque vous créerez de nouveaux souvenirs.';
+  String get knowledgeGraphWillBuildAutomatically => 'Votre graphe de connaissances sera construit automatiquement lorsque vous créerez de nouveaux souvenirs.';
 
   @override
   String get buildGraphButton => 'Construire le graphe';
@@ -6700,8 +6523,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get failedToLoadContacts => 'Échec du chargement des contacts';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Échec de la préparation de la conversation pour le partage. Veuillez réessayer.';
+  String get failedToPrepareConversationForSharing => 'Échec de la préparation de la conversation pour le partage. Veuillez réessayer.';
 
   @override
   String get couldNotOpenSmsApp => 'Impossible d\'ouvrir l\'application SMS. Veuillez réessayer.';
@@ -6767,8 +6589,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Téléchargement de l\'audio depuis la carte SD de votre appareil';
 
   @override
-  String get transferRequiredDescription =>
-      'Cet enregistrement est stocké sur la carte SD de votre appareil. Transférez-le sur votre téléphone pour le lire ou le partager.';
+  String get transferRequiredDescription => 'Cet enregistrement est stocké sur la carte SD de votre appareil. Transférez-le sur votre téléphone pour le lire ou le partager.';
 
   @override
   String get cancelTransfer => 'Annuler le transfert';
@@ -6789,8 +6610,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareRecording => 'Partager l\'enregistrement';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Êtes-vous sûr de vouloir supprimer définitivement cet enregistrement ? Cette action est irréversible.';
+  String get deleteRecordingConfirmation => 'Êtes-vous sûr de vouloir supprimer définitivement cet enregistrement ? Cette action est irréversible.';
 
   @override
   String get recordingIdLabel => 'ID d\'enregistrement';
@@ -6849,15 +6669,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get enableFastTransfer => 'Activer le transfert rapide';
 
   @override
-  String get fastTransferDescription =>
-      'Le transfert rapide utilise le WiFi pour des vitesses ~5x plus rapides. Votre téléphone se connectera temporairement au réseau WiFi de votre appareil Omi pendant le transfert.';
+  String get fastTransferDescription => 'Le transfert rapide utilise le WiFi pour des vitesses ~5x plus rapides. Votre téléphone se connectera temporairement au réseau WiFi de votre appareil Omi pendant le transfert.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'L\'accès Internet est suspendu pendant le transfert';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Choisissez comment les enregistrements sont transférés de votre appareil Omi vers votre téléphone.';
+  String get chooseTransferMethodDescription => 'Choisissez comment les enregistrements sont transférés de votre appareil Omi vers votre téléphone.';
 
   @override
   String get wifiSpeed => '~150 Ko/s via WiFi';
@@ -6866,8 +6684,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fiveTimesFaster => '5X PLUS RAPIDE';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Crée une connexion WiFi directe à votre appareil Omi. Votre téléphone se déconnecte temporairement de votre WiFi habituel pendant le transfert.';
+  String get fastTransferMethodDescription => 'Crée une connexion WiFi directe à votre appareil Omi. Votre téléphone se déconnecte temporairement de votre WiFi habituel pendant le transfert.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6876,8 +6693,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get bleSpeed => '~30 Ko/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Utilise une connexion Bluetooth Low Energy standard. Plus lent mais n\'affecte pas votre connexion WiFi.';
+  String get bluetoothMethodDescription => 'Utilise une connexion Bluetooth Low Energy standard. Plus lent mais n\'affecte pas votre connexion WiFi.';
 
   @override
   String get selected => 'Sélectionné';
@@ -6915,12 +6731,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appDeleteFailed => 'Échec de la suppression de l\'application. Veuillez réessayer plus tard.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'La visibilité de l\'application a été modifiée avec succès. Cela peut prendre quelques minutes.';
+  String get appVisibilityChangedSuccessfully => 'La visibilité de l\'application a été modifiée avec succès. Cela peut prendre quelques minutes.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Erreur lors de l\'activation de l\'application. S\'il s\'agit d\'une intégration, assurez-vous que la configuration est terminée.';
+  String get errorActivatingAppIntegration => 'Erreur lors de l\'activation de l\'application. S\'il s\'agit d\'une intégration, assurez-vous que la configuration est terminée.';
 
   @override
   String get errorUpdatingAppStatus => 'Une erreur s\'est produite lors de la mise à jour du statut de l\'application.';
@@ -6988,8 +6802,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get importantConversationTitle => 'Conversation importante';
 
   @override
-  String get importantConversationBody =>
-      'Vous venez d\'avoir une conversation importante. Appuyez pour partager le résumé.';
+  String get importantConversationBody => 'Vous venez d\'avoir une conversation importante. Appuyez pour partager le résumé.';
 
   @override
   String get templateName => 'Nom du modèle';
@@ -7001,8 +6814,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Le nom doit contenir au moins 3 caractères';
 
   @override
-  String get conversationPromptHint =>
-      'ex., Extraire les actions, les décisions prises et les points clés de la conversation fournie.';
+  String get conversationPromptHint => 'ex., Extraire les actions, les décisions prises et les points clés de la conversation fournie.';
 
   @override
   String get pleaseEnterAppPrompt => 'Veuillez entrer une invite pour votre application';
@@ -7035,12 +6847,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get failedToCreateApp => 'Échec de la création. Veuillez réessayer.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'Veuillez sélectionner une capacité principale supplémentaire pour votre application';
+  String get addAppSelectCoreCapability => 'Veuillez sélectionner une capacité principale supplémentaire pour votre application';
 
   @override
-  String get addAppSelectPaymentPlan =>
-      'Veuillez sélectionner un plan de paiement et entrer un prix pour votre application';
+  String get addAppSelectPaymentPlan => 'Veuillez sélectionner un plan de paiement et entrer un prix pour votre application';
 
   @override
   String get addAppSelectCapability => 'Veuillez sélectionner au moins une capacité pour votre application';
@@ -7100,23 +6910,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get addAppErrorSelectingThumbnailRetry => 'Erreur lors de la sélection de la miniature. Veuillez réessayer.';
 
   @override
-  String get addAppCapabilityConflictWithPersona =>
-      'Les autres capacités ne peuvent pas être sélectionnées avec Persona';
+  String get addAppCapabilityConflictWithPersona => 'Les autres capacités ne peuvent pas être sélectionnées avec Persona';
 
   @override
   String get addAppPersonaConflictWithCapabilities => 'Persona ne peut pas être sélectionné avec d\'autres capacités';
 
   @override
-  String get paymentFailedToFetchCountries =>
-      'Échec de la récupération des pays pris en charge. Veuillez réessayer plus tard.';
+  String get paymentFailedToFetchCountries => 'Échec de la récupération des pays pris en charge. Veuillez réessayer plus tard.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Échec de la définition du mode de paiement par défaut. Veuillez réessayer plus tard.';
+  String get paymentFailedToSetDefault => 'Échec de la définition du mode de paiement par défaut. Veuillez réessayer plus tard.';
 
   @override
-  String get paymentFailedToSavePaypal =>
-      'Échec de l\'enregistrement des détails PayPal. Veuillez réessayer plus tard.';
+  String get paymentFailedToSavePaypal => 'Échec de l\'enregistrement des détails PayPal. Veuillez réessayer plus tard.';
 
   @override
   String get paypalEmailHint => 'nik@example.com';
@@ -7195,19 +7001,16 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Mise à niveau programmée ! Votre plan mensuel continue jusqu\'à la fin de votre période de facturation, puis passe automatiquement à l\'annuel.';
+  String get planUpgradeScheduledMessage => 'Mise à niveau programmée ! Votre plan mensuel continue jusqu\'à la fin de votre période de facturation, puis passe automatiquement à l\'annuel.';
 
   @override
   String get couldNotSchedulePlanChange => 'Impossible de programmer le changement de plan. Veuillez réessayer.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Votre abonnement a été réactivé ! Pas de frais maintenant - vous serez facturé à la fin de votre période actuelle.';
+  String get subscriptionReactivatedDefault => 'Votre abonnement a été réactivé ! Pas de frais maintenant - vous serez facturé à la fin de votre période actuelle.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Abonnement réussi ! Vous avez été facturé pour la nouvelle période de facturation.';
+  String get subscriptionSuccessfulCharged => 'Abonnement réussi ! Vous avez été facturé pour la nouvelle période de facturation.';
 
   @override
   String get couldNotProcessSubscription => 'Impossible de traiter l\'abonnement. Veuillez réessayer.';
@@ -7372,8 +7175,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Échec de la récupération du jeton Firebase, veuillez réessayer.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Erreur inattendue lors de la connexion, erreur Firebase, veuillez réessayer.';
+  String get authUnexpectedErrorFirebase => 'Erreur inattendue lors de la connexion, erreur Firebase, veuillez réessayer.';
 
   @override
   String get authUnexpectedError => 'Erreur inattendue lors de la connexion, veuillez réessayer';
@@ -7388,8 +7190,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get onboardingBluetoothRequired => 'L\'autorisation Bluetooth est requise pour connecter votre appareil.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Autorisation Bluetooth refusée. Veuillez accorder l\'autorisation dans les Préférences Système.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Autorisation Bluetooth refusée. Veuillez accorder l\'autorisation dans les Préférences Système.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7402,12 +7203,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Autorisation de notification refusée. Veuillez accorder l\'autorisation dans les Préférences Système.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Autorisation de notification refusée. Veuillez accorder l\'autorisation dans les Préférences Système.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Autorisation de notification refusée. Veuillez accorder l\'autorisation dans Préférences Système > Notifications.';
+  String get onboardingNotificationDeniedNotifications => 'Autorisation de notification refusée. Veuillez accorder l\'autorisation dans Préférences Système > Notifications.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7420,15 +7219,13 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Veuillez accorder l\'autorisation de localisation dans Réglages > Confidentialité et sécurité > Services de localisation';
+  String get onboardingLocationGrantInSettings => 'Veuillez accorder l\'autorisation de localisation dans Réglages > Confidentialité et sécurité > Services de localisation';
 
   @override
   String get onboardingMicrophoneRequired => 'L\'autorisation du microphone est requise pour l\'enregistrement.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Autorisation du microphone refusée. Veuillez accorder l\'autorisation dans Préférences Système > Confidentialité et sécurité > Microphone.';
+  String get onboardingMicrophoneDenied => 'Autorisation du microphone refusée. Veuillez accorder l\'autorisation dans Préférences Système > Confidentialité et sécurité > Microphone.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7441,12 +7238,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'L\'autorisation de capture d\'écran est requise pour l\'enregistrement audio système.';
+  String get onboardingScreenCaptureRequired => 'L\'autorisation de capture d\'écran est requise pour l\'enregistrement audio système.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Autorisation de capture d\'écran refusée. Veuillez accorder l\'autorisation dans Préférences Système > Confidentialité et sécurité > Enregistrement d\'écran.';
+  String get onboardingScreenCaptureDenied => 'Autorisation de capture d\'écran refusée. Veuillez accorder l\'autorisation dans Préférences Système > Confidentialité et sécurité > Enregistrement d\'écran.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7459,8 +7254,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'L\'autorisation d\'accessibilité est requise pour détecter les réunions du navigateur.';
+  String get onboardingAccessibilityRequired => 'L\'autorisation d\'accessibilité est requise pour détecter les réunions du navigateur.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7500,8 +7294,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Permission photos refusée. Veuillez autoriser l\'accès aux photos pour sélectionner des images';
+  String get msgPhotosPermissionDenied => 'Permission photos refusée. Veuillez autoriser l\'accès aux photos pour sélectionner des images';
 
   @override
   String get msgSelectImagesGenericError => 'Erreur lors de la sélection d\'images. Veuillez réessayer.';
@@ -7543,8 +7336,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Autorisation du microphone requise';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Accordez l\'autorisation du microphone dans les Préférences Système';
+  String get captureMicrophonePermissionInSystemPreferences => 'Accordez l\'autorisation du microphone dans les Préférences Système';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Autorisation d\'enregistrement d\'écran requise';
@@ -7574,8 +7366,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get locationPermissionRequired => 'Autorisation de localisation requise';
 
   @override
-  String get locationPermissionContent =>
-      'Le transfert rapide nécessite l\'autorisation de localisation pour vérifier la connexion WiFi. Veuillez accorder l\'autorisation de localisation pour continuer.';
+  String get locationPermissionContent => 'Le transfert rapide nécessite l\'autorisation de localisation pour vérifier la connexion WiFi. Veuillez accorder l\'autorisation de localisation pour continuer.';
 
   @override
   String get pdfTranscriptExport => 'Export de transcription';
@@ -7738,8 +7529,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'L\'appareil ne prend pas en charge la synchronisation WiFi, passage au Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'L\'appareil ne prend pas en charge la synchronisation WiFi, passage au Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health n\'est pas disponible sur cet appareil';
@@ -8035,8 +7825,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Mettez Omi DevKit en mode d\'appairage';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Appuyez une fois sur le bouton pour allumer. La LED clignotera en violet en mode d\'appairage.';
+  String get pairingDescOmiDevkit => 'Appuyez une fois sur le bouton pour allumer. La LED clignotera en violet en mode d\'appairage.';
 
   @override
   String get pairingTitleOmiGlass => 'Allumez Omi Glass';
@@ -8048,50 +7837,43 @@ class AppLocalizationsFr extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Mettez Plaud Note en mode d\'appairage';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Appuyez longuement sur le bouton latéral pendant 2 secondes. La LED rouge clignotera quand il sera prêt à s\'appairer.';
+  String get pairingDescPlaudNote => 'Appuyez longuement sur le bouton latéral pendant 2 secondes. La LED rouge clignotera quand il sera prêt à s\'appairer.';
 
   @override
   String get pairingTitleBee => 'Mettez Bee en mode d\'appairage';
 
   @override
-  String get pairingDescBee =>
-      'Appuyez sur le bouton 5 fois de suite. La lumière commencera à clignoter en bleu et vert.';
+  String get pairingDescBee => 'Appuyez sur le bouton 5 fois de suite. La lumière commencera à clignoter en bleu et vert.';
 
   @override
   String get pairingTitleLimitless => 'Mettez Limitless en mode d\'appairage';
 
   @override
-  String get pairingDescLimitless =>
-      'Quand une lumière est visible, appuyez une fois puis appuyez longuement jusqu\'à ce que l\'appareil affiche une lumière rose, puis relâchez.';
+  String get pairingDescLimitless => 'Quand une lumière est visible, appuyez une fois puis appuyez longuement jusqu\'à ce que l\'appareil affiche une lumière rose, puis relâchez.';
 
   @override
   String get pairingTitleFriendPendant => 'Mettez Friend Pendant en mode d\'appairage';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Appuyez sur le bouton du pendentif pour l\'allumer. Il passera automatiquement en mode d\'appairage.';
+  String get pairingDescFriendPendant => 'Appuyez sur le bouton du pendentif pour l\'allumer. Il passera automatiquement en mode d\'appairage.';
 
   @override
   String get pairingTitleFieldy => 'Mettez Fieldy en mode d\'appairage';
 
   @override
-  String get pairingDescFieldy =>
-      'Appuyez longuement sur l\'appareil jusqu\'à ce que la lumière apparaisse pour l\'allumer.';
+  String get pairingDescFieldy => 'Appuyez longuement sur l\'appareil jusqu\'à ce que la lumière apparaisse pour l\'allumer.';
 
   @override
   String get pairingTitleAppleWatch => 'Connecter Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Installez et ouvrez l\'application Omi sur votre Apple Watch, puis appuyez sur Connecter dans l\'application.';
+  String get pairingDescAppleWatch => 'Installez et ouvrez l\'application Omi sur votre Apple Watch, puis appuyez sur Connecter dans l\'application.';
 
   @override
   String get pairingTitleNeoOne => 'Mettez Neo One en mode d\'appairage';
 
   @override
-  String get pairingDescNeoOne =>
-      'Appuyez longuement sur le bouton d\'alimentation jusqu\'à ce que la LED clignote. L\'appareil sera détectable.';
+  String get pairingDescNeoOne => 'Appuyez longuement sur le bouton d\'alimentation jusqu\'à ce que la LED clignote. L\'appareil sera détectable.';
 
   @override
   String get downloadingFromDevice => 'Téléchargement depuis l\'appareil';
@@ -8161,8 +7943,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get wifiConfiguration => 'Configuration WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Entrez vos identifiants WiFi pour permettre à l\'appareil de télécharger le micrologiciel.';
+  String get wifiConfigurationSubtitle => 'Entrez vos identifiants WiFi pour permettre à l\'appareil de télécharger le micrologiciel.';
 
   @override
   String get networkNameSsid => 'Nom du réseau (SSID)';
@@ -8180,8 +7961,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Ce que je sais de vous';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Voici un résumé de ce que je sais de vous d\'après nos conversations. Vous pouvez modifier tout ce qui n\'est pas correct.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Voici un résumé de ce que je sais de vous d\'après nos conversations. Vous pouvez modifier tout ce qui n\'est pas correct.';
 
   @override
   String get apiEnvironment => 'Environnement API';
@@ -8210,8 +7990,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get switchAndRestart => 'Changer';
 
   @override
-  String get stagingDisclaimer =>
-      'L\'environnement staging peut être instable, avoir des performances incohérentes et les données peuvent être perdues. Utilisez-le uniquement pour les tests.';
+  String get stagingDisclaimer => 'L\'environnement staging peut être instable, avoir des performances incohérentes et les données peuvent être perdues. Utilisez-le uniquement pour les tests.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Enregistré. Fermez et rouvrez l\'application pour appliquer.';
@@ -8262,8 +8041,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get phoneGetStarted => 'Commencer';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'L\'enregistrement d\'appels peut necessiter un consentement dans votre juridiction';
+  String get callRecordingConsentDisclaimer => 'L\'enregistrement d\'appels peut necessiter un consentement dans votre juridiction';
 
   @override
   String get enterYourNumber => 'Entrez votre numero';
@@ -8441,8 +8219,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Appels téléphoniques via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Passez des appels via Omi et obtenez une transcription en temps réel, des résumés automatiques et plus encore.';
+  String get phoneCallsUpsellSubtitle => 'Passez des appels via Omi et obtenez une transcription en temps réel, des résumés automatiques et plus encore.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transcription en temps réel de chaque appel';
@@ -8469,8 +8246,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteSyncedFiles => 'Supprimer les enregistrements synchronisés';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Ces enregistrements ont déjà été synchronisés avec votre téléphone. Cette action est irréversible.';
+  String get deleteSyncedFilesMessage => 'Ces enregistrements ont déjà été synchronisés avec votre téléphone. Cette action est irréversible.';
 
   @override
   String get syncedFilesDeleted => 'Enregistrements synchronisés supprimés';
@@ -8482,8 +8258,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deletePendingFiles => 'Supprimer les enregistrements en attente';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Ces enregistrements ne sont PAS synchronisés avec votre téléphone et seront définitivement perdus. Cette action est irréversible.';
+  String get deletePendingFilesWarning => 'Ces enregistrements ne sont PAS synchronisés avec votre téléphone et seront définitivement perdus. Cette action est irréversible.';
 
   @override
   String get pendingFilesDeleted => 'Enregistrements en attente supprimés';
@@ -8495,8 +8270,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteAll => 'Tout supprimer';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Cela supprimera les enregistrements synchronisés et en attente. Les enregistrements en attente ne sont PAS synchronisés et seront définitivement perdus.';
+  String get deleteAllFilesWarning => 'Cela supprimera les enregistrements synchronisés et en attente. Les enregistrements en attente ne sont PAS synchronisés et seront définitivement perdus.';
 
   @override
   String get allFilesDeleted => 'Tous les enregistrements supprimés';
@@ -8561,8 +8335,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fairUseAboutTitle => 'À propos de l\'utilisation raisonnable';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi est conçu pour les conversations personnelles, les réunions et les interactions en direct. L\'utilisation est mesurée par le temps de parole réel détecté, et non par le temps de connexion. Si l\'utilisation dépasse significativement les schémas normaux pour du contenu non personnel, des ajustements peuvent s\'appliquer.';
+  String get fairUseAboutBody => 'Omi est conçu pour les conversations personnelles, les réunions et les interactions en direct. L\'utilisation est mesurée par le temps de parole réel détecté, et non par le temps de connexion. Si l\'utilisation dépasse significativement les schémas normaux pour du contenu non personnel, des ajustements peuvent s\'appliquer.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8600,8 +8373,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get improveConnectionTitle => 'Améliorer la connexion';
 
   @override
-  String get improveConnectionContent =>
-      'Nous avons amélioré la façon dont Omi reste connecté à votre appareil. Pour activer cela, allez sur la page Infos de l\'appareil, appuyez sur \"Déconnecter l\'appareil\", puis reconnectez votre appareil.';
+  String get improveConnectionContent => 'Nous avons amélioré la façon dont Omi reste connecté à votre appareil. Pour activer cela, allez sur la page Infos de l\'appareil, appuyez sur \"Déconnecter l\'appareil\", puis reconnectez votre appareil.';
 
   @override
   String get improveConnectionAction => 'Compris';
@@ -8627,8 +8399,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noSyncedRecordings => 'Aucun enregistrement synchronisé pour le moment';
 
   @override
-  String get recordingsSyncAutomatically =>
-      'Les enregistrements se synchronisent automatiquement — aucune action requise.';
+  String get recordingsSyncAutomatically => 'Les enregistrements se synchronisent automatiquement — aucune action requise.';
 
   @override
   String get filesDownloadedUploadedNextTime => 'Les fichiers déjà téléchargés seront envoyés la prochaine fois.';
@@ -8657,16 +8428,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cancelSyncQuestion => 'Annuler la synchronisation ?';
 
   @override
-  String get omisStorageDesc =>
-      'Lorsque votre Omi n\'est pas connecté à votre téléphone, il stocke l\'audio localement dans sa mémoire intégrée. Vous ne perdez jamais un enregistrement.';
+  String get omisStorageDesc => 'Lorsque votre Omi n\'est pas connecté à votre téléphone, il stocke l\'audio localement dans sa mémoire intégrée. Vous ne perdez jamais un enregistrement.';
 
   @override
-  String get phoneStorageDesc =>
-      'Lorsqu\'Omi se reconnecte, les enregistrements sont automatiquement transférés sur votre téléphone avant l\'envoi.';
+  String get phoneStorageDesc => 'Lorsqu\'Omi se reconnecte, les enregistrements sont automatiquement transférés sur votre téléphone avant l\'envoi.';
 
   @override
-  String get cloudStorageDesc =>
-      'Une fois envoyés, vos enregistrements sont traités et transcrits. Les conversations seront disponibles en une minute.';
+  String get cloudStorageDesc => 'Une fois envoyés, vos enregistrements sont traités et transcrits. Les conversations seront disponibles en une minute.';
 
   @override
   String get tipKeepPhoneNearby => 'Gardez votre téléphone à proximité pour une synchronisation plus rapide';
@@ -8690,12 +8458,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get permissionEnable => 'Activer';
 
   @override
-  String get permissionsPageDescription =>
-      'Ces autorisations sont essentielles au fonctionnement d\'Omi. Elles activent des fonctionnalités clés comme les notifications, les expériences basées sur la localisation et la capture audio.';
+  String get permissionsPageDescription => 'Ces autorisations sont essentielles au fonctionnement d\'Omi. Elles activent des fonctionnalités clés comme les notifications, les expériences basées sur la localisation et la capture audio.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi a besoin de quelques autorisations pour fonctionner correctement. Veuillez les accorder pour continuer.';
+  String get permissionsRequiredDescription => 'Omi a besoin de quelques autorisations pour fonctionner correctement. Veuillez les accorder pour continuer.';
 
   @override
   String get permissionsSetupTitle => 'Profitez de la meilleure expérience';
@@ -8749,8 +8515,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get justAMoment => 'Un instant, s\'il vous plaît';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Nous vous recommandons vivement d\'explorer vos autres options au lieu d\'annuler.';
+  String get cancelConsequencesSubtitle => 'Nous vous recommandons vivement d\'explorer vos autres options au lieu d\'annuler.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8952,8 +8717,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get enableLocationTitle => 'Activer la localisation';
 
   @override
-  String get enableLocationDescription =>
-      'L\'autorisation de localisation est nécessaire pour trouver les appareils Bluetooth à proximité.';
+  String get enableLocationDescription => 'L\'autorisation de localisation est nécessaire pour trouver les appareils Bluetooth à proximité.';
 
   @override
   String get voiceRecordingFound => 'Enregistrement trouvé';
@@ -8974,8 +8738,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get firmwareWarningTitle => 'Important : Lisez avant de mettre à jour';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ce firmware formatera la carte SD. Veuillez vous assurer que toutes les données hors ligne sont synchronisées avant la mise à jour.\n\nSi vous voyez un voyant rouge clignotant après l\'installation de cette version, ne vous inquiétez pas. Connectez simplement l\'appareil à l\'application et il devrait devenir bleu. Le voyant rouge signifie que l\'horloge de l\'appareil n\'a pas encore été synchronisée.';
+  String get firmwareFormatWarning => 'Ce firmware formatera la carte SD. Veuillez vous assurer que toutes les données hors ligne sont synchronisées avant la mise à jour.\n\nSi vous voyez un voyant rouge clignotant après l\'installation de cette version, ne vous inquiétez pas. Connectez simplement l\'appareil à l\'application et il devrait devenir bleu. Le voyant rouge signifie que l\'horloge de l\'appareil n\'a pas encore été synchronisée.';
 
   @override
   String get continueAnyway => 'Continuer';
@@ -8995,8 +8758,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tasksMarkComplete => 'Marqué comme terminé';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi accède à Apple Health via le framework HealthKit d\'Apple. Vous pouvez révoquer l\'accès à tout moment dans les Réglages iOS.';
+  String get appleHealthManageNote => 'Omi accède à Apple Health via le framework HealthKit d\'Apple. Vous pouvez révoquer l\'accès à tout moment dans les Réglages iOS.';
 
   @override
   String get appleHealthConnectCta => 'Connecter à Apple Health';
@@ -9011,8 +8773,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appleHealthFeatureChatTitle => 'Discutez de votre santé';
 
   @override
-  String get appleHealthFeatureChatDesc =>
-      'Demandez à Omi vos pas, votre sommeil, votre fréquence cardiaque et vos entraînements.';
+  String get appleHealthFeatureChatDesc => 'Demandez à Omi vos pas, votre sommeil, votre fréquence cardiaque et vos entraînements.';
 
   @override
   String get appleHealthFeatureReadOnlyTitle => 'Accès en lecture seule';
@@ -9024,15 +8785,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appleHealthFeatureSecureTitle => 'Synchronisation sécurisée';
 
   @override
-  String get appleHealthFeatureSecureDesc =>
-      'Vos données Apple Health se synchronisent en privé avec votre compte Omi.';
+  String get appleHealthFeatureSecureDesc => 'Vos données Apple Health se synchronisent en privé avec votre compte Omi.';
 
   @override
   String get appleHealthDeniedTitle => 'Accès à Apple Health refusé';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi n\'a pas l\'autorisation de lire vos données Apple Health. Activez-la dans Réglages iOS → Confidentialité et sécurité → Santé → Omi.';
+  String get appleHealthDeniedBody => 'Omi n\'a pas l\'autorisation de lire vos données Apple Health. Activez-la dans Réglages iOS → Confidentialité et sécurité → Santé → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Pourquoi partez-vous ?';
@@ -9101,8 +8860,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get planUpdate => 'Mise à jour du plan';
 
   @override
-  String get planDeprecationMessage =>
-      'Votre plan Unlimited est en cours de retrait. Passez au plan Operator — les mêmes fonctionnalités à \$49/mois. Votre plan actuel continuera de fonctionner en attendant.';
+  String get planDeprecationMessage => 'Votre plan Unlimited est en cours de retrait. Passez au plan Operator — les mêmes fonctionnalités à \$49/mois. Votre plan actuel continuera de fonctionner en attendant.';
 
   @override
   String get upgradeYourPlan => 'Améliorez votre forfait';
@@ -9213,8 +8971,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Vous avez atteint votre limite mensuelle. Passez à un plan supérieur pour continuer à discuter avec Omi sans restrictions.';
+  String get chatQuotaExceededReply => 'Vous avez atteint votre limite mensuelle. Passez à un plan supérieur pour continuer à discuter avec Omi sans restrictions.';
 
   @override
   String get voiceResponseAudio => 'Lire la réponse d\'Omi à haute voix';
@@ -9245,4 +9002,25 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Ajouter une tâche';
+
+  @override
+  String get quickActionAskOmiAnything => 'Demandez n\'importe quoi à Omi';
+
+  @override
+  String get quickActionVoiceMode => 'Mode vocal';
+
+  @override
+  String get quickActionMute => 'Couper le son';
+
+  @override
+  String get quickActionUnmute => 'Activer le son';
+
+  @override
+  String get quickActionConnectDevice => 'Connecter l\'appareil';
+
+  @override
+  String get quickActionDeviceSettings => 'Paramètres de l\'appareil';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -24,8 +24,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get deleteConversationTitle => 'מחיקת שיחה?';
 
   @override
-  String get deleteConversationMessage =>
-      'פעולה זו תמחק גם זיכרונות משויכים, משימות וקבצי אודיו. לא ניתן לבטל פעולה זו.';
+  String get deleteConversationMessage => 'פעולה זו תמחק גם זיכרונות משויכים, משימות וקבצי אודיו. לא ניתן לבטל פעולה זו.';
 
   @override
   String get confirm => 'אישור';
@@ -354,19 +353,16 @@ class AppLocalizationsHe extends AppLocalizations {
   String get appsDisconnected => 'האפליקציות והאינטגרציות שלך יהיו מנותקות באופן מיידי.';
 
   @override
-  String get exportBeforeDelete =>
-      'אתה יכול לייצא את הנתונים שלך לפני מחיקת החשבון, אך לאחר מחיקה, לא ניתן להחזיר אותם.';
+  String get exportBeforeDelete => 'אתה יכול לייצא את הנתונים שלך לפני מחיקת החשבון, אך לאחר מחיקה, לא ניתן להחזיר אותם.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'אני מבין שמחיקת החשבון שלי היא קבע וכל הנתונים, כולל זיכרונות ושיחות, יימחקו ולא יוכלו להיאחזר.';
+  String get deleteAccountCheckbox => 'אני מבין שמחיקת החשבון שלי היא קבע וכל הנתונים, כולל זיכרונות ושיחות, יימחקו ולא יוכלו להיאחזר.';
 
   @override
   String get areYouSure => 'האם אתה בטוח?';
 
   @override
-  String get deleteAccountFinal =>
-      'פעולה זו בלתי הפיכה ותמחק לצמיתות את החשבון שלך ואת כל הנתונים המשויכים. האם אתה בטוח שברצונך להמשיך?';
+  String get deleteAccountFinal => 'פעולה זו בלתי הפיכה ותמחק לצמיתות את החשבון שלך ואת כל הנתונים המשויכים. האם אתה בטוח שברצונך להמשיך?';
 
   @override
   String get deleteNow => 'מחק עכשיו';
@@ -453,8 +449,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get yourPrivacyYourControl => 'הפרטיות שלך, השליטה שלך';
 
   @override
-  String get privacyIntro =>
-      'ב-Omi, אנחנו מתחייבים להגן על הפרטיות שלך. דף זה מאפשר לך לשלוט בכיצד הנתונים שלך מאוחסנים ומשומשים.';
+  String get privacyIntro => 'ב-Omi, אנחנו מתחייבים להגן על הפרטיות שלך. דף זה מאפשר לך לשלוט בכיצד הנתונים שלך מאוחסנים ומשומשים.';
 
   @override
   String get learnMore => 'למד עוד...';
@@ -463,8 +458,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get dataProtectionLevel => 'רמת הגנה נתונים';
 
   @override
-  String get dataProtectionDesc =>
-      'הנתונים שלך מאובטחים כברירת מחדל בהצפנה חזקה. בדוק את ההגדרות שלך ואפשרויות הפרטיות העתידיות להלן.';
+  String get dataProtectionDesc => 'הנתונים שלך מאובטחים כברירת מחדל בהצפנה חזקה. בדוק את ההגדרות שלך ואפשרויות הפרטיות העתידיות להלן.';
 
   @override
   String get appAccess => 'גישה אפליקציה';
@@ -527,15 +521,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get deviceDisconnectedMessage => 'ה-Omi שלך נותק 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'מכשיר לא זוווג. עבור להגדרות > Bluetooth ושכח את המכשיר כדי להשלים את הביטול זיווג.';
+  String get deviceUnpairedMessage => 'מכשיר לא זוווג. עבור להגדרות > Bluetooth ושכח את המכשיר כדי להשלים את הביטול זיווג.';
 
   @override
   String get unpairDialogTitle => 'בטל זיווג מכשיר';
 
   @override
-  String get unpairDialogMessage =>
-      'פעולה זו תבטל את זיווג המכשיר כדי שניתן יהיה להתחברות אותו לטלפון אחר. תצטרך לעבור להגדרות > Bluetooth ולשכוח את המכשיר כדי להשלים את התהליך.';
+  String get unpairDialogMessage => 'פעולה זו תבטל את זיווג המכשיר כדי שניתן יהיה להתחברות אותו לטלפון אחר. תצטרך לעבור להגדרות > Bluetooth ולשכוח את המכשיר כדי להשלים את התהליך.';
 
   @override
   String get deviceNotConnected => 'מכשיר לא מחובר';
@@ -556,8 +548,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get v2Undetected => 'V2 לא זוהה';
 
   @override
-  String get v2UndetectedMessage =>
-      'אנו רואים שיש לך מכשיר V1 או שהמכשיר שלך לא מחובר. פונקציונליות כרטיס SD זמינה רק למכשירי V2.';
+  String get v2UndetectedMessage => 'אנו רואים שיש לך מכשיר V1 או שהמכשיר שלך לא מחובר. פונקציונליות כרטיס SD זמינה רק למכשירי V2.';
 
   @override
   String get endConversation => 'סיים שיחה';
@@ -831,8 +822,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'מחיקת גרף ידע?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'פעולה זו תמחק את כל נתוני גרף הידע הנגזרים (צמתים וחיבורים). הזיכרונות המקוריים שלך יישארו בטוחים. הגרף יוחדש לאורך זמן או בעת הבקשה הבאה.';
+  String get deleteKnowledgeGraphMessage => 'פעולה זו תמחק את כל נתוני גרף הידע הנגזרים (צמתים וחיבורים). הזיכרונות המקוריים שלך יישארו בטוחים. הגרף יוחדש לאורך זמן או בעת הבקשה הבאה.';
 
   @override
   String get knowledgeGraphDeleted => 'גרף ידע נמחק';
@@ -1096,12 +1086,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get enhanceTranscriptAccuracy => 'שפר את דיוק התמלול';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'כשהמודל שלנו משתפר, אנחנו יכולים לספק תוצאות תמלול טובות יותר לההקלטות שלך.';
+  String get enhanceTranscriptAccuracyDesc => 'כשהמודל שלנו משתפר, אנחנו יכולים לספק תוצאות תמלול טובות יותר לההקלטות שלך.';
 
   @override
-  String get legalNotice =>
-      'הודעה משפטית: חוקיות ההקלטה ואחסון נתוני קול עשויים להשתנות בהתאם למיקום ואופן השימוש בתכונה זו. זו אחריותך לוודא עמידה בחוקים ותקנות מקומיים.';
+  String get legalNotice => 'הודעה משפטית: חוקיות ההקלטה ואחסון נתוני קול עשויים להשתנות בהתאם למיקום ואופן השימוש בתכונה זו. זו אחריותך לוודא עמידה בחוקים ותקנות מקומיים.';
 
   @override
   String get alreadyAuthorized => 'כבר מוסמך';
@@ -1347,8 +1335,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get defaultRepository => 'מאגר ברירת המחדל';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'בחר מאגר ברירת מחדל ליצירת בעיות. אתה עדיין יכול לציין מאגר שונה בעת יצירת בעיות.';
+  String get selectDefaultRepoDesc => 'בחר מאגר ברירת מחדל ליצירת בעיות. אתה עדיין יכול לציין מאגר שונה בעת יצירת בעיות.';
 
   @override
   String get noReposFound => 'לא נמצאו מאגרים';
@@ -1756,8 +1743,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get locationServiceDisabled => 'שירות מיקום מושבת';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'שירות מיקום מושבת. בבקשה עבור להגדרות > פרטיות וביטחון > שירותי מיקום והפעל אותו';
+  String get locationServiceDisabledDesc => 'שירות מיקום מושבת. בבקשה עבור להגדרות > פרטיות וביטחון > שירותי מיקום והפעל אותו';
 
   @override
   String get backgroundLocationDenied => 'גישת מיקום רקע נדחתה';
@@ -1772,8 +1758,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get leaveReviewIos => 'עזור לנו להגיע ליותר אנשים על ידי השארת ביקורת ב-App Store. המשוב שלך אומר לנו הרבה!';
 
   @override
-  String get leaveReviewAndroid =>
-      'עזור לנו להגיע ליותר אנשים על ידי השארת ביקורת ב-Google Play Store. המשוב שלך אומר לנו הרבה!';
+  String get leaveReviewAndroid => 'עזור לנו להגיע ליותר אנשים על ידי השארת ביקורת ב-Google Play Store. המשוב שלך אומר לנו הרבה!';
 
   @override
   String get rateOnAppStore => 'דרג ב-App Store';
@@ -1845,8 +1830,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get permissionsRequired => 'הרשאות נדרשות';
 
   @override
-  String get permissionsRequiredDesc =>
-      'אפליקציה זו זקוקה להרשאות Bluetooth ומיקום כדי לתפקד כראוי. בבקשה הפעל אותן בהגדרות.';
+  String get permissionsRequiredDesc => 'אפליקציה זו זקוקה להרשאות Bluetooth ומיקום כדי לתפקד כראוי. בבקשה הפעל אותן בהגדרות.';
 
   @override
   String get openSettings => 'פתח הגדרות';
@@ -1891,8 +1875,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get permissionGrantedNow => 'הרשאה ניתנה! עכשיו:\n\nפתח את אפליקציית Omi בשעון שלך וטפוק \"המשך\" למטה';
 
   @override
-  String get needMicrophonePermission =>
-      'אנחנו זקוקים להרשאת מיקרופון.\n\n1. טפוק \"הנח הרשאה\"\n2. אפשר באייפון שלך\n3. אפליקציית השעון תיסגר\n4. פתח מחדש וטפוק \"המשך\"';
+  String get needMicrophonePermission => 'אנחנו זקוקים להרשאת מיקרופון.\n\n1. טפוק \"הנח הרשאה\"\n2. אפשר באייפון שלך\n3. אפליקציית השעון תיסגר\n4. פתח מחדש וטפוק \"המשך\"';
 
   @override
   String get grantPermissionButton => 'הנח הרשאה';
@@ -1901,15 +1884,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get needHelp => 'זקוק לעזרה?';
 
   @override
-  String get troubleshootingSteps =>
-      'פתרון בעיות:\n\n1. ודא שOmi מותקן בשעון שלך\n2. פתח את אפליקציית Omi בשעון שלך\n3. חפש את חלון ההרשאה\n4. טפוק \"אפשר\" כשתתבקש\n5. אפליקציה בשעון שלך תיסגר - פתח מחדש\n6. חזור וטפוק \"המשך\" באייפון שלך';
+  String get troubleshootingSteps => 'פתרון בעיות:\n\n1. ודא שOmi מותקן בשעון שלך\n2. פתח את אפליקציית Omi בשעון שלך\n3. חפש את חלון ההרשאה\n4. טפוק \"אפשר\" כשתתבקש\n5. אפליקציה בשעון שלך תיסגר - פתח מחדש\n6. חזור וטפוק \"המשך\" באייפון שלך';
 
   @override
   String get recordingStartedSuccessfully => 'הקלטה התחילה בהצלחה!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'הרשאה עדיין לא ניתנה. בבקשה ודא שאפשרת גישת מיקרופון ופתחת את האפליקציה בשעון שלך מחדש.';
+  String get permissionNotGrantedYet => 'הרשאה עדיין לא ניתנה. בבקשה ודא שאפשרת גישת מיקרופון ופתחת את האפליקציה בשעון שלך מחדש.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2006,8 +1987,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get welcomeActionItemsTitle => 'מוכן לפריטי פעולה';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'הבינה המלאכותית שלך תחלץ באופן אוטומטי משימות ועסקים לעשות מהשיחות שלך. הם יופיעו כאן כשייווצרו.';
+  String get welcomeActionItemsDescription => 'הבינה המלאכותית שלך תחלץ באופן אוטומטי משימות ועסקים לעשות מהשיחות שלך. הם יופיעו כאן כשייווצרו.';
 
   @override
   String get autoExtractionFeature => 'מחולץ באופן אוטומטי משיחות';
@@ -2203,8 +2183,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'דיבור וריבוי מדיה';
 
   @override
-  String get languageSettingsHelperText =>
-      'שינוי שפת אפליקציה משנה תפריטים וכפתורים. שפת דיבור משפיעה על אופן התמלול של ההקלטות שלך.';
+  String get languageSettingsHelperText => 'שינוי שפת אפליקציה משנה תפריטים וכפתורים. שפת דיבור משפיעה על אופן התמלול של ההקלטות שלך.';
 
   @override
   String get translationNotice => 'הודעת תרגום';
@@ -2372,8 +2351,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'נתק מכשיר';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'זה ינתק את המכשיר כדי שיוכל להתחבר לטלפון אחר. יהיה עליך ללכת להגדרות > Bluetooth ולשכוח את המכשיר כדי להשלים את התהליך.';
+  String get unpairDeviceDialogMessage => 'זה ינתק את המכשיר כדי שיוכל להתחבר לטלפון אחר. יהיה עליך ללכת להגדרות > Bluetooth ולשכוח את המכשיר כדי להשלים את התהליך.';
 
   @override
   String get unpair => 'נתק';
@@ -2855,12 +2833,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get submitAppQuestion => 'להגיש אפליקציה?';
 
   @override
-  String get submitAppPublicDescription =>
-      'האפליקציה שלך תבדוק ותהיה ציבורית. אתה יכול להתחיל להשתמש בה מיד, אפילו במהלך הבדיקה!';
+  String get submitAppPublicDescription => 'האפליקציה שלך תבדוק ותהיה ציבורית. אתה יכול להתחיל להשתמש בה מיד, אפילו במהלך הבדיקה!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'האפליקציה שלך תבדוק ותהיה זמינה לך באופן פרטי. אתה יכול להתחיל להשתמש בה מיד, אפילו במהלך הבדיקה!';
+  String get submitAppPrivateDescription => 'האפליקציה שלך תבדוק ותהיה זמינה לך באופן פרטי. אתה יכול להתחיל להשתמש בה מיד, אפילו במהלך הבדיקה!';
 
   @override
   String get startEarning => 'התחל להרוויח! 💰';
@@ -2884,8 +2860,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get dataAccessNotice => 'הודעת גישה לנתונים';
 
   @override
-  String get dataAccessWarning =>
-      'אפליקציה זו תוכל לגשת לנתונים שלך. Omi AI אינה אחראית לאופן שבו הנתונים שלך משמשים, משתנים או נמחקים על ידי אפליקציה זו';
+  String get dataAccessWarning => 'אפליקציה זו תוכל לגשת לנתונים שלך. Omi AI אינה אחראית לאופן שבו הנתונים שלך משמשים, משתנים או נמחקים על ידי אפליקציה זו';
 
   @override
   String get installApp => 'התקן אפליקציה';
@@ -2959,8 +2934,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get descriptionLabel => 'תיאור';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'אפליקציה נהדרת שלי היא אפליקציה מעולה שעושה דברים מדהימים. היא האפליקציה הטובה ביותר!';
+  String get appDescriptionPlaceholder => 'אפליקציה נהדרת שלי היא אפליקציה מעולה שעושה דברים מדהימים. היא האפליקציה הטובה ביותר!';
 
   @override
   String get pleaseProvideValidDescription => 'אנא בחר תיאור תקף';
@@ -3112,8 +3086,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get microphonePermissionRequired => 'הרשאת מיקרופון נדרשת לביצוע שיחות';
 
   @override
-  String get microphonePermissionDenied =>
-      'הרשאת מיקרופון נדחתה. אנא תן הרשאה בהעדפות המערכת > פרטיות וביטחון > מיקרופון.';
+  String get microphonePermissionDenied => 'הרשאת מיקרופון נדחתה. אנא תן הרשאה בהעדפות המערכת > פרטיות וביטחון > מיקרופון.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3346,8 +3319,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get whatWeCollect => 'מה אנחנו אוספים';
 
   @override
-  String get dataCollectionMessage =>
-      'בהמשך שלך, השיחות, ההקלטות והמידע האישי שלך יישמרו בצורה מאובטחת בשרתים שלנו כדי לספק תובנות בהנעת AI ולהפוך את כל תכונות האפליקציה לאפשריות.';
+  String get dataCollectionMessage => 'בהמשך שלך, השיחות, ההקלטות והמידע האישי שלך יישמרו בצורה מאובטחת בשרתים שלנו כדי לספק תובנות בהנעת AI ולהפוך את כל תכונות האפליקציה לאפשריות.';
 
   @override
   String get dataProtection => 'הגנת נתונים';
@@ -3380,8 +3352,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'השם חייב להיות לפחות 2 תווים';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'ספר לנו איך היית רוצה להיקרא. זה עוזר להתאים אישית את חוויית Omi שלך.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'ספר לנו איך היית רוצה להיקרא. זה עוזר להתאים אישית את חוויית Omi שלך.';
 
   @override
   String charactersCount(int count) {
@@ -3416,8 +3387,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'זהה פגישות מבוססות דפדפן';
 
   @override
-  String get accessibilityDescription =>
-      'Omi זקוקה להרשאת נגישות כדי לזהות כאשר אתה משתתף בפגישות Zoom, Meet או Teams בדפדפן שלך.';
+  String get accessibilityDescription => 'Omi זקוקה להרשאת נגישות כדי לזהות כאשר אתה משתתף בפגישות Zoom, Meet או Teams בדפדפן שלך.';
 
   @override
   String get pleaseWait => 'אנא המתן...';
@@ -3489,8 +3459,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get conversationsExportStarted => 'ייצוא שיחות החל. זה עשוי לקחת כמה שניות, אנא המתן.';
 
   @override
-  String get mcpDescription =>
-      'כדי לחבר את Omi עם יישומים אחרים כדי לקרוא, לחפוש ולנהל את הזיכרונות והשיחות שלך. צור מפתח כדי להתחיל.';
+  String get mcpDescription => 'כדי לחבר את Omi עם יישומים אחרים כדי לקרוא, לחפוש ולנהל את הזיכרונות והשיחות שלך. צור מפתח כדי להתחיל.';
 
   @override
   String get apiKeys => 'מפתחות API';
@@ -3646,8 +3615,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get preparingSystemAudioCapture => 'הכנה ללכידת אודיו מערכת';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'לחץ על הכפתור כדי ללכוד אודיו עבור עתודות חיות, תובנות AI וחיסכון אוטומטי.';
+  String get clickTheButtonToCaptureAudio => 'לחץ על הכפתור כדי ללכוד אודיו עבור עתודות חיות, תובנות AI וחיסכון אוטומטי.';
 
   @override
   String get reconnecting => 'חיבור חדש...';
@@ -3874,8 +3842,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'מחק גרף ידע?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'זה ימחק את כל נתוני גרף הידע שהוכלו. הזיכרונות המקוריים שלך נשמרים בבטחון.';
+  String get deleteKnowledgeGraphWarning => 'זה ימחק את כל נתוני גרף הידע שהוכלו. הזיכרונות המקוריים שלך נשמרים בבטחון.';
 
   @override
   String get connectOmiWithAI => 'חבר את Omi עם עוזרים AI';
@@ -3998,8 +3965,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'בטל מנוי?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'האם אתה בטוח שברצונך לבטל את המנוי שלך? תהיה לך גישה מתמשכת עד סוף תקופת החיוב הנוכחית.';
+  String get cancelSubscriptionConfirmation => 'האם אתה בטוח שברצונך לבטל את המנוי שלך? תהיה לך גישה מתמשכת עד סוף תקופת החיוב הנוכחית.';
 
   @override
   String get cancelSubscriptionButton => 'בטל מנוי';
@@ -4068,8 +4034,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get issueActivatingApp => 'היתה בעיה בהפעלת האפליקציה הזו. אנא נסה שוב.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'אפליקציה זו תגיע לגישה לנתונים שלך. Omi AI אינה אחראית לאופן השימוש, השינוי או המחיקה של הנתונים שלך על ידי אפליקציה זו.';
+  String get dataAccessNoticeDescription => 'אפליקציה זו תגיע לגישה לנתונים שלך. Omi AI אינה אחראית לאופן השימוש, השינוי או המחיקה של הנתונים שלך על ידי אפליקציה זו.';
 
   @override
   String get copyUrl => 'העתק כתובת URL';
@@ -4157,8 +4122,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get omiApiKeys => 'מפתחות API של Omi';
 
   @override
-  String get apiKeysDescription =>
-      'מפתחות API משמשים לאימות כאשר האפליקציה שלך תקשרת עם שרת OMI. הם מאפשרים לאפליקציה שלך ליצור זיכרונות ולגשת לשירותי OMI אחרים בצורה מאובטחת.';
+  String get apiKeysDescription => 'מפתחות API משמשים לאימות כאשר האפליקציה שלך תקשרת עם שרת OMI. הם מאפשרים לאפליקציה שלך ליצור זיכרונות ולגשת לשירותי OMI אחרים בצורה מאובטחת.';
 
   @override
   String get aboutOmiApiKeys => 'אודות מפתחות API של Omi';
@@ -4280,8 +4244,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get externalAppAccess => 'גישה לאפליקציה חיצונית';
 
   @override
-  String get externalAppAccessDescription =>
-      'היישומים המותקנים הבאים כוללים שילובים חיצוניים ויכולים לגשת לנתונים שלך, כגון שיחות וזיכרונות.';
+  String get externalAppAccessDescription => 'היישומים המותקנים הבאים כוללים שילובים חיצוניים ויכולים לגשת לנתונים שלך, כגון שיחות וזיכרונות.';
 
   @override
   String get noExternalAppsHaveAccess => 'לאיזה אפליקציות חיצוניות אין גישה לנתונים שלך.';
@@ -4290,8 +4253,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get maximumSecurityE2ee => 'אבטחה מקסימלית (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'הצפנה מקצה לקצה היא התקן הזהב לפרטיות. כאשר זה מופעל, הנתונים שלך מוצפנים בהתקן שלך לפני שהם נשלחים לשרתים שלנו. זה אומר שאף אחד, אפילו Omi, לא יכול לגשת לתוכן שלך.';
+  String get e2eeDescription => 'הצפנה מקצה לקצה היא התקן הזהב לפרטיות. כאשר זה מופעל, הנתונים שלך מוצפנים בהתקן שלך לפני שהם נשלחים לשרתים שלנו. זה אומר שאף אחד, אפילו Omi, לא יכול לגשת לתוכן שלך.';
 
   @override
   String get importantTradeoffs => 'סחר חשוב:';
@@ -4325,8 +4287,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get secureEncryption => 'הצפנה מאובטחת';
 
   @override
-  String get secureEncryptionDescription =>
-      'הנתונים שלך מוצפנים עם מפתח ייחודי לך בשרתים שלנו, מתוחזקים על Google Cloud. זה אומר שהתוכן הגולמי שלך לא נגיש לאף אחד, כולל צוות Omi או Google, ישירות מ-DB.';
+  String get secureEncryptionDescription => 'הנתונים שלך מוצפנים עם מפתח ייחודי לך בשרתים שלנו, מתוחזקים על Google Cloud. זה אומר שהתוכן הגולמי שלך לא נגיש לאף אחד, כולל צוות Omi או Google, ישירות מ-DB.';
 
   @override
   String get endToEndEncryption => 'הצפנה מקצה לקצה';
@@ -4403,8 +4364,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get getOmiUnlimitedFree => 'קבל Omi Unlimited בחינם על ידי תרומת הנתונים שלך לאימון מודלי AI.';
 
   @override
-  String get trainingDataBullets =>
-      '• הנתונים שלך עוזרים לשפר את מודלי ה-AI\n• רק נתונים שאינם רגישים משותפים\n• תהליך שקוף לחלוטין';
+  String get trainingDataBullets => '• הנתונים שלך עוזרים לשפר את מודלי ה-AI\n• רק נתונים שאינם רגישים משותפים\n• תהליך שקוף לחלוטין';
 
   @override
   String get learnMoreAtOmiTraining => 'למד עוד בכתובת omi.me/training';
@@ -4564,8 +4524,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'הפרטיות שלך חשובה לנו';
 
   @override
-  String get privacyIntroText =>
-      'ב-Omi, אנחנו לוקחים את הפרטיות שלך ברצינות רבה. אנחנו רוצים להיות שקופים לגבי הנתונים שאנחנו אוספים וכיצד אנחנו משתמשים בהם כדי לשפר את המוצר שלך. הנה מה שאתה צריך לדעת:';
+  String get privacyIntroText => 'ב-Omi, אנחנו לוקחים את הפרטיות שלך ברצינות רבה. אנחנו רוצים להיות שקופים לגבי הנתונים שאנחנו אוספים וכיצד אנחנו משתמשים בהם כדי לשפר את המוצר שלך. הנה מה שאתה צריך לדעת:';
 
   @override
   String get whatWeTrack => 'מה אנחנו עוקבים';
@@ -4580,12 +4539,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get ourCommitment => 'ההתחייבות שלנו';
 
   @override
-  String get commitmentText =>
-      'אנחנו מחויבים להשתמש בנתונים שאנחנו אוספים רק כדי לעשות את Omi למוצר טוב יותר בשבילך. הפרטיות והאמון שלך הם חיוניים לנו.';
+  String get commitmentText => 'אנחנו מחויבים להשתמש בנתונים שאנחנו אוספים רק כדי לעשות את Omi למוצר טוב יותר בשבילך. הפרטיות והאמון שלך הם חיוניים לנו.';
 
   @override
-  String get thankYouText =>
-      'תודה על היותך משתמש מוערך של Omi. אם יש לך שאלות או חששות, אתה מוזמן לפנות אלינו ל-team@basedhardware.com.';
+  String get thankYouText => 'תודה על היותך משתמש מוערך של Omi. אם יש לך שאלות או חששות, אתה מוזמן לפנות אלינו ל-team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'הגדרות סנכרון WiFi';
@@ -4594,8 +4551,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get enterHotspotCredentials => 'הזן את פרטי הנקודה הציבורית של הטלפון שלך';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'סנכרון WiFi משתמש בטלפון שלך כנקודה ציבורית. מצא את שם הנקודה הציבורית וסיסמה בהגדרות > Personal Hotspot.';
+  String get wifiSyncUsesHotspot => 'סנכרון WiFi משתמש בטלפון שלך כנקודה ציבורית. מצא את שם הנקודה הציבורית וסיסמה בהגדרות > Personal Hotspot.';
 
   @override
   String get hotspotNameSsid => 'שם הנקודה הציבורית (SSID)';
@@ -4660,8 +4616,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'ייצוא החל. זה עשוי לקחת כמה שניות...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'זה יימחק את כל נתוני תרשים הידע הנגזרות (צמתים וחיבורים). הזכרונות המקוריים שלך יישארו בטוחים. התרשים יבנה מחדש לאורך זמן או בבקשה הבאה.';
+  String get knowledgeGraphDeleteDescription => 'זה יימחק את כל נתוני תרשים הידע הנגזרות (צמתים וחיבורים). הזכרונות המקוריים שלך יישארו בטוחים. התרשים יבנה מחדש לאורך זמן או בבקשה הבאה.';
 
   @override
   String get configureDailySummaryDigest => 'הגדר את עיכול פריטי הפעולה היומיים שלך';
@@ -4787,8 +4742,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get howItWorksTitle => 'איך זה עובד?';
 
   @override
-  String get howPeopleWorks =>
-      'ברגע שנוצרת אדם, אתה יכול ללכת לתמלול שיחה, ולהקצות להם את הקטעים המתאימים שלהם, בדרך זו Omi יוכל גם לזהות את הדיבור שלהם!';
+  String get howPeopleWorks => 'ברגע שנוצרת אדם, אתה יכול ללכת לתמלול שיחה, ולהקצות להם את הקטעים המתאימים שלהם, בדרך זו Omi יוכל גם לזהות את הדיבור שלהם!';
 
   @override
   String get tapToDelete => 'הקש כדי למחוק';
@@ -4814,8 +4768,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get privacyNotice => 'הודעת פרטיות';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'הקלטות עשויות ללכוד קולות של אחרים. ודא שיש לך הסכמה מכל המשתתפים לפני הפעלה.';
+  String get recordingsMayCaptureOthers => 'הקלטות עשויות ללכוד קולות של אחרים. ודא שיש לך הסכמה מכל המשתתפים לפני הפעלה.';
 
   @override
   String get enable => 'הפעל';
@@ -4827,8 +4780,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get on => 'פעיל';
 
   @override
-  String get storeAudioDescription =>
-      'שמור את כל הקלטות האודיו באופן מקומי בטלפון שלך. כאשר מבוטל, רק ההעלאות שנכשלו נשמרות כדי לחסוך מקום אחסון.';
+  String get storeAudioDescription => 'שמור את כל הקלטות האודיו באופן מקומי בטלפון שלך. כאשר מבוטל, רק ההעלאות שנכשלו נשמרות כדי לחסוך מקום אחסון.';
 
   @override
   String get enableLocalStorage => 'הפעל אחסון מקומי';
@@ -4849,8 +4801,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get cloudStorageDialogMessage => 'הקלטות ההזמנה שלך תאוחסנה בפרטי אחסון ענן כפי שאתה מדבר.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'אחסן את הקלטות ההזמנה שלך באחסון ענן פרטי כפי שאתה מדבר. אודיו נתפס ונשמר בבטחה בזמן אמת.';
+  String get storeAudioCloudDescription => 'אחסן את הקלטות ההזמנה שלך באחסון ענן פרטי כפי שאתה מדבר. אודיו נתפס ונשמר בבטחה בזמן אמת.';
 
   @override
   String get downloadingFirmware => 'הורדת Firmware';
@@ -4957,8 +4908,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get connectingYourStripeAccount => 'חיבור חשבון Stripe שלך';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'אנא השלם את תהליך ההתרשמות של Stripe בדפדפן שלך. דף זה יתעדכן באופן אוטומטי לאחר השלמתו.';
+  String get stripeOnboardingInstructions => 'אנא השלם את תהליך ההתרשמות של Stripe בדפדפן שלך. דף זה יתעדכן באופן אוטומטי לאחר השלמתו.';
 
   @override
   String get failedTryAgain => 'נכשל? נסה שוב';
@@ -4970,8 +4920,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get successfullyConnected => 'מחובר בהצלחה!';
 
   @override
-  String get stripeReadyForPayments =>
-      'חשבון Stripe שלך מוכן כעת לקבל תשלומים. אתה יכול להתחיל להרוויח מכל מכירות האפליקציה שלך מיד.';
+  String get stripeReadyForPayments => 'חשבון Stripe שלך מוכן כעת לקבל תשלומים. אתה יכול להתחיל להרוויח מכל מכירות האפליקציה שלך מיד.';
 
   @override
   String get updateStripeDetails => 'עדכן פרטי Stripe';
@@ -5050,8 +4999,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'דוגמה דיבור נוספת הוסרה';
 
   @override
-  String get consentDataMessage =>
-      'בהמשך, השיחות, ההקלטות והמידע האישי שלך יאוחסנו בצורה מאובטחת בשרתים שלנו. הקלטות האודיו והתמלולים שלך מעובדים על ידי שירותי AI של צד שלישי (כולל Deepgram לתמלול ו-OpenAI לניתוח) כדי לספק לך תובנות מבוססות AI ולאפשר את כל תכונות האפליקציה.';
+  String get consentDataMessage => 'בהמשך, השיחות, ההקלטות והמידע האישי שלך יאוחסנו בצורה מאובטחת בשרתים שלנו. הקלטות האודיו והתמלולים שלך מעובדים על ידי שירותי AI של צד שלישי (כולל Deepgram לתמלול ו-OpenAI לניתוח) כדי לספק לך תובנות מבוססות AI ולאפשר את כל תכונות האפליקציה.';
 
   @override
   String get tasksEmptyStateMessage => 'משימות משיחותיך יופיעו כאן.\\nלחץ + כדי ליצור אחת ידנית.';
@@ -5090,15 +5038,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get installOmiOnAppleWatch => 'התקן Omi ב-\\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'כדי להשתמש ב-Apple Watch שלך עם Omi, תחילה עליך להתקין את אפליקציית Omi בשעון שלך.';
+  String get installOmiOnAppleWatchDescription => 'כדי להשתמש ב-Apple Watch שלך עם Omi, תחילה עליך להתקין את אפליקציית Omi בשעון שלך.';
 
   @override
   String get openOmiOnAppleWatch => 'פתח Omi ב-\\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'אפליקציית Omi מותקנת ב-Apple Watch שלך. פתח אותה והקש Start כדי להתחיל.';
+  String get openOmiOnAppleWatchDescription => 'אפליקציית Omi מותקנת ב-Apple Watch שלך. פתח אותה והקש Start כדי להתחיל.';
 
   @override
   String get openWatchApp => 'פתח אפליקציית Watch';
@@ -5107,8 +5053,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'התקנתי ופתחתי את האפליקציה';
 
   @override
-  String get unableToOpenWatchApp =>
-      'לא ניתן לפתוח אפליקציית Apple Watch. אנא פתח ידנית את אפליקציית Watch בשעון Apple Watch שלך והתקן את Omi מסעיף \"Available Apps\".';
+  String get unableToOpenWatchApp => 'לא ניתן לפתוח אפליקציית Apple Watch. אנא פתח ידנית את אפליקציית Watch בשעון Apple Watch שלך והתקן את Omi מסעיף \"Available Apps\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch מחובר בהצלחה!';
@@ -5560,8 +5505,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get howToTakeGoodSample => 'איך לקחת דגימה טובה?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. וודא שאתה במקום שקט.\n2. דבר בבירור ובטבעיות.\n3. וודא שהמכשיר שלך נמצא במצבו הטבעי, על הצוואר שלך.\n\nלאחר יצירתה, תוכל תמיד לשפר אותה או לעשות אותה שוב.';
+  String get goodSampleInstructions => '1. וודא שאתה במקום שקט.\n2. דבר בבירור ובטבעיות.\n3. וודא שהמכשיר שלך נמצא במצבו הטבעי, על הצוואר שלך.\n\nלאחר יצירתה, תוכל תמיד לשפר אותה או לעשות אותה שוב.';
 
   @override
   String get noDeviceConnectedUseMic => 'אין מכשיר מחובר. יהיה שימוש במיקרופון הטלפון.';
@@ -5624,8 +5568,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get howItWorks => 'איך זה עובד';
 
   @override
-  String get dailyScoreExplanation =>
-      'הניקוד היומי שלך מבוסס על השלמת משימות. השלם את המשימות שלך כדי לשפר את הניקוד שלך!';
+  String get dailyScoreExplanation => 'הניקוד היומי שלך מבוסס על השלמת משימות. השלם את המשימות שלך כדי לשפר את הניקוד שלך!';
 
   @override
   String get notificationFrequencyDescription => 'שלוט בתדירות של הודעות ותזכורות פרואקטיביות של Omi.';
@@ -6017,8 +5960,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get performanceWarning => 'אזהרת ביצועים';
 
   @override
-  String get largeModelWarning =>
-      'דגם זה גדול ועלול להתרסק או לרוץ לאט מאוד במכשירים ניידים.\n\n\"small\" או \"base\" מומלץ.';
+  String get largeModelWarning => 'דגם זה גדול ועלול להתרסק או לרוץ לאט מאוד במכשירים ניידים.\n\n\"small\" או \"base\" מומלץ.';
 
   @override
   String get usingNativeIosSpeech => 'שימוש בזיהוי דיבור iOS מקומי';
@@ -6093,8 +6035,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get modelLabel => 'דגם';
 
   @override
-  String get modelTooLargeWarning =>
-      'דגם זה גדול ועלול להתרסק או לרוץ לאט מאוד במכשירים ניידים.\n\n\"small\" או \"base\" מומלץ.';
+  String get modelTooLargeWarning => 'דגם זה גדול ועלול להתרסק או לרוץ לאט מאוד במכשירים ניידים.\n\n\"small\" או \"base\" מומלץ.';
 
   @override
   String get nativeEngineNoDownload => 'מנוע הדיבור המקומי של המכשיר שלך יהיה בשימוש. הורדת דגם אינה נדרשת.';
@@ -6133,8 +6074,7 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'התמלול החי המובנה של Omi מותאם לשיחות בזמן אמת עם זיהוי דוברים אוטומטי וdiarization.';
+  String get omiTranscriptionOptimized => 'התמלול החי המובנה של Omi מותאם לשיחות בזמן אמת עם זיהוי דוברים אוטומטי וdiarization.';
 
   @override
   String get reset => 'איפוס';
@@ -6656,8 +6596,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'הורדה של אודיו מכרטיס ה-SD של המכשיר שלך';
 
   @override
-  String get transferRequiredDescription =>
-      'הקלטה זו מאוחסנת בכרטיס ה-SD של המכשיר שלך. העבר אותה לטלפון כדי להשמיע או לשתף.';
+  String get transferRequiredDescription => 'הקלטה זו מאוחסנת בכרטיס ה-SD של המכשיר שלך. העבר אותה לטלפון כדי להשמיע או לשתף.';
 
   @override
   String get cancelTransfer => 'ביטול העברה';
@@ -6737,8 +6676,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get enableFastTransfer => 'הפעל Fast Transfer';
 
   @override
-  String get fastTransferDescription =>
-      'Fast Transfer משתמש ב-WiFi כדי להשיג מהירויות גבוהות פי 5. הטלפון שלך יתחבר זמנית לרשת ה-WiFi של התקן Omi שלך במהלך ההעברה.';
+  String get fastTransferDescription => 'Fast Transfer משתמש ב-WiFi כדי להשיג מהירויות גבוהות פי 5. הטלפון שלך יתחבר זמנית לרשת ה-WiFi של התקן Omi שלך במהלך ההעברה.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'גישת האינטרנט מושהית במהלך ההעברה';
@@ -6753,8 +6691,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get fiveTimesFaster => 'פי 5 מהר יותר';
 
   @override
-  String get fastTransferMethodDescription =>
-      'יוצר חיבור WiFi ישיר להתקן Omi שלך. הטלפון שלך יתנתק זמנית מ-WiFi הרגיל שלך במהלך ההעברה.';
+  String get fastTransferMethodDescription => 'יוצר חיבור WiFi ישיר להתקן Omi שלך. הטלפון שלך יתנתק זמנית מ-WiFi הרגיל שלך במהלך ההעברה.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6763,8 +6700,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get bleSpeed => '~30 KB/s דרך BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'משתמש בחיבור Bluetooth Low Energy סטנדרטי. איטי יותר אך לא משפיע על חיבור ה-WiFi שלך.';
+  String get bluetoothMethodDescription => 'משתמש בחיבור Bluetooth Low Energy סטנדרטי. איטי יותר אך לא משפיע על חיבור ה-WiFi שלך.';
 
   @override
   String get selected => 'נבחר';
@@ -7072,8 +7008,7 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'שדרוג זמין! תוכנית החודשית שלך נמשכת עד סוף תקופת החיוב שלך, ואז עוברת אוטומטית לתשנתי.';
+  String get planUpgradeScheduledMessage => 'שדרוג זמין! תוכנית החודשית שלך נמשכת עד סוף תקופת החיוב שלך, ואז עוברת אוטומטית לתשנתי.';
 
   @override
   String get couldNotSchedulePlanChange => 'לא היתה אפשרות לתזמן שינוי תוכנית. אנא נסה שוב.';
@@ -7297,8 +7232,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get onboardingMicrophoneRequired => 'הרשאת מיקרופון נדרשת להקלטה.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'הרשאת מיקרופון נדחתה. אנא הגרם הרשאה בהעדפות מערכת > פרטיות וביטחון > מיקרופון.';
+  String get onboardingMicrophoneDenied => 'הרשאת מיקרופון נדחתה. אנא הגרם הרשאה בהעדפות מערכת > פרטיות וביטחון > מיקרופון.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7314,8 +7248,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'הרשאת צילום מסך נדרשת להקלטת אודיו מערכת.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'הרשאת צילום מסך נדחתה. אנא הגרם הרשאה בהעדפות מערכת > פרטיות וביטחון > צילום מסך.';
+  String get onboardingScreenCaptureDenied => 'הרשאת צילום מסך נדחתה. אנא הגרם הרשאה בהעדפות מערכת > פרטיות וביטחון > צילום מסך.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7440,8 +7373,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get locationPermissionRequired => 'הרשאת מיקום נדרשת';
 
   @override
-  String get locationPermissionContent =>
-      'Fast Transfer דורש הרשאת מיקום כדי לאמת חיבור WiFi. אנא הגרם הרשאת מיקום כדי להמשיך.';
+  String get locationPermissionContent => 'Fast Transfer דורש הרשאת מיקום כדי לאמת חיבור WiFi. אנא הגרם הרשאת מיקום כדי להמשיך.';
 
   @override
   String get pdfTranscriptExport => 'ייצוא תמלול';
@@ -7924,8 +7856,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get pairingTitleLimitless => 'הכנס את Limitless למצב זיווג';
 
   @override
-  String get pairingDescLimitless =>
-      'כאשר אור כלשהו נראה, לחץ פעם אחת ואז לחץ וחזיק עד שההתקן מראה אור ורוד, ואז שחרר.';
+  String get pairingDescLimitless => 'כאשר אור כלשהו נראה, לחץ פעם אחת ואז לחץ וחזיק עד שההתקן מראה אור ורוד, ואז שחרר.';
 
   @override
   String get pairingTitleFriendPendant => 'הכנס את Friend Pendant למצב זיווג';
@@ -8066,8 +7997,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get switchAndRestart => 'שנה';
 
   @override
-  String get stagingDisclaimer =>
-      'שלב בדיקה עלול להיות בעל באגים, ביצועים לא עקביים, וניתן שיאבדו נתונים. השתמש רק לבדיקה.';
+  String get stagingDisclaimer => 'שלב בדיקה עלול להיות בעל באגים, ביצועים לא עקביים, וניתן שיאבדו נתונים. השתמש רק לבדיקה.';
 
   @override
   String get apiEnvSavedRestartRequired => 'נשמר. סגור ופתח מחדש את האפליקציה כדי להחיל.';
@@ -8296,8 +8226,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'שיחות טלפון דרך Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'בצע שיחות דרך Omi וקבל תמלול בזמן אמת, סיכומים אוטומטיים ועוד. זמין אך ורק למנויי תוכנית Unlimited.';
+  String get phoneCallsUpsellSubtitle => 'בצע שיחות דרך Omi וקבל תמלול בזמן אמת, סיכומים אוטומטיים ועוד. זמין אך ורק למנויי תוכנית Unlimited.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'תמלול בזמן אמת של כל שיחה';
@@ -8348,8 +8277,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get deleteAll => 'מחק הכל';
 
   @override
-  String get deleteAllFilesWarning =>
-      'זה ימחק הן הקלטות מסונכרנות והן בהמתנה. הקלטות בהמתנה לא סונכרנו ויאבדו לצמיתות. לא ניתן לבטל פעולה זו.';
+  String get deleteAllFilesWarning => 'זה ימחק הן הקלטות מסונכרנות והן בהמתנה. הקלטות בהמתנה לא סונכרנו ויאבדו לצמיתות. לא ניתן לבטל פעולה זו.';
 
   @override
   String get allFilesDeleted => 'כל ההקלטות נמחקו';
@@ -8414,8 +8342,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get fairUseAboutTitle => 'אודות שימוש הוגן';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi מעוצב לשיחות אישיות, פגישות ואינטראקציות חיות. השימוש נמדד לפי זמן דיבור אמיתי שזוהה, לא זמן חיבור. אם השימוש חורג משמעותית מדפוסים רגילים לתוכן שאינו אישי, ייתכנו התאמות.';
+  String get fairUseAboutBody => 'Omi מעוצב לשיחות אישיות, פגישות ואינטראקציות חיות. השימוש נמדד לפי זמן דיבור אמיתי שזוהה, לא זמן חיבור. אם השימוש חורג משמעותית מדפוסים רגילים לתוכן שאינו אישי, ייתכנו התאמות.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8453,8 +8380,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get improveConnectionTitle => 'שפר חיבור';
 
   @override
-  String get improveConnectionContent =>
-      'שיפרנו את אופן החיבור של Omi להתקן שלך. כדי להפעיל זאת, אנא עבור לעמוד פרטי ההתקן, הקש על \"ניתוק התקן\", ואז חבר את ההתקן שלך שוב.';
+  String get improveConnectionContent => 'שיפרנו את אופן החיבור של Omi להתקן שלך. כדי להפעיל זאת, אנא עבור לעמוד פרטי ההתקן, הקש על \"ניתוק התקן\", ואז חבר את ההתקן שלך שוב.';
 
   @override
   String get improveConnectionAction => 'הבנתי';
@@ -8509,12 +8435,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get cancelSyncQuestion => 'בטל סנכרון?';
 
   @override
-  String get omisStorageDesc =>
-      'כאשר ה-Omi שלך לא מחובר לטלפון, הוא מאחסן אודיו מקומית בזיכרון המובנה שלו. אתה לעולם לא מאבד הקלטה.';
+  String get omisStorageDesc => 'כאשר ה-Omi שלך לא מחובר לטלפון, הוא מאחסן אודיו מקומית בזיכרון המובנה שלו. אתה לעולם לא מאבד הקלטה.';
 
   @override
-  String get phoneStorageDesc =>
-      'כאשר Omi מתחבר מחדש, הקלטות מועברות באופן אוטומטי לטלפון שלך כאזור החזקה זמני לפני העלאה.';
+  String get phoneStorageDesc => 'כאשר Omi מתחבר מחדש, הקלטות מועברות באופן אוטומטי לטלפון שלך כאזור החזקה זמני לפני העלאה.';
 
   @override
   String get cloudStorageDesc => 'לאחר העלאה, ההקלטות שלך מעובדות ותמלולות. שיחות יהיו זמינות תוך דקה.';
@@ -8541,8 +8465,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get permissionEnable => 'הפעל';
 
   @override
-  String get permissionsPageDescription =>
-      'הרשאות אלה הן ליבה לאופן ה-Omi. הן מאפשרות תכונות חיוניות כמו הודעות, חוויות מבוססות מיקום והילוכי אודיו.';
+  String get permissionsPageDescription => 'הרשאות אלה הן ליבה לאופן ה-Omi. הן מאפשרות תכונות חיוניות כמו הודעות, חוויות מבוססות מיקום והילוכי אודיו.';
 
   @override
   String get permissionsRequiredDescription => 'Omi זקוק לכמה הרשאות כדי לפעול כראוי. אנא הענק אותן כדי להמשיך.';
@@ -8822,8 +8745,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get firmwareWarningTitle => 'חשוב: קראו לפני העדכון';
 
   @override
-  String get firmwareFormatWarning =>
-      'קושחה זו תפרמט את כרטיס ה-SD. אנא ודאו שכל הנתונים הלא מקוונים מסונכרנים לפני השדרוג.\n\nאם אתם רואים אור אדום מהבהב לאחר התקנת גרסה זו, אל תדאגו. פשוט חברו את המכשיר לאפליקציה והוא אמור להפוך לכחול. האור האדום אומר שהשעון של המכשיר עדיין לא סונכרן.';
+  String get firmwareFormatWarning => 'קושחה זו תפרמט את כרטיס ה-SD. אנא ודאו שכל הנתונים הלא מקוונים מסונכרנים לפני השדרוג.\n\nאם אתם רואים אור אדום מהבהב לאחר התקנת גרסה זו, אל תדאגו. פשוט חברו את המכשיר לאפליקציה והוא אמור להפוך לכחול. האור האדום אומר שהשעון של המכשיר עדיין לא סונכרן.';
 
   @override
   String get continueAnyway => 'המשך';
@@ -8843,8 +8765,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get tasksMarkComplete => 'סומן כהושלם';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi ניגש ל-Apple Health דרך מסגרת העבודה HealthKit של Apple. ניתן לבטל את הגישה בכל עת בהגדרות iOS.';
+  String get appleHealthManageNote => 'Omi ניגש ל-Apple Health דרך מסגרת העבודה HealthKit של Apple. ניתן לבטל את הגישה בכל עת בהגדרות iOS.';
 
   @override
   String get appleHealthConnectCta => 'התחבר ל-Apple Health';
@@ -8877,8 +8798,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get appleHealthDeniedTitle => 'הגישה ל-Apple Health נדחתה';
 
   @override
-  String get appleHealthDeniedBody =>
-      'ל-Omi אין הרשאה לקרוא את נתוני Apple Health שלך. הפעל אותה בהגדרות iOS ← פרטיות ואבטחה ← Health ← Omi.';
+  String get appleHealthDeniedBody => 'ל-Omi אין הרשאה לקרוא את נתוני Apple Health שלך. הפעל אותה בהגדרות iOS ← פרטיות ואבטחה ← Health ← Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'למה אתה עוזב?';
@@ -8947,8 +8867,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get planUpdate => 'עדכון תוכנית';
 
   @override
-  String get planDeprecationMessage =>
-      'תוכנית ה-Unlimited שלך מופסקת. עברו לתוכנית Operator — אותן תכונות מעולות ב-\$49/חודש. התוכנית הנוכחית שלך תמשיך לפעול בינתיים.';
+  String get planDeprecationMessage => 'תוכנית ה-Unlimited שלך מופסקת. עברו לתוכנית Operator — אותן תכונות מעולות ב-\$49/חודש. התוכנית הנוכחית שלך תמשיך לפעול בינתיים.';
 
   @override
   String get upgradeYourPlan => 'שדרג את התוכנית שלך';
@@ -9090,4 +9009,25 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'הוסף משימה';
+
+  @override
+  String get quickActionAskOmiAnything => 'שאל את Omi כל דבר';
+
+  @override
+  String get quickActionVoiceMode => 'מצב קול';
+
+  @override
+  String get quickActionMute => 'השתק';
+
+  @override
+  String get quickActionUnmute => 'בטל השתקה';
+
+  @override
+  String get quickActionConnectDevice => 'חבר מכשיר';
+
+  @override
+  String get quickActionDeviceSettings => 'הגדרות מכשיר';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -24,8 +24,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deleteConversationTitle => 'बातचीत हटाएं?';
 
   @override
-  String get deleteConversationMessage =>
-      'इससे संबंधित यादें, कार्य और ऑडियो फ़ाइलें भी हटा दी जाएंगी। यह क्रिया पूर्ववत नहीं की जा सकती।';
+  String get deleteConversationMessage => 'इससे संबंधित यादें, कार्य और ऑडियो फ़ाइलें भी हटा दी जाएंगी। यह क्रिया पूर्ववत नहीं की जा सकती।';
 
   @override
   String get confirm => 'पुष्टि करें';
@@ -354,19 +353,16 @@ class AppLocalizationsHi extends AppLocalizations {
   String get appsDisconnected => 'आपके ऐप्स और एकीकरण तुरंत डिस्कनेक्ट हो जाएंगे।';
 
   @override
-  String get exportBeforeDelete =>
-      'अपना खाता हटाने से पहले आप अपना डेटा निर्यात कर सकते हैं। एक बार हटाए जाने के बाद, इसे पुनर्प्राप्त नहीं किया जा सकता है।';
+  String get exportBeforeDelete => 'अपना खाता हटाने से पहले आप अपना डेटा निर्यात कर सकते हैं। एक बार हटाए जाने के बाद, इसे पुनर्प्राप्त नहीं किया जा सकता है।';
 
   @override
-  String get deleteAccountCheckbox =>
-      'मैं समझता/समझती हूं कि अपना खाता हटाना स्थायी है और यादों और बातचीत सहित सभी डेटा हमेशा के लिए खो जाएंगे।';
+  String get deleteAccountCheckbox => 'मैं समझता/समझती हूं कि अपना खाता हटाना स्थायी है और यादों और बातचीत सहित सभी डेटा हमेशा के लिए खो जाएंगे।';
 
   @override
   String get areYouSure => 'क्या आप सुनिश्चित हैं?';
 
   @override
-  String get deleteAccountFinal =>
-      'यह क्रिया अपरिवर्तनीय है और आपके खाते और उससे जुड़े सभी डेटा को स्थायी रूप से हटा देगी। क्या आप जारी रखना चाहते हैं?';
+  String get deleteAccountFinal => 'यह क्रिया अपरिवर्तनीय है और आपके खाते और उससे जुड़े सभी डेटा को स्थायी रूप से हटा देगी। क्या आप जारी रखना चाहते हैं?';
 
   @override
   String get deleteNow => 'अभी हटाएं';
@@ -375,8 +371,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get goBack => 'वापस जाएं';
 
   @override
-  String get checkBoxToConfirm =>
-      'पुष्टि करने के लिए चेकबॉक्स चेक करें कि आप समझते हैं कि आपका खाता हटाना स्थायी और अपरिवर्तनीय है।';
+  String get checkBoxToConfirm => 'पुष्टि करने के लिए चेकबॉक्स चेक करें कि आप समझते हैं कि आपका खाता हटाना स्थायी और अपरिवर्तनीय है।';
 
   @override
   String get profile => 'प्रोफ़ाइल';
@@ -454,8 +449,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get yourPrivacyYourControl => 'आपकी गोपनीयता, आपका नियंत्रण';
 
   @override
-  String get privacyIntro =>
-      'Omi में, हम आपकी गोपनीयता की रक्षा के लिए प्रतिबद्ध हैं। यह पृष्ठ आपको यह नियंत्रित करने की अनुमति देता है कि आपका डेटा कैसे सहेजा और उपयोग किया जाता है।';
+  String get privacyIntro => 'Omi में, हम आपकी गोपनीयता की रक्षा के लिए प्रतिबद्ध हैं। यह पृष्ठ आपको यह नियंत्रित करने की अनुमति देता है कि आपका डेटा कैसे सहेजा और उपयोग किया जाता है।';
 
   @override
   String get learnMore => 'और जानें...';
@@ -470,8 +464,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get appAccess => 'ऐप एक्सेस';
 
   @override
-  String get appAccessDesc =>
-      'निम्नलिखित ऐप्स के पास आपके डेटा तक पहुंच है। अनुमतियाँ प्रबंधित करने के लिए किसी ऐप पर टैप करें।';
+  String get appAccessDesc => 'निम्नलिखित ऐप्स के पास आपके डेटा तक पहुंच है। अनुमतियाँ प्रबंधित करने के लिए किसी ऐप पर टैप करें।';
 
   @override
   String get noAppsExternalAccess => 'किसी भी इंस्टॉल किए गए ऐप के पास आपके डेटा तक बाहरी पहुंच नहीं है।';
@@ -528,15 +521,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deviceDisconnectedMessage => 'आपका Omi डिस्कनेक्ट हो गया 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'डिवाइस अनपेयर किया गया। अनपेयरिंग पूरी करने के लिए सेटिंग्स > ब्लूटूथ पर जाएं और डिवाइस को भूल जाएं।';
+  String get deviceUnpairedMessage => 'डिवाइस अनपेयर किया गया। अनपेयरिंग पूरी करने के लिए सेटिंग्स > ब्लूटूथ पर जाएं और डिवाइस को भूल जाएं।';
 
   @override
   String get unpairDialogTitle => 'डिवाइस अनपेयर करें';
 
   @override
-  String get unpairDialogMessage =>
-      'यह डिवाइस को अनपेयर कर देगा ताकि इसे दूसरे फोन पर इस्तेमाल किया जा सके। प्रक्रिया पूरी करने के लिए आपको सेटिंग्स > ब्लूटूथ पर जाना होगा और डिवाइस को भूलना होगा।';
+  String get unpairDialogMessage => 'यह डिवाइस को अनपेयर कर देगा ताकि इसे दूसरे फोन पर इस्तेमाल किया जा सके। प्रक्रिया पूरी करने के लिए आपको सेटिंग्स > ब्लूटूथ पर जाना होगा और डिवाइस को भूलना होगा।';
 
   @override
   String get deviceNotConnected => 'डिवाइस कनेक्ट नहीं है';
@@ -557,8 +548,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get v2Undetected => 'V2 का पता नहीं चला';
 
   @override
-  String get v2UndetectedMessage =>
-      'हमें लगता है कि आप V1 डिवाइस का उपयोग कर रहे हैं या यह कनेक्ट नहीं है। SD कार्ड कार्यक्षमता केवल V2 उपकरणों के लिए है।';
+  String get v2UndetectedMessage => 'हमें लगता है कि आप V1 डिवाइस का उपयोग कर रहे हैं या यह कनेक्ट नहीं है। SD कार्ड कार्यक्षमता केवल V2 उपकरणों के लिए है।';
 
   @override
   String get endConversation => 'बातचीत समाप्त करें';
@@ -832,8 +822,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'नॉलेज ग्राफ़ हटाएं?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'यह सभी व्युत्पन्न ग्राफ़ डेटा (नोड्स और कनेक्शन) को हटा देगा। आपकी मूल यादें सुरक्षित रहती हैं।';
+  String get deleteKnowledgeGraphMessage => 'यह सभी व्युत्पन्न ग्राफ़ डेटा (नोड्स और कनेक्शन) को हटा देगा। आपकी मूल यादें सुरक्षित रहती हैं।';
 
   @override
   String get knowledgeGraphDeleted => 'ज्ञान ग्राफ़ हटाया गया';
@@ -1076,8 +1065,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get needYourPermission => 'हमें आपकी अनुमति चाहिए';
 
   @override
-  String get alreadyGavePermission =>
-      'आपने हमें अपनी रिकॉर्डिंग सहेजने की अनुमति पहले ही दे दी है। हमें इसकी आवश्यकता क्यों है, इसका एक अनुस्मारक:';
+  String get alreadyGavePermission => 'आपने हमें अपनी रिकॉर्डिंग सहेजने की अनुमति पहले ही दे दी है। हमें इसकी आवश्यकता क्यों है, इसका एक अनुस्मारक:';
 
   @override
   String get wouldLikePermission => 'हम आपकी वॉयस रिकॉर्डिंग सहेजने के लिए आपकी अनुमति चाहते हैं। यहाँ क्यों है:';
@@ -1086,22 +1074,19 @@ class AppLocalizationsHi extends AppLocalizations {
   String get improveSpeechProfile => 'अपनी वाक् प्रोफ़ाइल सुधारें';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'हम आपकी व्यक्तिगत वाक् प्रोफ़ाइल को आगे प्रशिक्षित करने और सुधारने के लिए रिकॉर्डिंग का उपयोग करते हैं।';
+  String get improveSpeechProfileDesc => 'हम आपकी व्यक्तिगत वाक् प्रोफ़ाइल को आगे प्रशिक्षित करने और सुधारने के लिए रिकॉर्डिंग का उपयोग करते हैं।';
 
   @override
   String get trainFamilyProfiles => 'दोस्तों और परिवार की प्रोफ़ाइल प्रशिक्षित करें';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'आपकी रिकॉर्डिंग हमें आपके दोस्तों और परिवार के सदस्यों को पहचानने और उनके लिए प्रोफ़ाइल बनाने में मदद करती हैं।';
+  String get trainFamilyProfilesDesc => 'आपकी रिकॉर्डिंग हमें आपके दोस्तों और परिवार के सदस्यों को पहचानने और उनके लिए प्रोफ़ाइल बनाने में मदद करती हैं।';
 
   @override
   String get enhanceTranscriptAccuracy => 'ट्रांसक्रिप्ट सटीकता बढ़ाएं';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'जैसे-जैसे हमारा मॉडल सुधरता है, हम आपकी रिकॉर्डिंग के लिए बेहतर ट्रांसक्रिप्ट प्रदान कर सकते हैं।';
+  String get enhanceTranscriptAccuracyDesc => 'जैसे-जैसे हमारा मॉडल सुधरता है, हम आपकी रिकॉर्डिंग के लिए बेहतर ट्रांसक्रिप्ट प्रदान कर सकते हैं।';
 
   @override
   String get legalNotice => 'कानूनी नोटिस: रिकॉर्डिंग की वैधता आपके स्थान के आधार पर भिन्न हो सकती है।';
@@ -1182,8 +1167,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get showEventsNoParticipants => 'बिना प्रतिभागियों वाले ईवेंट दिखाएं';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'यदि सक्षम किया गया, तो \'आगामी\' बिना प्रतिभागियों या वीडियो लिंक वाले ईवेंट दिखाएगा।';
+  String get showEventsNoParticipantsDesc => 'यदि सक्षम किया गया, तो \'आगामी\' बिना प्रतिभागियों या वीडियो लिंक वाले ईवेंट दिखाएगा।';
 
   @override
   String get yourMeetings => 'आपकी बैठकें';
@@ -1931,8 +1915,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get actionItemsTitle => 'कार्य';
 
   @override
-  String get actionItemsDescription =>
-      'संपादित करने के लिए टैप करें • चुनने के लिए होल्ड करें • कार्रवाई के लिए स्वाइप करें';
+  String get actionItemsDescription => 'संपादित करने के लिए टैप करें • चुनने के लिए होल्ड करें • कार्रवाई के लिए स्वाइप करें';
 
   @override
   String get tabToDo => 'करने के लिए';
@@ -2194,15 +2177,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'वाणी और ट्रांसक्रिप्शन';
 
   @override
-  String get languageSettingsHelperText =>
-      'ऐप भाषा मेनू और बटन बदलती है। वाणी भाषा आपकी रिकॉर्डिंग के ट्रांसक्रिप्शन को प्रभावित करती है।';
+  String get languageSettingsHelperText => 'ऐप भाषा मेनू और बटन बदलती है। वाणी भाषा आपकी रिकॉर्डिंग के ट्रांसक्रिप्शन को प्रभावित करती है।';
 
   @override
   String get translationNotice => 'अनुवाद सूचना';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi बातचीत को आपकी मुख्य भाषा में अनुवाद करता है। इसे सेटिंग्स → प्रोफाइल में कभी भी अपडेट करें।';
+  String get translationNoticeMessage => 'Omi बातचीत को आपकी मुख्य भाषा में अनुवाद करता है। इसे सेटिंग्स → प्रोफाइल में कभी भी अपडेट करें।';
 
   @override
   String get pleaseCheckInternetConnection => 'कृपया अपना इंटरनेट कनेक्शन जांचें और पुनः प्रयास करें';
@@ -2357,8 +2338,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'डिवाइस को अनपेयर करें';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'यह डिवाइस को अनपेयर कर देगा ताकि इसे किसी अन्य फोन से कनेक्ट किया जा सके। प्रक्रिया पूरी करने के लिए आपको सेटिंग्स > ब्लूटूथ पर जाना होगा और डिवाइस को भूलना होगा।';
+  String get unpairDeviceDialogMessage => 'यह डिवाइस को अनपेयर कर देगा ताकि इसे किसी अन्य फोन से कनेक्ट किया जा सके। प्रक्रिया पूरी करने के लिए आपको सेटिंग्स > ब्लूटूथ पर जाना होगा और डिवाइस को भूलना होगा।';
 
   @override
   String get unpair => 'अनपेयर करें';
@@ -2539,8 +2519,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get youreAllSet => 'आप तैयार हैं!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Omi में आपका स्वागत है! आपका AI साथी बातचीत, कार्यों और अधिक में आपकी सहायता के लिए तैयार है।';
+  String get welcomeToOmiDescription => 'Omi में आपका स्वागत है! आपका AI साथी बातचीत, कार्यों और अधिक में आपकी सहायता के लिए तैयार है।';
 
   @override
   String get startUsingOmi => 'Omi उपयोग शुरू करें';
@@ -2640,8 +2619,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get dailyScore => 'दैनिक स्कोर';
 
   @override
-  String get dailyScoreDescription =>
-      'एक स्कोर जो आपको बेहतर तरीके से\nनिष्पादन पर ध्यान केंद्रित करने में मदद करता है।';
+  String get dailyScoreDescription => 'एक स्कोर जो आपको बेहतर तरीके से\nनिष्पादन पर ध्यान केंद्रित करने में मदद करता है।';
 
   @override
   String get searchResults => 'खोज परिणाम';
@@ -2677,8 +2655,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get noTasksYet => 'अभी तक कोई कार्य नहीं';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'आपकी बातचीत से कार्य यहां दिखाई देंगे।\nमैन्युअल रूप से एक जोड़ने के लिए बनाएं पर क्लिक करें।';
+  String get tasksFromConversationsWillAppear => 'आपकी बातचीत से कार्य यहां दिखाई देंगे।\nमैन्युअल रूप से एक जोड़ने के लिए बनाएं पर क्लिक करें।';
 
   @override
   String get monthJan => 'जन';
@@ -2735,8 +2712,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deleteActionItem => 'कार्य आइटम हटाएं';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'क्या आप वाकई इस कार्य आइटम को हटाना चाहते हैं? इस क्रिया को पूर्ववत नहीं किया जा सकता।';
+  String get deleteActionItemConfirmation => 'क्या आप वाकई इस कार्य आइटम को हटाना चाहते हैं? इस क्रिया को पूर्ववत नहीं किया जा सकता।';
 
   @override
   String get enterActionItemDescription => 'कार्य आइटम विवरण दर्ज करें...';
@@ -2811,8 +2787,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get chatPrompt => 'चैट संकेत';
 
   @override
-  String get chatPromptPlaceholder =>
-      'आप एक शानदार ऐप हैं, आपका काम उपयोगकर्ता के प्रश्नों का उत्तर देना और उन्हें अच्छा महसूस कराना है...';
+  String get chatPromptPlaceholder => 'आप एक शानदार ऐप हैं, आपका काम उपयोगकर्ता के प्रश्नों का उत्तर देना और उन्हें अच्छा महसूस कराना है...';
 
   @override
   String get conversationPrompt => 'बातचीत प्रॉम्प्ट';
@@ -2830,8 +2805,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get makeMyAppPublic => 'मेरे ऐप को सार्वजनिक बनाएं';
 
   @override
-  String get submitAppTermsAgreement =>
-      'इस ऐप को सबमिट करके, मैं Omi AI की सेवा की शर्तों और गोपनीयता नीति से सहमत हूं';
+  String get submitAppTermsAgreement => 'इस ऐप को सबमिट करके, मैं Omi AI की सेवा की शर्तों और गोपनीयता नीति से सहमत हूं';
 
   @override
   String get submitApp => 'ऐप सबमिट करें';
@@ -2846,12 +2820,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get submitAppQuestion => 'ऐप सबमिट करें?';
 
   @override
-  String get submitAppPublicDescription =>
-      'आपके ऐप की समीक्षा की जाएगी और इसे सार्वजनिक किया जाएगा। आप इसे तुरंत उपयोग करना शुरू कर सकते हैं, यहां तक कि समीक्षा के दौरान भी!';
+  String get submitAppPublicDescription => 'आपके ऐप की समीक्षा की जाएगी और इसे सार्वजनिक किया जाएगा। आप इसे तुरंत उपयोग करना शुरू कर सकते हैं, यहां तक कि समीक्षा के दौरान भी!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'आपके ऐप की समीक्षा की जाएगी और इसे आपके लिए निजी तौर पर उपलब्ध कराया जाएगा। आप इसे तुरंत उपयोग करना शुरू कर सकते हैं, यहां तक कि समीक्षा के दौरान भी!';
+  String get submitAppPrivateDescription => 'आपके ऐप की समीक्षा की जाएगी और इसे आपके लिए निजी तौर पर उपलब्ध कराया जाएगा। आप इसे तुरंत उपयोग करना शुरू कर सकते हैं, यहां तक कि समीक्षा के दौरान भी!';
 
   @override
   String get startEarning => 'कमाई शुरू करें! 💰';
@@ -2875,23 +2847,19 @@ class AppLocalizationsHi extends AppLocalizations {
   String get dataAccessNotice => 'डेटा एक्सेस सूचना';
 
   @override
-  String get dataAccessWarning =>
-      'यह ऐप आपके डेटा तक पहुंच बनाएगा। Omi AI इस बात के लिए जिम्मेदार नहीं है कि इस ऐप द्वारा आपके डेटा का उपयोग, संशोधन या हटाया कैसे जाता है';
+  String get dataAccessWarning => 'यह ऐप आपके डेटा तक पहुंच बनाएगा। Omi AI इस बात के लिए जिम्मेदार नहीं है कि इस ऐप द्वारा आपके डेटा का उपयोग, संशोधन या हटाया कैसे जाता है';
 
   @override
   String get installApp => 'ऐप इंस्टॉल करें';
 
   @override
-  String get betaTesterNotice =>
-      'आप इस ऐप के लिए बीटा परीक्षक हैं। यह अभी तक सार्वजनिक नहीं है। स्वीकृत होने के बाद यह सार्वजनिक हो जाएगा।';
+  String get betaTesterNotice => 'आप इस ऐप के लिए बीटा परीक्षक हैं। यह अभी तक सार्वजनिक नहीं है। स्वीकृत होने के बाद यह सार्वजनिक हो जाएगा।';
 
   @override
-  String get appUnderReviewOwner =>
-      'आपका ऐप समीक्षाधीन है और केवल आपके लिए दृश्यमान है। स्वीकृत होने के बाद यह सार्वजनिक हो जाएगा।';
+  String get appUnderReviewOwner => 'आपका ऐप समीक्षाधीन है और केवल आपके लिए दृश्यमान है। स्वीकृत होने के बाद यह सार्वजनिक हो जाएगा।';
 
   @override
-  String get appRejectedNotice =>
-      'आपका ऐप अस्वीकार कर दिया गया है। कृपया ऐप विवरण अपडेट करें और समीक्षा के लिए पुनः सबमिट करें।';
+  String get appRejectedNotice => 'आपका ऐप अस्वीकार कर दिया गया है। कृपया ऐप विवरण अपडेट करें और समीक्षा के लिए पुनः सबमिट करें।';
 
   @override
   String get setupSteps => 'सेटअप चरण';
@@ -3090,8 +3058,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get clearChatTitle => 'चैट साफ़ करें?';
 
   @override
-  String get confirmClearChat =>
-      'क्या आप निश्चित रूप से चैट साफ़ करना चाहते हैं? इस क्रिया को पूर्ववत नहीं किया जा सकता।';
+  String get confirmClearChat => 'क्या आप निश्चित रूप से चैट साफ़ करना चाहते हैं? इस क्रिया को पूर्ववत नहीं किया जा सकता।';
 
   @override
   String get copy => 'कॉपी करें';
@@ -3106,8 +3073,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get microphonePermissionRequired => 'वॉयस रिकॉर्डिंग के लिए माइक्रोफ़ोन अनुमति आवश्यक है।';
 
   @override
-  String get microphonePermissionDenied =>
-      'माइक्रोफ़ोन अनुमति अस्वीकार। कृपया सिस्टम प्राथमिकताएं > गोपनीयता और सुरक्षा > माइक्रोफ़ोन में अनुमति दें।';
+  String get microphonePermissionDenied => 'माइक्रोफ़ोन अनुमति अस्वीकार। कृपया सिस्टम प्राथमिकताएं > गोपनीयता और सुरक्षा > माइक्रोफ़ोन में अनुमति दें।';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3266,8 +3232,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get createMemory => 'स्मृति बनाएं';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'क्या आप वाकई इस स्मृति को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।';
+  String get deleteMemoryConfirmation => 'क्या आप वाकई इस स्मृति को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।';
 
   @override
   String get makePrivate => 'निजी बनाएं';
@@ -3341,8 +3306,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get whatWeCollect => 'हम क्या एकत्र करते हैं';
 
   @override
-  String get dataCollectionMessage =>
-      'जारी रखने से, आपकी बातचीत, रिकॉर्डिंग और व्यक्तिगत जानकारी AI-संचालित अंतर्दृष्टि प्रदान करने और सभी ऐप सुविधाओं को सक्षम करने के लिए हमारे सर्वर पर सुरक्षित रूप से संग्रहीत की जाएगी।';
+  String get dataCollectionMessage => 'जारी रखने से, आपकी बातचीत, रिकॉर्डिंग और व्यक्तिगत जानकारी AI-संचालित अंतर्दृष्टि प्रदान करने और सभी ऐप सुविधाओं को सक्षम करने के लिए हमारे सर्वर पर सुरक्षित रूप से संग्रहीत की जाएगी।';
 
   @override
   String get dataProtection => 'डेटा सुरक्षा';
@@ -3375,8 +3339,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'नाम कम से कम 2 वर्णों का होना चाहिए';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'हमें बताएं कि आप कैसे संबोधित होना पसंद करेंगे। यह आपके Omi अनुभव को वैयक्तिकृत करने में मदद करता है।';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'हमें बताएं कि आप कैसे संबोधित होना पसंद करेंगे। यह आपके Omi अनुभव को वैयक्तिकृत करने में मदद करता है।';
 
   @override
   String charactersCount(int count) {
@@ -3393,8 +3356,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get recordAudioConversations => 'ऑडियो वार्तालाप रिकॉर्ड करें';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi को आपकी बातचीत रिकॉर्ड करने और ट्रांसक्रिप्शन प्रदान करने के लिए माइक्रोफ़ोन एक्सेस की आवश्यकता है।';
+  String get microphoneAccessDescription => 'Omi को आपकी बातचीत रिकॉर्ड करने और ट्रांसक्रिप्शन प्रदान करने के लिए माइक्रोफ़ोन एक्सेस की आवश्यकता है।';
 
   @override
   String get screenRecording => 'स्क्रीन रिकॉर्डिंग';
@@ -3403,8 +3365,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'मीटिंग से सिस्टम ऑडियो कैप्चर करें';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi को आपके ब्राउज़र-आधारित मीटिंग से सिस्टम ऑडियो कैप्चर करने के लिए स्क्रीन रिकॉर्डिंग अनुमति की आवश्यकता है।';
+  String get screenRecordingDescription => 'Omi को आपके ब्राउज़र-आधारित मीटिंग से सिस्टम ऑडियो कैप्चर करने के लिए स्क्रीन रिकॉर्डिंग अनुमति की आवश्यकता है।';
 
   @override
   String get accessibility => 'पहुंच-योग्यता';
@@ -3413,8 +3374,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'ब्राउज़र-आधारित मीटिंग का पता लगाएं';
 
   @override
-  String get accessibilityDescription =>
-      'Omi को यह पता लगाने के लिए पहुंच-योग्यता अनुमति की आवश्यकता है कि आप अपने ब्राउज़र में Zoom, Meet, या Teams मीटिंग में कब शामिल होते हैं।';
+  String get accessibilityDescription => 'Omi को यह पता लगाने के लिए पहुंच-योग्यता अनुमति की आवश्यकता है कि आप अपने ब्राउज़र में Zoom, Meet, या Teams मीटिंग में कब शामिल होते हैं।';
 
   @override
   String get pleaseWait => 'कृपया प्रतीक्षा करें...';
@@ -3483,12 +3443,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get exportAllConversationsToJson => 'अपनी सभी बातचीत को JSON फ़ाइल में निर्यात करें।';
 
   @override
-  String get conversationsExportStarted =>
-      'बातचीत निर्यात शुरू हुआ। इसमें कुछ सेकंड लग सकते हैं, कृपया प्रतीक्षा करें।';
+  String get conversationsExportStarted => 'बातचीत निर्यात शुरू हुआ। इसमें कुछ सेकंड लग सकते हैं, कृपया प्रतीक्षा करें।';
 
   @override
-  String get mcpDescription =>
-      'अपनी यादों और बातचीत को पढ़ने, खोजने और प्रबंधित करने के लिए Omi को अन्य अनुप्रयोगों से कनेक्ट करने के लिए। शुरू करने के लिए एक कुंजी बनाएं।';
+  String get mcpDescription => 'अपनी यादों और बातचीत को पढ़ने, खोजने और प्रबंधित करने के लिए Omi को अन्य अनुप्रयोगों से कनेक्ट करने के लिए। शुरू करने के लिए एक कुंजी बनाएं।';
 
   @override
   String get apiKeys => 'API कुंजियाँ';
@@ -3535,8 +3493,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'नए वक्ताओं को स्वचालित रूप से बनाएं और टैग करें';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'जब ट्रांसक्रिप्ट में एक नाम का पता चलता है तो स्वचालित रूप से एक नया व्यक्ति बनाएं।';
+  String get automaticallyCreateNewPerson => 'जब ट्रांसक्रिप्ट में एक नाम का पता चलता है तो स्वचालित रूप से एक नया व्यक्ति बनाएं।';
 
   @override
   String get pilotFeatures => 'पायलट सुविधाएं';
@@ -3597,8 +3554,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Omi को स्वचालित रूप से सर्वोत्तम ऐप चुनने दें';
 
   @override
-  String get deleteConversationConfirmation =>
-      'क्या आप वाकई इस बातचीत को हटाना चाहते हैं? इस क्रिया को पूर्ववत नहीं किया जा सकता।';
+  String get deleteConversationConfirmation => 'क्या आप वाकई इस बातचीत को हटाना चाहते हैं? इस क्रिया को पूर्ववत नहीं किया जा सकता।';
 
   @override
   String get conversationDeleted => 'बातचीत हटा दी गई';
@@ -3646,8 +3602,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get preparingSystemAudioCapture => 'सिस्टम ऑडियो कैप्चर तैयार हो रहा है';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'लाइव ट्रांसक्रिप्ट, AI जानकारी और स्वचालित सहेजने के लिए ऑडियो कैप्चर करने के लिए बटन पर क्लिक करें।';
+  String get clickTheButtonToCaptureAudio => 'लाइव ट्रांसक्रिप्ट, AI जानकारी और स्वचालित सहेजने के लिए ऑडियो कैप्चर करने के लिए बटन पर क्लिक करें।';
 
   @override
   String get reconnecting => 'फिर से कनेक्ट हो रहा है...';
@@ -3874,8 +3829,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'ज्ञान ग्राफ हटाएं?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'यह सभी व्युत्पन्न ज्ञान ग्राफ डेटा हटा देगा। आपकी मूल यादें सुरक्षित रहती हैं।';
+  String get deleteKnowledgeGraphWarning => 'यह सभी व्युत्पन्न ज्ञान ग्राफ डेटा हटा देगा। आपकी मूल यादें सुरक्षित रहती हैं।';
 
   @override
   String get connectOmiWithAI => 'Omi को AI सहायकों से कनेक्ट करें';
@@ -3917,8 +3871,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'शर्तें और गोपनीयता नीति';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'समस्याओं का निदान करने में मदद करता है। 3 दिनों के बाद स्वचालित रूप से हटा दिया जाता है।';
+  String get helpsDiagnoseIssuesAutoDeletes => 'समस्याओं का निदान करने में मदद करता है। 3 दिनों के बाद स्वचालित रूप से हटा दिया जाता है।';
 
   @override
   String get manageYourApp => 'अपना ऐप प्रबंधित करें';
@@ -3933,8 +3886,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get updateAppQuestion => 'ऐप अपडेट करें?';
 
   @override
-  String get updateAppConfirmation =>
-      'क्या आप वाकई अपना ऐप अपडेट करना चाहते हैं? परिवर्तन हमारी टीम द्वारा समीक्षा के बाद दिखाई देंगे।';
+  String get updateAppConfirmation => 'क्या आप वाकई अपना ऐप अपडेट करना चाहते हैं? परिवर्तन हमारी टीम द्वारा समीक्षा के बाद दिखाई देंगे।';
 
   @override
   String get updateApp => 'ऐप अपडेट करें';
@@ -3964,8 +3916,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get no => 'नहीं';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'सदस्यता सफलतापूर्वक रद्द हो गई। यह वर्तमान बिलिंग अवधि के अंत तक सक्रिय रहेगी।';
+  String get subscriptionCancelledSuccessfully => 'सदस्यता सफलतापूर्वक रद्द हो गई। यह वर्तमान बिलिंग अवधि के अंत तक सक्रिय रहेगी।';
 
   @override
   String get failedToCancelSubscription => 'सदस्यता रद्द करने में विफल। कृपया पुनः प्रयास करें।';
@@ -4001,8 +3952,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'सदस्यता रद्द करें?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'क्या आप वाकई अपनी सदस्यता रद्द करना चाहते हैं? आपकी वर्तमान बिलिंग अवधि के अंत तक पहुंच जारी रहेगी।';
+  String get cancelSubscriptionConfirmation => 'क्या आप वाकई अपनी सदस्यता रद्द करना चाहते हैं? आपकी वर्तमान बिलिंग अवधि के अंत तक पहुंच जारी रहेगी।';
 
   @override
   String get cancelSubscriptionButton => 'सदस्यता रद्द करें';
@@ -4011,12 +3961,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get cancelling => 'रद्द हो रहा है...';
 
   @override
-  String get betaTesterMessage =>
-      'आप इस ऐप के बीटा टेस्टर हैं। यह अभी सार्वजनिक नहीं है। अनुमोदित होने के बाद सार्वजनिक होगा।';
+  String get betaTesterMessage => 'आप इस ऐप के बीटा टेस्टर हैं। यह अभी सार्वजनिक नहीं है। अनुमोदित होने के बाद सार्वजनिक होगा।';
 
   @override
-  String get appUnderReviewMessage =>
-      'आपका ऐप समीक्षाधीन है और केवल आपको दिखाई दे रहा है। अनुमोदित होने के बाद सार्वजनिक होगा।';
+  String get appUnderReviewMessage => 'आपका ऐप समीक्षाधीन है और केवल आपको दिखाई दे रहा है। अनुमोदित होने के बाद सार्वजनिक होगा।';
 
   @override
   String get appRejectedMessage => 'आपका ऐप अस्वीकृत हो गया। कृपया विवरण अपडेट करें और समीक्षा के लिए पुनः सबमिट करें।';
@@ -4073,8 +4021,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get issueActivatingApp => 'इस ऐप को सक्रिय करने में समस्या हुई। कृपया पुनः प्रयास करें।';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'आपका डेटा सुरक्षित रूप से संग्रहीत है और केवल आपके द्वारा उपयोग किया जाता है। हम आपकी अनुमति के बिना आपका डेटा तीसरे पक्ष के साथ साझा नहीं करते।';
+  String get dataAccessNoticeDescription => 'आपका डेटा सुरक्षित रूप से संग्रहीत है और केवल आपके द्वारा उपयोग किया जाता है। हम आपकी अनुमति के बिना आपका डेटा तीसरे पक्ष के साथ साझा नहीं करते।';
 
   @override
   String get copyUrl => 'URL कॉपी करें';
@@ -4162,8 +4109,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get omiApiKeys => 'Omi API कुंजियाँ';
 
   @override
-  String get apiKeysDescription =>
-      'API कुंजियाँ प्रमाणीकरण के लिए उपयोग की जाती हैं जब आपका ऐप OMI सर्वर के साथ संवाद करता है। वे आपके एप्लिकेशन को यादें बनाने और अन्य OMI सेवाओं तक सुरक्षित रूप से पहुंचने की अनुमति देती हैं।';
+  String get apiKeysDescription => 'API कुंजियाँ प्रमाणीकरण के लिए उपयोग की जाती हैं जब आपका ऐप OMI सर्वर के साथ संवाद करता है। वे आपके एप्लिकेशन को यादें बनाने और अन्य OMI सेवाओं तक सुरक्षित रूप से पहुंचने की अनुमति देती हैं।';
 
   @override
   String get aboutOmiApiKeys => 'Omi API कुंजियों के बारे में';
@@ -4187,8 +4133,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API कुंजी रद्द करें?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'यह क्रिया वापस नहीं की जा सकती। इस कुंजी का उपयोग करने वाले कोई भी एप्लिकेशन अब API तक नहीं पहुंच पाएंगे।';
+  String get revokeApiKeyWarning => 'यह क्रिया वापस नहीं की जा सकती। इस कुंजी का उपयोग करने वाले कोई भी एप्लिकेशन अब API तक नहीं पहुंच पाएंगे।';
 
   @override
   String get revoke => 'रद्द करें';
@@ -4286,8 +4231,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get externalAppAccess => 'बाहरी ऐप एक्सेस';
 
   @override
-  String get externalAppAccessDescription =>
-      'निम्नलिखित इंस्टॉल किए गए ऐप्स में बाहरी एकीकरण हैं और वे आपके डेटा तक पहुंच सकते हैं, जैसे बातचीत और यादें।';
+  String get externalAppAccessDescription => 'निम्नलिखित इंस्टॉल किए गए ऐप्स में बाहरी एकीकरण हैं और वे आपके डेटा तक पहुंच सकते हैं, जैसे बातचीत और यादें।';
 
   @override
   String get noExternalAppsHaveAccess => 'किसी भी बाहरी ऐप के पास आपके डेटा तक पहुंच नहीं है।';
@@ -4296,8 +4240,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get maximumSecurityE2ee => 'अधिकतम सुरक्षा (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'एंड-टू-एंड एन्क्रिप्शन गोपनीयता का स्वर्ण मानक है। सक्षम होने पर, आपका डेटा हमारे सर्वर पर भेजे जाने से पहले आपके डिवाइस पर एन्क्रिप्ट किया जाता है। इसका मतलब है कि कोई भी, यहां तक कि Omi भी, आपकी सामग्री तक नहीं पहुंच सकता।';
+  String get e2eeDescription => 'एंड-टू-एंड एन्क्रिप्शन गोपनीयता का स्वर्ण मानक है। सक्षम होने पर, आपका डेटा हमारे सर्वर पर भेजे जाने से पहले आपके डिवाइस पर एन्क्रिप्ट किया जाता है। इसका मतलब है कि कोई भी, यहां तक कि Omi भी, आपकी सामग्री तक नहीं पहुंच सकता।';
 
   @override
   String get importantTradeoffs => 'महत्वपूर्ण समझौते:';
@@ -4331,15 +4274,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get secureEncryption => 'सुरक्षित एन्क्रिप्शन';
 
   @override
-  String get secureEncryptionDescription =>
-      'आपका डेटा हमारे सर्वर पर आपके लिए एक अद्वितीय कुंजी के साथ एन्क्रिप्ट किया गया है, जो Google Cloud पर होस्ट किया गया है। इसका मतलब है कि आपकी कच्ची सामग्री किसी के लिए भी अप्राप्य है, जिसमें Omi स्टाफ या Google शामिल हैं, सीधे डेटाबेस से।';
+  String get secureEncryptionDescription => 'आपका डेटा हमारे सर्वर पर आपके लिए एक अद्वितीय कुंजी के साथ एन्क्रिप्ट किया गया है, जो Google Cloud पर होस्ट किया गया है। इसका मतलब है कि आपकी कच्ची सामग्री किसी के लिए भी अप्राप्य है, जिसमें Omi स्टाफ या Google शामिल हैं, सीधे डेटाबेस से।';
 
   @override
   String get endToEndEncryption => 'एंड-टू-एंड एन्क्रिप्शन';
 
   @override
-  String get e2eeCardDescription =>
-      'अधिकतम सुरक्षा के लिए सक्षम करें जहां केवल आप अपना डेटा एक्सेस कर सकते हैं। अधिक जानने के लिए टैप करें।';
+  String get e2eeCardDescription => 'अधिकतम सुरक्षा के लिए सक्षम करें जहां केवल आप अपना डेटा एक्सेस कर सकते हैं। अधिक जानने के लिए टैप करें।';
 
   @override
   String get dataAlwaysEncrypted => 'स्तर के बावजूद, आपका डेटा हमेशा आराम और पारगमन में एन्क्रिप्टेड रहता है।';
@@ -4407,12 +4348,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get trainingDataProgram => 'प्रशिक्षण डेटा कार्यक्रम';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'AI मॉडल को प्रशिक्षित करने के लिए अपना डेटा योगदान करके मुफ्त में Omi अनलिमिटेड प्राप्त करें।';
+  String get getOmiUnlimitedFree => 'AI मॉडल को प्रशिक्षित करने के लिए अपना डेटा योगदान करके मुफ्त में Omi अनलिमिटेड प्राप्त करें।';
 
   @override
-  String get trainingDataBullets =>
-      '• आपका डेटा AI मॉडल को बेहतर बनाने में मदद करता है\n• केवल गैर-संवेदनशील डेटा साझा किया जाता है\n• पूरी तरह से पारदर्शी प्रक्रिया';
+  String get trainingDataBullets => '• आपका डेटा AI मॉडल को बेहतर बनाने में मदद करता है\n• केवल गैर-संवेदनशील डेटा साझा किया जाता है\n• पूरी तरह से पारदर्शी प्रक्रिया';
 
   @override
   String get learnMoreAtOmiTraining => 'omi.me/training पर और जानें';
@@ -4462,8 +4401,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get monthlyPlanContinues => 'आपकी वर्तमान मासिक योजना आपके बिलिंग अवधि के अंत तक जारी रहेगी';
 
   @override
-  String get paymentMethodCharged =>
-      'जब आपकी मासिक योजना समाप्त होगी तो आपकी मौजूदा भुगतान विधि से स्वचालित रूप से शुल्क लिया जाएगा';
+  String get paymentMethodCharged => 'जब आपकी मासिक योजना समाप्त होगी तो आपकी मौजूदा भुगतान विधि से स्वचालित रूप से शुल्क लिया जाएगा';
 
   @override
   String get annualSubscriptionStarts => 'आपकी 12 महीने की वार्षिक सदस्यता शुल्क के बाद स्वचालित रूप से शुरू हो जाएगी';
@@ -4506,8 +4444,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'जब आपकी मासिक योजना समाप्त होगी तो आपकी वार्षिक योजना स्वचालित रूप से शुरू हो जाएगी।';
+  String get annualPlanStartsAutomatically => 'जब आपकी मासिक योजना समाप्त होगी तो आपकी वार्षिक योजना स्वचालित रूप से शुरू हो जाएगी।';
 
   @override
   String planRenewsOn(String date) {
@@ -4574,8 +4511,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'आपकी गोपनीयता हमारे लिए महत्वपूर्ण है';
 
   @override
-  String get privacyIntroText =>
-      'Omi में, हम आपकी गोपनीयता को बहुत गंभीरता से लेते हैं। हम उन डेटा के बारे में पारदर्शी रहना चाहते हैं जो हम एकत्र करते हैं और उनका उपयोग कैसे करते हैं। यहाँ आपको क्या जानना चाहिए:';
+  String get privacyIntroText => 'Omi में, हम आपकी गोपनीयता को बहुत गंभीरता से लेते हैं। हम उन डेटा के बारे में पारदर्शी रहना चाहते हैं जो हम एकत्र करते हैं और उनका उपयोग कैसे करते हैं। यहाँ आपको क्या जानना चाहिए:';
 
   @override
   String get whatWeTrack => 'हम क्या ट्रैक करते हैं';
@@ -4590,12 +4526,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get ourCommitment => 'हमारी प्रतिबद्धता';
 
   @override
-  String get commitmentText =>
-      'हम केवल Omi को आपके लिए बेहतर उत्पाद बनाने के लिए एकत्र किए गए डेटा का उपयोग करने के लिए प्रतिबद्ध हैं। आपकी गोपनीयता और विश्वास हमारे लिए सर्वोपरि हैं।';
+  String get commitmentText => 'हम केवल Omi को आपके लिए बेहतर उत्पाद बनाने के लिए एकत्र किए गए डेटा का उपयोग करने के लिए प्रतिबद्ध हैं। आपकी गोपनीयता और विश्वास हमारे लिए सर्वोपरि हैं।';
 
   @override
-  String get thankYouText =>
-      'Omi के एक मूल्यवान उपयोगकर्ता होने के लिए धन्यवाद। यदि आपके कोई प्रश्न या चिंताएं हैं, तो team@basedhardware.com पर हमसे संपर्क करें।';
+  String get thankYouText => 'Omi के एक मूल्यवान उपयोगकर्ता होने के लिए धन्यवाद। यदि आपके कोई प्रश्न या चिंताएं हैं, तो team@basedhardware.com पर हमसे संपर्क करें।';
 
   @override
   String get wifiSyncSettings => 'WiFi सिंक सेटिंग्स';
@@ -4604,8 +4538,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get enterHotspotCredentials => 'अपने फोन के हॉटस्पॉट क्रेडेंशियल दर्ज करें';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi सिंक आपके फोन को हॉटस्पॉट के रूप में उपयोग करता है। सेटिंग्स > पर्सनल हॉटस्पॉट में नाम और पासवर्ड खोजें।';
+  String get wifiSyncUsesHotspot => 'WiFi सिंक आपके फोन को हॉटस्पॉट के रूप में उपयोग करता है। सेटिंग्स > पर्सनल हॉटस्पॉट में नाम और पासवर्ड खोजें।';
 
   @override
   String get hotspotNameSsid => 'हॉटस्पॉट नाम (SSID)';
@@ -4640,8 +4573,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'सारांश बनाने में विफल। सुनिश्चित करें कि उस दिन की बातचीत हो।';
+  String get failedToGenerateSummaryCheckConversations => 'सारांश बनाने में विफल। सुनिश्चित करें कि उस दिन की बातचीत हो।';
 
   @override
   String get summaryNotFound => 'सारांश नहीं मिला';
@@ -4671,8 +4603,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'निर्यात शुरू हुआ। इसमें कुछ सेकंड लग सकते हैं...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'यह सभी व्युत्पन्न नॉलेज ग्राफ डेटा (नोड्स और कनेक्शन) को हटा देगा। आपकी मूल यादें सुरक्षित रहेंगी। ग्राफ समय के साथ या अगले अनुरोध पर पुनर्निर्मित होगा।';
+  String get knowledgeGraphDeleteDescription => 'यह सभी व्युत्पन्न नॉलेज ग्राफ डेटा (नोड्स और कनेक्शन) को हटा देगा। आपकी मूल यादें सुरक्षित रहेंगी। ग्राफ समय के साथ या अगले अनुरोध पर पुनर्निर्मित होगा।';
 
   @override
   String get configureDailySummaryDigest => 'अपना दैनिक कार्य सारांश कॉन्फ़िगर करें';
@@ -4742,8 +4673,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'सभी Limitless वार्तालाप हटाएं?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'यह Limitless से आयातित सभी वार्तालापों को स्थायी रूप से हटा देगा। यह क्रिया पूर्ववत नहीं की जा सकती।';
+  String get deleteAllLimitlessWarning => 'यह Limitless से आयातित सभी वार्तालापों को स्थायी रूप से हटा देगा। यह क्रिया पूर्ववत नहीं की जा सकती।';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4799,8 +4729,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get howItWorksTitle => 'यह कैसे काम करता है?';
 
   @override
-  String get howPeopleWorks =>
-      'एक बार व्यक्ति बन जाने के बाद, आप बातचीत के ट्रांसक्रिप्ट में जा सकते हैं और उन्हें उनके संबंधित सेगमेंट असाइन कर सकते हैं, इस तरह Omi उनकी आवाज़ को भी पहचान पाएगा!';
+  String get howPeopleWorks => 'एक बार व्यक्ति बन जाने के बाद, आप बातचीत के ट्रांसक्रिप्ट में जा सकते हैं और उन्हें उनके संबंधित सेगमेंट असाइन कर सकते हैं, इस तरह Omi उनकी आवाज़ को भी पहचान पाएगा!';
 
   @override
   String get tapToDelete => 'हटाने के लिए टैप करें';
@@ -4826,8 +4755,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get privacyNotice => 'गोपनीयता सूचना';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'रिकॉर्डिंग दूसरों की आवाज़ें कैप्चर कर सकती हैं। सक्षम करने से पहले सभी प्रतिभागियों की सहमति सुनिश्चित करें।';
+  String get recordingsMayCaptureOthers => 'रिकॉर्डिंग दूसरों की आवाज़ें कैप्चर कर सकती हैं। सक्षम करने से पहले सभी प्रतिभागियों की सहमति सुनिश्चित करें।';
 
   @override
   String get enable => 'सक्षम करें';
@@ -4839,8 +4767,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get on => 'चालू';
 
   @override
-  String get storeAudioDescription =>
-      'सभी ऑडियो रिकॉर्डिंग को अपने फ़ोन पर स्थानीय रूप से संग्रहीत रखें। अक्षम होने पर, केवल विफल अपलोड संग्रहण स्थान बचाने के लिए रखे जाते हैं।';
+  String get storeAudioDescription => 'सभी ऑडियो रिकॉर्डिंग को अपने फ़ोन पर स्थानीय रूप से संग्रहीत रखें। अक्षम होने पर, केवल विफल अपलोड संग्रहण स्थान बचाने के लिए रखे जाते हैं।';
 
   @override
   String get enableLocalStorage => 'स्थानीय संग्रहण सक्षम करें';
@@ -4858,12 +4785,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get storeAudioOnCloud => 'ऑडियो क्लाउड में संग्रहित करें';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'बोलते समय आपकी रीयल-टाइम रिकॉर्डिंग निजी क्लाउड स्टोरेज में संग्रहीत की जाएंगी।';
+  String get cloudStorageDialogMessage => 'बोलते समय आपकी रीयल-टाइम रिकॉर्डिंग निजी क्लाउड स्टोरेज में संग्रहीत की जाएंगी।';
 
   @override
-  String get storeAudioCloudDescription =>
-      'बोलते समय अपनी रीयल-टाइम रिकॉर्डिंग को निजी क्लाउड स्टोरेज में संग्रहीत करें। ऑडियो रीयल-टाइम में सुरक्षित रूप से कैप्चर और सहेजा जाता है।';
+  String get storeAudioCloudDescription => 'बोलते समय अपनी रीयल-टाइम रिकॉर्डिंग को निजी क्लाउड स्टोरेज में संग्रहीत करें। ऑडियो रीयल-टाइम में सुरक्षित रूप से कैप्चर और सहेजा जाता है।';
 
   @override
   String get downloadingFirmware => 'फर्मवेयर डाउनलोड हो रहा है';
@@ -4916,8 +4841,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get payments => 'भुगतान';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'अपने ऐप्स के लिए भुगतान प्राप्त करना शुरू करने के लिए नीचे एक भुगतान विधि कनेक्ट करें।';
+  String get connectPaymentMethodInfo => 'अपने ऐप्स के लिए भुगतान प्राप्त करना शुरू करने के लिए नीचे एक भुगतान विधि कनेक्ट करें।';
 
   @override
   String get selectedPaymentMethod => 'चयनित भुगतान विधि';
@@ -4944,8 +4868,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get monthlyPayouts => 'मासिक भुगतान';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'जब आप \$10 की कमाई तक पहुंचें तो सीधे अपने खाते में मासिक भुगतान प्राप्त करें';
+  String get monthlyPayoutsDescription => 'जब आप \$10 की कमाई तक पहुंचें तो सीधे अपने खाते में मासिक भुगतान प्राप्त करें';
 
   @override
   String get secureAndReliable => 'सुरक्षित और विश्वसनीय';
@@ -4972,8 +4895,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get connectingYourStripeAccount => 'आपका Stripe खाता कनेक्ट हो रहा है';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'कृपया अपने ब्राउज़र में Stripe ऑनबोर्डिंग प्रक्रिया पूरी करें। पूरा होने पर यह पेज स्वचालित रूप से अपडेट हो जाएगा।';
+  String get stripeOnboardingInstructions => 'कृपया अपने ब्राउज़र में Stripe ऑनबोर्डिंग प्रक्रिया पूरी करें। पूरा होने पर यह पेज स्वचालित रूप से अपडेट हो जाएगा।';
 
   @override
   String get failedTryAgain => 'विफल? पुनः प्रयास करें';
@@ -4985,8 +4907,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get successfullyConnected => 'सफलतापूर्वक कनेक्ट हो गया!';
 
   @override
-  String get stripeReadyForPayments =>
-      'आपका Stripe खाता अब भुगतान प्राप्त करने के लिए तैयार है। आप तुरंत अपने ऐप की बिक्री से कमाई शुरू कर सकते हैं।';
+  String get stripeReadyForPayments => 'आपका Stripe खाता अब भुगतान प्राप्त करने के लिए तैयार है। आप तुरंत अपने ऐप की बिक्री से कमाई शुरू कर सकते हैं।';
 
   @override
   String get updateStripeDetails => 'Stripe विवरण अपडेट करें';
@@ -5004,8 +4925,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get updatePayPalAccountDetails => 'अपने PayPal खाते का विवरण अपडेट करें';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'अपने ऐप्स के लिए भुगतान प्राप्त करना शुरू करने के लिए अपना PayPal खाता कनेक्ट करें';
+  String get connectPayPalToReceivePayments => 'अपने ऐप्स के लिए भुगतान प्राप्त करना शुरू करने के लिए अपना PayPal खाता कनेक्ट करें';
 
   @override
   String get paypalEmail => 'PayPal ईमेल';
@@ -5014,8 +4934,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me लिंक';
 
   @override
-  String get stripeRecommendation =>
-      'यदि आपके देश में Stripe उपलब्ध है, तो तेज़ और आसान भुगतान के लिए हम इसका उपयोग करने की अत्यधिक अनुशंसा करते हैं।';
+  String get stripeRecommendation => 'यदि आपके देश में Stripe उपलब्ध है, तो तेज़ और आसान भुगतान के लिए हम इसका उपयोग करने की अत्यधिक अनुशंसा करते हैं।';
 
   @override
   String get updatePayPalDetails => 'PayPal विवरण अपडेट करें';
@@ -5067,12 +4986,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'अतिरिक्त भाषण नमूना हटाया गया';
 
   @override
-  String get consentDataMessage =>
-      'जारी रखने पर, आपकी बातचीत, रिकॉर्डिंग और व्यक्तिगत जानकारी हमारे सर्वर पर सुरक्षित रूप से संग्रहीत की जाएगी। आपकी ऑडियो रिकॉर्डिंग और ट्रांसक्रिप्ट तीसरे पक्ष की AI सेवाओं (ट्रांसक्रिप्शन के लिए Deepgram और विश्लेषण के लिए OpenAI सहित) द्वारा संसाधित किए जाते हैं ताकि आपको AI-संचालित अंतर्दृष्टि प्रदान की जा सके और सभी ऐप सुविधाएँ सक्षम की जा सकें।';
+  String get consentDataMessage => 'जारी रखने पर, आपकी बातचीत, रिकॉर्डिंग और व्यक्तिगत जानकारी हमारे सर्वर पर सुरक्षित रूप से संग्रहीत की जाएगी। आपकी ऑडियो रिकॉर्डिंग और ट्रांसक्रिप्ट तीसरे पक्ष की AI सेवाओं (ट्रांसक्रिप्शन के लिए Deepgram और विश्लेषण के लिए OpenAI सहित) द्वारा संसाधित किए जाते हैं ताकि आपको AI-संचालित अंतर्दृष्टि प्रदान की जा सके और सभी ऐप सुविधाएँ सक्षम की जा सकें।';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'आपकी बातचीत के कार्य यहां दिखाई देंगे।\nमैन्युअल रूप से बनाने के लिए + टैप करें।';
+  String get tasksEmptyStateMessage => 'आपकी बातचीत के कार्य यहां दिखाई देंगे।\nमैन्युअल रूप से बनाने के लिए + टैप करें।';
 
   @override
   String get clearChatAction => 'चैट साफ़ करें';
@@ -5108,15 +5025,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get installOmiOnAppleWatch => 'अपने Apple Watch पर\nOmi इंस्टॉल करें';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Omi के साथ Apple Watch का उपयोग करने के लिए, आपको पहले अपनी घड़ी पर Omi ऐप इंस्टॉल करना होगा।';
+  String get installOmiOnAppleWatchDescription => 'Omi के साथ Apple Watch का उपयोग करने के लिए, आपको पहले अपनी घड़ी पर Omi ऐप इंस्टॉल करना होगा।';
 
   @override
   String get openOmiOnAppleWatch => 'अपने Apple Watch पर\nOmi खोलें';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi ऐप आपके Apple Watch पर इंस्टॉल है। इसे खोलें और शुरू करने के लिए Start पर टैप करें।';
+  String get openOmiOnAppleWatchDescription => 'Omi ऐप आपके Apple Watch पर इंस्टॉल है। इसे खोलें और शुरू करने के लिए Start पर टैप करें।';
 
   @override
   String get openWatchApp => 'Watch ऐप खोलें';
@@ -5125,15 +5040,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'मैंने ऐप इंस्टॉल और खोल लिया है';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch ऐप खोलने में असमर्थ। कृपया अपने Apple Watch पर Watch ऐप मैन्युअल रूप से खोलें और \"उपलब्ध ऐप्स\" सेक्शन से Omi इंस्टॉल करें।';
+  String get unableToOpenWatchApp => 'Apple Watch ऐप खोलने में असमर्थ। कृपया अपने Apple Watch पर Watch ऐप मैन्युअल रूप से खोलें और \"उपलब्ध ऐप्स\" सेक्शन से Omi इंस्टॉल करें।';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch सफलतापूर्वक कनेक्ट हो गया!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch अभी भी पहुंच योग्य नहीं है। कृपया सुनिश्चित करें कि Omi ऐप आपकी घड़ी पर खुला है।';
+  String get appleWatchNotReachable => 'Apple Watch अभी भी पहुंच योग्य नहीं है। कृपया सुनिश्चित करें कि Omi ऐप आपकी घड़ी पर खुला है।';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5561,8 +5474,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get multipleSpeakersDetected => 'कई वक्ता पाए गए';
 
   @override
-  String get multipleSpeakersDescription =>
-      'ऐसा लगता है कि रिकॉर्डिंग में कई वक्ता हैं। कृपया सुनिश्चित करें कि आप एक शांत जगह पर हैं और पुनः प्रयास करें।';
+  String get multipleSpeakersDescription => 'ऐसा लगता है कि रिकॉर्डिंग में कई वक्ता हैं। कृपया सुनिश्चित करें कि आप एक शांत जगह पर हैं और पुनः प्रयास करें।';
 
   @override
   String get invalidRecordingDetected => 'अमान्य रिकॉर्डिंग पाई गई';
@@ -5574,15 +5486,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get speechDurationDescription => 'कृपया सुनिश्चित करें कि आप कम से कम 5 सेकंड और 90 से अधिक नहीं बोलते हैं।';
 
   @override
-  String get connectionLostDescription =>
-      'कनेक्शन बाधित हो गया था। कृपया अपना इंटरनेट कनेक्शन जांचें और पुनः प्रयास करें।';
+  String get connectionLostDescription => 'कनेक्शन बाधित हो गया था। कृपया अपना इंटरनेट कनेक्शन जांचें और पुनः प्रयास करें।';
 
   @override
   String get howToTakeGoodSample => 'एक अच्छा नमूना कैसे लें?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. सुनिश्चित करें कि आप एक शांत जगह पर हैं।\n2. स्पष्ट और स्वाभाविक रूप से बोलें।\n3. सुनिश्चित करें कि आपका उपकरण आपकी गर्दन पर अपनी प्राकृतिक स्थिति में है।\n\nएक बार बन जाने के बाद, आप इसे हमेशा सुधार सकते हैं या फिर से कर सकते हैं।';
+  String get goodSampleInstructions => '1. सुनिश्चित करें कि आप एक शांत जगह पर हैं।\n2. स्पष्ट और स्वाभाविक रूप से बोलें।\n3. सुनिश्चित करें कि आपका उपकरण आपकी गर्दन पर अपनी प्राकृतिक स्थिति में है।\n\nएक बार बन जाने के बाद, आप इसे हमेशा सुधार सकते हैं या फिर से कर सकते हैं।';
 
   @override
   String get noDeviceConnectedUseMic => 'कोई उपकरण कनेक्ट नहीं है। फोन माइक्रोफोन का उपयोग किया जाएगा।';
@@ -5645,12 +5555,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get howItWorks => 'यह कैसे काम करता है';
 
   @override
-  String get dailyScoreExplanation =>
-      'आपका दैनिक स्कोर कार्य पूर्णता पर आधारित है। अपना स्कोर सुधारने के लिए अपने कार्य पूरे करें!';
+  String get dailyScoreExplanation => 'आपका दैनिक स्कोर कार्य पूर्णता पर आधारित है। अपना स्कोर सुधारने के लिए अपने कार्य पूरे करें!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'नियंत्रित करें कि Omi आपको कितनी बार सक्रिय सूचनाएं और अनुस्मारक भेजता है।';
+  String get notificationFrequencyDescription => 'नियंत्रित करें कि Omi आपको कितनी बार सक्रिय सूचनाएं और अनुस्मारक भेजता है।';
 
   @override
   String get sliderOff => 'बंद';
@@ -5895,8 +5803,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get recordings => 'रिकॉर्डिंग';
 
   @override
-  String get enableRemindersAccess =>
-      'Apple रिमाइंडर का उपयोग करने के लिए कृपया सेटिंग्स में रिमाइंडर एक्सेस सक्षम करें';
+  String get enableRemindersAccess => 'Apple रिमाइंडर का उपयोग करने के लिए कृपया सेटिंग्स में रिमाइंडर एक्सेस सक्षम करें';
 
   @override
   String todayAtTime(String time) {
@@ -5951,8 +5858,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL सेट नहीं है';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'इस सुविधा का उपयोग करने के लिए कृपया डेवलपर सेटिंग्स में webhook URL सेट करें।';
+  String get setWebhookUrlInSettings => 'इस सुविधा का उपयोग करने के लिए कृपया डेवलपर सेटिंग्स में webhook URL सेट करें।';
 
   @override
   String get sendWebUrl => 'वेब URL भेजें';
@@ -6032,8 +5938,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get viewUsage => 'उपयोग देखें';
 
   @override
-  String get localProcessingInfo =>
-      'ऑडियो स्थानीय रूप से प्रोसेस होता है। ऑफलाइन काम करता है, अधिक निजी है, लेकिन अधिक बैटरी का उपयोग करता है।';
+  String get localProcessingInfo => 'ऑडियो स्थानीय रूप से प्रोसेस होता है। ऑफलाइन काम करता है, अधिक निजी है, लेकिन अधिक बैटरी का उपयोग करता है।';
 
   @override
   String get model => 'मॉडल';
@@ -6042,15 +5947,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get performanceWarning => 'प्रदर्शन चेतावनी';
 
   @override
-  String get largeModelWarning =>
-      'यह मॉडल बड़ा है और मोबाइल डिवाइस पर ऐप क्रैश हो सकता है या बहुत धीमे चल सकता है।\n\n\"small\" या \"base\" की सिफारिश की जाती है।';
+  String get largeModelWarning => 'यह मॉडल बड़ा है और मोबाइल डिवाइस पर ऐप क्रैश हो सकता है या बहुत धीमे चल सकता है।\n\n\"small\" या \"base\" की सिफारिश की जाती है।';
 
   @override
   String get usingNativeIosSpeech => 'मूल iOS स्पीच रिकग्निशन का उपयोग';
 
   @override
-  String get noModelDownloadRequired =>
-      'आपके डिवाइस का नेटिव स्पीच इंजन उपयोग किया जाएगा। कोई मॉडल डाउनलोड आवश्यक नहीं।';
+  String get noModelDownloadRequired => 'आपके डिवाइस का नेटिव स्पीच इंजन उपयोग किया जाएगा। कोई मॉडल डाउनलोड आवश्यक नहीं।';
 
   @override
   String get modelReady => 'मॉडल तैयार';
@@ -6107,12 +6010,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get batteryDrainSignificantly => 'बैटरी की खपत काफी बढ़ जाएगी।';
 
   @override
-  String get premiumMinutesMonth =>
-      '1,200 प्रीमियम मिनट/माह। ऑन-डिवाइस टैब असीमित मुफ्त ट्रांसक्रिप्शन प्रदान करता है। ';
+  String get premiumMinutesMonth => '1,200 प्रीमियम मिनट/माह। ऑन-डिवाइस टैब असीमित मुफ्त ट्रांसक्रिप्शन प्रदान करता है। ';
 
   @override
-  String get audioProcessedLocally =>
-      'ऑडियो स्थानीय रूप से संसाधित होता है। ऑफ़लाइन काम करता है, अधिक निजी, लेकिन अधिक बैटरी उपयोग करता है।';
+  String get audioProcessedLocally => 'ऑडियो स्थानीय रूप से संसाधित होता है। ऑफ़लाइन काम करता है, अधिक निजी, लेकिन अधिक बैटरी उपयोग करता है।';
 
   @override
   String get languageLabel => 'भाषा';
@@ -6121,8 +6022,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get modelLabel => 'मॉडल';
 
   @override
-  String get modelTooLargeWarning =>
-      'यह मॉडल बड़ा है और मोबाइल डिवाइस पर ऐप क्रैश या बहुत धीमा हो सकता है।\n\nsmall या base की सिफारिश की जाती है।';
+  String get modelTooLargeWarning => 'यह मॉडल बड़ा है और मोबाइल डिवाइस पर ऐप क्रैश या बहुत धीमा हो सकता है।\n\nsmall या base की सिफारिश की जाती है।';
 
   @override
   String get nativeEngineNoDownload => 'आपके डिवाइस का मूल स्पीच इंजन उपयोग किया जाएगा। मॉडल डाउनलोड की आवश्यकता नहीं।';
@@ -6161,8 +6061,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi की अंतर्निहित लाइव ट्रांसक्रिप्शन स्वचालित स्पीकर डिटेक्शन और डायराइज़ेशन के साथ रियल-टाइम वार्तालाप के लिए अनुकूलित है।';
+  String get omiTranscriptionOptimized => 'Omi की अंतर्निहित लाइव ट्रांसक्रिप्शन स्वचालित स्पीकर डिटेक्शन और डायराइज़ेशन के साथ रियल-टाइम वार्तालाप के लिए अनुकूलित है।';
 
   @override
   String get reset => 'रीसेट';
@@ -6382,8 +6281,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'यादों से ज्ञान ग्राफ़ बनाया जा रहा है...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'जब आप नई यादें बनाएंगे तो आपका ज्ञान ग्राफ़ स्वचालित रूप से बनेगा।';
+  String get knowledgeGraphWillBuildAutomatically => 'जब आप नई यादें बनाएंगे तो आपका ज्ञान ग्राफ़ स्वचालित रूप से बनेगा।';
 
   @override
   String get buildGraphButton => 'ग्राफ़ बनाएं';
@@ -6619,8 +6517,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get failedToLoadContacts => 'संपर्क लोड करने में विफल';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'साझा करने के लिए बातचीत तैयार करने में विफल। कृपया पुनः प्रयास करें।';
+  String get failedToPrepareConversationForSharing => 'साझा करने के लिए बातचीत तैयार करने में विफल। कृपया पुनः प्रयास करें।';
 
   @override
   String get couldNotOpenSmsApp => 'SMS ऐप नहीं खोला जा सका। कृपया पुनः प्रयास करें।';
@@ -6766,15 +6663,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get enableFastTransfer => 'फास्ट ट्रांसफर सक्षम करें';
 
   @override
-  String get fastTransferDescription =>
-      'फास्ट ट्रांसफर ~5x तेज गति के लिए WiFi का उपयोग करता है। ट्रांसफर के दौरान आपका फोन अस्थायी रूप से आपके Omi डिवाइस के WiFi नेटवर्क से कनेक्ट होगा।';
+  String get fastTransferDescription => 'फास्ट ट्रांसफर ~5x तेज गति के लिए WiFi का उपयोग करता है। ट्रांसफर के दौरान आपका फोन अस्थायी रूप से आपके Omi डिवाइस के WiFi नेटवर्क से कनेक्ट होगा।';
 
   @override
   String get internetAccessPausedDuringTransfer => 'ट्रांसफर के दौरान इंटरनेट एक्सेस रुका हुआ है';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'चुनें कि आपके Omi डिवाइस से आपके फोन में रिकॉर्डिंग कैसे ट्रांसफर की जाएं।';
+  String get chooseTransferMethodDescription => 'चुनें कि आपके Omi डिवाइस से आपके फोन में रिकॉर्डिंग कैसे ट्रांसफर की जाएं।';
 
   @override
   String get wifiSpeed => '~150 KB/s WiFi के माध्यम से';
@@ -6783,8 +6678,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get fiveTimesFaster => '5X तेज';
 
   @override
-  String get fastTransferMethodDescription =>
-      'आपके Omi डिवाइस से सीधा WiFi कनेक्शन बनाता है। ट्रांसफर के दौरान आपका फोन अस्थायी रूप से आपके सामान्य WiFi से डिस्कनेक्ट हो जाता है।';
+  String get fastTransferMethodDescription => 'आपके Omi डिवाइस से सीधा WiFi कनेक्शन बनाता है। ट्रांसफर के दौरान आपका फोन अस्थायी रूप से आपके सामान्य WiFi से डिस्कनेक्ट हो जाता है।';
 
   @override
   String get bluetooth => 'ब्लूटूथ';
@@ -6793,8 +6687,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get bleSpeed => '~30 KB/s BLE के माध्यम से';
 
   @override
-  String get bluetoothMethodDescription =>
-      'मानक ब्लूटूथ लो एनर्जी कनेक्शन का उपयोग करता है। धीमा लेकिन आपके WiFi कनेक्शन को प्रभावित नहीं करता।';
+  String get bluetoothMethodDescription => 'मानक ब्लूटूथ लो एनर्जी कनेक्शन का उपयोग करता है। धीमा लेकिन आपके WiFi कनेक्शन को प्रभावित नहीं करता।';
 
   @override
   String get selected => 'चयनित';
@@ -6832,12 +6725,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get appDeleteFailed => 'ऐप हटाने में विफल। कृपया बाद में पुन: प्रयास करें।';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'ऐप दृश्यता सफलतापूर्वक बदल दी गई। प्रतिबिंबित होने में कुछ मिनट लग सकते हैं।';
+  String get appVisibilityChangedSuccessfully => 'ऐप दृश्यता सफलतापूर्वक बदल दी गई। प्रतिबिंबित होने में कुछ मिनट लग सकते हैं।';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'ऐप सक्रिय करने में त्रुटि। यदि यह एकीकरण ऐप है, तो सुनिश्चित करें कि सेटअप पूरा हो गया है।';
+  String get errorActivatingAppIntegration => 'ऐप सक्रिय करने में त्रुटि। यदि यह एकीकरण ऐप है, तो सुनिश्चित करें कि सेटअप पूरा हो गया है।';
 
   @override
   String get errorUpdatingAppStatus => 'ऐप स्थिति अपडेट करते समय एक त्रुटि हुई।';
@@ -7104,15 +6995,13 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'आपका प्लान अपग्रेड शेड्यूल हो गया है और आपकी वर्तमान अवधि समाप्त होने पर सक्रिय होगा।';
+  String get planUpgradeScheduledMessage => 'आपका प्लान अपग्रेड शेड्यूल हो गया है और आपकी वर्तमान अवधि समाप्त होने पर सक्रिय होगा।';
 
   @override
   String get couldNotSchedulePlanChange => 'प्लान परिवर्तन शेड्यूल नहीं हो सका। कृपया पुनः प्रयास करें।';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'आपकी सदस्यता फिर से सक्रिय हो गई है। अभी कोई शुल्क नहीं - आपकी वर्तमान अवधि के अंत में बिल आएगा।';
+  String get subscriptionReactivatedDefault => 'आपकी सदस्यता फिर से सक्रिय हो गई है। अभी कोई शुल्क नहीं - आपकी वर्तमान अवधि के अंत में बिल आएगा।';
 
   @override
   String get subscriptionSuccessfulCharged => 'सदस्यता सफल। आपसे शुल्क लिया गया है।';
@@ -7280,8 +7169,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Firebase टोकन प्राप्त करने में विफल, कृपया पुनः प्रयास करें।';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'साइन इन करते समय अप्रत्याशित त्रुटि, Firebase त्रुटि, कृपया पुनः प्रयास करें।';
+  String get authUnexpectedErrorFirebase => 'साइन इन करते समय अप्रत्याशित त्रुटि, Firebase त्रुटि, कृपया पुनः प्रयास करें।';
 
   @override
   String get authUnexpectedError => 'साइन इन करते समय अप्रत्याशित त्रुटि, कृपया पुनः प्रयास करें';
@@ -7296,8 +7184,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get onboardingBluetoothRequired => 'आपके डिवाइस से कनेक्ट करने के लिए ब्लूटूथ अनुमति आवश्यक है।';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'ब्लूटूथ अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताओं में अनुमति प्रदान करें।';
+  String get onboardingBluetoothDeniedSystemPrefs => 'ब्लूटूथ अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताओं में अनुमति प्रदान करें।';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7310,12 +7197,10 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'सूचना अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताओं में अनुमति प्रदान करें।';
+  String get onboardingNotificationDeniedSystemPrefs => 'सूचना अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताओं में अनुमति प्रदान करें।';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'सूचना अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताएं > सूचनाएं में अनुमति प्रदान करें।';
+  String get onboardingNotificationDeniedNotifications => 'सूचना अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताएं > सूचनाएं में अनुमति प्रदान करें।';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7328,15 +7213,13 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'कृपया सेटिंग्स > गोपनीयता और सुरक्षा > स्थान सेवाओं में स्थान अनुमति प्रदान करें';
+  String get onboardingLocationGrantInSettings => 'कृपया सेटिंग्स > गोपनीयता और सुरक्षा > स्थान सेवाओं में स्थान अनुमति प्रदान करें';
 
   @override
   String get onboardingMicrophoneRequired => 'रिकॉर्डिंग के लिए माइक्रोफ़ोन अनुमति आवश्यक है।';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'माइक्रोफ़ोन अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताएं > गोपनीयता और सुरक्षा > माइक्रोफ़ोन में अनुमति प्रदान करें।';
+  String get onboardingMicrophoneDenied => 'माइक्रोफ़ोन अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताएं > गोपनीयता और सुरक्षा > माइक्रोफ़ोन में अनुमति प्रदान करें।';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7352,8 +7235,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'सिस्टम ऑडियो रिकॉर्डिंग के लिए स्क्रीन कैप्चर अनुमति आवश्यक है।';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'स्क्रीन कैप्चर अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताएं > गोपनीयता और सुरक्षा > स्क्रीन रिकॉर्डिंग में अनुमति प्रदान करें।';
+  String get onboardingScreenCaptureDenied => 'स्क्रीन कैप्चर अनुमति अस्वीकृत। कृपया सिस्टम प्राथमिकताएं > गोपनीयता और सुरक्षा > स्क्रीन रिकॉर्डिंग में अनुमति प्रदान करें।';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7406,8 +7288,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'फोटो अनुमति अस्वीकृत। छवियों का चयन करने के लिए कृपया फ़ोटो एक्सेस की अनुमति दें';
+  String get msgPhotosPermissionDenied => 'फोटो अनुमति अस्वीकृत। छवियों का चयन करने के लिए कृपया फ़ोटो एक्सेस की अनुमति दें';
 
   @override
   String get msgSelectImagesGenericError => 'छवियों का चयन करने में त्रुटि। कृपया पुनः प्रयास करें।';
@@ -7479,8 +7360,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get locationPermissionRequired => 'स्थान अनुमति आवश्यक';
 
   @override
-  String get locationPermissionContent =>
-      'फास्ट ट्रांसफर को WiFi कनेक्शन सत्यापित करने के लिए स्थान अनुमति की आवश्यकता है। कृपया जारी रखने के लिए स्थान अनुमति दें।';
+  String get locationPermissionContent => 'फास्ट ट्रांसफर को WiFi कनेक्शन सत्यापित करने के लिए स्थान अनुमति की आवश्यकता है। कृपया जारी रखने के लिए स्थान अनुमति दें।';
 
   @override
   String get pdfTranscriptExport => 'ट्रांसक्रिप्ट निर्यात';
@@ -7643,8 +7523,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'डिवाइस WiFi सिंक का समर्थन नहीं करता, Bluetooth पर स्विच कर रहा है';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'डिवाइस WiFi सिंक का समर्थन नहीं करता, Bluetooth पर स्विच कर रहा है';
 
   @override
   String get appleHealthNotAvailable => 'इस डिवाइस पर Apple Health उपलब्ध नहीं है';
@@ -7940,8 +7819,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Omi DevKit को पेयरिंग मोड में डालें';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'चालू करने के लिए बटन एक बार दबाएं। पेयरिंग मोड में LED बैंगनी रंग में ब्लिंक करेगी।';
+  String get pairingDescOmiDevkit => 'चालू करने के लिए बटन एक बार दबाएं। पेयरिंग मोड में LED बैंगनी रंग में ब्लिंक करेगी।';
 
   @override
   String get pairingTitleOmiGlass => 'Omi Glass चालू करें';
@@ -7953,8 +7831,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note को पेयरिंग मोड में डालें';
 
   @override
-  String get pairingDescPlaudNote =>
-      'साइड बटन को 2 सेकंड तक दबाकर रखें। पेयर करने के लिए तैयार होने पर लाल LED ब्लिंक करेगी।';
+  String get pairingDescPlaudNote => 'साइड बटन को 2 सेकंड तक दबाकर रखें। पेयर करने के लिए तैयार होने पर लाल LED ब्लिंक करेगी।';
 
   @override
   String get pairingTitleBee => 'Bee को पेयरिंग मोड में डालें';
@@ -7966,15 +7843,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get pairingTitleLimitless => 'Limitless को पेयरिंग मोड में डालें';
 
   @override
-  String get pairingDescLimitless =>
-      'जब कोई भी लाइट दिखाई दे, एक बार दबाएं और फिर दबाकर रखें जब तक डिवाइस गुलाबी लाइट न दिखाए, फिर छोड़ दें।';
+  String get pairingDescLimitless => 'जब कोई भी लाइट दिखाई दे, एक बार दबाएं और फिर दबाकर रखें जब तक डिवाइस गुलाबी लाइट न दिखाए, फिर छोड़ दें।';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant को पेयरिंग मोड में डालें';
 
   @override
-  String get pairingDescFriendPendant =>
-      'पेंडेंट पर बटन दबाकर इसे चालू करें। यह स्वचालित रूप से पेयरिंग मोड में प्रवेश करेगा।';
+  String get pairingDescFriendPendant => 'पेंडेंट पर बटन दबाकर इसे चालू करें। यह स्वचालित रूप से पेयरिंग मोड में प्रवेश करेगा।';
 
   @override
   String get pairingTitleFieldy => 'Fieldy को पेयरिंग मोड में डालें';
@@ -7986,8 +7861,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch कनेक्ट करें';
 
   @override
-  String get pairingDescAppleWatch =>
-      'अपने Apple Watch पर Omi ऐप इंस्टॉल करें और खोलें, फिर ऐप में कनेक्ट पर टैप करें।';
+  String get pairingDescAppleWatch => 'अपने Apple Watch पर Omi ऐप इंस्टॉल करें और खोलें, फिर ऐप में कनेक्ट पर टैप करें।';
 
   @override
   String get pairingTitleNeoOne => 'Neo One को पेयरिंग मोड में डालें';
@@ -8063,8 +7937,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get wifiConfiguration => 'वाईफाई कॉन्फ़िगरेशन';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'डिवाइस को फ़र्मवेयर डाउनलोड करने देने के लिए अपने वाईफाई क्रेडेंशियल दर्ज करें।';
+  String get wifiConfigurationSubtitle => 'डिवाइस को फ़र्मवेयर डाउनलोड करने देने के लिए अपने वाईफाई क्रेडेंशियल दर्ज करें।';
 
   @override
   String get networkNameSsid => 'नेटवर्क नाम (SSID)';
@@ -8111,8 +7984,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get switchAndRestart => 'बदलें';
 
   @override
-  String get stagingDisclaimer =>
-      'स्टेजिंग अस्थिर हो सकता है, प्रदर्शन असंगत हो सकता है, और डेटा खो सकता है। केवल परीक्षण के लिए।';
+  String get stagingDisclaimer => 'स्टेजिंग अस्थिर हो सकता है, प्रदर्शन असंगत हो सकता है, और डेटा खो सकता है। केवल परीक्षण के लिए।';
 
   @override
   String get apiEnvSavedRestartRequired => 'सहेजा गया। बदलाव लागू करने के लिए ऐप बंद करें और फिर से खोलें।';
@@ -8341,8 +8213,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Omi से फ़ोन कॉल';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Omi से कॉल करें और रियल-टाइम ट्रांसक्रिप्शन, स्वचालित सारांश और बहुत कुछ पाएं।';
+  String get phoneCallsUpsellSubtitle => 'Omi से कॉल करें और रियल-टाइम ट्रांसक्रिप्शन, स्वचालित सारांश और बहुत कुछ पाएं।';
 
   @override
   String get phoneCallsUpsellFeature1 => 'हर कॉल की रियल-टाइम ट्रांसक्रिप्शन';
@@ -8369,8 +8240,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deleteSyncedFiles => 'सिंक की गई रिकॉर्डिंग हटाएं';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'ये रिकॉर्डिंग पहले से आपके फोन पर सिंक हो चुकी हैं। यह पूर्ववत नहीं किया जा सकता।';
+  String get deleteSyncedFilesMessage => 'ये रिकॉर्डिंग पहले से आपके फोन पर सिंक हो चुकी हैं। यह पूर्ववत नहीं किया जा सकता।';
 
   @override
   String get syncedFilesDeleted => 'सिंक की गई रिकॉर्डिंग हटाई गईं';
@@ -8382,8 +8252,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deletePendingFiles => 'लंबित रिकॉर्डिंग हटाएं';
 
   @override
-  String get deletePendingFilesWarning =>
-      'ये रिकॉर्डिंग आपके फोन पर सिंक नहीं हुई हैं और स्थायी रूप से खो जाएंगी। यह पूर्ववत नहीं किया जा सकता।';
+  String get deletePendingFilesWarning => 'ये रिकॉर्डिंग आपके फोन पर सिंक नहीं हुई हैं और स्थायी रूप से खो जाएंगी। यह पूर्ववत नहीं किया जा सकता।';
 
   @override
   String get pendingFilesDeleted => 'लंबित रिकॉर्डिंग हटाई गईं';
@@ -8395,8 +8264,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deleteAll => 'सब हटाएं';
 
   @override
-  String get deleteAllFilesWarning =>
-      'यह सिंक की गई और लंबित दोनों रिकॉर्डिंग हटा देगा। लंबित रिकॉर्डिंग सिंक नहीं हुई हैं और स्थायी रूप से खो जाएंगी।';
+  String get deleteAllFilesWarning => 'यह सिंक की गई और लंबित दोनों रिकॉर्डिंग हटा देगा। लंबित रिकॉर्डिंग सिंक नहीं हुई हैं और स्थायी रूप से खो जाएंगी।';
 
   @override
   String get allFilesDeleted => 'सभी रिकॉर्डिंग हटाई गईं';
@@ -8461,8 +8329,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get fairUseAboutTitle => 'उचित उपयोग के बारे में';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi व्यक्तिगत वार्तालाप, बैठकों और लाइव इंटरैक्शन के लिए डिज़ाइन किया गया है। उपयोग को वास्तविक पहचानी गई वाक् समय से मापा जाता है, कनेक्शन समय से नहीं। यदि उपयोग गैर-व्यक्तिगत सामग्री के लिए सामान्य पैटर्न से काफी अधिक हो जाता है, तो समायोजन लागू हो सकते हैं।';
+  String get fairUseAboutBody => 'Omi व्यक्तिगत वार्तालाप, बैठकों और लाइव इंटरैक्शन के लिए डिज़ाइन किया गया है। उपयोग को वास्तविक पहचानी गई वाक् समय से मापा जाता है, कनेक्शन समय से नहीं। यदि उपयोग गैर-व्यक्तिगत सामग्री के लिए सामान्य पैटर्न से काफी अधिक हो जाता है, तो समायोजन लागू हो सकते हैं।';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8500,8 +8367,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get improveConnectionTitle => 'कनेक्शन सुधारें';
 
   @override
-  String get improveConnectionContent =>
-      'हमने Omi के आपके डिवाइस से जुड़े रहने के तरीके में सुधार किया है। इसे सक्रिय करने के लिए, डिवाइस जानकारी पृष्ठ पर जाएं, \"डिवाइस डिस्कनेक्ट करें\" पर टैप करें, और अपने डिवाइस को फिर से पेयर करें।';
+  String get improveConnectionContent => 'हमने Omi के आपके डिवाइस से जुड़े रहने के तरीके में सुधार किया है। इसे सक्रिय करने के लिए, डिवाइस जानकारी पृष्ठ पर जाएं, \"डिवाइस डिस्कनेक्ट करें\" पर टैप करें, और अपने डिवाइस को फिर से पेयर करें।';
 
   @override
   String get improveConnectionAction => 'समझ गया';
@@ -8556,16 +8422,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get cancelSyncQuestion => 'सिंक रद्द करें?';
 
   @override
-  String get omisStorageDesc =>
-      'जब आपका Omi फ़ोन से कनेक्ट नहीं होता, तो यह ऑडियो को अपनी बिल्ट-इन मेमोरी में स्टोर करता है। आप कभी कोई रिकॉर्डिंग नहीं खोएंगे।';
+  String get omisStorageDesc => 'जब आपका Omi फ़ोन से कनेक्ट नहीं होता, तो यह ऑडियो को अपनी बिल्ट-इन मेमोरी में स्टोर करता है। आप कभी कोई रिकॉर्डिंग नहीं खोएंगे।';
 
   @override
-  String get phoneStorageDesc =>
-      'जब Omi फिर से कनेक्ट होता है, रिकॉर्डिंग अपलोड से पहले आपके फ़ोन में ऑटो-ट्रांसफर होती हैं।';
+  String get phoneStorageDesc => 'जब Omi फिर से कनेक्ट होता है, रिकॉर्डिंग अपलोड से पहले आपके फ़ोन में ऑटो-ट्रांसफर होती हैं।';
 
   @override
-  String get cloudStorageDesc =>
-      'अपलोड होने के बाद, आपकी रिकॉर्डिंग प्रोसेस और ट्रांसक्राइब होती हैं। बातचीत एक मिनट में उपलब्ध होंगी।';
+  String get cloudStorageDesc => 'अपलोड होने के बाद, आपकी रिकॉर्डिंग प्रोसेस और ट्रांसक्राइब होती हैं। बातचीत एक मिनट में उपलब्ध होंगी।';
 
   @override
   String get tipKeepPhoneNearby => 'तेज़ सिंक के लिए अपना फ़ोन पास रखें';
@@ -8589,12 +8452,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get permissionEnable => 'सक्षम करें';
 
   @override
-  String get permissionsPageDescription =>
-      'ये अनुमतियाँ Omi के काम करने के लिए आवश्यक हैं। ये सूचनाएँ, स्थान-आधारित अनुभव और ऑडियो कैप्चर जैसी प्रमुख सुविधाएँ सक्षम करती हैं।';
+  String get permissionsPageDescription => 'ये अनुमतियाँ Omi के काम करने के लिए आवश्यक हैं। ये सूचनाएँ, स्थान-आधारित अनुभव और ऑडियो कैप्चर जैसी प्रमुख सुविधाएँ सक्षम करती हैं।';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi को ठीक से काम करने के लिए कुछ अनुमतियों की आवश्यकता है। कृपया जारी रखने के लिए उन्हें प्रदान करें।';
+  String get permissionsRequiredDescription => 'Omi को ठीक से काम करने के लिए कुछ अनुमतियों की आवश्यकता है। कृपया जारी रखने के लिए उन्हें प्रदान करें।';
 
   @override
   String get permissionsSetupTitle => 'सर्वोत्तम अनुभव प्राप्त करें';
@@ -8648,8 +8509,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get justAMoment => 'एक क्षण, कृपया';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'हम दृढ़ता से अनुशंसा करते हैं कि आप रद्द करने के बजाय अपने अन्य विकल्पों का पता लगाएं।';
+  String get cancelConsequencesSubtitle => 'हम दृढ़ता से अनुशंसा करते हैं कि आप रद्द करने के बजाय अपने अन्य विकल्पों का पता लगाएं।';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8702,8 +8562,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get feedbackSubtitleTooExpensive => 'आपकी प्रतिक्रिया हमें सही संतुलन खोजने में मदद करती है।';
 
   @override
-  String get feedbackSubtitleMissingFeatures =>
-      'हम हमेशा निर्माण कर रहे हैं — इससे हमें प्राथमिकता तय करने में मदद मिलती है।';
+  String get feedbackSubtitleMissingFeatures => 'हम हमेशा निर्माण कर रहे हैं — इससे हमें प्राथमिकता तय करने में मदद मिलती है।';
 
   @override
   String get feedbackSubtitleAudioQuality => 'हम समझना चाहेंगे कि क्या गलत हुआ।';
@@ -8873,8 +8732,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get firmwareWarningTitle => 'महत्वपूर्ण: अपडेट करने से पहले पढ़ें';
 
   @override
-  String get firmwareFormatWarning =>
-      'यह फर्मवेयर SD कार्ड को फॉर्मेट करेगा। कृपया अपग्रेड करने से पहले सुनिश्चित करें कि सभी ऑफ़लाइन डेटा सिंक हो गया है।\n\nयदि इस संस्करण को इंस्टॉल करने के बाद लाल बत्ती चमकती दिखाई दे, तो चिंता न करें। बस डिवाइस को ऐप से कनेक्ट करें और यह नीला हो जाना चाहिए। लाल बत्ती का मतलब है कि डिवाइस की घड़ी अभी तक सिंक नहीं हुई है।';
+  String get firmwareFormatWarning => 'यह फर्मवेयर SD कार्ड को फॉर्मेट करेगा। कृपया अपग्रेड करने से पहले सुनिश्चित करें कि सभी ऑफ़लाइन डेटा सिंक हो गया है।\n\nयदि इस संस्करण को इंस्टॉल करने के बाद लाल बत्ती चमकती दिखाई दे, तो चिंता न करें। बस डिवाइस को ऐप से कनेक्ट करें और यह नीला हो जाना चाहिए। लाल बत्ती का मतलब है कि डिवाइस की घड़ी अभी तक सिंक नहीं हुई है।';
 
   @override
   String get continueAnyway => 'जारी रखें';
@@ -8894,8 +8752,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get tasksMarkComplete => 'पूर्ण के रूप में चिह्नित';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi Apple के HealthKit फ्रेमवर्क के माध्यम से Apple Health तक पहुँचता है। आप किसी भी समय iOS सेटिंग्स से एक्सेस रद्द कर सकते हैं।';
+  String get appleHealthManageNote => 'Omi Apple के HealthKit फ्रेमवर्क के माध्यम से Apple Health तक पहुँचता है। आप किसी भी समय iOS सेटिंग्स से एक्सेस रद्द कर सकते हैं।';
 
   @override
   String get appleHealthConnectCta => 'Apple Health से कनेक्ट करें';
@@ -8928,8 +8785,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health एक्सेस अस्वीकृत';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi के पास आपका Apple Health डेटा पढ़ने की अनुमति नहीं है। iOS सेटिंग्स → गोपनीयता और सुरक्षा → Health → Omi में इसे सक्षम करें।';
+  String get appleHealthDeniedBody => 'Omi के पास आपका Apple Health डेटा पढ़ने की अनुमति नहीं है। iOS सेटिंग्स → गोपनीयता और सुरक्षा → Health → Omi में इसे सक्षम करें।';
 
   @override
   String get deleteFlowReasonTitle => 'आप क्यों जा रहे हैं?';
@@ -8998,8 +8854,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get planUpdate => 'प्लान अपडेट';
 
   @override
-  String get planDeprecationMessage =>
-      'आपका Unlimited प्लान बंद किया जा रहा है। Operator प्लान पर स्विच करें — वही बेहतरीन सुविधाएँ \$49/माह पर। आपका वर्तमान प्लान तब तक काम करता रहेगा।';
+  String get planDeprecationMessage => 'आपका Unlimited प्लान बंद किया जा रहा है। Operator प्लान पर स्विच करें — वही बेहतरीन सुविधाएँ \$49/माह पर। आपका वर्तमान प्लान तब तक काम करता रहेगा।';
 
   @override
   String get upgradeYourPlan => 'अपना प्लान अपग्रेड करें';
@@ -9110,8 +8965,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'आपने अपनी मासिक सीमा पूरी कर ली है। बिना प्रतिबंध के Omi से चैट जारी रखने के लिए अपग्रेड करें।';
+  String get chatQuotaExceededReply => 'आपने अपनी मासिक सीमा पूरी कर ली है। बिना प्रतिबंध के Omi से चैट जारी रखने के लिए अपग्रेड करें।';
 
   @override
   String get voiceResponseAudio => 'Omi का जवाब ज़ोर से पढ़ें';
@@ -9142,4 +8996,25 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'कार्य जोड़ें';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi से कुछ भी पूछें';
+
+  @override
+  String get quickActionVoiceMode => 'वॉयस मोड';
+
+  @override
+  String get quickActionMute => 'म्यूट करें';
+
+  @override
+  String get quickActionUnmute => 'म्यूट हटाएं';
+
+  @override
+  String get quickActionConnectDevice => 'डिवाइस कनेक्ट करें';
+
+  @override
+  String get quickActionDeviceSettings => 'डिवाइस सेटिंग्स';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -24,8 +24,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteConversationTitle => 'Obrisati razgovor?';
 
   @override
-  String get deleteConversationMessage =>
-      'Ovo će obrisati i povezane uspomene, zadatke i audio datoteke. Ova radnja se ne može poništiti.';
+  String get deleteConversationMessage => 'Ovo će obrisati i povezane uspomene, zadatke i audio datoteke. Ova radnja se ne može poništiti.';
 
   @override
   String get confirm => 'Potvrdi';
@@ -146,8 +145,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleting => 'Brisanje...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Završi autentifikaciju u svom pregledniku. Kada završiš, vrati se u aplikaciju.';
+  String get pleaseCompleteAuthentication => 'Završi autentifikaciju u svom pregledniku. Kada završiš, vrati se u aplikaciju.';
 
   @override
   String get failedToStartAuthentication => 'Nije moguće započeti autentifikaciju';
@@ -228,8 +226,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noStarredConversations => 'Nema zvjezdanih razgovora';
 
   @override
-  String get starConversationHint =>
-      'Ako želiš označiti razgovor zvjezdicom, otvori ga i dodirnite ikonu zvjezdice u zaglavlju.';
+  String get starConversationHint => 'Ako želiš označiti razgovor zvjezdicom, otvori ga i dodirnite ikonu zvjezdice u zaglavlju.';
 
   @override
   String get searchConversations => 'Pretraži razgovore...';
@@ -356,19 +353,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get appsDisconnected => 'Tvoje aplikacije i integracije bit će odspojene odmah.';
 
   @override
-  String get exportBeforeDelete =>
-      'Možeš izvesti podatke prije brisanja računa, ali nakon što budeš obrisao/a, ne mogu se vratiti.';
+  String get exportBeforeDelete => 'Možeš izvesti podatke prije brisanja računa, ali nakon što budeš obrisao/a, ne mogu se vratiti.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Razumijem da je brisanje mog računa trajno i svi podaci, uključujući uspomene i razgovore, bit će trajno izbrisani i ne mogu se vratiti.';
+  String get deleteAccountCheckbox => 'Razumijem da je brisanje mog računa trajno i svi podaci, uključujući uspomene i razgovore, bit će trajno izbrisani i ne mogu se vratiti.';
 
   @override
   String get areYouSure => 'Jesi li siguran/a?';
 
   @override
-  String get deleteAccountFinal =>
-      'Ova radnja je nepovratna i trajno će obrisati tvoj račun i sve povezane podatke. Jesi li siguran/a da želiš nastaviti?';
+  String get deleteAccountFinal => 'Ova radnja je nepovratna i trajno će obrisati tvoj račun i sve povezane podatke. Jesi li siguran/a da želiš nastaviti?';
 
   @override
   String get deleteNow => 'Obriši sada';
@@ -377,8 +371,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get goBack => 'Vrati se';
 
   @override
-  String get checkBoxToConfirm =>
-      'Potvrdi polje kako bi potvrdio/a da razumiješ da je brisanje tvog računa trajno i nepovratno.';
+  String get checkBoxToConfirm => 'Potvrdi polje kako bi potvrdio/a da razumiješ da je brisanje tvog računa trajno i nepovratno.';
 
   @override
   String get profile => 'Profil';
@@ -456,8 +449,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get yourPrivacyYourControl => 'Tvoja privatnost, tvoja kontrola';
 
   @override
-  String get privacyIntro =>
-      'U Omi smo posvećeni zaštiti tvoje privatnosti. Ova stranica ti omogućava kontrolu kako se tvoji podaci spremi i koriste.';
+  String get privacyIntro => 'U Omi smo posvećeni zaštiti tvoje privatnosti. Ova stranica ti omogućava kontrolu kako se tvoji podaci spremi i koriste.';
 
   @override
   String get learnMore => 'Saznaj više...';
@@ -466,15 +458,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get dataProtectionLevel => 'Razina zaštite podataka';
 
   @override
-  String get dataProtectionDesc =>
-      'Tvoji podaci su zaštićeni po zadanoj postavci snažnom enkripcijom. Pregled svojih postavki i budućih opcija privatnosti ispod.';
+  String get dataProtectionDesc => 'Tvoji podaci su zaštićeni po zadanoj postavci snažnom enkripcijom. Pregled svojih postavki i budućih opcija privatnosti ispod.';
 
   @override
   String get appAccess => 'Pristup aplikacije';
 
   @override
-  String get appAccessDesc =>
-      'Sljedeće aplikacije mogu pristupiti tvojim podacima. Dodirnite aplikaciju za upravljanje dozvolama.';
+  String get appAccessDesc => 'Sljedeće aplikacije mogu pristupiti tvojim podacima. Dodirnite aplikaciju za upravljanje dozvolama.';
 
   @override
   String get noAppsExternalAccess => 'Nijedna instalirana aplikacija nema vanjski pristup tvojim podacima.';
@@ -531,15 +521,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Tvoj Omi je odspojen 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Uređaj je uklonjen. Idi na Postavke > Bluetooth i zaboravi uređaj kako bi završio uklanjanje.';
+  String get deviceUnpairedMessage => 'Uređaj je uklonjen. Idi na Postavke > Bluetooth i zaboravi uređaj kako bi završio uklanjanje.';
 
   @override
   String get unpairDialogTitle => 'Ukloni uređaj';
 
   @override
-  String get unpairDialogMessage =>
-      'Ovo će ukloniti uređaj kako bi se mogao spajati na drugi telefon. Trebat će ti ići na Postavke > Bluetooth i zaboraviti uređaj kako bi završio proces.';
+  String get unpairDialogMessage => 'Ovo će ukloniti uređaj kako bi se mogao spajati na drugi telefon. Trebat će ti ići na Postavke > Bluetooth i zaboraviti uređaj kako bi završio proces.';
 
   @override
   String get deviceNotConnected => 'Uređaj nije spojen';
@@ -560,8 +548,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get v2Undetected => 'V2 nije detektiran';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vidimo da imaš V1 uređaj ili da tvoj uređaj nije spojen. Funkcionalnost SD kartice dostupna je samo za V2 uređaje.';
+  String get v2UndetectedMessage => 'Vidimo da imaš V1 uređaj ili da tvoj uređaj nije spojen. Funkcionalnost SD kartice dostupna je samo za V2 uređaje.';
 
   @override
   String get endConversation => 'Završi razgovor';
@@ -755,8 +742,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get shareStatsMessage =>
-      'Dijeljenje mojih Omi statistike! (omi.me - tvoj AI asistent koji je uvijek dostupan)';
+  String get shareStatsMessage => 'Dijeljenje mojih Omi statistike! (omi.me - tvoj AI asistent koji je uvijek dostupan)';
 
   @override
   String get sharePeriodToday => 'Danas, omi je:';
@@ -836,8 +822,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Obrisati graf znanja?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Ovo će obrisati sve izvedene podatke grafa znanja (čvorove i veze). Tvoje izvorne uspomene će ostati sigurne. Graf će biti ponovno izgrađen s vremenom ili na sljedeći zahtjev.';
+  String get deleteKnowledgeGraphMessage => 'Ovo će obrisati sve izvedene podatke grafa znanja (čvorove i veze). Tvoje izvorne uspomene će ostati sigurne. Graf će biti ponovno izgrađen s vremenom ili na sljedeći zahtjev.';
 
   @override
   String get knowledgeGraphDeleted => 'Graf znanja je obrisan';
@@ -985,8 +970,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get shortConversationThreshold => 'Prag kratkog razgovora';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Razgovori kraći od toga će biti skriveni osim ako nisu omogućeni gore';
+  String get shortConversationThresholdSubtitle => 'Razgovori kraći od toga će biti skriveni osim ako nisu omogućeni gore';
 
   @override
   String get durationThreshold => 'Prag trajanja';
@@ -1081,8 +1065,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get needYourPermission => 'Trebamo tvoju dozvolu';
 
   @override
-  String get alreadyGavePermission =>
-      'Već si nam dao/dala dozvolu da spremi tvoje snimke. Evo podsjetnika zašto trebamo:';
+  String get alreadyGavePermission => 'Već si nam dao/dala dozvolu da spremi tvoje snimke. Evo podsjetnika zašto trebamo:';
 
   @override
   String get wouldLikePermission => 'Željeli bi tvoju dozvolu da spremi tvoje snimke glasa. Evo zašto:';
@@ -1091,26 +1074,22 @@ class AppLocalizationsHr extends AppLocalizations {
   String get improveSpeechProfile => 'Poboljšaj svoj profil govora';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Koristimo snimke da dodatno treniramo i poboljšamo tvoj osobni profil govora.';
+  String get improveSpeechProfileDesc => 'Koristimo snimke da dodatno treniramo i poboljšamo tvoj osobni profil govora.';
 
   @override
   String get trainFamilyProfiles => 'Treniraj profile za prijatelje i obitelj';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Tvoji snimci nam pomažu da prepoznamo i kreiramo profile za tvoje prijatelje i obitelj.';
+  String get trainFamilyProfilesDesc => 'Tvoji snimci nam pomažu da prepoznamo i kreiramo profile za tvoje prijatelje i obitelj.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Poboljšaj točnost transkripcije';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Kako se naš model poboljšava, možemo pružiti bolje rezultate transkripcije za tvoje snimke.';
+  String get enhanceTranscriptAccuracyDesc => 'Kako se naš model poboljšava, možemo pružiti bolje rezultate transkripcije za tvoje snimke.';
 
   @override
-  String get legalNotice =>
-      'Pravna napomena: Zakonitost snimanja i spremanja podataka o glasu može varirati ovisno o tvojoj lokaciji i kako koristiš ovu funkciju. Tvoja je odgovornost osigurati sukladnost s lokalnim zakonima i propisima.';
+  String get legalNotice => 'Pravna napomena: Zakonitost snimanja i spremanja podataka o glasu može varirati ovisno o tvojoj lokaciji i kako koristiš ovu funkciju. Tvoja je odgovornost osigurati sukladnost s lokalnim zakonima i propisima.';
 
   @override
   String get alreadyAuthorized => 'Već autoriziran/a';
@@ -1182,15 +1161,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showMeetingsMenuBar => 'Prikaži nadolazeće sastanke u traci izbornika';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Prikazuje vaš sljedeći sastanak i vrijeme do njegovog početka u macOS traci izbornika';
+  String get showMeetingsMenuBarDesc => 'Prikazuje vaš sljedeći sastanak i vrijeme do njegovog početka u macOS traci izbornika';
 
   @override
   String get showEventsNoParticipants => 'Prikaži događaje bez sudionika';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Kada je omogućeno, Coming Up prikazuje događaje bez sudionika ili video veze.';
+  String get showEventsNoParticipantsDesc => 'Kada je omogućeno, Coming Up prikazuje događaje bez sudionika ili video veze.';
 
   @override
   String get yourMeetings => 'Vaši Sastanci';
@@ -1358,8 +1335,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get defaultRepository => 'Zadano Spremište';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Odaberite zadano spremište za stvaranje problema. Ipak možete navesti različito spremište pri stvaranju problema.';
+  String get selectDefaultRepoDesc => 'Odaberite zadano spremište za stvaranje problema. Ipak možete navesti različito spremište pri stvaranju problema.';
 
   @override
   String get noReposFound => 'Nema pronađenih spremišta';
@@ -1406,8 +1382,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get configureSettings => 'Konfiguriranje Postavki';
 
   @override
-  String get completeAuthBrowser =>
-      'Molimo dovršite autentifikaciju u svojem pregledniku. Kada završite, vratite se u aplikaciju.';
+  String get completeAuthBrowser => 'Molimo dovršite autentifikaciju u svojem pregledniku. Kada završite, vratite se u aplikaciju.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1735,8 +1710,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get enableBluetooth => 'Omogući Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi trebaju Bluetooth da bi se spojio na tvoj prijenosni uređaj. Molimo omogući Bluetooth i pokušaj ponovno.';
+  String get bluetoothNeeded => 'Omi trebaju Bluetooth da bi se spojio na tvoj prijenosni uređaj. Molimo omogući Bluetooth i pokušaj ponovno.';
 
   @override
   String get contactSupport => 'Kontaktiraj Podršku?';
@@ -1769,26 +1743,22 @@ class AppLocalizationsHr extends AppLocalizations {
   String get locationServiceDisabled => 'Usluga Lokacije Onemogućena';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Usluga Lokacije je Onemogućena. Molimo idi na Postavke > Privatnost i Sigurnost > Usluge Lokacije i omogući je';
+  String get locationServiceDisabledDesc => 'Usluga Lokacije je Onemogućena. Molimo idi na Postavke > Privatnost i Sigurnost > Usluge Lokacije i omogući je';
 
   @override
   String get backgroundLocationDenied => 'Pristup Pozadinkskoj Lokaciji Odbijen';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Molimo idi na postavke uređaja i postavi dozvolu lokacije na \"Uvijek Dozvoli\"';
+  String get backgroundLocationDeniedDesc => 'Molimo idi na postavke uređaja i postavi dozvolu lokacije na \"Uvijek Dozvoli\"';
 
   @override
   String get lovingOmi => 'Sviđa ti se Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Pomozi nam dosegnuti više ljudi ostavljanjem recenzije u App Store. Tvoj povratni podaci su nam veoma važni!';
+  String get leaveReviewIos => 'Pomozi nam dosegnuti više ljudi ostavljanjem recenzije u App Store. Tvoj povratni podaci su nam veoma važni!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Pomozi nam dosegnuti više ljudi ostavljanjem recenzije u Google Play Storeu. Tvoj povratni podaci su nam veoma važni!';
+  String get leaveReviewAndroid => 'Pomozi nam dosegnuti više ljudi ostavljanjem recenzije u Google Play Storeu. Tvoj povratni podaci su nam veoma važni!';
 
   @override
   String get rateOnAppStore => 'Ocijeni na App Store';
@@ -1821,15 +1791,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get connectionError => 'Greška Veze';
 
   @override
-  String get connectionErrorDesc =>
-      'Povezivanje sa poslužiteljem nije uspjelo. Molimo provjeri svoju internetsku vezu i pokušaj ponovno.';
+  String get connectionErrorDesc => 'Povezivanje sa poslužiteljem nije uspjelo. Molimo provjeri svoju internetsku vezu i pokušaj ponovno.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Nevaljana snimka otkrivena';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Čini se da ima više govornika u snimci. Molimo uvjeri se da si na tihem mjestu i pokušaj ponovno.';
+  String get multipleSpeakersDesc => 'Čini se da ima više govornika u snimci. Molimo uvjeri se da si na tihem mjestu i pokušaj ponovno.';
 
   @override
   String get tooShortDesc => 'Nema dovoljno otkrivenog govora. Molimo govori više i pokušaj ponovno.';
@@ -1841,8 +1809,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get areYouThere => 'Jesi li tu?';
 
   @override
-  String get noSpeechDesc =>
-      'Nismo mogli otkriti nikakav govor. Molimo govori najmanje 10 sekundi i ne više od 3 minute.';
+  String get noSpeechDesc => 'Nismo mogli otkriti nikakav govor. Molimo govori najmanje 10 sekundi i ne više od 3 minute.';
 
   @override
   String get connectionLost => 'Veza Izgubljena';
@@ -1863,8 +1830,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get permissionsRequired => 'Dozvole Obavezne';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Ova aplikacija trebanju Bluetooth i Lokacija dozvole da bi ispravno funkcionirala. Molimo omogući ih u postavkama.';
+  String get permissionsRequiredDesc => 'Ova aplikacija trebanju Bluetooth i Lokacija dozvole da bi ispravno funkcionirala. Molimo omogući ih u postavkama.';
 
   @override
   String get openSettings => 'Otvori Postavke';
@@ -1906,12 +1872,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get microphonePermission => 'Dozvola za Mikrofon';
 
   @override
-  String get permissionGrantedNow =>
-      'Dozvola dana! Sada:\n\nOtvori Omi aplikaciju na svojem satu i dodirni \"Nastavi\" ispod';
+  String get permissionGrantedNow => 'Dozvola dana! Sada:\n\nOtvori Omi aplikaciju na svojem satu i dodirni \"Nastavi\" ispod';
 
   @override
-  String get needMicrophonePermission =>
-      'Trebamo dozvolu za mikrofon.\n\n1. Dodirni \"Dozvoli Dozvolu\"\n2. Dozvoli na svojem iPhoneu\n3. Aplikacija sata će se zatvoriti\n4. Ponovno otvori i dodirni \"Nastavi\"';
+  String get needMicrophonePermission => 'Trebamo dozvolu za mikrofon.\n\n1. Dodirni \"Dozvoli Dozvolu\"\n2. Dozvoli na svojem iPhoneu\n3. Aplikacija sata će se zatvoriti\n4. Ponovno otvori i dodirni \"Nastavi\"';
 
   @override
   String get grantPermissionButton => 'Dozvoli Dozvolu';
@@ -1920,15 +1884,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get needHelp => 'Trebam Pomoć?';
 
   @override
-  String get troubleshootingSteps =>
-      'Otklanjanje Problema:\n\n1. Osiguraj da je Omi instaliran na svojem satu\n2. Otvori Omi aplikaciju na svojem satu\n3. Traži popup dozvole\n4. Dodirni \"Dozvoli\" kada se pojavi\n5. Aplikacija na твом satu će se zatvoriti - ponovno je otvori\n6. Vrati se i dodirni \"Nastavi\" na svom iPhoneu';
+  String get troubleshootingSteps => 'Otklanjanje Problema:\n\n1. Osiguraj da je Omi instaliran na svojem satu\n2. Otvori Omi aplikaciju na svojem satu\n3. Traži popup dozvole\n4. Dodirni \"Dozvoli\" kada se pojavi\n5. Aplikacija na твом satu će se zatvoriti - ponovno je otvori\n6. Vrati se i dodirni \"Nastavi\" na svom iPhoneu';
 
   @override
   String get recordingStartedSuccessfully => 'Snimanje je uspješno započeto!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Dozvola još nije data. Molimo uvjeri se da si dopustio pristup mikrofonu i ponovno otvorio aplikaciju na svojem satu.';
+  String get permissionNotGrantedYet => 'Dozvola još nije data. Molimo uvjeri se da si dopustio pristup mikrofonu i ponovno otvorio aplikaciju na svojem satu.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2025,8 +1987,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Spreman/a za Stavke za Akciju';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Tvoj AI će automatski ekstrahirati zadatke i za-napraviti stavke iz tvojih razgovora. Pojavit će se ovdje kada se stvorei.';
+  String get welcomeActionItemsDescription => 'Tvoj AI će automatski ekstrahirati zadatke i za-napraviti stavke iz tvojih razgovora. Pojavit će se ovdje kada se stvorei.';
 
   @override
   String get autoExtractionFeature => 'Automatski ekstrahirano iz razgovora';
@@ -2076,8 +2037,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get clearMemoryTitle => 'Očisti Omijinu Uspomenu';
 
   @override
-  String get clearMemoryMessage =>
-      'Jeste li sigurni da želite očistiti Omijinu uspomenu? Ova akcija se ne može poništiti.';
+  String get clearMemoryMessage => 'Jeste li sigurni da želite očistiti Omijinu uspomenu? Ova akcija se ne može poništiti.';
 
   @override
   String get clearMemoryButton => 'Očisti Uspomenu';
@@ -2223,15 +2183,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'GOVOR I TRANSKRIPCIJA';
 
   @override
-  String get languageSettingsHelperText =>
-      'Jezičke promjene Aplikacije Meniji i gumbi. Jezični Govor utječe na to kako se vaše snimke transkribiraju.';
+  String get languageSettingsHelperText => 'Jezičke promjene Aplikacije Meniji i gumbi. Jezični Govor utječe na to kako se vaše snimke transkribiraju.';
 
   @override
   String get translationNotice => 'Obavijest o Prijevodu';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi prevodi razgovore u tvoj primarni jezik. Ažuriraj ga bilo kada u Postavkama → Profili.';
+  String get translationNoticeMessage => 'Omi prevodi razgovore u tvoj primarni jezik. Ažuriraj ga bilo kada u Postavkama → Profili.';
 
   @override
   String get pleaseCheckInternetConnection => 'Molimo provjeri svoju internetsku vezu i pokušaj ponovno';
@@ -2393,8 +2351,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Ukloni uređaj';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Ovo će ukloniti uređaj kako bi se mogao povezati sa drugim telefonom. Trebate otići na Postavke > Bluetooth i zaboraviti uređaj kako biste završili postupak.';
+  String get unpairDeviceDialogMessage => 'Ovo će ukloniti uređaj kako bi se mogao povezati sa drugim telefonom. Trebate otići na Postavke > Bluetooth i zaboraviti uređaj kako biste završili postupak.';
 
   @override
   String get unpair => 'Ukloni';
@@ -2575,8 +2532,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get youreAllSet => 'Sve je spremno!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Dobrodošao u Omi! Tvoj AI suputnik je spreman da te pomogne sa razgovorima, zadacima i još mnogo toga.';
+  String get welcomeToOmiDescription => 'Dobrodošao u Omi! Tvoj AI suputnik je spreman da te pomogne sa razgovorima, zadacima i još mnogo toga.';
 
   @override
   String get startUsingOmi => 'Počni koristiti Omi';
@@ -2712,8 +2668,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noTasksYet => 'Nema zadataka';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Zadaci iz tvojih razgovora će se pojaviti ovdje.\nKlikni Kreiraj kako bi ručno dodao jedan.';
+  String get tasksFromConversationsWillAppear => 'Zadaci iz tvojih razgovora će se pojaviti ovdje.\nKlikni Kreiraj kako bi ručno dodao jedan.';
 
   @override
   String get monthJan => 'Jan';
@@ -2770,8 +2725,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteActionItem => 'Obriši stavku aktivnosti';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Jeste li sigurni da želite obrisati ovu stavku aktivnosti? Ova radnja se ne može poništiti.';
+  String get deleteActionItemConfirmation => 'Jeste li sigurni da želite obrisati ovu stavku aktivnosti? Ova radnja se ne može poništiti.';
 
   @override
   String get enterActionItemDescription => 'Unesite opis stavke aktivnosti...';
@@ -2846,15 +2800,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get chatPrompt => 'Upit za razgovor';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ti si odličnih aplikacija, tvoj zadatak je odgovori na upite korisnika i učini ga sretnima...';
+  String get chatPromptPlaceholder => 'Ti si odličnih aplikacija, tvoj zadatak je odgovori na upite korisnika i učini ga sretnima...';
 
   @override
   String get conversationPrompt => 'Upit za razgovor';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Ti si odličnih aplikacija, bit će ti dati transkript i sažetak razgovora...';
+  String get conversationPromptPlaceholder => 'Ti si odličnih aplikacija, bit će ti dati transkript i sažetak razgovora...';
 
   @override
   String get notificationScopes => 'Dosezi obavijesti';
@@ -2866,8 +2818,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get makeMyAppPublic => 'Učini moju aplikaciju javnom';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Podnošenjem ove aplikacije, slažem se sa Omi AI Uvjetima korištenja i Politikom privatnosti';
+  String get submitAppTermsAgreement => 'Podnošenjem ove aplikacije, slažem se sa Omi AI Uvjetima korištenja i Politikom privatnosti';
 
   @override
   String get submitApp => 'Podnesi aplikaciju';
@@ -2882,12 +2833,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get submitAppQuestion => 'Podnesti aplikaciju?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Vaša aplikacija će biti pregledana i učinjena javnom. Možete je početi koristiti odmah, čak i tijekom pregleda!';
+  String get submitAppPublicDescription => 'Vaša aplikacija će biti pregledana i učinjena javnom. Možete je početi koristiti odmah, čak i tijekom pregleda!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Vaša aplikacija će biti pregledana i učinjena dostupnom vam privatno. Možete je početi koristiti odmah, čak i tijekom pregleda!';
+  String get submitAppPrivateDescription => 'Vaša aplikacija će biti pregledana i učinjena dostupnom vam privatno. Možete je početi koristiti odmah, čak i tijekom pregleda!';
 
   @override
   String get startEarning => 'Počni zaraditi! 💰';
@@ -2911,23 +2860,19 @@ class AppLocalizationsHr extends AppLocalizations {
   String get dataAccessNotice => 'Obavijest o pristupu podacima';
 
   @override
-  String get dataAccessWarning =>
-      'Ova aplikacija će pristupiti tvojim podacima. Omi AI nije odgovorna za način na koji se tvoji podaci koriste, mijenjaju ili brišu od strane ove aplikacije';
+  String get dataAccessWarning => 'Ova aplikacija će pristupiti tvojim podacima. Omi AI nije odgovorna za način na koji se tvoji podaci koriste, mijenjaju ili brišu od strane ove aplikacije';
 
   @override
   String get installApp => 'Instaliraj aplikaciju';
 
   @override
-  String get betaTesterNotice =>
-      'Vi ste beta tester za ovu aplikaciju. Još nije javna. Bit će javna nakon što bude odobrena.';
+  String get betaTesterNotice => 'Vi ste beta tester za ovu aplikaciju. Još nije javna. Bit će javna nakon što bude odobrena.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Vaša aplikacija je na pregledu i vidljiva samo vama. Bit će javna nakon što bude odobrena.';
+  String get appUnderReviewOwner => 'Vaša aplikacija je na pregledu i vidljiva samo vama. Bit će javna nakon što bude odobrena.';
 
   @override
-  String get appRejectedNotice =>
-      'Vaša aplikacija je odbijena. Molimo ažurirajte detalje aplikacije i ponovno podnesi za pregled.';
+  String get appRejectedNotice => 'Vaša aplikacija je odbijena. Molimo ažurirajte detalje aplikacije i ponovno podnesi za pregled.';
 
   @override
   String get setupSteps => 'Koraci postavljanja';
@@ -2962,8 +2907,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get errorActivatingApp => 'Greška pri aktivaciji aplikacije';
 
   @override
-  String get integrationSetupRequired =>
-      'Ako je ovo aplikacija za integraciju, provjerite da je postavljanje dovršeno.';
+  String get integrationSetupRequired => 'Ako je ovo aplikacija za integraciju, provjerite da je postavljanje dovršeno.';
 
   @override
   String get installed => 'Instalirano';
@@ -2990,8 +2934,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get descriptionLabel => 'Opis';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Moja odličnih aplikacija je odličnih aplikacija koja radi zadivljujuće stvari. To je najbolja aplikacija ikada!';
+  String get appDescriptionPlaceholder => 'Moja odličnih aplikacija je odličnih aplikacija koja radi zadivljujuće stvari. To je najbolja aplikacija ikada!';
 
   @override
   String get pleaseProvideValidDescription => 'Molimo navedite validan opis';
@@ -3143,8 +3086,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get microphonePermissionRequired => 'Dozvola za mikrofon je potrebna za pozive';
 
   @override
-  String get microphonePermissionDenied =>
-      'Dozvola za mikrofon odbijena. Molimo dodjeli dozvolu u Postavke sustava > Privatnost i sigurnost > Mikrofon.';
+  String get microphonePermissionDenied => 'Dozvola za mikrofon odbijena. Molimo dodjeli dozvolu u Postavke sustava > Privatnost i sigurnost > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3303,8 +3245,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get createMemory => 'Kreiraj uspomenu';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Jeste li sigurni da želite obrisati ovu uspomenu? Ova radnja se ne može poništiti.';
+  String get deleteMemoryConfirmation => 'Jeste li sigurni da želite obrisati ovu uspomenu? Ova radnja se ne može poništiti.';
 
   @override
   String get makePrivate => 'Učini privatnom';
@@ -3378,8 +3319,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get whatWeCollect => 'Što prikupljamo';
 
   @override
-  String get dataCollectionMessage =>
-      'Nastavljanjem će vaši razgovori, snimke i osobni podaci biti sigurno pohranjeni na našim poslužiteljima kako bi vam pružili AI-pogonske uvide i omogućili sve značajke aplikacije.';
+  String get dataCollectionMessage => 'Nastavljanjem će vaši razgovori, snimke i osobni podaci biti sigurno pohranjeni na našim poslužiteljima kako bi vam pružili AI-pogonske uvide i omogućili sve značajke aplikacije.';
 
   @override
   String get dataProtection => 'Zaštita podataka';
@@ -3412,8 +3352,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Ime mora biti najmanje 2 znaka';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Recite nam kako biste voljeli biti obraćeni. To pomaže personalizirati vaše Omi iskustvo.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Recite nam kako biste voljeli biti obraćeni. To pomaže personalizirati vaše Omi iskustvo.';
 
   @override
   String charactersCount(int count) {
@@ -3430,8 +3369,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get recordAudioConversations => 'Snimanje audio razgovora';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi trebam pristup mikrofonu kako bi snimio vaše razgovore i dao transkripcije.';
+  String get microphoneAccessDescription => 'Omi trebam pristup mikrofonu kako bi snimio vaše razgovore i dao transkripcije.';
 
   @override
   String get screenRecording => 'Snimanje zaslona';
@@ -3440,8 +3378,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Hvatanje sistemskog zvuka s sastanaka';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi trebam dozvolu za snimanje zaslona kako bi hvatao sistemski zvuk s vaših mrežnih sastanaka.';
+  String get screenRecordingDescription => 'Omi trebam dozvolu za snimanje zaslona kako bi hvatao sistemski zvuk s vaših mrežnih sastanaka.';
 
   @override
   String get accessibility => 'Pristupačnost';
@@ -3450,8 +3387,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Otkrivanje mrežnih sastanaka';
 
   @override
-  String get accessibilityDescription =>
-      'Omi trebam dozvolu za pristupačnost kako bi otkrio kada se pridružite Zoom, Meet ili Teams sastancima u vašem pregledniku.';
+  String get accessibilityDescription => 'Omi trebam dozvolu za pristupačnost kako bi otkrio kada se pridružite Zoom, Meet ili Teams sastancima u vašem pregledniku.';
 
   @override
   String get pleaseWait => 'Molimo pričekajte...';
@@ -3520,12 +3456,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get exportAllConversationsToJson => 'Izvezite sve svoje razgovore u JSON datoteku.';
 
   @override
-  String get conversationsExportStarted =>
-      'Izvoz razgovora započet. To može potrajati nekoliko sekundi, molimo pričekajte.';
+  String get conversationsExportStarted => 'Izvoz razgovora započet. To može potrajati nekoliko sekundi, molimo pričekajte.';
 
   @override
-  String get mcpDescription =>
-      'Za povezivanje Omi-ja s drugim aplikacijama kako bi čitao, pretraživao i upravljao vašim uspomenama i razgovorima. Kreirajte ključ kako bi započeli.';
+  String get mcpDescription => 'Za povezivanje Omi-ja s drugim aplikacijama kako bi čitao, pretraživao i upravljao vašim uspomenama i razgovorima. Kreirajte ključ kako bi započeli.';
 
   @override
   String get apiKeys => 'API ključevi';
@@ -3596,8 +3530,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get auto => 'Automatski';
 
   @override
-  String get noSummaryForApp =>
-      'Nema dostupnog sažetka za ovu aplikaciju. Pokušajte s drugom aplikacijom za bolje rezultate.';
+  String get noSummaryForApp => 'Nema dostupnog sažetka za ovu aplikaciju. Pokušajte s drugom aplikacijom za bolje rezultate.';
 
   @override
   String get tryAnotherApp => 'Pokušaj drugu aplikaciju';
@@ -3634,8 +3567,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Neka Omi automatski odabere najbolju aplikaciju';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Ste li sigurni da želite izbrisati ovaj razgovor? Ova radnja se ne može poništiti.';
+  String get deleteConversationConfirmation => 'Ste li sigurni da želite izbrisati ovaj razgovor? Ova radnja se ne može poništiti.';
 
   @override
   String get conversationDeleted => 'Razgovor izbrisan';
@@ -3683,8 +3615,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Priprema hvatanja sistemskog zvuka';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Kliknite gumb kako bi hvatali zvuk za užive transkripcije, AI uvide i automatsko spremanje.';
+  String get clickTheButtonToCaptureAudio => 'Kliknite gumb kako bi hvatali zvuk za užive transkripcije, AI uvide i automatsko spremanje.';
 
   @override
   String get reconnecting => 'Ponovno povezivanje...';
@@ -3842,8 +3773,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get dailySummaryTitle => 'Dnevni sažetak';
 
   @override
-  String get dailySummaryDescription =>
-      'Dobijte personalizirani sažetak razgovora vašeg dana dostavljen kao obavijest.';
+  String get dailySummaryDescription => 'Dobijte personalizirani sažetak razgovora vašeg dana dostavljen kao obavijest.';
 
   @override
   String get deliveryTime => 'Vrijeme dostave';
@@ -3888,8 +3818,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get shortcuts => 'Prečaci';
 
   @override
-  String get shortcutChangeInstruction =>
-      'Kliknite na prečac kako bi ga promijenili. Pritisnite Escape kako bi odustali.';
+  String get shortcutChangeInstruction => 'Kliknite na prečac kako bi ga promijenili. Pritisnite Escape kako bi odustali.';
 
   @override
   String get configureSTTProvider => 'Konfigurirajte STT davatelja';
@@ -3913,8 +3842,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Obriši graf znanja?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Ovo će obrisati sve izvedene podatke grafa znanja. Vaše izvorne uspomene ostaju sigurne.';
+  String get deleteKnowledgeGraphWarning => 'Ovo će obrisati sve izvedene podatke grafa znanja. Vaše izvorne uspomene ostaju sigurne.';
 
   @override
   String get connectOmiWithAI => 'Povežite Omi-ja s AI asistentima';
@@ -3971,8 +3899,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get updateAppQuestion => 'Ažurirati aplikaciju?';
 
   @override
-  String get updateAppConfirmation =>
-      'Ste li sigurni da želite ažurirati vašu aplikaciju? Promjene će se odraziti kada bude pregledana od strane našeg tima.';
+  String get updateAppConfirmation => 'Ste li sigurni da želite ažurirati vašu aplikaciju? Promjene će se odraziti kada bude pregledana od strane našeg tima.';
 
   @override
   String get updateApp => 'Ažurira aplikaciju';
@@ -4002,8 +3929,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get no => 'Ne';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Pretplata uspješno otkazana. Ostaje aktivna do kraja trenutnog razdoblja naplate.';
+  String get subscriptionCancelledSuccessfully => 'Pretplata uspješno otkazana. Ostaje aktivna do kraja trenutnog razdoblja naplate.';
 
   @override
   String get failedToCancelSubscription => 'Neuspješno otkazivanje pretplate. Molimo pokušajte ponovno.';
@@ -4039,8 +3965,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Otkazati pretplatu?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Ste li sigurni da želite otkazati vašu pretplatu? Nastavit ćete imati pristup do kraja vašeg trenutnog razdoblja naplate.';
+  String get cancelSubscriptionConfirmation => 'Ste li sigurni da želite otkazati vašu pretplatu? Nastavit ćete imati pristup do kraja vašeg trenutnog razdoblja naplate.';
 
   @override
   String get cancelSubscriptionButton => 'Otkaži pretplatu';
@@ -4049,16 +3974,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get cancelling => 'Otkazivanje...';
 
   @override
-  String get betaTesterMessage =>
-      'Ste beta tester za ovu aplikaciju. Nije još javna. Bit će javna nakon što bude odobrena.';
+  String get betaTesterMessage => 'Ste beta tester za ovu aplikaciju. Nije još javna. Bit će javna nakon što bude odobrena.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Vaša aplikacija je na pregledu i vidljiva je samo vama. Bit će javna nakon što bude odobrena.';
+  String get appUnderReviewMessage => 'Vaša aplikacija je na pregledu i vidljiva je samo vama. Bit će javna nakon što bude odobrena.';
 
   @override
-  String get appRejectedMessage =>
-      'Vaša aplikacija je odbijena. Molimo ažurirajte detalje aplikacije i ponovno pošaljite na pregled.';
+  String get appRejectedMessage => 'Vaša aplikacija je odbijena. Molimo ažurirajte detalje aplikacije i ponovno pošaljite na pregled.';
 
   @override
   String get invalidIntegrationUrl => 'Nevaljani URL integracije';
@@ -4112,8 +4034,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get issueActivatingApp => 'Došlo je do problema pri aktiviranju ove aplikacije. Molimo pokušajte ponovno.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Ova aplikacija će pristupiti vašim podacima. Omi AI nije odgovorna za kako se vaši podaci koriste, mijenjaju ili brišu od strane ove aplikacije';
+  String get dataAccessNoticeDescription => 'Ova aplikacija će pristupiti vašim podacima. Omi AI nije odgovorna za kako se vaši podaci koriste, mijenjaju ili brišu od strane ove aplikacije';
 
   @override
   String get copyUrl => 'Kopira URL';
@@ -4201,8 +4122,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get omiApiKeys => 'Omi API ključevi';
 
   @override
-  String get apiKeysDescription =>
-      'API ključevi se koriste za autentifikaciju kada vaša aplikacija komunicira s OMI poslužiteljem. Omogućavaju vašoj aplikaciji da sigurno kreira uspomene i pristupa drugim OMI uslugama.';
+  String get apiKeysDescription => 'API ključevi se koriste za autentifikaciju kada vaša aplikacija komunicira s OMI poslužiteljem. Omogućavaju vašoj aplikaciji da sigurno kreira uspomene i pristupa drugim OMI uslugama.';
 
   @override
   String get aboutOmiApiKeys => 'O Omi API ključevima';
@@ -4226,8 +4146,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Opozovi API ključ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Ova radnja se ne može poništiti. Bilo koje aplikacije koje koriste ovaj ključ više neće moći pristupiti API-ju.';
+  String get revokeApiKeyWarning => 'Ova radnja se ne može poništiti. Bilo koje aplikacije koje koriste ovaj ključ više neće moći pristupiti API-ju.';
 
   @override
   String get revoke => 'Opozovi';
@@ -4325,8 +4244,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get externalAppAccess => 'Pristup vanjskoj aplikaciji';
 
   @override
-  String get externalAppAccessDescription =>
-      'Sljedeće instalirane aplikacije imaju eksterne integracije i mogu pristupiti vašim podacima, kao što su razgovori i uspomene.';
+  String get externalAppAccessDescription => 'Sljedeće instalirane aplikacije imaju eksterne integracije i mogu pristupiti vašim podacima, kao što su razgovori i uspomene.';
 
   @override
   String get noExternalAppsHaveAccess => 'Nema vanjskih aplikacija koje imaju pristup vašim podacima.';
@@ -4335,8 +4253,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimalna sigurnost (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Šifriranje od kraja do kraja je zlatni standard za privatnost. Kada je omogućeno, vaši podaci se šifriraju na vašem uređaju prije nego što se pošalju našim poslužiteljima. To znači da nitko, čak ni Omi, ne može pristupiti vašem sadržaju.';
+  String get e2eeDescription => 'Šifriranje od kraja do kraja je zlatni standard za privatnost. Kada je omogućeno, vaši podaci se šifriraju na vašem uređaju prije nego što se pošalju našim poslužiteljima. To znači da nitko, čak ni Omi, ne može pristupiti vašem sadržaju.';
 
   @override
   String get importantTradeoffs => 'Važni kompromisi:';
@@ -4351,8 +4268,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get featureComingSoon => 'Ova značajka uskoro stiže!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migracija je u tijeku. Ne možete promijeniti razinu zaštite dok se ne završi.';
+  String get migrationInProgressMessage => 'Migracija je u tijeku. Ne možete promijeniti razinu zaštite dok se ne završi.';
 
   @override
   String get migrationFailed => 'Migracija neuspješna';
@@ -4371,19 +4287,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get secureEncryption => 'Sigurna šifriranje';
 
   @override
-  String get secureEncryptionDescription =>
-      'Vaši podaci se šifriraju s ključem jedinstvenim za vas na našim poslužiteljima, hostiranim na Google Cloud-u. To znači da je vaš sadržaj u neobrađenom obliku nedostupan svima, uključujući Omi osoblje ili Google, izravno iz baze podataka.';
+  String get secureEncryptionDescription => 'Vaši podaci se šifriraju s ključem jedinstvenim za vas na našim poslužiteljima, hostiranim na Google Cloud-u. To znači da je vaš sadržaj u neobrađenom obliku nedostupan svima, uključujući Omi osoblje ili Google, izravno iz baze podataka.';
 
   @override
   String get endToEndEncryption => 'Šifriranje od kraja do kraja';
 
   @override
-  String get e2eeCardDescription =>
-      'Omogućite za maksimalnu sigurnost gdje samo vi možete pristupiti svojim podacima. Dodirnite kako bi saznali više.';
+  String get e2eeCardDescription => 'Omogućite za maksimalnu sigurnost gdje samo vi možete pristupiti svojim podacima. Dodirnite kako bi saznali više.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Bez obzira na razinu, vaši podaci su uvijek šifrirani tijekom mirovanju i putovanja.';
+  String get dataAlwaysEncrypted => 'Bez obzira na razinu, vaši podaci su uvijek šifrirani tijekom mirovanju i putovanja.';
 
   @override
   String get readOnlyScope => 'Samo čitanje';
@@ -4428,8 +4341,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get permissionsLabel => 'DOZVOLE';
 
   @override
-  String get permissionsInfoNote =>
-      'R = Čitanje, W = Pisanje. Zadana vrijednost je samo čitanje ako ništa nije odabrano.';
+  String get permissionsInfoNote => 'R = Čitanje, W = Pisanje. Zadana vrijednost je samo čitanje ako ništa nije odabrano.';
 
   @override
   String get developerApi => 'API za razvojne programere';
@@ -4452,8 +4364,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Dobijte Omi Unlimited besplatno doprinoseći svoje podatke za obuku AI modela.';
 
   @override
-  String get trainingDataBullets =>
-      '• Vaši podaci pomažu poboljšati AI modele\n• Samo neosjetan podaci se dijele\n• Potpuno transparentan proces';
+  String get trainingDataBullets => '• Vaši podaci pomažu poboljšati AI modele\n• Samo neosjetan podaci se dijele\n• Potpuno transparentan proces';
 
   @override
   String get learnMoreAtOmiTraining => 'Saznajte više na omi.me/training';
@@ -4465,8 +4376,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get submitRequest => 'Pošalji zahtjev';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Hvala vam! Vaš zahtjev je na pregledu. Obavijestit ćemo vas nakon što bude odobren.';
+  String get thankYouRequestUnderReview => 'Hvala vam! Vaš zahtjev je na pregledu. Obavijestit ćemo vas nakon što bude odobren.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4504,15 +4414,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get monthlyPlanContinues => 'Vaš trenutni mjesečni plan će nastaviti do kraja vašeg razdoblja naplate';
 
   @override
-  String get paymentMethodCharged =>
-      'Vašoj postojećoj metodi plaćanja će biti automatski naplaćena kada se mjesečni plan završi';
+  String get paymentMethodCharged => 'Vašoj postojećoj metodi plaćanja će biti automatski naplaćena kada se mjesečni plan završi';
 
   @override
   String get annualSubscriptionStarts => 'Vaša 12-mjesečna godišnja pretplata će se automatski pokrenuti nakon naplate';
 
   @override
-  String get thirteenMonthsCoverage =>
-      'Dobit ćete ukupno 13 mjeseci pokrivanja (trenutni mjesec + 12 mjeseci godišnje)';
+  String get thirteenMonthsCoverage => 'Dobit ćete ukupno 13 mjeseci pokrivanja (trenutni mjesec + 12 mjeseci godišnje)';
 
   @override
   String get confirmUpgrade => 'Potvrdi nadogradnju';
@@ -4549,8 +4457,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Vaš godišnji plan će se automatski pokrenuti kada se mjesečni plan završi.';
+  String get annualPlanStartsAutomatically => 'Vaš godišnji plan će se automatski pokrenuti kada se mjesečni plan završi.';
 
   @override
   String planRenewsOn(String date) {
@@ -4617,8 +4524,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Vaša privatnost je nama važna';
 
   @override
-  String get privacyIntroText =>
-      'U Omiju shvaćamo vašu privatnost vrlo ozbiljno. Želimo biti transparentni o podacima koje prikupljamo i kako ih koristimo kako bismo poboljšali naš proizvod za vas. Evo što trebate znati:';
+  String get privacyIntroText => 'U Omiju shvaćamo vašu privatnost vrlo ozbiljno. Želimo biti transparentni o podacima koje prikupljamo i kako ih koristimo kako bismo poboljšali naš proizvod za vas. Evo što trebate znati:';
 
   @override
   String get whatWeTrack => 'Što pratimo';
@@ -4633,12 +4539,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get ourCommitment => 'Naš pristup';
 
   @override
-  String get commitmentText =>
-      'Posvećeni smo korištenju podataka koje prikupljamo samo da bi Omi bio bolji proizvod za vas. Vaša privatnost i povjerenje su nam najvažniji.';
+  String get commitmentText => 'Posvećeni smo korištenju podataka koje prikupljamo samo da bi Omi bio bolji proizvod za vas. Vaša privatnost i povjerenje su nam najvažniji.';
 
   @override
-  String get thankYouText =>
-      'Hvala vam što ste vrijedni korisnik Omija. Ako imate bilo koja pitanja ili zabrinute, slobodno nam napišite na team@basedhardware.com.';
+  String get thankYouText => 'Hvala vam što ste vrijedni korisnik Omija. Ako imate bilo koja pitanja ili zabrinute, slobodno nam napišite na team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Postavke WiFi sinhronizacije';
@@ -4647,8 +4551,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get enterHotspotCredentials => 'Unesite vjerodajnice osobnog pristupnog mjesta vašeg telefona';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi sinhronizacija koristi vaš telefon kao osobno pristupno mjesto. Pronađite naziv i lozinku osobnog pristupnog mjesta u Postavkama > Osobno pristupno mjesto.';
+  String get wifiSyncUsesHotspot => 'WiFi sinhronizacija koristi vaš telefon kao osobno pristupno mjesto. Pronađite naziv i lozinku osobnog pristupnog mjesta u Postavkama > Osobno pristupno mjesto.';
 
   @override
   String get hotspotNameSsid => 'Naziv osobnog pristupnog mjesta (SSID)';
@@ -4683,8 +4586,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nije moguće generirati sažetak. Provjerite da li imate razgovore za taj dan.';
+  String get failedToGenerateSummaryCheckConversations => 'Nije moguće generirati sažetak. Provjerite da li imate razgovore za taj dan.';
 
   @override
   String get summaryNotFound => 'Sažetak nije pronađen';
@@ -4714,8 +4616,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Izvoz je počeo. To može potrajati nekoliko sekundi...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ovo će izbrisati sve izvedene podatke grafa znanja (čvorove i veze). Vaša originalna sjećanja će ostati sigurna. Graf će se ponovno izgraditi tijekom vremena ili na sljedeći zahtjev.';
+  String get knowledgeGraphDeleteDescription => 'Ovo će izbrisati sve izvedene podatke grafa znanja (čvorove i veze). Vaša originalna sjećanja će ostati sigurna. Graf će se ponovno izgraditi tijekom vremena ili na sljedeći zahtjev.';
 
   @override
   String get configureDailySummaryDigest => 'Konfigurira svoj dnevni sažetak stavki za izvršenje';
@@ -4785,8 +4686,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Obrisati sve Limitless razgovore?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Ovo će trajno izbrisati sve razgovore uvezene iz Limitlessa. Ova radnja se ne može poništiti.';
+  String get deleteAllLimitlessWarning => 'Ovo će trajno izbrisati sve razgovore uvezene iz Limitlessa. Ova radnja se ne može poništiti.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4842,8 +4742,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get howItWorksTitle => 'Kako funkcionira?';
 
   @override
-  String get howPeopleWorks =>
-      'Kada se osoba kreira, možete otići na transkripciju razgovora i dodijeliti joj odgovarajuće segmente, na taj način će Omi moći prepoznati i njezin govor!';
+  String get howPeopleWorks => 'Kada se osoba kreira, možete otići na transkripciju razgovora i dodijeliti joj odgovarajuće segmente, na taj način će Omi moći prepoznati i njezin govor!';
 
   @override
   String get tapToDelete => 'Dodirnite za brisanje';
@@ -4869,8 +4768,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get privacyNotice => 'Obavijest o privatnosti';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Snimanja mogu hvatiti glasove drugih. Provjerite da li imate pristanak svih sudionika prije omogućavanja.';
+  String get recordingsMayCaptureOthers => 'Snimanja mogu hvatiti glasove drugih. Provjerite da li imate pristanak svih sudionika prije omogućavanja.';
 
   @override
   String get enable => 'Omogući';
@@ -4882,8 +4780,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get on => 'Uključeno';
 
   @override
-  String get storeAudioDescription =>
-      'Čuvajte sve audio snimke pohranjene lokalno na vašem telefonu. Kada je onemogućeno, samo neuspješna učitavanja se čuvaju kako bi se uštedjelo prostora za pohranu.';
+  String get storeAudioDescription => 'Čuvajte sve audio snimke pohranjene lokalno na vašem telefonu. Kada je onemogućeno, samo neuspješna učitavanja se čuvaju kako bi se uštedjelo prostora za pohranu.';
 
   @override
   String get enableLocalStorage => 'Omogući lokalno pohranjivanje';
@@ -4901,12 +4798,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get storeAudioOnCloud => 'Pohrani audio u oblak';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Vaša snimanja u realnom vremenu će biti pohranjena u privatnu pohranu u oblaku dok govorite.';
+  String get cloudStorageDialogMessage => 'Vaša snimanja u realnom vremenu će biti pohranjena u privatnu pohranu u oblaku dok govorite.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Pohranjujte snimanja u realnom vremenu u privatnu pohranu u oblaku dok govorite. Audio se hvaća i sigurno pohranjuje u realnom vremenu.';
+  String get storeAudioCloudDescription => 'Pohranjujte snimanja u realnom vremenu u privatnu pohranu u oblaku dok govorite. Audio se hvaća i sigurno pohranjuje u realnom vremenu.';
 
   @override
   String get downloadingFirmware => 'Preuzimanje firmvera';
@@ -4915,8 +4810,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get installingFirmware => 'Instalacija firmvera';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Nemojte zatvarati aplikaciju ili isključivati uređaj. Ovo bi moglo oštetiti vaš uređaj.';
+  String get firmwareUpdateWarning => 'Nemojte zatvarati aplikaciju ili isključivati uređaj. Ovo bi moglo oštetiti vaš uređaj.';
 
   @override
   String get firmwareUpdated => 'Firmver je ažuriran';
@@ -4960,8 +4854,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get payments => 'Plaćanja';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Povežite metodu plaćanja dolje kako biste počeli primati isplate za vaše aplikacije.';
+  String get connectPaymentMethodInfo => 'Povežite metodu plaćanja dolje kako biste počeli primati isplate za vaše aplikacije.';
 
   @override
   String get selectedPaymentMethod => 'Odabrana metoda plaćanja';
@@ -4988,8 +4881,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get monthlyPayouts => 'Mjesečne isplate';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Primajte mjesečna plaćanja izravno na svoj račun kada dostignete \$10 u zarađenoj';
+  String get monthlyPayoutsDescription => 'Primajte mjesečna plaćanja izravno na svoj račun kada dostignete \$10 u zarađenoj';
 
   @override
   String get secureAndReliable => 'Sigurno i pouzdano';
@@ -5016,8 +4908,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get connectingYourStripeAccount => 'Povezivanje vašeg Stripe računa';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Molimo dovršite Stripe onboarding proces u vašem pregledniku. Ova se stranica automatski ažurira nakon što završite.';
+  String get stripeOnboardingInstructions => 'Molimo dovršite Stripe onboarding proces u vašem pregledniku. Ova se stranica automatski ažurira nakon što završite.';
 
   @override
   String get failedTryAgain => 'Neuspješno? Pokušajte ponovno';
@@ -5029,8 +4920,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get successfullyConnected => 'Uspješno povezano!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Vaš Stripe račun je sada spreman za primanje plaćanja. Možete odmah početi zarađivati od prodaje svoje aplikacije.';
+  String get stripeReadyForPayments => 'Vaš Stripe račun je sada spreman za primanje plaćanja. Možete odmah početi zarađivati od prodaje svoje aplikacije.';
 
   @override
   String get updateStripeDetails => 'Ažuriraj Stripe detalje';
@@ -5048,8 +4938,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Ažurirajte detalje vašeg PayPal računa';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Povežite svoj PayPal račun kako biste počeli primati plaćanja za vaše aplikacije';
+  String get connectPayPalToReceivePayments => 'Povežite svoj PayPal račun kako biste počeli primati plaćanja za vaše aplikacije';
 
   @override
   String get paypalEmail => 'PayPal email';
@@ -5058,8 +4947,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me veza';
 
   @override
-  String get stripeRecommendation =>
-      'Ako je Stripe dostupan u vašoj zemlji, preporučujemo vam da ga koristite za brže i lakše isplate.';
+  String get stripeRecommendation => 'Ako je Stripe dostupan u vašoj zemlji, preporučujemo vam da ga koristite za brže i lakše isplate.';
 
   @override
   String get updatePayPalDetails => 'Ažuriraj PayPal detalje';
@@ -5111,12 +4999,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Dodatni uzorak govora je uklonjen';
 
   @override
-  String get consentDataMessage =>
-      'Nastavljanjem, vaši razgovori, snimke i osobni podaci bit će sigurno pohranjeni na našim poslužiteljima. Vaši audio zapisi i transkripti obrađuju se od strane AI usluga trećih strana (uključujući Deepgram za transkripciju i OpenAI za analizu) kako bi vam pružili uvide pokretane umjetnom inteligencijom i omogućili sve značajke aplikacije.';
+  String get consentDataMessage => 'Nastavljanjem, vaši razgovori, snimke i osobni podaci bit će sigurno pohranjeni na našim poslužiteljima. Vaši audio zapisi i transkripti obrađuju se od strane AI usluga trećih strana (uključujući Deepgram za transkripciju i OpenAI za analizu) kako bi vam pružili uvide pokretane umjetnom inteligencijom i omogućili sve značajke aplikacije.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Zadaci iz vaših razgovora će se pojavljati ovdje.\\nDodirnite + da biste ručno kreirali jedan.';
+  String get tasksEmptyStateMessage => 'Zadaci iz vaših razgovora će se pojavljati ovdje.\\nDodirnite + da biste ručno kreirali jedan.';
 
   @override
   String get clearChatAction => 'Očisti razgovor';
@@ -5152,15 +5038,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Instalirajte Omi na vaš\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Kako biste koristili Apple Watch sa Omijem, morate prvo instalirati Omi aplikaciju na vaš sat.';
+  String get installOmiOnAppleWatchDescription => 'Kako biste koristili Apple Watch sa Omijem, morate prvo instalirati Omi aplikaciju na vaš sat.';
 
   @override
   String get openOmiOnAppleWatch => 'Otvorite Omi na vaš\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi aplikacija je instalirana na vaš Apple Watch. Otvorite je i dodirnite Start kako biste počeli.';
+  String get openOmiOnAppleWatchDescription => 'Omi aplikacija je instalirana na vaš Apple Watch. Otvorite je i dodirnite Start kako biste počeli.';
 
   @override
   String get openWatchApp => 'Otvori Watch aplikaciju';
@@ -5169,15 +5053,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Instalirao/la sam i otvorio/la aplikaciju';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Nije moguće otvoriti Apple Watch aplikaciju. Molimo ručno otvorite Watch aplikaciju na vašem Apple Watchu i instalirajte Omi iz \"Available Apps\" sekcije.';
+  String get unableToOpenWatchApp => 'Nije moguće otvoriti Apple Watch aplikaciju. Molimo ručno otvorite Watch aplikaciju na vašem Apple Watchu i instalirajte Omi iz \"Available Apps\" sekcije.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch je uspješno povezan!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch još nije dostižan. Provjerite da li je Omi aplikacija otvorena na vašem satnom.';
+  String get appleWatchNotReachable => 'Apple Watch još nije dostižan. Provjerite da li je Omi aplikacija otvorena na vašem satnom.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5605,8 +5487,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get multipleSpeakersDetected => 'Detektirano više govornika';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Čini se da u snimanju ima više govornika. Provjerite da li ste na tihoj lokaciji i pokušajte ponovno.';
+  String get multipleSpeakersDescription => 'Čini se da u snimanju ima više govornika. Provjerite da li ste na tihoj lokaciji i pokušajte ponovno.';
 
   @override
   String get invalidRecordingDetected => 'Detektirano nije valjano snimanje';
@@ -5618,15 +5499,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get speechDurationDescription => 'Molimo osigurajte da govorite najmanje 5 sekundi i ne više od 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Veza je prekinuta. Molimo provjerite vašu internetsku vezu i pokušajte ponovno.';
+  String get connectionLostDescription => 'Veza je prekinuta. Molimo provjerite vašu internetsku vezu i pokušajte ponovno.';
 
   @override
   String get howToTakeGoodSample => 'Kako snimiti dobar primjer?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Osigurajte da ste na tiskom mjestu.\n2. Govorite jasno i prirodno.\n3. Osigurajte da je vaš uređaj u prirodnoj poziciji, na vašoj vratu.\n\nKad je kreiran, uvijek ga možete poboljšati ili ponoviti.';
+  String get goodSampleInstructions => '1. Osigurajte da ste na tiskom mjestu.\n2. Govorite jasno i prirodno.\n3. Osigurajte da je vaš uređaj u prirodnoj poziciji, na vašoj vratu.\n\nKad je kreiran, uvijek ga možete poboljšati ili ponoviti.';
 
   @override
   String get noDeviceConnectedUseMic => 'Nema povezanog uređaja. Koristit će se mikrofon telefona.';
@@ -5689,12 +5568,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get howItWorks => 'Kako funkcionira';
 
   @override
-  String get dailyScoreExplanation =>
-      'Vaš dnevni rezultat temelji se na završetku zadataka. Završite svoje zadatke da poboljšate svoj rezultat!';
+  String get dailyScoreExplanation => 'Vaš dnevni rezultat temelji se na završetku zadataka. Završite svoje zadatke da poboljšate svoj rezultat!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontrolirajte kako često vam Omi šalje proaktivne obavijesti i podsjetnika.';
+  String get notificationFrequencyDescription => 'Kontrolirajte kako često vam Omi šalje proaktivne obavijesti i podsjetnika.';
 
   @override
   String get sliderOff => 'Isključeno';
@@ -5787,8 +5664,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get selectApp => 'Odaberite aplikaciju';
 
   @override
-  String get noChatAppsEnabled =>
-      'Nema omogućenih aplikacija za razgovor.\nTapnite \"Omogući aplikacije\" da dodate neke.';
+  String get noChatAppsEnabled => 'Nema omogućenih aplikacija za razgovor.\nTapnite \"Omogući aplikacije\" da dodate neke.';
 
   @override
   String get disable => 'Onemogući';
@@ -5940,8 +5816,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get recordings => 'Snimke';
 
   @override
-  String get enableRemindersAccess =>
-      'Molimo omogućite pristup podsjetnicima u postavkama da koristite Apple podsjetnika';
+  String get enableRemindersAccess => 'Molimo omogućite pristup podsjetnicima u postavkama da koristite Apple podsjetnika';
 
   @override
   String todayAtTime(String time) {
@@ -6070,8 +5945,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get cloudProvider => 'Pružatelj usluga u oblaku';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 premium minuta/mjesec. Kartica Na uređaju nudi neograničenu besplatnu transkripciju.';
+  String get premiumMinutesInfo => '1.200 premium minuta/mjesec. Kartica Na uređaju nudi neograničenu besplatnu transkripciju.';
 
   @override
   String get viewUsage => 'Prikaži upotrebu';
@@ -6086,8 +5960,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get performanceWarning => 'Upozorenje o performansama';
 
   @override
-  String get largeModelWarning =>
-      'Ovaj model je velik i može srušiti aplikaciju ili biti vrlo spora na mobilnim uređajima.\n\n\"small\" ili \"base\" se preporučuju.';
+  String get largeModelWarning => 'Ovaj model je velik i može srušiti aplikaciju ili biti vrlo spora na mobilnim uređajima.\n\n\"small\" ili \"base\" se preporučuju.';
 
   @override
   String get usingNativeIosSpeech => 'Korištenje nativnog iOS prepoznavanja govora';
@@ -6150,8 +6023,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get batteryDrainSignificantly => 'Istekovanje baterije će se značajno povećati.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 premium minuta/mjesec. Kartica Na uređaju nudi neograničenu besplatnu transkripciju.';
+  String get premiumMinutesMonth => '1.200 premium minuta/mjesec. Kartica Na uređaju nudi neograničenu besplatnu transkripciju.';
 
   @override
   String get audioProcessedLocally => 'Zvuk se obrađuje lokalno. Radi bez veze, privatnije, ali koristi više baterije.';
@@ -6163,8 +6035,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Ovaj model je velik i može srušiti aplikaciju ili biti vrlo spora na mobilnim uređajima.\n\n\"small\" ili \"base\" se preporučuju.';
+  String get modelTooLargeWarning => 'Ovaj model je velik i može srušiti aplikaciju ili biti vrlo spora na mobilnim uređajima.\n\n\"small\" ili \"base\" se preporučuju.';
 
   @override
   String get nativeEngineNoDownload => 'Koristit će se motor govora vašeg uređaja. Preuzimanje modela nije potrebno.';
@@ -6203,8 +6074,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi-jeva ugrađena transkripcija u realnom vremenu optimizirana je za razgovore u realnom vremenu sa automatskim prepoznavanjem govornika i dijalizacijom.';
+  String get omiTranscriptionOptimized => 'Omi-jeva ugrađena transkripcija u realnom vremenu optimizirana je za razgovore u realnom vremenu sa automatskim prepoznavanjem govornika i dijalizacijom.';
 
   @override
   String get reset => 'Resetiraj';
@@ -6424,8 +6294,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Gradnja vašeg grafa znanja iz uspomena...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Vaš graf znanja će se automatski graditi kako kreirate nove uspomene.';
+  String get knowledgeGraphWillBuildAutomatically => 'Vaš graf znanja će se automatski graditi kako kreirate nove uspomene.';
 
   @override
   String get buildGraphButton => 'Gradi graf';
@@ -6661,8 +6530,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get failedToLoadContacts => 'Neuspješno učitavanje kontakata';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Neuspješno pripremanje razgovora za dijeljenje. Molimo pokušajte ponovno.';
+  String get failedToPrepareConversationForSharing => 'Neuspješno pripremanje razgovora za dijeljenje. Molimo pokušajte ponovno.';
 
   @override
   String get couldNotOpenSmsApp => 'Nije se mogla otvoriti aplikacija za SMS. Molimo pokušajte ponovno.';
@@ -6728,8 +6596,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Preuzimanje zvuka sa SD kartice vašeg uređaja';
 
   @override
-  String get transferRequiredDescription =>
-      'Ova snimka je spremljena na SD kartici vašeg uređaja. Prenesite je na telefon kako biste je reproducirali ili podijelili.';
+  String get transferRequiredDescription => 'Ova snimka je spremljena na SD kartici vašeg uređaja. Prenesite je na telefon kako biste je reproducirali ili podijelili.';
 
   @override
   String get cancelTransfer => 'Otkaži prijenos';
@@ -6750,8 +6617,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get shareRecording => 'Dijeli Snimku';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Jeste li sigurni da želite trajno obrisati ovu snimku? To se ne može poništiti.';
+  String get deleteRecordingConfirmation => 'Jeste li sigurni da želite trajno obrisati ovu snimku? To se ne može poništiti.';
 
   @override
   String get recordingIdLabel => 'ID Snimke';
@@ -6810,8 +6676,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get enableFastTransfer => 'Omogući Brz Prijenos';
 
   @override
-  String get fastTransferDescription =>
-      'Brz Prijenos koristi WiFi za oko 5x brže brzine. Vaš telefon će se privremeno povezati na WiFi mrežu vašeg Omi uređaja tijekom prijenosa.';
+  String get fastTransferDescription => 'Brz Prijenos koristi WiFi za oko 5x brže brzine. Vaš telefon će se privremeno povezati na WiFi mrežu vašeg Omi uređaja tijekom prijenosa.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Pristup internetu je pauziran tijekom prijenosa';
@@ -6826,8 +6691,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fiveTimesFaster => '5X BRŽE';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Kreira izravnu WiFi vezu s vašim Omi uređajem. Vaš telefon će se privremeno odspojiti od vaše standardne WiFi mreže tijekom prijenosa.';
+  String get fastTransferMethodDescription => 'Kreira izravnu WiFi vezu s vašim Omi uređajem. Vaš telefon će se privremeno odspojiti od vaše standardne WiFi mreže tijekom prijenosa.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6836,8 +6700,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get bleSpeed => '~30 KB/s putem BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Koristi standardnu vezu Bluetooth Low Energy. Sporije, ali ne utječe na vašu WiFi vezu.';
+  String get bluetoothMethodDescription => 'Koristi standardnu vezu Bluetooth Low Energy. Sporije, ali ne utječe na vašu WiFi vezu.';
 
   @override
   String get selected => 'Odabrano';
@@ -6855,8 +6718,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'Vaš Omi Uređaj Je Odspoj';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'Molim vas da se ponovno povežete da biste nastavili koristiti vaš Omi.';
+  String get deviceDisconnectedNotificationBody => 'Molim vas da se ponovno povežete da biste nastavili koristiti vaš Omi.';
 
   @override
   String get firmwareUpdateAvailable => 'Dostupna Je Ažuriranja Firmwarea';
@@ -6876,12 +6738,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get appDeleteFailed => 'Brisanje aplikacije nije uspjelo. Molim vas pokušajte kasnije.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Vidljivost aplikacije je uspješno promijenjena. Mogu biti potrebne nekoliko minuta da se reflektira.';
+  String get appVisibilityChangedSuccessfully => 'Vidljivost aplikacije je uspješno promijenjena. Mogu biti potrebne nekoliko minuta da se reflektira.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Greška pri aktiviranju aplikacije. Ako je to integracyjska aplikacija, provjerite je li postav dovršen.';
+  String get errorActivatingAppIntegration => 'Greška pri aktiviranju aplikacije. Ako je to integracyjska aplikacija, provjerite je li postav dovršen.';
 
   @override
   String get errorUpdatingAppStatus => 'Došlo je do greške pri ažuriranju statusa aplikacije.';
@@ -6949,8 +6809,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get importantConversationTitle => 'Važan Razgovor';
 
   @override
-  String get importantConversationBody =>
-      'Upravo ste imali važan razgovor. Dodirnite da biste podijelili sažetak s drugima.';
+  String get importantConversationBody => 'Upravo ste imali važan razgovor. Dodirnite da biste podijelili sažetak s drugima.';
 
   @override
   String get templateName => 'Naziv Predloška';
@@ -6962,8 +6821,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Naziv mora biti najmanje 3 znaka';
 
   @override
-  String get conversationPromptHint =>
-      'npr. Ekstrahirajte stavke akcije, donesene odluke i ključne zaključke iz priloženog razgovora.';
+  String get conversationPromptHint => 'npr. Ekstrahirajte stavke akcije, donesene odluke i ključne zaključke iz priloženog razgovora.';
 
   @override
   String get pleaseEnterAppPrompt => 'Molim vas unesite promptu za vašu aplikaciju';
@@ -6996,8 +6854,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get failedToCreateApp => 'Stvaranje aplikacije nije uspjelo. Molim vas pokušajte ponovno.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'Molim vas odaberite još jednu osnovnu mogućnost za vašu aplikaciju da biste nastavili';
+  String get addAppSelectCoreCapability => 'Molim vas odaberite još jednu osnovnu mogućnost za vašu aplikaciju da biste nastavili';
 
   @override
   String get addAppSelectPaymentPlan => 'Molim vas odaberite plan plaćanja i unesite cijenu za vašu aplikaciju';
@@ -7046,8 +6903,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'Dozvola za fotografije odbijena. Molim vas dopustite pristup fotografijama za odabir slike';
+  String get addAppPhotosPermissionDenied => 'Dozvola za fotografije odbijena. Molim vas dopustite pristup fotografijama za odabir slike';
 
   @override
   String get addAppErrorSelectingImageRetry => 'Greška pri odabiru slike. Molim vas pokušajte ponovno.';
@@ -7070,8 +6926,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get paymentFailedToFetchCountries => 'Dohvaćanje podržanih zemalja nije uspjelo. Molim vas pokušajte kasnije.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Postavljanje zadane metode plaćanja nije uspjelo. Molim vas pokušajte kasnije.';
+  String get paymentFailedToSetDefault => 'Postavljanje zadane metode plaćanja nije uspjelo. Molim vas pokušajte kasnije.';
 
   @override
   String get paymentFailedToSavePaypal => 'Spremanje PayPal podataka nije uspjelo. Molim vas pokušajte kasnije.';
@@ -7153,15 +7008,13 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Ažuriranje je zakazano! Vaš mjesečni plan se nastavlja do kraja vašeg razdoblja naplate, zatim se automatski prebacuje na godišnji.';
+  String get planUpgradeScheduledMessage => 'Ažuriranje je zakazano! Vaš mjesečni plan se nastavlja do kraja vašeg razdoblja naplate, zatim se automatski prebacuje na godišnji.';
 
   @override
   String get couldNotSchedulePlanChange => 'Zakazivanje promjene plana nije uspjelo. Molim vas pokušajte ponovno.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Vaša pretplata je reaktivirana! Nema naplate sada - bit ćete naplaćeni na kraju vašeg trenutnog razdoblja.';
+  String get subscriptionReactivatedDefault => 'Vaša pretplata je reaktivirana! Nema naplate sada - bit ćete naplaćeni na kraju vašeg trenutnog razdoblja.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Pretplata je uspješna! Naplaćeni ste za novo razdoblje naplate.';
@@ -7284,8 +7137,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get successfullyConnectedGoogleTasks => 'Uspješno ste se povezali na Google Tasks!';
 
   @override
-  String get failedToConnectGoogleTasksRetry =>
-      'Povezivanje na Google Tasks nije uspjelo. Molim vas pokušajte ponovno.';
+  String get failedToConnectGoogleTasksRetry => 'Povezivanje na Google Tasks nije uspjelo. Molim vas pokušajte ponovno.';
 
   @override
   String get successfullyConnectedClickUp => 'Uspješno ste se povezali na ClickUp!';
@@ -7330,8 +7182,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Dohvaćanje firebase tokena nije uspjelo, molim vas pokušajte ponovno.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Neočekivana greška pri prijavi, Firebase greška, molim vas pokušajte ponovno.';
+  String get authUnexpectedErrorFirebase => 'Neočekivana greška pri prijavi, Firebase greška, molim vas pokušajte ponovno.';
 
   @override
   String get authUnexpectedError => 'Neočekivana greška pri prijavi, molim vas pokušajte ponovno';
@@ -7346,8 +7197,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Dozvola za Bluetooth je obavezna za povezivanje s vašim uređajem.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Dozvola za Bluetooth je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Dozvola za Bluetooth je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7360,12 +7210,10 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Dozvola za Notifikacije je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Dozvola za Notifikacije je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Dozvola za Notifikacije je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama > Notifikacije.';
+  String get onboardingNotificationDeniedNotifications => 'Dozvola za Notifikacije je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama > Notifikacije.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7378,15 +7226,13 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Molim vas dodijelite dozvolu za lokaciju u Postavke > Privatnost i Sigurnost > Usluge Lokacije';
+  String get onboardingLocationGrantInSettings => 'Molim vas dodijelite dozvolu za lokaciju u Postavke > Privatnost i Sigurnost > Usluge Lokacije';
 
   @override
   String get onboardingMicrophoneRequired => 'Dozvola za Mikrofon je obavezna za snimanje.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Dozvola za Mikrofon je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama > Privatnost i Sigurnost > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Dozvola za Mikrofon je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama > Privatnost i Sigurnost > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7402,8 +7248,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Dozvola za Snimanje Zaslona je obavezna za snimanje sustavnog zvuka.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Dozvola za Snimanje Zaslona je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama > Privatnost i Sigurnost > Snimanje Zaslona.';
+  String get onboardingScreenCaptureDenied => 'Dozvola za Snimanje Zaslona je odbijena. Molim vas dodijelite dozvolu u Sistemskim Postavama > Privatnost i Sigurnost > Snimanje Zaslona.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7416,8 +7261,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Dozvola za Pristupačnost je obavezna za detektiranje susreta u pregledniku.';
+  String get onboardingAccessibilityRequired => 'Dozvola za Pristupačnost je obavezna za detektiranje susreta u pregledniku.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7457,8 +7301,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Dozvola za Fotografije je odbijena. Molim vas dopustite pristup fotografijama za odabir slika';
+  String get msgPhotosPermissionDenied => 'Dozvola za Fotografije je odbijena. Molim vas dopustite pristup fotografijama za odabir slika';
 
   @override
   String get msgSelectImagesGenericError => 'Greška pri odabiru slika. Molim vas pokušajte ponovno.';
@@ -7530,8 +7373,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get locationPermissionRequired => 'Dozvola za Lokaciju je Obavezna';
 
   @override
-  String get locationPermissionContent =>
-      'Brz Prijenos zahtijeva dozvolu za lokaciju da provjerite WiFi vezu. Molim vas dodijelite dozvolu za lokaciju da biste nastavili.';
+  String get locationPermissionContent => 'Brz Prijenos zahtijeva dozvolu za lokaciju da provjerite WiFi vezu. Molim vas dodijelite dozvolu za lokaciju da biste nastavili.';
 
   @override
   String get pdfTranscriptExport => 'Izvoz Transkripcije';
@@ -7694,8 +7536,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Uređaj ne podržava WiFi sinhronizaciju, prebacivanje na Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Uređaj ne podržava WiFi sinhronizaciju, prebacivanje na Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health nije dostupan na ovom uređaju';
@@ -7991,8 +7832,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Stavite Omi DevKit u modus uparivanja';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Pritisnite gumb jednom da uključite. LED će bljeskati ljubičasto kada je u modu uparivanja.';
+  String get pairingDescOmiDevkit => 'Pritisnite gumb jednom da uključite. LED će bljeskati ljubičasto kada je u modu uparivanja.';
 
   @override
   String get pairingTitleOmiGlass => 'Uključite Omi Glass';
@@ -8004,8 +7844,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Stavite Plaud Note u modus uparivanja';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Dugo pritisnite bočnu tipku 2 sekunde. Crveni LED će bljeskati kada je spreman za uparavanje.';
+  String get pairingDescPlaudNote => 'Dugo pritisnite bočnu tipku 2 sekunde. Crveni LED će bljeskati kada je spreman za uparavanje.';
 
   @override
   String get pairingTitleBee => 'Stavite Bee u modus uparivanja';
@@ -8017,15 +7856,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get pairingTitleLimitless => 'Stavite Limitless u modus uparivanja';
 
   @override
-  String get pairingDescLimitless =>
-      'Kada je bilo koje svjetlo vidljivo, pritisnite jednom, zatim pritisnite i držite dok uređaj ne pokaže ružičasto svjetlo, zatim otpustite.';
+  String get pairingDescLimitless => 'Kada je bilo koje svjetlo vidljivo, pritisnite jednom, zatim pritisnite i držite dok uređaj ne pokaže ružičasto svjetlo, zatim otpustite.';
 
   @override
   String get pairingTitleFriendPendant => 'Stavite Friend Pendant u modus uparivanja';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Pritisnite gumb na privjesku da ga uključite. Automatski će ući u modus uparivanja.';
+  String get pairingDescFriendPendant => 'Pritisnite gumb na privjesku da ga uključite. Automatski će ući u modus uparivanja.';
 
   @override
   String get pairingTitleFieldy => 'Stavite Fieldy u modus uparivanja';
@@ -8037,15 +7874,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Povežite Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Instalirajte i otvorite Omi aplikaciju na vašem Apple Watchu, zatim dodirnite Poveži u aplikaciji.';
+  String get pairingDescAppleWatch => 'Instalirajte i otvorite Omi aplikaciju na vašem Apple Watchu, zatim dodirnite Poveži u aplikaciji.';
 
   @override
   String get pairingTitleNeoOne => 'Stavite Neo One u modus uparivanja';
 
   @override
-  String get pairingDescNeoOne =>
-      'Pritisnite i držite gumb za napajanje dok LED ne počne bljeskati. Uređaj će biti vidljiv.';
+  String get pairingDescNeoOne => 'Pritisnite i držite gumb za napajanje dok LED ne počne bljeskati. Uređaj će biti vidljiv.';
 
   @override
   String get downloadingFromDevice => 'Preuzimanje s uređaja';
@@ -8162,8 +7997,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get switchAndRestart => 'Prebaci';
 
   @override
-  String get stagingDisclaimer =>
-      'Staging može biti nestabilan, imati nekonzistentne performanse, a podaci mogu biti izgubljeni. Koristite samo za testiranje.';
+  String get stagingDisclaimer => 'Staging može biti nestabilan, imati nekonzistentne performanse, a podaci mogu biti izgubljeni. Koristite samo za testiranje.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Spremljeno. Zatvorite i ponovno otvorite aplikaciju da biste primijenili.';
@@ -8392,8 +8226,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonski razgovori putem Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Pravite pozive kroz Omi i dobijte prenos u stvarnom vremenu, automatske sažetke i još mnogo toga. Dostupno isključivo za pretplatnike Unlimited plana.';
+  String get phoneCallsUpsellSubtitle => 'Pravite pozive kroz Omi i dobijte prenos u stvarnom vremenu, automatske sažetke i još mnogo toga. Dostupno isključivo za pretplatnike Unlimited plana.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Prenos svakog poziva u stvarnom vremenu';
@@ -8420,8 +8253,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteSyncedFiles => 'Obriši sinhronizovane snimke';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Ove snimke su već sinhronizovane s vašim telefonom. Ovo se ne može poništiti.';
+  String get deleteSyncedFilesMessage => 'Ove snimke su već sinhronizovane s vašim telefonom. Ovo se ne može poništiti.';
 
   @override
   String get syncedFilesDeleted => 'Sinhronizovane snimke obrisane';
@@ -8433,8 +8265,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deletePendingFiles => 'Obriši snimke na čekanju';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Ove snimke NISU sinhronizovane s vašim telefonom i bit će trajno izgubljene. Ovo se ne može poništiti.';
+  String get deletePendingFilesWarning => 'Ove snimke NISU sinhronizovane s vašim telefonom i bit će trajno izgubljene. Ovo se ne može poništiti.';
 
   @override
   String get pendingFilesDeleted => 'Snimke na čekanju obrisane';
@@ -8446,8 +8277,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deleteAll => 'Obriši sve';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Ovo će obrisati i sinhronizovane i snimke na čekanju. Snimke na čekanju NISU sinhronizovane i bit će trajno izgubljene. Ovo se ne može poništiti.';
+  String get deleteAllFilesWarning => 'Ovo će obrisati i sinhronizovane i snimke na čekanju. Snimke na čekanju NISU sinhronizovane i bit će trajno izgubljene. Ovo se ne može poništiti.';
 
   @override
   String get allFilesDeleted => 'Sve snimke obrisane';
@@ -8512,8 +8342,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fairUseAboutTitle => 'O poštenoj upotrebi';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi je dizajniran za osobne razgovore, sastanke i žive interakcije. Upotreba se mjeri prema stvarnom vremenu detektiranog govora, ne vremenu povezivanja. Ako upotreba značajno premašuje normale obrasce za sadržaj koji nije osoban, može doći do prilagodbi.';
+  String get fairUseAboutBody => 'Omi je dizajniran za osobne razgovore, sastanke i žive interakcije. Upotreba se mjeri prema stvarnom vremenu detektiranog govora, ne vremenu povezivanja. Ako upotreba značajno premašuje normale obrasce za sadržaj koji nije osoban, može doći do prilagodbi.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8551,8 +8380,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get improveConnectionTitle => 'Poboljšajte povezivanje';
 
   @override
-  String get improveConnectionContent =>
-      'Poboljšali smo kako Omi ostaje povezan s vašim uređajem. Da biste ovo aktivirali, molimo idite na stranicu Informacije o uređaju, dodirnite \"Odvoji uređaj\", a zatim ponovno upari uređaj.';
+  String get improveConnectionContent => 'Poboljšali smo kako Omi ostaje povezan s vašim uređajem. Da biste ovo aktivirali, molimo idite na stranicu Informacije o uređaju, dodirnite \"Odvoji uređaj\", a zatim ponovno upari uređaj.';
 
   @override
   String get improveConnectionAction => 'Razumijem';
@@ -8607,16 +8435,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get cancelSyncQuestion => 'Poništiti sinhronizaciju?';
 
   @override
-  String get omisStorageDesc =>
-      'Kada vaš Omi nije povezan s vašim telefonom, on pohranjuje audio lokalno na svojoj ugrađenoj memoriji. Nikad ne gubite snimku.';
+  String get omisStorageDesc => 'Kada vaš Omi nije povezan s vašim telefonom, on pohranjuje audio lokalno na svojoj ugrađenoj memoriji. Nikad ne gubite snimku.';
 
   @override
-  String get phoneStorageDesc =>
-      'Kada se Omi ponovno poveže, snimke se automatski prebacuju na vaš telefon kao privremeno skladište prije učitavanja.';
+  String get phoneStorageDesc => 'Kada se Omi ponovno poveže, snimke se automatski prebacuju na vaš telefon kao privremeno skladište prije učitavanja.';
 
   @override
-  String get cloudStorageDesc =>
-      'Kada se učitaju, snimke se obrađuju i prenose. Razgovori će biti dostupni u roku minute.';
+  String get cloudStorageDesc => 'Kada se učitaju, snimke se obrađuju i prenose. Razgovori će biti dostupni u roku minute.';
 
   @override
   String get tipKeepPhoneNearby => 'Čuvajte telefon blizu za bržu sinhronizaciju';
@@ -8640,12 +8465,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get permissionEnable => 'Omogući';
 
   @override
-  String get permissionsPageDescription =>
-      'Ove dozvole su temeljne za funkcionalnost Omi-ja. One omogućavaju ključne funkcije kao obavijesti, iskustva na temelju lokacije i snimanje audio-a.';
+  String get permissionsPageDescription => 'Ove dozvole su temeljne za funkcionalnost Omi-ja. One omogućavaju ključne funkcije kao obavijesti, iskustva na temelju lokacije i snimanje audio-a.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi trebaju nekoliko dozvola da bi radio pravilno. Molimo dodijelite ih kako biste nastavili.';
+  String get permissionsRequiredDescription => 'Omi trebaju nekoliko dozvola da bi radio pravilno. Molimo dodijelite ih kako biste nastavili.';
 
   @override
   String get permissionsSetupTitle => 'Uživajte u najboljem iskustvu';
@@ -8699,8 +8522,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get justAMoment => 'Molimo čekajte';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Toplo vam preporučujemo da istražite svoje ostale opcije umjesto otkazivanja.';
+  String get cancelConsequencesSubtitle => 'Toplo vam preporučujemo da istražite svoje ostale opcije umjesto otkazivanja.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8923,8 +8745,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get firmwareWarningTitle => 'Važno: Pročitajte prije ažuriranja';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ovaj firmware će formatirati SD karticu. Molimo osigurajte da su svi offline podaci sinkronizirani prije nadogradnje.\n\nAko vidite trepćuće crveno svjetlo nakon instaliranja ove verzije, ne brinite. Jednostavno povežite uređaj s aplikacijom i trebao bi postati plav. Crveno svjetlo znači da sat uređaja još nije sinkroniziran.';
+  String get firmwareFormatWarning => 'Ovaj firmware će formatirati SD karticu. Molimo osigurajte da su svi offline podaci sinkronizirani prije nadogradnje.\n\nAko vidite trepćuće crveno svjetlo nakon instaliranja ove verzije, ne brinite. Jednostavno povežite uređaj s aplikacijom i trebao bi postati plav. Crveno svjetlo znači da sat uređaja još nije sinkroniziran.';
 
   @override
   String get continueAnyway => 'Nastavi';
@@ -8944,8 +8765,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get tasksMarkComplete => 'Označeno kao završeno';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi pristupa Apple Health-u putem Appleovog HealthKit okvira. Pristup možete opozvati u bilo kojem trenutku u iOS postavkama.';
+  String get appleHealthManageNote => 'Omi pristupa Apple Health-u putem Appleovog HealthKit okvira. Pristup možete opozvati u bilo kojem trenutku u iOS postavkama.';
 
   @override
   String get appleHealthConnectCta => 'Poveži s Apple Health';
@@ -8978,8 +8798,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Pristup Apple Health-u odbijen';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi nema dozvolu za čitanje vaših Apple Health podataka. Omogućite ga u iOS Postavke → Privatnost i sigurnost → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi nema dozvolu za čitanje vaših Apple Health podataka. Omogućite ga u iOS Postavke → Privatnost i sigurnost → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Zašto odlazite?';
@@ -9048,8 +8867,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get planUpdate => 'Ažuriranje plana';
 
   @override
-  String get planDeprecationMessage =>
-      'Vaš Unlimited plan se ukida. Prijeđite na Operator plan — iste izvrsne značajke za \$49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.';
+  String get planDeprecationMessage => 'Vaš Unlimited plan se ukida. Prijeđite na Operator plan — iste izvrsne značajke za \$49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.';
 
   @override
   String get upgradeYourPlan => 'Nadogradite svoj plan';
@@ -9160,8 +8978,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Dosegli ste svoj mjesečni limit. Nadogradite da nastavite razgovarati s Omi bez ograničenja.';
+  String get chatQuotaExceededReply => 'Dosegli ste svoj mjesečni limit. Nadogradite da nastavite razgovarati s Omi bez ograničenja.';
 
   @override
   String get voiceResponseAudio => 'Pročitaj Omijev odgovor naglas';
@@ -9192,4 +9009,25 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Dodaj zadatak';
+
+  @override
+  String get quickActionAskOmiAnything => 'Pitajte Omi bilo što';
+
+  @override
+  String get quickActionVoiceMode => 'Glasovni način rada';
+
+  @override
+  String get quickActionMute => 'Isključi zvuk';
+
+  @override
+  String get quickActionUnmute => 'Uključi zvuk';
+
+  @override
+  String get quickActionConnectDevice => 'Poveži uređaj';
+
+  @override
+  String get quickActionDeviceSettings => 'Postavke uređaja';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -24,8 +24,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteConversationTitle => 'Beszélgetés törlése?';
 
   @override
-  String get deleteConversationMessage =>
-      'Ez törli a kapcsolódó emlékeket, feladatokat és hangfájlokat is. Ez a művelet nem vonható vissza.';
+  String get deleteConversationMessage => 'Ez törli a kapcsolódó emlékeket, feladatokat és hangfájlokat is. Ez a művelet nem vonható vissza.';
 
   @override
   String get confirm => 'Megerősítés';
@@ -82,8 +81,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get conversationUrlNotShared => 'A beszélgetés URL-je nem volt megosztható.';
 
   @override
-  String get errorProcessingConversation =>
-      'Hiba történt a beszélgetés feldolgozása során. Kérlek, próbáld újra később.';
+  String get errorProcessingConversation => 'Hiba történt a beszélgetés feldolgozása során. Kérlek, próbáld újra később.';
 
   @override
   String get noInternetConnection => 'Nincs internetkapcsolat';
@@ -147,8 +145,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleting => 'Törlés...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
+  String get pleaseCompleteAuthentication => 'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
 
   @override
   String get failedToStartAuthentication => 'A hitelesítés indítása sikertelen';
@@ -229,8 +226,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noStarredConversations => 'Nincsenek csillagozott beszélgetések';
 
   @override
-  String get starConversationHint =>
-      'Beszélgetés csillagozásához nyisd meg, és érintsd meg a csillag ikont a fejlécben.';
+  String get starConversationHint => 'Beszélgetés csillagozásához nyisd meg, és érintsd meg a csillag ikont a fejlécben.';
 
   @override
   String get searchConversations => 'Beszélgetések keresése...';
@@ -321,8 +317,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get installedApps => 'Telepített alkalmazások';
 
   @override
-  String get unableToFetchApps =>
-      'Nem sikerült betölteni az alkalmazásokat :(\n\nKérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
+  String get unableToFetchApps => 'Nem sikerült betölteni az alkalmazásokat :(\n\nKérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
 
   @override
   String get aboutOmi => 'Az Omi-ról';
@@ -358,19 +353,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get appsDisconnected => 'Alkalmazásaid és integrációid azonnal leválasztásra kerülnek.';
 
   @override
-  String get exportBeforeDelete =>
-      'Exportálhatod az adataidat a fiók törlése előtt, de törlés után nem állítható vissza.';
+  String get exportBeforeDelete => 'Exportálhatod az adataidat a fiók törlése előtt, de törlés után nem állítható vissza.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Megértettem, hogy a fiókom törlése végleges, és minden adat, beleértve az emlékeket és beszélgetéseket, elvész és nem állítható vissza.';
+  String get deleteAccountCheckbox => 'Megértettem, hogy a fiókom törlése végleges, és minden adat, beleértve az emlékeket és beszélgetéseket, elvész és nem állítható vissza.';
 
   @override
   String get areYouSure => 'Biztos vagy benne?';
 
   @override
-  String get deleteAccountFinal =>
-      'Ez a művelet visszafordíthatatlan, és véglegesen törli a fiókodat és minden kapcsolódó adatot. Biztosan folytatni szeretnéd?';
+  String get deleteAccountFinal => 'Ez a művelet visszafordíthatatlan, és véglegesen törli a fiókodat és minden kapcsolódó adatot. Biztosan folytatni szeretnéd?';
 
   @override
   String get deleteNow => 'Törlés most';
@@ -379,8 +371,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get goBack => 'Vissza';
 
   @override
-  String get checkBoxToConfirm =>
-      'Jelöld be a négyzetet, hogy megerősítsd, megértetted, hogy a fiókod törlése végleges és visszafordíthatatlan.';
+  String get checkBoxToConfirm => 'Jelöld be a négyzetet, hogy megerősítsd, megértetted, hogy a fiókod törlése végleges és visszafordíthatatlan.';
 
   @override
   String get profile => 'Profil';
@@ -458,8 +449,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get yourPrivacyYourControl => 'Adatvédelem, saját ellenőrzésed alatt';
 
   @override
-  String get privacyIntro =>
-      'Az Omi-nál elkötelezettek vagyunk az adatvédelem iránt. Ez az oldal lehetővé teszi az adataid tárolásának és felhasználásának szabályozását.';
+  String get privacyIntro => 'Az Omi-nál elkötelezettek vagyunk az adatvédelem iránt. Ez az oldal lehetővé teszi az adataid tárolásának és felhasználásának szabályozását.';
 
   @override
   String get learnMore => 'További információ...';
@@ -468,15 +458,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get dataProtectionLevel => 'Adatvédelmi szint';
 
   @override
-  String get dataProtectionDesc =>
-      'Az adataid alapértelmezetten erős titkosítással védettek. Tekintsd át a beállításaidat és a jövőbeli adatvédelmi lehetőségeket alább.';
+  String get dataProtectionDesc => 'Az adataid alapértelmezetten erős titkosítással védettek. Tekintsd át a beállításaidat és a jövőbeli adatvédelmi lehetőségeket alább.';
 
   @override
   String get appAccess => 'Alkalmazás hozzáférés';
 
   @override
-  String get appAccessDesc =>
-      'A következő alkalmazások férhetnek hozzá az adataidhoz. Érintsd meg az alkalmazást az engedélyek kezeléséhez.';
+  String get appAccessDesc => 'A következő alkalmazások férhetnek hozzá az adataidhoz. Érintsd meg az alkalmazást az engedélyek kezeléséhez.';
 
   @override
   String get noAppsExternalAccess => 'Egyik telepített alkalmazás sem rendelkezik külső hozzáféréssel az adataidhoz.';
@@ -533,22 +521,19 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Az Omi leválasztásra került 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Eszköz párosítása megszüntetve. Menjen a Beállítások > Bluetooth menüpontba, és felejtse el az eszközt a párosítás megszüntetésének befejezéséhez.';
+  String get deviceUnpairedMessage => 'Eszköz párosítása megszüntetve. Menjen a Beállítások > Bluetooth menüpontba, és felejtse el az eszközt a párosítás megszüntetésének befejezéséhez.';
 
   @override
   String get unpairDialogTitle => 'Eszköz párosításának megszüntetése';
 
   @override
-  String get unpairDialogMessage =>
-      'Ez megszünteti az eszköz párosítását, így másik telefonhoz csatlakoztatható. Menned kell a Beállítások > Bluetooth menübe, és el kell felejtened az eszközt a folyamat befejezéséhez.';
+  String get unpairDialogMessage => 'Ez megszünteti az eszköz párosítását, így másik telefonhoz csatlakoztatható. Menned kell a Beállítások > Bluetooth menübe, és el kell felejtened az eszközt a folyamat befejezéséhez.';
 
   @override
   String get deviceNotConnected => 'Eszköz nincs csatlakoztatva';
 
   @override
-  String get connectDeviceMessage =>
-      'Csatlakoztasd az Omi eszközödet az eszköz\nbeállítások és testreszabás eléréséhez';
+  String get connectDeviceMessage => 'Csatlakoztasd az Omi eszközödet az eszköz\nbeállítások és testreszabás eléréséhez';
 
   @override
   String get deviceInfoSection => 'Eszköz információk';
@@ -563,8 +548,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get v2Undetected => 'V2 nem észlelhető';
 
   @override
-  String get v2UndetectedMessage =>
-      'Úgy látjuk, hogy vagy V1 eszközöd van, vagy az eszközöd nincs csatlakoztatva. Az SD kártya funkció csak V2 eszközökön érhető el.';
+  String get v2UndetectedMessage => 'Úgy látjuk, hogy vagy V1 eszközöd van, vagy az eszközöd nincs csatlakoztatva. Az SD kártya funkció csak V2 eszközökön érhető el.';
 
   @override
   String get endConversation => 'Beszélgetés befejezése';
@@ -696,8 +680,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noActivityYet => 'Még nincs aktivitás';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Kezdj egy beszélgetést Omi-val,\nhogy itt lásd a használati statisztikáidat.';
+  String get startConversationToSeeInsights => 'Kezdj egy beszélgetést Omi-val,\nhogy itt lásd a használati statisztikáidat.';
 
   @override
   String get listening => 'Figyelés';
@@ -759,8 +742,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get shareStatsMessage =>
-      'Megosztom az Omi statisztikáimat! (omi.me - mindig rendelkezésre álló AI asszisztensed)';
+  String get shareStatsMessage => 'Megosztom az Omi statisztikáimat! (omi.me - mindig rendelkezésre álló AI asszisztensed)';
 
   @override
   String get sharePeriodToday => 'Ma az omi:';
@@ -840,8 +822,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Tudásgráf törlése?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Ez törli az összes származtatott tudásgráf adatot (csomópontok és kapcsolatok). Az eredeti emlékeid biztonságban maradnak. A gráf idővel vagy a következő kérésre újjáépül.';
+  String get deleteKnowledgeGraphMessage => 'Ez törli az összes származtatott tudásgráf adatot (csomópontok és kapcsolatok). Az eredeti emlékeid biztonságban maradnak. A gráf idővel vagy a következő kérésre újjáépül.';
 
   @override
   String get knowledgeGraphDeleted => 'Tudásgráf törölve';
@@ -989,8 +970,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get shortConversationThreshold => 'Rövid beszélgetés küszöbérték';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Ennél rövidebb beszélgetések el lesznek rejtve, ha fent nincs engedélyezve';
+  String get shortConversationThresholdSubtitle => 'Ennél rövidebb beszélgetések el lesznek rejtve, ha fent nincs engedélyezve';
 
   @override
   String get durationThreshold => 'Időtartam küszöbérték';
@@ -1022,12 +1002,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get comingSoon => 'Hamarosan';
 
   @override
-  String get integrationsFooter =>
-      'Csatlakoztasd az alkalmazásaidat az adatok és metrikák megjelenítéséhez a csevegésben.';
+  String get integrationsFooter => 'Csatlakoztasd az alkalmazásaidat az adatok és metrikák megjelenítéséhez a csevegésben.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
+  String get completeAuthInBrowser => 'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1087,37 +1065,31 @@ class AppLocalizationsHu extends AppLocalizations {
   String get needYourPermission => 'Szükségünk van az engedélyedre';
 
   @override
-  String get alreadyGavePermission =>
-      'Már engedélyezted a felvételeid mentését. Itt egy emlékeztető, hogy miért van erre szükségünk:';
+  String get alreadyGavePermission => 'Már engedélyezted a felvételeid mentését. Itt egy emlékeztető, hogy miért van erre szükségünk:';
 
   @override
-  String get wouldLikePermission =>
-      'Szeretnénk az engedélyedet kérni a hangfelvételeid mentéséhez. Itt van, hogy miért:';
+  String get wouldLikePermission => 'Szeretnénk az engedélyedet kérni a hangfelvételeid mentéséhez. Itt van, hogy miért:';
 
   @override
   String get improveSpeechProfile => 'Beszédprofil fejlesztése';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'A felvételeket használjuk a személyes beszédprofilod további tanítására és fejlesztésére.';
+  String get improveSpeechProfileDesc => 'A felvételeket használjuk a személyes beszédprofilod további tanítására és fejlesztésére.';
 
   @override
   String get trainFamilyProfiles => 'Profilok tanítása barátoknak és családtagoknak';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'A felvételeid segítenek felismerni és profilokat létrehozni a barátaidnak és családtagjaidnak.';
+  String get trainFamilyProfilesDesc => 'A felvételeid segítenek felismerni és profilokat létrehozni a barátaidnak és családtagjaidnak.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Átirat pontosságának növelése';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Ahogy a modellünk fejlődik, jobb átírási eredményeket tudunk biztosítani a felvételeidhez.';
+  String get enhanceTranscriptAccuracyDesc => 'Ahogy a modellünk fejlődik, jobb átírási eredményeket tudunk biztosítani a felvételeidhez.';
 
   @override
-  String get legalNotice =>
-      'Jogi közlemény: A hangadatok rögzítésének és tárolásának jogszerűsége a tartózkodási helyedtől és a funkció használatától függően változhat. A helyi törvényeknek és szabályozásoknak való megfelelés a te felelősséged.';
+  String get legalNotice => 'Jogi közlemény: A hangadatok rögzítésének és tárolásának jogszerűsége a tartózkodási helyedtől és a funkció használatától függően változhat. A helyi törvényeknek és szabályozásoknak való megfelelés a te felelősséged.';
 
   @override
   String get alreadyAuthorized => 'Már engedélyezve';
@@ -1189,15 +1161,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get showMeetingsMenuBar => 'Közelgő találkozók megjelenítése a menüsorban';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'A következő találkozód és a kezdésig hátralévő idő megjelenítése a macOS menüsorban';
+  String get showMeetingsMenuBarDesc => 'A következő találkozód és a kezdésig hátralévő idő megjelenítése a macOS menüsorban';
 
   @override
   String get showEventsNoParticipants => 'Résztvevők nélküli események megjelenítése';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Ha engedélyezve van, a Közelgő események résztvevők vagy videó link nélküli eseményeket is mutat.';
+  String get showEventsNoParticipantsDesc => 'Ha engedélyezve van, a Közelgő események résztvevők vagy videó link nélküli eseményeket is mutat.';
 
   @override
   String get yourMeetings => 'Találkozóid';
@@ -1238,8 +1208,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noProjectsInWorkspace => 'Nem találhatók projektek ebben a munkaterületen';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Válaszd ki, mennyi ideig várjon csendben a beszélgetés automatikus befejezése előtt:';
+  String get conversationTimeoutDesc => 'Válaszd ki, mennyi ideig várjon csendben a beszélgetés automatikus befejezése előtt:';
 
   @override
   String get timeout2Minutes => '2 perc';
@@ -1286,8 +1255,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get languageForTranscription => 'Állítsd be a nyelvedet a pontosabb átíráshoz és személyre szabott élményhez.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Egynyelvű mód engedélyezve. A fordítás ki van kapcsolva a nagyobb pontosság érdekében.';
+  String get singleLanguageModeInfo => 'Egynyelvű mód engedélyezve. A fordítás ki van kapcsolva a nagyobb pontosság érdekében.';
 
   @override
   String get searchLanguageHint => 'Keress nyelvet név vagy kód alapján';
@@ -1367,8 +1335,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get defaultRepository => 'Alapértelmezett tároló';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Válassz egy alapértelmezett tárolót a problémák létrehozásához. Problémák létrehozásakor továbbra is megadhatsz másik tárolót.';
+  String get selectDefaultRepoDesc => 'Válassz egy alapértelmezett tárolót a problémák létrehozásához. Problémák létrehozásakor továbbra is megadhatsz másik tárolót.';
 
   @override
   String get noReposFound => 'Nem találhatók tárolók';
@@ -1415,8 +1382,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get configureSettings => 'Beállítások konfigurálása';
 
   @override
-  String get completeAuthBrowser =>
-      'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
+  String get completeAuthBrowser => 'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1744,8 +1710,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth engedélyezése';
 
   @override
-  String get bluetoothNeeded =>
-      'Az Omi-nak Bluetoothra van szüksége a viselhető eszközhöz való csatlakozáshoz. Kérlek, engedélyezd a Bluetooth-t, és próbáld újra.';
+  String get bluetoothNeeded => 'Az Omi-nak Bluetoothra van szüksége a viselhető eszközhöz való csatlakozáshoz. Kérlek, engedélyezd a Bluetooth-t, és próbáld újra.';
 
   @override
   String get contactSupport => 'Ügyfélszolgálat elérése?';
@@ -1778,26 +1743,22 @@ class AppLocalizationsHu extends AppLocalizations {
   String get locationServiceDisabled => 'Helymeghatározási szolgáltatás letiltva';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'A helymeghatározási szolgáltatás le van tiltva. Kérlek, menj a Beállítások > Adatvédelem és biztonság > Helyszolgáltatások menübe, és engedélyezd';
+  String get locationServiceDisabledDesc => 'A helymeghatározási szolgáltatás le van tiltva. Kérlek, menj a Beállítások > Adatvédelem és biztonság > Helyszolgáltatások menübe, és engedélyezd';
 
   @override
   String get backgroundLocationDenied => 'Háttérhelymeghatározás megtagadva';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Kérlek, menj az eszköz beállításaihoz, és állítsd a helymeghatározási engedélyt \"Mindig engedélyezés\"-re';
+  String get backgroundLocationDeniedDesc => 'Kérlek, menj az eszköz beállításaihoz, és állítsd a helymeghatározási engedélyt \"Mindig engedélyezés\"-re';
 
   @override
   String get lovingOmi => 'Tetszik az Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Segíts elérni több embert azzal, hogy értékelést hagysz az App Store-ban. A visszajelzésed sokat jelent nekünk!';
+  String get leaveReviewIos => 'Segíts elérni több embert azzal, hogy értékelést hagysz az App Store-ban. A visszajelzésed sokat jelent nekünk!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Segíts elérni több embert azzal, hogy értékelést hagysz a Google Play Áruházban. A visszajelzésed sokat jelent nekünk!';
+  String get leaveReviewAndroid => 'Segíts elérni több embert azzal, hogy értékelést hagysz a Google Play Áruházban. A visszajelzésed sokat jelent nekünk!';
 
   @override
   String get rateOnAppStore => 'Értékelés az App Store-ban';
@@ -1830,36 +1791,31 @@ class AppLocalizationsHu extends AppLocalizations {
   String get connectionError => 'Kapcsolódási hiba';
 
   @override
-  String get connectionErrorDesc =>
-      'Nem sikerült csatlakozni a szerverhez. Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
+  String get connectionErrorDesc => 'Nem sikerült csatlakozni a szerverhez. Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Érvénytelen felvétel észlelve';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Úgy tűnik, több beszélő van a felvételen. Kérlek, győződj meg róla, hogy csendes helyen vagy, és próbáld újra.';
+  String get multipleSpeakersDesc => 'Úgy tűnik, több beszélő van a felvételen. Kérlek, győződj meg róla, hogy csendes helyen vagy, és próbáld újra.';
 
   @override
   String get tooShortDesc => 'Nem észlelhető elegendő beszéd. Kérlek, beszélj többet, és próbáld újra.';
 
   @override
-  String get invalidRecordingDesc =>
-      'Kérlek, győződj meg róla, hogy legalább 5 másodpercig, de legfeljebb 90 másodpercig beszélsz.';
+  String get invalidRecordingDesc => 'Kérlek, győződj meg róla, hogy legalább 5 másodpercig, de legfeljebb 90 másodpercig beszélsz.';
 
   @override
   String get areYouThere => 'Ott vagy?';
 
   @override
-  String get noSpeechDesc =>
-      'Nem tudtunk beszédet észlelni. Kérlek, győződj meg róla, hogy legalább 10 másodpercig, de legfeljebb 3 percig beszélsz.';
+  String get noSpeechDesc => 'Nem tudtunk beszédet észlelni. Kérlek, győződj meg róla, hogy legalább 10 másodpercig, de legfeljebb 3 percig beszélsz.';
 
   @override
   String get connectionLost => 'Kapcsolat megszakadt';
 
   @override
-  String get connectionLostDesc =>
-      'A kapcsolat megszakadt. Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
+  String get connectionLostDesc => 'A kapcsolat megszakadt. Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
 
   @override
   String get tryAgain => 'Próbáld újra';
@@ -1874,8 +1830,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get permissionsRequired => 'Engedélyek szükségesek';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Ez az alkalmazás Bluetooth és helymeghatározási engedélyekre van szüksége a megfelelő működéshez. Kérlek, engedélyezd őket a beállításokban.';
+  String get permissionsRequiredDesc => 'Ez az alkalmazás Bluetooth és helymeghatározási engedélyekre van szüksége a megfelelő működéshez. Kérlek, engedélyezd őket a beállításokban.';
 
   @override
   String get openSettings => 'Beállítások megnyitása';
@@ -1905,8 +1860,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – AI társad';
 
   @override
-  String get captureEveryMoment =>
-      'Rögzítsd minden pillanatot. Kapj AI-alapú\nösszefoglalókat. Soha többé ne kelljen jegyzetet készítened.';
+  String get captureEveryMoment => 'Rögzítsd minden pillanatot. Kapj AI-alapú\nösszefoglalókat. Soha többé ne kelljen jegyzetet készítened.';
 
   @override
   String get appleWatchSetup => 'Apple Watch beállítása';
@@ -1918,12 +1872,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get microphonePermission => 'Mikrofon engedély';
 
   @override
-  String get permissionGrantedNow =>
-      'Engedély megadva! Most:\n\nNyisd meg az Omi alkalmazást az órádon, és érintsd meg a \"Folytatás\" gombot alább';
+  String get permissionGrantedNow => 'Engedély megadva! Most:\n\nNyisd meg az Omi alkalmazást az órádon, és érintsd meg a \"Folytatás\" gombot alább';
 
   @override
-  String get needMicrophonePermission =>
-      'Mikrofon engedélyre van szükségünk.\n\n1. Érintsd meg az \"Engedély megadása\" gombot\n2. Engedélyezd az iPhone-odon\n3. Az óra alkalmazás bezárul\n4. Nyisd meg újra, és érintsd meg a \"Folytatás\" gombot';
+  String get needMicrophonePermission => 'Mikrofon engedélyre van szükségünk.\n\n1. Érintsd meg az \"Engedély megadása\" gombot\n2. Engedélyezd az iPhone-odon\n3. Az óra alkalmazás bezárul\n4. Nyisd meg újra, és érintsd meg a \"Folytatás\" gombot';
 
   @override
   String get grantPermissionButton => 'Engedély megadása';
@@ -1932,15 +1884,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get needHelp => 'Segítség kell?';
 
   @override
-  String get troubleshootingSteps =>
-      'Hibaelhárítás:\n\n1. Győződj meg róla, hogy az Omi telepítve van az órádon\n2. Nyisd meg az Omi alkalmazást az órádon\n3. Keresd az engedély felugró ablakot\n4. Érintsd meg az \"Engedélyezés\" gombot, amikor megjelenik\n5. Az óra alkalmazás bezárul - nyisd meg újra\n6. Térj vissza, és érintsd meg a \"Folytatás\" gombot az iPhone-odon';
+  String get troubleshootingSteps => 'Hibaelhárítás:\n\n1. Győződj meg róla, hogy az Omi telepítve van az órádon\n2. Nyisd meg az Omi alkalmazást az órádon\n3. Keresd az engedély felugró ablakot\n4. Érintsd meg az \"Engedélyezés\" gombot, amikor megjelenik\n5. Az óra alkalmazás bezárul - nyisd meg újra\n6. Térj vissza, és érintsd meg a \"Folytatás\" gombot az iPhone-odon';
 
   @override
   String get recordingStartedSuccessfully => 'Felvétel sikeresen elindult!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Az engedély még nincs megadva. Kérlek, győződj meg róla, hogy engedélyezted a mikrofon hozzáférést, és újra megnyitottad az alkalmazást az órádon.';
+  String get permissionNotGrantedYet => 'Az engedély még nincs megadva. Kérlek, győződj meg róla, hogy engedélyezted a mikrofon hozzáférést, és újra megnyitottad az alkalmazást az órádon.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1971,8 +1921,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get actionItemsTitle => 'Teendők';
 
   @override
-  String get actionItemsDescription =>
-      'Érintsd meg a szerkesztéshez • Hosszan nyomd a kiválasztáshoz • Húzd a műveletekhez';
+  String get actionItemsDescription => 'Érintsd meg a szerkesztéshez • Hosszan nyomd a kiválasztáshoz • Húzd a műveletekhez';
 
   @override
   String get tabToDo => 'Tennivaló';
@@ -2038,8 +1987,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Készen állsz a teendőkre';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Az AI automatikusan kinyeri a feladatokat és teendőket a beszélgetéseidből. Itt jelennek meg, amikor létrejönnek.';
+  String get welcomeActionItemsDescription => 'Az AI automatikusan kinyeri a feladatokat és teendőket a beszélgetéseidből. Itt jelennek meg, amikor létrejönnek.';
 
   @override
   String get autoExtractionFeature => 'Automatikusan kinyerve a beszélgetésekből';
@@ -2235,15 +2183,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'BESZÉD ÉS ÁTÍRÁS';
 
   @override
-  String get languageSettingsHelperText =>
-      'Az alkalmazás nyelve megváltoztatja a menüket és gombokat. A beszéd nyelve befolyásolja, hogyan íródnak át a felvételei.';
+  String get languageSettingsHelperText => 'Az alkalmazás nyelve megváltoztatja a menüket és gombokat. A beszéd nyelve befolyásolja, hogyan íródnak át a felvételei.';
 
   @override
   String get translationNotice => 'Fordítási értesítés';
 
   @override
-  String get translationNoticeMessage =>
-      'Az Omi az elsődleges nyelvedre fordítja a beszélgetéseket. Bármikor frissítheted a Beállítások → Profilok menüpontban.';
+  String get translationNoticeMessage => 'Az Omi az elsődleges nyelvedre fordítja a beszélgetéseket. Bármikor frissítheted a Beállítások → Profilok menüpontban.';
 
   @override
   String get pleaseCheckInternetConnection => 'Kérjük, ellenőrizd az internetkapcsolatot, és próbáld újra';
@@ -2398,8 +2344,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Eszköz párosítás megszüntetése';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Ez megszünteti az eszköz párosítását, hogy egy másik telefonhoz csatlakozhasson. A Beállítások > Bluetooth menüpontba kell mennie, és el kell felejtenie az eszközt a folyamat befejezéséhez.';
+  String get unpairDeviceDialogMessage => 'Ez megszünteti az eszköz párosítását, hogy egy másik telefonhoz csatlakozhasson. A Beállítások > Bluetooth menüpontba kell mennie, és el kell felejtenie az eszközt a folyamat befejezéséhez.';
 
   @override
   String get unpair => 'Párosítás megszüntetése';
@@ -2565,8 +2510,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get howDoesItWork => 'Hogyan működik?';
 
   @override
-  String get sdCardSyncDescription =>
-      'Az SD kártya szinkronizálás importálja az emlékeidet az SD kártyáról az alkalmazásba';
+  String get sdCardSyncDescription => 'Az SD kártya szinkronizálás importálja az emlékeidet az SD kártyáról az alkalmazásba';
 
   @override
   String get checksForAudioFiles => 'Ellenőrzi a hangfájlokat az SD kártyán';
@@ -2581,8 +2525,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get youreAllSet => 'Készen állsz!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Üdvözöljük az Omi-ban! Az AI társad készen áll, hogy segítsen a beszélgetésekben, feladatokban és még sok másban.';
+  String get welcomeToOmiDescription => 'Üdvözöljük az Omi-ban! Az AI társad készen áll, hogy segítsen a beszélgetésekben, feladatokban és még sok másban.';
 
   @override
   String get startUsingOmi => 'Omi használatának megkezdése';
@@ -2661,8 +2604,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get reviewAndManageConversations => 'Tekintse át és kezelje rögzített beszélgetéseit';
 
   @override
-  String get startCapturingConversations =>
-      'Kezdje el rögzíteni a beszélgetéseket Omi eszközével, hogy itt láthassa őket.';
+  String get startCapturingConversations => 'Kezdje el rögzíteni a beszélgetéseket Omi eszközével, hogy itt láthassa őket.';
 
   @override
   String get useMobileAppToCapture => 'Használja mobilalkalmazását hang rögzítéséhez';
@@ -2719,8 +2661,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noTasksYet => 'Még nincsenek feladatok';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'A beszélgetésekből származó feladatok itt jelennek meg.\nKattintson a Létrehozás gombra egy manuális hozzáadásához.';
+  String get tasksFromConversationsWillAppear => 'A beszélgetésekből származó feladatok itt jelennek meg.\nKattintson a Létrehozás gombra egy manuális hozzáadásához.';
 
   @override
   String get monthJan => 'Jan';
@@ -2777,8 +2718,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteActionItem => 'Feladat törlése';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Biztosan törölni szeretné ezt a feladatot? Ez a művelet nem vonható vissza.';
+  String get deleteActionItemConfirmation => 'Biztosan törölni szeretné ezt a feladatot? Ez a művelet nem vonható vissza.';
 
   @override
   String get enterActionItemDescription => 'Adja meg a feladat leírását...';
@@ -2853,15 +2793,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get chatPrompt => 'Chat utasítás';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Egy fantasztikus alkalmazás vagy, a feladatod, hogy válaszolj a felhasználói kérdésekre és jól éreztess velük...';
+  String get chatPromptPlaceholder => 'Egy fantasztikus alkalmazás vagy, a feladatod, hogy válaszolj a felhasználói kérdésekre és jól éreztess velük...';
 
   @override
   String get conversationPrompt => 'Beszélgetési felszólítás';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Egy fantasztikus alkalmazás vagy, kapsz egy beszélgetés átírását és összefoglalóját...';
+  String get conversationPromptPlaceholder => 'Egy fantasztikus alkalmazás vagy, kapsz egy beszélgetés átírását és összefoglalóját...';
 
   @override
   String get notificationScopes => 'Értesítési körök';
@@ -2873,8 +2811,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get makeMyAppPublic => 'Tedd nyilvánossá az alkalmazásomat';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Az alkalmazás beküldésével elfogadom az Omi AI Szolgáltatási Feltételeit és Adatvédelmi Irányelveit';
+  String get submitAppTermsAgreement => 'Az alkalmazás beküldésével elfogadom az Omi AI Szolgáltatási Feltételeit és Adatvédelmi Irányelveit';
 
   @override
   String get submitApp => 'Alkalmazás beküldése';
@@ -2889,19 +2826,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get submitAppQuestion => 'Alkalmazás beküldése?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Alkalmazásod felülvizsgálásra kerül és nyilvánossá válik. Azonnal elkezdheted használni, még a felülvizsgálat alatt is!';
+  String get submitAppPublicDescription => 'Alkalmazásod felülvizsgálásra kerül és nyilvánossá válik. Azonnal elkezdheted használni, még a felülvizsgálat alatt is!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Alkalmazásod felülvizsgálásra kerül és privát módon elérhetővé válik számodra. Azonnal elkezdheted használni, még a felülvizsgálat alatt is!';
+  String get submitAppPrivateDescription => 'Alkalmazásod felülvizsgálásra kerül és privát módon elérhetővé válik számodra. Azonnal elkezdheted használni, még a felülvizsgálat alatt is!';
 
   @override
   String get startEarning => 'Kezdj el keresni! 💰';
 
   @override
-  String get connectStripeOrPayPal =>
-      'Csatlakoztasd a Stripe-ot vagy PayPalt, hogy fizetéseket fogadhass az alkalmazásodért.';
+  String get connectStripeOrPayPal => 'Csatlakoztasd a Stripe-ot vagy PayPalt, hogy fizetéseket fogadhass az alkalmazásodért.';
 
   @override
   String get connectNow => 'Csatlakoztatás most';
@@ -2919,23 +2853,19 @@ class AppLocalizationsHu extends AppLocalizations {
   String get dataAccessNotice => 'Adathozzáférési értesítés';
 
   @override
-  String get dataAccessWarning =>
-      'Ez az alkalmazás hozzáfér az adataihoz. Az Omi AI nem felelős azért, hogy ez az alkalmazás hogyan használja, módosítja vagy törli az adatait';
+  String get dataAccessWarning => 'Ez az alkalmazás hozzáfér az adataihoz. Az Omi AI nem felelős azért, hogy ez az alkalmazás hogyan használja, módosítja vagy törli az adatait';
 
   @override
   String get installApp => 'Alkalmazás telepítése';
 
   @override
-  String get betaTesterNotice =>
-      'Ön ennek az alkalmazásnak a béta tesztelője. Még nem nyilvános. Jóváhagyás után nyilvános lesz.';
+  String get betaTesterNotice => 'Ön ennek az alkalmazásnak a béta tesztelője. Még nem nyilvános. Jóváhagyás után nyilvános lesz.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Az alkalmazása felülvizsgálat alatt áll, és csak Ön számára látható. Jóváhagyás után nyilvános lesz.';
+  String get appUnderReviewOwner => 'Az alkalmazása felülvizsgálat alatt áll, és csak Ön számára látható. Jóváhagyás után nyilvános lesz.';
 
   @override
-  String get appRejectedNotice =>
-      'Az alkalmazását elutasították. Kérjük, frissítse az alkalmazás adatait, és küldje be újra felülvizsgálatra.';
+  String get appRejectedNotice => 'Az alkalmazását elutasították. Kérjük, frissítse az alkalmazás adatait, és küldje be újra felülvizsgálatra.';
 
   @override
   String get setupSteps => 'Beállítási lépések';
@@ -2970,8 +2900,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get errorActivatingApp => 'Hiba az alkalmazás aktiválása során';
 
   @override
-  String get integrationSetupRequired =>
-      'Ha ez egy integrációs alkalmazás, győződjön meg róla, hogy a beállítás befejeződött.';
+  String get integrationSetupRequired => 'Ha ez egy integrációs alkalmazás, győződjön meg róla, hogy a beállítás befejeződött.';
 
   @override
   String get installed => 'Telepítve';
@@ -2998,8 +2927,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get descriptionLabel => 'Leírás';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Nagyszerű alkalmazásom egy remek alkalmazás, amely csodálatos dolgokat tesz. Ez a legjobb alkalmazás!';
+  String get appDescriptionPlaceholder => 'Nagyszerű alkalmazásom egy remek alkalmazás, amely csodálatos dolgokat tesz. Ez a legjobb alkalmazás!';
 
   @override
   String get pleaseProvideValidDescription => 'Kérjük, adjon meg érvényes leírást';
@@ -3151,8 +3079,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get microphonePermissionRequired => 'Mikrofon engedély szükséges a hangfelvételhez.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofon engedély megtagadva. Kérjük, adjon engedélyt a Rendszerbeállítások > Adatvédelem és biztonság > Mikrofon alatt.';
+  String get microphonePermissionDenied => 'Mikrofon engedély megtagadva. Kérjük, adjon engedélyt a Rendszerbeállítások > Adatvédelem és biztonság > Mikrofon alatt.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3311,8 +3238,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get createMemory => 'Emlékezet létrehozása';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Biztosan törölni szeretnéd ezt az emlékezetet? Ez a művelet nem vonható vissza.';
+  String get deleteMemoryConfirmation => 'Biztosan törölni szeretnéd ezt az emlékezetet? Ez a művelet nem vonható vissza.';
 
   @override
   String get makePrivate => 'Priváttá tétel';
@@ -3386,8 +3312,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get whatWeCollect => 'Mit gyűjtünk';
 
   @override
-  String get dataCollectionMessage =>
-      'A folytatással beszélgetéseid, felvételeid és személyes adataid biztonságosan tárolódnak szervereiken, hogy AI-alapú betekintéseket nyújtsunk és engedélyezzük az összes app funkciót.';
+  String get dataCollectionMessage => 'A folytatással beszélgetéseid, felvételeid és személyes adataid biztonságosan tárolódnak szervereiken, hogy AI-alapú betekintéseket nyújtsunk és engedélyezzük az összes app funkciót.';
 
   @override
   String get dataProtection => 'Adatvédelem';
@@ -3420,8 +3345,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'A névnek legalább 2 karakterből kell állnia';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Mondja el nekünk, hogyan szeretné, ha megszólítanánk. Ez segít személyre szabni az Omi élményt.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Mondja el nekünk, hogyan szeretné, ha megszólítanánk. Ez segít személyre szabni az Omi élményt.';
 
   @override
   String charactersCount(int count) {
@@ -3438,8 +3362,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get recordAudioConversations => 'Hangbeszélgetések rögzítése';
 
   @override
-  String get microphoneAccessDescription =>
-      'Az Omi-nak mikrofon hozzáférésre van szüksége a beszélgetések rögzítéséhez és átirat készítéséhez.';
+  String get microphoneAccessDescription => 'Az Omi-nak mikrofon hozzáférésre van szüksége a beszélgetések rögzítéséhez és átirat készítéséhez.';
 
   @override
   String get screenRecording => 'Képernyőrögzítés';
@@ -3448,8 +3371,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Rendszerhang rögzítése találkozókból';
 
   @override
-  String get screenRecordingDescription =>
-      'Az Omi-nak képernyőrögzítési engedélyre van szüksége a rendszerhang rögzítéséhez a böngésző alapú találkozókból.';
+  String get screenRecordingDescription => 'Az Omi-nak képernyőrögzítési engedélyre van szüksége a rendszerhang rögzítéséhez a böngésző alapú találkozókból.';
 
   @override
   String get accessibility => 'Akadálymentesség';
@@ -3458,8 +3380,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Böngésző alapú találkozók észlelése';
 
   @override
-  String get accessibilityDescription =>
-      'Az Omi-nak akadálymentesítési engedélyre van szüksége annak észleléséhez, amikor csatlakozik Zoom, Meet vagy Teams találkozókhoz a böngészőjében.';
+  String get accessibilityDescription => 'Az Omi-nak akadálymentesítési engedélyre van szüksége annak észleléséhez, amikor csatlakozik Zoom, Meet vagy Teams találkozókhoz a böngészőjében.';
 
   @override
   String get pleaseWait => 'Kérem várjon...';
@@ -3528,12 +3449,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get exportAllConversationsToJson => 'Exportálja az összes beszélgetését JSON fájlba.';
 
   @override
-  String get conversationsExportStarted =>
-      'Beszélgetések exportálása elindult. Ez eltarthat néhány másodpercig, kérem várjon.';
+  String get conversationsExportStarted => 'Beszélgetések exportálása elindult. Ez eltarthat néhány másodpercig, kérem várjon.';
 
   @override
-  String get mcpDescription =>
-      'Az Omi más alkalmazásokhoz való csatlakoztatásához, hogy olvassa, keresse és kezelje az emlékeit és beszélgetéseit. Hozzon létre egy kulcsot az induláshoz.';
+  String get mcpDescription => 'Az Omi más alkalmazásokhoz való csatlakoztatásához, hogy olvassa, keresse és kezelje az emlékeit és beszélgetéseit. Hozzon létre egy kulcsot az induláshoz.';
 
   @override
   String get apiKeys => 'API kulcsok';
@@ -3574,8 +3493,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Átírási szolgáltatás diagnosztikai állapota';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Részletes diagnosztikai üzenetek engedélyezése az átírási szolgáltatástól';
+  String get enableDetailedDiagnosticMessages => 'Részletes diagnosztikai üzenetek engedélyezése az átírási szolgáltatástól';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Új beszélők automatikus létrehozása és címkézése';
@@ -3605,8 +3523,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get auto => 'Automatikus';
 
   @override
-  String get noSummaryForApp =>
-      'Nincs elérhető összefoglaló ehhez az alkalmazáshoz. Próbálj ki egy másik alkalmazást a jobb eredmények érdekében.';
+  String get noSummaryForApp => 'Nincs elérhető összefoglaló ehhez az alkalmazáshoz. Próbálj ki egy másik alkalmazást a jobb eredmények érdekében.';
 
   @override
   String get tryAnotherApp => 'Próbáljon ki egy másik alkalmazást';
@@ -3691,8 +3608,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Rendszer hangfelvétel előkészítése';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Kattintson a gombra hangfelvétel készítéséhez élő átiratok, AI betekintések és automatikus mentés céljából.';
+  String get clickTheButtonToCaptureAudio => 'Kattintson a gombra hangfelvétel készítéséhez élő átiratok, AI betekintések és automatikus mentés céljából.';
 
   @override
   String get reconnecting => 'Újracsatlakozás...';
@@ -3895,8 +3811,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get shortcuts => 'Gyorsbillentyűk';
 
   @override
-  String get shortcutChangeInstruction =>
-      'Kattintson egy gyorsbillentyűre a módosításához. Nyomja meg az Escape gombot a megszakításhoz.';
+  String get shortcutChangeInstruction => 'Kattintson egy gyorsbillentyűre a módosításához. Nyomja meg az Escape gombot a megszakításhoz.';
 
   @override
   String get configureSTTProvider => 'STT szolgáltató konfigurálása';
@@ -3920,8 +3835,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Törölni a tudásgráfot?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Ez törli az összes származtatott tudásgráf adatot. Az eredeti emlékei biztonságban maradnak.';
+  String get deleteKnowledgeGraphWarning => 'Ez törli az összes származtatott tudásgráf adatot. Az eredeti emlékei biztonságban maradnak.';
 
   @override
   String get connectOmiWithAI => 'Csatlakoztassa az Omi-t AI asszisztensekhez';
@@ -3963,8 +3877,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Feltételek és Adatvédelmi Irányelvek';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Segít a problémák diagnosztizálásában. 3 nap után automatikusan törlődik.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Segít a problémák diagnosztizálásában. 3 nap után automatikusan törlődik.';
 
   @override
   String get manageYourApp => 'Alkalmazás kezelése';
@@ -3979,8 +3892,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get updateAppQuestion => 'Alkalmazás frissítése?';
 
   @override
-  String get updateAppConfirmation =>
-      'Biztosan frissíteni szeretné az alkalmazást? A változtatások a csapatunk általi felülvizsgálat után lépnek érvénybe.';
+  String get updateAppConfirmation => 'Biztosan frissíteni szeretné az alkalmazást? A változtatások a csapatunk általi felülvizsgálat után lépnek érvénybe.';
 
   @override
   String get updateApp => 'Alkalmazás frissítése';
@@ -4010,8 +3922,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get no => 'Nem';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Előfizetés sikeresen lemondva. Az aktuális számlázási időszak végéig aktív marad.';
+  String get subscriptionCancelledSuccessfully => 'Előfizetés sikeresen lemondva. Az aktuális számlázási időszak végéig aktív marad.';
 
   @override
   String get failedToCancelSubscription => 'Az előfizetés lemondása sikertelen. Kérjük, próbálja újra.';
@@ -4047,8 +3958,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Előfizetés lemondása?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Biztosan le szeretné mondani az előfizetését? Az aktuális számlázási időszak végéig továbbra is hozzáférhet.';
+  String get cancelSubscriptionConfirmation => 'Biztosan le szeretné mondani az előfizetését? Az aktuális számlázási időszak végéig továbbra is hozzáférhet.';
 
   @override
   String get cancelSubscriptionButton => 'Előfizetés lemondása';
@@ -4057,12 +3967,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get cancelling => 'Lemondás...';
 
   @override
-  String get betaTesterMessage =>
-      'Ön ennek az alkalmazásnak a béta tesztelője. Még nem nyilvános. A jóváhagyás után lesz nyilvános.';
+  String get betaTesterMessage => 'Ön ennek az alkalmazásnak a béta tesztelője. Még nem nyilvános. A jóváhagyás után lesz nyilvános.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Az alkalmazása felülvizsgálat alatt áll és csak Ön láthatja. A jóváhagyás után lesz nyilvános.';
+  String get appUnderReviewMessage => 'Az alkalmazása felülvizsgálat alatt áll és csak Ön láthatja. A jóváhagyás után lesz nyilvános.';
 
   @override
   String get appRejectedMessage => 'Az alkalmazása el lett utasítva. Kérjük, frissítse az adatokat és küldje el újra.';
@@ -4119,8 +4027,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get issueActivatingApp => 'Probléma merült fel az alkalmazás aktiválásakor. Kérjük, próbálja újra.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Ez az alkalmazás hozzá fog férni az adataidhoz. Az Omi AI nem felelős azért, hogy ez az alkalmazás hogyan használja, módosítja vagy törli az adataidat';
+  String get dataAccessNoticeDescription => 'Ez az alkalmazás hozzá fog férni az adataidhoz. Az Omi AI nem felelős azért, hogy ez az alkalmazás hogyan használja, módosítja vagy törli az adataidat';
 
   @override
   String get copyUrl => 'URL másolása';
@@ -4208,8 +4115,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get omiApiKeys => 'Omi API-kulcsok';
 
   @override
-  String get apiKeysDescription =>
-      'Az API-kulcsokat hitelesítésre használják, amikor az alkalmazásod kommunikál az OMI szerverrel. Lehetővé teszik az alkalmazásod számára, hogy emlékeket hozzon létre és biztonságosan hozzáférjen más OMI szolgáltatásokhoz.';
+  String get apiKeysDescription => 'Az API-kulcsokat hitelesítésre használják, amikor az alkalmazásod kommunikál az OMI szerverrel. Lehetővé teszik az alkalmazásod számára, hogy emlékeket hozzon létre és biztonságosan hozzáférjen más OMI szolgáltatásokhoz.';
 
   @override
   String get aboutOmiApiKeys => 'Az Omi API-kulcsokról';
@@ -4233,8 +4139,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API-kulcs visszavonása?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Ez a művelet nem vonható vissza. Az ezt a kulcsot használó alkalmazások többé nem férhetnek hozzá az API-hoz.';
+  String get revokeApiKeyWarning => 'Ez a művelet nem vonható vissza. Az ezt a kulcsot használó alkalmazások többé nem férhetnek hozzá az API-hoz.';
 
   @override
   String get revoke => 'Visszavonás';
@@ -4332,8 +4237,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get externalAppAccess => 'Külső alkalmazás hozzáférés';
 
   @override
-  String get externalAppAccessDescription =>
-      'A következő telepített alkalmazásoknak külső integrációi vannak, és hozzáférhetnek az adataihoz, például beszélgetésekhez és emlékekhez.';
+  String get externalAppAccessDescription => 'A következő telepített alkalmazásoknak külső integrációi vannak, és hozzáférhetnek az adataihoz, például beszélgetésekhez és emlékekhez.';
 
   @override
   String get noExternalAppsHaveAccess => 'Egyetlen külső alkalmazásnak sincs hozzáférése az adataihoz.';
@@ -4342,8 +4246,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maximális biztonság (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'A végpontok közötti titkosítás a magánélet aranystandardja. Ha engedélyezve van, az adatait az eszközén titkosítjuk, mielőtt elküldenénk a szervereinkre. Ez azt jelenti, hogy senki, még az Omi sem férhet hozzá a tartalmához.';
+  String get e2eeDescription => 'A végpontok közötti titkosítás a magánélet aranystandardja. Ha engedélyezve van, az adatait az eszközén titkosítjuk, mielőtt elküldenénk a szervereinkre. Ez azt jelenti, hogy senki, még az Omi sem férhet hozzá a tartalmához.';
 
   @override
   String get importantTradeoffs => 'Fontos kompromisszumok:';
@@ -4358,8 +4261,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get featureComingSoon => 'Ez a funkció hamarosan érkezik!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migráció folyamatban. A védelmi szintet nem módosíthatja, amíg be nem fejeződik.';
+  String get migrationInProgressMessage => 'Migráció folyamatban. A védelmi szintet nem módosíthatja, amíg be nem fejeződik.';
 
   @override
   String get migrationFailed => 'A migráció sikertelen';
@@ -4378,19 +4280,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get secureEncryption => 'Biztonságos titkosítás';
 
   @override
-  String get secureEncryptionDescription =>
-      'Az adatait egy Önnek egyedi kulccsal titkosítjuk a szervereink, amelyek a Google Cloudon vannak. Ez azt jelenti, hogy a nyers tartalma senkinek sem hozzáférhető, beleértve az Omi személyzetét vagy a Google-t, közvetlenül az adatbázisból.';
+  String get secureEncryptionDescription => 'Az adatait egy Önnek egyedi kulccsal titkosítjuk a szervereink, amelyek a Google Cloudon vannak. Ez azt jelenti, hogy a nyers tartalma senkinek sem hozzáférhető, beleértve az Omi személyzetét vagy a Google-t, közvetlenül az adatbázisból.';
 
   @override
   String get endToEndEncryption => 'Végpontok közötti titkosítás';
 
   @override
-  String get e2eeCardDescription =>
-      'Engedélyezze a maximális biztonságot, ahol csak ön férhet hozzá adataihoz. Érintse meg a további információkért.';
+  String get e2eeCardDescription => 'Engedélyezze a maximális biztonságot, ahol csak ön férhet hozzá adataihoz. Érintse meg a további információkért.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'A szinttől függetlenül az adatai mindig titkosítva vannak nyugalmi állapotban és átvitel közben.';
+  String get dataAlwaysEncrypted => 'A szinttől függetlenül az adatai mindig titkosítva vannak nyugalmi állapotban és átvitel közben.';
 
   @override
   String get readOnlyScope => 'Csak olvasható';
@@ -4435,8 +4334,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get permissionsLabel => 'ENGEDÉLYEK';
 
   @override
-  String get permissionsInfoNote =>
-      'R = Olvasás, W = Írás. Alapértelmezés szerint csak olvasható, ha nincs semmi kiválasztva.';
+  String get permissionsInfoNote => 'R = Olvasás, W = Írás. Alapértelmezés szerint csak olvasható, ha nincs semmi kiválasztva.';
 
   @override
   String get developerApi => 'Fejlesztői API';
@@ -4456,12 +4354,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get trainingDataProgram => 'Képzési adatprogram';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Szerezze meg az Omi Unlimited-et ingyen, ha hozzájárul adataival az AI modellek képzéséhez.';
+  String get getOmiUnlimitedFree => 'Szerezze meg az Omi Unlimited-et ingyen, ha hozzájárul adataival az AI modellek képzéséhez.';
 
   @override
-  String get trainingDataBullets =>
-      '• Az adatai segítenek az AI modellek fejlesztésében\n• Csak nem érzékeny adatok kerülnek megosztásra\n• Teljesen átlátható folyamat';
+  String get trainingDataBullets => '• Az adatai segítenek az AI modellek fejlesztésében\n• Csak nem érzékeny adatok kerülnek megosztásra\n• Teljesen átlátható folyamat';
 
   @override
   String get learnMoreAtOmiTraining => 'További információ: omi.me/training';
@@ -4511,8 +4407,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get monthlyPlanContinues => 'Jelenlegi havi csomagja a számlázási időszak végéig folytatódik';
 
   @override
-  String get paymentMethodCharged =>
-      'A meglévő fizetési módja automatikusan terhelésre kerül, amikor a havi csomagja lejár';
+  String get paymentMethodCharged => 'A meglévő fizetési módja automatikusan terhelésre kerül, amikor a havi csomagja lejár';
 
   @override
   String get annualSubscriptionStarts => '12 hónapos éves előfizetése automatikusan elindul a terhelés után';
@@ -4622,8 +4517,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Adatai védelme fontos számunkra';
 
   @override
-  String get privacyIntroText =>
-      'Az Ominál nagyon komolyan vesszük az adatvédelmet. Átláthatóak szeretnénk lenni az általunk gyűjtött adatokról és azok felhasználásáról. Íme, amit tudnia kell:';
+  String get privacyIntroText => 'Az Ominál nagyon komolyan vesszük az adatvédelmet. Átláthatóak szeretnénk lenni az általunk gyűjtött adatokról és azok felhasználásáról. Íme, amit tudnia kell:';
 
   @override
   String get whatWeTrack => 'Mit követünk nyomon';
@@ -4638,12 +4532,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get ourCommitment => 'Elkötelezettségünk';
 
   @override
-  String get commitmentText =>
-      'Elkötelezettek vagyunk amellett, hogy az általunk gyűjtött adatokat csak arra használjuk, hogy az Omi jobb termék legyen az Ön számára. Adatainak védelme és bizalma kiemelten fontos számunkra.';
+  String get commitmentText => 'Elkötelezettek vagyunk amellett, hogy az általunk gyűjtött adatokat csak arra használjuk, hogy az Omi jobb termék legyen az Ön számára. Adatainak védelme és bizalma kiemelten fontos számunkra.';
 
   @override
-  String get thankYouText =>
-      'Köszönjük, hogy az Omi értékes felhasználója. Ha kérdése vagy aggálya van, forduljon hozzánk a team@basedhardware.com címen.';
+  String get thankYouText => 'Köszönjük, hogy az Omi értékes felhasználója. Ha kérdése vagy aggálya van, forduljon hozzánk a team@basedhardware.com címen.';
 
   @override
   String get wifiSyncSettings => 'WiFi szinkronizálás beállításai';
@@ -4652,8 +4544,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get enterHotspotCredentials => 'Adja meg telefonja hotspot hitelesítő adatait';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'A WiFi szinkronizálás a telefont hotspotként használja. A nevet és jelszót a Beállítások > Személyes hotspot menüben találja.';
+  String get wifiSyncUsesHotspot => 'A WiFi szinkronizálás a telefont hotspotként használja. A nevet és jelszót a Beállítások > Személyes hotspot menüben találja.';
 
   @override
   String get hotspotNameSsid => 'Hotspot neve (SSID)';
@@ -4688,8 +4579,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nem sikerült létrehozni az összefoglalót. Győződjön meg róla, hogy vannak beszélgetései aznap.';
+  String get failedToGenerateSummaryCheckConversations => 'Nem sikerült létrehozni az összefoglalót. Győződjön meg róla, hogy vannak beszélgetései aznap.';
 
   @override
   String get summaryNotFound => 'Összefoglaló nem található';
@@ -4719,8 +4609,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Exportálás elindítva. Ez eltarthat néhány másodpercig...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ez törli az összes származtatott tudásgráf adatot (csomópontokat és kapcsolatokat). Az eredeti emlékei biztonságban maradnak. A gráf idővel vagy a következő kérésnél újraépül.';
+  String get knowledgeGraphDeleteDescription => 'Ez törli az összes származtatott tudásgráf adatot (csomópontokat és kapcsolatokat). Az eredeti emlékei biztonságban maradnak. A gráf idővel vagy a következő kérésnél újraépül.';
 
   @override
   String get configureDailySummaryDigest => 'Állítsa be a napi feladatösszesítőt';
@@ -4790,8 +4679,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Törli az összes Limitless beszélgetést?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Ez véglegesen törli a Limitlessből importált összes beszélgetést. Ez a művelet nem vonható vissza.';
+  String get deleteAllLimitlessWarning => 'Ez véglegesen törli a Limitlessből importált összes beszélgetést. Ez a művelet nem vonható vissza.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4847,8 +4735,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get howItWorksTitle => 'Hogyan működik?';
 
   @override
-  String get howPeopleWorks =>
-      'Ha létrehoz egy személyt, elmehet egy beszélgetés átiratához, és hozzárendelheti a megfelelő szegmenseket, így az Omi képes lesz felismerni az ő beszédét is!';
+  String get howPeopleWorks => 'Ha létrehoz egy személyt, elmehet egy beszélgetés átiratához, és hozzárendelheti a megfelelő szegmenseket, így az Omi képes lesz felismerni az ő beszédét is!';
 
   @override
   String get tapToDelete => 'Koppintson a törléshez';
@@ -4874,8 +4761,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get privacyNotice => 'Adatvédelmi figyelmeztetés';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'A felvételek rögzíthetik mások hangját. A bekapcsolás előtt győződjön meg arról, hogy minden résztvevő beleegyezését megkapta.';
+  String get recordingsMayCaptureOthers => 'A felvételek rögzíthetik mások hangját. A bekapcsolás előtt győződjön meg arról, hogy minden résztvevő beleegyezését megkapta.';
 
   @override
   String get enable => 'Engedélyezés';
@@ -4887,8 +4773,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get on => 'Be';
 
   @override
-  String get storeAudioDescription =>
-      'Tartsa az összes hangfelvételt helyileg tárolva a telefonján. Letiltva csak a sikertelen feltöltések maradnak meg a tárhely megtakarítása érdekében.';
+  String get storeAudioDescription => 'Tartsa az összes hangfelvételt helyileg tárolva a telefonján. Letiltva csak a sikertelen feltöltések maradnak meg a tárhely megtakarítása érdekében.';
 
   @override
   String get enableLocalStorage => 'Helyi tárolás engedélyezése';
@@ -4906,12 +4791,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get storeAudioOnCloud => 'Hanganyag tárolása felhőben';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Valós idejű felvételei a beszéd közben privát felhőtárhelyen kerülnek tárolásra.';
+  String get cloudStorageDialogMessage => 'Valós idejű felvételei a beszéd közben privát felhőtárhelyen kerülnek tárolásra.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Tárolja valós idejű felvételeit privát felhőtárhelyen beszéd közben. A hang valós időben, biztonságosan rögzítésre és mentésre kerül.';
+  String get storeAudioCloudDescription => 'Tárolja valós idejű felvételeit privát felhőtárhelyen beszéd közben. A hang valós időben, biztonságosan rögzítésre és mentésre kerül.';
 
   @override
   String get downloadingFirmware => 'Firmware letöltése';
@@ -4920,8 +4803,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get installingFirmware => 'Firmware telepítése';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Ne zárja be az alkalmazást és ne kapcsolja ki az eszközt. Ez károsíthatja az eszközét.';
+  String get firmwareUpdateWarning => 'Ne zárja be az alkalmazást és ne kapcsolja ki az eszközt. Ez károsíthatja az eszközét.';
 
   @override
   String get firmwareUpdated => 'Firmware frissítve';
@@ -4965,8 +4847,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get payments => 'Fizetések';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Csatlakoztasson alább egy fizetési módot, hogy elkezdhesse fogadni a kifizetéseket az alkalmazásaiért.';
+  String get connectPaymentMethodInfo => 'Csatlakoztasson alább egy fizetési módot, hogy elkezdhesse fogadni a kifizetéseket az alkalmazásaiért.';
 
   @override
   String get selectedPaymentMethod => 'Kiválasztott fizetési mód';
@@ -4993,15 +4874,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get monthlyPayouts => 'Havi kifizetések';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Kapjon havi kifizetéseket közvetlenül a számlájára, amikor eléri a 10 \$ bevételt';
+  String get monthlyPayoutsDescription => 'Kapjon havi kifizetéseket közvetlenül a számlájára, amikor eléri a 10 \$ bevételt';
 
   @override
   String get secureAndReliable => 'Biztonságos és megbízható';
 
   @override
-  String get stripeSecureDescription =>
-      'A Stripe biztonságos és időben történő átutalásokat biztosít az alkalmazás bevételeihez';
+  String get stripeSecureDescription => 'A Stripe biztonságos és időben történő átutalásokat biztosít az alkalmazás bevételeihez';
 
   @override
   String get selectYourCountry => 'Válassza ki az országát';
@@ -5022,8 +4901,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get connectingYourStripeAccount => 'Stripe fiókjának csatlakoztatása';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Kérjük, fejezze be a Stripe bevezetési folyamatot a böngészőjében. Ez az oldal automatikusan frissül a befejezés után.';
+  String get stripeOnboardingInstructions => 'Kérjük, fejezze be a Stripe bevezetési folyamatot a böngészőjében. Ez az oldal automatikusan frissül a befejezés után.';
 
   @override
   String get failedTryAgain => 'Sikertelen? Próbálja újra';
@@ -5035,8 +4913,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get successfullyConnected => 'Sikeresen csatlakoztatva!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Stripe-fiókja készen áll a kifizetések fogadására. Azonnal elkezdheti a keresést az alkalmazás-eladásaiból.';
+  String get stripeReadyForPayments => 'Stripe-fiókja készen áll a kifizetések fogadására. Azonnal elkezdheti a keresést az alkalmazás-eladásaiból.';
 
   @override
   String get updateStripeDetails => 'Stripe adatok frissítése';
@@ -5054,8 +4931,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Frissítse PayPal-fiókja adatait';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Csatlakoztassa PayPal-fiókját, hogy elkezdhesse fogadni a kifizetéseket az alkalmazásaiért';
+  String get connectPayPalToReceivePayments => 'Csatlakoztassa PayPal-fiókját, hogy elkezdhesse fogadni a kifizetéseket az alkalmazásaiért';
 
   @override
   String get paypalEmail => 'PayPal e-mail';
@@ -5064,8 +4940,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me link';
 
   @override
-  String get stripeRecommendation =>
-      'Ha a Stripe elérhető az Ön országában, erősen javasoljuk, hogy használja a gyorsabb és egyszerűbb kifizetésekhez.';
+  String get stripeRecommendation => 'Ha a Stripe elérhető az Ön országában, erősen javasoljuk, hogy használja a gyorsabb és egyszerűbb kifizetésekhez.';
 
   @override
   String get updatePayPalDetails => 'PayPal adatok frissítése';
@@ -5117,12 +4992,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'További hangminta eltávolítva';
 
   @override
-  String get consentDataMessage =>
-      'A folytatással beszélgetéseit, felvételeit és személyes adatait biztonságosan tároljuk szervereinken. Hangfelvételeit és átiratait harmadik féltől származó AI szolgáltatások dolgozzák fel (beleértve a Deepgramot az átíráshoz és az OpenAI-t az elemzéshez), hogy AI-alapú betekintéseket nyújtsunk Önnek és az alkalmazás összes funkcióját biztosítsuk.';
+  String get consentDataMessage => 'A folytatással beszélgetéseit, felvételeit és személyes adatait biztonságosan tároljuk szervereinken. Hangfelvételeit és átiratait harmadik féltől származó AI szolgáltatások dolgozzák fel (beleértve a Deepgramot az átíráshoz és az OpenAI-t az elemzéshez), hogy AI-alapú betekintéseket nyújtsunk Önnek és az alkalmazás összes funkcióját biztosítsuk.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'A beszélgetéseidből származó feladatok itt jelennek meg.\nKoppints a + gombra manuális létrehozáshoz.';
+  String get tasksEmptyStateMessage => 'A beszélgetéseidből származó feladatok itt jelennek meg.\nKoppints a + gombra manuális létrehozáshoz.';
 
   @override
   String get clearChatAction => 'Chat törlése';
@@ -5158,15 +5031,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Telepítse az Omit az\nApple Watch-ra';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Az Apple Watch Omival való használatához először telepítenie kell az Omi alkalmazást az órájára.';
+  String get installOmiOnAppleWatchDescription => 'Az Apple Watch Omival való használatához először telepítenie kell az Omi alkalmazást az órájára.';
 
   @override
   String get openOmiOnAppleWatch => 'Nyissa meg az Omit az\nApple Watch-on';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Az Omi alkalmazás telepítve van az Apple Watch-ra. Nyissa meg és érintse meg a Start gombot.';
+  String get openOmiOnAppleWatchDescription => 'Az Omi alkalmazás telepítve van az Apple Watch-ra. Nyissa meg és érintse meg a Start gombot.';
 
   @override
   String get openWatchApp => 'Watch alkalmazás megnyitása';
@@ -5175,15 +5046,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Telepítettem és megnyitottam az alkalmazást';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Nem sikerült megnyitni az Apple Watch alkalmazást. Nyissa meg manuálisan a Watch alkalmazást az Apple Watch-on, és telepítse az Omit az \"Elérhető alkalmazások\" részből.';
+  String get unableToOpenWatchApp => 'Nem sikerült megnyitni az Apple Watch alkalmazást. Nyissa meg manuálisan a Watch alkalmazást az Apple Watch-on, és telepítse az Omit az \"Elérhető alkalmazások\" részből.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch sikeresen csatlakoztatva!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Az Apple Watch még nem érhető el. Győződjön meg róla, hogy az Omi alkalmazás nyitva van az óráján.';
+  String get appleWatchNotReachable => 'Az Apple Watch még nem érhető el. Győződjön meg róla, hogy az Omi alkalmazás nyitva van az óráján.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5200,8 +5069,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get finishedConversation => 'Beszélgetés befejezve?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Biztosan le szeretné állítani a felvételt és most összefoglalni a beszélgetést?';
+  String get stopRecordingConfirmation => 'Biztosan le szeretné állítani a felvételt és most összefoglalni a beszélgetést?';
 
   @override
   String get conversationEndsManually => 'A beszélgetés csak manuálisan fejeződik be.';
@@ -5271,8 +5139,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get welcomeBackSimple => 'Üdv újra';
 
   @override
-  String get addVocabularyDescription =>
-      'Adjon hozzá szavakat, amelyeket az Omi-nak fel kell ismernie az átírás során.';
+  String get addVocabularyDescription => 'Adjon hozzá szavakat, amelyeket az Omi-nak fel kell ismernie az átírás során.';
 
   @override
   String get enterWordsCommaSeparated => 'Adja meg a szavakat (vesszővel elválasztva)';
@@ -5613,8 +5480,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get multipleSpeakersDetected => 'Több beszélő észlelve';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Úgy tűnik, hogy több beszélő van a felvételen. Győződjön meg róla, hogy csendes helyen van, és próbálja újra.';
+  String get multipleSpeakersDescription => 'Úgy tűnik, hogy több beszélő van a felvételen. Győződjön meg róla, hogy csendes helyen van, és próbálja újra.';
 
   @override
   String get invalidRecordingDetected => 'Érvénytelen felvétel észlelve';
@@ -5623,19 +5489,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get notEnoughSpeechDescription => 'Nem észleltünk elég beszédet. Kérjük, beszéljen többet és próbálja újra.';
 
   @override
-  String get speechDurationDescription =>
-      'Győződjön meg róla, hogy legalább 5 másodpercig és legfeljebb 90 másodpercig beszél.';
+  String get speechDurationDescription => 'Győződjön meg róla, hogy legalább 5 másodpercig és legfeljebb 90 másodpercig beszél.';
 
   @override
-  String get connectionLostDescription =>
-      'A kapcsolat megszakadt. Kérjük, ellenőrizze az internetkapcsolatát és próbálja újra.';
+  String get connectionLostDescription => 'A kapcsolat megszakadt. Kérjük, ellenőrizze az internetkapcsolatát és próbálja újra.';
 
   @override
   String get howToTakeGoodSample => 'Hogyan készítsünk jó mintát?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Győződjön meg róla, hogy csendes helyen van.\n2. Beszéljen tisztán és természetesen.\n3. Győződjön meg róla, hogy készüléke természetes helyzetben van a nyakán.\n\nHa elkészült, mindig javíthatja vagy újra elkészítheti.';
+  String get goodSampleInstructions => '1. Győződjön meg róla, hogy csendes helyen van.\n2. Beszéljen tisztán és természetesen.\n3. Győződjön meg róla, hogy készüléke természetes helyzetben van a nyakán.\n\nHa elkészült, mindig javíthatja vagy újra elkészítheti.';
 
   @override
   String get noDeviceConnectedUseMic => 'Nincs csatlakoztatott eszköz. A telefon mikrofonját használjuk.';
@@ -5698,12 +5561,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get howItWorks => 'Hogyan működik';
 
   @override
-  String get dailyScoreExplanation =>
-      'A napi pontszáma a feladatok befejezésén alapul. Fejezze be feladatait a pontszám javításához!';
+  String get dailyScoreExplanation => 'A napi pontszáma a feladatok befejezésén alapul. Fejezze be feladatait a pontszám javításához!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Szabályozd, milyen gyakran küld az Omi proaktív értesítéseket és emlékeztetőket.';
+  String get notificationFrequencyDescription => 'Szabályozd, milyen gyakran küld az Omi proaktív értesítéseket és emlékeztetőket.';
 
   @override
   String get sliderOff => 'Ki';
@@ -5717,8 +5578,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Nem sikerült összefoglalót generálni. Győződj meg róla, hogy vannak beszélgetések arra a napra.';
+  String get failedToGenerateSummary => 'Nem sikerült összefoglalót generálni. Győződj meg róla, hogy vannak beszélgetések arra a napra.';
 
   @override
   String get recap => 'Összefoglaló';
@@ -5797,8 +5657,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get selectApp => 'Alkalmazás kiválasztása';
 
   @override
-  String get noChatAppsEnabled =>
-      'Nincs engedélyezett chat alkalmazás.\nKoppintson az \"Alkalmazások engedélyezése\" gombra a hozzáadáshoz.';
+  String get noChatAppsEnabled => 'Nincs engedélyezett chat alkalmazás.\nKoppintson az \"Alkalmazások engedélyezése\" gombra a hozzáadáshoz.';
 
   @override
   String get disable => 'Letiltás';
@@ -5950,8 +5809,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get recordings => 'Felvételek';
 
   @override
-  String get enableRemindersAccess =>
-      'Kérjük, engedélyezze az Emlékeztetők hozzáférést a Beállításokban az Apple Emlékeztetők használatához';
+  String get enableRemindersAccess => 'Kérjük, engedélyezze az Emlékeztetők hozzáférést a Beállításokban az Apple Emlékeztetők használatához';
 
   @override
   String todayAtTime(String time) {
@@ -6086,8 +5944,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get viewUsage => 'Használat megtekintése';
 
   @override
-  String get localProcessingInfo =>
-      'A hang helyben kerül feldolgozásra. Offline működik, több adatvédelmet biztosít, de több akkumulátort fogyaszt.';
+  String get localProcessingInfo => 'A hang helyben kerül feldolgozásra. Offline működik, több adatvédelmet biztosít, de több akkumulátort fogyaszt.';
 
   @override
   String get model => 'Modell';
@@ -6096,15 +5953,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get performanceWarning => 'Teljesítmény figyelmeztetés';
 
   @override
-  String get largeModelWarning =>
-      'Ez a modell nagy méretű, és mobileszközökön összeomolhat az alkalmazás, vagy nagyon lassan futhat.\n\nA \"small\" vagy \"base\" ajánlott.';
+  String get largeModelWarning => 'Ez a modell nagy méretű, és mobileszközökön összeomolhat az alkalmazás, vagy nagyon lassan futhat.\n\nA \"small\" vagy \"base\" ajánlott.';
 
   @override
   String get usingNativeIosSpeech => 'Natív iOS beszédfelismerés használata';
 
   @override
-  String get noModelDownloadRequired =>
-      'Készüléke natív beszédfelismerő motorja lesz használva. Nincs szükség modell letöltésére.';
+  String get noModelDownloadRequired => 'Készüléke natív beszédfelismerő motorja lesz használva. Nincs szükség modell letöltésére.';
 
   @override
   String get modelReady => 'Modell kész';
@@ -6164,8 +6019,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get premiumMinutesMonth => '1200 prémium perc/hónap. Az Eszközön fül korlátlan ingyenes átírást kínál. ';
 
   @override
-  String get audioProcessedLocally =>
-      'A hang helyileg kerül feldolgozásra. Offline működik, privátabb, de több akkumulátort használ.';
+  String get audioProcessedLocally => 'A hang helyileg kerül feldolgozásra. Offline működik, privátabb, de több akkumulátort használ.';
 
   @override
   String get languageLabel => 'Nyelv';
@@ -6174,12 +6028,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get modelLabel => 'Modell';
 
   @override
-  String get modelTooLargeWarning =>
-      'Ez a modell nagy, és az alkalmazás összeomlását vagy nagyon lassú működését okozhatja mobileszközökön.\n\nA small vagy base ajánlott.';
+  String get modelTooLargeWarning => 'Ez a modell nagy, és az alkalmazás összeomlását vagy nagyon lassú működését okozhatja mobileszközökön.\n\nA small vagy base ajánlott.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Az eszközöd natív beszédmotorja lesz használva. Nem szükséges modell letöltése.';
+  String get nativeEngineNoDownload => 'Az eszközöd natív beszédmotorja lesz használva. Nem szükséges modell letöltése.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6215,8 +6067,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Az Omi beépített élő átírása valós idejű beszélgetésekre van optimalizálva automatikus beszélő-felismeréssel és diarizációval.';
+  String get omiTranscriptionOptimized => 'Az Omi beépített élő átírása valós idejű beszélgetésekre van optimalizálva automatikus beszélő-felismeréssel és diarizációval.';
 
   @override
   String get reset => 'Visszaállítás';
@@ -6436,8 +6287,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Tudásgráf építése az emlékekből...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'A tudásgráfja automatikusan felépül, amikor új emlékeket hoz létre.';
+  String get knowledgeGraphWillBuildAutomatically => 'A tudásgráfja automatikusan felépül, amikor új emlékeket hoz létre.';
 
   @override
   String get buildGraphButton => 'Gráf építése';
@@ -6673,8 +6523,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get failedToLoadContacts => 'A névjegyek betöltése sikertelen';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'A beszélgetés előkészítése a megosztáshoz sikertelen. Kérjük, próbálja újra.';
+  String get failedToPrepareConversationForSharing => 'A beszélgetés előkészítése a megosztáshoz sikertelen. Kérjük, próbálja újra.';
 
   @override
   String get couldNotOpenSmsApp => 'Az SMS alkalmazás nem nyitható meg. Kérjük, próbálja újra.';
@@ -6740,8 +6589,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Hanganyag letöltése az eszközöd SD kártyájáról';
 
   @override
-  String get transferRequiredDescription =>
-      'Ez a felvétel az eszközöd SD kártyáján van tárolva. Vidd át a telefonodra a lejátszáshoz vagy megosztáshoz.';
+  String get transferRequiredDescription => 'Ez a felvétel az eszközöd SD kártyáján van tárolva. Vidd át a telefonodra a lejátszáshoz vagy megosztáshoz.';
 
   @override
   String get cancelTransfer => 'Átvitel megszakítása';
@@ -6762,8 +6610,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get shareRecording => 'Felvétel megosztása';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Biztosan véglegesen törölni szeretnéd ezt a felvételt? Ez nem vonható vissza.';
+  String get deleteRecordingConfirmation => 'Biztosan véglegesen törölni szeretnéd ezt a felvételt? Ez nem vonható vissza.';
 
   @override
   String get recordingIdLabel => 'Felvétel azonosító';
@@ -6822,15 +6669,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get enableFastTransfer => 'Gyors átvitel engedélyezése';
 
   @override
-  String get fastTransferDescription =>
-      'A gyors átvitel WiFi-t használ ~5x gyorsabb sebességekhez. A telefonja ideiglenesen csatlakozik az Omi eszköz WiFi hálózatához az átvitel során.';
+  String get fastTransferDescription => 'A gyors átvitel WiFi-t használ ~5x gyorsabb sebességekhez. A telefonja ideiglenesen csatlakozik az Omi eszköz WiFi hálózatához az átvitel során.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Az internetelérés szünetel az átvitel alatt';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Válassza ki, hogyan kerüljenek át a felvételek az Omi eszközről a telefonjára.';
+  String get chooseTransferMethodDescription => 'Válassza ki, hogyan kerüljenek át a felvételek az Omi eszközről a telefonjára.';
 
   @override
   String get wifiSpeed => '~150 KB/s WiFi-n keresztül';
@@ -6839,8 +6684,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fiveTimesFaster => '5X GYORSABB';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Közvetlen WiFi kapcsolatot hoz létre az Omi eszközével. A telefonja ideiglenesen lecsatlakozik a szokásos WiFi-ről az átvitel alatt.';
+  String get fastTransferMethodDescription => 'Közvetlen WiFi kapcsolatot hoz létre az Omi eszközével. A telefonja ideiglenesen lecsatlakozik a szokásos WiFi-ről az átvitel alatt.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6849,8 +6693,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get bleSpeed => '~30 KB/s BLE-n keresztül';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Szabványos Bluetooth Low Energy kapcsolatot használ. Lassabb, de nem befolyásolja a WiFi kapcsolatot.';
+  String get bluetoothMethodDescription => 'Szabványos Bluetooth Low Energy kapcsolatot használ. Lassabb, de nem befolyásolja a WiFi kapcsolatot.';
 
   @override
   String get selected => 'Kiválasztva';
@@ -6888,12 +6731,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get appDeleteFailed => 'Nem sikerült törölni az alkalmazást. Kérjük, próbáld újra később.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Az alkalmazás láthatósága sikeresen megváltozott. Néhány percig eltarthat, amíg érvénybe lép.';
+  String get appVisibilityChangedSuccessfully => 'Az alkalmazás láthatósága sikeresen megváltozott. Néhány percig eltarthat, amíg érvénybe lép.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Hiba az alkalmazás aktiválásakor. Ha integrációs alkalmazásról van szó, győződj meg róla, hogy a beállítás befejeződött.';
+  String get errorActivatingAppIntegration => 'Hiba az alkalmazás aktiválásakor. Ha integrációs alkalmazásról van szó, győződj meg róla, hogy a beállítás befejeződött.';
 
   @override
   String get errorUpdatingAppStatus => 'Hiba történt az alkalmazás állapotának frissítése közben.';
@@ -6961,8 +6802,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get importantConversationTitle => 'Fontos beszélgetés';
 
   @override
-  String get importantConversationBody =>
-      'Most volt egy fontos beszélgetésed. Érintsd meg az összefoglaló megosztásához.';
+  String get importantConversationBody => 'Most volt egy fontos beszélgetésed. Érintsd meg az összefoglaló megosztásához.';
 
   @override
   String get templateName => 'Sablon neve';
@@ -6974,8 +6814,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'A névnek legalább 3 karakterből kell állnia';
 
   @override
-  String get conversationPromptHint =>
-      'pl. Nyerje ki a feladatpontokat, döntéseket és fő tanulságokat a beszélgetésből.';
+  String get conversationPromptHint => 'pl. Nyerje ki a feladatpontokat, döntéseket és fő tanulságokat a beszélgetésből.';
 
   @override
   String get pleaseEnterAppPrompt => 'Kérjük, adjon meg egy promptot az alkalmazásához';
@@ -7162,15 +7001,13 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Frissítés ütemezve! A havi csomagod a számlázási időszak végéig folytatódik, majd automatikusan átvált évesre.';
+  String get planUpgradeScheduledMessage => 'Frissítés ütemezve! A havi csomagod a számlázási időszak végéig folytatódik, majd automatikusan átvált évesre.';
 
   @override
   String get couldNotSchedulePlanChange => 'A csomagváltás ütemezése sikertelen. Kérlek, próbáld újra.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Az előfizetésed újra aktiválva! Most nincs díj - a jelenlegi időszak végén leszel számlázva.';
+  String get subscriptionReactivatedDefault => 'Az előfizetésed újra aktiválva! Most nincs díj - a jelenlegi időszak végén leszel számlázva.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Sikeres előfizetés! A számlázás megtörtént az új számlázási időszakra.';
@@ -7353,8 +7190,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Bluetooth-engedély szükséges az eszközhöz való csatlakozáshoz.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth-engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállításokban.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth-engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállításokban.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7367,12 +7203,10 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Értesítési engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállításokban.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Értesítési engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállításokban.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Értesítési engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállítások > Értesítések menüpontban.';
+  String get onboardingNotificationDeniedNotifications => 'Értesítési engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállítások > Értesítések menüpontban.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7385,15 +7219,13 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Kérjük, adja meg a helymeghatározási engedélyt a Beállítások > Adatvédelem és biztonság > Helyszolgáltatások menüpontban';
+  String get onboardingLocationGrantInSettings => 'Kérjük, adja meg a helymeghatározási engedélyt a Beállítások > Adatvédelem és biztonság > Helyszolgáltatások menüpontban';
 
   @override
   String get onboardingMicrophoneRequired => 'Mikrofon-engedély szükséges a felvételhez.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofon-engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállítások > Adatvédelem és biztonság > Mikrofon menüpontban.';
+  String get onboardingMicrophoneDenied => 'Mikrofon-engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállítások > Adatvédelem és biztonság > Mikrofon menüpontban.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7409,8 +7241,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Képernyőrögzítési engedély szükséges a rendszerhang rögzítéséhez.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Képernyőrögzítési engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállítások > Adatvédelem és biztonság > Képernyőfelvétel menüpontban.';
+  String get onboardingScreenCaptureDenied => 'Képernyőrögzítési engedély megtagadva. Kérjük, adja meg az engedélyt a Rendszerbeállítások > Adatvédelem és biztonság > Képernyőfelvétel menüpontban.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7423,8 +7254,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Akadálymentesítési engedély szükséges a böngészőtalálkozók észleléséhez.';
+  String get onboardingAccessibilityRequired => 'Akadálymentesítési engedély szükséges a böngészőtalálkozók észleléséhez.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7440,8 +7270,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get msgCameraNotAvailable => 'A kamerarögzítés nem érhető el ezen a platformon';
 
   @override
-  String get msgCameraPermissionDenied =>
-      'Kamera engedély megtagadva. Kérjük, engedélyezze a kamerához való hozzáférést';
+  String get msgCameraPermissionDenied => 'Kamera engedély megtagadva. Kérjük, engedélyezze a kamerához való hozzáférést';
 
   @override
   String msgCameraAccessError(String error) {
@@ -7465,8 +7294,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Fényképek engedély megtagadva. Kérjük, engedélyezze a fényképekhez való hozzáférést a képek kiválasztásához';
+  String get msgPhotosPermissionDenied => 'Fényképek engedély megtagadva. Kérjük, engedélyezze a fényképekhez való hozzáférést a képek kiválasztásához';
 
   @override
   String get msgSelectImagesGenericError => 'Hiba a képek kiválasztásakor. Kérjük, próbálja újra.';
@@ -7538,8 +7366,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get locationPermissionRequired => 'Helymeghatározási engedély szükséges';
 
   @override
-  String get locationPermissionContent =>
-      'A gyors átvitelhez helymeghatározási engedély szükséges a WiFi-kapcsolat ellenőrzéséhez. Kérjük, adja meg a helymeghatározási engedélyt a folytatáshoz.';
+  String get locationPermissionContent => 'A gyors átvitelhez helymeghatározási engedély szükséges a WiFi-kapcsolat ellenőrzéséhez. Kérjük, adja meg a helymeghatározási engedélyt a folytatáshoz.';
 
   @override
   String get pdfTranscriptExport => 'Átirat exportálása';
@@ -7702,8 +7529,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Az eszköz nem támogatja a WiFi szinkronizálást, váltás Bluetooth-ra';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Az eszköz nem támogatja a WiFi szinkronizálást, váltás Bluetooth-ra';
 
   @override
   String get appleHealthNotAvailable => 'Az Apple Health nem érhető el ezen az eszközön';
@@ -7999,8 +7825,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Állítsa Omi DevKit-et párosítási módba';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Nyomja meg a gombot egyszer a bekapcsoláshoz. A LED lilán villog párosítási módban.';
+  String get pairingDescOmiDevkit => 'Nyomja meg a gombot egyszer a bekapcsoláshoz. A LED lilán villog párosítási módban.';
 
   @override
   String get pairingTitleOmiGlass => 'Kapcsolja be az Omi Glass-t';
@@ -8012,8 +7837,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Állítsa Plaud Note-ot párosítási módba';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Tartsa nyomva az oldalgombot 2 másodpercig. A piros LED villogni kezd, amikor párosításra kész.';
+  String get pairingDescPlaudNote => 'Tartsa nyomva az oldalgombot 2 másodpercig. A piros LED villogni kezd, amikor párosításra kész.';
 
   @override
   String get pairingTitleBee => 'Állítsa Bee-t párosítási módba';
@@ -8025,15 +7849,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get pairingTitleLimitless => 'Állítsa Limitless-t párosítási módba';
 
   @override
-  String get pairingDescLimitless =>
-      'Amikor bármilyen fény látható, nyomja meg egyszer, majd tartsa nyomva, amíg az eszköz rózsaszín fényt nem mutat, majd engedje el.';
+  String get pairingDescLimitless => 'Amikor bármilyen fény látható, nyomja meg egyszer, majd tartsa nyomva, amíg az eszköz rózsaszín fényt nem mutat, majd engedje el.';
 
   @override
   String get pairingTitleFriendPendant => 'Állítsa Friend Pendant-et párosítási módba';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Nyomja meg a gombot a medálon a bekapcsoláshoz. Automatikusan párosítási módba lép.';
+  String get pairingDescFriendPendant => 'Nyomja meg a gombot a medálon a bekapcsoláshoz. Automatikusan párosítási módba lép.';
 
   @override
   String get pairingTitleFieldy => 'Állítsa Fieldy-t párosítási módba';
@@ -8045,15 +7867,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch csatlakoztatása';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Telepítse és nyissa meg az Omi alkalmazást Apple Watch-ján, majd koppintson a Csatlakozás gombra az alkalmazásban.';
+  String get pairingDescAppleWatch => 'Telepítse és nyissa meg az Omi alkalmazást Apple Watch-ján, majd koppintson a Csatlakozás gombra az alkalmazásban.';
 
   @override
   String get pairingTitleNeoOne => 'Állítsa Neo One-t párosítási módba';
 
   @override
-  String get pairingDescNeoOne =>
-      'Tartsa nyomva a bekapcsoló gombot, amíg a LED villogni nem kezd. Az eszköz felfedezhető lesz.';
+  String get pairingDescNeoOne => 'Tartsa nyomva a bekapcsoló gombot, amíg a LED villogni nem kezd. Az eszköz felfedezhető lesz.';
 
   @override
   String get downloadingFromDevice => 'Letöltés az eszközről';
@@ -8170,8 +7990,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get switchAndRestart => 'Váltás';
 
   @override
-  String get stagingDisclaimer =>
-      'A tesztkörnyezet instabil lehet, teljesítménye változó, és az adatok elveszhetnek. Csak tesztelésre.';
+  String get stagingDisclaimer => 'A tesztkörnyezet instabil lehet, teljesítménye változó, és az adatok elveszhetnek. Csak tesztelésre.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Mentve. Zárd be és nyisd újra az alkalmazást a módosítások alkalmazásához.';
@@ -8400,8 +8219,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonhívások az Omi-n keresztül';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Hívjon az Omi-n keresztül, és kapjon valós idejű átírást, automatikus összefoglalókat és még többet.';
+  String get phoneCallsUpsellSubtitle => 'Hívjon az Omi-n keresztül, és kapjon valós idejű átírást, automatikus összefoglalókat és még többet.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Minden hívás valós idejű átírása';
@@ -8428,8 +8246,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteSyncedFiles => 'Szinkronizált felvételek törlése';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Ezek a felvételek már szinkronizálva vannak a telefonjával. Ez nem vonható vissza.';
+  String get deleteSyncedFilesMessage => 'Ezek a felvételek már szinkronizálva vannak a telefonjával. Ez nem vonható vissza.';
 
   @override
   String get syncedFilesDeleted => 'Szinkronizált felvételek törölve';
@@ -8441,8 +8258,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deletePendingFiles => 'Függő felvételek törlése';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Ezek a felvételek NINCSENEK szinkronizálva a telefonjával és véglegesen elvesznek. Ez nem vonható vissza.';
+  String get deletePendingFilesWarning => 'Ezek a felvételek NINCSENEK szinkronizálva a telefonjával és véglegesen elvesznek. Ez nem vonható vissza.';
 
   @override
   String get pendingFilesDeleted => 'Függő felvételek törölve';
@@ -8454,8 +8270,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deleteAll => 'Összes törlése';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Ez törli a szinkronizált és függő felvételeket. A függő felvételek NINCSENEK szinkronizálva és véglegesen elvesznek.';
+  String get deleteAllFilesWarning => 'Ez törli a szinkronizált és függő felvételeket. A függő felvételek NINCSENEK szinkronizálva és véglegesen elvesznek.';
 
   @override
   String get allFilesDeleted => 'Összes felvétel törölve';
@@ -8520,8 +8335,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fairUseAboutTitle => 'A méltányos használatról';
 
   @override
-  String get fairUseAboutBody =>
-      'Az Omi személyes beszélgetésekhez, megbeszélésekhez és élő interakciókhoz készült. A használatot a ténylegesen észlelt beszédidő alapján mérik, nem a csatlakozási idő alapján. Ha a használat jelentősen meghaladja a nem személyes tartalom normális mintáit, módosítások alkalmazhatók.';
+  String get fairUseAboutBody => 'Az Omi személyes beszélgetésekhez, megbeszélésekhez és élő interakciókhoz készült. A használatot a ténylegesen észlelt beszédidő alapján mérik, nem a csatlakozási idő alapján. Ha a használat jelentősen meghaladja a nem személyes tartalom normális mintáit, módosítások alkalmazhatók.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8559,8 +8373,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get improveConnectionTitle => 'Kapcsolat javítása';
 
   @override
-  String get improveConnectionContent =>
-      'Javítottuk, hogyan marad az Omi csatlakozva az eszközödhöz. Az aktiváláshoz menj az Eszközinfo oldalra, koppints az \"Eszköz leválasztása\" gombra, majd párosítsd újra az eszközödet.';
+  String get improveConnectionContent => 'Javítottuk, hogyan marad az Omi csatlakozva az eszközödhöz. Az aktiváláshoz menj az Eszközinfo oldalra, koppints az \"Eszköz leválasztása\" gombra, majd párosítsd újra az eszközödet.';
 
   @override
   String get improveConnectionAction => 'Értem';
@@ -8615,16 +8428,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get cancelSyncQuestion => 'Szinkronizálás megszakítása?';
 
   @override
-  String get omisStorageDesc =>
-      'Amikor az Omi nincs csatlakoztatva a telefonjához, a hangot helyileg tárolja a beépített memóriájában. Soha nem veszít el egy felvételt sem.';
+  String get omisStorageDesc => 'Amikor az Omi nincs csatlakoztatva a telefonjához, a hangot helyileg tárolja a beépített memóriájában. Soha nem veszít el egy felvételt sem.';
 
   @override
-  String get phoneStorageDesc =>
-      'Amikor az Omi újra csatlakozik, a felvételek automatikusan átkerülnek a telefonjára feltöltés előtt.';
+  String get phoneStorageDesc => 'Amikor az Omi újra csatlakozik, a felvételek automatikusan átkerülnek a telefonjára feltöltés előtt.';
 
   @override
-  String get cloudStorageDesc =>
-      'Feltöltés után a felvételei feldolgozásra és átírásra kerülnek. A beszélgetések egy percen belül elérhetők lesznek.';
+  String get cloudStorageDesc => 'Feltöltés után a felvételei feldolgozásra és átírásra kerülnek. A beszélgetések egy percen belül elérhetők lesznek.';
 
   @override
   String get tipKeepPhoneNearby => 'Tartsa a telefonját a közelben a gyorsabb szinkronizáláshoz';
@@ -8648,12 +8458,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get permissionEnable => 'Engedélyezés';
 
   @override
-  String get permissionsPageDescription =>
-      'Ezek az engedélyek alapvetőek az Omi működéséhez. Kulcsfontosságú funkciókat tesznek lehetővé, mint az értesítések, helymeghatározáson alapuló élmények és hangfelvétel.';
+  String get permissionsPageDescription => 'Ezek az engedélyek alapvetőek az Omi működéséhez. Kulcsfontosságú funkciókat tesznek lehetővé, mint az értesítések, helymeghatározáson alapuló élmények és hangfelvétel.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Az Omi néhány engedélyre van szüksége a megfelelő működéshez. Kérjük, add meg őket a folytatáshoz.';
+  String get permissionsRequiredDescription => 'Az Omi néhány engedélyre van szüksége a megfelelő működéshez. Kérjük, add meg őket a folytatáshoz.';
 
   @override
   String get permissionsSetupTitle => 'Szerezd meg a legjobb élményt';
@@ -8707,8 +8515,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get justAMoment => 'Egy pillanat, kérlek';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Erősen javasoljuk, hogy a lemondás helyett fedezd fel a többi lehetőségedet.';
+  String get cancelConsequencesSubtitle => 'Erősen javasoljuk, hogy a lemondás helyett fedezd fel a többi lehetőségedet.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8910,8 +8717,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get enableLocationTitle => 'Helymeghatározás engedélyezése';
 
   @override
-  String get enableLocationDescription =>
-      'A helymeghatározási engedély szükséges a közeli Bluetooth-eszközök megtalálásához.';
+  String get enableLocationDescription => 'A helymeghatározási engedély szükséges a közeli Bluetooth-eszközök megtalálásához.';
 
   @override
   String get voiceRecordingFound => 'Felvétel találva';
@@ -8932,8 +8738,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get firmwareWarningTitle => 'Fontos: Olvassa el a frissítés előtt';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ez a firmware formázni fogja az SD-kártyát. Kérjük, győződjön meg arról, hogy minden offline adat szinkronizálva van a frissítés előtt.\n\nHa a verzió telepítése után villogó piros fényt lát, ne aggódjon. Egyszerűen csatlakoztassa az eszközt az alkalmazáshoz, és kékre kell váltania. A piros fény azt jelenti, hogy az eszköz órája még nem lett szinkronizálva.';
+  String get firmwareFormatWarning => 'Ez a firmware formázni fogja az SD-kártyát. Kérjük, győződjön meg arról, hogy minden offline adat szinkronizálva van a frissítés előtt.\n\nHa a verzió telepítése után villogó piros fényt lát, ne aggódjon. Egyszerűen csatlakoztassa az eszközt az alkalmazáshoz, és kékre kell váltania. A piros fény azt jelenti, hogy az eszköz órája még nem lett szinkronizálva.';
 
   @override
   String get continueAnyway => 'Folytatás';
@@ -8953,8 +8758,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get tasksMarkComplete => 'Befejezettként megjelölve';
 
   @override
-  String get appleHealthManageNote =>
-      'Az Omi az Apple HealthKit keretrendszerén keresztül fér hozzá az Apple Healthhez. A hozzáférést bármikor visszavonhatod az iOS beállításaiból.';
+  String get appleHealthManageNote => 'Az Omi az Apple HealthKit keretrendszerén keresztül fér hozzá az Apple Healthhez. A hozzáférést bármikor visszavonhatod az iOS beállításaiból.';
 
   @override
   String get appleHealthConnectCta => 'Csatlakozás az Apple Healthhez';
@@ -8987,8 +8791,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health-hozzáférés megtagadva';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Az Ominak nincs engedélye az Apple Health-adataid olvasására. Engedélyezd: iOS Beállítások → Adatvédelem és biztonság → Health → Omi.';
+  String get appleHealthDeniedBody => 'Az Ominak nincs engedélye az Apple Health-adataid olvasására. Engedélyezd: iOS Beállítások → Adatvédelem és biztonság → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Miért távozol?';
@@ -9057,8 +8860,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get planUpdate => 'Csomag frissítés';
 
   @override
-  String get planDeprecationMessage =>
-      'Az Unlimited csomagja megszűnik. Váltson az Operator csomagra — ugyanazok a kiváló funkciók \$49/hó áron. A jelenlegi csomagja addig is tovább működik.';
+  String get planDeprecationMessage => 'Az Unlimited csomagja megszűnik. Váltson az Operator csomagra — ugyanazok a kiváló funkciók \$49/hó áron. A jelenlegi csomagja addig is tovább működik.';
 
   @override
   String get upgradeYourPlan => 'Frissítsd a csomagodat';
@@ -9169,8 +8971,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Elérted a havi limitedet. Frissíts, hogy korlátozás nélkül folytasd a csevegést az Omival.';
+  String get chatQuotaExceededReply => 'Elérted a havi limitedet. Frissíts, hogy korlátozás nélkül folytasd a csevegést az Omival.';
 
   @override
   String get voiceResponseAudio => 'Omi válaszának felolvasása';
@@ -9201,4 +9002,25 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Feladat hozzáadása';
+
+  @override
+  String get quickActionAskOmiAnything => 'Kérdezz bármit Omitól';
+
+  @override
+  String get quickActionVoiceMode => 'Hangmód';
+
+  @override
+  String get quickActionMute => 'Némítás';
+
+  @override
+  String get quickActionUnmute => 'Némítás feloldása';
+
+  @override
+  String get quickActionConnectDevice => 'Eszköz csatlakoztatása';
+
+  @override
+  String get quickActionDeviceSettings => 'Eszközbeállítások';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -24,8 +24,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get deleteConversationTitle => 'Hapus Percakapan?';
 
   @override
-  String get deleteConversationMessage =>
-      'Ini juga akan menghapus kenangan, tugas, dan file audio terkait. Tindakan ini tidak dapat dibatalkan.';
+  String get deleteConversationMessage => 'Ini juga akan menghapus kenangan, tugas, dan file audio terkait. Tindakan ini tidak dapat dibatalkan.';
 
   @override
   String get confirm => 'Konfirmasi';
@@ -146,8 +145,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get deleting => 'Menghapus...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
+  String get pleaseCompleteAuthentication => 'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
 
   @override
   String get failedToStartAuthentication => 'Gagal memulai autentikasi';
@@ -319,8 +317,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get installedApps => 'Aplikasi Terinstal';
 
   @override
-  String get unableToFetchApps =>
-      'Tidak dapat mengambil aplikasi :(\n\nSilakan periksa koneksi internet Anda dan coba lagi.';
+  String get unableToFetchApps => 'Tidak dapat mengambil aplikasi :(\n\nSilakan periksa koneksi internet Anda dan coba lagi.';
 
   @override
   String get aboutOmi => 'Tentang Omi';
@@ -356,19 +353,16 @@ class AppLocalizationsId extends AppLocalizations {
   String get appsDisconnected => 'Aplikasi dan Integrasi Anda akan segera diputuskan.';
 
   @override
-  String get exportBeforeDelete =>
-      'Anda dapat mengekspor data Anda sebelum menghapus akun, tetapi setelah dihapus, tidak dapat dipulihkan.';
+  String get exportBeforeDelete => 'Anda dapat mengekspor data Anda sebelum menghapus akun, tetapi setelah dihapus, tidak dapat dipulihkan.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Saya memahami bahwa menghapus akun saya bersifat permanen dan semua data, termasuk memori dan percakapan, akan hilang dan tidak dapat dipulihkan.';
+  String get deleteAccountCheckbox => 'Saya memahami bahwa menghapus akun saya bersifat permanen dan semua data, termasuk memori dan percakapan, akan hilang dan tidak dapat dipulihkan.';
 
   @override
   String get areYouSure => 'Apakah Anda yakin?';
 
   @override
-  String get deleteAccountFinal =>
-      'Tindakan ini tidak dapat dibatalkan dan akan menghapus akun dan semua data terkait secara permanen. Apakah Anda yakin ingin melanjutkan?';
+  String get deleteAccountFinal => 'Tindakan ini tidak dapat dibatalkan dan akan menghapus akun dan semua data terkait secara permanen. Apakah Anda yakin ingin melanjutkan?';
 
   @override
   String get deleteNow => 'Hapus Sekarang';
@@ -377,8 +371,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get goBack => 'Kembali';
 
   @override
-  String get checkBoxToConfirm =>
-      'Centang kotak untuk mengonfirmasi bahwa Anda memahami penghapusan akun bersifat permanen dan tidak dapat dibatalkan.';
+  String get checkBoxToConfirm => 'Centang kotak untuk mengonfirmasi bahwa Anda memahami penghapusan akun bersifat permanen dan tidak dapat dibatalkan.';
 
   @override
   String get profile => 'Profil';
@@ -456,8 +449,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get yourPrivacyYourControl => 'Privasi Anda, Kontrol Anda';
 
   @override
-  String get privacyIntro =>
-      'Di Omi, kami berkomitmen untuk melindungi privasi Anda. Halaman ini memungkinkan Anda mengontrol bagaimana data Anda disimpan dan digunakan.';
+  String get privacyIntro => 'Di Omi, kami berkomitmen untuk melindungi privasi Anda. Halaman ini memungkinkan Anda mengontrol bagaimana data Anda disimpan dan digunakan.';
 
   @override
   String get learnMore => 'Pelajari lebih lanjut...';
@@ -466,8 +458,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get dataProtectionLevel => 'Tingkat Perlindungan Data';
 
   @override
-  String get dataProtectionDesc =>
-      'Data Anda diamankan secara default dengan enkripsi yang kuat. Tinjau pengaturan dan opsi privasi Anda di bawah ini.';
+  String get dataProtectionDesc => 'Data Anda diamankan secara default dengan enkripsi yang kuat. Tinjau pengaturan dan opsi privasi Anda di bawah ini.';
 
   @override
   String get appAccess => 'Akses Aplikasi';
@@ -530,22 +521,19 @@ class AppLocalizationsId extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Omi Anda telah terputus 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Perangkat diputuskan pemasangannya. Buka Pengaturan > Bluetooth dan lupakan perangkat untuk menyelesaikan pemutusan pemasangan.';
+  String get deviceUnpairedMessage => 'Perangkat diputuskan pemasangannya. Buka Pengaturan > Bluetooth dan lupakan perangkat untuk menyelesaikan pemutusan pemasangan.';
 
   @override
   String get unpairDialogTitle => 'Batalkan Pasangan Perangkat';
 
   @override
-  String get unpairDialogMessage =>
-      'Ini akan membatalkan pasangan perangkat sehingga dapat dihubungkan ke ponsel lain. Anda perlu pergi ke Pengaturan > Bluetooth dan melupakan perangkat untuk menyelesaikan proses.';
+  String get unpairDialogMessage => 'Ini akan membatalkan pasangan perangkat sehingga dapat dihubungkan ke ponsel lain. Anda perlu pergi ke Pengaturan > Bluetooth dan melupakan perangkat untuk menyelesaikan proses.';
 
   @override
   String get deviceNotConnected => 'Perangkat Tidak Terhubung';
 
   @override
-  String get connectDeviceMessage =>
-      'Hubungkan perangkat Omi Anda untuk mengakses\npengaturan dan kustomisasi perangkat';
+  String get connectDeviceMessage => 'Hubungkan perangkat Omi Anda untuk mengakses\npengaturan dan kustomisasi perangkat';
 
   @override
   String get deviceInfoSection => 'Informasi Perangkat';
@@ -560,8 +548,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get v2Undetected => 'V2 tidak terdeteksi';
 
   @override
-  String get v2UndetectedMessage =>
-      'Kami melihat bahwa Anda memiliki perangkat V1 atau perangkat Anda tidak terhubung. Fungsi Kartu SD hanya tersedia untuk perangkat V2.';
+  String get v2UndetectedMessage => 'Kami melihat bahwa Anda memiliki perangkat V1 atau perangkat Anda tidak terhubung. Fungsi Kartu SD hanya tersedia untuk perangkat V2.';
 
   @override
   String get endConversation => 'Akhiri Percakapan';
@@ -693,8 +680,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get noActivityYet => 'Belum Ada Aktivitas';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Mulai percakapan dengan Omi\nuntuk melihat wawasan penggunaan Anda di sini.';
+  String get startConversationToSeeInsights => 'Mulai percakapan dengan Omi\nuntuk melihat wawasan penggunaan Anda di sini.';
 
   @override
   String get listening => 'Mendengarkan';
@@ -836,8 +822,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Hapus Grafik Pengetahuan?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Ini akan menghapus semua data grafik pengetahuan turunan (simpul dan koneksi). Memori asli Anda akan tetap aman. Grafik akan dibangun kembali seiring waktu atau pada permintaan berikutnya.';
+  String get deleteKnowledgeGraphMessage => 'Ini akan menghapus semua data grafik pengetahuan turunan (simpul dan koneksi). Memori asli Anda akan tetap aman. Grafik akan dibangun kembali seiring waktu atau pada permintaan berikutnya.';
 
   @override
   String get knowledgeGraphDeleted => 'Grafik pengetahuan dihapus';
@@ -985,8 +970,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get shortConversationThreshold => 'Ambang Percakapan Pendek';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Percakapan yang lebih pendek dari ini akan disembunyikan kecuali diaktifkan di atas';
+  String get shortConversationThresholdSubtitle => 'Percakapan yang lebih pendek dari ini akan disembunyikan kecuali diaktifkan di atas';
 
   @override
   String get durationThreshold => 'Ambang Durasi';
@@ -1021,8 +1005,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get integrationsFooter => 'Hubungkan aplikasi Anda untuk melihat data dan metrik dalam obrolan.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
+  String get completeAuthInBrowser => 'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1082,8 +1065,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get needYourPermission => 'Kami memerlukan izin Anda';
 
   @override
-  String get alreadyGavePermission =>
-      'Anda sudah memberi kami izin untuk menyimpan rekaman Anda. Berikut pengingat mengapa kami membutuhkannya:';
+  String get alreadyGavePermission => 'Anda sudah memberi kami izin untuk menyimpan rekaman Anda. Berikut pengingat mengapa kami membutuhkannya:';
 
   @override
   String get wouldLikePermission => 'Kami ingin izin Anda untuk menyimpan rekaman suara Anda. Berikut alasannya:';
@@ -1092,26 +1074,22 @@ class AppLocalizationsId extends AppLocalizations {
   String get improveSpeechProfile => 'Tingkatkan Profil Suara Anda';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Kami menggunakan rekaman untuk melatih dan meningkatkan profil suara pribadi Anda lebih lanjut.';
+  String get improveSpeechProfileDesc => 'Kami menggunakan rekaman untuk melatih dan meningkatkan profil suara pribadi Anda lebih lanjut.';
 
   @override
   String get trainFamilyProfiles => 'Latih Profil untuk Teman dan Keluarga';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Rekaman Anda membantu kami mengenali dan membuat profil untuk teman dan keluarga Anda.';
+  String get trainFamilyProfilesDesc => 'Rekaman Anda membantu kami mengenali dan membuat profil untuk teman dan keluarga Anda.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Tingkatkan Akurasi Transkrip';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Seiring model kami meningkat, kami dapat memberikan hasil transkripsi yang lebih baik untuk rekaman Anda.';
+  String get enhanceTranscriptAccuracyDesc => 'Seiring model kami meningkat, kami dapat memberikan hasil transkripsi yang lebih baik untuk rekaman Anda.';
 
   @override
-  String get legalNotice =>
-      'Pemberitahuan Hukum: Legalitas merekam dan menyimpan data suara dapat bervariasi tergantung pada lokasi Anda dan bagaimana Anda menggunakan fitur ini. Ini adalah tanggung jawab Anda untuk memastikan kepatuhan terhadap hukum dan peraturan lokal.';
+  String get legalNotice => 'Pemberitahuan Hukum: Legalitas merekam dan menyimpan data suara dapat bervariasi tergantung pada lokasi Anda dan bagaimana Anda menggunakan fitur ini. Ini adalah tanggung jawab Anda untuk memastikan kepatuhan terhadap hukum dan peraturan lokal.';
 
   @override
   String get alreadyAuthorized => 'Sudah Diizinkan';
@@ -1189,8 +1167,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get showEventsNoParticipants => 'Tampilkan acara tanpa peserta';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Saat diaktifkan, Coming Up menampilkan acara tanpa peserta atau tautan video.';
+  String get showEventsNoParticipantsDesc => 'Saat diaktifkan, Coming Up menampilkan acara tanpa peserta atau tautan video.';
 
   @override
   String get yourMeetings => 'Rapat Anda';
@@ -1231,8 +1208,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get noProjectsInWorkspace => 'Tidak ada proyek ditemukan di ruang kerja ini';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Pilih berapa lama menunggu dalam keheningan sebelum otomatis mengakhiri percakapan:';
+  String get conversationTimeoutDesc => 'Pilih berapa lama menunggu dalam keheningan sebelum otomatis mengakhiri percakapan:';
 
   @override
   String get timeout2Minutes => '2 menit';
@@ -1276,12 +1252,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Beri tahu kami bahasa utama Anda';
 
   @override
-  String get languageForTranscription =>
-      'Atur bahasa Anda untuk transkripsi yang lebih tajam dan pengalaman yang dipersonalisasi.';
+  String get languageForTranscription => 'Atur bahasa Anda untuk transkripsi yang lebih tajam dan pengalaman yang dipersonalisasi.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Mode Bahasa Tunggal diaktifkan. Terjemahan dinonaktifkan untuk akurasi yang lebih tinggi.';
+  String get singleLanguageModeInfo => 'Mode Bahasa Tunggal diaktifkan. Terjemahan dinonaktifkan untuk akurasi yang lebih tinggi.';
 
   @override
   String get searchLanguageHint => 'Cari bahasa berdasarkan nama atau kode';
@@ -1361,8 +1335,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get defaultRepository => 'Repositori Default';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Pilih repositori default untuk membuat issue. Anda masih dapat menentukan repositori yang berbeda saat membuat issue.';
+  String get selectDefaultRepoDesc => 'Pilih repositori default untuk membuat issue. Anda masih dapat menentukan repositori yang berbeda saat membuat issue.';
 
   @override
   String get noReposFound => 'Tidak ada repositori ditemukan';
@@ -1409,8 +1382,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get configureSettings => 'Konfigurasi Pengaturan';
 
   @override
-  String get completeAuthBrowser =>
-      'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
+  String get completeAuthBrowser => 'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1738,8 +1710,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get enableBluetooth => 'Aktifkan Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi membutuhkan Bluetooth untuk terhubung ke perangkat yang dapat dipakai Anda. Silakan aktifkan Bluetooth dan coba lagi.';
+  String get bluetoothNeeded => 'Omi membutuhkan Bluetooth untuk terhubung ke perangkat yang dapat dipakai Anda. Silakan aktifkan Bluetooth dan coba lagi.';
 
   @override
   String get contactSupport => 'Hubungi Dukungan?';
@@ -1772,26 +1743,22 @@ class AppLocalizationsId extends AppLocalizations {
   String get locationServiceDisabled => 'Layanan Lokasi Dinonaktifkan';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Layanan Lokasi Dinonaktifkan. Silakan buka Pengaturan > Privasi & Keamanan > Layanan Lokasi dan aktifkan';
+  String get locationServiceDisabledDesc => 'Layanan Lokasi Dinonaktifkan. Silakan buka Pengaturan > Privasi & Keamanan > Layanan Lokasi dan aktifkan';
 
   @override
   String get backgroundLocationDenied => 'Akses Lokasi Latar Belakang Ditolak';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Silakan buka pengaturan perangkat dan atur izin lokasi ke \"Selalu Izinkan\"';
+  String get backgroundLocationDeniedDesc => 'Silakan buka pengaturan perangkat dan atur izin lokasi ke \"Selalu Izinkan\"';
 
   @override
   String get lovingOmi => 'Menyukai Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Bantu kami menjangkau lebih banyak orang dengan meninggalkan ulasan di App Store. Masukan Anda sangat berarti bagi kami!';
+  String get leaveReviewIos => 'Bantu kami menjangkau lebih banyak orang dengan meninggalkan ulasan di App Store. Masukan Anda sangat berarti bagi kami!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Bantu kami menjangkau lebih banyak orang dengan meninggalkan ulasan di Google Play Store. Masukan Anda sangat berarti bagi kami!';
+  String get leaveReviewAndroid => 'Bantu kami menjangkau lebih banyak orang dengan meninggalkan ulasan di Google Play Store. Masukan Anda sangat berarti bagi kami!';
 
   @override
   String get rateOnAppStore => 'Beri Nilai di App Store';
@@ -1830,8 +1797,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get invalidRecordingMultipleSpeakers => 'Rekaman tidak valid terdeteksi';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Sepertinya ada beberapa pembicara dalam rekaman. Pastikan Anda berada di lokasi yang sunyi dan coba lagi.';
+  String get multipleSpeakersDesc => 'Sepertinya ada beberapa pembicara dalam rekaman. Pastikan Anda berada di lokasi yang sunyi dan coba lagi.';
 
   @override
   String get tooShortDesc => 'Tidak cukup ucapan terdeteksi. Silakan berbicara lebih banyak dan coba lagi.';
@@ -1843,8 +1809,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get areYouThere => 'Apakah Anda di sana?';
 
   @override
-  String get noSpeechDesc =>
-      'Kami tidak dapat mendeteksi ucapan apa pun. Pastikan untuk berbicara setidaknya selama 10 detik dan tidak lebih dari 3 menit.';
+  String get noSpeechDesc => 'Kami tidak dapat mendeteksi ucapan apa pun. Pastikan untuk berbicara setidaknya selama 10 detik dan tidak lebih dari 3 menit.';
 
   @override
   String get connectionLost => 'Koneksi Terputus';
@@ -1865,8 +1830,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get permissionsRequired => 'Izin diperlukan';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Aplikasi ini memerlukan izin Bluetooth dan Lokasi agar berfungsi dengan baik. Silakan aktifkan di pengaturan.';
+  String get permissionsRequiredDesc => 'Aplikasi ini memerlukan izin Bluetooth dan Lokasi agar berfungsi dengan baik. Silakan aktifkan di pengaturan.';
 
   @override
   String get openSettings => 'Buka Pengaturan';
@@ -1896,8 +1860,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Pendamping AI Anda';
 
   @override
-  String get captureEveryMoment =>
-      'Tangkap setiap momen. Dapatkan ringkasan\nbertenaga AI. Jangan pernah mencatat lagi.';
+  String get captureEveryMoment => 'Tangkap setiap momen. Dapatkan ringkasan\nbertenaga AI. Jangan pernah mencatat lagi.';
 
   @override
   String get appleWatchSetup => 'Pengaturan Apple Watch';
@@ -1909,12 +1872,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get microphonePermission => 'Izin Mikrofon';
 
   @override
-  String get permissionGrantedNow =>
-      'Izin diberikan! Sekarang:\n\nBuka aplikasi Omi di jam tangan Anda dan ketuk \"Lanjutkan\" di bawah ini';
+  String get permissionGrantedNow => 'Izin diberikan! Sekarang:\n\nBuka aplikasi Omi di jam tangan Anda dan ketuk \"Lanjutkan\" di bawah ini';
 
   @override
-  String get needMicrophonePermission =>
-      'Kami memerlukan izin mikrofon.\n\n1. Ketuk \"Berikan Izin\"\n2. Izinkan di iPhone Anda\n3. Aplikasi jam tangan akan tertutup\n4. Buka kembali dan ketuk \"Lanjutkan\"';
+  String get needMicrophonePermission => 'Kami memerlukan izin mikrofon.\n\n1. Ketuk \"Berikan Izin\"\n2. Izinkan di iPhone Anda\n3. Aplikasi jam tangan akan tertutup\n4. Buka kembali dan ketuk \"Lanjutkan\"';
 
   @override
   String get grantPermissionButton => 'Berikan Izin';
@@ -1923,15 +1884,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get needHelp => 'Butuh Bantuan?';
 
   @override
-  String get troubleshootingSteps =>
-      'Pemecahan Masalah:\n\n1. Pastikan Omi terinstal di jam tangan Anda\n2. Buka aplikasi Omi di jam tangan Anda\n3. Cari popup izin\n4. Ketuk \"Izinkan\" saat diminta\n5. Aplikasi di jam tangan Anda akan tertutup - buka kembali\n6. Kembali dan ketuk \"Lanjutkan\" di iPhone Anda';
+  String get troubleshootingSteps => 'Pemecahan Masalah:\n\n1. Pastikan Omi terinstal di jam tangan Anda\n2. Buka aplikasi Omi di jam tangan Anda\n3. Cari popup izin\n4. Ketuk \"Izinkan\" saat diminta\n5. Aplikasi di jam tangan Anda akan tertutup - buka kembali\n6. Kembali dan ketuk \"Lanjutkan\" di iPhone Anda';
 
   @override
   String get recordingStartedSuccessfully => 'Rekaman berhasil dimulai!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Izin belum diberikan. Pastikan Anda telah mengizinkan akses mikrofon dan membuka kembali aplikasi di jam tangan Anda.';
+  String get permissionNotGrantedYet => 'Izin belum diberikan. Pastikan Anda telah mengizinkan akses mikrofon dan membuka kembali aplikasi di jam tangan Anda.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1947,8 +1906,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get selectPrimaryLanguage => 'Pilih bahasa utama Anda';
 
   @override
-  String get languageBenefits =>
-      'Atur bahasa Anda untuk transkripsi yang lebih tajam dan pengalaman yang dipersonalisasi';
+  String get languageBenefits => 'Atur bahasa Anda untuk transkripsi yang lebih tajam dan pengalaman yang dipersonalisasi';
 
   @override
   String get whatsYourPrimaryLanguage => 'Apa bahasa utama Anda?';
@@ -1957,8 +1915,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get selectYourLanguage => 'Pilih bahasa Anda';
 
   @override
-  String get personalGrowthJourney =>
-      'Perjalanan pertumbuhan pribadi Anda dengan AI yang mendengarkan setiap kata Anda.';
+  String get personalGrowthJourney => 'Perjalanan pertumbuhan pribadi Anda dengan AI yang mendengarkan setiap kata Anda.';
 
   @override
   String get actionItemsTitle => 'Daftar Tugas';
@@ -2030,8 +1987,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Siap untuk Item Tindakan';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'AI Anda akan secara otomatis mengekstrak tugas dan hal-hal yang harus dilakukan dari percakapan Anda. Mereka akan muncul di sini saat dibuat.';
+  String get welcomeActionItemsDescription => 'AI Anda akan secara otomatis mengekstrak tugas dan hal-hal yang harus dilakukan dari percakapan Anda. Mereka akan muncul di sini saat dibuat.';
 
   @override
   String get autoExtractionFeature => 'Secara otomatis diekstrak dari percakapan';
@@ -2227,15 +2183,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'UCAPAN & TRANSKRIPSI';
 
   @override
-  String get languageSettingsHelperText =>
-      'Bahasa Aplikasi mengubah menu dan tombol. Bahasa Ucapan mempengaruhi cara rekaman Anda ditranskripsi.';
+  String get languageSettingsHelperText => 'Bahasa Aplikasi mengubah menu dan tombol. Bahasa Ucapan mempengaruhi cara rekaman Anda ditranskripsi.';
 
   @override
   String get translationNotice => 'Pemberitahuan Terjemahan';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi menerjemahkan percakapan ke bahasa utama Anda. Perbarui kapan saja di Pengaturan → Profil.';
+  String get translationNoticeMessage => 'Omi menerjemahkan percakapan ke bahasa utama Anda. Perbarui kapan saja di Pengaturan → Profil.';
 
   @override
   String get pleaseCheckInternetConnection => 'Harap periksa koneksi internet Anda dan coba lagi';
@@ -2390,8 +2344,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Putuskan Pemasangan Perangkat';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Ini akan memutuskan pemasangan perangkat agar dapat terhubung ke ponsel lain. Anda perlu membuka Pengaturan > Bluetooth dan melupakan perangkat untuk menyelesaikan prosesnya.';
+  String get unpairDeviceDialogMessage => 'Ini akan memutuskan pemasangan perangkat agar dapat terhubung ke ponsel lain. Anda perlu membuka Pengaturan > Bluetooth dan melupakan perangkat untuk menyelesaikan prosesnya.';
 
   @override
   String get unpair => 'Putuskan Pemasangan';
@@ -2572,8 +2525,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get youreAllSet => 'Anda siap!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Selamat datang di Omi! Pendamping AI Anda siap membantu Anda dengan percakapan, tugas, dan banyak lagi.';
+  String get welcomeToOmiDescription => 'Selamat datang di Omi! Pendamping AI Anda siap membantu Anda dengan percakapan, tugas, dan banyak lagi.';
 
   @override
   String get startUsingOmi => 'Mulai Menggunakan Omi';
@@ -2652,8 +2604,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get reviewAndManageConversations => 'Tinjau dan kelola percakapan yang telah direkam';
 
   @override
-  String get startCapturingConversations =>
-      'Mulai merekam percakapan dengan perangkat Omi Anda untuk melihatnya di sini.';
+  String get startCapturingConversations => 'Mulai merekam percakapan dengan perangkat Omi Anda untuk melihatnya di sini.';
 
   @override
   String get useMobileAppToCapture => 'Gunakan aplikasi seluler Anda untuk merekam audio';
@@ -2668,8 +2619,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get showAll => 'Tampilkan semua →';
 
   @override
-  String get noTasksForToday =>
-      'Tidak ada tugas untuk hari ini.\nTanyakan Omi untuk lebih banyak tugas atau buat secara manual.';
+  String get noTasksForToday => 'Tidak ada tugas untuk hari ini.\nTanyakan Omi untuk lebih banyak tugas atau buat secara manual.';
 
   @override
   String get dailyScore => 'SKOR HARIAN';
@@ -2711,8 +2661,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get noTasksYet => 'Belum ada tugas';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Tugas dari percakapan Anda akan muncul di sini.\nKlik Buat untuk menambahkan satu secara manual.';
+  String get tasksFromConversationsWillAppear => 'Tugas dari percakapan Anda akan muncul di sini.\nKlik Buat untuk menambahkan satu secara manual.';
 
   @override
   String get monthJan => 'Jan';
@@ -2769,8 +2718,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get deleteActionItem => 'Hapus item tindakan';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Apakah Anda yakin ingin menghapus item tindakan ini? Tindakan ini tidak dapat dibatalkan.';
+  String get deleteActionItemConfirmation => 'Apakah Anda yakin ingin menghapus item tindakan ini? Tindakan ini tidak dapat dibatalkan.';
 
   @override
   String get enterActionItemDescription => 'Masukkan deskripsi item tindakan...';
@@ -2845,15 +2793,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get chatPrompt => 'Petunjuk Chat';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Anda adalah aplikasi yang luar biasa, tugas Anda adalah merespons pertanyaan pengguna dan membuat mereka merasa baik...';
+  String get chatPromptPlaceholder => 'Anda adalah aplikasi yang luar biasa, tugas Anda adalah merespons pertanyaan pengguna dan membuat mereka merasa baik...';
 
   @override
   String get conversationPrompt => 'Prompt Percakapan';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Anda adalah aplikasi yang luar biasa, Anda akan diberikan transkrip dan ringkasan percakapan...';
+  String get conversationPromptPlaceholder => 'Anda adalah aplikasi yang luar biasa, Anda akan diberikan transkrip dan ringkasan percakapan...';
 
   @override
   String get notificationScopes => 'Cakupan Notifikasi';
@@ -2865,8 +2811,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get makeMyAppPublic => 'Buat aplikasi saya publik';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Dengan mengirimkan aplikasi ini, saya menyetujui Ketentuan Layanan dan Kebijakan Privasi Omi AI';
+  String get submitAppTermsAgreement => 'Dengan mengirimkan aplikasi ini, saya menyetujui Ketentuan Layanan dan Kebijakan Privasi Omi AI';
 
   @override
   String get submitApp => 'Kirim Aplikasi';
@@ -2881,12 +2826,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get submitAppQuestion => 'Kirim Aplikasi?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Aplikasi Anda akan ditinjau dan dipublikasikan. Anda dapat mulai menggunakannya segera, bahkan selama peninjauan!';
+  String get submitAppPublicDescription => 'Aplikasi Anda akan ditinjau dan dipublikasikan. Anda dapat mulai menggunakannya segera, bahkan selama peninjauan!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Aplikasi Anda akan ditinjau dan tersedia untuk Anda secara pribadi. Anda dapat mulai menggunakannya segera, bahkan selama peninjauan!';
+  String get submitAppPrivateDescription => 'Aplikasi Anda akan ditinjau dan tersedia untuk Anda secara pribadi. Anda dapat mulai menggunakannya segera, bahkan selama peninjauan!';
 
   @override
   String get startEarning => 'Mulai Menghasilkan! 💰';
@@ -2910,23 +2853,19 @@ class AppLocalizationsId extends AppLocalizations {
   String get dataAccessNotice => 'Pemberitahuan Akses Data';
 
   @override
-  String get dataAccessWarning =>
-      'Aplikasi ini akan mengakses data Anda. Omi AI tidak bertanggung jawab atas bagaimana data Anda digunakan, dimodifikasi, atau dihapus oleh aplikasi ini';
+  String get dataAccessWarning => 'Aplikasi ini akan mengakses data Anda. Omi AI tidak bertanggung jawab atas bagaimana data Anda digunakan, dimodifikasi, atau dihapus oleh aplikasi ini';
 
   @override
   String get installApp => 'Instal Aplikasi';
 
   @override
-  String get betaTesterNotice =>
-      'Anda adalah penguji beta untuk aplikasi ini. Ini belum publik. Ini akan menjadi publik setelah disetujui.';
+  String get betaTesterNotice => 'Anda adalah penguji beta untuk aplikasi ini. Ini belum publik. Ini akan menjadi publik setelah disetujui.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Aplikasi Anda sedang dalam peninjauan dan hanya terlihat oleh Anda. Ini akan menjadi publik setelah disetujui.';
+  String get appUnderReviewOwner => 'Aplikasi Anda sedang dalam peninjauan dan hanya terlihat oleh Anda. Ini akan menjadi publik setelah disetujui.';
 
   @override
-  String get appRejectedNotice =>
-      'Aplikasi Anda telah ditolak. Harap perbarui detail aplikasi dan kirim ulang untuk ditinjau.';
+  String get appRejectedNotice => 'Aplikasi Anda telah ditolak. Harap perbarui detail aplikasi dan kirim ulang untuk ditinjau.';
 
   @override
   String get setupSteps => 'Langkah Pengaturan';
@@ -2988,8 +2927,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get descriptionLabel => 'Deskripsi';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Aplikasi Hebat Saya adalah aplikasi luar biasa yang melakukan hal-hal menakjubkan. Ini adalah aplikasi terbaik!';
+  String get appDescriptionPlaceholder => 'Aplikasi Hebat Saya adalah aplikasi luar biasa yang melakukan hal-hal menakjubkan. Ini adalah aplikasi terbaik!';
 
   @override
   String get pleaseProvideValidDescription => 'Harap berikan deskripsi yang valid';
@@ -3141,8 +3079,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get microphonePermissionRequired => 'Izin mikrofon diperlukan untuk perekaman suara.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Izin mikrofon ditolak. Harap berikan izin di Preferensi Sistem > Privasi & Keamanan > Mikrofon.';
+  String get microphonePermissionDenied => 'Izin mikrofon ditolak. Harap berikan izin di Preferensi Sistem > Privasi & Keamanan > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3301,8 +3238,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get createMemory => 'Buat Memori';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Apakah Anda yakin ingin menghapus memori ini? Tindakan ini tidak dapat dibatalkan.';
+  String get deleteMemoryConfirmation => 'Apakah Anda yakin ingin menghapus memori ini? Tindakan ini tidak dapat dibatalkan.';
 
   @override
   String get makePrivate => 'Jadikan Privat';
@@ -3376,8 +3312,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get whatWeCollect => 'Apa yang kami kumpulkan';
 
   @override
-  String get dataCollectionMessage =>
-      'Dengan melanjutkan, percakapan, rekaman, dan informasi pribadi Anda akan disimpan dengan aman di server kami untuk memberikan wawasan berbasis AI dan mengaktifkan semua fitur aplikasi.';
+  String get dataCollectionMessage => 'Dengan melanjutkan, percakapan, rekaman, dan informasi pribadi Anda akan disimpan dengan aman di server kami untuk memberikan wawasan berbasis AI dan mengaktifkan semua fitur aplikasi.';
 
   @override
   String get dataProtection => 'Perlindungan Data';
@@ -3410,8 +3345,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Nama harus minimal 2 karakter';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Beri tahu kami bagaimana Anda ingin disapa. Ini membantu mempersonalisasi pengalaman Omi Anda.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Beri tahu kami bagaimana Anda ingin disapa. Ini membantu mempersonalisasi pengalaman Omi Anda.';
 
   @override
   String charactersCount(int count) {
@@ -3428,8 +3362,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get recordAudioConversations => 'Rekam percakapan audio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi memerlukan akses mikrofon untuk merekam percakapan Anda dan memberikan transkripsi.';
+  String get microphoneAccessDescription => 'Omi memerlukan akses mikrofon untuk merekam percakapan Anda dan memberikan transkripsi.';
 
   @override
   String get screenRecording => 'Perekaman Layar';
@@ -3438,8 +3371,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Tangkap audio sistem dari rapat';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi memerlukan izin perekaman layar untuk menangkap audio sistem dari rapat berbasis browser Anda.';
+  String get screenRecordingDescription => 'Omi memerlukan izin perekaman layar untuk menangkap audio sistem dari rapat berbasis browser Anda.';
 
   @override
   String get accessibility => 'Aksesibilitas';
@@ -3448,8 +3380,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Deteksi rapat berbasis browser';
 
   @override
-  String get accessibilityDescription =>
-      'Omi memerlukan izin aksesibilitas untuk mendeteksi saat Anda bergabung dengan rapat Zoom, Meet, atau Teams di browser Anda.';
+  String get accessibilityDescription => 'Omi memerlukan izin aksesibilitas untuk mendeteksi saat Anda bergabung dengan rapat Zoom, Meet, atau Teams di browser Anda.';
 
   @override
   String get pleaseWait => 'Harap tunggu...';
@@ -3518,12 +3449,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get exportAllConversationsToJson => 'Ekspor semua percakapan Anda ke file JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Ekspor Percakapan Dimulai. Ini mungkin memakan waktu beberapa detik, harap tunggu.';
+  String get conversationsExportStarted => 'Ekspor Percakapan Dimulai. Ini mungkin memakan waktu beberapa detik, harap tunggu.';
 
   @override
-  String get mcpDescription =>
-      'Untuk menghubungkan Omi dengan aplikasi lain untuk membaca, mencari, dan mengelola kenangan dan percakapan Anda. Buat kunci untuk memulai.';
+  String get mcpDescription => 'Untuk menghubungkan Omi dengan aplikasi lain untuk membaca, mencari, dan mengelola kenangan dan percakapan Anda. Buat kunci untuk memulai.';
 
   @override
   String get apiKeys => 'Kunci API';
@@ -3594,8 +3523,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get auto => 'Otomatis';
 
   @override
-  String get noSummaryForApp =>
-      'Tidak ada ringkasan yang tersedia untuk aplikasi ini. Coba aplikasi lain untuk hasil yang lebih baik.';
+  String get noSummaryForApp => 'Tidak ada ringkasan yang tersedia untuk aplikasi ini. Coba aplikasi lain untuk hasil yang lebih baik.';
 
   @override
   String get tryAnotherApp => 'Coba Aplikasi Lain';
@@ -3632,8 +3560,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Biarkan Omi memilih aplikasi terbaik secara otomatis';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Apakah Anda yakin ingin menghapus percakapan ini? Tindakan ini tidak dapat dibatalkan.';
+  String get deleteConversationConfirmation => 'Apakah Anda yakin ingin menghapus percakapan ini? Tindakan ini tidak dapat dibatalkan.';
 
   @override
   String get conversationDeleted => 'Percakapan dihapus';
@@ -3681,8 +3608,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Menyiapkan tangkapan audio sistem';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klik tombol untuk menangkap audio untuk transkripsi langsung, wawasan AI, dan penyimpanan otomatis.';
+  String get clickTheButtonToCaptureAudio => 'Klik tombol untuk menangkap audio untuk transkripsi langsung, wawasan AI, dan penyimpanan otomatis.';
 
   @override
   String get reconnecting => 'Menyambung kembali...';
@@ -3909,8 +3835,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Hapus Grafik Pengetahuan?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Ini akan menghapus semua data grafik pengetahuan turunan. Kenangan asli Anda tetap aman.';
+  String get deleteKnowledgeGraphWarning => 'Ini akan menghapus semua data grafik pengetahuan turunan. Kenangan asli Anda tetap aman.';
 
   @override
   String get connectOmiWithAI => 'Hubungkan Omi dengan asisten AI';
@@ -3967,8 +3892,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get updateAppQuestion => 'Perbarui Aplikasi?';
 
   @override
-  String get updateAppConfirmation =>
-      'Apakah Anda yakin ingin memperbarui aplikasi? Perubahan akan terlihat setelah ditinjau oleh tim kami.';
+  String get updateAppConfirmation => 'Apakah Anda yakin ingin memperbarui aplikasi? Perubahan akan terlihat setelah ditinjau oleh tim kami.';
 
   @override
   String get updateApp => 'Perbarui Aplikasi';
@@ -3998,8 +3922,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get no => 'Tidak';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Langganan berhasil dibatalkan. Akan tetap aktif hingga akhir periode penagihan saat ini.';
+  String get subscriptionCancelledSuccessfully => 'Langganan berhasil dibatalkan. Akan tetap aktif hingga akhir periode penagihan saat ini.';
 
   @override
   String get failedToCancelSubscription => 'Gagal membatalkan langganan. Silakan coba lagi.';
@@ -4035,8 +3958,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Batalkan Langganan?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Apakah Anda yakin ingin membatalkan langganan? Anda akan tetap memiliki akses hingga akhir periode penagihan saat ini.';
+  String get cancelSubscriptionConfirmation => 'Apakah Anda yakin ingin membatalkan langganan? Anda akan tetap memiliki akses hingga akhir periode penagihan saat ini.';
 
   @override
   String get cancelSubscriptionButton => 'Batalkan Langganan';
@@ -4045,12 +3967,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get cancelling => 'Membatalkan...';
 
   @override
-  String get betaTesterMessage =>
-      'Anda adalah penguji beta untuk aplikasi ini. Belum dipublikasikan. Akan dipublikasikan setelah disetujui.';
+  String get betaTesterMessage => 'Anda adalah penguji beta untuk aplikasi ini. Belum dipublikasikan. Akan dipublikasikan setelah disetujui.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Aplikasi Anda sedang ditinjau dan hanya terlihat oleh Anda. Akan dipublikasikan setelah disetujui.';
+  String get appUnderReviewMessage => 'Aplikasi Anda sedang ditinjau dan hanya terlihat oleh Anda. Akan dipublikasikan setelah disetujui.';
 
   @override
   String get appRejectedMessage => 'Aplikasi Anda ditolak. Perbarui detail dan kirim ulang untuk ditinjau.';
@@ -4195,8 +4115,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get omiApiKeys => 'Kunci API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Kunci API digunakan untuk autentikasi saat aplikasi Anda berkomunikasi dengan server OMI. Kunci ini memungkinkan aplikasi Anda membuat memori dan mengakses layanan OMI lainnya dengan aman.';
+  String get apiKeysDescription => 'Kunci API digunakan untuk autentikasi saat aplikasi Anda berkomunikasi dengan server OMI. Kunci ini memungkinkan aplikasi Anda membuat memori dan mengakses layanan OMI lainnya dengan aman.';
 
   @override
   String get aboutOmiApiKeys => 'Tentang Kunci API Omi';
@@ -4220,8 +4139,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Cabut Kunci API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Tindakan ini tidak dapat dibatalkan. Aplikasi apa pun yang menggunakan kunci ini tidak akan dapat mengakses API lagi.';
+  String get revokeApiKeyWarning => 'Tindakan ini tidak dapat dibatalkan. Aplikasi apa pun yang menggunakan kunci ini tidak akan dapat mengakses API lagi.';
 
   @override
   String get revoke => 'Cabut';
@@ -4310,8 +4228,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get keyCreated => 'Kunci Dibuat';
 
   @override
-  String get keyCreatedMessage =>
-      'Kunci baru Anda telah dibuat. Silakan salin sekarang. Anda tidak akan dapat melihatnya lagi.';
+  String get keyCreatedMessage => 'Kunci baru Anda telah dibuat. Silakan salin sekarang. Anda tidak akan dapat melihatnya lagi.';
 
   @override
   String get keyWord => 'Kunci';
@@ -4320,8 +4237,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get externalAppAccess => 'Akses Aplikasi Eksternal';
 
   @override
-  String get externalAppAccessDescription =>
-      'Aplikasi terinstal berikut memiliki integrasi eksternal dan dapat mengakses data Anda, seperti percakapan dan kenangan.';
+  String get externalAppAccessDescription => 'Aplikasi terinstal berikut memiliki integrasi eksternal dan dapat mengakses data Anda, seperti percakapan dan kenangan.';
 
   @override
   String get noExternalAppsHaveAccess => 'Tidak ada aplikasi eksternal yang memiliki akses ke data Anda.';
@@ -4330,8 +4246,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get maximumSecurityE2ee => 'Keamanan Maksimum (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Enkripsi end-to-end adalah standar emas untuk privasi. Saat diaktifkan, data Anda dienkripsi di perangkat Anda sebelum dikirim ke server kami. Ini berarti tidak ada seorang pun, bahkan Omi, yang dapat mengakses konten Anda.';
+  String get e2eeDescription => 'Enkripsi end-to-end adalah standar emas untuk privasi. Saat diaktifkan, data Anda dienkripsi di perangkat Anda sebelum dikirim ke server kami. Ini berarti tidak ada seorang pun, bahkan Omi, yang dapat mengakses konten Anda.';
 
   @override
   String get importantTradeoffs => 'Pertimbangan Penting:';
@@ -4346,8 +4261,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get featureComingSoon => 'Fitur ini akan segera hadir!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migrasi sedang berlangsung. Anda tidak dapat mengubah tingkat perlindungan sampai selesai.';
+  String get migrationInProgressMessage => 'Migrasi sedang berlangsung. Anda tidak dapat mengubah tingkat perlindungan sampai selesai.';
 
   @override
   String get migrationFailed => 'Migrasi Gagal';
@@ -4366,19 +4280,16 @@ class AppLocalizationsId extends AppLocalizations {
   String get secureEncryption => 'Enkripsi Aman';
 
   @override
-  String get secureEncryptionDescription =>
-      'Data Anda dienkripsi dengan kunci yang unik untuk Anda di server kami, yang dihosting di Google Cloud. Ini berarti konten mentah Anda tidak dapat diakses oleh siapa pun, termasuk staf Omi atau Google, langsung dari database.';
+  String get secureEncryptionDescription => 'Data Anda dienkripsi dengan kunci yang unik untuk Anda di server kami, yang dihosting di Google Cloud. Ini berarti konten mentah Anda tidak dapat diakses oleh siapa pun, termasuk staf Omi atau Google, langsung dari database.';
 
   @override
   String get endToEndEncryption => 'Enkripsi End-to-End';
 
   @override
-  String get e2eeCardDescription =>
-      'Aktifkan untuk keamanan maksimum di mana hanya Anda yang dapat mengakses data Anda. Ketuk untuk mempelajari lebih lanjut.';
+  String get e2eeCardDescription => 'Aktifkan untuk keamanan maksimum di mana hanya Anda yang dapat mengakses data Anda. Ketuk untuk mempelajari lebih lanjut.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Terlepas dari levelnya, data Anda selalu dienkripsi saat diam dan dalam perjalanan.';
+  String get dataAlwaysEncrypted => 'Terlepas dari levelnya, data Anda selalu dienkripsi saat diam dan dalam perjalanan.';
 
   @override
   String get readOnlyScope => 'Hanya Baca';
@@ -4443,12 +4354,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get trainingDataProgram => 'Program Data Pelatihan';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Dapatkan Omi Unlimited gratis dengan menyumbangkan data Anda untuk melatih model AI.';
+  String get getOmiUnlimitedFree => 'Dapatkan Omi Unlimited gratis dengan menyumbangkan data Anda untuk melatih model AI.';
 
   @override
-  String get trainingDataBullets =>
-      '• Data Anda membantu meningkatkan model AI\n• Hanya data non-sensitif yang dibagikan\n• Proses sepenuhnya transparan';
+  String get trainingDataBullets => '• Data Anda membantu meningkatkan model AI\n• Hanya data non-sensitif yang dibagikan\n• Proses sepenuhnya transparan';
 
   @override
   String get learnMoreAtOmiTraining => 'Pelajari lebih lanjut di omi.me/training';
@@ -4460,8 +4369,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get submitRequest => 'Kirim Permintaan';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Terima kasih! Permintaan Anda sedang ditinjau. Kami akan memberi tahu Anda setelah disetujui.';
+  String get thankYouRequestUnderReview => 'Terima kasih! Permintaan Anda sedang ditinjau. Kami akan memberi tahu Anda setelah disetujui.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4499,12 +4407,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get monthlyPlanContinues => 'Paket bulanan Anda saat ini akan berlanjut hingga akhir periode penagihan';
 
   @override
-  String get paymentMethodCharged =>
-      'Metode pembayaran Anda yang ada akan dikenakan biaya secara otomatis saat paket bulanan Anda berakhir';
+  String get paymentMethodCharged => 'Metode pembayaran Anda yang ada akan dikenakan biaya secara otomatis saat paket bulanan Anda berakhir';
 
   @override
-  String get annualSubscriptionStarts =>
-      'Langganan tahunan 12 bulan Anda akan dimulai secara otomatis setelah pembayaran';
+  String get annualSubscriptionStarts => 'Langganan tahunan 12 bulan Anda akan dimulai secara otomatis setelah pembayaran';
 
   @override
   String get thirteenMonthsCoverage => 'Anda akan mendapatkan total 13 bulan cakupan (bulan ini + 12 bulan tahunan)';
@@ -4544,8 +4450,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Paket tahunan Anda akan dimulai secara otomatis saat paket bulanan Anda berakhir.';
+  String get annualPlanStartsAutomatically => 'Paket tahunan Anda akan dimulai secara otomatis saat paket bulanan Anda berakhir.';
 
   @override
   String planRenewsOn(String date) {
@@ -4612,8 +4517,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Privasi Anda Penting bagi Kami';
 
   @override
-  String get privacyIntroText =>
-      'Di Omi, kami menganggap privasi Anda dengan sangat serius. Kami ingin transparan tentang data yang kami kumpulkan dan bagaimana kami menggunakannya. Inilah yang perlu Anda ketahui:';
+  String get privacyIntroText => 'Di Omi, kami menganggap privasi Anda dengan sangat serius. Kami ingin transparan tentang data yang kami kumpulkan dan bagaimana kami menggunakannya. Inilah yang perlu Anda ketahui:';
 
   @override
   String get whatWeTrack => 'Apa yang Kami Lacak';
@@ -4628,12 +4532,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get ourCommitment => 'Komitmen Kami';
 
   @override
-  String get commitmentText =>
-      'Kami berkomitmen untuk menggunakan data yang kami kumpulkan hanya untuk membuat Omi menjadi produk yang lebih baik untuk Anda. Privasi dan kepercayaan Anda sangat penting bagi kami.';
+  String get commitmentText => 'Kami berkomitmen untuk menggunakan data yang kami kumpulkan hanya untuk membuat Omi menjadi produk yang lebih baik untuk Anda. Privasi dan kepercayaan Anda sangat penting bagi kami.';
 
   @override
-  String get thankYouText =>
-      'Terima kasih telah menjadi pengguna Omi yang berharga. Jika Anda memiliki pertanyaan atau kekhawatiran, jangan ragu untuk menghubungi kami di team@basedhardware.com.';
+  String get thankYouText => 'Terima kasih telah menjadi pengguna Omi yang berharga. Jika Anda memiliki pertanyaan atau kekhawatiran, jangan ragu untuk menghubungi kami di team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Pengaturan Sinkronisasi WiFi';
@@ -4642,8 +4544,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get enterHotspotCredentials => 'Masukkan kredensial hotspot ponsel Anda';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'Sinkronisasi WiFi menggunakan ponsel Anda sebagai hotspot. Temukan nama dan kata sandi di Pengaturan > Hotspot Pribadi.';
+  String get wifiSyncUsesHotspot => 'Sinkronisasi WiFi menggunakan ponsel Anda sebagai hotspot. Temukan nama dan kata sandi di Pengaturan > Hotspot Pribadi.';
 
   @override
   String get hotspotNameSsid => 'Nama Hotspot (SSID)';
@@ -4678,8 +4579,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Gagal membuat ringkasan. Pastikan Anda memiliki percakapan untuk hari itu.';
+  String get failedToGenerateSummaryCheckConversations => 'Gagal membuat ringkasan. Pastikan Anda memiliki percakapan untuk hari itu.';
 
   @override
   String get summaryNotFound => 'Ringkasan tidak ditemukan';
@@ -4709,8 +4609,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Ekspor dimulai. Ini mungkin memerlukan beberapa detik...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ini akan menghapus semua data grafik pengetahuan turunan (node dan koneksi). Memori asli Anda akan tetap aman. Grafik akan dibangun kembali seiring waktu atau pada permintaan berikutnya.';
+  String get knowledgeGraphDeleteDescription => 'Ini akan menghapus semua data grafik pengetahuan turunan (node dan koneksi). Memori asli Anda akan tetap aman. Grafik akan dibangun kembali seiring waktu atau pada permintaan berikutnya.';
 
   @override
   String get configureDailySummaryDigest => 'Konfigurasikan ringkasan tugas harian Anda';
@@ -4780,8 +4679,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Hapus Semua Percakapan Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Ini akan menghapus secara permanen semua percakapan yang diimpor dari Limitless. Tindakan ini tidak dapat dibatalkan.';
+  String get deleteAllLimitlessWarning => 'Ini akan menghapus secara permanen semua percakapan yang diimpor dari Limitless. Tindakan ini tidak dapat dibatalkan.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4837,8 +4735,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get howItWorksTitle => 'Bagaimana cara kerjanya?';
 
   @override
-  String get howPeopleWorks =>
-      'Setelah seseorang dibuat, Anda dapat pergi ke transkrip percakapan dan menetapkan segmen yang sesuai, dengan cara itu Omi akan dapat mengenali ucapan mereka juga!';
+  String get howPeopleWorks => 'Setelah seseorang dibuat, Anda dapat pergi ke transkrip percakapan dan menetapkan segmen yang sesuai, dengan cara itu Omi akan dapat mengenali ucapan mereka juga!';
 
   @override
   String get tapToDelete => 'Ketuk untuk menghapus';
@@ -4864,8 +4761,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get privacyNotice => 'Pemberitahuan Privasi';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Rekaman dapat menangkap suara orang lain. Pastikan Anda memiliki persetujuan dari semua peserta sebelum mengaktifkan.';
+  String get recordingsMayCaptureOthers => 'Rekaman dapat menangkap suara orang lain. Pastikan Anda memiliki persetujuan dari semua peserta sebelum mengaktifkan.';
 
   @override
   String get enable => 'Aktifkan';
@@ -4877,8 +4773,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get on => 'Aktif';
 
   @override
-  String get storeAudioDescription =>
-      'Simpan semua rekaman audio secara lokal di ponsel Anda. Saat dinonaktifkan, hanya unggahan yang gagal yang disimpan untuk menghemat ruang penyimpanan.';
+  String get storeAudioDescription => 'Simpan semua rekaman audio secara lokal di ponsel Anda. Saat dinonaktifkan, hanya unggahan yang gagal yang disimpan untuk menghemat ruang penyimpanan.';
 
   @override
   String get enableLocalStorage => 'Aktifkan Penyimpanan Lokal';
@@ -4896,12 +4791,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get storeAudioOnCloud => 'Simpan Audio di Cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Rekaman real-time Anda akan disimpan di penyimpanan cloud pribadi saat Anda berbicara.';
+  String get cloudStorageDialogMessage => 'Rekaman real-time Anda akan disimpan di penyimpanan cloud pribadi saat Anda berbicara.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Simpan rekaman real-time Anda di penyimpanan cloud pribadi saat Anda berbicara. Audio ditangkap dan disimpan dengan aman secara real-time.';
+  String get storeAudioCloudDescription => 'Simpan rekaman real-time Anda di penyimpanan cloud pribadi saat Anda berbicara. Audio ditangkap dan disimpan dengan aman secara real-time.';
 
   @override
   String get downloadingFirmware => 'Mengunduh Firmware';
@@ -4954,8 +4847,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get payments => 'Pembayaran';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Hubungkan metode pembayaran di bawah untuk mulai menerima pembayaran untuk aplikasi Anda.';
+  String get connectPaymentMethodInfo => 'Hubungkan metode pembayaran di bawah untuk mulai menerima pembayaran untuk aplikasi Anda.';
 
   @override
   String get selectedPaymentMethod => 'Metode Pembayaran Terpilih';
@@ -4982,8 +4874,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get monthlyPayouts => 'Pembayaran bulanan';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Terima pembayaran bulanan langsung ke akun Anda saat mencapai \$10 dalam penghasilan';
+  String get monthlyPayoutsDescription => 'Terima pembayaran bulanan langsung ke akun Anda saat mencapai \$10 dalam penghasilan';
 
   @override
   String get secureAndReliable => 'Aman dan andal';
@@ -5010,8 +4901,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get connectingYourStripeAccount => 'Menghubungkan akun Stripe Anda';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Silakan selesaikan proses orientasi Stripe di browser Anda. Halaman ini akan diperbarui secara otomatis setelah selesai.';
+  String get stripeOnboardingInstructions => 'Silakan selesaikan proses orientasi Stripe di browser Anda. Halaman ini akan diperbarui secara otomatis setelah selesai.';
 
   @override
   String get failedTryAgain => 'Gagal? Coba Lagi';
@@ -5023,8 +4913,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get successfullyConnected => 'Berhasil Terhubung!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Akun Stripe Anda sekarang siap menerima pembayaran. Anda dapat mulai menghasilkan dari penjualan aplikasi segera.';
+  String get stripeReadyForPayments => 'Akun Stripe Anda sekarang siap menerima pembayaran. Anda dapat mulai menghasilkan dari penjualan aplikasi segera.';
 
   @override
   String get updateStripeDetails => 'Perbarui Detail Stripe';
@@ -5042,8 +4931,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Perbarui detail akun PayPal Anda';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Hubungkan akun PayPal Anda untuk mulai menerima pembayaran untuk aplikasi Anda';
+  String get connectPayPalToReceivePayments => 'Hubungkan akun PayPal Anda untuk mulai menerima pembayaran untuk aplikasi Anda';
 
   @override
   String get paypalEmail => 'Email PayPal';
@@ -5052,8 +4940,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get paypalMeLink => 'Tautan PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Jika Stripe tersedia di negara Anda, kami sangat menyarankan untuk menggunakannya untuk pembayaran yang lebih cepat dan mudah.';
+  String get stripeRecommendation => 'Jika Stripe tersedia di negara Anda, kami sangat menyarankan untuk menggunakannya untuk pembayaran yang lebih cepat dan mudah.';
 
   @override
   String get updatePayPalDetails => 'Perbarui Detail PayPal';
@@ -5105,12 +4992,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Sampel suara tambahan dihapus';
 
   @override
-  String get consentDataMessage =>
-      'Dengan melanjutkan, percakapan, rekaman, dan informasi pribadi Anda akan disimpan dengan aman di server kami. Rekaman audio dan transkrip Anda diproses oleh layanan AI pihak ketiga (termasuk Deepgram untuk transkripsi dan OpenAI untuk analisis) untuk memberikan Anda wawasan berbasis AI dan mengaktifkan semua fitur aplikasi.';
+  String get consentDataMessage => 'Dengan melanjutkan, percakapan, rekaman, dan informasi pribadi Anda akan disimpan dengan aman di server kami. Rekaman audio dan transkrip Anda diproses oleh layanan AI pihak ketiga (termasuk Deepgram untuk transkripsi dan OpenAI untuk analisis) untuk memberikan Anda wawasan berbasis AI dan mengaktifkan semua fitur aplikasi.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Tugas dari percakapan Anda akan muncul di sini.\nKetuk + untuk membuat secara manual.';
+  String get tasksEmptyStateMessage => 'Tugas dari percakapan Anda akan muncul di sini.\nKetuk + untuk membuat secara manual.';
 
   @override
   String get clearChatAction => 'Hapus obrolan';
@@ -5146,15 +5031,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Instal Omi di\nApple Watch Anda';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Untuk menggunakan Apple Watch dengan Omi, Anda perlu menginstal aplikasi Omi di jam tangan Anda terlebih dahulu.';
+  String get installOmiOnAppleWatchDescription => 'Untuk menggunakan Apple Watch dengan Omi, Anda perlu menginstal aplikasi Omi di jam tangan Anda terlebih dahulu.';
 
   @override
   String get openOmiOnAppleWatch => 'Buka Omi di\nApple Watch Anda';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Aplikasi Omi sudah terinstal di Apple Watch Anda. Buka dan ketuk Mulai untuk memulai.';
+  String get openOmiOnAppleWatchDescription => 'Aplikasi Omi sudah terinstal di Apple Watch Anda. Buka dan ketuk Mulai untuk memulai.';
 
   @override
   String get openWatchApp => 'Buka Aplikasi Watch';
@@ -5163,15 +5046,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Saya Sudah Menginstal & Membuka Aplikasi';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Tidak dapat membuka aplikasi Apple Watch. Silakan buka aplikasi Watch secara manual di Apple Watch Anda dan instal Omi dari bagian \"Aplikasi Tersedia\".';
+  String get unableToOpenWatchApp => 'Tidak dapat membuka aplikasi Apple Watch. Silakan buka aplikasi Watch secara manual di Apple Watch Anda dan instal Omi dari bagian \"Aplikasi Tersedia\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch berhasil terhubung!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch masih tidak dapat dijangkau. Pastikan aplikasi Omi terbuka di jam tangan Anda.';
+  String get appleWatchNotReachable => 'Apple Watch masih tidak dapat dijangkau. Pastikan aplikasi Omi terbuka di jam tangan Anda.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5188,8 +5069,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get finishedConversation => 'Percakapan selesai?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Apakah Anda yakin ingin menghentikan rekaman dan merangkum percakapan sekarang?';
+  String get stopRecordingConfirmation => 'Apakah Anda yakin ingin menghentikan rekaman dan merangkum percakapan sekarang?';
 
   @override
   String get conversationEndsManually => 'Percakapan hanya akan berakhir secara manual.';
@@ -5600,15 +5480,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get multipleSpeakersDetected => 'Beberapa pembicara terdeteksi';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Sepertinya ada beberapa pembicara dalam rekaman. Pastikan Anda berada di tempat yang tenang dan coba lagi.';
+  String get multipleSpeakersDescription => 'Sepertinya ada beberapa pembicara dalam rekaman. Pastikan Anda berada di tempat yang tenang dan coba lagi.';
 
   @override
   String get invalidRecordingDetected => 'Rekaman tidak valid terdeteksi';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Tidak cukup ucapan terdeteksi. Silakan berbicara lebih banyak dan coba lagi.';
+  String get notEnoughSpeechDescription => 'Tidak cukup ucapan terdeteksi. Silakan berbicara lebih banyak dan coba lagi.';
 
   @override
   String get speechDurationDescription => 'Pastikan Anda berbicara setidaknya 5 detik dan tidak lebih dari 90.';
@@ -5620,8 +5498,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get howToTakeGoodSample => 'Bagaimana cara membuat sampel yang baik?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Pastikan Anda berada di tempat yang tenang.\n2. Berbicara dengan jelas dan alami.\n3. Pastikan perangkat Anda dalam posisi alaminya di leher Anda.\n\nSetelah dibuat, Anda selalu dapat memperbaikinya atau membuatnya lagi.';
+  String get goodSampleInstructions => '1. Pastikan Anda berada di tempat yang tenang.\n2. Berbicara dengan jelas dan alami.\n3. Pastikan perangkat Anda dalam posisi alaminya di leher Anda.\n\nSetelah dibuat, Anda selalu dapat memperbaikinya atau membuatnya lagi.';
 
   @override
   String get noDeviceConnectedUseMic => 'Tidak ada perangkat yang terhubung. Mikrofon telepon akan digunakan.';
@@ -5684,12 +5561,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get howItWorks => 'Cara kerjanya';
 
   @override
-  String get dailyScoreExplanation =>
-      'Skor harian Anda berdasarkan penyelesaian tugas. Selesaikan tugas Anda untuk meningkatkan skor!';
+  String get dailyScoreExplanation => 'Skor harian Anda berdasarkan penyelesaian tugas. Selesaikan tugas Anda untuk meningkatkan skor!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontrol seberapa sering Omi mengirimkan notifikasi dan pengingat proaktif.';
+  String get notificationFrequencyDescription => 'Kontrol seberapa sering Omi mengirimkan notifikasi dan pengingat proaktif.';
 
   @override
   String get sliderOff => 'Mati';
@@ -5782,8 +5657,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get selectApp => 'Pilih Aplikasi';
 
   @override
-  String get noChatAppsEnabled =>
-      'Tidak ada aplikasi obrolan yang diaktifkan.\nKetuk \"Aktifkan Aplikasi\" untuk menambahkan.';
+  String get noChatAppsEnabled => 'Tidak ada aplikasi obrolan yang diaktifkan.\nKetuk \"Aktifkan Aplikasi\" untuk menambahkan.';
 
   @override
   String get disable => 'Nonaktifkan';
@@ -5848,8 +5722,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get cancelSync => 'Batalkan Sinkronisasi';
 
   @override
-  String get cancelSyncMessage =>
-      'Apakah Anda yakin ingin membatalkan sinkronisasi? Ini akan menghentikan transfer data yang sedang berlangsung.';
+  String get cancelSyncMessage => 'Apakah Anda yakin ingin membatalkan sinkronisasi? Ini akan menghentikan transfer data yang sedang berlangsung.';
 
   @override
   String get syncCancelled => 'Sinkronisasi dibatalkan';
@@ -5991,8 +5864,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get webhookUrlNotSet => 'URL Webhook belum diatur';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Silakan atur URL webhook di pengaturan pengembang untuk menggunakan fitur ini.';
+  String get setWebhookUrlInSettings => 'Silakan atur URL webhook di pengaturan pengembang untuk menggunakan fitur ini.';
 
   @override
   String get sendWebUrl => 'Kirim URL web';
@@ -6066,15 +5938,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get cloudProvider => 'Penyedia Cloud';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 menit premium/bulan. Tab Di Perangkat menawarkan transkripsi gratis tanpa batas.';
+  String get premiumMinutesInfo => '1.200 menit premium/bulan. Tab Di Perangkat menawarkan transkripsi gratis tanpa batas.';
 
   @override
   String get viewUsage => 'Lihat penggunaan';
 
   @override
-  String get localProcessingInfo =>
-      'Audio diproses secara lokal. Bekerja offline, lebih privat, tetapi menggunakan lebih banyak baterai.';
+  String get localProcessingInfo => 'Audio diproses secara lokal. Bekerja offline, lebih privat, tetapi menggunakan lebih banyak baterai.';
 
   @override
   String get model => 'Model';
@@ -6083,15 +5953,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get performanceWarning => 'Peringatan Kinerja';
 
   @override
-  String get largeModelWarning =>
-      'Model ini besar dan mungkin menyebabkan aplikasi crash atau berjalan sangat lambat di perangkat seluler.\n\n\"small\" atau \"base\" disarankan.';
+  String get largeModelWarning => 'Model ini besar dan mungkin menyebabkan aplikasi crash atau berjalan sangat lambat di perangkat seluler.\n\n\"small\" atau \"base\" disarankan.';
 
   @override
   String get usingNativeIosSpeech => 'Menggunakan Pengenalan Suara iOS Asli';
 
   @override
-  String get noModelDownloadRequired =>
-      'Mesin ucapan bawaan perangkat Anda akan digunakan. Tidak perlu mengunduh model.';
+  String get noModelDownloadRequired => 'Mesin ucapan bawaan perangkat Anda akan digunakan. Tidak perlu mengunduh model.';
 
   @override
   String get modelReady => 'Model Siap';
@@ -6148,12 +6016,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get batteryDrainSignificantly => 'Pengurasan baterai akan meningkat secara signifikan.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 menit premium/bulan. Tab Di Perangkat menawarkan transkripsi gratis tanpa batas. ';
+  String get premiumMinutesMonth => '1.200 menit premium/bulan. Tab Di Perangkat menawarkan transkripsi gratis tanpa batas. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Audio diproses secara lokal. Bekerja offline, lebih privat, tetapi menggunakan lebih banyak baterai.';
+  String get audioProcessedLocally => 'Audio diproses secara lokal. Bekerja offline, lebih privat, tetapi menggunakan lebih banyak baterai.';
 
   @override
   String get languageLabel => 'Bahasa';
@@ -6162,8 +6028,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Model ini besar dan dapat menyebabkan aplikasi crash atau berjalan sangat lambat di perangkat seluler.\n\nsmall atau base disarankan.';
+  String get modelTooLargeWarning => 'Model ini besar dan dapat menyebabkan aplikasi crash atau berjalan sangat lambat di perangkat seluler.\n\nsmall atau base disarankan.';
 
   @override
   String get nativeEngineNoDownload => 'Mesin suara asli perangkat Anda akan digunakan. Tidak perlu mengunduh model.';
@@ -6202,8 +6067,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Transkripsi langsung bawaan Omi dioptimalkan untuk percakapan real-time dengan deteksi pembicara otomatis dan diarisasi.';
+  String get omiTranscriptionOptimized => 'Transkripsi langsung bawaan Omi dioptimalkan untuk percakapan real-time dengan deteksi pembicara otomatis dan diarisasi.';
 
   @override
   String get reset => 'Reset';
@@ -6423,8 +6287,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Membangun graf pengetahuan dari kenangan...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Graf pengetahuan Anda akan dibangun secara otomatis saat Anda membuat kenangan baru.';
+  String get knowledgeGraphWillBuildAutomatically => 'Graf pengetahuan Anda akan dibangun secara otomatis saat Anda membuat kenangan baru.';
 
   @override
   String get buildGraphButton => 'Bangun Graf';
@@ -6747,8 +6610,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareRecording => 'Bagikan rekaman';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Apakah Anda yakin ingin menghapus rekaman ini secara permanen? Tindakan ini tidak dapat dibatalkan.';
+  String get deleteRecordingConfirmation => 'Apakah Anda yakin ingin menghapus rekaman ini secara permanen? Tindakan ini tidak dapat dibatalkan.';
 
   @override
   String get recordingIdLabel => 'ID Rekaman';
@@ -6807,8 +6669,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get enableFastTransfer => 'Aktifkan Transfer Cepat';
 
   @override
-  String get fastTransferDescription =>
-      'Transfer Cepat menggunakan WiFi untuk kecepatan ~5x lebih cepat. Ponsel Anda akan terhubung sementara ke jaringan WiFi perangkat Omi selama transfer.';
+  String get fastTransferDescription => 'Transfer Cepat menggunakan WiFi untuk kecepatan ~5x lebih cepat. Ponsel Anda akan terhubung sementara ke jaringan WiFi perangkat Omi selama transfer.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Akses internet dijeda selama transfer';
@@ -6823,8 +6684,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get fiveTimesFaster => '5X LEBIH CEPAT';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Membuat koneksi WiFi langsung ke perangkat Omi Anda. Ponsel Anda sementara terputus dari WiFi biasa selama transfer.';
+  String get fastTransferMethodDescription => 'Membuat koneksi WiFi langsung ke perangkat Omi Anda. Ponsel Anda sementara terputus dari WiFi biasa selama transfer.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6833,8 +6693,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get bleSpeed => '~30 KB/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Menggunakan koneksi Bluetooth Low Energy standar. Lebih lambat tetapi tidak mempengaruhi koneksi WiFi Anda.';
+  String get bluetoothMethodDescription => 'Menggunakan koneksi Bluetooth Low Energy standar. Lebih lambat tetapi tidak mempengaruhi koneksi WiFi Anda.';
 
   @override
   String get selected => 'Dipilih';
@@ -6872,12 +6731,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get appDeleteFailed => 'Gagal menghapus aplikasi. Silakan coba lagi nanti.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Visibilitas aplikasi berhasil diubah. Mungkin memerlukan beberapa menit untuk diterapkan.';
+  String get appVisibilityChangedSuccessfully => 'Visibilitas aplikasi berhasil diubah. Mungkin memerlukan beberapa menit untuk diterapkan.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Kesalahan saat mengaktifkan aplikasi. Jika ini adalah aplikasi integrasi, pastikan pengaturan sudah selesai.';
+  String get errorActivatingAppIntegration => 'Kesalahan saat mengaktifkan aplikasi. Jika ini adalah aplikasi integrasi, pastikan pengaturan sudah selesai.';
 
   @override
   String get errorUpdatingAppStatus => 'Terjadi kesalahan saat memperbarui status aplikasi.';
@@ -6945,8 +6802,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get importantConversationTitle => 'Percakapan Penting';
 
   @override
-  String get importantConversationBody =>
-      'Anda baru saja melakukan percakapan penting. Ketuk untuk membagikan ringkasan.';
+  String get importantConversationBody => 'Anda baru saja melakukan percakapan penting. Ketuk untuk membagikan ringkasan.';
 
   @override
   String get templateName => 'Nama Template';
@@ -7319,8 +7175,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Gagal mengambil token. Silakan coba lagi.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Terjadi kesalahan tak terduga saat masuk dengan Firebase. Silakan coba lagi.';
+  String get authUnexpectedErrorFirebase => 'Terjadi kesalahan tak terduga saat masuk dengan Firebase. Silakan coba lagi.';
 
   @override
   String get authUnexpectedError => 'Terjadi kesalahan tak terduga saat masuk. Silakan coba lagi.';
@@ -7351,8 +7206,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get onboardingNotificationDeniedSystemPrefs => 'Izin notifikasi ditolak. Harap aktifkan di Preferensi Sistem.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Izin notifikasi ditolak. Harap aktifkan di pengaturan Notifikasi.';
+  String get onboardingNotificationDeniedNotifications => 'Izin notifikasi ditolak. Harap aktifkan di pengaturan Notifikasi.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7512,8 +7366,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get locationPermissionRequired => 'Izin Lokasi Diperlukan';
 
   @override
-  String get locationPermissionContent =>
-      'Transfer Cepat memerlukan izin lokasi untuk memverifikasi koneksi WiFi. Harap berikan izin lokasi untuk melanjutkan.';
+  String get locationPermissionContent => 'Transfer Cepat memerlukan izin lokasi untuk memverifikasi koneksi WiFi. Harap berikan izin lokasi untuk melanjutkan.';
 
   @override
   String get pdfTranscriptExport => 'Ekspor Transkrip';
@@ -7676,8 +7529,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Perangkat tidak mendukung sinkronisasi WiFi, beralih ke Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Perangkat tidak mendukung sinkronisasi WiFi, beralih ke Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health tidak tersedia di perangkat ini';
@@ -7973,8 +7825,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Masukkan Omi DevKit ke Mode Pemasangan';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Tekan tombol sekali untuk menyalakan. LED akan berkedip ungu saat dalam mode pemasangan.';
+  String get pairingDescOmiDevkit => 'Tekan tombol sekali untuk menyalakan. LED akan berkedip ungu saat dalam mode pemasangan.';
 
   @override
   String get pairingTitleOmiGlass => 'Nyalakan Omi Glass';
@@ -7986,8 +7837,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Masukkan Plaud Note ke Mode Pemasangan';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Tekan dan tahan tombol samping selama 2 detik. LED merah akan berkedip saat siap dipasangkan.';
+  String get pairingDescPlaudNote => 'Tekan dan tahan tombol samping selama 2 detik. LED merah akan berkedip saat siap dipasangkan.';
 
   @override
   String get pairingTitleBee => 'Masukkan Bee ke Mode Pemasangan';
@@ -7999,15 +7849,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get pairingTitleLimitless => 'Masukkan Limitless ke Mode Pemasangan';
 
   @override
-  String get pairingDescLimitless =>
-      'Saat lampu menyala, tekan sekali lalu tekan dan tahan hingga perangkat menunjukkan lampu merah muda, lalu lepaskan.';
+  String get pairingDescLimitless => 'Saat lampu menyala, tekan sekali lalu tekan dan tahan hingga perangkat menunjukkan lampu merah muda, lalu lepaskan.';
 
   @override
   String get pairingTitleFriendPendant => 'Masukkan Friend Pendant ke Mode Pemasangan';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Tekan tombol pada liontin untuk menyalakannya. Perangkat akan masuk mode pemasangan secara otomatis.';
+  String get pairingDescFriendPendant => 'Tekan tombol pada liontin untuk menyalakannya. Perangkat akan masuk mode pemasangan secara otomatis.';
 
   @override
   String get pairingTitleFieldy => 'Masukkan Fieldy ke Mode Pemasangan';
@@ -8019,8 +7867,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Hubungkan Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Instal dan buka aplikasi Omi di Apple Watch Anda, lalu ketuk Hubungkan di aplikasi.';
+  String get pairingDescAppleWatch => 'Instal dan buka aplikasi Omi di Apple Watch Anda, lalu ketuk Hubungkan di aplikasi.';
 
   @override
   String get pairingTitleNeoOne => 'Masukkan Neo One ke Mode Pemasangan';
@@ -8143,8 +7990,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get switchAndRestart => 'Ganti';
 
   @override
-  String get stagingDisclaimer =>
-      'Lingkungan pengujian mungkin tidak stabil, memiliki kinerja yang tidak konsisten, dan data mungkin hilang. Hanya untuk pengujian.';
+  String get stagingDisclaimer => 'Lingkungan pengujian mungkin tidak stabil, memiliki kinerja yang tidak konsisten, dan data mungkin hilang. Hanya untuk pengujian.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Tersimpan. Tutup dan buka kembali aplikasi untuk menerapkan perubahan.';
@@ -8373,8 +8219,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Panggilan Telepon via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Lakukan panggilan melalui Omi dan dapatkan transkripsi real-time, ringkasan otomatis, dan lainnya.';
+  String get phoneCallsUpsellSubtitle => 'Lakukan panggilan melalui Omi dan dapatkan transkripsi real-time, ringkasan otomatis, dan lainnya.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transkripsi real-time setiap panggilan';
@@ -8413,8 +8258,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get deletePendingFiles => 'Hapus rekaman tertunda';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Rekaman ini BELUM disinkronkan ke ponsel Anda dan akan hilang secara permanen. Ini tidak dapat dibatalkan.';
+  String get deletePendingFilesWarning => 'Rekaman ini BELUM disinkronkan ke ponsel Anda dan akan hilang secara permanen. Ini tidak dapat dibatalkan.';
 
   @override
   String get pendingFilesDeleted => 'Rekaman tertunda dihapus';
@@ -8426,8 +8270,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get deleteAll => 'Hapus semua';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Ini akan menghapus rekaman tersinkronisasi dan tertunda. Rekaman tertunda BELUM disinkronkan dan akan hilang secara permanen.';
+  String get deleteAllFilesWarning => 'Ini akan menghapus rekaman tersinkronisasi dan tertunda. Rekaman tertunda BELUM disinkronkan dan akan hilang secara permanen.';
 
   @override
   String get allFilesDeleted => 'Semua rekaman dihapus';
@@ -8492,8 +8335,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get fairUseAboutTitle => 'Tentang Penggunaan Wajar';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi dirancang untuk percakapan pribadi, rapat, dan interaksi langsung. Penggunaan diukur berdasarkan waktu bicara nyata yang terdeteksi, bukan waktu koneksi. Jika penggunaan secara signifikan melebihi pola normal untuk konten non-pribadi, penyesuaian dapat diterapkan.';
+  String get fairUseAboutBody => 'Omi dirancang untuk percakapan pribadi, rapat, dan interaksi langsung. Penggunaan diukur berdasarkan waktu bicara nyata yang terdeteksi, bukan waktu koneksi. Jika penggunaan secara signifikan melebihi pola normal untuk konten non-pribadi, penyesuaian dapat diterapkan.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8531,8 +8373,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get improveConnectionTitle => 'Tingkatkan Koneksi';
 
   @override
-  String get improveConnectionContent =>
-      'Kami telah meningkatkan cara Omi tetap terhubung ke perangkat Anda. Untuk mengaktifkan ini, buka halaman Info Perangkat, ketuk \"Putuskan Perangkat\", lalu pasangkan perangkat Anda kembali.';
+  String get improveConnectionContent => 'Kami telah meningkatkan cara Omi tetap terhubung ke perangkat Anda. Untuk mengaktifkan ini, buka halaman Info Perangkat, ketuk \"Putuskan Perangkat\", lalu pasangkan perangkat Anda kembali.';
 
   @override
   String get improveConnectionAction => 'Mengerti';
@@ -8587,16 +8428,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get cancelSyncQuestion => 'Batalkan sinkronisasi?';
 
   @override
-  String get omisStorageDesc =>
-      'Saat Omi tidak terhubung ke ponsel Anda, ia menyimpan audio secara lokal di memori bawaannya. Anda tidak akan pernah kehilangan rekaman.';
+  String get omisStorageDesc => 'Saat Omi tidak terhubung ke ponsel Anda, ia menyimpan audio secara lokal di memori bawaannya. Anda tidak akan pernah kehilangan rekaman.';
 
   @override
-  String get phoneStorageDesc =>
-      'Saat Omi terhubung kembali, rekaman ditransfer otomatis ke ponsel Anda sebelum diunggah.';
+  String get phoneStorageDesc => 'Saat Omi terhubung kembali, rekaman ditransfer otomatis ke ponsel Anda sebelum diunggah.';
 
   @override
-  String get cloudStorageDesc =>
-      'Setelah diunggah, rekaman Anda diproses dan ditranskripsikan. Percakapan akan tersedia dalam satu menit.';
+  String get cloudStorageDesc => 'Setelah diunggah, rekaman Anda diproses dan ditranskripsikan. Percakapan akan tersedia dalam satu menit.';
 
   @override
   String get tipKeepPhoneNearby => 'Jaga ponsel Anda dekat untuk sinkronisasi lebih cepat';
@@ -8620,12 +8458,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get permissionEnable => 'Aktifkan';
 
   @override
-  String get permissionsPageDescription =>
-      'Izin ini penting untuk cara kerja Omi. Izin ini mengaktifkan fitur utama seperti notifikasi, pengalaman berbasis lokasi, dan perekaman audio.';
+  String get permissionsPageDescription => 'Izin ini penting untuk cara kerja Omi. Izin ini mengaktifkan fitur utama seperti notifikasi, pengalaman berbasis lokasi, dan perekaman audio.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi memerlukan beberapa izin agar dapat berfungsi dengan baik. Silakan berikan izin untuk melanjutkan.';
+  String get permissionsRequiredDescription => 'Omi memerlukan beberapa izin agar dapat berfungsi dengan baik. Silakan berikan izin untuk melanjutkan.';
 
   @override
   String get permissionsSetupTitle => 'Dapatkan pengalaman terbaik';
@@ -8679,8 +8515,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get justAMoment => 'Sebentar, silakan';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Kami sangat menyarankan untuk menjelajahi opsi lain Anda daripada membatalkan.';
+  String get cancelConsequencesSubtitle => 'Kami sangat menyarankan untuk menjelajahi opsi lain Anda daripada membatalkan.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8903,8 +8738,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get firmwareWarningTitle => 'Penting: Baca Sebelum Memperbarui';
 
   @override
-  String get firmwareFormatWarning =>
-      'Firmware ini akan memformat kartu SD. Pastikan semua data offline telah disinkronkan sebelum memperbarui.\n\nJika Anda melihat lampu merah berkedip setelah menginstal versi ini, jangan khawatir. Cukup hubungkan perangkat ke aplikasi dan lampu akan berubah menjadi biru. Lampu merah berarti jam perangkat belum disinkronkan.';
+  String get firmwareFormatWarning => 'Firmware ini akan memformat kartu SD. Pastikan semua data offline telah disinkronkan sebelum memperbarui.\n\nJika Anda melihat lampu merah berkedip setelah menginstal versi ini, jangan khawatir. Cukup hubungkan perangkat ke aplikasi dan lampu akan berubah menjadi biru. Lampu merah berarti jam perangkat belum disinkronkan.';
 
   @override
   String get continueAnyway => 'Lanjutkan';
@@ -8924,8 +8758,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get tasksMarkComplete => 'Ditandai selesai';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi mengakses Apple Health melalui framework HealthKit dari Apple. Anda dapat mencabut akses kapan saja di Pengaturan iOS.';
+  String get appleHealthManageNote => 'Omi mengakses Apple Health melalui framework HealthKit dari Apple. Anda dapat mencabut akses kapan saja di Pengaturan iOS.';
 
   @override
   String get appleHealthConnectCta => 'Hubungkan ke Apple Health';
@@ -8958,8 +8791,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Akses Apple Health ditolak';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi tidak memiliki izin untuk membaca data Apple Health Anda. Aktifkan di Pengaturan iOS → Privasi & Keamanan → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi tidak memiliki izin untuk membaca data Apple Health Anda. Aktifkan di Pengaturan iOS → Privasi & Keamanan → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Mengapa Anda pergi?';
@@ -9028,8 +8860,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get planUpdate => 'Pembaruan Paket';
 
   @override
-  String get planDeprecationMessage =>
-      'Paket Unlimited Anda akan dihentikan. Beralih ke paket Operator — fitur hebat yang sama seharga \$49/bulan. Paket Anda saat ini akan terus berfungsi untuk sementara.';
+  String get planDeprecationMessage => 'Paket Unlimited Anda akan dihentikan. Beralih ke paket Operator — fitur hebat yang sama seharga \$49/bulan. Paket Anda saat ini akan terus berfungsi untuk sementara.';
 
   @override
   String get upgradeYourPlan => 'Tingkatkan Paket Anda';
@@ -9140,8 +8971,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Anda telah mencapai batas bulanan. Upgrade untuk terus mengobrol dengan Omi tanpa batasan.';
+  String get chatQuotaExceededReply => 'Anda telah mencapai batas bulanan. Upgrade untuk terus mengobrol dengan Omi tanpa batasan.';
 
   @override
   String get voiceResponseAudio => 'Bacakan respons Omi';
@@ -9172,4 +9002,25 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Tambah Tugas';
+
+  @override
+  String get quickActionAskOmiAnything => 'Tanyakan apa saja kepada Omi';
+
+  @override
+  String get quickActionVoiceMode => 'Mode Suara';
+
+  @override
+  String get quickActionMute => 'Bisukan';
+
+  @override
+  String get quickActionUnmute => 'Aktifkan Suara';
+
+  @override
+  String get quickActionConnectDevice => 'Hubungkan Perangkat';
+
+  @override
+  String get quickActionDeviceSettings => 'Pengaturan Perangkat';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -24,8 +24,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteConversationTitle => 'Eliminare Conversazione?';
 
   @override
-  String get deleteConversationMessage =>
-      'Questo eliminerà anche i ricordi, le attività e i file audio associati. Questa azione non può essere annullata.';
+  String get deleteConversationMessage => 'Questo eliminerà anche i ricordi, le attività e i file audio associati. Questa azione non può essere annullata.';
 
   @override
   String get confirm => 'Conferma';
@@ -146,8 +145,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleting => 'Eliminazione...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Completa l\'autenticazione nel tuo browser. Una volta fatto, torna all\'app.';
+  String get pleaseCompleteAuthentication => 'Completa l\'autenticazione nel tuo browser. Una volta fatto, torna all\'app.';
 
   @override
   String get failedToStartAuthentication => 'Impossibile avviare l\'autenticazione';
@@ -228,8 +226,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noStarredConversations => 'Nessuna conversazione con stella';
 
   @override
-  String get starConversationHint =>
-      'Per aggiungere una conversazione ai preferiti, aprila e tocca l\'icona stella nell\'intestazione.';
+  String get starConversationHint => 'Per aggiungere una conversazione ai preferiti, aprila e tocca l\'icona stella nell\'intestazione.';
 
   @override
   String get searchConversations => 'Cerca conversazioni...';
@@ -320,8 +317,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get installedApps => 'App installate';
 
   @override
-  String get unableToFetchApps =>
-      'Impossibile recuperare le app :(\n\nControlla la tua connessione internet e riprova.';
+  String get unableToFetchApps => 'Impossibile recuperare le app :(\n\nControlla la tua connessione internet e riprova.';
 
   @override
   String get aboutOmi => 'Informazioni su Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get appsDisconnected => 'Le tue App e Integrazioni saranno disconnesse immediatamente.';
 
   @override
-  String get exportBeforeDelete =>
-      'Puoi esportare i tuoi dati prima di eliminare il tuo account, ma una volta eliminato, non può essere recuperato.';
+  String get exportBeforeDelete => 'Puoi esportare i tuoi dati prima di eliminare il tuo account, ma una volta eliminato, non può essere recuperato.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Comprendo che l\'eliminazione del mio account è permanente e tutti i dati, inclusi ricordi e conversazioni, saranno persi e non potranno essere recuperati.';
+  String get deleteAccountCheckbox => 'Comprendo che l\'eliminazione del mio account è permanente e tutti i dati, inclusi ricordi e conversazioni, saranno persi e non potranno essere recuperati.';
 
   @override
   String get areYouSure => 'Sei sicuro?';
 
   @override
-  String get deleteAccountFinal =>
-      'Questa azione è irreversibile e eliminerà permanentemente il tuo account e tutti i dati associati. Sei sicuro di voler procedere?';
+  String get deleteAccountFinal => 'Questa azione è irreversibile e eliminerà permanentemente il tuo account e tutti i dati associati. Sei sicuro di voler procedere?';
 
   @override
   String get deleteNow => 'Elimina Ora';
@@ -378,8 +371,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get goBack => 'Indietro';
 
   @override
-  String get checkBoxToConfirm =>
-      'Seleziona la casella per confermare di aver compreso che l\'eliminazione del tuo account è permanente e irreversibile.';
+  String get checkBoxToConfirm => 'Seleziona la casella per confermare di aver compreso che l\'eliminazione del tuo account è permanente e irreversibile.';
 
   @override
   String get profile => 'Profilo';
@@ -457,8 +449,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get yourPrivacyYourControl => 'La Tua Privacy, Il Tuo Controllo';
 
   @override
-  String get privacyIntro =>
-      'In Omi ci impegniamo a proteggere la tua privacy. Questa pagina ti permette di controllare come vengono archiviati e utilizzati i tuoi dati.';
+  String get privacyIntro => 'In Omi ci impegniamo a proteggere la tua privacy. Questa pagina ti permette di controllare come vengono archiviati e utilizzati i tuoi dati.';
 
   @override
   String get learnMore => 'Scopri di più...';
@@ -467,15 +458,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dataProtectionLevel => 'Livello di Protezione Dati';
 
   @override
-  String get dataProtectionDesc =>
-      'I tuoi dati sono protetti di default con crittografia avanzata. Rivedi le tue impostazioni e le future opzioni di privacy qui sotto.';
+  String get dataProtectionDesc => 'I tuoi dati sono protetti di default con crittografia avanzata. Rivedi le tue impostazioni e le future opzioni di privacy qui sotto.';
 
   @override
   String get appAccess => 'Accesso App';
 
   @override
-  String get appAccessDesc =>
-      'Le seguenti app possono accedere ai tuoi dati. Tocca un\'app per gestire i suoi permessi.';
+  String get appAccessDesc => 'Le seguenti app possono accedere ai tuoi dati. Tocca un\'app per gestire i suoi permessi.';
 
   @override
   String get noAppsExternalAccess => 'Nessuna app installata ha accesso esterno ai tuoi dati.';
@@ -532,22 +521,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Il tuo Omi è stato disconnesso 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Dispositivo disaccoppiato. Vai in Impostazioni > Bluetooth e dimentica il dispositivo per completare il disaccoppiamento.';
+  String get deviceUnpairedMessage => 'Dispositivo disaccoppiato. Vai in Impostazioni > Bluetooth e dimentica il dispositivo per completare il disaccoppiamento.';
 
   @override
   String get unpairDialogTitle => 'Disaccoppia Dispositivo';
 
   @override
-  String get unpairDialogMessage =>
-      'Questo disaccoppierà il dispositivo in modo che possa essere connesso a un altro telefono. Dovrai andare su Impostazioni > Bluetooth e dimenticare il dispositivo per completare il processo.';
+  String get unpairDialogMessage => 'Questo disaccoppierà il dispositivo in modo che possa essere connesso a un altro telefono. Dovrai andare su Impostazioni > Bluetooth e dimenticare il dispositivo per completare il processo.';
 
   @override
   String get deviceNotConnected => 'Dispositivo Non Connesso';
 
   @override
-  String get connectDeviceMessage =>
-      'Connetti il tuo dispositivo Omi per accedere\nalle impostazioni e alla personalizzazione del dispositivo';
+  String get connectDeviceMessage => 'Connetti il tuo dispositivo Omi per accedere\nalle impostazioni e alla personalizzazione del dispositivo';
 
   @override
   String get deviceInfoSection => 'Informazioni Dispositivo';
@@ -562,8 +548,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get v2Undetected => 'V2 non rilevato';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vediamo che hai un dispositivo V1 o il tuo dispositivo non è connesso. La funzionalità della scheda SD è disponibile solo per i dispositivi V2.';
+  String get v2UndetectedMessage => 'Vediamo che hai un dispositivo V1 o il tuo dispositivo non è connesso. La funzionalità della scheda SD è disponibile solo per i dispositivi V2.';
 
   @override
   String get endConversation => 'Termina Conversazione';
@@ -695,8 +680,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noActivityYet => 'Nessuna Attività Ancora';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Inizia una conversazione con Omi\nper vedere le tue statistiche di utilizzo qui.';
+  String get startConversationToSeeInsights => 'Inizia una conversazione con Omi\nper vedere le tue statistiche di utilizzo qui.';
 
   @override
   String get listening => 'Ascolto';
@@ -838,8 +822,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Eliminare Grafo di Conoscenza?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Questo eliminerà tutti i dati del grafo di conoscenza derivato (nodi e connessioni). I tuoi ricordi originali rimarranno al sicuro. Il grafo sarà ricostruito nel tempo o alla prossima richiesta.';
+  String get deleteKnowledgeGraphMessage => 'Questo eliminerà tutti i dati del grafo di conoscenza derivato (nodi e connessioni). I tuoi ricordi originali rimarranno al sicuro. Il grafo sarà ricostruito nel tempo o alla prossima richiesta.';
 
   @override
   String get knowledgeGraphDeleted => 'Grafico della conoscenza eliminato';
@@ -987,8 +970,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get shortConversationThreshold => 'Soglia Conversazione Breve';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Le conversazioni più brevi di questa soglia saranno nascoste se non abilitate sopra';
+  String get shortConversationThresholdSubtitle => 'Le conversazioni più brevi di questa soglia saranno nascoste se non abilitate sopra';
 
   @override
   String get durationThreshold => 'Soglia Durata';
@@ -1083,8 +1065,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get needYourPermission => 'Abbiamo bisogno del tuo permesso';
 
   @override
-  String get alreadyGavePermission =>
-      'Ci hai già dato il permesso di salvare le tue registrazioni. Ecco un promemoria del perché ne abbiamo bisogno:';
+  String get alreadyGavePermission => 'Ci hai già dato il permesso di salvare le tue registrazioni. Ecco un promemoria del perché ne abbiamo bisogno:';
 
   @override
   String get wouldLikePermission => 'Vorremmo il tuo permesso per salvare le tue registrazioni vocali. Ecco perché:';
@@ -1093,26 +1074,22 @@ class AppLocalizationsIt extends AppLocalizations {
   String get improveSpeechProfile => 'Migliora il Tuo Profilo Vocale';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Utilizziamo le registrazioni per addestrare e migliorare ulteriormente il tuo profilo vocale personale.';
+  String get improveSpeechProfileDesc => 'Utilizziamo le registrazioni per addestrare e migliorare ulteriormente il tuo profilo vocale personale.';
 
   @override
   String get trainFamilyProfiles => 'Addestra Profili per Amici e Famiglia';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Le tue registrazioni ci aiutano a riconoscere e creare profili per i tuoi amici e familiari.';
+  String get trainFamilyProfilesDesc => 'Le tue registrazioni ci aiutano a riconoscere e creare profili per i tuoi amici e familiari.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Migliora Precisione Trascrizione';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Man mano che il nostro modello migliora, possiamo fornire risultati di trascrizione migliori per le tue registrazioni.';
+  String get enhanceTranscriptAccuracyDesc => 'Man mano che il nostro modello migliora, possiamo fornire risultati di trascrizione migliori per le tue registrazioni.';
 
   @override
-  String get legalNotice =>
-      'Avviso Legale: La legalità della registrazione e dell\'archiviazione dei dati vocali può variare a seconda della tua posizione e di come utilizzi questa funzione. È tua responsabilità garantire la conformità con le leggi e i regolamenti locali.';
+  String get legalNotice => 'Avviso Legale: La legalità della registrazione e dell\'archiviazione dei dati vocali può variare a seconda della tua posizione e di come utilizzi questa funzione. È tua responsabilità garantire la conformità con le leggi e i regolamenti locali.';
 
   @override
   String get alreadyAuthorized => 'Già Autorizzato';
@@ -1184,15 +1161,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showMeetingsMenuBar => 'Mostra riunioni imminenti nella barra dei menu';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Visualizza la tua prossima riunione e il tempo rimanente nella barra dei menu di macOS';
+  String get showMeetingsMenuBarDesc => 'Visualizza la tua prossima riunione e il tempo rimanente nella barra dei menu di macOS';
 
   @override
   String get showEventsNoParticipants => 'Mostra eventi senza partecipanti';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Quando abilitato, Prossimi Eventi mostra eventi senza partecipanti o link video.';
+  String get showEventsNoParticipantsDesc => 'Quando abilitato, Prossimi Eventi mostra eventi senza partecipanti o link video.';
 
   @override
   String get yourMeetings => 'Le Tue Riunioni';
@@ -1233,8 +1208,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noProjectsInWorkspace => 'Nessun progetto trovato in quest\'area di lavoro';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Scegli quanto tempo attendere in silenzio prima di terminare automaticamente una conversazione:';
+  String get conversationTimeoutDesc => 'Scegli quanto tempo attendere in silenzio prima di terminare automaticamente una conversazione:';
 
   @override
   String get timeout2Minutes => '2 minuti';
@@ -1278,12 +1252,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Dicci la tua lingua principale';
 
   @override
-  String get languageForTranscription =>
-      'Imposta la tua lingua per trascrizioni più accurate e un\'esperienza personalizzata.';
+  String get languageForTranscription => 'Imposta la tua lingua per trascrizioni più accurate e un\'esperienza personalizzata.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Modalità Lingua Singola attivata. La traduzione è disabilitata per una maggiore precisione.';
+  String get singleLanguageModeInfo => 'Modalità Lingua Singola attivata. La traduzione è disabilitata per una maggiore precisione.';
 
   @override
   String get searchLanguageHint => 'Cerca lingua per nome o codice';
@@ -1363,8 +1335,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get defaultRepository => 'Repository Predefinito';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Seleziona un repository predefinito per creare issue. Puoi comunque specificare un repository diverso durante la creazione di issue.';
+  String get selectDefaultRepoDesc => 'Seleziona un repository predefinito per creare issue. Puoi comunque specificare un repository diverso durante la creazione di issue.';
 
   @override
   String get noReposFound => 'Nessun repository trovato';
@@ -1739,8 +1710,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get enableBluetooth => 'Abilita Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi ha bisogno del Bluetooth per connettersi al tuo dispositivo indossabile. Abilita il Bluetooth e riprova.';
+  String get bluetoothNeeded => 'Omi ha bisogno del Bluetooth per connettersi al tuo dispositivo indossabile. Abilita il Bluetooth e riprova.';
 
   @override
   String get contactSupport => 'Contatta Supporto?';
@@ -1773,26 +1743,22 @@ class AppLocalizationsIt extends AppLocalizations {
   String get locationServiceDisabled => 'Servizio di Localizzazione Disabilitato';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Il Servizio di Localizzazione è disabilitato. Vai su Impostazioni > Privacy e Sicurezza > Servizi di Localizzazione e abilitalo';
+  String get locationServiceDisabledDesc => 'Il Servizio di Localizzazione è disabilitato. Vai su Impostazioni > Privacy e Sicurezza > Servizi di Localizzazione e abilitalo';
 
   @override
   String get backgroundLocationDenied => 'Accesso Posizione in Background Negato';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Vai nelle impostazioni del dispositivo e imposta il permesso di localizzazione su \"Consenti sempre\"';
+  String get backgroundLocationDeniedDesc => 'Vai nelle impostazioni del dispositivo e imposta il permesso di localizzazione su \"Consenti sempre\"';
 
   @override
   String get lovingOmi => 'Ti piace Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Aiutaci a raggiungere più persone lasciando una recensione sull\'App Store. Il tuo feedback è prezioso per noi!';
+  String get leaveReviewIos => 'Aiutaci a raggiungere più persone lasciando una recensione sull\'App Store. Il tuo feedback è prezioso per noi!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Aiutaci a raggiungere più persone lasciando una recensione sul Google Play Store. Il tuo feedback è prezioso per noi!';
+  String get leaveReviewAndroid => 'Aiutaci a raggiungere più persone lasciando una recensione sul Google Play Store. Il tuo feedback è prezioso per noi!';
 
   @override
   String get rateOnAppStore => 'Valuta su App Store';
@@ -1825,15 +1791,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get connectionError => 'Errore di Connessione';
 
   @override
-  String get connectionErrorDesc =>
-      'Impossibile connettersi al server. Controlla la tua connessione internet e riprova.';
+  String get connectionErrorDesc => 'Impossibile connettersi al server. Controlla la tua connessione internet e riprova.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Registrazione non valida rilevata';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Sembra che ci siano più persone che parlano nella registrazione. Assicurati di essere in un luogo silenzioso e riprova.';
+  String get multipleSpeakersDesc => 'Sembra che ci siano più persone che parlano nella registrazione. Assicurati di essere in un luogo silenzioso e riprova.';
 
   @override
   String get tooShortDesc => 'Non è stato rilevato abbastanza parlato. Parla di più e riprova.';
@@ -1845,15 +1809,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get areYouThere => 'Ci sei?';
 
   @override
-  String get noSpeechDesc =>
-      'Non abbiamo rilevato nessun parlato. Assicurati di parlare per almeno 10 secondi e non più di 3 minuti.';
+  String get noSpeechDesc => 'Non abbiamo rilevato nessun parlato. Assicurati di parlare per almeno 10 secondi e non più di 3 minuti.';
 
   @override
   String get connectionLost => 'Connessione Persa';
 
   @override
-  String get connectionLostDesc =>
-      'La connessione è stata interrotta. Controlla la tua connessione internet e riprova.';
+  String get connectionLostDesc => 'La connessione è stata interrotta. Controlla la tua connessione internet e riprova.';
 
   @override
   String get tryAgain => 'Riprova';
@@ -1868,8 +1830,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get permissionsRequired => 'Autorizzazioni richieste';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Questa app ha bisogno dei permessi Bluetooth e Posizione per funzionare correttamente. Abilitali nelle impostazioni.';
+  String get permissionsRequiredDesc => 'Questa app ha bisogno dei permessi Bluetooth e Posizione per funzionare correttamente. Abilitali nelle impostazioni.';
 
   @override
   String get openSettings => 'Apri Impostazioni';
@@ -1899,8 +1860,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Il Tuo Compagno AI';
 
   @override
-  String get captureEveryMoment =>
-      'Cattura ogni momento. Ottieni riepiloghi\nbasati sull\'AI. Non prendere mai più appunti.';
+  String get captureEveryMoment => 'Cattura ogni momento. Ottieni riepiloghi\nbasati sull\'AI. Non prendere mai più appunti.';
 
   @override
   String get appleWatchSetup => 'Configurazione Apple Watch';
@@ -1912,12 +1872,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get microphonePermission => 'Permesso Microfono';
 
   @override
-  String get permissionGrantedNow =>
-      'Permesso concesso! Ora:\n\nApri l\'app Omi sul tuo watch e tocca \"Continua\" qui sotto';
+  String get permissionGrantedNow => 'Permesso concesso! Ora:\n\nApri l\'app Omi sul tuo watch e tocca \"Continua\" qui sotto';
 
   @override
-  String get needMicrophonePermission =>
-      'Abbiamo bisogno del permesso microfono.\n\n1. Tocca \"Concedi Permesso\"\n2. Consenti sul tuo iPhone\n3. L\'app Watch si chiuderà\n4. Riaprila e tocca \"Continua\"';
+  String get needMicrophonePermission => 'Abbiamo bisogno del permesso microfono.\n\n1. Tocca \"Concedi Permesso\"\n2. Consenti sul tuo iPhone\n3. L\'app Watch si chiuderà\n4. Riaprila e tocca \"Continua\"';
 
   @override
   String get grantPermissionButton => 'Concedi Permesso';
@@ -1926,15 +1884,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get needHelp => 'Serve Aiuto?';
 
   @override
-  String get troubleshootingSteps =>
-      'Risoluzione problemi:\n\n1. Assicurati che Omi sia installato sul tuo watch\n2. Apri l\'app Omi sul tuo watch\n3. Cerca il popup di permesso\n4. Tocca \"Consenti\" quando richiesto\n5. L\'app sul watch si chiuderà - riaprila\n6. Torna e tocca \"Continua\" sul tuo iPhone';
+  String get troubleshootingSteps => 'Risoluzione problemi:\n\n1. Assicurati che Omi sia installato sul tuo watch\n2. Apri l\'app Omi sul tuo watch\n3. Cerca il popup di permesso\n4. Tocca \"Consenti\" quando richiesto\n5. L\'app sul watch si chiuderà - riaprila\n6. Torna e tocca \"Continua\" sul tuo iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Registrazione avviata con successo!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Permesso non ancora concesso. Assicurati di aver consentito l\'accesso al microfono e di aver riaperto l\'app sul tuo watch.';
+  String get permissionNotGrantedYet => 'Permesso non ancora concesso. Assicurati di aver consentito l\'accesso al microfono e di aver riaperto l\'app sul tuo watch.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2031,8 +1987,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Pronto per le Azioni';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'La tua AI estrarrà automaticamente attività e cose da fare dalle tue conversazioni. Appariranno qui quando create.';
+  String get welcomeActionItemsDescription => 'La tua AI estrarrà automaticamente attività e cose da fare dalle tue conversazioni. Appariranno qui quando create.';
 
   @override
   String get autoExtractionFeature => 'Estratto automaticamente dalle conversazioni';
@@ -2082,8 +2037,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get clearMemoryTitle => 'Cancella Memoria di Omi';
 
   @override
-  String get clearMemoryMessage =>
-      'Sei sicuro di voler cancellare la memoria di Omi? Questa azione non può essere annullata.';
+  String get clearMemoryMessage => 'Sei sicuro di voler cancellare la memoria di Omi? Questa azione non può essere annullata.';
 
   @override
   String get clearMemoryButton => 'Cancella memoria';
@@ -2229,15 +2183,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'VOCE E TRASCRIZIONE';
 
   @override
-  String get languageSettingsHelperText =>
-      'La lingua dell\'app modifica menu e pulsanti. La lingua vocale influisce su come vengono trascritte le tue registrazioni.';
+  String get languageSettingsHelperText => 'La lingua dell\'app modifica menu e pulsanti. La lingua vocale influisce su come vengono trascritte le tue registrazioni.';
 
   @override
   String get translationNotice => 'Avviso di traduzione';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi traduce le conversazioni nella tua lingua principale. Aggiornala in qualsiasi momento in Impostazioni → Profili.';
+  String get translationNoticeMessage => 'Omi traduce le conversazioni nella tua lingua principale. Aggiornala in qualsiasi momento in Impostazioni → Profili.';
 
   @override
   String get pleaseCheckInternetConnection => 'Controlla la tua connessione Internet e riprova';
@@ -2257,8 +2209,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Questa conversazione non può essere unita (bloccata o già in fase di unione)';
+  String get conversationCannotBeMerged => 'Questa conversazione non può essere unita (bloccata o già in fase di unione)';
 
   @override
   String get pleaseEnterFolderName => 'Inserisci un nome per la cartella';
@@ -2393,8 +2344,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Disaccoppia dispositivo';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Questo disaccoppierà il dispositivo in modo che possa essere connesso a un altro telefono. Dovrai andare in Impostazioni > Bluetooth e dimenticare il dispositivo per completare il processo.';
+  String get unpairDeviceDialogMessage => 'Questo disaccoppierà il dispositivo in modo che possa essere connesso a un altro telefono. Dovrai andare in Impostazioni > Bluetooth e dimenticare il dispositivo per completare il processo.';
 
   @override
   String get unpair => 'Disaccoppia';
@@ -2560,8 +2510,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get howDoesItWork => 'Come funziona?';
 
   @override
-  String get sdCardSyncDescription =>
-      'La sincronizzazione della scheda SD importerà i tuoi ricordi dalla scheda SD all\'app';
+  String get sdCardSyncDescription => 'La sincronizzazione della scheda SD importerà i tuoi ricordi dalla scheda SD all\'app';
 
   @override
   String get checksForAudioFiles => 'Controlla i file audio sulla scheda SD';
@@ -2576,8 +2525,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get youreAllSet => 'Sei pronto!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Benvenuto in Omi! Il tuo compagno AI è pronto ad aiutarti con conversazioni, attività e molto altro.';
+  String get welcomeToOmiDescription => 'Benvenuto in Omi! Il tuo compagno AI è pronto ad aiutarti con conversazioni, attività e molto altro.';
 
   @override
   String get startUsingOmi => 'Inizia a usare Omi';
@@ -2656,8 +2604,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get reviewAndManageConversations => 'Rivedi e gestisci le tue conversazioni registrate';
 
   @override
-  String get startCapturingConversations =>
-      'Inizia a catturare conversazioni con il tuo dispositivo Omi per vederle qui.';
+  String get startCapturingConversations => 'Inizia a catturare conversazioni con il tuo dispositivo Omi per vederle qui.';
 
   @override
   String get useMobileAppToCapture => 'Usa la tua app mobile per catturare l\'audio';
@@ -2714,8 +2661,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noTasksYet => 'Nessuna attività ancora';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Le attività dalle tue conversazioni appariranno qui.\nFai clic su Crea per aggiungerne una manualmente.';
+  String get tasksFromConversationsWillAppear => 'Le attività dalle tue conversazioni appariranno qui.\nFai clic su Crea per aggiungerne una manualmente.';
 
   @override
   String get monthJan => 'Gen';
@@ -2772,8 +2718,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteActionItem => 'Elimina attività';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Sei sicuro di voler eliminare questa attività? Questa azione non può essere annullata.';
+  String get deleteActionItemConfirmation => 'Sei sicuro di voler eliminare questa attività? Questa azione non può essere annullata.';
 
   @override
   String get enterActionItemDescription => 'Inserisci la descrizione dell\'attività...';
@@ -2848,15 +2793,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chatPrompt => 'Prompt Chat';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Sei un\'app fantastica, il tuo compito è rispondere alle domande degli utenti e farli sentire bene...';
+  String get chatPromptPlaceholder => 'Sei un\'app fantastica, il tuo compito è rispondere alle domande degli utenti e farli sentire bene...';
 
   @override
   String get conversationPrompt => 'Prompt di conversazione';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Sei un\'app fantastica, ti verrà fornita una trascrizione e un riepilogo di una conversazione...';
+  String get conversationPromptPlaceholder => 'Sei un\'app fantastica, ti verrà fornita una trascrizione e un riepilogo di una conversazione...';
 
   @override
   String get notificationScopes => 'Ambiti di Notifica';
@@ -2868,8 +2811,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get makeMyAppPublic => 'Rendi pubblica la mia app';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Inviando questa app, accetto i Termini di Servizio e l\'Informativa sulla Privacy di Omi AI';
+  String get submitAppTermsAgreement => 'Inviando questa app, accetto i Termini di Servizio e l\'Informativa sulla Privacy di Omi AI';
 
   @override
   String get submitApp => 'Invia App';
@@ -2884,12 +2826,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get submitAppQuestion => 'Inviare l\'App?';
 
   @override
-  String get submitAppPublicDescription =>
-      'La tua app sarà revisionata e resa pubblica. Puoi iniziare a usarla immediatamente, anche durante la revisione!';
+  String get submitAppPublicDescription => 'La tua app sarà revisionata e resa pubblica. Puoi iniziare a usarla immediatamente, anche durante la revisione!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'La tua app sarà revisionata e resa disponibile per te privatamente. Puoi iniziare a usarla immediatamente, anche durante la revisione!';
+  String get submitAppPrivateDescription => 'La tua app sarà revisionata e resa disponibile per te privatamente. Puoi iniziare a usarla immediatamente, anche durante la revisione!';
 
   @override
   String get startEarning => 'Inizia a Guadagnare! 💰';
@@ -2913,23 +2853,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dataAccessNotice => 'Avviso di accesso ai dati';
 
   @override
-  String get dataAccessWarning =>
-      'Questa app accederà ai tuoi dati. Omi AI non è responsabile di come i tuoi dati vengono utilizzati, modificati o eliminati da questa app';
+  String get dataAccessWarning => 'Questa app accederà ai tuoi dati. Omi AI non è responsabile di come i tuoi dati vengono utilizzati, modificati o eliminati da questa app';
 
   @override
   String get installApp => 'Installa app';
 
   @override
-  String get betaTesterNotice =>
-      'Sei un beta tester per questa app. Non è ancora pubblica. Diventerà pubblica una volta approvata.';
+  String get betaTesterNotice => 'Sei un beta tester per questa app. Non è ancora pubblica. Diventerà pubblica una volta approvata.';
 
   @override
-  String get appUnderReviewOwner =>
-      'La tua app è in revisione e visibile solo a te. Diventerà pubblica una volta approvata.';
+  String get appUnderReviewOwner => 'La tua app è in revisione e visibile solo a te. Diventerà pubblica una volta approvata.';
 
   @override
-  String get appRejectedNotice =>
-      'La tua app è stata rifiutata. Aggiorna i dettagli dell\'app e inviala nuovamente per la revisione.';
+  String get appRejectedNotice => 'La tua app è stata rifiutata. Aggiorna i dettagli dell\'app e inviala nuovamente per la revisione.';
 
   @override
   String get setupSteps => 'Passaggi di configurazione';
@@ -2964,8 +2900,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get errorActivatingApp => 'Errore nell\'attivazione dell\'app';
 
   @override
-  String get integrationSetupRequired =>
-      'Se questa è un\'app di integrazione, assicurati che la configurazione sia completata.';
+  String get integrationSetupRequired => 'Se questa è un\'app di integrazione, assicurati che la configurazione sia completata.';
 
   @override
   String get installed => 'Installato';
@@ -2992,8 +2927,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get descriptionLabel => 'Descrizione';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'La mia fantastica app è un\'app fantastica che fa cose incredibili. È la migliore app di sempre!';
+  String get appDescriptionPlaceholder => 'La mia fantastica app è un\'app fantastica che fa cose incredibili. È la migliore app di sempre!';
 
   @override
   String get pleaseProvideValidDescription => 'Fornisci una descrizione valida';
@@ -3145,8 +3079,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get microphonePermissionRequired => 'È richiesta l\'autorizzazione del microfono per la registrazione vocale.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Autorizzazione microfono negata. Concedi l\'autorizzazione in Preferenze di Sistema > Privacy e sicurezza > Microfono.';
+  String get microphonePermissionDenied => 'Autorizzazione microfono negata. Concedi l\'autorizzazione in Preferenze di Sistema > Privacy e sicurezza > Microfono.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3305,8 +3238,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get createMemory => 'Crea memoria';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Sei sicuro di voler eliminare questa memoria? Questa azione non può essere annullata.';
+  String get deleteMemoryConfirmation => 'Sei sicuro di voler eliminare questa memoria? Questa azione non può essere annullata.';
 
   @override
   String get makePrivate => 'Rendi privato';
@@ -3380,8 +3312,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get whatWeCollect => 'Cosa raccogliamo';
 
   @override
-  String get dataCollectionMessage =>
-      'Continuando, le tue conversazioni, registrazioni e informazioni personali verranno archiviate in modo sicuro sui nostri server per fornire informazioni basate sull\'IA e abilitare tutte le funzionalità dell\'app.';
+  String get dataCollectionMessage => 'Continuando, le tue conversazioni, registrazioni e informazioni personali verranno archiviate in modo sicuro sui nostri server per fornire informazioni basate sull\'IA e abilitare tutte le funzionalità dell\'app.';
 
   @override
   String get dataProtection => 'Protezione dei dati';
@@ -3396,8 +3327,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chooseYourLanguage => 'Scegli la tua lingua';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'Seleziona la tua lingua preferita per la migliore esperienza Omi';
+  String get selectPreferredLanguageForBestExperience => 'Seleziona la tua lingua preferita per la migliore esperienza Omi';
 
   @override
   String get searchLanguages => 'Cerca lingue...';
@@ -3415,8 +3345,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Il nome deve contenere almeno 2 caratteri';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Dicci come vorresti essere chiamato. Questo aiuta a personalizzare la tua esperienza Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Dicci come vorresti essere chiamato. Questo aiuta a personalizzare la tua esperienza Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3424,8 +3353,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Abilita le funzionalità per la migliore esperienza Omi sul tuo dispositivo.';
+  String get enableFeaturesForBestExperience => 'Abilita le funzionalità per la migliore esperienza Omi sul tuo dispositivo.';
 
   @override
   String get microphoneAccess => 'Accesso al microfono';
@@ -3434,8 +3362,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get recordAudioConversations => 'Registra conversazioni audio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi ha bisogno dell\'accesso al microfono per registrare le tue conversazioni e fornire trascrizioni.';
+  String get microphoneAccessDescription => 'Omi ha bisogno dell\'accesso al microfono per registrare le tue conversazioni e fornire trascrizioni.';
 
   @override
   String get screenRecording => 'Registrazione schermo';
@@ -3444,8 +3371,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Cattura l\'audio di sistema dalle riunioni';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi ha bisogno dell\'autorizzazione per la registrazione dello schermo per catturare l\'audio di sistema dalle tue riunioni basate sul browser.';
+  String get screenRecordingDescription => 'Omi ha bisogno dell\'autorizzazione per la registrazione dello schermo per catturare l\'audio di sistema dalle tue riunioni basate sul browser.';
 
   @override
   String get accessibility => 'Accessibilità';
@@ -3454,8 +3380,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Rileva riunioni basate sul browser';
 
   @override
-  String get accessibilityDescription =>
-      'Omi ha bisogno dell\'autorizzazione di accessibilità per rilevare quando partecipi a riunioni Zoom, Meet o Teams nel tuo browser.';
+  String get accessibilityDescription => 'Omi ha bisogno dell\'autorizzazione di accessibilità per rilevare quando partecipi a riunioni Zoom, Meet o Teams nel tuo browser.';
 
   @override
   String get pleaseWait => 'Attendere prego...';
@@ -3524,12 +3449,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get exportAllConversationsToJson => 'Esporta tutte le tue conversazioni in un file JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Esportazione conversazioni avviata. Questo potrebbe richiedere alcuni secondi, attendere prego.';
+  String get conversationsExportStarted => 'Esportazione conversazioni avviata. Questo potrebbe richiedere alcuni secondi, attendere prego.';
 
   @override
-  String get mcpDescription =>
-      'Per connettere Omi ad altre applicazioni per leggere, cercare e gestire i tuoi ricordi e conversazioni. Crea una chiave per iniziare.';
+  String get mcpDescription => 'Per connettere Omi ad altre applicazioni per leggere, cercare e gestire i tuoi ricordi e conversazioni. Crea una chiave per iniziare.';
 
   @override
   String get apiKeys => 'Chiavi API';
@@ -3570,15 +3493,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Stato diagnostico del servizio di trascrizione';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Abilita messaggi diagnostici dettagliati dal servizio di trascrizione';
+  String get enableDetailedDiagnosticMessages => 'Abilita messaggi diagnostici dettagliati dal servizio di trascrizione';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Crea e etichetta automaticamente nuovi parlanti';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Crea automaticamente una nuova persona quando viene rilevato un nome nella trascrizione.';
+  String get automaticallyCreateNewPerson => 'Crea automaticamente una nuova persona quando viene rilevato un nome nella trascrizione.';
 
   @override
   String get pilotFeatures => 'Funzionalità pilota';
@@ -3602,8 +3523,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get auto => 'Automatico';
 
   @override
-  String get noSummaryForApp =>
-      'Nessun riepilogo disponibile per questa app. Prova un\'altra app per risultati migliori.';
+  String get noSummaryForApp => 'Nessun riepilogo disponibile per questa app. Prova un\'altra app per risultati migliori.';
 
   @override
   String get tryAnotherApp => 'Prova un\'altra app';
@@ -3640,8 +3560,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Lascia che Omi scelga automaticamente l\'app migliore';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Sei sicuro di voler eliminare questa conversazione? Questa azione non può essere annullata.';
+  String get deleteConversationConfirmation => 'Sei sicuro di voler eliminare questa conversazione? Questa azione non può essere annullata.';
 
   @override
   String get conversationDeleted => 'Conversazione eliminata';
@@ -3689,8 +3608,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Preparazione della cattura audio di sistema';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Fai clic sul pulsante per catturare audio per trascrizioni dal vivo, informazioni AI e salvataggio automatico.';
+  String get clickTheButtonToCaptureAudio => 'Fai clic sul pulsante per catturare audio per trascrizioni dal vivo, informazioni AI e salvataggio automatico.';
 
   @override
   String get reconnecting => 'Riconnessione...';
@@ -3848,8 +3766,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dailySummaryTitle => 'Riepilogo Giornaliero';
 
   @override
-  String get dailySummaryDescription =>
-      'Ricevi un riepilogo personalizzato delle conversazioni della giornata come notifica.';
+  String get dailySummaryDescription => 'Ricevi un riepilogo personalizzato delle conversazioni della giornata come notifica.';
 
   @override
   String get deliveryTime => 'Orario di consegna';
@@ -3918,8 +3835,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Eliminare Grafico della Conoscenza?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Questo eliminerà tutti i dati derivati del grafico della conoscenza. I tuoi ricordi originali rimangono al sicuro.';
+  String get deleteKnowledgeGraphWarning => 'Questo eliminerà tutti i dati derivati del grafico della conoscenza. I tuoi ricordi originali rimangono al sicuro.';
 
   @override
   String get connectOmiWithAI => 'Collega Omi con assistenti IA';
@@ -3961,8 +3877,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Termini e Informativa sulla Privacy';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Aiuta a diagnosticare i problemi. Eliminato automaticamente dopo 3 giorni.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Aiuta a diagnosticare i problemi. Eliminato automaticamente dopo 3 giorni.';
 
   @override
   String get manageYourApp => 'Gestisci la tua app';
@@ -3977,8 +3892,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get updateAppQuestion => 'Aggiornare l\'app?';
 
   @override
-  String get updateAppConfirmation =>
-      'Sei sicuro di voler aggiornare la tua app? Le modifiche saranno visibili dopo la revisione del nostro team.';
+  String get updateAppConfirmation => 'Sei sicuro di voler aggiornare la tua app? Le modifiche saranno visibili dopo la revisione del nostro team.';
 
   @override
   String get updateApp => 'Aggiorna app';
@@ -4008,8 +3922,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get no => 'No';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abbonamento annullato con successo. Rimarrà attivo fino alla fine del periodo di fatturazione corrente.';
+  String get subscriptionCancelledSuccessfully => 'Abbonamento annullato con successo. Rimarrà attivo fino alla fine del periodo di fatturazione corrente.';
 
   @override
   String get failedToCancelSubscription => 'Impossibile annullare l\'abbonamento. Riprova.';
@@ -4045,8 +3958,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Annullare l\'abbonamento?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Sei sicuro di voler annullare l\'abbonamento? Continuerai ad avere accesso fino alla fine del periodo di fatturazione corrente.';
+  String get cancelSubscriptionConfirmation => 'Sei sicuro di voler annullare l\'abbonamento? Continuerai ad avere accesso fino alla fine del periodo di fatturazione corrente.';
 
   @override
   String get cancelSubscriptionButton => 'Annulla abbonamento';
@@ -4055,16 +3967,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cancelling => 'Annullamento...';
 
   @override
-  String get betaTesterMessage =>
-      'Sei un beta tester per questa app. Non è ancora pubblica. Sarà pubblica dopo l\'approvazione.';
+  String get betaTesterMessage => 'Sei un beta tester per questa app. Non è ancora pubblica. Sarà pubblica dopo l\'approvazione.';
 
   @override
-  String get appUnderReviewMessage =>
-      'La tua app è in revisione e visibile solo a te. Sarà pubblica dopo l\'approvazione.';
+  String get appUnderReviewMessage => 'La tua app è in revisione e visibile solo a te. Sarà pubblica dopo l\'approvazione.';
 
   @override
-  String get appRejectedMessage =>
-      'La tua app è stata rifiutata. Aggiorna i dettagli e invia nuovamente per la revisione.';
+  String get appRejectedMessage => 'La tua app è stata rifiutata. Aggiorna i dettagli e invia nuovamente per la revisione.';
 
   @override
   String get invalidIntegrationUrl => 'URL di integrazione non valido';
@@ -4118,8 +4027,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get issueActivatingApp => 'Si è verificato un problema nell\'attivazione di questa app. Riprova.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'I tuoi dati vengono elaborati in modo sicuro secondo le tue impostazioni sulla privacy';
+  String get dataAccessNoticeDescription => 'I tuoi dati vengono elaborati in modo sicuro secondo le tue impostazioni sulla privacy';
 
   @override
   String get copyUrl => 'Copia URL';
@@ -4207,8 +4115,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get omiApiKeys => 'Chiavi API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Le chiavi API vengono utilizzate per l\'autenticazione quando la tua app comunica con il server OMI. Consentono alla tua applicazione di creare ricordi e accedere ad altri servizi OMI in modo sicuro.';
+  String get apiKeysDescription => 'Le chiavi API vengono utilizzate per l\'autenticazione quando la tua app comunica con il server OMI. Consentono alla tua applicazione di creare ricordi e accedere ad altri servizi OMI in modo sicuro.';
 
   @override
   String get aboutOmiApiKeys => 'Informazioni sulle chiavi API Omi';
@@ -4232,8 +4139,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Revocare la chiave API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Questa azione non può essere annullata. Le applicazioni che utilizzano questa chiave non potranno più accedere all\'API.';
+  String get revokeApiKeyWarning => 'Questa azione non può essere annullata. Le applicazioni che utilizzano questa chiave non potranno più accedere all\'API.';
 
   @override
   String get revoke => 'Revoca';
@@ -4331,8 +4237,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get externalAppAccess => 'Accesso app esterne';
 
   @override
-  String get externalAppAccessDescription =>
-      'Le seguenti app installate hanno integrazioni esterne e possono accedere ai tuoi dati, come conversazioni e ricordi.';
+  String get externalAppAccessDescription => 'Le seguenti app installate hanno integrazioni esterne e possono accedere ai tuoi dati, come conversazioni e ricordi.';
 
   @override
   String get noExternalAppsHaveAccess => 'Nessuna app esterna ha accesso ai tuoi dati.';
@@ -4341,15 +4246,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get maximumSecurityE2ee => 'Sicurezza massima (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'La crittografia end-to-end è lo standard d\'oro per la privacy. Quando abilitata, i tuoi dati vengono crittografati sul tuo dispositivo prima di essere inviati ai nostri server. Ciò significa che nessuno, nemmeno Omi, può accedere ai tuoi contenuti.';
+  String get e2eeDescription => 'La crittografia end-to-end è lo standard d\'oro per la privacy. Quando abilitata, i tuoi dati vengono crittografati sul tuo dispositivo prima di essere inviati ai nostri server. Ciò significa che nessuno, nemmeno Omi, può accedere ai tuoi contenuti.';
 
   @override
   String get importantTradeoffs => 'Compromessi importanti:';
 
   @override
-  String get e2eeTradeoff1 =>
-      '• Alcune funzionalità come le integrazioni di app esterne potrebbero essere disabilitate.';
+  String get e2eeTradeoff1 => '• Alcune funzionalità come le integrazioni di app esterne potrebbero essere disabilitate.';
 
   @override
   String get e2eeTradeoff2 => '• Se perdi la password, i tuoi dati non possono essere recuperati.';
@@ -4358,8 +4261,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get featureComingSoon => 'Questa funzionalità sarà disponibile presto!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migrazione in corso. Non puoi cambiare il livello di protezione finché non è completata.';
+  String get migrationInProgressMessage => 'Migrazione in corso. Non puoi cambiare il livello di protezione finché non è completata.';
 
   @override
   String get migrationFailed => 'Migrazione fallita';
@@ -4378,19 +4280,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get secureEncryption => 'Crittografia sicura';
 
   @override
-  String get secureEncryptionDescription =>
-      'I tuoi dati sono crittografati con una chiave unica per te sui nostri server, ospitati su Google Cloud. Ciò significa che i tuoi contenuti grezzi sono inaccessibili a chiunque, incluso il personale di Omi o Google, direttamente dal database.';
+  String get secureEncryptionDescription => 'I tuoi dati sono crittografati con una chiave unica per te sui nostri server, ospitati su Google Cloud. Ciò significa che i tuoi contenuti grezzi sono inaccessibili a chiunque, incluso il personale di Omi o Google, direttamente dal database.';
 
   @override
   String get endToEndEncryption => 'Crittografia end-to-end';
 
   @override
-  String get e2eeCardDescription =>
-      'Abilita per la massima sicurezza dove solo tu puoi accedere ai tuoi dati. Tocca per saperne di più.';
+  String get e2eeCardDescription => 'Abilita per la massima sicurezza dove solo tu puoi accedere ai tuoi dati. Tocca per saperne di più.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Indipendentemente dal livello, i tuoi dati sono sempre crittografati a riposo e in transito.';
+  String get dataAlwaysEncrypted => 'Indipendentemente dal livello, i tuoi dati sono sempre crittografati a riposo e in transito.';
 
   @override
   String get readOnlyScope => 'Solo lettura';
@@ -4435,8 +4334,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get permissionsLabel => 'PERMESSI';
 
   @override
-  String get permissionsInfoNote =>
-      'R = Lettura, W = Scrittura. Solo lettura di default se non viene selezionato nulla.';
+  String get permissionsInfoNote => 'R = Lettura, W = Scrittura. Solo lettura di default se non viene selezionato nulla.';
 
   @override
   String get developerApi => 'API sviluppatore';
@@ -4456,26 +4354,22 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trainingDataProgram => 'Programma dati di formazione';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Ottieni Omi Unlimited gratis contribuendo con i tuoi dati per addestrare modelli AI.';
+  String get getOmiUnlimitedFree => 'Ottieni Omi Unlimited gratis contribuendo con i tuoi dati per addestrare modelli AI.';
 
   @override
-  String get trainingDataBullets =>
-      '• I tuoi dati aiutano a migliorare i modelli AI\n• Vengono condivisi solo dati non sensibili\n• Processo completamente trasparente';
+  String get trainingDataBullets => '• I tuoi dati aiutano a migliorare i modelli AI\n• Vengono condivisi solo dati non sensibili\n• Processo completamente trasparente';
 
   @override
   String get learnMoreAtOmiTraining => 'Scopri di più su omi.me/training';
 
   @override
-  String get agreeToContributeData =>
-      'Comprendo e accetto di contribuire con i miei dati per l\'addestramento dell\'IA';
+  String get agreeToContributeData => 'Comprendo e accetto di contribuire con i miei dati per l\'addestramento dell\'IA';
 
   @override
   String get submitRequest => 'Invia richiesta';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Grazie! La tua richiesta è in revisione. Ti avviseremo una volta approvata.';
+  String get thankYouRequestUnderReview => 'Grazie! La tua richiesta è in revisione. Ti avviseremo una volta approvata.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4510,16 +4404,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get importantBillingInfo => 'Informazioni di fatturazione importanti:';
 
   @override
-  String get monthlyPlanContinues =>
-      'Il tuo attuale piano mensile continuerà fino alla fine del periodo di fatturazione';
+  String get monthlyPlanContinues => 'Il tuo attuale piano mensile continuerà fino alla fine del periodo di fatturazione';
 
   @override
-  String get paymentMethodCharged =>
-      'Il tuo metodo di pagamento esistente verrà addebitato automaticamente al termine del piano mensile';
+  String get paymentMethodCharged => 'Il tuo metodo di pagamento esistente verrà addebitato automaticamente al termine del piano mensile';
 
   @override
-  String get annualSubscriptionStarts =>
-      'Il tuo abbonamento annuale di 12 mesi inizierà automaticamente dopo l\'addebito';
+  String get annualSubscriptionStarts => 'Il tuo abbonamento annuale di 12 mesi inizierà automaticamente dopo l\'addebito';
 
   @override
   String get thirteenMonthsCoverage => 'Avrai 13 mesi di copertura totale (mese corrente + 12 mesi annuali)';
@@ -4559,8 +4450,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Il tuo piano annuale inizierà automaticamente al termine del piano mensile.';
+  String get annualPlanStartsAutomatically => 'Il tuo piano annuale inizierà automaticamente al termine del piano mensile.';
 
   @override
   String planRenewsOn(String date) {
@@ -4580,8 +4470,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get youreOnAnnualPlan => 'Sei sul piano annuale';
 
   @override
-  String get alreadyBestValuePlan =>
-      'Hai già il piano dal miglior rapporto qualità-prezzo. Non sono necessarie modifiche.';
+  String get alreadyBestValuePlan => 'Hai già il piano dal miglior rapporto qualità-prezzo. Non sono necessarie modifiche.';
 
   @override
   String get unableToLoadPlans => 'Impossibile caricare i piani';
@@ -4628,8 +4517,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'La tua privacy è importante per noi';
 
   @override
-  String get privacyIntroText =>
-      'In Omi, prendiamo molto sul serio la tua privacy. Vogliamo essere trasparenti sui dati che raccogliamo e come li utilizziamo per migliorare il prodotto. Ecco cosa devi sapere:';
+  String get privacyIntroText => 'In Omi, prendiamo molto sul serio la tua privacy. Vogliamo essere trasparenti sui dati che raccogliamo e come li utilizziamo per migliorare il prodotto. Ecco cosa devi sapere:';
 
   @override
   String get whatWeTrack => 'Cosa monitoriamo';
@@ -4644,12 +4532,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get ourCommitment => 'Il nostro impegno';
 
   @override
-  String get commitmentText =>
-      'Ci impegniamo a utilizzare i dati raccolti solo per rendere Omi un prodotto migliore per te. La tua privacy e la tua fiducia sono fondamentali per noi.';
+  String get commitmentText => 'Ci impegniamo a utilizzare i dati raccolti solo per rendere Omi un prodotto migliore per te. La tua privacy e la tua fiducia sono fondamentali per noi.';
 
   @override
-  String get thankYouText =>
-      'Grazie per essere un utente prezioso di Omi. Se hai domande o dubbi, non esitare a contattarci a team@basedhardware.com.';
+  String get thankYouText => 'Grazie per essere un utente prezioso di Omi. Se hai domande o dubbi, non esitare a contattarci a team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Impostazioni sincronizzazione WiFi';
@@ -4658,8 +4544,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get enterHotspotCredentials => 'Inserisci le credenziali hotspot del tuo telefono';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'La sincronizzazione WiFi usa il telefono come hotspot. Trova nome e password in Impostazioni > Hotspot personale.';
+  String get wifiSyncUsesHotspot => 'La sincronizzazione WiFi usa il telefono come hotspot. Trova nome e password in Impostazioni > Hotspot personale.';
 
   @override
   String get hotspotNameSsid => 'Nome hotspot (SSID)';
@@ -4694,8 +4579,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Impossibile generare il riepilogo. Assicurati di avere conversazioni per quel giorno.';
+  String get failedToGenerateSummaryCheckConversations => 'Impossibile generare il riepilogo. Assicurati di avere conversazioni per quel giorno.';
 
   @override
   String get summaryNotFound => 'Riepilogo non trovato';
@@ -4725,8 +4609,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Esportazione avviata. Potrebbe richiedere qualche secondo...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Questo eliminerà tutti i dati derivati del grafo della conoscenza (nodi e connessioni). I tuoi ricordi originali rimarranno al sicuro. Il grafo verrà ricostruito nel tempo o alla prossima richiesta.';
+  String get knowledgeGraphDeleteDescription => 'Questo eliminerà tutti i dati derivati del grafo della conoscenza (nodi e connessioni). I tuoi ricordi originali rimarranno al sicuro. Il grafo verrà ricostruito nel tempo o alla prossima richiesta.';
 
   @override
   String get configureDailySummaryDigest => 'Configura il tuo riepilogo giornaliero delle attività';
@@ -4796,8 +4679,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Eliminare tutte le conversazioni Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Questo eliminerà permanentemente tutte le conversazioni importate da Limitless. Questa azione non può essere annullata.';
+  String get deleteAllLimitlessWarning => 'Questo eliminerà permanentemente tutte le conversazioni importate da Limitless. Questa azione non può essere annullata.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4853,8 +4735,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get howItWorksTitle => 'Come funziona?';
 
   @override
-  String get howPeopleWorks =>
-      'Una volta creata una persona, puoi andare alla trascrizione di una conversazione e assegnare i segmenti corrispondenti, in questo modo Omi sarà in grado di riconoscere anche la loro voce!';
+  String get howPeopleWorks => 'Una volta creata una persona, puoi andare alla trascrizione di una conversazione e assegnare i segmenti corrispondenti, in questo modo Omi sarà in grado di riconoscere anche la loro voce!';
 
   @override
   String get tapToDelete => 'Tocca per eliminare';
@@ -4880,8 +4761,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get privacyNotice => 'Avviso sulla privacy';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Le registrazioni potrebbero catturare le voci di altri. Assicurati di avere il consenso di tutti i partecipanti prima di abilitare.';
+  String get recordingsMayCaptureOthers => 'Le registrazioni potrebbero catturare le voci di altri. Assicurati di avere il consenso di tutti i partecipanti prima di abilitare.';
 
   @override
   String get enable => 'Attiva';
@@ -4893,8 +4773,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Mantieni tutte le registrazioni audio memorizzate localmente sul tuo telefono. Quando disabilitato, vengono conservati solo i caricamenti non riusciti per risparmiare spazio.';
+  String get storeAudioDescription => 'Mantieni tutte le registrazioni audio memorizzate localmente sul tuo telefono. Quando disabilitato, vengono conservati solo i caricamenti non riusciti per risparmiare spazio.';
 
   @override
   String get enableLocalStorage => 'Abilita archiviazione locale';
@@ -4912,12 +4791,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get storeAudioOnCloud => 'Archivia audio nel cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Le tue registrazioni in tempo reale saranno archiviate in uno spazio di archiviazione cloud privato mentre parli.';
+  String get cloudStorageDialogMessage => 'Le tue registrazioni in tempo reale saranno archiviate in uno spazio di archiviazione cloud privato mentre parli.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Archivia le tue registrazioni in tempo reale nello spazio di archiviazione cloud privato mentre parli. L\'audio viene catturato e salvato in modo sicuro in tempo reale.';
+  String get storeAudioCloudDescription => 'Archivia le tue registrazioni in tempo reale nello spazio di archiviazione cloud privato mentre parli. L\'audio viene catturato e salvato in modo sicuro in tempo reale.';
 
   @override
   String get downloadingFirmware => 'Download del firmware';
@@ -4926,8 +4803,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get installingFirmware => 'Installazione del firmware';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Non chiudere l\'app o spegnere il dispositivo. Questo potrebbe danneggiare il dispositivo.';
+  String get firmwareUpdateWarning => 'Non chiudere l\'app o spegnere il dispositivo. Questo potrebbe danneggiare il dispositivo.';
 
   @override
   String get firmwareUpdated => 'Firmware aggiornato';
@@ -4971,8 +4847,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get payments => 'Pagamenti';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Collega un metodo di pagamento qui sotto per iniziare a ricevere pagamenti per le tue app.';
+  String get connectPaymentMethodInfo => 'Collega un metodo di pagamento qui sotto per iniziare a ricevere pagamenti per le tue app.';
 
   @override
   String get selectedPaymentMethod => 'Metodo di pagamento selezionato';
@@ -4999,8 +4874,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get monthlyPayouts => 'Pagamenti mensili';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Ricevi pagamenti mensili direttamente sul tuo conto quando raggiungi \$10 di guadagni';
+  String get monthlyPayoutsDescription => 'Ricevi pagamenti mensili direttamente sul tuo conto quando raggiungi \$10 di guadagni';
 
   @override
   String get secureAndReliable => 'Sicuro e affidabile';
@@ -5027,8 +4901,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get connectingYourStripeAccount => 'Connessione del tuo account Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Completa il processo di onboarding Stripe nel tuo browser. Questa pagina si aggiornerà automaticamente una volta completato.';
+  String get stripeOnboardingInstructions => 'Completa il processo di onboarding Stripe nel tuo browser. Questa pagina si aggiornerà automaticamente una volta completato.';
 
   @override
   String get failedTryAgain => 'Fallito? Riprova';
@@ -5040,8 +4913,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get successfullyConnected => 'Connesso con successo!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Il tuo account Stripe è ora pronto a ricevere pagamenti. Puoi iniziare a guadagnare dalle vendite delle tue app subito.';
+  String get stripeReadyForPayments => 'Il tuo account Stripe è ora pronto a ricevere pagamenti. Puoi iniziare a guadagnare dalle vendite delle tue app subito.';
 
   @override
   String get updateStripeDetails => 'Aggiorna dettagli Stripe';
@@ -5059,8 +4931,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Aggiorna i dettagli del tuo account PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Collega il tuo account PayPal per iniziare a ricevere pagamenti per le tue app';
+  String get connectPayPalToReceivePayments => 'Collega il tuo account PayPal per iniziare a ricevere pagamenti per le tue app';
 
   @override
   String get paypalEmail => 'Email PayPal';
@@ -5069,8 +4940,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get paypalMeLink => 'Link PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Se Stripe è disponibile nel tuo paese, ti consigliamo vivamente di usarlo per pagamenti più veloci e facili.';
+  String get stripeRecommendation => 'Se Stripe è disponibile nel tuo paese, ti consigliamo vivamente di usarlo per pagamenti più veloci e facili.';
 
   @override
   String get updatePayPalDetails => 'Aggiorna dettagli PayPal';
@@ -5122,12 +4992,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Campione vocale aggiuntivo rimosso';
 
   @override
-  String get consentDataMessage =>
-      'Continuando, le tue conversazioni, registrazioni e informazioni personali saranno archiviate in modo sicuro sui nostri server. Le tue registrazioni audio e trascrizioni vengono elaborate da servizi AI di terze parti (inclusi Deepgram per la trascrizione e OpenAI per l\'analisi) per fornirti approfondimenti basati sull\'AI e abilitare tutte le funzionalità dell\'app.';
+  String get consentDataMessage => 'Continuando, le tue conversazioni, registrazioni e informazioni personali saranno archiviate in modo sicuro sui nostri server. Le tue registrazioni audio e trascrizioni vengono elaborate da servizi AI di terze parti (inclusi Deepgram per la trascrizione e OpenAI per l\'analisi) per fornirti approfondimenti basati sull\'AI e abilitare tutte le funzionalità dell\'app.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Le attività dalle tue conversazioni appariranno qui.\nTocca + per crearne una manualmente.';
+  String get tasksEmptyStateMessage => 'Le attività dalle tue conversazioni appariranno qui.\nTocca + per crearne una manualmente.';
 
   @override
   String get clearChatAction => 'Cancella chat';
@@ -5163,15 +5031,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Installa Omi sul tuo\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Per utilizzare il tuo Apple Watch con Omi, devi prima installare l\'app Omi sul tuo orologio.';
+  String get installOmiOnAppleWatchDescription => 'Per utilizzare il tuo Apple Watch con Omi, devi prima installare l\'app Omi sul tuo orologio.';
 
   @override
   String get openOmiOnAppleWatch => 'Apri Omi sul tuo\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'L\'app Omi è installata sul tuo Apple Watch. Aprila e tocca Avvia per iniziare.';
+  String get openOmiOnAppleWatchDescription => 'L\'app Omi è installata sul tuo Apple Watch. Aprila e tocca Avvia per iniziare.';
 
   @override
   String get openWatchApp => 'Apri app Watch';
@@ -5180,15 +5046,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Ho installato e aperto l\'app';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Impossibile aprire l\'app Apple Watch. Apri manualmente l\'app Watch sul tuo Apple Watch e installa Omi dalla sezione \"App disponibili\".';
+  String get unableToOpenWatchApp => 'Impossibile aprire l\'app Apple Watch. Apri manualmente l\'app Watch sul tuo Apple Watch e installa Omi dalla sezione \"App disponibili\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch connesso con successo!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch ancora non raggiungibile. Assicurati che l\'app Omi sia aperta sul tuo orologio.';
+  String get appleWatchNotReachable => 'Apple Watch ancora non raggiungibile. Assicurati che l\'app Omi sia aperta sul tuo orologio.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5205,8 +5069,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get finishedConversation => 'Conversazione terminata?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Sei sicuro di voler interrompere la registrazione e riassumere la conversazione ora?';
+  String get stopRecordingConfirmation => 'Sei sicuro di voler interrompere la registrazione e riassumere la conversazione ora?';
 
   @override
   String get conversationEndsManually => 'La conversazione terminerà solo manualmente.';
@@ -5617,29 +5480,25 @@ class AppLocalizationsIt extends AppLocalizations {
   String get multipleSpeakersDetected => 'Rilevati più interlocutori';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Sembra che ci siano più interlocutori nella registrazione. Assicurati di essere in un luogo tranquillo e riprova.';
+  String get multipleSpeakersDescription => 'Sembra che ci siano più interlocutori nella registrazione. Assicurati di essere in un luogo tranquillo e riprova.';
 
   @override
   String get invalidRecordingDetected => 'Rilevata registrazione non valida';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Non è stato rilevato abbastanza parlato. Per favore parla di più e riprova.';
+  String get notEnoughSpeechDescription => 'Non è stato rilevato abbastanza parlato. Per favore parla di più e riprova.';
 
   @override
   String get speechDurationDescription => 'Assicurati di parlare almeno 5 secondi e non più di 90.';
 
   @override
-  String get connectionLostDescription =>
-      'La connessione è stata interrotta. Controlla la tua connessione internet e riprova.';
+  String get connectionLostDescription => 'La connessione è stata interrotta. Controlla la tua connessione internet e riprova.';
 
   @override
   String get howToTakeGoodSample => 'Come fare un buon campione?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Assicurati di essere in un luogo tranquillo.\n2. Parla chiaramente e naturalmente.\n3. Assicurati che il tuo dispositivo sia nella sua posizione naturale sul collo.\n\nUna volta creato, puoi sempre migliorarlo o rifarlo.';
+  String get goodSampleInstructions => '1. Assicurati di essere in un luogo tranquillo.\n2. Parla chiaramente e naturalmente.\n3. Assicurati che il tuo dispositivo sia nella sua posizione naturale sul collo.\n\nUna volta creato, puoi sempre migliorarlo o rifarlo.';
 
   @override
   String get noDeviceConnectedUseMic => 'Nessun dispositivo connesso. Verrà utilizzato il microfono del telefono.';
@@ -5702,12 +5561,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get howItWorks => 'Come funziona';
 
   @override
-  String get dailyScoreExplanation =>
-      'Il tuo punteggio giornaliero si basa sul completamento delle attività. Completa le tue attività per migliorare il punteggio!';
+  String get dailyScoreExplanation => 'Il tuo punteggio giornaliero si basa sul completamento delle attività. Completa le tue attività per migliorare il punteggio!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Controlla quanto spesso Omi ti invia notifiche proattive e promemoria.';
+  String get notificationFrequencyDescription => 'Controlla quanto spesso Omi ti invia notifiche proattive e promemoria.';
 
   @override
   String get sliderOff => 'Off';
@@ -5721,8 +5578,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Impossibile generare il riepilogo. Assicurati di avere conversazioni per quel giorno.';
+  String get failedToGenerateSummary => 'Impossibile generare il riepilogo. Assicurati di avere conversazioni per quel giorno.';
 
   @override
   String get recap => 'Riepilogo';
@@ -5881,8 +5737,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get wifiEnableFailed => 'Impossibile abilitare il WiFi sul dispositivo. Riprova.';
 
   @override
-  String get deviceNoFastTransfer =>
-      'Il tuo dispositivo non supporta il Trasferimento Rapido. Usa il Bluetooth invece.';
+  String get deviceNoFastTransfer => 'Il tuo dispositivo non supporta il Trasferimento Rapido. Usa il Bluetooth invece.';
 
   @override
   String get enableHotspotMessage => 'Abilita l\'hotspot del telefono e riprova.';
@@ -5954,8 +5809,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get recordings => 'Registrazioni';
 
   @override
-  String get enableRemindersAccess =>
-      'Abilita l\'accesso ai Promemoria nelle Impostazioni per utilizzare Promemoria Apple';
+  String get enableRemindersAccess => 'Abilita l\'accesso ai Promemoria nelle Impostazioni per utilizzare Promemoria Apple';
 
   @override
   String todayAtTime(String time) {
@@ -6010,8 +5864,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get webhookUrlNotSet => 'URL webhook non impostato';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Imposta l\'URL del webhook nelle impostazioni sviluppatore per usare questa funzione.';
+  String get setWebhookUrlInSettings => 'Imposta l\'URL del webhook nelle impostazioni sviluppatore per usare questa funzione.';
 
   @override
   String get sendWebUrl => 'Invia URL web';
@@ -6085,15 +5938,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cloudProvider => 'Provider cloud';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 minuti premium/mese. La scheda Su dispositivo offre trascrizione gratuita illimitata.';
+  String get premiumMinutesInfo => '1.200 minuti premium/mese. La scheda Su dispositivo offre trascrizione gratuita illimitata.';
 
   @override
   String get viewUsage => 'Visualizza utilizzo';
 
   @override
-  String get localProcessingInfo =>
-      'L\'audio viene elaborato localmente. Funziona offline, più privato, ma consuma più batteria.';
+  String get localProcessingInfo => 'L\'audio viene elaborato localmente. Funziona offline, più privato, ma consuma più batteria.';
 
   @override
   String get model => 'Modello';
@@ -6102,15 +5953,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get performanceWarning => 'Avviso sulle prestazioni';
 
   @override
-  String get largeModelWarning =>
-      'Questo modello è grande e potrebbe causare il crash dell\'app o funzionare molto lentamente sui dispositivi mobili.\n\nSi consiglia \"small\" o \"base\".';
+  String get largeModelWarning => 'Questo modello è grande e potrebbe causare il crash dell\'app o funzionare molto lentamente sui dispositivi mobili.\n\nSi consiglia \"small\" o \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Utilizzo del riconoscimento vocale nativo iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Verrà utilizzato il motore vocale nativo del dispositivo. Non è richiesto il download di alcun modello.';
+  String get noModelDownloadRequired => 'Verrà utilizzato il motore vocale nativo del dispositivo. Non è richiesto il download di alcun modello.';
 
   @override
   String get modelReady => 'Modello pronto';
@@ -6155,12 +6004,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Dispositivo non compatibile';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'Il tuo dispositivo non soddisfa i requisiti per la trascrizione sul dispositivo.';
+  String get deviceNotMeetRequirements => 'Il tuo dispositivo non soddisfa i requisiti per la trascrizione sul dispositivo.';
 
   @override
-  String get transcriptionSlowerOnDevice =>
-      'La trascrizione sul dispositivo potrebbe essere più lenta su questo dispositivo.';
+  String get transcriptionSlowerOnDevice => 'La trascrizione sul dispositivo potrebbe essere più lenta su questo dispositivo.';
 
   @override
   String get computationallyIntensive => 'La trascrizione sul dispositivo è computazionalmente intensiva.';
@@ -6169,12 +6016,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get batteryDrainSignificantly => 'Il consumo della batteria aumenterà significativamente.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 minuti premium/mese. La scheda Sul dispositivo offre trascrizione gratuita illimitata. ';
+  String get premiumMinutesMonth => '1.200 minuti premium/mese. La scheda Sul dispositivo offre trascrizione gratuita illimitata. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Laudio viene elaborato localmente. Funziona offline, più privato, ma consuma più batteria.';
+  String get audioProcessedLocally => 'Laudio viene elaborato localmente. Funziona offline, più privato, ma consuma più batteria.';
 
   @override
   String get languageLabel => 'Lingua';
@@ -6183,12 +6028,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get modelLabel => 'Modello';
 
   @override
-  String get modelTooLargeWarning =>
-      'Questo modello è grande e potrebbe causare il crash dellapp o un funzionamento molto lento sui dispositivi mobili.\n\nSi consiglia small o base.';
+  String get modelTooLargeWarning => 'Questo modello è grande e potrebbe causare il crash dellapp o un funzionamento molto lento sui dispositivi mobili.\n\nSi consiglia small o base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Verrà utilizzato il motore vocale nativo del tuo dispositivo. Non è necessario scaricare un modello.';
+  String get nativeEngineNoDownload => 'Verrà utilizzato il motore vocale nativo del tuo dispositivo. Non è necessario scaricare un modello.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6224,8 +6067,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'La trascrizione live integrata di Omi è ottimizzata per conversazioni in tempo reale con rilevamento automatico dei parlanti e diarizzazione.';
+  String get omiTranscriptionOptimized => 'La trascrizione live integrata di Omi è ottimizzata per conversazioni in tempo reale con rilevamento automatico dei parlanti e diarizzazione.';
 
   @override
   String get reset => 'Reimposta';
@@ -6445,8 +6287,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Costruzione del grafo della conoscenza dai ricordi...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Il tuo grafo della conoscenza verrà costruito automaticamente quando creerai nuovi ricordi.';
+  String get knowledgeGraphWillBuildAutomatically => 'Il tuo grafo della conoscenza verrà costruito automaticamente quando creerai nuovi ricordi.';
 
   @override
   String get buildGraphButton => 'Costruisci grafo';
@@ -6682,8 +6523,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get failedToLoadContacts => 'Impossibile caricare i contatti';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Impossibile preparare la conversazione per la condivisione. Riprova.';
+  String get failedToPrepareConversationForSharing => 'Impossibile preparare la conversazione per la condivisione. Riprova.';
 
   @override
   String get couldNotOpenSmsApp => 'Impossibile aprire l\'app SMS. Riprova.';
@@ -6749,8 +6589,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Scaricamento audio dalla scheda SD del dispositivo';
 
   @override
-  String get transferRequiredDescription =>
-      'Questa registrazione è memorizzata sulla scheda SD del tuo dispositivo. Trasferiscila sul telefono per riprodurla o condividerla.';
+  String get transferRequiredDescription => 'Questa registrazione è memorizzata sulla scheda SD del tuo dispositivo. Trasferiscila sul telefono per riprodurla o condividerla.';
 
   @override
   String get cancelTransfer => 'Annulla Trasferimento';
@@ -6771,8 +6610,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get shareRecording => 'Condividi registrazione';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Sei sicuro di voler eliminare permanentemente questa registrazione? Questa azione non può essere annullata.';
+  String get deleteRecordingConfirmation => 'Sei sicuro di voler eliminare permanentemente questa registrazione? Questa azione non può essere annullata.';
 
   @override
   String get recordingIdLabel => 'ID registrazione';
@@ -6831,15 +6669,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get enableFastTransfer => 'Abilita trasferimento rapido';
 
   @override
-  String get fastTransferDescription =>
-      'Il trasferimento rapido utilizza il WiFi per velocità ~5x più veloci. Il tuo telefono si connetterà temporaneamente alla rete WiFi del dispositivo Omi durante il trasferimento.';
+  String get fastTransferDescription => 'Il trasferimento rapido utilizza il WiFi per velocità ~5x più veloci. Il tuo telefono si connetterà temporaneamente alla rete WiFi del dispositivo Omi durante il trasferimento.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'L\'accesso a Internet è sospeso durante il trasferimento';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Scegli come le registrazioni vengono trasferite dal dispositivo Omi al telefono.';
+  String get chooseTransferMethodDescription => 'Scegli come le registrazioni vengono trasferite dal dispositivo Omi al telefono.';
 
   @override
   String get wifiSpeed => '~150 KB/s via WiFi';
@@ -6848,8 +6684,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fiveTimesFaster => '5X PIÙ VELOCE';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Crea una connessione WiFi diretta al dispositivo Omi. Il telefono si disconnette temporaneamente dal WiFi normale durante il trasferimento.';
+  String get fastTransferMethodDescription => 'Crea una connessione WiFi diretta al dispositivo Omi. Il telefono si disconnette temporaneamente dal WiFi normale durante il trasferimento.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6858,8 +6693,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get bleSpeed => '~30 KB/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Utilizza la connessione Bluetooth Low Energy standard. Più lento ma non influisce sulla connessione WiFi.';
+  String get bluetoothMethodDescription => 'Utilizza la connessione Bluetooth Low Energy standard. Più lento ma non influisce sulla connessione WiFi.';
 
   @override
   String get selected => 'Selezionato';
@@ -6897,12 +6731,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get appDeleteFailed => 'Impossibile eliminare l\'app. Riprova più tardi.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Visibilità dell\'app modificata con successo. Potrebbero essere necessari alcuni minuti.';
+  String get appVisibilityChangedSuccessfully => 'Visibilità dell\'app modificata con successo. Potrebbero essere necessari alcuni minuti.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Errore nell\'attivazione dell\'app. Se è un\'app di integrazione, assicurati che la configurazione sia completata.';
+  String get errorActivatingAppIntegration => 'Errore nell\'attivazione dell\'app. Se è un\'app di integrazione, assicurati che la configurazione sia completata.';
 
   @override
   String get errorUpdatingAppStatus => 'Si è verificato un errore durante l\'aggiornamento dello stato dell\'app.';
@@ -6970,8 +6802,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get importantConversationTitle => 'Conversazione importante';
 
   @override
-  String get importantConversationBody =>
-      'Hai appena avuto una conversazione importante. Tocca per condividere il riepilogo.';
+  String get importantConversationBody => 'Hai appena avuto una conversazione importante. Tocca per condividere il riepilogo.';
 
   @override
   String get templateName => 'Nome modello';
@@ -6983,8 +6814,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Il nome deve essere di almeno 3 caratteri';
 
   @override
-  String get conversationPromptHint =>
-      'es., Estrai azioni, decisioni prese e punti chiave dalla conversazione fornita.';
+  String get conversationPromptHint => 'es., Estrai azioni, decisioni prese e punti chiave dalla conversazione fornita.';
 
   @override
   String get pleaseEnterAppPrompt => 'Inserisci un prompt per la tua app';
@@ -7171,19 +7001,16 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade programmato! Il tuo piano mensile continua fino alla fine del periodo di fatturazione, poi passa automaticamente all\'annuale.';
+  String get planUpgradeScheduledMessage => 'Upgrade programmato! Il tuo piano mensile continua fino alla fine del periodo di fatturazione, poi passa automaticamente all\'annuale.';
 
   @override
   String get couldNotSchedulePlanChange => 'Impossibile programmare il cambio di piano. Riprova.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Il tuo abbonamento è stato riattivato! Nessun addebito ora - sarai fatturato alla fine del periodo corrente.';
+  String get subscriptionReactivatedDefault => 'Il tuo abbonamento è stato riattivato! Nessun addebito ora - sarai fatturato alla fine del periodo corrente.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Abbonamento completato! Sei stato addebitato per il nuovo periodo di fatturazione.';
+  String get subscriptionSuccessfulCharged => 'Abbonamento completato! Sei stato addebitato per il nuovo periodo di fatturazione.';
 
   @override
   String get couldNotProcessSubscription => 'Impossibile elaborare l\'abbonamento. Riprova.';
@@ -7363,8 +7190,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get onboardingBluetoothRequired => 'È necessaria l\'autorizzazione Bluetooth per connettersi al dispositivo.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Autorizzazione Bluetooth negata. Concedi l\'autorizzazione in Preferenze di Sistema.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Autorizzazione Bluetooth negata. Concedi l\'autorizzazione in Preferenze di Sistema.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7377,12 +7203,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Autorizzazione notifiche negata. Concedi l\'autorizzazione in Preferenze di Sistema.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Autorizzazione notifiche negata. Concedi l\'autorizzazione in Preferenze di Sistema.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Autorizzazione notifiche negata. Concedi l\'autorizzazione in Preferenze di Sistema > Notifiche.';
+  String get onboardingNotificationDeniedNotifications => 'Autorizzazione notifiche negata. Concedi l\'autorizzazione in Preferenze di Sistema > Notifiche.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7395,15 +7219,13 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Concedi l\'autorizzazione alla posizione in Impostazioni > Privacy e sicurezza > Servizi di localizzazione';
+  String get onboardingLocationGrantInSettings => 'Concedi l\'autorizzazione alla posizione in Impostazioni > Privacy e sicurezza > Servizi di localizzazione';
 
   @override
   String get onboardingMicrophoneRequired => 'È necessaria l\'autorizzazione microfono per registrare.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Autorizzazione microfono negata. Concedi l\'autorizzazione in Preferenze di Sistema > Privacy e sicurezza > Microfono.';
+  String get onboardingMicrophoneDenied => 'Autorizzazione microfono negata. Concedi l\'autorizzazione in Preferenze di Sistema > Privacy e sicurezza > Microfono.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7416,12 +7238,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'È necessaria l\'autorizzazione di cattura schermo per la registrazione audio di sistema.';
+  String get onboardingScreenCaptureRequired => 'È necessaria l\'autorizzazione di cattura schermo per la registrazione audio di sistema.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Autorizzazione cattura schermo negata. Concedi l\'autorizzazione in Preferenze di Sistema > Privacy e sicurezza > Registrazione schermo.';
+  String get onboardingScreenCaptureDenied => 'Autorizzazione cattura schermo negata. Concedi l\'autorizzazione in Preferenze di Sistema > Privacy e sicurezza > Registrazione schermo.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7434,8 +7254,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'È necessaria l\'autorizzazione accessibilità per rilevare riunioni del browser.';
+  String get onboardingAccessibilityRequired => 'È necessaria l\'autorizzazione accessibilità per rilevare riunioni del browser.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7451,8 +7270,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get msgCameraNotAvailable => 'La cattura della fotocamera non è disponibile su questa piattaforma';
 
   @override
-  String get msgCameraPermissionDenied =>
-      'Permesso fotocamera negato. Si prega di consentire l\'accesso alla fotocamera';
+  String get msgCameraPermissionDenied => 'Permesso fotocamera negato. Si prega di consentire l\'accesso alla fotocamera';
 
   @override
   String msgCameraAccessError(String error) {
@@ -7476,8 +7294,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Permesso foto negato. Si prega di consentire l\'accesso alle foto per selezionare le immagini';
+  String get msgPhotosPermissionDenied => 'Permesso foto negato. Si prega di consentire l\'accesso alle foto per selezionare le immagini';
 
   @override
   String get msgSelectImagesGenericError => 'Errore nella selezione delle immagini. Si prega di riprovare.';
@@ -7519,8 +7336,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Autorizzazione microfono richiesta';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Concedi l\'autorizzazione al microfono nelle Preferenze di Sistema';
+  String get captureMicrophonePermissionInSystemPreferences => 'Concedi l\'autorizzazione al microfono nelle Preferenze di Sistema';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Autorizzazione registrazione schermo richiesta';
@@ -7550,8 +7366,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get locationPermissionRequired => 'Autorizzazione posizione richiesta';
 
   @override
-  String get locationPermissionContent =>
-      'Il trasferimento rapido richiede l\'autorizzazione alla posizione per verificare la connessione WiFi. Concedi l\'autorizzazione alla posizione per continuare.';
+  String get locationPermissionContent => 'Il trasferimento rapido richiede l\'autorizzazione alla posizione per verificare la connessione WiFi. Concedi l\'autorizzazione alla posizione per continuare.';
 
   @override
   String get pdfTranscriptExport => 'Esportazione trascrizione';
@@ -7714,8 +7529,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Il dispositivo non supporta la sincronizzazione WiFi, passaggio al Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Il dispositivo non supporta la sincronizzazione WiFi, passaggio al Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health non è disponibile su questo dispositivo';
@@ -8011,8 +7825,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Metti Omi DevKit in modalità di accoppiamento';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Premi il pulsante una volta per accendere. Il LED lampeggerà in viola in modalità di accoppiamento.';
+  String get pairingDescOmiDevkit => 'Premi il pulsante una volta per accendere. Il LED lampeggerà in viola in modalità di accoppiamento.';
 
   @override
   String get pairingTitleOmiGlass => 'Accendi Omi Glass';
@@ -8024,8 +7837,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Metti Plaud Note in modalità di accoppiamento';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Tieni premuto il pulsante laterale per 2 secondi. Il LED rosso lampeggerà quando è pronto per l\'accoppiamento.';
+  String get pairingDescPlaudNote => 'Tieni premuto il pulsante laterale per 2 secondi. Il LED rosso lampeggerà quando è pronto per l\'accoppiamento.';
 
   @override
   String get pairingTitleBee => 'Metti Bee in modalità di accoppiamento';
@@ -8037,15 +7849,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get pairingTitleLimitless => 'Metti Limitless in modalità di accoppiamento';
 
   @override
-  String get pairingDescLimitless =>
-      'Quando una luce è visibile, premi una volta poi tieni premuto finché il dispositivo non mostra una luce rosa, quindi rilascia.';
+  String get pairingDescLimitless => 'Quando una luce è visibile, premi una volta poi tieni premuto finché il dispositivo non mostra una luce rosa, quindi rilascia.';
 
   @override
   String get pairingTitleFriendPendant => 'Metti Friend Pendant in modalità di accoppiamento';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Premi il pulsante sul ciondolo per accenderlo. Entrerà automaticamente in modalità di accoppiamento.';
+  String get pairingDescFriendPendant => 'Premi il pulsante sul ciondolo per accenderlo. Entrerà automaticamente in modalità di accoppiamento.';
 
   @override
   String get pairingTitleFieldy => 'Metti Fieldy in modalità di accoppiamento';
@@ -8063,8 +7873,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get pairingTitleNeoOne => 'Metti Neo One in modalità di accoppiamento';
 
   @override
-  String get pairingDescNeoOne =>
-      'Tieni premuto il pulsante di accensione finché il LED non lampeggia. Il dispositivo sarà rilevabile.';
+  String get pairingDescNeoOne => 'Tieni premuto il pulsante di accensione finché il LED non lampeggia. Il dispositivo sarà rilevabile.';
 
   @override
   String get downloadingFromDevice => 'Download dal dispositivo';
@@ -8134,8 +7943,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get wifiConfiguration => 'Configurazione WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Inserisci le credenziali WiFi per consentire al dispositivo di scaricare il firmware.';
+  String get wifiConfigurationSubtitle => 'Inserisci le credenziali WiFi per consentire al dispositivo di scaricare il firmware.';
 
   @override
   String get networkNameSsid => 'Nome rete (SSID)';
@@ -8153,8 +7961,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Quello che so di te';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Ecco un riepilogo di ciò che so di te dalle nostre conversazioni. Puoi modificare tutto ciò che non è corretto.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Ecco un riepilogo di ciò che so di te dalle nostre conversazioni. Puoi modificare tutto ciò che non è corretto.';
 
   @override
   String get apiEnvironment => 'Ambiente API';
@@ -8183,8 +7990,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get switchAndRestart => 'Cambia';
 
   @override
-  String get stagingDisclaimer =>
-      'L\'ambiente di staging potrebbe essere instabile, avere prestazioni inconsistenti e i dati potrebbero andare persi. Usalo solo per i test.';
+  String get stagingDisclaimer => 'L\'ambiente di staging potrebbe essere instabile, avere prestazioni inconsistenti e i dati potrebbero andare persi. Usalo solo per i test.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Salvato. Chiudi e riapri l\'app per applicare.';
@@ -8235,8 +8041,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get phoneGetStarted => 'Inizia';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'La registrazione delle chiamate potrebbe richiedere il consenso nella tua giurisdizione';
+  String get callRecordingConsentDisclaimer => 'La registrazione delle chiamate potrebbe richiedere il consenso nella tua giurisdizione';
 
   @override
   String get enterYourNumber => 'Inserisci il tuo numero';
@@ -8414,8 +8219,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Chiamate telefoniche tramite Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Effettua chiamate tramite Omi e ottieni trascrizione in tempo reale, riassunti automatici e altro.';
+  String get phoneCallsUpsellSubtitle => 'Effettua chiamate tramite Omi e ottieni trascrizione in tempo reale, riassunti automatici e altro.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Trascrizione in tempo reale di ogni chiamata';
@@ -8442,8 +8246,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteSyncedFiles => 'Elimina registrazioni sincronizzate';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Queste registrazioni sono già state sincronizzate con il tuo telefono. Questa azione non può essere annullata.';
+  String get deleteSyncedFilesMessage => 'Queste registrazioni sono già state sincronizzate con il tuo telefono. Questa azione non può essere annullata.';
 
   @override
   String get syncedFilesDeleted => 'Registrazioni sincronizzate eliminate';
@@ -8455,8 +8258,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deletePendingFiles => 'Elimina registrazioni in sospeso';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Queste registrazioni NON sono state sincronizzate con il tuo telefono e andranno perse permanentemente. Questa azione non può essere annullata.';
+  String get deletePendingFilesWarning => 'Queste registrazioni NON sono state sincronizzate con il tuo telefono e andranno perse permanentemente. Questa azione non può essere annullata.';
 
   @override
   String get pendingFilesDeleted => 'Registrazioni in sospeso eliminate';
@@ -8468,8 +8270,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deleteAll => 'Elimina tutto';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Questo eliminerà le registrazioni sincronizzate e in sospeso. Le registrazioni in sospeso NON sono state sincronizzate e andranno perse permanentemente.';
+  String get deleteAllFilesWarning => 'Questo eliminerà le registrazioni sincronizzate e in sospeso. Le registrazioni in sospeso NON sono state sincronizzate e andranno perse permanentemente.';
 
   @override
   String get allFilesDeleted => 'Tutte le registrazioni eliminate';
@@ -8534,8 +8335,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fairUseAboutTitle => 'Informazioni sull\'uso corretto';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi è progettato per conversazioni personali, riunioni e interazioni dal vivo. L\'utilizzo è misurato dal tempo reale di parlato rilevato, non dal tempo di connessione. Se l\'utilizzo supera significativamente i modelli normali per contenuti non personali, potrebbero essere applicate modifiche.';
+  String get fairUseAboutBody => 'Omi è progettato per conversazioni personali, riunioni e interazioni dal vivo. L\'utilizzo è misurato dal tempo reale di parlato rilevato, non dal tempo di connessione. Se l\'utilizzo supera significativamente i modelli normali per contenuti non personali, potrebbero essere applicate modifiche.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8573,8 +8373,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get improveConnectionTitle => 'Migliora connessione';
 
   @override
-  String get improveConnectionContent =>
-      'Abbiamo migliorato il modo in cui Omi rimane connesso al tuo dispositivo. Per attivarlo, vai alla pagina Info dispositivo, tocca \"Disconnetti dispositivo\" e associa nuovamente il tuo dispositivo.';
+  String get improveConnectionContent => 'Abbiamo migliorato il modo in cui Omi rimane connesso al tuo dispositivo. Per attivarlo, vai alla pagina Info dispositivo, tocca \"Disconnetti dispositivo\" e associa nuovamente il tuo dispositivo.';
 
   @override
   String get improveConnectionAction => 'Capito';
@@ -8600,8 +8399,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noSyncedRecordings => 'Nessuna registrazione sincronizzata ancora';
 
   @override
-  String get recordingsSyncAutomatically =>
-      'Le registrazioni si sincronizzano automaticamente — nessuna azione necessaria.';
+  String get recordingsSyncAutomatically => 'Le registrazioni si sincronizzano automaticamente — nessuna azione necessaria.';
 
   @override
   String get filesDownloadedUploadedNextTime => 'I file già scaricati verranno caricati la prossima volta.';
@@ -8630,16 +8428,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cancelSyncQuestion => 'Annullare la sincronizzazione?';
 
   @override
-  String get omisStorageDesc =>
-      'Quando il tuo Omi non è collegato al telefono, memorizza l\'audio localmente nella sua memoria integrata. Non perderai mai una registrazione.';
+  String get omisStorageDesc => 'Quando il tuo Omi non è collegato al telefono, memorizza l\'audio localmente nella sua memoria integrata. Non perderai mai una registrazione.';
 
   @override
-  String get phoneStorageDesc =>
-      'Quando Omi si riconnette, le registrazioni vengono trasferite automaticamente al telefono prima del caricamento.';
+  String get phoneStorageDesc => 'Quando Omi si riconnette, le registrazioni vengono trasferite automaticamente al telefono prima del caricamento.';
 
   @override
-  String get cloudStorageDesc =>
-      'Una volta caricate, le registrazioni vengono elaborate e trascritte. Le conversazioni saranno disponibili entro un minuto.';
+  String get cloudStorageDesc => 'Una volta caricate, le registrazioni vengono elaborate e trascritte. Le conversazioni saranno disponibili entro un minuto.';
 
   @override
   String get tipKeepPhoneNearby => 'Tieni il telefono vicino per una sincronizzazione più veloce';
@@ -8663,12 +8458,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get permissionEnable => 'Attiva';
 
   @override
-  String get permissionsPageDescription =>
-      'Queste autorizzazioni sono fondamentali per il funzionamento di Omi. Abilitano funzionalità chiave come notifiche, esperienze basate sulla posizione e acquisizione audio.';
+  String get permissionsPageDescription => 'Queste autorizzazioni sono fondamentali per il funzionamento di Omi. Abilitano funzionalità chiave come notifiche, esperienze basate sulla posizione e acquisizione audio.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi ha bisogno di alcune autorizzazioni per funzionare correttamente. Per favore, concedile per continuare.';
+  String get permissionsRequiredDescription => 'Omi ha bisogno di alcune autorizzazioni per funzionare correttamente. Per favore, concedile per continuare.';
 
   @override
   String get permissionsSetupTitle => 'Ottieni la migliore esperienza';
@@ -8722,8 +8515,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get justAMoment => 'Un momento, per favore';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Ti consigliamo vivamente di esplorare le tue altre opzioni invece di annullare.';
+  String get cancelConsequencesSubtitle => 'Ti consigliamo vivamente di esplorare le tue altre opzioni invece di annullare.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8925,8 +8717,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get enableLocationTitle => 'Attiva posizione';
 
   @override
-  String get enableLocationDescription =>
-      'L\'autorizzazione alla posizione è necessaria per trovare i dispositivi Bluetooth nelle vicinanze.';
+  String get enableLocationDescription => 'L\'autorizzazione alla posizione è necessaria per trovare i dispositivi Bluetooth nelle vicinanze.';
 
   @override
   String get voiceRecordingFound => 'Registrazione trovata';
@@ -8947,8 +8738,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get firmwareWarningTitle => 'Importante: Leggere prima dell\'aggiornamento';
 
   @override
-  String get firmwareFormatWarning =>
-      'Questo firmware formatterà la scheda SD. Assicurati che tutti i dati offline siano sincronizzati prima dell\'aggiornamento.\n\nSe vedi una luce rossa lampeggiante dopo aver installato questa versione, non preoccuparti. Collega semplicemente il dispositivo all\'app e dovrebbe diventare blu. La luce rossa significa che l\'orologio del dispositivo non è ancora stato sincronizzato.';
+  String get firmwareFormatWarning => 'Questo firmware formatterà la scheda SD. Assicurati che tutti i dati offline siano sincronizzati prima dell\'aggiornamento.\n\nSe vedi una luce rossa lampeggiante dopo aver installato questa versione, non preoccuparti. Collega semplicemente il dispositivo all\'app e dovrebbe diventare blu. La luce rossa significa che l\'orologio del dispositivo non è ancora stato sincronizzato.';
 
   @override
   String get continueAnyway => 'Continua';
@@ -8968,8 +8758,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tasksMarkComplete => 'Contrassegnato come completato';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi accede ad Apple Health tramite il framework HealthKit di Apple. Puoi revocare l\'accesso in qualsiasi momento dalle Impostazioni iOS.';
+  String get appleHealthManageNote => 'Omi accede ad Apple Health tramite il framework HealthKit di Apple. Puoi revocare l\'accesso in qualsiasi momento dalle Impostazioni iOS.';
 
   @override
   String get appleHealthConnectCta => 'Connetti ad Apple Health';
@@ -8996,15 +8785,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get appleHealthFeatureSecureTitle => 'Sincronizzazione sicura';
 
   @override
-  String get appleHealthFeatureSecureDesc =>
-      'I tuoi dati Apple Health si sincronizzano privatamente con il tuo account Omi.';
+  String get appleHealthFeatureSecureDesc => 'I tuoi dati Apple Health si sincronizzano privatamente con il tuo account Omi.';
 
   @override
   String get appleHealthDeniedTitle => 'Accesso ad Apple Health negato';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi non ha il permesso di leggere i tuoi dati di Apple Health. Attivalo in Impostazioni iOS → Privacy e sicurezza → Salute → Omi.';
+  String get appleHealthDeniedBody => 'Omi non ha il permesso di leggere i tuoi dati di Apple Health. Attivalo in Impostazioni iOS → Privacy e sicurezza → Salute → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Perché te ne stai andando?';
@@ -9073,8 +8860,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get planUpdate => 'Aggiornamento del piano';
 
   @override
-  String get planDeprecationMessage =>
-      'Il tuo piano Unlimited viene ritirato. Passa al piano Operator — le stesse fantastiche funzionalità a \$49/mese. Il tuo piano attuale continuerà a funzionare nel frattempo.';
+  String get planDeprecationMessage => 'Il tuo piano Unlimited viene ritirato. Passa al piano Operator — le stesse fantastiche funzionalità a \$49/mese. Il tuo piano attuale continuerà a funzionare nel frattempo.';
 
   @override
   String get upgradeYourPlan => 'Aggiorna il tuo piano';
@@ -9185,8 +8971,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Hai raggiunto il tuo limite mensile. Aggiorna per continuare a chattare con Omi senza restrizioni.';
+  String get chatQuotaExceededReply => 'Hai raggiunto il tuo limite mensile. Aggiorna per continuare a chattare con Omi senza restrizioni.';
 
   @override
   String get voiceResponseAudio => 'Leggi la risposta di Omi ad alta voce';
@@ -9217,4 +9002,25 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Aggiungi attività';
+
+  @override
+  String get quickActionAskOmiAnything => 'Chiedi qualsiasi cosa a Omi';
+
+  @override
+  String get quickActionVoiceMode => 'Modalità voce';
+
+  @override
+  String get quickActionMute => 'Silenzia';
+
+  @override
+  String get quickActionUnmute => 'Riattiva audio';
+
+  @override
+  String get quickActionConnectDevice => 'Connetti dispositivo';
+
+  @override
+  String get quickActionDeviceSettings => 'Impostazioni dispositivo';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -527,8 +527,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get unpairDialogTitle => 'デバイスのペアリング解除';
 
   @override
-  String get unpairDialogMessage =>
-      'これにより、デバイスのペアリングが解除され、別の電話に接続できるようになります。プロセスを完了するには、設定 > Bluetoothに移動してデバイスを忘れる必要があります。';
+  String get unpairDialogMessage => 'これにより、デバイスのペアリングが解除され、別の電話に接続できるようになります。プロセスを完了するには、設定 > Bluetoothに移動してデバイスを忘れる必要があります。';
 
   @override
   String get deviceNotConnected => 'デバイスが接続されていません';
@@ -823,8 +822,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'ナレッジグラフを削除しますか？';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'これにより、派生したすべてのナレッジグラフデータ（ノードと接続）が削除されます。元の記憶は安全なままです。グラフは時間の経過とともに、または次のリクエスト時に再構築されます。';
+  String get deleteKnowledgeGraphMessage => 'これにより、派生したすべてのナレッジグラフデータ（ノードと接続）が削除されます。元の記憶は安全なままです。グラフは時間の経過とともに、または次のリクエスト時に再構築されます。';
 
   @override
   String get knowledgeGraphDeleted => 'ナレッジグラフを削除しました';
@@ -1871,8 +1869,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get permissionGrantedNow => '許可されました！次は：\n\nApple WatchでOmiアプリを開き、下の「続ける」をタップしてください';
 
   @override
-  String get needMicrophonePermission =>
-      'マイクの許可が必要です。\n\n1. 「許可する」をタップ\n2. iPhoneで許可を選択\n3. Watchアプリが閉じます\n4. 再度開いて「続ける」をタップ';
+  String get needMicrophonePermission => 'マイクの許可が必要です。\n\n1. 「許可する」をタップ\n2. iPhoneで許可を選択\n3. Watchアプリが閉じます\n4. 再度開いて「続ける」をタップ';
 
   @override
   String get grantPermissionButton => '許可する';
@@ -1881,8 +1878,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get needHelp => 'ヘルプ';
 
   @override
-  String get troubleshootingSteps =>
-      'トラブルシューティング：\n\n1. WatchにOmiがインストールされているか確認\n2. WatchでOmiアプリを開く\n3. 許可のポップアップを探す\n4. 「許可」をタップ\n5. Watchアプリが閉じたら再度開く\n6. iPhoneに戻り「続ける」をタップ';
+  String get troubleshootingSteps => 'トラブルシューティング：\n\n1. WatchにOmiがインストールされているか確認\n2. WatchでOmiアプリを開く\n3. 許可のポップアップを探す\n4. 「許可」をタップ\n5. Watchアプリが閉じたら再度開く\n6. iPhoneに戻り「続ける」をタップ';
 
   @override
   String get recordingStartedSuccessfully => '録音が正常に開始されました！';
@@ -2342,8 +2338,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'デバイスのペアリング解除';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'これにより、デバイスのペアリングが解除され、別の電話に接続できるようになります。設定 > Bluetoothに移動し、デバイスを削除してプロセスを完了する必要があります。';
+  String get unpairDeviceDialogMessage => 'これにより、デバイスのペアリングが解除され、別の電話に接続できるようになります。設定 > Bluetoothに移動し、デバイスを削除してプロセスを完了する必要があります。';
 
   @override
   String get unpair => 'ペアリング解除';
@@ -4245,8 +4240,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get maximumSecurityE2ee => '最大セキュリティ（E2EE）';
 
   @override
-  String get e2eeDescription =>
-      'エンドツーエンド暗号化はプライバシーの最高基準です。有効にすると、データはサーバーに送信される前にデバイス上で暗号化されます。これは、Omiを含め、誰もあなたのコンテンツにアクセスできないことを意味します。';
+  String get e2eeDescription => 'エンドツーエンド暗号化はプライバシーの最高基準です。有効にすると、データはサーバーに送信される前にデバイス上で暗号化されます。これは、Omiを含め、誰もあなたのコンテンツにアクセスできないことを意味します。';
 
   @override
   String get importantTradeoffs => '重要なトレードオフ：';
@@ -4280,8 +4274,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get secureEncryption => '安全な暗号化';
 
   @override
-  String get secureEncryptionDescription =>
-      'あなたのデータは、Google Cloudでホストされている当社のサーバー上で、あなた固有の鍵で暗号化されています。これは、生のコンテンツがOmiスタッフやGoogleを含む誰にも、データベースから直接アクセスできないことを意味します。';
+  String get secureEncryptionDescription => 'あなたのデータは、Google Cloudでホストされている当社のサーバー上で、あなた固有の鍵で暗号化されています。これは、生のコンテンツがOmiスタッフやGoogleを含む誰にも、データベースから直接アクセスできないことを意味します。';
 
   @override
   String get endToEndEncryption => 'エンドツーエンド暗号化';
@@ -4610,8 +4603,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'エクスポートを開始しました。数秒かかる場合があります...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'これにより、すべての派生ナレッジグラフデータ（ノードと接続）が削除されます。元の記憶は安全に保たれます。グラフは時間の経過とともに、または次のリクエスト時に再構築されます。';
+  String get knowledgeGraphDeleteDescription => 'これにより、すべての派生ナレッジグラフデータ（ノードと接続）が削除されます。元の記憶は安全に保たれます。グラフは時間の経過とともに、または次のリクエスト時に再構築されます。';
 
   @override
   String get configureDailySummaryDigest => '毎日のタスクダイジェストを設定する';
@@ -4994,8 +4986,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get additionalSpeechSampleRemoved => '追加の音声サンプルを削除しました';
 
   @override
-  String get consentDataMessage =>
-      '続行することで、会話、録音、個人情報は安全に当社のサーバーに保存されます。音声録音と文字起こしは、サードパーティのAIサービス（文字起こし用のDeepgramと分析用のOpenAIを含む）によって処理され、AI駆動のインサイトを提供し、すべてのアプリ機能を有効にします。';
+  String get consentDataMessage => '続行することで、会話、録音、個人情報は安全に当社のサーバーに保存されます。音声録音と文字起こしは、サードパーティのAIサービス（文字起こし用のDeepgramと分析用のOpenAIを含む）によって処理され、AI駆動のインサイトを提供し、すべてのアプリ機能を有効にします。';
 
   @override
   String get tasksEmptyStateMessage => '会話からのタスクがここに表示されます。\n手動で作成するには + をタップしてください。';
@@ -5049,8 +5040,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'アプリをインストールして開きました';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watchアプリを開けませんでした。Apple WatchのWatchアプリを手動で開き、「利用可能なApp」セクションからOmiをインストールしてください。';
+  String get unableToOpenWatchApp => 'Apple Watchアプリを開けませんでした。Apple WatchのWatchアプリを手動で開き、「利用可能なApp」セクションからOmiをインストールしてください。';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watchが正常に接続されました！';
@@ -5502,8 +5492,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get howToTakeGoodSample => '良いサンプルの取り方は？';
 
   @override
-  String get goodSampleInstructions =>
-      '1. 静かな場所にいることを確認してください。\n2. 明確に自然に話してください。\n3. デバイスが首の自然な位置にあることを確認してください。\n\n作成後、いつでも改善したり、やり直したりできます。';
+  String get goodSampleInstructions => '1. 静かな場所にいることを確認してください。\n2. 明確に自然に話してください。\n3. デバイスが首の自然な位置にあることを確認してください。\n\n作成後、いつでも改善したり、やり直したりできます。';
 
   @override
   String get noDeviceConnectedUseMic => '接続されているデバイスがありません。電話のマイクを使用します。';
@@ -8340,8 +8329,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get fairUseAboutTitle => 'フェアユースについて';
 
   @override
-  String get fairUseAboutBody =>
-      'Omiは個人的な会話、会議、ライブのやり取りのために設計されています。使用量は接続時間ではなく、検出された実際の発話時間で測定されます。非個人的なコンテンツに対して通常のパターンを大幅に超える使用がある場合、調整が適用されることがあります。';
+  String get fairUseAboutBody => 'Omiは個人的な会話、会議、ライブのやり取りのために設計されています。使用量は接続時間ではなく、検出された実際の発話時間で測定されます。非個人的なコンテンツに対して通常のパターンを大幅に超える使用がある場合、調整が適用されることがあります。';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8379,8 +8367,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get improveConnectionTitle => '接続を改善';
 
   @override
-  String get improveConnectionContent =>
-      'Omiがデバイスとの接続を維持する方法を改善しました。これを有効にするには、デバイス情報ページに移動し、「デバイスを切断」をタップしてから、デバイスを再度ペアリングしてください。';
+  String get improveConnectionContent => 'Omiがデバイスとの接続を維持する方法を改善しました。これを有効にするには、デバイス情報ページに移動し、「デバイスを切断」をタップしてから、デバイスを再度ペアリングしてください。';
 
   @override
   String get improveConnectionAction => '了解';
@@ -8745,8 +8732,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get firmwareWarningTitle => '重要：更新前にお読みください';
 
   @override
-  String get firmwareFormatWarning =>
-      'このファームウェアはSDカードをフォーマットします。アップグレード前にすべてのオフラインデータが同期されていることを確認してください。\n\nこのバージョンのインストール後に赤いライトが点滅しても心配しないでください。デバイスをアプリに接続するだけで青に変わるはずです。赤いライトはデバイスの時計がまだ同期されていないことを意味します。';
+  String get firmwareFormatWarning => 'このファームウェアはSDカードをフォーマットします。アップグレード前にすべてのオフラインデータが同期されていることを確認してください。\n\nこのバージョンのインストール後に赤いライトが点滅しても心配しないでください。デバイスをアプリに接続するだけで青に変わるはずです。赤いライトはデバイスの時計がまだ同期されていないことを意味します。';
 
   @override
   String get continueAnyway => '続行';
@@ -8766,8 +8752,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get tasksMarkComplete => '完了としてマーク';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi は Apple の HealthKit フレームワークを通じて Apple Health にアクセスします。アクセスはいつでも iOS の設定から取り消せます。';
+  String get appleHealthManageNote => 'Omi は Apple の HealthKit フレームワークを通じて Apple Health にアクセスします。アクセスはいつでも iOS の設定から取り消せます。';
 
   @override
   String get appleHealthConnectCta => 'Apple Health に接続';
@@ -8800,8 +8785,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health へのアクセスが拒否されました';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi は Apple Health データを読み取る権限がありません。iOS の設定 → プライバシーとセキュリティ → ヘルスケア → Omi で有効にしてください。';
+  String get appleHealthDeniedBody => 'Omi は Apple Health データを読み取る権限がありません。iOS の設定 → プライバシーとセキュリティ → ヘルスケア → Omi で有効にしてください。';
 
   @override
   String get deleteFlowReasonTitle => 'どうして離れるのですか?';
@@ -8870,8 +8854,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get planUpdate => 'プラン更新';
 
   @override
-  String get planDeprecationMessage =>
-      'Unlimitedプランは廃止予定です。Operatorプランに切り替えてください — 同じ優れた機能が月額\$49でご利用いただけます。現在のプランは当面の間引き続きご利用いただけます。';
+  String get planDeprecationMessage => 'Unlimitedプランは廃止予定です。Operatorプランに切り替えてください — 同じ優れた機能が月額\$49でご利用いただけます。現在のプランは当面の間引き続きご利用いただけます。';
 
   @override
   String get upgradeYourPlan => 'プランをアップグレード';
@@ -9013,4 +8996,25 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'タスクを追加';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omiに何でも聞く';
+
+  @override
+  String get quickActionVoiceMode => '音声モード';
+
+  @override
+  String get quickActionMute => 'ミュート';
+
+  @override
+  String get quickActionUnmute => 'ミュート解除';
+
+  @override
+  String get quickActionConnectDevice => 'デバイスを接続';
+
+  @override
+  String get quickActionDeviceSettings => 'デバイス設定';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -24,8 +24,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deleteConversationTitle => 'ಸಂವಾದ ಅಳಿಸಿ?';
 
   @override
-  String get deleteConversationMessage =>
-      'ಇದು ಸಂಬಂಧಿತ ಸ್ಮೃತಿಗಳು, ಕಾರ್ಯಗಳು ಮತ್ತು ಆಡಿಯೋ ಫೈಲ್‌ಗಳನ್ನೂ ಅಳಿಸುತ್ತದೆ. ಈ ಕ್ರಿಯೆಯನ್ನು ಹಿಂತೆಗೆದುಕೊಳ್ಳಲಾಗುವುದಿಲ್ಲ.';
+  String get deleteConversationMessage => 'ಇದು ಸಂಬಂಧಿತ ಸ್ಮೃತಿಗಳು, ಕಾರ್ಯಗಳು ಮತ್ತು ಆಡಿಯೋ ಫೈಲ್‌ಗಳನ್ನೂ ಅಳಿಸುತ್ತದೆ. ಈ ಕ್ರಿಯೆಯನ್ನು ಹಿಂತೆಗೆದುಕೊಳ್ಳಲಾಗುವುದಿಲ್ಲ.';
 
   @override
   String get confirm => 'ಖಚಿತಪಡಿಸಿ';
@@ -146,8 +145,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deleting => 'ಅಳಿಸುತ್ತಿದೆ...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'ನಿಮ್ಮ ಬ್ರೌಜರ್‌ನಲ್ಲಿ ಪ್ರಮಾಣೀಕರಣ ಪೂರ್ಣ ಮಾಡಿ. ಪೂರ್ಣವಾದ ನಂತರ, ಅಪ್ಲಿಕೇಶನಿಗೆ ಹಿಂತಿರುಗಿ.';
+  String get pleaseCompleteAuthentication => 'ನಿಮ್ಮ ಬ್ರೌಜರ್‌ನಲ್ಲಿ ಪ್ರಮಾಣೀಕರಣ ಪೂರ್ಣ ಮಾಡಿ. ಪೂರ್ಣವಾದ ನಂತರ, ಅಪ್ಲಿಕೇಶನಿಗೆ ಹಿಂತಿರುಗಿ.';
 
   @override
   String get failedToStartAuthentication => 'ಪ್ರಮಾಣೀಕರಣ ಪ್ರಾರಂಭಿಸಲು ವಿಫಲ';
@@ -228,8 +226,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get noStarredConversations => 'ಯಾವ ನಕ್ಷತ್ರಾಕೃತ ಸಂವಾದ ಇಲ್ಲ';
 
   @override
-  String get starConversationHint =>
-      'ಸಂವಾದಕ್ಕೆ ನಕ್ಷತ್ರ ಮಾಡಲು, ಅದನ್ನು ತೆರೆಯಿರಿ ಮತ್ತು ತಲೆಬರದಲ್ಲಿ ನಕ್ಷತ್ರ ಐಕನ್ ಟ್ಯಾಪ್ ಮಾಡಿ.';
+  String get starConversationHint => 'ಸಂವಾದಕ್ಕೆ ನಕ್ಷತ್ರ ಮಾಡಲು, ಅದನ್ನು ತೆರೆಯಿರಿ ಮತ್ತು ತಲೆಬರದಲ್ಲಿ ನಕ್ಷತ್ರ ಐಕನ್ ಟ್ಯಾಪ್ ಮಾಡಿ.';
 
   @override
   String get searchConversations => 'ಸಂವಾದ ಹುಡುಕಿ...';
@@ -287,8 +284,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get clearChat => 'ಚ್ಯಾಟ್ ತೆರವುಗೊಳಿಸಿ';
 
   @override
-  String get clearChatConfirm =>
-      'ನೀವು ಖಚಿತವಾಗಿ ಚ್ಯಾಟ್ ತೆರವುಗೊಳಿಸಲು ಬಯಸುತ್ತೀರಾ? ಈ ಕ್ರಿಯೆಯನ್ನು ಹಿಂತೆಗೆದುಕೊಳ್ಳಲಾಗುವುದಿಲ್ಲ.';
+  String get clearChatConfirm => 'ನೀವು ಖಚಿತವಾಗಿ ಚ್ಯಾಟ್ ತೆರವುಗೊಳಿಸಲು ಬಯಸುತ್ತೀರಾ? ಈ ಕ್ರಿಯೆಯನ್ನು ಹಿಂತೆಗೆದುಕೊಳ್ಳಲಾಗುವುದಿಲ್ಲ.';
 
   @override
   String get maxFilesLimit => 'ಒಂದು ಸಮಯದಲ್ಲಿ 4 ಫೈಲ್‌ಗಳು ಮಾತ್ರ ಅಪ್‌ಲೋಡ್ ಮಾಡಬಹುದು';
@@ -357,19 +353,16 @@ class AppLocalizationsKn extends AppLocalizations {
   String get appsDisconnected => 'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಮತ್ತು ಸಮಾವೇಶವು ತಕ್ಷಣವೇ ಸಂಪರ್ಕ ಛಿನ್ನಗೊಳ್ಳುತ್ತದೆ.';
 
   @override
-  String get exportBeforeDelete =>
-      'ನಿಮ್ಮ ಖಾತೆ ಅಳಿಸುವ ಮೊದಲು ನಿಮ್ಮ ಡೇಟಾ ರಫ್ತಿ ಮಾಡಬಹುದು, ಆದರೆ ಒಮ್ಮೆ ಅಳಿಸಿದ ನಂತರ ಅದನ್ನು ಮರುಸ್ಥಾಪಿತ ಮಾಡಲಾಗುವುದಿಲ್ಲ.';
+  String get exportBeforeDelete => 'ನಿಮ್ಮ ಖಾತೆ ಅಳಿಸುವ ಮೊದಲು ನಿಮ್ಮ ಡೇಟಾ ರಫ್ತಿ ಮಾಡಬಹುದು, ಆದರೆ ಒಮ್ಮೆ ಅಳಿಸಿದ ನಂತರ ಅದನ್ನು ಮರುಸ್ಥಾಪಿತ ಮಾಡಲಾಗುವುದಿಲ್ಲ.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'ನಿಮ್ಮ ಖಾತೆ ಅಳಿಸುವುದು ಶಾಶ್ವತವಾಗಿದೆ ಮತ್ತು ಸ್ಮೃತಿ ಮತ್ತು ಸಂವಾದಗಳು ಸಹ ಸಾಂಸ್ಕೃತಿಕವಾಗಿ ಅಳಿಸಲಾಯುತ್ತದೆ ಮತ್ತು ಮರುಸ್ಥಾಪಿತ ಮಾಡಲಾಗುವುದಿಲ್ಲ ಎಂದು ನಾನು ಅರ್ಥ ಮಾಡಿಕೊಂಡಿದ್ದೇನೆ.';
+  String get deleteAccountCheckbox => 'ನಿಮ್ಮ ಖಾತೆ ಅಳಿಸುವುದು ಶಾಶ್ವತವಾಗಿದೆ ಮತ್ತು ಸ್ಮೃತಿ ಮತ್ತು ಸಂವಾದಗಳು ಸಹ ಸಾಂಸ್ಕೃತಿಕವಾಗಿ ಅಳಿಸಲಾಯುತ್ತದೆ ಮತ್ತು ಮರುಸ್ಥಾಪಿತ ಮಾಡಲಾಗುವುದಿಲ್ಲ ಎಂದು ನಾನು ಅರ್ಥ ಮಾಡಿಕೊಂಡಿದ್ದೇನೆ.';
 
   @override
   String get areYouSure => 'ನೀವು ಖಚಿತವಾಗಿದ್ದೀರಾ?';
 
   @override
-  String get deleteAccountFinal =>
-      'ಈ ಕ್ರಿಯೆಯು ಅಳಿಸುವ ಮಟ್ಟುವಿಲ್ಲ ಮತ್ತು ನಿಮ್ಮ ಖಾತೆ ಮತ್ತು ಎಲ್ಲಾ ಸಂಬಂಧಿತ ಡೇಟಾ ಶಾಶ್ವತವಾಗಿ ಅಳಿಸುತ್ತದೆ. ನೀವು ಖಚಿತವಾಗಿ ಮುಂದುವರಿಸಲು ಬಯಸುತ್ತೀರಾ?';
+  String get deleteAccountFinal => 'ಈ ಕ್ರಿಯೆಯು ಅಳಿಸುವ ಮಟ್ಟುವಿಲ್ಲ ಮತ್ತು ನಿಮ್ಮ ಖಾತೆ ಮತ್ತು ಎಲ್ಲಾ ಸಂಬಂಧಿತ ಡೇಟಾ ಶಾಶ್ವತವಾಗಿ ಅಳಿಸುತ್ತದೆ. ನೀವು ಖಚಿತವಾಗಿ ಮುಂದುವರಿಸಲು ಬಯಸುತ್ತೀರಾ?';
 
   @override
   String get deleteNow => 'ಈಗ ಅಳಿಸಿ';
@@ -378,8 +371,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get goBack => 'ಹಿಂದಕ್ಕೆ ಹೋಗಿ';
 
   @override
-  String get checkBoxToConfirm =>
-      'ನಿಮ್ಮ ಖಾತೆ ಅಳಿಸುವುದು ಶಾಶ್ವತವಾಗಿದೆ ಮತ್ತು ಮರುಸ್ಥಾಪಿತ ಮಾಡಲಾಗುವುದಿಲ್ಲ ಎಂದು ಸ್ಪಷ್ಟವಾಗಿ ಅರ್ಥ ಮಾಡಿಕೊಳ್ಳಲು ಪೆಟ್ಟಿಗೆ ಪರಿಶೀಲಿಸಿ.';
+  String get checkBoxToConfirm => 'ನಿಮ್ಮ ಖಾತೆ ಅಳಿಸುವುದು ಶಾಶ್ವತವಾಗಿದೆ ಮತ್ತು ಮರುಸ್ಥಾಪಿತ ಮಾಡಲಾಗುವುದಿಲ್ಲ ಎಂದು ಸ್ಪಷ್ಟವಾಗಿ ಅರ್ಥ ಮಾಡಿಕೊಳ್ಳಲು ಪೆಟ್ಟಿಗೆ ಪರಿಶೀಲಿಸಿ.';
 
   @override
   String get profile => 'ಪ್ರೊಫೈಲ್';
@@ -457,8 +449,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get yourPrivacyYourControl => 'ನಿಮ್ಮ ಗೌಪ್ಯತೆ, ನಿಮ್ಮ ನಿಯಂತ್ರಣ';
 
   @override
-  String get privacyIntro =>
-      'ಓಮಿಯಲ್ಲಿ, ನಾವು ನಿಮ್ಮ ಗೌಪ್ಯತೆ ರಕ್ಷಿಸಲು ಪ್ರತಿಶ್ರುತರಾಗಿದ್ದೇವೆ. ಈ ಪುಟವು ನಿಮ್ಮ ಡೇಟಾ ಹೇಗೆ ಸಂಗ್ರಹ ಮತ್ತು ಬಳಕೆ ಮಾಡಬೇಕೆ ಎಂಬುದನ್ನು ನಿಯಂತ್ರಿಸಲು ಅನುಮತಿ ನೀಡುತ್ತದೆ.';
+  String get privacyIntro => 'ಓಮಿಯಲ್ಲಿ, ನಾವು ನಿಮ್ಮ ಗೌಪ್ಯತೆ ರಕ್ಷಿಸಲು ಪ್ರತಿಶ್ರುತರಾಗಿದ್ದೇವೆ. ಈ ಪುಟವು ನಿಮ್ಮ ಡೇಟಾ ಹೇಗೆ ಸಂಗ್ರಹ ಮತ್ತು ಬಳಕೆ ಮಾಡಬೇಕೆ ಎಂಬುದನ್ನು ನಿಯಂತ್ರಿಸಲು ಅನುಮತಿ ನೀಡುತ್ತದೆ.';
 
   @override
   String get learnMore => 'ಹೆಚ್ಚಿನ ತಿಳಿ...';
@@ -467,15 +458,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get dataProtectionLevel => 'ಡೇಟಾ ಸುರಕ್ಷಣೆ ಮಟ್ಟ';
 
   @override
-  String get dataProtectionDesc =>
-      'ನಿಮ್ಮ ಡೇಟಾ ಪ್ರಬಲ ಎನ್‌ಕ್ರಿಪ್ಶನ್‌ನಿಂದ ಮೂಲನಿರ್ಧಾರ ರಕ್ಷಿತ ಆಗಿದೆ. ನಿಮ್ಮ ಸೆಟ್ಟಿಂಗ್‌ಗಳು ಮತ್ತು ಭವಿಷ್ಯತ್ ಗೌಪ್ಯತೆ ಆಯ್ಕೆಗಳನ್ನು ಪರಿಶೀಲಿಸಿ.';
+  String get dataProtectionDesc => 'ನಿಮ್ಮ ಡೇಟಾ ಪ್ರಬಲ ಎನ್‌ಕ್ರಿಪ್ಶನ್‌ನಿಂದ ಮೂಲನಿರ್ಧಾರ ರಕ್ಷಿತ ಆಗಿದೆ. ನಿಮ್ಮ ಸೆಟ್ಟಿಂಗ್‌ಗಳು ಮತ್ತು ಭವಿಷ್ಯತ್ ಗೌಪ್ಯತೆ ಆಯ್ಕೆಗಳನ್ನು ಪರಿಶೀಲಿಸಿ.';
 
   @override
   String get appAccess => 'ಅಪ್ಲಿಕೇಶನ ಪ್ರವೇಶ';
 
   @override
-  String get appAccessDesc =>
-      'ಕೆಳಗಿನ ಅಪ್ಲಿಕೇಶನಗಳು ನಿಮ್ಮ ಡೇಟಾ ಪ್ರವೇಶ ಮಾಡಬಹುದು. ಇದರ ಅನುಮತಿಗಳನ್ನು ನಿರ್ವಹಿಸಲು ಅಪ್ಲಿಕೇಶನ ಟ್ಯಾಪ್ ಮಾಡಿ.';
+  String get appAccessDesc => 'ಕೆಳಗಿನ ಅಪ್ಲಿಕೇಶನಗಳು ನಿಮ್ಮ ಡೇಟಾ ಪ್ರವೇಶ ಮಾಡಬಹುದು. ಇದರ ಅನುಮತಿಗಳನ್ನು ನಿರ್ವಹಿಸಲು ಅಪ್ಲಿಕೇಶನ ಟ್ಯಾಪ್ ಮಾಡಿ.';
 
   @override
   String get noAppsExternalAccess => 'ಯಾವ ಅನುಸ್ಥಾಪಿತ ಅಪ್ಲಿಕೇಶನ ನಿಮ್ಮ ಡೇಟಾಗೆ ಬಾಹ್ಯ ಪ್ರವೇಶನ ಹೊಂದಿಲ್ಲ.';
@@ -532,15 +521,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deviceDisconnectedMessage => 'ನಿಮ್ಮ ಓಮಿ ಸಂಪರ್ಕ ಛಿನ್ನಗೊಂಡಿದೆ 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'ಸಾಧನ ಜೋಡಿ ರದ್ದುಗೊಳಿಸಲಾಗಿದೆ. ಜೋಡಿ ಪ್ರಕ್ರಿಯೆ ಪೂರ್ಣ ಮಾಡಲು ಸೆಟ್ಟಿಂಗ್ > ಬ್ಲೂಟೂತ್ ಗಿಂತ ಸಾಧನ ಸಾಬೋಟ್‌ಗೆ ಹೋಗಿ.';
+  String get deviceUnpairedMessage => 'ಸಾಧನ ಜೋಡಿ ರದ್ದುಗೊಳಿಸಲಾಗಿದೆ. ಜೋಡಿ ಪ್ರಕ್ರಿಯೆ ಪೂರ್ಣ ಮಾಡಲು ಸೆಟ್ಟಿಂಗ್ > ಬ್ಲೂಟೂತ್ ಗಿಂತ ಸಾಧನ ಸಾಬೋಟ್‌ಗೆ ಹೋಗಿ.';
 
   @override
   String get unpairDialogTitle => 'ಜೋಡಿ ಜೋಡಿ ರದ್ದುಗೊಳಿಸಿ';
 
   @override
-  String get unpairDialogMessage =>
-      'ಇದು ಸಾಧನ ಜೋಡಿ ರದ್ದುಗೊಳಿಸುತ್ತದೆ ಆದ್ದರಿಂದ ಅದು ಬೇರೆ ದೂರವಾಣಿಗೆ ಸಂಪರ್ಕ ಮಾಡಬಹುದು. ನೀವು ಜೋಡಿ ಪ್ರಕ್ರಿಯೆ ಪೂರ್ಣ ಮಾಡಲು ಸೆಟ್ಟಿಂಗ್ > ಬ್ಲೂಟೂತ್ ಗಿಂತ ಸಾಧನ ಸಾಬೋಟ್‌ಗೆ ಹೋಗಿದ್ದರಿಂದ ಅದನ್ನು ನೀವೇ ಸಾಬೋಟ್ ಮಾಡಿ.';
+  String get unpairDialogMessage => 'ಇದು ಸಾಧನ ಜೋಡಿ ರದ್ದುಗೊಳಿಸುತ್ತದೆ ಆದ್ದರಿಂದ ಅದು ಬೇರೆ ದೂರವಾಣಿಗೆ ಸಂಪರ್ಕ ಮಾಡಬಹುದು. ನೀವು ಜೋಡಿ ಪ್ರಕ್ರಿಯೆ ಪೂರ್ಣ ಮಾಡಲು ಸೆಟ್ಟಿಂಗ್ > ಬ್ಲೂಟೂತ್ ಗಿಂತ ಸಾಧನ ಸಾಬೋಟ್‌ಗೆ ಹೋಗಿದ್ದರಿಂದ ಅದನ್ನು ನೀವೇ ಸಾಬೋಟ್ ಮಾಡಿ.';
 
   @override
   String get deviceNotConnected => 'ಸಾಧನ ಸಂಪರ್ಕ ಆಗಿಲ್ಲ';
@@ -561,8 +548,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get v2Undetected => 'V2 ಪತ್ತೆ ಮಾಡಲಾಗಿಲ್ಲ';
 
   @override
-  String get v2UndetectedMessage =>
-      'ನಾವು ನೀವು ಯಾವುದೇ V1 ಸಾಧನ ಹೊಂದಿದ್ದೇನೆ ಅಥವಾ ನಿಮ್ಮ ಸಾಧನ ಸಂಪರ್ಕ ಆಗಿಲ್ಲ. SD ಕಾರ್ಡ ಕಾರ್ಯವು V2 ಸಾಧನಗಳಿಗೆ ಮಾತ್ರ ಲಭ್ಯ.';
+  String get v2UndetectedMessage => 'ನಾವು ನೀವು ಯಾವುದೇ V1 ಸಾಧನ ಹೊಂದಿದ್ದೇನೆ ಅಥವಾ ನಿಮ್ಮ ಸಾಧನ ಸಂಪರ್ಕ ಆಗಿಲ್ಲ. SD ಕಾರ್ಡ ಕಾರ್ಯವು V2 ಸಾಧನಗಳಿಗೆ ಮಾತ್ರ ಲಭ್ಯ.';
 
   @override
   String get endConversation => 'ಸಂವಾದ ಆತೊಡೆತು';
@@ -836,8 +822,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'ತಿಳಿವಳಿ ಗ್ರಾಫ್ ಅಳಿಸಿ?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'ಇದು ಎಲ್ಲಾ ವ್ಯುತ್ಪನ್ನ ತಿಳಿವಳಿ ಗ್ರಾಫ್ ಡೇಟಾ (ನೋಡ್ ಮತ್ತು ಸಂಪರ್ಕ) ಅಳಿಸುತ್ತದೆ. ನಿಮ್ಮ ಮೂಲ ಸ್ಮೃತಿಗಳು ಸುರಕ್ಷಿತ ಉಳಿಯುತ್ತವೆ. ಗ್ರಾಫ್ ಸಮಯಾಯ ಅಥವಾ ನೆಮ್ಮದಿ ಬಯಸಿದಾಗ ಪುನರ್ನಿರ್ಮಾಣ ಆಗುತ್ತವೆ.';
+  String get deleteKnowledgeGraphMessage => 'ಇದು ಎಲ್ಲಾ ವ್ಯುತ್ಪನ್ನ ತಿಳಿವಳಿ ಗ್ರಾಫ್ ಡೇಟಾ (ನೋಡ್ ಮತ್ತು ಸಂಪರ್ಕ) ಅಳಿಸುತ್ತದೆ. ನಿಮ್ಮ ಮೂಲ ಸ್ಮೃತಿಗಳು ಸುರಕ್ಷಿತ ಉಳಿಯುತ್ತವೆ. ಗ್ರಾಫ್ ಸಮಯಾಯ ಅಥವಾ ನೆಮ್ಮದಿ ಬಯಸಿದಾಗ ಪುನರ್ನಿರ್ಮಾಣ ಆಗುತ್ತವೆ.';
 
   @override
   String get knowledgeGraphDeleted => 'ತಿಳಿವಳಿ ಗ್ರಾಫ್ ಅಳಿಸಿ';
@@ -1020,8 +1005,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get integrationsFooter => 'ಚ್ಯಾಟ್‌ನಲ್ಲಿ ಡೇಟಾ ಮತ್ತು ಅಂಕಿ ನೋಡಲು ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಸಂಪರ್ಕ ಮಾಡಿ.';
 
   @override
-  String get completeAuthInBrowser =>
-      'ನಿಮ್ಮ ಬ್ರೌಜರ್‌ನಲ್ಲಿ ಪ್ರಮಾಣೀಕರಣ ಪೂರ್ಣ ಮಾಡಿ. ಪೂರ್ಣವಾದ ನಂತರ, ಅಪ್ಲಿಕೇಶನಿಗೆ ಹಿಂತಿರುಗಿ.';
+  String get completeAuthInBrowser => 'ನಿಮ್ಮ ಬ್ರೌಜರ್‌ನಲ್ಲಿ ಪ್ರಮಾಣೀಕರಣ ಪೂರ್ಣ ಮಾಡಿ. ಪೂರ್ಣವಾದ ನಂತರ, ಅಪ್ಲಿಕೇಶನಿಗೆ ಹಿಂತಿರುಗಿ.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1081,8 +1065,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get needYourPermission => 'ನಾವು ನಿಮ್ಮ ಅನುಮತಿ ಅಗತ್ಯ';
 
   @override
-  String get alreadyGavePermission =>
-      'ನೀವು ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್ ಸುತ್ತುಚೆವಾಣೆ ಅನುಮತಿ ಕೆಲವು ಪೂರ್ವ ಇತ್ತೀ. ನಾವು ಅದು ಅಗತ್ಯ ಕೆಳಗಿನ ಅನುಸ್ಮಾರಕ:';
+  String get alreadyGavePermission => 'ನೀವು ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್ ಸುತ್ತುಚೆವಾಣೆ ಅನುಮತಿ ಕೆಲವು ಪೂರ್ವ ಇತ್ತೀ. ನಾವು ಅದು ಅಗತ್ಯ ಕೆಳಗಿನ ಅನುಸ್ಮಾರಕ:';
 
   @override
   String get wouldLikePermission => 'ನಾವು ನಿಮ್ಮ ವಾಯ್ಸ್ ರೆಕಾರ್ಡಿಂಗ್ ಸುತ್ತುಚೆವಾಣೆ ಅನುಮತಿ ಅಪೇಕ್ಷೆ. ಕೆಳಗೆ ಯಾಕೆ:';
@@ -1097,19 +1080,16 @@ class AppLocalizationsKn extends AppLocalizations {
   String get trainFamilyProfiles => 'ಗಿಟ್ಟು ಮತ್ತು ಕುಟುಂಬ ಪ್ರೊಫೈಲ್ ತರಬೇತಿ ಮಾಡಿ';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್ ನಾವು ಗುರುತಿಸಿ ಮತ್ತು ನಿಮ್ಮ ಗಿಟ್ಟು ಮತ್ತು ಕುಟುಂಬ ಪ್ರೊಫೈಲ್ ರಚಿತ ಸಹಾಯ.';
+  String get trainFamilyProfilesDesc => 'ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್ ನಾವು ಗುರುತಿಸಿ ಮತ್ತು ನಿಮ್ಮ ಗಿಟ್ಟು ಮತ್ತು ಕುಟುಂಬ ಪ್ರೊಫೈಲ್ ರಚಿತ ಸಹಾಯ.';
 
   @override
   String get enhanceTranscriptAccuracy => 'ಪ್ರತಿಲಿಪಿ ನಿಖುಂತತೆ ಸುಧಾರಿತ';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'ನಾವು ಮಾದರಿ ಸುಧಾರಿತ ಪರಿಧಿಗೆ, ನಾವು ಉತ್ತಮ ಪ್ರತಿಲಿಪಿ ಫಲ ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್ ಒದಗಿಸಬಹುದು.';
+  String get enhanceTranscriptAccuracyDesc => 'ನಾವು ಮಾದರಿ ಸುಧಾರಿತ ಪರಿಧಿಗೆ, ನಾವು ಉತ್ತಮ ಪ್ರತಿಲಿಪಿ ಫಲ ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್ ಒದಗಿಸಬಹುದು.';
 
   @override
-  String get legalNotice =>
-      'ಕಾನೂನಿ ಶೆಪೈಲಾ: ರೆಕಾರ್ಡಿಂಗ್ ಮತ್ತು ವಾಯ್ಸ್ ಡೇಟಾ ಸಂಗ್ರಹ ಕಾನುನತೆ ನಿಮ್ಮ ಸ್ಥಳ ಮತ್ತು ನಾನೋ ನೀವು ಈ ವೈಶಿಷ್ಟ್ಯ ಬಳಕೆ ಮಾಡುವುದು ಮೇಲೆ ಸಂಬಂಧಿತ. ನೀವು ದೀರ್ಘ ಪ್ರಚಾರ ಮತ್ತು ಕಾನೂನುಗಳು ಮತ್ತು ಕಾನುನತೆ ಅನುಸರಣ ಸುನಿಶ್ಚಿತ ಜವಾಬದಾರಿ.';
+  String get legalNotice => 'ಕಾನೂನಿ ಶೆಪೈಲಾ: ರೆಕಾರ್ಡಿಂಗ್ ಮತ್ತು ವಾಯ್ಸ್ ಡೇಟಾ ಸಂಗ್ರಹ ಕಾನುನತೆ ನಿಮ್ಮ ಸ್ಥಳ ಮತ್ತು ನಾನೋ ನೀವು ಈ ವೈಶಿಷ್ಟ್ಯ ಬಳಕೆ ಮಾಡುವುದು ಮೇಲೆ ಸಂಬಂಧಿತ. ನೀವು ದೀರ್ಘ ಪ್ರಚಾರ ಮತ್ತು ಕಾನೂನುಗಳು ಮತ್ತು ಕಾನುನತೆ ಅನುಸರಣ ಸುನಿಶ್ಚಿತ ಜವಾಬದಾರಿ.';
 
   @override
   String get alreadyAuthorized => 'ಈಗಾಗಲೇ ಅಧಿಕೃತಕೃತ';
@@ -1187,8 +1167,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get showEventsNoParticipants => 'ಭಾಗವಹಿಸುವವರಿಲ್ಲದೆ ಇವೆಂಟ್‌ಗಳನ್ನು ತೋರಿಸಿ';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'ಸಕ್ರಿಯಗೊಳಿಸಿದಾಗ, Coming Up ಭಾಗವಹಿಸುವವರು ಅಥವಾ ವಿಡಿಯೊ ಲಿಂಕ್ ಇಲ್ಲದ ಇವೆಂಟ್‌ಗಳನ್ನು ತೋರಿಸುತ್ತದೆ.';
+  String get showEventsNoParticipantsDesc => 'ಸಕ್ರಿಯಗೊಳಿಸಿದಾಗ, Coming Up ಭಾಗವಹಿಸುವವರು ಅಥವಾ ವಿಡಿಯೊ ಲಿಂಕ್ ಇಲ್ಲದ ಇವೆಂಟ್‌ಗಳನ್ನು ತೋರಿಸುತ್ತದೆ.';
 
   @override
   String get yourMeetings => 'ನಿಮ್ಮ ಸಭೆಗಳು';
@@ -1229,8 +1208,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get noProjectsInWorkspace => 'ಈ ವರ್ಕ್‌ಸ್ಪೇಸ್‌ನಲ್ಲಿ ಯಾವುದೇ ಪ್ರಾಜೆಕ್ಟ್ ಕಂಡುಬಂದಿಲ್ಲ';
 
   @override
-  String get conversationTimeoutDesc =>
-      'ಸಂವಾದವನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಕೊನೆಗೊಳಿಸುವ ಮೊದಲು ಸಂಭಾಷಣೆಯಲ್ಲಿ ಎಷ್ಟು ಸಮಯ ಕಾಯಬೇಕೆಂದು ಆರಿಸಿ:';
+  String get conversationTimeoutDesc => 'ಸಂವಾದವನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಕೊನೆಗೊಳಿಸುವ ಮೊದಲು ಸಂಭಾಷಣೆಯಲ್ಲಿ ಎಷ್ಟು ಸಮಯ ಕಾಯಬೇಕೆಂದು ಆರಿಸಿ:';
 
   @override
   String get timeout2Minutes => '2 ನಿಮಿಷ';
@@ -1277,8 +1255,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get languageForTranscription => 'ಗಾಢ ಟ್ರಾನ್ಸ್ಕ್ರಿಪ್ಷನ್ ಮತ್ತು ವ್ಯಕ್ತಿಗತ ಅನುಭವಕ್ಕಾಗಿ ನಿಮ್ಮ ಭಾಷೆ ಹೊಂದಿಸಿ.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'ಸಿಂಗಲ್ ಲ್ಯಾಂಗ್ವೇಜ್ ಮೋಡ್ ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ. ಹೆಚ್ಚಿನ ನಿಖುರತೆಗಾಗಿ ಅನುವಾದ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ.';
+  String get singleLanguageModeInfo => 'ಸಿಂಗಲ್ ಲ್ಯಾಂಗ್ವೇಜ್ ಮೋಡ್ ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ. ಹೆಚ್ಚಿನ ನಿಖುರತೆಗಾಗಿ ಅನುವಾದ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ.';
 
   @override
   String get searchLanguageHint => 'ಭಾಷೆಯನ್ನು ಹೆಸರು ಅಥವಾ ಕೋಡಿನಿಂದ ಹುಡುಕಿ';
@@ -1358,8 +1335,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get defaultRepository => 'ಡಿಫಾಲ್ಟ ರಿಪಾಜಿಟರಿ';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'ಸಮಸ್ಯೆಗಳನ್ನು ರಚಿಸುವ ಸಮಯ ಡಿಫಾಲ್ಟ ರಿಪಾಜಿಟರಿ ಆರಿಸಿ. ಸಮಸ್ಯೆಗಳನ್ನು ರಚಿಸುವಾಗ ನೀವು ಇನ್ನೂ ವಿಭಿನ್ನ ರಿಪಾಜಿಟರಿ ನಿರ್ದಿಷ್ಟಪಡಿಸಬಹುದು.';
+  String get selectDefaultRepoDesc => 'ಸಮಸ್ಯೆಗಳನ್ನು ರಚಿಸುವ ಸಮಯ ಡಿಫಾಲ್ಟ ರಿಪಾಜಿಟರಿ ಆರಿಸಿ. ಸಮಸ್ಯೆಗಳನ್ನು ರಚಿಸುವಾಗ ನೀವು ಇನ್ನೂ ವಿಭಿನ್ನ ರಿಪಾಜಿಟರಿ ನಿರ್ದಿಷ್ಟಪಡಿಸಬಹುದು.';
 
   @override
   String get noReposFound => 'ಯಾವುದೇ ರಿಪಾಜಿಟರಿ ಕಂಡುಬಂದಿಲ್ಲ';
@@ -1406,8 +1382,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get configureSettings => 'ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಕಾನ್ಫಿಗರ್ ಮಾಡಿ';
 
   @override
-  String get completeAuthBrowser =>
-      'ದಯವಿಟ್ಟು ನಿಮ್ಮ ಬ್ರೌಜರ್‌ನಲ್ಲಿ ಪ್ರಮಾಣೀಕರಣ ಪೂರ್ಣ ಮಾಡಿ. ಪೂರ್ಣವಾದ ನಂತರ, ಅ್ಯಪ್‌ಗೆ ಹಿಂತಿರುಗಿ.';
+  String get completeAuthBrowser => 'ದಯವಿಟ್ಟು ನಿಮ್ಮ ಬ್ರೌಜರ್‌ನಲ್ಲಿ ಪ್ರಮಾಣೀಕರಣ ಪೂರ್ಣ ಮಾಡಿ. ಪೂರ್ಣವಾದ ನಂತರ, ಅ್ಯಪ್‌ಗೆ ಹಿಂತಿರುಗಿ.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1735,8 +1710,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth ಸಕ್ರಿಯಗೊಳಿಸಿ';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi ನಿಮ್ಮ ವಿಯರೇಬಲ್‌ನೊಂದಿಗೆ ಸಂಪರ್ಕ ಮಾಡಲು Bluetooth ಅಗತ್ಯವಿದೆ. ದಯವಿಟ್ಟು Bluetooth ಸಕ್ರಿಯಗೊಳಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get bluetoothNeeded => 'Omi ನಿಮ್ಮ ವಿಯರೇಬಲ್‌ನೊಂದಿಗೆ ಸಂಪರ್ಕ ಮಾಡಲು Bluetooth ಅಗತ್ಯವಿದೆ. ದಯವಿಟ್ಟು Bluetooth ಸಕ್ರಿಯಗೊಳಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
   String get contactSupport => 'ಸಹಾಯಕ ಸಂಪರ್ಕ ಮಾಡಿ?';
@@ -1769,26 +1743,22 @@ class AppLocalizationsKn extends AppLocalizations {
   String get locationServiceDisabled => 'ಸ್ಥಾನ ಸೇವೆ ನಿಷ್ಕ್ರಿಯ';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'ಸ್ಥಾನ ಸೇವೆ ನಿಷ್ಕ್ರಿಯ. ದಯವಿಟ್ಟು ಸೆಟ್ಟಿಂಗ್‌ಗಳು > ಗೌಪ್ಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಸ್ಥಾನ ಸೇವೆಗಳು ಗಿಕೆ ಮತ್ತು ಸಕ್ರಿಯಗೊಳಿಸಿ';
+  String get locationServiceDisabledDesc => 'ಸ್ಥಾನ ಸೇವೆ ನಿಷ್ಕ್ರಿಯ. ದಯವಿಟ್ಟು ಸೆಟ್ಟಿಂಗ್‌ಗಳು > ಗೌಪ್ಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಸ್ಥಾನ ಸೇವೆಗಳು ಗಿಕೆ ಮತ್ತು ಸಕ್ರಿಯಗೊಳಿಸಿ';
 
   @override
   String get backgroundLocationDenied => 'ಹಿನ್ನಿಲೆ ಸ್ಥಾನ ಪ್ರವೇಶ ನಿರಾಕರಿಸಲಾಗಿದೆ';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'ದಯವಿಟ್ಟು ಸಾಧನ ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಗೆ ಹೋಗಿ ಮತ್ತು ಸ್ಥಾನ ಅನುಮತಿ \"ಯಾವಾಗಲೂ ಅನುಮತಿ\" ಗೆ ಹೊಂದಿಸಿ';
+  String get backgroundLocationDeniedDesc => 'ದಯವಿಟ್ಟು ಸಾಧನ ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಗೆ ಹೋಗಿ ಮತ್ತು ಸ್ಥಾನ ಅನುಮತಿ \"ಯಾವಾಗಲೂ ಅನುಮತಿ\" ಗೆ ಹೊಂದಿಸಿ';
 
   @override
   String get lovingOmi => 'Omi ಪಸಂದ ಮಾಡುತ್ತಿದ್ದೀರೆ?';
 
   @override
-  String get leaveReviewIos =>
-      'App Store ನಲ್ಲಿ ವಿಮರ್ಶೆ ಬಿಡುವುದರ ಮೂಲಕ ನಮಗೆ ಹೆಚ್ಚಿನ ಜನರ ಬಳಿ ತಲುಪಲು ಸಾಹಾಯ್ಯ ಮಾಡಿ. ನಿಮ್ಮ ಪ್ರತಿಕ್ರಿಯೆ ನಮಗೆ ಬೇಸರ ಬರುತ್ತದೆ!';
+  String get leaveReviewIos => 'App Store ನಲ್ಲಿ ವಿಮರ್ಶೆ ಬಿಡುವುದರ ಮೂಲಕ ನಮಗೆ ಹೆಚ್ಚಿನ ಜನರ ಬಳಿ ತಲುಪಲು ಸಾಹಾಯ್ಯ ಮಾಡಿ. ನಿಮ್ಮ ಪ್ರತಿಕ್ರಿಯೆ ನಮಗೆ ಬೇಸರ ಬರುತ್ತದೆ!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Google Play Store ನಲ್ಲಿ ವಿಮರ್ಶೆ ಬಿಡುವುದರ ಮೂಲಕ ನಮಗೆ ಹೆಚ್ಚಿನ ಜನರ ಬಳಿ ತಲುಪಲು ಸಾಹಾಯ್ಯ ಮಾಡಿ. ನಿಮ್ಮ ಪ್ರತಿಕ್ರಿಯೆ ನಮಗೆ ಬೇಸರ ಬರುತ್ತದೆ!';
+  String get leaveReviewAndroid => 'Google Play Store ನಲ್ಲಿ ವಿಮರ್ಶೆ ಬಿಡುವುದರ ಮೂಲಕ ನಮಗೆ ಹೆಚ್ಚಿನ ಜನರ ಬಳಿ ತಲುಪಲು ಸಾಹಾಯ್ಯ ಮಾಡಿ. ನಿಮ್ಮ ಪ್ರತಿಕ್ರಿಯೆ ನಮಗೆ ಬೇಸರ ಬರುತ್ತದೆ!';
 
   @override
   String get rateOnAppStore => 'App Store ನಲ್ಲಿ ರೇಟ್ ಮಾಡಿ';
@@ -1800,8 +1770,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get maybeLater => 'ಬಹುಶಃ ನಂತರ';
 
   @override
-  String get speechProfileIntro =>
-      'Omi ನಿಮ್ಮ ಗುರಿಗಳು ಮತ್ತು ನಿಮ್ಮ ಧ್ವನಿ ಕಲಿಯಬೇಕು. ನೀವು ಅದನ್ನು ನಂತರ ಮಾರ್ಪಡಿಸಲು ಸಾಧ್ಯ ಆಗುತ್ತದೆ.';
+  String get speechProfileIntro => 'Omi ನಿಮ್ಮ ಗುರಿಗಳು ಮತ್ತು ನಿಮ್ಮ ಧ್ವನಿ ಕಲಿಯಬೇಕು. ನೀವು ಅದನ್ನು ನಂತರ ಮಾರ್ಪಡಿಸಲು ಸಾಧ್ಯ ಆಗುತ್ತದೆ.';
 
   @override
   String get getStarted => 'ಪ್ರಾರಂಭ ಮಾಡಿ';
@@ -1822,29 +1791,25 @@ class AppLocalizationsKn extends AppLocalizations {
   String get connectionError => 'ಸಂಪರ್ಕ ದೋಷ';
 
   @override
-  String get connectionErrorDesc =>
-      'ಸರ್ವರಿಗೆ ಸಂಪರ್ಕ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ. ದಯವಿಟ್ಟು ನಿಮ್ಮ ಇಂಟರನೆಟ್ ಸಂಪರ್ಕ ಪರಿಶೀಲಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get connectionErrorDesc => 'ಸರ್ವರಿಗೆ ಸಂಪರ್ಕ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ. ದಯವಿಟ್ಟು ನಿಮ್ಮ ಇಂಟರನೆಟ್ ಸಂಪರ್ಕ ಪರಿಶೀಲಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'ಅಮಾನ್ಯ ರೆಕಾರ್ಡಿಂಗ್ ಸನ್ನಿವೇಶಿತ';
 
   @override
-  String get multipleSpeakersDesc =>
-      'ರೆಕಾರ್ಡಿಂಗ್‌ನಲ್ಲಿ ಅನೇಕ ಸ್ಪೀಕರ್‌ಗಳಿರುವಂತೆ ತೋರುತ್ತದೆ. ದಯವಿಟ್ಟು ನೀವು ಶಾಂತ ಸ್ಥಳದಲ್ಲಿ ಇರುವಿರಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get multipleSpeakersDesc => 'ರೆಕಾರ್ಡಿಂಗ್‌ನಲ್ಲಿ ಅನೇಕ ಸ್ಪೀಕರ್‌ಗಳಿರುವಂತೆ ತೋರುತ್ತದೆ. ದಯವಿಟ್ಟು ನೀವು ಶಾಂತ ಸ್ಥಳದಲ್ಲಿ ಇರುವಿರಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
   String get tooShortDesc => 'ಸಾಕಷ್ಟು ಭಾಷಣ ಕಂಡುಬಂದಿಲ್ಲ. ದಯವಿಟ್ಟು ಹೆಚ್ಚು ಮಾತನಾಡಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
-  String get invalidRecordingDesc =>
-      'ದಯವಿಟ್ಟು ನೀವು ಕನಿಷ್ಠ 5 ಸೆಕೆಂಡುಗಳಿಗೆ ಮತ್ತು 90 ಸೆಕೆಂಡುಗಳಿಗಿಂತ ಹೆಚ್ಚೆ ಮಾತನಾಡೆಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.';
+  String get invalidRecordingDesc => 'ದಯವಿಟ್ಟು ನೀವು ಕನಿಷ್ಠ 5 ಸೆಕೆಂಡುಗಳಿಗೆ ಮತ್ತು 90 ಸೆಕೆಂಡುಗಳಿಗಿಂತ ಹೆಚ್ಚೆ ಮಾತನಾಡೆಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.';
 
   @override
   String get areYouThere => 'ನೀವು ಇರುವಿರಾ?';
 
   @override
-  String get noSpeechDesc =>
-      'ನಾವು ಯಾವುದೇ ಭಾಷಣ ಕಂಡುಹಿಡಿಯಲು ಸಾಧ್ಯ ಆಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ನೀವು ಕನಿಷ್ಠ 10 ಸೆಕೆಂಡುಗಳಿಗೆ ಮತ್ತು 3 ನಿಮಿಷಗಳಿಗಿಂತ ಹೆಚ್ಚೆ ಮಾತನಾಡೆಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.';
+  String get noSpeechDesc => 'ನಾವು ಯಾವುದೇ ಭಾಷಣ ಕಂಡುಹಿಡಿಯಲು ಸಾಧ್ಯ ಆಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ನೀವು ಕನಿಷ್ಠ 10 ಸೆಕೆಂಡುಗಳಿಗೆ ಮತ್ತು 3 ನಿಮಿಷಗಳಿಗಿಂತ ಹೆಚ್ಚೆ ಮಾತನಾಡೆಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.';
 
   @override
   String get connectionLost => 'ಸಂಪರ್ಕ ಕಳೆದುಹೋಯಿತು';
@@ -1865,8 +1830,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get permissionsRequired => 'ಅನುಮತಿ ಅಗತ್ಯ';
 
   @override
-  String get permissionsRequiredDesc =>
-      'ಈ ಅ್ಯಪ್ ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡಲು Bluetooth ಮತ್ತು ಸ್ಥಾನ ಅನುಮತಿಯ ಅಗತ್ಯವಿದೆ. ದಯವಿಟ್ಟು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಅವುಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ.';
+  String get permissionsRequiredDesc => 'ಈ ಅ್ಯಪ್ ಸರಿಯಾಗಿ ಕೆಲಸ ಮಾಡಲು Bluetooth ಮತ್ತು ಸ್ಥಾನ ಅನುಮತಿಯ ಅಗತ್ಯವಿದೆ. ದಯವಿಟ್ಟು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಅವುಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ.';
 
   @override
   String get openSettings => 'ಸೆಟ್ಟಿಂಗ್‌ಗಳು ತೆರೆಯಿರಿ';
@@ -1896,8 +1860,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – ನಿಮ್ಮ AI ಸಹಾಯಕ';
 
   @override
-  String get captureEveryMoment =>
-      'ಪ್ರತಿಯೊಂದು ಕ್ಷಣವನ್ನು ಹಿಡಿಯಿರಿ. AI-ನ ಚಾಲಿತ\nಸಾರಾಂಶಗಳನ್ನು ಪಡೆಯಿರಿ. ಪುನಃ ಗಮನಾರ್ಹತೆಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳಬೇಡಿ.';
+  String get captureEveryMoment => 'ಪ್ರತಿಯೊಂದು ಕ್ಷಣವನ್ನು ಹಿಡಿಯಿರಿ. AI-ನ ಚಾಲಿತ\nಸಾರಾಂಶಗಳನ್ನು ಪಡೆಯಿರಿ. ಪುನಃ ಗಮನಾರ್ಹತೆಗಳನ್ನು ತೆಗೆದುಕೊಳ್ಳಬೇಡಿ.';
 
   @override
   String get appleWatchSetup => 'Apple Watch ಸೆಟಪ್';
@@ -1909,12 +1872,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get microphonePermission => 'ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ';
 
   @override
-  String get permissionGrantedNow =>
-      'ಅನುಮತಿ ನೀಡಲಾಗಿದೆ! ಈಗ:\n\nನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ Omi ಅ್ಯಪ್ ತೆರೆಯಿರಿ ಮತ್ತು ಕೆಳಗೆ \"ಮುಂದುವರಿಸಿ\" ಹೊಡೆಯಿರಿ';
+  String get permissionGrantedNow => 'ಅನುಮತಿ ನೀಡಲಾಗಿದೆ! ಈಗ:\n\nನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ Omi ಅ್ಯಪ್ ತೆರೆಯಿರಿ ಮತ್ತು ಕೆಳಗೆ \"ಮುಂದುವರಿಸಿ\" ಹೊಡೆಯಿರಿ';
 
   @override
-  String get needMicrophonePermission =>
-      'ನಮಗೆ ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿಯ ಅಗತ್ಯವಿದೆ.\n\n1. \"ಅನುಮತಿ ನೀಡಿ\" ಹೊಡೆಯಿರಿ\n2. ನಿಮ್ಮ iPhone ನಲ್ಲಿ ಅನುಮತಿ ನೀಡಿ\n3. ವಾಚ್ ಅ್ಯಪ್ ಮುಚ್ಚುತ್ತದೆ\n4. ಪುನರಾವರ್ತಿತ ತೆರೆಯಿರಿ ಮತ್ತು \"ಮುಂದುವರಿಸಿ\" ಹೊಡೆಯಿರಿ';
+  String get needMicrophonePermission => 'ನಮಗೆ ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿಯ ಅಗತ್ಯವಿದೆ.\n\n1. \"ಅನುಮತಿ ನೀಡಿ\" ಹೊಡೆಯಿರಿ\n2. ನಿಮ್ಮ iPhone ನಲ್ಲಿ ಅನುಮತಿ ನೀಡಿ\n3. ವಾಚ್ ಅ್ಯಪ್ ಮುಚ್ಚುತ್ತದೆ\n4. ಪುನರಾವರ್ತಿತ ತೆರೆಯಿರಿ ಮತ್ತು \"ಮುಂದುವರಿಸಿ\" ಹೊಡೆಯಿರಿ';
 
   @override
   String get grantPermissionButton => 'ಅನುಮತಿ ನೀಡಿ';
@@ -1923,15 +1884,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get needHelp => 'ಸಹಾಯ ಅಗತ್ಯ?';
 
   @override
-  String get troubleshootingSteps =>
-      'ತೊಂದರೆ ನಿವಾರಣೆ:\n\n1. Omi ನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ ಸ್ಥಾಪಿತವಾಗಿದೆ ಖಚಿತ ಮಾಡಿ\n2. ನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ Omi ಅ್ಯಪ್ ತೆರೆಯಿರಿ\n3. ಅನುಮತಿ ಪಾಪ್‌ಅಪ್ ಹುಡುಕಿ\n4. ಪ್ರಸ್ತಾವನೆ ಮಾಡಿದಾಗ \"ಅನುಮತಿ\" ಹೊಡೆಯಿರಿ\n5. ನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ ಅ್ಯಪ್ ಮುಚ್ಚುತ್ತದೆ - ಪುನರಾವರ್ತಿತ ತೆರೆಯಿರಿ\n6. ನಿಮ್ಮ iPhone ನಲ್ಲಿ ಹಿಂತಿರುಗಬಂದು \"ಮುಂದುವರಿಸಿ\" ಹೊಡೆಯಿರಿ';
+  String get troubleshootingSteps => 'ತೊಂದರೆ ನಿವಾರಣೆ:\n\n1. Omi ನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ ಸ್ಥಾಪಿತವಾಗಿದೆ ಖಚಿತ ಮಾಡಿ\n2. ನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ Omi ಅ್ಯಪ್ ತೆರೆಯಿರಿ\n3. ಅನುಮತಿ ಪಾಪ್‌ಅಪ್ ಹುಡುಕಿ\n4. ಪ್ರಸ್ತಾವನೆ ಮಾಡಿದಾಗ \"ಅನುಮತಿ\" ಹೊಡೆಯಿರಿ\n5. ನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ ಅ್ಯಪ್ ಮುಚ್ಚುತ್ತದೆ - ಪುನರಾವರ್ತಿತ ತೆರೆಯಿರಿ\n6. ನಿಮ್ಮ iPhone ನಲ್ಲಿ ಹಿಂತಿರುಗಬಂದು \"ಮುಂದುವರಿಸಿ\" ಹೊಡೆಯಿರಿ';
 
   @override
   String get recordingStartedSuccessfully => 'ರೆಕಾರ್ಡಿಂಗ್ ಯಶಸ್ವಿಯಾಗಿ ಪ್ರಾರಂಭವಾಗಿದೆ!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'ಅನುಮತಿ ಇನ್ನೂ ನೀಡಲಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ನೀವು ಮೈಕ್ರೋಫೋನ್ ಪ್ರವೇಶ ಅನುಮತಿ ನೀಡಿದ್ದೀರಿ ಮತ್ತು ನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ ಅ್ಯಪ್ ಪುನರಾವರ್ತಿತ ತೆರೆದ್ದೀರಿ ಖಚಿತ ಮಾಡಿ.';
+  String get permissionNotGrantedYet => 'ಅನುಮತಿ ಇನ್ನೂ ನೀಡಲಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ನೀವು ಮೈಕ್ರೋಫೋನ್ ಪ್ರವೇಶ ಅನುಮತಿ ನೀಡಿದ್ದೀರಿ ಮತ್ತು ನಿಮ್ಮ ವಾಚ್‌ನಲ್ಲಿ ಅ್ಯಪ್ ಪುನರಾವರ್ತಿತ ತೆರೆದ್ದೀರಿ ಖಚಿತ ಮಾಡಿ.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1956,8 +1915,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get selectYourLanguage => 'ನಿಮ್ಮ ಭಾಷೆ ಆರಿಸಿ';
 
   @override
-  String get personalGrowthJourney =>
-      'ನಿಮ್ಮ ವ್ಯಕ್ತಿಗತ ಬೆಳವಣಿಗೆ AI ಯೊಂದಿಗೆ ಯಾತ್ರೆ ಇದು ನಿಮ್ಮ ಪ್ರತಿಯೊಂದು ಪದವನ್ನು ಕೇಳುತ್ತದೆ.';
+  String get personalGrowthJourney => 'ನಿಮ್ಮ ವ್ಯಕ್ತಿಗತ ಬೆಳವಣಿಗೆ AI ಯೊಂದಿಗೆ ಯಾತ್ರೆ ಇದು ನಿಮ್ಮ ಪ್ರತಿಯೊಂದು ಪದವನ್ನು ಕೇಳುತ್ತದೆ.';
 
   @override
   String get actionItemsTitle => 'To-Do\'s';
@@ -2029,8 +1987,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get welcomeActionItemsTitle => 'ಕ್ರಿಯಾ ಐಟಂಗಳಿಗೆ ಸಿದ್ಧ';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'ನಿಮ್ಮ AI ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನಿಮ್ಮ ಸಂವಾದಗಳಿಂದ ಕಾರ್ಯಗಳು ಮತ್ತು to-do\'s ಹೊರತೆಗೆಯುತ್ತದೆ. ರಚಿಸಲಾದ ಸಮಯ ಇಲ್ಲಿ ಕಾಣಿಸುತ್ತವೆ.';
+  String get welcomeActionItemsDescription => 'ನಿಮ್ಮ AI ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನಿಮ್ಮ ಸಂವಾದಗಳಿಂದ ಕಾರ್ಯಗಳು ಮತ್ತು to-do\'s ಹೊರತೆಗೆಯುತ್ತದೆ. ರಚಿಸಲಾದ ಸಮಯ ಇಲ್ಲಿ ಕಾಣಿಸುತ್ತವೆ.';
 
   @override
   String get autoExtractionFeature => 'ಸಂವಾದಗಳಿಂದ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊರತೆಗೆಯಲಾಗಿದೆ';
@@ -2226,15 +2183,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'ಭಾಷಣ ಮತ್ತು ಟ್ರಾನ್ಸ್ಕ್ರಿಪ್ಷನ್';
 
   @override
-  String get languageSettingsHelperText =>
-      'ಅ್ಯಪ್ ಭಾಷೆ ಮೆನುಗಳು ಮತ್ತು ಬಟನ್‌ಗಳನ್ನು ಬದಲಾಯಿಸುತ್ತದೆ. ಭಾಷಣ ಭಾಷೆ ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಹೇಗೆ ಟ್ರಾನ್ಸ್ಕ್ರೈಬ್ ಮಾಡಲಾಗುತ್ತದೆ ಪರಿಣಾಮ ಬೀರುತ್ತದೆ.';
+  String get languageSettingsHelperText => 'ಅ್ಯಪ್ ಭಾಷೆ ಮೆನುಗಳು ಮತ್ತು ಬಟನ್‌ಗಳನ್ನು ಬದಲಾಯಿಸುತ್ತದೆ. ಭಾಷಣ ಭಾಷೆ ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಹೇಗೆ ಟ್ರಾನ್ಸ್ಕ್ರೈಬ್ ಮಾಡಲಾಗುತ್ತದೆ ಪರಿಣಾಮ ಬೀರುತ್ತದೆ.';
 
   @override
   String get translationNotice => 'ಅನುವಾದ ಸೂಚನೆ';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi ನಿಮ್ಮ ಮುಖ್ಯ ಭಾಷೆಗೆ ಸಂವಾದಗಳನ್ನು ಅನುವಾದಿಸುತ್ತದೆ. ಸೆಟ್ಟಿಂಗ್‌ಗಳು → ಪ್ರೊಫೈಲ್‌ಗಳಲ್ಲಿ ಯಾವಾಗಲೂ ನವೀಕರಣ ಮಾಡಿ.';
+  String get translationNoticeMessage => 'Omi ನಿಮ್ಮ ಮುಖ್ಯ ಭಾಷೆಗೆ ಸಂವಾದಗಳನ್ನು ಅನುವಾದಿಸುತ್ತದೆ. ಸೆಟ್ಟಿಂಗ್‌ಗಳು → ಪ್ರೊಫೈಲ್‌ಗಳಲ್ಲಿ ಯಾವಾಗಲೂ ನವೀಕರಣ ಮಾಡಿ.';
 
   @override
   String get pleaseCheckInternetConnection => 'ದಯವಿಟ್ಟು ನಿಮ್ಮ ಇಂಟರನೆಟ್ ಸಂಪರ್ಕ ಪರಿಶೀಲಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ';
@@ -2396,8 +2351,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'ಯಂತ್ರ ಅನ್ನೋ ಮಾಡಿ';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'ಇದು ಯಂತ್ರವನ್ನು ಅನ್ನೋ ಮಾಡುತ್ತದೆ ಇದರಿಂದ ಅದನ್ನು ಇತರ ಫೋನ್‌ಗೆ ಸಂಪರ್ಕ ಮಾಡಬಹುದು. ಪ್ರಕ್ರಿಯೆ ಪೂರ್ಣ ಮಾಡಲು ನೀವು ಸೆಟಿಂಗ್‌ಗಳು > ಬ್ಲೂಟೂತ್‌ಗೆ ಹೋಗಿ ಯಂತ್ರವನ್ನು ಮರೆಯಬೇಕು.';
+  String get unpairDeviceDialogMessage => 'ಇದು ಯಂತ್ರವನ್ನು ಅನ್ನೋ ಮಾಡುತ್ತದೆ ಇದರಿಂದ ಅದನ್ನು ಇತರ ಫೋನ್‌ಗೆ ಸಂಪರ್ಕ ಮಾಡಬಹುದು. ಪ್ರಕ್ರಿಯೆ ಪೂರ್ಣ ಮಾಡಲು ನೀವು ಸೆಟಿಂಗ್‌ಗಳು > ಬ್ಲೂಟೂತ್‌ಗೆ ಹೋಗಿ ಯಂತ್ರವನ್ನು ಮರೆಯಬೇಕು.';
 
   @override
   String get unpair => 'ಅನ್ನೋ ಮಾಡಿ';
@@ -2578,8 +2532,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get youreAllSet => 'ನೀವು ಸಿದ್ಧರಿದ್ದೀರಿ!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Omi ಗೆ ಸ್ವಾಗತ! ನಿಮ್ಮ AI ಸಹಚರ ಸಂವಾದಗಳು, ಕಾರ್ಯಗಳು ಮತ್ತು ಇನ್ನಷ್ಟು ನೆರವೇರಿಸಲು ಸಿದ್ಧವಾಗಿದೆ.';
+  String get welcomeToOmiDescription => 'Omi ಗೆ ಸ್ವಾಗತ! ನಿಮ್ಮ AI ಸಹಚರ ಸಂವಾದಗಳು, ಕಾರ್ಯಗಳು ಮತ್ತು ಇನ್ನಷ್ಟು ನೆರವೇರಿಸಲು ಸಿದ್ಧವಾಗಿದೆ.';
 
   @override
   String get startUsingOmi => 'Omi ಬಳಸಲು ಪ್ರಾರಂಭಿಸಿ';
@@ -2658,8 +2611,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get reviewAndManageConversations => 'ನಿಮ್ಮ ಕ್ಯಾಪ್ಚರ್ ಮಾಡಿದ ಸಂವಾದಗಳನ್ನು ಪರಿಶೀಲಿಸಿ ಮತ್ತು ನಿರ್ವಹಿಸಿ';
 
   @override
-  String get startCapturingConversations =>
-      'ಇಲ್ಲಿ ನೋಡಲು ನಿಮ್ಮ Omi ಯಂತ್ರದೊಂದಿಗೆ ಸಂವಾದಗಳನ್ನು ಕ್ಯಾಪ್ಚರ್ ಮಾಡಲು ಪ್ರಾರಂಭಿಸಿ.';
+  String get startCapturingConversations => 'ಇಲ್ಲಿ ನೋಡಲು ನಿಮ್ಮ Omi ಯಂತ್ರದೊಂದಿಗೆ ಸಂವಾದಗಳನ್ನು ಕ್ಯಾಪ್ಚರ್ ಮಾಡಲು ಪ್ರಾರಂಭಿಸಿ.';
 
   @override
   String get useMobileAppToCapture => 'ಆಡಿಯೋ ಕ್ಯಾಪ್ಚರ್ ಮಾಡಲು ನಿಮ್ಮ ಮೊಬೈಲ್ ಅ್ಯಾಪ್ ಬಳಸಿ';
@@ -2674,8 +2626,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get showAll => 'ಸಮಸ್ತ ತೋರಿಸಿ';
 
   @override
-  String get noTasksForToday =>
-      'ಇಂದು ಯಾವ ಕಾರ್ಯಗಳೂ ಇಲ್ಲ.\nOmi ನನ್ನ ಮತ್ತಷ್ಟು ಕಾರ್ಯಗಳ ಬಗ್ಗೆ ಕೇಳಿ ಅಥವಾ ಹಸ್ತಚಾಲಿತವಾಗಿ ರಚಿಸಿ.';
+  String get noTasksForToday => 'ಇಂದು ಯಾವ ಕಾರ್ಯಗಳೂ ಇಲ್ಲ.\nOmi ನನ್ನ ಮತ್ತಷ್ಟು ಕಾರ್ಯಗಳ ಬಗ್ಗೆ ಕೇಳಿ ಅಥವಾ ಹಸ್ತಚಾಲಿತವಾಗಿ ರಚಿಸಿ.';
 
   @override
   String get dailyScore => 'ದೈನಿಕ ಸ್ಕೋರ್';
@@ -2717,8 +2668,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get noTasksYet => 'ಇನ್ನೂ ಯಾವ ಕಾರ್ಯಗಳೂ ಇಲ್ಲ';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'ನಿಮ್ಮ ಸಂವಾದಗಳಿಂದ ಕಾರ್ಯಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಬೇಕು.\nಹಸ್ತಚಾಲಿತವಾಗಿ ಸೇರಿಸಲು ರಚಿಸುವುದನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ.';
+  String get tasksFromConversationsWillAppear => 'ನಿಮ್ಮ ಸಂವಾದಗಳಿಂದ ಕಾರ್ಯಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಬೇಕು.\nಹಸ್ತಚಾಲಿತವಾಗಿ ಸೇರಿಸಲು ರಚಿಸುವುದನ್ನು ಕ್ಲಿಕ್ ಮಾಡಿ.';
 
   @override
   String get monthJan => 'ಜನ';
@@ -2850,8 +2800,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get chatPrompt => 'ಚ್ಯಾಟ್ ಪ್ರಾಂಪ್ಟ್';
 
   @override
-  String get chatPromptPlaceholder =>
-      'ನೀವು ಅದ್ಭುತ ಅ್ಯಾಪ್, ನಿಮ್ಮ ಕೆಲಸವು ಬಳಕೆದಾರರ ಪ್ರಶ್ನೆಗಳಿಗೆ ಪ್ರತಿಕ್ರಿಯಿಸುವುದು ಮತ್ತು ಅವರನ್ನು ಸಂತೋಷಿಸುವುದು...';
+  String get chatPromptPlaceholder => 'ನೀವು ಅದ್ಭುತ ಅ್ಯಾಪ್, ನಿಮ್ಮ ಕೆಲಸವು ಬಳಕೆದಾರರ ಪ್ರಶ್ನೆಗಳಿಗೆ ಪ್ರತಿಕ್ರಿಯಿಸುವುದು ಮತ್ತು ಅವರನ್ನು ಸಂತೋಷಿಸುವುದು...';
 
   @override
   String get conversationPrompt => 'ಸಂವಾದ ಪ್ರಾಂಪ್ಟ್';
@@ -2869,8 +2818,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get makeMyAppPublic => 'ನನ್ನ ಅ್ಯಾಪ್ ಸಾರ್ವಜನಿಕ ಮಾಡಿ';
 
   @override
-  String get submitAppTermsAgreement =>
-      'ಈ ಅ್ಯಾಪ್ ಸಲ್ಲಿಕೆ ಮಾಡುವ ಮೂಲಕ, ನಾನು Omi AI ಸೇವೆಯ ನಿಯಮಗಳು ಮತ್ತು ಗೌಪ್ಯತೆ ನೀತಿಗೆ ಸಮ್ಮತಿ ಜಾಹೀರು ಮಾಡುತ್ತೇನೆ';
+  String get submitAppTermsAgreement => 'ಈ ಅ್ಯಾಪ್ ಸಲ್ಲಿಕೆ ಮಾಡುವ ಮೂಲಕ, ನಾನು Omi AI ಸೇವೆಯ ನಿಯಮಗಳು ಮತ್ತು ಗೌಪ್ಯತೆ ನೀತಿಗೆ ಸಮ್ಮತಿ ಜಾಹೀರು ಮಾಡುತ್ತೇನೆ';
 
   @override
   String get submitApp => 'ಅ್ಯಾಪ್ ಸಲ್ಲಿಕೆ ಮಾಡಿ';
@@ -2885,12 +2833,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get submitAppQuestion => 'ಅ್ಯಾಪ್ ಸಲ್ಲಿಕೆ ಮಾಡುವುದೇ?';
 
   @override
-  String get submitAppPublicDescription =>
-      'ನಿಮ್ಮ ಅ್ಯಾಪ್ ಪರಿಶೀಲಿತವಾಗುತ್ತದೆ ಮತ್ತು ಸಾರ್ವಜನಿಕ ಮಾಡಲಾಗುತ್ತದೆ. ಪರಿಶೀಲನೆಯ ಸಮಯದಲ್ಲಿಯೂ ಕೂಡ ನೀವು ಅದನ್ನು ತಕ್ಷಣ ಬಳಸಲು ಪ್ರಾರಂಭಿಸಬಹುದು!';
+  String get submitAppPublicDescription => 'ನಿಮ್ಮ ಅ್ಯಾಪ್ ಪರಿಶೀಲಿತವಾಗುತ್ತದೆ ಮತ್ತು ಸಾರ್ವಜನಿಕ ಮಾಡಲಾಗುತ್ತದೆ. ಪರಿಶೀಲನೆಯ ಸಮಯದಲ್ಲಿಯೂ ಕೂಡ ನೀವು ಅದನ್ನು ತಕ್ಷಣ ಬಳಸಲು ಪ್ರಾರಂಭಿಸಬಹುದು!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'ನಿಮ್ಮ ಅ್ಯಾಪ್ ಪರಿಶೀಲಿತವಾಗುತ್ತದೆ ಮತ್ತು ನಿಮಗೆ ನಿಜಿ ಸಾಧ್ಯತೆ ನೀಡಲಾಗುತ್ತದೆ. ಪರಿಶೀಲನೆಯ ಸಮಯದಲ್ಲಿಯೂ ಕೂಡ ನೀವು ಅದನ್ನು ತಕ್ಷಣ ಬಳಸಲು ಪ್ರಾರಂಭಿಸಬಹುದು!';
+  String get submitAppPrivateDescription => 'ನಿಮ್ಮ ಅ್ಯಾಪ್ ಪರಿಶೀಲಿತವಾಗುತ್ತದೆ ಮತ್ತು ನಿಮಗೆ ನಿಜಿ ಸಾಧ್ಯತೆ ನೀಡಲಾಗುತ್ತದೆ. ಪರಿಶೀಲನೆಯ ಸಮಯದಲ್ಲಿಯೂ ಕೂಡ ನೀವು ಅದನ್ನು ತಕ್ಷಣ ಬಳಸಲು ಪ್ರಾರಂಭಿಸಬಹುದು!';
 
   @override
   String get startEarning => 'ಕಮಾಯಿ ಪ್ರಾರಂಭಿಸಿ! 💰';
@@ -2914,23 +2860,19 @@ class AppLocalizationsKn extends AppLocalizations {
   String get dataAccessNotice => 'ಡೇಟಾ ಪ್ರವೇಶ ಸೂಚನೆ';
 
   @override
-  String get dataAccessWarning =>
-      'ಈ ಅ್ಯಾಪ್ ನಿಮ್ಮ ಡೇಟಾ ಪ್ರವೇಶ ನೀಡುತ್ತದೆ. Omi AI ಈ ಅ್ಯಾಪ್ ನಿಮ್ಮ ಡೇಟಾ ಹೇಗೆ ಬಳಸುತ್ತದೆ, ಮಾರ್ಪಡಿಸುತ್ತದೆ ಅಥವಾ ಅಳಿಸುತ್ತದೆ ಅದರ ಜೊತೆ ಕಾರಣಕ್ತರಣೆ ನೀಡುತ್ತಿಲ್ಲ';
+  String get dataAccessWarning => 'ಈ ಅ್ಯಾಪ್ ನಿಮ್ಮ ಡೇಟಾ ಪ್ರವೇಶ ನೀಡುತ್ತದೆ. Omi AI ಈ ಅ್ಯಾಪ್ ನಿಮ್ಮ ಡೇಟಾ ಹೇಗೆ ಬಳಸುತ್ತದೆ, ಮಾರ್ಪಡಿಸುತ್ತದೆ ಅಥವಾ ಅಳಿಸುತ್ತದೆ ಅದರ ಜೊತೆ ಕಾರಣಕ್ತರಣೆ ನೀಡುತ್ತಿಲ್ಲ';
 
   @override
   String get installApp => 'ಅ್ಯಾಪ್ ಸ್ಥಾಪಿಸಿ';
 
   @override
-  String get betaTesterNotice =>
-      'ನೀವು ಈ ಅ್ಯಾಪ್‌ನ ಬೀಟಾ ಪರೀಕ್ಷಕರು. ಇದು ಇನ್ನೂ ಸಾರ್ವಜನಿಕ ಅಲ್ಲ. ಇದು ಅನುಮೋದನೆ ನಂತರ ಸಾರ್ವಜನಿಕ ಆಗುತ್ತದೆ.';
+  String get betaTesterNotice => 'ನೀವು ಈ ಅ್ಯಾಪ್‌ನ ಬೀಟಾ ಪರೀಕ್ಷಕರು. ಇದು ಇನ್ನೂ ಸಾರ್ವಜನಿಕ ಅಲ್ಲ. ಇದು ಅನುಮೋದನೆ ನಂತರ ಸಾರ್ವಜನಿಕ ಆಗುತ್ತದೆ.';
 
   @override
-  String get appUnderReviewOwner =>
-      'ನಿಮ್ಮ ಅ್ಯಾಪ್ ಪರಿಶೀಲನೆಯ ಅಡಿಯಲ್ಲಿ ಮತ್ತು ಕೇವಲ ನಿಮ್ಮ ಮಾತ್ರ ನೋಡಬಹುದು. ಇದು ಅನುಮೋದನೆ ನಂತರ ಸಾರ್ವಜನಿಕ ಆಗುತ್ತದೆ.';
+  String get appUnderReviewOwner => 'ನಿಮ್ಮ ಅ್ಯಾಪ್ ಪರಿಶೀಲನೆಯ ಅಡಿಯಲ್ಲಿ ಮತ್ತು ಕೇವಲ ನಿಮ್ಮ ಮಾತ್ರ ನೋಡಬಹುದು. ಇದು ಅನುಮೋದನೆ ನಂತರ ಸಾರ್ವಜನಿಕ ಆಗುತ್ತದೆ.';
 
   @override
-  String get appRejectedNotice =>
-      'ನಿಮ್ಮ ಅ್ಯಾಪ್ ನಿರಾಕೃತವಾಗಿದೆ. ದಯವಿಟ್ಟು ಅ್ಯಾಪ್ ವಿವರವಣನೆಗಳನ್ನು ನವೀಕರಿಸಿ ಮತ್ತು ಪರಿಶೀಲನೆಯ ಜೊತೆ ಪುನರ್ಸಲ್ಲಿಕೆ ಮಾಡಿ.';
+  String get appRejectedNotice => 'ನಿಮ್ಮ ಅ್ಯಾಪ್ ನಿರಾಕೃತವಾಗಿದೆ. ದಯವಿಟ್ಟು ಅ್ಯಾಪ್ ವಿವರವಣನೆಗಳನ್ನು ನವೀಕರಿಸಿ ಮತ್ತು ಪರಿಶೀಲನೆಯ ಜೊತೆ ಪುನರ್ಸಲ್ಲಿಕೆ ಮಾಡಿ.';
 
   @override
   String get setupSteps => 'ಸೆಟಿಂಗ್ ಹಂತಗಳು';
@@ -3144,8 +3086,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get microphonePermissionRequired => 'ಕರೆಗಳನ್ನು ಮಾಡಲು ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ ಅಗತ್ಯ';
 
   @override
-  String get microphonePermissionDenied =>
-      'ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಯಿತು. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೆಫರೆನ್ಸ್ > ಗೌಪ್ಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಮೈಕ್ರೋಫೋನ್‌ನಲ್ಲಿ ಅನುಮತಿ ನೀಡಿ.';
+  String get microphonePermissionDenied => 'ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಯಿತು. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೆಫರೆನ್ಸ್ > ಗೌಪ್ಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಮೈಕ್ರೋಫೋನ್‌ನಲ್ಲಿ ಅನುಮತಿ ನೀಡಿ.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3378,8 +3319,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get whatWeCollect => 'ನಾವು ಸಂಗ್ರಹಿಸುವುದು';
 
   @override
-  String get dataCollectionMessage =>
-      'ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನಿಮ್ಮ ಸಂವಾದಗಳು, ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಮತ್ತು ವ್ಯಕ್ತಿಗತ ಮಾಹಿತಿ AI-ಚಾಲಿತ ಒಳನೋಟಗಳನ್ನು ಒದಗಿಸಲು ಮತ್ತು ಎಲ್ಲಾ ಅ್ಯಾಪ್ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ನಮ್ಮ ಸರ್ವರ್‌ಗಳಲ್ಲಿ ಸುರಕ್ಷಿತವಾಗಿ ಸಂಗ್ರಹಿಸಲಾಗುತ್ತದೆ.';
+  String get dataCollectionMessage => 'ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನಿಮ್ಮ ಸಂವಾದಗಳು, ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಮತ್ತು ವ್ಯಕ್ತಿಗತ ಮಾಹಿತಿ AI-ಚಾಲಿತ ಒಳನೋಟಗಳನ್ನು ಒದಗಿಸಲು ಮತ್ತು ಎಲ್ಲಾ ಅ್ಯಾಪ್ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ನಮ್ಮ ಸರ್ವರ್‌ಗಳಲ್ಲಿ ಸುರಕ್ಷಿತವಾಗಿ ಸಂಗ್ರಹಿಸಲಾಗುತ್ತದೆ.';
 
   @override
   String get dataProtection => 'ಡೇಟಾ ಸುರಕ್ಷೆ';
@@ -3394,8 +3334,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get chooseYourLanguage => 'ನಿಮ್ಮ ಭಾಷೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿ';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'ಸಿ Omi ಅನುಭವಕ್ಕೆ ಸಾಮಾನ್ಯವಾಗಿ ನಿಮ್ಮ ಆದ್ಯತೆಯ ಭಾಷೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿ';
+  String get selectPreferredLanguageForBestExperience => 'ಸಿ Omi ಅನುಭವಕ್ಕೆ ಸಾಮಾನ್ಯವಾಗಿ ನಿಮ್ಮ ಆದ್ಯತೆಯ ಭಾಷೆಯನ್ನು ಆಯ್ಕೆ ಮಾಡಿ';
 
   @override
   String get searchLanguages => 'ಭಾಷೆಗಳನ್ನು ಹುಡುಕಿ...';
@@ -3413,8 +3352,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'ಹೆಸರು ಕನಿಷ್ಠ 2 ಅಕ್ಷರ ಹೊಂದಿರಬೇಕು';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'ನಾವು ನಿಮ್ಮನ್ನು ಹೇಗೆ ಸಂಭೋಧಿಸಲು ಬಯಸುತ್ತೀರಿ ಎಂಬುದನ್ನು ನಮಗೆ ತಿಳಿಸಿ. ಇದು ನಿಮ್ಮ Omi ಅನುಭವವನ್ನು ವ್ಯಕ್ತಿಗತವಾಗಿ ಮಾಡಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'ನಾವು ನಿಮ್ಮನ್ನು ಹೇಗೆ ಸಂಭೋಧಿಸಲು ಬಯಸುತ್ತೀರಿ ಎಂಬುದನ್ನು ನಮಗೆ ತಿಳಿಸಿ. ಇದು ನಿಮ್ಮ Omi ಅನುಭವವನ್ನು ವ್ಯಕ್ತಿಗತವಾಗಿ ಮಾಡಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ.';
 
   @override
   String charactersCount(int count) {
@@ -3431,8 +3369,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get recordAudioConversations => 'ಆಡಿಯೋ ಸಂವಾದಗಳನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡಿ';
 
   @override
-  String get microphoneAccessDescription =>
-      'ನಿಮ್ಮ ಸಂವಾದಗಳನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡಲು ಮತ್ತು ಪ್ರತಿಲೇಖನಗಳನ್ನು ಒದಗಿಸಲು Omi ಮೈಕ್ರೋಫೋನ್ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ.';
+  String get microphoneAccessDescription => 'ನಿಮ್ಮ ಸಂವಾದಗಳನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡಲು ಮತ್ತು ಪ್ರತಿಲೇಖನಗಳನ್ನು ಒದಗಿಸಲು Omi ಮೈಕ್ರೋಫೋನ್ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ.';
 
   @override
   String get screenRecording => 'ಸ್ಕ್ರೀನ್ ರೆಕಾರ್ಡಿಂಗ್';
@@ -3441,8 +3378,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'ಸಭೆಗಳಿಂದ ಸಿಸ್ಟಮ್ ಆಡಿಯೋ ಹಿಡಿಯಿರಿ';
 
   @override
-  String get screenRecordingDescription =>
-      'ನಿಮ್ಮ ಬ್ರೌಜರ್-ಆಧಾರಿತ ಸಭೆಗಳಿಂದ ಸಿಸ್ಟಮ್ ಆಡಿಯೋ ಹಿಡಿಯಲು Omi ಸ್ಕ್ರೀನ್ ರೆಕಾರ್ಡಿಂಗ್ ಅನುಮತಿ ಅಗತ್ಯವಿದೆ.';
+  String get screenRecordingDescription => 'ನಿಮ್ಮ ಬ್ರೌಜರ್-ಆಧಾರಿತ ಸಭೆಗಳಿಂದ ಸಿಸ್ಟಮ್ ಆಡಿಯೋ ಹಿಡಿಯಲು Omi ಸ್ಕ್ರೀನ್ ರೆಕಾರ್ಡಿಂಗ್ ಅನುಮತಿ ಅಗತ್ಯವಿದೆ.';
 
   @override
   String get accessibility => 'ಪ್ರವೇಶ್ಯತೆ';
@@ -3451,8 +3387,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'ಬ್ರೌಜರ್-ಆಧಾರಿತ ಸಭೆಗಳನ್ನು ಪತ್ತೆ ಮಾಡಿ';
 
   @override
-  String get accessibilityDescription =>
-      'ನಿಮ್ಮ ಬ್ರೌಜರ್‌ನಲ್ಲಿ Zoom, Meet ಅಥವಾ Teams ಸಭೆಗಳಿಗೆ ಚಾಲನ ಮಾಡುವ ಸಮಯ ಪತ್ತೆ ಮಾಡಲು Omi ಪ್ರವೇಶ್ಯತೆ ಅನುಮತಿ ಅಗತ್ಯವಿದೆ.';
+  String get accessibilityDescription => 'ನಿಮ್ಮ ಬ್ರೌಜರ್‌ನಲ್ಲಿ Zoom, Meet ಅಥವಾ Teams ಸಭೆಗಳಿಗೆ ಚಾಲನ ಮಾಡುವ ಸಮಯ ಪತ್ತೆ ಮಾಡಲು Omi ಪ್ರವೇಶ್ಯತೆ ಅನುಮತಿ ಅಗತ್ಯವಿದೆ.';
 
   @override
   String get pleaseWait => 'ದಯವಿಟ್ಟು ಕಾಯಿರಿ...';
@@ -3521,12 +3456,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get exportAllConversationsToJson => 'ನಿಮ್ಮ ಎಲ್ಲಾ ಸಂವಾದಗಳನ್ನು JSON ಫೈಲ್‌ಗೆ ರಫ್ತು ಮಾಡಿ.';
 
   @override
-  String get conversationsExportStarted =>
-      'ಸಂವಾದಗಳ ರಫ್ತು ಪ್ರಾರಂಭವಾಯಿತು. ಇದು ಕೆಲವೆ ಸೆಕೆಂಡ್ ತೆಗೆದುಕೊಳ್ಳಬಹುದು, ದಯವಿಟ್ಟು ಕಾಯಿರಿ.';
+  String get conversationsExportStarted => 'ಸಂವಾದಗಳ ರಫ್ತು ಪ್ರಾರಂಭವಾಯಿತು. ಇದು ಕೆಲವೆ ಸೆಕೆಂಡ್ ತೆಗೆದುಕೊಳ್ಳಬಹುದು, ದಯವಿಟ್ಟು ಕಾಯಿರಿ.';
 
   @override
-  String get mcpDescription =>
-      'Omi ಅನ್ನು ಇತರ ಅಪ್ಲಿಕೇಶನ್‌ಗಳೊಂದಿಗೆ ಸಂಪರ್ಕಿಸಲು ನಿಮ್ಮ ಆಲೋಚನೆಗಳು ಮತ್ತು ಸಂವಾದಗಳನ್ನು ಓದಲು, ಹುಡುಕಲು ಮತ್ತು ನಿರ್ವಹಿಸಲು. ಪ್ರಾರಂಭಿಸಲು ಒಂದು ಕೀ ರಚಿಸಿ.';
+  String get mcpDescription => 'Omi ಅನ್ನು ಇತರ ಅಪ್ಲಿಕೇಶನ್‌ಗಳೊಂದಿಗೆ ಸಂಪರ್ಕಿಸಲು ನಿಮ್ಮ ಆಲೋಚನೆಗಳು ಮತ್ತು ಸಂವಾದಗಳನ್ನು ಓದಲು, ಹುಡುಕಲು ಮತ್ತು ನಿರ್ವಹಿಸಲು. ಪ್ರಾರಂಭಿಸಲು ಒಂದು ಕೀ ರಚಿಸಿ.';
 
   @override
   String get apiKeys => 'API ಕೀಲಿಗಳು';
@@ -3573,8 +3506,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'ಸ್ವಯಂ-ರಚನೆ ಮತ್ತು ಹೊಸ ವಕ್ತಾರನ್ನು ಟ್ಯಾಗ್ ಮಾಡಿ';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'ಪ್ರತಿಲೇಖನದಲ್ಲಿ ಹೆಸರನ್ನು ಪತ್ತೆ ಮಾಡಿದಾಗ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊಸ ವ್ಯಕ್ತಿಯನ್ನು ರಚಿಸಿ.';
+  String get automaticallyCreateNewPerson => 'ಪ್ರತಿಲೇಖನದಲ್ಲಿ ಹೆಸರನ್ನು ಪತ್ತೆ ಮಾಡಿದಾಗ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಹೊಸ ವ್ಯಕ್ತಿಯನ್ನು ರಚಿಸಿ.';
 
   @override
   String get pilotFeatures => 'ಪೈಲಟ್ ವೈಶಿಷ್ಟ್ಯಗಳು';
@@ -3632,12 +3564,10 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get letOmiChooseAutomatically =>
-      'Omi ಅನ್ನು ಸಿ ಉತ್ತಮ ಅಪ್ಲಿಕೇಶನ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಆಯ್ಕೆ ಮಾಡಲು ನಿರ್ಬಂಧಿತಕ್ಕೆ ಗೊತ್ತಪಡಿಸಿ';
+  String get letOmiChooseAutomatically => 'Omi ಅನ್ನು ಸಿ ಉತ್ತಮ ಅಪ್ಲಿಕೇಶನ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಆಯ್ಕೆ ಮಾಡಲು ನಿರ್ಬಂಧಿತಕ್ಕೆ ಗೊತ್ತಪಡಿಸಿ';
 
   @override
-  String get deleteConversationConfirmation =>
-      'ನೀವು ಖಚಿತವಾಗಿ ಈ ಸಂವಾದವನ್ನು ಅಳಿಸಲು ಬಯಸುವಿರಾ? ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ.';
+  String get deleteConversationConfirmation => 'ನೀವು ಖಚಿತವಾಗಿ ಈ ಸಂವಾದವನ್ನು ಅಳಿಸಲು ಬಯಸುವಿರಾ? ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ.';
 
   @override
   String get conversationDeleted => 'ಸಂವಾದ ಅಳಿಸಲಾಗಿದೆ';
@@ -3685,8 +3615,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get preparingSystemAudioCapture => 'ಸಿಸ್ಟಮ್ ಆಡಿಯೋ ಸೆರೆ ತಯಾರಿ ಮಾಡುತ್ತಿದೆ';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'ಲೈವ್ ಪ್ರತಿಲೇಖನ, AI ಒಳನೋಟಗಳು ಮತ್ತು ಸ್ವಯಂಚಾಲಿತ ಉಳಿತಾಯಿಗಾಗಿ ಆಡಿಯೋ ಹಿಡಿಯಲು ಬಟನ್ ನೀಡಿ.';
+  String get clickTheButtonToCaptureAudio => 'ಲೈವ್ ಪ್ರತಿಲೇಖನ, AI ಒಳನೋಟಗಳು ಮತ್ತು ಸ್ವಯಂಚಾಲಿತ ಉಳಿತಾಯಿಗಾಗಿ ಆಡಿಯೋ ಹಿಡಿಯಲು ಬಟನ್ ನೀಡಿ.';
 
   @override
   String get reconnecting => 'ಮರುಸಂಪರ್ಕ ಸಾಧನೆ...';
@@ -3913,8 +3842,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'ಜ್ಞಾನ ಗ್ರಾಫ್ ಅಳಿಸಿ?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'ಇದು ಪಡೆದ ಜ್ಞಾನ ಗ್ರಾಫ್ ಡೇಟಾವನ್ನು ಅಳಿಸುತ್ತದೆ. ನಿಮ್ಮ ಮೂಲ ಆಲೋಚನೆಗಳು ಸುರಕ್ಷಿತವಾಗಿ ಉಳಿಯುತ್ತವೆ.';
+  String get deleteKnowledgeGraphWarning => 'ಇದು ಪಡೆದ ಜ್ಞಾನ ಗ್ರಾಫ್ ಡೇಟಾವನ್ನು ಅಳಿಸುತ್ತದೆ. ನಿಮ್ಮ ಮೂಲ ಆಲೋಚನೆಗಳು ಸುರಕ್ಷಿತವಾಗಿ ಉಳಿಯುತ್ತವೆ.';
 
   @override
   String get connectOmiWithAI => 'Omi ಅನ್ನು AI ಸಹಾಯಕರೊಂದಿಗೆ ಸಂಪರ್ಕಿಸಿ';
@@ -3956,8 +3884,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'ನಿಯಮಗಳು ಮತ್ತು ಗೌಪ್ಯತೆ ನೀತಿ';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'ಸಮಸ್ಯೆಗಳನ್ನು ನಿರ್ಣಯಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ. 3 ದಿನಗಳ ನಂತರ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಅಳಿಸುತ್ತದೆ.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'ಸಮಸ್ಯೆಗಳನ್ನು ನಿರ್ಣಯಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತದೆ. 3 ದಿನಗಳ ನಂತರ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಅಳಿಸುತ್ತದೆ.';
 
   @override
   String get manageYourApp => 'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನನ್ನು ನಿರ್ವಹಿಸಿ';
@@ -3972,8 +3899,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get updateAppQuestion => 'ಅಪ್ಲಿಕೇಶನ ಅಪ್ಡೇಟ್ ಮಾಡುವುದೇ?';
 
   @override
-  String get updateAppConfirmation =>
-      'ನೀವು ಖಚಿತವಾಗಿ ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನವನ್ನು ಅಪ್ಡೇಟ್ ಮಾಡಲು ಬಯಸುವಿರಾ? ನಮ್ಮ ತಂಡದ ಮೂಲಕ ಪರಿಶೀಲಿಸಿದ ನಂತರ ಬದಲಾವಣೆಗಳು ಪ್ರತಿಬಿಂಬಿಸುತ್ತವೆ.';
+  String get updateAppConfirmation => 'ನೀವು ಖಚಿತವಾಗಿ ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನವನ್ನು ಅಪ್ಡೇಟ್ ಮಾಡಲು ಬಯಸುವಿರಾ? ನಮ್ಮ ತಂಡದ ಮೂಲಕ ಪರಿಶೀಲಿಸಿದ ನಂತರ ಬದಲಾವಣೆಗಳು ಪ್ರತಿಬಿಂಬಿಸುತ್ತವೆ.';
 
   @override
   String get updateApp => 'ಅಪ್ಲಿಕೇಶನ ಅಪ್ಡೇಟ್ ಮಾಡಿ';
@@ -4003,8 +3929,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get no => 'ಇಲ್ಲ';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'ಸಾಬಸ್ಕ್ರಿಪ್ಷನ್ ಯಶಸ್ವಿಯಾಗಿ ರದ್ದುಗೊಳಿಸಲಾಗಿದೆ. ಇದು ಪ್ರವಾಹಿ ಬಿಲ್ಲಿಂಗ್ ಅವಧಿಯ ಅಂತ್ಯ ತನಕ ಸಕ್ರಿಯವಾಗಿರುತ್ತದೆ.';
+  String get subscriptionCancelledSuccessfully => 'ಸಾಬಸ್ಕ್ರಿಪ್ಷನ್ ಯಶಸ್ವಿಯಾಗಿ ರದ್ದುಗೊಳಿಸಲಾಗಿದೆ. ಇದು ಪ್ರವಾಹಿ ಬಿಲ್ಲಿಂಗ್ ಅವಧಿಯ ಅಂತ್ಯ ತನಕ ಸಕ್ರಿಯವಾಗಿರುತ್ತದೆ.';
 
   @override
   String get failedToCancelSubscription => 'ಸಾಬಸ್ಕ್ರಿಪ್ಷನ್ ರದ್ದುಗೊಳಿಸಲು ವಿಫಲವಾಗಿದೆ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
@@ -4040,8 +3965,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'ಸಾಬಸ್ಕ್ರಿಪ್ಷನ್ ರದ್ದುಗೊಳಿಸುವುದೇ?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'ನೀವು ಖಚಿತವಾಗಿ ನಿಮ್ಮ ಸಾಬಸ್ಕ್ರಿಪ್ಷನ್ ರದ್ದುಗೊಳಿಸಲು ಬಯಸುವಿರಾ? ನೀವು ನಿಮ್ಮ ಪ್ರವಾಹಿ ಬಿಲ್ಲಿಂಗ್ ಅವಧಿಯ ಅಂತ್ಯ ತನಕ ಪ್ರವೇಶ ಹೊಂದಿರುತ್ತೀರಿ.';
+  String get cancelSubscriptionConfirmation => 'ನೀವು ಖಚಿತವಾಗಿ ನಿಮ್ಮ ಸಾಬಸ್ಕ್ರಿಪ್ಷನ್ ರದ್ದುಗೊಳಿಸಲು ಬಯಸುವಿರಾ? ನೀವು ನಿಮ್ಮ ಪ್ರವಾಹಿ ಬಿಲ್ಲಿಂಗ್ ಅವಧಿಯ ಅಂತ್ಯ ತನಕ ಪ್ರವೇಶ ಹೊಂದಿರುತ್ತೀರಿ.';
 
   @override
   String get cancelSubscriptionButton => 'ಸಾಬಸ್ಕ್ರಿಪ್ಷನ್ ರದ್ದುಗೊಳಿಸಿ';
@@ -4050,16 +3974,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get cancelling => 'ರದ್ದುಗೊಳಿಸುತ್ತಿದೆ...';
 
   @override
-  String get betaTesterMessage =>
-      'ನೀವು ಈ ಅಪ್ಲಿಕೇಶನಿಗೆ ಬೀಟಾ ಪರೀಕ್ಷೆ ನಿರ್ವಾಹಕರು. ಇದು ಇನ್ನೂ ಸಾರ್ವಜನಿಕವಿಲ್ಲ. ಅನುಮೋದಿಸಿದ ನಂತರ ಇದು ಸಾರ್ವಜನಿಕವಾಗುತ್ತದೆ.';
+  String get betaTesterMessage => 'ನೀವು ಈ ಅಪ್ಲಿಕೇಶನಿಗೆ ಬೀಟಾ ಪರೀಕ್ಷೆ ನಿರ್ವಾಹಕರು. ಇದು ಇನ್ನೂ ಸಾರ್ವಜನಿಕವಿಲ್ಲ. ಅನುಮೋದಿಸಿದ ನಂತರ ಇದು ಸಾರ್ವಜನಿಕವಾಗುತ್ತದೆ.';
 
   @override
-  String get appUnderReviewMessage =>
-      'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಪರಿಶೀಲನೆಯ ಅಡಿಯಲ್ಲಿ ಮತ್ತು ನಿಮಗೆ ಮಾತ್ರ ಗೋಚರವಾಗಿದೆ. ಅನುಮೋದಿಸಿದ ನಂತರ ಇದು ಸಾರ್ವಜನಿಕವಾಗುತ್ತದೆ.';
+  String get appUnderReviewMessage => 'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಪರಿಶೀಲನೆಯ ಅಡಿಯಲ್ಲಿ ಮತ್ತು ನಿಮಗೆ ಮಾತ್ರ ಗೋಚರವಾಗಿದೆ. ಅನುಮೋದಿಸಿದ ನಂತರ ಇದು ಸಾರ್ವಜನಿಕವಾಗುತ್ತದೆ.';
 
   @override
-  String get appRejectedMessage =>
-      'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಹಿಂದೆ ಸರಿಬೆರೆಮೆ. ದಯವಿಟ್ಟು ಅಪ್ಲಿಕೇಶನ ವಿವರಗಳನ್ನು ನವೀಕರಿಸಿ ಮತ್ತು ಪರಿಶೀಲನೆಗಾಗಿ ಮರುಸಲ್ಲಿಸಿ.';
+  String get appRejectedMessage => 'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಹಿಂದೆ ಸರಿಬೆರೆಮೆ. ದಯವಿಟ್ಟು ಅಪ್ಲಿಕೇಶನ ವಿವರಗಳನ್ನು ನವೀಕರಿಸಿ ಮತ್ತು ಪರಿಶೀಲನೆಗಾಗಿ ಮರುಸಲ್ಲಿಸಿ.';
 
   @override
   String get invalidIntegrationUrl => 'ಅಮಾನ್ಯ ಸಂಯೋಗ URL';
@@ -4113,8 +4034,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get issueActivatingApp => 'ಈ ಅಪ್ಲಿಕೇಶನವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಒಂದು ಸಮಸ್ಯೆ ಇದೆ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'ಈ ಅಪ್ಲಿಕೇಶನ ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಪ್ರವೇಶಿಸುತ್ತದೆ. Omi AI ಈ ಅಪ್ಲಿಕೇಶನದ ಮೂಲಕ ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಹೇಗೆ ಉಪಯೋಗಿಸಲಾಗುತ್ತದೆ, ಪರಿವರ್ತನೆ ಮಾಡಲಾಗುತ್ತದೆ ಅಥವಾ ಅಳಿಸಲಾಗುತ್ತದೆ ಎಂಬುದರ ಮೇಲೆ ಜವಾಬ್ದಾರಿ ಹೊಂದಿಲ್ಲ';
+  String get dataAccessNoticeDescription => 'ಈ ಅಪ್ಲಿಕೇಶನ ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಪ್ರವೇಶಿಸುತ್ತದೆ. Omi AI ಈ ಅಪ್ಲಿಕೇಶನದ ಮೂಲಕ ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಹೇಗೆ ಉಪಯೋಗಿಸಲಾಗುತ್ತದೆ, ಪರಿವರ್ತನೆ ಮಾಡಲಾಗುತ್ತದೆ ಅಥವಾ ಅಳಿಸಲಾಗುತ್ತದೆ ಎಂಬುದರ ಮೇಲೆ ಜವಾಬ್ದಾರಿ ಹೊಂದಿಲ್ಲ';
 
   @override
   String get copyUrl => 'URL ನಕಲಿ ಕರಿ';
@@ -4202,8 +4122,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get omiApiKeys => 'Omi API ಕೀಲಿಗಳು';
 
   @override
-  String get apiKeysDescription =>
-      'API ಕೀಲಿಗಳು ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ OMI ಸರ್ವರೊಂದಿಗೆ ಸಂವಹನ ಮಾಡುವಾಗ ಪ್ರಮಾಣೀಕರಣ ಮಾಡಲು ಬಳಸಲಾಗುತ್ತದೆ. ಅವರು ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಸ್ಮೃತಿಶಾಸ್ತ್ರ ರಚಿಸಲು ಮತ್ತು ಇತರ OMI ಸೇವಾಗಳನ್ನು ಸುರಕ್ಷಿತವಾಗಿ ಪ್ರವೇಶಿಸಲು ನಿರ್ಬಂಧಿತ ಮಾಡುತ್ತದೆ.';
+  String get apiKeysDescription => 'API ಕೀಲಿಗಳು ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ OMI ಸರ್ವರೊಂದಿಗೆ ಸಂವಹನ ಮಾಡುವಾಗ ಪ್ರಮಾಣೀಕರಣ ಮಾಡಲು ಬಳಸಲಾಗುತ್ತದೆ. ಅವರು ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಸ್ಮೃತಿಶಾಸ್ತ್ರ ರಚಿಸಲು ಮತ್ತು ಇತರ OMI ಸೇವಾಗಳನ್ನು ಸುರಕ್ಷಿತವಾಗಿ ಪ್ರವೇಶಿಸಲು ನಿರ್ಬಂಧಿತ ಮಾಡುತ್ತದೆ.';
 
   @override
   String get aboutOmiApiKeys => 'Omi API ಕೀಲಿಗಳ ಬಗ್ಗೆ';
@@ -4227,8 +4146,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API ಕೀ ರದ್ದುಗೊಳಿಸುವುದೇ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ. ಈ ಕೀಯನ್ನು ಬಳಸುವ ಯಾವುದೇ ಅಪ್ಲಿಕೇಶನ API ಗೆ ಹೆಚ್ಚುತರ ಪ್ರವೇಶವನ್ನು ಹೊಂದಿರುವುದಿಲ್ಲ.';
+  String get revokeApiKeyWarning => 'ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ. ಈ ಕೀಯನ್ನು ಬಳಸುವ ಯಾವುದೇ ಅಪ್ಲಿಕೇಶನ API ಗೆ ಹೆಚ್ಚುತರ ಪ್ರವೇಶವನ್ನು ಹೊಂದಿರುವುದಿಲ್ಲ.';
 
   @override
   String get revoke => 'ರದ್ದುಗೊಳಿಸಿ';
@@ -4317,8 +4235,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get keyCreated => 'ಕೀ ರಚಿಸಿದೆ';
 
   @override
-  String get keyCreatedMessage =>
-      'ನಿಮ್ಮ ಹೊಸ ಕೀಯನ್ನು ರಚಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಈಗ ಅದನ್ನು ನಕಲಿ ಮಾಡಿ. ನೀವು ಅದನ್ನು ಮತ್ತೆ ನೋಡಲಾಗುವುದಿಲ್ಲ.';
+  String get keyCreatedMessage => 'ನಿಮ್ಮ ಹೊಸ ಕೀಯನ್ನು ರಚಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಈಗ ಅದನ್ನು ನಕಲಿ ಮಾಡಿ. ನೀವು ಅದನ್ನು ಮತ್ತೆ ನೋಡಲಾಗುವುದಿಲ್ಲ.';
 
   @override
   String get keyWord => 'ಕೀ';
@@ -4327,8 +4244,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get externalAppAccess => 'ಬಾಹ್ಯ ಅಪ್ಲಿಕೇಶನ ಪ್ರವೇಶ';
 
   @override
-  String get externalAppAccessDescription =>
-      'ಈ ಕೆಳಗೆ ನಮೂದಿಸಲಾದ ಅಪ್ಲಿಕೇಶನಗಳು ಬಾಹ್ಯ ಸಂಯೋಗಗಳನ್ನು ಹೊಂದಿದೆ ಮತ್ತು ನಿಮ್ಮ ಡೇಟಾ, ಅಂದರೆ ಸಂವಾದಗಳು ಮತ್ತು ಆಲೋಚನೆಗಳನ್ನು ಪ್ರವೇಶಿಸಬಹುದು.';
+  String get externalAppAccessDescription => 'ಈ ಕೆಳಗೆ ನಮೂದಿಸಲಾದ ಅಪ್ಲಿಕೇಶನಗಳು ಬಾಹ್ಯ ಸಂಯೋಗಗಳನ್ನು ಹೊಂದಿದೆ ಮತ್ತು ನಿಮ್ಮ ಡೇಟಾ, ಅಂದರೆ ಸಂವಾದಗಳು ಮತ್ತು ಆಲೋಚನೆಗಳನ್ನು ಪ್ರವೇಶಿಸಬಹುದು.';
 
   @override
   String get noExternalAppsHaveAccess => 'ಯಾವುದೇ ಬಾಹ್ಯ ಅಪ್ಲಿಕೇಶನಗಳು ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಪ್ರವೇಶಿಸುವುದಿಲ್ಲ.';
@@ -4337,8 +4253,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get maximumSecurityE2ee => 'ಸಮನ್ವಿತ ಸುರಕ್ಷೆ (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'ಅಂತ್ಯ-ನಿರ್ದಿಷ್ಟ ಎನ್‌ಕ್ರಿಪ್ಶನ್ ಗೌಪ್ಯತೆಗೆ ಸ್ವರ್ಣ ಮಾನದಂಡವಾಗಿದೆ. ಸಕ್ರಿಯಗೊಳಿಸಿದಾಗ, ನಿಮ್ಮ ಡೇಟಾವನ್ನು ನಮ್ಮ ಸರ್ವರ್‌ಗಳಿಗೆ ಕಳುಹಿಸುವ ಮೊದಲು ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಲಾಗುತ್ತದೆ. ಇದರರ್ಥ ಯಾವುದೇ ವ್ಯಕ್ತಿ, ಸಹ Omi, ನಿಮ್ಮ ವಿಷಯವನ್ನು ಪ್ರವೇಶಿಸಬಹುದು.';
+  String get e2eeDescription => 'ಅಂತ್ಯ-ನಿರ್ದಿಷ್ಟ ಎನ್‌ಕ್ರಿಪ್ಶನ್ ಗೌಪ್ಯತೆಗೆ ಸ್ವರ್ಣ ಮಾನದಂಡವಾಗಿದೆ. ಸಕ್ರಿಯಗೊಳಿಸಿದಾಗ, ನಿಮ್ಮ ಡೇಟಾವನ್ನು ನಮ್ಮ ಸರ್ವರ್‌ಗಳಿಗೆ ಕಳುಹಿಸುವ ಮೊದಲು ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಲಾಗುತ್ತದೆ. ಇದರರ್ಥ ಯಾವುದೇ ವ್ಯಕ್ತಿ, ಸಹ Omi, ನಿಮ್ಮ ವಿಷಯವನ್ನು ಪ್ರವೇಶಿಸಬಹುದು.';
 
   @override
   String get importantTradeoffs => 'ಮುಖ್ಯ ವ್ಯವಹಾರ:';
@@ -4353,8 +4268,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get featureComingSoon => 'ಈ ವೈಶಿಷ್ಟ್ಯವು ಶೀಘ್ರ ಬರುತ್ತಿದೆ!';
 
   @override
-  String get migrationInProgressMessage =>
-      'ರೂಪಾಂತರ ಪ್ರಗತಿಯಲ್ಲಿದೆ. ಅದು ಪೂರ್ಣವಾಗುವವರೆಗೆ ನೀವು ಸುರಕ್ಷೆಯ ಅಂಶ ಬದಲಾಯಿಸಲಾಗುವುದಿಲ್ಲ.';
+  String get migrationInProgressMessage => 'ರೂಪಾಂತರ ಪ್ರಗತಿಯಲ್ಲಿದೆ. ಅದು ಪೂರ್ಣವಾಗುವವರೆಗೆ ನೀವು ಸುರಕ್ಷೆಯ ಅಂಶ ಬದಲಾಯಿಸಲಾಗುವುದಿಲ್ಲ.';
 
   @override
   String get migrationFailed => 'ರೂಪಾಂತರ ವಿಫಲವಾಗಿದೆ';
@@ -4373,19 +4287,16 @@ class AppLocalizationsKn extends AppLocalizations {
   String get secureEncryption => 'ಸುರಕ್ಷಿತ ಎನ್‌ಕ್ರಿಪ್ಶನ್';
 
   @override
-  String get secureEncryptionDescription =>
-      'ನಿಮ್ಮ ಡೇಟಾವನ್ನು Google Cloud ನಲ್ಲಿ ಹೋಸ್ಟ್ ಮಾಡಿ ನಮ್ಮ ಸರ್ವರ್‌ಗಳಲ್ಲಿ ನಿಮಗೆ ಅನನ್ಯ ಕೀ ಧ್ವನಿ ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಿದೆ. ಇದರರ್ಥ ನಿಮ್ಮ ರಾ ವಿಷಯವು ಡೇಟಾಬೇಸ್ ಸೇರಿ ಯಾವುದೇ ವ್ಯಕ್ತಿಗೆ ನೇರವಾಗಿ ಪ್ರವೇಶಯೋಗ್ಯವಿಲ್ಲ.';
+  String get secureEncryptionDescription => 'ನಿಮ್ಮ ಡೇಟಾವನ್ನು Google Cloud ನಲ್ಲಿ ಹೋಸ್ಟ್ ಮಾಡಿ ನಮ್ಮ ಸರ್ವರ್‌ಗಳಲ್ಲಿ ನಿಮಗೆ ಅನನ್ಯ ಕೀ ಧ್ವನಿ ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಿದೆ. ಇದರರ್ಥ ನಿಮ್ಮ ರಾ ವಿಷಯವು ಡೇಟಾಬೇಸ್ ಸೇರಿ ಯಾವುದೇ ವ್ಯಕ್ತಿಗೆ ನೇರವಾಗಿ ಪ್ರವೇಶಯೋಗ್ಯವಿಲ್ಲ.';
 
   @override
   String get endToEndEncryption => 'ಅಂತ್ಯ-ನಿರ್ದಿಷ್ಟ ಎನ್‌ಕ್ರಿಪ್ಶನ್';
 
   @override
-  String get e2eeCardDescription =>
-      'ಸಮನ್ವಿತ ಸುರಕ್ಷೆಯಾಗಿ ಸಕ್ರಿಯಗೊಳಿಸಿ ಅಲ್ಲಿ ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಪ್ರವೇಶಿಸಲು ಮಾತ್ರ ನೀವು ಪಾರ್ಶ್ವಪ್ರದರ್ಶನೀ ಮಾಡಬಹುದು.';
+  String get e2eeCardDescription => 'ಸಮನ್ವಿತ ಸುರಕ್ಷೆಯಾಗಿ ಸಕ್ರಿಯಗೊಳಿಸಿ ಅಲ್ಲಿ ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಪ್ರವೇಶಿಸಲು ಮಾತ್ರ ನೀವು ಪಾರ್ಶ್ವಪ್ರದರ್ಶನೀ ಮಾಡಬಹುದು.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'ಸ್ಥಿರತಾ ಅಂಶ ಅಸಂಬದ್ಧ, ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಸದಾ ವಿಶ್ರಾಮ ನಿರ್ಮಾಣ ಮತ್ತು ನಿರ್ಮಾಣ ನಿರ್ಮಾಣಕ್ಷಮ ಎನ್ಕ್ರಿಪ್ಟ್ ಮಾಡಲಾಗುತ್ತದೆ.';
+  String get dataAlwaysEncrypted => 'ಸ್ಥಿರತಾ ಅಂಶ ಅಸಂಬದ್ಧ, ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಸದಾ ವಿಶ್ರಾಮ ನಿರ್ಮಾಣ ಮತ್ತು ನಿರ್ಮಾಣ ನಿರ್ಮಾಣಕ್ಷಮ ಎನ್ಕ್ರಿಪ್ಟ್ ಮಾಡಲಾಗುತ್ತದೆ.';
 
   @override
   String get readOnlyScope => 'ಓದಿ ಮಾತ್ರ';
@@ -4450,12 +4361,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get trainingDataProgram => 'ತರಾಜು ಡೇಟಾ ಕಾರ್ಯಕ್ರಮ';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'AI ಮಾದರಿಗಳನ್ನು ತರಾಜು ಮಾಡಲು ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಕಾರ್ಯಕ್ರಮದಿಂದ ಉಚಿತ ಎಂದು Omi Unlimited ಪಡೆಯಿರಿ.';
+  String get getOmiUnlimitedFree => 'AI ಮಾದರಿಗಳನ್ನು ತರಾಜು ಮಾಡಲು ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಕಾರ್ಯಕ್ರಮದಿಂದ ಉಚಿತ ಎಂದು Omi Unlimited ಪಡೆಯಿರಿ.';
 
   @override
-  String get trainingDataBullets =>
-      '• ನಿಮ್ಮ ಡೇಟಾವು AI ಮಾದರಿ ಸುಧಾರಣೆ ಸಹಾಯಿಸುತ್ತದೆ\n• ಅಗತ್ಯವಿಲ್ಲದ ಡೇಟಾವನ್ನು ಮಾತ್ರ ಹಂಚಿಕೆ\n• ಸರ್ವಸಂಸ್ಕೃತ ಪ್ರಕ್ರಿಯೆ';
+  String get trainingDataBullets => '• ನಿಮ್ಮ ಡೇಟಾವು AI ಮಾದರಿ ಸುಧಾರಣೆ ಸಹಾಯಿಸುತ್ತದೆ\n• ಅಗತ್ಯವಿಲ್ಲದ ಡೇಟಾವನ್ನು ಮಾತ್ರ ಹಂಚಿಕೆ\n• ಸರ್ವಸಂಸ್ಕೃತ ಪ್ರಕ್ರಿಯೆ';
 
   @override
   String get learnMoreAtOmiTraining => 'omi.me/training ನಲ್ಲಿ ಹೆಚ್ಚಿನ ಮಾಹಿತಿ ಪಡೆಯಿರಿ';
@@ -4467,8 +4376,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get submitRequest => 'ವಿನಂತಿ ಸಲ್ಲಿಸಿ';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'ಧನ್ಯವಾದ! ನಿಮ್ಮ ವಿನಂತಿ ಪರಿಶೀಲನೆಯ ಅಡಿಯಲ್ಲಿದೆ. ಅನುಮೋದಿಸಿದ ನಂತರ ನಾವು ನಿಮ್ಮನ್ನು ಸೂಚಿತ ಮಾಡುತ್ತೇವೆ.';
+  String get thankYouRequestUnderReview => 'ಧನ್ಯವಾದ! ನಿಮ್ಮ ವಿನಂತಿ ಪರಿಶೀಲನೆಯ ಅಡಿಯಲ್ಲಿದೆ. ಅನುಮೋದಿಸಿದ ನಂತರ ನಾವು ನಿಮ್ಮನ್ನು ಸೂಚಿತ ಮಾಡುತ್ತೇವೆ.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4506,8 +4414,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get monthlyPlanContinues => 'ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಮಾಸಿಕ ಯೋಜನೆ ನಿಮ್ಮ ಬಿಲಿಂಗ್ ಅವಧಿಯ ಅಂತ್ಯ ವರೆಗೆ ಮುಂದುವರಿಯುತ್ತದೆ';
 
   @override
-  String get paymentMethodCharged =>
-      'ನಿಮ್ಮ ಮಾಸಿಕ ಯೋಜನೆ ಕೊನೆಗೊಂಡಾಗ ನಿಮ್ಮ ಅಸ್ತಿತ್ವದ ಪೇಮೆಂಟ್ ವಿಧಾನಕ್ಕೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಶುಲ್ಕ ವಿಧಿಸಲಾಗುವುದು';
+  String get paymentMethodCharged => 'ನಿಮ್ಮ ಮಾಸಿಕ ಯೋಜನೆ ಕೊನೆಗೊಂಡಾಗ ನಿಮ್ಮ ಅಸ್ತಿತ್ವದ ಪೇಮೆಂಟ್ ವಿಧಾನಕ್ಕೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಶುಲ್ಕ ವಿಧಿಸಲಾಗುವುದು';
 
   @override
   String get annualSubscriptionStarts => 'ಶುಲ್ಕದ ನಂತರ ನಿಮ್ಮ 12-ತಿಂಗಳ ವಾರ್ಷಿಕ ಸದಸ್ಯತೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪ್ರಾರಂಭ ಆಗುತ್ತದೆ';
@@ -4550,8 +4457,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'ನಿಮ್ಮ ಮಾಸಿಕ ಯೋಜನೆ ಕೊನೆಗೊಂಡಾಗ ನಿಮ್ಮ ವಾರ್ಷಿಕ ಯೋಜನೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪ್ರಾರಂಭ ಆಗುತ್ತದೆ.';
+  String get annualPlanStartsAutomatically => 'ನಿಮ್ಮ ಮಾಸಿಕ ಯೋಜನೆ ಕೊನೆಗೊಂಡಾಗ ನಿಮ್ಮ ವಾರ್ಷಿಕ ಯೋಜನೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪ್ರಾರಂಭ ಆಗುತ್ತದೆ.';
 
   @override
   String planRenewsOn(String date) {
@@ -4618,8 +4524,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'ನಿಮ್ಮ ಗೌಪ್ಯತೆ ನಮಗೆ ಮುಖ್ಯ';
 
   @override
-  String get privacyIntroText =>
-      'Omi ನಲ್ಲಿ, ನಾವು ನಿಮ್ಮ ಗೌಪ್ಯತೆಯನ್ನು ತುಂಬಾ ಗಂಭೀರವಾಗಿ ತೆಗೆದುಕೊಳ್ಳುತ್ತೇವೆ. ನಾವು ಸಂಗ್ರಹ ಮಾಡುವ ಮತ್ತು ನಮ್ಮ ಉತ್ಪನ್ನವನ್ನು ನಿಮಗೆ ಸುಧಾರಿಸಲು ಹೇಗೆ ಬಳಸುವ ಡೇಟಾದ ಬಗ್ಗೆ ಸ್ವಚ್ಛವಾಗಿರಲು ನಿರ್ದೇಶಿತವಾಗಿದ್ದೇವೆ. ಇಲ್ಲಿ ನಿಮಗೆ ತಿಳಿದಿರುವ ಮಾಹಿತಿ:';
+  String get privacyIntroText => 'Omi ನಲ್ಲಿ, ನಾವು ನಿಮ್ಮ ಗೌಪ್ಯತೆಯನ್ನು ತುಂಬಾ ಗಂಭೀರವಾಗಿ ತೆಗೆದುಕೊಳ್ಳುತ್ತೇವೆ. ನಾವು ಸಂಗ್ರಹ ಮಾಡುವ ಮತ್ತು ನಮ್ಮ ಉತ್ಪನ್ನವನ್ನು ನಿಮಗೆ ಸುಧಾರಿಸಲು ಹೇಗೆ ಬಳಸುವ ಡೇಟಾದ ಬಗ್ಗೆ ಸ್ವಚ್ಛವಾಗಿರಲು ನಿರ್ದೇಶಿತವಾಗಿದ್ದೇವೆ. ಇಲ್ಲಿ ನಿಮಗೆ ತಿಳಿದಿರುವ ಮಾಹಿತಿ:';
 
   @override
   String get whatWeTrack => 'ನಾವು ಏನು ಟ್ರ್ಯಾಕ್ ಮಾಡುತ್ತೇವೆ';
@@ -4634,12 +4539,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get ourCommitment => 'ನಮ್ಮ ವಾಗ್ದಾನ';
 
   @override
-  String get commitmentText =>
-      'ನಾವು ನಾವು ಸಂಗ್ರಹ ಮಾಡುವ ಡೇಟಾವನ್ನು ಕೇವಲ Omi ಅನ್ನು ನಿಮಗೆ ಉತ್ತಮ ಉತ್ಪನ್ನ ಮಾಡಲು ಬಳಸುತ್ತೇವೆ ಎಂದು ಪ್ರತಿಶ್ರುತಿಬದ್ಧವಾಗಿದ್ದೇವೆ. ನಿಮ್ಮ ಗೌಪ್ಯತೆ ಮತ್ತು ನಿಮ್ಮ ವಿಶ್ವಾಸ ನಮಗೆ ಮುಖ್ಯತ್ವ.';
+  String get commitmentText => 'ನಾವು ನಾವು ಸಂಗ್ರಹ ಮಾಡುವ ಡೇಟಾವನ್ನು ಕೇವಲ Omi ಅನ್ನು ನಿಮಗೆ ಉತ್ತಮ ಉತ್ಪನ್ನ ಮಾಡಲು ಬಳಸುತ್ತೇವೆ ಎಂದು ಪ್ರತಿಶ್ರುತಿಬದ್ಧವಾಗಿದ್ದೇವೆ. ನಿಮ್ಮ ಗೌಪ್ಯತೆ ಮತ್ತು ನಿಮ್ಮ ವಿಶ್ವಾಸ ನಮಗೆ ಮುಖ್ಯತ್ವ.';
 
   @override
-  String get thankYouText =>
-      'Omi ನ ಮೌಲ್ಯಯುತ ಬಳಕೆದಾರ ಆಗಿರುವುದಕ್ಕಾಗಿ ನಿಮಗೆ ಧನ್ಯವಾದ. ಯಾವುದೇ ಪ್ರಶ್ನೆಗಳು ಅಥವಾ ಆತ್ಮಾಭಿಮಾನಗಳಿದ್ದರೆ, ನಮಗೆ team@basedhardware.com ಕ್ಕೆ ಸಂಪರ್ಕ ಮಾಡಲು ಮುಕ್ತವಾಗಿರಿ.';
+  String get thankYouText => 'Omi ನ ಮೌಲ್ಯಯುತ ಬಳಕೆದಾರ ಆಗಿರುವುದಕ್ಕಾಗಿ ನಿಮಗೆ ಧನ್ಯವಾದ. ಯಾವುದೇ ಪ್ರಶ್ನೆಗಳು ಅಥವಾ ಆತ್ಮಾಭಿಮಾನಗಳಿದ್ದರೆ, ನಮಗೆ team@basedhardware.com ಕ್ಕೆ ಸಂಪರ್ಕ ಮಾಡಲು ಮುಕ್ತವಾಗಿರಿ.';
 
   @override
   String get wifiSyncSettings => 'WiFi ಸಿಂಕ್ ಸಂಯೋಜನೆಗಳು';
@@ -4648,8 +4551,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get enterHotspotCredentials => 'ನಿಮ್ಮ ಫೋನ್‌ನ ಹಾಟ್‌ಸ್ಪಾಟ್ ಪ್ರಮಾಣಪತ್ರ ನಮೂದಿಸಿ';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi ಸಿಂಕ್ ನಿಮ್ಮ ಫೋನ್‌ನನ್ನು ಹಾಟ್‌ಸ್ಪಾಟ್ ಆಗಿ ಬಳಸುತ್ತದೆ. ಸೆಟ್ಟಿಂಗ್‌ಗಳು > ಪರ್ಸನಲ್ ಹಾಟ್‌ಸ್ಪಾಟ್‌ನಲ್ಲಿ ನಿಮ್ಮ ಹಾಟ್‌ಸ್ಪಾಟ್ ಹೆಸರು ಮತ್ತು ಪಾಸ್‌ವರ್ಡ್ ಕಂಡುಕೊಳ್ಳಿ.';
+  String get wifiSyncUsesHotspot => 'WiFi ಸಿಂಕ್ ನಿಮ್ಮ ಫೋನ್‌ನನ್ನು ಹಾಟ್‌ಸ್ಪಾಟ್ ಆಗಿ ಬಳಸುತ್ತದೆ. ಸೆಟ್ಟಿಂಗ್‌ಗಳು > ಪರ್ಸನಲ್ ಹಾಟ್‌ಸ್ಪಾಟ್‌ನಲ್ಲಿ ನಿಮ್ಮ ಹಾಟ್‌ಸ್ಪಾಟ್ ಹೆಸರು ಮತ್ತು ಪಾಸ್‌ವರ್ಡ್ ಕಂಡುಕೊಳ್ಳಿ.';
 
   @override
   String get hotspotNameSsid => 'ಹಾಟ್‌ಸ್ಪಾಟ್ ಹೆಸರು (SSID)';
@@ -4684,8 +4586,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'ಸಾರಾಂಶ ತಯಾರಿ ವಿಫಲ. ಆ ದಿನಕ್ಕಾಗಿ ನಿಮ್ಮಲ್ಲಿ ಸಂಭಾಷಣೆಗಳಿವೆ ಎಂದು ಖಚಿತಪಡಿಸಿ.';
+  String get failedToGenerateSummaryCheckConversations => 'ಸಾರಾಂಶ ತಯಾರಿ ವಿಫಲ. ಆ ದಿನಕ್ಕಾಗಿ ನಿಮ್ಮಲ್ಲಿ ಸಂಭಾಷಣೆಗಳಿವೆ ಎಂದು ಖಚಿತಪಡಿಸಿ.';
 
   @override
   String get summaryNotFound => 'ಸಾರಾಂಶ ಕಂಡುಬಂದಿಲ್ಲ';
@@ -4715,8 +4616,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'ರಫ್ತೆ ಪ್ರಾರಂಭವಾಗಿದೆ. ಇದು ಕೆಲವು ಸೆಕೆಂಡ ತೆಗೆದುಕೊಳ್ಳಬಹುದು...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'ಇದು ಎಲ್ಲಾ ವ್ಯುತ್ಪನ್ನ ಜ್ಞಾನ ಗ್ರಾಫ್ ಡೇಟಾ (ನೋಡ್ ಮತ್ತು ಸಂಪರ್ಕಗಳು) ಅಳಿಸುತ್ತದೆ. ನಿಮ್ಮ ಮೂಲ ಸ್ಮೃತಿಗಳು ಸುರಕ್ಷಿತವಾಗಿರುತ್ತದೆ. ಗ್ರಾಫ್ ಸಮಯಾನುಸಾರ ಅಥವಾ ಮುಂದಿನ ವಿನಂತಿಯ ಮೇಲೆ ನಿರ್ಮಿತವಾಗುತ್ತದೆ.';
+  String get knowledgeGraphDeleteDescription => 'ಇದು ಎಲ್ಲಾ ವ್ಯುತ್ಪನ್ನ ಜ್ಞಾನ ಗ್ರಾಫ್ ಡೇಟಾ (ನೋಡ್ ಮತ್ತು ಸಂಪರ್ಕಗಳು) ಅಳಿಸುತ್ತದೆ. ನಿಮ್ಮ ಮೂಲ ಸ್ಮೃತಿಗಳು ಸುರಕ್ಷಿತವಾಗಿರುತ್ತದೆ. ಗ್ರಾಫ್ ಸಮಯಾನುಸಾರ ಅಥವಾ ಮುಂದಿನ ವಿನಂತಿಯ ಮೇಲೆ ನಿರ್ಮಿತವಾಗುತ್ತದೆ.';
 
   @override
   String get configureDailySummaryDigest => 'ನಿಮ್ಮ ದೈನಿಕ ಕಾರ್ಯ ಪಟ್ಟಿ ಸಂಕ್ಷೇಪಣ ಸಂರೂಪಿಸಿ';
@@ -4786,8 +4686,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'ಎಲ್ಲಾ Limitless ಸಂಭಾಷಣೆಗಳು ಅಳಿಸುವುದೇ?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'ಇದು Limitless ನಿಂದ ಆಮದು ಮಾಡಲಾದ ಎಲ್ಲಾ ಸಂಭಾಷಣೆಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸುತ್ತದೆ. ಈ ಕ್ರಿಯೆ ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ.';
+  String get deleteAllLimitlessWarning => 'ಇದು Limitless ನಿಂದ ಆಮದು ಮಾಡಲಾದ ಎಲ್ಲಾ ಸಂಭಾಷಣೆಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸುತ್ತದೆ. ಈ ಕ್ರಿಯೆ ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4843,8 +4742,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get howItWorksTitle => 'ಇದು ಹೇಗೆ ಕೆಲಸ ಮಾಡುತ್ತದೆ?';
 
   @override
-  String get howPeopleWorks =>
-      'ಒಮ್ಮೆ ಒಬ್ಬ ವ್ಯಕ್ತಿ ಸೃಷ್ಟಿವಾಗಿದ್ದರೆ, ನೀವು ಸಂಭಾಷಣೆ ಪ್ರತಿಲೇಖಕ್ಕೆ ಹೋಗಬಹುದು, ಮತ್ತು ಅವರ ಅನುಗುಣ ವಿಭಾಗಗಳನ್ನು ಅವರಿಗೆ ನಿಯೋಜಿಸಬಹುದು, ಅದರಿಂದ Omi ಅವರ ಭಾಷಣವನ್ನು ಸಹ ಗುರುತಿಸಲು ಸಾಧ್ಯವಾಗುವುದು!';
+  String get howPeopleWorks => 'ಒಮ್ಮೆ ಒಬ್ಬ ವ್ಯಕ್ತಿ ಸೃಷ್ಟಿವಾಗಿದ್ದರೆ, ನೀವು ಸಂಭಾಷಣೆ ಪ್ರತಿಲೇಖಕ್ಕೆ ಹೋಗಬಹುದು, ಮತ್ತು ಅವರ ಅನುಗುಣ ವಿಭಾಗಗಳನ್ನು ಅವರಿಗೆ ನಿಯೋಜಿಸಬಹುದು, ಅದರಿಂದ Omi ಅವರ ಭಾಷಣವನ್ನು ಸಹ ಗುರುತಿಸಲು ಸಾಧ್ಯವಾಗುವುದು!';
 
   @override
   String get tapToDelete => 'ಅಳಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ';
@@ -4870,8 +4768,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get privacyNotice => 'ಗೌಪ್ಯತೆ ಸೂಚನೆ';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಇತರರ ಗಾಮಗಳನ್ನು ಸೆರೆಹಿಡಿಯಬಹುದು. ಸಕ್ರಿಯ ಮಾಡುವ ಮೊದಲು ಎಲ್ಲಾ ಭಾಗವಹಿಸುವವರಿಂದ ಒಪ್ಪಿಕೆ ಬಿಟ್ಟುಕೊಳ್ಳಿ.';
+  String get recordingsMayCaptureOthers => 'ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಇತರರ ಗಾಮಗಳನ್ನು ಸೆರೆಹಿಡಿಯಬಹುದು. ಸಕ್ರಿಯ ಮಾಡುವ ಮೊದಲು ಎಲ್ಲಾ ಭಾಗವಹಿಸುವವರಿಂದ ಒಪ್ಪಿಕೆ ಬಿಟ್ಟುಕೊಳ್ಳಿ.';
 
   @override
   String get enable => 'ಸಕ್ರಿಯ ಮಾಡಿ';
@@ -4883,8 +4780,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get on => 'ಸಕ್ರಿಯ';
 
   @override
-  String get storeAudioDescription =>
-      'ಎಲ್ಲಾ ಆಡಿಯೋ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ನಿಮ್ಮ ಫೋನ್‌ನಲ್ಲಿ ಸ್ಥಳೀಯವಾಗಿ ಸಂಗ್ರಹ ಮಾಡಿ. ನಿಷ್ಕ್ರಿಯ ಮಾಡಿದಾಗ, ಸಂಗ್ರಹ ಸ್ಥಾನ ಸಂರಕ್ಷಣೆಗಾಗಿ ವಿಫಲ ಅಪ್‌ಲೋಡ್‌ಗಳನ್ನು ಮಾತ್ರ ಸಂಗ್ರಹ ಮಾಡುತ್ತೇವೆ.';
+  String get storeAudioDescription => 'ಎಲ್ಲಾ ಆಡಿಯೋ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ನಿಮ್ಮ ಫೋನ್‌ನಲ್ಲಿ ಸ್ಥಳೀಯವಾಗಿ ಸಂಗ್ರಹ ಮಾಡಿ. ನಿಷ್ಕ್ರಿಯ ಮಾಡಿದಾಗ, ಸಂಗ್ರಹ ಸ್ಥಾನ ಸಂರಕ್ಷಣೆಗಾಗಿ ವಿಫಲ ಅಪ್‌ಲೋಡ್‌ಗಳನ್ನು ಮಾತ್ರ ಸಂಗ್ರಹ ಮಾಡುತ್ತೇವೆ.';
 
   @override
   String get enableLocalStorage => 'ಸ್ಥಳೀಯ ಭಾಂಡಾರ ಸಕ್ರಿಯ ಮಾಡಿ';
@@ -4902,12 +4798,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get storeAudioOnCloud => 'ಕ್ಲೌಡ್‌ನಲ್ಲಿ ಆಡಿಯೋ ಸಂಗ್ರಹ ಮಾಡಿ';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'ನಿಮ್ಮ ರಿಯಲ್-ಟೈಮ್ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ನೀವು ಮಾತನಾಡುವಾಗ ಖಾಸಗಿ ಕ್ಲೌಡ್ ಭಾಂಡಾರದಲ್ಲಿ ಸಂಗ್ರಹ ಮಾಡಲಾಗುವುದು.';
+  String get cloudStorageDialogMessage => 'ನಿಮ್ಮ ರಿಯಲ್-ಟೈಮ್ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ನೀವು ಮಾತನಾಡುವಾಗ ಖಾಸಗಿ ಕ್ಲೌಡ್ ಭಾಂಡಾರದಲ್ಲಿ ಸಂಗ್ರಹ ಮಾಡಲಾಗುವುದು.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'ನಿಮ್ಮ ರಿಯಲ್-ಟೈಮ್ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಖಾಸಗಿ ಕ್ಲೌಡ್ ಭಾಂಡಾರದಲ್ಲಿ ನೀವು ಮಾತನಾಡುವಾಗ ಸಂಗ್ರಹ ಮಾಡಿ. ಆಡಿಯೋ ರಿಯಲ್-ಟೈಮ್‌ನಲ್ಲಿ ಸುರಕ್ಷಿತವಾಗಿ ಸೆರೆಹಿಡಿಯಲಾಗುತ್ತದೆ ಮತ್ತು ಸಂಗ್ರಹ ಮಾಡಲಾಗುತ್ತದೆ.';
+  String get storeAudioCloudDescription => 'ನಿಮ್ಮ ರಿಯಲ್-ಟೈಮ್ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಖಾಸಗಿ ಕ್ಲೌಡ್ ಭಾಂಡಾರದಲ್ಲಿ ನೀವು ಮಾತನಾಡುವಾಗ ಸಂಗ್ರಹ ಮಾಡಿ. ಆಡಿಯೋ ರಿಯಲ್-ಟೈಮ್‌ನಲ್ಲಿ ಸುರಕ್ಷಿತವಾಗಿ ಸೆರೆಹಿಡಿಯಲಾಗುತ್ತದೆ ಮತ್ತು ಸಂಗ್ರಹ ಮಾಡಲಾಗುತ್ತದೆ.';
 
   @override
   String get downloadingFirmware => 'ಫರ್ಮ್‌ವೇರ್ ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತಿದೆ';
@@ -4916,8 +4810,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get installingFirmware => 'ಫರ್ಮ್‌ವೇರ್ ಸ್ಥಾಪಿಸುತ್ತಿದೆ';
 
   @override
-  String get firmwareUpdateWarning =>
-      'ಅಪ್ಲಿಕೇಶನ ಮುಚ್ಚಬೇಡಿ ಅಥವಾ ಸಾಧನವನ್ನು ಆಘಾತ ಮಾಡಬೇಡಿ. ಇದು ನಿಮ್ಮ ಸಾಧನವನ್ನು ಹಾಳೆ ಮಾಡಬಹುದು.';
+  String get firmwareUpdateWarning => 'ಅಪ್ಲಿಕೇಶನ ಮುಚ್ಚಬೇಡಿ ಅಥವಾ ಸಾಧನವನ್ನು ಆಘಾತ ಮಾಡಬೇಡಿ. ಇದು ನಿಮ್ಮ ಸಾಧನವನ್ನು ಹಾಳೆ ಮಾಡಬಹುದು.';
 
   @override
   String get firmwareUpdated => 'ಫರ್ಮ್‌ವೇರ್ ನವೀಕೃತವಾಗಿದೆ';
@@ -4961,8 +4854,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get payments => 'ಪೇಮೆಂಟ್‌ಗಳು';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನಗಳಿಗಾಗಿ ಪೇಮೆಂಟ್‌ಗಳನ್ನು ಪಡೆಯಲು ಮುಂದೆ ನೀಡಲಾದ ಪೇಮೆಂಟ್ ವಿಧಾನ ಸಂಯೋಜಿಸಿ.';
+  String get connectPaymentMethodInfo => 'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನಗಳಿಗಾಗಿ ಪೇಮೆಂಟ್‌ಗಳನ್ನು ಪಡೆಯಲು ಮುಂದೆ ನೀಡಲಾದ ಪೇಮೆಂಟ್ ವಿಧಾನ ಸಂಯೋಜಿಸಿ.';
 
   @override
   String get selectedPaymentMethod => 'ಆಯ್ದ ಪೇಮೆಂಟ್ ವಿಧಾನ';
@@ -4995,8 +4887,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get secureAndReliable => 'ಸುರಕ್ಷಿತ ಮತ್ತು ವಿಶ್ವಾಸಾರ್ಹ';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ರಾಜಸ್ವದ ಸುರಕ್ಷಿತ ಮತ್ತು ಸಾಕಾಲೀನ ವರ್ಗಾವಣೆಯನ್ನು ಖಾತ್ರಿ ಮಾಡುತ್ತದೆ';
+  String get stripeSecureDescription => 'Stripe ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ರಾಜಸ್ವದ ಸುರಕ್ಷಿತ ಮತ್ತು ಸಾಕಾಲೀನ ವರ್ಗಾವಣೆಯನ್ನು ಖಾತ್ರಿ ಮಾಡುತ್ತದೆ';
 
   @override
   String get selectYourCountry => 'ನಿಮ್ಮ ದೇಶ ಆಯ್ಕೆ ಮಾಡಿ';
@@ -5017,8 +4908,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get connectingYourStripeAccount => 'ನಿಮ್ಮ Stripe ಖಾತೆ ಸಂಯೋಜಿತ ಮಾಡುತ್ತಿದೆ';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'ದಯವಿಟ್ಟು ನಿಮ್ಮ ವೆಬ್‌ಸೈಟಿನಲ್ಲಿ Stripe ಸ್ವಾಗತ ಪ್ರಕ್ರಿಯೆ ಪೂರ್ಣ ಮಾಡಿ. ಪೂರ್ಣಗೊಂಡ ನಂತರ ಈ ಪುಟವು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನವೀಕರಣವಾಗುತ್ತದೆ.';
+  String get stripeOnboardingInstructions => 'ದಯವಿಟ್ಟು ನಿಮ್ಮ ವೆಬ್‌ಸೈಟಿನಲ್ಲಿ Stripe ಸ್ವಾಗತ ಪ್ರಕ್ರಿಯೆ ಪೂರ್ಣ ಮಾಡಿ. ಪೂರ್ಣಗೊಂಡ ನಂತರ ಈ ಪುಟವು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನವೀಕರಣವಾಗುತ್ತದೆ.';
 
   @override
   String get failedTryAgain => 'ವಿಫಲ? ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ';
@@ -5030,8 +4920,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get successfullyConnected => 'ಯಶಸ್ವಿಯಾಗಿ ಸಂಯೋಜಿತ!';
 
   @override
-  String get stripeReadyForPayments =>
-      'ನಿಮ್ಮ Stripe ಖಾತೆ ಈಗ ಪೇಮೆಂಟ್‌ಗಳನ್ನು ಸ್ವೀಕರಿಸಲು ಸಿದ್ಧ. ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಮಾರಾಟಗಳಿಂದ ತಕ್ಷಣವೇ ಗಳಿಕೆ ಮಾಡಲು ಪ್ರಾರಂಭ ಮಾಡಬಹುದು.';
+  String get stripeReadyForPayments => 'ನಿಮ್ಮ Stripe ಖಾತೆ ಈಗ ಪೇಮೆಂಟ್‌ಗಳನ್ನು ಸ್ವೀಕರಿಸಲು ಸಿದ್ಧ. ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನ ಮಾರಾಟಗಳಿಂದ ತಕ್ಷಣವೇ ಗಳಿಕೆ ಮಾಡಲು ಪ್ರಾರಂಭ ಮಾಡಬಹುದು.';
 
   @override
   String get updateStripeDetails => 'Stripe ವಿವರಗಳನ್ನು ನವೀಕರಣ ಮಾಡಿ';
@@ -5049,8 +4938,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get updatePayPalAccountDetails => 'ನಿಮ್ಮ PayPal ಖಾತೆ ವಿವರಗಳನ್ನು ನವೀಕರಣ ಮಾಡಿ';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನಗಳಿಗಾಗಿ ಪೇಮೆಂಟ್‌ಗಳನ್ನು ಸ್ವೀಕರಿಸಲು ನಿಮ್ಮ PayPal ಖಾತೆ ಸಂಯೋಜಿತ ಮಾಡಿ';
+  String get connectPayPalToReceivePayments => 'ನಿಮ್ಮ ಅಪ್ಲಿಕೇಶನಗಳಿಗಾಗಿ ಪೇಮೆಂಟ್‌ಗಳನ್ನು ಸ್ವೀಕರಿಸಲು ನಿಮ್ಮ PayPal ಖಾತೆ ಸಂಯೋಜಿತ ಮಾಡಿ';
 
   @override
   String get paypalEmail => 'PayPal ಇಮೇಲ್';
@@ -5059,8 +4947,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me ಸಂಪರ್ಕ';
 
   @override
-  String get stripeRecommendation =>
-      'Stripe ನಿಮ್ಮ ದೇಶದಲ್ಲಿ ಲಭ್ಯವಿದ್ದರೆ, ನಾವು ವೇಗದ ಮತ್ತು ಸುಲಭ ಪೇಮೆಂಟ್‌ಗಳಿಗಾಗಿ ಅದನ್ನು ಬಳಸಲು ಸಶಕ್ತವಾಗಿ ಶಿಫಾರಿಸುತ್ತೇವೆ.';
+  String get stripeRecommendation => 'Stripe ನಿಮ್ಮ ದೇಶದಲ್ಲಿ ಲಭ್ಯವಿದ್ದರೆ, ನಾವು ವೇಗದ ಮತ್ತು ಸುಲಭ ಪೇಮೆಂಟ್‌ಗಳಿಗಾಗಿ ಅದನ್ನು ಬಳಸಲು ಸಶಕ್ತವಾಗಿ ಶಿಫಾರಿಸುತ್ತೇವೆ.';
 
   @override
   String get updatePayPalDetails => 'PayPal ವಿವರಗಳನ್ನು ನವೀಕರಣ ಮಾಡಿ';
@@ -5112,12 +4999,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'ಹೆಚ್ಚುವರಿ ಭಾಷಣ ಮಾದರಿ ತೆಗೆದುಹಾಕಲಾಗಿದೆ';
 
   @override
-  String get consentDataMessage =>
-      'ಮುಂದುವರಿಯುವ ಮೂಲಕ, ನಿಮ್ಮ ಸಂಭಾಷಣೆಗಳು, ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಮತ್ತು ವೈಯಕ್ತಿಕ ಮಾಹಿತಿಯನ್ನು ನಮ್ಮ ಸರ್ವರ್‌ಗಳಲ್ಲಿ ಸುರಕ್ಷಿತವಾಗಿ ಸಂಗ್ರಹಿಸಲಾಗುತ್ತದೆ. ನಿಮ್ಮ ಆಡಿಯೋ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಮತ್ತು ಟ್ರಾನ್ಸ್‌ಕ್ರಿಪ್ಟ್‌ಗಳನ್ನು ಮೂರನೇ ವ್ಯಕ್ತಿಯ AI ಸೇವೆಗಳಿಂದ ಸಂಸ್ಕರಿಸಲಾಗುತ್ತದೆ (ಟ್ರಾನ್ಸ್‌ಕ್ರಿಪ್ಷನ್‌ಗಾಗಿ Deepgram ಮತ್ತು ವಿಶ್ಲೇಷಣೆಗಾಗಿ OpenAI ಸೇರಿದಂತೆ) AI-ಚಾಲಿತ ಒಳನೋಟಗಳನ್ನು ಒದಗಿಸಲು ಮತ್ತು ಎಲ್ಲಾ ಅಪ್ಲಿಕೇಶನ್ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು.';
+  String get consentDataMessage => 'ಮುಂದುವರಿಯುವ ಮೂಲಕ, ನಿಮ್ಮ ಸಂಭಾಷಣೆಗಳು, ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಮತ್ತು ವೈಯಕ್ತಿಕ ಮಾಹಿತಿಯನ್ನು ನಮ್ಮ ಸರ್ವರ್‌ಗಳಲ್ಲಿ ಸುರಕ್ಷಿತವಾಗಿ ಸಂಗ್ರಹಿಸಲಾಗುತ್ತದೆ. ನಿಮ್ಮ ಆಡಿಯೋ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳು ಮತ್ತು ಟ್ರಾನ್ಸ್‌ಕ್ರಿಪ್ಟ್‌ಗಳನ್ನು ಮೂರನೇ ವ್ಯಕ್ತಿಯ AI ಸೇವೆಗಳಿಂದ ಸಂಸ್ಕರಿಸಲಾಗುತ್ತದೆ (ಟ್ರಾನ್ಸ್‌ಕ್ರಿಪ್ಷನ್‌ಗಾಗಿ Deepgram ಮತ್ತು ವಿಶ್ಲೇಷಣೆಗಾಗಿ OpenAI ಸೇರಿದಂತೆ) AI-ಚಾಲಿತ ಒಳನೋಟಗಳನ್ನು ಒದಗಿಸಲು ಮತ್ತು ಎಲ್ಲಾ ಅಪ್ಲಿಕೇಶನ್ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'ನಿಮ್ಮ ಸಂಭಾಷಣೆಗಳಿಂದ ಕಾರ್ಯಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ.\\nಒಂದು ಹಸ್ತಚಾಲಿತವಾಗಿ ರಚಿಸಲು + ಟ್ಯಾಪ್ ಮಾಡಿ.';
+  String get tasksEmptyStateMessage => 'ನಿಮ್ಮ ಸಂಭಾಷಣೆಗಳಿಂದ ಕಾರ್ಯಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ.\\nಒಂದು ಹಸ್ತಚಾಲಿತವಾಗಿ ರಚಿಸಲು + ಟ್ಯಾಪ್ ಮಾಡಿ.';
 
   @override
   String get clearChatAction => 'ಚ್ಯಾಟ್ ತೀಕ್ಷ್ಣ ಮಾಡಿ';
@@ -5153,15 +5038,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Omi ಅನ್ನು ನಿಮ್ಮ\\nApple Watch ನಲ್ಲಿ ಸ್ಥಾಪಿಸಿ';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Omi ನೊಂದಿಗೆ ಆಪಲ್ ಗಡಿಯಾರವನ್ನು ಬಳಸಲು, ನೀವು ಮೊದಲು ನಿಮ್ಮ ಗಡಿಯಾರದಲ್ಲಿ Omi ಅಪ್ಲಿಕೇಶನ ಸ್ಥಾಪಿಸಬೇಕು.';
+  String get installOmiOnAppleWatchDescription => 'Omi ನೊಂದಿಗೆ ಆಪಲ್ ಗಡಿಯಾರವನ್ನು ಬಳಸಲು, ನೀವು ಮೊದಲು ನಿಮ್ಮ ಗಡಿಯಾರದಲ್ಲಿ Omi ಅಪ್ಲಿಕೇಶನ ಸ್ಥಾಪಿಸಬೇಕು.';
 
   @override
   String get openOmiOnAppleWatch => 'Omi ಅನ್ನು ನಿಮ್ಮ\\nApple Watch ನಲ್ಲಿ ತೆರೆಯಿರಿ';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi ಅಪ್ಲಿಕೇಶನ ನಿಮ್ಮ Apple Watch ನಲ್ಲಿ ಸ್ಥಾಪಿತವಾಗಿದೆ. ಅದನ್ನು ತೆರೆಯಿರಿ ಮತ್ತು ಪ್ರಾರಂಭ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ.';
+  String get openOmiOnAppleWatchDescription => 'Omi ಅಪ್ಲಿಕೇಶನ ನಿಮ್ಮ Apple Watch ನಲ್ಲಿ ಸ್ಥಾಪಿತವಾಗಿದೆ. ಅದನ್ನು ತೆರೆಯಿರಿ ಮತ್ತು ಪ್ರಾರಂಭ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ.';
 
   @override
   String get openWatchApp => 'ಗಡಿಯಾರ ಅಪ್ಲಿಕೇಶನ ತೆರೆಯಿರಿ';
@@ -5170,15 +5053,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'ನಾನು ಅಪ್ಲಿಕೇಶನ ಸ್ಥಾಪಿಸಿ ಮತ್ತು ತೆರೆದಿದ್ದೇನೆ';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch ಅಪ್ಲಿಕೇಶನ ತೆರೆಯಲು ಸಾಧ್ಯವಿಲ್ಲ. ದಯವಿಟ್ಟು ನಿಮ್ಮ Apple Watch ನಲ್ಲಿ ಗಡಿಯಾರ ಅಪ್ಲಿಕೇಶನವನ್ನು ಹೆಚ್ಚುತ್ತೆ ತೆರೆಯಿರಿ ಮತ್ತು \"ಲಭ್ಯವಿರುವ ಅಪ್ಲಿಕೇಶನಗಳು\" ವಿಭಾಗದಿಂದ Omi ಸ್ಥಾಪಿಸಿ.';
+  String get unableToOpenWatchApp => 'Apple Watch ಅಪ್ಲಿಕೇಶನ ತೆರೆಯಲು ಸಾಧ್ಯವಿಲ್ಲ. ದಯವಿಟ್ಟು ನಿಮ್ಮ Apple Watch ನಲ್ಲಿ ಗಡಿಯಾರ ಅಪ್ಲಿಕೇಶನವನ್ನು ಹೆಚ್ಚುತ್ತೆ ತೆರೆಯಿರಿ ಮತ್ತು \"ಲಭ್ಯವಿರುವ ಅಪ್ಲಿಕೇಶನಗಳು\" ವಿಭಾಗದಿಂದ Omi ಸ್ಥಾಪಿಸಿ.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch ಯಶಸ್ವಿಯಾಗಿ ಸಂಯೋಜಿತವಾಗಿದೆ!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch ಇನ್ನೂ ಪಡೆಯಾಗುವುದಿಲ್ಲ. ದಯವಿಟ್ಟು ಖಚಿತಪಡಿಸಿ Omi ಅಪ್ಲಿಕೇಶನ ನಿಮ್ಮ ಗಡಿಯಾರದಲ್ಲಿ ತೆರೆದಿದೆ.';
+  String get appleWatchNotReachable => 'Apple Watch ಇನ್ನೂ ಪಡೆಯಾಗುವುದಿಲ್ಲ. ದಯವಿಟ್ಟು ಖಚಿತಪಡಿಸಿ Omi ಅಪ್ಲಿಕೇಶನ ನಿಮ್ಮ ಗಡಿಯಾರದಲ್ಲಿ ತೆರೆದಿದೆ.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5606,30 +5487,25 @@ class AppLocalizationsKn extends AppLocalizations {
   String get multipleSpeakersDetected => 'ಮಾರುಕಟ್ಟೆ ವಕ್ತಾರಗಳು ಕಂಡುಬಂದಿದೆ';
 
   @override
-  String get multipleSpeakersDescription =>
-      'ರೆಕಾರ್ಡಿಂಗ್‌ನಲ್ಲಿ ಏನೋ ಮಾರುಕಟ್ಟೆ ವಕ್ತಾರಗಳನ್ನು ತೋರುತ್ತಿದೆ. ಸುಮಧುರ ಸ್ಥಳದಲ್ಲಿ ಇದ್ದೀರಾ ಎಂದು ಖಾತ್ರಿ ಮಾಡಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get multipleSpeakersDescription => 'ರೆಕಾರ್ಡಿಂಗ್‌ನಲ್ಲಿ ಏನೋ ಮಾರುಕಟ್ಟೆ ವಕ್ತಾರಗಳನ್ನು ತೋರುತ್ತಿದೆ. ಸುಮಧುರ ಸ್ಥಳದಲ್ಲಿ ಇದ್ದೀರಾ ಎಂದು ಖಾತ್ರಿ ಮಾಡಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
   String get invalidRecordingDetected => 'ಅಸಿದ್ಧ ರೆಕಾರ್ಡಿಂಗ್ ಕಂಡುಬಂದಿದೆ';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'ಕಾಫಿ ಭಾಷಣವನ್ನು ಕಂಡುಬಂದಿಲ್ಲ. ದಯವಿಟ್ಟು ಹೆಚ್ಚಾಗಿ ಮಾತನಾಡಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get notEnoughSpeechDescription => 'ಕಾಫಿ ಭಾಷಣವನ್ನು ಕಂಡುಬಂದಿಲ್ಲ. ದಯವಿಟ್ಟು ಹೆಚ್ಚಾಗಿ ಮಾತನಾಡಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
-  String get speechDurationDescription =>
-      'ದಯವಿಟ್ಟು ಅತಿ ಕಡಿಮೆ 5 ಸೆಕೆಂಡ್‌ಗಳು ಮತ್ತು 90 ಕ್ಕಿಂತ ಹೆಚ್ಚಿಲ್ಲ ಎಂದು ಮಾತನಾಡುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.';
+  String get speechDurationDescription => 'ದಯವಿಟ್ಟು ಅತಿ ಕಡಿಮೆ 5 ಸೆಕೆಂಡ್‌ಗಳು ಮತ್ತು 90 ಕ್ಕಿಂತ ಹೆಚ್ಚಿಲ್ಲ ಎಂದು ಮಾತನಾಡುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.';
 
   @override
-  String get connectionLostDescription =>
-      'ಸಂಪರ್ಕ ಅಡ್ಡಿ಄ಟ್ಟಿತು. ದಯವಿಟ್ಟು ನಿಮ್ಮ ಇಂಟರ್‌ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get connectionLostDescription => 'ಸಂಪರ್ಕ ಅಡ್ಡಿ಄ಟ್ಟಿತು. ದಯವಿಟ್ಟು ನಿಮ್ಮ ಇಂಟರ್‌ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
   String get howToTakeGoodSample => 'ಉತ್ತಮ ಮಾದರಿ ಹೇಗೆ ತೆಗೆದುಕೊಳ್ಳುವುದು?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. ನೀವು ಸುಮಾರು ಸ್ಥಳದಲ್ಲಿ ಇದ್ದೀರಿ ಎಂದು ಖಾತ್ರಿ ಮಾಡಿ.\n2. ಸ್ಪಷ್ಟವಾಗಿ ಮತ್ತು ನೈಸರ್ಗಿಕವಾಗಿ ಮಾತನಾಡಿ.\n3. ನಿಮ್ಮ ಸಾಧನವು ಅದರ ನೈಸರ್ಗಿಕ ಸ್ಥಿತಿಯಲ್ಲಿ, ನಿಮ್ಮ ಕುತ್ತಿಗೆಯಲ್ಲಿ ಇದೆ ಎಂದು ಖಾತ್ರಿ ಮಾಡಿ.\n\nಅದನ್ನು ರಚಿಸಿದ ನಂತರ, ನೀವು ಯಾವಾಗಲೂ ಅದನ್ನು ಸುಧಾರಿಸಬಹುದು ಅಥವಾ ಮತ್ತೆ ಮಾಡಬಹುದು.';
+  String get goodSampleInstructions => '1. ನೀವು ಸುಮಾರು ಸ್ಥಳದಲ್ಲಿ ಇದ್ದೀರಿ ಎಂದು ಖಾತ್ರಿ ಮಾಡಿ.\n2. ಸ್ಪಷ್ಟವಾಗಿ ಮತ್ತು ನೈಸರ್ಗಿಕವಾಗಿ ಮಾತನಾಡಿ.\n3. ನಿಮ್ಮ ಸಾಧನವು ಅದರ ನೈಸರ್ಗಿಕ ಸ್ಥಿತಿಯಲ್ಲಿ, ನಿಮ್ಮ ಕುತ್ತಿಗೆಯಲ್ಲಿ ಇದೆ ಎಂದು ಖಾತ್ರಿ ಮಾಡಿ.\n\nಅದನ್ನು ರಚಿಸಿದ ನಂತರ, ನೀವು ಯಾವಾಗಲೂ ಅದನ್ನು ಸುಧಾರಿಸಬಹುದು ಅಥವಾ ಮತ್ತೆ ಮಾಡಬಹುದು.';
 
   @override
   String get noDeviceConnectedUseMic => 'ಯಾವುದೇ ಸಾಧನ ಸಂಪರ್ಕಿತವಾಗಿಲ್ಲ. ಫೋನ್ ಮೈಕ್ರೋಫೋನ್ ಬಳಸಲಾಗುವುದು.';
@@ -5692,12 +5568,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get howItWorks => 'ಇದು ಹೇಗೆ ಕೆಲಸ ಮಾಡುತ್ತದೆ';
 
   @override
-  String get dailyScoreExplanation =>
-      'ನಿಮ್ಮ ದೈನಂದಿನ ಸ್ಕೋರ್ ಕರ್ತವ್ಯ ಪೂರ್ಣತೆಯ ಮೇಲೆ ಆಧಾರಿತವಾಗಿದೆ. ನಿಮ್ಮ ಸ್ಕೋರ್ ಸುಧಾರಿಸಲು ನಿಮ್ಮ ಕರ್ತವ್ಯಗಳನ್ನು ಪೂರ್ಣಗೊಳಿಸಿ!';
+  String get dailyScoreExplanation => 'ನಿಮ್ಮ ದೈನಂದಿನ ಸ್ಕೋರ್ ಕರ್ತವ್ಯ ಪೂರ್ಣತೆಯ ಮೇಲೆ ಆಧಾರಿತವಾಗಿದೆ. ನಿಮ್ಮ ಸ್ಕೋರ್ ಸುಧಾರಿಸಲು ನಿಮ್ಮ ಕರ್ತವ್ಯಗಳನ್ನು ಪೂರ್ಣಗೊಳಿಸಿ!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Omi ನಿಮಗೆ ಕಳುಹಿಸುವ ಪ್ರೋಯಾಕ್ಟಿವ್ ಅಧಿಸೂಚನೆಗಳು ಮತ್ತು ಜ್ಞಾಪನೆಗಳ ಆವೃತ್ತಿಯನ್ನು ನಿಯಂತ್ರಿಸಿ.';
+  String get notificationFrequencyDescription => 'Omi ನಿಮಗೆ ಕಳುಹಿಸುವ ಪ್ರೋಯಾಕ್ಟಿವ್ ಅಧಿಸೂಚನೆಗಳು ಮತ್ತು ಜ್ಞಾಪನೆಗಳ ಆವೃತ್ತಿಯನ್ನು ನಿಯಂತ್ರಿಸಿ.';
 
   @override
   String get sliderOff => 'ಆಫ್';
@@ -5790,8 +5664,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get selectApp => 'ಅಪ್ಲಿಕೇಶನ್ ಆರಿಸಿ';
 
   @override
-  String get noChatAppsEnabled =>
-      'ಯಾವುದೇ ಚ್ಯಾಟ್ ಅಪ್ಲಿಕೇಶನ್ ಸಕ್ರಿಯವಾಗಿಲ್ಲ.\n\"ಅಪ್ಲಿಕೇಶನ್ ಸಕ್ರಿಯ ಮಾಡಿ\"ಗೆ ತಾಪಿಸಿ ಕೆಲವುವನ್ನು ಸೇರಿಸಲು.';
+  String get noChatAppsEnabled => 'ಯಾವುದೇ ಚ್ಯಾಟ್ ಅಪ್ಲಿಕೇಶನ್ ಸಕ್ರಿಯವಾಗಿಲ್ಲ.\n\"ಅಪ್ಲಿಕೇಶನ್ ಸಕ್ರಿಯ ಮಾಡಿ\"ಗೆ ತಾಪಿಸಿ ಕೆಲವುವನ್ನು ಸೇರಿಸಲು.';
 
   @override
   String get disable => 'ಅಕ್ರಿಯ ಮಾಡಿ';
@@ -6072,15 +5945,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get cloudProvider => 'Cloud ಪೂರೈತೆ';
 
   @override
-  String get premiumMinutesInfo =>
-      'ಪ್ರತಿ ತಿಂಗಳು 1,200 ಪ್ರೀಮಿಯಂ ನಿಮಿಷಗಳು. On-Device ಟ್ಯಾಬ್ ಅಸೀಮಿತ ಉಚ್ಛ ಲಿಪ್ಯಂತರ ನೀಡುತ್ತದೆ.';
+  String get premiumMinutesInfo => 'ಪ್ರತಿ ತಿಂಗಳು 1,200 ಪ್ರೀಮಿಯಂ ನಿಮಿಷಗಳು. On-Device ಟ್ಯಾಬ್ ಅಸೀಮಿತ ಉಚ್ಛ ಲಿಪ್ಯಂತರ ನೀಡುತ್ತದೆ.';
 
   @override
   String get viewUsage => 'ಬಳಕೆ ವಿವರಿಸಿ';
 
   @override
-  String get localProcessingInfo =>
-      'ಆಡಿಯೋ ಸ್ಥಳೀಯವಾಗಿ ಪ್ರಕ್ರಿಯೆಗೊಳ್ಳುತ್ತದೆ. ಮೊಬೈಲ್ ಇಂಟರ್‌ನೆಟ್ ಇಲ್ಲದೇ ಕೆಲಸ ಮಾಡುತ್ತದೆ, ಹೆಚ್ಚು ಖಾಸಗಿ, ಆದರೆ ಹೆಚ್ಚು ಬ್ಯಾಟರಿ ಬಳಕೆ ಮಾಡುತ್ತದೆ.';
+  String get localProcessingInfo => 'ಆಡಿಯೋ ಸ್ಥಳೀಯವಾಗಿ ಪ್ರಕ್ರಿಯೆಗೊಳ್ಳುತ್ತದೆ. ಮೊಬೈಲ್ ಇಂಟರ್‌ನೆಟ್ ಇಲ್ಲದೇ ಕೆಲಸ ಮಾಡುತ್ತದೆ, ಹೆಚ್ಚು ಖಾಸಗಿ, ಆದರೆ ಹೆಚ್ಚು ಬ್ಯಾಟರಿ ಬಳಕೆ ಮಾಡುತ್ತದೆ.';
 
   @override
   String get model => 'ಮಾದರಿ';
@@ -6089,15 +5960,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get performanceWarning => 'ಕಾರ್ಯಕ್ಷಮತೆ ಎಚ್ಚರಿಕೆ';
 
   @override
-  String get largeModelWarning =>
-      'ಈ ಮಾದರಿ ಗುರುತ್ವವಾಗಿದೆ ಮತ್ತು ಸಂಭವವಾಗಿ ಅಪ್ಲಿಕೇಶನ್ ಅದೃಶ್ಯ ಮಾಡುವುದು ಅಥವಾ ಮೊಬೈಲ್ ಸಾಧನಗಳಲ್ಲಿ ಬಹಳ ನಿಧಾನವಾಗಿ ಚಲಾಯಿಸುವುದು.\n\n\"small\" ಅಥವಾ \"base\" ಶಿಫಾರಸುಮಾಡಲಾಗುತ್ತದೆ.';
+  String get largeModelWarning => 'ಈ ಮಾದರಿ ಗುರುತ್ವವಾಗಿದೆ ಮತ್ತು ಸಂಭವವಾಗಿ ಅಪ್ಲಿಕೇಶನ್ ಅದೃಶ್ಯ ಮಾಡುವುದು ಅಥವಾ ಮೊಬೈಲ್ ಸಾಧನಗಳಲ್ಲಿ ಬಹಳ ನಿಧಾನವಾಗಿ ಚಲಾಯಿಸುವುದು.\n\n\"small\" ಅಥವಾ \"base\" ಶಿಫಾರಸುಮಾಡಲಾಗುತ್ತದೆ.';
 
   @override
   String get usingNativeIosSpeech => 'ಸ್ಥಳೀಯ iOS ಭಾಷಣ ಗುರುತನೆ ಬಳಸುವುದು';
 
   @override
-  String get noModelDownloadRequired =>
-      'ನಿಮ್ಮ ಸಾಧನದ ಸ್ಥಳೀಯ ಭಾಷಣ ಇಂಜಿನ್ ಬಳಸಲಾಗುವುದು. ಯಾವುದೇ ಮಾದರಿ ಡೌನ್‌ಲೋಡ್ ಅಗತ್ಯವಿಲ್ಲ.';
+  String get noModelDownloadRequired => 'ನಿಮ್ಮ ಸಾಧನದ ಸ್ಥಳೀಯ ಭಾಷಣ ಇಂಜಿನ್ ಬಳಸಲಾಗುವುದು. ಯಾವುದೇ ಮಾದರಿ ಡೌನ್‌ಲೋಡ್ ಅಗತ್ಯವಿಲ್ಲ.';
 
   @override
   String get modelReady => 'ಮಾದರಿ ತಯಾರ';
@@ -6154,12 +6023,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get batteryDrainSignificantly => 'ಬ್ಯಾಟರಿ ಕ್ಷರಣವು ಗಮನಾರ್ಹವಾಗಿ ಹೆಚ್ಚುತ್ತದೆ.';
 
   @override
-  String get premiumMinutesMonth =>
-      'ಪ್ರತಿ ತಿಂಗಳು 1,200 ಪ್ರೀಮಿಯಂ ನಿಮಿಷಗಳು. On-Device ಟ್ಯಾಬ್ ಅಸೀಮಿತ ಉಚ್ಛ ಲಿಪ್ಯಂತರ ನೀಡುತ್ತದೆ.';
+  String get premiumMinutesMonth => 'ಪ್ರತಿ ತಿಂಗಳು 1,200 ಪ್ರೀಮಿಯಂ ನಿಮಿಷಗಳು. On-Device ಟ್ಯಾಬ್ ಅಸೀಮಿತ ಉಚ್ಛ ಲಿಪ್ಯಂತರ ನೀಡುತ್ತದೆ.';
 
   @override
-  String get audioProcessedLocally =>
-      'ಆಡಿಯೋ ಸ್ಥಳೀಯವಾಗಿ ಪ್ರಕ್ರಿಯೆಗೊಳ್ಳುತ್ತದೆ. ಮೊಬೈಲ್ ಇಂಟರ್‌ನೆಟ್ ಇಲ್ಲದೇ ಕೆಲಸ ಮಾಡುತ್ತದೆ, ಹೆಚ್ಚು ಖಾಸಗಿ, ಆದರೆ ಹೆಚ್ಚು ಬ್ಯಾಟರಿ ಬಳಕೆ ಮಾಡುತ್ತದೆ.';
+  String get audioProcessedLocally => 'ಆಡಿಯೋ ಸ್ಥಳೀಯವಾಗಿ ಪ್ರಕ್ರಿಯೆಗೊಳ್ಳುತ್ತದೆ. ಮೊಬೈಲ್ ಇಂಟರ್‌ನೆಟ್ ಇಲ್ಲದೇ ಕೆಲಸ ಮಾಡುತ್ತದೆ, ಹೆಚ್ಚು ಖಾಸಗಿ, ಆದರೆ ಹೆಚ್ಚು ಬ್ಯಾಟರಿ ಬಳಕೆ ಮಾಡುತ್ತದೆ.';
 
   @override
   String get languageLabel => 'ಭಾಷೆ';
@@ -6168,8 +6035,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get modelLabel => 'ಮಾದರಿ';
 
   @override
-  String get modelTooLargeWarning =>
-      'ಈ ಮಾದರಿ ಗುರುತ್ವವಾಗಿದೆ ಮತ್ತು ಸಂಭವವಾಗಿ ಅಪ್ಲಿಕೇಶನ್ ಅದೃಶ್ಯ ಮಾಡುವುದು ಅಥವಾ ಮೊಬೈಲ್ ಸಾಧನಗಳಲ್ಲಿ ಬಹಳ ನಿಧಾನವಾಗಿ ಚಲಾಯಿಸುವುದು.\n\n\"small\" ಅಥವಾ \"base\" ಶಿಫಾರಸುಮಾಡಲಾಗುತ್ತದೆ.';
+  String get modelTooLargeWarning => 'ಈ ಮಾದರಿ ಗುರುತ್ವವಾಗಿದೆ ಮತ್ತು ಸಂಭವವಾಗಿ ಅಪ್ಲಿಕೇಶನ್ ಅದೃಶ್ಯ ಮಾಡುವುದು ಅಥವಾ ಮೊಬೈಲ್ ಸಾಧನಗಳಲ್ಲಿ ಬಹಳ ನಿಧಾನವಾಗಿ ಚಲಾಯಿಸುವುದು.\n\n\"small\" ಅಥವಾ \"base\" ಶಿಫಾರಸುಮಾಡಲಾಗುತ್ತದೆ.';
 
   @override
   String get nativeEngineNoDownload => 'ನಿಮ್ಮ ಸಾಧನದ ಸ್ಥಳೀಯ ಭಾಷಣ ಇಂಜಿನ್ ಬಳಸಲಾಗುವುದು. ಯಾವುದೇ ಮಾದರಿ ಡೌನ್‌ಲೋಡ್ ಅಗತ್ಯವಿಲ್ಲ.';
@@ -6208,8 +6074,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi ನ ನಿರ್ಮಿತ ಲೈವ್ ಲಿಪ್ಯಂತರವು ಸ್ವಯಂಚಾಲಿತ ವಕ್ತೃ ಪತ್ತೆ ಮತ್ತು diarization ನೊಂದಿಗೆ ನೈಜ-ಸಮಯ ಸಂಭಾಷಣೆಗಳಿಗೆ ಆಪ್ಟಿಮೈಜ್ ಮಾಡಲಾಗಿದೆ.';
+  String get omiTranscriptionOptimized => 'Omi ನ ನಿರ್ಮಿತ ಲೈವ್ ಲಿಪ್ಯಂತರವು ಸ್ವಯಂಚಾಲಿತ ವಕ್ತೃ ಪತ್ತೆ ಮತ್ತು diarization ನೊಂದಿಗೆ ನೈಜ-ಸಮಯ ಸಂಭಾಷಣೆಗಳಿಗೆ ಆಪ್ಟಿಮೈಜ್ ಮಾಡಲಾಗಿದೆ.';
 
   @override
   String get reset => 'ಮರುಹೊಂದಿಸಿ';
@@ -6429,8 +6294,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'ಸ್ಮೃತಿಗಳಿಂದ ನಿಮ್ಮ ಜ್ಞಾನ ಗ್ರಾಫ್ ನಿರ್ಮಾಣ ಮಾಡುತ್ತಿದೆ...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'ನೀವು ನವೀನ ಸ್ಮೃತಿಗಳನ್ನು ರಚಿಸುವಾಗ ನಿಮ್ಮ ಜ್ಞಾನ ಗ್ರಾಫ್ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನಿರ್ಮಾಣ ಮಾಡುತ್ತದೆ.';
+  String get knowledgeGraphWillBuildAutomatically => 'ನೀವು ನವೀನ ಸ್ಮೃತಿಗಳನ್ನು ರಚಿಸುವಾಗ ನಿಮ್ಮ ಜ್ಞಾನ ಗ್ರಾಫ್ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನಿರ್ಮಾಣ ಮಾಡುತ್ತದೆ.';
 
   @override
   String get buildGraphButton => 'ಗ್ರಾಫ್ ನಿರ್ಮಿಸಿ';
@@ -6666,8 +6530,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get failedToLoadContacts => 'ಸಂಪರ್ಕಗಳನ್ನು ಲೋಡ್ ಮಾಡಲು ವಿಫಲ';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'ಹಂಚಿಕೊಳ್ಳಲು ಸಂಭಾಷಣೆ ಸಿದ್ಧಪಡಿಸಲು ವಿಫಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+  String get failedToPrepareConversationForSharing => 'ಹಂಚಿಕೊಳ್ಳಲು ಸಂಭಾಷಣೆ ಸಿದ್ಧಪಡಿಸಲು ವಿಫಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
   String get couldNotOpenSmsApp => 'SMS ಅಪ್ಲಿಕೇಶನ್ ತೆರೆಯಲಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
@@ -6733,8 +6596,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'ನಿಮ್ಮ ಸಾಧನದ SD ಕಾರ್ಡ್‌ನಿಂದ ಆಡಿಯೋ ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತಿದೆ';
 
   @override
-  String get transferRequiredDescription =>
-      'ಈ ರೆಕಾರ್ಡಿಂಗ್ ನಿಮ್ಮ ಸಾಧನದ SD ಕಾರ್ಡ್‌ನಲ್ಲಿ ಸೂಕ್ತಿಸಲಾಗಿದೆ. ಸ್ವಯಂಚಾಲಿತ ಮತ್ತು ಹಂಚಿಕೊಳ್ಳಲು ಅದನ್ನು ನಿಮ್ಮ ಫೋನ್‌ನೆ ವರ್ಗಾವಣೆ ಮಾಡಿ.';
+  String get transferRequiredDescription => 'ಈ ರೆಕಾರ್ಡಿಂಗ್ ನಿಮ್ಮ ಸಾಧನದ SD ಕಾರ್ಡ್‌ನಲ್ಲಿ ಸೂಕ್ತಿಸಲಾಗಿದೆ. ಸ್ವಯಂಚಾಲಿತ ಮತ್ತು ಹಂಚಿಕೊಳ್ಳಲು ಅದನ್ನು ನಿಮ್ಮ ಫೋನ್‌ನೆ ವರ್ಗಾವಣೆ ಮಾಡಿ.';
 
   @override
   String get cancelTransfer => 'ವರ್ಗಾವಣೆ ರದ್ದು ಮಾಡಿ';
@@ -6755,8 +6617,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get shareRecording => 'ರೆಕಾರ್ಡಿಂಗ್ ಹಂಚಿಕೊಳ್ಳಿ';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'ನೀವು ಈ ರೆಕಾರ್ಡಿಂಗ್ ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲು ನಿಶ್ಚಿತವಾಗಿ ಬಯಸಿದ್ದೀರಾ? ಇದನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ.';
+  String get deleteRecordingConfirmation => 'ನೀವು ಈ ರೆಕಾರ್ಡಿಂಗ್ ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲು ನಿಶ್ಚಿತವಾಗಿ ಬಯಸಿದ್ದೀರಾ? ಇದನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗುವುದಿಲ್ಲ.';
 
   @override
   String get recordingIdLabel => 'ರೆಕಾರ್ಡಿಂಗ್ ID';
@@ -6815,15 +6676,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get enableFastTransfer => 'ವೇಗದ ವರ್ಗಾವಣೆ ಸಕ್ರಿಯಗೊಳಿಸಿ';
 
   @override
-  String get fastTransferDescription =>
-      'ವೇಗದ ವರ್ಗಾವಣೆ WiFi ಬಳಸಿ ಸುಮಾರು 5 ಪಟ್ಟು ವೇಗವಾನ ಗತಿಯನ್ನು ಬಳಸುತ್ತದೆ. ವರ್ಗಾವಣೆಯ ಸಮಯದಲ್ಲಿ ನಿಮ್ಮ ಫೋನ್ ಠಾಯಿ Omi ಸಾಧನದ WiFi ನೆಟ್ವರ್ಕ್ಗೆ ಠಾಯಿಗೆ ಸಂಪರ್ಕ ಸ್ಥಾಪಿಸುತ್ತದೆ.';
+  String get fastTransferDescription => 'ವೇಗದ ವರ್ಗಾವಣೆ WiFi ಬಳಸಿ ಸುಮಾರು 5 ಪಟ್ಟು ವೇಗವಾನ ಗತಿಯನ್ನು ಬಳಸುತ್ತದೆ. ವರ್ಗಾವಣೆಯ ಸಮಯದಲ್ಲಿ ನಿಮ್ಮ ಫೋನ್ ಠಾಯಿ Omi ಸಾಧನದ WiFi ನೆಟ್ವರ್ಕ್ಗೆ ಠಾಯಿಗೆ ಸಂಪರ್ಕ ಸ್ಥಾಪಿಸುತ್ತದೆ.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'ವರ್ಗಾವಣೆಯ ಸಮಯದಲ್ಲಿ ಇಂಟರ್ನೆಟ್ ಪ್ರವೇಶ ಸ್ಥಗಿತಗೊಂಡಿದೆ';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'ರೆಕಾರ್ಡಿಂಗ್ಗಳನ್ನು ನಿಮ್ಮ Omi ಸಾಧನದಿಂದ ಫೋನ್ಗೆ ವರ್ಗಾವಣೆ ಮಾಡುವ ವಿಧಾನವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ.';
+  String get chooseTransferMethodDescription => 'ರೆಕಾರ್ಡಿಂಗ್ಗಳನ್ನು ನಿಮ್ಮ Omi ಸಾಧನದಿಂದ ಫೋನ್ಗೆ ವರ್ಗಾವಣೆ ಮಾಡುವ ವಿಧಾನವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ.';
 
   @override
   String get wifiSpeed => 'WiFi ಮೂಲಕ ~150 KB/s';
@@ -6832,8 +6691,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get fiveTimesFaster => '5X ವೇಗವಾಯಿತು';
 
   @override
-  String get fastTransferMethodDescription =>
-      'ನಿಮ್ಮ Omi ಸಾಧನಕ್ಕೆ ನೇರ WiFi ಸಂಪರ್ಕವನ್ನು ರಚಿಸುತ್ತದೆ. ನಿಮ್ಮ ಫೋನ್ ವರ್ಗಾವಣೆಯ ಸಮಯದಲ್ಲಿ ಠಾಯಿಗೆ ಸಾಮಾನ್ಯ WiFi ನಿಂದ ಸಂಪರ್ಕವಿಚ್ಛಿನ್ನ ಆಗುತ್ತದೆ.';
+  String get fastTransferMethodDescription => 'ನಿಮ್ಮ Omi ಸಾಧನಕ್ಕೆ ನೇರ WiFi ಸಂಪರ್ಕವನ್ನು ರಚಿಸುತ್ತದೆ. ನಿಮ್ಮ ಫೋನ್ ವರ್ಗಾವಣೆಯ ಸಮಯದಲ್ಲಿ ಠಾಯಿಗೆ ಸಾಮಾನ್ಯ WiFi ನಿಂದ ಸಂಪರ್ಕವಿಚ್ಛಿನ್ನ ಆಗುತ್ತದೆ.';
 
   @override
   String get bluetooth => 'ಬ್ಲೂಟೂತ್';
@@ -6842,8 +6700,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get bleSpeed => 'BLE ಮೂಲಕ ~30 KB/s';
 
   @override
-  String get bluetoothMethodDescription =>
-      'ಪ್ರಮಾಣಿತ ಬ್ಲೂಟೂತ್ ಲೋ ಎನರ್ಜಿ ಸಂಪರ್ಕವನ್ನು ಬಳಸುತ್ತದೆ. ನಿಧಾನ ಆದರೆ ನಿಮ್ಮ WiFi ಸಂಪರ್ಕದ ಮೇಲೆ ಪ್ರಭಾವ ಬೀರುವುದಿಲ್ಲ.';
+  String get bluetoothMethodDescription => 'ಪ್ರಮಾಣಿತ ಬ್ಲೂಟೂತ್ ಲೋ ಎನರ್ಜಿ ಸಂಪರ್ಕವನ್ನು ಬಳಸುತ್ತದೆ. ನಿಧಾನ ಆದರೆ ನಿಮ್ಮ WiFi ಸಂಪರ್ಕದ ಮೇಲೆ ಪ್ರಭಾವ ಬೀರುವುದಿಲ್ಲ.';
 
   @override
   String get selected => 'ಆಯ್ಕೆಗೊಂಡ';
@@ -6881,12 +6738,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get appDeleteFailed => 'ಅ್ಯಪ್ ಅಳಿಸಲು ವಿಫಲವಾಗಿದೆ. ದಯವಿಟ್ಟು ನಂತರ ಪುನಃ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'ಅ್ಯಪ್ ದೃಶ್ಯಮಾನತೆ ಯಶಸ್ವಿಯಾಗಿ ಬದಲಾಯಿತು. ಇದನ್ನು ಪ್ರತಿಫಲಿತ ಮಾಡಲು ಕೆಲವು ನಿಮಿಷಗಳನ್ನು ತೆಗೆದುಕೊಂಡು ಬಹುದು.';
+  String get appVisibilityChangedSuccessfully => 'ಅ್ಯಪ್ ದೃಶ್ಯಮಾನತೆ ಯಶಸ್ವಿಯಾಗಿ ಬದಲಾಯಿತು. ಇದನ್ನು ಪ್ರತಿಫಲಿತ ಮಾಡಲು ಕೆಲವು ನಿಮಿಷಗಳನ್ನು ತೆಗೆದುಕೊಂಡು ಬಹುದು.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'ಅ್ಯಪ್ ಸಕ್ರಿಯಗೊಳಿಸುವಲ್ಲಿ ದೋಷ. ಇದು ಇಂಟಿಗ್ರೇಶನ್ ಅ್ಯಪ್ ಆಗಿದ್ದರೆ, ಸೆಟಪ್ ಪೂರ್ಣಾಗಿದೆ ಎಂದು ಖಚಿತಪಡಿಸಿ.';
+  String get errorActivatingAppIntegration => 'ಅ್ಯಪ್ ಸಕ್ರಿಯಗೊಳಿಸುವಲ್ಲಿ ದೋಷ. ಇದು ಇಂಟಿಗ್ರೇಶನ್ ಅ್ಯಪ್ ಆಗಿದ್ದರೆ, ಸೆಟಪ್ ಪೂರ್ಣಾಗಿದೆ ಎಂದು ಖಚಿತಪಡಿಸಿ.';
 
   @override
   String get errorUpdatingAppStatus => 'ಅ್ಯಪ್ ಸ್ಥಿತಿ ನವೀಕರಣ ಮಾಡುವಲ್ಲಿ ದೋಷ ಸಂಭವಿಸಿದೆ.';
@@ -6954,8 +6809,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get importantConversationTitle => 'ಮುಖ್ಯ ಸಂಭಾಷಣೆ';
 
   @override
-  String get importantConversationBody =>
-      'ನೀವು ಒಂದು ಪ್ರಮುಖ ಸಂಭಾಷಣೆ ಹೊಂದಿದ್ದೀರಿ. ಇತರರೊಂದಿಗೆ ಸಾರಾಂಶ ಹಂಚಿಕೊಳ್ಳಲು ಟ್ಯಾಪ್ ಮಾಡಿ.';
+  String get importantConversationBody => 'ನೀವು ಒಂದು ಪ್ರಮುಖ ಸಂಭಾಷಣೆ ಹೊಂದಿದ್ದೀರಿ. ಇತರರೊಂದಿಗೆ ಸಾರಾಂಶ ಹಂಚಿಕೊಳ್ಳಲು ಟ್ಯಾಪ್ ಮಾಡಿ.';
 
   @override
   String get templateName => 'ಟೆಂಪ್ಲೇಟ್ ಹೆಸರು';
@@ -6967,8 +6821,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'ಹೆಸರು ಕನಿಷ್ಠ 3 ಅಕ್ಷರ ಆಗಿರಬೇಕು';
 
   @override
-  String get conversationPromptHint =>
-      'ಉದಾಹರಣೆ, ಕ್ರಿಯಾ ಐಟಮ್ಗಳು, ನೆರವೆತರಿಸಿದ ನಿರ್ಣಯಗಳು ಮತ್ತು ಸಾಲಿಸಿದ ಪ್ರದಾನಗಳನ್ನು ಪಡೆಯಿರಿ.';
+  String get conversationPromptHint => 'ಉದಾಹರಣೆ, ಕ್ರಿಯಾ ಐಟಮ್ಗಳು, ನೆರವೆತರಿಸಿದ ನಿರ್ಣಯಗಳು ಮತ್ತು ಸಾಲಿಸಿದ ಪ್ರದಾನಗಳನ್ನು ಪಡೆಯಿರಿ.';
 
   @override
   String get pleaseEnterAppPrompt => 'ದಯವಿಟ್ಟು ನಿಮ್ಮ ಅ್ಯಪ್ಗೆ ಸೂಚನೆ ನಮೂದಿಸಿ';
@@ -7050,8 +6903,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'ಚಿತ್ರಗಳ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ಚಿತ್ರ ಆಯ್ಕೆ ಮಾಡಲು ಚಿತ್ರಗಳನ್ನು ಪ್ರವೇಶಾಧಿಕಾರ ಕಲ್ಪನೆ';
+  String get addAppPhotosPermissionDenied => 'ಚಿತ್ರಗಳ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ಚಿತ್ರ ಆಯ್ಕೆ ಮಾಡಲು ಚಿತ್ರಗಳನ್ನು ಪ್ರವೇಶಾಧಿಕಾರ ಕಲ್ಪನೆ';
 
   @override
   String get addAppErrorSelectingImageRetry => 'ಚಿತ್ರ ಆಯ್ಕೆ ಮಾಡುವಲ್ಲಿ ದೋಷ. ದಯವಿಟ್ಟು ಪುನಃ ಪ್ರಯತ್ನಿಸಿ.';
@@ -7156,15 +7008,13 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'ಅಪ್‌ಗ್ರೇಡ್ ನಿಗದಿತಗೊಂಡಿದೆ! ನಿಮ್ಮ ಮಾಸಿಕ ಯೋಜನೆ ನಿಮ್ಮ ಬಿಲಿಂಗ್ ಅವಧಿಯ ಅಂತ್ಯ ವರೆಗೆ ಮುಂದುವರಿಯುತ್ತದೆ, ನಂತರ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ವಾರ್ಷಿಕಕ್ಕೆ ಬದಲಾಗುತ್ತದೆ.';
+  String get planUpgradeScheduledMessage => 'ಅಪ್‌ಗ್ರೇಡ್ ನಿಗದಿತಗೊಂಡಿದೆ! ನಿಮ್ಮ ಮಾಸಿಕ ಯೋಜನೆ ನಿಮ್ಮ ಬಿಲಿಂಗ್ ಅವಧಿಯ ಅಂತ್ಯ ವರೆಗೆ ಮುಂದುವರಿಯುತ್ತದೆ, ನಂತರ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ವಾರ್ಷಿಕಕ್ಕೆ ಬದಲಾಗುತ್ತದೆ.';
 
   @override
   String get couldNotSchedulePlanChange => 'ಯೋಜನೆ ಬದಲಾವಣೆ ನಿಗದಿತ ಮಾಡಲಾಗುವುದಿಲ್ಲ. ದಯವಿಟ್ಟು ಪುನಃ ಪ್ರಯತ್ನಿಸಿ.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'ನಿಮ್ಮ ಅನುಕ್ರಮಣ ಪುನರ್ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ! ಈಗ ಯಾವುದೇ ಶುಲ್ಕ ಇಲ್ಲ - ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಅವಧಿಯ ಅಂತ್ಯದಲ್ಲಿ ನೀವು ಬಿಲ್ ಮಾಡಲಾಗುತ್ತದೆ.';
+  String get subscriptionReactivatedDefault => 'ನಿಮ್ಮ ಅನುಕ್ರಮಣ ಪುನರ್ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ! ಈಗ ಯಾವುದೇ ಶುಲ್ಕ ಇಲ್ಲ - ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಅವಧಿಯ ಅಂತ್ಯದಲ್ಲಿ ನೀವು ಬಿಲ್ ಮಾಡಲಾಗುತ್ತದೆ.';
 
   @override
   String get subscriptionSuccessfulCharged => 'ಅನುಕ್ರಮಣ ಯಶಸ್ವಿ! ನೀವು ಹೊಸ ಬಿಲಿಂಗ್ ಅವಧಿಗೆ ಚಾರ್ಜ್ ಆಯಿತು.';
@@ -7347,8 +7197,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get onboardingBluetoothRequired => 'ಸಾಧನಕ್ಕೆ ಸಂಪರ್ಕಿಸಲು ಬ್ಲೂಟೂತ್ ಅನುಮತಿ ಅಗತ್ಯ.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'ಬ್ಲೂಟೂತ್ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ಗಲ್ಲಿ ಅನುಮತಿ ನೀಡಿ.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'ಬ್ಲೂಟೂತ್ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ಗಲ್ಲಿ ಅನುಮತಿ ನೀಡಿ.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7361,12 +7210,10 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'ಅಧಿಸೂಚನೆ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ಗಲ್ಲಿ ಅನುಮತಿ ನೀಡಿ.';
+  String get onboardingNotificationDeniedSystemPrefs => 'ಅಧಿಸೂಚನೆ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ಗಲ್ಲಿ ಅನುಮತಿ ನೀಡಿ.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'ಅಧಿಸೂಚನೆ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ > ಅಧಿಸೂಚನೆಗಳಿಂದ ಅನುಮತಿ ನೀಡಿ.';
+  String get onboardingNotificationDeniedNotifications => 'ಅಧಿಸೂಚನೆ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ > ಅಧಿಸೂಚನೆಗಳಿಂದ ಅನುಮತಿ ನೀಡಿ.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7379,15 +7226,13 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'ದಯವಿಟ್ಟು ಸೆಟ್ಟಿಂಗ್ > ಗೋಪನೀಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಸ್ಥಳ ಸೇವೆಗಳಿಂದ ಸ್ಥಾನ ಅನುಮತಿ ನೀಡಿ';
+  String get onboardingLocationGrantInSettings => 'ದಯವಿಟ್ಟು ಸೆಟ್ಟಿಂಗ್ > ಗೋಪನೀಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಸ್ಥಳ ಸೇವೆಗಳಿಂದ ಸ್ಥಾನ ಅನುಮತಿ ನೀಡಿ';
 
   @override
   String get onboardingMicrophoneRequired => 'ರೆಕಾರ್ಡಿಂಗ್ಗೆ ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ ಅಗತ್ಯ.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ > ಗೋಪನೀಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ ನೀಡಿ.';
+  String get onboardingMicrophoneDenied => 'ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ > ಗೋಪನೀಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಮೈಕ್ರೋಫೋನ್ ಅನುಮತಿ ನೀಡಿ.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7403,8 +7248,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'ಸಿಸ್ಟಮ್ ಆಡಿಯೋ ರೆಕಾರ್ಡಿಂಗ್ಗೆ ಪರದೆ ಸೆರೆತೆಗೆ ಅನುಮತಿ ಅಗತ್ಯ.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'ಪರದೆ ಸೆರೆತೆಗೆ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ > ಗೋಪನೀಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಸ್ಕ್ರೀನ್ ರೆಕಾರ್ಡಿಂಗ್ ಅನುಮತಿ ನೀಡಿ.';
+  String get onboardingScreenCaptureDenied => 'ಪರದೆ ಸೆರೆತೆಗೆ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಸಿಸ್ಟಮ್ ಪ್ರೇಫರೆನ್ಸಿಂಗ್ > ಗೋಪನೀಯತೆ ಮತ್ತು ಸುರಕ್ಷೆ > ಸ್ಕ್ರೀನ್ ರೆಕಾರ್ಡಿಂಗ್ ಅನುಮತಿ ನೀಡಿ.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7433,8 +7277,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get msgCameraNotAvailable => 'ಕ್ಯಾಮೆರಾ ಸೆರೆತೆ ಈ ವೇದಿಕೆಯಲ್ಲಿ ಲಭ್ಯವಿಲ್ಲ';
 
   @override
-  String get msgCameraPermissionDenied =>
-      'ಕ್ಯಾಮೆರಾ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಕ್ಯಾಮೆರಾಗೆ ಪ್ರವೇಶಾಧಿಕಾರ ಅನುಮತಿ ನೀಡಿ';
+  String get msgCameraPermissionDenied => 'ಕ್ಯಾಮೆರಾ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಕ್ಯಾಮೆರಾಗೆ ಪ್ರವೇಶಾಧಿಕಾರ ಅನುಮತಿ ನೀಡಿ';
 
   @override
   String msgCameraAccessError(String error) {
@@ -7458,8 +7301,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'ಚಿತ್ರಗಳ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಚಿತ್ರಗಳನ್ನು ಆಯ್ಕೆ ಮಾಡಲು ಚಿತ್ರಗಳನ್ನು ಪ್ರವೇಶಾಧಿಕಾರ ಅನುಮತಿ ನೀಡಿ';
+  String get msgPhotosPermissionDenied => 'ಚಿತ್ರಗಳ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ದಯವಿಟ್ಟು ಚಿತ್ರಗಳನ್ನು ಆಯ್ಕೆ ಮಾಡಲು ಚಿತ್ರಗಳನ್ನು ಪ್ರವೇಶಾಧಿಕಾರ ಅನುಮತಿ ನೀಡಿ';
 
   @override
   String get msgSelectImagesGenericError => 'ಚಿತ್ರಗಳನ್ನು ಆಯ್ಕೆ ಮಾಡುವಲ್ಲಿ ದೋಷ. ದಯವಿಟ್ಟು ಪುನಃ ಪ್ರಯತ್ನಿಸಿ.';
@@ -7531,8 +7373,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get locationPermissionRequired => 'ಸ್ಥಳ ಅನುಮತಿ ಅಗತ್ಯ';
 
   @override
-  String get locationPermissionContent =>
-      'ವೇಗದ ವರ್ಗಾವಣೆ WiFi ಸಂಪರ್ಕ ಪರಿಶೀಲಿಸಲು ಸ್ಥಳ ಅನುಮತಿ ಅಗತ್ಯ. ದಯವಿಟ್ಟು ಸ್ಥಳ ಅನುಮತಿ ನೀಡಿ ಮುಂದುವರೆಯಲು.';
+  String get locationPermissionContent => 'ವೇಗದ ವರ್ಗಾವಣೆ WiFi ಸಂಪರ್ಕ ಪರಿಶೀಲಿಸಲು ಸ್ಥಳ ಅನುಮತಿ ಅಗತ್ಯ. ದಯವಿಟ್ಟು ಸ್ಥಳ ಅನುಮತಿ ನೀಡಿ ಮುಂದುವರೆಯಲು.';
 
   @override
   String get pdfTranscriptExport => 'ಟ್ರಾನ್ಸ್‌ಕ್ರಿಪ್ಟ್ ರಕಷ್ಯ';
@@ -7695,8 +7536,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'ಸಾಧನವು WiFi ಸಿಂಕ್ ಬೆಂಬಲಿಸುವುದಿಲ್ಲ, ಬ್ಲೂಟೂತ್ಗೆ ಬದಲಾಯಿಸಿಕೊಳ್ಳುತ್ತಿದೆ';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'ಸಾಧನವು WiFi ಸಿಂಕ್ ಬೆಂಬಲಿಸುವುದಿಲ್ಲ, ಬ್ಲೂಟೂತ್ಗೆ ಬದಲಾಯಿಸಿಕೊಳ್ಳುತ್ತಿದೆ';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health ಈ ಸಾಧನದಲ್ಲಿ ಲಭ್ಯವಿಲ್ಲ';
@@ -7992,8 +7832,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Omi DevKit ಅನ್ನು ಜೋಡಣೆ ಮೋಡ್‌ಗಿಂದ ಹೊಂದಿಸಿ';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'ಚಾಲು ಮಾಡಲು ಬಟನ್ ಒಮ್ಮೆ ಒತ್ತಿ. ಜೋಡಣೆ ಮೋಡ್ ತಯಾರಿಸುವಾಗ LED ನೇರಳೆ ಬಣ್ಣದಲ್ಲಿ ಮಿನುಗುತ್ತದೆ.';
+  String get pairingDescOmiDevkit => 'ಚಾಲು ಮಾಡಲು ಬಟನ್ ಒಮ್ಮೆ ಒತ್ತಿ. ಜೋಡಣೆ ಮೋಡ್ ತಯಾರಿಸುವಾಗ LED ನೇರಳೆ ಬಣ್ಣದಲ್ಲಿ ಮಿನುಗುತ್ತದೆ.';
 
   @override
   String get pairingTitleOmiGlass => 'Omi Glass ಅನ್ನು ಚಾಲು ಮಾಡಿ';
@@ -8005,8 +7844,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note ಅನ್ನು ಜೋಡಣೆ ಮೋಡ್‌ಗಿಂದ ಹೊಂದಿಸಿ';
 
   @override
-  String get pairingDescPlaudNote =>
-      'ಪಕ್ಷದ ಬಟನ್ ಅನ್ನು 2 ಸೆಕೆಂಡುಗಳ ಕಾಲ ಒತ್ತಿ. ಕೆಂಪು LED ಜೋಡಣೆಗೆ ಸಿದ್ಧವಾದಾಗ ಮಿನುಗುತ್ತದೆ.';
+  String get pairingDescPlaudNote => 'ಪಕ್ಷದ ಬಟನ್ ಅನ್ನು 2 ಸೆಕೆಂಡುಗಳ ಕಾಲ ಒತ್ತಿ. ಕೆಂಪು LED ಜೋಡಣೆಗೆ ಸಿದ್ಧವಾದಾಗ ಮಿನುಗುತ್ತದೆ.';
 
   @override
   String get pairingTitleBee => 'Bee ಅನ್ನು ಜೋಡಣೆ ಮೋಡ್‌ಗಿಂದ ಹೊಂದಿಸಿ';
@@ -8018,15 +7856,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get pairingTitleLimitless => 'Limitless ಅನ್ನು ಜೋಡಣೆ ಮೋಡ್‌ಗಿಂದ ಹೊಂದಿಸಿ';
 
   @override
-  String get pairingDescLimitless =>
-      'ಯಾವುದೇ ಬೆಳಕು ಕಾಣಿಸುತ್ತಿದ್ದರೆ, ಒಮ್ಮೆ ಒತ್ತಿ ತದನಂತರ ಸಾಧನ ಗುಲಾಬಿ ಬೆಳಕನ್ನು ತೋರುವವರೆಗೆ ಧರಿಸಿ ಅನಂತರ ಬಿಡಿ.';
+  String get pairingDescLimitless => 'ಯಾವುದೇ ಬೆಳಕು ಕಾಣಿಸುತ್ತಿದ್ದರೆ, ಒಮ್ಮೆ ಒತ್ತಿ ತದನಂತರ ಸಾಧನ ಗುಲಾಬಿ ಬೆಳಕನ್ನು ತೋರುವವರೆಗೆ ಧರಿಸಿ ಅನಂತರ ಬಿಡಿ.';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant ಅನ್ನು ಜೋಡಣೆ ಮೋಡ್‌ಗಿಂದ ಹೊಂದಿಸಿ';
 
   @override
-  String get pairingDescFriendPendant =>
-      'ಪೆಂಡೆಂಟ್ ಪರ ಬಟನ್ ಅನ್ನು ಒತ್ತಿ ಅದನ್ನು ಚಾಲು ಮಾಡಿ. ಇದು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಜೋಡಣೆ ಮೋಡ್‌ಗೆ ಸೇರುತ್ತದೆ.';
+  String get pairingDescFriendPendant => 'ಪೆಂಡೆಂಟ್ ಪರ ಬಟನ್ ಅನ್ನು ಒತ್ತಿ ಅದನ್ನು ಚಾಲು ಮಾಡಿ. ಇದು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಜೋಡಣೆ ಮೋಡ್‌ಗೆ ಸೇರುತ್ತದೆ.';
 
   @override
   String get pairingTitleFieldy => 'Fieldy ಅನ್ನು ಜೋಡಣೆ ಮೋಡ್‌ಗಿಂದ ಹೊಂದಿಸಿ';
@@ -8038,8 +7874,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch ಸಂಪರ್ಕ ಮಾಡಿ';
 
   @override
-  String get pairingDescAppleWatch =>
-      'ನಿಮ್ಮ Apple Watch ಪರ Omi ಅಪ್ಲಿಕೇಶನ ಅನ್ನು ಸ್ಥಾಪನ ಮಾಡಿ ಮತ್ತು ತೆರೆಯಿರಿ, ತದನಂತರ ಅಪ್ಲಿಕೇಶನ ತಲುಪ ಮಾಡಲು ಸಂಪರ್ಕಿಸಿ.';
+  String get pairingDescAppleWatch => 'ನಿಮ್ಮ Apple Watch ಪರ Omi ಅಪ್ಲಿಕೇಶನ ಅನ್ನು ಸ್ಥಾಪನ ಮಾಡಿ ಮತ್ತು ತೆರೆಯಿರಿ, ತದನಂತರ ಅಪ್ಲಿಕೇಶನ ತಲುಪ ಮಾಡಲು ಸಂಪರ್ಕಿಸಿ.';
 
   @override
   String get pairingTitleNeoOne => 'Neo One ಅನ್ನು ಜೋಡಣೆ ಮೋಡ್‌ಗಿಂದ ಹೊಂದಿಸಿ';
@@ -8133,8 +7968,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'ನಾನು ನಿಮ್ಮ ಬಗ್ಗೆ ತಿಳಿದುಕೊಂಡಿರುವುದು ಇಲ್ಲಿ';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'ಈ ನಕ್ಷೆ Omi ನಿಮ್ಮ ಸಂವಾದದಿಂದ ಕಲಿಯುತ್ತಿದ್ದುದಾಗಿ ನವೀಕರಿತ ಮಾಡಲಾಗುತ್ತದೆ.';
+  String get onboardingWhatIKnowAboutYouDescription => 'ಈ ನಕ್ಷೆ Omi ನಿಮ್ಮ ಸಂವಾದದಿಂದ ಕಲಿಯುತ್ತಿದ್ದುದಾಗಿ ನವೀಕರಿತ ಮಾಡಲಾಗುತ್ತದೆ.';
 
   @override
   String get apiEnvironment => 'API ಪರಿವೇಶ';
@@ -8163,8 +7997,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get switchAndRestart => 'ಪರಿವರ್ತನೆ';
 
   @override
-  String get stagingDisclaimer =>
-      'ಕ್ರಮಾವಳಿ ದೋಷೀಯ, ನೈರ್ಮಾಲ್ಯ ಕಾರ್ಯಕ್ಷಮತೆ ಮತ್ತು ವಿಷಯಗಳು ಅಗತ್ಯ ಪ್ರದರ್ಶನ ಬೇಕು. ಪರೀಕ್ಷೆಯ ಜನ್ಯವಾಗಿ ಉಪಯೋಗಿಸಿ.';
+  String get stagingDisclaimer => 'ಕ್ರಮಾವಳಿ ದೋಷೀಯ, ನೈರ್ಮಾಲ್ಯ ಕಾರ್ಯಕ್ಷಮತೆ ಮತ್ತು ವಿಷಯಗಳು ಅಗತ್ಯ ಪ್ರದರ್ಶನ ಬೇಕು. ಪರೀಕ್ಷೆಯ ಜನ್ಯವಾಗಿ ಉಪಯೋಗಿಸಿ.';
 
   @override
   String get apiEnvSavedRestartRequired => 'ಸಂಸ್ಕರಣಾ ಮಾಡಲಾಗಿದೆ. ಅನ್ವಯಿಸಲು ಅಪ್ಲಿಕೇಶನ ಮುಚ್ಚಿ ಮರುತೆರೆಯಿರಿ.';
@@ -8215,8 +8048,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get phoneGetStarted => 'ಪ್ರಾರಂಭ ಮಾಡಿ';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'ಕರೆ ರೆಕಾರ್ಡಿಂಗ್ ನಿಮ್ಮ ನ್ಯಾಯವ್ಯವಸ್ಥೆಗಳಲ್ಲಿ ಮತ್ತಿಸುವುದು ಅಗತ್ಯ ಭಾವಿಸುತ್ತವೆ';
+  String get callRecordingConsentDisclaimer => 'ಕರೆ ರೆಕಾರ್ಡಿಂಗ್ ನಿಮ್ಮ ನ್ಯಾಯವ್ಯವಸ್ಥೆಗಳಲ್ಲಿ ಮತ್ತಿಸುವುದು ಅಗತ್ಯ ಭಾವಿಸುತ್ತವೆ';
 
   @override
   String get enterYourNumber => 'ನಿಮ್ಮ ಸಂಖ್ಯೆ ನಿರ್ಬಂಧಿಸಿ';
@@ -8394,8 +8226,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Omi ನೊಂದಿಗೆ ಫೋನ್ ಕರೆ';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Omi ನೊಂದಿಗೆ ಕರೆ ಮಾಡಿ ಮತ್ತು ನೈಜ ಸಮಯದ ಪ್ರತಿಲೇಖನ, ಸ್ವಯಂಚಾಲಿತ ಸಾರಾಂಶಗಳು ಮತ್ತು ಬೆಂಬಲ ಪಡೆ. Unlimited ಯೋಜನೆ ಸಂರಕ್ಷಣೆಗಳ ಲಿಆ ನಿರ್ಧಾರಿತ.';
+  String get phoneCallsUpsellSubtitle => 'Omi ನೊಂದಿಗೆ ಕರೆ ಮಾಡಿ ಮತ್ತು ನೈಜ ಸಮಯದ ಪ್ರತಿಲೇಖನ, ಸ್ವಯಂಚಾಲಿತ ಸಾರಾಂಶಗಳು ಮತ್ತು ಬೆಂಬಲ ಪಡೆ. Unlimited ಯೋಜನೆ ಸಂರಕ್ಷಣೆಗಳ ಲಿಆ ನಿರ್ಧಾರಿತ.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'ಪ್ರತಿಲೇಖನ ನೈಜ ಸಮಯದ ಪ್ರತಿಲೇಖನ';
@@ -8422,8 +8253,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deleteSyncedFiles => 'ಸಮನ್ವಯಿತ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಅಳಿಸಿ';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'ಈ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಈಗಾಗಲೇ ನಿಮ್ಮ ಫೋನಕ್ಕೆ ಸಮನ್ವಯ ಮಾಡಲಾಗಿದೆ. ಇದನ್ನು ರದ್ದುಗೊಳಿಸಲು ಸಾಧ್ಯ.';
+  String get deleteSyncedFilesMessage => 'ಈ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಈಗಾಗಲೇ ನಿಮ್ಮ ಫೋನಕ್ಕೆ ಸಮನ್ವಯ ಮಾಡಲಾಗಿದೆ. ಇದನ್ನು ರದ್ದುಗೊಳಿಸಲು ಸಾಧ್ಯ.';
 
   @override
   String get syncedFilesDeleted => 'ಸಮನ್ವಯಿತ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಅಳಿಸಿದೆ';
@@ -8435,8 +8265,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deletePendingFiles => 'ಪಕ್ಷಾನುಮತಿ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಅಳಿಸಿ';
 
   @override
-  String get deletePendingFilesWarning =>
-      'ಈ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ನಿಮ್ಮ ಫೋನಕ್ಕೆ ಸಮನ್ವಯ ಮಾಡಿಲ್ಲ ಮತ್ತು ಶಾಶ್ವತವಾಗಿ ಸೋಲಾಗುತ್ತವೆ. ಇದನ್ನು ರದ್ದುಗೊಳಿಸಲು ಸಾಧ್ಯ.';
+  String get deletePendingFilesWarning => 'ಈ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ನಿಮ್ಮ ಫೋನಕ್ಕೆ ಸಮನ್ವಯ ಮಾಡಿಲ್ಲ ಮತ್ತು ಶಾಶ್ವತವಾಗಿ ಸೋಲಾಗುತ್ತವೆ. ಇದನ್ನು ರದ್ದುಗೊಳಿಸಲು ಸಾಧ್ಯ.';
 
   @override
   String get pendingFilesDeleted => 'ಪಕ್ಷಾನುಮತಿ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಅಳಿಸಿದೆ';
@@ -8448,8 +8277,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deleteAll => 'ಎಲ್ಲವನ್ನೂ ಅಳಿಸಿ';
 
   @override
-  String get deleteAllFilesWarning =>
-      'ಇದು ಸಮನ್ವಯಿತ ಮತ್ತು ಪಕ್ಷಾನುಮತಿ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಅಳಿಸಿ. ಪಕ್ಷಾನುಮತಿ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಸಮನ್ವಯ ಮಾಡಿಲ್ಲ ಮತ್ತು ಶಾಶ್ವತವಾಗಿ ಸೋಲಾಗುತ್ತವೆ. ಇದನ್ನು ರದ್ದುಗೊಳಿಸಲು ಸಾಧ್ಯ.';
+  String get deleteAllFilesWarning => 'ಇದು ಸಮನ್ವಯಿತ ಮತ್ತು ಪಕ್ಷಾನುಮತಿ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಅಳಿಸಿ. ಪಕ್ಷಾನುಮತಿ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಸಮನ್ವಯ ಮಾಡಿಲ್ಲ ಮತ್ತು ಶಾಶ್ವತವಾಗಿ ಸೋಲಾಗುತ್ತವೆ. ಇದನ್ನು ರದ್ದುಗೊಳಿಸಲು ಸಾಧ್ಯ.';
 
   @override
   String get allFilesDeleted => 'ಎಲ್ಲ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಅಳಿಸಿದೆ';
@@ -8514,8 +8342,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get fairUseAboutTitle => 'ನ್ಯಾಯಯುಕ್ತ ಬಳಕೆ ಬಗ್ಗೆ';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi ವ್ಯಕ್ತಿಗತ ಸಂವಾದಗಳು, ಸಭೆಗಳು ಮತ್ತು ನೈಜ ಸಂವಾದಾಭಿವ್ಯಕ್ತಿಗಳಿಗೆ ತರುವನೆ. ಬಳಕೆ ನೈಜ ಭಾಷಣ ಸಮಯ ಗುರುತಿಸಿಣ ಮಾಪಿಸಿ, ಪ್ರಕರಣ ಸಮಯ ನಹೀಂ. ಬಳಕೆ ವ್ಯಕ್ತಿಗತ ನೀಗೆ ವಿಷಯವಿಲ್ಲ ಪಠ್ಯಾಂಶಗಳಿಂದ ಮಾದ ಮಾಡಿದ ಸರ್ವೃತ ಸ್ಫುಟವಾಗಿ ಪಎ, ಅನ್ವಯಗಳನ್ನು ಅನ್ವಯಿಸಬಹುದು.';
+  String get fairUseAboutBody => 'Omi ವ್ಯಕ್ತಿಗತ ಸಂವಾದಗಳು, ಸಭೆಗಳು ಮತ್ತು ನೈಜ ಸಂವಾದಾಭಿವ್ಯಕ್ತಿಗಳಿಗೆ ತರುವನೆ. ಬಳಕೆ ನೈಜ ಭಾಷಣ ಸಮಯ ಗುರುತಿಸಿಣ ಮಾಪಿಸಿ, ಪ್ರಕರಣ ಸಮಯ ನಹೀಂ. ಬಳಕೆ ವ್ಯಕ್ತಿಗತ ನೀಗೆ ವಿಷಯವಿಲ್ಲ ಪಠ್ಯಾಂಶಗಳಿಂದ ಮಾದ ಮಾಡಿದ ಸರ್ವೃತ ಸ್ಫುಟವಾಗಿ ಪಎ, ಅನ್ವಯಗಳನ್ನು ಅನ್ವಯಿಸಬಹುದು.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8553,8 +8380,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get improveConnectionTitle => 'ಸಂಪರ್ಕ ಉಂಚುತ್ತಿರಿ';
 
   @override
-  String get improveConnectionContent =>
-      'ನಾವು Omi ನಿಮ್ಮ ಸಾಧನಗೆ ಸಂಪರ್ಕಿತ ಬಾಕಿ ಕಿ ನೀಪಿಸಿದೆ. ಇದನ್ನು ಸಕ್ರಿಯ ಮಾಡಲು, ದಯವಿಟ್ಟು ಸಾಧನ ಮಾಹಿತಿ ಪುಟಕ್ಕೆ ಹೋಗಿ, \"ವಿಚ್ಛೇದನ ಸಾಧನ\" ತಲುಪ ಮಾಡಿ, ನಂತರ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಮತ್ತೆ ಜೋಡಿಸಿ.';
+  String get improveConnectionContent => 'ನಾವು Omi ನಿಮ್ಮ ಸಾಧನಗೆ ಸಂಪರ್ಕಿತ ಬಾಕಿ ಕಿ ನೀಪಿಸಿದೆ. ಇದನ್ನು ಸಕ್ರಿಯ ಮಾಡಲು, ದಯವಿಟ್ಟು ಸಾಧನ ಮಾಹಿತಿ ಪುಟಕ್ಕೆ ಹೋಗಿ, \"ವಿಚ್ಛೇದನ ಸಾಧನ\" ತಲುಪ ಮಾಡಿ, ನಂತರ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಮತ್ತೆ ಜೋಡಿಸಿ.';
 
   @override
   String get improveConnectionAction => 'ಯೋಚಿಸಿದೆ';
@@ -8609,16 +8435,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get cancelSyncQuestion => 'ಸಮನ್ವಯ ರದ್ದುಗೊಳಿಸುವುದೇ?';
 
   @override
-  String get omisStorageDesc =>
-      'ನಿಮ್ಮ Omi ನಿಮ್ಮ ಫೋನಕ್ಕೆ ಸಂಪರ್ಕಿತವಾಗಿಲ್ಲದಿದ್ದರೆ, ಇದು ಆಡಿಯೋ ಸ್ಥಳೀಯವಾಗಿ ತನ್ನ ಪಟ್ಟೆ ಪಟ್ಟೆಯ ಮೆಮೊರಿ ಸಂಗ್ರಹಣೆಗೆ ಪ್ರಕಿರ್ಣ ಪುರಿಸುತ್ತಾನೆ. ನೀವು ಎಂದೂ ಸ್ಥಾನ ಅಪಜಿಲ್ಲ.';
+  String get omisStorageDesc => 'ನಿಮ್ಮ Omi ನಿಮ್ಮ ಫೋನಕ್ಕೆ ಸಂಪರ್ಕಿತವಾಗಿಲ್ಲದಿದ್ದರೆ, ಇದು ಆಡಿಯೋ ಸ್ಥಳೀಯವಾಗಿ ತನ್ನ ಪಟ್ಟೆ ಪಟ್ಟೆಯ ಮೆಮೊರಿ ಸಂಗ್ರಹಣೆಗೆ ಪ್ರಕಿರ್ಣ ಪುರಿಸುತ್ತಾನೆ. ನೀವು ಎಂದೂ ಸ್ಥಾನ ಅಪಜಿಲ್ಲ.';
 
   @override
-  String get phoneStorageDesc =>
-      'Omi ಮರುಸಂಪರ್ಕಿತವಾದಾಗ, ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನಿಮ್ಮ ಫೋನಕ್ಕೆ ಅಪ್‌ಲೋಡ್ ಆಗಿ ಚೌಕಟ್ಟಿನ ಗೋಪನೀಯತೆ ಶುರುಕೊಲ್ಪಿಸಿ ಮೊದಲು ತೇವೆ.';
+  String get phoneStorageDesc => 'Omi ಮರುಸಂಪರ್ಕಿತವಾದಾಗ, ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ನಿಮ್ಮ ಫೋನಕ್ಕೆ ಅಪ್‌ಲೋಡ್ ಆಗಿ ಚೌಕಟ್ಟಿನ ಗೋಪನೀಯತೆ ಶುರುಕೊಲ್ಪಿಸಿ ಮೊದಲು ತೇವೆ.';
 
   @override
-  String get cloudStorageDesc =>
-      'ಅಪ್‌ಲೋಡ್ ಮಾಡಿದ ನಂತರ, ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಪ್ರಕ್ರಿಯೆ ಮಾಡಲಾಗುತ್ತದೆ ಮತ್ತು ಪ್ರತಿಲೇಖನ ಮಾಡಲಾಗುತ್ತದೆ. ಸಂವಾದಗಳನ್ನು ಮಾಧಿತಿಮೊದ ಒಂದು ಮಿನಿಟ್ ಲಾಗುತ್ತವೆ.';
+  String get cloudStorageDesc => 'ಅಪ್‌ಲೋಡ್ ಮಾಡಿದ ನಂತರ, ನಿಮ್ಮ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳನ್ನು ಪ್ರಕ್ರಿಯೆ ಮಾಡಲಾಗುತ್ತದೆ ಮತ್ತು ಪ್ರತಿಲೇಖನ ಮಾಡಲಾಗುತ್ತದೆ. ಸಂವಾದಗಳನ್ನು ಮಾಧಿತಿಮೊದ ಒಂದು ಮಿನಿಟ್ ಲಾಗುತ್ತವೆ.';
 
   @override
   String get tipKeepPhoneNearby => 'ವೇಗ ಸಮನ್ವಯಾಗಿ ನಿಮ್ಮ ಫೋನ್ ಹತುತ್ಕೇ ಇಕೆ';
@@ -8642,12 +8465,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get permissionEnable => 'ಸಕ್ರಿಯ ಮಾಡಿ';
 
   @override
-  String get permissionsPageDescription =>
-      'ಈ ಪ್ರದೇಶಗಳು Omi ಹೋಕ್ಕೆ ಅನುಕೂಲತಮವಾಗಿದೆ. ಅವು ಸೂಚನೆಗಳು, ನಿಲುವು-ಆಧಾರಿತ ಅನುಭವಗಳು, ಮತ್ತು ಆಡಿಯೋ ಕ್ಯಾಪ್ಚರ್ ನಂತಹ ಮುಖ್ಯ ವೈಶಿಷ್ಟ್ಯ ಪರಿಸಮನ್ವಯ.';
+  String get permissionsPageDescription => 'ಈ ಪ್ರದೇಶಗಳು Omi ಹೋಕ್ಕೆ ಅನುಕೂಲತಮವಾಗಿದೆ. ಅವು ಸೂಚನೆಗಳು, ನಿಲುವು-ಆಧಾರಿತ ಅನುಭವಗಳು, ಮತ್ತು ಆಡಿಯೋ ಕ್ಯಾಪ್ಚರ್ ನಂತಹ ಮುಖ್ಯ ವೈಶಿಷ್ಟ್ಯ ಪರಿಸಮನ್ವಯ.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi ಸರಿಯಾಗಿ ಕಾರ್ಯ ಮಾಡಲು ಕೆಲವು ಪ್ರದೇಶ ಅಗತ್ಯ. ಮುಂದುವರಿಸಲು ದಯವಿಟ್ಟು ನೀಯತೆಗಳನ್ನು ಅನುದಾನ.';
+  String get permissionsRequiredDescription => 'Omi ಸರಿಯಾಗಿ ಕಾರ್ಯ ಮಾಡಲು ಕೆಲವು ಪ್ರದೇಶ ಅಗತ್ಯ. ಮುಂದುವರಿಸಲು ದಯವಿಟ್ಟು ನೀಯತೆಗಳನ್ನು ಅನುದಾನ.';
 
   @override
   String get permissionsSetupTitle => 'ಉತ್ತಮ ಅನುಭವ ಪಡೆ';
@@ -8924,8 +8745,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get firmwareWarningTitle => 'ಮುಖ್ಯ: ನವೀಕರಿಸುವ ಮೊದಲು ಓದಿ';
 
   @override
-  String get firmwareFormatWarning =>
-      'ಈ ಫರ್ಮ್‌ವೇರ್ SD ಕಾರ್ಡ್ ಅನ್ನು ಫಾರ್ಮ್ಯಾಟ್ ಮಾಡುತ್ತದೆ. ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡುವ ಮೊದಲು ಎಲ್ಲಾ ಆಫ್‌ಲೈನ್ ಡೇಟಾ ಸಿಂಕ್ ಆಗಿದೆ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.\n\nಈ ಆವೃತ್ತಿಯನ್ನು ಸ್ಥಾಪಿಸಿದ ನಂತರ ಕೆಂಪು ಬೆಳಕು ಮಿನುಗುತ್ತಿದ್ದರೆ ಚಿಂತಿಸಬೇಡಿ. ಸಾಧನವನ್ನು ಅಪ್ಲಿಕೇಶನ್‌ಗೆ ಸಂಪರ್ಕಿಸಿ ಮತ್ತು ಅದು ನೀಲಿ ಬಣ್ಣಕ್ಕೆ ಬದಲಾಗಬೇಕು.';
+  String get firmwareFormatWarning => 'ಈ ಫರ್ಮ್‌ವೇರ್ SD ಕಾರ್ಡ್ ಅನ್ನು ಫಾರ್ಮ್ಯಾಟ್ ಮಾಡುತ್ತದೆ. ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡುವ ಮೊದಲು ಎಲ್ಲಾ ಆಫ್‌ಲೈನ್ ಡೇಟಾ ಸಿಂಕ್ ಆಗಿದೆ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.\n\nಈ ಆವೃತ್ತಿಯನ್ನು ಸ್ಥಾಪಿಸಿದ ನಂತರ ಕೆಂಪು ಬೆಳಕು ಮಿನುಗುತ್ತಿದ್ದರೆ ಚಿಂತಿಸಬೇಡಿ. ಸಾಧನವನ್ನು ಅಪ್ಲಿಕೇಶನ್‌ಗೆ ಸಂಪರ್ಕಿಸಿ ಮತ್ತು ಅದು ನೀಲಿ ಬಣ್ಣಕ್ಕೆ ಬದಲಾಗಬೇಕು.';
 
   @override
   String get continueAnyway => 'ಮುಂದುವರಿಸಿ';
@@ -8945,8 +8765,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get tasksMarkComplete => 'ಪೂರ್ಣಗೊಂಡಿದೆ ಎಂದು ಗುರುತಿಸಲಾಗಿದೆ';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi Apple ನ HealthKit ಫ್ರೇಮ್‌ವರ್ಕ್ ಮೂಲಕ Apple Health ಅನ್ನು ಪ್ರವೇಶಿಸುತ್ತದೆ. ನೀವು iOS ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ಪ್ರವೇಶವನ್ನು ಹಿಂಪಡೆಯಬಹುದು.';
+  String get appleHealthManageNote => 'Omi Apple ನ HealthKit ಫ್ರೇಮ್‌ವರ್ಕ್ ಮೂಲಕ Apple Health ಅನ್ನು ಪ್ರವೇಶಿಸುತ್ತದೆ. ನೀವು iOS ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ಪ್ರವೇಶವನ್ನು ಹಿಂಪಡೆಯಬಹುದು.';
 
   @override
   String get appleHealthConnectCta => 'Apple Health ಗೆ ಸಂಪರ್ಕಿಸಿ';
@@ -8967,8 +8786,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get appleHealthFeatureReadOnlyTitle => 'ಕೇವಲ ಓದುವ ಪ್ರವೇಶ';
 
   @override
-  String get appleHealthFeatureReadOnlyDesc =>
-      'Omi ಎಂದಿಗೂ Apple Health ಗೆ ಬರೆಯುವುದಿಲ್ಲ ಅಥವಾ ಡೇಟಾವನ್ನು ಬದಲಾಯಿಸುವುದಿಲ್ಲ.';
+  String get appleHealthFeatureReadOnlyDesc => 'Omi ಎಂದಿಗೂ Apple Health ಗೆ ಬರೆಯುವುದಿಲ್ಲ ಅಥವಾ ಡೇಟಾವನ್ನು ಬದಲಾಯಿಸುವುದಿಲ್ಲ.';
 
   @override
   String get appleHealthFeatureSecureTitle => 'ಸುರಕ್ಷಿತ ಸಿಂಕ್';
@@ -8980,8 +8798,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health ಪ್ರವೇಶ ನಿರಾಕರಿಸಲಾಗಿದೆ';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi ಗೆ ನಿಮ್ಮ Apple Health ಡೇಟಾವನ್ನು ಓದುವ ಅನುಮತಿ ಇಲ್ಲ. iOS ಸೆಟ್ಟಿಂಗ್‌ಗಳು → ಗೌಪ್ಯತೆ ಮತ್ತು ಭದ್ರತೆ → Health → Omi ನಲ್ಲಿ ಇದನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ.';
+  String get appleHealthDeniedBody => 'Omi ಗೆ ನಿಮ್ಮ Apple Health ಡೇಟಾವನ್ನು ಓದುವ ಅನುಮತಿ ಇಲ್ಲ. iOS ಸೆಟ್ಟಿಂಗ್‌ಗಳು → ಗೌಪ್ಯತೆ ಮತ್ತು ಭದ್ರತೆ → Health → Omi ನಲ್ಲಿ ಇದನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ.';
 
   @override
   String get deleteFlowReasonTitle => 'ನೀವೇಕೆ ಹೋಗುತ್ತಿದ್ದೀರಿ?';
@@ -9050,8 +8867,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get planUpdate => 'ಯೋಜನೆ ನವೀಕರಣ';
 
   @override
-  String get planDeprecationMessage =>
-      'ನಿಮ್ಮ Unlimited ಯೋಜನೆಯನ್ನು ನಿಲ್ಲಿಸಲಾಗುತ್ತಿದೆ. Operator ಯೋಜನೆಗೆ ಬದಲಾಯಿಸಿ — ಅದೇ ಅದ್ಭುತ ವೈಶಿಷ್ಟ್ಯಗಳು \$49/ತಿಂಗಳಿಗೆ. ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಯೋಜನೆ ಈ ಮಧ್ಯೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಲೇ ಇರುತ್ತದೆ.';
+  String get planDeprecationMessage => 'ನಿಮ್ಮ Unlimited ಯೋಜನೆಯನ್ನು ನಿಲ್ಲಿಸಲಾಗುತ್ತಿದೆ. Operator ಯೋಜನೆಗೆ ಬದಲಾಯಿಸಿ — ಅದೇ ಅದ್ಭುತ ವೈಶಿಷ್ಟ್ಯಗಳು \$49/ತಿಂಗಳಿಗೆ. ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಯೋಜನೆ ಈ ಮಧ್ಯೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಲೇ ಇರುತ್ತದೆ.';
 
   @override
   String get upgradeYourPlan => 'ನಿಮ್ಮ ಯೋಜನೆಯನ್ನು ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ';
@@ -9162,8 +8978,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'ನೀವು ನಿಮ್ಮ ಮಾಸಿಕ ಮಿತಿಯನ್ನು ತಲುಪಿದ್ದೀರಿ. ನಿರ್ಬಂಧಗಳಿಲ್ಲದೆ Omi ಜೊತೆ ಚಾಟ್ ಮುಂದುವರಿಸಲು ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ.';
+  String get chatQuotaExceededReply => 'ನೀವು ನಿಮ್ಮ ಮಾಸಿಕ ಮಿತಿಯನ್ನು ತಲುಪಿದ್ದೀರಿ. ನಿರ್ಬಂಧಗಳಿಲ್ಲದೆ Omi ಜೊತೆ ಚಾಟ್ ಮುಂದುವರಿಸಲು ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ.';
 
   @override
   String get voiceResponseAudio => 'Omi ಪ್ರತಿಕ್ರಿಯೆಯನ್ನು ಜೋರಾಗಿ ಓದಿ';
@@ -9194,4 +9009,25 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'ಕಾರ್ಯ ಸೇರಿಸಿ';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi ಗೆ ಯಾವುದನ್ನಾದರೂ ಕೇಳಿ';
+
+  @override
+  String get quickActionVoiceMode => 'ಧ್ವನಿ ಮೋಡ್';
+
+  @override
+  String get quickActionMute => 'ಮ್ಯೂಟ್';
+
+  @override
+  String get quickActionUnmute => 'ಅನ್‌ಮ್ಯೂಟ್';
+
+  @override
+  String get quickActionConnectDevice => 'ಸಾಧನ ಸಂಪರ್ಕಿಸಿ';
+
+  @override
+  String get quickActionDeviceSettings => 'ಸಾಧನ ಸೆಟ್ಟಿಂಗ್‌ಗಳು';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -822,8 +822,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => '지식 그래프를 삭제하시겠습니까?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      '파생된 모든 지식 그래프 데이터(노드 및 연결)가 삭제됩니다. 원본 기억은 안전하게 유지됩니다. 그래프는 시간이 지나면 다시 구축되거나 다음 요청 시 재구축됩니다.';
+  String get deleteKnowledgeGraphMessage => '파생된 모든 지식 그래프 데이터(노드 및 연결)가 삭제됩니다. 원본 기억은 안전하게 유지됩니다. 그래프는 시간이 지나면 다시 구축되거나 다음 요청 시 재구축됩니다.';
 
   @override
   String get knowledgeGraphDeleted => '지식 그래프가 삭제되었습니다';
@@ -1090,8 +1089,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get enhanceTranscriptAccuracyDesc => '모델이 개선됨에 따라 녹음에 대한 더 나은 변환 결과를 제공할 수 있습니다.';
 
   @override
-  String get legalNotice =>
-      '법적 고지: 음성 데이터 녹음 및 저장의 합법성은 위치 및 이 기능 사용 방법에 따라 다를 수 있습니다. 현지 법률 및 규정을 준수하는지 확인하는 것은 귀하의 책임입니다.';
+  String get legalNotice => '법적 고지: 음성 데이터 녹음 및 저장의 합법성은 위치 및 이 기능 사용 방법에 따라 다를 수 있습니다. 현지 법률 및 규정을 준수하는지 확인하는 것은 귀하의 책임입니다.';
 
   @override
   String get alreadyAuthorized => '이미 승인됨';
@@ -1871,8 +1869,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get permissionGrantedNow => '권한이 부여되었습니다! 이제:\n\n워치에서 Omi 앱을 열고 아래의 \"계속\"을 탭하세요';
 
   @override
-  String get needMicrophonePermission =>
-      '마이크 권한이 필요합니다.\n\n1. \"권한 부여\" 탭\n2. iPhone에서 허용\n3. 워치 앱이 닫힙니다\n4. 다시 열고 \"계속\" 탭';
+  String get needMicrophonePermission => '마이크 권한이 필요합니다.\n\n1. \"권한 부여\" 탭\n2. iPhone에서 허용\n3. 워치 앱이 닫힙니다\n4. 다시 열고 \"계속\" 탭';
 
   @override
   String get grantPermissionButton => '권한 부여';
@@ -1881,8 +1878,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get needHelp => '도움이 필요하신가요?';
 
   @override
-  String get troubleshootingSteps =>
-      '문제 해결:\n\n1. 워치에 Omi가 설치되어 있는지 확인\n2. 워치에서 Omi 앱 열기\n3. 권한 팝업 찾기\n4. 메시지가 나타나면 \"허용\" 탭\n5. 워치의 앱이 닫힙니다 - 다시 열기\n6. 돌아와서 iPhone에서 \"계속\" 탭';
+  String get troubleshootingSteps => '문제 해결:\n\n1. 워치에 Omi가 설치되어 있는지 확인\n2. 워치에서 Omi 앱 열기\n3. 권한 팝업 찾기\n4. 메시지가 나타나면 \"허용\" 탭\n5. 워치의 앱이 닫힙니다 - 다시 열기\n6. 돌아와서 iPhone에서 \"계속\" 탭';
 
   @override
   String get recordingStartedSuccessfully => '녹음이 성공적으로 시작되었습니다!';
@@ -2342,8 +2338,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get unpairDeviceDialogTitle => '기기 페어링 해제';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      '기기 페어링을 해제하여 다른 전화기에 연결할 수 있도록 합니다. 설정 > Bluetooth로 이동하여 기기를 삭제하여 프로세스를 완료해야 합니다.';
+  String get unpairDeviceDialogMessage => '기기 페어링을 해제하여 다른 전화기에 연결할 수 있도록 합니다. 설정 > Bluetooth로 이동하여 기기를 삭제하여 프로세스를 완료해야 합니다.';
 
   @override
   String get unpair => '페어링 해제';
@@ -4114,8 +4109,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get omiApiKeys => 'Omi API 키';
 
   @override
-  String get apiKeysDescription =>
-      'API 키는 앱이 OMI 서버와 통신할 때 인증에 사용됩니다. 애플리케이션이 메모리를 생성하고 다른 OMI 서비스에 안전하게 접근할 수 있게 합니다.';
+  String get apiKeysDescription => 'API 키는 앱이 OMI 서버와 통신할 때 인증에 사용됩니다. 애플리케이션이 메모리를 생성하고 다른 OMI 서비스에 안전하게 접근할 수 있게 합니다.';
 
   @override
   String get aboutOmiApiKeys => 'Omi API 키 정보';
@@ -4246,8 +4240,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get maximumSecurityE2ee => '최대 보안 (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      '엔드투엔드 암호화는 개인정보 보호의 최고 기준입니다. 활성화되면 데이터가 서버로 전송되기 전에 기기에서 암호화됩니다. 이는 Omi를 포함한 그 누구도 귀하의 콘텐츠에 접근할 수 없음을 의미합니다.';
+  String get e2eeDescription => '엔드투엔드 암호화는 개인정보 보호의 최고 기준입니다. 활성화되면 데이터가 서버로 전송되기 전에 기기에서 암호화됩니다. 이는 Omi를 포함한 그 누구도 귀하의 콘텐츠에 접근할 수 없음을 의미합니다.';
 
   @override
   String get importantTradeoffs => '중요한 절충 사항:';
@@ -4281,8 +4274,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get secureEncryption => '안전한 암호화';
 
   @override
-  String get secureEncryptionDescription =>
-      '귀하의 데이터는 Google Cloud에서 호스팅되는 당사 서버에서 귀하만의 고유한 키로 암호화됩니다. 이는 Omi 직원이나 Google을 포함한 누구도 데이터베이스에서 직접 귀하의 원시 콘텐츠에 접근할 수 없음을 의미합니다.';
+  String get secureEncryptionDescription => '귀하의 데이터는 Google Cloud에서 호스팅되는 당사 서버에서 귀하만의 고유한 키로 암호화됩니다. 이는 Omi 직원이나 Google을 포함한 누구도 데이터베이스에서 직접 귀하의 원시 콘텐츠에 접근할 수 없음을 의미합니다.';
 
   @override
   String get endToEndEncryption => '엔드투엔드 암호화';
@@ -4519,8 +4511,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get yourPrivacyMattersToUs => '당신의 개인정보는 우리에게 중요합니다';
 
   @override
-  String get privacyIntroText =>
-      'Omi에서는 귀하의 개인정보를 매우 중요하게 생각합니다. 수집하는 데이터와 사용 방법에 대해 투명하게 알려드리고자 합니다. 알아야 할 사항은 다음과 같습니다:';
+  String get privacyIntroText => 'Omi에서는 귀하의 개인정보를 매우 중요하게 생각합니다. 수집하는 데이터와 사용 방법에 대해 투명하게 알려드리고자 합니다. 알아야 할 사항은 다음과 같습니다:';
 
   @override
   String get whatWeTrack => '추적 항목';
@@ -4612,8 +4603,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => '내보내기가 시작되었습니다. 몇 초 정도 걸릴 수 있습니다...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      '이렇게 하면 모든 파생 지식 그래프 데이터(노드 및 연결)가 삭제됩니다. 원본 기억은 안전하게 유지됩니다. 그래프는 시간이 지나면서 또는 다음 요청 시 다시 구축됩니다.';
+  String get knowledgeGraphDeleteDescription => '이렇게 하면 모든 파생 지식 그래프 데이터(노드 및 연결)가 삭제됩니다. 원본 기억은 안전하게 유지됩니다. 그래프는 시간이 지나면서 또는 다음 요청 시 다시 구축됩니다.';
 
   @override
   String get configureDailySummaryDigest => '일일 작업 요약 구성';
@@ -4996,8 +4986,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get additionalSpeechSampleRemoved => '추가 음성 샘플이 삭제되었습니다';
 
   @override
-  String get consentDataMessage =>
-      '계속하면 대화, 녹음 및 개인 정보가 서버에 안전하게 저장됩니다. 오디오 녹음 및 텍스트 변환은 제3자 AI 서비스(전사를 위한 Deepgram 및 분석을 위한 OpenAI 포함)에 의해 처리되어 AI 기반 인사이트를 제공하고 모든 앱 기능을 활성화합니다.';
+  String get consentDataMessage => '계속하면 대화, 녹음 및 개인 정보가 서버에 안전하게 저장됩니다. 오디오 녹음 및 텍스트 변환은 제3자 AI 서비스(전사를 위한 Deepgram 및 분석을 위한 OpenAI 포함)에 의해 처리되어 AI 기반 인사이트를 제공하고 모든 앱 기능을 활성화합니다.';
 
   @override
   String get tasksEmptyStateMessage => '대화에서 생성된 작업이 여기에 표시됩니다.\n수동으로 만들려면 +를 탭하세요.';
@@ -5051,8 +5040,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => '앱을 설치하고 열었습니다';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch 앱을 열 수 없습니다. Apple Watch에서 Watch 앱을 수동으로 열고 \"사용 가능한 앱\" 섹션에서 Omi를 설치하세요.';
+  String get unableToOpenWatchApp => 'Apple Watch 앱을 열 수 없습니다. Apple Watch에서 Watch 앱을 수동으로 열고 \"사용 가능한 앱\" 섹션에서 Omi를 설치하세요.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch가 성공적으로 연결되었습니다!';
@@ -5504,8 +5492,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get howToTakeGoodSample => '좋은 샘플을 얻는 방법은?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. 조용한 장소에 있는지 확인하세요.\n2. 명확하고 자연스럽게 말하세요.\n3. 기기가 목에 자연스러운 위치에 있는지 확인하세요.\n\n생성 후에는 언제든지 개선하거나 다시 할 수 있습니다.';
+  String get goodSampleInstructions => '1. 조용한 장소에 있는지 확인하세요.\n2. 명확하고 자연스럽게 말하세요.\n3. 기기가 목에 자연스러운 위치에 있는지 확인하세요.\n\n생성 후에는 언제든지 개선하거나 다시 할 수 있습니다.';
 
   @override
   String get noDeviceConnectedUseMic => '연결된 기기가 없습니다. 휴대폰 마이크를 사용합니다.';
@@ -8342,8 +8329,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get fairUseAboutTitle => '공정 사용에 대하여';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi는 개인 대화, 회의 및 실시간 상호작용을 위해 설계되었습니다. 사용량은 연결 시간이 아닌 감지된 실제 발화 시간으로 측정됩니다. 비개인적 콘텐츠에 대해 정상 패턴을 크게 초과하는 사용이 있을 경우 조정이 적용될 수 있습니다.';
+  String get fairUseAboutBody => 'Omi는 개인 대화, 회의 및 실시간 상호작용을 위해 설계되었습니다. 사용량은 연결 시간이 아닌 감지된 실제 발화 시간으로 측정됩니다. 비개인적 콘텐츠에 대해 정상 패턴을 크게 초과하는 사용이 있을 경우 조정이 적용될 수 있습니다.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8381,8 +8367,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get improveConnectionTitle => '연결 개선';
 
   @override
-  String get improveConnectionContent =>
-      'Omi가 기기와 연결을 유지하는 방식을 개선했습니다. 이를 활성화하려면 기기 정보 페이지로 이동하여 \"기기 연결 해제\"를 탭한 다음 기기를 다시 페어링하세요.';
+  String get improveConnectionContent => 'Omi가 기기와 연결을 유지하는 방식을 개선했습니다. 이를 활성화하려면 기기 정보 페이지로 이동하여 \"기기 연결 해제\"를 탭한 다음 기기를 다시 페어링하세요.';
 
   @override
   String get improveConnectionAction => '알겠습니다';
@@ -8747,8 +8732,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get firmwareWarningTitle => '중요: 업데이트 전 확인사항';
 
   @override
-  String get firmwareFormatWarning =>
-      '이 펌웨어는 SD 카드를 포맷합니다. 업그레이드 전에 모든 오프라인 데이터가 동기화되었는지 확인하세요.\n\n이 버전 설치 후 빨간 불이 깜빡이더라도 걱정하지 마세요. 기기를 앱에 연결하면 파란색으로 바뀝니다. 빨간 불은 기기의 시계가 아직 동기화되지 않았다는 의미입니다.';
+  String get firmwareFormatWarning => '이 펌웨어는 SD 카드를 포맷합니다. 업그레이드 전에 모든 오프라인 데이터가 동기화되었는지 확인하세요.\n\n이 버전 설치 후 빨간 불이 깜빡이더라도 걱정하지 마세요. 기기를 앱에 연결하면 파란색으로 바뀝니다. 빨간 불은 기기의 시계가 아직 동기화되지 않았다는 의미입니다.';
 
   @override
   String get continueAnyway => '계속';
@@ -8768,8 +8752,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get tasksMarkComplete => '완료로 표시됨';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi는 Apple의 HealthKit 프레임워크를 통해 Apple Health에 접근합니다. iOS 설정에서 언제든지 접근 권한을 철회할 수 있습니다.';
+  String get appleHealthManageNote => 'Omi는 Apple의 HealthKit 프레임워크를 통해 Apple Health에 접근합니다. iOS 설정에서 언제든지 접근 권한을 철회할 수 있습니다.';
 
   @override
   String get appleHealthConnectCta => 'Apple Health에 연결';
@@ -8871,8 +8854,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get planUpdate => '플랜 업데이트';
 
   @override
-  String get planDeprecationMessage =>
-      'Unlimited 플랜이 중단됩니다. Operator 플랜으로 전환하세요 — 동일한 훌륭한 기능을 월 \$49에 이용할 수 있습니다. 현재 플랜은 당분간 계속 사용할 수 있습니다.';
+  String get planDeprecationMessage => 'Unlimited 플랜이 중단됩니다. Operator 플랜으로 전환하세요 — 동일한 훌륭한 기능을 월 \$49에 이용할 수 있습니다. 현재 플랜은 당분간 계속 사용할 수 있습니다.';
 
   @override
   String get upgradeYourPlan => '플랜 업그레이드';
@@ -9014,4 +8996,25 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => '작업 추가';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi에게 무엇이든 물어보세요';
+
+  @override
+  String get quickActionVoiceMode => '음성 모드';
+
+  @override
+  String get quickActionMute => '음소거';
+
+  @override
+  String get quickActionUnmute => '음소거 해제';
+
+  @override
+  String get quickActionConnectDevice => '기기 연결';
+
+  @override
+  String get quickActionDeviceSettings => '기기 설정';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -24,8 +24,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deleteConversationTitle => 'Ištrinti pokalbį?';
 
   @override
-  String get deleteConversationMessage =>
-      'Tai taip pat ištrins susijusius prisiminimus, užduotis ir garso failus. Šio veiksmo negalima atšaukti.';
+  String get deleteConversationMessage => 'Tai taip pat ištrins susijusius prisiminimus, užduotis ir garso failus. Šio veiksmo negalima atšaukti.';
 
   @override
   String get confirm => 'Patvirtinti';
@@ -227,8 +226,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noStarredConversations => 'Nėra pokalbių su žvaigždute';
 
   @override
-  String get starConversationHint =>
-      'Norėdami pažymėti pokalbį, atidarykite jį ir paspauskite žvaigždutės piktogramą antraštėje.';
+  String get starConversationHint => 'Norėdami pažymėti pokalbį, atidarykite jį ir paspauskite žvaigždutės piktogramą antraštėje.';
 
   @override
   String get searchConversations => 'Ieškoti pokalbių...';
@@ -319,8 +317,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get installedApps => 'Įdiegtos programėlės';
 
   @override
-  String get unableToFetchApps =>
-      'Nepavyko gauti programėlių :(\n\nPatikrinkite interneto ryšį ir bandykite dar kartą.';
+  String get unableToFetchApps => 'Nepavyko gauti programėlių :(\n\nPatikrinkite interneto ryšį ir bandykite dar kartą.';
 
   @override
   String get aboutOmi => 'Apie Omi';
@@ -356,19 +353,16 @@ class AppLocalizationsLt extends AppLocalizations {
   String get appsDisconnected => 'Jūsų programėlės ir integracijos bus nedelsiant atjungtos.';
 
   @override
-  String get exportBeforeDelete =>
-      'Prieš ištrindami paskyrą galite eksportuoti duomenis, tačiau ištrynus jų atkurti neįmanoma.';
+  String get exportBeforeDelete => 'Prieš ištrindami paskyrą galite eksportuoti duomenis, tačiau ištrynus jų atkurti neįmanoma.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Suprantu, kad mano paskyros ištrynimas yra galutinis ir visi duomenys, įskaitant prisiminimus ir pokalbius, bus prarasti ir jų atkurti nebus įmanoma.';
+  String get deleteAccountCheckbox => 'Suprantu, kad mano paskyros ištrynimas yra galutinis ir visi duomenys, įskaitant prisiminimus ir pokalbius, bus prarasti ir jų atkurti nebus įmanoma.';
 
   @override
   String get areYouSure => 'Ar tikrai?';
 
   @override
-  String get deleteAccountFinal =>
-      'Šis veiksmas yra negrįžtamas ir galutinai ištrins jūsų paskyrą ir visus susijusius duomenis. Ar tikrai norite tęsti?';
+  String get deleteAccountFinal => 'Šis veiksmas yra negrįžtamas ir galutinai ištrins jūsų paskyrą ir visus susijusius duomenis. Ar tikrai norite tęsti?';
 
   @override
   String get deleteNow => 'Ištrinti dabar';
@@ -377,8 +371,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get goBack => 'Grįžti atgal';
 
   @override
-  String get checkBoxToConfirm =>
-      'Pažymėkite langelį, kad patvirtintumėte, jog suprantate, kad paskyros ištrynimas yra galutinis ir negrįžtamas.';
+  String get checkBoxToConfirm => 'Pažymėkite langelį, kad patvirtintumėte, jog suprantate, kad paskyros ištrynimas yra galutinis ir negrįžtamas.';
 
   @override
   String get profile => 'Profilis';
@@ -456,8 +449,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get yourPrivacyYourControl => 'Jūsų privatumas, jūsų kontrolė';
 
   @override
-  String get privacyIntro =>
-      'Omi įsipareigoja saugoti jūsų privatumą. Šis puslapis leidžia kontroliuoti, kaip jūsų duomenys saugomi ir naudojami.';
+  String get privacyIntro => 'Omi įsipareigoja saugoti jūsų privatumą. Šis puslapis leidžia kontroliuoti, kaip jūsų duomenys saugomi ir naudojami.';
 
   @override
   String get learnMore => 'Sužinoti daugiau...';
@@ -466,15 +458,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get dataProtectionLevel => 'Duomenų apsaugos lygis';
 
   @override
-  String get dataProtectionDesc =>
-      'Jūsų duomenys pagal numatytuosius nustatymus apsaugoti stipriu šifravimu. Peržiūrėkite savo nustatymus ir būsimas privatumo parinktis žemiau.';
+  String get dataProtectionDesc => 'Jūsų duomenys pagal numatytuosius nustatymus apsaugoti stipriu šifravimu. Peržiūrėkite savo nustatymus ir būsimas privatumo parinktis žemiau.';
 
   @override
   String get appAccess => 'Programėlių prieiga';
 
   @override
-  String get appAccessDesc =>
-      'Šios programėlės gali pasiekti jūsų duomenis. Paspauskite programėlę, kad valdytumėte jos leidimus.';
+  String get appAccessDesc => 'Šios programėlės gali pasiekti jūsų duomenis. Paspauskite programėlę, kad valdytumėte jos leidimus.';
 
   @override
   String get noAppsExternalAccess => 'Jokios įdiegtos programėlės neturi išorinės prieigos prie jūsų duomenų.';
@@ -531,15 +521,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Jūsų Omi buvo atjungtas 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Įrenginys atjungtas. Eikite į Nustatymai > Bluetooth ir pamiršite įrenginį, kad užbaigtumėte atsiejimą.';
+  String get deviceUnpairedMessage => 'Įrenginys atjungtas. Eikite į Nustatymai > Bluetooth ir pamiršite įrenginį, kad užbaigtumėte atsiejimą.';
 
   @override
   String get unpairDialogTitle => 'Atjungti įrenginį';
 
   @override
-  String get unpairDialogMessage =>
-      'Taip atjungsite įrenginį, kad jį būtų galima prijungti prie kito telefono. Norėdami užbaigti procesą, turėsite eiti į Nustatymus > „Bluetooth\" ir pamiršti įrenginį.';
+  String get unpairDialogMessage => 'Taip atjungsite įrenginį, kad jį būtų galima prijungti prie kito telefono. Norėdami užbaigti procesą, turėsite eiti į Nustatymus > „Bluetooth\" ir pamiršti įrenginį.';
 
   @override
   String get deviceNotConnected => 'Įrenginys neprijungtas';
@@ -560,8 +548,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get v2Undetected => 'V2 neaptiktas';
 
   @override
-  String get v2UndetectedMessage =>
-      'Matome, kad turite V1 įrenginį arba jūsų įrenginys neprijungtas. SD kortelės funkcija prieinama tik V2 įrenginiams.';
+  String get v2UndetectedMessage => 'Matome, kad turite V1 įrenginį arba jūsų įrenginys neprijungtas. SD kortelės funkcija prieinama tik V2 įrenginiams.';
 
   @override
   String get endConversation => 'Baigti pokalbį';
@@ -835,8 +822,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Ištrinti žinių grafiką?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Taip bus ištrinti visi išvesti žinių grafiko duomenys (mazgai ir ryšiai). Jūsų originalūs prisiminimai liks saugūs. Grafikas bus atstatytas laikui bėgant arba pagal kitą užklausą.';
+  String get deleteKnowledgeGraphMessage => 'Taip bus ištrinti visi išvesti žinių grafiko duomenys (mazgai ir ryšiai). Jūsų originalūs prisiminimai liks saugūs. Grafikas bus atstatytas laikui bėgant arba pagal kitą užklausą.';
 
   @override
   String get knowledgeGraphDeleted => 'Žinių grafas ištrintas';
@@ -984,8 +970,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get shortConversationThreshold => 'Trumpo pokalbio riba';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Pokalbiai, trumpesni už šią ribą, bus paslėpti, nebent įjungta aukščiau';
+  String get shortConversationThresholdSubtitle => 'Pokalbiai, trumpesni už šią ribą, bus paslėpti, nebent įjungta aukščiau';
 
   @override
   String get durationThreshold => 'Trukmės riba';
@@ -1089,8 +1074,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get improveSpeechProfile => 'Pagerinti jūsų kalbos profilį';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Naudojame įrašus tolesniam jūsų asmeninio kalbos profilio mokymui ir tobulinimui.';
+  String get improveSpeechProfileDesc => 'Naudojame įrašus tolesniam jūsų asmeninio kalbos profilio mokymui ir tobulinimui.';
 
   @override
   String get trainFamilyProfiles => 'Mokyti draugų ir šeimos profilius';
@@ -1102,12 +1086,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get enhanceTranscriptAccuracy => 'Pagerinti transkripcijos tikslumą';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Mūsų modeliui tobulėjant, galime pateikti geresnius transkripcijos rezultatus jūsų įrašams.';
+  String get enhanceTranscriptAccuracyDesc => 'Mūsų modeliui tobulėjant, galime pateikti geresnius transkripcijos rezultatus jūsų įrašams.';
 
   @override
-  String get legalNotice =>
-      'Teisinis pranešimas: balso duomenų įrašymo ir saugojimo teisėtumas gali skirtis priklausomai nuo jūsų buvimo vietos ir kaip naudojate šią funkciją. Tai jūsų atsakomybė užtikrinti atitiktį vietiniams įstatymams ir taisyklėms.';
+  String get legalNotice => 'Teisinis pranešimas: balso duomenų įrašymo ir saugojimo teisėtumas gali skirtis priklausomai nuo jūsų buvimo vietos ir kaip naudojate šią funkciją. Tai jūsų atsakomybė užtikrinti atitiktį vietiniams įstatymams ir taisyklėms.';
 
   @override
   String get alreadyAuthorized => 'Jau autorizuota';
@@ -1270,12 +1252,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Pasakykite mums savo pagrindinę kalbą';
 
   @override
-  String get languageForTranscription =>
-      'Nustatykite savo kalbą tikslesnėms transkripcijoms ir individualizuotai patirčiai.';
+  String get languageForTranscription => 'Nustatykite savo kalbą tikslesnėms transkripcijoms ir individualizuotai patirčiai.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Įjungtas vienos kalbos režimas. Vertimas išjungtas, kad būtų didesnis tikslumas.';
+  String get singleLanguageModeInfo => 'Įjungtas vienos kalbos režimas. Vertimas išjungtas, kad būtų didesnis tikslumas.';
 
   @override
   String get searchLanguageHint => 'Ieškoti kalbos pagal pavadinimą ar kodą';
@@ -1355,8 +1335,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get defaultRepository => 'Numatytoji saugykla';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Pasirinkite numatytąją saugyklą problemų kūrimui. Kurdami problemas galite nurodyti kitą saugyklą.';
+  String get selectDefaultRepoDesc => 'Pasirinkite numatytąją saugyklą problemų kūrimui. Kurdami problemas galite nurodyti kitą saugyklą.';
 
   @override
   String get noReposFound => 'Saugyklų nerasta';
@@ -1731,8 +1710,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get enableBluetooth => 'Įjungti Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi reikia Bluetooth, kad prisijungtų prie jūsų nešiojamo įrenginio. Įjunkite Bluetooth ir bandykite dar kartą.';
+  String get bluetoothNeeded => 'Omi reikia Bluetooth, kad prisijungtų prie jūsų nešiojamo įrenginio. Įjunkite Bluetooth ir bandykite dar kartą.';
 
   @override
   String get contactSupport => 'Susisiekti su palaikymu?';
@@ -1765,26 +1743,22 @@ class AppLocalizationsLt extends AppLocalizations {
   String get locationServiceDisabled => 'Vietos tarnyba išjungta';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Vietos tarnyba išjungta. Eikite į Nustatymus > Privatumas ir sauga > Vietos tarnybos ir įjunkite ją';
+  String get locationServiceDisabledDesc => 'Vietos tarnyba išjungta. Eikite į Nustatymus > Privatumas ir sauga > Vietos tarnybos ir įjunkite ją';
 
   @override
   String get backgroundLocationDenied => 'Foninės vietos prieiga atmesta';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Eikite į įrenginio nustatymus ir nustatykite vietos leidimą į „Visada leisti\"';
+  String get backgroundLocationDeniedDesc => 'Eikite į įrenginio nustatymus ir nustatykite vietos leidimą į „Visada leisti\"';
 
   @override
   String get lovingOmi => 'Patinka Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Padėkite mums pasiekti daugiau žmonių palikdami atsiliepimą App Store. Jūsų atsiliepimas mums reiškia labai daug!';
+  String get leaveReviewIos => 'Padėkite mums pasiekti daugiau žmonių palikdami atsiliepimą App Store. Jūsų atsiliepimas mums reiškia labai daug!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Padėkite mums pasiekti daugiau žmonių palikdami atsiliepimą „Google Play\" parduotuvėje. Jūsų atsiliepimas mums reiškia labai daug!';
+  String get leaveReviewAndroid => 'Padėkite mums pasiekti daugiau žmonių palikdami atsiliepimą „Google Play\" parduotuvėje. Jūsų atsiliepimas mums reiškia labai daug!';
 
   @override
   String get rateOnAppStore => 'Įvertinti App Store';
@@ -1817,15 +1791,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get connectionError => 'Ryšio klaida';
 
   @override
-  String get connectionErrorDesc =>
-      'Nepavyko prisijungti prie serverio. Patikrinkite interneto ryšį ir bandykite dar kartą.';
+  String get connectionErrorDesc => 'Nepavyko prisijungti prie serverio. Patikrinkite interneto ryšį ir bandykite dar kartą.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Aptiktas netinkamas įrašas';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Atrodo, kad įraše yra keli kalbėtojai. Įsitikinkite, kad esate tylioje vietoje, ir bandykite dar kartą.';
+  String get multipleSpeakersDesc => 'Atrodo, kad įraše yra keli kalbėtojai. Įsitikinkite, kad esate tylioje vietoje, ir bandykite dar kartą.';
 
   @override
   String get tooShortDesc => 'Neaptikta pakankamai kalbos. Kalbėkite daugiau ir bandykite dar kartą.';
@@ -1837,8 +1809,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get areYouThere => 'Ar jūs čia?';
 
   @override
-  String get noSpeechDesc =>
-      'Nepavyko aptikti jokios kalbos. Įsitikinkite, kad kalbate bent 10 sekundžių ir ne ilgiau nei 3 minutes.';
+  String get noSpeechDesc => 'Nepavyko aptikti jokios kalbos. Įsitikinkite, kad kalbate bent 10 sekundžių ir ne ilgiau nei 3 minutes.';
 
   @override
   String get connectionLost => 'Ryšys prarastas';
@@ -1859,8 +1830,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get permissionsRequired => 'Reikalingi leidimai';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Šiai programai reikia Bluetooth ir vietos leidimų, kad tinkamai veiktų. Įjunkite juos nustatymuose.';
+  String get permissionsRequiredDesc => 'Šiai programai reikia Bluetooth ir vietos leidimų, kad tinkamai veiktų. Įjunkite juos nustatymuose.';
 
   @override
   String get openSettings => 'Atidaryti nustatymus';
@@ -1890,8 +1860,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – jūsų DI palydovas';
 
   @override
-  String get captureEveryMoment =>
-      'Užfiksuokite kiekvieną akimirką. Gaukite DI pagrindu\nsukurtas santraukas. Daugiau nebedarykite užrašų.';
+  String get captureEveryMoment => 'Užfiksuokite kiekvieną akimirką. Gaukite DI pagrindu\nsukurtas santraukas. Daugiau nebedarykite užrašų.';
 
   @override
   String get appleWatchSetup => 'Apple Watch sąranka';
@@ -1903,12 +1872,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get microphonePermission => 'Mikrofono leidimas';
 
   @override
-  String get permissionGrantedNow =>
-      'Leidimas suteiktas! Dabar:\n\nAtidarykite Omi programą savo laikrodyje ir paspauskite „Tęsti\" žemiau';
+  String get permissionGrantedNow => 'Leidimas suteiktas! Dabar:\n\nAtidarykite Omi programą savo laikrodyje ir paspauskite „Tęsti\" žemiau';
 
   @override
-  String get needMicrophonePermission =>
-      'Mums reikia mikrofono leidimo.\n\n1. Paspauskite „Suteikti leidimą\"\n2. Leiskite savo iPhone\n3. Laikrodžio programėlė užsidarys\n4. Atidarykite iš naujo ir paspauskite „Tęsti\"';
+  String get needMicrophonePermission => 'Mums reikia mikrofono leidimo.\n\n1. Paspauskite „Suteikti leidimą\"\n2. Leiskite savo iPhone\n3. Laikrodžio programėlė užsidarys\n4. Atidarykite iš naujo ir paspauskite „Tęsti\"';
 
   @override
   String get grantPermissionButton => 'Suteikti leidimą';
@@ -1917,15 +1884,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get needHelp => 'Reikia pagalbos?';
 
   @override
-  String get troubleshootingSteps =>
-      'Trikčių šalinimas:\n\n1. Įsitikinkite, kad Omi įdiegtas jūsų laikrodyje\n2. Atidarykite Omi programą savo laikrodyje\n3. Ieškokite leidimo iššokančio lango\n4. Paspauskite „Leisti\", kai bus paprašyta\n5. Programėlė jūsų laikrodyje užsidarys – atidarykite ją iš naujo\n6. Grįžkite ir paspauskite „Tęsti\" savo iPhone';
+  String get troubleshootingSteps => 'Trikčių šalinimas:\n\n1. Įsitikinkite, kad Omi įdiegtas jūsų laikrodyje\n2. Atidarykite Omi programą savo laikrodyje\n3. Ieškokite leidimo iššokančio lango\n4. Paspauskite „Leisti\", kai bus paprašyta\n5. Programėlė jūsų laikrodyje užsidarys – atidarykite ją iš naujo\n6. Grįžkite ir paspauskite „Tęsti\" savo iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Įrašymas pradėtas sėkmingai!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Leidimas dar nesuteiktas. Įsitikinkite, kad leidote prieigą prie mikrofono ir iš naujo atidarėte programą savo laikrodyje.';
+  String get permissionNotGrantedYet => 'Leidimas dar nesuteiktas. Įsitikinkite, kad leidote prieigą prie mikrofono ir iš naujo atidarėte programą savo laikrodyje.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1956,8 +1921,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get actionItemsTitle => 'Užduotys';
 
   @override
-  String get actionItemsDescription =>
-      'Bakstelėkite, kad redaguotumėte • Ilgai spauskite, kad pasirinktumėte • Braukite veiksmams';
+  String get actionItemsDescription => 'Bakstelėkite, kad redaguotumėte • Ilgai spauskite, kad pasirinktumėte • Braukite veiksmams';
 
   @override
   String get tabToDo => 'Atlikti';
@@ -2023,8 +1987,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Pasiruošę užduotims';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Jūsų DI automatiškai išgaus užduotis iš jūsų pokalbių. Jos atsiras čia, kai bus sukurtos.';
+  String get welcomeActionItemsDescription => 'Jūsų DI automatiškai išgaus užduotis iš jūsų pokalbių. Jos atsiras čia, kai bus sukurtos.';
 
   @override
   String get autoExtractionFeature => 'Automatiškai išgauta iš pokalbių';
@@ -2220,15 +2183,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'KALBA IR TRANSKRIBAVIMAS';
 
   @override
-  String get languageSettingsHelperText =>
-      'Programos kalba keičia meniu ir mygtukus. Kalbos kalba įtakoja, kaip transkribuojami jūsų įrašai.';
+  String get languageSettingsHelperText => 'Programos kalba keičia meniu ir mygtukus. Kalbos kalba įtakoja, kaip transkribuojami jūsų įrašai.';
 
   @override
   String get translationNotice => 'Vertimo pranešimas';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi verčia pokalbius į jūsų pagrindinę kalbą. Atnaujinkite bet kada skiltyje Nustatymai → Profiliai.';
+  String get translationNoticeMessage => 'Omi verčia pokalbius į jūsų pagrindinę kalbą. Atnaujinkite bet kada skiltyje Nustatymai → Profiliai.';
 
   @override
   String get pleaseCheckInternetConnection => 'Patikrinkite interneto ryšį ir bandykite dar kartą';
@@ -2383,8 +2344,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Atjungti įrenginio susiejimą';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Tai atjungs įrenginio susiejimą, kad jį būtų galima prijungti prie kito telefono. Turėsite eiti į Nustatymai > Bluetooth ir pamiršti įrenginį, kad užbaigtumėte procesą.';
+  String get unpairDeviceDialogMessage => 'Tai atjungs įrenginio susiejimą, kad jį būtų galima prijungti prie kito telefono. Turėsite eiti į Nustatymai > Bluetooth ir pamiršti įrenginį, kad užbaigtumėte procesą.';
 
   @override
   String get unpair => 'Atjungti susiejimą';
@@ -2550,8 +2510,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get howDoesItWork => 'Kaip tai veikia?';
 
   @override
-  String get sdCardSyncDescription =>
-      'SD kortelės sinchronizavimas importuos jūsų atsiminimus iš SD kortelės į programą';
+  String get sdCardSyncDescription => 'SD kortelės sinchronizavimas importuos jūsų atsiminimus iš SD kortelės į programą';
 
   @override
   String get checksForAudioFiles => 'Patikrina garso failus SD kortelėje';
@@ -2566,8 +2525,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get youreAllSet => 'Viskas paruošta!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Sveiki atvykę į Omi! Jūsų AI palydovas pasirengęs padėti jums pokalbių, užduočių ir daugiau.';
+  String get welcomeToOmiDescription => 'Sveiki atvykę į Omi! Jūsų AI palydovas pasirengęs padėti jums pokalbių, užduočių ir daugiau.';
 
   @override
   String get startUsingOmi => 'Pradėti naudoti Omi';
@@ -2661,8 +2619,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showAll => 'Rodyti viską →';
 
   @override
-  String get noTasksForToday =>
-      'Šiandien nėra užduočių.\nPaprašykite Omi daugiau užduočių arba sukurkite rankiniu būdu.';
+  String get noTasksForToday => 'Šiandien nėra užduočių.\nPaprašykite Omi daugiau užduočių arba sukurkite rankiniu būdu.';
 
   @override
   String get dailyScore => 'DIENOS BALAS';
@@ -2704,8 +2661,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noTasksYet => 'Dar nėra užduočių';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Užduotys iš jūsų pokalbių bus rodomos čia.\nSpustelėkite Kurti, kad pridėtumėte vieną rankiniu būdu.';
+  String get tasksFromConversationsWillAppear => 'Užduotys iš jūsų pokalbių bus rodomos čia.\nSpustelėkite Kurti, kad pridėtumėte vieną rankiniu būdu.';
 
   @override
   String get monthJan => 'Saus';
@@ -2762,8 +2718,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deleteActionItem => 'Ištrinti veiksmo elementą';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Ar tikrai norite ištrinti šį veiksmo elementą? Šio veiksmo negalima atšaukti.';
+  String get deleteActionItemConfirmation => 'Ar tikrai norite ištrinti šį veiksmo elementą? Šio veiksmo negalima atšaukti.';
 
   @override
   String get enterActionItemDescription => 'Įveskite veiksmo elemento aprašymą...';
@@ -2838,15 +2793,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get chatPrompt => 'Pokalbio nurodymas';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Jūs esate puiki programėlė, jūsų darbas – atsakyti į vartotojų užklausas ir padaryti, kad jie jaustųsi gerai...';
+  String get chatPromptPlaceholder => 'Jūs esate puiki programėlė, jūsų darbas – atsakyti į vartotojų užklausas ir padaryti, kad jie jaustųsi gerai...';
 
   @override
   String get conversationPrompt => 'Pokalbio raginimas';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Jūs esate puiki programėlė, gausite pokalbio transkripcą ir santrauką...';
+  String get conversationPromptPlaceholder => 'Jūs esate puiki programėlė, gausite pokalbio transkripcą ir santrauką...';
 
   @override
   String get notificationScopes => 'Pranešimų sritys';
@@ -2858,8 +2811,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get makeMyAppPublic => 'Padaryti mano programėlę viešą';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Pateikdamas šią programėlę, sutinku su Omi AI paslaugų teikimo sąlygomis ir privatumo politika';
+  String get submitAppTermsAgreement => 'Pateikdamas šią programėlę, sutinku su Omi AI paslaugų teikimo sąlygomis ir privatumo politika';
 
   @override
   String get submitApp => 'Pateikti programėlę';
@@ -2874,12 +2826,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get submitAppQuestion => 'Pateikti programėlę?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Jūsų programėlė bus peržiūrėta ir padaryta vieša. Galite pradėti ją naudoti iš karto, net peržiūros metu!';
+  String get submitAppPublicDescription => 'Jūsų programėlė bus peržiūrėta ir padaryta vieša. Galite pradėti ją naudoti iš karto, net peržiūros metu!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Jūsų programėlė bus peržiūrėta ir padaryta prieinama jums privačiai. Galite pradėti ją naudoti iš karto, net peržiūros metu!';
+  String get submitAppPrivateDescription => 'Jūsų programėlė bus peržiūrėta ir padaryta prieinama jums privačiai. Galite pradėti ją naudoti iš karto, net peržiūros metu!';
 
   @override
   String get startEarning => 'Pradėkite uždirbti! 💰';
@@ -2903,8 +2853,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get dataAccessNotice => 'Duomenų prieigos pranešimas';
 
   @override
-  String get dataAccessWarning =>
-      'Ši programa turės prieigą prie jūsų duomenų. Omi AI neatsako už tai, kaip ši programa naudoja, modifikuoja ar ištrina jūsų duomenis';
+  String get dataAccessWarning => 'Ši programa turės prieigą prie jūsų duomenų. Omi AI neatsako už tai, kaip ši programa naudoja, modifikuoja ar ištrina jūsų duomenis';
 
   @override
   String get installApp => 'Įdiegti programą';
@@ -2916,8 +2865,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get appUnderReviewOwner => 'Jūsų programa peržiūrima ir matoma tik jums. Ji taps vieša patvirtinus.';
 
   @override
-  String get appRejectedNotice =>
-      'Jūsų programa buvo atmesta. Atnaujinkite programos informaciją ir pateikite ją iš naujo peržiūrai.';
+  String get appRejectedNotice => 'Jūsų programa buvo atmesta. Atnaujinkite programos informaciją ir pateikite ją iš naujo peržiūrai.';
 
   @override
   String get setupSteps => 'Sąrankos veiksmai';
@@ -2979,8 +2927,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get descriptionLabel => 'Aprašymas';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Mano nuostabi programa yra puiki programa, kuri daro nuostabius dalykus. Tai geriausia programa!';
+  String get appDescriptionPlaceholder => 'Mano nuostabi programa yra puiki programa, kuri daro nuostabius dalykus. Tai geriausia programa!';
 
   @override
   String get pleaseProvideValidDescription => 'Pateikite tinkamą aprašymą';
@@ -3132,8 +3079,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get microphonePermissionRequired => 'Norint įrašyti balsą, reikalingas mikrofono leidimas.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofono leidimas atmestas. Suteikite leidimą Sistemos nustatymai > Privatumas ir sauga > Mikrofonas.';
+  String get microphonePermissionDenied => 'Mikrofono leidimas atmestas. Suteikite leidimą Sistemos nustatymai > Privatumas ir sauga > Mikrofonas.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3366,8 +3312,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get whatWeCollect => 'Ką renkame';
 
   @override
-  String get dataCollectionMessage =>
-      'Tęsdami, jūsų pokalbiai, įrašai ir asmeninė informacija bus saugiai saugomi mūsų serveriuose, kad galėtume teikti AI valdomą įžvalgą ir įgalinti visas programos funkcijas.';
+  String get dataCollectionMessage => 'Tęsdami, jūsų pokalbiai, įrašai ir asmeninė informacija bus saugiai saugomi mūsų serveriuose, kad galėtume teikti AI valdomą įžvalgą ir įgalinti visas programos funkcijas.';
 
   @override
   String get dataProtection => 'Duomenų apsauga';
@@ -3400,8 +3345,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Vardas turi būti bent 2 simbolių';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Pasakykite mums, kaip norėtumėte būti kreipiamasi. Tai padeda personalizuoti jūsų Omi patirtį.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Pasakykite mums, kaip norėtumėte būti kreipiamasi. Tai padeda personalizuoti jūsų Omi patirtį.';
 
   @override
   String charactersCount(int count) {
@@ -3418,8 +3362,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get recordAudioConversations => 'Įrašyti garso pokalbius';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi reikia mikrofono prieigos, kad įrašytų jūsų pokalbius ir pateiktų transkripciją.';
+  String get microphoneAccessDescription => 'Omi reikia mikrofono prieigos, kad įrašytų jūsų pokalbius ir pateiktų transkripciją.';
 
   @override
   String get screenRecording => 'Ekrano įrašymas';
@@ -3428,8 +3371,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Užfiksuoti sistemos garsą iš susitikimų';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi reikia ekrano įrašymo leidimo, kad užfiksuotų sistemos garsą iš jūsų naršyklėje vykstančių susitikimų.';
+  String get screenRecordingDescription => 'Omi reikia ekrano įrašymo leidimo, kad užfiksuotų sistemos garsą iš jūsų naršyklėje vykstančių susitikimų.';
 
   @override
   String get accessibility => 'Prieinamumas';
@@ -3438,8 +3380,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Aptikti naršyklėje vykstančius susitikimus';
 
   @override
-  String get accessibilityDescription =>
-      'Omi reikia prieinamumo leidimo, kad aptiktų, kada prisijungiate prie Zoom, Meet ar Teams susitikimų naršyklėje.';
+  String get accessibilityDescription => 'Omi reikia prieinamumo leidimo, kad aptiktų, kada prisijungiate prie Zoom, Meet ar Teams susitikimų naršyklėje.';
 
   @override
   String get pleaseWait => 'Prašome palaukti...';
@@ -3508,12 +3449,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get exportAllConversationsToJson => 'Eksportuokite visus savo pokalbius į JSON failą.';
 
   @override
-  String get conversationsExportStarted =>
-      'Pokalbių eksportavimas pradėtas. Tai gali užtrukti kelias sekundes, palaukite.';
+  String get conversationsExportStarted => 'Pokalbių eksportavimas pradėtas. Tai gali užtrukti kelias sekundes, palaukite.';
 
   @override
-  String get mcpDescription =>
-      'Norėdami prijungti Omi prie kitų programų, kad skaitytumėte, ieškotumėte ir tvarkytumėte savo prisiminimus ir pokalbius. Sukurkite raktą, kad pradėtumėte.';
+  String get mcpDescription => 'Norėdami prijungti Omi prie kitų programų, kad skaitytumėte, ieškotumėte ir tvarkytumėte savo prisiminimus ir pokalbius. Sukurkite raktą, kad pradėtumėte.';
 
   @override
   String get apiKeys => 'API raktai';
@@ -3560,8 +3499,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'Automatiškai kurti ir žymėti naujus kalbėtojus';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Automatiškai sukurti naują asmenį, kai transkripcijoje aptinkamas vardas.';
+  String get automaticallyCreateNewPerson => 'Automatiškai sukurti naują asmenį, kai transkripcijoje aptinkamas vardas.';
 
   @override
   String get pilotFeatures => 'Bandomosios funkcijos';
@@ -3670,8 +3608,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Ruošiamas sistemos garso įrašymas';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Spustelėkite mygtuką, kad įrašytumėte garsą tiesioginiam transkribavimui, AI įžvalgoms ir automatiniam išsaugojimui.';
+  String get clickTheButtonToCaptureAudio => 'Spustelėkite mygtuką, kad įrašytumėte garsą tiesioginiam transkribavimui, AI įžvalgoms ir automatiniam išsaugojimui.';
 
   @override
   String get reconnecting => 'Jungiamasi iš naujo...';
@@ -3874,8 +3811,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get shortcuts => 'Spartieji klavišai';
 
   @override
-  String get shortcutChangeInstruction =>
-      'Spustelėkite spartųjį klavišą, kad jį pakeistumėte. Paspauskite Escape, kad atšauktumėte.';
+  String get shortcutChangeInstruction => 'Spustelėkite spartųjį klavišą, kad jį pakeistumėte. Paspauskite Escape, kad atšauktumėte.';
 
   @override
   String get configureSTTProvider => 'Sukonfigūruoti STT teikėją';
@@ -3899,8 +3835,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Ištrinti žinių grafiką?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Tai ištrins visus išvestinius žinių grafiko duomenis. Jūsų originalios atminties išliks saugios.';
+  String get deleteKnowledgeGraphWarning => 'Tai ištrins visus išvestinius žinių grafiko duomenis. Jūsų originalios atminties išliks saugios.';
 
   @override
   String get connectOmiWithAI => 'Prijunkite Omi prie AI asistentų';
@@ -3957,8 +3892,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get updateAppQuestion => 'Atnaujinti programėlę?';
 
   @override
-  String get updateAppConfirmation =>
-      'Ar tikrai norite atnaujinti savo programėlę? Pakeitimai bus matomi po mūsų komandos peržiūros.';
+  String get updateAppConfirmation => 'Ar tikrai norite atnaujinti savo programėlę? Pakeitimai bus matomi po mūsų komandos peržiūros.';
 
   @override
   String get updateApp => 'Atnaujinti programėlę';
@@ -3988,8 +3922,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get no => 'Ne';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Prenumerata sėkmingai atšaukta. Ji liks aktyvi iki dabartinio atsiskaitymo laikotarpio pabaigos.';
+  String get subscriptionCancelledSuccessfully => 'Prenumerata sėkmingai atšaukta. Ji liks aktyvi iki dabartinio atsiskaitymo laikotarpio pabaigos.';
 
   @override
   String get failedToCancelSubscription => 'Nepavyko atšaukti prenumeratos. Bandykite dar kartą.';
@@ -4025,8 +3958,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Atšaukti prenumeratą?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Ar tikrai norite atšaukti prenumeratą? Turėsite prieigą iki dabartinio atsiskaitymo laikotarpio pabaigos.';
+  String get cancelSubscriptionConfirmation => 'Ar tikrai norite atšaukti prenumeratą? Turėsite prieigą iki dabartinio atsiskaitymo laikotarpio pabaigos.';
 
   @override
   String get cancelSubscriptionButton => 'Atšaukti prenumeratą';
@@ -4035,12 +3967,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get cancelling => 'Atšaukiama...';
 
   @override
-  String get betaTesterMessage =>
-      'Jūs esate šios programėlės beta testuotojas. Ji dar nėra vieša. Ji taps vieša po patvirtinimo.';
+  String get betaTesterMessage => 'Jūs esate šios programėlės beta testuotojas. Ji dar nėra vieša. Ji taps vieša po patvirtinimo.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Jūsų programėlė yra peržiūrima ir matoma tik jums. Ji taps vieša po patvirtinimo.';
+  String get appUnderReviewMessage => 'Jūsų programėlė yra peržiūrima ir matoma tik jums. Ji taps vieša po patvirtinimo.';
 
   @override
   String get appRejectedMessage => 'Jūsų programėlė buvo atmesta. Atnaujinkite informaciją ir pateikite iš naujo.';
@@ -4097,8 +4027,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get issueActivatingApp => 'Aktyvuojant šią programėlę įvyko klaida. Bandykite dar kartą.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Ši programėlė turės prieigą prie jūsų duomenų. Omi AI nėra atsakinga už tai, kaip jūsų duomenis naudoja, keičia ar ištrina ši programėlė';
+  String get dataAccessNoticeDescription => 'Ši programėlė turės prieigą prie jūsų duomenų. Omi AI nėra atsakinga už tai, kaip jūsų duomenis naudoja, keičia ar ištrina ši programėlė';
 
   @override
   String get copyUrl => 'Kopijuoti URL';
@@ -4186,8 +4115,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get omiApiKeys => 'Omi API raktai';
 
   @override
-  String get apiKeysDescription =>
-      'API raktai naudojami autentifikavimui, kai jūsų programa bendrauja su OMI serveriu. Jie leidžia jūsų programai kurti prisiminimus ir saugiai pasiekti kitas OMI paslaugas.';
+  String get apiKeysDescription => 'API raktai naudojami autentifikavimui, kai jūsų programa bendrauja su OMI serveriu. Jie leidžia jūsų programai kurti prisiminimus ir saugiai pasiekti kitas OMI paslaugas.';
 
   @override
   String get aboutOmiApiKeys => 'Apie Omi API raktus';
@@ -4211,8 +4139,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Atšaukti API raktą?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Šio veiksmo negalima atšaukti. Programos, naudojančios šį raktą, nebegalės pasiekti API.';
+  String get revokeApiKeyWarning => 'Šio veiksmo negalima atšaukti. Programos, naudojančios šį raktą, nebegalės pasiekti API.';
 
   @override
   String get revoke => 'Atšaukti';
@@ -4310,8 +4237,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get externalAppAccess => 'Išorinių programų prieiga';
 
   @override
-  String get externalAppAccessDescription =>
-      'Šios įdiegtos programos turi išorines integracijas ir gali pasiekti jūsų duomenis, tokius kaip pokalbiai ir prisiminimai.';
+  String get externalAppAccessDescription => 'Šios įdiegtos programos turi išorines integracijas ir gali pasiekti jūsų duomenis, tokius kaip pokalbiai ir prisiminimai.';
 
   @override
   String get noExternalAppsHaveAccess => 'Jokios išorinės programos neturi prieigos prie jūsų duomenų.';
@@ -4320,8 +4246,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimalus saugumas (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Šifravimas nuo galo iki galo yra privatumo aukso standartas. Kai įjungta, jūsų duomenys užšifruojami jūsų įrenginyje prieš juos siunčiant į mūsų serverius. Tai reiškia, kad niekas, net Omi, negali pasiekti jūsų turinio.';
+  String get e2eeDescription => 'Šifravimas nuo galo iki galo yra privatumo aukso standartas. Kai įjungta, jūsų duomenys užšifruojami jūsų įrenginyje prieš juos siunčiant į mūsų serverius. Tai reiškia, kad niekas, net Omi, negali pasiekti jūsų turinio.';
 
   @override
   String get importantTradeoffs => 'Svarbūs kompromisai:';
@@ -4355,19 +4280,16 @@ class AppLocalizationsLt extends AppLocalizations {
   String get secureEncryption => 'Saugus šifravimas';
 
   @override
-  String get secureEncryptionDescription =>
-      'Jūsų duomenys yra užšifruoti jums unikaliu raktu mūsų serveriuose, prieglobstuose Google Cloud. Tai reiškia, kad jūsų neapdoroti duomenys yra neprieinami niekam, įskaitant Omi darbuotojus ar Google, tiesiogiai iš duomenų bazės.';
+  String get secureEncryptionDescription => 'Jūsų duomenys yra užšifruoti jums unikaliu raktu mūsų serveriuose, prieglobstuose Google Cloud. Tai reiškia, kad jūsų neapdoroti duomenys yra neprieinami niekam, įskaitant Omi darbuotojus ar Google, tiesiogiai iš duomenų bazės.';
 
   @override
   String get endToEndEncryption => 'Šifravimas nuo galo iki galo';
 
   @override
-  String get e2eeCardDescription =>
-      'Įgalinkite maksimaliam saugumui, kai tik jūs galite pasiekti savo duomenis. Bakstelėkite, kad sužinotumėte daugiau.';
+  String get e2eeCardDescription => 'Įgalinkite maksimaliam saugumui, kai tik jūs galite pasiekti savo duomenis. Bakstelėkite, kad sužinotumėte daugiau.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Nepriklausomai nuo lygio, jūsų duomenys visada yra užšifruoti ramybės būsenoje ir perduodami.';
+  String get dataAlwaysEncrypted => 'Nepriklausomai nuo lygio, jūsų duomenys visada yra užšifruoti ramybės būsenoje ir perduodami.';
 
   @override
   String get readOnlyScope => 'Tik skaitymas';
@@ -4432,12 +4354,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get trainingDataProgram => 'Mokymo duomenų programa';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Gaukite Omi Unlimited nemokamai, prisidėdami savo duomenimis prie AI modelių mokymo.';
+  String get getOmiUnlimitedFree => 'Gaukite Omi Unlimited nemokamai, prisidėdami savo duomenimis prie AI modelių mokymo.';
 
   @override
-  String get trainingDataBullets =>
-      '• Jūsų duomenys padeda tobulinti AI modelius\n• Dalijamasi tik nejautriais duomenimis\n• Visiškai skaidrus procesas';
+  String get trainingDataBullets => '• Jūsų duomenys padeda tobulinti AI modelius\n• Dalijamasi tik nejautriais duomenimis\n• Visiškai skaidrus procesas';
 
   @override
   String get learnMoreAtOmiTraining => 'Sužinokite daugiau omi.me/training';
@@ -4487,8 +4407,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get monthlyPlanContinues => 'Jūsų dabartinis mėnesinis planas tęsis iki atsiskaitymo laikotarpio pabaigos';
 
   @override
-  String get paymentMethodCharged =>
-      'Jūsų esamas mokėjimo būdas bus automatiškai apmokestintas, kai baigsis mėnesinis planas';
+  String get paymentMethodCharged => 'Jūsų esamas mokėjimo būdas bus automatiškai apmokestintas, kai baigsis mėnesinis planas';
 
   @override
   String get annualSubscriptionStarts => 'Jūsų 12 mėnesių metinė prenumerata automatiškai prasidės po apmokėjimo';
@@ -4531,8 +4450,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Jūsų metinis planas automatiškai prasidės, kai baigsis mėnesinis planas.';
+  String get annualPlanStartsAutomatically => 'Jūsų metinis planas automatiškai prasidės, kai baigsis mėnesinis planas.';
 
   @override
   String planRenewsOn(String date) {
@@ -4599,8 +4517,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Jūsų privatumas mums svarbus';
 
   @override
-  String get privacyIntroText =>
-      'Omi labai rimtai žiūrime į jūsų privatumą. Norime būti skaidrūs dėl renkamų duomenų ir kaip juos naudojame. Štai ką turite žinoti:';
+  String get privacyIntroText => 'Omi labai rimtai žiūrime į jūsų privatumą. Norime būti skaidrūs dėl renkamų duomenų ir kaip juos naudojame. Štai ką turite žinoti:';
 
   @override
   String get whatWeTrack => 'Ką sekame';
@@ -4615,12 +4532,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get ourCommitment => 'Mūsų įsipareigojimas';
 
   @override
-  String get commitmentText =>
-      'Mes įsipareigojame naudoti surinktus duomenis tik tam, kad Omi būtų geresnis produktas jums. Jūsų privatumas ir pasitikėjimas mums yra svarbiausias.';
+  String get commitmentText => 'Mes įsipareigojame naudoti surinktus duomenis tik tam, kad Omi būtų geresnis produktas jums. Jūsų privatumas ir pasitikėjimas mums yra svarbiausias.';
 
   @override
-  String get thankYouText =>
-      'Dėkojame, kad esate vertinamas Omi vartotojas. Jei turite klausimų ar rūpesčių, susisiekite su mumis adresu team@basedhardware.com.';
+  String get thankYouText => 'Dėkojame, kad esate vertinamas Omi vartotojas. Jei turite klausimų ar rūpesčių, susisiekite su mumis adresu team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi sinchronizavimo nustatymai';
@@ -4629,8 +4544,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get enterHotspotCredentials => 'Įveskite telefono viešosios prieigos taško duomenis';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi sinchronizavimas naudoja jūsų telefoną kaip viešosios prieigos tašką. Raskite pavadinimą ir slaptažodį Nustatymai > Asmeninis viešosios prieigos taškas.';
+  String get wifiSyncUsesHotspot => 'WiFi sinchronizavimas naudoja jūsų telefoną kaip viešosios prieigos tašką. Raskite pavadinimą ir slaptažodį Nustatymai > Asmeninis viešosios prieigos taškas.';
 
   @override
   String get hotspotNameSsid => 'Viešosios prieigos taško pavadinimas (SSID)';
@@ -4665,8 +4579,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nepavyko sukurti santraukos. Įsitikinkite, kad turite pokalbių tai dienai.';
+  String get failedToGenerateSummaryCheckConversations => 'Nepavyko sukurti santraukos. Įsitikinkite, kad turite pokalbių tai dienai.';
 
   @override
   String get summaryNotFound => 'Santrauka nerasta';
@@ -4696,8 +4609,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Eksportas pradėtas. Tai gali užtrukti kelias sekundes...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Tai ištrins visus išvestinius žinių grafo duomenis (mazgus ir ryšius). Jūsų originalūs prisiminimai išliks saugūs. Grafas bus atstatytas laikui bėgant arba kitą kartą pateikus užklausą.';
+  String get knowledgeGraphDeleteDescription => 'Tai ištrins visus išvestinius žinių grafo duomenis (mazgus ir ryšius). Jūsų originalūs prisiminimai išliks saugūs. Grafas bus atstatytas laikui bėgant arba kitą kartą pateikus užklausą.';
 
   @override
   String get configureDailySummaryDigest => 'Sukonfigūruokite savo kasdienę užduočių suvestinę';
@@ -4767,8 +4679,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Ištrinti visus Limitless pokalbius?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Tai visam laikui ištrins visus iš Limitless importuotus pokalbius. Šio veiksmo negalima atšaukti.';
+  String get deleteAllLimitlessWarning => 'Tai visam laikui ištrins visus iš Limitless importuotus pokalbius. Šio veiksmo negalima atšaukti.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4824,8 +4735,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get howItWorksTitle => 'Kaip tai veikia?';
 
   @override
-  String get howPeopleWorks =>
-      'Kai asmuo sukurtas, galite eiti į pokalbio transkripciją ir priskirti jam atitinkamus segmentus, tokiu būdu Omi galės atpažinti ir jų kalbą!';
+  String get howPeopleWorks => 'Kai asmuo sukurtas, galite eiti į pokalbio transkripciją ir priskirti jam atitinkamus segmentus, tokiu būdu Omi galės atpažinti ir jų kalbą!';
 
   @override
   String get tapToDelete => 'Bakstelėkite, kad ištrintumėte';
@@ -4851,8 +4761,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get privacyNotice => 'Privatumo pranešimas';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Įrašai gali užfiksuoti kitų balsus. Prieš įjungdami įsitikinkite, kad turite visų dalyvių sutikimą.';
+  String get recordingsMayCaptureOthers => 'Įrašai gali užfiksuoti kitų balsus. Prieš įjungdami įsitikinkite, kad turite visų dalyvių sutikimą.';
 
   @override
   String get enable => 'Įjungti';
@@ -4864,8 +4773,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get on => 'Įj.';
 
   @override
-  String get storeAudioDescription =>
-      'Saugokite visus garso įrašus lokaliai savo telefone. Išjungus, saugomi tik nepavykę įkėlimai, kad būtų sutaupyta vietos.';
+  String get storeAudioDescription => 'Saugokite visus garso įrašus lokaliai savo telefone. Išjungus, saugomi tik nepavykę įkėlimai, kad būtų sutaupyta vietos.';
 
   @override
   String get enableLocalStorage => 'Įjungti vietinę saugyklą';
@@ -4883,12 +4791,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get storeAudioOnCloud => 'Saugoti garsą debesyje';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Jūsų įrašai realiuoju laiku bus saugomi privačioje debesų saugykloje, kol kalbate.';
+  String get cloudStorageDialogMessage => 'Jūsų įrašai realiuoju laiku bus saugomi privačioje debesų saugykloje, kol kalbate.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Saugokite savo įrašus realiuoju laiku privačioje debesų saugykloje, kol kalbate. Garsas fiksuojamas ir saugiai išsaugomas realiuoju laiku.';
+  String get storeAudioCloudDescription => 'Saugokite savo įrašus realiuoju laiku privačioje debesų saugykloje, kol kalbate. Garsas fiksuojamas ir saugiai išsaugomas realiuoju laiku.';
 
   @override
   String get downloadingFirmware => 'Atsisiunčiama programinė įranga';
@@ -4897,8 +4803,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get installingFirmware => 'Diegiama programinė įranga';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Neuždarykite programos ir neišjunkite įrenginio. Tai gali sugadinti jūsų įrenginį.';
+  String get firmwareUpdateWarning => 'Neuždarykite programos ir neišjunkite įrenginio. Tai gali sugadinti jūsų įrenginį.';
 
   @override
   String get firmwareUpdated => 'Programinė įranga atnaujinta';
@@ -4942,8 +4847,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get payments => 'Mokėjimai';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Prijunkite mokėjimo būdą žemiau, kad pradėtumėte gauti išmokas už savo programas.';
+  String get connectPaymentMethodInfo => 'Prijunkite mokėjimo būdą žemiau, kad pradėtumėte gauti išmokas už savo programas.';
 
   @override
   String get selectedPaymentMethod => 'Pasirinktas mokėjimo būdas';
@@ -4970,8 +4874,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get monthlyPayouts => 'Mėnesiniai mokėjimai';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Gaukite mėnesinius mokėjimus tiesiai į sąskaitą, kai pasiekiate 10 \$ uždarbį';
+  String get monthlyPayoutsDescription => 'Gaukite mėnesinius mokėjimus tiesiai į sąskaitą, kai pasiekiate 10 \$ uždarbį';
 
   @override
   String get secureAndReliable => 'Saugus ir patikimas';
@@ -4998,8 +4901,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get connectingYourStripeAccount => 'Jūsų Stripe paskyros prijungimas';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Prašome užbaigti Stripe registracijos procesą naršyklėje. Šis puslapis bus automatiškai atnaujintas po užbaigimo.';
+  String get stripeOnboardingInstructions => 'Prašome užbaigti Stripe registracijos procesą naršyklėje. Šis puslapis bus automatiškai atnaujintas po užbaigimo.';
 
   @override
   String get failedTryAgain => 'Nepavyko? Bandykite dar kartą';
@@ -5011,8 +4913,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get successfullyConnected => 'Sėkmingai prisijungta!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Jūsų Stripe paskyra dabar paruošta gauti mokėjimus. Galite iš karto pradėti uždirbti iš programų pardavimų.';
+  String get stripeReadyForPayments => 'Jūsų Stripe paskyra dabar paruošta gauti mokėjimus. Galite iš karto pradėti uždirbti iš programų pardavimų.';
 
   @override
   String get updateStripeDetails => 'Atnaujinti Stripe duomenis';
@@ -5030,8 +4931,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Atnaujinkite savo PayPal paskyros duomenis';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Prijunkite savo PayPal paskyrą, kad pradėtumėte gauti mokėjimus už savo programas';
+  String get connectPayPalToReceivePayments => 'Prijunkite savo PayPal paskyrą, kad pradėtumėte gauti mokėjimus už savo programas';
 
   @override
   String get paypalEmail => 'PayPal el. paštas';
@@ -5040,8 +4940,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me nuoroda';
 
   @override
-  String get stripeRecommendation =>
-      'Jei Stripe yra prieinamas jūsų šalyje, labai rekomenduojame jį naudoti greitesnėms ir lengvesnėms išmokoms.';
+  String get stripeRecommendation => 'Jei Stripe yra prieinamas jūsų šalyje, labai rekomenduojame jį naudoti greitesnėms ir lengvesnėms išmokoms.';
 
   @override
   String get updatePayPalDetails => 'Atnaujinti PayPal duomenis';
@@ -5093,12 +4992,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Papildomas balso pavyzdys pašalintas';
 
   @override
-  String get consentDataMessage =>
-      'Tęsdami, jūsų pokalbiai, įrašai ir asmeninė informacija bus saugiai saugomi mūsų serveriuose. Jūsų garso įrašai ir transkripcijos apdorojami trečiųjų šalių AI paslaugų (įskaitant Deepgram transkripcijai ir OpenAI analizei), kad suteiktų jums AI paremtas įžvalgas ir įgalintų visas programėlės funkcijas.';
+  String get consentDataMessage => 'Tęsdami, jūsų pokalbiai, įrašai ir asmeninė informacija bus saugiai saugomi mūsų serveriuose. Jūsų garso įrašai ir transkripcijos apdorojami trečiųjų šalių AI paslaugų (įskaitant Deepgram transkripcijai ir OpenAI analizei), kad suteiktų jums AI paremtas įžvalgas ir įgalintų visas programėlės funkcijas.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Užduotys iš jūsų pokalbių bus rodomos čia.\nBakstelėkite + norėdami sukurti rankiniu būdu.';
+  String get tasksEmptyStateMessage => 'Užduotys iš jūsų pokalbių bus rodomos čia.\nBakstelėkite + norėdami sukurti rankiniu būdu.';
 
   @override
   String get clearChatAction => 'Išvalyti pokalbį';
@@ -5134,15 +5031,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Įdiekite Omi savo\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Norėdami naudoti Apple Watch su Omi, pirmiausia turite įdiegti Omi programą savo laikrodyje.';
+  String get installOmiOnAppleWatchDescription => 'Norėdami naudoti Apple Watch su Omi, pirmiausia turite įdiegti Omi programą savo laikrodyje.';
 
   @override
   String get openOmiOnAppleWatch => 'Atidarykite Omi savo\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi programa įdiegta jūsų Apple Watch. Atidarykite ją ir bakstelėkite Pradėti.';
+  String get openOmiOnAppleWatchDescription => 'Omi programa įdiegta jūsų Apple Watch. Atidarykite ją ir bakstelėkite Pradėti.';
 
   @override
   String get openWatchApp => 'Atidaryti Watch programą';
@@ -5151,15 +5046,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Įdiegiau ir atidariau programą';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Nepavyko atidaryti Apple Watch programos. Rankiniu būdu atidarykite Watch programą savo Apple Watch ir įdiekite Omi iš skyriaus \"Galimos programos\".';
+  String get unableToOpenWatchApp => 'Nepavyko atidaryti Apple Watch programos. Rankiniu būdu atidarykite Watch programą savo Apple Watch ir įdiekite Omi iš skyriaus \"Galimos programos\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch sėkmingai prijungtas!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch vis dar nepasiekiamas. Įsitikinkite, kad Omi programa atidaryta jūsų laikrodyje.';
+  String get appleWatchNotReachable => 'Apple Watch vis dar nepasiekiamas. Įsitikinkite, kad Omi programa atidaryta jūsų laikrodyje.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5587,8 +5480,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get multipleSpeakersDetected => 'Aptikti keli kalbėtojai';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Atrodo, kad įraše yra keli kalbėtojai. Įsitikinkite, kad esate ramioje vietoje ir bandykite dar kartą.';
+  String get multipleSpeakersDescription => 'Atrodo, kad įraše yra keli kalbėtojai. Įsitikinkite, kad esate ramioje vietoje ir bandykite dar kartą.';
 
   @override
   String get invalidRecordingDetected => 'Aptiktas netinkamas įrašas';
@@ -5606,8 +5498,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get howToTakeGoodSample => 'Kaip padaryti gerą pavyzdį?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Įsitikinkite, kad esate ramioje vietoje.\n2. Kalbėkite aiškiai ir natūraliai.\n3. Įsitikinkite, kad jūsų įrenginys yra natūralioje padėtyje ant kaklo.\n\nSukūrus visada galite patobulinti arba padaryti iš naujo.';
+  String get goodSampleInstructions => '1. Įsitikinkite, kad esate ramioje vietoje.\n2. Kalbėkite aiškiai ir natūraliai.\n3. Įsitikinkite, kad jūsų įrenginys yra natūralioje padėtyje ant kaklo.\n\nSukūrus visada galite patobulinti arba padaryti iš naujo.';
 
   @override
   String get noDeviceConnectedUseMic => 'Neprijungtas joks įrenginys. Bus naudojamas telefono mikrofonas.';
@@ -5670,12 +5561,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get howItWorks => 'Kaip tai veikia';
 
   @override
-  String get dailyScoreExplanation =>
-      'Jūsų dienos balas pagrįstas užduočių atlikimu. Atlikite užduotis, kad pagerintumėte balą!';
+  String get dailyScoreExplanation => 'Jūsų dienos balas pagrįstas užduočių atlikimu. Atlikite užduotis, kad pagerintumėte balą!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Valdykite, kaip dažnai Omi siunčia jums aktyvius pranešimus ir priminimus.';
+  String get notificationFrequencyDescription => 'Valdykite, kaip dažnai Omi siunčia jums aktyvius pranešimus ir priminimus.';
 
   @override
   String get sliderOff => 'Išjungta';
@@ -5768,8 +5657,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get selectApp => 'Pasirinkti programą';
 
   @override
-  String get noChatAppsEnabled =>
-      'Nėra įjungtų pokalbių programų.\nBakstelėkite \"Įjungti programas\", kad pridėtumėte.';
+  String get noChatAppsEnabled => 'Nėra įjungtų pokalbių programų.\nBakstelėkite \"Įjungti programas\", kad pridėtumėte.';
 
   @override
   String get disable => 'Išjungti';
@@ -5921,8 +5809,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get recordings => 'Įrašai';
 
   @override
-  String get enableRemindersAccess =>
-      'Norėdami naudoti Apple Priminimus, įgalinkite prieigą prie Priminimų Nustatymuose';
+  String get enableRemindersAccess => 'Norėdami naudoti Apple Priminimus, įgalinkite prieigą prie Priminimų Nustatymuose';
 
   @override
   String todayAtTime(String time) {
@@ -6051,15 +5938,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get cloudProvider => 'Debesies tiekėjas';
 
   @override
-  String get premiumMinutesInfo =>
-      '1 200 premium minučių per mėnesį. Įrenginio skirtukas siūlo neribotą nemokamą transkripciją.';
+  String get premiumMinutesInfo => '1 200 premium minučių per mėnesį. Įrenginio skirtukas siūlo neribotą nemokamą transkripciją.';
 
   @override
   String get viewUsage => 'Peržiūrėti naudojimą';
 
   @override
-  String get localProcessingInfo =>
-      'Garsas apdorojamas vietoje. Veikia neprisijungus, privatiau, bet naudoja daugiau akumuliatoriaus.';
+  String get localProcessingInfo => 'Garsas apdorojamas vietoje. Veikia neprisijungus, privatiau, bet naudoja daugiau akumuliatoriaus.';
 
   @override
   String get model => 'Modelis';
@@ -6068,15 +5953,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get performanceWarning => 'Veikimo įspėjimas';
 
   @override
-  String get largeModelWarning =>
-      'Šis modelis yra didelis ir gali sukelti programos gedimą arba labai lėtą veikimą mobiliuosiuose įrenginiuose.\n\nRekomenduojama \"small\" arba \"base\".';
+  String get largeModelWarning => 'Šis modelis yra didelis ir gali sukelti programos gedimą arba labai lėtą veikimą mobiliuosiuose įrenginiuose.\n\nRekomenduojama \"small\" arba \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Naudojamas vietinis iOS kalbos atpažinimas';
 
   @override
-  String get noModelDownloadRequired =>
-      'Bus naudojamas jūsų įrenginio kalbos variklis. Modelio atsisiuntimas nereikalingas.';
+  String get noModelDownloadRequired => 'Bus naudojamas jūsų įrenginio kalbos variklis. Modelio atsisiuntimas nereikalingas.';
 
   @override
   String get modelReady => 'Modelis paruoštas';
@@ -6133,12 +6016,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get batteryDrainSignificantly => 'Baterijos išsikrovimas žymiai padidės.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 premium minučių/mėn. Įrenginyje skirtukas siūlo neribotą nemokamą transkripciją. ';
+  String get premiumMinutesMonth => '1200 premium minučių/mėn. Įrenginyje skirtukas siūlo neribotą nemokamą transkripciją. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Garsas apdorojamas vietoje. Veikia neprisijungus, privatiau, bet naudoja daugiau baterijos.';
+  String get audioProcessedLocally => 'Garsas apdorojamas vietoje. Veikia neprisijungus, privatiau, bet naudoja daugiau baterijos.';
 
   @override
   String get languageLabel => 'Kalba';
@@ -6147,12 +6028,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get modelLabel => 'Modelis';
 
   @override
-  String get modelTooLargeWarning =>
-      'Šis modelis yra didelis ir gali sukelti programos užstrigimą arba labai lėtą veikimą mobiliuosiuose įrenginiuose.\n\nRekomenduojama small arba base.';
+  String get modelTooLargeWarning => 'Šis modelis yra didelis ir gali sukelti programos užstrigimą arba labai lėtą veikimą mobiliuosiuose įrenginiuose.\n\nRekomenduojama small arba base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Bus naudojamas jūsų įrenginio vietinis kalbos variklis. Modelio atsisiuntimas nereikalingas.';
+  String get nativeEngineNoDownload => 'Bus naudojamas jūsų įrenginio vietinis kalbos variklis. Modelio atsisiuntimas nereikalingas.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6188,8 +6067,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi integruota tiesioginė transkripcija optimizuota realaus laiko pokalbiams su automatiniu kalbėtojų aptikimu ir diarizacija.';
+  String get omiTranscriptionOptimized => 'Omi integruota tiesioginė transkripcija optimizuota realaus laiko pokalbiams su automatiniu kalbėtojų aptikimu ir diarizacija.';
 
   @override
   String get reset => 'Atstatyti';
@@ -6409,8 +6287,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Kuriamas žinių grafas iš prisiminimų...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Jūsų žinių grafas bus sukurtas automatiškai, kai sukursite naujų prisiminimų.';
+  String get knowledgeGraphWillBuildAutomatically => 'Jūsų žinių grafas bus sukurtas automatiškai, kai sukursite naujų prisiminimų.';
 
   @override
   String get buildGraphButton => 'Sukurti grafą';
@@ -6712,8 +6589,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Atsisiunčiamas garsas iš jūsų įrenginio SD kortelės';
 
   @override
-  String get transferRequiredDescription =>
-      'Šis įrašas saugomas jūsų įrenginio SD kortelėje. Perkelkite jį į telefoną, kad galėtumėte paleisti arba bendrinti.';
+  String get transferRequiredDescription => 'Šis įrašas saugomas jūsų įrenginio SD kortelėje. Perkelkite jį į telefoną, kad galėtumėte paleisti arba bendrinti.';
 
   @override
   String get cancelTransfer => 'Atšaukti perkėlimą';
@@ -6734,8 +6610,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get shareRecording => 'Bendrinti įrašą';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Ar tikrai norite visam laikui ištrinti šį įrašą? Šio veiksmo negalima atšaukti.';
+  String get deleteRecordingConfirmation => 'Ar tikrai norite visam laikui ištrinti šį įrašą? Šio veiksmo negalima atšaukti.';
 
   @override
   String get recordingIdLabel => 'Įrašo ID';
@@ -6794,8 +6669,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get enableFastTransfer => 'Įjungti greitą perdavimą';
 
   @override
-  String get fastTransferDescription =>
-      'Greitas perdavimas naudoja WiFi ~5x greitesniam greičiui. Perdavimo metu telefonas laikinai prisijungs prie Omi įrenginio WiFi tinklo.';
+  String get fastTransferDescription => 'Greitas perdavimas naudoja WiFi ~5x greitesniam greičiui. Perdavimo metu telefonas laikinai prisijungs prie Omi įrenginio WiFi tinklo.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Interneto prieiga pristabdyta perdavimo metu';
@@ -6810,8 +6684,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fiveTimesFaster => '5X GREIČIAU';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Sukuria tiesioginį WiFi ryšį su Omi įrenginiu. Perdavimo metu telefonas laikinai atsijungia nuo įprasto WiFi.';
+  String get fastTransferMethodDescription => 'Sukuria tiesioginį WiFi ryšį su Omi įrenginiu. Perdavimo metu telefonas laikinai atsijungia nuo įprasto WiFi.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6820,8 +6693,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get bleSpeed => '~30 KB/s per BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Naudoja standartinį Bluetooth Low Energy ryšį. Lėčiau, bet neturi įtakos WiFi ryšiui.';
+  String get bluetoothMethodDescription => 'Naudoja standartinį Bluetooth Low Energy ryšį. Lėčiau, bet neturi įtakos WiFi ryšiui.';
 
   @override
   String get selected => 'Pasirinkta';
@@ -6859,12 +6731,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get appDeleteFailed => 'Nepavyko ištrinti programos. Bandykite vėliau.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Programos matomumas sėkmingai pakeistas. Gali užtrukti kelias minutes.';
+  String get appVisibilityChangedSuccessfully => 'Programos matomumas sėkmingai pakeistas. Gali užtrukti kelias minutes.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Klaida aktyvuojant programą. Jei tai integracijos programa, įsitikinkite, kad sąranka užbaigta.';
+  String get errorActivatingAppIntegration => 'Klaida aktyvuojant programą. Jei tai integracijos programa, įsitikinkite, kad sąranka užbaigta.';
 
   @override
   String get errorUpdatingAppStatus => 'Atnaujinant programos būseną įvyko klaida.';
@@ -6932,8 +6802,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get importantConversationTitle => 'Svarbus pokalbis';
 
   @override
-  String get importantConversationBody =>
-      'Ką tik turėjote svarbų pokalbį. Bakstelėkite, kad pasidalintumėte santrauka.';
+  String get importantConversationBody => 'Ką tik turėjote svarbų pokalbį. Bakstelėkite, kad pasidalintumėte santrauka.';
 
   @override
   String get templateName => 'Šablono pavadinimas';
@@ -6945,8 +6814,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Pavadinimas turi būti bent 3 simbolių';
 
   @override
-  String get conversationPromptHint =>
-      'pvz., Ištraukite veiksmų punktus, priimtus sprendimus ir pagrindinius dalykus iš pokalbio.';
+  String get conversationPromptHint => 'pvz., Ištraukite veiksmų punktus, priimtus sprendimus ir pagrindinius dalykus iš pokalbio.';
 
   @override
   String get pleaseEnterAppPrompt => 'Įveskite programėlės užuominą';
@@ -7133,19 +7001,16 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Atnaujinimas suplanuotas\\! Jūsų mėnesinis planas tęsiasi iki atsiskaitymo laikotarpio pabaigos, tada automatiškai persijungia į metinį.';
+  String get planUpgradeScheduledMessage => 'Atnaujinimas suplanuotas\\! Jūsų mėnesinis planas tęsiasi iki atsiskaitymo laikotarpio pabaigos, tada automatiškai persijungia į metinį.';
 
   @override
   String get couldNotSchedulePlanChange => 'Nepavyko suplanuoti plano pakeitimo. Bandykite dar kartą.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Jūsų prenumerata buvo atnaujinta\\! Dabar mokėjimo nėra – jums bus išrašyta sąskaita jūsų dabartinio laikotarpio pabaigoje.';
+  String get subscriptionReactivatedDefault => 'Jūsų prenumerata buvo atnaujinta\\! Dabar mokėjimo nėra – jums bus išrašyta sąskaita jūsų dabartinio laikotarpio pabaigoje.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Prenumerata sėkminga\\! Jums buvo nuskaičiuota už naują atsiskaitymo laikotarpį.';
+  String get subscriptionSuccessfulCharged => 'Prenumerata sėkminga\\! Jums buvo nuskaičiuota už naują atsiskaitymo laikotarpį.';
 
   @override
   String get couldNotProcessSubscription => 'Nepavyko apdoroti prenumeratos. Bandykite dar kartą.';
@@ -7325,8 +7190,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Norint prisijungti prie įrenginio, reikalingas Bluetooth leidimas.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth leidimas atmestas. Suteikite leidimą Sistemos nuostatose.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth leidimas atmestas. Suteikite leidimą Sistemos nuostatose.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7339,12 +7203,10 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Pranešimų leidimas atmestas. Suteikite leidimą Sistemos nuostatose.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Pranešimų leidimas atmestas. Suteikite leidimą Sistemos nuostatose.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Pranešimų leidimas atmestas. Suteikite leidimą Sistemos nuostatos > Pranešimai.';
+  String get onboardingNotificationDeniedNotifications => 'Pranešimų leidimas atmestas. Suteikite leidimą Sistemos nuostatos > Pranešimai.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7357,15 +7219,13 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Suteikite vietos leidimą Nustatymai > Privatumas ir sauga > Vietos paslaugos';
+  String get onboardingLocationGrantInSettings => 'Suteikite vietos leidimą Nustatymai > Privatumas ir sauga > Vietos paslaugos';
 
   @override
   String get onboardingMicrophoneRequired => 'Įrašymui reikalingas mikrofono leidimas.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofono leidimas atmestas. Suteikite leidimą Sistemos nuostatos > Privatumas ir sauga > Mikrofonas.';
+  String get onboardingMicrophoneDenied => 'Mikrofono leidimas atmestas. Suteikite leidimą Sistemos nuostatos > Privatumas ir sauga > Mikrofonas.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7381,8 +7241,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Sistemos garso įrašymui reikalingas ekrano fiksavimo leidimas.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Ekrano fiksavimo leidimas atmestas. Suteikite leidimą Sistemos nuostatos > Privatumas ir sauga > Ekrano įrašymas.';
+  String get onboardingScreenCaptureDenied => 'Ekrano fiksavimo leidimas atmestas. Suteikite leidimą Sistemos nuostatos > Privatumas ir sauga > Ekrano įrašymas.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7435,8 +7294,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Nuotraukų leidimas atmestas. Leiskite prieigą prie nuotraukų, kad galėtumėte pasirinkti paveikslėlius';
+  String get msgPhotosPermissionDenied => 'Nuotraukų leidimas atmestas. Leiskite prieigą prie nuotraukų, kad galėtumėte pasirinkti paveikslėlius';
 
   @override
   String get msgSelectImagesGenericError => 'Klaida renkantis paveikslėlius. Bandykite dar kartą.';
@@ -7508,8 +7366,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get locationPermissionRequired => 'Reikalingas vietos leidimas';
 
   @override
-  String get locationPermissionContent =>
-      'Greitam perdavimui reikia vietos leidimo, kad būtų galima patikrinti WiFi ryšį. Suteikite vietos leidimą, kad galėtumėte tęsti.';
+  String get locationPermissionContent => 'Greitam perdavimui reikia vietos leidimo, kad būtų galima patikrinti WiFi ryšį. Suteikite vietos leidimą, kad galėtumėte tęsti.';
 
   @override
   String get pdfTranscriptExport => 'Transkripcijos eksportas';
@@ -7672,8 +7529,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Įrenginys nepalaiko WiFi sinchronizavimo, perjungiama į Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Įrenginys nepalaiko WiFi sinchronizavimo, perjungiama į Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health nepasiekiama šiame įrenginyje';
@@ -7969,8 +7825,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Įjunkite Omi DevKit susiejimo režimą';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Paspauskite mygtuką vieną kartą, kad įjungtumėte. LED mirksės violetine spalva susiejimo režimu.';
+  String get pairingDescOmiDevkit => 'Paspauskite mygtuką vieną kartą, kad įjungtumėte. LED mirksės violetine spalva susiejimo režimu.';
 
   @override
   String get pairingTitleOmiGlass => 'Įjunkite Omi Glass';
@@ -7982,8 +7837,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Įjunkite Plaud Note susiejimo režimą';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Paspauskite ir palaikykite šoninį mygtuką 2 sekundes. Raudonas LED mirksės, kai bus paruoštas susiejimui.';
+  String get pairingDescPlaudNote => 'Paspauskite ir palaikykite šoninį mygtuką 2 sekundes. Raudonas LED mirksės, kai bus paruoštas susiejimui.';
 
   @override
   String get pairingTitleBee => 'Įjunkite Bee susiejimo režimą';
@@ -7995,15 +7849,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get pairingTitleLimitless => 'Įjunkite Limitless susiejimo režimą';
 
   @override
-  String get pairingDescLimitless =>
-      'Kai matoma bet kokia šviesa, paspauskite vieną kartą, tada paspauskite ir palaikykite, kol įrenginys parodys rožinę šviesą, tada atleiskite.';
+  String get pairingDescLimitless => 'Kai matoma bet kokia šviesa, paspauskite vieną kartą, tada paspauskite ir palaikykite, kol įrenginys parodys rožinę šviesą, tada atleiskite.';
 
   @override
   String get pairingTitleFriendPendant => 'Įjunkite Friend Pendant susiejimo režimą';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Paspauskite mygtuką ant pakabuko, kad jį įjungtumėte. Jis automatiškai persijungs į susiejimo režimą.';
+  String get pairingDescFriendPendant => 'Paspauskite mygtuką ant pakabuko, kad jį įjungtumėte. Jis automatiškai persijungs į susiejimo režimą.';
 
   @override
   String get pairingTitleFieldy => 'Įjunkite Fieldy susiejimo režimą';
@@ -8015,15 +7867,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Prijunkite Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Įdiekite ir atidarykite Omi programėlę savo Apple Watch, tada bakstelėkite Prisijungti programėlėje.';
+  String get pairingDescAppleWatch => 'Įdiekite ir atidarykite Omi programėlę savo Apple Watch, tada bakstelėkite Prisijungti programėlėje.';
 
   @override
   String get pairingTitleNeoOne => 'Įjunkite Neo One susiejimo režimą';
 
   @override
-  String get pairingDescNeoOne =>
-      'Paspauskite ir palaikykite maitinimo mygtuką, kol LED pradės mirksėti. Įrenginys bus aptinkamas.';
+  String get pairingDescNeoOne => 'Paspauskite ir palaikykite maitinimo mygtuką, kol LED pradės mirksėti. Įrenginys bus aptinkamas.';
 
   @override
   String get downloadingFromDevice => 'Atsisiunčiama iš įrenginio';
@@ -8093,8 +7943,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get wifiConfiguration => 'WiFi konfigūracija';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Įveskite WiFi prisijungimo duomenis, kad įrenginys galėtų atsisiųsti programinę įrangą.';
+  String get wifiConfigurationSubtitle => 'Įveskite WiFi prisijungimo duomenis, kad įrenginys galėtų atsisiųsti programinę įrangą.';
 
   @override
   String get networkNameSsid => 'Tinklo pavadinimas (SSID)';
@@ -8141,12 +7990,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get switchAndRestart => 'Perjungti';
 
   @override
-  String get stagingDisclaimer =>
-      'Testavimo aplinka gali būti nestabili, turėti nenuoseklų veikimą ir duomenys gali būti prarasti. Tik testavimui.';
+  String get stagingDisclaimer => 'Testavimo aplinka gali būti nestabili, turėti nenuoseklų veikimą ir duomenys gali būti prarasti. Tik testavimui.';
 
   @override
-  String get apiEnvSavedRestartRequired =>
-      'Išsaugota. Uždarykite ir vėl atidarykite programėlę, kad pritaikytumėte pakeitimus.';
+  String get apiEnvSavedRestartRequired => 'Išsaugota. Uždarykite ir vėl atidarykite programėlę, kad pritaikytumėte pakeitimus.';
 
   @override
   String get shared => 'Bendrinamas';
@@ -8372,8 +8219,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefono skambučiai per Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Skambinkite per Omi ir gaukite transkripcijas realiu laiku, automatinius santraukas ir daugiau.';
+  String get phoneCallsUpsellSubtitle => 'Skambinkite per Omi ir gaukite transkripcijas realiu laiku, automatinius santraukas ir daugiau.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Kiekvieno skambučio transkripcija realiu laiku';
@@ -8412,8 +8258,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deletePendingFiles => 'Ištrinti laukiančius įrašus';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Šie įrašai NĖRA sinchronizuoti su jūsų telefonu ir bus visam laikui prarasti. To atšaukti negalima.';
+  String get deletePendingFilesWarning => 'Šie įrašai NĖRA sinchronizuoti su jūsų telefonu ir bus visam laikui prarasti. To atšaukti negalima.';
 
   @override
   String get pendingFilesDeleted => 'Laukiantys įrašai ištrinti';
@@ -8425,8 +8270,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deleteAll => 'Ištrinti viską';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Tai ištrins sinchronizuotus ir laukiančius įrašus. Laukiantys įrašai NĖRA sinchronizuoti ir bus visam laikui prarasti.';
+  String get deleteAllFilesWarning => 'Tai ištrins sinchronizuotus ir laukiančius įrašus. Laukiantys įrašai NĖRA sinchronizuoti ir bus visam laikui prarasti.';
 
   @override
   String get allFilesDeleted => 'Visi įrašai ištrinti';
@@ -8491,8 +8335,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fairUseAboutTitle => 'Apie sąžiningą naudojimą';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi sukurtas asmeniniams pokalbiams, susitikimams ir tiesioginei sąveikai. Naudojimas matuojamas pagal aptiktą tikrąjį kalbos laiką, o ne prisijungimo laiką. Jei naudojimas žymiai viršija įprastus modelius ne asmeniniam turiniui, gali būti taikomi koregavimai.';
+  String get fairUseAboutBody => 'Omi sukurtas asmeniniams pokalbiams, susitikimams ir tiesioginei sąveikai. Naudojimas matuojamas pagal aptiktą tikrąjį kalbos laiką, o ne prisijungimo laiką. Jei naudojimas žymiai viršija įprastus modelius ne asmeniniam turiniui, gali būti taikomi koregavimai.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8530,8 +8373,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get improveConnectionTitle => 'Pagerinti ryšį';
 
   @override
-  String get improveConnectionContent =>
-      'Patobulinome, kaip Omi lieka prisijungęs prie jūsų įrenginio. Norėdami tai aktyvuoti, eikite į įrenginio informacijos puslapį, bakstelėkite \"Atjungti įrenginį\" ir vėl susiekite savo įrenginį.';
+  String get improveConnectionContent => 'Patobulinome, kaip Omi lieka prisijungęs prie jūsų įrenginio. Norėdami tai aktyvuoti, eikite į įrenginio informacijos puslapį, bakstelėkite \"Atjungti įrenginį\" ir vėl susiekite savo įrenginį.';
 
   @override
   String get improveConnectionAction => 'Supratau';
@@ -8586,16 +8428,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get cancelSyncQuestion => 'Atšaukti sinchronizavimą?';
 
   @override
-  String get omisStorageDesc =>
-      'Kai jūsų Omi nėra prijungtas prie telefono, jis saugo garsą vietoje savo integruotoje atmintyje. Niekada neprarasite įrašo.';
+  String get omisStorageDesc => 'Kai jūsų Omi nėra prijungtas prie telefono, jis saugo garsą vietoje savo integruotoje atmintyje. Niekada neprarasite įrašo.';
 
   @override
-  String get phoneStorageDesc =>
-      'Kai Omi vėl prisijungia, įrašai automatiškai perkeliami į jūsų telefoną prieš įkėlimą.';
+  String get phoneStorageDesc => 'Kai Omi vėl prisijungia, įrašai automatiškai perkeliami į jūsų telefoną prieš įkėlimą.';
 
   @override
-  String get cloudStorageDesc =>
-      'Įkėlus, jūsų įrašai apdorojami ir transkribuojami. Pokalbiai bus prieinami per minutę.';
+  String get cloudStorageDesc => 'Įkėlus, jūsų įrašai apdorojami ir transkribuojami. Pokalbiai bus prieinami per minutę.';
 
   @override
   String get tipKeepPhoneNearby => 'Laikykite telefoną šalia greitesniam sinchronizavimui';
@@ -8619,12 +8458,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get permissionEnable => 'Įjungti';
 
   @override
-  String get permissionsPageDescription =>
-      'Šie leidimai yra esminiai Omi veikimui. Jie įgalina pagrindines funkcijas, tokias kaip pranešimai, vieta pagrįstos patirtys ir garso įrašymas.';
+  String get permissionsPageDescription => 'Šie leidimai yra esminiai Omi veikimui. Jie įgalina pagrindines funkcijas, tokias kaip pranešimai, vieta pagrįstos patirtys ir garso įrašymas.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi reikia kelių leidimų, kad tinkamai veiktų. Prašome juos suteikti, kad galėtumėte tęsti.';
+  String get permissionsRequiredDescription => 'Omi reikia kelių leidimų, kad tinkamai veiktų. Prašome juos suteikti, kad galėtumėte tęsti.';
 
   @override
   String get permissionsSetupTitle => 'Gaukite geriausią patirtį';
@@ -8880,8 +8717,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get enableLocationTitle => 'Įjungti vietą';
 
   @override
-  String get enableLocationDescription =>
-      'Vietos leidimas reikalingas norint rasti netoliese esančius Bluetooth įrenginius.';
+  String get enableLocationDescription => 'Vietos leidimas reikalingas norint rasti netoliese esančius Bluetooth įrenginius.';
 
   @override
   String get voiceRecordingFound => 'Rastas įrašas';
@@ -8902,8 +8738,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get firmwareWarningTitle => 'Svarbu: Perskaitykite prieš atnaujinimą';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ši programinė įranga suformatuos SD kortelę. Prieš atnaujinimą įsitikinkite, kad visi neprisijungus esantys duomenys yra sinchronizuoti.\n\nJei po šios versijos įdiegimo matote mirksintį raudoną šviesą, nesijaudinkite. Tiesiog prijunkite įrenginį prie programėlės ir jis turėtų tapti mėlynas. Raudona šviesa reiškia, kad įrenginio laikrodis dar nebuvo sinchronizuotas.';
+  String get firmwareFormatWarning => 'Ši programinė įranga suformatuos SD kortelę. Prieš atnaujinimą įsitikinkite, kad visi neprisijungus esantys duomenys yra sinchronizuoti.\n\nJei po šios versijos įdiegimo matote mirksintį raudoną šviesą, nesijaudinkite. Tiesiog prijunkite įrenginį prie programėlės ir jis turėtų tapti mėlynas. Raudona šviesa reiškia, kad įrenginio laikrodis dar nebuvo sinchronizuotas.';
 
   @override
   String get continueAnyway => 'Tęsti';
@@ -8923,8 +8758,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get tasksMarkComplete => 'Pažymėta kaip atlikta';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi pasiekia Apple Health per Apple HealthKit sistemą. Prieigą galite bet kada atšaukti iOS nustatymuose.';
+  String get appleHealthManageNote => 'Omi pasiekia Apple Health per Apple HealthKit sistemą. Prieigą galite bet kada atšaukti iOS nustatymuose.';
 
   @override
   String get appleHealthConnectCta => 'Prijungti Apple Health';
@@ -8957,8 +8791,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Prieiga prie Apple Health atmesta';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi neturi leidimo skaityti jūsų Apple Health duomenis. Įjunkite: iOS Nustatymai → Privatumas ir sauga → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi neturi leidimo skaityti jūsų Apple Health duomenis. Įjunkite: iOS Nustatymai → Privatumas ir sauga → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Kodėl išeini?';
@@ -9027,8 +8860,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get planUpdate => 'Plano atnaujinimas';
 
   @override
-  String get planDeprecationMessage =>
-      'Jūsų Unlimited planas nutraukiamas. Pereikite prie Operator plano — tos pačios puikios funkcijos už \$49/mėn. Jūsų dabartinis planas tuo tarpu veiks toliau.';
+  String get planDeprecationMessage => 'Jūsų Unlimited planas nutraukiamas. Pereikite prie Operator plano — tos pačios puikios funkcijos už \$49/mėn. Jūsų dabartinis planas tuo tarpu veiks toliau.';
 
   @override
   String get upgradeYourPlan => 'Atnaujinkite savo planą';
@@ -9139,8 +8971,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Pasiekėte savo mėnesinį limitą. Atnaujinkite, kad galėtumėte toliau bendrauti su Omi be apribojimų.';
+  String get chatQuotaExceededReply => 'Pasiekėte savo mėnesinį limitą. Atnaujinkite, kad galėtumėte toliau bendrauti su Omi be apribojimų.';
 
   @override
   String get voiceResponseAudio => 'Skaityti Omi atsakymą garsiai';
@@ -9171,4 +9002,25 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Pridėti užduotį';
+
+  @override
+  String get quickActionAskOmiAnything => 'Paklauskite Omi bet ko';
+
+  @override
+  String get quickActionVoiceMode => 'Balso režimas';
+
+  @override
+  String get quickActionMute => 'Nutildyti';
+
+  @override
+  String get quickActionUnmute => 'Įjungti garsą';
+
+  @override
+  String get quickActionConnectDevice => 'Prijungti įrenginį';
+
+  @override
+  String get quickActionDeviceSettings => 'Įrenginio nustatymai';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -24,8 +24,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deleteConversationTitle => 'Dzēst sarunu?';
 
   @override
-  String get deleteConversationMessage =>
-      'Tas arī izdzēsīs saistītās atmiņas, uzdevumus un audio failus. Šo darbību nevar atsaukt.';
+  String get deleteConversationMessage => 'Tas arī izdzēsīs saistītās atmiņas, uzdevumus un audio failus. Šo darbību nevar atsaukt.';
 
   @override
   String get confirm => 'Apstiprināt';
@@ -146,8 +145,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deleting => 'Dzēš...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
+  String get pleaseCompleteAuthentication => 'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
 
   @override
   String get failedToStartAuthentication => 'Neizdevās sākt autentifikāciju';
@@ -228,8 +226,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get noStarredConversations => 'Nav sarunu ar zvaigzni';
 
   @override
-  String get starConversationHint =>
-      'Lai atzīmētu sarunu ar zvaigznīti, atveriet to un piespiediet zvaigznītes ikonu galvenē.';
+  String get starConversationHint => 'Lai atzīmētu sarunu ar zvaigznīti, atveriet to un piespiediet zvaigznītes ikonu galvenē.';
 
   @override
   String get searchConversations => 'Meklēt sarunas...';
@@ -320,8 +317,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get installedApps => 'Instalētās lietotnes';
 
   @override
-  String get unableToFetchApps =>
-      'Nevar ielādēt lietotnes :(\n\nLūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
+  String get unableToFetchApps => 'Nevar ielādēt lietotnes :(\n\nLūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
 
   @override
   String get aboutOmi => 'Par Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsLv extends AppLocalizations {
   String get appsDisconnected => 'Jūsu lietotnes un integrācijas tiks atsavi notas nekavējoties.';
 
   @override
-  String get exportBeforeDelete =>
-      'Jūs varat eksportēt savus datus pirms konta dzēšanas, bet pēc dzēšanas tos vairs nevarēs atjaunot.';
+  String get exportBeforeDelete => 'Jūs varat eksportēt savus datus pirms konta dzēšanas, bet pēc dzēšanas tos vairs nevarēs atjaunot.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Es saprotu, ka konta dzēšana ir neatgriezeniska un visi dati, tostarp atmiņas un sarunas, tiks zaudēti un tos nevarēs atgūt.';
+  String get deleteAccountCheckbox => 'Es saprotu, ka konta dzēšana ir neatgriezeniska un visi dati, tostarp atmiņas un sarunas, tiks zaudēti un tos nevarēs atgūt.';
 
   @override
   String get areYouSure => 'Vai esat pārliecināts?';
 
   @override
-  String get deleteAccountFinal =>
-      'Šī darbība ir neatgriezeniska un neatgriezeniski izdzēsīs jūsu kontu un visus saistītos datus. Vai tiešām vēlaties turpināt?';
+  String get deleteAccountFinal => 'Šī darbība ir neatgriezeniska un neatgriezeniski izdzēsīs jūsu kontu un visus saistītos datus. Vai tiešām vēlaties turpināt?';
 
   @override
   String get deleteNow => 'Dzēst tagad';
@@ -378,8 +371,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get goBack => 'Atgriezties';
 
   @override
-  String get checkBoxToConfirm =>
-      'Atzīmējiet izvēles rūtiņu, lai apstiprinātu, ka saprotat, ka konta dzēšana ir neatgriezeniska un neatceļama.';
+  String get checkBoxToConfirm => 'Atzīmējiet izvēles rūtiņu, lai apstiprinātu, ka saprotat, ka konta dzēšana ir neatgriezeniska un neatceļama.';
 
   @override
   String get profile => 'Profils';
@@ -457,8 +449,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get yourPrivacyYourControl => 'Jūsu privātums, jūsu kontrole';
 
   @override
-  String get privacyIntro =>
-      'Omi mēs esam apņēmušies aizsargāt jūsu privātumu. Šī lapa ļauj jums kontrolēt, kā jūsu dati tiek uzglabāti un izmantoti.';
+  String get privacyIntro => 'Omi mēs esam apņēmušies aizsargāt jūsu privātumu. Šī lapa ļauj jums kontrolēt, kā jūsu dati tiek uzglabāti un izmantoti.';
 
   @override
   String get learnMore => 'Uzzināt vairāk...';
@@ -467,15 +458,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get dataProtectionLevel => 'Datu aizsardzības līmenis';
 
   @override
-  String get dataProtectionDesc =>
-      'Jūsu dati pēc noklusējuma ir aizsargāti ar spēcīgu šifrēšanu. Pārskatiet savus iestatījumus un turpmākās privātuma opcijas zemāk.';
+  String get dataProtectionDesc => 'Jūsu dati pēc noklusējuma ir aizsargāti ar spēcīgu šifrēšanu. Pārskatiet savus iestatījumus un turpmākās privātuma opcijas zemāk.';
 
   @override
   String get appAccess => 'Lietotņu piekļuve';
 
   @override
-  String get appAccessDesc =>
-      'Šādas lietotnes var piekļūt jūsu datiem. Piespiediet uz lietotnes, lai pārvaldītu tās atļaujas.';
+  String get appAccessDesc => 'Šādas lietotnes var piekļūt jūsu datiem. Piespiediet uz lietotnes, lai pārvaldītu tās atļaujas.';
 
   @override
   String get noAppsExternalAccess => 'Nevienai instalētajai lietotnei nav ārējas piekļuves jūsu datiem.';
@@ -532,15 +521,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Jūsu Omi ir atvienots 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Ierīce atvienota. Dodieties uz Iestatījumi > Bluetooth un aizmirstiet ierīci, lai pabeigtu sapārošanas atcelšanu.';
+  String get deviceUnpairedMessage => 'Ierīce atvienota. Dodieties uz Iestatījumi > Bluetooth un aizmirstiet ierīci, lai pabeigtu sapārošanas atcelšanu.';
 
   @override
   String get unpairDialogTitle => 'Atpārošana ierīci';
 
   @override
-  String get unpairDialogMessage =>
-      'Tas atpāros ierīci, lai to varētu savienot ar citu tālruni. Jums būs jādodas uz Iestatījumi > Bluetooth un jāaizmirst ierīce, lai pabeigtu procesu.';
+  String get unpairDialogMessage => 'Tas atpāros ierīci, lai to varētu savienot ar citu tālruni. Jums būs jādodas uz Iestatījumi > Bluetooth un jāaizmirst ierīce, lai pabeigtu procesu.';
 
   @override
   String get deviceNotConnected => 'Ierīce nav savienota';
@@ -561,8 +548,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get v2Undetected => 'V2 nav atklāts';
 
   @override
-  String get v2UndetectedMessage =>
-      'Redzam, ka jums ir V1 ierīce vai jūsu ierīce nav savienota. SD kartes funkcionalitāte ir pieejama tikai V2 ierīcēm.';
+  String get v2UndetectedMessage => 'Redzam, ka jums ir V1 ierīce vai jūsu ierīce nav savienota. SD kartes funkcionalitāte ir pieejama tikai V2 ierīcēm.';
 
   @override
   String get endConversation => 'Beigt sarunu';
@@ -836,8 +822,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Dzēst zināšanu grafu?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Tas izdzēsīs visus atvasinātos zināšanu grafa datus (mezglus un savienojumus). Jūsu oriģinālās atmiņas paliks drošībā. Grafs tiks atjaunots ar laiku vai pēc nākamā pieprasījuma.';
+  String get deleteKnowledgeGraphMessage => 'Tas izdzēsīs visus atvasinātos zināšanu grafa datus (mezglus un savienojumus). Jūsu oriģinālās atmiņas paliks drošībā. Grafs tiks atjaunots ar laiku vai pēc nākamā pieprasījuma.';
 
   @override
   String get knowledgeGraphDeleted => 'Zināšanu grafs izdzēsts';
@@ -985,8 +970,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get shortConversationThreshold => 'Īsās sarunas slieksnis';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Sarunas, kas ir īsākas par šo, tiks slēptas, ja vien nav iespējotas iepriekš';
+  String get shortConversationThresholdSubtitle => 'Sarunas, kas ir īsākas par šo, tiks slēptas, ja vien nav iespējotas iepriekš';
 
   @override
   String get durationThreshold => 'Ilguma slieksnis';
@@ -1021,8 +1005,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get integrationsFooter => 'Savienojiet savas lietotnes, lai skatītu datus un metriku tērzēšanā.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
+  String get completeAuthInBrowser => 'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1082,8 +1065,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get needYourPermission => 'Mums nepieciešama jūsu atļauja';
 
   @override
-  String get alreadyGavePermission =>
-      'Jūs jau esat devis mums atļauju saglabāt jūsu ierakstus. Šeit ir atgādinājums, kāpēc mums tas ir nepieciešams:';
+  String get alreadyGavePermission => 'Jūs jau esat devis mums atļauju saglabāt jūsu ierakstus. Šeit ir atgādinājums, kāpēc mums tas ir nepieciešams:';
 
   @override
   String get wouldLikePermission => 'Mēs vēlētos jūsu atļauju saglabāt jūsu balss ierakstus. Šeit ir iemesls:';
@@ -1092,26 +1074,22 @@ class AppLocalizationsLv extends AppLocalizations {
   String get improveSpeechProfile => 'Uzlabot jūsu runas profilu';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Mēs izmantojam ierakstus, lai turpinātu apmācīt un uzlabotu jūsu personīgo runas profilu.';
+  String get improveSpeechProfileDesc => 'Mēs izmantojam ierakstus, lai turpinātu apmācīt un uzlabotu jūsu personīgo runas profilu.';
 
   @override
   String get trainFamilyProfiles => 'Apmācīt profilus draugiem un ģimenei';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Jūsu ieraksti palīdz mums atpazīt un izveidot profilus jūsu draugiem un ģimenei.';
+  String get trainFamilyProfilesDesc => 'Jūsu ieraksti palīdz mums atpazīt un izveidot profilus jūsu draugiem un ģimenei.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Uzlabot transkripcijas precizitāti';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Uzlabojoties mūsu modelim, mēs varam sniegt labākus transkripcijas rezultātus jūsu ierakstiem.';
+  String get enhanceTranscriptAccuracyDesc => 'Uzlabojoties mūsu modelim, mēs varam sniegt labākus transkripcijas rezultātus jūsu ierakstiem.';
 
   @override
-  String get legalNotice =>
-      'Juridisks paziņojums: Balss datu ierakstīšanas un uzglabāšanas likumība var atšķirties atkarībā no jūsu atrašanās vietas un tā, kā izmantojat šo funkciju. Ir jūsu atbildība nodrošināt atbilstību vietējiem likumiem un noteikumiem.';
+  String get legalNotice => 'Juridisks paziņojums: Balss datu ierakstīšanas un uzglabāšanas likumība var atšķirties atkarībā no jūsu atrašanās vietas un tā, kā izmantojat šo funkciju. Ir jūsu atbildība nodrošināt atbilstību vietējiem likumiem un noteikumiem.';
 
   @override
   String get alreadyAuthorized => 'Jau autorizēts';
@@ -1189,8 +1167,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showEventsNoParticipants => 'Rādīt notikumus bez dalībniekiem';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Ja iespējots, Coming Up rāda notikumus bez dalībniekiem vai video saites.';
+  String get showEventsNoParticipantsDesc => 'Ja iespējots, Coming Up rāda notikumus bez dalībniekiem vai video saites.';
 
   @override
   String get yourMeetings => 'Jūsu sanāksmes';
@@ -1278,8 +1255,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get languageForTranscription => 'Iestatiet savu valodu precīzākai transkripcijai un personalizētai pieredzei.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Vienas valodas režīms ir iespējots. Tulkošana ir atspējota lielākai precizitātei.';
+  String get singleLanguageModeInfo => 'Vienas valodas režīms ir iespējots. Tulkošana ir atspējota lielākai precizitātei.';
 
   @override
   String get searchLanguageHint => 'Meklēt valodu pēc nosaukuma vai koda';
@@ -1359,8 +1335,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get defaultRepository => 'Noklusējuma repozitorijs';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Izvēlieties noklusējuma repozitoriju problēmu izveidošanai. Jūs joprojām varat norādīt citu repozitoriju, veidojot problēmas.';
+  String get selectDefaultRepoDesc => 'Izvēlieties noklusējuma repozitoriju problēmu izveidošanai. Jūs joprojām varat norādīt citu repozitoriju, veidojot problēmas.';
 
   @override
   String get noReposFound => 'Repozitoriji nav atrasti';
@@ -1407,8 +1382,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get configureSettings => 'Konfigurēt iestatījumus';
 
   @override
-  String get completeAuthBrowser =>
-      'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
+  String get completeAuthBrowser => 'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1736,8 +1710,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get enableBluetooth => 'Iespējot Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi nepieciešams Bluetooth, lai savienotos ar jūsu valkājamo ierīci. Lūdzu, iespējojiet Bluetooth un mēģiniet vēlreiz.';
+  String get bluetoothNeeded => 'Omi nepieciešams Bluetooth, lai savienotos ar jūsu valkājamo ierīci. Lūdzu, iespējojiet Bluetooth un mēģiniet vēlreiz.';
 
   @override
   String get contactSupport => 'Sazināties ar atbalstu?';
@@ -1770,26 +1743,22 @@ class AppLocalizationsLv extends AppLocalizations {
   String get locationServiceDisabled => 'Atrašanās vietas pakalpojums atspējots';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Atrašanās vietas pakalpojums ir atspējots. Lūdzu, dodieties uz Iestatījumi > Privātums un drošība > Atrašanās vietas pakalpojumi un iespējojiet to';
+  String get locationServiceDisabledDesc => 'Atrašanās vietas pakalpojums ir atspējots. Lūdzu, dodieties uz Iestatījumi > Privātums un drošība > Atrašanās vietas pakalpojumi un iespējojiet to';
 
   @override
   String get backgroundLocationDenied => 'Fona atrašanās vietas piekļuve liegta';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Lūdzu, dodieties uz ierīces iestatījumiem un iestatiet atrašanās vietas atļauju uz \"Vienmēr atļaut\"';
+  String get backgroundLocationDeniedDesc => 'Lūdzu, dodieties uz ierīces iestatījumiem un iestatiet atrašanās vietas atļauju uz \"Vienmēr atļaut\"';
 
   @override
   String get lovingOmi => 'Patīk Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Palīdziet mums sasniegt vairāk cilvēku, atstājot atsauksmi App Store. Jūsu atsauksmes mums nozīmē visu!';
+  String get leaveReviewIos => 'Palīdziet mums sasniegt vairāk cilvēku, atstājot atsauksmi App Store. Jūsu atsauksmes mums nozīmē visu!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Palīdziet mums sasniegt vairāk cilvēku, atstājot atsauksmi Google Play Store. Jūsu atsauksmes mums nozīmē visu!';
+  String get leaveReviewAndroid => 'Palīdziet mums sasniegt vairāk cilvēku, atstājot atsauksmi Google Play Store. Jūsu atsauksmes mums nozīmē visu!';
 
   @override
   String get rateOnAppStore => 'Novērtēt App Store';
@@ -1822,15 +1791,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get connectionError => 'Savienojuma kļūda';
 
   @override
-  String get connectionErrorDesc =>
-      'Neizdevās izveidot savienojumu ar serveri. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
+  String get connectionErrorDesc => 'Neizdevās izveidot savienojumu ar serveri. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Atklāts nederīgs ieraksts';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Šķiet, ka ierakstā ir vairāki runātāji. Lūdzu, pārliecinieties, ka atrodaties klusā vietā, un mēģiniet vēlreiz.';
+  String get multipleSpeakersDesc => 'Šķiet, ka ierakstā ir vairāki runātāji. Lūdzu, pārliecinieties, ka atrodaties klusā vietā, un mēģiniet vēlreiz.';
 
   @override
   String get tooShortDesc => 'Nav atklāts pietiekami daudz runas. Lūdzu, runājiet vairāk un mēģiniet vēlreiz.';
@@ -1842,15 +1809,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get areYouThere => 'Vai jūs esat tur?';
 
   @override
-  String get noSpeechDesc =>
-      'Mēs nevarējām atklāt nevienu runu. Lūdzu, pārliecinieties, ka runājat vismaz 10 sekundes un ne vairāk kā 3 minūtes.';
+  String get noSpeechDesc => 'Mēs nevarējām atklāt nevienu runu. Lūdzu, pārliecinieties, ka runājat vismaz 10 sekundes un ne vairāk kā 3 minūtes.';
 
   @override
   String get connectionLost => 'Savienojums zaudēts';
 
   @override
-  String get connectionLostDesc =>
-      'Savienojums tika pārtraukts. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
+  String get connectionLostDesc => 'Savienojums tika pārtraukts. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
 
   @override
   String get tryAgain => 'Mēģināt vēlreiz';
@@ -1865,8 +1830,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get permissionsRequired => 'Nepieciešamas atļaujas';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Šai lietotnei ir nepieciešamas Bluetooth un Atrašanās vietas atļaujas, lai darbotos pareizi. Lūdzu, iespējojiet tās iestatījumos.';
+  String get permissionsRequiredDesc => 'Šai lietotnei ir nepieciešamas Bluetooth un Atrašanās vietas atļaujas, lai darbotos pareizi. Lūdzu, iespējojiet tās iestatījumos.';
 
   @override
   String get openSettings => 'Atvērt iestatījumus';
@@ -1896,8 +1860,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – jūsu AI pavadonis';
 
   @override
-  String get captureEveryMoment =>
-      'Fiksējiet katru brīdi. Iegūstiet AI\nkopsavilkumus. Nekad vairs nerakstiet piezīmes.';
+  String get captureEveryMoment => 'Fiksējiet katru brīdi. Iegūstiet AI\nkopsavilkumus. Nekad vairs nerakstiet piezīmes.';
 
   @override
   String get appleWatchSetup => 'Apple Watch iestatīšana';
@@ -1909,12 +1872,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get microphonePermission => 'Mikrofona atļauja';
 
   @override
-  String get permissionGrantedNow =>
-      'Atļauja piešķirta! Tagad:\n\nAtveriet Omi lietotni savā pulkstenī un piespiediet \"Turpināt\" zemāk';
+  String get permissionGrantedNow => 'Atļauja piešķirta! Tagad:\n\nAtveriet Omi lietotni savā pulkstenī un piespiediet \"Turpināt\" zemāk';
 
   @override
-  String get needMicrophonePermission =>
-      'Mums nepieciešama mikrofona atļauja.\n\n1. Piespiediet \"Piešķirt atļauju\"\n2. Atļaut iPhone\n3. Pulksteņa lietotne aizvērsies\n4. Atkārtoti atveriet un piespiediet \"Turpināt\"';
+  String get needMicrophonePermission => 'Mums nepieciešama mikrofona atļauja.\n\n1. Piespiediet \"Piešķirt atļauju\"\n2. Atļaut iPhone\n3. Pulksteņa lietotne aizvērsies\n4. Atkārtoti atveriet un piespiediet \"Turpināt\"';
 
   @override
   String get grantPermissionButton => 'Piešķirt atļauju';
@@ -1923,15 +1884,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get needHelp => 'Nepieciešama palīdzība?';
 
   @override
-  String get troubleshootingSteps =>
-      'Problēmu novēršana:\n\n1. Pārliecinieties, ka Omi ir instalēts jūsu pulkstenī\n2. Atveriet Omi lietotni savā pulkstenī\n3. Meklējiet atļaujas uznirstošo logu\n4. Piespiediet \"Atļaut\", kad tiek piedāvāts\n5. Lietotne jūsu pulkstenī aizvērsies - atkārtoti atveriet to\n6. Atgriezieties un piespiediet \"Turpināt\" savā iPhone';
+  String get troubleshootingSteps => 'Problēmu novēršana:\n\n1. Pārliecinieties, ka Omi ir instalēts jūsu pulkstenī\n2. Atveriet Omi lietotni savā pulkstenī\n3. Meklējiet atļaujas uznirstošo logu\n4. Piespiediet \"Atļaut\", kad tiek piedāvāts\n5. Lietotne jūsu pulkstenī aizvērsies - atkārtoti atveriet to\n6. Atgriezieties un piespiediet \"Turpināt\" savā iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Ierakstīšana veiksmīgi sākta!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Atļauja vēl nav piešķirta. Lūdzu, pārliecinieties, ka atļāvāt mikrofona piekļuvi un atkārtoti atvērāt lietotni savā pulkstenī.';
+  String get permissionNotGrantedYet => 'Atļauja vēl nav piešķirta. Lūdzu, pārliecinieties, ka atļāvāt mikrofona piekļuvi un atkārtoti atvērāt lietotni savā pulkstenī.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1962,8 +1921,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get actionItemsTitle => 'Darāmie darbi';
 
   @override
-  String get actionItemsDescription =>
-      'Piespiediet, lai rediģētu • Ilgi turiet, lai atlasītu • Velciet, lai veiktu darbības';
+  String get actionItemsDescription => 'Piespiediet, lai rediģētu • Ilgi turiet, lai atlasītu • Velciet, lai veiktu darbības';
 
   @override
   String get tabToDo => 'Darāms';
@@ -2029,8 +1987,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Gatavs uzdevumiem';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Jūsu AI automātiski izvilks uzdevumus no jūsu sarunām. Tie parādīsies šeit, kad tiks izveidoti.';
+  String get welcomeActionItemsDescription => 'Jūsu AI automātiski izvilks uzdevumus no jūsu sarunām. Tie parādīsies šeit, kad tiks izveidoti.';
 
   @override
   String get autoExtractionFeature => 'Automātiski izvilkts no sarunām';
@@ -2226,15 +2183,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'RUNA UN TRANSKRIPCIJA';
 
   @override
-  String get languageSettingsHelperText =>
-      'Lietojumprogrammas valoda maina izvēlnes un pogas. Runas valoda ietekmē to, kā tiek transkribēti jūsu ieraksti.';
+  String get languageSettingsHelperText => 'Lietojumprogrammas valoda maina izvēlnes un pogas. Runas valoda ietekmē to, kā tiek transkribēti jūsu ieraksti.';
 
   @override
   String get translationNotice => 'Tulkošanas paziņojums';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi tulko sarunas jūsu galvenajā valodā. Atjauniniet to jebkurā laikā sadaļā Iestatījumi → Profili.';
+  String get translationNoticeMessage => 'Omi tulko sarunas jūsu galvenajā valodā. Atjauniniet to jebkurā laikā sadaļā Iestatījumi → Profili.';
 
   @override
   String get pleaseCheckInternetConnection => 'Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz';
@@ -2389,8 +2344,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Atvienot ierīces sapārošanu';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Tas atvienos ierīces sapārošanu, lai to varētu savienot ar citu tālruni. Jums būs jādodas uz Iestatījumi > Bluetooth un jāaizmirst ierīce, lai pabeigtu procesu.';
+  String get unpairDeviceDialogMessage => 'Tas atvienos ierīces sapārošanu, lai to varētu savienot ar citu tālruni. Jums būs jādodas uz Iestatījumi > Bluetooth un jāaizmirst ierīce, lai pabeigtu procesu.';
 
   @override
   String get unpair => 'Atvienot sapārošanu';
@@ -2571,8 +2525,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get youreAllSet => 'Viss ir gatavs!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Laipni lūdzam Omi! Jūsu AI kompanjons ir gatavs palīdzēt jums sarunās, uzdevumos un vēl daudz ko.';
+  String get welcomeToOmiDescription => 'Laipni lūdzam Omi! Jūsu AI kompanjons ir gatavs palīdzēt jums sarunās, uzdevumos un vēl daudz ko.';
 
   @override
   String get startUsingOmi => 'Sākt izmantot Omi';
@@ -2666,8 +2619,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showAll => 'Rādīt visu →';
 
   @override
-  String get noTasksForToday =>
-      'Šodien nav uzdevumu.\nJautājiet Omi par vairāk uzdevumiem vai izveidojiet tos manuāli.';
+  String get noTasksForToday => 'Šodien nav uzdevumu.\nJautājiet Omi par vairāk uzdevumiem vai izveidojiet tos manuāli.';
 
   @override
   String get dailyScore => 'DIENAS REZULTĀTS';
@@ -2709,8 +2661,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get noTasksYet => 'Vēl nav uzdevumu';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Šeit parādīsies uzdevumi no jūsu sarunām.\nNoklikšķiniet uz Izveidot, lai pievienotu vienu manuāli.';
+  String get tasksFromConversationsWillAppear => 'Šeit parādīsies uzdevumi no jūsu sarunām.\nNoklikšķiniet uz Izveidot, lai pievienotu vienu manuāli.';
 
   @override
   String get monthJan => 'Jan';
@@ -2842,15 +2793,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get chatPrompt => 'Tērzēšanas norādījums';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Jūs esat lieliska lietotne, jūsu darbs ir atbildēt uz lietotāju jautājumiem un likt viņiem justies labi...';
+  String get chatPromptPlaceholder => 'Jūs esat lieliska lietotne, jūsu darbs ir atbildēt uz lietotāju jautājumiem un likt viņiem justies labi...';
 
   @override
   String get conversationPrompt => 'Sarunas uzvedne';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Jūs esat lieliska lietotne, jums tiks sniegta sarunas transkripcija un kopsavilkums...';
+  String get conversationPromptPlaceholder => 'Jūs esat lieliska lietotne, jums tiks sniegta sarunas transkripcija un kopsavilkums...';
 
   @override
   String get notificationScopes => 'Paziņojumu jomas';
@@ -2862,8 +2811,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get makeMyAppPublic => 'Padarīt manu lietotni publisku';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Iesniedzot šo lietotni, es piekrītu Omi AI pakalpojumu sniegšanas noteikumiem un privātuma politikai';
+  String get submitAppTermsAgreement => 'Iesniedzot šo lietotni, es piekrītu Omi AI pakalpojumu sniegšanas noteikumiem un privātuma politikai';
 
   @override
   String get submitApp => 'Iesniegt lietotni';
@@ -2878,12 +2826,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get submitAppQuestion => 'Iesniegt lietotni?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Jūsu lietotne tiks pārskatīta un padarīta publiska. Varat sākt to izmantot uzreiz, pat pārskatīšanas laikā!';
+  String get submitAppPublicDescription => 'Jūsu lietotne tiks pārskatīta un padarīta publiska. Varat sākt to izmantot uzreiz, pat pārskatīšanas laikā!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Jūsu lietotne tiks pārskatīta un padarīta jums pieejama privāti. Varat sākt to izmantot uzreiz, pat pārskatīšanas laikā!';
+  String get submitAppPrivateDescription => 'Jūsu lietotne tiks pārskatīta un padarīta jums pieejama privāti. Varat sākt to izmantot uzreiz, pat pārskatīšanas laikā!';
 
   @override
   String get startEarning => 'Sāciet pelnīt! 💰';
@@ -2907,23 +2853,19 @@ class AppLocalizationsLv extends AppLocalizations {
   String get dataAccessNotice => 'Datu piekļuves paziņojums';
 
   @override
-  String get dataAccessWarning =>
-      'Šī lietotne piekļūs jūsu datiem. Omi AI nav atbildīgs par to, kā šī lietotne izmanto, modificē vai dzēš jūsu datus';
+  String get dataAccessWarning => 'Šī lietotne piekļūs jūsu datiem. Omi AI nav atbildīgs par to, kā šī lietotne izmanto, modificē vai dzēš jūsu datus';
 
   @override
   String get installApp => 'Instalēt lietotni';
 
   @override
-  String get betaTesterNotice =>
-      'Jūs esat šīs lietotnes beta testētājs. Tā vēl nav publiska. Tā kļūs publiska pēc apstiprināšanas.';
+  String get betaTesterNotice => 'Jūs esat šīs lietotnes beta testētājs. Tā vēl nav publiska. Tā kļūs publiska pēc apstiprināšanas.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Jūsu lietotne tiek pārskatīta un ir redzama tikai jums. Tā kļūs publiska pēc apstiprināšanas.';
+  String get appUnderReviewOwner => 'Jūsu lietotne tiek pārskatīta un ir redzama tikai jums. Tā kļūs publiska pēc apstiprināšanas.';
 
   @override
-  String get appRejectedNotice =>
-      'Jūsu lietotne tika noraidīta. Lūdzu, atjauniniet lietotnes informāciju un atkārtoti iesniedziet to pārskatīšanai.';
+  String get appRejectedNotice => 'Jūsu lietotne tika noraidīta. Lūdzu, atjauniniet lietotnes informāciju un atkārtoti iesniedziet to pārskatīšanai.';
 
   @override
   String get setupSteps => 'Iestatīšanas soļi';
@@ -2985,8 +2927,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get descriptionLabel => 'Apraksts';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Mana brīnišķīgā lietotne ir lieliska lietotne, kas dara pārsteidzošas lietas. Tā ir labākā lietotne!';
+  String get appDescriptionPlaceholder => 'Mana brīnišķīgā lietotne ir lieliska lietotne, kas dara pārsteidzošas lietas. Tā ir labākā lietotne!';
 
   @override
   String get pleaseProvideValidDescription => 'Lūdzu, norādiet derīgu aprakstu';
@@ -3138,8 +3079,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get microphonePermissionRequired => 'Balss ierakstam nepieciešama mikrofona atļauja.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofona atļauja liegta. Lūdzu, dodiet atļauju Sistēmas iestatījumi > Privātums un drošība > Mikrofons.';
+  String get microphonePermissionDenied => 'Mikrofona atļauja liegta. Lūdzu, dodiet atļauju Sistēmas iestatījumi > Privātums un drošība > Mikrofons.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3372,8 +3312,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get whatWeCollect => 'Ko mēs vācam';
 
   @override
-  String get dataCollectionMessage =>
-      'Turpinot, jūsu sarunas, ieraksti un personiskā informācija tiks droši glabāta mūsu serveros, lai sniegtu AI vadītu ieskatu un iespējotu visas lietotnes funkcijas.';
+  String get dataCollectionMessage => 'Turpinot, jūsu sarunas, ieraksti un personiskā informācija tiks droši glabāta mūsu serveros, lai sniegtu AI vadītu ieskatu un iespējotu visas lietotnes funkcijas.';
 
   @override
   String get dataProtection => 'Datu aizsardzība';
@@ -3406,8 +3345,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Vārdam jābūt vismaz 2 rakstzīmes garam';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Pastāstiet mums, kā jūs vēlētos, lai jūs uzrunātu. Tas palīdz personalizēt jūsu Omi pieredzi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Pastāstiet mums, kā jūs vēlētos, lai jūs uzrunātu. Tas palīdz personalizēt jūsu Omi pieredzi.';
 
   @override
   String charactersCount(int count) {
@@ -3424,8 +3362,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get recordAudioConversations => 'Ierakstīt audio sarunas';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi nepieciešama mikrofona piekļuve, lai ierakstītu jūsu sarunas un nodrošinātu transkripcijas.';
+  String get microphoneAccessDescription => 'Omi nepieciešama mikrofona piekļuve, lai ierakstītu jūsu sarunas un nodrošinātu transkripcijas.';
 
   @override
   String get screenRecording => 'Ekrāna ierakstīšana';
@@ -3434,8 +3371,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Uzņemt sistēmas audio no sapulcēm';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi nepieciešama ekrāna ierakstīšanas atļauja, lai uzņemtu sistēmas audio no jūsu pārlūkprogrammā balstītajām sapulcēm.';
+  String get screenRecordingDescription => 'Omi nepieciešama ekrāna ierakstīšanas atļauja, lai uzņemtu sistēmas audio no jūsu pārlūkprogrammā balstītajām sapulcēm.';
 
   @override
   String get accessibility => 'Pieejamība';
@@ -3444,8 +3380,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Noteikt pārlūkprogrammā balstītas sapulces';
 
   @override
-  String get accessibilityDescription =>
-      'Omi nepieciešama pieejamības atļauja, lai noteiktu, kad pievienojaties Zoom, Meet vai Teams sapulcēm savā pārlūkprogrammā.';
+  String get accessibilityDescription => 'Omi nepieciešama pieejamības atļauja, lai noteiktu, kad pievienojaties Zoom, Meet vai Teams sapulcēm savā pārlūkprogrammā.';
 
   @override
   String get pleaseWait => 'Lūdzu, uzgaidiet...';
@@ -3514,12 +3449,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get exportAllConversationsToJson => 'Eksportējiet visas savas sarunas uz JSON failu.';
 
   @override
-  String get conversationsExportStarted =>
-      'Sarunu eksportēšana sākta. Tas var aizņemt dažas sekundes, lūdzu, uzgaidiet.';
+  String get conversationsExportStarted => 'Sarunu eksportēšana sākta. Tas var aizņemt dažas sekundes, lūdzu, uzgaidiet.';
 
   @override
-  String get mcpDescription =>
-      'Lai savienotu Omi ar citām lietojumprogrammām, lai lasītu, meklētu un pārvaldītu savas atmiņas un sarunas. Izveidojiet atslēgu, lai sāktu.';
+  String get mcpDescription => 'Lai savienotu Omi ar citām lietojumprogrammām, lai lasītu, meklētu un pārvaldītu savas atmiņas un sarunas. Izveidojiet atslēgu, lai sāktu.';
 
   @override
   String get apiKeys => 'API atslēgas';
@@ -3560,8 +3493,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Transkribēšanas pakalpojuma diagnostikas statuss';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Iespējot detalizētus diagnostikas ziņojumus no transkribēšanas pakalpojuma';
+  String get enableDetailedDiagnosticMessages => 'Iespējot detalizētus diagnostikas ziņojumus no transkribēšanas pakalpojuma';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Automātiski izveidot un atzīmēt jaunus runātājus';
@@ -3591,8 +3523,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get auto => 'Automātisks';
 
   @override
-  String get noSummaryForApp =>
-      'Šai lietotnei kopsavilkums nav pieejams. Izmēģiniet citu lietotni labākiem rezultātiem.';
+  String get noSummaryForApp => 'Šai lietotnei kopsavilkums nav pieejams. Izmēģiniet citu lietotni labākiem rezultātiem.';
 
   @override
   String get tryAnotherApp => 'Izmēģiniet citu lietotni';
@@ -3677,8 +3608,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Notiek sistēmas audio ierakstīšanas sagatavošana';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Noklikšķiniet uz pogas, lai ierakstītu audio tiešraides transkripcijām, AI ieskaitiem un automātiskai saglabāšanai.';
+  String get clickTheButtonToCaptureAudio => 'Noklikšķiniet uz pogas, lai ierakstītu audio tiešraides transkripcijām, AI ieskaitiem un automātiskai saglabāšanai.';
 
   @override
   String get reconnecting => 'Notiek atkārtota savienošana...';
@@ -3905,8 +3835,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Dzēst zināšanu grafu?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Tas izdzēsīs visus atvasinātos zināšanu grafa datus. Jūsu sākotnējās atmiņas paliks drošībā.';
+  String get deleteKnowledgeGraphWarning => 'Tas izdzēsīs visus atvasinātos zināšanu grafa datus. Jūsu sākotnējās atmiņas paliks drošībā.';
 
   @override
   String get connectOmiWithAI => 'Savienojiet Omi ar AI asistentiem';
@@ -3963,8 +3892,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get updateAppQuestion => 'Atjaunināt lietotni?';
 
   @override
-  String get updateAppConfirmation =>
-      'Vai tiešām vēlaties atjaunināt savu lietotni? Izmaiņas būs redzamas pēc mūsu komandas pārskatīšanas.';
+  String get updateAppConfirmation => 'Vai tiešām vēlaties atjaunināt savu lietotni? Izmaiņas būs redzamas pēc mūsu komandas pārskatīšanas.';
 
   @override
   String get updateApp => 'Atjaunināt lietotni';
@@ -3994,8 +3922,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get no => 'Nē';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abonements veiksmīgi atcelts. Tas paliks aktīvs līdz pašreizējā norēķinu perioda beigām.';
+  String get subscriptionCancelledSuccessfully => 'Abonements veiksmīgi atcelts. Tas paliks aktīvs līdz pašreizējā norēķinu perioda beigām.';
 
   @override
   String get failedToCancelSubscription => 'Neizdevās atcelt abonementu. Lūdzu, mēģiniet vēlreiz.';
@@ -4031,8 +3958,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Atcelt abonementu?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Vai tiešām vēlaties atcelt abonementu? Jums būs piekļuve līdz pašreizējā norēķinu perioda beigām.';
+  String get cancelSubscriptionConfirmation => 'Vai tiešām vēlaties atcelt abonementu? Jums būs piekļuve līdz pašreizējā norēķinu perioda beigām.';
 
   @override
   String get cancelSubscriptionButton => 'Atcelt abonementu';
@@ -4041,16 +3967,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get cancelling => 'Atceļ...';
 
   @override
-  String get betaTesterMessage =>
-      'Jūs esat šīs lietotnes beta testētājs. Tā vēl nav publiska. Tā kļūs publiska pēc apstiprināšanas.';
+  String get betaTesterMessage => 'Jūs esat šīs lietotnes beta testētājs. Tā vēl nav publiska. Tā kļūs publiska pēc apstiprināšanas.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Jūsu lietotne tiek pārskatīta un ir redzama tikai jums. Tā kļūs publiska pēc apstiprināšanas.';
+  String get appUnderReviewMessage => 'Jūsu lietotne tiek pārskatīta un ir redzama tikai jums. Tā kļūs publiska pēc apstiprināšanas.';
 
   @override
-  String get appRejectedMessage =>
-      'Jūsu lietotne tika noraidīta. Lūdzu, atjauniniet informāciju un iesniedziet atkārtoti.';
+  String get appRejectedMessage => 'Jūsu lietotne tika noraidīta. Lūdzu, atjauniniet informāciju un iesniedziet atkārtoti.';
 
   @override
   String get invalidIntegrationUrl => 'Nederīgs integrācijas URL';
@@ -4104,8 +4027,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get issueActivatingApp => 'Aktivizējot šo lietotni, radās problēma. Lūdzu, mēģiniet vēlreiz.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Šī lietotne piekļūs jūsu datiem. Omi AI nav atbildīgs par to, kā jūsu datus izmanto, modificē vai dzēš šī lietotne';
+  String get dataAccessNoticeDescription => 'Šī lietotne piekļūs jūsu datiem. Omi AI nav atbildīgs par to, kā jūsu datus izmanto, modificē vai dzēš šī lietotne';
 
   @override
   String get copyUrl => 'Kopēt URL';
@@ -4193,8 +4115,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get omiApiKeys => 'Omi API atslēgas';
 
   @override
-  String get apiKeysDescription =>
-      'API atslēgas izmanto autentifikācijai, kad jūsu lietotne sazinās ar OMI serveri. Tās ļauj jūsu lietojumprogrammai droši izveidot atmiņas un piekļūt citiem OMI pakalpojumiem.';
+  String get apiKeysDescription => 'API atslēgas izmanto autentifikācijai, kad jūsu lietotne sazinās ar OMI serveri. Tās ļauj jūsu lietojumprogrammai droši izveidot atmiņas un piekļūt citiem OMI pakalpojumiem.';
 
   @override
   String get aboutOmiApiKeys => 'Par Omi API atslēgām';
@@ -4218,8 +4139,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Atsaukt API atslēgu?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Šo darbību nevar atsaukt. Lietojumprogrammas, kas izmanto šo atslēgu, vairs nevarēs piekļūt API.';
+  String get revokeApiKeyWarning => 'Šo darbību nevar atsaukt. Lietojumprogrammas, kas izmanto šo atslēgu, vairs nevarēs piekļūt API.';
 
   @override
   String get revoke => 'Atsaukt';
@@ -4308,8 +4228,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get keyCreated => 'Atslēga izveidota';
 
   @override
-  String get keyCreatedMessage =>
-      'Jūsu jaunā atslēga ir izveidota. Lūdzu, nokopējiet to tagad. Jūs to vairs neredzēsiet.';
+  String get keyCreatedMessage => 'Jūsu jaunā atslēga ir izveidota. Lūdzu, nokopējiet to tagad. Jūs to vairs neredzēsiet.';
 
   @override
   String get keyWord => 'Atslēga';
@@ -4318,8 +4237,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get externalAppAccess => 'Ārējo lietotņu piekļuve';
 
   @override
-  String get externalAppAccessDescription =>
-      'Šīm instalētajām lietotnēm ir ārējās integrācijas, un tās var piekļūt jūsu datiem, piemēram, sarunām un atmiņām.';
+  String get externalAppAccessDescription => 'Šīm instalētajām lietotnēm ir ārējās integrācijas, un tās var piekļūt jūsu datiem, piemēram, sarunām un atmiņām.';
 
   @override
   String get noExternalAppsHaveAccess => 'Nevienai ārējai lietotnei nav piekļuves jūsu datiem.';
@@ -4328,8 +4246,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimāla drošība (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Pilnīga šifrēšana ir privātuma zelta standarts. Kad tā ir iespējota, jūsu dati tiek šifrēti jūsu ierīcē pirms nosūtīšanas uz mūsu serveriem. Tas nozīmē, ka neviens, pat ne Omi, nevar piekļūt jūsu saturam.';
+  String get e2eeDescription => 'Pilnīga šifrēšana ir privātuma zelta standarts. Kad tā ir iespējota, jūsu dati tiek šifrēti jūsu ierīcē pirms nosūtīšanas uz mūsu serveriem. Tas nozīmē, ka neviens, pat ne Omi, nevar piekļūt jūsu saturam.';
 
   @override
   String get importantTradeoffs => 'Svarīgi kompromisi:';
@@ -4344,8 +4261,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get featureComingSoon => 'Šī funkcija drīzumā būs pieejama!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migrācija notiek. Jūs nevarat mainīt aizsardzības līmeni, kamēr tā nav pabeigta.';
+  String get migrationInProgressMessage => 'Migrācija notiek. Jūs nevarat mainīt aizsardzības līmeni, kamēr tā nav pabeigta.';
 
   @override
   String get migrationFailed => 'Migrācija neizdevās';
@@ -4364,19 +4280,16 @@ class AppLocalizationsLv extends AppLocalizations {
   String get secureEncryption => 'Droša šifrēšana';
 
   @override
-  String get secureEncryptionDescription =>
-      'Jūsu dati tiek šifrēti ar jums unikālu atslēgu mūsu serveros, kas mitināti Google Cloud. Tas nozīmē, ka jūsu neapstrādātais saturs nav pieejams nevienam, ieskaitot Omi darbiniekus vai Google, tieši no datu bāzes.';
+  String get secureEncryptionDescription => 'Jūsu dati tiek šifrēti ar jums unikālu atslēgu mūsu serveros, kas mitināti Google Cloud. Tas nozīmē, ka jūsu neapstrādātais saturs nav pieejams nevienam, ieskaitot Omi darbiniekus vai Google, tieši no datu bāzes.';
 
   @override
   String get endToEndEncryption => 'Pilnīga šifrēšana';
 
   @override
-  String get e2eeCardDescription =>
-      'Iespējojiet maksimālu drošību, kur tikai jūs varat piekļūt saviem datiem. Pieskarieties, lai uzzinātu vairāk.';
+  String get e2eeCardDescription => 'Iespējojiet maksimālu drošību, kur tikai jūs varat piekļūt saviem datiem. Pieskarieties, lai uzzinātu vairāk.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Neatkarīgi no līmeņa, jūsu dati vienmēr ir šifrēti miera stāvoklī un pārsūtīšanas laikā.';
+  String get dataAlwaysEncrypted => 'Neatkarīgi no līmeņa, jūsu dati vienmēr ir šifrēti miera stāvoklī un pārsūtīšanas laikā.';
 
   @override
   String get readOnlyScope => 'Tikai lasīšana';
@@ -4444,8 +4357,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Iegūstiet Omi Unlimited bez maksas, sniedzot savus datus AI modeļu apmācībai.';
 
   @override
-  String get trainingDataBullets =>
-      '• Jūsu dati palīdz uzlabot AI modeļus\n• Tiek kopīgoti tikai nejutīgi dati\n• Pilnībā pārredzams process';
+  String get trainingDataBullets => '• Jūsu dati palīdz uzlabot AI modeļus\n• Tiek kopīgoti tikai nejutīgi dati\n• Pilnībā pārredzams process';
 
   @override
   String get learnMoreAtOmiTraining => 'Uzziniet vairāk vietnē omi.me/training';
@@ -4457,8 +4369,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get submitRequest => 'Iesniegt pieprasījumu';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Paldies! Jūsu pieprasījums tiek izskatīts. Mēs jūs informēsim pēc apstiprināšanas.';
+  String get thankYouRequestUnderReview => 'Paldies! Jūsu pieprasījums tiek izskatīts. Mēs jūs informēsim pēc apstiprināšanas.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4496,8 +4407,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get monthlyPlanContinues => 'Jūsu pašreizējais mēneša plāns turpināsies līdz norēķinu perioda beigām';
 
   @override
-  String get paymentMethodCharged =>
-      'Jūsu esošais maksājuma veids tiks automātiski iekasēts, kad beigsies jūsu mēneša plāns';
+  String get paymentMethodCharged => 'Jūsu esošais maksājuma veids tiks automātiski iekasēts, kad beigsies jūsu mēneša plāns';
 
   @override
   String get annualSubscriptionStarts => 'Jūsu 12 mēnešu gada abonements automātiski sāksies pēc maksājuma';
@@ -4607,8 +4517,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Jūsu privātums mums ir svarīgs';
 
   @override
-  String get privacyIntroText =>
-      'Omi mēs ļoti nopietni uztveram jūsu privātumu. Mēs vēlamies būt caurspīdīgi par datiem, ko apkopojam un kā tos izmantojam. Lūk, kas jums jāzina:';
+  String get privacyIntroText => 'Omi mēs ļoti nopietni uztveram jūsu privātumu. Mēs vēlamies būt caurspīdīgi par datiem, ko apkopojam un kā tos izmantojam. Lūk, kas jums jāzina:';
 
   @override
   String get whatWeTrack => 'Ko mēs izsekojam';
@@ -4623,12 +4532,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get ourCommitment => 'Mūsu apņemšanās';
 
   @override
-  String get commitmentText =>
-      'Mēs esam apņēmušies izmantot apkopotos datus tikai, lai padarītu Omi par labāku produktu jums. Jūsu privātums un uzticība mums ir vissvarīgākā.';
+  String get commitmentText => 'Mēs esam apņēmušies izmantot apkopotos datus tikai, lai padarītu Omi par labāku produktu jums. Jūsu privātums un uzticība mums ir vissvarīgākā.';
 
   @override
-  String get thankYouText =>
-      'Paldies, ka esat vērtīgs Omi lietotājs. Ja jums ir kādi jautājumi vai bažas, sazinieties ar mums pa team@basedhardware.com.';
+  String get thankYouText => 'Paldies, ka esat vērtīgs Omi lietotājs. Ja jums ir kādi jautājumi vai bažas, sazinieties ar mums pa team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi sinhronizācijas iestatījumi';
@@ -4637,8 +4544,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get enterHotspotCredentials => 'Ievadiet tālruņa tīklāja akreditācijas datus';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi sinhronizācija izmanto jūsu tālruni kā tīklāju. Atrodiet nosaukumu un paroli sadaļā Iestatījumi > Personālais tīklājs.';
+  String get wifiSyncUsesHotspot => 'WiFi sinhronizācija izmanto jūsu tālruni kā tīklāju. Atrodiet nosaukumu un paroli sadaļā Iestatījumi > Personālais tīklājs.';
 
   @override
   String get hotspotNameSsid => 'Tīklāja nosaukums (SSID)';
@@ -4673,8 +4579,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Neizdevās izveidot kopsavilkumu. Pārliecinieties, ka jums ir sarunas par šo dienu.';
+  String get failedToGenerateSummaryCheckConversations => 'Neizdevās izveidot kopsavilkumu. Pārliecinieties, ka jums ir sarunas par šo dienu.';
 
   @override
   String get summaryNotFound => 'Kopsavilkums nav atrasts';
@@ -4704,8 +4609,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Eksports sākts. Tas var aizņemt dažas sekundes...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Tas dzēsīs visus atvasinātos zināšanu grafa datus (mezglus un savienojumus). Jūsu sākotnējās atmiņas paliks drošībā. Grafs tiks atjaunots laika gaitā vai nākamajā pieprasījumā.';
+  String get knowledgeGraphDeleteDescription => 'Tas dzēsīs visus atvasinātos zināšanu grafa datus (mezglus un savienojumus). Jūsu sākotnējās atmiņas paliks drošībā. Grafs tiks atjaunots laika gaitā vai nākamajā pieprasījumā.';
 
   @override
   String get configureDailySummaryDigest => 'Konfigurējiet savu ikdienas uzdevumu kopsavilkumu';
@@ -4775,8 +4679,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Dzēst visas Limitless sarunas?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Tas neatgriezeniski izdzēsīs visas no Limitless importētās sarunas. Šo darbību nevar atsaukt.';
+  String get deleteAllLimitlessWarning => 'Tas neatgriezeniski izdzēsīs visas no Limitless importētās sarunas. Šo darbību nevar atsaukt.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4832,8 +4735,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get howItWorksTitle => 'Kā tas darbojas?';
 
   @override
-  String get howPeopleWorks =>
-      'Kad persona ir izveidota, varat doties uz sarunas transkripciju un piešķirt viņiem atbilstošos segmentus, tādā veidā Omi varēs atpazīt arī viņu runu!';
+  String get howPeopleWorks => 'Kad persona ir izveidota, varat doties uz sarunas transkripciju un piešķirt viņiem atbilstošos segmentus, tādā veidā Omi varēs atpazīt arī viņu runu!';
 
   @override
   String get tapToDelete => 'Pieskarieties, lai dzēstu';
@@ -4859,8 +4761,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get privacyNotice => 'Privātuma paziņojums';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Ieraksti var ierakstīt citu cilvēku balsis. Pirms iespējošanas pārliecinieties, ka esat saņēmis visu dalībnieku piekrišanu.';
+  String get recordingsMayCaptureOthers => 'Ieraksti var ierakstīt citu cilvēku balsis. Pirms iespējošanas pārliecinieties, ka esat saņēmis visu dalībnieku piekrišanu.';
 
   @override
   String get enable => 'Iespējot';
@@ -4872,8 +4773,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get on => 'Ieslēgts';
 
   @override
-  String get storeAudioDescription =>
-      'Saglabājiet visus audio ierakstus lokāli savā tālrunī. Kad ir atspējots, tiek saglabāti tikai neveiksmīgie augšupielādēšanas gadījumi, lai ietaupītu vietu.';
+  String get storeAudioDescription => 'Saglabājiet visus audio ierakstus lokāli savā tālrunī. Kad ir atspējots, tiek saglabāti tikai neveiksmīgie augšupielādēšanas gadījumi, lai ietaupītu vietu.';
 
   @override
   String get enableLocalStorage => 'Iespējot lokālo krātuvi';
@@ -4894,8 +4794,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get cloudStorageDialogMessage => 'Jūsu reāllaika ieraksti tiks glabāti privātā mākoņkrātuvē, kamēr runājat.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Saglabājiet savus reāllaika ierakstus privātā mākoņkrātuvē, kamēr runājat. Audio tiek tverts un droši saglabāts reāllaikā.';
+  String get storeAudioCloudDescription => 'Saglabājiet savus reāllaika ierakstus privātā mākoņkrātuvē, kamēr runājat. Audio tiek tverts un droši saglabāts reāllaikā.';
 
   @override
   String get downloadingFirmware => 'Lejupielādē programmaparatūru';
@@ -4948,8 +4847,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get payments => 'Maksājumi';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Pievienojiet maksājuma metodi zemāk, lai sāktu saņemt maksājumus par savām lietotnēm.';
+  String get connectPaymentMethodInfo => 'Pievienojiet maksājuma metodi zemāk, lai sāktu saņemt maksājumus par savām lietotnēm.';
 
   @override
   String get selectedPaymentMethod => 'Izvēlētā maksājuma metode';
@@ -4976,8 +4874,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get monthlyPayouts => 'Ikmēneša maksājumi';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Saņemiet ikmēneša maksājumus tieši savā kontā, kad sasniedzat \$10 ieņēmumus';
+  String get monthlyPayoutsDescription => 'Saņemiet ikmēneša maksājumus tieši savā kontā, kad sasniedzat \$10 ieņēmumus';
 
   @override
   String get secureAndReliable => 'Drošs un uzticams';
@@ -5004,8 +4901,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get connectingYourStripeAccount => 'Jūsu Stripe konta savienošana';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Lūdzu, pabeidziet Stripe reģistrācijas procesu savā pārlūkprogrammā. Šī lapa tiks automātiski atjaunināta pēc pabeigšanas.';
+  String get stripeOnboardingInstructions => 'Lūdzu, pabeidziet Stripe reģistrācijas procesu savā pārlūkprogrammā. Šī lapa tiks automātiski atjaunināta pēc pabeigšanas.';
 
   @override
   String get failedTryAgain => 'Neizdevās? Mēģināt vēlreiz';
@@ -5017,8 +4913,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get successfullyConnected => 'Veiksmīgi savienots!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Jūsu Stripe konts tagad ir gatavs saņemt maksājumus. Jūs varat nekavējoties sākt pelnīt no savu lietotņu pārdošanas.';
+  String get stripeReadyForPayments => 'Jūsu Stripe konts tagad ir gatavs saņemt maksājumus. Jūs varat nekavējoties sākt pelnīt no savu lietotņu pārdošanas.';
 
   @override
   String get updateStripeDetails => 'Atjaunināt Stripe informāciju';
@@ -5036,8 +4931,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Atjauniniet sava PayPal konta informāciju';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Pievienojiet savu PayPal kontu, lai sāktu saņemt maksājumus par savām lietotnēm';
+  String get connectPayPalToReceivePayments => 'Pievienojiet savu PayPal kontu, lai sāktu saņemt maksājumus par savām lietotnēm';
 
   @override
   String get paypalEmail => 'PayPal e-pasts';
@@ -5046,8 +4940,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me saite';
 
   @override
-  String get stripeRecommendation =>
-      'Ja Stripe ir pieejams jūsu valstī, mēs ļoti iesakām to izmantot ātrākiem un vienkāršākiem maksājumiem.';
+  String get stripeRecommendation => 'Ja Stripe ir pieejams jūsu valstī, mēs ļoti iesakām to izmantot ātrākiem un vienkāršākiem maksājumiem.';
 
   @override
   String get updatePayPalDetails => 'Atjaunināt PayPal informāciju';
@@ -5099,12 +4992,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Papildu balss paraugs noņemts';
 
   @override
-  String get consentDataMessage =>
-      'Turpinot, jūsu sarunas, ieraksti un personiskā informācija tiks droši glabāta mūsu serveros. Jūsu audio ieraksti un transkripcijas tiek apstrādātas ar trešo pušu AI pakalpojumiem (ieskaitot Deepgram transkripcijai un OpenAI analīzei), lai sniegtu jums AI vadītus ieskatus un iespējotu visas lietotnes funkcijas.';
+  String get consentDataMessage => 'Turpinot, jūsu sarunas, ieraksti un personiskā informācija tiks droši glabāta mūsu serveros. Jūsu audio ieraksti un transkripcijas tiek apstrādātas ar trešo pušu AI pakalpojumiem (ieskaitot Deepgram transkripcijai un OpenAI analīzei), lai sniegtu jums AI vadītus ieskatus un iespējotu visas lietotnes funkcijas.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Uzdevumi no jūsu sarunām parādīsies šeit.\nPieskarieties +, lai izveidotu manuāli.';
+  String get tasksEmptyStateMessage => 'Uzdevumi no jūsu sarunām parādīsies šeit.\nPieskarieties +, lai izveidotu manuāli.';
 
   @override
   String get clearChatAction => 'Notīrīt tērzēšanu';
@@ -5140,15 +5031,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Instalējiet Omi savā\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Lai izmantotu Apple Watch ar Omi, vispirms jāinstalē Omi lietotne pulkstenī.';
+  String get installOmiOnAppleWatchDescription => 'Lai izmantotu Apple Watch ar Omi, vispirms jāinstalē Omi lietotne pulkstenī.';
 
   @override
   String get openOmiOnAppleWatch => 'Atveriet Omi savā\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi lietotne ir instalēta jūsu Apple Watch. Atveriet to un pieskarieties Sākt.';
+  String get openOmiOnAppleWatchDescription => 'Omi lietotne ir instalēta jūsu Apple Watch. Atveriet to un pieskarieties Sākt.';
 
   @override
   String get openWatchApp => 'Atvērt Watch lietotni';
@@ -5157,15 +5046,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Esmu instalējis un atvēris lietotni';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Nevar atvērt Apple Watch lietotni. Lūdzu, manuāli atveriet Watch lietotni savā Apple Watch un instalējiet Omi no sadaļas \"Pieejamās lietotnes\".';
+  String get unableToOpenWatchApp => 'Nevar atvērt Apple Watch lietotni. Lūdzu, manuāli atveriet Watch lietotni savā Apple Watch un instalējiet Omi no sadaļas \"Pieejamās lietotnes\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch veiksmīgi savienots!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch joprojām nav sasniedzams. Lūdzu, pārliecinieties, ka Omi lietotne ir atvērta jūsu pulkstenī.';
+  String get appleWatchNotReachable => 'Apple Watch joprojām nav sasniedzams. Lūdzu, pārliecinieties, ka Omi lietotne ir atvērta jūsu pulkstenī.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5593,29 +5480,25 @@ class AppLocalizationsLv extends AppLocalizations {
   String get multipleSpeakersDetected => 'Konstatēti vairāki runātāji';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Izskatās, ka ierakstā ir vairāki runātāji. Pārliecinieties, ka atrodaties klusā vietā, un mēģiniet vēlreiz.';
+  String get multipleSpeakersDescription => 'Izskatās, ka ierakstā ir vairāki runātāji. Pārliecinieties, ka atrodaties klusā vietā, un mēģiniet vēlreiz.';
 
   @override
   String get invalidRecordingDetected => 'Konstatēts nederīgs ieraksts';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Netika konstatēta pietiekama runa. Lūdzu, runājiet vairāk un mēģiniet vēlreiz.';
+  String get notEnoughSpeechDescription => 'Netika konstatēta pietiekama runa. Lūdzu, runājiet vairāk un mēģiniet vēlreiz.';
 
   @override
   String get speechDurationDescription => 'Pārliecinieties, ka runājat vismaz 5 sekundes un ne vairāk kā 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Savienojums tika pārtraukts. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
+  String get connectionLostDescription => 'Savienojums tika pārtraukts. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
 
   @override
   String get howToTakeGoodSample => 'Kā iegūt labu paraugu?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Pārliecinieties, ka atrodaties klusā vietā.\n2. Runājiet skaidri un dabiski.\n3. Pārliecinieties, ka ierīce atrodas dabiskā stāvoklī uz kakla.\n\nPēc izveides vienmēr varat to uzlabot vai izveidot no jauna.';
+  String get goodSampleInstructions => '1. Pārliecinieties, ka atrodaties klusā vietā.\n2. Runājiet skaidri un dabiski.\n3. Pārliecinieties, ka ierīce atrodas dabiskā stāvoklī uz kakla.\n\nPēc izveides vienmēr varat to uzlabot vai izveidot no jauna.';
 
   @override
   String get noDeviceConnectedUseMic => 'Nav pievienota neviena ierīce. Tiks izmantots tālruņa mikrofons.';
@@ -5678,12 +5561,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get howItWorks => 'Kā tas darbojas';
 
   @override
-  String get dailyScoreExplanation =>
-      'Jūsu dienas rezultāts balstās uz uzdevumu izpildi. Pabeidziet uzdevumus, lai uzlabotu rezultātu!';
+  String get dailyScoreExplanation => 'Jūsu dienas rezultāts balstās uz uzdevumu izpildi. Pabeidziet uzdevumus, lai uzlabotu rezultātu!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontrolējiet, cik bieži Omi sūta jums proaktīvus paziņojumus un atgādinājumus.';
+  String get notificationFrequencyDescription => 'Kontrolējiet, cik bieži Omi sūta jums proaktīvus paziņojumus un atgādinājumus.';
 
   @override
   String get sliderOff => 'Izslēgts';
@@ -5697,8 +5578,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Neizdevās izveidot kopsavilkumu. Pārliecinieties, ka jums ir sarunas par šo dienu.';
+  String get failedToGenerateSummary => 'Neizdevās izveidot kopsavilkumu. Pārliecinieties, ka jums ir sarunas par šo dienu.';
 
   @override
   String get recap => 'Kopsavilkums';
@@ -5777,8 +5657,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get selectApp => 'Izvēlēties lietotni';
 
   @override
-  String get noChatAppsEnabled =>
-      'Nav iespējotas tērzēšanas lietotnes.\nPieskarieties \"Iespējot lietotnes\", lai pievienotu.';
+  String get noChatAppsEnabled => 'Nav iespējotas tērzēšanas lietotnes.\nPieskarieties \"Iespējot lietotnes\", lai pievienotu.';
 
   @override
   String get disable => 'Atspējot';
@@ -5930,8 +5809,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get recordings => 'Ieraksti';
 
   @override
-  String get enableRemindersAccess =>
-      'Lūdzu, iespējojiet piekļuvi atgādinājumiem Iestatījumos, lai izmantotu Apple Atgādinājumus';
+  String get enableRemindersAccess => 'Lūdzu, iespējojiet piekļuvi atgādinājumiem Iestatījumos, lai izmantotu Apple Atgādinājumus';
 
   @override
   String todayAtTime(String time) {
@@ -5986,8 +5864,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL nav iestatīts';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Lūdzu, iestatiet webhook URL izstrādātāja iestatījumos, lai izmantotu šo funkciju.';
+  String get setWebhookUrlInSettings => 'Lūdzu, iestatiet webhook URL izstrādātāja iestatījumos, lai izmantotu šo funkciju.';
 
   @override
   String get sendWebUrl => 'Sūtīt tīmekļa URL';
@@ -6061,15 +5938,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get cloudProvider => 'Mākoņa nodrošinātājs';
 
   @override
-  String get premiumMinutesInfo =>
-      '1200 premium minūtes mēnesī. Cilne \"Ierīcē\" piedāvā neierobežotu bezmaksas transkripciju.';
+  String get premiumMinutesInfo => '1200 premium minūtes mēnesī. Cilne \"Ierīcē\" piedāvā neierobežotu bezmaksas transkripciju.';
 
   @override
   String get viewUsage => 'Skatīt lietojumu';
 
   @override
-  String get localProcessingInfo =>
-      'Audio tiek apstrādāts lokāli. Darbojas bezsaistē, privātāk, bet patērē vairāk akumulatora.';
+  String get localProcessingInfo => 'Audio tiek apstrādāts lokāli. Darbojas bezsaistē, privātāk, bet patērē vairāk akumulatora.';
 
   @override
   String get model => 'Modelis';
@@ -6078,15 +5953,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get performanceWarning => 'Veiktspējas brīdinājums';
 
   @override
-  String get largeModelWarning =>
-      'Šis modelis ir liels un var izraisīt lietotnes avāriju vai ļoti lēnu darbību mobilajās ierīcēs.\n\nIeteicams izvēlēties \"small\" vai \"base\".';
+  String get largeModelWarning => 'Šis modelis ir liels un var izraisīt lietotnes avāriju vai ļoti lēnu darbību mobilajās ierīcēs.\n\nIeteicams izvēlēties \"small\" vai \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Tiek izmantota vietējā iOS runas atpazīšana';
 
   @override
-  String get noModelDownloadRequired =>
-      'Tiks izmantots jūsu ierīces sākotnējais runas dzinējs. Modeļa lejupielāde nav nepieciešama.';
+  String get noModelDownloadRequired => 'Tiks izmantots jūsu ierīces sākotnējais runas dzinējs. Modeļa lejupielāde nav nepieciešama.';
 
   @override
   String get modelReady => 'Modelis gatavs';
@@ -6143,12 +6016,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get batteryDrainSignificantly => 'Akumulatora izlāde ievērojami palielināsies.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 premium minūtes/mēnesī. Cilnē Ierīcē piedāvā neierobežotu bezmaksas transkripciju. ';
+  String get premiumMinutesMonth => '1200 premium minūtes/mēnesī. Cilnē Ierīcē piedāvā neierobežotu bezmaksas transkripciju. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Audio tiek apstrādāts lokāli. Darbojas bezsaistē, privātāk, bet patērē vairāk akumulatora.';
+  String get audioProcessedLocally => 'Audio tiek apstrādāts lokāli. Darbojas bezsaistē, privātāk, bet patērē vairāk akumulatora.';
 
   @override
   String get languageLabel => 'Valoda';
@@ -6157,12 +6028,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get modelLabel => 'Modelis';
 
   @override
-  String get modelTooLargeWarning =>
-      'Šis modelis ir liels un var izraisīt lietotnes avāriju vai ļoti lēnu darbību mobilajās ierīcēs.\n\nIeteicams small vai base.';
+  String get modelTooLargeWarning => 'Šis modelis ir liels un var izraisīt lietotnes avāriju vai ļoti lēnu darbību mobilajās ierīcēs.\n\nIeteicams small vai base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Tiks izmantots jūsu ierīces vietējais runas dzinējs. Modeļa lejupielāde nav nepieciešama.';
+  String get nativeEngineNoDownload => 'Tiks izmantots jūsu ierīces vietējais runas dzinējs. Modeļa lejupielāde nav nepieciešama.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6198,8 +6067,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi iebūvētā tiešraides transkripcija ir optimizēta reāllaika sarunām ar automātisku runātāju noteikšanu un diarizāciju.';
+  String get omiTranscriptionOptimized => 'Omi iebūvētā tiešraides transkripcija ir optimizēta reāllaika sarunām ar automātisku runātāju noteikšanu un diarizāciju.';
 
   @override
   String get reset => 'Atiestatīt';
@@ -6419,8 +6287,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Veido zināšanu grafu no atmiņām...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Jūsu zināšanu grafs tiks izveidots automātiski, kad veidosiet jaunas atmiņas.';
+  String get knowledgeGraphWillBuildAutomatically => 'Jūsu zināšanu grafs tiks izveidots automātiski, kad veidosiet jaunas atmiņas.';
 
   @override
   String get buildGraphButton => 'Izveidot grafu';
@@ -6656,8 +6523,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get failedToLoadContacts => 'Neizdevās ielādēt kontaktus';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Neizdevās sagatavot sarunu kopīgošanai. Lūdzu, mēģiniet vēlreiz.';
+  String get failedToPrepareConversationForSharing => 'Neizdevās sagatavot sarunu kopīgošanai. Lūdzu, mēģiniet vēlreiz.';
 
   @override
   String get couldNotOpenSmsApp => 'Neizdevās atvērt SMS lietotni. Lūdzu, mēģiniet vēlreiz.';
@@ -6723,8 +6589,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Lejupielādē audio no ierīces SD kartes';
 
   @override
-  String get transferRequiredDescription =>
-      'Šis ieraksts ir saglabāts jūsu ierīces SD kartē. Pārsūtiet to uz tālruni, lai atskaņotu vai kopīgotu.';
+  String get transferRequiredDescription => 'Šis ieraksts ir saglabāts jūsu ierīces SD kartē. Pārsūtiet to uz tālruni, lai atskaņotu vai kopīgotu.';
 
   @override
   String get cancelTransfer => 'Atcelt pārsūtīšanu';
@@ -6804,8 +6669,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get enableFastTransfer => 'Iespējot ātro pārsūtīšanu';
 
   @override
-  String get fastTransferDescription =>
-      'Ātrā pārsūtīšana izmanto WiFi ~5x ātrākam ātrumam. Pārsūtīšanas laikā tālrunis īslaicīgi pieslēgsies Omi ierīces WiFi tīklam.';
+  String get fastTransferDescription => 'Ātrā pārsūtīšana izmanto WiFi ~5x ātrākam ātrumam. Pārsūtīšanas laikā tālrunis īslaicīgi pieslēgsies Omi ierīces WiFi tīklam.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Interneta piekļuve ir apturēta pārsūtīšanas laikā';
@@ -6820,8 +6684,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get fiveTimesFaster => '5X ĀTRĀK';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Izveido tiešu WiFi savienojumu ar Omi ierīci. Pārsūtīšanas laikā tālrunis īslaicīgi atvienojas no parastā WiFi.';
+  String get fastTransferMethodDescription => 'Izveido tiešu WiFi savienojumu ar Omi ierīci. Pārsūtīšanas laikā tālrunis īslaicīgi atvienojas no parastā WiFi.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6830,8 +6693,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get bleSpeed => '~30 KB/s caur BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Izmanto standarta Bluetooth Low Energy savienojumu. Lēnāk, bet neietekmē WiFi savienojumu.';
+  String get bluetoothMethodDescription => 'Izmanto standarta Bluetooth Low Energy savienojumu. Lēnāk, bet neietekmē WiFi savienojumu.';
 
   @override
   String get selected => 'Atlasīts';
@@ -6869,12 +6731,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get appDeleteFailed => 'Neizdevās izdzēst lietotni. Lūdzu, mēģiniet vēlāk.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Lietotnes redzamība veiksmīgi mainīta. Var paiet dažas minūtes, līdz izmaiņas stājas spēkā.';
+  String get appVisibilityChangedSuccessfully => 'Lietotnes redzamība veiksmīgi mainīta. Var paiet dažas minūtes, līdz izmaiņas stājas spēkā.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Kļūda, aktivizējot lietotni. Ja tā ir integrācijas lietotne, pārliecinieties, ka iestatīšana ir pabeigta.';
+  String get errorActivatingAppIntegration => 'Kļūda, aktivizējot lietotni. Ja tā ir integrācijas lietotne, pārliecinieties, ka iestatīšana ir pabeigta.';
 
   @override
   String get errorUpdatingAppStatus => 'Atjauninot lietotnes statusu, radās kļūda.';
@@ -6954,8 +6814,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Nosaukumam jābūt vismaz 3 rakstzīmēm';
 
   @override
-  String get conversationPromptHint =>
-      'piem., Izvelciet darbību punktus, pieņemtos lēmumus un galvenos secinājumus no sarunas.';
+  String get conversationPromptHint => 'piem., Izvelciet darbību punktus, pieņemtos lēmumus un galvenos secinājumus no sarunas.';
 
   @override
   String get pleaseEnterAppPrompt => 'Lūdzu, ievadiet uzvedni savai lietotnei';
@@ -7142,19 +7001,16 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Jaunināšana ieplānota! Jūsu mēneša plāns turpinās līdz norēķinu perioda beigām, pēc tam automātiski pārslēgsies uz gada plānu.';
+  String get planUpgradeScheduledMessage => 'Jaunināšana ieplānota! Jūsu mēneša plāns turpinās līdz norēķinu perioda beigām, pēc tam automātiski pārslēgsies uz gada plānu.';
 
   @override
   String get couldNotSchedulePlanChange => 'Nevarēja ieplānot plāna maiņu. Lūdzu, mēģiniet vēlreiz.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Jūsu abonements ir atkārtoti aktivizēts! Šobrīd maksājuma nav - jums tiks izrakstīts rēķins pašreizējā perioda beigās.';
+  String get subscriptionReactivatedDefault => 'Jūsu abonements ir atkārtoti aktivizēts! Šobrīd maksājuma nav - jums tiks izrakstīts rēķins pašreizējā perioda beigās.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Abonements veiksmīgs! Jums tika iekasēta maksa par jauno norēķinu periodu.';
+  String get subscriptionSuccessfulCharged => 'Abonements veiksmīgs! Jums tika iekasēta maksa par jauno norēķinu periodu.';
 
   @override
   String get couldNotProcessSubscription => 'Nevarēja apstrādāt abonementu. Lūdzu, mēģiniet vēlreiz.';
@@ -7274,8 +7130,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get successfullyConnectedGoogleTasks => 'Veiksmīgi savienots ar Google Tasks!';
 
   @override
-  String get failedToConnectGoogleTasksRetry =>
-      'Neizdevās izveidot savienojumu ar Google Tasks. Lūdzu, mēģiniet vēlreiz.';
+  String get failedToConnectGoogleTasksRetry => 'Neizdevās izveidot savienojumu ar Google Tasks. Lūdzu, mēģiniet vēlreiz.';
 
   @override
   String get successfullyConnectedClickUp => 'Veiksmīgi savienots ar ClickUp!';
@@ -7320,8 +7175,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Neizdevās iegūt Firebase marķieri, lūdzu, mēģiniet vēlreiz.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Neparedzēta kļūda pierakstīšanās laikā, Firebase kļūda, lūdzu, mēģiniet vēlreiz.';
+  String get authUnexpectedErrorFirebase => 'Neparedzēta kļūda pierakstīšanās laikā, Firebase kļūda, lūdzu, mēģiniet vēlreiz.';
 
   @override
   String get authUnexpectedError => 'Neparedzēta kļūda pierakstīšanās laikā, lūdzu, mēģiniet vēlreiz';
@@ -7336,8 +7190,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Bluetooth atļauja ir nepieciešama, lai izveidotu savienojumu ar ierīci.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumos.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumos.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7350,12 +7203,10 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Paziņojumu atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumos.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Paziņojumu atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumos.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Paziņojumu atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumi > Paziņojumi.';
+  String get onboardingNotificationDeniedNotifications => 'Paziņojumu atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumi > Paziņojumi.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7368,15 +7219,13 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Lūdzu, piešķiriet atrašanās vietas atļauju Iestatījumi > Privātums un drošība > Atrašanās vietas pakalpojumi';
+  String get onboardingLocationGrantInSettings => 'Lūdzu, piešķiriet atrašanās vietas atļauju Iestatījumi > Privātums un drošība > Atrašanās vietas pakalpojumi';
 
   @override
   String get onboardingMicrophoneRequired => 'Ierakstīšanai ir nepieciešama mikrofona atļauja.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofona atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumi > Privātums un drošība > Mikrofons.';
+  String get onboardingMicrophoneDenied => 'Mikrofona atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumi > Privātums un drošība > Mikrofons.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7389,12 +7238,10 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Sistēmas audio ierakstīšanai ir nepieciešama ekrāna tveršanas atļauja.';
+  String get onboardingScreenCaptureRequired => 'Sistēmas audio ierakstīšanai ir nepieciešama ekrāna tveršanas atļauja.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Ekrāna tveršanas atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumi > Privātums un drošība > Ekrāna ierakstīšana.';
+  String get onboardingScreenCaptureDenied => 'Ekrāna tveršanas atļauja noraidīta. Lūdzu, piešķiriet atļauju Sistēmas iestatījumi > Privātums un drošība > Ekrāna ierakstīšana.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7447,8 +7294,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Fotoattēlu atļauja liegta. Lūdzu, atļaujiet piekļuvi fotoattēliem, lai atlasītu attēlus';
+  String get msgPhotosPermissionDenied => 'Fotoattēlu atļauja liegta. Lūdzu, atļaujiet piekļuvi fotoattēliem, lai atlasītu attēlus';
 
   @override
   String get msgSelectImagesGenericError => 'Kļūda atlasot attēlus. Lūdzu, mēģiniet vēlreiz.';
@@ -7520,8 +7366,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get locationPermissionRequired => 'Nepieciešama atrašanās vietas atļauja';
 
   @override
-  String get locationPermissionContent =>
-      'Ātrai pārsūtīšanai nepieciešama atrašanās vietas atļauja, lai pārbaudītu WiFi savienojumu. Lūdzu, piešķiriet atrašanās vietas atļauju, lai turpinātu.';
+  String get locationPermissionContent => 'Ātrai pārsūtīšanai nepieciešama atrašanās vietas atļauja, lai pārbaudītu WiFi savienojumu. Lūdzu, piešķiriet atrašanās vietas atļauju, lai turpinātu.';
 
   @override
   String get pdfTranscriptExport => 'Transkripcijas eksports';
@@ -7980,8 +7825,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Ieslēdziet Omi DevKit savienošanas režīmā';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Nospiediet pogu vienu reizi, lai ieslēgtu. LED mirgos violeti savienošanas režīmā.';
+  String get pairingDescOmiDevkit => 'Nospiediet pogu vienu reizi, lai ieslēgtu. LED mirgos violeti savienošanas režīmā.';
 
   @override
   String get pairingTitleOmiGlass => 'Ieslēdziet Omi Glass';
@@ -7993,8 +7837,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Ieslēdziet Plaud Note savienošanas režīmā';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Nospiediet un turiet sānu pogu 2 sekundes. Sarkanais LED mirgos, kad ierīce ir gatava savienošanai.';
+  String get pairingDescPlaudNote => 'Nospiediet un turiet sānu pogu 2 sekundes. Sarkanais LED mirgos, kad ierīce ir gatava savienošanai.';
 
   @override
   String get pairingTitleBee => 'Ieslēdziet Bee savienošanas režīmā';
@@ -8006,15 +7849,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get pairingTitleLimitless => 'Ieslēdziet Limitless savienošanas režīmā';
 
   @override
-  String get pairingDescLimitless =>
-      'Kad redzama jebkura gaisma, nospiediet vienu reizi, tad nospiediet un turiet, līdz ierīce rāda rozā gaismu, tad atlaidiet.';
+  String get pairingDescLimitless => 'Kad redzama jebkura gaisma, nospiediet vienu reizi, tad nospiediet un turiet, līdz ierīce rāda rozā gaismu, tad atlaidiet.';
 
   @override
   String get pairingTitleFriendPendant => 'Ieslēdziet Friend Pendant savienošanas režīmā';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Nospiediet pogu uz kulona, lai to ieslēgtu. Tas automātiski pārslēgsies savienošanas režīmā.';
+  String get pairingDescFriendPendant => 'Nospiediet pogu uz kulona, lai to ieslēgtu. Tas automātiski pārslēgsies savienošanas režīmā.';
 
   @override
   String get pairingTitleFieldy => 'Ieslēdziet Fieldy savienošanas režīmā';
@@ -8026,8 +7867,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Pievienojiet Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Instalējiet un atveriet Omi lietotni savā Apple Watch, tad pieskarieties Savienot lietotnē.';
+  String get pairingDescAppleWatch => 'Instalējiet un atveriet Omi lietotni savā Apple Watch, tad pieskarieties Savienot lietotnē.';
 
   @override
   String get pairingTitleNeoOne => 'Ieslēdziet Neo One savienošanas režīmā';
@@ -8103,8 +7943,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get wifiConfiguration => 'WiFi konfigurācija';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Ievadiet WiFi akreditācijas datus, lai ierīce varētu lejupielādēt programmaparatūru.';
+  String get wifiConfigurationSubtitle => 'Ievadiet WiFi akreditācijas datus, lai ierīce varētu lejupielādēt programmaparatūru.';
 
   @override
   String get networkNameSsid => 'Tīkla nosaukums (SSID)';
@@ -8151,8 +7990,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get switchAndRestart => 'Pārslēgt';
 
   @override
-  String get stagingDisclaimer =>
-      'Testa vide var būt nestabila, ar nevienmērīgu veiktspēju, un dati var tikt zaudēti. Tikai testēšanai.';
+  String get stagingDisclaimer => 'Testa vide var būt nestabila, ar nevienmērīgu veiktspēju, un dati var tikt zaudēti. Tikai testēšanai.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Saglabāts. Aizveriet un atveriet lietotni vēlreiz, lai piemērotu izmaiņas.';
@@ -8381,8 +8219,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Tālruņa zvani caur Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Veiciet zvanus caur Omi un saņemiet reāllaika transkripciju, automātiskus kopsavilkumus un daudz ko citu.';
+  String get phoneCallsUpsellSubtitle => 'Veiciet zvanus caur Omi un saņemiet reāllaika transkripciju, automātiskus kopsavilkumus un daudz ko citu.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Katra zvana reāllaika transkripcija';
@@ -8421,8 +8258,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deletePendingFiles => 'Dzēst gaidošos ierakstus';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Šie ieraksti NAV sinhronizēti ar jūsu tālruni un tiks neatgriezeniski zaudēti. To nevar atsaukt.';
+  String get deletePendingFilesWarning => 'Šie ieraksti NAV sinhronizēti ar jūsu tālruni un tiks neatgriezeniski zaudēti. To nevar atsaukt.';
 
   @override
   String get pendingFilesDeleted => 'Gaidošie ieraksti dzēsti';
@@ -8434,8 +8270,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deleteAll => 'Dzēst visu';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Tas dzēsīs sinhronizētos un gaidošos ierakstus. Gaidošie ieraksti NAV sinhronizēti un tiks neatgriezeniski zaudēti.';
+  String get deleteAllFilesWarning => 'Tas dzēsīs sinhronizētos un gaidošos ierakstus. Gaidošie ieraksti NAV sinhronizēti un tiks neatgriezeniski zaudēti.';
 
   @override
   String get allFilesDeleted => 'Visi ieraksti dzēsti';
@@ -8500,8 +8335,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get fairUseAboutTitle => 'Par godīgu lietošanu';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi ir izstrādāts personīgām sarunām, sanāksmēm un tiešsaistes mijiedarbībai. Lietojums tiek mērīts pēc konstatētā reālā runas laika, nevis savienojuma laika. Ja lietojums ievērojami pārsniedz parastos modeļus nepersoniskam saturam, var tikt piemēroti pielāgojumi.';
+  String get fairUseAboutBody => 'Omi ir izstrādāts personīgām sarunām, sanāksmēm un tiešsaistes mijiedarbībai. Lietojums tiek mērīts pēc konstatētā reālā runas laika, nevis savienojuma laika. Ja lietojums ievērojami pārsniedz parastos modeļus nepersoniskam saturam, var tikt piemēroti pielāgojumi.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8539,8 +8373,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get improveConnectionTitle => 'Uzlabot savienojumu';
 
   @override
-  String get improveConnectionContent =>
-      'Mēs esam uzlabojuši veidu, kā Omi paliek savienots ar jūsu ierīci. Lai to aktivizētu, dodieties uz ierīces informācijas lapu, pieskarieties \"Atvienot ierīci\" un savienojiet ierīci pārī no jauna.';
+  String get improveConnectionContent => 'Mēs esam uzlabojuši veidu, kā Omi paliek savienots ar jūsu ierīci. Lai to aktivizētu, dodieties uz ierīces informācijas lapu, pieskarieties \"Atvienot ierīci\" un savienojiet ierīci pārī no jauna.';
 
   @override
   String get improveConnectionAction => 'Sapratu';
@@ -8595,16 +8428,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get cancelSyncQuestion => 'Atcelt sinhronizāciju?';
 
   @override
-  String get omisStorageDesc =>
-      'Kad jūsu Omi nav savienots ar tālruni, tas saglabā audio lokāli iebūvētajā atmiņā. Jūs nekad nezaudēsiet ierakstu.';
+  String get omisStorageDesc => 'Kad jūsu Omi nav savienots ar tālruni, tas saglabā audio lokāli iebūvētajā atmiņā. Jūs nekad nezaudēsiet ierakstu.';
 
   @override
-  String get phoneStorageDesc =>
-      'Kad Omi atkārtoti pieslēdzas, ieraksti automātiski tiek pārsūtīti uz jūsu tālruni pirms augšupielādes.';
+  String get phoneStorageDesc => 'Kad Omi atkārtoti pieslēdzas, ieraksti automātiski tiek pārsūtīti uz jūsu tālruni pirms augšupielādes.';
 
   @override
-  String get cloudStorageDesc =>
-      'Pēc augšupielādes jūsu ieraksti tiek apstrādāti un transkribēti. Sarunas būs pieejamas minūtes laikā.';
+  String get cloudStorageDesc => 'Pēc augšupielādes jūsu ieraksti tiek apstrādāti un transkribēti. Sarunas būs pieejamas minūtes laikā.';
 
   @override
   String get tipKeepPhoneNearby => 'Turiet tālruni tuvumā ātrākai sinhronizācijai';
@@ -8628,12 +8458,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get permissionEnable => 'Iespējot';
 
   @override
-  String get permissionsPageDescription =>
-      'Šīs atļaujas ir būtiskas Omi darbībai. Tās nodrošina galvenās funkcijas, piemēram, paziņojumus, uz atrašanās vietu balstītas pieredzes un audio ierakstīšanu.';
+  String get permissionsPageDescription => 'Šīs atļaujas ir būtiskas Omi darbībai. Tās nodrošina galvenās funkcijas, piemēram, paziņojumus, uz atrašanās vietu balstītas pieredzes un audio ierakstīšanu.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi ir nepieciešamas dažas atļaujas, lai pareizi darbotos. Lūdzu, piešķiriet tās, lai turpinātu.';
+  String get permissionsRequiredDescription => 'Omi ir nepieciešamas dažas atļaujas, lai pareizi darbotos. Lūdzu, piešķiriet tās, lai turpinātu.';
 
   @override
   String get permissionsSetupTitle => 'Iegūstiet vislabāko pieredzi';
@@ -8889,8 +8717,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get enableLocationTitle => 'Iespējot atrašanās vietu';
 
   @override
-  String get enableLocationDescription =>
-      'Atrašanās vietas atļauja ir nepieciešama, lai atrastu tuvumā esošās Bluetooth ierīces.';
+  String get enableLocationDescription => 'Atrašanās vietas atļauja ir nepieciešama, lai atrastu tuvumā esošās Bluetooth ierīces.';
 
   @override
   String get voiceRecordingFound => 'Ieraksts atrasts';
@@ -8911,8 +8738,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get firmwareWarningTitle => 'Svarīgi: Izlasiet pirms atjaunināšanas';
 
   @override
-  String get firmwareFormatWarning =>
-      'Šī programmaparatūra formatēs SD karti. Lūdzu, pārliecinieties, ka visi bezsaistes dati ir sinhronizēti pirms jaunināšanas.\n\nJa pēc šīs versijas instalēšanas redzat mirgojoššu sarkanu gaismu, neuztraucieties. Vienkārši pievienojiet ierīci lietotnei, un tai vajadzētu kļūt zilai. Sarkanā gaisma nozīmē, ka ierīces pulkstenis vēl nav sinhronizēts.';
+  String get firmwareFormatWarning => 'Šī programmaparatūra formatēs SD karti. Lūdzu, pārliecinieties, ka visi bezsaistes dati ir sinhronizēti pirms jaunināšanas.\n\nJa pēc šīs versijas instalēšanas redzat mirgojoššu sarkanu gaismu, neuztraucieties. Vienkārši pievienojiet ierīci lietotnei, un tai vajadzētu kļūt zilai. Sarkanā gaisma nozīmē, ka ierīces pulkstenis vēl nav sinhronizēts.';
 
   @override
   String get continueAnyway => 'Turpināt';
@@ -8932,8 +8758,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get tasksMarkComplete => 'Atzīmēts kā pabeigts';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi piekļūst Apple Health, izmantojot Apple HealthKit ietvaru. Piekļuvi varat atsaukt jebkurā laikā iOS iestatījumos.';
+  String get appleHealthManageNote => 'Omi piekļūst Apple Health, izmantojot Apple HealthKit ietvaru. Piekļuvi varat atsaukt jebkurā laikā iOS iestatījumos.';
 
   @override
   String get appleHealthConnectCta => 'Pievienot Apple Health';
@@ -8966,8 +8791,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Piekļuve Apple Health liegta';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi nav atļaujas lasīt jūsu Apple Health datus. Iespējojiet: iOS Iestatījumi → Privātums un drošība → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi nav atļaujas lasīt jūsu Apple Health datus. Iespējojiet: iOS Iestatījumi → Privātums un drošība → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Kāpēc tu aizej?';
@@ -9036,8 +8860,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get planUpdate => 'Plāna atjauninājums';
 
   @override
-  String get planDeprecationMessage =>
-      'Jūsu Unlimited plāns tiek pārtraukts. Pārejiet uz Operator plānu — tās pašas lieliskās funkcijas par \$49/mēnesī. Jūsu pašreizējais plāns turpinās darboties pa to laiku.';
+  String get planDeprecationMessage => 'Jūsu Unlimited plāns tiek pārtraukts. Pārejiet uz Operator plānu — tās pašas lieliskās funkcijas par \$49/mēnesī. Jūsu pašreizējais plāns turpinās darboties pa to laiku.';
 
   @override
   String get upgradeYourPlan => 'Uzlabojiet savu plānu';
@@ -9148,8 +8971,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Jūs esat sasniedzis savu mēneša limitu. Jauniniet, lai turpinātu tērzēt ar Omi bez ierobežojumiem.';
+  String get chatQuotaExceededReply => 'Jūs esat sasniedzis savu mēneša limitu. Jauniniet, lai turpinātu tērzēt ar Omi bez ierobežojumiem.';
 
   @override
   String get voiceResponseAudio => 'Lasīt Omi atbildi skaļi';
@@ -9180,4 +9002,25 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Pievienot uzdevumu';
+
+  @override
+  String get quickActionAskOmiAnything => 'Jautājiet Omi jebko';
+
+  @override
+  String get quickActionVoiceMode => 'Balss režīms';
+
+  @override
+  String get quickActionMute => 'Izslēgt skaņu';
+
+  @override
+  String get quickActionUnmute => 'Ieslēgt skaņu';
+
+  @override
+  String get quickActionConnectDevice => 'Savienot ierīci';
+
+  @override
+  String get quickActionDeviceSettings => 'Ierīces iestatījumi';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -24,8 +24,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deleteConversationTitle => 'Избриши разговор?';
 
   @override
-  String get deleteConversationMessage =>
-      'Ова ќе избрише и поврзаните спомени, задачи и аудио датотеки. Оваа акција не може да се отповика.';
+  String get deleteConversationMessage => 'Ова ќе избрише и поврзаните спомени, задачи и аудио датотеки. Оваа акција не може да се отповика.';
 
   @override
   String get confirm => 'Потврди';
@@ -146,8 +145,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deleting => 'Бришам...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Завршите аутентификација во вашиот претседател. Откако ќе завршите, вратете се во апликацијата.';
+  String get pleaseCompleteAuthentication => 'Завршите аутентификација во вашиот претседател. Откако ќе завршите, вратете се во апликацијата.';
 
   @override
   String get failedToStartAuthentication => 'Неуспешен почеток на аутентификација';
@@ -228,8 +226,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get noStarredConversations => 'Нема означени разговори со ѕвезда';
 
   @override
-  String get starConversationHint =>
-      'За да означите разговор со ѕвезда, отворете го и допрете икона ѕвезда во заглавието.';
+  String get starConversationHint => 'За да означите разговор со ѕвезда, отворете го и допрете икона ѕвезда во заглавието.';
 
   @override
   String get searchConversations => 'Пребарај разговори...';
@@ -287,8 +284,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get clearChat => 'Очисти разговор';
 
   @override
-  String get clearChatConfirm =>
-      'Дали сте сигурни дека сакате да го очистите разговорот? Оваа акција не може да се отповика.';
+  String get clearChatConfirm => 'Дали сте сигурни дека сакате да го очистите разговорот? Оваа акција не може да се отповика.';
 
   @override
   String get maxFilesLimit => 'Можете да подигнете максимално 4 датотеки одеднаш';
@@ -321,8 +317,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get installedApps => 'Инсталирани апликации';
 
   @override
-  String get unableToFetchApps =>
-      'Неможно да се преземат апликациите :(\n\nПроверете ја интернет врската и обидете се повторно.';
+  String get unableToFetchApps => 'Неможно да се преземат апликациите :(\n\nПроверете ја интернет врската и обидете се повторно.';
 
   @override
   String get aboutOmi => 'За Omi';
@@ -358,19 +353,16 @@ class AppLocalizationsMk extends AppLocalizations {
   String get appsDisconnected => 'Ваши апликации и интеграции ќе бидат исклучени веднаш.';
 
   @override
-  String get exportBeforeDelete =>
-      'Можете да ги извезете ваши податоци пред да го избришете профилот, но откако ќе биде избришан, не може да се врати.';
+  String get exportBeforeDelete => 'Можете да ги извезете ваши податоци пред да го избришете профилот, но откако ќе биде избришан, не може да се врати.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Разбирам дека бришењето на мој профил е трајно и сите податоци, вклучувајќи ги спомените и разговорите, ќе бидат изгубени и не можат да се вратат.';
+  String get deleteAccountCheckbox => 'Разбирам дека бришењето на мој профил е трајно и сите податоци, вклучувајќи ги спомените и разговорите, ќе бидат изгубени и не можат да се вратат.';
 
   @override
   String get areYouSure => 'Дали сте сигурни?';
 
   @override
-  String get deleteAccountFinal =>
-      'Оваа акција е неревидна и трајно ќе го избрише вашиот профил и сите поврзани податоци. Дали сте сигурни дека сакате да продолжите?';
+  String get deleteAccountFinal => 'Оваа акција е неревидна и трајно ќе го избрише вашиот профил и сите поврзани податоци. Дали сте сигурни дека сакате да продолжите?';
 
   @override
   String get deleteNow => 'Избриши сега';
@@ -379,8 +371,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get goBack => 'Назад';
 
   @override
-  String get checkBoxToConfirm =>
-      'Означете го полето за да потврдите дека разбирате дека бришењето на вашиот профил е трајно и неревидно.';
+  String get checkBoxToConfirm => 'Означете го полето за да потврдите дека разбирате дека бришењето на вашиот профил е трајно и неревидно.';
 
   @override
   String get profile => 'Профил';
@@ -458,8 +449,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get yourPrivacyYourControl => 'Вашата приватност, вашата контрола';
 
   @override
-  String get privacyIntro =>
-      'На Omi, сме посветени на заштита на вашата приватност. Оваа страница вам овозможува контрола како ваши податоци се складираат и користат.';
+  String get privacyIntro => 'На Omi, сме посветени на заштита на вашата приватност. Оваа страница вам овозможува контрола како ваши податоци се складираат и користат.';
 
   @override
   String get learnMore => 'Научи повеќе...';
@@ -468,15 +458,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get dataProtectionLevel => 'Ниво на заштита на податоци';
 
   @override
-  String get dataProtectionDesc =>
-      'Вашите податоци се безбедни по стандард со силна енкрипција. Преглед ваши поставки и идните опции за приватност подолу.';
+  String get dataProtectionDesc => 'Вашите податоци се безбедни по стандард со силна енкрипција. Преглед ваши поставки и идните опции за приватност подолу.';
 
   @override
   String get appAccess => 'Пристап на апликација';
 
   @override
-  String get appAccessDesc =>
-      'Следниве апликации можат да пристапат до ваши податоци. Допрете апликација за управување нејзините дозволи.';
+  String get appAccessDesc => 'Следниве апликации можат да пристапат до ваши податоци. Допрете апликација за управување нејзините дозволи.';
 
   @override
   String get noAppsExternalAccess => 'Нема инсталирани апликации со надворешен пристап до ваши податоци.';
@@ -533,15 +521,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Вашиот Omi е исклучен 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Уредот е раскачен. Одите на Поставки > Bluetooth и заборавете го уредот за завршување раскачување.';
+  String get deviceUnpairedMessage => 'Уредот е раскачен. Одите на Поставки > Bluetooth и заборавете го уредот за завршување раскачување.';
 
   @override
   String get unpairDialogTitle => 'Раскачи уред';
 
   @override
-  String get unpairDialogMessage =>
-      'Ово ќе го раскачи уредот така што може да се поврзи со друг телефон. Ќе мора да одите на Поставки > Bluetooth и да го заборавите уредот за завршување на процесот.';
+  String get unpairDialogMessage => 'Ово ќе го раскачи уредот така што може да се поврзи со друг телефон. Ќе мора да одите на Поставки > Bluetooth и да го заборавите уредот за завршување на процесот.';
 
   @override
   String get deviceNotConnected => 'Уредот не е поврзан';
@@ -562,8 +548,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get v2Undetected => 'V2 не е детектирано';
 
   @override
-  String get v2UndetectedMessage =>
-      'Видиме дека имате V1 уред или вашиот уред не е поврзан. Функционалност на SD картичка е достапна само за V2 уреди.';
+  String get v2UndetectedMessage => 'Видиме дека имате V1 уред или вашиот уред не е поврзан. Функционалност на SD картичка е достапна само за V2 уреди.';
 
   @override
   String get endConversation => 'Крај разговор';
@@ -837,8 +822,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Избриши граф на знаење?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Ово ќе избрише сави извлечени податоци на граф на знаење (чворови и врски). Ваши оригинални спомени ќе останат безбедни. Графот ќе биде обновен со текот на времето или при следното барање.';
+  String get deleteKnowledgeGraphMessage => 'Ово ќе избрише сави извлечени податоци на граф на знаење (чворови и врски). Ваши оригинални спомени ќе останат безбедни. Графот ќе биде обновен со текот на времето или при следното барање.';
 
   @override
   String get knowledgeGraphDeleted => 'Граф на знаење е избришан';
@@ -986,8 +970,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get shortConversationThreshold => 'Праг на кратък разговор';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Разговори пократки од ова ќе бидат скриени освен ако е овозможено горе';
+  String get shortConversationThresholdSubtitle => 'Разговори пократки од ова ќе бидат скриени освен ако е овозможено горе';
 
   @override
   String get durationThreshold => 'Праг на траење';
@@ -1022,8 +1005,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get integrationsFooter => 'Поврзи ги ваши апликации за преглед на податоци и метрики во разговор.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Завршите аутентификација во вашиот претседател. Откако ќе завршите, вратете се во апликацијата.';
+  String get completeAuthInBrowser => 'Завршите аутентификација во вашиот претседател. Откако ќе завршите, вратете се во апликацијата.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1083,8 +1065,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get needYourPermission => 'Ви треба вашата дозвола';
 
   @override
-  String get alreadyGavePermission =>
-      'Веќе ни дадовте дозвола да ги зачувуваме ваши записи. Еве напомена зошто ни треба:';
+  String get alreadyGavePermission => 'Веќе ни дадовте дозвола да ги зачувуваме ваши записи. Еве напомена зошто ни треба:';
 
   @override
   String get wouldLikePermission => 'Би ја сакале вашата дозвола да ги зачувуваме ваши гласни записи. Еве зошто:';
@@ -1093,26 +1074,22 @@ class AppLocalizationsMk extends AppLocalizations {
   String get improveSpeechProfile => 'Подобри ја твојата токолна личност';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Ги користиме записите за понатамошно обука и подобрување на твојот личен профил на глас.';
+  String get improveSpeechProfileDesc => 'Ги користиме записите за понатамошно обука и подобрување на твојот личен профил на глас.';
 
   @override
   String get trainFamilyProfiles => 'Обучи профили за пријатели и семејство';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Ваши записи ни помагаат да препознаеме и направиме профили за вашите пријатели и семејство.';
+  String get trainFamilyProfilesDesc => 'Ваши записи ни помагаат да препознаеме и направиме профили за вашите пријатели и семејство.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Подобри точност на транскрипт';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Како што нашиот модел се подобрува, можеме да обезбедиме подобри резултати на транскрипција за ваши записи.';
+  String get enhanceTranscriptAccuracyDesc => 'Како што нашиот модел се подобрува, можеме да обезбедиме подобри резултати на транскрипција за ваши записи.';
 
   @override
-  String get legalNotice =>
-      'Правна напомена: Законитоста на снимање и складирање на гласни податоци може да варира во зависност од вашата локација и начинот на кој ја користите оваа функција. Вашa е одговорност да обезбедите соответност со локалните закони и регулативи.';
+  String get legalNotice => 'Правна напомена: Законитоста на снимање и складирање на гласни податоци може да варира во зависност од вашата локација и начинот на кој ја користите оваа функција. Вашa е одговорност да обезбедите соответност со локалните закони и регулативи.';
 
   @override
   String get alreadyAuthorized => 'Веќе авторизирано';
@@ -1184,8 +1161,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get showMeetingsMenuBar => 'Прикажи предстојни состаноци во мени лента';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Прикажете го вашиот следниот состанок и време до почеток во macOS мени лентата';
+  String get showMeetingsMenuBarDesc => 'Прикажете го вашиот следниот состанок и време до почеток во macOS мени лентата';
 
   @override
   String get showEventsNoParticipants => 'Прикажи настани без учесници';
@@ -1232,8 +1208,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get noProjectsInWorkspace => 'Нема пронајдени проекти во оваа работна област';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Изберете колку долго да чекате во тишина пред автоматско завршување на разговор:';
+  String get conversationTimeoutDesc => 'Изберете колку долго да чекате во тишина пред автоматско завршување на разговор:';
 
   @override
   String get timeout2Minutes => '2 минути';
@@ -1277,8 +1252,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Кажете ни го вашиот основен јазик';
 
   @override
-  String get languageForTranscription =>
-      'Поставете го вашиот јазик за поостри транскрипции и персонализирано искуство.';
+  String get languageForTranscription => 'Поставете го вашиот јазик за поостри транскрипции и персонализирано искуство.';
 
   @override
   String get singleLanguageModeInfo => 'Режимот на еден јазик е активиран. Преводот е онемогучен за поголема точност.';
@@ -1361,8 +1335,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get defaultRepository => 'Стандардно складиште';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Изберете стандардно складиште за создавање на проблеми. Сепак можете да назначите различно складиште при создавање на проблеми.';
+  String get selectDefaultRepoDesc => 'Изберете стандардно складиште за создавање на проблеми. Сепак можете да назначите различно складиште при создавање на проблеми.';
 
   @override
   String get noReposFound => 'Нема пронајдени складишта';
@@ -1409,8 +1382,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get configureSettings => 'Конфигурирај поставки';
 
   @override
-  String get completeAuthBrowser =>
-      'Ве молиме завршете аутентификација во вашиот прелистувач. По завршувањето, вратете се во апликацијата.';
+  String get completeAuthBrowser => 'Ве молиме завршете аутентификација во вашиот прелистувач. По завршувањето, вратете се во апликацијата.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1738,8 +1710,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get enableBluetooth => 'Активирај Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi има потреба од Bluetooth за поврзување на вашето нослива опрема. Ве молиме активирајте Bluetooth и пробајте повторно.';
+  String get bluetoothNeeded => 'Omi има потреба од Bluetooth за поврзување на вашето нослива опрема. Ве молиме активирајте Bluetooth и пробајте повторно.';
 
   @override
   String get contactSupport => 'Контактирај поддршка?';
@@ -1772,26 +1743,22 @@ class AppLocalizationsMk extends AppLocalizations {
   String get locationServiceDisabled => 'Услугата за локација е деактивирана';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Услугата за локација е деактивирана. Ве молиме одите на Поставки > Приватност и безбедност > Услуги за локација и активирајте ја';
+  String get locationServiceDisabledDesc => 'Услугата за локација е деактивирана. Ве молиме одите на Поставки > Приватност и безбедност > Услуги за локација и активирајте ја';
 
   @override
   String get backgroundLocationDenied => 'Пристап на локација во позадина одбиен';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Ве молиме одите на поставки на уредот и поставете дозвола за локација на \"Секогаш дозволи\"';
+  String get backgroundLocationDeniedDesc => 'Ве молиме одите на поставки на уредот и поставете дозвола за локација на \"Секогаш дозволи\"';
 
   @override
   String get lovingOmi => 'Вам се допаѓа Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Помогнете ни да дојдеме до повеќе луѓе со оставување рецензија во App Store. Вашата повратна информација ни значи многу!';
+  String get leaveReviewIos => 'Помогнете ни да дојдеме до повеќе луѓе со оставување рецензија во App Store. Вашата повратна информација ни значи многу!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Помогнете ни да дојдеме до повеќе луѓе со оставување рецензија во Google Play Store. Вашата повратна информација ни значи многу!';
+  String get leaveReviewAndroid => 'Помогнете ни да дојдеме до повеќе луѓе со оставување рецензија во Google Play Store. Вашата повратна информација ни значи многу!';
 
   @override
   String get rateOnAppStore => 'Оценете во App Store';
@@ -1803,8 +1770,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get maybeLater => 'Можеби подоцна';
 
   @override
-  String get speechProfileIntro =>
-      'Omi има потреба да научи ваши цели и вашиот глас. Ќе можете да го менувате подоцна.';
+  String get speechProfileIntro => 'Omi има потреба да научи ваши цели и вашиот глас. Ќе можете да го менувате подоцна.';
 
   @override
   String get getStarted => 'Почни';
@@ -1825,15 +1791,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get connectionError => 'Грешка при поврзување';
 
   @override
-  String get connectionErrorDesc =>
-      'Не успеав да се поврзам на серверот. Ве молиме проверете ја вашата интернет врска и пробајте повторно.';
+  String get connectionErrorDesc => 'Не успеав да се поврзам на серверот. Ве молиме проверете ја вашата интернет врска и пробајте повторно.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Пронајдена невалидна снимка';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Изгледа дека има повеќе звучници во снимката. Ве молиме осигурајте се дека сте на тивуа локација и пробајте повторно.';
+  String get multipleSpeakersDesc => 'Изгледа дека има повеќе звучници во снимката. Ве молиме осигурајте се дека сте на тивуа локација и пробајте повторно.';
 
   @override
   String get tooShortDesc => 'Нема доволно откриен говор. Ве молиме говорете повеќе и пробајте повторно.';
@@ -1845,15 +1809,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get areYouThere => 'Дали сте тука?';
 
   @override
-  String get noSpeechDesc =>
-      'Не можевме да откријеме никакво говор. Ве молиме осигурајте се да говорите барем 10 секунди и не повеќе од 3 минути.';
+  String get noSpeechDesc => 'Не можевме да откријеме никакво говор. Ве молиме осигурајте се да говорите барем 10 секунди и не повеќе од 3 минути.';
 
   @override
   String get connectionLost => 'Врската е прекината';
 
   @override
-  String get connectionLostDesc =>
-      'Врската беше прекината. Ве молиме проверете ја вашата интернет врска и пробајте повторно.';
+  String get connectionLostDesc => 'Врската беше прекината. Ве молиме проверете ја вашата интернет врска и пробајте повторно.';
 
   @override
   String get tryAgain => 'Пробај повторно';
@@ -1868,8 +1830,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get permissionsRequired => 'Потребни се дозволи';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Оваа апликација има потреба од Bluetooth и дозволи за локација за да функционира правилно. Ве молиме активирајте ги во поставките.';
+  String get permissionsRequiredDesc => 'Оваа апликација има потреба од Bluetooth и дозволи за локација за да функционира правилно. Ве молиме активирајте ги во поставките.';
 
   @override
   String get openSettings => 'Отворете поставки';
@@ -1899,8 +1860,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Ваш AI сопатник';
 
   @override
-  String get captureEveryMoment =>
-      'Фатете секој момент. Добијте AI-напаљени\nрезимеа. Никогаш нема да пишувате белешки повторно.';
+  String get captureEveryMoment => 'Фатете секој момент. Добијте AI-напаљени\nрезимеа. Никогаш нема да пишувате белешки повторно.';
 
   @override
   String get appleWatchSetup => 'Подесување на Apple Watch';
@@ -1912,12 +1872,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get microphonePermission => 'Дозвола за микрофон';
 
   @override
-  String get permissionGrantedNow =>
-      'Дозволата е дозволена! Сега:\n\nОтворете ја апликацијата Omi на вашиот часовник и притиснете \"Продолжи\" подолу';
+  String get permissionGrantedNow => 'Дозволата е дозволена! Сега:\n\nОтворете ја апликацијата Omi на вашиот часовник и притиснете \"Продолжи\" подолу';
 
   @override
-  String get needMicrophonePermission =>
-      'Ни треба дозвола за микрофон.\n\n1. Притиснете \"Одобри дозвола\"\n2. Дозволете на вашиот iPhone\n3. Апликацијата на часовникот ќе се затвори\n4. Отворете ја повторно и притиснете \"Продолжи\"';
+  String get needMicrophonePermission => 'Ни треба дозвола за микрофон.\n\n1. Притиснете \"Одобри дозвола\"\n2. Дозволете на вашиот iPhone\n3. Апликацијата на часовникот ќе се затвори\n4. Отворете ја повторно и притиснете \"Продолжи\"';
 
   @override
   String get grantPermissionButton => 'Одобри дозвола';
@@ -1926,15 +1884,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get needHelp => 'Ви треба помош?';
 
   @override
-  String get troubleshootingSteps =>
-      'Отстранување на проблеми:\n\n1. Осигурајте се дека Omi е инсталирана на вашиот часовник\n2. Отворете ја апликацијата Omi на вашиот часовник\n3. Барајте го popup за дозвола\n4. Притиснете \"Дозволи\" кога ќе се барате\n5. Апликацијата на вашиот часовник ќе се затвори - отворете ја повторно\n6. Вратете се и притиснете \"Продолжи\" на вашиот iPhone';
+  String get troubleshootingSteps => 'Отстранување на проблеми:\n\n1. Осигурајте се дека Omi е инсталирана на вашиот часовник\n2. Отворете ја апликацијата Omi на вашиот часовник\n3. Барајте го popup за дозвола\n4. Притиснете \"Дозволи\" кога ќе се барате\n5. Апликацијата на вашиот часовник ќе се затвори - отворете ја повторно\n6. Вратете се и притиснете \"Продолжи\" на вашиот iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Снимката е успешно започната!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Дозволата сеуште не е дозволена. Ве молиме осигурајте се дека сте дозволиле пристап на микрофон и отворивте ја апликацијата на вашиот часовник.';
+  String get permissionNotGrantedYet => 'Дозволата сеуште не е дозволена. Ве молиме осигурајте се дека сте дозволиле пристап на микрофон и отворивте ја апликацијата на вашиот часовник.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2031,8 +1987,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Готови за работни предмети';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Вашиот AI автоматски ќе извлекува задачи и за да направам од вашите разговори. Тие ќе се појават овде кога ќе бидат создадени.';
+  String get welcomeActionItemsDescription => 'Вашиот AI автоматски ќе извлекува задачи и за да направам од вашите разговори. Тие ќе се појават овде кога ќе бидат создадени.';
 
   @override
   String get autoExtractionFeature => 'Автоматски извлечено од разговори';
@@ -2082,8 +2037,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get clearMemoryTitle => 'Исчисти ја меморијата на Omi';
 
   @override
-  String get clearMemoryMessage =>
-      'Дали сте сигурни дека сакате да ја исчистите меморијата на Omi? Оваа акција не може да биде намалена.';
+  String get clearMemoryMessage => 'Дали сте сигурни дека сакате да ја исчистите меморијата на Omi? Оваа акција не може да биде намалена.';
 
   @override
   String get clearMemoryButton => 'Исчисти меморија';
@@ -2229,15 +2183,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'ГОВОР И ТРАНСКРИПЦИЈА';
 
   @override
-  String get languageSettingsHelperText =>
-      'Јазикот на апликацијата менува менија и копчиња. Јазикот на говор влијае на тоа како ваши записи се транскрибираат.';
+  String get languageSettingsHelperText => 'Јазикот на апликацијата менува менија и копчиња. Јазикот на говор влијае на тоа како ваши записи се транскрибираат.';
 
   @override
   String get translationNotice => 'Известување за превод';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi преводи разговори на вашиот основен јазик. Ажурирајте го во било кое време во Поставки → Профили.';
+  String get translationNoticeMessage => 'Omi преводи разговори на вашиот основен јазик. Ажурирајте го во било кое време во Поставки → Профили.';
 
   @override
   String get pleaseCheckInternetConnection => 'Ве молиме проверете ја вашата интернет врска и пробајте повторно';
@@ -2399,8 +2351,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Отвори паирање на уред';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Ова ќе го отвори паирањето на уредот така што може да се поврзе на телефон. Ќе мораш да отидеш на Поставки > Bluetooth и да го заборавиш уредот за да го завршиш процесот.';
+  String get unpairDeviceDialogMessage => 'Ова ќе го отвори паирањето на уредот така што може да се поврзе на телефон. Ќе мораш да отидеш на Поставки > Bluetooth и да го заборавиш уредот за да го завршиш процесот.';
 
   @override
   String get unpair => 'Отвори паирање';
@@ -2566,8 +2517,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get howDoesItWork => 'Како функционира?';
 
   @override
-  String get sdCardSyncDescription =>
-      'SD картата за синхронизација ќе ги увезе твои мемории од SD картата во апликацијата';
+  String get sdCardSyncDescription => 'SD картата за синхронизација ќе ги увезе твои мемории од SD картата во апликацијата';
 
   @override
   String get checksForAudioFiles => 'Проверува за аудио датотеки на SD картата';
@@ -2582,8 +2532,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get youreAllSet => 'Сте целосно подготвени!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Добредојде на Omi! Твојот AI придружник е подготвен да ти помогне со разговори, задачи и повеќе.';
+  String get welcomeToOmiDescription => 'Добредојде на Omi! Твојот AI придружник е подготвен да ти помогне со разговори, задачи и повеќе.';
 
   @override
   String get startUsingOmi => 'Почни да користиш Omi';
@@ -2719,8 +2668,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get noTasksYet => 'Нема задачи сè уште';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Задачи од твои разговори ќе се појават тука.\nКликни Создај за да додаш една рачно.';
+  String get tasksFromConversationsWillAppear => 'Задачи од твои разговори ќе се појават тука.\nКликни Создај за да додаш една рачно.';
 
   @override
   String get monthJan => 'јан';
@@ -2777,8 +2725,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deleteActionItem => 'Избриши активен предмет';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Дали си сигурен дека сакаш да го избришеш овој активен предмет? Оваа акција не може да се отповика.';
+  String get deleteActionItemConfirmation => 'Дали си сигурен дека сакаш да го избришеш овој активен предмет? Оваа акција не може да се отповика.';
 
   @override
   String get enterActionItemDescription => 'Внеси опис на активниот предмет...';
@@ -2853,8 +2800,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get chatPrompt => 'Упатствување за разговор';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ти си одлична апликација, твоја работа е да одговориш на прашањата на корисникот и да го направиш среќен...';
+  String get chatPromptPlaceholder => 'Ти си одлична апликација, твоја работа е да одговориш на прашањата на корисникот и да го направиш среќен...';
 
   @override
   String get conversationPrompt => 'Упатствување за разговор';
@@ -2872,8 +2818,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get makeMyAppPublic => 'Направи моја апликација јавна';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Со поднесување на оваа апликација, се согласувам со Omi AI услови за услуга и политика за приватност';
+  String get submitAppTermsAgreement => 'Со поднесување на оваа апликација, се согласувам со Omi AI услови за услуга и политика за приватност';
 
   @override
   String get submitApp => 'Поднеси апликација';
@@ -2888,12 +2833,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get submitAppQuestion => 'Поднеси апликација?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Твоја апликација ќе биде прегледана и направена јавна. Можеш да почнеш да ја користиш веднаш, дури и за време на преглед!';
+  String get submitAppPublicDescription => 'Твоја апликација ќе биде прегледана и направена јавна. Можеш да почнеш да ја користиш веднаш, дури и за време на преглед!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Твоја апликација ќе биде прегледана и направена достапна за тебе приватно. Можеш да почнеш да ја користиш веднаш, дури и за време на преглед!';
+  String get submitAppPrivateDescription => 'Твоја апликација ќе биде прегледана и направена достапна за тебе приватно. Можеш да почнеш да ја користиш веднаш, дури и за време на преглед!';
 
   @override
   String get startEarning => 'Почни да заработуваш! 💰';
@@ -2917,23 +2860,19 @@ class AppLocalizationsMk extends AppLocalizations {
   String get dataAccessNotice => 'Известување за пристап до податоци';
 
   @override
-  String get dataAccessWarning =>
-      'Оваа апликација ќе има пристап до твои податоци. Omi AI не е одговорна за начинот на кој твои податоци се користат, менуваат или бришат од оваа апликација';
+  String get dataAccessWarning => 'Оваа апликација ќе има пристап до твои податоци. Omi AI не е одговорна за начинот на кој твои податоци се користат, менуваат или бришат од оваа апликација';
 
   @override
   String get installApp => 'Инсталирај апликација';
 
   @override
-  String get betaTesterNotice =>
-      'Ти си бета тестер за оваа апликација. Сè уште не е јавна. Ќе биде јавна откако ќе биде одобрена.';
+  String get betaTesterNotice => 'Ти си бета тестер за оваа апликација. Сè уште не е јавна. Ќе биде јавна откако ќе биде одобрена.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Твоја апликација е под преглед и видлива само за тебе. Ќе биде јавна откако ќе биде одобрена.';
+  String get appUnderReviewOwner => 'Твоја апликација е под преглед и видлива само за тебе. Ќе биде јавна откако ќе биде одобрена.';
 
   @override
-  String get appRejectedNotice =>
-      'Твоја апликација е одбиена. Молиме ажурирај ги деталите на апликацијата и повторно поднеси за преглед.';
+  String get appRejectedNotice => 'Твоја апликација е одбиена. Молиме ажурирај ги деталите на апликацијата и повторно поднеси за преглед.';
 
   @override
   String get setupSteps => 'Чекори на подготовка';
@@ -2995,8 +2934,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get descriptionLabel => 'Опис';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Моја одлична апликација е одлична апликација која прави невероватни работи. Таа е најдобрата апликација кога икогаш!';
+  String get appDescriptionPlaceholder => 'Моја одлична апликација е одлична апликација која прави невероватни работи. Таа е најдобрата апликација кога икогаш!';
 
   @override
   String get pleaseProvideValidDescription => 'Молиме обезбеди важечки опис';
@@ -3133,8 +3071,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get clearChatTitle => 'Обриши разговор?';
 
   @override
-  String get confirmClearChat =>
-      'Дали си сигурен дека сакаш да го обришеш разговорот? Оваа акција не може да се отповика.';
+  String get confirmClearChat => 'Дали си сигурен дека сакаш да го обришеш разговорот? Оваа акција не може да се отповика.';
 
   @override
   String get copy => 'Копирај';
@@ -3149,8 +3086,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get microphonePermissionRequired => 'Дозвола за микрофон е потребна за да прави повици';
 
   @override
-  String get microphonePermissionDenied =>
-      'Дозвола за микрофон е одбиена. Молиме додели дозвола во Системски поставки > Приватност и безбедност > Микрофон.';
+  String get microphonePermissionDenied => 'Дозвола за микрофон е одбиена. Молиме додели дозвола во Системски поставки > Приватност и безбедност > Микрофон.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3309,8 +3245,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get createMemory => 'Создај меморија';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Дали си сигурен дека сакаш да ја избришеш оваа меморија? Оваа акција не може да се отповика.';
+  String get deleteMemoryConfirmation => 'Дали си сигурен дека сакаш да ја избришеш оваа меморија? Оваа акција не може да се отповика.';
 
   @override
   String get makePrivate => 'Направи приватна';
@@ -3384,8 +3319,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get whatWeCollect => 'Што собираме';
 
   @override
-  String get dataCollectionMessage =>
-      'Со продолжување, вашите разговори, записи и лични информации ќе бидат безбедно складирани на нашите серверни места за да обезбедиме AI-моќни увиди и да ги омозниме сите функции на апликацијата.';
+  String get dataCollectionMessage => 'Со продолжување, вашите разговори, записи и лични информации ќе бидат безбедно складирани на нашите серверни места за да обезбедиме AI-моќни увиди и да ги омозниме сите функции на апликацијата.';
 
   @override
   String get dataProtection => 'Заштита на податоци';
@@ -3400,8 +3334,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get chooseYourLanguage => 'Одберете го вашиот јазик';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'Одберете го вашиот претпочитан јазик за најдобро Omi искуство';
+  String get selectPreferredLanguageForBestExperience => 'Одберете го вашиот претпочитан јазик за најдобро Omi искуство';
 
   @override
   String get searchLanguages => 'Пребарувај јазици...';
@@ -3419,8 +3352,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Името мора да има барем 2 знака';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Кажи ни како би сакал/сакала да бидеш титулиран/титулирана. Ово помага да го персонализираме твоето Omi искуство.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Кажи ни како би сакал/сакала да бидеш титулиран/титулирана. Ово помага да го персонализираме твоето Omi искуство.';
 
   @override
   String charactersCount(int count) {
@@ -3437,8 +3369,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get recordAudioConversations => 'Запиши аудио разговори';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi треба приступ на микрофон за да запише твои разговори и да обезбеди транскрипции.';
+  String get microphoneAccessDescription => 'Omi треба приступ на микрофон за да запише твои разговори и да обезбеди транскрипции.';
 
   @override
   String get screenRecording => 'Снимање на екран';
@@ -3447,8 +3378,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Прилози системски аудио од состаноци';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi треба дозвола за снимање на екран за да прилози системски аудио од твои состаноци преку веб-прелистувач.';
+  String get screenRecordingDescription => 'Omi треба дозвола за снимање на екран за да прилози системски аудио од твои состаноци преку веб-прелистувач.';
 
   @override
   String get accessibility => 'Приступачност';
@@ -3457,8 +3387,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Откри состаноци врз основа на прелистувач';
 
   @override
-  String get accessibilityDescription =>
-      'Omi треба дозвола за приступачност за да откри кога се приклучиш на Zoom, Meet или Teams состаноци во твоја веб-прелистувач.';
+  String get accessibilityDescription => 'Omi треба дозвола за приступачност за да откри кога се приклучиш на Zoom, Meet или Teams состаноци во твоја веб-прелистувач.';
 
   @override
   String get pleaseWait => 'Молам, чекајте...';
@@ -3527,12 +3456,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get exportAllConversationsToJson => 'Експортирај ги сите твои разговори во JSON датотека.';
 
   @override
-  String get conversationsExportStarted =>
-      'Експортирање на разговори почнатокритично. Ово може да потрае неколку секунди, молам чекајте.';
+  String get conversationsExportStarted => 'Експортирање на разговори почнатокритично. Ово може да потрае неколку секунди, молам чекајте.';
 
   @override
-  String get mcpDescription =>
-      'За да поврзи Omi со други апликации за да читаш, пребарув и управуваш со твои спомени и разговори. Создај клуч за да почнеш.';
+  String get mcpDescription => 'За да поврзи Omi со други апликации за да читаш, пребарув и управуваш со твои спомени и разговори. Создај клуч за да почнеш.';
 
   @override
   String get apiKeys => 'API клучеви';
@@ -3603,8 +3530,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get auto => 'Автоматско';
 
   @override
-  String get noSummaryForApp =>
-      'Нема достапно резиме за оваа апликација. Пробај друга апликација за подобри резултати.';
+  String get noSummaryForApp => 'Нема достапно резиме за оваа апликација. Пробај друга апликација за подобри резултати.';
 
   @override
   String get tryAnotherApp => 'Пробај друга апликација';
@@ -3641,8 +3567,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Дозволи му на Omi да избере најдобра апликација автоматски';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Дали си сигурен/сигурна дека сакаш да го избришеш овој разговор? Ова дејство не може да се врати.';
+  String get deleteConversationConfirmation => 'Дали си сигурен/сигурна дека сакаш да го избришеш овој разговор? Ова дејство не може да се врати.';
 
   @override
   String get conversationDeleted => 'Разговор избришан';
@@ -3690,8 +3615,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Подготовка на прилог на системски аудио';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Кликни го копчето за да прилович аудио за жив транскрипт, AI увиди и автоматско зачувување.';
+  String get clickTheButtonToCaptureAudio => 'Кликни го копчето за да прилович аудио за жив транскрипт, AI увиди и автоматско зачувување.';
 
   @override
   String get reconnecting => 'Повторно поврзување...';
@@ -3849,8 +3773,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get dailySummaryTitle => 'Дневно резиме';
 
   @override
-  String get dailySummaryDescription =>
-      'Добиј персонализирано резиме на твојот дневен разговор доставено како известување.';
+  String get dailySummaryDescription => 'Добиј персонализирано резиме на твојот дневен разговор доставено како известување.';
 
   @override
   String get deliveryTime => 'Време на доставување';
@@ -3919,8 +3842,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Избриши граф на знаење?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Ово ќе избрише сви изведени податоци на граф на знаење. Твоите оригинални спомени остануваат безбедни.';
+  String get deleteKnowledgeGraphWarning => 'Ово ќе избрише сви изведени податоци на граф на знаење. Твоите оригинални спомени остануваат безбедни.';
 
   @override
   String get connectOmiWithAI => 'Поврзи Omi со AI асистенти';
@@ -3962,8 +3884,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Услови и политика на приватност';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Помага да се дијагностицираат проблеми. Автоматски се избришува по 3 дена.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Помага да се дијагностицираат проблеми. Автоматски се избришува по 3 дена.';
 
   @override
   String get manageYourApp => 'Управувај со твоја апликација';
@@ -3978,8 +3899,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get updateAppQuestion => 'Ажурирај апликација?';
 
   @override
-  String get updateAppConfirmation =>
-      'Дали си сигурен/сигурна дека сакаш да ја ажурираш твоја апликација? Промените ќе се рефлектираат кога ќе бидат одобрени од нашиот тим.';
+  String get updateAppConfirmation => 'Дали си сигурен/сигурна дека сакаш да ја ажурираш твоја апликација? Промените ќе се рефлектираат кога ќе бидат одобрени од нашиот тим.';
 
   @override
   String get updateApp => 'Ажурирај апликација';
@@ -4009,8 +3929,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get no => 'Не';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Претплатата успешно отказана. Тоа ќе остане активно до крајот на текуцата година за наплата.';
+  String get subscriptionCancelledSuccessfully => 'Претплатата успешно отказана. Тоа ќе остане активно до крајот на текуцата година за наплата.';
 
   @override
   String get failedToCancelSubscription => 'Неуспешно откажување на претплатата. Молам, пробајте повторно.';
@@ -4046,8 +3965,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Откажи претплата?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Дали си сигурен/сигурна дека сакаш да ја откажеш твоја претплата? Ќе имаш приступ до крајот на твојата теречна година за наплата.';
+  String get cancelSubscriptionConfirmation => 'Дали си сигурен/сигурна дека сакаш да ја откажеш твоја претплата? Ќе имаш приступ до крајот на твојата теречна година за наплата.';
 
   @override
   String get cancelSubscriptionButton => 'Откажи претплата';
@@ -4056,16 +3974,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get cancelling => 'Откажување...';
 
   @override
-  String get betaTesterMessage =>
-      'Ти си бета тестер за оваа апликација. Таа сеуште не е јавна. Ќе биде јавна кога ќе биде одобрена.';
+  String get betaTesterMessage => 'Ти си бета тестер за оваа апликација. Таа сеуште не е јавна. Ќе биде јавна кога ќе биде одобрена.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Твоја апликација е под преглед и видлива само за тебе. Ќе биде јавна кога ќе биде одобрена.';
+  String get appUnderReviewMessage => 'Твоја апликација е под преглед и видлива само за тебе. Ќе биде јавна кога ќе биде одобрена.';
 
   @override
-  String get appRejectedMessage =>
-      'Твоја апликација е отфрлена. Молам, ажурирај детали на апликацијата и повторно поднеси за преглед.';
+  String get appRejectedMessage => 'Твоја апликација е отфрлена. Молам, ажурирај детали на апликацијата и повторно поднеси за преглед.';
 
   @override
   String get invalidIntegrationUrl => 'Невалидна URL на интеграција';
@@ -4119,8 +4034,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get issueActivatingApp => 'Имаше проблем при активирање на оваа апликација. Молам, пробајте повторно.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Оваа апликација ќе пристапи твои податоци. Omi AI не е одговорна за тоа како твои податоци се користат, модифицираат или избришуваат од оваа апликација';
+  String get dataAccessNoticeDescription => 'Оваа апликација ќе пристапи твои податоци. Omi AI не е одговорна за тоа како твои податоци се користат, модифицираат или избришуваат од оваа апликација';
 
   @override
   String get copyUrl => 'Копирај URL';
@@ -4208,8 +4122,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get omiApiKeys => 'Omi API клучеви';
 
   @override
-  String get apiKeysDescription =>
-      'API клучевите се користат за аутентификација кога твоја апликација комуницира со OMI серверот. Тие овозможуваат твоја апликација да создава спомени и безбедно пристапува други OMI услуги.';
+  String get apiKeysDescription => 'API клучевите се користат за аутентификација кога твоја апликација комуницира со OMI серверот. Тие овозможуваат твоја апликација да создава спомени и безбедно пристапува други OMI услуги.';
 
   @override
   String get aboutOmiApiKeys => 'За Omi API клучеви';
@@ -4233,8 +4146,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Одозови API клуч?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Ово дејство не може да се врати. Сите апликации што го користат овој клуч нема да можат да пристапат API.';
+  String get revokeApiKeyWarning => 'Ово дејство не може да се врати. Сите апликации што го користат овој клуч нема да можат да пристапат API.';
 
   @override
   String get revoke => 'Одозови';
@@ -4323,8 +4235,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get keyCreated => 'Клуч создаден';
 
   @override
-  String get keyCreatedMessage =>
-      'Твој нов клуч е создаден. Молам, копирај го сега. Нема да можеш да го видиш повторно.';
+  String get keyCreatedMessage => 'Твој нов клуч е создаден. Молам, копирај го сега. Нема да можеш да го видиш повторно.';
 
   @override
   String get keyWord => 'Клуч';
@@ -4333,8 +4244,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get externalAppAccess => 'Приступ на надворешна апликација';
 
   @override
-  String get externalAppAccessDescription =>
-      'Следните инсталирани апликации имаат надворешни интеграции и можат да пристапат твои податоци, како што се разговори и спомени.';
+  String get externalAppAccessDescription => 'Следните инсталирани апликации имаат надворешни интеграции и можат да пристапат твои податоци, како што се разговори и спомени.';
 
   @override
   String get noExternalAppsHaveAccess => 'Нема надворешни апликации што имаат приступ твои податоци.';
@@ -4343,8 +4253,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get maximumSecurityE2ee => 'Максимална безбедност (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Криптирање крај-до-крај е голдениот стандард за приватност. Кога е овозможено, твои податоци се криптирани на твоето уредување пред да се испрати на нашите серверски места. Тоа значи нема никој, дури и Omi, може да пристапи твој содржај.';
+  String get e2eeDescription => 'Криптирање крај-до-крај е голдениот стандард за приватност. Кога е овозможено, твои податоци се криптирани на твоето уредување пред да се испрати на нашите серверски места. Тоа значи нема никој, дури и Omi, може да пристапи твој содржај.';
 
   @override
   String get importantTradeoffs => 'Важни трговски замени:';
@@ -4359,8 +4268,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get featureComingSoon => 'Оваа функција доаѓа наскоро!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Миграција во прогрес. Не можеш да го промениш нивото на заштита додека не завршиме.';
+  String get migrationInProgressMessage => 'Миграција во прогрес. Не можеш да го промениш нивото на заштита додека не завршиме.';
 
   @override
   String get migrationFailed => 'Миграција неуспешна';
@@ -4379,19 +4287,16 @@ class AppLocalizationsMk extends AppLocalizations {
   String get secureEncryption => 'Безбедна криптирање';
 
   @override
-  String get secureEncryptionDescription =>
-      'Твои податоци се криптирани со клуч единствен за тебе на нашите серверски места, хостирани на Google Cloud. Тоа значи твој суров содржај е недостапен за никој, вклучително Omi персонал или Google, директно од базата на податоци.';
+  String get secureEncryptionDescription => 'Твои податоци се криптирани со клуч единствен за тебе на нашите серверски места, хостирани на Google Cloud. Тоа значи твој суров содржај е недостапен за никој, вклучително Omi персонал или Google, директно од базата на податоци.';
 
   @override
   String get endToEndEncryption => 'Криптирање крај-до-крај';
 
   @override
-  String get e2eeCardDescription =>
-      'Овозможи за максимална безбедност каде само ти можеш пристапи твои податоци. Кликни за да научиш повеќе.';
+  String get e2eeCardDescription => 'Овозможи за максимална безбедност каде само ти можеш пристапи твои податоци. Кликни за да научиш повеќе.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Независно од нивото, твои податоци се секогаш криптирани на мирување и во транзит.';
+  String get dataAlwaysEncrypted => 'Независно од нивото, твои податоци се секогаш криптирани на мирување и во транзит.';
 
   @override
   String get readOnlyScope => 'Само читање';
@@ -4456,12 +4361,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get trainingDataProgram => 'Програма за обучни податоци';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Добиј Omi неограничено бесплатно со допринесување твои податоци за обука на AI модели.';
+  String get getOmiUnlimitedFree => 'Добиј Omi неограничено бесплатно со допринесување твои податоци за обука на AI модели.';
 
   @override
-  String get trainingDataBullets =>
-      '• Твои податоци помагаат да го подобриме AI модели\n• Само неосетливи податоци се делат\n• Целосно транспарентен процес';
+  String get trainingDataBullets => '• Твои податоци помагаат да го подобриме AI модели\n• Само неосетливи податоци се делат\n• Целосно транспарентен процес';
 
   @override
   String get learnMoreAtOmiTraining => 'Научи повеќе на omi.me/training';
@@ -4473,8 +4376,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get submitRequest => 'Поднеси барање';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Благодарам! Твое барање е под преглед. Ќе те известиме кога ќе биде одобрено.';
+  String get thankYouRequestUnderReview => 'Благодарам! Твое барање е под преглед. Ќе те известиме кога ќе биде одобрено.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4512,8 +4414,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get monthlyPlanContinues => 'Вашиот тековен месечен план ќе продолжи до крајот на периодот на наплатување';
 
   @override
-  String get paymentMethodCharged =>
-      'Вашиот постоечки начин на плаќање ќе биде наплатен автоматски кога ќе заврши месечниот план';
+  String get paymentMethodCharged => 'Вашиот постоечки начин на плаќање ќе биде наплатен автоматски кога ќе заврши месечниот план';
 
   @override
   String get annualSubscriptionStarts => 'Вашата 12-месечна годишна претплата ќе почне автоматски по наплатата';
@@ -4623,8 +4524,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Вашата приватност е важна за нас';
 
   @override
-  String get privacyIntroText =>
-      'Во Omi, го земаме вашата приватност многу сериозно. Сакаме да бидеме транспарентни за податоците што ги собираме и како ги користиме за да го подобриме нашиот производ за вас. Ево што треба да знаете:';
+  String get privacyIntroText => 'Во Omi, го земаме вашата приватност многу сериозно. Сакаме да бидеме транспарентни за податоците што ги собираме и како ги користиме за да го подобриме нашиот производ за вас. Ево што треба да знаете:';
 
   @override
   String get whatWeTrack => 'Што го следиме';
@@ -4639,12 +4539,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get ourCommitment => 'Нашето обврзување';
 
   @override
-  String get commitmentText =>
-      'Посветени сме да ги користиме соберените податоци само за да го направиме Omi подобар производ за вас. Вашата приватност и доверба се од највисокo значење за нас.';
+  String get commitmentText => 'Посветени сме да ги користиме соберените податоци само за да го направиме Omi подобар производ за вас. Вашата приватност и доверба се од највисокo значење за нас.';
 
   @override
-  String get thankYouText =>
-      'Благодариме што сте вреден корисник на Omi. Ако имате прашања или забрзи, слободно нас контактирајте на team@basedhardware.com.';
+  String get thankYouText => 'Благодариме што сте вреден корисник на Omi. Ако имате прашања или забрзи, слободно нас контактирајте на team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Поставки за WiFi синхронизација';
@@ -4653,8 +4551,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get enterHotspotCredentials => 'Внесете ги врите за личната точка на вашиот телефон';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi синхронизација ја користи вашата телефон како личната точка. Најдете го називот на вашата личната точка и лозинката во Поставки > Лична точка.';
+  String get wifiSyncUsesHotspot => 'WiFi синхронизација ја користи вашата телефон како личната точка. Најдете го називот на вашата личната точка и лозинката во Поставки > Лична точка.';
 
   @override
   String get hotspotNameSsid => 'Назив на личната точка (SSID)';
@@ -4689,8 +4586,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Не успеа да се генерира резиме. Проверете дали имате разговори за тој ден.';
+  String get failedToGenerateSummaryCheckConversations => 'Не успеа да се генерира резиме. Проверете дали имате разговори за тој ден.';
 
   @override
   String get summaryNotFound => 'Резиме не е пронајдено';
@@ -4720,8 +4616,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Извозот почна. Ова може да потрае неколку секунди...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ова ќе го избрише целиот извлечен графички податок на знаење (чворови и врски). Вашите оригинални мемории ќе остану безбедни. Графикот ќе се преправи со текот на времето или по следната барање.';
+  String get knowledgeGraphDeleteDescription => 'Ова ќе го избрише целиот извлечен графички податок на знаење (чворови и врски). Вашите оригинални мемории ќе остану безбедни. Графикот ќе се преправи со текот на времето или по следната барање.';
 
   @override
   String get configureDailySummaryDigest => 'Конфигурирајте го вашиот дневен резиме на список на работи';
@@ -4791,8 +4686,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Избриши ги сите разговори од Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Ова ќе го трајно избрише сите разговори увезени од Limitless. Оваа акција не може да се отмене.';
+  String get deleteAllLimitlessWarning => 'Ова ќе го трајно избрише сите разговори увезени од Limitless. Оваа акција не може да се отмене.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4848,8 +4742,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get howItWorksTitle => 'Како функционира?';
 
   @override
-  String get howPeopleWorks =>
-      'Откако лицето ќе се создаде, можете да одите на разговор транскрипт и да им доделите одговарачки сегменти, на тој начин Omi ќе биде способен да го препознае и нивниот говор!';
+  String get howPeopleWorks => 'Откако лицето ќе се создаде, можете да одите на разговор транскрипт и да им доделите одговарачки сегменти, на тој начин Omi ќе биде способен да го препознае и нивниот говор!';
 
   @override
   String get tapToDelete => 'Отвори за да избришеш';
@@ -4875,8 +4768,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get privacyNotice => 'Обвест за приватност';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Снимките може да ја прифатат гласовите на други. Осигурајте се дека имате согласност од сите учесници пред да активирате.';
+  String get recordingsMayCaptureOthers => 'Снимките може да ја прифатат гласовите на други. Осигурајте се дека имате согласност од сите учесници пред да активирате.';
 
   @override
   String get enable => 'Активирај';
@@ -4888,8 +4780,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get on => 'Вклучено';
 
   @override
-  String get storeAudioDescription =>
-      'Задржи ги сите аудио снимки складирани локално на твој телефон. Кога е деактивирано, само неуспешните преноси се задржуваат за да заштедиш простор за складирање.';
+  String get storeAudioDescription => 'Задржи ги сите аудио снимки складирани локално на твој телефон. Кога е деактивирано, само неуспешните преноси се задржуваат за да заштедиш простор за складирање.';
 
   @override
   String get enableLocalStorage => 'Активирај локално складирање';
@@ -4907,12 +4798,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get storeAudioOnCloud => 'Складирај аудио на облак';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Вашите снимки во реално време ќе бидат складирани во приватно облачно складирање додека говорите.';
+  String get cloudStorageDialogMessage => 'Вашите снимки во реално време ќе бидат складирани во приватно облачно складирање додека говорите.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Складирајте ги вашите снимки во реално време во приватно облачно складирање додека говорите. Аудиото се прифаќа и зачувува безбедно во реално време.';
+  String get storeAudioCloudDescription => 'Складирајте ги вашите снимки во реално време во приватно облачно складирање додека говорите. Аудиото се прифаќа и зачувува безбедно во реално време.';
 
   @override
   String get downloadingFirmware => 'Преземање на фирмвер';
@@ -4921,8 +4810,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get installingFirmware => 'Инсталирање на фирмвер';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Не затворајте ја апликацијата или исклучувајте го уредот. Ова може да го оштети вашиот уред.';
+  String get firmwareUpdateWarning => 'Не затворајте ја апликацијата или исклучувајте го уредот. Ова може да го оштети вашиот уред.';
 
   @override
   String get firmwareUpdated => 'Фирмверот е ажуриран';
@@ -4966,8 +4854,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get payments => 'Плаќања';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Поврзи начин на плаќање подолу за да почнеш да добиваш исплати за твоите апликации.';
+  String get connectPaymentMethodInfo => 'Поврзи начин на плаќање подолу за да почнеш да добиваш исплати за твоите апликации.';
 
   @override
   String get selectedPaymentMethod => 'Избран начин на плаќање';
@@ -4994,15 +4881,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get monthlyPayouts => 'Месечни исплати';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Добивајте месечни плаќања директно на вашата сметка кога ќе достигнете \$10 зараб';
+  String get monthlyPayoutsDescription => 'Добивајте месечни плаќања директно на вашата сметка кога ќе достигнете \$10 зараб';
 
   @override
   String get secureAndReliable => 'Безбедно и поуздано';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe осигурува безбедни и навремени трансфери на вашите приходи од апликацијата';
+  String get stripeSecureDescription => 'Stripe осигурува безбедни и навремени трансфери на вашите приходи од апликацијата';
 
   @override
   String get selectYourCountry => 'Избери ја твоја земја';
@@ -5023,8 +4908,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get connectingYourStripeAccount => 'Поврзување на вашата Stripe сметка';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Ве молиме завршете го процесот на Stripe онбординг во вашиот прелистувач. Оваа страница ќе се ажурира автоматски откако ќе завршите.';
+  String get stripeOnboardingInstructions => 'Ве молиме завршете го процесот на Stripe онбординг во вашиот прелистувач. Оваа страница ќе се ажурира автоматски откако ќе завршите.';
 
   @override
   String get failedTryAgain => 'Неуспешно? Обидете се повторно';
@@ -5036,8 +4920,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get successfullyConnected => 'Успешно поврзан!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Вашата Stripe сметка е сега подготвена да прима плаќања. Можете да почнете да заработувате од продажба на вашата апликација веднаш.';
+  String get stripeReadyForPayments => 'Вашата Stripe сметка е сега подготвена да прима плаќања. Можете да почнете да заработувате од продажба на вашата апликација веднаш.';
 
   @override
   String get updateStripeDetails => 'Ажурирај детали на Stripe';
@@ -5055,8 +4938,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Ажурирајте ги детали на вашата PayPal сметка';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Поврзете ја вашата PayPal сметка за да почнете да примате плаќања за вашите апликации';
+  String get connectPayPalToReceivePayments => 'Поврзете ја вашата PayPal сметка за да почнете да примате плаќања за вашите апликации';
 
   @override
   String get paypalEmail => 'PayPal е-пошта';
@@ -5065,8 +4947,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me врска';
 
   @override
-  String get stripeRecommendation =>
-      'Ако Stripe е достапен во вашата земја, ја препорачуваме да ја користите за побрзи и полесни исплати.';
+  String get stripeRecommendation => 'Ако Stripe е достапен во вашата земја, ја препорачуваме да ја користите за побрзи и полесни исплати.';
 
   @override
   String get updatePayPalDetails => 'Ажурирај детали на PayPal';
@@ -5118,12 +4999,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Дополнителен примерок на говор отстранет';
 
   @override
-  String get consentDataMessage =>
-      'Со продолжување, вашите разговори, снимки и лични информации ќе бидат безбедно зачувани на нашите сервери. Вашите аудио снимки и транскрипти се обработуваат од AI услуги на трети страни (вклучувајќи Deepgram за транскрипција и OpenAI за анализа) за да ви обезбедат увиди базирани на AI и да ги овозможат сите функции на апликацијата.';
+  String get consentDataMessage => 'Со продолжување, вашите разговори, снимки и лични информации ќе бидат безбедно зачувани на нашите сервери. Вашите аудио снимки и транскрипти се обработуваат од AI услуги на трети страни (вклучувајќи Deepgram за транскрипција и OpenAI за анализа) за да ви обезбедат увиди базирани на AI и да ги овозможат сите функции на апликацијата.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Задачите од вашите разговори ќе се појават овде.\\nОтвори + за да создадеш една ручно.';
+  String get tasksEmptyStateMessage => 'Задачите од вашите разговори ќе се појават овде.\\nОтвори + за да создадеш една ручно.';
 
   @override
   String get clearChatAction => 'Очисти разговор';
@@ -5159,15 +5038,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Инсталирај Omi на вашиот\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'За да го користите вашиот Apple Watch со Omi, прво мораш да ја инсталираш апликацијата Omi на твој часовник.';
+  String get installOmiOnAppleWatchDescription => 'За да го користите вашиот Apple Watch со Omi, прво мораш да ја инсталираш апликацијата Omi на твој часовник.';
 
   @override
   String get openOmiOnAppleWatch => 'Отвори Omi на вашиот\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Апликацијата Omi е инсталирана на вашиот Apple Watch. Отвори ја и отвори го Start за да почнеш.';
+  String get openOmiOnAppleWatchDescription => 'Апликацијата Omi е инсталирана на вашиот Apple Watch. Отвори ја и отвори го Start за да почнеш.';
 
   @override
   String get openWatchApp => 'Отвори апликацијата на часовникот';
@@ -5176,15 +5053,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Ја инсталирав и отворив апликацијата';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Не можеше да се отвори апликацијата на Apple Watch. Ве молиме ручно отворете ја апликацијата на часовникот на вашиот Apple Watch и инсталирајте Omi од секцијата \"Достапни апликации\".';
+  String get unableToOpenWatchApp => 'Не можеше да се отвори апликацијата на Apple Watch. Ве молиме ручно отворете ја апликацијата на часовникот на вашиот Apple Watch и инсталирајте Omi од секцијата \"Достапни апликации\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch успешно поврзан!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch сè уште не е достапен. Ве молиме проверете дали апликацијата Omi е отворена на вашиот часовник.';
+  String get appleWatchNotReachable => 'Apple Watch сè уште не е достапен. Ве молиме проверете дали апликацијата Omi е отворена на вашиот часовник.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5201,8 +5076,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get finishedConversation => 'Завршена разговор?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Дали сигурно сакате да престанете да снимате и да го резимирате разговорот сега?';
+  String get stopRecordingConfirmation => 'Дали сигурно сакате да престанете да снимате и да го резимирате разговорот сега?';
 
   @override
   String get conversationEndsManually => 'Разговорот ќе завршип само ручно.';
@@ -5613,29 +5487,25 @@ class AppLocalizationsMk extends AppLocalizations {
   String get multipleSpeakersDetected => 'Обнаружени повеќе говорници';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Изгледа дека има повеќе говорници во снимката. Ве молиме проверете дали сте на тихо место и обидете се повторно.';
+  String get multipleSpeakersDescription => 'Изгледа дека има повеќе говорници во снимката. Ве молиме проверете дали сте на тихо место и обидете се повторно.';
 
   @override
   String get invalidRecordingDetected => 'Обнаружена невалидна снимка';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Нема доволно говор обнаружен. Ве молиме говорете повеќе и обидете се повторно.';
+  String get notEnoughSpeechDescription => 'Нема доволно говор обнаружен. Ве молиме говорете повеќе и обидете се повторно.';
 
   @override
   String get speechDurationDescription => 'Моля, обезбедете да зборувате најмалку 5 секунди и не повеќе од 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Врската беше прекината. Моля, проверете ја вашата интернет врска и обидете се повторно.';
+  String get connectionLostDescription => 'Врската беше прекината. Моля, проверете ја вашата интернет врска и обидете се повторно.';
 
   @override
   String get howToTakeGoodSample => 'Како да земе добар примерок?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Обезбедете дека сте на тихо место.\n2. Зборувајте јасно и природно.\n3. Обезбедете дека вашиот уред е во неговата природна позиција, на вашата врат.\n\nКога ќе биде создадено, можете да го подобрите или да го направите повторно.';
+  String get goodSampleInstructions => '1. Обезбедете дека сте на тихо место.\n2. Зборувајте јасно и природно.\n3. Обезбедете дека вашиот уред е во неговата природна позиција, на вашата врат.\n\nКога ќе биде создадено, можете да го подобрите или да го направите повторно.';
 
   @override
   String get noDeviceConnectedUseMic => 'Нема поврзан уред. Ќе се користи микрофон на телефон.';
@@ -5698,12 +5568,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get howItWorks => 'Како работи';
 
   @override
-  String get dailyScoreExplanation =>
-      'Вашиот дневен резултат е врз основа на завршување на задачи. Завршете ги вашите задачи за да го подобрите вашиот резултат!';
+  String get dailyScoreExplanation => 'Вашиот дневен резултат е врз основа на завршување на задачи. Завршете ги вашите задачи за да го подобрите вашиот резултат!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Контролирајте колку често Omi ви испраќа проактивни известувања и потсетници.';
+  String get notificationFrequencyDescription => 'Контролирајте колку често Omi ви испраќа проактивни известувања и потсетници.';
 
   @override
   String get sliderOff => 'Исклучено';
@@ -5796,8 +5664,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get selectApp => 'Избери апликација';
 
   @override
-  String get noChatAppsEnabled =>
-      'Нема активирани апликации за разговор.\nТапни \"Активирај апликации\" за да додаш некои.';
+  String get noChatAppsEnabled => 'Нема активирани апликации за разговор.\nТапни \"Активирај апликации\" за да додаш некои.';
 
   @override
   String get disable => 'Деактивирај';
@@ -5949,8 +5816,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get recordings => 'Записи';
 
   @override
-  String get enableRemindersAccess =>
-      'Моля, активирајте пристап до потсетници во подесувањата за да го користите Apple Reminders';
+  String get enableRemindersAccess => 'Моля, активирајте пристап до потсетници во подесувањата за да го користите Apple Reminders';
 
   @override
   String todayAtTime(String time) {
@@ -6005,8 +5871,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get webhookUrlNotSet => 'URL-ot за webhook не е поставен';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Моля, поставете го URL-от на webhook во подесувањата за програмери за да ја користите оваа функција.';
+  String get setWebhookUrlInSettings => 'Моля, поставете го URL-от на webhook во подесувањата за програмери за да ја користите оваа функција.';
 
   @override
   String get sendWebUrl => 'Пошали веб URL';
@@ -6080,15 +5945,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get cloudProvider => 'Облачен добавувач';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 премиум минути/месец. Картичката На-уред нуди неограничена бесплатна транскрипција.';
+  String get premiumMinutesInfo => '1.200 премиум минути/месец. Картичката На-уред нуди неограничена бесплатна транскрипција.';
 
   @override
   String get viewUsage => 'Преглед на користење';
 
   @override
-  String get localProcessingInfo =>
-      'Аудиото се обработува локално. Работи без интернет, поприватно, но користи повеќе батеријата.';
+  String get localProcessingInfo => 'Аудиото се обработува локално. Работи без интернет, поприватно, но користи повеќе батеријата.';
 
   @override
   String get model => 'Модел';
@@ -6097,15 +5960,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get performanceWarning => 'Предупредување за перформанси';
 
   @override
-  String get largeModelWarning =>
-      'Овој модел е голем и може да предизвика крај на апликацијата или многу спора работа на мобилни уреди.\n\n\"small\" или \"base\" е препорачано.';
+  String get largeModelWarning => 'Овој модел е голем и може да предизвика крај на апликацијата или многу спора работа на мобилни уреди.\n\n\"small\" или \"base\" е препорачано.';
 
   @override
   String get usingNativeIosSpeech => 'Користи нативно iOS препознавање на говор';
 
   @override
-  String get noModelDownloadRequired =>
-      'Ќе се користи нативната говор-машина на твојот уред. Нема потреба од преземање модел.';
+  String get noModelDownloadRequired => 'Ќе се користи нативната говор-машина на твојот уред. Нема потреба од преземање модел.';
 
   @override
   String get modelReady => 'Модел е подготвен';
@@ -6162,12 +6023,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get batteryDrainSignificantly => 'Потрошувачката на батеријата ќе се зголеми значајно.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 премиум минути/месец. Картичката На-уред нуди неограничена бесплатна транскрипција. ';
+  String get premiumMinutesMonth => '1.200 премиум минути/месец. Картичката На-уред нуди неограничена бесплатна транскрипција. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Аудиото се обработува локално. Работи без интернет, поприватно, но користи повеќе батеријата.';
+  String get audioProcessedLocally => 'Аудиото се обработува локално. Работи без интернет, поприватно, но користи повеќе батеријата.';
 
   @override
   String get languageLabel => 'Јазик';
@@ -6176,12 +6035,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get modelLabel => 'Модел';
 
   @override
-  String get modelTooLargeWarning =>
-      'Овој модел е голем и може да предизвика крај на апликацијата или многу спора работа на мобилни уреди.\n\n\"small\" или \"base\" е препорачано.';
+  String get modelTooLargeWarning => 'Овој модел е голем и може да предизвика крај на апликацијата или многу спора работа на мобилни уреди.\n\n\"small\" или \"base\" е препорачано.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Ќе се користи нативната машина за говор на твојот уред. Нема потреба од преземање модел.';
+  String get nativeEngineNoDownload => 'Ќе се користи нативната машина за говор на твојот уред. Нема потреба од преземање модел.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6217,8 +6074,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Вградената живо транскрипција на Omi е оптимизирана за разговори во реално време со автоматско препознавање и диаризирање на говорник.';
+  String get omiTranscriptionOptimized => 'Вградената живо транскрипција на Omi е оптимизирана за разговори во реално време со автоматско препознавање и диаризирање на говорник.';
 
   @override
   String get reset => 'Ресетирај';
@@ -6438,8 +6294,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Се гради твојата граф на знаење од сеќавања...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Твојата граф на знаење ќе се гради автоматски кога ќе создадаш нови сеќавања.';
+  String get knowledgeGraphWillBuildAutomatically => 'Твојата граф на знаење ќе се гради автоматски кога ќе создадаш нови сеќавања.';
 
   @override
   String get buildGraphButton => 'Направи граф';
@@ -6675,8 +6530,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get failedToLoadContacts => 'Не успеаше да се вчитаат контакти';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Не успеаше да се подготви разговор за делење. Молиме, обидете се повторно.';
+  String get failedToPrepareConversationForSharing => 'Не успеаше да се подготви разговор за делење. Молиме, обидете се повторно.';
 
   @override
   String get couldNotOpenSmsApp => 'Не можеше да се отвори SMS апликација. Молиме, обидете се повторно.';
@@ -6742,8 +6596,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Се преземa аудио од SD картичката на твојот уред';
 
   @override
-  String get transferRequiredDescription =>
-      'Овој запис е складиран на SD картичката на твојот уред. Пренеси го на твојот телефон за да можеш да го слушаш или делиш.';
+  String get transferRequiredDescription => 'Овој запис е складиран на SD картичката на твојот уред. Пренеси го на твојот телефон за да можеш да го слушаш или делиш.';
 
   @override
   String get cancelTransfer => 'Откажи пренос';
@@ -6764,8 +6617,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get shareRecording => 'Сподели Снимање';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Сигурни ли сте дека сакате трајно да го избришете ова снимање? Ова не може да се отповика.';
+  String get deleteRecordingConfirmation => 'Сигурни ли сте дека сакате трајно да го избришете ова снимање? Ова не може да се отповика.';
 
   @override
   String get recordingIdLabel => 'ID на Снимање';
@@ -6824,15 +6676,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get enableFastTransfer => 'Активирај Брз Трансфер';
 
   @override
-  String get fastTransferDescription =>
-      'Брз трансфер користи WiFi за ~5x побрзи брзини. Вашиот телефон привремено ќе се поврзе со WiFi мрежата на вашиот Omi уред durante трансферот.';
+  String get fastTransferDescription => 'Брз трансфер користи WiFi за ~5x побрзи брзини. Вашиот телефон привремено ќе се поврзе со WiFi мрежата на вашиот Omi уред durante трансферот.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Пристапот до интернет е паузиран durante трансферот';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Одберете како снимањата ќе се трансферуваат од вашиот Omi уред на вашиот телефон.';
+  String get chooseTransferMethodDescription => 'Одберете како снимањата ќе се трансферуваат од вашиот Omi уред на вашиот телефон.';
 
   @override
   String get wifiSpeed => '~150 KB/s преку WiFi';
@@ -6841,8 +6691,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get fiveTimesFaster => '5X ПОБРЗО';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Создава директна WiFi врска со вашиот Omi уред. Вашиот телефон привремено се откачува од вашата редовна WiFi durante трансферот.';
+  String get fastTransferMethodDescription => 'Создава директна WiFi врска со вашиот Omi уред. Вашиот телефон привремено се откачува од вашата редовна WiFi durante трансферот.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6851,8 +6700,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get bleSpeed => '~30 KB/s преку BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Користи стандардна Bluetooth Low Energy врска. Побавно, но не влијае на вашата WiFi врска.';
+  String get bluetoothMethodDescription => 'Користи стандардна Bluetooth Low Energy врска. Побавно, но не влијае на вашата WiFi врска.';
 
   @override
   String get selected => 'Избрано';
@@ -6870,8 +6718,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'Вашиот Omi Уред се Откачи';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'Ве молиме се поврзете повторно за да продолжите да го користите вашиот Omi.';
+  String get deviceDisconnectedNotificationBody => 'Ве молиме се поврзете повторно за да продолжите да го користите вашиот Omi.';
 
   @override
   String get firmwareUpdateAvailable => 'Достапна е Ажурирање на Firmware';
@@ -6891,12 +6738,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get appDeleteFailed => 'Неуспешно бришење на апликација. Ве молиме обидете се подоцна.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Видливоста на апликацијата е променена успешно. Може да потрае неколку минути да се рефлектира.';
+  String get appVisibilityChangedSuccessfully => 'Видливоста на апликацијата е променена успешно. Може да потрае неколку минути да се рефлектира.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Грешка при активирање на апликацијата. Ако е интеграциона апликација, осигурајте се дека постапката за подготовка е завршена.';
+  String get errorActivatingAppIntegration => 'Грешка при активирање на апликацијата. Ако е интеграциона апликација, осигурајте се дека постапката за подготовка е завршена.';
 
   @override
   String get errorUpdatingAppStatus => 'Дошло до грешка при ажурирање на статусот на апликацијата.';
@@ -6964,8 +6809,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get importantConversationTitle => 'Важен Разговор';
 
   @override
-  String get importantConversationBody =>
-      'Штотуку имавте важен разговор. Допрете за да го споделите резимеот со други.';
+  String get importantConversationBody => 'Штотуку имавте важен разговор. Допрете за да го споделите резимеот со други.';
 
   @override
   String get templateName => 'Име на Шаблон';
@@ -6977,8 +6821,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Името мора да содржи најмалку 3 карактери';
 
   @override
-  String get conversationPromptHint =>
-      'нпр., Извлеци акциони ставки, одлуки направени и клучни заклучоци од дадениот разговор.';
+  String get conversationPromptHint => 'нпр., Извлеци акциони ставки, одлуки направени и клучни заклучоци од дадениот разговор.';
 
   @override
   String get pleaseEnterAppPrompt => 'Ве молиме внесете промпт за вашата апликација';
@@ -7011,8 +6854,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get failedToCreateApp => 'Неуспешно создавање на апликација. Ве молиме обидете се повторно.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'Ве молиме одберете една повеќе основна способност за вашата апликација за да продолжите';
+  String get addAppSelectCoreCapability => 'Ве молиме одберете една повеќе основна способност за вашата апликација за да продолжите';
 
   @override
   String get addAppSelectPaymentPlan => 'Ве молиме одберете план за плаќање и внесете цена за вашата апликација';
@@ -7061,8 +6903,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'Дозвола за фотографии одбиена. Ве молиме дозволете пристап до фотографии за да одберете слика';
+  String get addAppPhotosPermissionDenied => 'Дозвола за фотографии одбиена. Ве молиме дозволете пристап до фотографии за да одберете слика';
 
   @override
   String get addAppErrorSelectingImageRetry => 'Грешка при избирање на слика. Ве молиме обидете се повторно.';
@@ -7085,8 +6926,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get paymentFailedToFetchCountries => 'Неуспешно преземање на поддржани держави. Ве молиме обидете се подоцна.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Неуспешна постава на стандарден метод за плаќање. Ве молиме обидете се подоцна.';
+  String get paymentFailedToSetDefault => 'Неуспешна постава на стандарден метод за плаќање. Ве молиме обидете се подоцна.';
 
   @override
   String get paymentFailedToSavePaypal => 'Неуспешно зачување на детали за PayPal. Ве молиме обидете се подоцна.';
@@ -7168,15 +7008,13 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Ажурирање закажано! Вашиот месечен план продолжува до крајот на вашиот билинг период, потоа автоматски се смена на годишен.';
+  String get planUpgradeScheduledMessage => 'Ажурирање закажано! Вашиот месечен план продолжува до крајот на вашиот билинг период, потоа автоматски се смена на годишен.';
 
   @override
   String get couldNotSchedulePlanChange => 'Не можеше да се закаже промена на план. Ве молиме обидете се повторно.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Вашата претплата е повторно активирана! Без наплата сега - ќе бидете наплатени на крајот на вашиот тековен период.';
+  String get subscriptionReactivatedDefault => 'Вашата претплата е повторно активирана! Без наплата сега - ќе бидете наплатени на крајот на вашиот тековен период.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Претплата успешна! Сте наплатени за новиот билинг период.';
@@ -7185,8 +7023,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get couldNotProcessSubscription => 'Не можеше да се обработи претплата. Ве молиме обидете се повторно.';
 
   @override
-  String get couldNotLaunchUpgradePage =>
-      'Не можеше да се лансира страница за ажурирање. Ве молиме обидете се повторно.';
+  String get couldNotLaunchUpgradePage => 'Не можеше да се лансира страница за ажурирање. Ве молиме обидете се повторно.';
 
   @override
   String get transcriptionJsonPlaceholder => 'Налепете вашата JSON конфигурација овде...';
@@ -7345,8 +7182,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Неуспешно преземање на firebase жетон, ве молиме обидете се повторно.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Неочекувана грешка при пријава, Firebase грешка, ве молиме обидете се повторно.';
+  String get authUnexpectedErrorFirebase => 'Неочекувана грешка при пријава, Firebase грешка, ве молиме обидете се повторно.';
 
   @override
   String get authUnexpectedError => 'Неочекувана грешка при пријава, ве молиме обидете се повторно';
@@ -7361,8 +7197,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Дозволата за Bluetooth е потребна за поврзување со вашиот уред.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Дозволата за Bluetooth е одбиена. Ве молиме дозволете дозвола во Системски Преференции.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Дозволата за Bluetooth е одбиена. Ве молиме дозволете дозвола во Системски Преференции.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7375,12 +7210,10 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Дозволата за Известување е одбиена. Ве молиме дозволете дозвола во Системски Преференции.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Дозволата за Известување е одбиена. Ве молиме дозволете дозвола во Системски Преференции.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Дозволата за Известување е одбиена. Ве молиме дозволете дозвола во Системски Преференции > Известувања.';
+  String get onboardingNotificationDeniedNotifications => 'Дозволата за Известување е одбиена. Ве молиме дозволете дозвола во Системски Преференции > Известувања.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7393,15 +7226,13 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Ве молиме дозволете дозвола за локација во Поставки > Приватност и Безбедност > Услуги на Локација';
+  String get onboardingLocationGrantInSettings => 'Ве молиме дозволете дозвола за локација во Поставки > Приватност и Безбедност > Услуги на Локација';
 
   @override
   String get onboardingMicrophoneRequired => 'Дозволата за Микрофон е потребна за снимање.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Дозволата за Микрофон е одбиена. Ве молиме дозволете дозвола во Системски Преференции > Приватност и Безбедност > Микрофон.';
+  String get onboardingMicrophoneDenied => 'Дозволата за Микрофон е одбиена. Ве молиме дозволете дозвола во Системски Преференции > Приватност и Безбедност > Микрофон.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7414,12 +7245,10 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Дозволата за Снимање на Екран е потребна за снимање на системски аудио.';
+  String get onboardingScreenCaptureRequired => 'Дозволата за Снимање на Екран е потребна за снимање на системски аудио.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Дозволата за Снимање на Екран е одбиена. Ве молиме дозволете дозвола во Системски Преференции > Приватност и Безбедност > Снимање на Екран.';
+  String get onboardingScreenCaptureDenied => 'Дозволата за Снимање на Екран е одбиена. Ве молиме дозволете дозвола во Системски Преференции > Приватност и Безбедност > Снимање на Екран.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7432,8 +7261,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Дозволата за Пристапност е потребна за детектирање на состаноци во прелистувачот.';
+  String get onboardingAccessibilityRequired => 'Дозволата за Пристапност е потребна за детектирање на состаноци во прелистувачот.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7473,8 +7301,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Дозволата за Фотографии е одбиена. Ве молиме дозволете пристап до фотографии за да одберете слики';
+  String get msgPhotosPermissionDenied => 'Дозволата за Фотографии е одбиена. Ве молиме дозволете пристап до фотографии за да одберете слики';
 
   @override
   String get msgSelectImagesGenericError => 'Грешка при избирање на слики. Ве молиме обидете се повторно.';
@@ -7546,8 +7373,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get locationPermissionRequired => 'Дозвола за Локација Потребна';
 
   @override
-  String get locationPermissionContent =>
-      'Брз трансфер бара дозвола за локација за потврда на WiFi врска. Ве молиме дозволете дозвола за локација за да продолжите.';
+  String get locationPermissionContent => 'Брз трансфер бара дозвола за локација за потврда на WiFi врска. Ве молиме дозволете дозвола за локација за да продолжите.';
 
   @override
   String get pdfTranscriptExport => 'Извоз на Транскрипт';
@@ -8006,8 +7832,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Стави го Omi DevKit во режим на спарување';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Притисни го копчето еднаш за вклучување. LED ќе блика виолетово кога е во режим на спарување.';
+  String get pairingDescOmiDevkit => 'Притисни го копчето еднаш за вклучување. LED ќе блика виолетово кога е во режим на спарување.';
 
   @override
   String get pairingTitleOmiGlass => 'Вклучи го Omi Glass';
@@ -8019,29 +7844,25 @@ class AppLocalizationsMk extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Стави го Plaud Note во режим на спарување';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Притисни и држи го страничното копче 2 секунди. Црвениот LED ќе блика кога е спремен за спарување.';
+  String get pairingDescPlaudNote => 'Притисни и држи го страничното копче 2 секунди. Црвениот LED ќе блика кога е спремен за спарување.';
 
   @override
   String get pairingTitleBee => 'Стави го Bee во режим на спарување';
 
   @override
-  String get pairingDescBee =>
-      'Притисни го копчето 5 пати последователно. Светлината ќе почне да блика синьо и зелено.';
+  String get pairingDescBee => 'Притисни го копчето 5 пати последователно. Светлината ќе почне да блика синьо и зелено.';
 
   @override
   String get pairingTitleLimitless => 'Стави го Limitless во режим на спарување';
 
   @override
-  String get pairingDescLimitless =>
-      'Кога е видлива каква било светлина, притисни еднаш и потоа притисни и држи додека уредот не покаже розова светлина, потоа пушти.';
+  String get pairingDescLimitless => 'Кога е видлива каква било светлина, притисни еднаш и потоа притисни и држи додека уредот не покаже розова светлина, потоа пушти.';
 
   @override
   String get pairingTitleFriendPendant => 'Стави го Friend Pendant во режим на спарување';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Притисни го копчето на привескот за да го вклучиш. Автоматски ќе влезе во режим на спарување.';
+  String get pairingDescFriendPendant => 'Притисни го копчето на привескот за да го вклучиш. Автоматски ќе влезе во режим на спарување.';
 
   @override
   String get pairingTitleFieldy => 'Стави го Fieldy во режим на спарување';
@@ -8053,15 +7874,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Поврзи го Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Инсталирај и отвори ја апликацијата Omi на твојот Apple Watch, потоа допри Поврзи во апликацијата.';
+  String get pairingDescAppleWatch => 'Инсталирај и отвори ја апликацијата Omi на твојот Apple Watch, потоа допри Поврзи во апликацијата.';
 
   @override
   String get pairingTitleNeoOne => 'Стави го Neo One во режим на спарување';
 
   @override
-  String get pairingDescNeoOne =>
-      'Притисни и држи го копчето за напајување додека LED не трепери. Уредот ќе биде достопен.';
+  String get pairingDescNeoOne => 'Притисни и држи го копчето за напајување додека LED не трепери. Уредот ќе биде достопен.';
 
   @override
   String get downloadingFromDevice => 'Преземање од уред';
@@ -8131,8 +7950,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get wifiConfiguration => 'WiFi конфигурација';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Внеси ги твоите WiFi верификации за да дозволиш уредот да ја преземе фирмверот.';
+  String get wifiConfigurationSubtitle => 'Внеси ги твоите WiFi верификации за да дозволиш уредот да ја преземе фирмверот.';
 
   @override
   String get networkNameSsid => 'Назив на мрежа (SSID)';
@@ -8179,8 +7997,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get switchAndRestart => 'Смени';
 
   @override
-  String get stagingDisclaimer =>
-      'Фаза на тестирање може да биде со грешки, нестабилна и податоците може да се изгубат. Користи само за тестирање.';
+  String get stagingDisclaimer => 'Фаза на тестирање може да биде со грешки, нестабилна и податоците може да се изгубат. Користи само за тестирање.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Сачувано. Затвори и повторно отвори ја апликацијата да применя.';
@@ -8409,8 +8226,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Телефонски разговори преку Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Направи повици преку Omi и добиј транскрипција во реално време, автоматски резимеја и многу повеќе. Достапно исклучиво за претплатници на Unlimited план.';
+  String get phoneCallsUpsellSubtitle => 'Направи повици преку Omi и добиј транскрипција во реално време, автоматски резимеја и многу повеќе. Достапно исклучиво за претплатници на Unlimited план.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Транскрипција во реално време на секој повик';
@@ -8437,8 +8253,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deleteSyncedFiles => 'Избриши синхронизирани записи';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Овие записи веќе се синхронизирани на твојот телефон. Ова не може да се откаже.';
+  String get deleteSyncedFilesMessage => 'Овие записи веќе се синхронизирани на твојот телефон. Ова не може да се откаже.';
 
   @override
   String get syncedFilesDeleted => 'Синхронизирани записи избришани';
@@ -8450,8 +8265,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deletePendingFiles => 'Избриши записи во очекување';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Овие записи НЕ се синхронизирани на твојот телефон и трајно ќе се изгубат. Ова не може да се откаже.';
+  String get deletePendingFilesWarning => 'Овие записи НЕ се синхронизирани на твојот телефон и трајно ќе се изгубат. Ова не може да се откаже.';
 
   @override
   String get pendingFilesDeleted => 'Записи во очекување избришани';
@@ -8463,8 +8277,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deleteAll => 'Избриши сите';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Ќе ги избришеш и синхронизираните и записите во очекување. Записите во очекување НЕ се синхронизирани и трајно ќе се изгубат. Ова не може да се откаже.';
+  String get deleteAllFilesWarning => 'Ќе ги избришеш и синхронизираните и записите во очекување. Записите во очекување НЕ се синхронизирани и трајно ќе се изгубат. Ова не може да се откаже.';
 
   @override
   String get allFilesDeleted => 'Сите записи избришани';
@@ -8529,8 +8342,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get fairUseAboutTitle => 'За правично користење';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi е дизајнирана за лични разговори, состаноци и живи интеракции. Употребата се мери по вистински детектиран говор време, а не по време на поврзување. Доколку употребата значајно надминува нормални обрасци за не-лично содржување, прилагодување може да се примени.';
+  String get fairUseAboutBody => 'Omi е дизајнирана за лични разговори, состаноци и живи интеракции. Употребата се мери по вистински детектиран говор време, а не по време на поврзување. Доколку употребата значајно надминува нормални обрасци за не-лично содржување, прилагодување може да се примени.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8568,8 +8380,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get improveConnectionTitle => 'Подобри врска';
 
   @override
-  String get improveConnectionContent =>
-      'Подобривме како Omi останува поврзана со твојот уред. За да го активираш ова, молиме оди на страницата Device Info, допри \"Откачи уред\" и потоа спарај го твојот уред повторно.';
+  String get improveConnectionContent => 'Подобривме како Omi останува поврзана со твојот уред. За да го активираш ова, молиме оди на страницата Device Info, допри \"Откачи уред\" и потоа спарај го твојот уред повторно.';
 
   @override
   String get improveConnectionAction => 'Разбирам';
@@ -8624,16 +8435,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get cancelSyncQuestion => 'Откажи синхронизирање?';
 
   @override
-  String get omisStorageDesc =>
-      'Кога твојот Omi не е поврзан на твојот телефон, тој складира звук локално на неговата вградена меморија. Никогаш не теглиш запис.';
+  String get omisStorageDesc => 'Кога твојот Omi не е поврзан на твојот телефон, тој складира звук локално на неговата вградена меморија. Никогаш не теглиш запис.';
 
   @override
-  String get phoneStorageDesc =>
-      'Кога Omi се повторно поврзе, записите се автоматски пренесуваат на твојот телефон како привремена облас за ископување пред ископување.';
+  String get phoneStorageDesc => 'Кога Omi се повторно поврзе, записите се автоматски пренесуваат на твојот телефон како привремена облас за ископување пред ископување.';
 
   @override
-  String get cloudStorageDesc =>
-      'Откако ќе ги ископаш, твоите записи се обработуваат и транскрибираат. Разговорите ќе бидат достапни во минута.';
+  String get cloudStorageDesc => 'Откако ќе ги ископаш, твоите записи се обработуваат и транскрибираат. Разговорите ќе бидат достапни во минута.';
 
   @override
   String get tipKeepPhoneNearby => 'Задржи го телефонот во близина за побрзо синхронизирање';
@@ -8657,12 +8465,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get permissionEnable => 'Дозволи';
 
   @override
-  String get permissionsPageDescription =>
-      'Овие дозволи се основни за тоа како функционира Omi. Тие овозможуваат клучни функции како известувања, локациски искуства и снимање звук.';
+  String get permissionsPageDescription => 'Овие дозволи се основни за тоа како функционира Omi. Тие овозможуваат клучни функции како известувања, локациски искуства и снимање звук.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi има потреба од неколку дозволи за правилна работа. Молиме дозволи им да продолжи.';
+  String get permissionsRequiredDescription => 'Omi има потреба од неколку дозволи за правилна работа. Молиме дозволи им да продолжи.';
 
   @override
   String get permissionsSetupTitle => 'Добиј најдобро искуство';
@@ -8716,8 +8522,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get justAMoment => 'Чекај малку, молиме';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Силно препорачуваме да ги истражиш твоите останатите опции наместо откажување.';
+  String get cancelConsequencesSubtitle => 'Силно препорачуваме да ги истражиш твоите останатите опции наместо откажување.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8728,8 +8533,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get ifYouCancel => 'Доколку го отказеш:';
 
   @override
-  String get cancelConsequenceNoAccess =>
-      'Нема да го имаш неограничениот пристап на крајот на твојот период на плаќање.';
+  String get cancelConsequenceNoAccess => 'Нема да го имаш неограничениот пристап на крајот на твојот период на плаќање.';
 
   @override
   String get cancelConsequenceBattery => '7x повеќе потрошување на батерија (обработка на уредот)';
@@ -8941,8 +8745,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get firmwareWarningTitle => 'Важно: Прочитајте пред ажурирање';
 
   @override
-  String get firmwareFormatWarning =>
-      'Овој фирмвер ќе ја форматира SD картичката. Ве молиме осигурајте се дека сите офлајн податоци се синхронизирани пред надградба.\n\nАко видите трепкачко црвено светло по инсталирањето на оваа верзија, не грижете се. Едноставно поврзете го уредот со апликацијата и треба да стане сино. Црвеното светло значи дека часовникот на уредот сè уште не е синхронизиран.';
+  String get firmwareFormatWarning => 'Овој фирмвер ќе ја форматира SD картичката. Ве молиме осигурајте се дека сите офлајн податоци се синхронизирани пред надградба.\n\nАко видите трепкачко црвено светло по инсталирањето на оваа верзија, не грижете се. Едноставно поврзете го уредот со апликацијата и треба да стане сино. Црвеното светло значи дека часовникот на уредот сè уште не е синхронизиран.';
 
   @override
   String get continueAnyway => 'Продолжи';
@@ -8962,8 +8765,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get tasksMarkComplete => 'Означено како завршено';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi пристапува до Apple Health преку HealthKit рамката на Apple. Пристапот можете да го повлечете во секое време во поставките на iOS.';
+  String get appleHealthManageNote => 'Omi пристапува до Apple Health преку HealthKit рамката на Apple. Пристапот можете да го повлечете во секое време во поставките на iOS.';
 
   @override
   String get appleHealthConnectCta => 'Поврзи со Apple Health';
@@ -8984,8 +8786,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get appleHealthFeatureReadOnlyTitle => 'Пристап само за читање';
 
   @override
-  String get appleHealthFeatureReadOnlyDesc =>
-      'Omi никогаш не запишува во Apple Health и не ги менува вашите податоци.';
+  String get appleHealthFeatureReadOnlyDesc => 'Omi никогаш не запишува во Apple Health и не ги менува вашите податоци.';
 
   @override
   String get appleHealthFeatureSecureTitle => 'Безбедна синхронизација';
@@ -8997,8 +8798,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Пристапот до Apple Health е одбиен';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi нема дозвола да ги чита вашите Apple Health податоци. Овозможете го во iOS Поставки → Приватност и безбедност → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi нема дозвола да ги чита вашите Apple Health податоци. Овозможете го во iOS Поставки → Приватност и безбедност → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Зошто си одите?';
@@ -9067,8 +8867,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get planUpdate => 'Ажурирање на планот';
 
   @override
-  String get planDeprecationMessage =>
-      'Вашиот Unlimited план се укинува. Преминете на Operator план — истите одлични функции за \$49/мес. Вашиот тековен план ќе продолжи да работи во меѓувреме.';
+  String get planDeprecationMessage => 'Вашиот Unlimited план се укинува. Преминете на Operator план — истите одлични функции за \$49/мес. Вашиот тековен план ќе продолжи да работи во меѓувреме.';
 
   @override
   String get upgradeYourPlan => 'Надградете го вашиот план';
@@ -9179,8 +8978,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Го достигнавте вашиот месечен лимит. Надградете за да продолжите да разговарате со Omi без ограничувања.';
+  String get chatQuotaExceededReply => 'Го достигнавте вашиот месечен лимит. Надградете за да продолжите да разговарате со Omi без ограничувања.';
 
   @override
   String get voiceResponseAudio => 'Прочитај го одговорот на Omi гласно';
@@ -9211,4 +9009,25 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Додај задача';
+
+  @override
+  String get quickActionAskOmiAnything => 'Прашај го Omi за нешто';
+
+  @override
+  String get quickActionVoiceMode => 'Гласовен режим';
+
+  @override
+  String get quickActionMute => 'Исклучи звук';
+
+  @override
+  String get quickActionUnmute => 'Вклучи звук';
+
+  @override
+  String get quickActionConnectDevice => 'Поврзи уред';
+
+  @override
+  String get quickActionDeviceSettings => 'Поставки на уред';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -24,8 +24,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deleteConversationTitle => 'संभाषण हटवू?';
 
   @override
-  String get deleteConversationMessage =>
-      'यामुळे संबंधित स्मृती, कार्य आणि ऑडिओ फाइल देखील हटवल्या जातील. ही कारवाई पूर्ववत केली जाऊ शकत नाही.';
+  String get deleteConversationMessage => 'यामुळे संबंधित स्मृती, कार्य आणि ऑडिओ फाइल देखील हटवल्या जातील. ही कारवाई पूर्ववत केली जाऊ शकत नाही.';
 
   @override
   String get confirm => 'पुष्टी करा';
@@ -146,8 +145,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deleting => 'हटवत आहे...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'कृपया आपल्या ब्राउজरमध्ये प्रमाणीकरण पूर्ण करा. केल्यानंतर, अ‍ॅपवर परत या.';
+  String get pleaseCompleteAuthentication => 'कृपया आपल्या ब्राउজरमध्ये प्रमाणीकरण पूर्ण करा. केल्यानंतर, अ‍ॅपवर परत या.';
 
   @override
   String get failedToStartAuthentication => 'प्रमाणीकरण सुरू करणे अयोग्य';
@@ -319,8 +317,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get installedApps => 'स्थापित अ‍ॅप्स';
 
   @override
-  String get unableToFetchApps =>
-      'अ‍ॅप्स आणू शकत नाही :(\n\nकृपया आपल्या इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.';
+  String get unableToFetchApps => 'अ‍ॅप्स आणू शकत नाही :(\n\nकृपया आपल्या इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.';
 
   @override
   String get aboutOmi => 'Omi बद्दल';
@@ -356,19 +353,16 @@ class AppLocalizationsMr extends AppLocalizations {
   String get appsDisconnected => 'आपली अ‍ॅप्स आणि एकीकरण तातडीने डिस्कनेक्ट केली जाईल.';
 
   @override
-  String get exportBeforeDelete =>
-      'आप आपला खाता हटवण्यापूर्वी आपल्या डेटा निर्यात करू शकता, परंतु एकदा हटवल्यानंतर, ते पुनर्प्राप्त केले जाऊ शकत नाही.';
+  String get exportBeforeDelete => 'आप आपला खाता हटवण्यापूर्वी आपल्या डेटा निर्यात करू शकता, परंतु एकदा हटवल्यानंतर, ते पुनर्प्राप्त केले जाऊ शकत नाही.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'मी समजतो की माझा खाता हटवणे स्थायी आहे आणि सर्व डेटा, स्मृती आणि संभाषण सह, हरवल्या जातील आणि पुनर्प्राप्त केले जाऊ शकत नाही.';
+  String get deleteAccountCheckbox => 'मी समजतो की माझा खाता हटवणे स्थायी आहे आणि सर्व डेटा, स्मृती आणि संभाषण सह, हरवल्या जातील आणि पुनर्प्राप्त केले जाऊ शकत नाही.';
 
   @override
   String get areYouSure => 'आप निश्चित आहात?';
 
   @override
-  String get deleteAccountFinal =>
-      'ही कारवाई पूर्ववत नाही आणि आपला खाता आणि सर्व संबंधित डेटा स्थायीपणे हटवल्या जातील. आप पुढे जाऊ इच्छिता?';
+  String get deleteAccountFinal => 'ही कारवाई पूर्ववत नाही आणि आपला खाता आणि सर्व संबंधित डेटा स्थायीपणे हटवल्या जातील. आप पुढे जाऊ इच्छिता?';
 
   @override
   String get deleteNow => 'आता हटवा';
@@ -377,8 +371,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get goBack => 'परत जा';
 
   @override
-  String get checkBoxToConfirm =>
-      'पुष्टी करण्यासाठी बॉक्स तपासा की आप समजतात की आपल्या खाता हटवणे स्थायी आणि पूर्ववत नाही.';
+  String get checkBoxToConfirm => 'पुष्टी करण्यासाठी बॉक्स तपासा की आप समजतात की आपल्या खाता हटवणे स्थायी आणि पूर्ववत नाही.';
 
   @override
   String get profile => 'प्रोफाइल';
@@ -456,8 +449,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get yourPrivacyYourControl => 'आपली गोपनीयता, आपला नियंत्रण';
 
   @override
-  String get privacyIntro =>
-      'Omi मध्ये, आम्ही आपल्या गोपनीयतेची संरक्षण करण्यासाठी प्रतिबद्ध आहोत. हे पृष्ठ आपल्याला आपल्या डेटा कसा संग्रहित आणि वापरला जातो याचे नियंत्रण करण्यास अनुमती देते.';
+  String get privacyIntro => 'Omi मध्ये, आम्ही आपल्या गोपनीयतेची संरक्षण करण्यासाठी प्रतिबद्ध आहोत. हे पृष्ठ आपल्याला आपल्या डेटा कसा संग्रहित आणि वापरला जातो याचे नियंत्रण करण्यास अनुमती देते.';
 
   @override
   String get learnMore => 'अधिक जाणून घ्या...';
@@ -466,15 +458,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get dataProtectionLevel => 'डेटा संरक्षण स्तर';
 
   @override
-  String get dataProtectionDesc =>
-      'आपल्या डेटा मजबूत एन्क्रिप्शनद्वारे डिफॉल्टनुसार सुरक्षित आहेत. खालील आपल्या सेटिंग्ज आणि भविष्यातील गोपनीयता पर्याय पुनरावलोकन करा.';
+  String get dataProtectionDesc => 'आपल्या डेटा मजबूत एन्क्रिप्शनद्वारे डिफॉल्टनुसार सुरक्षित आहेत. खालील आपल्या सेटिंग्ज आणि भविष्यातील गोपनीयता पर्याय पुनरावलोकन करा.';
 
   @override
   String get appAccess => 'अ‍ॅप प्रवेश';
 
   @override
-  String get appAccessDesc =>
-      'खालील अ‍ॅप्स आपल्या डेटा अ‍ॅक्सेस करू शकते. त्याचे अनुमती व्यवस्थापित करण्यासाठी अ‍ॅपवर टॅप करा.';
+  String get appAccessDesc => 'खालील अ‍ॅप्स आपल्या डेटा अ‍ॅक्सेस करू शकते. त्याचे अनुमती व्यवस्थापित करण्यासाठी अ‍ॅपवर टॅप करा.';
 
   @override
   String get noAppsExternalAccess => 'स्थापित अ‍ॅप्सचा आपल्या डेटासाठी कोणताही बाह्य प्रवेश नाही.';
@@ -531,22 +521,19 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deviceDisconnectedMessage => 'आपल्या Omi डिस्कनेक्ट केला गेला आहे 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'डिव्हाइस अनपेअर केला. अनपेअरिंग पूर्ण करण्यासाठी सेटिंग्ज > Bluetooth वर जा आणि डिव्हाइस विसरा.';
+  String get deviceUnpairedMessage => 'डिव्हाइस अनपेअर केला. अनपेअरिंग पूर्ण करण्यासाठी सेटिंग्ज > Bluetooth वर जा आणि डिव्हाइस विसरा.';
 
   @override
   String get unpairDialogTitle => 'डिव्हाइस अनपेअर करा';
 
   @override
-  String get unpairDialogMessage =>
-      'यामुळे डिव्हाइस अनपेअर होईल जेणेकरून ते दुसर्‍या फोनवर कनेक्ट केले जाऊ शकेल. आपल्याला सेटिंग्ज > Bluetooth वर जावे लागेल आणि प्रक्रिया पूर्ण करण्यासाठी डिव्हाइस विसरावे लागेल.';
+  String get unpairDialogMessage => 'यामुळे डिव्हाइस अनपेअर होईल जेणेकरून ते दुसर्‍या फोनवर कनेक्ट केले जाऊ शकेल. आपल्याला सेटिंग्ज > Bluetooth वर जावे लागेल आणि प्रक्रिया पूर्ण करण्यासाठी डिव्हाइस विसरावे लागेल.';
 
   @override
   String get deviceNotConnected => 'डिव्हाइस कनेक्ट नाही';
 
   @override
-  String get connectDeviceMessage =>
-      'डिव्हाइस सेटिंग्ज आणि कस्टमाइজेशन अ‍ॅक्सेस करण्यासाठी आपल्या Omi डिव्हाइस कनेक्ट करा';
+  String get connectDeviceMessage => 'डिव्हाइस सेटिंग्ज आणि कस्टमाइজेशन अ‍ॅक्सेस करण्यासाठी आपल्या Omi डिव्हाइस कनेक्ट करा';
 
   @override
   String get deviceInfoSection => 'डिव्हाइस माहिती';
@@ -561,8 +548,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get v2Undetected => 'V2 ओळखला नाही';
 
   @override
-  String get v2UndetectedMessage =>
-      'आम्ही पाहतो की आपल्याकडे V1 डिव्हाइस आहे किंवा आपल्या डिव्हाइस कनेक्ट नाही. SD कार्ड कार्यक्षमता केवळ V2 डिव्हाइससाठी उपलब्ध आहे.';
+  String get v2UndetectedMessage => 'आम्ही पाहतो की आपल्याकडे V1 डिव्हाइस आहे किंवा आपल्या डिव्हाइस कनेक्ट नाही. SD कार्ड कार्यक्षमता केवळ V2 डिव्हाइससाठी उपलब्ध आहे.';
 
   @override
   String get endConversation => 'संभाषण समाप्त करा';
@@ -836,8 +822,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'ज्ञान ग्राफ हटवू?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'यामुळे सर्व व्युत्पन्न ज्ञान ग्राफ डेटा (नोड्स आणि कनेक्शन) हटवल्या जातील. आपल्या मूळ स्मृती सुरक्षित राहतील. ग्राफ कालांतराने किंवा पुढील विनंतीवर पुनर्निर्मित होईल.';
+  String get deleteKnowledgeGraphMessage => 'यामुळे सर्व व्युत्पन्न ज्ञान ग्राफ डेटा (नोड्स आणि कनेक्शन) हटवल्या जातील. आपल्या मूळ स्मृती सुरक्षित राहतील. ग्राफ कालांतराने किंवा पुढील विनंतीवर पुनर्निर्मित होईल.';
 
   @override
   String get knowledgeGraphDeleted => 'ज्ञान ग्राफ हटवला';
@@ -985,8 +970,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get shortConversationThreshold => 'लघु संभाषण मर्यादा';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'या मर्यादेपेक्षा लहान संभाषण लपवल्या जातील जोपर्यंत वरील सक्षम नाही';
+  String get shortConversationThresholdSubtitle => 'या मर्यादेपेक्षा लहान संभाषण लपवल्या जातील जोपर्यंत वरील सक्षम नाही';
 
   @override
   String get durationThreshold => 'अवधान मर्यादा';
@@ -1081,8 +1065,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get needYourPermission => 'आमला आपल्या अनुमतीची आवश्यकता आहे';
 
   @override
-  String get alreadyGavePermission =>
-      'आपण आमला आपल्या रेकॉर्डिंग संरक्षण करण्याची अनुमती दिली आहे. हे आवश्यक असणार्या कारणाचे स्मरण:';
+  String get alreadyGavePermission => 'आपण आमला आपल्या रेकॉर्डिंग संरक्षण करण्याची अनुमती दिली आहे. हे आवश्यक असणार्या कारणाचे स्मरण:';
 
   @override
   String get wouldLikePermission => 'आम्हाला आपल्या व्हॉयस रेकॉर्डिंग संरक्षण करण्याची अनुमती हवी आहे. येथे का आहे:';
@@ -1091,26 +1074,22 @@ class AppLocalizationsMr extends AppLocalizations {
   String get improveSpeechProfile => 'आपल्या वाण प्रोफाइल सुधारा';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'आम्ही आपल्या व्यक्तिगत वाण प्रोफाइल प्रशिक्षित आणि वाढवण्यासाठी रेकॉर्डिंग वापरतो.';
+  String get improveSpeechProfileDesc => 'आम्ही आपल्या व्यक्तिगत वाण प्रोफाइल प्रशिक्षित आणि वाढवण्यासाठी रेकॉर्डिंग वापरतो.';
 
   @override
   String get trainFamilyProfiles => 'मित्र आणि कुटुंब सदस्यांसाठी प्रोफाइल प्रशिक्षित करा';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'आपल्या रेकॉर्डिंग आपल्या मित्र आणि कुटुंब सदस्यांना ओळखायला आणि प्रोफाइल तयार करायला मदत करते.';
+  String get trainFamilyProfilesDesc => 'आपल्या रेकॉर्डिंग आपल्या मित्र आणि कुटुंब सदस्यांना ओळखायला आणि प्रोफाइल तयार करायला मदत करते.';
 
   @override
   String get enhanceTranscriptAccuracy => 'प्रतिलेख अचूकता वाढवा';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'आमचा मॉडेल सुधारत असताना, आम्ही आपल्या रेकॉर्डिंगसाठी बेहतर प्रतिलेख परिणाम प्रदान करू शकतो.';
+  String get enhanceTranscriptAccuracyDesc => 'आमचा मॉडेल सुधारत असताना, आम्ही आपल्या रेकॉर्डिंगसाठी बेहतर प्रतिलेख परिणाम प्रदान करू शकतो.';
 
   @override
-  String get legalNotice =>
-      'कायदेशीर सूचना: आपल्या स्थान आणि या वैशिष्ट्याचा वापर कसा करतात यावर आधारित, रेकॉर्डिंग आणि व्हॉयस डेटा संरक्षण करणे कानूनी असू शकते किंवा नसू शकते. स्थानिक कायदे आणि नियमांचे पालन सुनिश्चित करणे हे आपल्याचे जबाबदारी आहे.';
+  String get legalNotice => 'कायदेशीर सूचना: आपल्या स्थान आणि या वैशिष्ट्याचा वापर कसा करतात यावर आधारित, रेकॉर्डिंग आणि व्हॉयस डेटा संरक्षण करणे कानूनी असू शकते किंवा नसू शकते. स्थानिक कायदे आणि नियमांचे पालन सुनिश्चित करणे हे आपल्याचे जबाबदारी आहे.';
 
   @override
   String get alreadyAuthorized => 'आधीच अधिकृत';
@@ -1188,8 +1167,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get showEventsNoParticipants => 'सहभागी नसलेली इव्हेंट दाखवा';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'सक्षम केल्यास, Coming Up सहभागी किंवा व्हिडिओ लिंक नसलेली इव्हेंट दाखवते.';
+  String get showEventsNoParticipantsDesc => 'सक्षम केल्यास, Coming Up सहभागी किंवा व्हिडिओ लिंक नसलेली इव्हेंट दाखवते.';
 
   @override
   String get yourMeetings => 'आपली मीटिंग्ज';
@@ -1357,8 +1335,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get defaultRepository => 'डिफॉल्ट रेपोजिटरी';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'समस्या तयार करण्यासाठी डिफॉल्ट रेपोजिटरी निवडा. आपण समस्या तयार करताना तरीही वेगळी रेपोजिटरी निर्दिष्ट करू शकता.';
+  String get selectDefaultRepoDesc => 'समस्या तयार करण्यासाठी डिफॉल्ट रेपोजिटरी निवडा. आपण समस्या तयार करताना तरीही वेगळी रेपोजिटरी निर्दिष्ट करू शकता.';
 
   @override
   String get noReposFound => 'कोणती रेपोजिटरी सापडली नाही';
@@ -1405,8 +1382,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get configureSettings => 'सेटिंग्ज कॉन्फिगर करा';
 
   @override
-  String get completeAuthBrowser =>
-      'कृपया आपल्या ब्राउজरमध्ये प्रमाणीकरण पूर्ण करा. पूर्ण झाल्यानंतर, अॅपमध्ये परत या.';
+  String get completeAuthBrowser => 'कृपया आपल्या ब्राउজरमध्ये प्रमाणीकरण पूर्ण करा. पूर्ण झाल्यानंतर, अॅपमध्ये परत या.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1734,8 +1710,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth सक्षम करा';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi आपल्या पहनने केल्या जाणार्‍या उपकरणाला जोडण्यासाठी Bluetooth आवश्यक आहे. कृपया Bluetooth सक्षम करा आणि पुन्हा प्रयत्न करा.';
+  String get bluetoothNeeded => 'Omi आपल्या पहनने केल्या जाणार्‍या उपकरणाला जोडण्यासाठी Bluetooth आवश्यक आहे. कृपया Bluetooth सक्षम करा आणि पुन्हा प्रयत्न करा.';
 
   @override
   String get contactSupport => 'समर्थन संपर्क करायचे?';
@@ -1768,26 +1743,22 @@ class AppLocalizationsMr extends AppLocalizations {
   String get locationServiceDisabled => 'स्थान सेवा अक्षम';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'स्थान सेवा अक्षम आहे. कृपया सेटिंग्ज > गोपनीयता आणि सुरक्षा > स्थान सेवा वर जा आणि सक्षम करा';
+  String get locationServiceDisabledDesc => 'स्थान सेवा अक्षम आहे. कृपया सेटिंग्ज > गोपनीयता आणि सुरक्षा > स्थान सेवा वर जा आणि सक्षम करा';
 
   @override
   String get backgroundLocationDenied => 'पार्श्वभूमी स्थान प्रवेश नाकारला';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'कृपया डिव्हाइस सेटिंग्जमध्ये जा आणि स्थान परवानगी \"नेहमी परवानगी द्या\" वर सेट करा';
+  String get backgroundLocationDeniedDesc => 'कृपया डिव्हाइस सेटिंग्जमध्ये जा आणि स्थान परवानगी \"नेहमी परवानगी द्या\" वर सेट करा';
 
   @override
   String get lovingOmi => 'Omi आवडतंय?';
 
   @override
-  String get leaveReviewIos =>
-      'App Store मध्ये पुनरावलोकन सोडून आम्हाला अधिक लोकांपर्यंत पोहोचण्यास मदत करा. आपल्या प्रतिक्रिया आमच्यासाठी खूप महत्वाची आहे!';
+  String get leaveReviewIos => 'App Store मध्ये पुनरावलोकन सोडून आम्हाला अधिक लोकांपर्यंत पोहोचण्यास मदत करा. आपल्या प्रतिक्रिया आमच्यासाठी खूप महत्वाची आहे!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Google Play Store मध्ये पुनरावलोकन सोडून आम्हाला अधिक लोकांपर्यंत पोहोचण्यास मदत करा. आपल्या प्रतिक्रिया आमच्यासाठी खूप महत्वाची आहे!';
+  String get leaveReviewAndroid => 'Google Play Store मध्ये पुनरावलोकन सोडून आम्हाला अधिक लोकांपर्यंत पोहोचण्यास मदत करा. आपल्या प्रतिक्रिया आमच्यासाठी खूप महत्वाची आहे!';
 
   @override
   String get rateOnAppStore => 'App Store वर रेट करा';
@@ -1820,15 +1791,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get connectionError => 'कनेक्शन त्रुटी';
 
   @override
-  String get connectionErrorDesc =>
-      'सर्व्हरला जोडण्यात अयशस्वी. कृपया आपल्या इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.';
+  String get connectionErrorDesc => 'सर्व्हरला जोडण्यात अयशस्वी. कृपया आपल्या इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'अमान्य रेकॉर्डिंग शोधली';
 
   @override
-  String get multipleSpeakersDesc =>
-      'असे दिसते की रेकॉर्डिंगमध्ये अनेक स्पीकर आहेत. कृपया खाली की शांत जागेत आहात याची खात्री करा आणि पुन्हा प्रयत्न करा.';
+  String get multipleSpeakersDesc => 'असे दिसते की रेकॉर्डिंगमध्ये अनेक स्पीकर आहेत. कृपया खाली की शांत जागेत आहात याची खात्री करा आणि पुन्हा प्रयत्न करा.';
 
   @override
   String get tooShortDesc => 'पुरेशी भाषण शोधली नाही. कृपया अधिक बोला आणि पुन्हा प्रयत्न करा.';
@@ -1840,8 +1809,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get areYouThere => 'आप तेथे आहात का?';
 
   @override
-  String get noSpeechDesc =>
-      'आम्ही कोणतीही भाषण शोधू शकलो नाही. कृपया कमीत कमी 10 सेकंद आणि 3 मिनिटांपेक्षा जास्त नाही बोलण्याची खात्री करा.';
+  String get noSpeechDesc => 'आम्ही कोणतीही भाषण शोधू शकलो नाही. कृपया कमीत कमी 10 सेकंद आणि 3 मिनिटांपेक्षा जास्त नाही बोलण्याची खात्री करा.';
 
   @override
   String get connectionLost => 'कनेक्शन हरवले';
@@ -1862,8 +1830,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get permissionsRequired => 'परवानग्या आवश्यक';
 
   @override
-  String get permissionsRequiredDesc =>
-      'या अॅपला योग्यरित्या कार्य करण्यासाठी Bluetooth आणि स्थान परवानग्या आवश्यक आहेत. कृपया सेटिंग्जमध्ये सक्षम करा.';
+  String get permissionsRequiredDesc => 'या अॅपला योग्यरित्या कार्य करण्यासाठी Bluetooth आणि स्थान परवानग्या आवश्यक आहेत. कृपया सेटिंग्जमध्ये सक्षम करा.';
 
   @override
   String get openSettings => 'सेटिंग्ज खोला';
@@ -1908,8 +1875,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get permissionGrantedNow => 'परवानगी दिली! आता:\n\nआपल्या वॉचवर Omi अॅप खोला आणि खाली \"सुरू करा\" टॅप करा';
 
   @override
-  String get needMicrophonePermission =>
-      'आम्हाला मायक्रोफोन परवानगी आवश्यक आहे.\n\n1. \"परवानगी दे\" टॅप करा\n2. आपल्या iPhone वर परवानगी द्या\n3. वॉच अॅप बंद होईल\n4. पुन्हा खोला आणि \"सुरू करा\" टॅप करा';
+  String get needMicrophonePermission => 'आम्हाला मायक्रोफोन परवानगी आवश्यक आहे.\n\n1. \"परवानगी दे\" टॅप करा\n2. आपल्या iPhone वर परवानगी द्या\n3. वॉच अॅप बंद होईल\n4. पुन्हा खोला आणि \"सुरू करा\" टॅप करा';
 
   @override
   String get grantPermissionButton => 'परवानगी द्या';
@@ -1918,15 +1884,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get needHelp => 'मदत हवी?';
 
   @override
-  String get troubleshootingSteps =>
-      'समस्या निवारणः\n\n1. Omi आपल्या वॉचवर इंस्टॉल आहे याची खात्री करा\n2. आपल्या वॉचवर Omi अॅप खोला\n3. परवानगी पॉपअप शोधा\n4. विचारले गेल्यावर \"परवानगी द्या\" टॅप करा\n5. आपल्या वॉचवर अॅप बंद होईल - ते पुन्हा खोला\n6. आपल्या iPhone वर परत या आणि \"सुरू करा\" टॅप करा';
+  String get troubleshootingSteps => 'समस्या निवारणः\n\n1. Omi आपल्या वॉचवर इंस्टॉल आहे याची खात्री करा\n2. आपल्या वॉचवर Omi अॅप खोला\n3. परवानगी पॉपअप शोधा\n4. विचारले गेल्यावर \"परवानगी द्या\" टॅप करा\n5. आपल्या वॉचवर अॅप बंद होईल - ते पुन्हा खोला\n6. आपल्या iPhone वर परत या आणि \"सुरू करा\" टॅप करा';
 
   @override
   String get recordingStartedSuccessfully => 'रेकॉर्डिंग यशस्वीरित्या सुरू झाली!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'परवानगी अद्याप दिली नाही. कृपया खात्री करा की आपण मायक्रोफोन प्रवेश परवानगी दिली आणि आपल्या वॉचवर अॅप पुन्हा खोली.';
+  String get permissionNotGrantedYet => 'परवानगी अद्याप दिली नाही. कृपया खात्री करा की आपण मायक्रोफोन प्रवेश परवानगी दिली आणि आपल्या वॉचवर अॅप पुन्हा खोली.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1957,8 +1921,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get actionItemsTitle => 'To-Do\'s';
 
   @override
-  String get actionItemsDescription =>
-      'संपादित करण्यासाठी टॅप करा • निवडण्यासाठी लांब प्रेस करा • क्रियांसाठी स्वाइप करा';
+  String get actionItemsDescription => 'संपादित करण्यासाठी टॅप करा • निवडण्यासाठी लांब प्रेस करा • क्रियांसाठी स्वाइप करा';
 
   @override
   String get tabToDo => 'करायचे';
@@ -2024,8 +1987,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get welcomeActionItemsTitle => 'कृती आयटमसाठी तयार';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'आपला AI संभाषणातून कार्य आणि to-do स्वतः काढून घेणार. ते येथे दिसतील जेव्हा तयार होतील.';
+  String get welcomeActionItemsDescription => 'आपला AI संभाषणातून कार्य आणि to-do स्वतः काढून घेणार. ते येथे दिसतील जेव्हा तयार होतील.';
 
   @override
   String get autoExtractionFeature => 'संभाषणातून स्वतः काढून घेतले';
@@ -2075,8 +2037,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get clearMemoryTitle => 'Omi ची स्मृती स्पष्ट करा';
 
   @override
-  String get clearMemoryMessage =>
-      'आपल्याला खरोखर Omi ची स्मृती स्पष्ट करायची आहे? हे क्रिया पूर्ववत् केली जाऊ शकत नाही.';
+  String get clearMemoryMessage => 'आपल्याला खरोखर Omi ची स्मृती स्पष्ट करायची आहे? हे क्रिया पूर्ववत् केली जाऊ शकत नाही.';
 
   @override
   String get clearMemoryButton => 'स्मृती स्पष्ट करा';
@@ -2222,15 +2183,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'भाषण आणि ट्रांसक्रिप्शन';
 
   @override
-  String get languageSettingsHelperText =>
-      'अॅप भाषा मेनू आणि बटण बदलते. भाषण भाषा आपल्या रेकॉर्डिंग कसे ट्रांसक्राइब केली जाते यावर परिणाम करते.';
+  String get languageSettingsHelperText => 'अॅप भाषा मेनू आणि बटण बदलते. भाषण भाषा आपल्या रेकॉर्डिंग कसे ट्रांसक्राइब केली जाते यावर परिणाम करते.';
 
   @override
   String get translationNotice => 'अनुवाद सूचना';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi संभाषण आपल्या प्राथमिक भाषेमध्ये अनुवादित करते. सेटिंग्ज → प्रोफाइल मध्ये कधीही अपडेट करा.';
+  String get translationNoticeMessage => 'Omi संभाषण आपल्या प्राथमिक भाषेमध्ये अनुवादित करते. सेटिंग्ज → प्रोफाइल मध्ये कधीही अपडेट करा.';
 
   @override
   String get pleaseCheckInternetConnection => 'कृपया आपल्या इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा';
@@ -2392,8 +2351,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'डिव्हाइस जोडणी काढून टाका';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'हे डिव्हाइसची जोडणी काढून टाकेल ज्यामुळे ते दुसऱ्या फोनशी कनेक्ट केले जाऊ शकेल. प्रक्रिया पूर्ण करण्यासाठी तुम्हाला सेटिंग्ज > ब्लूटूथ वर जाऊन डिव्हाइस विसरावे लागेल.';
+  String get unpairDeviceDialogMessage => 'हे डिव्हाइसची जोडणी काढून टाकेल ज्यामुळे ते दुसऱ्या फोनशी कनेक्ट केले जाऊ शकेल. प्रक्रिया पूर्ण करण्यासाठी तुम्हाला सेटिंग्ज > ब्लूटूथ वर जाऊन डिव्हाइस विसरावे लागेल.';
 
   @override
   String get unpair => 'जोडणी काढून टाका';
@@ -2574,8 +2532,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get youreAllSet => 'तुम्ही सब्कुशीत आहात!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Omi मध्ये स्वागत आहे! आपला AI सहचर संभाषण, कार्य इत्यादी मध्ये आपल्याला मदत करण्यासाठी तयार आहे।';
+  String get welcomeToOmiDescription => 'Omi मध्ये स्वागत आहे! आपला AI सहचर संभाषण, कार्य इत्यादी मध्ये आपल्याला मदत करण्यासाठी तयार आहे।';
 
   @override
   String get startUsingOmi => 'Omi वापरण्यास सुरुवात करा';
@@ -2654,8 +2611,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get reviewAndManageConversations => 'आपल्या कॅप्चर केलेल्या संभाषणांची पुनरावलोकन करा आणि व्यवस्थापन करा';
 
   @override
-  String get startCapturingConversations =>
-      'आपल्या Omi डिव्हाइसशी संभाषण कॅप्चर करण्यास सुरुवात करा त्यांना येथे पाहण्यासाठी।';
+  String get startCapturingConversations => 'आपल्या Omi डिव्हाइसशी संभाषण कॅप्चर करण्यास सुरुवात करा त्यांना येथे पाहण्यासाठी।';
 
   @override
   String get useMobileAppToCapture => 'ऑडिओ कॅप्चर करण्यासाठी आपल्या मोबाइल अ‍ॅपचा वापर करा';
@@ -2712,8 +2668,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get noTasksYet => 'अजून कोणतेही कार्य नाहीत';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'आपल्या संभाषणातील कार्य येथे दिसू शकतील।\nएक स्वहस्ते जोडण्यासाठी तयार करा क्लिक करा।';
+  String get tasksFromConversationsWillAppear => 'आपल्या संभाषणातील कार्य येथे दिसू शकतील।\nएक स्वहस्ते जोडण्यासाठी तयार करा क्लिक करा।';
 
   @override
   String get monthJan => 'जान';
@@ -2770,8 +2725,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deleteActionItem => 'कृती आयटम हटवा';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'आप्या खात्रीने हे कृती आयटम हटवू इच्छितात? हे कृती पूर्ववत केली जाऊ शकत नाही।';
+  String get deleteActionItemConfirmation => 'आप्या खात्रीने हे कृती आयटम हटवू इच्छितात? हे कृती पूर्ववत केली जाऊ शकत नाही।';
 
   @override
   String get enterActionItemDescription => 'कृती आयटमचे वर्णन प्रविष्ट करा...';
@@ -2846,15 +2800,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get chatPrompt => 'चॅट प्रॉम्प्ट';
 
   @override
-  String get chatPromptPlaceholder =>
-      'तुम्ही एक अद्भुत अ‍ॅप आहात, तुमचे काम उपयोगकर्त्याच्या क्वेरीला प्रतिक्रिया देणे आणि त्यांना चांगले वाटवणे आहे...';
+  String get chatPromptPlaceholder => 'तुम्ही एक अद्भुत अ‍ॅप आहात, तुमचे काम उपयोगकर्त्याच्या क्वेरीला प्रतिक्रिया देणे आणि त्यांना चांगले वाटवणे आहे...';
 
   @override
   String get conversationPrompt => 'संभाषण प्रॉम्प्ट';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'तुम्ही एक अद्भुत अ‍ॅप आहात, तुम्हाला संभाषणाची ट्रान्सक्रिप्ट आणि सारांश दिला जाईल...';
+  String get conversationPromptPlaceholder => 'तुम्ही एक अद्भुत अ‍ॅप आहात, तुम्हाला संभाषणाची ट्रान्सक्रिप्ट आणि सारांश दिला जाईल...';
 
   @override
   String get notificationScopes => 'सूचना स्कोप्स';
@@ -2881,12 +2833,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get submitAppQuestion => 'अ‍ॅप जमा करा?';
 
   @override
-  String get submitAppPublicDescription =>
-      'आपला अ‍ॅप पुनरावलोकन केला जाईल आणि सार्वजनिक केला जाईल. आप्य तक्षणच वापरण्यास सुरुवात करू शकता, पुनरावलोकन सुरु असतानाही!';
+  String get submitAppPublicDescription => 'आपला अ‍ॅप पुनरावलोकन केला जाईल आणि सार्वजनिक केला जाईल. आप्य तक्षणच वापरण्यास सुरुवात करू शकता, पुनरावलोकन सुरु असतानाही!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'आपला अ‍ॅप पुनरावलोकन केला जाईल आणि आपल्यासाठी खाजगीपणे उपलब्ध केला जाईल. आप्य तक्षणच वापरण्यास सुरुवात करू शकता, पुनरावलोकन सुरु असतानाही!';
+  String get submitAppPrivateDescription => 'आपला अ‍ॅप पुनरावलोकन केला जाईल आणि आपल्यासाठी खाजगीपणे उपलब्ध केला जाईल. आप्य तक्षणच वापरण्यास सुरुवात करू शकता, पुनरावलोकन सुरु असतानाही!';
 
   @override
   String get startEarning => 'कमाई सुरू करा! 💰';
@@ -2910,23 +2860,19 @@ class AppLocalizationsMr extends AppLocalizations {
   String get dataAccessNotice => 'डेटा प्रवेश सूचना';
 
   @override
-  String get dataAccessWarning =>
-      'हा अ‍ॅप आपल्या डेटामध्ये प्रवेश करेल. Omi AI आपल्या डेटा या अ‍ॅपद्वारे कसे वापरला, सुधारला किंवा हटवला जाते याबद्दल जबाबदार नाही';
+  String get dataAccessWarning => 'हा अ‍ॅप आपल्या डेटामध्ये प्रवेश करेल. Omi AI आपल्या डेटा या अ‍ॅपद्वारे कसे वापरला, सुधारला किंवा हटवला जाते याबद्दल जबाबदार नाही';
 
   @override
   String get installApp => 'अ‍ॅप इंस्टॉल करा';
 
   @override
-  String get betaTesterNotice =>
-      'तुम्ही या अ‍ॅपचे बीटा टेस्टर आहात. हा अजून सार्वजनिक नाही. मंजूरी मिळल्यावर हा सार्वजनिक होईल।';
+  String get betaTesterNotice => 'तुम्ही या अ‍ॅपचे बीटा टेस्टर आहात. हा अजून सार्वजनिक नाही. मंजूरी मिळल्यावर हा सार्वजनिक होईल।';
 
   @override
-  String get appUnderReviewOwner =>
-      'आपला अ‍ॅप पुनरावलोकनाधीन आहे आणि केवळ आपल्यासाठी दृश्यमान आहे. मंजूरी मिळल्यावर हा सार्वजनिक होईल।';
+  String get appUnderReviewOwner => 'आपला अ‍ॅप पुनरावलोकनाधीन आहे आणि केवळ आपल्यासाठी दृश्यमान आहे. मंजूरी मिळल्यावर हा सार्वजनिक होईल।';
 
   @override
-  String get appRejectedNotice =>
-      'आपला अ‍ॅप नाकारला गेला आहे. कृपया अ‍ॅपचे तपशील अपडेट करा आणि पुनरावलोकनासाठी पुन्हा जमा करा।';
+  String get appRejectedNotice => 'आपला अ‍ॅप नाकारला गेला आहे. कृपया अ‍ॅपचे तपशील अपडेट करा आणि पुनरावलोकनासाठी पुन्हा जमा करा।';
 
   @override
   String get setupSteps => 'सेटअप चरण';
@@ -2988,8 +2934,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get descriptionLabel => 'वर्णन';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'माझा अद्भुत अ‍ॅप एक छान अ‍ॅप आहे जे आश्चर्यकारी गोष्टी करते. हा सर्वात छान अ‍ॅप आहे!';
+  String get appDescriptionPlaceholder => 'माझा अद्भुत अ‍ॅप एक छान अ‍ॅप आहे जे आश्चर्यकारी गोष्टी करते. हा सर्वात छान अ‍ॅप आहे!';
 
   @override
   String get pleaseProvideValidDescription => 'कृपया वैध वर्णन प्रदान करा';
@@ -3141,8 +3086,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get microphonePermissionRequired => 'कॉल करण्यासाठी मायक्रोफोन परवानगी आवश्यक आहे';
 
   @override
-  String get microphonePermissionDenied =>
-      'मायक्रोफोन परवानगी नकारली गेली. कृपया सिस्टम प्राधान्ये > गोपनीयता आणि सुरक्षा > मायक्रोफोन मध्ये परवानगी द्या।';
+  String get microphonePermissionDenied => 'मायक्रोफोन परवानगी नकारली गेली. कृपया सिस्टम प्राधान्ये > गोपनीयता आणि सुरक्षा > मायक्रोफोन मध्ये परवानगी द्या।';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3375,8 +3319,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get whatWeCollect => 'आम्ही काय संकलित करतो';
 
   @override
-  String get dataCollectionMessage =>
-      'सुरू ठेवून, आपले संभाषण, रेकॉर्डिंग्‍स आणि व्यक्तिगत माहिती आमच्या सर्व्हरवर सुरक्षित ठेवली जाईल जेणेकरून AI-संचालित अंतर्दृष्टी प्रदान करू शकू शकें आणि सर्व अॅप वैशिष्ट्य सक्षम करू शकें.';
+  String get dataCollectionMessage => 'सुरू ठेवून, आपले संभाषण, रेकॉर्डिंग्‍स आणि व्यक्तिगत माहिती आमच्या सर्व्हरवर सुरक्षित ठेवली जाईल जेणेकरून AI-संचालित अंतर्दृष्टी प्रदान करू शकू शकें आणि सर्व अॅप वैशिष्ट्य सक्षम करू शकें.';
 
   @override
   String get dataProtection => 'डेटा संरक्षण';
@@ -3409,8 +3352,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'नाव किमान २ वर्ण असणे आवश्यक आहे';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'आमला सांगा कि आपल्याला कसे संबोधले जावे. हे आपल्या Omi अनुभव वैयक्तिकृत करण्यास मदत करते.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'आमला सांगा कि आपल्याला कसे संबोधले जावे. हे आपल्या Omi अनुभव वैयक्तिकृत करण्यास मदत करते.';
 
   @override
   String charactersCount(int count) {
@@ -3427,8 +3369,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get recordAudioConversations => 'ऑडियो संभाषण रेकॉर्ड करा';
 
   @override
-  String get microphoneAccessDescription =>
-      'आपले संभाषण रेकॉर्ड करण्यासाठी आणि लिप्यंतरण प्रदान करण्यासाठी Omi ला मायक्रोफोन प्रवेश आवश्यक आहे.';
+  String get microphoneAccessDescription => 'आपले संभाषण रेकॉर्ड करण्यासाठी आणि लिप्यंतरण प्रदान करण्यासाठी Omi ला मायक्रोफोन प्रवेश आवश्यक आहे.';
 
   @override
   String get screenRecording => 'स्क्रीन रेकॉर्डिंग';
@@ -3437,8 +3378,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'मीटिंग्समधून सिस्टम ऑडियो कॅप्चर करा';
 
   @override
-  String get screenRecordingDescription =>
-      'आपल्या ब्राउজर-आधारित मीटिंग्समधून सिस्टम ऑडियो कॅप्चर करण्यासाठी Omi ला स्क्रीन रेकॉर्डिंग परवानगी आवश्यक आहे.';
+  String get screenRecordingDescription => 'आपल्या ब्राउজर-आधारित मीटिंग्समधून सिस्टम ऑडियो कॅप्चर करण्यासाठी Omi ला स्क्रीन रेकॉर्डिंग परवानगी आवश्यक आहे.';
 
   @override
   String get accessibility => 'अॅक्सेसिबिलिटी';
@@ -3447,8 +3387,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'ब्राउজर-आधारित मीटिंग्स शोधा';
 
   @override
-  String get accessibilityDescription =>
-      'आपण आपल्या ब्राउজरमध्ये Zoom, Meet किंवा Teams मीटिंग्समध्ये सामील होताना शोधण्यासाठी Omi ला अॅक्सेसिबिलिटी परवानगी आवश्यक आहे.';
+  String get accessibilityDescription => 'आपण आपल्या ब्राउজरमध्ये Zoom, Meet किंवा Teams मीटिंग्समध्ये सामील होताना शोधण्यासाठी Omi ला अॅक्सेसिबिलिटी परवानगी आवश्यक आहे.';
 
   @override
   String get pleaseWait => 'कृपया प्रतीक्षा करा...';
@@ -3520,8 +3459,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get conversationsExportStarted => 'संभाषण निर्यात सुरू झाला. हे काही सेकंद लागू शकते, कृपया प्रतीक्षा करा.';
 
   @override
-  String get mcpDescription =>
-      'Omi ला इतर अनुप्रयोगांसह कनेक्ट करण्यासाठी आपल्या आठवणी आणि संभाषण वाचा, शोधा आणि व्यवस्थापित करा. सुरू करण्यासाठी की तयार करा.';
+  String get mcpDescription => 'Omi ला इतर अनुप्रयोगांसह कनेक्ट करण्यासाठी आपल्या आठवणी आणि संभाषण वाचा, शोधा आणि व्यवस्थापित करा. सुरू करण्यासाठी की तयार करा.';
 
   @override
   String get apiKeys => 'API की';
@@ -3629,8 +3567,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Omi ला स्वयंचलितपणे सर्वोत्तम अॅप निवडू द्या';
 
   @override
-  String get deleteConversationConfirmation =>
-      'आप हा संभाषण हटविण्याचे सुनिश्चित आहात? हे क्रिया पूर्ववत् करू शकत नाही.';
+  String get deleteConversationConfirmation => 'आप हा संभाषण हटविण्याचे सुनिश्चित आहात? हे क्रिया पूर्ववत् करू शकत नाही.';
 
   @override
   String get conversationDeleted => 'संभाषण हटवले';
@@ -3678,8 +3615,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get preparingSystemAudioCapture => 'सिस्टम ऑडियो कॅप्चर तयार होत आहे';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'लाइव्ह लिप्यंतरण, AI अंतर्दृष्टी आणि स्वयंचलित सेव्हिंगसाठी ऑडियो कॅप्चर करण्यासाठी बटण क्लिक करा.';
+  String get clickTheButtonToCaptureAudio => 'लाइव्ह लिप्यंतरण, AI अंतर्दृष्टी आणि स्वयंचलित सेव्हिंगसाठी ऑडियो कॅप्चर करण्यासाठी बटण क्लिक करा.';
 
   @override
   String get reconnecting => 'पुन्हा कनेक्ट होत आहे...';
@@ -3906,8 +3842,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'ज्ञान आलेख हटवा?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'हे सर्व व्युत्पन्न ज्ञान आलेख डेटा हटवेल. आपल्या मूळ आठवणी सुरक्षित राहतात.';
+  String get deleteKnowledgeGraphWarning => 'हे सर्व व्युत्पन्न ज्ञान आलेख डेटा हटवेल. आपल्या मूळ आठवणी सुरक्षित राहतात.';
 
   @override
   String get connectOmiWithAI => 'Omi ला AI सहायकांसह कनेक्ट करा';
@@ -3964,8 +3899,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get updateAppQuestion => 'अॅप अपडेट करा?';
 
   @override
-  String get updateAppConfirmation =>
-      'आप आपल्या अॅप अपडेट करण्याचे सुनिश्चित आहात? आमच्या टीम द्वारे पुनरावलोकन केल्यानंतर बदल प्रतिबिंबित होतील.';
+  String get updateAppConfirmation => 'आप आपल्या अॅप अपडेट करण्याचे सुनिश्चित आहात? आमच्या टीम द्वारे पुनरावलोकन केल्यानंतर बदल प्रतिबिंबित होतील.';
 
   @override
   String get updateApp => 'अॅप अपडेट करा';
@@ -3995,8 +3929,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get no => 'नाही';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'सदस्यता यशस्वीरित्या रद्द केली. ती चालू बिलिंग कालावधीच्या शेवटपर्यंत सक्रिय राहील.';
+  String get subscriptionCancelledSuccessfully => 'सदस्यता यशस्वीरित्या रद्द केली. ती चालू बिलिंग कालावधीच्या शेवटपर्यंत सक्रिय राहील.';
 
   @override
   String get failedToCancelSubscription => 'सदस्यता रद्द करण्यास अपयश आली. कृपया पुन्हा प्रयत्न करा.';
@@ -4032,8 +3965,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'सदस्यता रद्द करा?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'आप आपल्या सदस्यता रद्द करण्याचे सुनिश्चित आहात? आप आपल्या चालू बिलिंग कालावधीच्या शेवटपर्यंत प्रवेश ठेवू शकतील.';
+  String get cancelSubscriptionConfirmation => 'आप आपल्या सदस्यता रद्द करण्याचे सुनिश्चित आहात? आप आपल्या चालू बिलिंग कालावधीच्या शेवटपर्यंत प्रवेश ठेवू शकतील.';
 
   @override
   String get cancelSubscriptionButton => 'सदस्यता रद्द करा';
@@ -4042,16 +3974,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get cancelling => 'रद्द होत आहे...';
 
   @override
-  String get betaTesterMessage =>
-      'आप या अॅपचे बीटा टेस्टर आहात. ते अजून सार्वजनिक नाही. मंजूरी मिळल्यावर ते सार्वजनिक होईल.';
+  String get betaTesterMessage => 'आप या अॅपचे बीटा टेस्टर आहात. ते अजून सार्वजनिक नाही. मंजूरी मिळल्यावर ते सार्वजनिक होईल.';
 
   @override
-  String get appUnderReviewMessage =>
-      'आपला अॅप पुनरावलोकनाखाली आहे आणि केवळ आपल्यास दृश्यमान आहे. मंजूरी मिळल्यावर ते सार्वजनिक होईल.';
+  String get appUnderReviewMessage => 'आपला अॅप पुनरावलोकनाखाली आहे आणि केवळ आपल्यास दृश्यमान आहे. मंजूरी मिळल्यावर ते सार्वजनिक होईल.';
 
   @override
-  String get appRejectedMessage =>
-      'आपल्या अॅपला अस्वीकार करण्यात आला आहे. कृपया अॅप तपशील अपडेट करा आणि पुनरावलोकनासाठी पुन्हा सबमिट करा.';
+  String get appRejectedMessage => 'आपल्या अॅपला अस्वीकार करण्यात आला आहे. कृपया अॅप तपशील अपडेट करा आणि पुनरावलोकनासाठी पुन्हा सबमिट करा.';
 
   @override
   String get invalidIntegrationUrl => 'अमान्य एकीकरण URL';
@@ -4105,8 +4034,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get issueActivatingApp => 'या अॅप सक्रिय करण्यात समस्या आली. कृपया पुन्हा प्रयत्न करा.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'हा अॅप आपल्या डेटामध्ये प्रवेश करेल. Omi AI हा अॅप आपल्या डेटा कसे वापरते, सुधारते किंवा हटवते याच्यासाठी जबाबदार नाही';
+  String get dataAccessNoticeDescription => 'हा अॅप आपल्या डेटामध्ये प्रवेश करेल. Omi AI हा अॅप आपल्या डेटा कसे वापरते, सुधारते किंवा हटवते याच्यासाठी जबाबदार नाही';
 
   @override
   String get copyUrl => 'URL कॉपी करा';
@@ -4194,8 +4122,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get omiApiKeys => 'Omi API की';
 
   @override
-  String get apiKeysDescription =>
-      'API की हे प्रमाणीकरणासाठी वापरली जातात जेव्हा आपल्या अॅप OMI सर्व्हरसह संवाद करते. ते आपल्या अनुप्रयोगास स्मृतिमान तयार करण्यास आणि इतर OMI सेवा सुरक्षितपणे प्रवेश करण्यास अनुमती देते.';
+  String get apiKeysDescription => 'API की हे प्रमाणीकरणासाठी वापरली जातात जेव्हा आपल्या अॅप OMI सर्व्हरसह संवाद करते. ते आपल्या अनुप्रयोगास स्मृतिमान तयार करण्यास आणि इतर OMI सेवा सुरक्षितपणे प्रवेश करण्यास अनुमती देते.';
 
   @override
   String get aboutOmiApiKeys => 'Omi API की बद्दल';
@@ -4219,8 +4146,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API की रद्द करा?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'हे क्रिया पूर्ववत् करू शकत नाही. या की वापरणारी कोणतीही अनुप्रयोग यापुढे API मध्ये प्रवेश करू शकणार नाही.';
+  String get revokeApiKeyWarning => 'हे क्रिया पूर्ववत् करू शकत नाही. या की वापरणारी कोणतीही अनुप्रयोग यापुढे API मध्ये प्रवेश करू शकणार नाही.';
 
   @override
   String get revoke => 'रद्द करा';
@@ -4309,8 +4235,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get keyCreated => 'की तयार झाली';
 
   @override
-  String get keyCreatedMessage =>
-      'आपल्या नवीन की तयार केली गेली आहे. कृपया आता कॉपी करा. आप हे पुन्हा पाहू शकणार नाही.';
+  String get keyCreatedMessage => 'आपल्या नवीन की तयार केली गेली आहे. कृपया आता कॉपी करा. आप हे पुन्हा पाहू शकणार नाही.';
 
   @override
   String get keyWord => 'की';
@@ -4319,8 +4244,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get externalAppAccess => 'बाह्य अॅप प्रवेश';
 
   @override
-  String get externalAppAccessDescription =>
-      'खालील स्थापित अॅप्सचे बाह्य एकीकरण आहे आणि आपल्या डेटामध्ये प्रवेश करू शकते, जसे संभाषण आणि आठवणी.';
+  String get externalAppAccessDescription => 'खालील स्थापित अॅप्सचे बाह्य एकीकरण आहे आणि आपल्या डेटामध्ये प्रवेश करू शकते, जसे संभाषण आणि आठवणी.';
 
   @override
   String get noExternalAppsHaveAccess => 'कोणत्याही बाह्य अॅप्सला आपल्या डेटामध्ये प्रवेश नाही.';
@@ -4329,8 +4253,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get maximumSecurityE2ee => 'अधिकतम सुरक्षा (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'एंड-टू-एंड एन्क्रिप्शन गोपनीयताचा सोने मानक आहे. सक्षम होताना, आपल्या डेटा आपल्या डिव्हाइसवर एन्क्रिप्ट केली जाते त्याच्या आगे आमच्या सर्व्हरला पाठवले जाते. याचा अर्थ असा की कोणीही, Omi सारखेच नाही, आपल्या सामग्रीमध्ये प्रवेश करू शकत नाही.';
+  String get e2eeDescription => 'एंड-टू-एंड एन्क्रिप्शन गोपनीयताचा सोने मानक आहे. सक्षम होताना, आपल्या डेटा आपल्या डिव्हाइसवर एन्क्रिप्ट केली जाते त्याच्या आगे आमच्या सर्व्हरला पाठवले जाते. याचा अर्थ असा की कोणीही, Omi सारखेच नाही, आपल्या सामग्रीमध्ये प्रवेश करू शकत नाही.';
 
   @override
   String get importantTradeoffs => 'महत्वपूर्ण ट्रेड-ऑफ:';
@@ -4345,8 +4268,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get featureComingSoon => 'ही वैशिष्ट्य जल्दीच आये!';
 
   @override
-  String get migrationInProgressMessage =>
-      'स्थलांतरण प्रगतीमध्ये आहे. हे पूर्ण होईपर्यंत आप संरक्षण स्तर बदलू शकत नाही.';
+  String get migrationInProgressMessage => 'स्थलांतरण प्रगतीमध्ये आहे. हे पूर्ण होईपर्यंत आप संरक्षण स्तर बदलू शकत नाही.';
 
   @override
   String get migrationFailed => 'स्थलांतरण अपयश आली';
@@ -4365,19 +4287,16 @@ class AppLocalizationsMr extends AppLocalizations {
   String get secureEncryption => 'सुरक्षित एन्क्रिप्शन';
 
   @override
-  String get secureEncryptionDescription =>
-      'आपल्या डेटा आपल्यासाठी अद्वितीय की सह आमच्या सर्व्हरवर एन्क्रिप्ट केली जाते, Google Cloud वर होस्ट केली जाते. याचा अर्थ असा की आपल्या कच्ची सामग्री डेटाबेसकडून कोणीही, Omi कर्मचारी किंवा Google सारखेच, सरळ प्रवेशयोग्य नाही.';
+  String get secureEncryptionDescription => 'आपल्या डेटा आपल्यासाठी अद्वितीय की सह आमच्या सर्व्हरवर एन्क्रिप्ट केली जाते, Google Cloud वर होस्ट केली जाते. याचा अर्थ असा की आपल्या कच्ची सामग्री डेटाबेसकडून कोणीही, Omi कर्मचारी किंवा Google सारखेच, सरळ प्रवेशयोग्य नाही.';
 
   @override
   String get endToEndEncryption => 'एंड-टू-एंड एन्क्रिप्शन';
 
   @override
-  String get e2eeCardDescription =>
-      'अधिकतम सुरक्षा सक्षम करा जेथे केवळ आप आपल्या डेटामध्ये प्रवेश करू शकता. अधिक जाणून घेण्यासाठी टॅप करा.';
+  String get e2eeCardDescription => 'अधिकतम सुरक्षा सक्षम करा जेथे केवळ आप आपल्या डेटामध्ये प्रवेश करू शकता. अधिक जाणून घेण्यासाठी टॅप करा.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'स्तरापेक्षा असूनही, आपल्या डेटा नेहमी विश्रांती वर आणि पारगमनात एन्क्रिप्ट केली जाते.';
+  String get dataAlwaysEncrypted => 'स्तरापेक्षा असूनही, आपल्या डेटा नेहमी विश्रांती वर आणि पारगमनात एन्क्रिप्ट केली जाते.';
 
   @override
   String get readOnlyScope => 'फक्त वाचा';
@@ -4442,12 +4361,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get trainingDataProgram => 'प्रशिक्षण डेटा कार्यक्रम';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'AI मॉडेल प्रशिक्षण साठी आपल्या डेटा योगदान करून Omi Unlimited विनामूल्य प्राप्त करा.';
+  String get getOmiUnlimitedFree => 'AI मॉडेल प्रशिक्षण साठी आपल्या डेटा योगदान करून Omi Unlimited विनामूल्य प्राप्त करा.';
 
   @override
-  String get trainingDataBullets =>
-      '• आपल्या डेटा AI मॉडेल सुधारण्यास मदत करते\n• फक्त गैर-संवेदनशील डेटा शेअर केली जाते\n• संपूर्ण पारदर्शी प्रक्रिया';
+  String get trainingDataBullets => '• आपल्या डेटा AI मॉडेल सुधारण्यास मदत करते\n• फक्त गैर-संवेदनशील डेटा शेअर केली जाते\n• संपूर्ण पारदर्शी प्रक्रिया';
 
   @override
   String get learnMoreAtOmiTraining => 'omi.me/training वर अधिक जाणून घ्या';
@@ -4459,8 +4376,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get submitRequest => 'विनंती सबमिट करा';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'धन्यवाद! आपल्या विनंती पुनरावलोकनाखाली आहे. मंजूरी मिळल्यावर आम्ही आपल्याला सूचित करु.';
+  String get thankYouRequestUnderReview => 'धन्यवाद! आपल्या विनंती पुनरावलोकनाखाली आहे. मंजूरी मिळल्यावर आम्ही आपल्याला सूचित करु.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4498,8 +4414,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get monthlyPlanContinues => 'आपली वर्तमान मासिक योजना आपच्या बिलिंग कालावधीच्या शेवटपर्यंत सुरू राहील';
 
   @override
-  String get paymentMethodCharged =>
-      'आपली विद्यमान पेमेंट पद्धत आपली मासिक योजना संपल्यावर स्वयंचलितपणे चार्ज केली जाईल';
+  String get paymentMethodCharged => 'आपली विद्यमान पेमेंट पद्धत आपली मासिक योजना संपल्यावर स्वयंचलितपणे चार्ज केली जाईल';
 
   @override
   String get annualSubscriptionStarts => 'आपली १२-महिन्यांची वार्षिक सदस्यता चार्जनंतर स्वयंचलितपणे सुरू होईल';
@@ -4609,8 +4524,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'आपली गोपनीयता आमच्यासाठी महत्वाची आहे';
 
   @override
-  String get privacyIntroText =>
-      'Omi मध्ये, आम्ही आपली गोपनीयता अत्यंत गंभीरपणे घेतो. आम्ही आपल्याकरिता आमच्या उत्पादनाची सुधारणा करण्यासाठी आम्ही कोणता डेटा संकलित करतो आणि कसे वापरतो याबद्दल पारदर्शक असू इच्छितो. येथे आपल्याला जाणून घेणे आवश्यक आहे:';
+  String get privacyIntroText => 'Omi मध्ये, आम्ही आपली गोपनीयता अत्यंत गंभीरपणे घेतो. आम्ही आपल्याकरिता आमच्या उत्पादनाची सुधारणा करण्यासाठी आम्ही कोणता डेटा संकलित करतो आणि कसे वापरतो याबद्दल पारदर्शक असू इच्छितो. येथे आपल्याला जाणून घेणे आवश्यक आहे:';
 
   @override
   String get whatWeTrack => 'आम्ही काय ट्रॅक करतो';
@@ -4625,12 +4539,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get ourCommitment => 'आमची प्रतिबद्धता';
 
   @override
-  String get commitmentText =>
-      'आम्ही आमच्या द्वारा संकलित डेटा Omi ला आपल्यासाठी एक चांगले उत्पादन बनवण्यासाठी वापरण्यास प्रतिबद्ध आहे. आपली गोपनीयता आणि विश्वास आमच्यासाठी सर्वोच्च प्राधान्य आहे.';
+  String get commitmentText => 'आम्ही आमच्या द्वारा संकलित डेटा Omi ला आपल्यासाठी एक चांगले उत्पादन बनवण्यासाठी वापरण्यास प्रतिबद्ध आहे. आपली गोपनीयता आणि विश्वास आमच्यासाठी सर्वोच्च प्राधान्य आहे.';
 
   @override
-  String get thankYouText =>
-      'Omi चे मूल्यवान वापरकर्ता असल्याबद्दल धन्यवाद. आपल्याला कोणतीही प्रश्न किंवा चिंता असल्यास, आमच्याशी संपर्क करण्यास नेहमी स्वागत आहे team@basedhardware.com.';
+  String get thankYouText => 'Omi चे मूल्यवान वापरकर्ता असल्याबद्दल धन्यवाद. आपल्याला कोणतीही प्रश्न किंवा चिंता असल्यास, आमच्याशी संपर्क करण्यास नेहमी स्वागत आहे team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi सिंक सेटिंग्ज';
@@ -4639,8 +4551,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get enterHotspotCredentials => 'आपल्या फोनच्या हॉटस्पॉट क्रेडेंशियल्स प्रविष्ट करा';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi सिंक आपल्या फोनला हॉटस्पॉट म्हणून वापरते. आपल्या हॉटस्पॉट नाव आणि पासवर्ड सेटिंग्ज > व्यक्तिगत हॉटस्पॉट मध्ये शोधा.';
+  String get wifiSyncUsesHotspot => 'WiFi सिंक आपल्या फोनला हॉटस्पॉट म्हणून वापरते. आपल्या हॉटस्पॉट नाव आणि पासवर्ड सेटिंग्ज > व्यक्तिगत हॉटस्पॉट मध्ये शोधा.';
 
   @override
   String get hotspotNameSsid => 'हॉटस्पॉट नाव (SSID)';
@@ -4675,8 +4586,7 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'सारांश तयार करण्यास अपयश आले. सुनिश्चित करा की आपल्याकडे त्या दिवसासाठी संभाषण आहेत.';
+  String get failedToGenerateSummaryCheckConversations => 'सारांश तयार करण्यास अपयश आले. सुनिश्चित करा की आपल्याकडे त्या दिवसासाठी संभाषण आहेत.';
 
   @override
   String get summaryNotFound => 'सारांश सापडला नाही';
@@ -4706,8 +4616,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'निर्यात सुरू झाले. यास काही सेकंद लागू शकतात...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'हे सर्व व्युत्पन्न ज्ञान ग्राफ डेटा (नोड्स आणि कनेक्शन) हटाईल. आपली मूळ स्मृती सुरक्षित राहील. ग्राफ समय मिळल्यावर किंवा पुढील विनंतीवर पुनर्निर्मित होईल.';
+  String get knowledgeGraphDeleteDescription => 'हे सर्व व्युत्पन्न ज्ञान ग्राफ डेटा (नोड्स आणि कनेक्शन) हटाईल. आपली मूळ स्मृती सुरक्षित राहील. ग्राफ समय मिळल्यावर किंवा पुढील विनंतीवर पुनर्निर्मित होईल.';
 
   @override
   String get configureDailySummaryDigest => 'आपल्या दैनिक कृती मुद्दे पचन कॉन्फ़िगर करा';
@@ -4777,8 +4686,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'सर्व सीमाहीन संभाषण हटवा?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'हे Limitless मधून आयात केलेले सर्व संभाषण स्थायीरित्या हटाईल. ही कारवाई पूर्ववत्त करता येणार नाही.';
+  String get deleteAllLimitlessWarning => 'हे Limitless मधून आयात केलेले सर्व संभाषण स्थायीरित्या हटाईल. ही कारवाई पूर्ववत्त करता येणार नाही.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4834,8 +4742,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get howItWorksTitle => 'हे कसे काम करते?';
 
   @override
-  String get howPeopleWorks =>
-      'एकदा व्यक्ती तयार झाल्यानंतर, आप संभाषण लेखा मध्ये जाऊ शकता आणि त्यांना त्यांचे संबंधित खंड नियुक्त करू शकता, त्या प्रकारे Omi त्यांच्या भाषणाची देखील ओळख करू शकेल!';
+  String get howPeopleWorks => 'एकदा व्यक्ती तयार झाल्यानंतर, आप संभाषण लेखा मध्ये जाऊ शकता आणि त्यांना त्यांचे संबंधित खंड नियुक्त करू शकता, त्या प्रकारे Omi त्यांच्या भाषणाची देखील ओळख करू शकेल!';
 
   @override
   String get tapToDelete => 'हटविण्यासाठी टॅप करा';
@@ -4861,8 +4768,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get privacyNotice => 'गोपनीयता सूचना';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'रेकॉर्डिंग्ज इतरांचे आवाज कॅप्चर करू शकतात. सक्षम करण्यापूर्वी सर्व सहभागींचा सहमती सुनिश्चित करा.';
+  String get recordingsMayCaptureOthers => 'रेकॉर्डिंग्ज इतरांचे आवाज कॅप्चर करू शकतात. सक्षम करण्यापूर्वी सर्व सहभागींचा सहमती सुनिश्चित करा.';
 
   @override
   String get enable => 'सक्षम करा';
@@ -4874,8 +4780,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get on => 'चालू';
 
   @override
-  String get storeAudioDescription =>
-      'सर्व ऑडिओ रेकॉर्डिंग्ज आपल्या फोनवर स्थानिकरित्या संग्रहीत ठेवा. अक्षम केल्यावर, संग्रहण स्थान वाचविण्यासाठी फक्त अपयश आपलोडचे ठेवले जातात.';
+  String get storeAudioDescription => 'सर्व ऑडिओ रेकॉर्डिंग्ज आपल्या फोनवर स्थानिकरित्या संग्रहीत ठेवा. अक्षम केल्यावर, संग्रहण स्थान वाचविण्यासाठी फक्त अपयश आपलोडचे ठेवले जातात.';
 
   @override
   String get enableLocalStorage => 'स्थानिक संग्रहण सक्षम करा';
@@ -4893,12 +4798,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get storeAudioOnCloud => 'क्लाउडवर ऑडिओ स्टोर करा';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'आपली रीयल-टाइम रेकॉर्डिंग्ज आपण बोलत असताना खाजगी क्लाउड संग्रहणमध्ये संग्रहीत केली जातील.';
+  String get cloudStorageDialogMessage => 'आपली रीयल-टाइम रेकॉर्डिंग्ज आपण बोलत असताना खाजगी क्लाउड संग्रहणमध्ये संग्रहीत केली जातील.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'आपली रीयल-टाइम रेकॉर्डिंग्ज आपण बोलत असताना खाजगी क्लाउड संग्रहणमध्ये संग्रहीत करा. ऑडिओ रीयल-टाइममध्ये सुरक्षितपणे कॅप्चर आणि सेव केला जातो.';
+  String get storeAudioCloudDescription => 'आपली रीयल-टाइम रेकॉर्डिंग्ज आपण बोलत असताना खाजगी क्लाउड संग्रहणमध्ये संग्रहीत करा. ऑडिओ रीयल-टाइममध्ये सुरक्षितपणे कॅप्चर आणि सेव केला जातो.';
 
   @override
   String get downloadingFirmware => 'फर्मवेयर डाउनलोड करत आहे';
@@ -4907,8 +4810,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get installingFirmware => 'फर्मवेयर स्थापित करत आहे';
 
   @override
-  String get firmwareUpdateWarning =>
-      'अ‍ॅप बंद करू नका किंवा डिव्हाइस बंद करू नका. यामुळे आपल्या डिव्हाइसचे नुकसान होऊ शकते.';
+  String get firmwareUpdateWarning => 'अ‍ॅप बंद करू नका किंवा डिव्हाइस बंद करू नका. यामुळे आपल्या डिव्हाइसचे नुकसान होऊ शकते.';
 
   @override
   String get firmwareUpdated => 'फर्मवेयर अपडेट केले';
@@ -4952,8 +4854,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get payments => 'पेमेंट्स';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'आपल्या अ‍ॅप्लिकेशनसाठी पेआउट प्राप्त करणे सुरू करण्यासाठी खाली पेमेंट पद्धती कनेक्ट करा.';
+  String get connectPaymentMethodInfo => 'आपल्या अ‍ॅप्लिकेशनसाठी पेआउट प्राप्त करणे सुरू करण्यासाठी खाली पेमेंट पद्धती कनेक्ट करा.';
 
   @override
   String get selectedPaymentMethod => 'निवडलेली पेमेंट पद्धती';
@@ -4980,8 +4881,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get monthlyPayouts => 'मासिक पेआउट्स';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'जेव्हा आप \$१० कमाई पर्यंत पोहोचता तेव्हा आपल्या खात्यात थेट मासिक पेमेंट प्राप्त करा';
+  String get monthlyPayoutsDescription => 'जेव्हा आप \$१० कमाई पर्यंत पोहोचता तेव्हा आपल्या खात्यात थेट मासिक पेमेंट प्राप्त करा';
 
   @override
   String get secureAndReliable => 'सुरक्षित आणि विश्वसनीय';
@@ -5008,8 +4908,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get connectingYourStripeAccount => 'आपल्या Stripe खाते कनेक्ट करत आहे';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'कृपया आपल्या ब्राउজरमध्ये Stripe ऑनबोर्डिंग प्रक्रिया पूर्ण करा. हा पृष्ठ पूर्ण झाल्यानंतर स्वयंचलितपणे अपडेट होईल.';
+  String get stripeOnboardingInstructions => 'कृपया आपल्या ब्राउজरमध्ये Stripe ऑनबोर्डिंग प्रक्रिया पूर्ण करा. हा पृष्ठ पूर्ण झाल्यानंतर स्वयंचलितपणे अपडेट होईल.';
 
   @override
   String get failedTryAgain => 'अपयश? पुन्हा प्रयत्न करा';
@@ -5021,8 +4920,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get successfullyConnected => 'यशस्वीरित्या कनेक्ट केले!';
 
   @override
-  String get stripeReadyForPayments =>
-      'आपल्या Stripe खाते आता पेमेंट प्राप्त करण्यासाठी तयार आहे. आप आपल्या अ‍ॅप विक्रीमधून लगेचच कमाई सुरू करू शकता.';
+  String get stripeReadyForPayments => 'आपल्या Stripe खाते आता पेमेंट प्राप्त करण्यासाठी तयार आहे. आप आपल्या अ‍ॅप विक्रीमधून लगेचच कमाई सुरू करू शकता.';
 
   @override
   String get updateStripeDetails => 'Stripe तपशील अपडेट करा';
@@ -5040,8 +4938,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get updatePayPalAccountDetails => 'आपल्या PayPal खाते तपशील अपडेट करा';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'आपल्या अ‍ॅप्लिकेशनसाठी पेमेंट प्राप्त करणे सुरू करण्यासाठी आपल्या PayPal खाते कनेक्ट करा';
+  String get connectPayPalToReceivePayments => 'आपल्या अ‍ॅप्लिकेशनसाठी पेमेंट प्राप्त करणे सुरू करण्यासाठी आपल्या PayPal खाते कनेक्ट करा';
 
   @override
   String get paypalEmail => 'PayPal ईमेल';
@@ -5050,8 +4947,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me लिंक';
 
   @override
-  String get stripeRecommendation =>
-      'जर Stripe आपल्या देशात उपलब्ध असेल, तर आम्ही वेगवान आणि सोपे पेआउटसाठी यासाठी अत्यंत शिफारस करतो.';
+  String get stripeRecommendation => 'जर Stripe आपल्या देशात उपलब्ध असेल, तर आम्ही वेगवान आणि सोपे पेआउटसाठी यासाठी अत्यंत शिफारस करतो.';
 
   @override
   String get updatePayPalDetails => 'PayPal तपशील अपडेट करा';
@@ -5103,8 +4999,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'अतिरिक्त भाषण नमुना काढून टाकला';
 
   @override
-  String get consentDataMessage =>
-      'पुढे चालू ठेवल्यास, तुमच्या संभाषणा, रेकॉर्डिंग आणि वैयक्तिक माहिती आमच्या सर्व्हरवर सुरक्षितपणे साठवली जाईल. तुमच्या ऑडिओ रेकॉर्डिंग आणि ट्रान्सक्रिप्ट तृतीय-पक्ष AI सेवांद्वारे प्रक्रिया केली जातात (ट्रान्सक्रिप्शनसाठी Deepgram आणि विश्लेषणासाठी OpenAI सह) तुम्हाला AI-चालित अंतर्दृष्टी प्रदान करण्यासाठी आणि सर्व अॅप वैशिष्ट्ये सक्षम करण्यासाठी.';
+  String get consentDataMessage => 'पुढे चालू ठेवल्यास, तुमच्या संभाषणा, रेकॉर्डिंग आणि वैयक्तिक माहिती आमच्या सर्व्हरवर सुरक्षितपणे साठवली जाईल. तुमच्या ऑडिओ रेकॉर्डिंग आणि ट्रान्सक्रिप्ट तृतीय-पक्ष AI सेवांद्वारे प्रक्रिया केली जातात (ट्रान्सक्रिप्शनसाठी Deepgram आणि विश्लेषणासाठी OpenAI सह) तुम्हाला AI-चालित अंतर्दृष्टी प्रदान करण्यासाठी आणि सर्व अॅप वैशिष्ट्ये सक्षम करण्यासाठी.';
 
   @override
   String get tasksEmptyStateMessage => 'आपल्या संभाषणातील कार्य येथे दिसतील.\\n+ टॅप करून एक मॅन्युअल्ली तयार करा.';
@@ -5143,15 +5038,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Omi आपल्या\\nApple Watch वर स्थापित करा';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Omi सह आपल्या Apple Watch वापरण्यासाठी, आपल्याला प्रथम आपल्या घड्याळावर Omi अ‍ॅप स्थापित करणे आवश्यक आहे.';
+  String get installOmiOnAppleWatchDescription => 'Omi सह आपल्या Apple Watch वापरण्यासाठी, आपल्याला प्रथम आपल्या घड्याळावर Omi अ‍ॅप स्थापित करणे आवश्यक आहे.';
 
   @override
   String get openOmiOnAppleWatch => 'Omi आपल्या\\nApple Watch वर उघडा';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi अ‍ॅप आपल्या Apple Watch वर स्थापित आहे. हे उघडा आणि प्रारंभ करण्यासाठी टॅप करा.';
+  String get openOmiOnAppleWatchDescription => 'Omi अ‍ॅप आपल्या Apple Watch वर स्थापित आहे. हे उघडा आणि प्रारंभ करण्यासाठी टॅप करा.';
 
   @override
   String get openWatchApp => 'Watch अ‍ॅप उघडा';
@@ -5160,15 +5053,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'मी अ‍ॅप स्थापित आणि खुले केले आहे';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch अ‍ॅप उघडू शकत नाही. कृपया आपल्या Apple Watch वरील Watch अ‍ॅप मॅन्युअल्ली उघडा आणि \"उपलब्ध अ‍ॅप्स\" विभागातून Omi स्थापित करा.';
+  String get unableToOpenWatchApp => 'Apple Watch अ‍ॅप उघडू शकत नाही. कृपया आपल्या Apple Watch वरील Watch अ‍ॅप मॅन्युअल्ली उघडा आणि \"उपलब्ध अ‍ॅप्स\" विभागातून Omi स्थापित करा.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch यशस्वीरित्या कनेक्ट केले!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch अद्यापही पोहोचता येत नाही. कृपया सुनिश्चित करा की Omi अ‍ॅप आपल्या घड्याळावर खुली आहे.';
+  String get appleWatchNotReachable => 'Apple Watch अद्यापही पोहोचता येत नाही. कृपया सुनिश्चित करा की Omi अ‍ॅप आपल्या घड्याळावर खुली आहे.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5596,8 +5487,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get multipleSpeakersDetected => 'एकाधिक वक्ते शोधले गेले';
 
   @override
-  String get multipleSpeakersDescription =>
-      'असे दिसते की रेकॉर्डिंगमध्ये एकाधिक वक्ते आहेत. कृपया सुनिश्चित करा की आप शांत ठिकाणी आहात आणि पुन्हा प्रयत्न करा.';
+  String get multipleSpeakersDescription => 'असे दिसते की रेकॉर्डिंगमध्ये एकाधिक वक्ते आहेत. कृपया सुनिश्चित करा की आप शांत ठिकाणी आहात आणि पुन्हा प्रयत्न करा.';
 
   @override
   String get invalidRecordingDetected => 'अमान्य रेकॉर्डिंग शोधली गेली';
@@ -5609,15 +5499,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get speechDurationDescription => 'कृपया सुनिश्चित करा की आप कमीतकमी 5 सेकंद आणि 90 पेक्षा जास्त नाही बोलता.';
 
   @override
-  String get connectionLostDescription =>
-      'कनेक्शन व्यस्त झाला. कृपया आपल्या इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.';
+  String get connectionLostDescription => 'कनेक्शन व्यस्त झाला. कृपया आपल्या इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.';
 
   @override
   String get howToTakeGoodSample => 'चांगला नमुना कसा घेायचा?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. सुनिश्चित करा की आप एक शांत जागेत आहात.\n2. स्पष्टपणे आणि नैसर्गिकरित्या बोला.\n3. सुनिश्चित करा की आपले डिव्हाइस त्याच्या नैसर्गिक स्थितीत आहे, आपल्या गळ्यावर.\n\nएकदा तयार झाल्यानंतर, आप हे सुधारू शकता किंवा पुन्हा करू शकता.';
+  String get goodSampleInstructions => '1. सुनिश्चित करा की आप एक शांत जागेत आहात.\n2. स्पष्टपणे आणि नैसर्गिकरित्या बोला.\n3. सुनिश्चित करा की आपले डिव्हाइस त्याच्या नैसर्गिक स्थितीत आहे, आपल्या गळ्यावर.\n\nएकदा तयार झाल्यानंतर, आप हे सुधारू शकता किंवा पुन्हा करू शकता.';
 
   @override
   String get noDeviceConnectedUseMic => 'कोणताही डिव्हाइस कनेक्ट नाही. फोन मायक्रोफोन वापरा.';
@@ -5680,8 +5568,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get howItWorks => 'हे कसे काम करते';
 
   @override
-  String get dailyScoreExplanation =>
-      'आपला दैनिक स्कोर कार्य पूर्णतेवर आधारित आहे. आपला स्कोर सुधारण्यासाठी आपले कार्य पूर्ण करा!';
+  String get dailyScoreExplanation => 'आपला दैनिक स्कोर कार्य पूर्णतेवर आधारित आहे. आपला स्कोर सुधारण्यासाठी आपले कार्य पूर्ण करा!';
 
   @override
   String get notificationFrequencyDescription => 'Omi किती वेळा सक्रिय सूचना आणि स्मरणीये पाठवते हे नियंत्रित करा.';
@@ -6058,15 +5945,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get cloudProvider => 'क्लाउड प्रदाता';
 
   @override
-  String get premiumMinutesInfo =>
-      '1,200 प्रीमियम मिनिटे/महिना. ऑन-डिव्हाइस टॅब अमर्यादित विनामूल्य ट्रान्सक्रिप्शन ऑफर करते.';
+  String get premiumMinutesInfo => '1,200 प्रीमियम मिनिटे/महिना. ऑन-डिव्हाइस टॅब अमर्यादित विनामूल्य ट्रान्सक्रिप्शन ऑफर करते.';
 
   @override
   String get viewUsage => 'वापर पहा';
 
   @override
-  String get localProcessingInfo =>
-      'ऑडिओ स्थानिकरित्या प्रक्रिया केला जातो. ऑफलाइन कार्य करते, अधिक खाजगी, परंतु अधिक बॅटरी वापरते.';
+  String get localProcessingInfo => 'ऑडिओ स्थानिकरित्या प्रक्रिया केला जातो. ऑफलाइन कार्य करते, अधिक खाजगी, परंतु अधिक बॅटरी वापरते.';
 
   @override
   String get model => 'मॉडेल';
@@ -6075,8 +5960,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get performanceWarning => 'कार्यप्रदर्शन सावधानी';
 
   @override
-  String get largeModelWarning =>
-      'हा मॉडेल मोठा आहे आणि मोबाइल डिव्हाइसवर अ‍ॅप क्रॅश किंवा खूप मंद चालू शकतो.\n\n\"small\" किंवा \"base\" अनुशंसित आहे.';
+  String get largeModelWarning => 'हा मॉडेल मोठा आहे आणि मोबाइल डिव्हाइसवर अ‍ॅप क्रॅश किंवा खूप मंद चालू शकतो.\n\n\"small\" किंवा \"base\" अनुशंसित आहे.';
 
   @override
   String get usingNativeIosSpeech => 'नेटिव्ह iOS स्पीच रिकग्निशन वापरत आहे';
@@ -6127,8 +6011,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'डिव्हाइस संगत नाही';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'आपल्या डिव्हाइसला ऑन-डिव्हाइस ट्रान्सक्रिप्शनसाठी आवश्यकतांची पूर्तता करत नाही.';
+  String get deviceNotMeetRequirements => 'आपल्या डिव्हाइसला ऑन-डिव्हाइस ट्रान्सक्रिप्शनसाठी आवश्यकतांची पूर्तता करत नाही.';
 
   @override
   String get transcriptionSlowerOnDevice => 'ऑन-डिव्हाइस ट्रान्सक्रिप्शन या डिव्हाइसवर मंद असू शकते.';
@@ -6140,12 +6023,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get batteryDrainSignificantly => 'बॅटरी ड्रेन लक्षणीयरित्या वाढेल.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1,200 प्रीमियम मिनिटे/महिना. ऑन-डिव्हाइस टॅब अमर्यादित विनामूल्य ट्रान्सक्रिप्शन ऑफर करते. ';
+  String get premiumMinutesMonth => '1,200 प्रीमियम मिनिटे/महिना. ऑन-डिव्हाइस टॅब अमर्यादित विनामूल्य ट्रान्सक्रिप्शन ऑफर करते. ';
 
   @override
-  String get audioProcessedLocally =>
-      'ऑडिओ स्थानिकरित्या प्रक्रिया केला जातो. ऑफलाइन कार्य करते, अधिक खाजगी, परंतु अधिक बॅटरी वापरते.';
+  String get audioProcessedLocally => 'ऑडिओ स्थानिकरित्या प्रक्रिया केला जातो. ऑफलाइन कार्य करते, अधिक खाजगी, परंतु अधिक बॅटरी वापरते.';
 
   @override
   String get languageLabel => 'भाषा';
@@ -6154,8 +6035,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get modelLabel => 'मॉडेल';
 
   @override
-  String get modelTooLargeWarning =>
-      'हा मॉडेल मोठा आहे आणि मोबाइल डिव्हाइसवर अ‍ॅप क्रॅश किंवा खूप मंद चालू शकतो.\n\n\"small\" किंवा \"base\" अनुशंसित आहे.';
+  String get modelTooLargeWarning => 'हा मॉडेल मोठा आहे आणि मोबाइल डिव्हाइसवर अ‍ॅप क्रॅश किंवा खूप मंद चालू शकतो.\n\n\"small\" किंवा \"base\" अनुशंसित आहे.';
 
   @override
   String get nativeEngineNoDownload => 'आपल्या डिव्हाइसचा नेटिव्ह स्पीच इंजिन वापरला जाईल. मॉडेल डाउनलोड आवश्यक नाही.';
@@ -6194,8 +6074,7 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi चा अंतर्निर्मित लाइव्ह ट्रान्सक्रिप्शन स्वयंचलित स्पीकर शोध आणि डायराइজेशनसह रिअल-टाइम संभाषणांसाठी अनुकूलित आहे.';
+  String get omiTranscriptionOptimized => 'Omi चा अंतर्निर्मित लाइव्ह ट्रान्सक्रिप्शन स्वयंचलित स्पीकर शोध आणि डायराइজेशनसह रिअल-टाइम संभाषणांसाठी अनुकूलित आहे.';
 
   @override
   String get reset => 'पुनःसेट करा';
@@ -6415,8 +6294,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'स्मृतीमधून आपला ज्ञान आलेख तयार करत आहे...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'आपल्या ज्ञान आलेखा स्वयंचलितपणे तयार केले जातील कारण आप नवीन स्मृती तयार करता.';
+  String get knowledgeGraphWillBuildAutomatically => 'आपल्या ज्ञान आलेखा स्वयंचलितपणे तयार केले जातील कारण आप नवीन स्मृती तयार करता.';
 
   @override
   String get buildGraphButton => 'आलेख तयार करा';
@@ -6652,8 +6530,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get failedToLoadContacts => 'संपर्क लोड करणे अयोग्य';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'शेअर करण्यासाठी संभाषण तयार करणे अयोग्य. कृपया पुन्हा प्रयत्न करा.';
+  String get failedToPrepareConversationForSharing => 'शेअर करण्यासाठी संभाषण तयार करणे अयोग्य. कृपया पुन्हा प्रयत्न करा.';
 
   @override
   String get couldNotOpenSmsApp => 'SMS अ‍ॅप उघडता येत नाही. कृपया पुन्हा प्रयत्न करा.';
@@ -6719,8 +6596,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'आपल्या डिव्हाइसच्या SD कार्डमधून ऑडिओ डाउनलोड करत आहे';
 
   @override
-  String get transferRequiredDescription =>
-      'हे रेकॉर्डिंग आपल्या डिव्हाइसच्या SD कार्डवर संग्रहित आहे. प्ले किंवा शेअर करण्यासाठी त्याचे आपल्या फोनवर स्थानांतर करा.';
+  String get transferRequiredDescription => 'हे रेकॉर्डिंग आपल्या डिव्हाइसच्या SD कार्डवर संग्रहित आहे. प्ले किंवा शेअर करण्यासाठी त्याचे आपल्या फोनवर स्थानांतर करा.';
 
   @override
   String get cancelTransfer => 'स्थानांतर रद्द करा';
@@ -6741,8 +6617,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get shareRecording => 'रेकॉर्डिंग शेयर करा';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'आपण खरोखर या रेकॉर्डिंगला कायमीपणे हटवू इच्छिता का? हे पूर्ववत करता येणार नाही.';
+  String get deleteRecordingConfirmation => 'आपण खरोखर या रेकॉर्डिंगला कायमीपणे हटवू इच्छिता का? हे पूर्ववत करता येणार नाही.';
 
   @override
   String get recordingIdLabel => 'रेकॉर्डिंग आयडी';
@@ -6801,15 +6676,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get enableFastTransfer => 'फास्ट ट्रांसफर सक्षम करा';
 
   @override
-  String get fastTransferDescription =>
-      'फास्ट ट्रांसफर WiFi वापरून ~5x वेगवान गती देतो. आपले फोन स्थानांतरणादरम्यान आपल्या Omi डिव्हाइसच्या WiFi नेटवर्कला तात्पुरते जोडेल.';
+  String get fastTransferDescription => 'फास्ट ट्रांसफर WiFi वापरून ~5x वेगवान गती देतो. आपले फोन स्थानांतरणादरम्यान आपल्या Omi डिव्हाइसच्या WiFi नेटवर्कला तात्पुरते जोडेल.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'स्थानांतरणादरम्यान इंटरनेट प्रवेश सक्षम केला आहे';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'आपल्या Omi डिव्हाइसमधून आपल्या फोनवर रेकॉर्डिंग कसे स्थानांतरित करायचे ते निवडा.';
+  String get chooseTransferMethodDescription => 'आपल्या Omi डिव्हाइसमधून आपल्या फोनवर रेकॉर्डिंग कसे स्थानांतरित करायचे ते निवडा.';
 
   @override
   String get wifiSpeed => 'WiFi द्वारे ~150 KB/s';
@@ -6818,8 +6691,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get fiveTimesFaster => '५X वेगवान';
 
   @override
-  String get fastTransferMethodDescription =>
-      'आपल्या Omi डिव्हाइसला थेट WiFi कनेक्शन तयार करते. स्थानांतरणादरम्यान आपले फोन आपल्या नियमित WiFi पासून तात्पुरते डिस्कनेक्ट होईल.';
+  String get fastTransferMethodDescription => 'आपल्या Omi डिव्हाइसला थेट WiFi कनेक्शन तयार करते. स्थानांतरणादरम्यान आपले फोन आपल्या नियमित WiFi पासून तात्पुरते डिस्कनेक्ट होईल.';
 
   @override
   String get bluetooth => 'ब्लूटूथ';
@@ -6828,8 +6700,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get bleSpeed => 'BLE द्वारे ~30 KB/s';
 
   @override
-  String get bluetoothMethodDescription =>
-      'मानक ब्लूटूथ कम ऊर्जा कनेक्शन वापरते. हळू पण आपल्या WiFi कनेक्शनवर परिणाम करत नाही.';
+  String get bluetoothMethodDescription => 'मानक ब्लूटूथ कम ऊर्जा कनेक्शन वापरते. हळू पण आपल्या WiFi कनेक्शनवर परिणाम करत नाही.';
 
   @override
   String get selected => 'निवडले';
@@ -6867,12 +6738,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get appDeleteFailed => 'अॅप हटवण्यात अयशस्वी. कृपया नंतर पुन्हा प्रयत्न करा.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'अॅप दृश्यमानता यशस्वीरित्या बदलली. प्रतिबिंबित होण्यास काही मिनिटे लागू शकतात.';
+  String get appVisibilityChangedSuccessfully => 'अॅप दृश्यमानता यशस्वीरित्या बदलली. प्रतिबिंबित होण्यास काही मिनिटे लागू शकतात.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'अॅप सक्रिय करण्यात त्रुटी. जर हे एकीकरण अॅप असेल तर सेटअप पूर्ण झाले आहे याची खात्री करा.';
+  String get errorActivatingAppIntegration => 'अॅप सक्रिय करण्यात त्रुटी. जर हे एकीकरण अॅप असेल तर सेटअप पूर्ण झाले आहे याची खात्री करा.';
 
   @override
   String get errorUpdatingAppStatus => 'अॅप स्थिती अपडेट करताना त्रुटी आली.';
@@ -6940,8 +6809,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get importantConversationTitle => 'महत्वाचे संभाषण';
 
   @override
-  String get importantConversationBody =>
-      'आप्पणे नुकताच एक महत्वाचे संभाषण केले. इतरांसह सारांश शेयर करण्यासाठी टॅप करा.';
+  String get importantConversationBody => 'आप्पणे नुकताच एक महत्वाचे संभाषण केले. इतरांसह सारांश शेयर करण्यासाठी टॅप करा.';
 
   @override
   String get templateName => 'टेम्पलेट नाव';
@@ -7035,8 +6903,7 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'फोटो परवानगी नाकारली गेली. प्रतिमा निवडण्यासाठी फोटोमध्ये प्रवेश अनुमती द्या';
+  String get addAppPhotosPermissionDenied => 'फोटो परवानगी नाकारली गेली. प्रतिमा निवडण्यासाठी फोटोमध्ये प्रवेश अनुमती द्या';
 
   @override
   String get addAppErrorSelectingImageRetry => 'प्रतिमा निवडण्यात त्रुटी. कृपया पुन्हा प्रयत्न करा.';
@@ -7141,15 +7008,13 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'अपग्रेड शेड्यूल केली! आपली मासिक योजना आपल्या बिलिंग कालावधीच्या शेवटपर्यंत चालू राहते, नंतर स्वयंचलितपणे वार्षिकमध्ये स्विच होते.';
+  String get planUpgradeScheduledMessage => 'अपग्रेड शेड्यूल केली! आपली मासिक योजना आपल्या बिलिंग कालावधीच्या शेवटपर्यंत चालू राहते, नंतर स्वयंचलितपणे वार्षिकमध्ये स्विच होते.';
 
   @override
   String get couldNotSchedulePlanChange => 'योजना बदल शेड्यूल करू शकत नाही. कृपया पुन्हा प्रयत्न करा.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'आपल्या सदस्यता पुन्हा सक्रिय केली गेली! आता कोणत्याही शुल्कास नाही - आपल्या वर्तमान कालावधीच्या शेवटी आपल्यास शुल्क दिले जाईल.';
+  String get subscriptionReactivatedDefault => 'आपल्या सदस्यता पुन्हा सक्रिय केली गेली! आता कोणत्याही शुल्कास नाही - आपल्या वर्तमान कालावधीच्या शेवटी आपल्यास शुल्क दिले जाईल.';
 
   @override
   String get subscriptionSuccessfulCharged => 'सदस्यता यशस्वी! आपल्यास नवीन बिलिंग कालावधीसाठी शुल्क दिले गेले आहे.';
@@ -7317,8 +7182,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get authFailedToRetrieveToken => 'firebase टोकन प्राप्त करण्यात अयशस्वी, कृपया पुन्हा प्रयत्न करा.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'साइन इन करताना अनपेक्षित त्रुटी, Firebase त्रुटी, कृपया पुन्हा प्रयत्न करा.';
+  String get authUnexpectedErrorFirebase => 'साइन इन करताना अनपेक्षित त्रुटी, Firebase त्रुटी, कृपया पुन्हा प्रयत्न करा.';
 
   @override
   String get authUnexpectedError => 'साइन इन करताना अनपेक्षित त्रुटी, कृपया पुन्हा प्रयत्न करा';
@@ -7333,8 +7197,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get onboardingBluetoothRequired => 'आपल्या डिव्हाइसला कनेक्ट करण्यासाठी ब्लूटूथ परवानगी आवश्यक आहे.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'ब्लूटूथ परवानगी नाकारली गेली. कृपया सिस्टम पसंदीमध्ये परवानगी द्या.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'ब्लूटूथ परवानगी नाकारली गेली. कृपया सिस्टम पसंदीमध्ये परवानगी द्या.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7347,12 +7210,10 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'सूचना परवानगी नाकारली गेली. कृपया सिस्टम पसंदीमध्ये परवानगी द्या.';
+  String get onboardingNotificationDeniedSystemPrefs => 'सूचना परवानगी नाकारली गेली. कृपया सिस्टम पसंदीमध्ये परवानगी द्या.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'सूचना परवानगी नाकारली गेली. कृपया सिस्टम पसंदी > सूचना मध्ये परवानगी द्या.';
+  String get onboardingNotificationDeniedNotifications => 'सूचना परवानगी नाकारली गेली. कृपया सिस्टम पसंदी > सूचना मध्ये परवानगी द्या.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7365,15 +7226,13 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'कृपया सेटिंग्ज > गोपनीयता आणि सुरक्षा > स्थान सेवा मध्ये स्थान परवानगी द्या';
+  String get onboardingLocationGrantInSettings => 'कृपया सेटिंग्ज > गोपनीयता आणि सुरक्षा > स्थान सेवा मध्ये स्थान परवानगी द्या';
 
   @override
   String get onboardingMicrophoneRequired => 'रेकॉर्डिंगसाठी मायक्रोफोन परवानगी आवश्यक आहे.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'मायक्रोफोन परवानगी नाकारली गेली. कृपया सिस्टम पसंदी > गोपनीयता आणि सुरक्षा > मायक्रोफोन मध्ये परवानगी द्या.';
+  String get onboardingMicrophoneDenied => 'मायक्रोफोन परवानगी नाकारली गेली. कृपया सिस्टम पसंदी > गोपनीयता आणि सुरक्षा > मायक्रोफोन मध्ये परवानगी द्या.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7389,8 +7248,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'प्रणाली ऑडिओ रेकॉर्डिंगसाठी स्क्रीन कॅप्चर परवानगी आवश्यक आहे.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'स्क्रीन कॅप्चर परवानगी नाकारली गेली. कृपया सिस्टम पसंदी > गोपनीयता आणि सुरक्षा > स्क्रीन रेकॉर्डिंग मध्ये परवानगी द्या.';
+  String get onboardingScreenCaptureDenied => 'स्क्रीन कॅप्चर परवानगी नाकारली गेली. कृपया सिस्टम पसंदी > गोपनीयता आणि सुरक्षा > स्क्रीन रेकॉर्डिंग मध्ये परवानगी द्या.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7443,8 +7301,7 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'फोटो परवानगी नाकारली गेली. प्रतिमा निवडण्यासाठी फोटोमध्ये प्रवेश अनुमती द्या';
+  String get msgPhotosPermissionDenied => 'फोटो परवानगी नाकारली गेली. प्रतिमा निवडण्यासाठी फोटोमध्ये प्रवेश अनुमती द्या';
 
   @override
   String get msgSelectImagesGenericError => 'प्रतिमा निवडण्यात त्रुटी. कृपया पुन्हा प्रयत्न करा.';
@@ -7516,8 +7373,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get locationPermissionRequired => 'स्थान परवानगी आवश्यक';
 
   @override
-  String get locationPermissionContent =>
-      'फास्ट ट्रांसफरला WiFi कनेक्शन सत्यापित करण्यासाठी स्थान परवानगी आवश्यक आहे. कृपया आगे जाण्यासाठी स्थान परवानगी द्या.';
+  String get locationPermissionContent => 'फास्ट ट्रांसफरला WiFi कनेक्शन सत्यापित करण्यासाठी स्थान परवानगी आवश्यक आहे. कृपया आगे जाण्यासाठी स्थान परवानगी द्या.';
 
   @override
   String get pdfTranscriptExport => 'ट्रान्सक्रिप्ट निर्यात';
@@ -7988,8 +7844,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note पेयरिंग मोडमध्ये ठेवा';
 
   @override
-  String get pairingDescPlaudNote =>
-      'बाजूचा बटण 2 सेकंडांसाठी दाबा आणि धरा. लाल LED जोडणीसाठी तयार असताना लगदगदी करेल.';
+  String get pairingDescPlaudNote => 'बाजूचा बटण 2 सेकंडांसाठी दाबा आणि धरा. लाल LED जोडणीसाठी तयार असताना लगदगदी करेल.';
 
   @override
   String get pairingTitleBee => 'Bee पेयरिंग मोडमध्ये ठेवा';
@@ -8001,15 +7856,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get pairingTitleLimitless => 'Limitless पेयरिंग मोडमध्ये ठेवा';
 
   @override
-  String get pairingDescLimitless =>
-      'जेव्हा कोणताही प्रकाश दिसत असेल तेव्हा एकदा दाबा आणि नंतर गुलाबी प्रकाश दिसेपर्यंत दाबा आणि धरा, नंतर सोडा.';
+  String get pairingDescLimitless => 'जेव्हा कोणताही प्रकाश दिसत असेल तेव्हा एकदा दाबा आणि नंतर गुलाबी प्रकाश दिसेपर्यंत दाबा आणि धरा, नंतर सोडा.';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant पेयरिंग मोडमध्ये ठेवा';
 
   @override
-  String get pairingDescFriendPendant =>
-      'लटकनीवरील बटण दाबा ते चालू करण्यासाठी. ते स्वयंचलितपणे पेयरिंग मोडमध्ये प्रवेश करेल.';
+  String get pairingDescFriendPendant => 'लटकनीवरील बटण दाबा ते चालू करण्यासाठी. ते स्वयंचलितपणे पेयरिंग मोडमध्ये प्रवेश करेल.';
 
   @override
   String get pairingTitleFieldy => 'Fieldy पेयरिंग मोडमध्ये ठेवा';
@@ -8144,8 +7997,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get switchAndRestart => 'स्विच करा';
 
   @override
-  String get stagingDisclaimer =>
-      'स्टेजिंग बगी असू शकते, अयोग्य कार्यक्षमता असू शकते आणि डेटा हरवू शकते. फक्त चाचणीसाठी वापरा.';
+  String get stagingDisclaimer => 'स्टेजिंग बगी असू शकते, अयोग्य कार्यक्षमता असू शकते आणि डेटा हरवू शकते. फक्त चाचणीसाठी वापरा.';
 
   @override
   String get apiEnvSavedRestartRequired => 'सेव केले गेले. लागू करण्यासाठी अॅप बंद आणि पुन्हा उघडा.';
@@ -8374,8 +8226,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Omi द्वारे फोन कॉल';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Omi द्वारे कॉल करा आणि वास्तविक-वेळ ट्रांसक्रिप्शन, स्वयंचलित सारांश आणि बरेच काही मिळवा. Unlimited योजना ग्राहकांसाठी विशेषरित्या उपलब्ध.';
+  String get phoneCallsUpsellSubtitle => 'Omi द्वारे कॉल करा आणि वास्तविक-वेळ ट्रांसक्रिप्शन, स्वयंचलित सारांश आणि बरेच काही मिळवा. Unlimited योजना ग्राहकांसाठी विशेषरित्या उपलब्ध.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'प्रत्येक कॉलचे वास्तविक-वेळ ट्रांसक्रिप्शन';
@@ -8402,8 +8253,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deleteSyncedFiles => 'सिंक केलेली रेकॉर्डिंग हटवा';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'या रेकॉर्डिंग आधीच तुमच्या फोनशी सिंक केली गेली आहेत. हे पूर्ववत् केले जाऊ शकत नाही.';
+  String get deleteSyncedFilesMessage => 'या रेकॉर्डिंग आधीच तुमच्या फोनशी सिंक केली गेली आहेत. हे पूर्ववत् केले जाऊ शकत नाही.';
 
   @override
   String get syncedFilesDeleted => 'सिंक केलेली रेकॉर्डिंग हटवली गेली';
@@ -8415,8 +8265,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deletePendingFiles => 'प्रलंबित रेकॉर्डिंग हटवा';
 
   @override
-  String get deletePendingFilesWarning =>
-      'या रेकॉर्डिंग तुमच्या फोनशी सिंक केल्या गेल्या नाहीत आणि कायमचे हरवली जातील. हे पूर्ववत् केले जाऊ शकत नाही.';
+  String get deletePendingFilesWarning => 'या रेकॉर्डिंग तुमच्या फोनशी सिंक केल्या गेल्या नाहीत आणि कायमचे हरवली जातील. हे पूर्ववत् केले जाऊ शकत नाही.';
 
   @override
   String get pendingFilesDeleted => 'प्रलंबित रेकॉर्डिंग हटवली गेली';
@@ -8428,8 +8277,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deleteAll => 'सर्व हटवा';
 
   @override
-  String get deleteAllFilesWarning =>
-      'हे सिंक केलेली आणि प्रलंबित दोन्ही रेकॉर्डिंग हटवेल. प्रलंबित रेकॉर्डिंग सिंक केलेली नाहीत आणि कायमचे हरवली जातील. हे पूर्ववत् केले जाऊ शकत नाही.';
+  String get deleteAllFilesWarning => 'हे सिंक केलेली आणि प्रलंबित दोन्ही रेकॉर्डिंग हटवेल. प्रलंबित रेकॉर्डिंग सिंक केलेली नाहीत आणि कायमचे हरवली जातील. हे पूर्ववत् केले जाऊ शकत नाही.';
 
   @override
   String get allFilesDeleted => 'सर्व रेकॉर्डिंग हटवली गेली';
@@ -8494,8 +8342,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get fairUseAboutTitle => 'न्याय्य वापराविषयी';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi व्यक्तिगत संभाषण, बैठक आणि लाइव संवादसाठी डिজाइन केले गेले आहे. वापर वास्तविक भाषण वेळ द्वारे मोजला जातो, जोडणी वेळ नाही. जर वापर गैर-व्यक्तिगत सामग्रीसाठी सामान्य पॅटर्नचा बराच अधिक असेल तर समायोजन लागू होऊ शकते.';
+  String get fairUseAboutBody => 'Omi व्यक्तिगत संभाषण, बैठक आणि लाइव संवादसाठी डिজाइन केले गेले आहे. वापर वास्तविक भाषण वेळ द्वारे मोजला जातो, जोडणी वेळ नाही. जर वापर गैर-व्यक्तिगत सामग्रीसाठी सामान्य पॅटर्नचा बराच अधिक असेल तर समायोजन लागू होऊ शकते.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8533,8 +8380,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get improveConnectionTitle => 'जोडणी सुधारा';
 
   @override
-  String get improveConnectionContent =>
-      'आम्ही Omi तुमच्या डिव्हाइसशी जोडून ठेवण्याचे तरीके सुधारले आहे. हे सक्रिय करण्यासाठी, कृपया डिव्हाइस माहिती पृष्ठावर जा, \"डिव्हाइस डिस्कनेक्ट करा\" टॅप करा आणि नंतर तुमचे डिव्हाइस पुन्हा जोडा.';
+  String get improveConnectionContent => 'आम्ही Omi तुमच्या डिव्हाइसशी जोडून ठेवण्याचे तरीके सुधारले आहे. हे सक्रिय करण्यासाठी, कृपया डिव्हाइस माहिती पृष्ठावर जा, \"डिव्हाइस डिस्कनेक्ट करा\" टॅप करा आणि नंतर तुमचे डिव्हाइस पुन्हा जोडा.';
 
   @override
   String get improveConnectionAction => 'समजले';
@@ -8589,16 +8435,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get cancelSyncQuestion => 'सिंक रद्द करा?';
 
   @override
-  String get omisStorageDesc =>
-      'जेव्हा तुमचा Omi तुमच्या फोनशी जोडलेला नसतो तेव्हा ते त्याच्या अंतर्निर्मित स्मृतीमध्ये ऑडिओ स्थानिकपणे संचयित करतो. तू कधीही रेकॉर्डिंग हरावतोस नाही.';
+  String get omisStorageDesc => 'जेव्हा तुमचा Omi तुमच्या फोनशी जोडलेला नसतो तेव्हा ते त्याच्या अंतर्निर्मित स्मृतीमध्ये ऑडिओ स्थानिकपणे संचयित करतो. तू कधीही रेकॉर्डिंग हरावतोस नाही.';
 
   @override
-  String get phoneStorageDesc =>
-      'जेव्हा Omi पुन्हा जोडते तेव्हा, रेकॉर्डिंग स्वयंचलितपणे तुमच्या फोनमध्ये हस्तांतरित केली जातात. अपलोडिंगपूर्वी हे एक तात्पुरते धारण क्षेत्र असते.';
+  String get phoneStorageDesc => 'जेव्हा Omi पुन्हा जोडते तेव्हा, रेकॉर्डिंग स्वयंचलितपणे तुमच्या फोनमध्ये हस्तांतरित केली जातात. अपलोडिंगपूर्वी हे एक तात्पुरते धारण क्षेत्र असते.';
 
   @override
-  String get cloudStorageDesc =>
-      'अपलोड केल्यानंतर, तुमच्या रेकॉर्डिंग प्रक्रिया केली जातात आणि लिखित केली जातात. संभाषण एक मिनिटामध्ये उपलब्ध असतील.';
+  String get cloudStorageDesc => 'अपलोड केल्यानंतर, तुमच्या रेकॉर्डिंग प्रक्रिया केली जातात आणि लिखित केली जातात. संभाषण एक मिनिटामध्ये उपलब्ध असतील.';
 
   @override
   String get tipKeepPhoneNearby => 'तेजस्वी सिंकिंगसाठी तुमचा फोन जवळ ठेवा';
@@ -8622,12 +8465,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get permissionEnable => 'सक्षम करा';
 
   @override
-  String get permissionsPageDescription =>
-      'या परवानगी Omi कसे काम करते याचे मूल आहेत. ते सूचना, स्थान-आधारित अनुभव आणि ऑडिओ कॅप्चर सारख्या मुख्य वैशिष्ट्य सक्षम करतात.';
+  String get permissionsPageDescription => 'या परवानगी Omi कसे काम करते याचे मूल आहेत. ते सूचना, स्थान-आधारित अनुभव आणि ऑडिओ कॅप्चर सारख्या मुख्य वैशिष्ट्य सक्षम करतात.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi योग्यरित्या काम करण्यासाठी काही परवानगी आवश्यक आहे. कृपया सुरू ठेवण्यासाठी त्यांना दे.';
+  String get permissionsRequiredDescription => 'Omi योग्यरित्या काम करण्यासाठी काही परवानगी आवश्यक आहे. कृपया सुरू ठेवण्यासाठी त्यांना दे.';
 
   @override
   String get permissionsSetupTitle => 'सर्वोत्तम अनुभव मिळवा';
@@ -8904,8 +8745,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get firmwareWarningTitle => 'महत्त्वाचे: अपडेट करण्यापूर्वी वाचा';
 
   @override
-  String get firmwareFormatWarning =>
-      'हे फर्मवेअर SD कार्ड फॉर्मेट करेल. कृपया अपग्रेड करण्यापूर्वी सर्व ऑफलाइन डेटा सिंक झाला आहे याची खात्री करा.\n\nहा आवृत्ती इंस्टॉल केल्यानंतर लाल दिवा चमकत असल्यास काळजी करू नका. फक्त डिव्हाइस अ‍ॅपशी कनेक्ट करा आणि ते निळे व्हायला हवे. लाल दिवा म्हणजे डिव्हाइसचे घड्याळ अजून सिंक झालेले नाही.';
+  String get firmwareFormatWarning => 'हे फर्मवेअर SD कार्ड फॉर्मेट करेल. कृपया अपग्रेड करण्यापूर्वी सर्व ऑफलाइन डेटा सिंक झाला आहे याची खात्री करा.\n\nहा आवृत्ती इंस्टॉल केल्यानंतर लाल दिवा चमकत असल्यास काळजी करू नका. फक्त डिव्हाइस अ‍ॅपशी कनेक्ट करा आणि ते निळे व्हायला हवे. लाल दिवा म्हणजे डिव्हाइसचे घड्याळ अजून सिंक झालेले नाही.';
 
   @override
   String get continueAnyway => 'पुढे सुरू ठेवा';
@@ -8925,8 +8765,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get tasksMarkComplete => 'पूर्ण म्हणून चिन्हांकित';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi Apple च्या HealthKit फ्रेमवर्कद्वारे Apple Health ला प्रवेश करतो. आपण कोणत्याही वेळी iOS सेटिंग्जमधून प्रवेश रद्द करू शकता.';
+  String get appleHealthManageNote => 'Omi Apple च्या HealthKit फ्रेमवर्कद्वारे Apple Health ला प्रवेश करतो. आपण कोणत्याही वेळी iOS सेटिंग्जमधून प्रवेश रद्द करू शकता.';
 
   @override
   String get appleHealthConnectCta => 'Apple Health शी कनेक्ट करा';
@@ -8959,8 +8798,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health प्रवेश नाकारला';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi कडे आपला Apple Health डेटा वाचण्याची परवानगी नाही. iOS सेटिंग्ज → गोपनीयता आणि सुरक्षा → Health → Omi मध्ये ते सक्षम करा.';
+  String get appleHealthDeniedBody => 'Omi कडे आपला Apple Health डेटा वाचण्याची परवानगी नाही. iOS सेटिंग्ज → गोपनीयता आणि सुरक्षा → Health → Omi मध्ये ते सक्षम करा.';
 
   @override
   String get deleteFlowReasonTitle => 'तुम्ही का सोडत आहात?';
@@ -9029,8 +8867,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get planUpdate => 'प्लॅन अपडेट';
 
   @override
-  String get planDeprecationMessage =>
-      'तुमचा Unlimited प्लॅन बंद केला जात आहे. Operator प्लॅनवर स्विच करा — तेच उत्कृष्ट वैशिष्ट्ये \$49/महिना. तुमचा सध्याचा प्लॅन तोपर्यंत काम करत राहील.';
+  String get planDeprecationMessage => 'तुमचा Unlimited प्लॅन बंद केला जात आहे. Operator प्लॅनवर स्विच करा — तेच उत्कृष्ट वैशिष्ट्ये \$49/महिना. तुमचा सध्याचा प्लॅन तोपर्यंत काम करत राहील.';
 
   @override
   String get upgradeYourPlan => 'तुमचा प्लॅन अपग्रेड करा';
@@ -9141,8 +8978,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'तुम्ही तुमची मासिक मर्यादा गाठली आहे. निर्बंधांशिवाय Omi सोबत चॅट सुरू ठेवण्यासाठी अपग्रेड करा.';
+  String get chatQuotaExceededReply => 'तुम्ही तुमची मासिक मर्यादा गाठली आहे. निर्बंधांशिवाय Omi सोबत चॅट सुरू ठेवण्यासाठी अपग्रेड करा.';
 
   @override
   String get voiceResponseAudio => 'Omi चे उत्तर मोठ्याने वाचा';
@@ -9173,4 +9009,25 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'कार्य जोडा';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi ला काहीही विचारा';
+
+  @override
+  String get quickActionVoiceMode => 'आवाज मोड';
+
+  @override
+  String get quickActionMute => 'म्यूट करा';
+
+  @override
+  String get quickActionUnmute => 'म्यूट रद्द करा';
+
+  @override
+  String get quickActionConnectDevice => 'डिव्हाइस जोडा';
+
+  @override
+  String get quickActionDeviceSettings => 'डिव्हाइस सेटिंग्ज';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -24,8 +24,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deleteConversationTitle => 'Padam Perbualan?';
 
   @override
-  String get deleteConversationMessage =>
-      'Ini juga akan memadam kenangan, tugasan dan fail audio yang berkaitan. Tindakan ini tidak boleh dibatalkan.';
+  String get deleteConversationMessage => 'Ini juga akan memadam kenangan, tugasan dan fail audio yang berkaitan. Tindakan ini tidak boleh dibatalkan.';
 
   @override
   String get confirm => 'Sahkan';
@@ -146,8 +145,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deleting => 'Memadam...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
+  String get pleaseCompleteAuthentication => 'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
 
   @override
   String get failedToStartAuthentication => 'Gagal memulakan pengesahan';
@@ -319,8 +317,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get installedApps => 'Aplikasi Dipasang';
 
   @override
-  String get unableToFetchApps =>
-      'Tidak dapat mendapatkan aplikasi :(\n\nSila semak sambungan internet anda dan cuba lagi.';
+  String get unableToFetchApps => 'Tidak dapat mendapatkan aplikasi :(\n\nSila semak sambungan internet anda dan cuba lagi.';
 
   @override
   String get aboutOmi => 'Tentang Omi';
@@ -356,19 +353,16 @@ class AppLocalizationsMs extends AppLocalizations {
   String get appsDisconnected => 'Aplikasi dan Integrasi anda akan diputuskan sambungan dengan serta-merta.';
 
   @override
-  String get exportBeforeDelete =>
-      'Anda boleh mengeksport data anda sebelum memadam akaun anda, tetapi setelah dipadam, ia tidak boleh dipulihkan.';
+  String get exportBeforeDelete => 'Anda boleh mengeksport data anda sebelum memadam akaun anda, tetapi setelah dipadam, ia tidak boleh dipulihkan.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Saya faham bahawa memadam akaun saya adalah kekal dan semua data, termasuk ingatan dan perbualan, akan hilang dan tidak boleh dipulihkan.';
+  String get deleteAccountCheckbox => 'Saya faham bahawa memadam akaun saya adalah kekal dan semua data, termasuk ingatan dan perbualan, akan hilang dan tidak boleh dipulihkan.';
 
   @override
   String get areYouSure => 'Adakah anda pasti?';
 
   @override
-  String get deleteAccountFinal =>
-      'Tindakan ini tidak boleh diterbalikkan dan akan memadam akaun anda dan semua data berkaitan secara kekal. Adakah anda pasti mahu meneruskan?';
+  String get deleteAccountFinal => 'Tindakan ini tidak boleh diterbalikkan dan akan memadam akaun anda dan semua data berkaitan secara kekal. Adakah anda pasti mahu meneruskan?';
 
   @override
   String get deleteNow => 'Padam Sekarang';
@@ -377,8 +371,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get goBack => 'Kembali';
 
   @override
-  String get checkBoxToConfirm =>
-      'Tandakan kotak untuk mengesahkan anda faham bahawa memadam akaun anda adalah kekal dan tidak boleh diterbalikkan.';
+  String get checkBoxToConfirm => 'Tandakan kotak untuk mengesahkan anda faham bahawa memadam akaun anda adalah kekal dan tidak boleh diterbalikkan.';
 
   @override
   String get profile => 'Profil';
@@ -456,8 +449,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get yourPrivacyYourControl => 'Privasi Anda, Kawalan Anda';
 
   @override
-  String get privacyIntro =>
-      'Di Omi, kami komited untuk melindungi privasi anda. Halaman ini membolehkan anda mengawal cara data anda disimpan dan digunakan.';
+  String get privacyIntro => 'Di Omi, kami komited untuk melindungi privasi anda. Halaman ini membolehkan anda mengawal cara data anda disimpan dan digunakan.';
 
   @override
   String get learnMore => 'Ketahui lebih lanjut...';
@@ -466,15 +458,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get dataProtectionLevel => 'Tahap Perlindungan Data';
 
   @override
-  String get dataProtectionDesc =>
-      'Data anda dijamin secara lalai dengan penyulitan yang kukuh. Semak tetapan dan pilihan privasi masa depan anda di bawah.';
+  String get dataProtectionDesc => 'Data anda dijamin secara lalai dengan penyulitan yang kukuh. Semak tetapan dan pilihan privasi masa depan anda di bawah.';
 
   @override
   String get appAccess => 'Akses Aplikasi';
 
   @override
-  String get appAccessDesc =>
-      'Aplikasi berikut boleh mengakses data anda. Ketik pada aplikasi untuk mengurus keizinannya.';
+  String get appAccessDesc => 'Aplikasi berikut boleh mengakses data anda. Ketik pada aplikasi untuk mengurus keizinannya.';
 
   @override
   String get noAppsExternalAccess => 'Tiada aplikasi yang dipasang mempunyai akses luaran ke data anda.';
@@ -531,15 +521,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Omi anda telah diputuskan sambungan 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Peranti dinyahpasangkan. Pergi ke Tetapan > Bluetooth dan lupakan peranti untuk melengkapkan penyahpasangan.';
+  String get deviceUnpairedMessage => 'Peranti dinyahpasangkan. Pergi ke Tetapan > Bluetooth dan lupakan peranti untuk melengkapkan penyahpasangan.';
 
   @override
   String get unpairDialogTitle => 'Nyahpasang Peranti';
 
   @override
-  String get unpairDialogMessage =>
-      'Ini akan menyahpasangkan peranti supaya ia boleh disambungkan ke telefon lain. Anda perlu pergi ke Tetapan > Bluetooth dan lupakan peranti untuk melengkapkan proses.';
+  String get unpairDialogMessage => 'Ini akan menyahpasangkan peranti supaya ia boleh disambungkan ke telefon lain. Anda perlu pergi ke Tetapan > Bluetooth dan lupakan peranti untuk melengkapkan proses.';
 
   @override
   String get deviceNotConnected => 'Peranti Tidak Disambungkan';
@@ -560,8 +548,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get v2Undetected => 'V2 tidak dikesan';
 
   @override
-  String get v2UndetectedMessage =>
-      'Kami lihat anda sama ada mempunyai peranti V1 atau peranti anda tidak disambungkan. Fungsi Kad SD hanya tersedia untuk peranti V2.';
+  String get v2UndetectedMessage => 'Kami lihat anda sama ada mempunyai peranti V1 atau peranti anda tidak disambungkan. Fungsi Kad SD hanya tersedia untuk peranti V2.';
 
   @override
   String get endConversation => 'Tamatkan Perbualan';
@@ -693,8 +680,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get noActivityYet => 'Tiada Aktiviti Lagi';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Mulakan perbualan dengan Omi\nuntuk melihat wawasan penggunaan anda di sini.';
+  String get startConversationToSeeInsights => 'Mulakan perbualan dengan Omi\nuntuk melihat wawasan penggunaan anda di sini.';
 
   @override
   String get listening => 'Mendengar';
@@ -836,8 +822,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Padam Graf Pengetahuan?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Ini akan memadam semua data graf pengetahuan terbitan (nod dan sambungan). Ingatan asal anda akan kekal selamat. Graf akan dibina semula dari semasa ke semasa atau atas permintaan seterusnya.';
+  String get deleteKnowledgeGraphMessage => 'Ini akan memadam semua data graf pengetahuan terbitan (nod dan sambungan). Ingatan asal anda akan kekal selamat. Graf akan dibina semula dari semasa ke semasa atau atas permintaan seterusnya.';
 
   @override
   String get knowledgeGraphDeleted => 'Graf pengetahuan dipadamkan';
@@ -985,8 +970,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get shortConversationThreshold => 'Ambang Perbualan Pendek';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Perbualan yang lebih pendek daripada ini akan disembunyikan melainkan didayakan di atas';
+  String get shortConversationThresholdSubtitle => 'Perbualan yang lebih pendek daripada ini akan disembunyikan melainkan didayakan di atas';
 
   @override
   String get durationThreshold => 'Ambang Tempoh';
@@ -1021,8 +1005,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get integrationsFooter => 'Sambungkan aplikasi anda untuk melihat data dan metrik dalam sembang.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
+  String get completeAuthInBrowser => 'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1082,8 +1065,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get needYourPermission => 'Kami memerlukan kebenaran anda';
 
   @override
-  String get alreadyGavePermission =>
-      'Anda telah memberi kami kebenaran untuk menyimpan rakaman anda. Berikut adalah peringatan mengapa kami memerlukannya:';
+  String get alreadyGavePermission => 'Anda telah memberi kami kebenaran untuk menyimpan rakaman anda. Berikut adalah peringatan mengapa kami memerlukannya:';
 
   @override
   String get wouldLikePermission => 'Kami ingin kebenaran anda untuk menyimpan rakaman suara anda. Sebabnya:';
@@ -1092,26 +1074,22 @@ class AppLocalizationsMs extends AppLocalizations {
   String get improveSpeechProfile => 'Tingkatkan Profil Pertuturan Anda';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Kami menggunakan rakaman untuk melatih dan meningkatkan profil pertuturan peribadi anda.';
+  String get improveSpeechProfileDesc => 'Kami menggunakan rakaman untuk melatih dan meningkatkan profil pertuturan peribadi anda.';
 
   @override
   String get trainFamilyProfiles => 'Latih Profil untuk Rakan dan Keluarga';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Rakaman anda membantu kami mengenali dan mencipta profil untuk rakan dan keluarga anda.';
+  String get trainFamilyProfilesDesc => 'Rakaman anda membantu kami mengenali dan mencipta profil untuk rakan dan keluarga anda.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Tingkatkan Ketepatan Transkrip';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Apabila model kami bertambah baik, kami boleh memberikan hasil transkripsi yang lebih baik untuk rakaman anda.';
+  String get enhanceTranscriptAccuracyDesc => 'Apabila model kami bertambah baik, kami boleh memberikan hasil transkripsi yang lebih baik untuk rakaman anda.';
 
   @override
-  String get legalNotice =>
-      'Notis Undang-undang: Kesahihan merakam dan menyimpan data suara mungkin berbeza bergantung pada lokasi anda dan cara anda menggunakan ciri ini. Adalah tanggungjawab anda untuk memastikan pematuhan undang-undang dan peraturan tempatan.';
+  String get legalNotice => 'Notis Undang-undang: Kesahihan merakam dan menyimpan data suara mungkin berbeza bergantung pada lokasi anda dan cara anda menggunakan ciri ini. Adalah tanggungjawab anda untuk memastikan pematuhan undang-undang dan peraturan tempatan.';
 
   @override
   String get alreadyAuthorized => 'Sudah Dibenarkan';
@@ -1183,15 +1161,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get showMeetingsMenuBar => 'Tunjukkan mesyuarat akan datang di bar menu';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Paparkan mesyuarat seterusnya anda dan masa sehingga ia bermula di bar menu macOS';
+  String get showMeetingsMenuBarDesc => 'Paparkan mesyuarat seterusnya anda dan masa sehingga ia bermula di bar menu macOS';
 
   @override
   String get showEventsNoParticipants => 'Tunjukkan acara tanpa peserta';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Apabila didayakan, Coming Up menunjukkan acara tanpa peserta atau pautan video.';
+  String get showEventsNoParticipantsDesc => 'Apabila didayakan, Coming Up menunjukkan acara tanpa peserta atau pautan video.';
 
   @override
   String get yourMeetings => 'Mesyuarat Anda';
@@ -1232,8 +1208,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get noProjectsInWorkspace => 'Tiada projek dijumpai dalam ruang kerja ini';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Pilih berapa lama untuk menunggu dalam senyap sebelum menamatkan perbualan secara automatik:';
+  String get conversationTimeoutDesc => 'Pilih berapa lama untuk menunggu dalam senyap sebelum menamatkan perbualan secara automatik:';
 
   @override
   String get timeout2Minutes => '2 minit';
@@ -1277,12 +1252,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Beritahu kami bahasa utama anda';
 
   @override
-  String get languageForTranscription =>
-      'Tetapkan bahasa anda untuk transkripsi yang lebih tajam dan pengalaman yang diperibadikan.';
+  String get languageForTranscription => 'Tetapkan bahasa anda untuk transkripsi yang lebih tajam dan pengalaman yang diperibadikan.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Mod Bahasa Tunggal didayakan. Terjemahan dilumpuhkan untuk ketepatan yang lebih tinggi.';
+  String get singleLanguageModeInfo => 'Mod Bahasa Tunggal didayakan. Terjemahan dilumpuhkan untuk ketepatan yang lebih tinggi.';
 
   @override
   String get searchLanguageHint => 'Cari bahasa mengikut nama atau kod';
@@ -1362,8 +1335,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get defaultRepository => 'Repositori Lalai';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Pilih repositori lalai untuk mencipta isu. Anda masih boleh menyatakan repositori yang berbeza semasa mencipta isu.';
+  String get selectDefaultRepoDesc => 'Pilih repositori lalai untuk mencipta isu. Anda masih boleh menyatakan repositori yang berbeza semasa mencipta isu.';
 
   @override
   String get noReposFound => 'Tiada repositori dijumpai';
@@ -1410,8 +1382,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get configureSettings => 'Konfigurasikan Tetapan';
 
   @override
-  String get completeAuthBrowser =>
-      'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
+  String get completeAuthBrowser => 'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1739,8 +1710,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get enableBluetooth => 'Dayakan Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi memerlukan Bluetooth untuk menyambung ke peranti boleh pakai anda. Sila dayakan Bluetooth dan cuba lagi.';
+  String get bluetoothNeeded => 'Omi memerlukan Bluetooth untuk menyambung ke peranti boleh pakai anda. Sila dayakan Bluetooth dan cuba lagi.';
 
   @override
   String get contactSupport => 'Hubungi Sokongan?';
@@ -1773,26 +1743,22 @@ class AppLocalizationsMs extends AppLocalizations {
   String get locationServiceDisabled => 'Perkhidmatan Lokasi Dilumpuhkan';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Perkhidmatan Lokasi dilumpuhkan. Sila pergi ke Tetapan > Privasi & Keselamatan > Perkhidmatan Lokasi dan dayakannya';
+  String get locationServiceDisabledDesc => 'Perkhidmatan Lokasi dilumpuhkan. Sila pergi ke Tetapan > Privasi & Keselamatan > Perkhidmatan Lokasi dan dayakannya';
 
   @override
   String get backgroundLocationDenied => 'Akses Lokasi Latar Belakang Ditolak';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Sila pergi ke tetapan peranti dan tetapkan kebenaran lokasi kepada \"Sentiasa Benarkan\"';
+  String get backgroundLocationDeniedDesc => 'Sila pergi ke tetapan peranti dan tetapkan kebenaran lokasi kepada \"Sentiasa Benarkan\"';
 
   @override
   String get lovingOmi => 'Suka Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Bantu kami menjangkau lebih ramai orang dengan meninggalkan ulasan di App Store. Maklum balas anda sangat bermakna bagi kami!';
+  String get leaveReviewIos => 'Bantu kami menjangkau lebih ramai orang dengan meninggalkan ulasan di App Store. Maklum balas anda sangat bermakna bagi kami!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Bantu kami menjangkau lebih ramai orang dengan meninggalkan ulasan di Google Play Store. Maklum balas anda sangat bermakna bagi kami!';
+  String get leaveReviewAndroid => 'Bantu kami menjangkau lebih ramai orang dengan meninggalkan ulasan di Google Play Store. Maklum balas anda sangat bermakna bagi kami!';
 
   @override
   String get rateOnAppStore => 'Nilai di App Store';
@@ -1831,22 +1797,19 @@ class AppLocalizationsMs extends AppLocalizations {
   String get invalidRecordingMultipleSpeakers => 'Rakaman tidak sah dikesan';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Nampaknya terdapat beberapa penutur dalam rakaman. Sila pastikan anda berada di lokasi yang senyap dan cuba lagi.';
+  String get multipleSpeakersDesc => 'Nampaknya terdapat beberapa penutur dalam rakaman. Sila pastikan anda berada di lokasi yang senyap dan cuba lagi.';
 
   @override
   String get tooShortDesc => 'Tidak cukup pertuturan dikesan. Sila bercakap lebih banyak dan cuba lagi.';
 
   @override
-  String get invalidRecordingDesc =>
-      'Sila pastikan anda bercakap sekurang-kurangnya 5 saat dan tidak lebih daripada 90.';
+  String get invalidRecordingDesc => 'Sila pastikan anda bercakap sekurang-kurangnya 5 saat dan tidak lebih daripada 90.';
 
   @override
   String get areYouThere => 'Adakah anda di sana?';
 
   @override
-  String get noSpeechDesc =>
-      'Kami tidak dapat mengesan sebarang pertuturan. Sila pastikan untuk bercakap sekurang-kurangnya 10 saat dan tidak lebih daripada 3 minit.';
+  String get noSpeechDesc => 'Kami tidak dapat mengesan sebarang pertuturan. Sila pastikan untuk bercakap sekurang-kurangnya 10 saat dan tidak lebih daripada 3 minit.';
 
   @override
   String get connectionLost => 'Sambungan Terputus';
@@ -1867,8 +1830,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get permissionsRequired => 'Kebenaran diperlukan';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Aplikasi ini memerlukan kebenaran Bluetooth dan Lokasi untuk berfungsi dengan betul. Sila dayakannya dalam tetapan.';
+  String get permissionsRequiredDesc => 'Aplikasi ini memerlukan kebenaran Bluetooth dan Lokasi untuk berfungsi dengan betul. Sila dayakannya dalam tetapan.';
 
   @override
   String get openSettings => 'Buka Tetapan';
@@ -1910,12 +1872,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get microphonePermission => 'Kebenaran Mikrofon';
 
   @override
-  String get permissionGrantedNow =>
-      'Kebenaran diberikan! Sekarang:\n\nBuka aplikasi Omi pada jam tangan anda dan ketik \"Teruskan\" di bawah';
+  String get permissionGrantedNow => 'Kebenaran diberikan! Sekarang:\n\nBuka aplikasi Omi pada jam tangan anda dan ketik \"Teruskan\" di bawah';
 
   @override
-  String get needMicrophonePermission =>
-      'Kami memerlukan kebenaran mikrofon.\n\n1. Ketik \"Berikan Kebenaran\"\n2. Benarkan pada iPhone anda\n3. Aplikasi jam tangan akan ditutup\n4. Buka semula dan ketik \"Teruskan\"';
+  String get needMicrophonePermission => 'Kami memerlukan kebenaran mikrofon.\n\n1. Ketik \"Berikan Kebenaran\"\n2. Benarkan pada iPhone anda\n3. Aplikasi jam tangan akan ditutup\n4. Buka semula dan ketik \"Teruskan\"';
 
   @override
   String get grantPermissionButton => 'Berikan Kebenaran';
@@ -1924,15 +1884,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get needHelp => 'Perlukan Bantuan?';
 
   @override
-  String get troubleshootingSteps =>
-      'Penyelesaian Masalah:\n\n1. Pastikan Omi dipasang pada jam tangan anda\n2. Buka aplikasi Omi pada jam tangan anda\n3. Cari popup kebenaran\n4. Ketik \"Benarkan\" apabila diminta\n5. Aplikasi pada jam tangan anda akan ditutup - buka semula\n6. Kembali dan ketik \"Teruskan\" pada iPhone anda';
+  String get troubleshootingSteps => 'Penyelesaian Masalah:\n\n1. Pastikan Omi dipasang pada jam tangan anda\n2. Buka aplikasi Omi pada jam tangan anda\n3. Cari popup kebenaran\n4. Ketik \"Benarkan\" apabila diminta\n5. Aplikasi pada jam tangan anda akan ditutup - buka semula\n6. Kembali dan ketik \"Teruskan\" pada iPhone anda';
 
   @override
   String get recordingStartedSuccessfully => 'Rakaman bermula dengan jayanya!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Kebenaran belum diberikan. Sila pastikan anda membenarkan akses mikrofon dan membuka semula aplikasi pada jam tangan anda.';
+  String get permissionNotGrantedYet => 'Kebenaran belum diberikan. Sila pastikan anda membenarkan akses mikrofon dan membuka semula aplikasi pada jam tangan anda.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1948,8 +1906,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get selectPrimaryLanguage => 'Pilih bahasa utama anda';
 
   @override
-  String get languageBenefits =>
-      'Tetapkan bahasa anda untuk transkripsi yang lebih tajam dan pengalaman yang diperibadikan';
+  String get languageBenefits => 'Tetapkan bahasa anda untuk transkripsi yang lebih tajam dan pengalaman yang diperibadikan';
 
   @override
   String get whatsYourPrimaryLanguage => 'Apakah bahasa utama anda?';
@@ -1958,8 +1915,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get selectYourLanguage => 'Pilih bahasa anda';
 
   @override
-  String get personalGrowthJourney =>
-      'Perjalanan pertumbuhan peribadi anda dengan AI yang mendengar setiap perkataan anda.';
+  String get personalGrowthJourney => 'Perjalanan pertumbuhan peribadi anda dengan AI yang mendengar setiap perkataan anda.';
 
   @override
   String get actionItemsTitle => 'Tugasan';
@@ -2031,8 +1987,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Sedia untuk Item Tindakan';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'AI anda akan secara automatik mengekstrak tugasan dan perkara-yang-perlu-dilakukan daripada perbualan anda. Ia akan muncul di sini apabila dicipta.';
+  String get welcomeActionItemsDescription => 'AI anda akan secara automatik mengekstrak tugasan dan perkara-yang-perlu-dilakukan daripada perbualan anda. Ia akan muncul di sini apabila dicipta.';
 
   @override
   String get autoExtractionFeature => 'Diekstrak secara automatik daripada perbualan';
@@ -2082,8 +2037,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get clearMemoryTitle => 'Kosongkan Ingatan Omi';
 
   @override
-  String get clearMemoryMessage =>
-      'Adakah anda pasti mahu mengosongkan ingatan Omi? Tindakan ini tidak boleh dibatalkan.';
+  String get clearMemoryMessage => 'Adakah anda pasti mahu mengosongkan ingatan Omi? Tindakan ini tidak boleh dibatalkan.';
 
   @override
   String get clearMemoryButton => 'Kosongkan Memori';
@@ -2229,15 +2183,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'PERTUTURAN & TRANSKRIPSI';
 
   @override
-  String get languageSettingsHelperText =>
-      'Bahasa Aplikasi menukar menu dan butang. Bahasa Pertuturan mempengaruhi cara rakaman anda ditranskripsi.';
+  String get languageSettingsHelperText => 'Bahasa Aplikasi menukar menu dan butang. Bahasa Pertuturan mempengaruhi cara rakaman anda ditranskripsi.';
 
   @override
   String get translationNotice => 'Notis Terjemahan';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi menterjemah perbualan ke bahasa utama anda. Kemas kini pada bila-bila masa di Tetapan → Profil.';
+  String get translationNoticeMessage => 'Omi menterjemah perbualan ke bahasa utama anda. Kemas kini pada bila-bila masa di Tetapan → Profil.';
 
   @override
   String get pleaseCheckInternetConnection => 'Sila semak sambungan internet anda dan cuba lagi';
@@ -2392,8 +2344,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Nyahpasangkan Peranti';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Ini akan menyahpasangkan peranti supaya ia boleh disambungkan ke telefon lain. Anda perlu pergi ke Tetapan > Bluetooth dan melupakan peranti untuk melengkapkan prosesnya.';
+  String get unpairDeviceDialogMessage => 'Ini akan menyahpasangkan peranti supaya ia boleh disambungkan ke telefon lain. Anda perlu pergi ke Tetapan > Bluetooth dan melupakan peranti untuk melengkapkan prosesnya.';
 
   @override
   String get unpair => 'Nyahpasangkan';
@@ -2574,8 +2525,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get youreAllSet => 'Anda sudah bersedia!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Selamat datang ke Omi! Pendamping AI anda bersedia membantu anda dengan perbualan, tugasan, dan banyak lagi.';
+  String get welcomeToOmiDescription => 'Selamat datang ke Omi! Pendamping AI anda bersedia membantu anda dengan perbualan, tugasan, dan banyak lagi.';
 
   @override
   String get startUsingOmi => 'Mula Menggunakan Omi';
@@ -2669,8 +2619,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get showAll => 'Tunjukkan semua →';
 
   @override
-  String get noTasksForToday =>
-      'Tiada tugasan untuk hari ini.\nTanya Omi untuk lebih banyak tugasan atau cipta secara manual.';
+  String get noTasksForToday => 'Tiada tugasan untuk hari ini.\nTanya Omi untuk lebih banyak tugasan atau cipta secara manual.';
 
   @override
   String get dailyScore => 'SKOR HARIAN';
@@ -2712,8 +2661,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get noTasksYet => 'Belum ada tugas';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Tugas daripada perbualan anda akan muncul di sini.\nKlik Cipta untuk menambah satu secara manual.';
+  String get tasksFromConversationsWillAppear => 'Tugas daripada perbualan anda akan muncul di sini.\nKlik Cipta untuk menambah satu secara manual.';
 
   @override
   String get monthJan => 'Jan';
@@ -2770,8 +2718,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deleteActionItem => 'Padam item tindakan';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Adakah anda pasti mahu memadam item tindakan ini? Tindakan ini tidak boleh dibatalkan.';
+  String get deleteActionItemConfirmation => 'Adakah anda pasti mahu memadam item tindakan ini? Tindakan ini tidak boleh dibatalkan.';
 
   @override
   String get enterActionItemDescription => 'Masukkan penerangan item tindakan...';
@@ -2846,15 +2793,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get chatPrompt => 'Gesaan Sembang';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Anda adalah aplikasi yang hebat, tugas anda adalah untuk menjawab pertanyaan pengguna dan membuat mereka berasa baik...';
+  String get chatPromptPlaceholder => 'Anda adalah aplikasi yang hebat, tugas anda adalah untuk menjawab pertanyaan pengguna dan membuat mereka berasa baik...';
 
   @override
   String get conversationPrompt => 'Gesaan Perbualan';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Anda adalah aplikasi yang hebat, anda akan diberikan transkrip dan ringkasan perbualan...';
+  String get conversationPromptPlaceholder => 'Anda adalah aplikasi yang hebat, anda akan diberikan transkrip dan ringkasan perbualan...';
 
   @override
   String get notificationScopes => 'Skop Pemberitahuan';
@@ -2866,8 +2811,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get makeMyAppPublic => 'Jadikan aplikasi saya awam';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Dengan menghantar aplikasi ini, saya bersetuju dengan Terma Perkhidmatan dan Dasar Privasi Omi AI';
+  String get submitAppTermsAgreement => 'Dengan menghantar aplikasi ini, saya bersetuju dengan Terma Perkhidmatan dan Dasar Privasi Omi AI';
 
   @override
   String get submitApp => 'Hantar Aplikasi';
@@ -2882,12 +2826,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get submitAppQuestion => 'Hantar Aplikasi?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Aplikasi anda akan disemak dan dijadikan awam. Anda boleh mula menggunakannya dengan serta-merta, walaupun semasa semakan!';
+  String get submitAppPublicDescription => 'Aplikasi anda akan disemak dan dijadikan awam. Anda boleh mula menggunakannya dengan serta-merta, walaupun semasa semakan!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Aplikasi anda akan disemak dan disediakan untuk anda secara peribadi. Anda boleh mula menggunakannya dengan serta-merta, walaupun semasa semakan!';
+  String get submitAppPrivateDescription => 'Aplikasi anda akan disemak dan disediakan untuk anda secara peribadi. Anda boleh mula menggunakannya dengan serta-merta, walaupun semasa semakan!';
 
   @override
   String get startEarning => 'Mula Memperoleh! 💰';
@@ -2911,23 +2853,19 @@ class AppLocalizationsMs extends AppLocalizations {
   String get dataAccessNotice => 'Notis Akses Data';
 
   @override
-  String get dataAccessWarning =>
-      'Apl ini akan mengakses data anda. Omi AI tidak bertanggungjawab terhadap bagaimana data anda digunakan, diubah suai, atau dipadamkan oleh apl ini';
+  String get dataAccessWarning => 'Apl ini akan mengakses data anda. Omi AI tidak bertanggungjawab terhadap bagaimana data anda digunakan, diubah suai, atau dipadamkan oleh apl ini';
 
   @override
   String get installApp => 'Pasang Apl';
 
   @override
-  String get betaTesterNotice =>
-      'Anda adalah penguji beta untuk apl ini. Ia belum lagi awam. Ia akan menjadi awam setelah diluluskan.';
+  String get betaTesterNotice => 'Anda adalah penguji beta untuk apl ini. Ia belum lagi awam. Ia akan menjadi awam setelah diluluskan.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Apl anda sedang dalam semakan dan hanya kelihatan kepada anda. Ia akan menjadi awam setelah diluluskan.';
+  String get appUnderReviewOwner => 'Apl anda sedang dalam semakan dan hanya kelihatan kepada anda. Ia akan menjadi awam setelah diluluskan.';
 
   @override
-  String get appRejectedNotice =>
-      'Apl anda telah ditolak. Sila kemas kini butiran apl dan hantar semula untuk semakan.';
+  String get appRejectedNotice => 'Apl anda telah ditolak. Sila kemas kini butiran apl dan hantar semula untuk semakan.';
 
   @override
   String get setupSteps => 'Langkah Persediaan';
@@ -2989,8 +2927,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get descriptionLabel => 'Keterangan';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Aplikasi Hebat Saya adalah aplikasi yang hebat yang melakukan perkara yang menakjubkan. Ia adalah aplikasi terbaik!';
+  String get appDescriptionPlaceholder => 'Aplikasi Hebat Saya adalah aplikasi yang hebat yang melakukan perkara yang menakjubkan. Ia adalah aplikasi terbaik!';
 
   @override
   String get pleaseProvideValidDescription => 'Sila berikan keterangan yang sah';
@@ -3142,8 +3079,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get microphonePermissionRequired => 'Kebenaran mikrofon diperlukan untuk rakaman suara.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Kebenaran mikrofon ditolak. Sila berikan kebenaran dalam Keutamaan Sistem > Privasi & Keselamatan > Mikrofon.';
+  String get microphonePermissionDenied => 'Kebenaran mikrofon ditolak. Sila berikan kebenaran dalam Keutamaan Sistem > Privasi & Keselamatan > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3302,8 +3238,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get createMemory => 'Cipta Memori';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Adakah anda pasti mahu memadam memori ini? Tindakan ini tidak boleh dibatalkan.';
+  String get deleteMemoryConfirmation => 'Adakah anda pasti mahu memadam memori ini? Tindakan ini tidak boleh dibatalkan.';
 
   @override
   String get makePrivate => 'Jadikan Peribadi';
@@ -3377,8 +3312,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get whatWeCollect => 'Apa yang kami kumpulkan';
 
   @override
-  String get dataCollectionMessage =>
-      'Dengan meneruskan, perbualan, rakaman dan maklumat peribadi anda akan disimpan dengan selamat di pelayan kami untuk memberikan wawasan dikuasakan AI dan membolehkan semua ciri aplikasi.';
+  String get dataCollectionMessage => 'Dengan meneruskan, perbualan, rakaman dan maklumat peribadi anda akan disimpan dengan selamat di pelayan kami untuk memberikan wawasan dikuasakan AI dan membolehkan semua ciri aplikasi.';
 
   @override
   String get dataProtection => 'Perlindungan Data';
@@ -3411,8 +3345,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Nama mesti sekurang-kurangnya 2 aksara';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Beritahu kami bagaimana anda ingin dipanggil. Ini membantu memperibadikan pengalaman Omi anda.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Beritahu kami bagaimana anda ingin dipanggil. Ini membantu memperibadikan pengalaman Omi anda.';
 
   @override
   String charactersCount(int count) {
@@ -3429,8 +3362,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get recordAudioConversations => 'Rakam perbualan audio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi memerlukan akses mikrofon untuk merakam perbualan anda dan menyediakan transkripsi.';
+  String get microphoneAccessDescription => 'Omi memerlukan akses mikrofon untuk merakam perbualan anda dan menyediakan transkripsi.';
 
   @override
   String get screenRecording => 'Rakaman Skrin';
@@ -3439,8 +3371,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Tangkap audio sistem dari mesyuarat';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi memerlukan kebenaran rakaman skrin untuk menangkap audio sistem dari mesyuarat berasaskan pelayar anda.';
+  String get screenRecordingDescription => 'Omi memerlukan kebenaran rakaman skrin untuk menangkap audio sistem dari mesyuarat berasaskan pelayar anda.';
 
   @override
   String get accessibility => 'Kebolehcapaian';
@@ -3449,8 +3380,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Kesan mesyuarat berasaskan pelayar';
 
   @override
-  String get accessibilityDescription =>
-      'Omi memerlukan kebenaran kebolehcapaian untuk mengesan apabila anda menyertai mesyuarat Zoom, Meet, atau Teams dalam pelayar anda.';
+  String get accessibilityDescription => 'Omi memerlukan kebenaran kebolehcapaian untuk mengesan apabila anda menyertai mesyuarat Zoom, Meet, atau Teams dalam pelayar anda.';
 
   @override
   String get pleaseWait => 'Sila tunggu...';
@@ -3519,12 +3449,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get exportAllConversationsToJson => 'Eksport semua perbualan anda ke fail JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Eksport Perbualan Dimulakan. Ini mungkin mengambil masa beberapa saat, sila tunggu.';
+  String get conversationsExportStarted => 'Eksport Perbualan Dimulakan. Ini mungkin mengambil masa beberapa saat, sila tunggu.';
 
   @override
-  String get mcpDescription =>
-      'Untuk menyambungkan Omi dengan aplikasi lain untuk membaca, mencari, dan mengurus kenangan dan perbualan anda. Cipta kunci untuk bermula.';
+  String get mcpDescription => 'Untuk menyambungkan Omi dengan aplikasi lain untuk membaca, mencari, dan mengurus kenangan dan perbualan anda. Cipta kunci untuk bermula.';
 
   @override
   String get apiKeys => 'Kunci API';
@@ -3565,15 +3493,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Status diagnostik perkhidmatan transkripsi';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Dayakan mesej diagnostik terperinci daripada perkhidmatan transkripsi';
+  String get enableDetailedDiagnosticMessages => 'Dayakan mesej diagnostik terperinci daripada perkhidmatan transkripsi';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Cipta dan tag penceramah baharu secara automatik';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Cipta orang baharu secara automatik apabila nama dikesan dalam transkrip.';
+  String get automaticallyCreateNewPerson => 'Cipta orang baharu secara automatik apabila nama dikesan dalam transkrip.';
 
   @override
   String get pilotFeatures => 'Ciri Perintis';
@@ -3634,8 +3560,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Biarkan Omi memilih aplikasi terbaik secara automatik';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Adakah anda pasti mahu memadam perbualan ini? Tindakan ini tidak boleh dibatalkan.';
+  String get deleteConversationConfirmation => 'Adakah anda pasti mahu memadam perbualan ini? Tindakan ini tidak boleh dibatalkan.';
 
   @override
   String get conversationDeleted => 'Perbualan dipadam';
@@ -3683,8 +3608,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Menyediakan tangkapan audio sistem';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klik butang untuk menangkap audio untuk transkripsi langsung, cerapan AI dan penyimpanan automatik.';
+  String get clickTheButtonToCaptureAudio => 'Klik butang untuk menangkap audio untuk transkripsi langsung, cerapan AI dan penyimpanan automatik.';
 
   @override
   String get reconnecting => 'Menyambung semula...';
@@ -3911,8 +3835,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Padam Graf Pengetahuan?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Ini akan memadam semua data graf pengetahuan yang diperoleh. Ingatan asal anda kekal selamat.';
+  String get deleteKnowledgeGraphWarning => 'Ini akan memadam semua data graf pengetahuan yang diperoleh. Ingatan asal anda kekal selamat.';
 
   @override
   String get connectOmiWithAI => 'Sambungkan Omi dengan pembantu AI';
@@ -3969,8 +3892,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get updateAppQuestion => 'Kemas kini Aplikasi?';
 
   @override
-  String get updateAppConfirmation =>
-      'Adakah anda pasti mahu mengemas kini aplikasi anda? Perubahan akan dipaparkan selepas disemak oleh pasukan kami.';
+  String get updateAppConfirmation => 'Adakah anda pasti mahu mengemas kini aplikasi anda? Perubahan akan dipaparkan selepas disemak oleh pasukan kami.';
 
   @override
   String get updateApp => 'Kemas kini Aplikasi';
@@ -4000,8 +3922,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get no => 'Tidak';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Langganan berjaya dibatalkan. Ia akan kekal aktif sehingga akhir tempoh pengebilan semasa.';
+  String get subscriptionCancelledSuccessfully => 'Langganan berjaya dibatalkan. Ia akan kekal aktif sehingga akhir tempoh pengebilan semasa.';
 
   @override
   String get failedToCancelSubscription => 'Gagal membatalkan langganan. Sila cuba lagi.';
@@ -4037,8 +3958,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Batalkan Langganan?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Adakah anda pasti mahu membatalkan langganan anda? Anda akan terus mempunyai akses sehingga akhir tempoh pengebilan semasa.';
+  String get cancelSubscriptionConfirmation => 'Adakah anda pasti mahu membatalkan langganan anda? Anda akan terus mempunyai akses sehingga akhir tempoh pengebilan semasa.';
 
   @override
   String get cancelSubscriptionButton => 'Batalkan Langganan';
@@ -4047,16 +3967,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get cancelling => 'Membatalkan...';
 
   @override
-  String get betaTesterMessage =>
-      'Anda adalah penguji beta untuk aplikasi ini. Ia belum dipublikasikan. Ia akan dipublikasikan setelah diluluskan.';
+  String get betaTesterMessage => 'Anda adalah penguji beta untuk aplikasi ini. Ia belum dipublikasikan. Ia akan dipublikasikan setelah diluluskan.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Aplikasi anda sedang disemak dan hanya kelihatan kepada anda. Ia akan dipublikasikan setelah diluluskan.';
+  String get appUnderReviewMessage => 'Aplikasi anda sedang disemak dan hanya kelihatan kepada anda. Ia akan dipublikasikan setelah diluluskan.';
 
   @override
-  String get appRejectedMessage =>
-      'Aplikasi anda telah ditolak. Sila kemas kini butiran dan hantar semula untuk semakan.';
+  String get appRejectedMessage => 'Aplikasi anda telah ditolak. Sila kemas kini butiran dan hantar semula untuk semakan.';
 
   @override
   String get invalidIntegrationUrl => 'URL integrasi tidak sah';
@@ -4110,8 +4027,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get issueActivatingApp => 'Terdapat masalah mengaktifkan aplikasi ini. Sila cuba lagi.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Aplikasi ini akan mengakses data anda. Omi AI tidak bertanggungjawab atas cara data anda digunakan oleh aplikasi ini.';
+  String get dataAccessNoticeDescription => 'Aplikasi ini akan mengakses data anda. Omi AI tidak bertanggungjawab atas cara data anda digunakan oleh aplikasi ini.';
 
   @override
   String get copyUrl => 'Salin URL';
@@ -4199,8 +4115,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get omiApiKeys => 'Kunci API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Kunci API digunakan untuk pengesahan apabila aplikasi anda berkomunikasi dengan pelayan OMI. Ia membenarkan aplikasi anda mencipta memori dan mengakses perkhidmatan OMI lain dengan selamat.';
+  String get apiKeysDescription => 'Kunci API digunakan untuk pengesahan apabila aplikasi anda berkomunikasi dengan pelayan OMI. Ia membenarkan aplikasi anda mencipta memori dan mengakses perkhidmatan OMI lain dengan selamat.';
 
   @override
   String get aboutOmiApiKeys => 'Tentang Kunci API Omi';
@@ -4224,8 +4139,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Batalkan Kunci API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Tindakan ini tidak boleh dibuat asal. Sebarang aplikasi yang menggunakan kunci ini tidak akan dapat mengakses API lagi.';
+  String get revokeApiKeyWarning => 'Tindakan ini tidak boleh dibuat asal. Sebarang aplikasi yang menggunakan kunci ini tidak akan dapat mengakses API lagi.';
 
   @override
   String get revoke => 'Batalkan';
@@ -4314,8 +4228,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get keyCreated => 'Kunci Dicipta';
 
   @override
-  String get keyCreatedMessage =>
-      'Kunci baharu anda telah dicipta. Sila salin sekarang. Anda tidak akan dapat melihatnya lagi.';
+  String get keyCreatedMessage => 'Kunci baharu anda telah dicipta. Sila salin sekarang. Anda tidak akan dapat melihatnya lagi.';
 
   @override
   String get keyWord => 'Kunci';
@@ -4324,8 +4237,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get externalAppAccess => 'Akses Aplikasi Luaran';
 
   @override
-  String get externalAppAccessDescription =>
-      'Aplikasi yang dipasang berikut mempunyai integrasi luaran dan boleh mengakses data anda, seperti perbualan dan kenangan.';
+  String get externalAppAccessDescription => 'Aplikasi yang dipasang berikut mempunyai integrasi luaran dan boleh mengakses data anda, seperti perbualan dan kenangan.';
 
   @override
   String get noExternalAppsHaveAccess => 'Tiada aplikasi luaran yang mempunyai akses kepada data anda.';
@@ -4334,8 +4246,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get maximumSecurityE2ee => 'Keselamatan Maksimum (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Penyulitan hujung ke hujung adalah standard emas untuk privasi. Apabila diaktifkan, data anda disulitkan pada peranti anda sebelum dihantar ke pelayan kami. Ini bermakna tiada sesiapa, malah Omi, boleh mengakses kandungan anda.';
+  String get e2eeDescription => 'Penyulitan hujung ke hujung adalah standard emas untuk privasi. Apabila diaktifkan, data anda disulitkan pada peranti anda sebelum dihantar ke pelayan kami. Ini bermakna tiada sesiapa, malah Omi, boleh mengakses kandungan anda.';
 
   @override
   String get importantTradeoffs => 'Pertimbangan Penting:';
@@ -4350,8 +4261,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get featureComingSoon => 'Ciri ini akan datang tidak lama lagi!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migrasi sedang berjalan. Anda tidak boleh menukar tahap perlindungan sehingga selesai.';
+  String get migrationInProgressMessage => 'Migrasi sedang berjalan. Anda tidak boleh menukar tahap perlindungan sehingga selesai.';
 
   @override
   String get migrationFailed => 'Migrasi Gagal';
@@ -4370,19 +4280,16 @@ class AppLocalizationsMs extends AppLocalizations {
   String get secureEncryption => 'Penyulitan Selamat';
 
   @override
-  String get secureEncryptionDescription =>
-      'Data anda disulitkan dengan kunci yang unik untuk anda di pelayan kami, yang dihoskan di Google Cloud. Ini bermakna kandungan mentah anda tidak boleh diakses oleh sesiapa, termasuk kakitangan Omi atau Google, terus dari pangkalan data.';
+  String get secureEncryptionDescription => 'Data anda disulitkan dengan kunci yang unik untuk anda di pelayan kami, yang dihoskan di Google Cloud. Ini bermakna kandungan mentah anda tidak boleh diakses oleh sesiapa, termasuk kakitangan Omi atau Google, terus dari pangkalan data.';
 
   @override
   String get endToEndEncryption => 'Penyulitan Hujung ke Hujung';
 
   @override
-  String get e2eeCardDescription =>
-      'Aktifkan untuk keselamatan maksimum di mana hanya anda boleh mengakses data anda. Ketik untuk mengetahui lebih lanjut.';
+  String get e2eeCardDescription => 'Aktifkan untuk keselamatan maksimum di mana hanya anda boleh mengakses data anda. Ketik untuk mengetahui lebih lanjut.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Tanpa mengira tahap, data anda sentiasa disulitkan semasa berehat dan dalam transit.';
+  String get dataAlwaysEncrypted => 'Tanpa mengira tahap, data anda sentiasa disulitkan semasa berehat dan dalam transit.';
 
   @override
   String get readOnlyScope => 'Baca Sahaja';
@@ -4447,12 +4354,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get trainingDataProgram => 'Program Data Latihan';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Dapatkan Omi Unlimited percuma dengan menyumbang data anda untuk melatih model AI.';
+  String get getOmiUnlimitedFree => 'Dapatkan Omi Unlimited percuma dengan menyumbang data anda untuk melatih model AI.';
 
   @override
-  String get trainingDataBullets =>
-      '• Data anda membantu meningkatkan model AI\n• Hanya data tidak sensitif yang dikongsi\n• Proses sepenuhnya telus';
+  String get trainingDataBullets => '• Data anda membantu meningkatkan model AI\n• Hanya data tidak sensitif yang dikongsi\n• Proses sepenuhnya telus';
 
   @override
   String get learnMoreAtOmiTraining => 'Ketahui lebih lanjut di omi.me/training';
@@ -4464,8 +4369,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get submitRequest => 'Hantar Permintaan';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Terima kasih! Permintaan anda sedang disemak. Kami akan memberitahu anda setelah diluluskan.';
+  String get thankYouRequestUnderReview => 'Terima kasih! Permintaan anda sedang disemak. Kami akan memberitahu anda setelah diluluskan.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4503,15 +4407,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get monthlyPlanContinues => 'Pelan bulanan semasa anda akan diteruskan sehingga akhir tempoh pengebilan';
 
   @override
-  String get paymentMethodCharged =>
-      'Kaedah pembayaran sedia ada anda akan dicaj secara automatik apabila pelan bulanan anda tamat';
+  String get paymentMethodCharged => 'Kaedah pembayaran sedia ada anda akan dicaj secara automatik apabila pelan bulanan anda tamat';
 
   @override
   String get annualSubscriptionStarts => 'Langganan tahunan 12 bulan anda akan bermula secara automatik selepas caj';
 
   @override
-  String get thirteenMonthsCoverage =>
-      'Anda akan mendapat liputan 13 bulan secara keseluruhan (bulan semasa + 12 bulan tahunan)';
+  String get thirteenMonthsCoverage => 'Anda akan mendapat liputan 13 bulan secara keseluruhan (bulan semasa + 12 bulan tahunan)';
 
   @override
   String get confirmUpgrade => 'Sahkan Naik Taraf';
@@ -4548,8 +4450,7 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Pelan tahunan anda akan bermula secara automatik apabila pelan bulanan anda tamat.';
+  String get annualPlanStartsAutomatically => 'Pelan tahunan anda akan bermula secara automatik apabila pelan bulanan anda tamat.';
 
   @override
   String planRenewsOn(String date) {
@@ -4616,8 +4517,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Privasi Anda Penting bagi Kami';
 
   @override
-  String get privacyIntroText =>
-      'Di Omi, kami mengambil privasi anda dengan sangat serius. Kami ingin telus tentang data yang kami kumpul dan cara kami menggunakannya. Inilah yang perlu anda ketahui:';
+  String get privacyIntroText => 'Di Omi, kami mengambil privasi anda dengan sangat serius. Kami ingin telus tentang data yang kami kumpul dan cara kami menggunakannya. Inilah yang perlu anda ketahui:';
 
   @override
   String get whatWeTrack => 'Apa yang Kami Jejaki';
@@ -4632,12 +4532,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get ourCommitment => 'Komitmen Kami';
 
   @override
-  String get commitmentText =>
-      'Kami komited untuk menggunakan data yang kami kumpul hanya untuk menjadikan Omi produk yang lebih baik untuk anda. Privasi dan kepercayaan anda adalah yang paling penting bagi kami.';
+  String get commitmentText => 'Kami komited untuk menggunakan data yang kami kumpul hanya untuk menjadikan Omi produk yang lebih baik untuk anda. Privasi dan kepercayaan anda adalah yang paling penting bagi kami.';
 
   @override
-  String get thankYouText =>
-      'Terima kasih kerana menjadi pengguna Omi yang dihargai. Jika anda mempunyai sebarang soalan atau kebimbangan, sila hubungi kami di team@basedhardware.com.';
+  String get thankYouText => 'Terima kasih kerana menjadi pengguna Omi yang dihargai. Jika anda mempunyai sebarang soalan atau kebimbangan, sila hubungi kami di team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Tetapan Segerak WiFi';
@@ -4646,8 +4544,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get enterHotspotCredentials => 'Masukkan kelayakan hotspot telefon anda';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'Segerak WiFi menggunakan telefon anda sebagai hotspot. Cari nama dan kata laluan di Tetapan > Hotspot Peribadi.';
+  String get wifiSyncUsesHotspot => 'Segerak WiFi menggunakan telefon anda sebagai hotspot. Cari nama dan kata laluan di Tetapan > Hotspot Peribadi.';
 
   @override
   String get hotspotNameSsid => 'Nama Hotspot (SSID)';
@@ -4682,8 +4579,7 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Gagal menjana ringkasan. Pastikan anda mempunyai perbualan untuk hari itu.';
+  String get failedToGenerateSummaryCheckConversations => 'Gagal menjana ringkasan. Pastikan anda mempunyai perbualan untuk hari itu.';
 
   @override
   String get summaryNotFound => 'Ringkasan tidak ditemui';
@@ -4713,8 +4609,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Eksport dimulakan. Ini mungkin mengambil beberapa saat...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ini akan memadamkan semua data graf pengetahuan terbitan (nod dan sambungan). Memori asal anda akan kekal selamat. Graf akan dibina semula dari semasa ke semasa atau atas permintaan seterusnya.';
+  String get knowledgeGraphDeleteDescription => 'Ini akan memadamkan semua data graf pengetahuan terbitan (nod dan sambungan). Memori asal anda akan kekal selamat. Graf akan dibina semula dari semasa ke semasa atau atas permintaan seterusnya.';
 
   @override
   String get configureDailySummaryDigest => 'Konfigurasikan ringkasan tugas harian anda';
@@ -4784,8 +4679,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Padam Semua Perbualan Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Ini akan memadam secara kekal semua perbualan yang diimport dari Limitless. Tindakan ini tidak boleh dibuat asal.';
+  String get deleteAllLimitlessWarning => 'Ini akan memadam secara kekal semua perbualan yang diimport dari Limitless. Tindakan ini tidak boleh dibuat asal.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4841,8 +4735,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get howItWorksTitle => 'Bagaimana ia berfungsi?';
 
   @override
-  String get howPeopleWorks =>
-      'Sebaik sahaja seseorang dicipta, anda boleh pergi ke transkrip perbualan dan menetapkan segmen yang sepadan kepada mereka, dengan cara itu Omi akan dapat mengenali pertuturan mereka juga!';
+  String get howPeopleWorks => 'Sebaik sahaja seseorang dicipta, anda boleh pergi ke transkrip perbualan dan menetapkan segmen yang sepadan kepada mereka, dengan cara itu Omi akan dapat mengenali pertuturan mereka juga!';
 
   @override
   String get tapToDelete => 'Ketik untuk memadam';
@@ -4868,8 +4761,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get privacyNotice => 'Notis Privasi';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Rakaman mungkin menangkap suara orang lain. Pastikan anda mendapat persetujuan daripada semua peserta sebelum mengaktifkan.';
+  String get recordingsMayCaptureOthers => 'Rakaman mungkin menangkap suara orang lain. Pastikan anda mendapat persetujuan daripada semua peserta sebelum mengaktifkan.';
 
   @override
   String get enable => 'Aktifkan';
@@ -4881,8 +4773,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Simpan semua rakaman audio secara tempatan di telefon anda. Apabila dilumpuhkan, hanya muat naik yang gagal disimpan untuk menjimatkan ruang storan.';
+  String get storeAudioDescription => 'Simpan semua rakaman audio secara tempatan di telefon anda. Apabila dilumpuhkan, hanya muat naik yang gagal disimpan untuk menjimatkan ruang storan.';
 
   @override
   String get enableLocalStorage => 'Aktifkan Storan Tempatan';
@@ -4900,12 +4791,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get storeAudioOnCloud => 'Simpan Audio di Awan';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Rakaman masa nyata anda akan disimpan dalam storan awan peribadi semasa anda bercakap.';
+  String get cloudStorageDialogMessage => 'Rakaman masa nyata anda akan disimpan dalam storan awan peribadi semasa anda bercakap.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Simpan rakaman masa nyata anda dalam storan awan peribadi semasa anda bercakap. Audio ditangkap dan disimpan dengan selamat dalam masa nyata.';
+  String get storeAudioCloudDescription => 'Simpan rakaman masa nyata anda dalam storan awan peribadi semasa anda bercakap. Audio ditangkap dan disimpan dengan selamat dalam masa nyata.';
 
   @override
   String get downloadingFirmware => 'Memuat turun Perisian Tegar';
@@ -4958,8 +4847,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get payments => 'Pembayaran';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Sambungkan kaedah pembayaran di bawah untuk mula menerima pembayaran untuk aplikasi anda.';
+  String get connectPaymentMethodInfo => 'Sambungkan kaedah pembayaran di bawah untuk mula menerima pembayaran untuk aplikasi anda.';
 
   @override
   String get selectedPaymentMethod => 'Kaedah Pembayaran Dipilih';
@@ -4986,15 +4874,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get monthlyPayouts => 'Pembayaran bulanan';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Terima bayaran bulanan terus ke akaun anda apabila mencapai \$10 dalam pendapatan';
+  String get monthlyPayoutsDescription => 'Terima bayaran bulanan terus ke akaun anda apabila mencapai \$10 dalam pendapatan';
 
   @override
   String get secureAndReliable => 'Selamat dan boleh dipercayai';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe memastikan pemindahan hasil aplikasi anda yang selamat dan tepat pada masanya';
+  String get stripeSecureDescription => 'Stripe memastikan pemindahan hasil aplikasi anda yang selamat dan tepat pada masanya';
 
   @override
   String get selectYourCountry => 'Pilih negara anda';
@@ -5015,8 +4901,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get connectingYourStripeAccount => 'Menyambungkan akaun Stripe anda';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Sila lengkapkan proses penerimaan Stripe dalam pelayar anda. Halaman ini akan dikemas kini secara automatik setelah selesai.';
+  String get stripeOnboardingInstructions => 'Sila lengkapkan proses penerimaan Stripe dalam pelayar anda. Halaman ini akan dikemas kini secara automatik setelah selesai.';
 
   @override
   String get failedTryAgain => 'Gagal? Cuba Lagi';
@@ -5028,8 +4913,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get successfullyConnected => 'Berjaya Disambungkan!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Akaun Stripe anda kini sedia menerima pembayaran. Anda boleh mula menjana pendapatan daripada jualan aplikasi anda dengan segera.';
+  String get stripeReadyForPayments => 'Akaun Stripe anda kini sedia menerima pembayaran. Anda boleh mula menjana pendapatan daripada jualan aplikasi anda dengan segera.';
 
   @override
   String get updateStripeDetails => 'Kemas Kini Butiran Stripe';
@@ -5047,8 +4931,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Kemas kini butiran akaun PayPal anda';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Sambungkan akaun PayPal anda untuk mula menerima pembayaran untuk aplikasi anda';
+  String get connectPayPalToReceivePayments => 'Sambungkan akaun PayPal anda untuk mula menerima pembayaran untuk aplikasi anda';
 
   @override
   String get paypalEmail => 'E-mel PayPal';
@@ -5057,8 +4940,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get paypalMeLink => 'Pautan PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Jika Stripe tersedia di negara anda, kami sangat mengesyorkan menggunakannya untuk pembayaran yang lebih cepat dan mudah.';
+  String get stripeRecommendation => 'Jika Stripe tersedia di negara anda, kami sangat mengesyorkan menggunakannya untuk pembayaran yang lebih cepat dan mudah.';
 
   @override
   String get updatePayPalDetails => 'Kemas Kini Butiran PayPal';
@@ -5110,12 +4992,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Sampel suara tambahan dibuang';
 
   @override
-  String get consentDataMessage =>
-      'Dengan meneruskan, perbualan, rakaman dan maklumat peribadi anda akan disimpan dengan selamat di pelayan kami. Rakaman audio dan transkrip anda diproses oleh perkhidmatan AI pihak ketiga (termasuk Deepgram untuk transkripsi dan OpenAI untuk analisis) untuk memberikan anda pandangan dikuasakan AI dan membolehkan semua ciri aplikasi.';
+  String get consentDataMessage => 'Dengan meneruskan, perbualan, rakaman dan maklumat peribadi anda akan disimpan dengan selamat di pelayan kami. Rakaman audio dan transkrip anda diproses oleh perkhidmatan AI pihak ketiga (termasuk Deepgram untuk transkripsi dan OpenAI untuk analisis) untuk memberikan anda pandangan dikuasakan AI dan membolehkan semua ciri aplikasi.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Tugasan daripada perbualan anda akan muncul di sini.\nKetik + untuk mencipta secara manual.';
+  String get tasksEmptyStateMessage => 'Tugasan daripada perbualan anda akan muncul di sini.\nKetik + untuk mencipta secara manual.';
 
   @override
   String get clearChatAction => 'Kosongkan sembang';
@@ -5151,15 +5031,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Pasang Omi pada\nApple Watch anda';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Untuk menggunakan Apple Watch dengan Omi, anda perlu memasang aplikasi Omi pada jam tangan anda terlebih dahulu.';
+  String get installOmiOnAppleWatchDescription => 'Untuk menggunakan Apple Watch dengan Omi, anda perlu memasang aplikasi Omi pada jam tangan anda terlebih dahulu.';
 
   @override
   String get openOmiOnAppleWatch => 'Buka Omi pada\nApple Watch anda';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Aplikasi Omi dipasang pada Apple Watch anda. Buka dan ketik Mula untuk bermula.';
+  String get openOmiOnAppleWatchDescription => 'Aplikasi Omi dipasang pada Apple Watch anda. Buka dan ketik Mula untuk bermula.';
 
   @override
   String get openWatchApp => 'Buka Aplikasi Watch';
@@ -5168,15 +5046,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Saya Telah Memasang & Membuka Aplikasi';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Tidak dapat membuka aplikasi Apple Watch. Sila buka aplikasi Watch secara manual pada Apple Watch anda dan pasang Omi dari bahagian \"Aplikasi Tersedia\".';
+  String get unableToOpenWatchApp => 'Tidak dapat membuka aplikasi Apple Watch. Sila buka aplikasi Watch secara manual pada Apple Watch anda dan pasang Omi dari bahagian \"Aplikasi Tersedia\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch berjaya disambungkan!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch masih tidak dapat dicapai. Pastikan aplikasi Omi dibuka pada jam tangan anda.';
+  String get appleWatchNotReachable => 'Apple Watch masih tidak dapat dicapai. Pastikan aplikasi Omi dibuka pada jam tangan anda.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5193,8 +5069,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get finishedConversation => 'Perbualan selesai?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Adakah anda pasti mahu menghentikan rakaman dan meringkaskan perbualan sekarang?';
+  String get stopRecordingConfirmation => 'Adakah anda pasti mahu menghentikan rakaman dan meringkaskan perbualan sekarang?';
 
   @override
   String get conversationEndsManually => 'Perbualan hanya akan tamat secara manual.';
@@ -5605,8 +5480,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get multipleSpeakersDetected => 'Berbilang penutur dikesan';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Nampaknya terdapat berbilang penutur dalam rakaman. Sila pastikan anda berada di tempat yang tenang dan cuba lagi.';
+  String get multipleSpeakersDescription => 'Nampaknya terdapat berbilang penutur dalam rakaman. Sila pastikan anda berada di tempat yang tenang dan cuba lagi.';
 
   @override
   String get invalidRecordingDetected => 'Rakaman tidak sah dikesan';
@@ -5615,8 +5489,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get notEnoughSpeechDescription => 'Tidak cukup pertuturan dikesan. Sila bercakap lebih banyak dan cuba lagi.';
 
   @override
-  String get speechDurationDescription =>
-      'Sila pastikan anda bercakap sekurang-kurangnya 5 saat dan tidak lebih dari 90.';
+  String get speechDurationDescription => 'Sila pastikan anda bercakap sekurang-kurangnya 5 saat dan tidak lebih dari 90.';
 
   @override
   String get connectionLostDescription => 'Sambungan terputus. Sila semak sambungan internet anda dan cuba lagi.';
@@ -5625,8 +5498,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get howToTakeGoodSample => 'Bagaimana untuk membuat sampel yang baik?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Pastikan anda berada di tempat yang tenang.\n2. Bercakap dengan jelas dan semula jadi.\n3. Pastikan peranti anda berada dalam kedudukan semula jadi di leher anda.\n\nSetelah dicipta, anda sentiasa boleh memperbaikinya atau membuatnya semula.';
+  String get goodSampleInstructions => '1. Pastikan anda berada di tempat yang tenang.\n2. Bercakap dengan jelas dan semula jadi.\n3. Pastikan peranti anda berada dalam kedudukan semula jadi di leher anda.\n\nSetelah dicipta, anda sentiasa boleh memperbaikinya atau membuatnya semula.';
 
   @override
   String get noDeviceConnectedUseMic => 'Tiada peranti disambungkan. Mikrofon telefon akan digunakan.';
@@ -5689,12 +5561,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get howItWorks => 'Bagaimana ia berfungsi';
 
   @override
-  String get dailyScoreExplanation =>
-      'Skor harian anda berdasarkan penyelesaian tugasan. Selesaikan tugasan anda untuk meningkatkan skor!';
+  String get dailyScoreExplanation => 'Skor harian anda berdasarkan penyelesaian tugasan. Selesaikan tugasan anda untuk meningkatkan skor!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kawal kekerapan Omi menghantar pemberitahuan dan peringatan proaktif kepada anda.';
+  String get notificationFrequencyDescription => 'Kawal kekerapan Omi menghantar pemberitahuan dan peringatan proaktif kepada anda.';
 
   @override
   String get sliderOff => 'Mati';
@@ -5708,8 +5578,7 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Gagal menjana ringkasan. Pastikan anda mempunyai perbualan untuk hari tersebut.';
+  String get failedToGenerateSummary => 'Gagal menjana ringkasan. Pastikan anda mempunyai perbualan untuk hari tersebut.';
 
   @override
   String get recap => 'Ringkasan';
@@ -6069,15 +5938,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get cloudProvider => 'Pembekal Awan';
 
   @override
-  String get premiumMinutesInfo =>
-      '1,200 minit premium/bulan. Tab Pada-Peranti menawarkan transkripsi percuma tanpa had.';
+  String get premiumMinutesInfo => '1,200 minit premium/bulan. Tab Pada-Peranti menawarkan transkripsi percuma tanpa had.';
 
   @override
   String get viewUsage => 'Lihat penggunaan';
 
   @override
-  String get localProcessingInfo =>
-      'Audio diproses secara tempatan. Berfungsi luar talian, lebih peribadi, tetapi menggunakan lebih banyak bateri.';
+  String get localProcessingInfo => 'Audio diproses secara tempatan. Berfungsi luar talian, lebih peribadi, tetapi menggunakan lebih banyak bateri.';
 
   @override
   String get model => 'Model';
@@ -6086,15 +5953,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get performanceWarning => 'Amaran Prestasi';
 
   @override
-  String get largeModelWarning =>
-      'Model ini besar dan mungkin menyebabkan aplikasi ranap atau berjalan sangat perlahan pada peranti mudah alih.\n\n\"small\" atau \"base\" disyorkan.';
+  String get largeModelWarning => 'Model ini besar dan mungkin menyebabkan aplikasi ranap atau berjalan sangat perlahan pada peranti mudah alih.\n\n\"small\" atau \"base\" disyorkan.';
 
   @override
   String get usingNativeIosSpeech => 'Menggunakan Pengecaman Pertuturan iOS Asli';
 
   @override
-  String get noModelDownloadRequired =>
-      'Enjin pertuturan asli peranti anda akan digunakan. Tiada muat turun model diperlukan.';
+  String get noModelDownloadRequired => 'Enjin pertuturan asli peranti anda akan digunakan. Tiada muat turun model diperlukan.';
 
   @override
   String get modelReady => 'Model Sedia';
@@ -6151,12 +6016,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get batteryDrainSignificantly => 'Pengurasan bateri akan meningkat dengan ketara.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1,200 minit premium/bulan. Tab Pada Peranti menawarkan transkripsi percuma tanpa had. ';
+  String get premiumMinutesMonth => '1,200 minit premium/bulan. Tab Pada Peranti menawarkan transkripsi percuma tanpa had. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Audio diproses secara tempatan. Berfungsi luar talian, lebih peribadi, tetapi menggunakan lebih banyak bateri.';
+  String get audioProcessedLocally => 'Audio diproses secara tempatan. Berfungsi luar talian, lebih peribadi, tetapi menggunakan lebih banyak bateri.';
 
   @override
   String get languageLabel => 'Bahasa';
@@ -6165,12 +6028,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Model ini besar dan mungkin menyebabkan aplikasi ranap atau berjalan sangat perlahan pada peranti mudah alih.\n\nsmall atau base disyorkan.';
+  String get modelTooLargeWarning => 'Model ini besar dan mungkin menyebabkan aplikasi ranap atau berjalan sangat perlahan pada peranti mudah alih.\n\nsmall atau base disyorkan.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Enjin pertuturan asli peranti anda akan digunakan. Tiada muat turun model diperlukan.';
+  String get nativeEngineNoDownload => 'Enjin pertuturan asli peranti anda akan digunakan. Tiada muat turun model diperlukan.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6206,8 +6067,7 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Transkripsi langsung terbina dalam Omi dioptimumkan untuk perbualan masa nyata dengan pengesanan penutur automatik dan diarisasi.';
+  String get omiTranscriptionOptimized => 'Transkripsi langsung terbina dalam Omi dioptimumkan untuk perbualan masa nyata dengan pengesanan penutur automatik dan diarisasi.';
 
   @override
   String get reset => 'Set semula';
@@ -6427,8 +6287,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Membina graf pengetahuan daripada kenangan...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Graf pengetahuan anda akan dibina secara automatik apabila anda mencipta kenangan baharu.';
+  String get knowledgeGraphWillBuildAutomatically => 'Graf pengetahuan anda akan dibina secara automatik apabila anda mencipta kenangan baharu.';
 
   @override
   String get buildGraphButton => 'Bina Graf';
@@ -6730,8 +6589,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Memuat turun audio dari kad SD peranti anda';
 
   @override
-  String get transferRequiredDescription =>
-      'Rakaman ini disimpan di kad SD peranti anda. Pindahkan ke telefon anda untuk memainkan semula.';
+  String get transferRequiredDescription => 'Rakaman ini disimpan di kad SD peranti anda. Pindahkan ke telefon anda untuk memainkan semula.';
 
   @override
   String get cancelTransfer => 'Batal Pemindahan';
@@ -6752,8 +6610,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get shareRecording => 'Kongsi Rakaman';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Adakah anda pasti mahu memadam rakaman ini secara kekal? Tindakan ini tidak boleh dibatalkan.';
+  String get deleteRecordingConfirmation => 'Adakah anda pasti mahu memadam rakaman ini secara kekal? Tindakan ini tidak boleh dibatalkan.';
 
   @override
   String get recordingIdLabel => 'ID Rakaman';
@@ -6812,8 +6669,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get enableFastTransfer => 'Aktifkan Pemindahan Pantas';
 
   @override
-  String get fastTransferDescription =>
-      'Pemindahan Pantas menggunakan WiFi untuk kelajuan ~5x lebih pantas. Telefon anda akan bersambung sementara ke rangkaian WiFi peranti Omi semasa pemindahan.';
+  String get fastTransferDescription => 'Pemindahan Pantas menggunakan WiFi untuk kelajuan ~5x lebih pantas. Telefon anda akan bersambung sementara ke rangkaian WiFi peranti Omi semasa pemindahan.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Akses internet dijeda semasa pemindahan';
@@ -6828,8 +6684,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get fiveTimesFaster => '5X LEBIH PANTAS';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Mencipta sambungan WiFi terus ke peranti Omi anda. Telefon anda terputus sementara dari WiFi biasa semasa pemindahan.';
+  String get fastTransferMethodDescription => 'Mencipta sambungan WiFi terus ke peranti Omi anda. Telefon anda terputus sementara dari WiFi biasa semasa pemindahan.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6838,8 +6693,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get bleSpeed => '~30 KB/s melalui BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Menggunakan sambungan Bluetooth Low Energy standard. Lebih perlahan tetapi tidak menjejaskan sambungan WiFi anda.';
+  String get bluetoothMethodDescription => 'Menggunakan sambungan Bluetooth Low Energy standard. Lebih perlahan tetapi tidak menjejaskan sambungan WiFi anda.';
 
   @override
   String get selected => 'Dipilih';
@@ -6877,12 +6731,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get appDeleteFailed => 'Gagal memadam apl. Sila cuba lagi kemudian.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Keterlihatan apl berjaya ditukar. Ia mungkin mengambil masa beberapa minit untuk dikemas kini.';
+  String get appVisibilityChangedSuccessfully => 'Keterlihatan apl berjaya ditukar. Ia mungkin mengambil masa beberapa minit untuk dikemas kini.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Ralat mengaktifkan apl. Jika ini adalah apl integrasi, pastikan persediaan telah selesai.';
+  String get errorActivatingAppIntegration => 'Ralat mengaktifkan apl. Jika ini adalah apl integrasi, pastikan persediaan telah selesai.';
 
   @override
   String get errorUpdatingAppStatus => 'Ralat berlaku semasa mengemas kini status apl.';
@@ -6950,8 +6802,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get importantConversationTitle => 'Perbualan Penting';
 
   @override
-  String get importantConversationBody =>
-      'Anda baru sahaja melakukan perbualan penting. Ketik untuk berkongsi ringkasan.';
+  String get importantConversationBody => 'Anda baru sahaja melakukan perbualan penting. Ketik untuk berkongsi ringkasan.';
 
   @override
   String get templateName => 'Nama Templat';
@@ -6963,8 +6814,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Nama mesti sekurang-kurangnya 3 aksara';
 
   @override
-  String get conversationPromptHint =>
-      'cth., Ekstrak item tindakan, keputusan yang dibuat, dan perkara utama dari perbualan yang diberikan.';
+  String get conversationPromptHint => 'cth., Ekstrak item tindakan, keputusan yang dibuat, dan perkara utama dari perbualan yang diberikan.';
 
   @override
   String get pleaseEnterAppPrompt => 'Sila masukkan prompt untuk aplikasi anda';
@@ -7151,15 +7001,13 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Naik taraf dijadualkan! Pelan bulanan anda diteruskan sehingga akhir tempoh bil anda.';
+  String get planUpgradeScheduledMessage => 'Naik taraf dijadualkan! Pelan bulanan anda diteruskan sehingga akhir tempoh bil anda.';
 
   @override
   String get couldNotSchedulePlanChange => 'Tidak dapat menjadualkan perubahan pelan. Sila cuba lagi.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Langganan anda telah diaktifkan semula! Tiada caj sekarang - anda akan dibilkan pada kadar baharu pada tempoh pengebilan seterusnya.';
+  String get subscriptionReactivatedDefault => 'Langganan anda telah diaktifkan semula! Tiada caj sekarang - anda akan dibilkan pada kadar baharu pada tempoh pengebilan seterusnya.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Langganan berjaya! Anda telah dicaj untuk tempoh pengebilan baharu.';
@@ -7342,8 +7190,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Kebenaran Bluetooth diperlukan untuk menyambung ke peranti anda.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Kebenaran Bluetooth ditolak. Sila berikan kebenaran dalam Keutamaan Sistem.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Kebenaran Bluetooth ditolak. Sila berikan kebenaran dalam Keutamaan Sistem.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7356,12 +7203,10 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Kebenaran pemberitahuan ditolak. Sila berikan kebenaran dalam Keutamaan Sistem.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Kebenaran pemberitahuan ditolak. Sila berikan kebenaran dalam Keutamaan Sistem.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Kebenaran pemberitahuan ditolak. Sila berikan kebenaran dalam Keutamaan Sistem > Pemberitahuan.';
+  String get onboardingNotificationDeniedNotifications => 'Kebenaran pemberitahuan ditolak. Sila berikan kebenaran dalam Keutamaan Sistem > Pemberitahuan.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7374,15 +7219,13 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Sila berikan kebenaran lokasi dalam Tetapan > Privasi & Keselamatan > Perkhidmatan Lokasi';
+  String get onboardingLocationGrantInSettings => 'Sila berikan kebenaran lokasi dalam Tetapan > Privasi & Keselamatan > Perkhidmatan Lokasi';
 
   @override
   String get onboardingMicrophoneRequired => 'Kebenaran mikrofon diperlukan untuk merakam.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Kebenaran mikrofon ditolak. Sila berikan kebenaran dalam Keutamaan Sistem > Privasi & Keselamatan > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Kebenaran mikrofon ditolak. Sila berikan kebenaran dalam Keutamaan Sistem > Privasi & Keselamatan > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7398,8 +7241,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Kebenaran tangkapan skrin diperlukan untuk merakam audio sistem.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Kebenaran tangkapan skrin ditolak. Sila berikan kebenaran dalam Keutamaan Sistem > Privasi & Keselamatan > Rakaman Skrin.';
+  String get onboardingScreenCaptureDenied => 'Kebenaran tangkapan skrin ditolak. Sila berikan kebenaran dalam Keutamaan Sistem > Privasi & Keselamatan > Rakaman Skrin.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7524,8 +7366,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get locationPermissionRequired => 'Kebenaran lokasi diperlukan';
 
   @override
-  String get locationPermissionContent =>
-      'Pemindahan Pantas memerlukan kebenaran lokasi untuk mengesahkan sambungan WiFi. Sila berikan kebenaran lokasi untuk meneruskan.';
+  String get locationPermissionContent => 'Pemindahan Pantas memerlukan kebenaran lokasi untuk mengesahkan sambungan WiFi. Sila berikan kebenaran lokasi untuk meneruskan.';
 
   @override
   String get pdfTranscriptExport => 'Eksport Transkrip';
@@ -7688,8 +7529,7 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Peranti tidak menyokong penyegerakan WiFi, bertukar kepada Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Peranti tidak menyokong penyegerakan WiFi, bertukar kepada Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health tidak tersedia pada peranti ini';
@@ -7985,8 +7825,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Letakkan Omi DevKit dalam Mod Berpasangan';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Tekan butang sekali untuk menghidupkan. LED akan berkelip ungu dalam mod berpasangan.';
+  String get pairingDescOmiDevkit => 'Tekan butang sekali untuk menghidupkan. LED akan berkelip ungu dalam mod berpasangan.';
 
   @override
   String get pairingTitleOmiGlass => 'Hidupkan Omi Glass';
@@ -7998,8 +7837,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Letakkan Plaud Note dalam Mod Berpasangan';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Tekan dan tahan butang sisi selama 2 saat. LED merah akan berkelip apabila sedia untuk berpasangan.';
+  String get pairingDescPlaudNote => 'Tekan dan tahan butang sisi selama 2 saat. LED merah akan berkelip apabila sedia untuk berpasangan.';
 
   @override
   String get pairingTitleBee => 'Letakkan Bee dalam Mod Berpasangan';
@@ -8011,15 +7849,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get pairingTitleLimitless => 'Letakkan Limitless dalam Mod Berpasangan';
 
   @override
-  String get pairingDescLimitless =>
-      'Apabila sebarang lampu kelihatan, tekan sekali kemudian tekan dan tahan sehingga peranti menunjukkan lampu merah jambu, kemudian lepaskan.';
+  String get pairingDescLimitless => 'Apabila sebarang lampu kelihatan, tekan sekali kemudian tekan dan tahan sehingga peranti menunjukkan lampu merah jambu, kemudian lepaskan.';
 
   @override
   String get pairingTitleFriendPendant => 'Letakkan Friend Pendant dalam Mod Berpasangan';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Tekan butang pada loket untuk menghidupkannya. Ia akan memasuki mod berpasangan secara automatik.';
+  String get pairingDescFriendPendant => 'Tekan butang pada loket untuk menghidupkannya. Ia akan memasuki mod berpasangan secara automatik.';
 
   @override
   String get pairingTitleFieldy => 'Letakkan Fieldy dalam Mod Berpasangan';
@@ -8031,8 +7867,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Sambungkan Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Pasang dan buka aplikasi Omi pada Apple Watch anda, kemudian ketik Sambung dalam aplikasi.';
+  String get pairingDescAppleWatch => 'Pasang dan buka aplikasi Omi pada Apple Watch anda, kemudian ketik Sambung dalam aplikasi.';
 
   @override
   String get pairingTitleNeoOne => 'Letakkan Neo One dalam Mod Berpasangan';
@@ -8108,8 +7943,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get wifiConfiguration => 'Konfigurasi WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Masukkan kelayakan WiFi anda untuk membenarkan peranti memuat turun perisian tegar.';
+  String get wifiConfigurationSubtitle => 'Masukkan kelayakan WiFi anda untuk membenarkan peranti memuat turun perisian tegar.';
 
   @override
   String get networkNameSsid => 'Nama Rangkaian (SSID)';
@@ -8127,8 +7961,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Inilah yang saya tahu tentang anda';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Peta ini dikemas kini apabila Omi belajar daripada perbualan anda.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Peta ini dikemas kini apabila Omi belajar daripada perbualan anda.';
 
   @override
   String get apiEnvironment => 'Persekitaran API';
@@ -8157,8 +7990,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get switchAndRestart => 'Tukar';
 
   @override
-  String get stagingDisclaimer =>
-      'Persekitaran ujian mungkin tidak stabil, mempunyai prestasi tidak konsisten dan data mungkin hilang. Untuk ujian sahaja.';
+  String get stagingDisclaimer => 'Persekitaran ujian mungkin tidak stabil, mempunyai prestasi tidak konsisten dan data mungkin hilang. Untuk ujian sahaja.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Disimpan. Tutup dan buka semula aplikasi untuk menggunakan perubahan.';
@@ -8387,8 +8219,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Panggilan Telefon melalui Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Buat panggilan melalui Omi dan dapatkan transkripsi masa nyata, ringkasan automatik dan banyak lagi.';
+  String get phoneCallsUpsellSubtitle => 'Buat panggilan melalui Omi dan dapatkan transkripsi masa nyata, ringkasan automatik dan banyak lagi.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transkripsi masa nyata setiap panggilan';
@@ -8427,8 +8258,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deletePendingFiles => 'Padam rakaman tertangguh';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Rakaman ini BELUM disegerakkan ke telefon anda dan akan hilang secara kekal. Ini tidak boleh dibuat asal.';
+  String get deletePendingFilesWarning => 'Rakaman ini BELUM disegerakkan ke telefon anda dan akan hilang secara kekal. Ini tidak boleh dibuat asal.';
 
   @override
   String get pendingFilesDeleted => 'Rakaman tertangguh dipadam';
@@ -8440,8 +8270,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deleteAll => 'Padam semua';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Ini akan memadam rakaman disegerakkan dan tertangguh. Rakaman tertangguh BELUM disegerakkan dan akan hilang secara kekal.';
+  String get deleteAllFilesWarning => 'Ini akan memadam rakaman disegerakkan dan tertangguh. Rakaman tertangguh BELUM disegerakkan dan akan hilang secara kekal.';
 
   @override
   String get allFilesDeleted => 'Semua rakaman dipadam';
@@ -8506,8 +8335,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get fairUseAboutTitle => 'Tentang Penggunaan Saksama';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi direka untuk perbualan peribadi, mesyuarat dan interaksi secara langsung. Penggunaan diukur berdasarkan masa pertuturan sebenar yang dikesan, bukan masa sambungan. Jika penggunaan melebihi corak biasa dengan ketara untuk kandungan bukan peribadi, pelarasan mungkin dikenakan.';
+  String get fairUseAboutBody => 'Omi direka untuk perbualan peribadi, mesyuarat dan interaksi secara langsung. Penggunaan diukur berdasarkan masa pertuturan sebenar yang dikesan, bukan masa sambungan. Jika penggunaan melebihi corak biasa dengan ketara untuk kandungan bukan peribadi, pelarasan mungkin dikenakan.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8545,8 +8373,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get improveConnectionTitle => 'Tingkatkan Sambungan';
 
   @override
-  String get improveConnectionContent =>
-      'Kami telah meningkatkan cara Omi kekal bersambung dengan peranti anda. Untuk mengaktifkan ini, pergi ke halaman Maklumat Peranti, ketik \"Putuskan Peranti\", dan gandingkan semula peranti anda.';
+  String get improveConnectionContent => 'Kami telah meningkatkan cara Omi kekal bersambung dengan peranti anda. Untuk mengaktifkan ini, pergi ke halaman Maklumat Peranti, ketik \"Putuskan Peranti\", dan gandingkan semula peranti anda.';
 
   @override
   String get improveConnectionAction => 'Faham';
@@ -8601,16 +8428,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get cancelSyncQuestion => 'Batalkan penyegerakan?';
 
   @override
-  String get omisStorageDesc =>
-      'Apabila Omi anda tidak disambungkan ke telefon, ia menyimpan audio secara tempatan dalam memori terbina dalam. Anda tidak akan kehilangan rakaman.';
+  String get omisStorageDesc => 'Apabila Omi anda tidak disambungkan ke telefon, ia menyimpan audio secara tempatan dalam memori terbina dalam. Anda tidak akan kehilangan rakaman.';
 
   @override
-  String get phoneStorageDesc =>
-      'Apabila Omi menyambung semula, rakaman dipindahkan secara automatik ke telefon anda sebelum dimuat naik.';
+  String get phoneStorageDesc => 'Apabila Omi menyambung semula, rakaman dipindahkan secara automatik ke telefon anda sebelum dimuat naik.';
 
   @override
-  String get cloudStorageDesc =>
-      'Selepas dimuat naik, rakaman anda diproses dan ditranskrip. Perbualan akan tersedia dalam satu minit.';
+  String get cloudStorageDesc => 'Selepas dimuat naik, rakaman anda diproses dan ditranskrip. Perbualan akan tersedia dalam satu minit.';
 
   @override
   String get tipKeepPhoneNearby => 'Pastikan telefon berdekatan untuk penyegerakan lebih pantas';
@@ -8634,12 +8458,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get permissionEnable => 'Dayakan';
 
   @override
-  String get permissionsPageDescription =>
-      'Kebenaran ini penting untuk cara Omi berfungsi. Ia membolehkan ciri utama seperti pemberitahuan, pengalaman berasaskan lokasi dan rakaman audio.';
+  String get permissionsPageDescription => 'Kebenaran ini penting untuk cara Omi berfungsi. Ia membolehkan ciri utama seperti pemberitahuan, pengalaman berasaskan lokasi dan rakaman audio.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi memerlukan beberapa kebenaran untuk berfungsi dengan betul. Sila berikan kebenaran untuk meneruskan.';
+  String get permissionsRequiredDescription => 'Omi memerlukan beberapa kebenaran untuk berfungsi dengan betul. Sila berikan kebenaran untuk meneruskan.';
 
   @override
   String get permissionsSetupTitle => 'Dapatkan pengalaman terbaik';
@@ -8693,8 +8515,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get justAMoment => 'Sebentar, sila';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Kami amat mengesyorkan anda meneroka pilihan lain anda daripada membatalkan.';
+  String get cancelConsequencesSubtitle => 'Kami amat mengesyorkan anda meneroka pilihan lain anda daripada membatalkan.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8917,8 +8738,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get firmwareWarningTitle => 'Penting: Baca Sebelum Mengemas Kini';
 
   @override
-  String get firmwareFormatWarning =>
-      'Firmware ini akan memformat kad SD. Sila pastikan semua data luar talian telah disegerakkan sebelum menaik taraf.\n\nJika anda melihat lampu merah berkelip selepas memasang versi ini, jangan risau. Sambungkan sahaja peranti ke aplikasi dan ia sepatutnya bertukar biru. Lampu merah bermakna jam peranti belum disegerakkan lagi.';
+  String get firmwareFormatWarning => 'Firmware ini akan memformat kad SD. Sila pastikan semua data luar talian telah disegerakkan sebelum menaik taraf.\n\nJika anda melihat lampu merah berkelip selepas memasang versi ini, jangan risau. Sambungkan sahaja peranti ke aplikasi dan ia sepatutnya bertukar biru. Lampu merah bermakna jam peranti belum disegerakkan lagi.';
 
   @override
   String get continueAnyway => 'Teruskan';
@@ -8938,8 +8758,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get tasksMarkComplete => 'Ditandai selesai';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi mengakses Apple Health melalui rangka kerja HealthKit Apple. Anda boleh membatalkan akses pada bila-bila masa dalam Tetapan iOS.';
+  String get appleHealthManageNote => 'Omi mengakses Apple Health melalui rangka kerja HealthKit Apple. Anda boleh membatalkan akses pada bila-bila masa dalam Tetapan iOS.';
 
   @override
   String get appleHealthConnectCta => 'Sambung ke Apple Health';
@@ -8972,8 +8791,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Akses Apple Health ditolak';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi tidak mempunyai kebenaran membaca data Apple Health anda. Dayakan di Tetapan iOS → Privasi & Keselamatan → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi tidak mempunyai kebenaran membaca data Apple Health anda. Dayakan di Tetapan iOS → Privasi & Keselamatan → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Mengapa anda pergi?';
@@ -9042,8 +8860,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get planUpdate => 'Kemas Kini Pelan';
 
   @override
-  String get planDeprecationMessage =>
-      'Pelan Unlimited anda sedang ditamatkan. Tukar ke pelan Operator — ciri-ciri hebat yang sama pada \$49/bulan. Pelan semasa anda akan terus berfungsi buat sementara waktu.';
+  String get planDeprecationMessage => 'Pelan Unlimited anda sedang ditamatkan. Tukar ke pelan Operator — ciri-ciri hebat yang sama pada \$49/bulan. Pelan semasa anda akan terus berfungsi buat sementara waktu.';
 
   @override
   String get upgradeYourPlan => 'Naik Taraf Pelan Anda';
@@ -9154,8 +8971,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Anda telah mencapai had bulanan. Naik taraf untuk terus bersembang dengan Omi tanpa sekatan.';
+  String get chatQuotaExceededReply => 'Anda telah mencapai had bulanan. Naik taraf untuk terus bersembang dengan Omi tanpa sekatan.';
 
   @override
   String get voiceResponseAudio => 'Baca respons Omi dengan kuat';
@@ -9186,4 +9002,25 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Tambah Tugas';
+
+  @override
+  String get quickActionAskOmiAnything => 'Tanya Omi apa sahaja';
+
+  @override
+  String get quickActionVoiceMode => 'Mod Suara';
+
+  @override
+  String get quickActionMute => 'Redam';
+
+  @override
+  String get quickActionUnmute => 'Nyahredam';
+
+  @override
+  String get quickActionConnectDevice => 'Sambung Peranti';
+
+  @override
+  String get quickActionDeviceSettings => 'Tetapan Peranti';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -24,8 +24,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteConversationTitle => 'Gesprek verwijderen?';
 
   @override
-  String get deleteConversationMessage =>
-      'Dit zal ook de bijbehorende herinneringen, taken en audiobestanden verwijderen. Deze actie kan niet ongedaan worden gemaakt.';
+  String get deleteConversationMessage => 'Dit zal ook de bijbehorende herinneringen, taken en audiobestanden verwijderen. Deze actie kan niet ongedaan worden gemaakt.';
 
   @override
   String get confirm => 'Bevestigen';
@@ -227,8 +226,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noStarredConversations => 'Geen gesprekken met ster';
 
   @override
-  String get starConversationHint =>
-      'Om een gesprek als favoriet te markeren, open het en tik op het stericoon in de header.';
+  String get starConversationHint => 'Om een gesprek als favoriet te markeren, open het en tik op het stericoon in de header.';
 
   @override
   String get searchConversations => 'Zoek gesprekken...';
@@ -286,8 +284,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get clearChat => 'Chat wissen';
 
   @override
-  String get clearChatConfirm =>
-      'Weet je zeker dat je de chat wilt wissen? Deze actie kan niet ongedaan worden gemaakt.';
+  String get clearChatConfirm => 'Weet je zeker dat je de chat wilt wissen? Deze actie kan niet ongedaan worden gemaakt.';
 
   @override
   String get maxFilesLimit => 'Je kunt maximaal 4 bestanden tegelijk uploaden';
@@ -320,8 +317,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get installedApps => 'Geïnstalleerde apps';
 
   @override
-  String get unableToFetchApps =>
-      'Kan apps niet ophalen :(\n\nControleer je internetverbinding en probeer het opnieuw.';
+  String get unableToFetchApps => 'Kan apps niet ophalen :(\n\nControleer je internetverbinding en probeer het opnieuw.';
 
   @override
   String get aboutOmi => 'Over Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get appsDisconnected => 'Je apps en integraties worden direct losgekoppeld.';
 
   @override
-  String get exportBeforeDelete =>
-      'Je kunt je gegevens exporteren voordat je je account verwijdert, maar eenmaal verwijderd kan het niet worden hersteld.';
+  String get exportBeforeDelete => 'Je kunt je gegevens exporteren voordat je je account verwijdert, maar eenmaal verwijderd kan het niet worden hersteld.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Ik begrijp dat het verwijderen van mijn account permanent is en alle gegevens, inclusief herinneringen en gesprekken, verloren gaan en niet kunnen worden hersteld.';
+  String get deleteAccountCheckbox => 'Ik begrijp dat het verwijderen van mijn account permanent is en alle gegevens, inclusief herinneringen en gesprekken, verloren gaan en niet kunnen worden hersteld.';
 
   @override
   String get areYouSure => 'Weet je het zeker?';
 
   @override
-  String get deleteAccountFinal =>
-      'Deze actie is onomkeerbaar en verwijdert permanent je account en alle bijbehorende gegevens. Weet je zeker dat je wilt doorgaan?';
+  String get deleteAccountFinal => 'Deze actie is onomkeerbaar en verwijdert permanent je account en alle bijbehorende gegevens. Weet je zeker dat je wilt doorgaan?';
 
   @override
   String get deleteNow => 'Nu verwijderen';
@@ -378,8 +371,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get goBack => 'Terug';
 
   @override
-  String get checkBoxToConfirm =>
-      'Vink het vakje aan om te bevestigen dat je begrijpt dat het verwijderen van je account permanent en onomkeerbaar is.';
+  String get checkBoxToConfirm => 'Vink het vakje aan om te bevestigen dat je begrijpt dat het verwijderen van je account permanent en onomkeerbaar is.';
 
   @override
   String get profile => 'Profiel';
@@ -457,8 +449,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get yourPrivacyYourControl => 'Jouw privacy, jouw controle';
 
   @override
-  String get privacyIntro =>
-      'Bij Omi zijn we toegewijd aan het beschermen van je privacy. Deze pagina stelt je in staat om te bepalen hoe je gegevens worden opgeslagen en gebruikt.';
+  String get privacyIntro => 'Bij Omi zijn we toegewijd aan het beschermen van je privacy. Deze pagina stelt je in staat om te bepalen hoe je gegevens worden opgeslagen en gebruikt.';
 
   @override
   String get learnMore => 'Meer informatie...';
@@ -467,15 +458,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dataProtectionLevel => 'Gegevensbeschermingsniveau';
 
   @override
-  String get dataProtectionDesc =>
-      'Je gegevens zijn standaard beveiligd met sterke encryptie. Bekijk hieronder je instellingen en toekomstige privacy-opties.';
+  String get dataProtectionDesc => 'Je gegevens zijn standaard beveiligd met sterke encryptie. Bekijk hieronder je instellingen en toekomstige privacy-opties.';
 
   @override
   String get appAccess => 'App-toegang';
 
   @override
-  String get appAccessDesc =>
-      'De volgende apps hebben toegang tot je gegevens. Tik op een app om de machtigingen te beheren.';
+  String get appAccessDesc => 'De volgende apps hebben toegang tot je gegevens. Tik op een app om de machtigingen te beheren.';
 
   @override
   String get noAppsExternalAccess => 'Geen geïnstalleerde apps hebben externe toegang tot je gegevens.';
@@ -532,22 +521,19 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Je Omi is losgekoppeld 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Apparaat ontkoppeld. Ga naar Instellingen > Bluetooth en vergeet het apparaat om het ontkoppelen te voltooien.';
+  String get deviceUnpairedMessage => 'Apparaat ontkoppeld. Ga naar Instellingen > Bluetooth en vergeet het apparaat om het ontkoppelen te voltooien.';
 
   @override
   String get unpairDialogTitle => 'Apparaat ontkoppelen';
 
   @override
-  String get unpairDialogMessage =>
-      'Dit ontkoppelt het apparaat zodat het met een andere telefoon kan worden verbonden. Je moet naar Instellingen > Bluetooth gaan en het apparaat vergeten om het proces te voltooien.';
+  String get unpairDialogMessage => 'Dit ontkoppelt het apparaat zodat het met een andere telefoon kan worden verbonden. Je moet naar Instellingen > Bluetooth gaan en het apparaat vergeten om het proces te voltooien.';
 
   @override
   String get deviceNotConnected => 'Apparaat niet verbonden';
 
   @override
-  String get connectDeviceMessage =>
-      'Verbind je Omi-apparaat om toegang te krijgen tot\napparaatinstellingen en aanpassingen';
+  String get connectDeviceMessage => 'Verbind je Omi-apparaat om toegang te krijgen tot\napparaatinstellingen en aanpassingen';
 
   @override
   String get deviceInfoSection => 'Apparaatinformatie';
@@ -562,8 +548,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get v2Undetected => 'V2 niet gedetecteerd';
 
   @override
-  String get v2UndetectedMessage =>
-      'We zien dat je een V1-apparaat hebt of je apparaat is niet verbonden. SD-kaartfunctionaliteit is alleen beschikbaar voor V2-apparaten.';
+  String get v2UndetectedMessage => 'We zien dat je een V1-apparaat hebt of je apparaat is niet verbonden. SD-kaartfunctionaliteit is alleen beschikbaar voor V2-apparaten.';
 
   @override
   String get endConversation => 'Gesprek beëindigen';
@@ -837,8 +822,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Kennisgraaf verwijderen?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Dit verwijdert alle afgeleide kennisgraafgegevens (knooppunten en verbindingen). Je originele herinneringen blijven veilig. De graaf wordt na verloop van tijd of bij het volgende verzoek opnieuw opgebouwd.';
+  String get deleteKnowledgeGraphMessage => 'Dit verwijdert alle afgeleide kennisgraafgegevens (knooppunten en verbindingen). Je originele herinneringen blijven veilig. De graaf wordt na verloop van tijd of bij het volgende verzoek opnieuw opgebouwd.';
 
   @override
   String get knowledgeGraphDeleted => 'Kennisgraaf verwijderd';
@@ -986,8 +970,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shortConversationThreshold => 'Drempel voor korte gesprekken';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Gesprekken korter dan dit worden verborgen tenzij hierboven ingeschakeld';
+  String get shortConversationThresholdSubtitle => 'Gesprekken korter dan dit worden verborgen tenzij hierboven ingeschakeld';
 
   @override
   String get durationThreshold => 'Duurdrempel';
@@ -1082,8 +1065,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get needYourPermission => 'We hebben je toestemming nodig';
 
   @override
-  String get alreadyGavePermission =>
-      'Je hebt ons al toestemming gegeven om je opnames op te slaan. Hier is een herinnering waarom we het nodig hebben:';
+  String get alreadyGavePermission => 'Je hebt ons al toestemming gegeven om je opnames op te slaan. Hier is een herinnering waarom we het nodig hebben:';
 
   @override
   String get wouldLikePermission => 'We willen graag je toestemming om je spraakopnames op te slaan. Dit is waarom:';
@@ -1092,26 +1074,22 @@ class AppLocalizationsNl extends AppLocalizations {
   String get improveSpeechProfile => 'Verbeter je spraakprofiel';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'We gebruiken opnames om je persoonlijke spraakprofiel verder te trainen en te verbeteren.';
+  String get improveSpeechProfileDesc => 'We gebruiken opnames om je persoonlijke spraakprofiel verder te trainen en te verbeteren.';
 
   @override
   String get trainFamilyProfiles => 'Train profielen voor vrienden en familie';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Je opnames helpen ons om profielen voor je vrienden en familie te herkennen en aan te maken.';
+  String get trainFamilyProfilesDesc => 'Je opnames helpen ons om profielen voor je vrienden en familie te herkennen en aan te maken.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Verbeter transcriptnauwkeurigheid';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Naarmate ons model verbetert, kunnen we betere transcriptieresultaten voor je opnames bieden.';
+  String get enhanceTranscriptAccuracyDesc => 'Naarmate ons model verbetert, kunnen we betere transcriptieresultaten voor je opnames bieden.';
 
   @override
-  String get legalNotice =>
-      'Juridische kennisgeving: De legaliteit van het opnemen en opslaan van spraakgegevens kan variëren afhankelijk van je locatie en hoe je deze functie gebruikt. Het is jouw verantwoordelijkheid om naleving van lokale wet- en regelgeving te waarborgen.';
+  String get legalNotice => 'Juridische kennisgeving: De legaliteit van het opnemen en opslaan van spraakgegevens kan variëren afhankelijk van je locatie en hoe je deze functie gebruikt. Het is jouw verantwoordelijkheid om naleving van lokale wet- en regelgeving te waarborgen.';
 
   @override
   String get alreadyAuthorized => 'Al geautoriseerd';
@@ -1189,8 +1167,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get showEventsNoParticipants => 'Evenementen zonder deelnemers tonen';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Wanneer ingeschakeld, toont Binnenkort evenementen zonder deelnemers of videolink.';
+  String get showEventsNoParticipantsDesc => 'Wanneer ingeschakeld, toont Binnenkort evenementen zonder deelnemers of videolink.';
 
   @override
   String get yourMeetings => 'Je vergaderingen';
@@ -1231,8 +1208,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noProjectsInWorkspace => 'Geen projecten gevonden in deze werkruimte';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Kies hoe lang te wachten in stilte voordat een gesprek automatisch wordt beëindigd:';
+  String get conversationTimeoutDesc => 'Kies hoe lang te wachten in stilte voordat een gesprek automatisch wordt beëindigd:';
 
   @override
   String get timeout2Minutes => '2 minuten';
@@ -1276,12 +1252,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Vertel ons je primaire taal';
 
   @override
-  String get languageForTranscription =>
-      'Stel je taal in voor scherpere transcripties en een gepersonaliseerde ervaring.';
+  String get languageForTranscription => 'Stel je taal in voor scherpere transcripties en een gepersonaliseerde ervaring.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Enkeltaalmodus is ingeschakeld. Vertaling is uitgeschakeld voor hogere nauwkeurigheid.';
+  String get singleLanguageModeInfo => 'Enkeltaalmodus is ingeschakeld. Vertaling is uitgeschakeld voor hogere nauwkeurigheid.';
 
   @override
   String get searchLanguageHint => 'Zoek taal op naam of code';
@@ -1361,8 +1335,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get defaultRepository => 'Standaard repository';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Selecteer een standaard repository voor het aanmaken van issues. Je kunt nog steeds een andere repository opgeven bij het aanmaken van issues.';
+  String get selectDefaultRepoDesc => 'Selecteer een standaard repository voor het aanmaken van issues. Je kunt nog steeds een andere repository opgeven bij het aanmaken van issues.';
 
   @override
   String get noReposFound => 'Geen repositories gevonden';
@@ -1737,8 +1710,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth inschakelen';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi heeft Bluetooth nodig om verbinding te maken met je wearable. Schakel Bluetooth in en probeer het opnieuw.';
+  String get bluetoothNeeded => 'Omi heeft Bluetooth nodig om verbinding te maken met je wearable. Schakel Bluetooth in en probeer het opnieuw.';
 
   @override
   String get contactSupport => 'Contact opnemen met support?';
@@ -1771,26 +1743,22 @@ class AppLocalizationsNl extends AppLocalizations {
   String get locationServiceDisabled => 'Locatieservice uitgeschakeld';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Locatieservice is uitgeschakeld. Ga naar Instellingen > Privacy en beveiliging > Locatievoorzieningen en schakel deze in';
+  String get locationServiceDisabledDesc => 'Locatieservice is uitgeschakeld. Ga naar Instellingen > Privacy en beveiliging > Locatievoorzieningen en schakel deze in';
 
   @override
   String get backgroundLocationDenied => 'Achtergrondlocatietoegang geweigerd';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Ga naar apparaatinstellingen en stel locatiemachtiging in op \"Altijd toestaan\"';
+  String get backgroundLocationDeniedDesc => 'Ga naar apparaatinstellingen en stel locatiemachtiging in op \"Altijd toestaan\"';
 
   @override
   String get lovingOmi => 'Ben je blij met Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Help ons meer mensen te bereiken door een review achter te laten in de App Store. Je feedback betekent enorm veel voor ons!';
+  String get leaveReviewIos => 'Help ons meer mensen te bereiken door een review achter te laten in de App Store. Je feedback betekent enorm veel voor ons!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Help ons meer mensen te bereiken door een review achter te laten in de Google Play Store. Je feedback betekent enorm veel voor ons!';
+  String get leaveReviewAndroid => 'Help ons meer mensen te bereiken door een review achter te laten in de Google Play Store. Je feedback betekent enorm veel voor ons!';
 
   @override
   String get rateOnAppStore => 'Beoordelen in App Store';
@@ -1823,15 +1791,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get connectionError => 'Verbindingsfout';
 
   @override
-  String get connectionErrorDesc =>
-      'Kan geen verbinding maken met de server. Controleer je internetverbinding en probeer het opnieuw.';
+  String get connectionErrorDesc => 'Kan geen verbinding maken met de server. Controleer je internetverbinding en probeer het opnieuw.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Ongeldige opname gedetecteerd';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Het lijkt erop dat er meerdere sprekers in de opname zijn. Zorg ervoor dat je op een rustige locatie bent en probeer het opnieuw.';
+  String get multipleSpeakersDesc => 'Het lijkt erop dat er meerdere sprekers in de opname zijn. Zorg ervoor dat je op een rustige locatie bent en probeer het opnieuw.';
 
   @override
   String get tooShortDesc => 'Er is niet genoeg spraak gedetecteerd. Spreek meer en probeer het opnieuw.';
@@ -1843,15 +1809,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get areYouThere => 'Ben je er nog?';
 
   @override
-  String get noSpeechDesc =>
-      'We konden geen spraak detecteren. Zorg ervoor dat je minimaal 10 seconden en niet meer dan 3 minuten spreekt.';
+  String get noSpeechDesc => 'We konden geen spraak detecteren. Zorg ervoor dat je minimaal 10 seconden en niet meer dan 3 minuten spreekt.';
 
   @override
   String get connectionLost => 'Verbinding verbroken';
 
   @override
-  String get connectionLostDesc =>
-      'De verbinding is onderbroken. Controleer je internetverbinding en probeer het opnieuw.';
+  String get connectionLostDesc => 'De verbinding is onderbroken. Controleer je internetverbinding en probeer het opnieuw.';
 
   @override
   String get tryAgain => 'Opnieuw proberen';
@@ -1866,8 +1830,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get permissionsRequired => 'Machtigingen vereist';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Deze app heeft Bluetooth- en locatiemachtigingen nodig om correct te functioneren. Schakel deze in via de instellingen.';
+  String get permissionsRequiredDesc => 'Deze app heeft Bluetooth- en locatiemachtigingen nodig om correct te functioneren. Schakel deze in via de instellingen.';
 
   @override
   String get openSettings => 'Instellingen openen';
@@ -1897,8 +1860,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Je AI-metgezel';
 
   @override
-  String get captureEveryMoment =>
-      'Leg elk moment vast. Krijg AI-aangedreven\nsamenvattingen. Nooit meer notities maken.';
+  String get captureEveryMoment => 'Leg elk moment vast. Krijg AI-aangedreven\nsamenvattingen. Nooit meer notities maken.';
 
   @override
   String get appleWatchSetup => 'Apple Watch instellen';
@@ -1910,12 +1872,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get microphonePermission => 'Microfoontoestemming';
 
   @override
-  String get permissionGrantedNow =>
-      'Toestemming verleend! Nu:\n\nOpen de Omi-app op je horloge en tik hieronder op \"Doorgaan\"';
+  String get permissionGrantedNow => 'Toestemming verleend! Nu:\n\nOpen de Omi-app op je horloge en tik hieronder op \"Doorgaan\"';
 
   @override
-  String get needMicrophonePermission =>
-      'We hebben microfoontoestemming nodig.\n\n1. Tik op \"Toestemming verlenen\"\n2. Sta toe op je iPhone\n3. Horloge-app sluit\n4. Heropen en tik op \"Doorgaan\"';
+  String get needMicrophonePermission => 'We hebben microfoontoestemming nodig.\n\n1. Tik op \"Toestemming verlenen\"\n2. Sta toe op je iPhone\n3. Horloge-app sluit\n4. Heropen en tik op \"Doorgaan\"';
 
   @override
   String get grantPermissionButton => 'Toestemming verlenen';
@@ -1924,15 +1884,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get needHelp => 'Hulp nodig?';
 
   @override
-  String get troubleshootingSteps =>
-      'Probleemoplossing:\n\n1. Zorg dat Omi op je horloge is geïnstalleerd\n2. Open de Omi-app op je horloge\n3. Zoek naar de toestemmingspopup\n4. Tik op \"Toestaan\" wanneer gevraagd\n5. App op je horloge sluit - heropen deze\n6. Kom terug en tik op \"Doorgaan\" op je iPhone';
+  String get troubleshootingSteps => 'Probleemoplossing:\n\n1. Zorg dat Omi op je horloge is geïnstalleerd\n2. Open de Omi-app op je horloge\n3. Zoek naar de toestemmingspopup\n4. Tik op \"Toestaan\" wanneer gevraagd\n5. App op je horloge sluit - heropen deze\n6. Kom terug en tik op \"Doorgaan\" op je iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Opname succesvol gestart!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Toestemming nog niet verleend. Zorg dat je microfoontoestemming hebt gegeven en de app op je horloge hebt heropend.';
+  String get permissionNotGrantedYet => 'Toestemming nog niet verleend. Zorg dat je microfoontoestemming hebt gegeven en de app op je horloge hebt heropend.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2029,8 +1987,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Klaar voor actiepunten';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Je AI haalt automatisch taken en to-do\'s uit je gesprekken. Ze verschijnen hier wanneer ze zijn aangemaakt.';
+  String get welcomeActionItemsDescription => 'Je AI haalt automatisch taken en to-do\'s uit je gesprekken. Ze verschijnen hier wanneer ze zijn aangemaakt.';
 
   @override
   String get autoExtractionFeature => 'Automatisch geëxtraheerd uit gesprekken';
@@ -2080,8 +2037,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get clearMemoryTitle => 'Omi\'s geheugen wissen';
 
   @override
-  String get clearMemoryMessage =>
-      'Weet je zeker dat je Omi\'s geheugen wilt wissen? Deze actie kan niet ongedaan worden gemaakt.';
+  String get clearMemoryMessage => 'Weet je zeker dat je Omi\'s geheugen wilt wissen? Deze actie kan niet ongedaan worden gemaakt.';
 
   @override
   String get clearMemoryButton => 'Geheugen wissen';
@@ -2227,15 +2183,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'SPRAAK & TRANSCRIPTIE';
 
   @override
-  String get languageSettingsHelperText =>
-      'App-taal verandert menu\'s en knoppen. Spraaktaal beïnvloedt hoe je opnames worden getranscribeerd.';
+  String get languageSettingsHelperText => 'App-taal verandert menu\'s en knoppen. Spraaktaal beïnvloedt hoe je opnames worden getranscribeerd.';
 
   @override
   String get translationNotice => 'Vertaalbericht';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi vertaalt gesprekken naar uw primaire taal. Update deze op elk moment in Instellingen → Profielen.';
+  String get translationNoticeMessage => 'Omi vertaalt gesprekken naar uw primaire taal. Update deze op elk moment in Instellingen → Profielen.';
 
   @override
   String get pleaseCheckInternetConnection => 'Controleer uw internetverbinding en probeer het opnieuw';
@@ -2255,8 +2209,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Dit gesprek kan niet worden samengevoegd (vergrendeld of al aan het samenvoegen)';
+  String get conversationCannotBeMerged => 'Dit gesprek kan niet worden samengevoegd (vergrendeld of al aan het samenvoegen)';
 
   @override
   String get pleaseEnterFolderName => 'Voer een mapnaam in';
@@ -2391,8 +2344,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Apparaat ontkoppelen';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Dit zal het apparaat ontkoppelen zodat het kan worden verbonden met een andere telefoon. U moet naar Instellingen > Bluetooth gaan en het apparaat vergeten om het proces te voltooien.';
+  String get unpairDeviceDialogMessage => 'Dit zal het apparaat ontkoppelen zodat het kan worden verbonden met een andere telefoon. U moet naar Instellingen > Bluetooth gaan en het apparaat vergeten om het proces te voltooien.';
 
   @override
   String get unpair => 'Ontkoppelen';
@@ -2573,8 +2525,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get youreAllSet => 'Je bent klaar!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Welkom bij Omi! Je AI-metgezel is klaar om je te helpen met gesprekken, taken en meer.';
+  String get welcomeToOmiDescription => 'Welkom bij Omi! Je AI-metgezel is klaar om je te helpen met gesprekken, taken en meer.';
 
   @override
   String get startUsingOmi => 'Begin met Omi';
@@ -2710,8 +2661,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noTasksYet => 'Nog geen taken';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Taken uit je gesprekken verschijnen hier.\nKlik op Aanmaken om er handmatig een toe te voegen.';
+  String get tasksFromConversationsWillAppear => 'Taken uit je gesprekken verschijnen hier.\nKlik op Aanmaken om er handmatig een toe te voegen.';
 
   @override
   String get monthJan => 'Jan';
@@ -2768,8 +2718,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteActionItem => 'Actie-item verwijderen';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Weet je zeker dat je dit actie-item wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.';
+  String get deleteActionItemConfirmation => 'Weet je zeker dat je dit actie-item wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.';
 
   @override
   String get enterActionItemDescription => 'Voer actie-itembeschrijving in...';
@@ -2844,15 +2793,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get chatPrompt => 'Chat-prompt';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Je bent een geweldige app, je taak is om te reageren op gebruikersvragen en hen zich goed te laten voelen...';
+  String get chatPromptPlaceholder => 'Je bent een geweldige app, je taak is om te reageren op gebruikersvragen en hen zich goed te laten voelen...';
 
   @override
   String get conversationPrompt => 'Gespreksprompt';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Je bent een geweldige app, je krijgt een transcriptie en samenvatting van een gesprek...';
+  String get conversationPromptPlaceholder => 'Je bent een geweldige app, je krijgt een transcriptie en samenvatting van een gesprek...';
 
   @override
   String get notificationScopes => 'Meldingsbereiken';
@@ -2864,8 +2811,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get makeMyAppPublic => 'Mijn app openbaar maken';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Door deze app in te dienen, ga ik akkoord met de Servicevoorwaarden en het Privacybeleid van Omi AI';
+  String get submitAppTermsAgreement => 'Door deze app in te dienen, ga ik akkoord met de Servicevoorwaarden en het Privacybeleid van Omi AI';
 
   @override
   String get submitApp => 'App indienen';
@@ -2880,12 +2826,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get submitAppQuestion => 'App indienen?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Je app wordt beoordeeld en openbaar gemaakt. Je kunt het onmiddellijk gebruiken, zelfs tijdens de beoordeling!';
+  String get submitAppPublicDescription => 'Je app wordt beoordeeld en openbaar gemaakt. Je kunt het onmiddellijk gebruiken, zelfs tijdens de beoordeling!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Je app wordt beoordeeld en privé beschikbaar gemaakt voor jou. Je kunt het onmiddellijk gebruiken, zelfs tijdens de beoordeling!';
+  String get submitAppPrivateDescription => 'Je app wordt beoordeeld en privé beschikbaar gemaakt voor jou. Je kunt het onmiddellijk gebruiken, zelfs tijdens de beoordeling!';
 
   @override
   String get startEarning => 'Begin met verdienen! 💰';
@@ -2909,23 +2853,19 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dataAccessNotice => 'Melding gegevenstoegang';
 
   @override
-  String get dataAccessWarning =>
-      'Deze app heeft toegang tot uw gegevens. Omi AI is niet verantwoordelijk voor hoe uw gegevens worden gebruikt, gewijzigd of verwijderd door deze app';
+  String get dataAccessWarning => 'Deze app heeft toegang tot uw gegevens. Omi AI is niet verantwoordelijk voor hoe uw gegevens worden gebruikt, gewijzigd of verwijderd door deze app';
 
   @override
   String get installApp => 'App installeren';
 
   @override
-  String get betaTesterNotice =>
-      'U bent een bètatester voor deze app. Het is nog niet openbaar. Het wordt openbaar zodra het is goedgekeurd.';
+  String get betaTesterNotice => 'U bent een bètatester voor deze app. Het is nog niet openbaar. Het wordt openbaar zodra het is goedgekeurd.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Uw app wordt beoordeeld en is alleen zichtbaar voor u. Het wordt openbaar zodra het is goedgekeurd.';
+  String get appUnderReviewOwner => 'Uw app wordt beoordeeld en is alleen zichtbaar voor u. Het wordt openbaar zodra het is goedgekeurd.';
 
   @override
-  String get appRejectedNotice =>
-      'Uw app is afgewezen. Werk de app-details bij en dien deze opnieuw in ter beoordeling.';
+  String get appRejectedNotice => 'Uw app is afgewezen. Werk de app-details bij en dien deze opnieuw in ter beoordeling.';
 
   @override
   String get setupSteps => 'Installatiestappen';
@@ -2960,8 +2900,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get errorActivatingApp => 'Fout bij activeren van de app';
 
   @override
-  String get integrationSetupRequired =>
-      'Als dit een integratie-app is, zorg er dan voor dat de installatie is voltooid.';
+  String get integrationSetupRequired => 'Als dit een integratie-app is, zorg er dan voor dat de installatie is voltooid.';
 
   @override
   String get installed => 'Geïnstalleerd';
@@ -2988,8 +2927,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get descriptionLabel => 'Beschrijving';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Mijn geweldige app is een geweldige app die geweldige dingen doet. Het is de beste app ooit!';
+  String get appDescriptionPlaceholder => 'Mijn geweldige app is een geweldige app die geweldige dingen doet. Het is de beste app ooit!';
 
   @override
   String get pleaseProvideValidDescription => 'Geef een geldige beschrijving op';
@@ -3141,8 +3079,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get microphonePermissionRequired => 'Microfoontoegang is vereist voor spraakopname.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Microfoontoegang geweigerd. Verleen toestemming in Systeemvoorkeuren > Privacy & beveiliging > Microfoon.';
+  String get microphonePermissionDenied => 'Microfoontoegang geweigerd. Verleen toestemming in Systeemvoorkeuren > Privacy & beveiliging > Microfoon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3301,8 +3238,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get createMemory => 'Geheugen maken';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Weet je zeker dat je dit geheugen wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.';
+  String get deleteMemoryConfirmation => 'Weet je zeker dat je dit geheugen wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.';
 
   @override
   String get makePrivate => 'Privé maken';
@@ -3376,8 +3312,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get whatWeCollect => 'Wat we verzamelen';
 
   @override
-  String get dataCollectionMessage =>
-      'Door door te gaan, worden je gesprekken, opnames en persoonlijke informatie veilig opgeslagen op onze servers om AI-gedreven inzichten te bieden en alle app-functies mogelijk te maken.';
+  String get dataCollectionMessage => 'Door door te gaan, worden je gesprekken, opnames en persoonlijke informatie veilig opgeslagen op onze servers om AI-gedreven inzichten te bieden en alle app-functies mogelijk te maken.';
 
   @override
   String get dataProtection => 'Gegevensbescherming';
@@ -3410,8 +3345,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Naam moet minstens 2 tekens bevatten';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Vertel ons hoe u aangesproken wilt worden. Dit helpt uw Omi-ervaring te personaliseren.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Vertel ons hoe u aangesproken wilt worden. Dit helpt uw Omi-ervaring te personaliseren.';
 
   @override
   String charactersCount(int count) {
@@ -3428,8 +3362,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get recordAudioConversations => 'Audiogesprekken opnemen';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi heeft microfoontoegang nodig om uw gesprekken op te nemen en transcripties te leveren.';
+  String get microphoneAccessDescription => 'Omi heeft microfoontoegang nodig om uw gesprekken op te nemen en transcripties te leveren.';
 
   @override
   String get screenRecording => 'Schermopname';
@@ -3438,8 +3371,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Systeemaudio van vergaderingen vastleggen';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi heeft toestemming voor schermopname nodig om systeemaudio van uw browsergebaseerde vergaderingen vast te leggen.';
+  String get screenRecordingDescription => 'Omi heeft toestemming voor schermopname nodig om systeemaudio van uw browsergebaseerde vergaderingen vast te leggen.';
 
   @override
   String get accessibility => 'Toegankelijkheid';
@@ -3448,8 +3380,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Browsergebaseerde vergaderingen detecteren';
 
   @override
-  String get accessibilityDescription =>
-      'Omi heeft toegankelijkheidstoestemming nodig om te detecteren wanneer u deelneemt aan Zoom-, Meet- of Teams-vergaderingen in uw browser.';
+  String get accessibilityDescription => 'Omi heeft toegankelijkheidstoestemming nodig om te detecteren wanneer u deelneemt aan Zoom-, Meet- of Teams-vergaderingen in uw browser.';
 
   @override
   String get pleaseWait => 'Even geduld...';
@@ -3521,8 +3452,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get conversationsExportStarted => 'Export van gesprekken gestart. Dit kan enkele seconden duren, even geduld.';
 
   @override
-  String get mcpDescription =>
-      'Om Omi te verbinden met andere applicaties om uw herinneringen en gesprekken te lezen, te zoeken en te beheren. Maak een sleutel om te beginnen.';
+  String get mcpDescription => 'Om Omi te verbinden met andere applicaties om uw herinneringen en gesprekken te lezen, te zoeken en te beheren. Maak een sleutel om te beginnen.';
 
   @override
   String get apiKeys => 'API-sleutels';
@@ -3563,15 +3493,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Diagnostische status van transcriptieservice';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Gedetailleerde diagnostische berichten van de transcriptieservice inschakelen';
+  String get enableDetailedDiagnosticMessages => 'Gedetailleerde diagnostische berichten van de transcriptieservice inschakelen';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Nieuwe sprekers automatisch aanmaken en taggen';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Maak automatisch een nieuwe persoon aan wanneer een naam wordt gedetecteerd in de transcriptie.';
+  String get automaticallyCreateNewPerson => 'Maak automatisch een nieuwe persoon aan wanneer een naam wordt gedetecteerd in de transcriptie.';
 
   @override
   String get pilotFeatures => 'Pilotfuncties';
@@ -3595,8 +3523,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get auto => 'Automatisch';
 
   @override
-  String get noSummaryForApp =>
-      'Geen samenvatting beschikbaar voor deze app. Probeer een andere app voor betere resultaten.';
+  String get noSummaryForApp => 'Geen samenvatting beschikbaar voor deze app. Probeer een andere app voor betere resultaten.';
 
   @override
   String get tryAnotherApp => 'Probeer een andere app';
@@ -3633,8 +3560,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Laat Omi automatisch de beste app kiezen';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Weet u zeker dat u dit gesprek wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.';
+  String get deleteConversationConfirmation => 'Weet u zeker dat u dit gesprek wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.';
 
   @override
   String get conversationDeleted => 'Gesprek verwijderd';
@@ -3682,8 +3608,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Systeemaudio-opname voorbereiden';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klik op de knop om audio vast te leggen voor live transcripties, AI-inzichten en automatisch opslaan.';
+  String get clickTheButtonToCaptureAudio => 'Klik op de knop om audio vast te leggen voor live transcripties, AI-inzichten en automatisch opslaan.';
 
   @override
   String get reconnecting => 'Opnieuw verbinden...';
@@ -3841,8 +3766,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dailySummaryTitle => 'Dagelijkse Samenvatting';
 
   @override
-  String get dailySummaryDescription =>
-      'Ontvang een gepersonaliseerde samenvatting van je dagelijkse gesprekken als melding.';
+  String get dailySummaryDescription => 'Ontvang een gepersonaliseerde samenvatting van je dagelijkse gesprekken als melding.';
 
   @override
   String get deliveryTime => 'Bezorgtijd';
@@ -3911,8 +3835,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Kennisgrafiek verwijderen?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Dit verwijdert alle afgeleide kennisgrafiekgegevens. Uw originele herinneringen blijven veilig.';
+  String get deleteKnowledgeGraphWarning => 'Dit verwijdert alle afgeleide kennisgrafiekgegevens. Uw originele herinneringen blijven veilig.';
 
   @override
   String get connectOmiWithAI => 'Verbind Omi met AI-assistenten';
@@ -3954,8 +3877,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Voorwaarden en Privacybeleid';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Helpt bij het diagnosticeren van problemen. Wordt na 3 dagen automatisch verwijderd.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Helpt bij het diagnosticeren van problemen. Wordt na 3 dagen automatisch verwijderd.';
 
   @override
   String get manageYourApp => 'Beheer uw app';
@@ -3970,8 +3892,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get updateAppQuestion => 'App bijwerken?';
 
   @override
-  String get updateAppConfirmation =>
-      'Weet u zeker dat u uw app wilt bijwerken? De wijzigingen worden doorgevoerd na beoordeling door ons team.';
+  String get updateAppConfirmation => 'Weet u zeker dat u uw app wilt bijwerken? De wijzigingen worden doorgevoerd na beoordeling door ons team.';
 
   @override
   String get updateApp => 'App bijwerken';
@@ -4001,8 +3922,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get no => 'Nee';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abonnement succesvol geannuleerd. Het blijft actief tot het einde van de huidige factureringsperiode.';
+  String get subscriptionCancelledSuccessfully => 'Abonnement succesvol geannuleerd. Het blijft actief tot het einde van de huidige factureringsperiode.';
 
   @override
   String get failedToCancelSubscription => 'Annuleren van abonnement mislukt. Probeer het opnieuw.';
@@ -4038,8 +3958,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Abonnement annuleren?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Weet u zeker dat u uw abonnement wilt annuleren? U behoudt toegang tot het einde van uw huidige factureringsperiode.';
+  String get cancelSubscriptionConfirmation => 'Weet u zeker dat u uw abonnement wilt annuleren? U behoudt toegang tot het einde van uw huidige factureringsperiode.';
 
   @override
   String get cancelSubscriptionButton => 'Abonnement annuleren';
@@ -4048,12 +3967,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get cancelling => 'Annuleren...';
 
   @override
-  String get betaTesterMessage =>
-      'U bent een bètatester voor deze app. Deze is nog niet openbaar. Deze wordt openbaar na goedkeuring.';
+  String get betaTesterMessage => 'U bent een bètatester voor deze app. Deze is nog niet openbaar. Deze wordt openbaar na goedkeuring.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Uw app wordt beoordeeld en is alleen voor u zichtbaar. Deze wordt openbaar na goedkeuring.';
+  String get appUnderReviewMessage => 'Uw app wordt beoordeeld en is alleen voor u zichtbaar. Deze wordt openbaar na goedkeuring.';
 
   @override
   String get appRejectedMessage => 'Uw app is afgewezen. Werk de gegevens bij en dien opnieuw in ter beoordeling.';
@@ -4110,8 +4027,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get issueActivatingApp => 'Er is een probleem opgetreden bij het activeren van deze app. Probeer het opnieuw.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Deze app krijgt toegang tot je gegevens. Omi AI is niet verantwoordelijk voor hoe je gegevens worden gebruikt, gewijzigd of verwijderd door deze app';
+  String get dataAccessNoticeDescription => 'Deze app krijgt toegang tot je gegevens. Omi AI is niet verantwoordelijk voor hoe je gegevens worden gebruikt, gewijzigd of verwijderd door deze app';
 
   @override
   String get copyUrl => 'URL kopiëren';
@@ -4199,8 +4115,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get omiApiKeys => 'Omi API-sleutels';
 
   @override
-  String get apiKeysDescription =>
-      'API-sleutels worden gebruikt voor authenticatie wanneer uw app communiceert met de OMI-server. Ze stellen uw applicatie in staat om herinneringen te maken en veilig toegang te krijgen tot andere OMI-services.';
+  String get apiKeysDescription => 'API-sleutels worden gebruikt voor authenticatie wanneer uw app communiceert met de OMI-server. Ze stellen uw applicatie in staat om herinneringen te maken en veilig toegang te krijgen tot andere OMI-services.';
 
   @override
   String get aboutOmiApiKeys => 'Over Omi API-sleutels';
@@ -4224,8 +4139,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API-sleutel intrekken?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Deze actie kan niet ongedaan worden gemaakt. Applicaties die deze sleutel gebruiken, hebben geen toegang meer tot de API.';
+  String get revokeApiKeyWarning => 'Deze actie kan niet ongedaan worden gemaakt. Applicaties die deze sleutel gebruiken, hebben geen toegang meer tot de API.';
 
   @override
   String get revoke => 'Intrekken';
@@ -4323,8 +4237,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get externalAppAccess => 'Externe app-toegang';
 
   @override
-  String get externalAppAccessDescription =>
-      'De volgende geïnstalleerde apps hebben externe integraties en kunnen toegang krijgen tot uw gegevens, zoals gesprekken en herinneringen.';
+  String get externalAppAccessDescription => 'De volgende geïnstalleerde apps hebben externe integraties en kunnen toegang krijgen tot uw gegevens, zoals gesprekken en herinneringen.';
 
   @override
   String get noExternalAppsHaveAccess => 'Geen externe apps hebben toegang tot uw gegevens.';
@@ -4333,8 +4246,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maximale beveiliging (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-end-encryptie is de gouden standaard voor privacy. Wanneer ingeschakeld, worden uw gegevens op uw apparaat versleuteld voordat ze naar onze servers worden verzonden. Dit betekent dat niemand, zelfs Omi niet, toegang heeft tot uw inhoud.';
+  String get e2eeDescription => 'End-to-end-encryptie is de gouden standaard voor privacy. Wanneer ingeschakeld, worden uw gegevens op uw apparaat versleuteld voordat ze naar onze servers worden verzonden. Dit betekent dat niemand, zelfs Omi niet, toegang heeft tot uw inhoud.';
 
   @override
   String get importantTradeoffs => 'Belangrijke afwegingen:';
@@ -4349,8 +4261,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get featureComingSoon => 'Deze functie komt binnenkort!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migratie bezig. U kunt het beveiligingsniveau niet wijzigen totdat deze is voltooid.';
+  String get migrationInProgressMessage => 'Migratie bezig. U kunt het beveiligingsniveau niet wijzigen totdat deze is voltooid.';
 
   @override
   String get migrationFailed => 'Migratie mislukt';
@@ -4369,19 +4280,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get secureEncryption => 'Veilige versleuteling';
 
   @override
-  String get secureEncryptionDescription =>
-      'Uw gegevens worden versleuteld met een voor u unieke sleutel op onze servers, gehost op Google Cloud. Dit betekent dat uw ruwe inhoud ontoegankelijk is voor iedereen, inclusief Omi-medewerkers of Google, rechtstreeks vanuit de database.';
+  String get secureEncryptionDescription => 'Uw gegevens worden versleuteld met een voor u unieke sleutel op onze servers, gehost op Google Cloud. Dit betekent dat uw ruwe inhoud ontoegankelijk is voor iedereen, inclusief Omi-medewerkers of Google, rechtstreeks vanuit de database.';
 
   @override
   String get endToEndEncryption => 'End-to-end-encryptie';
 
   @override
-  String get e2eeCardDescription =>
-      'Schakel in voor maximale beveiliging waarbij alleen u toegang heeft tot uw gegevens. Tik om meer te weten te komen.';
+  String get e2eeCardDescription => 'Schakel in voor maximale beveiliging waarbij alleen u toegang heeft tot uw gegevens. Tik om meer te weten te komen.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Ongeacht het niveau zijn uw gegevens altijd versleuteld in rust en tijdens overdracht.';
+  String get dataAlwaysEncrypted => 'Ongeacht het niveau zijn uw gegevens altijd versleuteld in rust en tijdens overdracht.';
 
   @override
   String get readOnlyScope => 'Alleen lezen';
@@ -4446,12 +4354,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trainingDataProgram => 'Trainingsdataprogramma';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Krijg Omi Unlimited gratis door uw gegevens bij te dragen voor het trainen van AI-modellen.';
+  String get getOmiUnlimitedFree => 'Krijg Omi Unlimited gratis door uw gegevens bij te dragen voor het trainen van AI-modellen.';
 
   @override
-  String get trainingDataBullets =>
-      '• Uw gegevens helpen AI-modellen te verbeteren\n• Alleen niet-gevoelige gegevens worden gedeeld\n• Volledig transparant proces';
+  String get trainingDataBullets => '• Uw gegevens helpen AI-modellen te verbeteren\n• Alleen niet-gevoelige gegevens worden gedeeld\n• Volledig transparant proces';
 
   @override
   String get learnMoreAtOmiTraining => 'Meer informatie op omi.me/training';
@@ -4463,8 +4369,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get submitRequest => 'Verzoek indienen';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Bedankt! Uw verzoek wordt beoordeeld. We laten u weten wanneer het is goedgekeurd.';
+  String get thankYouRequestUnderReview => 'Bedankt! Uw verzoek wordt beoordeeld. We laten u weten wanneer het is goedgekeurd.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4502,8 +4407,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get monthlyPlanContinues => 'Uw huidige maandabonnement loopt door tot het einde van uw factureringsperiode';
 
   @override
-  String get paymentMethodCharged =>
-      'Uw bestaande betaalmethode wordt automatisch belast wanneer uw maandabonnement eindigt';
+  String get paymentMethodCharged => 'Uw bestaande betaalmethode wordt automatisch belast wanneer uw maandabonnement eindigt';
 
   @override
   String get annualSubscriptionStarts => 'Uw 12-maanden jaarabonnement start automatisch na de betaling';
@@ -4613,8 +4517,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Uw privacy is belangrijk voor ons';
 
   @override
-  String get privacyIntroText =>
-      'Bij Omi nemen we uw privacy zeer serieus. We willen transparant zijn over de gegevens die we verzamelen en hoe we deze gebruiken. Dit moet u weten:';
+  String get privacyIntroText => 'Bij Omi nemen we uw privacy zeer serieus. We willen transparant zijn over de gegevens die we verzamelen en hoe we deze gebruiken. Dit moet u weten:';
 
   @override
   String get whatWeTrack => 'Wat we bijhouden';
@@ -4629,12 +4532,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get ourCommitment => 'Onze toezegging';
 
   @override
-  String get commitmentText =>
-      'We zijn toegewijd om de verzamelde gegevens alleen te gebruiken om Omi een beter product voor u te maken. Uw privacy en vertrouwen zijn van het grootste belang voor ons.';
+  String get commitmentText => 'We zijn toegewijd om de verzamelde gegevens alleen te gebruiken om Omi een beter product voor u te maken. Uw privacy en vertrouwen zijn van het grootste belang voor ons.';
 
   @override
-  String get thankYouText =>
-      'Bedankt dat u een gewaardeerde gebruiker van Omi bent. Als u vragen of zorgen heeft, neem dan gerust contact met ons op via team@basedhardware.com.';
+  String get thankYouText => 'Bedankt dat u een gewaardeerde gebruiker van Omi bent. Als u vragen of zorgen heeft, neem dan gerust contact met ons op via team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi-synchronisatie-instellingen';
@@ -4643,8 +4544,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get enterHotspotCredentials => 'Voer de hotspot-inloggegevens van uw telefoon in';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi-sync gebruikt uw telefoon als hotspot. Vind de naam en het wachtwoord in Instellingen > Persoonlijke hotspot.';
+  String get wifiSyncUsesHotspot => 'WiFi-sync gebruikt uw telefoon als hotspot. Vind de naam en het wachtwoord in Instellingen > Persoonlijke hotspot.';
 
   @override
   String get hotspotNameSsid => 'Hotspotnaam (SSID)';
@@ -4679,8 +4579,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Kon samenvatting niet genereren. Zorg ervoor dat u gesprekken heeft voor die dag.';
+  String get failedToGenerateSummaryCheckConversations => 'Kon samenvatting niet genereren. Zorg ervoor dat u gesprekken heeft voor die dag.';
 
   @override
   String get summaryNotFound => 'Samenvatting niet gevonden';
@@ -4710,8 +4609,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Export gestart. Dit kan enkele seconden duren...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Dit verwijdert alle afgeleide kennisgraafgegevens (knooppunten en verbindingen). Uw originele herinneringen blijven veilig. De grafiek wordt in de loop van de tijd of bij het volgende verzoek opnieuw opgebouwd.';
+  String get knowledgeGraphDeleteDescription => 'Dit verwijdert alle afgeleide kennisgraafgegevens (knooppunten en verbindingen). Uw originele herinneringen blijven veilig. De grafiek wordt in de loop van de tijd of bij het volgende verzoek opnieuw opgebouwd.';
 
   @override
   String get configureDailySummaryDigest => 'Configureer je dagelijkse taaknoverzicht';
@@ -4781,8 +4679,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Alle Limitless-gesprekken verwijderen?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Dit verwijdert permanent alle gesprekken die zijn geïmporteerd uit Limitless. Deze actie kan niet ongedaan worden gemaakt.';
+  String get deleteAllLimitlessWarning => 'Dit verwijdert permanent alle gesprekken die zijn geïmporteerd uit Limitless. Deze actie kan niet ongedaan worden gemaakt.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4838,8 +4735,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get howItWorksTitle => 'Hoe werkt het?';
 
   @override
-  String get howPeopleWorks =>
-      'Zodra een persoon is aangemaakt, kun je naar een gesprekstranscriptie gaan en de bijbehorende segmenten toewijzen, zo kan Omi ook hun spraak herkennen!';
+  String get howPeopleWorks => 'Zodra een persoon is aangemaakt, kun je naar een gesprekstranscriptie gaan en de bijbehorende segmenten toewijzen, zo kan Omi ook hun spraak herkennen!';
 
   @override
   String get tapToDelete => 'Tik om te verwijderen';
@@ -4865,8 +4761,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get privacyNotice => 'Privacyverklaring';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Opnames kunnen de stemmen van anderen vastleggen. Zorg ervoor dat u toestemming hebt van alle deelnemers voordat u inschakelt.';
+  String get recordingsMayCaptureOthers => 'Opnames kunnen de stemmen van anderen vastleggen. Zorg ervoor dat u toestemming hebt van alle deelnemers voordat u inschakelt.';
 
   @override
   String get enable => 'Inschakelen';
@@ -4878,8 +4773,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get on => 'Aan';
 
   @override
-  String get storeAudioDescription =>
-      'Bewaar alle audio-opnames lokaal op uw telefoon. Wanneer uitgeschakeld, worden alleen mislukte uploads bewaard om opslagruimte te besparen.';
+  String get storeAudioDescription => 'Bewaar alle audio-opnames lokaal op uw telefoon. Wanneer uitgeschakeld, worden alleen mislukte uploads bewaard om opslagruimte te besparen.';
 
   @override
   String get enableLocalStorage => 'Lokale opslag inschakelen';
@@ -4897,12 +4791,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get storeAudioOnCloud => 'Audio opslaan in de cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Uw realtime opnames worden opgeslagen in privé cloudopslag terwijl u spreekt.';
+  String get cloudStorageDialogMessage => 'Uw realtime opnames worden opgeslagen in privé cloudopslag terwijl u spreekt.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Sla uw realtime opnames op in privé cloudopslag terwijl u spreekt. Audio wordt veilig vastgelegd en opgeslagen in realtime.';
+  String get storeAudioCloudDescription => 'Sla uw realtime opnames op in privé cloudopslag terwijl u spreekt. Audio wordt veilig vastgelegd en opgeslagen in realtime.';
 
   @override
   String get downloadingFirmware => 'Firmware downloaden';
@@ -4911,8 +4803,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get installingFirmware => 'Firmware installeren';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Sluit de app niet en schakel het apparaat niet uit. Dit kan uw apparaat beschadigen.';
+  String get firmwareUpdateWarning => 'Sluit de app niet en schakel het apparaat niet uit. Dit kan uw apparaat beschadigen.';
 
   @override
   String get firmwareUpdated => 'Firmware bijgewerkt';
@@ -4956,8 +4847,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get payments => 'Betalingen';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Verbind hieronder een betaalmethode om uitbetalingen voor uw apps te ontvangen.';
+  String get connectPaymentMethodInfo => 'Verbind hieronder een betaalmethode om uitbetalingen voor uw apps te ontvangen.';
 
   @override
   String get selectedPaymentMethod => 'Geselecteerde betaalmethode';
@@ -4984,8 +4874,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get monthlyPayouts => 'Maandelijkse uitbetalingen';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Ontvang maandelijkse betalingen rechtstreeks op uw rekening wanneer u \$10 aan inkomsten bereikt';
+  String get monthlyPayoutsDescription => 'Ontvang maandelijkse betalingen rechtstreeks op uw rekening wanneer u \$10 aan inkomsten bereikt';
 
   @override
   String get secureAndReliable => 'Veilig en betrouwbaar';
@@ -5012,8 +4901,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get connectingYourStripeAccount => 'Uw Stripe-account verbinden';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Voltooi het Stripe-onboardingproces in uw browser. Deze pagina wordt automatisch bijgewerkt zodra het proces is voltooid.';
+  String get stripeOnboardingInstructions => 'Voltooi het Stripe-onboardingproces in uw browser. Deze pagina wordt automatisch bijgewerkt zodra het proces is voltooid.';
 
   @override
   String get failedTryAgain => 'Mislukt? Probeer opnieuw';
@@ -5025,8 +4913,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get successfullyConnected => 'Succesvol verbonden!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Uw Stripe-account is nu klaar om betalingen te ontvangen. U kunt direct beginnen met verdienen aan uw app-verkopen.';
+  String get stripeReadyForPayments => 'Uw Stripe-account is nu klaar om betalingen te ontvangen. U kunt direct beginnen met verdienen aan uw app-verkopen.';
 
   @override
   String get updateStripeDetails => 'Stripe-gegevens bijwerken';
@@ -5053,8 +4940,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me-link';
 
   @override
-  String get stripeRecommendation =>
-      'Als Stripe beschikbaar is in uw land, raden we het ten zeerste aan voor snellere en gemakkelijkere uitbetalingen.';
+  String get stripeRecommendation => 'Als Stripe beschikbaar is in uw land, raden we het ten zeerste aan voor snellere en gemakkelijkere uitbetalingen.';
 
   @override
   String get updatePayPalDetails => 'PayPal-gegevens bijwerken';
@@ -5106,12 +4992,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Extra spraakvoorbeeld verwijderd';
 
   @override
-  String get consentDataMessage =>
-      'Door verder te gaan worden uw gesprekken, opnames en persoonlijke informatie veilig opgeslagen op onze servers. Uw audio-opnames en transcripties worden verwerkt door AI-diensten van derden (waaronder Deepgram voor transcriptie en OpenAI voor analyse) om u AI-gestuurde inzichten te bieden en alle app-functies mogelijk te maken.';
+  String get consentDataMessage => 'Door verder te gaan worden uw gesprekken, opnames en persoonlijke informatie veilig opgeslagen op onze servers. Uw audio-opnames en transcripties worden verwerkt door AI-diensten van derden (waaronder Deepgram voor transcriptie en OpenAI voor analyse) om u AI-gestuurde inzichten te bieden en alle app-functies mogelijk te maken.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Taken uit je gesprekken verschijnen hier.\nTik op + om er handmatig een te maken.';
+  String get tasksEmptyStateMessage => 'Taken uit je gesprekken verschijnen hier.\nTik op + om er handmatig een te maken.';
 
   @override
   String get clearChatAction => 'Chat wissen';
@@ -5147,15 +5031,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Installeer Omi op je\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Om je Apple Watch met Omi te gebruiken, moet je eerst de Omi-app op je horloge installeren.';
+  String get installOmiOnAppleWatchDescription => 'Om je Apple Watch met Omi te gebruiken, moet je eerst de Omi-app op je horloge installeren.';
 
   @override
   String get openOmiOnAppleWatch => 'Open Omi op je\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'De Omi-app is geïnstalleerd op je Apple Watch. Open deze en tik op Start om te beginnen.';
+  String get openOmiOnAppleWatchDescription => 'De Omi-app is geïnstalleerd op je Apple Watch. Open deze en tik op Start om te beginnen.';
 
   @override
   String get openWatchApp => 'Watch-app openen';
@@ -5164,15 +5046,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Ik heb de app geïnstalleerd en geopend';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Kan Apple Watch-app niet openen. Open handmatig de Watch-app op je Apple Watch en installeer Omi vanuit het gedeelte \"Beschikbare apps\".';
+  String get unableToOpenWatchApp => 'Kan Apple Watch-app niet openen. Open handmatig de Watch-app op je Apple Watch en installeer Omi vanuit het gedeelte \"Beschikbare apps\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch succesvol verbonden!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch nog steeds niet bereikbaar. Zorg ervoor dat de Omi-app geopend is op je horloge.';
+  String get appleWatchNotReachable => 'Apple Watch nog steeds niet bereikbaar. Zorg ervoor dat de Omi-app geopend is op je horloge.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5189,8 +5069,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get finishedConversation => 'Gesprek beëindigd?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Weet je zeker dat je de opname wilt stoppen en het gesprek nu wilt samenvatten?';
+  String get stopRecordingConfirmation => 'Weet je zeker dat je de opname wilt stoppen en het gesprek nu wilt samenvatten?';
 
   @override
   String get conversationEndsManually => 'Het gesprek eindigt alleen handmatig.';
@@ -5601,29 +5480,25 @@ class AppLocalizationsNl extends AppLocalizations {
   String get multipleSpeakersDetected => 'Meerdere sprekers gedetecteerd';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Het lijkt erop dat er meerdere sprekers in de opname zijn. Zorg ervoor dat je op een rustige plek bent en probeer het opnieuw.';
+  String get multipleSpeakersDescription => 'Het lijkt erop dat er meerdere sprekers in de opname zijn. Zorg ervoor dat je op een rustige plek bent en probeer het opnieuw.';
 
   @override
   String get invalidRecordingDetected => 'Ongeldige opname gedetecteerd';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Er is niet genoeg spraak gedetecteerd. Spreek alsjeblieft meer en probeer het opnieuw.';
+  String get notEnoughSpeechDescription => 'Er is niet genoeg spraak gedetecteerd. Spreek alsjeblieft meer en probeer het opnieuw.';
 
   @override
   String get speechDurationDescription => 'Zorg ervoor dat je minimaal 5 seconden en maximaal 90 seconden spreekt.';
 
   @override
-  String get connectionLostDescription =>
-      'De verbinding werd onderbroken. Controleer je internetverbinding en probeer het opnieuw.';
+  String get connectionLostDescription => 'De verbinding werd onderbroken. Controleer je internetverbinding en probeer het opnieuw.';
 
   @override
   String get howToTakeGoodSample => 'Hoe maak je een goed voorbeeld?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Zorg ervoor dat je op een rustige plek bent.\n2. Spreek duidelijk en natuurlijk.\n3. Zorg ervoor dat je apparaat in zijn natuurlijke positie op je nek zit.\n\nNa het maken kun je het altijd verbeteren of opnieuw doen.';
+  String get goodSampleInstructions => '1. Zorg ervoor dat je op een rustige plek bent.\n2. Spreek duidelijk en natuurlijk.\n3. Zorg ervoor dat je apparaat in zijn natuurlijke positie op je nek zit.\n\nNa het maken kun je het altijd verbeteren of opnieuw doen.';
 
   @override
   String get noDeviceConnectedUseMic => 'Geen apparaat verbonden. De telefoonmicrofoon wordt gebruikt.';
@@ -5686,8 +5561,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get howItWorks => 'Hoe het werkt';
 
   @override
-  String get dailyScoreExplanation =>
-      'Je dagelijkse score is gebaseerd op taakvoltooiing. Voltooi je taken om je score te verbeteren!';
+  String get dailyScoreExplanation => 'Je dagelijkse score is gebaseerd op taakvoltooiing. Voltooi je taken om je score te verbeteren!';
 
   @override
   String get notificationFrequencyDescription => 'Bepaal hoe vaak Omi je proactieve meldingen en herinneringen stuurt.';
@@ -5704,8 +5578,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Kon samenvatting niet genereren. Zorg ervoor dat je gesprekken hebt voor die dag.';
+  String get failedToGenerateSummary => 'Kon samenvatting niet genereren. Zorg ervoor dat je gesprekken hebt voor die dag.';
 
   @override
   String get recap => 'Samenvatting';
@@ -5864,8 +5737,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get wifiEnableFailed => 'Kon WiFi niet inschakelen op apparaat. Probeer opnieuw.';
 
   @override
-  String get deviceNoFastTransfer =>
-      'Je apparaat ondersteunt geen snelle overdracht. Gebruik Bluetooth in plaats daarvan.';
+  String get deviceNoFastTransfer => 'Je apparaat ondersteunt geen snelle overdracht. Gebruik Bluetooth in plaats daarvan.';
 
   @override
   String get enableHotspotMessage => 'Schakel de hotspot van je telefoon in en probeer opnieuw.';
@@ -5937,8 +5809,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get recordings => 'Opnames';
 
   @override
-  String get enableRemindersAccess =>
-      'Schakel toegang tot Herinneringen in via Instellingen om Apple Herinneringen te gebruiken';
+  String get enableRemindersAccess => 'Schakel toegang tot Herinneringen in via Instellingen om Apple Herinneringen te gebruiken';
 
   @override
   String todayAtTime(String time) {
@@ -5993,8 +5864,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL niet ingesteld';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Stel de webhook URL in bij ontwikkelaarsinstellingen om deze functie te gebruiken.';
+  String get setWebhookUrlInSettings => 'Stel de webhook URL in bij ontwikkelaarsinstellingen om deze functie te gebruiken.';
 
   @override
   String get sendWebUrl => 'Verstuur web-URL';
@@ -6068,15 +5938,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get cloudProvider => 'Cloud-provider';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 premium minuten/maand. Het On-Device tabblad biedt onbeperkte gratis transcriptie.';
+  String get premiumMinutesInfo => '1.200 premium minuten/maand. Het On-Device tabblad biedt onbeperkte gratis transcriptie.';
 
   @override
   String get viewUsage => 'Bekijk gebruik';
 
   @override
-  String get localProcessingInfo =>
-      'Audio wordt lokaal verwerkt. Werkt offline, meer privacy, maar gebruikt meer batterij.';
+  String get localProcessingInfo => 'Audio wordt lokaal verwerkt. Werkt offline, meer privacy, maar gebruikt meer batterij.';
 
   @override
   String get model => 'Model';
@@ -6085,15 +5953,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get performanceWarning => 'Prestatiewaarschuwing';
 
   @override
-  String get largeModelWarning =>
-      'Dit model is groot en kan de app laten crashen of zeer traag draaien op mobiele apparaten.\n\n\"small\" of \"base\" wordt aanbevolen.';
+  String get largeModelWarning => 'Dit model is groot en kan de app laten crashen of zeer traag draaien op mobiele apparaten.\n\n\"small\" of \"base\" wordt aanbevolen.';
 
   @override
   String get usingNativeIosSpeech => 'Gebruik van native iOS spraakherkenning';
 
   @override
-  String get noModelDownloadRequired =>
-      'De native spraakengine van je apparaat wordt gebruikt. Geen modeldownload vereist.';
+  String get noModelDownloadRequired => 'De native spraakengine van je apparaat wordt gebruikt. Geen modeldownload vereist.';
 
   @override
   String get modelReady => 'Model gereed';
@@ -6150,12 +6016,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get batteryDrainSignificantly => 'Batterijverbruik zal aanzienlijk toenemen.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 premium minuten/maand. Het tabblad On-device biedt onbeperkte gratis transcriptie. ';
+  String get premiumMinutesMonth => '1.200 premium minuten/maand. Het tabblad On-device biedt onbeperkte gratis transcriptie. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Audio wordt lokaal verwerkt. Werkt offline, meer privacy, maar gebruikt meer batterij.';
+  String get audioProcessedLocally => 'Audio wordt lokaal verwerkt. Werkt offline, meer privacy, maar gebruikt meer batterij.';
 
   @override
   String get languageLabel => 'Taal';
@@ -6164,12 +6028,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Dit model is groot en kan de app laten crashen of zeer langzaam werken op mobiele apparaten.\n\nsmall of base wordt aanbevolen.';
+  String get modelTooLargeWarning => 'Dit model is groot en kan de app laten crashen of zeer langzaam werken op mobiele apparaten.\n\nsmall of base wordt aanbevolen.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'De native spraakengine van je apparaat wordt gebruikt. Geen model download nodig.';
+  String get nativeEngineNoDownload => 'De native spraakengine van je apparaat wordt gebruikt. Geen model download nodig.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6205,8 +6067,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omis ingebouwde live transcriptie is geoptimaliseerd voor realtime gesprekken met automatische sprekersdetectie en diarisatie.';
+  String get omiTranscriptionOptimized => 'Omis ingebouwde live transcriptie is geoptimaliseerd voor realtime gesprekken met automatische sprekersdetectie en diarisatie.';
 
   @override
   String get reset => 'Resetten';
@@ -6426,8 +6287,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Kennisgrafiek opbouwen vanuit herinneringen...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Uw kennisgrafiek wordt automatisch opgebouwd wanneer u nieuwe herinneringen maakt.';
+  String get knowledgeGraphWillBuildAutomatically => 'Uw kennisgrafiek wordt automatisch opgebouwd wanneer u nieuwe herinneringen maakt.';
 
   @override
   String get buildGraphButton => 'Grafiek bouwen';
@@ -6729,8 +6589,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Audio downloaden van de SD-kaart van je apparaat';
 
   @override
-  String get transferRequiredDescription =>
-      'Deze opname staat op de SD-kaart van je apparaat. Zet deze over naar je telefoon om af te spelen of te delen.';
+  String get transferRequiredDescription => 'Deze opname staat op de SD-kaart van je apparaat. Zet deze over naar je telefoon om af te spelen of te delen.';
 
   @override
   String get cancelTransfer => 'Overdracht annuleren';
@@ -6751,8 +6610,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareRecording => 'Opname delen';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Weet je zeker dat je deze opname permanent wilt verwijderen? Dit kan niet ongedaan worden gemaakt.';
+  String get deleteRecordingConfirmation => 'Weet je zeker dat je deze opname permanent wilt verwijderen? Dit kan niet ongedaan worden gemaakt.';
 
   @override
   String get recordingIdLabel => 'Opname-ID';
@@ -6811,15 +6669,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get enableFastTransfer => 'Snelle overdracht inschakelen';
 
   @override
-  String get fastTransferDescription =>
-      'Snelle overdracht gebruikt WiFi voor ~5x snellere snelheden. Je telefoon maakt tijdens de overdracht tijdelijk verbinding met het WiFi-netwerk van je Omi-apparaat.';
+  String get fastTransferDescription => 'Snelle overdracht gebruikt WiFi voor ~5x snellere snelheden. Je telefoon maakt tijdens de overdracht tijdelijk verbinding met het WiFi-netwerk van je Omi-apparaat.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Internettoegang is onderbroken tijdens overdracht';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Kies hoe opnames worden overgedragen van je Omi-apparaat naar je telefoon.';
+  String get chooseTransferMethodDescription => 'Kies hoe opnames worden overgedragen van je Omi-apparaat naar je telefoon.';
 
   @override
   String get wifiSpeed => '~150 KB/s via WiFi';
@@ -6828,8 +6684,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fiveTimesFaster => '5X SNELLER';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Maakt een directe WiFi-verbinding met je Omi-apparaat. Je telefoon wordt tijdens de overdracht tijdelijk losgekoppeld van je normale WiFi.';
+  String get fastTransferMethodDescription => 'Maakt een directe WiFi-verbinding met je Omi-apparaat. Je telefoon wordt tijdens de overdracht tijdelijk losgekoppeld van je normale WiFi.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6838,8 +6693,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get bleSpeed => '~30 KB/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Gebruikt standaard Bluetooth Low Energy-verbinding. Langzamer maar beïnvloedt je WiFi-verbinding niet.';
+  String get bluetoothMethodDescription => 'Gebruikt standaard Bluetooth Low Energy-verbinding. Langzamer maar beïnvloedt je WiFi-verbinding niet.';
 
   @override
   String get selected => 'Geselecteerd';
@@ -6877,12 +6731,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get appDeleteFailed => 'Kan app niet verwijderen. Probeer het later opnieuw.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Zichtbaarheid van app succesvol gewijzigd. Het kan enkele minuten duren voordat dit zichtbaar is.';
+  String get appVisibilityChangedSuccessfully => 'Zichtbaarheid van app succesvol gewijzigd. Het kan enkele minuten duren voordat dit zichtbaar is.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Fout bij het activeren van de app. Als het een integratie-app is, zorg ervoor dat de installatie is voltooid.';
+  String get errorActivatingAppIntegration => 'Fout bij het activeren van de app. Als het een integratie-app is, zorg ervoor dat de installatie is voltooid.';
 
   @override
   String get errorUpdatingAppStatus => 'Er is een fout opgetreden bij het bijwerken van de app-status.';
@@ -6962,8 +6814,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Naam moet minimaal 3 tekens zijn';
 
   @override
-  String get conversationPromptHint =>
-      'bijv., Haal actiepunten, genomen beslissingen en belangrijke punten uit het gesprek.';
+  String get conversationPromptHint => 'bijv., Haal actiepunten, genomen beslissingen en belangrijke punten uit het gesprek.';
 
   @override
   String get pleaseEnterAppPrompt => 'Voer een prompt in voor uw app';
@@ -7150,19 +7001,16 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade gepland! Je maandelijkse abonnement loopt door tot het einde van je factureringsperiode en schakelt dan automatisch over naar jaarlijks.';
+  String get planUpgradeScheduledMessage => 'Upgrade gepland! Je maandelijkse abonnement loopt door tot het einde van je factureringsperiode en schakelt dan automatisch over naar jaarlijks.';
 
   @override
   String get couldNotSchedulePlanChange => 'Kon planwijziging niet plannen. Probeer opnieuw.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Je abonnement is opnieuw geactiveerd! Geen kosten nu - je wordt gefactureerd aan het einde van je huidige periode.';
+  String get subscriptionReactivatedDefault => 'Je abonnement is opnieuw geactiveerd! Geen kosten nu - je wordt gefactureerd aan het einde van je huidige periode.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Abonnement succesvol! Je bent gefactureerd voor de nieuwe factureringsperiode.';
+  String get subscriptionSuccessfulCharged => 'Abonnement succesvol! Je bent gefactureerd voor de nieuwe factureringsperiode.';
 
   @override
   String get couldNotProcessSubscription => 'Kon abonnement niet verwerken. Probeer opnieuw.';
@@ -7342,8 +7190,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Bluetooth-toestemming is vereist om verbinding te maken met uw apparaat.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth-toestemming geweigerd. Verleen toestemming in Systeemvoorkeuren.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth-toestemming geweigerd. Verleen toestemming in Systeemvoorkeuren.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7356,12 +7203,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Meldingstoestemming geweigerd. Verleen toestemming in Systeemvoorkeuren.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Meldingstoestemming geweigerd. Verleen toestemming in Systeemvoorkeuren.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Meldingstoestemming geweigerd. Verleen toestemming in Systeemvoorkeuren > Meldingen.';
+  String get onboardingNotificationDeniedNotifications => 'Meldingstoestemming geweigerd. Verleen toestemming in Systeemvoorkeuren > Meldingen.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7374,15 +7219,13 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Verleen locatietoestemming in Instellingen > Privacy en beveiliging > Locatievoorzieningen';
+  String get onboardingLocationGrantInSettings => 'Verleen locatietoestemming in Instellingen > Privacy en beveiliging > Locatievoorzieningen';
 
   @override
   String get onboardingMicrophoneRequired => 'Microfoontoestemming is vereist voor opname.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Microfoontoestemming geweigerd. Verleen toestemming in Systeemvoorkeuren > Privacy en beveiliging > Microfoon.';
+  String get onboardingMicrophoneDenied => 'Microfoontoestemming geweigerd. Verleen toestemming in Systeemvoorkeuren > Privacy en beveiliging > Microfoon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7398,8 +7241,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Schermopnametoestemming is vereist voor systeemaudio-opname.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Schermopnametoestemming geweigerd. Verleen toestemming in Systeemvoorkeuren > Privacy en beveiliging > Schermopname.';
+  String get onboardingScreenCaptureDenied => 'Schermopnametoestemming geweigerd. Verleen toestemming in Systeemvoorkeuren > Privacy en beveiliging > Schermopname.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7412,8 +7254,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Toegankelijkheidstoestemming is vereist voor het detecteren van browservergaderingen.';
+  String get onboardingAccessibilityRequired => 'Toegankelijkheidstoestemming is vereist voor het detecteren van browservergaderingen.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7453,8 +7294,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Fototoestemming geweigerd. Geef alstublieft toegang tot foto\'s om afbeeldingen te selecteren';
+  String get msgPhotosPermissionDenied => 'Fototoestemming geweigerd. Geef alstublieft toegang tot foto\'s om afbeeldingen te selecteren';
 
   @override
   String get msgSelectImagesGenericError => 'Fout bij selecteren van afbeeldingen. Probeer het opnieuw.';
@@ -7526,8 +7366,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get locationPermissionRequired => 'Locatiemachtiging vereist';
 
   @override
-  String get locationPermissionContent =>
-      'Snelle overdracht vereist locatietoestemming om de WiFi-verbinding te verifiëren. Verleen alstublieft locatietoestemming om door te gaan.';
+  String get locationPermissionContent => 'Snelle overdracht vereist locatietoestemming om de WiFi-verbinding te verifiëren. Verleen alstublieft locatietoestemming om door te gaan.';
 
   @override
   String get pdfTranscriptExport => 'Transcript exporteren';
@@ -7690,8 +7529,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Apparaat ondersteunt geen WiFi-synchronisatie, overschakelen naar Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Apparaat ondersteunt geen WiFi-synchronisatie, overschakelen naar Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health is niet beschikbaar op dit apparaat';
@@ -7987,8 +7825,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Zet Omi DevKit in koppelingsmodus';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Druk eenmaal op de knop om in te schakelen. De LED knippert paars in koppelingsmodus.';
+  String get pairingDescOmiDevkit => 'Druk eenmaal op de knop om in te schakelen. De LED knippert paars in koppelingsmodus.';
 
   @override
   String get pairingTitleOmiGlass => 'Zet Omi Glass aan';
@@ -8000,8 +7837,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Zet Plaud Note in koppelingsmodus';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Houd de zijknop 2 seconden ingedrukt. De rode LED knippert wanneer het klaar is om te koppelen.';
+  String get pairingDescPlaudNote => 'Houd de zijknop 2 seconden ingedrukt. De rode LED knippert wanneer het klaar is om te koppelen.';
 
   @override
   String get pairingTitleBee => 'Zet Bee in koppelingsmodus';
@@ -8013,15 +7849,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pairingTitleLimitless => 'Zet Limitless in koppelingsmodus';
 
   @override
-  String get pairingDescLimitless =>
-      'Wanneer een lampje brandt, druk eenmaal en houd dan ingedrukt totdat het apparaat een roze licht toont, laat dan los.';
+  String get pairingDescLimitless => 'Wanneer een lampje brandt, druk eenmaal en houd dan ingedrukt totdat het apparaat een roze licht toont, laat dan los.';
 
   @override
   String get pairingTitleFriendPendant => 'Zet Friend Pendant in koppelingsmodus';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Druk op de knop op de hanger om deze in te schakelen. Het gaat automatisch naar de koppelingsmodus.';
+  String get pairingDescFriendPendant => 'Druk op de knop op de hanger om deze in te schakelen. Het gaat automatisch naar de koppelingsmodus.';
 
   @override
   String get pairingTitleFieldy => 'Zet Fieldy in koppelingsmodus';
@@ -8033,15 +7867,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Verbind Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Installeer en open de Omi-app op je Apple Watch en tik vervolgens op Verbinden in de app.';
+  String get pairingDescAppleWatch => 'Installeer en open de Omi-app op je Apple Watch en tik vervolgens op Verbinden in de app.';
 
   @override
   String get pairingTitleNeoOne => 'Zet Neo One in koppelingsmodus';
 
   @override
-  String get pairingDescNeoOne =>
-      'Houd de aan-/uitknop ingedrukt totdat de LED knippert. Het apparaat is dan vindbaar.';
+  String get pairingDescNeoOne => 'Houd de aan-/uitknop ingedrukt totdat de LED knippert. Het apparaat is dan vindbaar.';
 
   @override
   String get downloadingFromDevice => 'Downloaden van apparaat';
@@ -8129,8 +7961,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Dit weet ik over jou';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Deze kaart wordt bijgewerkt naarmate Omi leert van je gesprekken.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Deze kaart wordt bijgewerkt naarmate Omi leert van je gesprekken.';
 
   @override
   String get apiEnvironment => 'API-omgeving';
@@ -8159,12 +7990,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get switchAndRestart => 'Wisselen';
 
   @override
-  String get stagingDisclaimer =>
-      'De testomgeving kan onstabiel zijn, inconsistente prestaties hebben en gegevens kunnen verloren gaan. Alleen voor testen.';
+  String get stagingDisclaimer => 'De testomgeving kan onstabiel zijn, inconsistente prestaties hebben en gegevens kunnen verloren gaan. Alleen voor testen.';
 
   @override
-  String get apiEnvSavedRestartRequired =>
-      'Opgeslagen. Sluit de app en open deze opnieuw om de wijzigingen toe te passen.';
+  String get apiEnvSavedRestartRequired => 'Opgeslagen. Sluit de app en open deze opnieuw om de wijzigingen toe te passen.';
 
   @override
   String get shared => 'Gedeeld';
@@ -8390,8 +8219,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefoongesprekken via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Bel via Omi en krijg realtime transcriptie, automatische samenvattingen en meer.';
+  String get phoneCallsUpsellSubtitle => 'Bel via Omi en krijg realtime transcriptie, automatische samenvattingen en meer.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Realtime transcriptie van elk gesprek';
@@ -8418,8 +8246,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteSyncedFiles => 'Gesynchroniseerde opnames verwijderen';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Deze opnames zijn al gesynchroniseerd met uw telefoon. Dit kan niet ongedaan worden gemaakt.';
+  String get deleteSyncedFilesMessage => 'Deze opnames zijn al gesynchroniseerd met uw telefoon. Dit kan niet ongedaan worden gemaakt.';
 
   @override
   String get syncedFilesDeleted => 'Gesynchroniseerde opnames verwijderd';
@@ -8431,8 +8258,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deletePendingFiles => 'Wachtende opnames verwijderen';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Deze opnames zijn NIET gesynchroniseerd met uw telefoon en gaan permanent verloren. Dit kan niet ongedaan worden gemaakt.';
+  String get deletePendingFilesWarning => 'Deze opnames zijn NIET gesynchroniseerd met uw telefoon en gaan permanent verloren. Dit kan niet ongedaan worden gemaakt.';
 
   @override
   String get pendingFilesDeleted => 'Wachtende opnames verwijderd';
@@ -8444,8 +8270,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deleteAll => 'Alles verwijderen';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Dit verwijdert gesynchroniseerde en wachtende opnames. Wachtende opnames zijn NIET gesynchroniseerd en gaan permanent verloren.';
+  String get deleteAllFilesWarning => 'Dit verwijdert gesynchroniseerde en wachtende opnames. Wachtende opnames zijn NIET gesynchroniseerd en gaan permanent verloren.';
 
   @override
   String get allFilesDeleted => 'Alle opnames verwijderd';
@@ -8510,8 +8335,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fairUseAboutTitle => 'Over redelijk gebruik';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi is ontworpen voor persoonlijke gesprekken, vergaderingen en live interacties. Het gebruik wordt gemeten aan de hand van de werkelijke gedetecteerde spreektijd, niet de verbindingstijd. Als het gebruik de normale patronen voor niet-persoonlijke inhoud aanzienlijk overschrijdt, kunnen aanpassingen worden toegepast.';
+  String get fairUseAboutBody => 'Omi is ontworpen voor persoonlijke gesprekken, vergaderingen en live interacties. Het gebruik wordt gemeten aan de hand van de werkelijke gedetecteerde spreektijd, niet de verbindingstijd. Als het gebruik de normale patronen voor niet-persoonlijke inhoud aanzienlijk overschrijdt, kunnen aanpassingen worden toegepast.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8549,8 +8373,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get improveConnectionTitle => 'Verbinding verbeteren';
 
   @override
-  String get improveConnectionContent =>
-      'We hebben verbeterd hoe Omi verbonden blijft met je apparaat. Om dit te activeren, ga naar de Apparaatinfo-pagina, tik op \"Apparaat loskoppelen\" en koppel je apparaat opnieuw.';
+  String get improveConnectionContent => 'We hebben verbeterd hoe Omi verbonden blijft met je apparaat. Om dit te activeren, ga naar de Apparaatinfo-pagina, tik op \"Apparaat loskoppelen\" en koppel je apparaat opnieuw.';
 
   @override
   String get improveConnectionAction => 'Begrepen';
@@ -8605,16 +8428,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get cancelSyncQuestion => 'Synchronisatie annuleren?';
 
   @override
-  String get omisStorageDesc =>
-      'Wanneer uw Omi niet verbonden is met uw telefoon, slaat het audio lokaal op in het ingebouwde geheugen. U verliest nooit een opname.';
+  String get omisStorageDesc => 'Wanneer uw Omi niet verbonden is met uw telefoon, slaat het audio lokaal op in het ingebouwde geheugen. U verliest nooit een opname.';
 
   @override
-  String get phoneStorageDesc =>
-      'Wanneer Omi opnieuw verbinding maakt, worden opnames automatisch naar uw telefoon overgebracht voor het uploaden.';
+  String get phoneStorageDesc => 'Wanneer Omi opnieuw verbinding maakt, worden opnames automatisch naar uw telefoon overgebracht voor het uploaden.';
 
   @override
-  String get cloudStorageDesc =>
-      'Na het uploaden worden uw opnames verwerkt en getranscribeerd. Gesprekken zijn binnen een minuut beschikbaar.';
+  String get cloudStorageDesc => 'Na het uploaden worden uw opnames verwerkt en getranscribeerd. Gesprekken zijn binnen een minuut beschikbaar.';
 
   @override
   String get tipKeepPhoneNearby => 'Houd uw telefoon dichtbij voor snellere synchronisatie';
@@ -8638,12 +8458,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get permissionEnable => 'Inschakelen';
 
   @override
-  String get permissionsPageDescription =>
-      'Deze machtigingen zijn essentieel voor de werking van Omi. Ze maken belangrijke functies mogelijk zoals meldingen, locatiegebaseerde ervaringen en audio-opname.';
+  String get permissionsPageDescription => 'Deze machtigingen zijn essentieel voor de werking van Omi. Ze maken belangrijke functies mogelijk zoals meldingen, locatiegebaseerde ervaringen en audio-opname.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi heeft een aantal machtigingen nodig om goed te werken. Verleen ze alsjeblieft om door te gaan.';
+  String get permissionsRequiredDescription => 'Omi heeft een aantal machtigingen nodig om goed te werken. Verleen ze alsjeblieft om door te gaan.';
 
   @override
   String get permissionsSetupTitle => 'Krijg de beste ervaring';
@@ -8697,8 +8515,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get justAMoment => 'Een moment, alsjeblieft';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'We raden je sterk aan om je andere opties te verkennen in plaats van te annuleren.';
+  String get cancelConsequencesSubtitle => 'We raden je sterk aan om je andere opties te verkennen in plaats van te annuleren.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8921,8 +8738,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get firmwareWarningTitle => 'Belangrijk: Lees voor het updaten';
 
   @override
-  String get firmwareFormatWarning =>
-      'Deze firmware zal de SD-kaart formatteren. Zorg ervoor dat alle offline gegevens gesynchroniseerd zijn voor de upgrade.\n\nAls u na het installeren van deze versie een knipperend rood lampje ziet, maak u geen zorgen. Verbind het apparaat gewoon met de app en het zou blauw moeten worden. Het rode lampje betekent dat de klok van het apparaat nog niet is gesynchroniseerd.';
+  String get firmwareFormatWarning => 'Deze firmware zal de SD-kaart formatteren. Zorg ervoor dat alle offline gegevens gesynchroniseerd zijn voor de upgrade.\n\nAls u na het installeren van deze versie een knipperend rood lampje ziet, maak u geen zorgen. Verbind het apparaat gewoon met de app en het zou blauw moeten worden. Het rode lampje betekent dat de klok van het apparaat nog niet is gesynchroniseerd.';
 
   @override
   String get continueAnyway => 'Doorgaan';
@@ -8942,8 +8758,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get tasksMarkComplete => 'Gemarkeerd als voltooid';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi heeft toegang tot Apple Health via Apple\'s HealthKit-framework. Je kunt de toegang op elk moment intrekken in de iOS-instellingen.';
+  String get appleHealthManageNote => 'Omi heeft toegang tot Apple Health via Apple\'s HealthKit-framework. Je kunt de toegang op elk moment intrekken in de iOS-instellingen.';
 
   @override
   String get appleHealthConnectCta => 'Verbinden met Apple Health';
@@ -8976,8 +8791,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health-toegang geweigerd';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi heeft geen toestemming om je Apple Health-gegevens te lezen. Schakel het in via iOS-instellingen → Privacy en beveiliging → Gezondheid → Omi.';
+  String get appleHealthDeniedBody => 'Omi heeft geen toestemming om je Apple Health-gegevens te lezen. Schakel het in via iOS-instellingen → Privacy en beveiliging → Gezondheid → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Waarom vertrek je?';
@@ -9046,8 +8860,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get planUpdate => 'Abonnement bijwerken';
 
   @override
-  String get planDeprecationMessage =>
-      'Uw Unlimited-abonnement wordt stopgezet. Schakel over naar het Operator-abonnement — dezelfde geweldige functies voor \$49/maand. Uw huidige abonnement blijft in de tussentijd werken.';
+  String get planDeprecationMessage => 'Uw Unlimited-abonnement wordt stopgezet. Schakel over naar het Operator-abonnement — dezelfde geweldige functies voor \$49/maand. Uw huidige abonnement blijft in de tussentijd werken.';
 
   @override
   String get upgradeYourPlan => 'Upgrade je abonnement';
@@ -9158,8 +8971,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Je hebt je maandelijkse limiet bereikt. Upgrade om zonder beperkingen met Omi te blijven chatten.';
+  String get chatQuotaExceededReply => 'Je hebt je maandelijkse limiet bereikt. Upgrade om zonder beperkingen met Omi te blijven chatten.';
 
   @override
   String get voiceResponseAudio => 'Lees Omi\'s antwoord voor';
@@ -9190,4 +9002,25 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Taak toevoegen';
+
+  @override
+  String get quickActionAskOmiAnything => 'Vraag Omi van alles';
+
+  @override
+  String get quickActionVoiceMode => 'Spraakmodus';
+
+  @override
+  String get quickActionMute => 'Dempen';
+
+  @override
+  String get quickActionUnmute => 'Dempen opheffen';
+
+  @override
+  String get quickActionConnectDevice => 'Apparaat verbinden';
+
+  @override
+  String get quickActionDeviceSettings => 'Apparaatinstellingen';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -24,8 +24,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteConversationTitle => 'Slette samtale?';
 
   @override
-  String get deleteConversationMessage =>
-      'Dette vil også slette tilknyttede minner, oppgaver og lydfiler. Denne handlingen kan ikke angres.';
+  String get deleteConversationMessage => 'Dette vil også slette tilknyttede minner, oppgaver og lydfiler. Denne handlingen kan ikke angres.';
 
   @override
   String get confirm => 'Bekreft';
@@ -146,8 +145,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleting => 'Sletter...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.';
+  String get pleaseCompleteAuthentication => 'Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.';
 
   @override
   String get failedToStartAuthentication => 'Kunne ikke starte autentisering';
@@ -228,8 +226,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get noStarredConversations => 'Ingen stjernede samtaler';
 
   @override
-  String get starConversationHint =>
-      'For å favorittmarkere en samtale, åpne den og trykk på stjerneikonet i overskriften.';
+  String get starConversationHint => 'For å favorittmarkere en samtale, åpne den og trykk på stjerneikonet i overskriften.';
 
   @override
   String get searchConversations => 'Søk i samtaler...';
@@ -356,19 +353,16 @@ class AppLocalizationsNo extends AppLocalizations {
   String get appsDisconnected => 'Appene og integrasjonene dine vil bli frakoblet umiddelbart.';
 
   @override
-  String get exportBeforeDelete =>
-      'Du kan eksportere dataene dine før du sletter kontoen, men når den er slettet, kan den ikke gjenopprettes.';
+  String get exportBeforeDelete => 'Du kan eksportere dataene dine før du sletter kontoen, men når den er slettet, kan den ikke gjenopprettes.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Jeg forstår at sletting av kontoen min er permanent og at alle data, inkludert minner og samtaler, vil gå tapt og ikke kan gjenopprettes.';
+  String get deleteAccountCheckbox => 'Jeg forstår at sletting av kontoen min er permanent og at alle data, inkludert minner og samtaler, vil gå tapt og ikke kan gjenopprettes.';
 
   @override
   String get areYouSure => 'Er du sikker?';
 
   @override
-  String get deleteAccountFinal =>
-      'Denne handlingen kan ikke angres og vil permanent slette kontoen din og alle tilknyttede data. Er du sikker på at du vil fortsette?';
+  String get deleteAccountFinal => 'Denne handlingen kan ikke angres og vil permanent slette kontoen din og alle tilknyttede data. Er du sikker på at du vil fortsette?';
 
   @override
   String get deleteNow => 'Slett nå';
@@ -377,8 +371,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get goBack => 'Gå tilbake';
 
   @override
-  String get checkBoxToConfirm =>
-      'Kryss av for å bekrefte at du forstår at sletting av kontoen din er permanent og irreversibel.';
+  String get checkBoxToConfirm => 'Kryss av for å bekrefte at du forstår at sletting av kontoen din er permanent og irreversibel.';
 
   @override
   String get profile => 'Profil';
@@ -456,8 +449,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get yourPrivacyYourControl => 'Ditt personvern, din kontroll';
 
   @override
-  String get privacyIntro =>
-      'Hos Omi er vi opptatt av å beskytte ditt personvern. Denne siden lar deg kontrollere hvordan dataene dine lagres og brukes.';
+  String get privacyIntro => 'Hos Omi er vi opptatt av å beskytte ditt personvern. Denne siden lar deg kontrollere hvordan dataene dine lagres og brukes.';
 
   @override
   String get learnMore => 'Lær mer...';
@@ -466,15 +458,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get dataProtectionLevel => 'Databeskyttelsesnivå';
 
   @override
-  String get dataProtectionDesc =>
-      'Dataene dine er sikret som standard med sterk kryptering. Se gjennom innstillingene dine og fremtidige personvernalternativer nedenfor.';
+  String get dataProtectionDesc => 'Dataene dine er sikret som standard med sterk kryptering. Se gjennom innstillingene dine og fremtidige personvernalternativer nedenfor.';
 
   @override
   String get appAccess => 'Apptilgang';
 
   @override
-  String get appAccessDesc =>
-      'Følgende apper har tilgang til dataene dine. Trykk på en app for å administrere tillatelsene.';
+  String get appAccessDesc => 'Følgende apper har tilgang til dataene dine. Trykk på en app for å administrere tillatelsene.';
 
   @override
   String get noAppsExternalAccess => 'Ingen installerte apper har ekstern tilgang til dataene dine.';
@@ -531,22 +521,19 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Din Omi har blitt frakoblet 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Enhet frakoblet. Gå til Innstillinger > Bluetooth og glem enheten for å fullføre frakoblingen.';
+  String get deviceUnpairedMessage => 'Enhet frakoblet. Gå til Innstillinger > Bluetooth og glem enheten for å fullføre frakoblingen.';
 
   @override
   String get unpairDialogTitle => 'Fjern paring av enhet';
 
   @override
-  String get unpairDialogMessage =>
-      'Dette vil fjerne paringen av enheten slik at den kan kobles til en annen telefon. Du må gå til Innstillinger > Bluetooth og glemme enheten for å fullføre prosessen.';
+  String get unpairDialogMessage => 'Dette vil fjerne paringen av enheten slik at den kan kobles til en annen telefon. Du må gå til Innstillinger > Bluetooth og glemme enheten for å fullføre prosessen.';
 
   @override
   String get deviceNotConnected => 'Enhet ikke tilkoblet';
 
   @override
-  String get connectDeviceMessage =>
-      'Koble til Omi-enheten din for å få tilgang til\nenhetsinnstillinger og tilpasning';
+  String get connectDeviceMessage => 'Koble til Omi-enheten din for å få tilgang til\nenhetsinnstillinger og tilpasning';
 
   @override
   String get deviceInfoSection => 'Enhetsinformasjon';
@@ -561,8 +548,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get v2Undetected => 'V2 ikke oppdaget';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vi ser at du enten har en V1-enhet eller at enheten din ikke er tilkoblet. SD-kortfunksjonalitet er kun tilgjengelig for V2-enheter.';
+  String get v2UndetectedMessage => 'Vi ser at du enten har en V1-enhet eller at enheten din ikke er tilkoblet. SD-kortfunksjonalitet er kun tilgjengelig for V2-enheter.';
 
   @override
   String get endConversation => 'Avslutt samtale';
@@ -836,8 +822,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Slette kunnskapsgraf?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Dette vil slette alle utledede kunnskapsdata (noder og forbindelser). De originale minnene dine vil forbli trygge. Grafen vil bli gjenoppbygget over tid eller ved neste forespørsel.';
+  String get deleteKnowledgeGraphMessage => 'Dette vil slette alle utledede kunnskapsdata (noder og forbindelser). De originale minnene dine vil forbli trygge. Grafen vil bli gjenoppbygget over tid eller ved neste forespørsel.';
 
   @override
   String get knowledgeGraphDeleted => 'Kunnskapsgraf slettet';
@@ -985,8 +970,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get shortConversationThreshold => 'Terskel for korte samtaler';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Samtaler kortere enn dette vil være skjult med mindre aktivert ovenfor';
+  String get shortConversationThresholdSubtitle => 'Samtaler kortere enn dette vil være skjult med mindre aktivert ovenfor';
 
   @override
   String get durationThreshold => 'Varighetsterskel';
@@ -1021,8 +1005,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get integrationsFooter => 'Koble til appene dine for å se data og måledata i chat.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.';
+  String get completeAuthInBrowser => 'Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1082,8 +1065,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get needYourPermission => 'Vi trenger din tillatelse';
 
   @override
-  String get alreadyGavePermission =>
-      'Du har allerede gitt oss tillatelse til å lagre opptakene dine. Her er en påminnelse om hvorfor vi trenger det:';
+  String get alreadyGavePermission => 'Du har allerede gitt oss tillatelse til å lagre opptakene dine. Her er en påminnelse om hvorfor vi trenger det:';
 
   @override
   String get wouldLikePermission => 'Vi vil gjerne ha tillatelse til å lagre stemmeopptakene dine. Her er hvorfor:';
@@ -1098,19 +1080,16 @@ class AppLocalizationsNo extends AppLocalizations {
   String get trainFamilyProfiles => 'Tren profiler for venner og familie';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Opptakene dine hjelper oss med å gjenkjenne og opprette profiler for venner og familie.';
+  String get trainFamilyProfilesDesc => 'Opptakene dine hjelper oss med å gjenkjenne og opprette profiler for venner og familie.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Forbedre transkripsjonsnøyaktighet';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Etter hvert som modellen vår forbedres, kan vi gi bedre transkripsjon av opptakene dine.';
+  String get enhanceTranscriptAccuracyDesc => 'Etter hvert som modellen vår forbedres, kan vi gi bedre transkripsjon av opptakene dine.';
 
   @override
-  String get legalNotice =>
-      'Juridisk merknad: Lovligheten av å ta opp og lagre taledata kan variere avhengig av hvor du befinner deg og hvordan du bruker denne funksjonen. Det er ditt ansvar å sikre overholdelse av lokale lover og forskrifter.';
+  String get legalNotice => 'Juridisk merknad: Lovligheten av å ta opp og lagre taledata kan variere avhengig av hvor du befinner deg og hvordan du bruker denne funksjonen. Det er ditt ansvar å sikre overholdelse av lokale lover og forskrifter.';
 
   @override
   String get alreadyAuthorized => 'Allerede autorisert';
@@ -1276,8 +1255,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get languageForTranscription => 'Angi språket ditt for skarpere transkripsjoner og en personlig opplevelse.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Enkeltspråkmodus er aktivert. Oversettelse er deaktivert for høyere nøyaktighet.';
+  String get singleLanguageModeInfo => 'Enkeltspråkmodus er aktivert. Oversettelse er deaktivert for høyere nøyaktighet.';
 
   @override
   String get searchLanguageHint => 'Søk etter språk med navn eller kode';
@@ -1357,8 +1335,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get defaultRepository => 'Standard repositorium';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Velg et standard repositorium for å opprette problemer. Du kan fortsatt spesifisere et annet repositorium når du oppretter problemer.';
+  String get selectDefaultRepoDesc => 'Velg et standard repositorium for å opprette problemer. Du kan fortsatt spesifisere et annet repositorium når du oppretter problemer.';
 
   @override
   String get noReposFound => 'Ingen repositorier funnet';
@@ -1733,8 +1710,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get enableBluetooth => 'Aktiver Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi trenger Bluetooth for å koble til den bærbare enheten din. Aktiver Bluetooth og prøv igjen.';
+  String get bluetoothNeeded => 'Omi trenger Bluetooth for å koble til den bærbare enheten din. Aktiver Bluetooth og prøv igjen.';
 
   @override
   String get contactSupport => 'Kontakte support?';
@@ -1767,26 +1743,22 @@ class AppLocalizationsNo extends AppLocalizations {
   String get locationServiceDisabled => 'Posisjonstjeneste deaktivert';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Posisjonstjeneste er deaktivert. Gå til Innstillinger > Personvern og sikkerhet > Posisjonstjenester og aktiver den';
+  String get locationServiceDisabledDesc => 'Posisjonstjeneste er deaktivert. Gå til Innstillinger > Personvern og sikkerhet > Posisjonstjenester og aktiver den';
 
   @override
   String get backgroundLocationDenied => 'Bakgrunnsposisjonstilgang nektet';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Gå til enhetsinnstillinger og sett posisjonstillatelse til \"Alltid tillat\"';
+  String get backgroundLocationDeniedDesc => 'Gå til enhetsinnstillinger og sett posisjonstillatelse til \"Alltid tillat\"';
 
   @override
   String get lovingOmi => 'Liker du Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Hjelp oss med å nå flere personer ved å legge igjen en anmeldelse i App Store. Tilbakemeldingen din betyr alt for oss!';
+  String get leaveReviewIos => 'Hjelp oss med å nå flere personer ved å legge igjen en anmeldelse i App Store. Tilbakemeldingen din betyr alt for oss!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Hjelp oss med å nå flere personer ved å legge igjen en anmeldelse i Google Play Store. Tilbakemeldingen din betyr alt for oss!';
+  String get leaveReviewAndroid => 'Hjelp oss med å nå flere personer ved å legge igjen en anmeldelse i Google Play Store. Tilbakemeldingen din betyr alt for oss!';
 
   @override
   String get rateOnAppStore => 'Vurder i App Store';
@@ -1825,8 +1797,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get invalidRecordingMultipleSpeakers => 'Ugyldig opptak oppdaget';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Det ser ut til å være flere talere i opptaket. Pass på at du er på et stille sted og prøv igjen.';
+  String get multipleSpeakersDesc => 'Det ser ut til å være flere talere i opptaket. Pass på at du er på et stille sted og prøv igjen.';
 
   @override
   String get tooShortDesc => 'Det er ikke nok tale oppdaget. Snakk mer og prøv igjen.';
@@ -1838,8 +1809,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get areYouThere => 'Er du der?';
 
   @override
-  String get noSpeechDesc =>
-      'Vi kunne ikke oppdage noen tale. Pass på å snakke i minst 10 sekunder og ikke mer enn 3 minutter.';
+  String get noSpeechDesc => 'Vi kunne ikke oppdage noen tale. Pass på å snakke i minst 10 sekunder og ikke mer enn 3 minutter.';
 
   @override
   String get connectionLost => 'Tilkobling tapt';
@@ -1860,8 +1830,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get permissionsRequired => 'Tillatelser kreves';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Denne appen trenger Bluetooth- og posisjonstillatelser for å fungere ordentlig. Aktiver dem i innstillingene.';
+  String get permissionsRequiredDesc => 'Denne appen trenger Bluetooth- og posisjonstillatelser for å fungere ordentlig. Aktiver dem i innstillingene.';
 
   @override
   String get openSettings => 'Åpne innstillinger';
@@ -1903,12 +1872,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get microphonePermission => 'Mikrofontillatelse';
 
   @override
-  String get permissionGrantedNow =>
-      'Tillatelse gitt! Nå:\n\nÅpne Omi-appen på klokken din og trykk \"Fortsett\" nedenfor';
+  String get permissionGrantedNow => 'Tillatelse gitt! Nå:\n\nÅpne Omi-appen på klokken din og trykk \"Fortsett\" nedenfor';
 
   @override
-  String get needMicrophonePermission =>
-      'Vi trenger mikrofontillatelse.\n\n1. Trykk \"Gi tillatelse\"\n2. Tillat på iPhone\n3. Klokkeapp vil lukkes\n4. Åpne på nytt og trykk \"Fortsett\"';
+  String get needMicrophonePermission => 'Vi trenger mikrofontillatelse.\n\n1. Trykk \"Gi tillatelse\"\n2. Tillat på iPhone\n3. Klokkeapp vil lukkes\n4. Åpne på nytt og trykk \"Fortsett\"';
 
   @override
   String get grantPermissionButton => 'Gi tillatelse';
@@ -1917,15 +1884,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get needHelp => 'Trenger du hjelp?';
 
   @override
-  String get troubleshootingSteps =>
-      'Feilsøking:\n\n1. Sørg for at Omi er installert på klokken din\n2. Åpne Omi-appen på klokken din\n3. Se etter tillatelsespopup\n4. Trykk \"Tillat\" når du blir bedt om det\n5. App på klokken vil lukkes - åpne den på nytt\n6. Kom tilbake og trykk \"Fortsett\" på iPhone';
+  String get troubleshootingSteps => 'Feilsøking:\n\n1. Sørg for at Omi er installert på klokken din\n2. Åpne Omi-appen på klokken din\n3. Se etter tillatelsespopup\n4. Trykk \"Tillat\" når du blir bedt om det\n5. App på klokken vil lukkes - åpne den på nytt\n6. Kom tilbake og trykk \"Fortsett\" på iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Opptak startet!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Tillatelse ikke gitt ennå. Pass på at du tillot mikrofontilgang og åpnet appen på nytt på klokken din.';
+  String get permissionNotGrantedYet => 'Tillatelse ikke gitt ennå. Pass på at du tillot mikrofontilgang og åpnet appen på nytt på klokken din.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2022,8 +1987,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Klar for handlingspunkter';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'AI-en din vil automatisk trekke ut oppgaver og gjøremål fra samtalene dine. De vil dukke opp her når de opprettes.';
+  String get welcomeActionItemsDescription => 'AI-en din vil automatisk trekke ut oppgaver og gjøremål fra samtalene dine. De vil dukke opp her når de opprettes.';
 
   @override
   String get autoExtractionFeature => 'Automatisk trukket ut fra samtaler';
@@ -2219,15 +2183,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'TALE OG TRANSKRIPSJON';
 
   @override
-  String get languageSettingsHelperText =>
-      'App-språk endrer menyer og knapper. Talespråk påvirker hvordan opptakene dine transkriberes.';
+  String get languageSettingsHelperText => 'App-språk endrer menyer og knapper. Talespråk påvirker hvordan opptakene dine transkriberes.';
 
   @override
   String get translationNotice => 'Oversettelsesvarsel';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi oversetter samtaler til hovedspråket ditt. Oppdater det når som helst i Innstillinger → Profiler.';
+  String get translationNoticeMessage => 'Omi oversetter samtaler til hovedspråket ditt. Oppdater det når som helst i Innstillinger → Profiler.';
 
   @override
   String get pleaseCheckInternetConnection => 'Vennligst sjekk internettforbindelsen din og prøv igjen';
@@ -2382,8 +2344,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Opphev sammenkoblingen av enheten';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Dette vil oppheve sammenkoblingen av enheten slik at den kan kobles til en annen telefon. Du må gå til Innstillinger > Bluetooth og glemme enheten for å fullføre prosessen.';
+  String get unpairDeviceDialogMessage => 'Dette vil oppheve sammenkoblingen av enheten slik at den kan kobles til en annen telefon. Du må gå til Innstillinger > Bluetooth og glemme enheten for å fullføre prosessen.';
 
   @override
   String get unpair => 'Opphev sammenkobling';
@@ -2564,8 +2525,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get youreAllSet => 'Du er klar!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Velkommen til Omi! Din AI-følgesvenn er klar til å hjelpe deg med samtaler, oppgaver og mer.';
+  String get welcomeToOmiDescription => 'Velkommen til Omi! Din AI-følgesvenn er klar til å hjelpe deg med samtaler, oppgaver og mer.';
 
   @override
   String get startUsingOmi => 'Begynn å bruke Omi';
@@ -2701,8 +2661,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get noTasksYet => 'Ingen oppgaver ennå';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Oppgaver fra samtalene dine vises her.\nKlikk på Opprett for å legge til en manuelt.';
+  String get tasksFromConversationsWillAppear => 'Oppgaver fra samtalene dine vises her.\nKlikk på Opprett for å legge til en manuelt.';
 
   @override
   String get monthJan => 'Jan';
@@ -2759,8 +2718,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteActionItem => 'Slett handlingselement';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Er du sikker på at du vil slette dette handlingselementet? Denne handlingen kan ikke angres.';
+  String get deleteActionItemConfirmation => 'Er du sikker på at du vil slette dette handlingselementet? Denne handlingen kan ikke angres.';
 
   @override
   String get enterActionItemDescription => 'Skriv inn beskrivelse av handlingselement...';
@@ -2835,15 +2793,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chatPrompt => 'Chat-instruksjon';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Du er en fantastisk app, jobben din er å svare på brukerforespørsler og få dem til å føle seg bra...';
+  String get chatPromptPlaceholder => 'Du er en fantastisk app, jobben din er å svare på brukerforespørsler og få dem til å føle seg bra...';
 
   @override
   String get conversationPrompt => 'Samtaleprompt';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Du er en fantastisk app, du vil få en transkripsjon og sammendrag av en samtale...';
+  String get conversationPromptPlaceholder => 'Du er en fantastisk app, du vil få en transkripsjon og sammendrag av en samtale...';
 
   @override
   String get notificationScopes => 'Varslingsområder';
@@ -2855,8 +2811,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get makeMyAppPublic => 'Gjør appen min offentlig';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Ved å sende inn denne appen godtar jeg Omi AI sine tjenestevilkår og personvernerklæring';
+  String get submitAppTermsAgreement => 'Ved å sende inn denne appen godtar jeg Omi AI sine tjenestevilkår og personvernerklæring';
 
   @override
   String get submitApp => 'Send inn app';
@@ -2871,12 +2826,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get submitAppQuestion => 'Send inn app?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Appen din vil bli gjennomgått og gjort offentlig. Du kan begynne å bruke den umiddelbart, selv under gjennomgangen!';
+  String get submitAppPublicDescription => 'Appen din vil bli gjennomgått og gjort offentlig. Du kan begynne å bruke den umiddelbart, selv under gjennomgangen!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Appen din vil bli gjennomgått og gjort tilgjengelig for deg privat. Du kan begynne å bruke den umiddelbart, selv under gjennomgangen!';
+  String get submitAppPrivateDescription => 'Appen din vil bli gjennomgått og gjort tilgjengelig for deg privat. Du kan begynne å bruke den umiddelbart, selv under gjennomgangen!';
 
   @override
   String get startEarning => 'Begynn å tjene! 💰';
@@ -2900,23 +2853,19 @@ class AppLocalizationsNo extends AppLocalizations {
   String get dataAccessNotice => 'Datatilgangsvarsel';
 
   @override
-  String get dataAccessWarning =>
-      'Denne appen vil få tilgang til dataene dine. Omi AI er ikke ansvarlig for hvordan dataene dine brukes, endres eller slettes av denne appen';
+  String get dataAccessWarning => 'Denne appen vil få tilgang til dataene dine. Omi AI er ikke ansvarlig for hvordan dataene dine brukes, endres eller slettes av denne appen';
 
   @override
   String get installApp => 'Installer app';
 
   @override
-  String get betaTesterNotice =>
-      'Du er betatester for denne appen. Den er ikke offentlig ennå. Den vil bli offentlig når den er godkjent.';
+  String get betaTesterNotice => 'Du er betatester for denne appen. Den er ikke offentlig ennå. Den vil bli offentlig når den er godkjent.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Appen din er under vurdering og bare synlig for deg. Den vil bli offentlig når den er godkjent.';
+  String get appUnderReviewOwner => 'Appen din er under vurdering og bare synlig for deg. Den vil bli offentlig når den er godkjent.';
 
   @override
-  String get appRejectedNotice =>
-      'Appen din har blitt avvist. Vennligst oppdater appdetaljene og send inn på nytt for vurdering.';
+  String get appRejectedNotice => 'Appen din har blitt avvist. Vennligst oppdater appdetaljene og send inn på nytt for vurdering.';
 
   @override
   String get setupSteps => 'Oppsettstrinn';
@@ -2978,8 +2927,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get descriptionLabel => 'Beskrivelse';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Min fantastiske app er en flott app som gjør fantastiske ting. Det er den beste appen!';
+  String get appDescriptionPlaceholder => 'Min fantastiske app er en flott app som gjør fantastiske ting. Det er den beste appen!';
 
   @override
   String get pleaseProvideValidDescription => 'Vennligst oppgi en gyldig beskrivelse';
@@ -3131,8 +3079,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get microphonePermissionRequired => 'Mikrofontillatelse kreves for stemmeoptak.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofontillatelse nektet. Vennligst gi tillatelse i Systeminnstillinger > Personvern og sikkerhet > Mikrofon.';
+  String get microphonePermissionDenied => 'Mikrofontillatelse nektet. Vennligst gi tillatelse i Systeminnstillinger > Personvern og sikkerhet > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3291,8 +3238,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get createMemory => 'Opprett minne';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Er du sikker på at du vil slette dette minnet? Denne handlingen kan ikke angres.';
+  String get deleteMemoryConfirmation => 'Er du sikker på at du vil slette dette minnet? Denne handlingen kan ikke angres.';
 
   @override
   String get makePrivate => 'Gjør privat';
@@ -3366,8 +3312,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get whatWeCollect => 'Hva vi samler inn';
 
   @override
-  String get dataCollectionMessage =>
-      'Ved å fortsette vil samtalene, opptakene og personlige informasjon bli sikkert lagret på våre servere for å gi AI-drevne innsikter og aktivere alle appfunksjoner.';
+  String get dataCollectionMessage => 'Ved å fortsette vil samtalene, opptakene og personlige informasjon bli sikkert lagret på våre servere for å gi AI-drevne innsikter og aktivere alle appfunksjoner.';
 
   @override
   String get dataProtection => 'Databeskyttelse';
@@ -3400,8 +3345,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Navnet må være minst 2 tegn';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Fortell oss hvordan du vil bli tiltalt. Dette hjelper til med å personalisere Omi-opplevelsen din.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Fortell oss hvordan du vil bli tiltalt. Dette hjelper til med å personalisere Omi-opplevelsen din.';
 
   @override
   String charactersCount(int count) {
@@ -3418,8 +3362,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get recordAudioConversations => 'Ta opp lydsamtaler';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi trenger mikrofontilgang for å ta opp samtalene dine og gi transkripsjoner.';
+  String get microphoneAccessDescription => 'Omi trenger mikrofontilgang for å ta opp samtalene dine og gi transkripsjoner.';
 
   @override
   String get screenRecording => 'Skjermopptak';
@@ -3428,8 +3371,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Fang opp systemlyd fra møter';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi trenger tillatelse til skjermopptak for å fange opp systemlyd fra nettleserbaserte møter.';
+  String get screenRecordingDescription => 'Omi trenger tillatelse til skjermopptak for å fange opp systemlyd fra nettleserbaserte møter.';
 
   @override
   String get accessibility => 'Tilgjengelighet';
@@ -3438,8 +3380,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Oppdag nettleserbaserte møter';
 
   @override
-  String get accessibilityDescription =>
-      'Omi trenger tilgjengelighetstillatelse for å oppdage når du deltar i Zoom-, Meet- eller Teams-møter i nettleseren din.';
+  String get accessibilityDescription => 'Omi trenger tilgjengelighetstillatelse for å oppdage når du deltar i Zoom-, Meet- eller Teams-møter i nettleseren din.';
 
   @override
   String get pleaseWait => 'Vennligst vent...';
@@ -3511,8 +3452,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get conversationsExportStarted => 'Eksport av samtaler startet. Dette kan ta noen sekunder, vennligst vent.';
 
   @override
-  String get mcpDescription =>
-      'For å koble Omi til andre applikasjoner for å lese, søke og administrere minnene og samtalene dine. Opprett en nøkkel for å komme i gang.';
+  String get mcpDescription => 'For å koble Omi til andre applikasjoner for å lese, søke og administrere minnene og samtalene dine. Opprett en nøkkel for å komme i gang.';
 
   @override
   String get apiKeys => 'API-nøkler';
@@ -3553,8 +3493,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Diagnostisk status for transkripsjonst jeneste';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Aktiver detaljerte diagnostiske meldinger fra transkripsjonst jenesten';
+  String get enableDetailedDiagnosticMessages => 'Aktiver detaljerte diagnostiske meldinger fra transkripsjonst jenesten';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Opprett og merk nye talere automatisk';
@@ -3584,8 +3523,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get auto => 'Automatisk';
 
   @override
-  String get noSummaryForApp =>
-      'Ingen oppsummering tilgjengelig for denne appen. Prøv en annen app for bedre resultater.';
+  String get noSummaryForApp => 'Ingen oppsummering tilgjengelig for denne appen. Prøv en annen app for bedre resultater.';
 
   @override
   String get tryAnotherApp => 'Prøv en annen app';
@@ -3622,8 +3560,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get letOmiChooseAutomatically => 'La Omi velge beste app automatisk';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Er du sikker på at du vil slette denne samtalen? Denne handlingen kan ikke angres.';
+  String get deleteConversationConfirmation => 'Er du sikker på at du vil slette denne samtalen? Denne handlingen kan ikke angres.';
 
   @override
   String get conversationDeleted => 'Samtale slettet';
@@ -3671,8 +3608,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Forbereder systemlydopptak';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klikk på knappen for å ta opp lyd for direkte transkripsjoner, AI-innsikt og automatisk lagring.';
+  String get clickTheButtonToCaptureAudio => 'Klikk på knappen for å ta opp lyd for direkte transkripsjoner, AI-innsikt og automatisk lagring.';
 
   @override
   String get reconnecting => 'Kobler til på nytt...';
@@ -3899,8 +3835,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Slette kunnskapsgraf?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Dette sletter alle avledede kunnskapsgrafdata. Dine opprinnelige minner forblir trygge.';
+  String get deleteKnowledgeGraphWarning => 'Dette sletter alle avledede kunnskapsgrafdata. Dine opprinnelige minner forblir trygge.';
 
   @override
   String get connectOmiWithAI => 'Koble Omi til AI-assistenter';
@@ -3942,8 +3877,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Vilkår og Personvernpolicy';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Hjelper med å diagnostisere problemer. Slettes automatisk etter 3 dager.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Hjelper med å diagnostisere problemer. Slettes automatisk etter 3 dager.';
 
   @override
   String get manageYourApp => 'Administrer appen din';
@@ -3958,8 +3892,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get updateAppQuestion => 'Oppdater app?';
 
   @override
-  String get updateAppConfirmation =>
-      'Er du sikker på at du vil oppdatere appen din? Endringene vil vises etter gjennomgang av teamet vårt.';
+  String get updateAppConfirmation => 'Er du sikker på at du vil oppdatere appen din? Endringene vil vises etter gjennomgang av teamet vårt.';
 
   @override
   String get updateApp => 'Oppdater app';
@@ -3989,8 +3922,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get no => 'Nei';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abonnement kansellert. Det forblir aktivt til slutten av gjeldende faktureringsperiode.';
+  String get subscriptionCancelledSuccessfully => 'Abonnement kansellert. Det forblir aktivt til slutten av gjeldende faktureringsperiode.';
 
   @override
   String get failedToCancelSubscription => 'Kunne ikke kansellere abonnement. Prøv igjen.';
@@ -4026,8 +3958,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Kanseller abonnement?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Er du sikker på at du vil kansellere abonnementet? Du vil fortsatt ha tilgang til slutten av gjeldende faktureringsperiode.';
+  String get cancelSubscriptionConfirmation => 'Er du sikker på at du vil kansellere abonnementet? Du vil fortsatt ha tilgang til slutten av gjeldende faktureringsperiode.';
 
   @override
   String get cancelSubscriptionButton => 'Kanseller abonnement';
@@ -4036,12 +3967,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get cancelling => 'Kansellerer...';
 
   @override
-  String get betaTesterMessage =>
-      'Du er betatester for denne appen. Den er ikke offentlig ennå. Den blir offentlig etter godkjenning.';
+  String get betaTesterMessage => 'Du er betatester for denne appen. Den er ikke offentlig ennå. Den blir offentlig etter godkjenning.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Appen din er under vurdering og bare synlig for deg. Den blir offentlig etter godkjenning.';
+  String get appUnderReviewMessage => 'Appen din er under vurdering og bare synlig for deg. Den blir offentlig etter godkjenning.';
 
   @override
   String get appRejectedMessage => 'Appen din er avvist. Oppdater detaljene og send inn på nytt for vurdering.';
@@ -4098,8 +4027,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get issueActivatingApp => 'Det oppstod et problem ved aktivering av denne appen. Prøv igjen.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Denne appen vil få tilgang til dataene dine. Omi AI er ikke ansvarlig for hvordan dataene dine brukes, endres eller slettes av denne appen';
+  String get dataAccessNoticeDescription => 'Denne appen vil få tilgang til dataene dine. Omi AI er ikke ansvarlig for hvordan dataene dine brukes, endres eller slettes av denne appen';
 
   @override
   String get copyUrl => 'Kopier URL';
@@ -4187,8 +4115,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get omiApiKeys => 'Omi API-nøkler';
 
   @override
-  String get apiKeysDescription =>
-      'API-nøkler brukes til autentisering når appen din kommuniserer med OMI-serveren. De lar applikasjonen din opprette minner og få sikker tilgang til andre OMI-tjenester.';
+  String get apiKeysDescription => 'API-nøkler brukes til autentisering når appen din kommuniserer med OMI-serveren. De lar applikasjonen din opprette minner og få sikker tilgang til andre OMI-tjenester.';
 
   @override
   String get aboutOmiApiKeys => 'Om Omi API-nøkler';
@@ -4212,8 +4139,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Tilbakekalle API-nøkkel?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Denne handlingen kan ikke angres. Alle applikasjoner som bruker denne nøkkelen vil ikke lenger kunne få tilgang til API-et.';
+  String get revokeApiKeyWarning => 'Denne handlingen kan ikke angres. Alle applikasjoner som bruker denne nøkkelen vil ikke lenger kunne få tilgang til API-et.';
 
   @override
   String get revoke => 'Tilbakekall';
@@ -4302,8 +4228,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get keyCreated => 'Nøkkel opprettet';
 
   @override
-  String get keyCreatedMessage =>
-      'Din nye nøkkel er opprettet. Vennligst kopier den nå. Du vil ikke kunne se den igjen.';
+  String get keyCreatedMessage => 'Din nye nøkkel er opprettet. Vennligst kopier den nå. Du vil ikke kunne se den igjen.';
 
   @override
   String get keyWord => 'Nøkkel';
@@ -4312,8 +4237,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get externalAppAccess => 'Ekstern app-tilgang';
 
   @override
-  String get externalAppAccessDescription =>
-      'Følgende installerte apper har eksterne integrasjoner og kan få tilgang til dataene dine, som samtaler og minner.';
+  String get externalAppAccessDescription => 'Følgende installerte apper har eksterne integrasjoner og kan få tilgang til dataene dine, som samtaler og minner.';
 
   @override
   String get noExternalAppsHaveAccess => 'Ingen eksterne apper har tilgang til dataene dine.';
@@ -4322,8 +4246,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimal sikkerhet (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Ende-til-ende-kryptering er gullstandarden for personvern. Når det er aktivert, krypteres dataene dine på enheten din før de sendes til serverne våre. Dette betyr at ingen, ikke engang Omi, kan få tilgang til innholdet ditt.';
+  String get e2eeDescription => 'Ende-til-ende-kryptering er gullstandarden for personvern. Når det er aktivert, krypteres dataene dine på enheten din før de sendes til serverne våre. Dette betyr at ingen, ikke engang Omi, kan få tilgang til innholdet ditt.';
 
   @override
   String get importantTradeoffs => 'Viktige avveininger:';
@@ -4357,15 +4280,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get secureEncryption => 'Sikker kryptering';
 
   @override
-  String get secureEncryptionDescription =>
-      'Dataene dine er kryptert med en nøkkel som er unik for deg på våre servere, hostet på Google Cloud. Dette betyr at råinnholdet ditt er utilgjengelig for alle, inkludert Omi-ansatte eller Google, direkte fra databasen.';
+  String get secureEncryptionDescription => 'Dataene dine er kryptert med en nøkkel som er unik for deg på våre servere, hostet på Google Cloud. Dette betyr at råinnholdet ditt er utilgjengelig for alle, inkludert Omi-ansatte eller Google, direkte fra databasen.';
 
   @override
   String get endToEndEncryption => 'Ende-til-ende-kryptering';
 
   @override
-  String get e2eeCardDescription =>
-      'Aktiver for maksimal sikkerhet der bare du har tilgang til dataene dine. Trykk for å lære mer.';
+  String get e2eeCardDescription => 'Aktiver for maksimal sikkerhet der bare du har tilgang til dataene dine. Trykk for å lære mer.';
 
   @override
   String get dataAlwaysEncrypted => 'Uavhengig av nivå er dataene dine alltid kryptert i hvile og under overføring.';
@@ -4436,8 +4357,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Få Omi Unlimited gratis ved å bidra med dataene dine til å trene AI-modeller.';
 
   @override
-  String get trainingDataBullets =>
-      '• Dataene dine hjelper med å forbedre AI-modeller\n• Bare ikke-sensitive data deles\n• Fullstendig gjennomsiktig prosess';
+  String get trainingDataBullets => '• Dataene dine hjelper med å forbedre AI-modeller\n• Bare ikke-sensitive data deles\n• Fullstendig gjennomsiktig prosess';
 
   @override
   String get learnMoreAtOmiTraining => 'Lær mer på omi.me/training';
@@ -4449,8 +4369,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get submitRequest => 'Send forespørsel';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Takk! Forespørselen din er under vurdering. Vi varsler deg når den er godkjent.';
+  String get thankYouRequestUnderReview => 'Takk! Forespørselen din er under vurdering. Vi varsler deg når den er godkjent.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4485,12 +4404,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get importantBillingInfo => 'Viktig faktureringsinformasjon:';
 
   @override
-  String get monthlyPlanContinues =>
-      'Ditt nåværende månedlige abonnement fortsetter til slutten av faktureringsperioden';
+  String get monthlyPlanContinues => 'Ditt nåværende månedlige abonnement fortsetter til slutten av faktureringsperioden';
 
   @override
-  String get paymentMethodCharged =>
-      'Din eksisterende betalingsmetode vil automatisk bli belastet når ditt månedlige abonnement avsluttes';
+  String get paymentMethodCharged => 'Din eksisterende betalingsmetode vil automatisk bli belastet når ditt månedlige abonnement avsluttes';
 
   @override
   String get annualSubscriptionStarts => 'Ditt 12-måneders årlige abonnement starter automatisk etter belastningen';
@@ -4533,8 +4450,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Ditt årlige abonnement starter automatisk når ditt månedlige abonnement avsluttes.';
+  String get annualPlanStartsAutomatically => 'Ditt årlige abonnement starter automatisk når ditt månedlige abonnement avsluttes.';
 
   @override
   String planRenewsOn(String date) {
@@ -4601,8 +4517,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Ditt personvern er viktig for oss';
 
   @override
-  String get privacyIntroText =>
-      'Hos Omi tar vi ditt personvern veldig alvorlig. Vi ønsker å være transparente om dataene vi samler inn og hvordan vi bruker dem. Her er det du trenger å vite:';
+  String get privacyIntroText => 'Hos Omi tar vi ditt personvern veldig alvorlig. Vi ønsker å være transparente om dataene vi samler inn og hvordan vi bruker dem. Her er det du trenger å vite:';
 
   @override
   String get whatWeTrack => 'Hva vi sporer';
@@ -4617,12 +4532,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get ourCommitment => 'Vår forpliktelse';
 
   @override
-  String get commitmentText =>
-      'Vi er forpliktet til å bruke dataene vi samler inn kun for å gjøre Omi til et bedre produkt for deg. Ditt personvern og din tillit er av største betydning for oss.';
+  String get commitmentText => 'Vi er forpliktet til å bruke dataene vi samler inn kun for å gjøre Omi til et bedre produkt for deg. Ditt personvern og din tillit er av største betydning for oss.';
 
   @override
-  String get thankYouText =>
-      'Takk for at du er en verdsatt bruker av Omi. Hvis du har spørsmål eller bekymringer, ta gjerne kontakt med oss på team@basedhardware.com.';
+  String get thankYouText => 'Takk for at du er en verdsatt bruker av Omi. Hvis du har spørsmål eller bekymringer, ta gjerne kontakt med oss på team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi-synkroniseringsinnstillinger';
@@ -4631,8 +4544,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get enterHotspotCredentials => 'Skriv inn telefonens hotspot-påloggingsinformasjon';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi-synkronisering bruker telefonen som hotspot. Finn navnet og passordet i Innstillinger > Personlig hotspot.';
+  String get wifiSyncUsesHotspot => 'WiFi-synkronisering bruker telefonen som hotspot. Finn navnet og passordet i Innstillinger > Personlig hotspot.';
 
   @override
   String get hotspotNameSsid => 'Hotspot-navn (SSID)';
@@ -4667,8 +4579,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Kunne ikke generere sammendrag. Sørg for at du har samtaler for den dagen.';
+  String get failedToGenerateSummaryCheckConversations => 'Kunne ikke generere sammendrag. Sørg for at du har samtaler for den dagen.';
 
   @override
   String get summaryNotFound => 'Sammendrag ikke funnet';
@@ -4698,8 +4609,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Eksport startet. Dette kan ta noen sekunder...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Dette vil slette alle avledede kunnskapsgrafdata (noder og forbindelser). Dine originale minner vil forbli trygge. Grafen vil gjenoppbygges over tid eller ved neste forespørsel.';
+  String get knowledgeGraphDeleteDescription => 'Dette vil slette alle avledede kunnskapsgrafdata (noder og forbindelser). Dine originale minner vil forbli trygge. Grafen vil gjenoppbygges over tid eller ved neste forespørsel.';
 
   @override
   String get configureDailySummaryDigest => 'Konfigurer din daglige oppgaveoversikt';
@@ -4769,8 +4679,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Slett alle Limitless-samtaler?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Dette vil permanent slette alle samtaler importert fra Limitless. Denne handlingen kan ikke angres.';
+  String get deleteAllLimitlessWarning => 'Dette vil permanent slette alle samtaler importert fra Limitless. Denne handlingen kan ikke angres.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4826,8 +4735,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get howItWorksTitle => 'Hvordan fungerer det?';
 
   @override
-  String get howPeopleWorks =>
-      'Når en person er opprettet, kan du gå til en samtaletranskript og tildele dem deres tilsvarende segmenter, på den måten vil Omi også kunne gjenkjenne deres tale!';
+  String get howPeopleWorks => 'Når en person er opprettet, kan du gå til en samtaletranskript og tildele dem deres tilsvarende segmenter, på den måten vil Omi også kunne gjenkjenne deres tale!';
 
   @override
   String get tapToDelete => 'Trykk for å slette';
@@ -4853,8 +4761,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get privacyNotice => 'Personvernerklæring';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Opptak kan fange opp andres stemmer. Sørg for at du har samtykke fra alle deltakere før du aktiverer.';
+  String get recordingsMayCaptureOthers => 'Opptak kan fange opp andres stemmer. Sørg for at du har samtykke fra alle deltakere før du aktiverer.';
 
   @override
   String get enable => 'Aktiver';
@@ -4866,8 +4773,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get on => 'På';
 
   @override
-  String get storeAudioDescription =>
-      'Behold alle lydopptak lagret lokalt på telefonen. Når deaktivert, beholdes bare mislykkede opplastinger for å spare lagringsplass.';
+  String get storeAudioDescription => 'Behold alle lydopptak lagret lokalt på telefonen. Når deaktivert, beholdes bare mislykkede opplastinger for å spare lagringsplass.';
 
   @override
   String get enableLocalStorage => 'Aktiver lokal lagring';
@@ -4888,8 +4794,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get cloudStorageDialogMessage => 'Dine sanntidsopptak lagres i privat skylagring mens du snakker.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Lagre sanntidsopptakene dine i privat skylagring mens du snakker. Lyd fanges opp og lagres sikkert i sanntid.';
+  String get storeAudioCloudDescription => 'Lagre sanntidsopptakene dine i privat skylagring mens du snakker. Lyd fanges opp og lagres sikkert i sanntid.';
 
   @override
   String get downloadingFirmware => 'Laster ned fastvare';
@@ -4942,8 +4847,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get payments => 'Betalinger';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Koble til en betalingsmetode nedenfor for å begynne å motta utbetalinger for appene dine.';
+  String get connectPaymentMethodInfo => 'Koble til en betalingsmetode nedenfor for å begynne å motta utbetalinger for appene dine.';
 
   @override
   String get selectedPaymentMethod => 'Valgt betalingsmetode';
@@ -4970,8 +4874,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get monthlyPayouts => 'Månedlige utbetalinger';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Motta månedlige utbetalinger direkte til kontoen din når du når \$10 i inntekter';
+  String get monthlyPayoutsDescription => 'Motta månedlige utbetalinger direkte til kontoen din når du når \$10 i inntekter';
 
   @override
   String get secureAndReliable => 'Sikkert og pålitelig';
@@ -4998,8 +4901,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get connectingYourStripeAccount => 'Kobler til Stripe-kontoen din';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Fullfør Stripe-onboardingprosessen i nettleseren din. Denne siden oppdateres automatisk når prosessen er fullført.';
+  String get stripeOnboardingInstructions => 'Fullfør Stripe-onboardingprosessen i nettleseren din. Denne siden oppdateres automatisk når prosessen er fullført.';
 
   @override
   String get failedTryAgain => 'Mislyktes? Prøv igjen';
@@ -5011,8 +4913,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get successfullyConnected => 'Vellykket tilkoblet!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Stripe-kontoen din er nå klar til å motta betalinger. Du kan begynne å tjene på appsalgene dine med en gang.';
+  String get stripeReadyForPayments => 'Stripe-kontoen din er nå klar til å motta betalinger. Du kan begynne å tjene på appsalgene dine med en gang.';
 
   @override
   String get updateStripeDetails => 'Oppdater Stripe-detaljer';
@@ -5030,8 +4931,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Oppdater PayPal-kontoinformasjonen din';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Koble til PayPal-kontoen din for å begynne å motta betalinger for appene dine';
+  String get connectPayPalToReceivePayments => 'Koble til PayPal-kontoen din for å begynne å motta betalinger for appene dine';
 
   @override
   String get paypalEmail => 'PayPal e-post';
@@ -5040,8 +4940,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me-lenke';
 
   @override
-  String get stripeRecommendation =>
-      'Hvis Stripe er tilgjengelig i ditt land, anbefaler vi sterkt å bruke det for raskere og enklere utbetalinger.';
+  String get stripeRecommendation => 'Hvis Stripe er tilgjengelig i ditt land, anbefaler vi sterkt å bruke det for raskere og enklere utbetalinger.';
 
   @override
   String get updatePayPalDetails => 'Oppdater PayPal-detaljer';
@@ -5093,8 +4992,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Ekstra taleprøve fjernet';
 
   @override
-  String get consentDataMessage =>
-      'Ved å fortsette vil samtalene, opptakene og den personlige informasjonen din bli lagret sikkert på våre servere. Lydopptakene og transkripsjonene dine behandles av tredjeparts AI-tjenester (inkludert Deepgram for transkripsjon og OpenAI for analyse) for å gi deg AI-drevne innsikter og aktivere alle appfunksjoner.';
+  String get consentDataMessage => 'Ved å fortsette vil samtalene, opptakene og den personlige informasjonen din bli lagret sikkert på våre servere. Lydopptakene og transkripsjonene dine behandles av tredjeparts AI-tjenester (inkludert Deepgram for transkripsjon og OpenAI for analyse) for å gi deg AI-drevne innsikter og aktivere alle appfunksjoner.';
 
   @override
   String get tasksEmptyStateMessage => 'Oppgaver fra samtalene dine vil vises her.\nTrykk på + for å opprette manuelt.';
@@ -5133,15 +5031,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Installer Omi på din\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'For å bruke Apple Watch med Omi, må du først installere Omi-appen på klokken din.';
+  String get installOmiOnAppleWatchDescription => 'For å bruke Apple Watch med Omi, må du først installere Omi-appen på klokken din.';
 
   @override
   String get openOmiOnAppleWatch => 'Åpne Omi på din\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi-appen er installert på Apple Watch. Åpne den og trykk på Start for å begynne.';
+  String get openOmiOnAppleWatchDescription => 'Omi-appen er installert på Apple Watch. Åpne den og trykk på Start for å begynne.';
 
   @override
   String get openWatchApp => 'Åpne Watch-appen';
@@ -5150,15 +5046,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Jeg har installert og åpnet appen';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Kan ikke åpne Apple Watch-appen. Åpne Watch-appen manuelt på Apple Watch og installer Omi fra seksjonen \"Tilgjengelige apper\".';
+  String get unableToOpenWatchApp => 'Kan ikke åpne Apple Watch-appen. Åpne Watch-appen manuelt på Apple Watch og installer Omi fra seksjonen \"Tilgjengelige apper\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch tilkoblet!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch er fortsatt ikke tilgjengelig. Sørg for at Omi-appen er åpen på klokken din.';
+  String get appleWatchNotReachable => 'Apple Watch er fortsatt ikke tilgjengelig. Sørg for at Omi-appen er åpen på klokken din.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5586,8 +5480,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get multipleSpeakersDetected => 'Flere talere oppdaget';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Det ser ut som det er flere talere i opptaket. Sørg for at du er på et stille sted og prøv igjen.';
+  String get multipleSpeakersDescription => 'Det ser ut som det er flere talere i opptaket. Sørg for at du er på et stille sted og prøv igjen.';
 
   @override
   String get invalidRecordingDetected => 'Ugyldig opptak oppdaget';
@@ -5605,8 +5498,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get howToTakeGoodSample => 'Hvordan ta et godt eksempel?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Sørg for at du er på et stille sted.\n2. Snakk tydelig og naturlig.\n3. Sørg for at enheten din er i sin naturlige posisjon på halsen.\n\nNår den er opprettet, kan du alltid forbedre den eller gjøre det på nytt.';
+  String get goodSampleInstructions => '1. Sørg for at du er på et stille sted.\n2. Snakk tydelig og naturlig.\n3. Sørg for at enheten din er i sin naturlige posisjon på halsen.\n\nNår den er opprettet, kan du alltid forbedre den eller gjøre det på nytt.';
 
   @override
   String get noDeviceConnectedUseMic => 'Ingen enhet tilkoblet. Telefonmikrofonen vil bli brukt.';
@@ -5669,12 +5561,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get howItWorks => 'Slik fungerer det';
 
   @override
-  String get dailyScoreExplanation =>
-      'Din daglige poengsum er basert på oppgavefullføring. Fullfør oppgavene dine for å forbedre poengsummen!';
+  String get dailyScoreExplanation => 'Din daglige poengsum er basert på oppgavefullføring. Fullfør oppgavene dine for å forbedre poengsummen!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontroller hvor ofte Omi sender deg proaktive varsler og påminnelser.';
+  String get notificationFrequencyDescription => 'Kontroller hvor ofte Omi sender deg proaktive varsler og påminnelser.';
 
   @override
   String get sliderOff => 'Av';
@@ -5974,8 +5864,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL ikke satt';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Vennligst angi webhook URL i utviklerinnstillinger for å bruke denne funksjonen.';
+  String get setWebhookUrlInSettings => 'Vennligst angi webhook URL i utviklerinnstillinger for å bruke denne funksjonen.';
 
   @override
   String get sendWebUrl => 'Send web-URL';
@@ -6049,8 +5938,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get cloudProvider => 'Skyleverandør';
 
   @override
-  String get premiumMinutesInfo =>
-      '1200 premium-minutter/måned. Fanen På enheten tilbyr ubegrenset gratis transkribering.';
+  String get premiumMinutesInfo => '1200 premium-minutter/måned. Fanen På enheten tilbyr ubegrenset gratis transkribering.';
 
   @override
   String get viewUsage => 'Se forbruk';
@@ -6065,8 +5953,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get performanceWarning => 'Ytelsesadvarsel';
 
   @override
-  String get largeModelWarning =>
-      'Denne modellen er stor og kan krasje appen eller kjøre veldig sakte på mobile enheter.\n\n\"small\" eller \"base\" anbefales.';
+  String get largeModelWarning => 'Denne modellen er stor og kan krasje appen eller kjøre veldig sakte på mobile enheter.\n\n\"small\" eller \"base\" anbefales.';
 
   @override
   String get usingNativeIosSpeech => 'Bruker innebygd iOS talegjenkjenning';
@@ -6129,8 +6016,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get batteryDrainSignificantly => 'Batteritømming vil øke betydelig.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 premium minutter/måned. På enheten-fanen tilbyr ubegrenset gratis transkribering. ';
+  String get premiumMinutesMonth => '1200 premium minutter/måned. På enheten-fanen tilbyr ubegrenset gratis transkribering. ';
 
   @override
   String get audioProcessedLocally => 'Lyd behandles lokalt. Fungerer offline, mer privat, men bruker mer batteri.';
@@ -6142,8 +6028,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get modelLabel => 'Modell';
 
   @override
-  String get modelTooLargeWarning =>
-      'Denne modellen er stor og kan føre til at appen krasjer eller kjører veldig sakte på mobile enheter.\n\nsmall eller base anbefales.';
+  String get modelTooLargeWarning => 'Denne modellen er stor og kan føre til at appen krasjer eller kjører veldig sakte på mobile enheter.\n\nsmall eller base anbefales.';
 
   @override
   String get nativeEngineNoDownload => 'Enhetens innebygde talemotor vil bli brukt. Ingen modellnedlasting nødvendig.';
@@ -6182,8 +6067,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omis innebygde live-transkribering er optimalisert for sanntidssamtaler med automatisk talerdeteksjon og diarisering.';
+  String get omiTranscriptionOptimized => 'Omis innebygde live-transkribering er optimalisert for sanntidssamtaler med automatisk talerdeteksjon og diarisering.';
 
   @override
   String get reset => 'Tilbakestill';
@@ -6403,8 +6287,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Bygger kunnskapsgraf fra minner...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Kunnskapsgrafen din vil bli bygget automatisk når du oppretter nye minner.';
+  String get knowledgeGraphWillBuildAutomatically => 'Kunnskapsgrafen din vil bli bygget automatisk når du oppretter nye minner.';
 
   @override
   String get buildGraphButton => 'Bygg graf';
@@ -6706,8 +6589,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Laster ned lyd fra enhetens SD-kort';
 
   @override
-  String get transferRequiredDescription =>
-      'Dette opptaket er lagret på enhetens SD-kort. Overfør det til telefonen for å spille av eller dele.';
+  String get transferRequiredDescription => 'Dette opptaket er lagret på enhetens SD-kort. Overfør det til telefonen for å spille av eller dele.';
 
   @override
   String get cancelTransfer => 'Avbryt overføring';
@@ -6728,8 +6610,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get shareRecording => 'Del opptak';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Er du sikker på at du vil slette dette opptaket permanent? Dette kan ikke angres.';
+  String get deleteRecordingConfirmation => 'Er du sikker på at du vil slette dette opptaket permanent? Dette kan ikke angres.';
 
   @override
   String get recordingIdLabel => 'Opptaks-ID';
@@ -6788,8 +6669,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get enableFastTransfer => 'Aktiver hurtig overføring';
 
   @override
-  String get fastTransferDescription =>
-      'Hurtig overføring bruker WiFi for ~5x raskere hastigheter. Telefonen din kobler seg midlertidig til Omi-enhetens WiFi-nettverk under overføring.';
+  String get fastTransferDescription => 'Hurtig overføring bruker WiFi for ~5x raskere hastigheter. Telefonen din kobler seg midlertidig til Omi-enhetens WiFi-nettverk under overføring.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Internettilgang er satt på pause under overføring';
@@ -6804,8 +6684,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get fiveTimesFaster => '5X RASKERE';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Oppretter en direkte WiFi-tilkobling til Omi-enheten. Telefonen kobler seg midlertidig fra vanlig WiFi under overføring.';
+  String get fastTransferMethodDescription => 'Oppretter en direkte WiFi-tilkobling til Omi-enheten. Telefonen kobler seg midlertidig fra vanlig WiFi under overføring.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6814,8 +6693,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get bleSpeed => '~30 KB/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Bruker standard Bluetooth Low Energy-tilkobling. Langsommere, men påvirker ikke WiFi-tilkoblingen.';
+  String get bluetoothMethodDescription => 'Bruker standard Bluetooth Low Energy-tilkobling. Langsommere, men påvirker ikke WiFi-tilkoblingen.';
 
   @override
   String get selected => 'Valgt';
@@ -6853,12 +6731,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get appDeleteFailed => 'Kunne ikke slette appen. Prøv igjen senere.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Appens synlighet ble endret. Det kan ta noen minutter før endringen vises.';
+  String get appVisibilityChangedSuccessfully => 'Appens synlighet ble endret. Det kan ta noen minutter før endringen vises.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Feil ved aktivering av appen. Hvis dette er en integrasjonsapp, sørg for at oppsettet er fullført.';
+  String get errorActivatingAppIntegration => 'Feil ved aktivering av appen. Hvis dette er en integrasjonsapp, sørg for at oppsettet er fullført.';
 
   @override
   String get errorUpdatingAppStatus => 'Det oppstod en feil under oppdatering av app-statusen.';
@@ -7125,19 +7001,16 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Oppgradering planlagt\\! Ditt månedlige abonnement fortsetter til slutten av faktureringsperioden, og bytter deretter automatisk til årlig.';
+  String get planUpgradeScheduledMessage => 'Oppgradering planlagt\\! Ditt månedlige abonnement fortsetter til slutten av faktureringsperioden, og bytter deretter automatisk til årlig.';
 
   @override
   String get couldNotSchedulePlanChange => 'Kunne ikke planlegge abonnementsendring. Prøv igjen.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Abonnementet ditt har blitt reaktivert\\! Ingen belastning nå - du vil bli fakturert ved slutten av din nåværende periode.';
+  String get subscriptionReactivatedDefault => 'Abonnementet ditt har blitt reaktivert\\! Ingen belastning nå - du vil bli fakturert ved slutten av din nåværende periode.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Abonnement vellykket\\! Du har blitt belastet for den nye faktureringsperioden.';
+  String get subscriptionSuccessfulCharged => 'Abonnement vellykket\\! Du har blitt belastet for den nye faktureringsperioden.';
 
   @override
   String get couldNotProcessSubscription => 'Kunne ikke behandle abonnement. Prøv igjen.';
@@ -7333,8 +7206,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get onboardingNotificationDeniedSystemPrefs => 'Varslingstillatelse avvist. Gi tillatelse i Systemvalg.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Varslingstillatelse avvist. Gi tillatelse i Systemvalg > Varsler.';
+  String get onboardingNotificationDeniedNotifications => 'Varslingstillatelse avvist. Gi tillatelse i Systemvalg > Varsler.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7347,15 +7219,13 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Gi posisjonstillatelse i Innstillinger > Personvern og sikkerhet > Posisjonstjenester';
+  String get onboardingLocationGrantInSettings => 'Gi posisjonstillatelse i Innstillinger > Personvern og sikkerhet > Posisjonstjenester';
 
   @override
   String get onboardingMicrophoneRequired => 'Mikrofontillatelse kreves for opptak.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofontillatelse avvist. Gi tillatelse i Systemvalg > Personvern og sikkerhet > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Mikrofontillatelse avvist. Gi tillatelse i Systemvalg > Personvern og sikkerhet > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7371,8 +7241,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Skjermopptakstillatelse kreves for opptak av systemlyd.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Skjermopptakstillatelse avvist. Gi tillatelse i Systemvalg > Personvern og sikkerhet > Skjermopptak.';
+  String get onboardingScreenCaptureDenied => 'Skjermopptakstillatelse avvist. Gi tillatelse i Systemvalg > Personvern og sikkerhet > Skjermopptak.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7425,8 +7294,7 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Fototillatelse avslått. Vennligst tillat tilgang til bilder for å velge bilder';
+  String get msgPhotosPermissionDenied => 'Fototillatelse avslått. Vennligst tillat tilgang til bilder for å velge bilder';
 
   @override
   String get msgSelectImagesGenericError => 'Feil ved valg av bilder. Vennligst prøv igjen.';
@@ -7498,8 +7366,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get locationPermissionRequired => 'Plasseringstillatelse kreves';
 
   @override
-  String get locationPermissionContent =>
-      'Hurtig overføring krever plasseringstillatelse for å verifisere WiFi-tilkobling. Gi plasseringstillatelse for å fortsette.';
+  String get locationPermissionContent => 'Hurtig overføring krever plasseringstillatelse for å verifisere WiFi-tilkobling. Gi plasseringstillatelse for å fortsette.';
 
   @override
   String get pdfTranscriptExport => 'Eksporter transkripsjon';
@@ -7970,8 +7837,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Sett Plaud Note i paringsmodus';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Trykk og hold sideknappen i 2 sekunder. Den røde LED-en blinker når den er klar til paring.';
+  String get pairingDescPlaudNote => 'Trykk og hold sideknappen i 2 sekunder. Den røde LED-en blinker når den er klar til paring.';
 
   @override
   String get pairingTitleBee => 'Sett Bee i paringsmodus';
@@ -7983,15 +7849,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get pairingTitleLimitless => 'Sett Limitless i paringsmodus';
 
   @override
-  String get pairingDescLimitless =>
-      'Når et lys er synlig, trykk én gang og trykk deretter og hold til enheten viser et rosa lys, slipp deretter.';
+  String get pairingDescLimitless => 'Når et lys er synlig, trykk én gang og trykk deretter og hold til enheten viser et rosa lys, slipp deretter.';
 
   @override
   String get pairingTitleFriendPendant => 'Sett Friend Pendant i paringsmodus';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Trykk på knappen på anhengeren for å slå den på. Den går automatisk i paringsmodus.';
+  String get pairingDescFriendPendant => 'Trykk på knappen på anhengeren for å slå den på. Den går automatisk i paringsmodus.';
 
   @override
   String get pairingTitleFieldy => 'Sett Fieldy i paringsmodus';
@@ -8003,8 +7867,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Koble til Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Installer og åpne Omi-appen på Apple Watch, trykk deretter på Koble til i appen.';
+  String get pairingDescAppleWatch => 'Installer og åpne Omi-appen på Apple Watch, trykk deretter på Koble til i appen.';
 
   @override
   String get pairingTitleNeoOne => 'Sett Neo One i paringsmodus';
@@ -8098,8 +7961,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Her er hva jeg vet om deg';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Dette kartet oppdateres etter hvert som Omi lærer fra samtalene dine.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Dette kartet oppdateres etter hvert som Omi lærer fra samtalene dine.';
 
   @override
   String get apiEnvironment => 'API-miljø';
@@ -8128,8 +7990,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get switchAndRestart => 'Bytt';
 
   @override
-  String get stagingDisclaimer =>
-      'Testmiljøet kan være ustabilt, ha inkonsistent ytelse, og data kan gå tapt. Kun for testing.';
+  String get stagingDisclaimer => 'Testmiljøet kan være ustabilt, ha inkonsistent ytelse, og data kan gå tapt. Kun for testing.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Lagret. Lukk og åpne appen på nytt for å bruke endringene.';
@@ -8385,8 +8246,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteSyncedFiles => 'Slett synkroniserte opptak';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Disse opptakene er allerede synkronisert med telefonen din. Dette kan ikke angres.';
+  String get deleteSyncedFilesMessage => 'Disse opptakene er allerede synkronisert med telefonen din. Dette kan ikke angres.';
 
   @override
   String get syncedFilesDeleted => 'Synkroniserte opptak slettet';
@@ -8398,8 +8258,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deletePendingFiles => 'Slett ventende opptak';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Disse opptakene er IKKE synkronisert med telefonen din og vil gå permanent tapt. Dette kan ikke angres.';
+  String get deletePendingFilesWarning => 'Disse opptakene er IKKE synkronisert med telefonen din og vil gå permanent tapt. Dette kan ikke angres.';
 
   @override
   String get pendingFilesDeleted => 'Ventende opptak slettet';
@@ -8411,8 +8270,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deleteAll => 'Slett alle';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Dette sletter synkroniserte og ventende opptak. Ventende opptak er IKKE synkronisert og vil gå permanent tapt.';
+  String get deleteAllFilesWarning => 'Dette sletter synkroniserte og ventende opptak. Ventende opptak er IKKE synkronisert og vil gå permanent tapt.';
 
   @override
   String get allFilesDeleted => 'Alle opptak slettet';
@@ -8477,8 +8335,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get fairUseAboutTitle => 'Om rimelig bruk';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi er designet for personlige samtaler, møter og direkte interaksjoner. Bruken måles etter faktisk oppdaget taletid, ikke tilkoblingstid. Hvis bruken vesentlig overstiger normale mønstre for ikke-personlig innhold, kan justeringer gjelde.';
+  String get fairUseAboutBody => 'Omi er designet for personlige samtaler, møter og direkte interaksjoner. Bruken måles etter faktisk oppdaget taletid, ikke tilkoblingstid. Hvis bruken vesentlig overstiger normale mønstre for ikke-personlig innhold, kan justeringer gjelde.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8516,8 +8373,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get improveConnectionTitle => 'Forbedre tilkobling';
 
   @override
-  String get improveConnectionContent =>
-      'Vi har forbedret hvordan Omi holder seg tilkoblet enheten din. For å aktivere dette, gå til Enhetsinformasjon-siden, trykk på \"Koble fra enhet\", og koble til enheten din på nytt.';
+  String get improveConnectionContent => 'Vi har forbedret hvordan Omi holder seg tilkoblet enheten din. For å aktivere dette, gå til Enhetsinformasjon-siden, trykk på \"Koble fra enhet\", og koble til enheten din på nytt.';
 
   @override
   String get improveConnectionAction => 'Forstått';
@@ -8572,16 +8428,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get cancelSyncQuestion => 'Avbryt synkronisering?';
 
   @override
-  String get omisStorageDesc =>
-      'Når din Omi ikke er koblet til telefonen, lagrer den lyd lokalt i det innebygde minnet. Du mister aldri et opptak.';
+  String get omisStorageDesc => 'Når din Omi ikke er koblet til telefonen, lagrer den lyd lokalt i det innebygde minnet. Du mister aldri et opptak.';
 
   @override
-  String get phoneStorageDesc =>
-      'Når Omi kobler til igjen, overføres opptak automatisk til telefonen din før opplasting.';
+  String get phoneStorageDesc => 'Når Omi kobler til igjen, overføres opptak automatisk til telefonen din før opplasting.';
 
   @override
-  String get cloudStorageDesc =>
-      'Etter opplasting behandles og transkriberes opptakene dine. Samtaler vil være tilgjengelige innen ett minutt.';
+  String get cloudStorageDesc => 'Etter opplasting behandles og transkriberes opptakene dine. Samtaler vil være tilgjengelige innen ett minutt.';
 
   @override
   String get tipKeepPhoneNearby => 'Hold telefonen i nærheten for raskere synkronisering';
@@ -8605,12 +8458,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get permissionEnable => 'Aktiver';
 
   @override
-  String get permissionsPageDescription =>
-      'Disse tillatelsene er sentrale for hvordan Omi fungerer. De aktiverer nøkkelfunksjoner som varsler, plasseringsbaserte opplevelser og lydopptak.';
+  String get permissionsPageDescription => 'Disse tillatelsene er sentrale for hvordan Omi fungerer. De aktiverer nøkkelfunksjoner som varsler, plasseringsbaserte opplevelser og lydopptak.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi trenger noen tillatelser for å fungere riktig. Vennligst gi dem for å fortsette.';
+  String get permissionsRequiredDescription => 'Omi trenger noen tillatelser for å fungere riktig. Vennligst gi dem for å fortsette.';
 
   @override
   String get permissionsSetupTitle => 'Få den beste opplevelsen';
@@ -8664,8 +8515,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get justAMoment => 'Et øyeblikk';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Vi anbefaler sterkt at du utforsker andre alternativer i stedet for å avbestille.';
+  String get cancelConsequencesSubtitle => 'Vi anbefaler sterkt at du utforsker andre alternativer i stedet for å avbestille.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8867,8 +8717,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get enableLocationTitle => 'Aktiver plassering';
 
   @override
-  String get enableLocationDescription =>
-      'Plasseringstillatelse er nødvendig for å finne Bluetooth-enheter i nærheten.';
+  String get enableLocationDescription => 'Plasseringstillatelse er nødvendig for å finne Bluetooth-enheter i nærheten.';
 
   @override
   String get voiceRecordingFound => 'Opptak funnet';
@@ -8889,8 +8738,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get firmwareWarningTitle => 'Viktig: Les før oppdatering';
 
   @override
-  String get firmwareFormatWarning =>
-      'Denne fastvaren vil formatere SD-kortet. Sørg for at alle offline-data er synkronisert før oppgradering.\n\nHvis du ser et blinkende rødt lys etter installasjon av denne versjonen, ikke bekymre deg. Koble enheten til appen, og den skal bli blå. Det røde lyset betyr at enhetens klokke ikke er synkronisert ennå.';
+  String get firmwareFormatWarning => 'Denne fastvaren vil formatere SD-kortet. Sørg for at alle offline-data er synkronisert før oppgradering.\n\nHvis du ser et blinkende rødt lys etter installasjon av denne versjonen, ikke bekymre deg. Koble enheten til appen, og den skal bli blå. Det røde lyset betyr at enhetens klokke ikke er synkronisert ennå.';
 
   @override
   String get continueAnyway => 'Fortsett';
@@ -8910,8 +8758,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get tasksMarkComplete => 'Merket som fullført';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi får tilgang til Apple Health gjennom Apples HealthKit-rammeverk. Du kan når som helst trekke tilbake tilgangen i iOS-innstillingene.';
+  String get appleHealthManageNote => 'Omi får tilgang til Apple Health gjennom Apples HealthKit-rammeverk. Du kan når som helst trekke tilbake tilgangen i iOS-innstillingene.';
 
   @override
   String get appleHealthConnectCta => 'Koble til Apple Health';
@@ -8944,8 +8791,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health-tilgang avvist';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi har ikke tillatelse til å lese Apple Health-dataene dine. Slå det på i iOS-innstillinger → Personvern og sikkerhet → Helse → Omi.';
+  String get appleHealthDeniedBody => 'Omi har ikke tillatelse til å lese Apple Health-dataene dine. Slå det på i iOS-innstillinger → Personvern og sikkerhet → Helse → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Hvorfor forlater du oss?';
@@ -9014,8 +8860,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get planUpdate => 'Planoppdatering';
 
   @override
-  String get planDeprecationMessage =>
-      'Ditt Unlimited-abonnement avvikles. Bytt til Operator-abonnementet — samme flotte funksjoner til \$49/md. Ditt nåværende abonnement vil fortsette å fungere i mellomtiden.';
+  String get planDeprecationMessage => 'Ditt Unlimited-abonnement avvikles. Bytt til Operator-abonnementet — samme flotte funksjoner til \$49/md. Ditt nåværende abonnement vil fortsette å fungere i mellomtiden.';
 
   @override
   String get upgradeYourPlan => 'Oppgrader planen din';
@@ -9126,8 +8971,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Du har nådd din månedlige grense. Oppgrader for å fortsette å chatte med Omi uten begrensninger.';
+  String get chatQuotaExceededReply => 'Du har nådd din månedlige grense. Oppgrader for å fortsette å chatte med Omi uten begrensninger.';
 
   @override
   String get voiceResponseAudio => 'Les Omis svar høyt';
@@ -9158,4 +9002,25 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Legg til oppgave';
+
+  @override
+  String get quickActionAskOmiAnything => 'Spør Omi om hva som helst';
+
+  @override
+  String get quickActionVoiceMode => 'Stemmetilstand';
+
+  @override
+  String get quickActionMute => 'Demp';
+
+  @override
+  String get quickActionUnmute => 'Opphev demping';
+
+  @override
+  String get quickActionConnectDevice => 'Koble til enhet';
+
+  @override
+  String get quickActionDeviceSettings => 'Enhetsinnstillinger';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -24,8 +24,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteConversationTitle => 'Usunąć rozmowę?';
 
   @override
-  String get deleteConversationMessage =>
-      'Spowoduje to również usunięcie powiązanych wspomnień, zadań i plików audio. Tej czynności nie można cofnąć.';
+  String get deleteConversationMessage => 'Spowoduje to również usunięcie powiązanych wspomnień, zadań i plików audio. Tej czynności nie można cofnąć.';
 
   @override
   String get confirm => 'Potwierdź';
@@ -146,8 +145,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleting => 'Usuwanie...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Ukończ uwierzytelnianie w przeglądarce. Po zakończeniu wróć do aplikacji.';
+  String get pleaseCompleteAuthentication => 'Ukończ uwierzytelnianie w przeglądarce. Po zakończeniu wróć do aplikacji.';
 
   @override
   String get failedToStartAuthentication => 'Nie udało się rozpocząć uwierzytelniania';
@@ -355,19 +353,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get appsDisconnected => 'Twoje aplikacje i integracje zostaną natychmiast rozłączone.';
 
   @override
-  String get exportBeforeDelete =>
-      'Możesz wyeksportować swoje dane przed usunięciem konta, ale po usunięciu nie można ich odzyskać.';
+  String get exportBeforeDelete => 'Możesz wyeksportować swoje dane przed usunięciem konta, ale po usunięciu nie można ich odzyskać.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Rozumiem, że usunięcie mojego konta jest trwałe i wszystkie dane, w tym wspomnienia i rozmowy, zostaną utracone bez możliwości odzyskania.';
+  String get deleteAccountCheckbox => 'Rozumiem, że usunięcie mojego konta jest trwałe i wszystkie dane, w tym wspomnienia i rozmowy, zostaną utracone bez możliwości odzyskania.';
 
   @override
   String get areYouSure => 'Czy jesteś pewien?';
 
   @override
-  String get deleteAccountFinal =>
-      'Ta czynność jest nieodwracalna i trwale usunie Twoje konto oraz wszystkie powiązane dane. Czy na pewno chcesz kontynuować?';
+  String get deleteAccountFinal => 'Ta czynność jest nieodwracalna i trwale usunie Twoje konto oraz wszystkie powiązane dane. Czy na pewno chcesz kontynuować?';
 
   @override
   String get deleteNow => 'Usuń teraz';
@@ -376,8 +371,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get goBack => 'Wróć';
 
   @override
-  String get checkBoxToConfirm =>
-      'Zaznacz pole, aby potwierdzić, że rozumiesz, iż usunięcie konta jest trwałe i nieodwracalne.';
+  String get checkBoxToConfirm => 'Zaznacz pole, aby potwierdzić, że rozumiesz, iż usunięcie konta jest trwałe i nieodwracalne.';
 
   @override
   String get profile => 'Profil';
@@ -455,8 +449,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get yourPrivacyYourControl => 'Twoja prywatność, Twoja kontrola';
 
   @override
-  String get privacyIntro =>
-      'W Omi dbamy o Twoją prywatność. Ta strona pozwala kontrolować sposób przechowywania i wykorzystywania Twoich danych.';
+  String get privacyIntro => 'W Omi dbamy o Twoją prywatność. Ta strona pozwala kontrolować sposób przechowywania i wykorzystywania Twoich danych.';
 
   @override
   String get learnMore => 'Dowiedz się więcej...';
@@ -465,15 +458,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dataProtectionLevel => 'Poziom ochrony danych';
 
   @override
-  String get dataProtectionDesc =>
-      'Twoje dane są domyślnie zabezpieczone silnym szyfrowaniem. Przejrzyj swoje ustawienia i przyszłe opcje prywatności poniżej.';
+  String get dataProtectionDesc => 'Twoje dane są domyślnie zabezpieczone silnym szyfrowaniem. Przejrzyj swoje ustawienia i przyszłe opcje prywatności poniżej.';
 
   @override
   String get appAccess => 'Dostęp aplikacji';
 
   @override
-  String get appAccessDesc =>
-      'Następujące aplikacje mogą uzyskać dostęp do Twoich danych. Dotknij aplikacji, aby zarządzać jej uprawnieniami.';
+  String get appAccessDesc => 'Następujące aplikacje mogą uzyskać dostęp do Twoich danych. Dotknij aplikacji, aby zarządzać jej uprawnieniami.';
 
   @override
   String get noAppsExternalAccess => 'Żadne zainstalowane aplikacje nie mają zewnętrznego dostępu do Twoich danych.';
@@ -530,22 +521,19 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Twoje Omi zostało rozłączone 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Urządzenie rozłączone. Przejdź do Ustawienia > Bluetooth i zapomnij urządzenie, aby zakończyć rozłączanie.';
+  String get deviceUnpairedMessage => 'Urządzenie rozłączone. Przejdź do Ustawienia > Bluetooth i zapomnij urządzenie, aby zakończyć rozłączanie.';
 
   @override
   String get unpairDialogTitle => 'Rozparuj urządzenie';
 
   @override
-  String get unpairDialogMessage =>
-      'Spowoduje to rozparowanie urządzenia, aby można je było podłączyć do innego telefonu. Musisz przejść do Ustawienia > Bluetooth i zapomnieć urządzenie, aby zakończyć proces.';
+  String get unpairDialogMessage => 'Spowoduje to rozparowanie urządzenia, aby można je było podłączyć do innego telefonu. Musisz przejść do Ustawienia > Bluetooth i zapomnieć urządzenie, aby zakończyć proces.';
 
   @override
   String get deviceNotConnected => 'Urządzenie nie jest podłączone';
 
   @override
-  String get connectDeviceMessage =>
-      'Podłącz swoje urządzenie Omi, aby uzyskać dostęp\ndo ustawień urządzenia i personalizacji';
+  String get connectDeviceMessage => 'Podłącz swoje urządzenie Omi, aby uzyskać dostęp\ndo ustawień urządzenia i personalizacji';
 
   @override
   String get deviceInfoSection => 'Informacje o urządzeniu';
@@ -560,8 +548,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get v2Undetected => 'Nie wykryto V2';
 
   @override
-  String get v2UndetectedMessage =>
-      'Widzimy, że masz urządzenie V1 lub Twoje urządzenie nie jest podłączone. Funkcja karty SD jest dostępna tylko dla urządzeń V2.';
+  String get v2UndetectedMessage => 'Widzimy, że masz urządzenie V1 lub Twoje urządzenie nie jest podłączone. Funkcja karty SD jest dostępna tylko dla urządzeń V2.';
 
   @override
   String get endConversation => 'Zakończ rozmowę';
@@ -693,8 +680,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get noActivityYet => 'Brak aktywności';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Rozpocznij rozmowę z Omi,\naby zobaczyć tutaj statystyki wykorzystania.';
+  String get startConversationToSeeInsights => 'Rozpocznij rozmowę z Omi,\naby zobaczyć tutaj statystyki wykorzystania.';
 
   @override
   String get listening => 'Słuchanie';
@@ -836,8 +822,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Usunąć graf wiedzy?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Spowoduje to usunięcie wszystkich danych grafu wiedzy (węzłów i połączeń). Twoje oryginalne wspomnienia pozostaną bezpieczne. Graf zostanie odbudowany z czasem lub na następne żądanie.';
+  String get deleteKnowledgeGraphMessage => 'Spowoduje to usunięcie wszystkich danych grafu wiedzy (węzłów i połączeń). Twoje oryginalne wspomnienia pozostaną bezpieczne. Graf zostanie odbudowany z czasem lub na następne żądanie.';
 
   @override
   String get knowledgeGraphDeleted => 'Graf wiedzy usunięty';
@@ -985,8 +970,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shortConversationThreshold => 'Próg krótkiej rozmowy';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Rozmowy krótsze niż ten próg będą ukryte, chyba że włączysz powyższą opcję';
+  String get shortConversationThresholdSubtitle => 'Rozmowy krótsze niż ten próg będą ukryte, chyba że włączysz powyższą opcję';
 
   @override
   String get durationThreshold => 'Próg czasu trwania';
@@ -1081,8 +1065,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get needYourPermission => 'Potrzebujemy Twojego pozwolenia';
 
   @override
-  String get alreadyGavePermission =>
-      'Już udzieliłeś nam zgody na zapisywanie nagrań. Oto przypomnienie, dlaczego tego potrzebujemy:';
+  String get alreadyGavePermission => 'Już udzieliłeś nam zgody na zapisywanie nagrań. Oto przypomnienie, dlaczego tego potrzebujemy:';
 
   @override
   String get wouldLikePermission => 'Chcielibyśmy uzyskać Twoją zgodę na zapisywanie nagrań głosowych. Oto dlaczego:';
@@ -1091,26 +1074,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get improveSpeechProfile => 'Popraw swój profil głosu';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Używamy nagrań do dalszego szkolenia i ulepszania Twojego osobistego profilu głosu.';
+  String get improveSpeechProfileDesc => 'Używamy nagrań do dalszego szkolenia i ulepszania Twojego osobistego profilu głosu.';
 
   @override
   String get trainFamilyProfiles => 'Trenuj profile dla przyjaciół i rodziny';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Twoje nagrania pomagają nam rozpoznawać i tworzyć profile dla Twoich przyjaciół i rodziny.';
+  String get trainFamilyProfilesDesc => 'Twoje nagrania pomagają nam rozpoznawać i tworzyć profile dla Twoich przyjaciół i rodziny.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Zwiększ dokładność transkrypcji';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'W miarę jak nasz model się poprawia, możemy zapewnić lepsze wyniki transkrypcji Twoich nagrań.';
+  String get enhanceTranscriptAccuracyDesc => 'W miarę jak nasz model się poprawia, możemy zapewnić lepsze wyniki transkrypcji Twoich nagrań.';
 
   @override
-  String get legalNotice =>
-      'Uwaga prawna: Legalność nagrywania i przechowywania danych głosowych może się różnić w zależności od lokalizacji i sposobu korzystania z tej funkcji. Twoim obowiązkiem jest zapewnienie zgodności z lokalnymi przepisami i regulacjami.';
+  String get legalNotice => 'Uwaga prawna: Legalność nagrywania i przechowywania danych głosowych może się różnić w zależności od lokalizacji i sposobu korzystania z tej funkcji. Twoim obowiązkiem jest zapewnienie zgodności z lokalnymi przepisami i regulacjami.';
 
   @override
   String get alreadyAuthorized => 'Już autoryzowano';
@@ -1188,8 +1167,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get showEventsNoParticipants => 'Pokaż wydarzenia bez uczestników';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Po włączeniu, Nadchodzące pokazuje wydarzenia bez uczestników lub linku wideo.';
+  String get showEventsNoParticipantsDesc => 'Po włączeniu, Nadchodzące pokazuje wydarzenia bez uczestników lub linku wideo.';
 
   @override
   String get yourMeetings => 'Twoje spotkania';
@@ -1274,12 +1252,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Podaj nam swój język podstawowy';
 
   @override
-  String get languageForTranscription =>
-      'Ustaw swój język dla ostrzejszych transkrypcji i spersonalizowanego doświadczenia.';
+  String get languageForTranscription => 'Ustaw swój język dla ostrzejszych transkrypcji i spersonalizowanego doświadczenia.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Tryb pojedynczego języka jest włączony. Tłumaczenie jest wyłączone dla większej dokładności.';
+  String get singleLanguageModeInfo => 'Tryb pojedynczego języka jest włączony. Tłumaczenie jest wyłączone dla większej dokładności.';
 
   @override
   String get searchLanguageHint => 'Szukaj języka według nazwy lub kodu';
@@ -1359,8 +1335,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get defaultRepository => 'Domyślne repozytorium';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Wybierz domyślne repozytorium do tworzenia problemów. Nadal możesz określić inne repozytorium podczas tworzenia problemów.';
+  String get selectDefaultRepoDesc => 'Wybierz domyślne repozytorium do tworzenia problemów. Nadal możesz określić inne repozytorium podczas tworzenia problemów.';
 
   @override
   String get noReposFound => 'Nie znaleziono repozytoriów';
@@ -1736,8 +1711,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get enableBluetooth => 'Włącz Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi potrzebuje Bluetooth, aby połączyć się z Twoim urządzeniem noszonym. Włącz Bluetooth i spróbuj ponownie.';
+  String get bluetoothNeeded => 'Omi potrzebuje Bluetooth, aby połączyć się z Twoim urządzeniem noszonym. Włącz Bluetooth i spróbuj ponownie.';
 
   @override
   String get contactSupport => 'Skontaktuj się z pomocą techniczną?';
@@ -1770,26 +1744,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get locationServiceDisabled => 'Usługa lokalizacji wyłączona';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Usługa lokalizacji jest wyłączona. Przejdź do Ustawienia > Prywatność i bezpieczeństwo > Usługi lokalizacji i włącz ją';
+  String get locationServiceDisabledDesc => 'Usługa lokalizacji jest wyłączona. Przejdź do Ustawienia > Prywatność i bezpieczeństwo > Usługi lokalizacji i włącz ją';
 
   @override
   String get backgroundLocationDenied => 'Odmowa dostępu do lokalizacji w tle';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Przejdź do ustawień urządzenia i ustaw uprawnienie lokalizacji na \"Zawsze zezwalaj\"';
+  String get backgroundLocationDeniedDesc => 'Przejdź do ustawień urządzenia i ustaw uprawnienie lokalizacji na \"Zawsze zezwalaj\"';
 
   @override
   String get lovingOmi => 'Podoba Ci się Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Pomóż nam dotrzeć do większej liczby osób, zostawiając recenzję w App Store. Twoja opinia wiele dla nas znaczy!';
+  String get leaveReviewIos => 'Pomóż nam dotrzeć do większej liczby osób, zostawiając recenzję w App Store. Twoja opinia wiele dla nas znaczy!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Pomóż nam dotrzeć do większej liczby osób, zostawiając recenzję w Google Play Store. Twoja opinia wiele dla nas znaczy!';
+  String get leaveReviewAndroid => 'Pomóż nam dotrzeć do większej liczby osób, zostawiając recenzję w Google Play Store. Twoja opinia wiele dla nas znaczy!';
 
   @override
   String get rateOnAppStore => 'Oceń w App Store';
@@ -1822,15 +1792,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get connectionError => 'Błąd połączenia';
 
   @override
-  String get connectionErrorDesc =>
-      'Nie udało się połączyć z serwerem. Sprawdź połączenie internetowe i spróbuj ponownie.';
+  String get connectionErrorDesc => 'Nie udało się połączyć z serwerem. Sprawdź połączenie internetowe i spróbuj ponownie.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Wykryto nieprawidłowe nagranie';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Wygląda na to, że w nagraniu jest wielu mówców. Upewnij się, że jesteś w cichym miejscu i spróbuj ponownie.';
+  String get multipleSpeakersDesc => 'Wygląda na to, że w nagraniu jest wielu mówców. Upewnij się, że jesteś w cichym miejscu i spróbuj ponownie.';
 
   @override
   String get tooShortDesc => 'Nie wykryto wystarczającej ilości mowy. Mów więcej i spróbuj ponownie.';
@@ -1842,8 +1810,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get areYouThere => 'Jesteś tam?';
 
   @override
-  String get noSpeechDesc =>
-      'Nie udało się wykryć żadnej mowy. Upewnij się, że mówisz przez co najmniej 10 sekund i nie więcej niż 3 minuty.';
+  String get noSpeechDesc => 'Nie udało się wykryć żadnej mowy. Upewnij się, że mówisz przez co najmniej 10 sekund i nie więcej niż 3 minuty.';
 
   @override
   String get connectionLost => 'Utracono połączenie';
@@ -1864,8 +1831,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get permissionsRequired => 'Wymagane uprawnienia';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Ta aplikacja wymaga uprawnień Bluetooth i lokalizacji, aby działać prawidłowo. Włącz je w ustawieniach.';
+  String get permissionsRequiredDesc => 'Ta aplikacja wymaga uprawnień Bluetooth i lokalizacji, aby działać prawidłowo. Włącz je w ustawieniach.';
 
   @override
   String get openSettings => 'Otwórz ustawienia';
@@ -1895,8 +1861,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Twój kompan AI';
 
   @override
-  String get captureEveryMoment =>
-      'Uchwycaj każdą chwilę. Otrzymuj podsumowania\nnapędzane przez AI. Nigdy więcej nie rób notatek.';
+  String get captureEveryMoment => 'Uchwycaj każdą chwilę. Otrzymuj podsumowania\nnapędzane przez AI. Nigdy więcej nie rób notatek.';
 
   @override
   String get appleWatchSetup => 'Konfiguracja Apple Watch';
@@ -1908,12 +1873,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get microphonePermission => 'Uprawnienie mikrofonu';
 
   @override
-  String get permissionGrantedNow =>
-      'Uprawnienie przyznane! Teraz:\n\nOtwórz aplikację Omi na zegarku i dotknij \"Kontynuuj\" poniżej';
+  String get permissionGrantedNow => 'Uprawnienie przyznane! Teraz:\n\nOtwórz aplikację Omi na zegarku i dotknij \"Kontynuuj\" poniżej';
 
   @override
-  String get needMicrophonePermission =>
-      'Potrzebujemy uprawnienia do mikrofonu.\n\n1. Dotknij \"Przyznaj uprawnienie\"\n2. Zezwól na iPhone\n3. Aplikacja na zegarku zostanie zamknięta\n4. Otwórz ponownie i dotknij \"Kontynuuj\"';
+  String get needMicrophonePermission => 'Potrzebujemy uprawnienia do mikrofonu.\n\n1. Dotknij \"Przyznaj uprawnienie\"\n2. Zezwól na iPhone\n3. Aplikacja na zegarku zostanie zamknięta\n4. Otwórz ponownie i dotknij \"Kontynuuj\"';
 
   @override
   String get grantPermissionButton => 'Przyznaj uprawnienie';
@@ -1922,15 +1885,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get needHelp => 'Potrzebujesz pomocy?';
 
   @override
-  String get troubleshootingSteps =>
-      'Rozwiązywanie problemów:\n\n1. Upewnij się, że Omi jest zainstalowane na Twoim zegarku\n2. Otwórz aplikację Omi na zegarku\n3. Poszukaj okna z prośbą o uprawnienie\n4. Dotknij \"Zezwól\" po wyświetleniu monitu\n5. Aplikacja na zegarku zostanie zamknięta - otwórz ją ponownie\n6. Wróć i dotknij \"Kontynuuj\" na iPhone';
+  String get troubleshootingSteps => 'Rozwiązywanie problemów:\n\n1. Upewnij się, że Omi jest zainstalowane na Twoim zegarku\n2. Otwórz aplikację Omi na zegarku\n3. Poszukaj okna z prośbą o uprawnienie\n4. Dotknij \"Zezwól\" po wyświetleniu monitu\n5. Aplikacja na zegarku zostanie zamknięta - otwórz ją ponownie\n6. Wróć i dotknij \"Kontynuuj\" na iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Nagrywanie rozpoczęte pomyślnie!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Uprawnienie nie zostało jeszcze przyznane. Upewnij się, że zezwoliłeś na dostęp do mikrofonu i ponownie otworzyłeś aplikację na zegarku.';
+  String get permissionNotGrantedYet => 'Uprawnienie nie zostało jeszcze przyznane. Upewnij się, że zezwoliłeś na dostęp do mikrofonu i ponownie otworzyłeś aplikację na zegarku.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2027,8 +1988,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Gotowe na zadania';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Twoje AI automatycznie wyodrębni zadania z Twoich rozmów. Pojawią się tutaj, gdy zostaną utworzone.';
+  String get welcomeActionItemsDescription => 'Twoje AI automatycznie wyodrębni zadania z Twoich rozmów. Pojawią się tutaj, gdy zostaną utworzone.';
 
   @override
   String get autoExtractionFeature => 'Automatycznie wyodrębniane z rozmów';
@@ -2224,15 +2184,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'MOWA I TRANSKRYPCJA';
 
   @override
-  String get languageSettingsHelperText =>
-      'Język aplikacji zmienia menu i przyciski. Język mowy wpływa na sposób transkrypcji nagrań.';
+  String get languageSettingsHelperText => 'Język aplikacji zmienia menu i przyciski. Język mowy wpływa na sposób transkrypcji nagrań.';
 
   @override
   String get translationNotice => 'Powiadomienie o tłumaczeniu';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi tłumaczy rozmowy na Twój główny język. Zaktualizuj to w dowolnym momencie w Ustawienia → Profile.';
+  String get translationNoticeMessage => 'Omi tłumaczy rozmowy na Twój główny język. Zaktualizuj to w dowolnym momencie w Ustawienia → Profile.';
 
   @override
   String get pleaseCheckInternetConnection => 'Sprawdź połączenie internetowe i spróbuj ponownie';
@@ -2387,8 +2345,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Rozłącz urządzenie';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'To rozłączy urządzenie, aby mogło zostać połączone z innym telefonem. Będziesz musiał przejść do Ustawienia > Bluetooth i zapomnieć urządzenie, aby zakończyć proces.';
+  String get unpairDeviceDialogMessage => 'To rozłączy urządzenie, aby mogło zostać połączone z innym telefonem. Będziesz musiał przejść do Ustawienia > Bluetooth i zapomnieć urządzenie, aby zakończyć proces.';
 
   @override
   String get unpair => 'Rozłącz';
@@ -2569,8 +2526,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get youreAllSet => 'Gotowe!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Witamy w Omi! Twój towarzysz AI jest gotowy, aby pomóc ci w rozmowach, zadaniach i nie tylko.';
+  String get welcomeToOmiDescription => 'Witamy w Omi! Twój towarzysz AI jest gotowy, aby pomóc ci w rozmowach, zadaniach i nie tylko.';
 
   @override
   String get startUsingOmi => 'Zacznij korzystać z Omi';
@@ -2649,8 +2605,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get reviewAndManageConversations => 'Przeglądaj i zarządzaj zapisanymi rozmowami';
 
   @override
-  String get startCapturingConversations =>
-      'Zacznij przechwytywać rozmowy za pomocą urządzenia Omi, aby je tutaj zobaczyć.';
+  String get startCapturingConversations => 'Zacznij przechwytywać rozmowy za pomocą urządzenia Omi, aby je tutaj zobaczyć.';
 
   @override
   String get useMobileAppToCapture => 'Użyj aplikacji mobilnej, aby nagrać dźwięk';
@@ -2707,8 +2662,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get noTasksYet => 'Jeszcze nie ma zadań';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Zadania z Twoich rozmów pojawią się tutaj.\nKliknij Utwórz, aby dodać jedno ręcznie.';
+  String get tasksFromConversationsWillAppear => 'Zadania z Twoich rozmów pojawią się tutaj.\nKliknij Utwórz, aby dodać jedno ręcznie.';
 
   @override
   String get monthJan => 'Sty';
@@ -2840,15 +2794,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get chatPrompt => 'Podpowiedź czatu';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Jesteś wspaniałą aplikacją, Twoim zadaniem jest odpowiadanie na zapytania użytkowników i sprawianie, by czuli się dobrze...';
+  String get chatPromptPlaceholder => 'Jesteś wspaniałą aplikacją, Twoim zadaniem jest odpowiadanie na zapytania użytkowników i sprawianie, by czuli się dobrze...';
 
   @override
   String get conversationPrompt => 'Podpowiedź konwersacji';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Jesteś wspaniałą aplikacją, otrzymasz transkrypcję i podsumowanie rozmowy...';
+  String get conversationPromptPlaceholder => 'Jesteś wspaniałą aplikacją, otrzymasz transkrypcję i podsumowanie rozmowy...';
 
   @override
   String get notificationScopes => 'Zakresy powiadomień';
@@ -2860,8 +2812,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get makeMyAppPublic => 'Upublicznij moją aplikację';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Przesyłając tę aplikację, akceptuję Warunki korzystania z usługi i Politykę prywatności Omi AI';
+  String get submitAppTermsAgreement => 'Przesyłając tę aplikację, akceptuję Warunki korzystania z usługi i Politykę prywatności Omi AI';
 
   @override
   String get submitApp => 'Prześlij aplikację';
@@ -2870,19 +2821,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get needHelpGettingStarted => 'Potrzebujesz pomocy na start?';
 
   @override
-  String get clickHereForAppBuildingGuides =>
-      'Kliknij tutaj, aby uzyskać przewodniki tworzenia aplikacji i dokumentację';
+  String get clickHereForAppBuildingGuides => 'Kliknij tutaj, aby uzyskać przewodniki tworzenia aplikacji i dokumentację';
 
   @override
   String get submitAppQuestion => 'Przesłać aplikację?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Twoja aplikacja zostanie sprawdzona i upubliczniona. Możesz zacząć z niej korzystać natychmiast, nawet podczas sprawdzania!';
+  String get submitAppPublicDescription => 'Twoja aplikacja zostanie sprawdzona i upubliczniona. Możesz zacząć z niej korzystać natychmiast, nawet podczas sprawdzania!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Twoja aplikacja zostanie sprawdzona i udostępniona Tobie prywatnie. Możesz zacząć z niej korzystać natychmiast, nawet podczas sprawdzania!';
+  String get submitAppPrivateDescription => 'Twoja aplikacja zostanie sprawdzona i udostępniona Tobie prywatnie. Możesz zacząć z niej korzystać natychmiast, nawet podczas sprawdzania!';
 
   @override
   String get startEarning => 'Zacznij zarabiać! 💰';
@@ -2906,23 +2854,19 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dataAccessNotice => 'Powiadomienie o dostępie do danych';
 
   @override
-  String get dataAccessWarning =>
-      'Ta aplikacja będzie miała dostęp do Twoich danych. Omi AI nie ponosi odpowiedzialności za sposób, w jaki Twoje dane są wykorzystywane, modyfikowane lub usuwane przez tę aplikację';
+  String get dataAccessWarning => 'Ta aplikacja będzie miała dostęp do Twoich danych. Omi AI nie ponosi odpowiedzialności za sposób, w jaki Twoje dane są wykorzystywane, modyfikowane lub usuwane przez tę aplikację';
 
   @override
   String get installApp => 'Zainstaluj aplikację';
 
   @override
-  String get betaTesterNotice =>
-      'Jesteś testerem beta tej aplikacji. Nie jest jeszcze publiczna. Stanie się publiczna po zatwierdzeniu.';
+  String get betaTesterNotice => 'Jesteś testerem beta tej aplikacji. Nie jest jeszcze publiczna. Stanie się publiczna po zatwierdzeniu.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Twoja aplikacja jest w trakcie przeglądu i widoczna tylko dla Ciebie. Stanie się publiczna po zatwierdzeniu.';
+  String get appUnderReviewOwner => 'Twoja aplikacja jest w trakcie przeglądu i widoczna tylko dla Ciebie. Stanie się publiczna po zatwierdzeniu.';
 
   @override
-  String get appRejectedNotice =>
-      'Twoja aplikacja została odrzucona. Zaktualizuj szczegóły aplikacji i prześlij ją ponownie do przeglądu.';
+  String get appRejectedNotice => 'Twoja aplikacja została odrzucona. Zaktualizuj szczegóły aplikacji i prześlij ją ponownie do przeglądu.';
 
   @override
   String get setupSteps => 'Kroki konfiguracji';
@@ -2957,8 +2901,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get errorActivatingApp => 'Błąd aktywacji aplikacji';
 
   @override
-  String get integrationSetupRequired =>
-      'Jeśli to aplikacja integracyjna, upewnij się, że konfiguracja jest zakończona.';
+  String get integrationSetupRequired => 'Jeśli to aplikacja integracyjna, upewnij się, że konfiguracja jest zakończona.';
 
   @override
   String get installed => 'Zainstalowano';
@@ -2985,8 +2928,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get descriptionLabel => 'Opis';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Moja wspaniała aplikacja to świetna aplikacja, która robi niesamowite rzeczy. To najlepsza aplikacja!';
+  String get appDescriptionPlaceholder => 'Moja wspaniała aplikacja to świetna aplikacja, która robi niesamowite rzeczy. To najlepsza aplikacja!';
 
   @override
   String get pleaseProvideValidDescription => 'Proszę podać prawidłowy opis';
@@ -3138,8 +3080,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get microphonePermissionRequired => 'Wymagane jest uprawnienie mikrofonu do nagrywania głosu.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Uprawnienie mikrofonu odrzucone. Przyznaj uprawnienie w Preferencje systemowe > Prywatność i bezpieczeństwo > Mikrofon.';
+  String get microphonePermissionDenied => 'Uprawnienie mikrofonu odrzucone. Przyznaj uprawnienie w Preferencje systemowe > Prywatność i bezpieczeństwo > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3372,8 +3313,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get whatWeCollect => 'Co zbieramy';
 
   @override
-  String get dataCollectionMessage =>
-      'Kontynuując, twoje rozmowy, nagrania i informacje osobiste będą bezpiecznie przechowywane na naszych serwerach, aby zapewnić wgląd napędzany AI i włączyć wszystkie funkcje aplikacji.';
+  String get dataCollectionMessage => 'Kontynuując, twoje rozmowy, nagrania i informacje osobiste będą bezpiecznie przechowywane na naszych serwerach, aby zapewnić wgląd napędzany AI i włączyć wszystkie funkcje aplikacji.';
 
   @override
   String get dataProtection => 'Ochrona danych';
@@ -3406,8 +3346,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Imię musi mieć co najmniej 2 znaki';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Powiedz nam, jak chciałbyś być zwracany. To pomaga spersonalizować Twoje doświadczenie Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Powiedz nam, jak chciałbyś być zwracany. To pomaga spersonalizować Twoje doświadczenie Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3424,8 +3363,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get recordAudioConversations => 'Nagrywaj rozmowy audio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi potrzebuje dostępu do mikrofonu, aby nagrywać rozmowy i dostarczać transkrypcje.';
+  String get microphoneAccessDescription => 'Omi potrzebuje dostępu do mikrofonu, aby nagrywać rozmowy i dostarczać transkrypcje.';
 
   @override
   String get screenRecording => 'Nagrywanie ekranu';
@@ -3434,8 +3372,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Przechwytuj dźwięk systemowy ze spotkań';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi potrzebuje uprawnień do nagrywania ekranu, aby przechwytywać dźwięk systemowy z twoich spotkań opartych na przeglądarce.';
+  String get screenRecordingDescription => 'Omi potrzebuje uprawnień do nagrywania ekranu, aby przechwytywać dźwięk systemowy z twoich spotkań opartych na przeglądarce.';
 
   @override
   String get accessibility => 'Dostępność';
@@ -3444,8 +3381,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Wykrywaj spotkania oparte na przeglądarce';
 
   @override
-  String get accessibilityDescription =>
-      'Omi potrzebuje uprawnień dostępności, aby wykrywać, kiedy dołączasz do spotkań Zoom, Meet lub Teams w przeglądarce.';
+  String get accessibilityDescription => 'Omi potrzebuje uprawnień dostępności, aby wykrywać, kiedy dołączasz do spotkań Zoom, Meet lub Teams w przeglądarce.';
 
   @override
   String get pleaseWait => 'Proszę czekać...';
@@ -3517,8 +3453,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get conversationsExportStarted => 'Rozpoczęto eksport rozmów. To może potrwać kilka sekund, proszę czekać.';
 
   @override
-  String get mcpDescription =>
-      'Aby połączyć Omi z innymi aplikacjami w celu odczytu, wyszukiwania i zarządzania wspomnieniami i rozmowami. Utwórz klucz, aby rozpocząć.';
+  String get mcpDescription => 'Aby połączyć Omi z innymi aplikacjami w celu odczytu, wyszukiwania i zarządzania wspomnieniami i rozmowami. Utwórz klucz, aby rozpocząć.';
 
   @override
   String get apiKeys => 'Klucze API';
@@ -3589,8 +3524,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get auto => 'Automatycznie';
 
   @override
-  String get noSummaryForApp =>
-      'Brak podsumowania dla tej aplikacji. Wypróbuj inną aplikację, aby uzyskać lepsze wyniki.';
+  String get noSummaryForApp => 'Brak podsumowania dla tej aplikacji. Wypróbuj inną aplikację, aby uzyskać lepsze wyniki.';
 
   @override
   String get tryAnotherApp => 'Wypróbuj inną aplikację';
@@ -3627,8 +3561,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Pozwól Omi automatycznie wybrać najlepszą aplikację';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Czy na pewno chcesz usunąć tę rozmowę? Ta operacja nie może zostać cofnięta.';
+  String get deleteConversationConfirmation => 'Czy na pewno chcesz usunąć tę rozmowę? Ta operacja nie może zostać cofnięta.';
 
   @override
   String get conversationDeleted => 'Rozmowa usunięta';
@@ -3676,8 +3609,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Przygotowywanie przechwytywania dźwięku systemu';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Kliknij przycisk, aby przechwycić dźwięk do transkrypcji na żywo, informacji AI i automatycznego zapisywania.';
+  String get clickTheButtonToCaptureAudio => 'Kliknij przycisk, aby przechwycić dźwięk do transkrypcji na żywo, informacji AI i automatycznego zapisywania.';
 
   @override
   String get reconnecting => 'Ponowne łączenie...';
@@ -3904,8 +3836,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Usunąć graf wiedzy?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Spowoduje to usunięcie wszystkich pochodnych danych grafu wiedzy. Twoje oryginalne wspomnienia pozostaną bezpieczne.';
+  String get deleteKnowledgeGraphWarning => 'Spowoduje to usunięcie wszystkich pochodnych danych grafu wiedzy. Twoje oryginalne wspomnienia pozostaną bezpieczne.';
 
   @override
   String get connectOmiWithAI => 'Połącz Omi z asystentami AI';
@@ -3962,8 +3893,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get updateAppQuestion => 'Zaktualizować aplikację?';
 
   @override
-  String get updateAppConfirmation =>
-      'Czy na pewno chcesz zaktualizować aplikację? Zmiany zostaną wprowadzone po sprawdzeniu przez nasz zespół.';
+  String get updateAppConfirmation => 'Czy na pewno chcesz zaktualizować aplikację? Zmiany zostaną wprowadzone po sprawdzeniu przez nasz zespół.';
 
   @override
   String get updateApp => 'Zaktualizuj aplikację';
@@ -3993,8 +3923,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get no => 'Nie';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Subskrypcja anulowana pomyślnie. Pozostanie aktywna do końca bieżącego okresu rozliczeniowego.';
+  String get subscriptionCancelledSuccessfully => 'Subskrypcja anulowana pomyślnie. Pozostanie aktywna do końca bieżącego okresu rozliczeniowego.';
 
   @override
   String get failedToCancelSubscription => 'Nie udało się anulować subskrypcji. Spróbuj ponownie.';
@@ -4030,8 +3959,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Anulować subskrypcję?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Czy na pewno chcesz anulować subskrypcję? Będziesz mieć dostęp do końca bieżącego okresu rozliczeniowego.';
+  String get cancelSubscriptionConfirmation => 'Czy na pewno chcesz anulować subskrypcję? Będziesz mieć dostęp do końca bieżącego okresu rozliczeniowego.';
 
   @override
   String get cancelSubscriptionButton => 'Anuluj subskrypcję';
@@ -4040,12 +3968,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get cancelling => 'Anulowanie...';
 
   @override
-  String get betaTesterMessage =>
-      'Jesteś beta testerem tej aplikacji. Nie jest jeszcze publiczna. Będzie publiczna po zatwierdzeniu.';
+  String get betaTesterMessage => 'Jesteś beta testerem tej aplikacji. Nie jest jeszcze publiczna. Będzie publiczna po zatwierdzeniu.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Twoja aplikacja jest w trakcie weryfikacji i widoczna tylko dla Ciebie. Będzie publiczna po zatwierdzeniu.';
+  String get appUnderReviewMessage => 'Twoja aplikacja jest w trakcie weryfikacji i widoczna tylko dla Ciebie. Będzie publiczna po zatwierdzeniu.';
 
   @override
   String get appRejectedMessage => 'Twoja aplikacja została odrzucona. Zaktualizuj szczegóły i prześlij ponownie.';
@@ -4102,8 +4028,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get issueActivatingApp => 'Wystąpił problem z aktywacją tej aplikacji. Spróbuj ponownie.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'This app will access your data. Omi AI is not responsible for how your data is used, modified, or deleted by this app';
+  String get dataAccessNoticeDescription => 'This app will access your data. Omi AI is not responsible for how your data is used, modified, or deleted by this app';
 
   @override
   String get copyUrl => 'Kopiuj URL';
@@ -4191,8 +4116,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get omiApiKeys => 'Klucze API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Klucze API są używane do uwierzytelniania, gdy aplikacja komunikuje się z serwerem OMI. Umożliwiają aplikacji tworzenie wspomnień i bezpieczny dostęp do innych usług OMI.';
+  String get apiKeysDescription => 'Klucze API są używane do uwierzytelniania, gdy aplikacja komunikuje się z serwerem OMI. Umożliwiają aplikacji tworzenie wspomnień i bezpieczny dostęp do innych usług OMI.';
 
   @override
   String get aboutOmiApiKeys => 'O kluczach API Omi';
@@ -4216,8 +4140,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Unieważnić klucz API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Tej akcji nie można cofnąć. Aplikacje używające tego klucza nie będą już mogły uzyskać dostępu do API.';
+  String get revokeApiKeyWarning => 'Tej akcji nie można cofnąć. Aplikacje używające tego klucza nie będą już mogły uzyskać dostępu do API.';
 
   @override
   String get revoke => 'Unieważnij';
@@ -4306,8 +4229,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get keyCreated => 'Klucz utworzony';
 
   @override
-  String get keyCreatedMessage =>
-      'Twój nowy klucz został utworzony. Skopiuj go teraz. Nie będziesz mógł go ponownie zobaczyć.';
+  String get keyCreatedMessage => 'Twój nowy klucz został utworzony. Skopiuj go teraz. Nie będziesz mógł go ponownie zobaczyć.';
 
   @override
   String get keyWord => 'Klucz';
@@ -4316,8 +4238,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get externalAppAccess => 'Dostęp aplikacji zewnętrznych';
 
   @override
-  String get externalAppAccessDescription =>
-      'Następujące zainstalowane aplikacje mają zewnętrzne integracje i mogą uzyskać dostęp do twoich danych, takich jak rozmowy i wspomnienia.';
+  String get externalAppAccessDescription => 'Następujące zainstalowane aplikacje mają zewnętrzne integracje i mogą uzyskać dostęp do twoich danych, takich jak rozmowy i wspomnienia.';
 
   @override
   String get noExternalAppsHaveAccess => 'Żadne zewnętrzne aplikacje nie mają dostępu do twoich danych.';
@@ -4326,15 +4247,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksymalne bezpieczeństwo (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Szyfrowanie end-to-end to złoty standard prywatności. Po włączeniu dane są szyfrowane na urządzeniu przed wysłaniem na nasze serwery. Oznacza to, że nikt, nawet Omi, nie może uzyskać dostępu do Twoich treści.';
+  String get e2eeDescription => 'Szyfrowanie end-to-end to złoty standard prywatności. Po włączeniu dane są szyfrowane na urządzeniu przed wysłaniem na nasze serwery. Oznacza to, że nikt, nawet Omi, nie może uzyskać dostępu do Twoich treści.';
 
   @override
   String get importantTradeoffs => 'Ważne kompromisy:';
 
   @override
-  String get e2eeTradeoff1 =>
-      '• Niektóre funkcje, takie jak integracje z zewnętrznymi aplikacjami, mogą być wyłączone.';
+  String get e2eeTradeoff1 => '• Niektóre funkcje, takie jak integracje z zewnętrznymi aplikacjami, mogą być wyłączone.';
 
   @override
   String get e2eeTradeoff2 => '• Jeśli zgubisz hasło, Twoje dane nie mogą zostać odzyskane.';
@@ -4343,8 +4262,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get featureComingSoon => 'Ta funkcja wkrótce będzie dostępna!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migracja w toku. Nie możesz zmienić poziomu ochrony, dopóki się nie zakończy.';
+  String get migrationInProgressMessage => 'Migracja w toku. Nie możesz zmienić poziomu ochrony, dopóki się nie zakończy.';
 
   @override
   String get migrationFailed => 'Migracja nie powiodła się';
@@ -4363,19 +4281,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get secureEncryption => 'Bezpieczne szyfrowanie';
 
   @override
-  String get secureEncryptionDescription =>
-      'Twoje dane są szyfrowane kluczem unikalnym dla Ciebie na naszych serwerach hostowanych w Google Cloud. Oznacza to, że Twoje surowe treści są niedostępne dla nikogo, w tym pracowników Omi lub Google, bezpośrednio z bazy danych.';
+  String get secureEncryptionDescription => 'Twoje dane są szyfrowane kluczem unikalnym dla Ciebie na naszych serwerach hostowanych w Google Cloud. Oznacza to, że Twoje surowe treści są niedostępne dla nikogo, w tym pracowników Omi lub Google, bezpośrednio z bazy danych.';
 
   @override
   String get endToEndEncryption => 'Szyfrowanie end-to-end';
 
   @override
-  String get e2eeCardDescription =>
-      'Włącz dla maksymalnego bezpieczeństwa, gdzie tylko Ty masz dostęp do swoich danych. Dotknij, aby dowiedzieć się więcej.';
+  String get e2eeCardDescription => 'Włącz dla maksymalnego bezpieczeństwa, gdzie tylko Ty masz dostęp do swoich danych. Dotknij, aby dowiedzieć się więcej.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Niezależnie od poziomu, Twoje dane są zawsze szyfrowane w stanie spoczynku i podczas przesyłania.';
+  String get dataAlwaysEncrypted => 'Niezależnie od poziomu, Twoje dane są zawsze szyfrowane w stanie spoczynku i podczas przesyłania.';
 
   @override
   String get readOnlyScope => 'Tylko odczyt';
@@ -4443,8 +4358,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Uzyskaj Omi Unlimited za darmo, przekazując swoje dane do trenowania modeli AI.';
 
   @override
-  String get trainingDataBullets =>
-      '• Twoje dane pomagają ulepszać modele AI\n• Udostępniane są tylko dane niewrażliwe\n• W pełni przejrzysty proces';
+  String get trainingDataBullets => '• Twoje dane pomagają ulepszać modele AI\n• Udostępniane są tylko dane niewrażliwe\n• W pełni przejrzysty proces';
 
   @override
   String get learnMoreAtOmiTraining => 'Dowiedz się więcej na omi.me/training';
@@ -4456,8 +4370,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get submitRequest => 'Wyślij prośbę';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Dziękujemy! Twoja prośba jest rozpatrywana. Powiadomimy Cię po zatwierdzeniu.';
+  String get thankYouRequestUnderReview => 'Dziękujemy! Twoja prośba jest rozpatrywana. Powiadomimy Cię po zatwierdzeniu.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4495,12 +4408,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get monthlyPlanContinues => 'Twój obecny plan miesięczny będzie kontynuowany do końca okresu rozliczeniowego';
 
   @override
-  String get paymentMethodCharged =>
-      'Twoja istniejąca metoda płatności zostanie automatycznie obciążona po zakończeniu planu miesięcznego';
+  String get paymentMethodCharged => 'Twoja istniejąca metoda płatności zostanie automatycznie obciążona po zakończeniu planu miesięcznego';
 
   @override
-  String get annualSubscriptionStarts =>
-      'Twoja 12-miesięczna subskrypcja roczna rozpocznie się automatycznie po obciążeniu';
+  String get annualSubscriptionStarts => 'Twoja 12-miesięczna subskrypcja roczna rozpocznie się automatycznie po obciążeniu';
 
   @override
   String get thirteenMonthsCoverage => 'Otrzymasz łącznie 13 miesięcy ochrony (bieżący miesiąc + 12 miesięcy rocznie)';
@@ -4540,8 +4451,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Twój plan roczny rozpocznie się automatycznie po zakończeniu planu miesięcznego.';
+  String get annualPlanStartsAutomatically => 'Twój plan roczny rozpocznie się automatycznie po zakończeniu planu miesięcznego.';
 
   @override
   String planRenewsOn(String date) {
@@ -4608,8 +4518,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Twoja prywatność jest dla nas ważna';
 
   @override
-  String get privacyIntroText =>
-      'W Omi bardzo poważnie traktujemy Twoją prywatność. Chcemy być przejrzyści w kwestii danych, które zbieramy i jak je wykorzystujemy. Oto co musisz wiedzieć:';
+  String get privacyIntroText => 'W Omi bardzo poważnie traktujemy Twoją prywatność. Chcemy być przejrzyści w kwestii danych, które zbieramy i jak je wykorzystujemy. Oto co musisz wiedzieć:';
 
   @override
   String get whatWeTrack => 'Co śledzimy';
@@ -4624,12 +4533,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get ourCommitment => 'Nasze zobowiązanie';
 
   @override
-  String get commitmentText =>
-      'Zobowiązujemy się wykorzystywać zebrane dane tylko po to, aby Omi był lepszym produktem dla Ciebie. Twoja prywatność i zaufanie są dla nas najważniejsze.';
+  String get commitmentText => 'Zobowiązujemy się wykorzystywać zebrane dane tylko po to, aby Omi był lepszym produktem dla Ciebie. Twoja prywatność i zaufanie są dla nas najważniejsze.';
 
   @override
-  String get thankYouText =>
-      'Dziękujemy za bycie cenionym użytkownikiem Omi. Jeśli masz jakiekolwiek pytania lub wątpliwości, skontaktuj się z nami pod adresem team@basedhardware.com.';
+  String get thankYouText => 'Dziękujemy za bycie cenionym użytkownikiem Omi. Jeśli masz jakiekolwiek pytania lub wątpliwości, skontaktuj się z nami pod adresem team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Ustawienia synchronizacji WiFi';
@@ -4638,8 +4545,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get enterHotspotCredentials => 'Wprowadź dane hotspotu telefonu';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'Synchronizacja WiFi używa telefonu jako hotspota. Znajdź nazwę i hasło w Ustawienia > Hotspot osobisty.';
+  String get wifiSyncUsesHotspot => 'Synchronizacja WiFi używa telefonu jako hotspota. Znajdź nazwę i hasło w Ustawienia > Hotspot osobisty.';
 
   @override
   String get hotspotNameSsid => 'Nazwa hotspota (SSID)';
@@ -4674,8 +4580,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nie udało się wygenerować podsumowania. Upewnij się, że masz rozmowy z tego dnia.';
+  String get failedToGenerateSummaryCheckConversations => 'Nie udało się wygenerować podsumowania. Upewnij się, że masz rozmowy z tego dnia.';
 
   @override
   String get summaryNotFound => 'Nie znaleziono podsumowania';
@@ -4705,8 +4610,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Eksport rozpoczęty. Może to zająć kilka sekund...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'To usunie wszystkie pochodne dane grafu wiedzy (węzły i połączenia). Twoje oryginalne wspomnienia pozostaną bezpieczne. Graf zostanie odbudowany z czasem lub przy następnym żądaniu.';
+  String get knowledgeGraphDeleteDescription => 'To usunie wszystkie pochodne dane grafu wiedzy (węzły i połączenia). Twoje oryginalne wspomnienia pozostaną bezpieczne. Graf zostanie odbudowany z czasem lub przy następnym żądaniu.';
 
   @override
   String get configureDailySummaryDigest => 'Skonfiguruj dzienny przegląd zadań';
@@ -4776,8 +4680,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Usunąć wszystkie rozmowy Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Spowoduje to trwałe usunięcie wszystkich rozmów zaimportowanych z Limitless. Tej akcji nie można cofnąć.';
+  String get deleteAllLimitlessWarning => 'Spowoduje to trwałe usunięcie wszystkich rozmów zaimportowanych z Limitless. Tej akcji nie można cofnąć.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4833,8 +4736,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get howItWorksTitle => 'Jak to działa?';
 
   @override
-  String get howPeopleWorks =>
-      'Po utworzeniu osoby możesz przejść do transkrypcji rozmowy i przypisać im odpowiednie segmenty, w ten sposób Omi będzie mógł rozpoznać również ich mowę!';
+  String get howPeopleWorks => 'Po utworzeniu osoby możesz przejść do transkrypcji rozmowy i przypisać im odpowiednie segmenty, w ten sposób Omi będzie mógł rozpoznać również ich mowę!';
 
   @override
   String get tapToDelete => 'Dotknij, aby usunąć';
@@ -4860,8 +4762,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get privacyNotice => 'Informacja o prywatności';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Nagrania mogą przechwytywać głosy innych osób. Przed włączeniem upewnij się, że masz zgodę wszystkich uczestników.';
+  String get recordingsMayCaptureOthers => 'Nagrania mogą przechwytywać głosy innych osób. Przed włączeniem upewnij się, że masz zgodę wszystkich uczestników.';
 
   @override
   String get enable => 'Włącz';
@@ -4873,8 +4774,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get on => 'Włącz';
 
   @override
-  String get storeAudioDescription =>
-      'Przechowuj wszystkie nagrania audio lokalnie na telefonie. Po wyłączeniu tylko nieudane przesyłania są zachowywane, aby zaoszczędzić miejsce.';
+  String get storeAudioDescription => 'Przechowuj wszystkie nagrania audio lokalnie na telefonie. Po wyłączeniu tylko nieudane przesyłania są zachowywane, aby zaoszczędzić miejsce.';
 
   @override
   String get enableLocalStorage => 'Włącz pamięć lokalną';
@@ -4892,12 +4792,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get storeAudioOnCloud => 'Store Audio on Cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Twoje nagrania w czasie rzeczywistym będą przechowywane w prywatnej chmurze podczas mówienia.';
+  String get cloudStorageDialogMessage => 'Twoje nagrania w czasie rzeczywistym będą przechowywane w prywatnej chmurze podczas mówienia.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Przechowuj nagrania w czasie rzeczywistym w prywatnej chmurze podczas mówienia. Dźwięk jest przechwytywany i bezpiecznie zapisywany w czasie rzeczywistym.';
+  String get storeAudioCloudDescription => 'Przechowuj nagrania w czasie rzeczywistym w prywatnej chmurze podczas mówienia. Dźwięk jest przechwytywany i bezpiecznie zapisywany w czasie rzeczywistym.';
 
   @override
   String get downloadingFirmware => 'Pobieranie oprogramowania';
@@ -4906,8 +4804,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get installingFirmware => 'Instalowanie oprogramowania';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Nie zamykaj aplikacji ani nie wyłączaj urządzenia. Może to uszkodzić urządzenie.';
+  String get firmwareUpdateWarning => 'Nie zamykaj aplikacji ani nie wyłączaj urządzenia. Może to uszkodzić urządzenie.';
 
   @override
   String get firmwareUpdated => 'Oprogramowanie zaktualizowane';
@@ -4951,8 +4848,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get payments => 'Płatności';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Połącz metodę płatności poniżej, aby zacząć otrzymywać wypłaty za swoje aplikacje.';
+  String get connectPaymentMethodInfo => 'Połącz metodę płatności poniżej, aby zacząć otrzymywać wypłaty za swoje aplikacje.';
 
   @override
   String get selectedPaymentMethod => 'Wybrana metoda płatności';
@@ -4979,8 +4875,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get monthlyPayouts => 'Miesięczne wypłaty';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Otrzymuj miesięczne płatności bezpośrednio na konto, gdy osiągniesz 10 \$ zarobków';
+  String get monthlyPayoutsDescription => 'Otrzymuj miesięczne płatności bezpośrednio na konto, gdy osiągniesz 10 \$ zarobków';
 
   @override
   String get secureAndReliable => 'Bezpieczne i niezawodne';
@@ -5007,8 +4902,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get connectingYourStripeAccount => 'Łączenie konta Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Proszę ukończyć proces rejestracji Stripe w przeglądarce. Ta strona zostanie automatycznie zaktualizowana po zakończeniu.';
+  String get stripeOnboardingInstructions => 'Proszę ukończyć proces rejestracji Stripe w przeglądarce. Ta strona zostanie automatycznie zaktualizowana po zakończeniu.';
 
   @override
   String get failedTryAgain => 'Nie udało się? Spróbuj ponownie';
@@ -5020,8 +4914,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get successfullyConnected => 'Pomyślnie połączono!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Twoje konto Stripe jest teraz gotowe do przyjmowania płatności. Możesz od razu zacząć zarabiać na sprzedaży aplikacji.';
+  String get stripeReadyForPayments => 'Twoje konto Stripe jest teraz gotowe do przyjmowania płatności. Możesz od razu zacząć zarabiać na sprzedaży aplikacji.';
 
   @override
   String get updateStripeDetails => 'Zaktualizuj dane Stripe';
@@ -5039,8 +4932,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Zaktualizuj dane swojego konta PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Połącz swoje konto PayPal, aby zacząć otrzymywać płatności za swoje aplikacje';
+  String get connectPayPalToReceivePayments => 'Połącz swoje konto PayPal, aby zacząć otrzymywać płatności za swoje aplikacje';
 
   @override
   String get paypalEmail => 'E-mail PayPal';
@@ -5049,8 +4941,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get paypalMeLink => 'Link PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Jeśli Stripe jest dostępny w Twoim kraju, zdecydowanie zalecamy korzystanie z niego dla szybszych i łatwiejszych wypłat.';
+  String get stripeRecommendation => 'Jeśli Stripe jest dostępny w Twoim kraju, zdecydowanie zalecamy korzystanie z niego dla szybszych i łatwiejszych wypłat.';
 
   @override
   String get updatePayPalDetails => 'Zaktualizuj dane PayPal';
@@ -5102,8 +4993,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Dodatkowa próbka głosowa usunięta';
 
   @override
-  String get consentDataMessage =>
-      'Kontynuując, Twoje rozmowy, nagrania i dane osobowe będą bezpiecznie przechowywane na naszych serwerach. Twoje nagrania audio i transkrypcje są przetwarzane przez zewnętrzne usługi AI (w tym Deepgram do transkrypcji i OpenAI do analizy), aby dostarczyć Ci wglądy oparte na AI i umożliwić wszystkie funkcje aplikacji.';
+  String get consentDataMessage => 'Kontynuując, Twoje rozmowy, nagrania i dane osobowe będą bezpiecznie przechowywane na naszych serwerach. Twoje nagrania audio i transkrypcje są przetwarzane przez zewnętrzne usługi AI (w tym Deepgram do transkrypcji i OpenAI do analizy), aby dostarczyć Ci wglądy oparte na AI i umożliwić wszystkie funkcje aplikacji.';
 
   @override
   String get tasksEmptyStateMessage => 'Zadania z twoich rozmów pojawią się tutaj.\nDotknij +, aby utworzyć ręcznie.';
@@ -5142,15 +5032,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Zainstaluj Omi na\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Aby używać Apple Watch z Omi, musisz najpierw zainstalować aplikację Omi na zegarku.';
+  String get installOmiOnAppleWatchDescription => 'Aby używać Apple Watch z Omi, musisz najpierw zainstalować aplikację Omi na zegarku.';
 
   @override
   String get openOmiOnAppleWatch => 'Otwórz Omi na\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Aplikacja Omi jest zainstalowana na Apple Watch. Otwórz ją i dotknij Start, aby rozpocząć.';
+  String get openOmiOnAppleWatchDescription => 'Aplikacja Omi jest zainstalowana na Apple Watch. Otwórz ją i dotknij Start, aby rozpocząć.';
 
   @override
   String get openWatchApp => 'Otwórz aplikację Watch';
@@ -5159,15 +5047,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Zainstalowałem i otworzyłem aplikację';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Nie można otworzyć aplikacji Apple Watch. Ręcznie otwórz aplikację Watch na Apple Watch i zainstaluj Omi z sekcji \"Dostępne aplikacje\".';
+  String get unableToOpenWatchApp => 'Nie można otworzyć aplikacji Apple Watch. Ręcznie otwórz aplikację Watch na Apple Watch i zainstaluj Omi z sekcji \"Dostępne aplikacje\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch połączony pomyślnie!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch nadal nieosiągalny. Upewnij się, że aplikacja Omi jest otwarta na zegarku.';
+  String get appleWatchNotReachable => 'Apple Watch nadal nieosiągalny. Upewnij się, że aplikacja Omi jest otwarta na zegarku.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5595,29 +5481,25 @@ class AppLocalizationsPl extends AppLocalizations {
   String get multipleSpeakersDetected => 'Wykryto wielu mówców';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Wygląda na to, że w nagraniu jest wielu mówców. Upewnij się, że jesteś w cichym miejscu i spróbuj ponownie.';
+  String get multipleSpeakersDescription => 'Wygląda na to, że w nagraniu jest wielu mówców. Upewnij się, że jesteś w cichym miejscu i spróbuj ponownie.';
 
   @override
   String get invalidRecordingDetected => 'Wykryto nieprawidłowe nagranie';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Nie wykryto wystarczającej ilości mowy. Proszę mówić więcej i spróbować ponownie.';
+  String get notEnoughSpeechDescription => 'Nie wykryto wystarczającej ilości mowy. Proszę mówić więcej i spróbować ponownie.';
 
   @override
   String get speechDurationDescription => 'Upewnij się, że mówisz co najmniej 5 sekund i nie więcej niż 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Połączenie zostało przerwane. Sprawdź połączenie internetowe i spróbuj ponownie.';
+  String get connectionLostDescription => 'Połączenie zostało przerwane. Sprawdź połączenie internetowe i spróbuj ponownie.';
 
   @override
   String get howToTakeGoodSample => 'Jak zrobić dobrą próbkę?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Upewnij się, że jesteś w cichym miejscu.\n2. Mów wyraźnie i naturalnie.\n3. Upewnij się, że urządzenie jest w naturalnej pozycji na szyi.\n\nPo utworzeniu zawsze możesz je ulepszyć lub zrobić ponownie.';
+  String get goodSampleInstructions => '1. Upewnij się, że jesteś w cichym miejscu.\n2. Mów wyraźnie i naturalnie.\n3. Upewnij się, że urządzenie jest w naturalnej pozycji na szyi.\n\nPo utworzeniu zawsze możesz je ulepszyć lub zrobić ponownie.';
 
   @override
   String get noDeviceConnectedUseMic => 'Brak podłączonego urządzenia. Zostanie użyty mikrofon telefonu.';
@@ -5680,12 +5562,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get howItWorks => 'Jak to działa';
 
   @override
-  String get dailyScoreExplanation =>
-      'Twój dzienny wynik opiera się na ukończeniu zadań. Ukończ zadania, aby poprawić wynik!';
+  String get dailyScoreExplanation => 'Twój dzienny wynik opiera się na ukończeniu zadań. Ukończ zadania, aby poprawić wynik!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontroluj, jak często Omi wysyła Ci proaktywne powiadomienia i przypomnienia.';
+  String get notificationFrequencyDescription => 'Kontroluj, jak często Omi wysyła Ci proaktywne powiadomienia i przypomnienia.';
 
   @override
   String get sliderOff => 'Wył.';
@@ -5699,8 +5579,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Nie udało się wygenerować podsumowania. Upewnij się, że masz rozmowy z tego dnia.';
+  String get failedToGenerateSummary => 'Nie udało się wygenerować podsumowania. Upewnij się, że masz rozmowy z tego dnia.';
 
   @override
   String get recap => 'Podsumowanie';
@@ -6060,15 +5939,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get cloudProvider => 'Dostawca chmury';
 
   @override
-  String get premiumMinutesInfo =>
-      '1200 minut premium/miesiąc. Zakładka Na urządzeniu oferuje nieograniczoną darmową transkrypcję.';
+  String get premiumMinutesInfo => '1200 minut premium/miesiąc. Zakładka Na urządzeniu oferuje nieograniczoną darmową transkrypcję.';
 
   @override
   String get viewUsage => 'Zobacz wykorzystanie';
 
   @override
-  String get localProcessingInfo =>
-      'Dźwięk jest przetwarzany lokalnie. Działa offline, większa prywatność, ale zużywa więcej baterii.';
+  String get localProcessingInfo => 'Dźwięk jest przetwarzany lokalnie. Działa offline, większa prywatność, ale zużywa więcej baterii.';
 
   @override
   String get model => 'Model';
@@ -6077,15 +5954,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get performanceWarning => 'Ostrzeżenie o wydajności';
 
   @override
-  String get largeModelWarning =>
-      'Ten model jest duży i może powodować awarie aplikacji lub działać bardzo wolno na urządzeniach mobilnych.';
+  String get largeModelWarning => 'Ten model jest duży i może powodować awarie aplikacji lub działać bardzo wolno na urządzeniach mobilnych.';
 
   @override
   String get usingNativeIosSpeech => 'Używanie natywnego rozpoznawania mowy iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Zostanie użyty natywny silnik mowy urządzenia. Pobieranie modelu nie jest wymagane.';
+  String get noModelDownloadRequired => 'Zostanie użyty natywny silnik mowy urządzenia. Pobieranie modelu nie jest wymagane.';
 
   @override
   String get modelReady => 'Model gotowy';
@@ -6142,12 +6017,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get batteryDrainSignificantly => 'Rozładowywanie baterii znacznie wzrośnie.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 minut premium/miesiąc. Karta Na urządzeniu oferuje nieograniczoną bezpłatną transkrypcję. ';
+  String get premiumMinutesMonth => '1200 minut premium/miesiąc. Karta Na urządzeniu oferuje nieograniczoną bezpłatną transkrypcję. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Dźwięk jest przetwarzany lokalnie. Działa offline, bardziej prywatnie, ale zużywa więcej baterii.';
+  String get audioProcessedLocally => 'Dźwięk jest przetwarzany lokalnie. Działa offline, bardziej prywatnie, ale zużywa więcej baterii.';
 
   @override
   String get languageLabel => 'Język';
@@ -6156,12 +6029,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Ten model jest duży i może spowodować awarię aplikacji lub bardzo wolne działanie na urządzeniach mobilnych.\n\nZalecane jest small lub base.';
+  String get modelTooLargeWarning => 'Ten model jest duży i może spowodować awarię aplikacji lub bardzo wolne działanie na urządzeniach mobilnych.\n\nZalecane jest small lub base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Zostanie użyty natywny silnik mowy Twojego urządzenia. Pobieranie modelu nie jest wymagane.';
+  String get nativeEngineNoDownload => 'Zostanie użyty natywny silnik mowy Twojego urządzenia. Pobieranie modelu nie jest wymagane.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6197,8 +6068,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Wbudowana transkrypcja na żywo Omi jest zoptymalizowana dla rozmów w czasie rzeczywistym z automatycznym wykrywaniem mówców i diaryzacją.';
+  String get omiTranscriptionOptimized => 'Wbudowana transkrypcja na żywo Omi jest zoptymalizowana dla rozmów w czasie rzeczywistym z automatycznym wykrywaniem mówców i diaryzacją.';
 
   @override
   String get reset => 'Resetuj';
@@ -6418,8 +6288,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Tworzenie grafu wiedzy ze wspomnień...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Graf wiedzy zostanie utworzony automatycznie podczas tworzenia nowych wspomnień.';
+  String get knowledgeGraphWillBuildAutomatically => 'Graf wiedzy zostanie utworzony automatycznie podczas tworzenia nowych wspomnień.';
 
   @override
   String get buildGraphButton => 'Utwórz graf';
@@ -6655,8 +6524,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get failedToLoadContacts => 'Nie udało się załadować kontaktów';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Nie udało się przygotować rozmowy do udostępnienia. Spróbuj ponownie.';
+  String get failedToPrepareConversationForSharing => 'Nie udało się przygotować rozmowy do udostępnienia. Spróbuj ponownie.';
 
   @override
   String get couldNotOpenSmsApp => 'Nie można otworzyć aplikacji SMS. Spróbuj ponownie.';
@@ -6722,8 +6590,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Pobieranie dźwięku z karty SD urządzenia';
 
   @override
-  String get transferRequiredDescription =>
-      'To nagranie jest przechowywane na karcie SD urządzenia. Prześlij je na telefon, aby odtworzyć lub udostępnić.';
+  String get transferRequiredDescription => 'To nagranie jest przechowywane na karcie SD urządzenia. Prześlij je na telefon, aby odtworzyć lub udostępnić.';
 
   @override
   String get cancelTransfer => 'Anuluj transfer';
@@ -6744,8 +6611,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shareRecording => 'Udostępnij nagranie';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Czy na pewno chcesz trwale usunąć to nagranie? Tej operacji nie można cofnąć.';
+  String get deleteRecordingConfirmation => 'Czy na pewno chcesz trwale usunąć to nagranie? Tej operacji nie można cofnąć.';
 
   @override
   String get recordingIdLabel => 'ID nagrania';
@@ -6804,8 +6670,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get enableFastTransfer => 'Włącz szybki transfer';
 
   @override
-  String get fastTransferDescription =>
-      'Szybki transfer używa WiFi dla ~5x szybszych prędkości. Twój telefon tymczasowo połączy się z siecią WiFi urządzenia Omi podczas transferu.';
+  String get fastTransferDescription => 'Szybki transfer używa WiFi dla ~5x szybszych prędkości. Twój telefon tymczasowo połączy się z siecią WiFi urządzenia Omi podczas transferu.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Dostęp do internetu jest wstrzymany podczas transferu';
@@ -6820,8 +6685,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fiveTimesFaster => '5X SZYBCIEJ';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Tworzy bezpośrednie połączenie WiFi z urządzeniem Omi. Telefon tymczasowo rozłącza się z normalnym WiFi podczas transferu.';
+  String get fastTransferMethodDescription => 'Tworzy bezpośrednie połączenie WiFi z urządzeniem Omi. Telefon tymczasowo rozłącza się z normalnym WiFi podczas transferu.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6830,8 +6694,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get bleSpeed => '~30 KB/s przez BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Używa standardowego połączenia Bluetooth Low Energy. Wolniejsze, ale nie wpływa na połączenie WiFi.';
+  String get bluetoothMethodDescription => 'Używa standardowego połączenia Bluetooth Low Energy. Wolniejsze, ale nie wpływa na połączenie WiFi.';
 
   @override
   String get selected => 'Wybrano';
@@ -6869,12 +6732,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get appDeleteFailed => 'Nie udało się usunąć aplikacji. Spróbuj ponownie później.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Widoczność aplikacji została zmieniona pomyślnie. Może to potrwać kilka minut.';
+  String get appVisibilityChangedSuccessfully => 'Widoczność aplikacji została zmieniona pomyślnie. Może to potrwać kilka minut.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Błąd podczas aktywacji aplikacji. Jeśli to aplikacja integracyjna, upewnij się, że konfiguracja jest zakończona.';
+  String get errorActivatingAppIntegration => 'Błąd podczas aktywacji aplikacji. Jeśli to aplikacja integracyjna, upewnij się, że konfiguracja jest zakończona.';
 
   @override
   String get errorUpdatingAppStatus => 'Wystąpił błąd podczas aktualizacji statusu aplikacji.';
@@ -7141,15 +7002,13 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Ulepszenie zaplanowane! Twój plan miesięczny będzie kontynuowany do końca okresu rozliczeniowego, a następnie automatycznie przełączy się na roczny.';
+  String get planUpgradeScheduledMessage => 'Ulepszenie zaplanowane! Twój plan miesięczny będzie kontynuowany do końca okresu rozliczeniowego, a następnie automatycznie przełączy się na roczny.';
 
   @override
   String get couldNotSchedulePlanChange => 'Nie udało się zaplanować zmiany planu. Spróbuj ponownie.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Twoja subskrypcja została reaktywowana! Bez opłat teraz - zostaniesz obciążony na koniec bieżącego okresu.';
+  String get subscriptionReactivatedDefault => 'Twoja subskrypcja została reaktywowana! Bez opłat teraz - zostaniesz obciążony na koniec bieżącego okresu.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Subskrypcja udana! Zostałeś obciążony za nowy okres rozliczeniowy.';
@@ -7332,8 +7191,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Uprawnienie Bluetooth jest wymagane do połączenia z urządzeniem.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Uprawnienie Bluetooth odrzucone. Przyznaj uprawnienie w Preferencjach systemowych.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Uprawnienie Bluetooth odrzucone. Przyznaj uprawnienie w Preferencjach systemowych.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7346,12 +7204,10 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Uprawnienie powiadomień odrzucone. Przyznaj uprawnienie w Preferencjach systemowych.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Uprawnienie powiadomień odrzucone. Przyznaj uprawnienie w Preferencjach systemowych.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Uprawnienie powiadomień odrzucone. Przyznaj uprawnienie w Preferencje systemowe > Powiadomienia.';
+  String get onboardingNotificationDeniedNotifications => 'Uprawnienie powiadomień odrzucone. Przyznaj uprawnienie w Preferencje systemowe > Powiadomienia.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7364,15 +7220,13 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Przyznaj uprawnienie lokalizacji w Ustawienia > Prywatność i bezpieczeństwo > Usługi lokalizacyjne';
+  String get onboardingLocationGrantInSettings => 'Przyznaj uprawnienie lokalizacji w Ustawienia > Prywatność i bezpieczeństwo > Usługi lokalizacyjne';
 
   @override
   String get onboardingMicrophoneRequired => 'Uprawnienie mikrofonu jest wymagane do nagrywania.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Uprawnienie mikrofonu odrzucone. Przyznaj uprawnienie w Preferencje systemowe > Prywatność i bezpieczeństwo > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Uprawnienie mikrofonu odrzucone. Przyznaj uprawnienie w Preferencje systemowe > Prywatność i bezpieczeństwo > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7385,12 +7239,10 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Uprawnienie przechwytywania ekranu jest wymagane do nagrywania dźwięku systemowego.';
+  String get onboardingScreenCaptureRequired => 'Uprawnienie przechwytywania ekranu jest wymagane do nagrywania dźwięku systemowego.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Uprawnienie przechwytywania ekranu odrzucone. Przyznaj uprawnienie w Preferencje systemowe > Prywatność i bezpieczeństwo > Nagrywanie ekranu.';
+  String get onboardingScreenCaptureDenied => 'Uprawnienie przechwytywania ekranu odrzucone. Przyznaj uprawnienie w Preferencje systemowe > Prywatność i bezpieczeństwo > Nagrywanie ekranu.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7403,8 +7255,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Uprawnienie dostępności jest wymagane do wykrywania spotkań przeglądarki.';
+  String get onboardingAccessibilityRequired => 'Uprawnienie dostępności jest wymagane do wykrywania spotkań przeglądarki.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7444,8 +7295,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Odmowa dostępu do zdjęć. Proszę zezwolić na dostęp do zdjęć, aby wybrać obrazy';
+  String get msgPhotosPermissionDenied => 'Odmowa dostępu do zdjęć. Proszę zezwolić na dostęp do zdjęć, aby wybrać obrazy';
 
   @override
   String get msgSelectImagesGenericError => 'Błąd podczas wybierania obrazów. Spróbuj ponownie.';
@@ -7487,8 +7337,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Wymagane pozwolenie na mikrofon';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Udziel pozwolenia na mikrofon w Preferencjach systemowych';
+  String get captureMicrophonePermissionInSystemPreferences => 'Udziel pozwolenia na mikrofon w Preferencjach systemowych';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Wymagane pozwolenie na nagrywanie ekranu';
@@ -7500,8 +7349,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get devModeInvalidAudioBytesWebhookUrl => 'Nieprawidłowy URL webhooka bajtów audio';
 
   @override
-  String get devModeInvalidRealtimeTranscriptWebhookUrl =>
-      'Nieprawidłowy URL webhooka transkrypcji w czasie rzeczywistym';
+  String get devModeInvalidRealtimeTranscriptWebhookUrl => 'Nieprawidłowy URL webhooka transkrypcji w czasie rzeczywistym';
 
   @override
   String get devModeInvalidConversationCreatedWebhookUrl => 'Nieprawidłowy URL webhooka utworzonej konwersacji';
@@ -7519,8 +7367,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get locationPermissionRequired => 'Potrzebne uprawnienie do lokalizacji';
 
   @override
-  String get locationPermissionContent =>
-      'Szybki transfer wymaga uprawnienia do lokalizacji, aby zweryfikować połączenie WiFi. Proszę przyznać uprawnienie do lokalizacji, aby kontynuować.';
+  String get locationPermissionContent => 'Szybki transfer wymaga uprawnienia do lokalizacji, aby zweryfikować połączenie WiFi. Proszę przyznać uprawnienie do lokalizacji, aby kontynuować.';
 
   @override
   String get pdfTranscriptExport => 'Eksport transkrypcji';
@@ -7683,8 +7530,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Urządzenie nie obsługuje synchronizacji WiFi, przełączanie na Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Urządzenie nie obsługuje synchronizacji WiFi, przełączanie na Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health nie jest dostępne na tym urządzeniu';
@@ -7980,8 +7826,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Przełącz Omi DevKit w tryb parowania';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Naciśnij przycisk raz, aby włączyć. LED będzie migać na fioletowo w trybie parowania.';
+  String get pairingDescOmiDevkit => 'Naciśnij przycisk raz, aby włączyć. LED będzie migać na fioletowo w trybie parowania.';
 
   @override
   String get pairingTitleOmiGlass => 'Włącz Omi Glass';
@@ -7993,8 +7838,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Przełącz Plaud Note w tryb parowania';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Naciśnij i przytrzymaj boczny przycisk przez 2 sekundy. Czerwona dioda LED zacznie migać, gdy będzie gotowy do parowania.';
+  String get pairingDescPlaudNote => 'Naciśnij i przytrzymaj boczny przycisk przez 2 sekundy. Czerwona dioda LED zacznie migać, gdy będzie gotowy do parowania.';
 
   @override
   String get pairingTitleBee => 'Przełącz Bee w tryb parowania';
@@ -8006,15 +7850,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get pairingTitleLimitless => 'Przełącz Limitless w tryb parowania';
 
   @override
-  String get pairingDescLimitless =>
-      'Gdy świeci się jakakolwiek kontrolka, naciśnij raz, a następnie naciśnij i przytrzymaj, aż urządzenie pokaże różowe światło, następnie puść.';
+  String get pairingDescLimitless => 'Gdy świeci się jakakolwiek kontrolka, naciśnij raz, a następnie naciśnij i przytrzymaj, aż urządzenie pokaże różowe światło, następnie puść.';
 
   @override
   String get pairingTitleFriendPendant => 'Przełącz Friend Pendant w tryb parowania';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Naciśnij przycisk na wisiorku, aby go włączyć. Automatycznie przejdzie w tryb parowania.';
+  String get pairingDescFriendPendant => 'Naciśnij przycisk na wisiorku, aby go włączyć. Automatycznie przejdzie w tryb parowania.';
 
   @override
   String get pairingTitleFieldy => 'Przełącz Fieldy w tryb parowania';
@@ -8026,15 +7868,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Połącz Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Zainstaluj i otwórz aplikację Omi na swoim Apple Watch, a następnie dotknij Połącz w aplikacji.';
+  String get pairingDescAppleWatch => 'Zainstaluj i otwórz aplikację Omi na swoim Apple Watch, a następnie dotknij Połącz w aplikacji.';
 
   @override
   String get pairingTitleNeoOne => 'Przełącz Neo One w tryb parowania';
 
   @override
-  String get pairingDescNeoOne =>
-      'Naciśnij i przytrzymaj przycisk zasilania, aż dioda LED zacznie migać. Urządzenie będzie wykrywalne.';
+  String get pairingDescNeoOne => 'Naciśnij i przytrzymaj przycisk zasilania, aż dioda LED zacznie migać. Urządzenie będzie wykrywalne.';
 
   @override
   String get downloadingFromDevice => 'Pobieranie z urządzenia';
@@ -8151,8 +7991,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get switchAndRestart => 'Przełącz';
 
   @override
-  String get stagingDisclaimer =>
-      'Środowisko testowe może być niestabilne, mieć niespójną wydajność, a dane mogą zostać utracone. Tylko do testów.';
+  String get stagingDisclaimer => 'Środowisko testowe może być niestabilne, mieć niespójną wydajność, a dane mogą zostać utracone. Tylko do testów.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Zapisano. Zamknij i ponownie otwórz aplikację, aby zastosować zmiany.';
@@ -8381,8 +8220,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Połączenia telefoniczne przez Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Dzwoń przez Omi i otrzymuj transkrypcję w czasie rzeczywistym, automatyczne podsumowania i wiele więcej.';
+  String get phoneCallsUpsellSubtitle => 'Dzwoń przez Omi i otrzymuj transkrypcję w czasie rzeczywistym, automatyczne podsumowania i wiele więcej.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transkrypcja w czasie rzeczywistym każdego połączenia';
@@ -8409,8 +8247,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteSyncedFiles => 'Usuń zsynchronizowane nagrania';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Te nagrania zostały już zsynchronizowane z telefonem. Tej operacji nie można cofnąć.';
+  String get deleteSyncedFilesMessage => 'Te nagrania zostały już zsynchronizowane z telefonem. Tej operacji nie można cofnąć.';
 
   @override
   String get syncedFilesDeleted => 'Zsynchronizowane nagrania usunięte';
@@ -8422,8 +8259,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deletePendingFiles => 'Usuń oczekujące nagrania';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Te nagrania NIE zostały zsynchronizowane z telefonem i zostaną trwale utracone. Tej operacji nie można cofnąć.';
+  String get deletePendingFilesWarning => 'Te nagrania NIE zostały zsynchronizowane z telefonem i zostaną trwale utracone. Tej operacji nie można cofnąć.';
 
   @override
   String get pendingFilesDeleted => 'Oczekujące nagrania usunięte';
@@ -8435,8 +8271,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteAll => 'Usuń wszystko';
 
   @override
-  String get deleteAllFilesWarning =>
-      'To usunie zsynchronizowane i oczekujące nagrania. Oczekujące nagrania NIE zostały zsynchronizowane i zostaną trwale utracone.';
+  String get deleteAllFilesWarning => 'To usunie zsynchronizowane i oczekujące nagrania. Oczekujące nagrania NIE zostały zsynchronizowane i zostaną trwale utracone.';
 
   @override
   String get allFilesDeleted => 'Wszystkie nagrania usunięte';
@@ -8501,8 +8336,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fairUseAboutTitle => 'O uczciwym korzystaniu';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi jest zaprojektowany do osobistych rozmów, spotkań i interakcji na żywo. Użytkowanie mierzone jest na podstawie wykrytego rzeczywistego czasu mowy, a nie czasu połączenia. Jeśli użytkowanie znacząco przekracza normalne wzorce dla treści nieosobistych, mogą zostać zastosowane korekty.';
+  String get fairUseAboutBody => 'Omi jest zaprojektowany do osobistych rozmów, spotkań i interakcji na żywo. Użytkowanie mierzone jest na podstawie wykrytego rzeczywistego czasu mowy, a nie czasu połączenia. Jeśli użytkowanie znacząco przekracza normalne wzorce dla treści nieosobistych, mogą zostać zastosowane korekty.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8540,8 +8374,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get improveConnectionTitle => 'Popraw połączenie';
 
   @override
-  String get improveConnectionContent =>
-      'Poprawiliśmy sposób, w jaki Omi utrzymuje połączenie z Twoim urządzeniem. Aby to aktywować, przejdź na stronę Informacje o urządzeniu, dotknij \"Odłącz urządzenie\" i ponownie sparuj urządzenie.';
+  String get improveConnectionContent => 'Poprawiliśmy sposób, w jaki Omi utrzymuje połączenie z Twoim urządzeniem. Aby to aktywować, przejdź na stronę Informacje o urządzeniu, dotknij \"Odłącz urządzenie\" i ponownie sparuj urządzenie.';
 
   @override
   String get improveConnectionAction => 'Rozumiem';
@@ -8596,16 +8429,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get cancelSyncQuestion => 'Anulować synchronizację?';
 
   @override
-  String get omisStorageDesc =>
-      'Gdy Omi nie jest podłączony do telefonu, przechowuje dźwięk lokalnie we wbudowanej pamięci. Nigdy nie stracisz nagrania.';
+  String get omisStorageDesc => 'Gdy Omi nie jest podłączony do telefonu, przechowuje dźwięk lokalnie we wbudowanej pamięci. Nigdy nie stracisz nagrania.';
 
   @override
-  String get phoneStorageDesc =>
-      'Gdy Omi ponownie się połączy, nagrania są automatycznie przenoszone na telefon przed przesłaniem.';
+  String get phoneStorageDesc => 'Gdy Omi ponownie się połączy, nagrania są automatycznie przenoszone na telefon przed przesłaniem.';
 
   @override
-  String get cloudStorageDesc =>
-      'Po przesłaniu nagrania są przetwarzane i transkrybowane. Rozmowy będą dostępne w ciągu minuty.';
+  String get cloudStorageDesc => 'Po przesłaniu nagrania są przetwarzane i transkrybowane. Rozmowy będą dostępne w ciągu minuty.';
 
   @override
   String get tipKeepPhoneNearby => 'Trzymaj telefon blisko dla szybszej synchronizacji';
@@ -8629,12 +8459,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get permissionEnable => 'Włącz';
 
   @override
-  String get permissionsPageDescription =>
-      'Te uprawnienia są kluczowe dla działania Omi. Umożliwiają kluczowe funkcje, takie jak powiadomienia, doświadczenia oparte na lokalizacji i nagrywanie dźwięku.';
+  String get permissionsPageDescription => 'Te uprawnienia są kluczowe dla działania Omi. Umożliwiają kluczowe funkcje, takie jak powiadomienia, doświadczenia oparte na lokalizacji i nagrywanie dźwięku.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi potrzebuje kilku uprawnień, aby działać prawidłowo. Proszę, przyznaj je, aby kontynuować.';
+  String get permissionsRequiredDescription => 'Omi potrzebuje kilku uprawnień, aby działać prawidłowo. Proszę, przyznaj je, aby kontynuować.';
 
   @override
   String get permissionsSetupTitle => 'Uzyskaj najlepsze wrażenia';
@@ -8890,8 +8718,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get enableLocationTitle => 'Włącz lokalizację';
 
   @override
-  String get enableLocationDescription =>
-      'Uprawnienie do lokalizacji jest potrzebne, aby znaleźć pobliskie urządzenia Bluetooth.';
+  String get enableLocationDescription => 'Uprawnienie do lokalizacji jest potrzebne, aby znaleźć pobliskie urządzenia Bluetooth.';
 
   @override
   String get voiceRecordingFound => 'Znaleziono nagranie';
@@ -8912,8 +8739,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get firmwareWarningTitle => 'Ważne: Przeczytaj przed aktualizacją';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ten firmware sformatuje kartę SD. Upewnij się, że wszystkie dane offline są zsynchronizowane przed aktualizacją.\n\nJeśli po zainstalowaniu tej wersji zobaczysz migającą czerwoną diodę, nie martw się. Po prostu podłącz urządzenie do aplikacji, a powinno zmienić kolor na niebieski. Czerwona dioda oznacza, że zegar urządzenia nie został jeszcze zsynchronizowany.';
+  String get firmwareFormatWarning => 'Ten firmware sformatuje kartę SD. Upewnij się, że wszystkie dane offline są zsynchronizowane przed aktualizacją.\n\nJeśli po zainstalowaniu tej wersji zobaczysz migającą czerwoną diodę, nie martw się. Po prostu podłącz urządzenie do aplikacji, a powinno zmienić kolor na niebieski. Czerwona dioda oznacza, że zegar urządzenia nie został jeszcze zsynchronizowany.';
 
   @override
   String get continueAnyway => 'Kontynuuj';
@@ -8933,8 +8759,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get tasksMarkComplete => 'Oznaczono jako ukończone';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi uzyskuje dostęp do Apple Health za pośrednictwem frameworka HealthKit firmy Apple. Dostęp możesz cofnąć w dowolnym momencie w Ustawieniach iOS.';
+  String get appleHealthManageNote => 'Omi uzyskuje dostęp do Apple Health za pośrednictwem frameworka HealthKit firmy Apple. Dostęp możesz cofnąć w dowolnym momencie w Ustawieniach iOS.';
 
   @override
   String get appleHealthConnectCta => 'Połącz z Apple Health';
@@ -8955,8 +8780,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get appleHealthFeatureReadOnlyTitle => 'Dostęp tylko do odczytu';
 
   @override
-  String get appleHealthFeatureReadOnlyDesc =>
-      'Omi nigdy nie zapisuje w Apple Health ani nie modyfikuje Twoich danych.';
+  String get appleHealthFeatureReadOnlyDesc => 'Omi nigdy nie zapisuje w Apple Health ani nie modyfikuje Twoich danych.';
 
   @override
   String get appleHealthFeatureSecureTitle => 'Bezpieczna synchronizacja';
@@ -8968,8 +8792,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Odmowa dostępu do Apple Health';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi nie ma uprawnień do odczytu Twoich danych z Apple Health. Włącz to w Ustawienia iOS → Prywatność i bezpieczeństwo → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi nie ma uprawnień do odczytu Twoich danych z Apple Health. Włącz to w Ustawienia iOS → Prywatność i bezpieczeństwo → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Dlaczego odchodzisz?';
@@ -9038,8 +8861,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get planUpdate => 'Aktualizacja planu';
 
   @override
-  String get planDeprecationMessage =>
-      'Twój plan Unlimited jest wycofywany. Przejdź na plan Operator — te same świetne funkcje za \$49/mies. Twój obecny plan będzie nadal działać w międzyczasie.';
+  String get planDeprecationMessage => 'Twój plan Unlimited jest wycofywany. Przejdź na plan Operator — te same świetne funkcje za \$49/mies. Twój obecny plan będzie nadal działać w międzyczasie.';
 
   @override
   String get upgradeYourPlan => 'Ulepsz swój plan';
@@ -9150,8 +8972,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Osiągnąłeś miesięczny limit. Ulepsz, aby kontynuować czatowanie z Omi bez ograniczeń.';
+  String get chatQuotaExceededReply => 'Osiągnąłeś miesięczny limit. Ulepsz, aby kontynuować czatowanie z Omi bez ograniczeń.';
 
   @override
   String get voiceResponseAudio => 'Odczytaj odpowiedź Omi na głos';
@@ -9182,4 +9003,25 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Dodaj zadanie';
+
+  @override
+  String get quickActionAskOmiAnything => 'Zapytaj Omi o cokolwiek';
+
+  @override
+  String get quickActionVoiceMode => 'Tryb głosowy';
+
+  @override
+  String get quickActionMute => 'Wycisz';
+
+  @override
+  String get quickActionUnmute => 'Wyłącz wyciszenie';
+
+  @override
+  String get quickActionConnectDevice => 'Podłącz urządzenie';
+
+  @override
+  String get quickActionDeviceSettings => 'Ustawienia urządzenia';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -24,8 +24,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteConversationTitle => 'Apagar conversa?';
 
   @override
-  String get deleteConversationMessage =>
-      'Isso também excluirá as memórias, tarefas e arquivos de áudio associados. Esta ação não pode ser desfeita.';
+  String get deleteConversationMessage => 'Isso também excluirá as memórias, tarefas e arquivos de áudio associados. Esta ação não pode ser desfeita.';
 
   @override
   String get confirm => 'Confirmar';
@@ -146,8 +145,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleting => 'Apagando...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Por favor, complete a autenticação no seu navegador. Volte para o app quando terminar.';
+  String get pleaseCompleteAuthentication => 'Por favor, complete a autenticação no seu navegador. Volte para o app quando terminar.';
 
   @override
   String get failedToStartAuthentication => 'Falha ao iniciar autenticação';
@@ -355,19 +353,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appsDisconnected => 'Seus apps e integrações serão desconectados imediatamente.';
 
   @override
-  String get exportBeforeDelete =>
-      'Você pode exportar seus dados antes de apagar sua conta. Uma vez apagada, não pode ser recuperada.';
+  String get exportBeforeDelete => 'Você pode exportar seus dados antes de apagar sua conta. Uma vez apagada, não pode ser recuperada.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Entendo que apagar minha conta é permanente e todos os dados, incluindo memórias e conversas, serão perdidos para sempre.';
+  String get deleteAccountCheckbox => 'Entendo que apagar minha conta é permanente e todos os dados, incluindo memórias e conversas, serão perdidos para sempre.';
 
   @override
   String get areYouSure => 'Tem certeza?';
 
   @override
-  String get deleteAccountFinal =>
-      'Esta ação é irreversível e apagará permanentemente sua conta e todos os dados associados. Deseja continuar?';
+  String get deleteAccountFinal => 'Esta ação é irreversível e apagará permanentemente sua conta e todos os dados associados. Deseja continuar?';
 
   @override
   String get deleteNow => 'Apagar agora';
@@ -376,8 +371,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get goBack => 'Voltar';
 
   @override
-  String get checkBoxToConfirm =>
-      'Marque a caixa para confirmar que entende que apagar sua conta é permanente e irreversível.';
+  String get checkBoxToConfirm => 'Marque a caixa para confirmar que entende que apagar sua conta é permanente e irreversível.';
 
   @override
   String get profile => 'Perfil';
@@ -455,8 +449,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get yourPrivacyYourControl => 'Sua privacidade, seu controle';
 
   @override
-  String get privacyIntro =>
-      'No Omi, estamos comprometidos em proteger sua privacidade. Esta página permite que você controle como seus dados são salvos e usados.';
+  String get privacyIntro => 'No Omi, estamos comprometidos em proteger sua privacidade. Esta página permite que você controle como seus dados são salvos e usados.';
 
   @override
   String get learnMore => 'Saiba mais...';
@@ -528,15 +521,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Seu Omi desconectou 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Dispositivo desvinculado. Vá para Configurações > Bluetooth e esqueça o dispositivo para concluir a desvinculação.';
+  String get deviceUnpairedMessage => 'Dispositivo desvinculado. Vá para Configurações > Bluetooth e esqueça o dispositivo para concluir a desvinculação.';
 
   @override
   String get unpairDialogTitle => 'Desparear dispositivo';
 
   @override
-  String get unpairDialogMessage =>
-      'Isso despareará o dispositivo para que possa ser usado em outro telefone. Você deve ir em Configurações > Bluetooth e esquecer o dispositivo para concluir.';
+  String get unpairDialogMessage => 'Isso despareará o dispositivo para que possa ser usado em outro telefone. Você deve ir em Configurações > Bluetooth e esquecer o dispositivo para concluir.';
 
   @override
   String get deviceNotConnected => 'Dispositivo não conectado';
@@ -557,8 +548,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get v2Undetected => 'V2 não detectado';
 
   @override
-  String get v2UndetectedMessage =>
-      'Detectamos que você está usando um dispositivo V1 ou não está conectado. A funcionalidade de cartão SD é apenas para dispositivos V2.';
+  String get v2UndetectedMessage => 'Detectamos que você está usando um dispositivo V1 ou não está conectado. A funcionalidade de cartão SD é apenas para dispositivos V2.';
 
   @override
   String get endConversation => 'Terminar conversa';
@@ -752,8 +742,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get shareStatsMessage =>
-      'Compartilhando minhas estatísticas do Omi! (omi.me - meu assistente IA sempre ativo)';
+  String get shareStatsMessage => 'Compartilhando minhas estatísticas do Omi! (omi.me - meu assistente IA sempre ativo)';
 
   @override
   String get sharePeriodToday => 'Hoje Omi:';
@@ -833,8 +822,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Apagar Gráfico de Conhecimento?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Isso apagará todos os dados derivados do gráfico (nós e conexões). Suas memórias originais permanecem seguras.';
+  String get deleteKnowledgeGraphMessage => 'Isso apagará todos os dados derivados do gráfico (nós e conexões). Suas memórias originais permanecem seguras.';
 
   @override
   String get knowledgeGraphDeleted => 'Gráfico de conhecimento excluído';
@@ -1077,8 +1065,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get needYourPermission => 'Precisamos da sua permissão';
 
   @override
-  String get alreadyGavePermission =>
-      'Você já nos deu permissão para salvar suas gravações. Aqui está o lembrete do porquê:';
+  String get alreadyGavePermission => 'Você já nos deu permissão para salvar suas gravações. Aqui está o lembrete do porquê:';
 
   @override
   String get wouldLikePermission => 'Gostaríamos da sua permissão para salvar suas gravações de voz. Eis o motivo:';
@@ -1093,8 +1080,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trainFamilyProfiles => 'Treinar perfis de amigos e família';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Suas gravações ajudam a reconhecer e criar perfis para seus amigos e familiares.';
+  String get trainFamilyProfilesDesc => 'Suas gravações ajudam a reconhecer e criar perfis para seus amigos e familiares.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Melhorar precisão da transcrição';
@@ -1181,8 +1167,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showEventsNoParticipants => 'Mostrar eventos sem participantes';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Se ativado, \'Em breve\' mostrará eventos sem participantes ou link de vídeo.';
+  String get showEventsNoParticipantsDesc => 'Se ativado, \'Em breve\' mostrará eventos sem participantes ou link de vídeo.';
 
   @override
   String get yourMeetings => 'Suas reuniões';
@@ -1397,8 +1382,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get configureSettings => 'Configurar ajustes';
 
   @override
-  String get completeAuthBrowser =>
-      'Por favor, complete a autenticação no seu navegador. Quando terminar, volte para o app.';
+  String get completeAuthBrowser => 'Por favor, complete a autenticação no seu navegador. Quando terminar, volte para o app.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1780,8 +1764,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get maybeLater => 'Talvez depois';
 
   @override
-  String get speechProfileIntro =>
-      'O Omi precisa de aprender os seus objetivos e a sua voz. Poderá modificá-lo mais tarde.';
+  String get speechProfileIntro => 'O Omi precisa de aprender os seus objetivos e a sua voz. Poderá modificá-lo mais tarde.';
 
   @override
   String get getStarted => 'Começar';
@@ -2194,15 +2177,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'FALA E TRANSCRIÇÃO';
 
   @override
-  String get languageSettingsHelperText =>
-      'O idioma do aplicativo altera menus e botões. O idioma de fala afeta como suas gravações são transcritas.';
+  String get languageSettingsHelperText => 'O idioma do aplicativo altera menus e botões. O idioma de fala afeta como suas gravações são transcritas.';
 
   @override
   String get translationNotice => 'Aviso de tradução';
 
   @override
-  String get translationNoticeMessage =>
-      'O Omi traduz conversas para o seu idioma principal. Atualize-o a qualquer momento em Configurações → Perfis.';
+  String get translationNoticeMessage => 'O Omi traduz conversas para o seu idioma principal. Atualize-o a qualquer momento em Configurações → Perfis.';
 
   @override
   String get pleaseCheckInternetConnection => 'Verifique sua conexão com a Internet e tente novamente';
@@ -2222,8 +2203,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Esta conversa não pode ser mesclada (bloqueada ou já em processo de mesclagem)';
+  String get conversationCannotBeMerged => 'Esta conversa não pode ser mesclada (bloqueada ou já em processo de mesclagem)';
 
   @override
   String get pleaseEnterFolderName => 'Por favor, insira um nome de pasta';
@@ -2358,8 +2338,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Desvincular Dispositivo';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Isso desvinculará o dispositivo para que ele possa ser conectado a outro telefone. Você precisará ir para Configurações > Bluetooth e esquecer o dispositivo para concluir o processo.';
+  String get unpairDeviceDialogMessage => 'Isso desvinculará o dispositivo para que ele possa ser conectado a outro telefone. Você precisará ir para Configurações > Bluetooth e esquecer o dispositivo para concluir o processo.';
 
   @override
   String get unpair => 'Desvincular';
@@ -2525,8 +2504,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get howDoesItWork => 'Como funciona?';
 
   @override
-  String get sdCardSyncDescription =>
-      'A sincronização do cartão SD importará suas memórias do cartão SD para o aplicativo';
+  String get sdCardSyncDescription => 'A sincronização do cartão SD importará suas memórias do cartão SD para o aplicativo';
 
   @override
   String get checksForAudioFiles => 'Verifica arquivos de áudio no cartão SD';
@@ -2541,8 +2519,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get youreAllSet => 'Está tudo pronto!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Bem-vindo ao Omi! Seu companheiro de IA está pronto para ajudá-lo com conversas, tarefas e muito mais.';
+  String get welcomeToOmiDescription => 'Bem-vindo ao Omi! Seu companheiro de IA está pronto para ajudá-lo com conversas, tarefas e muito mais.';
 
   @override
   String get startUsingOmi => 'Começar a usar o Omi';
@@ -2678,8 +2655,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noTasksYet => 'Ainda não há tarefas';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'As tarefas de suas conversas aparecerão aqui.\nClique em Criar para adicionar uma manualmente.';
+  String get tasksFromConversationsWillAppear => 'As tarefas de suas conversas aparecerão aqui.\nClique em Criar para adicionar uma manualmente.';
 
   @override
   String get monthJan => 'Jan';
@@ -2736,8 +2712,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteActionItem => 'Excluir item de ação';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Tem certeza de que deseja excluir este item de ação? Esta ação não pode ser desfeita.';
+  String get deleteActionItemConfirmation => 'Tem certeza de que deseja excluir este item de ação? Esta ação não pode ser desfeita.';
 
   @override
   String get enterActionItemDescription => 'Digite a descrição do item de ação...';
@@ -2779,8 +2754,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get checkBackLaterForNewApps => 'Volte mais tarde para novos aplicativos';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'Por favor, verifique sua conexão com a internet e tente novamente';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'Por favor, verifique sua conexão com a internet e tente novamente';
 
   @override
   String get createNewApp => 'Criar Novo Aplicativo';
@@ -2813,15 +2787,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chatPrompt => 'Prompt de Chat';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Você é um aplicativo incrível, seu trabalho é responder às consultas dos usuários e fazê-los se sentirem bem...';
+  String get chatPromptPlaceholder => 'Você é um aplicativo incrível, seu trabalho é responder às consultas dos usuários e fazê-los se sentirem bem...';
 
   @override
   String get conversationPrompt => 'Prompt de conversa';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Você é um aplicativo incrível, você receberá uma transcrição e resumo de uma conversa...';
+  String get conversationPromptPlaceholder => 'Você é um aplicativo incrível, você receberá uma transcrição e resumo de uma conversa...';
 
   @override
   String get notificationScopes => 'Escopos de Notificação';
@@ -2833,8 +2805,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get makeMyAppPublic => 'Tornar meu aplicativo público';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Ao enviar este aplicativo, concordo com os Termos de Serviço e Política de Privacidade do Omi AI';
+  String get submitAppTermsAgreement => 'Ao enviar este aplicativo, concordo com os Termos de Serviço e Política de Privacidade do Omi AI';
 
   @override
   String get submitApp => 'Enviar Aplicativo';
@@ -2849,12 +2820,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get submitAppQuestion => 'Enviar Aplicativo?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Seu aplicativo será revisado e tornado público. Você pode começar a usá-lo imediatamente, mesmo durante a revisão!';
+  String get submitAppPublicDescription => 'Seu aplicativo será revisado e tornado público. Você pode começar a usá-lo imediatamente, mesmo durante a revisão!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Seu aplicativo será revisado e disponibilizado para você de forma privada. Você pode começar a usá-lo imediatamente, mesmo durante a revisão!';
+  String get submitAppPrivateDescription => 'Seu aplicativo será revisado e disponibilizado para você de forma privada. Você pode começar a usá-lo imediatamente, mesmo durante a revisão!';
 
   @override
   String get startEarning => 'Comece a Ganhar! 💰';
@@ -2878,23 +2847,19 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dataAccessNotice => 'Aviso de acesso a dados';
 
   @override
-  String get dataAccessWarning =>
-      'Este aplicativo acessará seus dados. Omi AI não é responsável por como seus dados são usados, modificados ou excluídos por este aplicativo';
+  String get dataAccessWarning => 'Este aplicativo acessará seus dados. Omi AI não é responsável por como seus dados são usados, modificados ou excluídos por este aplicativo';
 
   @override
   String get installApp => 'Instalar aplicativo';
 
   @override
-  String get betaTesterNotice =>
-      'Você é um testador beta deste aplicativo. Ele ainda não é público. Ele será público assim que for aprovado.';
+  String get betaTesterNotice => 'Você é um testador beta deste aplicativo. Ele ainda não é público. Ele será público assim que for aprovado.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Seu aplicativo está em análise e visível apenas para você. Ele será público assim que for aprovado.';
+  String get appUnderReviewOwner => 'Seu aplicativo está em análise e visível apenas para você. Ele será público assim que for aprovado.';
 
   @override
-  String get appRejectedNotice =>
-      'Seu aplicativo foi rejeitado. Por favor, atualize os detalhes do aplicativo e reenvie para análise.';
+  String get appRejectedNotice => 'Seu aplicativo foi rejeitado. Por favor, atualize os detalhes do aplicativo e reenvie para análise.';
 
   @override
   String get setupSteps => 'Etapas de configuração';
@@ -2929,8 +2894,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get errorActivatingApp => 'Erro ao ativar o aplicativo';
 
   @override
-  String get integrationSetupRequired =>
-      'Se este for um aplicativo de integração, certifique-se de que a configuração está concluída.';
+  String get integrationSetupRequired => 'Se este for um aplicativo de integração, certifique-se de que a configuração está concluída.';
 
   @override
   String get installed => 'Instalado';
@@ -2957,8 +2921,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get descriptionLabel => 'Descrição';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Meu aplicativo incrível é um aplicativo incrível que faz coisas incríveis. É o melhor aplicativo!';
+  String get appDescriptionPlaceholder => 'Meu aplicativo incrível é um aplicativo incrível que faz coisas incríveis. É o melhor aplicativo!';
 
   @override
   String get pleaseProvideValidDescription => 'Por favor, forneça uma descrição válida';
@@ -3110,8 +3073,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get microphonePermissionRequired => 'Permissão de microfone é necessária para gravação de voz.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Permissão de microfone negada. Por favor, conceda permissão em Preferências do Sistema > Privacidade e Segurança > Microfone.';
+  String get microphonePermissionDenied => 'Permissão de microfone negada. Por favor, conceda permissão em Preferências do Sistema > Privacidade e Segurança > Microfone.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3270,8 +3232,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get createMemory => 'Criar memória';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Tem certeza de que deseja excluir esta memória? Esta ação não pode ser desfeita.';
+  String get deleteMemoryConfirmation => 'Tem certeza de que deseja excluir esta memória? Esta ação não pode ser desfeita.';
 
   @override
   String get makePrivate => 'Tornar privado';
@@ -3345,8 +3306,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get whatWeCollect => 'O que coletamos';
 
   @override
-  String get dataCollectionMessage =>
-      'Ao continuar, suas conversas, gravações e informações pessoais serão armazenadas com segurança em nossos servidores para fornecer insights alimentados por IA e habilitar todos os recursos do aplicativo.';
+  String get dataCollectionMessage => 'Ao continuar, suas conversas, gravações e informações pessoais serão armazenadas com segurança em nossos servidores para fornecer insights alimentados por IA e habilitar todos os recursos do aplicativo.';
 
   @override
   String get dataProtection => 'Proteção de dados';
@@ -3361,8 +3321,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chooseYourLanguage => 'Escolha o seu idioma';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'Selecione o seu idioma preferido para a melhor experiência Omi';
+  String get selectPreferredLanguageForBestExperience => 'Selecione o seu idioma preferido para a melhor experiência Omi';
 
   @override
   String get searchLanguages => 'Pesquisar idiomas...';
@@ -3380,8 +3339,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'O nome deve ter pelo menos 2 caracteres';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Diga-nos como gostaria de ser chamado. Isso ajuda a personalizar sua experiência Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Diga-nos como gostaria de ser chamado. Isso ajuda a personalizar sua experiência Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3398,8 +3356,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get recordAudioConversations => 'Gravar conversas de áudio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi precisa de acesso ao microfone para gravar suas conversas e fornecer transcrições.';
+  String get microphoneAccessDescription => 'Omi precisa de acesso ao microfone para gravar suas conversas e fornecer transcrições.';
 
   @override
   String get screenRecording => 'Gravação de Tela';
@@ -3408,8 +3365,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Capturar áudio do sistema de reuniões';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi precisa de permissão de gravação de tela para capturar o áudio do sistema de suas reuniões baseadas no navegador.';
+  String get screenRecordingDescription => 'Omi precisa de permissão de gravação de tela para capturar o áudio do sistema de suas reuniões baseadas no navegador.';
 
   @override
   String get accessibility => 'Acessibilidade';
@@ -3418,8 +3374,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Detectar reuniões baseadas no navegador';
 
   @override
-  String get accessibilityDescription =>
-      'Omi precisa de permissão de acessibilidade para detectar quando você participa de reuniões do Zoom, Meet ou Teams no seu navegador.';
+  String get accessibilityDescription => 'Omi precisa de permissão de acessibilidade para detectar quando você participa de reuniões do Zoom, Meet ou Teams no seu navegador.';
 
   @override
   String get pleaseWait => 'Por favor, aguarde...';
@@ -3488,12 +3443,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get exportAllConversationsToJson => 'Exporte todas as suas conversas para um ficheiro JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Exportação de conversas iniciada. Isto pode demorar alguns segundos, por favor aguarde.';
+  String get conversationsExportStarted => 'Exportação de conversas iniciada. Isto pode demorar alguns segundos, por favor aguarde.';
 
   @override
-  String get mcpDescription =>
-      'Para conectar Omi com outras aplicações para ler, pesquisar e gerir as suas memórias e conversas. Crie uma chave para começar.';
+  String get mcpDescription => 'Para conectar Omi com outras aplicações para ler, pesquisar e gerir as suas memórias e conversas. Crie uma chave para começar.';
 
   @override
   String get apiKeys => 'Chaves API';
@@ -3528,8 +3481,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get triggersWhenDaySummaryGenerated => 'Dispara quando o resumo do dia é gerado.';
 
   @override
-  String get tryLatestExperimentalFeatures =>
-      'Experimente as mais recentes funcionalidades experimentais da equipa Omi.';
+  String get tryLatestExperimentalFeatures => 'Experimente as mais recentes funcionalidades experimentais da equipa Omi.';
 
   @override
   String get transcriptionServiceDiagnosticStatus => 'Estado de diagnóstico do serviço de transcrição';
@@ -3541,8 +3493,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'Criar e etiquetar automaticamente novos oradores';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Criar automaticamente uma nova pessoa quando um nome é detetado na transcrição.';
+  String get automaticallyCreateNewPerson => 'Criar automaticamente uma nova pessoa quando um nome é detetado na transcrição.';
 
   @override
   String get pilotFeatures => 'Funcionalidades piloto';
@@ -3603,8 +3554,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Deixe o Omi escolher automaticamente o melhor aplicativo';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Tem certeza de que deseja excluir esta conversa? Esta ação não pode ser desfeita.';
+  String get deleteConversationConfirmation => 'Tem certeza de que deseja excluir esta conversa? Esta ação não pode ser desfeita.';
 
   @override
   String get conversationDeleted => 'Conversa excluída';
@@ -3652,8 +3602,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Preparando captura de áudio do sistema';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Clique no botão para capturar áudio para transcrições ao vivo, insights de IA e salvamento automático.';
+  String get clickTheButtonToCaptureAudio => 'Clique no botão para capturar áudio para transcrições ao vivo, insights de IA e salvamento automático.';
 
   @override
   String get reconnecting => 'Reconectando...';
@@ -3880,8 +3829,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Excluir Grafo de Conhecimento?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Isso excluirá todos os dados derivados do grafo de conhecimento. Suas memórias originais permanecem seguras.';
+  String get deleteKnowledgeGraphWarning => 'Isso excluirá todos os dados derivados do grafo de conhecimento. Suas memórias originais permanecem seguras.';
 
   @override
   String get connectOmiWithAI => 'Conecte Omi com assistentes de IA';
@@ -3938,8 +3886,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get updateAppQuestion => 'Atualizar aplicação?';
 
   @override
-  String get updateAppConfirmation =>
-      'Tem a certeza de que pretende atualizar a sua aplicação? As alterações serão refletidas após revisão pela nossa equipa.';
+  String get updateAppConfirmation => 'Tem a certeza de que pretende atualizar a sua aplicação? As alterações serão refletidas após revisão pela nossa equipa.';
 
   @override
   String get updateApp => 'Atualizar aplicação';
@@ -3969,8 +3916,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get no => 'Não';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Assinatura cancelada com sucesso. Permanecerá ativa até o final do período de faturamento atual.';
+  String get subscriptionCancelledSuccessfully => 'Assinatura cancelada com sucesso. Permanecerá ativa até o final do período de faturamento atual.';
 
   @override
   String get failedToCancelSubscription => 'Falha ao cancelar a assinatura. Por favor, tente novamente.';
@@ -4006,8 +3952,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Cancelar assinatura?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Tem certeza de que deseja cancelar sua assinatura? Você continuará tendo acesso até o final do período de faturamento atual.';
+  String get cancelSubscriptionConfirmation => 'Tem certeza de que deseja cancelar sua assinatura? Você continuará tendo acesso até o final do período de faturamento atual.';
 
   @override
   String get cancelSubscriptionButton => 'Cancelar assinatura';
@@ -4016,12 +3961,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cancelling => 'Cancelando...';
 
   @override
-  String get betaTesterMessage =>
-      'Você é um testador beta deste aplicativo. Ainda não é público. Será público após aprovação.';
+  String get betaTesterMessage => 'Você é um testador beta deste aplicativo. Ainda não é público. Será público após aprovação.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Seu aplicativo está em análise e visível apenas para você. Será público após aprovação.';
+  String get appUnderReviewMessage => 'Seu aplicativo está em análise e visível apenas para você. Será público após aprovação.';
 
   @override
   String get appRejectedMessage => 'Seu aplicativo foi rejeitado. Atualize os detalhes e envie novamente para análise.';
@@ -4078,8 +4021,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get issueActivatingApp => 'Houve um problema ao ativar este aplicativo. Por favor, tente novamente.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Este aplicativo acessará seus dados. Omi AI não é responsável por como seus dados são usados, modificados ou excluídos por este aplicativo';
+  String get dataAccessNoticeDescription => 'Este aplicativo acessará seus dados. Omi AI não é responsável por como seus dados são usados, modificados ou excluídos por este aplicativo';
 
   @override
   String get copyUrl => 'Copiar URL';
@@ -4167,8 +4109,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get omiApiKeys => 'Chaves API do Omi';
 
   @override
-  String get apiKeysDescription =>
-      'As chaves API são usadas para autenticação quando seu aplicativo se comunica com o servidor OMI. Elas permitem que seu aplicativo crie memórias e acesse outros serviços do OMI com segurança.';
+  String get apiKeysDescription => 'As chaves API são usadas para autenticação quando seu aplicativo se comunica com o servidor OMI. Elas permitem que seu aplicativo crie memórias e acesse outros serviços do OMI com segurança.';
 
   @override
   String get aboutOmiApiKeys => 'Sobre as chaves API do Omi';
@@ -4192,8 +4133,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Revogar chave API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Esta ação não pode ser desfeita. Quaisquer aplicativos que usem esta chave não poderão mais acessar a API.';
+  String get revokeApiKeyWarning => 'Esta ação não pode ser desfeita. Quaisquer aplicativos que usem esta chave não poderão mais acessar a API.';
 
   @override
   String get revoke => 'Revogar';
@@ -4282,8 +4222,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get keyCreated => 'Chave criada';
 
   @override
-  String get keyCreatedMessage =>
-      'Sua nova chave foi criada. Por favor, copie-a agora. Você não poderá vê-la novamente.';
+  String get keyCreatedMessage => 'Sua nova chave foi criada. Por favor, copie-a agora. Você não poderá vê-la novamente.';
 
   @override
   String get keyWord => 'Chave';
@@ -4292,8 +4231,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get externalAppAccess => 'Acesso de aplicativos externos';
 
   @override
-  String get externalAppAccessDescription =>
-      'Os seguintes aplicativos instalados têm integrações externas e podem acessar seus dados, como conversas e memórias.';
+  String get externalAppAccessDescription => 'Os seguintes aplicativos instalados têm integrações externas e podem acessar seus dados, como conversas e memórias.';
 
   @override
   String get noExternalAppsHaveAccess => 'Nenhum aplicativo externo tem acesso aos seus dados.';
@@ -4302,8 +4240,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get maximumSecurityE2ee => 'Segurança máxima (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'A criptografia de ponta a ponta é o padrão ouro para privacidade. Quando ativada, seus dados são criptografados no seu dispositivo antes de serem enviados para nossos servidores. Isso significa que ninguém, nem mesmo a Omi, pode acessar seu conteúdo.';
+  String get e2eeDescription => 'A criptografia de ponta a ponta é o padrão ouro para privacidade. Quando ativada, seus dados são criptografados no seu dispositivo antes de serem enviados para nossos servidores. Isso significa que ninguém, nem mesmo a Omi, pode acessar seu conteúdo.';
 
   @override
   String get importantTradeoffs => 'Compromissos importantes:';
@@ -4318,8 +4255,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get featureComingSoon => 'Este recurso estará disponível em breve!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migração em andamento. Você não pode alterar o nível de proteção até que seja concluída.';
+  String get migrationInProgressMessage => 'Migração em andamento. Você não pode alterar o nível de proteção até que seja concluída.';
 
   @override
   String get migrationFailed => 'Falha na migração';
@@ -4338,19 +4274,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get secureEncryption => 'Criptografia segura';
 
   @override
-  String get secureEncryptionDescription =>
-      'Seus dados são criptografados com uma chave única para você em nossos servidores, hospedados no Google Cloud. Isso significa que seu conteúdo bruto é inacessível para qualquer pessoa, incluindo funcionários da Omi ou Google, diretamente do banco de dados.';
+  String get secureEncryptionDescription => 'Seus dados são criptografados com uma chave única para você em nossos servidores, hospedados no Google Cloud. Isso significa que seu conteúdo bruto é inacessível para qualquer pessoa, incluindo funcionários da Omi ou Google, diretamente do banco de dados.';
 
   @override
   String get endToEndEncryption => 'Criptografia de ponta a ponta';
 
   @override
-  String get e2eeCardDescription =>
-      'Ative para máxima segurança onde apenas você pode acessar seus dados. Toque para saber mais.';
+  String get e2eeCardDescription => 'Ative para máxima segurança onde apenas você pode acessar seus dados. Toque para saber mais.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Independentemente do nível, seus dados estão sempre criptografados em repouso e em trânsito.';
+  String get dataAlwaysEncrypted => 'Independentemente do nível, seus dados estão sempre criptografados em repouso e em trânsito.';
 
   @override
   String get readOnlyScope => 'Somente leitura';
@@ -4415,12 +4348,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trainingDataProgram => 'Programa de dados de treinamento';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Obtenha Omi Ilimitado grátis contribuindo com seus dados para treinar modelos de IA.';
+  String get getOmiUnlimitedFree => 'Obtenha Omi Ilimitado grátis contribuindo com seus dados para treinar modelos de IA.';
 
   @override
-  String get trainingDataBullets =>
-      '• Seus dados ajudam a melhorar os modelos de IA\n• Apenas dados não sensíveis são compartilhados\n• Processo totalmente transparente';
+  String get trainingDataBullets => '• Seus dados ajudam a melhorar os modelos de IA\n• Apenas dados não sensíveis são compartilhados\n• Processo totalmente transparente';
 
   @override
   String get learnMoreAtOmiTraining => 'Saiba mais em omi.me/training';
@@ -4432,8 +4363,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get submitRequest => 'Enviar solicitação';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Obrigado! Sua solicitação está em análise. Notificaremos você após a aprovação.';
+  String get thankYouRequestUnderReview => 'Obrigado! Sua solicitação está em análise. Notificaremos você após a aprovação.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4471,8 +4401,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get monthlyPlanContinues => 'Seu plano mensal atual continuará até o final do período de cobrança';
 
   @override
-  String get paymentMethodCharged =>
-      'Seu método de pagamento existente será cobrado automaticamente quando seu plano mensal terminar';
+  String get paymentMethodCharged => 'Seu método de pagamento existente será cobrado automaticamente quando seu plano mensal terminar';
 
   @override
   String get annualSubscriptionStarts => 'Sua assinatura anual de 12 meses começará automaticamente após a cobrança';
@@ -4515,8 +4444,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Seu plano anual começará automaticamente quando seu plano mensal terminar.';
+  String get annualPlanStartsAutomatically => 'Seu plano anual começará automaticamente quando seu plano mensal terminar.';
 
   @override
   String planRenewsOn(String date) {
@@ -4554,8 +4482,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get resubscribe => 'Assinar novamente';
 
   @override
-  String get couldNotOpenPaymentSettings =>
-      'Não foi possível abrir as configurações de pagamento. Por favor, tente novamente.';
+  String get couldNotOpenPaymentSettings => 'Não foi possível abrir as configurações de pagamento. Por favor, tente novamente.';
 
   @override
   String get managePaymentMethod => 'Gerenciar método de pagamento';
@@ -4584,8 +4511,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Sua privacidade é importante para nós';
 
   @override
-  String get privacyIntroText =>
-      'Na Omi, levamos sua privacidade muito a sério. Queremos ser transparentes sobre os dados que coletamos e como os usamos. Aqui está o que você precisa saber:';
+  String get privacyIntroText => 'Na Omi, levamos sua privacidade muito a sério. Queremos ser transparentes sobre os dados que coletamos e como os usamos. Aqui está o que você precisa saber:';
 
   @override
   String get whatWeTrack => 'O que rastreamos';
@@ -4600,12 +4526,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get ourCommitment => 'Nosso compromisso';
 
   @override
-  String get commitmentText =>
-      'Estamos comprometidos em usar os dados que coletamos apenas para tornar o Omi um produto melhor para você. Sua privacidade e confiança são primordiais para nós.';
+  String get commitmentText => 'Estamos comprometidos em usar os dados que coletamos apenas para tornar o Omi um produto melhor para você. Sua privacidade e confiança são primordiais para nós.';
 
   @override
-  String get thankYouText =>
-      'Obrigado por ser um usuário valioso do Omi. Se você tiver alguma dúvida ou preocupação, entre em contato conosco em team@basedhardware.com.';
+  String get thankYouText => 'Obrigado por ser um usuário valioso do Omi. Se você tiver alguma dúvida ou preocupação, entre em contato conosco em team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Configurações de sincronização WiFi';
@@ -4614,8 +4538,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get enterHotspotCredentials => 'Insira as credenciais do ponto de acesso do seu telefone';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'A sincronização WiFi usa seu telefone como ponto de acesso. Encontre o nome e a senha em Ajustes > Ponto de Acesso Pessoal.';
+  String get wifiSyncUsesHotspot => 'A sincronização WiFi usa seu telefone como ponto de acesso. Encontre o nome e a senha em Ajustes > Ponto de Acesso Pessoal.';
 
   @override
   String get hotspotNameSsid => 'Nome do ponto de acesso (SSID)';
@@ -4650,8 +4573,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Falha ao gerar resumo. Certifique-se de ter conversas para esse dia.';
+  String get failedToGenerateSummaryCheckConversations => 'Falha ao gerar resumo. Certifique-se de ter conversas para esse dia.';
 
   @override
   String get summaryNotFound => 'Resumo não encontrado';
@@ -4681,8 +4603,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Exportação iniciada. Isso pode levar alguns segundos...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Isso excluirá todos os dados derivados do grafo de conhecimento (nós e conexões). Suas memórias originais permanecerão seguras. O grafo será reconstruído ao longo do tempo ou na próxima solicitação.';
+  String get knowledgeGraphDeleteDescription => 'Isso excluirá todos os dados derivados do grafo de conhecimento (nós e conexões). Suas memórias originais permanecerão seguras. O grafo será reconstruído ao longo do tempo ou na próxima solicitação.';
 
   @override
   String get configureDailySummaryDigest => 'Configure seu resumo diário de tarefas';
@@ -4752,8 +4673,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Excluir todas as conversas do Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Isso excluirá permanentemente todas as conversas importadas do Limitless. Esta ação não pode ser desfeita.';
+  String get deleteAllLimitlessWarning => 'Isso excluirá permanentemente todas as conversas importadas do Limitless. Esta ação não pode ser desfeita.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4809,8 +4729,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get howItWorksTitle => 'Como funciona?';
 
   @override
-  String get howPeopleWorks =>
-      'Depois que uma pessoa é criada, você pode ir para a transcrição de uma conversa e atribuir os segmentos correspondentes, assim o Omi também poderá reconhecer a fala dela!';
+  String get howPeopleWorks => 'Depois que uma pessoa é criada, você pode ir para a transcrição de uma conversa e atribuir os segmentos correspondentes, assim o Omi também poderá reconhecer a fala dela!';
 
   @override
   String get tapToDelete => 'Toque para excluir';
@@ -4836,8 +4755,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get privacyNotice => 'Aviso de privacidade';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'As gravações podem capturar as vozes de outras pessoas. Certifique-se de ter o consentimento de todos os participantes antes de ativar.';
+  String get recordingsMayCaptureOthers => 'As gravações podem capturar as vozes de outras pessoas. Certifique-se de ter o consentimento de todos os participantes antes de ativar.';
 
   @override
   String get enable => 'Ativar';
@@ -4849,8 +4767,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Mantenha todas as gravações de áudio armazenadas localmente no seu telefone. Quando desativado, apenas uploads com falha são mantidos para economizar espaço.';
+  String get storeAudioDescription => 'Mantenha todas as gravações de áudio armazenadas localmente no seu telefone. Quando desativado, apenas uploads com falha são mantidos para economizar espaço.';
 
   @override
   String get enableLocalStorage => 'Ativar armazenamento local';
@@ -4868,12 +4785,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get storeAudioOnCloud => 'Armazenar Áudio na Nuvem';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Suas gravações em tempo real serão armazenadas em armazenamento em nuvem privado enquanto você fala.';
+  String get cloudStorageDialogMessage => 'Suas gravações em tempo real serão armazenadas em armazenamento em nuvem privado enquanto você fala.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Armazene suas gravações em tempo real em armazenamento em nuvem privado enquanto você fala. O áudio é capturado e salvo com segurança em tempo real.';
+  String get storeAudioCloudDescription => 'Armazene suas gravações em tempo real em armazenamento em nuvem privado enquanto você fala. O áudio é capturado e salvo com segurança em tempo real.';
 
   @override
   String get downloadingFirmware => 'Baixando Firmware';
@@ -4882,8 +4797,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get installingFirmware => 'Instalando Firmware';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Não feche o aplicativo ou desligue o dispositivo. Isso pode danificar seu dispositivo.';
+  String get firmwareUpdateWarning => 'Não feche o aplicativo ou desligue o dispositivo. Isso pode danificar seu dispositivo.';
 
   @override
   String get firmwareUpdated => 'Firmware Atualizado';
@@ -4927,8 +4841,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get payments => 'Pagamentos';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Conecte um método de pagamento abaixo para começar a receber pagamentos pelos seus aplicativos.';
+  String get connectPaymentMethodInfo => 'Conecte um método de pagamento abaixo para começar a receber pagamentos pelos seus aplicativos.';
 
   @override
   String get selectedPaymentMethod => 'Método de Pagamento Selecionado';
@@ -4955,15 +4868,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get monthlyPayouts => 'Pagamentos mensais';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Receba pagamentos mensais diretamente em sua conta quando atingir \$10 em ganhos';
+  String get monthlyPayoutsDescription => 'Receba pagamentos mensais diretamente em sua conta quando atingir \$10 em ganhos';
 
   @override
   String get secureAndReliable => 'Seguro e confiável';
 
   @override
-  String get stripeSecureDescription =>
-      'O Stripe garante transferências seguras e pontuais das receitas do seu aplicativo';
+  String get stripeSecureDescription => 'O Stripe garante transferências seguras e pontuais das receitas do seu aplicativo';
 
   @override
   String get selectYourCountry => 'Selecione seu país';
@@ -4984,8 +4895,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get connectingYourStripeAccount => 'Conectando sua conta Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Por favor, complete o processo de integração do Stripe no seu navegador. Esta página será atualizada automaticamente após a conclusão.';
+  String get stripeOnboardingInstructions => 'Por favor, complete o processo de integração do Stripe no seu navegador. Esta página será atualizada automaticamente após a conclusão.';
 
   @override
   String get failedTryAgain => 'Falhou? Tente Novamente';
@@ -4997,15 +4907,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get successfullyConnected => 'Conectado com Sucesso!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Sua conta Stripe está pronta para receber pagamentos. Você pode começar a ganhar com as vendas dos seus aplicativos imediatamente.';
+  String get stripeReadyForPayments => 'Sua conta Stripe está pronta para receber pagamentos. Você pode começar a ganhar com as vendas dos seus aplicativos imediatamente.';
 
   @override
   String get updateStripeDetails => 'Atualizar Detalhes do Stripe';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Erro ao atualizar detalhes do Stripe! Por favor, tente novamente mais tarde.';
+  String get errorUpdatingStripeDetails => 'Erro ao atualizar detalhes do Stripe! Por favor, tente novamente mais tarde.';
 
   @override
   String get updatePayPal => 'Atualizar PayPal';
@@ -5017,8 +4925,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Atualize os detalhes da sua conta PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Conecte sua conta PayPal para começar a receber pagamentos pelos seus aplicativos';
+  String get connectPayPalToReceivePayments => 'Conecte sua conta PayPal para começar a receber pagamentos pelos seus aplicativos';
 
   @override
   String get paypalEmail => 'E-mail do PayPal';
@@ -5027,8 +4934,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get paypalMeLink => 'Link do PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Se o Stripe estiver disponível em seu país, recomendamos fortemente usá-lo para pagamentos mais rápidos e fáceis.';
+  String get stripeRecommendation => 'Se o Stripe estiver disponível em seu país, recomendamos fortemente usá-lo para pagamentos mais rápidos e fáceis.';
 
   @override
   String get updatePayPalDetails => 'Atualizar Detalhes do PayPal';
@@ -5080,12 +4986,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Amostra de voz adicional removida';
 
   @override
-  String get consentDataMessage =>
-      'Ao continuar, suas conversas, gravações e informações pessoais serão armazenadas com segurança em nossos servidores. Suas gravações de áudio e transcrições são processadas por serviços de IA de terceiros (incluindo Deepgram para transcrição e OpenAI para análise) para fornecer insights baseados em IA e habilitar todos os recursos do aplicativo.';
+  String get consentDataMessage => 'Ao continuar, suas conversas, gravações e informações pessoais serão armazenadas com segurança em nossos servidores. Suas gravações de áudio e transcrições são processadas por serviços de IA de terceiros (incluindo Deepgram para transcrição e OpenAI para análise) para fornecer insights baseados em IA e habilitar todos os recursos do aplicativo.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'As tarefas das suas conversas aparecerão aqui.\nToque em + para criar uma manualmente.';
+  String get tasksEmptyStateMessage => 'As tarefas das suas conversas aparecerão aqui.\nToque em + para criar uma manualmente.';
 
   @override
   String get clearChatAction => 'Limpar conversa';
@@ -5121,15 +5025,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Instale o Omi no seu\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Para usar seu Apple Watch com o Omi, você precisa primeiro instalar o aplicativo Omi no seu relógio.';
+  String get installOmiOnAppleWatchDescription => 'Para usar seu Apple Watch com o Omi, você precisa primeiro instalar o aplicativo Omi no seu relógio.';
 
   @override
   String get openOmiOnAppleWatch => 'Abra o Omi no seu\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'O aplicativo Omi está instalado no seu Apple Watch. Abra-o e toque em Iniciar para começar.';
+  String get openOmiOnAppleWatchDescription => 'O aplicativo Omi está instalado no seu Apple Watch. Abra-o e toque em Iniciar para começar.';
 
   @override
   String get openWatchApp => 'Abrir app Watch';
@@ -5138,15 +5040,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Instalei e abri o aplicativo';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Não foi possível abrir o app Apple Watch. Abra manualmente o app Watch no seu Apple Watch e instale o Omi na seção \"Apps Disponíveis\".';
+  String get unableToOpenWatchApp => 'Não foi possível abrir o app Apple Watch. Abra manualmente o app Watch no seu Apple Watch e instale o Omi na seção \"Apps Disponíveis\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch conectado com sucesso!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch ainda não está acessível. Certifique-se de que o app Omi está aberto no seu relógio.';
+  String get appleWatchNotReachable => 'Apple Watch ainda não está acessível. Certifique-se de que o app Omi está aberto no seu relógio.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5574,8 +5474,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get multipleSpeakersDetected => 'Vários oradores detectados';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Parece que há vários oradores na gravação. Certifique-se de que está num local silencioso e tente novamente.';
+  String get multipleSpeakersDescription => 'Parece que há vários oradores na gravação. Certifique-se de que está num local silencioso e tente novamente.';
 
   @override
   String get invalidRecordingDetected => 'Gravação inválida detectada';
@@ -5587,15 +5486,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get speechDurationDescription => 'Certifique-se de falar pelo menos 5 segundos e não mais de 90.';
 
   @override
-  String get connectionLostDescription =>
-      'A ligação foi interrompida. Por favor, verifique a sua ligação à internet e tente novamente.';
+  String get connectionLostDescription => 'A ligação foi interrompida. Por favor, verifique a sua ligação à internet e tente novamente.';
 
   @override
   String get howToTakeGoodSample => 'Como fazer uma boa amostra?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Certifique-se de que está num local silencioso.\n2. Fale clara e naturalmente.\n3. Certifique-se de que o seu dispositivo está na posição natural no pescoço.\n\nDepois de criado, pode sempre melhorá-lo ou fazê-lo novamente.';
+  String get goodSampleInstructions => '1. Certifique-se de que está num local silencioso.\n2. Fale clara e naturalmente.\n3. Certifique-se de que o seu dispositivo está na posição natural no pescoço.\n\nDepois de criado, pode sempre melhorá-lo ou fazê-lo novamente.';
 
   @override
   String get noDeviceConnectedUseMic => 'Nenhum dispositivo ligado. Será utilizado o microfone do telefone.';
@@ -5658,12 +5555,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get howItWorks => 'Como funciona';
 
   @override
-  String get dailyScoreExplanation =>
-      'Sua pontuação diária é baseada na conclusão de tarefas. Conclua suas tarefas para melhorar sua pontuação!';
+  String get dailyScoreExplanation => 'Sua pontuação diária é baseada na conclusão de tarefas. Conclua suas tarefas para melhorar sua pontuação!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Controle com que frequência o Omi envia notificações proativas e lembretes.';
+  String get notificationFrequencyDescription => 'Controle com que frequência o Omi envia notificações proativas e lembretes.';
 
   @override
   String get sliderOff => 'Desligado';
@@ -5908,8 +5803,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get recordings => 'Gravações';
 
   @override
-  String get enableRemindersAccess =>
-      'Por favor, ative o acesso aos Lembretes nas Configurações para usar os Lembretes da Apple';
+  String get enableRemindersAccess => 'Por favor, ative o acesso aos Lembretes nas Configurações para usar os Lembretes da Apple';
 
   @override
   String todayAtTime(String time) {
@@ -5964,8 +5858,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get webhookUrlNotSet => 'URL do webhook não definida';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Por favor, defina a URL do webhook nas configurações de desenvolvedor para usar este recurso.';
+  String get setWebhookUrlInSettings => 'Por favor, defina a URL do webhook nas configurações de desenvolvedor para usar este recurso.';
 
   @override
   String get sendWebUrl => 'Enviar URL da web';
@@ -6039,15 +5932,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cloudProvider => 'Provedor de nuvem';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 minutos premium/mês. A aba No Dispositivo oferece transcrição gratuita ilimitada.';
+  String get premiumMinutesInfo => '1.200 minutos premium/mês. A aba No Dispositivo oferece transcrição gratuita ilimitada.';
 
   @override
   String get viewUsage => 'Ver uso';
 
   @override
-  String get localProcessingInfo =>
-      'O áudio é processado localmente. Funciona offline, mais privado, mas usa mais bateria.';
+  String get localProcessingInfo => 'O áudio é processado localmente. Funciona offline, mais privado, mas usa mais bateria.';
 
   @override
   String get model => 'Modelo';
@@ -6056,15 +5947,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get performanceWarning => 'Aviso de desempenho';
 
   @override
-  String get largeModelWarning =>
-      'Este modelo é grande e pode travar o aplicativo ou funcionar muito lentamente em dispositivos móveis.\n\n\"small\" ou \"base\" é recomendado.';
+  String get largeModelWarning => 'Este modelo é grande e pode travar o aplicativo ou funcionar muito lentamente em dispositivos móveis.\n\n\"small\" ou \"base\" é recomendado.';
 
   @override
   String get usingNativeIosSpeech => 'Usando reconhecimento de fala nativo do iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'O mecanismo de fala nativo do seu dispositivo será usado. Nenhum download de modelo necessário.';
+  String get noModelDownloadRequired => 'O mecanismo de fala nativo do seu dispositivo será usado. Nenhum download de modelo necessário.';
 
   @override
   String get modelReady => 'Modelo Pronto';
@@ -6121,12 +6010,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get batteryDrainSignificantly => 'O consumo de bateria aumentará significativamente.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 minutos premium/mês. A aba No dispositivo oferece transcrição gratuita ilimitada. ';
+  String get premiumMinutesMonth => '1.200 minutos premium/mês. A aba No dispositivo oferece transcrição gratuita ilimitada. ';
 
   @override
-  String get audioProcessedLocally =>
-      'O áudio é processado localmente. Funciona offline, mais privado, mas usa mais bateria.';
+  String get audioProcessedLocally => 'O áudio é processado localmente. Funciona offline, mais privado, mas usa mais bateria.';
 
   @override
   String get languageLabel => 'Idioma';
@@ -6135,12 +6022,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get modelLabel => 'Modelo';
 
   @override
-  String get modelTooLargeWarning =>
-      'Este modelo é grande e pode fazer o app travar ou funcionar muito lentamente em dispositivos móveis.\n\nsmall ou base é recomendado.';
+  String get modelTooLargeWarning => 'Este modelo é grande e pode fazer o app travar ou funcionar muito lentamente em dispositivos móveis.\n\nsmall ou base é recomendado.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'O mecanismo de fala nativo do seu dispositivo será usado. Não é necessário baixar modelo.';
+  String get nativeEngineNoDownload => 'O mecanismo de fala nativo do seu dispositivo será usado. Não é necessário baixar modelo.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6176,8 +6061,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'A transcrição ao vivo integrada do Omi é otimizada para conversas em tempo real com detecção automática de falantes e diarização.';
+  String get omiTranscriptionOptimized => 'A transcrição ao vivo integrada do Omi é otimizada para conversas em tempo real com detecção automática de falantes e diarização.';
 
   @override
   String get reset => 'Redefinir';
@@ -6397,8 +6281,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Construindo grafo de conhecimento a partir de memórias...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Seu grafo de conhecimento será construído automaticamente quando você criar novas memórias.';
+  String get knowledgeGraphWillBuildAutomatically => 'Seu grafo de conhecimento será construído automaticamente quando você criar novas memórias.';
 
   @override
   String get buildGraphButton => 'Construir grafo';
@@ -6634,8 +6517,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get failedToLoadContacts => 'Falha ao carregar contatos';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Falha ao preparar a conversa para compartilhamento. Por favor, tente novamente.';
+  String get failedToPrepareConversationForSharing => 'Falha ao preparar a conversa para compartilhamento. Por favor, tente novamente.';
 
   @override
   String get couldNotOpenSmsApp => 'Não foi possível abrir o aplicativo de SMS. Por favor, tente novamente.';
@@ -6701,8 +6583,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Baixando áudio do cartão SD do seu dispositivo';
 
   @override
-  String get transferRequiredDescription =>
-      'Esta gravação está armazenada no cartão SD do seu dispositivo. Transfira para o seu telefone para reproduzir ou compartilhar.';
+  String get transferRequiredDescription => 'Esta gravação está armazenada no cartão SD do seu dispositivo. Transfira para o seu telefone para reproduzir ou compartilhar.';
 
   @override
   String get cancelTransfer => 'Cancelar Transferência';
@@ -6723,8 +6604,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareRecording => 'Compartilhar Gravação';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Tem certeza de que deseja excluir permanentemente esta gravação? Isso não pode ser desfeito.';
+  String get deleteRecordingConfirmation => 'Tem certeza de que deseja excluir permanentemente esta gravação? Isso não pode ser desfeito.';
 
   @override
   String get recordingIdLabel => 'ID da Gravação';
@@ -6783,15 +6663,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get enableFastTransfer => 'Ativar transferência rápida';
 
   @override
-  String get fastTransferDescription =>
-      'A transferência rápida usa WiFi para velocidades ~5x mais rápidas. Seu telefone se conectará temporariamente à rede WiFi do dispositivo Omi durante a transferência.';
+  String get fastTransferDescription => 'A transferência rápida usa WiFi para velocidades ~5x mais rápidas. Seu telefone se conectará temporariamente à rede WiFi do dispositivo Omi durante a transferência.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'O acesso à internet é pausado durante a transferência';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Escolha como as gravações são transferidas do dispositivo Omi para seu telefone.';
+  String get chooseTransferMethodDescription => 'Escolha como as gravações são transferidas do dispositivo Omi para seu telefone.';
 
   @override
   String get wifiSpeed => '~150 KB/s via WiFi';
@@ -6800,8 +6678,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fiveTimesFaster => '5X MAIS RÁPIDO';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Cria uma conexão WiFi direta com seu dispositivo Omi. Seu telefone se desconecta temporariamente do WiFi normal durante a transferência.';
+  String get fastTransferMethodDescription => 'Cria uma conexão WiFi direta com seu dispositivo Omi. Seu telefone se desconecta temporariamente do WiFi normal durante a transferência.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6810,8 +6687,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get bleSpeed => '~30 KB/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Usa conexão Bluetooth Low Energy padrão. Mais lento, mas não afeta sua conexão WiFi.';
+  String get bluetoothMethodDescription => 'Usa conexão Bluetooth Low Energy padrão. Mais lento, mas não afeta sua conexão WiFi.';
 
   @override
   String get selected => 'Selecionado';
@@ -6849,12 +6725,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appDeleteFailed => 'Falha ao excluir o app. Por favor, tente novamente mais tarde.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Visibilidade do app alterada com sucesso. Pode levar alguns minutos para refletir.';
+  String get appVisibilityChangedSuccessfully => 'Visibilidade do app alterada com sucesso. Pode levar alguns minutos para refletir.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Erro ao ativar o app. Se for um app de integração, certifique-se de que a configuração esteja concluída.';
+  String get errorActivatingAppIntegration => 'Erro ao ativar o app. Se for um app de integração, certifique-se de que a configuração esteja concluída.';
 
   @override
   String get errorUpdatingAppStatus => 'Ocorreu um erro ao atualizar o status do app.';
@@ -6922,8 +6796,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get importantConversationTitle => 'Conversa importante';
 
   @override
-  String get importantConversationBody =>
-      'Você acabou de ter uma conversa importante. Toque para compartilhar o resumo.';
+  String get importantConversationBody => 'Você acabou de ter uma conversa importante. Toque para compartilhar o resumo.';
 
   @override
   String get templateName => 'Nome do modelo';
@@ -6935,8 +6808,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'O nome deve ter pelo menos 3 caracteres';
 
   @override
-  String get conversationPromptHint =>
-      'ex., Extraia itens de ação, decisões tomadas e pontos-chave da conversa fornecida.';
+  String get conversationPromptHint => 'ex., Extraia itens de ação, decisões tomadas e pontos-chave da conversa fornecida.';
 
   @override
   String get pleaseEnterAppPrompt => 'Por favor, insira um prompt para o seu aplicativo';
@@ -7123,19 +6995,16 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade agendado! Seu plano mensal continua até o final do período de cobrança e depois muda automaticamente para anual.';
+  String get planUpgradeScheduledMessage => 'Upgrade agendado! Seu plano mensal continua até o final do período de cobrança e depois muda automaticamente para anual.';
 
   @override
   String get couldNotSchedulePlanChange => 'Não foi possível agendar a mudança de plano. Tente novamente.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Sua assinatura foi reativada! Sem cobrança agora - você será cobrado no final do período atual.';
+  String get subscriptionReactivatedDefault => 'Sua assinatura foi reativada! Sem cobrança agora - você será cobrado no final do período atual.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Assinatura bem-sucedida! Você foi cobrado pelo novo período de cobrança.';
+  String get subscriptionSuccessfulCharged => 'Assinatura bem-sucedida! Você foi cobrado pelo novo período de cobrança.';
 
   @override
   String get couldNotProcessSubscription => 'Não foi possível processar a assinatura. Tente novamente.';
@@ -7315,8 +7184,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get onboardingBluetoothRequired => 'A permissão de Bluetooth é necessária para conectar ao seu dispositivo.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Permissão de Bluetooth negada. Conceda permissão nas Preferências do Sistema.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Permissão de Bluetooth negada. Conceda permissão nas Preferências do Sistema.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7329,12 +7197,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Permissão de notificação negada. Conceda permissão nas Preferências do Sistema.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Permissão de notificação negada. Conceda permissão nas Preferências do Sistema.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Permissão de notificação negada. Conceda permissão em Preferências do Sistema > Notificações.';
+  String get onboardingNotificationDeniedNotifications => 'Permissão de notificação negada. Conceda permissão em Preferências do Sistema > Notificações.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7347,15 +7213,13 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Conceda permissão de localização em Configurações > Privacidade e Segurança > Serviços de Localização';
+  String get onboardingLocationGrantInSettings => 'Conceda permissão de localização em Configurações > Privacidade e Segurança > Serviços de Localização';
 
   @override
   String get onboardingMicrophoneRequired => 'A permissão de microfone é necessária para gravação.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Permissão de microfone negada. Conceda permissão em Preferências do Sistema > Privacidade e Segurança > Microfone.';
+  String get onboardingMicrophoneDenied => 'Permissão de microfone negada. Conceda permissão em Preferências do Sistema > Privacidade e Segurança > Microfone.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7368,12 +7232,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'A permissão de captura de tela é necessária para gravação de áudio do sistema.';
+  String get onboardingScreenCaptureRequired => 'A permissão de captura de tela é necessária para gravação de áudio do sistema.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Permissão de captura de tela negada. Conceda permissão em Preferências do Sistema > Privacidade e Segurança > Gravação de Tela.';
+  String get onboardingScreenCaptureDenied => 'Permissão de captura de tela negada. Conceda permissão em Preferências do Sistema > Privacidade e Segurança > Gravação de Tela.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7386,8 +7248,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'A permissão de acessibilidade é necessária para detectar reuniões do navegador.';
+  String get onboardingAccessibilityRequired => 'A permissão de acessibilidade é necessária para detectar reuniões do navegador.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7427,8 +7288,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Permissão de fotos negada. Por favor, permita o acesso às fotos para selecionar imagens';
+  String get msgPhotosPermissionDenied => 'Permissão de fotos negada. Por favor, permita o acesso às fotos para selecionar imagens';
 
   @override
   String get msgSelectImagesGenericError => 'Erro ao selecionar imagens. Por favor, tente novamente.';
@@ -7470,8 +7330,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Permissão de microfone necessária';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Conceda permissão de microfone nas Preferências do Sistema';
+  String get captureMicrophonePermissionInSystemPreferences => 'Conceda permissão de microfone nas Preferências do Sistema';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Permissão de gravação de tela necessária';
@@ -7501,8 +7360,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get locationPermissionRequired => 'Permissão de localização necessária';
 
   @override
-  String get locationPermissionContent =>
-      'A Transferência Rápida requer permissão de localização para verificar a conexão WiFi. Por favor, conceda a permissão de localização para continuar.';
+  String get locationPermissionContent => 'A Transferência Rápida requer permissão de localização para verificar a conexão WiFi. Por favor, conceda a permissão de localização para continuar.';
 
   @override
   String get pdfTranscriptExport => 'Exportar transcrição';
@@ -7665,8 +7523,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'O dispositivo não suporta sincronização WiFi, mudando para Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'O dispositivo não suporta sincronização WiFi, mudando para Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health não está disponível neste dispositivo';
@@ -7962,8 +7819,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Coloque o Omi DevKit no modo de emparelhamento';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Pressione o botão uma vez para ligar. O LED piscará em roxo no modo de emparelhamento.';
+  String get pairingDescOmiDevkit => 'Pressione o botão uma vez para ligar. O LED piscará em roxo no modo de emparelhamento.';
 
   @override
   String get pairingTitleOmiGlass => 'Ligue o Omi Glass';
@@ -7975,8 +7831,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Coloque o Plaud Note no modo de emparelhamento';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Pressione e segure o botão lateral por 2 segundos. O LED vermelho piscará quando estiver pronto para emparelhar.';
+  String get pairingDescPlaudNote => 'Pressione e segure o botão lateral por 2 segundos. O LED vermelho piscará quando estiver pronto para emparelhar.';
 
   @override
   String get pairingTitleBee => 'Coloque o Bee no modo de emparelhamento';
@@ -7988,15 +7843,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get pairingTitleLimitless => 'Coloque o Limitless no modo de emparelhamento';
 
   @override
-  String get pairingDescLimitless =>
-      'Quando qualquer luz estiver visível, pressione uma vez e depois pressione e segure até que o dispositivo mostre uma luz rosa, depois solte.';
+  String get pairingDescLimitless => 'Quando qualquer luz estiver visível, pressione uma vez e depois pressione e segure até que o dispositivo mostre uma luz rosa, depois solte.';
 
   @override
   String get pairingTitleFriendPendant => 'Coloque o Friend Pendant no modo de emparelhamento';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Pressione o botão no pingente para ligá-lo. Ele entrará no modo de emparelhamento automaticamente.';
+  String get pairingDescFriendPendant => 'Pressione o botão no pingente para ligá-lo. Ele entrará no modo de emparelhamento automaticamente.';
 
   @override
   String get pairingTitleFieldy => 'Coloque o Fieldy no modo de emparelhamento';
@@ -8008,15 +7861,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Conectar Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Instale e abra o aplicativo Omi no seu Apple Watch, depois toque em Conectar no aplicativo.';
+  String get pairingDescAppleWatch => 'Instale e abra o aplicativo Omi no seu Apple Watch, depois toque em Conectar no aplicativo.';
 
   @override
   String get pairingTitleNeoOne => 'Coloque o Neo One no modo de emparelhamento';
 
   @override
-  String get pairingDescNeoOne =>
-      'Pressione e segure o botão de energia até que o LED pisque. O dispositivo estará visível.';
+  String get pairingDescNeoOne => 'Pressione e segure o botão de energia até que o LED pisque. O dispositivo estará visível.';
 
   @override
   String get downloadingFromDevice => 'Transferindo do dispositivo';
@@ -8086,8 +7937,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get wifiConfiguration => 'Configuração WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Insira suas credenciais WiFi para permitir que o dispositivo baixe o firmware.';
+  String get wifiConfigurationSubtitle => 'Insira suas credenciais WiFi para permitir que o dispositivo baixe o firmware.';
 
   @override
   String get networkNameSsid => 'Nome da rede (SSID)';
@@ -8105,8 +7955,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Aqui está o que eu sei sobre você';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Este mapa é atualizado à medida que o Omi aprende com suas conversas.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Este mapa é atualizado à medida que o Omi aprende com suas conversas.';
 
   @override
   String get apiEnvironment => 'Ambiente API';
@@ -8135,8 +7984,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get switchAndRestart => 'Trocar';
 
   @override
-  String get stagingDisclaimer =>
-      'O ambiente de teste pode ser instável, ter desempenho inconsistente e os dados podem ser perdidos. Apenas para testes.';
+  String get stagingDisclaimer => 'O ambiente de teste pode ser instável, ter desempenho inconsistente e os dados podem ser perdidos. Apenas para testes.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Salvo. Feche e reabra o aplicativo para aplicar as alterações.';
@@ -8365,8 +8213,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Chamadas telefónicas via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Faça chamadas pelo Omi e obtenha transcrição em tempo real, resumos automáticos e muito mais.';
+  String get phoneCallsUpsellSubtitle => 'Faça chamadas pelo Omi e obtenha transcrição em tempo real, resumos automáticos e muito mais.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transcrição em tempo real de cada chamada';
@@ -8393,8 +8240,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteSyncedFiles => 'Excluir gravações sincronizadas';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Estas gravações já foram sincronizadas com seu telefone. Isso não pode ser desfeito.';
+  String get deleteSyncedFilesMessage => 'Estas gravações já foram sincronizadas com seu telefone. Isso não pode ser desfeito.';
 
   @override
   String get syncedFilesDeleted => 'Gravações sincronizadas excluídas';
@@ -8406,8 +8252,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deletePendingFiles => 'Excluir gravações pendentes';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Estas gravações NÃO foram sincronizadas com seu telefone e serão permanentemente perdidas. Isso não pode ser desfeito.';
+  String get deletePendingFilesWarning => 'Estas gravações NÃO foram sincronizadas com seu telefone e serão permanentemente perdidas. Isso não pode ser desfeito.';
 
   @override
   String get pendingFilesDeleted => 'Gravações pendentes excluídas';
@@ -8419,8 +8264,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deleteAll => 'Eliminar tudo';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Isso excluirá gravações sincronizadas e pendentes. Gravações pendentes NÃO foram sincronizadas e serão permanentemente perdidas.';
+  String get deleteAllFilesWarning => 'Isso excluirá gravações sincronizadas e pendentes. Gravações pendentes NÃO foram sincronizadas e serão permanentemente perdidas.';
 
   @override
   String get allFilesDeleted => 'Todas as gravações excluídas';
@@ -8485,8 +8329,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fairUseAboutTitle => 'Sobre o uso justo';
 
   @override
-  String get fairUseAboutBody =>
-      'O Omi é projetado para conversas pessoais, reuniões e interações ao vivo. O uso é medido pelo tempo real de fala detectado, não pelo tempo de conexão. Se o uso exceder significativamente os padrões normais para conteúdo não pessoal, ajustes podem ser aplicados.';
+  String get fairUseAboutBody => 'O Omi é projetado para conversas pessoais, reuniões e interações ao vivo. O uso é medido pelo tempo real de fala detectado, não pelo tempo de conexão. Se o uso exceder significativamente os padrões normais para conteúdo não pessoal, ajustes podem ser aplicados.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8524,8 +8367,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get improveConnectionTitle => 'Melhorar conexão';
 
   @override
-  String get improveConnectionContent =>
-      'Melhorámos a forma como o Omi se mantém ligado ao seu dispositivo. Para ativar isto, vá à página de Informações do dispositivo, toque em \"Desligar dispositivo\" e emparelhe o seu dispositivo novamente.';
+  String get improveConnectionContent => 'Melhorámos a forma como o Omi se mantém ligado ao seu dispositivo. Para ativar isto, vá à página de Informações do dispositivo, toque em \"Desligar dispositivo\" e emparelhe o seu dispositivo novamente.';
 
   @override
   String get improveConnectionAction => 'Entendi';
@@ -8580,16 +8422,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get cancelSyncQuestion => 'Cancelar sincronização?';
 
   @override
-  String get omisStorageDesc =>
-      'Quando seu Omi não está conectado ao telefone, ele armazena o áudio localmente na memória integrada. Você nunca perderá uma gravação.';
+  String get omisStorageDesc => 'Quando seu Omi não está conectado ao telefone, ele armazena o áudio localmente na memória integrada. Você nunca perderá uma gravação.';
 
   @override
-  String get phoneStorageDesc =>
-      'Quando o Omi reconecta, as gravações são transferidas automaticamente para o telefone antes do envio.';
+  String get phoneStorageDesc => 'Quando o Omi reconecta, as gravações são transferidas automaticamente para o telefone antes do envio.';
 
   @override
-  String get cloudStorageDesc =>
-      'Após o envio, suas gravações são processadas e transcritas. As conversas estarão disponíveis em um minuto.';
+  String get cloudStorageDesc => 'Após o envio, suas gravações são processadas e transcritas. As conversas estarão disponíveis em um minuto.';
 
   @override
   String get tipKeepPhoneNearby => 'Mantenha o telefone por perto para sincronização mais rápida';
@@ -8613,12 +8452,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get permissionEnable => 'Ativar';
 
   @override
-  String get permissionsPageDescription =>
-      'Estas permissões são essenciais para o funcionamento do Omi. Elas habilitam recursos-chave como notificações, experiências baseadas em localização e captura de áudio.';
+  String get permissionsPageDescription => 'Estas permissões são essenciais para o funcionamento do Omi. Elas habilitam recursos-chave como notificações, experiências baseadas em localização e captura de áudio.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'O Omi precisa de algumas permissões para funcionar corretamente. Por favor, conceda-as para continuar.';
+  String get permissionsRequiredDescription => 'O Omi precisa de algumas permissões para funcionar corretamente. Por favor, conceda-as para continuar.';
 
   @override
   String get permissionsSetupTitle => 'Tenha a melhor experiência';
@@ -8854,8 +8691,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fetchingStableFirmware => 'Obtendo o último firmware estável...';
 
   @override
-  String get noStableFirmwareFound =>
-      'Não foi possível encontrar uma versão estável do firmware para o seu dispositivo.';
+  String get noStableFirmwareFound => 'Não foi possível encontrar uma versão estável do firmware para o seu dispositivo.';
 
   @override
   String get installStableFirmware => 'Instalar firmware estável';
@@ -8875,8 +8711,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get enableLocationTitle => 'Ativar localização';
 
   @override
-  String get enableLocationDescription =>
-      'A permissão de localização é necessária para encontrar dispositivos Bluetooth próximos.';
+  String get enableLocationDescription => 'A permissão de localização é necessária para encontrar dispositivos Bluetooth próximos.';
 
   @override
   String get voiceRecordingFound => 'Gravação encontrada';
@@ -8897,8 +8732,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get firmwareWarningTitle => 'Importante: Leia antes de atualizar';
 
   @override
-  String get firmwareFormatWarning =>
-      'Este firmware irá formatar o cartão SD. Certifique-se de que todos os dados offline estão sincronizados antes de atualizar.\n\nSe vir uma luz vermelha a piscar após instalar esta versão, não se preocupe. Basta ligar o dispositivo à aplicação e deverá ficar azul. A luz vermelha significa que o relógio do dispositivo ainda não foi sincronizado.';
+  String get firmwareFormatWarning => 'Este firmware irá formatar o cartão SD. Certifique-se de que todos os dados offline estão sincronizados antes de atualizar.\n\nSe vir uma luz vermelha a piscar após instalar esta versão, não se preocupe. Basta ligar o dispositivo à aplicação e deverá ficar azul. A luz vermelha significa que o relógio do dispositivo ainda não foi sincronizado.';
 
   @override
   String get continueAnyway => 'Continuar';
@@ -8918,8 +8752,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get tasksMarkComplete => 'Marcado como concluído';
 
   @override
-  String get appleHealthManageNote =>
-      'O Omi acessa o Apple Health através do framework HealthKit da Apple. Você pode revogar o acesso a qualquer momento nos Ajustes do iOS.';
+  String get appleHealthManageNote => 'O Omi acessa o Apple Health através do framework HealthKit da Apple. Você pode revogar o acesso a qualquer momento nos Ajustes do iOS.';
 
   @override
   String get appleHealthConnectCta => 'Conectar ao Apple Health';
@@ -8952,8 +8785,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Acesso ao Apple Health negado';
 
   @override
-  String get appleHealthDeniedBody =>
-      'O Omi não tem permissão para ler seus dados do Apple Health. Ative em Ajustes do iOS → Privacidade e Segurança → Saúde → Omi.';
+  String get appleHealthDeniedBody => 'O Omi não tem permissão para ler seus dados do Apple Health. Ative em Ajustes do iOS → Privacidade e Segurança → Saúde → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Por que você está saindo?';
@@ -9022,8 +8854,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get planUpdate => 'Atualização do plano';
 
   @override
-  String get planDeprecationMessage =>
-      'Seu plano Unlimited está sendo descontinuado. Mude para o plano Operator — os mesmos ótimos recursos por \$49/mês. Seu plano atual continuará funcionando enquanto isso.';
+  String get planDeprecationMessage => 'Seu plano Unlimited está sendo descontinuado. Mude para o plano Operator — os mesmos ótimos recursos por \$49/mês. Seu plano atual continuará funcionando enquanto isso.';
 
   @override
   String get upgradeYourPlan => 'Atualize seu plano';
@@ -9134,8 +8965,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Você atingiu seu limite mensal. Atualize para continuar conversando com Omi sem restrições.';
+  String get chatQuotaExceededReply => 'Você atingiu seu limite mensal. Atualize para continuar conversando com Omi sem restrições.';
 
   @override
   String get voiceResponseAudio => 'Ler resposta do Omi em voz alta';
@@ -9166,4 +8996,25 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Adicionar tarefa';
+
+  @override
+  String get quickActionAskOmiAnything => 'Pergunte qualquer coisa ao Omi';
+
+  @override
+  String get quickActionVoiceMode => 'Modo de voz';
+
+  @override
+  String get quickActionMute => 'Silenciar';
+
+  @override
+  String get quickActionUnmute => 'Ativar som';
+
+  @override
+  String get quickActionConnectDevice => 'Conectar dispositivo';
+
+  @override
+  String get quickActionDeviceSettings => 'Configurações do dispositivo';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -24,8 +24,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteConversationTitle => 'Ștergi conversația?';
 
   @override
-  String get deleteConversationMessage =>
-      'Aceasta va șterge și amintirile, sarcinile și fișierele audio asociate. Această acțiune nu poate fi anulată.';
+  String get deleteConversationMessage => 'Aceasta va șterge și amintirile, sarcinile și fișierele audio asociate. Această acțiune nu poate fi anulată.';
 
   @override
   String get confirm => 'Confirmă';
@@ -82,8 +81,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get conversationUrlNotShared => 'URL-ul conversației nu a putut fi partajat.';
 
   @override
-  String get errorProcessingConversation =>
-      'Eroare la procesarea conversației. Te rugăm să încerci din nou mai târziu.';
+  String get errorProcessingConversation => 'Eroare la procesarea conversației. Te rugăm să încerci din nou mai târziu.';
 
   @override
   String get noInternetConnection => 'Fără conexiune la internet';
@@ -147,8 +145,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleting => 'Se șterge...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
+  String get pleaseCompleteAuthentication => 'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
 
   @override
   String get failedToStartAuthentication => 'Nu s-a putut inițializa autentificarea';
@@ -229,8 +226,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noStarredConversations => 'Nicio conversație cu stea';
 
   @override
-  String get starConversationHint =>
-      'Pentru a marca o conversație ca favorită, deschide-o și apasă iconița de stea din antet.';
+  String get starConversationHint => 'Pentru a marca o conversație ca favorită, deschide-o și apasă iconița de stea din antet.';
 
   @override
   String get searchConversations => 'Căutare conversații...';
@@ -321,8 +317,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get installedApps => 'Aplicații instalate';
 
   @override
-  String get unableToFetchApps =>
-      'Nu s-au putut prelua aplicațiile :(\n\nTe rugăm să verifici conexiunea la internet și să încerci din nou.';
+  String get unableToFetchApps => 'Nu s-au putut prelua aplicațiile :(\n\nTe rugăm să verifici conexiunea la internet și să încerci din nou.';
 
   @override
   String get aboutOmi => 'Despre Omi';
@@ -358,19 +353,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get appsDisconnected => 'Aplicațiile și integrările tale vor fi deconectate imediat.';
 
   @override
-  String get exportBeforeDelete =>
-      'Poți exporta datele înainte de a-ți șterge contul, dar odată șters, nu poate fi recuperat.';
+  String get exportBeforeDelete => 'Poți exporta datele înainte de a-ți șterge contul, dar odată șters, nu poate fi recuperat.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Înțeleg că ștergerea contului meu este permanentă și toate datele, inclusiv amintirile și conversațiile, vor fi pierdute și nu pot fi recuperate.';
+  String get deleteAccountCheckbox => 'Înțeleg că ștergerea contului meu este permanentă și toate datele, inclusiv amintirile și conversațiile, vor fi pierdute și nu pot fi recuperate.';
 
   @override
   String get areYouSure => 'Ești sigur?';
 
   @override
-  String get deleteAccountFinal =>
-      'Această acțiune este ireversibilă și va șterge permanent contul tău și toate datele asociate. Ești sigur că vrei să continui?';
+  String get deleteAccountFinal => 'Această acțiune este ireversibilă și va șterge permanent contul tău și toate datele asociate. Ești sigur că vrei să continui?';
 
   @override
   String get deleteNow => 'Șterge acum';
@@ -379,8 +371,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get goBack => 'Înapoi';
 
   @override
-  String get checkBoxToConfirm =>
-      'Bifează caseta pentru a confirma că înțelegi că ștergerea contului este permanentă și ireversibilă.';
+  String get checkBoxToConfirm => 'Bifează caseta pentru a confirma că înțelegi că ștergerea contului este permanentă și ireversibilă.';
 
   @override
   String get profile => 'Profil';
@@ -458,8 +449,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get yourPrivacyYourControl => 'Confidențialitatea ta, sub controlul tău';
 
   @override
-  String get privacyIntro =>
-      'La Omi, ne angajăm să îți protejăm confidențialitatea. Această pagină îți permite să controlezi modul în care datele tale sunt stocate și utilizate.';
+  String get privacyIntro => 'La Omi, ne angajăm să îți protejăm confidențialitatea. Această pagină îți permite să controlezi modul în care datele tale sunt stocate și utilizate.';
 
   @override
   String get learnMore => 'Află mai multe...';
@@ -468,15 +458,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dataProtectionLevel => 'Nivel de protecție a datelor';
 
   @override
-  String get dataProtectionDesc =>
-      'Datele tale sunt securizate implicit cu criptare puternică. Revizuiește setările și opțiunile viitoare de confidențialitate mai jos.';
+  String get dataProtectionDesc => 'Datele tale sunt securizate implicit cu criptare puternică. Revizuiește setările și opțiunile viitoare de confidențialitate mai jos.';
 
   @override
   String get appAccess => 'Acces aplicații';
 
   @override
-  String get appAccessDesc =>
-      'Următoarele aplicații pot accesa datele tale. Apasă pe o aplicație pentru a-i gestiona permisiunile.';
+  String get appAccessDesc => 'Următoarele aplicații pot accesa datele tale. Apasă pe o aplicație pentru a-i gestiona permisiunile.';
 
   @override
   String get noAppsExternalAccess => 'Nicio aplicație instalată nu are acces extern la datele tale.';
@@ -533,22 +521,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Omi-ul tău a fost deconectat 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Dispozitiv deconectat. Mergeți la Setări > Bluetooth și uitați dispozitivul pentru a finaliza deconectarea.';
+  String get deviceUnpairedMessage => 'Dispozitiv deconectat. Mergeți la Setări > Bluetooth și uitați dispozitivul pentru a finaliza deconectarea.';
 
   @override
   String get unpairDialogTitle => 'Deperechează dispozitivul';
 
   @override
-  String get unpairDialogMessage =>
-      'Acest lucru va deperechia dispozitivul astfel încât să poată fi conectat la alt telefon. Va trebui să mergi la Setări > Bluetooth și să uiți dispozitivul pentru a finaliza procesul.';
+  String get unpairDialogMessage => 'Acest lucru va deperechia dispozitivul astfel încât să poată fi conectat la alt telefon. Va trebui să mergi la Setări > Bluetooth și să uiți dispozitivul pentru a finaliza procesul.';
 
   @override
   String get deviceNotConnected => 'Dispozitiv neconectat';
 
   @override
-  String get connectDeviceMessage =>
-      'Conectează dispozitivul Omi pentru a accesa\nsetările și personalizarea dispozitivului';
+  String get connectDeviceMessage => 'Conectează dispozitivul Omi pentru a accesa\nsetările și personalizarea dispozitivului';
 
   @override
   String get deviceInfoSection => 'Informații dispozitiv';
@@ -563,8 +548,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get v2Undetected => 'V2 nedetectat';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vedem că ai fie un dispozitiv V1, fie dispozitivul tău nu este conectat. Funcționalitatea card SD este disponibilă doar pentru dispozitivele V2.';
+  String get v2UndetectedMessage => 'Vedem că ai fie un dispozitiv V1, fie dispozitivul tău nu este conectat. Funcționalitatea card SD este disponibilă doar pentru dispozitivele V2.';
 
   @override
   String get endConversation => 'Încheie conversația';
@@ -696,8 +680,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noActivityYet => 'Încă nu există activitate';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Începe o conversație cu Omi\npentru a vedea statisticile de utilizare aici.';
+  String get startConversationToSeeInsights => 'Începe o conversație cu Omi\npentru a vedea statisticile de utilizare aici.';
 
   @override
   String get listening => 'Ascultare';
@@ -839,8 +822,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Ștergi graficul de cunoștințe?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Acest lucru va șterge toate datele derivate din graficul de cunoștințe (noduri și conexiuni). Amintirile tale originale vor rămâne în siguranță. Graficul va fi reconstruit în timp sau la următoarea solicitare.';
+  String get deleteKnowledgeGraphMessage => 'Acest lucru va șterge toate datele derivate din graficul de cunoștințe (noduri și conexiuni). Amintirile tale originale vor rămâne în siguranță. Graficul va fi reconstruit în timp sau la următoarea solicitare.';
 
   @override
   String get knowledgeGraphDeleted => 'Graficul de cunoștințe a fost șters';
@@ -988,8 +970,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shortConversationThreshold => 'Prag conversații scurte';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Conversațiile mai scurte decât aceasta vor fi ascunse dacă nu este activată opțiunea de mai sus';
+  String get shortConversationThresholdSubtitle => 'Conversațiile mai scurte decât aceasta vor fi ascunse dacă nu este activată opțiunea de mai sus';
 
   @override
   String get durationThreshold => 'Prag durată';
@@ -1024,8 +1005,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get integrationsFooter => 'Conectează aplicațiile tale pentru a vizualiza date și statistici în chat.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
+  String get completeAuthInBrowser => 'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1085,8 +1065,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get needYourPermission => 'Avem nevoie de permisiunea ta';
 
   @override
-  String get alreadyGavePermission =>
-      'Ne-ai dat deja permisiunea de a salva înregistrările tale. Iată un memento despre motivul pentru care avem nevoie:';
+  String get alreadyGavePermission => 'Ne-ai dat deja permisiunea de a salva înregistrările tale. Iată un memento despre motivul pentru care avem nevoie:';
 
   @override
   String get wouldLikePermission => 'Am dori permisiunea ta de a salva înregistrările vocale. Iată de ce:';
@@ -1095,26 +1074,22 @@ class AppLocalizationsRo extends AppLocalizations {
   String get improveSpeechProfile => 'Îmbunătățește profilul tău vocal';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Folosim înregistrările pentru a antrena și îmbunătăți în continuare profilul tău vocal personal.';
+  String get improveSpeechProfileDesc => 'Folosim înregistrările pentru a antrena și îmbunătăți în continuare profilul tău vocal personal.';
 
   @override
   String get trainFamilyProfiles => 'Antrenează profiluri pentru prieteni și familie';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Înregistrările tale ne ajută să recunoaștem și să creăm profiluri pentru prietenii și familia ta.';
+  String get trainFamilyProfilesDesc => 'Înregistrările tale ne ajută să recunoaștem și să creăm profiluri pentru prietenii și familia ta.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Îmbunătățește acuratețea transcrierii';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Pe măsură ce modelul nostru se îmbunătățește, putem oferi rezultate de transcriere mai bune pentru înregistrările tale.';
+  String get enhanceTranscriptAccuracyDesc => 'Pe măsură ce modelul nostru se îmbunătățește, putem oferi rezultate de transcriere mai bune pentru înregistrările tale.';
 
   @override
-  String get legalNotice =>
-      'Notificare legală: Legalitatea înregistrării și stocării datelor vocale poate varia în funcție de locația ta și modul în care folosești această funcție. Este responsabilitatea ta să te asiguri că respecți legile și reglementările locale.';
+  String get legalNotice => 'Notificare legală: Legalitatea înregistrării și stocării datelor vocale poate varia în funcție de locația ta și modul în care folosești această funcție. Este responsabilitatea ta să te asiguri că respecți legile și reglementările locale.';
 
   @override
   String get alreadyAuthorized => 'Deja autorizat';
@@ -1186,15 +1161,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showMeetingsMenuBar => 'Afișează întâlnirile viitoare în bara de meniu';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Afișează următoarea întâlnire și timpul rămas până începe în bara de meniu macOS';
+  String get showMeetingsMenuBarDesc => 'Afișează următoarea întâlnire și timpul rămas până începe în bara de meniu macOS';
 
   @override
   String get showEventsNoParticipants => 'Afișează evenimente fără participanți';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Când este activat, Coming Up afișează evenimente fără participanți sau link video.';
+  String get showEventsNoParticipantsDesc => 'Când este activat, Coming Up afișează evenimente fără participanți sau link video.';
 
   @override
   String get yourMeetings => 'Întâlnirile tale';
@@ -1235,8 +1208,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noProjectsInWorkspace => 'Nu s-au găsit proiecte în acest spațiu de lucru';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Alege cât timp să aștepți în tăcere înainte de a încheia automat o conversație:';
+  String get conversationTimeoutDesc => 'Alege cât timp să aștepți în tăcere înainte de a încheia automat o conversație:';
 
   @override
   String get timeout2Minutes => '2 minute';
@@ -1283,8 +1255,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get languageForTranscription => 'Setează limba pentru transcrieri mai precise și o experiență personalizată.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Modul limbă unică este activat. Traducerea este dezactivată pentru o acuratețe mai mare.';
+  String get singleLanguageModeInfo => 'Modul limbă unică este activat. Traducerea este dezactivată pentru o acuratețe mai mare.';
 
   @override
   String get searchLanguageHint => 'Caută limba după nume sau cod';
@@ -1364,8 +1335,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get defaultRepository => 'Repository implicit';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Selectează un repository implicit pentru crearea de issue-uri. Poți specifica totuși un repository diferit când creezi issue-uri.';
+  String get selectDefaultRepoDesc => 'Selectează un repository implicit pentru crearea de issue-uri. Poți specifica totuși un repository diferit când creezi issue-uri.';
 
   @override
   String get noReposFound => 'Nu s-au găsit repository-uri';
@@ -1412,8 +1382,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get configureSettings => 'Configurează setările';
 
   @override
-  String get completeAuthBrowser =>
-      'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
+  String get completeAuthBrowser => 'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1582,8 +1551,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get logsCopied => 'Jurnale copiate';
 
   @override
-  String get noLogsYet =>
-      'Încă nu există jurnale. Începe să înregistrezi pentru a vedea activitatea STT personalizată.';
+  String get noLogsYet => 'Încă nu există jurnale. Începe să înregistrezi pentru a vedea activitatea STT personalizată.';
 
   @override
   String deviceUsesCodec(String device, String reason) {
@@ -1742,8 +1710,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get enableBluetooth => 'Activare Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi are nevoie de Bluetooth pentru a se conecta la dispozitivul dvs. Activați Bluetooth și încercați din nou.';
+  String get bluetoothNeeded => 'Omi are nevoie de Bluetooth pentru a se conecta la dispozitivul dvs. Activați Bluetooth și încercați din nou.';
 
   @override
   String get contactSupport => 'Contactează suportul?';
@@ -1776,26 +1743,22 @@ class AppLocalizationsRo extends AppLocalizations {
   String get locationServiceDisabled => 'Serviciul de locație dezactivat';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Serviciul de locație este dezactivat. Te rugăm să mergi la Setări > Confidențialitate și securitate > Servicii de locație și să-l activezi';
+  String get locationServiceDisabledDesc => 'Serviciul de locație este dezactivat. Te rugăm să mergi la Setări > Confidențialitate și securitate > Servicii de locație și să-l activezi';
 
   @override
   String get backgroundLocationDenied => 'Acces la locație în fundal refuzat';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Te rugăm să mergi la setările dispozitivului și să setezi permisiunea de locație la \"Permite întotdeauna\"';
+  String get backgroundLocationDeniedDesc => 'Te rugăm să mergi la setările dispozitivului și să setezi permisiunea de locație la \"Permite întotdeauna\"';
 
   @override
   String get lovingOmi => 'Vă place Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Ajută-ne să ajungem la mai mulți oameni lăsând o recenzie în App Store. Feedback-ul tău înseamnă enorm pentru noi!';
+  String get leaveReviewIos => 'Ajută-ne să ajungem la mai mulți oameni lăsând o recenzie în App Store. Feedback-ul tău înseamnă enorm pentru noi!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Ajutați-ne să ajungem la mai multe persoane lăsând o recenzie în Google Play Store. Feedback-ul dvs. înseamnă enorm pentru noi!';
+  String get leaveReviewAndroid => 'Ajutați-ne să ajungem la mai multe persoane lăsând o recenzie în Google Play Store. Feedback-ul dvs. înseamnă enorm pentru noi!';
 
   @override
   String get rateOnAppStore => 'Evaluează în App Store';
@@ -1828,15 +1791,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get connectionError => 'Eroare de conexiune';
 
   @override
-  String get connectionErrorDesc =>
-      'Conectarea la server a eșuat. Te rugăm să verifici conexiunea la internet și să încerci din nou.';
+  String get connectionErrorDesc => 'Conectarea la server a eșuat. Te rugăm să verifici conexiunea la internet și să încerci din nou.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Înregistrare invalidă detectată';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Se pare că sunt mai mulți vorbitori în înregistrare. Te rugăm să te asiguri că ești într-un loc liniștit și să încerci din nou.';
+  String get multipleSpeakersDesc => 'Se pare că sunt mai mulți vorbitori în înregistrare. Te rugăm să te asiguri că ești într-un loc liniștit și să încerci din nou.';
 
   @override
   String get tooShortDesc => 'Nu s-a detectat suficientă vorbire. Te rugăm să vorbești mai mult și să încerci din nou.';
@@ -1848,15 +1809,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get areYouThere => 'Ești acolo?';
 
   @override
-  String get noSpeechDesc =>
-      'Nu am putut detecta nicio vorbire. Te rugăm să vorbești cel puțin 10 secunde și nu mai mult de 3 minute.';
+  String get noSpeechDesc => 'Nu am putut detecta nicio vorbire. Te rugăm să vorbești cel puțin 10 secunde și nu mai mult de 3 minute.';
 
   @override
   String get connectionLost => 'Conexiune pierdută';
 
   @override
-  String get connectionLostDesc =>
-      'Conexiunea a fost întreruptă. Te rugăm să verifici conexiunea la internet și să încerci din nou.';
+  String get connectionLostDesc => 'Conexiunea a fost întreruptă. Te rugăm să verifici conexiunea la internet și să încerci din nou.';
 
   @override
   String get tryAgain => 'Încearcă din nou';
@@ -1871,8 +1830,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get permissionsRequired => 'Permisiuni necesare';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Această aplicație necesită permisiuni Bluetooth și Locație. Activați-le din setări.';
+  String get permissionsRequiredDesc => 'Această aplicație necesită permisiuni Bluetooth și Locație. Activați-le din setări.';
 
   @override
   String get openSettings => 'Deschide setările';
@@ -1914,12 +1872,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get microphonePermission => 'Permisiune microfon';
 
   @override
-  String get permissionGrantedNow =>
-      'Permisiune acordată! Acum:\n\nDeschideți aplicația Omi pe ceas și apăsați „Continuare” mai jos';
+  String get permissionGrantedNow => 'Permisiune acordată! Acum:\n\nDeschideți aplicația Omi pe ceas și apăsați „Continuare” mai jos';
 
   @override
-  String get needMicrophonePermission =>
-      'Avem nevoie de permisiunea microfonului.\n\n1. Apasă \"Acordă permisiunea\"\n2. Permite pe iPhone\n3. Aplicația de ceas se va închide\n4. Redeschide și apasă \"Continuă\"';
+  String get needMicrophonePermission => 'Avem nevoie de permisiunea microfonului.\n\n1. Apasă \"Acordă permisiunea\"\n2. Permite pe iPhone\n3. Aplicația de ceas se va închide\n4. Redeschide și apasă \"Continuă\"';
 
   @override
   String get grantPermissionButton => 'Acordă permisiunea';
@@ -1928,15 +1884,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get needHelp => 'Ai nevoie de ajutor?';
 
   @override
-  String get troubleshootingSteps =>
-      'Depanare:\n\n1. Asigurați-vă că Omi este instalat pe ceas\n2. Deschideți aplicația Omi pe ceas\n3. Căutați fereastra de permisiuni\n4. Apăsați „Permite” când vi se solicită\n5. Aplicația de pe ceas se va închide - redeschideți-o\n6. Reveniți și apăsați „Continuare” pe iPhone';
+  String get troubleshootingSteps => 'Depanare:\n\n1. Asigurați-vă că Omi este instalat pe ceas\n2. Deschideți aplicația Omi pe ceas\n3. Căutați fereastra de permisiuni\n4. Apăsați „Permite” când vi se solicită\n5. Aplicația de pe ceas se va închide - redeschideți-o\n6. Reveniți și apăsați „Continuare” pe iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Înregistrarea a început cu succes!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Permisiunea nu a fost acordată încă. Te rugăm să te asiguri că ai permis accesul la microfon și ai redeschis aplicația pe ceas.';
+  String get permissionNotGrantedYet => 'Permisiunea nu a fost acordată încă. Te rugăm să te asiguri că ai permis accesul la microfon și ai redeschis aplicația pe ceas.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2033,8 +1987,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Pregătit pentru elemente de acțiune';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'AI-ul tău va extrage automat sarcini și de făcut din conversațiile tale. Vor apărea aici când sunt create.';
+  String get welcomeActionItemsDescription => 'AI-ul tău va extrage automat sarcini și de făcut din conversațiile tale. Vor apărea aici când sunt create.';
 
   @override
   String get autoExtractionFeature => 'Extras automat din conversații';
@@ -2084,8 +2037,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get clearMemoryTitle => 'Șterge memoria lui Omi';
 
   @override
-  String get clearMemoryMessage =>
-      'Sunteți sigur că doriți să ștergeți memoria lui Omi? Această acțiune nu poate fi anulată.';
+  String get clearMemoryMessage => 'Sunteți sigur că doriți să ștergeți memoria lui Omi? Această acțiune nu poate fi anulată.';
 
   @override
   String get clearMemoryButton => 'Șterge memoria';
@@ -2231,15 +2183,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'VORBIRE ȘI TRANSCRIERE';
 
   @override
-  String get languageSettingsHelperText =>
-      'Limba aplicației schimbă meniurile și butoanele. Limba vorbirii afectează modul în care sunt transcrise înregistrările.';
+  String get languageSettingsHelperText => 'Limba aplicației schimbă meniurile și butoanele. Limba vorbirii afectează modul în care sunt transcrise înregistrările.';
 
   @override
   String get translationNotice => 'Notificare de traducere';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi traduce conversațiile în limba ta principală. Actualizează-o oricând în Setări → Profiluri.';
+  String get translationNoticeMessage => 'Omi traduce conversațiile în limba ta principală. Actualizează-o oricând în Setări → Profiluri.';
 
   @override
   String get pleaseCheckInternetConnection => 'Verifică conexiunea la internet și încearcă din nou';
@@ -2259,8 +2209,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get conversationCannotBeMerged =>
-      'Această conversație nu poate fi fuzionată (blocată sau deja în curs de fuzionare)';
+  String get conversationCannotBeMerged => 'Această conversație nu poate fi fuzionată (blocată sau deja în curs de fuzionare)';
 
   @override
   String get pleaseEnterFolderName => 'Te rugăm să introduci un nume de dosar';
@@ -2395,8 +2344,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Deconectează dispozitivul';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Aceasta va deconecta dispozitivul astfel încât să poată fi conectat la un alt telefon. Va trebui să mergeți la Setări > Bluetooth și să uitați dispozitivul pentru a finaliza procesul.';
+  String get unpairDeviceDialogMessage => 'Aceasta va deconecta dispozitivul astfel încât să poată fi conectat la un alt telefon. Va trebui să mergeți la Setări > Bluetooth și să uitați dispozitivul pentru a finaliza procesul.';
 
   @override
   String get unpair => 'Deconectează';
@@ -2562,8 +2510,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get howDoesItWork => 'Cum funcționează?';
 
   @override
-  String get sdCardSyncDescription =>
-      'Sincronizarea cardului SD va importa amintirile tale de pe cardul SD în aplicație';
+  String get sdCardSyncDescription => 'Sincronizarea cardului SD va importa amintirile tale de pe cardul SD în aplicație';
 
   @override
   String get checksForAudioFiles => 'Verifică fișierele audio de pe cardul SD';
@@ -2578,8 +2525,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get youreAllSet => 'Sunteți gata!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Bun venit la Omi! Companionul tău AI este gata să te ajute cu conversații, sarcini și multe altele.';
+  String get welcomeToOmiDescription => 'Bun venit la Omi! Companionul tău AI este gata să te ajute cu conversații, sarcini și multe altele.';
 
   @override
   String get startUsingOmi => 'Începeți să folosiți Omi';
@@ -2658,8 +2604,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get reviewAndManageConversations => 'Revizuiește și gestionează conversațiile înregistrate';
 
   @override
-  String get startCapturingConversations =>
-      'Începe să capturezi conversații cu dispozitivul Omi pentru a le vedea aici.';
+  String get startCapturingConversations => 'Începe să capturezi conversații cu dispozitivul Omi pentru a le vedea aici.';
 
   @override
   String get useMobileAppToCapture => 'Folosește aplicația mobilă pentru a captura audio';
@@ -2674,8 +2619,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showAll => 'Arată tot →';
 
   @override
-  String get noTasksForToday =>
-      'Nicio sarcină pentru astăzi.\nÎntrebați Omi pentru mai multe sarcini sau creați manual.';
+  String get noTasksForToday => 'Nicio sarcină pentru astăzi.\nÎntrebați Omi pentru mai multe sarcini sau creați manual.';
 
   @override
   String get dailyScore => 'SCOR ZILNIC';
@@ -2717,8 +2661,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noTasksYet => 'Încă nu există sarcini';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Sarcinile din conversațiile dvs. vor apărea aici.\nFaceți clic pe Creați pentru a adăuga una manual.';
+  String get tasksFromConversationsWillAppear => 'Sarcinile din conversațiile dvs. vor apărea aici.\nFaceți clic pe Creați pentru a adăuga una manual.';
 
   @override
   String get monthJan => 'Ian';
@@ -2775,8 +2718,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteActionItem => 'Șterge elementul de acțiune';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Sigur doriți să ștergeți acest element de acțiune? Această acțiune nu poate fi anulată.';
+  String get deleteActionItemConfirmation => 'Sigur doriți să ștergeți acest element de acțiune? Această acțiune nu poate fi anulată.';
 
   @override
   String get enterActionItemDescription => 'Introduceți descrierea elementului de acțiune...';
@@ -2818,8 +2760,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get checkBackLaterForNewApps => 'Reveniți mai târziu pentru aplicații noi';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'Vă rugăm să verificați conexiunea la internet și să încercați din nou';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'Vă rugăm să verificați conexiunea la internet și să încercați din nou';
 
   @override
   String get createNewApp => 'Creează Aplicație Nouă';
@@ -2852,15 +2793,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chatPrompt => 'Solicitare Chat';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ești o aplicație grozavă, treaba ta este să răspunzi la întrebările utilizatorilor și să-i faci să se simtă bine...';
+  String get chatPromptPlaceholder => 'Ești o aplicație grozavă, treaba ta este să răspunzi la întrebările utilizatorilor și să-i faci să se simtă bine...';
 
   @override
   String get conversationPrompt => 'Prompt de conversație';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Ești o aplicație grozavă, vei primi o transcriere și un rezumat al unei conversații...';
+  String get conversationPromptPlaceholder => 'Ești o aplicație grozavă, vei primi o transcriere și un rezumat al unei conversații...';
 
   @override
   String get notificationScopes => 'Domenii de Notificare';
@@ -2872,8 +2811,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get makeMyAppPublic => 'Fă aplicația mea publică';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Prin trimiterea acestei aplicații, sunt de acord cu Termenii de Serviciu și Politica de Confidențialitate Omi AI';
+  String get submitAppTermsAgreement => 'Prin trimiterea acestei aplicații, sunt de acord cu Termenii de Serviciu și Politica de Confidențialitate Omi AI';
 
   @override
   String get submitApp => 'Trimite Aplicația';
@@ -2888,12 +2826,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get submitAppQuestion => 'Trimite Aplicația?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Aplicația ta va fi revizuită și făcută publică. Poți începe să o folosești imediat, chiar și în timpul reviziei!';
+  String get submitAppPublicDescription => 'Aplicația ta va fi revizuită și făcută publică. Poți începe să o folosești imediat, chiar și în timpul reviziei!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Aplicația ta va fi revizuită și pusă la dispoziția ta în mod privat. Poți începe să o folosești imediat, chiar și în timpul reviziei!';
+  String get submitAppPrivateDescription => 'Aplicația ta va fi revizuită și pusă la dispoziția ta în mod privat. Poți începe să o folosești imediat, chiar și în timpul reviziei!';
 
   @override
   String get startEarning => 'Începe să Câștigi! 💰';
@@ -2917,23 +2853,19 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dataAccessNotice => 'Notificare acces la date';
 
   @override
-  String get dataAccessWarning =>
-      'Această aplicație va accesa datele dvs. Omi AI nu este responsabil pentru modul în care datele dvs. sunt utilizate, modificate sau șterse de această aplicație';
+  String get dataAccessWarning => 'Această aplicație va accesa datele dvs. Omi AI nu este responsabil pentru modul în care datele dvs. sunt utilizate, modificate sau șterse de această aplicație';
 
   @override
   String get installApp => 'Instalează aplicația';
 
   @override
-  String get betaTesterNotice =>
-      'Ești tester beta pentru această aplicație. Nu este încă publică. Va fi publică odată ce va fi aprobată.';
+  String get betaTesterNotice => 'Ești tester beta pentru această aplicație. Nu este încă publică. Va fi publică odată ce va fi aprobată.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Aplicația ta este în curs de revizuire și vizibilă doar pentru tine. Va fi publică odată ce va fi aprobată.';
+  String get appUnderReviewOwner => 'Aplicația ta este în curs de revizuire și vizibilă doar pentru tine. Va fi publică odată ce va fi aprobată.';
 
   @override
-  String get appRejectedNotice =>
-      'Aplicația ta a fost respinsă. Te rugăm să actualizezi detaliile aplicației și să o trimiți din nou pentru revizuire.';
+  String get appRejectedNotice => 'Aplicația ta a fost respinsă. Te rugăm să actualizezi detaliile aplicației și să o trimiți din nou pentru revizuire.';
 
   @override
   String get setupSteps => 'Pași de configurare';
@@ -2968,8 +2900,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get errorActivatingApp => 'Eroare la activarea aplicației';
 
   @override
-  String get integrationSetupRequired =>
-      'Dacă aceasta este o aplicație de integrare, asigurați-vă că configurarea este completă.';
+  String get integrationSetupRequired => 'Dacă aceasta este o aplicație de integrare, asigurați-vă că configurarea este completă.';
 
   @override
   String get installed => 'Instalat';
@@ -2996,8 +2927,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get descriptionLabel => 'Descriere';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Aplicația mea minunată este o aplicație grozavă care face lucruri uimitoare. Este cea mai bună aplicație!';
+  String get appDescriptionPlaceholder => 'Aplicația mea minunată este o aplicație grozavă care face lucruri uimitoare. Este cea mai bună aplicație!';
 
   @override
   String get pleaseProvideValidDescription => 'Vă rugăm să furnizați o descriere validă';
@@ -3149,8 +3079,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get microphonePermissionRequired => 'Permisiunea microfonului este necesară pentru înregistrarea vocală.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Permisiunea microfonului refuzată. Vă rugăm să acordați permisiunea în Preferințe sistem > Confidențialitate și securitate > Microfon.';
+  String get microphonePermissionDenied => 'Permisiunea microfonului refuzată. Vă rugăm să acordați permisiunea în Preferințe sistem > Confidențialitate și securitate > Microfon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3309,8 +3238,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get createMemory => 'Creează amintire';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Ești sigur că vrei să ștergi această amintire? Această acțiune nu poate fi anulată.';
+  String get deleteMemoryConfirmation => 'Ești sigur că vrei să ștergi această amintire? Această acțiune nu poate fi anulată.';
 
   @override
   String get makePrivate => 'Fă privat';
@@ -3384,8 +3312,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get whatWeCollect => 'Ce colectăm';
 
   @override
-  String get dataCollectionMessage =>
-      'Continuând, conversațiile, înregistrările și informațiile personale vor fi stocate în siguranță pe serverele noastre pentru a oferi informații alimentate de AI și a activa toate funcțiile aplicației.';
+  String get dataCollectionMessage => 'Continuând, conversațiile, înregistrările și informațiile personale vor fi stocate în siguranță pe serverele noastre pentru a oferi informații alimentate de AI și a activa toate funcțiile aplicației.';
 
   @override
   String get dataProtection => 'Protecția datelor';
@@ -3418,8 +3345,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Numele trebuie să aibă cel puțin 2 caractere';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Spuneți-ne cum doriți să fiți adresat. Acest lucru ajută la personalizarea experienței Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Spuneți-ne cum doriți să fiți adresat. Acest lucru ajută la personalizarea experienței Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3427,8 +3353,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Activați funcțiile pentru cea mai bună experiență Omi pe dispozitivul dvs.';
+  String get enableFeaturesForBestExperience => 'Activați funcțiile pentru cea mai bună experiență Omi pe dispozitivul dvs.';
 
   @override
   String get microphoneAccess => 'Acces la microfon';
@@ -3437,8 +3362,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get recordAudioConversations => 'Înregistrați conversații audio';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi are nevoie de acces la microfon pentru a înregistra conversațiile dvs. și a furniza transcripții.';
+  String get microphoneAccessDescription => 'Omi are nevoie de acces la microfon pentru a înregistra conversațiile dvs. și a furniza transcripții.';
 
   @override
   String get screenRecording => 'Înregistrare ecran';
@@ -3447,8 +3371,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Capturați audio-ul sistemului din întâlniri';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi are nevoie de permisiune de înregistrare a ecranului pentru a captura audio-ul sistemului din întâlnirile dvs. bazate pe browser.';
+  String get screenRecordingDescription => 'Omi are nevoie de permisiune de înregistrare a ecranului pentru a captura audio-ul sistemului din întâlnirile dvs. bazate pe browser.';
 
   @override
   String get accessibility => 'Accesibilitate';
@@ -3457,8 +3380,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Detectați întâlnirile bazate pe browser';
 
   @override
-  String get accessibilityDescription =>
-      'Omi are nevoie de permisiune de accesibilitate pentru a detecta când vă alăturați întâlnirilor Zoom, Meet sau Teams în browser-ul dvs.';
+  String get accessibilityDescription => 'Omi are nevoie de permisiune de accesibilitate pentru a detecta când vă alăturați întâlnirilor Zoom, Meet sau Teams în browser-ul dvs.';
 
   @override
   String get pleaseWait => 'Vă rugăm așteptați...';
@@ -3527,12 +3449,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get exportAllConversationsToJson => 'Exportați toate conversațiile dvs. într-un fișier JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Export conversații pornit. Aceasta poate dura câteva secunde, vă rugăm așteptați.';
+  String get conversationsExportStarted => 'Export conversații pornit. Aceasta poate dura câteva secunde, vă rugăm așteptați.';
 
   @override
-  String get mcpDescription =>
-      'Pentru a conecta Omi cu alte aplicații pentru a citi, căuta și gestiona amintirile și conversațiile dvs. Creați o cheie pentru a începe.';
+  String get mcpDescription => 'Pentru a conecta Omi cu alte aplicații pentru a citi, căuta și gestiona amintirile și conversațiile dvs. Creați o cheie pentru a începe.';
 
   @override
   String get apiKeys => 'Chei API';
@@ -3573,15 +3493,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Starea diagnostică a serviciului de transcriere';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Activați mesajele de diagnostic detaliate de la serviciul de transcriere';
+  String get enableDetailedDiagnosticMessages => 'Activați mesajele de diagnostic detaliate de la serviciul de transcriere';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Creați și etich etați automat vorbitori noi';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Creați automat o persoană nouă când un nume este detectat în transcriere.';
+  String get automaticallyCreateNewPerson => 'Creați automat o persoană nouă când un nume este detectat în transcriere.';
 
   @override
   String get pilotFeatures => 'Funcții pilot';
@@ -3605,8 +3523,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get auto => 'Automat';
 
   @override
-  String get noSummaryForApp =>
-      'Nu există rezumat disponibil pentru această aplicație. Încearcă altă aplicație pentru rezultate mai bune.';
+  String get noSummaryForApp => 'Nu există rezumat disponibil pentru această aplicație. Încearcă altă aplicație pentru rezultate mai bune.';
 
   @override
   String get tryAnotherApp => 'Încercați o altă aplicație';
@@ -3643,8 +3560,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Lăsați Omi să aleagă automat cea mai bună aplicație';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Sigur doriți să ștergeți această conversație? Această acțiune nu poate fi anulată.';
+  String get deleteConversationConfirmation => 'Sigur doriți să ștergeți această conversație? Această acțiune nu poate fi anulată.';
 
   @override
   String get conversationDeleted => 'Conversație ștearsă';
@@ -3692,8 +3608,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Pregătirea capturării audio a sistemului';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Faceți clic pe buton pentru a captura audio pentru transcrieri live, informații AI și salvare automată.';
+  String get clickTheButtonToCaptureAudio => 'Faceți clic pe buton pentru a captura audio pentru transcrieri live, informații AI și salvare automată.';
 
   @override
   String get reconnecting => 'Reconectare...';
@@ -3896,8 +3811,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shortcuts => 'Comenzi rapide';
 
   @override
-  String get shortcutChangeInstruction =>
-      'Faceți clic pe o comandă rapidă pentru a o modifica. Apăsați Escape pentru a anula.';
+  String get shortcutChangeInstruction => 'Faceți clic pe o comandă rapidă pentru a o modifica. Apăsați Escape pentru a anula.';
 
   @override
   String get configureSTTProvider => 'Configurați furnizorul STT';
@@ -3921,8 +3835,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Ștergeți graficul de cunoștințe?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Aceasta va șterge toate datele derivate din graficul de cunoștințe. Amintirile dvs. originale rămân în siguranță.';
+  String get deleteKnowledgeGraphWarning => 'Aceasta va șterge toate datele derivate din graficul de cunoștințe. Amintirile dvs. originale rămân în siguranță.';
 
   @override
   String get connectOmiWithAI => 'Conectați Omi cu asistenți AI';
@@ -3979,8 +3892,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get updateAppQuestion => 'Actualizați aplicația?';
 
   @override
-  String get updateAppConfirmation =>
-      'Sunteți sigur că doriți să actualizați aplicația? Modificările vor fi vizibile după examinarea de către echipa noastră.';
+  String get updateAppConfirmation => 'Sunteți sigur că doriți să actualizați aplicația? Modificările vor fi vizibile după examinarea de către echipa noastră.';
 
   @override
   String get updateApp => 'Actualizare aplicație';
@@ -4010,8 +3922,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get no => 'Nu';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abonament anulat cu succes. Va rămâne activ până la sfârșitul perioadei curente de facturare.';
+  String get subscriptionCancelledSuccessfully => 'Abonament anulat cu succes. Va rămâne activ până la sfârșitul perioadei curente de facturare.';
 
   @override
   String get failedToCancelSubscription => 'Anularea abonamentului a eșuat. Vă rugăm să încercați din nou.';
@@ -4047,8 +3958,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Anulați abonamentul?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Sunteți sigur că doriți să vă anulați abonamentul? Veți avea în continuare acces până la sfârșitul perioadei curente de facturare.';
+  String get cancelSubscriptionConfirmation => 'Sunteți sigur că doriți să vă anulați abonamentul? Veți avea în continuare acces până la sfârșitul perioadei curente de facturare.';
 
   @override
   String get cancelSubscriptionButton => 'Anulare abonament';
@@ -4057,16 +3967,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get cancelling => 'Se anulează...';
 
   @override
-  String get betaTesterMessage =>
-      'Sunteți un tester beta pentru această aplicație. Nu este încă publică. Va fi publică după aprobare.';
+  String get betaTesterMessage => 'Sunteți un tester beta pentru această aplicație. Nu este încă publică. Va fi publică după aprobare.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Aplicația dvs. este în curs de examinare și vizibilă doar pentru dvs. Va fi publică după aprobare.';
+  String get appUnderReviewMessage => 'Aplicația dvs. este în curs de examinare și vizibilă doar pentru dvs. Va fi publică după aprobare.';
 
   @override
-  String get appRejectedMessage =>
-      'Aplicația dvs. a fost respinsă. Actualizați detaliile și retrimiteți pentru examinare.';
+  String get appRejectedMessage => 'Aplicația dvs. a fost respinsă. Actualizați detaliile și retrimiteți pentru examinare.';
 
   @override
   String get invalidIntegrationUrl => 'URL de integrare invalid';
@@ -4120,8 +4027,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get issueActivatingApp => 'A apărut o problemă la activarea acestei aplicații. Vă rugăm să încercați din nou.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Datele tale sunt procesate în siguranță conform setărilor de confidențialitate';
+  String get dataAccessNoticeDescription => 'Datele tale sunt procesate în siguranță conform setărilor de confidențialitate';
 
   @override
   String get copyUrl => 'Copiază URL';
@@ -4209,8 +4115,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get omiApiKeys => 'Chei API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Cheile API sunt folosite pentru autentificare atunci când aplicația ta comunică cu serverul OMI. Ele permit aplicației tale să creeze amintiri și să acceseze alte servicii OMI în siguranță.';
+  String get apiKeysDescription => 'Cheile API sunt folosite pentru autentificare atunci când aplicația ta comunică cu serverul OMI. Ele permit aplicației tale să creeze amintiri și să acceseze alte servicii OMI în siguranță.';
 
   @override
   String get aboutOmiApiKeys => 'Despre cheile API Omi';
@@ -4234,8 +4139,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Revoci cheia API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Această acțiune nu poate fi anulată. Orice aplicații care folosesc această cheie nu vor mai putea accesa API-ul.';
+  String get revokeApiKeyWarning => 'Această acțiune nu poate fi anulată. Orice aplicații care folosesc această cheie nu vor mai putea accesa API-ul.';
 
   @override
   String get revoke => 'Revocă';
@@ -4333,8 +4237,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get externalAppAccess => 'Acces aplicații externe';
 
   @override
-  String get externalAppAccessDescription =>
-      'Următoarele aplicații instalate au integrări externe și pot accesa datele tale, cum ar fi conversațiile și amintirile.';
+  String get externalAppAccessDescription => 'Următoarele aplicații instalate au integrări externe și pot accesa datele tale, cum ar fi conversațiile și amintirile.';
 
   @override
   String get noExternalAppsHaveAccess => 'Nicio aplicație externă nu are acces la datele tale.';
@@ -4343,8 +4246,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get maximumSecurityE2ee => 'Securitate maximă (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Criptarea end-to-end este standardul de aur pentru confidențialitate. Când este activată, datele dvs. sunt criptate pe dispozitivul dvs. înainte de a fi trimise la serverele noastre. Aceasta înseamnă că nimeni, nici măcar Omi, nu poate accesa conținutul dvs.';
+  String get e2eeDescription => 'Criptarea end-to-end este standardul de aur pentru confidențialitate. Când este activată, datele dvs. sunt criptate pe dispozitivul dvs. înainte de a fi trimise la serverele noastre. Aceasta înseamnă că nimeni, nici măcar Omi, nu poate accesa conținutul dvs.';
 
   @override
   String get importantTradeoffs => 'Compromisuri importante:';
@@ -4359,8 +4261,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get featureComingSoon => 'Această funcție va fi disponibilă în curând!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migrație în curs. Nu puteți schimba nivelul de protecție până la finalizare.';
+  String get migrationInProgressMessage => 'Migrație în curs. Nu puteți schimba nivelul de protecție până la finalizare.';
 
   @override
   String get migrationFailed => 'Migrația a eșuat';
@@ -4379,19 +4280,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get secureEncryption => 'Criptare securizată';
 
   @override
-  String get secureEncryptionDescription =>
-      'Datele dvs. sunt criptate cu o cheie unică pentru dvs. pe serverele noastre, găzduite pe Google Cloud. Aceasta înseamnă că conținutul dvs. brut este inaccesibil pentru oricine, inclusiv personalul Omi sau Google, direct din baza de date.';
+  String get secureEncryptionDescription => 'Datele dvs. sunt criptate cu o cheie unică pentru dvs. pe serverele noastre, găzduite pe Google Cloud. Aceasta înseamnă că conținutul dvs. brut este inaccesibil pentru oricine, inclusiv personalul Omi sau Google, direct din baza de date.';
 
   @override
   String get endToEndEncryption => 'Criptare end-to-end';
 
   @override
-  String get e2eeCardDescription =>
-      'Activați pentru securitate maximă, unde doar dvs. puteți accesa datele dvs. Atingeți pentru a afla mai multe.';
+  String get e2eeCardDescription => 'Activați pentru securitate maximă, unde doar dvs. puteți accesa datele dvs. Atingeți pentru a afla mai multe.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Indiferent de nivel, datele dvs. sunt întotdeauna criptate în repaus și în tranzit.';
+  String get dataAlwaysEncrypted => 'Indiferent de nivel, datele dvs. sunt întotdeauna criptate în repaus și în tranzit.';
 
   @override
   String get readOnlyScope => 'Doar citire';
@@ -4456,12 +4354,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trainingDataProgram => 'Program de date de antrenament';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Obțineți Omi Unlimited gratuit contribuind cu datele dvs. pentru antrenarea modelelor AI.';
+  String get getOmiUnlimitedFree => 'Obțineți Omi Unlimited gratuit contribuind cu datele dvs. pentru antrenarea modelelor AI.';
 
   @override
-  String get trainingDataBullets =>
-      '• Datele dvs. ajută la îmbunătățirea modelelor AI\n• Sunt partajate doar date nesensibile\n• Proces complet transparent';
+  String get trainingDataBullets => '• Datele dvs. ajută la îmbunătățirea modelelor AI\n• Sunt partajate doar date nesensibile\n• Proces complet transparent';
 
   @override
   String get learnMoreAtOmiTraining => 'Aflați mai multe la omi.me/training';
@@ -4473,8 +4369,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get submitRequest => 'Trimite cererea';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Mulțumim! Cererea dvs. este în curs de examinare. Vă vom notifica după aprobare.';
+  String get thankYouRequestUnderReview => 'Mulțumim! Cererea dvs. este în curs de examinare. Vă vom notifica după aprobare.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4512,8 +4407,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get monthlyPlanContinues => 'Planul dvs. lunar actual va continua până la sfârșitul perioadei de facturare';
 
   @override
-  String get paymentMethodCharged =>
-      'Metoda dvs. de plată existentă va fi debitată automat când planul lunar se încheie';
+  String get paymentMethodCharged => 'Metoda dvs. de plată existentă va fi debitată automat când planul lunar se încheie';
 
   @override
   String get annualSubscriptionStarts => 'Abonamentul dvs. anual de 12 luni va începe automat după debitare';
@@ -4623,8 +4517,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Confidențialitatea ta ne interesează';
 
   @override
-  String get privacyIntroText =>
-      'La Omi, luăm foarte în serios confidențialitatea ta. Vrem să fim transparenți despre datele pe care le colectăm și cum le folosim. Iată ce trebuie să știi:';
+  String get privacyIntroText => 'La Omi, luăm foarte în serios confidențialitatea ta. Vrem să fim transparenți despre datele pe care le colectăm și cum le folosim. Iată ce trebuie să știi:';
 
   @override
   String get whatWeTrack => 'Ce urmărim';
@@ -4639,12 +4532,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get ourCommitment => 'Angajamentul nostru';
 
   @override
-  String get commitmentText =>
-      'Ne angajăm să folosim datele pe care le colectăm doar pentru a face Omi un produs mai bun pentru tine. Confidențialitatea și încrederea ta sunt primordiale pentru noi.';
+  String get commitmentText => 'Ne angajăm să folosim datele pe care le colectăm doar pentru a face Omi un produs mai bun pentru tine. Confidențialitatea și încrederea ta sunt primordiale pentru noi.';
 
   @override
-  String get thankYouText =>
-      'Îți mulțumim că ești un utilizator valoros al Omi. Dacă ai întrebări sau nelămuriri, nu ezita să ne contactezi la team@basedhardware.com.';
+  String get thankYouText => 'Îți mulțumim că ești un utilizator valoros al Omi. Dacă ai întrebări sau nelămuriri, nu ezita să ne contactezi la team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Setări sincronizare WiFi';
@@ -4653,8 +4544,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get enterHotspotCredentials => 'Introduceți datele hotspot-ului telefonului';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'Sincronizarea WiFi folosește telefonul ca hotspot. Găsește numele și parola în Setări > Hotspot personal.';
+  String get wifiSyncUsesHotspot => 'Sincronizarea WiFi folosește telefonul ca hotspot. Găsește numele și parola în Setări > Hotspot personal.';
 
   @override
   String get hotspotNameSsid => 'Nume hotspot (SSID)';
@@ -4689,8 +4579,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nu s-a putut genera rezumatul. Asigură-te că ai conversații pentru acea zi.';
+  String get failedToGenerateSummaryCheckConversations => 'Nu s-a putut genera rezumatul. Asigură-te că ai conversații pentru acea zi.';
 
   @override
   String get summaryNotFound => 'Rezumatul nu a fost găsit';
@@ -4720,8 +4609,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Export început. Poate dura câteva secunde...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Aceasta va șterge toate datele derivate ale graficului cunoștințelor (noduri și conexiuni). Amintirile tale originale vor rămâne în siguranță. Graficul va fi reconstruit în timp sau la următoarea solicitare.';
+  String get knowledgeGraphDeleteDescription => 'Aceasta va șterge toate datele derivate ale graficului cunoștințelor (noduri și conexiuni). Amintirile tale originale vor rămâne în siguranță. Graficul va fi reconstruit în timp sau la următoarea solicitare.';
 
   @override
   String get configureDailySummaryDigest => 'Configurați rezumatul zilnic al sarcinilor';
@@ -4791,8 +4679,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Ștergeți toate conversațiile Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Aceasta va șterge permanent toate conversațiile importate din Limitless. Această acțiune nu poate fi anulată.';
+  String get deleteAllLimitlessWarning => 'Aceasta va șterge permanent toate conversațiile importate din Limitless. Această acțiune nu poate fi anulată.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4848,8 +4735,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get howItWorksTitle => 'Cum funcționează?';
 
   @override
-  String get howPeopleWorks =>
-      'Odată ce o persoană este creată, puteți merge la transcripția unei conversații și să le atribuiți segmentele corespunzătoare, astfel Omi va putea recunoaște și vocea lor!';
+  String get howPeopleWorks => 'Odată ce o persoană este creată, puteți merge la transcripția unei conversații și să le atribuiți segmentele corespunzătoare, astfel Omi va putea recunoaște și vocea lor!';
 
   @override
   String get tapToDelete => 'Atingeți pentru a șterge';
@@ -4875,8 +4761,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get privacyNotice => 'Notificare de confidențialitate';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Înregistrările pot captura vocile altora. Asigurați-vă că aveți consimțământul tuturor participanților înainte de activare.';
+  String get recordingsMayCaptureOthers => 'Înregistrările pot captura vocile altora. Asigurați-vă că aveți consimțământul tuturor participanților înainte de activare.';
 
   @override
   String get enable => 'Activează';
@@ -4888,8 +4773,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get on => 'Pornit';
 
   @override
-  String get storeAudioDescription =>
-      'Păstrați toate înregistrările audio stocate local pe telefon. Când este dezactivat, doar încărcările eșuate sunt păstrate pentru a economisi spațiu.';
+  String get storeAudioDescription => 'Păstrați toate înregistrările audio stocate local pe telefon. Când este dezactivat, doar încărcările eșuate sunt păstrate pentru a economisi spațiu.';
 
   @override
   String get enableLocalStorage => 'Activare stocare locală';
@@ -4907,12 +4791,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get storeAudioOnCloud => 'Stochează audio în cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Înregistrările dvs. în timp real vor fi stocate în spațiul de stocare cloud privat în timp ce vorbiți.';
+  String get cloudStorageDialogMessage => 'Înregistrările dvs. în timp real vor fi stocate în spațiul de stocare cloud privat în timp ce vorbiți.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Stocați înregistrările în timp real în spațiul de stocare cloud privat în timp ce vorbiți. Audio este capturat și salvat în siguranță în timp real.';
+  String get storeAudioCloudDescription => 'Stocați înregistrările în timp real în spațiul de stocare cloud privat în timp ce vorbiți. Audio este capturat și salvat în siguranță în timp real.';
 
   @override
   String get downloadingFirmware => 'Se descarcă firmware-ul';
@@ -4921,8 +4803,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get installingFirmware => 'Se instalează firmware-ul';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Nu închideți aplicația și nu opriți dispozitivul. Acest lucru ar putea deteriora dispozitivul.';
+  String get firmwareUpdateWarning => 'Nu închideți aplicația și nu opriți dispozitivul. Acest lucru ar putea deteriora dispozitivul.';
 
   @override
   String get firmwareUpdated => 'Firmware actualizat';
@@ -4966,8 +4847,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get payments => 'Plăți';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Conectați o metodă de plată mai jos pentru a începe să primiți plăți pentru aplicațiile dvs.';
+  String get connectPaymentMethodInfo => 'Conectați o metodă de plată mai jos pentru a începe să primiți plăți pentru aplicațiile dvs.';
 
   @override
   String get selectedPaymentMethod => 'Metodă de plată selectată';
@@ -5021,8 +4901,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get connectingYourStripeAccount => 'Conectarea contului dvs. Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Vă rugăm să finalizați procesul de integrare Stripe în browserul dvs. Această pagină se va actualiza automat după finalizare.';
+  String get stripeOnboardingInstructions => 'Vă rugăm să finalizați procesul de integrare Stripe în browserul dvs. Această pagină se va actualiza automat după finalizare.';
 
   @override
   String get failedTryAgain => 'A eșuat? Încercați din nou';
@@ -5034,15 +4913,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get successfullyConnected => 'Conectat cu succes!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Contul dvs. Stripe este acum gata să primească plăți. Puteți începe să câștigați din vânzările aplicațiilor imediat.';
+  String get stripeReadyForPayments => 'Contul dvs. Stripe este acum gata să primească plăți. Puteți începe să câștigați din vânzările aplicațiilor imediat.';
 
   @override
   String get updateStripeDetails => 'Actualizați detaliile Stripe';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Eroare la actualizarea detaliilor Stripe! Vă rugăm să încercați din nou mai târziu.';
+  String get errorUpdatingStripeDetails => 'Eroare la actualizarea detaliilor Stripe! Vă rugăm să încercați din nou mai târziu.';
 
   @override
   String get updatePayPal => 'Actualizați PayPal';
@@ -5054,8 +4931,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Actualizați detaliile contului dvs. PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Conectați contul dvs. PayPal pentru a începe să primiți plăți pentru aplicațiile dvs.';
+  String get connectPayPalToReceivePayments => 'Conectați contul dvs. PayPal pentru a începe să primiți plăți pentru aplicațiile dvs.';
 
   @override
   String get paypalEmail => 'E-mail PayPal';
@@ -5064,8 +4940,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get paypalMeLink => 'Link PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Dacă Stripe este disponibil în țara dvs., vă recomandăm cu tărie să îl utilizați pentru plăți mai rapide și mai ușoare.';
+  String get stripeRecommendation => 'Dacă Stripe este disponibil în țara dvs., vă recomandăm cu tărie să îl utilizați pentru plăți mai rapide și mai ușoare.';
 
   @override
   String get updatePayPalDetails => 'Actualizați detaliile PayPal';
@@ -5117,12 +4992,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Mostră vocală suplimentară eliminată';
 
   @override
-  String get consentDataMessage =>
-      'Continuând, conversațiile, înregistrările și informațiile dvs. personale vor fi stocate în siguranță pe serverele noastre. Înregistrările audio și transcrierile dvs. sunt procesate de servicii AI terțe (inclusiv Deepgram pentru transcriere și OpenAI pentru analiză) pentru a vă oferi informații bazate pe AI și a activa toate funcțiile aplicației.';
+  String get consentDataMessage => 'Continuând, conversațiile, înregistrările și informațiile dvs. personale vor fi stocate în siguranță pe serverele noastre. Înregistrările audio și transcrierile dvs. sunt procesate de servicii AI terțe (inclusiv Deepgram pentru transcriere și OpenAI pentru analiză) pentru a vă oferi informații bazate pe AI și a activa toate funcțiile aplicației.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Sarcinile din conversațiile tale vor apărea aici.\nAtinge + pentru a crea una manual.';
+  String get tasksEmptyStateMessage => 'Sarcinile din conversațiile tale vor apărea aici.\nAtinge + pentru a crea una manual.';
 
   @override
   String get clearChatAction => 'Șterge conversația';
@@ -5158,15 +5031,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Instalează Omi pe\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Pentru a utiliza Apple Watch cu Omi, trebuie să instalezi mai întâi aplicația Omi pe ceas.';
+  String get installOmiOnAppleWatchDescription => 'Pentru a utiliza Apple Watch cu Omi, trebuie să instalezi mai întâi aplicația Omi pe ceas.';
 
   @override
   String get openOmiOnAppleWatch => 'Deschide Omi pe\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Aplicația Omi este instalată pe Apple Watch. Deschide-o și apasă Start pentru a începe.';
+  String get openOmiOnAppleWatchDescription => 'Aplicația Omi este instalată pe Apple Watch. Deschide-o și apasă Start pentru a începe.';
 
   @override
   String get openWatchApp => 'Deschide aplicația Watch';
@@ -5175,15 +5046,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Am instalat și deschis aplicația';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Nu se poate deschide aplicația Apple Watch. Deschide manual aplicația Watch pe Apple Watch și instalează Omi din secțiunea \"Aplicații disponibile\".';
+  String get unableToOpenWatchApp => 'Nu se poate deschide aplicația Apple Watch. Deschide manual aplicația Watch pe Apple Watch și instalează Omi din secțiunea \"Aplicații disponibile\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch conectat cu succes!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch încă nu este accesibil. Asigură-te că aplicația Omi este deschisă pe ceas.';
+  String get appleWatchNotReachable => 'Apple Watch încă nu este accesibil. Asigură-te că aplicația Omi este deschisă pe ceas.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5270,8 +5139,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get welcomeBackSimple => 'Bine ai revenit';
 
   @override
-  String get addVocabularyDescription =>
-      'Adăugați cuvinte pe care Omi ar trebui să le recunoască în timpul transcrierii.';
+  String get addVocabularyDescription => 'Adăugați cuvinte pe care Omi ar trebui să le recunoască în timpul transcrierii.';
 
   @override
   String get enterWordsCommaSeparated => 'Introduceți cuvinte (separate prin virgulă)';
@@ -5612,29 +5480,25 @@ class AppLocalizationsRo extends AppLocalizations {
   String get multipleSpeakersDetected => 'Au fost detectați mai mulți vorbitori';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Se pare că în înregistrare sunt mai mulți vorbitori. Asigurați-vă că sunteți într-un loc liniștit și încercați din nou.';
+  String get multipleSpeakersDescription => 'Se pare că în înregistrare sunt mai mulți vorbitori. Asigurați-vă că sunteți într-un loc liniștit și încercați din nou.';
 
   @override
   String get invalidRecordingDetected => 'Înregistrare invalidă detectată';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Nu a fost detectată suficientă vorbire. Vă rugăm să vorbiți mai mult și să încercați din nou.';
+  String get notEnoughSpeechDescription => 'Nu a fost detectată suficientă vorbire. Vă rugăm să vorbiți mai mult și să încercați din nou.';
 
   @override
   String get speechDurationDescription => 'Asigurați-vă că vorbiți cel puțin 5 secunde și nu mai mult de 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Conexiunea a fost întreruptă. Verificați conexiunea la internet și încercați din nou.';
+  String get connectionLostDescription => 'Conexiunea a fost întreruptă. Verificați conexiunea la internet și încercați din nou.';
 
   @override
   String get howToTakeGoodSample => 'Cum să faci o probă bună?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Asigurați-vă că sunteți într-un loc liniștit.\n2. Vorbiți clar și natural.\n3. Asigurați-vă că dispozitivul dvs. este în poziția sa naturală pe gât.\n\nOdată creat, îl puteți îmbunătăți oricând sau îl puteți face din nou.';
+  String get goodSampleInstructions => '1. Asigurați-vă că sunteți într-un loc liniștit.\n2. Vorbiți clar și natural.\n3. Asigurați-vă că dispozitivul dvs. este în poziția sa naturală pe gât.\n\nOdată creat, îl puteți îmbunătăți oricând sau îl puteți face din nou.';
 
   @override
   String get noDeviceConnectedUseMic => 'Niciun dispozitiv conectat. Se va folosi microfonul telefonului.';
@@ -5697,12 +5561,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get howItWorks => 'Cum funcționează';
 
   @override
-  String get dailyScoreExplanation =>
-      'Scorul tău zilnic se bazează pe finalizarea sarcinilor. Finalizează sarcinile pentru a-ți îmbunătăți scorul!';
+  String get dailyScoreExplanation => 'Scorul tău zilnic se bazează pe finalizarea sarcinilor. Finalizează sarcinile pentru a-ți îmbunătăți scorul!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Controlează cât de des îți trimite Omi notificări proactive și mementouri.';
+  String get notificationFrequencyDescription => 'Controlează cât de des îți trimite Omi notificări proactive și mementouri.';
 
   @override
   String get sliderOff => 'Oprit';
@@ -5795,8 +5657,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get selectApp => 'Selectează aplicația';
 
   @override
-  String get noChatAppsEnabled =>
-      'Nicio aplicație de chat activată.\nApasă pe \"Activează aplicații\" pentru a adăuga.';
+  String get noChatAppsEnabled => 'Nicio aplicație de chat activată.\nApasă pe \"Activează aplicații\" pentru a adăuga.';
 
   @override
   String get disable => 'Dezactivează';
@@ -6003,8 +5864,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get webhookUrlNotSet => 'URL-ul webhook nu este setat';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Te rugăm să setezi URL-ul webhook în setările pentru dezvoltatori pentru a folosi această funcție.';
+  String get setWebhookUrlInSettings => 'Te rugăm să setezi URL-ul webhook în setările pentru dezvoltatori pentru a folosi această funcție.';
 
   @override
   String get sendWebUrl => 'Trimite URL web';
@@ -6078,15 +5938,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get cloudProvider => 'Furnizor cloud';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 minute premium/lună. Fila Pe dispozitiv oferă transcriere gratuită nelimitată.';
+  String get premiumMinutesInfo => '1.200 minute premium/lună. Fila Pe dispozitiv oferă transcriere gratuită nelimitată.';
 
   @override
   String get viewUsage => 'Vizualizați utilizarea';
 
   @override
-  String get localProcessingInfo =>
-      'Audio este procesat local. Funcționează offline, mai privat, dar consumă mai multă baterie.';
+  String get localProcessingInfo => 'Audio este procesat local. Funcționează offline, mai privat, dar consumă mai multă baterie.';
 
   @override
   String get model => 'Model';
@@ -6095,15 +5953,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get performanceWarning => 'Avertisment de performanță';
 
   @override
-  String get largeModelWarning =>
-      'Acest model este mare și poate bloca aplicația sau poate rula foarte lent pe dispozitive mobile.\n\n\"small\" sau \"base\" este recomandat.';
+  String get largeModelWarning => 'Acest model este mare și poate bloca aplicația sau poate rula foarte lent pe dispozitive mobile.\n\n\"small\" sau \"base\" este recomandat.';
 
   @override
   String get usingNativeIosSpeech => 'Utilizarea recunoașterii vocale native iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Se va utiliza motorul de vorbire nativ al dispozitivului. Nu este necesară descărcarea unui model.';
+  String get noModelDownloadRequired => 'Se va utiliza motorul de vorbire nativ al dispozitivului. Nu este necesară descărcarea unui model.';
 
   @override
   String get modelReady => 'Model pregătit';
@@ -6148,8 +6004,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Dispozitiv incompatibil';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'Dispozitivul dvs. nu îndeplinește cerințele pentru transcrierea pe dispozitiv.';
+  String get deviceNotMeetRequirements => 'Dispozitivul dvs. nu îndeplinește cerințele pentru transcrierea pe dispozitiv.';
 
   @override
   String get transcriptionSlowerOnDevice => 'Transcrierea pe dispozitiv poate fi mai lentă pe acest dispozitiv.';
@@ -6161,12 +6016,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get batteryDrainSignificantly => 'Descărcarea bateriei va crește semnificativ.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 minute premium/lună. Fila Pe dispozitiv oferă transcriere gratuită nelimitată. ';
+  String get premiumMinutesMonth => '1.200 minute premium/lună. Fila Pe dispozitiv oferă transcriere gratuită nelimitată. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Audio este procesat local. Funcționează offline, mai privat, dar consumă mai multă baterie.';
+  String get audioProcessedLocally => 'Audio este procesat local. Funcționează offline, mai privat, dar consumă mai multă baterie.';
 
   @override
   String get languageLabel => 'Limbă';
@@ -6175,12 +6028,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Acest model este mare și poate cauza blocarea aplicației sau rulare foarte lentă pe dispozitivele mobile.\n\nsmall sau base este recomandat.';
+  String get modelTooLargeWarning => 'Acest model este mare și poate cauza blocarea aplicației sau rulare foarte lentă pe dispozitivele mobile.\n\nsmall sau base este recomandat.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Motorul vocal nativ al dispozitivului va fi folosit. Nu este necesară descărcarea modelului.';
+  String get nativeEngineNoDownload => 'Motorul vocal nativ al dispozitivului va fi folosit. Nu este necesară descărcarea modelului.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6216,8 +6067,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Transcrierea live integrată a Omi este optimizată pentru conversații în timp real cu detectarea automată a vorbitorului și diarizare.';
+  String get omiTranscriptionOptimized => 'Transcrierea live integrată a Omi este optimizată pentru conversații în timp real cu detectarea automată a vorbitorului și diarizare.';
 
   @override
   String get reset => 'Resetează';
@@ -6437,8 +6287,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Se construiește graficul cunoștințelor din amintiri...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Graficul cunoștințelor va fi construit automat când creați amintiri noi.';
+  String get knowledgeGraphWillBuildAutomatically => 'Graficul cunoștințelor va fi construit automat când creați amintiri noi.';
 
   @override
   String get buildGraphButton => 'Construiește grafic';
@@ -6662,8 +6511,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get contactsPermissionRequiredForSms => 'Permisiunea pentru contacte este necesară pentru partajare prin SMS';
 
   @override
-  String get grantContactsPermissionForSms =>
-      'Vă rugăm să acordați permisiunea pentru contacte pentru a partaja prin SMS';
+  String get grantContactsPermissionForSms => 'Vă rugăm să acordați permisiunea pentru contacte pentru a partaja prin SMS';
 
   @override
   String get noContactsWithPhoneNumbers => 'Nu s-au găsit contacte cu numere de telefon';
@@ -6675,8 +6523,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get failedToLoadContacts => 'Nu s-au putut încărca contactele';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Nu s-a putut pregăti conversația pentru partajare. Vă rugăm să încercați din nou.';
+  String get failedToPrepareConversationForSharing => 'Nu s-a putut pregăti conversația pentru partajare. Vă rugăm să încercați din nou.';
 
   @override
   String get couldNotOpenSmsApp => 'Nu s-a putut deschide aplicația SMS. Vă rugăm să încercați din nou.';
@@ -6742,8 +6589,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Se descarcă audio de pe cardul SD al dispozitivului';
 
   @override
-  String get transferRequiredDescription =>
-      'Această înregistrare este stocată pe cardul SD al dispozitivului. Transferați-o pe telefon pentru a o reda sau partaja.';
+  String get transferRequiredDescription => 'Această înregistrare este stocată pe cardul SD al dispozitivului. Transferați-o pe telefon pentru a o reda sau partaja.';
 
   @override
   String get cancelTransfer => 'Anulează transferul';
@@ -6764,8 +6610,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shareRecording => 'Partajează înregistrarea';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Ești sigur că vrei să ștergi definitiv această înregistrare? Această acțiune nu poate fi anulată.';
+  String get deleteRecordingConfirmation => 'Ești sigur că vrei să ștergi definitiv această înregistrare? Această acțiune nu poate fi anulată.';
 
   @override
   String get recordingIdLabel => 'ID înregistrare';
@@ -6824,15 +6669,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get enableFastTransfer => 'Activează transferul rapid';
 
   @override
-  String get fastTransferDescription =>
-      'Transferul rapid folosește WiFi pentru viteze de ~5x mai rapide. Telefonul se va conecta temporar la rețeaua WiFi a dispozitivului Omi în timpul transferului.';
+  String get fastTransferDescription => 'Transferul rapid folosește WiFi pentru viteze de ~5x mai rapide. Telefonul se va conecta temporar la rețeaua WiFi a dispozitivului Omi în timpul transferului.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Accesul la internet este întrerupt în timpul transferului';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Alegeți cum sunt transferate înregistrările de pe dispozitivul Omi pe telefon.';
+  String get chooseTransferMethodDescription => 'Alegeți cum sunt transferate înregistrările de pe dispozitivul Omi pe telefon.';
 
   @override
   String get wifiSpeed => '~150 KB/s prin WiFi';
@@ -6841,8 +6684,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fiveTimesFaster => 'DE 5X MAI RAPID';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Creează o conexiune WiFi directă la dispozitivul Omi. Telefonul se deconectează temporar de la WiFi-ul obișnuit în timpul transferului.';
+  String get fastTransferMethodDescription => 'Creează o conexiune WiFi directă la dispozitivul Omi. Telefonul se deconectează temporar de la WiFi-ul obișnuit în timpul transferului.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6851,8 +6693,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get bleSpeed => '~30 KB/s prin BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Folosește conexiunea Bluetooth Low Energy standard. Mai lent, dar nu afectează conexiunea WiFi.';
+  String get bluetoothMethodDescription => 'Folosește conexiunea Bluetooth Low Energy standard. Mai lent, dar nu afectează conexiunea WiFi.';
 
   @override
   String get selected => 'Selectat';
@@ -6890,12 +6731,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get appDeleteFailed => 'Nu s-a putut șterge aplicația. Vă rugăm să încercați din nou mai târziu.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Vizibilitatea aplicației a fost schimbată cu succes. Poate dura câteva minute până se reflectă.';
+  String get appVisibilityChangedSuccessfully => 'Vizibilitatea aplicației a fost schimbată cu succes. Poate dura câteva minute până se reflectă.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Eroare la activarea aplicației. Dacă este o aplicație de integrare, asigurați-vă că configurarea este completă.';
+  String get errorActivatingAppIntegration => 'Eroare la activarea aplicației. Dacă este o aplicație de integrare, asigurați-vă că configurarea este completă.';
 
   @override
   String get errorUpdatingAppStatus => 'A apărut o eroare la actualizarea stării aplicației.';
@@ -6975,8 +6814,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Numele trebuie să aibă cel puțin 3 caractere';
 
   @override
-  String get conversationPromptHint =>
-      'ex., Extrageți acțiuni, decizii luate și concluzii cheie din conversația furnizată.';
+  String get conversationPromptHint => 'ex., Extrageți acțiuni, decizii luate și concluzii cheie din conversația furnizată.';
 
   @override
   String get pleaseEnterAppPrompt => 'Vă rugăm să introduceți un prompt pentru aplicația dvs.';
@@ -7163,15 +7001,13 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade programat! Planul tău lunar continuă până la sfârșitul perioadei de facturare, apoi trece automat la anual.';
+  String get planUpgradeScheduledMessage => 'Upgrade programat! Planul tău lunar continuă până la sfârșitul perioadei de facturare, apoi trece automat la anual.';
 
   @override
   String get couldNotSchedulePlanChange => 'Nu s-a putut programa schimbarea planului. Te rugăm să încerci din nou.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Abonamentul tău a fost reactivat! Fără taxă acum - vei fi facturat la sfârșitul perioadei curente.';
+  String get subscriptionReactivatedDefault => 'Abonamentul tău a fost reactivat! Fără taxă acum - vei fi facturat la sfârșitul perioadei curente.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Abonament reușit! Ai fost taxat pentru noua perioadă de facturare.';
@@ -7339,8 +7175,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Nu s-a putut obține tokenul Firebase, vă rugăm încercați din nou.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Eroare neașteptată la autentificare, eroare Firebase, vă rugăm încercați din nou.';
+  String get authUnexpectedErrorFirebase => 'Eroare neașteptată la autentificare, eroare Firebase, vă rugăm încercați din nou.';
 
   @override
   String get authUnexpectedError => 'Eroare neașteptată la autentificare, vă rugăm încercați din nou';
@@ -7355,8 +7190,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Este necesară permisiunea Bluetooth pentru a vă conecta la dispozitiv.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Permisiunea Bluetooth a fost refuzată. Acordați permisiunea în Preferințe Sistem.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Permisiunea Bluetooth a fost refuzată. Acordați permisiunea în Preferințe Sistem.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7369,12 +7203,10 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Permisiunea pentru notificări a fost refuzată. Acordați permisiunea în Preferințe Sistem.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Permisiunea pentru notificări a fost refuzată. Acordați permisiunea în Preferințe Sistem.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Permisiunea pentru notificări a fost refuzată. Acordați permisiunea în Preferințe Sistem > Notificări.';
+  String get onboardingNotificationDeniedNotifications => 'Permisiunea pentru notificări a fost refuzată. Acordați permisiunea în Preferințe Sistem > Notificări.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7387,15 +7219,13 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Acordați permisiunea pentru locație în Setări > Confidențialitate și securitate > Servicii de localizare';
+  String get onboardingLocationGrantInSettings => 'Acordați permisiunea pentru locație în Setări > Confidențialitate și securitate > Servicii de localizare';
 
   @override
   String get onboardingMicrophoneRequired => 'Este necesară permisiunea pentru microfon pentru înregistrare.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Permisiunea pentru microfon a fost refuzată. Acordați permisiunea în Preferințe Sistem > Confidențialitate și securitate > Microfon.';
+  String get onboardingMicrophoneDenied => 'Permisiunea pentru microfon a fost refuzată. Acordați permisiunea în Preferințe Sistem > Confidențialitate și securitate > Microfon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7408,12 +7238,10 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Este necesară permisiunea de captură a ecranului pentru înregistrarea audio a sistemului.';
+  String get onboardingScreenCaptureRequired => 'Este necesară permisiunea de captură a ecranului pentru înregistrarea audio a sistemului.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Permisiunea de captură a ecranului a fost refuzată. Acordați permisiunea în Preferințe Sistem > Confidențialitate și securitate > Înregistrare ecran.';
+  String get onboardingScreenCaptureDenied => 'Permisiunea de captură a ecranului a fost refuzată. Acordați permisiunea în Preferințe Sistem > Confidențialitate și securitate > Înregistrare ecran.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7426,8 +7254,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Este necesară permisiunea de accesibilitate pentru detectarea întâlnirilor din browser.';
+  String get onboardingAccessibilityRequired => 'Este necesară permisiunea de accesibilitate pentru detectarea întâlnirilor din browser.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7467,8 +7294,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Permisiunea pentru fotografii refuzată. Vă rugăm să permiteți accesul la fotografii pentru a selecta imagini';
+  String get msgPhotosPermissionDenied => 'Permisiunea pentru fotografii refuzată. Vă rugăm să permiteți accesul la fotografii pentru a selecta imagini';
 
   @override
   String get msgSelectImagesGenericError => 'Eroare la selectarea imaginilor. Vă rugăm să încercați din nou.';
@@ -7540,8 +7366,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get locationPermissionRequired => 'Permisiune de locație necesară';
 
   @override
-  String get locationPermissionContent =>
-      'Transferul rapid necesită permisiune de locație pentru a verifica conexiunea WiFi. Vă rugăm să acordați permisiunea de locație pentru a continua.';
+  String get locationPermissionContent => 'Transferul rapid necesită permisiune de locație pentru a verifica conexiunea WiFi. Vă rugăm să acordați permisiunea de locație pentru a continua.';
 
   @override
   String get pdfTranscriptExport => 'Export transcriere';
@@ -7704,8 +7529,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Dispozitivul nu acceptă sincronizare WiFi, comutare la Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Dispozitivul nu acceptă sincronizare WiFi, comutare la Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health nu este disponibil pe acest dispozitiv';
@@ -8001,8 +7825,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Puneți Omi DevKit în modul de asociere';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Apăsați butonul o dată pentru a porni. LED-ul va clipi violet în modul de asociere.';
+  String get pairingDescOmiDevkit => 'Apăsați butonul o dată pentru a porni. LED-ul va clipi violet în modul de asociere.';
 
   @override
   String get pairingTitleOmiGlass => 'Porniți Omi Glass';
@@ -8014,8 +7837,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Puneți Plaud Note în modul de asociere';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Apăsați și mențineți apăsat butonul lateral timp de 2 secunde. LED-ul roșu va clipi când este gata de asociere.';
+  String get pairingDescPlaudNote => 'Apăsați și mențineți apăsat butonul lateral timp de 2 secunde. LED-ul roșu va clipi când este gata de asociere.';
 
   @override
   String get pairingTitleBee => 'Puneți Bee în modul de asociere';
@@ -8027,15 +7849,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get pairingTitleLimitless => 'Puneți Limitless în modul de asociere';
 
   @override
-  String get pairingDescLimitless =>
-      'Când orice lumină este vizibilă, apăsați o dată apoi apăsați și mențineți apăsat până când dispozitivul arată o lumină roz, apoi eliberați.';
+  String get pairingDescLimitless => 'Când orice lumină este vizibilă, apăsați o dată apoi apăsați și mențineți apăsat până când dispozitivul arată o lumină roz, apoi eliberați.';
 
   @override
   String get pairingTitleFriendPendant => 'Puneți Friend Pendant în modul de asociere';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Apăsați butonul de pe pandantiv pentru a-l porni. Va intra automat în modul de asociere.';
+  String get pairingDescFriendPendant => 'Apăsați butonul de pe pandantiv pentru a-l porni. Va intra automat în modul de asociere.';
 
   @override
   String get pairingTitleFieldy => 'Puneți Fieldy în modul de asociere';
@@ -8047,15 +7867,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Conectați Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Instalați și deschideți aplicația Omi pe Apple Watch, apoi apăsați Conectare în aplicație.';
+  String get pairingDescAppleWatch => 'Instalați și deschideți aplicația Omi pe Apple Watch, apoi apăsați Conectare în aplicație.';
 
   @override
   String get pairingTitleNeoOne => 'Puneți Neo One în modul de asociere';
 
   @override
-  String get pairingDescNeoOne =>
-      'Apăsați și mențineți apăsat butonul de alimentare până când LED-ul clipește. Dispozitivul va fi detectabil.';
+  String get pairingDescNeoOne => 'Apăsați și mențineți apăsat butonul de alimentare până când LED-ul clipește. Dispozitivul va fi detectabil.';
 
   @override
   String get downloadingFromDevice => 'Se descarcă de pe dispozitiv';
@@ -8125,8 +7943,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get wifiConfiguration => 'Configurare WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Introduceți datele WiFi pentru a permite dispozitivului să descarce firmware-ul.';
+  String get wifiConfigurationSubtitle => 'Introduceți datele WiFi pentru a permite dispozitivului să descarce firmware-ul.';
 
   @override
   String get networkNameSsid => 'Numele rețelei (SSID)';
@@ -8144,8 +7961,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Iată ce știu despre tine';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Această hartă se actualizează pe măsură ce Omi învață din conversațiile tale.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Această hartă se actualizează pe măsură ce Omi învață din conversațiile tale.';
 
   @override
   String get apiEnvironment => 'Mediu API';
@@ -8174,8 +7990,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get switchAndRestart => 'Comută';
 
   @override
-  String get stagingDisclaimer =>
-      'Mediul de testare poate fi instabil, cu performanță inconsistentă și datele pot fi pierdute. Doar pentru testare.';
+  String get stagingDisclaimer => 'Mediul de testare poate fi instabil, cu performanță inconsistentă și datele pot fi pierdute. Doar pentru testare.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Salvat. Închideți și redeschideți aplicația pentru a aplica modificările.';
@@ -8226,8 +8041,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get phoneGetStarted => 'Incepe';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'Inregistrarea apelurilor poate necesita consimtamant in jurisdictia dvs.';
+  String get callRecordingConsentDisclaimer => 'Inregistrarea apelurilor poate necesita consimtamant in jurisdictia dvs.';
 
   @override
   String get enterYourNumber => 'Introduceti numarul dvs.';
@@ -8405,8 +8219,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Apeluri telefonice prin Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Efectuați apeluri prin Omi și obțineți transcriere în timp real, rezumate automate și multe altele.';
+  String get phoneCallsUpsellSubtitle => 'Efectuați apeluri prin Omi și obțineți transcriere în timp real, rezumate automate și multe altele.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transcriere în timp real a fiecărui apel';
@@ -8433,8 +8246,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteSyncedFiles => 'Șterge înregistrările sincronizate';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Aceste înregistrări sunt deja sincronizate cu telefonul dvs. Aceasta nu poate fi anulată.';
+  String get deleteSyncedFilesMessage => 'Aceste înregistrări sunt deja sincronizate cu telefonul dvs. Aceasta nu poate fi anulată.';
 
   @override
   String get syncedFilesDeleted => 'Înregistrările sincronizate au fost șterse';
@@ -8446,8 +8258,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deletePendingFiles => 'Șterge înregistrările în așteptare';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Aceste înregistrări NU sunt sincronizate cu telefonul dvs. și vor fi pierdute permanent. Aceasta nu poate fi anulată.';
+  String get deletePendingFilesWarning => 'Aceste înregistrări NU sunt sincronizate cu telefonul dvs. și vor fi pierdute permanent. Aceasta nu poate fi anulată.';
 
   @override
   String get pendingFilesDeleted => 'Înregistrările în așteptare au fost șterse';
@@ -8459,8 +8270,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deleteAll => 'Șterge tot';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Aceasta va șterge înregistrările sincronizate și în așteptare. Înregistrările în așteptare NU sunt sincronizate și vor fi pierdute permanent.';
+  String get deleteAllFilesWarning => 'Aceasta va șterge înregistrările sincronizate și în așteptare. Înregistrările în așteptare NU sunt sincronizate și vor fi pierdute permanent.';
 
   @override
   String get allFilesDeleted => 'Toate înregistrările au fost șterse';
@@ -8525,8 +8335,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fairUseAboutTitle => 'Despre utilizarea echitabilă';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi este conceput pentru conversații personale, întâlniri și interacțiuni în direct. Utilizarea este măsurată prin timpul real de vorbire detectat, nu prin timpul de conexiune. Dacă utilizarea depășește semnificativ tiparele normale pentru conținut non-personal, se pot aplica ajustări.';
+  String get fairUseAboutBody => 'Omi este conceput pentru conversații personale, întâlniri și interacțiuni în direct. Utilizarea este măsurată prin timpul real de vorbire detectat, nu prin timpul de conexiune. Dacă utilizarea depășește semnificativ tiparele normale pentru conținut non-personal, se pot aplica ajustări.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8564,8 +8373,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get improveConnectionTitle => 'Îmbunătățire conexiune';
 
   @override
-  String get improveConnectionContent =>
-      'Am îmbunătățit modul în care Omi rămâne conectat la dispozitivul tău. Pentru a activa acest lucru, mergi la pagina Informații dispozitiv, apasă \"Deconectare dispozitiv\" și împerechează din nou dispozitivul.';
+  String get improveConnectionContent => 'Am îmbunătățit modul în care Omi rămâne conectat la dispozitivul tău. Pentru a activa acest lucru, mergi la pagina Informații dispozitiv, apasă \"Deconectare dispozitiv\" și împerechează din nou dispozitivul.';
 
   @override
   String get improveConnectionAction => 'Am înțeles';
@@ -8620,16 +8428,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get cancelSyncQuestion => 'Anulezi sincronizarea?';
 
   @override
-  String get omisStorageDesc =>
-      'Când Omi nu este conectat la telefon, stochează audio local în memoria sa integrată. Nu veți pierde niciodată o înregistrare.';
+  String get omisStorageDesc => 'Când Omi nu este conectat la telefon, stochează audio local în memoria sa integrată. Nu veți pierde niciodată o înregistrare.';
 
   @override
-  String get phoneStorageDesc =>
-      'Când Omi se reconectează, înregistrările sunt transferate automat pe telefon înainte de încărcare.';
+  String get phoneStorageDesc => 'Când Omi se reconectează, înregistrările sunt transferate automat pe telefon înainte de încărcare.';
 
   @override
-  String get cloudStorageDesc =>
-      'După încărcare, înregistrările sunt procesate și transcrise. Conversațiile vor fi disponibile într-un minut.';
+  String get cloudStorageDesc => 'După încărcare, înregistrările sunt procesate și transcrise. Conversațiile vor fi disponibile într-un minut.';
 
   @override
   String get tipKeepPhoneNearby => 'Păstrați telefonul aproape pentru sincronizare mai rapidă';
@@ -8653,12 +8458,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get permissionEnable => 'Activare';
 
   @override
-  String get permissionsPageDescription =>
-      'Aceste permisiuni sunt esențiale pentru funcționarea Omi. Ele activează funcții cheie precum notificări, experiențe bazate pe locație și captură audio.';
+  String get permissionsPageDescription => 'Aceste permisiuni sunt esențiale pentru funcționarea Omi. Ele activează funcții cheie precum notificări, experiențe bazate pe locație și captură audio.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi are nevoie de câteva permisiuni pentru a funcționa corect. Te rugăm să le acorzi pentru a continua.';
+  String get permissionsRequiredDescription => 'Omi are nevoie de câteva permisiuni pentru a funcționa corect. Te rugăm să le acorzi pentru a continua.';
 
   @override
   String get permissionsSetupTitle => 'Obține cea mai bună experiență';
@@ -8914,8 +8717,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get enableLocationTitle => 'Activează locația';
 
   @override
-  String get enableLocationDescription =>
-      'Permisiunea de locație este necesară pentru a găsi dispozitivele Bluetooth din apropiere.';
+  String get enableLocationDescription => 'Permisiunea de locație este necesară pentru a găsi dispozitivele Bluetooth din apropiere.';
 
   @override
   String get voiceRecordingFound => 'Înregistrare găsită';
@@ -8936,8 +8738,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get firmwareWarningTitle => 'Important: Citiți înainte de actualizare';
 
   @override
-  String get firmwareFormatWarning =>
-      'Acest firmware va formata cardul SD. Vă rugăm să vă asigurați că toate datele offline sunt sincronizate înainte de actualizare.\n\nDacă vedeți o lumină roșie care clipește după instalarea acestei versiuni, nu vă faceți griji. Pur și simplu conectați dispozitivul la aplicație și ar trebui să devină albastru. Lumina roșie înseamnă că ceasul dispozitivului nu a fost încă sincronizat.';
+  String get firmwareFormatWarning => 'Acest firmware va formata cardul SD. Vă rugăm să vă asigurați că toate datele offline sunt sincronizate înainte de actualizare.\n\nDacă vedeți o lumină roșie care clipește după instalarea acestei versiuni, nu vă faceți griji. Pur și simplu conectați dispozitivul la aplicație și ar trebui să devină albastru. Lumina roșie înseamnă că ceasul dispozitivului nu a fost încă sincronizat.';
 
   @override
   String get continueAnyway => 'Continuă';
@@ -8957,8 +8758,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get tasksMarkComplete => 'Marcat ca finalizat';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi accesează Apple Health prin framework-ul HealthKit de la Apple. Poți revoca accesul oricând din Setările iOS.';
+  String get appleHealthManageNote => 'Omi accesează Apple Health prin framework-ul HealthKit de la Apple. Poți revoca accesul oricând din Setările iOS.';
 
   @override
   String get appleHealthConnectCta => 'Conectează-te la Apple Health';
@@ -8991,8 +8791,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Acces la Apple Health refuzat';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi nu are permisiunea de a citi datele tale Apple Health. Activează din Setări iOS → Confidențialitate și securitate → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi nu are permisiunea de a citi datele tale Apple Health. Activează din Setări iOS → Confidențialitate și securitate → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'De ce pleci?';
@@ -9061,8 +8860,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get planUpdate => 'Actualizare plan';
 
   @override
-  String get planDeprecationMessage =>
-      'Planul dvs. Unlimited este retras. Treceți la planul Operator — aceleași funcții excelente la \$49/lună. Planul dvs. actual va continua să funcționeze între timp.';
+  String get planDeprecationMessage => 'Planul dvs. Unlimited este retras. Treceți la planul Operator — aceleași funcții excelente la \$49/lună. Planul dvs. actual va continua să funcționeze între timp.';
 
   @override
   String get upgradeYourPlan => 'Îmbunătățește-ți planul';
@@ -9173,8 +8971,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Ai atins limita lunară. Fă upgrade pentru a continua să discuți cu Omi fără restricții.';
+  String get chatQuotaExceededReply => 'Ai atins limita lunară. Fă upgrade pentru a continua să discuți cu Omi fără restricții.';
 
   @override
   String get voiceResponseAudio => 'Citește răspunsul Omi cu voce tare';
@@ -9205,4 +9002,25 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Adaugă sarcină';
+
+  @override
+  String get quickActionAskOmiAnything => 'Întreabă Omi orice';
+
+  @override
+  String get quickActionVoiceMode => 'Mod voce';
+
+  @override
+  String get quickActionMute => 'Dezactivare sunet';
+
+  @override
+  String get quickActionUnmute => 'Activare sunet';
+
+  @override
+  String get quickActionConnectDevice => 'Conectează dispozitiv';
+
+  @override
+  String get quickActionDeviceSettings => 'Setări dispozitiv';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -24,8 +24,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteConversationTitle => 'Удалить разговор?';
 
   @override
-  String get deleteConversationMessage =>
-      'Это также удалит связанные воспоминания, задачи и аудиофайлы. Это действие нельзя отменить.';
+  String get deleteConversationMessage => 'Это также удалит связанные воспоминания, задачи и аудиофайлы. Это действие нельзя отменить.';
 
   @override
   String get confirm => 'Подтвердить';
@@ -146,8 +145,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleting => 'Удаление...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
+  String get pleaseCompleteAuthentication => 'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
 
   @override
   String get failedToStartAuthentication => 'Не удалось начать аутентификацию';
@@ -228,8 +226,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noStarredConversations => 'Нет избранных бесед';
 
   @override
-  String get starConversationHint =>
-      'Чтобы добавить разговор в избранное, откройте его и нажмите на значок звезды в заголовке.';
+  String get starConversationHint => 'Чтобы добавить разговор в избранное, откройте его и нажмите на значок звезды в заголовке.';
 
   @override
   String get searchConversations => 'Поиск разговоров...';
@@ -320,8 +317,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get installedApps => 'Установленные приложения';
 
   @override
-  String get unableToFetchApps =>
-      'Не удалось загрузить приложения :(\n\nПожалуйста, проверьте подключение к интернету и попробуйте снова.';
+  String get unableToFetchApps => 'Не удалось загрузить приложения :(\n\nПожалуйста, проверьте подключение к интернету и попробуйте снова.';
 
   @override
   String get aboutOmi => 'О Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get appsDisconnected => 'Ваши приложения и интеграции будут немедленно отключены.';
 
   @override
-  String get exportBeforeDelete =>
-      'Вы можете экспортировать свои данные перед удалением аккаунта, но после удаления восстановить их будет невозможно.';
+  String get exportBeforeDelete => 'Вы можете экспортировать свои данные перед удалением аккаунта, но после удаления восстановить их будет невозможно.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Я понимаю, что удаление аккаунта необратимо, и все данные, включая воспоминания и разговоры, будут потеряны без возможности восстановления.';
+  String get deleteAccountCheckbox => 'Я понимаю, что удаление аккаунта необратимо, и все данные, включая воспоминания и разговоры, будут потеряны без возможности восстановления.';
 
   @override
   String get areYouSure => 'Вы уверены?';
 
   @override
-  String get deleteAccountFinal =>
-      'Это действие необратимо и навсегда удалит ваш аккаунт и все связанные с ним данные. Вы уверены, что хотите продолжить?';
+  String get deleteAccountFinal => 'Это действие необратимо и навсегда удалит ваш аккаунт и все связанные с ним данные. Вы уверены, что хотите продолжить?';
 
   @override
   String get deleteNow => 'Удалить сейчас';
@@ -378,8 +371,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get goBack => 'Вернуться назад';
 
   @override
-  String get checkBoxToConfirm =>
-      'Поставьте галочку, чтобы подтвердить, что вы понимаете: удаление аккаунта необратимо.';
+  String get checkBoxToConfirm => 'Поставьте галочку, чтобы подтвердить, что вы понимаете: удаление аккаунта необратимо.';
 
   @override
   String get profile => 'Профиль';
@@ -457,8 +449,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get yourPrivacyYourControl => 'Ваша конфиденциальность, ваш контроль';
 
   @override
-  String get privacyIntro =>
-      'В Omi мы стремимся защитить вашу конфиденциальность. Эта страница позволяет вам контролировать, как хранятся и используются ваши данные.';
+  String get privacyIntro => 'В Omi мы стремимся защитить вашу конфиденциальность. Эта страница позволяет вам контролировать, как хранятся и используются ваши данные.';
 
   @override
   String get learnMore => 'Узнать больше...';
@@ -467,15 +458,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get dataProtectionLevel => 'Уровень защиты данных';
 
   @override
-  String get dataProtectionDesc =>
-      'Ваши данные по умолчанию защищены надёжным шифрованием. Просмотрите ваши настройки и будущие опции конфиденциальности ниже.';
+  String get dataProtectionDesc => 'Ваши данные по умолчанию защищены надёжным шифрованием. Просмотрите ваши настройки и будущие опции конфиденциальности ниже.';
 
   @override
   String get appAccess => 'Доступ приложений';
 
   @override
-  String get appAccessDesc =>
-      'Следующие приложения могут получить доступ к вашим данным. Нажмите на приложение, чтобы управлять его разрешениями.';
+  String get appAccessDesc => 'Следующие приложения могут получить доступ к вашим данным. Нажмите на приложение, чтобы управлять его разрешениями.';
 
   @override
   String get noAppsExternalAccess => 'Ни одно установленное приложение не имеет внешнего доступа к вашим данным.';
@@ -532,15 +521,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Ваш Omi был отключён 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Сопряжение устройства отменено. Перейдите в Настройки > Bluetooth и забудьте устройство, чтобы завершить отмену сопряжения.';
+  String get deviceUnpairedMessage => 'Сопряжение устройства отменено. Перейдите в Настройки > Bluetooth и забудьте устройство, чтобы завершить отмену сопряжения.';
 
   @override
   String get unpairDialogTitle => 'Разорвать пару с устройством';
 
   @override
-  String get unpairDialogMessage =>
-      'Это разорвёт пару с устройством, чтобы оно могло быть подключено к другому телефону. Вам нужно будет перейти в Настройки > Bluetooth и забыть устройство для завершения процесса.';
+  String get unpairDialogMessage => 'Это разорвёт пару с устройством, чтобы оно могло быть подключено к другому телефону. Вам нужно будет перейти в Настройки > Bluetooth и забыть устройство для завершения процесса.';
 
   @override
   String get deviceNotConnected => 'Устройство не подключено';
@@ -561,8 +548,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get v2Undetected => 'V2 не обнаружено';
 
   @override
-  String get v2UndetectedMessage =>
-      'Мы видим, что у вас либо устройство V1, либо ваше устройство не подключено. Функция SD-карты доступна только для устройств V2.';
+  String get v2UndetectedMessage => 'Мы видим, что у вас либо устройство V1, либо ваше устройство не подключено. Функция SD-карты доступна только для устройств V2.';
 
   @override
   String get endConversation => 'Завершить разговор';
@@ -694,8 +680,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noActivityYet => 'Активности пока нет';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Начните разговор с Omi,\nчтобы увидеть здесь вашу статистику использования.';
+  String get startConversationToSeeInsights => 'Начните разговор с Omi,\nчтобы увидеть здесь вашу статистику использования.';
 
   @override
   String get listening => 'Прослушивание';
@@ -837,8 +822,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Удалить граф знаний?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Это удалит все производные данные графа знаний (узлы и связи). Ваши исходные воспоминания останутся в безопасности. Граф будет восстановлен со временем или при следующем запросе.';
+  String get deleteKnowledgeGraphMessage => 'Это удалит все производные данные графа знаний (узлы и связи). Ваши исходные воспоминания останутся в безопасности. Граф будет восстановлен со временем или при следующем запросе.';
 
   @override
   String get knowledgeGraphDeleted => 'Граф знаний удалён';
@@ -986,8 +970,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get shortConversationThreshold => 'Порог коротких разговоров';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Разговоры короче этого значения будут скрыты, если не включено выше';
+  String get shortConversationThresholdSubtitle => 'Разговоры короче этого значения будут скрыты, если не включено выше';
 
   @override
   String get durationThreshold => 'Порог длительности';
@@ -1022,8 +1005,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get integrationsFooter => 'Подключите ваши приложения для просмотра данных и метрик в чате.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
+  String get completeAuthInBrowser => 'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1083,37 +1065,31 @@ class AppLocalizationsRu extends AppLocalizations {
   String get needYourPermission => 'Нам нужно ваше разрешение';
 
   @override
-  String get alreadyGavePermission =>
-      'Вы уже дали нам разрешение на сохранение ваших записей. Напоминаем, зачем нам это нужно:';
+  String get alreadyGavePermission => 'Вы уже дали нам разрешение на сохранение ваших записей. Напоминаем, зачем нам это нужно:';
 
   @override
-  String get wouldLikePermission =>
-      'Мы хотели бы получить ваше разрешение на сохранение ваших голосовых записей. Вот почему:';
+  String get wouldLikePermission => 'Мы хотели бы получить ваше разрешение на сохранение ваших голосовых записей. Вот почему:';
 
   @override
   String get improveSpeechProfile => 'Улучшение вашего голосового профиля';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Мы используем записи для дальнейшего обучения и улучшения вашего персонального голосового профиля.';
+  String get improveSpeechProfileDesc => 'Мы используем записи для дальнейшего обучения и улучшения вашего персонального голосового профиля.';
 
   @override
   String get trainFamilyProfiles => 'Обучение профилей друзей и семьи';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Ваши записи помогают нам распознавать и создавать профили для ваших друзей и семьи.';
+  String get trainFamilyProfilesDesc => 'Ваши записи помогают нам распознавать и создавать профили для ваших друзей и семьи.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Повышение точности расшифровки';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'По мере улучшения нашей модели мы сможем предоставлять лучшие результаты расшифровки для ваших записей.';
+  String get enhanceTranscriptAccuracyDesc => 'По мере улучшения нашей модели мы сможем предоставлять лучшие результаты расшифровки для ваших записей.';
 
   @override
-  String get legalNotice =>
-      'Юридическое уведомление: Законность записи и хранения голосовых данных может различаться в зависимости от вашего местоположения и того, как вы используете эту функцию. Вы несёте ответственность за соблюдение местных законов и нормативных актов.';
+  String get legalNotice => 'Юридическое уведомление: Законность записи и хранения голосовых данных может различаться в зависимости от вашего местоположения и того, как вы используете эту функцию. Вы несёте ответственность за соблюдение местных законов и нормативных актов.';
 
   @override
   String get alreadyAuthorized => 'Уже разрешено';
@@ -1191,8 +1167,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showEventsNoParticipants => 'Показывать события без участников';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Когда включено, Coming Up показывает события без участников или видеосвязи.';
+  String get showEventsNoParticipantsDesc => 'Когда включено, Coming Up показывает события без участников или видеосвязи.';
 
   @override
   String get yourMeetings => 'Ваши встречи';
@@ -1233,8 +1208,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noProjectsInWorkspace => 'Проекты в этом рабочем пространстве не найдены';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Выберите, сколько времени ждать в тишине перед автоматическим завершением разговора:';
+  String get conversationTimeoutDesc => 'Выберите, сколько времени ждать в тишине перед автоматическим завершением разговора:';
 
   @override
   String get timeout2Minutes => '2 минуты';
@@ -1278,8 +1252,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Укажите ваш основной язык';
 
   @override
-  String get languageForTranscription =>
-      'Установите ваш язык для более точной расшифровки и персонализированного опыта.';
+  String get languageForTranscription => 'Установите ваш язык для более точной расшифровки и персонализированного опыта.';
 
   @override
   String get singleLanguageModeInfo => 'Режим одного языка включён. Перевод отключён для повышения точности.';
@@ -1362,8 +1335,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get defaultRepository => 'Репозиторий по умолчанию';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Выберите репозиторий по умолчанию для создания задач. Вы все еще можете указать другой репозиторий при создании задач.';
+  String get selectDefaultRepoDesc => 'Выберите репозиторий по умолчанию для создания задач. Вы все еще можете указать другой репозиторий при создании задач.';
 
   @override
   String get noReposFound => 'Репозитории не найдены';
@@ -1410,8 +1382,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get configureSettings => 'Настроить параметры';
 
   @override
-  String get completeAuthBrowser =>
-      'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
+  String get completeAuthBrowser => 'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1740,8 +1711,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get enableBluetooth => 'Включите Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi требуется Bluetooth для подключения к вашему устройству. Пожалуйста, включите Bluetooth и попробуйте снова.';
+  String get bluetoothNeeded => 'Omi требуется Bluetooth для подключения к вашему устройству. Пожалуйста, включите Bluetooth и попробуйте снова.';
 
   @override
   String get contactSupport => 'Связаться с поддержкой?';
@@ -1774,26 +1744,22 @@ class AppLocalizationsRu extends AppLocalizations {
   String get locationServiceDisabled => 'Служба определения местоположения отключена';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Служба определения местоположения отключена. Пожалуйста, перейдите в Настройки > Конфиденциальность и безопасность > Службы геолокации и включите её';
+  String get locationServiceDisabledDesc => 'Служба определения местоположения отключена. Пожалуйста, перейдите в Настройки > Конфиденциальность и безопасность > Службы геолокации и включите её';
 
   @override
   String get backgroundLocationDenied => 'Доступ к местоположению в фоновом режиме отклонён';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Пожалуйста, перейдите в настройки устройства и установите разрешение на местоположение как \"Всегда разрешать\"';
+  String get backgroundLocationDeniedDesc => 'Пожалуйста, перейдите в настройки устройства и установите разрешение на местоположение как \"Всегда разрешать\"';
 
   @override
   String get lovingOmi => 'Нравится Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Помогите нам достичь большего количества людей, оставив отзыв в App Store. Ваш отзыв очень важен для нас!';
+  String get leaveReviewIos => 'Помогите нам достичь большего количества людей, оставив отзыв в App Store. Ваш отзыв очень важен для нас!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Помогите нам достичь большего количества людей, оставив отзыв в Google Play Store. Ваш отзыв очень важен для нас!';
+  String get leaveReviewAndroid => 'Помогите нам достичь большего количества людей, оставив отзыв в Google Play Store. Ваш отзыв очень важен для нас!';
 
   @override
   String get rateOnAppStore => 'Оценить в App Store';
@@ -1826,15 +1792,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get connectionError => 'Ошибка подключения';
 
   @override
-  String get connectionErrorDesc =>
-      'Не удалось подключиться к серверу. Пожалуйста, проверьте подключение к интернету и попробуйте снова.';
+  String get connectionErrorDesc => 'Не удалось подключиться к серверу. Пожалуйста, проверьте подключение к интернету и попробуйте снова.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Обнаружена недействительная запись';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Похоже, в записи несколько говорящих. Пожалуйста, убедитесь, что вы находитесь в тихом месте, и попробуйте снова.';
+  String get multipleSpeakersDesc => 'Похоже, в записи несколько говорящих. Пожалуйста, убедитесь, что вы находитесь в тихом месте, и попробуйте снова.';
 
   @override
   String get tooShortDesc => 'Обнаружено недостаточно речи. Пожалуйста, говорите больше и попробуйте снова.';
@@ -1846,15 +1810,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get areYouThere => 'Вы здесь?';
 
   @override
-  String get noSpeechDesc =>
-      'Мы не смогли обнаружить речь. Пожалуйста, убедитесь, что говорите не менее 10 секунд и не более 3 минут.';
+  String get noSpeechDesc => 'Мы не смогли обнаружить речь. Пожалуйста, убедитесь, что говорите не менее 10 секунд и не более 3 минут.';
 
   @override
   String get connectionLost => 'Соединение потеряно';
 
   @override
-  String get connectionLostDesc =>
-      'Соединение было прервано. Пожалуйста, проверьте подключение к интернету и попробуйте снова.';
+  String get connectionLostDesc => 'Соединение было прервано. Пожалуйста, проверьте подключение к интернету и попробуйте снова.';
 
   @override
   String get tryAgain => 'Попробовать снова';
@@ -1869,8 +1831,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get permissionsRequired => 'Требуются разрешения';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Этому приложению нужны разрешения Bluetooth и Местоположение для правильной работы. Пожалуйста, включите их в настройках.';
+  String get permissionsRequiredDesc => 'Этому приложению нужны разрешения Bluetooth и Местоположение для правильной работы. Пожалуйста, включите их в настройках.';
 
   @override
   String get openSettings => 'Открыть настройки';
@@ -1912,12 +1873,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get microphonePermission => 'Разрешение на микрофон';
 
   @override
-  String get permissionGrantedNow =>
-      'Разрешение предоставлено! Теперь:\n\nОткройте приложение Omi на ваших часах и нажмите \"Продолжить\" ниже';
+  String get permissionGrantedNow => 'Разрешение предоставлено! Теперь:\n\nОткройте приложение Omi на ваших часах и нажмите \"Продолжить\" ниже';
 
   @override
-  String get needMicrophonePermission =>
-      'Нам нужно разрешение на микрофон.\n\n1. Нажмите \"Предоставить разрешение\"\n2. Разрешите на вашем iPhone\n3. Приложение на часах закроется\n4. Откройте снова и нажмите \"Продолжить\"';
+  String get needMicrophonePermission => 'Нам нужно разрешение на микрофон.\n\n1. Нажмите \"Предоставить разрешение\"\n2. Разрешите на вашем iPhone\n3. Приложение на часах закроется\n4. Откройте снова и нажмите \"Продолжить\"';
 
   @override
   String get grantPermissionButton => 'Предоставить разрешение';
@@ -1926,15 +1885,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get needHelp => 'Нужна помощь?';
 
   @override
-  String get troubleshootingSteps =>
-      'Устранение неполадок:\n\n1. Убедитесь, что Omi установлен на ваших часах\n2. Откройте приложение Omi на ваших часах\n3. Найдите всплывающее окно с разрешением\n4. Нажмите \"Разрешить\" при запросе\n5. Приложение на часах закроется - откройте его снова\n6. Вернитесь и нажмите \"Продолжить\" на вашем iPhone';
+  String get troubleshootingSteps => 'Устранение неполадок:\n\n1. Убедитесь, что Omi установлен на ваших часах\n2. Откройте приложение Omi на ваших часах\n3. Найдите всплывающее окно с разрешением\n4. Нажмите \"Разрешить\" при запросе\n5. Приложение на часах закроется - откройте его снова\n6. Вернитесь и нажмите \"Продолжить\" на вашем iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Запись успешно начата!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Разрешение ещё не предоставлено. Пожалуйста, убедитесь, что вы разрешили доступ к микрофону и открыли приложение на часах заново.';
+  String get permissionNotGrantedYet => 'Разрешение ещё не предоставлено. Пожалуйста, убедитесь, что вы разрешили доступ к микрофону и открыли приложение на часах заново.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2031,8 +1988,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Готово к задачам';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Ваш AI автоматически извлечёт задачи и дела из ваших разговоров. Они появятся здесь при создании.';
+  String get welcomeActionItemsDescription => 'Ваш AI автоматически извлечёт задачи и дела из ваших разговоров. Они появятся здесь при создании.';
 
   @override
   String get autoExtractionFeature => 'Автоматически извлекается из разговоров';
@@ -2228,15 +2184,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'РЕЧЬ И ТРАНСКРИПЦИЯ';
 
   @override
-  String get languageSettingsHelperText =>
-      'Язык приложения изменяет меню и кнопки. Язык речи влияет на то, как транскрибируются ваши записи.';
+  String get languageSettingsHelperText => 'Язык приложения изменяет меню и кнопки. Язык речи влияет на то, как транскрибируются ваши записи.';
 
   @override
   String get translationNotice => 'Уведомление о переводе';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi переводит разговоры на ваш основной язык. Обновите его в любое время в Настройки → Профили.';
+  String get translationNoticeMessage => 'Omi переводит разговоры на ваш основной язык. Обновите его в любое время в Настройки → Профили.';
 
   @override
   String get pleaseCheckInternetConnection => 'Пожалуйста, проверьте подключение к Интернету и повторите попытку';
@@ -2391,8 +2345,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Отменить сопряжение устройства';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Это отменит сопряжение устройства, чтобы его можно было подключить к другому телефону. Вам нужно будет перейти в Настройки > Bluetooth и забыть устройство, чтобы завершить процесс.';
+  String get unpairDeviceDialogMessage => 'Это отменит сопряжение устройства, чтобы его можно было подключить к другому телефону. Вам нужно будет перейти в Настройки > Bluetooth и забыть устройство, чтобы завершить процесс.';
 
   @override
   String get unpair => 'Отменить сопряжение';
@@ -2573,8 +2526,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get youreAllSet => 'Всё готово!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Добро пожаловать в Omi! Ваш AI-компаньон готов помочь вам с разговорами, задачами и многим другим.';
+  String get welcomeToOmiDescription => 'Добро пожаловать в Omi! Ваш AI-компаньон готов помочь вам с разговорами, задачами и многим другим.';
 
   @override
   String get startUsingOmi => 'Начать использовать Omi';
@@ -2653,8 +2605,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get reviewAndManageConversations => 'Просматривайте и управляйте записанными разговорами';
 
   @override
-  String get startCapturingConversations =>
-      'Начните записывать разговоры с помощью устройства Omi, чтобы увидеть их здесь.';
+  String get startCapturingConversations => 'Начните записывать разговоры с помощью устройства Omi, чтобы увидеть их здесь.';
 
   @override
   String get useMobileAppToCapture => 'Используйте мобильное приложение для записи аудио';
@@ -2711,8 +2662,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noTasksYet => 'Пока нет задач';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Задачи из ваших разговоров появятся здесь.\nНажмите Создать, чтобы добавить задачу вручную.';
+  String get tasksFromConversationsWillAppear => 'Задачи из ваших разговоров появятся здесь.\nНажмите Создать, чтобы добавить задачу вручную.';
 
   @override
   String get monthJan => 'Янв';
@@ -2811,8 +2761,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get checkBackLaterForNewApps => 'Загляните позже за новыми приложениями';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'Пожалуйста, проверьте подключение к Интернету и попробуйте снова';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'Пожалуйста, проверьте подключение к Интернету и попробуйте снова';
 
   @override
   String get createNewApp => 'Создать новое приложение';
@@ -2845,15 +2794,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chatPrompt => 'Подсказка чата';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Вы - отличное приложение, ваша задача - отвечать на запросы пользователей и заставлять их чувствовать себя хорошо...';
+  String get chatPromptPlaceholder => 'Вы - отличное приложение, ваша задача - отвечать на запросы пользователей и заставлять их чувствовать себя хорошо...';
 
   @override
   String get conversationPrompt => 'Запрос разговора';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Вы - отличное приложение, вам будут предоставлены транскрипция и краткое содержание разговора...';
+  String get conversationPromptPlaceholder => 'Вы - отличное приложение, вам будут предоставлены транскрипция и краткое содержание разговора...';
 
   @override
   String get notificationScopes => 'Области уведомлений';
@@ -2865,8 +2812,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get makeMyAppPublic => 'Сделать мое приложение публичным';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Отправляя это приложение, я принимаю Условия использования и Политику конфиденциальности Omi AI';
+  String get submitAppTermsAgreement => 'Отправляя это приложение, я принимаю Условия использования и Политику конфиденциальности Omi AI';
 
   @override
   String get submitApp => 'Отправить приложение';
@@ -2881,12 +2827,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get submitAppQuestion => 'Отправить приложение?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Ваше приложение будет рассмотрено и опубликовано. Вы можете начать использовать его немедленно, даже во время рассмотрения!';
+  String get submitAppPublicDescription => 'Ваше приложение будет рассмотрено и опубликовано. Вы можете начать использовать его немедленно, даже во время рассмотрения!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Ваше приложение будет рассмотрено и станет доступным для вас в частном порядке. Вы можете начать использовать его немедленно, даже во время рассмотрения!';
+  String get submitAppPrivateDescription => 'Ваше приложение будет рассмотрено и станет доступным для вас в частном порядке. Вы можете начать использовать его немедленно, даже во время рассмотрения!';
 
   @override
   String get startEarning => 'Начните зарабатывать! 💰';
@@ -2910,23 +2854,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get dataAccessNotice => 'Уведомление о доступе к данным';
 
   @override
-  String get dataAccessWarning =>
-      'Это приложение получит доступ к вашим данным. Omi AI не несет ответственности за то, как ваши данные используются, изменяются или удаляются этим приложением';
+  String get dataAccessWarning => 'Это приложение получит доступ к вашим данным. Omi AI не несет ответственности за то, как ваши данные используются, изменяются или удаляются этим приложением';
 
   @override
   String get installApp => 'Установить приложение';
 
   @override
-  String get betaTesterNotice =>
-      'Вы бета-тестер этого приложения. Оно еще не является публичным. Оно станет публичным после одобрения.';
+  String get betaTesterNotice => 'Вы бета-тестер этого приложения. Оно еще не является публичным. Оно станет публичным после одобрения.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Ваше приложение находится на рассмотрении и видно только вам. Оно станет публичным после одобрения.';
+  String get appUnderReviewOwner => 'Ваше приложение находится на рассмотрении и видно только вам. Оно станет публичным после одобрения.';
 
   @override
-  String get appRejectedNotice =>
-      'Ваше приложение было отклонено. Пожалуйста, обновите информацию о приложении и отправьте его на рассмотрение снова.';
+  String get appRejectedNotice => 'Ваше приложение было отклонено. Пожалуйста, обновите информацию о приложении и отправьте его на рассмотрение снова.';
 
   @override
   String get setupSteps => 'Шаги настройки';
@@ -2988,8 +2928,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get descriptionLabel => 'Описание';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Моё потрясающее приложение — это отличное приложение, которое делает удивительные вещи. Это лучшее приложение!';
+  String get appDescriptionPlaceholder => 'Моё потрясающее приложение — это отличное приложение, которое делает удивительные вещи. Это лучшее приложение!';
 
   @override
   String get pleaseProvideValidDescription => 'Пожалуйста, предоставьте действительное описание';
@@ -3141,8 +3080,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get microphonePermissionRequired => 'Для записи голоса требуется разрешение микрофона.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Доступ к микрофону запрещен. Пожалуйста, предоставьте разрешение в Системные настройки > Конфиденциальность и безопасность > Микрофон.';
+  String get microphonePermissionDenied => 'Доступ к микрофону запрещен. Пожалуйста, предоставьте разрешение в Системные настройки > Конфиденциальность и безопасность > Микрофон.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3375,8 +3313,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get whatWeCollect => 'Что мы собираем';
 
   @override
-  String get dataCollectionMessage =>
-      'Продолжая, ваши разговоры, записи и личная информация будут надежно храниться на наших серверах для предоставления аналитики на основе ИИ и включения всех функций приложения.';
+  String get dataCollectionMessage => 'Продолжая, ваши разговоры, записи и личная информация будут надежно храниться на наших серверах для предоставления аналитики на основе ИИ и включения всех функций приложения.';
 
   @override
   String get dataProtection => 'Защита данных';
@@ -3409,8 +3346,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Имя должно содержать не менее 2 символов';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Скажите нам, как вы хотели бы, чтобы к вам обращались. Это помогает персонализировать ваш опыт Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Скажите нам, как вы хотели бы, чтобы к вам обращались. Это помогает персонализировать ваш опыт Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3427,8 +3363,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get recordAudioConversations => 'Записывать аудиоразговоры';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi нужен доступ к микрофону для записи ваших разговоров и предоставления транскрипций.';
+  String get microphoneAccessDescription => 'Omi нужен доступ к микрофону для записи ваших разговоров и предоставления транскрипций.';
 
   @override
   String get screenRecording => 'Запись экрана';
@@ -3437,8 +3372,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Захват системного звука со встреч';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi нужно разрешение на запись экрана для захвата системного звука с ваших встреч на базе браузера.';
+  String get screenRecordingDescription => 'Omi нужно разрешение на запись экрана для захвата системного звука с ваших встреч на базе браузера.';
 
   @override
   String get accessibility => 'Доступность';
@@ -3447,8 +3381,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Обнаружение встреч на базе браузера';
 
   @override
-  String get accessibilityDescription =>
-      'Omi нужно разрешение доступности для обнаружения, когда вы присоединяетесь к встречам Zoom, Meet или Teams в вашем браузере.';
+  String get accessibilityDescription => 'Omi нужно разрешение доступности для обнаружения, когда вы присоединяетесь к встречам Zoom, Meet или Teams в вашем браузере.';
 
   @override
   String get pleaseWait => 'Пожалуйста, подождите...';
@@ -3517,12 +3450,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get exportAllConversationsToJson => 'Экспортируйте все свои беседы в файл JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Экспорт бесед начат. Это может занять несколько секунд, пожалуйста, подождите.';
+  String get conversationsExportStarted => 'Экспорт бесед начат. Это может занять несколько секунд, пожалуйста, подождите.';
 
   @override
-  String get mcpDescription =>
-      'Для подключения Omi к другим приложениям для чтения, поиска и управления вашими воспоминаниями и беседами. Создайте ключ для начала.';
+  String get mcpDescription => 'Для подключения Omi к другим приложениям для чтения, поиска и управления вашими воспоминаниями и беседами. Создайте ключ для начала.';
 
   @override
   String get apiKeys => 'Ключи API';
@@ -3569,8 +3500,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'Автоматически создавать и помечать новых говорящих';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Автоматически создавать нового человека, когда имя обнаружено в транскрипте.';
+  String get automaticallyCreateNewPerson => 'Автоматически создавать нового человека, когда имя обнаружено в транскрипте.';
 
   @override
   String get pilotFeatures => 'Пилотные функции';
@@ -3631,8 +3561,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Позвольте Omi автоматически выбрать лучшее приложение';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Вы уверены, что хотите удалить этот разговор? Это действие нельзя отменить.';
+  String get deleteConversationConfirmation => 'Вы уверены, что хотите удалить этот разговор? Это действие нельзя отменить.';
 
   @override
   String get conversationDeleted => 'Разговор удален';
@@ -3680,8 +3609,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Подготовка записи системного аудио';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Нажмите кнопку, чтобы записать аудио для живых транскриптов, AI-инсайтов и автоматического сохранения.';
+  String get clickTheButtonToCaptureAudio => 'Нажмите кнопку, чтобы записать аудио для живых транскриптов, AI-инсайтов и автоматического сохранения.';
 
   @override
   String get reconnecting => 'Переподключение...';
@@ -3908,8 +3836,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Удалить граф знаний?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Это удалит все производные данные графа знаний. Ваши исходные воспоминания останутся в безопасности.';
+  String get deleteKnowledgeGraphWarning => 'Это удалит все производные данные графа знаний. Ваши исходные воспоминания останутся в безопасности.';
 
   @override
   String get connectOmiWithAI => 'Подключите Omi к ИИ-ассистентам';
@@ -3951,8 +3878,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Условия и Политика конфиденциальности';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Помогает диагностировать проблемы. Автоматически удаляется через 3 дня.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Помогает диагностировать проблемы. Автоматически удаляется через 3 дня.';
 
   @override
   String get manageYourApp => 'Управление приложением';
@@ -3967,8 +3893,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get updateAppQuestion => 'Обновить приложение?';
 
   @override
-  String get updateAppConfirmation =>
-      'Вы уверены, что хотите обновить приложение? Изменения вступят в силу после проверки нашей командой.';
+  String get updateAppConfirmation => 'Вы уверены, что хотите обновить приложение? Изменения вступят в силу после проверки нашей командой.';
 
   @override
   String get updateApp => 'Обновить приложение';
@@ -3998,8 +3923,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get no => 'Нет';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Подписка успешно отменена. Она останется активной до конца текущего расчетного периода.';
+  String get subscriptionCancelledSuccessfully => 'Подписка успешно отменена. Она останется активной до конца текущего расчетного периода.';
 
   @override
   String get failedToCancelSubscription => 'Не удалось отменить подписку. Пожалуйста, попробуйте снова.';
@@ -4035,8 +3959,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Отменить подписку?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Вы уверены, что хотите отменить подписку? У вас будет доступ до конца текущего расчетного периода.';
+  String get cancelSubscriptionConfirmation => 'Вы уверены, что хотите отменить подписку? У вас будет доступ до конца текущего расчетного периода.';
 
   @override
   String get cancelSubscriptionButton => 'Отменить подписку';
@@ -4045,12 +3968,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get cancelling => 'Отмена...';
 
   @override
-  String get betaTesterMessage =>
-      'Вы бета-тестер этого приложения. Оно еще не опубликовано. Станет публичным после одобрения.';
+  String get betaTesterMessage => 'Вы бета-тестер этого приложения. Оно еще не опубликовано. Станет публичным после одобрения.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Ваше приложение на рассмотрении и видно только вам. Станет публичным после одобрения.';
+  String get appUnderReviewMessage => 'Ваше приложение на рассмотрении и видно только вам. Станет публичным после одобрения.';
 
   @override
   String get appRejectedMessage => 'Ваше приложение отклонено. Обновите данные и отправьте повторно на рассмотрение.';
@@ -4107,8 +4028,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get issueActivatingApp => 'При активации этого приложения возникла проблема. Пожалуйста, попробуйте снова.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Это приложение получит доступ к вашим данным. Omi AI не несет ответственности за то, как ваши данные используются, изменяются или удаляются этим приложением';
+  String get dataAccessNoticeDescription => 'Это приложение получит доступ к вашим данным. Omi AI не несет ответственности за то, как ваши данные используются, изменяются или удаляются этим приложением';
 
   @override
   String get copyUrl => 'Копировать URL';
@@ -4196,8 +4116,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get omiApiKeys => 'API-ключи Omi';
 
   @override
-  String get apiKeysDescription =>
-      'API-ключи используются для аутентификации, когда ваше приложение взаимодействует с сервером OMI. Они позволяют вашему приложению создавать воспоминания и безопасно получать доступ к другим сервисам OMI.';
+  String get apiKeysDescription => 'API-ключи используются для аутентификации, когда ваше приложение взаимодействует с сервером OMI. Они позволяют вашему приложению создавать воспоминания и безопасно получать доступ к другим сервисам OMI.';
 
   @override
   String get aboutOmiApiKeys => 'Об API-ключах Omi';
@@ -4221,8 +4140,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Отозвать API-ключ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Это действие нельзя отменить. Приложения, использующие этот ключ, больше не смогут получить доступ к API.';
+  String get revokeApiKeyWarning => 'Это действие нельзя отменить. Приложения, использующие этот ключ, больше не смогут получить доступ к API.';
 
   @override
   String get revoke => 'Отозвать';
@@ -4311,8 +4229,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get keyCreated => 'Ключ создан';
 
   @override
-  String get keyCreatedMessage =>
-      'Ваш новый ключ создан. Пожалуйста, скопируйте его сейчас. Вы больше не сможете его увидеть.';
+  String get keyCreatedMessage => 'Ваш новый ключ создан. Пожалуйста, скопируйте его сейчас. Вы больше не сможете его увидеть.';
 
   @override
   String get keyWord => 'Ключ';
@@ -4321,8 +4238,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get externalAppAccess => 'Доступ внешних приложений';
 
   @override
-  String get externalAppAccessDescription =>
-      'Следующие установленные приложения имеют внешние интеграции и могут получить доступ к вашим данным, таким как разговоры и воспоминания.';
+  String get externalAppAccessDescription => 'Следующие установленные приложения имеют внешние интеграции и могут получить доступ к вашим данным, таким как разговоры и воспоминания.';
 
   @override
   String get noExternalAppsHaveAccess => 'Ни одно внешнее приложение не имеет доступа к вашим данным.';
@@ -4331,15 +4247,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get maximumSecurityE2ee => 'Максимальная безопасность (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Сквозное шифрование — это золотой стандарт конфиденциальности. При включении ваши данные шифруются на вашем устройстве перед отправкой на наши серверы. Это означает, что никто, даже Omi, не может получить доступ к вашему контенту.';
+  String get e2eeDescription => 'Сквозное шифрование — это золотой стандарт конфиденциальности. При включении ваши данные шифруются на вашем устройстве перед отправкой на наши серверы. Это означает, что никто, даже Omi, не может получить доступ к вашему контенту.';
 
   @override
   String get importantTradeoffs => 'Важные компромиссы:';
 
   @override
-  String get e2eeTradeoff1 =>
-      '• Некоторые функции, такие как интеграции с внешними приложениями, могут быть отключены.';
+  String get e2eeTradeoff1 => '• Некоторые функции, такие как интеграции с внешними приложениями, могут быть отключены.';
 
   @override
   String get e2eeTradeoff2 => '• Если вы потеряете пароль, ваши данные не могут быть восстановлены.';
@@ -4348,8 +4262,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get featureComingSoon => 'Эта функция скоро появится!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Миграция выполняется. Вы не можете изменить уровень защиты, пока она не завершится.';
+  String get migrationInProgressMessage => 'Миграция выполняется. Вы не можете изменить уровень защиты, пока она не завершится.';
 
   @override
   String get migrationFailed => 'Миграция не удалась';
@@ -4368,19 +4281,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get secureEncryption => 'Безопасное шифрование';
 
   @override
-  String get secureEncryptionDescription =>
-      'Ваши данные шифруются уникальным для вас ключом на наших серверах, размещенных в Google Cloud. Это означает, что ваш необработанный контент недоступен никому, включая сотрудников Omi или Google, напрямую из базы данных.';
+  String get secureEncryptionDescription => 'Ваши данные шифруются уникальным для вас ключом на наших серверах, размещенных в Google Cloud. Это означает, что ваш необработанный контент недоступен никому, включая сотрудников Omi или Google, напрямую из базы данных.';
 
   @override
   String get endToEndEncryption => 'Сквозное шифрование';
 
   @override
-  String get e2eeCardDescription =>
-      'Включите для максимальной безопасности, где только вы можете получить доступ к своим данным. Нажмите, чтобы узнать больше.';
+  String get e2eeCardDescription => 'Включите для максимальной безопасности, где только вы можете получить доступ к своим данным. Нажмите, чтобы узнать больше.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Независимо от уровня, ваши данные всегда зашифрованы в состоянии покоя и при передаче.';
+  String get dataAlwaysEncrypted => 'Независимо от уровня, ваши данные всегда зашифрованы в состоянии покоя и при передаче.';
 
   @override
   String get readOnlyScope => 'Только чтение';
@@ -4445,12 +4355,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get trainingDataProgram => 'Программа данных для обучения';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Получите Omi Unlimited бесплатно, предоставив свои данные для обучения моделей ИИ.';
+  String get getOmiUnlimitedFree => 'Получите Omi Unlimited бесплатно, предоставив свои данные для обучения моделей ИИ.';
 
   @override
-  String get trainingDataBullets =>
-      '• Ваши данные помогают улучшать модели ИИ\n• Передаются только нечувствительные данные\n• Полностью прозрачный процесс';
+  String get trainingDataBullets => '• Ваши данные помогают улучшать модели ИИ\n• Передаются только нечувствительные данные\n• Полностью прозрачный процесс';
 
   @override
   String get learnMoreAtOmiTraining => 'Узнайте больше на omi.me/training';
@@ -4500,8 +4408,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get monthlyPlanContinues => 'Ваш текущий месячный план будет действовать до конца расчетного периода';
 
   @override
-  String get paymentMethodCharged =>
-      'С вашего существующего способа оплаты будет автоматически списана сумма по окончании месячного плана';
+  String get paymentMethodCharged => 'С вашего существующего способа оплаты будет автоматически списана сумма по окончании месячного плана';
 
   @override
   String get annualSubscriptionStarts => 'Ваша 12-месячная годовая подписка начнется автоматически после списания';
@@ -4611,8 +4518,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Ваша конфиденциальность важна для нас';
 
   @override
-  String get privacyIntroText =>
-      'В Omi мы очень серьезно относимся к вашей конфиденциальности. Мы хотим быть прозрачными в отношении собираемых данных и их использования. Вот что вам нужно знать:';
+  String get privacyIntroText => 'В Omi мы очень серьезно относимся к вашей конфиденциальности. Мы хотим быть прозрачными в отношении собираемых данных и их использования. Вот что вам нужно знать:';
 
   @override
   String get whatWeTrack => 'Что мы отслеживаем';
@@ -4627,12 +4533,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get ourCommitment => 'Наше обязательство';
 
   @override
-  String get commitmentText =>
-      'Мы обязуемся использовать собранные данные только для улучшения Omi для вас. Ваша конфиденциальность и доверие имеют для нас первостепенное значение.';
+  String get commitmentText => 'Мы обязуемся использовать собранные данные только для улучшения Omi для вас. Ваша конфиденциальность и доверие имеют для нас первостепенное значение.';
 
   @override
-  String get thankYouText =>
-      'Спасибо, что вы ценный пользователь Omi. Если у вас есть вопросы или проблемы, свяжитесь с нами по адресу team@basedhardware.com.';
+  String get thankYouText => 'Спасибо, что вы ценный пользователь Omi. Если у вас есть вопросы или проблемы, свяжитесь с нами по адресу team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Настройки синхронизации WiFi';
@@ -4641,8 +4545,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get enterHotspotCredentials => 'Введите данные точки доступа телефона';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi синхронизация использует телефон как точку доступа. Найдите имя и пароль в Настройки > Режим модема.';
+  String get wifiSyncUsesHotspot => 'WiFi синхронизация использует телефон как точку доступа. Найдите имя и пароль в Настройки > Режим модема.';
 
   @override
   String get hotspotNameSsid => 'Имя точки доступа (SSID)';
@@ -4677,8 +4580,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Не удалось создать сводку. Убедитесь, что у вас есть разговоры за этот день.';
+  String get failedToGenerateSummaryCheckConversations => 'Не удалось создать сводку. Убедитесь, что у вас есть разговоры за этот день.';
 
   @override
   String get summaryNotFound => 'Сводка не найдена';
@@ -4708,8 +4610,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Экспорт начат. Это может занять несколько секунд...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Это удалит все производные данные графа знаний (узлы и связи). Ваши исходные воспоминания останутся в безопасности. Граф будет восстановлен со временем или по следующему запросу.';
+  String get knowledgeGraphDeleteDescription => 'Это удалит все производные данные графа знаний (узлы и связи). Ваши исходные воспоминания останутся в безопасности. Граф будет восстановлен со временем или по следующему запросу.';
 
   @override
   String get configureDailySummaryDigest => 'Настройте ежедневную сводку задач';
@@ -4779,8 +4680,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Удалить все разговоры Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Это навсегда удалит все разговоры, импортированные из Limitless. Это действие нельзя отменить.';
+  String get deleteAllLimitlessWarning => 'Это навсегда удалит все разговоры, импортированные из Limitless. Это действие нельзя отменить.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4836,8 +4736,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get howItWorksTitle => 'Как это работает?';
 
   @override
-  String get howPeopleWorks =>
-      'После создания человека вы можете перейти к расшифровке разговора и назначить ему соответствующие сегменты, тогда Omi сможет распознавать и его речь!';
+  String get howPeopleWorks => 'После создания человека вы можете перейти к расшифровке разговора и назначить ему соответствующие сегменты, тогда Omi сможет распознавать и его речь!';
 
   @override
   String get tapToDelete => 'Нажмите для удаления';
@@ -4863,8 +4762,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get privacyNotice => 'Уведомление о конфиденциальности';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Записи могут захватывать голоса других людей. Перед включением убедитесь, что у вас есть согласие всех участников.';
+  String get recordingsMayCaptureOthers => 'Записи могут захватывать голоса других людей. Перед включением убедитесь, что у вас есть согласие всех участников.';
 
   @override
   String get enable => 'Включить';
@@ -4876,8 +4774,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Храните все аудиозаписи локально на телефоне. При отключении сохраняются только неудачные загрузки для экономии места.';
+  String get storeAudioDescription => 'Храните все аудиозаписи локально на телефоне. При отключении сохраняются только неудачные загрузки для экономии места.';
 
   @override
   String get enableLocalStorage => 'Включить локальное хранилище';
@@ -4895,12 +4792,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get storeAudioOnCloud => 'Хранить аудио в облаке';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Ваши записи в реальном времени будут храниться в частном облачном хранилище во время разговора.';
+  String get cloudStorageDialogMessage => 'Ваши записи в реальном времени будут храниться в частном облачном хранилище во время разговора.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Храните записи в реальном времени в частном облачном хранилище во время разговора. Аудио захватывается и сохраняется безопасно в реальном времени.';
+  String get storeAudioCloudDescription => 'Храните записи в реальном времени в частном облачном хранилище во время разговора. Аудио захватывается и сохраняется безопасно в реальном времени.';
 
   @override
   String get downloadingFirmware => 'Загрузка прошивки';
@@ -4909,8 +4804,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get installingFirmware => 'Установка прошивки';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Не закрывайте приложение и не выключайте устройство. Это может повредить устройство.';
+  String get firmwareUpdateWarning => 'Не закрывайте приложение и не выключайте устройство. Это может повредить устройство.';
 
   @override
   String get firmwareUpdated => 'Прошивка обновлена';
@@ -4954,8 +4848,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get payments => 'Платежи';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Подключите способ оплаты ниже, чтобы начать получать выплаты за ваши приложения.';
+  String get connectPaymentMethodInfo => 'Подключите способ оплаты ниже, чтобы начать получать выплаты за ваши приложения.';
 
   @override
   String get selectedPaymentMethod => 'Выбранный способ оплаты';
@@ -5009,8 +4902,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get connectingYourStripeAccount => 'Подключение вашего аккаунта Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Пожалуйста, завершите процесс регистрации Stripe в браузере. Эта страница автоматически обновится после завершения.';
+  String get stripeOnboardingInstructions => 'Пожалуйста, завершите процесс регистрации Stripe в браузере. Эта страница автоматически обновится после завершения.';
 
   @override
   String get failedTryAgain => 'Не удалось? Попробовать снова';
@@ -5022,8 +4914,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get successfullyConnected => 'Успешно подключено!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Ваш аккаунт Stripe готов принимать платежи. Вы можете сразу начать зарабатывать на продажах приложений.';
+  String get stripeReadyForPayments => 'Ваш аккаунт Stripe готов принимать платежи. Вы можете сразу начать зарабатывать на продажах приложений.';
 
   @override
   String get updateStripeDetails => 'Обновить данные Stripe';
@@ -5041,8 +4932,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Обновите данные вашего аккаунта PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Подключите свой аккаунт PayPal, чтобы начать получать платежи за ваши приложения';
+  String get connectPayPalToReceivePayments => 'Подключите свой аккаунт PayPal, чтобы начать получать платежи за ваши приложения';
 
   @override
   String get paypalEmail => 'Email PayPal';
@@ -5051,8 +4941,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get paypalMeLink => 'Ссылка PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Если Stripe доступен в вашей стране, мы настоятельно рекомендуем использовать его для более быстрых и простых выплат.';
+  String get stripeRecommendation => 'Если Stripe доступен в вашей стране, мы настоятельно рекомендуем использовать его для более быстрых и простых выплат.';
 
   @override
   String get updatePayPalDetails => 'Обновить данные PayPal';
@@ -5104,8 +4993,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Дополнительный образец голоса удален';
 
   @override
-  String get consentDataMessage =>
-      'Продолжая, ваши разговоры, записи и личная информация будут надежно храниться на наших серверах. Ваши аудиозаписи и транскрипции обрабатываются сторонними AI-сервисами (включая Deepgram для транскрипции и OpenAI для анализа), чтобы предоставить вам аналитику на основе ИИ и обеспечить работу всех функций приложения.';
+  String get consentDataMessage => 'Продолжая, ваши разговоры, записи и личная информация будут надежно храниться на наших серверах. Ваши аудиозаписи и транскрипции обрабатываются сторонними AI-сервисами (включая Deepgram для транскрипции и OpenAI для анализа), чтобы предоставить вам аналитику на основе ИИ и обеспечить работу всех функций приложения.';
 
   @override
   String get tasksEmptyStateMessage => 'Задачи из ваших разговоров появятся здесь.\nНажмите +, чтобы создать вручную.';
@@ -5144,15 +5032,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Установите Omi на\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Чтобы использовать Apple Watch с Omi, сначала необходимо установить приложение Omi на часы.';
+  String get installOmiOnAppleWatchDescription => 'Чтобы использовать Apple Watch с Omi, сначала необходимо установить приложение Omi на часы.';
 
   @override
   String get openOmiOnAppleWatch => 'Откройте Omi на\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Приложение Omi установлено на Apple Watch. Откройте его и нажмите Старт.';
+  String get openOmiOnAppleWatchDescription => 'Приложение Omi установлено на Apple Watch. Откройте его и нажмите Старт.';
 
   @override
   String get openWatchApp => 'Открыть приложение Watch';
@@ -5161,15 +5047,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Я установил и открыл приложение';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Не удалось открыть приложение Apple Watch. Откройте приложение Watch вручную на Apple Watch и установите Omi из раздела \"Доступные приложения\".';
+  String get unableToOpenWatchApp => 'Не удалось открыть приложение Apple Watch. Откройте приложение Watch вручную на Apple Watch и установите Omi из раздела \"Доступные приложения\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch успешно подключены!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch все еще недоступны. Убедитесь, что приложение Omi открыто на часах.';
+  String get appleWatchNotReachable => 'Apple Watch все еще недоступны. Убедитесь, что приложение Omi открыто на часах.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5597,29 +5481,25 @@ class AppLocalizationsRu extends AppLocalizations {
   String get multipleSpeakersDetected => 'Обнаружено несколько говорящих';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Похоже, что в записи несколько говорящих. Убедитесь, что вы находитесь в тихом месте, и попробуйте снова.';
+  String get multipleSpeakersDescription => 'Похоже, что в записи несколько говорящих. Убедитесь, что вы находитесь в тихом месте, и попробуйте снова.';
 
   @override
   String get invalidRecordingDetected => 'Обнаружена недействительная запись';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Недостаточно речи обнаружено. Пожалуйста, говорите больше и попробуйте снова.';
+  String get notEnoughSpeechDescription => 'Недостаточно речи обнаружено. Пожалуйста, говорите больше и попробуйте снова.';
 
   @override
   String get speechDurationDescription => 'Убедитесь, что вы говорите не менее 5 секунд и не более 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Соединение было прервано. Проверьте подключение к интернету и попробуйте снова.';
+  String get connectionLostDescription => 'Соединение было прервано. Проверьте подключение к интернету и попробуйте снова.';
 
   @override
   String get howToTakeGoodSample => 'Как сделать хороший образец?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Убедитесь, что вы находитесь в тихом месте.\n2. Говорите четко и естественно.\n3. Убедитесь, что ваше устройство находится в естественном положении на шее.\n\nПосле создания вы всегда можете улучшить его или сделать заново.';
+  String get goodSampleInstructions => '1. Убедитесь, что вы находитесь в тихом месте.\n2. Говорите четко и естественно.\n3. Убедитесь, что ваше устройство находится в естественном положении на шее.\n\nПосле создания вы всегда можете улучшить его или сделать заново.';
 
   @override
   String get noDeviceConnectedUseMic => 'Устройство не подключено. Будет использоваться микрофон телефона.';
@@ -5682,12 +5562,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get howItWorks => 'Как это работает';
 
   @override
-  String get dailyScoreExplanation =>
-      'Ваш дневной счёт основан на выполнении задач. Выполняйте задачи, чтобы улучшить свой счёт!';
+  String get dailyScoreExplanation => 'Ваш дневной счёт основан на выполнении задач. Выполняйте задачи, чтобы улучшить свой счёт!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Управляйте тем, как часто Omi отправляет вам проактивные уведомления и напоминания.';
+  String get notificationFrequencyDescription => 'Управляйте тем, как часто Omi отправляет вам проактивные уведомления и напоминания.';
 
   @override
   String get sliderOff => 'Выкл.';
@@ -5932,8 +5810,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get recordings => 'Записи';
 
   @override
-  String get enableRemindersAccess =>
-      'Пожалуйста, включите доступ к Напоминаниям в Настройках для использования Apple Напоминаний';
+  String get enableRemindersAccess => 'Пожалуйста, включите доступ к Напоминаниям в Настройках для использования Apple Напоминаний';
 
   @override
   String todayAtTime(String time) {
@@ -5988,8 +5865,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get webhookUrlNotSet => 'URL вебхука не установлен';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Установите URL вебхука в настройках разработчика для использования этой функции.';
+  String get setWebhookUrlInSettings => 'Установите URL вебхука в настройках разработчика для использования этой функции.';
 
   @override
   String get sendWebUrl => 'Отправить веб-ссылку';
@@ -6063,15 +5939,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get cloudProvider => 'Облачный провайдер';
 
   @override
-  String get premiumMinutesInfo =>
-      '1 200 премиум-минут в месяц. Вкладка \"На устройстве\" предлагает неограниченную бесплатную транскрипцию.';
+  String get premiumMinutesInfo => '1 200 премиум-минут в месяц. Вкладка \"На устройстве\" предлагает неограниченную бесплатную транскрипцию.';
 
   @override
   String get viewUsage => 'Посмотреть использование';
 
   @override
-  String get localProcessingInfo =>
-      'Аудио обрабатывается локально. Работает офлайн, более приватно, но расходует больше заряда батареи.';
+  String get localProcessingInfo => 'Аудио обрабатывается локально. Работает офлайн, более приватно, но расходует больше заряда батареи.';
 
   @override
   String get model => 'Модель';
@@ -6080,15 +5954,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get performanceWarning => 'Предупреждение о производительности';
 
   @override
-  String get largeModelWarning =>
-      'Эта модель большая и может привести к сбою приложения или очень медленной работе на мобильных устройствах.\n\nРекомендуется использовать \"small\" или \"base\".';
+  String get largeModelWarning => 'Эта модель большая и может привести к сбою приложения или очень медленной работе на мобильных устройствах.\n\nРекомендуется использовать \"small\" или \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Использование встроенного распознавания речи iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Будет использован встроенный механизм распознавания речи вашего устройства. Загрузка модели не требуется.';
+  String get noModelDownloadRequired => 'Будет использован встроенный механизм распознавания речи вашего устройства. Загрузка модели не требуется.';
 
   @override
   String get modelReady => 'Модель готова';
@@ -6133,8 +6005,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Устройство несовместимо';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'Ваше устройство не соответствует требованиям для транскрипции на устройстве.';
+  String get deviceNotMeetRequirements => 'Ваше устройство не соответствует требованиям для транскрипции на устройстве.';
 
   @override
   String get transcriptionSlowerOnDevice => 'Транскрипция на устройстве может быть медленнее на этом устройстве.';
@@ -6146,12 +6017,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get batteryDrainSignificantly => 'Расход батареи значительно увеличится.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 премиум-минут/месяц. Вкладка На устройстве предлагает неограниченную бесплатную транскрипцию. ';
+  String get premiumMinutesMonth => '1200 премиум-минут/месяц. Вкладка На устройстве предлагает неограниченную бесплатную транскрипцию. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Аудио обрабатывается локально. Работает офлайн, более приватно, но расходует больше батареи.';
+  String get audioProcessedLocally => 'Аудио обрабатывается локально. Работает офлайн, более приватно, но расходует больше батареи.';
 
   @override
   String get languageLabel => 'Язык';
@@ -6160,12 +6029,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get modelLabel => 'Модель';
 
   @override
-  String get modelTooLargeWarning =>
-      'Эта модель большая и может вызвать сбой приложения или очень медленную работу на мобильных устройствах.\n\nРекомендуется small или base.';
+  String get modelTooLargeWarning => 'Эта модель большая и может вызвать сбой приложения или очень медленную работу на мобильных устройствах.\n\nРекомендуется small или base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Будет использован встроенный речевой движок вашего устройства. Загрузка модели не требуется.';
+  String get nativeEngineNoDownload => 'Будет использован встроенный речевой движок вашего устройства. Загрузка модели не требуется.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6201,8 +6068,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Встроенная живая транскрипция Omi оптимизирована для разговоров в реальном времени с автоматическим определением говорящего и диаризацией.';
+  String get omiTranscriptionOptimized => 'Встроенная живая транскрипция Omi оптимизирована для разговоров в реальном времени с автоматическим определением говорящего и диаризацией.';
 
   @override
   String get reset => 'Сбросить';
@@ -6422,8 +6288,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Построение графа знаний из воспоминаний...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Ваш граф знаний будет построен автоматически при создании новых воспоминаний.';
+  String get knowledgeGraphWillBuildAutomatically => 'Ваш граф знаний будет построен автоматически при создании новых воспоминаний.';
 
   @override
   String get buildGraphButton => 'Построить граф';
@@ -6647,8 +6512,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get contactsPermissionRequiredForSms => 'Для отправки по SMS требуется разрешение на доступ к контактам';
 
   @override
-  String get grantContactsPermissionForSms =>
-      'Пожалуйста, предоставьте разрешение на доступ к контактам для отправки по SMS';
+  String get grantContactsPermissionForSms => 'Пожалуйста, предоставьте разрешение на доступ к контактам для отправки по SMS';
 
   @override
   String get noContactsWithPhoneNumbers => 'Контакты с номерами телефонов не найдены';
@@ -6660,8 +6524,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get failedToLoadContacts => 'Не удалось загрузить контакты';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Не удалось подготовить разговор для отправки. Пожалуйста, попробуйте снова.';
+  String get failedToPrepareConversationForSharing => 'Не удалось подготовить разговор для отправки. Пожалуйста, попробуйте снова.';
 
   @override
   String get couldNotOpenSmsApp => 'Не удалось открыть приложение SMS. Пожалуйста, попробуйте снова.';
@@ -6727,8 +6590,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Загрузка аудио с SD-карты вашего устройства';
 
   @override
-  String get transferRequiredDescription =>
-      'Эта запись хранится на SD-карте вашего устройства. Передайте её на телефон для воспроизведения или обмена.';
+  String get transferRequiredDescription => 'Эта запись хранится на SD-карте вашего устройства. Передайте её на телефон для воспроизведения или обмена.';
 
   @override
   String get cancelTransfer => 'Отменить передачу';
@@ -6749,8 +6611,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get shareRecording => 'Поделиться записью';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Вы уверены, что хотите безвозвратно удалить эту запись? Это действие нельзя отменить.';
+  String get deleteRecordingConfirmation => 'Вы уверены, что хотите безвозвратно удалить эту запись? Это действие нельзя отменить.';
 
   @override
   String get recordingIdLabel => 'ID записи';
@@ -6809,8 +6670,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get enableFastTransfer => 'Включить быструю передачу';
 
   @override
-  String get fastTransferDescription =>
-      'Быстрая передача использует WiFi для ~5x более быстрых скоростей. Ваш телефон временно подключится к WiFi-сети устройства Omi во время передачи.';
+  String get fastTransferDescription => 'Быстрая передача использует WiFi для ~5x более быстрых скоростей. Ваш телефон временно подключится к WiFi-сети устройства Omi во время передачи.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Доступ в интернет приостановлен во время передачи';
@@ -6825,8 +6685,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get fiveTimesFaster => 'В 5 РАЗ БЫСТРЕЕ';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Создаёт прямое WiFi-подключение к устройству Omi. Телефон временно отключается от обычного WiFi во время передачи.';
+  String get fastTransferMethodDescription => 'Создаёт прямое WiFi-подключение к устройству Omi. Телефон временно отключается от обычного WiFi во время передачи.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6835,8 +6694,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get bleSpeed => '~30 КБ/с через BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Использует стандартное подключение Bluetooth Low Energy. Медленнее, но не влияет на WiFi-соединение.';
+  String get bluetoothMethodDescription => 'Использует стандартное подключение Bluetooth Low Energy. Медленнее, но не влияет на WiFi-соединение.';
 
   @override
   String get selected => 'Выбрано';
@@ -6854,8 +6712,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'Ваше устройство Omi отключено';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'Пожалуйста, подключитесь снова, чтобы продолжить использование Omi.';
+  String get deviceDisconnectedNotificationBody => 'Пожалуйста, подключитесь снова, чтобы продолжить использование Omi.';
 
   @override
   String get firmwareUpdateAvailable => 'Доступно обновление прошивки';
@@ -6875,12 +6732,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get appDeleteFailed => 'Не удалось удалить приложение. Попробуйте позже.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Видимость приложения успешно изменена. Изменения могут отобразиться через несколько минут.';
+  String get appVisibilityChangedSuccessfully => 'Видимость приложения успешно изменена. Изменения могут отобразиться через несколько минут.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Ошибка при активации приложения. Если это приложение-интеграция, убедитесь, что настройка завершена.';
+  String get errorActivatingAppIntegration => 'Ошибка при активации приложения. Если это приложение-интеграция, убедитесь, что настройка завершена.';
 
   @override
   String get errorUpdatingAppStatus => 'Произошла ошибка при обновлении статуса приложения.';
@@ -7147,19 +7002,16 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Обновление запланировано! Ваш месячный план продолжает действовать до конца расчётного периода, затем автоматически переключится на годовой.';
+  String get planUpgradeScheduledMessage => 'Обновление запланировано! Ваш месячный план продолжает действовать до конца расчётного периода, затем автоматически переключится на годовой.';
 
   @override
   String get couldNotSchedulePlanChange => 'Не удалось запланировать смену тарифа. Пожалуйста, попробуйте снова.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Ваша подписка восстановлена! Оплата сейчас не взимается — счёт будет выставлен в конце текущего периода.';
+  String get subscriptionReactivatedDefault => 'Ваша подписка восстановлена! Оплата сейчас не взимается — счёт будет выставлен в конце текущего периода.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Подписка успешно оформлена! Вам выставлен счёт за новый расчётный период.';
+  String get subscriptionSuccessfulCharged => 'Подписка успешно оформлена! Вам выставлен счёт за новый расчётный период.';
 
   @override
   String get couldNotProcessSubscription => 'Не удалось обработать подписку. Пожалуйста, попробуйте снова.';
@@ -7324,8 +7176,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Не удалось получить токен Firebase, пожалуйста, попробуйте снова.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Непредвиденная ошибка при входе, ошибка Firebase, пожалуйста, попробуйте снова.';
+  String get authUnexpectedErrorFirebase => 'Непредвиденная ошибка при входе, ошибка Firebase, пожалуйста, попробуйте снова.';
 
   @override
   String get authUnexpectedError => 'Непредвиденная ошибка при входе, пожалуйста, попробуйте снова';
@@ -7340,8 +7191,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Для подключения к устройству требуется разрешение Bluetooth.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Разрешение Bluetooth отклонено. Предоставьте разрешение в Системных настройках.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Разрешение Bluetooth отклонено. Предоставьте разрешение в Системных настройках.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7354,12 +7204,10 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Разрешение на уведомления отклонено. Предоставьте разрешение в Системных настройках.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Разрешение на уведомления отклонено. Предоставьте разрешение в Системных настройках.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Разрешение на уведомления отклонено. Предоставьте разрешение в Системные настройки > Уведомления.';
+  String get onboardingNotificationDeniedNotifications => 'Разрешение на уведомления отклонено. Предоставьте разрешение в Системные настройки > Уведомления.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7372,15 +7220,13 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Предоставьте разрешение на геолокацию в Настройки > Конфиденциальность и безопасность > Службы геолокации';
+  String get onboardingLocationGrantInSettings => 'Предоставьте разрешение на геолокацию в Настройки > Конфиденциальность и безопасность > Службы геолокации';
 
   @override
   String get onboardingMicrophoneRequired => 'Для записи требуется разрешение микрофона.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Разрешение микрофона отклонено. Предоставьте разрешение в Системные настройки > Конфиденциальность и безопасность > Микрофон.';
+  String get onboardingMicrophoneDenied => 'Разрешение микрофона отклонено. Предоставьте разрешение в Системные настройки > Конфиденциальность и безопасность > Микрофон.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7396,8 +7242,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Для записи системного звука требуется разрешение на захват экрана.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Разрешение на захват экрана отклонено. Предоставьте разрешение в Системные настройки > Конфиденциальность и безопасность > Запись экрана.';
+  String get onboardingScreenCaptureDenied => 'Разрешение на захват экрана отклонено. Предоставьте разрешение в Системные настройки > Конфиденциальность и безопасность > Запись экрана.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7410,8 +7255,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Для обнаружения встреч в браузере требуется разрешение на специальные возможности.';
+  String get onboardingAccessibilityRequired => 'Для обнаружения встреч в браузере требуется разрешение на специальные возможности.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7451,8 +7295,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Разрешение на фото отклонено. Пожалуйста, разрешите доступ к фото для выбора изображений';
+  String get msgPhotosPermissionDenied => 'Разрешение на фото отклонено. Пожалуйста, разрешите доступ к фото для выбора изображений';
 
   @override
   String get msgSelectImagesGenericError => 'Ошибка выбора изображений. Пожалуйста, попробуйте снова.';
@@ -7494,8 +7337,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Требуется разрешение на использование микрофона';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Предоставьте разрешение на микрофон в Системных настройках';
+  String get captureMicrophonePermissionInSystemPreferences => 'Предоставьте разрешение на микрофон в Системных настройках';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Требуется разрешение на запись экрана';
@@ -7507,8 +7349,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get devModeInvalidAudioBytesWebhookUrl => 'Недействительный URL вебхука аудио-байтов';
 
   @override
-  String get devModeInvalidRealtimeTranscriptWebhookUrl =>
-      'Недействительный URL вебхука транскрипции в реальном времени';
+  String get devModeInvalidRealtimeTranscriptWebhookUrl => 'Недействительный URL вебхука транскрипции в реальном времени';
 
   @override
   String get devModeInvalidConversationCreatedWebhookUrl => 'Недействительный URL вебхука созданной беседы';
@@ -7526,8 +7367,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get locationPermissionRequired => 'Требуется разрешение на местоположение';
 
   @override
-  String get locationPermissionContent =>
-      'Для быстрой передачи требуется разрешение на определение местоположения для проверки WiFi-соединения. Пожалуйста, предоставьте разрешение на местоположение, чтобы продолжить.';
+  String get locationPermissionContent => 'Для быстрой передачи требуется разрешение на определение местоположения для проверки WiFi-соединения. Пожалуйста, предоставьте разрешение на местоположение, чтобы продолжить.';
 
   @override
   String get pdfTranscriptExport => 'Экспорт транскрипции';
@@ -7690,8 +7530,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Устройство не поддерживает синхронизацию WiFi, переключение на Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Устройство не поддерживает синхронизацию WiFi, переключение на Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health недоступно на этом устройстве';
@@ -7987,8 +7826,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Переведите Omi DevKit в режим сопряжения';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Нажмите кнопку один раз для включения. Светодиод будет мигать фиолетовым в режиме сопряжения.';
+  String get pairingDescOmiDevkit => 'Нажмите кнопку один раз для включения. Светодиод будет мигать фиолетовым в режиме сопряжения.';
 
   @override
   String get pairingTitleOmiGlass => 'Включите Omi Glass';
@@ -8000,8 +7838,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Переведите Plaud Note в режим сопряжения';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Нажмите и удерживайте боковую кнопку 2 секунды. Красный светодиод замигает, когда устройство будет готово к сопряжению.';
+  String get pairingDescPlaudNote => 'Нажмите и удерживайте боковую кнопку 2 секунды. Красный светодиод замигает, когда устройство будет готово к сопряжению.';
 
   @override
   String get pairingTitleBee => 'Переведите Bee в режим сопряжения';
@@ -8013,15 +7850,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get pairingTitleLimitless => 'Переведите Limitless в режим сопряжения';
 
   @override
-  String get pairingDescLimitless =>
-      'Когда горит любой индикатор, нажмите один раз, затем нажмите и удерживайте, пока устройство не покажет розовый свет, затем отпустите.';
+  String get pairingDescLimitless => 'Когда горит любой индикатор, нажмите один раз, затем нажмите и удерживайте, пока устройство не покажет розовый свет, затем отпустите.';
 
   @override
   String get pairingTitleFriendPendant => 'Переведите Friend Pendant в режим сопряжения';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Нажмите кнопку на кулоне, чтобы включить его. Он автоматически перейдёт в режим сопряжения.';
+  String get pairingDescFriendPendant => 'Нажмите кнопку на кулоне, чтобы включить его. Он автоматически перейдёт в режим сопряжения.';
 
   @override
   String get pairingTitleFieldy => 'Переведите Fieldy в режим сопряжения';
@@ -8033,15 +7868,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Подключить Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Установите и откройте приложение Omi на Apple Watch, затем нажмите Подключить в приложении.';
+  String get pairingDescAppleWatch => 'Установите и откройте приложение Omi на Apple Watch, затем нажмите Подключить в приложении.';
 
   @override
   String get pairingTitleNeoOne => 'Переведите Neo One в режим сопряжения';
 
   @override
-  String get pairingDescNeoOne =>
-      'Нажмите и удерживайте кнопку питания, пока не замигает светодиод. Устройство станет обнаруживаемым.';
+  String get pairingDescNeoOne => 'Нажмите и удерживайте кнопку питания, пока не замигает светодиод. Устройство станет обнаруживаемым.';
 
   @override
   String get downloadingFromDevice => 'Загрузка с устройства';
@@ -8129,8 +7962,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Вот что я знаю о тебе';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Эта карта обновляется по мере того, как Omi учится на ваших разговорах.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Эта карта обновляется по мере того, как Omi учится на ваших разговорах.';
 
   @override
   String get apiEnvironment => 'Среда API';
@@ -8159,12 +7991,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get switchAndRestart => 'Переключить';
 
   @override
-  String get stagingDisclaimer =>
-      'Тестовая среда может быть нестабильной, с непостоянной производительностью, и данные могут быть потеряны. Только для тестирования.';
+  String get stagingDisclaimer => 'Тестовая среда может быть нестабильной, с непостоянной производительностью, и данные могут быть потеряны. Только для тестирования.';
 
   @override
-  String get apiEnvSavedRestartRequired =>
-      'Сохранено. Закройте и снова откройте приложение, чтобы применить изменения.';
+  String get apiEnvSavedRestartRequired => 'Сохранено. Закройте и снова откройте приложение, чтобы применить изменения.';
 
   @override
   String get shared => 'Общий';
@@ -8390,8 +8220,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Звонки через Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Совершайте звонки через Omi и получайте транскрипцию в реальном времени, автоматические сводки и многое другое.';
+  String get phoneCallsUpsellSubtitle => 'Совершайте звонки через Omi и получайте транскрипцию в реальном времени, автоматические сводки и многое другое.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Транскрипция каждого звонка в реальном времени';
@@ -8418,8 +8247,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteSyncedFiles => 'Удалить синхронизированные записи';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Эти записи уже синхронизированы с вашим телефоном. Это действие нельзя отменить.';
+  String get deleteSyncedFilesMessage => 'Эти записи уже синхронизированы с вашим телефоном. Это действие нельзя отменить.';
 
   @override
   String get syncedFilesDeleted => 'Синхронизированные записи удалены';
@@ -8431,8 +8259,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deletePendingFiles => 'Удалить ожидающие записи';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Эти записи НЕ синхронизированы с вашим телефоном и будут безвозвратно потеряны. Это действие нельзя отменить.';
+  String get deletePendingFilesWarning => 'Эти записи НЕ синхронизированы с вашим телефоном и будут безвозвратно потеряны. Это действие нельзя отменить.';
 
   @override
   String get pendingFilesDeleted => 'Ожидающие записи удалены';
@@ -8444,8 +8271,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deleteAll => 'Удалить все';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Это удалит синхронизированные и ожидающие записи. Ожидающие записи НЕ синхронизированы и будут безвозвратно потеряны.';
+  String get deleteAllFilesWarning => 'Это удалит синхронизированные и ожидающие записи. Ожидающие записи НЕ синхронизированы и будут безвозвратно потеряны.';
 
   @override
   String get allFilesDeleted => 'Все записи удалены';
@@ -8477,8 +8303,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get fairUsePolicy => 'Добросовестное использование';
 
   @override
-  String get fairUseLoadError =>
-      'Не удалось загрузить статус добросовестного использования. Пожалуйста, попробуйте снова.';
+  String get fairUseLoadError => 'Не удалось загрузить статус добросовестного использования. Пожалуйста, попробуйте снова.';
 
   @override
   String get fairUseStatusNormal => 'Ваше использование в пределах нормы.';
@@ -8511,8 +8336,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get fairUseAboutTitle => 'О добросовестном использовании';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi предназначен для личных разговоров, встреч и живого общения. Использование измеряется по фактическому обнаруженному времени речи, а не по времени подключения. Если использование значительно превышает обычные модели для неличного контента, могут применяться корректировки.';
+  String get fairUseAboutBody => 'Omi предназначен для личных разговоров, встреч и живого общения. Использование измеряется по фактическому обнаруженному времени речи, а не по времени подключения. Если использование значительно превышает обычные модели для неличного контента, могут применяться корректировки.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8550,8 +8374,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get improveConnectionTitle => 'Улучшить соединение';
 
   @override
-  String get improveConnectionContent =>
-      'Мы улучшили способ подключения Omi к вашему устройству. Чтобы активировать это, перейдите на страницу информации об устройстве, нажмите \"Отключить устройство\" и снова подключите ваше устройство.';
+  String get improveConnectionContent => 'Мы улучшили способ подключения Omi к вашему устройству. Чтобы активировать это, перейдите на страницу информации об устройстве, нажмите \"Отключить устройство\" и снова подключите ваше устройство.';
 
   @override
   String get improveConnectionAction => 'Понятно';
@@ -8606,16 +8429,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get cancelSyncQuestion => 'Отменить синхронизацию?';
 
   @override
-  String get omisStorageDesc =>
-      'Когда ваш Omi не подключён к телефону, он сохраняет аудио локально во встроенной памяти. Вы никогда не потеряете запись.';
+  String get omisStorageDesc => 'Когда ваш Omi не подключён к телефону, он сохраняет аудио локально во встроенной памяти. Вы никогда не потеряете запись.';
 
   @override
-  String get phoneStorageDesc =>
-      'При повторном подключении Omi записи автоматически переносятся на телефон перед загрузкой.';
+  String get phoneStorageDesc => 'При повторном подключении Omi записи автоматически переносятся на телефон перед загрузкой.';
 
   @override
-  String get cloudStorageDesc =>
-      'После загрузки ваши записи обрабатываются и расшифровываются. Разговоры будут доступны в течение минуты.';
+  String get cloudStorageDesc => 'После загрузки ваши записи обрабатываются и расшифровываются. Разговоры будут доступны в течение минуты.';
 
   @override
   String get tipKeepPhoneNearby => 'Держите телефон рядом для быстрой синхронизации';
@@ -8639,12 +8459,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get permissionEnable => 'Включить';
 
   @override
-  String get permissionsPageDescription =>
-      'Эти разрешения необходимы для работы Omi. Они обеспечивают ключевые функции, такие как уведомления, функции на основе местоположения и запись звука.';
+  String get permissionsPageDescription => 'Эти разрешения необходимы для работы Omi. Они обеспечивают ключевые функции, такие как уведомления, функции на основе местоположения и запись звука.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi нужны некоторые разрешения для правильной работы. Пожалуйста, предоставьте их, чтобы продолжить.';
+  String get permissionsRequiredDescription => 'Omi нужны некоторые разрешения для правильной работы. Пожалуйста, предоставьте их, чтобы продолжить.';
 
   @override
   String get permissionsSetupTitle => 'Получите лучший опыт';
@@ -8900,8 +8718,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get enableLocationTitle => 'Включить местоположение';
 
   @override
-  String get enableLocationDescription =>
-      'Разрешение на определение местоположения необходимо для поиска ближайших Bluetooth-устройств.';
+  String get enableLocationDescription => 'Разрешение на определение местоположения необходимо для поиска ближайших Bluetooth-устройств.';
 
   @override
   String get voiceRecordingFound => 'Запись найдена';
@@ -8922,8 +8739,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get firmwareWarningTitle => 'Важно: Прочитайте перед обновлением';
 
   @override
-  String get firmwareFormatWarning =>
-      'Эта прошивка отформатирует SD-карту. Пожалуйста, убедитесь, что все офлайн-данные синхронизированы перед обновлением.\n\nЕсли после установки этой версии вы увидите мигающий красный свет, не беспокойтесь. Просто подключите устройство к приложению, и оно должно стать синим. Красный свет означает, что часы устройства ещё не синхронизированы.';
+  String get firmwareFormatWarning => 'Эта прошивка отформатирует SD-карту. Пожалуйста, убедитесь, что все офлайн-данные синхронизированы перед обновлением.\n\nЕсли после установки этой версии вы увидите мигающий красный свет, не беспокойтесь. Просто подключите устройство к приложению, и оно должно стать синим. Красный свет означает, что часы устройства ещё не синхронизированы.';
 
   @override
   String get continueAnyway => 'Продолжить';
@@ -8943,8 +8759,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get tasksMarkComplete => 'Отмечено как выполненное';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi получает доступ к Apple Health через фреймворк HealthKit от Apple. Вы можете отозвать доступ в любой момент в Настройках iOS.';
+  String get appleHealthManageNote => 'Omi получает доступ к Apple Health через фреймворк HealthKit от Apple. Вы можете отозвать доступ в любой момент в Настройках iOS.';
 
   @override
   String get appleHealthConnectCta => 'Подключить Apple Health';
@@ -8977,8 +8792,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Доступ к Apple Health запрещён';
 
   @override
-  String get appleHealthDeniedBody =>
-      'У Omi нет разрешения на чтение данных Apple Health. Включите его в Настройках iOS → Конфиденциальность и безопасность → Здоровье → Omi.';
+  String get appleHealthDeniedBody => 'У Omi нет разрешения на чтение данных Apple Health. Включите его в Настройках iOS → Конфиденциальность и безопасность → Здоровье → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Почему вы уходите?';
@@ -9047,8 +8861,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get planUpdate => 'Обновление плана';
 
   @override
-  String get planDeprecationMessage =>
-      'Ваш план Unlimited прекращается. Перейдите на план Operator — те же отличные функции за \$49/мес. Ваш текущий план продолжит работать тем временем.';
+  String get planDeprecationMessage => 'Ваш план Unlimited прекращается. Перейдите на план Operator — те же отличные функции за \$49/мес. Ваш текущий план продолжит работать тем временем.';
 
   @override
   String get upgradeYourPlan => 'Улучшите свой план';
@@ -9159,8 +8972,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Вы достигли месячного лимита. Обновите план, чтобы продолжить общение с Omi без ограничений.';
+  String get chatQuotaExceededReply => 'Вы достигли месячного лимита. Обновите план, чтобы продолжить общение с Omi без ограничений.';
 
   @override
   String get voiceResponseAudio => 'Читать ответ Omi вслух';
@@ -9191,4 +9003,25 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Добавить задачу';
+
+  @override
+  String get quickActionAskOmiAnything => 'Спросите Omi о чём угодно';
+
+  @override
+  String get quickActionVoiceMode => 'Голосовой режим';
+
+  @override
+  String get quickActionMute => 'Отключить звук';
+
+  @override
+  String get quickActionUnmute => 'Включить звук';
+
+  @override
+  String get quickActionConnectDevice => 'Подключить устройство';
+
+  @override
+  String get quickActionDeviceSettings => 'Настройки устройства';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -24,8 +24,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteConversationTitle => 'Odstrániť konverzáciu?';
 
   @override
-  String get deleteConversationMessage =>
-      'Tým sa tiež vymažú súvisiace spomienky, úlohy a zvukové súbory. Túto akciu nie je možné vrátiť späť.';
+  String get deleteConversationMessage => 'Tým sa tiež vymažú súvisiace spomienky, úlohy a zvukové súbory. Túto akciu nie je možné vrátiť späť.';
 
   @override
   String get confirm => 'Potvrdiť';
@@ -146,8 +145,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleting => 'Odstraňuje sa...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
+  String get pleaseCompleteAuthentication => 'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
 
   @override
   String get failedToStartAuthentication => 'Nepodarilo sa spustiť autentifikáciu';
@@ -228,8 +226,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noStarredConversations => 'Žiadne konverzácie s hviezdičkou';
 
   @override
-  String get starConversationHint =>
-      'Ak chcete označiť konverzáciu hviezdičkou, otvorte ju a ťuknite na ikonu hviezdy v hlavičke.';
+  String get starConversationHint => 'Ak chcete označiť konverzáciu hviezdičkou, otvorte ju a ťuknite na ikonu hviezdy v hlavičke.';
 
   @override
   String get searchConversations => 'Hľadať konverzácie...';
@@ -320,8 +317,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get installedApps => 'Nainštalované aplikácie';
 
   @override
-  String get unableToFetchApps =>
-      'Nepodarilo sa načítať aplikácie :(\n\nSkontrolujte prosím svoje internetové pripojenie a skúste to znova.';
+  String get unableToFetchApps => 'Nepodarilo sa načítať aplikácie :(\n\nSkontrolujte prosím svoje internetové pripojenie a skúste to znova.';
 
   @override
   String get aboutOmi => 'O Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsSk extends AppLocalizations {
   String get appsDisconnected => 'Vaše aplikácie a integrácie budú okamžite odpojené.';
 
   @override
-  String get exportBeforeDelete =>
-      'Pred odstránením účtu môžete exportovať svoje údaje, ale po odstránení ich nebude možné obnoviť.';
+  String get exportBeforeDelete => 'Pred odstránením účtu môžete exportovať svoje údaje, ale po odstránení ich nebude možné obnoviť.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Rozumiem, že odstránenie môjho účtu je trvalé a všetky údaje vrátane spomienok a konverzácií budú stratené a nebude ich možné obnoviť.';
+  String get deleteAccountCheckbox => 'Rozumiem, že odstránenie môjho účtu je trvalé a všetky údaje vrátane spomienok a konverzácií budú stratené a nebude ich možné obnoviť.';
 
   @override
   String get areYouSure => 'Ste si istí?';
 
   @override
-  String get deleteAccountFinal =>
-      'Táto akcia je nezvratná a natrvalo odstráni váš účet a všetky súvisiace údaje. Naozaj chcete pokračovať?';
+  String get deleteAccountFinal => 'Táto akcia je nezvratná a natrvalo odstráni váš účet a všetky súvisiace údaje. Naozaj chcete pokračovať?';
 
   @override
   String get deleteNow => 'Odstrániť teraz';
@@ -378,8 +371,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get goBack => 'Vrátiť sa';
 
   @override
-  String get checkBoxToConfirm =>
-      'Začiarknite políčko na potvrdenie, že rozumiete, že odstránenie vášho účtu je trvalé a nezvratné.';
+  String get checkBoxToConfirm => 'Začiarknite políčko na potvrdenie, že rozumiete, že odstránenie vášho účtu je trvalé a nezvratné.';
 
   @override
   String get profile => 'Profil';
@@ -457,8 +449,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get yourPrivacyYourControl => 'Vaše súkromie, vaša kontrola';
 
   @override
-  String get privacyIntro =>
-      'V Omi sa zaväzujeme chrániť vaše súkromie. Táto stránka vám umožňuje kontrolovať, ako sú vaše údaje ukladané a používané.';
+  String get privacyIntro => 'V Omi sa zaväzujeme chrániť vaše súkromie. Táto stránka vám umožňuje kontrolovať, ako sú vaše údaje ukladané a používané.';
 
   @override
   String get learnMore => 'Dozvedieť sa viac...';
@@ -467,15 +458,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get dataProtectionLevel => 'Úroveň ochrany údajov';
 
   @override
-  String get dataProtectionDesc =>
-      'Vaše údaje sú predvolene zabezpečené silným šifrovaním. Skontrolujte svoje nastavenia a budúce možnosti ochrany súkromia nižšie.';
+  String get dataProtectionDesc => 'Vaše údaje sú predvolene zabezpečené silným šifrovaním. Skontrolujte svoje nastavenia a budúce možnosti ochrany súkromia nižšie.';
 
   @override
   String get appAccess => 'Prístup aplikácií';
 
   @override
-  String get appAccessDesc =>
-      'Nasledujúce aplikácie majú prístup k vašim údajom. Ťuknutím na aplikáciu spravujte jej oprávnenia.';
+  String get appAccessDesc => 'Nasledujúce aplikácie majú prístup k vašim údajom. Ťuknutím na aplikáciu spravujte jej oprávnenia.';
 
   @override
   String get noAppsExternalAccess => 'Žiadne nainštalované aplikácie nemajú externý prístup k vašim údajom.';
@@ -532,22 +521,19 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Vaše Omi bolo odpojené 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Zariadenie odpárované. Prejdite do Nastavenia > Bluetooth a zabudnite zariadenie na dokončenie odpárovania.';
+  String get deviceUnpairedMessage => 'Zariadenie odpárované. Prejdite do Nastavenia > Bluetooth a zabudnite zariadenie na dokončenie odpárovania.';
 
   @override
   String get unpairDialogTitle => 'Zrušiť párovanie zariadenia';
 
   @override
-  String get unpairDialogMessage =>
-      'Týmto sa zruší párovanie zariadenia, aby sa mohlo pripojiť k inému telefónu. Budete musieť prejsť do Nastavenia > Bluetooth a zabudnúť zariadenie pre dokončenie procesu.';
+  String get unpairDialogMessage => 'Týmto sa zruší párovanie zariadenia, aby sa mohlo pripojiť k inému telefónu. Budete musieť prejsť do Nastavenia > Bluetooth a zabudnúť zariadenie pre dokončenie procesu.';
 
   @override
   String get deviceNotConnected => 'Zariadenie nie je pripojené';
 
   @override
-  String get connectDeviceMessage =>
-      'Pripojte svoje zariadenie Omi pre prístup\nk nastaveniam a prispôsobeniu zariadenia';
+  String get connectDeviceMessage => 'Pripojte svoje zariadenie Omi pre prístup\nk nastaveniam a prispôsobeniu zariadenia';
 
   @override
   String get deviceInfoSection => 'Informácie o zariadení';
@@ -562,8 +548,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get v2Undetected => 'V2 nebolo zistené';
 
   @override
-  String get v2UndetectedMessage =>
-      'Zistili sme, že máte zariadenie V1 alebo vaše zariadenie nie je pripojené. Funkcia SD karty je dostupná len pre zariadenia V2.';
+  String get v2UndetectedMessage => 'Zistili sme, že máte zariadenie V1 alebo vaše zariadenie nie je pripojené. Funkcia SD karty je dostupná len pre zariadenia V2.';
 
   @override
   String get endConversation => 'Ukončiť konverzáciu';
@@ -695,8 +680,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noActivityYet => 'Zatiaľ žiadna aktivita';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Začnite konverzáciu s Omi,\naby ste tu videli svoje štatistiky využitia.';
+  String get startConversationToSeeInsights => 'Začnite konverzáciu s Omi,\naby ste tu videli svoje štatistiky využitia.';
 
   @override
   String get listening => 'Počúvanie';
@@ -838,8 +822,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Odstrániť graf znalostí?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Týmto odstránite všetky odvodené údaje grafu znalostí (uzly a prepojenia). Vaše pôvodné spomienky zostanú v bezpečí. Graf bude znovu vytvorený postupom času alebo na ďalšiu požiadavku.';
+  String get deleteKnowledgeGraphMessage => 'Týmto odstránite všetky odvodené údaje grafu znalostí (uzly a prepojenia). Vaše pôvodné spomienky zostanú v bezpečí. Graf bude znovu vytvorený postupom času alebo na ďalšiu požiadavku.';
 
   @override
   String get knowledgeGraphDeleted => 'Graf znalostí zmazaný';
@@ -987,8 +970,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get shortConversationThreshold => 'Hranica krátkej konverzácie';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Konverzácie kratšie ako toto budú skryté, pokiaľ nie sú povolené vyššie';
+  String get shortConversationThresholdSubtitle => 'Konverzácie kratšie ako toto budú skryté, pokiaľ nie sú povolené vyššie';
 
   @override
   String get durationThreshold => 'Hranica trvania';
@@ -1023,8 +1005,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get integrationsFooter => 'Pripojte svoje aplikácie na zobrazenie údajov a metrík v chate.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
+  String get completeAuthInBrowser => 'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1084,8 +1065,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get needYourPermission => 'Potrebujeme vaše povolenie';
 
   @override
-  String get alreadyGavePermission =>
-      'Už ste nám dali povolenie uložiť vaše nahrávky. Tu je pripomenutie, prečo ho potrebujeme:';
+  String get alreadyGavePermission => 'Už ste nám dali povolenie uložiť vaše nahrávky. Tu je pripomenutie, prečo ho potrebujeme:';
 
   @override
   String get wouldLikePermission => 'Chceli by sme vaše povolenie na uloženie vašich hlasových nahrávok. Tu je dôvod:';
@@ -1094,26 +1074,22 @@ class AppLocalizationsSk extends AppLocalizations {
   String get improveSpeechProfile => 'Zlepšiť váš hlasový profil';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Používame nahrávky na ďalšie trénovanie a vylepšenie vášho osobného hlasového profilu.';
+  String get improveSpeechProfileDesc => 'Používame nahrávky na ďalšie trénovanie a vylepšenie vášho osobného hlasového profilu.';
 
   @override
   String get trainFamilyProfiles => 'Trénovať profily pre priateľov a rodinu';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Vaše nahrávky nám pomáhajú rozpoznávať a vytvárať profily pre vašich priateľov a rodinu.';
+  String get trainFamilyProfilesDesc => 'Vaše nahrávky nám pomáhajú rozpoznávať a vytvárať profily pre vašich priateľov a rodinu.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Zlepšiť presnosť prepisu';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Keď sa náš model zlepší, môžeme poskytovať lepšie výsledky prepisu pre vaše nahrávky.';
+  String get enhanceTranscriptAccuracyDesc => 'Keď sa náš model zlepší, môžeme poskytovať lepšie výsledky prepisu pre vaše nahrávky.';
 
   @override
-  String get legalNotice =>
-      'Právne upozornenie: Zákonnosť nahrávania a ukladania hlasových dát sa môže líšiť v závislosti od vašej lokality a spôsobu používania tejto funkcie. Je vašou zodpovednosťou zabezpečiť súlad s miestnymi zákonmi a predpismi.';
+  String get legalNotice => 'Právne upozornenie: Zákonnosť nahrávania a ukladania hlasových dát sa môže líšiť v závislosti od vašej lokality a spôsobu používania tejto funkcie. Je vašou zodpovednosťou zabezpečiť súlad s miestnymi zákonmi a predpismi.';
 
   @override
   String get alreadyAuthorized => 'Už autorizované';
@@ -1191,8 +1167,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get showEventsNoParticipants => 'Zobraziť udalosti bez účastníkov';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Keď je povolené, Nadchádzajúce zobrazí udalosti bez účastníkov alebo video odkazu.';
+  String get showEventsNoParticipantsDesc => 'Keď je povolené, Nadchádzajúce zobrazí udalosti bez účastníkov alebo video odkazu.';
 
   @override
   String get yourMeetings => 'Vaše stretnutia';
@@ -1360,8 +1335,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get defaultRepository => 'Predvolený repozitár';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Vyberte predvolený repozitár pre vytváranie problémov. Pri vytváraní problémov môžete stále zadať iný repozitár.';
+  String get selectDefaultRepoDesc => 'Vyberte predvolený repozitár pre vytváranie problémov. Pri vytváraní problémov môžete stále zadať iný repozitár.';
 
   @override
   String get noReposFound => 'Neboli nájdené žiadne repozitáre';
@@ -1408,8 +1382,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get configureSettings => 'Konfigurovať nastavenia';
 
   @override
-  String get completeAuthBrowser =>
-      'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
+  String get completeAuthBrowser => 'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1737,8 +1710,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get enableBluetooth => 'Povoliť Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi potrebuje Bluetooth na pripojenie k vášmu nositeľnému zariadeniu. Povoľte prosím Bluetooth a skúste to znova.';
+  String get bluetoothNeeded => 'Omi potrebuje Bluetooth na pripojenie k vášmu nositeľnému zariadeniu. Povoľte prosím Bluetooth a skúste to znova.';
 
   @override
   String get contactSupport => 'Kontaktovať podporu?';
@@ -1771,26 +1743,22 @@ class AppLocalizationsSk extends AppLocalizations {
   String get locationServiceDisabled => 'Služba polohy je vypnutá';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Služba polohy je vypnutá. Prejdite do Nastavenia > Súkromie a zabezpečenie > Služby polohy a povoľte ju';
+  String get locationServiceDisabledDesc => 'Služba polohy je vypnutá. Prejdite do Nastavenia > Súkromie a zabezpečenie > Služby polohy a povoľte ju';
 
   @override
   String get backgroundLocationDenied => 'Prístup k polohe na pozadí bol zamietnutý';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Prejdite do nastavení zariadenia a nastavte povolenie polohy na \"Vždy povoliť\"';
+  String get backgroundLocationDeniedDesc => 'Prejdite do nastavení zariadenia a nastavte povolenie polohy na \"Vždy povoliť\"';
 
   @override
   String get lovingOmi => 'Páči sa vám Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Pomôžte nám osloviť viac ľudí tým, že zanecháte recenziu v App Store. Vaša spätná väzba pre nás znamená celý svet!';
+  String get leaveReviewIos => 'Pomôžte nám osloviť viac ľudí tým, že zanecháte recenziu v App Store. Vaša spätná väzba pre nás znamená celý svet!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Pomôžte nám osloviť viac ľudí tým, že zanecháte recenziu v Google Play Store. Vaša spätná väzba pre nás znamená celý svet!';
+  String get leaveReviewAndroid => 'Pomôžte nám osloviť viac ľudí tým, že zanecháte recenziu v Google Play Store. Vaša spätná väzba pre nás znamená celý svet!';
 
   @override
   String get rateOnAppStore => 'Ohodnotiť v App Store';
@@ -1823,15 +1791,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get connectionError => 'Chyba pripojenia';
 
   @override
-  String get connectionErrorDesc =>
-      'Nepodarilo sa pripojiť k serveru. Skontrolujte prosím svoje internetové pripojenie a skúste to znova.';
+  String get connectionErrorDesc => 'Nepodarilo sa pripojiť k serveru. Skontrolujte prosím svoje internetové pripojenie a skúste to znova.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Bola zistená neplatná nahrávka';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Zdá sa, že v nahrávke je viacero rečníkov. Uistite sa, že ste na tichom mieste, a skúste to znova.';
+  String get multipleSpeakersDesc => 'Zdá sa, že v nahrávke je viacero rečníkov. Uistite sa, že ste na tichom mieste, a skúste to znova.';
 
   @override
   String get tooShortDesc => 'Nezistilo sa dostatok reči. Hovorte viac a skúste to znova.';
@@ -1843,15 +1809,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get areYouThere => 'Ste tam?';
 
   @override
-  String get noSpeechDesc =>
-      'Nepodarilo sa zistiť žiadnu reč. Uistite sa, že hovoríte minimálne 10 sekúnd a najviac 3 minúty.';
+  String get noSpeechDesc => 'Nepodarilo sa zistiť žiadnu reč. Uistite sa, že hovoríte minimálne 10 sekúnd a najviac 3 minúty.';
 
   @override
   String get connectionLost => 'Pripojenie bolo stratené';
 
   @override
-  String get connectionLostDesc =>
-      'Pripojenie bolo prerušené. Skontrolujte prosím svoje internetové pripojenie a skúste to znova.';
+  String get connectionLostDesc => 'Pripojenie bolo prerušené. Skontrolujte prosím svoje internetové pripojenie a skúste to znova.';
 
   @override
   String get tryAgain => 'Skúsiť znova';
@@ -1866,8 +1830,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get permissionsRequired => 'Vyžadované oprávnenia';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Táto aplikácia potrebuje povolenia Bluetooth a Poloha, aby mohla správne fungovať. Povoľte ich prosím v nastaveniach.';
+  String get permissionsRequiredDesc => 'Táto aplikácia potrebuje povolenia Bluetooth a Poloha, aby mohla správne fungovať. Povoľte ich prosím v nastaveniach.';
 
   @override
   String get openSettings => 'Otvoriť nastavenia';
@@ -1897,8 +1860,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Váš AI spoločník';
 
   @override
-  String get captureEveryMoment =>
-      'Zachyťte každý moment. Získajte zhrnutia\npoháňané AI. Nikdy viac si nerobte poznámky.';
+  String get captureEveryMoment => 'Zachyťte každý moment. Získajte zhrnutia\npoháňané AI. Nikdy viac si nerobte poznámky.';
 
   @override
   String get appleWatchSetup => 'Nastavenie Apple Watch';
@@ -1910,12 +1872,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get microphonePermission => 'Povolenie mikrofónu';
 
   @override
-  String get permissionGrantedNow =>
-      'Povolenie bolo udelené! Teraz:\n\nOtvorte aplikáciu Omi na hodinkách a ťuknite na \"Pokračovať\" nižšie';
+  String get permissionGrantedNow => 'Povolenie bolo udelené! Teraz:\n\nOtvorte aplikáciu Omi na hodinkách a ťuknite na \"Pokračovať\" nižšie';
 
   @override
-  String get needMicrophonePermission =>
-      'Potrebujeme povolenie mikrofónu.\n\n1. Ťuknite na \"Udeliť povolenie\"\n2. Povoľte na vašom iPhone\n3. Aplikácia na hodinkách sa zatvorí\n4. Znovu ju otvorte a ťuknite na \"Pokračovať\"';
+  String get needMicrophonePermission => 'Potrebujeme povolenie mikrofónu.\n\n1. Ťuknite na \"Udeliť povolenie\"\n2. Povoľte na vašom iPhone\n3. Aplikácia na hodinkách sa zatvorí\n4. Znovu ju otvorte a ťuknite na \"Pokračovať\"';
 
   @override
   String get grantPermissionButton => 'Udeliť povolenie';
@@ -1924,15 +1884,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get needHelp => 'Potrebujete pomoc?';
 
   @override
-  String get troubleshootingSteps =>
-      'Riešenie problémov:\n\n1. Uistite sa, že Omi je nainštalované na vašich hodinkách\n2. Otvorte aplikáciu Omi na hodinkách\n3. Hľadajte vyskakovacie okno s povolením\n4. Ťuknite na \"Povoliť\", keď sa zobrazí\n5. Aplikácia na hodinkách sa zatvorí - znovu ju otvorte\n6. Vráťte sa a ťuknite na \"Pokračovať\" na vašom iPhone';
+  String get troubleshootingSteps => 'Riešenie problémov:\n\n1. Uistite sa, že Omi je nainštalované na vašich hodinkách\n2. Otvorte aplikáciu Omi na hodinkách\n3. Hľadajte vyskakovacie okno s povolením\n4. Ťuknite na \"Povoliť\", keď sa zobrazí\n5. Aplikácia na hodinkách sa zatvorí - znovu ju otvorte\n6. Vráťte sa a ťuknite na \"Pokračovať\" na vašom iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Nahrávanie bolo úspešne spustené!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Povolenie ešte nebolo udelené. Uistite sa, že ste povolili prístup k mikrofónu a znovu otvorili aplikáciu na hodinkách.';
+  String get permissionNotGrantedYet => 'Povolenie ešte nebolo udelené. Uistite sa, že ste povolili prístup k mikrofónu a znovu otvorili aplikáciu na hodinkách.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2029,8 +1987,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Pripravené na úlohy';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Vaša AI automaticky extrahuje úlohy z vašich konverzácií. Objavia sa tu, keď budú vytvorené.';
+  String get welcomeActionItemsDescription => 'Vaša AI automaticky extrahuje úlohy z vašich konverzácií. Objavia sa tu, keď budú vytvorené.';
 
   @override
   String get autoExtractionFeature => 'Automaticky extrahované z konverzácií';
@@ -2226,15 +2183,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'REČ A PREPIS';
 
   @override
-  String get languageSettingsHelperText =>
-      'Jazyk aplikácie mení ponuky a tlačidlá. Jazyk reči ovplyvňuje spôsob prepisu vašich nahrávok.';
+  String get languageSettingsHelperText => 'Jazyk aplikácie mení ponuky a tlačidlá. Jazyk reči ovplyvňuje spôsob prepisu vašich nahrávok.';
 
   @override
   String get translationNotice => 'Oznámenie o preklade';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi prekladá konverzácie do vášho hlavného jazyka. Aktualizujte to kedykoľvek v Nastavenia → Profily.';
+  String get translationNoticeMessage => 'Omi prekladá konverzácie do vášho hlavného jazyka. Aktualizujte to kedykoľvek v Nastavenia → Profily.';
 
   @override
   String get pleaseCheckInternetConnection => 'Skontrolujte prosím pripojenie k internetu a skúste to znova';
@@ -2389,8 +2344,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Zrušiť párovanie zariadenia';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Tým sa zruší párovanie zariadenia, aby sa mohlo pripojiť k inému telefónu. Budete musieť prejsť do Nastavenia > Bluetooth a zabudnúť zariadenie na dokončenie procesu.';
+  String get unpairDeviceDialogMessage => 'Tým sa zruší párovanie zariadenia, aby sa mohlo pripojiť k inému telefónu. Budete musieť prejsť do Nastavenia > Bluetooth a zabudnúť zariadenie na dokončenie procesu.';
 
   @override
   String get unpair => 'Zrušiť párovanie';
@@ -2571,8 +2525,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get youreAllSet => 'Všetko je pripravené!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Vitajte v Omi! Váš AI spoločník je pripravený pomôcť vám s rozhovormi, úlohami a oveľa viac.';
+  String get welcomeToOmiDescription => 'Vitajte v Omi! Váš AI spoločník je pripravený pomôcť vám s rozhovormi, úlohami a oveľa viac.';
 
   @override
   String get startUsingOmi => 'Začať používať Omi';
@@ -2708,8 +2661,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noTasksYet => 'Zatiaľ žiadne úlohy';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Úlohy z vašich konverzácií sa tu zobrazia.\nKliknite na Vytvoriť a pridajte jednu ručne.';
+  String get tasksFromConversationsWillAppear => 'Úlohy z vašich konverzácií sa tu zobrazia.\nKliknite na Vytvoriť a pridajte jednu ručne.';
 
   @override
   String get monthJan => 'Jan';
@@ -2766,8 +2718,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteActionItem => 'Odstrániť položku úlohy';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Naozaj chcete odstrániť túto položku úlohy? Túto akciu nemožno vrátiť späť.';
+  String get deleteActionItemConfirmation => 'Naozaj chcete odstrániť túto položku úlohy? Túto akciu nemožno vrátiť späť.';
 
   @override
   String get enterActionItemDescription => 'Zadajte popis položky úlohy...';
@@ -2842,8 +2793,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get chatPrompt => 'Výzva chatu';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ste skvelá aplikácia, vašou úlohou je reagovať na otázky používateľov a dať im dobrý pocit...';
+  String get chatPromptPlaceholder => 'Ste skvelá aplikácia, vašou úlohou je reagovať na otázky používateľov a dať im dobrý pocit...';
 
   @override
   String get conversationPrompt => 'Výzva konverzácie';
@@ -2861,8 +2811,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get makeMyAppPublic => 'Zverejniť moju aplikáciu';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Odoslaním tejto aplikácie súhlasím so Zmluvnými podmienkami a Zásadami ochrany osobných údajov Omi AI';
+  String get submitAppTermsAgreement => 'Odoslaním tejto aplikácie súhlasím so Zmluvnými podmienkami a Zásadami ochrany osobných údajov Omi AI';
 
   @override
   String get submitApp => 'Odoslať aplikáciu';
@@ -2877,12 +2826,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get submitAppQuestion => 'Odoslať aplikáciu?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Vaša aplikácia bude skontrolovaná a zverejnená. Môžete ju začať používať okamžite, aj počas kontroly!';
+  String get submitAppPublicDescription => 'Vaša aplikácia bude skontrolovaná a zverejnená. Môžete ju začať používať okamžite, aj počas kontroly!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Vaša aplikácia bude skontrolovaná a sprístupnená vám súkromne. Môžete ju začať používať okamžite, aj počas kontroly!';
+  String get submitAppPrivateDescription => 'Vaša aplikácia bude skontrolovaná a sprístupnená vám súkromne. Môžete ju začať používať okamžite, aj počas kontroly!';
 
   @override
   String get startEarning => 'Začnite zarábať! 💰';
@@ -2906,8 +2853,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get dataAccessNotice => 'Upozornenie na prístup k údajom';
 
   @override
-  String get dataAccessWarning =>
-      'Táto aplikácia bude mať prístup k vašim údajom. Omi AI nie je zodpovedný za to, ako táto aplikácia používa, upravuje alebo maže vaše údaje';
+  String get dataAccessWarning => 'Táto aplikácia bude mať prístup k vašim údajom. Omi AI nie je zodpovedný za to, ako táto aplikácia používa, upravuje alebo maže vaše údaje';
 
   @override
   String get installApp => 'Inštalovať aplikáciu';
@@ -2919,8 +2865,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get appUnderReviewOwner => 'Vaša aplikácia je v recenzii a viditeľná len pre vás. Bude verejná po schválení.';
 
   @override
-  String get appRejectedNotice =>
-      'Vaša aplikácia bola zamietnutá. Aktualizujte prosím podrobnosti aplikácie a odošlite ju znova na recenziu.';
+  String get appRejectedNotice => 'Vaša aplikácia bola zamietnutá. Aktualizujte prosím podrobnosti aplikácie a odošlite ju znova na recenziu.';
 
   @override
   String get setupSteps => 'Kroky nastavenia';
@@ -2982,8 +2927,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get descriptionLabel => 'Popis';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Moja úžasná aplikácia je skvelá aplikácia, ktorá robí úžasné veci. Je to najlepšia aplikácia!';
+  String get appDescriptionPlaceholder => 'Moja úžasná aplikácia je skvelá aplikácia, ktorá robí úžasné veci. Je to najlepšia aplikácia!';
 
   @override
   String get pleaseProvideValidDescription => 'Zadajte prosím platný popis';
@@ -3135,8 +3079,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get microphonePermissionRequired => 'Na hlasový záznam je potrebné povolenie mikrofónu.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Povolenie mikrofónu zamietnuté. Udeľte prosím povolenie v Predvoľby systému > Súkromie a bezpečnosť > Mikrofón.';
+  String get microphonePermissionDenied => 'Povolenie mikrofónu zamietnuté. Udeľte prosím povolenie v Predvoľby systému > Súkromie a bezpečnosť > Mikrofón.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3369,8 +3312,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get whatWeCollect => 'Čo zbierame';
 
   @override
-  String get dataCollectionMessage =>
-      'Pokračovaním budú vaše konverzácie, nahrávky a osobné údaje bezpečne uložené na našich serveroch, aby poskytli prehľady založené na AI a umožnili všetky funkcie aplikácie.';
+  String get dataCollectionMessage => 'Pokračovaním budú vaše konverzácie, nahrávky a osobné údaje bezpečne uložené na našich serveroch, aby poskytli prehľady založené na AI a umožnili všetky funkcie aplikácie.';
 
   @override
   String get dataProtection => 'Ochrana dát';
@@ -3403,8 +3345,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Meno musí mať aspoň 2 znaky';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Povedzte nám, ako by ste chceli byť oslovovaní. To pomáha prispôsobiť váš Omi zážitok.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Povedzte nám, ako by ste chceli byť oslovovaní. To pomáha prispôsobiť váš Omi zážitok.';
 
   @override
   String charactersCount(int count) {
@@ -3421,8 +3362,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get recordAudioConversations => 'Nahrávať audio konverzácie';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi potrebuje prístup k mikrofónu na nahrávanie vašich konverzácií a poskytovanie prepisov.';
+  String get microphoneAccessDescription => 'Omi potrebuje prístup k mikrofónu na nahrávanie vašich konverzácií a poskytovanie prepisov.';
 
   @override
   String get screenRecording => 'Záznam obrazovky';
@@ -3431,8 +3371,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Zachytiť systémový zvuk zo schôdzok';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi potrebuje povolenie na záznam obrazovky na zachytenie systémového zvuku z vašich schôdzok v prehliadači.';
+  String get screenRecordingDescription => 'Omi potrebuje povolenie na záznam obrazovky na zachytenie systémového zvuku z vašich schôdzok v prehliadači.';
 
   @override
   String get accessibility => 'Prístupnosť';
@@ -3441,8 +3380,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Detekovať schôdzky v prehliadači';
 
   @override
-  String get accessibilityDescription =>
-      'Omi potrebuje povolenie prístupnosti na detekciu, kedy sa pripájate k schôdzkam Zoom, Meet alebo Teams vo vašom prehliadači.';
+  String get accessibilityDescription => 'Omi potrebuje povolenie prístupnosti na detekciu, kedy sa pripájate k schôdzkam Zoom, Meet alebo Teams vo vašom prehliadači.';
 
   @override
   String get pleaseWait => 'Prosím čakajte...';
@@ -3514,8 +3452,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get conversationsExportStarted => 'Export konverzácií začal. Môže to trvať niekoľko sekúnd, prosím čakajte.';
 
   @override
-  String get mcpDescription =>
-      'Na pripojenie Omi k iným aplikáciám na čítanie, vyhľadávanie a správu vašich spomienok a konverzácií. Vytvorte kľúč na začatie.';
+  String get mcpDescription => 'Na pripojenie Omi k iným aplikáciám na čítanie, vyhľadávanie a správu vašich spomienok a konverzácií. Vytvorte kľúč na začatie.';
 
   @override
   String get apiKeys => 'API kľúče';
@@ -3586,8 +3523,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get auto => 'Automaticky';
 
   @override
-  String get noSummaryForApp =>
-      'Pre túto aplikáciu nie je k dispozícii zhrnutie. Skúste inú aplikáciu pre lepšie výsledky.';
+  String get noSummaryForApp => 'Pre túto aplikáciu nie je k dispozícii zhrnutie. Skúste inú aplikáciu pre lepšie výsledky.';
 
   @override
   String get tryAnotherApp => 'Vyskúšať inú aplikáciu';
@@ -3624,8 +3560,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Nechajte Omi automaticky vybrať najlepšiu aplikáciu';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Naozaj chcete odstrániť túto konverzáciu? Túto akciu nemožno vrátiť späť.';
+  String get deleteConversationConfirmation => 'Naozaj chcete odstrániť túto konverzáciu? Túto akciu nemožno vrátiť späť.';
 
   @override
   String get conversationDeleted => 'Konverzácia odstránená';
@@ -3673,8 +3608,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Príprava záznamu systémového zvuku';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Kliknite na tlačidlo na záznam zvuku pre živé prepisy, AI poznatky a automatické ukladanie.';
+  String get clickTheButtonToCaptureAudio => 'Kliknite na tlačidlo na záznam zvuku pre živé prepisy, AI poznatky a automatické ukladanie.';
 
   @override
   String get reconnecting => 'Opätovné pripájanie...';
@@ -3901,8 +3835,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Vymazať graf znalostí?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Tým sa vymažú všetky odvodené údaje grafu znalostí. Vaše pôvodné spomienky zostanú v bezpečí.';
+  String get deleteKnowledgeGraphWarning => 'Tým sa vymažú všetky odvodené údaje grafu znalostí. Vaše pôvodné spomienky zostanú v bezpečí.';
 
   @override
   String get connectOmiWithAI => 'Pripojte Omi k AI asistentom';
@@ -3959,8 +3892,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get updateAppQuestion => 'Aktualizovať aplikáciu?';
 
   @override
-  String get updateAppConfirmation =>
-      'Ste si istý, že chcete aktualizovať svoju aplikáciu? Zmeny sa prejavia po kontrole naším tímom.';
+  String get updateAppConfirmation => 'Ste si istý, že chcete aktualizovať svoju aplikáciu? Zmeny sa prejavia po kontrole naším tímom.';
 
   @override
   String get updateApp => 'Aktualizovať aplikáciu';
@@ -3990,8 +3922,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get no => 'Nie';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Predplatné bolo úspešne zrušené. Zostane aktívne do konca aktuálneho fakturačného obdobia.';
+  String get subscriptionCancelledSuccessfully => 'Predplatné bolo úspešne zrušené. Zostane aktívne do konca aktuálneho fakturačného obdobia.';
 
   @override
   String get failedToCancelSubscription => 'Zrušenie predplatného zlyhalo. Skúste to prosím znova.';
@@ -4027,8 +3958,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Zrušiť predplatné?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Ste si istý, že chcete zrušiť predplatné? Budete mať prístup do konca aktuálneho fakturačného obdobia.';
+  String get cancelSubscriptionConfirmation => 'Ste si istý, že chcete zrušiť predplatné? Budete mať prístup do konca aktuálneho fakturačného obdobia.';
 
   @override
   String get cancelSubscriptionButton => 'Zrušiť predplatné';
@@ -4040,8 +3970,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get betaTesterMessage => 'Ste beta tester tejto aplikácie. Zatiaľ nie je verejná. Bude verejná po schválení.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Vaša aplikácia je v procese kontroly a viditeľná len pre vás. Bude verejná po schválení.';
+  String get appUnderReviewMessage => 'Vaša aplikácia je v procese kontroly a viditeľná len pre vás. Bude verejná po schválení.';
 
   @override
   String get appRejectedMessage => 'Vaša aplikácia bola zamietnutá. Aktualizujte údaje a znova odošlite na kontrolu.';
@@ -4186,8 +4115,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get omiApiKeys => 'Omi API kľúče';
 
   @override
-  String get apiKeysDescription =>
-      'API kľúče sa používajú na overenie, keď vaša aplikácia komunikuje so serverom OMI. Umožňujú vašej aplikácii vytvárať spomienky a bezpečne pristupovať k ďalším službám OMI.';
+  String get apiKeysDescription => 'API kľúče sa používajú na overenie, keď vaša aplikácia komunikuje so serverom OMI. Umožňujú vašej aplikácii vytvárať spomienky a bezpečne pristupovať k ďalším službám OMI.';
 
   @override
   String get aboutOmiApiKeys => 'O Omi API kľúčoch';
@@ -4211,8 +4139,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Odvolať API kľúč?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Túto akciu nie je možné vrátiť späť. Aplikácie používajúce tento kľúč už nebudú mať prístup k API.';
+  String get revokeApiKeyWarning => 'Túto akciu nie je možné vrátiť späť. Aplikácie používajúce tento kľúč už nebudú mať prístup k API.';
 
   @override
   String get revoke => 'Odvolať';
@@ -4310,8 +4237,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get externalAppAccess => 'Prístup externých aplikácií';
 
   @override
-  String get externalAppAccessDescription =>
-      'Nasledujúce nainštalované aplikácie majú externé integrácie a môžu pristupovať k vašim údajom, ako sú konverzácie a spomienky.';
+  String get externalAppAccessDescription => 'Nasledujúce nainštalované aplikácie majú externé integrácie a môžu pristupovať k vašim údajom, ako sú konverzácie a spomienky.';
 
   @override
   String get noExternalAppsHaveAccess => 'Žiadne externé aplikácie nemajú prístup k vašim údajom.';
@@ -4320,8 +4246,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maximálne zabezpečenie (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-end šifrovanie je zlatý štandard ochrany súkromia. Keď je povolené, vaše údaje sú šifrované na vašom zariadení pred odoslaním na naše servery. To znamená, že nikto, ani Omi, nemôže pristupovať k vášmu obsahu.';
+  String get e2eeDescription => 'End-to-end šifrovanie je zlatý štandard ochrany súkromia. Keď je povolené, vaše údaje sú šifrované na vašom zariadení pred odoslaním na naše servery. To znamená, že nikto, ani Omi, nemôže pristupovať k vášmu obsahu.';
 
   @override
   String get importantTradeoffs => 'Dôležité kompromisy:';
@@ -4355,15 +4280,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get secureEncryption => 'Bezpečné šifrovanie';
 
   @override
-  String get secureEncryptionDescription =>
-      'Vaše údaje sú šifrované kľúčom jedinečným pre vás na našich serveroch hostovaných v Google Cloud. To znamená, že váš surový obsah je neprístupný nikomu, vrátane zamestnancov Omi alebo Google, priamo z databázy.';
+  String get secureEncryptionDescription => 'Vaše údaje sú šifrované kľúčom jedinečným pre vás na našich serveroch hostovaných v Google Cloud. To znamená, že váš surový obsah je neprístupný nikomu, vrátane zamestnancov Omi alebo Google, priamo z databázy.';
 
   @override
   String get endToEndEncryption => 'End-to-end šifrovanie';
 
   @override
-  String get e2eeCardDescription =>
-      'Povoľte pre maximálne zabezpečenie, kde iba vy máte prístup k vašim údajom. Klepnutím sa dozviete viac.';
+  String get e2eeCardDescription => 'Povoľte pre maximálne zabezpečenie, kde iba vy máte prístup k vašim údajom. Klepnutím sa dozviete viac.';
 
   @override
   String get dataAlwaysEncrypted => 'Bez ohľadu na úroveň sú vaše údaje vždy šifrované v pokoji aj pri prenose.';
@@ -4434,8 +4357,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Získajte Omi Unlimited zadarmo prispením vašich dát na trénovanie AI modelov.';
 
   @override
-  String get trainingDataBullets =>
-      '• Vaše dáta pomáhajú zlepšovať AI modely\n• Zdieľajú sa len necitlivé dáta\n• Úplne transparentný proces';
+  String get trainingDataBullets => '• Vaše dáta pomáhajú zlepšovať AI modely\n• Zdieľajú sa len necitlivé dáta\n• Úplne transparentný proces';
 
   @override
   String get learnMoreAtOmiTraining => 'Zistite viac na omi.me/training';
@@ -4485,8 +4407,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get monthlyPlanContinues => 'Váš súčasný mesačný plán bude pokračovať do konca fakturačného obdobia';
 
   @override
-  String get paymentMethodCharged =>
-      'Váš existujúci spôsob platby bude automaticky účtovaný po skončení mesačného plánu';
+  String get paymentMethodCharged => 'Váš existujúci spôsob platby bude automaticky účtovaný po skončení mesačného plánu';
 
   @override
   String get annualSubscriptionStarts => 'Vaše 12-mesačné ročné predplatné sa automaticky spustí po zaúčtovaní';
@@ -4596,8 +4517,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Na vašom súkromí nám záleží';
 
   @override
-  String get privacyIntroText =>
-      'V Omi berieme vaše súkromie veľmi vážne. Chceme byť transparentní ohľadom údajov, ktoré zhromažďujeme a ako ich používame. Tu je to, čo potrebujete vedieť:';
+  String get privacyIntroText => 'V Omi berieme vaše súkromie veľmi vážne. Chceme byť transparentní ohľadom údajov, ktoré zhromažďujeme a ako ich používame. Tu je to, čo potrebujete vedieť:';
 
   @override
   String get whatWeTrack => 'Čo sledujeme';
@@ -4612,12 +4532,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get ourCommitment => 'Náš záväzok';
 
   @override
-  String get commitmentText =>
-      'Zaväzujeme sa používať zhromaždené údaje len na to, aby sme z Omi urobili lepší produkt pre vás. Vaše súkromie a dôvera sú pre nás prvoradé.';
+  String get commitmentText => 'Zaväzujeme sa používať zhromaždené údaje len na to, aby sme z Omi urobili lepší produkt pre vás. Vaše súkromie a dôvera sú pre nás prvoradé.';
 
   @override
-  String get thankYouText =>
-      'Ďakujeme, že ste cenený používateľ Omi. Ak máte akékoľvek otázky alebo obavy, neváhajte nás kontaktovať na team@basedhardware.com.';
+  String get thankYouText => 'Ďakujeme, že ste cenený používateľ Omi. Ak máte akékoľvek otázky alebo obavy, neváhajte nás kontaktovať na team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Nastavenia synchronizácie WiFi';
@@ -4626,8 +4544,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get enterHotspotCredentials => 'Zadajte prihlasovacie údaje hotspotu telefónu';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi synchronizácia používa váš telefón ako hotspot. Nájdite názov a heslo v Nastavenia > Osobný hotspot.';
+  String get wifiSyncUsesHotspot => 'WiFi synchronizácia používa váš telefón ako hotspot. Nájdite názov a heslo v Nastavenia > Osobný hotspot.';
 
   @override
   String get hotspotNameSsid => 'Názov hotspotu (SSID)';
@@ -4662,8 +4579,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nepodarilo sa vytvoriť zhrnutie. Uistite sa, že máte konverzácie pre daný deň.';
+  String get failedToGenerateSummaryCheckConversations => 'Nepodarilo sa vytvoriť zhrnutie. Uistite sa, že máte konverzácie pre daný deň.';
 
   @override
   String get summaryNotFound => 'Zhrnutie nenájdené';
@@ -4693,8 +4609,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Export sa začal. Môže to trvať niekoľko sekúnd...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Toto vymaže všetky odvodené údaje grafu znalostí (uzly a spojenia). Vaše pôvodné spomienky zostanú v bezpečí. Graf sa obnoví časom alebo pri ďalšej požiadavke.';
+  String get knowledgeGraphDeleteDescription => 'Toto vymaže všetky odvodené údaje grafu znalostí (uzly a spojenia). Vaše pôvodné spomienky zostanú v bezpečí. Graf sa obnoví časom alebo pri ďalšej požiadavke.';
 
   @override
   String get configureDailySummaryDigest => 'Nastavte si denný prehľad úloh';
@@ -4764,8 +4679,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Odstrániť všetky konverzácie Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Toto natrvalo odstráni všetky konverzácie importované z Limitless. Túto akciu nemožno vrátiť späť.';
+  String get deleteAllLimitlessWarning => 'Toto natrvalo odstráni všetky konverzácie importované z Limitless. Túto akciu nemožno vrátiť späť.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4821,8 +4735,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get howItWorksTitle => 'Ako to funguje?';
 
   @override
-  String get howPeopleWorks =>
-      'Po vytvorení osoby môžete prejsť na prepis konverzácie a priradiť im zodpovedajúce segmenty, takto bude Omi schopné rozpoznať aj ich reč!';
+  String get howPeopleWorks => 'Po vytvorení osoby môžete prejsť na prepis konverzácie a priradiť im zodpovedajúce segmenty, takto bude Omi schopné rozpoznať aj ich reč!';
 
   @override
   String get tapToDelete => 'Klepnite pre odstránenie';
@@ -4848,8 +4761,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get privacyNotice => 'Oznámenie o ochrane súkromia';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Nahrávky môžu zachytiť hlasy ostatných. Pred povolením sa uistite, že máte súhlas všetkých účastníkov.';
+  String get recordingsMayCaptureOthers => 'Nahrávky môžu zachytiť hlasy ostatných. Pred povolením sa uistite, že máte súhlas všetkých účastníkov.';
 
   @override
   String get enable => 'Povoliť';
@@ -4861,8 +4773,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get on => 'Zap.';
 
   @override
-  String get storeAudioDescription =>
-      'Uchovávajte všetky zvukové nahrávky uložené lokálne v telefóne. Pri vypnutí sa ukladajú iba neúspešné nahrávania pre úsporu miesta.';
+  String get storeAudioDescription => 'Uchovávajte všetky zvukové nahrávky uložené lokálne v telefóne. Pri vypnutí sa ukladajú iba neúspešné nahrávania pre úsporu miesta.';
 
   @override
   String get enableLocalStorage => 'Povoliť lokálne úložisko';
@@ -4880,12 +4791,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get storeAudioOnCloud => 'Ukladať audio do cloudu';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Vaše nahrávky v reálnom čase budú uložené v súkromnom cloudovom úložisku počas rozprávania.';
+  String get cloudStorageDialogMessage => 'Vaše nahrávky v reálnom čase budú uložené v súkromnom cloudovom úložisku počas rozprávania.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Ukladajte svoje nahrávky v reálnom čase do súkromného cloudového úložiska počas rozprávania. Zvuk sa zachytáva a bezpečne ukladá v reálnom čase.';
+  String get storeAudioCloudDescription => 'Ukladajte svoje nahrávky v reálnom čase do súkromného cloudového úložiska počas rozprávania. Zvuk sa zachytáva a bezpečne ukladá v reálnom čase.';
 
   @override
   String get downloadingFirmware => 'Sťahovanie firmvéru';
@@ -4894,8 +4803,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get installingFirmware => 'Inštalácia firmvéru';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Nezatvárajte aplikáciu ani nevypínajte zariadenie. Mohlo by to poškodiť vaše zariadenie.';
+  String get firmwareUpdateWarning => 'Nezatvárajte aplikáciu ani nevypínajte zariadenie. Mohlo by to poškodiť vaše zariadenie.';
 
   @override
   String get firmwareUpdated => 'Firmvér aktualizovaný';
@@ -4939,8 +4847,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get payments => 'Platby';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Pripojte nižšie platobnú metódu a začnite prijímať platby za svoje aplikácie.';
+  String get connectPaymentMethodInfo => 'Pripojte nižšie platobnú metódu a začnite prijímať platby za svoje aplikácie.';
 
   @override
   String get selectedPaymentMethod => 'Vybraná platobná metóda';
@@ -4994,8 +4901,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get connectingYourStripeAccount => 'Pripájanie vášho účtu Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Dokončite prosím proces registrácie Stripe vo vašom prehliadači. Táto stránka sa automaticky aktualizuje po dokončení.';
+  String get stripeOnboardingInstructions => 'Dokončite prosím proces registrácie Stripe vo vašom prehliadači. Táto stránka sa automaticky aktualizuje po dokončení.';
 
   @override
   String get failedTryAgain => 'Zlyhalo? Skúsiť znova';
@@ -5007,8 +4913,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get successfullyConnected => 'Úspešne pripojené!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Váš účet Stripe je teraz pripravený prijímať platby. Môžete ihneď začať zarábať z predaja aplikácií.';
+  String get stripeReadyForPayments => 'Váš účet Stripe je teraz pripravený prijímať platby. Môžete ihneď začať zarábať z predaja aplikácií.';
 
   @override
   String get updateStripeDetails => 'Aktualizovať údaje Stripe';
@@ -5035,8 +4940,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get paypalMeLink => 'Odkaz PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Ak je Stripe k dispozícii vo vašej krajine, dôrazne odporúčame jeho použitie pre rýchlejšie a jednoduchšie výplaty.';
+  String get stripeRecommendation => 'Ak je Stripe k dispozícii vo vašej krajine, dôrazne odporúčame jeho použitie pre rýchlejšie a jednoduchšie výplaty.';
 
   @override
   String get updatePayPalDetails => 'Aktualizovať údaje PayPal';
@@ -5088,12 +4992,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Ďalšia hlasová vzorka odstránená';
 
   @override
-  String get consentDataMessage =>
-      'Pokračovaním budú vaše konverzácie, nahrávky a osobné údaje bezpečne uložené na našich serveroch. Vaše audio nahrávky a prepisy sú spracovávané AI službami tretích strán (vrátane Deepgram na prepis a OpenAI na analýzu), aby vám poskytli poznatky založené na AI a umožnili všetky funkcie aplikácie.';
+  String get consentDataMessage => 'Pokračovaním budú vaše konverzácie, nahrávky a osobné údaje bezpečne uložené na našich serveroch. Vaše audio nahrávky a prepisy sú spracovávané AI službami tretích strán (vrátane Deepgram na prepis a OpenAI na analýzu), aby vám poskytli poznatky založené na AI a umožnili všetky funkcie aplikácie.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Úlohy z vašich konverzácií sa zobrazia tu.\nKlepnite na + pre manuálne vytvorenie.';
+  String get tasksEmptyStateMessage => 'Úlohy z vašich konverzácií sa zobrazia tu.\nKlepnite na + pre manuálne vytvorenie.';
 
   @override
   String get clearChatAction => 'Vymazať chat';
@@ -5129,15 +5031,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Nainštalujte Omi na\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Ak chcete používať Apple Watch s Omi, musíte najprv nainštalovať aplikáciu Omi na hodinky.';
+  String get installOmiOnAppleWatchDescription => 'Ak chcete používať Apple Watch s Omi, musíte najprv nainštalovať aplikáciu Omi na hodinky.';
 
   @override
   String get openOmiOnAppleWatch => 'Otvorte Omi na\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Aplikácia Omi je nainštalovaná na Apple Watch. Otvorte ju a klepnite na Štart.';
+  String get openOmiOnAppleWatchDescription => 'Aplikácia Omi je nainštalovaná na Apple Watch. Otvorte ju a klepnite na Štart.';
 
   @override
   String get openWatchApp => 'Otvoriť aplikáciu Watch';
@@ -5146,15 +5046,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Nainštaloval(a) som a otvoril(a) aplikáciu';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Aplikáciu Apple Watch sa nepodarilo otvoriť. Manuálne otvorte aplikáciu Watch na Apple Watch a nainštalujte Omi zo sekcie \"Dostupné aplikácie\".';
+  String get unableToOpenWatchApp => 'Aplikáciu Apple Watch sa nepodarilo otvoriť. Manuálne otvorte aplikáciu Watch na Apple Watch a nainštalujte Omi zo sekcie \"Dostupné aplikácie\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch úspešne pripojené!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch stále nie je dostupné. Uistite sa, že aplikácia Omi je na hodinkách otvorená.';
+  String get appleWatchNotReachable => 'Apple Watch stále nie je dostupné. Uistite sa, že aplikácia Omi je na hodinkách otvorená.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5582,8 +5480,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get multipleSpeakersDetected => 'Zistených viacero rečníkov';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Zdá sa, že v nahrávke je viacero rečníkov. Uistite sa, že ste na tichom mieste a skúste to znova.';
+  String get multipleSpeakersDescription => 'Zdá sa, že v nahrávke je viacero rečníkov. Uistite sa, že ste na tichom mieste a skúste to znova.';
 
   @override
   String get invalidRecordingDetected => 'Zistená neplatná nahrávka';
@@ -5595,15 +5492,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get speechDurationDescription => 'Uistite sa, že hovoríte aspoň 5 sekúnd a nie viac ako 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Spojenie bolo prerušené. Skontrolujte svoje internetové pripojenie a skúste to znova.';
+  String get connectionLostDescription => 'Spojenie bolo prerušené. Skontrolujte svoje internetové pripojenie a skúste to znova.';
 
   @override
   String get howToTakeGoodSample => 'Ako urobiť dobrú vzorku?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Uistite sa, že ste na tichom mieste.\n2. Hovorte jasne a prirodzene.\n3. Uistite sa, že vaše zariadenie je v prirodzenej polohe na krku.\n\nPo vytvorení ho môžete vždy vylepšiť alebo urobiť znova.';
+  String get goodSampleInstructions => '1. Uistite sa, že ste na tichom mieste.\n2. Hovorte jasne a prirodzene.\n3. Uistite sa, že vaše zariadenie je v prirodzenej polohe na krku.\n\nPo vytvorení ho môžete vždy vylepšiť alebo urobiť znova.';
 
   @override
   String get noDeviceConnectedUseMic => 'Žiadne pripojené zariadenie. Bude použitý mikrofón telefónu.';
@@ -5666,12 +5561,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get howItWorks => 'Ako to funguje';
 
   @override
-  String get dailyScoreExplanation =>
-      'Vaše denné skóre je založené na plnení úloh. Dokončite svoje úlohy pre zlepšenie skóre!';
+  String get dailyScoreExplanation => 'Vaše denné skóre je založené na plnení úloh. Dokončite svoje úlohy pre zlepšenie skóre!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Ovládajte, ako často vám Omi posiela proaktívne upozornenia a pripomienky.';
+  String get notificationFrequencyDescription => 'Ovládajte, ako často vám Omi posiela proaktívne upozornenia a pripomienky.';
 
   @override
   String get sliderOff => 'Vyp.';
@@ -5685,8 +5578,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Nepodarilo sa vygenerovať súhrn. Uistite sa, že máte konverzácie pre tento deň.';
+  String get failedToGenerateSummary => 'Nepodarilo sa vygenerovať súhrn. Uistite sa, že máte konverzácie pre tento deň.';
 
   @override
   String get recap => 'Zhrnutie';
@@ -5765,8 +5657,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get selectApp => 'Vybrať aplikáciu';
 
   @override
-  String get noChatAppsEnabled =>
-      'Žiadne chatové aplikácie nie sú povolené.\nKlepnite na \"Povoliť aplikácie\" pre pridanie.';
+  String get noChatAppsEnabled => 'Žiadne chatové aplikácie nie sú povolené.\nKlepnite na \"Povoliť aplikácie\" pre pridanie.';
 
   @override
   String get disable => 'Zakázať';
@@ -6047,15 +5938,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get cloudProvider => 'Cloudový poskytovateľ';
 
   @override
-  String get premiumMinutesInfo =>
-      '1 200 prémiových minút/mesiac. Karta Na zariadení ponúka neobmedzený bezplatný prepis.';
+  String get premiumMinutesInfo => '1 200 prémiových minút/mesiac. Karta Na zariadení ponúka neobmedzený bezplatný prepis.';
 
   @override
   String get viewUsage => 'Zobraziť využitie';
 
   @override
-  String get localProcessingInfo =>
-      'Zvuk sa spracováva lokálne. Funguje offline, väčšie súkromie, ale vyššia spotreba batérie.';
+  String get localProcessingInfo => 'Zvuk sa spracováva lokálne. Funguje offline, väčšie súkromie, ale vyššia spotreba batérie.';
 
   @override
   String get model => 'Model';
@@ -6064,15 +5953,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get performanceWarning => 'Varovanie o výkone';
 
   @override
-  String get largeModelWarning =>
-      'Tento model je veľký a môže spôsobiť pád aplikácie alebo veľmi pomalý chod na mobilných zariadeniach.\n\nOdporúča sa \"small\" alebo \"base\".';
+  String get largeModelWarning => 'Tento model je veľký a môže spôsobiť pád aplikácie alebo veľmi pomalý chod na mobilných zariadeniach.\n\nOdporúča sa \"small\" alebo \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Používanie natívneho rozpoznávania reči iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Použije sa natívny hlasový engine vášho zariadenia. Nie je potrebné sťahovať model.';
+  String get noModelDownloadRequired => 'Použije sa natívny hlasový engine vášho zariadenia. Nie je potrebné sťahovať model.';
 
   @override
   String get modelReady => 'Model pripravený';
@@ -6129,12 +6016,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get batteryDrainSignificantly => 'Vybíjanie batérie sa výrazne zvýši.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1 200 prémiových minút/mesiac. Karta Na zariadení ponúka neobmedzený bezplatný prepis. ';
+  String get premiumMinutesMonth => '1 200 prémiových minút/mesiac. Karta Na zariadení ponúka neobmedzený bezplatný prepis. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Zvuk sa spracováva lokálne. Funguje offline, je súkromnejší, ale spotrebováva viac batérie.';
+  String get audioProcessedLocally => 'Zvuk sa spracováva lokálne. Funguje offline, je súkromnejší, ale spotrebováva viac batérie.';
 
   @override
   String get languageLabel => 'Jazyk';
@@ -6143,12 +6028,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Tento model je veľký a môže spôsobiť pád aplikácie alebo veľmi pomalý beh na mobilných zariadeniach.\n\nOdporúča sa small alebo base.';
+  String get modelTooLargeWarning => 'Tento model je veľký a môže spôsobiť pád aplikácie alebo veľmi pomalý beh na mobilných zariadeniach.\n\nOdporúča sa small alebo base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Bude použitý natívny hlasový engine vášho zariadenia. Nie je potrebné sťahovať model.';
+  String get nativeEngineNoDownload => 'Bude použitý natívny hlasový engine vášho zariadenia. Nie je potrebné sťahovať model.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6184,8 +6067,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Vstavaný živý prepis Omi je optimalizovaný pre konverzácie v reálnom čase s automatickou detekciou rečníkov a diarizáciou.';
+  String get omiTranscriptionOptimized => 'Vstavaný živý prepis Omi je optimalizovaný pre konverzácie v reálnom čase s automatickou detekciou rečníkov a diarizáciou.';
 
   @override
   String get reset => 'Resetovať';
@@ -6405,8 +6287,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Vytvára sa znalostný graf zo spomienok...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Váš znalostný graf sa vytvorí automaticky, keď vytvoríte nové spomienky.';
+  String get knowledgeGraphWillBuildAutomatically => 'Váš znalostný graf sa vytvorí automaticky, keď vytvoríte nové spomienky.';
 
   @override
   String get buildGraphButton => 'Vytvoriť graf';
@@ -6642,8 +6523,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get failedToLoadContacts => 'Nepodarilo sa načítať kontakty';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Nepodarilo sa pripraviť konverzáciu na zdieľanie. Skúste to znova.';
+  String get failedToPrepareConversationForSharing => 'Nepodarilo sa pripraviť konverzáciu na zdieľanie. Skúste to znova.';
 
   @override
   String get couldNotOpenSmsApp => 'Nepodarilo sa otvoriť aplikáciu SMS. Skúste to znova.';
@@ -6789,8 +6669,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get enableFastTransfer => 'Povoliť rýchly prenos';
 
   @override
-  String get fastTransferDescription =>
-      'Rýchly prenos používa WiFi pre ~5x rýchlejšie prenosy. Váš telefón sa dočasne pripojí k WiFi sieti zariadenia Omi počas prenosu.';
+  String get fastTransferDescription => 'Rýchly prenos používa WiFi pre ~5x rýchlejšie prenosy. Váš telefón sa dočasne pripojí k WiFi sieti zariadenia Omi počas prenosu.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Prístup na internet je počas prenosu pozastavený';
@@ -6805,8 +6684,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fiveTimesFaster => '5X RÝCHLEJŠÍ';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Vytvorí priame WiFi pripojenie k zariadeniu Omi. Telefón sa dočasne odpojí od bežnej WiFi počas prenosu.';
+  String get fastTransferMethodDescription => 'Vytvorí priame WiFi pripojenie k zariadeniu Omi. Telefón sa dočasne odpojí od bežnej WiFi počas prenosu.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6815,8 +6693,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get bleSpeed => '~30 KB/s cez BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Používa štandardné Bluetooth Low Energy pripojenie. Pomalšie, ale neovplyvňuje WiFi pripojenie.';
+  String get bluetoothMethodDescription => 'Používa štandardné Bluetooth Low Energy pripojenie. Pomalšie, ale neovplyvňuje WiFi pripojenie.';
 
   @override
   String get selected => 'Vybrané';
@@ -6834,8 +6711,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'Vaše zariadenie Omi bolo odpojené';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'Prosím, znova sa pripojte, aby ste mohli pokračovať v používaní Omi.';
+  String get deviceDisconnectedNotificationBody => 'Prosím, znova sa pripojte, aby ste mohli pokračovať v používaní Omi.';
 
   @override
   String get firmwareUpdateAvailable => 'K dispozícii je aktualizácia firmvéru';
@@ -6855,12 +6731,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get appDeleteFailed => 'Nepodarilo sa odstrániť aplikáciu. Skúste to neskôr.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Viditeľnosť aplikácie bola úspešne zmenená. Môže to trvať niekoľko minút.';
+  String get appVisibilityChangedSuccessfully => 'Viditeľnosť aplikácie bola úspešne zmenená. Môže to trvať niekoľko minút.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Chyba pri aktivácii aplikácie. Ak ide o integračnú aplikáciu, uistite sa, že nastavenie je dokončené.';
+  String get errorActivatingAppIntegration => 'Chyba pri aktivácii aplikácie. Ak ide o integračnú aplikáciu, uistite sa, že nastavenie je dokončené.';
 
   @override
   String get errorUpdatingAppStatus => 'Pri aktualizácii stavu aplikácie došlo k chybe.';
@@ -7127,8 +7001,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade naplánovaný. Váš nový plán začne na začiatku ďalšieho fakturačného obdobia.';
+  String get planUpgradeScheduledMessage => 'Upgrade naplánovaný. Váš nový plán začne na začiatku ďalšieho fakturačného obdobia.';
 
   @override
   String get couldNotSchedulePlanChange => 'Nepodarilo sa naplánovať zmenu plánu';
@@ -7656,8 +7529,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Zariadenie nepodporuje WiFi synchronizáciu, prepínanie na Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Zariadenie nepodporuje WiFi synchronizáciu, prepínanie na Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health nie je na tomto zariadení k dispozícii';
@@ -7965,8 +7837,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Prepnite Plaud Note do režimu párovania';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Stlačte a podržte bočné tlačidlo na 2 sekundy. Červená LED začne blikať, keď bude pripravené na párovanie.';
+  String get pairingDescPlaudNote => 'Stlačte a podržte bočné tlačidlo na 2 sekundy. Červená LED začne blikať, keď bude pripravené na párovanie.';
 
   @override
   String get pairingTitleBee => 'Prepnite Bee do režimu párovania';
@@ -7978,15 +7849,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get pairingTitleLimitless => 'Prepnite Limitless do režimu párovania';
 
   @override
-  String get pairingDescLimitless =>
-      'Keď svieti akékoľvek svetlo, stlačte raz a potom stlačte a podržte, kým zariadenie neukáže ružové svetlo, potom uvoľnite.';
+  String get pairingDescLimitless => 'Keď svieti akékoľvek svetlo, stlačte raz a potom stlačte a podržte, kým zariadenie neukáže ružové svetlo, potom uvoľnite.';
 
   @override
   String get pairingTitleFriendPendant => 'Prepnite Friend Pendant do režimu párovania';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Stlačte tlačidlo na prívesek pre zapnutie. Automaticky prejde do režimu párovania.';
+  String get pairingDescFriendPendant => 'Stlačte tlačidlo na prívesek pre zapnutie. Automaticky prejde do režimu párovania.';
 
   @override
   String get pairingTitleFieldy => 'Prepnite Fieldy do režimu párovania';
@@ -7998,15 +7867,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Pripojte Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Nainštalujte a otvorte aplikáciu Omi na Apple Watch, potom klepnite na Pripojiť v aplikácii.';
+  String get pairingDescAppleWatch => 'Nainštalujte a otvorte aplikáciu Omi na Apple Watch, potom klepnite na Pripojiť v aplikácii.';
 
   @override
   String get pairingTitleNeoOne => 'Prepnite Neo One do režimu párovania';
 
   @override
-  String get pairingDescNeoOne =>
-      'Stlačte a podržte tlačidlo napájania, kým LED nezačne blikať. Zariadenie bude viditeľné.';
+  String get pairingDescNeoOne => 'Stlačte a podržte tlačidlo napájania, kým LED nezačne blikať. Zariadenie bude viditeľné.';
 
   @override
   String get downloadingFromDevice => 'Sťahovanie zo zariadenia';
@@ -8123,8 +7990,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get switchAndRestart => 'Prepnúť';
 
   @override
-  String get stagingDisclaimer =>
-      'Testovacie prostredie môže byť nestabilné, s nekonzistentným výkonom a dáta sa môžu stratiť. Iba na testovanie.';
+  String get stagingDisclaimer => 'Testovacie prostredie môže byť nestabilné, s nekonzistentným výkonom a dáta sa môžu stratiť. Iba na testovanie.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Uložené. Zatvorte a znova otvorte aplikáciu na použitie zmien.';
@@ -8353,8 +8219,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonáty cez Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Telefonujte cez Omi a získajte prepis v reálnom čase, automatické zhrnutia a ďalšie.';
+  String get phoneCallsUpsellSubtitle => 'Telefonujte cez Omi a získajte prepis v reálnom čase, automatické zhrnutia a ďalšie.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Prepis každého hovoru v reálnom čase';
@@ -8381,8 +8246,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteSyncedFiles => 'Zmazať synchronizované nahrávky';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Tieto nahrávky sú už synchronizované s vaším telefónom. Toto sa nedá vrátiť späť.';
+  String get deleteSyncedFilesMessage => 'Tieto nahrávky sú už synchronizované s vaším telefónom. Toto sa nedá vrátiť späť.';
 
   @override
   String get syncedFilesDeleted => 'Synchronizované nahrávky zmazané';
@@ -8394,8 +8258,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deletePendingFiles => 'Zmazať čakajúce nahrávky';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Tieto nahrávky NIE sú synchronizované s vaším telefónom a budú trvalo stratené. Toto sa nedá vrátiť späť.';
+  String get deletePendingFilesWarning => 'Tieto nahrávky NIE sú synchronizované s vaším telefónom a budú trvalo stratené. Toto sa nedá vrátiť späť.';
 
   @override
   String get pendingFilesDeleted => 'Čakajúce nahrávky zmazané';
@@ -8407,8 +8270,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deleteAll => 'Vymazať všetko';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Toto zmaže synchronizované aj čakajúce nahrávky. Čakajúce nahrávky NIE sú synchronizované a budú trvalo stratené.';
+  String get deleteAllFilesWarning => 'Toto zmaže synchronizované aj čakajúce nahrávky. Čakajúce nahrávky NIE sú synchronizované a budú trvalo stratené.';
 
   @override
   String get allFilesDeleted => 'Všetky nahrávky zmazané';
@@ -8473,8 +8335,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fairUseAboutTitle => 'O spravodlivom používaní';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi je navrhnutý pre osobné konverzácie, stretnutia a živé interakcie. Používanie sa meria skutočným detegovaným časom reči, nie časom pripojenia. Ak používanie výrazne prekročí bežné vzory pre neosobný obsah, môžu sa uplatniť úpravy.';
+  String get fairUseAboutBody => 'Omi je navrhnutý pre osobné konverzácie, stretnutia a živé interakcie. Používanie sa meria skutočným detegovaným časom reči, nie časom pripojenia. Ak používanie výrazne prekročí bežné vzory pre neosobný obsah, môžu sa uplatniť úpravy.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8512,8 +8373,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get improveConnectionTitle => 'Zlepšiť pripojenie';
 
   @override
-  String get improveConnectionContent =>
-      'Vylepšili sme spôsob, akým Omi zostáva pripojené k vášmu zariadeniu. Pre aktiváciu prejdite na stránku Informácie o zariadení, klepnite na \"Odpojiť zariadenie\" a znova spárujte zariadenie.';
+  String get improveConnectionContent => 'Vylepšili sme spôsob, akým Omi zostáva pripojené k vášmu zariadeniu. Pre aktiváciu prejdite na stránku Informácie o zariadení, klepnite na \"Odpojiť zariadenie\" a znova spárujte zariadenie.';
 
   @override
   String get improveConnectionAction => 'Rozumiem';
@@ -8568,8 +8428,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get cancelSyncQuestion => 'Zrušiť synchronizáciu?';
 
   @override
-  String get omisStorageDesc =>
-      'Keď váš Omi nie je pripojený k telefónu, ukladá zvuk lokálne vo vstavanej pamäti. Nikdy nestratíte nahrávku.';
+  String get omisStorageDesc => 'Keď váš Omi nie je pripojený k telefónu, ukladá zvuk lokálne vo vstavanej pamäti. Nikdy nestratíte nahrávku.';
 
   @override
   String get phoneStorageDesc => 'Keď sa Omi znova pripojí, nahrávky sa automaticky prenesú do telefónu pred nahraním.';
@@ -8599,12 +8458,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get permissionEnable => 'Povoliť';
 
   @override
-  String get permissionsPageDescription =>
-      'Tieto oprávnenia sú kľúčové pre fungovanie Omi. Umožňujú kľúčové funkcie ako upozornenia, zážitky založené na polohe a nahrávanie zvuku.';
+  String get permissionsPageDescription => 'Tieto oprávnenia sú kľúčové pre fungovanie Omi. Umožňujú kľúčové funkcie ako upozornenia, zážitky založené na polohe a nahrávanie zvuku.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi potrebuje niekoľko oprávnení, aby správne fungoval. Prosím, udeľte ich pre pokračovanie.';
+  String get permissionsRequiredDescription => 'Omi potrebuje niekoľko oprávnení, aby správne fungoval. Prosím, udeľte ich pre pokračovanie.';
 
   @override
   String get permissionsSetupTitle => 'Získajte najlepší zážitok';
@@ -8881,8 +8738,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get firmwareWarningTitle => 'Dôležité: Prečítajte si pred aktualizáciou';
 
   @override
-  String get firmwareFormatWarning =>
-      'Tento firmvér naformátuje SD kartu. Pred aktualizáciou sa uistite, že všetky offline dáta sú synchronizované.\n\nAk po inštalácii tejto verzie uvidíte blikajúce červené svetlo, neznepokojujte sa. Jednoducho pripojte zariadenie k aplikácii a malo by sa rozsvietiť namodro. Červené svetlo znamená, že hodiny zariadenia ešte neboli synchronizované.';
+  String get firmwareFormatWarning => 'Tento firmvér naformátuje SD kartu. Pred aktualizáciou sa uistite, že všetky offline dáta sú synchronizované.\n\nAk po inštalácii tejto verzie uvidíte blikajúce červené svetlo, neznepokojujte sa. Jednoducho pripojte zariadenie k aplikácii a malo by sa rozsvietiť namodro. Červené svetlo znamená, že hodiny zariadenia ešte neboli synchronizované.';
 
   @override
   String get continueAnyway => 'Pokračovať';
@@ -8902,8 +8758,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get tasksMarkComplete => 'Označené ako dokončené';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi pristupuje k Apple Health prostredníctvom frameworku HealthKit od spoločnosti Apple. Prístup môžete kedykoľvek zrušiť v Nastaveniach iOS.';
+  String get appleHealthManageNote => 'Omi pristupuje k Apple Health prostredníctvom frameworku HealthKit od spoločnosti Apple. Prístup môžete kedykoľvek zrušiť v Nastaveniach iOS.';
 
   @override
   String get appleHealthConnectCta => 'Pripojiť k Apple Health';
@@ -8936,8 +8791,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Prístup k Apple Health zamietnutý';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi nemá povolenie na čítanie vašich údajov Apple Health. Povoľte ho v Nastaveniach iOS → Súkromie a bezpečnosť → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi nemá povolenie na čítanie vašich údajov Apple Health. Povoľte ho v Nastaveniach iOS → Súkromie a bezpečnosť → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Prečo odchádzate?';
@@ -9006,8 +8860,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get planUpdate => 'Aktualizácia plánu';
 
   @override
-  String get planDeprecationMessage =>
-      'Váš plán Unlimited sa ruší. Prejdite na plán Operator — rovnaké skvelé funkcie za \$49/mes. Váš súčasný plán bude zatiaľ naďalej fungovať.';
+  String get planDeprecationMessage => 'Váš plán Unlimited sa ruší. Prejdite na plán Operator — rovnaké skvelé funkcie za \$49/mes. Váš súčasný plán bude zatiaľ naďalej fungovať.';
 
   @override
   String get upgradeYourPlan => 'Vylepšite svoj plán';
@@ -9118,8 +8971,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Dosiahli ste svoj mesačný limit. Inovujte, aby ste mohli pokračovať v chate s Omi bez obmedzení.';
+  String get chatQuotaExceededReply => 'Dosiahli ste svoj mesačný limit. Inovujte, aby ste mohli pokračovať v chate s Omi bez obmedzení.';
 
   @override
   String get voiceResponseAudio => 'Prečítať odpoveď Omi nahlas';
@@ -9150,4 +9002,25 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Pridať úlohu';
+
+  @override
+  String get quickActionAskOmiAnything => 'Opýtajte sa Omi čokoľvek';
+
+  @override
+  String get quickActionVoiceMode => 'Hlasový režim';
+
+  @override
+  String get quickActionMute => 'Stíšiť';
+
+  @override
+  String get quickActionUnmute => 'Zrušiť stíšenie';
+
+  @override
+  String get quickActionConnectDevice => 'Pripojiť zariadenie';
+
+  @override
+  String get quickActionDeviceSettings => 'Nastavenia zariadenia';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -24,8 +24,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteConversationTitle => 'Izbriši pogovor?';
 
   @override
-  String get deleteConversationMessage =>
-      'To bo tudi izbrisalo povezane spomine, naloge in zvočne datoteke. To dejanje ni mogoče razveljaviti.';
+  String get deleteConversationMessage => 'To bo tudi izbrisalo povezane spomine, naloge in zvočne datoteke. To dejanje ni mogoče razveljaviti.';
 
   @override
   String get confirm => 'Potrdi';
@@ -146,8 +145,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleting => 'Brisanje...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Prosimo, dokončajte avtentifikacijo v brskalniku. Ko ste končali, se vrnite v aplikacijo.';
+  String get pleaseCompleteAuthentication => 'Prosimo, dokončajte avtentifikacijo v brskalniku. Ko ste končali, se vrnite v aplikacijo.';
 
   @override
   String get failedToStartAuthentication => 'Avtentifikacija se ni mogla začeti';
@@ -319,8 +317,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get installedApps => 'Nameščene aplikacije';
 
   @override
-  String get unableToFetchApps =>
-      'Aplikacij ni bilo mogoče pridobiti :(\n\nProsimo, preverite internetno povezavo in poskusite ponovno.';
+  String get unableToFetchApps => 'Aplikacij ni bilo mogoče pridobiti :(\n\nProsimo, preverite internetno povezavo in poskusite ponovno.';
 
   @override
   String get aboutOmi => 'O Omi';
@@ -356,19 +353,16 @@ class AppLocalizationsSl extends AppLocalizations {
   String get appsDisconnected => 'Vaše aplikacije in integracije bodo takoj odklopljene.';
 
   @override
-  String get exportBeforeDelete =>
-      'Podatke lahko izvozite pred brisanjem računa, vendar jih po brisanju ni mogoče obnoviti.';
+  String get exportBeforeDelete => 'Podatke lahko izvozite pred brisanjem računa, vendar jih po brisanju ni mogoče obnoviti.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Razumem, da je brisanje računa trajno in da bodo vsi podatki, vključno s spomini in pogovori, izginuli in jih ni mogoče obnoviti.';
+  String get deleteAccountCheckbox => 'Razumem, da je brisanje računa trajno in da bodo vsi podatki, vključno s spomini in pogovori, izginuli in jih ni mogoče obnoviti.';
 
   @override
   String get areYouSure => 'Ali ste prepričani?';
 
   @override
-  String get deleteAccountFinal =>
-      'To dejanje je nepovratno in bo trajno izbrisalo vaš račun in vse povezane podatke. Ali ste prepričani, da želite nadaljevati?';
+  String get deleteAccountFinal => 'To dejanje je nepovratno in bo trajno izbrisalo vaš račun in vse povezane podatke. Ali ste prepričani, da želite nadaljevati?';
 
   @override
   String get deleteNow => 'Izbriši zdaj';
@@ -455,8 +449,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get yourPrivacyYourControl => 'Vaša zasebnost, vaš nadzor';
 
   @override
-  String get privacyIntro =>
-      'Pri Omi smo zavezani zaščiti vaše zasebnosti. Ta stran vam omogoči nadzor nad tem, kako se vaši podatki shranjevajo in uporabljajo.';
+  String get privacyIntro => 'Pri Omi smo zavezani zaščiti vaše zasebnosti. Ta stran vam omogoči nadzor nad tem, kako se vaši podatki shranjevajo in uporabljajo.';
 
   @override
   String get learnMore => 'Izvedite več...';
@@ -465,15 +458,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get dataProtectionLevel => 'Raven zaščite podatkov';
 
   @override
-  String get dataProtectionDesc =>
-      'Vaši podatki so privzeto zaščiteni s krepko enkripcijo. Preglejte svoje nastavitve in prihodnje možnosti zasebnosti spodaj.';
+  String get dataProtectionDesc => 'Vaši podatki so privzeto zaščiteni s krepko enkripcijo. Preglejte svoje nastavitve in prihodnje možnosti zasebnosti spodaj.';
 
   @override
   String get appAccess => 'Dostop aplikacije';
 
   @override
-  String get appAccessDesc =>
-      'Naslednje aplikacije lahko dostopajo do vaših podatkov. Dotaknite se aplikacije za upravljanje njenih dovoljenj.';
+  String get appAccessDesc => 'Naslednje aplikacije lahko dostopajo do vaših podatkov. Dotaknite se aplikacije za upravljanje njenih dovoljenj.';
 
   @override
   String get noAppsExternalAccess => 'Nobena nameščena aplikacija nima zunanjega dostopa do vaših podatkov.';
@@ -530,15 +521,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Vaš Omi je bil odklopljen 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Naprava je preklopljena. Pojdite v Nastavitve > Bluetooth in pozabite napravo, da dokončate preklapljanje.';
+  String get deviceUnpairedMessage => 'Naprava je preklopljena. Pojdite v Nastavitve > Bluetooth in pozabite napravo, da dokončate preklapljanje.';
 
   @override
   String get unpairDialogTitle => 'Prekinji povezavo naprave';
 
   @override
-  String get unpairDialogMessage =>
-      'To bo prekinilo povezavo naprave, da se jo lahko poveže z drugim telefonom. Trebat ćete ići na Postavke > Bluetooth i zaboraviti uređaj da završite proces.';
+  String get unpairDialogMessage => 'To bo prekinilo povezavo naprave, da se jo lahko poveže z drugim telefonom. Trebat ćete ići na Postavke > Bluetooth i zaboraviti uređaj da završite proces.';
 
   @override
   String get deviceNotConnected => 'Naprava ni priključena';
@@ -559,8 +548,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get v2Undetected => 'V2 ni zaznan';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vidimo, da imate V1 napravo ali pa je vaša naprava nepriključena. Funkcionalnost SD kartice je dostopna samo za naprave V2.';
+  String get v2UndetectedMessage => 'Vidimo, da imate V1 napravo ali pa je vaša naprava nepriključena. Funkcionalnost SD kartice je dostopna samo za naprave V2.';
 
   @override
   String get endConversation => 'Končaj pogovor';
@@ -834,8 +822,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Izbriši graf znanja?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'To bo izbrisalo vse izpeljane podatke grafa znanja (vozlišča in povezave). Vaši izvirni spomin ostanejo varni. Graf se bo sčasoma ponovno zgrajen ali ob naslednji zahtevi.';
+  String get deleteKnowledgeGraphMessage => 'To bo izbrisalo vse izpeljane podatke grafa znanja (vozlišča in povezave). Vaši izvirni spomin ostanejo varni. Graf se bo sčasoma ponovno zgrajen ali ob naslednji zahtevi.';
 
   @override
   String get knowledgeGraphDeleted => 'Graf znanja je izbrisan';
@@ -1018,8 +1005,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get integrationsFooter => 'Povežite svoje aplikacije za prikaz podatkov in metrike v klepetu.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Prosimo, dokončajte avtentifikacijo v brskalniku. Ko ste končali, se vrnite v aplikacijo.';
+  String get completeAuthInBrowser => 'Prosimo, dokončajte avtentifikacijo v brskalniku. Ko ste končali, se vrnite v aplikacijo.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1079,8 +1065,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get needYourPermission => 'Potrebujemo vašo dovoljenje';
 
   @override
-  String get alreadyGavePermission =>
-      'Že ste nam dali dovoljenje za shranjevanje vaših posnetkov. Tu je opomnik, zakaj ga potrebujemo:';
+  String get alreadyGavePermission => 'Že ste nam dali dovoljenje za shranjevanje vaših posnetkov. Tu je opomnik, zakaj ga potrebujemo:';
 
   @override
   String get wouldLikePermission => 'Radi bi vaše dovoljenje za shranjevanje vaših glasovnih posnetkov. Evo zakaj:';
@@ -1089,26 +1074,22 @@ class AppLocalizationsSl extends AppLocalizations {
   String get improveSpeechProfile => 'Izboljšaj svoj profil govora';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Posnetke uporabljamo za dodatno usposabljanje in izboljšanje vašega osebnega profila govora.';
+  String get improveSpeechProfileDesc => 'Posnetke uporabljamo za dodatno usposabljanje in izboljšanje vašega osebnega profila govora.';
 
   @override
   String get trainFamilyProfiles => 'Profilov usposabljanja za prijatelje in družino';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Vaši posnetki nam pomagajo prepoznati in ustvariti profile za vaše prijatelje in družino.';
+  String get trainFamilyProfilesDesc => 'Vaši posnetki nam pomagajo prepoznati in ustvariti profile za vaše prijatelje in družino.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Izboljšaj natančnost prepisa';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Ko se naš model izboljša, lahko zagotovimo boljše rezultate transkripcije za vaše posnetke.';
+  String get enhanceTranscriptAccuracyDesc => 'Ko se naš model izboljša, lahko zagotovimo boljše rezultate transkripcije za vaše posnetke.';
 
   @override
-  String get legalNotice =>
-      'Pravno obvestilo: Zakonitost snemanja in shranjevanja podatkov govora se lahko razlikuje glede na vašo lokacijo in kako uporabljate to funkcijo. Vaša odgovornost je, da zagotovite skladnost z lokalnimi zakoni in predpisi.';
+  String get legalNotice => 'Pravno obvestilo: Zakonitost snemanja in shranjevanja podatkov govora se lahko razlikuje glede na vašo lokacijo in kako uporabljate to funkcijo. Vaša odgovornost je, da zagotovite skladnost z lokalnimi zakoni in predpisi.';
 
   @override
   String get alreadyAuthorized => 'Že avtorizirano';
@@ -1180,15 +1161,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showMeetingsMenuBar => 'Pokaži prihajajo sestanke v menijski vrstici';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Prikaži svoj naslednji sestanek in čas do njegovega začetka v menijski vrstici macOS';
+  String get showMeetingsMenuBarDesc => 'Prikaži svoj naslednji sestanek in čas do njegovega začetka v menijski vrstici macOS';
 
   @override
   String get showEventsNoParticipants => 'Pokaži dogodke brez udeležencev';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Če je omogočeno, »Prihajajo« prikazuje dogodke brez udeležencev ali video povezave.';
+  String get showEventsNoParticipantsDesc => 'Če je omogočeno, »Prihajajo« prikazuje dogodke brez udeležencev ali video povezave.';
 
   @override
   String get yourMeetings => 'Vaši sestanki';
@@ -1356,8 +1335,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get defaultRepository => 'Privzeto skladišče';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Izberite privzeto skladišče za ustvarjanje težav. Pri ustvarjanju težav še vedno lahko določite drugo skladišče.';
+  String get selectDefaultRepoDesc => 'Izberite privzeto skladišče za ustvarjanje težav. Pri ustvarjanju težav še vedno lahko določite drugo skladišče.';
 
   @override
   String get noReposFound => 'Ni najdenih skladišč';
@@ -1404,8 +1382,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get configureSettings => 'Nastavite nastavitve';
 
   @override
-  String get completeAuthBrowser =>
-      'Prosimo dokončajte avtentikacijo v brskalniku. Ko je to storjeno, se vrnite v aplikacijo.';
+  String get completeAuthBrowser => 'Prosimo dokončajte avtentikacijo v brskalniku. Ko je to storjeno, se vrnite v aplikacijo.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1733,8 +1710,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get enableBluetooth => 'Omogočite Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi potrebuje Bluetooth za povezavo z vašo nosljivo napravo. Prosimo omogočite Bluetooth in poskusite znova.';
+  String get bluetoothNeeded => 'Omi potrebuje Bluetooth za povezavo z vašo nosljivo napravo. Prosimo omogočite Bluetooth in poskusite znova.';
 
   @override
   String get contactSupport => 'Stopite v kontakt s podporo?';
@@ -1767,26 +1743,22 @@ class AppLocalizationsSl extends AppLocalizations {
   String get locationServiceDisabled => 'Storitev lokacije je onemogočena';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Storitev lokacije je onemogočena. Prosimo, pojdite v Nastavitve > Zasebnost in varnost > Storitve lokacije in omogočite';
+  String get locationServiceDisabledDesc => 'Storitev lokacije je onemogočena. Prosimo, pojdite v Nastavitve > Zasebnost in varnost > Storitve lokacije in omogočite';
 
   @override
   String get backgroundLocationDenied => 'Dostop do lokacije v ozadju je zavrnjen';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Prosimo, pojdite v nastavitve naprave in nastavite dovoljenka za lokacijo na »Vedno dovoli«';
+  String get backgroundLocationDeniedDesc => 'Prosimo, pojdite v nastavitve naprave in nastavite dovoljenka za lokacijo na »Vedno dovoli«';
 
   @override
   String get lovingOmi => 'Vam je všeč Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Pomagajte nam dosegati več ljudi s povzetkom v App Storu. Vaše povratne informacije pomenijo svet!';
+  String get leaveReviewIos => 'Pomagajte nam dosegati več ljudi s povzetkom v App Storu. Vaše povratne informacije pomenijo svet!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Pomagajte nam dosegati več ljudi s povzetkom v Google Play Storu. Vaše povratne informacije pomenijo svet!';
+  String get leaveReviewAndroid => 'Pomagajte nam dosegati več ljudi s povzetkom v Google Play Storu. Vaše povratne informacije pomenijo svet!';
 
   @override
   String get rateOnAppStore => 'Ocenite v App Storu';
@@ -1819,15 +1791,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get connectionError => 'Napaka povezave';
 
   @override
-  String get connectionErrorDesc =>
-      'Povezava na strežnik ni uspela. Prosimo preverite internet povezavo in poskusite znova.';
+  String get connectionErrorDesc => 'Povezava na strežnik ni uspela. Prosimo preverite internet povezavo in poskusite znova.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Zaznana neveljavna snemka';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Videti je, da so v snemki večje govorca. Prosimo prepričajte se, da ste na tihem mestu in poskusite znova.';
+  String get multipleSpeakersDesc => 'Videti je, da so v snemki večje govorca. Prosimo prepričajte se, da ste na tihem mestu in poskusite znova.';
 
   @override
   String get tooShortDesc => 'Zaznano ni dovolj govora. Prosimo govorite več in poskusite znova.';
@@ -1845,8 +1815,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get connectionLost => 'Povezava je prekinjena';
 
   @override
-  String get connectionLostDesc =>
-      'Povezava je bila prekinjena. Prosimo preverite internet povezavo in poskusite znova.';
+  String get connectionLostDesc => 'Povezava je bila prekinjena. Prosimo preverite internet povezavo in poskusite znova.';
 
   @override
   String get tryAgain => 'Poskusite znova';
@@ -1861,8 +1830,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get permissionsRequired => 'Potrebne so dovoljenke';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Ta aplikacija potrebuje dovoljenke Bluetooth in lokacije za pravilno delovanje. Prosimo omogočite jih v nastavitvah.';
+  String get permissionsRequiredDesc => 'Ta aplikacija potrebuje dovoljenke Bluetooth in lokacije za pravilno delovanje. Prosimo omogočite jih v nastavitvah.';
 
   @override
   String get openSettings => 'Odpri nastavitve';
@@ -1892,8 +1860,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Vaš AI spremljevalec';
 
   @override
-  String get captureEveryMoment =>
-      'Zajemite vsak trenutek. Dobite povzetke na podlagi umetne inteligence.\nNikoli več ne pisujte opombk.';
+  String get captureEveryMoment => 'Zajemite vsak trenutek. Dobite povzetke na podlagi umetne inteligence.\nNikoli več ne pisujte opombk.';
 
   @override
   String get appleWatchSetup => 'Namestitev Apple Watch';
@@ -1905,12 +1872,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get microphonePermission => 'Dovoljenka mikrofona';
 
   @override
-  String get permissionGrantedNow =>
-      'Dovoljenka je bila odobrena! Zdaj:\n\nOdprite aplikacijo Omi na uri in tapnite »Nadaljuj« spodaj';
+  String get permissionGrantedNow => 'Dovoljenka je bila odobrena! Zdaj:\n\nOdprite aplikacijo Omi na uri in tapnite »Nadaljuj« spodaj';
 
   @override
-  String get needMicrophonePermission =>
-      'Potrebujemo dovoljenka za mikrofon.\n\n1. Tapnite »Dodelite dovoljenka«\n2. Dovolite na iPhonu\n3. Aplikacija na uri se bo zaprla\n4. Ponovno jo odprite in tapnite »Nadaljuj«';
+  String get needMicrophonePermission => 'Potrebujemo dovoljenka za mikrofon.\n\n1. Tapnite »Dodelite dovoljenka«\n2. Dovolite na iPhonu\n3. Aplikacija na uri se bo zaprla\n4. Ponovno jo odprite in tapnite »Nadaljuj«';
 
   @override
   String get grantPermissionButton => 'Dodelite dovoljenka';
@@ -1919,15 +1884,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get needHelp => 'Potrebujete pomoč?';
 
   @override
-  String get troubleshootingSteps =>
-      'Odpravljanje težav:\n\n1. Prepričajte se, da je Omi nameščen na vaši uri\n2. Odprite aplikacijo Omi na vaši uri\n3. Poiščite okno dovoljenke\n4. Tapnite »Dovoli« ko je prikazano\n5. Aplikacija na uri se bo zaprla - ponovno jo odprite\n6. Pridite nazaj in tapnite »Nadaljuj« na iPhonu';
+  String get troubleshootingSteps => 'Odpravljanje težav:\n\n1. Prepričajte se, da je Omi nameščen na vaši uri\n2. Odprite aplikacijo Omi na vaši uri\n3. Poiščite okno dovoljenke\n4. Tapnite »Dovoli« ko je prikazano\n5. Aplikacija na uri se bo zaprla - ponovno jo odprite\n6. Pridite nazaj in tapnite »Nadaljuj« na iPhonu';
 
   @override
   String get recordingStartedSuccessfully => 'Snemanje je uspešno začeto!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Dovoljenka še ni odobrena. Prosimo prepričajte se, da ste dovolili dostop do mikrofona in ponovno odprli aplikacijo na uri.';
+  String get permissionNotGrantedYet => 'Dovoljenka še ni odobrena. Prosimo prepričajte se, da ste dovolili dostop do mikrofona in ponovno odprli aplikacijo na uri.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2024,8 +1987,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Pripravljena za opravila';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Vaša umetna inteligenca bo samodejno izluščila naloge in opravila iz pogovorov. Pojavila se bodo tukaj, ko bodo ustvarjena.';
+  String get welcomeActionItemsDescription => 'Vaša umetna inteligenca bo samodejno izluščila naloge in opravila iz pogovorov. Pojavila se bodo tukaj, ko bodo ustvarjena.';
 
   @override
   String get autoExtractionFeature => 'Samodejno izluščeno iz pogovorov';
@@ -2075,8 +2037,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get clearMemoryTitle => 'Počisti Omijevo spominno';
 
   @override
-  String get clearMemoryMessage =>
-      'Ali ste prepričani, da želite počistiti Omijevo spomin? To dejanje ne moremo razveljaviti.';
+  String get clearMemoryMessage => 'Ali ste prepričani, da želite počistiti Omijevo spomin? To dejanje ne moremo razveljaviti.';
 
   @override
   String get clearMemoryButton => 'Počisti spomin';
@@ -2222,15 +2183,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'GOVOR IN TRANSKRIPCIJA';
 
   @override
-  String get languageSettingsHelperText =>
-      'Jezik aplikacije spreminja menuje in gumbe. Jezik govora vpliva na transkripcijo svojih posnetkov.';
+  String get languageSettingsHelperText => 'Jezik aplikacije spreminja menuje in gumbe. Jezik govora vpliva na transkripcijo svojih posnetkov.';
 
   @override
   String get translationNotice => 'Obvestilo o prevodu';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi prevaja pogovore v svoj primarni jezik. Posodobite ga kadar koli v Nastavitve → Profili.';
+  String get translationNoticeMessage => 'Omi prevaja pogovore v svoj primarni jezik. Posodobite ga kadar koli v Nastavitve → Profili.';
 
   @override
   String get pleaseCheckInternetConnection => 'Prosimo preverite internet povezavo in poskusite znova';
@@ -2392,8 +2351,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Nepovežite napravo';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'To bo nepovezalo napravo, da jo je mogoče povezati z drugim telefonom. Pojdite na Nastavitve > Bluetooth in pozabite napravo, da dokončate postopek.';
+  String get unpairDeviceDialogMessage => 'To bo nepovezalo napravo, da jo je mogoče povezati z drugim telefonom. Pojdite na Nastavitve > Bluetooth in pozabite napravo, da dokončate postopek.';
 
   @override
   String get unpair => 'Nepoveži';
@@ -2574,8 +2532,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get youreAllSet => 'Vse je pripravljeno!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Dobrodošli v Omi! Vaš AI spremljevalec je pripravljen, da vam pomaga s pogovori, nalogami in še več.';
+  String get welcomeToOmiDescription => 'Dobrodošli v Omi! Vaš AI spremljevalec je pripravljen, da vam pomaga s pogovori, nalogami in še več.';
 
   @override
   String get startUsingOmi => 'Začni uporabljati Omi';
@@ -2711,8 +2668,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get noTasksYet => 'Še ni nalog';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Naloge iz svojih pogovorov se bodo pojavile tukaj.\nKlikni Ustvari, da jo dodaš ročno.';
+  String get tasksFromConversationsWillAppear => 'Naloge iz svojih pogovorov se bodo pojavile tukaj.\nKlikni Ustvari, da jo dodaš ročno.';
 
   @override
   String get monthJan => 'Jan';
@@ -2769,8 +2725,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteActionItem => 'Izbriši akcijsko točko';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Ali ste prepričani, da želite izbrisati to akcijsko točko? Tega dejanja ni mogoče razveljaviti.';
+  String get deleteActionItemConfirmation => 'Ali ste prepričani, da želite izbrisati to akcijsko točko? Tega dejanja ni mogoče razveljaviti.';
 
   @override
   String get enterActionItemDescription => 'Vnesite opis akcijske točke...';
@@ -2845,8 +2800,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get chatPrompt => 'Poziv za klepet';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Vsi ste odličan aplikacija, vaša naloga je odgovarjati na vprašanja uporabnika in jih narediti srečne...';
+  String get chatPromptPlaceholder => 'Vsi ste odličan aplikacija, vaša naloga je odgovarjati na vprašanja uporabnika in jih narediti srečne...';
 
   @override
   String get conversationPrompt => 'Poziv za pogovor';
@@ -2864,8 +2818,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get makeMyAppPublic => 'Naredi svojo aplikacijo javno';
 
   @override
-  String get submitAppTermsAgreement =>
-      'S predložitvijo te aplikacije se strinjam s pogoji storitve in politiko zasebnosti Omi AI';
+  String get submitAppTermsAgreement => 'S predložitvijo te aplikacije se strinjam s pogoji storitve in politiko zasebnosti Omi AI';
 
   @override
   String get submitApp => 'Pošlji aplikacijo';
@@ -2880,12 +2833,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get submitAppQuestion => 'Pošlji aplikacijo?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Vaša aplikacija bo pregledana in narejena javna. Lahko jo začnete uporabljati takoj, tudi med pregledom!';
+  String get submitAppPublicDescription => 'Vaša aplikacija bo pregledana in narejena javna. Lahko jo začnete uporabljati takoj, tudi med pregledom!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Vaša aplikacija bo pregledana in vam bo dostopna zasebno. Lahko jo začnete uporabljati takoj, tudi med pregledom!';
+  String get submitAppPrivateDescription => 'Vaša aplikacija bo pregledana in vam bo dostopna zasebno. Lahko jo začnete uporabljati takoj, tudi med pregledom!';
 
   @override
   String get startEarning => 'Začni zaslužavati! 💰';
@@ -2909,8 +2860,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get dataAccessNotice => 'Obvestilo o dostopu do podatkov';
 
   @override
-  String get dataAccessWarning =>
-      'Ta aplikacija bo dostopala do vaših podatkov. Omi AI ni odgovoren za to, kako so vaši podatki uporabljeni, spremenjeni ali izbrisani s stran te aplikacije';
+  String get dataAccessWarning => 'Ta aplikacija bo dostopala do vaših podatkov. Omi AI ni odgovoren za to, kako so vaši podatki uporabljeni, spremenjeni ali izbrisani s stran te aplikacije';
 
   @override
   String get installApp => 'Namesti aplikacijo';
@@ -2922,8 +2872,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get appUnderReviewOwner => 'Vaša aplikacija je v pregledu in vidna samo vam. Javna bo, ko bo odobrena.';
 
   @override
-  String get appRejectedNotice =>
-      'Vaša aplikacija je bila zavrnjena. Prosimo, posodobite podrobnosti aplikacije in ponovno predložite v pregled.';
+  String get appRejectedNotice => 'Vaša aplikacija je bila zavrnjena. Prosimo, posodobite podrobnosti aplikacije in ponovno predložite v pregled.';
 
   @override
   String get setupSteps => 'Koraki nastavitve';
@@ -2958,8 +2907,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get errorActivatingApp => 'Napaka pri aktiviranju aplikacije';
 
   @override
-  String get integrationSetupRequired =>
-      'Če je to integracijska aplikacija, se prepričajte, da je nastavitev dokončana.';
+  String get integrationSetupRequired => 'Če je to integracijska aplikacija, se prepričajte, da je nastavitev dokončana.';
 
   @override
   String get installed => 'Nameščeno';
@@ -2986,8 +2934,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get descriptionLabel => 'Opis';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Moja odlična aplikacija je odličen aplikacija, ki počne čudovite stvari. To je najboljša aplikacija vseh časov!';
+  String get appDescriptionPlaceholder => 'Moja odlična aplikacija je odličen aplikacija, ki počne čudovite stvari. To je najboljša aplikacija vseh časov!';
 
   @override
   String get pleaseProvideValidDescription => 'Prosimo, navedite veljaven opis';
@@ -3139,8 +3086,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get microphonePermissionRequired => 'Dovoljenj za mikrofon je potrebno za klice';
 
   @override
-  String get microphonePermissionDenied =>
-      'Dovoljenj za mikrofon je zavrnjeno. Prosimo, dajte dovoljenje v Sistemskih nastavitvah > Zasebnost in varnost > Mikrofon.';
+  String get microphonePermissionDenied => 'Dovoljenj za mikrofon je zavrnjeno. Prosimo, dajte dovoljenje v Sistemskih nastavitvah > Zasebnost in varnost > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3299,8 +3245,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get createMemory => 'Ustvari spomin';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Ali ste prepričani, da želite izbrisati ta spomin? Tega dejanja ni mogoče razveljaviti.';
+  String get deleteMemoryConfirmation => 'Ali ste prepričani, da želite izbrisati ta spomin? Tega dejanja ni mogoče razveljaviti.';
 
   @override
   String get makePrivate => 'Naredi zasebno';
@@ -3374,8 +3319,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get whatWeCollect => 'Kaj zbiramo';
 
   @override
-  String get dataCollectionMessage =>
-      'Z nadaljevanjem bodo vaši pogovori, posnetki in osebni podatki varno shranjeni na naših strežnikih, da bi vam omogočili rezultate na osnovi umetne inteligence in vse funkcije aplikacije.';
+  String get dataCollectionMessage => 'Z nadaljevanjem bodo vaši pogovori, posnetki in osebni podatki varno shranjeni na naših strežnikih, da bi vam omogočili rezultate na osnovi umetne inteligence in vse funkcije aplikacije.';
 
   @override
   String get dataProtection => 'Zaščita podatkov';
@@ -3408,8 +3352,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Ime mora imeti najmanj 2 znaka';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Povejte nam, kako vas želite nagovarjati. To pomaga pri personalizaciji vaše izkušnje z Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Povejte nam, kako vas želite nagovarjati. To pomaga pri personalizaciji vaše izkušnje z Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3426,8 +3369,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get recordAudioConversations => 'Snemanje audio pogovorov';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi potrebuje dostop do mikrofona za snemanje vaših pogovorov in zagotavljanje prepisov.';
+  String get microphoneAccessDescription => 'Omi potrebuje dostop do mikrofona za snemanje vaših pogovorov in zagotavljanje prepisov.';
 
   @override
   String get screenRecording => 'Snemanje zaslona';
@@ -3436,8 +3378,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Zajemanje sistemskega zvoka s srečanj';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi potrebuje dovoljenježe za snemanje zaslona, da bi zajel sistemski zvok iz vaših srečanj v brskalnikih.';
+  String get screenRecordingDescription => 'Omi potrebuje dovoljenježe za snemanje zaslona, da bi zajel sistemski zvok iz vaših srečanj v brskalnikih.';
 
   @override
   String get accessibility => 'Dostopnost';
@@ -3446,8 +3387,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Zaznavanje srečanj v brskalniku';
 
   @override
-  String get accessibilityDescription =>
-      'Omi potrebuje dovoljenje za dostopnost za zaznavanje, ko se pridružite srečanjem Zoom, Meet ali Teams v vašem brskalniku.';
+  String get accessibilityDescription => 'Omi potrebuje dovoljenje za dostopnost za zaznavanje, ko se pridružite srečanjem Zoom, Meet ali Teams v vašem brskalniku.';
 
   @override
   String get pleaseWait => 'Prosimo, počakajte...';
@@ -3519,8 +3459,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get conversationsExportStarted => 'Izvoz pogovorov je začet. To lahko traja nekaj sekund, prosimo počakajte.';
 
   @override
-  String get mcpDescription =>
-      'Če želite Omi povezati z drugimi aplikacijami za branje, iskanje in upravljanje vaših spomin in pogovorov. Ustvarite ključ, da bi se začeli.';
+  String get mcpDescription => 'Če želite Omi povezati z drugimi aplikacijami za branje, iskanje in upravljanje vaših spomin in pogovorov. Ustvarite ključ, da bi se začeli.';
 
   @override
   String get apiKeys => 'Ključi API';
@@ -3591,8 +3530,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get auto => 'Samodejno';
 
   @override
-  String get noSummaryForApp =>
-      'Za to aplikacijo ni dostopnega povzetka. Poskusite z drugo aplikacijo za boljše rezultate.';
+  String get noSummaryForApp => 'Za to aplikacijo ni dostopnega povzetka. Poskusite z drugo aplikacijo za boljše rezultate.';
 
   @override
   String get tryAnotherApp => 'Poskusite drugo aplikacijo';
@@ -3629,8 +3567,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Pusti Omi, da samodejno izbere najboljšo aplikacijo';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Ste prepričani, da želite izbrisati ta pogovor? Te akcije ni mogoče razveljaviti.';
+  String get deleteConversationConfirmation => 'Ste prepričani, da želite izbrisati ta pogovor? Te akcije ni mogoče razveljaviti.';
 
   @override
   String get conversationDeleted => 'Pogovor je izbrisan';
@@ -3678,8 +3615,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Priprava zajemanja sistemskega zvoka';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Kliknite gumb za zajemanje zvoka za žive prepise, umetne inteligence in samodejno shranjevanje.';
+  String get clickTheButtonToCaptureAudio => 'Kliknite gumb za zajemanje zvoka za žive prepise, umetne inteligence in samodejno shranjevanje.';
 
   @override
   String get reconnecting => 'Ponovno povezovanje...';
@@ -3837,8 +3773,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get dailySummaryTitle => 'Dnevni povzetek';
 
   @override
-  String get dailySummaryDescription =>
-      'Pridobite osebni povzetek pogovorov vašega dneva, dostavljenega kot obvestilo.';
+  String get dailySummaryDescription => 'Pridobite osebni povzetek pogovorov vašega dneva, dostavljenega kot obvestilo.';
 
   @override
   String get deliveryTime => 'Čas dostave';
@@ -3907,8 +3842,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Izbriši graf znanja?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'To bo izbrisalo vse izpeljane podatke grafa znanja. Vaši prvotni spomini ostajajo varni.';
+  String get deleteKnowledgeGraphWarning => 'To bo izbrisalo vse izpeljane podatke grafa znanja. Vaši prvotni spomini ostajajo varni.';
 
   @override
   String get connectOmiWithAI => 'Povežite Omi s pomočniki umetne inteligence';
@@ -3965,8 +3899,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get updateAppQuestion => 'Posodobi aplikacijo?';
 
   @override
-  String get updateAppConfirmation =>
-      'Ste prepričani, da želite posodobiti svojo aplikacijo? Spremembe se bodo odražale, ko jih pregleda naš tim.';
+  String get updateAppConfirmation => 'Ste prepričani, da želite posodobiti svojo aplikacijo? Spremembe se bodo odražale, ko jih pregleda naš tim.';
 
   @override
   String get updateApp => 'Posodobi aplikacijo';
@@ -3996,8 +3929,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get no => 'Ne';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Naročnina je uspešno preklicana. Ostane aktivna do konca trenutnega obračunskega obdobja.';
+  String get subscriptionCancelledSuccessfully => 'Naročnina je uspešno preklicana. Ostane aktivna do konca trenutnega obračunskega obdobja.';
 
   @override
   String get failedToCancelSubscription => 'Neuspešno preklicanje naročnine. Prosimo, poskusite znova.';
@@ -4033,8 +3965,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Preklici naročnino?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Ste prepričani, da želite preklicati naročnino? Nadaljeval boste imeti dostop do konca trenutnega obračunskega obdobja.';
+  String get cancelSubscriptionConfirmation => 'Ste prepričani, da želite preklicati naročnino? Nadaljeval boste imeti dostop do konca trenutnega obračunskega obdobja.';
 
   @override
   String get cancelSubscriptionButton => 'Preklici naročnino';
@@ -4049,8 +3980,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get appUnderReviewMessage => 'Vaša aplikacija je v pregledu in vidna samo vam. Javna bo, ko bo potrjena.';
 
   @override
-  String get appRejectedMessage =>
-      'Vaša aplikacija je bila zavrnjene. Prosimo, posodobite podrobnosti aplikacije in ponovno oddajte v pregled.';
+  String get appRejectedMessage => 'Vaša aplikacija je bila zavrnjene. Prosimo, posodobite podrobnosti aplikacije in ponovno oddajte v pregled.';
 
   @override
   String get invalidIntegrationUrl => 'Neveljavna URL integracije';
@@ -4104,8 +4034,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get issueActivatingApp => 'Prišlo je do težave pri aktiviranju te aplikacije. Prosimo, poskusite znova.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Ta aplikacija bo dostopala do vaših podatkov. Omi AI ni odgovorna za to, kako vaši podatki se uporabljajo, spreminjajo ali brišejo s te aplikacije';
+  String get dataAccessNoticeDescription => 'Ta aplikacija bo dostopala do vaših podatkov. Omi AI ni odgovorna za to, kako vaši podatki se uporabljajo, spreminjajo ali brišejo s te aplikacije';
 
   @override
   String get copyUrl => 'Kopiraj URL';
@@ -4193,8 +4122,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get omiApiKeys => 'Omi ključi API';
 
   @override
-  String get apiKeysDescription =>
-      'Ključi API se uporabljajo za avtentifikacijo, ko vaša aplikacija komunicira s strežnikom OMI. Omogočajo vaši aplikaciji, da varno ustvari spomine in dostopa do drugih storitev OMI.';
+  String get apiKeysDescription => 'Ključi API se uporabljajo za avtentifikacijo, ko vaša aplikacija komunicira s strežnikom OMI. Omogočajo vaši aplikaciji, da varno ustvari spomine in dostopa do drugih storitev OMI.';
 
   @override
   String get aboutOmiApiKeys => 'O Omi ključih API';
@@ -4218,8 +4146,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Preklici ključ API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Te akcije ni mogoče razveljaviti. Nobene aplikacije, ki uporabljajo ta ključ, ne bodo več imele dostopa do API.';
+  String get revokeApiKeyWarning => 'Te akcije ni mogoče razveljaviti. Nobene aplikacije, ki uporabljajo ta ključ, ne bodo več imele dostopa do API.';
 
   @override
   String get revoke => 'Preklici';
@@ -4308,8 +4235,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get keyCreated => 'Ključ je ustvaren';
 
   @override
-  String get keyCreatedMessage =>
-      'Vaš novi ključ je bil ustvaren. Prosimo, ga kopirajte zdaj. Ne boste ga mogli videti znova.';
+  String get keyCreatedMessage => 'Vaš novi ključ je bil ustvaren. Prosimo, ga kopirajte zdaj. Ne boste ga mogli videti znova.';
 
   @override
   String get keyWord => 'Ključ';
@@ -4318,8 +4244,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get externalAppAccess => 'Dostop zunanje aplikacije';
 
   @override
-  String get externalAppAccessDescription =>
-      'Naslednje nameščene aplikacije imajo zunanje integracije in imajo dostop do vaših podatkov, kot so pogovori in spomine.';
+  String get externalAppAccessDescription => 'Naslednje nameščene aplikacije imajo zunanje integracije in imajo dostop do vaših podatkov, kot so pogovori in spomine.';
 
   @override
   String get noExternalAppsHaveAccess => 'Nobena zunanja aplikacija nima dostopa do vaših podatkov.';
@@ -4328,8 +4253,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get maximumSecurityE2ee => 'Največja varnost (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Šifriranje od konca do konca je zlati standard za zasebnost. Ko je omogočeno, se vaši podatki šifrirajo na vaši napravi, preden se pošljejo na naše strežnike. To pomeni, da nihče, niti Omi, ne more dostopati do vaše vsebine.';
+  String get e2eeDescription => 'Šifriranje od konca do konca je zlati standard za zasebnost. Ko je omogočeno, se vaši podatki šifrirajo na vaši napravi, preden se pošljejo na naše strežnike. To pomeni, da nihče, niti Omi, ne more dostopati do vaše vsebine.';
 
   @override
   String get importantTradeoffs => 'Pomembni kompromisi:';
@@ -4363,15 +4287,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get secureEncryption => 'Varno šifriranje';
 
   @override
-  String get secureEncryptionDescription =>
-      'Vaši podatki so šifrirani s ključem, ki je edinstven za vas na naših strežnikih, gostovanih na Google Cloud. To pomeni, da je vaša surova vsebina nedostopna komurkoli, vključno z osebjem Omi ali Google, neposredno iz baze podatkov.';
+  String get secureEncryptionDescription => 'Vaši podatki so šifrirani s ključem, ki je edinstven za vas na naših strežnikih, gostovanih na Google Cloud. To pomeni, da je vaša surova vsebina nedostopna komurkoli, vključno z osebjem Omi ali Google, neposredno iz baze podatkov.';
 
   @override
   String get endToEndEncryption => 'Šifriranje od konca do konca';
 
   @override
-  String get e2eeCardDescription =>
-      'Omogočite za največjo varnost, kjer samo vi lahko dostopate do vaših podatkov. Tapnite, da se več naučite.';
+  String get e2eeCardDescription => 'Omogočite za največjo varnost, kjer samo vi lahko dostopate do vaših podatkov. Tapnite, da se več naučite.';
 
   @override
   String get dataAlwaysEncrypted => 'Ne glede na raven so vaši podatki vedno šifrirani v mirovanju in med prenosom.';
@@ -4439,19 +4361,16 @@ class AppLocalizationsSl extends AppLocalizations {
   String get trainingDataProgram => 'Program podatkov usposabljanja';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Pridobite Omi Unlimited brezplačno z deljenjem podatkov za usposabljanje modelov umetne inteligence.';
+  String get getOmiUnlimitedFree => 'Pridobite Omi Unlimited brezplačno z deljenjem podatkov za usposabljanje modelov umetne inteligence.';
 
   @override
-  String get trainingDataBullets =>
-      '• Vaši podatki pomagajo izboljšati modele umetne inteligence\n• Samo necitljivi podatki se delijo\n• Povsem transparenten proces';
+  String get trainingDataBullets => '• Vaši podatki pomagajo izboljšati modele umetne inteligence\n• Samo necitljivi podatki se delijo\n• Povsem transparenten proces';
 
   @override
   String get learnMoreAtOmiTraining => 'Več o tem na omi.me/training';
 
   @override
-  String get agreeToContributeData =>
-      'Razumem in se strinjam, da prispevam podatke za usposabljanje umetne inteligence';
+  String get agreeToContributeData => 'Razumem in se strinjam, da prispevam podatke za usposabljanje umetne inteligence';
 
   @override
   String get submitRequest => 'Oddaj zahtevo';
@@ -4495,8 +4414,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get monthlyPlanContinues => 'Vaš trenutni mesečni načrt se bo nadaljeval do konca vašega obračunskega obdobja';
 
   @override
-  String get paymentMethodCharged =>
-      'Vaša obstoječa način plačila bo samodejno napolnjena, ko se bo vaš mesečni načrt končal';
+  String get paymentMethodCharged => 'Vaša obstoječa način plačila bo samodejno napolnjena, ko se bo vaš mesečni načrt končal';
 
   @override
   String get annualSubscriptionStarts => 'Vaša 12-mesečna letna naročnina se bo samodejno začela po obračunu';
@@ -4539,8 +4457,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Vaš letni načrt se bo samodejno začel, ko se bo vaš mesečni načrt končal.';
+  String get annualPlanStartsAutomatically => 'Vaš letni načrt se bo samodejno začel, ko se bo vaš mesečni načrt končal.';
 
   @override
   String planRenewsOn(String date) {
@@ -4607,8 +4524,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Vaša zasebnost nam je važna';
 
   @override
-  String get privacyIntroText =>
-      'V Omi zelo resno jemljemo vašo zasebnost. Želimo biti transparentni o podatkih, ki jih zbiramo, in kako jih uporabljamo za izboljšanje našega izdelka za vas. Tukaj je, kaj morate vedeti:';
+  String get privacyIntroText => 'V Omi zelo resno jemljemo vašo zasebnost. Želimo biti transparentni o podatkih, ki jih zbiramo, in kako jih uporabljamo za izboljšanje našega izdelka za vas. Tukaj je, kaj morate vedeti:';
 
   @override
   String get whatWeTrack => 'Kaj sledimo';
@@ -4623,12 +4539,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get ourCommitment => 'Naše zavezanosti';
 
   @override
-  String get commitmentText =>
-      'Zavezani smo, da podatke, ki jih zbiramo, uporabljamo samo za izboljšanje Omija za vas. Vaša zasebnost in zaupanje sta nam največje.';
+  String get commitmentText => 'Zavezani smo, da podatke, ki jih zbiramo, uporabljamo samo za izboljšanje Omija za vas. Vaša zasebnost in zaupanje sta nam največje.';
 
   @override
-  String get thankYouText =>
-      'Hvala, ker ste dragoceni uporabnik Omija. Če imate vprašanja ali pomisleke, se lahko obrnete na nas na team@basedhardware.com.';
+  String get thankYouText => 'Hvala, ker ste dragoceni uporabnik Omija. Če imate vprašanja ali pomisleke, se lahko obrnete na nas na team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Nastavitve WiFi sinhronizacije';
@@ -4637,8 +4551,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get enterHotspotCredentials => 'Vnesite poverilnice osebne dostopne točke vašega telefona';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi sinhronizacija uporablja vaš telefon kot dostopno točko. Poiščite ime dostopne točke in geslo v Nastavitve > Osebna dostopna točka.';
+  String get wifiSyncUsesHotspot => 'WiFi sinhronizacija uporablja vaš telefon kot dostopno točko. Poiščite ime dostopne točke in geslo v Nastavitve > Osebna dostopna točka.';
 
   @override
   String get hotspotNameSsid => 'Ime dostopne točke (SSID)';
@@ -4673,8 +4586,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Ni mogoče ustvariti povzetka. Prepričajte se, da imate pogovore za ta dan.';
+  String get failedToGenerateSummaryCheckConversations => 'Ni mogoče ustvariti povzetka. Prepričajte se, da imate pogovore za ta dan.';
 
   @override
   String get summaryNotFound => 'Povzetek ni najden';
@@ -4704,8 +4616,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Izvoz se je začel. To lahko traja nekaj sekund...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'To bo izbrisalo vse izpeljane podatke grafa znanja (vozlišča in povezave). Vaša originalna spomina bodo ostala varna. Graf bo ponovno zgrajen s časom ali ob naslednji zahtevi.';
+  String get knowledgeGraphDeleteDescription => 'To bo izbrisalo vse izpeljane podatke grafa znanja (vozlišča in povezave). Vaša originalna spomina bodo ostala varna. Graf bo ponovno zgrajen s časom ali ob naslednji zahtevi.';
 
   @override
   String get configureDailySummaryDigest => 'Nastavite svojo dnevno povzetko akcijskih postavk';
@@ -4775,8 +4686,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Izbrisati vse pogovore Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'To bo trajno izbrisalo vse pogovore, uvožene iz Limitless. To dejanja ne moremo razveljaviti.';
+  String get deleteAllLimitlessWarning => 'To bo trajno izbrisalo vse pogovore, uvožene iz Limitless. To dejanja ne moremo razveljaviti.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4832,8 +4742,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get howItWorksTitle => 'Kako deluje?';
 
   @override
-  String get howPeopleWorks =>
-      'Ko je oseba ustvarjena, lahko greste na prepis pogovora in jim dodelite njihove pripadajoče segmente, na ta način bo Omi sposoben prepoznati tudi njihov govor!';
+  String get howPeopleWorks => 'Ko je oseba ustvarjena, lahko greste na prepis pogovora in jim dodelite njihove pripadajoče segmente, na ta način bo Omi sposoben prepoznati tudi njihov govor!';
 
   @override
   String get tapToDelete => 'Tapnite za brisanje';
@@ -4859,8 +4768,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get privacyNotice => 'Obvestilo o zasebnosti';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Posnetki lahko zajamejo glasove drugih. Preden omogočite, se prepričajte, da imate soglasje vseh udeležencev.';
+  String get recordingsMayCaptureOthers => 'Posnetki lahko zajamejo glasove drugih. Preden omogočite, se prepričajte, da imate soglasje vseh udeležencev.';
 
   @override
   String get enable => 'Omogočite';
@@ -4872,8 +4780,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get on => 'Vključeno';
 
   @override
-  String get storeAudioDescription =>
-      'Ohranite vse avdio posnetke shranjene lokalno na telefonu. Če je onemogočeno, se samo neuspeli prenosi ohranijo za varčevanje s prostorom.';
+  String get storeAudioDescription => 'Ohranite vse avdio posnetke shranjene lokalno na telefonu. Če je onemogočeno, se samo neuspeli prenosi ohranijo za varčevanje s prostorom.';
 
   @override
   String get enableLocalStorage => 'Omogočite lokalno shranjevanje';
@@ -4891,12 +4798,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get storeAudioOnCloud => 'Shranite avdio v oblak';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Vaši posnetki v realnem času bodo shranjeni v zasebnem oblačnem shranjevanju, medtem ko govorite.';
+  String get cloudStorageDialogMessage => 'Vaši posnetki v realnem času bodo shranjeni v zasebnem oblačnem shranjevanju, medtem ko govorite.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Shranite svoje posnetke v realnem času v zasebno oblačno shranjevanje, medtem ko govorite. Avdio je zajeti in varno shranjen v realnem času.';
+  String get storeAudioCloudDescription => 'Shranite svoje posnetke v realnem času v zasebno oblačno shranjevanje, medtem ko govorite. Avdio je zajeti in varno shranjen v realnem času.';
 
   @override
   String get downloadingFirmware => 'Prenos vdelane programske opreme';
@@ -4905,8 +4810,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get installingFirmware => 'Namestitev vdelane programske opreme';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Ne zaprite aplikacije in ne izklapljajte naprave. To bi lahko pokvarilo vašo napravo.';
+  String get firmwareUpdateWarning => 'Ne zaprite aplikacije in ne izklapljajte naprave. To bi lahko pokvarilo vašo napravo.';
 
   @override
   String get firmwareUpdated => 'Vdelana programska oprema je posodobljena';
@@ -4950,8 +4854,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get payments => 'Plačila';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Spodaj povežite način plačila, da začnete prejemati izplate za svoje aplikacije.';
+  String get connectPaymentMethodInfo => 'Spodaj povežite način plačila, da začnete prejemati izplate za svoje aplikacije.';
 
   @override
   String get selectedPaymentMethod => 'Izbrani način plačila';
@@ -4978,8 +4881,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get monthlyPayouts => 'Mesečne izplate';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Prejemajte mesečna plačila neposredno na vaš račun, ko dosežete 10 \$ zaslužka';
+  String get monthlyPayoutsDescription => 'Prejemajte mesečna plačila neposredno na vaš račun, ko dosežete 10 \$ zaslužka';
 
   @override
   String get secureAndReliable => 'Varno in zanesljivo';
@@ -5006,8 +4908,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get connectingYourStripeAccount => 'Povezovanje vašega Stripe računa';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Prosimo, dokončajte Stripe onboarding proces v vašem brskalniku. Ta stran se bo samodejno posodobila, ko bo končano.';
+  String get stripeOnboardingInstructions => 'Prosimo, dokončajte Stripe onboarding proces v vašem brskalniku. Ta stran se bo samodejno posodobila, ko bo končano.';
 
   @override
   String get failedTryAgain => 'Ni uspelo? Poskusite ponovno';
@@ -5019,15 +4920,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get successfullyConnected => 'Uspešno povezano!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Vaš Stripe račun je sedaj pripravljen za prejemanje plačil. Takoj lahko začnete zaslužiti s prodajo aplikacije.';
+  String get stripeReadyForPayments => 'Vaš Stripe račun je sedaj pripravljen za prejemanje plačil. Takoj lahko začnete zaslužiti s prodajo aplikacije.';
 
   @override
   String get updateStripeDetails => 'Posodobite podatke Stripe';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Napaka pri posodabljanju podatkov Stripe! Prosimo, poskusite ponovno kasneje.';
+  String get errorUpdatingStripeDetails => 'Napaka pri posodabljanju podatkov Stripe! Prosimo, poskusite ponovno kasneje.';
 
   @override
   String get updatePayPal => 'Posodobite PayPal';
@@ -5039,8 +4938,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Posodobite podatke vašega PayPal računa';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Povežite svoj PayPal račun, da začnete prejemati plačila za svoje aplikacije';
+  String get connectPayPalToReceivePayments => 'Povežite svoj PayPal račun, da začnete prejemati plačila za svoje aplikacije';
 
   @override
   String get paypalEmail => 'PayPal email';
@@ -5049,8 +4947,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me povezava';
 
   @override
-  String get stripeRecommendation =>
-      'Če je Stripe dostopen v vaši državi, vam toplo priporočamo, da ga uporabljate za hitrejše in enostavnejše izplate.';
+  String get stripeRecommendation => 'Če je Stripe dostopen v vaši državi, vam toplo priporočamo, da ga uporabljate za hitrejše in enostavnejše izplate.';
 
   @override
   String get updatePayPalDetails => 'Posodobite PayPal podrobnosti';
@@ -5102,12 +4999,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Dodatni govori vzorec je bil odstranjen';
 
   @override
-  String get consentDataMessage =>
-      'Z nadaljevanjem bodo vaši pogovori, posnetki in osebni podatki varno shranjeni na naših strežnikih. Vaši zvočni posnetki in prepisi se obdelujejo s storitvami umetne inteligence tretjih oseb (vključno z Deepgram za prepis in OpenAI za analizo), da vam zagotovimo vpoglede, ki jih poganja umetna inteligenca, in omogočimo vse funkcije aplikacije.';
+  String get consentDataMessage => 'Z nadaljevanjem bodo vaši pogovori, posnetki in osebni podatki varno shranjeni na naših strežnikih. Vaši zvočni posnetki in prepisi se obdelujejo s storitvami umetne inteligence tretjih oseb (vključno z Deepgram za prepis in OpenAI za analizo), da vam zagotovimo vpoglede, ki jih poganja umetna inteligenca, in omogočimo vse funkcije aplikacije.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Naloge iz vaših pogovorov se bodo prikazale tukaj.\\nTapnite + za ročno ustvarjanje.';
+  String get tasksEmptyStateMessage => 'Naloge iz vaših pogovorov se bodo prikazale tukaj.\\nTapnite + za ročno ustvarjanje.';
 
   @override
   String get clearChatAction => 'Počistite klepet';
@@ -5143,15 +5038,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Namestite Omi na vaš\\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Za uporabo vašega Apple Watch z Omijem morali najprej namestiti aplikacijo Omi na uro.';
+  String get installOmiOnAppleWatchDescription => 'Za uporabo vašega Apple Watch z Omijem morali najprej namestiti aplikacijo Omi na uro.';
 
   @override
   String get openOmiOnAppleWatch => 'Odprite Omi na vašem\\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Aplikacija Omi je nameščena na vašem Apple Watch. Odprite jo in tapnite Začni.';
+  String get openOmiOnAppleWatchDescription => 'Aplikacija Omi je nameščena na vašem Apple Watch. Odprite jo in tapnite Začni.';
 
   @override
   String get openWatchApp => 'Odprite Watch aplikacijo';
@@ -5160,15 +5053,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Namestil sem in odprli aplikacijo';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Ni mogoče odpreti Apple Watch aplikacijo. Prosimo, ročno odprite Watch aplikacijo na svojem Apple Watch in namestite Omi iz razdelka \"Razpoložljive aplikacije\".';
+  String get unableToOpenWatchApp => 'Ni mogoče odpreti Apple Watch aplikacijo. Prosimo, ročno odprite Watch aplikacijo na svojem Apple Watch in namestite Omi iz razdelka \"Razpoložljive aplikacije\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch je bil uspešno povezan!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch je še vedno nedostopen. Prosimo, prepričajte se, da je aplikacija Omi odprta na vaši uri.';
+  String get appleWatchNotReachable => 'Apple Watch je še vedno nedostopen. Prosimo, prepričajte se, da je aplikacija Omi odprta na vaši uri.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5185,8 +5076,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get finishedConversation => 'Zaključen pogovor?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Ali ste prepričani, da želite prenehati s snemanjem in povzeti pogovor sedaj?';
+  String get stopRecordingConfirmation => 'Ali ste prepričani, da želite prenehati s snemanjem in povzeti pogovor sedaj?';
 
   @override
   String get conversationEndsManually => 'Pogovor se bo končal samo ročno.';
@@ -5597,8 +5487,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get multipleSpeakersDetected => 'Zaznani več govorcev';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Zdi se, da so v posnetku govorci. Prosimo, prepričajte se, da ste na mirnem mestu in poskusite ponovno.';
+  String get multipleSpeakersDescription => 'Zdi se, da so v posnetku govorci. Prosimo, prepričajte se, da ste na mirnem mestu in poskusite ponovno.';
 
   @override
   String get invalidRecordingDetected => 'Zaznana neveljavna snemanja';
@@ -5610,15 +5499,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get speechDurationDescription => 'Prepričajte se, da govorite najmanj 5 sekund in ne več kot 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Povezava je bila prekinjena. Preverite svojo internetno povezavo in poskusite znova.';
+  String get connectionLostDescription => 'Povezava je bila prekinjena. Preverite svojo internetno povezavo in poskusite znova.';
 
   @override
   String get howToTakeGoodSample => 'Kako narediti dobro vzorec?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Prepričajte se, da ste na mirnem mestu.\n2. Govorite jasno in naravno.\n3. Prepričajte se, da je naprava v naravnem položaju, na vratu.\n\nKo je ustvarjena, jo lahko kadar koli izboljšate ali ponovno naredite.';
+  String get goodSampleInstructions => '1. Prepričajte se, da ste na mirnem mestu.\n2. Govorite jasno in naravno.\n3. Prepričajte se, da je naprava v naravnem položaju, na vratu.\n\nKo je ustvarjena, jo lahko kadar koli izboljšate ali ponovno naredite.';
 
   @override
   String get noDeviceConnectedUseMic => 'Nobena naprava ni povezana. Uporabil bom mikrofon telefona.';
@@ -5681,12 +5568,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get howItWorks => 'Kako deluje';
 
   @override
-  String get dailyScoreExplanation =>
-      'Vaš dnevni rezultat temelji na opravljanju nalog. Opravite svoje naloge, da izboljšate svoj rezultat!';
+  String get dailyScoreExplanation => 'Vaš dnevni rezultat temelji na opravljanju nalog. Opravite svoje naloge, da izboljšate svoj rezultat!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontrolirajte, kako pogosto Omi pošilja proaktivna obvestila in opomniki.';
+  String get notificationFrequencyDescription => 'Kontrolirajte, kako pogosto Omi pošilja proaktivna obvestila in opomniki.';
 
   @override
   String get sliderOff => 'Izključeno';
@@ -5779,8 +5664,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get selectApp => 'Izberite aplikacijo';
 
   @override
-  String get noChatAppsEnabled =>
-      'Nobena aplikacija za klepet ni omogočena.\nTapnite \"Omogoči aplikacije\", da jih dodate.';
+  String get noChatAppsEnabled => 'Nobena aplikacija za klepet ni omogočena.\nTapnite \"Omogoči aplikacije\", da jih dodate.';
 
   @override
   String get disable => 'Onemogući';
@@ -5932,8 +5816,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get recordings => 'Snemanja';
 
   @override
-  String get enableRemindersAccess =>
-      'Prosim, omogočite dostop do spomnnikov v nastavitvah, da uporabite Apple Reminders';
+  String get enableRemindersAccess => 'Prosim, omogočite dostop do spomnnikov v nastavitvah, da uporabite Apple Reminders';
 
   @override
   String todayAtTime(String time) {
@@ -5988,8 +5871,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get webhookUrlNotSet => 'Spletni naslov webhook ni nastavljen';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Prosim, nastavite spletni naslov webhook v nastavitvah razvijalca, da uporabite to funkcijo.';
+  String get setWebhookUrlInSettings => 'Prosim, nastavite spletni naslov webhook v nastavitvah razvijalca, da uporabite to funkcijo.';
 
   @override
   String get sendWebUrl => 'Pošlji spletni naslov';
@@ -6063,15 +5945,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get cloudProvider => 'Ponudnik oblaka';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 premijskih minut/mesec. Zavihek Na napravi ponuja neomejeno brezplačno transkripcijo.';
+  String get premiumMinutesInfo => '1.200 premijskih minut/mesec. Zavihek Na napravi ponuja neomejeno brezplačno transkripcijo.';
 
   @override
   String get viewUsage => 'Poglej uporabo';
 
   @override
-  String get localProcessingInfo =>
-      'Zvok se obdeluje lokalno. Deluje brez interneta, bolj zasebno, vendar porabi več baterije.';
+  String get localProcessingInfo => 'Zvok se obdeluje lokalno. Deluje brez interneta, bolj zasebno, vendar porabi več baterije.';
 
   @override
   String get model => 'Model';
@@ -6080,8 +5960,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get performanceWarning => 'Opozorilo zmogljivosti';
 
   @override
-  String get largeModelWarning =>
-      'Ta model je velik in lahko sesede aplikacijo ali se izvaja zelo počasi na mobilnih napravah.\n\nPriporočljivi so \"mali\" ali \"osnovni\" modeli.';
+  String get largeModelWarning => 'Ta model je velik in lahko sesede aplikacijo ali se izvaja zelo počasi na mobilnih napravah.\n\nPriporočljivi so \"mali\" ali \"osnovni\" modeli.';
 
   @override
   String get usingNativeIosSpeech => 'Uporaba nativnega prepoznavanja govora iOS';
@@ -6144,12 +6023,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get batteryDrainSignificantly => 'Poraba baterije se bo significantly povečala.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 premijskih minut/mesec. Zavihek Na napravi ponuja neomejeno brezplačno transkripcijo. ';
+  String get premiumMinutesMonth => '1.200 premijskih minut/mesec. Zavihek Na napravi ponuja neomejeno brezplačno transkripcijo. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Zvok se obdeluje lokalno. Deluje brez interneta, bolj zasebno, vendar porabi več baterije.';
+  String get audioProcessedLocally => 'Zvok se obdeluje lokalno. Deluje brez interneta, bolj zasebno, vendar porabi več baterije.';
 
   @override
   String get languageLabel => 'Jezik';
@@ -6158,8 +6035,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Ta model je velik in lahko sesede aplikacijo ali se izvaja zelo počasi na mobilnih napravah.\n\nPriporočljivi so \"mali\" ali \"osnovni\" modeli.';
+  String get modelTooLargeWarning => 'Ta model je velik in lahko sesede aplikacijo ali se izvaja zelo počasi na mobilnih napravah.\n\nPriporočljivi so \"mali\" ali \"osnovni\" modeli.';
 
   @override
   String get nativeEngineNoDownload => 'Uporabljena bo nativna govorica naprave. Prenos modela ni potreben.';
@@ -6198,8 +6074,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Vgrajena transkripcija Omi je optimizirana za pogovore v realnem času z avtomatskim prepoznavanjem govorcev in diarizacijo.';
+  String get omiTranscriptionOptimized => 'Vgrajena transkripcija Omi je optimizirana za pogovore v realnem času z avtomatskim prepoznavanjem govorcev in diarizacijo.';
 
   @override
   String get reset => 'Ponastavite';
@@ -6419,8 +6294,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Gradim vaš grafikon znanja iz spominov...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Vaš grafikon znanja se bo samodejno gradil, ko boste ustvarjali nove spomine.';
+  String get knowledgeGraphWillBuildAutomatically => 'Vaš grafikon znanja se bo samodejno gradil, ko boste ustvarjali nove spomine.';
 
   @override
   String get buildGraphButton => 'Zgradite grafikon';
@@ -6722,8 +6596,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Prenašanje zvoka iz SD kartice vaše naprave';
 
   @override
-  String get transferRequiredDescription =>
-      'To snemanje je shranjeno na SD kartici vaše naprave. Prenesete ga na telefon, da ga lahko predvajate ali delite.';
+  String get transferRequiredDescription => 'To snemanje je shranjeno na SD kartici vaše naprave. Prenesete ga na telefon, da ga lahko predvajate ali delite.';
 
   @override
   String get cancelTransfer => 'Prekliči prenos';
@@ -6744,8 +6617,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get shareRecording => 'Deli Snemanje';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Ali ste prepričani, da želite trajno izbrisati to snemanje? To se ne more razveljaviti.';
+  String get deleteRecordingConfirmation => 'Ali ste prepričani, da želite trajno izbrisati to snemanje? To se ne more razveljaviti.';
 
   @override
   String get recordingIdLabel => 'ID Snemanja';
@@ -6804,8 +6676,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get enableFastTransfer => 'Omogoči Hiter Prenos';
 
   @override
-  String get fastTransferDescription =>
-      'Hiter prenos uporablja WiFi za približno 5-krat hitrejše hitrosti. Vaš telefon se bo med prenosom začasno povezal na WiFi omrežje naprave Omi.';
+  String get fastTransferDescription => 'Hiter prenos uporablja WiFi za približno 5-krat hitrejše hitrosti. Vaš telefon se bo med prenosom začasno povezal na WiFi omrežje naprave Omi.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Dostop do interneta je zaustavljen med prenosom';
@@ -6820,8 +6691,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fiveTimesFaster => '5-KRAT HITREJŠE';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Ustvari neposredno WiFi povezavo z napravo Omi. Vaš telefon se med prenosom začasno odklopi od običajnega WiFi omrežja.';
+  String get fastTransferMethodDescription => 'Ustvari neposredno WiFi povezavo z napravo Omi. Vaš telefon se med prenosom začasno odklopi od običajnega WiFi omrežja.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6830,8 +6700,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get bleSpeed => '~30 KB/s prek BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Uporablja standardno Bluetooth Low Energy povezavo. Počasneje, vendar ne vpliva na vašo WiFi povezavo.';
+  String get bluetoothMethodDescription => 'Uporablja standardno Bluetooth Low Energy povezavo. Počasneje, vendar ne vpliva na vašo WiFi povezavo.';
 
   @override
   String get selected => 'Izbrano';
@@ -6869,12 +6738,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get appDeleteFailed => 'Brisanje aplikacije ni uspelo. Prosimo, poskusite ponovno pozneje.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Vidnost aplikacije se je uspešno spremenila. Morda bo potrebnih nekaj minut, da se to odraži.';
+  String get appVisibilityChangedSuccessfully => 'Vidnost aplikacije se je uspešno spremenila. Morda bo potrebnih nekaj minut, da se to odraži.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Napaka pri aktivaciji aplikacije. Če je to integrativna aplikacija, se prepričajte, da je nastavitev končana.';
+  String get errorActivatingAppIntegration => 'Napaka pri aktivaciji aplikacije. Če je to integrativna aplikacija, se prepričajte, da je nastavitev končana.';
 
   @override
   String get errorUpdatingAppStatus => 'Prišlo je do napake pri posodabljanju statusa aplikacije.';
@@ -6954,8 +6821,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Ime mora biti dolgo najmanj 3 znake';
 
   @override
-  String get conversationPromptHint =>
-      'npr. Izvedite akcijske postavke, sprejete odločitve in ključne ugotovitve iz podanega pogovora.';
+  String get conversationPromptHint => 'npr. Izvedite akcijske postavke, sprejete odločitve in ključne ugotovitve iz podanega pogovora.';
 
   @override
   String get pleaseEnterAppPrompt => 'Prosimo, vnesite nalogo za vašo aplikacijo';
@@ -6988,8 +6854,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get failedToCreateApp => 'Ustvarjanje aplikacije ni uspelo. Prosimo, poskusite ponovno.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'Prosimo, izberite eno dodatno temeljno sposobnost za vašo aplikacijo, da nadaljujete';
+  String get addAppSelectCoreCapability => 'Prosimo, izberite eno dodatno temeljno sposobnost za vašo aplikacijo, da nadaljujete';
 
   @override
   String get addAppSelectPaymentPlan => 'Prosimo, izberite načrt plačila in vnesite ceno za vašo aplikacijo';
@@ -7038,8 +6903,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'Dovoljenje za dostop do fotografij je zavrnjeno. Prosimo, dovolite dostop do fotografij, da izberete sliko';
+  String get addAppPhotosPermissionDenied => 'Dovoljenje za dostop do fotografij je zavrnjeno. Prosimo, dovolite dostop do fotografij, da izberete sliko';
 
   @override
   String get addAppErrorSelectingImageRetry => 'Napaka pri izbiri slike. Prosimo, poskusite ponovno.';
@@ -7059,12 +6923,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get addAppPersonaConflictWithCapabilities => 'Osebnosti ni mogoče izbrati z drugimi sposobnostmi';
 
   @override
-  String get paymentFailedToFetchCountries =>
-      'Pridobivanje podprtih držav ni uspelo. Prosimo, poskusite ponovno pozneje.';
+  String get paymentFailedToFetchCountries => 'Pridobivanje podprtih držav ni uspelo. Prosimo, poskusite ponovno pozneje.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Nastavitev privzete metode plačila ni uspela. Prosimo, poskusite ponovno pozneje.';
+  String get paymentFailedToSetDefault => 'Nastavitev privzete metode plačila ni uspela. Prosimo, poskusite ponovno pozneje.';
 
   @override
   String get paymentFailedToSavePaypal => 'Shranjevanje podatkov PayPal ni uspelo. Prosimo, poskusite ponovno pozneje.';
@@ -7146,15 +7008,13 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Nadgradnja je zakazana! Vaš mesečni načrt se nadaljuje do konca vašega obračunskega obdobja, nato pa se samodejno spremeni na letni.';
+  String get planUpgradeScheduledMessage => 'Nadgradnja je zakazana! Vaš mesečni načrt se nadaljuje do konca vašega obračunskega obdobja, nato pa se samodejno spremeni na letni.';
 
   @override
   String get couldNotSchedulePlanChange => 'Spremembe načrta ni bilo mogoče zakazati. Prosimo, poskusite ponovno.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Vaša naročnina je bila ponovno aktivirana! Brez doplačila zdaj - zaračunani boste ob koncu vašega trenutnega obdobja.';
+  String get subscriptionReactivatedDefault => 'Vaša naročnina je bila ponovno aktivirana! Brez doplačila zdaj - zaračunani boste ob koncu vašega trenutnega obdobja.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Naročnina je uspešna! Za novo obračunsko obdobje ste bili zaračunani.';
@@ -7322,8 +7182,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get authFailedToRetrieveToken => 'Pridobivanje Firebase žetona ni uspelo, prosimo, poskusite ponovno.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'Nepričakana napaka pri prijavi, napaka Firebase, prosimo, poskusite ponovno.';
+  String get authUnexpectedErrorFirebase => 'Nepričakana napaka pri prijavi, napaka Firebase, prosimo, poskusite ponovno.';
 
   @override
   String get authUnexpectedError => 'Nepričakana napaka pri prijavi, prosimo, poskusite ponovno';
@@ -7338,8 +7197,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Dovoljenječe za Bluetooth je potrebno za povezavo z napravo.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Dovoljenječe za Bluetooth je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Dovoljenječe za Bluetooth je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7352,12 +7210,10 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Dovoljenječe za Obvestila je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Dovoljenječe za Obvestila je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Dovoljenječe za Obvestila je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah > Obvestila.';
+  String get onboardingNotificationDeniedNotifications => 'Dovoljenječe za Obvestila je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah > Obvestila.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7370,15 +7226,13 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Prosimo, dovolite dovoljenječe za lokacijo v Nastavitve > Zasebnost in Varnost > Storitve Lokacije';
+  String get onboardingLocationGrantInSettings => 'Prosimo, dovolite dovoljenječe za lokacijo v Nastavitve > Zasebnost in Varnost > Storitve Lokacije';
 
   @override
   String get onboardingMicrophoneRequired => 'Dovoljenječe za Mikrofon je potrebno za snemanje.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Dovoljenječe za Mikrofon je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah > Zasebnost in Varnost > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Dovoljenječe za Mikrofon je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah > Zasebnost in Varnost > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7391,12 +7245,10 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Dovoljenječe za Zajem Zaslona je potrebno za snemanje sistemskega zvoka.';
+  String get onboardingScreenCaptureRequired => 'Dovoljenječe za Zajem Zaslona je potrebno za snemanje sistemskega zvoka.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Dovoljenječe za Zajem Zaslona je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah > Zasebnost in Varnost > Snemanje Zaslona.';
+  String get onboardingScreenCaptureDenied => 'Dovoljenječe za Zajem Zaslona je zavrnjeno. Prosimo, dovolite dostop v Sistemskih Preferencah > Zasebnost in Varnost > Snemanje Zaslona.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7409,8 +7261,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Dovoljenječe za Dostopnost je potrebno za zaznavanje brskalniških sestankov.';
+  String get onboardingAccessibilityRequired => 'Dovoljenječe za Dostopnost je potrebno za zaznavanje brskalniških sestankov.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7450,8 +7301,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Dovoljenječe za Fotografije je zavrnjeno. Prosimo, dovolite dostop do fotografij, da izberete slike';
+  String get msgPhotosPermissionDenied => 'Dovoljenječe za Fotografije je zavrnjeno. Prosimo, dovolite dostop do fotografij, da izberete slike';
 
   @override
   String get msgSelectImagesGenericError => 'Napaka pri izbiri slik. Prosimo, poskusite ponovno.';
@@ -7493,8 +7343,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get captureMicrophonePermissionRequired => 'Potrebno je dovoljenječe za Mikrofon';
 
   @override
-  String get captureMicrophonePermissionInSystemPreferences =>
-      'Dodelite dovoljenječe za Mikrofon v Sistemskih Preferencah';
+  String get captureMicrophonePermissionInSystemPreferences => 'Dodelite dovoljenječe za Mikrofon v Sistemskih Preferencah';
 
   @override
   String get captureScreenRecordingPermissionRequired => 'Potrebno je dovoljenječe za Snemanje Zaslona';
@@ -7524,8 +7373,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get locationPermissionRequired => 'Dovoljenječe za Lokacijo je Potrebno';
 
   @override
-  String get locationPermissionContent =>
-      'Hiter prenos zahteva dovoljenječe za lokacijo za preverjanje WiFi povezave. Prosimo, dovolite dovoljenječe za lokacijo, da nadaljujete.';
+  String get locationPermissionContent => 'Hiter prenos zahteva dovoljenječe za lokacijo za preverjanje WiFi povezave. Prosimo, dovolite dovoljenječe za lokacijo, da nadaljujete.';
 
   @override
   String get pdfTranscriptExport => 'Izvoz Prepisа';
@@ -7688,8 +7536,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Naprava ne podpira WiFi sinhronizacije, preklapljam na Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Naprava ne podpira WiFi sinhronizacije, preklapljam na Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health ni dostopen na tej napravi';
@@ -7985,8 +7832,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Postavi Omi DevKit v način pariranja';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Pritisni gumb enkrat, da ga vključiš. LED bo migal vijolično, ko je v načinu pariranja.';
+  String get pairingDescOmiDevkit => 'Pritisni gumb enkrat, da ga vključiš. LED bo migal vijolično, ko je v načinu pariranja.';
 
   @override
   String get pairingTitleOmiGlass => 'Vključi Omi Glass';
@@ -7998,8 +7844,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Postavi Plaud Note v način pariranja';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Drži in pritisni bočni gumb 2 sekundi. Rdeči LED bo migal, ko je pripravljena za pariranje.';
+  String get pairingDescPlaudNote => 'Drži in pritisni bočni gumb 2 sekundi. Rdeči LED bo migal, ko je pripravljena za pariranje.';
 
   @override
   String get pairingTitleBee => 'Postavi Bee v način pariranja';
@@ -8011,15 +7856,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get pairingTitleLimitless => 'Postavi Limitless v način pariranja';
 
   @override
-  String get pairingDescLimitless =>
-      'Ko je vidna kakšna luč, pritisni enkrat, nato pa drži, dokler naprava ne pokaže rožnate luči, nato spusti.';
+  String get pairingDescLimitless => 'Ko je vidna kakšna luč, pritisni enkrat, nato pa drži, dokler naprava ne pokaže rožnate luči, nato spusti.';
 
   @override
   String get pairingTitleFriendPendant => 'Postavi Friend Pendant v način pariranja';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Pritisni gumb na obesku, da ga vključiš. Avtomatsko bo vstopil v način pariranja.';
+  String get pairingDescFriendPendant => 'Pritisni gumb na obesku, da ga vključiš. Avtomatsko bo vstopil v način pariranja.';
 
   @override
   String get pairingTitleFieldy => 'Postavi Fieldy v način pariranja';
@@ -8037,8 +7880,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get pairingTitleNeoOne => 'Postavi Neo One v način pariranja';
 
   @override
-  String get pairingDescNeoOne =>
-      'Drži in pritisni gumb za napajanje, dokler LED ne začne migati. Naprava bo vidna za odkrivanje.';
+  String get pairingDescNeoOne => 'Drži in pritisni gumb za napajanje, dokler LED ne začne migati. Naprava bo vidna za odkrivanje.';
 
   @override
   String get downloadingFromDevice => 'Prenašam z naprave';
@@ -8108,8 +7950,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get wifiConfiguration => 'Konfiguracija WiFi';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Vneseuvoje WiFi poverilnice, da bo naprava mogla prenesti vdelano programsko opremo.';
+  String get wifiConfigurationSubtitle => 'Vneseuvoje WiFi poverilnice, da bo naprava mogla prenesti vdelano programsko opremo.';
 
   @override
   String get networkNameSsid => 'Ime omrežja (SSID)';
@@ -8156,8 +7997,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get switchAndRestart => 'Preklopi';
 
   @override
-  String get stagingDisclaimer =>
-      'Testiranje je lahko polno napak, zmogljivost je nestabilna, podatki pa se lahko izgubijo. Uporabi samo za preskušanje.';
+  String get stagingDisclaimer => 'Testiranje je lahko polno napak, zmogljivost je nestabilna, podatki pa se lahko izgubijo. Uporabi samo za preskušanje.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Shranjeno. Zatvori in ponovno odpri aplikacijo, da se uporabijo spremembe.';
@@ -8386,8 +8226,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonski klici prek Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Kliči prek Omi in prejmi živo prepisovanje, samodejne povzetke in več. Na voljo izključno za naročnike načrta Unlimited.';
+  String get phoneCallsUpsellSubtitle => 'Kliči prek Omi in prejmi živo prepisovanje, samodejne povzetke in več. Na voljo izključno za naročnike načrta Unlimited.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Živo prepisovanje vsakega klica';
@@ -8414,8 +8253,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteSyncedFiles => 'Izbriši sinhronizirane posnetke';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Ti posnetki so bili že sinhronizirani s tvojim telefonom. Tega ni mogoče razveljaviti.';
+  String get deleteSyncedFilesMessage => 'Ti posnetki so bili že sinhronizirani s tvojim telefonom. Tega ni mogoče razveljaviti.';
 
   @override
   String get syncedFilesDeleted => 'Sinhronizirani posnetki so izbrisani';
@@ -8427,8 +8265,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deletePendingFiles => 'Izbriši čakajoče posnetke';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Ti posnetki NISO bili sinhronizirani s tvojim telefonom in bodo trajno izgubljeni. Tega ni mogoče razveljaviti.';
+  String get deletePendingFilesWarning => 'Ti posnetki NISO bili sinhronizirani s tvojim telefonom in bodo trajno izgubljeni. Tega ni mogoče razveljaviti.';
 
   @override
   String get pendingFilesDeleted => 'Čakajoči posnetki so izbrisani';
@@ -8440,8 +8277,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deleteAll => 'Izbriši vse';
 
   @override
-  String get deleteAllFilesWarning =>
-      'To bo izbrisalo tako sinhronizirane kot čakajoče posnetke. Čakajoči posnetki NISO bili sinhronizirani in bodo trajno izgubljeni. Tega ni mogoče razveljaviti.';
+  String get deleteAllFilesWarning => 'To bo izbrisalo tako sinhronizirane kot čakajoče posnetke. Čakajoči posnetki NISO bili sinhronizirani in bodo trajno izgubljeni. Tega ni mogoče razveljaviti.';
 
   @override
   String get allFilesDeleted => 'Vsi posnetki so izbrisani';
@@ -8506,8 +8342,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fairUseAboutTitle => 'O pošteni rabi';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi je namenjen osebnim pogovorom, sestankom in živim interakcijam. Poraba se meri z detektiranim dejanskim časom govora, ne s časom povezave. Če poraba bistveno presega običajne vzorce za neprofesionalno vsebino, se lahko uporabijo prilagoditve.';
+  String get fairUseAboutBody => 'Omi je namenjen osebnim pogovorom, sestankom in živim interakcijam. Poraba se meri z detektiranim dejanskim časom govora, ne s časom povezave. Če poraba bistveno presega običajne vzorce za neprofesionalno vsebino, se lahko uporabijo prilagoditve.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8545,8 +8380,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get improveConnectionTitle => 'Izboljšaj povezavo';
 
   @override
-  String get improveConnectionContent =>
-      'Izboljšali smo, kako se Omi ostane povezana z tvojo napravo. Če želiš to aktivirati, pojdi na stran Podatki naprave, tapni \"Prekini napravo\" in nato ponovno poveži svojo napravo.';
+  String get improveConnectionContent => 'Izboljšali smo, kako se Omi ostane povezana z tvojo napravo. Če želiš to aktivirati, pojdi na stran Podatki naprave, tapni \"Prekini napravo\" in nato ponovno poveži svojo napravo.';
 
   @override
   String get improveConnectionAction => 'Razumem';
@@ -8601,16 +8435,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get cancelSyncQuestion => 'Prekini sinhronizacijo?';
 
   @override
-  String get omisStorageDesc =>
-      'Ko se tvoj Omi ne poveži s tvojim telefonom, shranja avdio lokalno v svoji vgrajeni pomnilnik. Nikoli ne izgubiš posnetka.';
+  String get omisStorageDesc => 'Ko se tvoj Omi ne poveži s tvojim telefonom, shranja avdio lokalno v svoji vgrajeni pomnilnik. Nikoli ne izgubiš posnetka.';
 
   @override
-  String get phoneStorageDesc =>
-      'Ko se Omi znova poveži, se posnetki avtomatično prenesejo na tvoj telefon kot začasno skladišče, preden se naložijo.';
+  String get phoneStorageDesc => 'Ko se Omi znova poveži, se posnetki avtomatično prenesejo na tvoj telefon kot začasno skladišče, preden se naložijo.';
 
   @override
-  String get cloudStorageDesc =>
-      'Ko se naložijo, so tvoji posnetki obdelani in prepisani. Pogovori bodo na voljo v minuti.';
+  String get cloudStorageDesc => 'Ko se naložijo, so tvoji posnetki obdelani in prepisani. Pogovori bodo na voljo v minuti.';
 
   @override
   String get tipKeepPhoneNearby => 'Drži svoj telefon blizu za hitrejšo sinhronizacijo';
@@ -8634,12 +8465,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get permissionEnable => 'Omogoči';
 
   @override
-  String get permissionsPageDescription =>
-      'Ta dovoljenja so ključna za delovanje Omi. Omogočajo ključne funkcije, kot so obvestila, izkušnje na osnovi lokacije in zajemanje avdija.';
+  String get permissionsPageDescription => 'Ta dovoljenja so ključna za delovanje Omi. Omogočajo ključne funkcije, kot so obvestila, izkušnje na osnovi lokacije in zajemanje avdija.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi potrebuje nekaj dovoljenj za pravilno delovanje. Prosimo, da jih odobriš, da nadaljuješ.';
+  String get permissionsRequiredDescription => 'Omi potrebuje nekaj dovoljenj za pravilno delovanje. Prosimo, da jih odobriš, da nadaljuješ.';
 
   @override
   String get permissionsSetupTitle => 'Pridobi najboljšo izkušnjo';
@@ -8875,8 +8704,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fetchingStableFirmware => 'Pridobivam najnovejšo stabilno vdelano programsko opremo ...';
 
   @override
-  String get noStableFirmwareFound =>
-      'Ni bilo mogoče najti stabilne različice vdelane programske opreme za tvojo napravo.';
+  String get noStableFirmwareFound => 'Ni bilo mogoče najti stabilne različice vdelane programske opreme za tvojo napravo.';
 
   @override
   String get installStableFirmware => 'Namesti stabilno vdelano programsko opremo';
@@ -8917,8 +8745,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get firmwareWarningTitle => 'Pomembno: Preberite pred posodobitvijo';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ta vdelana programska oprema bo formatirala kartico SD. Pred nadgradnjo se prepričajte, da so vsi podatki brez povezave sinhronizirani.\n\nČe po namestitvi te različice vidite utripajočo rdečo lučko, ne skrbite. Preprosto povežite napravo z aplikacijo in morala bi postati modra. Rdeča lučka pomeni, da ura naprave še ni bila sinhronizirana.';
+  String get firmwareFormatWarning => 'Ta vdelana programska oprema bo formatirala kartico SD. Pred nadgradnjo se prepričajte, da so vsi podatki brez povezave sinhronizirani.\n\nČe po namestitvi te različice vidite utripajočo rdečo lučko, ne skrbite. Preprosto povežite napravo z aplikacijo in morala bi postati modra. Rdeča lučka pomeni, da ura naprave še ni bila sinhronizirana.';
 
   @override
   String get continueAnyway => 'Nadaljuj';
@@ -8938,8 +8765,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get tasksMarkComplete => 'Označeno kot dokončano';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi dostopa do Apple Health prek Applovega ogrodja HealthKit. Dostop lahko kadar koli prekličete v nastavitvah iOS.';
+  String get appleHealthManageNote => 'Omi dostopa do Apple Health prek Applovega ogrodja HealthKit. Dostop lahko kadar koli prekličete v nastavitvah iOS.';
 
   @override
   String get appleHealthConnectCta => 'Poveži z Apple Health';
@@ -8972,8 +8798,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Dostop do Apple Health zavrnjen';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi nima dovoljenja za branje vaših podatkov Apple Health. Omogočite ga v Nastavitvah iOS → Zasebnost in varnost → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi nima dovoljenja za branje vaših podatkov Apple Health. Omogočite ga v Nastavitvah iOS → Zasebnost in varnost → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Zakaj odhajate?';
@@ -9042,8 +8867,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get planUpdate => 'Posodobitev načrta';
 
   @override
-  String get planDeprecationMessage =>
-      'Vaš načrt Unlimited se ukinja. Preklopite na načrt Operator — enake odlične funkcije za \$49/mesec. Vaš trenutni načrt bo medtem še naprej deloval.';
+  String get planDeprecationMessage => 'Vaš načrt Unlimited se ukinja. Preklopite na načrt Operator — enake odlične funkcije za \$49/mesec. Vaš trenutni načrt bo medtem še naprej deloval.';
 
   @override
   String get upgradeYourPlan => 'Nadgradite svoj načrt';
@@ -9154,8 +8978,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Dosegli ste svojo mesečno omejitev. Nadgradite, da nadaljujete pogovor z Omi brez omejitev.';
+  String get chatQuotaExceededReply => 'Dosegli ste svojo mesečno omejitev. Nadgradite, da nadaljujete pogovor z Omi brez omejitev.';
 
   @override
   String get voiceResponseAudio => 'Preberi odgovor Omi na glas';
@@ -9186,4 +9009,25 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Dodaj nalogo';
+
+  @override
+  String get quickActionAskOmiAnything => 'Vprašajte Omi karkoli';
+
+  @override
+  String get quickActionVoiceMode => 'Glasovni način';
+
+  @override
+  String get quickActionMute => 'Utišaj';
+
+  @override
+  String get quickActionUnmute => 'Vklopi zvok';
+
+  @override
+  String get quickActionConnectDevice => 'Poveži napravo';
+
+  @override
+  String get quickActionDeviceSettings => 'Nastavitve naprave';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -24,8 +24,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deleteConversationTitle => 'Обрисати разговор?';
 
   @override
-  String get deleteConversationMessage =>
-      'Ово ће такође обрисати повезане успомене, задатке и аудио датотеке. Ова радња се не може отказати.';
+  String get deleteConversationMessage => 'Ово ће такође обрисати повезане успомене, задатке и аудио датотеке. Ова радња се не може отказати.';
 
   @override
   String get confirm => 'Потврди';
@@ -146,8 +145,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deleting => 'Брисање...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Молим вас, завршите аутентификацију у својој прегледачу. Када завршите, вратите се у апликацију.';
+  String get pleaseCompleteAuthentication => 'Молим вас, завршите аутентификацију у својој прегледачу. Када завршите, вратите се у апликацију.';
 
   @override
   String get failedToStartAuthentication => 'Неуспешан почетак аутентификације';
@@ -319,8 +317,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get installedApps => 'Инсталиране апликације';
 
   @override
-  String get unableToFetchApps =>
-      'Није могуће добити апликације :(\n\nМолим вас, проверите вашу интернет повезаност и покушајте поново.';
+  String get unableToFetchApps => 'Није могуће добити апликације :(\n\nМолим вас, проверите вашу интернет повезаност и покушајте поново.';
 
   @override
   String get aboutOmi => 'О Omi';
@@ -356,19 +353,16 @@ class AppLocalizationsSr extends AppLocalizations {
   String get appsDisconnected => 'Ваше апликације и интеграције ће бити одмах одсоединене.';
 
   @override
-  String get exportBeforeDelete =>
-      'Можете извезти своје податке пре брисања налога, али када буду обрисани, не могу се опоравити.';
+  String get exportBeforeDelete => 'Можете извезти своје податке пре брисања налога, али када буду обрисани, не могу се опоравити.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Разумем да је брисање мог налога трајно и сви подаци, укључујући успомене и разговоре, биће изгубљени и не могу се опоравити.';
+  String get deleteAccountCheckbox => 'Разумем да је брисање мог налога трајно и сви подаци, укључујући успомене и разговоре, биће изгубљени и не могу се опоравити.';
 
   @override
   String get areYouSure => 'Да ли сте сигурни?';
 
   @override
-  String get deleteAccountFinal =>
-      'Ова радња је неповратна и трајно ће обрисати ваш налог и све повезане податке. Да ли сте сигурни да желите да наставите?';
+  String get deleteAccountFinal => 'Ова радња је неповратна и трајно ће обрисати ваш налог и све повезане податке. Да ли сте сигурни да желите да наставите?';
 
   @override
   String get deleteNow => 'Обриши сада';
@@ -455,8 +449,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get yourPrivacyYourControl => 'Твоја приватност, твоја контрола';
 
   @override
-  String get privacyIntro =>
-      'На Omi, посвећени смо заштити ваше приватности. Ова страница вам омогућава да контролишете како се ваши подаци чувају и користе.';
+  String get privacyIntro => 'На Omi, посвећени смо заштити ваше приватности. Ова страница вам омогућава да контролишете како се ваши подаци чувају и користе.';
 
   @override
   String get learnMore => 'Сазнајте више...';
@@ -465,15 +458,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get dataProtectionLevel => 'Ниво заштите података';
 
   @override
-  String get dataProtectionDesc =>
-      'Ваши подаци су подразумевано заштићени јаким шифровањем. Прегледајте своја подешавања и будуће опције приватности испод.';
+  String get dataProtectionDesc => 'Ваши подаци су подразумевано заштићени јаким шифровањем. Прегледајте своја подешавања и будуће опције приватности испод.';
 
   @override
   String get appAccess => 'Приступ апликације';
 
   @override
-  String get appAccessDesc =>
-      'Следеће апликације могу приступити вашим подацима. Додирни апликацију да управљаш њеним дозволама.';
+  String get appAccessDesc => 'Следеће апликације могу приступити вашим подацима. Додирни апликацију да управљаш њеним дозволама.';
 
   @override
   String get noAppsExternalAccess => 'Ниједна инсталирана апликација нема спољни приступ вашим подацима.';
@@ -530,15 +521,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Ваш Omi је прекинут 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Уређај је распарен. Идите на Подешавања > Bluetooth и забавите уређај да завршите распаривање.';
+  String get deviceUnpairedMessage => 'Уређај је распарен. Идите на Подешавања > Bluetooth и забавите уређај да завршите распаривање.';
 
   @override
   String get unpairDialogTitle => 'Распари уређај';
 
   @override
-  String get unpairDialogMessage =>
-      'Ово ће распарити уређај тако да га можеш повезати са другим телефоном. Мораћеш да идеш на Подешавања > Bluetooth и забаву уређај да завршиш процес.';
+  String get unpairDialogMessage => 'Ово ће распарити уређај тако да га можеш повезати са другим телефоном. Мораћеш да идеш на Подешавања > Bluetooth и забаву уређај да завршиш процес.';
 
   @override
   String get deviceNotConnected => 'Уређај није повезан';
@@ -559,8 +548,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get v2Undetected => 'V2 није детектован';
 
   @override
-  String get v2UndetectedMessage =>
-      'Видимо да имате V1 уређај или ваш уређај није повезан. Функционалност SD картице је доступна само за V2 уређаје.';
+  String get v2UndetectedMessage => 'Видимо да имате V1 уређај или ваш уређај није повезан. Функционалност SD картице је доступна само за V2 уређаје.';
 
   @override
   String get endConversation => 'Заврши разговор';
@@ -834,8 +822,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Обриши граф знања?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Ово ће обрисати све изведене податке графа знања (чворове и конекције). Ваше оригиналне успомене остају безбедне. Граф ће бити обновљен током времена или при следећем захтеву.';
+  String get deleteKnowledgeGraphMessage => 'Ово ће обрисати све изведене податке графа знања (чворове и конекције). Ваше оригиналне успомене остају безбедне. Граф ће бити обновљен током времена или при следећем захтеву.';
 
   @override
   String get knowledgeGraphDeleted => 'Граф знања обрисан';
@@ -983,8 +970,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get shortConversationThreshold => 'Праг кратког разговора';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Разговори краћи од овога ће бити скривени осим ако су омогућени горе';
+  String get shortConversationThresholdSubtitle => 'Разговори краћи од овога ће бити скривени осим ако су омогућени горе';
 
   @override
   String get durationThreshold => 'Праг трајања';
@@ -1019,8 +1005,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get integrationsFooter => 'Повежи своје апликације да видиш податке и метрике у разговору.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Молим вас, завршите аутентификацију у својој прегледачу. Када завршите, вратите се у апликацију.';
+  String get completeAuthInBrowser => 'Молим вас, завршите аутентификацију у својој прегледачу. Када завршите, вратите се у апликацију.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1080,8 +1065,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get needYourPermission => 'Требамо твоју дозволу';
 
   @override
-  String get alreadyGavePermission =>
-      'Већ си нам дао дозволу да чувамо твоје снимке. Ево подсетника зашто је то потребно:';
+  String get alreadyGavePermission => 'Већ си нам дао дозволу да чувамо твоје снимке. Ево подсетника зашто је то потребно:';
 
   @override
   String get wouldLikePermission => 'Желели бисмо твоју дозволу да чувамо твоје гласовне снимке. Ево зашто:';
@@ -1096,19 +1080,16 @@ class AppLocalizationsSr extends AppLocalizations {
   String get trainFamilyProfiles => 'Обучи профиле за пријатеље и породицу';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Твоји снимци нам помажу да препознамо и направимо профиле за твоје пријатеље и породицу.';
+  String get trainFamilyProfilesDesc => 'Твоји снимци нам помажу да препознамо и направимо профиле за твоје пријатеље и породицу.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Побољшај тачност преписа';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Како се наш модел побољшава, можемо пружити боље резултате преписа за твоје снимке.';
+  String get enhanceTranscriptAccuracyDesc => 'Како се наш модел побољшава, можемо пружити боље резултате преписа за твоје снимке.';
 
   @override
-  String get legalNotice =>
-      'Правна напомена: Законитост снимања и чувања гласовних података може варирати у зависности од твоје локације и како користиш ову функцију. Твоја је одговорност да обезбедиш усклађеност са локалним законима и прописима.';
+  String get legalNotice => 'Правна напомена: Законитост снимања и чувања гласовних података може варирати у зависности од твоје локације и како користиш ову функцију. Твоја је одговорност да обезбедиш усклађеност са локалним законима и прописима.';
 
   @override
   String get alreadyAuthorized => 'Већ овлашћен';
@@ -1186,8 +1167,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get showEventsNoParticipants => 'Прикажи догађаје без учесника';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Када је омогућено, Coming Up приказује догађаје без учесника или видео линка.';
+  String get showEventsNoParticipantsDesc => 'Када је омогућено, Coming Up приказује догађаје без учесника или видео линка.';
 
   @override
   String get yourMeetings => 'Ваши састанци';
@@ -1228,8 +1208,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get noProjectsInWorkspace => 'Нису пронађени пројекти у овом радном простору';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Одаберите колико дуго чекати у тишини пре него што аутоматски завршите разговор:';
+  String get conversationTimeoutDesc => 'Одаберите колико дуго чекати у тишини пре него што аутоматски завршите разговор:';
 
   @override
   String get timeout2Minutes => '2 минута';
@@ -1356,8 +1335,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get defaultRepository => 'Подразумевано складиште';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Одаберите подразумевано складиште за прављење проблема. Можете и даље одредити друго складиште при прављењу проблема.';
+  String get selectDefaultRepoDesc => 'Одаберите подразумевано складиште за прављење проблема. Можете и даље одредити друго складиште при прављењу проблема.';
 
   @override
   String get noReposFound => 'Нису пронађена складишта';
@@ -1404,8 +1382,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get configureSettings => 'Подешавања';
 
   @override
-  String get completeAuthBrowser =>
-      'Молим вас, завршите аутентификацију у браузеру. Када завршите, вратите се у апликацију.';
+  String get completeAuthBrowser => 'Молим вас, завршите аутентификацију у браузеру. Када завршите, вратите се у апликацију.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1733,8 +1710,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get enableBluetooth => 'Омогући Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi треба Bluetooth да би се повезао на вашу носиву. Омогућите Bluetooth и покушајте поново.';
+  String get bluetoothNeeded => 'Omi треба Bluetooth да би се повезао на вашу носиву. Омогућите Bluetooth и покушајте поново.';
 
   @override
   String get contactSupport => 'Контактирајте подршку?';
@@ -1767,26 +1743,22 @@ class AppLocalizationsSr extends AppLocalizations {
   String get locationServiceDisabled => 'Услуга локације је онемогућена';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Услуга локације је онемогућена. Молим вас идите на Подешавања > Приватност и безбедност > Услуге локације и омогућите је';
+  String get locationServiceDisabledDesc => 'Услуга локације је онемогућена. Молим вас идите на Подешавања > Приватност и безбедност > Услуге локације и омогућите је';
 
   @override
   String get backgroundLocationDenied => 'Приступ позадинској локацији је одбијен';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Молим вас идите на подешавања уређаја и постављање дозволе за локацију на \"Увек дозволи\"';
+  String get backgroundLocationDeniedDesc => 'Молим вас идите на подешавања уређаја и постављање дозволе за локацију на \"Увек дозволи\"';
 
   @override
   String get lovingOmi => 'Волиш ли Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Помози нам да дође до више људи остављањем рецензије у App Store-у. Твој повратни информације значи много нам!';
+  String get leaveReviewIos => 'Помози нам да дође до више људи остављањем рецензије у App Store-у. Твој повратни информације значи много нам!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Помози нам да дође до више људи остављањем рецензије у Google Play Store-у. Твој повратни информације значи много нам!';
+  String get leaveReviewAndroid => 'Помози нам да дође до више људи остављањем рецензије у Google Play Store-у. Твој повратни информације значи много нам!';
 
   @override
   String get rateOnAppStore => 'Оцени на App Store-у';
@@ -1819,15 +1791,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get connectionError => 'Грешка при повезивању';
 
   @override
-  String get connectionErrorDesc =>
-      'Не могу да се повежем на сервер. Молим вас проверите интернет везу и покушајте поново.';
+  String get connectionErrorDesc => 'Не могу да се повежем на сервер. Молим вас проверите интернет везу и покушајте поново.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Неважећи снимак открит';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Чини се да су у снимку мултипли говорници. Молим вас уверите се да сте на тихој локацији и покушајте поново.';
+  String get multipleSpeakersDesc => 'Чини се да су у снимку мултипли говорници. Молим вас уверите се да сте на тихој локацији и покушајте поново.';
 
   @override
   String get tooShortDesc => 'Нема довољно говора открит. Молим вас говорите више и покушајте поново.';
@@ -1839,8 +1809,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get areYouThere => 'Да ли си ту?';
 
   @override
-  String get noSpeechDesc =>
-      'Нисмо могли открит говор. Молим вас уверите се да говорите најмање 10 секунди и не више од 3 минута.';
+  String get noSpeechDesc => 'Нисмо могли открит говор. Молим вас уверите се да говорите најмање 10 секунди и не више од 3 минута.';
 
   @override
   String get connectionLost => 'Веза је потргана';
@@ -1861,8 +1830,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get permissionsRequired => 'Дозволе су обавезне';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Ова апликација треба Bluetooth и дозволе за локацију да функционише правилно. Молим вас омогућите их у подешавањима.';
+  String get permissionsRequiredDesc => 'Ова апликација треба Bluetooth и дозволе за локацију да функционише правилно. Молим вас омогућите их у подешавањима.';
 
   @override
   String get openSettings => 'Отвори подешавања';
@@ -1904,12 +1872,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get microphonePermission => 'Дозвола за микрофон';
 
   @override
-  String get permissionGrantedNow =>
-      'Дозвола је додељена! Сада:\n\nОтвори Omi апликацију на часовнику и нажми на \"Настави\" испод';
+  String get permissionGrantedNow => 'Дозвола је додељена! Сада:\n\nОтвори Omi апликацију на часовнику и нажми на \"Настави\" испод';
 
   @override
-  String get needMicrophonePermission =>
-      'Trebamo дозволу за микрофон.\n\n1. Нажми \"Додели дозволу\"\n2. Дозволи на iPhone-у\n3. Апликација на часовнику ће се затворити\n4. Поново отвори и нажми \"Настави\"';
+  String get needMicrophonePermission => 'Trebamo дозволу за микрофон.\n\n1. Нажми \"Додели дозволу\"\n2. Дозволи на iPhone-у\n3. Апликација на часовнику ће се затворити\n4. Поново отвори и нажми \"Настави\"';
 
   @override
   String get grantPermissionButton => 'Додели дозволу';
@@ -1918,15 +1884,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get needHelp => 'Требаш помоћ?';
 
   @override
-  String get troubleshootingSteps =>
-      'Отклањање проблема:\n\n1. Уверите се да је Omi инсталиран на часовнику\n2. Отвори Omi апликацију на часовнику\n3. Потражи поп-ап дозволе\n4. Нажми \"Дозволи\" када је упитан\n5. Апликација на часовнику ће се затворити - поново је отвори\n6. Врати се и нажми \"Настави\" на iPhone-у';
+  String get troubleshootingSteps => 'Отклањање проблема:\n\n1. Уверите се да је Omi инсталиран на часовнику\n2. Отвори Omi апликацију на часовнику\n3. Потражи поп-ап дозволе\n4. Нажми \"Дозволи\" када је упитан\n5. Апликација на часовнику ће се затворити - поново је отвори\n6. Врати се и нажми \"Настави\" на iPhone-у';
 
   @override
   String get recordingStartedSuccessfully => 'Снимање је успешно почело!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Дозвола није додељена. Молим вас уверите се да сте дозволили приступ микрофону и поново отворили апликацију на часовнику.';
+  String get permissionNotGrantedYet => 'Дозвола није додељена. Молим вас уверите се да сте дозволили приступ микрофону и поново отворили апликацију на часовнику.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2023,8 +1987,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Спреман за задатке';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Твој AI ће аутоматски извлачити задатке и за-рађивања из твоих разговора. Они ће се појавити овде када буду креирани.';
+  String get welcomeActionItemsDescription => 'Твој AI ће аутоматски извлачити задатке и за-рађивања из твоих разговора. Они ће се појавити овде када буду креирани.';
 
   @override
   String get autoExtractionFeature => 'Аутоматски извучено из разговора';
@@ -2074,8 +2037,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get clearMemoryTitle => 'Очисти Omi-јево сећање';
 
   @override
-  String get clearMemoryMessage =>
-      'Да ли си сигуран да желиш да очистиш Omi-јево сећање? Ова акција се не може поништити.';
+  String get clearMemoryMessage => 'Да ли си сигуран да желиш да очистиш Omi-јево сећање? Ова акција се не може поништити.';
 
   @override
   String get clearMemoryButton => 'Очисти сећање';
@@ -2221,15 +2183,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'ГОВОР И ПРЕПОЗНАВАЊЕ';
 
   @override
-  String get languageSettingsHelperText =>
-      'Језик апликације мења менијеe и дугмад. Језик говора утиче на то како су твоја снимања препозната.';
+  String get languageSettingsHelperText => 'Језик апликације мења менијеe и дугмад. Језик говора утиче на то како су твоја снимања препозната.';
 
   @override
   String get translationNotice => 'Напомена о преводу';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi преводи разговоре на твој примарни језик. Ажурирај га у било које време у Подешавањима → Профили.';
+  String get translationNoticeMessage => 'Omi преводи разговоре на твој примарни језик. Ажурирај га у било које време у Подешавањима → Профили.';
 
   @override
   String get pleaseCheckInternetConnection => 'Молим вас проверите интернет везу и покушајте поново';
@@ -2391,8 +2351,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Откачи уређај';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Ово ће откачити уређај како би могао бити повезан на други телефон. Мораћете да идете на Подешавања > Bluetooth и заборавите уређај да бисте завршили процес.';
+  String get unpairDeviceDialogMessage => 'Ово ће откачити уређај како би могао бити повезан на други телефон. Мораћете да идете на Подешавања > Bluetooth и заборавите уређај да бисте завршили процес.';
 
   @override
   String get unpair => 'Откачи';
@@ -2573,8 +2532,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get youreAllSet => 'Све си спремна!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Добродошли у Omi! Твој AI пратилац је спреман да те помогне са разговорима, задацима и још много чега.';
+  String get welcomeToOmiDescription => 'Добродошли у Omi! Твој AI пратилац је спреман да те помогне са разговорима, задацима и још много чега.';
 
   @override
   String get startUsingOmi => 'Почни користити Omi';
@@ -2710,8 +2668,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get noTasksYet => 'Нема задатака';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Задаци из твоих разговора ће се појавити овде.\nЛикни Направи да додаш један ручно.';
+  String get tasksFromConversationsWillAppear => 'Задаци из твоих разговора ће се појавити овде.\nЛикни Направи да додаш један ручно.';
 
   @override
   String get monthJan => 'Јан';
@@ -2768,8 +2725,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deleteActionItem => 'Обриши ставку радног списка';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Да ли си сигуран да желиш да обришеш ову ставку радног списка? Ова радња се не може опозвати.';
+  String get deleteActionItemConfirmation => 'Да ли си сигуран да желиш да обришеш ову ставку радног списка? Ова радња се не може опозвати.';
 
   @override
   String get enterActionItemDescription => 'Унеси опис ставке радног списка...';
@@ -2844,8 +2800,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get chatPrompt => 'Чат упит';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ти си невероватна апликација, твој посао је да одговориш на упите корисника и учиниш га срећним...';
+  String get chatPromptPlaceholder => 'Ти си невероватна апликација, твој посао је да одговориш на упите корисника и учиниш га срећним...';
 
   @override
   String get conversationPrompt => 'Упит разговора';
@@ -2863,8 +2818,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get makeMyAppPublic => 'Направи моју апликацију јавном';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Слањем ове апликације, слажем се са Omi AI условима коришћења и политиком приватности';
+  String get submitAppTermsAgreement => 'Слањем ове апликације, слажем се са Omi AI условима коришћења и политиком приватности';
 
   @override
   String get submitApp => 'Пошаљи апликацију';
@@ -2879,12 +2833,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get submitAppQuestion => 'Пошаљи апликацију?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Твоја апликација ће бити прегледана и направљена јавна. Можеш почети да је користиш одмах, чак и док је у прегледу!';
+  String get submitAppPublicDescription => 'Твоја апликација ће бити прегледана и направљена јавна. Можеш почети да је користиш одмах, чак и док је у прегледу!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Твоја апликација ће бити прегледана и направљена доступна теби приватно. Можеш почети да је користиш одмах, чак и док је у прегледу!';
+  String get submitAppPrivateDescription => 'Твоја апликација ће бити прегледана и направљена доступна теби приватно. Можеш почети да је користиш одмах, чак и док је у прегледу!';
 
   @override
   String get startEarning => 'Почни да зарађиваш! 💰';
@@ -2908,23 +2860,19 @@ class AppLocalizationsSr extends AppLocalizations {
   String get dataAccessNotice => 'Обавеза приступа подаципма';
 
   @override
-  String get dataAccessWarning =>
-      'Ова апликација ће приступити твоим подаципма. Omi AI није одговоран за начин на који твоји подаци буду коришћени, модификовани или обрисани од стране ове апликације';
+  String get dataAccessWarning => 'Ова апликација ће приступити твоим подаципма. Omi AI није одговоран за начин на који твоји подаци буду коришћени, модификовани или обрисани од стране ове апликације';
 
   @override
   String get installApp => 'Инсталирај апликацију';
 
   @override
-  String get betaTesterNotice =>
-      'Ти си бета тестер за ову апликацију. Она још није јавна. Биће јавна када буде одобрена.';
+  String get betaTesterNotice => 'Ти си бета тестер за ову апликацију. Она још није јавна. Биће јавна када буде одобрена.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Твоја апликација је на прегледу и видљива само теби. Биће јавна када буде одобрена.';
+  String get appUnderReviewOwner => 'Твоја апликација је на прегледу и видљива само теби. Биће јавна када буде одобрена.';
 
   @override
-  String get appRejectedNotice =>
-      'Твоја апликација је одбијена. Молимо ажурирај детаље апликације и поново пошаљи на преглед.';
+  String get appRejectedNotice => 'Твоја апликација је одбијена. Молимо ажурирај детаље апликације и поново пошаљи на преглед.';
 
   @override
   String get setupSteps => 'Кораци подешавања';
@@ -2986,8 +2934,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get descriptionLabel => 'Опис';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Моја невероватна апликација је одличнна апликација која чини невероватне ствари. То је најбоља апликација икад!';
+  String get appDescriptionPlaceholder => 'Моја невероватна апликација је одличнна апликација која чини невероватне ствари. То је најбоља апликација икад!';
 
   @override
   String get pleaseProvideValidDescription => 'Молимо дај важећи опис';
@@ -3139,8 +3086,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get microphonePermissionRequired => 'Дозвола за микрофон је потребна за позивање';
 
   @override
-  String get microphonePermissionDenied =>
-      'Дозвола за микрофон одбијена. Молимо одобри дозволу у системским подешавањима > Приватност и безбедност > Микрофон.';
+  String get microphonePermissionDenied => 'Дозвола за микрофон одбијена. Молимо одобри дозволу у системским подешавањима > Приватност и безбедност > Микрофон.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3299,8 +3245,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get createMemory => 'Направи меморију';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Да ли си сигуран да желиш да обришеш ову меморију? Ова радња се не може опозвати.';
+  String get deleteMemoryConfirmation => 'Да ли си сигуран да желиш да обришеш ову меморију? Ова радња се не може опозвати.';
 
   @override
   String get makePrivate => 'Направи приватном';
@@ -3374,8 +3319,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get whatWeCollect => 'Шта прикупљамо';
 
   @override
-  String get dataCollectionMessage =>
-      'Наставком, ваше разговоре, снимке и личне информације ће бити безбедно похрањене на нашим серверима да би вам пружили AI-подржане увиде и омогућили све функције апликације.';
+  String get dataCollectionMessage => 'Наставком, ваше разговоре, снимке и личне информације ће бити безбедно похрањене на нашим серверима да би вам пружили AI-подржане увиде и омогућили све функције апликације.';
 
   @override
   String get dataProtection => 'Заштита podataka';
@@ -3408,8 +3352,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Име мора имати најмање 2 карактера';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Скажите нам како бисте желели да будете названи. Ово помаже да персонализујемо ваше Omi искуство.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Скажите нам како бисте желели да будете названи. Ово помаже да персонализујемо ваше Omi искуство.';
 
   @override
   String charactersCount(int count) {
@@ -3426,8 +3369,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get recordAudioConversations => 'Снимајте аудио разговоре';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi треба приступ микрофону да би снимио ваше разговоре и пружио транскрипције.';
+  String get microphoneAccessDescription => 'Omi треба приступ микрофону да би снимио ваше разговоре и пружио транскрипције.';
 
   @override
   String get screenRecording => 'Снимање екрана';
@@ -3436,8 +3378,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Хватајте системски звук са састанака';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi треба дозвола за снимање екрана да би хватио системски звук са ваших веб-базираних састанака.';
+  String get screenRecordingDescription => 'Omi треба дозвола за снимање екрана да би хватио системски звук са ваших веб-базираних састанака.';
 
   @override
   String get accessibility => 'Приступачност';
@@ -3446,8 +3387,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Откријте веб-базиране састанке';
 
   @override
-  String get accessibilityDescription =>
-      'Omi треба дозвола за приступачност да би открио када се прикључите Zoom, Meet или Teams sastancima у вашем прегледачу.';
+  String get accessibilityDescription => 'Omi треба дозвола за приступачност да би открио када се прикључите Zoom, Meet или Teams sastancima у вашем прегледачу.';
 
   @override
   String get pleaseWait => 'Молимо чекајте...';
@@ -3516,12 +3456,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get exportAllConversationsToJson => 'Извезите све своје разговоре у JSON датотеку.';
 
   @override
-  String get conversationsExportStarted =>
-      'Извоз разговора почео. Ово може потрајати неколико секунди, молимо чекајте.';
+  String get conversationsExportStarted => 'Извоз разговора почео. Ово може потрајати неколико секунди, молимо чекајте.';
 
   @override
-  String get mcpDescription =>
-      'Повежите Omi са другим апликацијама да читате, претражите и управљате својим успоменама и разговорима. Направите кључ да почнете.';
+  String get mcpDescription => 'Повежите Omi са другим апликацијама да читате, претражите и управљате својим успоменама и разговорима. Направите кључ да почнете.';
 
   @override
   String get apiKeys => 'API кључеви';
@@ -3592,8 +3530,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get auto => 'Аутоматско';
 
   @override
-  String get noSummaryForApp =>
-      'Нема доступног резимеа за ову апликацију. Пробајте другу апликацију за боље резултате.';
+  String get noSummaryForApp => 'Нема доступног резимеа за ову апликацију. Пробајте другу апликацију за боље резултате.';
 
   @override
   String get tryAnotherApp => 'Пробајте другу апликацију';
@@ -3630,8 +3567,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Дозволи Omi да аутоматски изабере најбољу апликацију';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Да ли сте сигурни да желите да обришете овај разговор? Ова радња не може бити отказана.';
+  String get deleteConversationConfirmation => 'Да ли сте сигурни да желите да обришете овај разговор? Ова радња не може бити отказана.';
 
   @override
   String get conversationDeleted => 'Разговор обрисан';
@@ -3679,8 +3615,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Припремање хватања системског звука';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Кликните на дугме да хватите звук за директне транскрипције, AI увиде и аутоматско чување.';
+  String get clickTheButtonToCaptureAudio => 'Кликните на дугме да хватите звук за директне транскрипције, AI увиде и аутоматско чување.';
 
   @override
   String get reconnecting => 'Поновно повезивање...';
@@ -3907,8 +3842,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Обришите граф знања?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Ово ће обрисати све изведене податке графа знања. Ваше оригиналне успомене остају безбедне.';
+  String get deleteKnowledgeGraphWarning => 'Ово ће обрисати све изведене податке графа знања. Ваше оригиналне успомене остају безбедне.';
 
   @override
   String get connectOmiWithAI => 'Повежите Omi са AI асистентима';
@@ -3950,8 +3884,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Условима и политиком приватности';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Помаже да се дијагностикују проблеми. Аутоматски брише се после 3 дана.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Помаже да се дијагностикују проблеми. Аутоматски брише се после 3 дана.';
 
   @override
   String get manageYourApp => 'Управљајте својом апликацијом';
@@ -3966,8 +3899,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get updateAppQuestion => 'Ажурирати апликацију?';
 
   @override
-  String get updateAppConfirmation =>
-      'Да ли сте сигурни да желите да ажурирате вашу апликацију? Измене ће бити рефлектоване када буду прегледане од наше тима.';
+  String get updateAppConfirmation => 'Да ли сте сигурни да желите да ажурирате вашу апликацију? Измене ће бити рефлектоване када буду прегледане од наше тима.';
 
   @override
   String get updateApp => 'Ажурирај апликацију';
@@ -3997,8 +3929,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get no => 'Не';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Претплата је успешно отказана. Остаће активна до краја тренутног периода наплате.';
+  String get subscriptionCancelledSuccessfully => 'Претплата је успешно отказана. Остаће активна до краја тренутног периода наплате.';
 
   @override
   String get failedToCancelSubscription => 'Неуспешно отказивање претплате. Молимо покушајте поново.';
@@ -4034,8 +3965,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Отказати претплату?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Да ли сте сигурни да желите да отказете вашу претплату? Наставићете да имате приступ до краја вашег тренутног периода наплате.';
+  String get cancelSubscriptionConfirmation => 'Да ли сте сигурни да желите да отказете вашу претплату? Наставићете да имате приступ до краја вашег тренутног периода наплате.';
 
   @override
   String get cancelSubscriptionButton => 'Отказати претплату';
@@ -4044,16 +3974,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get cancelling => 'Отказивање...';
 
   @override
-  String get betaTesterMessage =>
-      'Вештаци сте бета тестер за ову апликацију. Није јавна. Биће јавна када буде одобрена.';
+  String get betaTesterMessage => 'Вештаци сте бета тестер за ову апликацију. Није јавна. Биће јавна када буде одобрена.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Ваша апликација је на прегледу и видљива је само вама. Биће јавна када буде одобрена.';
+  String get appUnderReviewMessage => 'Ваша апликација је на прегледу и видљива је само вама. Биће јавна када буде одобрена.';
 
   @override
-  String get appRejectedMessage =>
-      'Ваша апликација је одбијена. Молимо ажурирајте детаље апликације и поново пошаљите на преглед.';
+  String get appRejectedMessage => 'Ваша апликација је одбијена. Молимо ажурирајте детаље апликације и поново пошаљите на преглед.';
 
   @override
   String get invalidIntegrationUrl => 'Неважећи URL интеграције';
@@ -4107,8 +4034,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get issueActivatingApp => 'Дошло је до проблема при активирању ове апликације. Молимо покушајте поново.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Ова апликација ће приступити вашим подацима. Omi AI није одговоран за то како ваши подаци буду коришћени, измењени или избрисани од стране ове апликације';
+  String get dataAccessNoticeDescription => 'Ова апликација ће приступити вашим подацима. Omi AI није одговоран за то како ваши подаци буду коришћени, измењени или избрисани од стране ове апликације';
 
   @override
   String get copyUrl => 'Копирај URL';
@@ -4196,8 +4122,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get omiApiKeys => 'Omi API кључеви';
 
   @override
-  String get apiKeysDescription =>
-      'API кључеви се користе за аутентификацију када ваша апликација комуницира са OMI серверу. Дозвољавају вашој апликацији да прави успомене и безбедно приступа другим OMI услугама.';
+  String get apiKeysDescription => 'API кључеви се користе за аутентификацију када ваша апликација комуницира са OMI серверу. Дозвољавају вашој апликацији да прави успомене и безбедно приступа другим OMI услугама.';
 
   @override
   String get aboutOmiApiKeys => 'О Omi API кључевима';
@@ -4221,8 +4146,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Опозови API кључ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Ова радња не може бити отказана. Било која апликација која користи овај кључ неће моћи да приступи API-ју.';
+  String get revokeApiKeyWarning => 'Ова радња не може бити отказана. Било која апликација која користи овај кључ неће моћи да приступи API-ју.';
 
   @override
   String get revoke => 'Опозови';
@@ -4320,8 +4244,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get externalAppAccess => 'Приступ外ње апликације';
 
   @override
-  String get externalAppAccessDescription =>
-      'Следеће инсталиране апликације имају外не интеграције и могу приступити вашим подацима, као што су разговори и успомене.';
+  String get externalAppAccessDescription => 'Следеће инсталиране апликације имају外не интеграције и могу приступити вашим подацима, као што су разговори и успомене.';
 
   @override
   String get noExternalAppsHaveAccess => 'Нема外њих апликација које имају приступ вашим подацима.';
@@ -4330,8 +4253,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get maximumSecurityE2ee => 'Максимална безбедност (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Криптировање од краја до краја је золни стандард за приватност. Када је омогућено, ваши подаци су криптовани на вашем уређају пре него што буду послати нашим серверима. То значи да нико, чак ни Omi, не може приступити вашем садржају.';
+  String get e2eeDescription => 'Криптировање од краја до краја је золни стандард за приватност. Када је омогућено, ваши подаци су криптовани на вашем уређају пре него што буду послати нашим серверима. То значи да нико, чак ни Omi, не може приступити вашем садржају.';
 
   @override
   String get importantTradeoffs => 'Важна одступања:';
@@ -4365,19 +4287,16 @@ class AppLocalizationsSr extends AppLocalizations {
   String get secureEncryption => 'Безбедна криптција';
 
   @override
-  String get secureEncryptionDescription =>
-      'Ваши подаци су криптовани са кључем јединственим за вас на нашим серверима, смештеним на Google Cloud. То значи да ваш сирови садржај није приступачан никоме, укључујући Omi особље или Google, директно из базе podataka.';
+  String get secureEncryptionDescription => 'Ваши подаци су криптовани са кључем јединственим за вас на нашим серверима, смештеним на Google Cloud. То значи да ваш сирови садржај није приступачан никоме, укључујући Omi особље или Google, директно из базе podataka.';
 
   @override
   String get endToEndEncryption => 'Криптирање од краја до краја';
 
   @override
-  String get e2eeCardDescription =>
-      'Омогућите за максималну безбедност где само вас можете приступити вашим подацима. Додирни да сазнаш више.';
+  String get e2eeCardDescription => 'Омогућите за максималну безбедност где само вас можете приступити вашим подацима. Додирни да сазнаш више.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Без обзира на ниво, ваши подаци су увек криптовани у мирујућем стању и у транзиту.';
+  String get dataAlwaysEncrypted => 'Без обзира на ниво, ваши подаци су увек криптовани у мирујућем стању и у транзиту.';
 
   @override
   String get readOnlyScope => 'Само читање';
@@ -4445,8 +4364,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Добијте Omi неограничено бесплатно доприносећи своје податке за обуку AI модела.';
 
   @override
-  String get trainingDataBullets =>
-      '• Ваши подаци помажу да се побољшају AI модели\n• Само неоседљиви подаци се деле\n• Потпуно транспарентан процес';
+  String get trainingDataBullets => '• Ваши подаци помажу да се побољшају AI модели\n• Само неоседљиви подаци се деле\n• Потпуно транспарентан процес';
 
   @override
   String get learnMoreAtOmiTraining => 'Сазнајте више на omi.me/training';
@@ -4496,8 +4414,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get monthlyPlanContinues => 'Ваш тренутни месечни план ће се наставити до краја вашег периода наплате';
 
   @override
-  String get paymentMethodCharged =>
-      'Ваш постојећи начин плаћања ће бити аутоматски наплаћен када се ваш месечни план заврши';
+  String get paymentMethodCharged => 'Ваш постојећи начин плаћања ће бити аутоматски наплаћен када се ваш месечни план заврши';
 
   @override
   String get annualSubscriptionStarts => 'Ваша 12-месечна годишња претплата ће почети аутоматски после наплате';
@@ -4607,8 +4524,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Твоја приватност је важна нама';
 
   @override
-  String get privacyIntroText =>
-      'У Omi, озбиљно узимамо вашу приватност. Желимо да будемо транспарентни у вези са подаците које скупљамо и како их користимо да унапредимо наш производ за вас. Ево шта требате знати:';
+  String get privacyIntroText => 'У Omi, озбиљно узимамо вашу приватност. Желимо да будемо транспарентни у вези са подаците које скупљамо и како их користимо да унапредимо наш производ за вас. Ево шта требате знати:';
 
   @override
   String get whatWeTrack => 'Шта ми пратимо';
@@ -4623,12 +4539,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get ourCommitment => 'Наша обавеза';
 
   @override
-  String get commitmentText =>
-      'Обавезани смо да користимо податке које скупљамо само да направимо Omi бољи производ за вас. Ваша приватност и поверење су од крајње важности за нас.';
+  String get commitmentText => 'Обавезани смо да користимо податке које скупљамо само да направимо Omi бољи производ за вас. Ваша приватност и поверење су од крајње важности за нас.';
 
   @override
-  String get thankYouText =>
-      'Хвала вам што сте драгоцени корисник Omi. Ако имате неке питање или забринутости, слободно нас контактирајте на team@basedhardware.com.';
+  String get thankYouText => 'Хвала вам што сте драгоцени корисник Omi. Ако имате неке питање или забринутости, слободно нас контактирајте на team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Поставке WiFi синхронизације';
@@ -4637,8 +4551,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get enterHotspotCredentials => 'Унесите акредитиве топле тачке вашег телефона';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi синхронизација користи ваш телефон као топлу тачку. Пронађите име и лозинку топле тачке у Поставкама > Лична топла тачка.';
+  String get wifiSyncUsesHotspot => 'WiFi синхронизација користи ваш телефон као топлу тачку. Пронађите име и лозинку топле тачке у Поставкама > Лична топла тачка.';
 
   @override
   String get hotspotNameSsid => 'Назив топле тачке (SSID)';
@@ -4673,8 +4586,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Неуспешно генерисање резимеа. Пажите да имате разговоре за тај дан.';
+  String get failedToGenerateSummaryCheckConversations => 'Неуспешно генерисање резимеа. Пажите да имате разговоре за тај дан.';
 
   @override
   String get summaryNotFound => 'Резиме није пронађен';
@@ -4704,8 +4616,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Извоз је почео. Ово може да потраје неколико секунди...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ово ће обрисати све изведене податке графа знања (чворове и конексије). Ваша оригинална меморија остаће безбедна. Граф ће бити обновљен течајом времена или при следећем захтеву.';
+  String get knowledgeGraphDeleteDescription => 'Ово ће обрисати све изведене податке графа знања (чворове и конексије). Ваша оригинална меморија остаће безбедна. Граф ће бити обновљен течајом времена или при следећем захтеву.';
 
   @override
   String get configureDailySummaryDigest => 'Конфигуриши твој дневни резиме активних ставки';
@@ -4775,8 +4686,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Избрисати све разговоре без ограничења?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Ово ће трајно обрисати све разговоре увезене из Limitless. Ова акција се не може отменити.';
+  String get deleteAllLimitlessWarning => 'Ово ће трајно обрисати све разговоре увезене из Limitless. Ова акција се не може отменити.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4832,8 +4742,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get howItWorksTitle => 'Како функционише?';
 
   @override
-  String get howPeopleWorks =>
-      'Када се особа направи, можете да идете на транскрипцију разговора и доделите јој одговарајуће сегменте, на тај начин Omi ће бити способна да препозна и њихов говор!';
+  String get howPeopleWorks => 'Када се особа направи, можете да идете на транскрипцију разговора и доделите јој одговарајуће сегменте, на тај начин Omi ће бити способна да препозна и њихов говор!';
 
   @override
   String get tapToDelete => 'Гаси да избришеш';
@@ -4859,8 +4768,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get privacyNotice => 'Обавештење о приватности';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Снимања могу захватити гласове других. Пажите да имате сагласност свих учесника пре омогућавања.';
+  String get recordingsMayCaptureOthers => 'Снимања могу захватити гласове других. Пажите да имате сагласност свих учесника пре омогућавања.';
 
   @override
   String get enable => 'Омогући';
@@ -4872,8 +4780,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get on => 'Укл.';
 
   @override
-  String get storeAudioDescription =>
-      'Чувај све аудио снимке локално на твом телефону. Када је онемогућено, само неуспешни преноси су чувани да бисте уштедели простор за складиштење.';
+  String get storeAudioDescription => 'Чувај све аудио снимке локално на твом телефону. Када је онемогућено, само неуспешни преноси су чувани да бисте уштедели простор за складиштење.';
 
   @override
   String get enableLocalStorage => 'Омогући локалну складишту';
@@ -4891,12 +4798,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get storeAudioOnCloud => 'Чувај аудио у облаку';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Ваша снимања у реалном времену ће бити чувана у приватном облак складишту док говорите.';
+  String get cloudStorageDialogMessage => 'Ваша снимања у реалном времену ће бити чувана у приватном облак складишту док говорите.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Чувај твоја снимања у реалном времену у приватном облак складишту док говориш. Аудио је захваћен и сачуван безбедно у реалном времену.';
+  String get storeAudioCloudDescription => 'Чувај твоја снимања у реалном времену у приватном облак складишту док говориш. Аудио је захваћен и сачуван безбедно у реалном времену.';
 
   @override
   String get downloadingFirmware => 'Преузимање фирмвера';
@@ -5003,8 +4908,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get connectingYourStripeAccount => 'Повезивање вашег Stripe рачуна';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Молим вас, завршите Stripe процес укупне обуке у вашем прегледачу. Ова страна ће се аутоматски ажурирати када буде завршена.';
+  String get stripeOnboardingInstructions => 'Молим вас, завршите Stripe процес укупне обуке у вашем прегледачу. Ова страна ће се аутоматски ажурирати када буде завршена.';
 
   @override
   String get failedTryAgain => 'Неуспешно? Покушај поново';
@@ -5016,8 +4920,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get successfullyConnected => 'Успешно повезано!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Ваш Stripe рачун је сада спреман да прима плаћања. Можете почети да зарађујете од продаје своје апликације одмах.';
+  String get stripeReadyForPayments => 'Ваш Stripe рачун је сада спреман да прима плаћања. Можете почети да зарађујете од продаје своје апликације одмах.';
 
   @override
   String get updateStripeDetails => 'Ажурирај Stripe детаље';
@@ -5035,8 +4938,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Ажурирај своје PayPal детаље рачуна';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Повежи свој PayPal рачун да почнеш да прима плаћања за своје апликације';
+  String get connectPayPalToReceivePayments => 'Повежи свој PayPal рачун да почнеш да прима плаћања за своје апликације';
 
   @override
   String get paypalEmail => 'PayPal имејл';
@@ -5045,8 +4947,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me веза';
 
   @override
-  String get stripeRecommendation =>
-      'Ако је Stripe доступан у вашој земљи, препоручујемо вам да га користите за брже и лакше исплате.';
+  String get stripeRecommendation => 'Ако је Stripe доступан у вашој земљи, препоручујемо вам да га користите за брже и лакше исплате.';
 
   @override
   String get updatePayPalDetails => 'Ажурирај PayPal детаље';
@@ -5098,12 +4999,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Додатни узорак говора је уклоњен';
 
   @override
-  String get consentDataMessage =>
-      'Настављањем, ваши разговори, снимци и лични подаци биће безбедно ускладиштени на нашим серверима. Ваши аудио снимци и транскрипти се обрађују од стране AI сервиса трећих страна (укључујући Deepgram за транскрипцију и OpenAI за анализу) како би вам пружили увиде засноване на вештачкој интелигенцији и омогућили све функције апликације.';
+  String get consentDataMessage => 'Настављањем, ваши разговори, снимци и лични подаци биће безбедно ускладиштени на нашим серверима. Ваши аудио снимци и транскрипти се обрађују од стране AI сервиса трећих страна (укључујући Deepgram за транскрипцију и OpenAI за анализу) како би вам пружили увиде засноване на вештачкој интелигенцији и омогућили све функције апликације.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Активне ставке из твоје разговора ће се појавити овде.\\nГаси + да направиш једну ручно.';
+  String get tasksEmptyStateMessage => 'Активне ставке из твоје разговора ће се појавити овде.\\nГаси + да направиш једну ручно.';
 
   @override
   String get clearChatAction => 'Обриши разговор';
@@ -5139,15 +5038,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Инсталирај Omi на твој\\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Да користиш Apple Watch са Omi, прво мораш да инсталираш Omi апликацију на твом часовнику.';
+  String get installOmiOnAppleWatchDescription => 'Да користиш Apple Watch са Omi, прво мораш да инсталираш Omi апликацију на твом часовнику.';
 
   @override
   String get openOmiOnAppleWatch => 'Отвори Omi на твој\\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi апликација је инсталирана на твом Apple Watch. Отвори је и гаски Почни да почнеш.';
+  String get openOmiOnAppleWatchDescription => 'Omi апликација је инсталирана на твом Apple Watch. Отвори је и гаски Почни да почнеш.';
 
   @override
   String get openWatchApp => 'Отвори Watch апликацију';
@@ -5156,15 +5053,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Сам инсталирао и открио апликацију';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Не могу да отворим Apple Watch апликацију. Молим вас, ручно отворите Watch апликацију на вашем Apple Watch и инсталирајте Omi из одељка \"Доступне апликације\".';
+  String get unableToOpenWatchApp => 'Не могу да отворим Apple Watch апликацију. Молим вас, ручно отворите Watch апликацију на вашем Apple Watch и инсталирајте Omi из одељка \"Доступне апликације\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch је успешно повезан!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch је и даље недостижан. Молим вас, пажите да је Omi апликација отворена на твом часовнику.';
+  String get appleWatchNotReachable => 'Apple Watch је и даље недостижан. Молим вас, пажите да је Omi апликација отворена на твом часовнику.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5181,8 +5076,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get finishedConversation => 'Завршио разговор?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Да ли сте сигурни да желите да zaustavите записивање и sažmete разговор сада?';
+  String get stopRecordingConfirmation => 'Да ли сте сигурни да желите да zaustavите записивање и sažmete разговор сада?';
 
   @override
   String get conversationEndsManually => 'Разговор ће завршити само ручно.';
@@ -5593,8 +5487,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get multipleSpeakersDetected => 'Открити више говорника';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Чини се да има више говорника у записивању. Молим вас, пажите да сте у тихој локацији и покушајте поново.';
+  String get multipleSpeakersDescription => 'Чини се да има више говорника у записивању. Молим вас, пажите да сте у тихој локацији и покушајте поново.';
 
   @override
   String get invalidRecordingDetected => 'Открити неважећи записивање';
@@ -5612,8 +5505,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get howToTakeGoodSample => 'Како направити добар узорак?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Уверите се да сте на тихом месту.\n2. Говорите јасно и природно.\n3. Уверите се да је ваш уређај у природној позицији, на вашем врату.\n\nКада буде креиран, можете га увек побољшати или поново направити.';
+  String get goodSampleInstructions => '1. Уверите се да сте на тихом месту.\n2. Говорите јасно и природно.\n3. Уверите се да је ваш уређај у природној позицији, на вашем врату.\n\nКада буде креиран, можете га увек побољшати или поново направити.';
 
   @override
   String get noDeviceConnectedUseMic => 'Ниједан уређај није повезан. Биће коришћен микрофон телефона.';
@@ -5676,8 +5568,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get howItWorks => 'Како то функционише';
 
   @override
-  String get dailyScoreExplanation =>
-      'Ваш дневни резултат је заснован на завршавању задатака. Завршите своје задатке да бисте побољшали резултат!';
+  String get dailyScoreExplanation => 'Ваш дневни резултат је заснован на завршавању задатака. Завршите своје задатке да бисте побољшали резултат!';
 
   @override
   String get notificationFrequencyDescription => 'Контролишите колико често Omi шаље активна обавештења и подсетнике.';
@@ -5773,8 +5664,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get selectApp => 'Одаберите апликацију';
 
   @override
-  String get noChatAppsEnabled =>
-      'Нема омогућених апликација за разговор.\nДотакните \"Омогући апликације\" да додате неке.';
+  String get noChatAppsEnabled => 'Нема омогућених апликација за разговор.\nДотакните \"Омогући апликације\" да додате неке.';
 
   @override
   String get disable => 'Искључи';
@@ -5981,8 +5871,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL није постављен';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Молимо поставите webhook URL у развојачка подешавања да користите ову функцију.';
+  String get setWebhookUrlInSettings => 'Молимо поставите webhook URL у развојачка подешавања да користите ову функцију.';
 
   @override
   String get sendWebUrl => 'Пошаљи веб адресу';
@@ -6056,15 +5945,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get cloudProvider => 'Облачни провајдер';
 
   @override
-  String get premiumMinutesInfo =>
-      '1.200 премиум минута/месец. Картица \"На уређају\" нуди неограничену бесплатну транскрипцију.';
+  String get premiumMinutesInfo => '1.200 премиум минута/месец. Картица \"На уређају\" нуди неограничену бесплатну транскрипцију.';
 
   @override
   String get viewUsage => 'Погледајте утрошак';
 
   @override
-  String get localProcessingInfo =>
-      'Аудио се обрађује локално. Функционише без интернета, приватније је, али больше исцрпљује батерију.';
+  String get localProcessingInfo => 'Аудио се обрађује локално. Функционише без интернета, приватније је, али больше исцрпљује батерију.';
 
   @override
   String get model => 'Модел';
@@ -6073,15 +5960,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get performanceWarning => 'Упозорење о перформансама';
 
   @override
-  String get largeModelWarning =>
-      'Овај модел је велик и може узроковати пад апликације или веома спорно покретање на мобилним уређајима.\n\nПрепоручена су \"small\" или \"base\".';
+  String get largeModelWarning => 'Овај модел је велик и може узроковати пад апликације или веома спорно покретање на мобилним уређајима.\n\nПрепоручена су \"small\" или \"base\".';
 
   @override
   String get usingNativeIosSpeech => 'Коришћење изворног iOS препознавања говора';
 
   @override
-  String get noModelDownloadRequired =>
-      'Биће коришћен изворни говорни механизам вашег уређаја. Преузимање модела није потребно.';
+  String get noModelDownloadRequired => 'Биће коришћен изворни говорни механизам вашег уређаја. Преузимање модела није потребно.';
 
   @override
   String get modelReady => 'Модел спреман';
@@ -6138,12 +6023,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get batteryDrainSignificantly => 'Исцрпљивање батерије ће се значајно повећати.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 премиум минута/месец. Картица \"На уређају\" нуди неограничену бесплатну транскрипцију. ';
+  String get premiumMinutesMonth => '1.200 премиум минута/месец. Картица \"На уређају\" нуди неограничену бесплатну транскрипцију. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Аудио се обрађује локално. Функционише без интернета, приватније је, али больше исцрпљује батерију.';
+  String get audioProcessedLocally => 'Аудио се обрађује локално. Функционише без интернета, приватније је, али больше исцрпљује батерију.';
 
   @override
   String get languageLabel => 'Језик';
@@ -6152,12 +6035,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get modelLabel => 'Модел';
 
   @override
-  String get modelTooLargeWarning =>
-      'Овај модел је велик и може узроковати пад апликације или веома спорно покретање на мобилним уређајима.\n\nПрепоручена су \"small\" или \"base\".';
+  String get modelTooLargeWarning => 'Овај модел је велик и може узроковати пад апликације или веома спорно покретање на мобилним уређајима.\n\nПрепоручена су \"small\" или \"base\".';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Биће коришћен изворни говорни механизам вашег уређаја. Преузимање модела није потребно.';
+  String get nativeEngineNoDownload => 'Биће коришћен изворни говорни механизам вашег уређаја. Преузимање модела није потребно.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6193,8 +6074,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Уграђена директна транскрипција Omi-ја је оптимизована за разговоре у реалном времену са аутоматским препознавањем и дијаризацијом говорника.';
+  String get omiTranscriptionOptimized => 'Уграђена директна транскрипција Omi-ја је оптимизована за разговоре у реалном времену са аутоматским препознавањем и дијаризацијом говорника.';
 
   @override
   String get reset => 'Ресетуј';
@@ -6414,8 +6294,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Грађење вашег графа знања из сећања...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Ваш граф знања ће бити изграђен аутоматски док креирате ново сећање.';
+  String get knowledgeGraphWillBuildAutomatically => 'Ваш граф знања ће бити изграђен аутоматски док креирате ново сећање.';
 
   @override
   String get buildGraphButton => 'Направи граф';
@@ -6717,8 +6596,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Преузимање аудиа са SD картице вашег уређаја';
 
   @override
-  String get transferRequiredDescription =>
-      'Овај снимак је сачуван на SD картици вашег уређаја. Пренесите га на телефон да бисте могли да га слушате или поделите.';
+  String get transferRequiredDescription => 'Овај снимак је сачуван на SD картици вашег уређаја. Пренесите га на телефон да бисте могли да га слушате или поделите.';
 
   @override
   String get cancelTransfer => 'Отказати пренос';
@@ -6739,8 +6617,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get shareRecording => 'Дели снимак';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Да ли сте сигурни да желите трајно да избришете овај снимак? Ово се не може отказати.';
+  String get deleteRecordingConfirmation => 'Да ли сте сигурни да желите трајно да избришете овај снимак? Ово се не може отказати.';
 
   @override
   String get recordingIdLabel => 'Шифра записа';
@@ -6799,15 +6676,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get enableFastTransfer => 'Омогући брз пренос';
 
   @override
-  String get fastTransferDescription =>
-      'Брз пренос користи WiFi за ~5x бржу брзину. Ваш телефон ће привремено бити повезан на WiFi мрежу вашег Omi уређаја током преноса.';
+  String get fastTransferDescription => 'Брз пренос користи WiFi за ~5x бржу брзину. Ваш телефон ће привремено бити повезан на WiFi мрежу вашег Omi уређаја током преноса.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Приступ интернету је паузиран током преноса';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Изаберите како ће се снимци преносити са вашег Omi уређаја на телефон.';
+  String get chooseTransferMethodDescription => 'Изаберите како ће се снимци преносити са вашег Omi уређаја на телефон.';
 
   @override
   String get wifiSpeed => '~150 KB/s преко WiFi';
@@ -6816,8 +6691,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get fiveTimesFaster => '5X БРЖЕ';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Прави директну WiFi везу са вашим Omi уређајем. Ваш телефон ће привремено бити одсоединут од обичне WiFi мреже током преноса.';
+  String get fastTransferMethodDescription => 'Прави директну WiFi везу са вашим Omi уређајем. Ваш телефон ће привремено бити одсоединут од обичне WiFi мреже током преноса.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6826,8 +6700,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get bleSpeed => '~30 KB/s преко BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Користи стандардну Bluetooth Low Energy везу. Спорија али не утиче на вашу WiFi везу.';
+  String get bluetoothMethodDescription => 'Користи стандардну Bluetooth Low Energy везу. Спорија али не утиче на вашу WiFi везу.';
 
   @override
   String get selected => 'Изабрано';
@@ -6865,12 +6738,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get appDeleteFailed => 'Неуспешно брисање апликације. Молим покушајте касније.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Видљивост апликације је успешно промењена. Може потрајати неколико минута да се рефлектује.';
+  String get appVisibilityChangedSuccessfully => 'Видљивост апликације је успешно промењена. Може потрајати неколико минута да се рефлектује.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Грешка при активирању апликације. Ако је ово апликација за интеграцију, проверите да ли је подешавање завршено.';
+  String get errorActivatingAppIntegration => 'Грешка при активирању апликације. Ако је ово апликација за интеграцију, проверите да ли је подешавање завршено.';
 
   @override
   String get errorUpdatingAppStatus => 'Дошло је до грешке при ажурирању статуса апликације.';
@@ -6950,8 +6821,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Назив мора имати најмање 3 карактера';
 
   @override
-  String get conversationPromptHint =>
-      'нпр. Извуците ставке за акцију, донета решења и кључне закључке из дате разговора.';
+  String get conversationPromptHint => 'нпр. Извуците ставке за акцију, донета решења и кључне закључке из дате разговора.';
 
   @override
   String get pleaseEnterAppPrompt => 'Молим унесите упутство за вашу апликацију';
@@ -6984,8 +6854,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get failedToCreateApp => 'Неуспешно прављење апликације. Молим покушајте поново.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'Молим одаберите једну другу основну способност за вашу апликацију да наставите';
+  String get addAppSelectCoreCapability => 'Молим одаберите једну другу основну способност за вашу апликацију да наставите';
 
   @override
   String get addAppSelectPaymentPlan => 'Молим одаберите план плаћања и унесите цену за вашу апликацију';
@@ -7034,8 +6903,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'Дозвола за слике је одбијена. Молим дозволите приступ сликама да одабрате слику';
+  String get addAppPhotosPermissionDenied => 'Дозвола за слике је одбијена. Молим дозволите приступ сликама да одабрате слику';
 
   @override
   String get addAppErrorSelectingImageRetry => 'Грешка при избору слике. Молим покушајте поново.';
@@ -7140,15 +7008,13 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Надоградња је заказана! Ваш месечни план наставља до краја периода наплате, а затим се аутоматски пребацује на годишњи.';
+  String get planUpgradeScheduledMessage => 'Надоградња је заказана! Ваш месечни план наставља до краја периода наплате, а затим се аутоматски пребацује на годишњи.';
 
   @override
   String get couldNotSchedulePlanChange => 'Није могуће заказати промену плана. Молим покушајте поново.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Ваша претплата је реактивирана! Нема наплате сада - биће вам наплаћено на крају текућег периода.';
+  String get subscriptionReactivatedDefault => 'Ваша претплата је реактивирана! Нема наплате сада - биће вам наплаћено на крају текућег периода.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Претплата је успешна! Наплаћена вам је за нови период наплате.';
@@ -7331,8 +7197,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Дозвола за Bluetooth је потребна да бисте се повезали на ваш уређај.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Дозвола за Bluetooth је одбијена. Молим дајте дозволу у Системским преферентијама.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Дозвола за Bluetooth је одбијена. Молим дајте дозволу у Системским преферентијама.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7345,12 +7210,10 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Дозвола за обавештења је одбијена. Молим дајте дозволу у Системским преферентијама.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Дозвола за обавештења је одбијена. Молим дајте дозволу у Системским преферентијама.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Дозвола за обавештења је одбијена. Молим дајте дозволу у Системским преферентијама > Обавештења.';
+  String get onboardingNotificationDeniedNotifications => 'Дозвола за обавештења је одбијена. Молим дајте дозволу у Системским преферентијама > Обавештења.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7363,15 +7226,13 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Молим дајте дозволу за локацију у Подешавањима > Приватност и безбедност > Услуге локације';
+  String get onboardingLocationGrantInSettings => 'Молим дајте дозволу за локацију у Подешавањима > Приватност и безбедност > Услуге локације';
 
   @override
   String get onboardingMicrophoneRequired => 'Дозвола за микрофон је потребна за снимање.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Дозвола за микрофон је одбијена. Молим дајте дозволу у Системским преферентијама > Приватност и безбедност > Микрофон.';
+  String get onboardingMicrophoneDenied => 'Дозвола за микрофон је одбијена. Молим дајте дозволу у Системским преферентијама > Приватност и безбедност > Микрофон.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7387,8 +7248,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Дозвола за снимање екрана је потребна за снимање системског звука.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Дозвола за снимање екрана је одбијена. Молим дајте дозволу у Системским преферентијама > Приватност и безбедност > Снимање екрана.';
+  String get onboardingScreenCaptureDenied => 'Дозвола за снимање екрана је одбијена. Молим дајте дозволу у Системским преферентијама > Приватност и безбедност > Снимање екрана.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7401,8 +7261,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Дозвола за приступачност је потребна за детектовање веб сајта мајтинга.';
+  String get onboardingAccessibilityRequired => 'Дозвола за приступачност је потребна за детектовање веб сајта мајтинга.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7442,8 +7301,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Дозвола за слике је одбијена. Молим дозволите приступ сликама да одабрате слике';
+  String get msgPhotosPermissionDenied => 'Дозвола за слике је одбијена. Молим дозволите приступ сликама да одабрате слике';
 
   @override
   String get msgSelectImagesGenericError => 'Грешка при избору слика. Молим покушајте поново.';
@@ -7515,8 +7373,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get locationPermissionRequired => 'Потребна је дозвола за локацију';
 
   @override
-  String get locationPermissionContent =>
-      'Брз пренос захтева дозволу за локацију да би се верификовала WiFi веза. Молим дајте дозволу за локацију да наставите.';
+  String get locationPermissionContent => 'Брз пренос захтева дозволу за локацију да би се верификовала WiFi веза. Молим дајте дозволу за локацију да наставите.';
 
   @override
   String get pdfTranscriptExport => 'Извоз транскрипта';
@@ -7679,8 +7536,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Уређај не подржава WiFi синхронизацију, пребацивање на Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Уређај не подржава WiFi синхронизацију, пребацивање на Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health није доступна на овом уређају';
@@ -7976,8 +7832,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Постави Omi DevKit у режим паривања';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Притисни дугме једном да укључиш. LED ће трептати наранџасто када је у режиму паривања.';
+  String get pairingDescOmiDevkit => 'Притисни дугме једном да укључиш. LED ће трептати наранџасто када је у режиму паривања.';
 
   @override
   String get pairingTitleOmiGlass => 'Укључи Omi Glass';
@@ -7989,8 +7844,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Постави Plaud Note у режим паривања';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Притисни и држи боково дугме 2 секунде. Црвена LED ће трептати када је спремна за паривање.';
+  String get pairingDescPlaudNote => 'Притисни и држи боково дугме 2 секунде. Црвена LED ће трептати када је спремна за паривање.';
 
   @override
   String get pairingTitleBee => 'Постави Bee у режим паривања';
@@ -8002,15 +7856,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get pairingTitleLimitless => 'Постави Limitless у режим паривања';
 
   @override
-  String get pairingDescLimitless =>
-      'Када су светла видљива, притисни једном и затим притисни и држи док уређај не покаже розо светло, затим отпусти.';
+  String get pairingDescLimitless => 'Када су светла видљива, притисни једном и затим притисни и држи док уређај не покаже розо светло, затим отпусти.';
 
   @override
   String get pairingTitleFriendPendant => 'Постави Friend Pendant у режим паривања';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Притисни дугме на привеску да га укључиш. Аутоматски ће ући у режим паривања.';
+  String get pairingDescFriendPendant => 'Притисни дугме на привеску да га укључиш. Аутоматски ће ући у режим паривања.';
 
   @override
   String get pairingTitleFieldy => 'Постави Fieldy у режим паривања';
@@ -8022,8 +7874,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Повежи Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Инсталирај и отвори Omi апликацију на Apple Watch, затим притисни \"Повежи\" у апликацији.';
+  String get pairingDescAppleWatch => 'Инсталирај и отвори Omi апликацију на Apple Watch, затим притисни \"Повежи\" у апликацији.';
 
   @override
   String get pairingTitleNeoOne => 'Постави Neo One у режим паривања';
@@ -8146,8 +7997,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get switchAndRestart => 'Промени';
 
   @override
-  String get stagingDisclaimer =>
-      'Staging може бити пун грешака, има неусаглашене перформансе и подаци могу бити изгубљени. Користи само за тестирање.';
+  String get stagingDisclaimer => 'Staging може бити пун грешака, има неусаглашене перформансе и подаци могу бити изгубљени. Користи само за тестирање.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Сачувано. Затвори и поново отвори апликацију да би се применила.';
@@ -8376,8 +8226,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Телефонски позиви преко Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Направи позиве преко Omi и добиј трансцирпцију у реално време, аутоматске резиме и више. Доступно искључиво за Unlimited план кориснике.';
+  String get phoneCallsUpsellSubtitle => 'Направи позиве преко Omi и добиј трансцирпцију у реално време, аутоматске резиме и више. Доступно искључиво за Unlimited план кориснике.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Трансцирпција у реално време за сваки позив';
@@ -8404,8 +8253,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deleteSyncedFiles => 'Избриши синхронизоване снимке';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Ови снимци су већ синхронизовани са твојим телефоном. Ово се не може отпозвати.';
+  String get deleteSyncedFilesMessage => 'Ови снимци су већ синхронизовани са твојим телефоном. Ово се не може отпозвати.';
 
   @override
   String get syncedFilesDeleted => 'Синхронизовани снимци избрисани';
@@ -8417,8 +8265,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deletePendingFiles => 'Избриши снимке на чекању';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Ови снимци НИСУ синхронизовани са твојим телефоном и биће трајно избрисани. Ово се не може отпозвати.';
+  String get deletePendingFilesWarning => 'Ови снимци НИСУ синхронизовани са твојим телефоном и биће трајно избрисани. Ово се не може отпозвати.';
 
   @override
   String get pendingFilesDeleted => 'Снимци на чекању избрисани';
@@ -8430,8 +8277,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deleteAll => 'Избриши све';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Ово ће избрисати синхронизоване и снимке на чекању. Снимци на чекању НИСУ синхронизовани и биће трајно избрисани. Ово се не може отпозвати.';
+  String get deleteAllFilesWarning => 'Ово ће избрисати синхронизоване и снимке на чекању. Снимци на чекању НИСУ синхронизовани и биће трајно избрисани. Ово се не може отпозвати.';
 
   @override
   String get allFilesDeleted => 'Сви снимци избрисани';
@@ -8496,8 +8342,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get fairUseAboutTitle => 'О честитој употреби';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi је направљен за личне разговоре, састанке и живе интеракције. Употреба се мери реалним временом говора, не временом повезивања. Ако употреба значајно превише превише превиши обрасцима за личну употребу, могу се применити прилагођавања.';
+  String get fairUseAboutBody => 'Omi је направљен за личне разговоре, састанке и живе интеракције. Употреба се мери реалним временом говора, не временом повезивања. Ако употреба значајно превише превише превиши обрасцима за личну употребу, могу се применити прилагођавања.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8535,8 +8380,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get improveConnectionTitle => 'Побољшај повезивање';
 
   @override
-  String get improveConnectionContent =>
-      'Побољшали смо како Omi остаје повезан са твојим уређајем. Да би активирао ово, молимо отиди на страницу Информације о уређају, притисни \"Одвежи уређај\" и затим поново упари твој уређај.';
+  String get improveConnectionContent => 'Побољшали смо како Omi остаје повезан са твојим уређајем. Да би активирао ово, молимо отиди на страницу Информације о уређају, притисни \"Одвежи уређај\" и затим поново упари твој уређај.';
 
   @override
   String get improveConnectionAction => 'Разумем';
@@ -8591,16 +8435,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get cancelSyncQuestion => 'Отказати синхронизовање?';
 
   @override
-  String get omisStorageDesc =>
-      'Када твој Omi није повезан са твојим телефоном, снимци аудио се чувају локално на уграђеној меморији. Никада не губиш снимак.';
+  String get omisStorageDesc => 'Када твој Omi није повезан са твојим телефоном, снимци аудио се чувају локално на уграђеној меморији. Никада не губиш снимак.';
 
   @override
-  String get phoneStorageDesc =>
-      'Када се Omi поново повезује, снимци се аутоматски преносе на твој телефон као привремена складишна подручја пре слања.';
+  String get phoneStorageDesc => 'Када се Omi поново повезује, снимци се аутоматски преносе на твој телефон као привремена складишна подручја пре слања.';
 
   @override
-  String get cloudStorageDesc =>
-      'Када буде послано, твоји снимци се обрађују и трансцирају. Разговори ће бити доступни за минут.';
+  String get cloudStorageDesc => 'Када буде послано, твоји снимци се обрађују и трансцирају. Разговори ће бити доступни за минут.';
 
   @override
   String get tipKeepPhoneNearby => 'Держи свој телефон близу за брже синхронизовање';
@@ -8624,12 +8465,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get permissionEnable => 'Омогући';
 
   @override
-  String get permissionsPageDescription =>
-      'Ове дозволе су суштине за то како Omi функционише. Омогућавају главне функције као обавештење, локацијске искуства и аудио прихватање.';
+  String get permissionsPageDescription => 'Ове дозволе су суштине за то како Omi функционише. Омогућавају главне функције као обавештење, локацијске искуства и аудио прихватање.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi затреба неколико дозвола да функционише правилно. Молимо их допусти да наставиш.';
+  String get permissionsRequiredDescription => 'Omi затреба неколико дозвола да функционише правилно. Молимо их допусти да наставиш.';
 
   @override
   String get permissionsSetupTitle => 'Добиј најбоље искуство';
@@ -8906,8 +8745,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get firmwareWarningTitle => 'Важно: Прочитајте пре ажурирања';
 
   @override
-  String get firmwareFormatWarning =>
-      'Овај фирмвер ће форматирати SD картицу. Молимо вас да се уверите да су сви офлајн подаци синхронизовани пре надоградње.\n\nАко видите треперeће црвено светло након инсталирања ове верзије, не брините. Једноставно повежите уређај са апликацијом и требало би да постане плаво. Црвено светло значи да сат уређаја још увек није синхронизован.';
+  String get firmwareFormatWarning => 'Овај фирмвер ће форматирати SD картицу. Молимо вас да се уверите да су сви офлајн подаци синхронизовани пре надоградње.\n\nАко видите треперeће црвено светло након инсталирања ове верзије, не брините. Једноставно повежите уређај са апликацијом и требало би да постане плаво. Црвено светло значи да сат уређаја још увек није синхронизован.';
 
   @override
   String get continueAnyway => 'Настави';
@@ -8927,8 +8765,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get tasksMarkComplete => 'Означено као завршено';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi приступа Apple Health-у преко Apple-овог HealthKit оквира. Приступ можете опозвати у било ком тренутку у подешавањима iOS-а.';
+  String get appleHealthManageNote => 'Omi приступа Apple Health-у преко Apple-овог HealthKit оквира. Приступ можете опозвати у било ком тренутку у подешавањима iOS-а.';
 
   @override
   String get appleHealthConnectCta => 'Повежи са Apple Health';
@@ -8961,8 +8798,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Приступ Apple Health-у одбијен';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi нема дозволу да чита ваше Apple Health податке. Омогућите га у iOS Подешавања → Приватност и безбедност → Health → Omi.';
+  String get appleHealthDeniedBody => 'Omi нема дозволу да чита ваше Apple Health податке. Омогућите га у iOS Подешавања → Приватност и безбедност → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Зашто одлазите?';
@@ -9031,8 +8867,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get planUpdate => 'Ажурирање плана';
 
   @override
-  String get planDeprecationMessage =>
-      'Ваш Unlimited план се укида. Пређите на Operator план — исте одличне функције за \$49/мес. Ваш тренутни план ће наставити да ради у међувремену.';
+  String get planDeprecationMessage => 'Ваш Unlimited план се укида. Пређите на Operator план — исте одличне функције за \$49/мес. Ваш тренутни план ће наставити да ради у међувремену.';
 
   @override
   String get upgradeYourPlan => 'Надоградите свој план';
@@ -9143,8 +8978,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Достигли сте свој месечни лимит. Надоградите да наставите да разговарате са Omi без ограничења.';
+  String get chatQuotaExceededReply => 'Достигли сте свој месечни лимит. Надоградите да наставите да разговарате са Omi без ограничења.';
 
   @override
   String get voiceResponseAudio => 'Прочитај Omi одговор наглас';
@@ -9175,4 +9009,25 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Додај задатак';
+
+  @override
+  String get quickActionAskOmiAnything => 'Питајте Omi шта год желите';
+
+  @override
+  String get quickActionVoiceMode => 'Гласовни режим';
+
+  @override
+  String get quickActionMute => 'Искључи звук';
+
+  @override
+  String get quickActionUnmute => 'Укључи звук';
+
+  @override
+  String get quickActionConnectDevice => 'Повежи уређај';
+
+  @override
+  String get quickActionDeviceSettings => 'Подешавања уређаја';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -24,8 +24,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteConversationTitle => 'Ta bort konversation?';
 
   @override
-  String get deleteConversationMessage =>
-      'Detta kommer också att radera tillhörande minnen, uppgifter och ljudfiler. Denna åtgärd kan inte ångras.';
+  String get deleteConversationMessage => 'Detta kommer också att radera tillhörande minnen, uppgifter och ljudfiler. Denna åtgärd kan inte ångras.';
 
   @override
   String get confirm => 'Bekräfta';
@@ -146,8 +145,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleting => 'Tar bort...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Slutför autentiseringen i din webbläsare. När du är klar, återvänd till appen.';
+  String get pleaseCompleteAuthentication => 'Slutför autentiseringen i din webbläsare. När du är klar, återvänd till appen.';
 
   @override
   String get failedToStartAuthentication => 'Det gick inte att starta autentisering';
@@ -228,8 +226,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noStarredConversations => 'Inga stjärnmärkta konversationer';
 
   @override
-  String get starConversationHint =>
-      'För att stjärnmärka en konversation, öppna den och tryck på stjärnikonen i sidhuvudet.';
+  String get starConversationHint => 'För att stjärnmärka en konversation, öppna den och tryck på stjärnikonen i sidhuvudet.';
 
   @override
   String get searchConversations => 'Sök konversationer...';
@@ -356,19 +353,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get appsDisconnected => 'Dina appar och integrationer kommer att kopplas från omedelbart.';
 
   @override
-  String get exportBeforeDelete =>
-      'Du kan exportera dina data innan du tar bort ditt konto, men när det väl är borttaget kan det inte återställas.';
+  String get exportBeforeDelete => 'Du kan exportera dina data innan du tar bort ditt konto, men när det väl är borttaget kan det inte återställas.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Jag förstår att borttagning av mitt konto är permanent och att all data, inklusive minnen och konversationer, kommer att förloras och inte kan återställas.';
+  String get deleteAccountCheckbox => 'Jag förstår att borttagning av mitt konto är permanent och att all data, inklusive minnen och konversationer, kommer att förloras och inte kan återställas.';
 
   @override
   String get areYouSure => 'Är du säker?';
 
   @override
-  String get deleteAccountFinal =>
-      'Denna åtgärd är oåterkallelig och kommer permanent ta bort ditt konto och all associerad data. Är du säker på att du vill fortsätta?';
+  String get deleteAccountFinal => 'Denna åtgärd är oåterkallelig och kommer permanent ta bort ditt konto och all associerad data. Är du säker på att du vill fortsätta?';
 
   @override
   String get deleteNow => 'Ta bort nu';
@@ -377,8 +371,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get goBack => 'Gå tillbaka';
 
   @override
-  String get checkBoxToConfirm =>
-      'Markera kryssrutan för att bekräfta att du förstår att borttagning av ditt konto är permanent och oåterkalleligt.';
+  String get checkBoxToConfirm => 'Markera kryssrutan för att bekräfta att du förstår att borttagning av ditt konto är permanent och oåterkalleligt.';
 
   @override
   String get profile => 'Profil';
@@ -456,8 +449,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get yourPrivacyYourControl => 'Din integritet, din kontroll';
 
   @override
-  String get privacyIntro =>
-      'På Omi är vi engagerade i att skydda din integritet. Denna sida låter dig kontrollera hur din data lagras och används.';
+  String get privacyIntro => 'På Omi är vi engagerade i att skydda din integritet. Denna sida låter dig kontrollera hur din data lagras och används.';
 
   @override
   String get learnMore => 'Läs mer...';
@@ -466,15 +458,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dataProtectionLevel => 'Dataskyddsnivå';
 
   @override
-  String get dataProtectionDesc =>
-      'Din data är säkrad som standard med stark kryptering. Granska dina inställningar och framtida integritetsalternativ nedan.';
+  String get dataProtectionDesc => 'Din data är säkrad som standard med stark kryptering. Granska dina inställningar och framtida integritetsalternativ nedan.';
 
   @override
   String get appAccess => 'Appåtkomst';
 
   @override
-  String get appAccessDesc =>
-      'Följande appar kan komma åt din data. Tryck på en app för att hantera dess behörigheter.';
+  String get appAccessDesc => 'Följande appar kan komma åt din data. Tryck på en app för att hantera dess behörigheter.';
 
   @override
   String get noAppsExternalAccess => 'Inga installerade appar har extern åtkomst till din data.';
@@ -531,22 +521,19 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Din Omi har kopplats från 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Enhet bortkopplad. Gå till Inställningar > Bluetooth och glöm enheten för att slutföra bortkopplingen.';
+  String get deviceUnpairedMessage => 'Enhet bortkopplad. Gå till Inställningar > Bluetooth och glöm enheten för att slutföra bortkopplingen.';
 
   @override
   String get unpairDialogTitle => 'Koppla bort enhet';
 
   @override
-  String get unpairDialogMessage =>
-      'Detta kommer att koppla bort enheten så att den kan anslutas till en annan telefon. Du behöver gå till Inställningar > Bluetooth och glömma enheten för att slutföra processen.';
+  String get unpairDialogMessage => 'Detta kommer att koppla bort enheten så att den kan anslutas till en annan telefon. Du behöver gå till Inställningar > Bluetooth och glömma enheten för att slutföra processen.';
 
   @override
   String get deviceNotConnected => 'Enheten är inte ansluten';
 
   @override
-  String get connectDeviceMessage =>
-      'Anslut din Omi-enhet för att få tillgång till\nenhetsinställningar och anpassning';
+  String get connectDeviceMessage => 'Anslut din Omi-enhet för att få tillgång till\nenhetsinställningar och anpassning';
 
   @override
   String get deviceInfoSection => 'Enhetsinformation';
@@ -561,8 +548,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get v2Undetected => 'V2 ej upptäckt';
 
   @override
-  String get v2UndetectedMessage =>
-      'Vi ser att du antingen har en V1-enhet eller att din enhet inte är ansluten. SD-kortsfunktionalitet är endast tillgänglig för V2-enheter.';
+  String get v2UndetectedMessage => 'Vi ser att du antingen har en V1-enhet eller att din enhet inte är ansluten. SD-kortsfunktionalitet är endast tillgänglig för V2-enheter.';
 
   @override
   String get endConversation => 'Avsluta konversation';
@@ -694,8 +680,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noActivityYet => 'Ingen aktivitet ännu';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Starta en konversation med Omi\nför att se dina användningsinsikter här.';
+  String get startConversationToSeeInsights => 'Starta en konversation med Omi\nför att se dina användningsinsikter här.';
 
   @override
   String get listening => 'Lyssnar';
@@ -837,8 +822,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Ta bort kunskapsgraf?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Detta kommer att ta bort all härledd kunskapsgrafsdata (noder och kopplingar). Dina ursprungliga minnen förblir säkra. Grafen kommer att byggas om över tid eller vid nästa begäran.';
+  String get deleteKnowledgeGraphMessage => 'Detta kommer att ta bort all härledd kunskapsgrafsdata (noder och kopplingar). Dina ursprungliga minnen förblir säkra. Grafen kommer att byggas om över tid eller vid nästa begäran.';
 
   @override
   String get knowledgeGraphDeleted => 'Kunskapsgraf raderad';
@@ -1081,8 +1065,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get needYourPermission => 'Vi behöver ditt tillstånd';
 
   @override
-  String get alreadyGavePermission =>
-      'Du har redan gett oss tillstånd att spara dina inspelningar. Här är en påminnelse om varför vi behöver det:';
+  String get alreadyGavePermission => 'Du har redan gett oss tillstånd att spara dina inspelningar. Här är en påminnelse om varför vi behöver det:';
 
   @override
   String get wouldLikePermission => 'Vi skulle vilja ha ditt tillstånd att spara dina röstinspelningar. Här är varför:';
@@ -1091,26 +1074,22 @@ class AppLocalizationsSv extends AppLocalizations {
   String get improveSpeechProfile => 'Förbättra din röstprofil';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Vi använder inspelningar för att ytterligare träna och förbättra din personliga röstprofil.';
+  String get improveSpeechProfileDesc => 'Vi använder inspelningar för att ytterligare träna och förbättra din personliga röstprofil.';
 
   @override
   String get trainFamilyProfiles => 'Träna profiler för vänner och familj';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Dina inspelningar hjälper oss att känna igen och skapa profiler för dina vänner och familj.';
+  String get trainFamilyProfilesDesc => 'Dina inspelningar hjälper oss att känna igen och skapa profiler för dina vänner och familj.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Förbättra transkriptionsnoggrannhet';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'När vår modell förbättras kan vi ge bättre transkriptionsresultat för dina inspelningar.';
+  String get enhanceTranscriptAccuracyDesc => 'När vår modell förbättras kan vi ge bättre transkriptionsresultat för dina inspelningar.';
 
   @override
-  String get legalNotice =>
-      'Juridiskt meddelande: Lagligheten av att spela in och lagra röstdata kan variera beroende på var du befinner dig och hur du använder denna funktion. Det är ditt ansvar att säkerställa efterlevnad av lokala lagar och förordningar.';
+  String get legalNotice => 'Juridiskt meddelande: Lagligheten av att spela in och lagra röstdata kan variera beroende på var du befinner dig och hur du använder denna funktion. Det är ditt ansvar att säkerställa efterlevnad av lokala lagar och förordningar.';
 
   @override
   String get alreadyAuthorized => 'Redan auktoriserad';
@@ -1188,8 +1167,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showEventsNoParticipants => 'Visa händelser utan deltagare';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'När det är aktiverat visar Kommande händelser utan deltagare eller en videolänk.';
+  String get showEventsNoParticipantsDesc => 'När det är aktiverat visar Kommande händelser utan deltagare eller en videolänk.';
 
   @override
   String get yourMeetings => 'Dina möten';
@@ -1230,8 +1208,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noProjectsInWorkspace => 'Inga projekt hittades i denna arbetsyta';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Välj hur länge du vill vänta i tystnad innan en konversation avslutas automatiskt:';
+  String get conversationTimeoutDesc => 'Välj hur länge du vill vänta i tystnad innan en konversation avslutas automatiskt:';
 
   @override
   String get timeout2Minutes => '2 minuter';
@@ -1275,8 +1252,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Berätta ditt primära språk';
 
   @override
-  String get languageForTranscription =>
-      'Ställ in ditt språk för skarpare transkriptioner och en personlig upplevelse.';
+  String get languageForTranscription => 'Ställ in ditt språk för skarpare transkriptioner och en personlig upplevelse.';
 
   @override
   String get singleLanguageModeInfo => 'Enspråksläge är aktiverat. Översättning är inaktiverad för högre noggrannhet.';
@@ -1359,8 +1335,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get defaultRepository => 'Standardrepository';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Välj en standardrepository för att skapa ärenden. Du kan fortfarande ange en annan repository när du skapar ärenden.';
+  String get selectDefaultRepoDesc => 'Välj en standardrepository för att skapa ärenden. Du kan fortfarande ange en annan repository när du skapar ärenden.';
 
   @override
   String get noReposFound => 'Inga repositories hittades';
@@ -1735,8 +1710,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get enableBluetooth => 'Aktivera Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi behöver Bluetooth för att ansluta till din bärbara enhet. Aktivera Bluetooth och försök igen.';
+  String get bluetoothNeeded => 'Omi behöver Bluetooth för att ansluta till din bärbara enhet. Aktivera Bluetooth och försök igen.';
 
   @override
   String get contactSupport => 'Kontakta support?';
@@ -1769,26 +1743,22 @@ class AppLocalizationsSv extends AppLocalizations {
   String get locationServiceDisabled => 'Platstjänst inaktiverad';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Platstjänsten är inaktiverad. Gå till Inställningar > Integritet och säkerhet > Platstjänster och aktivera den';
+  String get locationServiceDisabledDesc => 'Platstjänsten är inaktiverad. Gå till Inställningar > Integritet och säkerhet > Platstjänster och aktivera den';
 
   @override
   String get backgroundLocationDenied => 'Bakgrundsplatsåtkomst nekad';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Gå till enhetsinställningar och ställ in platsbehörighet till \"Tillåt alltid\"';
+  String get backgroundLocationDeniedDesc => 'Gå till enhetsinställningar och ställ in platsbehörighet till \"Tillåt alltid\"';
 
   @override
   String get lovingOmi => 'Älskar du Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Hjälp oss att nå fler människor genom att lämna en recension i App Store. Din återkoppling betyder världen för oss!';
+  String get leaveReviewIos => 'Hjälp oss att nå fler människor genom att lämna en recension i App Store. Din återkoppling betyder världen för oss!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Hjälp oss att nå fler människor genom att lämna en recension i Google Play Store. Din återkoppling betyder världen för oss!';
+  String get leaveReviewAndroid => 'Hjälp oss att nå fler människor genom att lämna en recension i Google Play Store. Din återkoppling betyder världen för oss!';
 
   @override
   String get rateOnAppStore => 'Betygsätt i App Store';
@@ -1821,15 +1791,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get connectionError => 'Anslutningsfel';
 
   @override
-  String get connectionErrorDesc =>
-      'Det gick inte att ansluta till servern. Kontrollera din internetanslutning och försök igen.';
+  String get connectionErrorDesc => 'Det gick inte att ansluta till servern. Kontrollera din internetanslutning och försök igen.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Ogiltig inspelning upptäckt';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Det verkar som det finns flera talare i inspelningen. Se till att du är på en tyst plats och försök igen.';
+  String get multipleSpeakersDesc => 'Det verkar som det finns flera talare i inspelningen. Se till att du är på en tyst plats och försök igen.';
 
   @override
   String get tooShortDesc => 'Det finns inte tillräckligt med tal upptäckt. Tala mer och försök igen.';
@@ -1841,8 +1809,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get areYouThere => 'Är du där?';
 
   @override
-  String get noSpeechDesc =>
-      'Vi kunde inte upptäcka något tal. Se till att tala i minst 10 sekunder och inte mer än 3 minuter.';
+  String get noSpeechDesc => 'Vi kunde inte upptäcka något tal. Se till att tala i minst 10 sekunder och inte mer än 3 minuter.';
 
   @override
   String get connectionLost => 'Anslutning förlorad';
@@ -1863,8 +1830,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get permissionsRequired => 'Behörigheter krävs';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Denna app behöver Bluetooth- och platsbehörigheter för att fungera korrekt. Aktivera dem i inställningarna.';
+  String get permissionsRequiredDesc => 'Denna app behöver Bluetooth- och platsbehörigheter för att fungera korrekt. Aktivera dem i inställningarna.';
 
   @override
   String get openSettings => 'Öppna inställningar';
@@ -1894,8 +1860,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Din AI-följeslagare';
 
   @override
-  String get captureEveryMoment =>
-      'Fånga varje ögonblick. Få AI-drivna\nsammanfattningar. Ta aldrig anteckningar igen.';
+  String get captureEveryMoment => 'Fånga varje ögonblick. Få AI-drivna\nsammanfattningar. Ta aldrig anteckningar igen.';
 
   @override
   String get appleWatchSetup => 'Apple Watch-konfiguration';
@@ -1907,12 +1872,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get microphonePermission => 'Mikrofonbehörighet';
 
   @override
-  String get permissionGrantedNow =>
-      'Behörighet beviljad! Nu:\n\nÖppna Omi-appen på din klocka och tryck på \"Fortsätt\" nedan';
+  String get permissionGrantedNow => 'Behörighet beviljad! Nu:\n\nÖppna Omi-appen på din klocka och tryck på \"Fortsätt\" nedan';
 
   @override
-  String get needMicrophonePermission =>
-      'Vi behöver mikrofonbehörighet.\n\n1. Tryck på \"Bevilja behörighet\"\n2. Tillåt på din iPhone\n3. Klockappen stängs\n4. Öppna igen och tryck på \"Fortsätt\"';
+  String get needMicrophonePermission => 'Vi behöver mikrofonbehörighet.\n\n1. Tryck på \"Bevilja behörighet\"\n2. Tillåt på din iPhone\n3. Klockappen stängs\n4. Öppna igen och tryck på \"Fortsätt\"';
 
   @override
   String get grantPermissionButton => 'Bevilja behörighet';
@@ -1921,15 +1884,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get needHelp => 'Behöver du hjälp?';
 
   @override
-  String get troubleshootingSteps =>
-      'Felsökning:\n\n1. Se till att Omi är installerat på din klocka\n2. Öppna Omi-appen på din klocka\n3. Leta efter behörighetspopupen\n4. Tryck på \"Tillåt\" när du uppmanas\n5. Appen på din klocka stängs - öppna den igen\n6. Kom tillbaka och tryck på \"Fortsätt\" på din iPhone';
+  String get troubleshootingSteps => 'Felsökning:\n\n1. Se till att Omi är installerat på din klocka\n2. Öppna Omi-appen på din klocka\n3. Leta efter behörighetspopupen\n4. Tryck på \"Tillåt\" när du uppmanas\n5. Appen på din klocka stängs - öppna den igen\n6. Kom tillbaka och tryck på \"Fortsätt\" på din iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Inspelning startade!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Behörighet har inte beviljats ännu. Se till att du tillät mikrofonåtkomst och öppnade appen igen på din klocka.';
+  String get permissionNotGrantedYet => 'Behörighet har inte beviljats ännu. Se till att du tillät mikrofonåtkomst och öppnade appen igen på din klocka.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2026,8 +1987,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Redo för åtgärder';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Din AI kommer automatiskt att extrahera uppgifter och att-göra-saker från dina konversationer. De kommer att visas här när de skapas.';
+  String get welcomeActionItemsDescription => 'Din AI kommer automatiskt att extrahera uppgifter och att-göra-saker från dina konversationer. De kommer att visas här när de skapas.';
 
   @override
   String get autoExtractionFeature => 'Automatiskt extraherat från konversationer';
@@ -2223,15 +2183,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'TAL OCH TRANSKRIPTION';
 
   @override
-  String get languageSettingsHelperText =>
-      'Appspråk ändrar menyer och knappar. Talspråk påverkar hur dina inspelningar transkriberas.';
+  String get languageSettingsHelperText => 'Appspråk ändrar menyer och knappar. Talspråk påverkar hur dina inspelningar transkriberas.';
 
   @override
   String get translationNotice => 'Översättningsmeddelande';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi översätter konversationer till ditt primära språk. Uppdatera det när som helst i Inställningar → Profiler.';
+  String get translationNoticeMessage => 'Omi översätter konversationer till ditt primära språk. Uppdatera det när som helst i Inställningar → Profiler.';
 
   @override
   String get pleaseCheckInternetConnection => 'Kontrollera din internetanslutning och försök igen';
@@ -2386,8 +2344,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Koppla bort enhet';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Detta kommer att koppla bort enheten så att den kan anslutas till en annan telefon. Du måste gå till Inställningar > Bluetooth och glömma enheten för att slutföra processen.';
+  String get unpairDeviceDialogMessage => 'Detta kommer att koppla bort enheten så att den kan anslutas till en annan telefon. Du måste gå till Inställningar > Bluetooth och glömma enheten för att slutföra processen.';
 
   @override
   String get unpair => 'Koppla bort';
@@ -2553,8 +2510,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get howDoesItWork => 'Hur fungerar det?';
 
   @override
-  String get sdCardSyncDescription =>
-      'SD-kortssynkronisering kommer att importera dina minnen från SD-kortet till appen';
+  String get sdCardSyncDescription => 'SD-kortssynkronisering kommer att importera dina minnen från SD-kortet till appen';
 
   @override
   String get checksForAudioFiles => 'Kontrollerar ljudfiler på SD-kortet';
@@ -2569,8 +2525,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get youreAllSet => 'Du är redo!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Välkommen till Omi! Din AI-följeslagare är redo att hjälpa dig med samtal, uppgifter och mer.';
+  String get welcomeToOmiDescription => 'Välkommen till Omi! Din AI-följeslagare är redo att hjälpa dig med samtal, uppgifter och mer.';
 
   @override
   String get startUsingOmi => 'Börja använda Omi';
@@ -2706,8 +2661,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noTasksYet => 'Inga uppgifter ännu';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Uppgifter från dina konversationer visas här.\nKlicka på Skapa för att lägga till en manuellt.';
+  String get tasksFromConversationsWillAppear => 'Uppgifter från dina konversationer visas här.\nKlicka på Skapa för att lägga till en manuellt.';
 
   @override
   String get monthJan => 'jan';
@@ -2764,8 +2718,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteActionItem => 'Radera åtgärd';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Är du säker på att du vill radera denna åtgärd? Denna handling kan inte ångras.';
+  String get deleteActionItemConfirmation => 'Är du säker på att du vill radera denna åtgärd? Denna handling kan inte ångras.';
 
   @override
   String get enterActionItemDescription => 'Ange beskrivning av åtgärd...';
@@ -2840,15 +2793,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get chatPrompt => 'Chattuppmaning';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Du är en fantastisk app, ditt jobb är att svara på användarfrågor och få dem att må bra...';
+  String get chatPromptPlaceholder => 'Du är en fantastisk app, ditt jobb är att svara på användarfrågor och få dem att må bra...';
 
   @override
   String get conversationPrompt => 'Samtalsprompt';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Du är en fantastisk app, du kommer att få en transkription och sammanfattning av ett samtal...';
+  String get conversationPromptPlaceholder => 'Du är en fantastisk app, du kommer att få en transkription och sammanfattning av ett samtal...';
 
   @override
   String get notificationScopes => 'Aviseringsomfång';
@@ -2860,8 +2811,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get makeMyAppPublic => 'Gör min app offentlig';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Genom att skicka in denna app godkänner jag Omi AI:s användarvillkor och sekretesspolicy';
+  String get submitAppTermsAgreement => 'Genom att skicka in denna app godkänner jag Omi AI:s användarvillkor och sekretesspolicy';
 
   @override
   String get submitApp => 'Skicka in app';
@@ -2876,12 +2826,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get submitAppQuestion => 'Skicka in app?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Din app kommer att granskas och göras offentlig. Du kan börja använda den omedelbart, även under granskningen!';
+  String get submitAppPublicDescription => 'Din app kommer att granskas och göras offentlig. Du kan börja använda den omedelbart, även under granskningen!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Din app kommer att granskas och göras tillgänglig för dig privat. Du kan börja använda den omedelbart, även under granskningen!';
+  String get submitAppPrivateDescription => 'Din app kommer att granskas och göras tillgänglig för dig privat. Du kan börja använda den omedelbart, även under granskningen!';
 
   @override
   String get startEarning => 'Börja tjäna! 💰';
@@ -2905,22 +2853,19 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dataAccessNotice => 'Meddelande om dataåtkomst';
 
   @override
-  String get dataAccessWarning =>
-      'Denna app kommer att få åtkomst till dina data. Omi AI är inte ansvarig för hur dina data används, modifieras eller raderas av denna app';
+  String get dataAccessWarning => 'Denna app kommer att få åtkomst till dina data. Omi AI är inte ansvarig för hur dina data används, modifieras eller raderas av denna app';
 
   @override
   String get installApp => 'Installera app';
 
   @override
-  String get betaTesterNotice =>
-      'Du är betatestare för denna app. Den är inte offentlig ännu. Den blir offentlig när den godkänns.';
+  String get betaTesterNotice => 'Du är betatestare för denna app. Den är inte offentlig ännu. Den blir offentlig när den godkänns.';
 
   @override
   String get appUnderReviewOwner => 'Din app granskas och är bara synlig för dig. Den blir offentlig när den godkänns.';
 
   @override
-  String get appRejectedNotice =>
-      'Din app har avvisats. Uppdatera appens detaljer och skicka in den igen för granskning.';
+  String get appRejectedNotice => 'Din app har avvisats. Uppdatera appens detaljer och skicka in den igen för granskning.';
 
   @override
   String get setupSteps => 'Installationssteg';
@@ -2982,8 +2927,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get descriptionLabel => 'Beskrivning';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Min fantastiska app är en fantastisk app som gör fantastiska saker. Det är den bästa appen!';
+  String get appDescriptionPlaceholder => 'Min fantastiska app är en fantastisk app som gör fantastiska saker. Det är den bästa appen!';
 
   @override
   String get pleaseProvideValidDescription => 'Ange en giltig beskrivning';
@@ -3135,8 +3079,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get microphonePermissionRequired => 'Mikrofontillstånd krävs för röstinspelning.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofontillstånd nekat. Ge tillstånd i Systeminställningar > Integritet och säkerhet > Mikrofon.';
+  String get microphonePermissionDenied => 'Mikrofontillstånd nekat. Ge tillstånd i Systeminställningar > Integritet och säkerhet > Mikrofon.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3295,8 +3238,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get createMemory => 'Skapa minne';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Är du säker på att du vill ta bort detta minne? Denna åtgärd kan inte ångras.';
+  String get deleteMemoryConfirmation => 'Är du säker på att du vill ta bort detta minne? Denna åtgärd kan inte ångras.';
 
   @override
   String get makePrivate => 'Gör privat';
@@ -3370,8 +3312,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get whatWeCollect => 'Vad vi samlar in';
 
   @override
-  String get dataCollectionMessage =>
-      'Genom att fortsätta kommer dina konversationer, inspelningar och personlig information att lagras säkert på våra servrar för att tillhandahålla AI-drivna insikter och aktivera alla appfunktioner.';
+  String get dataCollectionMessage => 'Genom att fortsätta kommer dina konversationer, inspelningar och personlig information att lagras säkert på våra servrar för att tillhandahålla AI-drivna insikter och aktivera alla appfunktioner.';
 
   @override
   String get dataProtection => 'Dataskydd';
@@ -3404,8 +3345,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Namnet måste vara minst 2 tecken';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Berätta för oss hur du vill bli tilltalad. Detta hjälper till att personalisera din Omi-upplevelse.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Berätta för oss hur du vill bli tilltalad. Detta hjälper till att personalisera din Omi-upplevelse.';
 
   @override
   String charactersCount(int count) {
@@ -3422,8 +3362,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get recordAudioConversations => 'Spela in ljudsamtal';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi behöver mikrofonåtkomst för att spela in dina samtal och tillhandahålla transkriptioner.';
+  String get microphoneAccessDescription => 'Omi behöver mikrofonåtkomst för att spela in dina samtal och tillhandahålla transkriptioner.';
 
   @override
   String get screenRecording => 'Skärminspelning';
@@ -3432,8 +3371,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Fånga systemljud från möten';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi behöver tillstånd för skärminspelning för att fånga systemljud från dina webbläsarbaserade möten.';
+  String get screenRecordingDescription => 'Omi behöver tillstånd för skärminspelning för att fånga systemljud från dina webbläsarbaserade möten.';
 
   @override
   String get accessibility => 'Tillgänglighet';
@@ -3442,8 +3380,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Upptäck webbläsarbaserade möten';
 
   @override
-  String get accessibilityDescription =>
-      'Omi behöver tillgänglighetstillstånd för att upptäcka när du ansluter till Zoom-, Meet- eller Teams-möten i din webbläsare.';
+  String get accessibilityDescription => 'Omi behöver tillgänglighetstillstånd för att upptäcka när du ansluter till Zoom-, Meet- eller Teams-möten i din webbläsare.';
 
   @override
   String get pleaseWait => 'Vänta...';
@@ -3512,12 +3449,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get exportAllConversationsToJson => 'Exportera alla dina konversationer till en JSON-fil.';
 
   @override
-  String get conversationsExportStarted =>
-      'Export av konversationer startad. Detta kan ta några sekunder, vänligen vänta.';
+  String get conversationsExportStarted => 'Export av konversationer startad. Detta kan ta några sekunder, vänligen vänta.';
 
   @override
-  String get mcpDescription =>
-      'För att ansluta Omi till andra applikationer för att läsa, söka och hantera dina minnen och konversationer. Skapa en nyckel för att komma igång.';
+  String get mcpDescription => 'För att ansluta Omi till andra applikationer för att läsa, söka och hantera dina minnen och konversationer. Skapa en nyckel för att komma igång.';
 
   @override
   String get apiKeys => 'API-nycklar';
@@ -3558,8 +3493,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Diagnostisk status för transkriptionstjänsten';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Aktivera detaljerade diagnostiska meddelanden från transkriptionstjänsten';
+  String get enableDetailedDiagnosticMessages => 'Aktivera detaljerade diagnostiska meddelanden från transkriptionstjänsten';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Skapa och tagga nya talare automatiskt';
@@ -3589,8 +3523,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get auto => 'Automatisk';
 
   @override
-  String get noSummaryForApp =>
-      'Ingen sammanfattning tillgänglig för denna app. Prova en annan app för bättre resultat.';
+  String get noSummaryForApp => 'Ingen sammanfattning tillgänglig för denna app. Prova en annan app för bättre resultat.';
 
   @override
   String get tryAnotherApp => 'Prova en annan app';
@@ -3627,8 +3560,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Låt Omi automatiskt välja den bästa appen';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Är du säker på att du vill radera den här konversationen? Denna åtgärd kan inte ångras.';
+  String get deleteConversationConfirmation => 'Är du säker på att du vill radera den här konversationen? Denna åtgärd kan inte ångras.';
 
   @override
   String get conversationDeleted => 'Konversation raderad';
@@ -3676,8 +3608,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Förbereder systemljudupptagning';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Klicka på knappen för att fånga ljud för livetranskriptioner, AI-insikter och automatisk sparning.';
+  String get clickTheButtonToCaptureAudio => 'Klicka på knappen för att fånga ljud för livetranskriptioner, AI-insikter och automatisk sparning.';
 
   @override
   String get reconnecting => 'Återansluter...';
@@ -3904,8 +3835,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Ta bort kunskapsgraf?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Detta raderar all härledd kunskapsgrafdata. Dina ursprungliga minnen förblir säkra.';
+  String get deleteKnowledgeGraphWarning => 'Detta raderar all härledd kunskapsgrafdata. Dina ursprungliga minnen förblir säkra.';
 
   @override
   String get connectOmiWithAI => 'Anslut Omi till AI-assistenter';
@@ -3947,8 +3877,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Villkor och Integritetspolicy';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Hjälper till att diagnostisera problem. Raderas automatiskt efter 3 dagar.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Hjälper till att diagnostisera problem. Raderas automatiskt efter 3 dagar.';
 
   @override
   String get manageYourApp => 'Hantera din app';
@@ -3963,8 +3892,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get updateAppQuestion => 'Uppdatera app?';
 
   @override
-  String get updateAppConfirmation =>
-      'Är du säker på att du vill uppdatera din app? Ändringarna visas efter granskning av vårt team.';
+  String get updateAppConfirmation => 'Är du säker på att du vill uppdatera din app? Ändringarna visas efter granskning av vårt team.';
 
   @override
   String get updateApp => 'Uppdatera app';
@@ -3994,8 +3922,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get no => 'Nej';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Prenumeration avbruten. Den förblir aktiv till slutet av den aktuella faktureringsperioden.';
+  String get subscriptionCancelledSuccessfully => 'Prenumeration avbruten. Den förblir aktiv till slutet av den aktuella faktureringsperioden.';
 
   @override
   String get failedToCancelSubscription => 'Det gick inte att avbryta prenumerationen. Försök igen.';
@@ -4031,8 +3958,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Avbryt prenumeration?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Är du säker på att du vill avbryta din prenumeration? Du kommer att ha tillgång till slutet av din nuvarande faktureringsperiod.';
+  String get cancelSubscriptionConfirmation => 'Är du säker på att du vill avbryta din prenumeration? Du kommer att ha tillgång till slutet av din nuvarande faktureringsperiod.';
 
   @override
   String get cancelSubscriptionButton => 'Avbryt prenumeration';
@@ -4041,12 +3967,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get cancelling => 'Avbryter...';
 
   @override
-  String get betaTesterMessage =>
-      'Du är betatestare för denna app. Den är inte offentlig ännu. Den blir offentlig efter godkännande.';
+  String get betaTesterMessage => 'Du är betatestare för denna app. Den är inte offentlig ännu. Den blir offentlig efter godkännande.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Din app granskas och är endast synlig för dig. Den blir offentlig efter godkännande.';
+  String get appUnderReviewMessage => 'Din app granskas och är endast synlig för dig. Den blir offentlig efter godkännande.';
 
   @override
   String get appRejectedMessage => 'Din app har avvisats. Uppdatera uppgifterna och skicka in igen för granskning.';
@@ -4103,8 +4027,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get issueActivatingApp => 'Det uppstod ett problem vid aktivering av denna app. Försök igen.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Denna app kommer att få tillgång till dina data. Omi AI ansvarar inte för hur dina data används av tredjepartsappar.';
+  String get dataAccessNoticeDescription => 'Denna app kommer att få tillgång till dina data. Omi AI ansvarar inte för hur dina data används av tredjepartsappar.';
 
   @override
   String get copyUrl => 'Kopiera URL';
@@ -4192,8 +4115,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get omiApiKeys => 'Omi API-nycklar';
 
   @override
-  String get apiKeysDescription =>
-      'API-nycklar används för autentisering när din app kommunicerar med OMI-servern. De låter din applikation skapa minnen och få säker åtkomst till andra OMI-tjänster.';
+  String get apiKeysDescription => 'API-nycklar används för autentisering när din app kommunicerar med OMI-servern. De låter din applikation skapa minnen och få säker åtkomst till andra OMI-tjänster.';
 
   @override
   String get aboutOmiApiKeys => 'Om Omi API-nycklar';
@@ -4217,8 +4139,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Återkalla API-nyckel?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Denna åtgärd kan inte ångras. Alla applikationer som använder denna nyckel kommer inte längre att kunna komma åt API:et.';
+  String get revokeApiKeyWarning => 'Denna åtgärd kan inte ångras. Alla applikationer som använder denna nyckel kommer inte längre att kunna komma åt API:et.';
 
   @override
   String get revoke => 'Återkalla';
@@ -4316,8 +4237,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get externalAppAccess => 'Extern app-åtkomst';
 
   @override
-  String get externalAppAccessDescription =>
-      'Följande installerade appar har externa integrationer och kan komma åt dina data, såsom konversationer och minnen.';
+  String get externalAppAccessDescription => 'Följande installerade appar har externa integrationer och kan komma åt dina data, såsom konversationer och minnen.';
 
   @override
   String get noExternalAppsHaveAccess => 'Inga externa appar har åtkomst till dina data.';
@@ -4326,8 +4246,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maximal säkerhet (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-end-kryptering är guldstandarden för integritet. När det är aktiverat krypteras dina data på din enhet innan de skickas till våra servrar. Det betyder att ingen, inte ens Omi, kan komma åt ditt innehåll.';
+  String get e2eeDescription => 'End-to-end-kryptering är guldstandarden för integritet. När det är aktiverat krypteras dina data på din enhet innan de skickas till våra servrar. Det betyder att ingen, inte ens Omi, kan komma åt ditt innehåll.';
 
   @override
   String get importantTradeoffs => 'Viktiga avvägningar:';
@@ -4361,15 +4280,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get secureEncryption => 'Säker kryptering';
 
   @override
-  String get secureEncryptionDescription =>
-      'Dina data krypteras med en nyckel som är unik för dig på våra servrar, som finns på Google Cloud. Det betyder att ditt råa innehåll är otillgängligt för alla, inklusive Omi-personal eller Google, direkt från databasen.';
+  String get secureEncryptionDescription => 'Dina data krypteras med en nyckel som är unik för dig på våra servrar, som finns på Google Cloud. Det betyder att ditt råa innehåll är otillgängligt för alla, inklusive Omi-personal eller Google, direkt från databasen.';
 
   @override
   String get endToEndEncryption => 'End-to-end-kryptering';
 
   @override
-  String get e2eeCardDescription =>
-      'Aktivera för maximal säkerhet där endast du kan komma åt dina data. Tryck för att lära dig mer.';
+  String get e2eeCardDescription => 'Aktivera för maximal säkerhet där endast du kan komma åt dina data. Tryck för att lära dig mer.';
 
   @override
   String get dataAlwaysEncrypted => 'Oavsett nivå är dina data alltid krypterade i vila och under överföring.';
@@ -4440,8 +4357,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Få Omi Unlimited gratis genom att bidra med dina data för att träna AI-modeller.';
 
   @override
-  String get trainingDataBullets =>
-      '• Dina data hjälper till att förbättra AI-modeller\n• Endast icke-känsliga data delas\n• Helt transparent process';
+  String get trainingDataBullets => '• Dina data hjälper till att förbättra AI-modeller\n• Endast icke-känsliga data delas\n• Helt transparent process';
 
   @override
   String get learnMoreAtOmiTraining => 'Läs mer på omi.me/training';
@@ -4601,8 +4517,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Din integritet är viktig för oss';
 
   @override
-  String get privacyIntroText =>
-      'På Omi tar vi din integritet på största allvar. Vi vill vara transparenta om de uppgifter vi samlar in och hur vi använder dem. Här är vad du behöver veta:';
+  String get privacyIntroText => 'På Omi tar vi din integritet på största allvar. Vi vill vara transparenta om de uppgifter vi samlar in och hur vi använder dem. Här är vad du behöver veta:';
 
   @override
   String get whatWeTrack => 'Vad vi spårar';
@@ -4617,12 +4532,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get ourCommitment => 'Vårt åtagande';
 
   @override
-  String get commitmentText =>
-      'Vi förbinder oss att endast använda de uppgifter vi samlar in för att göra Omi till en bättre produkt för dig. Din integritet och ditt förtroende är av största vikt för oss.';
+  String get commitmentText => 'Vi förbinder oss att endast använda de uppgifter vi samlar in för att göra Omi till en bättre produkt för dig. Din integritet och ditt förtroende är av största vikt för oss.';
 
   @override
-  String get thankYouText =>
-      'Tack för att du är en uppskattad användare av Omi. Om du har frågor eller funderingar, kontakta oss gärna på team@basedhardware.com.';
+  String get thankYouText => 'Tack för att du är en uppskattad användare av Omi. Om du har frågor eller funderingar, kontakta oss gärna på team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi-synkroniseringsinställningar';
@@ -4631,8 +4544,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get enterHotspotCredentials => 'Ange din telefons hotspot-uppgifter';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi-synkronisering använder din telefon som hotspot. Hitta namnet och lösenordet i Inställningar > Internetdelning.';
+  String get wifiSyncUsesHotspot => 'WiFi-synkronisering använder din telefon som hotspot. Hitta namnet och lösenordet i Inställningar > Internetdelning.';
 
   @override
   String get hotspotNameSsid => 'Hotspotnamn (SSID)';
@@ -4667,8 +4579,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Kunde inte generera sammanfattning. Se till att du har samtal för den dagen.';
+  String get failedToGenerateSummaryCheckConversations => 'Kunde inte generera sammanfattning. Se till att du har samtal för den dagen.';
 
   @override
   String get summaryNotFound => 'Sammanfattning hittades inte';
@@ -4698,8 +4609,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Export startad. Detta kan ta några sekunder...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Detta kommer att radera alla härledda kunskapsgrafdata (noder och anslutningar). Dina ursprungliga minnen förblir säkra. Grafen kommer att byggas om över tid eller vid nästa begäran.';
+  String get knowledgeGraphDeleteDescription => 'Detta kommer att radera alla härledda kunskapsgrafdata (noder och anslutningar). Dina ursprungliga minnen förblir säkra. Grafen kommer att byggas om över tid eller vid nästa begäran.';
 
   @override
   String get configureDailySummaryDigest => 'Konfigurera din dagliga uppgiftssammanfattning';
@@ -4769,8 +4679,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Ta bort alla Limitless-konversationer?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Detta kommer permanent att radera alla konversationer importerade från Limitless. Denna åtgärd kan inte ångras.';
+  String get deleteAllLimitlessWarning => 'Detta kommer permanent att radera alla konversationer importerade från Limitless. Denna åtgärd kan inte ångras.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4826,8 +4735,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get howItWorksTitle => 'Hur fungerar det?';
 
   @override
-  String get howPeopleWorks =>
-      'När en person har skapats kan du gå till en konversationsutskrift och tilldela dem deras motsvarande segment, på så sätt kommer Omi att kunna känna igen deras tal också!';
+  String get howPeopleWorks => 'När en person har skapats kan du gå till en konversationsutskrift och tilldela dem deras motsvarande segment, på så sätt kommer Omi att kunna känna igen deras tal också!';
 
   @override
   String get tapToDelete => 'Tryck för att ta bort';
@@ -4853,8 +4761,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get privacyNotice => 'Sekretessmeddelande';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Inspelningar kan fånga andras röster. Se till att du har samtycke från alla deltagare innan du aktiverar.';
+  String get recordingsMayCaptureOthers => 'Inspelningar kan fånga andras röster. Se till att du har samtycke från alla deltagare innan du aktiverar.';
 
   @override
   String get enable => 'Aktivera';
@@ -4866,8 +4773,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get on => 'På';
 
   @override
-  String get storeAudioDescription =>
-      'Behåll alla ljudinspelningar lagrade lokalt på din telefon. När inaktiverad sparas endast misslyckade uppladdningar för att spara lagringsutrymme.';
+  String get storeAudioDescription => 'Behåll alla ljudinspelningar lagrade lokalt på din telefon. När inaktiverad sparas endast misslyckade uppladdningar för att spara lagringsutrymme.';
 
   @override
   String get enableLocalStorage => 'Aktivera lokal lagring';
@@ -4888,8 +4794,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get cloudStorageDialogMessage => 'Dina realtidsinspelningar lagras i privat molnlagring medan du talar.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Lagra dina realtidsinspelningar i privat molnlagring medan du talar. Ljud fångas upp och sparas säkert i realtid.';
+  String get storeAudioCloudDescription => 'Lagra dina realtidsinspelningar i privat molnlagring medan du talar. Ljud fångas upp och sparas säkert i realtid.';
 
   @override
   String get downloadingFirmware => 'Laddar ner firmware';
@@ -4942,8 +4847,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get payments => 'Betalningar';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Anslut en betalningsmetod nedan för att börja ta emot utbetalningar för dina appar.';
+  String get connectPaymentMethodInfo => 'Anslut en betalningsmetod nedan för att börja ta emot utbetalningar för dina appar.';
 
   @override
   String get selectedPaymentMethod => 'Vald betalningsmetod';
@@ -4970,8 +4874,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get monthlyPayouts => 'Månatliga utbetalningar';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Få månatliga utbetalningar direkt till ditt konto när du når \$10 i intäkter';
+  String get monthlyPayoutsDescription => 'Få månatliga utbetalningar direkt till ditt konto när du når \$10 i intäkter';
 
   @override
   String get secureAndReliable => 'Säkert och pålitligt';
@@ -4998,8 +4901,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get connectingYourStripeAccount => 'Ansluter ditt Stripe-konto';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Slutför Stripe-onboardingprocessen i din webbläsare. Denna sida uppdateras automatiskt när processen är klar.';
+  String get stripeOnboardingInstructions => 'Slutför Stripe-onboardingprocessen i din webbläsare. Denna sida uppdateras automatiskt när processen är klar.';
 
   @override
   String get failedTryAgain => 'Misslyckades? Försök igen';
@@ -5011,8 +4913,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get successfullyConnected => 'Framgångsrikt ansluten!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Ditt Stripe-konto är nu redo att ta emot betalningar. Du kan börja tjäna pengar på dina appförsäljningar direkt.';
+  String get stripeReadyForPayments => 'Ditt Stripe-konto är nu redo att ta emot betalningar. Du kan börja tjäna pengar på dina appförsäljningar direkt.';
 
   @override
   String get updateStripeDetails => 'Uppdatera Stripe-uppgifter';
@@ -5030,8 +4931,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Uppdatera dina PayPal-kontouppgifter';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Anslut ditt PayPal-konto för att börja ta emot betalningar för dina appar';
+  String get connectPayPalToReceivePayments => 'Anslut ditt PayPal-konto för att börja ta emot betalningar för dina appar';
 
   @override
   String get paypalEmail => 'PayPal-e-post';
@@ -5040,8 +4940,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me-länk';
 
   @override
-  String get stripeRecommendation =>
-      'Om Stripe är tillgängligt i ditt land rekommenderar vi starkt att använda det för snabbare och enklare utbetalningar.';
+  String get stripeRecommendation => 'Om Stripe är tillgängligt i ditt land rekommenderar vi starkt att använda det för snabbare och enklare utbetalningar.';
 
   @override
   String get updatePayPalDetails => 'Uppdatera PayPal-uppgifter';
@@ -5093,12 +4992,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Ytterligare röstprov borttaget';
 
   @override
-  String get consentDataMessage =>
-      'Genom att fortsätta kommer dina konversationer, inspelningar och personlig information att lagras säkert på våra servrar. Dina ljudinspelningar och transkriptioner behandlas av AI-tjänster från tredje part (inklusive Deepgram för transkription och OpenAI för analys) för att ge dig AI-drivna insikter och aktivera alla appfunktioner.';
+  String get consentDataMessage => 'Genom att fortsätta kommer dina konversationer, inspelningar och personlig information att lagras säkert på våra servrar. Dina ljudinspelningar och transkriptioner behandlas av AI-tjänster från tredje part (inklusive Deepgram för transkription och OpenAI för analys) för att ge dig AI-drivna insikter och aktivera alla appfunktioner.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Uppgifter från dina konversationer visas här.\nTryck på + för att skapa manuellt.';
+  String get tasksEmptyStateMessage => 'Uppgifter från dina konversationer visas här.\nTryck på + för att skapa manuellt.';
 
   @override
   String get clearChatAction => 'Rensa chatt';
@@ -5134,15 +5031,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Installera Omi på din\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'För att använda din Apple Watch med Omi måste du först installera Omi-appen på din klocka.';
+  String get installOmiOnAppleWatchDescription => 'För att använda din Apple Watch med Omi måste du först installera Omi-appen på din klocka.';
 
   @override
   String get openOmiOnAppleWatch => 'Öppna Omi på din\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi-appen är installerad på din Apple Watch. Öppna den och tryck på Start för att börja.';
+  String get openOmiOnAppleWatchDescription => 'Omi-appen är installerad på din Apple Watch. Öppna den och tryck på Start för att börja.';
 
   @override
   String get openWatchApp => 'Öppna Watch-appen';
@@ -5151,15 +5046,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Jag har installerat och öppnat appen';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Kan inte öppna Apple Watch-appen. Öppna Watch-appen manuellt på din Apple Watch och installera Omi från avsnittet \"Tillgängliga appar\".';
+  String get unableToOpenWatchApp => 'Kan inte öppna Apple Watch-appen. Öppna Watch-appen manuellt på din Apple Watch och installera Omi från avsnittet \"Tillgängliga appar\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch ansluten!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch är fortfarande inte nåbar. Se till att Omi-appen är öppen på din klocka.';
+  String get appleWatchNotReachable => 'Apple Watch är fortfarande inte nåbar. Se till att Omi-appen är öppen på din klocka.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5176,8 +5069,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get finishedConversation => 'Konversation avslutad?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Är du säker på att du vill stoppa inspelningen och sammanfatta konversationen nu?';
+  String get stopRecordingConfirmation => 'Är du säker på att du vill stoppa inspelningen och sammanfatta konversationen nu?';
 
   @override
   String get conversationEndsManually => 'Konversationen avslutas endast manuellt.';
@@ -5588,8 +5480,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get multipleSpeakersDetected => 'Flera talare upptäckta';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Det verkar som att det finns flera talare i inspelningen. Se till att du är på en lugn plats och försök igen.';
+  String get multipleSpeakersDescription => 'Det verkar som att det finns flera talare i inspelningen. Se till att du är på en lugn plats och försök igen.';
 
   @override
   String get invalidRecordingDetected => 'Ogiltig inspelning upptäckt';
@@ -5607,8 +5498,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get howToTakeGoodSample => 'Hur tar man ett bra prov?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Se till att du är på en lugn plats.\n2. Prata tydligt och naturligt.\n3. Se till att din enhet är i sin naturliga position på halsen.\n\nNär det är skapat kan du alltid förbättra det eller göra det igen.';
+  String get goodSampleInstructions => '1. Se till att du är på en lugn plats.\n2. Prata tydligt och naturligt.\n3. Se till att din enhet är i sin naturliga position på halsen.\n\nNär det är skapat kan du alltid förbättra det eller göra det igen.';
 
   @override
   String get noDeviceConnectedUseMic => 'Ingen enhet ansluten. Telefonens mikrofon kommer att användas.';
@@ -5671,12 +5561,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get howItWorks => 'Så fungerar det';
 
   @override
-  String get dailyScoreExplanation =>
-      'Din dagliga poäng baseras på uppgiftsslutförande. Slutför dina uppgifter för att förbättra din poäng!';
+  String get dailyScoreExplanation => 'Din dagliga poäng baseras på uppgiftsslutförande. Slutför dina uppgifter för att förbättra din poäng!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontrollera hur ofta Omi skickar dig proaktiva aviseringar och påminnelser.';
+  String get notificationFrequencyDescription => 'Kontrollera hur ofta Omi skickar dig proaktiva aviseringar och påminnelser.';
 
   @override
   String get sliderOff => 'Av';
@@ -5690,8 +5578,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Kunde inte generera sammanfattning. Se till att du har konversationer för den dagen.';
+  String get failedToGenerateSummary => 'Kunde inte generera sammanfattning. Se till att du har konversationer för den dagen.';
 
   @override
   String get recap => 'Sammanfattning';
@@ -5922,8 +5809,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get recordings => 'Inspelningar';
 
   @override
-  String get enableRemindersAccess =>
-      'Aktivera åtkomst till Påminnelser i Inställningar för att använda Apple Påminnelser';
+  String get enableRemindersAccess => 'Aktivera åtkomst till Påminnelser i Inställningar för att använda Apple Påminnelser';
 
   @override
   String todayAtTime(String time) {
@@ -5978,8 +5864,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL inte inställd';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Vänligen ställ in webhook URL i utvecklarinställningar för att använda denna funktion.';
+  String get setWebhookUrlInSettings => 'Vänligen ställ in webhook URL i utvecklarinställningar för att använda denna funktion.';
 
   @override
   String get sendWebUrl => 'Skicka webb-URL';
@@ -6053,8 +5938,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get cloudProvider => 'Molnleverantör';
 
   @override
-  String get premiumMinutesInfo =>
-      '1 200 premiumminuter/månad. Fliken På enheten erbjuder obegränsad gratis transkription.';
+  String get premiumMinutesInfo => '1 200 premiumminuter/månad. Fliken På enheten erbjuder obegränsad gratis transkription.';
 
   @override
   String get viewUsage => 'Visa användning';
@@ -6069,15 +5953,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get performanceWarning => 'Prestandavarning';
 
   @override
-  String get largeModelWarning =>
-      'Den här modellen är stor och kan krascha appen eller köras mycket långsamt på mobila enheter.\n\n\"small\" eller \"base\" rekommenderas.';
+  String get largeModelWarning => 'Den här modellen är stor och kan krascha appen eller köras mycket långsamt på mobila enheter.\n\n\"small\" eller \"base\" rekommenderas.';
 
   @override
   String get usingNativeIosSpeech => 'Använder inbyggd iOS-taligenkänning';
 
   @override
-  String get noModelDownloadRequired =>
-      'Din enhets inbyggda talmotor kommer att användas. Ingen modellnedladdning krävs.';
+  String get noModelDownloadRequired => 'Din enhets inbyggda talmotor kommer att användas. Ingen modellnedladdning krävs.';
 
   @override
   String get modelReady => 'Modellen är redo';
@@ -6134,8 +6016,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get batteryDrainSignificantly => 'Batteritömningen kommer att öka avsevärt.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1 200 premiumminuter/månad. Fliken På enheten erbjuder obegränsad gratis transkription. ';
+  String get premiumMinutesMonth => '1 200 premiumminuter/månad. Fliken På enheten erbjuder obegränsad gratis transkription. ';
 
   @override
   String get audioProcessedLocally => 'Ljud behandlas lokalt. Fungerar offline, mer privat, men använder mer batteri.';
@@ -6147,12 +6028,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get modelLabel => 'Modell';
 
   @override
-  String get modelTooLargeWarning =>
-      'Denna modell är stor och kan få appen att krascha eller köra mycket långsamt på mobila enheter.\n\nsmall eller base rekommenderas.';
+  String get modelTooLargeWarning => 'Denna modell är stor och kan få appen att krascha eller köra mycket långsamt på mobila enheter.\n\nsmall eller base rekommenderas.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Din enhets inbyggda talmotor kommer att användas. Ingen modellnedladdning krävs.';
+  String get nativeEngineNoDownload => 'Din enhets inbyggda talmotor kommer att användas. Ingen modellnedladdning krävs.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6188,8 +6067,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omis inbyggda livetranskription är optimerad för realtidskonversationer med automatisk talarigenkänning och diarisering.';
+  String get omiTranscriptionOptimized => 'Omis inbyggda livetranskription är optimerad för realtidskonversationer med automatisk talarigenkänning och diarisering.';
 
   @override
   String get reset => 'Återställ';
@@ -6409,8 +6287,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Bygger kunskapsgraf från minnen...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Din kunskapsgraf kommer att byggas automatiskt när du skapar nya minnen.';
+  String get knowledgeGraphWillBuildAutomatically => 'Din kunskapsgraf kommer att byggas automatiskt när du skapar nya minnen.';
 
   @override
   String get buildGraphButton => 'Bygg graf';
@@ -6712,8 +6589,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Laddar ned ljud från enhetens SD-kort';
 
   @override
-  String get transferRequiredDescription =>
-      'Denna inspelning är lagrad på enhetens SD-kort. Överför den till din telefon för att lyssna.';
+  String get transferRequiredDescription => 'Denna inspelning är lagrad på enhetens SD-kort. Överför den till din telefon för att lyssna.';
 
   @override
   String get cancelTransfer => 'Avbryt överföring';
@@ -6734,8 +6610,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get shareRecording => 'Dela inspelning';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Är du säker på att du vill ta bort denna inspelning permanent? Detta kan inte ångras.';
+  String get deleteRecordingConfirmation => 'Är du säker på att du vill ta bort denna inspelning permanent? Detta kan inte ångras.';
 
   @override
   String get recordingIdLabel => 'Inspelnings-ID';
@@ -6794,8 +6669,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get enableFastTransfer => 'Aktivera snabb överföring';
 
   @override
-  String get fastTransferDescription =>
-      'Snabb överföring använder WiFi för ~5x snabbare hastigheter. Din telefon ansluter tillfälligt till Omi-enhetens WiFi-nätverk under överföringen.';
+  String get fastTransferDescription => 'Snabb överföring använder WiFi för ~5x snabbare hastigheter. Din telefon ansluter tillfälligt till Omi-enhetens WiFi-nätverk under överföringen.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Internetåtkomst pausas under överföring';
@@ -6810,8 +6684,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get fiveTimesFaster => '5X SNABBARE';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Skapar en direkt WiFi-anslutning till din Omi-enhet. Din telefon kopplas tillfälligt från ditt vanliga WiFi under överföringen.';
+  String get fastTransferMethodDescription => 'Skapar en direkt WiFi-anslutning till din Omi-enhet. Din telefon kopplas tillfälligt från ditt vanliga WiFi under överföringen.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6820,8 +6693,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get bleSpeed => '~30 KB/s via BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Använder standard Bluetooth Low Energy-anslutning. Långsammare men påverkar inte din WiFi-anslutning.';
+  String get bluetoothMethodDescription => 'Använder standard Bluetooth Low Energy-anslutning. Långsammare men påverkar inte din WiFi-anslutning.';
 
   @override
   String get selected => 'Vald';
@@ -6859,12 +6731,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get appDeleteFailed => 'Kunde inte ta bort appen. Försök igen senare.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Appens synlighet har ändrats. Det kan ta några minuter innan ändringen syns.';
+  String get appVisibilityChangedSuccessfully => 'Appens synlighet har ändrats. Det kan ta några minuter innan ändringen syns.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Fel vid aktivering av appen. Om det är en integrationsapp, se till att konfigurationen är slutförd.';
+  String get errorActivatingAppIntegration => 'Fel vid aktivering av appen. Om det är en integrationsapp, se till att konfigurationen är slutförd.';
 
   @override
   String get errorUpdatingAppStatus => 'Ett fel uppstod vid uppdatering av appstatus.';
@@ -6944,8 +6814,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Namnet måste vara minst 3 tecken';
 
   @override
-  String get conversationPromptHint =>
-      't.ex., Extrahera åtgärdspunkter, fattade beslut och viktiga slutsatser från samtalet.';
+  String get conversationPromptHint => 't.ex., Extrahera åtgärdspunkter, fattade beslut och viktiga slutsatser från samtalet.';
 
   @override
   String get pleaseEnterAppPrompt => 'Ange en prompt för din app';
@@ -7132,19 +7001,16 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Uppgradering schemalagd! Din månadsplan fortsätter till slutet av din faktureringsperiod.';
+  String get planUpgradeScheduledMessage => 'Uppgradering schemalagd! Din månadsplan fortsätter till slutet av din faktureringsperiod.';
 
   @override
   String get couldNotSchedulePlanChange => 'Kunde inte schemalägga planbyte. Försök igen.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Din prenumeration har återaktiverats! Ingen debitering nu - du faktureras i slutet av din faktureringsperiod.';
+  String get subscriptionReactivatedDefault => 'Din prenumeration har återaktiverats! Ingen debitering nu - du faktureras i slutet av din faktureringsperiod.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Prenumerationen lyckades! Du har debiterats för den nya faktureringsperioden.';
+  String get subscriptionSuccessfulCharged => 'Prenumerationen lyckades! Du har debiterats för den nya faktureringsperioden.';
 
   @override
   String get couldNotProcessSubscription => 'Kunde inte behandla prenumerationen. Försök igen.';
@@ -7324,8 +7190,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Bluetooth-behörighet krävs för att ansluta till din enhet.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth-behörighet nekad. Bevilja behörighet i Systeminställningar.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth-behörighet nekad. Bevilja behörighet i Systeminställningar.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7338,12 +7203,10 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Aviseringsbehörighet nekad. Bevilja behörighet i Systeminställningar.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Aviseringsbehörighet nekad. Bevilja behörighet i Systeminställningar.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Aviseringsbehörighet nekad. Bevilja behörighet i Systeminställningar > Aviseringar.';
+  String get onboardingNotificationDeniedNotifications => 'Aviseringsbehörighet nekad. Bevilja behörighet i Systeminställningar > Aviseringar.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7356,15 +7219,13 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Bevilja platsbehörighet i Inställningar > Integritet och säkerhet > Platstjänster';
+  String get onboardingLocationGrantInSettings => 'Bevilja platsbehörighet i Inställningar > Integritet och säkerhet > Platstjänster';
 
   @override
   String get onboardingMicrophoneRequired => 'Mikrofonbehörighet krävs för inspelning.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofonbehörighet nekad. Bevilja behörighet i Systeminställningar > Integritet och säkerhet > Mikrofon.';
+  String get onboardingMicrophoneDenied => 'Mikrofonbehörighet nekad. Bevilja behörighet i Systeminställningar > Integritet och säkerhet > Mikrofon.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7380,8 +7241,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Skärminspelningsbehörighet krävs för systemljudinspelning.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Skärminspelningsbehörighet nekad. Bevilja behörighet i Systeminställningar > Integritet och säkerhet > Skärminspelning.';
+  String get onboardingScreenCaptureDenied => 'Skärminspelningsbehörighet nekad. Bevilja behörighet i Systeminställningar > Integritet och säkerhet > Skärminspelning.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7434,8 +7294,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Fototillstånd nekad. Vänligen tillåt åtkomst till foton för att välja bilder';
+  String get msgPhotosPermissionDenied => 'Fototillstånd nekad. Vänligen tillåt åtkomst till foton för att välja bilder';
 
   @override
   String get msgSelectImagesGenericError => 'Fel vid val av bilder. Försök igen.';
@@ -7507,8 +7366,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get locationPermissionRequired => 'Platstillstånd krävs';
 
   @override
-  String get locationPermissionContent =>
-      'Snabb överföring kräver platstillstånd för att verifiera WiFi-anslutningen. Vänligen ge platstillstånd för att fortsätta.';
+  String get locationPermissionContent => 'Snabb överföring kräver platstillstånd för att verifiera WiFi-anslutningen. Vänligen ge platstillstånd för att fortsätta.';
 
   @override
   String get pdfTranscriptExport => 'Transkriptionsexport';
@@ -7979,8 +7837,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Sätt Plaud Note i parkopplingsläge';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Tryck och håll sidoknappen i 2 sekunder. Den röda LED:en blinkar när den är redo att parkoppla.';
+  String get pairingDescPlaudNote => 'Tryck och håll sidoknappen i 2 sekunder. Den röda LED:en blinkar när den är redo att parkoppla.';
 
   @override
   String get pairingTitleBee => 'Sätt Bee i parkopplingsläge';
@@ -7992,15 +7849,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get pairingTitleLimitless => 'Sätt Limitless i parkopplingsläge';
 
   @override
-  String get pairingDescLimitless =>
-      'När en lampa lyser, tryck en gång och tryck sedan och håll tills enheten visar ett rosa ljus, släpp sedan.';
+  String get pairingDescLimitless => 'När en lampa lyser, tryck en gång och tryck sedan och håll tills enheten visar ett rosa ljus, släpp sedan.';
 
   @override
   String get pairingTitleFriendPendant => 'Sätt Friend Pendant i parkopplingsläge';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Tryck på knappen på hänget för att slå på det. Det går automatiskt till parkopplingsläge.';
+  String get pairingDescFriendPendant => 'Tryck på knappen på hänget för att slå på det. Det går automatiskt till parkopplingsläge.';
 
   @override
   String get pairingTitleFieldy => 'Sätt Fieldy i parkopplingsläge';
@@ -8012,8 +7867,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Anslut Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Installera och öppna Omi-appen på din Apple Watch, tryck sedan på Anslut i appen.';
+  String get pairingDescAppleWatch => 'Installera och öppna Omi-appen på din Apple Watch, tryck sedan på Anslut i appen.';
 
   @override
   String get pairingTitleNeoOne => 'Sätt Neo One i parkopplingsläge';
@@ -8136,8 +7990,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get switchAndRestart => 'Byt';
 
   @override
-  String get stagingDisclaimer =>
-      'Testmiljön kan vara instabil, ha inkonsekvent prestanda och data kan gå förlorad. Endast för testning.';
+  String get stagingDisclaimer => 'Testmiljön kan vara instabil, ha inkonsekvent prestanda och data kan gå förlorad. Endast för testning.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Sparat. Stäng och öppna appen igen för att tillämpa ändringarna.';
@@ -8366,8 +8219,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Telefonsamtal via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Ring via Omi och få transkription i realtid, automatiska sammanfattningar och mer.';
+  String get phoneCallsUpsellSubtitle => 'Ring via Omi och få transkription i realtid, automatiska sammanfattningar och mer.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Transkription i realtid av varje samtal';
@@ -8394,8 +8246,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteSyncedFiles => 'Radera synkroniserade inspelningar';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'Dessa inspelningar har redan synkroniserats med din telefon. Detta kan inte ångras.';
+  String get deleteSyncedFilesMessage => 'Dessa inspelningar har redan synkroniserats med din telefon. Detta kan inte ångras.';
 
   @override
   String get syncedFilesDeleted => 'Synkroniserade inspelningar raderade';
@@ -8407,8 +8258,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deletePendingFiles => 'Radera väntande inspelningar';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Dessa inspelningar har INTE synkroniserats med din telefon och kommer att förloras permanent. Detta kan inte ångras.';
+  String get deletePendingFilesWarning => 'Dessa inspelningar har INTE synkroniserats med din telefon och kommer att förloras permanent. Detta kan inte ångras.';
 
   @override
   String get pendingFilesDeleted => 'Väntande inspelningar raderade';
@@ -8420,8 +8270,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deleteAll => 'Ta bort alla';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Detta raderar synkroniserade och väntande inspelningar. Väntande inspelningar har INTE synkroniserats och kommer att förloras permanent.';
+  String get deleteAllFilesWarning => 'Detta raderar synkroniserade och väntande inspelningar. Väntande inspelningar har INTE synkroniserats och kommer att förloras permanent.';
 
   @override
   String get allFilesDeleted => 'Alla inspelningar raderade';
@@ -8486,8 +8335,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get fairUseAboutTitle => 'Om rimlig användning';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi är utformat för personliga samtal, möten och liveinteraktioner. Användningen mäts efter faktisk detekterad taltid, inte anslutningstid. Om användningen avsevärt överstiger normala mönster för icke-personligt innehåll kan justeringar tillämpas.';
+  String get fairUseAboutBody => 'Omi är utformat för personliga samtal, möten och liveinteraktioner. Användningen mäts efter faktisk detekterad taltid, inte anslutningstid. Om användningen avsevärt överstiger normala mönster för icke-personligt innehåll kan justeringar tillämpas.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8525,8 +8373,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get improveConnectionTitle => 'Förbättra anslutning';
 
   @override
-  String get improveConnectionContent =>
-      'Vi har förbättrat hur Omi förblir ansluten till din enhet. För att aktivera detta, gå till sidan Enhetsinformation, tryck på \"Koppla från enhet\" och para ihop din enhet igen.';
+  String get improveConnectionContent => 'Vi har förbättrat hur Omi förblir ansluten till din enhet. För att aktivera detta, gå till sidan Enhetsinformation, tryck på \"Koppla från enhet\" och para ihop din enhet igen.';
 
   @override
   String get improveConnectionAction => 'Förstått';
@@ -8581,16 +8428,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get cancelSyncQuestion => 'Avbryta synkronisering?';
 
   @override
-  String get omisStorageDesc =>
-      'När din Omi inte är ansluten till din telefon lagrar den ljud lokalt i sitt inbyggda minne. Du förlorar aldrig en inspelning.';
+  String get omisStorageDesc => 'När din Omi inte är ansluten till din telefon lagrar den ljud lokalt i sitt inbyggda minne. Du förlorar aldrig en inspelning.';
 
   @override
-  String get phoneStorageDesc =>
-      'När Omi återansluter överförs inspelningar automatiskt till din telefon innan uppladdning.';
+  String get phoneStorageDesc => 'När Omi återansluter överförs inspelningar automatiskt till din telefon innan uppladdning.';
 
   @override
-  String get cloudStorageDesc =>
-      'Efter uppladdning bearbetas och transkriberas dina inspelningar. Konversationer blir tillgängliga inom en minut.';
+  String get cloudStorageDesc => 'Efter uppladdning bearbetas och transkriberas dina inspelningar. Konversationer blir tillgängliga inom en minut.';
 
   @override
   String get tipKeepPhoneNearby => 'Håll telefonen nära för snabbare synkronisering';
@@ -8614,12 +8458,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get permissionEnable => 'Aktivera';
 
   @override
-  String get permissionsPageDescription =>
-      'Dessa behörigheter är centrala för hur Omi fungerar. De aktiverar nyckelfunktioner som aviseringar, platsbaserade upplevelser och ljudinspelning.';
+  String get permissionsPageDescription => 'Dessa behörigheter är centrala för hur Omi fungerar. De aktiverar nyckelfunktioner som aviseringar, platsbaserade upplevelser och ljudinspelning.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi behöver några behörigheter för att fungera korrekt. Vänligen bevilja dem för att fortsätta.';
+  String get permissionsRequiredDescription => 'Omi behöver några behörigheter för att fungera korrekt. Vänligen bevilja dem för att fortsätta.';
 
   @override
   String get permissionsSetupTitle => 'Få den bästa upplevelsen';
@@ -8673,8 +8515,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get justAMoment => 'Ett ögonblick, tack';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Vi rekommenderar starkt att utforska dina andra alternativ istället för att avbryta.';
+  String get cancelConsequencesSubtitle => 'Vi rekommenderar starkt att utforska dina andra alternativ istället för att avbryta.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8897,8 +8738,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get firmwareWarningTitle => 'Viktigt: Läs innan du uppdaterar';
 
   @override
-  String get firmwareFormatWarning =>
-      'Denna firmware kommer att formatera SD-kortet. Se till att all offlinedata är synkroniserad innan du uppgraderar.\n\nOm du ser ett blinkande rött ljus efter att ha installerat denna version, oroa dig inte. Anslut bara enheten till appen och den bör bli blå. Det röda ljuset betyder att enhetens klocka inte har synkroniserats ännu.';
+  String get firmwareFormatWarning => 'Denna firmware kommer att formatera SD-kortet. Se till att all offlinedata är synkroniserad innan du uppgraderar.\n\nOm du ser ett blinkande rött ljus efter att ha installerat denna version, oroa dig inte. Anslut bara enheten till appen och den bör bli blå. Det röda ljuset betyder att enhetens klocka inte har synkroniserats ännu.';
 
   @override
   String get continueAnyway => 'Fortsätt';
@@ -8918,8 +8758,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get tasksMarkComplete => 'Markerad som klar';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi får åtkomst till Apple Health via Apples HealthKit-ramverk. Du kan återkalla åtkomsten när som helst i iOS-inställningarna.';
+  String get appleHealthManageNote => 'Omi får åtkomst till Apple Health via Apples HealthKit-ramverk. Du kan återkalla åtkomsten när som helst i iOS-inställningarna.';
 
   @override
   String get appleHealthConnectCta => 'Anslut till Apple Health';
@@ -8952,8 +8791,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Åtkomst till Apple Health nekad';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi har inte behörighet att läsa dina Apple Health-data. Aktivera det i iOS-inställningar → Integritet och säkerhet → Hälsa → Omi.';
+  String get appleHealthDeniedBody => 'Omi har inte behörighet att läsa dina Apple Health-data. Aktivera det i iOS-inställningar → Integritet och säkerhet → Hälsa → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Varför lämnar du oss?';
@@ -9022,8 +8860,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get planUpdate => 'Planuppdatering';
 
   @override
-  String get planDeprecationMessage =>
-      'Ditt Unlimited-abonnemang fasas ut. Byt till Operator-abonnemanget — samma fantastiska funktioner för \$49/mån. Ditt nuvarande abonnemang kommer att fortsätta fungera under tiden.';
+  String get planDeprecationMessage => 'Ditt Unlimited-abonnemang fasas ut. Byt till Operator-abonnemanget — samma fantastiska funktioner för \$49/mån. Ditt nuvarande abonnemang kommer att fortsätta fungera under tiden.';
 
   @override
   String get upgradeYourPlan => 'Uppgradera din plan';
@@ -9134,8 +8971,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Du har nått din månatliga gräns. Uppgradera för att fortsätta chatta med Omi utan begränsningar.';
+  String get chatQuotaExceededReply => 'Du har nått din månatliga gräns. Uppgradera för att fortsätta chatta med Omi utan begränsningar.';
 
   @override
   String get voiceResponseAudio => 'Läs upp Omis svar';
@@ -9166,4 +9002,25 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Lägg till uppgift';
+
+  @override
+  String get quickActionAskOmiAnything => 'Fråga Omi vad som helst';
+
+  @override
+  String get quickActionVoiceMode => 'Röstläge';
+
+  @override
+  String get quickActionMute => 'Stäng av ljud';
+
+  @override
+  String get quickActionUnmute => 'Slå på ljud';
+
+  @override
+  String get quickActionConnectDevice => 'Anslut enhet';
+
+  @override
+  String get quickActionDeviceSettings => 'Enhetsinställningar';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -24,8 +24,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleteConversationTitle => 'உரையாடலை நீக்கவா?';
 
   @override
-  String get deleteConversationMessage =>
-      'இது தொடர்புடைய நினைவுகள், பணிகள் மற்றும் ஆடியோ ফাইல்களையும் நீக்கும். இந்த நடவடிக்கையை மாற்ற முடியாது.';
+  String get deleteConversationMessage => 'இது தொடர்புடைய நினைவுகள், பணிகள் மற்றும் ஆடியோ ফাইல்களையும் நீக்கும். இந்த நடவடிக்கையை மாற்ற முடியாது.';
 
   @override
   String get confirm => 'உறுதிப்படுத்து';
@@ -146,8 +145,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleting => 'நீக்குகிறது...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'உங்கள் உலாவியில் அங்கீகாரத்தை முடிக்கவும். முடிந்ததும், பயன்பாட்டுக்குத் திரும்பவும்.';
+  String get pleaseCompleteAuthentication => 'உங்கள் உலாவியில் அங்கீகாரத்தை முடிக்கவும். முடிந்ததும், பயன்பாட்டுக்குத் திரும்பவும்.';
 
   @override
   String get failedToStartAuthentication => 'அங்கீகாரத்தைத் தொடங்க முடியவில்லை';
@@ -228,8 +226,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get noStarredConversations => 'நட்சத்திரம் சூட்ட உரையாடல் இல்லை';
 
   @override
-  String get starConversationHint =>
-      'உரையாடலுக்கு நட்சத்திரம் சூட்ட, அதைத் திறந்து தலைப்பில் உள்ள நட்சத்திரக் குறியை தட்டவும்.';
+  String get starConversationHint => 'உரையாடலுக்கு நட்சத்திரம் சூட்ட, அதைத் திறந்து தலைப்பில் உள்ள நட்சத்திரக் குறியை தட்டவும்.';
 
   @override
   String get searchConversations => 'உரையாடல்களைத் தேடுங்கள்...';
@@ -320,8 +317,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get installedApps => 'நிறுவப்பட்ட பயன்பாடுகள்';
 
   @override
-  String get unableToFetchApps =>
-      'பயன்பாடுகளைப் பெற முடியவில்லை :(\n\nআপনার இணையம் இணைப்பைப் பரிசோதிக்கவும் மற்றும் மீண்டும் முயலுங்கள்.';
+  String get unableToFetchApps => 'பயன்பாடுகளைப் பெற முடியவில்லை :(\n\nআপনার இணையம் இணைப்பைப் பரிசோதிக்கவும் மற்றும் மீண்டும் முயலுங்கள்.';
 
   @override
   String get aboutOmi => 'Omi பற்றி';
@@ -357,19 +353,16 @@ class AppLocalizationsTa extends AppLocalizations {
   String get appsDisconnected => 'உங்கள் பயன்பாடுகள் மற்றும் ஒருங்கிணைப்புகள் உடனடியாக துண்டிக்கப்படும்.';
 
   @override
-  String get exportBeforeDelete =>
-      'உங்கள் கணக்கை நீக்குவதற்கு முன் உங்கள் தரவை ஏற்றுமதி செய்யலாம், ஆனால் நீக்கப்பட்டபின், அதை மீட்டெடுக்க முடியாது.';
+  String get exportBeforeDelete => 'உங்கள் கணக்கை நீக்குவதற்கு முன் உங்கள் தரவை ஏற்றுமதி செய்யலாம், ஆனால் நீக்கப்பட்டபின், அதை மீட்டெடுக்க முடியாது.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'உங்கள் கணக்கை நீக்குவது நிரந்தரம் என்றும் அனைத்து தரவு, நினைவுகள் மற்றும் உரையாடல்கள் உட்பட நிரந்தரமாக நீக்கப்பட்டு மீட்டெடுக்க முடியாது என்பது நான் புரிந்துகொள்கிறேன்.';
+  String get deleteAccountCheckbox => 'உங்கள் கணக்கை நீக்குவது நிரந்தரம் என்றும் அனைத்து தரவு, நினைவுகள் மற்றும் உரையாடல்கள் உட்பட நிரந்தரமாக நீக்கப்பட்டு மீட்டெடுக்க முடியாது என்பது நான் புரிந்துகொள்கிறேன்.';
 
   @override
   String get areYouSure => 'நிச்சயமாக?';
 
   @override
-  String get deleteAccountFinal =>
-      'இந்த நடவடிக்கை மாற்றியமைக்க முடியாது மற்றும் உங்கள் கணக்கு மற்றும் சம்பந்தப்பட்ட அனைத்து தரவுகளையும் நிரந்தரமாக நீக்கும். நீங்கள் தொடர விரும்புகிறீர்களா?';
+  String get deleteAccountFinal => 'இந்த நடவடிக்கை மாற்றியமைக்க முடியாது மற்றும் உங்கள் கணக்கு மற்றும் சம்பந்தப்பட்ட அனைத்து தரவுகளையும் நிரந்தரமாக நீக்கும். நீங்கள் தொடர விரும்புகிறீர்களா?';
 
   @override
   String get deleteNow => 'இப்போது நீக்கவும்';
@@ -378,8 +371,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get goBack => 'பின்னால் செல்வோம்';
 
   @override
-  String get checkBoxToConfirm =>
-      'உங்கள் கணக்கை நீக்குவது நிரந்தரம் மற்றும் மாற்றியமைக்க முடியாது என்பதை நீங்கள் புரிந்துகொள்கிறீர்கள் என்பதை உறுதிப்படுத்த பெட்டியைச் சரிபார்க்கவும்.';
+  String get checkBoxToConfirm => 'உங்கள் கணக்கை நீக்குவது நிரந்தரம் மற்றும் மாற்றியமைக்க முடியாது என்பதை நீங்கள் புரிந்துகொள்கிறீர்கள் என்பதை உறுதிப்படுத்த பெட்டியைச் சரிபார்க்கவும்.';
 
   @override
   String get profile => 'சுயவிவரம்';
@@ -457,8 +449,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get yourPrivacyYourControl => 'உங்கள் தனியுரிமை, உங்கள் கட்டுப்பாடு';
 
   @override
-  String get privacyIntro =>
-      'Omi இல், நாங்கள் உங்கள் தனியுரிமையைக் காப்பாற்ற உறுதிபட்டுள்ளோம். இந்தப் பக்கம் உங்கள் தரவை எவ்வாறு சேமிக்கப்பட்டு பயன்படுத்தப்படுகிறது என்பதை கட்டுப்படுத்த அनुमति கொடுக்கிறது.';
+  String get privacyIntro => 'Omi இல், நாங்கள் உங்கள் தனியுரிமையைக் காப்பாற்ற உறுதிபட்டுள்ளோம். இந்தப் பக்கம் உங்கள் தரவை எவ்வாறு சேமிக்கப்பட்டு பயன்படுத்தப்படுகிறது என்பதை கட்டுப்படுத்த அनुमति கொடுக்கிறது.';
 
   @override
   String get learnMore => 'மேலும் அறியவும்...';
@@ -467,19 +458,16 @@ class AppLocalizationsTa extends AppLocalizations {
   String get dataProtectionLevel => 'தரவு பாதுகாப்பு நிலை';
 
   @override
-  String get dataProtectionDesc =>
-      'உங்கள் தரவு வலுவான என்ற்িப்ட்ஸனுடன் இயல்பாக பாதுகாக்கப்படுகிறது. உங்கள் அமைப்புகளைப் பரிசோதிக்கவும் மற்றும் கீழே உள்ள எதிர்கால தனியுரிமை விருப்பங்களைப் பரிசோதிக்கவும்.';
+  String get dataProtectionDesc => 'உங்கள் தரவு வலுவான என்ற்িப்ட்ஸனுடன் இயல்பாக பாதுகாக்கப்படுகிறது. உங்கள் அமைப்புகளைப் பரிசோதிக்கவும் மற்றும் கீழே உள்ள எதிர்கால தனியுரிமை விருப்பங்களைப் பரிசோதிக்கவும்.';
 
   @override
   String get appAccess => 'பயன்பாடு அணுகல்';
 
   @override
-  String get appAccessDesc =>
-      'பின்வரும் பயன்பாடுகள் உங்கள் தரவை அணுக முடியும். ஒரு பயன்பாடு பகிர்ந்து கொள்ள நிர்வாகித்துக் கொள்ள தட்டவும்.';
+  String get appAccessDesc => 'பின்வரும் பயன்பாடுகள் உங்கள் தரவை அணுக முடியும். ஒரு பயன்பாடு பகிர்ந்து கொள்ள நிர்வாகித்துக் கொள்ள தட்டவும்.';
 
   @override
-  String get noAppsExternalAccess =>
-      'நிறுவப்பட்ட பயன்பாடுகள் எதுவும் உங்கள் தரவுக்கு வெளிப்புற அணுகலைக் கொண்டிருக்கவில்லை.';
+  String get noAppsExternalAccess => 'நிறுவப்பட்ட பயன்பாடுகள் எதுவும் உங்கள் தரவுக்கு வெளிப்புற அணுகலைக் கொண்டிருக்கவில்லை.';
 
   @override
   String get deviceName => 'சாதன பெயர்';
@@ -533,22 +521,19 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deviceDisconnectedMessage => 'உங்கள் Omi இணைப்பு நீக்கப்பட்டுள்ளது 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'சாதனம் பொருத்தம் நீக்கப்பட்டது. அமைப்புகள் > Bluetooth க்குச் சென்று சாதனத்தை மறந்துவிடவும் பொருத்தம் முடிக்க.';
+  String get deviceUnpairedMessage => 'சாதனம் பொருத்தம் நீக்கப்பட்டது. அமைப்புகள் > Bluetooth க்குச் சென்று சாதனத்தை மறந்துவிடவும் பொருத்தம் முடிக்க.';
 
   @override
   String get unpairDialogTitle => 'சாதனத்தை பொருத்தம் நீக்கவும்';
 
   @override
-  String get unpairDialogMessage =>
-      'இது சாதனத்தைப் பொருத்தம் நீக்கும் பதவியை மற்றொரு ஃபோனுக்கு இணைக்க முடியும். நீங்கள் அமைப்புகள் > Bluetooth க்குச் சென்று சாதனத்தை மறந்துவிட வேண்டிய செயல்முறையை முடிக்க வேண்டும்.';
+  String get unpairDialogMessage => 'இது சாதனத்தைப் பொருத்தம் நீக்கும் பதவியை மற்றொரு ஃபோனுக்கு இணைக்க முடியும். நீங்கள் அமைப்புகள் > Bluetooth க்குச் சென்று சாதனத்தை மறந்துவிட வேண்டிய செயல்முறையை முடிக்க வேண்டும்.';
 
   @override
   String get deviceNotConnected => 'சாதனம் இணைக்கப்படவில்லை';
 
   @override
-  String get connectDeviceMessage =>
-      'உங்கள் Omi சாதனத்தை இணைக்கவும் அணுகல் மற்றும் தனிப்பயனாக்கல் என்ற சாதன அமைப்புகள்';
+  String get connectDeviceMessage => 'உங்கள் Omi சாதனத்தை இணைக்கவும் அணுகல் மற்றும் தனிப்பயனாக்கல் என்ற சாதன அமைப்புகள்';
 
   @override
   String get deviceInfoSection => 'சாதன தகவல்';
@@ -563,8 +548,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get v2Undetected => 'V2 கண்டுபிடிக்கப்படவில்லை';
 
   @override
-  String get v2UndetectedMessage =>
-      'உங்களுக்கு V1 சாதனம் அல்லது உங்கள் சாதனம் இணைக்கப்படவில்லை என்பதைக் கண்டோம். SD கார்ட் செயல்பாடு V2 சாதனங்களுக்கு மட்டுமே கிடைக்கிறது.';
+  String get v2UndetectedMessage => 'உங்களுக்கு V1 சாதனம் அல்லது உங்கள் சாதனம் இணைக்கப்படவில்லை என்பதைக் கண்டோம். SD கார்ட் செயல்பாடு V2 சாதனங்களுக்கு மட்டுமே கிடைக்கிறது.';
 
   @override
   String get endConversation => 'உரையாடல் முடிக்கவும்';
@@ -696,8 +680,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get noActivityYet => 'இன்னும் செயல்பாடு இல்லை';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Omi உடன் ஒரு உரையாடல் தொடங்கவும் உங்கள் பயன்பாட்டு அंতর्दृष्टি இங்கே பார்க்கவும்.';
+  String get startConversationToSeeInsights => 'Omi உடன் ஒரு உரையாடல் தொடங்கவும் உங்கள் பயன்பாட்டு அंতর्दृष्टি இங்கே பார்க்கவும்.';
 
   @override
   String get listening => 'கேட்கிறது';
@@ -839,8 +822,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'அறிவு வரைபடத்தை நீக்கவா?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'இது அனைத்து பெறப்பட்ட அறிவு வரைபட தரவையும் நீக்கும் (முனைப்புகள் மற்றும் இணைப்புகள்). உங்கள் அசல் நினைவுகள் பாதுகாப்பாக இருக்கும். வரைபடம் கால மற்றும் அல்லது அடுத்த கோரிக்கை மீது மீண்டும் உருவாக்கப்படும்.';
+  String get deleteKnowledgeGraphMessage => 'இது அனைத்து பெறப்பட்ட அறிவு வரைபட தரவையும் நீக்கும் (முனைப்புகள் மற்றும் இணைப்புகள்). உங்கள் அசல் நினைவுகள் பாதுகாப்பாக இருக்கும். வரைபடம் கால மற்றும் அல்லது அடுத்த கோரிக்கை மீது மீண்டும் உருவாக்கப்படும்.';
 
   @override
   String get knowledgeGraphDeleted => 'அறிவு வரைபடம் நீக்கப்பட்டது';
@@ -1023,8 +1005,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get integrationsFooter => 'சாட்டில் தரவு மற்றும் மெட்ரிக்ஸ் பார்க்க உங்கள் பயன்பாடுகளை இணைக்கவும்.';
 
   @override
-  String get completeAuthInBrowser =>
-      'உங்கள் உலாவியில் அங்கீகாரத்தை முடிக்கவும். முடிந்ததும், பயன்பாட்டுக்குத் திரும்பவும்.';
+  String get completeAuthInBrowser => 'உங்கள் உலாவியில் அங்கீகாரத்தை முடிக்கவும். முடிந்ததும், பயன்பாட்டுக்குத் திரும்பவும்.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1084,8 +1065,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get needYourPermission => 'நாங்கள் உங்கள் அனுமதி தேவை';
 
   @override
-  String get alreadyGavePermission =>
-      'உங்கள் பதிவுகளை சேமிக்க உங்களுக்கு ஏற்கனவே அனுமதி கொடுத்துள்ளீர்கள். நாங்கள் ஏன் தேவை என்பதற்கு இங்கே ஒரு நினைவூட்டல்:';
+  String get alreadyGavePermission => 'உங்கள் பதிவுகளை சேமிக்க உங்களுக்கு ஏற்கனவே அனுமதி கொடுத்துள்ளீர்கள். நாங்கள் ஏன் தேவை என்பதற்கு இங்கே ஒரு நினைவூட்டல்:';
 
   @override
   String get wouldLikePermission => 'உங்கள் குரல் பதிவுகளை சேமிக்க நாங்கள் உங்கள் அனுமதி விரும்புகிறோம். ஏன்:';
@@ -1094,26 +1074,22 @@ class AppLocalizationsTa extends AppLocalizations {
   String get improveSpeechProfile => 'உங்கள் பேச்சு சுயவிவரம் மேம்படுத்தவும்';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'உங்கள் ব্যক்তिगत பேச்சு சுயவிவரத்தைப் பயிற்சி மற்றும் மேம்படுத்த நாங்கள் பதிவுகள் பயன்படுத்துகிறோம்.';
+  String get improveSpeechProfileDesc => 'உங்கள் ব্যক்তिगत பேச்சு சுயவிவரத்தைப் பயிற்சி மற்றும் மேம்படுத்த நாங்கள் பதிவுகள் பயன்படுத்துகிறோம்.';
 
   @override
   String get trainFamilyProfiles => 'நண்பர்கள் மற்றும் குடும்ப சுயவிவரங்களைப் பயிற்சி';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'உங்கள் நண்பர்கள் மற்றும் குடும்ப உறுப்பினர்களை அங்கீகரிக்கவும் சுயவிவரங்களை உருவாக்க உங்கள் பதிவுகள் நாங்கள் உதவுகிறது.';
+  String get trainFamilyProfilesDesc => 'உங்கள் நண்பர்கள் மற்றும் குடும்ப உறுப்பினர்களை அங்கீகரிக்கவும் சுயவிவரங்களை உருவாக்க உங்கள் பதிவுகள் நாங்கள் உதவுகிறது.';
 
   @override
   String get enhanceTranscriptAccuracy => 'வேண்டுகோள் நির்ভুलத்தை மேம்படுத்தவும்';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'எங்கள் மாதிரி উন்নত, நாங்கள் உங்கள் பதிவுகளுக்கு சிறந்த வேண்டுகோள் முடிவுகள் வழங்க முடியும்.';
+  String get enhanceTranscriptAccuracyDesc => 'எங்கள் மாதிரி উন்নত, நாங்கள் உங்கள் பதிவுகளுக்கு சிறந்த வேண்டுகோள் முடிவுகள் வழங்க முடியும்.';
 
   @override
-  String get legalNotice =>
-      'சட்ட மாற்றம்: குரல் தரவு பதிவு மற்றும் சேமிப்பு சட்டம் உங்கள் இடத்தைப் பொறுத்து மாறுவது சட்ட முறை மாறுவது சாத்தியமுள்ளது. உங்கள் உள்ளூர் சட்டங்கள் மற்றும் விதிமுறைகளுடன் இணங்கக் உறுதி செய்வது உங்கள் பொறுப்பு.';
+  String get legalNotice => 'சட்ட மாற்றம்: குரல் தரவு பதிவு மற்றும் சேமிப்பு சட்டம் உங்கள் இடத்தைப் பொறுத்து மாறுவது சட்ட முறை மாறுவது சாத்தியமுள்ளது. உங்கள் உள்ளூர் சட்டங்கள் மற்றும் விதிமுறைகளுடன் இணங்கக் உறுதி செய்வது உங்கள் பொறுப்பு.';
 
   @override
   String get alreadyAuthorized => 'ஏற்கனவே அங்கீகரிக்கப்பட்ட';
@@ -1185,15 +1161,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get showMeetingsMenuBar => 'மெனு பட்டியில் வரவிருக்கும் சந்திப்புகளைக் காட்டவும்';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'macOS மெனு பட்டியில் உங்கள் அடுத்த சந்திப்பு மற்றும் தொடங்குவதற்கான நேரத்தைக் காட்டவும்';
+  String get showMeetingsMenuBarDesc => 'macOS மெனு பட்டியில் உங்கள் அடுத்த சந்திப்பு மற்றும் தொடங்குவதற்கான நேரத்தைக் காட்டவும்';
 
   @override
   String get showEventsNoParticipants => 'பங்கேற்பாளர்கள் இல்லாத நிகழ்வுகளைக் காட்டவும்';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'இயக்கப்பட்டுள்ளபோது, வரவிருப்பவை பங்கேற்பாளர்கள் இல்லாத அல்லது வீடியோ இணைப்பு இல்லாத நிகழ்வுகளைக் காட்டுகிறது.';
+  String get showEventsNoParticipantsDesc => 'இயக்கப்பட்டுள்ளபோது, வரவிருப்பவை பங்கேற்பாளர்கள் இல்லாத அல்லது வீடியோ இணைப்பு இல்லாத நிகழ்வுகளைக் காட்டுகிறது.';
 
   @override
   String get yourMeetings => 'உங்கள் சந்திப்புகள்';
@@ -1234,8 +1208,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get noProjectsInWorkspace => 'இந்த பணிப்பெருங்களத்தில் திட்டங்கள் கிடைக்கவில்லை';
 
   @override
-  String get conversationTimeoutDesc =>
-      'கிறுக்களத்தை தானாக முடிக்க முன்பாக எத்தனை நேரம் மிஞ்சே தென்பதைத் தேர்ந்தெடுக்கவும்:';
+  String get conversationTimeoutDesc => 'கிறுக்களத்தை தானாக முடிக்க முன்பாக எத்தனை நேரம் மிஞ்சே தென்பதைத் தேர்ந்தெடுக்கவும்:';
 
   @override
   String get timeout2Minutes => '2 நிமிடங்கள்';
@@ -1279,12 +1252,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'உங்கள் முதன்மை மொழி என்ன என்று சொல்லுங்கள்';
 
   @override
-  String get languageForTranscription =>
-      'தட்டச்சுக்கு உங்கள் மொழியைத் தேர்ந்தெடுக்கவும் மேலும் ஒரு தனிப்பட்ட அভিজ்ஞதைக்கு.';
+  String get languageForTranscription => 'தட்டச்சுக்கு உங்கள் மொழியைத் தேர்ந்தெடுக்கவும் மேலும் ஒரு தனிப்பட்ட அভিজ்ஞதைக்கு.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'ஒற்றை மொழி பயன்முறை இயக்கப்பட்டுள்ளது. மொழிபெயர்ப்பு அதிக নির்ভুலமாக்க முடக்கப்பட்டுள்ளது.';
+  String get singleLanguageModeInfo => 'ஒற்றை மொழி பயன்முறை இயக்கப்பட்டுள்ளது. மொழிபெயர்ப்பு அதிக নির்ভুலமாக்க முடக்கப்பட்டுள்ளது.';
 
   @override
   String get searchLanguageHint => 'பெயர் அல்லது குறியீட்டின் மூலம் மொழியைத் தேடவும்';
@@ -1364,8 +1335,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get defaultRepository => 'இயல்புநிலை களஞ்சியம்';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'சிக்கல்களை உருவாக்குவதற்கான ஒரு இயல்புநிலை களஞ்சியத்தைத் தேர்ந்தெடுக்கவும். நீங்கள் சிக்கல்களை உருவாக்கும்போது வேறு ஒரு களஞ்சியத்தைக் குறிப்பிடலாம்.';
+  String get selectDefaultRepoDesc => 'சிக்கல்களை உருவாக்குவதற்கான ஒரு இயல்புநிலை களஞ்சியத்தைத் தேர்ந்தெடுக்கவும். நீங்கள் சிக்கல்களை உருவாக்கும்போது வேறு ஒரு களஞ்சியத்தைக் குறிப்பிடலாம்.';
 
   @override
   String get noReposFound => 'களஞ்சியங்கள் கிடைக்கவில்லை';
@@ -1412,8 +1382,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get configureSettings => 'அமைப்புகளை உள்ளமைக்கவும்';
 
   @override
-  String get completeAuthBrowser =>
-      'உங்கள் உலாவியில் அங்கீகாரத்தை முடிக்கவும். முடிந்ததும், பயன்பாட்டுக்குத் திரும்பவும்.';
+  String get completeAuthBrowser => 'உங்கள் உலாவியில் அங்கீகாரத்தை முடிக்கவும். முடிந்ததும், பயன்பாட்டுக்குத் திரும்பவும்.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1462,8 +1431,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get bringYourOwn => 'உங்களையே கொண்டு வாருங்கள்';
 
   @override
-  String get payYourSttProvider =>
-      'Omi ஐ சுதந்திரமாகப் பயன்படுத்தவும். நீங்கள் உங்கள் STT வழங்குநரிடம் நேரடியாக பணம் செலுத்துங்கள்.';
+  String get payYourSttProvider => 'Omi ஐ சுதந்திரமாகப் பயன்படுத்தவும். நீங்கள் உங்கள் STT வழங்குநரிடம் நேரடியாக பணம் செலுத்துங்கள்.';
 
   @override
   String get freeMinutesMonth => 'மாதத்திற்கு 1,200 இலவச நிமிடங்கள் அடங்கியுள்ளது. ';
@@ -1742,8 +1710,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth ஐ இயக்கவும்';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi உங்கள் உணர்வுமான சாதனத்துடன் இணைக்க Bluetooth தேவை. Bluetooth ஐ இயக்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
+  String get bluetoothNeeded => 'Omi உங்கள் உணர்வுமான சாதனத்துடன் இணைக்க Bluetooth தேவை. Bluetooth ஐ இயக்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get contactSupport => 'ஆதரவுடன் যোগாசையை கொள்ளவா?';
@@ -1776,26 +1743,22 @@ class AppLocalizationsTa extends AppLocalizations {
   String get locationServiceDisabled => 'இட சேவை முடக்கப்பட்டுள்ளது';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'இட சேவை முடக்கப்பட்டுள்ளது. அமைப்புகளுக்கு செல்லவும் > தனிமை & பாதுகாப்பு > இட சேவைகள் மற்றும் இதை இயக்கவும்';
+  String get locationServiceDisabledDesc => 'இட சேவை முடக்கப்பட்டுள்ளது. அமைப்புகளுக்கு செல்லவும் > தனிமை & பாதுகாப்பு > இட சேவைகள் மற்றும் இதை இயக்கவும்';
 
   @override
   String get backgroundLocationDenied => 'பின்னணி இட அணுகல் மறுக்கப்பட்டுள்ளது';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'சாதன அமைப்புகளுக்கு செல்லவும் மற்றும் இட அனுமதியை \"எப்போதும் அனுமதிக்க\" அமைக்கவும்';
+  String get backgroundLocationDeniedDesc => 'சாதன அமைப்புகளுக்கு செல்லவும் மற்றும் இட அனுமதியை \"எப்போதும் அனுமதிக்க\" அமைக்கவும்';
 
   @override
   String get lovingOmi => 'Omi ஐ விரும்புகிறீர்களா?';
 
   @override
-  String get leaveReviewIos =>
-      'App Store இல் ஒரு மதிப்பாய்வு விட்டு மேலும் நபர்களை அடைய எங்களுக்கு உதவவும். உங்கள் பதிப்பு எங்களுக்கு உலகத்தைக் குறிக்கிறது!';
+  String get leaveReviewIos => 'App Store இல் ஒரு மதிப்பாய்வு விட்டு மேலும் நபர்களை அடைய எங்களுக்கு உதவவும். உங்கள் பதிப்பு எங்களுக்கு உலகத்தைக் குறிக்கிறது!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Google Play Store இல் ஒரு மதிப்பாய்வு விட்டு மேலும் நபர்களை அடைய எங்களுக்கு உதவவும். உங்கள் பதிப்பு எங்களுக்கு உலகத்தைக் குறிக்கிறது!';
+  String get leaveReviewAndroid => 'Google Play Store இல் ஒரு மதிப்பாய்வு விட்டு மேலும் நபர்களை அடைய எங்களுக்கு உதவவும். உங்கள் பதிப்பு எங்களுக்கு உலகத்தைக் குறிக்கிறது!';
 
   @override
   String get rateOnAppStore => 'App Store இல் மதிப்பிடவும்';
@@ -1807,8 +1770,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get maybeLater => 'ஒருவேளை பிறகு';
 
   @override
-  String get speechProfileIntro =>
-      'Omi உங்கள் இலக்குகள் மற்றும் உங்கள் குரலைக் கற்க வேண்டும். நீங்கள் இதை பிறகு மாற்ற முடிந்தது.';
+  String get speechProfileIntro => 'Omi உங்கள் இலக்குகள் மற்றும் உங்கள் குரலைக் கற்க வேண்டும். நீங்கள் இதை பிறகு மாற்ற முடிந்தது.';
 
   @override
   String get getStarted => 'தொடங்குங்கள்';
@@ -1829,36 +1791,31 @@ class AppLocalizationsTa extends AppLocalizations {
   String get connectionError => 'இணைப்பு பிழை';
 
   @override
-  String get connectionErrorDesc =>
-      'சேவையகத்துடன் இணைக்க முடியவில்லை. உங்கள் இணைய இணைப்பை சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
+  String get connectionErrorDesc => 'சேவையகத்துடன் இணைக்க முடியவில்லை. உங்கள் இணைய இணைப்பை சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'செல்லாத பதிவு கண்டுபிடிக்கப்பட்டுள்ளது';
 
   @override
-  String get multipleSpeakersDesc =>
-      'பதிவில் பல பேச்சாளர்கள் உள்ளனர் என்று தோன்றுகிறது. நீங்கள் ஒரு조용한் இடத்தில் இருக்கிறீர்கள் என்பதை உறுதிசெய்து மீண்டும் முயற்சி செய்யவும்.';
+  String get multipleSpeakersDesc => 'பதிவில் பல பேச்சாளர்கள் உள்ளனர் என்று தோன்றுகிறது. நீங்கள் ஒரு조용한் இடத்தில் இருக்கிறீர்கள் என்பதை உறுதிசெய்து மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get tooShortDesc => 'போதுமான பேச்சு கண்டறிக்கப்படவில்லை. மேலும் பேச மற்றும் மீண்டும் முயற்சி செய்யவும்.';
 
   @override
-  String get invalidRecordingDesc =>
-      'நீங்கள் குறைந்தபட்சம் 5 நொடிகளாவது பேசினர் என்பதை உறுதிசெய்து 90 நொடிகளுக்கு மேல் பேசவில்லை என்பதை உறுதிசெய்யவும்.';
+  String get invalidRecordingDesc => 'நீங்கள் குறைந்தபட்சம் 5 நொடிகளாவது பேசினர் என்பதை உறுதிசெய்து 90 நொடிகளுக்கு மேல் பேசவில்லை என்பதை உறுதிசெய்யவும்.';
 
   @override
   String get areYouThere => 'நீங்கள் இருக்கிறீர்களா?';
 
   @override
-  String get noSpeechDesc =>
-      'நாங்கள் எந்த பேச்சையும் கண்டறிய முடியவில்லை. நீங்கள் குறைந்தபட்சம் 10 நொடிகளாவது பேசினர் என்பதை உறுதிசெய்து 3 நிமிடங்களுக்கு மேல் பேசவில்லை.';
+  String get noSpeechDesc => 'நாங்கள் எந்த பேச்சையும் கண்டறிய முடியவில்லை. நீங்கள் குறைந்தபட்சம் 10 நொடிகளாவது பேசினர் என்பதை உறுதிசெய்து 3 நிமிடங்களுக்கு மேல் பேசவில்லை.';
 
   @override
   String get connectionLost => 'இணைப்பு இழக்கப்பட்டுள்ளது';
 
   @override
-  String get connectionLostDesc =>
-      'இணைப்பு தடுக்கப்பட்டுள்ளது. உங்கள் இணைய இணைப்பை சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
+  String get connectionLostDesc => 'இணைப்பு தடுக்கப்பட்டுள்ளது. உங்கள் இணைய இணைப்பை சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get tryAgain => 'மீண்டும் முயற்சி செய்யவும்';
@@ -1873,8 +1830,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get permissionsRequired => 'அனுமதிகள் தேவை';
 
   @override
-  String get permissionsRequiredDesc =>
-      'இந்தப் பயன்பாடு சரியாக வேலைக்கு Bluetooth மற்றும் இட அனுமதிகள் தேவை. கருவி அமைப்புகளில் அவற்றை இயக்கவும்.';
+  String get permissionsRequiredDesc => 'இந்தப் பயன்பாடு சரியாக வேலைக்கு Bluetooth மற்றும் இட அனுமதிகள் தேவை. கருவி அமைப்புகளில் அவற்றை இயக்கவும்.';
 
   @override
   String get openSettings => 'அமைப்புகளைத் திறக்கவும்';
@@ -1904,8 +1860,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – உங்கள் AI சாங்கี';
 
   @override
-  String get captureEveryMoment =>
-      'ஒவ்வொரு தருணத்தையும் ஆட்டவும். AI-உயர்ந்த\nசுருக்கங்களைப் பெற்றுக் கொள்ளவும். பதிப்புகளை உருவாக்க வேண்டாம்.';
+  String get captureEveryMoment => 'ஒவ்வொரு தருணத்தையும் ஆட்டவும். AI-உயர்ந்த\nசுருக்கங்களைப் பெற்றுக் கொள்ளவும். பதிப்புகளை உருவாக்க வேண்டாம்.';
 
   @override
   String get appleWatchSetup => 'Apple Watch அமைப்பு';
@@ -1917,12 +1872,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get microphonePermission => 'மைக்ரோபோன் அனுமதி';
 
   @override
-  String get permissionGrantedNow =>
-      'அனுமதி வழங்கப்பட்டுள்ளது! இப்போது:\n\nஉங்கள் கடிகாரத்தில் Omi பயன்பாட்டை திறந்து கீழே \"தொடரவும்\" ஐ தட்டவும்';
+  String get permissionGrantedNow => 'அனுமதி வழங்கப்பட்டுள்ளது! இப்போது:\n\nஉங்கள் கடிகாரத்தில் Omi பயன்பாட்டை திறந்து கீழே \"தொடரவும்\" ஐ தட்டவும்';
 
   @override
-  String get needMicrophonePermission =>
-      'நங்கள் மைக்ரோபோன் அனுமதி தேவை.\n\n1. \"அனுமதி வழங்குங்கள்\" தட்டவும்\n2. உங்கள் iPhone இல் அனுமதி அளிக்கவும்\n3. கடிகார பயன்பாடு மூடும்\n4. மீண்டும் திறந்து \"தொடரவும்\" ஐ தட்டவும்';
+  String get needMicrophonePermission => 'நங்கள் மைக்ரோபோன் அனுமதி தேவை.\n\n1. \"அனுமதி வழங்குங்கள்\" தட்டவும்\n2. உங்கள் iPhone இல் அனுமதி அளிக்கவும்\n3. கடிகார பயன்பாடு மூடும்\n4. மீண்டும் திறந்து \"தொடரவும்\" ஐ தட்டவும்';
 
   @override
   String get grantPermissionButton => 'அனுமதி வழங்குங்கள்';
@@ -1931,15 +1884,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get needHelp => 'உதவி தேவை?';
 
   @override
-  String get troubleshootingSteps =>
-      'சிக்கலைத் தீர்க்க:\n\n1. Omi உங்கள் கடிகாரத்தில் நிறுவப்பட்டுள்ளதை உறுதிசெய்யவும்\n2. உங்கள் கடிகாரத்தில் Omi பயன்பாட்டை திறக்கவும்\n3. அனுமதி பாப்அப்பைத் தேடவும்\n4. பணிக்குறிப்பு செய்யப்பட்டு \"அனுமதி\" ஐ தட்டவும்\n5. உங்கள் கடிகாரத்தில் பயன்பாடு மூடும் - மீண்டும் திறக்கவும்\n6. உங்கள் iPhone இல் திரும்பி \"தொடரவும்\" ஐ தட்டவும்';
+  String get troubleshootingSteps => 'சிக்கலைத் தீர்க்க:\n\n1. Omi உங்கள் கடிகாரத்தில் நிறுவப்பட்டுள்ளதை உறுதிசெய்யவும்\n2. உங்கள் கடிகாரத்தில் Omi பயன்பாட்டை திறக்கவும்\n3. அனுமதி பாப்அப்பைத் தேடவும்\n4. பணிக்குறிப்பு செய்யப்பட்டு \"அனுமதி\" ஐ தட்டவும்\n5. உங்கள் கடிகாரத்தில் பயன்பாடு மூடும் - மீண்டும் திறக்கவும்\n6. உங்கள் iPhone இல் திரும்பி \"தொடரவும்\" ஐ தட்டவும்';
 
   @override
   String get recordingStartedSuccessfully => 'பதிவு வெற்றிகரமாக தொடங்கியுள்ளது!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'அனுமதி இன்னும் வழங்கப்படவில்லை. உங்கள் கடிகாரத்தில் மைக்ரோபோன் அணுகல் அனுமதி செய்தீர்கள் என்பதை உறுதிசெய்து மீண்டும் திறந்துவிட்டீர்கள்.';
+  String get permissionNotGrantedYet => 'அனுமதி இன்னும் வழங்கப்படவில்லை. உங்கள் கடிகாரத்தில் மைக்ரோபோன் அணுகல் அனுமதி செய்தீர்கள் என்பதை உறுதிசெய்து மீண்டும் திறந்துவிட்டீர்கள்.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2036,8 +1987,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get welcomeActionItemsTitle => 'செயல் பணிகளுக்கு தயாரிக்கப்பட்டுள்ளது';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'உங்கள் AI தானாகவே உரையாடல்களிலிருந்து பணிகள் மற்றும் செய்ய வேண்டிய பணிகளை எழுப்பும். அவை உருவாக்கப்பட்டுள்ளபோது இங்கே தோன்றும்.';
+  String get welcomeActionItemsDescription => 'உங்கள் AI தானாகவே உரையாடல்களிலிருந்து பணிகள் மற்றும் செய்ய வேண்டிய பணிகளை எழுப்பும். அவை உருவாக்கப்பட்டுள்ளபோது இங்கே தோன்றும்.';
 
   @override
   String get autoExtractionFeature => 'உரையாடல்களிலிருந்து தானாகவே எழுப்பப்பட்ட';
@@ -2233,15 +2183,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'பேச்சு & தட்டச்சு';
 
   @override
-  String get languageSettingsHelperText =>
-      'பயன்பாட்டு மொழி மெனுக்கள் மற்றும் பொத்தான்கள் மாற்றுகிறது. பேச்சு மொழி உங்கள் பதிவுகளை எவ்வாறு தட்டச்சு செய்யப்படுகிறது என்பதைப் பாதிக்கிறது.';
+  String get languageSettingsHelperText => 'பயன்பாட்டு மொழி மெனுக்கள் மற்றும் பொத்தான்கள் மாற்றுகிறது. பேச்சு மொழி உங்கள் பதிவுகளை எவ்வாறு தட்டச்சு செய்யப்படுகிறது என்பதைப் பாதிக்கிறது.';
 
   @override
   String get translationNotice => 'மொழிபெயர்ப்பு குறிப்பு';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi உங்கள் முதன்மை மொழிতে உரையாடல்களை மொழிபெயர்க்கிறது. அমைப்புகளில் -> சுயவிவரங்களில் ஏதேனும் நேரம் அதைப் புதுப்பிக்கவும்.';
+  String get translationNoticeMessage => 'Omi உங்கள் முதன்மை மொழிতে உரையாடல்களை மொழிபெயர்க்கிறது. அমைப்புகளில் -> சுயவிவரங்களில் ஏதேனும் நேரம் அதைப் புதுப்பிக்கவும்.';
 
   @override
   String get pleaseCheckInternetConnection => 'உங்கள் இணைய இணைப்பை சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்';
@@ -2403,8 +2351,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'சாதனத்தை இணையாக்கவும்';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'இது சாதனத்தை வேறு ஃபோனுக்கு இணைக்க இணையாக்கும். Settings > Bluetooth க்கு சென்று சாதனத்தை மறந்து செயல்முறையை முடிக்க வேண்டும்.';
+  String get unpairDeviceDialogMessage => 'இது சாதனத்தை வேறு ஃபோனுக்கு இணைக்க இணையாக்கும். Settings > Bluetooth க்கு சென்று சாதனத்தை மறந்து செயல்முறையை முடிக்க வேண்டும்.';
 
   @override
   String get unpair => 'இணையாக்கு';
@@ -2570,8 +2517,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get howDoesItWork => 'இது எப்படி வேலை செய்கிறது?';
 
   @override
-  String get sdCardSyncDescription =>
-      'SD கார்டு ஒத்திசைவு உங்கள் நினைவுகளை SD கார்டிலிருந்து ஆப்பிற்கு இறக்குமதி செய்யும்';
+  String get sdCardSyncDescription => 'SD கார்டு ஒத்திசைவு உங்கள் நினைவுகளை SD கார்டிலிருந்து ஆப்பிற்கு இறக்குமதி செய்யும்';
 
   @override
   String get checksForAudioFiles => 'SD கார்டில் ஆடியோ கோப்புகளை சரிபார்க்கிறது';
@@ -2586,8 +2532,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get youreAllSet => 'நீங்கள் அனைத்து தயாரிக்கப்பட்டுள்ளீர்கள்!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Omi க்கு வரவேற்கிறோம்! உங்கள் AI தோழி உரையாடல், பணிகள் மற்றும் பலவற்றை உங்களுக்கு உதவ தயாரிக்கப்பட்டுள்ளார்.';
+  String get welcomeToOmiDescription => 'Omi க்கு வரவேற்கிறோம்! உங்கள் AI தோழி உரையாடல், பணிகள் மற்றும் பலவற்றை உங்களுக்கு உதவ தயாரிக்கப்பட்டுள்ளார்.';
 
   @override
   String get startUsingOmi => 'Omi ஐ பயன்படுத்த தொடங்கவும்';
@@ -2723,8 +2668,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get noTasksYet => 'இன்னும் பணிகள் இல்லை';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'உங்கள் உரையாடல்களிலிருந்து பணிகள் இங்கே தோன்றும்.\nகையால் சேர்க்க உருவாக்கவும் தட்டவும்.';
+  String get tasksFromConversationsWillAppear => 'உங்கள் உரையாடல்களிலிருந்து பணிகள் இங்கே தோன்றும்.\nகையால் சேர்க்க உருவாக்கவும் தட்டவும்.';
 
   @override
   String get monthJan => 'ஜனவரி';
@@ -2781,8 +2725,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleteActionItem => 'செயல் உருப்படியை நீக்கு';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'இந்த செயல் உருப்படியை நீக்க விரும்புகிறீர்களா? இந்த செயலை செயல்நீக்கம் செய்ய முடியாது.';
+  String get deleteActionItemConfirmation => 'இந்த செயல் உருப்படியை நீக்க விரும்புகிறீர்களா? இந்த செயலை செயல்நீக்கம் செய்ய முடியாது.';
 
   @override
   String get enterActionItemDescription => 'செயல் உருப்படி விளக்கம் உள்ளிடவும்...';
@@ -2824,8 +2767,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get checkBackLaterForNewApps => 'புதிய பயன்பாடுகளுக்கு பிற்பாடு திரும்பச் சரிபார்க்கவும்';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'உங்கள் இணைய இணைப்பை சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சி செய்க';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'உங்கள் இணைய இணைப்பை சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சி செய்க';
 
   @override
   String get createNewApp => 'புதிய பயன்பாட்டை உருவாக்கு';
@@ -2858,15 +2800,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get chatPrompt => 'சட்டப்பூர்வ வசன குறிப்பு';
 
   @override
-  String get chatPromptPlaceholder =>
-      'நீங்கள் ஒரு அற்புத பயன்பாடு உள்ளீர், உபயோகி வினாக்களுக்கு பதிலளிப்பது மற்றும் அவர்களை நன்றாக உணர்வது உங்கள் வேலை...';
+  String get chatPromptPlaceholder => 'நீங்கள் ஒரு அற்புத பயன்பாடு உள்ளீர், உபயோகி வினாக்களுக்கு பதிலளிப்பது மற்றும் அவர்களை நன்றாக உணர்வது உங்கள் வேலை...';
 
   @override
   String get conversationPrompt => 'உரையாடல் வசன குறிப்பு';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'நீங்கள் ஒரு அற்புத பயன்பாடு உள்ளீர், உரையாடலின் மொழிபெயர்ப்பு மற்றும் சுருக்கம் உங்களுக்கு கொடுக்கப்படும்...';
+  String get conversationPromptPlaceholder => 'நீங்கள் ஒரு அற்புத பயன்பாடு உள்ளீர், உரையாடலின் மொழிபெயர்ப்பு மற்றும் சுருக்கம் உங்களுக்கு கொடுக்கப்படும்...';
 
   @override
   String get notificationScopes => 'அறிவிப்பு கணை';
@@ -2878,8 +2818,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get makeMyAppPublic => 'என் பயன்பாடு பொதுவாக்கு';
 
   @override
-  String get submitAppTermsAgreement =>
-      'இந்த பயன்பாட்டைச் சமர்ப்பிப்பதன் மூலம், நான் Omi AI சேவை விதிமுறைகள் மற்றும் தனியுரிமை கொள்கைக்கு ஒப்புக்கொள்ளுகிறேன்';
+  String get submitAppTermsAgreement => 'இந்த பயன்பாட்டைச் சமர்ப்பிப்பதன் மூலம், நான் Omi AI சேவை விதிமுறைகள் மற்றும் தனியுரிமை கொள்கைக்கு ஒப்புக்கொள்ளுகிறேன்';
 
   @override
   String get submitApp => 'பயன்பாடு சமர்ப்பிக்கவும்';
@@ -2888,19 +2827,16 @@ class AppLocalizationsTa extends AppLocalizations {
   String get needHelpGettingStarted => 'தொடங்குவதற்கு உதவி தேவையா?';
 
   @override
-  String get clickHereForAppBuildingGuides =>
-      'பயன்பாடு உருவாக்கும் வழிகாட்டிகள் மற்றும் ஆவணங்களுக்கு இங்கே கிளிக் செய்க';
+  String get clickHereForAppBuildingGuides => 'பயன்பாடு உருவாக்கும் வழிகாட்டிகள் மற்றும் ஆவணங்களுக்கு இங்கே கிளிக் செய்க';
 
   @override
   String get submitAppQuestion => 'பயன்பாடு சமர்ப்பிக்கவுமா?';
 
   @override
-  String get submitAppPublicDescription =>
-      'உங்கள் பயன்பாடு மீளாய்வு செய்யப்பட்டு பொதுவாக்கப்படும். மீளாய்வின் போது கூட நீங்கள் உடனே இதைப் பயன்படுத்தத் தொடங்கலாம்!';
+  String get submitAppPublicDescription => 'உங்கள் பயன்பாடு மீளாய்வு செய்யப்பட்டு பொதுவாக்கப்படும். மீளாய்வின் போது கூட நீங்கள் உடனே இதைப் பயன்படுத்தத் தொடங்கலாம்!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'உங்கள் பயன்பாடு மீளாய்வு செய்யப்பட்டு தனிப்பட்ட முறையில் உங்களுக்கு கிடைக்கும். மீளாய்வின் போது கூட நீங்கள் உடனே இதைப் பயன்படுத்தத் தொடங்கலாம்!';
+  String get submitAppPrivateDescription => 'உங்கள் பயன்பாடு மீளாய்வு செய்யப்பட்டு தனிப்பட்ட முறையில் உங்களுக்கு கிடைக்கும். மீளாய்வின் போது கூட நீங்கள் உடனே இதைப் பயன்படுத்தத் தொடங்கலாம்!';
 
   @override
   String get startEarning => 'சம்பாதிக்க தொடங்கவும்! 💰';
@@ -2924,23 +2860,19 @@ class AppLocalizationsTa extends AppLocalizations {
   String get dataAccessNotice => 'தரவு அணுகல் அறிவிப்பு';
 
   @override
-  String get dataAccessWarning =>
-      'இந்த பயன்பாடு உங்கள் தரவை அணுகும். Omi AI இந்த பயன்பாட்டால் உங்கள் தரவு எப்படி பயன்படுத்தப்படுகிறது, மாற்றப்படுகிறது அல்லது நீக்கப்படுகிறது என்பதற்கு பொறுப்பல்ல';
+  String get dataAccessWarning => 'இந்த பயன்பாடு உங்கள் தரவை அணுகும். Omi AI இந்த பயன்பாட்டால் உங்கள் தரவு எப்படி பயன்படுத்தப்படுகிறது, மாற்றப்படுகிறது அல்லது நீக்கப்படுகிறது என்பதற்கு பொறுப்பல்ல';
 
   @override
   String get installApp => 'பயன்பாடு நிறுவ';
 
   @override
-  String get betaTesterNotice =>
-      'நீங்கள் இந்த பயன்பாட்டின் பீட்டா சோதனையாளர்ஆக இருந்துள்ளீர்கள். இது இன்னும் பொதுவாக இல்லை. அது அங்கீகৃத முடிந்தவுடன் பொதுவாக இருக்கும்.';
+  String get betaTesterNotice => 'நீங்கள் இந்த பயன்பாட்டின் பீட்டா சோதனையாளர்ஆக இருந்துள்ளீர்கள். இது இன்னும் பொதுவாக இல்லை. அது அங்கீகৃத முடிந்தவுடன் பொதுவாக இருக்கும்.';
 
   @override
-  String get appUnderReviewOwner =>
-      'உங்கள் பயன்பாடு மீளாய்வின் கீழ் உள்ளது மற்றும் கூ உங்களுக்கு மட்டுமே பார்வையாக இருக்கும். அது அங்கீகৃத முடிந்தவுடன் பொதுவாக இருக்கும்.';
+  String get appUnderReviewOwner => 'உங்கள் பயன்பாடு மீளாய்வின் கீழ் உள்ளது மற்றும் கூ உங்களுக்கு மட்டுமே பார்வையாக இருக்கும். அது அங்கீகৃத முடிந்தவுடன் பொதுவாக இருக்கும்.';
 
   @override
-  String get appRejectedNotice =>
-      'உங்கள் பயன்பாடு நிராகரிக்கப்பட்டது. பயன்பாடு விவரங்களைப் புதுப்பிக்க மற்றும் மீளாய்வுக்கு மீண்டும் சமர்ப்பிக்க வேண்டும்.';
+  String get appRejectedNotice => 'உங்கள் பயன்பாடு நிராகரிக்கப்பட்டது. பயன்பாடு விவரங்களைப் புதுப்பிக்க மற்றும் மீளாய்வுக்கு மீண்டும் சமர்ப்பிக்க வேண்டும்.';
 
   @override
   String get setupSteps => 'நிறுவப்பட்ட படிகள்';
@@ -3002,8 +2934,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get descriptionLabel => 'விளக்கம்';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'என் அற்புத பயன்பாடு ஒரு சிறந்த பயன்பாடு ஆகும் அதிசயமான விஷயங்களைச் செய்கிறது. இது சாவதை சிறந்த பயன்பாடு!';
+  String get appDescriptionPlaceholder => 'என் அற்புத பயன்பாடு ஒரு சிறந்த பயன்பாடு ஆகும் அதிசயமான விஷயங்களைச் செய்கிறது. இது சாவதை சிறந்த பயன்பாடு!';
 
   @override
   String get pleaseProvideValidDescription => 'செல்லுபடியாகும் விளக்கம் வழங்கவும்';
@@ -3155,8 +3086,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get microphonePermissionRequired => 'அழைப்பு செய்ய மைக்ரோஃபோன் அனுமতி தேவை';
 
   @override
-  String get microphonePermissionDenied =>
-      'மைக்ரோஃபோன் அனுமதி நிராகரிக்கப்பட்டது. System Preferences > Privacy & Security > Microphone இல் அனுமதி வழங்கவும்.';
+  String get microphonePermissionDenied => 'மைக்ரோஃபோன் அனுமதி நிராகரிக்கப்பட்டது. System Preferences > Privacy & Security > Microphone இல் அனுமதி வழங்கவும்.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3389,8 +3319,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get whatWeCollect => 'நாங்கள் எதை சேகரிக்கிறோம்';
 
   @override
-  String get dataCollectionMessage =>
-      'தொடர்வதன் மூலம், உங்கள் உரையாடல்கள், பதிவுகள் மற்றும் ব்যக்তிগத தகவல்கள் நம் சர்வரில் பாதுகாப்பாகச் சேமிக்கப்படும், AI-இயக்கிய நுண்ணறிவுகளை வழங்க மற்றும் அனைத்து பயன்பாட்டு அம்சங்களை செயல்படுத்த.';
+  String get dataCollectionMessage => 'தொடர்வதன் மூலம், உங்கள் உரையாடல்கள், பதிவுகள் மற்றும் ব்যக்তிগத தகவல்கள் நம் சர்வரில் பாதுகாப்பாகச் சேமிக்கப்படும், AI-இயக்கிய நுண்ணறிவுகளை வழங்க மற்றும் அனைத்து பயன்பாட்டு அம்சங்களை செயல்படுத்த.';
 
   @override
   String get dataProtection => 'தரவு பாதுகாப்பு';
@@ -3405,8 +3334,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get chooseYourLanguage => 'உங்கள் மொழியைத் தேர்ந்தெடுக்கவும்';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'சிறந்த Omi அভிজ্ঞதைக்கான உங்கள் விரும்பிய மொழியைத் தேர்ந்தெடுக்கவும்';
+  String get selectPreferredLanguageForBestExperience => 'சிறந்த Omi அভிজ্ঞதைக்கான உங்கள் விரும்பிய மொழியைத் தேர்ந்தெடுக்கவும்';
 
   @override
   String get searchLanguages => 'மொழிகளைத் தேடவும்...';
@@ -3424,8 +3352,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'பெயர் குறைந்தது 2 எழுத்துக்கள் இருக்க வேண்டும்';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'உங்களை எப்படி சম்போதிக்க வேண்டுமென்று சொல்லவும். இது உங்கள் Omi அভிজ்ஞதையை நபர்மயமாக்க உதவுகிறது.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'உங்களை எப்படி சম்போதிக்க வேண்டுமென்று சொல்லவும். இது உங்கள் Omi அভிজ்ஞதையை நபர்மயமாக்க உதவுகிறது.';
 
   @override
   String charactersCount(int count) {
@@ -3442,8 +3369,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get recordAudioConversations => 'ஆடியோ உரையாடல்களைப் பதிவு செய்யவும்';
 
   @override
-  String get microphoneAccessDescription =>
-      'உங்கள் உரையாடல்களைப் பதிவு செய்து எழுத்தாக்க வழங்க Omi மைக்ரோஃபோன் அணுக்கம் தேவை.';
+  String get microphoneAccessDescription => 'உங்கள் உரையாடல்களைப் பதிவு செய்து எழுத்தாக்க வழங்க Omi மைக்ரோஃபோன் அணுக்கம் தேவை.';
 
   @override
   String get screenRecording => 'திரை பதிவு';
@@ -3452,8 +3378,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'சந்திப்புகளிலிருந்து கணினி ஆடியோவைப் பிடிக்கவும்';
 
   @override
-  String get screenRecordingDescription =>
-      'உங்கள் உலாவி-அடிப்படையிலான சந்திப்புகளிலிருந்து கணினி ஆடியோவைப் பிடிக்க Omi திரை பதிவு அনுமதி தேவை.';
+  String get screenRecordingDescription => 'உங்கள் உலாவி-அடிப்படையிலான சந்திப்புகளிலிருந்து கணினி ஆடியோவைப் பிடிக்க Omi திரை பதிவு அনுமதி தேவை.';
 
   @override
   String get accessibility => 'அணுகல்தன்மை';
@@ -3462,8 +3387,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'உலாவி-அடிப்படையிலான சந்திப்புகளைக் கண்டறியவும்';
 
   @override
-  String get accessibilityDescription =>
-      'நீங்கள் உங்கள் உலாவியில் Zoom, Meet அல்லது Teams சந்திப்புகளில் சேரும்போது கண்டறிய Omi அணுகல்தன்மை அனுமதி தேவை.';
+  String get accessibilityDescription => 'நீங்கள் உங்கள் உலாவியில் Zoom, Meet அல்லது Teams சந்திப்புகளில் சேரும்போது கண்டறிய Omi அணுகல்தன்மை அனுமதி தேவை.';
 
   @override
   String get pleaseWait => 'தயவு செய்து காத்திருங்கள்...';
@@ -3532,12 +3456,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get exportAllConversationsToJson => 'உங்கள் அனைத்து உரையாடல்களை JSON ফাইலுக்கு ஏற்றுமதி செய்யவும்.';
 
   @override
-  String get conversationsExportStarted =>
-      'உரையாடல்கள் ஏற்றுமதி தொடங்கியுள்ளது. இது சில வினாடிகள் எடுக்கலாம், தயவு செய்து காத்திருங்கள்.';
+  String get conversationsExportStarted => 'உரையாடல்கள் ஏற்றுமதி தொடங்கியுள்ளது. இது சில வினாடிகள் எடுக்கலாம், தயவு செய்து காத்திருங்கள்.';
 
   @override
-  String get mcpDescription =>
-      'Omi ஐ மற்ற பயன்பாடுகளுடன் இணைக்க உங்கள் நினைவுகள் மற்றும் உரையாடல்களைப் படிக்க, தேட மற்றும் நிர்வகிக்க. ஒரு முக்கியத்தை உருவாக்கவும் தொடங்க.';
+  String get mcpDescription => 'Omi ஐ மற்ற பயன்பாடுகளுடன் இணைக்க உங்கள் நினைவுகள் மற்றும் உரையாடல்களைப் படிக்க, தேட மற்றும் நிர்வகிக்க. ஒரு முக்கியத்தை உருவாக்கவும் தொடங்க.';
 
   @override
   String get apiKeys => 'API விசைகள்';
@@ -3578,8 +3500,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'எழுத்தாக்க சேவை நோயறிதல் நிலை';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'எழுத்தாக்க சேவையிலிருந்து விস்தரிக்கப்பட்ட நோயறிதல் செய்திகளை செயல்படுத்தவும்';
+  String get enableDetailedDiagnosticMessages => 'எழுத்தாக்க சேவையிலிருந்து விস்தரிக்கப்பட்ட நோயறிதல் செய்திகளை செயல்படுத்தவும்';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'புதிய பேச்சாளர்களை தானாக உருவாக்கவும் மற்றும் குறியிடவும்';
@@ -3609,8 +3530,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get auto => 'தானாக';
 
   @override
-  String get noSummaryForApp =>
-      'இந்த பயன்பாட்டிற்கு சுருக்கம் கிடைக்கவில்லை. சிறந்த முடிவுக்கு மற்றொரு பயன்பாட்டை முயற்சி செய்யவும்.';
+  String get noSummaryForApp => 'இந்த பயன்பாட்டிற்கு சுருக்கம் கிடைக்கவில்லை. சிறந்த முடிவுக்கு மற்றொரு பயன்பாட்டை முயற்சி செய்யவும்.';
 
   @override
   String get tryAnotherApp => 'மற்றொரு பயன்பாட்டை முயற்சி செய்யவும்';
@@ -3647,8 +3567,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Omi சிறந்த பயன்பாட்டைத் தானாக தேர்ந்தெடுக்க அனுமதிக்கவும்';
 
   @override
-  String get deleteConversationConfirmation =>
-      'இந்த உரையாடலை நீக்க விரும்புகிறீர்களா? இந்த செயலை செயல்தவிர்க்க முடியாது.';
+  String get deleteConversationConfirmation => 'இந்த உரையாடலை நீக்க விரும்புகிறீர்களா? இந்த செயலை செயல்தவிர்க்க முடியாது.';
 
   @override
   String get conversationDeleted => 'உரையாடல் நீக்கப்பட்டது';
@@ -3696,8 +3615,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get preparingSystemAudioCapture => 'கணினி ஆடியோ பிடிப்பைத் தயாரிக்கிறது';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'நிகழ்நேர எழுத்தாக்கம், AI நுண்ணறிவுகள் மற்றும் தானாக சேமிக்கத்திற்கான ஆடியோவைப் பிடிக்க பொத்தானைக் கிளிக் செய்யவும்.';
+  String get clickTheButtonToCaptureAudio => 'நிகழ்நேர எழுத்தாக்கம், AI நுண்ணறிவுகள் மற்றும் தானாக சேமிக்கத்திற்கான ஆடியோவைப் பிடிக்க பொத்தானைக் கிளிக் செய்யவும்.';
 
   @override
   String get reconnecting => 'மீண்டும் இணைக்கிறது...';
@@ -3855,8 +3773,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get dailySummaryTitle => 'தினசரி சுருக்கம்';
 
   @override
-  String get dailySummaryDescription =>
-      'உங்கள் நாளின் உரையாடல்களின் நபர்மயமான சுருக்கத்தைப் பெற்று அறிவிப்பாக வழங்கப்படுகிறது.';
+  String get dailySummaryDescription => 'உங்கள் நாளின் உரையாடல்களின் நபர்மயமான சுருக்கத்தைப் பெற்று அறிவிப்பாக வழங்கப்படுகிறது.';
 
   @override
   String get deliveryTime => 'விநியோக நேரம்';
@@ -3925,8 +3842,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'அறிவு வரைபடத்தை நீக்கவா?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'இது அனைத்து பெறப்பட்ட அறிவு வரைபட தரவையும் நீக்கும். உங்கள் அசல் நினைவுகள் பாதுகாப்பாக இருக்கும்.';
+  String get deleteKnowledgeGraphWarning => 'இது அனைத்து பெறப்பட்ட அறிவு வரைபட தரவையும் நீக்கும். உங்கள் அசல் நினைவுகள் பாதுகாப்பாக இருக்கும்.';
 
   @override
   String get connectOmiWithAI => 'Omi ஐ AI உதவியாளர்களுடன் இணைக்கவும்';
@@ -3968,8 +3884,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'விதிகள் மற்றும் இரகசியத கொள்கை';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'சிக்கல்களை நோயறிய உதவுகிறது. 3 நாட்களுக்குப் பிறகு தானாக நீக்கப்படுகிறது.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'சிக்கல்களை நோயறிய உதவுகிறது. 3 நாட்களுக்குப் பிறகு தானாக நீக்கப்படுகிறது.';
 
   @override
   String get manageYourApp => 'உங்கள் பயன்பாட்டை நிர்வகிக்கவும்';
@@ -3984,8 +3899,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get updateAppQuestion => 'பயன்பாட்டை புதுப்பிக்கவா?';
 
   @override
-  String get updateAppConfirmation =>
-      'உங்கள் பயன்பாட்டை புதுப்பிக்க விரும்புகிறீர்களா? நமது குழு மதிப்பாய்வு செய்த பிறகு மாற்றங்கள் பிரதிபலிக்கும்.';
+  String get updateAppConfirmation => 'உங்கள் பயன்பாட்டை புதுப்பிக்க விரும்புகிறீர்களா? நமது குழு மதிப்பாய்வு செய்த பிறகு மாற்றங்கள் பிரதிபலிக்கும்.';
 
   @override
   String get updateApp => 'பயன்பாட்டை புதுப்பிக்கவும்';
@@ -4015,8 +3929,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get no => 'இல்லை';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'சந்தா வெற்றிகரமாக ரத்து செய்யப்பட்டது. இது தற்போதைய பில்லிங் காலத்தின் முடிவு வரை சক்திய நிலையில் இருக்கும்.';
+  String get subscriptionCancelledSuccessfully => 'சந்தா வெற்றிகரமாக ரத்து செய்யப்பட்டது. இது தற்போதைய பில்லிங் காலத்தின் முடிவு வரை சক்திய நிலையில் இருக்கும்.';
 
   @override
   String get failedToCancelSubscription => 'சந்தாவை ரத்து செய்ய தவறிவிட்டது. மீண்டும் முயற்சி செய்யவும்.';
@@ -4052,8 +3965,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'சந்தாவை ரத்து செய்யவா?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'உங்கள் சந்தாவை ரத்து செய்ய விரும்புகிறீர்களா? உங்கள் தற்போதைய பில்லிங் காலத்தின் முடிவு வரை நீங்கள் அணுக்கத்தைப் பெற்றிருப்பீர்கள்.';
+  String get cancelSubscriptionConfirmation => 'உங்கள் சந்தாவை ரத்து செய்ய விரும்புகிறீர்களா? உங்கள் தற்போதைய பில்லிங் காலத்தின் முடிவு வரை நீங்கள் அணுக்கத்தைப் பெற்றிருப்பீர்கள்.';
 
   @override
   String get cancelSubscriptionButton => 'சந்தாவை ரத்து செய்யவும்';
@@ -4062,16 +3974,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get cancelling => 'ரத்து செய்யப்படுகிறது...';
 
   @override
-  String get betaTesterMessage =>
-      'இந்த பயன்பாட்டிற்குப் பீடா சோதனையாளர் நீங்கள். இது இன்னும் பொதுவாக இல்லை. அনுமதிக்கப்பட்ட பிறகு இது பொதுவாக இருக்கும்.';
+  String get betaTesterMessage => 'இந்த பயன்பாட்டிற்குப் பீடா சோதனையாளர் நீங்கள். இது இன்னும் பொதுவாக இல்லை. அনுமதிக்கப்பட்ட பிறகு இது பொதுவாக இருக்கும்.';
 
   @override
-  String get appUnderReviewMessage =>
-      'உங்கள் பயன்பாடு மதிப்பாய்விற்கு கீழ் உள்ளது மற்றும் உங்களுக்கு மட்டுமே புலப்படும். அனுமதிக்கப்பட்ட பிறகு இது பொதுவாக இருக்கும்.';
+  String get appUnderReviewMessage => 'உங்கள் பயன்பாடு மதிப்பாய்விற்கு கீழ் உள்ளது மற்றும் உங்களுக்கு மட்டுமே புலப்படும். அனுமதிக்கப்பட்ட பிறகு இது பொதுவாக இருக்கும்.';
 
   @override
-  String get appRejectedMessage =>
-      'உங்கள் பயன்பாடு நிராகரிக்கப்பட்டுள்ளது. பயன்பாட்டு விவரங்களைப் புதுப்பிக்கவும் மற்றும் மீண்டும் மதிப்பாய்வுக்கு சமர்ப்பிக்கவும்.';
+  String get appRejectedMessage => 'உங்கள் பயன்பாடு நிராகரிக்கப்பட்டுள்ளது. பயன்பாட்டு விவரங்களைப் புதுப்பிக்கவும் மற்றும் மீண்டும் மதிப்பாய்வுக்கு சமர்ப்பிக்கவும்.';
 
   @override
   String get invalidIntegrationUrl => 'தவறான ஒருங்கிணைப்பு URL';
@@ -4122,12 +4031,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get anonymousUser => 'அநாமதேய பயனர்';
 
   @override
-  String get issueActivatingApp =>
-      'இந்த பயன்பாட்டை செயல்படுத்துவதில் ஒரு சிக்கல் ஏற்பட்டது. மீண்டும் முயற்சி செய்யவும்.';
+  String get issueActivatingApp => 'இந்த பயன்பாட்டை செயல்படுத்துவதில் ஒரு சிக்கல் ஏற்பட்டது. மீண்டும் முயற்சி செய்யவும்.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'இந்த பயன்பாடு உங்கள் தரவை அணுகும். Omi AI இந்த பயன்பாடு உங்கள் தரவை எவ்வாறு பயன்படுத்துகிறது, மாற்றுகிறது அல்லது நீக்குகிறது என்பதற்கு பொறுப்பாகாது';
+  String get dataAccessNoticeDescription => 'இந்த பயன்பாடு உங்கள் தரவை அணுகும். Omi AI இந்த பயன்பாடு உங்கள் தரவை எவ்வாறு பயன்படுத்துகிறது, மாற்றுகிறது அல்லது நீக்குகிறது என்பதற்கு பொறுப்பாகாது';
 
   @override
   String get copyUrl => 'URL ஐ நகल் செய்யவும்';
@@ -4215,8 +4122,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get omiApiKeys => 'Omi API விசைகள்';
 
   @override
-  String get apiKeysDescription =>
-      'API விசைகள் உங்கள் பயன்பாடு OMI சர்வருடன் தொடர்பு கொள்ளும்போது அங்கீகாரத்திற்கு பயன்படுத்தப்படுகிறது. அவை உங்கள் பயன்பாடு நினைவுகளை உருவாக்கவும் மற்ற OMI சேவைகளுக்கு அணுக வாய்ப்பளிக்கிறது.';
+  String get apiKeysDescription => 'API விசைகள் உங்கள் பயன்பாடு OMI சர்வருடன் தொடர்பு கொள்ளும்போது அங்கீகாரத்திற்கு பயன்படுத்தப்படுகிறது. அவை உங்கள் பயன்பாடு நினைவுகளை உருவாக்கவும் மற்ற OMI சேவைகளுக்கு அணுக வாய்ப்பளிக்கிறது.';
 
   @override
   String get aboutOmiApiKeys => 'Omi API விசைகளைப் பற்றி';
@@ -4240,8 +4146,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API விசையை மறுக்கவா?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'இந்த செயலை செயல்தவிர்க்க முடியாது. இந்த விசையைப் பயன்படுத்தும் எந்த பயன்பாடுகளும் API க்கு மீண்டும் அணுக முடியாது.';
+  String get revokeApiKeyWarning => 'இந்த செயலை செயல்தவிர்க்க முடியாது. இந்த விசையைப் பயன்படுத்தும் எந்த பயன்பாடுகளும் API க்கு மீண்டும் அணுக முடியாது.';
 
   @override
   String get revoke => 'மறுக்கவும்';
@@ -4330,8 +4235,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get keyCreated => 'விசை உருவாக்கப்பட்டது';
 
   @override
-  String get keyCreatedMessage =>
-      'உங்கள் புதிய விசை உருவாக்கப்பட்டுள்ளது. தயவு செய்து இப்போது நகல் செய்யவும். நீங்கள் இதை மீண்டும் பார்க்க முடியாது.';
+  String get keyCreatedMessage => 'உங்கள் புதிய விசை உருவாக்கப்பட்டுள்ளது. தயவு செய்து இப்போது நகல் செய்யவும். நீங்கள் இதை மீண்டும் பார்க்க முடியாது.';
 
   @override
   String get keyWord => 'விசை';
@@ -4340,8 +4244,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get externalAppAccess => 'வெளிப்புற பயன்பாட்டு அணுக்கம்';
 
   @override
-  String get externalAppAccessDescription =>
-      'பின்வரும் நிறுவப்பட்ட பயன்பாடுகள் வெளிப்புற ஒருங்கிணைப்புகளைக் கொண்டுள்ளது மற்றும் உங்கள் தரவு, உரையாடல்கள் மற்றும் நினைவுகளை அணுக முடியும்.';
+  String get externalAppAccessDescription => 'பின்வரும் நிறுவப்பட்ட பயன்பாடுகள் வெளிப்புற ஒருங்கிணைப்புகளைக் கொண்டுள்ளது மற்றும் உங்கள் தரவு, உரையாடல்கள் மற்றும் நினைவுகளை அணுக முடியும்.';
 
   @override
   String get noExternalAppsHaveAccess => 'வெளிப்புற பயன்பாடுகள் உங்கள் தரவை அணுக முடியாது.';
@@ -4350,8 +4253,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get maximumSecurityE2ee => 'அதிகம் பாதுகாப்பு (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'End-to-end encryption இரகசியதைக்கான தங்கம் தரமாகும். செயல்படுத்தப்பட்டபோது, உங்கள் தரவு நம் சர்வரிற்கு அனுப்பப்படுவதற்கு முன் உங்கள் சாதனத்தில் குறியாக்கம் செய்யப்படுகிறது. இதன் பொருள் யாரும், Omi கூட, உங்கள் உள்ளடக்கத்தை அணுக முடியாது.';
+  String get e2eeDescription => 'End-to-end encryption இரகசியதைக்கான தங்கம் தரமாகும். செயல்படுத்தப்பட்டபோது, உங்கள் தரவு நம் சர்வரிற்கு அனுப்பப்படுவதற்கு முன் உங்கள் சாதனத்தில் குறியாக்கம் செய்யப்படுகிறது. இதன் பொருள் யாரும், Omi கூட, உங்கள் உள்ளடக்கத்தை அணுக முடியாது.';
 
   @override
   String get importantTradeoffs => 'முக்கியமான வாணிக்க:';
@@ -4366,8 +4268,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get featureComingSoon => 'இந்த அம்சம் விரைவில் வரவிருக்கிறது!';
 
   @override
-  String get migrationInProgressMessage =>
-      'இடப்பெயர்ப்பு நடந்து கொண்டிருக்கிறது. இது முடியாத வரை பாதுகாப்பு நிலையை மாற்ற முடியாது.';
+  String get migrationInProgressMessage => 'இடப்பெயர்ப்பு நடந்து கொண்டிருக்கிறது. இது முடியாத வரை பாதுகாப்பு நிலையை மாற்ற முடியாது.';
 
   @override
   String get migrationFailed => 'இடப்பெயர்ப்பு ব்যর்థ';
@@ -4386,8 +4287,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get secureEncryption => 'பாதுகாப்பான குறியாக்கம்';
 
   @override
-  String get secureEncryptionDescription =>
-      'உங்கள் தரவு Google Cloud இல் புலனாய்வு செய்யப்பட்ட சர்வரில் உங்களுக்கு தனிப்பட்ட விசையுடன் குறியாக்கம் செய்யப்படுகிறது. இதன் பொருள் உங்கள் மூல உள்ளடக்கம் Omi ஊழியர்கள் அல்லது Google உட்பட, தரவுதளத்திலிருந்து நேரடியாக அணுக முடியாது.';
+  String get secureEncryptionDescription => 'உங்கள் தரவு Google Cloud இல் புலனாய்வு செய்யப்பட்ட சர்வரில் உங்களுக்கு தனிப்பட்ட விசையுடன் குறியாக்கம் செய்யப்படுகிறது. இதன் பொருள் உங்கள் மூல உள்ளடக்கம் Omi ஊழியர்கள் அல்லது Google உட்பட, தரவுதளத்திலிருந்து நேரடியாக அணுக முடியாது.';
 
   @override
   String get endToEndEncryption => 'End-to-End குறியாக்கம்';
@@ -4396,8 +4296,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get e2eeCardDescription => 'அதிகம் பாதுகாப்புக்கு செயல்படுத்தவும். தட்டவும் மேலும் அறிய.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'பகுதி குறித்தில் இல்லாமல், உங்கள் தரவு எப்போதுமே ஓய்வில் மற்றும் போக்குவரத்தில் குறியாக்கம் செய்யப்படுகிறது.';
+  String get dataAlwaysEncrypted => 'பகுதி குறித்தில் இல்லாமல், உங்கள் தரவு எப்போதுமே ஓய்வில் மற்றும் போக்குவரத்தில் குறியாக்கம் செய்யப்படுகிறது.';
 
   @override
   String get readOnlyScope => 'படிக்க மட்டுமே';
@@ -4442,8 +4341,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get permissionsLabel => 'அனுமதிகள்';
 
   @override
-  String get permissionsInfoNote =>
-      'R = படிக்க, W = எழுதவும். எதுவும் தேர்ந்தெடுக்கப்படாவிட்டால் படிக்க-மட்டுமே இயல்புநிலை.';
+  String get permissionsInfoNote => 'R = படிக்க, W = எழுதவும். எதுவும் தேர்ந்தெடுக்கப்படாவிட்டால் படிக்க-மட்டுமே இயல்புநிலை.';
 
   @override
   String get developerApi => 'டெவலப்பர் API';
@@ -4463,12 +4361,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get trainingDataProgram => 'பயிற்சி தரவு திட்டம்';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'AI மாதிரികளை பயிற்சி செய்ய உங்கள் தரவு பங்களிப்பதன் மூலம் Omi Unlimited ஐ இலவசமாகப் பெறவும்.';
+  String get getOmiUnlimitedFree => 'AI மாதிரികளை பயிற்சி செய்ய உங்கள் தரவு பங்களிப்பதன் மூலம் Omi Unlimited ஐ இலவசமாகப் பெறவும்.';
 
   @override
-  String get trainingDataBullets =>
-      '• உங்கள் தரவு AI மாதிரிகளை மேம்படுத்த உதவுகிறது\n• இரகசியமற்ற தரவு மட்டுமே பகிரப்படுகிறது\n• முழுமையாக வெளிப்படையான செயல்முறை';
+  String get trainingDataBullets => '• உங்கள் தரவு AI மாதிரிகளை மேம்படுத்த உதவுகிறது\n• இரகசியமற்ற தரவு மட்டுமே பகிரப்படுகிறது\n• முழுமையாக வெளிப்படையான செயல்முறை';
 
   @override
   String get learnMoreAtOmiTraining => 'omi.me/training இல் மேலும் அறிந்து கொள்ளவும்';
@@ -4480,8 +4376,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get submitRequest => 'கோரிக்கையை சமர்ப்பிக்கவும்';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'நன்றி! உங்கள் கோரிக்கை மதிப்பாய்வு கீழ் உள்ளது. அனுமதிக்கப்பட்ட பிறகு நாங்கள் உங்களுக்கு தெரிவிப்போம்.';
+  String get thankYouRequestUnderReview => 'நன்றி! உங்கள் கோரிக்கை மதிப்பாய்வு கீழ் உள்ளது. அனுமதிக்கப்பட்ட பிறகு நாங்கள் உங்களுக்கு தெரிவிப்போம்.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4516,12 +4411,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get importantBillingInfo => 'முக்கிய பணம் செலுத்தும் தகவல்:';
 
   @override
-  String get monthlyPlanContinues =>
-      'உங்கள் தற்போதைய மாসிக திட்டம் உங்கள் பணம் செலுத்தும் காலத்தின் முடிவு வரை தொடர்ந்து இருக்கும்';
+  String get monthlyPlanContinues => 'உங்கள் தற்போதைய மாসிக திட்டம் உங்கள் பணம் செலுத்தும் காலத்தின் முடிவு வரை தொடர்ந்து இருக்கும்';
 
   @override
-  String get paymentMethodCharged =>
-      'உங்கள் বিদ்யமான பணம் செலுத்தும் முறை உங்கள் மாசிக திட்டம் முடிந்தவுடன் தானாக கட்டணம் செலுத்தப்படும்';
+  String get paymentMethodCharged => 'உங்கள் বিদ்யமான பணம் செலுத்தும் முறை உங்கள் மாசிக திட்டம் முடிந்தவுடன் தானாக கட்டணம் செலுத்தப்படும்';
 
   @override
   String get annualSubscriptionStarts => 'உங்கள் 12 மாস ஆண்டு சந்தா கட்டணத்தின் பிறகு தானாக தொடங்கும்';
@@ -4602,8 +4495,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get resubscribe => 'மீண்டும் சந்தா செய்யவும்';
 
   @override
-  String get couldNotOpenPaymentSettings =>
-      'பணம் செலுத்தும் அமைப்புகளைத் திறக்க முடியவில்லை. மீண்டும் முயற்சி செய்யவும்.';
+  String get couldNotOpenPaymentSettings => 'பணம் செலுத்தும் அமைப்புகளைத் திறக்க முடியவில்லை. மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get managePaymentMethod => 'பணம் செலுத்தும் முறையை நிர்வகிக்கவும்';
@@ -4632,8 +4524,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'உங்கள் தனியுரிமை எங்களுக்கு முக்கியம்';
 
   @override
-  String get privacyIntroText =>
-      'Omi இல், நாங்கள் உங்கள் தனியுரிமையை மிகவும் தீவிரமாக எடுத்துக்கொள்கிறோம். நாம் சேகரிக்கும் தரவு மற்றும் அதை உங்களுக்கான எங்கள் தயாரிப்பை மேம்படுத்த எவ்வாறு பயன்படுத்துகிறோம் என்பது பற்றி நாங்கள் வெளிப்படையாக இருக்க விரும்புகிறோம். நீங்கள் தெரிந்து கொள்ள வேண்டிய விஷயங்கள் இங்கே உள்ளன:';
+  String get privacyIntroText => 'Omi இல், நாங்கள் உங்கள் தனியுரிமையை மிகவும் தீவிரமாக எடுத்துக்கொள்கிறோம். நாம் சேகரிக்கும் தரவு மற்றும் அதை உங்களுக்கான எங்கள் தயாரிப்பை மேம்படுத்த எவ்வாறு பயன்படுத்துகிறோம் என்பது பற்றி நாங்கள் வெளிப்படையாக இருக்க விரும்புகிறோம். நீங்கள் தெரிந்து கொள்ள வேண்டிய விஷயங்கள் இங்கே உள்ளன:';
 
   @override
   String get whatWeTrack => 'நாங்கள் என்ன ட்র্যাக் செய்கிறோம்';
@@ -4648,12 +4539,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get ourCommitment => 'எங்கள் சேவையுறவு';
 
   @override
-  String get commitmentText =>
-      'நாங்கள் சேகரிக்கும் தரவை Omi ஐ உங்களுக்கு சிறந்த தயாரிப்பாக செய்ய பயன்படுத்த பிரতிசெரிக்கப் பட்டுள்ளோம். உங்கள் தனியுரிமை மற்றும் நம்பிக்கை எங்களுக்கு மிக முக்கியம்.';
+  String get commitmentText => 'நாங்கள் சேகரிக்கும் தரவை Omi ஐ உங்களுக்கு சிறந்த தயாரிப்பாக செய்ய பயன்படுத்த பிரতிசெரிக்கப் பட்டுள்ளோம். உங்கள் தனியுரிமை மற்றும் நம்பிக்கை எங்களுக்கு மிக முக்கியம்.';
 
   @override
-  String get thankYouText =>
-      'Omi இன் மதிப்புள்ள ব்যবহারকாரராக இருந்தமைக்கு நன்றி. உங்களுக்கு ஏதேனும் கேள்விகள் அல்லது கவலைகள் இருந்தால், team@basedhardware.com ஐக்கு தொடர்பு கொள்ளவும்.';
+  String get thankYouText => 'Omi இன் மதிப்புள்ள ব்যবহারকாரராக இருந்தமைக்கு நன்றி. உங்களுக்கு ஏதேனும் கேள்விகள் அல்லது கவலைகள் இருந்தால், team@basedhardware.com ஐக்கு தொடர்பு கொள்ளவும்.';
 
   @override
   String get wifiSyncSettings => 'WiFi ஒத்திசைவு அமைப்புகள்';
@@ -4662,8 +4551,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get enterHotspotCredentials => 'உங்கள் ஃபோனின் ஹாட்ஸ்பாட் நற்சான்றுகளை உள்ளிடவும்';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi ஒத்திசைவு உங்கள் ஃபோனைப் பயன்படுத்தி ஹாட்ஸ்பாட்டாக பயன்படுத்துகிறது. அமைப்புகள் > தனிப்பட்ட ஹாட்ஸ்பாட்டில் உங்கள் ஹாட்ஸ்பாட் பெயர் மற்றும் கடவுச்சொல்லைக் கண்டறியவும்.';
+  String get wifiSyncUsesHotspot => 'WiFi ஒத்திசைவு உங்கள் ஃபோனைப் பயன்படுத்தி ஹாட்ஸ்பாட்டாக பயன்படுத்துகிறது. அமைப்புகள் > தனிப்பட்ட ஹாட்ஸ்பாட்டில் உங்கள் ஹாட்ஸ்பாட் பெயர் மற்றும் கடவுச்சொல்லைக் கண்டறியவும்.';
 
   @override
   String get hotspotNameSsid => 'ஹாட்ஸ்பாட் பெயர் (SSID)';
@@ -4698,8 +4586,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'சுருக்கம் உருவாக்க முடியவில்லை. அந்த நாளுக்கான உரையாடல்கள் உள்ளதா என்பதைச் சரிபார்க்கவும்.';
+  String get failedToGenerateSummaryCheckConversations => 'சுருக்கம் உருவாக்க முடியவில்லை. அந்த நாளுக்கான உரையாடல்கள் உள்ளதா என்பதைச் சரிபார்க்கவும்.';
 
   @override
   String get summaryNotFound => 'சுருக்கம் கிடைக்கவில்லை';
@@ -4729,8 +4616,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'ஏற்றுமதி தொடங்கியது. இது சில நொடிகள் ஆகலாம்...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'இது அனைத்து பெறப்பட்ட அறிவு வரைபட தரவு (முனைகள் மற்றும் இணைப்புகள்) நீக்கும். உங்கள் அசல் நினைவுகள் பாதுகாப்பாக இருக்கும். வரைபடம் সময়ের சாக்கில் அல்லது அடுத்த요request இல் மறுபடியும் உருவாக்கப்படும்.';
+  String get knowledgeGraphDeleteDescription => 'இது அனைத்து பெறப்பட்ட அறிவு வரைபட தரவு (முனைகள் மற்றும் இணைப்புகள்) நீக்கும். உங்கள் அசல் நினைவுகள் பாதுகாப்பாக இருக்கும். வரைபடம் সময়ের சாக்கில் அல்லது அடுத்த요request இல் மறுபடியும் உருவாக்கப்படும்.';
 
   @override
   String get configureDailySummaryDigest => 'உங்கள் தினசரி செயல்பாட்டு உருப்பொறிப்பு செய்திகளை கட்டமைக்கவும்';
@@ -4800,8 +4686,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'அனைத்து Limitless உரையாடல்களையும் நீக்கவா?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'இது Limitless இலிருந்து ஏற்றுமதி செய்யப்பட்ட அனைத்து உரையாடல்களையும் நிரந்தரமாக நீக்கும். இந்த வினை செய்ய முடியாது.';
+  String get deleteAllLimitlessWarning => 'இது Limitless இலிருந்து ஏற்றுமதி செய்யப்பட்ட அனைத்து உரையாடல்களையும் நிரந்தரமாக நீக்கும். இந்த வினை செய்ய முடியாது.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4857,8 +4742,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get howItWorksTitle => 'இது எவ்வாறு செயல்படுகிறது?';
 
   @override
-  String get howPeopleWorks =>
-      'ஒரு ব்যக்தி உருவாக்கப்பட்டவுடன், நீங்கள் ஒரு உரையாடல் பதிவுக்குச் சென்று அவர்களை அவர்களின் தொடர்புடைய பிரிவுகளுக்கு நியமித்து, Omi அவர்களின் பேச்சை உணர்ந்து கொள்ள முடியும்!';
+  String get howPeopleWorks => 'ஒரு ব்যக்தி உருவாக்கப்பட்டவுடன், நீங்கள் ஒரு உரையாடல் பதிவுக்குச் சென்று அவர்களை அவர்களின் தொடர்புடைய பிரிவுகளுக்கு நியமித்து, Omi அவர்களின் பேச்சை உணர்ந்து கொள்ள முடியும்!';
 
   @override
   String get tapToDelete => 'நீக்க தட்டவும்';
@@ -4884,8 +4768,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get privacyNotice => 'தனியுரிமை அறிவிப்பு';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'பதிவுகள் மற்றவர்களின் குரல்களைப் பெறலாம். இயக்குவதற்கு முன் அனைத்து பங்கேற்றவர்களிடமிருந்து ஒப்புதல் பெறவும்.';
+  String get recordingsMayCaptureOthers => 'பதிவுகள் மற்றவர்களின் குரல்களைப் பெறலாம். இயக்குவதற்கு முன் அனைத்து பங்கேற்றவர்களிடமிருந்து ஒப்புதல் பெறவும்.';
 
   @override
   String get enable => 'இயக்கவும்';
@@ -4897,8 +4780,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get on => 'இயக்கம்';
 
   @override
-  String get storeAudioDescription =>
-      'அனைத்து ஆடியோ பதிவுகளையும் உங்கள் ஃபோனில் உள்ளூரில் சேமிக்கவும். முடக்கப்பட்டால், சேமிப்பு இடத்தைச் சேமிக்க தோல்வியுற்ற பதிவுகள் மட்டுமே வைக்கப்படுகிறது.';
+  String get storeAudioDescription => 'அனைத்து ஆடியோ பதிவுகளையும் உங்கள் ஃபோனில் உள்ளூரில் சேமிக்கவும். முடக்கப்பட்டால், சேமிப்பு இடத்தைச் சேமிக்க தோல்வியுற்ற பதிவுகள் மட்டுமே வைக்கப்படுகிறது.';
 
   @override
   String get enableLocalStorage => 'உள்ளூர் சேமிப்பை இயக்கவும்';
@@ -4916,12 +4798,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get storeAudioOnCloud => 'ஆடியோவை கிளவுடில் சேமிக்கவும்';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'உங்கள் நிகழ்நேர பதிவுகள் நீங்கள் பேசும்போது தனிப்பட்ட கிளவுட் சேமிப்பில் சேமிக்கப்படும்.';
+  String get cloudStorageDialogMessage => 'உங்கள் நிகழ்நேர பதிவுகள் நீங்கள் பேசும்போது தனிப்பட்ட கிளவுட் சேமிப்பில் சேமிக்கப்படும்.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'உங்கள் நிகழ்நேர பதிவுகளை நீங்கள் பேசும்போது தனிப்பட்ட கிளவுட் சேமிப்பில் சேமிக்கவும். ஆடியோ நிகழ்நேரத்தில் பெறப்பட்டு பாதுகாப்பாக சேமிக்கப்படுகிறது.';
+  String get storeAudioCloudDescription => 'உங்கள் நிகழ்நேர பதிவுகளை நீங்கள் பேசும்போது தனிப்பட்ட கிளவுட் சேமிப்பில் சேமிக்கவும். ஆடியோ நிகழ்நேரத்தில் பெறப்பட்டு பாதுகாப்பாக சேமிக்கப்படுகிறது.';
 
   @override
   String get downloadingFirmware => 'ஃபার்மওয়்যேர் பதிவிறக்கம் செய்யப்படுகிறது';
@@ -4930,8 +4810,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get installingFirmware => 'ஃபார்மூவேர் நிறுவப்படுகிறது';
 
   @override
-  String get firmwareUpdateWarning =>
-      'பயன்பாட்டைப் பூட்டாதீர்கள் அல்லது சாதனத்தை முடக்காதீர்கள். இது உங்கள் சாதனத்தை பாதிக்கலாம்।';
+  String get firmwareUpdateWarning => 'பயன்பாட்டைப் பூட்டாதீர்கள் அல்லது சாதனத்தை முடக்காதீர்கள். இது உங்கள் சாதனத்தை பாதிக்கலாம்।';
 
   @override
   String get firmwareUpdated => 'ஃபार்மூவேர் புதுப்பிக்கப்பட்டது';
@@ -4975,8 +4854,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get payments => 'பணப் பரிமாற்றங்கள்';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'உங்கள் பயன்பாடுகளுக்கான பணம் பெற ஒரு பணம் செலுத்தும் முறையைக் கீழே இணைக்கவும்.';
+  String get connectPaymentMethodInfo => 'உங்கள் பயன்பாடுகளுக்கான பணம் பெற ஒரு பணம் செலுத்தும் முறையைக் கீழே இணைக்கவும்.';
 
   @override
   String get selectedPaymentMethod => 'தேர்ந்தெடுக்கப்பட்ட பணம் செலுத்தும் முறை';
@@ -5003,15 +4881,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get monthlyPayouts => 'மாசிக வெளியாதல்';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'நீங்கள் \$10 இல் வருவாயை அடையும்போது உங்கள் கணக்குக்கு நேரடியாக மাசிக பணம் பெறவும்';
+  String get monthlyPayoutsDescription => 'நீங்கள் \$10 இல் வருவாயை அடையும்போது உங்கள் கணக்குக்கு நேரடியாக மাசிக பணம் பெறவும்';
 
   @override
   String get secureAndReliable => 'பாதுகாப்பற்ற மற்றும் நம்பகமான';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe உங்கள் பயன்பாட்டு வருவாய் பாதுகாப்பற்ற மற்றும் சময மாறுதல் உறுதி செய்கிறது';
+  String get stripeSecureDescription => 'Stripe உங்கள் பயன்பாட்டு வருவாய் பாதுகாப்பற்ற மற்றும் சময மாறுதல் உறுதி செய்கிறது';
 
   @override
   String get selectYourCountry => 'உங்கள் நாட்டைத் தேர்ந்தெடுக்கவும்';
@@ -5032,8 +4908,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get connectingYourStripeAccount => 'உங்கள் Stripe கணக்கை இணைக்கப்படுகிறது';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'தயவுசெய்து உங்கள் உலாவியில் Stripe onboarding செயல்முறையை முடிக்கவும். இந்த பக்கம் முடிந்தவுடன் தானாக புதுப்பிக்கப்படும்.';
+  String get stripeOnboardingInstructions => 'தயவுசெய்து உங்கள் உலாவியில் Stripe onboarding செயல்முறையை முடிக்கவும். இந்த பக்கம் முடிந்தவுடன் தானாக புதுப்பிக்கப்படும்.';
 
   @override
   String get failedTryAgain => 'தோல்வி? மீண்டும் முயற்சி செய்யவும்';
@@ -5045,15 +4920,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get successfullyConnected => 'வெற்றிகரமாக இணைக்கப்பட்டது!';
 
   @override
-  String get stripeReadyForPayments =>
-      'உங்கள் Stripe கணக்கு இப்போது பணம் பெற தயாரிடமாக உள்ளது. நீங்கள் உங்கள் பயன்பாட்டு விற்பனைகளிலிருந்து உடனே பணம் அர்ப்பணிக்க தொடங்கலாம்।';
+  String get stripeReadyForPayments => 'உங்கள் Stripe கணக்கு இப்போது பணம் பெற தயாரிடமாக உள்ளது. நீங்கள் உங்கள் பயன்பாட்டு விற்பனைகளிலிருந்து உடனே பணம் அர்ப்பணிக்க தொடங்கலாம்।';
 
   @override
   String get updateStripeDetails => 'Stripe விவரங்களைப் புதுப்பிக்கவும்';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Stripe விவரங்களைப் புதுப்பிப்பதில் பிழை! பிற்பாக மீண்டும் முயற்சி செய்யவும்.';
+  String get errorUpdatingStripeDetails => 'Stripe விவரங்களைப் புதுப்பிப்பதில் பிழை! பிற்பாக மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get updatePayPal => 'PayPal ஐ புதுப்பிக்கவும்';
@@ -5074,8 +4947,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me இணைப்பு';
 
   @override
-  String get stripeRecommendation =>
-      'Stripe உங்கள் நாட்டில் கிடைக்குமாறு, வேகமான மற்றும் எளிய வெளியாதலுக்கு இதைப் பயன்படுத்த மிக உயர்ந்த பரிந்துரை செய்கிறோம்.';
+  String get stripeRecommendation => 'Stripe உங்கள் நாட்டில் கிடைக்குமாறு, வேகமான மற்றும் எளிய வெளியாதலுக்கு இதைப் பயன்படுத்த மிக உயர்ந்த பரிந்துரை செய்கிறோம்.';
 
   @override
   String get updatePayPalDetails => 'PayPal விவரங்களைப் புதுப்பிக்கவும்';
@@ -5127,12 +4999,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'கூடுதல் பேச்சு மாதிரி அகற்றப்பட்டது';
 
   @override
-  String get consentDataMessage =>
-      'தொடர்வதன் மூலம், உங்கள் உரையாடல்கள், பதிவுகள் மற்றும் தனிப்பட்ட தகவல்கள் எங்கள் சேவையகங்களில் பாதுகாப்பாக சேமிக்கப்படும். உங்கள் ஆடியோ பதிவுகள் மற்றும் படியெடுப்புகள் மூன்றாம் தரப்பு AI சேவைகளால் செயலாக்கப்படுகின்றன (படியெடுப்பிற்கு Deepgram மற்றும் பகுப்பாய்விற்கு OpenAI உட்பட) AI இயக்கும் நுண்ணறிவுகளை உங்களுக்கு வழங்கவும் அனைத்து பயன்பாட்டு அம்சங்களையும் இயக்கவும்.';
+  String get consentDataMessage => 'தொடர்வதன் மூலம், உங்கள் உரையாடல்கள், பதிவுகள் மற்றும் தனிப்பட்ட தகவல்கள் எங்கள் சேவையகங்களில் பாதுகாப்பாக சேமிக்கப்படும். உங்கள் ஆடியோ பதிவுகள் மற்றும் படியெடுப்புகள் மூன்றாம் தரப்பு AI சேவைகளால் செயலாக்கப்படுகின்றன (படியெடுப்பிற்கு Deepgram மற்றும் பகுப்பாய்விற்கு OpenAI உட்பட) AI இயக்கும் நுண்ணறிவுகளை உங்களுக்கு வழங்கவும் அனைத்து பயன்பாட்டு அம்சங்களையும் இயக்கவும்.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'உங்கள் உரையாடல்களிலிருந்து பணிகள் இங்கே தோன்றும்।\\n+ தட்டி கைமுறை ஒன்றை உருவாக்கவும்।';
+  String get tasksEmptyStateMessage => 'உங்கள் உரையாடல்களிலிருந்து பணிகள் இங்கே தோன்றும்।\\n+ தட்டி கைமுறை ஒன்றை உருவாக்கவும்।';
 
   @override
   String get clearChatAction => 'உரையாடலைத் தெளிக்கவும்';
@@ -5168,15 +5038,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get installOmiOnAppleWatch => 'உங்கள் Apple Watch இல் Omi ஐ நிறுவவும்';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Omi உடன் உங்கள் Apple Watch ஐப் பயன்படுத்த, நீங்கள் முதலில் Omi பயன்பாட்டை உங்கள் கடிகாரத்தில் நிறுவ வேண்டும்.';
+  String get installOmiOnAppleWatchDescription => 'Omi உடன் உங்கள் Apple Watch ஐப் பயன்படுத்த, நீங்கள் முதலில் Omi பயன்பாட்டை உங்கள் கடிகாரத்தில் நிறுவ வேண்டும்.';
 
   @override
   String get openOmiOnAppleWatch => 'உங்கள் Apple Watch இல் Omi ஐத் திறக்கவும்';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi பயன்பாடு உங்கள் Apple Watch இல் நிறுவப்பட்டுள்ளது. அதைத் திறந்து தொடங்க தட்டவும்.';
+  String get openOmiOnAppleWatchDescription => 'Omi பயன்பாடு உங்கள் Apple Watch இல் நிறுவப்பட்டுள்ளது. அதைத் திறந்து தொடங்க தட்டவும்.';
 
   @override
   String get openWatchApp => 'Watch பயன்பாட்டைத் திறக்கவும்';
@@ -5185,15 +5053,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'நான் பயன்பாட்டை நிறுவ மற்றும் திறந்துவிட்டேன்';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch பயன்பாட்டைத் திறக்க முடியவில்லை. உங்கள் Apple Watch இல் Watch பயன்பாட்டை கைமுறையாக திறந்து \"Available Apps\" பிரிவிலிருந்து Omi ஐ நிறுவவும்.';
+  String get unableToOpenWatchApp => 'Apple Watch பயன்பாட்டைத் திறக்க முடியவில்லை. உங்கள் Apple Watch இல் Watch பயன்பாட்டை கைமுறையாக திறந்து \"Available Apps\" பிரிவிலிருந்து Omi ஐ நிறுவவும்.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch வெற்றிகரமாக இணைக்கப்பட்டது!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch இன்னும் அடையாளவாக இல்லை. Omi பயன்பாடு உங்கள் கடிகாரத்தில் திறந்திருக்கிறதா என்பதை உறுதிப்படுத்தவும்।';
+  String get appleWatchNotReachable => 'Apple Watch இன்னும் அடையாளவாக இல்லை. Omi பயன்பாடு உங்கள் கடிகாரத்தில் திறந்திருக்கிறதா என்பதை உறுதிப்படுத்தவும்।';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5621,30 +5487,25 @@ class AppLocalizationsTa extends AppLocalizations {
   String get multipleSpeakersDetected => 'பல பேச்சாளர்கள் கண்டறியப்பட்டனர்';
 
   @override
-  String get multipleSpeakersDescription =>
-      'பதிவில் பல பேச்சாளர்கள் இருக்கிறார்களாக தோன்றுகிறது. நீங்கள் அமைதியான இடத்தில் உள்ளீர்களா என்பதைத் திறக்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
+  String get multipleSpeakersDescription => 'பதிவில் பல பேச்சாளர்கள் இருக்கிறார்களாக தோன்றுகிறது. நீங்கள் அமைதியான இடத்தில் உள்ளீர்களா என்பதைத் திறக்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get invalidRecordingDetected => 'தவறான பதிவு கண்டறியப்பட்டது';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'போதுமான பேச்சு கண்டறியப்படவில்லை. மேலும் பேசவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
+  String get notEnoughSpeechDescription => 'போதுமான பேச்சு கண்டறியப்படவில்லை. மேலும் பேசவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
 
   @override
-  String get speechDurationDescription =>
-      'குறைந்தபட்சம் 5 விநாடிகளுக்கு பேச வேண்டும், 90 விநாடிகளுக்கு மேல் பேசக்கூடாது.';
+  String get speechDurationDescription => 'குறைந்தபட்சம் 5 விநாடிகளுக்கு பேச வேண்டும், 90 விநாடிகளுக்கு மேல் பேசக்கூடாது.';
 
   @override
-  String get connectionLostDescription =>
-      'இணைப்பு துண்டிக்கப்பட்டுவிட்டது. உங்கள் இணைய இணைப்பை சரிபார்த்து மீண்டும் முயற்சி செய்யவும்.';
+  String get connectionLostDescription => 'இணைப்பு துண்டிக்கப்பட்டுவிட்டது. உங்கள் இணைய இணைப்பை சரிபார்த்து மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get howToTakeGoodSample => 'ஒரு நல்ல மாதிரி எப்படி பதிவுசெய்வது?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. நீங்கள் ஒரு조용한அமைப்பில் இருக்கிறீர்கள் என்பதை உறுதிசெய்யவும்.\n2. தெளிவாக மற்றும் இயல்பாக பேசுங்கள்.\n3. உங்கள் சாதனம் உங்கள் கழுத்தில் இயல்பான நிலையில் இருக்கிறது என்பதை உறுதிசெய்யவும்.\n\nஒருமுறை உருவாக்கிய பின், நீங்கள் எப்போதும் அதை மேம்படுத்தலாம் அல்லது மீண்டும் செய்யலாம்.';
+  String get goodSampleInstructions => '1. நீங்கள் ஒரு조용한அமைப்பில் இருக்கிறீர்கள் என்பதை உறுதிசெய்யவும்.\n2. தெளிவாக மற்றும் இயல்பாக பேசுங்கள்.\n3. உங்கள் சாதனம் உங்கள் கழுத்தில் இயல்பான நிலையில் இருக்கிறது என்பதை உறுதிசெய்யவும்.\n\nஒருமுறை உருவாக்கிய பின், நீங்கள் எப்போதும் அதை மேம்படுத்தலாம் அல்லது மீண்டும் செய்யலாம்.';
 
   @override
   String get noDeviceConnectedUseMic => 'சாதனம் இணைக்கப்படவில்லை. தொலைபேசி மைக்ரோஃபோனைப் பயன்படுத்தப்படும்.';
@@ -5686,8 +5547,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get notificationFrequency => 'அறிவிப்பு அதிர்வெண்';
 
   @override
-  String get controlNotificationFrequency =>
-      'Omi உங்களுக்கு தீவிர அறிவிப்புகளை எவ்வளவு அடிக்கடி அனுப்புகிறது என்பதை নিয়ந்திரணம் செய்யுங்கள்.';
+  String get controlNotificationFrequency => 'Omi உங்களுக்கு தீவிர அறிவிப்புகளை எவ்வளவு அடிக்கடி அனுப்புகிறது என்பதை নিয়ந்திரணம் செய்யுங்கள்.';
 
   @override
   String get yourScore => 'உங்கள் மதிப்பெண்';
@@ -5708,12 +5568,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get howItWorks => 'இது எவ்வாறு செயல்படுகிறது';
 
   @override
-  String get dailyScoreExplanation =>
-      'உங்கள் தினசரி மதிப்பெண் பணி நிறைவுக்கு அடிப்படையாக உள்ளது. உங்கள் மதிப்பெண்ணை மேம்படுத்த உங்கள் பணிகளை நிறைவு செய்யவும்!';
+  String get dailyScoreExplanation => 'உங்கள் தினசரி மதிப்பெண் பணி நிறைவுக்கு அடிப்படையாக உள்ளது. உங்கள் மதிப்பெண்ணை மேம்படுத்த உங்கள் பணிகளை நிறைவு செய்யவும்!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Omi உங்களுக்கு தீவிர அறிவிப்புகள் மற்றும் நினைவூட்டல்களை எவ்வளவு அடிக்கடி அனுப்புகிறது என்பதை நிய்ந்திரணம் செய்யுங்கள்.';
+  String get notificationFrequencyDescription => 'Omi உங்களுக்கு தீவிர அறிவிப்புகள் மற்றும் நினைவூட்டல்களை எவ்வளவு அடிக்கடி அனுப்புகிறது என்பதை நிய்ந்திரணம் செய்யுங்கள்.';
 
   @override
   String get sliderOff => 'முடக்கவும்';
@@ -5727,8 +5585,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'சுருக்கம் உருவாக்க தவறிவிட்டது. அந்த நாளில் உரையாடல்கள் உள்ளன என்பதை உறுதிசெய்யவும்.';
+  String get failedToGenerateSummary => 'சுருக்கம் உருவாக்க தவறிவிட்டது. அந்த நாளில் உரையாடல்கள் உள்ளன என்பதை உறுதிசெய்யவும்.';
 
   @override
   String get recap => 'மறுபார்வை';
@@ -5807,8 +5664,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get selectApp => 'பயன்பாட்டைத் தேர்ந்தெடுக்கவும்';
 
   @override
-  String get noChatAppsEnabled =>
-      'எந்த உரையாடல் பயன்பாடுகளும் இயக்கப்பட்டிருக்கவில்லை.\n\"பயன்பாடுகளை இயக்கு\" என்பதற்கு தட்டவும் சிலவற்றைச் சேர்க்க.';
+  String get noChatAppsEnabled => 'எந்த உரையாடல் பயன்பாடுகளும் இயக்கப்பட்டிருக்கவில்லை.\n\"பயன்பாடுகளை இயக்கு\" என்பதற்கு தட்டவும் சிலவற்றைச் சேர்க்க.';
 
   @override
   String get disable => 'முடக்கவும்';
@@ -5888,8 +5744,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get wifiEnableFailed => 'சாதனத்தில் WiFi இயக்க முடியவில்லை. மீண்டும் முயற்சி செய்யவும்.';
 
   @override
-  String get deviceNoFastTransfer =>
-      'உங்கள் சாதனம் வேகமான பரிமாற்றம் ஆதரிக்காது. அதற்கு பதிலாக Bluetooth பயன்படுத்தவும்.';
+  String get deviceNoFastTransfer => 'உங்கள் சாதனம் வேகமான பரிமாற்றம் ஆதரிக்காது. அதற்கு பதிலாக Bluetooth பயன்படுத்தவும்.';
 
   @override
   String get enableHotspotMessage => 'உங்கள் தொலைபேசியின் ஹாட்ஸ்பாட்டை இயக்கவும் மற்றும் மீண்டும் முயற்சி செய்யவும்.';
@@ -6016,8 +5871,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL அமைக்கப்படவில்லை';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'இந்த அம்சத்தைப் பயன்படுத்த மேம்பாட்டாளர் அமைப்புகளில் webhook URL ஐ அமைக்கவும்.';
+  String get setWebhookUrlInSettings => 'இந்த அம்சத்தைப் பயன்படுத்த மேம்பாட்டாளர் அமைப்புகளில் webhook URL ஐ அமைக்கவும்.';
 
   @override
   String get sendWebUrl => 'வலை URL அனுப்பவும்';
@@ -6055,8 +5909,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get willLikelyCrash => 'இதை இயக்குவது பயன்பாட்டை செயலிழக்க அல்லது முடக்க வாய்ப்புள்ளது.';
 
   @override
-  String get transcriptionSlowerLessAccurate =>
-      'உபாய கேட்டுபேரல் கணிசமாக மெதுவாக இருக்கும் மற்றும் குறைவாக துல்லியமாக இருக்கும்.';
+  String get transcriptionSlowerLessAccurate => 'உபாய கேட்டுபேரல் கணிசமாக மெதுவாக இருக்கும் மற்றும் குறைவாக துல்லியமாக இருக்கும்.';
 
   @override
   String get proceedAnyway => 'எதிர்பாராக தொடரவும்';
@@ -6092,15 +5945,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get cloudProvider => 'மேக்லெவ பின்தொடரக்காரர்';
 
   @override
-  String get premiumMinutesInfo =>
-      'மாத மாதம் 1,200 பிரீமியம் நிமிடங்கள்.온-சாதன ট্যাब সীमाहीन இலவச உபாய கேட்டுபேரல் வழங்குகிறது।';
+  String get premiumMinutesInfo => 'மாத மாதம் 1,200 பிரீமியம் நிமிடங்கள்.온-சாதன ট্যাब সীमाहीन இலவச உபாய கேட்டுபேரல் வழங்குகிறது।';
 
   @override
   String get viewUsage => 'பயன்பாட்டைக் கவனிக்கவும்';
 
   @override
-  String get localProcessingInfo =>
-      'ஆடியோ உள்ளூரிலேயே செயலாக்கப்படுகிறது। অফலைனில் செயல்படுகிறது, மேலும் தனியுரிமை இருக்கிறது, ஆனால் அதிக பேட்டரி பயன்படுத்துகிறது।';
+  String get localProcessingInfo => 'ஆடியோ உள்ளூரிலேயே செயலாக்கப்படுகிறது। অফலைனில் செயல்படுகிறது, மேலும் தனியுரிமை இருக்கிறது, ஆனால் அதிக பேட்டரி பயன்படுத்துகிறது।';
 
   @override
   String get model => 'மாதிரி';
@@ -6109,15 +5960,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get performanceWarning => 'செயல்திறன் எச்சரிக்கை';
 
   @override
-  String get largeModelWarning =>
-      'இந்த மாதிரி பெரியதாக உள்ளது மற்றும் மொபைல் சாதனங்களில் பயன்பாட்டை செயலிழக்க அல்லது மிக மெதுவாக இயங்கக்கூடும்.\n\n\"சிறியவை\" அல்லது \"அடிப்படை\" பரிந்துரைக்கப்படுகிறது.';
+  String get largeModelWarning => 'இந்த மாதிரி பெரியதாக உள்ளது மற்றும் மொபைல் சாதனங்களில் பயன்பாட்டை செயலிழக்க அல்லது மிக மெதுவாக இயங்கக்கூடும்.\n\n\"சிறியவை\" அல்லது \"அடிப்படை\" பரிந்துரைக்கப்படுகிறது.';
 
   @override
   String get usingNativeIosSpeech => 'பூர்வீக iOS பேச்சு அங்கீகாரத்தைப் பயன்படுத்துகிறது';
 
   @override
-  String get noModelDownloadRequired =>
-      'உங்கள் சாதனத்தின் பூர்வீக பேச்சு ஞ்சனം பயன்படுத்தப்படும். மாதிரி பதிவிறக்கம் தேவையில்லை।';
+  String get noModelDownloadRequired => 'உங்கள் சாதனத்தின் பூர்வீக பேச்சு ஞ்சனം பயன்படுத்தப்படும். மாதிரி பதிவிறக்கம் தேவையில்லை।';
 
   @override
   String get modelReady => 'மாதிரி தயாரம்';
@@ -6174,12 +6023,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get batteryDrainSignificantly => 'பேட்டரி வெளியேற்றம் கணிசமாக அதிகரிக்கும்।';
 
   @override
-  String get premiumMinutesMonth =>
-      'மாத மாதம் 1,200 பிரீமியம் நிமிடங்கள்.온-சாதன ট்যாब சீமाहीन இலவச உபாய கேட்டுபேரல் வழங்குகிறது।';
+  String get premiumMinutesMonth => 'மாத மாதம் 1,200 பிரீமியம் நிமிடங்கள்.온-சாதன ট்যாब சீமाहीन இலவச உபாய கேட்டுபேரல் வழங்குகிறது।';
 
   @override
-  String get audioProcessedLocally =>
-      'ஆடியோ உள்ளூரிலேயே செயலாக்கப்படுகிறது। அफ்லைனில் செயல்படுகிறது, மேலும் தனியுரிமை இருக்கிறது, ஆனால் அதிக பேட்டரி பயன்படுத்துகிறது।';
+  String get audioProcessedLocally => 'ஆடியோ உள்ளூரிலேயே செயலாக்கப்படுகிறது। அफ்லைனில் செயல்படுகிறது, மேலும் தனியுரிமை இருக்கிறது, ஆனால் அதிக பேட்டரி பயன்படுத்துகிறது।';
 
   @override
   String get languageLabel => 'மொழி';
@@ -6188,12 +6035,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get modelLabel => 'மாதிரி';
 
   @override
-  String get modelTooLargeWarning =>
-      'இந்த மாதிரி பெரியதாக உள்ளது மற்றும் மொபைல் சாதனங்களில் பயன்பாட்டை செயலிழக்க அல்லது மிக மெதுவாக இயங்கக்கூடும்.\n\n\"சிறியவை\" அல்லது \"அடிப்படை\" பரிந்துரைக்கப்படுகிறது.';
+  String get modelTooLargeWarning => 'இந்த மாதிரி பெரியதாக உள்ளது மற்றும் மொபைல் சாதனங்களில் பயன்பாட்டை செயலிழக்க அல்லது மிக மெதுவாக இயங்கக்கூடும்.\n\n\"சிறியவை\" அல்லது \"அடிப்படை\" பரிந்துரைக்கப்படுகிறது.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'உங்கள் சாதனத்தின் பூர்வீக பேச்சு ஞ்சனம் பயன்படுத்தப்படும்। மாதிரி பதிவிறக்கம் தேவையில்லை।';
+  String get nativeEngineNoDownload => 'உங்கள் சாதனத்தின் பூர்வீக பேச்சு ஞ்சனம் பயன்படுத்தப்படும்। மாதிரி பதிவிறக்கம் தேவையில்லை।';
 
   @override
   String modelReadyWithName(String model) {
@@ -6229,8 +6074,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi இன் உள்ளமைந்த நேரடி உபாய கேட்டுபேரல் உரையாடல் பற்றிய ஒத்திசைப்பு மற்றும் தற்போதைய பேச்சாளர் கண்டறிதலுக்கு தெளிவு செய்யப்பட்டுள்ளது।';
+  String get omiTranscriptionOptimized => 'Omi இன் உள்ளமைந்த நேரடி உபாய கேட்டுபேரல் உரையாடல் பற்றிய ஒத்திசைப்பு மற்றும் தற்போதைய பேச்சாளர் கண்டறிதலுக்கு தெளிவு செய்யப்பட்டுள்ளது।';
 
   @override
   String get reset => 'மீட்டமைக்கவும்';
@@ -6450,8 +6294,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'நினைவுகளிலிருந்து உங்கள் ஞ்ஞான வரைபடத்தை உருவாக்குகிறது...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'நீங்கள் புதிய நினைவுகளை உருவாக்கும்போது உங்கள் ஞ்ஞான வரைபடம் தானாகவே உருவாக்கப்படும்.';
+  String get knowledgeGraphWillBuildAutomatically => 'நீங்கள் புதிய நினைவுகளை உருவாக்கும்போது உங்கள் ஞ்ஞான வரைபடம் தானாகவே உருவாக்கப்படும்.';
 
   @override
   String get buildGraphButton => 'வரைபடம் உருவாக்குங்கள்';
@@ -6619,8 +6462,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get personNameAlreadyExists => 'இந்த பெயரைக் கொண்ட ஒரு நபர் ஏற்கனவே உள்ளது।';
 
   @override
-  String get selectYouFromList =>
-      'உங்களைக் குறிப்பிட, பயன்படுத்தாதவர்கள் பட்டியலிலிருந்து \"நீங்கள்\" என்பதைத் தேர்ந்தெடுக்கவும்।';
+  String get selectYouFromList => 'உங்களைக் குறிப்பிட, பயன்படுத்தாதவர்கள் பட்டியலிலிருந்து \"நீங்கள்\" என்பதைத் தேர்ந்தெடுக்கவும்।';
 
   @override
   String get enterPersonsName => 'நபரின் பெயரை உள்ளிடவும்';
@@ -6643,8 +6485,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get shareViaSms => 'SMS வழியாக பகிர்ந்து கொள்ளுங்கள்';
 
   @override
-  String get selectContactsToShareSummary =>
-      'உங்கள் உரையாடல் சுருக்கம் பகிர்ந்து கொள்ள பொருத்தப்பட்ட தொடர்பைத் தேர்ந்தெடுக்கவும்';
+  String get selectContactsToShareSummary => 'உங்கள் உரையாடல் சுருக்கம் பகிர்ந்து கொள்ள பொருத்தப்பட்ட தொடர்பைத் தேர்ந்தெடுக்கவும்';
 
   @override
   String get searchContactsHint => 'பொருத்தப்பட்ட தொடர்பைத் தேடவும்...';
@@ -6689,8 +6530,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get failedToLoadContacts => 'பொருத்தப்பட்ட தொடர்பை லோடுசெய்ய முடியவில்லை';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'பகிர்ந்து கொள்ள உரையாடலைத் தயாரிக்க முடியவில்லை. மீண்டும் முயற்சி செய்யவும்.';
+  String get failedToPrepareConversationForSharing => 'பகிர்ந்து கொள்ள உரையாடலைத் தயாரிக்க முடியவில்லை. மீண்டும் முயற்சி செய்யவும்.';
 
   @override
   String get couldNotOpenSmsApp => 'SMS பயன்பாட்டைத் திறக்க முடியவில்லை. மீண்டும் முயற்சி செய்யவும்.';
@@ -6756,8 +6596,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'உங்கள் சாதனத்தின் SD கார்டிலிருந்து ஆடியோ பதிவிறக்குகிறது';
 
   @override
-  String get transferRequiredDescription =>
-      'இந்த பதிவுசெய்தல் உங்கள் சாதனத்தின் SD கார்டில் சேமிக்கப்பட்டுள்ளது. இதை விளையாட அல்லது பகிர்ந்து கொள்ள உங்கள் தொலைபேசியில் மாற்றவும்.';
+  String get transferRequiredDescription => 'இந்த பதிவுசெய்தல் உங்கள் சாதனத்தின் SD கார்டில் சேமிக்கப்பட்டுள்ளது. இதை விளையாட அல்லது பகிர்ந்து கொள்ள உங்கள் தொலைபேசியில் மாற்றவும்.';
 
   @override
   String get cancelTransfer => 'பரிமாற்றம் ரத்து செய்யவும்';
@@ -6778,8 +6617,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get shareRecording => 'பதிவை பகிரவும்';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'இந்த பதிவை நிரந்தரமாக நீக்க விரும்புகிறீர்களா? இதை செயல்தவிர்க்க முடியாது.';
+  String get deleteRecordingConfirmation => 'இந்த பதிவை நிரந்தரமாக நீக்க விரும்புகிறீர்களா? இதை செயல்தவிர்க்க முடியாது.';
 
   @override
   String get recordingIdLabel => 'பதிவு ID';
@@ -6838,15 +6676,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get enableFastTransfer => 'விரைவு பரிமாற்றம் இயக்கவும்';
 
   @override
-  String get fastTransferDescription =>
-      'விரைவு பரிமாற்றம் WiFi ஐ பயன்படுத்தி ~5 மடங்கு வேகமாக பரிமாற்றம் செய்கிறது. பரிமாற்றத்தின் போது உங்கள் ஃபோன் தற்காலிகமாக உங்கள் Omi சாதனத்தின் WiFi நெட்வொர்க்குடன் இணைக்கப்படும்.';
+  String get fastTransferDescription => 'விரைவு பரிமாற்றம் WiFi ஐ பயன்படுத்தி ~5 மடங்கு வேகமாக பரிமாற்றம் செய்கிறது. பரிமாற்றத்தின் போது உங்கள் ஃபோன் தற்காலிகமாக உங்கள் Omi சாதனத்தின் WiFi நெட்வொர்க்குடன் இணைக்கப்படும்.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'பரிமாற்றத்தின் போது இணைய அணுகல் நிறுத்தப்பட்டது';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'உங்கள் Omi சாதனத்தில் இருந்து உங்கள் ஃபோனுக்கு பதிவுகளை எவ்வாறு பரிமாற்ற வேண்டும் என்பதைத் தேர்ந்தெடுக்கவும்.';
+  String get chooseTransferMethodDescription => 'உங்கள் Omi சாதனத்தில் இருந்து உங்கள் ஃபோனுக்கு பதிவுகளை எவ்வாறு பரிமாற்ற வேண்டும் என்பதைத் தேர்ந்தெடுக்கவும்.';
 
   @override
   String get wifiSpeed => 'WiFi வழியாக ~150 KB/s';
@@ -6855,8 +6691,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get fiveTimesFaster => '5 மடங்கு வேகமாக';
 
   @override
-  String get fastTransferMethodDescription =>
-      'உங்கள் Omi சாதனத்திற்கு நேரடி WiFi இணைப்பை உருவாக்குகிறது. பரிமாற்றத்தின் போது உங்கள் ஃபோன் உங்கள் வழக்கமான WiFi இல் இருந்து தற்காலிகமாக துண்டிக்கப்படும்.';
+  String get fastTransferMethodDescription => 'உங்கள் Omi சாதனத்திற்கு நேரடி WiFi இணைப்பை உருவாக்குகிறது. பரிமாற்றத்தின் போது உங்கள் ஃபோன் உங்கள் வழக்கமான WiFi இல் இருந்து தற்காலிகமாக துண்டிக்கப்படும்.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6865,8 +6700,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get bleSpeed => 'BLE வழியாக ~30 KB/s';
 
   @override
-  String get bluetoothMethodDescription =>
-      'நிலையான Bluetooth குறைந்த ஆற்றல் இணைப்பைப் பயன்படுத்துகிறது. மெதுவாக இருந்தாலும் உங்கள் WiFi இணைப்பை பாதிக்காது.';
+  String get bluetoothMethodDescription => 'நிலையான Bluetooth குறைந்த ஆற்றல் இணைப்பைப் பயன்படுத்துகிறது. மெதுவாக இருந்தாலும் உங்கள் WiFi இணைப்பை பாதிக்காது.';
 
   @override
   String get selected => 'தேர்ந்தெடுக்கப்பட்டது';
@@ -6878,8 +6712,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get lowBatteryAlertTitle => 'குறைந்த பேட்டரி எச்சரிக்கை';
 
   @override
-  String get lowBatteryAlertBody =>
-      'உங்கள் சாதனத்தின் பேட்டரி குறைந்து விட்டது. மீண்டும் சார்ஜ் செய்ய வேண்டிய நேரம்! 🔋';
+  String get lowBatteryAlertBody => 'உங்கள் சாதனத்தின் பேட்டரி குறைந்து விட்டது. மீண்டும் சார்ஜ் செய்ய வேண்டிய நேரம்! 🔋';
 
   @override
   String get deviceDisconnectedNotificationTitle => 'உங்கள் Omi சாதனம் துண்டிக்கப்பட்டது';
@@ -6905,12 +6738,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get appDeleteFailed => 'பயன்பாடு நீக்க தோல்வியுற்றது. பின்னர் மீண்டும் முயற்சிக்கவும்.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'பயன்பாட்டு கண்ணியத் திறன் வெற்றிகரமாக மாற்றப்பட்டது. இது பிரதிபலிக்க சில நிமிடங்கள் ஆகலாம்.';
+  String get appVisibilityChangedSuccessfully => 'பயன்பாட்டு கண்ணியத் திறன் வெற்றிகரமாக மாற்றப்பட்டது. இது பிரதிபலிக்க சில நிமிடங்கள் ஆகலாம்.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'பயன்பாட்டைச் செயல்படுத்தும் போது பிழை. இது ஒரு ஒருங்கிணைப்பு பயன்பாடாக இருந்தால், அமைப்பு முடிந்துவிட்டதுதா என்பதை உறுதிசெய்யவும்.';
+  String get errorActivatingAppIntegration => 'பயன்பாட்டைச் செயல்படுத்தும் போது பிழை. இது ஒரு ஒருங்கிணைப்பு பயன்பாடாக இருந்தால், அமைப்பு முடிந்துவிட்டதுதா என்பதை உறுதிசெய்யவும்.';
 
   @override
   String get errorUpdatingAppStatus => 'பயன்பாட்டு நிலை புதுப்பிக்கும் போது பிழை ஏற்பட்டது.';
@@ -6949,8 +6780,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get allObjectsMigratedFinalizing =>
-      'அனைத்து பொருட்கள் இடம்பெயர்ப்பு செய்யப்பட்டுள்ளன. இறுதிசெய்யப்படுகிறது...';
+  String get allObjectsMigratedFinalizing => 'அனைத்து பொருட்கள் இடம்பெயர்ப்பு செய்யப்பட்டுள்ளன. இறுதிசெய்யப்படுகிறது...';
 
   @override
   String get migrationErrorOccurred => 'இடம்பெயர்ப்பு செய்யும் போது பிழை ஏற்பட்டது. மீண்டும் முயற்சிக்கவும்.';
@@ -6979,8 +6809,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get importantConversationTitle => 'முக்கியமான உரையாடல்';
 
   @override
-  String get importantConversationBody =>
-      'நீங்கள் ஒரு முக்கியமான உரையாடல் கொண்டிருந்தீர்கள். சுருக்கத்தை மற்றவர்களுடன் பகிர்ந்தெடுக்க தொடவும்.';
+  String get importantConversationBody => 'நீங்கள் ஒரு முக்கியமான உரையாடல் கொண்டிருந்தீர்கள். சுருக்கத்தை மற்றவர்களுடன் பகிர்ந்தெடுக்க தொடவும்.';
 
   @override
   String get templateName => 'டெம்பிளேட் பெயர்';
@@ -6992,8 +6821,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'பெயர் குறைந்தபட்சம் 3 எழுத்துக்கள் இருக்க வேண்டும்';
 
   @override
-  String get conversationPromptHint =>
-      'எ.கா., வழங்கப்பட்ட உரையாடலிலிருந்து செயல் பணிகள், சிদ்ധாந்த முடிவுகள் மற்றும் முக்கிய கருத்துக்களை பிரித்தெடுக்கவும்.';
+  String get conversationPromptHint => 'எ.கா., வழங்கப்பட்ட உரையாடலிலிருந்து செயல் பணிகள், சிদ்ധாந்த முடிவுகள் மற்றும் முக்கிய கருத்துக்களை பிரித்தெடுக்கவும்.';
 
   @override
   String get pleaseEnterAppPrompt => 'உங்கள் பயன்பாட்டிற்கான ஒரு உத்தரவு உள்ளிடவும்';
@@ -7026,12 +6854,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get failedToCreateApp => 'பயன்பாடு உருவாக்க தோல்வியுற்றது. மீண்டும் முயற்சிக்கவும்.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'தொடர்ந்து செல்ல உங்கள் பயன்பாட்டிற்கு ஒன்று அல்லது அதற்கு மேல் முக்கிய திறன்களைத் தேர்ந்தெடுக்கவும்';
+  String get addAppSelectCoreCapability => 'தொடர்ந்து செல்ல உங்கள் பயன்பாட்டிற்கு ஒன்று அல்லது அதற்கு மேல் முக்கிய திறன்களைத் தேர்ந்தெடுக்கவும்';
 
   @override
-  String get addAppSelectPaymentPlan =>
-      'உங்கள் பயன்பாட்டிற்கான பணம் செலுத்துதல் திட்டம் மற்றும் விலையை தேர்ந்தெடுக்கவும் மற்றும் உள்ளிடவும்';
+  String get addAppSelectPaymentPlan => 'உங்கள் பயன்பாட்டிற்கான பணம் செலுத்துதல் திட்டம் மற்றும் விலையை தேர்ந்தெடுக்கவும் மற்றும் உள்ளிடவும்';
 
   @override
   String get addAppSelectCapability => 'உங்கள் பயன்பாட்டிற்கு குறைந்தபட்சம் ஒரு திறன்களைத் தேர்ந்தெடுக்கவும்';
@@ -7077,8 +6903,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'புகைப்படங்கள் அனுமதி மறுக்கப்பட்டது. படத்தைத் தேர்ந்தெடுக்க புகைப்படங்களுக்கான அணுகலை அனுமதிக்கவும்';
+  String get addAppPhotosPermissionDenied => 'புகைப்படங்கள் அனுமதி மறுக்கப்பட்டது. படத்தைத் தேர்ந்தெடுக்க புகைப்படங்களுக்கான அணுகலை அனுமதிக்கவும்';
 
   @override
   String get addAppErrorSelectingImageRetry => 'படத்தைத் தேர்ந்தெடுக்கும் போது பிழை. மீண்டும் முயற்சிக்கவும்.';
@@ -7098,12 +6923,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get addAppPersonaConflictWithCapabilities => 'Persona மற்ற திறன்களுடன் தேர்ந்தெடுக்க முடியாது';
 
   @override
-  String get paymentFailedToFetchCountries =>
-      'ஆதரிக்கப்படும் நாடுகளை கொண்டு வர தோல்வியுற்றது. பின்னர் மீண்டும் முயற்சிக்கவும்.';
+  String get paymentFailedToFetchCountries => 'ஆதரிக்கப்படும் நாடுகளை கொண்டு வர தோல்வியுற்றது. பின்னர் மீண்டும் முயற்சிக்கவும்.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'இயல்பு பணம் செலுத்துதல் முறையை அமைக்க தோல்வியுற்றது. பின்னர் மீண்டும் முயற்சிக்கவும்.';
+  String get paymentFailedToSetDefault => 'இயல்பு பணம் செலுத்துதல் முறையை அமைக்க தோல்வியுற்றது. பின்னர் மீண்டும் முயற்சிக்கவும்.';
 
   @override
   String get paymentFailedToSavePaypal => 'PayPal விவரங்களைச் சேமிக்க தோல்வியுற்றது. பின்னர் மீண்டும் முயற்சிக்கவும்.';
@@ -7185,19 +7008,16 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'அபிவிருத்தி திட்டமிடப்பட்டுள்ளது! உங்கள் மாதாந்திர திட்டம் உங்கள் பிற்படிக்கும் காலத்தின் முடிவு வரை தொடர்ந்து, பின்னர் தானாக வாராந்திரத்தாக மாற்றப்படும்.';
+  String get planUpgradeScheduledMessage => 'அபிவிருத்தி திட்டமிடப்பட்டுள்ளது! உங்கள் மாதாந்திர திட்டம் உங்கள் பிற்படிக்கும் காலத்தின் முடிவு வரை தொடர்ந்து, பின்னர் தானாக வாராந்திரத்தாக மாற்றப்படும்.';
 
   @override
   String get couldNotSchedulePlanChange => 'திட்டம் மாற்றத்தை திட்டமிட முடியவில்லை. மீண்டும் முயற்சிக்கவும்.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'உங்கள் சந்தா மீண்டும் செயல்படுத்தப்பட்டுள்ளது! இப்போது கட்டணம் இல்லை - உங்கள் தற்போதைய காலத்தின் முடிவে பிற்படிக்க வேண்டிய வரை பாக்கியுள்ளது.';
+  String get subscriptionReactivatedDefault => 'உங்கள் சந்தா மீண்டும் செயல்படுத்தப்பட்டுள்ளது! இப்போது கட்டணம் இல்லை - உங்கள் தற்போதைய காலத்தின் முடிவে பிற்படிக்க வேண்டிய வரை பாக்கியுள்ளது.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'சந்தா வெற்றிகரமாக! நতுங்கள் புதிய பிற்படிக்கும் காலத்திற்கு பாக்கியுள்ளது.';
+  String get subscriptionSuccessfulCharged => 'சந்தா வெற்றிகரமாக! நতுங்கள் புதிய பிற்படிக்கும் காலத்திற்கு பாக்கியுள்ளது.';
 
   @override
   String get couldNotProcessSubscription => 'சந்தா செயல்படுத்த முடியவில்லை. மீண்டும் முயற்சிக்கவும்.';
@@ -7377,8 +7197,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get onboardingBluetoothRequired => 'உங்கள் சாதனத்துடன் இணைக்க Bluetooth அனுமதி தேவை.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth அனுமதி மறுக்கப்பட்டது. সিஸ்டம் விருப்பங்களில் அனுமதி வழங்கவும்.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth அனுமதி மறுக்கப்பட்டது. সিஸ்டம் விருப்பங்களில் அனுமதி வழங்கவும்.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7391,12 +7210,10 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'அறிவிப்பு அனுமதி மறுக்கப்பட்டது. சிஸ்டம் விருப்பங்களில் அனுமதி வழங்கவும்.';
+  String get onboardingNotificationDeniedSystemPrefs => 'அறிவிப்பு அனுமதி மறுக்கப்பட்டது. சிஸ்டம் விருப்பங்களில் அனுமதி வழங்கவும்.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'அறிவிப்பு அனுமதி மறுக்கப்பட்டது. சிஸ்டம் விருப்பங்கள் > அறிவிப்புகளில் அனுமதி வழங்கவும்.';
+  String get onboardingNotificationDeniedNotifications => 'அறிவிப்பு அனுமதி மறுக்கப்பட்டது. சிஸ்டம் விருப்பங்கள் > அறிவிப்புகளில் அனுமதி வழங்கவும்.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7409,15 +7226,13 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'அமைப்புகள் > தனியுரிமை & பாதுகாப்பு > இருப்பிடம் சேவைகளில் இருப்பிடம் அனுமதி வழங்கவும்';
+  String get onboardingLocationGrantInSettings => 'அமைப்புகள் > தனியுரிமை & பாதுகாப்பு > இருப்பிடம் சேவைகளில் இருப்பிடம் அனுமதி வழங்கவும்';
 
   @override
   String get onboardingMicrophoneRequired => 'ஒலிபதிவுக்கு மைக்ரோஃபோன் அனுமதி தேவை.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'மைக்ரோஃபோன் அனுமதி மறுக்கப்பட்டது. சிஸ்டம் விருப்பங்கள் > தனியுரிமை & பாதுகாப்பு > மைக்ரோஃபோனில் அனுமதி வழங்கவும்.';
+  String get onboardingMicrophoneDenied => 'மைக்ரோஃபோன் அனுமதி மறுக்கப்பட்டது. சிஸ்டம் விருப்பங்கள் > தனியுரிமை & பாதுகாப்பு > மைக்ரோஃபோனில் அனுமதி வழங்கவும்.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7433,8 +7248,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'கணினி ஆடியோ ஒலிபதிவுக்கு திரை பிடிப்பு அனுமதி தேவை.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'திரை பிடிப்பு அனுமதி மறுக்கப்பட்டது. சிஸ்டம் விருப்பங்கள் > தனியுரிமை & பாதுகாப்பு > திரை ஒலிபதிவுகளில் அனுமதி வழங்கவும்.';
+  String get onboardingScreenCaptureDenied => 'திரை பிடிப்பு அனுமதி மறுக்கப்பட்டது. சிஸ்டம் விருப்பங்கள் > தனியுரிமை & பாதுகாப்பு > திரை ஒலிபதிவுகளில் அனுமதி வழங்கவும்.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7487,8 +7301,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'புகைப்படங்கள் அனுமதி மறுக்கப்பட்டது. புகைப்படங்களைத் தேர்ந்தெடுக்க புகைப்படங்களுக்கான அணுகலை அனுமதிக்கவும்';
+  String get msgPhotosPermissionDenied => 'புகைப்படங்கள் அனுமதி மறுக்கப்பட்டது. புகைப்படங்களைத் தேர்ந்தெடுக்க புகைப்படங்களுக்கான அணுகலை அனுமதிக்கவும்';
 
   @override
   String get msgSelectImagesGenericError => 'புகைப்படங்களைத் தேர்ந்தெடுக்கும் போது பிழை. மீண்டும் முயற்சிக்கவும்.';
@@ -7560,8 +7373,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get locationPermissionRequired => 'இருப்பிடம் அனுமதி தேவை';
 
   @override
-  String get locationPermissionContent =>
-      'விரைவு பரிமாற்றம் WiFi இணைப்பை சரிசெய்ய இருப்பிடம் அனுமதி தேவை. தொடர்ந்து செல்ல இருப்பிடம் அனுமதி வழங்கவும்.';
+  String get locationPermissionContent => 'விரைவு பரிமாற்றம் WiFi இணைப்பை சரிசெய்ய இருப்பிடம் அனுமதி தேவை. தொடர்ந்து செல்ல இருப்பிடம் அனுமதி வழங்கவும்.';
 
   @override
   String get pdfTranscriptExport => 'மாற்றுரை ஏற்றுமதி';
@@ -7724,8 +7536,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'சாதனம் WiFi ஒத்திசைவை ஆதரிக்கவில்லை, Bluetooth இற்கு மாற்றப்படுகிறது';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'சாதனம் WiFi ஒத்திசைவை ஆதரிக்கவில்லை, Bluetooth இற்கு மாற்றப்படுகிறது';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health இந்த சாதனத்தில் கிடைக்கவில்லை';
@@ -8021,8 +7832,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Omi DevKit ஐ ஜோடி மோடில் வைக்கவும்';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'இயக்கப் பொத்தானை ஒரு முறை அழுத்தவும். LED ஜோடி மோடில் இருக்கும்போது இளஞ்சிவப்பு நிறத்தில் மின்னும்.';
+  String get pairingDescOmiDevkit => 'இயக்கப் பொத்தானை ஒரு முறை அழுத்தவும். LED ஜோடி மோடில் இருக்கும்போது இளஞ்சிவப்பு நிறத்தில் மின்னும்.';
 
   @override
   String get pairingTitleOmiGlass => 'Omi Glass ஐ இயக்கவும்';
@@ -8034,22 +7844,19 @@ class AppLocalizationsTa extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note ஐ ஜோடி மோடில் வைக்கவும்';
 
   @override
-  String get pairingDescPlaudNote =>
-      'பக்க பொத்தானை 2 வினாடிகளுக்கு அழுத்திப் பிடித்திருக்கவும். சிவப்பு LED ஜோடியாக்க தயாரிக்கும்போது மின்னும்.';
+  String get pairingDescPlaudNote => 'பக்க பொத்தானை 2 வினாடிகளுக்கு அழுத்திப் பிடித்திருக்கவும். சிவப்பு LED ஜோடியாக்க தயாரிக்கும்போது மின்னும்.';
 
   @override
   String get pairingTitleBee => 'Bee ஐ ஜோடி மோடில் வைக்கவும்';
 
   @override
-  String get pairingDescBee =>
-      'பொத்தானை 5 முறை தொடர்ந்து அழுத்தவும். விளக்கு நீல மற்றும் பச்சை நிறத்தில் மின்ன ஆரம்பிக்கும்.';
+  String get pairingDescBee => 'பொத்தானை 5 முறை தொடர்ந்து அழுத்தவும். விளக்கு நீல மற்றும் பச்சை நிறத்தில் மின்ன ஆரம்பிக்கும்.';
 
   @override
   String get pairingTitleLimitless => 'Limitless ஐ ஜோடி மோடில் வைக்கவும்';
 
   @override
-  String get pairingDescLimitless =>
-      'ஏதேனும் விளக்கு தெரியும்போது, ஒரு முறை அழுத்தவும் பின்னர் சாதனம் இளஞ்சிவப்பு விளக்கைக் காட்டும் வரை அழுத்திப் பிடித்திருக்கவும்.';
+  String get pairingDescLimitless => 'ஏதேனும் விளக்கு தெரியும்போது, ஒரு முறை அழுத்தவும் பின்னர் சாதனம் இளஞ்சிவப்பு விளக்கைக் காட்டும் வரை அழுத்திப் பிடித்திருக்கவும்.';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant ஐ ஜோடி மோடில் வைக்கவும்';
@@ -8067,15 +7874,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch ஐ இணைக்கவும்';
 
   @override
-  String get pairingDescAppleWatch =>
-      'உங்கள் Apple Watch ல் Omi பயன்பாட்டை நிறுவி திறக்கவும், பின்னர் பயன்பாட்டில் இணைக்கவும்.';
+  String get pairingDescAppleWatch => 'உங்கள் Apple Watch ல் Omi பயன்பாட்டை நிறுவி திறக்கவும், பின்னர் பயன்பாட்டில் இணைக்கவும்.';
 
   @override
   String get pairingTitleNeoOne => 'Neo One ஐ ஜோடி மோடில் வைக்கவும்';
 
   @override
-  String get pairingDescNeoOne =>
-      'LED மின்னும் வரை power பொத்தானை அழுத்திப் பிடித்திருக்கவும். சாதனம் கண்டறியக்கூடியதாக இருக்கும்.';
+  String get pairingDescNeoOne => 'LED மின்னும் வரை power பொத்தானை அழுத்திப் பிடித்திருக்கவும். சாதனம் கண்டறியக்கூடியதாக இருக்கும்.';
 
   @override
   String get downloadingFromDevice => 'சாதனத்தில் இருந்து பதிவிறக்குகிறது';
@@ -8163,8 +7968,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'இதை நான் உங்களைப் பற்றி அறிந்துள்ளேன்';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Omi உங்கள் உரையாடல்களிலிருந்து கற்கும்போது இந்தக் கட்டம் புதுப்பிக்கப்படுகிறது.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Omi உங்கள் உரையாடல்களிலிருந்து கற்கும்போது இந்தக் கட்டம் புதுப்பிக்கப்படுகிறது.';
 
   @override
   String get apiEnvironment => 'API சூழல்';
@@ -8193,8 +7997,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get switchAndRestart => 'மாற்று';
 
   @override
-  String get stagingDisclaimer =>
-      'Staging சேதமாக இருக்கலாம், நிலையற்ற செயல்திறன் இருக்கலாம், மற்றும் தரவு இழப்பதற்குக் கூடியது. சோதனைக்கு மாத்திரமே பயன்படுத்தவும்.';
+  String get stagingDisclaimer => 'Staging சேதமாக இருக்கலாம், நிலையற்ற செயல்திறன் இருக்கலாம், மற்றும் தரவு இழப்பதற்குக் கூடியது. சோதனைக்கு மாத்திரமே பயன்படுத்தவும்.';
 
   @override
   String get apiEnvSavedRestartRequired => 'சேமிக்கப்பட்டது. பயன்பாட்டை மூடி மீண்டு திறந்து பயன்படுத்த.';
@@ -8359,8 +8162,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get yourVerifiedNumbers => 'உங்கள் சரிபார்க்கப்பட்ட எண்கள்';
 
   @override
-  String get verifiedNumbersDescription =>
-      'நீங்கள் யாரையாவது அழைக்கும்போது, அவர்கள் தங்கள் தொலைபேசிகளில் இந்த எண்ணைக் காண்பார்கள்';
+  String get verifiedNumbersDescription => 'நீங்கள் யாரையாவது அழைக்கும்போது, அவர்கள் தங்கள் தொலைபேசிகளில் இந்த எண்ணைக் காண்பார்கள்';
 
   @override
   String get noVerifiedNumbers => 'சரிபார்க்கப்பட்ட எண்கள் இல்லை';
@@ -8424,8 +8226,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Omi மூலம் தொலைபேசி அழைப்புகள்';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Omi மூலம் அழைப்புகளை செய்து நேரலை மொழிபெயர்ப்பு, தானாக மொழிபெயர்ப்பு, மற்றும் மேலும் பெறவும். Unlimited திட்ட வாடிக்கையாளர்களுக்கு மாத்திரமே கிடைக்கும்.';
+  String get phoneCallsUpsellSubtitle => 'Omi மூலம் அழைப்புகளை செய்து நேரலை மொழிபெயர்ப்பு, தானாக மொழிபெயர்ப்பு, மற்றும் மேலும் பெறவும். Unlimited திட்ட வாடிக்கையாளர்களுக்கு மாத்திரமே கிடைக்கும்.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'ஒவ்வொரு அழைப்பின் நேரலை மொழிபெயர்ப்பு';
@@ -8452,8 +8253,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleteSyncedFiles => 'ஒத்திசைக்கப்பட்ட பதிவுகளை நீக்கு';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'இந்த பதிவுகள் ஏற்கனவே உங்கள் தொலைபேசிக்கு ஒத்திசைக்கப்பட்டுள்ளன. இதை செய்ய முடியாது.';
+  String get deleteSyncedFilesMessage => 'இந்த பதிவுகள் ஏற்கனவே உங்கள் தொலைபேசிக்கு ஒத்திசைக்கப்பட்டுள்ளன. இதை செய்ய முடியாது.';
 
   @override
   String get syncedFilesDeleted => 'ஒத்திசைக்கப்பட்ட பதிவுகள் நீக்கப்பட்டுள்ளன';
@@ -8465,8 +8265,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deletePendingFiles => 'நிலுவையில் உள்ள பதிவுகளை நீக்கு';
 
   @override
-  String get deletePendingFilesWarning =>
-      'இந்த பதிவுகள் உங்கள் தொலைபேசிக்கு ஒத்திசைக்கப்படவில்லை மற்றும் நிரந்தரமாக இழக்கப்படும். இதை செய்ய முடியாது.';
+  String get deletePendingFilesWarning => 'இந்த பதிவுகள் உங்கள் தொலைபேசிக்கு ஒத்திசைக்கப்படவில்லை மற்றும் நிரந்தரமாக இழக்கப்படும். இதை செய்ய முடியாது.';
 
   @override
   String get pendingFilesDeleted => 'நிலுவையில் உள்ள பதிவுகள் நீக்கப்பட்டுள்ளன';
@@ -8478,8 +8277,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleteAll => 'அனைத்தையும் நீக்கு';
 
   @override
-  String get deleteAllFilesWarning =>
-      'இது ஒத்திசைக்கப்பட்ட மற்றும் நிலுவையில் உள்ள பதிவுகளை நீக்கும். நிலுவையில் உள்ள பதிவுகள் ஒத்திசைக்கப்படவில்லை மற்றும் நிரந்தரமாக இழக்கப்படும். இதை செய்ய முடியாது.';
+  String get deleteAllFilesWarning => 'இது ஒத்திசைக்கப்பட்ட மற்றும் நிலுவையில் உள்ள பதிவுகளை நீக்கும். நிலுவையில் உள்ள பதிவுகள் ஒத்திசைக்கப்படவில்லை மற்றும் நிரந்தரமாக இழக்கப்படும். இதை செய்ய முடியாது.';
 
   @override
   String get allFilesDeleted => 'அனைத்துப் பதிவுகளும் நீக்கப்பட்டுள்ளன';
@@ -8544,8 +8342,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get fairUseAboutTitle => 'நியாய பயன்பாட்டு பற்றி';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi தனிப்பட்ட உரையாடல்கள், கூட்டங்கள், மற்றும் நேரடி தொடர்பினை நோக்கமாகக் கொண்டுள்ளது. பயன்பாடு கண்டறியப்பட்ட உண்மையான ஆவாஸ் நேரத்தால் அளவிடப்படுகிறது, இணைப்பு நேரம் அல்ல. பயன்பாடு தனிப்பட்ட உள்ளடக்கம் அல்ல வழக்கமான வடிவங்கலை கணிசமாக கடக்க நிலைமாறினால், சரிசெய்தல் பயன்படுத்தப்படலாம்.';
+  String get fairUseAboutBody => 'Omi தனிப்பட்ட உரையாடல்கள், கூட்டங்கள், மற்றும் நேரடி தொடர்பினை நோக்கமாகக் கொண்டுள்ளது. பயன்பாடு கண்டறியப்பட்ட உண்மையான ஆவாஸ் நேரத்தால் அளவிடப்படுகிறது, இணைப்பு நேரம் அல்ல. பயன்பாடு தனிப்பட்ட உள்ளடக்கம் அல்ல வழக்கமான வடிவங்கலை கணிசமாக கடக்க நிலைமாறினால், சரிசெய்தல் பயன்படுத்தப்படலாம்.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8572,8 +8369,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get transcriptionPaused => 'பதிவு, மீண்டு இணையப்படுகிறது';
 
   @override
-  String get transcriptionPausedReconnecting =>
-      'இன்னும் பதிவு செய்யப்படுகிறது — மொழிபெயர்ப்புக்கு மீண்டு இணையப்படுகிறது...';
+  String get transcriptionPausedReconnecting => 'இன்னும் பதிவு செய்யப்படுகிறது — மொழிபெயர்ப்புக்கு மீண்டு இணையப்படுகிறது...';
 
   @override
   String fairUseBannerStatus(String status) {
@@ -8584,8 +8380,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get improveConnectionTitle => 'இணைப்பை மேம்படுத்து';
 
   @override
-  String get improveConnectionContent =>
-      'Omi உங்கள் சாதனத்துடன் இணைக்கப்பட்டுள்ளதாக இருப்பதற்கான முறையை நாங்கள் மேம்படுத்தியுள்ளோம். இதைத் தூண்டப் சாதனம் தகவல் பக்கத்திற்குச் செல்லவும், \"சாதனத்தை விலக்கவும்\" வெற்றியடையவும், பின்னர் உங்கள் சாதனத்தை மீண்டு ஜோடியாக்கவும்.';
+  String get improveConnectionContent => 'Omi உங்கள் சாதனத்துடன் இணைக்கப்பட்டுள்ளதாக இருப்பதற்கான முறையை நாங்கள் மேம்படுத்தியுள்ளோம். இதைத் தூண்டப் சாதனம் தகவல் பக்கத்திற்குச் செல்லவும், \"சாதனத்தை விலக்கவும்\" வெற்றியடையவும், பின்னர் உங்கள் சாதனத்தை மீண்டு ஜோடியாக்கவும்.';
 
   @override
   String get improveConnectionAction => 'புரிந்து கொண்டேன்';
@@ -8640,16 +8435,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get cancelSyncQuestion => 'ஒத்திசைப்பை ரத்து செய்யலாமா?';
 
   @override
-  String get omisStorageDesc =>
-      'உங்கள் Omi உங்கள் தொலைபேசிக்குத் தொடர்புபடாமல் இருக்கும்போது, அது ஆடியோவை அதன் உள்ளமைக்கப்பட்ட நினைவகத்தில் உள்ளூரில் சேமிக்கிறது। நீங்கள் ஒருபோதும் ஒரு பதிவை இழக்கமாட்டீர்கள்.';
+  String get omisStorageDesc => 'உங்கள் Omi உங்கள் தொலைபேசிக்குத் தொடர்புபடாமல் இருக்கும்போது, அது ஆடியோவை அதன் உள்ளமைக்கப்பட்ட நினைவகத்தில் உள்ளூரில் சேமிக்கிறது। நீங்கள் ஒருபோதும் ஒரு பதிவை இழக்கமாட்டீர்கள்.';
 
   @override
-  String get phoneStorageDesc =>
-      'Omi மீண்டு இணையப்படும்போது, பதிவுகள் தானாகவே உங்கள் தொலைபேசிக்கு அப்ளோட் செய்ய முன் தற்காலிக நிலையீடாக மாற்றப்படுகிறது.';
+  String get phoneStorageDesc => 'Omi மீண்டு இணையப்படும்போது, பதிவுகள் தானாகவே உங்கள் தொலைபேசிக்கு அப்ளோட் செய்ய முன் தற்காலிக நிலையீடாக மாற்றப்படுகிறது.';
 
   @override
-  String get cloudStorageDesc =>
-      'பதிவேற்றப்பட்டபின், உங்கள் பதிவுகள் செயல்படுத்தப்பட்டு மொழிபெயர்க்கப்படுகிறது. உரையாடல்கள் ஒரு நிமிஷத்தில் கிடைப்பாயிற்று.';
+  String get cloudStorageDesc => 'பதிவேற்றப்பட்டபின், உங்கள் பதிவுகள் செயல்படுத்தப்பட்டு மொழிபெயர்க்கப்படுகிறது. உரையாடல்கள் ஒரு நிமிஷத்தில் கிடைப்பாயிற்று.';
 
   @override
   String get tipKeepPhoneNearby => 'வேகமான ஒத்திசைப்புக்கு உங்கள் தொலைபேசியை அருகாமையில் வைக்கவும்';
@@ -8673,12 +8465,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get permissionEnable => 'இயக்கவும்';
 
   @override
-  String get permissionsPageDescription =>
-      'இந்த அனுமதிகள் Omi எவ்வாறு செயல்படுகிறது என்பதற்கு மூலமுள்ளவை. அவை அறிவிப்புகள், தொடர்பிலான அভিজ্ঞதங்கள், மற்றும் ஆடியோ பிடிப்பு போன்ற முக்கிய வசதিகளை இயக்குகிறது.';
+  String get permissionsPageDescription => 'இந்த அனுமதிகள் Omi எவ்வாறு செயல்படுகிறது என்பதற்கு மூலமுள்ளவை. அவை அறிவிப்புகள், தொடர்பிலான அভিজ্ঞதங்கள், மற்றும் ஆடியோ பிடிப்பு போன்ற முக்கிய வசதিகளை இயக்குகிறது.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi சரிந்து செயல்பாட்ட சில அனுமதிகள் தேவைப்படுகிறது. தொடர செய்ய தயவுசெய்து அவற்றை வழங்கவும்.';
+  String get permissionsRequiredDescription => 'Omi சரிந்து செயல்பாட்ட சில அனுமதிகள் தேவைப்படுகிறது. தொடர செய்ய தயவுசெய்து அவற்றை வழங்கவும்.';
 
   @override
   String get permissionsSetupTitle => 'சிறந்த அভிজ்ঞதம் பெறவும்';
@@ -8732,8 +8522,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get justAMoment => 'கொஞ்சம் நேரம் தயவுசெய்து';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'ரத்து செய்யுவதற்கு பதிலாக உங்கள் பிற தெரிவுகளை ஆய்வு செய்ய நாங்கள் உயர்ந்தமாக பரிந்துரைக்கிறோம்.';
+  String get cancelConsequencesSubtitle => 'ரத்து செய்யுவதற்கு பதிலாக உங்கள் பிற தெரிவுகளை ஆய்வு செய்ய நாங்கள் உயர்ந்தமாக பரிந்துரைக்கிறோம்.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8744,8 +8533,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get ifYouCancel => 'நீங்கள் ரத்து செய்யினால்:';
 
   @override
-  String get cancelConsequenceNoAccess =>
-      'உங்கள் பிள் கொணை முடிவிற்கு வரும் வரை unlimited அணுகலை நீங்கள் இனி பெறமாட்டீர்கள்.';
+  String get cancelConsequenceNoAccess => 'உங்கள் பிள் கொணை முடிவிற்கு வரும் வரை unlimited அணுகலை நீங்கள் இனி பெறமாட்டீர்கள்.';
 
   @override
   String get cancelConsequenceBattery => '7 மடங்கு அधिक பேட்டரி பயன்பாடு (சாதன செயல்பாட்டு)';
@@ -8787,8 +8575,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get feedbackSubtitleTooExpensive => 'உங்கள் கருத்து சரியான சமநிலை கண்டுபிடிக்க உதவுகிறது.';
 
   @override
-  String get feedbackSubtitleMissingFeatures =>
-      'நாங்கள் எப்போதும் கட்டுவதை செய்கிறோம் — இது முன்னுரிமை கொடுக்க உதவுகிறது.';
+  String get feedbackSubtitleMissingFeatures => 'நாங்கள் எப்போதும் கட்டுவதை செய்கிறோம் — இது முன்னுரிமை கொடுக்க உதவுகிறது.';
 
   @override
   String get feedbackSubtitleAudioQuality => 'எவ்வாறு தவறு விட்டிருந்தவை என்பதை புரிந்து கொள்ள நாங்கள் விரும்புகிறோம்.';
@@ -8797,8 +8584,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get feedbackSubtitleBatteryDrain => 'இது எங்கள் hardware குழுவை மேம்படுத்த உதவுகிறது.';
 
   @override
-  String get feedbackSubtitleFoundAlternative =>
-      'உங்கள் கண்ணை எவ்வாறு நிறுத்தினவை என்பதை நாங்கள் கற்றுக் கொள்ள விரும்புகிறோம்.';
+  String get feedbackSubtitleFoundAlternative => 'உங்கள் கண்ணை எவ்வாறு நிறுத்தினவை என்பதை நாங்கள் கற்றுக் கொள்ள விரும்புகிறோம்.';
 
   @override
   String get feedbackSubtitleNotUsing => 'Omi ஐ நீங்கள் மேலும் பயனுள்ளதாக்க நாங்கள் விரும்புகிறோம்.';
@@ -8959,8 +8745,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get firmwareWarningTitle => 'முக்கியம்: புதுப்பிக்கும் முன் படிக்கவும்';
 
   @override
-  String get firmwareFormatWarning =>
-      'இந்த firmware SD கார்டை வடிவமைக்கும். மேம்படுத்துவதற்கு முன் அனைத்து ஆஃப்லைன் தரவும் ஒத்திசைக்கப்பட்டிருப்பதை உறுதிசெய்யவும்.\n\nஇந்த பதிப்பை நிறுவிய பிறகு சிவப்பு விளக்கு ஒளிர்ந்தால் கவலைப்பட வேண்டாம். சாதனத்தை செயலியுடன் இணைக்கவும், அது நீல நிறமாக மாற வேண்டும். சிவப்பு விளக்கு என்பது சாதனத்தின் கடிகாரம் இன்னும் ஒத்திசைக்கப்படவில்லை என்று அர்த்தம்.';
+  String get firmwareFormatWarning => 'இந்த firmware SD கார்டை வடிவமைக்கும். மேம்படுத்துவதற்கு முன் அனைத்து ஆஃப்லைன் தரவும் ஒத்திசைக்கப்பட்டிருப்பதை உறுதிசெய்யவும்.\n\nஇந்த பதிப்பை நிறுவிய பிறகு சிவப்பு விளக்கு ஒளிர்ந்தால் கவலைப்பட வேண்டாம். சாதனத்தை செயலியுடன் இணைக்கவும், அது நீல நிறமாக மாற வேண்டும். சிவப்பு விளக்கு என்பது சாதனத்தின் கடிகாரம் இன்னும் ஒத்திசைக்கப்படவில்லை என்று அர்த்தம்.';
 
   @override
   String get continueAnyway => 'தொடரவும்';
@@ -8980,8 +8765,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get tasksMarkComplete => 'முடிந்தது என குறிக்கப்பட்டது';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi, Apple இன் HealthKit கட்டமைப்பின் மூலம் Apple Health-ஐ அணுகுகிறது. iOS அமைப்புகளில் எந்த நேரத்திலும் அணுகலை ரத்து செய்யலாம்.';
+  String get appleHealthManageNote => 'Omi, Apple இன் HealthKit கட்டமைப்பின் மூலம் Apple Health-ஐ அணுகுகிறது. iOS அமைப்புகளில் எந்த நேரத்திலும் அணுகலை ரத்து செய்யலாம்.';
 
   @override
   String get appleHealthConnectCta => 'Apple Health-உடன் இணை';
@@ -8996,8 +8780,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get appleHealthFeatureChatTitle => 'உங்கள் ஆரோக்கியம் பற்றி அரட்டை';
 
   @override
-  String get appleHealthFeatureChatDesc =>
-      'Omi இடம் உங்கள் படிகள், தூக்கம், இதயத் துடிப்பு, உடற்பயிற்சிகள் பற்றி கேளுங்கள்.';
+  String get appleHealthFeatureChatDesc => 'Omi இடம் உங்கள் படிகள், தூக்கம், இதயத் துடிப்பு, உடற்பயிற்சிகள் பற்றி கேளுங்கள்.';
 
   @override
   String get appleHealthFeatureReadOnlyTitle => 'படிக்க மட்டுமே அணுகல்';
@@ -9009,15 +8792,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get appleHealthFeatureSecureTitle => 'பாதுகாப்பான ஒத்திசைவு';
 
   @override
-  String get appleHealthFeatureSecureDesc =>
-      'உங்கள் Apple Health தரவு உங்கள் Omi கணக்குடன் தனிப்பட்ட முறையில் ஒத்திசைக்கப்படுகிறது.';
+  String get appleHealthFeatureSecureDesc => 'உங்கள் Apple Health தரவு உங்கள் Omi கணக்குடன் தனிப்பட்ட முறையில் ஒத்திசைக்கப்படுகிறது.';
 
   @override
   String get appleHealthDeniedTitle => 'Apple Health அணுகல் மறுக்கப்பட்டது';
 
   @override
-  String get appleHealthDeniedBody =>
-      'உங்கள் Apple Health தரவைப் படிக்க Omi க்கு அனுமதி இல்லை. iOS அமைப்புகள் → தனியுரிமை & பாதுகாப்பு → Health → Omi இல் இதை இயக்கவும்.';
+  String get appleHealthDeniedBody => 'உங்கள் Apple Health தரவைப் படிக்க Omi க்கு அனுமதி இல்லை. iOS அமைப்புகள் → தனியுரிமை & பாதுகாப்பு → Health → Omi இல் இதை இயக்கவும்.';
 
   @override
   String get deleteFlowReasonTitle => 'நீங்கள் ஏன் வெளியேறுகிறீர்கள்?';
@@ -9053,8 +8834,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deleteFlowFeedbackSubtitle => 'Omi உங்களுக்கு எவ்வாறு பயனுள்ளதாக இருந்திருக்கும்?';
 
   @override
-  String get deleteFlowFeedbackHint =>
-      'விருப்பத்தேர்வு — உங்கள் எண்ணங்கள் சிறந்த தயாரிப்பை உருவாக்க எங்களுக்கு உதவுகின்றன.';
+  String get deleteFlowFeedbackHint => 'விருப்பத்தேர்வு — உங்கள் எண்ணங்கள் சிறந்த தயாரிப்பை உருவாக்க எங்களுக்கு உதவுகின்றன.';
 
   @override
   String get deleteFlowConfirmTitle => 'இது நிரந்தரமானது';
@@ -9087,8 +8867,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get planUpdate => 'திட்ட புதுப்பிப்பு';
 
   @override
-  String get planDeprecationMessage =>
-      'உங்கள் Unlimited திட்டம் நிறுத்தப்படுகிறது. Operator திட்டத்திற்கு மாறுங்கள் — அதே சிறந்த அம்சங்கள் \$49/மாதம். உங்கள் தற்போதைய திட்டம் இதற்கிடையில் தொடர்ந்து செயல்படும்.';
+  String get planDeprecationMessage => 'உங்கள் Unlimited திட்டம் நிறுத்தப்படுகிறது. Operator திட்டத்திற்கு மாறுங்கள் — அதே சிறந்த அம்சங்கள் \$49/மாதம். உங்கள் தற்போதைய திட்டம் இதற்கிடையில் தொடர்ந்து செயல்படும்.';
 
   @override
   String get upgradeYourPlan => 'உங்கள் திட்டத்தை மேம்படுத்தவும்';
@@ -9199,8 +8978,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'நீங்கள் உங்கள் மாதாந்திர வரம்பை அடைந்துவிட்டீர்கள். கட்டுப்பாடுகள் இல்லாமல் Omi உடன் அரட்டையைத் தொடர மேம்படுத்தவும்.';
+  String get chatQuotaExceededReply => 'நீங்கள் உங்கள் மாதாந்திர வரம்பை அடைந்துவிட்டீர்கள். கட்டுப்பாடுகள் இல்லாமல் Omi உடன் அரட்டையைத் தொடர மேம்படுத்தவும்.';
 
   @override
   String get voiceResponseAudio => 'Omi பதிலை சத்தமாக படிக்கவும்';
@@ -9231,4 +9009,25 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'பணி சேர்க்கவும்';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi ஐ எதுவும் கேளுங்கள்';
+
+  @override
+  String get quickActionVoiceMode => 'குரல் பயன்முறை';
+
+  @override
+  String get quickActionMute => 'முடக்கு';
+
+  @override
+  String get quickActionUnmute => 'முடக்கத்தை நீக்கு';
+
+  @override
+  String get quickActionConnectDevice => 'சாதனத்தை இணைக்கவும்';
+
+  @override
+  String get quickActionDeviceSettings => 'சாதன அமைப்புகள்';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -24,8 +24,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deleteConversationTitle => 'సంభాషణను తొలగించాలా?';
 
   @override
-  String get deleteConversationMessage =>
-      'ఇది సంబంధిత జ్ఞాపకాలు, పనులు మరియు ఆడియో ఫైల్‌లను కూడా తొలగిస్తుంది. ఈ చర్య రద్దు చేయబడదు.';
+  String get deleteConversationMessage => 'ఇది సంబంధిత జ్ఞాపకాలు, పనులు మరియు ఆడియో ఫైల్‌లను కూడా తొలగిస్తుంది. ఈ చర్య రద్దు చేయబడదు.';
 
   @override
   String get confirm => 'ఖచ్చితం చేయండి';
@@ -123,8 +122,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get editPerson => 'వ్యక్తిని సవరించండి';
 
   @override
-  String get createPersonHint =>
-      'కొత్త వ్యక్తిని సృష్టించండి మరియు వారి ఉపన్యాసాన్ని గుర్తించడానికి Omiని శిక్షణ ఇవ్వండి!';
+  String get createPersonHint => 'కొత్త వ్యక్తిని సృష్టించండి మరియు వారి ఉపన్యాసాన్ని గుర్తించడానికి Omiని శిక్షణ ఇవ్వండి!';
 
   @override
   String get speechProfile => 'ఉపన్యాస ప్రొఫైల్';
@@ -147,8 +145,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deleting => 'తొలగిస్తోంది...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'దయచేసి మీ బ్రౌజర్‌లో ప్రామాణీకరణను పూర్తి చేయండి. పూర్తి చేసిన తర్వాత, అనువర్తనానికి తిరిగి వెళ్లండి.';
+  String get pleaseCompleteAuthentication => 'దయచేసి మీ బ్రౌజర్‌లో ప్రామాణీకరణను పూర్తి చేయండి. పూర్తి చేసిన తర్వాత, అనువర్తనానికి తిరిగి వెళ్లండి.';
 
   @override
   String get failedToStartAuthentication => 'ప్రామాణీకరణను ప్రారంభించడంలో విఫలమైంది';
@@ -320,8 +317,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get installedApps => 'ఇన్‌స్టాల్ చేసిన అనువర్తనాలు';
 
   @override
-  String get unableToFetchApps =>
-      'అనువర్తనాలను పొందలేకపోయాము :(\n\nదయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి.';
+  String get unableToFetchApps => 'అనువర్తనాలను పొందలేకపోయాము :(\n\nదయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి.';
 
   @override
   String get aboutOmi => 'Omiని గురించి';
@@ -357,19 +353,16 @@ class AppLocalizationsTe extends AppLocalizations {
   String get appsDisconnected => 'మీ అనువర్తనాలు మరియు ఇంటిగ్రేషన్‌లు వెంటనే డిస్‌కనెక్ట్ చేయబడుతుంది.';
 
   @override
-  String get exportBeforeDelete =>
-      'మీరు మీ ఖాతాను తొలగించడానికి ముందు మీ డేటాను ఎగుమతి చేయవచ్చు, కానీ ఒకసారి తొలగించిన తర్వాత, దానిని పునరుద్ధరించలేము.';
+  String get exportBeforeDelete => 'మీరు మీ ఖాతాను తొలగించడానికి ముందు మీ డేటాను ఎగుమతి చేయవచ్చు, కానీ ఒకసారి తొలగించిన తర్వాత, దానిని పునరుద్ధరించలేము.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'మీ ఖాతాను తొలగించడం శాశ్వతం మరియు జ్ఞాపకాలు మరియు సంభాషణలతో సహా అన్ని డేటా కోల్పోతుందని మరియు పునరుద్ధరించలేమని నేను అర్థం చేసుకున్నాను.';
+  String get deleteAccountCheckbox => 'మీ ఖాతాను తొలగించడం శాశ్వతం మరియు జ్ఞాపకాలు మరియు సంభాషణలతో సహా అన్ని డేటా కోల్పోతుందని మరియు పునరుద్ధరించలేమని నేను అర్థం చేసుకున్నాను.';
 
   @override
   String get areYouSure => 'మీరు ఖచ్చితమైనారా?';
 
   @override
-  String get deleteAccountFinal =>
-      'ఈ చర్య చేయలేనిది మరియు మీ ఖాతా మరియు సమస్త సంబంధిత డేటాను శాశ్వతంగా తొలగిస్తుంది. మీరు ముందుకు సాగాలనుకుంటున్నారని మీరు ఖచ్చితమైనారా?';
+  String get deleteAccountFinal => 'ఈ చర్య చేయలేనిది మరియు మీ ఖాతా మరియు సమస్త సంబంధిత డేటాను శాశ్వతంగా తొలగిస్తుంది. మీరు ముందుకు సాగాలనుకుంటున్నారని మీరు ఖచ్చితమైనారా?';
 
   @override
   String get deleteNow => 'ఇప్పుడు తొలగించు';
@@ -378,8 +371,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get goBack => 'వెనుక చెంది';
 
   @override
-  String get checkBoxToConfirm =>
-      'మీ ఖాతాను తొలగించడం శాశ్వతం మరియు చేయలేనిది అని మీరు అర్థం చేసుకున్నారని నిర్ధారించడానికి పెట్టెను తనిఖీ చేయండి.';
+  String get checkBoxToConfirm => 'మీ ఖాతాను తొలగించడం శాశ్వతం మరియు చేయలేనిది అని మీరు అర్థం చేసుకున్నారని నిర్ధారించడానికి పెట్టెను తనిఖీ చేయండి.';
 
   @override
   String get profile => 'ప్రొఫైల్';
@@ -457,8 +449,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get yourPrivacyYourControl => 'మీ గోప్యత, మీ నియంత్రణ';
 
   @override
-  String get privacyIntro =>
-      'Omiలో, మేము మీ గోప్యతను రక్షించడానికి ప్రతిబద్ధులు. ఈ పేజీ మీ డేటా ఎలా నిల్వ చేయబడుతుందో మరియు ఎలా ఉపయోగించబడుతుందో నియంత్రించడానికి మిమ్మల్ని అనుమతిస్తుంది.';
+  String get privacyIntro => 'Omiలో, మేము మీ గోప్యతను రక్షించడానికి ప్రతిబద్ధులు. ఈ పేజీ మీ డేటా ఎలా నిల్వ చేయబడుతుందో మరియు ఎలా ఉపయోగించబడుతుందో నియంత్రించడానికి మిమ్మల్ని అనుమతిస్తుంది.';
 
   @override
   String get learnMore => 'మరింత తెలుసుకోండి...';
@@ -467,15 +458,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get dataProtectionLevel => 'డేటా సంరక్షణ స్థాయి';
 
   @override
-  String get dataProtectionDesc =>
-      'మీ డేటా బలమైన ఎన్‌క్రిప్షన్‌తో డిఫాల్ట్‌గా సురక్షితంగా ఉంది. క్రింద మీ సెట్టింగ్‌లు మరియు భవిష్యత్ గోప్యతా ఎంపికలను సమీక్షించండి.';
+  String get dataProtectionDesc => 'మీ డేటా బలమైన ఎన్‌క్రిప్షన్‌తో డిఫాల్ట్‌గా సురక్షితంగా ఉంది. క్రింద మీ సెట్టింగ్‌లు మరియు భవిష్యత్ గోప్యతా ఎంపికలను సమీక్షించండి.';
 
   @override
   String get appAccess => 'అనువర్తన ప్రాప్తి';
 
   @override
-  String get appAccessDesc =>
-      'ఈ క్రింది అనువర్తనాలు మీ డేటాను యాక్సెస్ చేయవచ్చు. దాని అనుమతులను నిర్వహించడానికి అనువర్తనంపై నొక్కండి.';
+  String get appAccessDesc => 'ఈ క్రింది అనువర్తనాలు మీ డేటాను యాక్సెస్ చేయవచ్చు. దాని అనుమతులను నిర్వహించడానికి అనువర్తనంపై నొక్కండి.';
 
   @override
   String get noAppsExternalAccess => 'ఇన్‌స్టాల్ చేసిన అనువర్తనాలకు మీ డేటాకు బాహ్య ప్రాప్తి లేదు.';
@@ -532,22 +521,19 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deviceDisconnectedMessage => 'మీ Omi డిస్‌కనెక్ట్ చేయబడింది 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'డివైస్ అన్‌పెయిర్ చేయబడింది. అన్‌పేరింగ్‌ను పూర్తి చేయడానికి సెట్టింగ్‌లు > బ్లూటూత్‌కు వెళ్లి డివైస్‌ను మర్చిపోండి.';
+  String get deviceUnpairedMessage => 'డివైస్ అన్‌పెయిర్ చేయబడింది. అన్‌పేరింగ్‌ను పూర్తి చేయడానికి సెట్టింగ్‌లు > బ్లూటూత్‌కు వెళ్లి డివైస్‌ను మర్చిపోండి.';
 
   @override
   String get unpairDialogTitle => 'డివైస్‌ను అన్‌పెయిర్ చేయండి';
 
   @override
-  String get unpairDialogMessage =>
-      'ఇది డివైస్‌ను విచ్ఛిన్నం చేస్తుంది కాబట్టి దానిని మరొక ఫోన్‌కు కనెక్ట్ చేయవచ్చు. ప్రక్రియను పూర్తి చేయడానికి మీరు సెట్టింగ్‌లు > బ్లూటూత్‌కు వెళ్లి డివైస్‌ను మర్చిపోవాలి.';
+  String get unpairDialogMessage => 'ఇది డివైస్‌ను విచ్ఛిన్నం చేస్తుంది కాబట్టి దానిని మరొక ఫోన్‌కు కనెక్ట్ చేయవచ్చు. ప్రక్రియను పూర్తి చేయడానికి మీరు సెట్టింగ్‌లు > బ్లూటూత్‌కు వెళ్లి డివైస్‌ను మర్చిపోవాలి.';
 
   @override
   String get deviceNotConnected => 'డివైస్ కనెక్ట్ చేయబడలేదు';
 
   @override
-  String get connectDeviceMessage =>
-      'ఆచిన సెట్టింగ్‌లు మరియు ఆచిన సెట్టింగ్‌లను యాక్సెస్ చేయడానికి మీ Omi ডివైస్‌ను కనెక్ట్ చేయండి';
+  String get connectDeviceMessage => 'ఆచిన సెట్టింగ్‌లు మరియు ఆచిన సెట్టింగ్‌లను యాక్సెస్ చేయడానికి మీ Omi ডివైస్‌ను కనెక్ట్ చేయండి';
 
   @override
   String get deviceInfoSection => 'ডివైస్ సమాచారం';
@@ -562,8 +548,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get v2Undetected => 'V2 గుర్తించబడలేదు';
 
   @override
-  String get v2UndetectedMessage =>
-      'V1 డివైస్ ఉందని లేదా మీ డివైస్ కనెక్ట్ చేయబడలేదని మేము చూస్తున్నాము. SD కార్డ్ కార్యకలాపం V2 డివైసెస్‌కు మాత్రమే అందుబాటులో ఉంది.';
+  String get v2UndetectedMessage => 'V1 డివైస్ ఉందని లేదా మీ డివైస్ కనెక్ట్ చేయబడలేదని మేము చూస్తున్నాము. SD కార్డ్ కార్యకలాపం V2 డివైసెస్‌కు మాత్రమే అందుబాటులో ఉంది.';
 
   @override
   String get endConversation => 'సంభాషణను ముగించండి';
@@ -837,8 +822,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'జ్ఞాన గ్రాఫ్‌ను తొలగించాలా?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'ఇది అన్ని ఉత్పన్న జ్ఞాన గ్రాఫ్ డేటా (నోడ్‌లు మరియు కనెక్షన్‌లు) తొలగిస్తుంది. మీ అసలు జ్ఞాపకాలు సురక్షితంగా ఉంటాయి. గ్రాఫ్ కాలక్రమేణ లేదా తర్వాత అభ్యర్థనపై పునర్నిర్మించబడుతుంది.';
+  String get deleteKnowledgeGraphMessage => 'ఇది అన్ని ఉత్పన్న జ్ఞాన గ్రాఫ్ డేటా (నోడ్‌లు మరియు కనెక్షన్‌లు) తొలగిస్తుంది. మీ అసలు జ్ఞాపకాలు సురక్షితంగా ఉంటాయి. గ్రాఫ్ కాలక్రమేణ లేదా తర్వాత అభ్యర్థనపై పునర్నిర్మించబడుతుంది.';
 
   @override
   String get knowledgeGraphDeleted => 'జ్ఞాన గ్రాఫ్ తొలగించబడింది';
@@ -1021,8 +1005,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get integrationsFooter => 'చ్యాట్‌లో డేటా మరియు మెట్రిక్‌లను చూడటానికి మీ అనువర్తనాలను కనెక్ట్ చేయండి.';
 
   @override
-  String get completeAuthInBrowser =>
-      'దయచేసి మీ బ్రౌజర్‌లో ప్రామాణీకరణను పూర్తి చేయండి. పూర్తి చేసిన తర్వాత, అనువర్తనానికి తిరిగి వెళ్లండి.';
+  String get completeAuthInBrowser => 'దయచేసి మీ బ్రౌజర్‌లో ప్రామాణీకరణను పూర్తి చేయండి. పూర్తి చేసిన తర్వాత, అనువర్తనానికి తిరిగి వెళ్లండి.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1082,8 +1065,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get needYourPermission => 'మాకు మీ అనుమతి కావాలి';
 
   @override
-  String get alreadyGavePermission =>
-      'మీరు ఇప్పటికే మీ రికార్డింగ్‌లను సేవ్ చేయడానికి మాకు అనుమతి ఇచ్చారు. మాకు దీని కారణం గుర్తించాయి:';
+  String get alreadyGavePermission => 'మీరు ఇప్పటికే మీ రికార్డింగ్‌లను సేవ్ చేయడానికి మాకు అనుమతి ఇచ్చారు. మాకు దీని కారణం గుర్తించాయి:';
 
   @override
   String get wouldLikePermission => 'మీ గ్రంథిత్వ రికార్డింగ్‌లను సేవ్ చేయడానికి మాకు మీ అనుమతి కావాలి. ఇక్కడ ఎందుకు:';
@@ -1092,26 +1074,22 @@ class AppLocalizationsTe extends AppLocalizations {
   String get improveSpeechProfile => 'మీ ఉపన్యాస ప్రొఫైల్‌ను మెరుగుపరచండి';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'మీ వ్యక్తిగత ఉపన్యాస ప్రొఫైల్‌ను శిక్షణ ఇవ్వడానికి మరియు మెరుగుపరచడానికి మేము రికార్డింగ్‌లను ఉపయోగిస్తాము.';
+  String get improveSpeechProfileDesc => 'మీ వ్యక్తిగత ఉపన్యాస ప్రొఫైల్‌ను శిక్షణ ఇవ్వడానికి మరియు మెరుగుపరచడానికి మేము రికార్డింగ్‌లను ఉపయోగిస్తాము.';
 
   @override
   String get trainFamilyProfiles => 'స్నేహితుల మరియు కుటుంబ సభ్యుల ప్రొఫైల్‌లను శిక్షణ ఇవ్వండి';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'మీ రికార్డింగ్‌లు మీ స్నేహితులు మరియు కుటుంబ సభ్యులను గుర్తించడానికి మరియు ప్రొఫైల్‌లను సృష్టించడానికి సహాయ చేస్తాయి.';
+  String get trainFamilyProfilesDesc => 'మీ రికార్డింగ్‌లు మీ స్నేహితులు మరియు కుటుంబ సభ్యులను గుర్తించడానికి మరియు ప్రొఫైల్‌లను సృష్టించడానికి సహాయ చేస్తాయి.';
 
   @override
   String get enhanceTranscriptAccuracy => 'ట్రాన్‌స్క్రిప్ట్ ఖచ్చితత్వాన్ని మెరుగుపరచండి';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'మా నమూనా మెరుగుపడుతున్నందున, మేము మీ రికార్డింగ్‌ల కోసం మెరుగైన ట్రాన్‌స్క్రిప్షన్ ఫలితాలను అందించవచ్చు.';
+  String get enhanceTranscriptAccuracyDesc => 'మా నమూనా మెరుగుపడుతున్నందున, మేము మీ రికార్డింగ్‌ల కోసం మెరుగైన ట్రాన్‌స్క్రిప్షన్ ఫలితాలను అందించవచ్చు.';
 
   @override
-  String get legalNotice =>
-      'చట్టపరమైన నోటీస్: వాయిస్ డేటాను రికార్డింగ్ మరియు నిల్వ చేయడం యొక్క చట్టబద్ధత మీ స్థానం మరియు ఎలా ఈ లక్షణాన్ని ఉపయోగిస్తున్నారో బట్టి భిన్నంగా ఉండవచ్చు. స్థానిక చట్టాలు మరియు నియమాలకు అనుగుణంగా ఉండటం మీ బాధ్యత.';
+  String get legalNotice => 'చట్టపరమైన నోటీస్: వాయిస్ డేటాను రికార్డింగ్ మరియు నిల్వ చేయడం యొక్క చట్టబద్ధత మీ స్థానం మరియు ఎలా ఈ లక్షణాన్ని ఉపయోగిస్తున్నారో బట్టి భిన్నంగా ఉండవచ్చు. స్థానిక చట్టాలు మరియు నియమాలకు అనుగుణంగా ఉండటం మీ బాధ్యత.';
 
   @override
   String get alreadyAuthorized => 'ఇప్పటికే అధికరించబడింది';
@@ -1183,15 +1161,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get showMeetingsMenuBar => 'మెనూ బార్‌లో రాబోయే సమావేశాలను చూపించండి';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'macOS మెనూ బార్‌లో మీ తదుపరి సమావేశ మరియు దానిని ప్రారంభించే వరకు సమయాన్ని ప్రదర్శించండి';
+  String get showMeetingsMenuBarDesc => 'macOS మెనూ బార్‌లో మీ తదుపరి సమావేశ మరియు దానిని ప్రారంభించే వరకు సమయాన్ని ప్రదర్శించండి';
 
   @override
   String get showEventsNoParticipants => 'పాల్గొనేవారు లేని ఈవెంట్‌లను చూపించండి';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'ప్రారంభించినప్పుడు, రాబోయేది పాల్గొనేవారు లేదా వీడియో లింక్ లేని ఈవెంట్‌లను చూపుస్తుంది.';
+  String get showEventsNoParticipantsDesc => 'ప్రారంభించినప్పుడు, రాబోయేది పాల్గొనేవారు లేదా వీడియో లింక్ లేని ఈవెంట్‌లను చూపుస్తుంది.';
 
   @override
   String get yourMeetings => 'మీ సమావేశాలు';
@@ -1232,8 +1208,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get noProjectsInWorkspace => 'ఈ కార్యక్షేత్రంలో ప్రాజెక్ట్‌లు కనుగొనబడలేదు';
 
   @override
-  String get conversationTimeoutDesc =>
-      'సంభాషణను స్వయంచాలకంగా ముగించడానికి ముందు నిశ్శబ్దంలో ఎంతకాలం వేచి ఉండాలో ఎంచుకోండి:';
+  String get conversationTimeoutDesc => 'సంభాషణను స్వయంచాలకంగా ముగించడానికి ముందు నిశ్శబ్దంలో ఎంతకాలం వేచి ఉండాలో ఎంచుకోండి:';
 
   @override
   String get timeout2Minutes => '2 నిమిషాలు';
@@ -1277,8 +1252,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'మీ ప్రాధమిక భాషను మాకు చెప్పండి';
 
   @override
-  String get languageForTranscription =>
-      'మరింత ఖచ్చితమైన ట్రాన్‌స్క్రిప్షన్‌లు మరియు ব్యక్తిగతకృత అనుభవం కోసం మీ భాష సెట్ చేయండి.';
+  String get languageForTranscription => 'మరింత ఖచ్చితమైన ట్రాన్‌స్క్రిప్షన్‌లు మరియు ব్యక్తిగతకృత అనుభవం కోసం మీ భాష సెట్ చేయండి.';
 
   @override
   String get singleLanguageModeInfo => 'ఏకీ భాష మోడ్ ప్రారంభించబడింది. అధిక ఖచ్చితత్వం కోసం అనువాదం నిలిపివేయబడింది.';
@@ -1361,8 +1335,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get defaultRepository => 'డిఫాల్ట్ రిపోజిటరీ';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'సమస్యలను సృష్టించడానికి డిఫాల్ట్ రిపోజిటరీని ఎంచుకోండి. సమస్యలను సృష్టించేటప్పుడు మీరు ఇప్పటికీ వేరేవ రిపోజిటరీని నిర్దేశించవచ్చు.';
+  String get selectDefaultRepoDesc => 'సమస్యలను సృష్టించడానికి డిఫాల్ట్ రిపోజిటరీని ఎంచుకోండి. సమస్యలను సృష్టించేటప్పుడు మీరు ఇప్పటికీ వేరేవ రిపోజిటరీని నిర్దేశించవచ్చు.';
 
   @override
   String get noReposFound => 'రిపోజిటరీలు కనుగొనబడలేదు';
@@ -1409,8 +1382,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get configureSettings => 'సెట్టింగ్‌లను కాన్ఫిగర్ చేయండి';
 
   @override
-  String get completeAuthBrowser =>
-      'దయచేసి మీ బ్రౌజర్‌లో ఆధికారాన్ని పూర్తి చేయండి. ఆ తర్వాత అనువర్తనానికి తిరిగి వెళ్లండి.';
+  String get completeAuthBrowser => 'దయచేసి మీ బ్రౌజర్‌లో ఆధికారాన్ని పూర్తి చేయండి. ఆ తర్వాత అనువర్తనానికి తిరిగి వెళ్లండి.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1738,8 +1710,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get enableBluetooth => 'బ్లూటూత్ ప్రారంభించండి';
 
   @override
-  String get bluetoothNeeded =>
-      'మీ ధరించదగిన పరికరానికి కనెక్ట్ చేయడానికి Omi కు బ్లూటూత్ అవసరం. దయచేసి బ్లూటూత్‌ను ప్రారంభించి మళ్లీ ప్రయత్నించండి.';
+  String get bluetoothNeeded => 'మీ ధరించదగిన పరికరానికి కనెక్ట్ చేయడానికి Omi కు బ్లూటూత్ అవసరం. దయచేసి బ్లూటూత్‌ను ప్రారంభించి మళ్లీ ప్రయత్నించండి.';
 
   @override
   String get contactSupport => 'సపోర్టుకు సంబంధం?';
@@ -1772,26 +1743,22 @@ class AppLocalizationsTe extends AppLocalizations {
   String get locationServiceDisabled => 'స్థానం సేవ నిలిపివేయబడింది';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'స్థానం సేవ నిలిపివేయబడింది. దయచేసి సెట్టింగ్‌లు > గోప్యతా & నిరాపత్త > స్థానం సేవలకు వెళ్లి దీన్ని ప్రారంభించండి';
+  String get locationServiceDisabledDesc => 'స్థానం సేవ నిలిపివేయబడింది. దయచేసి సెట్టింగ్‌లు > గోప్యతా & నిరాపత్త > స్థానం సేవలకు వెళ్లి దీన్ని ప్రారంభించండి';
 
   @override
   String get backgroundLocationDenied => 'నేపథ్య స్థానం యాక్సెస్ నిరాకరించబడింది';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'దయచేసి పరికరం సెట్టింగ్‌లకు వెళ్లి స్థానం అనుమతిని \"ఎల్లప్పుడూ అనుమతించు\" కు సెట్ చేయండి';
+  String get backgroundLocationDeniedDesc => 'దయచేసి పరికరం సెట్టింగ్‌లకు వెళ్లి స్థానం అనుమతిని \"ఎల్లప్పుడూ అనుమతించు\" కు సెట్ చేయండి';
 
   @override
   String get lovingOmi => 'Omi ని ఇష్టపడుతున్నారా?';
 
   @override
-  String get leaveReviewIos =>
-      'App Store లో సమీక్ష ఇవ్వడం ద్వారా మాకు మరిన్ని ప్రజలకు చేరుకోవడానికి సహాయం చేయండి. మీ ఫీడ్‌బ్యాక్ మాకు ప్రపంచానికి అర్థమైనది!';
+  String get leaveReviewIos => 'App Store లో సమీక్ష ఇవ్వడం ద్వారా మాకు మరిన్ని ప్రజలకు చేరుకోవడానికి సహాయం చేయండి. మీ ఫీడ్‌బ్యాక్ మాకు ప్రపంచానికి అర్థమైనది!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Google Play Store లో సమీక్ష ఇవ్వడం ద్వారా మాకు మరిన్ని ప్రజలకు చేరుకోవడానికి సహాయం చేయండి. మీ ఫీడ్‌బ్యాక్ మాకు ప్రపంచానికి అర్థమైనది!';
+  String get leaveReviewAndroid => 'Google Play Store లో సమీక్ష ఇవ్వడం ద్వారా మాకు మరిన్ని ప్రజలకు చేరుకోవడానికి సహాయం చేయండి. మీ ఫీడ్‌బ్యాక్ మాకు ప్రపంచానికి అర్థమైనది!';
 
   @override
   String get rateOnAppStore => 'App Store లో రేట్ చేయండి';
@@ -1824,36 +1791,31 @@ class AppLocalizationsTe extends AppLocalizations {
   String get connectionError => 'కనెక్షన్ ఎర్రర్';
 
   @override
-  String get connectionErrorDesc =>
-      'సర్వర్‌కు కనెక్ట్ చేయడానికి విఫలమైంది. దయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి.';
+  String get connectionErrorDesc => 'సర్వర్‌కు కనెక్ట్ చేయడానికి విఫలమైంది. దయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'చెల్లని రికార్డింగ్ గుర్తించబడింది';
 
   @override
-  String get multipleSpeakersDesc =>
-      'రికార్డింగ్‌లో బహుళ స్పీకర్‌లు ఉన్నట్లు కనిపిస్తుంది. దయచేసి మీరు నిశ్శబ్ద ప్రదేశంలో ఉన్నారని నిర్ధారించుకోండి మరియు మళ్లీ ప్రయత్నించండి.';
+  String get multipleSpeakersDesc => 'రికార్డింగ్‌లో బహుళ స్పీకర్‌లు ఉన్నట్లు కనిపిస్తుంది. దయచేసి మీరు నిశ్శబ్ద ప్రదేశంలో ఉన్నారని నిర్ధారించుకోండి మరియు మళ్లీ ప్రయత్నించండి.';
 
   @override
   String get tooShortDesc => 'తగినంత ఉచ్చారణ గుర్తించబడలేదు. దయచేసి మరిన్ని మాట్లాడండి మరియు మళ్లీ ప్రయత్నించండి.';
 
   @override
-  String get invalidRecordingDesc =>
-      'దయచేసి మీరు కనీసం 5 సెకన్లు మరియు 90 కంటే ఎక్కువ కాకుండా మాట్లాడిన నిర్ధారించుకోండి.';
+  String get invalidRecordingDesc => 'దయచేసి మీరు కనీసం 5 సెకన్లు మరియు 90 కంటే ఎక్కువ కాకుండా మాట్లాడిన నిర్ధారించుకోండి.';
 
   @override
   String get areYouThere => 'మీరు ఉన్నారా?';
 
   @override
-  String get noSpeechDesc =>
-      'మేము ఏ ఉచ్చారణను గుర్తించలేము. దయచేసి కనీసం 10 సెకన్లు మరియు 3 నిమిషాల కంటే ఎక్కువ కాకుండా మాట్లాడిన నిర్ధారించుకోండి.';
+  String get noSpeechDesc => 'మేము ఏ ఉచ్చారణను గుర్తించలేము. దయచేసి కనీసం 10 సెకన్లు మరియు 3 నిమిషాల కంటే ఎక్కువ కాకుండా మాట్లాడిన నిర్ధారించుకోండి.';
 
   @override
   String get connectionLost => 'కనెక్షన్ కోల్పోయారు';
 
   @override
-  String get connectionLostDesc =>
-      'కనెక్షన్ అంతరాయం కలిగింది. దయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి.';
+  String get connectionLostDesc => 'కనెక్షన్ అంతరాయం కలిగింది. దయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి.';
 
   @override
   String get tryAgain => 'మళ్లీ ప్రయత్నించండి';
@@ -1868,8 +1830,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get permissionsRequired => 'అనుమతులు అవసరం';
 
   @override
-  String get permissionsRequiredDesc =>
-      'ఈ అనువర్తనానికి సరిగ్గా పని చేయడానికి బ్లూటూత్ మరియు స్థానం అనుమతులు అవసరం. దయచేసి సెట్టింగ్‌లలో వాటిని ప్రారంభించండి.';
+  String get permissionsRequiredDesc => 'ఈ అనువర్తనానికి సరిగ్గా పని చేయడానికి బ్లూటూత్ మరియు స్థానం అనుమతులు అవసరం. దయచేసి సెట్టింగ్‌లలో వాటిని ప్రారంభించండి.';
 
   @override
   String get openSettings => 'సెట్టింగ్‌లను తెరండి';
@@ -1899,8 +1860,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – మీ AI సహచరి';
 
   @override
-  String get captureEveryMoment =>
-      'ప్రతి క్షణాన్ని చేపట్టండి. AI ఆధారిత\nసారాంశాలను పొందండి. ఎప్పుడూ నోట్‌లు తీసుకోవద్దు.';
+  String get captureEveryMoment => 'ప్రతి క్షణాన్ని చేపట్టండి. AI ఆధారిత\nసారాంశాలను పొందండి. ఎప్పుడూ నోట్‌లు తీసుకోవద్దు.';
 
   @override
   String get appleWatchSetup => 'Apple Watch సెటప్';
@@ -1912,12 +1872,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get microphonePermission => 'మైక్రోఫోన్ అనుమతి';
 
   @override
-  String get permissionGrantedNow =>
-      'అనుమతి ఇవ్వబడింది! ఇప్పుడు:\n\nమీ గడియారంపై Omi అనువర్తనాన్ని తెరిచి దిగువ \"కొనసాగించండి\" ని నొక్కండి';
+  String get permissionGrantedNow => 'అనుమతి ఇవ్వబడింది! ఇప్పుడు:\n\nమీ గడియారంపై Omi అనువర్తనాన్ని తెరిచి దిగువ \"కొనసాగించండి\" ని నొక్కండి';
 
   @override
-  String get needMicrophonePermission =>
-      'మాకు మైక్రోఫోన్ అనుమతి అవసరం.\n\n1. \"అనుమతి ఇవ్వండి\" నొక్కండి\n2. మీ iPhone లో అనుమతించండి\n3. గడియారం అనువర్తనం మూసిపోతుంది\n4. మళ్లీ తెరిచి \"కొనసాగించండి\" నొక్కండి';
+  String get needMicrophonePermission => 'మాకు మైక్రోఫోన్ అనుమతి అవసరం.\n\n1. \"అనుమతి ఇవ్వండి\" నొక్కండి\n2. మీ iPhone లో అనుమతించండి\n3. గడియారం అనువర్తనం మూసిపోతుంది\n4. మళ్లీ తెరిచి \"కొనసాగించండి\" నొక్కండి';
 
   @override
   String get grantPermissionButton => 'అనుమతి ఇవ్వండి';
@@ -1926,15 +1884,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get needHelp => 'సహాయం అవసరమా?';
 
   @override
-  String get troubleshootingSteps =>
-      'సమస్య పరిష్కారం:\n\n1. Omi మీ గడియారంపై ఇన్‌స్టాల్ చేయబడిందని నిర్ధారించుకోండి\n2. మీ గడియారంపై Omi అనువర్తనాన్ని తెరిచి\n3. అనుమతి పాపప్ కోసం చూడండి\n4. అడిగినప్పుడు \"అనుమతించు\" నొక్కండి\n5. మీ గడియారంపై అనువర్తనం మూసిపోతుంది - దీన్ని తిరిగి తెరిచండి\n6. మీ iPhone లో ఫిరి కమ్మండి మరియు \"కొనసాగించండి\" నొక్కండి';
+  String get troubleshootingSteps => 'సమస్య పరిష్కారం:\n\n1. Omi మీ గడియారంపై ఇన్‌స్టాల్ చేయబడిందని నిర్ధారించుకోండి\n2. మీ గడియారంపై Omi అనువర్తనాన్ని తెరిచి\n3. అనుమతి పాపప్ కోసం చూడండి\n4. అడిగినప్పుడు \"అనుమతించు\" నొక్కండి\n5. మీ గడియారంపై అనువర్తనం మూసిపోతుంది - దీన్ని తిరిగి తెరిచండి\n6. మీ iPhone లో ఫిరి కమ్మండి మరియు \"కొనసాగించండి\" నొక్కండి';
 
   @override
   String get recordingStartedSuccessfully => 'రికార్డింగ్ విజయవంతంగా ప్రారంభమైంది!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'ఇంకా అనుమతి ఇవ్వలేదు. దయచేసి మీరు మీ గడియారంపై మైక్రోఫోన్ ప్రాప్యతను అనుమతించారని మరియు అనువర్తనాన్ని తిరిగి తెరిచారని నిర్ధారించుకోండి.';
+  String get permissionNotGrantedYet => 'ఇంకా అనుమతి ఇవ్వలేదు. దయచేసి మీరు మీ గడియారంపై మైక్రోఫోన్ ప్రాప్యతను అనుమతించారని మరియు అనువర్తనాన్ని తిరిగి తెరిచారని నిర్ధారించుకోండి.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1950,8 +1906,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get selectPrimaryLanguage => 'మీ ప్రాధమిక భాషను ఎంచుకోండి';
 
   @override
-  String get languageBenefits =>
-      'మరింత ఖచ్చితమైన ట్రాన్‌స్క్రిప్షన్‌లు మరియు ఎంపిక చేసిన అనుభవం కోసం మీ భాష సెట్ చేయండి';
+  String get languageBenefits => 'మరింత ఖచ్చితమైన ట్రాన్‌స్క్రిప్షన్‌లు మరియు ఎంపిక చేసిన అనుభవం కోసం మీ భాష సెట్ చేయండి';
 
   @override
   String get whatsYourPrimaryLanguage => 'మీ ప్రాధమిక భాష ఏమిటి?';
@@ -1966,8 +1921,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get actionItemsTitle => 'చేయవలసిన పనులు';
 
   @override
-  String get actionItemsDescription =>
-      'సవరించడానికి నొక్కండి • ఎంచుకోవటానికి ఎక్కువ సమయం నొక్కండి • చర్యలకు స్వైప్ చేయండి';
+  String get actionItemsDescription => 'సవరించడానికి నొక్కండి • ఎంచుకోవటానికి ఎక్కువ సమయం నొక్కండి • చర్యలకు స్వైప్ చేయండి';
 
   @override
   String get tabToDo => 'చేయవలసిన పని';
@@ -2033,8 +1987,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get welcomeActionItemsTitle => 'చర్య చర్యల కోసం సిద్ధమైంది';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'మీ AI స్వయంచాలకంగా మీ సంభాషణల నుండి పనులను మరియు చేయవలసిన పనులను సంగ్రహిస్తుంది. సృష్టించినప్పుడు వారు ఇక్కడ కనిపిస్తారు.';
+  String get welcomeActionItemsDescription => 'మీ AI స్వయంచాలకంగా మీ సంభాషణల నుండి పనులను మరియు చేయవలసిన పనులను సంగ్రహిస్తుంది. సృష్టించినప్పుడు వారు ఇక్కడ కనిపిస్తారు.';
 
   @override
   String get autoExtractionFeature => 'సంభాషణల నుండి స్వయంచాలకంగా సంగ్రహించబడింది';
@@ -2230,15 +2183,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'ఉచ్చారణ & ట్రాన్‌స్క్రిప్షన్';
 
   @override
-  String get languageSettingsHelperText =>
-      'ఆ విషయానికి సంబంధించిన భాష మెనూలు మరియు బటన్‌లను మార్చుతుంది. ఉచ్చారణ భాష మీ రికార్డింగ్‌లను ఎలా ట్రాన్‌స్క్రిప్ట్ చేయాలో ప్రభావితం చేస్తుంది.';
+  String get languageSettingsHelperText => 'ఆ విషయానికి సంబంధించిన భాష మెనూలు మరియు బటన్‌లను మార్చుతుంది. ఉచ్చారణ భాష మీ రికార్డింగ్‌లను ఎలా ట్రాన్‌స్క్రిప్ట్ చేయాలో ప్రభావితం చేస్తుంది.';
 
   @override
   String get translationNotice => 'అనువాద సూచన';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi సంభాషణలను మీ ప్రాధమిక భాషకు అనువదిస్తుంది. సెట్టింగ్‌లు → ప్రొఫైల్‌లలో ఏ సమయానికీ దీన్ని నవీకరించండి.';
+  String get translationNoticeMessage => 'Omi సంభాషణలను మీ ప్రాధమిక భాషకు అనువదిస్తుంది. సెట్టింగ్‌లు → ప్రొఫైల్‌లలో ఏ సమయానికీ దీన్ని నవీకరించండి.';
 
   @override
   String get pleaseCheckInternetConnection => 'దయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి';
@@ -2400,8 +2351,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'డివైస్ జత తెంచండి';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'ఇది డివైస్‌ను జత తీసి మరొక ఫోన్‌కు కనెక్ట్ చేయవచ్చు. ప్రక్రియను పూర్తి చేయడానికి మీరు సెట్టింగ్‌లు > బ్లూటూత్‌కు వెళ్లి డివైస్‌ను మర్చిపోవాలి.';
+  String get unpairDeviceDialogMessage => 'ఇది డివైస్‌ను జత తీసి మరొక ఫోన్‌కు కనెక్ట్ చేయవచ్చు. ప్రక్రియను పూర్తి చేయడానికి మీరు సెట్టింగ్‌లు > బ్లూటూత్‌కు వెళ్లి డివైస్‌ను మర్చిపోవాలి.';
 
   @override
   String get unpair => 'జత తెంచండి';
@@ -2582,8 +2532,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get youreAllSet => 'మీరు సిద్ధంగా ఉన్నారు!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Omi కు స్వాగతం! మీ AI సঙ్గి సంభాషణలు, పనులు మరియు మరిన్నింటితో మీకు సహాయ చేయడానికి సిద్ధంగా ఉంది.';
+  String get welcomeToOmiDescription => 'Omi కు స్వాగతం! మీ AI సঙ్గి సంభాషణలు, పనులు మరియు మరిన్నింటితో మీకు సహాయ చేయడానికి సిద్ధంగా ఉంది.';
 
   @override
   String get startUsingOmi => 'Omi ఉపయోగం ప్రారంభించండి';
@@ -2662,8 +2611,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get reviewAndManageConversations => 'మీ సంపాదించిన సంభాషణలను సమీక్షించండి మరియు నిర్వహించండి';
 
   @override
-  String get startCapturingConversations =>
-      'మీ Omi డివైస్‌తో సంభాషణలను సంపాదించడం ప్రారంభించండి వాటిని ఇక్కడ చూడటానికి.';
+  String get startCapturingConversations => 'మీ Omi డివైస్‌తో సంభాషణలను సంపాదించడం ప్రారంభించండి వాటిని ఇక్కడ చూడటానికి.';
 
   @override
   String get useMobileAppToCapture => 'ఆడియో సంపాదించడానికి మీ మొబైల్ అ్యాప్ ఉపయోగించండి';
@@ -2720,8 +2668,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get noTasksYet => 'ఇంకా పనులు లేవు';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'మీ సంభాషణల నుండి పనులు ఇక్కడ కనిపిస్తాయి.\nఒకటిని మానవీయంగా జోడించడానికి సృష్టించుకు నొక్కండి.';
+  String get tasksFromConversationsWillAppear => 'మీ సంభాషణల నుండి పనులు ఇక్కడ కనిపిస్తాయి.\nఒకటిని మానవీయంగా జోడించడానికి సృష్టించుకు నొక్కండి.';
 
   @override
   String get monthJan => 'జన';
@@ -2778,8 +2725,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deleteActionItem => 'కార్యాచరణ అంశం తొలగించండి';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'ఈ కార్యాచరణ అంశాన్ని తొలగించాలని మీరు నిశ్చితమైనారా? ఈ చర్యను రద్దు చేయలేము.';
+  String get deleteActionItemConfirmation => 'ఈ కార్యాచరణ అంశాన్ని తొలగించాలని మీరు నిశ్చితమైనారా? ఈ చర్యను రద్దు చేయలేము.';
 
   @override
   String get enterActionItemDescription => 'కార్యాచరణ అంశం వివరణ ప్రవేశించండి...';
@@ -2821,8 +2767,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get checkBackLaterForNewApps => 'నতून అ్యాప్‌ల కోసం తర్వాత తిరిగి చెక్ చేయండి';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'మీ ఇంటర్నెట్ కనెక్షన్‌ను చెక్ చేయండి మరియు మళ్లీ ప్రయత్నించండి';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'మీ ఇంటర్నెట్ కనెక్షన్‌ను చెక్ చేయండి మరియు మళ్లీ ప్రయత్నించండి';
 
   @override
   String get createNewApp => 'నూతన అ్యాప్ సృష్టించండి';
@@ -2855,15 +2800,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get chatPrompt => 'చాట్ సూచన';
 
   @override
-  String get chatPromptPlaceholder =>
-      'మీరు అద్భుత అ్యాప్‌ ఉన్నారు, మీ ఉద్యోగం వినియోగదారు ప్రశ్నలకు ప్రతిస్పందించడం మరియు వారిని మంచిదనిపిస్తూ చేయడం...';
+  String get chatPromptPlaceholder => 'మీరు అద్భుత అ్యాప్‌ ఉన్నారు, మీ ఉద్యోగం వినియోగదారు ప్రశ్నలకు ప్రతిస్పందించడం మరియు వారిని మంచిదనిపిస్తూ చేయడం...';
 
   @override
   String get conversationPrompt => 'సంభాషణ సూచన';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'మీరు అద్భుత అ్యాప్‌ ఉన్నారు, మీకు సంభాషణ ట్రాన్‌స్క్రిప్ట్ మరియు సారాంశం ఇవ్వబడుతుంది...';
+  String get conversationPromptPlaceholder => 'మీరు అద్భుత అ్యాప్‌ ఉన్నారు, మీకు సంభాషణ ట్రాన్‌స్క్రిప్ట్ మరియు సారాంశం ఇవ్వబడుతుంది...';
 
   @override
   String get notificationScopes => 'నోటిఫికేషన్ స్కోప్‌లు';
@@ -2875,8 +2818,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get makeMyAppPublic => 'నా అ్యాప్‌ను సార్వजనిక చేయండి';
 
   @override
-  String get submitAppTermsAgreement =>
-      'ఈ అ్యాప్‌ను సమర్పించడం ద్వారా, నేను Omi AI సేవా నిబంధనలు మరియు గోప్యతా విధానానికి అంగీకరిస్తున్నాను';
+  String get submitAppTermsAgreement => 'ఈ అ్యాప్‌ను సమర్పించడం ద్వారా, నేను Omi AI సేవా నిబంధనలు మరియు గోప్యతా విధానానికి అంగీకరిస్తున్నాను';
 
   @override
   String get submitApp => 'అ్యాప్ సమర్పించండి';
@@ -2891,12 +2833,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get submitAppQuestion => 'అ్యాప్ సమర్పించాలా?';
 
   @override
-  String get submitAppPublicDescription =>
-      'మీ అ్యాప్ సమీక్షించబడుతుంది మరియు సార్వజనికంగా చేయబడుతుంది. సమీక్ష సమయంలో కూడా మీరు దీనిని తక్షణమే ఉపయోగించడం ప్రారంభించవచ్చు!';
+  String get submitAppPublicDescription => 'మీ అ్యాప్ సమీక్షించబడుతుంది మరియు సార్వజనికంగా చేయబడుతుంది. సమీక్ష సమయంలో కూడా మీరు దీనిని తక్షణమే ఉపయోగించడం ప్రారంభించవచ్చు!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'మీ అ్యాప్ సమీక్షించబడుతుంది మరియు మీకు ఖాగితిగా అందుబాటులోకి వస్తుంది. సమీక్ష సమయంలో కూడా మీరు దీనిని తక్షణమే ఉపయోగించడం ప్రారంభించవచ్చు!';
+  String get submitAppPrivateDescription => 'మీ అ్యాప్ సమీక్షించబడుతుంది మరియు మీకు ఖాగితిగా అందుబాటులోకి వస్తుంది. సమీక్ష సమయంలో కూడా మీరు దీనిని తక్షణమే ఉపయోగించడం ప్రారంభించవచ్చు!';
 
   @override
   String get startEarning => 'సంపాదించడం ప్రారంభించండి! 💰';
@@ -2920,23 +2860,19 @@ class AppLocalizationsTe extends AppLocalizations {
   String get dataAccessNotice => 'డేటా యాక్సెస్ నోటిస్';
 
   @override
-  String get dataAccessWarning =>
-      'ఈ అ్యాప్ మీ డేటాకు ప్రాప్యత కలిగి ఉంటుంది. Omi AI ఈ అ్యాప్ ద్వారా మీ డేటా ఎలా ఉపయోగించబడుతుంది, సవరించబడుతుంది లేదా తొలగించబడుతుంది చేత్వం కోసం బాధ్యత వహించదు';
+  String get dataAccessWarning => 'ఈ అ్యాప్ మీ డేటాకు ప్రాప్యత కలిగి ఉంటుంది. Omi AI ఈ అ్యాప్ ద్వారా మీ డేటా ఎలా ఉపయోగించబడుతుంది, సవరించబడుతుంది లేదా తొలగించబడుతుంది చేత్వం కోసం బాధ్యత వహించదు';
 
   @override
   String get installApp => 'అ్యాప్ ఇన్‌స్టాల్ చేయండి';
 
   @override
-  String get betaTesterNotice =>
-      'మీరు ఈ అ్యాప్ కోసం బీటా టెస్టర్. ఇది ఇంకా సార్వజనిక కాదు. ఇది ఆమోదించినపుడు సార్వజనికం అవుతుంది.';
+  String get betaTesterNotice => 'మీరు ఈ అ్యాప్ కోసం బీటా టెస్టర్. ఇది ఇంకా సార్వజనిక కాదు. ఇది ఆమోదించినపుడు సార్వజనికం అవుతుంది.';
 
   @override
-  String get appUnderReviewOwner =>
-      'మీ అ్యాప్ సమీక్షలో ఉంది మరియు మీకు మాత్రమే కనిపిస్తుంది. ఇది ఆమోదించినపుడు సార్వజనికం అవుతుంది.';
+  String get appUnderReviewOwner => 'మీ అ్యాప్ సమీక్షలో ఉంది మరియు మీకు మాత్రమే కనిపిస్తుంది. ఇది ఆమోదించినపుడు సార్వజనికం అవుతుంది.';
 
   @override
-  String get appRejectedNotice =>
-      'మీ అ్యాప్ తిరస్కరించబడింది. దయచేసి అ్యాప్ వివరాలను నవీకరించండి మరియు సమీక్ష కోసం మళ్లీ సమర్పించండి.';
+  String get appRejectedNotice => 'మీ అ్యాప్ తిరస్కరించబడింది. దయచేసి అ్యాప్ వివరాలను నవీకరించండి మరియు సమీక్ష కోసం మళ్లీ సమర్పించండి.';
 
   @override
   String get setupSteps => 'సెటప్ దశలు';
@@ -2998,8 +2934,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get descriptionLabel => 'వివరణ';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'నా అద్భుత అ్యాప్ అద్భుత విషయాలు చేసే గొప్ప అ్యాప్. ఇది ఎప్పుడూ గొప్ప అ్యాప్!';
+  String get appDescriptionPlaceholder => 'నా అద్భుత అ్యాప్ అద్భుత విషయాలు చేసే గొప్ప అ్యాప్. ఇది ఎప్పుడూ గొప్ప అ్యాప్!';
 
   @override
   String get pleaseProvideValidDescription => 'దయచేసి చెల్లుబాటుయొక్క వివరణ ఇవ్వండి';
@@ -3151,8 +3086,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get microphonePermissionRequired => 'కాల్‌లు చేయడానికి మైక్రోఫోన్ అనుమతి అవసరం';
 
   @override
-  String get microphonePermissionDenied =>
-      'మైక్రోఫోన్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్సెస్ > గోప్యత & భద్రత > మైక్రోఫోన్‌లో అనుమతిని మంజూరు చేయండి.';
+  String get microphonePermissionDenied => 'మైక్రోఫోన్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్సెస్ > గోప్యత & భద్రత > మైక్రోఫోన్‌లో అనుమతిని మంజూరు చేయండి.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3385,8 +3319,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get whatWeCollect => 'మేము సేకరించేది';
 
   @override
-  String get dataCollectionMessage =>
-      'కొనసాగించడం ద్వారా, మీ సంభాషణలు, రికార్డింగ్‌లు మరియు వ్యక్తిగత సమాచారం AI-శక్తిమైన అంతర్దృష్టులను అందించడానికి మరియు అన్ని అ్యాప్ ఫీచర్‌లను ప్రారంభించడానికి మా సర్వర్‌లలో సురక్షితంగా నిల్వ చేయబడుతుంది.';
+  String get dataCollectionMessage => 'కొనసాగించడం ద్వారా, మీ సంభాషణలు, రికార్డింగ్‌లు మరియు వ్యక్తిగత సమాచారం AI-శక్తిమైన అంతర్దృష్టులను అందించడానికి మరియు అన్ని అ్యాప్ ఫీచర్‌లను ప్రారంభించడానికి మా సర్వర్‌లలో సురక్షితంగా నిల్వ చేయబడుతుంది.';
 
   @override
   String get dataProtection => 'డేటా సంరక్షణ';
@@ -3419,8 +3352,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'పేరు కనీసం 2 అక్షరాలు ఉండాలి';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'మీరు ఎలా సంబోధించాలనుకుంటున్నారో చెప్పండి. ఇది మీ Omi అనుభవాన్ని వ్యక్తిగతీకరించడానికి సహాయపడుతుంది.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'మీరు ఎలా సంబోధించాలనుకుంటున్నారో చెప్పండి. ఇది మీ Omi అనుభవాన్ని వ్యక్తిగతీకరించడానికి సహాయపడుతుంది.';
 
   @override
   String charactersCount(int count) {
@@ -3437,8 +3369,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get recordAudioConversations => 'ఆడియో సంభాషణలను రికార్డ్ చేయండి';
 
   @override
-  String get microphoneAccessDescription =>
-      'మీ సంభాషణలను రికార్డ్ చేయడానికి మరియు ట్రాన్‌స్‌క్రిప్షన్‌లను అందించడానికి Omi కు మైక్రోఫోన్ యాక్సెస్ అవసరం.';
+  String get microphoneAccessDescription => 'మీ సంభాషణలను రికార్డ్ చేయడానికి మరియు ట్రాన్‌స్‌క్రిప్షన్‌లను అందించడానికి Omi కు మైక్రోఫోన్ యాక్సెస్ అవసరం.';
 
   @override
   String get screenRecording => 'స్క్రీన్ రికార్డింగ్';
@@ -3447,8 +3378,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'సమావేశాల నుండి సిస్టమ్ ఆడియోను సంగ్రహించండి';
 
   @override
-  String get screenRecordingDescription =>
-      'మీ బ్రౌజర్-ఆధారిత సమావేశాల నుండి సిస్టమ్ ఆడియోను సంగ్రహించడానికి Omi కు స్క్రీన్ రికార్డింగ్ అనుమతి అవసరం.';
+  String get screenRecordingDescription => 'మీ బ్రౌజర్-ఆధారిత సమావేశాల నుండి సిస్టమ్ ఆడియోను సంగ్రహించడానికి Omi కు స్క్రీన్ రికార్డింగ్ అనుమతి అవసరం.';
 
   @override
   String get accessibility => 'యాక్సెసిబిలిటీ';
@@ -3457,8 +3387,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'బ్రౌజర్-ఆధారిత సమావేశాలను గుర్తించండి';
 
   @override
-  String get accessibilityDescription =>
-      'మీ బ్రౌజర్‌లో Zoom, Meet లేదా Teams సమావేశాలకు చేరిక చేసినప్పుడు గుర్తించడానికి Omi కు యాక్సెసిబిలిటీ అనుమతి అవసరం.';
+  String get accessibilityDescription => 'మీ బ్రౌజర్‌లో Zoom, Meet లేదా Teams సమావేశాలకు చేరిక చేసినప్పుడు గుర్తించడానికి Omi కు యాక్సెసిబిలిటీ అనుమతి అవసరం.';
 
   @override
   String get pleaseWait => 'దయచేసి ఆగండి...';
@@ -3506,8 +3435,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get preferences => 'ప్రాధాన్యతలు';
 
   @override
-  String get helpImproveOmiBySharing =>
-      'నామరూప విశ్లేషణ డేటాను భాగస్వామ్యం చేయడం ద్వారా Omi ను మెరుగుపరచడానికి సహాయ చేయండి';
+  String get helpImproveOmiBySharing => 'నామరూప విశ్లేషణ డేటాను భాగస్వామ్యం చేయడం ద్వారా Omi ను మెరుగుపరచడానికి సహాయ చేయండి';
 
   @override
   String get deleteAccount => 'ఖాతాను తొలగించండి';
@@ -3528,12 +3456,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get exportAllConversationsToJson => 'మీ సంభాషణలన్నిటిని JSON ఫైల్‌కు ఎగుమతి చేయండి.';
 
   @override
-  String get conversationsExportStarted =>
-      'సంభాషణల ఎగుమతి ప్రారంభమైంది. ఇది కొన్ని సెకన్ల పాటు తీసుకోవచ్చు, దయచేసి ఆగండి.';
+  String get conversationsExportStarted => 'సంభాషణల ఎగుమతి ప్రారంభమైంది. ఇది కొన్ని సెకన్ల పాటు తీసుకోవచ్చు, దయచేసి ఆగండి.';
 
   @override
-  String get mcpDescription =>
-      'Omi ను ఇతర అ్యాప్లికేషన్‌లతో కనెక్ట్ చేయడానికి మీ జ్ఞాపనలు మరియు సంభాషణలను చదవడానికి, శోధించడానికి మరియు నిర్వహించడానికి. ప్రారంభించడానికి కీని సృష్టించండి.';
+  String get mcpDescription => 'Omi ను ఇతర అ్యాప్లికేషన్‌లతో కనెక్ట్ చేయడానికి మీ జ్ఞాపనలు మరియు సంభాషణలను చదవడానికి, శోధించడానికి మరియు నిర్వహించడానికి. ప్రారంభించడానికి కీని సృష్టించండి.';
 
   @override
   String get apiKeys => 'API కీలు';
@@ -3574,15 +3500,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'ట్రాన్‌స్‌క్రిప్షన్ సేవ నిర్ధారణ స్థితి';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'ట్రాన్‌స్‌క్రిప్షన్ సేవ నుండి వివరణాత్మక నిర్ధారణ సందేశాలను ప్రారంభించండి';
+  String get enableDetailedDiagnosticMessages => 'ట్రాన్‌స్‌క్రిప్షన్ సేవ నుండి వివరణాత్మక నిర్ధారణ సందేశాలను ప్రారంభించండి';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'కొత్త స్పీకర్‌లను స్వయంచాలకంగా సృష్టించండి మరియు ట్యాగ్ చేయండి';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'ట్రాన్‌స్‌క్రిప్ట్‌లో పేరు గుర్తించినప్పుడు కొత్త వ్యక్తిని స్వయంచాలకంగా సృష్టించండి.';
+  String get automaticallyCreateNewPerson => 'ట్రాన్‌స్‌క్రిప్ట్‌లో పేరు గుర్తించినప్పుడు కొత్త వ్యక్తిని స్వయంచాలకంగా సృష్టించండి.';
 
   @override
   String get pilotFeatures => 'పైలట్ ఫీచర్‌లు';
@@ -3643,8 +3567,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Omi ఉత్తమ అ్యాప్‌ను స్వయంచాలకంగా ఎంచుకోనివ్వండి';
 
   @override
-  String get deleteConversationConfirmation =>
-      'ఈ సంభాషణను తొలగించాలనుకుంటున్నారని మీరు నిశ్చితమైనారా? ఈ చర్య చేసి విషయాన్ని తిరిగి సరిచేయలేము.';
+  String get deleteConversationConfirmation => 'ఈ సంభాషణను తొలగించాలనుకుంటున్నారని మీరు నిశ్చితమైనారా? ఈ చర్య చేసి విషయాన్ని తిరిగి సరిచేయలేము.';
 
   @override
   String get conversationDeleted => 'సంభాషణ తొలగించబడింది';
@@ -3692,8 +3615,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get preparingSystemAudioCapture => 'సిస్టమ్ ఆడియో సంగ్రహణ ప్రস్తుత చేయబడుతోంది';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'లైవ్ ట్రాన్‌స్‌క్రిప్ట్‌లు, AI అంతర్దృష్టులు మరియు స్వయంచాలక సేవ కోసం ఆడియోను సంగ్రహించడానికి బటన్‌ను క్లిక్ చేయండి.';
+  String get clickTheButtonToCaptureAudio => 'లైవ్ ట్రాన్‌స్‌క్రిప్ట్‌లు, AI అంతర్దృష్టులు మరియు స్వయంచాలక సేవ కోసం ఆడియోను సంగ్రహించడానికి బటన్‌ను క్లిక్ చేయండి.';
 
   @override
   String get reconnecting => 'తిరిగి కనెక్ట్ చేయబడుతోంది...';
@@ -3764,8 +3686,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get settingUpSystemAudioCapture => 'సిస్టమ్ ఆడియో సంగ్రహణ సెట్ అప్ చేయబడుతోంది';
 
   @override
-  String get capturingAudioAndGeneratingTranscript =>
-      'ఆడియోను సంగ్రహిస్తోంది మరియు ట్రాన్‌స్‌క్రిప్ట్ జనరేట్ చేస్తోంది';
+  String get capturingAudioAndGeneratingTranscript => 'ఆడియోను సంగ్రహిస్తోంది మరియు ట్రాన్‌స్‌క్రిప్ట్ జనరేట్ చేస్తోంది';
 
   @override
   String get clickToBeginRecordingSystemAudio => 'సిస్టమ్ ఆడియో రికార్డింగ్ ప్రారంభించడానికి క్లిక్ చేయండి';
@@ -3897,8 +3818,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get shortcuts => 'షార్టকట్‌లు';
 
   @override
-  String get shortcutChangeInstruction =>
-      'షార్టకట్‌ను మార్చడానికి దానిపై క్లిక్ చేయండి. రద్దు చేయడానికి Escape నొక్కండి.';
+  String get shortcutChangeInstruction => 'షార్టకట్‌ను మార్చడానికి దానిపై క్లిక్ చేయండి. రద్దు చేయడానికి Escape నొక్కండి.';
 
   @override
   String get configureSTTProvider => 'STT ప్రొవైడర్ కాన్ఫిగర్ చేయండి';
@@ -3922,8 +3842,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'జ్ఞానం గ్రాఫ్ తొలగించాలా?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'ఇది అన్ని ఉత్పత్తి కంపిల్ జ్ఞానం గ్రాఫ్ డేటాను తొలగిస్తుంది. మీ అసలు జ్ఞాపనలు సురక్షితమైనవిగా ఉంటాయి.';
+  String get deleteKnowledgeGraphWarning => 'ఇది అన్ని ఉత్పత్తి కంపిల్ జ్ఞానం గ్రాఫ్ డేటాను తొలగిస్తుంది. మీ అసలు జ్ఞాపనలు సురక్షితమైనవిగా ఉంటాయి.';
 
   @override
   String get connectOmiWithAI => 'Omi ను AI సహాయకులతో కనెక్ట్ చేయండి';
@@ -3965,8 +3884,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'నిబంధనలు & గోప్యత విధానం';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'సమస్యలను నిర్ధారణ చేయటానికి సహాయపడుతుంది. 3 రోజుల తర్వాత స్వయంచాలకంగా తొలగించబడుతుంది.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'సమస్యలను నిర్ధారణ చేయటానికి సహాయపడుతుంది. 3 రోజుల తర్వాత స్వయంచాలకంగా తొలగించబడుతుంది.';
 
   @override
   String get manageYourApp => 'మీ అ్యాప్ నిర్వహించండి';
@@ -3981,8 +3899,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get updateAppQuestion => 'అ్యాప్‌ను నవీకరించాలా?';
 
   @override
-  String get updateAppConfirmation =>
-      'మీ అ్యాప్‌ను నవీకరించాలనుకుంటున్నారని మీరు నిశ్చితమైనారా? మార్పులు మా టీమ్ ద్వారా సమీక్ష చేసిన తర్వాత ప్రతిబింబిస్తాయి.';
+  String get updateAppConfirmation => 'మీ అ్యాప్‌ను నవీకరించాలనుకుంటున్నారని మీరు నిశ్చితమైనారా? మార్పులు మా టీమ్ ద్వారా సమీక్ష చేసిన తర్వాత ప్రతిబింబిస్తాయి.';
 
   @override
   String get updateApp => 'అ్యాప్‌ను నవీకరించండి';
@@ -4012,8 +3929,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get no => 'లేదు';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'సభ్యత విజయవంతంగా రద్దు చేయబడింది. ఇది ప్రస్తుత బిలింగ్ కాలం చివర వరకు సక్రియంగా ఉంటుంది.';
+  String get subscriptionCancelledSuccessfully => 'సభ్యత విజయవంతంగా రద్దు చేయబడింది. ఇది ప్రస్తుత బిలింగ్ కాలం చివర వరకు సక్రియంగా ఉంటుంది.';
 
   @override
   String get failedToCancelSubscription => 'సభ్యత రద్దు చేయటానికి విఫలమైంది. దయచేసి మళ్లీ ప్రయత్నించండి.';
@@ -4049,8 +3965,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'సభ్యత రద్దు చేయాలా?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'సభ్యత రద్దు చేయాలనుకుంటున్నారని మీరు నిశ్చితమైనారా? మీ ప్రస్తుత బిలింగ్ కాలం చివర వరకు మీరు యాక్సెస్‌ను కలిగి ఉంటారు.';
+  String get cancelSubscriptionConfirmation => 'సభ్యత రద్దు చేయాలనుకుంటున్నారని మీరు నిశ్చితమైనారా? మీ ప్రస్తుత బిలింగ్ కాలం చివర వరకు మీరు యాక్సెస్‌ను కలిగి ఉంటారు.';
 
   @override
   String get cancelSubscriptionButton => 'సభ్యత రద్దు చేయండి';
@@ -4059,16 +3974,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get cancelling => 'రద్దు చేయబడుతోంది...';
 
   @override
-  String get betaTesterMessage =>
-      'ఈ అ్యాప్ కోసం మీరు బీటా టెస్టర్. ఇది ఇంకా పబ్లిక్‌కు కాదు. ఇది ఆమోదించిన తర్వాత పబ్లిక్‌గా ఉంటుంది.';
+  String get betaTesterMessage => 'ఈ అ్యాప్ కోసం మీరు బీటా టెస్టర్. ఇది ఇంకా పబ్లిక్‌కు కాదు. ఇది ఆమోదించిన తర్వాత పబ్లిక్‌గా ఉంటుంది.';
 
   @override
-  String get appUnderReviewMessage =>
-      'మీ అ్యాప్ సమీక్ష క్రింద ఉంది మరియు కేవలం మీకు కనిపిస్తుంది. ఇది ఆమోదించిన తర్వాత పబ్లిక్‌గా ఉంటుంది.';
+  String get appUnderReviewMessage => 'మీ అ్యాప్ సమీక్ష క్రింద ఉంది మరియు కేవలం మీకు కనిపిస్తుంది. ఇది ఆమోదించిన తర్వాత పబ్లిక్‌గా ఉంటుంది.';
 
   @override
-  String get appRejectedMessage =>
-      'మీ అ్యాప్ తిరస్కరించబడింది. దయచేసి అ్యాప్ వివరాలను నవీకరించండి మరియు సమీక్ష కోసం తిరిగి సమర్పించండి.';
+  String get appRejectedMessage => 'మీ అ్యాప్ తిరస్కరించబడింది. దయచేసి అ్యాప్ వివరాలను నవీకరించండి మరియు సమీక్ష కోసం తిరిగి సమర్పించండి.';
 
   @override
   String get invalidIntegrationUrl => 'చెల్లని ఇంటిగ్రేషన్ URL';
@@ -4122,8 +4034,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get issueActivatingApp => 'ఈ అ్యాప్‌ను సక్రియం చేయడంలో సమస్య ఉంది. దయచేసి మళ్లీ ప్రయత్నించండి.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'ఈ అ్యాప్ మీ డేటాను యాక్సెస్ చేస్తుంది. Omi AI ఈ అ్యాప్ ద్వారా మీ డేటా ఎలా ఉపయోగించబడుతుంది, సవరించబడుతుంది లేదా తొలగించబడుతుందో వానికి బాధ్యత లేనిది';
+  String get dataAccessNoticeDescription => 'ఈ అ్యాప్ మీ డేటాను యాక్సెస్ చేస్తుంది. Omi AI ఈ అ్యాప్ ద్వారా మీ డేటా ఎలా ఉపయోగించబడుతుంది, సవరించబడుతుంది లేదా తొలగించబడుతుందో వానికి బాధ్యత లేనిది';
 
   @override
   String get copyUrl => 'URL కాపీ చేయండి';
@@ -4211,8 +4122,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get omiApiKeys => 'Omi API కీలు';
 
   @override
-  String get apiKeysDescription =>
-      'API కీలు మీ అ్యాప్ OMI సర్వర్‌తో సంభాషణ చేసినప్పుడు ప్రామాణీకరణ కోసం ఉపయోగించబడతాయి. అవి మీ అ్యాప్‌కు జ్ఞాపనలను సృష్టించడానికి మరియు ఇతర OMI సేవలను సురక్షితంగా యాక్సెస్ చేయడానికి అనుమతిస్తాయి.';
+  String get apiKeysDescription => 'API కీలు మీ అ్యాప్ OMI సర్వర్‌తో సంభాషణ చేసినప్పుడు ప్రామాణీకరణ కోసం ఉపయోగించబడతాయి. అవి మీ అ్యాప్‌కు జ్ఞాపనలను సృష్టించడానికి మరియు ఇతర OMI సేవలను సురక్షితంగా యాక్సెస్ చేయడానికి అనుమతిస్తాయి.';
 
   @override
   String get aboutOmiApiKeys => 'Omi API కీల గురించి';
@@ -4236,8 +4146,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API కీని రిభోక్ చేయాలా?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'ఈ చర్య చేసి విషయాన్ని తిరిగి సరిచేయలేము. ఈ కీని ఉపయోగించే ఏదైనా అ్యాప్లికేషన్‌లు API కు యాక్సెస్ చేయలేరు.';
+  String get revokeApiKeyWarning => 'ఈ చర్య చేసి విషయాన్ని తిరిగి సరిచేయలేము. ఈ కీని ఉపయోగించే ఏదైనా అ్యాప్లికేషన్‌లు API కు యాక్సెస్ చేయలేరు.';
 
   @override
   String get revoke => 'రిభోక్ చేయండి';
@@ -4335,8 +4244,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get externalAppAccess => 'బాహ్య అ్యాప్ యాక్సెస్';
 
   @override
-  String get externalAppAccessDescription =>
-      'కింది ఇన్‌స్టాల్ చేయబడిన అ్యాప్‌లకు బాహ్య ఇంటిగ్రేషన్‌లు ఉన్నాయి మరియు సంభాషణలు మరియు జ్ఞాపనల వంటి మీ డేటాను యాక్సెస్ చేయవచ్చు.';
+  String get externalAppAccessDescription => 'కింది ఇన్‌స్టాల్ చేయబడిన అ్యాప్‌లకు బాహ్య ఇంటిగ్రేషన్‌లు ఉన్నాయి మరియు సంభాషణలు మరియు జ్ఞాపనల వంటి మీ డేటాను యాక్సెస్ చేయవచ్చు.';
 
   @override
   String get noExternalAppsHaveAccess => 'బాహ్య అ్యాప్‌లకు మీ డేటాకు యాక్సెస్ లేనిది.';
@@ -4345,8 +4253,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get maximumSecurityE2ee => 'గరిష్ట సురక్ష (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'చివర నుండి చివర ఎన్‌క్రిప్షన్ గోప్యతకు పేద ప్రమాణం. ఈనాబిల్ చేసినప్పుడు, మీ డేటా మీ పరికరంపై ఎన్‌క్రిప్ట్ చేయబడుతుంది అది మా సర్వర్‌లకు పంపబడుముందు. అంటే, ఎవరూ కాదు, Omi కూడా మీ విషయవస్తువను యాక్సెస్ చేయలేరు.';
+  String get e2eeDescription => 'చివర నుండి చివర ఎన్‌క్రిప్షన్ గోప్యతకు పేద ప్రమాణం. ఈనాబిల్ చేసినప్పుడు, మీ డేటా మీ పరికరంపై ఎన్‌క్రిప్ట్ చేయబడుతుంది అది మా సర్వర్‌లకు పంపబడుముందు. అంటే, ఎవరూ కాదు, Omi కూడా మీ విషయవస్తువను యాక్సెస్ చేయలేరు.';
 
   @override
   String get importantTradeoffs => 'ముఖ్యమైన నష్టాలు:';
@@ -4380,19 +4287,16 @@ class AppLocalizationsTe extends AppLocalizations {
   String get secureEncryption => 'సురక్షిత ఎన్‌క్రిప్షన్';
 
   @override
-  String get secureEncryptionDescription =>
-      'మీ డేటా Google క్లౌడ్‌లో హోస్ట్ చేయబడిన మీ సర్వర్‌లలో మీకు సంబంధించిన కీ ద్వారా ఎన్‌క్రిప్ట్ చేయబడుతుంది. అంటే, మీ ముడి విషయవస్తువు డేటాబేస్ నుండి ఎవరికీ సమర్థించలేమని, Omi సిబ్బందికీ లేదా Google కీ.';
+  String get secureEncryptionDescription => 'మీ డేటా Google క్లౌడ్‌లో హోస్ట్ చేయబడిన మీ సర్వర్‌లలో మీకు సంబంధించిన కీ ద్వారా ఎన్‌క్రిప్ట్ చేయబడుతుంది. అంటే, మీ ముడి విషయవస్తువు డేటాబేస్ నుండి ఎవరికీ సమర్థించలేమని, Omi సిబ్బందికీ లేదా Google కీ.';
 
   @override
   String get endToEndEncryption => 'చివర నుండి చివర ఎన్‌క్రిప్షన్';
 
   @override
-  String get e2eeCardDescription =>
-      'కేవలం మీరు మీ డేటాను యాక్సెస్ చేయగలిగే గరిష్ట సురక్ష కోసం ఈనాబిల్ చేయండి. మరిన్ని తెలుసుకోవటానికి నొక్కండి.';
+  String get e2eeCardDescription => 'కేవలం మీరు మీ డేటాను యాక్సెస్ చేయగలిగే గరిష్ట సురక్ష కోసం ఈనాబిల్ చేయండి. మరిన్ని తెలుసుకోవటానికి నొక్కండి.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'స్థాయితో సంబంధం లేకుండా, మీ డేటా ఎల్లప్పుడు విశ్రాంతి సమయంలో మరియు రవాణా సమయంలో ఎన్‌క్రిప్ట్ చేయబడుతుంది.';
+  String get dataAlwaysEncrypted => 'స్థాయితో సంబంధం లేకుండా, మీ డేటా ఎల్లప్పుడు విశ్రాంతి సమయంలో మరియు రవాణా సమయంలో ఎన్‌క్రిప్ట్ చేయబడుతుంది.';
 
   @override
   String get readOnlyScope => 'చదువు చేయడానికి మాత్రమే';
@@ -4457,12 +4361,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get trainingDataProgram => 'శిక్షణ డేటా కార్యక్రమం';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'AI నమూనాలను శిక్షణ ఇవ్వటానికి మీ డేటాకు సహకరించడం ద్వారా Omi అనీమితాన్ని ఉచితంగా పొందండి.';
+  String get getOmiUnlimitedFree => 'AI నమూనాలను శిక్షణ ఇవ్వటానికి మీ డేటాకు సహకరించడం ద్వారా Omi అనీమితాన్ని ఉచితంగా పొందండి.';
 
   @override
-  String get trainingDataBullets =>
-      '• మీ డేటా AI నమూనాలను మెరుగుపరచడానికి సహాయపడుతుంది\n• కేవలం సున్నితమైన డేటా మాత్రమే భాగస్వామ్యం చేయబడుతుంది\n• పూర్తిగా పారదర్శక ప్రక్రియ';
+  String get trainingDataBullets => '• మీ డేటా AI నమూనాలను మెరుగుపరచడానికి సహాయపడుతుంది\n• కేవలం సున్నితమైన డేటా మాత్రమే భాగస్వామ్యం చేయబడుతుంది\n• పూర్తిగా పారదర్శక ప్రక్రియ';
 
   @override
   String get learnMoreAtOmiTraining => 'omi.me/training లో మరిన్ని తెలుసుకోండి';
@@ -4474,8 +4376,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get submitRequest => 'అభ్యర్థనను సమర్పించండి';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'ధన్యవాదాలు! మీ అభ్యర్థన సమీక్ష క్రింద ఉంది. ఆమోదించినప్పుడు మేము మీకు తెలియజేస్తాము.';
+  String get thankYouRequestUnderReview => 'ధన్యవాదాలు! మీ అభ్యర్థన సమీక్ష క్రింద ఉంది. ఆమోదించినప్పుడు మేము మీకు తెలియజేస్తాము.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4513,12 +4414,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get monthlyPlanContinues => 'మీ ప్రస్తుత నెలవారీ ప్లాన్ మీ బిల్లింగ్ వ్యవధి ముగిసే వరకు కొనసాగుతుంది';
 
   @override
-  String get paymentMethodCharged =>
-      'మీ ఇప్పటికే ఉన్న చెల్లింపు పద్ధతి మీ నెలవారీ ప్లాన్ ముగిసినప్పుడు స్వయంచాలకంగా ఛార్జ్ చేయబడుతుంది';
+  String get paymentMethodCharged => 'మీ ఇప్పటికే ఉన్న చెల్లింపు పద్ధతి మీ నెలవారీ ప్లాన్ ముగిసినప్పుడు స్వయంచాలకంగా ఛార్జ్ చేయబడుతుంది';
 
   @override
-  String get annualSubscriptionStarts =>
-      'చెల్లింపు తరువాత మీ 12-నెల వార్షిక సబ్‌స్క్రిప్షన్ స్వయంచాలకంగా ప్రారంభమవుతుంది';
+  String get annualSubscriptionStarts => 'చెల్లింపు తరువాత మీ 12-నెల వార్షిక సబ్‌స్క్రిప్షన్ స్వయంచాలకంగా ప్రారంభమవుతుంది';
 
   @override
   String get thirteenMonthsCoverage => 'మీకు మొత్తం 13 నెలల కవరేజీ లభిస్తుంది (ప్రస్తుత నెల + 12 నెల వార్షిక)';
@@ -4558,8 +4457,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'మీ నెలవారీ ప్లాన్ ముగిసినప్పుడు మీ వార్షిక ప్లాన్ స్వయంచాలకంగా ప్రారంభమవుతుంది.';
+  String get annualPlanStartsAutomatically => 'మీ నెలవారీ ప్లాన్ ముగిసినప్పుడు మీ వార్షిక ప్లాన్ స్వయంచాలకంగా ప్రారంభమవుతుంది.';
 
   @override
   String planRenewsOn(String date) {
@@ -4626,8 +4524,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'మీ గోప్యత మాకు ముఖ్యమైనది';
 
   @override
-  String get privacyIntroText =>
-      'Omi లో, మేము మీ గోప్యతను చాలా జరుపుకుంటాము. మేము మీ కోసం ఉత్పన్నమైన డేటా గురించి పారదర్శకంగా ఉండాలనుకుంటాము మరియు దానిని ఎలా ఉపయోగిస్తున్నాము. మీరు తెలుసుకోవలసిన విషయం ఇది:';
+  String get privacyIntroText => 'Omi లో, మేము మీ గోప్యతను చాలా జరుపుకుంటాము. మేము మీ కోసం ఉత్పన్నమైన డేటా గురించి పారదర్శకంగా ఉండాలనుకుంటాము మరియు దానిని ఎలా ఉపయోగిస్తున్నాము. మీరు తెలుసుకోవలసిన విషయం ఇది:';
 
   @override
   String get whatWeTrack => 'మేము ఏమి ట్రాక్ చేస్తాము';
@@ -4642,12 +4539,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get ourCommitment => 'మా ప్రతిశ్రుతి';
 
   @override
-  String get commitmentText =>
-      'మేము సేకరించిన డేటాను Omi ను మీ కోసం మెరుగైన ఉత్పన్నం చేయడానికి మాత్రమే ఉపయోగించాలని ప్రతిశ్రుతిబద్ధులు. మీ గోప్యత మరియు నమ్మకం మాకు అత్యంత ముఖ్యమైనవి.';
+  String get commitmentText => 'మేము సేకరించిన డేటాను Omi ను మీ కోసం మెరుగైన ఉత్పన్నం చేయడానికి మాత్రమే ఉపయోగించాలని ప్రతిశ్రుతిబద్ధులు. మీ గోప్యత మరియు నమ్మకం మాకు అత్యంత ముఖ్యమైనవి.';
 
   @override
-  String get thankYouText =>
-      'Omi యొక్క విలువైన వినియోగదారుగా ఉన్నందుకు ధన్యవాదాలు. మీకు ఏవైనా ప్రశ్నలు లేదా ఆందోళనలు ఉంటే, team@basedhardware.com కు సంప్రదించడానికి సంకోచించకండి.';
+  String get thankYouText => 'Omi యొక్క విలువైన వినియోగదారుగా ఉన్నందుకు ధన్యవాదాలు. మీకు ఏవైనా ప్రశ్నలు లేదా ఆందోళనలు ఉంటే, team@basedhardware.com కు సంప్రదించడానికి సంకోచించకండి.';
 
   @override
   String get wifiSyncSettings => 'WiFi సమకాలీకరణ సెట్టింగ్‌లు';
@@ -4656,8 +4551,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get enterHotspotCredentials => 'మీ ఫోన్ యొక్క హాట్‌స్పాట్ సంలग్నాలను నమోదు చేయండి';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi సమకాలీకరణ మీ ఫోన్‌ను హాట్‌స్పాట్‌గా ఉపయోగిస్తుంది. సెట్టింగ్‌లు > ఖ్యాతిమත్తర హాట్‌స్పాట్‌లో మీ హాట్‌స్పాట్ పేరు మరియు పాస్‌వర్డ్ కనుగొనండి.';
+  String get wifiSyncUsesHotspot => 'WiFi సమకాలీకరణ మీ ఫోన్‌ను హాట్‌స్పాట్‌గా ఉపయోగిస్తుంది. సెట్టింగ్‌లు > ఖ్యాతిమත్తర హాట్‌స్పాట్‌లో మీ హాట్‌స్పాట్ పేరు మరియు పాస్‌వర్డ్ కనుగొనండి.';
 
   @override
   String get hotspotNameSsid => 'హాట్‌స్పాట్ పేరు (SSID)';
@@ -4692,8 +4586,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'సారాంశం రూపొందించడం విఫలమైంది. ఆ రోజున మీకు సంభాషణలు ఉన్నాయని నిర్ధారించుకోండి.';
+  String get failedToGenerateSummaryCheckConversations => 'సారాంశం రూపొందించడం విఫలమైంది. ఆ రోజున మీకు సంభాషణలు ఉన్నాయని నిర్ధారించుకోండి.';
 
   @override
   String get summaryNotFound => 'సారాంశం కనుగొనబడలేదు';
@@ -4723,8 +4616,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'ఎగుమతి ప్రారంభమైంది. ఇది కొన్ని సెకన్లు పట్టవచ్చు...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'ఇది అన్ని ఉత్పన్నమైన జ్ఞానం గ్రాఫ్ డేటా (నోడ్‌లు మరియు కనెక్షన్‌లు) తొలగిస్తుంది. మీ అసలు జ్ఞాపకాలు సురక్షితంగా ఉంటాయి. గ్రాఫ్ కాలక్రమేణా లేదా తరువాతి అభ్యర్థన యొక్క నిమిషాల్లో పునర్నిర్మించబడుతుంది.';
+  String get knowledgeGraphDeleteDescription => 'ఇది అన్ని ఉత్పన్నమైన జ్ఞానం గ్రాఫ్ డేటా (నోడ్‌లు మరియు కనెక్షన్‌లు) తొలగిస్తుంది. మీ అసలు జ్ఞాపకాలు సురక్షితంగా ఉంటాయి. గ్రాఫ్ కాలక్రమేణా లేదా తరువాతి అభ్యర్థన యొక్క నిమిషాల్లో పునర్నిర్మించబడుతుంది.';
 
   @override
   String get configureDailySummaryDigest => 'మీ నిత్య చర్య సమితులను సంగ్రహం చేయండి';
@@ -4794,8 +4686,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'అన్ని Limitless సంభాషణలను తొలగించాలా?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'ఇది Limitless నుండి దిగుమతి చేసిన అన్ని సంభాషణలను శాశ్వతంగా తొలగిస్తుంది. ఈ చర్యను తిరిగి చేయలేము.';
+  String get deleteAllLimitlessWarning => 'ఇది Limitless నుండి దిగుమతి చేసిన అన్ని సంభాషణలను శాశ్వతంగా తొలగిస్తుంది. ఈ చర్యను తిరిగి చేయలేము.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4851,8 +4742,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get howItWorksTitle => 'ఇది ఎలా పనిచేస్తుంది?';
 
   @override
-  String get howPeopleWorks =>
-      'ఒక వ్యక్తి సృష్టించిన తర్వాత, మీరు సంభాషణ ట్రాన్‌స్క్రిప్ట్‌కు వెళ్లవచ్చు మరియు వారిని తమ సంబంధిత సెగ్మెంట్‌లకు కేటాయించవచ్చు, ఈ విధంగా Omi వారి ప్రసంగాన్ని కూడా గుర్తించగలుగుతుంది!';
+  String get howPeopleWorks => 'ఒక వ్యక్తి సృష్టించిన తర్వాత, మీరు సంభాషణ ట్రాన్‌స్క్రిప్ట్‌కు వెళ్లవచ్చు మరియు వారిని తమ సంబంధిత సెగ్మెంట్‌లకు కేటాయించవచ్చు, ఈ విధంగా Omi వారి ప్రసంగాన్ని కూడా గుర్తించగలుగుతుంది!';
 
   @override
   String get tapToDelete => 'తొలగించడానికి ట్యాప్ చేయండి';
@@ -4878,8 +4768,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get privacyNotice => 'గోప్యతా నోటిసు';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'రికార్డింగ్‌లు ఇతరుల గొంతులను సంగ్రహించవచ్చు. ఎనబుల్ చేయడానికి ముందు అన్ని భాగస్వాములకు సమ్మతి ఉందని నిర్ధారించుకోండి.';
+  String get recordingsMayCaptureOthers => 'రికార్డింగ్‌లు ఇతరుల గొంతులను సంగ్రహించవచ్చు. ఎనబుల్ చేయడానికి ముందు అన్ని భాగస్వాములకు సమ్మతి ఉందని నిర్ధారించుకోండి.';
 
   @override
   String get enable => 'సక్షమం చేయండి';
@@ -4891,8 +4780,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get on => 'ఆన్';
 
   @override
-  String get storeAudioDescription =>
-      'అన్ని ఆడియో రికార్డింగ్‌లను మీ ఫోన్‌లో స్థానికంగా నిల్వ చేయండి. నిలిపివేయబడినప్పుడు, నిల్వ స్థలాన్ని సేవ చేయడానికి విఫల అప్‌లోడ్‌లు మాత్రమే ఉంటాయి.';
+  String get storeAudioDescription => 'అన్ని ఆడియో రికార్డింగ్‌లను మీ ఫోన్‌లో స్థానికంగా నిల్వ చేయండి. నిలిపివేయబడినప్పుడు, నిల్వ స్థలాన్ని సేవ చేయడానికి విఫల అప్‌లోడ్‌లు మాత్రమే ఉంటాయి.';
 
   @override
   String get enableLocalStorage => 'స్థానిక నిల్వను సక్షమం చేయండి';
@@ -4910,12 +4798,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get storeAudioOnCloud => 'ఆడియోను క్లౌడ్‌లో నిల్వ చేయండి';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'మీ రియల్-టైమ్ రికార్డింగ్‌లు మీరు మాట్లాడేటప్పుడు ఖాతగత క్లౌడ్ నిల్వలో నిల్వ చేయబడుతాయి.';
+  String get cloudStorageDialogMessage => 'మీ రియల్-టైమ్ రికార్డింగ్‌లు మీరు మాట్లాడేటప్పుడు ఖాతగత క్లౌడ్ నిల్వలో నిల్వ చేయబడుతాయి.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'మీ రియల్-టైమ్ రికార్డింగ్‌లను ఖాతగత క్లౌడ్ నిల్వలో నిల్వ చేయండి మీరు మాట్లాడేటప్పుడు. ఆడియో రియల్-టైమ్‌లో సురక్షితంగా సంగ్రహించబడి సేవ చేయబడుతుంది.';
+  String get storeAudioCloudDescription => 'మీ రియల్-టైమ్ రికార్డింగ్‌లను ఖాతగత క్లౌడ్ నిల్వలో నిల్వ చేయండి మీరు మాట్లాడేటప్పుడు. ఆడియో రియల్-టైమ్‌లో సురక్షితంగా సంగ్రహించబడి సేవ చేయబడుతుంది.';
 
   @override
   String get downloadingFirmware => 'ఫర్మ్‌వేర్‌ను డౌన్‌లోడ్ చేస్తోంది';
@@ -4924,8 +4810,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get installingFirmware => 'ఫర్మ్‌వేర్‌ను ఇన్‌స్టాల్ చేస్తోంది';
 
   @override
-  String get firmwareUpdateWarning =>
-      'అనువర్తనాన్ని మూసివేయవద్దు లేదా పరికరాన్ని ఆపివేయవద్దు. ఇది మీ పరికరాన్ని నష్టపరిచేవచ్చు.';
+  String get firmwareUpdateWarning => 'అనువర్తనాన్ని మూసివేయవద్దు లేదా పరికరాన్ని ఆపివేయవద్దు. ఇది మీ పరికరాన్ని నష్టపరిచేవచ్చు.';
 
   @override
   String get firmwareUpdated => 'ఫర్మ్‌వేర్ అప్‌డేట్ చేయబడింది';
@@ -4969,8 +4854,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get payments => 'చెల్లింపులు';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'మీ అనువర్తనాల కోసం చెల్లింపులను స్వీకరించడం ప్రారంభించడానికి దిగువ చెల్లింపు పద్ధతిని కనెక్ట్ చేయండి.';
+  String get connectPaymentMethodInfo => 'మీ అనువర్తనాల కోసం చెల్లింపులను స్వీకరించడం ప్రారంభించడానికి దిగువ చెల్లింపు పద్ధతిని కనెక్ట్ చేయండి.';
 
   @override
   String get selectedPaymentMethod => 'ఎంచుకున్న చెల్లింపు పద్ధతి';
@@ -4997,15 +4881,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get monthlyPayouts => 'నెలవారీ చెల్లింపులు';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'మీ ఖాతాకు నేరుగా నెలవారీ చెల్లింపులను స్వీకరించండి మీరు \$ 10 లో సంపాదన చేసినప్పుడు';
+  String get monthlyPayoutsDescription => 'మీ ఖాతాకు నేరుగా నెలవారీ చెల్లింపులను స్వీకరించండి మీరు \$ 10 లో సంపాదన చేసినప్పుడు';
 
   @override
   String get secureAndReliable => 'సురక్షితమైన మరియు నమ్మకమైన';
 
   @override
-  String get stripeSecureDescription =>
-      'Stripe మీ అనువర్తన రాజస్వ యొక్క సురక్షితమైన మరియు సమయోచిత బదిలీలను నిర్ధారిస్తుంది';
+  String get stripeSecureDescription => 'Stripe మీ అనువర్తన రాజస్వ యొక్క సురక్షితమైన మరియు సమయోచిత బదిలీలను నిర్ధారిస్తుంది';
 
   @override
   String get selectYourCountry => 'మీ దేశాన్ని ఎంచుకోండి';
@@ -5026,8 +4908,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get connectingYourStripeAccount => 'మీ Stripe ఖాతాను కనెక్ట్ చేస్తోంది';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'దయచేసి మీ బ్రౌజర్‌లో Stripe ఆన్‌బోర్డింగ్ ప్రక్రియను పూర్తి చేయండి. ఈ పేజీ పూర్తయిన తర్వాత స్వయంచాలకంగా అప్‌డేట్ చేయబడుతుంది.';
+  String get stripeOnboardingInstructions => 'దయచేసి మీ బ్రౌజర్‌లో Stripe ఆన్‌బోర్డింగ్ ప్రక్రియను పూర్తి చేయండి. ఈ పేజీ పూర్తయిన తర్వాత స్వయంచాలకంగా అప్‌డేట్ చేయబడుతుంది.';
 
   @override
   String get failedTryAgain => 'విఫలమైనా? మళ్లీ ప్రయత్నించండి';
@@ -5039,15 +4920,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get successfullyConnected => 'విజయవంతంగా కనెక్ట్ చేయబడింది!';
 
   @override
-  String get stripeReadyForPayments =>
-      'మీ Stripe ఖాతా ఇప్పుడు చెల్లింపులను స్వీకరించడానికి సిద్ధంగా ఉంది. మీరు వెంటనే మీ అనువర్తన విక్రయాల నుండి సంపాదించడం ప్రారంభించవచ్చు.';
+  String get stripeReadyForPayments => 'మీ Stripe ఖాతా ఇప్పుడు చెల్లింపులను స్వీకరించడానికి సిద్ధంగా ఉంది. మీరు వెంటనే మీ అనువర్తన విక్రయాల నుండి సంపాదించడం ప్రారంభించవచ్చు.';
 
   @override
   String get updateStripeDetails => 'Stripe విశ్లేషణలను అప్‌డేట్ చేయండి';
 
   @override
-  String get errorUpdatingStripeDetails =>
-      'Stripe విశ్లేషణలను అప్‌డేట్ చేయడంలో ఎర్రర్! దయచేసి తరువాత మళ్లీ ప్రయత్నించండి.';
+  String get errorUpdatingStripeDetails => 'Stripe విశ్లేషణలను అప్‌డేట్ చేయడంలో ఎర్రర్! దయచేసి తరువాత మళ్లీ ప్రయత్నించండి.';
 
   @override
   String get updatePayPal => 'PayPal ను అప్‌డేట్ చేయండి';
@@ -5059,8 +4938,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get updatePayPalAccountDetails => 'మీ PayPal ఖాతా విశ్లేషణలను అప్‌డేట్ చేయండి';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'మీ అనువర్తనాల కోసం చెల్లింపులను స్వీకరించడం ప్రారంభించడానికి మీ PayPal ఖాతాను కనెక్ట్ చేయండి';
+  String get connectPayPalToReceivePayments => 'మీ అనువర్తనాల కోసం చెల్లింపులను స్వీకరించడం ప్రారంభించడానికి మీ PayPal ఖాతాను కనెక్ట్ చేయండి';
 
   @override
   String get paypalEmail => 'PayPal ఇమెయిల్';
@@ -5069,8 +4947,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me లింక్';
 
   @override
-  String get stripeRecommendation =>
-      'Stripe మీ దేశంలో అందుబాటులో ఉంటే, వేగవంతమైన మరియు సులభమైన చెల్లింపుల కోసం దానిని ఉపయోగించమని మేము ఆsusan్నిగా సిఫారసు చేస్తాము.';
+  String get stripeRecommendation => 'Stripe మీ దేశంలో అందుబాటులో ఉంటే, వేగవంతమైన మరియు సులభమైన చెల్లింపుల కోసం దానిని ఉపయోగించమని మేము ఆsusan్నిగా సిఫారసు చేస్తాము.';
 
   @override
   String get updatePayPalDetails => 'PayPal విశ్లేషణలను అప్‌డేట్ చేయండి';
@@ -5122,12 +4999,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'అదనపు ప్రసంగ నమూనా తీసివేయబడింది';
 
   @override
-  String get consentDataMessage =>
-      'కొనసాగించడం ద్వారా, మీ సంభాషణలు, రికార్డింగ్‌లు మరియు వ్యక్తిగత సమాచారం మా సర్వర్‌లలో సురక్షితంగా నిల్వ చేయబడతాయి. మీ ఆడియో రికార్డింగ్‌లు మరియు ట్రాన్‌స్క్రిప్ట్‌లు థర్డ్-పార్టీ AI సేవల ద్వారా ప్రాసెస్ చేయబడతాయి (ట్రాన్‌స్క్రిప్షన్ కోసం Deepgram మరియు విశ్లేషణ కోసం OpenAI సహా) AI-ఆధారిత అంతర్దృష్టులను అందించడానికి మరియు అన్ని యాప్ ఫీచర్‌లను ప్రారంభించడానికి.';
+  String get consentDataMessage => 'కొనసాగించడం ద్వారా, మీ సంభాషణలు, రికార్డింగ్‌లు మరియు వ్యక్తిగత సమాచారం మా సర్వర్‌లలో సురక్షితంగా నిల్వ చేయబడతాయి. మీ ఆడియో రికార్డింగ్‌లు మరియు ట్రాన్‌స్క్రిప్ట్‌లు థర్డ్-పార్టీ AI సేవల ద్వారా ప్రాసెస్ చేయబడతాయి (ట్రాన్‌స్క్రిప్షన్ కోసం Deepgram మరియు విశ్లేషణ కోసం OpenAI సహా) AI-ఆధారిత అంతర్దృష్టులను అందించడానికి మరియు అన్ని యాప్ ఫీచర్‌లను ప్రారంభించడానికి.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'మీ సంభాషణల నుండి చర్యలు ఇక్కడ కనిపిస్తాయి.\\n+ నిర్ణయం చేయడానికి ట్యాప్ చేయండి.';
+  String get tasksEmptyStateMessage => 'మీ సంభాషణల నుండి చర్యలు ఇక్కడ కనిపిస్తాయి.\\n+ నిర్ణయం చేయడానికి ట్యాప్ చేయండి.';
 
   @override
   String get clearChatAction => 'చాట్‌ను క్లియర్ చేయండి';
@@ -5163,15 +5038,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Omi ని మీ\\nApple Watch లో ఇన్‌స్టాల్ చేయండి';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'మీ Apple Watch ని Omi ఉపయోగించడానికి, మీరు ముందుగా మీ గడియారం మీద Omi అనువర్తనాన్ని ఇన్‌స్టాల్ చేయాలి.';
+  String get installOmiOnAppleWatchDescription => 'మీ Apple Watch ని Omi ఉపయోగించడానికి, మీరు ముందుగా మీ గడియారం మీద Omi అనువర్తనాన్ని ఇన్‌స్టాల్ చేయాలి.';
 
   @override
   String get openOmiOnAppleWatch => 'Omi ని మీ\\nApple Watch లో తెరవండి';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi అనువర్తనం మీ Apple Watch న ఇన్‌స్టాల్ చేయబడింది. దానిని తెరవండి మరియు ప్రారంభించడానికి ట్యాప్ చేయండి.';
+  String get openOmiOnAppleWatchDescription => 'Omi అనువర్తనం మీ Apple Watch న ఇన్‌స్టాల్ చేయబడింది. దానిని తెరవండి మరియు ప్రారంభించడానికి ట్యాప్ చేయండి.';
 
   @override
   String get openWatchApp => 'గడియార అనువర్తనాన్ని తెరవండి';
@@ -5180,15 +5053,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'నేను దానిని ఇన్‌స్టాల్ చేసాను మరియు అనువర్తనాన్ని తెరిచాను';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch అనువర్తనాన్ని తెరవలేకపోయాను. దయచేసి మీ Apple Watch పై గడియార అనువర్తనాన్ని నిర్ణయం చేసి \"అందుబాటులో ఉన్న అనువర్తనాలు\" విభాగం నుండి Omi ని ఇన్‌స్టాల్ చేయండి.';
+  String get unableToOpenWatchApp => 'Apple Watch అనువర్తనాన్ని తెరవలేకపోయాను. దయచేసి మీ Apple Watch పై గడియార అనువర్తనాన్ని నిర్ణయం చేసి \"అందుబాటులో ఉన్న అనువర్తనాలు\" విభాగం నుండి Omi ని ఇన్‌స్టాల్ చేయండి.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch విజయవంతంగా కనెక్ట్ చేయబడింది!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch ఇప్పటికీ నిరన్తరం కనబడటం లేదు. దయచేసి Omi అనువర్తనం మీ గడియారం మీద తెరిచి ఉందని నిర్ధారించుకోండి.';
+  String get appleWatchNotReachable => 'Apple Watch ఇప్పటికీ నిరన్తరం కనబడటం లేదు. దయచేసి Omi అనువర్తనం మీ గడియారం మీద తెరిచి ఉందని నిర్ధారించుకోండి.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5205,8 +5076,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get finishedConversation => 'సంభాషణ పూర్తయిందా?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'రికార్డింగ్‌ను ఆపివేసి సంభాషణను ఇప్పుడే సారాంశం చేయాలని మీరు చెప్పుకుంటున్నారా?';
+  String get stopRecordingConfirmation => 'రికార్డింగ్‌ను ఆపివేసి సంభాషణను ఇప్పుడే సారాంశం చేయాలని మీరు చెప్పుకుంటున్నారా?';
 
   @override
   String get conversationEndsManually => 'సంభాషణ కేవలం నిర్ణయం చేయడం ద్వారా ముగుస్తుంది.';
@@ -5617,30 +5487,25 @@ class AppLocalizationsTe extends AppLocalizations {
   String get multipleSpeakersDetected => 'బహుళ సంభాషణదారులు గుర్తించబడ్డారు';
 
   @override
-  String get multipleSpeakersDescription =>
-      'రికార్డింగ్‌లో బహుళ సంభాషణదారులు ఉన్నట్లు కనిపిస్తుంది. దయచేసి మీరు నిశ్శబ్దమైన ప్రదేశంలో ఉన్నారని నిర్ధారించుకోండి మరియు మళ్లీ ప్రయత్నించండి.';
+  String get multipleSpeakersDescription => 'రికార్డింగ్‌లో బహుళ సంభాషణదారులు ఉన్నట్లు కనిపిస్తుంది. దయచేసి మీరు నిశ్శబ్దమైన ప్రదేశంలో ఉన్నారని నిర్ధారించుకోండి మరియు మళ్లీ ప్రయత్నించండి.';
 
   @override
   String get invalidRecordingDetected => 'చెల్లని రికార్డింగ్ గుర్తించబడింది';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'తగినంత ప్రసంగం గుర్తించబడలేదు. దయచేసి మరిన్ని మాట్లాడండి మరియు మళ్లీ ప్రయత్నించండి.';
+  String get notEnoughSpeechDescription => 'తగినంత ప్రసంగం గుర్తించబడలేదు. దయచేసి మరిన్ని మాట్లాడండి మరియు మళ్లీ ప్రయత్నించండి.';
 
   @override
-  String get speechDurationDescription =>
-      'దయచేసి కనీసం 5 సెకన్లు మరియు 90 కంటే ఎక్కువ లేకుండా మీరు నిశ్చయంగా మాట్లాడండి.';
+  String get speechDurationDescription => 'దయచేసి కనీసం 5 సెకన్లు మరియు 90 కంటే ఎక్కువ లేకుండా మీరు నిశ్చయంగా మాట్లాడండి.';
 
   @override
-  String get connectionLostDescription =>
-      'సংযోగం విచ్ఛిన్నమైంది. దయచేసి మీ ఇంటర్నెట్ సংయోగాన్ని తనిఖీ చేసి మరలా ప్రయత్నించండి.';
+  String get connectionLostDescription => 'సংযోగం విచ్ఛిన్నమైంది. దయచేసి మీ ఇంటర్నెట్ సংయోగాన్ని తనిఖీ చేసి మరలా ప్రయత్నించండి.';
 
   @override
   String get howToTakeGoodSample => 'మంచి నమూనాను ఎలా తీసుకోవాలి?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. మీరు నిశ్చితంగా నిశ్చుప్త స్థలంలో ఉన్నారని నిర్ధారించుకోండి.\n2. స్పష్టంగా మరియు సహజంగా మాట్లాడండి.\n3. మీ పరికరం దాని సహజ స్థితిలో, మీ మెడపై ఉందని నిర్ధారించుకోండి.\n\nఇది సృష్టించబడిన తర్వాత, మీరు ఎల్లప్పుడు దానిని మెరుగుపర్చవచ్చు లేదా మరలా చేయవచ్చు.';
+  String get goodSampleInstructions => '1. మీరు నిశ్చితంగా నిశ్చుప్త స్థలంలో ఉన్నారని నిర్ధారించుకోండి.\n2. స్పష్టంగా మరియు సహజంగా మాట్లాడండి.\n3. మీ పరికరం దాని సహజ స్థితిలో, మీ మెడపై ఉందని నిర్ధారించుకోండి.\n\nఇది సృష్టించబడిన తర్వాత, మీరు ఎల్లప్పుడు దానిని మెరుగుపర్చవచ్చు లేదా మరలా చేయవచ్చు.';
 
   @override
   String get noDeviceConnectedUseMic => 'ఏ పరికరం కనెక్ట్ చేయబడలేదు. ఫోన్ మైక్రోఫోన్ను ఉపయోగిస్తుంది.';
@@ -5703,12 +5568,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get howItWorks => 'ఇది ఎలా పనిచేస్తుంది';
 
   @override
-  String get dailyScoreExplanation =>
-      'మీ రోజువారీ స్కోర్ టాస్క్ పూర్తికి ఆధారపడి ఉంటుంది. మీ స్కోర్ మెరుగుపర్చడానికి మీ పనులను పూర్తిచేయండి!';
+  String get dailyScoreExplanation => 'మీ రోజువారీ స్కోర్ టాస్క్ పూర్తికి ఆధారపడి ఉంటుంది. మీ స్కోర్ మెరుగుపర్చడానికి మీ పనులను పూర్తిచేయండి!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Omi మీకు సక్రియ నోటిఫికేషన్‌లు మరియు రిమైండర్‌లను ఎంత తరచుగా పంపుతుందో నియంత్రించండి.';
+  String get notificationFrequencyDescription => 'Omi మీకు సక్రియ నోటిఫికేషన్‌లు మరియు రిమైండర్‌లను ఎంత తరచుగా పంపుతుందో నియంత్రించండి.';
 
   @override
   String get sliderOff => 'ఆఫ్';
@@ -5722,8 +5585,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'సారాంశం రూపొందించడంలో విఫలమైంది. ఆ రోజుకు మీకు సంభాషణలు ఉన్నాయని నిర్ధారించుకోండి.';
+  String get failedToGenerateSummary => 'సారాంశం రూపొందించడంలో విఫలమైంది. ఆ రోజుకు మీకు సంభాషణలు ఉన్నాయని నిర్ధారించుకోండి.';
 
   @override
   String get recap => 'పరిశీలన';
@@ -5802,8 +5664,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get selectApp => 'ఆ్యాప్ ఎంచుకోండి';
 
   @override
-  String get noChatAppsEnabled =>
-      'ఏ చాట్ ఆప్‌లు ప్రారంభం కాలేదు.\n\"ఆప్‌లను ప్రారంభించండి\" నొక్కండి కొన్నింటిని జోడించటానికి.';
+  String get noChatAppsEnabled => 'ఏ చాట్ ఆప్‌లు ప్రారంభం కాలేదు.\n\"ఆప్‌లను ప్రారంభించండి\" నొక్కండి కొన్నింటిని జోడించటానికి.';
 
   @override
   String get disable => 'నిలిపివేయండి';
@@ -5955,8 +5816,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get recordings => 'రికార్డింగ్‌లు';
 
   @override
-  String get enableRemindersAccess =>
-      'Apple రిమైండర్‌లను ఉపయోగించటానికి సెట్టింగ్‌లలో రిమైండర్‌ల యాక్సెస్‌ను ప్రారంభించండి';
+  String get enableRemindersAccess => 'Apple రిమైండర్‌లను ఉపయోగించటానికి సెట్టింగ్‌లలో రిమైండర్‌ల యాక్సెస్‌ను ప్రారంభించండి';
 
   @override
   String todayAtTime(String time) {
@@ -6011,8 +5871,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get webhookUrlNotSet => 'వెబ్‌హుక్ URL సెట్ చేయబడలేదు';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'ఈ ఫీచర్‌ను ఉపయోగించటానికి దయచేసి డెవలపర్ సెట్టింగ్‌లలో వెబ్‌హుక్ URL సెట్ చేయండి.';
+  String get setWebhookUrlInSettings => 'ఈ ఫీచర్‌ను ఉపయోగించటానికి దయచేసి డెవలపర్ సెట్టింగ్‌లలో వెబ్‌హుక్ URL సెట్ చేయండి.';
 
   @override
   String get sendWebUrl => 'వెబ్ url పంపండి';
@@ -6050,8 +5909,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get willLikelyCrash => 'ఇది ప్రారంభం చేస్తే, ఆ్యాప్ క్రాష్ లేదా ఫ్రీజ్ కావచ్చు.';
 
   @override
-  String get transcriptionSlowerLessAccurate =>
-      'ట్రాన్‌స్క్రిప్షన్ గణనీయంగా నెమ్మదిగా మరియు తక్కువ ఖచ్చితమైనది ఉంటుంది.';
+  String get transcriptionSlowerLessAccurate => 'ట్రాన్‌స్క్రిప్షన్ గణనీయంగా నెమ్మదిగా మరియు తక్కువ ఖచ్చితమైనది ఉంటుంది.';
 
   @override
   String get proceedAnyway => 'ఏదేమైనా కొనసాగండి';
@@ -6087,15 +5945,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get cloudProvider => 'క్లౌడ్ ప్రదాత';
 
   @override
-  String get premiumMinutesInfo =>
-      'నెలకు 1,200 ప్రిమియం నిమిషాలు. ఆన్-డివైస్ ట్యాబ్ అపరిమిత ఉచిత ట్రాన్‌స్క్రిప్షన్ అందిస్తుంది.';
+  String get premiumMinutesInfo => 'నెలకు 1,200 ప్రిమియం నిమిషాలు. ఆన్-డివైస్ ట్యాబ్ అపరిమిత ఉచిత ట్రాన్‌స్క్రిప్షన్ అందిస్తుంది.';
 
   @override
   String get viewUsage => 'వినియోగాన్ని చూడండి';
 
   @override
-  String get localProcessingInfo =>
-      'ఆడియో స్థానికంగా ప్రక్రియ చేయబడుతుంది. ఆఫ్‌లైన్‌లో పనిచేస్తుంది, మరింత ప్రైవేట్, కానీ ఎక్కువ బ్యాటరీని ఉపయోగిస్తుంది.';
+  String get localProcessingInfo => 'ఆడియో స్థానికంగా ప్రక్రియ చేయబడుతుంది. ఆఫ్‌లైన్‌లో పనిచేస్తుంది, మరింత ప్రైవేట్, కానీ ఎక్కువ బ్యాటరీని ఉపయోగిస్తుంది.';
 
   @override
   String get model => 'మోడల్';
@@ -6104,15 +5960,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get performanceWarning => 'పనితీరు హెచ్చరిక';
 
   @override
-  String get largeModelWarning =>
-      'ఈ మోడల్ పెద్దదిగా ఉంది మరియు మొబైల్ పరికరాలపై ఆ్యాప్ క్రాష్ లేదా చాలా నెమ్మదిగా అమలు చేయవచ్చు.\n\n\"small\" లేదా \"base\" సిఫారసు చేయబడుతుంది.';
+  String get largeModelWarning => 'ఈ మోడల్ పెద్దదిగా ఉంది మరియు మొబైల్ పరికరాలపై ఆ్యాప్ క్రాష్ లేదా చాలా నెమ్మదిగా అమలు చేయవచ్చు.\n\n\"small\" లేదా \"base\" సిఫారసు చేయబడుతుంది.';
 
   @override
   String get usingNativeIosSpeech => 'నేటివ్ iOS స్పీచ్ రికగ్నిషన్ ఉపయోగిస్తున్నాను';
 
   @override
-  String get noModelDownloadRequired =>
-      'మీ పరికరం యొక్క నేటివ్ స్పీచ్ ఇంజిన్ ఉపయోగించబడుతుంది. మోడల్ డౌన్‌లోడ్ అవసరం లేదు.';
+  String get noModelDownloadRequired => 'మీ పరికరం యొక్క నేటివ్ స్పీచ్ ఇంజిన్ ఉపయోగించబడుతుంది. మోడల్ డౌన్‌లోడ్ అవసరం లేదు.';
 
   @override
   String get modelReady => 'మోడల్ సిద్ధం';
@@ -6169,12 +6023,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get batteryDrainSignificantly => 'బ్యాటరీ డ్రెయిన్ గణనీయంగా పెరుగుతుంది.';
 
   @override
-  String get premiumMinutesMonth =>
-      'నెలకు 1,200 ప్రిమియం నిమిషాలు. ఆన్-డివైస్ ట్యాబ్ అపరిమిత ఉచిత ట్రాన్‌స్క్రిప్షన్ అందిస్తుంది. ';
+  String get premiumMinutesMonth => 'నెలకు 1,200 ప్రిమియం నిమిషాలు. ఆన్-డివైస్ ట్యాబ్ అపరిమిత ఉచిత ట్రాన్‌స్క్రిప్షన్ అందిస్తుంది. ';
 
   @override
-  String get audioProcessedLocally =>
-      'ఆడియో స్థానికంగా ప్రక్రియ చేయబడుతుంది. ఆఫ్‌లైన్‌లో పనిచేస్తుంది, మరింత ప్రైవేట్, కానీ ఎక్కువ బ్యాటరీని ఉపయోగిస్తుంది.';
+  String get audioProcessedLocally => 'ఆడియో స్థానికంగా ప్రక్రియ చేయబడుతుంది. ఆఫ్‌లైన్‌లో పనిచేస్తుంది, మరింత ప్రైవేట్, కానీ ఎక్కువ బ్యాటరీని ఉపయోగిస్తుంది.';
 
   @override
   String get languageLabel => 'భాష';
@@ -6183,12 +6035,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get modelLabel => 'మోడల్';
 
   @override
-  String get modelTooLargeWarning =>
-      'ఈ మోడల్ పెద్దదిగా ఉంది మరియు మొబైల్ పరికరాలపై ఆ్యాప్ క్రాష్ లేదా చాలా నెమ్మదిగా అమలు చేయవచ్చు.\n\n\"small\" లేదా \"base\" సిఫారసు చేయబడుతుంది.';
+  String get modelTooLargeWarning => 'ఈ మోడల్ పెద్దదిగా ఉంది మరియు మొబైల్ పరికరాలపై ఆ్యాప్ క్రాష్ లేదా చాలా నెమ్మదిగా అమలు చేయవచ్చు.\n\n\"small\" లేదా \"base\" సిఫారసు చేయబడుతుంది.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'మీ పరికరం యొక్క నేటివ్ స్పీచ్ ఇంజిన్ ఉపయోగించబడుతుంది. మోడల్ డౌన్‌లోడ్ అవసరం లేదు.';
+  String get nativeEngineNoDownload => 'మీ పరికరం యొక్క నేటివ్ స్పీచ్ ఇంజిన్ ఉపయోగించబడుతుంది. మోడల్ డౌన్‌లోడ్ అవసరం లేదు.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6224,8 +6074,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi యొక్క అంతర్నిర్మిత లైవ్ ట్రాన్‌స్క్రిప్షన్ స్వయంచాలక స్పీకర్ గుర్తింపు మరియు డయారిజేషన్‌తో రియల్-టైమ్ సంభాషణల కోసం ఆప్టిమైజ్ చేయబడింది.';
+  String get omiTranscriptionOptimized => 'Omi యొక్క అంతర్నిర్మిత లైవ్ ట్రాన్‌స్క్రిప్షన్ స్వయంచాలక స్పీకర్ గుర్తింపు మరియు డయారిజేషన్‌తో రియల్-టైమ్ సంభాషణల కోసం ఆప్టిమైజ్ చేయబడింది.';
 
   @override
   String get reset => 'రీసెట్';
@@ -6313,8 +6162,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get writeReviewOptional => 'రివ్యూ రాయండి (ఐచ్ఛికం)';
 
   @override
-  String get setupQuestionsIntro =>
-      'కొన్ని ప్రశ్నలకు సమాధానం ఇవ్వడం ద్వారా Omi మెరుగుపరచటానికి మాకు సహాయం చేయండి.  🫶 💜';
+  String get setupQuestionsIntro => 'కొన్ని ప్రశ్నలకు సమాధానం ఇవ్వడం ద్వారా Omi మెరుగుపరచటానికి మాకు సహాయం చేయండి.  🫶 💜';
 
   @override
   String get setupQuestionProfession => '1. మీరు ఏ పనిలో ఉన్నారు?';
@@ -6446,8 +6294,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'జ్ఞాపకాల నుండి మీ జ్ఞాన గ్రాఫ్ నిర్మిస్తున్నాను...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'మీరు కొత్త జ్ఞాపకాలను సృష్టించినప్పుడు మీ జ్ఞాన గ్రాఫ్ స్వయంచాలకంగా నిర్మిస్తారు.';
+  String get knowledgeGraphWillBuildAutomatically => 'మీరు కొత్త జ్ఞాపకాలను సృష్టించినప్పుడు మీ జ్ఞాన గ్రాఫ్ స్వయంచాలకంగా నిర్మిస్తారు.';
 
   @override
   String get buildGraphButton => 'గ్రాఫ్ నిర్మించండి';
@@ -6683,8 +6530,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get failedToLoadContacts => 'సంప్రదాయాలను లోడ్ చేయడంలో విఫలమైంది';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'షేరింగ్ కోసం సంభాషణను సిద్ధం చేయడంలో విఫలమైంది. దయచేసి మరలా ప్రయత్నించండి.';
+  String get failedToPrepareConversationForSharing => 'షేరింగ్ కోసం సంభాషణను సిద్ధం చేయడంలో విఫలమైంది. దయచేసి మరలా ప్రయత్నించండి.';
 
   @override
   String get couldNotOpenSmsApp => 'SMS అ్యాప్ ఆపరు చేయలేకపోయాను. దయచేసి మరలా ప్రయత్నించండి.';
@@ -6750,8 +6596,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'మీ పరికరం యొక్క SD కార్డ్ నుండి ఆడియో డౌన్‌లోడ్ చేస్తున్నాను';
 
   @override
-  String get transferRequiredDescription =>
-      'ఈ రికార్డింగ్ మీ పరికరం యొక్క SD కార్డ్‌లో నిల్వ చేయబడింది. ఆటోపై చేయటానికి లేదా షేర్ చేయటానికి దీన్ని మీ ఫోన్‌కు బదిలీ చేయండి.';
+  String get transferRequiredDescription => 'ఈ రికార్డింగ్ మీ పరికరం యొక్క SD కార్డ్‌లో నిల్వ చేయబడింది. ఆటోపై చేయటానికి లేదా షేర్ చేయటానికి దీన్ని మీ ఫోన్‌కు బదిలీ చేయండి.';
 
   @override
   String get cancelTransfer => 'బదిలీ రద్దు చేయండి';
@@ -6831,15 +6676,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get enableFastTransfer => 'ఫాస్ట్ ట్రాన్‌సర్‌ను సక్రియం చేయండి';
 
   @override
-  String get fastTransferDescription =>
-      'ఫాస్ట్ ట్రాన్‌సర్ WiFi ను ఉపయోగించి ~5x వేగవంతమైన వేగం. బదిలీ సమయంలో మీ ఫోన్잠시Omi పరికరం యొక్క WiFi నెట్‌వర్క్‌కు అనుసంధానం అవుతుంది.';
+  String get fastTransferDescription => 'ఫాస్ట్ ట్రాన్‌సర్ WiFi ను ఉపయోగించి ~5x వేగవంతమైన వేగం. బదిలీ సమయంలో మీ ఫోన్잠시Omi పరికరం యొక్క WiFi నెట్‌వర్క్‌కు అనుసంధానం అవుతుంది.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'బదిలీ సమయంలో ఇంటర్నెట్ యాక్సెస్ పాజ్ చేయబడింది';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'మీ Omi పరికరం నుండి మీ ఫోన్‌కు రికార్డింగ్‌లు ఎలా బదిలీ చేయాలో ఎంచుకోండి.';
+  String get chooseTransferMethodDescription => 'మీ Omi పరికరం నుండి మీ ఫోన్‌కు రికార్డింగ్‌లు ఎలా బదిలీ చేయాలో ఎంచుకోండి.';
 
   @override
   String get wifiSpeed => 'WiFi ద్వారా ~150 KB/s';
@@ -6848,8 +6691,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get fiveTimesFaster => '5X వేగవంతమైనది';
 
   @override
-  String get fastTransferMethodDescription =>
-      'మీ Omi పరికరానికి నేరుగా WiFi కనెక్షన్ సృష్టిస్తుంది. బదిలీ సమయంలో మీ ఫోన్잠ిக్కా మీ సాధారణ WiFi నుండి డిస్‌కనెక్ట్ చేయబడుతుంది.';
+  String get fastTransferMethodDescription => 'మీ Omi పరికరానికి నేరుగా WiFi కనెక్షన్ సృష్టిస్తుంది. బదిలీ సమయంలో మీ ఫోన్잠ిக్కా మీ సాధారణ WiFi నుండి డిస్‌కనెక్ట్ చేయబడుతుంది.';
 
   @override
   String get bluetooth => 'బ్లూటూత్';
@@ -6858,8 +6700,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get bleSpeed => 'BLE ద్వారా ~30 KB/s';
 
   @override
-  String get bluetoothMethodDescription =>
-      'ప్రామాణిక బ్లూటూత్ లో ఎనర్జీ సంযోగం ఉపయోగిస్తుంది. నెమ్మదిగా ఉంటుందిగా ఉంది కానీ మీ WiFi కనెక్షన్‌ను ప్రభావితం చేయదు.';
+  String get bluetoothMethodDescription => 'ప్రామాణిక బ్లూటూత్ లో ఎనర్జీ సంযోగం ఉపయోగిస్తుంది. నెమ్మదిగా ఉంటుందిగా ఉంది కానీ మీ WiFi కనెక్షన్‌ను ప్రభావితం చేయదు.';
 
   @override
   String get selected => 'ఎంచుకోబడింది';
@@ -6877,8 +6718,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'మీ Omi పరికరం డిస్‌కనెక్ట్ చేయబడింది';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'మీ Omi ను ఉపయోగించిన్న కొనసాగించడానికి దయచేసి తిరిగి కనెక్ట్ చేయండి.';
+  String get deviceDisconnectedNotificationBody => 'మీ Omi ను ఉపయోగించిన్న కొనసాగించడానికి దయచేసి తిరిగి కనెక్ట్ చేయండి.';
 
   @override
   String get firmwareUpdateAvailable => 'ఫర్మ్‌వేర్ అపడేట్ అందుబాటులో ఉంది';
@@ -6898,12 +6738,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get appDeleteFailed => 'యాప్‌ను తొలగించడానికి విఫలమైంది. దయచేసి తరువాత ప్రయత్నించండి.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'యాప్ దృశ్యమానత విజయవంతంగా మార్చబడింది. ప్రతిబింబిత చేయడానికి కొన్ని నిమిషాలు పట్టవచ్చు.';
+  String get appVisibilityChangedSuccessfully => 'యాప్ దృశ్యమానత విజయవంతంగా మార్చబడింది. ప్రతిబింబిత చేయడానికి కొన్ని నిమిషాలు పట్టవచ్చు.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'యాప్‌ను సక్రియం చేసేటప్పుడు లోపం. ఇది ఇంటిగ్రేషన్ యాప్ అయితే, సెటప్ పూర్తి చేయబడిందని నిర్ధారించుకోండి.';
+  String get errorActivatingAppIntegration => 'యాప్‌ను సక్రియం చేసేటప్పుడు లోపం. ఇది ఇంటిగ్రేషన్ యాప్ అయితే, సెటప్ పూర్తి చేయబడిందని నిర్ధారించుకోండి.';
 
   @override
   String get errorUpdatingAppStatus => 'యాప్ స్థితి నవీకరించేటప్పుడు ఒక లోపం సంభవించింది.';
@@ -6971,8 +6809,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get importantConversationTitle => 'ముఖ్యమైన సంభాషణ';
 
   @override
-  String get importantConversationBody =>
-      'మీరు ఒక ముఖ్యమైన సంభాషణ ఉన్నారు. ఇతరులకు సారాంశం భాగస్వామ్యం చేయడానికి నొక్కండి.';
+  String get importantConversationBody => 'మీరు ఒక ముఖ్యమైన సంభాషణ ఉన్నారు. ఇతరులకు సారాంశం భాగస్వామ్యం చేయడానికి నొక్కండి.';
 
   @override
   String get templateName => 'టెంప్లేట్ పేరు';
@@ -6984,8 +6821,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'పేరు కనీసం 3 అక్షరాలు ఉండాలి';
 
   @override
-  String get conversationPromptHint =>
-      'ఉదా., సంభాషణ నుండి చర్య చేసిన ఐటమ్‌లు, నిర్ణయాలు మరియు కీ టేక్‌అవేలను సంగ్రహించండి.';
+  String get conversationPromptHint => 'ఉదా., సంభాషణ నుండి చర్య చేసిన ఐటమ్‌లు, నిర్ణయాలు మరియు కీ టేక్‌అవేలను సంగ్రహించండి.';
 
   @override
   String get pleaseEnterAppPrompt => 'దయచేసి మీ యాప్‌కు ఒక సూచనను నమోదు చేయండి';
@@ -7067,8 +6903,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'ఫోటోలు అనుమతి నిరాకరించబడింది. చిత్రం ఎంచుకోవడానికి ఫోటోలకు యాక్సెస్‌ను అనుమతించండి';
+  String get addAppPhotosPermissionDenied => 'ఫోటోలు అనుమతి నిరాకరించబడింది. చిత్రం ఎంచుకోవడానికి ఫోటోలకు యాక్సెస్‌ను అనుమతించండి';
 
   @override
   String get addAppErrorSelectingImageRetry => 'చిత్రం ఎంచుకోవడంలో లోపం. దయచేసి ప్రయత్నించండి.';
@@ -7091,8 +6926,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get paymentFailedToFetchCountries => 'సమర్థిత దేశాలను పొందడానికి విఫలమైంది. దయచేసి తరువాత ప్రయత్నించండి.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'డిఫాల్ట్ చెల్లింపు పద్ధతిని సెట్ చేయడానికి విఫలమైంది. దయచేసి తరువాత ప్రయత్నించండి.';
+  String get paymentFailedToSetDefault => 'డిఫాల్ట్ చెల్లింపు పద్ధతిని సెట్ చేయడానికి విఫలమైంది. దయచేసి తరువాత ప్రయత్నించండి.';
 
   @override
   String get paymentFailedToSavePaypal => 'PayPal వివరాలను సేవ్ చేయడానికి విఫలమైంది. దయచేసి తరువాత ప్రయత్నించండి.';
@@ -7174,15 +7008,13 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'అప్‌గ్రేడ్ షెడ్యూల్ చేయబడింది! మీ నెలవారీ ప్రణాళిక మీ బిల్లింగ్ వ్యవధి ముగింపు వరకు కొనసాగుతుంది, తరువాత స్వయంచాలకంగా వార్షికకు మారుతుంది.';
+  String get planUpgradeScheduledMessage => 'అప్‌గ్రేడ్ షెడ్యూల్ చేయబడింది! మీ నెలవారీ ప్రణాళిక మీ బిల్లింగ్ వ్యవధి ముగింపు వరకు కొనసాగుతుంది, తరువాత స్వయంచాలకంగా వార్షికకు మారుతుంది.';
 
   @override
   String get couldNotSchedulePlanChange => 'ప్రణాళిక మార్పును షెడ్యూల్ చేయలేకపోయారు. దయచేసి ప్రయత్నించండి.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'మీ సభ్యత్వం పునరీక్రియాజనకరణ చేయబడింది! ఇప్పుడు ఛార్జ్ లేదు - మీ ప్రస్తుత వ్యవధి ముగింపులో బిల్లు చేయబడతారు.';
+  String get subscriptionReactivatedDefault => 'మీ సభ్యత్వం పునరీక్రియాజనకరణ చేయబడింది! ఇప్పుడు ఛార్జ్ లేదు - మీ ప్రస్తుత వ్యవధి ముగింపులో బిల్లు చేయబడతారు.';
 
   @override
   String get subscriptionSuccessfulCharged => 'సభ్యత్వం విజయవంతం! కొత్త బిల్లింగ్ వ్యవధికి మీకు బిల్లు చేయబడింది.';
@@ -7350,8 +7182,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get authFailedToRetrieveToken => 'firebase టోకెన్‌ను పొందడానికి విఫలమైంది, దయచేసి ప్రయత్నించండి.';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'సైన్ ఇన్ చేసేటప్పుడు అనిర్దేశ్య లోపం, Firebase లోపం, దయచేసి ప్రయత్నించండి.';
+  String get authUnexpectedErrorFirebase => 'సైన్ ఇన్ చేసేటప్పుడు అనిర్దేశ్య లోపం, Firebase లోపం, దయచేసి ప్రయత్నించండి.';
 
   @override
   String get authUnexpectedError => 'సైన్ ఇన్ చేసేటప్పుడు అనిర్దేశ్య లోపం, దయచేసి ప్రయత్నించండి';
@@ -7366,8 +7197,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get onboardingBluetoothRequired => 'మీ పరికరానికి కనెక్ట్ చేయడానికి బ్లూటూత్ అనుమతి అవసరం.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'బ్లూటూత్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్‌లో అనుమతిని మంజూరు చేయండి.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'బ్లూటూత్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్‌లో అనుమతిని మంజూరు చేయండి.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7380,12 +7210,10 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'ఆంటిఫిकేషన్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్‌లో అనుమతిని మంజూరు చేయండి.';
+  String get onboardingNotificationDeniedSystemPrefs => 'ఆంటిఫిकేషన్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్‌లో అనుమతిని మంజూరు చేయండి.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'ఆంటిఫిकేషన్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్ > ఆంటిఫికేషన్‌లలో అనుమతిని మంజూరు చేయండి.';
+  String get onboardingNotificationDeniedNotifications => 'ఆంటిఫిकేషన్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్ > ఆంటిఫికేషన్‌లలో అనుమతిని మంజూరు చేయండి.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7398,15 +7226,13 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'దయచేసి సెట్టింగ్‌లు > గోపనీయత & సంరక్షణ > స్థానం సేవలలో స్థానం అనుమతిని మంజూరు చేయండి';
+  String get onboardingLocationGrantInSettings => 'దయచేసి సెట్టింగ్‌లు > గోపనీయత & సంరక్షణ > స్థానం సేవలలో స్థానం అనుమతిని మంజూరు చేయండి';
 
   @override
   String get onboardingMicrophoneRequired => 'రికార్డింగ్‌కు మైక్రోఫోన్ అనుమతి అవసరం.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'మైక్రోఫోన్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్ > గోపనీయత & సంరక్షణ > మైక్రోఫోన్‌లో అనుమతిని మంజూరు చేయండి.';
+  String get onboardingMicrophoneDenied => 'మైక్రోఫోన్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్ > గోపనీయత & సంరక్షణ > మైక్రోఫోన్‌లో అనుమతిని మంజూరు చేయండి.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7422,8 +7248,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'సిస్టమ్ ఆడియో రికార్డింగ్‌కు స్క్రీన్ క్యాప్చర్ అనుమతి అవసరం.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'స్క్రీన్ క్యాప్చర్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్ > గోపనీయత & సంరక్షణ > స్క్రీన్ రికార్డింగ్‌లో అనుమతిని మంజూరు చేయండి.';
+  String get onboardingScreenCaptureDenied => 'స్క్రీన్ క్యాప్చర్ అనుమతి నిరాకరించబడింది. దయచేసి సిస్టమ్ ప్రిఫరెన్‌సెస్ > గోపనీయత & సంరక్షణ > స్క్రీన్ రికార్డింగ్‌లో అనుమతిని మంజూరు చేయండి.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7476,8 +7301,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'ఫోటోలు అనుమతి నిరాకరించబడింది. చిత్రాలను ఎంచుకోవడానికి ఫోటోలకు యాక్సెస్‌ను అనుమతించండి';
+  String get msgPhotosPermissionDenied => 'ఫోటోలు అనుమతి నిరాకరించబడింది. చిత్రాలను ఎంచుకోవడానికి ఫోటోలకు యాక్సెస్‌ను అనుమతించండి';
 
   @override
   String get msgSelectImagesGenericError => 'చిత్రాలను ఎంచుకోవడంలో లోపం. దయచేసి ప్రయత్నించండి.';
@@ -7549,8 +7373,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get locationPermissionRequired => 'స్థానం అనుమతి అవసరం';
 
   @override
-  String get locationPermissionContent =>
-      'ఫాస్ట్ ట్రాన్‌సర్‌కు WiFi సంయోగం ధృవీకరించడానికి స్థానం అనుమతి అవసరం. దయచేసి కొనసాగించడానికి స్థానం అనుమతిని ఇవ్వండి.';
+  String get locationPermissionContent => 'ఫాస్ట్ ట్రాన్‌సర్‌కు WiFi సంయోగం ధృవీకరించడానికి స్థానం అనుమతి అవసరం. దయచేసి కొనసాగించడానికి స్థానం అనుమతిని ఇవ్వండి.';
 
   @override
   String get pdfTranscriptExport => 'ట్రాన్‌స్క్రిప్ట్ ఎక్సపోర్ట్';
@@ -8009,8 +7832,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Omi DevKit ను జత చేయడానికి మోడ్‌లో ఉంచండి';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'ఆన్ చేయడానికి బటన్‌ను ఒక్కసారి నొక్కండి. జత చేయడం మోడ్‌లో ఉన్నప్పుడు LED ఊదా రంగులో చెమ్ముతుంది.';
+  String get pairingDescOmiDevkit => 'ఆన్ చేయడానికి బటన్‌ను ఒక్కసారి నొక్కండి. జత చేయడం మోడ్‌లో ఉన్నప్పుడు LED ఊదా రంగులో చెమ్ముతుంది.';
 
   @override
   String get pairingTitleOmiGlass => 'Omi Glass ను ఆన్ చేయండి';
@@ -8022,29 +7844,25 @@ class AppLocalizationsTe extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note ను జత చేయడానికి మోడ్‌లో ఉంచండి';
 
   @override
-  String get pairingDescPlaudNote =>
-      'సైడ్ బటన్‌ను 2 సెకన్ల పాటు నొక్కి ఉంచండి. ఎరుపు LED జత చేయడానికి సిద్ధంగా ఉన్నప్పుడు చెమ్ముతుంది.';
+  String get pairingDescPlaudNote => 'సైడ్ బటన్‌ను 2 సెకన్ల పాటు నొక్కి ఉంచండి. ఎరుపు LED జత చేయడానికి సిద్ధంగా ఉన్నప్పుడు చెమ్ముతుంది.';
 
   @override
   String get pairingTitleBee => 'Bee ను జత చేయడానికి మోడ్‌లో ఉంచండి';
 
   @override
-  String get pairingDescBee =>
-      'బటన్‌ను 5 సార్లు నిరంతరం నొక్కండి. లైట్ నీలం మరియు ఆకుపచ్చ రంగులో చెమ్మడం ప్రారంభిస్తుంది.';
+  String get pairingDescBee => 'బటన్‌ను 5 సార్లు నిరంతరం నొక్కండి. లైట్ నీలం మరియు ఆకుపచ్చ రంగులో చెమ్మడం ప్రారంభిస్తుంది.';
 
   @override
   String get pairingTitleLimitless => 'Limitless ను జత చేయడానికి మోడ్‌లో ఉంచండి';
 
   @override
-  String get pairingDescLimitless =>
-      'ఎటువంటి కాంతి కనిపించినప్పుడు, ఒక్కసారి నొక్కి, తర్వాత పరికరం గులాబీ కాంతిని చూపిస్తుంది, ఆపై విడుదల చేయండి.';
+  String get pairingDescLimitless => 'ఎటువంటి కాంతి కనిపించినప్పుడు, ఒక్కసారి నొక్కి, తర్వాత పరికరం గులాబీ కాంతిని చూపిస్తుంది, ఆపై విడుదల చేయండి.';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant ను జత చేయడానికి మోడ్‌లో ఉంచండి';
 
   @override
-  String get pairingDescFriendPendant =>
-      'పెండెంట్‌పై బటన్‌ను నొక్కి ఆన్ చేయండి. ఇది స్వయంచాలకంగా జత చేయడం మోడ్‌లోకి ప్రవేశిస్తుంది.';
+  String get pairingDescFriendPendant => 'పెండెంట్‌పై బటన్‌ను నొక్కి ఆన్ చేయండి. ఇది స్వయంచాలకంగా జత చేయడం మోడ్‌లోకి ప్రవేశిస్తుంది.';
 
   @override
   String get pairingTitleFieldy => 'Fieldy ను జత చేయడానికి మోడ్‌లో ఉంచండి';
@@ -8056,15 +7874,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch కనెక్ట్ చేయండి';
 
   @override
-  String get pairingDescAppleWatch =>
-      'మీ Apple Watch లో Omi యాప్‌ను ఇన్‌స్టాల్ చేసి, తెరవండి, ఆపై యాప్‌లో కనెక్ట్‌ను నొక్కండి.';
+  String get pairingDescAppleWatch => 'మీ Apple Watch లో Omi యాప్‌ను ఇన్‌స్టాల్ చేసి, తెరవండి, ఆపై యాప్‌లో కనెక్ట్‌ను నొక్కండి.';
 
   @override
   String get pairingTitleNeoOne => 'Neo One ను జత చేయడానికి మోడ్‌లో ఉంచండి';
 
   @override
-  String get pairingDescNeoOne =>
-      'LED చెమ్మడం ప్రారంభం చేయడం వరకు విద్యుత్ బటన్‌ను నొక్కి ఉంచండి. పరికరం కనుగొనదగినదిగా ఉంటుంది.';
+  String get pairingDescNeoOne => 'LED చెమ్మడం ప్రారంభం చేయడం వరకు విద్యుత్ బటన్‌ను నొక్కి ఉంచండి. పరికరం కనుగొనదగినదిగా ఉంటుంది.';
 
   @override
   String get downloadingFromDevice => 'పరికరం నుండి డౌన్‌లోడ్ చేస్తోంది';
@@ -8134,8 +7950,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get wifiConfiguration => 'WiFi కాన్ఫిగరేషన్';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'ఫర్మ్‌వేర్‌ను డౌన్‌లోడ్ చేయడానికి అనుమతించడానికి మీ WiFi ఆధారపడిన సమాచారం నమోదు చేయండి.';
+  String get wifiConfigurationSubtitle => 'ఫర్మ్‌వేర్‌ను డౌన్‌లోడ్ చేయడానికి అనుమతించడానికి మీ WiFi ఆధారపడిన సమాచారం నమోదు చేయండి.';
 
   @override
   String get networkNameSsid => 'నెట్‌వర్క్ పేరు (SSID)';
@@ -8153,8 +7968,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'ఇది నేను మీ గురించి తెలుసుకున్న';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Omi మీ సంభాషణల నుండి నేర్చుకున్నందున ఈ మ్యాప్ నవీకరించబడుతుంది.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Omi మీ సంభాషణల నుండి నేర్చుకున్నందున ఈ మ్యాప్ నవీకరించబడుతుంది.';
 
   @override
   String get apiEnvironment => 'API పరిసర';
@@ -8183,8 +7997,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get switchAndRestart => 'స్విచ్ చేయండి';
 
   @override
-  String get stagingDisclaimer =>
-      'స్టేజింగ్ బగ్‌లను కలిగి ఉండవచ్చు, అసమానమైన పనితీరుకు మరియు డేటా కోల్పోయే అవకాశం ఉంది. పరీక్షణ కోసం మాత్రమే ఉపయోగించండి.';
+  String get stagingDisclaimer => 'స్టేజింగ్ బగ్‌లను కలిగి ఉండవచ్చు, అసమానమైన పనితీరుకు మరియు డేటా కోల్పోయే అవకాశం ఉంది. పరీక్షణ కోసం మాత్రమే ఉపయోగించండి.';
 
   @override
   String get apiEnvSavedRestartRequired => 'సేవ్ చేయబడింది. యాప్‌ను వర్తించడానికి మూసి, మరోసారి తెరవండి.';
@@ -8413,8 +8226,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Omi ద్వారా ఫోన్ కాల్‌లు';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Omi ద్వారా కాల్‌లు చేయండి మరియు రియల్-టైమ్ ట్రాన్‌స్క్రిప్షన్, స్వయంచాలక సారాంశాలు మరియు మరిన్నిటిని పొందండి. అన్‌లిమిటెడ్ ప్లాన్ సబ్‌స్క్రైబర్‌ల కోసం ప్రత్యేకంగా అందుబాటులో ఉంది.';
+  String get phoneCallsUpsellSubtitle => 'Omi ద్వారా కాల్‌లు చేయండి మరియు రియల్-టైమ్ ట్రాన్‌స్క్రిప్షన్, స్వయంచాలక సారాంశాలు మరియు మరిన్నిటిని పొందండి. అన్‌లిమిటెడ్ ప్లాన్ సబ్‌స్క్రైబర్‌ల కోసం ప్రత్యేకంగా అందుబాటులో ఉంది.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'ప్రతి కాల్ రియల్-టైమ్ ట్రాన్‌స్క్రిప్షన్';
@@ -8453,8 +8265,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deletePendingFiles => 'పెండింగ్ రికార్డింగ్‌లను తొలగించండి';
 
   @override
-  String get deletePendingFilesWarning =>
-      'ఈ రికార్డింగ్‌లు మీ ఫోన్‌కు సమకాలీకరించబడలేదు మరియు శాశ్వతంగా కోల్పోతాయి. ఇది రద్దు చేయబడదు.';
+  String get deletePendingFilesWarning => 'ఈ రికార్డింగ్‌లు మీ ఫోన్‌కు సమకాలీకరించబడలేదు మరియు శాశ్వతంగా కోల్పోతాయి. ఇది రద్దు చేయబడదు.';
 
   @override
   String get pendingFilesDeleted => 'పెండింగ్ రికార్డింగ్‌లు తొలగించబడ్డాయి';
@@ -8466,8 +8277,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deleteAll => 'అన్నీ తొలగించు';
 
   @override
-  String get deleteAllFilesWarning =>
-      'ఇది సమకాలీకరించిన మరియు పెండింగ్ రికార్డింగ్‌లను తొలగిస్తుంది. పెండింగ్ రికార్డింగ్‌లు సమకాలీకరించబడలేదు మరియు శాశ్వతంగా కోల్పోతాయి. ఇది రద్దు చేయబడదు.';
+  String get deleteAllFilesWarning => 'ఇది సమకాలీకరించిన మరియు పెండింగ్ రికార్డింగ్‌లను తొలగిస్తుంది. పెండింగ్ రికార్డింగ్‌లు సమకాలీకరించబడలేదు మరియు శాశ్వతంగా కోల్పోతాయి. ఇది రద్దు చేయబడదు.';
 
   @override
   String get allFilesDeleted => 'అన్ని రికార్డింగ్‌లు తొలగించబడ్డాయి';
@@ -8532,8 +8342,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get fairUseAboutTitle => 'న్యాయమైన ఉపయోగం గురించి';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi వ్యక్తిగత సంభాషణలు, సమావేశాలు మరియు జీవంత పరిస్థితుల కోసం డిజైన్ చేయబడింది. ఉపయోగం కనెక్షన్ సమయం కాకుండా కనుగొనబడిన నిజమైన స్పీచ్ సమయం ద్వారా కొలుస్తారు. ఉపయోగం నిజమైన కాని నిజమైన కాని విషయవస్తువుల కోసం సాధారణ నమూనాలను గణనీయంగా మించిపోయినట్లయితే, సమన్వయాలు వర్తించవచ్చు.';
+  String get fairUseAboutBody => 'Omi వ్యక్తిగత సంభాషణలు, సమావేశాలు మరియు జీవంత పరిస్థితుల కోసం డిజైన్ చేయబడింది. ఉపయోగం కనెక్షన్ సమయం కాకుండా కనుగొనబడిన నిజమైన స్పీచ్ సమయం ద్వారా కొలుస్తారు. ఉపయోగం నిజమైన కాని నిజమైన కాని విషయవస్తువుల కోసం సాధారణ నమూనాలను గణనీయంగా మించిపోయినట్లయితే, సమన్వయాలు వర్తించవచ్చు.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8560,8 +8369,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get transcriptionPaused => 'రికార్డింగ్, మరోసారి కనెక్ట్ చేస్తోంది';
 
   @override
-  String get transcriptionPausedReconnecting =>
-      'ఇంకా రికార్డింగ్ చేస్తోంది — ట్రాన్‌స్క్రిప్షన్‌కు మరోసారి కనెక్ట్ చేస్తోంది...';
+  String get transcriptionPausedReconnecting => 'ఇంకా రికార్డింగ్ చేస్తోంది — ట్రాన్‌స్క్రిప్షన్‌కు మరోసారి కనెక్ట్ చేస్తోంది...';
 
   @override
   String fairUseBannerStatus(String status) {
@@ -8572,8 +8380,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get improveConnectionTitle => 'కనెక్షన్ మెరుగుపరచండి';
 
   @override
-  String get improveConnectionContent =>
-      'Omi మీ పరికరానికి కనెక్ట్ చేయబడిన విధానాన్ని మేము మెరుగుపరచాము. ఇది సక్రియం చేయడానికి, దయచేసి పరికరం సమాచారం పేజీకి వెళ్లండి, \"పరికరం డిస్‌కనెక్ట్ చేయండి\" నొక్కండి మరియు అప్పుడు మీ పరికరాన్ని మరోసారి జత చేయండి.';
+  String get improveConnectionContent => 'Omi మీ పరికరానికి కనెక్ట్ చేయబడిన విధానాన్ని మేము మెరుగుపరచాము. ఇది సక్రియం చేయడానికి, దయచేసి పరికరం సమాచారం పేజీకి వెళ్లండి, \"పరికరం డిస్‌కనెక్ట్ చేయండి\" నొక్కండి మరియు అప్పుడు మీ పరికరాన్ని మరోసారి జత చేయండి.';
 
   @override
   String get improveConnectionAction => 'నిర్థారణ';
@@ -8628,16 +8435,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get cancelSyncQuestion => 'సమకాలీకరణ రద్దు చేయాలా?';
 
   @override
-  String get omisStorageDesc =>
-      'మీ Omi మీ ఫోన్‌కు కనెక్ట్ చేయనప్పుడు, ఇది నిర్మిత మెమరీపై స్థానికంగా ఆడియోను నిల్వ చేస్తుంది. మీరు ఎప్పటికీ రికార్డింగ్‌ను కోల్పోరు.';
+  String get omisStorageDesc => 'మీ Omi మీ ఫోన్‌కు కనెక్ట్ చేయనప్పుడు, ఇది నిర్మిత మెమరీపై స్థానికంగా ఆడియోను నిల్వ చేస్తుంది. మీరు ఎప్పటికీ రికార్డింగ్‌ను కోల్పోరు.';
 
   @override
-  String get phoneStorageDesc =>
-      'Omi మరోసారి కనెక్ట్ చేసినప్పుడు, రికార్డింగ్‌లు స్వయంచాలకంగా మీ ఫోన్‌కు అప్‌లోడ్ చేయడానికి ముందు తాత్కాలిక హోల్డింగ్ ఆ రూపంగా బదిలీ చేయబడతాయి.';
+  String get phoneStorageDesc => 'Omi మరోసారి కనెక్ట్ చేసినప్పుడు, రికార్డింగ్‌లు స్వయంచాలకంగా మీ ఫోన్‌కు అప్‌లోడ్ చేయడానికి ముందు తాత్కాలిక హోల్డింగ్ ఆ రూపంగా బదిలీ చేయబడతాయి.';
 
   @override
-  String get cloudStorageDesc =>
-      'అప్‌లోడ్ చేసిన తర్వాత, మీ రికార్డింగ్‌లు ప్రక్రియ చేయబడతాయి మరియు ట్రాన్‌స్క్రిబ్ చేయబడతాయి. సంభాషణలు ఒక నిమిషంలో అందుబాటులో ఉంటాయి.';
+  String get cloudStorageDesc => 'అప్‌లోడ్ చేసిన తర్వాత, మీ రికార్డింగ్‌లు ప్రక్రియ చేయబడతాయి మరియు ట్రాన్‌స్క్రిబ్ చేయబడతాయి. సంభాషణలు ఒక నిమిషంలో అందుబాటులో ఉంటాయి.';
 
   @override
   String get tipKeepPhoneNearby => 'వేగవంతమైన సమకాలీకరణ కోసం మీ ఫోన్‌ను దగ్గరగా ఉంచండి';
@@ -8661,12 +8465,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get permissionEnable => 'ప్రారంభించండి';
 
   @override
-  String get permissionsPageDescription =>
-      'ఈ అనుమతులు Omi ఎలా పని చేస్తుంది అనేటువంటి ప్రధానమైనవి. అవి నోటిఫికేషన్‌లు, స్థానం-ఆధారిత అనుభవాలు మరియు ఆడియో సంగ్రహణ వంటి ముఖ్య లక్షణాలను ఎనేబుల్ చేస్తాయి.';
+  String get permissionsPageDescription => 'ఈ అనుమతులు Omi ఎలా పని చేస్తుంది అనేటువంటి ప్రధానమైనవి. అవి నోటిఫికేషన్‌లు, స్థానం-ఆధారిత అనుభవాలు మరియు ఆడియో సంగ్రహణ వంటి ముఖ్య లక్షణాలను ఎనేబుల్ చేస్తాయి.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi సరిగ్గా పని చేయడానికి కొన్ని అనుమతులు అవసరం. దయచేసి కొనసాగించటానికి వాటిని ఇవ్వండి.';
+  String get permissionsRequiredDescription => 'Omi సరిగ్గా పని చేయడానికి కొన్ని అనుమతులు అవసరం. దయచేసి కొనసాగించటానికి వాటిని ఇవ్వండి.';
 
   @override
   String get permissionsSetupTitle => 'ఉత్తమ అనుభవం పొందండి';
@@ -8720,8 +8522,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get justAMoment => 'క్షణానికి మరోసారి, దయచేసి';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'మేము రద్దు చేయకుండా మీ ఇతర ఎంపికలను అన్వేషించమని సంప్రదాయవశంగా సిఫార్సు చేస్తున్నాము.';
+  String get cancelConsequencesSubtitle => 'మేము రద్దు చేయకుండా మీ ఇతర ఎంపికలను అన్వేషించమని సంప్రదాయవశంగా సిఫార్సు చేస్తున్నాము.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8944,8 +8745,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get firmwareWarningTitle => 'ముఖ్యం: అప్‌డేట్ చేయడానికి ముందు చదవండి';
 
   @override
-  String get firmwareFormatWarning =>
-      'ఈ ఫర్మ్‌వేర్ SD కార్డ్‌ను ఫార్మాట్ చేస్తుంది. అప్‌గ్రేడ్ చేయడానికి ముందు అన్ని ఆఫ్‌లైన్ డేటా సింక్ అయిందని నిర్ధారించుకోండి.\n\nఈ వెర్షన్ ఇన్‌స్టాల్ చేసిన తర్వాత ఎరుపు లైట్ మినుకుమినుకుమంటే ఆందోళన చెందకండి. పరికరాన్ని యాప్‌కి కనెక్ట్ చేయండి, అది నీలం రంగులోకి మారాలి. ఎరుపు లైట్ అంటే పరికరం యొక్క గడియారం ఇంకా సింక్ కాలేదు.';
+  String get firmwareFormatWarning => 'ఈ ఫర్మ్‌వేర్ SD కార్డ్‌ను ఫార్మాట్ చేస్తుంది. అప్‌గ్రేడ్ చేయడానికి ముందు అన్ని ఆఫ్‌లైన్ డేటా సింక్ అయిందని నిర్ధారించుకోండి.\n\nఈ వెర్షన్ ఇన్‌స్టాల్ చేసిన తర్వాత ఎరుపు లైట్ మినుకుమినుకుమంటే ఆందోళన చెందకండి. పరికరాన్ని యాప్‌కి కనెక్ట్ చేయండి, అది నీలం రంగులోకి మారాలి. ఎరుపు లైట్ అంటే పరికరం యొక్క గడియారం ఇంకా సింక్ కాలేదు.';
 
   @override
   String get continueAnyway => 'కొనసాగించు';
@@ -8965,8 +8765,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get tasksMarkComplete => 'పూర్తయినట్లు గుర్తించబడింది';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi Apple యొక్క HealthKit ఫ్రేమ్‌వర్క్ ద్వారా Apple Health ను యాక్సెస్ చేస్తుంది. మీరు ఎప్పుడైనా iOS సెట్టింగ్‌ల నుండి యాక్సెస్‌ను ఉపసంహరించుకోవచ్చు.';
+  String get appleHealthManageNote => 'Omi Apple యొక్క HealthKit ఫ్రేమ్‌వర్క్ ద్వారా Apple Health ను యాక్సెస్ చేస్తుంది. మీరు ఎప్పుడైనా iOS సెట్టింగ్‌ల నుండి యాక్సెస్‌ను ఉపసంహరించుకోవచ్చు.';
 
   @override
   String get appleHealthConnectCta => 'Apple Health కి కనెక్ట్ చేయండి';
@@ -8999,8 +8798,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health యాక్సెస్ తిరస్కరించబడింది';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi కి మీ Apple Health డేటాను చదవడానికి అనుమతి లేదు. iOS సెట్టింగ్‌లు → గోప్యత & భద్రత → Health → Omi లో దీన్ని ప్రారంభించండి.';
+  String get appleHealthDeniedBody => 'Omi కి మీ Apple Health డేటాను చదవడానికి అనుమతి లేదు. iOS సెట్టింగ్‌లు → గోప్యత & భద్రత → Health → Omi లో దీన్ని ప్రారంభించండి.';
 
   @override
   String get deleteFlowReasonTitle => 'మీరు ఎందుకు వెళ్తున్నారు?';
@@ -9069,8 +8867,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get planUpdate => 'ప్లాన్ అప్‌డేట్';
 
   @override
-  String get planDeprecationMessage =>
-      'మీ Unlimited ప్లాన్ ఆపివేయబడుతోంది. Operator ప్లాన్‌కి మారండి — అదే అద్భుతమైన ఫీచర్లు \$49/నెలకు. మీ ప్రస్తుత ప్లాన్ ఈలోగా పని చేస్తూనే ఉంటుంది.';
+  String get planDeprecationMessage => 'మీ Unlimited ప్లాన్ ఆపివేయబడుతోంది. Operator ప్లాన్‌కి మారండి — అదే అద్భుతమైన ఫీచర్లు \$49/నెలకు. మీ ప్రస్తుత ప్లాన్ ఈలోగా పని చేస్తూనే ఉంటుంది.';
 
   @override
   String get upgradeYourPlan => 'మీ ప్లాన్‌ను అప్‌గ్రేడ్ చేయండి';
@@ -9181,8 +8978,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'మీరు మీ నెలవారీ పరిమితిని చేరుకున్నారు. పరిమితులు లేకుండా Omi తో చాట్ కొనసాగించడానికి అప్‌గ్రేడ్ చేయండి.';
+  String get chatQuotaExceededReply => 'మీరు మీ నెలవారీ పరిమితిని చేరుకున్నారు. పరిమితులు లేకుండా Omi తో చాట్ కొనసాగించడానికి అప్‌గ్రేడ్ చేయండి.';
 
   @override
   String get voiceResponseAudio => 'Omi ప్రతిస్పందనను బిగ్గరగా చదవండి';
@@ -9213,4 +9009,25 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'పని జోడించండి';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi ని ఏదైనా అడగండి';
+
+  @override
+  String get quickActionVoiceMode => 'వాయిస్ మోడ్';
+
+  @override
+  String get quickActionMute => 'మ్యూట్';
+
+  @override
+  String get quickActionUnmute => 'అన్‌మ్యూట్';
+
+  @override
+  String get quickActionConnectDevice => 'పరికరాన్ని కనెక్ట్ చేయండి';
+
+  @override
+  String get quickActionDeviceSettings => 'పరికర సెట్టింగ్‌లు';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -24,8 +24,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deleteConversationTitle => 'ลบบทสนทนา?';
 
   @override
-  String get deleteConversationMessage =>
-      'การดำเนินการนี้จะลบความทรงจำ งาน และไฟล์เสียงที่เกี่ยวข้องด้วย การดำเนินการนี้ไม่สามารถย้อนกลับได้';
+  String get deleteConversationMessage => 'การดำเนินการนี้จะลบความทรงจำ งาน และไฟล์เสียงที่เกี่ยวข้องด้วย การดำเนินการนี้ไม่สามารถย้อนกลับได้';
 
   @override
   String get confirm => 'ยืนยัน';
@@ -318,8 +317,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get installedApps => 'แอปที่ติดตั้งแล้ว';
 
   @override
-  String get unableToFetchApps =>
-      'ไม่สามารถดึงข้อมูลแอปได้ :(\n\nกรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองใหม่อีกครั้ง';
+  String get unableToFetchApps => 'ไม่สามารถดึงข้อมูลแอปได้ :(\n\nกรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองใหม่อีกครั้ง';
 
   @override
   String get aboutOmi => 'เกี่ยวกับ Omi';
@@ -358,15 +356,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get exportBeforeDelete => 'คุณสามารถส่งออกข้อมูลของคุณก่อนลบบัญชี แต่เมื่อลบแล้วจะไม่สามารถกู้คืนได้';
 
   @override
-  String get deleteAccountCheckbox =>
-      'ฉันเข้าใจว่าการลบบัญชีของฉันเป็นการถาวรและข้อมูลทั้งหมด รวมถึงความทรงจำและบทสนทนา จะสูญหายและไม่สามารถกู้คืนได้';
+  String get deleteAccountCheckbox => 'ฉันเข้าใจว่าการลบบัญชีของฉันเป็นการถาวรและข้อมูลทั้งหมด รวมถึงความทรงจำและบทสนทนา จะสูญหายและไม่สามารถกู้คืนได้';
 
   @override
   String get areYouSure => 'คุณแน่ใจหรือไม่?';
 
   @override
-  String get deleteAccountFinal =>
-      'การดำเนินการนี้ไม่สามารถย้อนกลับได้และจะลบบัญชีของคุณและข้อมูลที่เกี่ยวข้องทั้งหมดอย่างถาวร คุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?';
+  String get deleteAccountFinal => 'การดำเนินการนี้ไม่สามารถย้อนกลับได้และจะลบบัญชีของคุณและข้อมูลที่เกี่ยวข้องทั้งหมดอย่างถาวร คุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?';
 
   @override
   String get deleteNow => 'ลบเลย';
@@ -375,8 +371,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get goBack => 'กลับ';
 
   @override
-  String get checkBoxToConfirm =>
-      'กาเครื่องหมายในช่องเพื่อยืนยันว่าคุณเข้าใจว่าการลบบัญชีของคุณเป็นการถาวรและไม่สามารถย้อนกลับได้';
+  String get checkBoxToConfirm => 'กาเครื่องหมายในช่องเพื่อยืนยันว่าคุณเข้าใจว่าการลบบัญชีของคุณเป็นการถาวรและไม่สามารถย้อนกลับได้';
 
   @override
   String get profile => 'โปรไฟล์';
@@ -454,8 +449,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get yourPrivacyYourControl => 'ความเป็นส่วนตัวของคุณ อยู่ในการควบคุมของคุณ';
 
   @override
-  String get privacyIntro =>
-      'ที่ Omi เรามุ่งมั่นในการปกป้องความเป็นส่วนตัวของคุณ หน้านี้ช่วยให้คุณสามารถควบคุมวิธีการจัดเก็บและใช้ข้อมูลของคุณได้';
+  String get privacyIntro => 'ที่ Omi เรามุ่งมั่นในการปกป้องความเป็นส่วนตัวของคุณ หน้านี้ช่วยให้คุณสามารถควบคุมวิธีการจัดเก็บและใช้ข้อมูลของคุณได้';
 
   @override
   String get learnMore => 'เรียนรู้เพิ่มเติม...';
@@ -464,8 +458,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get dataProtectionLevel => 'ระดับการปกป้องข้อมูล';
 
   @override
-  String get dataProtectionDesc =>
-      'ข้อมูลของคุณได้รับการรักษาความปลอดภัยโดยค่าเริ่มต้นด้วยการเข้ารหัสที่แข็งแกร่ง ตรวจสอบการตั้งค่าและตัวเลือกความเป็นส่วนตัวในอนาคตด้านล่าง';
+  String get dataProtectionDesc => 'ข้อมูลของคุณได้รับการรักษาความปลอดภัยโดยค่าเริ่มต้นด้วยการเข้ารหัสที่แข็งแกร่ง ตรวจสอบการตั้งค่าและตัวเลือกความเป็นส่วนตัวในอนาคตด้านล่าง';
 
   @override
   String get appAccess => 'การเข้าถึงแอป';
@@ -528,15 +521,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Omi ของคุณถูกตัดการเชื่อมต่อแล้ว 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'ยกเลิกการจับคู่อุปกรณ์แล้ว ไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำการยกเลิกการจับคู่ให้เสร็จสมบูรณ์';
+  String get deviceUnpairedMessage => 'ยกเลิกการจับคู่อุปกรณ์แล้ว ไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำการยกเลิกการจับคู่ให้เสร็จสมบูรณ์';
 
   @override
   String get unpairDialogTitle => 'ยกเลิกการจับคู่อุปกรณ์';
 
   @override
-  String get unpairDialogMessage =>
-      'นี่จะยกเลิกการจับคู่อุปกรณ์เพื่อให้สามารถเชื่อมต่อกับโทรศัพท์เครื่องอื่นได้ คุณจะต้องไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำกระบวนการให้เสร็จสมบูรณ์';
+  String get unpairDialogMessage => 'นี่จะยกเลิกการจับคู่อุปกรณ์เพื่อให้สามารถเชื่อมต่อกับโทรศัพท์เครื่องอื่นได้ คุณจะต้องไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำกระบวนการให้เสร็จสมบูรณ์';
 
   @override
   String get deviceNotConnected => 'ไม่ได้เชื่อมต่ออุปกรณ์';
@@ -557,8 +548,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get v2Undetected => 'ไม่พบ V2';
 
   @override
-  String get v2UndetectedMessage =>
-      'เราเห็นว่าคุณมีอุปกรณ์ V1 หรืออุปกรณ์ของคุณไม่ได้เชื่อมต่อ ฟังก์ชัน SD Card จะใช้ได้เฉพาะกับอุปกรณ์ V2 เท่านั้น';
+  String get v2UndetectedMessage => 'เราเห็นว่าคุณมีอุปกรณ์ V1 หรืออุปกรณ์ของคุณไม่ได้เชื่อมต่อ ฟังก์ชัน SD Card จะใช้ได้เฉพาะกับอุปกรณ์ V2 เท่านั้น';
 
   @override
   String get endConversation => 'จบบทสนทนา';
@@ -832,8 +822,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'ลบกราฟความรู้?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'นี่จะลบข้อมูลกราฟความรู้ที่สร้างขึ้นทั้งหมด (โหนดและการเชื่อมต่อ) ความทรงจำเดิมของคุณจะยังคงปลอดภัย กราฟจะถูกสร้างขึ้นใหม่เมื่อเวลาผ่านไปหรือเมื่อมีคำขอครั้งถัดไป';
+  String get deleteKnowledgeGraphMessage => 'นี่จะลบข้อมูลกราฟความรู้ที่สร้างขึ้นทั้งหมด (โหนดและการเชื่อมต่อ) ความทรงจำเดิมของคุณจะยังคงปลอดภัย กราฟจะถูกสร้างขึ้นใหม่เมื่อเวลาผ่านไปหรือเมื่อมีคำขอครั้งถัดไป';
 
   @override
   String get knowledgeGraphDeleted => 'ลบกราฟความรู้แล้ว';
@@ -1097,12 +1086,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get enhanceTranscriptAccuracy => 'เพิ่มความแม่นยำของการถอดเสียง';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'เมื่อโมเดลของเราดีขึ้น เราสามารถให้ผลการถอดเสียงที่ดีขึ้นสำหรับการบันทึกของคุณ';
+  String get enhanceTranscriptAccuracyDesc => 'เมื่อโมเดลของเราดีขึ้น เราสามารถให้ผลการถอดเสียงที่ดีขึ้นสำหรับการบันทึกของคุณ';
 
   @override
-  String get legalNotice =>
-      'ประกาศทางกฎหมาย: ความถูกต้องตามกฎหมายในการบันทึกและจัดเก็บข้อมูลเสียงอาจแตกต่างกันไปตามสถานที่และวิธีที่คุณใช้ฟีเจอร์นี้ เป็นความรับผิดชอบของคุณที่จะต้องปฏิบัติตามกฎหมายและข้อบังคับในพื้นที่';
+  String get legalNotice => 'ประกาศทางกฎหมาย: ความถูกต้องตามกฎหมายในการบันทึกและจัดเก็บข้อมูลเสียงอาจแตกต่างกันไปตามสถานที่และวิธีที่คุณใช้ฟีเจอร์นี้ เป็นความรับผิดชอบของคุณที่จะต้องปฏิบัติตามกฎหมายและข้อบังคับในพื้นที่';
 
   @override
   String get alreadyAuthorized => 'อนุญาตแล้ว';
@@ -1180,8 +1167,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showEventsNoParticipants => 'แสดงกิจกรรมที่ไม่มีผู้เข้าร่วม';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'เมื่อเปิดใช้งาน Coming Up จะแสดงกิจกรรมที่ไม่มีผู้เข้าร่วมหรือลิงก์วิดีโอ';
+  String get showEventsNoParticipantsDesc => 'เมื่อเปิดใช้งาน Coming Up จะแสดงกิจกรรมที่ไม่มีผู้เข้าร่วมหรือลิงก์วิดีโอ';
 
   @override
   String get yourMeetings => 'การประชุมของคุณ';
@@ -1349,8 +1335,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get defaultRepository => 'ที่เก็บเริ่มต้น';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'เลือกที่เก็บเริ่มต้นสำหรับสร้าง issue คุณยังสามารถระบุที่เก็บอื่นได้เมื่อสร้าง issue';
+  String get selectDefaultRepoDesc => 'เลือกที่เก็บเริ่มต้นสำหรับสร้าง issue คุณยังสามารถระบุที่เก็บอื่นได้เมื่อสร้าง issue';
 
   @override
   String get noReposFound => 'ไม่พบที่เก็บ';
@@ -1725,8 +1710,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get enableBluetooth => 'เปิดใช้งาน Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi ต้องการ Bluetooth เพื่อเชื่อมต่อกับอุปกรณ์สวมใส่ของคุณ กรุณาเปิดใช้งาน Bluetooth แล้วลองอีกครั้ง';
+  String get bluetoothNeeded => 'Omi ต้องการ Bluetooth เพื่อเชื่อมต่อกับอุปกรณ์สวมใส่ของคุณ กรุณาเปิดใช้งาน Bluetooth แล้วลองอีกครั้ง';
 
   @override
   String get contactSupport => 'ติดต่อฝ่ายสนับสนุน?';
@@ -1759,8 +1743,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get locationServiceDisabled => 'บริการตำแหน่งถูกปิด';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'บริการตำแหน่งถูกปิด กรุณาไปที่ การตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการตำแหน่ง แล้วเปิดใช้งาน';
+  String get locationServiceDisabledDesc => 'บริการตำแหน่งถูกปิด กรุณาไปที่ การตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการตำแหน่ง แล้วเปิดใช้งาน';
 
   @override
   String get backgroundLocationDenied => 'การเข้าถึงตำแหน่งพื้นหลังถูกปฏิเสธ';
@@ -1772,12 +1755,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get lovingOmi => 'ชอบ Omi ไหม?';
 
   @override
-  String get leaveReviewIos =>
-      'ช่วยเราเข้าถึงคนมากขึ้นด้วยการรีวิวใน App Store ความคิดเห็นของคุณมีความหมายมากสำหรับเรา!';
+  String get leaveReviewIos => 'ช่วยเราเข้าถึงคนมากขึ้นด้วยการรีวิวใน App Store ความคิดเห็นของคุณมีความหมายมากสำหรับเรา!';
 
   @override
-  String get leaveReviewAndroid =>
-      'ช่วยเราเข้าถึงคนมากขึ้นด้วยการรีวิวใน Google Play Store ความคิดเห็นของคุณมีความหมายมากสำหรับเรา!';
+  String get leaveReviewAndroid => 'ช่วยเราเข้าถึงคนมากขึ้นด้วยการรีวิวใน Google Play Store ความคิดเห็นของคุณมีความหมายมากสำหรับเรา!';
 
   @override
   String get rateOnAppStore => 'ให้คะแนนบน App Store';
@@ -1810,15 +1791,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get connectionError => 'ข้อผิดพลาดในการเชื่อมต่อ';
 
   @override
-  String get connectionErrorDesc =>
-      'เชื่อมต่อกับเซิร์ฟเวอร์ไม่สำเร็จ กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง';
+  String get connectionErrorDesc => 'เชื่อมต่อกับเซิร์ฟเวอร์ไม่สำเร็จ กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'ตรวจพบการบันทึกที่ไม่ถูกต้อง';
 
   @override
-  String get multipleSpeakersDesc =>
-      'ดูเหมือนว่ามีผู้พูดหลายคนในการบันทึก กรุณาตรวจสอบให้แน่ใจว่าคุณอยู่ในสถานที่เงียบและลองอีกครั้ง';
+  String get multipleSpeakersDesc => 'ดูเหมือนว่ามีผู้พูดหลายคนในการบันทึก กรุณาตรวจสอบให้แน่ใจว่าคุณอยู่ในสถานที่เงียบและลองอีกครั้ง';
 
   @override
   String get tooShortDesc => 'ตรวจพบคำพูดไม่เพียงพอ กรุณาพูดมากขึ้นและลองอีกครั้ง';
@@ -1851,8 +1830,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get permissionsRequired => 'ต้องการสิทธิ์';
 
   @override
-  String get permissionsRequiredDesc =>
-      'แอปนี้ต้องการสิทธิ์ Bluetooth และตำแหน่งเพื่อทำงานอย่างถูกต้อง กรุณาเปิดใช้งานในการตั้งค่า';
+  String get permissionsRequiredDesc => 'แอปนี้ต้องการสิทธิ์ Bluetooth และตำแหน่งเพื่อทำงานอย่างถูกต้อง กรุณาเปิดใช้งานในการตั้งค่า';
 
   @override
   String get openSettings => 'เปิดการตั้งค่า';
@@ -1894,12 +1872,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get microphonePermission => 'สิทธิ์ไมโครโฟน';
 
   @override
-  String get permissionGrantedNow =>
-      'อนุญาตสิทธิ์แล้ว! ตอนนี้:\n\nเปิดแอป Omi บนนาฬิกาของคุณและแตะ \"ดำเนินการต่อ\" ด้านล่าง';
+  String get permissionGrantedNow => 'อนุญาตสิทธิ์แล้ว! ตอนนี้:\n\nเปิดแอป Omi บนนาฬิกาของคุณและแตะ \"ดำเนินการต่อ\" ด้านล่าง';
 
   @override
-  String get needMicrophonePermission =>
-      'เราต้องการสิทธิ์ไมโครโฟน\n\n1. แตะ \"อนุญาตสิทธิ์\"\n2. อนุญาตบน iPhone ของคุณ\n3. แอปบนนาฬิกาจะปิด\n4. เปิดใหม่และแตะ \"ดำเนินการต่อ\"';
+  String get needMicrophonePermission => 'เราต้องการสิทธิ์ไมโครโฟน\n\n1. แตะ \"อนุญาตสิทธิ์\"\n2. อนุญาตบน iPhone ของคุณ\n3. แอปบนนาฬิกาจะปิด\n4. เปิดใหม่และแตะ \"ดำเนินการต่อ\"';
 
   @override
   String get grantPermissionButton => 'อนุญาตสิทธิ์';
@@ -1908,15 +1884,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get needHelp => 'ต้องการความช่วยเหลือ?';
 
   @override
-  String get troubleshootingSteps =>
-      'วิธีแก้ปัญหา:\n\n1. ตรวจสอบว่าได้ติดตั้ง Omi บนนาฬิกาแล้ว\n2. เปิดแอป Omi บนนาฬิกาของคุณ\n3. มองหาป๊อปอัปสิทธิ์\n4. แตะ \"อนุญาต\" เมื่อได้รับแจ้ง\n5. แอปบนนาฬิกาจะปิด - เปิดใหม่\n6. กลับมาและแตะ \"ดำเนินการต่อ\" บน iPhone ของคุณ';
+  String get troubleshootingSteps => 'วิธีแก้ปัญหา:\n\n1. ตรวจสอบว่าได้ติดตั้ง Omi บนนาฬิกาแล้ว\n2. เปิดแอป Omi บนนาฬิกาของคุณ\n3. มองหาป๊อปอัปสิทธิ์\n4. แตะ \"อนุญาต\" เมื่อได้รับแจ้ง\n5. แอปบนนาฬิกาจะปิด - เปิดใหม่\n6. กลับมาและแตะ \"ดำเนินการต่อ\" บน iPhone ของคุณ';
 
   @override
   String get recordingStartedSuccessfully => 'เริ่มบันทึกสำเร็จ!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'ยังไม่ได้อนุญาตสิทธิ์ กรุณาตรวจสอบให้แน่ใจว่าคุณได้อนุญาตการเข้าถึงไมโครโฟนและเปิดแอปบนนาฬิกาใหม่แล้ว';
+  String get permissionNotGrantedYet => 'ยังไม่ได้อนุญาตสิทธิ์ กรุณาตรวจสอบให้แน่ใจว่าคุณได้อนุญาตการเข้าถึงไมโครโฟนและเปิดแอปบนนาฬิกาใหม่แล้ว';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2013,8 +1987,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get welcomeActionItemsTitle => 'พร้อมสำหรับสิ่งที่ต้องทำ';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'AI ของคุณจะดึงงานและสิ่งที่ต้องทำจากบทสนทนาโดยอัตโนมัติ รายการจะปรากฏที่นี่เมื่อสร้าง';
+  String get welcomeActionItemsDescription => 'AI ของคุณจะดึงงานและสิ่งที่ต้องทำจากบทสนทนาโดยอัตโนมัติ รายการจะปรากฏที่นี่เมื่อสร้าง';
 
   @override
   String get autoExtractionFeature => 'ดึงจากบทสนทนาอัตโนมัติ';
@@ -2371,8 +2344,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'ยกเลิกการจับคู่อุปกรณ์';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'การดำเนินการนี้จะยกเลิกการจับคู่อุปกรณ์เพื่อให้สามารถเชื่อมต่อกับโทรศัพท์เครื่องอื่นได้ คุณจะต้องไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำกระบวนการให้เสร็จสมบูรณ์';
+  String get unpairDeviceDialogMessage => 'การดำเนินการนี้จะยกเลิกการจับคู่อุปกรณ์เพื่อให้สามารถเชื่อมต่อกับโทรศัพท์เครื่องอื่นได้ คุณจะต้องไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำกระบวนการให้เสร็จสมบูรณ์';
 
   @override
   String get unpair => 'ยกเลิกการจับคู่';
@@ -2553,8 +2525,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get youreAllSet => 'คุณพร้อมแล้ว!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'ยินดีต้อนรับสู่ Omi! คู่หูAIของคุณพร้อมที่จะช่วยเหลือคุณในการสนทนา งาน และอื่นๆ';
+  String get welcomeToOmiDescription => 'ยินดีต้อนรับสู่ Omi! คู่หูAIของคุณพร้อมที่จะช่วยเหลือคุณในการสนทนา งาน และอื่นๆ';
 
   @override
   String get startUsingOmi => 'เริ่มใช้ Omi';
@@ -2747,8 +2718,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deleteActionItem => 'ลบรายการงาน';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'คุณแน่ใจหรือไม่ว่าต้องการลบรายการงานนี้ การดำเนินการนี้ไม่สามารถยกเลิกได้';
+  String get deleteActionItemConfirmation => 'คุณแน่ใจหรือไม่ว่าต้องการลบรายการงานนี้ การดำเนินการนี้ไม่สามารถยกเลิกได้';
 
   @override
   String get enterActionItemDescription => 'ป้อนคำอธิบายรายการงาน...';
@@ -2856,12 +2826,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get submitAppQuestion => 'ส่งแอปหรือไม่?';
 
   @override
-  String get submitAppPublicDescription =>
-      'แอปของคุณจะได้รับการตรวจสอบและเผยแพร่สู่สาธารณะ คุณสามารถเริ่มใช้งานได้ทันที แม้ในระหว่างการตรวจสอบ!';
+  String get submitAppPublicDescription => 'แอปของคุณจะได้รับการตรวจสอบและเผยแพร่สู่สาธารณะ คุณสามารถเริ่มใช้งานได้ทันที แม้ในระหว่างการตรวจสอบ!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'แอปของคุณจะได้รับการตรวจสอบและเปิดให้คุณใช้งานแบบส่วนตัว คุณสามารถเริ่มใช้งานได้ทันที แม้ในระหว่างการตรวจสอบ!';
+  String get submitAppPrivateDescription => 'แอปของคุณจะได้รับการตรวจสอบและเปิดให้คุณใช้งานแบบส่วนตัว คุณสามารถเริ่มใช้งานได้ทันที แม้ในระหว่างการตรวจสอบ!';
 
   @override
   String get startEarning => 'เริ่มหารายได้! 💰';
@@ -2885,19 +2853,16 @@ class AppLocalizationsTh extends AppLocalizations {
   String get dataAccessNotice => 'ประกาศการเข้าถึงข้อมูล';
 
   @override
-  String get dataAccessWarning =>
-      'แอปนี้จะเข้าถึงข้อมูลของคุณ Omi AI ไม่รับผิดชอบต่อวิธีการใช้ แก้ไข หรือลบข้อมูลของคุณโดยแอปนี้';
+  String get dataAccessWarning => 'แอปนี้จะเข้าถึงข้อมูลของคุณ Omi AI ไม่รับผิดชอบต่อวิธีการใช้ แก้ไข หรือลบข้อมูลของคุณโดยแอปนี้';
 
   @override
   String get installApp => 'ติดตั้งแอป';
 
   @override
-  String get betaTesterNotice =>
-      'คุณเป็นผู้ทดสอบเบต้าสำหรับแอปนี้ ยังไม่เปิดเผยต่อสาธารณะ จะเปิดเผยต่อสาธารณะเมื่อได้รับการอนุมัติ';
+  String get betaTesterNotice => 'คุณเป็นผู้ทดสอบเบต้าสำหรับแอปนี้ ยังไม่เปิดเผยต่อสาธารณะ จะเปิดเผยต่อสาธารณะเมื่อได้รับการอนุมัติ';
 
   @override
-  String get appUnderReviewOwner =>
-      'แอปของคุณกำลังอยู่ในระหว่างการตรวจสอบและมองเห็นได้เฉพาะคุณเท่านั้น จะเปิดเผยต่อสาธารณะเมื่อได้รับการอนุมัติ';
+  String get appUnderReviewOwner => 'แอปของคุณกำลังอยู่ในระหว่างการตรวจสอบและมองเห็นได้เฉพาะคุณเท่านั้น จะเปิดเผยต่อสาธารณะเมื่อได้รับการอนุมัติ';
 
   @override
   String get appRejectedNotice => 'แอปของคุณถูกปฏิเสธ โปรดอัปเดตรายละเอียดแอปและส่งอีกครั้งเพื่อตรวจสอบ';
@@ -2962,8 +2927,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get descriptionLabel => 'คำอธิบาย';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'แอปที่ยอดเยี่ยมของฉันเป็นแอปที่ยอดเยี่ยมที่ทำสิ่งที่น่าทึ่ง มันเป็นแอปที่ดีที่สุด!';
+  String get appDescriptionPlaceholder => 'แอปที่ยอดเยี่ยมของฉันเป็นแอปที่ยอดเยี่ยมที่ทำสิ่งที่น่าทึ่ง มันเป็นแอปที่ดีที่สุด!';
 
   @override
   String get pleaseProvideValidDescription => 'กรุณาให้คำอธิบายที่ถูกต้อง';
@@ -3115,8 +3079,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get microphonePermissionRequired => 'ต้องการสิทธิ์การใช้ไมโครโฟนสำหรับการบันทึกเสียง';
 
   @override
-  String get microphonePermissionDenied =>
-      'สิทธิ์การใช้ไมโครโฟนถูกปฏิเสธ กรุณาอนุญาตสิทธิ์ใน การตั้งค่าระบบ > ความเป็นส่วนตัวและความปลอดภัย > ไมโครโฟน';
+  String get microphonePermissionDenied => 'สิทธิ์การใช้ไมโครโฟนถูกปฏิเสธ กรุณาอนุญาตสิทธิ์ใน การตั้งค่าระบบ > ความเป็นส่วนตัวและความปลอดภัย > ไมโครโฟน';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3349,8 +3312,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get whatWeCollect => 'สิ่งที่เราเก็บรวบรวม';
 
   @override
-  String get dataCollectionMessage =>
-      'การดำเนินการต่อจะทำให้การสนทนา การบันทึก และข้อมูลส่วนบุคคลของคุณถูกเก็บไว้อย่างปลอดภัยบนเซิร์ฟเวอร์ของเราเพื่อมอบข้อมูลเชิงลึกที่ขับเคลื่อนด้วย AI และเปิดใช้งานคุณสมบัติทั้งหมดของแอป';
+  String get dataCollectionMessage => 'การดำเนินการต่อจะทำให้การสนทนา การบันทึก และข้อมูลส่วนบุคคลของคุณถูกเก็บไว้อย่างปลอดภัยบนเซิร์ฟเวอร์ของเราเพื่อมอบข้อมูลเชิงลึกที่ขับเคลื่อนด้วย AI และเปิดใช้งานคุณสมบัติทั้งหมดของแอป';
 
   @override
   String get dataProtection => 'การป้องกันข้อมูล';
@@ -3383,8 +3345,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'ชื่อต้องมีอย่างน้อย 2 ตัวอักษร';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'บอกเราว่าคุณต้องการให้เรียกคุณอย่างไร นี่จะช่วยปรับแต่งประสบการณ์ Omi ของคุณ';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'บอกเราว่าคุณต้องการให้เรียกคุณอย่างไร นี่จะช่วยปรับแต่งประสบการณ์ Omi ของคุณ';
 
   @override
   String charactersCount(int count) {
@@ -3410,8 +3371,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'จับภาพเสียงระบบจากการประชุม';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi ต้องการสิทธิ์ในการบันทึกหน้าจอเพื่อจับภาพเสียงระบบจากการประชุมที่ใช้เบราว์เซอร์ของคุณ';
+  String get screenRecordingDescription => 'Omi ต้องการสิทธิ์ในการบันทึกหน้าจอเพื่อจับภาพเสียงระบบจากการประชุมที่ใช้เบราว์เซอร์ของคุณ';
 
   @override
   String get accessibility => 'การเข้าถึง';
@@ -3420,8 +3380,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'ตรวจจับการประชุมที่ใช้เบราว์เซอร์';
 
   @override
-  String get accessibilityDescription =>
-      'Omi ต้องการสิทธิ์การเข้าถึงเพื่อตรวจจับเมื่อคุณเข้าร่วมการประชุม Zoom, Meet หรือ Teams ในเบราว์เซอร์ของคุณ';
+  String get accessibilityDescription => 'Omi ต้องการสิทธิ์การเข้าถึงเพื่อตรวจจับเมื่อคุณเข้าร่วมการประชุม Zoom, Meet หรือ Teams ในเบราว์เซอร์ของคุณ';
 
   @override
   String get pleaseWait => 'กรุณารอสักครู่...';
@@ -3493,8 +3452,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get conversationsExportStarted => 'เริ่มการส่งออกการสนทนาแล้ว อาจใช้เวลาสักครู่ โปรดรอสักครู่';
 
   @override
-  String get mcpDescription =>
-      'เพื่อเชื่อมต่อ Omi กับแอปพลิเคชันอื่น ๆ เพื่ออ่าน ค้นหา และจัดการความทรงจำและการสนทนาของคุณ สร้างคีย์เพื่อเริ่มต้น';
+  String get mcpDescription => 'เพื่อเชื่อมต่อ Omi กับแอปพลิเคชันอื่น ๆ เพื่ออ่าน ค้นหา และจัดการความทรงจำและการสนทนาของคุณ สร้างคีย์เพื่อเริ่มต้น';
 
   @override
   String get apiKeys => 'คีย์ API';
@@ -3650,8 +3608,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get preparingSystemAudioCapture => 'กำลังเตรียมการจับภาพเสียงของระบบ';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'คลิกปุ่มเพื่อจับภาพเสียงสำหรับการถอดความสด ข้อมูลเชิงลึกของ AI และการบันทึกอัตโนมัติ';
+  String get clickTheButtonToCaptureAudio => 'คลิกปุ่มเพื่อจับภาพเสียงสำหรับการถอดความสด ข้อมูลเชิงลึกของ AI และการบันทึกอัตโนมัติ';
 
   @override
   String get reconnecting => 'กำลังเชื่อมต่อใหม่...';
@@ -3878,8 +3835,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'ลบกราฟความรู้หรือไม่';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'การดำเนินการนี้จะลบข้อมูลกราฟความรู้ที่ได้รับทั้งหมด ความทรงจำต้นฉบับของคุณจะยังคงปลอดภัย';
+  String get deleteKnowledgeGraphWarning => 'การดำเนินการนี้จะลบข้อมูลกราฟความรู้ที่ได้รับทั้งหมด ความทรงจำต้นฉบับของคุณจะยังคงปลอดภัย';
 
   @override
   String get connectOmiWithAI => 'เชื่อมต่อ Omi กับผู้ช่วย AI';
@@ -3966,8 +3922,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get no => 'ไม่';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'ยกเลิกการสมัครสมาชิกสำเร็จ จะยังคงใช้งานได้จนถึงสิ้นสุดรอบบิลปัจจุบัน';
+  String get subscriptionCancelledSuccessfully => 'ยกเลิกการสมัครสมาชิกสำเร็จ จะยังคงใช้งานได้จนถึงสิ้นสุดรอบบิลปัจจุบัน';
 
   @override
   String get failedToCancelSubscription => 'ไม่สามารถยกเลิกการสมัครสมาชิกได้ กรุณาลองอีกครั้ง';
@@ -4003,8 +3958,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'ยกเลิกการสมัครสมาชิก?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'คุณแน่ใจหรือไม่ว่าต้องการยกเลิกการสมัครสมาชิก? คุณจะยังคงเข้าถึงได้จนถึงสิ้นสุดรอบบิลปัจจุบัน';
+  String get cancelSubscriptionConfirmation => 'คุณแน่ใจหรือไม่ว่าต้องการยกเลิกการสมัครสมาชิก? คุณจะยังคงเข้าถึงได้จนถึงสิ้นสุดรอบบิลปัจจุบัน';
 
   @override
   String get cancelSubscriptionButton => 'ยกเลิกการสมัครสมาชิก';
@@ -4013,12 +3967,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get cancelling => 'กำลังยกเลิก...';
 
   @override
-  String get betaTesterMessage =>
-      'คุณเป็นผู้ทดสอบเบต้าของแอปนี้ ยังไม่เปิดให้สาธารณะ จะเปิดให้สาธารณะเมื่อได้รับการอนุมัติ';
+  String get betaTesterMessage => 'คุณเป็นผู้ทดสอบเบต้าของแอปนี้ ยังไม่เปิดให้สาธารณะ จะเปิดให้สาธารณะเมื่อได้รับการอนุมัติ';
 
   @override
-  String get appUnderReviewMessage =>
-      'แอปของคุณกำลังอยู่ระหว่างการตรวจสอบและมองเห็นได้เฉพาะคุณ จะเปิดให้สาธารณะเมื่อได้รับการอนุมัติ';
+  String get appUnderReviewMessage => 'แอปของคุณกำลังอยู่ระหว่างการตรวจสอบและมองเห็นได้เฉพาะคุณ จะเปิดให้สาธารณะเมื่อได้รับการอนุมัติ';
 
   @override
   String get appRejectedMessage => 'แอปของคุณถูกปฏิเสธ กรุณาอัปเดตรายละเอียดและส่งใหม่เพื่อตรวจสอบ';
@@ -4075,8 +4027,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get issueActivatingApp => 'เกิดปัญหาในการเปิดใช้งานแอปนี้ กรุณาลองอีกครั้ง';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'แอปนี้จะเข้าถึงข้อมูลของคุณ Omi AI ไม่รับผิดชอบต่อวิธีการใช้ แก้ไข หรือลบข้อมูลของคุณโดยแอปนี้';
+  String get dataAccessNoticeDescription => 'แอปนี้จะเข้าถึงข้อมูลของคุณ Omi AI ไม่รับผิดชอบต่อวิธีการใช้ แก้ไข หรือลบข้อมูลของคุณโดยแอปนี้';
 
   @override
   String get copyUrl => 'คัดลอก URL';
@@ -4164,8 +4115,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get omiApiKeys => 'คีย์ API ของ Omi';
 
   @override
-  String get apiKeysDescription =>
-      'คีย์ API ใช้สำหรับการยืนยันตัวตนเมื่อแอปของคุณสื่อสารกับเซิร์ฟเวอร์ OMI ช่วยให้แอปพลิเคชันของคุณสร้างความทรงจำและเข้าถึงบริการ OMI อื่นๆ ได้อย่างปลอดภัย';
+  String get apiKeysDescription => 'คีย์ API ใช้สำหรับการยืนยันตัวตนเมื่อแอปของคุณสื่อสารกับเซิร์ฟเวอร์ OMI ช่วยให้แอปพลิเคชันของคุณสร้างความทรงจำและเข้าถึงบริการ OMI อื่นๆ ได้อย่างปลอดภัย';
 
   @override
   String get aboutOmiApiKeys => 'เกี่ยวกับคีย์ API ของ Omi';
@@ -4189,8 +4139,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get revokeApiKeyQuestion => 'เพิกถอนคีย์ API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'การดำเนินการนี้ไม่สามารถยกเลิกได้ แอปพลิเคชันใดๆ ที่ใช้คีย์นี้จะไม่สามารถเข้าถึง API ได้อีกต่อไป';
+  String get revokeApiKeyWarning => 'การดำเนินการนี้ไม่สามารถยกเลิกได้ แอปพลิเคชันใดๆ ที่ใช้คีย์นี้จะไม่สามารถเข้าถึง API ได้อีกต่อไป';
 
   @override
   String get revoke => 'เพิกถอน';
@@ -4288,8 +4237,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get externalAppAccess => 'การเข้าถึงแอปภายนอก';
 
   @override
-  String get externalAppAccessDescription =>
-      'แอปที่ติดตั้งต่อไปนี้มีการเชื่อมต่อภายนอกและสามารถเข้าถึงข้อมูลของคุณ เช่น การสนทนาและความทรงจำ';
+  String get externalAppAccessDescription => 'แอปที่ติดตั้งต่อไปนี้มีการเชื่อมต่อภายนอกและสามารถเข้าถึงข้อมูลของคุณ เช่น การสนทนาและความทรงจำ';
 
   @override
   String get noExternalAppsHaveAccess => 'ไม่มีแอปภายนอกที่สามารถเข้าถึงข้อมูลของคุณ';
@@ -4298,8 +4246,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get maximumSecurityE2ee => 'ความปลอดภัยสูงสุด (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'การเข้ารหัสแบบ end-to-end เป็นมาตรฐานทองคำสำหรับความเป็นส่วนตัว เมื่อเปิดใช้งาน ข้อมูลของคุณจะถูกเข้ารหัสบนอุปกรณ์ของคุณก่อนที่จะส่งไปยังเซิร์ฟเวอร์ของเรา ซึ่งหมายความว่าไม่มีใคร แม้แต่ Omi สามารถเข้าถึงเนื้อหาของคุณได้';
+  String get e2eeDescription => 'การเข้ารหัสแบบ end-to-end เป็นมาตรฐานทองคำสำหรับความเป็นส่วนตัว เมื่อเปิดใช้งาน ข้อมูลของคุณจะถูกเข้ารหัสบนอุปกรณ์ของคุณก่อนที่จะส่งไปยังเซิร์ฟเวอร์ของเรา ซึ่งหมายความว่าไม่มีใคร แม้แต่ Omi สามารถเข้าถึงเนื้อหาของคุณได้';
 
   @override
   String get importantTradeoffs => 'ข้อควรพิจารณาที่สำคัญ:';
@@ -4314,8 +4261,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get featureComingSoon => 'คุณสมบัตินี้จะมาเร็วๆ นี้!';
 
   @override
-  String get migrationInProgressMessage =>
-      'การย้ายข้อมูลกำลังดำเนินการ คุณไม่สามารถเปลี่ยนระดับการป้องกันจนกว่าจะเสร็จสิ้น';
+  String get migrationInProgressMessage => 'การย้ายข้อมูลกำลังดำเนินการ คุณไม่สามารถเปลี่ยนระดับการป้องกันจนกว่าจะเสร็จสิ้น';
 
   @override
   String get migrationFailed => 'การย้ายข้อมูลล้มเหลว';
@@ -4334,15 +4280,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get secureEncryption => 'การเข้ารหัสที่ปลอดภัย';
 
   @override
-  String get secureEncryptionDescription =>
-      'ข้อมูลของคุณถูกเข้ารหัสด้วยคีย์ที่ไม่ซ้ำกันสำหรับคุณบนเซิร์ฟเวอร์ของเรา ซึ่งโฮสต์บน Google Cloud ซึ่งหมายความว่าเนื้อหาดิบของคุณไม่สามารถเข้าถึงได้โดยใครก็ตาม รวมถึงพนักงาน Omi หรือ Google โดยตรงจากฐานข้อมูล';
+  String get secureEncryptionDescription => 'ข้อมูลของคุณถูกเข้ารหัสด้วยคีย์ที่ไม่ซ้ำกันสำหรับคุณบนเซิร์ฟเวอร์ของเรา ซึ่งโฮสต์บน Google Cloud ซึ่งหมายความว่าเนื้อหาดิบของคุณไม่สามารถเข้าถึงได้โดยใครก็ตาม รวมถึงพนักงาน Omi หรือ Google โดยตรงจากฐานข้อมูล';
 
   @override
   String get endToEndEncryption => 'การเข้ารหัสแบบ end-to-end';
 
   @override
-  String get e2eeCardDescription =>
-      'เปิดใช้งานเพื่อความปลอดภัยสูงสุดที่มีเพียงคุณเท่านั้นที่สามารถเข้าถึงข้อมูลของคุณ แตะเพื่อเรียนรู้เพิ่มเติม';
+  String get e2eeCardDescription => 'เปิดใช้งานเพื่อความปลอดภัยสูงสุดที่มีเพียงคุณเท่านั้นที่สามารถเข้าถึงข้อมูลของคุณ แตะเพื่อเรียนรู้เพิ่มเติม';
 
   @override
   String get dataAlwaysEncrypted => 'ไม่ว่าระดับใด ข้อมูลของคุณจะถูกเข้ารหัสเสมอทั้งขณะพักและขณะส่ง';
@@ -4413,8 +4357,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get getOmiUnlimitedFree => 'รับ Omi Unlimited ฟรีโดยการมีส่วนร่วมข้อมูลของคุณเพื่อฝึกโมเดล AI';
 
   @override
-  String get trainingDataBullets =>
-      '• ข้อมูลของคุณช่วยปรับปรุงโมเดล AI\n• แชร์เฉพาะข้อมูลที่ไม่ละเอียดอ่อน\n• กระบวนการที่โปร่งใสอย่างสมบูรณ์';
+  String get trainingDataBullets => '• ข้อมูลของคุณช่วยปรับปรุงโมเดล AI\n• แชร์เฉพาะข้อมูลที่ไม่ละเอียดอ่อน\n• กระบวนการที่โปร่งใสอย่างสมบูรณ์';
 
   @override
   String get learnMoreAtOmiTraining => 'เรียนรู้เพิ่มเติมที่ omi.me/training';
@@ -4426,8 +4369,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get submitRequest => 'ส่งคำขอ';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'ขอบคุณ! คำขอของคุณอยู่ระหว่างการตรวจสอบ เราจะแจ้งให้คุณทราบเมื่อได้รับการอนุมัติ';
+  String get thankYouRequestUnderReview => 'ขอบคุณ! คำขอของคุณอยู่ระหว่างการตรวจสอบ เราจะแจ้งให้คุณทราบเมื่อได้รับการอนุมัติ';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4465,8 +4407,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get monthlyPlanContinues => 'แพ็คเกจรายเดือนปัจจุบันของคุณจะดำเนินต่อไปจนถึงสิ้นสุดรอบการเรียกเก็บเงิน';
 
   @override
-  String get paymentMethodCharged =>
-      'วิธีการชำระเงินที่มีอยู่ของคุณจะถูกเรียกเก็บโดยอัตโนมัติเมื่อแพ็คเกจรายเดือนของคุณสิ้นสุด';
+  String get paymentMethodCharged => 'วิธีการชำระเงินที่มีอยู่ของคุณจะถูกเรียกเก็บโดยอัตโนมัติเมื่อแพ็คเกจรายเดือนของคุณสิ้นสุด';
 
   @override
   String get annualSubscriptionStarts => 'การสมัครรายปี 12 เดือนของคุณจะเริ่มโดยอัตโนมัติหลังจากการเรียกเก็บเงิน';
@@ -4576,8 +4517,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'ความเป็นส่วนตัวของคุณสำคัญสำหรับเรา';
 
   @override
-  String get privacyIntroText =>
-      'ที่ Omi เราให้ความสำคัญกับความเป็นส่วนตัวของคุณอย่างจริงจัง เราต้องการมีความโปร่งใสเกี่ยวกับข้อมูลที่เรารวบรวมและวิธีการใช้งาน นี่คือสิ่งที่คุณต้องรู้:';
+  String get privacyIntroText => 'ที่ Omi เราให้ความสำคัญกับความเป็นส่วนตัวของคุณอย่างจริงจัง เราต้องการมีความโปร่งใสเกี่ยวกับข้อมูลที่เรารวบรวมและวิธีการใช้งาน นี่คือสิ่งที่คุณต้องรู้:';
 
   @override
   String get whatWeTrack => 'สิ่งที่เราติดตาม';
@@ -4592,12 +4532,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get ourCommitment => 'คำมั่นสัญญาของเรา';
 
   @override
-  String get commitmentText =>
-      'เรามุ่งมั่นที่จะใช้ข้อมูลที่เรารวบรวมเพียงเพื่อทำให้ Omi เป็นผลิตภัณฑ์ที่ดีขึ้นสำหรับคุณ ความเป็นส่วนตัวและความไว้วางใจของคุณเป็นสิ่งสำคัญที่สุดสำหรับเรา';
+  String get commitmentText => 'เรามุ่งมั่นที่จะใช้ข้อมูลที่เรารวบรวมเพียงเพื่อทำให้ Omi เป็นผลิตภัณฑ์ที่ดีขึ้นสำหรับคุณ ความเป็นส่วนตัวและความไว้วางใจของคุณเป็นสิ่งสำคัญที่สุดสำหรับเรา';
 
   @override
-  String get thankYouText =>
-      'ขอบคุณที่เป็นผู้ใช้ที่มีคุณค่าของ Omi หากคุณมีคำถามหรือข้อกังวลใดๆ โปรดติดต่อเราที่ team@basedhardware.com';
+  String get thankYouText => 'ขอบคุณที่เป็นผู้ใช้ที่มีคุณค่าของ Omi หากคุณมีคำถามหรือข้อกังวลใดๆ โปรดติดต่อเราที่ team@basedhardware.com';
 
   @override
   String get wifiSyncSettings => 'การตั้งค่าการซิงค์ WiFi';
@@ -4606,8 +4544,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get enterHotspotCredentials => 'ป้อนข้อมูลรับรองฮอตสปอตของโทรศัพท์';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'การซิงค์ WiFi ใช้โทรศัพท์ของคุณเป็นฮอตสปอต ค้นหาชื่อและรหัสผ่านในการตั้งค่า > ฮอตสปอตส่วนตัว';
+  String get wifiSyncUsesHotspot => 'การซิงค์ WiFi ใช้โทรศัพท์ของคุณเป็นฮอตสปอต ค้นหาชื่อและรหัสผ่านในการตั้งค่า > ฮอตสปอตส่วนตัว';
 
   @override
   String get hotspotNameSsid => 'ชื่อฮอตสปอต (SSID)';
@@ -4642,8 +4579,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'ไม่สามารถสร้างสรุปได้ ตรวจสอบให้แน่ใจว่าคุณมีการสนทนาสำหรับวันนั้น';
+  String get failedToGenerateSummaryCheckConversations => 'ไม่สามารถสร้างสรุปได้ ตรวจสอบให้แน่ใจว่าคุณมีการสนทนาสำหรับวันนั้น';
 
   @override
   String get summaryNotFound => 'ไม่พบสรุป';
@@ -4673,8 +4609,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'เริ่มส่งออกแล้ว อาจใช้เวลาสักครู่...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'การดำเนินการนี้จะลบข้อมูลกราฟความรู้ที่ได้มาทั้งหมด (โหนดและการเชื่อมต่อ) ความทรงจำดั้งเดิมของคุณจะยังคงปลอดภัย กราฟจะถูกสร้างขึ้นใหม่เมื่อเวลาผ่านไปหรือเมื่อมีการร้องขอครั้งต่อไป';
+  String get knowledgeGraphDeleteDescription => 'การดำเนินการนี้จะลบข้อมูลกราฟความรู้ที่ได้มาทั้งหมด (โหนดและการเชื่อมต่อ) ความทรงจำดั้งเดิมของคุณจะยังคงปลอดภัย กราฟจะถูกสร้างขึ้นใหม่เมื่อเวลาผ่านไปหรือเมื่อมีการร้องขอครั้งต่อไป';
 
   @override
   String get configureDailySummaryDigest => 'กำหนดค่าสรุปงานประจำวันของคุณ';
@@ -4744,8 +4679,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'ลบการสนทนา Limitless ทั้งหมด?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'การดำเนินการนี้จะลบการสนทนาทั้งหมดที่นำเข้าจาก Limitless อย่างถาวร ไม่สามารถยกเลิกการกระทำนี้ได้';
+  String get deleteAllLimitlessWarning => 'การดำเนินการนี้จะลบการสนทนาทั้งหมดที่นำเข้าจาก Limitless อย่างถาวร ไม่สามารถยกเลิกการกระทำนี้ได้';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4801,8 +4735,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get howItWorksTitle => 'มันทำงานอย่างไร?';
 
   @override
-  String get howPeopleWorks =>
-      'เมื่อสร้างบุคคลแล้ว คุณสามารถไปที่การถอดเสียงบทสนทนาและกำหนดส่วนที่เกี่ยวข้องให้พวกเขา ด้วยวิธีนี้ Omi จะสามารถจดจำเสียงพูดของพวกเขาได้เช่นกัน!';
+  String get howPeopleWorks => 'เมื่อสร้างบุคคลแล้ว คุณสามารถไปที่การถอดเสียงบทสนทนาและกำหนดส่วนที่เกี่ยวข้องให้พวกเขา ด้วยวิธีนี้ Omi จะสามารถจดจำเสียงพูดของพวกเขาได้เช่นกัน!';
 
   @override
   String get tapToDelete => 'แตะเพื่อลบ';
@@ -4828,8 +4761,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get privacyNotice => 'ประกาศความเป็นส่วนตัว';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'การบันทึกอาจบันทึกเสียงของผู้อื่น ตรวจสอบให้แน่ใจว่าคุณได้รับความยินยอมจากผู้เข้าร่วมทุกคนก่อนเปิดใช้งาน';
+  String get recordingsMayCaptureOthers => 'การบันทึกอาจบันทึกเสียงของผู้อื่น ตรวจสอบให้แน่ใจว่าคุณได้รับความยินยอมจากผู้เข้าร่วมทุกคนก่อนเปิดใช้งาน';
 
   @override
   String get enable => 'เปิดใช้งาน';
@@ -4841,8 +4773,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get on => 'เปิด';
 
   @override
-  String get storeAudioDescription =>
-      'เก็บการบันทึกเสียงทั้งหมดไว้ในโทรศัพท์ของคุณ เมื่อปิดใช้งาน จะเก็บเฉพาะการอัปโหลดที่ล้มเหลวเพื่อประหยัดพื้นที่';
+  String get storeAudioDescription => 'เก็บการบันทึกเสียงทั้งหมดไว้ในโทรศัพท์ของคุณ เมื่อปิดใช้งาน จะเก็บเฉพาะการอัปโหลดที่ล้มเหลวเพื่อประหยัดพื้นที่';
 
   @override
   String get enableLocalStorage => 'เปิดใช้งานที่เก็บข้อมูลในเครื่อง';
@@ -4860,12 +4791,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get storeAudioOnCloud => 'จัดเก็บเสียงบนคลาวด์';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'การบันทึกแบบเรียลไทม์ของคุณจะถูกเก็บไว้ในที่เก็บข้อมูลคลาวด์ส่วนตัวขณะที่คุณพูด';
+  String get cloudStorageDialogMessage => 'การบันทึกแบบเรียลไทม์ของคุณจะถูกเก็บไว้ในที่เก็บข้อมูลคลาวด์ส่วนตัวขณะที่คุณพูด';
 
   @override
-  String get storeAudioCloudDescription =>
-      'เก็บการบันทึกแบบเรียลไทม์ของคุณในที่เก็บข้อมูลคลาวด์ส่วนตัวขณะที่คุณพูด เสียงจะถูกบันทึกและบันทึกอย่างปลอดภัยแบบเรียลไทม์';
+  String get storeAudioCloudDescription => 'เก็บการบันทึกแบบเรียลไทม์ของคุณในที่เก็บข้อมูลคลาวด์ส่วนตัวขณะที่คุณพูด เสียงจะถูกบันทึกและบันทึกอย่างปลอดภัยแบบเรียลไทม์';
 
   @override
   String get downloadingFirmware => 'กำลังดาวน์โหลดเฟิร์มแวร์';
@@ -4972,8 +4901,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get connectingYourStripeAccount => 'กำลังเชื่อมต่อบัญชี Stripe ของคุณ';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'กรุณาดำเนินการลงทะเบียน Stripe ให้เสร็จสิ้นในเบราว์เซอร์ของคุณ หน้านี้จะอัปเดตโดยอัตโนมัติเมื่อเสร็จสิ้น';
+  String get stripeOnboardingInstructions => 'กรุณาดำเนินการลงทะเบียน Stripe ให้เสร็จสิ้นในเบราว์เซอร์ของคุณ หน้านี้จะอัปเดตโดยอัตโนมัติเมื่อเสร็จสิ้น';
 
   @override
   String get failedTryAgain => 'ล้มเหลว? ลองอีกครั้ง';
@@ -4985,8 +4913,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get successfullyConnected => 'เชื่อมต่อสำเร็จ!';
 
   @override
-  String get stripeReadyForPayments =>
-      'บัญชี Stripe ของคุณพร้อมรับการชำระเงินแล้ว คุณสามารถเริ่มสร้างรายได้จากการขายแอปได้ทันที';
+  String get stripeReadyForPayments => 'บัญชี Stripe ของคุณพร้อมรับการชำระเงินแล้ว คุณสามารถเริ่มสร้างรายได้จากการขายแอปได้ทันที';
 
   @override
   String get updateStripeDetails => 'อัปเดตรายละเอียด Stripe';
@@ -5013,8 +4940,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get paypalMeLink => 'ลิงก์ PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'หาก Stripe พร้อมใช้งานในประเทศของคุณ เราขอแนะนำอย่างยิ่งให้ใช้เพื่อการจ่ายเงินที่รวดเร็วและง่ายขึ้น';
+  String get stripeRecommendation => 'หาก Stripe พร้อมใช้งานในประเทศของคุณ เราขอแนะนำอย่างยิ่งให้ใช้เพื่อการจ่ายเงินที่รวดเร็วและง่ายขึ้น';
 
   @override
   String get updatePayPalDetails => 'อัปเดตรายละเอียด PayPal';
@@ -5066,8 +4992,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'ลบตัวอย่างเสียงเพิ่มเติมแล้ว';
 
   @override
-  String get consentDataMessage =>
-      'เมื่อดำเนินการต่อ การสนทนา การบันทึก และข้อมูลส่วนบุคคลของคุณจะถูกจัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ของเรา การบันทึกเสียงและการถอดความของคุณจะถูกประมวลผลโดยบริการ AI ของบุคคลที่สาม (รวมถึง Deepgram สำหรับการถอดความ และ OpenAI สำหรับการวิเคราะห์) เพื่อมอบข้อมูลเชิงลึกที่ขับเคลื่อนด้วย AI และเปิดใช้งานคุณสมบัติทั้งหมดของแอป';
+  String get consentDataMessage => 'เมื่อดำเนินการต่อ การสนทนา การบันทึก และข้อมูลส่วนบุคคลของคุณจะถูกจัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ของเรา การบันทึกเสียงและการถอดความของคุณจะถูกประมวลผลโดยบริการ AI ของบุคคลที่สาม (รวมถึง Deepgram สำหรับการถอดความ และ OpenAI สำหรับการวิเคราะห์) เพื่อมอบข้อมูลเชิงลึกที่ขับเคลื่อนด้วย AI และเปิดใช้งานคุณสมบัติทั้งหมดของแอป';
 
   @override
   String get tasksEmptyStateMessage => 'งานจากการสนทนาของคุณจะปรากฏที่นี่\nแตะ + เพื่อสร้างด้วยตนเอง';
@@ -5106,8 +5031,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get installOmiOnAppleWatch => 'ติดตั้ง Omi บน\nApple Watch ของคุณ';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'หากต้องการใช้ Apple Watch กับ Omi คุณต้องติดตั้งแอป Omi บนนาฬิกาก่อน';
+  String get installOmiOnAppleWatchDescription => 'หากต้องการใช้ Apple Watch กับ Omi คุณต้องติดตั้งแอป Omi บนนาฬิกาก่อน';
 
   @override
   String get openOmiOnAppleWatch => 'เปิด Omi บน\nApple Watch ของคุณ';
@@ -5122,15 +5046,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'ฉันได้ติดตั้งและเปิดแอปแล้ว';
 
   @override
-  String get unableToOpenWatchApp =>
-      'ไม่สามารถเปิดแอป Apple Watch ได้ กรุณาเปิดแอป Watch บน Apple Watch ด้วยตนเองและติดตั้ง Omi จากส่วน \"แอปที่มี\"';
+  String get unableToOpenWatchApp => 'ไม่สามารถเปิดแอป Apple Watch ได้ กรุณาเปิดแอป Watch บน Apple Watch ด้วยตนเองและติดตั้ง Omi จากส่วน \"แอปที่มี\"';
 
   @override
   String get appleWatchConnectedSuccessfully => 'เชื่อมต่อ Apple Watch สำเร็จ!';
 
   @override
-  String get appleWatchNotReachable =>
-      'ยังไม่สามารถเข้าถึง Apple Watch ได้ โปรดตรวจสอบว่าแอป Omi เปิดอยู่บนนาฬิกาของคุณ';
+  String get appleWatchNotReachable => 'ยังไม่สามารถเข้าถึง Apple Watch ได้ โปรดตรวจสอบว่าแอป Omi เปิดอยู่บนนาฬิกาของคุณ';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5558,8 +5480,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get multipleSpeakersDetected => 'ตรวจพบผู้พูดหลายคน';
 
   @override
-  String get multipleSpeakersDescription =>
-      'ดูเหมือนว่าจะมีผู้พูดหลายคนในการบันทึก กรุณาตรวจสอบว่าคุณอยู่ในที่เงียบและลองอีกครั้ง';
+  String get multipleSpeakersDescription => 'ดูเหมือนว่าจะมีผู้พูดหลายคนในการบันทึก กรุณาตรวจสอบว่าคุณอยู่ในที่เงียบและลองอีกครั้ง';
 
   @override
   String get invalidRecordingDetected => 'ตรวจพบการบันทึกที่ไม่ถูกต้อง';
@@ -5571,15 +5492,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get speechDurationDescription => 'กรุณาตรวจสอบว่าคุณพูดอย่างน้อย 5 วินาทีและไม่เกิน 90 วินาที';
 
   @override
-  String get connectionLostDescription =>
-      'การเชื่อมต่อถูกขัดจังหวะ กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง';
+  String get connectionLostDescription => 'การเชื่อมต่อถูกขัดจังหวะ กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง';
 
   @override
   String get howToTakeGoodSample => 'วิธีการทำตัวอย่างที่ดี?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. ตรวจสอบว่าคุณอยู่ในที่เงียบ\n2. พูดชัดเจนและเป็นธรรมชาติ\n3. ตรวจสอบว่าอุปกรณ์ของคุณอยู่ในตำแหน่งธรรมชาติบนคอของคุณ\n\nเมื่อสร้างแล้ว คุณสามารถปรับปรุงหรือทำใหม่ได้เสมอ';
+  String get goodSampleInstructions => '1. ตรวจสอบว่าคุณอยู่ในที่เงียบ\n2. พูดชัดเจนและเป็นธรรมชาติ\n3. ตรวจสอบว่าอุปกรณ์ของคุณอยู่ในตำแหน่งธรรมชาติบนคอของคุณ\n\nเมื่อสร้างแล้ว คุณสามารถปรับปรุงหรือทำใหม่ได้เสมอ';
 
   @override
   String get noDeviceConnectedUseMic => 'ไม่มีอุปกรณ์ที่เชื่อมต่อ จะใช้ไมโครโฟนของโทรศัพท์';
@@ -6025,8 +5944,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get viewUsage => 'ดูการใช้งาน';
 
   @override
-  String get localProcessingInfo =>
-      'เสียงถูกประมวลผลในเครื่อง ใช้งานออฟไลน์ได้ เป็นส่วนตัวมากขึ้น แต่ใช้แบตเตอรี่มากขึ้น';
+  String get localProcessingInfo => 'เสียงถูกประมวลผลในเครื่อง ใช้งานออฟไลน์ได้ เป็นส่วนตัวมากขึ้น แต่ใช้แบตเตอรี่มากขึ้น';
 
   @override
   String get model => 'โมเดล';
@@ -6035,8 +5953,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get performanceWarning => 'คำเตือนเกี่ยวกับประสิทธิภาพ';
 
   @override
-  String get largeModelWarning =>
-      'โมเดลนี้มีขนาดใหญ่และอาจทำให้แอปขัดข้องหรือทำงานช้ามากบนอุปกรณ์มือถือ\n\nแนะนำให้ใช้ \"small\" หรือ \"base\"';
+  String get largeModelWarning => 'โมเดลนี้มีขนาดใหญ่และอาจทำให้แอปขัดข้องหรือทำงานช้ามากบนอุปกรณ์มือถือ\n\nแนะนำให้ใช้ \"small\" หรือ \"base\"';
 
   @override
   String get usingNativeIosSpeech => 'ใช้การรู้จำเสียง iOS แบบเนทีฟ';
@@ -6102,8 +6019,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get premiumMinutesMonth => '1,200 นาทีพรีเมียม/เดือน แท็บบนอุปกรณ์ให้การถอดความฟรีไม่จำกัด ';
 
   @override
-  String get audioProcessedLocally =>
-      'เสียงถูกประมวลผลในเครื่อง ใช้งานแบบออฟไลน์ได้ มีความเป็นส่วนตัวมากขึ้น แต่ใช้แบตเตอรี่มากขึ้น';
+  String get audioProcessedLocally => 'เสียงถูกประมวลผลในเครื่อง ใช้งานแบบออฟไลน์ได้ มีความเป็นส่วนตัวมากขึ้น แต่ใช้แบตเตอรี่มากขึ้น';
 
   @override
   String get languageLabel => 'ภาษา';
@@ -6112,8 +6028,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get modelLabel => 'โมเดล';
 
   @override
-  String get modelTooLargeWarning =>
-      'โมเดลนี้มีขนาดใหญ่และอาจทำให้แอปหยุดทำงานหรือทำงานช้ามากบนอุปกรณ์มือถือ\n\nแนะนำให้ใช้ small หรือ base';
+  String get modelTooLargeWarning => 'โมเดลนี้มีขนาดใหญ่และอาจทำให้แอปหยุดทำงานหรือทำงานช้ามากบนอุปกรณ์มือถือ\n\nแนะนำให้ใช้ small หรือ base';
 
   @override
   String get nativeEngineNoDownload => 'จะใช้เอนจินเสียงแบบเนทีฟของอุปกรณ์ ไม่ต้องดาวน์โหลดโมเดล';
@@ -6152,8 +6067,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'การถอดความสดในตัวของ Omi ถูกปรับให้เหมาะสมสำหรับการสนทนาแบบเรียลไทม์พร้อมการตรวจจับผู้พูดอัตโนมัติและการแยกผู้พูด';
+  String get omiTranscriptionOptimized => 'การถอดความสดในตัวของ Omi ถูกปรับให้เหมาะสมสำหรับการสนทนาแบบเรียลไทม์พร้อมการตรวจจับผู้พูดอัตโนมัติและการแยกผู้พูด';
 
   @override
   String get reset => 'รีเซ็ต';
@@ -6373,8 +6287,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'กำลังสร้างกราฟความรู้จากความทรงจำ...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'กราฟความรู้ของคุณจะถูกสร้างโดยอัตโนมัติเมื่อคุณสร้างความทรงจำใหม่';
+  String get knowledgeGraphWillBuildAutomatically => 'กราฟความรู้ของคุณจะถูกสร้างโดยอัตโนมัติเมื่อคุณสร้างความทรงจำใหม่';
 
   @override
   String get buildGraphButton => 'สร้างกราฟ';
@@ -6676,8 +6589,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'กำลังดาวน์โหลดเสียงจาก SD card ของอุปกรณ์';
 
   @override
-  String get transferRequiredDescription =>
-      'การบันทึกนี้จัดเก็บบน SD card ของอุปกรณ์ ถ่ายโอนไปยังโทรศัพท์เพื่อเล่นหรือแชร์';
+  String get transferRequiredDescription => 'การบันทึกนี้จัดเก็บบน SD card ของอุปกรณ์ ถ่ายโอนไปยังโทรศัพท์เพื่อเล่นหรือแชร์';
 
   @override
   String get cancelTransfer => 'ยกเลิกการถ่ายโอน';
@@ -6698,8 +6610,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get shareRecording => 'แชร์การบันทึก';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'คุณแน่ใจหรือไม่ว่าต้องการลบการบันทึกนี้ถาวร? การดำเนินการนี้ไม่สามารถยกเลิกได้';
+  String get deleteRecordingConfirmation => 'คุณแน่ใจหรือไม่ว่าต้องการลบการบันทึกนี้ถาวร? การดำเนินการนี้ไม่สามารถยกเลิกได้';
 
   @override
   String get recordingIdLabel => 'รหัสการบันทึก';
@@ -6758,8 +6669,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get enableFastTransfer => 'เปิดใช้งานการถ่ายโอนเร็ว';
 
   @override
-  String get fastTransferDescription =>
-      'การถ่ายโอนเร็วใช้ WiFi สำหรับความเร็ว ~5 เท่า โทรศัพท์ของคุณจะเชื่อมต่อกับเครือข่าย WiFi ของอุปกรณ์ Omi ชั่วคราวระหว่างการถ่ายโอน';
+  String get fastTransferDescription => 'การถ่ายโอนเร็วใช้ WiFi สำหรับความเร็ว ~5 เท่า โทรศัพท์ของคุณจะเชื่อมต่อกับเครือข่าย WiFi ของอุปกรณ์ Omi ชั่วคราวระหว่างการถ่ายโอน';
 
   @override
   String get internetAccessPausedDuringTransfer => 'การเข้าถึงอินเทอร์เน็ตถูกหยุดชั่วคราวระหว่างการถ่ายโอน';
@@ -6774,8 +6684,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get fiveTimesFaster => 'เร็วกว่า 5 เท่า';
 
   @override
-  String get fastTransferMethodDescription =>
-      'สร้างการเชื่อมต่อ WiFi โดยตรงไปยังอุปกรณ์ Omi โทรศัพท์ของคุณจะตัดการเชื่อมต่อ WiFi ปกติชั่วคราวระหว่างการถ่ายโอน';
+  String get fastTransferMethodDescription => 'สร้างการเชื่อมต่อ WiFi โดยตรงไปยังอุปกรณ์ Omi โทรศัพท์ของคุณจะตัดการเชื่อมต่อ WiFi ปกติชั่วคราวระหว่างการถ่ายโอน';
 
   @override
   String get bluetooth => 'บลูทูธ';
@@ -6784,8 +6693,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get bleSpeed => '~30 KB/s ผ่าน BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'ใช้การเชื่อมต่อ Bluetooth Low Energy มาตรฐาน ช้ากว่าแต่ไม่ส่งผลต่อการเชื่อมต่อ WiFi';
+  String get bluetoothMethodDescription => 'ใช้การเชื่อมต่อ Bluetooth Low Energy มาตรฐาน ช้ากว่าแต่ไม่ส่งผลต่อการเชื่อมต่อ WiFi';
 
   @override
   String get selected => 'เลือกแล้ว';
@@ -6826,8 +6734,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get appVisibilityChangedSuccessfully => 'เปลี่ยนการมองเห็นแอปสำเร็จแล้ว อาจใช้เวลาสักครู่ในการอัปเดต';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'เกิดข้อผิดพลาดในการเปิดใช้งานแอป หากเป็นแอปการรวม โปรดตรวจสอบว่าการตั้งค่าเสร็จสมบูรณ์แล้ว';
+  String get errorActivatingAppIntegration => 'เกิดข้อผิดพลาดในการเปิดใช้งานแอป หากเป็นแอปการรวม โปรดตรวจสอบว่าการตั้งค่าเสร็จสมบูรณ์แล้ว';
 
   @override
   String get errorUpdatingAppStatus => 'เกิดข้อผิดพลาดขณะอัปเดตสถานะแอป';
@@ -7094,15 +7001,13 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'กำหนดการอัปเกรดแล้ว! แผนรายเดือนของคุณจะดำเนินต่อไปจนกว่าจะสิ้นสุดรอบการเรียกเก็บเงิน จากนั้นจะเปลี่ยนเป็นรายปีโดยอัตโนมัติ';
+  String get planUpgradeScheduledMessage => 'กำหนดการอัปเกรดแล้ว! แผนรายเดือนของคุณจะดำเนินต่อไปจนกว่าจะสิ้นสุดรอบการเรียกเก็บเงิน จากนั้นจะเปลี่ยนเป็นรายปีโดยอัตโนมัติ';
 
   @override
   String get couldNotSchedulePlanChange => 'ไม่สามารถกำหนดการเปลี่ยนแผนได้ กรุณาลองอีกครั้ง';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'เปิดใช้งานการสมัครสมาชิกของคุณอีกครั้งแล้ว! ไม่มีค่าใช้จ่ายตอนนี้ - คุณจะถูกเรียกเก็บเงินเมื่อสิ้นสุดรอบปัจจุบัน';
+  String get subscriptionReactivatedDefault => 'เปิดใช้งานการสมัครสมาชิกของคุณอีกครั้งแล้ว! ไม่มีค่าใช้จ่ายตอนนี้ - คุณจะถูกเรียกเก็บเงินเมื่อสิ้นสุดรอบปัจจุบัน';
 
   @override
   String get subscriptionSuccessfulCharged => 'สมัครสมาชิกสำเร็จ! คุณถูกเรียกเก็บเงินสำหรับรอบการเรียกเก็บเงินใหม่แล้ว';
@@ -7270,8 +7175,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get authFailedToRetrieveToken => 'ไม่สามารถดึงโทเคน Firebase ได้ กรุณาลองอีกครั้ง';
 
   @override
-  String get authUnexpectedErrorFirebase =>
-      'เกิดข้อผิดพลาดที่ไม่คาดคิดขณะเข้าสู่ระบบ ข้อผิดพลาด Firebase กรุณาลองอีกครั้ง';
+  String get authUnexpectedErrorFirebase => 'เกิดข้อผิดพลาดที่ไม่คาดคิดขณะเข้าสู่ระบบ ข้อผิดพลาด Firebase กรุณาลองอีกครั้ง';
 
   @override
   String get authUnexpectedError => 'เกิดข้อผิดพลาดที่ไม่คาดคิดขณะเข้าสู่ระบบ กรุณาลองอีกครั้ง';
@@ -7302,8 +7206,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get onboardingNotificationDeniedSystemPrefs => 'สิทธิ์การแจ้งเตือนถูกปฏิเสธ กรุณาให้สิทธิ์ในการตั้งค่าระบบ';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'สิทธิ์การแจ้งเตือนถูกปฏิเสธ กรุณาให้สิทธิ์ในการตั้งค่าระบบ > การแจ้งเตือน';
+  String get onboardingNotificationDeniedNotifications => 'สิทธิ์การแจ้งเตือนถูกปฏิเสธ กรุณาให้สิทธิ์ในการตั้งค่าระบบ > การแจ้งเตือน';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7316,15 +7219,13 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'กรุณาให้สิทธิ์ตำแหน่งที่ตั้งในการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการตำแหน่งที่ตั้ง';
+  String get onboardingLocationGrantInSettings => 'กรุณาให้สิทธิ์ตำแหน่งที่ตั้งในการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการตำแหน่งที่ตั้ง';
 
   @override
   String get onboardingMicrophoneRequired => 'ต้องมีสิทธิ์ไมโครโฟนสำหรับการบันทึก';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'สิทธิ์ไมโครโฟนถูกปฏิเสธ กรุณาให้สิทธิ์ในการตั้งค่าระบบ > ความเป็นส่วนตัวและความปลอดภัย > ไมโครโฟน';
+  String get onboardingMicrophoneDenied => 'สิทธิ์ไมโครโฟนถูกปฏิเสธ กรุณาให้สิทธิ์ในการตั้งค่าระบบ > ความเป็นส่วนตัวและความปลอดภัย > ไมโครโฟน';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7340,8 +7241,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'ต้องมีสิทธิ์จับภาพหน้าจอสำหรับการบันทึกเสียงระบบ';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'สิทธิ์จับภาพหน้าจอถูกปฏิเสธ กรุณาให้สิทธิ์ในการตั้งค่าระบบ > ความเป็นส่วนตัวและความปลอดภัย > การบันทึกหน้าจอ';
+  String get onboardingScreenCaptureDenied => 'สิทธิ์จับภาพหน้าจอถูกปฏิเสธ กรุณาให้สิทธิ์ในการตั้งค่าระบบ > ความเป็นส่วนตัวและความปลอดภัย > การบันทึกหน้าจอ';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7466,8 +7366,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get locationPermissionRequired => 'ต้องได้รับอนุญาตตำแหน่ง';
 
   @override
-  String get locationPermissionContent =>
-      'การถ่ายโอนเร็วต้องได้รับอนุญาตตำแหน่งเพื่อตรวจสอบการเชื่อมต่อ WiFi โปรดให้สิทธิ์ตำแหน่งเพื่อดำเนินการต่อ';
+  String get locationPermissionContent => 'การถ่ายโอนเร็วต้องได้รับอนุญาตตำแหน่งเพื่อตรวจสอบการเชื่อมต่อ WiFi โปรดให้สิทธิ์ตำแหน่งเพื่อดำเนินการต่อ';
 
   @override
   String get pdfTranscriptExport => 'ส่งออกบทถอดเสียง';
@@ -8091,8 +7990,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get switchAndRestart => 'สลับ';
 
   @override
-  String get stagingDisclaimer =>
-      'สภาพแวดล้อมทดสอบอาจไม่เสถียร มีประสิทธิภาพไม่สม่ำเสมอ และข้อมูลอาจสูญหาย สำหรับการทดสอบเท่านั้น';
+  String get stagingDisclaimer => 'สภาพแวดล้อมทดสอบอาจไม่เสถียร มีประสิทธิภาพไม่สม่ำเสมอ และข้อมูลอาจสูญหาย สำหรับการทดสอบเท่านั้น';
 
   @override
   String get apiEnvSavedRestartRequired => 'บันทึกแล้ว ปิดและเปิดแอปใหม่เพื่อใช้งานการเปลี่ยนแปลง';
@@ -8360,8 +8258,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deletePendingFiles => 'ลบการบันทึกที่รอดำเนินการ';
 
   @override
-  String get deletePendingFilesWarning =>
-      'การบันทึกเหล่านี้ยังไม่ได้ซิงค์กับโทรศัพท์ของคุณและจะสูญหายถาวร ไม่สามารถย้อนกลับได้';
+  String get deletePendingFilesWarning => 'การบันทึกเหล่านี้ยังไม่ได้ซิงค์กับโทรศัพท์ของคุณและจะสูญหายถาวร ไม่สามารถย้อนกลับได้';
 
   @override
   String get pendingFilesDeleted => 'ลบการบันทึกที่รอดำเนินการแล้ว';
@@ -8373,8 +8270,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deleteAll => 'ลบทั้งหมด';
 
   @override
-  String get deleteAllFilesWarning =>
-      'การดำเนินการนี้จะลบการบันทึกที่ซิงค์แล้วและที่รอดำเนินการ การบันทึกที่รอดำเนินการยังไม่ได้ซิงค์และจะสูญหายถาวร';
+  String get deleteAllFilesWarning => 'การดำเนินการนี้จะลบการบันทึกที่ซิงค์แล้วและที่รอดำเนินการ การบันทึกที่รอดำเนินการยังไม่ได้ซิงค์และจะสูญหายถาวร';
 
   @override
   String get allFilesDeleted => 'ลบการบันทึกทั้งหมดแล้ว';
@@ -8439,8 +8335,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get fairUseAboutTitle => 'เกี่ยวกับการใช้งานอย่างเป็นธรรม';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi ออกแบบมาสำหรับการสนทนาส่วนตัว การประชุม และการโต้ตอบสด การใช้งานวัดจากเวลาพูดจริงที่ตรวจพบ ไม่ใช่เวลาเชื่อมต่อ หากการใช้งานเกินรูปแบบปกติอย่างมากสำหรับเนื้อหาที่ไม่ใช่ส่วนบุคคล อาจมีการปรับเปลี่ยน';
+  String get fairUseAboutBody => 'Omi ออกแบบมาสำหรับการสนทนาส่วนตัว การประชุม และการโต้ตอบสด การใช้งานวัดจากเวลาพูดจริงที่ตรวจพบ ไม่ใช่เวลาเชื่อมต่อ หากการใช้งานเกินรูปแบบปกติอย่างมากสำหรับเนื้อหาที่ไม่ใช่ส่วนบุคคล อาจมีการปรับเปลี่ยน';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8478,8 +8373,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get improveConnectionTitle => 'ปรับปรุงการเชื่อมต่อ';
 
   @override
-  String get improveConnectionContent =>
-      'เราได้ปรับปรุงวิธีที่ Omi เชื่อมต่อกับอุปกรณ์ของคุณ เพื่อเปิดใช้งาน ให้ไปที่หน้าข้อมูลอุปกรณ์ แตะ \"ยกเลิกการเชื่อมต่ออุปกรณ์\" แล้วจับคู่อุปกรณ์อีกครั้ง';
+  String get improveConnectionContent => 'เราได้ปรับปรุงวิธีที่ Omi เชื่อมต่อกับอุปกรณ์ของคุณ เพื่อเปิดใช้งาน ให้ไปที่หน้าข้อมูลอุปกรณ์ แตะ \"ยกเลิกการเชื่อมต่ออุปกรณ์\" แล้วจับคู่อุปกรณ์อีกครั้ง';
 
   @override
   String get improveConnectionAction => 'เข้าใจแล้ว';
@@ -8534,15 +8428,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get cancelSyncQuestion => 'ยกเลิกการซิงค์?';
 
   @override
-  String get omisStorageDesc =>
-      'เมื่อ Omi ของคุณไม่ได้เชื่อมต่อกับโทรศัพท์ มันจะเก็บเสียงไว้ในหน่วยความจำภายใน คุณจะไม่สูญเสียการบันทึกใดๆ';
+  String get omisStorageDesc => 'เมื่อ Omi ของคุณไม่ได้เชื่อมต่อกับโทรศัพท์ มันจะเก็บเสียงไว้ในหน่วยความจำภายใน คุณจะไม่สูญเสียการบันทึกใดๆ';
 
   @override
   String get phoneStorageDesc => 'เมื่อ Omi เชื่อมต่ออีกครั้ง การบันทึกจะถูกโอนไปยังโทรศัพท์โดยอัตโนมัติก่อนอัปโหลด';
 
   @override
-  String get cloudStorageDesc =>
-      'เมื่ออัปโหลดแล้ว การบันทึกของคุณจะถูกประมวลผลและถอดเสียง บทสนทนาจะพร้อมใช้งานภายในหนึ่งนาที';
+  String get cloudStorageDesc => 'เมื่ออัปโหลดแล้ว การบันทึกของคุณจะถูกประมวลผลและถอดเสียง บทสนทนาจะพร้อมใช้งานภายในหนึ่งนาที';
 
   @override
   String get tipKeepPhoneNearby => 'ให้โทรศัพท์อยู่ใกล้เพื่อการซิงค์ที่เร็วขึ้น';
@@ -8566,12 +8458,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get permissionEnable => 'เปิดใช้งาน';
 
   @override
-  String get permissionsPageDescription =>
-      'สิทธิ์เหล่านี้มีความสำคัญต่อการทำงานของ Omi ช่วยเปิดใช้งานฟีเจอร์หลัก เช่น การแจ้งเตือน ประสบการณ์ตามตำแหน่ง และการบันทึกเสียง';
+  String get permissionsPageDescription => 'สิทธิ์เหล่านี้มีความสำคัญต่อการทำงานของ Omi ช่วยเปิดใช้งานฟีเจอร์หลัก เช่น การแจ้งเตือน ประสบการณ์ตามตำแหน่ง และการบันทึกเสียง';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi ต้องการสิทธิ์บางอย่างเพื่อทำงานได้อย่างถูกต้อง กรุณาอนุญาตเพื่อดำเนินการต่อ';
+  String get permissionsRequiredDescription => 'Omi ต้องการสิทธิ์บางอย่างเพื่อทำงานได้อย่างถูกต้อง กรุณาอนุญาตเพื่อดำเนินการต่อ';
 
   @override
   String get permissionsSetupTitle => 'รับประสบการณ์ที่ดีที่สุด';
@@ -8848,8 +8738,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get firmwareWarningTitle => 'สำคัญ: อ่านก่อนอัปเดต';
 
   @override
-  String get firmwareFormatWarning =>
-      'เฟิร์มแวร์นี้จะฟอร์แมตการ์ด SD กรุณาตรวจสอบให้แน่ใจว่าข้อมูลออฟไลน์ทั้งหมดได้รับการซิงค์ก่อนอัปเกรด\n\nหากคุณเห็นไฟสีแดงกะพริบหลังจากติดตั้งเวอร์ชันนี้ อย่ากังวล เพียงเชื่อมต่ออุปกรณ์กับแอปและไฟควรเปลี่ยนเป็นสีน้ำเงิน ไฟสีแดงหมายความว่านาฬิกาของอุปกรณ์ยังไม่ได้ซิงค์';
+  String get firmwareFormatWarning => 'เฟิร์มแวร์นี้จะฟอร์แมตการ์ด SD กรุณาตรวจสอบให้แน่ใจว่าข้อมูลออฟไลน์ทั้งหมดได้รับการซิงค์ก่อนอัปเกรด\n\nหากคุณเห็นไฟสีแดงกะพริบหลังจากติดตั้งเวอร์ชันนี้ อย่ากังวล เพียงเชื่อมต่ออุปกรณ์กับแอปและไฟควรเปลี่ยนเป็นสีน้ำเงิน ไฟสีแดงหมายความว่านาฬิกาของอุปกรณ์ยังไม่ได้ซิงค์';
 
   @override
   String get continueAnyway => 'ดำเนินการต่อ';
@@ -8869,8 +8758,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get tasksMarkComplete => 'ทำเครื่องหมายว่าเสร็จสิ้น';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi เข้าถึง Apple Health ผ่านเฟรมเวิร์ก HealthKit ของ Apple คุณสามารถเพิกถอนการเข้าถึงได้ทุกเมื่อในการตั้งค่า iOS';
+  String get appleHealthManageNote => 'Omi เข้าถึง Apple Health ผ่านเฟรมเวิร์ก HealthKit ของ Apple คุณสามารถเพิกถอนการเข้าถึงได้ทุกเมื่อในการตั้งค่า iOS';
 
   @override
   String get appleHealthConnectCta => 'เชื่อมต่อ Apple Health';
@@ -8903,8 +8791,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get appleHealthDeniedTitle => 'การเข้าถึง Apple Health ถูกปฏิเสธ';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi ไม่มีสิทธิ์อ่านข้อมูล Apple Health ของคุณ เปิดใช้งานในการตั้งค่า iOS → ความเป็นส่วนตัวและความปลอดภัย → Health → Omi';
+  String get appleHealthDeniedBody => 'Omi ไม่มีสิทธิ์อ่านข้อมูล Apple Health ของคุณ เปิดใช้งานในการตั้งค่า iOS → ความเป็นส่วนตัวและความปลอดภัย → Health → Omi';
 
   @override
   String get deleteFlowReasonTitle => 'ทำไมคุณถึงจะไป?';
@@ -8973,8 +8860,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get planUpdate => 'อัปเดตแผน';
 
   @override
-  String get planDeprecationMessage =>
-      'แผน Unlimited ของคุณกำลังถูกยกเลิก เปลี่ยนไปใช้แผน Operator — ฟีเจอร์ดีเยี่ยมเหมือนเดิมในราคา \$49/เดือน แผนปัจจุบันของคุณจะยังคงใช้งานได้ในระหว่างนี้';
+  String get planDeprecationMessage => 'แผน Unlimited ของคุณกำลังถูกยกเลิก เปลี่ยนไปใช้แผน Operator — ฟีเจอร์ดีเยี่ยมเหมือนเดิมในราคา \$49/เดือน แผนปัจจุบันของคุณจะยังคงใช้งานได้ในระหว่างนี้';
 
   @override
   String get upgradeYourPlan => 'อัปเกรดแผนของคุณ';
@@ -9116,4 +9002,25 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'เพิ่มงาน';
+
+  @override
+  String get quickActionAskOmiAnything => 'ถาม Omi ได้ทุกอย่าง';
+
+  @override
+  String get quickActionVoiceMode => 'โหมดเสียง';
+
+  @override
+  String get quickActionMute => 'ปิดเสียง';
+
+  @override
+  String get quickActionUnmute => 'เปิดเสียง';
+
+  @override
+  String get quickActionConnectDevice => 'เชื่อมต่ออุปกรณ์';
+
+  @override
+  String get quickActionDeviceSettings => 'การตั้งค่าอุปกรณ์';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -24,8 +24,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deleteConversationTitle => 'Tanggalin ang Pag-uusap?';
 
   @override
-  String get deleteConversationMessage =>
-      'Tatanggalin din nito ang mga nauugnay na alaala, gawain, at audio file. Hindi maaaring bawiin ang aksyong ito.';
+  String get deleteConversationMessage => 'Tatanggalin din nito ang mga nauugnay na alaala, gawain, at audio file. Hindi maaaring bawiin ang aksyong ito.';
 
   @override
   String get confirm => 'Kumpirma';
@@ -146,8 +145,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deleting => 'Inaalis...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Kumpleto ang pag-authenticate sa iyong browser. Kapag tapos na, bumalik sa app.';
+  String get pleaseCompleteAuthentication => 'Kumpleto ang pag-authenticate sa iyong browser. Kapag tapos na, bumalik sa app.';
 
   @override
   String get failedToStartAuthentication => 'Nabigo ang pagsisimula ng pag-authenticate';
@@ -228,8 +226,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get noStarredConversations => 'Walang may-bituing pag-uusap';
 
   @override
-  String get starConversationHint =>
-      'Para maglagay ng bituin sa isang pag-uusap, buksan ito at i-tap ang bituin icon sa header.';
+  String get starConversationHint => 'Para maglagay ng bituin sa isang pag-uusap, buksan ito at i-tap ang bituin icon sa header.';
 
   @override
   String get searchConversations => 'Maghanap ng pag-uusap...';
@@ -320,8 +317,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get installedApps => 'Naka-install na Mga App';
 
   @override
-  String get unableToFetchApps =>
-      'Hindi makuha ang mga app :(\n\nMangyaring suriin ang iyong koneksyon sa internet at subukan ulit.';
+  String get unableToFetchApps => 'Hindi makuha ang mga app :(\n\nMangyaring suriin ang iyong koneksyon sa internet at subukan ulit.';
 
   @override
   String get aboutOmi => 'Tungkol sa Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsTl extends AppLocalizations {
   String get appsDisconnected => 'Ang iyong Mga App at Integrations ay mawawalan ng koneksyon kaagad.';
 
   @override
-  String get exportBeforeDelete =>
-      'Maaari mong i-export ang iyong data bago tanggalin ang iyong account, ngunit kapag tanggal na, hindi na ito mababawi.';
+  String get exportBeforeDelete => 'Maaari mong i-export ang iyong data bago tanggalin ang iyong account, ngunit kapag tanggal na, hindi na ito mababawi.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Nauunawaan ko na ang pagtanggal ng iyong account ay permanente at lahat ng data, kasama ang mga alaala at pag-uusap, ay mawawalan at hindi mababawi.';
+  String get deleteAccountCheckbox => 'Nauunawaan ko na ang pagtanggal ng iyong account ay permanente at lahat ng data, kasama ang mga alaala at pag-uusap, ay mawawalan at hindi mababawi.';
 
   @override
   String get areYouSure => 'Sigurado ka ba?';
 
   @override
-  String get deleteAccountFinal =>
-      'Ang aksyong ito ay hindi na mababawi at magtatanggal ng permanente sa iyong account at lahat ng nauugnay na data. Sigurado ka na bang nais magpatuloy?';
+  String get deleteAccountFinal => 'Ang aksyong ito ay hindi na mababawi at magtatanggal ng permanente sa iyong account at lahat ng nauugnay na data. Sigurado ka na bang nais magpatuloy?';
 
   @override
   String get deleteNow => 'Tanggalin Na';
@@ -378,8 +371,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get goBack => 'Bumalik';
 
   @override
-  String get checkBoxToConfirm =>
-      'Suriin ang kahon upang kumpirmahin na nauunawaan mo na ang pagtanggal ng iyong account ay permanente at hindi na mababawi.';
+  String get checkBoxToConfirm => 'Suriin ang kahon upang kumpirmahin na nauunawaan mo na ang pagtanggal ng iyong account ay permanente at hindi na mababawi.';
 
   @override
   String get profile => 'Profile';
@@ -457,8 +449,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get yourPrivacyYourControl => 'Ang Iyong Privacy, Ang Iyong Kontrol';
 
   @override
-  String get privacyIntro =>
-      'Sa Omi, kami ay nakatuon sa pagprotekta ng iyong privacy. Ang pahina na ito ay nagbibigay-daan sa iyo na kontrolin kung paano ginagamit at iniimbak ang iyong data.';
+  String get privacyIntro => 'Sa Omi, kami ay nakatuon sa pagprotekta ng iyong privacy. Ang pahina na ito ay nagbibigay-daan sa iyo na kontrolin kung paano ginagamit at iniimbak ang iyong data.';
 
   @override
   String get learnMore => 'Matutunan ang higit pa...';
@@ -467,15 +458,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get dataProtectionLevel => 'Antas ng Proteksyon ng Data';
 
   @override
-  String get dataProtectionDesc =>
-      'Ang iyong data ay protektado ng default gamit ang mataas na encryption. Suriin ang iyong mga setting at hinaharap na privacy options sa ibaba.';
+  String get dataProtectionDesc => 'Ang iyong data ay protektado ng default gamit ang mataas na encryption. Suriin ang iyong mga setting at hinaharap na privacy options sa ibaba.';
 
   @override
   String get appAccess => 'Pag-access ng App';
 
   @override
-  String get appAccessDesc =>
-      'Ang mga sumusunod na apps ay maaaring mag-access sa iyong data. I-tap ang isang app upang pamahalaan ang mga pahintulot nito.';
+  String get appAccessDesc => 'Ang mga sumusunod na apps ay maaaring mag-access sa iyong data. I-tap ang isang app upang pamahalaan ang mga pahintulot nito.';
 
   @override
   String get noAppsExternalAccess => 'Walang naka-install na apps na may external access sa iyong data.';
@@ -532,22 +521,19 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Ang iyong Omi ay nawawalan ng koneksyon 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Device ay nai-unpair na. Pumunta sa Settings > Bluetooth at kalimutan ang device upang makumpleto ang pag-unpair.';
+  String get deviceUnpairedMessage => 'Device ay nai-unpair na. Pumunta sa Settings > Bluetooth at kalimutan ang device upang makumpleto ang pag-unpair.';
 
   @override
   String get unpairDialogTitle => 'I-unpair ang Device';
 
   @override
-  String get unpairDialogMessage =>
-      'Ito ay ire-unpair ang device upang maaaring ikonekta sa iba pang telepono. Kailangan mong pumunta sa Settings > Bluetooth at kalimutan ang device upang makumpleto ang proseso.';
+  String get unpairDialogMessage => 'Ito ay ire-unpair ang device upang maaaring ikonekta sa iba pang telepono. Kailangan mong pumunta sa Settings > Bluetooth at kalimutan ang device upang makumpleto ang proseso.';
 
   @override
   String get deviceNotConnected => 'Device ay Hindi Konektado';
 
   @override
-  String get connectDeviceMessage =>
-      'Ikonekta ang iyong Omi device upang ma-access\nang device settings at pag-customize';
+  String get connectDeviceMessage => 'Ikonekta ang iyong Omi device upang ma-access\nang device settings at pag-customize';
 
   @override
   String get deviceInfoSection => 'Impormasyon ng Device';
@@ -562,8 +548,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get v2Undetected => 'V2 ay hindi na-detect';
 
   @override
-  String get v2UndetectedMessage =>
-      'Nakita namin na mayroon kang V1 device o ang iyong device ay hindi konektado. Ang SD Card functionality ay available lamang para sa V2 devices.';
+  String get v2UndetectedMessage => 'Nakita namin na mayroon kang V1 device o ang iyong device ay hindi konektado. Ang SD Card functionality ay available lamang para sa V2 devices.';
 
   @override
   String get endConversation => 'Tapusin ang Pag-uusap';
@@ -695,8 +680,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get noActivityYet => 'Walang Aktibidad Pa';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Magsimula ng pag-uusap sa Omi\nupang makita ang iyong usage insights dito.';
+  String get startConversationToSeeInsights => 'Magsimula ng pag-uusap sa Omi\nupang makita ang iyong usage insights dito.';
 
   @override
   String get listening => 'Nakikinig';
@@ -838,8 +822,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Tanggalin ang Knowledge Graph?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Ito ay tatanggal ang lahat ng derived knowledge graph data (nodes at connections). Ang iyong orihinal na mga alaala ay manatiling ligtas. Ang graph ay muling bubuo sa paglipas ng panahon o sa susunod na request.';
+  String get deleteKnowledgeGraphMessage => 'Ito ay tatanggal ang lahat ng derived knowledge graph data (nodes at connections). Ang iyong orihinal na mga alaala ay manatiling ligtas. Ang graph ay muling bubuo sa paglipas ng panahon o sa susunod na request.';
 
   @override
   String get knowledgeGraphDeleted => 'Knowledge Graph ay natanggal';
@@ -987,8 +970,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get shortConversationThreshold => 'Short Conversation Threshold';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Ang mga pag-uusap na mas maikli kaysa dito ay nakatagong maliban kung na-enable ang nasa itaas';
+  String get shortConversationThresholdSubtitle => 'Ang mga pag-uusap na mas maikli kaysa dito ay nakatagong maliban kung na-enable ang nasa itaas';
 
   @override
   String get durationThreshold => 'Duration Threshold';
@@ -1083,37 +1065,31 @@ class AppLocalizationsTl extends AppLocalizations {
   String get needYourPermission => 'Kailangan namin ng iyong pahintulot';
 
   @override
-  String get alreadyGavePermission =>
-      'Nagbigay ka na sa amin ng pahintulot na i-save ang iyong mga recording. Narito ang isang reminder kung bakit namin kailangan:';
+  String get alreadyGavePermission => 'Nagbigay ka na sa amin ng pahintulot na i-save ang iyong mga recording. Narito ang isang reminder kung bakit namin kailangan:';
 
   @override
-  String get wouldLikePermission =>
-      'Nais naming makakuha ng iyong pahintulot upang i-save ang iyong mga voice recording. Narito kung bakit:';
+  String get wouldLikePermission => 'Nais naming makakuha ng iyong pahintulot upang i-save ang iyong mga voice recording. Narito kung bakit:';
 
   @override
   String get improveSpeechProfile => 'Mapabuti ang Iyong Profil ng Boses';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Gumagamit kami ng mga recording upang higit na pagsanayin at pahusayin ang iyong personal na profil ng boses.';
+  String get improveSpeechProfileDesc => 'Gumagamit kami ng mga recording upang higit na pagsanayin at pahusayin ang iyong personal na profil ng boses.';
 
   @override
   String get trainFamilyProfiles => 'Tukuyin ang Mga Profil para sa Mga Kaibigan at Pamilya';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Ang iyong mga recording ay tumutulong sa amin na kilalanin at lumikha ng mga profil para sa iyong mga kaibigan at pamilya.';
+  String get trainFamilyProfilesDesc => 'Ang iyong mga recording ay tumutulong sa amin na kilalanin at lumikha ng mga profil para sa iyong mga kaibigan at pamilya.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Pahusayin ang Accuracy ng Transcript';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Habang umuunlad ang aming modelo, maaari kaming magbigay ng mas mahusay na resulta ng transkeribsyon para sa iyong mga recording.';
+  String get enhanceTranscriptAccuracyDesc => 'Habang umuunlad ang aming modelo, maaari kaming magbigay ng mas mahusay na resulta ng transkeribsyon para sa iyong mga recording.';
 
   @override
-  String get legalNotice =>
-      'Legal Notice: Ang legality ng pag-record at pag-store ng voice data ay maaaring magkakaiba depende sa iyong lokasyon at paano mo ginagamit ang feature na ito. Ang iyong responsibilidad na matiyak ang compliance sa local laws at regulations.';
+  String get legalNotice => 'Legal Notice: Ang legality ng pag-record at pag-store ng voice data ay maaaring magkakaiba depende sa iyong lokasyon at paano mo ginagamit ang feature na ito. Ang iyong responsibilidad na matiyak ang compliance sa local laws at regulations.';
 
   @override
   String get alreadyAuthorized => 'Naauthorize Na';
@@ -1191,8 +1167,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get showEventsNoParticipants => 'Ipakita ang mga kaganapan na walang participants';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Kapag pinagana, ang Coming Up ay magpapakita ng mga kaganapan na walang participants o video link.';
+  String get showEventsNoParticipantsDesc => 'Kapag pinagana, ang Coming Up ay magpapakita ng mga kaganapan na walang participants o video link.';
 
   @override
   String get yourMeetings => 'Ang Iyong Mga Pulong';
@@ -1233,8 +1208,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get noProjectsInWorkspace => 'Walang mga proyekto na nahanap sa workspace na ito';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Pumili kung gaano katagal ang maghintay sa kalmado bago awtomatikong pagtatapos ng pag-usap:';
+  String get conversationTimeoutDesc => 'Pumili kung gaano katagal ang maghintay sa kalmado bago awtomatikong pagtatapos ng pag-usap:';
 
   @override
   String get timeout2Minutes => '2 minuto';
@@ -1278,12 +1252,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Sabihin sa amin ang iyong pangunahing wika';
 
   @override
-  String get languageForTranscription =>
-      'Itakda ang iyong wika para sa mas matalinong transcriptions at personalized na karanasan.';
+  String get languageForTranscription => 'Itakda ang iyong wika para sa mas matalinong transcriptions at personalized na karanasan.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Ang Single Language Mode ay pinagana na. Ang pagsasalin ay hindi pinagana para sa mas mataas na accuracy.';
+  String get singleLanguageModeInfo => 'Ang Single Language Mode ay pinagana na. Ang pagsasalin ay hindi pinagana para sa mas mataas na accuracy.';
 
   @override
   String get searchLanguageHint => 'Maghanap ng wika ayon sa pangalan o code';
@@ -1363,8 +1335,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get defaultRepository => 'Default Repository';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Pumili ng default na repositoryo para sa paglikha ng mga isyu. Maaari pa ring tukuyin ang ibang repositoryo kapag lumilikha ng mga isyu.';
+  String get selectDefaultRepoDesc => 'Pumili ng default na repositoryo para sa paglikha ng mga isyu. Maaari pa ring tukuyin ang ibang repositoryo kapag lumilikha ng mga isyu.';
 
   @override
   String get noReposFound => 'Walang mga repositoryo na nahanap';
@@ -1411,8 +1382,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get configureSettings => 'I-configure ang Mga Setting';
 
   @override
-  String get completeAuthBrowser =>
-      'Mangyaring kumpletuhin ang authentication sa iyong browser. Kapag tapos na, bumalik sa app.';
+  String get completeAuthBrowser => 'Mangyaring kumpletuhin ang authentication sa iyong browser. Kapag tapos na, bumalik sa app.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1740,8 +1710,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get enableBluetooth => 'Paganahin ang Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Ang Omi ay kailangan ng Bluetooth upang kumonekta sa iyong wearable. Mangyaring paganahin ang Bluetooth at subukan muli.';
+  String get bluetoothNeeded => 'Ang Omi ay kailangan ng Bluetooth upang kumonekta sa iyong wearable. Mangyaring paganahin ang Bluetooth at subukan muli.';
 
   @override
   String get contactSupport => 'Makipag-ugnayan sa Support?';
@@ -1774,26 +1743,22 @@ class AppLocalizationsTl extends AppLocalizations {
   String get locationServiceDisabled => 'Ang Location Service ay Disabled';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Ang Location Service ay Disabled. Mangyaring pumunta sa Settings > Privacy & Security > Location Services at paganahin ito';
+  String get locationServiceDisabledDesc => 'Ang Location Service ay Disabled. Mangyaring pumunta sa Settings > Privacy & Security > Location Services at paganahin ito';
 
   @override
   String get backgroundLocationDenied => 'Ang Background Location Access ay Dineny';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Mangyaring pumunta sa device settings at itakda ang location permission sa \"Always Allow\"';
+  String get backgroundLocationDeniedDesc => 'Mangyaring pumunta sa device settings at itakda ang location permission sa \"Always Allow\"';
 
   @override
   String get lovingOmi => 'Gusto mo ba ang Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Tumulong sa amin na maabot ang mas maraming tao sa pamamagitan ng pag-iwan ng review sa App Store. Ang iyong feedback ay napakahalagang para sa amin!';
+  String get leaveReviewIos => 'Tumulong sa amin na maabot ang mas maraming tao sa pamamagitan ng pag-iwan ng review sa App Store. Ang iyong feedback ay napakahalagang para sa amin!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Tumulong sa amin na maabot ang mas maraming tao sa pamamagitan ng pag-iwan ng review sa Google Play Store. Ang iyong feedback ay napakahalagang para sa amin!';
+  String get leaveReviewAndroid => 'Tumulong sa amin na maabot ang mas maraming tao sa pamamagitan ng pag-iwan ng review sa Google Play Store. Ang iyong feedback ay napakahalagang para sa amin!';
 
   @override
   String get rateOnAppStore => 'Mag-rate sa App Store';
@@ -1805,8 +1770,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get maybeLater => 'Siguro mamaya';
 
   @override
-  String get speechProfileIntro =>
-      'Ang Omi ay kailangan matuto ng iyong mga layunin at iyong boses. Makakabago ka nito mamaya.';
+  String get speechProfileIntro => 'Ang Omi ay kailangan matuto ng iyong mga layunin at iyong boses. Makakabago ka nito mamaya.';
 
   @override
   String get getStarted => 'Magsimula';
@@ -1827,36 +1791,31 @@ class AppLocalizationsTl extends AppLocalizations {
   String get connectionError => 'Connection Error';
 
   @override
-  String get connectionErrorDesc =>
-      'Nabigo ang koneksyon sa server. Mangyaring suriin ang iyong internet connection at subukan muli.';
+  String get connectionErrorDesc => 'Nabigo ang koneksyon sa server. Mangyaring suriin ang iyong internet connection at subukan muli.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Ang invalid recording ay nadetect';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Mukhang may maraming speakers sa recording. Mangyaring masiguro na ikaw ay nasa tahimik na lugar at subukan muli.';
+  String get multipleSpeakersDesc => 'Mukhang may maraming speakers sa recording. Mangyaring masiguro na ikaw ay nasa tahimik na lugar at subukan muli.';
 
   @override
   String get tooShortDesc => 'Walang sapat na speech na nadetect. Mangyaring magsalita nang higit pa at subukan muli.';
 
   @override
-  String get invalidRecordingDesc =>
-      'Mangyaring masiguro na ikaw ay nagsasalita ng hindi bababa sa 5 segundo at hindi higit sa 90.';
+  String get invalidRecordingDesc => 'Mangyaring masiguro na ikaw ay nagsasalita ng hindi bababa sa 5 segundo at hindi higit sa 90.';
 
   @override
   String get areYouThere => 'Nandito ka ba?';
 
   @override
-  String get noSpeechDesc =>
-      'Hindi namin nadetect ang anumang speech. Mangyaring masiguro na nagsasalita ka ng hindi bababa sa 10 segundo at hindi higit sa 3 minuto.';
+  String get noSpeechDesc => 'Hindi namin nadetect ang anumang speech. Mangyaring masiguro na nagsasalita ka ng hindi bababa sa 10 segundo at hindi higit sa 3 minuto.';
 
   @override
   String get connectionLost => 'Ang Koneksyon ay Nawala';
 
   @override
-  String get connectionLostDesc =>
-      'Ang koneksyon ay naintriga. Mangyaring suriin ang iyong internet connection at subukan muli.';
+  String get connectionLostDesc => 'Ang koneksyon ay naintriga. Mangyaring suriin ang iyong internet connection at subukan muli.';
 
   @override
   String get tryAgain => 'Subukan Muli';
@@ -1871,8 +1830,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get permissionsRequired => 'Mga Pahintulot na Kinakailangan';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Ang app na ito ay kailangan ng Bluetooth at Location permissions upang gumana nang maayos. Mangyaring paganahin ang mga ito sa settings.';
+  String get permissionsRequiredDesc => 'Ang app na ito ay kailangan ng Bluetooth at Location permissions upang gumana nang maayos. Mangyaring paganahin ang mga ito sa settings.';
 
   @override
   String get openSettings => 'Buksan ang Settings';
@@ -1902,8 +1860,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – Ang Iyong AI Companion';
 
   @override
-  String get captureEveryMoment =>
-      'Kunan ang bawat sandali. Makakuha ng AI-powered\nsummaries. Hindi na kailangan mag-notes.';
+  String get captureEveryMoment => 'Kunan ang bawat sandali. Makakuha ng AI-powered\nsummaries. Hindi na kailangan mag-notes.';
 
   @override
   String get appleWatchSetup => 'Apple Watch Setup';
@@ -1915,12 +1872,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get microphonePermission => 'Microphone Permission';
 
   @override
-  String get permissionGrantedNow =>
-      'Ang pahintulot ay nabigyan na! Ngayon:\n\nBuksan ang Omi app sa iyong watch at tapin ang \"Continue\" sa ibaba';
+  String get permissionGrantedNow => 'Ang pahintulot ay nabigyan na! Ngayon:\n\nBuksan ang Omi app sa iyong watch at tapin ang \"Continue\" sa ibaba';
 
   @override
-  String get needMicrophonePermission =>
-      'Kailangan namin ng microphone permission.\n\n1. Tapin ang \"Grant Permission\"\n2. Payagan sa iyong iPhone\n3. Ang watch app ay magsasara\n4. Muling buksan at tapin ang \"Continue\"';
+  String get needMicrophonePermission => 'Kailangan namin ng microphone permission.\n\n1. Tapin ang \"Grant Permission\"\n2. Payagan sa iyong iPhone\n3. Ang watch app ay magsasara\n4. Muling buksan at tapin ang \"Continue\"';
 
   @override
   String get grantPermissionButton => 'Bigyan ng Permission';
@@ -1929,15 +1884,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get needHelp => 'Kailangan ng Tulong?';
 
   @override
-  String get troubleshootingSteps =>
-      'Troubleshooting:\n\n1. Masiguro na ang Omi ay naka-install sa iyong watch\n2. Buksan ang Omi app sa iyong watch\n3. Hanapin ang permission popup\n4. Tapin ang \"Allow\" kapag hiniling\n5. Ang app sa iyong watch ay magsasara - buksan ito muli\n6. Bumalik at tapin ang \"Continue\" sa iyong iPhone';
+  String get troubleshootingSteps => 'Troubleshooting:\n\n1. Masiguro na ang Omi ay naka-install sa iyong watch\n2. Buksan ang Omi app sa iyong watch\n3. Hanapin ang permission popup\n4. Tapin ang \"Allow\" kapag hiniling\n5. Ang app sa iyong watch ay magsasara - buksan ito muli\n6. Bumalik at tapin ang \"Continue\" sa iyong iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Ang recording ay nagsimula na!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Ang pahintulot ay hindi pa nabigyan. Mangyaring masiguro na pinahintulutan mo ang microphone access at muling binuksan ang app sa iyong watch.';
+  String get permissionNotGrantedYet => 'Ang pahintulot ay hindi pa nabigyan. Mangyaring masiguro na pinahintulutan mo ang microphone access at muling binuksan ang app sa iyong watch.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1953,8 +1906,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get selectPrimaryLanguage => 'Pumili ng iyong pangunahing wika';
 
   @override
-  String get languageBenefits =>
-      'Itakda ang iyong wika para sa mas matalinong transcriptions at personalized na karanasan';
+  String get languageBenefits => 'Itakda ang iyong wika para sa mas matalinong transcriptions at personalized na karanasan';
 
   @override
   String get whatsYourPrimaryLanguage => 'Ano ang iyong pangunahing wika?';
@@ -2035,8 +1987,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Handa para sa Action Items';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Ang iyong AI ay awtomatikong makakakuha ng mga tasks at to-dos mula sa iyong mga pag-usap. Makikita nila dito kapag ginawa.';
+  String get welcomeActionItemsDescription => 'Ang iyong AI ay awtomatikong makakakuha ng mga tasks at to-dos mula sa iyong mga pag-usap. Makikita nila dito kapag ginawa.';
 
   @override
   String get autoExtractionFeature => 'Awtomatikong na-extract mula sa mga pag-usap';
@@ -2086,8 +2037,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get clearMemoryTitle => 'I-clear ang Alaala ng Omi';
 
   @override
-  String get clearMemoryMessage =>
-      'Sigurado ka ba na gusto mong i-clear ang alaala ng Omi? Ang aksyon na ito ay hindi mababawi.';
+  String get clearMemoryMessage => 'Sigurado ka ba na gusto mong i-clear ang alaala ng Omi? Ang aksyon na ito ay hindi mababawi.';
 
   @override
   String get clearMemoryButton => 'I-clear ang Alaala';
@@ -2233,15 +2183,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'SPEECH & TRANSCRIPTION';
 
   @override
-  String get languageSettingsHelperText =>
-      'Ang App Language ay nagbabago ng mga menu at button. Ang Speech Language ay nakakaapekto sa kung paano na-transcribe ang iyong mga recording.';
+  String get languageSettingsHelperText => 'Ang App Language ay nagbabago ng mga menu at button. Ang Speech Language ay nakakaapekto sa kung paano na-transcribe ang iyong mga recording.';
 
   @override
   String get translationNotice => 'Translation Notice';
 
   @override
-  String get translationNoticeMessage =>
-      'Ang Omi ay nagsasalin ng mga pag-usap sa iyong pangunahing wika. I-update ito anumang oras sa Settings → Profiles.';
+  String get translationNoticeMessage => 'Ang Omi ay nagsasalin ng mga pag-usap sa iyong pangunahing wika. I-update ito anumang oras sa Settings → Profiles.';
 
   @override
   String get pleaseCheckInternetConnection => 'Mangyaring suriin ang iyong internet connection at subukan muli';
@@ -2348,8 +2296,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get firmwareDisconnectUsb => 'Ikabit ang USB';
 
   @override
-  String get firmwareUsbWarning =>
-      'Ang koneksyon ng USB sa panahon ng mga update ay maaaring makasama sa iyong device.';
+  String get firmwareUsbWarning => 'Ang koneksyon ng USB sa panahon ng mga update ay maaaring makasama sa iyong device.';
 
   @override
   String get firmwareBatteryAbove15 => 'Baterya sa Itaas ng 15%';
@@ -2404,8 +2351,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'I-unpair ang Device';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Ito ay mag-unpair ng device upang maaari itong ikonekta sa iba pang telepono. Kailangan mong pumunta sa Settings > Bluetooth at kalimutan ang device upang makumpleto ang proseso.';
+  String get unpairDeviceDialogMessage => 'Ito ay mag-unpair ng device upang maaari itong ikonekta sa iba pang telepono. Kailangan mong pumunta sa Settings > Bluetooth at kalimutan ang device upang makumpleto ang proseso.';
 
   @override
   String get unpair => 'I-unpair';
@@ -2571,8 +2517,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get howDoesItWork => 'Paano ito gumagana?';
 
   @override
-  String get sdCardSyncDescription =>
-      'Ang SD Card Sync ay mag-import ng iyong mga memories mula sa SD Card patungo sa app';
+  String get sdCardSyncDescription => 'Ang SD Card Sync ay mag-import ng iyong mga memories mula sa SD Card patungo sa app';
 
   @override
   String get checksForAudioFiles => 'Sinusuri ang mga audio file sa SD Card';
@@ -2587,8 +2532,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get youreAllSet => 'Lahat ay handa na!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Maligayang pagdating sa Omi! Ang iyong AI companion ay handa nang tulungan ka sa mga conversation, gawain, at marami pa.';
+  String get welcomeToOmiDescription => 'Maligayang pagdating sa Omi! Ang iyong AI companion ay handa nang tulungan ka sa mga conversation, gawain, at marami pa.';
 
   @override
   String get startUsingOmi => 'Magsimulang Gumamit ng Omi';
@@ -2667,8 +2611,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get reviewAndManageConversations => 'Suriin at pamahalaan ang iyong mga captured na conversation';
 
   @override
-  String get startCapturingConversations =>
-      'Magsimulang kumuha ng mga conversation gamit ang iyong Omi device upang makita ang mga ito dito.';
+  String get startCapturingConversations => 'Magsimulang kumuha ng mga conversation gamit ang iyong Omi device upang makita ang mga ito dito.';
 
   @override
   String get useMobileAppToCapture => 'Gamitin ang iyong mobile app upang kumuha ng audio';
@@ -2683,8 +2626,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get showAll => 'Ipakita ang Lahat';
 
   @override
-  String get noTasksForToday =>
-      'Walang mga gawain para sa araw na ito.\nTanungin ang Omi para sa higit pang mga gawain o lumikha nang manu-mano.';
+  String get noTasksForToday => 'Walang mga gawain para sa araw na ito.\nTanungin ang Omi para sa higit pang mga gawain o lumikha nang manu-mano.';
 
   @override
   String get dailyScore => 'PANG-ARAW-ARAW NA PUNTUASYON';
@@ -2726,8 +2668,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get noTasksYet => 'Walang Mga Gawain Pa';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Ang mga gawain mula sa iyong mga conversation ay lilitaw dito.\nI-click ang Create upang magdagdag ng isa nang manu-mano.';
+  String get tasksFromConversationsWillAppear => 'Ang mga gawain mula sa iyong mga conversation ay lilitaw dito.\nI-click ang Create upang magdagdag ng isa nang manu-mano.';
 
   @override
   String get monthJan => 'Ene';
@@ -2784,8 +2725,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deleteActionItem => 'Burahin ang Action Item';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Sigurado ka na ba na nais mong burahin ang action item na ito? Ang aksyong ito ay hindi maaaring bawiin.';
+  String get deleteActionItemConfirmation => 'Sigurado ka na ba na nais mong burahin ang action item na ito? Ang aksyong ito ay hindi maaaring bawiin.';
 
   @override
   String get enterActionItemDescription => 'Magpasok ng paglalarawan ng action item...';
@@ -2860,15 +2800,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get chatPrompt => 'Chat Prompt';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ikaw ay isang kahanga-hangang app, ang iyong trabaho ay tumugon sa mga query ng user at gawing masaya sila...';
+  String get chatPromptPlaceholder => 'Ikaw ay isang kahanga-hangang app, ang iyong trabaho ay tumugon sa mga query ng user at gawing masaya sila...';
 
   @override
   String get conversationPrompt => 'Conversation Prompt';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Ikaw ay isang kahanga-hangang app, bibigyan ka ng transcript at summary ng isang conversation...';
+  String get conversationPromptPlaceholder => 'Ikaw ay isang kahanga-hangang app, bibigyan ka ng transcript at summary ng isang conversation...';
 
   @override
   String get notificationScopes => 'Notification Scopes';
@@ -2880,8 +2818,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get makeMyAppPublic => 'Gawing public ang aking app';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Sa pag-submit ng app na ito, sumasang-ayon ako sa Omi AI Terms of Service at Privacy Policy';
+  String get submitAppTermsAgreement => 'Sa pag-submit ng app na ito, sumasang-ayon ako sa Omi AI Terms of Service at Privacy Policy';
 
   @override
   String get submitApp => 'Magpadala ng App';
@@ -2896,12 +2833,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get submitAppQuestion => 'Magpadala ng App?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Ang iyong app ay ire-review at ginagawang public. Maaari kang magsimulang gamitin ito kaagad, kahit sa panahon ng review!';
+  String get submitAppPublicDescription => 'Ang iyong app ay ire-review at ginagawang public. Maaari kang magsimulang gamitin ito kaagad, kahit sa panahon ng review!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Ang iyong app ay ire-review at gagawin itong available sa iyo nang pribado. Maaari kang magsimulang gamitin ito kaagad, kahit sa panahon ng review!';
+  String get submitAppPrivateDescription => 'Ang iyong app ay ire-review at gagawin itong available sa iyo nang pribado. Maaari kang magsimulang gamitin ito kaagad, kahit sa panahon ng review!';
 
   @override
   String get startEarning => 'Magsimulang Kumita! 💰';
@@ -2925,23 +2860,19 @@ class AppLocalizationsTl extends AppLocalizations {
   String get dataAccessNotice => 'Data Access Notice';
 
   @override
-  String get dataAccessWarning =>
-      'Ang app na ito ay makakapag-access sa iyong data. Ang Omi AI ay hindi responsable sa kung paano ang iyong data ay ginagamit, binabago, o bina-delete ng app na ito';
+  String get dataAccessWarning => 'Ang app na ito ay makakapag-access sa iyong data. Ang Omi AI ay hindi responsable sa kung paano ang iyong data ay ginagamit, binabago, o bina-delete ng app na ito';
 
   @override
   String get installApp => 'I-install ang App';
 
   @override
-  String get betaTesterNotice =>
-      'Ikaw ay isang beta tester para sa app na ito. Ito ay hindi pa public. Magiging public ito kapag naunang aprubahan.';
+  String get betaTesterNotice => 'Ikaw ay isang beta tester para sa app na ito. Ito ay hindi pa public. Magiging public ito kapag naunang aprubahan.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Ang iyong app ay nasa ilalim ng review at makikita lamang ng iyo. Magiging public ito kapag naunang aprubahan.';
+  String get appUnderReviewOwner => 'Ang iyong app ay nasa ilalim ng review at makikita lamang ng iyo. Magiging public ito kapag naunang aprubahan.';
 
   @override
-  String get appRejectedNotice =>
-      'Ang iyong app ay nireject. Pakibago ang mga detalye ng app at muling ipadala para sa review.';
+  String get appRejectedNotice => 'Ang iyong app ay nireject. Pakibago ang mga detalye ng app at muling ipadala para sa review.';
 
   @override
   String get setupSteps => 'Setup Steps';
@@ -3003,8 +2934,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get descriptionLabel => 'Description';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'My Awesome App ay isang mahusay na app na gumagawa ng mga kahanga-hangang bagay. Ito ang pinakamagandang app!';
+  String get appDescriptionPlaceholder => 'My Awesome App ay isang mahusay na app na gumagawa ng mga kahanga-hangang bagay. Ito ang pinakamagandang app!';
 
   @override
   String get pleaseProvideValidDescription => 'Pakibigay ng isang wastong paglalarawan';
@@ -3141,8 +3071,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get clearChatTitle => 'I-clear ang Chat?';
 
   @override
-  String get confirmClearChat =>
-      'Sigurado ka na ba na nais mong i-clear ang chat? Ang aksyong ito ay hindi maaaring bawiin.';
+  String get confirmClearChat => 'Sigurado ka na ba na nais mong i-clear ang chat? Ang aksyong ito ay hindi maaaring bawiin.';
 
   @override
   String get copy => 'Kopyahin';
@@ -3157,8 +3086,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get microphonePermissionRequired => 'Kailangan ng microphone permission upang gumawa ng mga tawag';
 
   @override
-  String get microphonePermissionDenied =>
-      'Microphone permission ay natatanggihan. Pakigive ng pahintulot sa System Preferences > Privacy & Security > Microphone.';
+  String get microphonePermissionDenied => 'Microphone permission ay natatanggihan. Pakigive ng pahintulot sa System Preferences > Privacy & Security > Microphone.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3317,8 +3245,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get createMemory => 'Lumikha ng Memory';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Sigurado ka na ba na nais mong burahin ang memory na ito? Ang aksyong ito ay hindi maaaring bawiin.';
+  String get deleteMemoryConfirmation => 'Sigurado ka na ba na nais mong burahin ang memory na ito? Ang aksyong ito ay hindi maaaring bawiin.';
 
   @override
   String get makePrivate => 'Gawing Private';
@@ -3392,8 +3319,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get whatWeCollect => 'Kung ano ang aming kinokolekta';
 
   @override
-  String get dataCollectionMessage =>
-      'Sa pamamagitan ng pagpatuloy, ang iyong mga conversation, recording, at personal na impormasyon ay ligtas na maiipon sa aming mga server upang magbigay ng AI-powered insights at paganahin ang lahat ng features ng app.';
+  String get dataCollectionMessage => 'Sa pamamagitan ng pagpatuloy, ang iyong mga conversation, recording, at personal na impormasyon ay ligtas na maiipon sa aming mga server upang magbigay ng AI-powered insights at paganahin ang lahat ng features ng app.';
 
   @override
   String get dataProtection => 'Proteksyon ng Data';
@@ -3408,8 +3334,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get chooseYourLanguage => 'Piliin ang iyong wika';
 
   @override
-  String get selectPreferredLanguageForBestExperience =>
-      'Piliin ang iyong preferred na wika para sa pinakamahusay na Omi experience';
+  String get selectPreferredLanguageForBestExperience => 'Piliin ang iyong preferred na wika para sa pinakamahusay na Omi experience';
 
   @override
   String get searchLanguages => 'Maghanap ng mga wika...';
@@ -3427,8 +3352,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Ang pangalan ay dapat na hindi bababa sa 2 characters';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Sabihin sa amin kung paano ka nais tawagan. Ito ay tumutulong na i-personalize ang iyong Omi experience.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Sabihin sa amin kung paano ka nais tawagan. Ito ay tumutulong na i-personalize ang iyong Omi experience.';
 
   @override
   String charactersCount(int count) {
@@ -3436,8 +3360,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Paganahin ang mga features para sa pinakamahusay na Omi experience sa iyong device.';
+  String get enableFeaturesForBestExperience => 'Paganahin ang mga features para sa pinakamahusay na Omi experience sa iyong device.';
 
   @override
   String get microphoneAccess => 'Microphone Access';
@@ -3446,8 +3369,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get recordAudioConversations => 'I-record ang audio conversations';
 
   @override
-  String get microphoneAccessDescription =>
-      'Kailangan ng Omi ang microphone access upang i-record ang iyong mga conversation at magbigay ng mga transcription.';
+  String get microphoneAccessDescription => 'Kailangan ng Omi ang microphone access upang i-record ang iyong mga conversation at magbigay ng mga transcription.';
 
   @override
   String get screenRecording => 'Screen Recording';
@@ -3456,8 +3378,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Kunin ang system audio mula sa mga meeting';
 
   @override
-  String get screenRecordingDescription =>
-      'Kailangan ng Omi ng screen recording permission upang kunin ang system audio mula sa iyong browser-based na mga meeting.';
+  String get screenRecordingDescription => 'Kailangan ng Omi ng screen recording permission upang kunin ang system audio mula sa iyong browser-based na mga meeting.';
 
   @override
   String get accessibility => 'Accessibility';
@@ -3466,8 +3387,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Tukuyin ang browser-based na mga meeting';
 
   @override
-  String get accessibilityDescription =>
-      'Kailangan ng Omi ng accessibility permission upang matukoy kung kailan ka sumali sa Zoom, Meet, o Teams meetings sa iyong browser.';
+  String get accessibilityDescription => 'Kailangan ng Omi ng accessibility permission upang matukoy kung kailan ka sumali sa Zoom, Meet, o Teams meetings sa iyong browser.';
 
   @override
   String get pleaseWait => 'Mangyaring maghintay...';
@@ -3515,8 +3435,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get preferences => 'Mga Kagustuhan';
 
   @override
-  String get helpImproveOmiBySharing =>
-      'Tumulong na mapabuti ang Omi sa pamamagitan ng pagbabahagi ng anonymized analytics data';
+  String get helpImproveOmiBySharing => 'Tumulong na mapabuti ang Omi sa pamamagitan ng pagbabahagi ng anonymized analytics data';
 
   @override
   String get deleteAccount => 'Burahin ang Account';
@@ -3537,12 +3456,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get exportAllConversationsToJson => 'I-export ang lahat ng iyong mga conversation sa isang JSON file.';
 
   @override
-  String get conversationsExportStarted =>
-      'Nagsimula na ang Conversations Export. Ito ay maaaring tumagal ng ilang segundo, mangyaring maghintay.';
+  String get conversationsExportStarted => 'Nagsimula na ang Conversations Export. Ito ay maaaring tumagal ng ilang segundo, mangyaring maghintay.';
 
   @override
-  String get mcpDescription =>
-      'Upang ikonekta ang Omi sa ibang mga aplikasyon upang basahin, maghanap, at pamahalaan ang iyong mga memory at conversation. Lumikha ng isang key upang magsimula.';
+  String get mcpDescription => 'Upang ikonekta ang Omi sa ibang mga aplikasyon upang basahin, maghanap, at pamahalaan ang iyong mga memory at conversation. Lumikha ng isang key upang magsimula.';
 
   @override
   String get apiKeys => 'API Keys';
@@ -3583,15 +3500,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get transcriptionServiceDiagnosticStatus => 'Transcription service diagnostic status';
 
   @override
-  String get enableDetailedDiagnosticMessages =>
-      'Paganahin ang detailed diagnostic messages mula sa transcription service';
+  String get enableDetailedDiagnosticMessages => 'Paganahin ang detailed diagnostic messages mula sa transcription service';
 
   @override
   String get autoCreateAndTagNewSpeakers => 'Auto-create at mag-tag ng bagong mga speaker';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Awtomatikong lumikha ng isang bagong tao kapag ang isang pangalan ay na-detect sa transcript.';
+  String get automaticallyCreateNewPerson => 'Awtomatikong lumikha ng isang bagong tao kapag ang isang pangalan ay na-detect sa transcript.';
 
   @override
   String get pilotFeatures => 'Pilot Features';
@@ -3615,8 +3530,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get auto => 'Awtomatiko';
 
   @override
-  String get noSummaryForApp =>
-      'Walang buod na available para sa app na ito. Subukan ang ibang app para sa mas mahusay na resulta.';
+  String get noSummaryForApp => 'Walang buod na available para sa app na ito. Subukan ang ibang app para sa mas mahusay na resulta.';
 
   @override
   String get tryAnotherApp => 'Subukan ang Ibang App';
@@ -3653,8 +3567,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Hayaan ang Omi na pumili ng pinakamahusay na app nang awtomatiko';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Sigurado ka na ba na gusto mong burahin ang conversation na ito? Ang aksyong ito ay hindi mababawi.';
+  String get deleteConversationConfirmation => 'Sigurado ka na ba na gusto mong burahin ang conversation na ito? Ang aksyong ito ay hindi mababawi.';
 
   @override
   String get conversationDeleted => 'Conversation na nabura';
@@ -3702,8 +3615,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Nag-prepare ng system audio capture';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'I-click ang button upang kunin ang audio para sa live transcripts, AI insights, at automatic saving.';
+  String get clickTheButtonToCaptureAudio => 'I-click ang button upang kunin ang audio para sa live transcripts, AI insights, at automatic saving.';
 
   @override
   String get reconnecting => 'Nag-reconnect...';
@@ -3861,8 +3773,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get dailySummaryTitle => 'Daily Summary';
 
   @override
-  String get dailySummaryDescription =>
-      'Makatanggap ng personalized na buod ng iyong mga conversation sa araw na ipadala bilang notipikasyon.';
+  String get dailySummaryDescription => 'Makatanggap ng personalized na buod ng iyong mga conversation sa araw na ipadala bilang notipikasyon.';
 
   @override
   String get deliveryTime => 'Oras ng Paghahatid';
@@ -3907,8 +3818,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get shortcuts => 'Mga Shortcut';
 
   @override
-  String get shortcutChangeInstruction =>
-      'I-click sa isang shortcut upang baguhin ito. Pindutin ang Escape upang kanselahin.';
+  String get shortcutChangeInstruction => 'I-click sa isang shortcut upang baguhin ito. Pindutin ang Escape upang kanselahin.';
 
   @override
   String get configureSTTProvider => 'I-configure ang STT provider';
@@ -3932,8 +3842,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Burahin ang Knowledge Graph?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Ito ay buburahin ang lahat ng derived knowledge graph data. Ang iyong original na mga memory ay manatiling ligtas.';
+  String get deleteKnowledgeGraphWarning => 'Ito ay buburahin ang lahat ng derived knowledge graph data. Ang iyong original na mga memory ay manatiling ligtas.';
 
   @override
   String get connectOmiWithAI => 'Ikonekta ang Omi sa AI assistants';
@@ -3990,8 +3899,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get updateAppQuestion => 'I-update ang App?';
 
   @override
-  String get updateAppConfirmation =>
-      'Sigurado ka na ba na gusto mong i-update ang iyong app? Ang mga pagbabago ay makikita kapag na-review na ng aming team.';
+  String get updateAppConfirmation => 'Sigurado ka na ba na gusto mong i-update ang iyong app? Ang mga pagbabago ay makikita kapag na-review na ng aming team.';
 
   @override
   String get updateApp => 'I-update ang App';
@@ -4021,8 +3929,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get no => 'Hindi';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Subscription na successfully na-cancel. Ito ay manatiling aktibo hanggang sa katapusan ng current billing period.';
+  String get subscriptionCancelledSuccessfully => 'Subscription na successfully na-cancel. Ito ay manatiling aktibo hanggang sa katapusan ng current billing period.';
 
   @override
   String get failedToCancelSubscription => 'Failed na i-cancel ang subscription. Mangyaring subukan ulit.';
@@ -4058,8 +3965,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'I-cancel ang Subscription?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Sigurado ka na ba na gusto mong i-cancel ang iyong subscription? Magpapatuloy kang may access hanggang sa katapusan ng iyong current billing period.';
+  String get cancelSubscriptionConfirmation => 'Sigurado ka na ba na gusto mong i-cancel ang iyong subscription? Magpapatuloy kang may access hanggang sa katapusan ng iyong current billing period.';
 
   @override
   String get cancelSubscriptionButton => 'I-cancel ang Subscription';
@@ -4068,16 +3974,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get cancelling => 'Nag-cancel...';
 
   @override
-  String get betaTesterMessage =>
-      'Ikaw ay isang beta tester para sa app na ito. Hindi pa ito pampubliko. Ito ay magiging pampubliko kapag na-approve na.';
+  String get betaTesterMessage => 'Ikaw ay isang beta tester para sa app na ito. Hindi pa ito pampubliko. Ito ay magiging pampubliko kapag na-approve na.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Ang iyong app ay nasa review at makikita lamang ng iyo. Ito ay magiging pampubliko kapag na-approve na.';
+  String get appUnderReviewMessage => 'Ang iyong app ay nasa review at makikita lamang ng iyo. Ito ay magiging pampubliko kapag na-approve na.';
 
   @override
-  String get appRejectedMessage =>
-      'Ang iyong app ay naging reject. Mangyaring i-update ang app details at mag-resubmit para sa review.';
+  String get appRejectedMessage => 'Ang iyong app ay naging reject. Mangyaring i-update ang app details at mag-resubmit para sa review.';
 
   @override
   String get invalidIntegrationUrl => 'Invalid integration URL';
@@ -4131,8 +4034,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get issueActivatingApp => 'Mayroong isyu sa pag-activate ng app na ito. Mangyaring subukan ulit.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Ang app na ito ay mag-access sa iyong data. Ang Omi AI ay hindi responsable kung paano ginagamit, binabago, o binubura ang iyong data ng app na ito';
+  String get dataAccessNoticeDescription => 'Ang app na ito ay mag-access sa iyong data. Ang Omi AI ay hindi responsable kung paano ginagamit, binabago, o binubura ang iyong data ng app na ito';
 
   @override
   String get copyUrl => 'Kopyahin ang URL';
@@ -4220,8 +4122,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get omiApiKeys => 'Omi API Keys';
 
   @override
-  String get apiKeysDescription =>
-      'Ang API Keys ay ginagamit para sa authentication kapag ang iyong app ay nakikipag-ugnayan sa OMI server. Pinapayagan nila ang iyong application na lumikha ng mga memory at mag-access ng ibang OMI services nang secure.';
+  String get apiKeysDescription => 'Ang API Keys ay ginagamit para sa authentication kapag ang iyong app ay nakikipag-ugnayan sa OMI server. Pinapayagan nila ang iyong application na lumikha ng mga memory at mag-access ng ibang OMI services nang secure.';
 
   @override
   String get aboutOmiApiKeys => 'Tungkol sa Omi API Keys';
@@ -4245,8 +4146,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Mag-revoke ng API Key?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Ang aksyong ito ay hindi mababawi. Ang anumang aplikasyon na gumagamit ng key na ito ay hindi na makakapag-access sa API.';
+  String get revokeApiKeyWarning => 'Ang aksyong ito ay hindi mababawi. Ang anumang aplikasyon na gumagamit ng key na ito ay hindi na makakapag-access sa API.';
 
   @override
   String get revoke => 'Mag-revoke';
@@ -4335,8 +4235,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get keyCreated => 'Key na Nilikha';
 
   @override
-  String get keyCreatedMessage =>
-      'Ang iyong bagong key ay na-create na. Mangyaring kopyahin ito ngayon. Hindi mo na makikita ito ulit.';
+  String get keyCreatedMessage => 'Ang iyong bagong key ay na-create na. Mangyaring kopyahin ito ngayon. Hindi mo na makikita ito ulit.';
 
   @override
   String get keyWord => 'Key';
@@ -4345,8 +4244,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get externalAppAccess => 'External App Access';
 
   @override
-  String get externalAppAccessDescription =>
-      'Ang sumusunod na installed apps ay may external integrations at maaaring mag-access sa iyong data, tulad ng mga conversation at memory.';
+  String get externalAppAccessDescription => 'Ang sumusunod na installed apps ay may external integrations at maaaring mag-access sa iyong data, tulad ng mga conversation at memory.';
 
   @override
   String get noExternalAppsHaveAccess => 'Walang external apps na may access sa iyong data.';
@@ -4355,8 +4253,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maximum Security (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Ang end-to-end encryption ay ang gold standard para sa privacy. Kapag na-enable ito, ang iyong data ay naka-encrypt sa iyong device bago ipadala sa aming mga server. Ito ay nangangahulugang walang isa, hindi pa naman ang Omi, ay makaka-access sa iyong content.';
+  String get e2eeDescription => 'Ang end-to-end encryption ay ang gold standard para sa privacy. Kapag na-enable ito, ang iyong data ay naka-encrypt sa iyong device bago ipadala sa aming mga server. Ito ay nangangahulugang walang isa, hindi pa naman ang Omi, ay makaka-access sa iyong content.';
 
   @override
   String get importantTradeoffs => 'Mga Mahalagang Trade-offs:';
@@ -4371,8 +4268,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get featureComingSoon => 'Ang feature na ito ay paparating na!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Migration na nag-iingay. Hindi mo mababago ang protection level hanggang sa ito ay nakumpleto.';
+  String get migrationInProgressMessage => 'Migration na nag-iingay. Hindi mo mababago ang protection level hanggang sa ito ay nakumpleto.';
 
   @override
   String get migrationFailed => 'Migration na Failed';
@@ -4391,15 +4287,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get secureEncryption => 'Secure Encryption';
 
   @override
-  String get secureEncryptionDescription =>
-      'Ang iyong data ay naka-encrypt gamit ang isang key na natatangi sa iyo sa aming mga server, hosted sa Google Cloud. Ito ay nangangahulugang ang iyong raw na content ay hindi accessible sa sinuman, kabilang ang Omi staff o Google, direkta mula sa database.';
+  String get secureEncryptionDescription => 'Ang iyong data ay naka-encrypt gamit ang isang key na natatangi sa iyo sa aming mga server, hosted sa Google Cloud. Ito ay nangangahulugang ang iyong raw na content ay hindi accessible sa sinuman, kabilang ang Omi staff o Google, direkta mula sa database.';
 
   @override
   String get endToEndEncryption => 'End-to-End Encryption';
 
   @override
-  String get e2eeCardDescription =>
-      'Paganahin para sa maximum security kung saan lamang ikaw ay maka-access sa iyong data. Itap upang matuto pa.';
+  String get e2eeCardDescription => 'Paganahin para sa maximum security kung saan lamang ikaw ay maka-access sa iyong data. Itap upang matuto pa.';
 
   @override
   String get dataAlwaysEncrypted => 'Anuman ang level, ang iyong data ay laging encrypted sa rest at in transit.';
@@ -4467,12 +4361,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get trainingDataProgram => 'Training Data Program';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Makakuha ng Omi Unlimited nang libre sa pamamagitan ng pagbibigay ng iyong data upang magsanay sa AI models.';
+  String get getOmiUnlimitedFree => 'Makakuha ng Omi Unlimited nang libre sa pamamagitan ng pagbibigay ng iyong data upang magsanay sa AI models.';
 
   @override
-  String get trainingDataBullets =>
-      '• Ang iyong data ay tumutulong na mapabuti ang AI models\n• Lamang ang non-sensitive data ang ibabahagi\n• Fully transparent na proseso';
+  String get trainingDataBullets => '• Ang iyong data ay tumutulong na mapabuti ang AI models\n• Lamang ang non-sensitive data ang ibabahagi\n• Fully transparent na proseso';
 
   @override
   String get learnMoreAtOmiTraining => 'Matuto pa sa omi.me/training';
@@ -4484,8 +4376,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get submitRequest => 'Mag-submit ng Request';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Salamat! Ang iyong request ay nasa review. Kami ay mag-notify sa iyo kapag na-approve na.';
+  String get thankYouRequestUnderReview => 'Salamat! Ang iyong request ay nasa review. Kami ay mag-notify sa iyo kapag na-approve na.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4520,20 +4411,16 @@ class AppLocalizationsTl extends AppLocalizations {
   String get importantBillingInfo => 'Mahalagang Impormasyon sa Pagbabayad:';
 
   @override
-  String get monthlyPlanContinues =>
-      'Ang iyong kasalukuyang monthly plan ay magpapatuloy hanggang sa katapusan ng iyong billing period';
+  String get monthlyPlanContinues => 'Ang iyong kasalukuyang monthly plan ay magpapatuloy hanggang sa katapusan ng iyong billing period';
 
   @override
-  String get paymentMethodCharged =>
-      'Ang iyong existing payment method ay awtomatikong babayaran kapag nagtatapos ang iyong monthly plan';
+  String get paymentMethodCharged => 'Ang iyong existing payment method ay awtomatikong babayaran kapag nagtatapos ang iyong monthly plan';
 
   @override
-  String get annualSubscriptionStarts =>
-      'Ang iyong 12-buwan na annual subscription ay awtomatikong magsisimula pagkatapos ng bayad';
+  String get annualSubscriptionStarts => 'Ang iyong 12-buwan na annual subscription ay awtomatikong magsisimula pagkatapos ng bayad';
 
   @override
-  String get thirteenMonthsCoverage =>
-      'Makakakuha ka ng kabuuang 13 buwan ng coverage (kasalukuyang buwan + 12 buwan annual)';
+  String get thirteenMonthsCoverage => 'Makakakuha ka ng kabuuang 13 buwan ng coverage (kasalukuyang buwan + 12 buwan annual)';
 
   @override
   String get confirmUpgrade => 'Kumpirmahin ang Upgrade';
@@ -4557,8 +4444,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get youAreOnUnlimitedPlan => 'Ikaw ay nasa Unlimited Plan.';
 
   @override
-  String get yourOmiUnleashed =>
-      'Ang iyong Omi, na walang hanggan. Maging unlimited para sa walang hanggang posibilidad.';
+  String get yourOmiUnleashed => 'Ang iyong Omi, na walang hanggan. Maging unlimited para sa walang hanggang posibilidad.';
 
   @override
   String planEndedOn(String date) {
@@ -4571,8 +4457,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Ang iyong annual plan ay awtomatikong magsisimula kapag nagtatapos ang iyong monthly plan.';
+  String get annualPlanStartsAutomatically => 'Ang iyong annual plan ay awtomatikong magsisimula kapag nagtatapos ang iyong monthly plan.';
 
   @override
   String planRenewsOn(String date) {
@@ -4639,8 +4524,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Mahalaga sa Amin ang Iyong Privacy';
 
   @override
-  String get privacyIntroText =>
-      'Sa Omi, seryoso kami ang kinuha ang iyong privacy. Nais naming maging transparent tungkol sa data na aming kinukuha at kung paano namin ito ginagamit upang mapabuti ang aming produkto para sa iyo. Narito kung ano ang kailangan mong malaman:';
+  String get privacyIntroText => 'Sa Omi, seryoso kami ang kinuha ang iyong privacy. Nais naming maging transparent tungkol sa data na aming kinukuha at kung paano namin ito ginagamit upang mapabuti ang aming produkto para sa iyo. Narito kung ano ang kailangan mong malaman:';
 
   @override
   String get whatWeTrack => 'Ano ang Aming Sinusubaybayan';
@@ -4655,12 +4539,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get ourCommitment => 'Ang Aming Pangako';
 
   @override
-  String get commitmentText =>
-      'Kami ay nakatuon sa paggamit ng data na aming kinukuha lamang upang gawing mas mahusay na produkto ang Omi para sa iyo. Ang iyong privacy at tiwala ay pangunahin para sa amin.';
+  String get commitmentText => 'Kami ay nakatuon sa paggamit ng data na aming kinukuha lamang upang gawing mas mahusay na produkto ang Omi para sa iyo. Ang iyong privacy at tiwala ay pangunahin para sa amin.';
 
   @override
-  String get thankYouText =>
-      'Salamat sa pagiging valued user ng Omi. Kung mayroon kang anumang mga katanungan o alalahanin, huwag mag-atubiling makipag-ugnayan sa amin sa team@basedhardware.com.';
+  String get thankYouText => 'Salamat sa pagiging valued user ng Omi. Kung mayroon kang anumang mga katanungan o alalahanin, huwag mag-atubiling makipag-ugnayan sa amin sa team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'WiFi Sync Settings';
@@ -4669,8 +4551,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get enterHotspotCredentials => 'Ipasok ang iyong phone hotspot credentials';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'Ang WiFi sync ay gumagamit ng iyong phone bilang hotspot. Hanapin ang iyong hotspot name at password sa Settings > Personal Hotspot.';
+  String get wifiSyncUsesHotspot => 'Ang WiFi sync ay gumagamit ng iyong phone bilang hotspot. Hanapin ang iyong hotspot name at password sa Settings > Personal Hotspot.';
 
   @override
   String get hotspotNameSsid => 'Hotspot Name (SSID)';
@@ -4705,8 +4586,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Nabigong lumikha ng summary. Tiyakin na mayroon kang mga pag-uusap para sa araw na iyon.';
+  String get failedToGenerateSummaryCheckConversations => 'Nabigong lumikha ng summary. Tiyakin na mayroon kang mga pag-uusap para sa araw na iyon.';
 
   @override
   String get summaryNotFound => 'Summary ay hindi nahanap';
@@ -4736,8 +4616,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Export ay nagsimula. Maaaring ito ay aabot ng ilang segundo...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Ito ay magbabura ng lahat ng derived knowledge graph data (nodes at connections). Ang iyong mga orihinal na memories ay magiging ligtas. Ang graph ay muling mabubuo sa paglipas ng panahon o sa susunod na request.';
+  String get knowledgeGraphDeleteDescription => 'Ito ay magbabura ng lahat ng derived knowledge graph data (nodes at connections). Ang iyong mga orihinal na memories ay magiging ligtas. Ang graph ay muling mabubuo sa paglipas ng panahon o sa susunod na request.';
 
   @override
   String get configureDailySummaryDigest => 'I-configure ang iyong daily action items digest';
@@ -4807,8 +4686,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Burahin ang Lahat ng Limitless Conversations?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Ito ay permanenteng magbabura ng lahat ng mga pag-uusap na na-import mula sa Limitless. Ang aksyon na ito ay hindi maaaring i-undo.';
+  String get deleteAllLimitlessWarning => 'Ito ay permanenteng magbabura ng lahat ng mga pag-uusap na na-import mula sa Limitless. Ang aksyon na ito ay hindi maaaring i-undo.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4864,8 +4742,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get howItWorksTitle => 'Paano ito gumagana?';
 
   @override
-  String get howPeopleWorks =>
-      'Kapag lumikha ng isang tao, maaari kang pumunta sa isang conversation transcript, at italaan sa kanila ang kanilang corresponding segments, sa ganitong paraan ang Omi ay makakapag-recognize ng kanilang speech din!';
+  String get howPeopleWorks => 'Kapag lumikha ng isang tao, maaari kang pumunta sa isang conversation transcript, at italaan sa kanila ang kanilang corresponding segments, sa ganitong paraan ang Omi ay makakapag-recognize ng kanilang speech din!';
 
   @override
   String get tapToDelete => 'I-tap upang burahin';
@@ -4891,8 +4768,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get privacyNotice => 'Privacy Notice';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Ang mga recordings ay maaaring kumuha ng ibang mga boses. Tiyakin na mayroon kang pahintulot mula sa lahat ng participants bago paganahin.';
+  String get recordingsMayCaptureOthers => 'Ang mga recordings ay maaaring kumuha ng ibang mga boses. Tiyakin na mayroon kang pahintulot mula sa lahat ng participants bago paganahin.';
 
   @override
   String get enable => 'I-enable';
@@ -4904,8 +4780,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Panatilihin ang lahat ng audio recordings na naka-store nang lokal sa iyong phone. Kapag naka-disable, ang mga nabigong uploads lamang ang iniingatan upang makatipid ng storage space.';
+  String get storeAudioDescription => 'Panatilihin ang lahat ng audio recordings na naka-store nang lokal sa iyong phone. Kapag naka-disable, ang mga nabigong uploads lamang ang iniingatan upang makatipid ng storage space.';
 
   @override
   String get enableLocalStorage => 'I-enable ang Local Storage';
@@ -4923,12 +4798,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get storeAudioOnCloud => 'Mag-store ng Audio sa Cloud';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Ang iyong real-time recordings ay ise-store sa private cloud storage habang nagsasalita ka.';
+  String get cloudStorageDialogMessage => 'Ang iyong real-time recordings ay ise-store sa private cloud storage habang nagsasalita ka.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'I-store ang iyong real-time recordings sa private cloud storage habang nagsasalita ka. Ang audio ay kina-capture at ina-save nang secure sa real-time.';
+  String get storeAudioCloudDescription => 'I-store ang iyong real-time recordings sa private cloud storage habang nagsasalita ka. Ang audio ay kina-capture at ina-save nang secure sa real-time.';
 
   @override
   String get downloadingFirmware => 'Nagda-download ng Firmware';
@@ -4937,8 +4810,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get installingFirmware => 'Nag-install ng Firmware';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Huwag itigil ang app o i-off ang device. Ito ay maaaring magdulot ng damage sa iyong device.';
+  String get firmwareUpdateWarning => 'Huwag itigil ang app o i-off ang device. Ito ay maaaring magdulot ng damage sa iyong device.';
 
   @override
   String get firmwareUpdated => 'Firmware Updated';
@@ -4982,8 +4854,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get payments => 'Mga Pagbabayad';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Kumonekta sa isang payment method sa ibaba upang magsimulang tumanggap ng payouts para sa iyong apps.';
+  String get connectPaymentMethodInfo => 'Kumonekta sa isang payment method sa ibaba upang magsimulang tumanggap ng payouts para sa iyong apps.';
 
   @override
   String get selectedPaymentMethod => 'Selected Payment Method';
@@ -5010,8 +4881,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get monthlyPayouts => 'Monthly payouts';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'Makatanggap ng monthly payments direkta sa iyong account kapag umabot ka na sa \$10 sa earnings';
+  String get monthlyPayoutsDescription => 'Makatanggap ng monthly payments direkta sa iyong account kapag umabot ka na sa \$10 sa earnings';
 
   @override
   String get secureAndReliable => 'Secure at reliable';
@@ -5023,8 +4893,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get selectYourCountry => 'Piliin ang iyong bansa';
 
   @override
-  String get countrySelectionPermanent =>
-      'Ang iyong country selection ay permanent at hindi maaaring baguhin sa hinaharap.';
+  String get countrySelectionPermanent => 'Ang iyong country selection ay permanent at hindi maaaring baguhin sa hinaharap.';
 
   @override
   String get byClickingConnectNow => 'Sa pamamagitan ng pag-click sa \"Connect Now\" sumasang-ayon ka sa';
@@ -5039,8 +4908,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get connectingYourStripeAccount => 'Konektado ang iyong Stripe account';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Mangyaring tapusin ang Stripe onboarding process sa iyong browser. Ang pahina na ito ay awtomatikong mag-update kapag tapos na.';
+  String get stripeOnboardingInstructions => 'Mangyaring tapusin ang Stripe onboarding process sa iyong browser. Ang pahina na ito ay awtomatikong mag-update kapag tapos na.';
 
   @override
   String get failedTryAgain => 'Nabigo? Subukan Muli';
@@ -5052,8 +4920,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get successfullyConnected => 'Successfully Connected!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Ang iyong Stripe account ay handa na na makatanggap ng payments. Maaari na kang magsimulang kumita mula sa iyong app sales kaagad.';
+  String get stripeReadyForPayments => 'Ang iyong Stripe account ay handa na na makatanggap ng payments. Maaari na kang magsimulang kumita mula sa iyong app sales kaagad.';
 
   @override
   String get updateStripeDetails => 'I-update ang Stripe Details';
@@ -5071,8 +4938,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get updatePayPalAccountDetails => 'I-update ang iyong PayPal account details';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Kumonekta sa iyong PayPal account upang magsimulang tumanggap ng payments para sa iyong apps';
+  String get connectPayPalToReceivePayments => 'Kumonekta sa iyong PayPal account upang magsimulang tumanggap ng payments para sa iyong apps';
 
   @override
   String get paypalEmail => 'PayPal Email';
@@ -5081,8 +4947,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me Link';
 
   @override
-  String get stripeRecommendation =>
-      'Kung ang Stripe ay available sa iyong bansa, lubos naming inirekomenda ang paggamit nito para sa mas mabilis at mas madaling payouts.';
+  String get stripeRecommendation => 'Kung ang Stripe ay available sa iyong bansa, lubos naming inirekomenda ang paggamit nito para sa mas mabilis at mas madaling payouts.';
 
   @override
   String get updatePayPalDetails => 'I-update ang PayPal Details';
@@ -5134,12 +4999,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Additional Speech Sample Removed';
 
   @override
-  String get consentDataMessage =>
-      'Sa pagpapatuloy, ang iyong mga pag-uusap, recording, at personal na impormasyon ay ligtas na maiimbak sa aming mga server. Ang iyong mga audio recording at transcript ay pinoproseso ng third-party na mga serbisyo ng AI (kabilang ang Deepgram para sa transcription at OpenAI para sa analysis) upang mabigyan ka ng AI-powered na mga insight at ma-enable ang lahat ng feature ng app.';
+  String get consentDataMessage => 'Sa pagpapatuloy, ang iyong mga pag-uusap, recording, at personal na impormasyon ay ligtas na maiimbak sa aming mga server. Ang iyong mga audio recording at transcript ay pinoproseso ng third-party na mga serbisyo ng AI (kabilang ang Deepgram para sa transcription at OpenAI para sa analysis) upang mabigyan ka ng AI-powered na mga insight at ma-enable ang lahat ng feature ng app.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Ang mga tasks mula sa iyong mga pag-uusap ay lilitaw dito.\\nI-tap ang + upang lumikha ng isa nang manual.';
+  String get tasksEmptyStateMessage => 'Ang mga tasks mula sa iyong mga pag-uusap ay lilitaw dito.\\nI-tap ang + upang lumikha ng isa nang manual.';
 
   @override
   String get clearChatAction => 'Burahin ang Chat';
@@ -5175,15 +5038,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get installOmiOnAppleWatch => 'I-install ang Omi sa iyong\\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Upang gamitin ang iyong Apple Watch kasama ang Omi, kailangan mo munang i-install ang Omi app sa iyong watch.';
+  String get installOmiOnAppleWatchDescription => 'Upang gamitin ang iyong Apple Watch kasama ang Omi, kailangan mo munang i-install ang Omi app sa iyong watch.';
 
   @override
   String get openOmiOnAppleWatch => 'Buksan ang Omi sa iyong\\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Ang Omi app ay naka-install na sa iyong Apple Watch. Buksan ito at i-tap ang Start upang magsimula.';
+  String get openOmiOnAppleWatchDescription => 'Ang Omi app ay naka-install na sa iyong Apple Watch. Buksan ito at i-tap ang Start upang magsimula.';
 
   @override
   String get openWatchApp => 'Buksan ang Watch App';
@@ -5192,15 +5053,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Nag-install na ako at Binuksan ang App';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Hindi maaaring buksan ang Apple Watch app. Mangyaring manu-manong buksan ang Watch app sa iyong Apple Watch at i-install ang Omi mula sa \"Available Apps\" section.';
+  String get unableToOpenWatchApp => 'Hindi maaaring buksan ang Apple Watch app. Mangyaring manu-manong buksan ang Watch app sa iyong Apple Watch at i-install ang Omi mula sa \"Available Apps\" section.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch ay matagumpay na konektado!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch ay hindi pa rin reachable. Mangyaring tiyakin na ang Omi app ay bukas sa iyong watch.';
+  String get appleWatchNotReachable => 'Apple Watch ay hindi pa rin reachable. Mangyaring tiyakin na ang Omi app ay bukas sa iyong watch.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5217,8 +5076,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get finishedConversation => 'Natapos ang Conversation?';
 
   @override
-  String get stopRecordingConfirmation =>
-      'Sigurado ka ba na gusto mong ihinto ang pag-record at i-summarize ang pag-uusap ngayon?';
+  String get stopRecordingConfirmation => 'Sigurado ka ba na gusto mong ihinto ang pag-record at i-summarize ang pag-uusap ngayon?';
 
   @override
   String get conversationEndsManually => 'Ang pag-uusap ay magtatapos lamang nang manual.';
@@ -5288,8 +5146,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get welcomeBackSimple => 'Maligayang pabalik';
 
   @override
-  String get addVocabularyDescription =>
-      'Magdagdag ng mga salita na dapat tanggapin ng Omi sa panahon ng transcription.';
+  String get addVocabularyDescription => 'Magdagdag ng mga salita na dapat tanggapin ng Omi sa panahon ng transcription.';
 
   @override
   String get enterWordsCommaSeparated => 'Ipasok ang mga salita (comma separated)';
@@ -5630,30 +5487,25 @@ class AppLocalizationsTl extends AppLocalizations {
   String get multipleSpeakersDetected => 'Ang maraming mga nagsasalita ay nahanap';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Mukhang mayroon kang maraming mga nagsasalita sa recording. Mangyaring tiyakin na nasa quiet location ka at subukan ulit.';
+  String get multipleSpeakersDescription => 'Mukhang mayroon kang maraming mga nagsasalita sa recording. Mangyaring tiyakin na nasa quiet location ka at subukan ulit.';
 
   @override
   String get invalidRecordingDetected => 'Ang invalid recording ay nahanap';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Walang sapat na pagsasalita na nahanap. Mangyaring magsalita ng higit pa at subukan ulit.';
+  String get notEnoughSpeechDescription => 'Walang sapat na pagsasalita na nahanap. Mangyaring magsalita ng higit pa at subukan ulit.';
 
   @override
-  String get speechDurationDescription =>
-      'Siguraduhin na nagsasalita ka ng hindi bababa sa 5 segundo at hindi higit sa 90.';
+  String get speechDurationDescription => 'Siguraduhin na nagsasalita ka ng hindi bababa sa 5 segundo at hindi higit sa 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Ang koneksyon ay nawasak. Pakisuri ang iyong internet na koneksyon at subukan ulit.';
+  String get connectionLostDescription => 'Ang koneksyon ay nawasak. Pakisuri ang iyong internet na koneksyon at subukan ulit.';
 
   @override
   String get howToTakeGoodSample => 'Paano gumawa ng magandang sample?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Siguraduhin na nasa matuling lugar ka.\n2. Magsalita ng malinaw at natural.\n3. Siguraduhin na ang iyong device ay nasa natural na posisyon, sa iyong leeg.\n\nKapag nagawa na, maaari mong palaging mapabuti ito o gawin itong muli.';
+  String get goodSampleInstructions => '1. Siguraduhin na nasa matuling lugar ka.\n2. Magsalita ng malinaw at natural.\n3. Siguraduhin na ang iyong device ay nasa natural na posisyon, sa iyong leeg.\n\nKapag nagawa na, maaari mong palaging mapabuti ito o gawin itong muli.';
 
   @override
   String get noDeviceConnectedUseMic => 'Walang konektadong device. Gagamitin ang mikropono ng telepono.';
@@ -5695,8 +5547,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get notificationFrequency => 'Dalas ng Mga Notipikasyon';
 
   @override
-  String get controlNotificationFrequency =>
-      'Kontrolin kung gaano kadalas ang Omi na magpadala sa iyo ng proactive na mga notipikasyon.';
+  String get controlNotificationFrequency => 'Kontrolin kung gaano kadalas ang Omi na magpadala sa iyo ng proactive na mga notipikasyon.';
 
   @override
   String get yourScore => 'Iyong marka';
@@ -5717,12 +5568,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get howItWorks => 'Paano ito gumagana';
 
   @override
-  String get dailyScoreExplanation =>
-      'Ang iyong pang-araw-araw na marka ay batay sa pagkakatapos ng gawain. Tapusin ang iyong mga gawain upang mapabuti ang iyong marka!';
+  String get dailyScoreExplanation => 'Ang iyong pang-araw-araw na marka ay batay sa pagkakatapos ng gawain. Tapusin ang iyong mga gawain upang mapabuti ang iyong marka!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Kontrolin kung gaano kadalas ang Omi na magpadala sa iyo ng proactive na mga notipikasyon at mga reminder.';
+  String get notificationFrequencyDescription => 'Kontrolin kung gaano kadalas ang Omi na magpadala sa iyo ng proactive na mga notipikasyon at mga reminder.';
 
   @override
   String get sliderOff => 'I-off';
@@ -5736,8 +5585,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummary =>
-      'Hindi na-generate ang summary. Siguraduhin na mayroon kang mga pag-usap para sa araw na iyon.';
+  String get failedToGenerateSummary => 'Hindi na-generate ang summary. Siguraduhin na mayroon kang mga pag-usap para sa araw na iyon.';
 
   @override
   String get recap => 'Recap';
@@ -5816,8 +5664,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get selectApp => 'Pumili ng App';
 
   @override
-  String get noChatAppsEnabled =>
-      'Walang naka-enable na chat apps.\nI-tap ang \"Enable Apps\" upang magdagdag ng ilan.';
+  String get noChatAppsEnabled => 'Walang naka-enable na chat apps.\nI-tap ang \"Enable Apps\" upang magdagdag ng ilan.';
 
   @override
   String get disable => 'I-disable';
@@ -5897,8 +5744,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get wifiEnableFailed => 'Nabigo ang pagpapagana ng WiFi sa device. Subukan ulit.';
 
   @override
-  String get deviceNoFastTransfer =>
-      'Ang iyong device ay hindi sumusuporta sa Fast Transfer. Gumamit ng Bluetooth sa halip.';
+  String get deviceNoFastTransfer => 'Ang iyong device ay hindi sumusuporta sa Fast Transfer. Gumamit ng Bluetooth sa halip.';
 
   @override
   String get enableHotspotMessage => 'Pakipagana ang hotspot ng iyong telepono at subukan ulit.';
@@ -6025,8 +5871,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get webhookUrlNotSet => 'Webhook URL ay hindi nakatakda';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Pakisiguro ang webhook URL sa developer settings upang gamitin ang feature na ito.';
+  String get setWebhookUrlInSettings => 'Pakisiguro ang webhook URL sa developer settings upang gamitin ang feature na ito.';
 
   @override
   String get sendWebUrl => 'Magpadala ng web url';
@@ -6058,8 +5903,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deviceNotCompatible => 'Device Not Compatible';
 
   @override
-  String get deviceRequirements =>
-      'Ang iyong device ay hindi nakakatugon sa mga kinakailangan para sa On-Device transcription.';
+  String get deviceRequirements => 'Ang iyong device ay hindi nakakatugon sa mga kinakailangan para sa On-Device transcription.';
 
   @override
   String get willLikelyCrash => 'Ang pagpapagana nito ay malamang na magdudulot ng pag-crash o pag-freeze sa app.';
@@ -6101,15 +5945,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get cloudProvider => 'Cloud Provider';
 
   @override
-  String get premiumMinutesInfo =>
-      '1,200 premium na minuto/buwan. Ang On-Device tab ay nag-aalok ng unlimited na libreng transcription.';
+  String get premiumMinutesInfo => '1,200 premium na minuto/buwan. Ang On-Device tab ay nag-aalok ng unlimited na libreng transcription.';
 
   @override
   String get viewUsage => 'Tingnan ang paggamit';
 
   @override
-  String get localProcessingInfo =>
-      'Ang audio ay napoproseso nang lokal. Gumagana nang offline, mas pribado, ngunit gumagamit ng mas maraming battery.';
+  String get localProcessingInfo => 'Ang audio ay napoproseso nang lokal. Gumagana nang offline, mas pribado, ngunit gumagamit ng mas maraming battery.';
 
   @override
   String get model => 'Model';
@@ -6118,15 +5960,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get performanceWarning => 'Performance Warning';
 
   @override
-  String get largeModelWarning =>
-      'Ang model na ito ay malaki at maaaring mag-crash sa app o tumatakbo ng napakabagal sa mobile devices.\n\n\"small\" o \"base\" ang inirerekomenda.';
+  String get largeModelWarning => 'Ang model na ito ay malaki at maaaring mag-crash sa app o tumatakbo ng napakabagal sa mobile devices.\n\n\"small\" o \"base\" ang inirerekomenda.';
 
   @override
   String get usingNativeIosSpeech => 'Gumagamit ng Native iOS Speech Recognition';
 
   @override
-  String get noModelDownloadRequired =>
-      'Ang native speech engine ng iyong device ay gagamitin. Walang model download na kailangan.';
+  String get noModelDownloadRequired => 'Ang native speech engine ng iyong device ay gagamitin. Walang model download na kailangan.';
 
   @override
   String get modelReady => 'Model Ready';
@@ -6171,8 +6011,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deviceNotCompatibleTitle => 'Device Not Compatible';
 
   @override
-  String get deviceNotMeetRequirements =>
-      'Ang iyong device ay hindi nakakatugon sa mga kinakailangan para sa On-Device transcription.';
+  String get deviceNotMeetRequirements => 'Ang iyong device ay hindi nakakatugon sa mga kinakailangan para sa On-Device transcription.';
 
   @override
   String get transcriptionSlowerOnDevice => 'Ang on-device transcription ay maaaring mas mabagal sa device na ito.';
@@ -6184,12 +6023,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get batteryDrainSignificantly => 'Ang battery drain ay tataas ng malaki.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1,200 premium na minuto/buwan. Ang On-Device tab ay nag-aalok ng unlimited na libreng transcription. ';
+  String get premiumMinutesMonth => '1,200 premium na minuto/buwan. Ang On-Device tab ay nag-aalok ng unlimited na libreng transcription. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Ang audio ay napoproseso nang lokal. Gumagana nang offline, mas pribado, ngunit gumagamit ng mas maraming battery.';
+  String get audioProcessedLocally => 'Ang audio ay napoproseso nang lokal. Gumagana nang offline, mas pribado, ngunit gumagamit ng mas maraming battery.';
 
   @override
   String get languageLabel => 'Wika';
@@ -6198,12 +6035,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Ang model na ito ay malaki at maaaring mag-crash sa app o tumatakbo ng napakabagal sa mobile devices.\n\n\"small\" o \"base\" ang inirerekomenda.';
+  String get modelTooLargeWarning => 'Ang model na ito ay malaki at maaaring mag-crash sa app o tumatakbo ng napakabagal sa mobile devices.\n\n\"small\" o \"base\" ang inirerekomenda.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Ang native speech engine ng iyong device ay gagamitin. Walang model download na kailangan.';
+  String get nativeEngineNoDownload => 'Ang native speech engine ng iyong device ay gagamitin. Walang model download na kailangan.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6239,8 +6074,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Ang built-in live transcription ng Omi ay na-optimize para sa real-time na pag-usap na may automatic speaker detection at diarization.';
+  String get omiTranscriptionOptimized => 'Ang built-in live transcription ng Omi ay na-optimize para sa real-time na pag-usap na may automatic speaker detection at diarization.';
 
   @override
   String get reset => 'I-reset';
@@ -6328,8 +6162,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get writeReviewOptional => 'Magsulat ng review (opsyonal)';
 
   @override
-  String get setupQuestionsIntro =>
-      'Tulungan kaming mapabuti ang Omi sa pamamagitan ng pagsagot sa ilang mga tanong.  🫶 💜';
+  String get setupQuestionsIntro => 'Tulungan kaming mapabuti ang Omi sa pamamagitan ng pagsagot sa ilang mga tanong.  🫶 💜';
 
   @override
   String get setupQuestionProfession => '1. Ano ang iyong ginagawa?';
@@ -6461,8 +6294,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Binubuo ang iyong knowledge graph mula sa mga alaala...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Ang iyong knowledge graph ay awtomatikong bubuo habang lumilikha ka ng mga bagong alaala.';
+  String get knowledgeGraphWillBuildAutomatically => 'Ang iyong knowledge graph ay awtomatikong bubuo habang lumilikha ka ng mga bagong alaala.';
 
   @override
   String get buildGraphButton => 'Bumuo ng Graph';
@@ -6683,8 +6515,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get contactsPermissionRequired => 'Mga permission sa contact na kailangan';
 
   @override
-  String get contactsPermissionRequiredForSms =>
-      'Ang mga permission sa contact ay kinakailangan upang ibahagi sa pamamagitan ng SMS';
+  String get contactsPermissionRequiredForSms => 'Ang mga permission sa contact ay kinakailangan upang ibahagi sa pamamagitan ng SMS';
 
   @override
   String get grantContactsPermissionForSms => 'Pakigrant ang contacts permission upang ibahagi sa pamamagitan ng SMS';
@@ -6699,8 +6530,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get failedToLoadContacts => 'Nabigo ang pag-load ng mga contact';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Nabigo ang paghahanda ng pag-usap para sa pagbabahagi. Subukan ulit.';
+  String get failedToPrepareConversationForSharing => 'Nabigo ang paghahanda ng pag-usap para sa pagbabahagi. Subukan ulit.';
 
   @override
   String get couldNotOpenSmsApp => 'Hindi makuha ang SMS app. Subukan ulit.';
@@ -6766,8 +6596,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Dine-download ang audio mula sa SD card ng iyong device';
 
   @override
-  String get transferRequiredDescription =>
-      'Ang recording na ito ay nakaimbak sa SD card ng iyong device. Ilipat ito sa iyong telepono upang maglaro o magbahagi.';
+  String get transferRequiredDescription => 'Ang recording na ito ay nakaimbak sa SD card ng iyong device. Ilipat ito sa iyong telepono upang maglaro o magbahagi.';
 
   @override
   String get cancelTransfer => 'Kanselahin ang Transfer';
@@ -6788,8 +6617,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get shareRecording => 'Ibahagi ang Recording';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Sigurado ka na gusto mong permanenteng tanggalin ang recording na ito? Hindi na ito mababawi.';
+  String get deleteRecordingConfirmation => 'Sigurado ka na gusto mong permanenteng tanggalin ang recording na ito? Hindi na ito mababawi.';
 
   @override
   String get recordingIdLabel => 'Recording ID';
@@ -6848,15 +6676,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get enableFastTransfer => 'I-enable ang Fast Transfer';
 
   @override
-  String get fastTransferDescription =>
-      'Gumagamit ang Fast Transfer ng WiFi para sa humigit-kumulang na 5x na mas mabilis na bilis. Ang iyong telepono ay pansamantalang magkonekta sa WiFi network ng iyong Omi device sa panahon ng paglipat.';
+  String get fastTransferDescription => 'Gumagamit ang Fast Transfer ng WiFi para sa humigit-kumulang na 5x na mas mabilis na bilis. Ang iyong telepono ay pansamantalang magkonekta sa WiFi network ng iyong Omi device sa panahon ng paglipat.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Ang internet access ay napigil sa panahon ng paglipat';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'Pumili kung paano ang mga recording ay ilipat mula sa iyong Omi device patungo sa iyong telepono.';
+  String get chooseTransferMethodDescription => 'Pumili kung paano ang mga recording ay ilipat mula sa iyong Omi device patungo sa iyong telepono.';
 
   @override
   String get wifiSpeed => '~150 KB/s sa pamamagitan ng WiFi';
@@ -6865,8 +6691,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get fiveTimesFaster => '5X MAS MABILIS';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Lumilikha ng direktang WiFi connection sa iyong Omi device. Ang iyong telepono ay pansamantalang nadadiskonekta mula sa iyong regular na WiFi sa panahon ng paglipat.';
+  String get fastTransferMethodDescription => 'Lumilikha ng direktang WiFi connection sa iyong Omi device. Ang iyong telepono ay pansamantalang nadadiskonekta mula sa iyong regular na WiFi sa panahon ng paglipat.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6875,8 +6700,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get bleSpeed => '~30 KB/s sa pamamagitan ng BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Gumagamit ng standard Bluetooth Low Energy connection. Mas mabagal ngunit hindi nakakaapekto sa iyong WiFi connection.';
+  String get bluetoothMethodDescription => 'Gumagamit ng standard Bluetooth Low Energy connection. Mas mabagal ngunit hindi nakakaapekto sa iyong WiFi connection.';
 
   @override
   String get selected => 'Napili';
@@ -6894,8 +6718,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deviceDisconnectedNotificationTitle => 'Ang Iyong Omi Device ay Nadiskonekta';
 
   @override
-  String get deviceDisconnectedNotificationBody =>
-      'Mangyaring mag-reconnect upang magpatuloy ng paggamit ng iyong Omi.';
+  String get deviceDisconnectedNotificationBody => 'Mangyaring mag-reconnect upang magpatuloy ng paggamit ng iyong Omi.';
 
   @override
   String get firmwareUpdateAvailable => 'Available ang Firmware Update';
@@ -6915,12 +6738,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get appDeleteFailed => 'Nabigo ang pagsisikap na burahin ang app. Mangyaring subukan ulit mamaya.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Matagumpay na binago ang visibility ng app. Maaaring tumagal ng ilang minuto upang makita ang pagbabago.';
+  String get appVisibilityChangedSuccessfully => 'Matagumpay na binago ang visibility ng app. Maaaring tumagal ng ilang minuto upang makita ang pagbabago.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Nagkamalian sa pag-activate ng app. Kung ito ay isang integration app, siguraduhin na tapos na ang setup.';
+  String get errorActivatingAppIntegration => 'Nagkamalian sa pag-activate ng app. Kung ito ay isang integration app, siguraduhin na tapos na ang setup.';
 
   @override
   String get errorUpdatingAppStatus => 'Nagkaroon ng error sa pag-update ng app status.';
@@ -7000,8 +6821,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Dapat ang pangalan ay hindi bababa sa 3 character';
 
   @override
-  String get conversationPromptHint =>
-      'e.g., I-extract ang action items, decisions na ginawa, at key takeaways mula sa ibinigay na conversation.';
+  String get conversationPromptHint => 'e.g., I-extract ang action items, decisions na ginawa, at key takeaways mula sa ibinigay na conversation.';
 
   @override
   String get pleaseEnterAppPrompt => 'Mangyaring magpasok ng prompt para sa iyong app';
@@ -7034,8 +6854,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get failedToCreateApp => 'Nabigo ang paglalakbay na lumikha ng app. Mangyaring subukan ulit.';
 
   @override
-  String get addAppSelectCoreCapability =>
-      'Mangyaring pumili ng isa pang core capability para sa iyong app upang magpatuloy';
+  String get addAppSelectCoreCapability => 'Mangyaring pumili ng isa pang core capability para sa iyong app upang magpatuloy';
 
   @override
   String get addAppSelectPaymentPlan => 'Mangyaring pumili ng payment plan at magpasok ng presyo para sa iyong app';
@@ -7084,8 +6903,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'Ang Photos permission ay tinanggihan. Mangyaring payagan ang access sa mga photo upang pumili ng imahe';
+  String get addAppPhotosPermissionDenied => 'Ang Photos permission ay tinanggihan. Mangyaring payagan ang access sa mga photo upang pumili ng imahe';
 
   @override
   String get addAppErrorSelectingImageRetry => 'Nagkamalian sa pagpili ng imahe. Mangyaring subukan ulit.';
@@ -7099,20 +6917,16 @@ class AppLocalizationsTl extends AppLocalizations {
   String get addAppErrorSelectingThumbnailRetry => 'Nagkamalian sa pagpili ng thumbnail. Mangyaring subukan ulit.';
 
   @override
-  String get addAppCapabilityConflictWithPersona =>
-      'Hindi maaaring piliin ang iba pang capabilities kasama ang Persona';
+  String get addAppCapabilityConflictWithPersona => 'Hindi maaaring piliin ang iba pang capabilities kasama ang Persona';
 
   @override
-  String get addAppPersonaConflictWithCapabilities =>
-      'Hindi maaaring piliin ang Persona kasama ang iba pang capabilities';
+  String get addAppPersonaConflictWithCapabilities => 'Hindi maaaring piliin ang Persona kasama ang iba pang capabilities';
 
   @override
-  String get paymentFailedToFetchCountries =>
-      'Nabigo ang pagkuha ng mga supported countries. Mangyaring subukan ulit mamaya.';
+  String get paymentFailedToFetchCountries => 'Nabigo ang pagkuha ng mga supported countries. Mangyaring subukan ulit mamaya.';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'Nabigo ang pagseset ng default payment method. Mangyaring subukan ulit mamaya.';
+  String get paymentFailedToSetDefault => 'Nabigo ang pagseset ng default payment method. Mangyaring subukan ulit mamaya.';
 
   @override
   String get paymentFailedToSavePaypal => 'Nabigo ang pagsave ng PayPal details. Mangyaring subukan ulit mamaya.';
@@ -7194,19 +7008,16 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Upgrade ay naka-schedule na! Ang iyong monthly plan ay patuloy hanggang sa dulo ng iyong billing period, pagkatapos ay awtomatikong magsasalit sa annual.';
+  String get planUpgradeScheduledMessage => 'Upgrade ay naka-schedule na! Ang iyong monthly plan ay patuloy hanggang sa dulo ng iyong billing period, pagkatapos ay awtomatikong magsasalit sa annual.';
 
   @override
   String get couldNotSchedulePlanChange => 'Hindi makasagawa ang pag-schedule ng plan change. Mangyaring subukan ulit.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Ang iyong subscription ay naka-reactivate na! Walang charge ngayon - ikaw ay ma-bill sa dulo ng iyong current period.';
+  String get subscriptionReactivatedDefault => 'Ang iyong subscription ay naka-reactivate na! Walang charge ngayon - ikaw ay ma-bill sa dulo ng iyong current period.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Matagumpay na subscription! Ikaw ay na-charge para sa bagong billing period.';
+  String get subscriptionSuccessfulCharged => 'Matagumpay na subscription! Ikaw ay na-charge para sa bagong billing period.';
 
   @override
   String get couldNotProcessSubscription => 'Hindi makasagawa ang proseso ng subscription. Mangyaring subukan ulit.';
@@ -7383,12 +7194,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get authFailedToLinkApple => 'Nabigo ang pag-link gamit ang Apple, mangyaring subukan ulit.';
 
   @override
-  String get onboardingBluetoothRequired =>
-      'Ang Bluetooth permission ay kinakailangan upang kumonekta sa iyong device.';
+  String get onboardingBluetoothRequired => 'Ang Bluetooth permission ay kinakailangan upang kumonekta sa iyong device.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Ang Bluetooth permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Ang Bluetooth permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7401,12 +7210,10 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Ang Notification permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Ang Notification permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Ang Notification permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences > Notifications.';
+  String get onboardingNotificationDeniedNotifications => 'Ang Notification permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences > Notifications.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7419,15 +7226,13 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Mangyaring bigyan ng location permission sa Settings > Privacy & Security > Location Services';
+  String get onboardingLocationGrantInSettings => 'Mangyaring bigyan ng location permission sa Settings > Privacy & Security > Location Services';
 
   @override
   String get onboardingMicrophoneRequired => 'Ang Microphone permission ay kinakailangan para sa pag-record.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Ang Microphone permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences > Privacy & Security > Microphone.';
+  String get onboardingMicrophoneDenied => 'Ang Microphone permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences > Privacy & Security > Microphone.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7440,12 +7245,10 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get onboardingScreenCaptureRequired =>
-      'Ang Screen capture permission ay kinakailangan para sa system audio recording.';
+  String get onboardingScreenCaptureRequired => 'Ang Screen capture permission ay kinakailangan para sa system audio recording.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Ang Screen capture permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences > Privacy & Security > Screen Recording.';
+  String get onboardingScreenCaptureDenied => 'Ang Screen capture permission ay tinanggihan. Mangyaring bigyan ng permission sa System Preferences > Privacy & Security > Screen Recording.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7458,8 +7261,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Ang Accessibility permission ay kinakailangan para sa pag-detect ng browser meetings.';
+  String get onboardingAccessibilityRequired => 'Ang Accessibility permission ay kinakailangan para sa pag-detect ng browser meetings.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7475,8 +7277,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get msgCameraNotAvailable => 'Ang Camera capture ay hindi available sa platform na ito';
 
   @override
-  String get msgCameraPermissionDenied =>
-      'Ang Camera permission ay tinanggihan. Mangyaring payagan ang access sa camera';
+  String get msgCameraPermissionDenied => 'Ang Camera permission ay tinanggihan. Mangyaring payagan ang access sa camera';
 
   @override
   String msgCameraAccessError(String error) {
@@ -7500,8 +7301,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Ang Photos permission ay tinanggihan. Mangyaring payagan ang access sa mga photo upang pumili ng mga imahe';
+  String get msgPhotosPermissionDenied => 'Ang Photos permission ay tinanggihan. Mangyaring payagan ang access sa mga photo upang pumili ng mga imahe';
 
   @override
   String get msgSelectImagesGenericError => 'Nagkamalian sa pagpili ng mga imahe. Mangyaring subukan ulit.';
@@ -7573,8 +7373,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get locationPermissionRequired => 'Ang Location Permission ay Kinakailangan';
 
   @override
-  String get locationPermissionContent =>
-      'Ang Fast Transfer ay nangangailangan ng location permission upang ma-verify ang WiFi connection. Mangyaring bigyan ng location permission upang magpatuloy.';
+  String get locationPermissionContent => 'Ang Fast Transfer ay nangangailangan ng location permission upang ma-verify ang WiFi connection. Mangyaring bigyan ng location permission upang magpatuloy.';
 
   @override
   String get pdfTranscriptExport => 'Transcript Export';
@@ -7737,8 +7536,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Ang device ay hindi sumusuporta sa WiFi sync, lumipat sa Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Ang device ay hindi sumusuporta sa WiFi sync, lumipat sa Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Ang Apple Health ay hindi available sa device na ito';
@@ -8034,8 +7832,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Ilagay ang Omi DevKit sa Pairing Mode';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Pindutin ang button nang isang beses upang i-on. Ang LED ay mag-blink ng purple kapag nasa pairing mode.';
+  String get pairingDescOmiDevkit => 'Pindutin ang button nang isang beses upang i-on. Ang LED ay mag-blink ng purple kapag nasa pairing mode.';
 
   @override
   String get pairingTitleOmiGlass => 'I-on ang Omi Glass';
@@ -8047,29 +7844,25 @@ class AppLocalizationsTl extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Ilagay ang Plaud Note sa Pairing Mode';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Pindutin at panatilihin ang side button sa loob ng 2 segundo. Ang red LED ay mag-blink kapag handa nang mag-pair.';
+  String get pairingDescPlaudNote => 'Pindutin at panatilihin ang side button sa loob ng 2 segundo. Ang red LED ay mag-blink kapag handa nang mag-pair.';
 
   @override
   String get pairingTitleBee => 'Ilagay ang Bee sa Pairing Mode';
 
   @override
-  String get pairingDescBee =>
-      'Pindutin ang button nang 5 beses nang tuluy-tuloy. Ang liwanag ay magsisimulang mag-blink ng asul at luntian.';
+  String get pairingDescBee => 'Pindutin ang button nang 5 beses nang tuluy-tuloy. Ang liwanag ay magsisimulang mag-blink ng asul at luntian.';
 
   @override
   String get pairingTitleLimitless => 'Ilagay ang Limitless sa Pairing Mode';
 
   @override
-  String get pairingDescLimitless =>
-      'Kapag may nakikitang liwanag, pindutin nang isang beses at pagkatapos ay pindutin at panatilihin hanggang sa ipakita ng device ang pink light, pagkatapos ay palayain.';
+  String get pairingDescLimitless => 'Kapag may nakikitang liwanag, pindutin nang isang beses at pagkatapos ay pindutin at panatilihin hanggang sa ipakita ng device ang pink light, pagkatapos ay palayain.';
 
   @override
   String get pairingTitleFriendPendant => 'Ilagay ang Friend Pendant sa Pairing Mode';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Pindutin ang button sa pendant upang i-on ito. Automatic na papasok ito sa pairing mode.';
+  String get pairingDescFriendPendant => 'Pindutin ang button sa pendant upang i-on ito. Automatic na papasok ito sa pairing mode.';
 
   @override
   String get pairingTitleFieldy => 'Ilagay ang Fieldy sa Pairing Mode';
@@ -8081,15 +7874,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Kumonekta sa Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'I-install at buksan ang Omi app sa iyong Apple Watch, pagkatapos ay i-tap ang Connect sa app.';
+  String get pairingDescAppleWatch => 'I-install at buksan ang Omi app sa iyong Apple Watch, pagkatapos ay i-tap ang Connect sa app.';
 
   @override
   String get pairingTitleNeoOne => 'Ilagay ang Neo One sa Pairing Mode';
 
   @override
-  String get pairingDescNeoOne =>
-      'Pindutin at panatilihin ang power button hanggang sa mag-blink ang LED. Ang device ay magiging discoverable.';
+  String get pairingDescNeoOne => 'Pindutin at panatilihin ang power button hanggang sa mag-blink ang LED. Ang device ay magiging discoverable.';
 
   @override
   String get downloadingFromDevice => 'Nag-download mula sa device';
@@ -8159,8 +7950,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get wifiConfiguration => 'WiFi Configuration';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Ipasok ang iyong WiFi credentials upang payagan ang device na mag-download ng firmware.';
+  String get wifiConfigurationSubtitle => 'Ipasok ang iyong WiFi credentials upang payagan ang device na mag-download ng firmware.';
 
   @override
   String get networkNameSsid => 'Network Name (SSID)';
@@ -8178,8 +7968,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Ito ang alam ko tungkol sa iyo';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Ang map na ito ay nag-update habang natututo ang Omi mula sa iyong mga conversation.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Ang map na ito ay nag-update habang natututo ang Omi mula sa iyong mga conversation.';
 
   @override
   String get apiEnvironment => 'API Environment';
@@ -8208,8 +7997,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get switchAndRestart => 'Lumipat';
 
   @override
-  String get stagingDisclaimer =>
-      'Ang Staging ay maaaring may bugs, hindi consistent na performance, at maaaring mawala ang data. Gamitin lamang para sa testing.';
+  String get stagingDisclaimer => 'Ang Staging ay maaaring may bugs, hindi consistent na performance, at maaaring mawala ang data. Gamitin lamang para sa testing.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Nakatipid. Isara at muling buksan ang app upang mag-apply.';
@@ -8260,8 +8048,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get phoneGetStarted => 'Magsimula';
 
   @override
-  String get callRecordingConsentDisclaimer =>
-      'Ang call recording ay maaaring na kailangan ng consent sa iyong jurisdiction';
+  String get callRecordingConsentDisclaimer => 'Ang call recording ay maaaring na kailangan ng consent sa iyong jurisdiction';
 
   @override
   String get enterYourNumber => 'Ipasok ang iyong number';
@@ -8375,8 +8162,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get yourVerifiedNumbers => 'Ang Iyong Na-verify na Mga Numero';
 
   @override
-  String get verifiedNumbersDescription =>
-      'Kapag tumatawag ka sa isang tao, makikita nila ang numerong ito sa kanilang phone';
+  String get verifiedNumbersDescription => 'Kapag tumatawag ka sa isang tao, makikita nila ang numerong ito sa kanilang phone';
 
   @override
   String get noVerifiedNumbers => 'Walang na-verify na mga numero';
@@ -8440,8 +8226,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Phone Calls via Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Gumawa ng mga call sa pamamagitan ng Omi at makakuha ng real-time transcription, automatic summaries, at marami pang iba. Available exclusively para sa Unlimited plan subscribers.';
+  String get phoneCallsUpsellSubtitle => 'Gumawa ng mga call sa pamamagitan ng Omi at makakuha ng real-time transcription, automatic summaries, at marami pang iba. Available exclusively para sa Unlimited plan subscribers.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Real-time transcription ng bawat call';
@@ -8450,8 +8235,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get phoneCallsUpsellFeature2 => 'Automatic call summaries at action items';
 
   @override
-  String get phoneCallsUpsellFeature3 =>
-      'Ang mga recipient ay makikita ang iyong tunay na numero, hindi ang random na numero';
+  String get phoneCallsUpsellFeature3 => 'Ang mga recipient ay makikita ang iyong tunay na numero, hindi ang random na numero';
 
   @override
   String get phoneCallsUpsellFeature4 => 'Ang iyong mga call ay nananatiling private at secure';
@@ -8481,8 +8265,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deletePendingFiles => 'Tanggalin ang Pending Recordings';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Ang mga recording na ito ay HINDI nag-sync sa iyong phone at permanent na mawawala. Hindi ito mababawi.';
+  String get deletePendingFilesWarning => 'Ang mga recording na ito ay HINDI nag-sync sa iyong phone at permanent na mawawala. Hindi ito mababawi.';
 
   @override
   String get pendingFilesDeleted => 'Ang pending recordings ay nakatanggal';
@@ -8494,8 +8277,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deleteAll => 'Tanggalin Ang Lahat';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Ito ay magtanggal ng parehong synced at pending recordings. Ang pending recordings ay HINDI nag-sync at permanent na mawawala. Hindi ito mababawi.';
+  String get deleteAllFilesWarning => 'Ito ay magtanggal ng parehong synced at pending recordings. Ang pending recordings ay HINDI nag-sync at permanent na mawawala. Hindi ito mababawi.';
 
   @override
   String get allFilesDeleted => 'Ang lahat ng recordings ay nakatanggal';
@@ -8560,8 +8342,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get fairUseAboutTitle => 'Tungkol sa Fair Use';
 
   @override
-  String get fairUseAboutBody =>
-      'Ang Omi ay dinisenyo para sa personal conversations, meetings, at live interactions. Ang usage ay sinusukat ng real speech time detected, hindi ang connection time. Kung ang usage ay significantly lumalampas sa normal patterns para sa non-personal content, ang mga adjustments ay maaaring mag-apply.';
+  String get fairUseAboutBody => 'Ang Omi ay dinisenyo para sa personal conversations, meetings, at live interactions. Ang usage ay sinusukat ng real speech time detected, hindi ang connection time. Kung ang usage ay significantly lumalampas sa normal patterns para sa non-personal content, ang mga adjustments ay maaaring mag-apply.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8599,8 +8380,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get improveConnectionTitle => 'Pagbutihin ang Connection';
 
   @override
-  String get improveConnectionContent =>
-      'Nag-improve kami ng kung paano ang Omi ay manatiling connected sa iyong device. Upang i-activate ito, mangyaring magpunta sa Device Info page, i-tap ang \"Disconnect Device\", at pagkatapos ay i-pair ang iyong device ulit.';
+  String get improveConnectionContent => 'Nag-improve kami ng kung paano ang Omi ay manatiling connected sa iyong device. Upang i-activate ito, mangyaring magpunta sa Device Info page, i-tap ang \"Disconnect Device\", at pagkatapos ay i-pair ang iyong device ulit.';
 
   @override
   String get improveConnectionAction => 'Nakaintindi';
@@ -8629,8 +8409,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get recordingsSyncAutomatically => 'Ang recordings ay nag-sync automatically — walang kailangang aksyon.';
 
   @override
-  String get filesDownloadedUploadedNextTime =>
-      'Ang mga file na na-download na ay iu-upload sa susunod na pagkakataon.';
+  String get filesDownloadedUploadedNextTime => 'Ang mga file na na-download na ay iu-upload sa susunod na pagkakataon.';
 
   @override
   String nConversationsCreated(int count) {
@@ -8656,16 +8435,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get cancelSyncQuestion => 'Kanselahin ang sync?';
 
   @override
-  String get omisStorageDesc =>
-      'Kapag ang iyong Omi ay hindi konektado sa iyong phone, ito ay nag-store ng audio locally sa built-in memory nito. Hindi mo kailanman mawawalan ng recording.';
+  String get omisStorageDesc => 'Kapag ang iyong Omi ay hindi konektado sa iyong phone, ito ay nag-store ng audio locally sa built-in memory nito. Hindi mo kailanman mawawalan ng recording.';
 
   @override
-  String get phoneStorageDesc =>
-      'Kapag muling kumokonekta ang Omi, ang mga recording ay automatic na inilipat sa iyong phone bilang isang temporary holding area bago i-upload.';
+  String get phoneStorageDesc => 'Kapag muling kumokonekta ang Omi, ang mga recording ay automatic na inilipat sa iyong phone bilang isang temporary holding area bago i-upload.';
 
   @override
-  String get cloudStorageDesc =>
-      'Pagkatapos ng pag-upload, ang iyong mga recording ay pinoproseso at naitranscribe. Ang mga conversation ay magiging available sa loob ng isang minuto.';
+  String get cloudStorageDesc => 'Pagkatapos ng pag-upload, ang iyong mga recording ay pinoproseso at naitranscribe. Ang mga conversation ay magiging available sa loob ng isang minuto.';
 
   @override
   String get tipKeepPhoneNearby => 'Panatilihing malapit ang iyong phone para sa mas mabilis na syncing';
@@ -8689,12 +8465,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get permissionEnable => 'I-enable';
 
   @override
-  String get permissionsPageDescription =>
-      'Ang mga permissions na ito ay core sa kung paano gumagana ang Omi. Pinapahintulutan nila ang mga key features tulad ng notifications, location-based experiences, at audio capture.';
+  String get permissionsPageDescription => 'Ang mga permissions na ito ay core sa kung paano gumagana ang Omi. Pinapahintulutan nila ang mga key features tulad ng notifications, location-based experiences, at audio capture.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Ang Omi ay nangangailangan ng ilang permissions upang gumana nang maayos. Mangyaring bigyan ang mga ito upang magpatuloy.';
+  String get permissionsRequiredDescription => 'Ang Omi ay nangangailangan ng ilang permissions upang gumana nang maayos. Mangyaring bigyan ang mga ito upang magpatuloy.';
 
   @override
   String get permissionsSetupTitle => 'Makakuha ng pinakamahusay na experience';
@@ -8748,8 +8522,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get justAMoment => 'Isang sandali lamang';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'Lubos naming nirerekomenda na tuklasin ang iyong iba pang mga pagpipilian sa halip na magcancel.';
+  String get cancelConsequencesSubtitle => 'Lubos naming nirerekomenda na tuklasin ang iyong iba pang mga pagpipilian sa halip na magcancel.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8951,8 +8724,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get enableLocationTitle => 'I-enable ang Location';
 
   @override
-  String get enableLocationDescription =>
-      'Ang location permission ay kailangan upang mahanap ang nearby Bluetooth devices.';
+  String get enableLocationDescription => 'Ang location permission ay kailangan upang mahanap ang nearby Bluetooth devices.';
 
   @override
   String get voiceRecordingFound => 'Recording na nahanap';
@@ -8973,8 +8745,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get firmwareWarningTitle => 'Mahalaga: Basahin Bago Mag-update';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ang firmware na ito ay magfo-format ng SD card. Pakitiyak na ang lahat ng offline na data ay naka-sync bago mag-upgrade.\n\nKung makakita ka ng kumukurap na pulang ilaw pagkatapos i-install ang bersyong ito, huwag mag-alala. Ikonekta lang ang device sa app at dapat itong maging asul. Ang pulang ilaw ay nangangahulugang hindi pa na-sync ang orasan ng device.';
+  String get firmwareFormatWarning => 'Ang firmware na ito ay magfo-format ng SD card. Pakitiyak na ang lahat ng offline na data ay naka-sync bago mag-upgrade.\n\nKung makakita ka ng kumukurap na pulang ilaw pagkatapos i-install ang bersyong ito, huwag mag-alala. Ikonekta lang ang device sa app at dapat itong maging asul. Ang pulang ilaw ay nangangahulugang hindi pa na-sync ang orasan ng device.';
 
   @override
   String get continueAnyway => 'Magpatuloy';
@@ -8994,8 +8765,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get tasksMarkComplete => 'Minarkahan bilang kumpleto';
 
   @override
-  String get appleHealthManageNote =>
-      'Ina-access ng Omi ang Apple Health sa pamamagitan ng HealthKit framework ng Apple. Maaari mong bawiin ang access anumang oras sa iOS Settings.';
+  String get appleHealthManageNote => 'Ina-access ng Omi ang Apple Health sa pamamagitan ng HealthKit framework ng Apple. Maaari mong bawiin ang access anumang oras sa iOS Settings.';
 
   @override
   String get appleHealthConnectCta => 'Ikonekta sa Apple Health';
@@ -9010,36 +8780,31 @@ class AppLocalizationsTl extends AppLocalizations {
   String get appleHealthFeatureChatTitle => 'Kumustahin ang iyong kalusugan';
 
   @override
-  String get appleHealthFeatureChatDesc =>
-      'Tanungin ang Omi tungkol sa iyong hakbang, tulog, tibok ng puso, at mga ehersisyo.';
+  String get appleHealthFeatureChatDesc => 'Tanungin ang Omi tungkol sa iyong hakbang, tulog, tibok ng puso, at mga ehersisyo.';
 
   @override
   String get appleHealthFeatureReadOnlyTitle => 'Access na pambasa lamang';
 
   @override
-  String get appleHealthFeatureReadOnlyDesc =>
-      'Hindi kailanman nagsusulat ang Omi sa Apple Health o nagbabago ng iyong datos.';
+  String get appleHealthFeatureReadOnlyDesc => 'Hindi kailanman nagsusulat ang Omi sa Apple Health o nagbabago ng iyong datos.';
 
   @override
   String get appleHealthFeatureSecureTitle => 'Ligtas na sync';
 
   @override
-  String get appleHealthFeatureSecureDesc =>
-      'Ang iyong datos sa Apple Health ay pribadong sinisync sa iyong Omi account.';
+  String get appleHealthFeatureSecureDesc => 'Ang iyong datos sa Apple Health ay pribadong sinisync sa iyong Omi account.';
 
   @override
   String get appleHealthDeniedTitle => 'Tinanggihan ang access sa Apple Health';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Walang pahintulot ang Omi na basahin ang iyong Apple Health data. I-enable ito sa iOS Settings → Privacy & Security → Health → Omi.';
+  String get appleHealthDeniedBody => 'Walang pahintulot ang Omi na basahin ang iyong Apple Health data. I-enable ito sa iOS Settings → Privacy & Security → Health → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Bakit ka aalis?';
 
   @override
-  String get deleteFlowReasonSubtitle =>
-      'Ang iyong feedback ay tumutulong sa amin na pagbutihin ang Omi para sa lahat.';
+  String get deleteFlowReasonSubtitle => 'Ang iyong feedback ay tumutulong sa amin na pagbutihin ang Omi para sa lahat.';
 
   @override
   String get deleteReasonPrivacy => 'Mga alalahanin sa privacy';
@@ -9069,8 +8834,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deleteFlowFeedbackSubtitle => 'Ano ang magiging dahilan para gumana ang Omi para sa iyo?';
 
   @override
-  String get deleteFlowFeedbackHint =>
-      'Opsyonal — ang mga isip mo ay tumutulong sa amin na makabuo ng mas mahusay na produkto.';
+  String get deleteFlowFeedbackHint => 'Opsyonal — ang mga isip mo ay tumutulong sa amin na makabuo ng mas mahusay na produkto.';
 
   @override
   String get deleteFlowConfirmTitle => 'Ito ay permanente';
@@ -9103,8 +8867,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get planUpdate => 'Update ng Plano';
 
   @override
-  String get planDeprecationMessage =>
-      'Ang iyong Unlimited na plano ay inihihinto na. Lumipat sa Operator na plano — parehong magagandang feature sa \$49/buwan. Ang kasalukuyan mong plano ay patuloy na gagana samantala.';
+  String get planDeprecationMessage => 'Ang iyong Unlimited na plano ay inihihinto na. Lumipat sa Operator na plano — parehong magagandang feature sa \$49/buwan. Ang kasalukuyan mong plano ay patuloy na gagana samantala.';
 
   @override
   String get upgradeYourPlan => 'I-upgrade ang Iyong Plano';
@@ -9215,8 +8978,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Naabot mo na ang iyong buwanang limitasyon. Mag-upgrade para magpatuloy ng chat sa Omi nang walang limitasyon.';
+  String get chatQuotaExceededReply => 'Naabot mo na ang iyong buwanang limitasyon. Mag-upgrade para magpatuloy ng chat sa Omi nang walang limitasyon.';
 
   @override
   String get voiceResponseAudio => 'Basahin nang malakas ang sagot ng Omi';
@@ -9247,4 +9009,25 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Magdagdag ng Gawain';
+
+  @override
+  String get quickActionAskOmiAnything => 'Itanong kay Omi ang kahit ano';
+
+  @override
+  String get quickActionVoiceMode => 'Mode ng Boses';
+
+  @override
+  String get quickActionMute => 'I-mute';
+
+  @override
+  String get quickActionUnmute => 'I-unmute';
+
+  @override
+  String get quickActionConnectDevice => 'I-connect ang Device';
+
+  @override
+  String get quickActionDeviceSettings => 'Mga Setting ng Device';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -24,8 +24,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deleteConversationTitle => 'Konuşma Silinsin mi?';
 
   @override
-  String get deleteConversationMessage =>
-      'Bu işlem ilişkili anıları, görevleri ve ses dosyalarını da silecektir. Bu işlem geri alınamaz.';
+  String get deleteConversationMessage => 'Bu işlem ilişkili anıları, görevleri ve ses dosyalarını da silecektir. Bu işlem geri alınamaz.';
 
   @override
   String get confirm => 'Onayla';
@@ -146,8 +145,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deleting => 'Siliniyor...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
+  String get pleaseCompleteAuthentication => 'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
 
   @override
   String get failedToStartAuthentication => 'Kimlik doğrulama başlatılamadı';
@@ -228,8 +226,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get noStarredConversations => 'Yıldızlı konuşma yok';
 
   @override
-  String get starConversationHint =>
-      'Bir konuşmayı favorilere eklemek için açın ve üst kısımdaki yıldız simgesine dokunun.';
+  String get starConversationHint => 'Bir konuşmayı favorilere eklemek için açın ve üst kısımdaki yıldız simgesine dokunun.';
 
   @override
   String get searchConversations => 'Konuşmaları ara...';
@@ -320,8 +317,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get installedApps => 'Yüklü Uygulamalar';
 
   @override
-  String get unableToFetchApps =>
-      'Uygulamalar alınamadı :(\n\nLütfen internet bağlantınızı kontrol edin ve tekrar deneyin.';
+  String get unableToFetchApps => 'Uygulamalar alınamadı :(\n\nLütfen internet bağlantınızı kontrol edin ve tekrar deneyin.';
 
   @override
   String get aboutOmi => 'Omi Hakkında';
@@ -357,19 +353,16 @@ class AppLocalizationsTr extends AppLocalizations {
   String get appsDisconnected => 'Uygulamalarınız ve Entegrasyonlarınızın bağlantısı derhal kesilecek.';
 
   @override
-  String get exportBeforeDelete =>
-      'Hesabınızı silmeden önce verilerinizi dışa aktarabilirsiniz, ancak silindikten sonra kurtarılamaz.';
+  String get exportBeforeDelete => 'Hesabınızı silmeden önce verilerinizi dışa aktarabilirsiniz, ancak silindikten sonra kurtarılamaz.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Hesabımı silmenin kalıcı olduğunu ve anılar ve konuşmalar dahil tüm verilerin kaybolacağını ve kurtarılamayacağını anlıyorum.';
+  String get deleteAccountCheckbox => 'Hesabımı silmenin kalıcı olduğunu ve anılar ve konuşmalar dahil tüm verilerin kaybolacağını ve kurtarılamayacağını anlıyorum.';
 
   @override
   String get areYouSure => 'Emin misiniz?';
 
   @override
-  String get deleteAccountFinal =>
-      'Bu işlem geri alınamaz ve hesabınızı ve tüm ilgili verileri kalıcı olarak silecektir. Devam etmek istediğinizden emin misiniz?';
+  String get deleteAccountFinal => 'Bu işlem geri alınamaz ve hesabınızı ve tüm ilgili verileri kalıcı olarak silecektir. Devam etmek istediğinizden emin misiniz?';
 
   @override
   String get deleteNow => 'Şimdi Sil';
@@ -378,8 +371,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get goBack => 'Geri Dön';
 
   @override
-  String get checkBoxToConfirm =>
-      'Hesabınızı silmenin kalıcı ve geri alınamaz olduğunu anladığınızı onaylamak için kutucuğu işaretleyin.';
+  String get checkBoxToConfirm => 'Hesabınızı silmenin kalıcı ve geri alınamaz olduğunu anladığınızı onaylamak için kutucuğu işaretleyin.';
 
   @override
   String get profile => 'Profil';
@@ -457,8 +449,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get yourPrivacyYourControl => 'Gizliliğiniz, Kontrolünüz';
 
   @override
-  String get privacyIntro =>
-      'Omi\'de gizliliğinizi korumaya kararlıyız. Bu sayfa verilerinizin nasıl saklandığını ve kullanıldığını kontrol etmenizi sağlar.';
+  String get privacyIntro => 'Omi\'de gizliliğinizi korumaya kararlıyız. Bu sayfa verilerinizin nasıl saklandığını ve kullanıldığını kontrol etmenizi sağlar.';
 
   @override
   String get learnMore => 'Daha fazla bilgi...';
@@ -467,15 +458,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dataProtectionLevel => 'Veri Koruma Seviyesi';
 
   @override
-  String get dataProtectionDesc =>
-      'Verileriniz varsayılan olarak güçlü şifreleme ile korunmaktadır. Ayarlarınızı ve gelecekteki gizlilik seçeneklerini aşağıda inceleyin.';
+  String get dataProtectionDesc => 'Verileriniz varsayılan olarak güçlü şifreleme ile korunmaktadır. Ayarlarınızı ve gelecekteki gizlilik seçeneklerini aşağıda inceleyin.';
 
   @override
   String get appAccess => 'Uygulama Erişimi';
 
   @override
-  String get appAccessDesc =>
-      'Aşağıdaki uygulamalar verilerinize erişebilir. İzinlerini yönetmek için bir uygulamaya dokunun.';
+  String get appAccessDesc => 'Aşağıdaki uygulamalar verilerinize erişebilir. İzinlerini yönetmek için bir uygulamaya dokunun.';
 
   @override
   String get noAppsExternalAccess => 'Yüklü hiçbir uygulama verilerinize harici erişime sahip değil.';
@@ -532,15 +521,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Omi\'nizin bağlantısı kesildi 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Cihaz eşleştirmesi kaldırıldı. Eşleştirme kaldırmayı tamamlamak için Ayarlar > Bluetooth\'a gidin ve cihazı unutun.';
+  String get deviceUnpairedMessage => 'Cihaz eşleştirmesi kaldırıldı. Eşleştirme kaldırmayı tamamlamak için Ayarlar > Bluetooth\'a gidin ve cihazı unutun.';
 
   @override
   String get unpairDialogTitle => 'Cihazı Eşleştirmeyi Kaldır';
 
   @override
-  String get unpairDialogMessage =>
-      'Bu, cihazın eşleştirilmesini kaldıracak ve başka bir telefona bağlanabilecek. İşlemi tamamlamak için Ayarlar > Bluetooth\'a gidip cihazı unutmanız gerekecek.';
+  String get unpairDialogMessage => 'Bu, cihazın eşleştirilmesini kaldıracak ve başka bir telefona bağlanabilecek. İşlemi tamamlamak için Ayarlar > Bluetooth\'a gidip cihazı unutmanız gerekecek.';
 
   @override
   String get deviceNotConnected => 'Cihaz Bağlı Değil';
@@ -561,8 +548,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get v2Undetected => 'V2 algılanamadı';
 
   @override
-  String get v2UndetectedMessage =>
-      'V1 cihazınız olduğunu veya cihazınızın bağlı olmadığını görüyoruz. SD Kart işlevi yalnızca V2 cihazlar için mevcuttur.';
+  String get v2UndetectedMessage => 'V1 cihazınız olduğunu veya cihazınızın bağlı olmadığını görüyoruz. SD Kart işlevi yalnızca V2 cihazlar için mevcuttur.';
 
   @override
   String get endConversation => 'Konuşmayı Sonlandır';
@@ -694,8 +680,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get noActivityYet => 'Henüz Aktivite Yok';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Kullanım içgörülerinizi burada görmek için\nOmi ile bir konuşma başlatın.';
+  String get startConversationToSeeInsights => 'Kullanım içgörülerinizi burada görmek için\nOmi ile bir konuşma başlatın.';
 
   @override
   String get listening => 'Dinleme';
@@ -837,8 +822,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Bilgi Grafiği Silinsin mi?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Bu, tüm türetilmiş bilgi grafiği verilerini (düğümler ve bağlantılar) silecektir. Orijinal anılarınız güvende kalacaktır. Grafik zamanla veya bir sonraki istekte yeniden oluşturulacaktır.';
+  String get deleteKnowledgeGraphMessage => 'Bu, tüm türetilmiş bilgi grafiği verilerini (düğümler ve bağlantılar) silecektir. Orijinal anılarınız güvende kalacaktır. Grafik zamanla veya bir sonraki istekte yeniden oluşturulacaktır.';
 
   @override
   String get knowledgeGraphDeleted => 'Bilgi grafiği silindi';
@@ -1021,8 +1005,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get integrationsFooter => 'Sohbette veri ve metrikleri görmek için uygulamalarınızı bağlayın.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
+  String get completeAuthInBrowser => 'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1082,8 +1065,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get needYourPermission => 'İzninize ihtiyacımız var';
 
   @override
-  String get alreadyGavePermission =>
-      'Kayıtlarınızı kaydetmemiz için bize zaten izin verdiniz. İşte neden buna ihtiyacımız olduğunun bir hatırlatması:';
+  String get alreadyGavePermission => 'Kayıtlarınızı kaydetmemiz için bize zaten izin verdiniz. İşte neden buna ihtiyacımız olduğunun bir hatırlatması:';
 
   @override
   String get wouldLikePermission => 'Ses kayıtlarınızı kaydetmek için izninizi istiyoruz. İşte nedeni:';
@@ -1092,26 +1074,22 @@ class AppLocalizationsTr extends AppLocalizations {
   String get improveSpeechProfile => 'Konuşma Profilinizi Geliştirin';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Kişisel konuşma profilinizi eğitmek ve geliştirmek için kayıtları kullanıyoruz.';
+  String get improveSpeechProfileDesc => 'Kişisel konuşma profilinizi eğitmek ve geliştirmek için kayıtları kullanıyoruz.';
 
   @override
   String get trainFamilyProfiles => 'Arkadaşlar ve Aile için Profil Eğitin';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Kayıtlarınız arkadaşlarınızı ve ailenizi tanımamıza ve profil oluşturmamıza yardımcı olur.';
+  String get trainFamilyProfilesDesc => 'Kayıtlarınız arkadaşlarınızı ve ailenizi tanımamıza ve profil oluşturmamıza yardımcı olur.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Transkript Doğruluğunu Artırın';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Modelimiz geliştikçe, kayıtlarınız için daha iyi transkripsiyon sonuçları sağlayabiliriz.';
+  String get enhanceTranscriptAccuracyDesc => 'Modelimiz geliştikçe, kayıtlarınız için daha iyi transkripsiyon sonuçları sağlayabiliriz.';
 
   @override
-  String get legalNotice =>
-      'Yasal Uyarı: Ses verilerini kaydetme ve saklama yasallığı bulunduğunuz yere ve bu özelliği nasıl kullandığınıza bağlı olarak değişebilir. Yerel yasalara ve düzenlemelere uyumu sağlamak sizin sorumluluğunuzdur.';
+  String get legalNotice => 'Yasal Uyarı: Ses verilerini kaydetme ve saklama yasallığı bulunduğunuz yere ve bu özelliği nasıl kullandığınıza bağlı olarak değişebilir. Yerel yasalara ve düzenlemelere uyumu sağlamak sizin sorumluluğunuzdur.';
 
   @override
   String get alreadyAuthorized => 'Zaten İzin Verildi';
@@ -1183,15 +1161,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get showMeetingsMenuBar => 'Yaklaşan toplantıları menü çubuğunda göster';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Bir sonraki toplantınızı ve başlamasına kalan süreyi macOS menü çubuğunda gösterin';
+  String get showMeetingsMenuBarDesc => 'Bir sonraki toplantınızı ve başlamasına kalan süreyi macOS menü çubuğunda gösterin';
 
   @override
   String get showEventsNoParticipants => 'Katılımcısı olmayan etkinlikleri göster';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Etkinleştirildiğinde, Yaklaşanlar katılımcısı veya video bağlantısı olmayan etkinlikleri gösterir.';
+  String get showEventsNoParticipantsDesc => 'Etkinleştirildiğinde, Yaklaşanlar katılımcısı veya video bağlantısı olmayan etkinlikleri gösterir.';
 
   @override
   String get yourMeetings => 'Toplantılarınız';
@@ -1232,8 +1208,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get noProjectsInWorkspace => 'Bu çalışma alanında proje bulunamadı';
 
   @override
-  String get conversationTimeoutDesc =>
-      'Sessizlikte ne kadar bekledikten sonra konuşmanın otomatik olarak sonlandırılacağını seçin:';
+  String get conversationTimeoutDesc => 'Sessizlikte ne kadar bekledikten sonra konuşmanın otomatik olarak sonlandırılacağını seçin:';
 
   @override
   String get timeout2Minutes => '2 dakika';
@@ -1277,8 +1252,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Bize ana dilinizi söyleyin';
 
   @override
-  String get languageForTranscription =>
-      'Daha keskin transkripsiyonlar ve kişiselleştirilmiş bir deneyim için dilinizi ayarlayın.';
+  String get languageForTranscription => 'Daha keskin transkripsiyonlar ve kişiselleştirilmiş bir deneyim için dilinizi ayarlayın.';
 
   @override
   String get singleLanguageModeInfo => 'Tek Dil Modu etkin. Daha yüksek doğruluk için çeviri devre dışı.';
@@ -1361,8 +1335,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get defaultRepository => 'Varsayılan Depo';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Sorun oluşturmak için varsayılan bir depo seçin. Sorun oluştururken farklı bir depo belirtebilirsiniz.';
+  String get selectDefaultRepoDesc => 'Sorun oluşturmak için varsayılan bir depo seçin. Sorun oluştururken farklı bir depo belirtebilirsiniz.';
 
   @override
   String get noReposFound => 'Depo bulunamadı';
@@ -1409,8 +1382,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get configureSettings => 'Ayarları Yapılandır';
 
   @override
-  String get completeAuthBrowser =>
-      'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
+  String get completeAuthBrowser => 'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1738,8 +1710,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth\'u Etkinleştir';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi\'nin giyilebilir cihazınıza bağlanması için Bluetooth gereklidir. Lütfen Bluetooth\'u etkinleştirin ve tekrar deneyin.';
+  String get bluetoothNeeded => 'Omi\'nin giyilebilir cihazınıza bağlanması için Bluetooth gereklidir. Lütfen Bluetooth\'u etkinleştirin ve tekrar deneyin.';
 
   @override
   String get contactSupport => 'Desteğe Başvur?';
@@ -1772,26 +1743,22 @@ class AppLocalizationsTr extends AppLocalizations {
   String get locationServiceDisabled => 'Konum Servisi Devre Dışı';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Konum Servisi Devre Dışı. Lütfen Ayarlar > Gizlilik ve Güvenlik > Konum Servisleri\'ne gidin ve etkinleştirin';
+  String get locationServiceDisabledDesc => 'Konum Servisi Devre Dışı. Lütfen Ayarlar > Gizlilik ve Güvenlik > Konum Servisleri\'ne gidin ve etkinleştirin';
 
   @override
   String get backgroundLocationDenied => 'Arka Plan Konum Erişimi Reddedildi';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Lütfen cihaz ayarlarına gidin ve konum iznini \"Her Zaman İzin Ver\" olarak ayarlayın';
+  String get backgroundLocationDeniedDesc => 'Lütfen cihaz ayarlarına gidin ve konum iznini \"Her Zaman İzin Ver\" olarak ayarlayın';
 
   @override
   String get lovingOmi => 'Omi\'yi Beğeniyor musunuz?';
 
   @override
-  String get leaveReviewIos =>
-      'App Store\'da bir yorum bırakarak daha fazla insana ulaşmamıza yardımcı olun. Geri bildiriminiz bizim için çok değerli!';
+  String get leaveReviewIos => 'App Store\'da bir yorum bırakarak daha fazla insana ulaşmamıza yardımcı olun. Geri bildiriminiz bizim için çok değerli!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Google Play Store\'da bir yorum bırakarak daha fazla insana ulaşmamıza yardımcı olun. Geri bildiriminiz bizim için çok değerli!';
+  String get leaveReviewAndroid => 'Google Play Store\'da bir yorum bırakarak daha fazla insana ulaşmamıza yardımcı olun. Geri bildiriminiz bizim için çok değerli!';
 
   @override
   String get rateOnAppStore => 'App Store\'da Değerlendir';
@@ -1824,15 +1791,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get connectionError => 'Bağlantı Hatası';
 
   @override
-  String get connectionErrorDesc =>
-      'Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.';
+  String get connectionErrorDesc => 'Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Geçersiz kayıt algılandı';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Kayıtta birden fazla konuşmacı var gibi görünüyor. Lütfen sessiz bir yerde olduğunuzdan emin olun ve tekrar deneyin.';
+  String get multipleSpeakersDesc => 'Kayıtta birden fazla konuşmacı var gibi görünüyor. Lütfen sessiz bir yerde olduğunuzdan emin olun ve tekrar deneyin.';
 
   @override
   String get tooShortDesc => 'Yeterli konuşma algılanamadı. Lütfen daha fazla konuşun ve tekrar deneyin.';
@@ -1844,8 +1809,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get areYouThere => 'Orada mısınız?';
 
   @override
-  String get noSpeechDesc =>
-      'Herhangi bir konuşma algılayamadık. Lütfen en az 10 saniye, en fazla 3 dakika konuştuğunuzdan emin olun.';
+  String get noSpeechDesc => 'Herhangi bir konuşma algılayamadık. Lütfen en az 10 saniye, en fazla 3 dakika konuştuğunuzdan emin olun.';
 
   @override
   String get connectionLost => 'Bağlantı Kesildi';
@@ -1866,8 +1830,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get permissionsRequired => 'İzinler gerekli';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Bu uygulamanın düzgün çalışması için Bluetooth ve Konum izinlerine ihtiyacı var. Lütfen ayarlardan bunları etkinleştirin.';
+  String get permissionsRequiredDesc => 'Bu uygulamanın düzgün çalışması için Bluetooth ve Konum izinlerine ihtiyacı var. Lütfen ayarlardan bunları etkinleştirin.';
 
   @override
   String get openSettings => 'Ayarları Aç';
@@ -1909,12 +1872,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get microphonePermission => 'Mikrofon İzni';
 
   @override
-  String get permissionGrantedNow =>
-      'İzin verildi! Şimdi:\n\nSaatinizdeki Omi uygulamasını açın ve aşağıda \"Devam Et\"e dokunun';
+  String get permissionGrantedNow => 'İzin verildi! Şimdi:\n\nSaatinizdeki Omi uygulamasını açın ve aşağıda \"Devam Et\"e dokunun';
 
   @override
-  String get needMicrophonePermission =>
-      'Mikrofon iznine ihtiyacımız var.\n\n1. \"İzin Ver\"e dokunun\n2. iPhone\'unuzda izin verin\n3. Saat uygulaması kapanacak\n4. Yeniden açın ve \"Devam Et\"e dokunun';
+  String get needMicrophonePermission => 'Mikrofon iznine ihtiyacımız var.\n\n1. \"İzin Ver\"e dokunun\n2. iPhone\'unuzda izin verin\n3. Saat uygulaması kapanacak\n4. Yeniden açın ve \"Devam Et\"e dokunun';
 
   @override
   String get grantPermissionButton => 'İzin Ver';
@@ -1923,15 +1884,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get needHelp => 'Yardıma mı İhtiyacınız Var?';
 
   @override
-  String get troubleshootingSteps =>
-      'Sorun giderme:\n\n1. Omi\'nin saatinizde yüklü olduğundan emin olun\n2. Saatinizdeki Omi uygulamasını açın\n3. İzin açılır penceresini arayın\n4. İstendiğinde \"İzin Ver\"e dokunun\n5. Saatinizdeki uygulama kapanacak - yeniden açın\n6. Geri gelin ve iPhone\'unuzda \"Devam Et\"e dokunun';
+  String get troubleshootingSteps => 'Sorun giderme:\n\n1. Omi\'nin saatinizde yüklü olduğundan emin olun\n2. Saatinizdeki Omi uygulamasını açın\n3. İzin açılır penceresini arayın\n4. İstendiğinde \"İzin Ver\"e dokunun\n5. Saatinizdeki uygulama kapanacak - yeniden açın\n6. Geri gelin ve iPhone\'unuzda \"Devam Et\"e dokunun';
 
   @override
   String get recordingStartedSuccessfully => 'Kayıt başarıyla başladı!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Henüz izin verilmedi. Lütfen mikrofon erişimine izin verdiğinizden ve saatinizdeki uygulamayı yeniden açtığınızdan emin olun.';
+  String get permissionNotGrantedYet => 'Henüz izin verilmedi. Lütfen mikrofon erişimine izin verdiğinizden ve saatinizdeki uygulamayı yeniden açtığınızdan emin olun.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1947,8 +1906,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get selectPrimaryLanguage => 'Ana dilinizi seçin';
 
   @override
-  String get languageBenefits =>
-      'Daha keskin transkripsiyonlar ve kişiselleştirilmiş bir deneyim için dilinizi ayarlayın';
+  String get languageBenefits => 'Daha keskin transkripsiyonlar ve kişiselleştirilmiş bir deneyim için dilinizi ayarlayın';
 
   @override
   String get whatsYourPrimaryLanguage => 'Ana diliniz nedir?';
@@ -2029,8 +1987,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Eylem Öğeleri için Hazır';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Yapay zekanız konuşmalarınızdan otomatik olarak görevleri ve yapılacakları çıkaracaktır. Oluşturulduklarında burada görünecekler.';
+  String get welcomeActionItemsDescription => 'Yapay zekanız konuşmalarınızdan otomatik olarak görevleri ve yapılacakları çıkaracaktır. Oluşturulduklarında burada görünecekler.';
 
   @override
   String get autoExtractionFeature => 'Konuşmalardan otomatik olarak çıkarıldı';
@@ -2080,8 +2037,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get clearMemoryTitle => 'Omi\'nin Hafızasını Temizle';
 
   @override
-  String get clearMemoryMessage =>
-      'Omi\'nin hafızasını temizlemek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
+  String get clearMemoryMessage => 'Omi\'nin hafızasını temizlemek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
 
   @override
   String get clearMemoryButton => 'Belleği Temizle';
@@ -2227,15 +2183,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'KONUŞMA VE TRANSKRİPSİYON';
 
   @override
-  String get languageSettingsHelperText =>
-      'Uygulama Dili menüleri ve düğmeleri değiştirir. Konuşma Dili, kayıtlarınızın nasıl transkribe edildiğini etkiler.';
+  String get languageSettingsHelperText => 'Uygulama Dili menüleri ve düğmeleri değiştirir. Konuşma Dili, kayıtlarınızın nasıl transkribe edildiğini etkiler.';
 
   @override
   String get translationNotice => 'Çeviri Bildirimi';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi konuşmaları birincil dilinize çevirir. İstediğiniz zaman Ayarlar → Profiller\'de güncelleyin.';
+  String get translationNoticeMessage => 'Omi konuşmaları birincil dilinize çevirir. İstediğiniz zaman Ayarlar → Profiller\'de güncelleyin.';
 
   @override
   String get pleaseCheckInternetConnection => 'Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin';
@@ -2390,8 +2344,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Cihaz Eşleştirmesini Kaldır';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Bu, cihazın başka bir telefona bağlanabilmesi için eşleştirmesini kaldıracaktır. İşlemi tamamlamak için Ayarlar > Bluetooth\'a gitmeniz ve cihazı unutmanız gerekecek.';
+  String get unpairDeviceDialogMessage => 'Bu, cihazın başka bir telefona bağlanabilmesi için eşleştirmesini kaldıracaktır. İşlemi tamamlamak için Ayarlar > Bluetooth\'a gitmeniz ve cihazı unutmanız gerekecek.';
 
   @override
   String get unpair => 'Eşleştirmeyi Kaldır';
@@ -2572,8 +2525,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get youreAllSet => 'Hazırsınız!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Omi\'ye hoş geldiniz! AI yardımcınız konuşmalar, görevler ve daha fazlasında size yardımcı olmaya hazır.';
+  String get welcomeToOmiDescription => 'Omi\'ye hoş geldiniz! AI yardımcınız konuşmalar, görevler ve daha fazlasında size yardımcı olmaya hazır.';
 
   @override
   String get startUsingOmi => 'Omi\'yi Kullanmaya Başla';
@@ -2709,8 +2661,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get noTasksYet => 'Henüz görev yok';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Konuşmalarınızdaki görevler burada görünecek.\nManuel olarak eklemek için Oluştur\'a tıklayın.';
+  String get tasksFromConversationsWillAppear => 'Konuşmalarınızdaki görevler burada görünecek.\nManuel olarak eklemek için Oluştur\'a tıklayın.';
 
   @override
   String get monthJan => 'Oca';
@@ -2767,8 +2718,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deleteActionItem => 'Eylem öğesini sil';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Bu eylem öğesini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
+  String get deleteActionItemConfirmation => 'Bu eylem öğesini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
 
   @override
   String get enterActionItemDescription => 'Eylem öğesi açıklamasını girin...';
@@ -2843,15 +2793,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get chatPrompt => 'Sohbet Yönlendirmesi';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Harika bir uygulamasınız, işiniz kullanıcı sorgularına yanıt vermek ve onları iyi hissettirmek...';
+  String get chatPromptPlaceholder => 'Harika bir uygulamasınız, işiniz kullanıcı sorgularına yanıt vermek ve onları iyi hissettirmek...';
 
   @override
   String get conversationPrompt => 'Konuşma İstemi';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Harika bir uygulamasınız, size bir konuşmanın transkripti ve özeti verilecek...';
+  String get conversationPromptPlaceholder => 'Harika bir uygulamasınız, size bir konuşmanın transkripti ve özeti verilecek...';
 
   @override
   String get notificationScopes => 'Bildirim Kapsamları';
@@ -2863,8 +2811,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get makeMyAppPublic => 'Uygulamamı herkese açık yap';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Bu uygulamayı göndererek, Omi AI Hizmet Koşullarını ve Gizlilik Politikasını kabul ediyorum';
+  String get submitAppTermsAgreement => 'Bu uygulamayı göndererek, Omi AI Hizmet Koşullarını ve Gizlilik Politikasını kabul ediyorum';
 
   @override
   String get submitApp => 'Uygulamayı Gönder';
@@ -2879,12 +2826,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get submitAppQuestion => 'Uygulama Gönderilsin mi?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Uygulamanız incelenecek ve herkese açık hale getirilecek. İnceleme sırasında bile hemen kullanmaya başlayabilirsiniz!';
+  String get submitAppPublicDescription => 'Uygulamanız incelenecek ve herkese açık hale getirilecek. İnceleme sırasında bile hemen kullanmaya başlayabilirsiniz!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Uygulamanız incelenecek ve size özel olarak sunulacak. İnceleme sırasında bile hemen kullanmaya başlayabilirsiniz!';
+  String get submitAppPrivateDescription => 'Uygulamanız incelenecek ve size özel olarak sunulacak. İnceleme sırasında bile hemen kullanmaya başlayabilirsiniz!';
 
   @override
   String get startEarning => 'Kazanmaya Başlayın! 💰';
@@ -2908,23 +2853,19 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dataAccessNotice => 'Veri Erişim Bildirimi';
 
   @override
-  String get dataAccessWarning =>
-      'Bu uygulama verilerinize erişecek. Omi AI, bu uygulama tarafından verilerinizin nasıl kullanıldığı, değiştirildiği veya silindiğinden sorumlu değildir';
+  String get dataAccessWarning => 'Bu uygulama verilerinize erişecek. Omi AI, bu uygulama tarafından verilerinizin nasıl kullanıldığı, değiştirildiği veya silindiğinden sorumlu değildir';
 
   @override
   String get installApp => 'Uygulamayı yükle';
 
   @override
-  String get betaTesterNotice =>
-      'Bu uygulamanın beta test kullanıcısısınız. Henüz herkese açık değil. Onaylandıktan sonra herkese açık olacak.';
+  String get betaTesterNotice => 'Bu uygulamanın beta test kullanıcısısınız. Henüz herkese açık değil. Onaylandıktan sonra herkese açık olacak.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Uygulamanız inceleniyor ve yalnızca size görünür. Onaylandıktan sonra herkese açık olacak.';
+  String get appUnderReviewOwner => 'Uygulamanız inceleniyor ve yalnızca size görünür. Onaylandıktan sonra herkese açık olacak.';
 
   @override
-  String get appRejectedNotice =>
-      'Uygulamanız reddedildi. Lütfen uygulama ayrıntılarını güncelleyin ve inceleme için yeniden gönderin.';
+  String get appRejectedNotice => 'Uygulamanız reddedildi. Lütfen uygulama ayrıntılarını güncelleyin ve inceleme için yeniden gönderin.';
 
   @override
   String get setupSteps => 'Kurulum Adımları';
@@ -2986,8 +2927,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get descriptionLabel => 'Açıklama';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Harika Uygulamam harika şeyler yapan harika bir uygulamadır. En iyi uygulama!';
+  String get appDescriptionPlaceholder => 'Harika Uygulamam harika şeyler yapan harika bir uygulamadır. En iyi uygulama!';
 
   @override
   String get pleaseProvideValidDescription => 'Lütfen geçerli bir açıklama sağlayın';
@@ -3139,8 +3079,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get microphonePermissionRequired => 'Ses kaydı için mikrofon izni gereklidir.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Mikrofon izni reddedildi. Lütfen Sistem Tercihleri > Gizlilik ve Güvenlik > Mikrofon\'da izin verin.';
+  String get microphonePermissionDenied => 'Mikrofon izni reddedildi. Lütfen Sistem Tercihleri > Gizlilik ve Güvenlik > Mikrofon\'da izin verin.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3373,8 +3312,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get whatWeCollect => 'Topladıklarımız';
 
   @override
-  String get dataCollectionMessage =>
-      'Devam ederek, konuşmalarınız, kayıtlarınız ve kişisel bilgileriniz AI destekli içgörüler sağlamak ve tüm uygulama özelliklerini etkinleştirmek için sunucularımızda güvenli bir şekilde saklanacaktır.';
+  String get dataCollectionMessage => 'Devam ederek, konuşmalarınız, kayıtlarınız ve kişisel bilgileriniz AI destekli içgörüler sağlamak ve tüm uygulama özelliklerini etkinleştirmek için sunucularımızda güvenli bir şekilde saklanacaktır.';
 
   @override
   String get dataProtection => 'Veri Koruması';
@@ -3407,8 +3345,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'İsim en az 2 karakter olmalıdır';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Nasıl hitap edilmesini istediğinizi bize söyleyin. Bu, Omi deneyiminizi kişiselleştirmeye yardımcı olur.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Nasıl hitap edilmesini istediğinizi bize söyleyin. Bu, Omi deneyiminizi kişiselleştirmeye yardımcı olur.';
 
   @override
   String charactersCount(int count) {
@@ -3425,8 +3362,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get recordAudioConversations => 'Sesli konuşmaları kaydet';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi, konuşmalarınızı kaydetmek ve transkript sağlamak için mikrofon erişimine ihtiyaç duyar.';
+  String get microphoneAccessDescription => 'Omi, konuşmalarınızı kaydetmek ve transkript sağlamak için mikrofon erişimine ihtiyaç duyar.';
 
   @override
   String get screenRecording => 'Ekran Kaydı';
@@ -3435,8 +3371,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Toplantılardan sistem sesini yakala';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi, tarayıcı tabanlı toplantılarınızdan sistem sesini yakalamak için ekran kaydı izni gerektirir.';
+  String get screenRecordingDescription => 'Omi, tarayıcı tabanlı toplantılarınızdan sistem sesini yakalamak için ekran kaydı izni gerektirir.';
 
   @override
   String get accessibility => 'Erişilebilirlik';
@@ -3445,8 +3380,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Tarayıcı tabanlı toplantıları algıla';
 
   @override
-  String get accessibilityDescription =>
-      'Omi, tarayıcınızda Zoom, Meet veya Teams toplantılarına katıldığınızı algılamak için erişilebilirlik izni gerektirir.';
+  String get accessibilityDescription => 'Omi, tarayıcınızda Zoom, Meet veya Teams toplantılarına katıldığınızı algılamak için erişilebilirlik izni gerektirir.';
 
   @override
   String get pleaseWait => 'Lütfen bekleyin...';
@@ -3494,8 +3428,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get preferences => 'Tercihler';
 
   @override
-  String get helpImproveOmiBySharing =>
-      'Anonimleştirilmiş analitik verileri paylaşarak Omi\'yi geliştirmeye yardımcı olun';
+  String get helpImproveOmiBySharing => 'Anonimleştirilmiş analitik verileri paylaşarak Omi\'yi geliştirmeye yardımcı olun';
 
   @override
   String get deleteAccount => 'Hesabı Sil';
@@ -3516,12 +3449,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get exportAllConversationsToJson => 'Tüm konuşmalarınızı bir JSON dosyasına aktarın.';
 
   @override
-  String get conversationsExportStarted =>
-      'Konuşma dışa aktarımı başlatıldı. Bu birkaç saniye sürebilir, lütfen bekleyin.';
+  String get conversationsExportStarted => 'Konuşma dışa aktarımı başlatıldı. Bu birkaç saniye sürebilir, lütfen bekleyin.';
 
   @override
-  String get mcpDescription =>
-      'Anılarınızı ve konuşmalarınızı okumak, aramak ve yönetmek için Omi\'yi diğer uygulamalarla bağlamak için. Başlamak için bir anahtar oluşturun.';
+  String get mcpDescription => 'Anılarınızı ve konuşmalarınızı okumak, aramak ve yönetmek için Omi\'yi diğer uygulamalarla bağlamak için. Başlamak için bir anahtar oluşturun.';
 
   @override
   String get apiKeys => 'API Anahtarları';
@@ -3568,8 +3499,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get autoCreateAndTagNewSpeakers => 'Yeni konuşmacıları otomatik olarak oluştur ve etiketle';
 
   @override
-  String get automaticallyCreateNewPerson =>
-      'Transkriptte bir ad algılandığında otomatik olarak yeni bir kişi oluştur.';
+  String get automaticallyCreateNewPerson => 'Transkriptte bir ad algılandığında otomatik olarak yeni bir kişi oluştur.';
 
   @override
   String get pilotFeatures => 'Pilot Özellikler';
@@ -3593,8 +3523,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get auto => 'Otomatik';
 
   @override
-  String get noSummaryForApp =>
-      'Bu uygulama için özet mevcut değil. Daha iyi sonuçlar için başka bir uygulama deneyin.';
+  String get noSummaryForApp => 'Bu uygulama için özet mevcut değil. Daha iyi sonuçlar için başka bir uygulama deneyin.';
 
   @override
   String get tryAnotherApp => 'Başka Bir Uygulama Deneyin';
@@ -3679,8 +3608,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Sistem ses kaydı hazırlanıyor';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Canlı transkriptler, AI içgörüleri ve otomatik kaydetme için ses kaydetmek üzere düğmeye tıklayın.';
+  String get clickTheButtonToCaptureAudio => 'Canlı transkriptler, AI içgörüleri ve otomatik kaydetme için ses kaydetmek üzere düğmeye tıklayın.';
 
   @override
   String get reconnecting => 'Yeniden bağlanıyor...';
@@ -3907,8 +3835,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Bilgi Grafiği Silinsin mi?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Bu, türetilmiş tüm bilgi grafiği verilerini silecektir. Orijinal anılarınız güvende kalır.';
+  String get deleteKnowledgeGraphWarning => 'Bu, türetilmiş tüm bilgi grafiği verilerini silecektir. Orijinal anılarınız güvende kalır.';
 
   @override
   String get connectOmiWithAI => 'Omi\'yi yapay zeka asistanlarıyla bağlayın';
@@ -3950,8 +3877,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get termsAndPrivacyPolicy => 'Şartlar ve Gizlilik Politikası';
 
   @override
-  String get helpsDiagnoseIssuesAutoDeletes =>
-      'Sorunların teşhisine yardımcı olur. 3 gün sonra otomatik olarak silinir.';
+  String get helpsDiagnoseIssuesAutoDeletes => 'Sorunların teşhisine yardımcı olur. 3 gün sonra otomatik olarak silinir.';
 
   @override
   String get manageYourApp => 'Uygulamanızı Yönetin';
@@ -3966,8 +3892,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get updateAppQuestion => 'Uygulama güncellensin mi?';
 
   @override
-  String get updateAppConfirmation =>
-      'Uygulamanızı güncellemek istediğinizden emin misiniz? Değişiklikler ekibimiz tarafından incelendikten sonra yansıtılacaktır.';
+  String get updateAppConfirmation => 'Uygulamanızı güncellemek istediğinizden emin misiniz? Değişiklikler ekibimiz tarafından incelendikten sonra yansıtılacaktır.';
 
   @override
   String get updateApp => 'Uygulamayı Güncelle';
@@ -3997,8 +3922,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get no => 'Hayır';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Abonelik başarıyla iptal edildi. Mevcut fatura döneminin sonuna kadar aktif kalacaktır.';
+  String get subscriptionCancelledSuccessfully => 'Abonelik başarıyla iptal edildi. Mevcut fatura döneminin sonuna kadar aktif kalacaktır.';
 
   @override
   String get failedToCancelSubscription => 'Abonelik iptal edilemedi. Lütfen tekrar deneyin.';
@@ -4034,8 +3958,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Aboneliği iptal et?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Aboneliğinizi iptal etmek istediğinizden emin misiniz? Mevcut fatura döneminin sonuna kadar erişiminiz devam edecektir.';
+  String get cancelSubscriptionConfirmation => 'Aboneliğinizi iptal etmek istediğinizden emin misiniz? Mevcut fatura döneminin sonuna kadar erişiminiz devam edecektir.';
 
   @override
   String get cancelSubscriptionButton => 'Aboneliği İptal Et';
@@ -4044,12 +3967,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get cancelling => 'İptal ediliyor...';
 
   @override
-  String get betaTesterMessage =>
-      'Bu uygulamanın beta test kullanıcısısınız. Henüz herkese açık değil. Onaylandıktan sonra herkese açık olacak.';
+  String get betaTesterMessage => 'Bu uygulamanın beta test kullanıcısısınız. Henüz herkese açık değil. Onaylandıktan sonra herkese açık olacak.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Uygulamanız inceleniyor ve yalnızca size görünür. Onaylandıktan sonra herkese açık olacak.';
+  String get appUnderReviewMessage => 'Uygulamanız inceleniyor ve yalnızca size görünür. Onaylandıktan sonra herkese açık olacak.';
 
   @override
   String get appRejectedMessage => 'Uygulamanız reddedildi. Lütfen detayları güncelleyip tekrar gönderin.';
@@ -4106,8 +4027,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get issueActivatingApp => 'Bu uygulamayı etkinleştirirken bir sorun oluştu. Lütfen tekrar deneyin.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Bu uygulama verilerinize erişecektir. Omi AI, verilerinizin bu uygulama tarafından nasıl kullanıldığından, değiştirildiğinden veya silindiğinden sorumlu değildir';
+  String get dataAccessNoticeDescription => 'Bu uygulama verilerinize erişecektir. Omi AI, verilerinizin bu uygulama tarafından nasıl kullanıldığından, değiştirildiğinden veya silindiğinden sorumlu değildir';
 
   @override
   String get copyUrl => 'URL\'yi Kopyala';
@@ -4195,8 +4115,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get omiApiKeys => 'Omi API Anahtarları';
 
   @override
-  String get apiKeysDescription =>
-      'API anahtarları, uygulamanız OMI sunucusuyla iletişim kurarken kimlik doğrulama için kullanılır. Uygulamanızın anılar oluşturmasına ve diğer OMI hizmetlerine güvenli bir şekilde erişmesine olanak tanır.';
+  String get apiKeysDescription => 'API anahtarları, uygulamanız OMI sunucusuyla iletişim kurarken kimlik doğrulama için kullanılır. Uygulamanızın anılar oluşturmasına ve diğer OMI hizmetlerine güvenli bir şekilde erişmesine olanak tanır.';
 
   @override
   String get aboutOmiApiKeys => 'Omi API Anahtarları Hakkında';
@@ -4220,8 +4139,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API Anahtarını İptal Et?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Bu işlem geri alınamaz. Bu anahtarı kullanan uygulamalar artık API\'ye erişemeyecektir.';
+  String get revokeApiKeyWarning => 'Bu işlem geri alınamaz. Bu anahtarı kullanan uygulamalar artık API\'ye erişemeyecektir.';
 
   @override
   String get revoke => 'İptal Et';
@@ -4319,8 +4237,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get externalAppAccess => 'Harici Uygulama Erişimi';
 
   @override
-  String get externalAppAccessDescription =>
-      'Aşağıdaki yüklü uygulamalar harici entegrasyonlara sahiptir ve sohbetler ve anılar gibi verilerinize erişebilir.';
+  String get externalAppAccessDescription => 'Aşağıdaki yüklü uygulamalar harici entegrasyonlara sahiptir ve sohbetler ve anılar gibi verilerinize erişebilir.';
 
   @override
   String get noExternalAppsHaveAccess => 'Hiçbir harici uygulama verilerinize erişemiyor.';
@@ -4329,8 +4246,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get maximumSecurityE2ee => 'Maksimum Güvenlik (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Uçtan uca şifreleme, gizlilik için altın standarttır. Etkinleştirildiğinde, verileriniz sunucularımıza gönderilmeden önce cihazınızda şifrelenir. Bu, Omi dahil hiç kimsenin içeriğinize erişemeyeceği anlamına gelir.';
+  String get e2eeDescription => 'Uçtan uca şifreleme, gizlilik için altın standarttır. Etkinleştirildiğinde, verileriniz sunucularımıza gönderilmeden önce cihazınızda şifrelenir. Bu, Omi dahil hiç kimsenin içeriğinize erişemeyeceği anlamına gelir.';
 
   @override
   String get importantTradeoffs => 'Önemli Ödünler:';
@@ -4364,19 +4280,16 @@ class AppLocalizationsTr extends AppLocalizations {
   String get secureEncryption => 'Güvenli Şifreleme';
 
   @override
-  String get secureEncryptionDescription =>
-      'Verileriniz, Google Cloud\'da barındırılan sunucularımızda size özgü bir anahtarla şifrelenir. Bu, ham içeriğinizin Omi personeli veya Google dahil hiç kimse tarafından doğrudan veritabanından erişilemez olduğu anlamına gelir.';
+  String get secureEncryptionDescription => 'Verileriniz, Google Cloud\'da barındırılan sunucularımızda size özgü bir anahtarla şifrelenir. Bu, ham içeriğinizin Omi personeli veya Google dahil hiç kimse tarafından doğrudan veritabanından erişilemez olduğu anlamına gelir.';
 
   @override
   String get endToEndEncryption => 'Uçtan Uca Şifreleme';
 
   @override
-  String get e2eeCardDescription =>
-      'Yalnızca sizin verilerinize erişebildiğiniz maksimum güvenlik için etkinleştirin. Daha fazla bilgi için dokunun.';
+  String get e2eeCardDescription => 'Yalnızca sizin verilerinize erişebildiğiniz maksimum güvenlik için etkinleştirin. Daha fazla bilgi için dokunun.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Seviyeden bağımsız olarak, verileriniz her zaman dinlenme halinde ve aktarım sırasında şifrelenir.';
+  String get dataAlwaysEncrypted => 'Seviyeden bağımsız olarak, verileriniz her zaman dinlenme halinde ve aktarım sırasında şifrelenir.';
 
   @override
   String get readOnlyScope => 'Yalnızca Okuma';
@@ -4441,12 +4354,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get trainingDataProgram => 'Eğitim Verisi Programı';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Verilerinizi AI modellerini eğitmek için katkıda bulunarak Omi Unlimited\'ı ücretsiz alın.';
+  String get getOmiUnlimitedFree => 'Verilerinizi AI modellerini eğitmek için katkıda bulunarak Omi Unlimited\'ı ücretsiz alın.';
 
   @override
-  String get trainingDataBullets =>
-      '• Verileriniz AI modellerini geliştirmeye yardımcı olur\n• Yalnızca hassas olmayan veriler paylaşılır\n• Tamamen şeffaf süreç';
+  String get trainingDataBullets => '• Verileriniz AI modellerini geliştirmeye yardımcı olur\n• Yalnızca hassas olmayan veriler paylaşılır\n• Tamamen şeffaf süreç';
 
   @override
   String get learnMoreAtOmiTraining => 'omi.me/training adresinde daha fazla bilgi edinin';
@@ -4458,8 +4369,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get submitRequest => 'İstek Gönder';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Teşekkürler! İsteğiniz inceleniyor. Onaylandıktan sonra sizi bilgilendireceğiz.';
+  String get thankYouRequestUnderReview => 'Teşekkürler! İsteğiniz inceleniyor. Onaylandıktan sonra sizi bilgilendireceğiz.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4497,8 +4407,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get monthlyPlanContinues => 'Mevcut aylık planınız fatura döneminizin sonuna kadar devam edecek';
 
   @override
-  String get paymentMethodCharged =>
-      'Aylık planınız sona erdiğinde mevcut ödeme yönteminiz otomatik olarak tahsil edilecek';
+  String get paymentMethodCharged => 'Aylık planınız sona erdiğinde mevcut ödeme yönteminiz otomatik olarak tahsil edilecek';
 
   @override
   String get annualSubscriptionStarts => '12 aylık yıllık aboneliğiniz ödeme sonrasında otomatik olarak başlayacak';
@@ -4541,8 +4450,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Aylık planınız sona erdiğinde yıllık planınız otomatik olarak başlayacak.';
+  String get annualPlanStartsAutomatically => 'Aylık planınız sona erdiğinde yıllık planınız otomatik olarak başlayacak.';
 
   @override
   String planRenewsOn(String date) {
@@ -4609,8 +4517,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Gizliliğiniz Bizim İçin Önemli';
 
   @override
-  String get privacyIntroText =>
-      'Omi\'de gizliliğinizi çok ciddiye alıyoruz. Topladığımız veriler ve bunları nasıl kullandığımız konusunda şeffaf olmak istiyoruz. İşte bilmeniz gerekenler:';
+  String get privacyIntroText => 'Omi\'de gizliliğinizi çok ciddiye alıyoruz. Topladığımız veriler ve bunları nasıl kullandığımız konusunda şeffaf olmak istiyoruz. İşte bilmeniz gerekenler:';
 
   @override
   String get whatWeTrack => 'Ne Takip Ediyoruz';
@@ -4625,12 +4532,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get ourCommitment => 'Taahhüdümüz';
 
   @override
-  String get commitmentText =>
-      'Topladığımız verileri yalnızca Omi\'yi sizin için daha iyi bir ürün haline getirmek için kullanmayı taahhüt ediyoruz. Gizliliğiniz ve güveniniz bizim için çok önemlidir.';
+  String get commitmentText => 'Topladığımız verileri yalnızca Omi\'yi sizin için daha iyi bir ürün haline getirmek için kullanmayı taahhüt ediyoruz. Gizliliğiniz ve güveniniz bizim için çok önemlidir.';
 
   @override
-  String get thankYouText =>
-      'Omi\'nin değerli bir kullanıcısı olduğunuz için teşekkür ederiz. Herhangi bir sorunuz veya endişeniz varsa, team@basedhardware.com adresinden bize ulaşmaktan çekinmeyin.';
+  String get thankYouText => 'Omi\'nin değerli bir kullanıcısı olduğunuz için teşekkür ederiz. Herhangi bir sorunuz veya endişeniz varsa, team@basedhardware.com adresinden bize ulaşmaktan çekinmeyin.';
 
   @override
   String get wifiSyncSettings => 'WiFi Senkronizasyon Ayarları';
@@ -4639,8 +4544,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get enterHotspotCredentials => 'Telefonunuzun hotspot kimlik bilgilerini girin';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi senkronizasyonu telefonunuzu hotspot olarak kullanır. Adı ve şifreyi Ayarlar > Kişisel Erişim Noktası\'nda bulun.';
+  String get wifiSyncUsesHotspot => 'WiFi senkronizasyonu telefonunuzu hotspot olarak kullanır. Adı ve şifreyi Ayarlar > Kişisel Erişim Noktası\'nda bulun.';
 
   @override
   String get hotspotNameSsid => 'Hotspot Adı (SSID)';
@@ -4675,8 +4579,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Özet oluşturulamadı. O gün için konuşmalarınız olduğundan emin olun.';
+  String get failedToGenerateSummaryCheckConversations => 'Özet oluşturulamadı. O gün için konuşmalarınız olduğundan emin olun.';
 
   @override
   String get summaryNotFound => 'Özet bulunamadı';
@@ -4706,8 +4609,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Dışa aktarma başladı. Bu birkaç saniye sürebilir...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Bu, tüm türetilmiş bilgi grafiği verilerini (düğümler ve bağlantılar) silecektir. Orijinal anılarınız güvende kalacaktır. Grafik zamanla veya bir sonraki istekte yeniden oluşturulacaktır.';
+  String get knowledgeGraphDeleteDescription => 'Bu, tüm türetilmiş bilgi grafiği verilerini (düğümler ve bağlantılar) silecektir. Orijinal anılarınız güvende kalacaktır. Grafik zamanla veya bir sonraki istekte yeniden oluşturulacaktır.';
 
   @override
   String get configureDailySummaryDigest => 'Günlük görev özetinizi yapılandırın';
@@ -4777,8 +4679,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Tüm Limitless konuşmaları silinsin mi?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Bu, Limitless\'tan içe aktarılan tüm konuşmaları kalıcı olarak silecektir. Bu işlem geri alınamaz.';
+  String get deleteAllLimitlessWarning => 'Bu, Limitless\'tan içe aktarılan tüm konuşmaları kalıcı olarak silecektir. Bu işlem geri alınamaz.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4834,8 +4735,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get howItWorksTitle => 'Nasıl çalışır?';
 
   @override
-  String get howPeopleWorks =>
-      'Bir kişi oluşturulduktan sonra, bir konuşma transkriptine gidebilir ve ilgili bölümleri atayabilirsiniz, böylece Omi onların konuşmasını da tanıyabilir!';
+  String get howPeopleWorks => 'Bir kişi oluşturulduktan sonra, bir konuşma transkriptine gidebilir ve ilgili bölümleri atayabilirsiniz, böylece Omi onların konuşmasını da tanıyabilir!';
 
   @override
   String get tapToDelete => 'Silmek için dokunun';
@@ -4861,8 +4761,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get privacyNotice => 'Gizlilik Bildirimi';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Kayıtlar başkalarının seslerini yakalayabilir. Etkinleştirmeden önce tüm katılımcıların onayını aldığınızdan emin olun.';
+  String get recordingsMayCaptureOthers => 'Kayıtlar başkalarının seslerini yakalayabilir. Etkinleştirmeden önce tüm katılımcıların onayını aldığınızdan emin olun.';
 
   @override
   String get enable => 'Etkinleştir';
@@ -4874,8 +4773,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get on => 'On';
 
   @override
-  String get storeAudioDescription =>
-      'Tüm ses kayıtlarını telefonunuzda yerel olarak saklayın. Devre dışı bırakıldığında, depolama alanından tasarruf etmek için yalnızca başarısız yüklemeler saklanır.';
+  String get storeAudioDescription => 'Tüm ses kayıtlarını telefonunuzda yerel olarak saklayın. Devre dışı bırakıldığında, depolama alanından tasarruf etmek için yalnızca başarısız yüklemeler saklanır.';
 
   @override
   String get enableLocalStorage => 'Yerel Depolamayı Etkinleştir';
@@ -4893,12 +4791,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get storeAudioOnCloud => 'Sesi Bulutta Depola';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Gerçek zamanlı kayıtlarınız konuşurken özel bulut depolamasında saklanacaktır.';
+  String get cloudStorageDialogMessage => 'Gerçek zamanlı kayıtlarınız konuşurken özel bulut depolamasında saklanacaktır.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Konuşurken gerçek zamanlı kayıtlarınızı özel bulut depolamasında saklayın. Ses gerçek zamanlı olarak güvenli bir şekilde yakalanır ve kaydedilir.';
+  String get storeAudioCloudDescription => 'Konuşurken gerçek zamanlı kayıtlarınızı özel bulut depolamasında saklayın. Ses gerçek zamanlı olarak güvenli bir şekilde yakalanır ve kaydedilir.';
 
   @override
   String get downloadingFirmware => 'Aygıt yazılımı indiriliyor';
@@ -4951,8 +4847,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get payments => 'Ödemeler';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Uygulamalarınız için ödeme almaya başlamak için aşağıdan bir ödeme yöntemi bağlayın.';
+  String get connectPaymentMethodInfo => 'Uygulamalarınız için ödeme almaya başlamak için aşağıdan bir ödeme yöntemi bağlayın.';
 
   @override
   String get selectedPaymentMethod => 'Seçilen Ödeme Yöntemi';
@@ -5006,8 +4901,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get connectingYourStripeAccount => 'Stripe hesabınız bağlanıyor';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Lütfen tarayıcınızda Stripe kayıt sürecini tamamlayın. Bu sayfa tamamlandıktan sonra otomatik olarak güncellenecektir.';
+  String get stripeOnboardingInstructions => 'Lütfen tarayıcınızda Stripe kayıt sürecini tamamlayın. Bu sayfa tamamlandıktan sonra otomatik olarak güncellenecektir.';
 
   @override
   String get failedTryAgain => 'Başarısız mı? Tekrar Dene';
@@ -5019,8 +4913,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get successfullyConnected => 'Başarıyla Bağlandı!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Stripe hesabınız artık ödeme almaya hazır. Uygulama satışlarınızdan hemen kazanmaya başlayabilirsiniz.';
+  String get stripeReadyForPayments => 'Stripe hesabınız artık ödeme almaya hazır. Uygulama satışlarınızdan hemen kazanmaya başlayabilirsiniz.';
 
   @override
   String get updateStripeDetails => 'Stripe Bilgilerini Güncelle';
@@ -5038,8 +4931,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get updatePayPalAccountDetails => 'PayPal hesap bilgilerinizi güncelleyin';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Uygulamalarınız için ödeme almaya başlamak için PayPal hesabınızı bağlayın';
+  String get connectPayPalToReceivePayments => 'Uygulamalarınız için ödeme almaya başlamak için PayPal hesabınızı bağlayın';
 
   @override
   String get paypalEmail => 'PayPal E-postası';
@@ -5048,8 +4940,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me Bağlantısı';
 
   @override
-  String get stripeRecommendation =>
-      'Stripe ülkenizde mevcutsa, daha hızlı ve kolay ödemeler için kullanmanızı şiddetle tavsiye ederiz.';
+  String get stripeRecommendation => 'Stripe ülkenizde mevcutsa, daha hızlı ve kolay ödemeler için kullanmanızı şiddetle tavsiye ederiz.';
 
   @override
   String get updatePayPalDetails => 'PayPal Bilgilerini Güncelle';
@@ -5101,12 +4992,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Ek ses örneği kaldırıldı';
 
   @override
-  String get consentDataMessage =>
-      'Devam ederek, konuşmalarınız, kayıtlarınız ve kişisel bilgileriniz sunucularımızda güvenli bir şekilde saklanacaktır. Ses kayıtlarınız ve transkriptleriniz, size yapay zeka destekli içgörüler sağlamak ve tüm uygulama özelliklerini etkinleştirmek için üçüncü taraf yapay zeka hizmetleri (transkripsiyon için Deepgram ve analiz için OpenAI dahil) tarafından işlenir.';
+  String get consentDataMessage => 'Devam ederek, konuşmalarınız, kayıtlarınız ve kişisel bilgileriniz sunucularımızda güvenli bir şekilde saklanacaktır. Ses kayıtlarınız ve transkriptleriniz, size yapay zeka destekli içgörüler sağlamak ve tüm uygulama özelliklerini etkinleştirmek için üçüncü taraf yapay zeka hizmetleri (transkripsiyon için Deepgram ve analiz için OpenAI dahil) tarafından işlenir.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Konuşmalarınızdaki görevler burada görünecek.\nManuel olarak oluşturmak için + simgesine dokunun.';
+  String get tasksEmptyStateMessage => 'Konuşmalarınızdaki görevler burada görünecek.\nManuel olarak oluşturmak için + simgesine dokunun.';
 
   @override
   String get clearChatAction => 'Sohbeti temizle';
@@ -5142,15 +5031,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Apple Watch\'unuza\nOmi yükleyin';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Apple Watch\'unuzu Omi ile kullanmak için önce saatinize Omi uygulamasını yüklemeniz gerekir.';
+  String get installOmiOnAppleWatchDescription => 'Apple Watch\'unuzu Omi ile kullanmak için önce saatinize Omi uygulamasını yüklemeniz gerekir.';
 
   @override
   String get openOmiOnAppleWatch => 'Apple Watch\'unuzda\nOmi\'yi açın';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi uygulaması Apple Watch\'unuza yüklü. Açın ve başlamak için Başlat\'a dokunun.';
+  String get openOmiOnAppleWatchDescription => 'Omi uygulaması Apple Watch\'unuza yüklü. Açın ve başlamak için Başlat\'a dokunun.';
 
   @override
   String get openWatchApp => 'Watch Uygulamasını Aç';
@@ -5159,15 +5046,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Uygulamayı Yükledim ve Açtım';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch uygulaması açılamadı. Lütfen Apple Watch\'unuzda Watch uygulamasını manuel olarak açın ve \"Mevcut Uygulamalar\" bölümünden Omi\'yi yükleyin.';
+  String get unableToOpenWatchApp => 'Apple Watch uygulaması açılamadı. Lütfen Apple Watch\'unuzda Watch uygulamasını manuel olarak açın ve \"Mevcut Uygulamalar\" bölümünden Omi\'yi yükleyin.';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch başarıyla bağlandı!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch hala erişilebilir değil. Lütfen Omi uygulamasının saatinizde açık olduğundan emin olun.';
+  String get appleWatchNotReachable => 'Apple Watch hala erişilebilir değil. Lütfen Omi uygulamasının saatinizde açık olduğundan emin olun.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5595,15 +5480,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get multipleSpeakersDetected => 'Birden fazla konuşmacı tespit edildi';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Kayıtta birden fazla konuşmacı var gibi görünüyor. Sessiz bir yerde olduğunuzdan emin olun ve tekrar deneyin.';
+  String get multipleSpeakersDescription => 'Kayıtta birden fazla konuşmacı var gibi görünüyor. Sessiz bir yerde olduğunuzdan emin olun ve tekrar deneyin.';
 
   @override
   String get invalidRecordingDetected => 'Geçersiz kayıt tespit edildi';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Yeterli konuşma tespit edilmedi. Lütfen daha fazla konuşun ve tekrar deneyin.';
+  String get notEnoughSpeechDescription => 'Yeterli konuşma tespit edilmedi. Lütfen daha fazla konuşun ve tekrar deneyin.';
 
   @override
   String get speechDurationDescription => 'En az 5 saniye ve en fazla 90 saniye konuştuğunuzdan emin olun.';
@@ -5615,8 +5498,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get howToTakeGoodSample => 'İyi bir örnek nasıl alınır?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Sessiz bir yerde olduğunuzdan emin olun.\n2. Net ve doğal bir şekilde konuşun.\n3. Cihazınızın boynunuzda doğal konumunda olduğundan emin olun.\n\nOluşturulduktan sonra her zaman geliştirebilir veya yeniden yapabilirsiniz.';
+  String get goodSampleInstructions => '1. Sessiz bir yerde olduğunuzdan emin olun.\n2. Net ve doğal bir şekilde konuşun.\n3. Cihazınızın boynunuzda doğal konumunda olduğundan emin olun.\n\nOluşturulduktan sonra her zaman geliştirebilir veya yeniden yapabilirsiniz.';
 
   @override
   String get noDeviceConnectedUseMic => 'Bağlı cihaz yok. Telefon mikrofonu kullanılacak.';
@@ -5658,8 +5540,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get notificationFrequency => 'Bildirim Sıklığı';
 
   @override
-  String get controlNotificationFrequency =>
-      'Omi\'nin size ne sıklıkta proaktif bildirimler göndereceğini kontrol edin.';
+  String get controlNotificationFrequency => 'Omi\'nin size ne sıklıkta proaktif bildirimler göndereceğini kontrol edin.';
 
   @override
   String get yourScore => 'Skorunuz';
@@ -5680,12 +5561,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get howItWorks => 'Nasıl çalışır';
 
   @override
-  String get dailyScoreExplanation =>
-      'Günlük skorunuz görev tamamlamaya dayanır. Skorunuzu artırmak için görevlerinizi tamamlayın!';
+  String get dailyScoreExplanation => 'Günlük skorunuz görev tamamlamaya dayanır. Skorunuzu artırmak için görevlerinizi tamamlayın!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Omi\'nin size ne sıklıkla proaktif bildirimler ve hatırlatıcılar gönderdiğini kontrol edin.';
+  String get notificationFrequencyDescription => 'Omi\'nin size ne sıklıkla proaktif bildirimler ve hatırlatıcılar gönderdiğini kontrol edin.';
 
   @override
   String get sliderOff => 'Kapalı';
@@ -5930,8 +5809,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get recordings => 'Kayıtlar';
 
   @override
-  String get enableRemindersAccess =>
-      'Apple Hatırlatıcılar\'ı kullanmak için lütfen Ayarlar\'da Hatırlatıcılar erişimini etkinleştirin';
+  String get enableRemindersAccess => 'Apple Hatırlatıcılar\'ı kullanmak için lütfen Ayarlar\'da Hatırlatıcılar erişimini etkinleştirin';
 
   @override
   String todayAtTime(String time) {
@@ -6021,8 +5899,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deviceRequirements => 'Cihazınız Cihaz Üzerinde transkripsiyon gereksinimlerini karşılamıyor.';
 
   @override
-  String get willLikelyCrash =>
-      'Bu özelliği etkinleştirmek muhtemelen uygulamanın çökmesine veya donmasına neden olacaktır.';
+  String get willLikelyCrash => 'Bu özelliği etkinleştirmek muhtemelen uygulamanın çökmesine veya donmasına neden olacaktır.';
 
   @override
   String get transcriptionSlowerLessAccurate => 'Transkripsiyon önemli ölçüde daha yavaş ve daha az doğru olacaktır.';
@@ -6061,15 +5938,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get cloudProvider => 'Bulut Sağlayıcı';
 
   @override
-  String get premiumMinutesInfo =>
-      'Ayda 1.200 premium dakika. Cihaz Üzerinde sekmesi sınırsız ücretsiz transkripsiyon sunar.';
+  String get premiumMinutesInfo => 'Ayda 1.200 premium dakika. Cihaz Üzerinde sekmesi sınırsız ücretsiz transkripsiyon sunar.';
 
   @override
   String get viewUsage => 'Kullanımı görüntüle';
 
   @override
-  String get localProcessingInfo =>
-      'Ses yerel olarak işlenir. Çevrimdışı çalışır, daha güvenlidir, ancak daha fazla pil kullanır.';
+  String get localProcessingInfo => 'Ses yerel olarak işlenir. Çevrimdışı çalışır, daha güvenlidir, ancak daha fazla pil kullanır.';
 
   @override
   String get model => 'Model';
@@ -6078,8 +5953,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get performanceWarning => 'Performans Uyarısı';
 
   @override
-  String get largeModelWarning =>
-      'Bu model büyük ve uygulamanın çökmesine veya mobil cihazlarda çok yavaş çalışmasına neden olabilir.\n\n\"small\" veya \"base\" önerilir.';
+  String get largeModelWarning => 'Bu model büyük ve uygulamanın çökmesine veya mobil cihazlarda çok yavaş çalışmasına neden olabilir.\n\n\"small\" veya \"base\" önerilir.';
 
   @override
   String get usingNativeIosSpeech => 'Yerel iOS Konuşma Tanıma Kullanılıyor';
@@ -6142,12 +6016,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get batteryDrainSignificantly => 'Pil tüketimi önemli ölçüde artacaktır.';
 
   @override
-  String get premiumMinutesMonth =>
-      'Ayda 1.200 premium dakika. Cihaz Üzerinde sekmesi sınırsız ücretsiz transkripsiyon sunar. ';
+  String get premiumMinutesMonth => 'Ayda 1.200 premium dakika. Cihaz Üzerinde sekmesi sınırsız ücretsiz transkripsiyon sunar. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Ses yerel olarak işlenir. Çevrimdışı çalışır, daha özel, ancak daha fazla pil kullanır.';
+  String get audioProcessedLocally => 'Ses yerel olarak işlenir. Çevrimdışı çalışır, daha özel, ancak daha fazla pil kullanır.';
 
   @override
   String get languageLabel => 'Dil';
@@ -6156,8 +6028,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get modelLabel => 'Model';
 
   @override
-  String get modelTooLargeWarning =>
-      'Bu model büyük ve mobil cihazlarda uygulamanın çökmesine veya çok yavaş çalışmasına neden olabilir.\n\nsmall veya base önerilir.';
+  String get modelTooLargeWarning => 'Bu model büyük ve mobil cihazlarda uygulamanın çökmesine veya çok yavaş çalışmasına neden olabilir.\n\nsmall veya base önerilir.';
 
   @override
   String get nativeEngineNoDownload => 'Cihazınızın yerel konuşma motoru kullanılacak. Model indirmesi gerekli değil.';
@@ -6196,8 +6067,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Ominin yerleşik canlı transkripsiyonu, otomatik konuşmacı algılama ve diarizasyon ile gerçek zamanlı konuşmalar için optimize edilmiştir.';
+  String get omiTranscriptionOptimized => 'Ominin yerleşik canlı transkripsiyonu, otomatik konuşmacı algılama ve diarizasyon ile gerçek zamanlı konuşmalar için optimize edilmiştir.';
 
   @override
   String get reset => 'Sıfırla';
@@ -6417,8 +6287,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Anılardan bilgi grafiği oluşturuluyor...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Yeni anılar oluşturdukça bilgi grafiğiniz otomatik olarak oluşturulacak.';
+  String get knowledgeGraphWillBuildAutomatically => 'Yeni anılar oluşturdukça bilgi grafiğiniz otomatik olarak oluşturulacak.';
 
   @override
   String get buildGraphButton => 'Grafik Oluştur';
@@ -6720,8 +6589,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Cihazınızın SD kartından ses indiriliyor';
 
   @override
-  String get transferRequiredDescription =>
-      'Bu kayıt cihazınızın SD kartında depolanıyor. Çalmak veya paylaşmak için telefonunuza aktarın.';
+  String get transferRequiredDescription => 'Bu kayıt cihazınızın SD kartında depolanıyor. Çalmak veya paylaşmak için telefonunuza aktarın.';
 
   @override
   String get cancelTransfer => 'Aktarımı İptal Et';
@@ -6742,8 +6610,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareRecording => 'Kaydı Paylaş';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Bu kaydı kalıcı olarak silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
+  String get deleteRecordingConfirmation => 'Bu kaydı kalıcı olarak silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
 
   @override
   String get recordingIdLabel => 'Kayıt Kimliği';
@@ -6802,8 +6669,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get enableFastTransfer => 'Hızlı aktarımı etkinleştir';
 
   @override
-  String get fastTransferDescription =>
-      'Hızlı aktarım, ~5 kat daha hızlı hızlar için WiFi kullanır. Telefonunuz aktarım sırasında geçici olarak Omi cihazınızın WiFi ağına bağlanacaktır.';
+  String get fastTransferDescription => 'Hızlı aktarım, ~5 kat daha hızlı hızlar için WiFi kullanır. Telefonunuz aktarım sırasında geçici olarak Omi cihazınızın WiFi ağına bağlanacaktır.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Aktarım sırasında internet erişimi duraklatıldı';
@@ -6818,8 +6684,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get fiveTimesFaster => '5 KAT DAHA HIZLI';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Omi cihazınıza doğrudan WiFi bağlantısı oluşturur. Telefonunuz aktarım sırasında geçici olarak normal WiFi bağlantısını keser.';
+  String get fastTransferMethodDescription => 'Omi cihazınıza doğrudan WiFi bağlantısı oluşturur. Telefonunuz aktarım sırasında geçici olarak normal WiFi bağlantısını keser.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6828,8 +6693,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get bleSpeed => 'BLE ile ~30 KB/s';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Standart Bluetooth Low Energy bağlantısı kullanır. Daha yavaş ama WiFi bağlantınızı etkilemez.';
+  String get bluetoothMethodDescription => 'Standart Bluetooth Low Energy bağlantısı kullanır. Daha yavaş ama WiFi bağlantınızı etkilemez.';
 
   @override
   String get selected => 'Seçildi';
@@ -6867,12 +6731,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get appDeleteFailed => 'Uygulama silinemedi. Lütfen daha sonra tekrar deneyin.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Uygulama görünürlüğü başarıyla değiştirildi. Yansıması birkaç dakika sürebilir.';
+  String get appVisibilityChangedSuccessfully => 'Uygulama görünürlüğü başarıyla değiştirildi. Yansıması birkaç dakika sürebilir.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Uygulama etkinleştirilirken hata oluştu. Bu bir entegrasyon uygulamasıysa, kurulumun tamamlandığından emin olun.';
+  String get errorActivatingAppIntegration => 'Uygulama etkinleştirilirken hata oluştu. Bu bir entegrasyon uygulamasıysa, kurulumun tamamlandığından emin olun.';
 
   @override
   String get errorUpdatingAppStatus => 'Uygulama durumu güncellenirken bir hata oluştu.';
@@ -6952,8 +6814,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Ad en az 3 karakter olmalıdır';
 
   @override
-  String get conversationPromptHint =>
-      'örn., Verilen konuşmadan eylem maddeleri, alınan kararlar ve önemli çıkarımları çıkarın.';
+  String get conversationPromptHint => 'örn., Verilen konuşmadan eylem maddeleri, alınan kararlar ve önemli çıkarımları çıkarın.';
 
   @override
   String get pleaseEnterAppPrompt => 'Lütfen uygulamanız için bir istem girin';
@@ -7140,15 +7001,13 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Yükseltme planlandı! Aylık planınız fatura döneminizin sonuna kadar devam eder, ardından otomatik olarak yıllık plana geçer.';
+  String get planUpgradeScheduledMessage => 'Yükseltme planlandı! Aylık planınız fatura döneminizin sonuna kadar devam eder, ardından otomatik olarak yıllık plana geçer.';
 
   @override
   String get couldNotSchedulePlanChange => 'Plan değişikliği planlanamadı. Lütfen tekrar deneyin.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Aboneliğiniz yeniden etkinleştirildi! Şimdi ücret alınmayacak - mevcut dönem sonunda faturalandırılacaksınız.';
+  String get subscriptionReactivatedDefault => 'Aboneliğiniz yeniden etkinleştirildi! Şimdi ücret alınmayacak - mevcut dönem sonunda faturalandırılacaksınız.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Abonelik başarılı! Yeni fatura dönemi için ücret alındı.';
@@ -7331,8 +7190,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Cihazınıza bağlanmak için Bluetooth izni gereklidir.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth izni reddedildi. Lütfen Sistem Tercihleri\'nde izin verin.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth izni reddedildi. Lütfen Sistem Tercihleri\'nde izin verin.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7345,12 +7203,10 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Bildirim izni reddedildi. Lütfen Sistem Tercihleri\'nde izin verin.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Bildirim izni reddedildi. Lütfen Sistem Tercihleri\'nde izin verin.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Bildirim izni reddedildi. Lütfen Sistem Tercihleri > Bildirimler\'de izin verin.';
+  String get onboardingNotificationDeniedNotifications => 'Bildirim izni reddedildi. Lütfen Sistem Tercihleri > Bildirimler\'de izin verin.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7363,15 +7219,13 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Lütfen Ayarlar > Gizlilik ve Güvenlik > Konum Servisleri\'nde konum izni verin';
+  String get onboardingLocationGrantInSettings => 'Lütfen Ayarlar > Gizlilik ve Güvenlik > Konum Servisleri\'nde konum izni verin';
 
   @override
   String get onboardingMicrophoneRequired => 'Kayıt için mikrofon izni gereklidir.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Mikrofon izni reddedildi. Lütfen Sistem Tercihleri > Gizlilik ve Güvenlik > Mikrofon\'da izin verin.';
+  String get onboardingMicrophoneDenied => 'Mikrofon izni reddedildi. Lütfen Sistem Tercihleri > Gizlilik ve Güvenlik > Mikrofon\'da izin verin.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7387,8 +7241,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Sistem ses kaydı için ekran yakalama izni gereklidir.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Ekran yakalama izni reddedildi. Lütfen Sistem Tercihleri > Gizlilik ve Güvenlik > Ekran Kaydı\'nda izin verin.';
+  String get onboardingScreenCaptureDenied => 'Ekran yakalama izni reddedildi. Lütfen Sistem Tercihleri > Gizlilik ve Güvenlik > Ekran Kaydı\'nda izin verin.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7401,8 +7254,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get onboardingAccessibilityRequired =>
-      'Tarayıcı toplantılarını algılamak için erişilebilirlik izni gereklidir.';
+  String get onboardingAccessibilityRequired => 'Tarayıcı toplantılarını algılamak için erişilebilirlik izni gereklidir.';
 
   @override
   String onboardingAccessibilityStatusCheckPrefs(String status) {
@@ -7442,8 +7294,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Fotoğraf izni reddedildi. Resim seçmek için lütfen fotoğraflara erişime izin verin';
+  String get msgPhotosPermissionDenied => 'Fotoğraf izni reddedildi. Resim seçmek için lütfen fotoğraflara erişime izin verin';
 
   @override
   String get msgSelectImagesGenericError => 'Resim seçerken hata oluştu. Lütfen tekrar deneyin.';
@@ -7515,8 +7366,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get locationPermissionRequired => 'Konum izni gerekli';
 
   @override
-  String get locationPermissionContent =>
-      'Hızlı Transfer, WiFi bağlantısını doğrulamak için konum izni gerektirir. Devam etmek için lütfen konum izni verin.';
+  String get locationPermissionContent => 'Hızlı Transfer, WiFi bağlantısını doğrulamak için konum izni gerektirir. Devam etmek için lütfen konum izni verin.';
 
   @override
   String get pdfTranscriptExport => 'Döküm Dışa Aktar';
@@ -7679,8 +7529,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Cihaz WiFi senkronizasyonunu desteklemiyor, Bluetooth\'a geçiliyor';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Cihaz WiFi senkronizasyonunu desteklemiyor, Bluetooth\'a geçiliyor';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health bu cihazda kullanılamıyor';
@@ -7988,8 +7837,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note\'u Eşleştirme Moduna Alın';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Yan düğmeyi 2 saniye basılı tutun. Eşleştirmeye hazır olduğunda kırmızı LED yanıp söner.';
+  String get pairingDescPlaudNote => 'Yan düğmeyi 2 saniye basılı tutun. Eşleştirmeye hazır olduğunda kırmızı LED yanıp söner.';
 
   @override
   String get pairingTitleBee => 'Bee\'yi Eşleştirme Moduna Alın';
@@ -8001,15 +7849,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get pairingTitleLimitless => 'Limitless\'ı Eşleştirme Moduna Alın';
 
   @override
-  String get pairingDescLimitless =>
-      'Herhangi bir ışık görünürken, bir kez basın, ardından cihaz pembe ışık gösterene kadar basılı tutun, sonra bırakın.';
+  String get pairingDescLimitless => 'Herhangi bir ışık görünürken, bir kez basın, ardından cihaz pembe ışık gösterene kadar basılı tutun, sonra bırakın.';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant\'ı Eşleştirme Moduna Alın';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Açmak için kolye üzerindeki düğmeye basın. Otomatik olarak eşleştirme moduna geçecektir.';
+  String get pairingDescFriendPendant => 'Açmak için kolye üzerindeki düğmeye basın. Otomatik olarak eşleştirme moduna geçecektir.';
 
   @override
   String get pairingTitleFieldy => 'Fieldy\'yi Eşleştirme Moduna Alın';
@@ -8021,8 +7867,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch Bağlayın';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Apple Watch\'unuza Omi uygulamasını yükleyin ve açın, ardından uygulamada Bağlan\'a dokunun.';
+  String get pairingDescAppleWatch => 'Apple Watch\'unuza Omi uygulamasını yükleyin ve açın, ardından uygulamada Bağlan\'a dokunun.';
 
   @override
   String get pairingTitleNeoOne => 'Neo One\'ı Eşleştirme Moduna Alın';
@@ -8098,8 +7943,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get wifiConfiguration => 'WiFi Yapılandırması';
 
   @override
-  String get wifiConfigurationSubtitle =>
-      'Cihazın donanım yazılımını indirebilmesi için WiFi kimlik bilgilerinizi girin.';
+  String get wifiConfigurationSubtitle => 'Cihazın donanım yazılımını indirebilmesi için WiFi kimlik bilgilerinizi girin.';
 
   @override
   String get networkNameSsid => 'Ağ Adı (SSID)';
@@ -8146,8 +7990,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get switchAndRestart => 'Değiştir';
 
   @override
-  String get stagingDisclaimer =>
-      'Test ortamı kararsız olabilir, tutarsız performans gösterebilir ve veriler kaybolabilir. Yalnızca test için.';
+  String get stagingDisclaimer => 'Test ortamı kararsız olabilir, tutarsız performans gösterebilir ve veriler kaybolabilir. Yalnızca test için.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Kaydedildi. Değişiklikleri uygulamak için uygulamayı kapatıp yeniden açın.';
@@ -8376,8 +8219,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Omi ile Telefon Aramaları';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Omi üzerinden arama yapın ve gerçek zamanlı transkripsiyon, otomatik özetler ve daha fazlasını alın.';
+  String get phoneCallsUpsellSubtitle => 'Omi üzerinden arama yapın ve gerçek zamanlı transkripsiyon, otomatik özetler ve daha fazlasını alın.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Her aramanın gerçek zamanlı transkripsiyonu';
@@ -8416,8 +8258,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deletePendingFiles => 'Bekleyen kayıtları sil';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Bu kayıtlar telefonunuzla senkronize EDİLMEDİ ve kalıcı olarak kaybolacak. Bu geri alınamaz.';
+  String get deletePendingFilesWarning => 'Bu kayıtlar telefonunuzla senkronize EDİLMEDİ ve kalıcı olarak kaybolacak. Bu geri alınamaz.';
 
   @override
   String get pendingFilesDeleted => 'Bekleyen kayıtlar silindi';
@@ -8429,8 +8270,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deleteAll => 'Tümünü sil';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Bu, senkronize ve bekleyen kayıtları silecek. Bekleyen kayıtlar senkronize EDİLMEDİ ve kalıcı olarak kaybolacak.';
+  String get deleteAllFilesWarning => 'Bu, senkronize ve bekleyen kayıtları silecek. Bekleyen kayıtlar senkronize EDİLMEDİ ve kalıcı olarak kaybolacak.';
 
   @override
   String get allFilesDeleted => 'Tüm kayıtlar silindi';
@@ -8495,8 +8335,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get fairUseAboutTitle => 'Adil Kullanım Hakkında';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi kişisel konuşmalar, toplantılar ve canlı etkileşimler için tasarlanmıştır. Kullanım, bağlantı süresine değil, tespit edilen gerçek konuşma süresine göre ölçülür. Kullanım, kişisel olmayan içerik için normal kalıpları önemli ölçüde aşarsa, düzenlemeler uygulanabilir.';
+  String get fairUseAboutBody => 'Omi kişisel konuşmalar, toplantılar ve canlı etkileşimler için tasarlanmıştır. Kullanım, bağlantı süresine değil, tespit edilen gerçek konuşma süresine göre ölçülür. Kullanım, kişisel olmayan içerik için normal kalıpları önemli ölçüde aşarsa, düzenlemeler uygulanabilir.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8534,8 +8373,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get improveConnectionTitle => 'Bağlantıyı İyileştir';
 
   @override
-  String get improveConnectionContent =>
-      'Omi\'nin cihazınıza bağlı kalma şeklini iyileştirdik. Bunu etkinleştirmek için Cihaz Bilgileri sayfasına gidin, \"Cihazı Kes\" seçeneğine dokunun ve cihazınızı tekrar eşleştirin.';
+  String get improveConnectionContent => 'Omi\'nin cihazınıza bağlı kalma şeklini iyileştirdik. Bunu etkinleştirmek için Cihaz Bilgileri sayfasına gidin, \"Cihazı Kes\" seçeneğine dokunun ve cihazınızı tekrar eşleştirin.';
 
   @override
   String get improveConnectionAction => 'Anladım';
@@ -8590,16 +8428,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get cancelSyncQuestion => 'Senkronizasyon iptal edilsin mi?';
 
   @override
-  String get omisStorageDesc =>
-      'Omi\'niz telefonunuza bağlı olmadığında, sesi yerleşik belleğinde yerel olarak saklar. Hiçbir kaydı kaybetmezsiniz.';
+  String get omisStorageDesc => 'Omi\'niz telefonunuza bağlı olmadığında, sesi yerleşik belleğinde yerel olarak saklar. Hiçbir kaydı kaybetmezsiniz.';
 
   @override
-  String get phoneStorageDesc =>
-      'Omi yeniden bağlandığında, kayıtlar yüklenmeden önce otomatik olarak telefonunuza aktarılır.';
+  String get phoneStorageDesc => 'Omi yeniden bağlandığında, kayıtlar yüklenmeden önce otomatik olarak telefonunuza aktarılır.';
 
   @override
-  String get cloudStorageDesc =>
-      'Yüklendikten sonra kayıtlarınız işlenir ve yazıya dökülür. Konuşmalar bir dakika içinde kullanılabilir olacaktır.';
+  String get cloudStorageDesc => 'Yüklendikten sonra kayıtlarınız işlenir ve yazıya dökülür. Konuşmalar bir dakika içinde kullanılabilir olacaktır.';
 
   @override
   String get tipKeepPhoneNearby => 'Daha hızlı senkronizasyon için telefonunuzu yakında tutun';
@@ -8623,12 +8458,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get permissionEnable => 'Etkinleştir';
 
   @override
-  String get permissionsPageDescription =>
-      'Bu izinler Omi\'nin çalışması için temeldir. Bildirimler, konum tabanlı deneyimler ve ses yakalama gibi temel özellikleri etkinleştirirler.';
+  String get permissionsPageDescription => 'Bu izinler Omi\'nin çalışması için temeldir. Bildirimler, konum tabanlı deneyimler ve ses yakalama gibi temel özellikleri etkinleştirirler.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi düzgün çalışmak için birkaç izne ihtiyaç duyar. Devam etmek için lütfen bunları verin.';
+  String get permissionsRequiredDescription => 'Omi düzgün çalışmak için birkaç izne ihtiyaç duyar. Devam etmek için lütfen bunları verin.';
 
   @override
   String get permissionsSetupTitle => 'En iyi deneyimi yaşayın';
@@ -8682,8 +8515,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get justAMoment => 'Bir dakika, lütfen';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'İptal etmek yerine diğer seçeneklerinizi keşfetmenizi şiddetle tavsiye ediyoruz.';
+  String get cancelConsequencesSubtitle => 'İptal etmek yerine diğer seçeneklerinizi keşfetmenizi şiddetle tavsiye ediyoruz.';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8906,8 +8738,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get firmwareWarningTitle => 'Önemli: Güncellemeden Önce Okuyun';
 
   @override
-  String get firmwareFormatWarning =>
-      'Bu yazılım SD kartı biçimlendirecektir. Lütfen yükseltmeden önce tüm çevrimdışı verilerin senkronize edildiğinden emin olun.\n\nBu sürümü yükledikten sonra yanıp sönen kırmızı bir ışık görürseniz endişelenmeyin. Cihazı uygulamaya bağlamanız yeterlidir ve mavi renğe dönmelidir. Kırmızı ışık, cihazın saatinin henüz senkronize edilmediği anlamına gelir.';
+  String get firmwareFormatWarning => 'Bu yazılım SD kartı biçimlendirecektir. Lütfen yükseltmeden önce tüm çevrimdışı verilerin senkronize edildiğinden emin olun.\n\nBu sürümü yükledikten sonra yanıp sönen kırmızı bir ışık görürseniz endişelenmeyin. Cihazı uygulamaya bağlamanız yeterlidir ve mavi renğe dönmelidir. Kırmızı ışık, cihazın saatinin henüz senkronize edilmediği anlamına gelir.';
 
   @override
   String get continueAnyway => 'Devam Et';
@@ -8927,8 +8758,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get tasksMarkComplete => 'Tamamlandı olarak işaretlendi';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi, Apple Health\'e Apple\'ın HealthKit çerçevesi üzerinden erişir. Erişimi istediğiniz zaman iOS Ayarlar\'dan iptal edebilirsiniz.';
+  String get appleHealthManageNote => 'Omi, Apple Health\'e Apple\'ın HealthKit çerçevesi üzerinden erişir. Erişimi istediğiniz zaman iOS Ayarlar\'dan iptal edebilirsiniz.';
 
   @override
   String get appleHealthConnectCta => 'Apple Health\'e Bağlan';
@@ -8961,8 +8791,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Apple Health erişimi reddedildi';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi\'nin Apple Health verilerinizi okuma izni yok. Bunu iOS Ayarlar → Gizlilik ve Güvenlik → Sağlık → Omi yolundan etkinleştirin.';
+  String get appleHealthDeniedBody => 'Omi\'nin Apple Health verilerinizi okuma izni yok. Bunu iOS Ayarlar → Gizlilik ve Güvenlik → Sağlık → Omi yolundan etkinleştirin.';
 
   @override
   String get deleteFlowReasonTitle => 'Neden ayrılıyorsun?';
@@ -9031,8 +8860,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get planUpdate => 'Plan Güncellemesi';
 
   @override
-  String get planDeprecationMessage =>
-      'Unlimited planınız kullanımdan kaldırılıyor. Operator planına geçin — aynı harika özellikler \$49/ay. Mevcut planınız bu süre zarfında çalışmaya devam edecek.';
+  String get planDeprecationMessage => 'Unlimited planınız kullanımdan kaldırılıyor. Operator planına geçin — aynı harika özellikler \$49/ay. Mevcut planınız bu süre zarfında çalışmaya devam edecek.';
 
   @override
   String get upgradeYourPlan => 'Planınızı Yükseltin';
@@ -9143,8 +8971,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Aylık limitinize ulaştınız. Kısıtlama olmadan Omi ile sohbete devam etmek için yükseltin.';
+  String get chatQuotaExceededReply => 'Aylık limitinize ulaştınız. Kısıtlama olmadan Omi ile sohbete devam etmek için yükseltin.';
 
   @override
   String get voiceResponseAudio => 'Omi yanıtını sesli oku';
@@ -9175,4 +9002,25 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Görev Ekle';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi\'ye herhangi bir şey sor';
+
+  @override
+  String get quickActionVoiceMode => 'Ses Modu';
+
+  @override
+  String get quickActionMute => 'Sesi Kapat';
+
+  @override
+  String get quickActionUnmute => 'Sesi Aç';
+
+  @override
+  String get quickActionConnectDevice => 'Cihaz Bağla';
+
+  @override
+  String get quickActionDeviceSettings => 'Cihaz Ayarları';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -24,8 +24,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deleteConversationTitle => 'Видалити розмову?';
 
   @override
-  String get deleteConversationMessage =>
-      'Це також видалить пов\'язані спогади, завдання та аудіофайли. Цю дію не можна скасувати.';
+  String get deleteConversationMessage => 'Це також видалить пов\'язані спогади, завдання та аудіофайли. Цю дію не можна скасувати.';
 
   @override
   String get confirm => 'Підтвердити';
@@ -146,8 +145,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deleting => 'Видалення...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
+  String get pleaseCompleteAuthentication => 'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
 
   @override
   String get failedToStartAuthentication => 'Не вдалося розпочати автентифікацію';
@@ -228,8 +226,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get noStarredConversations => 'Немає обраних бесід';
 
   @override
-  String get starConversationHint =>
-      'Щоб позначити розмову зірочкою, відкрийте її та натисніть іконку зірки в заголовку.';
+  String get starConversationHint => 'Щоб позначити розмову зірочкою, відкрийте її та натисніть іконку зірки в заголовку.';
 
   @override
   String get searchConversations => 'Пошук розмов...';
@@ -320,8 +317,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get installedApps => 'Встановлені додатки';
 
   @override
-  String get unableToFetchApps =>
-      'Не вдалося завантажити додатки :(\n\nБудь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
+  String get unableToFetchApps => 'Не вдалося завантажити додатки :(\n\nБудь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
 
   @override
   String get aboutOmi => 'Про Omi';
@@ -357,19 +353,16 @@ class AppLocalizationsUk extends AppLocalizations {
   String get appsDisconnected => 'Ваші додатки та інтеграції будуть негайно відключені.';
 
   @override
-  String get exportBeforeDelete =>
-      'Ви можете експортувати свої дані перед видаленням облікового запису, але після видалення їх неможливо буде відновити.';
+  String get exportBeforeDelete => 'Ви можете експортувати свої дані перед видаленням облікового запису, але після видалення їх неможливо буде відновити.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Я розумію, що видалення мого облікового запису є остаточним, і всі дані, включно зі спогадами та розмовами, будуть втрачені і не можуть бути відновлені.';
+  String get deleteAccountCheckbox => 'Я розумію, що видалення мого облікового запису є остаточним, і всі дані, включно зі спогадами та розмовами, будуть втрачені і не можуть бути відновлені.';
 
   @override
   String get areYouSure => 'Ви впевнені?';
 
   @override
-  String get deleteAccountFinal =>
-      'Ця дія є незворотною та назавжди видалить ваш обліковий запис і всі пов\'язані дані. Ви впевнені, що хочете продовжити?';
+  String get deleteAccountFinal => 'Ця дія є незворотною та назавжди видалить ваш обліковий запис і всі пов\'язані дані. Ви впевнені, що хочете продовжити?';
 
   @override
   String get deleteNow => 'Видалити зараз';
@@ -378,8 +371,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get goBack => 'Повернутися';
 
   @override
-  String get checkBoxToConfirm =>
-      'Встановіть прапорець, щоб підтвердити, що ви розумієте, що видалення облікового запису є остаточним і незворотним.';
+  String get checkBoxToConfirm => 'Встановіть прапорець, щоб підтвердити, що ви розумієте, що видалення облікового запису є остаточним і незворотним.';
 
   @override
   String get profile => 'Профіль';
@@ -457,8 +449,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get yourPrivacyYourControl => 'Ваша конфіденційність, ваш контроль';
 
   @override
-  String get privacyIntro =>
-      'В Omi ми прагнемо захистити вашу конфіденційність. Ця сторінка дозволяє контролювати, як зберігаються та використовуються ваші дані.';
+  String get privacyIntro => 'В Omi ми прагнемо захистити вашу конфіденційність. Ця сторінка дозволяє контролювати, як зберігаються та використовуються ваші дані.';
 
   @override
   String get learnMore => 'Дізнатися більше...';
@@ -467,15 +458,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get dataProtectionLevel => 'Рівень захисту даних';
 
   @override
-  String get dataProtectionDesc =>
-      'Ваші дані за замовчуванням захищені надійним шифруванням. Перегляньте свої налаштування та майбутні параметри конфіденційності нижче.';
+  String get dataProtectionDesc => 'Ваші дані за замовчуванням захищені надійним шифруванням. Перегляньте свої налаштування та майбутні параметри конфіденційності нижче.';
 
   @override
   String get appAccess => 'Доступ додатків';
 
   @override
-  String get appAccessDesc =>
-      'Наступні додатки можуть отримувати доступ до ваших даних. Натисніть на додаток, щоб керувати його дозволами.';
+  String get appAccessDesc => 'Наступні додатки можуть отримувати доступ до ваших даних. Натисніть на додаток, щоб керувати його дозволами.';
 
   @override
   String get noAppsExternalAccess => 'Жоден встановлений додаток не має зовнішнього доступу до ваших даних.';
@@ -532,22 +521,19 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Ваш Omi було відключено 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'З\'єднання пристрою скасовано. Перейдіть до Налаштування > Bluetooth і забудьте пристрій, щоб завершити скасування з\'єднання.';
+  String get deviceUnpairedMessage => 'З\'єднання пристрою скасовано. Перейдіть до Налаштування > Bluetooth і забудьте пристрій, щоб завершити скасування з\'єднання.';
 
   @override
   String get unpairDialogTitle => 'Роз\'єднати пристрій';
 
   @override
-  String get unpairDialogMessage =>
-      'Це роз\'єднає пристрій, щоб його можна було підключити до іншого телефону. Вам потрібно буде перейти до Налаштування > Bluetooth і забути пристрій, щоб завершити процес.';
+  String get unpairDialogMessage => 'Це роз\'єднає пристрій, щоб його можна було підключити до іншого телефону. Вам потрібно буде перейти до Налаштування > Bluetooth і забути пристрій, щоб завершити процес.';
 
   @override
   String get deviceNotConnected => 'Пристрій не підключено';
 
   @override
-  String get connectDeviceMessage =>
-      'Підключіть свій пристрій Omi для доступу до\nналаштувань пристрою та налаштування';
+  String get connectDeviceMessage => 'Підключіть свій пристрій Omi для доступу до\nналаштувань пристрою та налаштування';
 
   @override
   String get deviceInfoSection => 'Інформація про пристрій';
@@ -562,8 +548,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get v2Undetected => 'V2 не виявлено';
 
   @override
-  String get v2UndetectedMessage =>
-      'Ми бачимо, що у вас або пристрій V1, або ваш пристрій не підключений. Функціонал SD-карти доступний лише для пристроїв V2.';
+  String get v2UndetectedMessage => 'Ми бачимо, що у вас або пристрій V1, або ваш пристрій не підключений. Функціонал SD-карти доступний лише для пристроїв V2.';
 
   @override
   String get endConversation => 'Завершити розмову';
@@ -837,8 +822,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Видалити граф знань?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Це видалить всі похідні дані графа знань (вузли та з\'єднання). Ваші оригінальні спогади залишаться в безпеці. Граф буде перебудовано з часом або за наступним запитом.';
+  String get deleteKnowledgeGraphMessage => 'Це видалить всі похідні дані графа знань (вузли та з\'єднання). Ваші оригінальні спогади залишаться в безпеці. Граф буде перебудовано з часом або за наступним запитом.';
 
   @override
   String get knowledgeGraphDeleted => 'Граф знань видалено';
@@ -986,8 +970,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get shortConversationThreshold => 'Поріг коротких розмов';
 
   @override
-  String get shortConversationThresholdSubtitle =>
-      'Розмови коротші за це значення будуть приховані, якщо не увімкнено вище';
+  String get shortConversationThresholdSubtitle => 'Розмови коротші за це значення будуть приховані, якщо не увімкнено вище';
 
   @override
   String get durationThreshold => 'Поріг тривалості';
@@ -1022,8 +1005,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get integrationsFooter => 'Підключіть свої додатки для перегляду даних та метрик у чаті.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
+  String get completeAuthInBrowser => 'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1083,8 +1065,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get needYourPermission => 'Нам потрібен ваш дозвіл';
 
   @override
-  String get alreadyGavePermission =>
-      'Ви вже надали нам дозвіл на збереження ваших записів. Нагадуємо, навіщо це потрібно:';
+  String get alreadyGavePermission => 'Ви вже надали нам дозвіл на збереження ваших записів. Нагадуємо, навіщо це потрібно:';
 
   @override
   String get wouldLikePermission => 'Ми хотіли б отримати ваш дозвіл на збереження ваших голосових записів. Ось чому:';
@@ -1093,26 +1074,22 @@ class AppLocalizationsUk extends AppLocalizations {
   String get improveSpeechProfile => 'Покращити ваш мовний профіль';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Ми використовуємо записи для подальшого навчання та покращення вашого особистого мовного профілю.';
+  String get improveSpeechProfileDesc => 'Ми використовуємо записи для подальшого навчання та покращення вашого особистого мовного профілю.';
 
   @override
   String get trainFamilyProfiles => 'Навчити профілі для друзів та родини';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Ваші записи допомагають нам розпізнавати та створювати профілі для ваших друзів та родини.';
+  String get trainFamilyProfilesDesc => 'Ваші записи допомагають нам розпізнавати та створювати профілі для ваших друзів та родини.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Покращити точність транскрипції';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'У міру вдосконалення нашої моделі ми можемо надавати кращі результати транскрипції ваших записів.';
+  String get enhanceTranscriptAccuracyDesc => 'У міру вдосконалення нашої моделі ми можемо надавати кращі результати транскрипції ваших записів.';
 
   @override
-  String get legalNotice =>
-      'Юридичне повідомлення: Законність запису та зберігання голосових даних може відрізнятися залежно від вашого місцезнаходження та того, як ви використовуєте цю функцію. Ви несете відповідальність за дотримання місцевих законів та правил.';
+  String get legalNotice => 'Юридичне повідомлення: Законність запису та зберігання голосових даних може відрізнятися залежно від вашого місцезнаходження та того, як ви використовуєте цю функцію. Ви несете відповідальність за дотримання місцевих законів та правил.';
 
   @override
   String get alreadyAuthorized => 'Вже авторизовано';
@@ -1358,8 +1335,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get defaultRepository => 'Репозиторій за замовчуванням';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Виберіть репозиторій за замовчуванням для створення issues. Ви все ще можете вказати інший репозиторій під час створення issues.';
+  String get selectDefaultRepoDesc => 'Виберіть репозиторій за замовчуванням для створення issues. Ви все ще можете вказати інший репозиторій під час створення issues.';
 
   @override
   String get noReposFound => 'Репозиторіїв не знайдено';
@@ -1406,8 +1382,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get configureSettings => 'Налаштувати параметри';
 
   @override
-  String get completeAuthBrowser =>
-      'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
+  String get completeAuthBrowser => 'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1735,8 +1710,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get enableBluetooth => 'Увімкнути Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi потребує Bluetooth для підключення до вашого носимого пристрою. Будь ласка, увімкніть Bluetooth та спробуйте ще раз.';
+  String get bluetoothNeeded => 'Omi потребує Bluetooth для підключення до вашого носимого пристрою. Будь ласка, увімкніть Bluetooth та спробуйте ще раз.';
 
   @override
   String get contactSupport => 'Зв\'язатися з підтримкою?';
@@ -1769,26 +1743,22 @@ class AppLocalizationsUk extends AppLocalizations {
   String get locationServiceDisabled => 'Служба визначення місцезнаходження вимкнена';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Служба визначення місцезнаходження вимкнена. Будь ласка, перейдіть до Налаштування > Конфіденційність і безпека > Служби визначення місцезнаходження та увімкніть її';
+  String get locationServiceDisabledDesc => 'Служба визначення місцезнаходження вимкнена. Будь ласка, перейдіть до Налаштування > Конфіденційність і безпека > Служби визначення місцезнаходження та увімкніть її';
 
   @override
   String get backgroundLocationDenied => 'Відмовлено в доступі до фонового місцезнаходження';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Будь ласка, перейдіть до налаштувань пристрою та встановіть дозвіл на місцезнаходження на \"Завжди дозволяти\"';
+  String get backgroundLocationDeniedDesc => 'Будь ласка, перейдіть до налаштувань пристрою та встановіть дозвіл на місцезнаходження на \"Завжди дозволяти\"';
 
   @override
   String get lovingOmi => 'Подобається Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Допоможіть нам охопити більше людей, залишивши відгук в App Store. Ваші відгуки дуже важливі для нас!';
+  String get leaveReviewIos => 'Допоможіть нам охопити більше людей, залишивши відгук в App Store. Ваші відгуки дуже важливі для нас!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Допоможіть нам охопити більше людей, залишивши відгук в Google Play Store. Ваші відгуки дуже важливі для нас!';
+  String get leaveReviewAndroid => 'Допоможіть нам охопити більше людей, залишивши відгук в Google Play Store. Ваші відгуки дуже важливі для нас!';
 
   @override
   String get rateOnAppStore => 'Оцінити в App Store';
@@ -1821,15 +1791,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get connectionError => 'Помилка підключення';
 
   @override
-  String get connectionErrorDesc =>
-      'Не вдалося підключитися до сервера. Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
+  String get connectionErrorDesc => 'Не вдалося підключитися до сервера. Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
 
   @override
   String get invalidRecordingMultipleSpeakers => 'Виявлено недійсний запис';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Схоже, що в записі кілька спікерів. Будь ласка, переконайтеся, що ви знаходитесь у тихому місці, та спробуйте ще раз.';
+  String get multipleSpeakersDesc => 'Схоже, що в записі кілька спікерів. Будь ласка, переконайтеся, що ви знаходитесь у тихому місці, та спробуйте ще раз.';
 
   @override
   String get tooShortDesc => 'Недостатньо мовлення виявлено. Будь ласка, говоріть більше та спробуйте ще раз.';
@@ -1841,15 +1809,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get areYouThere => 'Ви тут?';
 
   @override
-  String get noSpeechDesc =>
-      'Ми не змогли виявити жодного мовлення. Будь ласка, переконайтеся, що ви говорите щонайменше 10 секунд і не більше 3 хвилин.';
+  String get noSpeechDesc => 'Ми не змогли виявити жодного мовлення. Будь ласка, переконайтеся, що ви говорите щонайменше 10 секунд і не більше 3 хвилин.';
 
   @override
   String get connectionLost => 'З\'єднання втрачено';
 
   @override
-  String get connectionLostDesc =>
-      'З\'єднання було перервано. Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
+  String get connectionLostDesc => 'З\'єднання було перервано. Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
 
   @override
   String get tryAgain => 'Спробувати ще раз';
@@ -1864,8 +1830,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get permissionsRequired => 'Потрібні дозволи';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Цей додаток потребує дозволів Bluetooth та Місцезнаходження для правильної роботи. Будь ласка, увімкніть їх у налаштуваннях.';
+  String get permissionsRequiredDesc => 'Цей додаток потребує дозволів Bluetooth та Місцезнаходження для правильної роботи. Будь ласка, увімкніть їх у налаштуваннях.';
 
   @override
   String get openSettings => 'Відкрити налаштування';
@@ -1895,8 +1860,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get omiYourAiCompanion => 'Omi – ваш AI-компаньйон';
 
   @override
-  String get captureEveryMoment =>
-      'Захопіть кожну мить. Отримуйте підсумки на основі AI.\nНіколи більше не робіть нотатки.';
+  String get captureEveryMoment => 'Захопіть кожну мить. Отримуйте підсумки на основі AI.\nНіколи більше не робіть нотатки.';
 
   @override
   String get appleWatchSetup => 'Налаштування Apple Watch';
@@ -1908,12 +1872,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get microphonePermission => 'Дозвіл на мікрофон';
 
   @override
-  String get permissionGrantedNow =>
-      'Дозвіл надано! Тепер:\n\nВідкрийте додаток Omi на вашому годиннику та натисніть \"Продовжити\" нижче';
+  String get permissionGrantedNow => 'Дозвіл надано! Тепер:\n\nВідкрийте додаток Omi на вашому годиннику та натисніть \"Продовжити\" нижче';
 
   @override
-  String get needMicrophonePermission =>
-      'Нам потрібен дозвіл на мікрофон.\n\n1. Натисніть \"Надати дозвіл\"\n2. Дозвольте на вашому iPhone\n3. Додаток на годиннику закриється\n4. Відкрийте знову та натисніть \"Продовжити\"';
+  String get needMicrophonePermission => 'Нам потрібен дозвіл на мікрофон.\n\n1. Натисніть \"Надати дозвіл\"\n2. Дозвольте на вашому iPhone\n3. Додаток на годиннику закриється\n4. Відкрийте знову та натисніть \"Продовжити\"';
 
   @override
   String get grantPermissionButton => 'Надати дозвіл';
@@ -1922,15 +1884,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get needHelp => 'Потрібна допомога?';
 
   @override
-  String get troubleshootingSteps =>
-      'Усунення несправностей:\n\n1. Переконайтеся, що Omi встановлено на вашому годиннику\n2. Відкрийте додаток Omi на вашому годиннику\n3. Шукайте спливаюче вікно дозволу\n4. Натисніть \"Дозволити\" при запиті\n5. Додаток на вашому годиннику закриється - відкрийте його знову\n6. Поверніться та натисніть \"Продовжити\" на вашому iPhone';
+  String get troubleshootingSteps => 'Усунення несправностей:\n\n1. Переконайтеся, що Omi встановлено на вашому годиннику\n2. Відкрийте додаток Omi на вашому годиннику\n3. Шукайте спливаюче вікно дозволу\n4. Натисніть \"Дозволити\" при запиті\n5. Додаток на вашому годиннику закриється - відкрийте його знову\n6. Поверніться та натисніть \"Продовжити\" на вашому iPhone';
 
   @override
   String get recordingStartedSuccessfully => 'Запис успішно розпочато!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Дозвіл ще не надано. Будь ласка, переконайтеся, що ви дозволили доступ до мікрофона та відкрили додаток на вашому годиннику знову.';
+  String get permissionNotGrantedYet => 'Дозвіл ще не надано. Будь ласка, переконайтеся, що ви дозволили доступ до мікрофона та відкрили додаток на вашому годиннику знову.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1955,8 +1915,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get selectYourLanguage => 'Виберіть свою мову';
 
   @override
-  String get personalGrowthJourney =>
-      'Ваша подорож особистісного зростання зі штучним інтелектом, який слухає кожне ваше слово.';
+  String get personalGrowthJourney => 'Ваша подорож особистісного зростання зі штучним інтелектом, який слухає кожне ваше слово.';
 
   @override
   String get actionItemsTitle => 'Завдання';
@@ -2028,8 +1987,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Готовий до завдань';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'Ваш AI автоматично витягатиме завдання з ваших розмов. Вони з\'являться тут після створення.';
+  String get welcomeActionItemsDescription => 'Ваш AI автоматично витягатиме завдання з ваших розмов. Вони з\'являться тут після створення.';
 
   @override
   String get autoExtractionFeature => 'Автоматично витягуються з розмов';
@@ -2225,15 +2183,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'МОВЛЕННЯ ТА ТРАНСКРИПЦІЯ';
 
   @override
-  String get languageSettingsHelperText =>
-      'Мова додатку змінює меню та кнопки. Мова мовлення впливає на те, як транскрибуються ваші записи.';
+  String get languageSettingsHelperText => 'Мова додатку змінює меню та кнопки. Мова мовлення впливає на те, як транскрибуються ваші записи.';
 
   @override
   String get translationNotice => 'Повідомлення про переклад';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi перекладає розмови на вашу основну мову. Оновіть її в будь-який час у Налаштування → Профілі.';
+  String get translationNoticeMessage => 'Omi перекладає розмови на вашу основну мову. Оновіть її в будь-який час у Налаштування → Профілі.';
 
   @override
   String get pleaseCheckInternetConnection => 'Будь ласка, перевірте підключення до Інтернету та спробуйте ще раз';
@@ -2388,8 +2344,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Скасувати з\'єднання пристрою';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Це скасує з\'єднання пристрою, щоб його можна було підключити до іншого телефону. Вам потрібно буде перейти до Налаштування > Bluetooth і забути пристрій, щоб завершити процес.';
+  String get unpairDeviceDialogMessage => 'Це скасує з\'єднання пристрою, щоб його можна було підключити до іншого телефону. Вам потрібно буде перейти до Налаштування > Bluetooth і забути пристрій, щоб завершити процес.';
 
   @override
   String get unpair => 'Скасувати з\'єднання';
@@ -2570,8 +2525,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get youreAllSet => 'Все готово!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Ласкаво просимо до Omi! Ваш AI-компаньйон готовий допомогти вам із розмовами, завданнями та багато іншим.';
+  String get welcomeToOmiDescription => 'Ласкаво просимо до Omi! Ваш AI-компаньйон готовий допомогти вам із розмовами, завданнями та багато іншим.';
 
   @override
   String get startUsingOmi => 'Почати використання Omi';
@@ -2650,8 +2604,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get reviewAndManageConversations => 'Переглядайте та керуйте записаними розмовами';
 
   @override
-  String get startCapturingConversations =>
-      'Почніть записувати розмови за допомогою пристрою Omi, щоб побачити їх тут.';
+  String get startCapturingConversations => 'Почніть записувати розмови за допомогою пристрою Omi, щоб побачити їх тут.';
 
   @override
   String get useMobileAppToCapture => 'Використовуйте мобільний додаток для запису аудіо';
@@ -2708,8 +2661,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get noTasksYet => 'Поки що немає завдань';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Завдання з ваших розмов з\'являться тут.\nНатисніть Створити, щоб додати завдання вручну.';
+  String get tasksFromConversationsWillAppear => 'Завдання з ваших розмов з\'являться тут.\nНатисніть Створити, щоб додати завдання вручну.';
 
   @override
   String get monthJan => 'Січ';
@@ -2766,8 +2718,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deleteActionItem => 'Видалити елемент дії';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Ви впевнені, що хочете видалити цей елемент дії? Цю дію не можна скасувати.';
+  String get deleteActionItemConfirmation => 'Ви впевнені, що хочете видалити цей елемент дії? Цю дію не можна скасувати.';
 
   @override
   String get enterActionItemDescription => 'Введіть опис елемента дії...';
@@ -2809,8 +2760,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get checkBackLaterForNewApps => 'Повертайтеся пізніше за новими додатками';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'Будь ласка, перевірте підключення до Інтернету та спробуйте ще раз';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'Будь ласка, перевірте підключення до Інтернету та спробуйте ще раз';
 
   @override
   String get createNewApp => 'Створити новий додаток';
@@ -2843,15 +2793,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get chatPrompt => 'Підказка чату';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Ви чудовий додаток, ваше завдання - відповідати на запити користувачів і змушувати їх почуватися добре...';
+  String get chatPromptPlaceholder => 'Ви чудовий додаток, ваше завдання - відповідати на запити користувачів і змушувати їх почуватися добре...';
 
   @override
   String get conversationPrompt => 'Запит розмови';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Ви чудовий додаток, вам будуть надані транскрипція та короткий зміст розмови...';
+  String get conversationPromptPlaceholder => 'Ви чудовий додаток, вам будуть надані транскрипція та короткий зміст розмови...';
 
   @override
   String get notificationScopes => 'Області сповіщень';
@@ -2863,8 +2811,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get makeMyAppPublic => 'Зробити мій додаток публічним';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Надсилаючи цей додаток, я приймаю Умови використання та Політику конфіденційності Omi AI';
+  String get submitAppTermsAgreement => 'Надсилаючи цей додаток, я приймаю Умови використання та Політику конфіденційності Omi AI';
 
   @override
   String get submitApp => 'Надіслати додаток';
@@ -2879,12 +2826,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get submitAppQuestion => 'Надіслати додаток?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Ваш додаток буде розглянуто і опубліковано. Ви можете почати використовувати його негайно, навіть під час розгляду!';
+  String get submitAppPublicDescription => 'Ваш додаток буде розглянуто і опубліковано. Ви можете почати використовувати його негайно, навіть під час розгляду!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Ваш додаток буде розглянуто і стане доступним для вас приватно. Ви можете почати використовувати його негайно, навіть під час розгляду!';
+  String get submitAppPrivateDescription => 'Ваш додаток буде розглянуто і стане доступним для вас приватно. Ви можете почати використовувати його негайно, навіть під час розгляду!';
 
   @override
   String get startEarning => 'Почніть заробляти! 💰';
@@ -2908,22 +2853,19 @@ class AppLocalizationsUk extends AppLocalizations {
   String get dataAccessNotice => 'Повідомлення про доступ до даних';
 
   @override
-  String get dataAccessWarning =>
-      'Цей додаток матиме доступ до ваших даних. Omi AI не несе відповідальності за те, як ваші дані використовуються, змінюються або видаляються цим додатком';
+  String get dataAccessWarning => 'Цей додаток матиме доступ до ваших даних. Omi AI не несе відповідальності за те, як ваші дані використовуються, змінюються або видаляються цим додатком';
 
   @override
   String get installApp => 'Встановити додаток';
 
   @override
-  String get betaTesterNotice =>
-      'Ви бета-тестувальник цього додатка. Він ще не є публічним. Він стане публічним після схвалення.';
+  String get betaTesterNotice => 'Ви бета-тестувальник цього додатка. Він ще не є публічним. Він стане публічним після схвалення.';
 
   @override
   String get appUnderReviewOwner => 'Ваш додаток на розгляді та видимий лише вам. Він стане публічним після схвалення.';
 
   @override
-  String get appRejectedNotice =>
-      'Ваш додаток було відхилено. Будь ласка, оновіть деталі додатка та надішліть його на розгляд знову.';
+  String get appRejectedNotice => 'Ваш додаток було відхилено. Будь ласка, оновіть деталі додатка та надішліть його на розгляд знову.';
 
   @override
   String get setupSteps => 'Кроки налаштування';
@@ -2985,8 +2927,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get descriptionLabel => 'Опис';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Мій чудовий додаток — це чудовий додаток, який робить дивовижні речі. Це найкращий додаток!';
+  String get appDescriptionPlaceholder => 'Мій чудовий додаток — це чудовий додаток, який робить дивовижні речі. Це найкращий додаток!';
 
   @override
   String get pleaseProvideValidDescription => 'Будь ласка, надайте дійсний опис';
@@ -3138,8 +3079,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get microphonePermissionRequired => 'Для запису голосу потрібен дозвіл мікрофона.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Доступ до мікрофона заборонено. Будь ласка, надайте дозвіл у Системні налаштування > Конфіденційність та безпека > Мікрофон.';
+  String get microphonePermissionDenied => 'Доступ до мікрофона заборонено. Будь ласка, надайте дозвіл у Системні налаштування > Конфіденційність та безпека > Мікрофон.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3372,8 +3312,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get whatWeCollect => 'Що ми збираємо';
 
   @override
-  String get dataCollectionMessage =>
-      'Продовжуючи, ваші розмови, записи та особиста інформація будуть безпечно зберігатися на наших серверах для надання аналітики на основі ШІ та увімкнення всіх функцій додатку.';
+  String get dataCollectionMessage => 'Продовжуючи, ваші розмови, записи та особиста інформація будуть безпечно зберігатися на наших серверах для надання аналітики на основі ШІ та увімкнення всіх функцій додатку.';
 
   @override
   String get dataProtection => 'Захист даних';
@@ -3406,8 +3345,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Ім\'я повинно містити принаймні 2 символи';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Розкажіть нам, як ви хотіли б, щоб до вас зверталися. Це допомагає персоналізувати ваш досвід Omi.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Розкажіть нам, як ви хотіли б, щоб до вас зверталися. Це допомагає персоналізувати ваш досвід Omi.';
 
   @override
   String charactersCount(int count) {
@@ -3424,8 +3362,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get recordAudioConversations => 'Записувати аудіо розмови';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi потребує доступу до мікрофона для запису ваших розмов і надання транскрипцій.';
+  String get microphoneAccessDescription => 'Omi потребує доступу до мікрофона для запису ваших розмов і надання транскрипцій.';
 
   @override
   String get screenRecording => 'Запис екрана';
@@ -3434,8 +3371,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Захоплення системного звуку зі зустрічей';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi потребує дозволу на запис екрана для захоплення системного звуку з ваших зустрічей на основі браузера.';
+  String get screenRecordingDescription => 'Omi потребує дозволу на запис екрана для захоплення системного звуку з ваших зустрічей на основі браузера.';
 
   @override
   String get accessibility => 'Доступність';
@@ -3444,8 +3380,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Виявлення зустрічей на основі браузера';
 
   @override
-  String get accessibilityDescription =>
-      'Omi потребує дозволу доступності для виявлення, коли ви приєднуєтесь до зустрічей Zoom, Meet або Teams у вашому браузері.';
+  String get accessibilityDescription => 'Omi потребує дозволу доступності для виявлення, коли ви приєднуєтесь до зустрічей Zoom, Meet або Teams у вашому браузері.';
 
   @override
   String get pleaseWait => 'Будь ласка, зачекайте...';
@@ -3514,12 +3449,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get exportAllConversationsToJson => 'Експортуйте всі свої розмови до файлу JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Експорт розмов розпочато. Це може зайняти кілька секунд, будь ласка, зачекайте.';
+  String get conversationsExportStarted => 'Експорт розмов розпочато. Це може зайняти кілька секунд, будь ласка, зачекайте.';
 
   @override
-  String get mcpDescription =>
-      'Для підключення Omi до інших додатків для читання, пошуку та керування вашими спогадами та розмовами. Створіть ключ для початку.';
+  String get mcpDescription => 'Для підключення Omi до інших додатків для читання, пошуку та керування вашими спогадами та розмовами. Створіть ключ для початку.';
 
   @override
   String get apiKeys => 'Ключі API';
@@ -3590,8 +3523,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get auto => 'Автоматично';
 
   @override
-  String get noSummaryForApp =>
-      'Для цього застосунку немає підсумку. Спробуйте інший застосунок для кращих результатів.';
+  String get noSummaryForApp => 'Для цього застосунку немає підсумку. Спробуйте інший застосунок для кращих результатів.';
 
   @override
   String get tryAnotherApp => 'Спробувати інший додаток';
@@ -3676,8 +3608,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Підготовка запису системного аудіо';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Натисніть кнопку, щоб записати аудіо для живих транскриптів, AI-інсайтів та автоматичного збереження.';
+  String get clickTheButtonToCaptureAudio => 'Натисніть кнопку, щоб записати аудіо для живих транскриптів, AI-інсайтів та автоматичного збереження.';
 
   @override
   String get reconnecting => 'Перепідключення...';
@@ -3880,8 +3811,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get shortcuts => 'Комбінації клавіш';
 
   @override
-  String get shortcutChangeInstruction =>
-      'Натисніть на комбінацію клавіш, щоб змінити її. Натисніть Escape для скасування.';
+  String get shortcutChangeInstruction => 'Натисніть на комбінацію клавіш, щоб змінити її. Натисніть Escape для скасування.';
 
   @override
   String get configureSTTProvider => 'Налаштувати постачальника STT';
@@ -3905,8 +3835,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Видалити граф знань?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Це видалить усі похідні дані графа знань. Ваші оригінальні спогади залишаться в безпеці.';
+  String get deleteKnowledgeGraphWarning => 'Це видалить усі похідні дані графа знань. Ваші оригінальні спогади залишаться в безпеці.';
 
   @override
   String get connectOmiWithAI => 'Підключіть Omi до ШІ-асистентів';
@@ -3963,8 +3892,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get updateAppQuestion => 'Оновити додаток?';
 
   @override
-  String get updateAppConfirmation =>
-      'Ви впевнені, що хочете оновити свій додаток? Зміни набудуть чинності після перевірки нашою командою.';
+  String get updateAppConfirmation => 'Ви впевнені, що хочете оновити свій додаток? Зміни набудуть чинності після перевірки нашою командою.';
 
   @override
   String get updateApp => 'Оновити додаток';
@@ -3994,8 +3922,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get no => 'Ні';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Підписку успішно скасовано. Вона залишиться активною до кінця поточного розрахункового періоду.';
+  String get subscriptionCancelledSuccessfully => 'Підписку успішно скасовано. Вона залишиться активною до кінця поточного розрахункового періоду.';
 
   @override
   String get failedToCancelSubscription => 'Не вдалося скасувати підписку. Будь ласка, спробуйте ще раз.';
@@ -4031,8 +3958,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Скасувати підписку?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Ви впевнені, що хочете скасувати підписку? Ви матимете доступ до кінця поточного розрахункового періоду.';
+  String get cancelSubscriptionConfirmation => 'Ви впевнені, що хочете скасувати підписку? Ви матимете доступ до кінця поточного розрахункового періоду.';
 
   @override
   String get cancelSubscriptionButton => 'Скасувати підписку';
@@ -4101,8 +4027,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get issueActivatingApp => 'Виникла проблема з активацією цього додатка. Будь ласка, спробуйте ще раз.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Цей додаток отримає доступ до ваших даних. Omi AI не несе відповідальності за те, як ваші дані використовуються, змінюються або видаляються цим додатком';
+  String get dataAccessNoticeDescription => 'Цей додаток отримає доступ до ваших даних. Omi AI не несе відповідальності за те, як ваші дані використовуються, змінюються або видаляються цим додатком';
 
   @override
   String get copyUrl => 'Копіювати URL';
@@ -4190,8 +4115,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get omiApiKeys => 'API-ключі Omi';
 
   @override
-  String get apiKeysDescription =>
-      'API-ключі використовуються для автентифікації, коли ваш додаток взаємодіє з сервером OMI. Вони дозволяють вашому додатку створювати спогади та безпечно отримувати доступ до інших сервісів OMI.';
+  String get apiKeysDescription => 'API-ключі використовуються для автентифікації, коли ваш додаток взаємодіє з сервером OMI. Вони дозволяють вашому додатку створювати спогади та безпечно отримувати доступ до інших сервісів OMI.';
 
   @override
   String get aboutOmiApiKeys => 'Про API-ключі Omi';
@@ -4215,8 +4139,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Відкликати API-ключ?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Цю дію не можна скасувати. Будь-які додатки, що використовують цей ключ, більше не зможуть отримати доступ до API.';
+  String get revokeApiKeyWarning => 'Цю дію не можна скасувати. Будь-які додатки, що використовують цей ключ, більше не зможуть отримати доступ до API.';
 
   @override
   String get revoke => 'Відкликати';
@@ -4305,8 +4228,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get keyCreated => 'Ключ створено';
 
   @override
-  String get keyCreatedMessage =>
-      'Ваш новий ключ створено. Будь ласка, скопіюйте його зараз. Ви більше не зможете його побачити.';
+  String get keyCreatedMessage => 'Ваш новий ключ створено. Будь ласка, скопіюйте його зараз. Ви більше не зможете його побачити.';
 
   @override
   String get keyWord => 'Ключ';
@@ -4315,8 +4237,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get externalAppAccess => 'Доступ зовнішніх додатків';
 
   @override
-  String get externalAppAccessDescription =>
-      'Наступні встановлені додатки мають зовнішні інтеграції та можуть отримати доступ до ваших даних, таких як розмови та спогади.';
+  String get externalAppAccessDescription => 'Наступні встановлені додатки мають зовнішні інтеграції та можуть отримати доступ до ваших даних, таких як розмови та спогади.';
 
   @override
   String get noExternalAppsHaveAccess => 'Жоден зовнішній додаток не має доступу до ваших даних.';
@@ -4325,8 +4246,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get maximumSecurityE2ee => 'Максимальна безпека (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Наскрізне шифрування є золотим стандартом конфіденційності. Коли ввімкнено, ваші дані шифруються на вашому пристрої перед відправленням на наші сервери. Це означає, що ніхто, навіть Omi, не може отримати доступ до вашого вмісту.';
+  String get e2eeDescription => 'Наскрізне шифрування є золотим стандартом конфіденційності. Коли ввімкнено, ваші дані шифруються на вашому пристрої перед відправленням на наші сервери. Це означає, що ніхто, навіть Omi, не може отримати доступ до вашого вмісту.';
 
   @override
   String get importantTradeoffs => 'Важливі компроміси:';
@@ -4341,8 +4261,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get featureComingSoon => 'Ця функція незабаром зявиться!';
 
   @override
-  String get migrationInProgressMessage =>
-      'Міграція виконується. Ви не можете змінити рівень захисту, поки вона не завершиться.';
+  String get migrationInProgressMessage => 'Міграція виконується. Ви не можете змінити рівень захисту, поки вона не завершиться.';
 
   @override
   String get migrationFailed => 'Міграція не вдалася';
@@ -4361,19 +4280,16 @@ class AppLocalizationsUk extends AppLocalizations {
   String get secureEncryption => 'Безпечне шифрування';
 
   @override
-  String get secureEncryptionDescription =>
-      'Ваші дані зашифровані унікальним для вас ключем на наших серверах, розміщених у Google Cloud. Це означає, що ваш необроблений вміст недоступний нікому, включаючи співробітників Omi або Google, безпосередньо з бази даних.';
+  String get secureEncryptionDescription => 'Ваші дані зашифровані унікальним для вас ключем на наших серверах, розміщених у Google Cloud. Це означає, що ваш необроблений вміст недоступний нікому, включаючи співробітників Omi або Google, безпосередньо з бази даних.';
 
   @override
   String get endToEndEncryption => 'Наскрізне шифрування';
 
   @override
-  String get e2eeCardDescription =>
-      'Увімкніть для максимальної безпеки, де тільки ви можете отримати доступ до своїх даних. Торкніться, щоб дізнатися більше.';
+  String get e2eeCardDescription => 'Увімкніть для максимальної безпеки, де тільки ви можете отримати доступ до своїх даних. Торкніться, щоб дізнатися більше.';
 
   @override
-  String get dataAlwaysEncrypted =>
-      'Незалежно від рівня, ваші дані завжди зашифровані в стані спокою та під час передачі.';
+  String get dataAlwaysEncrypted => 'Незалежно від рівня, ваші дані завжди зашифровані в стані спокою та під час передачі.';
 
   @override
   String get readOnlyScope => 'Лише читання';
@@ -4441,8 +4357,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get getOmiUnlimitedFree => 'Отримайте Omi Unlimited безкоштовно, надавши свої дані для навчання моделей ШІ.';
 
   @override
-  String get trainingDataBullets =>
-      '• Ваші дані допомагають покращувати моделі ШІ\n• Передаються лише нечутливі дані\n• Повністю прозорий процес';
+  String get trainingDataBullets => '• Ваші дані допомагають покращувати моделі ШІ\n• Передаються лише нечутливі дані\n• Повністю прозорий процес';
 
   @override
   String get learnMoreAtOmiTraining => 'Дізнайтеся більше на omi.me/training';
@@ -4492,15 +4407,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get monthlyPlanContinues => 'Ваш поточний місячний план продовжуватиметься до кінця розрахункового періоду';
 
   @override
-  String get paymentMethodCharged =>
-      'Ваш існуючий спосіб оплати буде автоматично списано, коли закінчиться ваш місячний план';
+  String get paymentMethodCharged => 'Ваш існуючий спосіб оплати буде автоматично списано, коли закінчиться ваш місячний план';
 
   @override
   String get annualSubscriptionStarts => 'Ваша 12-місячна річна підписка розпочнеться автоматично після списання';
 
   @override
-  String get thirteenMonthsCoverage =>
-      'Ви отримаєте 13 місяців покриття загалом (поточний місяць + 12 місяців річної підписки)';
+  String get thirteenMonthsCoverage => 'Ви отримаєте 13 місяців покриття загалом (поточний місяць + 12 місяців річної підписки)';
 
   @override
   String get confirmUpgrade => 'Підтвердити оновлення';
@@ -4537,8 +4450,7 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'Ваш річний план розпочнеться автоматично, коли закінчиться ваш місячний план.';
+  String get annualPlanStartsAutomatically => 'Ваш річний план розпочнеться автоматично, коли закінчиться ваш місячний план.';
 
   @override
   String planRenewsOn(String date) {
@@ -4605,8 +4517,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Ваша конфіденційність важлива для нас';
 
   @override
-  String get privacyIntroText =>
-      'В Omi ми дуже серйозно ставимося до вашої конфіденційності. Ми хочемо бути прозорими щодо даних, які збираємо, і як їх використовуємо. Ось що вам потрібно знати:';
+  String get privacyIntroText => 'В Omi ми дуже серйозно ставимося до вашої конфіденційності. Ми хочемо бути прозорими щодо даних, які збираємо, і як їх використовуємо. Ось що вам потрібно знати:';
 
   @override
   String get whatWeTrack => 'Що ми відстежуємо';
@@ -4621,12 +4532,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get ourCommitment => 'Наше зобов\'язання';
 
   @override
-  String get commitmentText =>
-      'Ми зобов\'язуємося використовувати зібрані дані лише для того, щоб зробити Omi кращим продуктом для вас. Ваша конфіденційність і довіра є для нас найважливішими.';
+  String get commitmentText => 'Ми зобов\'язуємося використовувати зібрані дані лише для того, щоб зробити Omi кращим продуктом для вас. Ваша конфіденційність і довіра є для нас найважливішими.';
 
   @override
-  String get thankYouText =>
-      'Дякуємо, що ви цінний користувач Omi. Якщо у вас є запитання чи занепокоєння, зв\'яжіться з нами за адресою team@basedhardware.com.';
+  String get thankYouText => 'Дякуємо, що ви цінний користувач Omi. Якщо у вас є запитання чи занепокоєння, зв\'яжіться з нами за адресою team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Налаштування синхронізації WiFi';
@@ -4635,8 +4544,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get enterHotspotCredentials => 'Введіть облікові дані точки доступу телефону';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi синхронізація використовує телефон як точку доступу. Знайдіть ім\'я та пароль у Налаштування > Режим модема.';
+  String get wifiSyncUsesHotspot => 'WiFi синхронізація використовує телефон як точку доступу. Знайдіть ім\'я та пароль у Налаштування > Режим модема.';
 
   @override
   String get hotspotNameSsid => 'Ім\'я точки доступу (SSID)';
@@ -4671,8 +4579,7 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Не вдалося створити підсумок. Переконайтеся, що у вас є розмови за цей день.';
+  String get failedToGenerateSummaryCheckConversations => 'Не вдалося створити підсумок. Переконайтеся, що у вас є розмови за цей день.';
 
   @override
   String get summaryNotFound => 'Підсумок не знайдено';
@@ -4702,8 +4609,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Експорт розпочато. Це може зайняти кілька секунд...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Це видалить усі похідні дані графа знань (вузли та з\'єднання). Ваші оригінальні спогади залишаться в безпеці. Граф буде відновлено з часом або за наступним запитом.';
+  String get knowledgeGraphDeleteDescription => 'Це видалить усі похідні дані графа знань (вузли та з\'єднання). Ваші оригінальні спогади залишаться в безпеці. Граф буде відновлено з часом або за наступним запитом.';
 
   @override
   String get configureDailySummaryDigest => 'Налаштуйте щоденний підсумок завдань';
@@ -4773,8 +4679,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Видалити всі розмови Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Це назавжди видалить усі розмови, імпортовані з Limitless. Цю дію не можна скасувати.';
+  String get deleteAllLimitlessWarning => 'Це назавжди видалить усі розмови, імпортовані з Limitless. Цю дію не можна скасувати.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4830,8 +4735,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get howItWorksTitle => 'Як це працює?';
 
   @override
-  String get howPeopleWorks =>
-      'Після створення особи ви можете перейти до транскрипції розмови та призначити їм відповідні сегменти, таким чином Omi зможе розпізнавати і їхнє мовлення!';
+  String get howPeopleWorks => 'Після створення особи ви можете перейти до транскрипції розмови та призначити їм відповідні сегменти, таким чином Omi зможе розпізнавати і їхнє мовлення!';
 
   @override
   String get tapToDelete => 'Торкніться, щоб видалити';
@@ -4857,8 +4761,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get privacyNotice => 'Повідомлення про конфіденційність';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Записи можуть фіксувати голоси інших людей. Перед увімкненням переконайтеся, що ви отримали згоду від усіх учасників.';
+  String get recordingsMayCaptureOthers => 'Записи можуть фіксувати голоси інших людей. Перед увімкненням переконайтеся, що ви отримали згоду від усіх учасників.';
 
   @override
   String get enable => 'Увімкнути';
@@ -4870,8 +4773,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get on => 'Увімк.';
 
   @override
-  String get storeAudioDescription =>
-      'Зберігайте всі аудіозаписи локально на телефоні. Коли вимкнено, зберігаються лише невдалі завантаження для економії місця.';
+  String get storeAudioDescription => 'Зберігайте всі аудіозаписи локально на телефоні. Коли вимкнено, зберігаються лише невдалі завантаження для економії місця.';
 
   @override
   String get enableLocalStorage => 'Увімкнути локальне сховище';
@@ -4889,12 +4791,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get storeAudioOnCloud => 'Зберігати аудіо в хмарі';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Ваші записи в реальному часі зберігатимуться в приватному хмарному сховищі під час розмови.';
+  String get cloudStorageDialogMessage => 'Ваші записи в реальному часі зберігатимуться в приватному хмарному сховищі під час розмови.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Зберігайте записи в реальному часі в приватному хмарному сховищі під час розмови. Аудіо захоплюється та безпечно зберігається в реальному часі.';
+  String get storeAudioCloudDescription => 'Зберігайте записи в реальному часі в приватному хмарному сховищі під час розмови. Аудіо захоплюється та безпечно зберігається в реальному часі.';
 
   @override
   String get downloadingFirmware => 'Завантаження прошивки';
@@ -4903,8 +4803,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get installingFirmware => 'Встановлення прошивки';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Не закривайте програму та не вимикайте пристрій. Це може пошкодити ваш пристрій.';
+  String get firmwareUpdateWarning => 'Не закривайте програму та не вимикайте пристрій. Це може пошкодити ваш пристрій.';
 
   @override
   String get firmwareUpdated => 'Прошивку оновлено';
@@ -4948,8 +4847,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get payments => 'Платежі';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Підключіть спосіб оплати нижче, щоб почати отримувати виплати за ваші додатки.';
+  String get connectPaymentMethodInfo => 'Підключіть спосіб оплати нижче, щоб почати отримувати виплати за ваші додатки.';
 
   @override
   String get selectedPaymentMethod => 'Обраний спосіб оплати';
@@ -5003,8 +4901,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get connectingYourStripeAccount => 'Підключення вашого облікового запису Stripe';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Будь ласка, завершіть процес реєстрації Stripe у вашому браузері. Ця сторінка автоматично оновиться після завершення.';
+  String get stripeOnboardingInstructions => 'Будь ласка, завершіть процес реєстрації Stripe у вашому браузері. Ця сторінка автоматично оновиться після завершення.';
 
   @override
   String get failedTryAgain => 'Не вдалося? Спробувати знову';
@@ -5016,8 +4913,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get successfullyConnected => 'Успішно підключено!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Ваш обліковий запис Stripe готовий отримувати платежі. Ви можете одразу почати заробляти на продажах додатків.';
+  String get stripeReadyForPayments => 'Ваш обліковий запис Stripe готовий отримувати платежі. Ви можете одразу почати заробляти на продажах додатків.';
 
   @override
   String get updateStripeDetails => 'Оновити дані Stripe';
@@ -5035,8 +4931,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Оновіть дані вашого облікового запису PayPal';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Підключіть свій обліковий запис PayPal, щоб почати отримувати платежі за ваші додатки';
+  String get connectPayPalToReceivePayments => 'Підключіть свій обліковий запис PayPal, щоб почати отримувати платежі за ваші додатки';
 
   @override
   String get paypalEmail => 'Email PayPal';
@@ -5045,8 +4940,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get paypalMeLink => 'Посилання PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Якщо Stripe доступний у вашій країні, ми наполегливо рекомендуємо використовувати його для швидших і простіших виплат.';
+  String get stripeRecommendation => 'Якщо Stripe доступний у вашій країні, ми наполегливо рекомендуємо використовувати його для швидших і простіших виплат.';
 
   @override
   String get updatePayPalDetails => 'Оновити дані PayPal';
@@ -5098,8 +4992,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Додатковий зразок голосу видалено';
 
   @override
-  String get consentDataMessage =>
-      'Продовжуючи, ваші розмови, записи та особиста інформація будуть надійно зберігатися на наших серверах. Ваші аудіозаписи та транскрипції обробляються сторонніми AI-сервісами (включаючи Deepgram для транскрипції та OpenAI для аналізу), щоб надати вам аналітику на основі ШІ та увімкнути всі функції додатку.';
+  String get consentDataMessage => 'Продовжуючи, ваші розмови, записи та особиста інформація будуть надійно зберігатися на наших серверах. Ваші аудіозаписи та транскрипції обробляються сторонніми AI-сервісами (включаючи Deepgram для транскрипції та OpenAI для аналізу), щоб надати вам аналітику на основі ШІ та увімкнути всі функції додатку.';
 
   @override
   String get tasksEmptyStateMessage => 'Завдання з ваших розмов з\'являться тут.\nНатисніть +, щоб створити вручну.';
@@ -5138,15 +5031,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Встановіть Omi на\nApple Watch';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Щоб використовувати Apple Watch з Omi, спочатку потрібно встановити додаток Omi на годинник.';
+  String get installOmiOnAppleWatchDescription => 'Щоб використовувати Apple Watch з Omi, спочатку потрібно встановити додаток Omi на годинник.';
 
   @override
   String get openOmiOnAppleWatch => 'Відкрийте Omi на\nApple Watch';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Додаток Omi встановлено на Apple Watch. Відкрийте його та натисніть Старт.';
+  String get openOmiOnAppleWatchDescription => 'Додаток Omi встановлено на Apple Watch. Відкрийте його та натисніть Старт.';
 
   @override
   String get openWatchApp => 'Відкрити додаток Watch';
@@ -5155,15 +5046,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Я встановив і відкрив додаток';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Не вдалося відкрити додаток Apple Watch. Відкрийте додаток Watch вручну на Apple Watch і встановіть Omi з розділу \"Доступні додатки\".';
+  String get unableToOpenWatchApp => 'Не вдалося відкрити додаток Apple Watch. Відкрийте додаток Watch вручну на Apple Watch і встановіть Omi з розділу \"Доступні додатки\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch успішно підключено!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch досі недоступний. Переконайтеся, що додаток Omi відкритий на годиннику.';
+  String get appleWatchNotReachable => 'Apple Watch досі недоступний. Переконайтеся, що додаток Omi відкритий на годиннику.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5591,29 +5480,25 @@ class AppLocalizationsUk extends AppLocalizations {
   String get multipleSpeakersDetected => 'Виявлено кількох мовців';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Схоже, що в записі є кілька мовців. Переконайтеся, що ви знаходитесь у тихому місці, і спробуйте знову.';
+  String get multipleSpeakersDescription => 'Схоже, що в записі є кілька мовців. Переконайтеся, що ви знаходитесь у тихому місці, і спробуйте знову.';
 
   @override
   String get invalidRecordingDetected => 'Виявлено недійсний запис';
 
   @override
-  String get notEnoughSpeechDescription =>
-      'Недостатньо мовлення виявлено. Будь ласка, говоріть більше і спробуйте знову.';
+  String get notEnoughSpeechDescription => 'Недостатньо мовлення виявлено. Будь ласка, говоріть більше і спробуйте знову.';
 
   @override
   String get speechDurationDescription => 'Переконайтеся, що ви говорите не менше 5 секунд і не більше 90.';
 
   @override
-  String get connectionLostDescription =>
-      'Зʼєднання було перервано. Перевірте підключення до інтернету і спробуйте знову.';
+  String get connectionLostDescription => 'Зʼєднання було перервано. Перевірте підключення до інтернету і спробуйте знову.';
 
   @override
   String get howToTakeGoodSample => 'Як зробити хороший зразок?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Переконайтеся, що ви в тихому місці.\n2. Говоріть чітко і природно.\n3. Переконайтеся, що ваш пристрій знаходиться в природному положенні на шиї.\n\nПісля створення ви завжди можете покращити його або зробити знову.';
+  String get goodSampleInstructions => '1. Переконайтеся, що ви в тихому місці.\n2. Говоріть чітко і природно.\n3. Переконайтеся, що ваш пристрій знаходиться в природному положенні на шиї.\n\nПісля створення ви завжди можете покращити його або зробити знову.';
 
   @override
   String get noDeviceConnectedUseMic => 'Пристрій не підключено. Буде використано мікрофон телефону.';
@@ -5676,12 +5561,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get howItWorks => 'Як це працює';
 
   @override
-  String get dailyScoreExplanation =>
-      'Ваш денний рахунок базується на виконанні завдань. Виконуйте завдання, щоб покращити рахунок!';
+  String get dailyScoreExplanation => 'Ваш денний рахунок базується на виконанні завдань. Виконуйте завдання, щоб покращити рахунок!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'Контролюйте, як часто Omi надсилає вам проактивні сповіщення та нагадування.';
+  String get notificationFrequencyDescription => 'Контролюйте, як часто Omi надсилає вам проактивні сповіщення та нагадування.';
 
   @override
   String get sliderOff => 'Вимк.';
@@ -5926,8 +5809,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get recordings => 'Записи';
 
   @override
-  String get enableRemindersAccess =>
-      'Будь ласка, увімкніть доступ до Нагадувань у Налаштуваннях для використання Нагадувань Apple';
+  String get enableRemindersAccess => 'Будь ласка, увімкніть доступ до Нагадувань у Налаштуваннях для використання Нагадувань Apple';
 
   @override
   String todayAtTime(String time) {
@@ -5982,8 +5864,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get webhookUrlNotSet => 'URL вебхука не встановлено';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Встановіть URL вебхука в налаштуваннях розробника для використання цієї функції.';
+  String get setWebhookUrlInSettings => 'Встановіть URL вебхука в налаштуваннях розробника для використання цієї функції.';
 
   @override
   String get sendWebUrl => 'Надіслати веб-посилання';
@@ -6057,15 +5938,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get cloudProvider => 'Хмарний провайдер';
 
   @override
-  String get premiumMinutesInfo =>
-      '1200 преміум хвилин/місяць. Вкладка \"На пристрої\" пропонує необмежену транскрипцію.';
+  String get premiumMinutesInfo => '1200 преміум хвилин/місяць. Вкладка \"На пристрої\" пропонує необмежену транскрипцію.';
 
   @override
   String get viewUsage => 'Переглянути використання';
 
   @override
-  String get localProcessingInfo =>
-      'Аудіо обробляється локально. Працює офлайн, більш приватно, але може бути менш точним.';
+  String get localProcessingInfo => 'Аудіо обробляється локально. Працює офлайн, більш приватно, але може бути менш точним.';
 
   @override
   String get model => 'Модель';
@@ -6080,8 +5959,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get usingNativeIosSpeech => 'Використання вбудованого розпізнавання мовлення iOS';
 
   @override
-  String get noModelDownloadRequired =>
-      'Буде використано вбудований мовний движок вашого пристрою. Завантаження моделі не потрібне.';
+  String get noModelDownloadRequired => 'Буде використано вбудований мовний движок вашого пристрою. Завантаження моделі не потрібне.';
 
   @override
   String get modelReady => 'Модель готова';
@@ -6138,12 +6016,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get batteryDrainSignificantly => 'Розряд батареї значно збільшиться.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1200 преміум-хвилин/місяць. Вкладка На пристрої пропонує необмежену безкоштовну транскрипцію. ';
+  String get premiumMinutesMonth => '1200 преміум-хвилин/місяць. Вкладка На пристрої пропонує необмежену безкоштовну транскрипцію. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Аудіо обробляється локально. Працює офлайн, більш приватно, але споживає більше батареї.';
+  String get audioProcessedLocally => 'Аудіо обробляється локально. Працює офлайн, більш приватно, але споживає більше батареї.';
 
   @override
   String get languageLabel => 'Мова';
@@ -6152,12 +6028,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get modelLabel => 'Модель';
 
   @override
-  String get modelTooLargeWarning =>
-      'Ця модель велика і може спричинити збій програми або дуже повільну роботу на мобільних пристроях.\n\nРекомендується small або base.';
+  String get modelTooLargeWarning => 'Ця модель велика і може спричинити збій програми або дуже повільну роботу на мобільних пристроях.\n\nРекомендується small або base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Буде використано вбудований мовленнєвий рушій вашого пристрою. Завантаження моделі не потрібне.';
+  String get nativeEngineNoDownload => 'Буде використано вбудований мовленнєвий рушій вашого пристрою. Завантаження моделі не потрібне.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6193,8 +6067,7 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Вбудована жива транскрипція Omi оптимізована для розмов у реальному часі з автоматичним визначенням мовця та діаризацією.';
+  String get omiTranscriptionOptimized => 'Вбудована жива транскрипція Omi оптимізована для розмов у реальному часі з автоматичним визначенням мовця та діаризацією.';
 
   @override
   String get reset => 'Скинути';
@@ -6414,8 +6287,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Побудова графа знань зі спогадів...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Ваш граф знань буде побудовано автоматично, коли ви створите нові спогади.';
+  String get knowledgeGraphWillBuildAutomatically => 'Ваш граф знань буде побудовано автоматично, коли ви створите нові спогади.';
 
   @override
   String get buildGraphButton => 'Побудувати граф';
@@ -6639,8 +6511,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get contactsPermissionRequiredForSms => 'Для надсилання через SMS потрібен дозвіл на доступ до контактів';
 
   @override
-  String get grantContactsPermissionForSms =>
-      'Будь ласка, надайте дозвіл на доступ до контактів для надсилання через SMS';
+  String get grantContactsPermissionForSms => 'Будь ласка, надайте дозвіл на доступ до контактів для надсилання через SMS';
 
   @override
   String get noContactsWithPhoneNumbers => 'Не знайдено контактів з номерами телефонів';
@@ -6652,8 +6523,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get failedToLoadContacts => 'Не вдалося завантажити контакти';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Не вдалося підготувати розмову для надсилання. Будь ласка, спробуйте знову.';
+  String get failedToPrepareConversationForSharing => 'Не вдалося підготувати розмову для надсилання. Будь ласка, спробуйте знову.';
 
   @override
   String get couldNotOpenSmsApp => 'Не вдалося відкрити додаток SMS. Будь ласка, спробуйте знову.';
@@ -6719,8 +6589,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Завантаження аудіо з SD-карти вашого пристрою';
 
   @override
-  String get transferRequiredDescription =>
-      'Цей запис зберігається на SD-карті вашого пристрою. Передайте його на телефон, щоб відтворити або поділитися.';
+  String get transferRequiredDescription => 'Цей запис зберігається на SD-карті вашого пристрою. Передайте його на телефон, щоб відтворити або поділитися.';
 
   @override
   String get cancelTransfer => 'Скасувати передачу';
@@ -6741,8 +6610,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get shareRecording => 'Поділитися записом';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Ви впевнені, що хочете остаточно видалити цей запис? Цю дію неможливо скасувати.';
+  String get deleteRecordingConfirmation => 'Ви впевнені, що хочете остаточно видалити цей запис? Цю дію неможливо скасувати.';
 
   @override
   String get recordingIdLabel => 'ID запису';
@@ -6801,8 +6669,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get enableFastTransfer => 'Увімкнути швидку передачу';
 
   @override
-  String get fastTransferDescription =>
-      'Швидка передача використовує WiFi для ~5x швидших швидкостей. Ваш телефон тимчасово підключиться до WiFi-мережі пристрою Omi під час передачі.';
+  String get fastTransferDescription => 'Швидка передача використовує WiFi для ~5x швидших швидкостей. Ваш телефон тимчасово підключиться до WiFi-мережі пристрою Omi під час передачі.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Доступ до інтернету призупинено під час передачі';
@@ -6817,8 +6684,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get fiveTimesFaster => 'У 5 РАЗІВ ШВИДШЕ';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Створює пряме WiFi-підключення до пристрою Omi. Телефон тимчасово відключається від звичайного WiFi під час передачі.';
+  String get fastTransferMethodDescription => 'Створює пряме WiFi-підключення до пристрою Omi. Телефон тимчасово відключається від звичайного WiFi під час передачі.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6827,8 +6693,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get bleSpeed => '~30 КБ/с через BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Використовує стандартне підключення Bluetooth Low Energy. Повільніше, але не впливає на WiFi-з\'єднання.';
+  String get bluetoothMethodDescription => 'Використовує стандартне підключення Bluetooth Low Energy. Повільніше, але не впливає на WiFi-з\'єднання.';
 
   @override
   String get selected => 'Вибрано';
@@ -6866,12 +6731,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get appDeleteFailed => 'Не вдалося видалити додаток. Спробуйте пізніше.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Видимість додатка успішно змінено. Зміни можуть відобразитися через кілька хвилин.';
+  String get appVisibilityChangedSuccessfully => 'Видимість додатка успішно змінено. Зміни можуть відобразитися через кілька хвилин.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Помилка при активації додатка. Якщо це інтеграційний додаток, переконайтеся, що налаштування завершено.';
+  String get errorActivatingAppIntegration => 'Помилка при активації додатка. Якщо це інтеграційний додаток, переконайтеся, що налаштування завершено.';
 
   @override
   String get errorUpdatingAppStatus => 'Виникла помилка під час оновлення статусу додатка.';
@@ -7138,19 +7001,16 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Оновлення заплановано! Ваш місячний план продовжується до кінця платіжного періоду, потім автоматично переключиться на річний.';
+  String get planUpgradeScheduledMessage => 'Оновлення заплановано! Ваш місячний план продовжується до кінця платіжного періоду, потім автоматично переключиться на річний.';
 
   @override
   String get couldNotSchedulePlanChange => 'Не вдалося запланувати зміну плану. Спробуйте ще раз.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Вашу підписку відновлено! Оплата зараз не стягується - вам буде виставлено рахунок наприкінці поточного періоду.';
+  String get subscriptionReactivatedDefault => 'Вашу підписку відновлено! Оплата зараз не стягується - вам буде виставлено рахунок наприкінці поточного періоду.';
 
   @override
-  String get subscriptionSuccessfulCharged =>
-      'Підписку успішно оформлено! З вас стягнуто оплату за новий платіжний період.';
+  String get subscriptionSuccessfulCharged => 'Підписку успішно оформлено! З вас стягнуто оплату за новий платіжний період.';
 
   @override
   String get couldNotProcessSubscription => 'Не вдалося обробити підписку. Спробуйте ще раз.';
@@ -7270,8 +7130,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get successfullyConnectedGoogleTasks => 'Успішно підключено до Google Tasks!';
 
   @override
-  String get failedToConnectGoogleTasksRetry =>
-      'Не вдалося підключитися до Google Tasks. Будь ласка, спробуйте ще раз.';
+  String get failedToConnectGoogleTasksRetry => 'Не вдалося підключитися до Google Tasks. Будь ласка, спробуйте ще раз.';
 
   @override
   String get successfullyConnectedClickUp => 'Успішно підключено до ClickUp!';
@@ -7331,8 +7190,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get onboardingBluetoothRequired => 'Для підключення до пристрою потрібен дозвіл Bluetooth.';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Дозвіл Bluetooth відхилено. Надайте дозвіл у Системних налаштуваннях.';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Дозвіл Bluetooth відхилено. Надайте дозвіл у Системних налаштуваннях.';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7345,12 +7203,10 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Дозвіл на сповіщення відхилено. Надайте дозвіл у Системних налаштуваннях.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Дозвіл на сповіщення відхилено. Надайте дозвіл у Системних налаштуваннях.';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'Дозвіл на сповіщення відхилено. Надайте дозвіл у Системні налаштування > Сповіщення.';
+  String get onboardingNotificationDeniedNotifications => 'Дозвіл на сповіщення відхилено. Надайте дозвіл у Системні налаштування > Сповіщення.';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7363,15 +7219,13 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'Надайте дозвіл на місцезнаходження в Налаштування > Конфіденційність і безпека > Служби геолокації';
+  String get onboardingLocationGrantInSettings => 'Надайте дозвіл на місцезнаходження в Налаштування > Конфіденційність і безпека > Служби геолокації';
 
   @override
   String get onboardingMicrophoneRequired => 'Для запису потрібен дозвіл мікрофона.';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'Дозвіл мікрофона відхилено. Надайте дозвіл у Системні налаштування > Конфіденційність і безпека > Мікрофон.';
+  String get onboardingMicrophoneDenied => 'Дозвіл мікрофона відхилено. Надайте дозвіл у Системні налаштування > Конфіденційність і безпека > Мікрофон.';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7387,8 +7241,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'Для запису системного звуку потрібен дозвіл на захоплення екрана.';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'Дозвіл на захоплення екрана відхилено. Надайте дозвіл у Системні налаштування > Конфіденційність і безпека > Запис екрана.';
+  String get onboardingScreenCaptureDenied => 'Дозвіл на захоплення екрана відхилено. Надайте дозвіл у Системні налаштування > Конфіденційність і безпека > Запис екрана.';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7441,8 +7294,7 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'Дозвіл на фото відхилено. Будь ласка, дозвольте доступ до фото для вибору зображень';
+  String get msgPhotosPermissionDenied => 'Дозвіл на фото відхилено. Будь ласка, дозвольте доступ до фото для вибору зображень';
 
   @override
   String get msgSelectImagesGenericError => 'Помилка вибору зображень. Будь ласка, спробуйте ще раз.';
@@ -7514,8 +7366,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get locationPermissionRequired => 'Потрібен дозвіл на місцезнаходження';
 
   @override
-  String get locationPermissionContent =>
-      'Для швидкої передачі потрібен дозвіл на місцезнаходження для перевірки з\'єднання WiFi. Будь ласка, надайте дозвіл на місцезнаходження, щоб продовжити.';
+  String get locationPermissionContent => 'Для швидкої передачі потрібен дозвіл на місцезнаходження для перевірки з\'єднання WiFi. Будь ласка, надайте дозвіл на місцезнаходження, щоб продовжити.';
 
   @override
   String get pdfTranscriptExport => 'Експорт транскрипції';
@@ -7678,8 +7529,7 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'Пристрій не підтримує синхронізацію WiFi, перемикання на Bluetooth';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'Пристрій не підтримує синхронізацію WiFi, перемикання на Bluetooth';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health недоступний на цьому пристрої';
@@ -7975,8 +7825,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Переведіть Omi DevKit в режим сполучення';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Натисніть кнопку один раз для ввімкнення. Світлодіод блиматиме фіолетовим у режимі сполучення.';
+  String get pairingDescOmiDevkit => 'Натисніть кнопку один раз для ввімкнення. Світлодіод блиматиме фіолетовим у режимі сполучення.';
 
   @override
   String get pairingTitleOmiGlass => 'Увімкніть Omi Glass';
@@ -7988,8 +7837,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Переведіть Plaud Note в режим сполучення';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Натисніть і утримуйте бічну кнопку протягом 2 секунд. Червоний світлодіод блиматиме, коли пристрій буде готовий до сполучення.';
+  String get pairingDescPlaudNote => 'Натисніть і утримуйте бічну кнопку протягом 2 секунд. Червоний світлодіод блиматиме, коли пристрій буде готовий до сполучення.';
 
   @override
   String get pairingTitleBee => 'Переведіть Bee в режим сполучення';
@@ -8001,15 +7849,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get pairingTitleLimitless => 'Переведіть Limitless в режим сполучення';
 
   @override
-  String get pairingDescLimitless =>
-      'Коли горить будь-який індикатор, натисніть один раз, потім натисніть і утримуйте, доки пристрій не покаже рожеве світло, потім відпустіть.';
+  String get pairingDescLimitless => 'Коли горить будь-який індикатор, натисніть один раз, потім натисніть і утримуйте, доки пристрій не покаже рожеве світло, потім відпустіть.';
 
   @override
   String get pairingTitleFriendPendant => 'Переведіть Friend Pendant в режим сполучення';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Натисніть кнопку на кулоні, щоб увімкнути його. Він автоматично перейде в режим сполучення.';
+  String get pairingDescFriendPendant => 'Натисніть кнопку на кулоні, щоб увімкнути його. Він автоматично перейде в режим сполучення.';
 
   @override
   String get pairingTitleFieldy => 'Переведіть Fieldy в режим сполучення';
@@ -8021,15 +7867,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Під\'єднайте Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Встановіть і відкрийте додаток Omi на Apple Watch, потім натисніть Під\'єднати в додатку.';
+  String get pairingDescAppleWatch => 'Встановіть і відкрийте додаток Omi на Apple Watch, потім натисніть Під\'єднати в додатку.';
 
   @override
   String get pairingTitleNeoOne => 'Переведіть Neo One в режим сполучення';
 
   @override
-  String get pairingDescNeoOne =>
-      'Натисніть і утримуйте кнопку живлення, доки не заблимає світлодіод. Пристрій стане видимим.';
+  String get pairingDescNeoOne => 'Натисніть і утримуйте кнопку живлення, доки не заблимає світлодіод. Пристрій стане видимим.';
 
   @override
   String get downloadingFromDevice => 'Завантаження з пристрою';
@@ -8146,8 +7990,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get switchAndRestart => 'Перемкнути';
 
   @override
-  String get stagingDisclaimer =>
-      'Тестове середовище може бути нестабільним, мати непослідовну продуктивність, і дані можуть бути втрачені. Тільки для тестування.';
+  String get stagingDisclaimer => 'Тестове середовище може бути нестабільним, мати непослідовну продуктивність, і дані можуть бути втрачені. Тільки для тестування.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Збережено. Закрийте та знову відкрийте додаток, щоб застосувати зміни.';
@@ -8376,8 +8219,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Телефонні дзвінки через Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Здійснюйте дзвінки через Omi та отримуйте транскрипцію в реальному часі, автоматичні зведення та багато іншого.';
+  String get phoneCallsUpsellSubtitle => 'Здійснюйте дзвінки через Omi та отримуйте транскрипцію в реальному часі, автоматичні зведення та багато іншого.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Транскрипція кожного дзвінка в реальному часі';
@@ -8416,8 +8258,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deletePendingFiles => 'Видалити очікувані записи';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Ці записи НЕ синхронізовані з вашим телефоном і будуть безповоротно втрачені. Це не можна скасувати.';
+  String get deletePendingFilesWarning => 'Ці записи НЕ синхронізовані з вашим телефоном і будуть безповоротно втрачені. Це не можна скасувати.';
 
   @override
   String get pendingFilesDeleted => 'Очікувані записи видалено';
@@ -8429,8 +8270,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deleteAll => 'Видалити все';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Це видалить синхронізовані та очікувані записи. Очікувані записи НЕ синхронізовані і будуть безповоротно втрачені.';
+  String get deleteAllFilesWarning => 'Це видалить синхронізовані та очікувані записи. Очікувані записи НЕ синхронізовані і будуть безповоротно втрачені.';
 
   @override
   String get allFilesDeleted => 'Всі записи видалено';
@@ -8462,8 +8302,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get fairUsePolicy => 'Справедливе використання';
 
   @override
-  String get fairUseLoadError =>
-      'Не вдалося завантажити статус справедливого використання. Будь ласка, спробуйте ще раз.';
+  String get fairUseLoadError => 'Не вдалося завантажити статус справедливого використання. Будь ласка, спробуйте ще раз.';
 
   @override
   String get fairUseStatusNormal => 'Ваше використання в межах норми.';
@@ -8496,8 +8335,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get fairUseAboutTitle => 'Про справедливе використання';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi призначений для особистих розмов, зустрічей та живої взаємодії. Використання вимірюється за фактичним виявленим часом мовлення, а не за часом підключення. Якщо використання значно перевищує звичайні шаблони для неособистого контенту, можуть бути застосовані коригування.';
+  String get fairUseAboutBody => 'Omi призначений для особистих розмов, зустрічей та живої взаємодії. Використання вимірюється за фактичним виявленим часом мовлення, а не за часом підключення. Якщо використання значно перевищує звичайні шаблони для неособистого контенту, можуть бути застосовані коригування.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8535,8 +8373,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get improveConnectionTitle => 'Покращити з\'єднання';
 
   @override
-  String get improveConnectionContent =>
-      'Ми покращили спосіб підключення Omi до вашого пристрою. Щоб активувати це, перейдіть на сторінку інформації про пристрій, натисніть \"Від\'єднати пристрій\" і знову підключіть ваш пристрій.';
+  String get improveConnectionContent => 'Ми покращили спосіб підключення Omi до вашого пристрою. Щоб активувати це, перейдіть на сторінку інформації про пристрій, натисніть \"Від\'єднати пристрій\" і знову підключіть ваш пристрій.';
 
   @override
   String get improveConnectionAction => 'Зрозуміло';
@@ -8591,16 +8428,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get cancelSyncQuestion => 'Скасувати синхронізацію?';
 
   @override
-  String get omisStorageDesc =>
-      'Коли ваш Omi не підключений до телефону, він зберігає аудіо локально у вбудованій пам\'яті. Ви ніколи не втратите запис.';
+  String get omisStorageDesc => 'Коли ваш Omi не підключений до телефону, він зберігає аудіо локально у вбудованій пам\'яті. Ви ніколи не втратите запис.';
 
   @override
-  String get phoneStorageDesc =>
-      'Коли Omi знову підключається, записи автоматично переносяться на телефон перед завантаженням.';
+  String get phoneStorageDesc => 'Коли Omi знову підключається, записи автоматично переносяться на телефон перед завантаженням.';
 
   @override
-  String get cloudStorageDesc =>
-      'Після завантаження ваші записи обробляються та транскрибуються. Розмови будуть доступні протягом хвилини.';
+  String get cloudStorageDesc => 'Після завантаження ваші записи обробляються та транскрибуються. Розмови будуть доступні протягом хвилини.';
 
   @override
   String get tipKeepPhoneNearby => 'Тримайте телефон поруч для швидшої синхронізації';
@@ -8624,12 +8458,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get permissionEnable => 'Увімкнути';
 
   @override
-  String get permissionsPageDescription =>
-      'Ці дозволи є ключовими для роботи Omi. Вони забезпечують основні функції, такі як сповіщення, функції на основі місцезнаходження та запис звуку.';
+  String get permissionsPageDescription => 'Ці дозволи є ключовими для роботи Omi. Вони забезпечують основні функції, такі як сповіщення, функції на основі місцезнаходження та запис звуку.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi потребує кількох дозволів для коректної роботи. Будь ласка, надайте їх, щоб продовжити.';
+  String get permissionsRequiredDescription => 'Omi потребує кількох дозволів для коректної роботи. Будь ласка, надайте їх, щоб продовжити.';
 
   @override
   String get permissionsSetupTitle => 'Отримайте найкращий досвід';
@@ -8885,8 +8717,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get enableLocationTitle => 'Увімкнути місцезнаходження';
 
   @override
-  String get enableLocationDescription =>
-      'Дозвіл на визначення місцезнаходження потрібен для пошуку пристроїв Bluetooth поблизу.';
+  String get enableLocationDescription => 'Дозвіл на визначення місцезнаходження потрібен для пошуку пристроїв Bluetooth поблизу.';
 
   @override
   String get voiceRecordingFound => 'Запис знайдено';
@@ -8907,8 +8738,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get firmwareWarningTitle => 'Важливо: Прочитайте перед оновленням';
 
   @override
-  String get firmwareFormatWarning =>
-      'Ця прошивка відформатує SD-карту. Будь ласка, переконайтеся, що всі офлайн-дані синхронізовані перед оновленням.\n\nЯкщо після встановлення цієї версії ви побачите блимаючий червоний індикатор, не хвилюйтеся. Просто підключіть пристрій до додатку, і він повинен стати синім. Червоний індикатор означає, що годинник пристрою ще не синхронізовано.';
+  String get firmwareFormatWarning => 'Ця прошивка відформатує SD-карту. Будь ласка, переконайтеся, що всі офлайн-дані синхронізовані перед оновленням.\n\nЯкщо після встановлення цієї версії ви побачите блимаючий червоний індикатор, не хвилюйтеся. Просто підключіть пристрій до додатку, і він повинен стати синім. Червоний індикатор означає, що годинник пристрою ще не синхронізовано.';
 
   @override
   String get continueAnyway => 'Продовжити';
@@ -8928,8 +8758,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get tasksMarkComplete => 'Позначено як виконане';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi отримує доступ до Apple Health через фреймворк HealthKit від Apple. Ви можете відкликати доступ у будь-який час у Налаштуваннях iOS.';
+  String get appleHealthManageNote => 'Omi отримує доступ до Apple Health через фреймворк HealthKit від Apple. Ви можете відкликати доступ у будь-який час у Налаштуваннях iOS.';
 
   @override
   String get appleHealthConnectCta => 'Підключити Apple Health';
@@ -8962,8 +8791,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Доступ до Apple Health заборонено';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi не має дозволу на читання даних Apple Health. Увімкніть це в Налаштування iOS → Конфіденційність і безпека → Здоров\'я → Omi.';
+  String get appleHealthDeniedBody => 'Omi не має дозволу на читання даних Apple Health. Увімкніть це в Налаштування iOS → Конфіденційність і безпека → Здоров\'я → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Чому ви йдете?';
@@ -9032,8 +8860,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get planUpdate => 'Оновлення плану';
 
   @override
-  String get planDeprecationMessage =>
-      'Ваш план Unlimited припиняється. Перейдіть на план Operator — ті самі чудові функції за \$49/міс. Ваш поточний план продовжить працювати тим часом.';
+  String get planDeprecationMessage => 'Ваш план Unlimited припиняється. Перейдіть на план Operator — ті самі чудові функції за \$49/міс. Ваш поточний план продовжить працювати тим часом.';
 
   @override
   String get upgradeYourPlan => 'Покращіть свій план';
@@ -9144,8 +8971,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Ви досягли місячного ліміту. Оновіть, щоб продовжити спілкування з Omi без обмежень.';
+  String get chatQuotaExceededReply => 'Ви досягли місячного ліміту. Оновіть, щоб продовжити спілкування з Omi без обмежень.';
 
   @override
   String get voiceResponseAudio => 'Читати відповідь Omi вголос';
@@ -9176,4 +9002,25 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Додати завдання';
+
+  @override
+  String get quickActionAskOmiAnything => 'Запитайте Omi про будь-що';
+
+  @override
+  String get quickActionVoiceMode => 'Голосовий режим';
+
+  @override
+  String get quickActionMute => 'Вимкнути звук';
+
+  @override
+  String get quickActionUnmute => 'Увімкнути звук';
+
+  @override
+  String get quickActionConnectDevice => 'Підключити пристрій';
+
+  @override
+  String get quickActionDeviceSettings => 'Налаштування пристрою';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -24,8 +24,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deleteConversationTitle => 'بات چیت حذف کریں؟';
 
   @override
-  String get deleteConversationMessage =>
-      'یہ منسلکہ یادیں، ٹاسک، اور آڈیو فائلیں بھی حذف کر دے گا۔ یہ عمل واپس نہیں کیا جا سکتا۔';
+  String get deleteConversationMessage => 'یہ منسلکہ یادیں، ٹاسک، اور آڈیو فائلیں بھی حذف کر دے گا۔ یہ عمل واپس نہیں کیا جا سکتا۔';
 
   @override
   String get confirm => 'تصدیق کریں';
@@ -146,8 +145,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deleting => 'حذف ہو رہا ہے...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'براہ کرم اپنے براؤزر میں تصدیق مکمل کریں۔ مکمل ہونے کے بعد، ایپ پر واپس جائیں۔';
+  String get pleaseCompleteAuthentication => 'براہ کرم اپنے براؤزر میں تصدیق مکمل کریں۔ مکمل ہونے کے بعد، ایپ پر واپس جائیں۔';
 
   @override
   String get failedToStartAuthentication => 'تصدیق شروع نہیں ہو سکی';
@@ -355,19 +353,16 @@ class AppLocalizationsUr extends AppLocalizations {
   String get appsDisconnected => 'آپ کی ایپلیکیشنز اور انضمام فوری طور پر منقطع ہو جائیں گے۔';
 
   @override
-  String get exportBeforeDelete =>
-      'آپ اپنا اکاؤنٹ حذف کرنے سے پہلے اپنا ڈیٹا ایکسپورٹ کر سکتے ہیں، لیکن ایک بار حذف ہونے کے بعد، اسے بحال نہیں کیا جا سکتا۔';
+  String get exportBeforeDelete => 'آپ اپنا اکاؤنٹ حذف کرنے سے پہلے اپنا ڈیٹا ایکسپورٹ کر سکتے ہیں، لیکن ایک بار حذف ہونے کے بعد، اسے بحال نہیں کیا جا سکتا۔';
 
   @override
-  String get deleteAccountCheckbox =>
-      'میں سمجھتا ہوں کہ میرے اکاؤنٹ کو حذف کرنا مستقل ہے اور تمام ڈیٹا، بشمول یادیں اور بات چیتیں، کھو جائیں گے اور بحال نہیں ہو سکیں گے۔';
+  String get deleteAccountCheckbox => 'میں سمجھتا ہوں کہ میرے اکاؤنٹ کو حذف کرنا مستقل ہے اور تمام ڈیٹا، بشمول یادیں اور بات چیتیں، کھو جائیں گے اور بحال نہیں ہو سکیں گے۔';
 
   @override
   String get areYouSure => 'کیا آپ یقین ہیں؟';
 
   @override
-  String get deleteAccountFinal =>
-      'یہ عمل ناقابل واپسی ہے اور آپ کے اکاؤنٹ اور تمام منسلکہ ڈیٹا کو مستقل طور پر حذف کر دے گا۔ کیا آپ آگے بڑھنا چاہتے ہیں؟';
+  String get deleteAccountFinal => 'یہ عمل ناقابل واپسی ہے اور آپ کے اکاؤنٹ اور تمام منسلکہ ڈیٹا کو مستقل طور پر حذف کر دے گا۔ کیا آپ آگے بڑھنا چاہتے ہیں؟';
 
   @override
   String get deleteNow => 'اب حذف کریں';
@@ -376,8 +371,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get goBack => 'واپس جائیں';
 
   @override
-  String get checkBoxToConfirm =>
-      'تصدیق کے لیے باکس چیک کریں کہ آپ سمجھتے ہیں کہ اپنے اکاؤنٹ کو حذف کرنا مستقل اور ناقابل واپسی ہے۔';
+  String get checkBoxToConfirm => 'تصدیق کے لیے باکس چیک کریں کہ آپ سمجھتے ہیں کہ اپنے اکاؤنٹ کو حذف کرنا مستقل اور ناقابل واپسی ہے۔';
 
   @override
   String get profile => 'پروفائل';
@@ -455,8 +449,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get yourPrivacyYourControl => 'آپ کی رازداری، آپ کا کنٹرول';
 
   @override
-  String get privacyIntro =>
-      'Omi میں، ہم آپ کی رازداری کی حفاظت کے لیے پرتوشامل ہیں۔ یہ صفحہ آپ کو اپنے ڈیٹا کو کیسے محفوظ اور استعمال کیا جاتا ہے اس پر کنٹرول کرنے کی اجازت دیتا ہے۔';
+  String get privacyIntro => 'Omi میں، ہم آپ کی رازداری کی حفاظت کے لیے پرتوشامل ہیں۔ یہ صفحہ آپ کو اپنے ڈیٹا کو کیسے محفوظ اور استعمال کیا جاتا ہے اس پر کنٹرول کرنے کی اجازت دیتا ہے۔';
 
   @override
   String get learnMore => 'مزید جانیں...';
@@ -465,15 +458,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dataProtectionLevel => 'ڈیٹا تحفظ کی سطح';
 
   @override
-  String get dataProtectionDesc =>
-      'آپ کا ڈیٹا مضبوط انکوڈنگ کے ساتھ ڈیفالٹ طور پر محفوظ ہے۔ اپنی ترتیبات اور نیچے کی مستقبل کی رازداری کے اختیارات کا جائزہ لیں۔';
+  String get dataProtectionDesc => 'آپ کا ڈیٹا مضبوط انکوڈنگ کے ساتھ ڈیفالٹ طور پر محفوظ ہے۔ اپنی ترتیبات اور نیچے کی مستقبل کی رازداری کے اختیارات کا جائزہ لیں۔';
 
   @override
   String get appAccess => 'ایپلیکیشن تک رسائی';
 
   @override
-  String get appAccessDesc =>
-      'درج ذیل ایپلیکیشنز آپ کے ڈیٹا تک رسائی کر سکتی ہیں۔ اس کے اذن کو سنبھالنے کے لیے کسی ایپلیکیشن پر تھپتھپائیں۔';
+  String get appAccessDesc => 'درج ذیل ایپلیکیشنز آپ کے ڈیٹا تک رسائی کر سکتی ہیں۔ اس کے اذن کو سنبھالنے کے لیے کسی ایپلیکیشن پر تھپتھپائیں۔';
 
   @override
   String get noAppsExternalAccess => 'کوئی بھی انسٹال شدہ ایپلیکیشن آپ کے ڈیٹا تک بیرونی رسائی نہیں رکھتی۔';
@@ -530,22 +521,19 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deviceDisconnectedMessage => 'آپ کا Omi منقطع ہو گیا ہے 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'ڈیوائس سے جوڑی ہٹائی گئی۔ ترتیبات > Bluetooth پر جائیں اور جوڑی ہٹانا مکمل کرنے کے لیے ڈیوائس بھول جائیں۔';
+  String get deviceUnpairedMessage => 'ڈیوائس سے جوڑی ہٹائی گئی۔ ترتیبات > Bluetooth پر جائیں اور جوڑی ہٹانا مکمل کرنے کے لیے ڈیوائس بھول جائیں۔';
 
   @override
   String get unpairDialogTitle => 'ڈیوائس سے جوڑی ہٹائیں';
 
   @override
-  String get unpairDialogMessage =>
-      'یہ ڈیوائس کو جوڑی سے ہٹا دے گا تاکہ اسے دوسرے فون سے جڑا جا سکے۔ آپ کو ترتیبات > Bluetooth پر جانا ہوگا اور عمل کو مکمل کرنے کے لیے ڈیوائس بھول جانا ہوگا۔';
+  String get unpairDialogMessage => 'یہ ڈیوائس کو جوڑی سے ہٹا دے گا تاکہ اسے دوسرے فون سے جڑا جا سکے۔ آپ کو ترتیبات > Bluetooth پر جانا ہوگا اور عمل کو مکمل کرنے کے لیے ڈیوائس بھول جانا ہوگا۔';
 
   @override
   String get deviceNotConnected => 'ڈیوائس متصل نہیں';
 
   @override
-  String get connectDeviceMessage =>
-      'اپنے Omi ڈیوائس کو جڑیں\nڈیوائس کی ترتیبات اور حسب ضرورت تک رسائی حاصل کرنے کے لیے';
+  String get connectDeviceMessage => 'اپنے Omi ڈیوائس کو جڑیں\nڈیوائس کی ترتیبات اور حسب ضرورت تک رسائی حاصل کرنے کے لیے';
 
   @override
   String get deviceInfoSection => 'ڈیوائس کی معلومات';
@@ -560,8 +548,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get v2Undetected => 'V2 شناخت نہیں';
 
   @override
-  String get v2UndetectedMessage =>
-      'ہمیں لگتا ہے کہ آپ کے پاس ایک V1 ڈیوائس ہے یا آپ کا ڈیوائس متصل نہیں ہے۔ SD کارڈ کی فعالیت صرف V2 ڈیوائسز کے لیے دستیاب ہے۔';
+  String get v2UndetectedMessage => 'ہمیں لگتا ہے کہ آپ کے پاس ایک V1 ڈیوائس ہے یا آپ کا ڈیوائس متصل نہیں ہے۔ SD کارڈ کی فعالیت صرف V2 ڈیوائسز کے لیے دستیاب ہے۔';
 
   @override
   String get endConversation => 'بات چیت ختم کریں';
@@ -693,8 +680,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get noActivityYet => 'ابھی کوئی سرگرمی نہیں';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Omi کے ساتھ بات چیت شروع کریں\nاپنے استعمال کے اندرونی خیالات یہاں دیکھنے کے لیے۔';
+  String get startConversationToSeeInsights => 'Omi کے ساتھ بات چیت شروع کریں\nاپنے استعمال کے اندرونی خیالات یہاں دیکھنے کے لیے۔';
 
   @override
   String get listening => 'سن رہا ہے';
@@ -836,8 +822,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'علم کے گراف کو حذف کریں؟';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'یہ تمام اخذ شدہ علم کے گراف کا ڈیٹا (نوڈز اور تعلقات) حذف کر دے گا۔ آپ کی اصل یادیں محفوظ رہیں گی۔ گراف وقت کے ساتھ یا اگلی درخواست پر دوبارہ تیار ہو گا۔';
+  String get deleteKnowledgeGraphMessage => 'یہ تمام اخذ شدہ علم کے گراف کا ڈیٹا (نوڈز اور تعلقات) حذف کر دے گا۔ آپ کی اصل یادیں محفوظ رہیں گی۔ گراف وقت کے ساتھ یا اگلی درخواست پر دوبارہ تیار ہو گا۔';
 
   @override
   String get knowledgeGraphDeleted => 'علم کا گراف حذف ہو گیا';
@@ -1080,8 +1065,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get needYourPermission => 'ہمیں آپ کی اجازت کی ضرورت ہے';
 
   @override
-  String get alreadyGavePermission =>
-      'آپ نے پہلے سے ہمیں اپنی ریکارڈنگز محفوظ کرنے کی اجازت دی ہے۔ یہاں یاد دہانی ہے کہ ہمیں یہ کیوں چاہیے:';
+  String get alreadyGavePermission => 'آپ نے پہلے سے ہمیں اپنی ریکارڈنگز محفوظ کرنے کی اجازت دی ہے۔ یہاں یاد دہانی ہے کہ ہمیں یہ کیوں چاہیے:';
 
   @override
   String get wouldLikePermission => 'ہم آپ کی آواز کی ریکارڈنگز محفوظ کرنے کی اجازت چاہتے ہیں۔ یہاں وجہ ہے:';
@@ -1090,26 +1074,22 @@ class AppLocalizationsUr extends AppLocalizations {
   String get improveSpeechProfile => 'اپنی تقریری پروفائل بہتر بنائیں';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'ہم ریکارڈنگز استعمال کرتے ہوئے اپنی ذاتی تقریری پروفائل کو مزید تربیت اور بہتری دیتے ہیں۔';
+  String get improveSpeechProfileDesc => 'ہم ریکارڈنگز استعمال کرتے ہوئے اپنی ذاتی تقریری پروفائل کو مزید تربیت اور بہتری دیتے ہیں۔';
 
   @override
   String get trainFamilyProfiles => 'دوستوں اور خاندان کے لیے پروفائلز تربیت دیں';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'آپ کی ریکارڈنگز ہمیں اپنے دوستوں اور خاندان کو سمجھنے اور پروفائلز بنانے میں مدد کرتے ہیں۔';
+  String get trainFamilyProfilesDesc => 'آپ کی ریکارڈنگز ہمیں اپنے دوستوں اور خاندان کو سمجھنے اور پروفائلز بنانے میں مدد کرتے ہیں۔';
 
   @override
   String get enhanceTranscriptAccuracy => 'ٹرانسکرپٹ کی درستگی میں اضافہ کریں';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'جیسے جیسے ہماری ماڈل بہتر ہوتی ہے، ہم آپ کی ریکارڈنگز کے لیے بہتر تحریری شکل میں تبدیلی کی نتائج فراہم کر سکتے ہیں۔';
+  String get enhanceTranscriptAccuracyDesc => 'جیسے جیسے ہماری ماڈل بہتر ہوتی ہے، ہم آپ کی ریکارڈنگز کے لیے بہتر تحریری شکل میں تبدیلی کی نتائج فراہم کر سکتے ہیں۔';
 
   @override
-  String get legalNotice =>
-      'قانونی نوٹس: آڈیو ڈیٹا ریکارڈ اور محفوظ کرنے کی قانونی حیثیت آپ کے مقام اور اس خصوصیت کو کس طریقے سے استعمال کرتے ہیں اس پر منحصر ہو سکتی ہے۔ یہ آپ کی ذمہ داری ہے کہ مقامی قوانین اور ضوابط کی تعریف کو یقینی بنائیں۔';
+  String get legalNotice => 'قانونی نوٹس: آڈیو ڈیٹا ریکارڈ اور محفوظ کرنے کی قانونی حیثیت آپ کے مقام اور اس خصوصیت کو کس طریقے سے استعمال کرتے ہیں اس پر منحصر ہو سکتی ہے۔ یہ آپ کی ذمہ داری ہے کہ مقامی قوانین اور ضوابط کی تعریف کو یقینی بنائیں۔';
 
   @override
   String get alreadyAuthorized => 'پہلے سے اجازت دی گئی';
@@ -1187,8 +1167,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get showEventsNoParticipants => 'بغیر شرکاء کے ایونٹس دکھائیں';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'جب فعال ہو تو Coming Up شرکاء کے بغیر یا ویڈیو لنک کے بغیر ایونٹس دکھاتا ہے۔';
+  String get showEventsNoParticipantsDesc => 'جب فعال ہو تو Coming Up شرکاء کے بغیر یا ویڈیو لنک کے بغیر ایونٹس دکھاتا ہے۔';
 
   @override
   String get yourMeetings => 'آپ کی میٹنگز';
@@ -1356,8 +1335,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get defaultRepository => 'ڈیفالٹ ذخیرہ';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'مسائل بنانے کے لیے ایک ڈیفالٹ ذخیرہ منتخب کریں۔ آپ مسائل بناتے وقت ایک مختلف ذخیرہ بھی متعین کر سکتے ہیں۔';
+  String get selectDefaultRepoDesc => 'مسائل بنانے کے لیے ایک ڈیفالٹ ذخیرہ منتخب کریں۔ آپ مسائل بناتے وقت ایک مختلف ذخیرہ بھی متعین کر سکتے ہیں۔';
 
   @override
   String get noReposFound => 'کوئی ذخائر نہیں ملے';
@@ -1732,8 +1710,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get enableBluetooth => 'Bluetooth فعال کریں';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi کو اپنے قابل پہننے کے آلے سے جڑنے کے لیے Bluetooth کی ضرورت ہے۔ براہ کرم Bluetooth فعال کریں اور دوبارہ کوشش کریں۔';
+  String get bluetoothNeeded => 'Omi کو اپنے قابل پہننے کے آلے سے جڑنے کے لیے Bluetooth کی ضرورت ہے۔ براہ کرم Bluetooth فعال کریں اور دوبارہ کوشش کریں۔';
 
   @override
   String get contactSupport => 'معاونت سے رابطہ کریں؟';
@@ -1766,26 +1743,22 @@ class AppLocalizationsUr extends AppLocalizations {
   String get locationServiceDisabled => 'مقام کی خدمت غیر فعال ہے';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'مقام کی خدمت غیر فعال ہے۔ براہ کرم Settings > Privacy & Security > Location Services میں جائیں اور اسے فعال کریں';
+  String get locationServiceDisabledDesc => 'مقام کی خدمت غیر فعال ہے۔ براہ کرم Settings > Privacy & Security > Location Services میں جائیں اور اسے فعال کریں';
 
   @override
   String get backgroundLocationDenied => 'پس منظر مقام رسائی مسترد کی گئی';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'براہ کرم آلے کی ترتیبات میں جائیں اور مقام کی اجازت کو \"ہمیشہ اجازت دیں\" میں سیٹ کریں';
+  String get backgroundLocationDeniedDesc => 'براہ کرم آلے کی ترتیبات میں جائیں اور مقام کی اجازت کو \"ہمیشہ اجازت دیں\" میں سیٹ کریں';
 
   @override
   String get lovingOmi => 'Omi سے محبت ہے؟';
 
   @override
-  String get leaveReviewIos =>
-      'ہمیں مزید لوگوں تک پہنچنے میں مدد کریں App Store میں ریویو چھوڑ کر۔ آپ کی رائے ہمارے لیے بہت اہم ہے!';
+  String get leaveReviewIos => 'ہمیں مزید لوگوں تک پہنچنے میں مدد کریں App Store میں ریویو چھوڑ کر۔ آپ کی رائے ہمارے لیے بہت اہم ہے!';
 
   @override
-  String get leaveReviewAndroid =>
-      'ہمیں مزید لوگوں تک پہنچنے میں مدد کریں Google Play Store میں ریویو چھوڑ کر۔ آپ کی رائے ہمارے لیے بہت اہم ہے!';
+  String get leaveReviewAndroid => 'ہمیں مزید لوگوں تک پہنچنے میں مدد کریں Google Play Store میں ریویو چھوڑ کر۔ آپ کی رائے ہمارے لیے بہت اہم ہے!';
 
   @override
   String get rateOnAppStore => 'App Store پر ریٹنگ دیں';
@@ -1797,8 +1770,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get maybeLater => 'شاید بعد میں';
 
   @override
-  String get speechProfileIntro =>
-      'Omi کو آپ کے مقاصد اور آپ کی آواز سے سیکھنے کی ضرورت ہے۔ آپ اسے بعد میں ترمیم کر سکیں گے۔';
+  String get speechProfileIntro => 'Omi کو آپ کے مقاصد اور آپ کی آواز سے سیکھنے کی ضرورت ہے۔ آپ اسے بعد میں ترمیم کر سکیں گے۔';
 
   @override
   String get getStarted => 'شروع کریں';
@@ -1825,8 +1797,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get invalidRecordingMultipleSpeakers => 'غلط ریکارڈنگ شدہ';
 
   @override
-  String get multipleSpeakersDesc =>
-      'ایسا لگتا ہے کہ ریکارڈنگ میں متعدد سپیکر ہیں۔ براہ کرم یقینی بنائیں کہ آپ خاموش جگہ میں ہیں اور دوبارہ کوشش کریں۔';
+  String get multipleSpeakersDesc => 'ایسا لگتا ہے کہ ریکارڈنگ میں متعدد سپیکر ہیں۔ براہ کرم یقینی بنائیں کہ آپ خاموش جگہ میں ہیں اور دوبارہ کوشش کریں۔';
 
   @override
   String get tooShortDesc => 'کافی تقریر شدہ نہیں ہے۔ براہ کرم زیادہ بول کر دوبارہ کوشش کریں۔';
@@ -1838,8 +1809,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get areYouThere => 'آپ ہیں؟';
 
   @override
-  String get noSpeechDesc =>
-      'ہم کوئی تقریر معلوم نہیں کر سکے۔ براہ کرم کم از کم 10 سیکنڈ اور 3 منٹ سے کم نہ بول کر یقینی بنائیں۔';
+  String get noSpeechDesc => 'ہم کوئی تقریر معلوم نہیں کر سکے۔ براہ کرم کم از کم 10 سیکنڈ اور 3 منٹ سے کم نہ بول کر یقینی بنائیں۔';
 
   @override
   String get connectionLost => 'کنکشن ٹوٹ گیا';
@@ -1860,8 +1830,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get permissionsRequired => 'اختیارات درکار ہیں';
 
   @override
-  String get permissionsRequiredDesc =>
-      'اس ایپ کو صحیح طریقے سے کام کرنے کے لیے Bluetooth اور Location کی اختیارات کی ضرورت ہے۔ براہ کرم انہیں ترتیبات میں فعال کریں۔';
+  String get permissionsRequiredDesc => 'اس ایپ کو صحیح طریقے سے کام کرنے کے لیے Bluetooth اور Location کی اختیارات کی ضرورت ہے۔ براہ کرم انہیں ترتیبات میں فعال کریں۔';
 
   @override
   String get openSettings => 'ترتیبات کھولیں';
@@ -1903,12 +1872,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get microphonePermission => 'مائیکروفون اختیار';
 
   @override
-  String get permissionGrantedNow =>
-      'اختیار دی گئی! اب:\n\nاپنی گھڑی پر Omi ایپ کھولیں اور نیچے \"جاری رکھیں\" پر ٹیپ کریں';
+  String get permissionGrantedNow => 'اختیار دی گئی! اب:\n\nاپنی گھڑی پر Omi ایپ کھولیں اور نیچے \"جاری رکھیں\" پر ٹیپ کریں';
 
   @override
-  String get needMicrophonePermission =>
-      'ہمیں مائیکروفون اختیار کی ضرورت ہے۔\n\n1. \"اختیار دیں\" ٹیپ کریں\n2. اپنے iPhone پر اجازت دیں\n3. گھڑی کی ایپ بند ہو جائے گی\n4. دوبارہ کھولیں اور \"جاری رکھیں\" ٹیپ کریں';
+  String get needMicrophonePermission => 'ہمیں مائیکروفون اختیار کی ضرورت ہے۔\n\n1. \"اختیار دیں\" ٹیپ کریں\n2. اپنے iPhone پر اجازت دیں\n3. گھڑی کی ایپ بند ہو جائے گی\n4. دوبارہ کھولیں اور \"جاری رکھیں\" ٹیپ کریں';
 
   @override
   String get grantPermissionButton => 'اختیار دیں';
@@ -1917,15 +1884,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get needHelp => 'مدد کی ضرورت ہے؟';
 
   @override
-  String get troubleshootingSteps =>
-      'مسائل کا حل:\n\n1. یقینی بنائیں کہ Omi آپ کی گھڑی پر انسٹال ہے\n2. اپنی گھڑی پر Omi ایپ کھولیں\n3. اختیار پاپ اپ تلاش کریں\n4. جب پوچھا جائے \"اجازت دیں\" ٹیپ کریں\n5. آپ کی گھڑی کی ایپ بند ہوگی - اسے دوبارہ کھولیں\n6. اپنے iPhone پر واپس آئیں اور \"جاری رکھیں\" ٹیپ کریں';
+  String get troubleshootingSteps => 'مسائل کا حل:\n\n1. یقینی بنائیں کہ Omi آپ کی گھڑی پر انسٹال ہے\n2. اپنی گھڑی پر Omi ایپ کھولیں\n3. اختیار پاپ اپ تلاش کریں\n4. جب پوچھا جائے \"اجازت دیں\" ٹیپ کریں\n5. آپ کی گھڑی کی ایپ بند ہوگی - اسے دوبارہ کھولیں\n6. اپنے iPhone پر واپس آئیں اور \"جاری رکھیں\" ٹیپ کریں';
 
   @override
   String get recordingStartedSuccessfully => 'ریکارڈنگ کامیابی سے شروع ہو گئی!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'اختیار ابھی نہیں دیا گیا۔ براہ کرم یقینی بنائیں کہ آپ نے مائیکروفون رسائی کی اجازت دی ہے اور اپنی گھڑی پر ایپ دوبارہ کھولی ہے۔';
+  String get permissionNotGrantedYet => 'اختیار ابھی نہیں دیا گیا۔ براہ کرم یقینی بنائیں کہ آپ نے مائیکروفون رسائی کی اجازت دی ہے اور اپنی گھڑی پر ایپ دوبارہ کھولی ہے۔';
 
   @override
   String errorRequestingPermission(String error) {
@@ -1956,8 +1921,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get actionItemsTitle => 'کام کریں';
 
   @override
-  String get actionItemsDescription =>
-      'ترمیم کرنے کے لیے ٹیپ کریں • منتخب کرنے کے لیے لمبی دبائیں • اقدامات کے لیے سوائپ کریں';
+  String get actionItemsDescription => 'ترمیم کرنے کے لیے ٹیپ کریں • منتخب کرنے کے لیے لمبی دبائیں • اقدامات کے لیے سوائپ کریں';
 
   @override
   String get tabToDo => 'کریں';
@@ -2023,8 +1987,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get welcomeActionItemsTitle => 'کام کے لیے تیار ہیں';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'آپ کا AI خودکار طور پر آپ کی بات چیت سے کام اور کام نکالے گا۔ وہ بنائے جانے پر یہاں ظاہر ہوں گے۔';
+  String get welcomeActionItemsDescription => 'آپ کا AI خودکار طور پر آپ کی بات چیت سے کام اور کام نکالے گا۔ وہ بنائے جانے پر یہاں ظاہر ہوں گے۔';
 
   @override
   String get autoExtractionFeature => 'بات چیت سے خودکار طور پر نکالا گیا';
@@ -2220,15 +2183,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'تقریر اور ٹرانسکرپشن';
 
   @override
-  String get languageSettingsHelperText =>
-      'ایپ کی زبان مینوز اور بٹن بدلتی ہے۔ تقریر کی زبان آپ کی ریکارڈنگز کی ٹرانسکرپشن کو متاثر کرتی ہے۔';
+  String get languageSettingsHelperText => 'ایپ کی زبان مینوز اور بٹن بدلتی ہے۔ تقریر کی زبان آپ کی ریکارڈنگز کی ٹرانسکرپشن کو متاثر کرتی ہے۔';
 
   @override
   String get translationNotice => 'ترجمے کا نوٹس';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi آپ کی بات چیت کو اپنی بنیادی زبان میں ترجمہ کرتا ہے۔ Settings → Profiles میں کسی بھی وقت اپ ڈیٹ کریں۔';
+  String get translationNoticeMessage => 'Omi آپ کی بات چیت کو اپنی بنیادی زبان میں ترجمہ کرتا ہے۔ Settings → Profiles میں کسی بھی وقت اپ ڈیٹ کریں۔';
 
   @override
   String get pleaseCheckInternetConnection => 'براہ کرم اپنی انٹرنیٹ کنکشن چیک کریں اور دوبارہ کوشش کریں';
@@ -2390,8 +2351,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'ڈیوائس کو الگ کریں';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'یہ ڈیوائس کو الگ کر دے گا تاکہ یہ دوسرے فون سے منسلک ہو سکے۔ اس عمل کو مکمل کرنے کے لیے آپ کو Settings > Bluetooth میں جانا ہوگا اور ڈیوائس کو بھول جانا ہوگا۔';
+  String get unpairDeviceDialogMessage => 'یہ ڈیوائس کو الگ کر دے گا تاکہ یہ دوسرے فون سے منسلک ہو سکے۔ اس عمل کو مکمل کرنے کے لیے آپ کو Settings > Bluetooth میں جانا ہوگا اور ڈیوائس کو بھول جانا ہوگا۔';
 
   @override
   String get unpair => 'الگ کریں';
@@ -2572,8 +2532,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get youreAllSet => 'آپ تیار ہیں!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Omi میں خوش آمدید! آپ کا AI ساتھی بات چیت، کاموں اور بہت کچھ میں آپ کی مدد کے لیے تیار ہے۔';
+  String get welcomeToOmiDescription => 'Omi میں خوش آمدید! آپ کا AI ساتھی بات چیت، کاموں اور بہت کچھ میں آپ کی مدد کے لیے تیار ہے۔';
 
   @override
   String get startUsingOmi => 'Omi استعمال کرنا شروع کریں';
@@ -2652,8 +2611,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get reviewAndManageConversations => 'اپنی پکڑی گئی بات چیتوں کا جائزہ لیں اور انتظام کریں';
 
   @override
-  String get startCapturingConversations =>
-      'اپنے Omi ڈیوائس کے ساتھ بات چیتوں کو پکڑنا شروع کریں تاکہ انہیں یہاں دیکھ سکیں۔';
+  String get startCapturingConversations => 'اپنے Omi ڈیوائس کے ساتھ بات چیتوں کو پکڑنا شروع کریں تاکہ انہیں یہاں دیکھ سکیں۔';
 
   @override
   String get useMobileAppToCapture => 'آڈیو پکڑنے کے لیے اپنی موبائل ایپ استعمال کریں';
@@ -2710,8 +2668,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get noTasksYet => 'ابھی کوئی کام نہیں';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'آپ کی بات چیتوں سے کام یہاں ظاہر ہوں گے۔\nدستی طور پر شامل کرنے کے لیے بنائیں پر کلک کریں۔';
+  String get tasksFromConversationsWillAppear => 'آپ کی بات چیتوں سے کام یہاں ظاہر ہوں گے۔\nدستی طور پر شامل کرنے کے لیے بنائیں پر کلک کریں۔';
 
   @override
   String get monthJan => 'جنوری';
@@ -2768,8 +2725,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deleteActionItem => 'کارروائی کی چیز حذف کریں';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'کیا آپ اس کارروائی کی چیز کو حذف کرنا چاہتے ہیں؟ یہ کارروائی واپس نہیں کی جا سکتی۔';
+  String get deleteActionItemConfirmation => 'کیا آپ اس کارروائی کی چیز کو حذف کرنا چاہتے ہیں؟ یہ کارروائی واپس نہیں کی جا سکتی۔';
 
   @override
   String get enterActionItemDescription => 'کارروائی کی چیز کی تفصیل درج کریں...';
@@ -2811,8 +2767,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get checkBackLaterForNewApps => 'نئی ایپس کے لیے بعد میں واپس چیک کریں';
 
   @override
-  String get pleaseCheckInternetConnectionAndTryAgain =>
-      'براہ کرم اپنے انٹرنیٹ کنکشن کی جانچ کریں اور دوبارہ کوشش کریں';
+  String get pleaseCheckInternetConnectionAndTryAgain => 'براہ کرم اپنے انٹرنیٹ کنکشن کی جانچ کریں اور دوبارہ کوشش کریں';
 
   @override
   String get createNewApp => 'نئی ایپ بنائیں';
@@ -2845,15 +2800,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get chatPrompt => 'چیٹ کا اشارہ';
 
   @override
-  String get chatPromptPlaceholder =>
-      'آپ ایک بہترین ایپ ہیں، آپ کا کام صارف کی سوالات کا جواب دینا اور انہیں خوش محسوس کرانا ہے...';
+  String get chatPromptPlaceholder => 'آپ ایک بہترین ایپ ہیں، آپ کا کام صارف کی سوالات کا جواب دینا اور انہیں خوش محسوس کرانا ہے...';
 
   @override
   String get conversationPrompt => 'بات چیت کا اشارہ';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'آپ ایک بہترین ایپ ہیں، آپ کو بات چیت کا ٹرانسکرپٹ اور خلاصہ دیا جائے گا...';
+  String get conversationPromptPlaceholder => 'آپ ایک بہترین ایپ ہیں، آپ کو بات چیت کا ٹرانسکرپٹ اور خلاصہ دیا جائے گا...';
 
   @override
   String get notificationScopes => 'اطلاع کے دائرے';
@@ -2865,8 +2818,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get makeMyAppPublic => 'میری ایپ کو عوامی بنائیں';
 
   @override
-  String get submitAppTermsAgreement =>
-      'اس ایپ کو جمع کر کے، میں Omi AI کی خدمات کی شرائط اور رازداری کی پالیسی سے متفق ہوں';
+  String get submitAppTermsAgreement => 'اس ایپ کو جمع کر کے، میں Omi AI کی خدمات کی شرائط اور رازداری کی پالیسی سے متفق ہوں';
 
   @override
   String get submitApp => 'ایپ جمع کریں';
@@ -2881,12 +2833,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get submitAppQuestion => 'ایپ جمع کریں؟';
 
   @override
-  String get submitAppPublicDescription =>
-      'آپ کی ایپ کا جائزہ لیا جائے گا اور عوامی بنایا جائے گا۔ جائزے کے دوران بھی آپ فوری طور پر اس کا استعمال شروع کر سکتے ہیں!';
+  String get submitAppPublicDescription => 'آپ کی ایپ کا جائزہ لیا جائے گا اور عوامی بنایا جائے گا۔ جائزے کے دوران بھی آپ فوری طور پر اس کا استعمال شروع کر سکتے ہیں!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'آپ کی ایپ کا جائزہ لیا جائے گا اور آپ کے لیے نجی طور پر دستیاب بنایا جائے گا۔ جائزے کے دوران بھی آپ فوری طور پر اس کا استعمال شروع کر سکتے ہیں!';
+  String get submitAppPrivateDescription => 'آپ کی ایپ کا جائزہ لیا جائے گا اور آپ کے لیے نجی طور پر دستیاب بنایا جائے گا۔ جائزے کے دوران بھی آپ فوری طور پر اس کا استعمال شروع کر سکتے ہیں!';
 
   @override
   String get startEarning => 'کمائی شروع کریں! 💰';
@@ -2910,22 +2860,19 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dataAccessNotice => 'ڈیٹا کی رسائی کا نوٹس';
 
   @override
-  String get dataAccessWarning =>
-      'یہ ایپ آپ کے ڈیٹا کو رسائی حاصل کرے گی۔ Omi AI اس بات کے لیے ذمہ دار نہیں ہے کہ یہ ایپ آپ کے ڈیٹا کو کیسے استعمال، تبدیل یا حذف کرتا ہے';
+  String get dataAccessWarning => 'یہ ایپ آپ کے ڈیٹا کو رسائی حاصل کرے گی۔ Omi AI اس بات کے لیے ذمہ دار نہیں ہے کہ یہ ایپ آپ کے ڈیٹا کو کیسے استعمال، تبدیل یا حذف کرتا ہے';
 
   @override
   String get installApp => 'ایپ انسٹال کریں';
 
   @override
-  String get betaTesterNotice =>
-      'آپ اس ایپ کے لیے بیٹا ٹیسٹر ہیں۔ یہ ابھی عوامی نہیں ہے۔ یہ منظور ہونے کے بعد عوامی ہوگا۔';
+  String get betaTesterNotice => 'آپ اس ایپ کے لیے بیٹا ٹیسٹر ہیں۔ یہ ابھی عوامی نہیں ہے۔ یہ منظور ہونے کے بعد عوامی ہوگا۔';
 
   @override
   String get appUnderReviewOwner => 'آپ کی ایپ جائزے میں ہے اور صرف آپ کو نظر آتی ہے۔ یہ منظور ہونے کے بعد عوامی ہوگی۔';
 
   @override
-  String get appRejectedNotice =>
-      'آپ کی ایپ مسترد کر دی گئی ہے۔ براہ کرم ایپ کی تفصیلات میں ترمیم کریں اور دوبارہ جائزے کے لیے جمع کریں۔';
+  String get appRejectedNotice => 'آپ کی ایپ مسترد کر دی گئی ہے۔ براہ کرم ایپ کی تفصیلات میں ترمیم کریں اور دوبارہ جائزے کے لیے جمع کریں۔';
 
   @override
   String get setupSteps => 'سیٹ اپ کے اقدامات';
@@ -2987,8 +2934,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get descriptionLabel => 'تفصیل';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'میری بہترین ایپ ایک بہترین ایپ ہے جو حیرت انگیز چیزیں کرتی ہے۔ یہ سب سے بہترین ایپ ہے!';
+  String get appDescriptionPlaceholder => 'میری بہترین ایپ ایک بہترین ایپ ہے جو حیرت انگیز چیزیں کرتی ہے۔ یہ سب سے بہترین ایپ ہے!';
 
   @override
   String get pleaseProvideValidDescription => 'براہ کرم درست تفصیل فراہم کریں';
@@ -3140,8 +3086,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get microphonePermissionRequired => 'کالز بنانے کے لیے مائیکروفون کی اجازت ضروری ہے';
 
   @override
-  String get microphonePermissionDenied =>
-      'مائیکروفون کی اجازت مسترد کر دی گئی۔ براہ کرم System Preferences > Privacy & Security > Microphone میں اجازت دیں۔';
+  String get microphonePermissionDenied => 'مائیکروفون کی اجازت مسترد کر دی گئی۔ براہ کرم System Preferences > Privacy & Security > Microphone میں اجازت دیں۔';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3374,8 +3319,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get whatWeCollect => 'ہم کیا جمع کرتے ہیں';
 
   @override
-  String get dataCollectionMessage =>
-      'جاری رکھنے سے آپ کی بات چیت، ریکارڈنگز، اور ذاتی معلومات ہماری سرورز پر محفوظ طریقے سے محفوظ ہوں گی تاکہ AI کی طاقتور بصیرت فراہم کی جا سکے اور تمام ایپ کی خصوصیات فعال ہوں۔';
+  String get dataCollectionMessage => 'جاری رکھنے سے آپ کی بات چیت، ریکارڈنگز، اور ذاتی معلومات ہماری سرورز پر محفوظ طریقے سے محفوظ ہوں گی تاکہ AI کی طاقتور بصیرت فراہم کی جا سکے اور تمام ایپ کی خصوصیات فعال ہوں۔';
 
   @override
   String get dataProtection => 'ڈیٹا کی حفاظت';
@@ -3408,8 +3352,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'نام میں کم از کم 2 حروف ہونے چاہیں';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'ہمیں بتائیں کہ آپ کو کیسے پکارا جائے۔ یہ آپ کے Omi تجربے کو ذاتی نوعیت سے تبدیل کرنے میں مدد کرتا ہے۔';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'ہمیں بتائیں کہ آپ کو کیسے پکارا جائے۔ یہ آپ کے Omi تجربے کو ذاتی نوعیت سے تبدیل کرنے میں مدد کرتا ہے۔';
 
   @override
   String charactersCount(int count) {
@@ -3426,8 +3369,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get recordAudioConversations => 'آڈیو کی بات چیت ریکارڈ کریں';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi کو آپ کی بات چیت ریکارڈ کرنے اور نقول فراہم کرنے کے لیے مائیکروفون کی رسائی کی ضرورت ہے۔';
+  String get microphoneAccessDescription => 'Omi کو آپ کی بات چیت ریکارڈ کرنے اور نقول فراہم کرنے کے لیے مائیکروفون کی رسائی کی ضرورت ہے۔';
 
   @override
   String get screenRecording => 'اسکرین ریکارڈنگ';
@@ -3436,8 +3378,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'میٹنگز سے سسٹم آڈیو کیپچر کریں';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi کو اپنے براؤزر پر مبنی میٹنگز سے سسٹم آڈیو کیپچر کرنے کے لیے اسکرین ریکارڈنگ کی اجازت کی ضرورت ہے۔';
+  String get screenRecordingDescription => 'Omi کو اپنے براؤزر پر مبنی میٹنگز سے سسٹم آڈیو کیپچر کرنے کے لیے اسکرین ریکارڈنگ کی اجازت کی ضرورت ہے۔';
 
   @override
   String get accessibility => 'رسائی';
@@ -3446,8 +3387,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'براؤزر پر مبنی میٹنگز کا پتہ لگائیں';
 
   @override
-  String get accessibilityDescription =>
-      'Omi کو جب آپ اپنے براؤزر میں Zoom، Meet، یا Teams میٹنگز میں شامل ہوں تب ان کا پتہ لگانے کے لیے رسائی کی اجازت کی ضرورت ہے۔';
+  String get accessibilityDescription => 'Omi کو جب آپ اپنے براؤزر میں Zoom، Meet، یا Teams میٹنگز میں شامل ہوں تب ان کا پتہ لگانے کے لیے رسائی کی اجازت کی ضرورت ہے۔';
 
   @override
   String get pleaseWait => 'براہ کرم انتظار کریں...';
@@ -3516,12 +3456,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get exportAllConversationsToJson => 'اپنی تمام بات چیت کو JSON فائل میں برآمد کریں۔';
 
   @override
-  String get conversationsExportStarted =>
-      'بات چیت کی برآمدگی شروع ہو گئی۔ یہ کچھ سیکنڈ لے سکتا ہے، براہ کرم انتظار کریں۔';
+  String get conversationsExportStarted => 'بات چیت کی برآمدگی شروع ہو گئی۔ یہ کچھ سیکنڈ لے سکتا ہے، براہ کرم انتظار کریں۔';
 
   @override
-  String get mcpDescription =>
-      'Omi کو دوسری ایپلیکیشنز کے ساتھ جڑنے کے لیے تاکہ آپ اپنی یادوں اور بات چیت کو پڑھ، تلاش، اور منظم کر سکیں۔ شروعات کرنے کے لیے کلید بنائیں۔';
+  String get mcpDescription => 'Omi کو دوسری ایپلیکیشنز کے ساتھ جڑنے کے لیے تاکہ آپ اپنی یادوں اور بات چیت کو پڑھ، تلاش، اور منظم کر سکیں۔ شروعات کرنے کے لیے کلید بنائیں۔';
 
   @override
   String get apiKeys => 'API کلیدیں';
@@ -3629,8 +3567,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Omi کو بہترین ایپ خودکار طور پر منتخب کرنے دیں';
 
   @override
-  String get deleteConversationConfirmation =>
-      'کیا آپ واقعی یہ بات چیت حذف کرنا چاہتے ہیں؟ یہ کارنامہ واپس نہیں ہو سکتا۔';
+  String get deleteConversationConfirmation => 'کیا آپ واقعی یہ بات چیت حذف کرنا چاہتے ہیں؟ یہ کارنامہ واپس نہیں ہو سکتا۔';
 
   @override
   String get conversationDeleted => 'بات چیت حذف ہو گئی';
@@ -3678,8 +3615,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get preparingSystemAudioCapture => 'سسٹم آڈیو کیپچر کی تیاری ہو رہی ہے';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'براہ راست نقول، AI کی بصیرت، اور خودکار بچت کے لیے آڈیو کیپچر کرنے کے لیے بٹن پر کلک کریں۔';
+  String get clickTheButtonToCaptureAudio => 'براہ راست نقول، AI کی بصیرت، اور خودکار بچت کے لیے آڈیو کیپچر کرنے کے لیے بٹن پر کلک کریں۔';
 
   @override
   String get reconnecting => 'دوبارہ جڑ رہے ہیں...';
@@ -3882,8 +3818,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get shortcuts => 'شارٹ کٹس';
 
   @override
-  String get shortcutChangeInstruction =>
-      'شارٹ کٹ کو تبدیل کرنے کے لیے اس پر کلک کریں۔ منسوخ کرنے کے لیے Escape دبائیں۔';
+  String get shortcutChangeInstruction => 'شارٹ کٹ کو تبدیل کرنے کے لیے اس پر کلک کریں۔ منسوخ کرنے کے لیے Escape دبائیں۔';
 
   @override
   String get configureSTTProvider => 'STT فراہم کنندہ کو ترتیب دیں';
@@ -3907,8 +3842,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'علم کا گراف حذف کریں؟';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'یہ تمام حاصل شدہ علم کے گراف کو حذف کرے گا۔ آپ کی اصل یادیں محفوظ رہیں گی۔';
+  String get deleteKnowledgeGraphWarning => 'یہ تمام حاصل شدہ علم کے گراف کو حذف کرے گا۔ آپ کی اصل یادیں محفوظ رہیں گی۔';
 
   @override
   String get connectOmiWithAI => 'Omi کو AI معاونین کے ساتھ جوڑیں';
@@ -3965,8 +3899,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get updateAppQuestion => 'ایپ اپ ڈیٹ کریں؟';
 
   @override
-  String get updateAppConfirmation =>
-      'کیا آپ واقعی اپنی ایپ اپ ڈیٹ کرنا چاہتے ہیں؟ ہماری ٹیم کے نقطہ نظر سے تبدیلیاں نظر آئیں گی۔';
+  String get updateAppConfirmation => 'کیا آپ واقعی اپنی ایپ اپ ڈیٹ کرنا چاہتے ہیں؟ ہماری ٹیم کے نقطہ نظر سے تبدیلیاں نظر آئیں گی۔';
 
   @override
   String get updateApp => 'ایپ اپ ڈیٹ کریں';
@@ -3996,8 +3929,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get no => 'نہیں';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'رکنیت کامیابی سے منسوخ کر دی گئی۔ یہ موجودہ بلنگ مدت کے اختتام تک فعال رہے گی۔';
+  String get subscriptionCancelledSuccessfully => 'رکنیت کامیابی سے منسوخ کر دی گئی۔ یہ موجودہ بلنگ مدت کے اختتام تک فعال رہے گی۔';
 
   @override
   String get failedToCancelSubscription => 'رکنیت منسوخ کرنا ناکام۔ براہ کرم دوبارہ کوشش کریں۔';
@@ -4033,8 +3965,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'رکنیت منسوخ کریں؟';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'کیا آپ واقعی اپنی رکنیت منسوخ کرنا چاہتے ہیں؟ آپ اپنی موجودہ بلنگ مدت کے اختتام تک رسائی میں رہیں گے۔';
+  String get cancelSubscriptionConfirmation => 'کیا آپ واقعی اپنی رکنیت منسوخ کرنا چاہتے ہیں؟ آپ اپنی موجودہ بلنگ مدت کے اختتام تک رسائی میں رہیں گے۔';
 
   @override
   String get cancelSubscriptionButton => 'رکنیت منسوخ کریں';
@@ -4043,16 +3974,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get cancelling => 'منسوخ کیا جا رہا ہے...';
 
   @override
-  String get betaTesterMessage =>
-      'آپ اس ایپ کے بیٹا ٹیسٹر ہیں۔ ابھی یہ عوامی نہیں ہے۔ منظوری کے بعد یہ عوامی ہو جائے گی۔';
+  String get betaTesterMessage => 'آپ اس ایپ کے بیٹا ٹیسٹر ہیں۔ ابھی یہ عوامی نہیں ہے۔ منظوری کے بعد یہ عوامی ہو جائے گی۔';
 
   @override
-  String get appUnderReviewMessage =>
-      'آپ کی ایپ جائزہ میں ہے اور صرف آپ کو نظر آتی ہے۔ منظوری کے بعد یہ عوامی ہو جائے گی۔';
+  String get appUnderReviewMessage => 'آپ کی ایپ جائزہ میں ہے اور صرف آپ کو نظر آتی ہے۔ منظوری کے بعد یہ عوامی ہو جائے گی۔';
 
   @override
-  String get appRejectedMessage =>
-      'آپ کی ایپ مسترد کر دی گئی ہے۔ براہ کرم ایپ کی تفصیلات اپ ڈیٹ کریں اور دوبارہ جائزہ کے لیے جمع کریں۔';
+  String get appRejectedMessage => 'آپ کی ایپ مسترد کر دی گئی ہے۔ براہ کرم ایپ کی تفصیلات اپ ڈیٹ کریں اور دوبارہ جائزہ کے لیے جمع کریں۔';
 
   @override
   String get invalidIntegrationUrl => 'غلط انضمام URL';
@@ -4106,8 +4034,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get issueActivatingApp => 'اس ایپ کو فعال کرنے میں مسئلہ ہوا۔ براہ کرم دوبارہ کوشش کریں۔';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'یہ ایپ آپ کے ڈیٹا تک رسائی حاصل کرے گی۔ Omi AI اس بات کے لیے ذمہ دار نہیں کہ آپ کا ڈیٹا اس ایپ نے کیسے استعمال، تبدیل یا حذف کیا ہے';
+  String get dataAccessNoticeDescription => 'یہ ایپ آپ کے ڈیٹا تک رسائی حاصل کرے گی۔ Omi AI اس بات کے لیے ذمہ دار نہیں کہ آپ کا ڈیٹا اس ایپ نے کیسے استعمال، تبدیل یا حذف کیا ہے';
 
   @override
   String get copyUrl => 'URL کاپی کریں';
@@ -4195,8 +4122,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get omiApiKeys => 'Omi API کلیدیں';
 
   @override
-  String get apiKeysDescription =>
-      'API کلیدیں تصدیق کے لیے استعمال ہوتی ہیں جب آپ کی ایپ OMI سرور سے بات کرے۔ یہ آپ کی ایپ کو یادوں بنانے اور دوسری OMI خدمات تک محفوظ طریقے سے رسائی حاصل کرنے دیتی ہے۔';
+  String get apiKeysDescription => 'API کلیدیں تصدیق کے لیے استعمال ہوتی ہیں جب آپ کی ایپ OMI سرور سے بات کرے۔ یہ آپ کی ایپ کو یادوں بنانے اور دوسری OMI خدمات تک محفوظ طریقے سے رسائی حاصل کرنے دیتی ہے۔';
 
   @override
   String get aboutOmiApiKeys => 'Omi API کلیدوں کے بارے میں';
@@ -4220,8 +4146,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get revokeApiKeyQuestion => 'API کلید منسوخ کریں؟';
 
   @override
-  String get revokeApiKeyWarning =>
-      'یہ کارنامہ واپس نہیں ہو سکتا۔ اس کلید کو استعمال کرنے والی کوئی بھی ایپلیکیشنز اب API تک رسائی نہیں کر سکیں گی۔';
+  String get revokeApiKeyWarning => 'یہ کارنامہ واپس نہیں ہو سکتا۔ اس کلید کو استعمال کرنے والی کوئی بھی ایپلیکیشنز اب API تک رسائی نہیں کر سکیں گی۔';
 
   @override
   String get revoke => 'منسوخ کریں';
@@ -4310,8 +4235,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get keyCreated => 'کلید بنائی گئی';
 
   @override
-  String get keyCreatedMessage =>
-      'آپ کی نئی کلید بنا دی گئی ہے۔ براہ کرم اسے اب کاپی کریں۔ آپ اسے دوبارہ نہیں دیکھ سکیں گے۔';
+  String get keyCreatedMessage => 'آپ کی نئی کلید بنا دی گئی ہے۔ براہ کرم اسے اب کاپی کریں۔ آپ اسے دوبارہ نہیں دیکھ سکیں گے۔';
 
   @override
   String get keyWord => 'کلید';
@@ -4320,8 +4244,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get externalAppAccess => 'بیرونی ایپ کی رسائی';
 
   @override
-  String get externalAppAccessDescription =>
-      'مندرجہ ذیل انسٹال شدہ ایپس میں بیرونی انضمام ہے اور آپ کے ڈیٹا تک رسائی حاصل کر سکتے ہیں، جیسے بات چیت اور یادیں۔';
+  String get externalAppAccessDescription => 'مندرجہ ذیل انسٹال شدہ ایپس میں بیرونی انضمام ہے اور آپ کے ڈیٹا تک رسائی حاصل کر سکتے ہیں، جیسے بات چیت اور یادیں۔';
 
   @override
   String get noExternalAppsHaveAccess => 'کوئی بیرونی ایپ آپ کے ڈیٹا تک رسائی نہیں کر سکتی۔';
@@ -4330,8 +4253,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get maximumSecurityE2ee => 'زیادہ سے زیادہ سیکیورٹی (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'اختتام سے اختتام تک مشفر کاری رازداری کا سونے کا معیار ہے۔ جب فعال ہو تو آپ کا ڈیٹا آپ کے ڈیوائس پر مشفر ہو جاتا ہے اس سے پہلے کہ یہ ہماری سرورز پر بھیجا جائے۔ اس کا مطلب یہ ہے کہ کوئی بھی، یہاں تک کہ Omi، آپ کے مواد تک رسائی حاصل نہیں کر سکتا۔';
+  String get e2eeDescription => 'اختتام سے اختتام تک مشفر کاری رازداری کا سونے کا معیار ہے۔ جب فعال ہو تو آپ کا ڈیٹا آپ کے ڈیوائس پر مشفر ہو جاتا ہے اس سے پہلے کہ یہ ہماری سرورز پر بھیجا جائے۔ اس کا مطلب یہ ہے کہ کوئی بھی، یہاں تک کہ Omi، آپ کے مواد تک رسائی حاصل نہیں کر سکتا۔';
 
   @override
   String get importantTradeoffs => 'اہم تبادلے:';
@@ -4365,15 +4287,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get secureEncryption => 'محفوظ مشفر کاری';
 
   @override
-  String get secureEncryptionDescription =>
-      'آپ کا ڈیٹا ہماری سرورز پر آپ کے لیے منفرد کلید کے ساتھ مشفر ہے، Google Cloud پر میزبان ہے۔ اس کا مطلب یہ ہے کہ آپ کا خام مواد ڈیٹا بیس سے براہ راست کسی کے لیے بھی رسائی سے دور ہے، بشمول Omi اسٹاف یا Google۔';
+  String get secureEncryptionDescription => 'آپ کا ڈیٹا ہماری سرورز پر آپ کے لیے منفرد کلید کے ساتھ مشفر ہے، Google Cloud پر میزبان ہے۔ اس کا مطلب یہ ہے کہ آپ کا خام مواد ڈیٹا بیس سے براہ راست کسی کے لیے بھی رسائی سے دور ہے، بشمول Omi اسٹاف یا Google۔';
 
   @override
   String get endToEndEncryption => 'اختتام سے اختتام تک مشفر کاری';
 
   @override
-  String get e2eeCardDescription =>
-      'زیادہ سے زیادہ سیکیورٹی کے لیے فعال کریں جہاں صرف آپ اپنے ڈیٹا تک رسائی حاصل کر سکتے ہوں۔ مزید جاننے کے لیے ٹیپ کریں۔';
+  String get e2eeCardDescription => 'زیادہ سے زیادہ سیکیورٹی کے لیے فعال کریں جہاں صرف آپ اپنے ڈیٹا تک رسائی حاصل کر سکتے ہوں۔ مزید جاننے کے لیے ٹیپ کریں۔';
 
   @override
   String get dataAlwaysEncrypted => 'سطح کے قطع نظر، آپ کا ڈیٹا ہمیشہ باقی اور ترسیل میں مشفر ہوتا ہے۔';
@@ -4444,8 +4364,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get getOmiUnlimitedFree => 'اپنے ڈیٹا کو AI ماڈلز کی تربیت کے لیے شراکت کر کے Omi Unlimited مفت حاصل کریں۔';
 
   @override
-  String get trainingDataBullets =>
-      '• آپ کا ڈیٹا AI ماڈلز کو بہتر بنانے میں مدد کرتا ہے\n• صرف غیر حساس ڈیٹا شیئر کیا جاتا ہے\n• مکمل طور پر شفاف عمل';
+  String get trainingDataBullets => '• آپ کا ڈیٹا AI ماڈلز کو بہتر بنانے میں مدد کرتا ہے\n• صرف غیر حساس ڈیٹا شیئر کیا جاتا ہے\n• مکمل طور پر شفاف عمل';
 
   @override
   String get learnMoreAtOmiTraining => 'omi.me/training پر مزید جانیں';
@@ -4495,8 +4414,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get monthlyPlanContinues => 'آپ کا موجودہ ماہانہ منصوبہ آپ کی بلنگ مدت کے اختتام تک جاری رہے گا';
 
   @override
-  String get paymentMethodCharged =>
-      'آپ کے موجودہ ادائیگی کے طریقے سے خود کار طریقے سے چارج کیا جائے گا جب آپ کا ماہانہ منصوبہ ختم ہوگا';
+  String get paymentMethodCharged => 'آپ کے موجودہ ادائیگی کے طریقے سے خود کار طریقے سے چارج کیا جائے گا جب آپ کا ماہانہ منصوبہ ختم ہوگا';
 
   @override
   String get annualSubscriptionStarts => 'آپ کی 12 ماہ کی سالانہ رکنیت خود کار طریقے سے چارج کے بعد شروع ہوگی';
@@ -4539,8 +4457,7 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get annualPlanStartsAutomatically =>
-      'آپ کی سالانہ رکنیت خود کار طریقے سے شروع ہوگی جب آپ کا ماہانہ منصوبہ ختم ہوگا۔';
+  String get annualPlanStartsAutomatically => 'آپ کی سالانہ رکنیت خود کار طریقے سے شروع ہوگی جب آپ کا ماہانہ منصوبہ ختم ہوگا۔';
 
   @override
   String planRenewsOn(String date) {
@@ -4607,8 +4524,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'آپ کی رازداری ہمارے لیے اہم ہے';
 
   @override
-  String get privacyIntroText =>
-      'Omi میں، ہم آپ کی رازداری کو بہت سنجیدگی سے لیتے ہیں۔ ہم ہماری جمع کردہ ڈیٹا اور اسے آپ کے لیے ہماری پروڈکٹ بہتر بنانے میں کیسے استعمال کرتے ہیں اس کے بارے میں شفاف رہنا چاہتے ہیں۔ یہاں وہ ہے جو آپ کو معلوم ہونے کی ضرورت ہے:';
+  String get privacyIntroText => 'Omi میں، ہم آپ کی رازداری کو بہت سنجیدگی سے لیتے ہیں۔ ہم ہماری جمع کردہ ڈیٹا اور اسے آپ کے لیے ہماری پروڈکٹ بہتر بنانے میں کیسے استعمال کرتے ہیں اس کے بارے میں شفاف رہنا چاہتے ہیں۔ یہاں وہ ہے جو آپ کو معلوم ہونے کی ضرورت ہے:';
 
   @override
   String get whatWeTrack => 'ہم کیا ٹریک کرتے ہیں';
@@ -4623,12 +4539,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get ourCommitment => 'ہماری پابندی';
 
   @override
-  String get commitmentText =>
-      'ہم ہماری جمع کردہ ڈیٹا کو صرف Omi کو آپ کے لیے بہتر پروڈکٹ بنانے کے لیے استعمال کرنے کے لیے پابند ہیں۔ آپ کی رازداری اور اعتماد ہمارے لیے سب سے اہم ہے۔';
+  String get commitmentText => 'ہم ہماری جمع کردہ ڈیٹا کو صرف Omi کو آپ کے لیے بہتر پروڈکٹ بنانے کے لیے استعمال کرنے کے لیے پابند ہیں۔ آپ کی رازداری اور اعتماد ہمارے لیے سب سے اہم ہے۔';
 
   @override
-  String get thankYouText =>
-      'Omi کے قدری صارف ہونے کے لیے آپ کا شکریہ۔ اگر آپ کے کوئی سوالات یا خدشات ہیں تو براہ کرم ہم سے رابطہ کریں team@basedhardware.com۔';
+  String get thankYouText => 'Omi کے قدری صارف ہونے کے لیے آپ کا شکریہ۔ اگر آپ کے کوئی سوالات یا خدشات ہیں تو براہ کرم ہم سے رابطہ کریں team@basedhardware.com۔';
 
   @override
   String get wifiSyncSettings => 'WiFi سنک کی ترتیبات';
@@ -4637,8 +4551,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get enterHotspotCredentials => 'اپنے فون کے ہاٹ اسپاٹ کی شناخت درج کریں';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'WiFi سنک آپ کے فون کو ہاٹ اسپاٹ کے طور پر استعمال کرتا ہے۔ ترتیبات میں اپنے ہاٹ اسپاٹ کا نام اور پاس ورڈ تلاش کریں > ذاتی ہاٹ اسپاٹ۔';
+  String get wifiSyncUsesHotspot => 'WiFi سنک آپ کے فون کو ہاٹ اسپاٹ کے طور پر استعمال کرتا ہے۔ ترتیبات میں اپنے ہاٹ اسپاٹ کا نام اور پاس ورڈ تلاش کریں > ذاتی ہاٹ اسپاٹ۔';
 
   @override
   String get hotspotNameSsid => 'ہاٹ اسپاٹ کا نام (SSID)';
@@ -4673,8 +4586,7 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'خلاصہ تیار کرنے میں ناکام۔ یقینی بنائیں کہ آپ کے پاس اس دن کی گفتگو ہے۔';
+  String get failedToGenerateSummaryCheckConversations => 'خلاصہ تیار کرنے میں ناکام۔ یقینی بنائیں کہ آپ کے پاس اس دن کی گفتگو ہے۔';
 
   @override
   String get summaryNotFound => 'خلاصہ نہیں ملا';
@@ -4704,8 +4616,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'برآمدگی شروع ہو گئی۔ اس میں کچھ سیکنڈ لگ سکتے ہیں...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'اس سے تمام اخذ شدہ علم کے گراف ڈیٹا (نوڈس اور کنکشنز) حذف ہوں گے۔ آپ کی اصل یادیں محفوظ رہیں گی۔ گراف وقت کے ساتھ یا اگلی درخواست پر دوبارہ بنایا جائے گا۔';
+  String get knowledgeGraphDeleteDescription => 'اس سے تمام اخذ شدہ علم کے گراف ڈیٹا (نوڈس اور کنکشنز) حذف ہوں گے۔ آپ کی اصل یادیں محفوظ رہیں گی۔ گراف وقت کے ساتھ یا اگلی درخواست پر دوبارہ بنایا جائے گا۔';
 
   @override
   String get configureDailySummaryDigest => 'اپنے روزانہ کام کی چیزوں کا خلاصہ ترتیب دیں';
@@ -4775,8 +4686,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'تمام Limitless کی گفتگو حذف کریں؟';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'اس سے Limitless سے درآمد شدہ تمام گفتگو مستقل طور پر حذف ہوں گی۔ یہ عمل واپس نہیں کیا جا سکتا۔';
+  String get deleteAllLimitlessWarning => 'اس سے Limitless سے درآمد شدہ تمام گفتگو مستقل طور پر حذف ہوں گی۔ یہ عمل واپس نہیں کیا جا سکتا۔';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4832,8 +4742,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get howItWorksTitle => 'یہ کیسے کام کرتا ہے؟';
 
   @override
-  String get howPeopleWorks =>
-      'ایک بار جب کوئی شخص بنایا جاتا ہے تو آپ کسی گفتگو کے ٹرانسکرپٹ پر جا سکتے ہیں اور انہیں ان کے متعلقہ حصے تفویض کر سکتے ہیں، اس طریقے سے Omi ان کی بھی تشخیص کرنے کے قابل ہوگا!';
+  String get howPeopleWorks => 'ایک بار جب کوئی شخص بنایا جاتا ہے تو آپ کسی گفتگو کے ٹرانسکرپٹ پر جا سکتے ہیں اور انہیں ان کے متعلقہ حصے تفویض کر سکتے ہیں، اس طریقے سے Omi ان کی بھی تشخیص کرنے کے قابل ہوگا!';
 
   @override
   String get tapToDelete => 'حذف کرنے کے لیے ٹیپ کریں';
@@ -4859,8 +4768,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get privacyNotice => 'رازداری کی نوٹس';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'ریکارڈنگز دوسروں کی آوازیں پکڑ سکتی ہیں۔ فعال کرنے سے پہلے تمام شرکاء سے رضامندی یقینی بنائیں۔';
+  String get recordingsMayCaptureOthers => 'ریکارڈنگز دوسروں کی آوازیں پکڑ سکتی ہیں۔ فعال کرنے سے پہلے تمام شرکاء سے رضامندی یقینی بنائیں۔';
 
   @override
   String get enable => 'فعال کریں';
@@ -4872,8 +4780,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get on => 'آن';
 
   @override
-  String get storeAudioDescription =>
-      'تمام آڈیو ریکارڈنگز اپنے فون پر مقامی طور پر محفوظ رکھیں۔ جب غیر فعال ہو تو اسٹوریج کی جگہ بچانے کے لیے صرف ناکام اپ لوڈز رکھے جاتے ہیں۔';
+  String get storeAudioDescription => 'تمام آڈیو ریکارڈنگز اپنے فون پر مقامی طور پر محفوظ رکھیں۔ جب غیر فعال ہو تو اسٹوریج کی جگہ بچانے کے لیے صرف ناکام اپ لوڈز رکھے جاتے ہیں۔';
 
   @override
   String get enableLocalStorage => 'مقامی اسٹوریج فعال کریں';
@@ -4891,12 +4798,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get storeAudioOnCloud => 'کلاؤڈ پر آڈیو محفوظ کریں';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'آپ کی حقیقی وقت کی ریکارڈنگز جیسے جیسے آپ بولتے ہیں نجی کلاؤڈ اسٹوریج میں محفوظ کی جائیں گی۔';
+  String get cloudStorageDialogMessage => 'آپ کی حقیقی وقت کی ریکارڈنگز جیسے جیسے آپ بولتے ہیں نجی کلاؤڈ اسٹوریج میں محفوظ کی جائیں گی۔';
 
   @override
-  String get storeAudioCloudDescription =>
-      'اپنی حقیقی وقت کی ریکارڈنگز نجی کلاؤڈ اسٹوریج میں محفوظ کریں جیسے جیسے آپ بولتے ہیں۔ آڈیو حقیقی وقت میں محفوظ طریقے سے پکڑی اور محفوظ کی جاتی ہے۔';
+  String get storeAudioCloudDescription => 'اپنی حقیقی وقت کی ریکارڈنگز نجی کلاؤڈ اسٹوریج میں محفوظ کریں جیسے جیسے آپ بولتے ہیں۔ آڈیو حقیقی وقت میں محفوظ طریقے سے پکڑی اور محفوظ کی جاتی ہے۔';
 
   @override
   String get downloadingFirmware => 'فرم وئیئر ڈاؤن لوڈ کیا جا رہا ہے';
@@ -4949,8 +4854,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get payments => 'ادائیگیاں';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'اپنی ایپس کے لیے ادائیگیاں وصول کرنا شروع کرنے کے لیے نیچے ادائیگی کا طریقہ منسلک کریں۔';
+  String get connectPaymentMethodInfo => 'اپنی ایپس کے لیے ادائیگیاں وصول کرنا شروع کرنے کے لیے نیچے ادائیگی کا طریقہ منسلک کریں۔';
 
   @override
   String get selectedPaymentMethod => 'منتخب ادائیگی کا طریقہ';
@@ -4977,8 +4881,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get monthlyPayouts => 'ماہانہ ادائیگیاں';
 
   @override
-  String get monthlyPayoutsDescription =>
-      'جب آپ \$10 کی کمائی حاصل کریں تو براہ راست اپنے اکاؤنٹ میں ماہانہ ادائیگیاں وصول کریں';
+  String get monthlyPayoutsDescription => 'جب آپ \$10 کی کمائی حاصل کریں تو براہ راست اپنے اکاؤنٹ میں ماہانہ ادائیگیاں وصول کریں';
 
   @override
   String get secureAndReliable => 'محفوظ اور قابل اعتماد';
@@ -5005,8 +4908,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get connectingYourStripeAccount => 'اپنے Stripe اکاؤنٹ کو منسلک کیا جا رہا ہے';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'براہ کرم اپنے براؤزر میں Stripe آن بورڈنگ عمل مکمل کریں۔ یہ صفحہ مکمل ہونے کے بعد خود کار طریقے سے اپڈیٹ ہوگا۔';
+  String get stripeOnboardingInstructions => 'براہ کرم اپنے براؤزر میں Stripe آن بورڈنگ عمل مکمل کریں۔ یہ صفحہ مکمل ہونے کے بعد خود کار طریقے سے اپڈیٹ ہوگا۔';
 
   @override
   String get failedTryAgain => 'ناکام؟ دوبارہ کوشش کریں';
@@ -5018,8 +4920,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get successfullyConnected => 'کامیابی سے منسلک!';
 
   @override
-  String get stripeReadyForPayments =>
-      'آپ کا Stripe اکاؤنٹ اب ادائیگیاں وصول کرنے کے لیے تیار ہے۔ آپ اپنی ایپ کی فروخت سے فوری ہی کمانا شروع کر سکتے ہیں۔';
+  String get stripeReadyForPayments => 'آپ کا Stripe اکاؤنٹ اب ادائیگیاں وصول کرنے کے لیے تیار ہے۔ آپ اپنی ایپ کی فروخت سے فوری ہی کمانا شروع کر سکتے ہیں۔';
 
   @override
   String get updateStripeDetails => 'Stripe کی تفصیلات اپڈیٹ کریں';
@@ -5046,8 +4947,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get paypalMeLink => 'PayPal.me لنک';
 
   @override
-  String get stripeRecommendation =>
-      'اگر Stripe آپ کے ملک میں دستیاب ہے تو ہم تیزی اور آسان ادائیگیوں کے لیے اسے استعمال کرنے کی سفارش کرتے ہیں۔';
+  String get stripeRecommendation => 'اگر Stripe آپ کے ملک میں دستیاب ہے تو ہم تیزی اور آسان ادائیگیوں کے لیے اسے استعمال کرنے کی سفارش کرتے ہیں۔';
 
   @override
   String get updatePayPalDetails => 'PayPal کی تفصیلات اپڈیٹ کریں';
@@ -5099,12 +4999,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'اضافی صوتی نمونہ ہٹایا گیا';
 
   @override
-  String get consentDataMessage =>
-      'جاری رکھ کر، آپ کی بات چیت، ریکارڈنگز اور ذاتی معلومات ہمارے سرورز پر محفوظ طریقے سے ذخیرہ کی جائیں گی۔ آپ کی آڈیو ریکارڈنگز اور ٹرانسکرپٹس تھرڈ پارٹی AI سروسز کے ذریعے پراسیس کی جاتی ہیں (بشمول ٹرانسکرپشن کے لیے Deepgram اور تجزیے کے لیے OpenAI) تاکہ آپ کو AI سے چلنے والی بصیرتیں فراہم کی جا سکیں اور ایپ کی تمام خصوصیات کو فعال کیا جا سکے۔';
+  String get consentDataMessage => 'جاری رکھ کر، آپ کی بات چیت، ریکارڈنگز اور ذاتی معلومات ہمارے سرورز پر محفوظ طریقے سے ذخیرہ کی جائیں گی۔ آپ کی آڈیو ریکارڈنگز اور ٹرانسکرپٹس تھرڈ پارٹی AI سروسز کے ذریعے پراسیس کی جاتی ہیں (بشمول ٹرانسکرپشن کے لیے Deepgram اور تجزیے کے لیے OpenAI) تاکہ آپ کو AI سے چلنے والی بصیرتیں فراہم کی جا سکیں اور ایپ کی تمام خصوصیات کو فعال کیا جا سکے۔';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'آپ کی گفتگو سے کام کی چیزیں یہاں ظاہر ہوں گی۔\n+ ٹیپ کریں دستی طور پر ایک بنانے کے لیے۔';
+  String get tasksEmptyStateMessage => 'آپ کی گفتگو سے کام کی چیزیں یہاں ظاہر ہوں گی۔\n+ ٹیپ کریں دستی طور پر ایک بنانے کے لیے۔';
 
   @override
   String get clearChatAction => 'بات کو صاف کریں';
@@ -5140,15 +5038,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Omi کو اپنے\nApple Watch پر انسٹال کریں';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Omi کے ساتھ اپنے Apple Watch کو استعمال کرنے کے لیے آپ کو پہلے اپنی گھڑی پر Omi ایپ انسٹال کرنی ہوگی۔';
+  String get installOmiOnAppleWatchDescription => 'Omi کے ساتھ اپنے Apple Watch کو استعمال کرنے کے لیے آپ کو پہلے اپنی گھڑی پر Omi ایپ انسٹال کرنی ہوگی۔';
 
   @override
   String get openOmiOnAppleWatch => 'Omi کو اپنے\nApple Watch پر کھولیں';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Omi ایپ آپ کی Apple Watch پر انسٹال ہے۔ اسے کھولیں اور شروع کرنے کے لیے شروع ٹیپ کریں۔';
+  String get openOmiOnAppleWatchDescription => 'Omi ایپ آپ کی Apple Watch پر انسٹال ہے۔ اسے کھولیں اور شروع کرنے کے لیے شروع ٹیپ کریں۔';
 
   @override
   String get openWatchApp => 'گھڑی کی ایپ کھولیں';
@@ -5157,15 +5053,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'میں نے ایپ انسٹال اور کھول دی';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Apple Watch کی ایپ نہیں کھول سکتے۔ براہ کرم اپنے Apple Watch پر Watch ایپ کو دستی طور پر کھولیں اور \"دستیاب ایپس\" حصے سے Omi انسٹال کریں۔';
+  String get unableToOpenWatchApp => 'Apple Watch کی ایپ نہیں کھول سکتے۔ براہ کرم اپنے Apple Watch پر Watch ایپ کو دستی طور پر کھولیں اور \"دستیاب ایپس\" حصے سے Omi انسٹال کریں۔';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Apple Watch کامیابی سے منسلک!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Apple Watch ابھی تک قابل رسائی نہیں۔ براہ کرم یقینی بنائیں کہ Omi ایپ آپ کی گھڑی پر کھلی ہے۔';
+  String get appleWatchNotReachable => 'Apple Watch ابھی تک قابل رسائی نہیں۔ براہ کرم یقینی بنائیں کہ Omi ایپ آپ کی گھڑی پر کھلی ہے۔';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5593,8 +5487,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get multipleSpeakersDetected => 'متعدد اسپیکرز شناخت کیے گئے';
 
   @override
-  String get multipleSpeakersDescription =>
-      'ایسا لگتا ہے کہ ریکارڈنگ میں متعدد اسپیکرز ہیں۔ براہ کرم یقینی بنائیں کہ آپ خاموش جگہ میں ہیں اور دوبارہ کوشش کریں۔';
+  String get multipleSpeakersDescription => 'ایسا لگتا ہے کہ ریکارڈنگ میں متعدد اسپیکرز ہیں۔ براہ کرم یقینی بنائیں کہ آپ خاموش جگہ میں ہیں اور دوبارہ کوشش کریں۔';
 
   @override
   String get invalidRecordingDetected => 'غلط ریکارڈنگ شناخت کی گئی';
@@ -5606,15 +5499,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get speechDurationDescription => 'براہ کرم یقینی بنائیں کہ آپ کم از کم 5 سیکنڈ اور 90 سے زیادہ نہ بولیں۔';
 
   @override
-  String get connectionLostDescription =>
-      'کنکشن میں خلل پڑا۔ براہ کرم اپنی انٹرنیٹ کنکشن کی جانچ کریں اور دوبارہ کوشش کریں۔';
+  String get connectionLostDescription => 'کنکشن میں خلل پڑا۔ براہ کرم اپنی انٹرنیٹ کنکشن کی جانچ کریں اور دوبارہ کوشش کریں۔';
 
   @override
   String get howToTakeGoodSample => 'اچھا نمونہ کیسے لیں؟';
 
   @override
-  String get goodSampleInstructions =>
-      '1. یقینی بنائیں کہ آپ کسی خاموش جگہ میں ہیں۔\n2. واضح طور سے اور قدرتی انداز میں بولیں۔\n3. یقینی بنائیں کہ آپ کا ڈیوائس اپنی قدرتی پوزیشن میں، آپ کی گردن پر ہے۔\n\nایک بار بننے کے بعد، آپ اسے ہمیشہ بہتر بنا سکتے ہیں یا دوبارہ کر سکتے ہیں۔';
+  String get goodSampleInstructions => '1. یقینی بنائیں کہ آپ کسی خاموش جگہ میں ہیں۔\n2. واضح طور سے اور قدرتی انداز میں بولیں۔\n3. یقینی بنائیں کہ آپ کا ڈیوائس اپنی قدرتی پوزیشن میں، آپ کی گردن پر ہے۔\n\nایک بار بننے کے بعد، آپ اسے ہمیشہ بہتر بنا سکتے ہیں یا دوبارہ کر سکتے ہیں۔';
 
   @override
   String get noDeviceConnectedUseMic => 'کوئی ڈیوائس متصل نہیں۔ فون مائیکروفون استعمال کیا جائے گا۔';
@@ -5677,12 +5568,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get howItWorks => 'یہ کیسے کام کرتا ہے';
 
   @override
-  String get dailyScoreExplanation =>
-      'آپ کا روزانہ سکور کام مکمل کرنے پر مبنی ہے۔ اپنا سکور بہتر بنانے کے لیے اپنے کام مکمل کریں!';
+  String get dailyScoreExplanation => 'آپ کا روزانہ سکور کام مکمل کرنے پر مبنی ہے۔ اپنا سکور بہتر بنانے کے لیے اپنے کام مکمل کریں!';
 
   @override
-  String get notificationFrequencyDescription =>
-      'یہ کنٹرول کریں کہ Omi آپ کو کتنی بار فعال طریقے سے مطلع کرتا ہے اور یاد دہانی دیتا ہے۔';
+  String get notificationFrequencyDescription => 'یہ کنٹرول کریں کہ Omi آپ کو کتنی بار فعال طریقے سے مطلع کرتا ہے اور یاد دہانی دیتا ہے۔';
 
   @override
   String get sliderOff => 'بند';
@@ -5855,8 +5744,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get wifiEnableFailed => 'ڈیوائس پر WiFi فعال کرنے میں ناکام۔ براہ کرم دوبارہ کوشش کریں۔';
 
   @override
-  String get deviceNoFastTransfer =>
-      'آپ کے ڈیوائس میں تیز رفتار منتقلی کی سہولت نہیں ہے۔ اس کی بجائے Bluetooth استعمال کریں۔';
+  String get deviceNoFastTransfer => 'آپ کے ڈیوائس میں تیز رفتار منتقلی کی سہولت نہیں ہے۔ اس کی بجائے Bluetooth استعمال کریں۔';
 
   @override
   String get enableHotspotMessage => 'براہ کرم اپنے فون کا ہاٹ سپاٹ فعال کریں اور دوبارہ کوشش کریں۔';
@@ -5928,8 +5816,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get recordings => 'ریکارڈنگز';
 
   @override
-  String get enableRemindersAccess =>
-      'Apple Reminders استعمال کرنے کے لیے براہ کرم سیٹنگز میں Reminders رسائی فعال کریں';
+  String get enableRemindersAccess => 'Apple Reminders استعمال کرنے کے لیے براہ کرم سیٹنگز میں Reminders رسائی فعال کریں';
 
   @override
   String todayAtTime(String time) {
@@ -5984,8 +5871,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get webhookUrlNotSet => 'ویب ہک URL سیٹ نہیں ہے';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'براہ کرم اس خصوصیت کو استعمال کرنے کے لیے ڈیولپر سیٹنگز میں ویب ہک URL سیٹ کریں۔';
+  String get setWebhookUrlInSettings => 'براہ کرم اس خصوصیت کو استعمال کرنے کے لیے ڈیولپر سیٹنگز میں ویب ہک URL سیٹ کریں۔';
 
   @override
   String get sendWebUrl => 'ویب URL بھیجیں';
@@ -6065,8 +5951,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get viewUsage => 'استعمال دیکھیں';
 
   @override
-  String get localProcessingInfo =>
-      'آڈیو مقامی طور پر پروسیس کیا جاتا ہے۔ آف لائن کام کرتا ہے، زیادہ نجی، لیکن زیادہ بیٹری استعمال کرتا ہے۔';
+  String get localProcessingInfo => 'آڈیو مقامی طور پر پروسیس کیا جاتا ہے۔ آف لائن کام کرتا ہے، زیادہ نجی، لیکن زیادہ بیٹری استعمال کرتا ہے۔';
 
   @override
   String get model => 'ماڈل';
@@ -6075,15 +5960,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get performanceWarning => 'کارکردگی انتباہ';
 
   @override
-  String get largeModelWarning =>
-      'یہ ماڈل بڑا ہے اور موبائل ڈیوائسز پر ایپ کو کریش کر سکتا ہے یا بہت سست چل سکتا ہے۔\n\n\"small\" یا \"base\" کی سفارش کی جاتی ہے۔';
+  String get largeModelWarning => 'یہ ماڈل بڑا ہے اور موبائل ڈیوائسز پر ایپ کو کریش کر سکتا ہے یا بہت سست چل سکتا ہے۔\n\n\"small\" یا \"base\" کی سفارش کی جاتی ہے۔';
 
   @override
   String get usingNativeIosSpeech => 'Native iOS Speech Recognition استعمال کیا جا رہا ہے';
 
   @override
-  String get noModelDownloadRequired =>
-      'آپ کے ڈیوائس کے native speech engine کا استعمال کیا جائے گا۔ کوئی ماڈل ڈاؤن لوڈ درکار نہیں۔';
+  String get noModelDownloadRequired => 'آپ کے ڈیوائس کے native speech engine کا استعمال کیا جائے گا۔ کوئی ماڈل ڈاؤن لوڈ درکار نہیں۔';
 
   @override
   String get modelReady => 'ماڈل تیار ہے';
@@ -6143,8 +6026,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get premiumMinutesMonth => 'ماہانہ 1,200 پریمیم منٹ۔ On-Device ٹیب غیر محدود مفت ٹرانسکریپشن فراہم کرتا ہے۔ ';
 
   @override
-  String get audioProcessedLocally =>
-      'آڈیو مقامی طور پر پروسیس کیا جاتا ہے۔ آف لائن کام کرتا ہے، زیادہ نجی، لیکن زیادہ بیٹری استعمال کرتا ہے۔';
+  String get audioProcessedLocally => 'آڈیو مقامی طور پر پروسیس کیا جاتا ہے۔ آف لائن کام کرتا ہے، زیادہ نجی، لیکن زیادہ بیٹری استعمال کرتا ہے۔';
 
   @override
   String get languageLabel => 'زبان';
@@ -6153,12 +6035,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get modelLabel => 'ماڈل';
 
   @override
-  String get modelTooLargeWarning =>
-      'یہ ماڈل بڑا ہے اور موبائل ڈیوائسز پر ایپ کو کریش کر سکتا ہے یا بہت سست چل سکتا ہے۔\n\n\"small\" یا \"base\" کی سفارش کی جاتی ہے۔';
+  String get modelTooLargeWarning => 'یہ ماڈل بڑا ہے اور موبائل ڈیوائسز پر ایپ کو کریش کر سکتا ہے یا بہت سست چل سکتا ہے۔\n\n\"small\" یا \"base\" کی سفارش کی جاتی ہے۔';
 
   @override
-  String get nativeEngineNoDownload =>
-      'آپ کے ڈیوائس کے native speech engine کا استعمال کیا جائے گا۔ کوئی ماڈل ڈاؤن لوڈ درکار نہیں۔';
+  String get nativeEngineNoDownload => 'آپ کے ڈیوائس کے native speech engine کا استعمال کیا جائے گا۔ کوئی ماڈل ڈاؤن لوڈ درکار نہیں۔';
 
   @override
   String modelReadyWithName(String model) {
@@ -6194,8 +6074,7 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Omi کا built-in لائیو ٹرانسکریپشن خودکار speaker detection اور diarization کے ساتھ real-time بات چیت کے لیے بہتر بنایا گیا ہے۔';
+  String get omiTranscriptionOptimized => 'Omi کا built-in لائیو ٹرانسکریپشن خودکار speaker detection اور diarization کے ساتھ real-time بات چیت کے لیے بہتر بنایا گیا ہے۔';
 
   @override
   String get reset => 'دوبارہ سیٹ کریں';
@@ -6415,8 +6294,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'یادوں سے آپ کا knowledge graph بنایا جا رہا ہے...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'جیسے ہی آپ نئی یادیں بنائیں گے آپ کا knowledge graph خود بخود بنایا جائے گا۔';
+  String get knowledgeGraphWillBuildAutomatically => 'جیسے ہی آپ نئی یادیں بنائیں گے آپ کا knowledge graph خود بخود بنایا جائے گا۔';
 
   @override
   String get buildGraphButton => 'گراف بنائیں';
@@ -6652,8 +6530,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get failedToLoadContacts => 'رابطے لوڈ کرنے میں ناکام';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'شیئرنگ کے لیے بات چیت کی تیاری میں ناکام۔ براہ کرم دوبارہ کوشش کریں۔';
+  String get failedToPrepareConversationForSharing => 'شیئرنگ کے لیے بات چیت کی تیاری میں ناکام۔ براہ کرم دوبارہ کوشش کریں۔';
 
   @override
   String get couldNotOpenSmsApp => 'SMS ایپ نہیں کھول سکا۔ براہ کرم دوبارہ کوشش کریں۔';
@@ -6719,8 +6596,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'آپ کے ڈیوائس کے SD کارڈ سے آڈیو ڈاؤن لوڈ کیا جا رہا ہے';
 
   @override
-  String get transferRequiredDescription =>
-      'یہ ریکارڈنگ آپ کے ڈیوائس کے SD کارڈ پر محفوظ ہے۔ اسے اپنے فون میں منتقل کریں تاکہ اسے چلا سکیں یا شیئر کر سکیں۔';
+  String get transferRequiredDescription => 'یہ ریکارڈنگ آپ کے ڈیوائس کے SD کارڈ پر محفوظ ہے۔ اسے اپنے فون میں منتقل کریں تاکہ اسے چلا سکیں یا شیئر کر سکیں۔';
 
   @override
   String get cancelTransfer => 'منتقلی منسوخ کریں';
@@ -6741,8 +6617,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get shareRecording => 'ریکارڈنگ شیئر کریں';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'کیا آپ یقینی ہیں کہ آپ یہ ریکارڈنگ مستقل طور پر ڈیلیٹ کرنا چاہتے ہیں؟ یہ واپس نہیں کیا جا سکتا۔';
+  String get deleteRecordingConfirmation => 'کیا آپ یقینی ہیں کہ آپ یہ ریکارڈنگ مستقل طور پر ڈیلیٹ کرنا چاہتے ہیں؟ یہ واپس نہیں کیا جا سکتا۔';
 
   @override
   String get recordingIdLabel => 'ریکارڈنگ ID';
@@ -6801,15 +6676,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get enableFastTransfer => 'Fast Transfer فعال کریں';
 
   @override
-  String get fastTransferDescription =>
-      'Fast Transfer WiFi استعمال کرتے ہوئے تقریباً 5 گنا تیز رفتار ہے۔ ٹرانسفر کے دوران آپ کا فون عارضی طور پر آپ کے Omi ڈیوائس کے WiFi نیٹ ورک سے منسلک ہوگا۔';
+  String get fastTransferDescription => 'Fast Transfer WiFi استعمال کرتے ہوئے تقریباً 5 گنا تیز رفتار ہے۔ ٹرانسفر کے دوران آپ کا فون عارضی طور پر آپ کے Omi ڈیوائس کے WiFi نیٹ ورک سے منسلک ہوگا۔';
 
   @override
   String get internetAccessPausedDuringTransfer => 'ٹرانسفر کے دوران انٹرنیٹ رسائی موقوف ہے';
 
   @override
-  String get chooseTransferMethodDescription =>
-      'آپ کے Omi ڈیوائس سے آپ کے فون تک ریکارڈنگز کو منتقل کرنے کا طریقہ منتخب کریں۔';
+  String get chooseTransferMethodDescription => 'آپ کے Omi ڈیوائس سے آپ کے فون تک ریکارڈنگز کو منتقل کرنے کا طریقہ منتخب کریں۔';
 
   @override
   String get wifiSpeed => 'WiFi کے ذریعے ~150 KB/s';
@@ -6818,8 +6691,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get fiveTimesFaster => '5 گنا تیز رفتار';
 
   @override
-  String get fastTransferMethodDescription =>
-      'آپ کے Omi ڈیوائس کے ساتھ براہ راست WiFi کنکشن بناتا ہے۔ ٹرانسفر کے دوران آپ کا فون عارضی طور پر آپ کے معمول کے WiFi سے منقطع ہوتا ہے۔';
+  String get fastTransferMethodDescription => 'آپ کے Omi ڈیوائس کے ساتھ براہ راست WiFi کنکشن بناتا ہے۔ ٹرانسفر کے دوران آپ کا فون عارضی طور پر آپ کے معمول کے WiFi سے منقطع ہوتا ہے۔';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6828,8 +6700,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get bleSpeed => 'BLE کے ذریعے ~30 KB/s';
 
   @override
-  String get bluetoothMethodDescription =>
-      'معیاری Bluetooth Low Energy کنکشن استعمال کرتا ہے۔ سست ہے لیکن آپ کے WiFi کنکشن کو متاثر نہیں کرتا۔';
+  String get bluetoothMethodDescription => 'معیاری Bluetooth Low Energy کنکشن استعمال کرتا ہے۔ سست ہے لیکن آپ کے WiFi کنکشن کو متاثر نہیں کرتا۔';
 
   @override
   String get selected => 'منتخب';
@@ -6867,12 +6738,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get appDeleteFailed => 'ایپ حذف کرنے میں ناکام۔ براہ کرم بعد میں دوبارہ کوشش کریں۔';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'ایپ کی نمائندگی کامیابی سے تبدیل کر دی گئی۔ اس میں کچھ منٹ لگ سکتے ہیں۔';
+  String get appVisibilityChangedSuccessfully => 'ایپ کی نمائندگی کامیابی سے تبدیل کر دی گئی۔ اس میں کچھ منٹ لگ سکتے ہیں۔';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'ایپ کو فعال کرنے میں خرابی۔ اگر یہ انضمام ایپ ہے، تو اس بات کو یقینی بنائیں کہ سیٹ اپ مکمل ہو گیا ہے۔';
+  String get errorActivatingAppIntegration => 'ایپ کو فعال کرنے میں خرابی۔ اگر یہ انضمام ایپ ہے، تو اس بات کو یقینی بنائیں کہ سیٹ اپ مکمل ہو گیا ہے۔';
 
   @override
   String get errorUpdatingAppStatus => 'ایپ کی حالت کو اپڈیٹ کرتے ہوئے ایک خرابی واقع ہوئی۔';
@@ -6940,8 +6809,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get importantConversationTitle => 'اہم بات چیت';
 
   @override
-  String get importantConversationBody =>
-      'آپ نے ابھی اہم بات چیت کی۔ دوسروں کے ساتھ خلاصہ شیئر کرنے کے لیے تھپتھپائیں۔';
+  String get importantConversationBody => 'آپ نے ابھی اہم بات چیت کی۔ دوسروں کے ساتھ خلاصہ شیئر کرنے کے لیے تھپتھپائیں۔';
 
   @override
   String get templateName => 'ٹیمپلیٹ کا نام';
@@ -7035,8 +6903,7 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get addAppPhotosPermissionDenied =>
-      'فوٹوز کی اجازت مسترد کر دی گئی۔ براہ کرم تصویر منتخب کرنے کے لیے فوٹوز تک رسائی کی اجازت دیں';
+  String get addAppPhotosPermissionDenied => 'فوٹوز کی اجازت مسترد کر دی گئی۔ براہ کرم تصویر منتخب کرنے کے لیے فوٹوز تک رسائی کی اجازت دیں';
 
   @override
   String get addAppErrorSelectingImageRetry => 'تصویر منتخب کرنے میں خرابی۔ براہ کرم دوبارہ کوشش کریں۔';
@@ -7059,8 +6926,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get paymentFailedToFetchCountries => 'معاون ممالک حاصل کرنے میں ناکام۔ براہ کرم بعد میں دوبارہ کوشش کریں۔';
 
   @override
-  String get paymentFailedToSetDefault =>
-      'ڈیفالٹ ادائیگی کا طریقہ سیٹ کرنے میں ناکام۔ براہ کرم بعد میں دوبارہ کوشش کریں۔';
+  String get paymentFailedToSetDefault => 'ڈیفالٹ ادائیگی کا طریقہ سیٹ کرنے میں ناکام۔ براہ کرم بعد میں دوبارہ کوشش کریں۔';
 
   @override
   String get paymentFailedToSavePaypal => 'PayPal تفصیلات محفوظ کرنے میں ناکام۔ براہ کرم بعد میں دوبارہ کوشش کریں۔';
@@ -7142,15 +7008,13 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'اپ گریڈ شیڈول کیا گیا! آپ کا ماہانہ منصوبہ آپ کی بلنگ مدت کے آخر تک جاری رہتا ہے، پھر خودکار طریقے سے سالانہ میں تبدیل ہو جاتا ہے۔';
+  String get planUpgradeScheduledMessage => 'اپ گریڈ شیڈول کیا گیا! آپ کا ماہانہ منصوبہ آپ کی بلنگ مدت کے آخر تک جاری رہتا ہے، پھر خودکار طریقے سے سالانہ میں تبدیل ہو جاتا ہے۔';
 
   @override
   String get couldNotSchedulePlanChange => 'منصوبے کی تبدیلی شیڈول نہیں کی جا سکی۔ براہ کرم دوبارہ کوشش کریں۔';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'آپ کی رکنیت دوبارہ فعال کر دی گئی ہے! ابھی کوئی خرچ نہیں - آپ کو اپنی موجودہ مدت کے آخر میں بل دیا جائے گا۔';
+  String get subscriptionReactivatedDefault => 'آپ کی رکنیت دوبارہ فعال کر دی گئی ہے! ابھی کوئی خرچ نہیں - آپ کو اپنی موجودہ مدت کے آخر میں بل دیا جائے گا۔';
 
   @override
   String get subscriptionSuccessfulCharged => 'سبسکرپشن کامیاب! آپ سے نئی بلنگ مدت کے لیے چارج کیا گیا ہے۔';
@@ -7333,8 +7197,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get onboardingBluetoothRequired => 'آپ کے ڈیوائس سے منسلک ہونے کے لیے Bluetooth اجازت ضروری ہے۔';
 
   @override
-  String get onboardingBluetoothDeniedSystemPrefs =>
-      'Bluetooth اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات میں اجازت دیں۔';
+  String get onboardingBluetoothDeniedSystemPrefs => 'Bluetooth اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات میں اجازت دیں۔';
 
   @override
   String onboardingBluetoothStatusCheckPrefs(String status) {
@@ -7347,12 +7210,10 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'اطلاع اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات میں اجازت دیں۔';
+  String get onboardingNotificationDeniedSystemPrefs => 'اطلاع اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات میں اجازت دیں۔';
 
   @override
-  String get onboardingNotificationDeniedNotifications =>
-      'اطلاع اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات > اطلاعات میں اجازت دیں۔';
+  String get onboardingNotificationDeniedNotifications => 'اطلاع اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات > اطلاعات میں اجازت دیں۔';
 
   @override
   String onboardingNotificationStatusCheckPrefs(String status) {
@@ -7365,15 +7226,13 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get onboardingLocationGrantInSettings =>
-      'براہ کرم ترتیبات > رازداری اور سیکیورٹی > مقام کی خدمات میں مقام کی اجازت دیں';
+  String get onboardingLocationGrantInSettings => 'براہ کرم ترتیبات > رازداری اور سیکیورٹی > مقام کی خدمات میں مقام کی اجازت دیں';
 
   @override
   String get onboardingMicrophoneRequired => 'ریکارڈنگ کے لیے مائیکروفون اجازت ضروری ہے۔';
 
   @override
-  String get onboardingMicrophoneDenied =>
-      'مائیکروفون اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات > رازداری اور سیکیورٹی > مائیکروفون میں اجازت دیں۔';
+  String get onboardingMicrophoneDenied => 'مائیکروفون اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات > رازداری اور سیکیورٹی > مائیکروفون میں اجازت دیں۔';
 
   @override
   String onboardingMicrophoneStatusCheckPrefs(String status) {
@@ -7389,8 +7248,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get onboardingScreenCaptureRequired => 'سسٹم آڈیو ریکارڈنگ کے لیے اسکرین کیپچر اجازت ضروری ہے۔';
 
   @override
-  String get onboardingScreenCaptureDenied =>
-      'اسکرین کیپچر اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات > رازداری اور سیکیورٹی > اسکرین ریکارڈنگ میں اجازت دیں۔';
+  String get onboardingScreenCaptureDenied => 'اسکرین کیپچر اجازت مسترد کر دی گئی۔ براہ کرم سسٹم ترجیحات > رازداری اور سیکیورٹی > اسکرین ریکارڈنگ میں اجازت دیں۔';
 
   @override
   String onboardingScreenCaptureStatusCheckPrefs(String status) {
@@ -7443,8 +7301,7 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get msgPhotosPermissionDenied =>
-      'فوٹوز کی اجازت مسترد کر دی گئی۔ براہ کرم تصاویر منتخب کرنے کے لیے فوٹوز تک رسائی کی اجازت دیں';
+  String get msgPhotosPermissionDenied => 'فوٹوز کی اجازت مسترد کر دی گئی۔ براہ کرم تصاویر منتخب کرنے کے لیے فوٹوز تک رسائی کی اجازت دیں';
 
   @override
   String get msgSelectImagesGenericError => 'تصاویر منتخب کرنے میں خرابی۔ براہ کرم دوبارہ کوشش کریں۔';
@@ -7516,8 +7373,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get locationPermissionRequired => 'مقام کی اجازت ضروری ہے';
 
   @override
-  String get locationPermissionContent =>
-      'Fast Transfer کو WiFi کنکشن کی تصدیق کے لیے مقام کی اجازت ضروری ہے۔ براہ کرم جاری رکھنے کے لیے مقام کی اجازت دیں۔';
+  String get locationPermissionContent => 'Fast Transfer کو WiFi کنکشن کی تصدیق کے لیے مقام کی اجازت ضروری ہے۔ براہ کرم جاری رکھنے کے لیے مقام کی اجازت دیں۔';
 
   @override
   String get pdfTranscriptExport => 'ٹرانسکرپٹ برآمد';
@@ -7680,8 +7536,7 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get deviceDoesNotSupportWifiSwitchingToBle =>
-      'ڈیوائس WiFi ہم آہنگی کو سپورٹ نہیں کرتا، Bluetooth پر سوئچ کیا جا رہا ہے';
+  String get deviceDoesNotSupportWifiSwitchingToBle => 'ڈیوائس WiFi ہم آہنگی کو سپورٹ نہیں کرتا، Bluetooth پر سوئچ کیا جا رہا ہے';
 
   @override
   String get appleHealthNotAvailable => 'Apple Health اس ڈیوائس پر دستیاب نہیں ہے';
@@ -7977,8 +7832,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Omi DevKit کو جوڑنے کی حالت میں رکھیں';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'چلانے کے لیے بٹن کو ایک بار دبائیں۔ جوڑنے کی حالت میں LED بنفشی رنگ میں جھلکے گی۔';
+  String get pairingDescOmiDevkit => 'چلانے کے لیے بٹن کو ایک بار دبائیں۔ جوڑنے کی حالت میں LED بنفشی رنگ میں جھلکے گی۔';
 
   @override
   String get pairingTitleOmiGlass => 'Omi Glass کو چلائیں';
@@ -7990,8 +7844,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Plaud Note کو جوڑنے کی حالت میں رکھیں';
 
   @override
-  String get pairingDescPlaudNote =>
-      'سائیڈ بٹن کو 2 سیکنڈ کے لیے دبائے رکھیں۔ جوڑنے کے لیے تیار ہونے پر سرخ LED جھلکے گی۔';
+  String get pairingDescPlaudNote => 'سائیڈ بٹن کو 2 سیکنڈ کے لیے دبائے رکھیں۔ جوڑنے کے لیے تیار ہونے پر سرخ LED جھلکے گی۔';
 
   @override
   String get pairingTitleBee => 'Bee کو جوڑنے کی حالت میں رکھیں';
@@ -8003,15 +7856,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get pairingTitleLimitless => 'Limitless کو جوڑنے کی حالت میں رکھیں';
 
   @override
-  String get pairingDescLimitless =>
-      'جب کوئی روشنی نظر آئے تو ایک بار دبائیں اور پھر دبائے رکھیں جب تک ڈیوائس گلابی روشنی نہ دکھائے، پھر چھوڑیں۔';
+  String get pairingDescLimitless => 'جب کوئی روشنی نظر آئے تو ایک بار دبائیں اور پھر دبائے رکھیں جب تک ڈیوائس گلابی روشنی نہ دکھائے، پھر چھوڑیں۔';
 
   @override
   String get pairingTitleFriendPendant => 'Friend Pendant کو جوڑنے کی حالت میں رکھیں';
 
   @override
-  String get pairingDescFriendPendant =>
-      'لاکیٹ پر بٹن دبائیں تاکہ یہ چلے۔ یہ خودکار طور پر جوڑنے کی حالت میں داخل ہوگا۔';
+  String get pairingDescFriendPendant => 'لاکیٹ پر بٹن دبائیں تاکہ یہ چلے۔ یہ خودکار طور پر جوڑنے کی حالت میں داخل ہوگا۔';
 
   @override
   String get pairingTitleFieldy => 'Fieldy کو جوڑنے کی حالت میں رکھیں';
@@ -8023,8 +7874,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Apple Watch کو منسلک کریں';
 
   @override
-  String get pairingDescAppleWatch =>
-      'اپنی Apple Watch پر Omi ایپ کو انسٹال اور کھولیں، پھر ایپ میں Connect کو ٹیپ کریں۔';
+  String get pairingDescAppleWatch => 'اپنی Apple Watch پر Omi ایپ کو انسٹال اور کھولیں، پھر ایپ میں Connect کو ٹیپ کریں۔';
 
   @override
   String get pairingTitleNeoOne => 'Neo One کو جوڑنے کی حالت میں رکھیں';
@@ -8147,8 +7997,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get switchAndRestart => 'سوئچ';
 
   @override
-  String get stagingDisclaimer =>
-      'اسٹیجنگ خرابیوں سے بھرپور ہو سکتی ہے، غیر مستقل کارکردگی رکھتی ہے، اور ڈیٹا کھو سکتا ہے۔ صرف ٹیسٹنگ کے لیے استعمال کریں۔';
+  String get stagingDisclaimer => 'اسٹیجنگ خرابیوں سے بھرپور ہو سکتی ہے، غیر مستقل کارکردگی رکھتی ہے، اور ڈیٹا کھو سکتا ہے۔ صرف ٹیسٹنگ کے لیے استعمال کریں۔';
 
   @override
   String get apiEnvSavedRestartRequired => 'محفوظ ہو گیا۔ لاگو کرنے کے لیے ایپ کو بند اور دوبارہ کھولیں۔';
@@ -8377,8 +8226,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Omi کے ذریعے فون کالیں';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Omi کے ذریعے کالیں کریں اور حقیقی وقت میں نسخہ، خودکار خلاصے، اور بہت کچھ حاصل کریں۔ صرف غیر محدود منصوبے کے صارفین کے لیے دستیاب۔';
+  String get phoneCallsUpsellSubtitle => 'Omi کے ذریعے کالیں کریں اور حقیقی وقت میں نسخہ، خودکار خلاصے، اور بہت کچھ حاصل کریں۔ صرف غیر محدود منصوبے کے صارفین کے لیے دستیاب۔';
 
   @override
   String get phoneCallsUpsellFeature1 => 'ہر کال کی حقیقی وقت میں نقل';
@@ -8405,8 +8253,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deleteSyncedFiles => 'ہم آہنگ ریکارڈنگز حذف کریں';
 
   @override
-  String get deleteSyncedFilesMessage =>
-      'یہ ریکارڈنگز پہلے سے آپ کے فون میں ہم آہنگ ہو چکی ہیں۔ یہ تبدیل نہیں ہو سکتا۔';
+  String get deleteSyncedFilesMessage => 'یہ ریکارڈنگز پہلے سے آپ کے فون میں ہم آہنگ ہو چکی ہیں۔ یہ تبدیل نہیں ہو سکتا۔';
 
   @override
   String get syncedFilesDeleted => 'ہم آہنگ ریکارڈنگز حذف ہو گئیں';
@@ -8418,8 +8265,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deletePendingFiles => 'زیرِ التوا ریکارڈنگز حذف کریں';
 
   @override
-  String get deletePendingFilesWarning =>
-      'یہ ریکارڈنگز آپ کے فون میں ہم آہنگ نہیں ہوئیں اور ہمیشہ کے لیے ضائع ہوں گی۔ یہ تبدیل نہیں ہو سکتا۔';
+  String get deletePendingFilesWarning => 'یہ ریکارڈنگز آپ کے فون میں ہم آہنگ نہیں ہوئیں اور ہمیشہ کے لیے ضائع ہوں گی۔ یہ تبدیل نہیں ہو سکتا۔';
 
   @override
   String get pendingFilesDeleted => 'زیرِ التوا ریکارڈنگز حذف ہو گئیں';
@@ -8431,8 +8277,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deleteAll => 'سب حذف کریں';
 
   @override
-  String get deleteAllFilesWarning =>
-      'یہ ہم آہنگ اور زیرِ التوا دونوں ریکارڈنگز حذف کرے گا۔ زیرِ التوا ریکارڈنگز ہم آہنگ نہیں ہوئیں اور ہمیشہ کے لیے ضائع ہوں گی۔ یہ تبدیل نہیں ہو سکتا۔';
+  String get deleteAllFilesWarning => 'یہ ہم آہنگ اور زیرِ التوا دونوں ریکارڈنگز حذف کرے گا۔ زیرِ التوا ریکارڈنگز ہم آہنگ نہیں ہوئیں اور ہمیشہ کے لیے ضائع ہوں گی۔ یہ تبدیل نہیں ہو سکتا۔';
 
   @override
   String get allFilesDeleted => 'تمام ریکارڈنگز حذف ہو گئیں';
@@ -8497,8 +8342,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get fairUseAboutTitle => 'منصفانہ استعمال کے بارے میں';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi ذاتی بات چیت، میٹنگ، اور براہ راست بات چیت کے لیے ڈیزائن کیا گیا ہے۔ استعمال کو حقیقی تقریر کے وقت سے ماپا جاتا ہے، منسلکی کے وقت سے نہیں۔ اگر استعمال ذاتی غیر مواد کے لیے عام نمونوں کو نمایاں طور پر تجاوز کرے، تو ایڈجسٹمنٹ لاگو ہو سکتے ہیں۔';
+  String get fairUseAboutBody => 'Omi ذاتی بات چیت، میٹنگ، اور براہ راست بات چیت کے لیے ڈیزائن کیا گیا ہے۔ استعمال کو حقیقی تقریر کے وقت سے ماپا جاتا ہے، منسلکی کے وقت سے نہیں۔ اگر استعمال ذاتی غیر مواد کے لیے عام نمونوں کو نمایاں طور پر تجاوز کرے، تو ایڈجسٹمنٹ لاگو ہو سکتے ہیں۔';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8536,8 +8380,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get improveConnectionTitle => 'منسلکی بہتر بنائیں';
 
   @override
-  String get improveConnectionContent =>
-      'ہم نے بہتر بنایا ہے کہ Omi آپ کے ڈیوائس سے کیسے منسلک رہتا ہے۔ اس کو فعال کرنے کے لیے، براہ کرم ڈیوائس معلومات کے صفحے پر جائیں، \"ڈیوائس کو ڈسکنیکٹ کریں\" کو ٹیپ کریں، اور پھر اپنے ڈیوائس کو دوبارہ جوڑیں۔';
+  String get improveConnectionContent => 'ہم نے بہتر بنایا ہے کہ Omi آپ کے ڈیوائس سے کیسے منسلک رہتا ہے۔ اس کو فعال کرنے کے لیے، براہ کرم ڈیوائس معلومات کے صفحے پر جائیں، \"ڈیوائس کو ڈسکنیکٹ کریں\" کو ٹیپ کریں، اور پھر اپنے ڈیوائس کو دوبارہ جوڑیں۔';
 
   @override
   String get improveConnectionAction => 'سمجھ گئے';
@@ -8592,16 +8435,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get cancelSyncQuestion => 'ہم آہنگی منسوخ کریں؟';
 
   @override
-  String get omisStorageDesc =>
-      'جب آپ کا Omi آپ کے فون سے منسلک نہ ہو، تو یہ آڈیو کو اپنی بنی ہوئی میموری میں مقامی طور پر محفوظ کرتا ہے۔ آپ کبھی بھی ریکارڈنگ نہیں کھوتے۔';
+  String get omisStorageDesc => 'جب آپ کا Omi آپ کے فون سے منسلک نہ ہو، تو یہ آڈیو کو اپنی بنی ہوئی میموری میں مقامی طور پر محفوظ کرتا ہے۔ آپ کبھی بھی ریکارڈنگ نہیں کھوتے۔';
 
   @override
-  String get phoneStorageDesc =>
-      'جب Omi دوبارہ منسلک ہوتا ہے، تو ریکارڈنگز خودکار طور پر آپ کے فون میں منتقل ہوتی ہیں اپ لوڈ کرنے سے پہلے ایک عارضی رکھنے والے علاقے کے طور پر۔';
+  String get phoneStorageDesc => 'جب Omi دوبارہ منسلک ہوتا ہے، تو ریکارڈنگز خودکار طور پر آپ کے فون میں منتقل ہوتی ہیں اپ لوڈ کرنے سے پہلے ایک عارضی رکھنے والے علاقے کے طور پر۔';
 
   @override
-  String get cloudStorageDesc =>
-      'اپ لوڈ ہونے کے بعد، آپ کی ریکارڈنگز پروسیس اور نقل ہوتی ہیں۔ بات چیت ایک منٹ میں دستیاب ہوں گی۔';
+  String get cloudStorageDesc => 'اپ لوڈ ہونے کے بعد، آپ کی ریکارڈنگز پروسیس اور نقل ہوتی ہیں۔ بات چیت ایک منٹ میں دستیاب ہوں گی۔';
 
   @override
   String get tipKeepPhoneNearby => 'تیز ہم آہنگی کے لیے اپنے فون کو قریب رکھیں';
@@ -8625,12 +8465,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get permissionEnable => 'فعال کریں';
 
   @override
-  String get permissionsPageDescription =>
-      'یہ اجازتیں Omi کے کام کرنے کے لیے اہم ہیں۔ وہ اطلاعات، مقام پر مبنی تجربات، اور آڈیو کی تفتیش جیسی اہم خصوصیات کو فعال کرتی ہیں۔';
+  String get permissionsPageDescription => 'یہ اجازتیں Omi کے کام کرنے کے لیے اہم ہیں۔ وہ اطلاعات، مقام پر مبنی تجربات، اور آڈیو کی تفتیش جیسی اہم خصوصیات کو فعال کرتی ہیں۔';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi کو صحیح طریقے سے کام کرنے کے لیے کچھ اجازتوں کی ضرورت ہے۔ براہ کرم جاری رکھنے کے لیے انہیں منظور کریں۔';
+  String get permissionsRequiredDescription => 'Omi کو صحیح طریقے سے کام کرنے کے لیے کچھ اجازتوں کی ضرورت ہے۔ براہ کرم جاری رکھنے کے لیے انہیں منظور کریں۔';
 
   @override
   String get permissionsSetupTitle => 'بہترین تجربہ حاصل کریں';
@@ -8684,8 +8522,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get justAMoment => 'برائے کرم ایک لمحہ انتظار کریں';
 
   @override
-  String get cancelConsequencesSubtitle =>
-      'ہم منسوخ کرنے کی بجائے اپنی دوسری اختیارات کی تلاش کرنے کی سختی سے سفارش کرتے ہیں۔';
+  String get cancelConsequencesSubtitle => 'ہم منسوخ کرنے کی بجائے اپنی دوسری اختیارات کی تلاش کرنے کی سختی سے سفارش کرتے ہیں۔';
 
   @override
   String cancelBillingPeriodInfo(String date) {
@@ -8908,8 +8745,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get firmwareWarningTitle => 'اہم: اپ ڈیٹ سے پہلے پڑھیں';
 
   @override
-  String get firmwareFormatWarning =>
-      'یہ فرم ویئر SD کارڈ کو فارمیٹ کرے گا۔ براہ کرم اپ گریڈ کرنے سے پہلے یقینی بنائیں کہ تمام آف لائن ڈیٹا مطابقت پذیر ہو چکا ہے۔\n\nاگر اس ورژن کو انسٹال کرنے کے بعد سرخ روشنی چمکتی نظر آئے تو پریشان نہ ہوں۔ بس آلے کو ایپ سے جوڑیں اور یہ نیلا ہو جانا چاہیے۔ سرخ روشنی کا مطلب ہے کہ آلے کی گھڑی ابھی تک مطابقت پذیر نہیں ہوئی۔';
+  String get firmwareFormatWarning => 'یہ فرم ویئر SD کارڈ کو فارمیٹ کرے گا۔ براہ کرم اپ گریڈ کرنے سے پہلے یقینی بنائیں کہ تمام آف لائن ڈیٹا مطابقت پذیر ہو چکا ہے۔\n\nاگر اس ورژن کو انسٹال کرنے کے بعد سرخ روشنی چمکتی نظر آئے تو پریشان نہ ہوں۔ بس آلے کو ایپ سے جوڑیں اور یہ نیلا ہو جانا چاہیے۔ سرخ روشنی کا مطلب ہے کہ آلے کی گھڑی ابھی تک مطابقت پذیر نہیں ہوئی۔';
 
   @override
   String get continueAnyway => 'جاری رکھیں';
@@ -8929,8 +8765,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get tasksMarkComplete => 'مکمل کے طور پر نشان زد';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi، Apple کے HealthKit فریم ورک کے ذریعے Apple Health تک رسائی حاصل کرتا ہے۔ آپ کسی بھی وقت iOS کی ترتیبات سے رسائی منسوخ کر سکتے ہیں۔';
+  String get appleHealthManageNote => 'Omi، Apple کے HealthKit فریم ورک کے ذریعے Apple Health تک رسائی حاصل کرتا ہے۔ آپ کسی بھی وقت iOS کی ترتیبات سے رسائی منسوخ کر سکتے ہیں۔';
 
   @override
   String get appleHealthConnectCta => 'Apple Health سے منسلک کریں';
@@ -8951,22 +8786,19 @@ class AppLocalizationsUr extends AppLocalizations {
   String get appleHealthFeatureReadOnlyTitle => 'صرف پڑھنے کی رسائی';
 
   @override
-  String get appleHealthFeatureReadOnlyDesc =>
-      'Omi کبھی Apple Health میں نہیں لکھتا اور نہ ہی آپ کا ڈیٹا تبدیل کرتا ہے۔';
+  String get appleHealthFeatureReadOnlyDesc => 'Omi کبھی Apple Health میں نہیں لکھتا اور نہ ہی آپ کا ڈیٹا تبدیل کرتا ہے۔';
 
   @override
   String get appleHealthFeatureSecureTitle => 'محفوظ ہم وقت سازی';
 
   @override
-  String get appleHealthFeatureSecureDesc =>
-      'آپ کا Apple Health ڈیٹا نجی طور پر آپ کے Omi اکاؤنٹ کے ساتھ ہم وقت ہوتا ہے۔';
+  String get appleHealthFeatureSecureDesc => 'آپ کا Apple Health ڈیٹا نجی طور پر آپ کے Omi اکاؤنٹ کے ساتھ ہم وقت ہوتا ہے۔';
 
   @override
   String get appleHealthDeniedTitle => 'Apple Health تک رسائی مسترد';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi کو آپ کا Apple Health ڈیٹا پڑھنے کی اجازت نہیں ہے۔ اسے iOS ترتیبات ← پرائیویسی اور سیکیورٹی ← Health ← Omi میں فعال کریں۔';
+  String get appleHealthDeniedBody => 'Omi کو آپ کا Apple Health ڈیٹا پڑھنے کی اجازت نہیں ہے۔ اسے iOS ترتیبات ← پرائیویسی اور سیکیورٹی ← Health ← Omi میں فعال کریں۔';
 
   @override
   String get deleteFlowReasonTitle => 'آپ کیوں جا رہے ہیں؟';
@@ -9035,8 +8867,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get planUpdate => 'پلان اپ ڈیٹ';
 
   @override
-  String get planDeprecationMessage =>
-      'آپ کا Unlimited پلان ختم کیا جا رہا ہے۔ Operator پلان پر سوئچ کریں — وہی شاندار فیچرز \$49/ماہ پر۔ آپ کا موجودہ پلان اس دوران کام کرتا رہے گا۔';
+  String get planDeprecationMessage => 'آپ کا Unlimited پلان ختم کیا جا رہا ہے۔ Operator پلان پر سوئچ کریں — وہی شاندار فیچرز \$49/ماہ پر۔ آپ کا موجودہ پلان اس دوران کام کرتا رہے گا۔';
 
   @override
   String get upgradeYourPlan => 'اپنا پلان اپ گریڈ کریں';
@@ -9147,8 +8978,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'آپ اپنی ماہانہ حد تک پہنچ گئے ہیں۔ بغیر کسی پابندی کے Omi کے ساتھ چیٹ جاری رکھنے کے لیے اپ گریڈ کریں۔';
+  String get chatQuotaExceededReply => 'آپ اپنی ماہانہ حد تک پہنچ گئے ہیں۔ بغیر کسی پابندی کے Omi کے ساتھ چیٹ جاری رکھنے کے لیے اپ گریڈ کریں۔';
 
   @override
   String get voiceResponseAudio => 'Omi کا جواب بلند آواز میں پڑھیں';
@@ -9179,4 +9009,25 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'کام شامل کریں';
+
+  @override
+  String get quickActionAskOmiAnything => 'Omi سے کچھ بھی پوچھیں';
+
+  @override
+  String get quickActionVoiceMode => 'آواز موڈ';
+
+  @override
+  String get quickActionMute => 'خاموش کریں';
+
+  @override
+  String get quickActionUnmute => 'آواز بحال کریں';
+
+  @override
+  String get quickActionConnectDevice => 'ڈیوائس منسلک کریں';
+
+  @override
+  String get quickActionDeviceSettings => 'ڈیوائس کی ترتیبات';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -24,8 +24,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deleteConversationTitle => 'Xóa cuộc trò chuyện?';
 
   @override
-  String get deleteConversationMessage =>
-      'Thao tác này cũng sẽ xóa các kỷ niệm, nhiệm vụ và tệp âm thanh liên quan. Hành động này không thể hoàn tác.';
+  String get deleteConversationMessage => 'Thao tác này cũng sẽ xóa các kỷ niệm, nhiệm vụ và tệp âm thanh liên quan. Hành động này không thể hoàn tác.';
 
   @override
   String get confirm => 'Xác nhận';
@@ -146,8 +145,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deleting => 'Đang xóa...';
 
   @override
-  String get pleaseCompleteAuthentication =>
-      'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
+  String get pleaseCompleteAuthentication => 'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
 
   @override
   String get failedToStartAuthentication => 'Không thể bắt đầu xác thực';
@@ -228,8 +226,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get noStarredConversations => 'Không có cuộc trò chuyện đã gắn sao';
 
   @override
-  String get starConversationHint =>
-      'Để gắn sao cuộc trò chuyện, hãy mở nó và nhấn vào biểu tượng ngôi sao ở phần đầu.';
+  String get starConversationHint => 'Để gắn sao cuộc trò chuyện, hãy mở nó và nhấn vào biểu tượng ngôi sao ở phần đầu.';
 
   @override
   String get searchConversations => 'Tìm kiếm cuộc trò chuyện...';
@@ -356,19 +353,16 @@ class AppLocalizationsVi extends AppLocalizations {
   String get appsDisconnected => 'Các ứng dụng và tích hợp của bạn sẽ bị ngắt kết nối ngay lập tức.';
 
   @override
-  String get exportBeforeDelete =>
-      'Bạn có thể xuất dữ liệu trước khi xóa tài khoản, nhưng một khi đã xóa, dữ liệu không thể khôi phục.';
+  String get exportBeforeDelete => 'Bạn có thể xuất dữ liệu trước khi xóa tài khoản, nhưng một khi đã xóa, dữ liệu không thể khôi phục.';
 
   @override
-  String get deleteAccountCheckbox =>
-      'Tôi hiểu rằng việc xóa tài khoản là vĩnh viễn và tất cả dữ liệu, bao gồm ký ức và cuộc trò chuyện, sẽ bị mất và không thể khôi phục.';
+  String get deleteAccountCheckbox => 'Tôi hiểu rằng việc xóa tài khoản là vĩnh viễn và tất cả dữ liệu, bao gồm ký ức và cuộc trò chuyện, sẽ bị mất và không thể khôi phục.';
 
   @override
   String get areYouSure => 'Bạn có chắc chắn?';
 
   @override
-  String get deleteAccountFinal =>
-      'Hành động này không thể hoàn tác và sẽ xóa vĩnh viễn tài khoản cùng tất cả dữ liệu liên quan. Bạn có chắc chắn muốn tiếp tục?';
+  String get deleteAccountFinal => 'Hành động này không thể hoàn tác và sẽ xóa vĩnh viễn tài khoản cùng tất cả dữ liệu liên quan. Bạn có chắc chắn muốn tiếp tục?';
 
   @override
   String get deleteNow => 'Xóa ngay';
@@ -377,8 +371,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get goBack => 'Quay lại';
 
   @override
-  String get checkBoxToConfirm =>
-      'Đánh dấu vào ô để xác nhận bạn hiểu rằng việc xóa tài khoản là vĩnh viễn và không thể hoàn tác.';
+  String get checkBoxToConfirm => 'Đánh dấu vào ô để xác nhận bạn hiểu rằng việc xóa tài khoản là vĩnh viễn và không thể hoàn tác.';
 
   @override
   String get profile => 'Hồ sơ';
@@ -456,8 +449,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get yourPrivacyYourControl => 'Quyền riêng tư của bạn, Quyền kiểm soát của bạn';
 
   @override
-  String get privacyIntro =>
-      'Tại Omi, chúng tôi cam kết bảo vệ quyền riêng tư của bạn. Trang này cho phép bạn kiểm soát cách dữ liệu của bạn được lưu trữ và sử dụng.';
+  String get privacyIntro => 'Tại Omi, chúng tôi cam kết bảo vệ quyền riêng tư của bạn. Trang này cho phép bạn kiểm soát cách dữ liệu của bạn được lưu trữ và sử dụng.';
 
   @override
   String get learnMore => 'Tìm hiểu thêm...';
@@ -466,19 +458,16 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dataProtectionLevel => 'Mức độ bảo vệ dữ liệu';
 
   @override
-  String get dataProtectionDesc =>
-      'Dữ liệu của bạn được bảo mật mặc định với mã hóa mạnh. Xem lại cài đặt và các tùy chọn bảo mật trong tương lai bên dưới.';
+  String get dataProtectionDesc => 'Dữ liệu của bạn được bảo mật mặc định với mã hóa mạnh. Xem lại cài đặt và các tùy chọn bảo mật trong tương lai bên dưới.';
 
   @override
   String get appAccess => 'Quyền truy cập ứng dụng';
 
   @override
-  String get appAccessDesc =>
-      'Các ứng dụng sau có thể truy cập dữ liệu của bạn. Nhấn vào ứng dụng để quản lý quyền của nó.';
+  String get appAccessDesc => 'Các ứng dụng sau có thể truy cập dữ liệu của bạn. Nhấn vào ứng dụng để quản lý quyền của nó.';
 
   @override
-  String get noAppsExternalAccess =>
-      'Không có ứng dụng đã cài đặt nào có quyền truy cập bên ngoài vào dữ liệu của bạn.';
+  String get noAppsExternalAccess => 'Không có ứng dụng đã cài đặt nào có quyền truy cập bên ngoài vào dữ liệu của bạn.';
 
   @override
   String get deviceName => 'Tên thiết bị';
@@ -532,15 +521,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deviceDisconnectedMessage => 'Omi của bạn đã bị ngắt kết nối 😔';
 
   @override
-  String get deviceUnpairedMessage =>
-      'Đã hủy ghép nối thiết bị. Đi tới Cài đặt > Bluetooth và quên thiết bị để hoàn tất việc hủy ghép nối.';
+  String get deviceUnpairedMessage => 'Đã hủy ghép nối thiết bị. Đi tới Cài đặt > Bluetooth và quên thiết bị để hoàn tất việc hủy ghép nối.';
 
   @override
   String get unpairDialogTitle => 'Hủy ghép nối thiết bị';
 
   @override
-  String get unpairDialogMessage =>
-      'Thao tác này sẽ hủy ghép nối thiết bị để có thể kết nối với điện thoại khác. Bạn cần vào Cài đặt > Bluetooth và xóa thiết bị để hoàn tất quá trình.';
+  String get unpairDialogMessage => 'Thao tác này sẽ hủy ghép nối thiết bị để có thể kết nối với điện thoại khác. Bạn cần vào Cài đặt > Bluetooth và xóa thiết bị để hoàn tất quá trình.';
 
   @override
   String get deviceNotConnected => 'Thiết bị chưa kết nối';
@@ -561,8 +548,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get v2Undetected => 'Không phát hiện V2';
 
   @override
-  String get v2UndetectedMessage =>
-      'Chúng tôi thấy rằng bạn có thiết bị V1 hoặc thiết bị của bạn chưa được kết nối. Chức năng thẻ SD chỉ khả dụng cho thiết bị V2.';
+  String get v2UndetectedMessage => 'Chúng tôi thấy rằng bạn có thiết bị V1 hoặc thiết bị của bạn chưa được kết nối. Chức năng thẻ SD chỉ khả dụng cho thiết bị V2.';
 
   @override
   String get endConversation => 'Kết thúc cuộc trò chuyện';
@@ -694,8 +680,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get noActivityYet => 'Chưa có hoạt động';
 
   @override
-  String get startConversationToSeeInsights =>
-      'Bắt đầu cuộc trò chuyện với Omi\nđể xem thông tin chi tiết về mức sử dụng của bạn tại đây.';
+  String get startConversationToSeeInsights => 'Bắt đầu cuộc trò chuyện với Omi\nđể xem thông tin chi tiết về mức sử dụng của bạn tại đây.';
 
   @override
   String get listening => 'Lắng nghe';
@@ -837,8 +822,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deleteKnowledgeGraphTitle => 'Xóa biểu đồ tri thức?';
 
   @override
-  String get deleteKnowledgeGraphMessage =>
-      'Thao tác này sẽ xóa tất cả dữ liệu biểu đồ tri thức được tạo ra (nút và kết nối). Ký ức gốc của bạn sẽ vẫn an toàn. Biểu đồ sẽ được xây dựng lại theo thời gian hoặc khi có yêu cầu tiếp theo.';
+  String get deleteKnowledgeGraphMessage => 'Thao tác này sẽ xóa tất cả dữ liệu biểu đồ tri thức được tạo ra (nút và kết nối). Ký ức gốc của bạn sẽ vẫn an toàn. Biểu đồ sẽ được xây dựng lại theo thời gian hoặc khi có yêu cầu tiếp theo.';
 
   @override
   String get knowledgeGraphDeleted => 'Đã xóa đồ thị kiến thức';
@@ -1021,8 +1005,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get integrationsFooter => 'Kết nối ứng dụng của bạn để xem dữ liệu và số liệu trong trò chuyện.';
 
   @override
-  String get completeAuthInBrowser =>
-      'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
+  String get completeAuthInBrowser => 'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
 
   @override
   String failedToStartAuth(String appName) {
@@ -1082,8 +1065,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get needYourPermission => 'Chúng tôi cần sự cho phép của bạn';
 
   @override
-  String get alreadyGavePermission =>
-      'Bạn đã cho phép chúng tôi lưu bản ghi âm của bạn. Đây là lời nhắc nhở về lý do chúng tôi cần:';
+  String get alreadyGavePermission => 'Bạn đã cho phép chúng tôi lưu bản ghi âm của bạn. Đây là lời nhắc nhở về lý do chúng tôi cần:';
 
   @override
   String get wouldLikePermission => 'Chúng tôi muốn được phép lưu bản ghi âm giọng nói của bạn. Đây là lý do:';
@@ -1092,26 +1074,22 @@ class AppLocalizationsVi extends AppLocalizations {
   String get improveSpeechProfile => 'Cải thiện hồ sơ giọng nói của bạn';
 
   @override
-  String get improveSpeechProfileDesc =>
-      'Chúng tôi sử dụng bản ghi âm để huấn luyện và nâng cao hồ sơ giọng nói cá nhân của bạn.';
+  String get improveSpeechProfileDesc => 'Chúng tôi sử dụng bản ghi âm để huấn luyện và nâng cao hồ sơ giọng nói cá nhân của bạn.';
 
   @override
   String get trainFamilyProfiles => 'Huấn luyện hồ sơ cho bạn bè và gia đình';
 
   @override
-  String get trainFamilyProfilesDesc =>
-      'Bản ghi âm của bạn giúp chúng tôi nhận dạng và tạo hồ sơ cho bạn bè và gia đình của bạn.';
+  String get trainFamilyProfilesDesc => 'Bản ghi âm của bạn giúp chúng tôi nhận dạng và tạo hồ sơ cho bạn bè và gia đình của bạn.';
 
   @override
   String get enhanceTranscriptAccuracy => 'Tăng độ chính xác bản ghi';
 
   @override
-  String get enhanceTranscriptAccuracyDesc =>
-      'Khi mô hình của chúng tôi được cải thiện, chúng tôi có thể cung cấp kết quả phiên âm tốt hơn cho bản ghi âm của bạn.';
+  String get enhanceTranscriptAccuracyDesc => 'Khi mô hình của chúng tôi được cải thiện, chúng tôi có thể cung cấp kết quả phiên âm tốt hơn cho bản ghi âm của bạn.';
 
   @override
-  String get legalNotice =>
-      'Thông báo pháp lý: Tính hợp pháp của việc ghi âm và lưu trữ dữ liệu giọng nói có thể khác nhau tùy thuộc vào vị trí của bạn và cách bạn sử dụng tính năng này. Bạn có trách nhiệm đảm bảo tuân thủ luật pháp và quy định địa phương.';
+  String get legalNotice => 'Thông báo pháp lý: Tính hợp pháp của việc ghi âm và lưu trữ dữ liệu giọng nói có thể khác nhau tùy thuộc vào vị trí của bạn và cách bạn sử dụng tính năng này. Bạn có trách nhiệm đảm bảo tuân thủ luật pháp và quy định địa phương.';
 
   @override
   String get alreadyAuthorized => 'Đã cho phép';
@@ -1183,15 +1161,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get showMeetingsMenuBar => 'Hiển thị cuộc họp sắp tới trên thanh menu';
 
   @override
-  String get showMeetingsMenuBarDesc =>
-      'Hiển thị cuộc họp tiếp theo và thời gian cho đến khi nó bắt đầu trên thanh menu macOS';
+  String get showMeetingsMenuBarDesc => 'Hiển thị cuộc họp tiếp theo và thời gian cho đến khi nó bắt đầu trên thanh menu macOS';
 
   @override
   String get showEventsNoParticipants => 'Hiển thị sự kiện không có người tham gia';
 
   @override
-  String get showEventsNoParticipantsDesc =>
-      'Khi được bật, Coming Up hiển thị các sự kiện không có người tham gia hoặc liên kết video.';
+  String get showEventsNoParticipantsDesc => 'Khi được bật, Coming Up hiển thị các sự kiện không có người tham gia hoặc liên kết video.';
 
   @override
   String get yourMeetings => 'Cuộc họp của bạn';
@@ -1276,12 +1252,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get tellUsPrimaryLanguage => 'Cho chúng tôi biết ngôn ngữ chính của bạn';
 
   @override
-  String get languageForTranscription =>
-      'Đặt ngôn ngữ của bạn để có phiên âm chính xác hơn và trải nghiệm được cá nhân hóa.';
+  String get languageForTranscription => 'Đặt ngôn ngữ của bạn để có phiên âm chính xác hơn và trải nghiệm được cá nhân hóa.';
 
   @override
-  String get singleLanguageModeInfo =>
-      'Chế độ đơn ngôn ngữ đã được bật. Dịch bị vô hiệu hóa để có độ chính xác cao hơn.';
+  String get singleLanguageModeInfo => 'Chế độ đơn ngôn ngữ đã được bật. Dịch bị vô hiệu hóa để có độ chính xác cao hơn.';
 
   @override
   String get searchLanguageHint => 'Tìm kiếm ngôn ngữ theo tên hoặc mã';
@@ -1361,8 +1335,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get defaultRepository => 'Kho lưu trữ mặc định';
 
   @override
-  String get selectDefaultRepoDesc =>
-      'Chọn một kho lưu trữ mặc định để tạo issue. Bạn vẫn có thể chỉ định kho lưu trữ khác khi tạo issue.';
+  String get selectDefaultRepoDesc => 'Chọn một kho lưu trữ mặc định để tạo issue. Bạn vẫn có thể chỉ định kho lưu trữ khác khi tạo issue.';
 
   @override
   String get noReposFound => 'Không tìm thấy kho lưu trữ';
@@ -1409,8 +1382,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get configureSettings => 'Cấu hình cài đặt';
 
   @override
-  String get completeAuthBrowser =>
-      'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
+  String get completeAuthBrowser => 'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
 
   @override
   String failedToStartAppAuth(String appName) {
@@ -1738,8 +1710,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get enableBluetooth => 'Bật Bluetooth';
 
   @override
-  String get bluetoothNeeded =>
-      'Omi cần Bluetooth để kết nối với thiết bị đeo của bạn. Vui lòng bật Bluetooth và thử lại.';
+  String get bluetoothNeeded => 'Omi cần Bluetooth để kết nối với thiết bị đeo của bạn. Vui lòng bật Bluetooth và thử lại.';
 
   @override
   String get contactSupport => 'Liên hệ hỗ trợ?';
@@ -1772,26 +1743,22 @@ class AppLocalizationsVi extends AppLocalizations {
   String get locationServiceDisabled => 'Dịch vụ vị trí đã bị tắt';
 
   @override
-  String get locationServiceDisabledDesc =>
-      'Dịch vụ vị trí đã bị tắt. Vui lòng vào Cài đặt > Quyền riêng tư & Bảo mật > Dịch vụ vị trí và bật nó';
+  String get locationServiceDisabledDesc => 'Dịch vụ vị trí đã bị tắt. Vui lòng vào Cài đặt > Quyền riêng tư & Bảo mật > Dịch vụ vị trí và bật nó';
 
   @override
   String get backgroundLocationDenied => 'Quyền truy cập vị trí nền bị từ chối';
 
   @override
-  String get backgroundLocationDeniedDesc =>
-      'Vui lòng vào cài đặt thiết bị và đặt quyền vị trí thành \"Luôn cho phép\"';
+  String get backgroundLocationDeniedDesc => 'Vui lòng vào cài đặt thiết bị và đặt quyền vị trí thành \"Luôn cho phép\"';
 
   @override
   String get lovingOmi => 'Bạn thích Omi?';
 
   @override
-  String get leaveReviewIos =>
-      'Giúp chúng tôi tiếp cận nhiều người hơn bằng cách để lại đánh giá trên App Store. Phản hồi của bạn có ý nghĩa rất lớn với chúng tôi!';
+  String get leaveReviewIos => 'Giúp chúng tôi tiếp cận nhiều người hơn bằng cách để lại đánh giá trên App Store. Phản hồi của bạn có ý nghĩa rất lớn với chúng tôi!';
 
   @override
-  String get leaveReviewAndroid =>
-      'Giúp chúng tôi tiếp cận nhiều người hơn bằng cách để lại đánh giá trên Google Play Store. Phản hồi của bạn có ý nghĩa rất lớn với chúng tôi!';
+  String get leaveReviewAndroid => 'Giúp chúng tôi tiếp cận nhiều người hơn bằng cách để lại đánh giá trên Google Play Store. Phản hồi của bạn có ý nghĩa rất lớn với chúng tôi!';
 
   @override
   String get rateOnAppStore => 'Đánh giá trên App Store';
@@ -1830,8 +1797,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get invalidRecordingMultipleSpeakers => 'Phát hiện bản ghi âm không hợp lệ';
 
   @override
-  String get multipleSpeakersDesc =>
-      'Có vẻ như có nhiều người nói trong bản ghi âm. Vui lòng đảm bảo bạn ở nơi yên tĩnh và thử lại.';
+  String get multipleSpeakersDesc => 'Có vẻ như có nhiều người nói trong bản ghi âm. Vui lòng đảm bảo bạn ở nơi yên tĩnh và thử lại.';
 
   @override
   String get tooShortDesc => 'Không phát hiện đủ giọng nói. Vui lòng nói nhiều hơn và thử lại.';
@@ -1843,8 +1809,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get areYouThere => 'Bạn có ở đó không?';
 
   @override
-  String get noSpeechDesc =>
-      'Chúng tôi không thể phát hiện giọng nói nào. Vui lòng đảm bảo nói ít nhất 10 giây và không quá 3 phút.';
+  String get noSpeechDesc => 'Chúng tôi không thể phát hiện giọng nói nào. Vui lòng đảm bảo nói ít nhất 10 giây và không quá 3 phút.';
 
   @override
   String get connectionLost => 'Mất kết nối';
@@ -1865,8 +1830,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get permissionsRequired => 'Yêu cầu quyền';
 
   @override
-  String get permissionsRequiredDesc =>
-      'Ứng dụng này cần quyền Bluetooth và Vị trí để hoạt động đúng cách. Vui lòng bật chúng trong cài đặt.';
+  String get permissionsRequiredDesc => 'Ứng dụng này cần quyền Bluetooth và Vị trí để hoạt động đúng cách. Vui lòng bật chúng trong cài đặt.';
 
   @override
   String get openSettings => 'Mở cài đặt';
@@ -1908,12 +1872,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get microphonePermission => 'Quyền microphone';
 
   @override
-  String get permissionGrantedNow =>
-      'Đã cấp quyền! Bây giờ:\n\nMở ứng dụng Omi trên đồng hồ của bạn và nhấn \"Tiếp tục\" bên dưới';
+  String get permissionGrantedNow => 'Đã cấp quyền! Bây giờ:\n\nMở ứng dụng Omi trên đồng hồ của bạn và nhấn \"Tiếp tục\" bên dưới';
 
   @override
-  String get needMicrophonePermission =>
-      'Chúng tôi cần quyền microphone.\n\n1. Nhấn \"Cấp quyền\"\n2. Cho phép trên iPhone của bạn\n3. Ứng dụng đồng hồ sẽ đóng\n4. Mở lại và nhấn \"Tiếp tục\"';
+  String get needMicrophonePermission => 'Chúng tôi cần quyền microphone.\n\n1. Nhấn \"Cấp quyền\"\n2. Cho phép trên iPhone của bạn\n3. Ứng dụng đồng hồ sẽ đóng\n4. Mở lại và nhấn \"Tiếp tục\"';
 
   @override
   String get grantPermissionButton => 'Cấp quyền';
@@ -1922,15 +1884,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get needHelp => 'Cần trợ giúp?';
 
   @override
-  String get troubleshootingSteps =>
-      'Khắc phục sự cố:\n\n1. Đảm bảo Omi được cài đặt trên đồng hồ của bạn\n2. Mở ứng dụng Omi trên đồng hồ của bạn\n3. Tìm cửa sổ bật lên yêu cầu quyền\n4. Nhấn \"Cho phép\" khi được nhắc\n5. Ứng dụng trên đồng hồ của bạn sẽ đóng - mở lại\n6. Quay lại và nhấn \"Tiếp tục\" trên iPhone của bạn';
+  String get troubleshootingSteps => 'Khắc phục sự cố:\n\n1. Đảm bảo Omi được cài đặt trên đồng hồ của bạn\n2. Mở ứng dụng Omi trên đồng hồ của bạn\n3. Tìm cửa sổ bật lên yêu cầu quyền\n4. Nhấn \"Cho phép\" khi được nhắc\n5. Ứng dụng trên đồng hồ của bạn sẽ đóng - mở lại\n6. Quay lại và nhấn \"Tiếp tục\" trên iPhone của bạn';
 
   @override
   String get recordingStartedSuccessfully => 'Đã bắt đầu ghi âm thành công!';
 
   @override
-  String get permissionNotGrantedYet =>
-      'Quyền chưa được cấp. Vui lòng đảm bảo bạn đã cho phép quyền microphone và mở lại ứng dụng trên đồng hồ của bạn.';
+  String get permissionNotGrantedYet => 'Quyền chưa được cấp. Vui lòng đảm bảo bạn đã cho phép quyền microphone và mở lại ứng dụng trên đồng hồ của bạn.';
 
   @override
   String errorRequestingPermission(String error) {
@@ -2027,8 +1987,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get welcomeActionItemsTitle => 'Sẵn sàng cho việc cần làm';
 
   @override
-  String get welcomeActionItemsDescription =>
-      'AI của bạn sẽ tự động trích xuất nhiệm vụ và việc cần làm từ cuộc trò chuyện của bạn. Chúng sẽ xuất hiện ở đây khi được tạo.';
+  String get welcomeActionItemsDescription => 'AI của bạn sẽ tự động trích xuất nhiệm vụ và việc cần làm từ cuộc trò chuyện của bạn. Chúng sẽ xuất hiện ở đây khi được tạo.';
 
   @override
   String get autoExtractionFeature => 'Tự động trích xuất từ cuộc trò chuyện';
@@ -2224,15 +2183,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get speechTranscriptionSectionTitle => 'GIỌNG NÓI & PHIÊN ÂM';
 
   @override
-  String get languageSettingsHelperText =>
-      'Ngôn ngữ Ứng dụng thay đổi menu và nút. Ngôn ngữ Giọng nói ảnh hưởng đến cách bản ghi âm của bạn được phiên âm.';
+  String get languageSettingsHelperText => 'Ngôn ngữ Ứng dụng thay đổi menu và nút. Ngôn ngữ Giọng nói ảnh hưởng đến cách bản ghi âm của bạn được phiên âm.';
 
   @override
   String get translationNotice => 'Thông báo dịch';
 
   @override
-  String get translationNoticeMessage =>
-      'Omi dịch các cuộc trò chuyện sang ngôn ngữ chính của bạn. Cập nhật bất cứ lúc nào trong Cài đặt → Hồ sơ.';
+  String get translationNoticeMessage => 'Omi dịch các cuộc trò chuyện sang ngôn ngữ chính của bạn. Cập nhật bất cứ lúc nào trong Cài đặt → Hồ sơ.';
 
   @override
   String get pleaseCheckInternetConnection => 'Vui lòng kiểm tra kết nối internet và thử lại';
@@ -2387,8 +2344,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get unpairDeviceDialogTitle => 'Hủy ghép nối thiết bị';
 
   @override
-  String get unpairDeviceDialogMessage =>
-      'Điều này sẽ hủy ghép nối thiết bị để có thể kết nối với điện thoại khác. Bạn sẽ cần đi tới Cài đặt > Bluetooth và quên thiết bị để hoàn tất quy trình.';
+  String get unpairDeviceDialogMessage => 'Điều này sẽ hủy ghép nối thiết bị để có thể kết nối với điện thoại khác. Bạn sẽ cần đi tới Cài đặt > Bluetooth và quên thiết bị để hoàn tất quy trình.';
 
   @override
   String get unpair => 'Hủy ghép nối';
@@ -2569,8 +2525,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get youreAllSet => 'Bạn đã sẵn sàng!';
 
   @override
-  String get welcomeToOmiDescription =>
-      'Chào mừng đến với Omi! Người bạn đồng hành AI của bạn đã sẵn sàng hỗ trợ bạn với các cuộc trò chuyện, nhiệm vụ và hơn thế nữa.';
+  String get welcomeToOmiDescription => 'Chào mừng đến với Omi! Người bạn đồng hành AI của bạn đã sẵn sàng hỗ trợ bạn với các cuộc trò chuyện, nhiệm vụ và hơn thế nữa.';
 
   @override
   String get startUsingOmi => 'Bắt đầu sử dụng Omi';
@@ -2649,8 +2604,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get reviewAndManageConversations => 'Xem xét và quản lý các cuộc trò chuyện đã ghi âm';
 
   @override
-  String get startCapturingConversations =>
-      'Bắt đầu ghi lại các cuộc trò chuyện bằng thiết bị Omi của bạn để xem chúng ở đây.';
+  String get startCapturingConversations => 'Bắt đầu ghi lại các cuộc trò chuyện bằng thiết bị Omi của bạn để xem chúng ở đây.';
 
   @override
   String get useMobileAppToCapture => 'Sử dụng ứng dụng di động của bạn để ghi âm';
@@ -2707,8 +2661,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get noTasksYet => 'Chưa có nhiệm vụ nào';
 
   @override
-  String get tasksFromConversationsWillAppear =>
-      'Nhiệm vụ từ các cuộc trò chuyện của bạn sẽ xuất hiện ở đây.\nNhấp vào Tạo để thêm một cách thủ công.';
+  String get tasksFromConversationsWillAppear => 'Nhiệm vụ từ các cuộc trò chuyện của bạn sẽ xuất hiện ở đây.\nNhấp vào Tạo để thêm một cách thủ công.';
 
   @override
   String get monthJan => 'Thg 1';
@@ -2765,8 +2718,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deleteActionItem => 'Xóa mục hành động';
 
   @override
-  String get deleteActionItemConfirmation =>
-      'Bạn có chắc chắn muốn xóa mục hành động này không? Hành động này không thể hoàn tác.';
+  String get deleteActionItemConfirmation => 'Bạn có chắc chắn muốn xóa mục hành động này không? Hành động này không thể hoàn tác.';
 
   @override
   String get enterActionItemDescription => 'Nhập mô tả mục hành động...';
@@ -2841,15 +2793,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get chatPrompt => 'Lời nhắc Trò chuyện';
 
   @override
-  String get chatPromptPlaceholder =>
-      'Bạn là một ứng dụng tuyệt vời, công việc của bạn là trả lời các truy vấn của người dùng và làm cho họ cảm thấy tốt...';
+  String get chatPromptPlaceholder => 'Bạn là một ứng dụng tuyệt vời, công việc của bạn là trả lời các truy vấn của người dùng và làm cho họ cảm thấy tốt...';
 
   @override
   String get conversationPrompt => 'Lời nhắc hội thoại';
 
   @override
-  String get conversationPromptPlaceholder =>
-      'Bạn là một ứng dụng tuyệt vời, bạn sẽ được cung cấp bản ghi và tóm tắt cuộc trò chuyện...';
+  String get conversationPromptPlaceholder => 'Bạn là một ứng dụng tuyệt vời, bạn sẽ được cung cấp bản ghi và tóm tắt cuộc trò chuyện...';
 
   @override
   String get notificationScopes => 'Phạm vi Thông báo';
@@ -2861,8 +2811,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get makeMyAppPublic => 'Công khai ứng dụng của tôi';
 
   @override
-  String get submitAppTermsAgreement =>
-      'Bằng việc gửi ứng dụng này, tôi đồng ý với Điều khoản Dịch vụ và Chính sách Bảo mật của Omi AI';
+  String get submitAppTermsAgreement => 'Bằng việc gửi ứng dụng này, tôi đồng ý với Điều khoản Dịch vụ và Chính sách Bảo mật của Omi AI';
 
   @override
   String get submitApp => 'Gửi Ứng dụng';
@@ -2877,12 +2826,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get submitAppQuestion => 'Gửi Ứng dụng?';
 
   @override
-  String get submitAppPublicDescription =>
-      'Ứng dụng của bạn sẽ được xem xét và công khai. Bạn có thể bắt đầu sử dụng ngay lập tức, ngay cả trong quá trình xem xét!';
+  String get submitAppPublicDescription => 'Ứng dụng của bạn sẽ được xem xét và công khai. Bạn có thể bắt đầu sử dụng ngay lập tức, ngay cả trong quá trình xem xét!';
 
   @override
-  String get submitAppPrivateDescription =>
-      'Ứng dụng của bạn sẽ được xem xét và có sẵn cho bạn một cách riêng tư. Bạn có thể bắt đầu sử dụng ngay lập tức, ngay cả trong quá trình xem xét!';
+  String get submitAppPrivateDescription => 'Ứng dụng của bạn sẽ được xem xét và có sẵn cho bạn một cách riêng tư. Bạn có thể bắt đầu sử dụng ngay lập tức, ngay cả trong quá trình xem xét!';
 
   @override
   String get startEarning => 'Bắt đầu Kiếm tiền! 💰';
@@ -2906,23 +2853,19 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dataAccessNotice => 'Thông báo truy cập dữ liệu';
 
   @override
-  String get dataAccessWarning =>
-      'Ứng dụng này sẽ truy cập dữ liệu của bạn. Omi AI không chịu trách nhiệm về cách dữ liệu của bạn được sử dụng, sửa đổi hoặc xóa bởi ứng dụng này';
+  String get dataAccessWarning => 'Ứng dụng này sẽ truy cập dữ liệu của bạn. Omi AI không chịu trách nhiệm về cách dữ liệu của bạn được sử dụng, sửa đổi hoặc xóa bởi ứng dụng này';
 
   @override
   String get installApp => 'Cài đặt ứng dụng';
 
   @override
-  String get betaTesterNotice =>
-      'Bạn là người kiểm tra beta cho ứng dụng này. Nó chưa được công khai. Nó sẽ được công khai sau khi được phê duyệt.';
+  String get betaTesterNotice => 'Bạn là người kiểm tra beta cho ứng dụng này. Nó chưa được công khai. Nó sẽ được công khai sau khi được phê duyệt.';
 
   @override
-  String get appUnderReviewOwner =>
-      'Ứng dụng của bạn đang được xem xét và chỉ hiển thị cho bạn. Nó sẽ được công khai sau khi được phê duyệt.';
+  String get appUnderReviewOwner => 'Ứng dụng của bạn đang được xem xét và chỉ hiển thị cho bạn. Nó sẽ được công khai sau khi được phê duyệt.';
 
   @override
-  String get appRejectedNotice =>
-      'Ứng dụng của bạn đã bị từ chối. Vui lòng cập nhật chi tiết ứng dụng và gửi lại để xem xét.';
+  String get appRejectedNotice => 'Ứng dụng của bạn đã bị từ chối. Vui lòng cập nhật chi tiết ứng dụng và gửi lại để xem xét.';
 
   @override
   String get setupSteps => 'Các bước thiết lập';
@@ -2984,8 +2927,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get descriptionLabel => 'Mô tả';
 
   @override
-  String get appDescriptionPlaceholder =>
-      'Ứng dụng tuyệt vời của tôi là một ứng dụng tuyệt vời làm những điều tuyệt vời. Đây là ứng dụng tốt nhất!';
+  String get appDescriptionPlaceholder => 'Ứng dụng tuyệt vời của tôi là một ứng dụng tuyệt vời làm những điều tuyệt vời. Đây là ứng dụng tốt nhất!';
 
   @override
   String get pleaseProvideValidDescription => 'Vui lòng cung cấp mô tả hợp lệ';
@@ -3137,8 +3079,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get microphonePermissionRequired => 'Cần quyền microphone để ghi âm giọng nói.';
 
   @override
-  String get microphonePermissionDenied =>
-      'Quyền microphone bị từ chối. Vui lòng cấp quyền trong Tùy chọn Hệ thống > Quyền riêng tư & Bảo mật > Microphone.';
+  String get microphonePermissionDenied => 'Quyền microphone bị từ chối. Vui lòng cấp quyền trong Tùy chọn Hệ thống > Quyền riêng tư & Bảo mật > Microphone.';
 
   @override
   String failedToCheckMicrophonePermission(String error) {
@@ -3297,8 +3238,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get createMemory => 'Tạo bộ nhớ';
 
   @override
-  String get deleteMemoryConfirmation =>
-      'Bạn có chắc chắn muốn xóa bộ nhớ này không? Hành động này không thể hoàn tác.';
+  String get deleteMemoryConfirmation => 'Bạn có chắc chắn muốn xóa bộ nhớ này không? Hành động này không thể hoàn tác.';
 
   @override
   String get makePrivate => 'Riêng tư';
@@ -3372,8 +3312,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get whatWeCollect => 'Những gì chúng tôi thu thập';
 
   @override
-  String get dataCollectionMessage =>
-      'Bằng cách tiếp tục, các cuộc trò chuyện, bản ghi và thông tin cá nhân của bạn sẽ được lưu trữ an toàn trên máy chủ của chúng tôi để cung cấp thông tin chi tiết được hỗ trợ bởi AI và kích hoạt tất cả các tính năng ứng dụng.';
+  String get dataCollectionMessage => 'Bằng cách tiếp tục, các cuộc trò chuyện, bản ghi và thông tin cá nhân của bạn sẽ được lưu trữ an toàn trên máy chủ của chúng tôi để cung cấp thông tin chi tiết được hỗ trợ bởi AI và kích hoạt tất cả các tính năng ứng dụng.';
 
   @override
   String get dataProtection => 'Bảo vệ dữ liệu';
@@ -3406,8 +3345,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get nameMustBeAtLeast2Characters => 'Tên phải có ít nhất 2 ký tự';
 
   @override
-  String get tellUsHowYouWouldLikeToBeAddressed =>
-      'Cho chúng tôi biết bạn muốn được gọi như thế nào. Điều này giúp cá nhân hóa trải nghiệm Omi của bạn.';
+  String get tellUsHowYouWouldLikeToBeAddressed => 'Cho chúng tôi biết bạn muốn được gọi như thế nào. Điều này giúp cá nhân hóa trải nghiệm Omi của bạn.';
 
   @override
   String charactersCount(int count) {
@@ -3415,8 +3353,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get enableFeaturesForBestExperience =>
-      'Bật các tính năng để có trải nghiệm Omi tốt nhất trên thiết bị của bạn.';
+  String get enableFeaturesForBestExperience => 'Bật các tính năng để có trải nghiệm Omi tốt nhất trên thiết bị của bạn.';
 
   @override
   String get microphoneAccess => 'Quyền truy cập micrô';
@@ -3425,8 +3362,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get recordAudioConversations => 'Ghi âm cuộc trò chuyện';
 
   @override
-  String get microphoneAccessDescription =>
-      'Omi cần quyền truy cập micrô để ghi lại các cuộc trò chuyện của bạn và cung cấp bản ghi âm.';
+  String get microphoneAccessDescription => 'Omi cần quyền truy cập micrô để ghi lại các cuộc trò chuyện của bạn và cung cấp bản ghi âm.';
 
   @override
   String get screenRecording => 'Ghi màn hình';
@@ -3435,8 +3371,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get captureSystemAudioFromMeetings => 'Ghi âm hệ thống từ các cuộc họp';
 
   @override
-  String get screenRecordingDescription =>
-      'Omi cần quyền ghi màn hình để ghi âm hệ thống từ các cuộc họp dựa trên trình duyệt của bạn.';
+  String get screenRecordingDescription => 'Omi cần quyền ghi màn hình để ghi âm hệ thống từ các cuộc họp dựa trên trình duyệt của bạn.';
 
   @override
   String get accessibility => 'Khả năng truy cập';
@@ -3445,8 +3380,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get detectBrowserBasedMeetings => 'Phát hiện các cuộc họp dựa trên trình duyệt';
 
   @override
-  String get accessibilityDescription =>
-      'Omi cần quyền truy cập để phát hiện khi bạn tham gia các cuộc họp Zoom, Meet hoặc Teams trong trình duyệt của bạn.';
+  String get accessibilityDescription => 'Omi cần quyền truy cập để phát hiện khi bạn tham gia các cuộc họp Zoom, Meet hoặc Teams trong trình duyệt của bạn.';
 
   @override
   String get pleaseWait => 'Vui lòng đợi...';
@@ -3515,12 +3449,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get exportAllConversationsToJson => 'Xuất tất cả cuộc trò chuyện của bạn vào tệp JSON.';
 
   @override
-  String get conversationsExportStarted =>
-      'Đã bắt đầu xuất cuộc trò chuyện. Điều này có thể mất vài giây, vui lòng đợi.';
+  String get conversationsExportStarted => 'Đã bắt đầu xuất cuộc trò chuyện. Điều này có thể mất vài giây, vui lòng đợi.';
 
   @override
-  String get mcpDescription =>
-      'Để kết nối Omi với các ứng dụng khác để đọc, tìm kiếm và quản lý ký ức và cuộc trò chuyện của bạn. Tạo khóa để bắt đầu.';
+  String get mcpDescription => 'Để kết nối Omi với các ứng dụng khác để đọc, tìm kiếm và quản lý ký ức và cuộc trò chuyện của bạn. Tạo khóa để bắt đầu.';
 
   @override
   String get apiKeys => 'Khóa API';
@@ -3628,8 +3560,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get letOmiChooseAutomatically => 'Để Omi tự động chọn ứng dụng tốt nhất';
 
   @override
-  String get deleteConversationConfirmation =>
-      'Bạn có chắc chắn muốn xóa cuộc trò chuyện này không? Hành động này không thể hoàn tác.';
+  String get deleteConversationConfirmation => 'Bạn có chắc chắn muốn xóa cuộc trò chuyện này không? Hành động này không thể hoàn tác.';
 
   @override
   String get conversationDeleted => 'Đã xóa cuộc trò chuyện';
@@ -3677,8 +3608,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get preparingSystemAudioCapture => 'Đang chuẩn bị ghi âm hệ thống';
 
   @override
-  String get clickTheButtonToCaptureAudio =>
-      'Nhấp vào nút để ghi âm cho bản ghi trực tiếp, thông tin chi tiết AI và lưu tự động.';
+  String get clickTheButtonToCaptureAudio => 'Nhấp vào nút để ghi âm cho bản ghi trực tiếp, thông tin chi tiết AI và lưu tự động.';
 
   @override
   String get reconnecting => 'Đang kết nối lại...';
@@ -3836,8 +3766,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dailySummaryTitle => 'Tóm tắt Hàng ngày';
 
   @override
-  String get dailySummaryDescription =>
-      'Nhận tóm tắt cá nhân hóa về các cuộc trò chuyện trong ngày dưới dạng thông báo.';
+  String get dailySummaryDescription => 'Nhận tóm tắt cá nhân hóa về các cuộc trò chuyện trong ngày dưới dạng thông báo.';
 
   @override
   String get deliveryTime => 'Thời gian gửi';
@@ -3906,8 +3835,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deleteKnowledgeGraphQuestion => 'Xóa Đồ thị Tri thức?';
 
   @override
-  String get deleteKnowledgeGraphWarning =>
-      'Điều này sẽ xóa tất cả dữ liệu đồ thị tri thức dẫn xuất. Ký ức gốc của bạn vẫn an toàn.';
+  String get deleteKnowledgeGraphWarning => 'Điều này sẽ xóa tất cả dữ liệu đồ thị tri thức dẫn xuất. Ký ức gốc của bạn vẫn an toàn.';
 
   @override
   String get connectOmiWithAI => 'Kết nối Omi với trợ lý AI';
@@ -3964,8 +3892,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get updateAppQuestion => 'Cập nhật ứng dụng?';
 
   @override
-  String get updateAppConfirmation =>
-      'Bạn có chắc chắn muốn cập nhật ứng dụng? Các thay đổi sẽ được phản ánh sau khi được đội ngũ của chúng tôi xem xét.';
+  String get updateAppConfirmation => 'Bạn có chắc chắn muốn cập nhật ứng dụng? Các thay đổi sẽ được phản ánh sau khi được đội ngũ của chúng tôi xem xét.';
 
   @override
   String get updateApp => 'Cập nhật ứng dụng';
@@ -3995,8 +3922,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get no => 'Không';
 
   @override
-  String get subscriptionCancelledSuccessfully =>
-      'Đã hủy đăng ký thành công. Nó sẽ vẫn hoạt động cho đến cuối kỳ thanh toán hiện tại.';
+  String get subscriptionCancelledSuccessfully => 'Đã hủy đăng ký thành công. Nó sẽ vẫn hoạt động cho đến cuối kỳ thanh toán hiện tại.';
 
   @override
   String get failedToCancelSubscription => 'Không thể hủy đăng ký. Vui lòng thử lại.';
@@ -4032,8 +3958,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get cancelSubscriptionQuestion => 'Hủy đăng ký?';
 
   @override
-  String get cancelSubscriptionConfirmation =>
-      'Bạn có chắc chắn muốn hủy đăng ký? Bạn sẽ tiếp tục có quyền truy cập cho đến cuối kỳ thanh toán hiện tại.';
+  String get cancelSubscriptionConfirmation => 'Bạn có chắc chắn muốn hủy đăng ký? Bạn sẽ tiếp tục có quyền truy cập cho đến cuối kỳ thanh toán hiện tại.';
 
   @override
   String get cancelSubscriptionButton => 'Hủy đăng ký';
@@ -4042,12 +3967,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get cancelling => 'Đang hủy...';
 
   @override
-  String get betaTesterMessage =>
-      'Bạn là người thử nghiệm beta cho ứng dụng này. Nó chưa được công khai. Sẽ được công khai sau khi được phê duyệt.';
+  String get betaTesterMessage => 'Bạn là người thử nghiệm beta cho ứng dụng này. Nó chưa được công khai. Sẽ được công khai sau khi được phê duyệt.';
 
   @override
-  String get appUnderReviewMessage =>
-      'Ứng dụng của bạn đang được xem xét và chỉ hiển thị với bạn. Sẽ được công khai sau khi được phê duyệt.';
+  String get appUnderReviewMessage => 'Ứng dụng của bạn đang được xem xét và chỉ hiển thị với bạn. Sẽ được công khai sau khi được phê duyệt.';
 
   @override
   String get appRejectedMessage => 'Ứng dụng của bạn đã bị từ chối. Vui lòng cập nhật thông tin và gửi lại để xem xét.';
@@ -4104,8 +4027,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get issueActivatingApp => 'Đã xảy ra sự cố khi kích hoạt ứng dụng này. Vui lòng thử lại.';
 
   @override
-  String get dataAccessNoticeDescription =>
-      'Ứng dụng này sẽ truy cập dữ liệu của bạn. Omi AI không chịu trách nhiệm về cách dữ liệu của bạn được sử dụng bởi các ứng dụng bên thứ ba.';
+  String get dataAccessNoticeDescription => 'Ứng dụng này sẽ truy cập dữ liệu của bạn. Omi AI không chịu trách nhiệm về cách dữ liệu của bạn được sử dụng bởi các ứng dụng bên thứ ba.';
 
   @override
   String get copyUrl => 'Sao chép URL';
@@ -4193,8 +4115,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get omiApiKeys => 'Khóa API Omi';
 
   @override
-  String get apiKeysDescription =>
-      'Khóa API được sử dụng để xác thực khi ứng dụng của bạn giao tiếp với máy chủ OMI. Chúng cho phép ứng dụng của bạn tạo kỷ niệm và truy cập an toàn vào các dịch vụ OMI khác.';
+  String get apiKeysDescription => 'Khóa API được sử dụng để xác thực khi ứng dụng của bạn giao tiếp với máy chủ OMI. Chúng cho phép ứng dụng của bạn tạo kỷ niệm và truy cập an toàn vào các dịch vụ OMI khác.';
 
   @override
   String get aboutOmiApiKeys => 'Về khóa API Omi';
@@ -4218,8 +4139,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get revokeApiKeyQuestion => 'Thu hồi khóa API?';
 
   @override
-  String get revokeApiKeyWarning =>
-      'Hành động này không thể hoàn tác. Bất kỳ ứng dụng nào sử dụng khóa này sẽ không thể truy cập API nữa.';
+  String get revokeApiKeyWarning => 'Hành động này không thể hoàn tác. Bất kỳ ứng dụng nào sử dụng khóa này sẽ không thể truy cập API nữa.';
 
   @override
   String get revoke => 'Thu hồi';
@@ -4308,8 +4228,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get keyCreated => 'Đã tạo khóa';
 
   @override
-  String get keyCreatedMessage =>
-      'Khóa mới của bạn đã được tạo. Vui lòng sao chép ngay bây giờ. Bạn sẽ không thể xem lại.';
+  String get keyCreatedMessage => 'Khóa mới của bạn đã được tạo. Vui lòng sao chép ngay bây giờ. Bạn sẽ không thể xem lại.';
 
   @override
   String get keyWord => 'Khóa';
@@ -4318,8 +4237,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get externalAppAccess => 'Truy cập ứng dụng bên ngoài';
 
   @override
-  String get externalAppAccessDescription =>
-      'Các ứng dụng đã cài đặt sau có tích hợp bên ngoài và có thể truy cập dữ liệu của bạn, chẳng hạn như cuộc trò chuyện và kỷ niệm.';
+  String get externalAppAccessDescription => 'Các ứng dụng đã cài đặt sau có tích hợp bên ngoài và có thể truy cập dữ liệu của bạn, chẳng hạn như cuộc trò chuyện và kỷ niệm.';
 
   @override
   String get noExternalAppsHaveAccess => 'Không có ứng dụng bên ngoài nào có quyền truy cập vào dữ liệu của bạn.';
@@ -4328,8 +4246,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get maximumSecurityE2ee => 'Bảo mật tối đa (E2EE)';
 
   @override
-  String get e2eeDescription =>
-      'Mã hóa đầu cuối là tiêu chuẩn vàng cho quyền riêng tư. Khi được bật, dữ liệu của bạn được mã hóa trên thiết bị của bạn trước khi gửi đến máy chủ của chúng tôi. Điều này có nghĩa là không ai, kể cả Omi, có thể truy cập nội dung của bạn.';
+  String get e2eeDescription => 'Mã hóa đầu cuối là tiêu chuẩn vàng cho quyền riêng tư. Khi được bật, dữ liệu của bạn được mã hóa trên thiết bị của bạn trước khi gửi đến máy chủ của chúng tôi. Điều này có nghĩa là không ai, kể cả Omi, có thể truy cập nội dung của bạn.';
 
   @override
   String get importantTradeoffs => 'Đánh đổi quan trọng:';
@@ -4363,15 +4280,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get secureEncryption => 'Mã hóa an toàn';
 
   @override
-  String get secureEncryptionDescription =>
-      'Dữ liệu của bạn được mã hóa bằng một khóa duy nhất cho bạn trên các máy chủ của chúng tôi, được lưu trữ trên Google Cloud. Điều này có nghĩa là nội dung thô của bạn không thể truy cập được bởi bất kỳ ai, bao gồm nhân viên Omi hoặc Google, trực tiếp từ cơ sở dữ liệu.';
+  String get secureEncryptionDescription => 'Dữ liệu của bạn được mã hóa bằng một khóa duy nhất cho bạn trên các máy chủ của chúng tôi, được lưu trữ trên Google Cloud. Điều này có nghĩa là nội dung thô của bạn không thể truy cập được bởi bất kỳ ai, bao gồm nhân viên Omi hoặc Google, trực tiếp từ cơ sở dữ liệu.';
 
   @override
   String get endToEndEncryption => 'Mã hóa đầu cuối';
 
   @override
-  String get e2eeCardDescription =>
-      'Bật để bảo mật tối đa, nơi chỉ bạn mới có thể truy cập dữ liệu của mình. Nhấn để tìm hiểu thêm.';
+  String get e2eeCardDescription => 'Bật để bảo mật tối đa, nơi chỉ bạn mới có thể truy cập dữ liệu của mình. Nhấn để tìm hiểu thêm.';
 
   @override
   String get dataAlwaysEncrypted => 'Bất kể mức nào, dữ liệu của bạn luôn được mã hóa khi lưu trữ và khi truyền tải.';
@@ -4439,12 +4354,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get trainingDataProgram => 'Chương trình dữ liệu huấn luyện';
 
   @override
-  String get getOmiUnlimitedFree =>
-      'Nhận Omi Unlimited miễn phí bằng cách đóng góp dữ liệu của bạn để huấn luyện các mô hình AI.';
+  String get getOmiUnlimitedFree => 'Nhận Omi Unlimited miễn phí bằng cách đóng góp dữ liệu của bạn để huấn luyện các mô hình AI.';
 
   @override
-  String get trainingDataBullets =>
-      '• Dữ liệu của bạn giúp cải thiện các mô hình AI\n• Chỉ chia sẻ dữ liệu không nhạy cảm\n• Quy trình hoàn toàn minh bạch';
+  String get trainingDataBullets => '• Dữ liệu của bạn giúp cải thiện các mô hình AI\n• Chỉ chia sẻ dữ liệu không nhạy cảm\n• Quy trình hoàn toàn minh bạch';
 
   @override
   String get learnMoreAtOmiTraining => 'Tìm hiểu thêm tại omi.me/training';
@@ -4456,8 +4369,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get submitRequest => 'Gửi yêu cầu';
 
   @override
-  String get thankYouRequestUnderReview =>
-      'Cảm ơn bạn! Yêu cầu của bạn đang được xem xét. Chúng tôi sẽ thông báo cho bạn sau khi được phê duyệt.';
+  String get thankYouRequestUnderReview => 'Cảm ơn bạn! Yêu cầu của bạn đang được xem xét. Chúng tôi sẽ thông báo cho bạn sau khi được phê duyệt.';
 
   @override
   String planRemainsActiveUntil(String date) {
@@ -4495,15 +4407,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get monthlyPlanContinues => 'Gói hàng tháng hiện tại của bạn sẽ tiếp tục cho đến cuối kỳ thanh toán';
 
   @override
-  String get paymentMethodCharged =>
-      'Phương thức thanh toán hiện tại của bạn sẽ được tính phí tự động khi gói hàng tháng kết thúc';
+  String get paymentMethodCharged => 'Phương thức thanh toán hiện tại của bạn sẽ được tính phí tự động khi gói hàng tháng kết thúc';
 
   @override
   String get annualSubscriptionStarts => 'Đăng ký năm 12 tháng của bạn sẽ tự động bắt đầu sau khi thanh toán';
 
   @override
-  String get thirteenMonthsCoverage =>
-      'Bạn sẽ nhận được tổng cộng 13 tháng bảo hiểm (tháng hiện tại + 12 tháng hàng năm)';
+  String get thirteenMonthsCoverage => 'Bạn sẽ nhận được tổng cộng 13 tháng bảo hiểm (tháng hiện tại + 12 tháng hàng năm)';
 
   @override
   String get confirmUpgrade => 'Xác nhận nâng cấp';
@@ -4607,8 +4517,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get yourPrivacyMattersToUs => 'Quyền riêng tư của bạn quan trọng với chúng tôi';
 
   @override
-  String get privacyIntroText =>
-      'Tại Omi, chúng tôi rất coi trọng quyền riêng tư của bạn. Chúng tôi muốn minh bạch về dữ liệu thu thập và cách sử dụng. Đây là những gì bạn cần biết:';
+  String get privacyIntroText => 'Tại Omi, chúng tôi rất coi trọng quyền riêng tư của bạn. Chúng tôi muốn minh bạch về dữ liệu thu thập và cách sử dụng. Đây là những gì bạn cần biết:';
 
   @override
   String get whatWeTrack => 'Chúng tôi theo dõi gì';
@@ -4623,12 +4532,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get ourCommitment => 'Cam kết của chúng tôi';
 
   @override
-  String get commitmentText =>
-      'Chúng tôi cam kết sử dụng dữ liệu thu thập chỉ để làm cho Omi trở thành sản phẩm tốt hơn cho bạn. Quyền riêng tư và sự tin tưởng của bạn là điều quan trọng nhất đối với chúng tôi.';
+  String get commitmentText => 'Chúng tôi cam kết sử dụng dữ liệu thu thập chỉ để làm cho Omi trở thành sản phẩm tốt hơn cho bạn. Quyền riêng tư và sự tin tưởng của bạn là điều quan trọng nhất đối với chúng tôi.';
 
   @override
-  String get thankYouText =>
-      'Cảm ơn bạn đã là người dùng quý giá của Omi. Nếu bạn có bất kỳ câu hỏi hoặc lo ngại nào, hãy liên hệ với chúng tôi tại team@basedhardware.com.';
+  String get thankYouText => 'Cảm ơn bạn đã là người dùng quý giá của Omi. Nếu bạn có bất kỳ câu hỏi hoặc lo ngại nào, hãy liên hệ với chúng tôi tại team@basedhardware.com.';
 
   @override
   String get wifiSyncSettings => 'Cài đặt đồng bộ WiFi';
@@ -4637,8 +4544,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get enterHotspotCredentials => 'Nhập thông tin đăng nhập điểm phát sóng điện thoại';
 
   @override
-  String get wifiSyncUsesHotspot =>
-      'Đồng bộ WiFi sử dụng điện thoại của bạn làm điểm phát sóng. Tìm tên và mật khẩu trong Cài đặt > Điểm truy cập cá nhân.';
+  String get wifiSyncUsesHotspot => 'Đồng bộ WiFi sử dụng điện thoại của bạn làm điểm phát sóng. Tìm tên và mật khẩu trong Cài đặt > Điểm truy cập cá nhân.';
 
   @override
   String get hotspotNameSsid => 'Tên điểm phát sóng (SSID)';
@@ -4673,8 +4579,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get failedToGenerateSummaryCheckConversations =>
-      'Không thể tạo tóm tắt. Hãy đảm bảo bạn có cuộc trò chuyện cho ngày đó.';
+  String get failedToGenerateSummaryCheckConversations => 'Không thể tạo tóm tắt. Hãy đảm bảo bạn có cuộc trò chuyện cho ngày đó.';
 
   @override
   String get summaryNotFound => 'Không tìm thấy tóm tắt';
@@ -4704,8 +4609,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get exportStartedMayTakeFewSeconds => 'Đã bắt đầu xuất. Quá trình này có thể mất vài giây...';
 
   @override
-  String get knowledgeGraphDeleteDescription =>
-      'Thao tác này sẽ xóa tất cả dữ liệu biểu đồ tri thức phái sinh (các nút và kết nối). Ký ức gốc của bạn sẽ vẫn an toàn. Biểu đồ sẽ được xây dựng lại theo thời gian hoặc khi có yêu cầu tiếp theo.';
+  String get knowledgeGraphDeleteDescription => 'Thao tác này sẽ xóa tất cả dữ liệu biểu đồ tri thức phái sinh (các nút và kết nối). Ký ức gốc của bạn sẽ vẫn an toàn. Biểu đồ sẽ được xây dựng lại theo thời gian hoặc khi có yêu cầu tiếp theo.';
 
   @override
   String get configureDailySummaryDigest => 'Cấu hình bản tóm tắt công việc hàng ngày của bạn';
@@ -4775,8 +4679,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deleteAllLimitlessConversations => 'Xóa tất cả cuộc hội thoại Limitless?';
 
   @override
-  String get deleteAllLimitlessWarning =>
-      'Điều này sẽ xóa vĩnh viễn tất cả các cuộc hội thoại được nhập từ Limitless. Hành động này không thể hoàn tác.';
+  String get deleteAllLimitlessWarning => 'Điều này sẽ xóa vĩnh viễn tất cả các cuộc hội thoại được nhập từ Limitless. Hành động này không thể hoàn tác.';
 
   @override
   String deletedLimitlessConversations(int count) {
@@ -4832,8 +4735,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get howItWorksTitle => 'Nó hoạt động như thế nào?';
 
   @override
-  String get howPeopleWorks =>
-      'Sau khi tạo một người, bạn có thể đi đến bản ghi cuộc trò chuyện và gán các phân đoạn tương ứng cho họ, bằng cách đó Omi cũng sẽ có thể nhận dạng giọng nói của họ!';
+  String get howPeopleWorks => 'Sau khi tạo một người, bạn có thể đi đến bản ghi cuộc trò chuyện và gán các phân đoạn tương ứng cho họ, bằng cách đó Omi cũng sẽ có thể nhận dạng giọng nói của họ!';
 
   @override
   String get tapToDelete => 'Nhấn để xóa';
@@ -4859,8 +4761,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get privacyNotice => 'Thông báo quyền riêng tư';
 
   @override
-  String get recordingsMayCaptureOthers =>
-      'Bản ghi có thể ghi lại giọng nói của người khác. Đảm bảo bạn có sự đồng ý của tất cả người tham gia trước khi bật.';
+  String get recordingsMayCaptureOthers => 'Bản ghi có thể ghi lại giọng nói của người khác. Đảm bảo bạn có sự đồng ý của tất cả người tham gia trước khi bật.';
 
   @override
   String get enable => 'Bật';
@@ -4872,8 +4773,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get on => 'Bật';
 
   @override
-  String get storeAudioDescription =>
-      'Lưu trữ tất cả bản ghi âm trên điện thoại của bạn. Khi tắt, chỉ các tải lên thất bại được giữ lại để tiết kiệm dung lượng.';
+  String get storeAudioDescription => 'Lưu trữ tất cả bản ghi âm trên điện thoại của bạn. Khi tắt, chỉ các tải lên thất bại được giữ lại để tiết kiệm dung lượng.';
 
   @override
   String get enableLocalStorage => 'Bật bộ nhớ cục bộ';
@@ -4891,12 +4791,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get storeAudioOnCloud => 'Lưu Âm thanh trên Đám mây';
 
   @override
-  String get cloudStorageDialogMessage =>
-      'Bản ghi thời gian thực của bạn sẽ được lưu trữ trong bộ nhớ đám mây riêng khi bạn nói.';
+  String get cloudStorageDialogMessage => 'Bản ghi thời gian thực của bạn sẽ được lưu trữ trong bộ nhớ đám mây riêng khi bạn nói.';
 
   @override
-  String get storeAudioCloudDescription =>
-      'Lưu trữ bản ghi thời gian thực của bạn trong bộ nhớ đám mây riêng khi bạn nói. Âm thanh được ghi lại và lưu an toàn theo thời gian thực.';
+  String get storeAudioCloudDescription => 'Lưu trữ bản ghi thời gian thực của bạn trong bộ nhớ đám mây riêng khi bạn nói. Âm thanh được ghi lại và lưu an toàn theo thời gian thực.';
 
   @override
   String get downloadingFirmware => 'Đang tải Firmware';
@@ -4905,8 +4803,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get installingFirmware => 'Đang cài đặt Firmware';
 
   @override
-  String get firmwareUpdateWarning =>
-      'Không đóng ứng dụng hoặc tắt thiết bị. Điều này có thể làm hỏng thiết bị của bạn.';
+  String get firmwareUpdateWarning => 'Không đóng ứng dụng hoặc tắt thiết bị. Điều này có thể làm hỏng thiết bị của bạn.';
 
   @override
   String get firmwareUpdated => 'Đã cập nhật Firmware';
@@ -4950,8 +4847,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get payments => 'Thanh toán';
 
   @override
-  String get connectPaymentMethodInfo =>
-      'Kết nối phương thức thanh toán bên dưới để bắt đầu nhận thanh toán cho ứng dụng của bạn.';
+  String get connectPaymentMethodInfo => 'Kết nối phương thức thanh toán bên dưới để bắt đầu nhận thanh toán cho ứng dụng của bạn.';
 
   @override
   String get selectedPaymentMethod => 'Phương thức thanh toán đã chọn';
@@ -5005,8 +4901,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get connectingYourStripeAccount => 'Đang kết nối tài khoản Stripe của bạn';
 
   @override
-  String get stripeOnboardingInstructions =>
-      'Vui lòng hoàn tất quy trình đăng ký Stripe trong trình duyệt của bạn. Trang này sẽ tự động cập nhật sau khi hoàn tất.';
+  String get stripeOnboardingInstructions => 'Vui lòng hoàn tất quy trình đăng ký Stripe trong trình duyệt của bạn. Trang này sẽ tự động cập nhật sau khi hoàn tất.';
 
   @override
   String get failedTryAgain => 'Thất bại? Thử lại';
@@ -5018,8 +4913,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get successfullyConnected => 'Kết nối thành công!';
 
   @override
-  String get stripeReadyForPayments =>
-      'Tài khoản Stripe của bạn đã sẵn sàng nhận thanh toán. Bạn có thể bắt đầu kiếm tiền từ việc bán ứng dụng ngay bây giờ.';
+  String get stripeReadyForPayments => 'Tài khoản Stripe của bạn đã sẵn sàng nhận thanh toán. Bạn có thể bắt đầu kiếm tiền từ việc bán ứng dụng ngay bây giờ.';
 
   @override
   String get updateStripeDetails => 'Cập nhật chi tiết Stripe';
@@ -5037,8 +4931,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get updatePayPalAccountDetails => 'Cập nhật chi tiết tài khoản PayPal của bạn';
 
   @override
-  String get connectPayPalToReceivePayments =>
-      'Kết nối tài khoản PayPal của bạn để bắt đầu nhận thanh toán cho ứng dụng của bạn';
+  String get connectPayPalToReceivePayments => 'Kết nối tài khoản PayPal của bạn để bắt đầu nhận thanh toán cho ứng dụng của bạn';
 
   @override
   String get paypalEmail => 'Email PayPal';
@@ -5047,8 +4940,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get paypalMeLink => 'Liên kết PayPal.me';
 
   @override
-  String get stripeRecommendation =>
-      'Nếu Stripe có sẵn tại quốc gia của bạn, chúng tôi khuyên bạn nên sử dụng để thanh toán nhanh hơn và dễ dàng hơn.';
+  String get stripeRecommendation => 'Nếu Stripe có sẵn tại quốc gia của bạn, chúng tôi khuyên bạn nên sử dụng để thanh toán nhanh hơn và dễ dàng hơn.';
 
   @override
   String get updatePayPalDetails => 'Cập nhật chi tiết PayPal';
@@ -5100,12 +4992,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get additionalSpeechSampleRemoved => 'Đã xóa mẫu giọng nói bổ sung';
 
   @override
-  String get consentDataMessage =>
-      'Bằng cách tiếp tục, các cuộc trò chuyện, bản ghi âm và thông tin cá nhân của bạn sẽ được lưu trữ an toàn trên máy chủ của chúng tôi. Bản ghi âm và bản phiên âm của bạn được xử lý bởi các dịch vụ AI bên thứ ba (bao gồm Deepgram cho phiên âm và OpenAI cho phân tích) để cung cấp cho bạn thông tin chi tiết được hỗ trợ bởi AI và kích hoạt tất cả các tính năng ứng dụng.';
+  String get consentDataMessage => 'Bằng cách tiếp tục, các cuộc trò chuyện, bản ghi âm và thông tin cá nhân của bạn sẽ được lưu trữ an toàn trên máy chủ của chúng tôi. Bản ghi âm và bản phiên âm của bạn được xử lý bởi các dịch vụ AI bên thứ ba (bao gồm Deepgram cho phiên âm và OpenAI cho phân tích) để cung cấp cho bạn thông tin chi tiết được hỗ trợ bởi AI và kích hoạt tất cả các tính năng ứng dụng.';
 
   @override
-  String get tasksEmptyStateMessage =>
-      'Các nhiệm vụ từ cuộc trò chuyện của bạn sẽ xuất hiện ở đây.\nNhấn + để tạo thủ công.';
+  String get tasksEmptyStateMessage => 'Các nhiệm vụ từ cuộc trò chuyện của bạn sẽ xuất hiện ở đây.\nNhấn + để tạo thủ công.';
 
   @override
   String get clearChatAction => 'Xóa cuộc trò chuyện';
@@ -5141,15 +5031,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get installOmiOnAppleWatch => 'Cài đặt Omi trên\nApple Watch của bạn';
 
   @override
-  String get installOmiOnAppleWatchDescription =>
-      'Để sử dụng Apple Watch với Omi, bạn cần cài đặt ứng dụng Omi trên đồng hồ trước.';
+  String get installOmiOnAppleWatchDescription => 'Để sử dụng Apple Watch với Omi, bạn cần cài đặt ứng dụng Omi trên đồng hồ trước.';
 
   @override
   String get openOmiOnAppleWatch => 'Mở Omi trên\nApple Watch của bạn';
 
   @override
-  String get openOmiOnAppleWatchDescription =>
-      'Ứng dụng Omi đã được cài đặt trên Apple Watch của bạn. Mở ứng dụng và nhấn Bắt đầu.';
+  String get openOmiOnAppleWatchDescription => 'Ứng dụng Omi đã được cài đặt trên Apple Watch của bạn. Mở ứng dụng và nhấn Bắt đầu.';
 
   @override
   String get openWatchApp => 'Mở ứng dụng Watch';
@@ -5158,15 +5046,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get iveInstalledAndOpenedTheApp => 'Tôi đã cài đặt và mở ứng dụng';
 
   @override
-  String get unableToOpenWatchApp =>
-      'Không thể mở ứng dụng Apple Watch. Vui lòng mở ứng dụng Watch trên Apple Watch và cài đặt Omi từ phần \"Ứng dụng có sẵn\".';
+  String get unableToOpenWatchApp => 'Không thể mở ứng dụng Apple Watch. Vui lòng mở ứng dụng Watch trên Apple Watch và cài đặt Omi từ phần \"Ứng dụng có sẵn\".';
 
   @override
   String get appleWatchConnectedSuccessfully => 'Kết nối Apple Watch thành công!';
 
   @override
-  String get appleWatchNotReachable =>
-      'Vẫn không thể kết nối Apple Watch. Vui lòng đảm bảo ứng dụng Omi đang mở trên đồng hồ.';
+  String get appleWatchNotReachable => 'Vẫn không thể kết nối Apple Watch. Vui lòng đảm bảo ứng dụng Omi đang mở trên đồng hồ.';
 
   @override
   String errorCheckingConnection(String error) {
@@ -5594,8 +5480,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get multipleSpeakersDetected => 'Phát hiện nhiều người nói';
 
   @override
-  String get multipleSpeakersDescription =>
-      'Có vẻ như có nhiều người nói trong bản ghi. Hãy đảm bảo bạn đang ở nơi yên tĩnh và thử lại.';
+  String get multipleSpeakersDescription => 'Có vẻ như có nhiều người nói trong bản ghi. Hãy đảm bảo bạn đang ở nơi yên tĩnh và thử lại.';
 
   @override
   String get invalidRecordingDetected => 'Phát hiện bản ghi không hợp lệ';
@@ -5607,15 +5492,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get speechDurationDescription => 'Hãy đảm bảo bạn nói ít nhất 5 giây và không quá 90 giây.';
 
   @override
-  String get connectionLostDescription =>
-      'Kết nối bị gián đoạn. Vui lòng kiểm tra kết nối internet của bạn và thử lại.';
+  String get connectionLostDescription => 'Kết nối bị gián đoạn. Vui lòng kiểm tra kết nối internet của bạn và thử lại.';
 
   @override
   String get howToTakeGoodSample => 'Làm thế nào để lấy mẫu tốt?';
 
   @override
-  String get goodSampleInstructions =>
-      '1. Đảm bảo bạn đang ở nơi yên tĩnh.\n2. Nói rõ ràng và tự nhiên.\n3. Đảm bảo thiết bị của bạn ở vị trí tự nhiên trên cổ.\n\nSau khi tạo, bạn luôn có thể cải thiện hoặc làm lại.';
+  String get goodSampleInstructions => '1. Đảm bảo bạn đang ở nơi yên tĩnh.\n2. Nói rõ ràng và tự nhiên.\n3. Đảm bảo thiết bị của bạn ở vị trí tự nhiên trên cổ.\n\nSau khi tạo, bạn luôn có thể cải thiện hoặc làm lại.';
 
   @override
   String get noDeviceConnectedUseMic => 'Không có thiết bị kết nối. Sẽ sử dụng micro điện thoại.';
@@ -5678,8 +5561,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get howItWorks => 'Cách hoạt động';
 
   @override
-  String get dailyScoreExplanation =>
-      'Điểm hàng ngày dựa trên việc hoàn thành nhiệm vụ. Hoàn thành nhiệm vụ để cải thiện điểm!';
+  String get dailyScoreExplanation => 'Điểm hàng ngày dựa trên việc hoàn thành nhiệm vụ. Hoàn thành nhiệm vụ để cải thiện điểm!';
 
   @override
   String get notificationFrequencyDescription => 'Kiểm soát tần suất Omi gửi thông báo và nhắc nhở chủ động cho bạn.';
@@ -5982,8 +5864,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get webhookUrlNotSet => 'URL Webhook chưa được đặt';
 
   @override
-  String get setWebhookUrlInSettings =>
-      'Vui lòng đặt URL webhook trong cài đặt nhà phát triển để sử dụng tính năng này.';
+  String get setWebhookUrlInSettings => 'Vui lòng đặt URL webhook trong cài đặt nhà phát triển để sử dụng tính năng này.';
 
   @override
   String get sendWebUrl => 'Gửi URL web';
@@ -6135,12 +6016,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get batteryDrainSignificantly => 'Tiêu hao pin sẽ tăng đáng kể.';
 
   @override
-  String get premiumMinutesMonth =>
-      '1.200 phút premium/tháng. Tab Trên thiết bị cung cấp phiên âm miễn phí không giới hạn. ';
+  String get premiumMinutesMonth => '1.200 phút premium/tháng. Tab Trên thiết bị cung cấp phiên âm miễn phí không giới hạn. ';
 
   @override
-  String get audioProcessedLocally =>
-      'Âm thanh được xử lý cục bộ. Hoạt động ngoại tuyến, riêng tư hơn, nhưng sử dụng nhiều pin hơn.';
+  String get audioProcessedLocally => 'Âm thanh được xử lý cục bộ. Hoạt động ngoại tuyến, riêng tư hơn, nhưng sử dụng nhiều pin hơn.';
 
   @override
   String get languageLabel => 'Ngôn ngữ';
@@ -6149,12 +6028,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get modelLabel => 'Mô hình';
 
   @override
-  String get modelTooLargeWarning =>
-      'Mô hình này lớn và có thể khiến ứng dụng bị treo hoặc chạy rất chậm trên thiết bị di động.\n\nKhuyến nghị sử dụng small hoặc base.';
+  String get modelTooLargeWarning => 'Mô hình này lớn và có thể khiến ứng dụng bị treo hoặc chạy rất chậm trên thiết bị di động.\n\nKhuyến nghị sử dụng small hoặc base.';
 
   @override
-  String get nativeEngineNoDownload =>
-      'Công cụ giọng nói gốc của thiết bị sẽ được sử dụng. Không cần tải xuống mô hình.';
+  String get nativeEngineNoDownload => 'Công cụ giọng nói gốc của thiết bị sẽ được sử dụng. Không cần tải xuống mô hình.';
 
   @override
   String modelReadyWithName(String model) {
@@ -6190,8 +6067,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get omiTranscriptionOptimized =>
-      'Phiên âm trực tiếp tích hợp của Omi được tối ưu hóa cho các cuộc hội thoại thời gian thực với phát hiện người nói tự động và phân tách người nói.';
+  String get omiTranscriptionOptimized => 'Phiên âm trực tiếp tích hợp của Omi được tối ưu hóa cho các cuộc hội thoại thời gian thực với phát hiện người nói tự động và phân tách người nói.';
 
   @override
   String get reset => 'Đặt lại';
@@ -6411,8 +6287,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get buildingKnowledgeGraphFromMemories => 'Đang xây dựng biểu đồ tri thức từ ký ức...';
 
   @override
-  String get knowledgeGraphWillBuildAutomatically =>
-      'Biểu đồ tri thức của bạn sẽ được xây dựng tự động khi bạn tạo ký ức mới.';
+  String get knowledgeGraphWillBuildAutomatically => 'Biểu đồ tri thức của bạn sẽ được xây dựng tự động khi bạn tạo ký ức mới.';
 
   @override
   String get buildGraphButton => 'Xây dựng biểu đồ';
@@ -6648,8 +6523,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get failedToLoadContacts => 'Không thể tải danh bạ';
 
   @override
-  String get failedToPrepareConversationForSharing =>
-      'Không thể chuẩn bị cuộc trò chuyện để chia sẻ. Vui lòng thử lại.';
+  String get failedToPrepareConversationForSharing => 'Không thể chuẩn bị cuộc trò chuyện để chia sẻ. Vui lòng thử lại.';
 
   @override
   String get couldNotOpenSmsApp => 'Không thể mở ứng dụng SMS. Vui lòng thử lại.';
@@ -6715,8 +6589,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get downloadingAudioFromSdCard => 'Đang tải âm thanh từ thẻ SD của thiết bị';
 
   @override
-  String get transferRequiredDescription =>
-      'Bản ghi này được lưu trên thẻ SD của thiết bị. Chuyển nó sang điện thoại để phát.';
+  String get transferRequiredDescription => 'Bản ghi này được lưu trên thẻ SD của thiết bị. Chuyển nó sang điện thoại để phát.';
 
   @override
   String get cancelTransfer => 'Hủy Chuyển';
@@ -6737,8 +6610,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get shareRecording => 'Chia sẻ Bản ghi';
 
   @override
-  String get deleteRecordingConfirmation =>
-      'Bạn có chắc chắn muốn xóa vĩnh viễn bản ghi này? Hành động này không thể hoàn tác.';
+  String get deleteRecordingConfirmation => 'Bạn có chắc chắn muốn xóa vĩnh viễn bản ghi này? Hành động này không thể hoàn tác.';
 
   @override
   String get recordingIdLabel => 'ID Bản ghi';
@@ -6797,8 +6669,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get enableFastTransfer => 'Bật truyền nhanh';
 
   @override
-  String get fastTransferDescription =>
-      'Truyền nhanh sử dụng WiFi để đạt tốc độ nhanh hơn ~5 lần. Điện thoại của bạn sẽ tạm thời kết nối với mạng WiFi của thiết bị Omi trong quá trình truyền.';
+  String get fastTransferDescription => 'Truyền nhanh sử dụng WiFi để đạt tốc độ nhanh hơn ~5 lần. Điện thoại của bạn sẽ tạm thời kết nối với mạng WiFi của thiết bị Omi trong quá trình truyền.';
 
   @override
   String get internetAccessPausedDuringTransfer => 'Truy cập internet bị tạm dừng trong quá trình truyền';
@@ -6813,8 +6684,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get fiveTimesFaster => 'NHANH HƠN 5 LẦN';
 
   @override
-  String get fastTransferMethodDescription =>
-      'Tạo kết nối WiFi trực tiếp đến thiết bị Omi. Điện thoại của bạn tạm thời ngắt kết nối WiFi thông thường trong quá trình truyền.';
+  String get fastTransferMethodDescription => 'Tạo kết nối WiFi trực tiếp đến thiết bị Omi. Điện thoại của bạn tạm thời ngắt kết nối WiFi thông thường trong quá trình truyền.';
 
   @override
   String get bluetooth => 'Bluetooth';
@@ -6823,8 +6693,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get bleSpeed => '~30 KB/s qua BLE';
 
   @override
-  String get bluetoothMethodDescription =>
-      'Sử dụng kết nối Bluetooth Low Energy tiêu chuẩn. Chậm hơn nhưng không ảnh hưởng đến kết nối WiFi của bạn.';
+  String get bluetoothMethodDescription => 'Sử dụng kết nối Bluetooth Low Energy tiêu chuẩn. Chậm hơn nhưng không ảnh hưởng đến kết nối WiFi của bạn.';
 
   @override
   String get selected => 'Đã chọn';
@@ -6862,12 +6731,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get appDeleteFailed => 'Không thể xóa ứng dụng. Vui lòng thử lại sau.';
 
   @override
-  String get appVisibilityChangedSuccessfully =>
-      'Đã thay đổi chế độ hiển thị ứng dụng thành công. Có thể mất vài phút để cập nhật.';
+  String get appVisibilityChangedSuccessfully => 'Đã thay đổi chế độ hiển thị ứng dụng thành công. Có thể mất vài phút để cập nhật.';
 
   @override
-  String get errorActivatingAppIntegration =>
-      'Lỗi khi kích hoạt ứng dụng. Nếu đây là ứng dụng tích hợp, hãy đảm bảo rằng việc thiết lập đã hoàn tất.';
+  String get errorActivatingAppIntegration => 'Lỗi khi kích hoạt ứng dụng. Nếu đây là ứng dụng tích hợp, hãy đảm bảo rằng việc thiết lập đã hoàn tất.';
 
   @override
   String get errorUpdatingAppStatus => 'Đã xảy ra lỗi khi cập nhật trạng thái ứng dụng.';
@@ -6947,8 +6814,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get nameMustBeAtLeast3Characters => 'Tên phải có ít nhất 3 ký tự';
 
   @override
-  String get conversationPromptHint =>
-      'VD: Trích xuất các hành động, quyết định và điểm chính từ cuộc hội thoại được cung cấp.';
+  String get conversationPromptHint => 'VD: Trích xuất các hành động, quyết định và điểm chính từ cuộc hội thoại được cung cấp.';
 
   @override
   String get pleaseEnterAppPrompt => 'Vui lòng nhập lời nhắc cho ứng dụng của bạn';
@@ -7135,15 +7001,13 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get planUpgradeScheduledMessage =>
-      'Đã lên lịch nâng cấp! Gói hàng tháng của bạn tiếp tục cho đến cuối kỳ thanh toán.';
+  String get planUpgradeScheduledMessage => 'Đã lên lịch nâng cấp! Gói hàng tháng của bạn tiếp tục cho đến cuối kỳ thanh toán.';
 
   @override
   String get couldNotSchedulePlanChange => 'Không thể lên lịch thay đổi gói. Vui lòng thử lại.';
 
   @override
-  String get subscriptionReactivatedDefault =>
-      'Đăng ký của bạn đã được kích hoạt lại! Không tính phí ngay - bạn sẽ được thanh toán vào đầu kỳ thanh toán tiếp theo.';
+  String get subscriptionReactivatedDefault => 'Đăng ký của bạn đã được kích hoạt lại! Không tính phí ngay - bạn sẽ được thanh toán vào đầu kỳ thanh toán tiếp theo.';
 
   @override
   String get subscriptionSuccessfulCharged => 'Đăng ký thành công! Bạn đã được tính phí cho kỳ thanh toán mới.';
@@ -7339,8 +7203,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get onboardingNotificationDeniedSystemPrefs =>
-      'Quyền thông báo bị từ chối. Vui lòng bật trong cài đặt hệ thống.';
+  String get onboardingNotificationDeniedSystemPrefs => 'Quyền thông báo bị từ chối. Vui lòng bật trong cài đặt hệ thống.';
 
   @override
   String get onboardingNotificationDeniedNotifications => 'Quyền thông báo bị từ chối. Vui lòng bật thông báo.';
@@ -7503,8 +7366,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get locationPermissionRequired => 'Cần Quyền Vị trí';
 
   @override
-  String get locationPermissionContent =>
-      'Ứng dụng cần quyền truy cập vị trí để hoạt động đúng. Vui lòng cấp quyền trong cài đặt.';
+  String get locationPermissionContent => 'Ứng dụng cần quyền truy cập vị trí để hoạt động đúng. Vui lòng cấp quyền trong cài đặt.';
 
   @override
   String get pdfTranscriptExport => 'Xuất Bản ghi';
@@ -7963,8 +7825,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get pairingTitleOmiDevkit => 'Đặt Omi DevKit vào chế độ ghép nối';
 
   @override
-  String get pairingDescOmiDevkit =>
-      'Nhấn nút một lần để bật nguồn. Đèn LED sẽ nhấp nháy màu tím khi ở chế độ ghép nối.';
+  String get pairingDescOmiDevkit => 'Nhấn nút một lần để bật nguồn. Đèn LED sẽ nhấp nháy màu tím khi ở chế độ ghép nối.';
 
   @override
   String get pairingTitleOmiGlass => 'Bật Omi Glass';
@@ -7976,8 +7837,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get pairingTitlePlaudNote => 'Đặt Plaud Note vào chế độ ghép nối';
 
   @override
-  String get pairingDescPlaudNote =>
-      'Nhấn và giữ nút bên cạnh trong 2 giây. Đèn LED đỏ sẽ nhấp nháy khi sẵn sàng ghép nối.';
+  String get pairingDescPlaudNote => 'Nhấn và giữ nút bên cạnh trong 2 giây. Đèn LED đỏ sẽ nhấp nháy khi sẵn sàng ghép nối.';
 
   @override
   String get pairingTitleBee => 'Đặt Bee vào chế độ ghép nối';
@@ -7989,15 +7849,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get pairingTitleLimitless => 'Đặt Limitless vào chế độ ghép nối';
 
   @override
-  String get pairingDescLimitless =>
-      'Khi có đèn sáng, nhấn một lần rồi nhấn và giữ cho đến khi thiết bị hiện đèn hồng, sau đó thả ra.';
+  String get pairingDescLimitless => 'Khi có đèn sáng, nhấn một lần rồi nhấn và giữ cho đến khi thiết bị hiện đèn hồng, sau đó thả ra.';
 
   @override
   String get pairingTitleFriendPendant => 'Đặt Friend Pendant vào chế độ ghép nối';
 
   @override
-  String get pairingDescFriendPendant =>
-      'Nhấn nút trên mặt dây chuyền để bật nguồn. Thiết bị sẽ tự động vào chế độ ghép nối.';
+  String get pairingDescFriendPendant => 'Nhấn nút trên mặt dây chuyền để bật nguồn. Thiết bị sẽ tự động vào chế độ ghép nối.';
 
   @override
   String get pairingTitleFieldy => 'Đặt Fieldy vào chế độ ghép nối';
@@ -8009,15 +7867,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get pairingTitleAppleWatch => 'Kết nối Apple Watch';
 
   @override
-  String get pairingDescAppleWatch =>
-      'Cài đặt và mở ứng dụng Omi trên Apple Watch của bạn, sau đó nhấn Kết nối trong ứng dụng.';
+  String get pairingDescAppleWatch => 'Cài đặt và mở ứng dụng Omi trên Apple Watch của bạn, sau đó nhấn Kết nối trong ứng dụng.';
 
   @override
   String get pairingTitleNeoOne => 'Đặt Neo One vào chế độ ghép nối';
 
   @override
-  String get pairingDescNeoOne =>
-      'Nhấn và giữ nút nguồn cho đến khi đèn LED nhấp nháy. Thiết bị sẽ có thể được phát hiện.';
+  String get pairingDescNeoOne => 'Nhấn và giữ nút nguồn cho đến khi đèn LED nhấp nháy. Thiết bị sẽ có thể được phát hiện.';
 
   @override
   String get downloadingFromDevice => 'Đang tải xuống từ thiết bị';
@@ -8105,8 +7961,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get onboardingWhatIKnowAboutYouTitle => 'Đây là những gì tôi biết về bạn';
 
   @override
-  String get onboardingWhatIKnowAboutYouDescription =>
-      'Bản đồ này được cập nhật khi Omi học hỏi từ các cuộc trò chuyện của bạn.';
+  String get onboardingWhatIKnowAboutYouDescription => 'Bản đồ này được cập nhật khi Omi học hỏi từ các cuộc trò chuyện của bạn.';
 
   @override
   String get apiEnvironment => 'Môi trường API';
@@ -8135,8 +7990,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get switchAndRestart => 'Chuyển';
 
   @override
-  String get stagingDisclaimer =>
-      'Môi trường thử nghiệm có thể không ổn định, hiệu suất không nhất quán và dữ liệu có thể bị mất. Chỉ dùng để thử nghiệm.';
+  String get stagingDisclaimer => 'Môi trường thử nghiệm có thể không ổn định, hiệu suất không nhất quán và dữ liệu có thể bị mất. Chỉ dùng để thử nghiệm.';
 
   @override
   String get apiEnvSavedRestartRequired => 'Đã lưu. Đóng và mở lại ứng dụng để áp dụng thay đổi.';
@@ -8365,8 +8219,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get phoneCallsUnlimitedOnly => 'Cuộc gọi điện thoại qua Omi';
 
   @override
-  String get phoneCallsUpsellSubtitle =>
-      'Gọi điện qua Omi và nhận phiên âm thời gian thực, tóm tắt tự động và nhiều hơn nữa.';
+  String get phoneCallsUpsellSubtitle => 'Gọi điện qua Omi và nhận phiên âm thời gian thực, tóm tắt tự động và nhiều hơn nữa.';
 
   @override
   String get phoneCallsUpsellFeature1 => 'Phiên âm thời gian thực mọi cuộc gọi';
@@ -8405,8 +8258,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deletePendingFiles => 'Xóa bản ghi đang chờ';
 
   @override
-  String get deletePendingFilesWarning =>
-      'Các bản ghi này CHƯA được đồng bộ với điện thoại của bạn và sẽ bị mất vĩnh viễn. Không thể hoàn tác.';
+  String get deletePendingFilesWarning => 'Các bản ghi này CHƯA được đồng bộ với điện thoại của bạn và sẽ bị mất vĩnh viễn. Không thể hoàn tác.';
 
   @override
   String get pendingFilesDeleted => 'Đã xóa bản ghi đang chờ';
@@ -8418,8 +8270,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deleteAll => 'Xóa tất cả';
 
   @override
-  String get deleteAllFilesWarning =>
-      'Thao tác này sẽ xóa các bản ghi đã đồng bộ và đang chờ. Bản ghi đang chờ CHƯA được đồng bộ và sẽ bị mất vĩnh viễn.';
+  String get deleteAllFilesWarning => 'Thao tác này sẽ xóa các bản ghi đã đồng bộ và đang chờ. Bản ghi đang chờ CHƯA được đồng bộ và sẽ bị mất vĩnh viễn.';
 
   @override
   String get allFilesDeleted => 'Đã xóa tất cả bản ghi';
@@ -8484,8 +8335,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get fairUseAboutTitle => 'Về sử dụng hợp lý';
 
   @override
-  String get fairUseAboutBody =>
-      'Omi được thiết kế cho các cuộc trò chuyện cá nhân, cuộc họp và tương tác trực tiếp. Mức sử dụng được đo bằng thời gian nói thực tế được phát hiện, không phải thời gian kết nối. Nếu mức sử dụng vượt quá đáng kể các mẫu bình thường cho nội dung không cá nhân, có thể áp dụng các điều chỉnh.';
+  String get fairUseAboutBody => 'Omi được thiết kế cho các cuộc trò chuyện cá nhân, cuộc họp và tương tác trực tiếp. Mức sử dụng được đo bằng thời gian nói thực tế được phát hiện, không phải thời gian kết nối. Nếu mức sử dụng vượt quá đáng kể các mẫu bình thường cho nội dung không cá nhân, có thể áp dụng các điều chỉnh.';
 
   @override
   String fairUseCaseRefCopied(String caseRef) {
@@ -8523,8 +8373,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get improveConnectionTitle => 'Cải thiện kết nối';
 
   @override
-  String get improveConnectionContent =>
-      'Chúng tôi đã cải thiện cách Omi duy trì kết nối với thiết bị của bạn. Để kích hoạt, hãy vào trang Thông tin thiết bị, nhấn \"Ngắt kết nối thiết bị\", rồi ghép nối lại thiết bị.';
+  String get improveConnectionContent => 'Chúng tôi đã cải thiện cách Omi duy trì kết nối với thiết bị của bạn. Để kích hoạt, hãy vào trang Thông tin thiết bị, nhấn \"Ngắt kết nối thiết bị\", rồi ghép nối lại thiết bị.';
 
   @override
   String get improveConnectionAction => 'Đã hiểu';
@@ -8579,15 +8428,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get cancelSyncQuestion => 'Hủy đồng bộ?';
 
   @override
-  String get omisStorageDesc =>
-      'Khi Omi không kết nối với điện thoại, nó lưu trữ âm thanh cục bộ trong bộ nhớ tích hợp. Bạn sẽ không bao giờ mất bản ghi.';
+  String get omisStorageDesc => 'Khi Omi không kết nối với điện thoại, nó lưu trữ âm thanh cục bộ trong bộ nhớ tích hợp. Bạn sẽ không bao giờ mất bản ghi.';
 
   @override
   String get phoneStorageDesc => 'Khi Omi kết nối lại, bản ghi tự động chuyển sang điện thoại trước khi tải lên.';
 
   @override
-  String get cloudStorageDesc =>
-      'Sau khi tải lên, bản ghi của bạn được xử lý và chuyển thành văn bản. Cuộc trò chuyện sẽ có trong vòng một phút.';
+  String get cloudStorageDesc => 'Sau khi tải lên, bản ghi của bạn được xử lý và chuyển thành văn bản. Cuộc trò chuyện sẽ có trong vòng một phút.';
 
   @override
   String get tipKeepPhoneNearby => 'Giữ điện thoại gần để đồng bộ nhanh hơn';
@@ -8611,12 +8458,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get permissionEnable => 'Bật';
 
   @override
-  String get permissionsPageDescription =>
-      'Các quyền này rất quan trọng đối với hoạt động của Omi. Chúng kích hoạt các tính năng chính như thông báo, trải nghiệm dựa trên vị trí và ghi âm.';
+  String get permissionsPageDescription => 'Các quyền này rất quan trọng đối với hoạt động của Omi. Chúng kích hoạt các tính năng chính như thông báo, trải nghiệm dựa trên vị trí và ghi âm.';
 
   @override
-  String get permissionsRequiredDescription =>
-      'Omi cần một số quyền để hoạt động bình thường. Vui lòng cấp quyền để tiếp tục.';
+  String get permissionsRequiredDescription => 'Omi cần một số quyền để hoạt động bình thường. Vui lòng cấp quyền để tiếp tục.';
 
   @override
   String get permissionsSetupTitle => 'Trải nghiệm tốt nhất';
@@ -8893,8 +8738,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get firmwareWarningTitle => 'Quan trọng: Đọc trước khi cập nhật';
 
   @override
-  String get firmwareFormatWarning =>
-      'Firmware này sẽ định dạng thẻ SD. Vui lòng đảm bảo tất cả dữ liệu ngoại tuyến đã được đồng bộ trước khi nâng cấp.\n\nNếu bạn thấy đèn đỏ nhấp nháy sau khi cài đặt phiên bản này, đừng lo lắng. Chỉ cần kết nối thiết bị với ứng dụng và nó sẽ chuyển sang màu xanh. Đèn đỏ có nghĩa là đồng hồ của thiết bị chưa được đồng bộ.';
+  String get firmwareFormatWarning => 'Firmware này sẽ định dạng thẻ SD. Vui lòng đảm bảo tất cả dữ liệu ngoại tuyến đã được đồng bộ trước khi nâng cấp.\n\nNếu bạn thấy đèn đỏ nhấp nháy sau khi cài đặt phiên bản này, đừng lo lắng. Chỉ cần kết nối thiết bị với ứng dụng và nó sẽ chuyển sang màu xanh. Đèn đỏ có nghĩa là đồng hồ của thiết bị chưa được đồng bộ.';
 
   @override
   String get continueAnyway => 'Tiếp tục';
@@ -8914,8 +8758,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get tasksMarkComplete => 'Đã đánh dấu hoàn thành';
 
   @override
-  String get appleHealthManageNote =>
-      'Omi truy cập Apple Health thông qua framework HealthKit của Apple. Bạn có thể thu hồi quyền truy cập bất cứ lúc nào trong Cài đặt iOS.';
+  String get appleHealthManageNote => 'Omi truy cập Apple Health thông qua framework HealthKit của Apple. Bạn có thể thu hồi quyền truy cập bất cứ lúc nào trong Cài đặt iOS.';
 
   @override
   String get appleHealthConnectCta => 'Kết nối với Apple Health';
@@ -8948,8 +8791,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get appleHealthDeniedTitle => 'Truy cập Apple Health bị từ chối';
 
   @override
-  String get appleHealthDeniedBody =>
-      'Omi không có quyền đọc dữ liệu Apple Health của bạn. Bật tính năng này trong Cài đặt iOS → Quyền riêng tư & Bảo mật → Sức khỏe → Omi.';
+  String get appleHealthDeniedBody => 'Omi không có quyền đọc dữ liệu Apple Health của bạn. Bật tính năng này trong Cài đặt iOS → Quyền riêng tư & Bảo mật → Sức khỏe → Omi.';
 
   @override
   String get deleteFlowReasonTitle => 'Vì sao bạn rời đi?';
@@ -9018,8 +8860,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get planUpdate => 'Cập nhật gói';
 
   @override
-  String get planDeprecationMessage =>
-      'Gói Unlimited của bạn đang được ngừng cung cấp. Chuyển sang gói Operator — cùng các tính năng tuyệt vời với giá \$49/tháng. Gói hiện tại của bạn sẽ tiếp tục hoạt động trong thời gian chờ đợi.';
+  String get planDeprecationMessage => 'Gói Unlimited của bạn đang được ngừng cung cấp. Chuyển sang gói Operator — cùng các tính năng tuyệt vời với giá \$49/tháng. Gói hiện tại của bạn sẽ tiếp tục hoạt động trong thời gian chờ đợi.';
 
   @override
   String get upgradeYourPlan => 'Nâng cấp gói của bạn';
@@ -9130,8 +8971,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get chatQuotaSubtitle => 'AI chat messages used with Omi this month.';
 
   @override
-  String get chatQuotaExceededReply =>
-      'Bạn đã đạt giới hạn hàng tháng. Nâng cấp để tiếp tục trò chuyện với Omi không giới hạn.';
+  String get chatQuotaExceededReply => 'Bạn đã đạt giới hạn hàng tháng. Nâng cấp để tiếp tục trò chuyện với Omi không giới hạn.';
 
   @override
   String get voiceResponseAudio => 'Đọc to phản hồi của Omi';
@@ -9162,4 +9002,25 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => 'Thêm nhiệm vụ';
+
+  @override
+  String get quickActionAskOmiAnything => 'Hỏi Omi bất cứ điều gì';
+
+  @override
+  String get quickActionVoiceMode => 'Chế độ giọng nói';
+
+  @override
+  String get quickActionMute => 'Tắt tiếng';
+
+  @override
+  String get quickActionUnmute => 'Bật tiếng';
+
+  @override
+  String get quickActionConnectDevice => 'Kết nối thiết bị';
+
+  @override
+  String get quickActionDeviceSettings => 'Cài đặt thiết bị';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -4274,8 +4274,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get secureEncryption => '安全加密';
 
   @override
-  String get secureEncryptionDescription =>
-      '您的数据使用您独有的密钥在我们托管于Google Cloud的服务器上加密。这意味着包括Omi员工或Google在内的任何人都无法直接从数据库访问您的原始内容。';
+  String get secureEncryptionDescription => '您的数据使用您独有的密钥在我们托管于Google Cloud的服务器上加密。这意味着包括Omi员工或Google在内的任何人都无法直接从数据库访问您的原始内容。';
 
   @override
   String get endToEndEncryption => '端到端加密';
@@ -4987,8 +4986,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get additionalSpeechSampleRemoved => '已删除附加语音样本';
 
   @override
-  String get consentDataMessage =>
-      '继续即表示您的对话、录音和个人信息将安全存储在我们的服务器上。您的音频录音和转录由第三方AI服务处理（包括用于转录的Deepgram和用于分析的OpenAI），以为您提供AI驱动的洞察并启用所有应用功能。';
+  String get consentDataMessage => '继续即表示您的对话、录音和个人信息将安全存储在我们的服务器上。您的音频录音和转录由第三方AI服务处理（包括用于转录的Deepgram和用于分析的OpenAI），以为您提供AI驱动的洞察并启用所有应用功能。';
 
   @override
   String get tasksEmptyStateMessage => '来自您对话的任务将显示在这里。\n点击 + 手动创建。';
@@ -8734,8 +8732,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get firmwareWarningTitle => '重要：更新前请阅读';
 
   @override
-  String get firmwareFormatWarning =>
-      '此固件将格式化SD卡。请确保在升级前同步所有离线数据。\n\n如果安装此版本后看到红灯闪烁，请不要担心。只需将设备连接到应用程序，它应该会变成蓝色。红灯表示设备的时钟尚未同步。';
+  String get firmwareFormatWarning => '此固件将格式化SD卡。请确保在升级前同步所有离线数据。\n\n如果安装此版本后看到红灯闪烁，请不要担心。只需将设备连接到应用程序，它应该会变成蓝色。红灯表示设备的时钟尚未同步。';
 
   @override
   String get continueAnyway => '继续';
@@ -8999,4 +8996,25 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get mindMap => 'Mind Map';
+
+  @override
+  String get quickActionAddTask => '添加任务';
+
+  @override
+  String get quickActionAskOmiAnything => '问Omi任何问题';
+
+  @override
+  String get quickActionVoiceMode => '语音模式';
+
+  @override
+  String get quickActionMute => '静音';
+
+  @override
+  String get quickActionUnmute => '取消静音';
+
+  @override
+  String get quickActionConnectDevice => '连接设备';
+
+  @override
+  String get quickActionDeviceSettings => '设备设置';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Pridėti užduotį",
+  "quickActionAskOmiAnything": "Paklauskite Omi bet ko",
+  "quickActionVoiceMode": "Balso režimas",
+  "quickActionMute": "Nutildyti",
+  "quickActionUnmute": "Įjungti garsą",
+  "quickActionConnectDevice": "Prijungti įrenginį",
+  "quickActionDeviceSettings": "Įrenginio nustatymai"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Pievienot uzdevumu",
+  "quickActionAskOmiAnything": "Jautājiet Omi jebko",
+  "quickActionVoiceMode": "Balss režīms",
+  "quickActionMute": "Izslēgt skaņu",
+  "quickActionUnmute": "Ieslēgt skaņu",
+  "quickActionConnectDevice": "Savienot ierīci",
+  "quickActionDeviceSettings": "Ierīces iestatījumi"
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Додај задача",
+  "quickActionAskOmiAnything": "Прашај го Omi за нешто",
+  "quickActionVoiceMode": "Гласовен режим",
+  "quickActionMute": "Исклучи звук",
+  "quickActionUnmute": "Вклучи звук",
+  "quickActionConnectDevice": "Поврзи уред",
+  "quickActionDeviceSettings": "Поставки на уред"
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "कार्य जोडा",
+  "quickActionAskOmiAnything": "Omi ला काहीही विचारा",
+  "quickActionVoiceMode": "आवाज मोड",
+  "quickActionMute": "म्यूट करा",
+  "quickActionUnmute": "म्यूट रद्द करा",
+  "quickActionConnectDevice": "डिव्हाइस जोडा",
+  "quickActionDeviceSettings": "डिव्हाइस सेटिंग्ज"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Tambah Tugas",
+  "quickActionAskOmiAnything": "Tanya Omi apa sahaja",
+  "quickActionVoiceMode": "Mod Suara",
+  "quickActionMute": "Redam",
+  "quickActionUnmute": "Nyahredam",
+  "quickActionConnectDevice": "Sambung Peranti",
+  "quickActionDeviceSettings": "Tetapan Peranti"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Taak toevoegen",
+  "quickActionAskOmiAnything": "Vraag Omi van alles",
+  "quickActionVoiceMode": "Spraakmodus",
+  "quickActionMute": "Dempen",
+  "quickActionUnmute": "Dempen opheffen",
+  "quickActionConnectDevice": "Apparaat verbinden",
+  "quickActionDeviceSettings": "Apparaatinstellingen"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Legg til oppgave",
+  "quickActionAskOmiAnything": "Spør Omi om hva som helst",
+  "quickActionVoiceMode": "Stemmetilstand",
+  "quickActionMute": "Demp",
+  "quickActionUnmute": "Opphev demping",
+  "quickActionConnectDevice": "Koble til enhet",
+  "quickActionDeviceSettings": "Enhetsinnstillinger"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3026,5 +3026,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Dodaj zadanie",
+  "quickActionAskOmiAnything": "Zapytaj Omi o cokolwiek",
+  "quickActionVoiceMode": "Tryb głosowy",
+  "quickActionMute": "Wycisz",
+  "quickActionUnmute": "Wyłącz wyciszenie",
+  "quickActionConnectDevice": "Podłącz urządzenie",
+  "quickActionDeviceSettings": "Ustawienia urządzenia"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3027,5 +3027,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Adicionar tarefa",
+  "quickActionAskOmiAnything": "Pergunte qualquer coisa ao Omi",
+  "quickActionVoiceMode": "Modo de voz",
+  "quickActionMute": "Silenciar",
+  "quickActionUnmute": "Ativar som",
+  "quickActionConnectDevice": "Conectar dispositivo",
+  "quickActionDeviceSettings": "Configurações do dispositivo"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Adaugă sarcină",
+  "quickActionAskOmiAnything": "Întreabă Omi orice",
+  "quickActionVoiceMode": "Mod voce",
+  "quickActionMute": "Dezactivare sunet",
+  "quickActionUnmute": "Activare sunet",
+  "quickActionConnectDevice": "Conectează dispozitiv",
+  "quickActionDeviceSettings": "Setări dispozitiv"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3026,5 +3026,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Добавить задачу",
+  "quickActionAskOmiAnything": "Спросите Omi о чём угодно",
+  "quickActionVoiceMode": "Голосовой режим",
+  "quickActionMute": "Отключить звук",
+  "quickActionUnmute": "Включить звук",
+  "quickActionConnectDevice": "Подключить устройство",
+  "quickActionDeviceSettings": "Настройки устройства"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2996,5 +2996,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Pridať úlohu",
+  "quickActionAskOmiAnything": "Opýtajte sa Omi čokoľvek",
+  "quickActionVoiceMode": "Hlasový režim",
+  "quickActionMute": "Stíšiť",
+  "quickActionUnmute": "Zrušiť stíšenie",
+  "quickActionConnectDevice": "Pripojiť zariadenie",
+  "quickActionDeviceSettings": "Nastavenia zariadenia"
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Dodaj nalogo",
+  "quickActionAskOmiAnything": "Vprašajte Omi karkoli",
+  "quickActionVoiceMode": "Glasovni način",
+  "quickActionMute": "Utišaj",
+  "quickActionUnmute": "Vklopi zvok",
+  "quickActionConnectDevice": "Poveži napravo",
+  "quickActionDeviceSettings": "Nastavitve naprave"
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Додај задатак",
+  "quickActionAskOmiAnything": "Питајте Omi шта год желите",
+  "quickActionVoiceMode": "Гласовни режим",
+  "quickActionMute": "Искључи звук",
+  "quickActionUnmute": "Укључи звук",
+  "quickActionConnectDevice": "Повежи уређај",
+  "quickActionDeviceSettings": "Подешавања уређаја"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Lägg till uppgift",
+  "quickActionAskOmiAnything": "Fråga Omi vad som helst",
+  "quickActionVoiceMode": "Röstläge",
+  "quickActionMute": "Stäng av ljud",
+  "quickActionUnmute": "Slå på ljud",
+  "quickActionConnectDevice": "Anslut enhet",
+  "quickActionDeviceSettings": "Enhetsinställningar"
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "பணி சேர்க்கவும்",
+  "quickActionAskOmiAnything": "Omi ஐ எதுவும் கேளுங்கள்",
+  "quickActionVoiceMode": "குரல் பயன்முறை",
+  "quickActionMute": "முடக்கு",
+  "quickActionUnmute": "முடக்கத்தை நீக்கு",
+  "quickActionConnectDevice": "சாதனத்தை இணைக்கவும்",
+  "quickActionDeviceSettings": "சாதன அமைப்புகள்"
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "పని జోడించండి",
+  "quickActionAskOmiAnything": "Omi ని ఏదైనా అడగండి",
+  "quickActionVoiceMode": "వాయిస్ మోడ్",
+  "quickActionMute": "మ్యూట్",
+  "quickActionUnmute": "అన్‌మ్యూట్",
+  "quickActionConnectDevice": "పరికరాన్ని కనెక్ట్ చేయండి",
+  "quickActionDeviceSettings": "పరికర సెట్టింగ్‌లు"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "เพิ่มงาน",
+  "quickActionAskOmiAnything": "ถาม Omi ได้ทุกอย่าง",
+  "quickActionVoiceMode": "โหมดเสียง",
+  "quickActionMute": "ปิดเสียง",
+  "quickActionUnmute": "เปิดเสียง",
+  "quickActionConnectDevice": "เชื่อมต่ออุปกรณ์",
+  "quickActionDeviceSettings": "การตั้งค่าอุปกรณ์"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Magdagdag ng Gawain",
+  "quickActionAskOmiAnything": "Itanong kay Omi ang kahit ano",
+  "quickActionVoiceMode": "Mode ng Boses",
+  "quickActionMute": "I-mute",
+  "quickActionUnmute": "I-unmute",
+  "quickActionConnectDevice": "I-connect ang Device",
+  "quickActionDeviceSettings": "Mga Setting ng Device"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3026,5 +3026,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Görev Ekle",
+  "quickActionAskOmiAnything": "Omi'ye herhangi bir şey sor",
+  "quickActionVoiceMode": "Ses Modu",
+  "quickActionMute": "Sesi Kapat",
+  "quickActionUnmute": "Sesi Aç",
+  "quickActionConnectDevice": "Cihaz Bağla",
+  "quickActionDeviceSettings": "Cihaz Ayarları"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2991,5 +2991,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Додати завдання",
+  "quickActionAskOmiAnything": "Запитайте Omi про будь-що",
+  "quickActionVoiceMode": "Голосовий режим",
+  "quickActionMute": "Вимкнути звук",
+  "quickActionUnmute": "Увімкнути звук",
+  "quickActionConnectDevice": "Підключити пристрій",
+  "quickActionDeviceSettings": "Налаштування пристрою"
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10699,5 +10699,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "کام شامل کریں",
+  "quickActionAskOmiAnything": "Omi سے کچھ بھی پوچھیں",
+  "quickActionVoiceMode": "آواز موڈ",
+  "quickActionMute": "خاموش کریں",
+  "quickActionUnmute": "آواز بحال کریں",
+  "quickActionConnectDevice": "ڈیوائس منسلک کریں",
+  "quickActionDeviceSettings": "ڈیوائس کی ترتیبات"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2996,5 +2996,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "Thêm nhiệm vụ",
+  "quickActionAskOmiAnything": "Hỏi Omi bất cứ điều gì",
+  "quickActionVoiceMode": "Chế độ giọng nói",
+  "quickActionMute": "Tắt tiếng",
+  "quickActionUnmute": "Bật tiếng",
+  "quickActionConnectDevice": "Kết nối thiết bị",
+  "quickActionDeviceSettings": "Cài đặt thiết bị"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3013,5 +3013,12 @@
   "mindMap": "Mind Map",
   "@mindMap": {
     "description": "Section header for memory knowledge graph on home page"
-  }
+  },
+  "quickActionAddTask": "添加任务",
+  "quickActionAskOmiAnything": "问Omi任何问题",
+  "quickActionVoiceMode": "语音模式",
+  "quickActionMute": "静音",
+  "quickActionUnmute": "取消静音",
+  "quickActionConnectDevice": "连接设备",
+  "quickActionDeviceSettings": "设备设置"
 }

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -134,6 +134,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
 
   CaptureProvider? _captureProvider;
   DeviceProvider? _deviceProviderForQuickActions;
+  CaptureProvider? _captureProviderForQuickActions;
 
   void _initiateApps() {
     context.read<AppProvider>().getApps();
@@ -483,6 +484,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
       QuickActionsService.instance.initialize(context);
       _deviceProviderForQuickActions = Provider.of<DeviceProvider>(context, listen: false);
       _deviceProviderForQuickActions!.addListener(_onDeviceStateChangedForQuickActions);
+      _captureProviderForQuickActions = Provider.of<CaptureProvider>(context, listen: false);
+      _captureProviderForQuickActions!.addListener(_onDeviceStateChangedForQuickActions);
     });
   }
 
@@ -1114,9 +1117,10 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
       deviceProvider.onDeviceConnected = null;
       deviceProvider.onOfflineDataDetected = null;
     } catch (_) {}
-    // Remove quick actions device listener
     _deviceProviderForQuickActions?.removeListener(_onDeviceStateChangedForQuickActions);
     _deviceProviderForQuickActions = null;
+    _captureProviderForQuickActions?.removeListener(_onDeviceStateChangedForQuickActions);
+    _captureProviderForQuickActions = null;
     // Clean up freemium handler
     _freemiumHandler.dispose();
     // Remove foreground task callback to prevent memory leak

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -54,6 +54,7 @@ import 'package:omi/providers/message_provider.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/providers/task_integration_provider.dart';
 import 'package:omi/services/apple_reminders_sync_service.dart';
+import 'package:omi/services/quick_actions_service.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/services/announcement_service.dart';
 import 'package:omi/services/notifications.dart';
@@ -132,6 +133,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
   final FreemiumSwitchHandler _freemiumHandler = FreemiumSwitchHandler();
 
   CaptureProvider? _captureProvider;
+  DeviceProvider? _deviceProviderForQuickActions;
 
   void _initiateApps() {
     context.read<AppProvider>().getApps();
@@ -433,6 +435,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
     _listenToFreemiumThreshold();
     _checkForAnnouncements();
     _registerAutoSyncCallback();
+    _initQuickActions();
     super.initState();
 
     // After init
@@ -472,6 +475,20 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
         }
       };
     });
+  }
+
+  void _initQuickActions() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      QuickActionsService.instance.initialize(context);
+      _deviceProviderForQuickActions = Provider.of<DeviceProvider>(context, listen: false);
+      _deviceProviderForQuickActions!.addListener(_onDeviceStateChangedForQuickActions);
+    });
+  }
+
+  void _onDeviceStateChangedForQuickActions() {
+    if (!mounted) return;
+    QuickActionsService.instance.updateShortcuts(context);
   }
 
   void _onDeviceConnectedForAnnouncements(BtDevice device) async {
@@ -1097,6 +1114,9 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
       deviceProvider.onDeviceConnected = null;
       deviceProvider.onOfflineDataDetected = null;
     } catch (_) {}
+    // Remove quick actions device listener
+    _deviceProviderForQuickActions?.removeListener(_onDeviceStateChangedForQuickActions);
+    _deviceProviderForQuickActions = null;
     // Clean up freemium handler
     _freemiumHandler.dispose();
     // Remove foreground task callback to prevent memory leak

--- a/app/lib/services/quick_actions_service.dart
+++ b/app/lib/services/quick_actions_service.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:quick_actions/quick_actions.dart';
+
+import 'package:omi/app_globals.dart';
+import 'package:omi/pages/action_items/widgets/action_item_form_sheet.dart';
+import 'package:omi/pages/chat/page.dart';
+import 'package:omi/pages/settings/device_settings.dart';
+import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/providers/device_provider.dart';
+import 'package:omi/providers/home_provider.dart';
+
+const _kAddTask = 'add_task';
+const _kAskOmi = 'ask_omi';
+const _kVoiceMode = 'voice_mode';
+const _kMute = 'mute';
+const _kUnmute = 'unmute';
+const _kConnectDevice = 'connect_device';
+const _kDeviceSettings = 'device_settings';
+
+class QuickActionsService {
+  static final QuickActionsService _instance = QuickActionsService._();
+  QuickActionsService._();
+  static QuickActionsService get instance => _instance;
+
+  final QuickActions _quickActions = const QuickActions();
+  bool _initialized = false;
+
+  void initialize(BuildContext context) {
+    if (!Platform.isIOS || _initialized) return;
+    _initialized = true;
+
+    _quickActions.initialize((shortcutType) {
+      _handleShortcut(shortcutType);
+    });
+
+    _updateShortcuts(context);
+  }
+
+  void updateShortcuts(BuildContext context) {
+    if (!Platform.isIOS) return;
+    _updateShortcuts(context);
+  }
+
+  void _updateShortcuts(BuildContext context) {
+    final deviceProvider = Provider.of<DeviceProvider>(context, listen: false);
+    final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
+
+    final isDeviceConnected = deviceProvider.isConnected;
+    final isMuted = captureProvider.recordingState.name == 'pause';
+
+    // iOS displays items in reverse array order (last = top of menu).
+    // Desired display (top→bottom): Add Task / Ask Omi Anything / Voice Mode / [Mute|Unmute] / Connect Device|Device Settings
+    final items = <ShortcutItem>[
+      ShortcutItem(
+        type: isDeviceConnected ? _kDeviceSettings : _kConnectDevice,
+        localizedTitle: isDeviceConnected ? 'Device Settings' : 'Connect Device',
+      ),
+      if (isDeviceConnected)
+        ShortcutItem(
+          type: isMuted ? _kUnmute : _kMute,
+          localizedTitle: isMuted ? 'Unmute' : 'Mute',
+        ),
+      const ShortcutItem(type: _kVoiceMode, localizedTitle: 'Voice Mode'),
+      const ShortcutItem(type: _kAskOmi, localizedTitle: 'Ask Omi Anything'),
+      const ShortcutItem(type: _kAddTask, localizedTitle: 'Add Task'),
+    ];
+
+    _quickActions.setShortcutItems(items);
+  }
+
+  void _handleShortcut(String shortcutType) {
+    final navigator = globalNavigatorKey.currentState;
+    final context = globalNavigatorKey.currentContext;
+    if (navigator == null || context == null) return;
+
+    switch (shortcutType) {
+      case _kAddTask:
+        _navigateToTasksAndOpenSheet(navigator, context);
+        break;
+      case _kAskOmi:
+        navigator.push(MaterialPageRoute(builder: (_) => const ChatPage(isPivotBottom: false)));
+        break;
+      case _kVoiceMode:
+        navigator.push(MaterialPageRoute(builder: (_) => const ChatPage(isPivotBottom: false, autoStartVoice: true)));
+        break;
+      case _kMute:
+        _toggleMute(context, mute: true);
+        break;
+      case _kUnmute:
+        _toggleMute(context, mute: false);
+        break;
+      case _kConnectDevice:
+        Provider.of<DeviceProvider>(context, listen: false).initiateConnection('QuickActions');
+        break;
+      case _kDeviceSettings:
+        navigator.push(MaterialPageRoute(builder: (_) => const DeviceSettings()));
+        break;
+    }
+  }
+
+  void _navigateToTasksAndOpenSheet(NavigatorState navigator, BuildContext context) {
+    Provider.of<HomeProvider>(context, listen: false).setIndex(2);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = globalNavigatorKey.currentContext;
+      if (ctx == null) return;
+      showModalBottomSheet(
+        context: ctx,
+        isScrollControlled: true,
+        backgroundColor: Colors.transparent,
+        builder: (_) => const ActionItemFormSheet(),
+      );
+    });
+  }
+
+  void _toggleMute(BuildContext context, {required bool mute}) {
+    final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
+    if (mute) {
+      if (captureProvider.havingRecordingDevice) {
+        captureProvider.pauseDeviceRecording();
+      } else {
+        captureProvider.stopStreamRecording();
+      }
+    } else {
+      if (captureProvider.havingRecordingDevice) {
+        captureProvider.resumeDeviceRecording();
+      } else {
+        captureProvider.streamRecording();
+      }
+    }
+  }
+}

--- a/app/lib/services/quick_actions_service.dart
+++ b/app/lib/services/quick_actions_service.dart
@@ -49,7 +49,7 @@ class QuickActionsService {
     final captureProvider = Provider.of<CaptureProvider>(context, listen: false);
 
     final isDeviceConnected = deviceProvider.isConnected;
-    final isMuted = captureProvider.recordingState.name == 'pause';
+    final isMuted = captureProvider.recordingState == RecordingState.pause;
 
     // iOS displays items in reverse array order (last = top of menu).
     // Desired display (top→bottom): Add Task / Ask Omi Anything / Voice Mode / [Mute|Unmute] / Connect Device|Device Settings

--- a/app/lib/services/quick_actions_service.dart
+++ b/app/lib/services/quick_actions_service.dart
@@ -11,6 +11,7 @@ import 'package:omi/pages/settings/device_settings.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/home_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
 
 const _kAddTask = 'add_task';
 const _kAskOmi = 'ask_omi';
@@ -53,19 +54,20 @@ class QuickActionsService {
 
     // iOS displays items in reverse array order (last = top of menu).
     // Desired display (top→bottom): Add Task / Ask Omi Anything / Voice Mode / [Mute|Unmute] / Connect Device|Device Settings
+    final l10n = context.l10n;
     final items = <ShortcutItem>[
       ShortcutItem(
         type: isDeviceConnected ? _kDeviceSettings : _kConnectDevice,
-        localizedTitle: isDeviceConnected ? 'Device Settings' : 'Connect Device',
+        localizedTitle: isDeviceConnected ? l10n.quickActionDeviceSettings : l10n.quickActionConnectDevice,
       ),
       if (isDeviceConnected)
         ShortcutItem(
           type: isMuted ? _kUnmute : _kMute,
-          localizedTitle: isMuted ? 'Unmute' : 'Mute',
+          localizedTitle: isMuted ? l10n.quickActionUnmute : l10n.quickActionMute,
         ),
-      const ShortcutItem(type: _kVoiceMode, localizedTitle: 'Voice Mode'),
-      const ShortcutItem(type: _kAskOmi, localizedTitle: 'Ask Omi Anything'),
-      const ShortcutItem(type: _kAddTask, localizedTitle: 'Add Task'),
+      ShortcutItem(type: _kVoiceMode, localizedTitle: l10n.quickActionVoiceMode),
+      ShortcutItem(type: _kAskOmi, localizedTitle: l10n.quickActionAskOmiAnything),
+      ShortcutItem(type: _kAddTask, localizedTitle: l10n.quickActionAddTask),
     ];
 
     _quickActions.setShortcutItems(items);

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -1466,18 +1466,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   mcumgr_flutter:
     dependency: "direct main"
     description:
@@ -1923,38 +1923,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  quick_actions:
-    dependency: "direct main"
-    description:
-      name: quick_actions
-      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
-  quick_actions_android:
-    dependency: transitive
-    description:
-      name: quick_actions_android
-      sha256: "8e491323342fa68420ca26a9bd5a2bbcdb526bda33db45b6427c6d139fb7316d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.29"
-  quick_actions_ios:
-    dependency: transitive
-    description:
-      name: quick_actions_ios
-      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.4"
-  quick_actions_platform_interface:
-    dependency: transitive
-    description:
-      name: quick_actions_platform_interface
-      sha256: "1fec7068db5122cd019e9340d3d7be5d36eab099695ef3402c7059ee058329a4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   recase:
     dependency: transitive
     description:
@@ -2260,10 +2228,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   time:
     dependency: transitive
     description:
@@ -2650,5 +2618,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1466,18 +1466,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   mcumgr_flutter:
     dependency: "direct main"
     description:
@@ -1923,6 +1923,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  quick_actions:
+    dependency: "direct main"
+    description:
+      name: quick_actions
+      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  quick_actions_android:
+    dependency: transitive
+    description:
+      name: quick_actions_android
+      sha256: "8e491323342fa68420ca26a9bd5a2bbcdb526bda33db45b6427c6d139fb7316d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.29"
+  quick_actions_ios:
+    dependency: transitive
+    description:
+      name: quick_actions_ios
+      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
+  quick_actions_platform_interface:
+    dependency: transitive
+    description:
+      name: quick_actions_platform_interface
+      sha256: "1fec7068db5122cd019e9340d3d7be5d36eab099695ef3402c7059ee058329a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   recase:
     dependency: transitive
     description:
@@ -2228,10 +2260,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:
@@ -2618,5 +2650,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -145,6 +145,7 @@ dependencies:
   pasteboard: ^0.4.0
   vector_math: ^2.2.0
   marionette_flutter: ^0.3.0
+  quick_actions: ^1.0.0
 
 dependency_overrides:
   js: ^0.7.1


### PR DESCRIPTION
## Summary

- Adds iOS home screen quick actions (long-press app icon) via the `quick_actions` package
- Registers 5 contextual shortcuts that update dynamically based on device state:
  - **Add Task** — navigates to Tasks page and opens the task creation sheet
  - **Ask Omi Anything** — navigates to Chat page
  - **Voice Mode** — navigates to Chat page with voice dictation auto-started
  - **Mute / Unmute** — toggles recording; only shown when a device is connected
  - **Connect Device** — shown when no device is paired; becomes **Device Settings** when connected
- Shortcuts re-sync whenever device connection or mute state changes

## Demo

https://github.com/user-attachments/assets/dc95959e-b818-4585-8f73-4cd487699b84

## Test plan

- [ ] Long-press Omi app icon on iOS home screen — confirm all shortcuts appear in correct order
- [ ] Tap **Add Task** — Tasks page opens with creation sheet
- [ ] Tap **Ask Omi Anything** — Chat page opens
- [ ] Tap **Voice Mode** — Chat page opens with dictation started
- [ ] With device connected: confirm **Mute** appears; tap it and confirm recording pauses; **Unmute** should then appear
- [ ] With device disconnected: confirm **Connect Device** appears; connect device and confirm it switches to **Device Settings**

Closes #7030

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>