### PR TITLE
fix(backend): add retry and fallback for KG extraction failures

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -62,6 +62,7 @@ pytest tests/unit/test_action_item_date_validation.py -v
 pytest tests/unit/test_tools_router.py -v
 pytest tests/unit/test_kg_user_type_mismatch.py -v
 pytest tests/unit/test_kg_edge_id_sanitization.py -v
+pytest tests/unit/test_kg_retry_fallback.py -v
 pytest tests/unit/test_listen_pipeline.py -v
 pytest tests/unit/test_fair_use_models.py -v
 pytest tests/unit/test_fair_use_engine.py -v

--- a/backend/tests/unit/test_kg_retry_fallback.py
+++ b/backend/tests/unit/test_kg_retry_fallback.py
@@ -1,0 +1,263 @@
+"""
+Tests for issue #6557: KG extraction retry and fallback.
+
+Verifies that knowledge_graph.py retries LLM invoke+parse as a unit
+(3 attempts with exponential backoff) and falls back gracefully when
+all attempts are exhausted.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import types
+from concurrent.futures import Future
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+import tenacity.nap
+
+# Disable tenacity sleep globally for this test module
+tenacity.nap.time.sleep = lambda seconds: None
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies before loading knowledge_graph via spec_from_file_location
+# ---------------------------------------------------------------------------
+
+# database.knowledge_graph
+_kg_db_stub = types.ModuleType("database.knowledge_graph")
+_kg_db_stub.get_knowledge_nodes = MagicMock(return_value=[])
+_kg_db_stub.upsert_knowledge_node = MagicMock(side_effect=lambda uid, data: data)
+_kg_db_stub.upsert_knowledge_edge = MagicMock(side_effect=lambda uid, data: data)
+_kg_db_stub.delete_knowledge_graph = MagicMock()
+_kg_db_stub.get_knowledge_graph = MagicMock(return_value={'nodes': [], 'edges': []})
+
+if "database" not in sys.modules or getattr(sys.modules["database"], "__file__", None) is None:
+    sys.modules["database"] = types.ModuleType("database")
+sys.modules["database.knowledge_graph"] = _kg_db_stub
+
+# utils.executors
+_executors_stub = types.ModuleType("utils.executors")
+_executors_stub.critical_executor = MagicMock()
+
+
+def _sync_submit(fn, *args, **kwargs):
+    f = Future()
+    try:
+        result = fn(*args, **kwargs)
+        f.set_result(result)
+    except Exception as e:
+        f.set_exception(e)
+    return f
+
+
+_mock_storage = MagicMock()
+_mock_storage.submit = _sync_submit
+_executors_stub.storage_executor = _mock_storage
+sys.modules["utils.executors"] = _executors_stub
+
+# utils.llm.clients — mock get_llm
+_mock_llm = MagicMock()
+_clients_stub = types.ModuleType("utils.llm.clients")
+_clients_stub.get_llm = MagicMock(return_value=_mock_llm)
+
+# utils.llm.usage_tracker — noop track_usage
+_tracker_stub = types.ModuleType("utils.llm.usage_tracker")
+
+
+@contextmanager
+def _noop_track(*args, **kwargs):
+    yield
+
+
+_tracker_stub.track_usage = _noop_track
+_features = MagicMock()
+_features.KNOWLEDGE_GRAPH = "knowledge_graph"
+_tracker_stub.Features = _features
+
+# Register utils.llm package stubs so relative imports in knowledge_graph.py resolve
+if "utils" not in sys.modules or getattr(sys.modules["utils"], "__file__", None) is None:
+    _utils_pkg = types.ModuleType("utils")
+    _utils_pkg.__path__ = []
+    sys.modules["utils"] = _utils_pkg
+if "utils.llm" not in sys.modules or getattr(sys.modules["utils.llm"], "__file__", None) is None:
+    _utils_llm_pkg = types.ModuleType("utils.llm")
+    _utils_llm_pkg.__path__ = []
+    sys.modules["utils.llm"] = _utils_llm_pkg
+sys.modules["utils.llm.clients"] = _clients_stub
+sys.modules["utils.llm.usage_tracker"] = _tracker_stub
+
+# Load knowledge_graph.py directly via spec_from_file_location
+_KG_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "utils", "llm", "knowledge_graph.py")
+_KG_PATH = os.path.normpath(_KG_PATH)
+_spec = importlib.util.spec_from_file_location("utils.llm.knowledge_graph", _KG_PATH)
+_kg_mod = importlib.util.module_from_spec(_spec)
+sys.modules["utils.llm.knowledge_graph"] = _kg_mod
+_spec.loader.exec_module(_kg_mod)
+
+# Pull out the symbols we need
+KG_RETRY_ATTEMPTS = _kg_mod.KG_RETRY_ATTEMPTS
+KnowledgeGraphExtraction = _kg_mod.KnowledgeGraphExtraction
+_extract_with_retry = _kg_mod._extract_with_retry
+extract_knowledge_from_memory = _kg_mod.extract_knowledge_from_memory
+rebuild_knowledge_graph = _kg_mod.rebuild_knowledge_graph
+
+# Valid JSON that PydanticOutputParser produces
+VALID_EXTRACTION_JSON = json.dumps(
+    {
+        "nodes": [
+            {"label": "Alice", "node_type": "person", "aliases": []},
+            {"label": "Paris", "node_type": "place", "aliases": ["City of Light"]},
+        ],
+        "edges": [
+            {"source_label": "Alice", "target_label": "Paris", "label": "lives in"},
+        ],
+    }
+)
+
+
+def _make_response(content):
+    """Create a mock LLM response with .content attribute."""
+    resp = MagicMock()
+    resp.content = content
+    return resp
+
+
+class TestExtractWithRetry:
+    """Tests for extract_knowledge_from_memory with retry behavior."""
+
+    def setup_method(self):
+        _mock_llm.reset_mock()
+        _mock_llm.invoke.side_effect = None
+        _kg_db_stub.get_knowledge_nodes.reset_mock()
+        _kg_db_stub.upsert_knowledge_node.reset_mock()
+        _kg_db_stub.upsert_knowledge_edge.reset_mock()
+        _kg_db_stub.get_knowledge_nodes.return_value = []
+        _kg_db_stub.upsert_knowledge_node.side_effect = lambda uid, data: data
+        _kg_db_stub.upsert_knowledge_edge.side_effect = lambda uid, data: data
+
+    def test_happy_path_no_retry(self):
+        """Valid first response is parsed without retry."""
+        _mock_llm.invoke.return_value = _make_response(VALID_EXTRACTION_JSON)
+
+        result = extract_knowledge_from_memory("uid1", "Alice lives in Paris", "mem1", "Alice")
+
+        assert result is not None
+        assert len(result['nodes']) == 2
+        assert len(result['edges']) == 1
+        assert _mock_llm.invoke.call_count == 1
+
+    def test_transient_failure_retries_then_succeeds(self):
+        """First invoke fails, second succeeds — extraction completes."""
+        _mock_llm.invoke.side_effect = [
+            Exception("rate limit"),
+            _make_response(VALID_EXTRACTION_JSON),
+        ]
+
+        result = extract_knowledge_from_memory("uid1", "Alice lives in Paris", "mem1", "Alice")
+
+        assert result is not None
+        assert len(result['nodes']) == 2
+        assert _mock_llm.invoke.call_count == 2
+
+    def test_parse_failure_retries_invoke(self):
+        """Malformed JSON triggers re-invoke (not re-parse of same bad content)."""
+        _mock_llm.invoke.side_effect = [
+            _make_response("not valid json at all"),
+            _make_response(VALID_EXTRACTION_JSON),
+        ]
+
+        result = extract_knowledge_from_memory("uid1", "Alice lives in Paris", "mem1", "Alice")
+
+        assert result is not None
+        assert _mock_llm.invoke.call_count == 2
+
+    def test_exhausted_retries_returns_none(self):
+        """All 3 attempts fail — returns None, no DB writes."""
+        _mock_llm.invoke.side_effect = Exception("persistent failure")
+
+        result = extract_knowledge_from_memory("uid1", "Alice lives in Paris", "mem1", "Alice")
+
+        assert result is None
+        assert _mock_llm.invoke.call_count == KG_RETRY_ATTEMPTS
+        _kg_db_stub.upsert_knowledge_node.assert_not_called()
+        _kg_db_stub.upsert_knowledge_edge.assert_not_called()
+
+    def test_no_db_writes_before_successful_parse(self):
+        """DB upserts happen only after successful parse, not during retries."""
+        _mock_llm.invoke.side_effect = [
+            Exception("transient"),
+            _make_response(VALID_EXTRACTION_JSON),
+        ]
+
+        result = extract_knowledge_from_memory("uid1", "Alice lives in Paris", "mem1", "Alice")
+
+        assert result is not None
+        assert _kg_db_stub.upsert_knowledge_node.call_count == 2
+        assert _kg_db_stub.upsert_knowledge_edge.call_count == 1
+
+
+class TestRebuildKnowledgeGraph:
+    """Tests for rebuild_knowledge_graph with retry behavior."""
+
+    def setup_method(self):
+        _mock_llm.reset_mock()
+        _mock_llm.invoke.side_effect = None
+        _kg_db_stub.get_knowledge_nodes.reset_mock()
+        _kg_db_stub.upsert_knowledge_node.reset_mock()
+        _kg_db_stub.upsert_knowledge_edge.reset_mock()
+        _kg_db_stub.delete_knowledge_graph.reset_mock()
+        _kg_db_stub.get_knowledge_graph.reset_mock()
+        _kg_db_stub.get_knowledge_nodes.return_value = []
+        _kg_db_stub.get_knowledge_graph.return_value = {'nodes': [], 'edges': []}
+        _kg_db_stub.upsert_knowledge_node.side_effect = lambda uid, data: data
+        _kg_db_stub.upsert_knowledge_edge.side_effect = lambda uid, data: data
+
+    def test_rebuild_one_fails_one_succeeds(self):
+        """One memory exhausts retries, another succeeds — batch completes."""
+        _mock_llm.invoke.side_effect = [
+            Exception("fail1"),
+            Exception("fail2"),
+            Exception("fail3"),
+            _make_response(VALID_EXTRACTION_JSON),
+        ]
+
+        memories = [
+            {'id': 'mem_bad', 'content': 'bad memory'},
+            {'id': 'mem_good', 'content': 'Alice lives in Paris'},
+        ]
+
+        result = rebuild_knowledge_graph("uid1", memories, "Alice")
+
+        assert result is not None
+        assert _mock_llm.invoke.call_count == 4
+
+    def test_rebuild_empty_content_skipped(self):
+        """Memories with empty content are skipped without LLM call."""
+        _mock_llm.invoke.return_value = _make_response(VALID_EXTRACTION_JSON)
+
+        memories = [
+            {'id': 'mem_empty', 'content': ''},
+            {'id': 'mem_good', 'content': 'Alice lives in Paris'},
+        ]
+
+        rebuild_knowledge_graph("uid1", memories, "Alice")
+
+        assert _mock_llm.invoke.call_count == 1
+
+
+class TestRetryConfig:
+    """Tests for retry configuration constants."""
+
+    def test_retry_attempts_is_three(self):
+        assert KG_RETRY_ATTEMPTS == 3
+
+    def test_extract_with_retry_has_retry_decorator(self):
+        """Verify the retry decorator is applied."""
+        assert hasattr(_extract_with_retry, 'retry')

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -491,12 +491,12 @@ def test_all_callsites_use_get_llm():
         conv_proc_calls.count('conv_structure') >= 2
     ), f"Expected at least 2 get_llm('conv_structure') calls (structure + reprocess), got {conv_proc_calls.count('conv_structure')}"
 
-    # knowledge_graph.py: 2 callsites
+    # knowledge_graph.py: 1 callsite (shared _extract_with_retry helper used by both functions)
     kg_source = (backend_dir / "utils" / "llm" / "knowledge_graph.py").read_text()
     kg_calls = re.findall(r"get_llm\('(\w+)'", kg_source)
     assert (
-        kg_calls.count('knowledge_graph') == 2
-    ), f"Expected 2 get_llm('knowledge_graph') calls, got {kg_calls.count('knowledge_graph')}"
+        kg_calls.count('knowledge_graph') == 1
+    ), f"Expected 1 get_llm('knowledge_graph') call (shared retry helper), got {kg_calls.count('knowledge_graph')}"
 
     # memories.py: 5 callsites (memories x2, learnings x1, memory_category x1, memory_conflict x1)
     mem_source = (backend_dir / "utils" / "llm" / "memories.py").read_text()
@@ -506,9 +506,9 @@ def test_all_callsites_use_get_llm():
     assert 'memory_category' in mem_calls, "Missing get_llm('memory_category') in memories.py"
     assert 'memory_conflict' in mem_calls, "Missing get_llm('memory_conflict') in memories.py"
 
-    # Total: 9 + 2 + 5 = 16 callsites
+    # Total: 9 + 1 + 5 = 15 callsites (kg reduced from 2→1 via shared retry helper)
     total = len(conv_proc_calls) + len(kg_calls) + len(mem_calls)
-    assert total == 16, f"Expected 16 total get_llm() callsites, got {total}"
+    assert total == 15, f"Expected 15 total get_llm() callsites, got {total}"
 
 
 def test_no_direct_llm_instance_usage_in_wired_files():

--- a/backend/utils/llm/knowledge_graph.py
+++ b/backend/utils/llm/knowledge_graph.py
@@ -5,6 +5,7 @@ import logging
 import json
 from concurrent.futures import as_completed
 
+from tenacity import before_sleep_log, retry, stop_after_attempt, wait_random_exponential
 from utils.executors import critical_executor, storage_executor
 
 from langchain_core.output_parsers import PydanticOutputParser
@@ -13,6 +14,10 @@ from pydantic import BaseModel, Field
 from .clients import get_llm
 from .usage_tracker import track_usage, Features
 from database import knowledge_graph as kg_db
+
+logger = logging.getLogger(__name__)
+
+KG_RETRY_ATTEMPTS = 3
 
 
 class ExtractedNode(BaseModel):
@@ -70,6 +75,27 @@ Extract entities and relationships. If no meaningful patterns found, return empt
 """
 
 
+@retry(
+    stop=stop_after_attempt(KG_RETRY_ATTEMPTS),
+    wait=wait_random_exponential(multiplier=1, max=8),
+    reraise=True,
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+)
+def _extract_with_retry(
+    uid: str,
+    prompt: str,
+    parser: PydanticOutputParser,
+) -> KnowledgeGraphExtraction:
+    """Invoke LLM and parse response, retrying on transient failures.
+
+    Retries the entire invoke+parse unit so that malformed JSON responses
+    trigger a fresh LLM call rather than re-parsing the same bad output.
+    """
+    with track_usage(uid, Features.KNOWLEDGE_GRAPH):
+        response = get_llm('knowledge_graph').invoke(prompt)
+    return parser.parse(response.content)
+
+
 def extract_knowledge_from_memory(
     uid: str, memory_content: str, memory_id: str, user_name: str = "User"
 ) -> Optional[Dict[str, Any]]:
@@ -96,9 +122,7 @@ def extract_knowledge_from_memory(
             format_instructions=parser.get_format_instructions(),
         )
 
-        with track_usage(uid, Features.KNOWLEDGE_GRAPH):
-            response = get_llm('knowledge_graph').invoke(prompt)
-        extraction: KnowledgeGraphExtraction = parser.parse(response.content)
+        extraction = _extract_with_retry(uid, prompt, parser)
 
         label_to_node_id = {}
         for existing in existing_nodes:
@@ -150,7 +174,7 @@ def extract_knowledge_from_memory(
         }
 
     except Exception:
-        logging.exception(f"Error extracting knowledge graph from memory_id: {memory_id}")
+        logger.exception("KG extraction failed for memory %s after %d attempts", memory_id, KG_RETRY_ATTEMPTS)
         return None
 
 
@@ -188,9 +212,7 @@ def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name:
                 format_instructions=parser.get_format_instructions(),
             )
 
-            with track_usage(uid, Features.KNOWLEDGE_GRAPH):
-                response = get_llm('knowledge_graph').invoke(prompt)
-            extraction: KnowledgeGraphExtraction = parser.parse(response.content)
+            extraction = _extract_with_retry(uid, prompt, parser)
 
             created_nodes = []
             created_edges = []
@@ -242,7 +264,7 @@ def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name:
             return {'nodes': created_nodes, 'edges': created_edges}
 
         except Exception:
-            logging.exception(f"Error extracting knowledge graph from memory_id: {memory_id}")
+            logger.exception("KG extraction failed for memory %s after %d attempts", memory_id, KG_RETRY_ATTEMPTS)
             return {'nodes': [], 'edges': []}
 
     all_nodes = []
@@ -255,6 +277,6 @@ def rebuild_knowledge_graph(uid: str, memories: List[Dict[str, Any]], user_name:
             all_nodes.extend(result.get('nodes', []))
             all_edges.extend(result.get('edges', []))
         except Exception:
-            logging.exception("Error in concurrent memory extraction")
+            logger.exception("Error in concurrent memory extraction")
 
     return kg_db.get_knowledge_graph(uid)


### PR DESCRIPTION
## Summary
Fixes #6557 — Knowledge graph extraction had no retry/backoff on LLM calls and no fallback on parse failures, causing silent data loss during transient OpenAI failures (127-hit burst on Apr 11) and chronic JSON decode errors (5-10/week).

**Reworks community PR #6705** with a more solid implementation:

- **Shared retry helper** `_extract_with_retry()` using tenacity (3 attempts, random exponential backoff up to 8s)
- **Retries the entire invoke→parse unit** — malformed JSON triggers a fresh LLM call, not re-parse of same bad content
- **Module-level logger** replacing scattered `logging.exception()` calls
- **DB writes stay outside retry loop** — no duplicate node/edge upserts during retries
- Both `extract_knowledge_from_memory()` and `rebuild_knowledge_graph.process_memory()` use the shared helper

### What PR #6705 was missing
- No retry/backoff on LLM invoke (the core issue)
- Only added try/except around parse (parse fallback returns empty, doesn't retry)
- No shared helper (duplicated pattern across both functions)

## Changes
| File | Change |
|------|--------|
| `backend/utils/llm/knowledge_graph.py` | Add `_extract_with_retry()`, `logger`, `KG_RETRY_ATTEMPTS` |
| `backend/tests/unit/test_kg_retry_fallback.py` | 9 tests: happy path, transient recovery, parse recovery, exhaustion, rebuild batch |
| `backend/tests/unit/test_process_conversation_usage_context.py` | Update callsite count (2→1 via shared helper) |
| `backend/test.sh` | Add new test file |

## Risks
- **Retry stacking**: tenacity 3 attempts × LangChain internal 2 retries = up to 6 HTTP calls per memory. Acceptable for background KG extraction.
- **Thread starvation**: Backoff sleeps hold `storage_executor` workers (16 threads). Bounded by max=8s wait and 3 attempts.
- **Cost**: Parse failures that re-invoke LLM are billable. Bounded to 3 total attempts.

## Test plan
- [x] 9 unit tests pass (happy path, transient failure, parse failure, exhaustion, rebuild batch, empty content, config)
- [x] Full `test.sh` passes (pre-existing storage test failures unrelated)
- [x] `black --line-length 120 --skip-string-normalization` formatting verified

Closes #6557
Supersedes #6705

_by AI for @beastoin_