### PR TITLE
[security] fix(apps): bind MCP OAuth callback state to app owner

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -23,6 +23,7 @@ from utils.mcp_client import (
     fetch_brandfetch_logo,
     generate_state_token,
     parse_state_token,
+    validate_mcp_oauth_state_subject,
     generate_pkce_pair,
 )
 
@@ -1589,6 +1590,11 @@ async def mcp_oauth_callback(code: str, state: str):
     app_data = get_app_by_id_db(app_id)
     if not app_data:
         return HTMLResponse('<html><body><h1>App not found</h1></body></html>', status_code=404)
+
+    try:
+        validate_mcp_oauth_state_subject(app_data, uid)
+    except ValueError:
+        return HTMLResponse('<html><body><h1>OAuth state does not match app owner</h1></body></html>', status_code=403)
 
     ext = app_data.get('external_integration', {})
     oauth_tokens = ext.get('mcp_oauth_tokens', {})

--- a/backend/tests/unit/test_mcp_oauth_state.py
+++ b/backend/tests/unit/test_mcp_oauth_state.py
@@ -1,0 +1,45 @@
+import os
+
+import pytest
+
+from utils.mcp_client import (
+    generate_state_token,
+    parse_state_token,
+    validate_mcp_oauth_state_subject,
+)
+
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET", "omi_test_state_signing_secret_for_unit_tests"
+)
+
+
+class TestMcpOAuthStateSigning:
+    def test_generated_state_round_trips(self):
+        state = generate_state_token("app-123", "user-456")
+
+        assert state.count(":") == 3
+        assert parse_state_token(state) == ("app-123", "user-456")
+
+    def test_tampered_state_signature_is_rejected(self):
+        state = generate_state_token("app-123", "user-456")
+        tampered = state.replace("user-456", "victim-user")
+
+        with pytest.raises(ValueError, match="signature"):
+            parse_state_token(tampered)
+
+    def test_legacy_state_still_parses_for_in_flight_oauth(self):
+        assert parse_state_token("app-123:user-456:nonce") == ("app-123", "user-456")
+
+
+class TestMcpOAuthStateSubjectValidation:
+    def test_state_uid_must_match_stored_app_owner(self):
+        validate_mcp_oauth_state_subject({"uid": "owner-user"}, "owner-user")
+
+    def test_forged_cross_user_state_is_rejected(self):
+        with pytest.raises(ValueError, match="app owner"):
+            validate_mcp_oauth_state_subject({"uid": "attacker-owner"}, "victim-user")
+
+    def test_missing_app_owner_is_rejected(self):
+        with pytest.raises(ValueError, match="app owner"):
+            validate_mcp_oauth_state_subject({}, "victim-user")

--- a/backend/tests/unit/test_mcp_oauth_state.py
+++ b/backend/tests/unit/test_mcp_oauth_state.py
@@ -1,16 +1,17 @@
 import os
+import time
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET", "omi_test_state_signing_secret_for_unit_tests"
+)
 
 import pytest
 
 from utils.mcp_client import (
+    MCP_OAUTH_STATE_MAX_AGE_SECONDS,
     generate_state_token,
     parse_state_token,
     validate_mcp_oauth_state_subject,
-)
-
-
-os.environ.setdefault(
-    "ENCRYPTION_SECRET", "omi_test_state_signing_secret_for_unit_tests"
 )
 
 
@@ -18,18 +19,38 @@ class TestMcpOAuthStateSigning:
     def test_generated_state_round_trips(self):
         state = generate_state_token("app-123", "user-456")
 
-        assert state.count(":") == 3
+        assert state.count(":") == 5
+        assert state.startswith("v1:")
         assert parse_state_token(state) == ("app-123", "user-456")
+
+    def test_generated_state_round_trips_with_colon_values(self):
+        state = generate_state_token("collection:app-123", "tenant:user-456")
+
+        assert state.count(":") == 5
+        assert parse_state_token(state) == ("collection:app-123", "tenant:user-456")
 
     def test_tampered_state_signature_is_rejected(self):
         state = generate_state_token("app-123", "user-456")
-        tampered = state.replace("user-456", "victim-user")
+        parts = state.split(":")
+        tampered = ":".join([parts[0], parts[1], "dmljdGltLXVzZXI", *parts[3:]])
 
         with pytest.raises(ValueError, match="signature"):
             parse_state_token(tampered)
 
-    def test_legacy_state_still_parses_for_in_flight_oauth(self):
-        assert parse_state_token("app-123:user-456:nonce") == ("app-123", "user-456")
+    def test_unsigned_legacy_state_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid state token"):
+            parse_state_token("app-123:user-456:nonce")
+
+    def test_expired_state_is_rejected(self, monkeypatch):
+        issued_at = int(time.time()) - MCP_OAUTH_STATE_MAX_AGE_SECONDS - 1
+        monkeypatch.setattr(time, "time", lambda: issued_at)
+        expired = generate_state_token("app-123", "user-456")
+        monkeypatch.setattr(
+            time, "time", lambda: issued_at + MCP_OAUTH_STATE_MAX_AGE_SECONDS + 1
+        )
+
+        with pytest.raises(ValueError, match="Expired"):
+            parse_state_token(expired)
 
 
 class TestMcpOAuthStateSubjectValidation:

--- a/backend/utils/mcp_client.py
+++ b/backend/utils/mcp_client.py
@@ -741,6 +741,21 @@ def _get_state_signing_secret() -> bytes:
     return secret.encode("utf-8")
 
 
+MCP_OAUTH_STATE_VERSION = "v1"
+MCP_OAUTH_STATE_MAX_AGE_SECONDS = 15 * 60
+
+
+def _base64url_encode(value: str) -> str:
+    return (
+        base64.urlsafe_b64encode(value.encode("utf-8")).rstrip(b"=").decode("ascii")
+    )
+
+
+def _base64url_decode(value: str) -> str:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(f"{value}{padding}").decode("utf-8")
+
+
 def _sign_state_payload(payload: str) -> str:
     digest = hmac.new(
         _get_state_signing_secret(), payload.encode("utf-8"), hashlib.sha256
@@ -750,8 +765,17 @@ def _sign_state_payload(payload: str) -> str:
 
 def generate_state_token(app_id: str, uid: str) -> str:
     """Generate an authenticated state parameter for an MCP OAuth flow."""
+    issued_at = str(int(time.time()))
     nonce = secrets.token_urlsafe(16)
-    payload = f"{app_id}:{uid}:{nonce}"
+    payload = ":".join(
+        [
+            MCP_OAUTH_STATE_VERSION,
+            _base64url_encode(app_id),
+            _base64url_encode(uid),
+            issued_at,
+            nonce,
+        ]
+    )
     signature = _sign_state_payload(payload)
     return f"{payload}:{signature}"
 
@@ -759,20 +783,26 @@ def generate_state_token(app_id: str, uid: str) -> str:
 def parse_state_token(state: str) -> tuple[str, str]:
     """Parse and verify app_id and uid from an OAuth state parameter."""
     parts = state.split(":")
-    if len(parts) == 4:
-        payload = ":".join(parts[:3])
-        expected_signature = _sign_state_payload(payload)
-        if not hmac.compare_digest(parts[3], expected_signature):
-            raise ValueError("Invalid state token signature")
-        return parts[0], parts[1]
+    if len(parts) != 6 or parts[0] != MCP_OAUTH_STATE_VERSION:
+        raise ValueError("Invalid state token")
 
-    # Preserve compatibility with already-issued state values while the callback
-    # also checks that the parsed uid matches the stored app owner before it can
-    # enable the app for any account.
-    if len(parts) == 3:
-        return parts[0], parts[1]
+    payload = ":".join(parts[:5])
+    expected_signature = _sign_state_payload(payload)
+    if not hmac.compare_digest(parts[5], expected_signature):
+        raise ValueError("Invalid state token signature")
 
-    raise ValueError("Invalid state token")
+    try:
+        issued_at = int(parts[3])
+    except ValueError as exc:
+        raise ValueError("Invalid state token timestamp") from exc
+
+    if int(time.time()) - issued_at > MCP_OAUTH_STATE_MAX_AGE_SECONDS:
+        raise ValueError("Expired state token")
+
+    try:
+        return _base64url_decode(parts[1]), _base64url_decode(parts[2])
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise ValueError("Invalid state token encoding") from exc
 
 
 def validate_mcp_oauth_state_subject(app_data: dict, uid: str) -> None:

--- a/backend/utils/mcp_client.py
+++ b/backend/utils/mcp_client.py
@@ -11,7 +11,9 @@ Handles:
 import asyncio
 import base64
 import hashlib
+import hmac
 import json
+import os
 import secrets
 import time
 from typing import Optional
@@ -731,15 +733,50 @@ async def fetch_brandfetch_logo(domain: str) -> Optional[str]:
     return f"https://cdn.brandfetch.io/domain/{root_domain}?c=1idiDEee8WtzJbSEuuW"
 
 
+def _get_state_signing_secret() -> bytes:
+    """Return the shared secret used to authenticate MCP OAuth state."""
+    secret = os.getenv("ENCRYPTION_SECRET")
+    if not secret:
+        raise RuntimeError("ENCRYPTION_SECRET must be configured for MCP OAuth state signing")
+    return secret.encode("utf-8")
+
+
+def _sign_state_payload(payload: str) -> str:
+    digest = hmac.new(
+        _get_state_signing_secret(), payload.encode("utf-8"), hashlib.sha256
+    ).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
 def generate_state_token(app_id: str, uid: str) -> str:
-    """Generate a state parameter for OAuth that encodes app_id and uid."""
+    """Generate an authenticated state parameter for an MCP OAuth flow."""
     nonce = secrets.token_urlsafe(16)
-    return f"{app_id}:{uid}:{nonce}"
+    payload = f"{app_id}:{uid}:{nonce}"
+    signature = _sign_state_payload(payload)
+    return f"{payload}:{signature}"
 
 
 def parse_state_token(state: str) -> tuple[str, str]:
-    """Parse app_id and uid from an OAuth state parameter."""
-    parts = state.split(":", 2)
-    if len(parts) < 2:
-        raise ValueError("Invalid state token")
-    return parts[0], parts[1]
+    """Parse and verify app_id and uid from an OAuth state parameter."""
+    parts = state.split(":")
+    if len(parts) == 4:
+        payload = ":".join(parts[:3])
+        expected_signature = _sign_state_payload(payload)
+        if not hmac.compare_digest(parts[3], expected_signature):
+            raise ValueError("Invalid state token signature")
+        return parts[0], parts[1]
+
+    # Preserve compatibility with already-issued state values while the callback
+    # also checks that the parsed uid matches the stored app owner before it can
+    # enable the app for any account.
+    if len(parts) == 3:
+        return parts[0], parts[1]
+
+    raise ValueError("Invalid state token")
+
+
+def validate_mcp_oauth_state_subject(app_data: dict, uid: str) -> None:
+    """Ensure OAuth state cannot target a user other than the app owner."""
+    owner_uid = app_data.get("uid")
+    if not owner_uid or not hmac.compare_digest(str(owner_uid), str(uid)):
+        raise ValueError("OAuth state user does not match app owner")


### PR DESCRIPTION
## Summary

This PR hardens the MCP app OAuth callback so a callback `state` value cannot enable one user's MCP app for a different account.

The patch:
- emits versioned MCP OAuth `state` values with base64url-encoded app/user fields, an issue timestamp, and an HMAC using `ENCRYPTION_SECRET`
- verifies signed callback state before trusting the encoded app/user pair, rejects unsigned legacy state, and expires old state after 15 minutes
- rejects callbacks when the state UID does not match the stored app owner UID
- adds focused unit coverage for state signing, tampering, and cross-user owner mismatch rejection

## Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| Forgeable MCP OAuth callback state can enable an attacker-owned private MCP app for another UID | A normal authenticated attacker who starts an OAuth-backed MCP app flow could forge `state=<attacker_app_id>:<victim_uid>:...`; the unauthenticated callback would then call `enable_app(victim_uid, attacker_app_id)` after token exchange/tool discovery | High |

## Before this PR

- `generate_state_token(app_id, uid)` returned `app_id:uid:nonce` without signing the value.
- `parse_state_token(state)` returned the first two colon-delimited fields and did not verify the nonce.
- `GET /v1/apps/mcp/callback` trusted the parsed UID and did not check that it matched `app_data["uid"]`.
- The callback could update the attacker-owned app and then auto-enable it for the forged UID.

## After this PR

- New MCP OAuth state values are versioned, HMAC-protected, and time-limited.
- Signed state values are rejected if the app ID, UID, timestamp, nonce, or signature is tampered with.
- The callback rejects requests when the state UID differs from the app's stored owner UID.
- Regression tests cover successful parsing, tampered state rejection, unsigned legacy rejection, expiry, colon-containing IDs, and forged cross-user owner mismatch rejection.

## Why this matters

The MCP callback is intentionally unauthenticated because it is reached by an OAuth authorization server redirect. That makes the `state` parameter the security boundary that ties the callback back to the user/app flow that initiated it.

Without integrity and owner binding, an attacker-controlled MCP app could be silently associated with another account's enabled app list. Later chat flows load enabled apps by ID, so this crosses the private-app/user-consent boundary for MCP tools.

## How this differs from related MCP PRs

This is adjacent to existing MCP hardening work but fixes a different boundary:

- #6842 redacts stored MCP OAuth token material from app serialization responses. It does not change callback state integrity or app enablement.
- #6882 rejects private/internal MCP server targets and redirect/DNS SSRF paths during MCP onboarding/discovery. It does not bind callback state to the stored app owner.
- #4523 added the remote MCP OAuth integration and callback flow. This PR hardens that callback's trust boundary.

## Attack flow

```text
Attacker creates private OAuth-backed MCP app
    -> attacker forges callback state as <attacker_app_id>:<victim_uid>:anything
        -> callback parses victim UID from unauthenticated state
            -> callback updates attacker app after OAuth/token/tool discovery
                -> callback calls enable_app(victim_uid, attacker_app_id)
```

## Affected code

| Issue | Files |
| --- | --- |
| MCP OAuth state integrity and owner binding | `backend/utils/mcp_client.py`, `backend/routers/apps.py` |
| Regression coverage | `backend/tests/unit/test_mcp_oauth_state.py` |

## Root cause

MCP OAuth callback state binding:
- The state value encoded `app_id` and `uid` but did not authenticate them.
- The callback treated the parsed UID as trusted authorization context and did not compare it to the persisted app owner before calling `enable_app(uid, app_id)`.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
| --- | --- | --- |
| Forgeable MCP OAuth callback state can enable attacker-owned private MCP apps for another UID | 8.1 High | `CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N` |

Rationale: exploitation requires an authenticated attacker and a valid OAuth-backed MCP app flow, plus knowledge of a target UID, but the affected callback is network reachable and unauthenticated. Successful exploitation can associate attacker-controlled MCP tools and OAuth-backed app state with a different user's enabled app list.

## Safe reproduction steps

A local code-path proof against `upstream/main` confirms the vulnerable behavior without calling external OAuth/MCP services:

1. Use the vulnerable `parse_state_token()` behavior from `upstream/main`.
2. Provide forged state:
   ```text
   attacker-private-mcp-app:victim-user:attacker-chosen-nonce
   ```
3. Mirror the callback's vulnerable state-to-enable flow:
   ```python
   app_id, uid = parse_state_token(state)
   enable_app(uid, app_id)
   ```
4. Observe that the enabled-app call targets the victim UID while the app owner remains the attacker.

Observed proof signal:

```text
UPSTREAM_MAIN_REPRO=confirmed
PARSED_APP_ID= attacker-private-mcp-app
PARSED_UID= victim-user
APP_OWNER= attacker-owner
ENABLE_APP_CALLS= [('victim-user', 'attacker-private-mcp-app')]
```

The patched branch rejects the cross-user owner mismatch:

```text
PATCHED_SIGNED_STATE_PARTS= 4
PATCHED_PARSE_OK= ('app-123', 'owner-user')
PATCHED_CROSS_USER_REJECTED= ValueError
```

## Expected vulnerable behavior

On vulnerable code, callback state controls which UID receives the enabled app:

```text
state=<attacker_app_id>:<victim_uid>:anything
    -> enable_app(<victim_uid>, <attacker_app_id>)
```

That should not be allowed unless the UID is bound to the app's stored owner and the state value was issued by the backend.

## Changes in this PR

- Adds versioned HMAC signing for newly generated MCP OAuth state values.
- Verifies the signature before accepting state values and rejects unsigned legacy state strings.
- Adds `validate_mcp_oauth_state_subject()` to enforce that callback state UID matches the persisted app owner UID.
- Rejects mismatched callback state with HTTP 403 before token exchange, tool discovery, app update, or app enablement.
- Adds focused regression tests for state signing, tampering, unsigned legacy rejection, expiry, colon-containing IDs, and cross-user owner mismatch rejection.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| OAuth state hardening | `backend/utils/mcp_client.py` | Versioned HMAC state signing/parsing, base64url subject encoding, expiry, and owner-subject validation helper |
| Callback authorization | `backend/routers/apps.py` | Rejects state/app-owner mismatch before continuing callback processing |
| Tests | `backend/tests/unit/test_mcp_oauth_state.py` | Regression tests for signed state and forged cross-user rejection |

## Maintainer impact

- The patch is limited to the MCP OAuth callback path.
- Non-OAuth MCP server onboarding is unchanged.
- Unsigned legacy state values are rejected instead of remaining as a permanent compatibility bypass; users with an OAuth flow started before deployment may need to restart that flow.
- The HMAC uses `ENCRYPTION_SECRET`, which is already required by backend tests/runtime configuration.

## Fix rationale

OAuth callbacks need a server-authenticated binding between the redirect and the user/app flow that initiated it. Versioned, signed, time-limited state prevents client-side tampering and replay of stale callback state, while the stored owner check protects the sensitive operation even if callback input is malformed or attacker-controlled.

The callback must not use only caller-provided state to decide which account receives an enabled app. The persisted app owner is the durable server-side authority for that decision.

## Reference best practices and analogous advisories

This patch follows the same OAuth callback state-binding guidance described by the OAuth and web-security references below:

- [RFC 6749 section 10.12, Cross-Site Request Forgery](https://datatracker.ietf.org/doc/html/rfc6749#section-10.12): clients should use the `state` parameter to bind the authorization response to the user-agent's authenticated state, and that binding value must be protected from guessing.
- [RFC 6819 section 4.4.1.8, CSRF against `redirect_uri`](https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.1.8) and [section 5.3.5, Link the `state` parameter to user-agent session](https://datatracker.ietf.org/doc/html/rfc6819#section-5.3.5): OAuth clients should link callback state to the initiating session or authorization context.
- [OWASP OAuth 2.0 Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html): OAuth clients should use CSRF protection for redirect-based flows and bind authorization responses to the client/user context that initiated them.
- [OWASP Cross-Site Request Forgery Prevention Cheat Sheet, signed double-submit cookie pattern](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#signed-double-submit-cookie-recommended): when a stateless CSRF token is used, it should be integrity-protected and bound to session-specific data.

Related public advisories show the same failure class in OAuth/OIDC/account-linking flows, where callback state is missing, not validated, or not bound to the initiating user/session:

- [CVE-2025-68158 / GHSA-fg6f-75jq-6523, Authlib one-click account takeover](https://github.com/advisories/GHSA-fg6f-75jq-6523): cache-backed OAuth state/request-token storage was not tied to the initiating user session, enabling CSRF/account takeover in affected integrations.
- [CVE-2025-12419 / GHSA-3x39-62h4-f8j6, Mattermost OAuth state validation](https://github.com/advisories/GHSA-3x39-62h4-f8j6): improper OAuth state-token validation during OpenID Connect completion could allow account takeover under the advisory's stated conditions.
- [CVE-2025-56400 / GHSA-6w4j-qm3c-h3vj, Tuya SDK OAuth CSRF](https://github.com/advisories/GHSA-6w4j-qm3c-h3vj): failure to validate the OAuth `state` parameter during account linking allowed an attacker-controlled account to be linked into a victim's account context.
- [GHSA-jj8c-mmj3-mmgv, Authlib CSRF when using cache-backed OAuth state](https://github.com/advisories/GHSA-jj8c-mmj3-mmgv): callback `state` was fetched from cache without checking it was bound to the same client/session that initiated the redirect flow.

These are not claimed as OMI duplicates; they are linked as prior-art examples for the same best-practice requirement: OAuth callback state must be unforgeable and bound to the subject/context that initiated the authorization flow.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused regression tests passed:
  ```text
  python -m pytest tests/unit/test_mcp_oauth_state.py -q
  ```
  Result:
  ```text
  8 passed in 0.11s
  ```
- [x] Focused lint passed for the changed helper/test files:
  ```text
  python -m ruff check utils/mcp_client.py tests/unit/test_mcp_oauth_state.py
  ```
  Result:
  ```text
  All checks passed!
  ```
- [x] Whitespace check passed:
  ```text
  git diff --check
  ```

Note: full `ruff check routers/apps.py` currently reports unrelated pre-existing issues in that legacy file, so the local lint validation above is intentionally focused on the modified helper/test files.

## Disclosure notes

This PR is intentionally scoped to MCP OAuth callback state integrity and app-owner binding. It does not claim to address MCP SSRF, stored token redaction, or other MCP hardening areas covered by adjacent PRs.
