### PR TITLE
fix(test): cancel WaveformSection periodic timer in test teardown

### DIFF
--- a/app/test/widgets/waveform_section_test.dart
+++ b/app/test/widgets/waveform_section_test.dart
@@ -76,6 +76,9 @@ void main() {
 
       // Widget should still be present and functional
       expect(find.byType(WaveformSection), findsOneWidget);
+
+      // Unmount widget tree to cancel the 250ms periodic timer in WaveformSection.dispose()
+      await tester.pumpWidget(const SizedBox.shrink());
     });
   });
 }


### PR DESCRIPTION
## Summary
- Fix `waveform_section_test.dart` failing with `!timersPending` assertion
- WaveformSection starts a 250ms `Timer.periodic` when `isPlaying=true`, but the test never unmounts the widget tree, leaving the timer active at teardown
- Add `pumpWidget(SizedBox.shrink())` at test end to trigger `dispose()` which cancels the timer

## Test plan
- [x] Run `cd app && flutter test test/widgets/waveform_section_test.dart` — passes without timer assertion error
- [x] Full test suite: 412/413 → 413/413 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)