### PR TITLE
fix(backend): add missing test stubs causing 5 test files to fail

### DIFF
--- a/backend/tests/unit/test_daily_summary_race_condition.py
+++ b/backend/tests/unit/test_daily_summary_race_condition.py
@@ -74,9 +74,19 @@ for name in [
     "utils.llm.external_integrations",
     "utils.notifications",
     "utils.webhooks",
+    "utils.conversations",
+    "utils.conversations.factory",
 ]:
     if name not in sys.modules:
-        _stub_module(name)
+        mod = _stub_module(name)
+        if name == "utils.conversations":
+            mod.__path__ = []
+
+# deserialize_conversation must return an object with transcript_segments and discarded attrs.
+_mock_convo = MagicMock()
+_mock_convo.transcript_segments = [{"text": "hello"}]
+_mock_convo.discarded = False
+sys.modules["utils.conversations.factory"].deserialize_conversation = MagicMock(return_value=_mock_convo)
 
 # Add needed attrs to stubs
 utils_llm_ext = sys.modules["utils.llm.external_integrations"]

--- a/backend/tests/unit/test_llm_usage_endpoints.py
+++ b/backend/tests/unit/test_llm_usage_endpoints.py
@@ -58,6 +58,17 @@ for attr in [
 ]:
     setattr(redis_mod, attr, MagicMock())
 
+
+# try_catch_decorator is used by database.phone_call_usage — provide a passthrough.
+def _passthrough_decorator(func):
+    return func
+
+
+redis_mod.try_catch_decorator = _passthrough_decorator
+
+cache_mod = sys.modules["database.cache"]
+cache_mod.get_memory_cache = MagicMock(return_value=None)
+
 users_mod = sys.modules["database.users"]
 users_mod.get_user_transcription_preferences = MagicMock()
 users_mod.set_user_transcription_preferences = MagicMock()
@@ -78,15 +89,28 @@ for name in [
     "utils.llm.external_integrations",
     "utils.webhooks",
     "utils.other.storage",
+    "utils.phone_calls",
+    "database.phone_call_usage",
+    "database.phone_call_config",
 ]:
     sys.modules[name] = types.ModuleType(name)
 
 sys.modules["utils.apps"].get_available_app_by_id = MagicMock()
 subscription_mod = sys.modules["utils.subscription"]
-subscription_mod.get_plan_limits = MagicMock()
-subscription_mod.get_plan_features = MagicMock()
-subscription_mod.get_monthly_usage_for_subscription = MagicMock()
-subscription_mod.reconcile_basic_plan_with_stripe = MagicMock()
+for attr in [
+    "get_plan_limits",
+    "get_plan_features",
+    "get_monthly_usage_for_subscription",
+    "reconcile_basic_plan_with_stripe",
+    "get_chat_quota_snapshot",
+    "get_plan_display_name",
+    "filter_plans_for_user",
+    "should_show_new_plans",
+    "adapt_plans_for_legacy_client",
+    "legacy_plan_features",
+    "is_paid_plan",
+]:
+    setattr(subscription_mod, attr, MagicMock())
 subscription_mod.get_paid_plan_definitions = MagicMock(return_value=[])
 
 sys.modules["utils.llm.followup"].followup_question_prompt = MagicMock()
@@ -98,6 +122,9 @@ sys.modules["utils.llm.external_integrations"].generate_comprehensive_daily_summ
 
 sys.modules["utils.webhooks"].webhook_first_time_setup = MagicMock()
 
+phone_calls_mod = sys.modules["utils.phone_calls"]
+phone_calls_mod.get_quota_snapshot = MagicMock()
+
 storage_mod = sys.modules["utils.other.storage"]
 storage_mod.delete_all_conversation_recordings = MagicMock()
 storage_mod.get_speech_sample_signed_urls = MagicMock()
@@ -106,6 +133,7 @@ storage_mod.delete_user_person_speech_sample = MagicMock()
 
 endpoints_module = types.ModuleType("utils.other.endpoints")
 endpoints_module.get_current_user_uid = lambda: "test-user"
+endpoints_module.get_current_user_uid_no_byok_validation = lambda: "test-user"
 sys.modules["utils.other.endpoints"] = endpoints_module
 
 from fastapi import FastAPI

--- a/backend/tests/unit/test_mentor_notifications.py
+++ b/backend/tests/unit/test_mentor_notifications.py
@@ -102,6 +102,7 @@ mock_llm_mini.invoke = MagicMock(return_value=MagicMock(content='test'))
 clients_mod = _stub_module("utils.llm.clients")
 clients_mod.llm_mini = mock_llm_mini
 clients_mod.generate_embedding = MagicMock(return_value=[0] * 3072)
+clients_mod.get_llm = MagicMock(return_value=mock_llm_mini)
 
 # Stub usage tracker — set __path__ to real directory so proactive_notification.py can be found
 utils_mod = _stub_module("utils")

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -57,6 +57,8 @@ for attr in [
     "delete_memory_vector",
     "upsert_vector2",
     "update_vector_metadata",
+    "upsert_action_item_vectors_batch",
+    "delete_action_item_vectors_batch",
 ]:
     setattr(vector_db_mod, attr, MagicMock())
 

--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -56,6 +56,17 @@ for sub in [
     mod = _stub_module(f"database.{sub}")
     setattr(database_mod, sub, mod)
 
+# Stub vector_db functions used by routers.action_items
+vector_db_mod = sys.modules["database.vector_db"]
+for attr in [
+    "upsert_action_item_vector",
+    "upsert_action_item_vectors_batch",
+    "delete_action_item_vector",
+    "delete_action_item_vectors_batch",
+    "search_action_items_by_vector",
+]:
+    setattr(vector_db_mod, attr, MagicMock())
+
 # Stub LLM clients to avoid OpenAI API key requirement
 clients_mod = _stub_module("utils.llm.clients")
 clients_mod.llm_mini = MagicMock()


### PR DESCRIPTION
## Summary
- Fix 5 test files that fail at collection due to missing module stubs
- Test stubs fell behind as the codebase grew (new imports added to production code but not reflected in test stubs)

### Files fixed:
| Test file | Missing stub |
|-----------|-------------|
| `test_process_conversation_usage_context.py` | `upsert/delete_action_item_vectors_batch` in `database.vector_db` |
| `test_llm_usage_endpoints.py` | `database.cache.get_memory_cache`, `database.phone_call_*`, `utils.phone_calls`, expanded `utils.subscription`, `get_current_user_uid_no_byok_validation` |
| `test_daily_summary_race_condition.py` | `utils.conversations.factory.deserialize_conversation` |
| `test_mentor_notifications.py` | `get_llm` in `utils.llm.clients` |
| `test_task_sharing.py` | `vector_db` action item functions for `routers.action_items` |

## Test plan
- [x] `bash backend/test.sh` — all 5 previously-failing files now pass (48 test files pass before hitting a pre-existing failure in `test_storage_upload_audio_chunk_data_protection.py`)
- [x] Verified all failures are pre-existing on main (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_by AI for @beastoin_