### PR TITLE
desktop(tasks): stop launch-spam — cap promotions at one per trigger

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Stop creating up to 5 tasks (and notifications) on every app launch \u2014 task promotion now happens at the natural cadence (when you complete a task, or every 5 minutes at most one at a time)"
+  ],
   "releases": [
     {
       "version": "0.11.366",

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
@@ -55,7 +55,12 @@ actor TaskPromotionService {
         defer { isPromoting = false }
 
         var promotedTasks: [TaskActionItem] = []
-        let maxIterations = targetCount  // Safety cap
+        // Promote at most one task per trigger. Bursting up to targetCount
+        // promotions in a single fire posted up to 5 "New task" notifications
+        // back-to-back, which users perceived as spam. The 5-minute safety
+        // timer + on-complete/on-delete events naturally fill the user's
+        // task list one item at a time.
+        let maxIterations = 1
 
         for _ in 0..<maxIterations {
             do {
@@ -109,14 +114,6 @@ actor TaskPromotionService {
             }
         }
         return promotedTasks
-    }
-
-    /// App startup: ensure minimum tasks are present.
-    /// Returns promoted tasks so caller can insert them directly.
-    @discardableResult
-    func ensureMinimumOnStartup() async -> [TaskActionItem] {
-        log("TaskPromotion: Checking minimum on startup")
-        return await promoteIfNeeded(shouldNotify: false)
     }
 
     // MARK: - Notification Context

--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -488,14 +488,10 @@ class TasksStore: ObservableObject {
             let userId = UserDefaults.standard.string(forKey: "auth_userId") ?? "unknown"
             await backfillRelevanceScoresIfNeeded(userId: userId)
         }
-        // Ensure minimum promoted tasks on startup — insert directly, no full reload
-        Task {
-            let promoted = await TaskPromotionService.shared.ensureMinimumOnStartup()
-            if !promoted.isEmpty {
-                self.incompleteTasks.append(contentsOf: promoted)
-                log("TasksStore: Inserted \(promoted.count) promoted tasks on startup")
-            }
-        }
+        // Note: no startup task promotion. Promotion happens on the natural
+        // cadence — when the user completes/deletes a task, or via the
+        // 5-minute safety-net timer. Bursting up to 5 promotions on every
+        // launch felt like spam.
     }
 
     /// Load incomplete tasks (To Do) using local-first pattern (like Memories)


### PR DESCRIPTION
## Summary
Two related changes to stop the "5 tasks (and notifications) every time I launch the app" spam:

1. **Drop the startup `ensureMinimumOnStartup` call** from `TasksStore.loadTasks()`. It was promoting up to 5 staged tasks on every launch and inserting them as a burst into the visible task list. Even with `shouldNotify: false`, users perceived the row burst as spam — and on a fresh install with the safety timer's default `shouldNotify: true`, it produced a flurry of "New task: …" notifications shortly after launch.
2. **Cap `promoteIfNeeded` at one promotion per trigger** (was up to `targetCount = 5`). The 5-min safety timer + on-complete/on-delete events still naturally fill the user's list one item at a time, with a single notification per event.
3. Drops the now-unused `ensureMinimumOnStartup` wrapper.

Promotion now runs only on natural triggers: user completing/deleting a task, and the 5-minute safety-net timer — one task at a time.

## Test plan
- [ ] Quit "Omi Beta" / "Omi Dev", relaunch — no burst of new task rows on the Tasks tab
- [ ] Wait through one 5-min cycle while signed in — at most one "New task: …" notification, not five
- [ ] Complete a task — exactly one replacement gets promoted (and one notification fires)
- [ ] Confirm `xcrun swift build -c debug --package-path Desktop` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)