### PR TITLE
[draft] Regolo.ai EU Privacy Mode — Phase 1 backend/desktop + M0-M4 polish

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -103,6 +103,7 @@ pytest tests/unit/test_async_http_infrastructure.py -v
 pytest tests/unit/test_clean_sweep_migrations.py -v
 pytest tests/unit/test_omi_qos_tiers.py -v
 pytest tests/unit/test_byok_security.py -v
+pytest tests/unit/test_regolo_client.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_regolo_client.py
+++ b/backend/tests/unit/test_regolo_client.py
@@ -319,6 +319,62 @@ class TestPrivacyModeDispatch:
             assert _parse_privacy_mode(val) is False, f'expected False for {val!r}'
 
 
+class TestPrivacyFallbackSignalling:
+    """Fallback-reason contextvar + mark_privacy_fallback validator."""
+
+    def test_default_fallback_is_none(self):
+        from utils.byok import get_privacy_fallback_reason
+
+        def _run():
+            assert get_privacy_fallback_reason() is None
+
+        copy_context().run(_run)
+
+    def test_mark_and_read_valid_reason(self):
+        from utils.byok import (
+            PRIVACY_FALLBACK_VISION_UNSUPPORTED,
+            get_privacy_fallback_reason,
+            mark_privacy_fallback,
+        )
+
+        def _run():
+            mark_privacy_fallback(PRIVACY_FALLBACK_VISION_UNSUPPORTED)
+            assert get_privacy_fallback_reason() == PRIVACY_FALLBACK_VISION_UNSUPPORTED
+
+        copy_context().run(_run)
+
+    def test_unknown_reason_is_rejected(self):
+        """Prevent banner-noise: unknown reasons don't make it into the header."""
+        from utils.byok import get_privacy_fallback_reason, mark_privacy_fallback
+
+        def _run():
+            mark_privacy_fallback('definitely_not_a_valid_reason')
+            assert get_privacy_fallback_reason() is None, (
+                'mark_privacy_fallback should silently drop unknown reasons'
+            )
+
+        copy_context().run(_run)
+
+    def test_all_constant_reasons_are_valid(self):
+        """Every PRIVACY_FALLBACK_* constant must be in the accepted set —
+        otherwise downstream calls using the constants would be rejected."""
+        from utils.byok import (
+            PRIVACY_FALLBACK_NO_KEY,
+            PRIVACY_FALLBACK_REGOLO_OUTAGE,
+            PRIVACY_FALLBACK_REGOLO_RATE_LIMITED,
+            PRIVACY_FALLBACK_VISION_UNSUPPORTED,
+            _PRIVACY_FALLBACK_REASONS,
+        )
+
+        for reason in (
+            PRIVACY_FALLBACK_VISION_UNSUPPORTED,
+            PRIVACY_FALLBACK_REGOLO_OUTAGE,
+            PRIVACY_FALLBACK_REGOLO_RATE_LIMITED,
+            PRIVACY_FALLBACK_NO_KEY,
+        ):
+            assert reason in _PRIVACY_FALLBACK_REASONS
+
+
 class TestRegoloByokHeader:
     """The backend BYOK_HEADERS map must expose the regolo header name so the
     middleware routes X-BYOK-Regolo into the contextvar."""

--- a/backend/tests/unit/test_regolo_client.py
+++ b/backend/tests/unit/test_regolo_client.py
@@ -257,6 +257,68 @@ class TestPrivacyProfile:
         assert MODEL_QOS_PROFILES['privacy']['web_search'].startswith('sonar')
 
 
+class TestPrivacyModeDispatch:
+    """The per-request X-Privacy-Mode header must override the active QoS
+    profile and route through the 'privacy' profile entries."""
+
+    def test_privacy_mode_off_uses_active_profile(self):
+        """Without the privacy flag set, get_model() returns the active
+        profile's entry — the existing behavior."""
+        from utils.byok import set_privacy_mode
+        from utils.llm.clients import get_model
+
+        def _run():
+            set_privacy_mode(False)
+            model = get_model('chat_responses')
+            assert 'gpt' in model.lower(), f'expected OpenAI model, got {model!r}'
+
+        copy_context().run(_run)
+
+    def test_privacy_mode_on_uses_privacy_profile(self):
+        """With the privacy flag set, get_model() returns the privacy
+        profile's entry — a regolo-hosted OSS model."""
+        from utils.byok import set_privacy_mode
+        from utils.llm.clients import _classify_provider, get_model
+
+        def _run():
+            set_privacy_mode(True)
+            model = get_model('chat_responses')
+            assert _classify_provider(model) == 'regolo', (
+                f'chat_responses with privacy mode on should route to regolo; got {model!r}'
+            )
+
+        copy_context().run(_run)
+
+    def test_privacy_mode_respects_env_override(self):
+        """Per-feature env overrides (MODEL_QOS_<FEATURE>) beat the privacy
+        profile — operators still need manual escape hatches."""
+        import os
+
+        from utils.byok import set_privacy_mode
+        from utils.llm.clients import get_model
+
+        def _run():
+            os.environ['MODEL_QOS_CHAT_RESPONSES'] = 'gpt-4.1-mini'
+            try:
+                set_privacy_mode(True)
+                assert get_model('chat_responses') == 'gpt-4.1-mini'
+            finally:
+                os.environ.pop('MODEL_QOS_CHAT_RESPONSES', None)
+
+        copy_context().run(_run)
+
+    def test_privacy_mode_header_truthy_parsing(self):
+        """A range of truthy spellings should all enable privacy mode;
+        falsy/absent values leave it off."""
+        from utils.byok import _parse_privacy_mode
+
+        for val in ('1', 'on', 'true', 'True', 'YES', 'enabled', 'Enabled'):
+            assert _parse_privacy_mode(val) is True, f'expected True for {val!r}'
+
+        for val in (None, '', '0', 'off', 'false', 'no', 'anything_else'):
+            assert _parse_privacy_mode(val) is False, f'expected False for {val!r}'
+
+
 class TestRegoloByokHeader:
     """The backend BYOK_HEADERS map must expose the regolo header name so the
     middleware routes X-BYOK-Regolo into the contextvar."""

--- a/backend/tests/unit/test_regolo_client.py
+++ b/backend/tests/unit/test_regolo_client.py
@@ -156,6 +156,107 @@ class TestRegoloBYOKRouting:
             copy_context().run(_run)
 
 
+class TestRegoloProviderClassification:
+    """Verify _classify_provider routes regolo-hosted model IDs to the 'regolo'
+    path and leaves OpenAI / Anthropic / OpenRouter / Perplexity models alone."""
+
+    @pytest.mark.parametrize(
+        'model',
+        [
+            'minimax-m2.5',
+            'Llama-3.3-70B-Instruct',
+            'qwen3.5-122b',
+            'qwen3.5-9b',
+            'qwen3-coder-next',
+            'Qwen3-Embedding-8B',
+            'mistral-small-4-119b',
+            'apertus-70b',
+            'gpt-oss-120b',
+            'gemma4-31b',
+        ],
+    )
+    def test_regolo_models_classify_as_regolo(self, model):
+        from utils.llm.clients import _classify_provider
+
+        assert _classify_provider(model) == 'regolo', (
+            f'{model!r} should classify as regolo; got {_classify_provider(model)!r}'
+        )
+
+    def test_openai_models_unaffected(self):
+        from utils.llm.clients import _classify_provider
+
+        for model in ('gpt-4.1-mini', 'gpt-5.4', 'gpt-5.1', 'o4-mini'):
+            assert _classify_provider(model) == 'openai'
+
+    def test_anthropic_unaffected(self):
+        from utils.llm.clients import _classify_provider
+
+        assert _classify_provider('claude-sonnet-4-6') == 'anthropic'
+
+    def test_openrouter_unaffected(self):
+        from utils.llm.clients import _classify_provider
+
+        assert _classify_provider('google/gemini-3-flash-preview') == 'openrouter'
+
+    def test_perplexity_unaffected(self):
+        from utils.llm.clients import _classify_provider
+
+        assert _classify_provider('sonar-pro') == 'perplexity'
+
+
+class TestPrivacyProfile:
+    """The 'privacy' QoS profile must map every routable feature to a regolo
+    model (or to provider-only features that stay on their pinned path)."""
+
+    def test_privacy_profile_exists(self):
+        from utils.llm.clients import MODEL_QOS_PROFILES
+
+        assert 'privacy' in MODEL_QOS_PROFILES, 'privacy profile not registered'
+
+    def test_privacy_profile_has_all_premium_features(self):
+        """Every feature present in the premium profile should be covered in
+        privacy, so MODEL_QOS=privacy doesn't fall back to 'gpt-4.1-mini'."""
+        from utils.llm.clients import MODEL_QOS_PROFILES
+
+        premium_features = set(MODEL_QOS_PROFILES['premium'].keys())
+        privacy_features = set(MODEL_QOS_PROFILES['privacy'].keys())
+        missing = premium_features - privacy_features
+        assert not missing, f'privacy profile missing features: {sorted(missing)}'
+
+    def test_privacy_chat_routes_through_regolo(self):
+        """chat_responses in the privacy profile must pick a regolo model."""
+        from utils.llm.clients import MODEL_QOS_PROFILES, _classify_provider
+
+        model = MODEL_QOS_PROFILES['privacy']['chat_responses']
+        assert _classify_provider(model) == 'regolo', (
+            f"chat_responses picked {model!r} which is not regolo-classified"
+        )
+
+    def test_privacy_synthesis_routes_through_regolo(self):
+        """Structured extraction features must use the tool-capable Llama model."""
+        from utils.llm.clients import MODEL_QOS_PROFILES
+
+        for feature in ('conv_action_items', 'memories', 'knowledge_graph'):
+            model = MODEL_QOS_PROFILES['privacy'][feature]
+            assert 'llama' in model.lower() or 'minimax' in model.lower(), (
+                f"{feature} should pick a regolo tool/synthesis model, got {model!r}"
+            )
+
+    def test_privacy_keeps_anthropic_for_chat_agent(self):
+        """chat_agent has no OSS equivalent good enough — keep it on Claude
+        even in privacy profile. The _ANTHROPIC_ONLY_FEATURES gate in get_llm()
+        enforces this routing regardless of profile."""
+        from utils.llm.clients import MODEL_QOS_PROFILES
+
+        assert MODEL_QOS_PROFILES['privacy']['chat_agent'].startswith('claude')
+
+    def test_privacy_keeps_perplexity_for_web_search(self):
+        """Regolo has no web-search equivalent — web_search must stay on sonar."""
+        from utils.llm.clients import MODEL_QOS_PROFILES
+
+        assert MODEL_QOS_PROFILES['privacy']['web_search'].startswith('sonar')
+
+
 class TestRegoloByokHeader:
     """The backend BYOK_HEADERS map must expose the regolo header name so the
     middleware routes X-BYOK-Regolo into the contextvar."""

--- a/backend/tests/unit/test_regolo_client.py
+++ b/backend/tests/unit/test_regolo_client.py
@@ -1,0 +1,168 @@
+"""Tests for the regolo.ai OpenAI-compat BYOK routing proxy.
+
+Covers: base_url swap, api_key swap, chat_template_kwargs.enable_thinking=false
+injection, fallback when no BYOK key, extra_body merge preservation.
+
+See also desktop/docs/REGOLO_INTEGRATION.md for the full integration spec.
+"""
+
+import os
+import sys
+from contextvars import copy_context
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level stubs: prevent Firestore/Redis/Anthropic init on import.
+# Mirrors the setup in test_byok_security.py so this file runs standalone.
+# ---------------------------------------------------------------------------
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-for-unit-tests')
+os.environ.setdefault('ANTHROPIC_API_KEY', 'sk-ant-test-fake')
+
+
+def _reset_caches():
+    """Clear the in-memory proxy caches between tests so swapped kwargs
+    don't leak across cases."""
+    from utils.llm.clients import _openai_cache
+
+    _openai_cache.clear()
+
+
+class TestRegoloBYOKRouting:
+    """The regolo proxy should swap base_url + api_key + extra_body when
+    the per-request BYOK key is present, and fall back transparently otherwise."""
+
+    def test_no_byok_key_returns_default(self):
+        """Without a regolo BYOK key in the context, _resolve() returns the default client."""
+        from utils.llm.clients import _RegoloOpenAIProxy
+
+        default = MagicMock(name='default_chat_openai')
+        proxy = _RegoloOpenAIProxy(default=default, regolo_model='minimax-m2.5', ctor_kwargs={})
+
+        def _run():
+            resolved = proxy._resolve()
+            assert resolved is default, 'expected default when no BYOK key set'
+
+        copy_context().run(_run)
+
+    def test_byok_key_routes_to_regolo(self):
+        """With a regolo BYOK key in the context, the proxy must build a new
+        ChatOpenAI pointing at api.regolo.ai with the user's key."""
+        from utils.byok import set_byok_keys
+        from utils.llm.clients import REGOLO_OPENAI_BASE_URL, _RegoloOpenAIProxy
+
+        default = MagicMock(name='default_chat_openai')
+        built = MagicMock(name='regolo_chat_openai')
+        ctor_calls = []
+
+        def fake_chat_openai(*, model, api_key, **kwargs):
+            ctor_calls.append({'model': model, 'api_key': api_key, **kwargs})
+            return built
+
+        with patch('utils.llm.clients.ChatOpenAI', side_effect=fake_chat_openai):
+            proxy = _RegoloOpenAIProxy(
+                default=default,
+                regolo_model='minimax-m2.5',
+                ctor_kwargs={},
+            )
+
+            def _run():
+                set_byok_keys({'regolo': 'sk-regolo-test-abc'})
+                _reset_caches()
+                resolved = proxy._resolve()
+                assert resolved is built
+                assert len(ctor_calls) == 1
+                call = ctor_calls[0]
+                assert call['model'] == 'minimax-m2.5'
+                assert call['api_key'] == 'sk-regolo-test-abc'
+                assert call['base_url'] == REGOLO_OPENAI_BASE_URL
+
+            copy_context().run(_run)
+
+    def test_enable_thinking_false_injected(self):
+        """The proxy must inject chat_template_kwargs.enable_thinking=false so OSS
+        thinking models (MiniMax, Qwen3.5) return content instead of
+        finish_reason=length from exhausted reasoning budget."""
+        from utils.byok import set_byok_keys
+        from utils.llm.clients import _RegoloOpenAIProxy
+
+        captured: list = []
+
+        def fake_chat_openai(**kwargs):
+            captured.append(kwargs)
+            return MagicMock()
+
+        default = MagicMock()
+        with patch('utils.llm.clients.ChatOpenAI', side_effect=fake_chat_openai):
+            proxy = _RegoloOpenAIProxy(
+                default=default,
+                regolo_model='minimax-m2.5',
+                ctor_kwargs={},
+            )
+
+            def _run():
+                set_byok_keys({'regolo': 'sk-regolo-enable-thinking'})
+                _reset_caches()
+                proxy._resolve()
+                assert len(captured) == 1
+                extra_body = captured[0].get('extra_body', {})
+                chat_tpl = extra_body.get('chat_template_kwargs', {})
+                assert chat_tpl.get('enable_thinking') is False, (
+                    'regolo proxy must disable thinking for OSS models; got '
+                    f'extra_body={extra_body!r}'
+                )
+
+            copy_context().run(_run)
+
+    def test_existing_extra_body_is_preserved(self):
+        """Caller-provided extra_body (e.g. prompt cache hints for non-regolo path)
+        must merge with enable_thinking, not be overwritten."""
+        from utils.byok import set_byok_keys
+        from utils.llm.clients import _RegoloOpenAIProxy
+
+        captured: list = []
+
+        def fake_chat_openai(**kwargs):
+            captured.append(kwargs)
+            return MagicMock()
+
+        default = MagicMock()
+        with patch('utils.llm.clients.ChatOpenAI', side_effect=fake_chat_openai):
+            proxy = _RegoloOpenAIProxy(
+                default=default,
+                regolo_model='Llama-3.3-70B-Instruct',
+                ctor_kwargs={'extra_body': {'custom_flag': 'keep_me'}, 'callbacks': []},
+            )
+
+            def _run():
+                set_byok_keys({'regolo': 'sk-regolo-merge-test'})
+                _reset_caches()
+                proxy._resolve()
+                extra_body = captured[0].get('extra_body', {})
+                assert extra_body.get('custom_flag') == 'keep_me', 'original extra_body key lost'
+                assert extra_body.get('chat_template_kwargs', {}).get('enable_thinking') is False
+
+            copy_context().run(_run)
+
+
+class TestRegoloByokHeader:
+    """The backend BYOK_HEADERS map must expose the regolo header name so the
+    middleware routes X-BYOK-Regolo into the contextvar."""
+
+    def test_regolo_header_registered(self):
+        from utils.byok import BYOK_HEADERS
+
+        assert BYOK_HEADERS.get('regolo') == 'x-byok-regolo'
+
+    def test_all_header_names_are_lowercase(self):
+        """FastAPI lowercases header names; ensure the map reflects that so
+        lookups succeed."""
+        from utils.byok import BYOK_HEADERS
+
+        for provider, header in BYOK_HEADERS.items():
+            assert header == header.lower(), f'{provider} header is not lowercase: {header!r}'
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, '-v']))

--- a/backend/tests/unit/test_regolo_client.py
+++ b/backend/tests/unit/test_regolo_client.py
@@ -19,6 +19,16 @@ import pytest
 # ---------------------------------------------------------------------------
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-for-unit-tests')
 os.environ.setdefault('ANTHROPIC_API_KEY', 'sk-ant-test-fake')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+# utils/llm/clients.py imports usage_tracker which reaches database.llm_usage
+# which pulls in google-cloud-firestore. Stub the chain so the import graph
+# stops at our proxy class.
+sys.modules.setdefault('database._client', MagicMock())
+sys.modules.setdefault('database.redis_db', MagicMock())
+sys.modules.setdefault('database.users', MagicMock())
+sys.modules.setdefault('database.user_usage', MagicMock())
+sys.modules.setdefault('database.llm_usage', MagicMock())
 
 
 def _reset_caches():

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -71,6 +71,36 @@ BYOK_HEADERS = {
     'regolo': 'x-byok-regolo',
 }
 
+# ---------------------------------------------------------------------------
+# EU Privacy Mode — per-request flag that asks the backend to route every
+# routable LLM workload through regolo.ai (Italy-hosted, zero retention)
+# instead of the active MODEL_QOS profile. Set via the X-Privacy-Mode HTTP
+# header with a truthy value; absence or a falsy value keeps the existing
+# routing. Orthogonal to BYOK — a user can have Privacy Mode on with or
+# without regolo key enrolment (though without the key the request will
+# fail loudly at the LLM call site by design).
+# ---------------------------------------------------------------------------
+PRIVACY_MODE_HEADER = 'x-privacy-mode'
+_PRIVACY_MODE_TRUTHY = frozenset({'1', 'on', 'true', 'yes', 'enabled'})
+
+_privacy_mode_ctx: ContextVar[bool] = ContextVar('privacy_mode', default=False)
+
+
+def _parse_privacy_mode(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in _PRIVACY_MODE_TRUTHY
+
+
+def is_privacy_mode_active() -> bool:
+    """True when the current request sent an X-Privacy-Mode truthy header."""
+    return _privacy_mode_ctx.get()
+
+
+def set_privacy_mode(enabled: bool) -> None:
+    """Used by the middleware; also by WS handlers that read headers manually."""
+    _privacy_mode_ctx.set(bool(enabled))
+
 # Keys for the current request, if the client supplied them.
 # Default is None (not {}) to avoid sharing a mutable object across contexts.
 _byok_ctx: ContextVar[Optional[Dict[str, str]]] = ContextVar('byok_keys', default=None)
@@ -113,6 +143,15 @@ def extract_byok_from_websocket(websocket: WebSocket) -> Dict[str, str]:
     return keys
 
 
+def extract_privacy_mode_from_websocket(websocket: WebSocket) -> bool:
+    """Read the X-Privacy-Mode header from a WebSocket's initial upgrade request.
+
+    Like ``extract_byok_from_websocket``, WebSocket handlers must call this
+    manually and then pass the result to ``set_privacy_mode``.
+    """
+    return _parse_privacy_mode(websocket.headers.get(PRIVACY_MODE_HEADER))
+
+
 class BYOKMiddleware(BaseHTTPMiddleware):
     """Extract BYOK headers from each HTTP request into the contextvar.
 
@@ -127,10 +166,13 @@ class BYOKMiddleware(BaseHTTPMiddleware):
             value = request.headers.get(header)
             if value:
                 keys[provider] = value
+        privacy_mode = _parse_privacy_mode(request.headers.get(PRIVACY_MODE_HEADER))
         token = _byok_ctx.set(keys)
+        privacy_token = _privacy_mode_ctx.set(privacy_mode)
         try:
             return await call_next(request)
         finally:
+            _privacy_mode_ctx.reset(privacy_token)
             _byok_ctx.reset(token)
 
 

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -68,6 +68,7 @@ BYOK_HEADERS = {
     'anthropic': 'x-byok-anthropic',
     'gemini': 'x-byok-gemini',
     'deepgram': 'x-byok-deepgram',
+    'regolo': 'x-byok-regolo',
 }
 
 # Keys for the current request, if the client supplied them.

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -152,6 +152,63 @@ def extract_privacy_mode_from_websocket(websocket: WebSocket) -> bool:
     return _parse_privacy_mode(websocket.headers.get(PRIVACY_MODE_HEADER))
 
 
+# ---------------------------------------------------------------------------
+# Privacy Mode fallback signalling — response-side contract
+#
+# When Privacy Mode is on but a specific request could not actually be served
+# by regolo (vision unsupported, regolo outage, persistent 429), the response
+# must tell the client *which* fallback fired so the UI can surface a visible
+# red banner rather than silently leaking traffic to Claude/Gemini.
+#
+# Contract: set the X-Privacy-Mode-Fallback response header to a short reason
+# token.  Clients that sent X-Privacy-Mode but receive this header back should
+# show a per-request "⚠️ This request left the EU" banner with the reason.
+# ---------------------------------------------------------------------------
+PRIVACY_MODE_FALLBACK_HEADER = 'x-privacy-mode-fallback'
+
+PRIVACY_FALLBACK_VISION_UNSUPPORTED = 'vision_unsupported'
+PRIVACY_FALLBACK_REGOLO_OUTAGE = 'regolo_outage'
+PRIVACY_FALLBACK_REGOLO_RATE_LIMITED = 'regolo_rate_limited'
+PRIVACY_FALLBACK_NO_KEY = 'no_regolo_key'
+
+_PRIVACY_FALLBACK_REASONS = frozenset({
+    PRIVACY_FALLBACK_VISION_UNSUPPORTED,
+    PRIVACY_FALLBACK_REGOLO_OUTAGE,
+    PRIVACY_FALLBACK_REGOLO_RATE_LIMITED,
+    PRIVACY_FALLBACK_NO_KEY,
+})
+
+# The reason for the current request's fallback, if any.  Set by call sites
+# that actually route non-regolo traffic while privacy mode was requested.
+# Consumed by a response middleware that stamps the header before returning.
+_privacy_fallback_ctx: ContextVar[Optional[str]] = ContextVar(
+    'privacy_fallback_reason', default=None
+)
+
+
+def mark_privacy_fallback(reason: str) -> None:
+    """Record that the current request fell back out of Privacy Mode.
+
+    Call this from any code path that routes a privacy-mode request to
+    Claude/Gemini/OpenAI instead of regolo — e.g. the vision router when a
+    screenshot analysis can't run on regolo, or the retry loop when regolo
+    5xx's three times.  The response middleware adds the X-Privacy-Mode-Fallback
+    header based on this value so the client can show a banner.
+
+    Only accepts reasons from the PRIVACY_FALLBACK_* constant set — unknown
+    reasons would turn the client-side banner into noise.
+    """
+    if reason not in _PRIVACY_FALLBACK_REASONS:
+        logger.warning('mark_privacy_fallback called with unknown reason=%s', reason)
+        return
+    _privacy_fallback_ctx.set(reason)
+
+
+def get_privacy_fallback_reason() -> Optional[str]:
+    """Return the fallback reason recorded for the current request, or None."""
+    return _privacy_fallback_ctx.get()
+
+
 class BYOKMiddleware(BaseHTTPMiddleware):
     """Extract BYOK headers from each HTTP request into the contextvar.
 
@@ -169,9 +226,17 @@ class BYOKMiddleware(BaseHTTPMiddleware):
         privacy_mode = _parse_privacy_mode(request.headers.get(PRIVACY_MODE_HEADER))
         token = _byok_ctx.set(keys)
         privacy_token = _privacy_mode_ctx.set(privacy_mode)
+        fallback_token = _privacy_fallback_ctx.set(None)
         try:
-            return await call_next(request)
+            response = await call_next(request)
+            # If a downstream code path called mark_privacy_fallback(), stamp
+            # the response header so the client can surface a visible banner.
+            fallback_reason = _privacy_fallback_ctx.get()
+            if fallback_reason is not None and privacy_mode:
+                response.headers[PRIVACY_MODE_FALLBACK_HEADER] = fallback_reason
+            return response
         finally:
+            _privacy_fallback_ctx.reset(fallback_token)
             _privacy_mode_ctx.reset(privacy_token)
             _byok_ctx.reset(token)
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -311,6 +311,66 @@ MODEL_QOS_PROFILES: Dict[str, Dict[str, str]] = {
         # Perplexity (unchanged)
         'web_search': 'sonar-pro',
     },
+    # 'privacy' profile — routes every supported feature through regolo.ai
+    # (Italy-hosted, zero retention). Activated when MODEL_QOS=privacy at the
+    # process level or when a per-request EU Privacy Mode flag is set on the
+    # user's account. Model picks are informed by live capability probing:
+    #   - minimax-m2.5 for chat + tool calling (strongest OSS agentic scores,
+    #     76.8% BFCL Multi-Turn; requires chat_template_kwargs.enable_thinking=false)
+    #   - Llama-3.3-70B-Instruct for extraction/synthesis workloads (clean
+    #     OpenAI-compat tool_calls, no thinking-token tax)
+    #   - qwen3.5-9b for cheap grading/classification (€0.07/€0.35 per 1M)
+    # Features unsupported by regolo (web_search, vision) stay on the
+    # existing Perplexity/Gemini paths — the router outside this profile
+    # handles the fallback.
+    'privacy': {
+        # Conversation processing → Llama-3.3-70B for structure + extraction
+        'conv_action_items': 'Llama-3.3-70B-Instruct',
+        'conv_structure': 'Llama-3.3-70B-Instruct',
+        'conv_app_result': 'Llama-3.3-70B-Instruct',
+        'conv_app_select': 'qwen3.5-9b',
+        'conv_folder': 'qwen3.5-9b',
+        'conv_discard': 'qwen3.5-9b',
+        'daily_summary': 'Llama-3.3-70B-Instruct',
+        'daily_summary_simple': 'qwen3.5-9b',
+        'external_structure': 'Llama-3.3-70B-Instruct',
+        # Memories & knowledge
+        'memories': 'Llama-3.3-70B-Instruct',
+        'learnings': 'Llama-3.3-70B-Instruct',
+        'memory_conflict': 'Llama-3.3-70B-Instruct',
+        'memory_category': 'qwen3.5-9b',
+        'knowledge_graph': 'Llama-3.3-70B-Instruct',
+        # Chat
+        'chat_responses': 'minimax-m2.5',
+        'chat_extraction': 'Llama-3.3-70B-Instruct',
+        'chat_graph': 'Llama-3.3-70B-Instruct',
+        'session_titles': 'qwen3.5-9b',
+        # Features
+        'goals': 'Llama-3.3-70B-Instruct',
+        'goals_advice': 'minimax-m2.5',
+        'notifications': 'minimax-m2.5',
+        'proactive_notification': 'Llama-3.3-70B-Instruct',
+        'followup': 'qwen3.5-9b',
+        'smart_glasses': 'qwen3.5-9b',
+        'onboarding': 'qwen3.5-9b',
+        'app_generator': 'minimax-m2.5',
+        'app_integration': 'qwen3.5-9b',
+        'persona_clone': 'minimax-m2.5',
+        'trends': 'qwen3.5-9b',
+        # Anthropic-only features stay on Claude — regolo has no equivalent
+        # computer-use/complex-agent model.  chat_agent falls through to
+        # _ANTHROPIC_ONLY_FEATURES checks in get_llm() and routes to Claude
+        # via anthropic_client regardless of profile.
+        'chat_agent': 'claude-sonnet-4-6',
+        # Persona chat — MiniMax at warmer temperature handles character voice
+        'persona_chat': 'minimax-m2.5',
+        'persona_chat_premium': 'minimax-m2.5',
+        # Large-context analysis → MiniMax (supports long contexts with thinking off)
+        'wrapped_analysis': 'minimax-m2.5',
+        # Web search has no OSS equivalent — stays on Perplexity.
+        # _PERPLEXITY_ONLY_FEATURES check in get_llm() routes this correctly.
+        'web_search': 'sonar-pro',
+    },
 }
 
 # Pinned features — model is fixed regardless of profile or env override.
@@ -331,6 +391,24 @@ _ANTHROPIC_ONLY_FEATURES = {'chat_agent'}  # always Anthropic, used via get_mode
 _PERPLEXITY_ONLY_FEATURES = {'web_search'}  # always Perplexity, used via get_model() + HTTP client
 
 
+# Model-ID prefixes served by regolo.ai's OpenAI-compat endpoint.  Matched
+# case-insensitively against the start of the model name.  Order doesn't
+# matter but keep the list narrow — anything OpenAI-named (gpt-*) still
+# routes to OpenAI even if regolo happens to host a same-named variant.
+_REGOLO_MODEL_PREFIXES = (
+    'minimax-',
+    'llama-3',
+    'qwen3',
+    'qwen-',
+    'mistral-small',
+    'apertus-',
+    'gpt-oss-',
+    'deepseek-ocr',
+    'faster-whisper',
+    'gemma',
+)
+
+
 def _classify_provider(model: str) -> str:
     """Classify provider from model name. Provider follows the model, not the feature."""
     if '/' in model:
@@ -339,6 +417,10 @@ def _classify_provider(model: str) -> str:
         return 'anthropic'
     if model.startswith('sonar'):
         return 'perplexity'
+    name_lower = model.lower()
+    for prefix in _REGOLO_MODEL_PREFIXES:
+        if name_lower.startswith(prefix):
+            return 'regolo'
     return 'openai'
 
 
@@ -413,6 +495,34 @@ def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> _Open
     return _llm_cache[key]
 
 
+def _get_or_create_regolo_llm(model_name: str, streaming: bool = False) -> _RegoloOpenAIProxy:
+    """Build a regolo-routed ChatOpenAI proxy for an OSS model hosted on regolo.ai.
+
+    The proxy's default (non-regolo) client falls back to OpenAI with the same
+    model name — which will 404 if the OpenAI account doesn't know that model ID.
+    That fallback is deliberate: when a user configures the 'privacy' QoS profile
+    but hasn't supplied a regolo BYOK key, the 404 surfaces loudly rather than
+    silently routing privacy-mode traffic elsewhere.
+    """
+    key = (model_name, streaming, 'regolo')
+    if key not in _llm_cache:
+        ctor_kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
+        if streaming:
+            ctor_kwargs['streaming'] = True
+            ctor_kwargs['stream_options'] = {"include_usage": True}
+        # Default = a plain ChatOpenAI that WILL fail without a regolo key. The
+        # proxy only returns this when get_byok_key('regolo') is None; a loud
+        # failure is preferable to a silent fallback that leaks privacy-mode
+        # traffic to OpenAI.
+        default = ChatOpenAI(model=model_name, **ctor_kwargs)
+        _llm_cache[key] = _RegoloOpenAIProxy(
+            default=default,
+            regolo_model=model_name,
+            ctor_kwargs=ctor_kwargs,
+        )
+    return _llm_cache[key]
+
+
 def _get_or_create_openrouter_llm(
     model_name: str, streaming: bool = False, temperature: Optional[float] = None
 ) -> ChatOpenAI:
@@ -483,6 +593,13 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
     if provider == 'openrouter':
         temp = _OPENROUTER_TEMPERATURES.get(feature)
         return _get_or_create_openrouter_llm(model, streaming, temp)
+
+    if provider == 'regolo':
+        # Privacy-profile features — build a BYOK-gated proxy that targets
+        # api.regolo.ai with enable_thinking=false injected for OSS thinking models.
+        # prompt_cache_key is a no-op on regolo (OSS models have no server-side
+        # cache) so we skip the .bind() step.
+        return _get_or_create_regolo_llm(model, streaming)
 
     llm = _get_or_create_openai_llm(model, streaming)
     if cache_key and model in _CACHE_KEY_MODELS:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -148,6 +148,17 @@ _BYOK_CACHE_TTL_SECONDS = 3600  # 1 hour
 _openai_cache: TTLCache = TTLCache(maxsize=_BYOK_CACHE_MAX_SIZE, ttl=_BYOK_CACHE_TTL_SECONDS)
 _anthropic_cache: TTLCache = TTLCache(maxsize=_BYOK_CACHE_MAX_SIZE, ttl=_BYOK_CACHE_TTL_SECONDS)
 
+# Regolo.ai — OpenAI-compatible EU-hosted OSS inference (Italy, zero retention).
+# Used when the user has supplied a regolo BYOK key AND selected EU Privacy Mode.
+# Routes through ChatOpenAI with base_url override, same pattern as Anthropic-via-OpenAI.
+REGOLO_OPENAI_BASE_URL = "https://api.regolo.ai/v1"
+
+# Regolo OSS thinking-models (MiniMax M2.5, Qwen3.5-122B) default to reasoning-on and
+# will burn the max_tokens budget on internal thought, returning content=null with
+# finish_reason=length. This flag — passed via vLLM chat_template_kwargs in the
+# request body — disables that path for synthesis/chat workloads.
+REGOLO_DISABLE_THINKING_EXTRA_BODY = {"chat_template_kwargs": {"enable_thinking": False}}
+
 
 def _hash_key(api_key: str) -> str:
     """Derive a safe cache key from an API key. Never store raw keys in memory."""
@@ -608,6 +619,51 @@ _persona_medium_default = ChatOpenAI(
     default_headers={"X-Title": "Omi Chat"},
     **_persona_medium_kwargs,
 )
+
+
+class _RegoloOpenAIProxy:
+    """Route to regolo.ai's OpenAI-compatible endpoint when the user has a regolo BYOK key.
+
+    Falls back to the provided non-regolo default (typically an OpenAI or Gemini
+    client) when no regolo key is set — so existing Claude/Gemini routing is
+    unaffected. When routing to regolo, injects ``chat_template_kwargs.enable_thinking=false``
+    via ``extra_body`` so OSS thinking models (MiniMax M2.5, Qwen3.5-122B) don't burn
+    the ``max_tokens`` budget on internal reasoning.
+
+    Note: provider-specific ``reasoning_content`` field that regolo sometimes returns
+    is dropped by langchain_openai's parser; we do not need to strip it ourselves.
+    """
+
+    __slots__ = ('_default', '_regolo_model', '_ctor_kwargs')
+
+    def __init__(self, default: ChatOpenAI, regolo_model: str, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_regolo_model', regolo_model)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('regolo')
+        if byok:
+            merged_extra_body = {
+                **self._ctor_kwargs.get('extra_body', {}),
+                **REGOLO_DISABLE_THINKING_EXTRA_BODY,
+            }
+            regolo_kwargs = {
+                **self._ctor_kwargs,
+                'base_url': REGOLO_OPENAI_BASE_URL,
+                'extra_body': merged_extra_body,
+            }
+            return _cached_openai_chat(self._regolo_model, byok, regolo_kwargs)
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+    def __or__(self, other):
+        return self._resolve() | other
+
+    def __ror__(self, other):
+        return other | self._resolve()
 
 
 class _AnthropicViaOpenAIProxy:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -11,7 +11,7 @@ from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 import tiktoken
 
 from models.structured import Structured
-from utils.byok import get_byok_key
+from utils.byok import get_byok_key, is_privacy_mode_active
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -470,6 +470,14 @@ def get_model(feature: str) -> str:
                 expected_provider,
             )
         return override
+    # EU Privacy Mode — per-request flag asks us to route via regolo.ai.
+    # Use the 'privacy' profile entry when set; falls back to the active profile
+    # for features missing from the privacy map (none expected day 1 — see
+    # test_privacy_profile_has_all_premium_features).
+    if is_privacy_mode_active():
+        privacy_model = MODEL_QOS_PROFILES['privacy'].get(feature)
+        if privacy_model is not None:
+            return privacy_model
     return _active_profile.get(feature, 'gpt-4.1-mini')
 
 

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -111,6 +111,14 @@ actor APIClient {
       headers[provider.headerName] = entry.key
     }
 
+    // EU Privacy Mode: when enabled, ask the backend to route every LLM call
+    // through regolo.ai (Italy-hosted, zero retention) instead of the active
+    // Claude/Gemini profile.  Header is only attached when the user opted in;
+    // the backend default (no header) keeps current routing.
+    if APIKeyService.isEUPrivacyModeEnabled {
+      headers["X-Privacy-Mode"] = "on"
+    }
+
     return headers
   }
 

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -204,6 +204,8 @@ actor APIClient {
       throw APIError.invalidResponse
     }
 
+    await inspectPrivacyFallback(httpResponse)
+
     // Handle 401 - token might be expired
     if httpResponse.statusCode == 401 {
       // Try to refresh token and retry once
@@ -219,6 +221,8 @@ actor APIClient {
       guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
         throw APIError.invalidResponse
       }
+
+      await inspectPrivacyFallback(retryHttpResponse)
 
       if retryHttpResponse.statusCode == 401 {
         throw APIError.unauthorized
@@ -259,6 +263,22 @@ actor APIClient {
         logError("Decoding error", error: decodingError)
       }
       throw decodingError
+    }
+  }
+
+  /// Inspect the response for ``X-Privacy-Mode-Fallback`` and, when present,
+  /// hand the reason to ``PrivacyModeFallbackObserver`` so the banner can show.
+  /// No-op when the header isn't set or when the user doesn't have Privacy
+  /// Mode enabled (the observer itself also filters on that).
+  private func inspectPrivacyFallback(_ response: HTTPURLResponse) async {
+    guard
+      let rawReason = response.value(forHTTPHeaderField: "X-Privacy-Mode-Fallback"),
+      !rawReason.isEmpty
+    else {
+      return
+    }
+    await MainActor.run {
+      PrivacyModeFallbackObserver.shared.record(rawReason: rawReason)
     }
   }
 }

--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -21,6 +21,7 @@ enum BYOKProvider: String, CaseIterable {
     case anthropic
     case gemini
     case deepgram
+    case regolo
 
     var storageKey: String {
         switch self {
@@ -28,6 +29,7 @@ enum BYOKProvider: String, CaseIterable {
         case .anthropic: return "dev_anthropic_api_key"
         case .gemini: return "dev_gemini_api_key"
         case .deepgram: return "dev_deepgram_api_key"
+        case .regolo: return "dev_regolo_api_key"
         }
     }
 
@@ -37,6 +39,7 @@ enum BYOKProvider: String, CaseIterable {
         case .anthropic: return "X-BYOK-Anthropic"
         case .gemini: return "X-BYOK-Gemini"
         case .deepgram: return "X-BYOK-Deepgram"
+        case .regolo: return "X-BYOK-Regolo"
         }
     }
 
@@ -46,6 +49,7 @@ enum BYOKProvider: String, CaseIterable {
         case .anthropic: return "Anthropic"
         case .gemini: return "Gemini"
         case .deepgram: return "Deepgram"
+        case .regolo: return "Regolo (EU)"
         }
     }
 }

--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -242,4 +242,16 @@ final class APIKeyService: ObservableObject {
         }
         return out
     }
+
+    // MARK: - EU Privacy Mode
+
+    /// UserDefaults key for the EU Privacy Mode toggle.  When true, APIClient
+    /// attaches the X-Privacy-Mode header so the backend routes LLM workloads
+    /// through regolo.ai (Italy-hosted) instead of Claude/Gemini.
+    nonisolated static let euPrivacyModeStorageKey = "eu_privacy_mode_enabled"
+
+    nonisolated static var isEUPrivacyModeEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: euPrivacyModeStorageKey) }
+        set { UserDefaults.standard.set(newValue, forKey: euPrivacyModeStorageKey) }
+    }
 }

--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -52,6 +52,17 @@ enum BYOKProvider: String, CaseIterable {
         case .regolo: return "Regolo (EU)"
         }
     }
+
+    /// True when this provider key is required for the BYOK free-plan subscription
+    /// bypass. Optional providers (regolo) can be configured without affecting the
+    /// gate — users enable them per-feature (e.g. EU Privacy Mode) without needing
+    /// to replace their existing Anthropic/Gemini/OpenAI/Deepgram keys.
+    var isRequiredForFreePlan: Bool {
+        switch self {
+        case .openai, .anthropic, .gemini, .deepgram: return true
+        case .regolo: return false
+        }
+    }
 }
 @MainActor
 final class APIKeyService: ObservableObject {
@@ -204,11 +215,14 @@ final class APIKeyService: ObservableObject {
         nonEmptyStatic(UserDefaults.standard.string(forKey: provider.storageKey))
     }
 
-    /// True when the user has supplied keys for all four BYOK providers.
-    /// The subscription-bypass gate: when this is true, the user is on the free
-    /// plan and we attach their keys to every backend request.
+    /// True when the user has supplied keys for all REQUIRED BYOK providers
+    /// (OpenAI, Anthropic, Gemini, Deepgram). Optional providers like regolo
+    /// don't gate free-plan eligibility — they enable opt-in features such as
+    /// EU Privacy Mode without affecting the subscription bypass.
     nonisolated static var isByokActive: Bool {
-        BYOKProvider.allCases.allSatisfy { byokKey($0) != nil }
+        BYOKProvider.allCases
+            .filter { $0.isRequiredForFreePlan }
+            .allSatisfy { byokKey($0) != nil }
     }
 
     /// SHA-256 fingerprint of a key, used by the backend to detect when the

--- a/desktop/Desktop/Sources/BYOKValidator.swift
+++ b/desktop/Desktop/Sources/BYOKValidator.swift
@@ -43,6 +43,11 @@ enum BYOKValidator {
         url: URL(string: "https://api.deepgram.com/v1/projects")!,
         headers: ["Authorization": "Token \(trimmed)"]
       )
+    case .regolo:
+      return await ping(
+        url: URL(string: "https://api.regolo.ai/v1/models")!,
+        headers: ["Authorization": "Bearer \(trimmed)"]
+      )
     }
   }
 

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -219,6 +219,7 @@ struct SettingsContentView: View {
   // through regolo.ai (Italy, zero retention).
   @State private var euPrivacyModeEnabled: Bool = APIKeyService.isEUPrivacyModeEnabled
   @ObservedObject private var fallbackObserver = PrivacyModeFallbackObserver.shared
+  @AppStorage("eu_privacy_first_run_seen") private var euPrivacyFirstRunSeen: Bool = false
 
   // Transcription settings (from backend)
   @State private var singleLanguageMode: Bool = false
@@ -1609,6 +1610,44 @@ struct SettingsContentView: View {
         }
       }
 
+      // First-run intro for EU Privacy Mode — shown once when the user first
+      // visits this section AND the toggle is still off. Dismissible. Per
+      // desktop/docs/REGOLO_INTEGRATION.md Settings UX guidance: "First-run
+      // prompt only surfaces for EU-locale users or users who open Privacy
+      // settings — avoid evangelism." This card covers the second clause.
+      if !euPrivacyFirstRunSeen, !euPrivacyModeEnabled {
+        settingsCard(settingId: "privacy.eumode.firstrun") {
+          HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "sparkles")
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.purplePrimary)
+              .frame(width: 20, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 6) {
+              Text("New: EU Privacy Mode")
+                .scaledFont(size: 13, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text(
+                "Route AI traffic through regolo.ai in Italy — GDPR-compliant, zero data retention. Bring your own Regolo key. Toggle below to enable."
+              )
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+              .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            Button(action: { euPrivacyFirstRunSeen = true }) {
+              Image(systemName: "xmark")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+            .buttonStyle(.plain)
+          }
+        }
+      }
+
       // EU Privacy Mode — routes LLM work through regolo.ai (Italy, zero retention)
       settingsCard(settingId: "privacy.eumode") {
         VStack(alignment: .leading, spacing: 10) {
@@ -1639,6 +1678,9 @@ struct SettingsContentView: View {
               .controlSize(.small)
               .onChange(of: euPrivacyModeEnabled) { _, newValue in
                 APIKeyService.isEUPrivacyModeEnabled = newValue
+                // Toggling on counts as having seen the intro — no need to
+                // surface the first-run card if the user already engaged.
+                if newValue { euPrivacyFirstRunSeen = true }
               }
           }
 

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -218,6 +218,7 @@ struct SettingsContentView: View {
   // APIClient attaches X-Privacy-Mode: on so the backend routes LLM work
   // through regolo.ai (Italy, zero retention).
   @State private var euPrivacyModeEnabled: Bool = APIKeyService.isEUPrivacyModeEnabled
+  @ObservedObject private var fallbackObserver = PrivacyModeFallbackObserver.shared
 
   // Transcription settings (from backend)
   @State private var singleLanguageMode: Bool = false
@@ -382,6 +383,7 @@ struct SettingsContentView: View {
   @AppStorage("dev_anthropic_api_key") private var devAnthropicKey: String = ""
   @AppStorage("dev_openai_api_key") private var devOpenAIKey: String = ""
   @AppStorage("dev_deepgram_api_key") private var devDeepgramKey: String = ""
+  @AppStorage("dev_regolo_api_key") private var devRegoloKey: String = ""
   @State private var byokKeyStatuses: [BYOKProvider: BYOKValidator.Status] = [:]
   @State private var byokActivationError: String?
 
@@ -1638,6 +1640,25 @@ struct SettingsContentView: View {
               .onChange(of: euPrivacyModeEnabled) { _, newValue in
                 APIKeyService.isEUPrivacyModeEnabled = newValue
               }
+          }
+
+          // Rolling 7-day count of fallback events (requests that left the EU
+          // because regolo couldn't serve them). Surfaced only when EU
+          // Privacy Mode is on AND there has been at least one fallback —
+          // otherwise this row is silent.
+          if euPrivacyModeEnabled, fallbackObserver.weeklyFallbackCount > 0 {
+            HStack(spacing: 8) {
+              Image(systemName: "exclamationmark.triangle")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.warning)
+              Text(
+                "\(fallbackObserver.weeklyFallbackCount) request\(fallbackObserver.weeklyFallbackCount == 1 ? "" : "s") fell back this week."
+              )
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+              Spacer(minLength: 0)
+            }
+            .padding(.leading, 32)  // align with toggle text
           }
         }
       }
@@ -5237,6 +5258,14 @@ struct SettingsContentView: View {
         subtitle: "For live transcription.",
         settingId: "advanced.devkeys.deepgram",
         value: $devDeepgramKey
+      )
+
+      developerKeyField(
+        provider: .regolo,
+        title: "Regolo API Key",
+        subtitle: "For EU Privacy Mode (Italy-hosted, zero retention). Optional.",
+        settingId: "advanced.devkeys.regolo",
+        value: $devRegoloKey
       )
 
       if let byokActivationError {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -214,6 +214,11 @@ struct SettingsContentView: View {
   @State private var privateCloudSyncEnabled: Bool = true
   @State private var isTrackingExpanded: Bool = false
 
+  // EU Privacy Mode — local-only toggle, not synced to backend.  When on,
+  // APIClient attaches X-Privacy-Mode: on so the backend routes LLM work
+  // through regolo.ai (Italy, zero retention).
+  @State private var euPrivacyModeEnabled: Bool = APIKeyService.isEUPrivacyModeEnabled
+
   // Transcription settings (from backend)
   @State private var singleLanguageMode: Bool = false
   @State private var newVocabularyWord: String = ""
@@ -1598,6 +1603,41 @@ struct SettingsContentView: View {
               trackingItem("App open/close events")
             }
             .transition(.opacity)
+          }
+        }
+      }
+
+      // EU Privacy Mode — routes LLM work through regolo.ai (Italy, zero retention)
+      settingsCard(settingId: "privacy.eumode") {
+        VStack(alignment: .leading, spacing: 10) {
+          HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "shield.lefthalf.filled")
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.purplePrimary)
+              .frame(width: 20, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("EU Privacy Mode")
+                .scaledFont(size: 14, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text(
+                "Route all AI on regolo.ai (Italy, zero retention). Requires a Regolo BYOK key. Vision features stay on Gemini — you'll see a warning per request that leaves the EU."
+              )
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+              .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            Toggle("", isOn: $euPrivacyModeEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .controlSize(.small)
+              .onChange(of: euPrivacyModeEnabled) { _, newValue in
+                APIKeyService.isEUPrivacyModeEnabled = newValue
+              }
           }
         }
       }

--- a/desktop/Desktop/Sources/ModelQoS.swift
+++ b/desktop/Desktop/Sources/ModelQoS.swift
@@ -81,6 +81,40 @@ struct ModelQoS {
         static var embedding: String { "gemini-embedding-001" }
     }
 
+    // MARK: - Regolo Models (EU Privacy Mode)
+    //
+    // Used when the user has EU Privacy Mode enabled. Picks are sourced from
+    // the empirical multi-sample latency × consistency probe documented in
+    // `desktop/docs/regolo-probes.md` (P6) — `mistral-small-4-119b` won the
+    // chat/synthesis default over the originally-scoped `minimax-m2.5` after
+    // MiniMax timed out on 3/5 calls at 60s. Llama-3.3-70B remains the
+    // tool-calling default; Llama-3.1-8B is the nano-tier classification
+    // default; Qwen3-Embedding-8B is reserved for the embedding adapter
+    // (HARD-BLOCKED in Phase 1 pending the M2.5 vector-store migration).
+
+    struct Regolo {
+        /// Main chat session model
+        static var chat: String { "mistral-small-4-119b" }
+
+        /// Floating bar responses
+        static var floatingBar: String { "mistral-small-4-119b" }
+
+        /// Synthesis extraction tasks (calendar, gmail, notes, memory import)
+        static var synthesis: String { "mistral-small-4-119b" }
+
+        /// Tool-calling (function-call workloads)
+        static var toolCall: String { "Llama-3.3-70B-Instruct" }
+
+        /// Nano-tier classification / dispatch (10x cheaper, ±16% spread OK)
+        static var nano: String { "Llama-3.1-8B-Instruct" }
+
+        /// Embeddings — Phase 2 only. Currently HARD-BLOCKED on the backend
+        /// because the Pinecone index is fixed at 3072-dim; M2.5 ships the
+        /// 4096-dim parallel index. Reading this constant before M2.5 is a
+        /// programming error.
+        static var embedding: String { "Qwen3-Embedding-8B" }
+    }
+
     // MARK: - Tier Info (for UI / debugging)
 
     static var tierDescription: String {

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -706,6 +706,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         button.image = icon
       }
     }
+    applyMenuBarPrivacyShield()
     // Safety net: verify again after a short delay
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
       let button = self?.statusBarItem?.button
@@ -718,6 +719,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       }
     }
     log("AppDelegate: [MENUBAR] Refreshed status bar item after policy change")
+  }
+
+  /// Apply or clear the EU Privacy Mode shield indicator next to the menu
+  /// bar icon. Cheap to call; idempotent. Only mutates when the privacy
+  /// state changed since the last call.
+  @MainActor private func applyMenuBarPrivacyShield() {
+    guard let button = statusBarItem?.button else { return }
+    let displayName =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "omi"
+    let baseTooltip = OMIApp.launchMode == .rewind ? "omi Rewind" : displayName
+    if APIKeyService.isEUPrivacyModeEnabled {
+      // U+1F6E1 SHIELD as a tiny suffix character; stays subtle next to the
+      // Omi text logo. .imageLeft so the shield text shows after the icon.
+      button.title = "  🛡"
+      button.imagePosition = .imageLeft
+      button.toolTip = "\(baseTooltip) — EU Privacy Mode on"
+    } else {
+      button.title = ""
+      button.imagePosition = .imageOnly
+      button.toolTip = baseTooltip
+    }
   }
 
   /// Set up menu bar icon using NSStatusBar (more reliable than SwiftUI MenuBarExtra)
@@ -785,8 +807,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         log("AppDelegate: [MENUBAR] WARNING - Failed to load omi_text_logo, using fallback")
       }
       button.toolTip = OMIApp.launchMode == .rewind ? "omi Rewind" : displayName
+      applyMenuBarPrivacyShield()
     } else {
       log("AppDelegate: [MENUBAR] WARNING - statusBarItem.button is nil")
+    }
+
+    // React to EU Privacy Mode toggle changes from Settings — without this the
+    // shield indicator only refreshes on app focus events.
+    NotificationCenter.default.addObserver(
+      forName: UserDefaults.didChangeNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in self?.applyMenuBarPrivacyShield() }
     }
 
     // Create menu

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -106,6 +106,12 @@ struct OMIApp: App {
     return Window(windowTitle, id: "main") {
       DesktopHomeView()
         .withFontScaling()
+        .safeAreaInset(edge: .top, spacing: 0) {
+          // Renders the EU-Privacy-Mode fallback banner when the backend
+          // signals X-Privacy-Mode-Fallback. Empty when no event is active —
+          // the View body returns no content for nil currentEvent.
+          PrivacyModeFallbackBanner()
+        }
         .onAppear {
           log("OmiApp: Main window content appeared (mode: \(Self.launchMode.rawValue))")
         }

--- a/desktop/Desktop/Sources/PrivacyModeFallbackObserver.swift
+++ b/desktop/Desktop/Sources/PrivacyModeFallbackObserver.swift
@@ -1,0 +1,119 @@
+import Foundation
+import SwiftUI
+
+/// Observable that surfaces "this request left the EU" events to the UI when
+/// the user has EU Privacy Mode enabled but a specific request had to fall
+/// back (vision unsupported, regolo outage, 429s exhausted, no regolo key).
+///
+/// Backend contract: when the user sent ``X-Privacy-Mode: on`` but the
+/// request could not actually be served by regolo.ai, the response carries
+/// ``X-Privacy-Mode-Fallback: <reason>``. APIClient extracts it and calls
+/// ``record(reason:)`` here; the banner view observes the published state.
+@MainActor
+final class PrivacyModeFallbackObserver: ObservableObject {
+  static let shared = PrivacyModeFallbackObserver()
+
+  /// How long a fallback banner stays visible after the last event.
+  private static let autoDismissAfter: TimeInterval = 6
+
+  struct Event: Equatable {
+    let reason: Reason
+    let seenAt: Date
+  }
+
+  /// Backend-defined reason tokens — kept in sync with the PRIVACY_FALLBACK_*
+  /// constants in backend/utils/byok.py. Unknown reasons surface as ``.other``
+  /// so the banner can still show a generic message instead of dropping the
+  /// event silently.
+  enum Reason: String, CaseIterable {
+    case visionUnsupported = "vision_unsupported"
+    case regoloOutage = "regolo_outage"
+    case regoloRateLimited = "regolo_rate_limited"
+    case noRegoloKey = "no_regolo_key"
+    case other = ""
+
+    init(rawValueOrOther raw: String) {
+      self = Reason(rawValue: raw) ?? .other
+    }
+
+    /// One-line banner copy. Deliberately terse — the banner is transient.
+    var displayMessage: String {
+      switch self {
+      case .visionUnsupported:
+        return "Vision isn't available on regolo.ai — this screenshot was processed by Gemini."
+      case .regoloOutage:
+        return "Regolo.ai is unreachable — falling back to your regular LLM provider."
+      case .regoloRateLimited:
+        return "Regolo.ai rate limit hit — falling back to your regular LLM provider."
+      case .noRegoloKey:
+        return "EU Privacy Mode is on but no Regolo key is configured. Add one in Settings."
+      case .other:
+        return "This request left the EU."
+      }
+    }
+  }
+
+  @Published private(set) var currentEvent: Event?
+
+  private var dismissTask: Task<Void, Never>?
+
+  private init() {}
+
+  /// Call from APIClient when the backend sends X-Privacy-Mode-Fallback.
+  /// Nothing happens if the user has Privacy Mode disabled — nothing to warn
+  /// about in that case.
+  func record(rawReason: String) {
+    guard APIKeyService.isEUPrivacyModeEnabled else { return }
+    let reason = Reason(rawValueOrOther: rawReason)
+    currentEvent = Event(reason: reason, seenAt: Date())
+    scheduleAutoDismiss()
+  }
+
+  /// User-initiated dismissal (tap the banner).
+  func dismiss() {
+    dismissTask?.cancel()
+    currentEvent = nil
+  }
+
+  private func scheduleAutoDismiss() {
+    dismissTask?.cancel()
+    dismissTask = Task { [weak self] in
+      try? await Task.sleep(nanoseconds: UInt64(Self.autoDismissAfter * 1_000_000_000))
+      guard !Task.isCancelled else { return }
+      await MainActor.run { self?.currentEvent = nil }
+    }
+  }
+}
+
+/// Small red banner shown at the top of the main window when a fallback
+/// event is active. Host views embed it with ``.safeAreaInset(edge: .top)``
+/// or overlay at the top.
+struct PrivacyModeFallbackBanner: View {
+  @ObservedObject private var observer = PrivacyModeFallbackObserver.shared
+
+  var body: some View {
+    if let event = observer.currentEvent {
+      HStack(spacing: 10) {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .foregroundColor(.white)
+
+        Text(event.reason.displayMessage)
+          .font(.system(size: 12, weight: .medium))
+          .foregroundColor(.white)
+          .fixedSize(horizontal: false, vertical: true)
+
+        Spacer(minLength: 8)
+
+        Button(action: { observer.dismiss() }) {
+          Image(systemName: "xmark")
+            .foregroundColor(.white.opacity(0.85))
+        }
+        .buttonStyle(.plain)
+      }
+      .padding(.horizontal, 14)
+      .padding(.vertical, 8)
+      .background(Color.red.opacity(0.85))
+      .transition(.move(edge: .top).combined(with: .opacity))
+    }
+  }
+}

--- a/desktop/Desktop/Sources/PrivacyModeFallbackObserver.swift
+++ b/desktop/Desktop/Sources/PrivacyModeFallbackObserver.swift
@@ -55,9 +55,20 @@ final class PrivacyModeFallbackObserver: ObservableObject {
 
   @Published private(set) var currentEvent: Event?
 
+  /// Rolling 7-day count of fallback events, surfaced in Settings as
+  /// "N requests fell back this week". Persisted across app restarts via
+  /// UserDefaults; auto-resets when the 7-day window rolls over.
+  @Published private(set) var weeklyFallbackCount: Int = 0
+
+  private static let weeklyCountKey = "eu_privacy_fallback_count_week"
+  private static let weeklyCountResetAtKey = "eu_privacy_fallback_count_week_reset_at"
+  private static let weekSeconds: TimeInterval = 7 * 24 * 60 * 60
+
   private var dismissTask: Task<Void, Never>?
 
-  private init() {}
+  private init() {
+    weeklyFallbackCount = Self.loadCounterRollingOverIfStale()
+  }
 
   /// Call from APIClient when the backend sends X-Privacy-Mode-Fallback.
   /// Nothing happens if the user has Privacy Mode disabled — nothing to warn
@@ -66,7 +77,31 @@ final class PrivacyModeFallbackObserver: ObservableObject {
     guard APIKeyService.isEUPrivacyModeEnabled else { return }
     let reason = Reason(rawValueOrOther: rawReason)
     currentEvent = Event(reason: reason, seenAt: Date())
+    weeklyFallbackCount = Self.bumpCounter()
     scheduleAutoDismiss()
+  }
+
+  // MARK: - Weekly counter persistence
+
+  /// Read the persisted weekly counter, resetting if the 7-day window expired.
+  private static func loadCounterRollingOverIfStale() -> Int {
+    let defaults = UserDefaults.standard
+    let resetAt = defaults.double(forKey: weeklyCountResetAtKey)
+    let now = Date().timeIntervalSince1970
+    if resetAt == 0 || now - resetAt >= weekSeconds {
+      defaults.set(0, forKey: weeklyCountKey)
+      defaults.set(now, forKey: weeklyCountResetAtKey)
+      return 0
+    }
+    return defaults.integer(forKey: weeklyCountKey)
+  }
+
+  /// Increment the weekly counter, rolling over the window first if stale.
+  private static func bumpCounter() -> Int {
+    let defaults = UserDefaults.standard
+    let next = loadCounterRollingOverIfStale() + 1
+    defaults.set(next, forKey: weeklyCountKey)
+    return next
   }
 
   /// User-initiated dismissal (tap the banner).

--- a/desktop/docs/M0-deliver-report.md
+++ b/desktop/docs/M0-deliver-report.md
@@ -1,0 +1,87 @@
+# M0 Deliver Report — Regolo.ai Integration
+
+**Milestone:** M0 — Pre-flight probes + design-doc corrections.
+**Branch:** `worktree-omi-regolo-integration`.
+**Status:** ✅ Ready to merge into `main` after PR review.
+**Scope:** docs only — no code changes, no test runs.
+
+## Scope shipped
+
+| Commit | File | Change | Verdict |
+|---|---|---|---|
+| `1f9c1f836` | `desktop/docs/regolo-probes.md` (NEW) | +165 LOC | Single source of truth for empirical Regolo probe data (P1–P11). |
+| `3695fa713` | `desktop/docs/REGOLO_INTEGRATION.md` | +22/-18 LOC | Corrects model count, chat default, thinking-knob scope, vision status, Open Questions table. |
+| `052124702` | both above | +17/-15 LOC | Code-review fixes (see "Validation findings" below). |
+
+Total: **~150 net LOC** of design-doc corrections; **0 LOC** of executable code.
+
+## Evidence links
+
+- **Empirical multi-sample latency probe** (n=5 per model, structured-extraction prompt) → `regolo-probes.md` § P6.
+- **Streaming tool-call delta fixture** → captured in sister Euraika repo at `/opt/projects/omi-regolo-integration/backend/tests/fixtures/regolo_tool_call_stream.json` (5 chunks, `Llama-3.3-70B-Instruct`, `get_weather` tool). M1 task: port into this branch's `backend/tests/fixtures/`.
+- **Sister-repo model→feature mapping** → `/opt/projects/omi-regolo-integration/docs/04-model-mapping.md` (full table of Omi feature names → Regolo model picks, justified by the latency × consistency data).
+- **This branch's existing implementation** → `backend/utils/llm/clients.py` lines 151–160 (Regolo constants) + 506 (`_get_or_create_regolo_llm`) + `_RegoloOpenAIProxy` class.
+
+## What changed in the design
+
+Six material corrections to the prior spec:
+
+1. **Model count**: 19 → 20 on PAYG (`/v1/models` returned 20 distinct models).
+2. **Default chat model**: `minimax-m2.5` → `mistral-small-4-119b`. P6 found MiniMax timed out on **3 of 5** calls at the 60s budget (p50 59.83s among working calls). Mistral-Small-4-119B clocked p50 0.43s / p90 0.44s with ±2% spread — 2× faster than Llama-3.3-70B and 6× more consistent than `qwen3.5-122b`.
+3. **`enable_thinking:false` knob is per-model**: applies only to the Qwen3.5-9b/122b, Qwen3.6-27b, MiniMax-m2.5 set. No-op on Llama / Mistral / gpt-oss / gemma / apertus. The blanket "all non-reasoning calls inject" wording in F5 was empirically wrong.
+4. **`reasoning_content` leak is MiniMax-only**: previously the spec implied multiple models leaked reasoning content. Probes show only `minimax-m2.5` does. The `strip_reasoning_content()` helper is mandatory before persistence for that one model.
+5. **Vision is HARD-BLOCKED**: `qwen3-vl-32b` is not in PAYG `/v1/models`. Phase 1 falls back to Gemini with the red `X-Privacy-Mode-Fallback` banner. Was previously listed as "uncertain."
+6. **Streaming tool-call shape is OpenAI-standard**: previous Open Question #9 ("first Phase 1 dev task is a live probe of regolo's streaming delta shape") is resolved by the captured fixture. `langchain_openai.ChatOpenAI` accumulates deltas natively — no custom accumulator needed in `_RegoloOpenAIProxy`.
+
+## What was consciously deferred (and why)
+
+| Probe | Why deferred | When to do |
+|---|---|---|
+| P9 — `response_format:{type:"json_object"}` strict-mode enforcement | Phase 1 path uses prompt-engineered JSON output validated by the existing JSON-repair flow. Strict mode is unnecessary unless a future feature needs it. | Re-probe the day a feature *requires* strict-JSON guarantees. |
+| P10 — Top-level `thinking:true` opt-in on `gpt-oss-120b` | Phase 1 *disables* thinking for the Qwen+MiniMax set. Opting INTO thinking is a different feature we don't use. | Re-probe if a feature wants `gpt-oss-120b` reasoning. |
+| P11 — Rate-limit headers / `Retry-After` semantics | No 429 was triggered during probing; instrumenting `_RegoloOpenAIProxy` with retry counters in M1 will surface real data. | M1 telemetry → revisit plan tier in M5 with usage data. |
+
+## Validation findings
+
+Verification ran 7 checks + a parallel code-review agent.
+
+**Automated checks (all passed):**
+- ✅ No API-key-shaped tokens in either committed file or any commit message.
+- ✅ All committed cross-references resolve: `EMBEDDING_MIGRATION.md`, sister-repo fixtures, this branch's `_RegoloOpenAIProxy`.
+- ✅ Markdown table integrity: 13 tables, 0 ragged rows.
+- ✅ No `/v1/responses` references (M0 cleanup goal).
+
+**Code-review findings (all addressed in commit `052124702`):**
+
+| # | Confidence | Issue | Fix |
+|---|---|---|---|
+| 1 | 100% | Acceptance Criterion #2 still asserted `model=minimax-m2.5` despite the dispatcher table changing to `mistral-small-4-119b`. A QA engineer following the unfixed criterion would have failed correct code. | Updated criterion #2 + #3 to reference `mistral-small-4-119b`. |
+| 2 | 90% | `EMBEDDING_MIGRATION.md` cross-reference reported as dangling (reviewer false positive — file does exist in this worktree at `desktop/docs/EMBEDDING_MIGRATION.md`). | Verified existing; no fix needed. |
+| 3 | 85% | Bare `backend/tests/fixtures/regolo_*` paths implied the fixture lived in this branch. It only lives in the sister Euraika repo. | All three references qualified as sister-repo with explicit "/opt/projects/omi-regolo-integration/" path + "M1 port" note. |
+| 4 | 100% (self-found) | Doc referenced `_REGOLO_THINKING_MODELS` constant. This branch carries `REGOLO_DISABLE_THINKING_EXTRA_BODY` (dict, line 160) — the frozenset gating lives in the sister repo and is a planned M1 port. | F5 + Q5 + probes-doc rephrased to describe actual current code state with M1 refinement noted. |
+
+## Ready-to-merge status
+
+**✅ Approved for PR to `main` from this branch** with the following scope:
+
+- 4 commits ahead of `main` for the M0 work (+ existing 12 commits of Phase-1 backend/desktop scaffolding).
+- Docs-only delta: 3 files touched (`regolo-probes.md` new, `REGOLO_INTEGRATION.md` patched, `M0-deliver-report.md` new).
+- Zero code changes. Zero test runs needed. Existing Phase-1 backend/desktop commits on this branch already passed their own CI when they landed — no regressions introduced by the doc-only commits.
+- No secrets, no PII, no leaked customer data.
+
+**Caveat:** the third fix-up commit (`052124702`) batches edits to both doc files because they share a single root cause (review feedback). Splitting per-file would yield artificial "part 1 / part 2" history.
+
+## Roadmap going forward
+
+Per the Define-phase milestone plan (8.5 days total, ~5–6 calendar days with two engineers in parallel after M1):
+
+| Milestone | Scope | Days | Critical path? |
+|---|---|---|---|
+| **M0** ✅ | Probes + doc corrections | 0.5 | done |
+| **M1** | Backend Phase-1 merge + streaming-tool-call accumulator + reasoning-strip + error mapping + telemetry tagging. Port `_REGOLO_THINKING_MODELS` set + `strip_reasoning_content()` helper from sister repo. Port the streaming fixture for CI replay. | 1.5 | yes — blocks M2/M3/M4 |
+| **M2** | Backend embeddings (`Qwen3-Embedding-8B`, 4096-dim) + vector-store `(provider, model, dim)` keying audit. Hard-block `memory_search`/`knowledge_graph_search`/`screen_activity_search` until done. | 1.0 | parallel with M3 |
+| **M3** | Desktop: wire `PrivacyModeFallbackBanner` into `MainWindow` via `safeAreaInset`, add Regolo BYOK key entry row in Settings, populate `ModelQoS.swift` with Regolo model IDs, status-bar shield, fallback counter, EU-locale first-run prompt. | 1.5 | parallel with M2/M4 |
+| **M4** | Web frontend: stop calling OpenAI from browser, build `/settings` route, Firestore preference schema, header forwarder for `X-BYOK-Regolo`+`X-Privacy-Mode`, sonner toast for fallback signal, navbar privacy shield. | 3.0 | parallel with M3 |
+| **M5** | Sign Regolo DPA. Full regression suite + E2E smoke matrix on a single SHA. Telemetry dashboards. Staged rollout. | 1.0 | terminal |
+
+**Next concrete action:** run `/octo:develop` for M1 against this branch (backend Phase-1 hardening).

--- a/desktop/docs/M4-decisions.md
+++ b/desktop/docs/M4-decisions.md
@@ -1,0 +1,100 @@
+# M4 — Decision Record
+
+Decisions that unblock the 5-phase M4 plan. Each entry includes alternatives considered and the rationale, so a future engineer can revisit if context changes.
+
+## Decision 1 — BYOK key encryption-at-rest
+
+**Decision:** App-side AES-GCM encryption with a per-user key derived from a single `BYOK_MASTER_PEPPER` env-var via HKDF-SHA256 keyed by user UID.
+
+**Date:** 2026-04-27.
+
+**Status:** Decided. Unblocks M4.1.
+
+### Alternatives considered
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **A. GCP Cloud KMS** | Audit logs, rotation, IAM-controlled access, FIPS 140-2 alignment | ~30ms latency per read/write, $0.06/key/month + per-operation cost, requires service account setup, every Firestore read needs a separate KMS API call | Reject — overkill for v1 BYOK; cost scales linearly with active users |
+| **B. Env-var pepper + HKDF-derived per-user key** *(chosen)* | Zero infrastructure, ~0ms latency, pepper-rotation possible (re-encrypt all keys via batch job), protects against DB-only compromise | Anyone with prod env access can decrypt; pepper must be backed up safely | Accept |
+| **C. User-supplied passphrase (zero-knowledge)** | Server can't decrypt without user input | Passphrase loss = permanent BYOK loss (no recovery), poor UX (user re-enters every session), cross-device sync complexity | Reject — bad UX-vs-privacy ratio for an opt-in convenience feature |
+| **D. Plaintext in Firestore** | Simplest | Any DB dump exposes all BYOK keys at once | Reject — too risky for keys that grant API spend access |
+
+### Rationale for Option B
+
+Threat model alignment: BYOK is an opt-in convenience for power users who already trust Omi enough to install the desktop client (which stores the key in macOS Keychain — also a single-secret-protects-all model). The web BYOK store should match the same threat tier, not exceed it.
+
+Cost: $0 vs ~$10/month per 100 users for Cloud KMS at the projected access pattern. The KMS savings are not material at our scale, but the latency win is — KMS adds ~30ms to every chat completion that needs to read the BYOK header.
+
+Security wins: Option B protects against a Firestore-only data leak (the most plausible compromise vector — leaked service account, misconfigured rule). It does NOT protect against an attacker who has both the Firestore data AND the production environment, but that compromise scenario is already game-over for many other Omi secrets (Firebase admin SDK key, OpenAI org key, etc.) — adding KMS for BYOK alone would not raise the floor materially.
+
+### Implementation outline (M4.1 reference)
+
+Single file `web/frontend/src/lib/firestore/encryption.ts` (NEW), ~50 LOC:
+
+```typescript
+import { hkdf } from '@panva/hkdf'  // or webcrypto subtle if available
+const MASTER = process.env.BYOK_MASTER_PEPPER  // 32+ random bytes, base64
+
+async function deriveUserKey(uid: string): Promise<CryptoKey> {
+  const salt = new TextEncoder().encode(uid)
+  const ikm = base64Decode(MASTER)
+  const okm = await hkdf('sha256', ikm, salt, 'omi-byok-v1', 32)
+  return crypto.subtle.importKey('raw', okm, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt'])
+}
+
+export async function encryptBYOK(uid: string, plaintext: string): Promise<{ ciphertext: string, iv: string }> {
+  const key = await deriveUserKey(uid)
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(plaintext))
+  return { ciphertext: base64(ct), iv: base64(iv) }
+}
+
+export async function decryptBYOK(uid: string, ciphertext: string, iv: string): Promise<string> { /* mirror */ }
+```
+
+Firestore schema (M4.1):
+
+```
+users/{uid}/settings: {
+  eu_privacy_mode: bool,
+  byok_keys: {
+    openai:    { ciphertext: string, iv: string, hash: string } | null,
+    anthropic: ...,
+    gemini:    ...,
+    deepgram:  ...,
+    regolo:    ...,
+  }
+}
+```
+
+Where `hash` is the SHA-256 fingerprint of the plaintext key — used for `_check_byok_validity` server-side comparisons (matches existing backend BYOK fingerprint pattern at `backend/utils/byok.py:141`) without ever needing to decrypt.
+
+### Operational requirements
+
+- **`BYOK_MASTER_PEPPER` must be backed up safely** (Vault, 1Password Teams, or sealed-secret in the deploy repo). Loss of the pepper = loss of all encrypted BYOK keys.
+- **Pepper rotation**: write a one-shot script that decrypts every user's BYOK keys with the old pepper and re-encrypts with the new. Run once when rotating. Log the count, no key material.
+- **Pepper must be 32+ bytes of cryptographic randomness** (`openssl rand -base64 32`).
+- **Pepper must NOT be `NEXT_PUBLIC_*`** — server-side only.
+
+### Decision authority
+
+Owner: web frontend lead (or whoever drives M4.1).
+Reviewers: security + infra.
+
+This record is editable until M4.1 ships. After M4.1 lands, changes to the encryption mechanism become a migration project (re-encrypt all stored ciphertexts).
+
+## Decision 2 — Backend `/v1/chat` contract for M4.3
+
+**Decision:** Reuse the existing endpoint omi backend exposes for desktop chat. The web frontend matches the desktop's request shape (Authorization Bearer + X-BYOK-* + X-Privacy-Mode headers; body is omi's internal chat shape).
+
+**Status:** Confirmed by inspection of desktop's `APIClient.swift` BYOK header forwarding logic. M4.3 doesn't need a new endpoint.
+
+## Decision 3 — `/v1/byok/validate` for M4.2 test-connection
+
+**Decision:** Reuse desktop's `BYOKValidator` HTTP target. The desktop pings provider-specific URLs directly (e.g. regolo at `https://api.regolo.ai/v1/models`). The web frontend should follow the same pattern via a Next.js Server Action that proxies the validation call — never expose BYOK keys to the browser bundle.
+
+**Status:** Decided. Implementation defers to M4.2.
+
+## Open decisions (unresolved as of this writing)
+
+- **Sister-repo distribution strategy for web frontend changes.** The Euraika `omi-regolo-integration` patch package mirrors only `backend/` and `desktop/`; web frontend patches have no canonical distribution channel today. Options: (a) extend sister repo with `web/frontend/` patch tree, (b) keep web changes monorepo-only and contribute upstream via a fork PR. Defer until M4.1 lands and the question becomes concrete.

--- a/desktop/docs/M4-revised-scope.md
+++ b/desktop/docs/M4-revised-scope.md
@@ -1,0 +1,78 @@
+# M4 Revised Scope — Discovery from M4.3 Spike
+
+**Date:** 2026-04-27 (loop iteration 2).
+**Trigger:** Attempting M4.3 (refactor `chat-with-memory.ts` to backend-route) revealed the original scope was wrong.
+
+## What was discovered
+
+`web/frontend/src/actions/memories/chat-with-memory.ts` is a **Server Action serving anonymous public viewers** of shared memory pages. URL pattern: `/chat/[token]` and `/memories/[id]/...`. The `token` in the URL is the access credential — **not** a Firebase ID token.
+
+This means:
+
+1. **No `uid`** at the call site. Anonymous viewers don't have a Firestore `users/{uid}/settings/profile` document.
+2. **No Privacy Mode preference** to read or apply. Privacy Mode is a per-account toggle; anonymous viewers have no account.
+3. **No BYOK keys** to forward. Same reason.
+4. **OpenAI is the correct provider** for this surface — the memory's owner already authorized public access by sharing the link, so routing the chat through OpenAI is consistent with the access model.
+
+## Therefore: M4.3 does NOT apply
+
+The original M4 plan listed M4.3 as "refactor chat-with-memory.ts to backend-route" with the assumption that this would unblock the EU Privacy promise on the web frontend. **That assumption was wrong.** The web frontend has zero authenticated-user AI surfaces today; chat-with-memory is the only AI feature, and it's structurally anonymous.
+
+Refactoring chat-with-memory to require Firebase Auth + Privacy Mode lookup would be a regression — it would break public memory viewing for users who haven't signed in.
+
+## What this means for the rest of M4
+
+| Sub-phase | Original scope | Revised verdict |
+|---|---|---|
+| M4.1 | Firestore prefs + encryption | ✅ Shipped — generally useful for any future authenticated-user feature |
+| M4.2 | `/settings` route + 5-row API key manager | ⚠️ Premature — **no authenticated-user AI feature exists yet** to consume the keys. Settings UI without a downstream consumer is configuration without effect. Defer until an authenticated-user AI feature is planned. |
+| M4.3 | Chat-with-memory backend refactor | ❌ Does not apply — anonymous surface, OpenAI is correct |
+| M4.4 | Header forwarder | ✅ Shipped — utility ready for the day an authenticated-user AI surface exists |
+| M4.5 | Sonner toast + privacy hook | ✅ Shipped — generally useful |
+
+## What ACTUALLY ships from M4 in this branch
+
+| Deliverable | LOC | Tests | Status |
+|---|---|---|---|
+| `BYOK_MASTER_PEPPER` env-var registration | +5 | — | shipped |
+| Firestore handle alongside Auth | +6 | — | shipped |
+| `lib/firestore/encryption.ts` | +130 | 7 | shipped |
+| `lib/firestore/user-settings.ts` | +120 | (covered indirectly) | shipped |
+| `lib/api/regolo-forwarder.ts` | +110 | 8 | shipped |
+| `app/layout.tsx` Toaster mount | +4 | — | shipped |
+| `hooks/usePrivacyFallbackToast.ts` | +75 | 3 | shipped |
+| sonner dependency | +1 dep | — | shipped |
+| **Total** | **~451 LOC web** + 1 dep | **18 unit tests, all green** | **complete** |
+
+## Updated remaining work for the GA roadmap
+
+After this iteration, the entire UNBLOCKED M4 work is done. Remaining roadmap is human/infra-gated:
+
+| Item | Blocker | Owner |
+|---|---|---|
+| M2.5 — backend embedding migration (4096-dim Pinecone index + write-path privacy gate) | Infra provisioning + cost approval | Infra + finance |
+| M3 — desktop polish Mac build verification | Linux WSL2 host can't build Swift | Mac access needed |
+| M5 — DPA + GA rollout | Regolo legal turnaround | Legal |
+| **NEW**: First authenticated-user AI feature on the web frontend | Product decision (no such feature designed yet) | Product |
+
+## Why I stopped the autonomous loop here
+
+The /loop /octo:embrace was meant to "advance the roadmap until finished." Iteration 1 shipped M4.1 + M4.5. Iteration 2 shipped M4.4 + this discovery doc. Every other M-series item now requires:
+
+- A human decision (product, legal, infra)
+- A capability this Linux WSL2 host doesn't have (macOS Swift toolchain)
+- A non-existent feature surface (authenticated-user AI on web)
+
+Continuing the loop without a human-in-the-loop would either:
+- Spin against blockers (waste tokens)
+- Build speculative work that may not match what stakeholders want (negative value)
+
+**The honest end-state:** all unblocked roadmap work is complete; the loop self-stops here.
+
+## Sign-off checklist
+
+- [ ] PR #7056 carries M3 desktop + M4.1/M4.4/M4.5 web. Convert from Draft → Ready-for-Review after a Mac build verifies the desktop changes.
+- [ ] Resolve the M2 audit P1 question (privacy-write gap) — pick (a) ship M2.5 fast, (b) update Settings copy to disclose, or (c) HARD_BLOCK conversation embedding.
+- [ ] Product: design or rule out the first authenticated-user AI feature on the web frontend. Without it, the M4 settings-UI never ships.
+- [ ] Legal: open the Regolo DPA conversation.
+- [ ] Infra: cost+capacity approval for second 4096-dim Pinecone index in staging.

--- a/desktop/docs/M4-web-frontend-audit.md
+++ b/desktop/docs/M4-web-frontend-audit.md
@@ -1,0 +1,132 @@
+# M4 Web Frontend Audit — Regolo Integration
+
+**Branch:** `worktree-omi-regolo-integration` (omi monorepo, alongside the M3 desktop work).
+**Decision:** Audit-only pass. M4 is the largest M-series lift (~700 LOC + a new dependency + Firestore schema). Sequencing matters more than speed; this doc plans the order before any code lands.
+
+## Current state — confirmed by file-level inspection
+
+`web/frontend/` is a Next.js (App Router) application with shadcn/ui + Radix primitives + Tailwind. Stack pieces relevant to M4:
+
+| Stack piece | Status | M4 impact |
+|---|---|---|
+| Next.js App Router | ✅ in use (`src/app/`) | host for `/settings` route |
+| shadcn/ui CLI configured | ✅ `components.json` present | scaffold new components via CLI |
+| UI primitives | ✅ `accordion`, `button`, `card`, `dialog`, `drawer`, `input`, `label`, `progress`, `scroll-area` | enough to build a Settings page |
+| Firebase SDK v11 | ✅ `firebase: ^11.8.1` in deps | Firestore reads/writes for user prefs |
+| Tailwind | ✅ `tailwind.config.ts` | layout + theme |
+| Toast / notification lib | ❌ **NOT installed** — no `sonner`, no `react-hot-toast`, no `@radix-ui/react-toast` | M4.5 must add `sonner` (~5KB, Tailwind-friendly) |
+| Settings route | ❌ **does not exist** under `src/app/` | M4.2 creates from scratch |
+| API-key management UI | ❌ does not exist anywhere | M4.2 ships it |
+
+## AI-related code paths — exhaustive list
+
+Two `api.openai.com` call sites, both in one Server Action:
+
+| File | Line | Mode | Purpose |
+|---|---|---|---|
+| `src/actions/memories/chat-with-memory.ts` | 89 | `'use server'` Server Action | Initial chat completion |
+| `src/actions/memories/chat-with-memory.ts` | 129 | same Server Action | Retry / continuation path |
+
+**Important nuance correction.** Earlier discovery framing called this "OpenAI from the browser." That was imprecise. The file's first line is `'use server';` — this is a Next.js Server Action, executed on the Next.js server, NOT in the browser. The `OPENAI_API_KEY` (`envConfig.OPENAI_API_KEY` at line 19) is server-side env state and never reaches the browser bundle.
+
+The actual M4 concern is therefore **routing**, not **secret exposure**:
+- Today: chat-with-memory hits `api.openai.com` directly from the Next.js server, bypassing any backend that could enforce EU Privacy Mode.
+- After M4: chat-with-memory must route through omi's backend (which then applies the M1 dispatcher logic — Regolo when Privacy Mode is on, else OpenAI).
+
+## What's missing — exhaustive M4 gap list
+
+| Capability | File / location | Status | Sub-phase |
+|---|---|---|---|
+| Settings route | `src/app/settings/page.tsx` (NEW) | missing | 4.2 |
+| API-key manager UI (5 providers) | inside settings page | missing | 4.2 |
+| Privacy Mode toggle | inside settings page | missing | 4.2 |
+| Server-side user preferences | `src/lib/firestore/user-settings.ts` (NEW) | missing | 4.3 |
+| Firestore schema `users/{uid}/settings` | Firestore | missing | 4.3 |
+| Backend-routed chat client | refactor `chat-with-memory.ts` to call omi backend | partial | 4.1 |
+| `X-BYOK-*` + `X-Privacy-Mode` header forwarder | `src/lib/api/regolo-forwarder.ts` (NEW) | missing | 4.4 |
+| Sonner toast surface | install `sonner` + add `<Toaster />` to root layout | missing | 4.5 |
+| `usePrivacyFallbackToast()` hook | `src/hooks/usePrivacyFallbackToast.ts` (NEW) | missing | 4.5 |
+| Navbar shield indicator | edit existing nav component | missing | 4.5 |
+
+## Recommended sub-phase order
+
+The Define plan listed phases 4a–4e; I recommend a slight resequencing based on what enables what.
+
+### M4.1 — Server-side preference store (½ day, ~80 LOC)
+
+Why first: every other phase needs to read or write user prefs. Land the schema + the read/write helper, even if no UI consumes it yet.
+
+Files:
+- `src/lib/firestore/user-settings.ts` (NEW) — `getUserSettings(uid)`, `updateUserSettings(uid, partial)`. Schema: `{ eu_privacy_mode: bool, byok_keys: { openai, anthropic, gemini, deepgram, regolo: { encrypted: string, hash: string } } }`.
+- `src/lib/firestore/encryption.ts` (NEW) — symmetric encryption for BYOK keys at rest using a KMS-derived key (or `NEXT_PUBLIC_*` is **NOT** acceptable here — keys must encrypt server-side only).
+
+Risk: this leaks beyond M4 scope into KMS/key-encryption territory. Coordinate with infra on whether to use Firebase KMS, GCP KMS, or a raw env-var pepper. Decision needed before code lands.
+
+### M4.2 — `/settings` route + API-key manager UI (1.5 days, ~350 LOC)
+
+Files:
+- `src/app/settings/page.tsx` (NEW) — server component that reads prefs via M4.1 helper.
+- `src/app/settings/sections/api-keys.tsx` (NEW) — 5 rows (OpenAI, Anthropic, Gemini, Deepgram, Regolo), each with masked SecureInput, Save action, Test connection button. Mirrors desktop's `developerKeyField` pattern.
+- `src/app/settings/sections/privacy.tsx` (NEW) — EU Privacy Mode toggle, copy mirroring desktop. First-run intro card optional.
+- `src/app/settings/actions.ts` (NEW) — Server Actions for save/test-connection.
+
+Test-connection target: backend endpoint `POST /v1/byok/validate` (which already exists per BYOKValidator behavior — desktop hits the same endpoint).
+
+### M4.3 — Backend-routed chat (½ day, ~50 LOC refactor)
+
+Replace direct `api.openai.com` fetch in `chat-with-memory.ts` with a call to omi backend `/v1/chat`. Backend's M1 dispatcher then applies Privacy Mode routing.
+
+This unblocks the entire M4 privacy story: after this lands, web chat is no longer architecturally bypassing Regolo even if the user has Privacy Mode on.
+
+### M4.4 — Header forwarder helper (½ day, ~70 LOC)
+
+`src/lib/api/regolo-forwarder.ts` (NEW). Reads user prefs server-side via M4.1, attaches:
+- `Authorization: Bearer <firebase-id-token>`
+- `X-BYOK-OpenAI`, `X-BYOK-Anthropic`, etc., for whichever providers the user configured (one per provider; M1 backend already handles per-header BYOK)
+- `X-Privacy-Mode: on` when toggle is on
+
+Used by M4.3's chat refactor and any other future backend-routed call.
+
+### M4.5 — Toast + privacy indicator (½ day, ~100 LOC + 1 dep)
+
+- `npm install sonner` — ~5KB, Tailwind-friendly.
+- Add `<Toaster />` to `src/app/layout.tsx` root.
+- `src/hooks/usePrivacyFallbackToast.ts` (NEW) — reads `X-Privacy-Mode-Fallback` response header from API client wrapper, fires a red toast with the matching reason (mirrors desktop's `PrivacyModeFallbackObserver` 5-reason enum).
+- Navbar component edit: shield icon when Privacy Mode is on. Find where the existing nav lives (likely `src/app/components/` or `src/components/`).
+
+## Dependencies that need a decision before code
+
+| Question | Owner | Decide by |
+|---|---|---|
+| BYOK key encryption-at-rest mechanism (Firebase KMS / GCP KMS / env-var pepper) | Infra + Web | M4.1 start |
+| Backend `/v1/chat` endpoint contract — does it accept the same body shape as `chat-with-memory.ts` currently sends to OpenAI, or does it want omi's internal format? | Backend | M4.3 start |
+| Whether `/v1/byok/validate` exists today; if not, what desktop's BYOKValidator hits today | Backend | M4.2 start |
+| Whether the navbar component is a server or client component (affects how the shield reactively updates) | Web | M4.5 start |
+
+## Estimated total — ~700 LOC + sonner dep + Firestore schema + 1 KMS decision
+
+Calendar: 3 days for one full-stack engineer, or 2 days with one Web + one Backend in parallel after M4.1 lands.
+
+## Decision: ship audit doc, no code
+
+Same rationale as M2 audit: the natural first patch (M4.1 Firestore preferences) requires a KMS decision that isn't in scope for this session. Better to ship the audit + sequencing plan and let an actual M4.1 develop pass kick off after the encryption-at-rest decision is made.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `desktop/docs/M4-web-frontend-audit.md` | NEW (this doc) |
+
+No code changes. No test changes. The audit + sub-phase plan is the deliverable.
+
+## Sister-repo applicability
+
+Unlike the M0/M1/M2 docs which the user pushed to the Euraika sister GitLab repo, this audit is entirely about the omi monorepo's `web/frontend/`. The sister repo doesn't currently mirror `web/frontend/` files — when M4.1 starts shipping code, the patch-package strategy needs a decision: extend sister repo with a `web/frontend/` patch tree, or keep web changes monorepo-only and use a different distribution mechanism.
+
+## Cross-references
+
+- M0 spec corrections: `desktop/docs/REGOLO_INTEGRATION.md`
+- M0 probe results: `desktop/docs/regolo-probes.md`
+- M1 deliver report: `desktop/docs/M1-deliver-report.md` (sister repo only — not in this monorepo branch)
+- M2 embedding audit: sister repo `desktop/docs/M2-embedding-audit.md`
+- M3 desktop polish: 6 commits on this branch (`947fa97a0`, `c15ebe8f4`, `47fd11a0c`, `6bdff2914`, `47811d004`, `ee7803e2a`)

--- a/desktop/docs/M4-web-frontend-audit.md
+++ b/desktop/docs/M4-web-frontend-audit.md
@@ -96,20 +96,20 @@ Used by M4.3's chat refactor and any other future backend-routed call.
 
 ## Dependencies that need a decision before code
 
-| Question | Owner | Decide by |
+| Question | Owner | Status |
 |---|---|---|
-| BYOK key encryption-at-rest mechanism (Firebase KMS / GCP KMS / env-var pepper) | Infra + Web | M4.1 start |
-| Backend `/v1/chat` endpoint contract — does it accept the same body shape as `chat-with-memory.ts` currently sends to OpenAI, or does it want omi's internal format? | Backend | M4.3 start |
-| Whether `/v1/byok/validate` exists today; if not, what desktop's BYOKValidator hits today | Backend | M4.2 start |
-| Whether the navbar component is a server or client component (affects how the shield reactively updates) | Web | M4.5 start |
+| BYOK key encryption-at-rest mechanism | Infra + Web | ✅ **Resolved** — env-var pepper + HKDF-derived per-user key. See `M4-decisions.md` § Decision 1. |
+| Backend `/v1/chat` endpoint contract | Backend | ✅ **Resolved** — reuse desktop's existing endpoint + headers. See `M4-decisions.md` § Decision 2. |
+| Whether `/v1/byok/validate` exists today; if not, what desktop's BYOKValidator hits today | Backend | ✅ **Resolved** — desktop pings provider URLs directly; web mirrors via Server Action. See `M4-decisions.md` § Decision 3. |
+| Whether the navbar component is a server or client component (affects how the shield reactively updates) | Web | Defer — answered when M4.5 starts touching the file |
 
 ## Estimated total — ~700 LOC + sonner dep + Firestore schema + 1 KMS decision
 
 Calendar: 3 days for one full-stack engineer, or 2 days with one Web + one Backend in parallel after M4.1 lands.
 
-## Decision: ship audit doc, no code
+## Decision: ship audit doc + decision record, no code
 
-Same rationale as M2 audit: the natural first patch (M4.1 Firestore preferences) requires a KMS decision that isn't in scope for this session. Better to ship the audit + sequencing plan and let an actual M4.1 develop pass kick off after the encryption-at-rest decision is made.
+Audit + sequencing plan is one half. The blocking KMS decision is now resolved in `M4-decisions.md` (env-var pepper + HKDF-derived per-user key). M4.1 is unblocked and can be the next concrete code milestone.
 
 ## Files touched
 

--- a/desktop/docs/REGOLO_INTEGRATION.md
+++ b/desktop/docs/REGOLO_INTEGRATION.md
@@ -1,0 +1,318 @@
+# Regolo.ai Integration — EU Privacy Mode
+
+## Overview
+
+Adds [regolo.ai](https://regolo.ai) as a third LLM provider path alongside the existing Anthropic (Claude) and Google (Gemini) paths. Regolo is an Italy-hosted, OpenAI-compatible inference platform with a stated zero-retention, GDPR-compliant posture — routing Omi's LLM traffic through it lets us offer an "EU Privacy Mode" in which chat, synthesis, tool-calling, and embedding workloads stay in European infrastructure.
+
+**Status (Apr 2026):** scoped, scaffolding in progress.
+**Author:** synthesis from `/octo:research` + `/octo:define` (Claude + Codex + Gemini consensus).
+
+### Implementation progress
+
+| Commit | What | Status |
+|---|---|---|
+| `desktop: add .regolo case to BYOKProvider enum` | Swift enum + switches | ✅ merged on branch |
+| `desktop: validate regolo.ai BYOK key against /v1/models` | BYOKValidator ping | ✅ merged on branch |
+| `backend: register x-byok-regolo in BYOK_HEADERS` | Middleware header map | ✅ merged on branch |
+| `backend: add _RegoloOpenAIProxy` | BYOK-gated proxy class | ✅ merged on branch |
+| `backend: unit tests for _RegoloOpenAIProxy` | 5 unit tests | ✅ merged on branch |
+| Swift APIClient header forwarding | `X-BYOK-Regolo` | ⏳ pending |
+| Settings UX (EU Privacy Mode toggle + banner) | `SettingsPrivacyView.swift` | ⏳ pending |
+| `ModelQoS.swift` regolo model IDs | Desktop model map | ⏳ pending |
+| Privacy QoS profile in `backend/utils/llm/clients.py` | feature → regolo model mapping | ⏳ pending |
+| Dispatcher integration (per-workload override based on privacy flag) | routing logic | ⏳ pending |
+| Integration tests for dispatcher decision table | 9-row table | ⏳ pending |
+| Register `test_regolo_client.py` in `backend/test.sh` | CI wiring | ⏳ pending |
+
+## Research context
+
+Regolo.ai exposes OpenAI-compatible endpoints at `https://api.regolo.ai/v1` and hosts ~19 open-source models. Live probes against the production API confirmed:
+
+| Capability | Model | Result |
+|---|---|---|
+| Auth + models list | `GET /v1/models` | ✓ |
+| Tool calling | `Llama-3.3-70B-Instruct` | ✓ clean OpenAI-compat `tool_calls`, bonus `reasoning_content` field |
+| Embeddings | `Qwen3-Embedding-8B` | ✓ 4096-dim |
+| Chat (thinking model) | `minimax-m2.5` | ✓ **requires** `chat_template_kwargs:{enable_thinking:false}`; else `content:null, finish_reason:length` |
+| Structured JSON extraction | `qwen3.5-122b` | ✓ same thinking caveat; clean JSON with thinking off |
+| Vision | `qwen3-vl-32b` | ⚠️ listed in some tiers only — availability uncertain on PAYG |
+
+**Pricing (Apr 2026):** per 1M tokens input/output — `minimax-m2.5` €0.60/€3.80, `Llama-3.3-70B-Instruct` €0.60/€2.70, `qwen3.5-122b` €1.00/€4.20, `qwen3.5-9b` €0.07/€0.35. Roughly 15–25 % of Claude Sonnet's rate for equivalent workloads.
+
+## Scope
+
+**In:** additive OSS-via-regolo path for chat, synthesis, tool calling, embeddings. Desktop settings toggle, backend routing, telemetry, error semantics.
+
+**Out:** replacing Claude/Gemini, fine-tuning, self-hosted models, custom GPU deployments on regolo, admin-issued regolo keys (BYOK only day 1).
+
+## Architectural decisions
+
+### EU Privacy Mode — global toggle, not per-workload
+
+One settings-level toggle flips chat + synthesis + tool-call + embedding workloads to regolo. Per-workload overrides live behind an "Advanced" disclosure and are disabled while Privacy Mode is on. Rationale: one simple mental model beats five independent provider pickers; the "force all" framing matches what users expect from a privacy guarantee.
+
+### Fallback behavior — preferred, not airlocked
+
+When Privacy Mode is on and a request cannot be served by regolo (vision unsupported, 5xx outage, persistent 429), the request falls back to the primary provider **with a visible banner** (`⚠️ This request left the EU — vision unsupported / outage`). This is a deliberate design choice: strict airlock behavior would disable too many features silently. Users who want hard airlock can disable the affected feature manually.
+
+### Thin transparent proxy, not LiteLLM
+
+Regolo needs provider-specific request shaping — most importantly `chat_template_kwargs.enable_thinking=false` injected via `extra_body` to disable OSS-model internal reasoning. LiteLLM would smooth that away. Omi's backend already ships with a "transparent proxy" pattern in `utils/llm/clients.py` (see `_OpenRouterGeminiProxy`, `_AnthropicViaOpenAIProxy`) that wraps a default `ChatOpenAI` and swaps in a BYOK-keyed client when the header is present. The regolo integration slots in as **`_RegoloOpenAIProxy`**, following the exact same pattern — no new adapter framework, no LiteLLM dependency.
+
+### Streaming tool calls — no custom accumulator needed
+
+Live probe against `api.regolo.ai/v1/chat/completions` with `stream=true` confirmed that regolo emits standard OpenAI-compat SSE chunks. `langchain_openai.ChatOpenAI` handles the tool-call delta accumulation natively — no custom accumulator required. Sample shape:
+
+```
+data: {"choices":[{"delta":{"tool_calls":[{"id":"tc_1","index":0,"function":{"arguments":"","name":"get_weather"},"type":"function"}]}}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\": \""}}]}}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Paris\"}"}}]}}]}
+data: {"choices":[{"finish_reason":"tool_calls","delta":{}}]}
+data: [DONE]
+```
+
+This simplifies the backend adapter significantly — the `regolo_client.py` file planned in the original spec is not needed as a separate module.
+
+## Request flow
+
+```mermaid
+flowchart TD
+    Start([User action: chat / synthesis / tool call / embedding / vision])
+    Start --> Classify{Workload type}
+
+    Classify -->|chat| WL_Chat[ChatWorkload]
+    Classify -->|synthesis| WL_Synth[SynthesisWorkload]
+    Classify -->|tool_call| WL_Tool[ToolCallWorkload]
+    Classify -->|embedding| WL_Emb[EmbeddingWorkload]
+    Classify -->|vision/screenshot| WL_Vis[VisionWorkload]
+
+    WL_Chat --> Privacy{EU Privacy<br/>Mode ON?}
+    WL_Synth --> Privacy
+    WL_Tool --> Privacy
+    WL_Emb --> Privacy
+    WL_Vis --> Privacy
+
+    Privacy -->|No| Native[Route to<br/>Claude / Gemini<br/>existing paths]
+    Privacy -->|Yes| CapCheck{Regolo supports<br/>this workload?}
+
+    CapCheck -->|No| BannerVision[Banner:<br/>⚠️ Request left EU<br/>vision unsupported]
+    BannerVision --> Native
+
+    CapCheck -->|Yes| CallRegolo[Call regolo<br/>+ enable_thinking:false]
+
+    CallRegolo --> ResCheck{Response OK?}
+
+    ResCheck -->|2xx| NormResp[Strip reasoning_content<br/>Normalize tool_calls]
+    NormResp --> Return([Return to caller])
+
+    ResCheck -->|5xx / timeout| Retry{Retry once?}
+    Retry -->|Yes| CallRegolo
+    Retry -->|No| BannerOutage[Banner:<br/>⚠️ Regolo down —<br/>fell back to primary]
+    BannerOutage --> Native
+
+    ResCheck -->|finish_reason:length| TruncErr[Surface truncation error<br/>NO auto-retry]
+    TruncErr --> Return
+
+    ResCheck -->|429| Backoff[Exp backoff<br/>max 3 attempts<br/>honor Retry-After]
+    Backoff --> CallRegolo
+
+    Native --> Return
+```
+
+## Component layout
+
+```mermaid
+graph LR
+    subgraph "Desktop (Swift)"
+        Settings[Settings › Privacy<br/>EU Privacy Mode toggle]
+        APIKS[APIKeyService.swift<br/>+ .regolo case in BYOKProvider]
+        BYV[BYOKValidator.swift<br/>+ regolo ping /v1/models]
+        APIC[APIClient.swift<br/>adds X-BYOK-Regolo header]
+        Settings --> APIKS
+        APIKS --> APIC
+        APIKS --> BYV
+    end
+
+    subgraph "Backend (Python FastAPI)"
+        Router[routers/chat.py<br/>conversations.py<br/>retrieval/*]
+        Clients[utils/llm/clients.py<br/>MODIFIED: add<br/>_RegoloOpenAIProxy<br/>+ privacy QoS profile]
+        ClaudeC[anthropic_client<br/>existing proxy]
+        GeminiC[_OpenRouterGeminiProxy<br/>existing]
+        RegoloC[_RegoloOpenAIProxy<br/>NEW: base_url swap<br/>+ enable_thinking:false<br/>via extra_body]
+
+        Router --> Clients
+        Clients --> ClaudeC
+        Clients --> GeminiC
+        Clients --> RegoloC
+    end
+
+    subgraph "External"
+        Anthropic[api.anthropic.com]
+        Google[generativelanguage<br/>.googleapis.com]
+        Regolo[api.regolo.ai/v1<br/>🇮🇹 Italy]
+    end
+
+    APIC -->|X-BYOK-*<br/>headers| Router
+    ClaudeC --> Anthropic
+    GeminiC --> Google
+    RegoloC --> Regolo
+```
+
+## Dispatcher decision table
+
+| Privacy Mode | Workload | Regolo supports? | Route → | Banner? |
+|---|---|---|---|---|
+| OFF | any | — | existing Claude/Gemini | no |
+| ON | chat | ✓ | `regolo: minimax-m2.5` | no |
+| ON | synthesis | ✓ | `regolo: Llama-3.3-70B-Instruct` | no |
+| ON | tool_call | ✓ | `regolo: Llama-3.3-70B-Instruct` | no |
+| ON | ChatLab grade | ✓ | `regolo: qwen3.5-9b` | no |
+| ON | embedding | ✓ | `regolo: Qwen3-Embedding-8B` | no |
+| ON | vision | ✗ (no qwen3-vl on PAYG) | `gemini: gemini-3-flash-preview` | ⚠️ left EU |
+| ON | regolo 5xx (after 1 retry) | temp no | fall back to Claude/Gemini | ⚠️ outage, left EU |
+| ON | regolo 429 | yes with backoff | regolo (3 attempts) | no |
+
+## Streaming tool-call sequence
+
+Regolo emits standard OpenAI-compat SSE chunks; `langchain_openai.ChatOpenAI` handles accumulation natively. The backend's role is limited to forwarding the stream.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant B as Backend<br/>_RegoloOpenAIProxy via<br/>ChatOpenAI
+    participant R as regolo.ai
+
+    C->>B: POST /v1/chat (stream=true, tools=[...])
+    B->>R: stream=true, chat_template_kwargs:{enable_thinking:false}
+    R-->>B: delta: {content:"Let me check "}
+    B-->>C: delta: text
+    R-->>B: delta: {tool_calls:[{index:0, id:"tc_1", function:{name:"get_weather"}}]}
+    R-->>B: delta: {tool_calls:[{index:0, function:{arguments:"{\"city\":\""}}]}
+    R-->>B: delta: {tool_calls:[{index:0, function:{arguments:"Paris\"}"}}]}
+    R-->>B: finish_reason:tool_calls
+    Note over B: langchain's native<br/>tool-call parser<br/>assembles the deltas
+    B-->>C: full tool_call event
+```
+
+## Functional requirements (Day 1)
+
+| # | Requirement |
+|---|---|
+| F1 | Add `.regolo` case to `BYOKProvider` in `APIKeyService.swift` with `X-BYOK-Regolo` header + `dev_regolo_api_key` storage key |
+| F2 | Extend `BYOKValidator.swift` to ping `GET https://api.regolo.ai/v1/models` with `Authorization: Bearer <key>` |
+| F3 | Backend accepts `X-BYOK-Regolo` and routes via `OSSProvider` client (`base_url=https://api.regolo.ai/v1`) |
+| F4 | Day-1 model map: `chat → minimax-m2.5`, `synthesis → Llama-3.3-70B-Instruct`, `chatLabGrade → qwen3.5-9b`, `embedding → Qwen3-Embedding-8B` |
+| F5 | All non-reasoning calls inject `chat_template_kwargs:{"enable_thinking":false}` |
+| F6 | Tool-call responses normalize to the existing internal shape; `reasoning_content` stripped before persistence |
+| F7 | Embedding responses normalize to the existing interface (4096-dim) |
+| F8 | Existing Claude/Gemini/OpenAI/Deepgram BYOK paths unchanged — zero regressions |
+
+## Non-functional requirements
+
+| Category | Requirement |
+|---|---|
+| Latency | P50 ≤ 2 s synthesis, ≤ 1.5 s first-token streaming chat. Routing overhead ≤ 20 ms. Client timeout 30 s, retry once on network error, no retry on 4xx. |
+| Error mapping | Regolo errors → existing `LLMProviderError` categories (auth / rate_limit / capability / truncation / network). |
+| Telemetry | Log `provider, workload, model, status, latency_ms, retry_count, fallback_used, finish_reason`. Never log prompts, completions, keys, embeddings, tool args. |
+| Privacy indicators | Status-bar shield icon when Privacy Mode is active. Fallback banner shown per request that left the EU; dismissible per-request, not permanently silenceable. |
+| Reliability | Regolo failures must not corrupt session state; streaming partial output must be discardable. |
+
+## Settings UX
+
+```
+┌─ Settings › Privacy ─────────────────────────────────┐
+│  [🛡] EU Privacy Mode                         [ ● ]  │
+│   All AI runs on regolo.ai (Italy, zero retention).  │
+│   Vision features require non-EU provider.          │
+│                                                      │
+│  ▸ Advanced (per-workload override)                  │
+│    — Disabled while Privacy Mode is on —             │
+└──────────────────────────────────────────────────────┘
+```
+
+- First-run prompt only surfaces for EU-locale users or users who open Privacy settings — avoid evangelism.
+- Banner copy when fallback fires: `⚠️ This request left the EU: vision is unsupported by regolo`. Styled red, dismissible per request. Count surfaced in settings ("12 requests fell back this week").
+
+## Edge cases — decided behaviors
+
+| Case | Behavior |
+|---|---|
+| Model 404 (e.g. `qwen3-vl-32b` missing from plan tier) | Fail fast with `ERR_PROVIDER_CAPABILITY_MISSING`; feature disabled in UI with tooltip. No silent cross-provider fallback unless Privacy-Mode fallback rules apply. |
+| `finish_reason:"length"` on thinking model | Surface truncation error; **do not auto-retry**. For synthesis, always send `enable_thinking:false` so this is rare. |
+| Malformed tool-call JSON | Attempt existing repair flow. If it fails, return `tool_call_parse_error`; do NOT execute tools speculatively. |
+| 429 rate limit | Respect `Retry-After` header; bounded exponential backoff (max 3 attempts, jitter). |
+| Streaming failure before first token | Retry once non-streaming. |
+| Streaming failure after first token | Propagate to caller; do not retry. |
+| Reasoning content leak | Strip `reasoning_content` before writing to chat history. Optionally expose as collapsible "thinking" disclosure in UI. |
+| Factual hallucination (e.g. MiniMax confused about regolo's HQ in live probe) | Chat workloads needing grounding route through existing RAG pipeline — don't trust OSS chat for factual claims. |
+
+## Migration & history portability
+
+- Normalized internal schema for tool calls; provider-specific IDs (`chatcmpl-tool-…`) are optional metadata.
+- Switching provider mid-session preserves history; messages re-translated to the target provider's format at request time.
+- Unsupported message parts (images, Anthropic cache markers) are downgraded / omitted with a visible warning, not silently dropped.
+- Embedding store uses `(provider, model)` composite key so 4096-dim Qwen3 embeddings don't collide with `gemini-embedding-001` vectors. No retro-reembed; existing embeddings keep their original provider tag.
+
+## Acceptance criteria (QA-observable)
+
+1. Desktop settings shows regolo provider row with key field, "Test connection" button, and test result (✓ / ✗ with error reason).
+2. Flipping "EU Privacy Mode" on routes chat messages to `minimax-m2.5` — verified by telemetry showing `provider=regolo, model=minimax-m2.5`.
+3. Synthesis workload (e.g. Gmail summary) produces valid JSON output using `Llama-3.3-70B-Instruct`.
+4. Tool-call flow ("create a reminder for tomorrow at 3pm") triggers `tools` with `tool_choice:auto`, receives a valid `tool_calls` response, and executes the reminder.
+5. Memory embedding + retrieval works end-to-end with `Qwen3-Embedding-8B` (4096-dim).
+6. With Privacy Mode ON, network capture confirms zero traffic to `anthropic.com` / `googleapis.com` / `openai.com` **except** for explicit fallback cases which emit the banner.
+7. Unsupported vision feature (when `qwen3-vl-32b` unavailable) falls back to Gemini with the red banner.
+8. `finish_reason:"length"` response surfaces as user-visible truncation warning, not a crash.
+9. Existing Claude/Gemini BYOK regression suite passes unchanged.
+10. Log sampling shows no API keys, no raw prompts, no raw completions at normal verbosity.
+
+## Open questions — status
+
+| # | Question | Status |
+|---|---|---|
+| 1 | Regolo tools schema matches OpenAI strict? | ✓ Resolved via live probe — Llama-3.3 returns standard `tool_calls`. |
+| 2 | Is `qwen3-vl-32b` production-available? | ⚠️ Open — missing from PAYG `/v1/models`. Need regolo support ticket / plan-tier confirmation. Day 1 ships without vision on regolo. |
+| 3 | Vision endpoint shape | Deferred to Phase 2. |
+| 4 | Embedding dimensionality | ✓ 4096 (live probe). DB schema must support variable `embedding_dim`. |
+| 5 | Is `enable_thinking` in body or header? | ✓ Body, under `chat_template_kwargs.enable_thinking`. |
+| 6 | Privacy Mode forces or defaults? | ✓ **Forces** all supported workloads; per-workload overrides disabled while on. |
+| 7 | Fallback allowed while Privacy Mode on? | ✓ **Yes, with visible red banner** per request. Preferred-by-default, not airlocked. |
+| 8 | Rate-limit tuning vs plan tier | Open — instrument telemetry in Phase 1; revisit plan choice with real usage data. |
+| 9 | Streaming parity for tool-call deltas | Open — first Phase 1 dev task is a live probe of regolo's streaming delta shape. |
+
+## Files touched (revised estimate after scaffolding)
+
+The original ~700 LOC estimate assumed a new `regolo_client.py` module + bespoke streaming accumulator + dispatcher. Live probing and code exploration revealed:
+
+1. Regolo's streaming SSE is OpenAI-compat — langchain handles it natively (no accumulator)
+2. Omi's backend already has a transparent-proxy pattern for BYOK routing (`_AnthropicViaOpenAIProxy`, `_OpenRouterGeminiProxy`)
+3. Model routing lives in a profile-based `MODEL_QOS_PROFILES` dict — regolo slots in as a new profile
+
+Revised scope:
+
+| File | Change | LOC | Status |
+|---|---|---|---|
+| `desktop/Desktop/Sources/APIKeyService.swift` | `.regolo` case + storage/header/display | +4 | ✅ |
+| `desktop/Desktop/Sources/BYOKValidator.swift` | regolo ping | +5 | ✅ |
+| `desktop/Desktop/Sources/APIClient.swift` | `X-BYOK-Regolo` header forwarding | ~5 | ⏳ |
+| `desktop/Desktop/Sources/ModelQoS.swift` | regolo model IDs | ~15 | ⏳ |
+| `desktop/Desktop/Sources/SettingsPrivacyView.swift` (NEW) | toggle + banner surface | ~80 | ⏳ |
+| `backend/utils/byok.py` | `x-byok-regolo` header registration | +1 | ✅ |
+| `backend/utils/llm/clients.py` | `_RegoloOpenAIProxy` class + constants | +56 | ✅ (scaffolded) |
+| `backend/utils/llm/clients.py` | `privacy` QoS profile + feature dispatch | ~60 | ⏳ |
+| `backend/tests/unit/test_regolo_client.py` (NEW) | proxy routing tests | +168 | ✅ |
+| `backend/tests/integration/test_privacy_mode.py` (NEW) | decision-table tests | ~100 | ⏳ |
+| `backend/test.sh` | register new test file | +1 | ⏳ |
+| **Total shipped so far** | | **~234** | |
+| **Total remaining** | | **~260** | |
+| **Revised total** | | **~500 LOC** | |
+
+Budget: **2–3 days** remaining (1 backend dispatch + Swift UX, 1 tests, 0.5 buffer).
+
+## References
+
+- [regolo.ai homepage](https://regolo.ai/)
+- [docs.regolo.ai](https://docs.regolo.ai/)
+- [regolo.ai pricing](https://regolo.ai/pricing/)
+- Live API probes: `GET /v1/models`, `POST /v1/chat/completions` (MiniMax, Llama 3.3), `POST /v1/embeddings` (Qwen3-Embedding-8B) — Apr 22 2026.
+- Internal: `/octo:research` output + `/octo:define` consensus (Claude + Codex + Gemini).

--- a/desktop/docs/REGOLO_INTEGRATION.md
+++ b/desktop/docs/REGOLO_INTEGRATION.md
@@ -32,7 +32,7 @@ Regolo.ai exposes OpenAI-compatible endpoints at `https://api.regolo.ai/v1` and 
 |---|---|---|
 | Auth + models list | `GET /v1/models` | ✓ — 20 models on PAYG |
 | Tool calling | `Llama-3.3-70B-Instruct` (default), uniform across all probed mid/large chat models | ✓ clean OpenAI-compat `tool_calls` |
-| Streaming tool-call deltas | `Llama-3.3-70B-Instruct` | ✓ OpenAI-standard SSE — `langchain_openai.ChatOpenAI` accumulates natively (fixture: `backend/tests/fixtures/regolo_tool_call_stream.json`) |
+| Streaming tool-call deltas | `Llama-3.3-70B-Instruct` | ✓ OpenAI-standard SSE — `langchain_openai.ChatOpenAI` accumulates natively (fixture in sister repo: `/opt/projects/omi-regolo-integration/backend/tests/fixtures/regolo_tool_call_stream.json`; M1 task to port into this branch) |
 | Embeddings | `Qwen3-Embedding-8B` | ✓ 4096-dim |
 | Chat — thinking-model knob | `qwen3.5-9b/122b`, `qwen3.6-27b`, `minimax-m2.5` | **require** `chat_template_kwargs:{enable_thinking:false}`; else `content:null, finish_reason:length`. **No-op** on Llama / Mistral / gpt-oss / gemma / apertus families. |
 | `reasoning_content` leakage | `minimax-m2.5` only | always emitted — `strip_reasoning_content()` mandatory before persistence |
@@ -205,8 +205,8 @@ sequenceDiagram
 | F1 | Add `.regolo` case to `BYOKProvider` in `APIKeyService.swift` with `X-BYOK-Regolo` header + `dev_regolo_api_key` storage key |
 | F2 | Extend `BYOKValidator.swift` to ping `GET https://api.regolo.ai/v1/models` with `Authorization: Bearer <key>` |
 | F3 | Backend accepts `X-BYOK-Regolo` and routes via `OSSProvider` client (`base_url=https://api.regolo.ai/v1`) |
-| F4 | Day-1 model map (post-P6 corrections): `chat → mistral-small-4-119b`, `synthesis → mistral-small-4-119b`, `tool_call → Llama-3.3-70B-Instruct`, `nano → Llama-3.1-8B-Instruct`, `embedding → Qwen3-Embedding-8B` (Phase 2). The `_REGOLO_THINKING_MODELS` set in `backend/utils/llm/clients.py` enumerates models still reachable via operator override (`MODEL_QOS_<FEATURE>=regolo/...`). |
-| F5 | Auto-inject `chat_template_kwargs:{"enable_thinking":false}` ONLY for models in `_REGOLO_THINKING_MODELS` (Qwen3.5-9b/122b, Qwen3.6-27b, MiniMax-m2.5). On Llama / Mistral / gpt-oss / gemma / apertus the flag is a no-op and is not sent. |
+| F4 | Day-1 model map (post-P6 corrections): `chat → mistral-small-4-119b`, `synthesis → mistral-small-4-119b`, `tool_call → Llama-3.3-70B-Instruct`, `nano → Llama-3.1-8B-Instruct`, `embedding → Qwen3-Embedding-8B` (Phase 2). Thinking models (Qwen3.5-9b/122b, Qwen3.6-27b, MiniMax-m2.5) remain reachable via operator override (`MODEL_QOS_<FEATURE>=regolo/...`). |
+| F5 | Inject `chat_template_kwargs:{"enable_thinking":false}` via the `REGOLO_DISABLE_THINKING_EXTRA_BODY` constant (`backend/utils/llm/clients.py`) so OSS thinking models (MiniMax M2.5, Qwen3.x) don't return `content:null, finish_reason:length`. M1 follow-up: gate the injection on a `_REGOLO_THINKING_MODELS` set so the no-op flag isn't sent to Llama / Mistral / gpt-oss / gemma / apertus. |
 | F6 | Tool-call responses normalize to the existing internal shape; `reasoning_content` stripped before persistence |
 | F7 | Embedding responses normalize to the existing interface (4096-dim) |
 | F8 | Existing Claude/Gemini/OpenAI/Deepgram BYOK paths unchanged — zero regressions |
@@ -260,8 +260,8 @@ sequenceDiagram
 ## Acceptance criteria (QA-observable)
 
 1. Desktop settings shows regolo provider row with key field, "Test connection" button, and test result (✓ / ✗ with error reason).
-2. Flipping "EU Privacy Mode" on routes chat messages to `minimax-m2.5` — verified by telemetry showing `provider=regolo, model=minimax-m2.5`.
-3. Synthesis workload (e.g. Gmail summary) produces valid JSON output using `Llama-3.3-70B-Instruct`.
+2. Flipping "EU Privacy Mode" on routes chat messages to `mistral-small-4-119b` — verified by telemetry showing `provider=regolo, model=mistral-small-4-119b`.
+3. Synthesis workload (e.g. Gmail summary) produces valid JSON output using `mistral-small-4-119b` (default) or `Llama-3.3-70B-Instruct` (operator override).
 4. Tool-call flow ("create a reminder for tomorrow at 3pm") triggers `tools` with `tool_choice:auto`, receives a valid `tool_calls` response, and executes the reminder.
 5. Memory embedding + retrieval works end-to-end with `Qwen3-Embedding-8B` (4096-dim).
 6. With Privacy Mode ON, network capture confirms zero traffic to `anthropic.com` / `googleapis.com` / `openai.com` **except** for explicit fallback cases which emit the banner.
@@ -278,11 +278,11 @@ sequenceDiagram
 | 2 | Is `qwen3-vl-32b` production-available? | ✗ **No on PAYG (P8).** HARD-BLOCKED in Phase 1. Vision falls back to Gemini with banner. To unblock: support ticket or plan upgrade. |
 | 3 | Vision endpoint shape | Deferred to Phase 2; not on Phase-1 critical path. |
 | 4 | Embedding dimensionality | ✓ Resolved (P7) — Qwen3-Embedding-8B is 4096-dim. Vector store keyed `(provider, model, dim)`. See `EMBEDDING_MIGRATION.md`. |
-| 5 | Is `enable_thinking` in body or header? | ✓ Resolved (P4) — body, under `chat_template_kwargs.enable_thinking`. **Per-model**: only the `_REGOLO_THINKING_MODELS` set requires it. The unrelated top-level `"thinking":true,"reasoning_effort":...` opt-in (Regolo docs, `gpt-oss-120b`) is not used in Phase 1 (P10). |
+| 5 | Is `enable_thinking` in body or header? | ✓ Resolved (P4) — body, under `chat_template_kwargs.enable_thinking`. **Per-model**: only the Qwen3.x family + MiniMax-m2.5 require it; this branch carries `REGOLO_DISABLE_THINKING_EXTRA_BODY` (`backend/utils/llm/clients.py:160`). M1 ports the per-model gating set from the sister repo. The unrelated top-level `"thinking":true,"reasoning_effort":...` opt-in (Regolo docs, `gpt-oss-120b`) is not used in Phase 1 (P10). |
 | 6 | Privacy Mode forces or defaults? | ✓ **Forces** all supported workloads; per-workload overrides disabled while on. |
 | 7 | Fallback allowed while Privacy Mode on? | ✓ **Yes, with visible red banner** per request. Preferred-by-default, not airlocked. |
 | 8 | Rate-limit tuning vs plan tier | Deferred (P11) — instrument telemetry in M1; revisit plan choice with real usage data in M5. |
-| 9 | Streaming parity for tool-call deltas | ✓ Resolved (P2) — OpenAI-standard SSE. Fixture committed at `backend/tests/fixtures/regolo_tool_call_stream.json`. `langchain_openai.ChatOpenAI` accumulates natively; no custom accumulator needed. |
+| 9 | Streaming parity for tool-call deltas | ✓ Resolved (P2) — OpenAI-standard SSE. Fixture in sister repo `/opt/projects/omi-regolo-integration/backend/tests/fixtures/regolo_tool_call_stream.json`; M1 ports it into this branch. `langchain_openai.ChatOpenAI` accumulates natively; no custom accumulator needed. |
 
 ## Files touched (revised estimate after scaffolding)
 

--- a/desktop/docs/REGOLO_INTEGRATION.md
+++ b/desktop/docs/REGOLO_INTEGRATION.md
@@ -26,16 +26,19 @@ Adds [regolo.ai](https://regolo.ai) as a third LLM provider path alongside the e
 
 ## Research context
 
-Regolo.ai exposes OpenAI-compatible endpoints at `https://api.regolo.ai/v1` and hosts ~19 open-source models. Live probes against the production API confirmed:
+Regolo.ai exposes OpenAI-compatible endpoints at `https://api.regolo.ai/v1` and hosts 20 open-source models on PAYG (Apr 2026 catalog). The full `/v1/models` listing and the empirical multi-sample latency/consistency data behind every model pick below are in [`regolo-probes.md`](./regolo-probes.md). Headline findings:
 
 | Capability | Model | Result |
 |---|---|---|
-| Auth + models list | `GET /v1/models` | ✓ |
-| Tool calling | `Llama-3.3-70B-Instruct` | ✓ clean OpenAI-compat `tool_calls`, bonus `reasoning_content` field |
+| Auth + models list | `GET /v1/models` | ✓ — 20 models on PAYG |
+| Tool calling | `Llama-3.3-70B-Instruct` (default), uniform across all probed mid/large chat models | ✓ clean OpenAI-compat `tool_calls` |
+| Streaming tool-call deltas | `Llama-3.3-70B-Instruct` | ✓ OpenAI-standard SSE — `langchain_openai.ChatOpenAI` accumulates natively (fixture: `backend/tests/fixtures/regolo_tool_call_stream.json`) |
 | Embeddings | `Qwen3-Embedding-8B` | ✓ 4096-dim |
-| Chat (thinking model) | `minimax-m2.5` | ✓ **requires** `chat_template_kwargs:{enable_thinking:false}`; else `content:null, finish_reason:length` |
-| Structured JSON extraction | `qwen3.5-122b` | ✓ same thinking caveat; clean JSON with thinking off |
-| Vision | `qwen3-vl-32b` | ⚠️ listed in some tiers only — availability uncertain on PAYG |
+| Chat — thinking-model knob | `qwen3.5-9b/122b`, `qwen3.6-27b`, `minimax-m2.5` | **require** `chat_template_kwargs:{enable_thinking:false}`; else `content:null, finish_reason:length`. **No-op** on Llama / Mistral / gpt-oss / gemma / apertus families. |
+| `reasoning_content` leakage | `minimax-m2.5` only | always emitted — `strip_reasoning_content()` mandatory before persistence |
+| Structured JSON extraction | every probed chat model | ✓ clean JSON via prompt-engineered output; `response_format:json_object` strict mode untested (P9) |
+| Latency × consistency winner | `mistral-small-4-119b` (n=5, p50 0.43s, p90 0.44s, ±2%) | beats Llama-3.3-70B (0.83s) and qwen3.5-122b (bimodal, p90 2.25s); minimax-m2.5 timed out 3/5 calls |
+| Vision | `qwen3-vl-32b` | ✗ **HARD-BLOCKED** — not in PAYG `/v1/models`. Vision falls back to Gemini with red banner. |
 
 **Pricing (Apr 2026):** per 1M tokens input/output — `minimax-m2.5` €0.60/€3.80, `Llama-3.3-70B-Instruct` €0.60/€2.70, `qwen3.5-122b` €1.00/€4.20, `qwen3.5-9b` €0.07/€0.35. Roughly 15–25 % of Claude Sonnet's rate for equivalent workloads.
 
@@ -163,10 +166,11 @@ graph LR
 | Privacy Mode | Workload | Regolo supports? | Route → | Banner? |
 |---|---|---|---|---|
 | OFF | any | — | existing Claude/Gemini | no |
-| ON | chat | ✓ | `regolo: minimax-m2.5` | no |
-| ON | synthesis | ✓ | `regolo: Llama-3.3-70B-Instruct` | no |
+| ON | chat | ✓ | `regolo: mistral-small-4-119b` (was `minimax-m2.5` in the original spec — replaced after P6 latency probe found 3/5 calls timed out at 60s) | no |
+| ON | synthesis | ✓ | `regolo: mistral-small-4-119b` (default) or `Llama-3.3-70B-Instruct` (where Llama's longer instruction-following helps) | no |
 | ON | tool_call | ✓ | `regolo: Llama-3.3-70B-Instruct` | no |
-| ON | ChatLab grade | ✓ | `regolo: qwen3.5-9b` | no |
+| ON | nano-tier classification | ✓ | `regolo: Llama-3.1-8B-Instruct` (€0.05/€0.25 per 1M, 0.62s p50) | no |
+| ON | ChatLab grade | ✓ (operator override only — bimodal latency) | `regolo: qwen3.5-9b` via `MODEL_QOS_*` env var | no |
 | ON | embedding | ✓ | `regolo: Qwen3-Embedding-8B` | no |
 | ON | vision | ✗ (no qwen3-vl on PAYG) | `gemini: gemini-3-flash-preview` | ⚠️ left EU |
 | ON | regolo 5xx (after 1 retry) | temp no | fall back to Claude/Gemini | ⚠️ outage, left EU |
@@ -201,8 +205,8 @@ sequenceDiagram
 | F1 | Add `.regolo` case to `BYOKProvider` in `APIKeyService.swift` with `X-BYOK-Regolo` header + `dev_regolo_api_key` storage key |
 | F2 | Extend `BYOKValidator.swift` to ping `GET https://api.regolo.ai/v1/models` with `Authorization: Bearer <key>` |
 | F3 | Backend accepts `X-BYOK-Regolo` and routes via `OSSProvider` client (`base_url=https://api.regolo.ai/v1`) |
-| F4 | Day-1 model map: `chat → minimax-m2.5`, `synthesis → Llama-3.3-70B-Instruct`, `chatLabGrade → qwen3.5-9b`, `embedding → Qwen3-Embedding-8B` |
-| F5 | All non-reasoning calls inject `chat_template_kwargs:{"enable_thinking":false}` |
+| F4 | Day-1 model map (post-P6 corrections): `chat → mistral-small-4-119b`, `synthesis → mistral-small-4-119b`, `tool_call → Llama-3.3-70B-Instruct`, `nano → Llama-3.1-8B-Instruct`, `embedding → Qwen3-Embedding-8B` (Phase 2). The `_REGOLO_THINKING_MODELS` set in `backend/utils/llm/clients.py` enumerates models still reachable via operator override (`MODEL_QOS_<FEATURE>=regolo/...`). |
+| F5 | Auto-inject `chat_template_kwargs:{"enable_thinking":false}` ONLY for models in `_REGOLO_THINKING_MODELS` (Qwen3.5-9b/122b, Qwen3.6-27b, MiniMax-m2.5). On Llama / Mistral / gpt-oss / gemma / apertus the flag is a no-op and is not sent. |
 | F6 | Tool-call responses normalize to the existing internal shape; `reasoning_content` stripped before persistence |
 | F7 | Embedding responses normalize to the existing interface (4096-dim) |
 | F8 | Existing Claude/Gemini/OpenAI/Deepgram BYOK paths unchanged — zero regressions |
@@ -270,15 +274,15 @@ sequenceDiagram
 
 | # | Question | Status |
 |---|---|---|
-| 1 | Regolo tools schema matches OpenAI strict? | ✓ Resolved via live probe — Llama-3.3 returns standard `tool_calls`. |
-| 2 | Is `qwen3-vl-32b` production-available? | ⚠️ Open — missing from PAYG `/v1/models`. Need regolo support ticket / plan-tier confirmation. Day 1 ships without vision on regolo. |
-| 3 | Vision endpoint shape | Deferred to Phase 2. |
-| 4 | Embedding dimensionality | ✓ 4096 (live probe). DB schema must support variable `embedding_dim`. |
-| 5 | Is `enable_thinking` in body or header? | ✓ Body, under `chat_template_kwargs.enable_thinking`. |
+| 1 | Regolo tools schema matches OpenAI strict? | ✓ Resolved (P3) — uniform OpenAI-compat across Llama 8B/70B, Mistral 3.2/119B, gpt-oss-120B, qwen3.5-122b, minimax-m2.5. |
+| 2 | Is `qwen3-vl-32b` production-available? | ✗ **No on PAYG (P8).** HARD-BLOCKED in Phase 1. Vision falls back to Gemini with banner. To unblock: support ticket or plan upgrade. |
+| 3 | Vision endpoint shape | Deferred to Phase 2; not on Phase-1 critical path. |
+| 4 | Embedding dimensionality | ✓ Resolved (P7) — Qwen3-Embedding-8B is 4096-dim. Vector store keyed `(provider, model, dim)`. See `EMBEDDING_MIGRATION.md`. |
+| 5 | Is `enable_thinking` in body or header? | ✓ Resolved (P4) — body, under `chat_template_kwargs.enable_thinking`. **Per-model**: only the `_REGOLO_THINKING_MODELS` set requires it. The unrelated top-level `"thinking":true,"reasoning_effort":...` opt-in (Regolo docs, `gpt-oss-120b`) is not used in Phase 1 (P10). |
 | 6 | Privacy Mode forces or defaults? | ✓ **Forces** all supported workloads; per-workload overrides disabled while on. |
 | 7 | Fallback allowed while Privacy Mode on? | ✓ **Yes, with visible red banner** per request. Preferred-by-default, not airlocked. |
-| 8 | Rate-limit tuning vs plan tier | Open — instrument telemetry in Phase 1; revisit plan choice with real usage data. |
-| 9 | Streaming parity for tool-call deltas | Open — first Phase 1 dev task is a live probe of regolo's streaming delta shape. |
+| 8 | Rate-limit tuning vs plan tier | Deferred (P11) — instrument telemetry in M1; revisit plan choice with real usage data in M5. |
+| 9 | Streaming parity for tool-call deltas | ✓ Resolved (P2) — OpenAI-standard SSE. Fixture committed at `backend/tests/fixtures/regolo_tool_call_stream.json`. `langchain_openai.ChatOpenAI` accumulates natively; no custom accumulator needed. |
 
 ## Files touched (revised estimate after scaffolding)
 

--- a/desktop/docs/regolo-probes.md
+++ b/desktop/docs/regolo-probes.md
@@ -1,0 +1,165 @@
+# Regolo.ai Live-Probe Results — M0 Evidence
+
+Single source of truth for what we have empirically verified about `api.regolo.ai/v1`. Cited from the integration design doc and the dispatcher's decision table. Anything not on this page is **assumption**, not evidence.
+
+**Probes captured:** 2026-04-22 → 2026-04-27 against `https://api.regolo.ai/v1` on the PAYG plan.
+
+## Probe index
+
+| # | What | Status | Artifact |
+|---|---|---|---|
+| P1 | Auth + model catalog (`GET /v1/models`) | ✓ resolved | inline below |
+| P2 | Streaming tool-call delta shape on Llama-3.3-70B | ✓ resolved | `backend/tests/fixtures/regolo_tool_call_stream.json` (sister repo) |
+| P3 | Tool-calling parity across mid/large models | ✓ resolved | inline below |
+| P4 | `chat_template_kwargs.enable_thinking:false` knob — which models require it | ✓ resolved | inline below |
+| P5 | `reasoning_content` field — which models emit it | ✓ resolved | inline below |
+| P6 | Latency × consistency multi-sample, all chat models | ✓ resolved | inline below |
+| P7 | Embedding model dimensionality + latency | ✓ resolved | inline below |
+| P8 | Vision (`qwen3-vl-32b`) PAYG availability | ✗ HARD-BLOCKED — model not in PAYG `/v1/models` | inline below |
+| P9 | `response_format:{type:"json_object"}` strict-JSON enforcement | ⏳ deferred — informal probes show clean JSON output without it; strict-mode behavior un-verified | future probe |
+| P10 | Top-level `thinking:true` opt-in shape on `gpt-oss-120b` | ⏳ deferred — not on Phase-1 critical path; `gpt-oss-120b` runs fine without thinking | future probe |
+| P11 | Rate-limit headers / `Retry-After` semantics on 429 | ⏳ deferred — instrument in Phase 1 telemetry, revisit with real usage data | future probe |
+
+## P1 — Auth + model catalog
+
+`GET https://api.regolo.ai/v1/models` with `Authorization: Bearer <key>` returns 200 with **20 models** on PAYG. Confirmed catalog (Apr 2026):
+
+`apertus-70b`, `brick-v1-beta`, `deepseek-ocr-2`, `faster-whisper-large-v3`, `gemma4-31b`, `gpt-oss-120b`, `gpt-oss-20b`, `gte-Qwen2`, `Llama-3.1-8B-Instruct`, `Llama-3.3-70B-Instruct`, `minimax-m2.5`, `mistral-small-4-119b`, `mistral-small3.2`, `Qwen-Image`, `Qwen3-Embedding-8B`, `Qwen3-Reranker-4B`, `qwen3-coder-next`, `qwen3.5-122b`, `qwen3.5-9b`, `qwen3.6-27b`.
+
+**Not in PAYG `/v1/models`:** `qwen3-vl-32b` (vision). See P8.
+
+## P2 — Streaming tool-call delta shape
+
+Captured fixture: `backend/tests/fixtures/regolo_tool_call_stream.json` (5 chunks, real model response from `Llama-3.3-70B-Instruct` answering `"What is the weather in Paris right now?"` with a `get_weather(city)` tool).
+
+**Verdict:** OpenAI-standard. The deltas concatenate to a valid tool call:
+
+```
+chunk 1  delta.tool_calls[0]: { id, function: { name: "get_weather", arguments: "" }, type: "function", index: 0 }
+chunk 2  delta.tool_calls[0].function.arguments: '{"city": "'
+chunk 3  delta.tool_calls[0].function.arguments: 'Paris"}'
+chunk 4  finish_reason: "tool_calls", delta: {}
+chunk 5  [DONE]
+```
+
+**Implication for backend:** `langchain_openai.ChatOpenAI` accumulates these natively. The custom streaming-tool-call accumulator the original design doc planned for `regolo_client.py` is **not needed** — confirmed by code review of the `_RegoloOpenAIProxy` class on this branch.
+
+## P3 — Tool-calling parity across models
+
+Same `get_weather` smoke test, non-streaming and streaming, against:
+
+- `Llama-3.1-8B-Instruct` ✓
+- `Llama-3.3-70B-Instruct` ✓ (default tool-call model on Phase 1)
+- `mistral-small3.2` ✓
+- `mistral-small-4-119b` ✓
+- `gpt-oss-120b` ✓
+- `qwen3.5-122b` (with `enable_thinking:false`) ✓
+- `minimax-m2.5` (with `enable_thinking:false`) ✓
+
+All emit OpenAI-shape `tool_calls` with `index`, `id`, `function.name`, `function.arguments` (JSON string). Argument concat across stream chunks always produces valid JSON.
+
+## P4 — Thinking knob: which models require `enable_thinking:false`
+
+Probe protocol: send a JSON-extraction prompt, `max_tokens=256`, no thinking flag. Record whether content is non-empty and JSON-parseable.
+
+| Model | Without flag | With `chat_template_kwargs:{enable_thinking:false}` |
+|---|---|---|
+| `qwen3.5-9b` | empty content, `finish_reason:length` | clean JSON |
+| `qwen3.5-122b` | empty content, `finish_reason:length` | clean JSON |
+| `qwen3.6-27b` | empty content, `finish_reason:length` | clean JSON |
+| `minimax-m2.5` | empty content, `finish_reason:length` | clean JSON, but emits `reasoning_content` (see P5) |
+| `Llama-3.1-8B-Instruct` | clean JSON | clean JSON (flag is no-op) |
+| `Llama-3.3-70B-Instruct` | clean JSON | clean JSON (no-op) |
+| `mistral-small3.2` | clean JSON | clean JSON (no-op) |
+| `mistral-small-4-119b` | clean JSON | clean JSON (no-op) |
+| `gpt-oss-120b` | clean JSON | clean JSON (no-op) |
+| `gemma4-31b` | clean JSON | clean JSON (no-op) |
+| `apertus-70b` | clean JSON | clean JSON (no-op) |
+
+**Implication:** the flag is **per-model, opt-out for thinking models only**. The opt-in path (top-level `"thinking":true, "reasoning_effort":"medium"` from `docs.regolo.ai/models/features/thinking`) is documented for `gpt-oss-120b` but is a *different* feature — Phase 1 does not enable thinking. The `_REGOLO_THINKING_MODELS` constant in `backend/utils/llm/clients.py` enumerates the set requiring auto-injection of `enable_thinking:false`.
+
+## P5 — `reasoning_content` field
+
+| Model | Emits `choices[].message.reasoning_content` even with thinking off? |
+|---|---|
+| `minimax-m2.5` | **YES** — leaks model's internal reasoning into responses |
+| All other probed models | no |
+
+**Implication:** the `strip_reasoning_content()` helper must run before any response is persisted to chat history. Without it: bloated DB rows + leakage of reasoning tokens to clients. The helper exists in this branch's `_RegoloOpenAIProxy`; tests in `test_regolo_client.py` cover the strip path.
+
+## P6 — Latency × consistency (multi-sample, n=5)
+
+Single-shot p50/p90 against `/v1/chat/completions` with a structured-extraction prompt, `max_tokens=256`, `temperature=0.2`, run 5× per model.
+
+| Model | n | p50 | p90 | spread | failure mode |
+|---|---|---|---|---|---|
+| `mistral-small-4-119b` | 5/5 | **0.43s** | **0.44s** | ±2% | none |
+| `Llama-3.3-70B-Instruct` | 5/5 | 0.83s | 0.84s | ±1% | none |
+| `Llama-3.1-8B-Instruct` | 5/5 | 0.62s | 0.72s | ±16% | none |
+| `qwen3.5-122b` *(thinking off)* | 5/5 | 0.36s | 2.25s | bimodal | fast 80%, 6× slower 20% |
+| `qwen3.5-9b` *(thinking off)* | 4/5 | 2.47s | 42.33s | very high | one 60s timeout |
+| `qwen3.6-27b` *(thinking off)* | 1/1 | 5.62s | n/a | unknown | always slow |
+| `minimax-m2.5` *(thinking off)* | 2/5 | 59.83s | 59.83s | catastrophic | **3 of 5 calls timed out at 60s** |
+
+**Implication:** the original design's `minimax-m2.5` chat pick is **wrong**. Empirical default for chat workloads is `mistral-small-4-119b` — 2× faster than Llama-3.3-70B, 6× more consistent than `qwen3.5-122b`, equally good on tools and JSON. See the "Dispatcher decision table" patch in `REGOLO_INTEGRATION.md` for the corrected mapping.
+
+The thinking models (Qwen3.x family + MiniMax) remain in `_REGOLO_THINKING_MODELS` so the knob is auto-injected when an operator picks them via `MODEL_QOS_<FEATURE>=regolo/qwen3.5-9b`, but they are NOT defaults.
+
+## P7 — Embeddings
+
+| Model | Cost | Latency | Dimensionality |
+|---|---|---|---|
+| `Qwen3-Embedding-8B` | €0.001/req | 0.24s | **4096** |
+| `gte-Qwen2` | €0.001/req | 0.22s | 3584 |
+
+**Implication:** dimensionality differs from OpenAI `text-embedding-3-large` (3072) and Gemini `gemini-embedding-001` (3072). The embedding store must key vectors by `(provider, model, dim)` to avoid index collision when a user toggles Privacy Mode mid-account. See `EMBEDDING_MIGRATION.md` for the parallel-index strategy. Phase 1 HARD-BLOCKS embedding-dependent features (`memory_search`, `knowledge_graph_search`, `screen_activity_search`) when EU mode is on; Phase 2 ships the adapter + migration.
+
+## P8 — Vision (`qwen3-vl-32b`)
+
+Not in the PAYG `/v1/models` listing (P1). `Qwen-Image` IS listed but is image *generation*, not vision *understanding*.
+
+**Verdict:** vision is **HARD-BLOCKED** in Phase 1. The Phase 1 dispatcher decision table falls back to `gemini-3-flash-preview` for vision workloads when Privacy Mode is on, with a red `X-Privacy-Mode-Fallback: vision` banner on every request.
+
+To unblock: open a Regolo support ticket asking for `qwen3-vl-32b` PAYG availability; or upgrade to whichever plan tier exposes it. This is design-doc Open Question #2.
+
+## P9 — `response_format:{type:"json_object"}`
+
+**Deferred.** Informal observation: structured-extraction prompts return clean JSON without the field, so omitting `response_format` is fine for Phase 1. Strict-mode enforcement (does Regolo refuse to emit non-JSON when this field is set?) was not explicitly probed.
+
+**Re-probe before relying on strict-JSON guarantees.** The Phase-1 path uses prompt-engineered JSON output, validated by the existing JSON-repair flow in `utils/llm/clients.py`. If a future feature *requires* strict mode, run the probe first.
+
+## P10 — Top-level `thinking:true` opt-in
+
+**Deferred.** Per `docs.regolo.ai/models/features/thinking`, `gpt-oss-120b` accepts `"thinking": true, "reasoning_effort": "low|medium|high"` at the request body's top level. We do NOT enable thinking in Phase 1 (we *disable* it for the Qwen + MiniMax thinking-mode set via `chat_template_kwargs`), so this knob is unused. If a future feature wants `gpt-oss-120b`-with-thinking, probe the response shape first — `reasoning_content` may behave differently than the MiniMax case.
+
+## P11 — Rate limits
+
+**Deferred.** No explicit 429 was triggered during probing. Plan: instrument `_RegoloOpenAIProxy` with retry counters and `Retry-After` parsing in M1; revisit plan-tier choice with real usage data in M5.
+
+## How to re-run the probes
+
+The streaming tool-call probe is reproducible:
+
+```bash
+cd backend/tests/fixtures
+REGOLO_API_KEY=<your_key> bash capture_regolo_tool_call_stream.sh
+diff regolo_tool_call_stream.json /tmp/replay-fixture.json
+```
+
+The chat / latency / thinking-knob probes ran as one-off Python scripts driven by `urllib.request`. Re-run after any Regolo catalog change to verify our model picks remain optimal. Pseudocode:
+
+```python
+for model in CATALOG:
+    body = {"model": model, "messages": [...JSON_PROMPT...], "max_tokens": 256}
+    if model in THINKING_MODELS:
+        body["chat_template_kwargs"] = {"enable_thinking": False}
+    t0 = time.perf_counter()
+    response = POST("/v1/chat/completions", body)
+    record_latency_and_json_quality(model, t0)
+```
+
+## Cross-references
+
+- Empirical model→feature mapping derived from these probes lives in the sister repo's `docs/04-model-mapping.md` (Euraika `omi-regolo-integration` GitLab project).
+- The Phase 1 implementation in this branch (`worktree-omi-regolo-integration`) reflects the corrected picks: `_REGOLO_THINKING_MODELS` + `strip_reasoning_content()` in `backend/utils/llm/clients.py`.
+- Open Questions #1, #2 (status), #3 (deferred), #4, #5, #9 in `REGOLO_INTEGRATION.md` are resolved by these probes.

--- a/desktop/docs/regolo-probes.md
+++ b/desktop/docs/regolo-probes.md
@@ -9,7 +9,7 @@ Single source of truth for what we have empirically verified about `api.regolo.a
 | # | What | Status | Artifact |
 |---|---|---|---|
 | P1 | Auth + model catalog (`GET /v1/models`) | ✓ resolved | inline below |
-| P2 | Streaming tool-call delta shape on Llama-3.3-70B | ✓ resolved | `backend/tests/fixtures/regolo_tool_call_stream.json` (sister repo) |
+| P2 | Streaming tool-call delta shape on Llama-3.3-70B | ✓ resolved | `regolo_tool_call_stream.json` — captured in the sister Euraika repo (`/opt/projects/omi-regolo-integration/backend/tests/fixtures/`); not yet ported into this branch (M1 task) |
 | P3 | Tool-calling parity across mid/large models | ✓ resolved | inline below |
 | P4 | `chat_template_kwargs.enable_thinking:false` knob — which models require it | ✓ resolved | inline below |
 | P5 | `reasoning_content` field — which models emit it | ✓ resolved | inline below |
@@ -30,7 +30,7 @@ Single source of truth for what we have empirically verified about `api.regolo.a
 
 ## P2 — Streaming tool-call delta shape
 
-Captured fixture: `backend/tests/fixtures/regolo_tool_call_stream.json` (5 chunks, real model response from `Llama-3.3-70B-Instruct` answering `"What is the weather in Paris right now?"` with a `get_weather(city)` tool).
+Captured fixture: `regolo_tool_call_stream.json` — lives in the sister Euraika repo at `/opt/projects/omi-regolo-integration/backend/tests/fixtures/regolo_tool_call_stream.json` (5 chunks, real model response from `Llama-3.3-70B-Instruct` answering `"What is the weather in Paris right now?"` with a `get_weather(city)` tool). Porting it into this branch's `backend/tests/fixtures/` is an M1 follow-up so the replay test can run from CI.
 
 **Verdict:** OpenAI-standard. The deltas concatenate to a valid tool call:
 
@@ -42,7 +42,7 @@ chunk 4  finish_reason: "tool_calls", delta: {}
 chunk 5  [DONE]
 ```
 
-**Implication for backend:** `langchain_openai.ChatOpenAI` accumulates these natively. The custom streaming-tool-call accumulator the original design doc planned for `regolo_client.py` is **not needed** — confirmed by code review of the `_RegoloOpenAIProxy` class on this branch.
+**Implication for backend:** `langchain_openai.ChatOpenAI` accumulates these natively. The custom streaming-tool-call accumulator the original design doc planned for `regolo_client.py` is **not needed** — confirmed by code review of the `_RegoloOpenAIProxy` class in `backend/utils/llm/clients.py` on this branch.
 
 ## P3 — Tool-calling parity across models
 
@@ -76,7 +76,7 @@ Probe protocol: send a JSON-extraction prompt, `max_tokens=256`, no thinking fla
 | `gemma4-31b` | clean JSON | clean JSON (no-op) |
 | `apertus-70b` | clean JSON | clean JSON (no-op) |
 
-**Implication:** the flag is **per-model, opt-out for thinking models only**. The opt-in path (top-level `"thinking":true, "reasoning_effort":"medium"` from `docs.regolo.ai/models/features/thinking`) is documented for `gpt-oss-120b` but is a *different* feature — Phase 1 does not enable thinking. The `_REGOLO_THINKING_MODELS` constant in `backend/utils/llm/clients.py` enumerates the set requiring auto-injection of `enable_thinking:false`.
+**Implication:** the flag is **per-model, opt-out for thinking models only**. The opt-in path (top-level `"thinking":true, "reasoning_effort":"medium"` from `docs.regolo.ai/models/features/thinking`) is documented for `gpt-oss-120b` but is a *different* feature — Phase 1 does not enable thinking. On this branch, `REGOLO_DISABLE_THINKING_EXTRA_BODY` in `backend/utils/llm/clients.py:160` carries the body extension. M1 follow-up: gate the injection behind a `_REGOLO_THINKING_MODELS = frozenset(...)` (already implemented in the sister Euraika repo) so the no-op flag isn't sent to non-thinking models.
 
 ## P5 — `reasoning_content` field
 
@@ -103,7 +103,7 @@ Single-shot p50/p90 against `/v1/chat/completions` with a structured-extraction 
 
 **Implication:** the original design's `minimax-m2.5` chat pick is **wrong**. Empirical default for chat workloads is `mistral-small-4-119b` — 2× faster than Llama-3.3-70B, 6× more consistent than `qwen3.5-122b`, equally good on tools and JSON. See the "Dispatcher decision table" patch in `REGOLO_INTEGRATION.md` for the corrected mapping.
 
-The thinking models (Qwen3.x family + MiniMax) remain in `_REGOLO_THINKING_MODELS` so the knob is auto-injected when an operator picks them via `MODEL_QOS_<FEATURE>=regolo/qwen3.5-9b`, but they are NOT defaults.
+The thinking models (Qwen3.x family + MiniMax) remain reachable via operator override (`MODEL_QOS_<FEATURE>=regolo/qwen3.5-9b`) — when picked, the `REGOLO_DISABLE_THINKING_EXTRA_BODY` injection auto-disables their thinking-on default — but they are NOT defaults.
 
 ## P7 — Embeddings
 
@@ -138,13 +138,15 @@ To unblock: open a Regolo support ticket asking for `qwen3-vl-32b` PAYG availabi
 
 ## How to re-run the probes
 
-The streaming tool-call probe is reproducible:
+The streaming tool-call probe is reproducible from the sister Euraika repo (which contains both the capture script and the committed fixture):
 
 ```bash
-cd backend/tests/fixtures
+cd /opt/projects/omi-regolo-integration/backend/tests/fixtures
 REGOLO_API_KEY=<your_key> bash capture_regolo_tool_call_stream.sh
 diff regolo_tool_call_stream.json /tmp/replay-fixture.json
 ```
+
+Porting this script + fixture into this branch's `backend/tests/fixtures/` is an M1 follow-up so the replay test can run from CI without depending on the sister repo's filesystem layout.
 
 The chat / latency / thinking-knob probes ran as one-off Python scripts driven by `urllib.request`. Re-run after any Regolo catalog change to verify our model picks remain optimal. Pseudocode:
 
@@ -161,5 +163,5 @@ for model in CATALOG:
 ## Cross-references
 
 - Empirical model→feature mapping derived from these probes lives in the sister repo's `docs/04-model-mapping.md` (Euraika `omi-regolo-integration` GitLab project).
-- The Phase 1 implementation in this branch (`worktree-omi-regolo-integration`) reflects the corrected picks: `_REGOLO_THINKING_MODELS` + `strip_reasoning_content()` in `backend/utils/llm/clients.py`.
+- The Phase 1 implementation in this branch (`worktree-omi-regolo-integration`) carries `REGOLO_DISABLE_THINKING_EXTRA_BODY` and the `_RegoloOpenAIProxy` class in `backend/utils/llm/clients.py`. M1 ports the `_REGOLO_THINKING_MODELS` set + `strip_reasoning_content()` helper from the sister repo.
 - Open Questions #1, #2 (status), #3 (deferred), #4, #5, #9 in `REGOLO_INTEGRATION.md` are resolved by these probes.

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "react-instantsearch": "^7.13.0",
         "redis": "^4.7.0",
         "sharp": "^0.33.5",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.1"
@@ -260,7 +261,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1473,7 +1473,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1491,7 +1490,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1504,7 +1502,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1520,7 +1517,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -1535,7 +1531,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1545,7 +1540,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1555,14 +1549,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1746,7 +1738,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1760,7 +1751,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1770,7 +1760,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1794,7 +1783,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2810,7 +2798,7 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -2823,7 +2811,7 @@
       "version": "18.3.22",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.22.tgz",
       "integrity": "sha512-vUhG0YmQZ7kL/tmKLrD3g5zXbXXreZXB3pmROW8bg3CnLnpjkRVwUlLne7Ufa2r9yJ8+/6B73RzhAek5TBKh2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2834,7 +2822,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3401,14 +3389,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3422,7 +3408,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3679,14 +3664,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3710,7 +3693,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3794,7 +3776,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3841,7 +3822,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -3866,7 +3846,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4007,7 +3986,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4024,7 +4002,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4039,7 +4016,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4052,7 +4028,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4196,7 +4172,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dir-glob": {
@@ -4216,7 +4191,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -4251,14 +4225,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-abstract": {
@@ -5027,7 +4999,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5044,7 +5015,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5071,7 +5041,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -5106,7 +5075,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5234,7 +5202,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -5285,7 +5252,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5300,7 +5266,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5458,7 +5423,6 @@
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
       "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -5481,7 +5445,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5494,7 +5457,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5504,7 +5466,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5678,7 +5639,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5903,7 +5863,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -5956,7 +5915,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6007,7 +5965,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6061,7 +6018,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -6087,7 +6043,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -6276,7 +6231,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -6301,7 +6255,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -6320,7 +6273,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -6443,7 +6395,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -6456,7 +6407,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -6530,7 +6480,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -6568,7 +6517,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6578,7 +6526,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6615,7 +6562,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6672,7 +6618,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -6825,7 +6770,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6847,7 +6791,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6857,7 +6800,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7091,7 +7033,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7101,14 +7042,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -7147,7 +7086,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7160,7 +7098,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7170,7 +7107,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7190,7 +7126,6 @@
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
       "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7219,7 +7154,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -7237,7 +7171,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -7257,7 +7190,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7283,7 +7215,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -7311,7 +7242,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/preact": {
@@ -7500,7 +7430,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7655,7 +7584,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -7665,7 +7593,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -7748,7 +7675,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -7789,7 +7715,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7839,7 +7764,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8053,7 +7977,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8066,7 +7989,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8152,7 +8074,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -8178,6 +8099,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {
@@ -8208,7 +8139,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -8227,7 +8157,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8242,14 +8171,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8262,7 +8189,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -8404,7 +8330,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8463,7 +8388,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -8499,7 +8423,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8522,7 +8445,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -8569,7 +8491,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8605,7 +8526,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8626,7 +8546,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -8636,7 +8555,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -8694,7 +8612,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -8720,7 +8637,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -9265,7 +9181,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vaul": {
@@ -9314,7 +9229,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9429,7 +9343,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -9448,7 +9361,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9466,14 +9378,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9488,7 +9398,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9501,7 +9410,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9514,7 +9422,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -9552,7 +9459,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
       "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -43,6 +43,7 @@
     "react-instantsearch": "^7.13.0",
     "redis": "^4.7.0",
     "sharp": "^0.33.5",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.1"

--- a/web/frontend/src/app/layout.tsx
+++ b/web/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Mulish } from 'next/font/google';
+import { Toaster } from 'sonner';
 import './globals.css';
 import AppHeader from '../components/shared/app-header';
 import ConditionalFooter from '../components/shared/conditional-footer';
@@ -43,6 +44,9 @@ export default function RootLayout({
           <div className="w-full flex-grow">{children}</div>
         </main>
         <ConditionalFooter />
+        {/* Toast surface for privacy-mode fallback events + future client-side
+            notifications. Mirrors the desktop's PrivacyModeFallbackBanner. */}
+        <Toaster richColors position="top-center" />
       </body>
       <GleapInit />
       <GoogleAnalytics />

--- a/web/frontend/src/app/settings/__tests__/actions.test.mjs
+++ b/web/frontend/src/app/settings/__tests__/actions.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * Tests for the BYOK validation request shape per provider.
+ *
+ * Run: node --test web/frontend/src/app/settings/__tests__/actions.test.mjs
+ *
+ * Same node:test pattern as the other web frontend tests. Re-implements
+ * the per-provider header / URL logic inline because the source file is
+ * a 'use server' module that imports Firestore — too heavy to load under
+ * node:test. Contract is the testBYOKConnection function in actions.ts;
+ * keep the inline mapping in sync if endpoints or auth shapes change.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const PROVIDER_VALIDATION_ENDPOINT = {
+  openai: 'https://api.openai.com/v1/models',
+  anthropic: 'https://api.anthropic.com/v1/models',
+  gemini: 'https://generativelanguage.googleapis.com/v1beta/models',
+  deepgram: 'https://api.deepgram.com/v1/projects',
+  regolo: 'https://api.regolo.ai/v1/models',
+};
+
+function buildValidationRequest(provider, plaintextKey) {
+  if (!plaintextKey || !plaintextKey.trim()) {
+    return { ok: false, error: 'Key is empty' };
+  }
+  const endpoint = PROVIDER_VALIDATION_ENDPOINT[provider];
+  if (!endpoint) return { ok: false, error: `No validation endpoint for ${provider}` };
+
+  const trimmed = plaintextKey.trim();
+  const init = { method: 'GET', cache: 'no-store' };
+  let url = endpoint;
+
+  if (provider === 'anthropic') {
+    init.headers = { 'x-api-key': trimmed, 'anthropic-version': '2023-06-01' };
+  } else if (provider === 'gemini') {
+    url = `${endpoint}?key=${encodeURIComponent(trimmed)}`;
+  } else if (provider === 'deepgram') {
+    init.headers = { Authorization: `Token ${trimmed}` };
+  } else {
+    init.headers = { Authorization: `Bearer ${trimmed}` };
+  }
+  return { url, init };
+}
+
+describe('testBYOKConnection request shape', () => {
+  it('rejects empty / whitespace-only keys before any HTTP call', () => {
+    assert.deepEqual(buildValidationRequest('openai', ''), { ok: false, error: 'Key is empty' });
+    assert.deepEqual(buildValidationRequest('openai', '   '), { ok: false, error: 'Key is empty' });
+  });
+
+  it('OpenAI uses Bearer auth on /v1/models', () => {
+    const r = buildValidationRequest('openai', 'sk-test-abc');
+    assert.equal(r.url, 'https://api.openai.com/v1/models');
+    assert.equal(r.init.headers.Authorization, 'Bearer sk-test-abc');
+  });
+
+  it('Regolo uses Bearer auth on its /v1/models', () => {
+    const r = buildValidationRequest('regolo', 'reg-test-xyz');
+    assert.equal(r.url, 'https://api.regolo.ai/v1/models');
+    assert.equal(r.init.headers.Authorization, 'Bearer reg-test-xyz');
+  });
+
+  it('Anthropic uses x-api-key + anthropic-version header (NOT Bearer)', () => {
+    const r = buildValidationRequest('anthropic', 'ant-test');
+    assert.equal(r.url, 'https://api.anthropic.com/v1/models');
+    assert.equal(r.init.headers['x-api-key'], 'ant-test');
+    assert.equal(r.init.headers['anthropic-version'], '2023-06-01');
+    assert.equal(r.init.headers.Authorization, undefined);
+  });
+
+  it('Gemini uses query-string key (key=...) NOT a header', () => {
+    const r = buildValidationRequest('gemini', 'gem-test+special chars');
+    assert.match(r.url, /^https:\/\/generativelanguage\.googleapis\.com\/v1beta\/models\?key=/);
+    assert.match(r.url, /gem-test%2Bspecial%20chars/);
+    assert.equal(r.init.headers, undefined);
+  });
+
+  it('Deepgram uses Token auth scheme (NOT Bearer)', () => {
+    const r = buildValidationRequest('deepgram', 'dg-test');
+    assert.equal(r.url, 'https://api.deepgram.com/v1/projects');
+    assert.equal(r.init.headers.Authorization, 'Token dg-test');
+  });
+
+  it('trims surrounding whitespace before sending', () => {
+    const r = buildValidationRequest('openai', '  sk-test-abc  ');
+    assert.equal(r.init.headers.Authorization, 'Bearer sk-test-abc');
+  });
+
+  it('rejects unknown provider', () => {
+    const r = buildValidationRequest('not-a-provider', 'k');
+    assert.equal(r.ok, false);
+    assert.match(r.error, /No validation endpoint/);
+  });
+});

--- a/web/frontend/src/app/settings/actions.ts
+++ b/web/frontend/src/app/settings/actions.ts
@@ -1,0 +1,128 @@
+'use server';
+
+/**
+ * Server Actions exposed to the /settings UI.
+ *
+ * The UI component (`page.tsx`) is a client component because Firebase Auth
+ * state is needed to extract the uid + Firebase ID token. These actions are
+ * the server-side bridge that wraps the M4.1 Firestore prefs store + the
+ * BYOK validator. Plaintext BYOK keys live only inside these actions and
+ * the encryption module — never returned to the client, never logged.
+ *
+ * Auth: every action takes the Firebase ID token as the first argument and
+ * verifies it against Firebase Admin to extract the uid. (For now we trust
+ * the client-supplied uid; once Firebase Admin is wired in, swap the
+ * `authenticateRequest` stub for a real verification step.)
+ */
+
+import {
+  BYOK_PROVIDERS,
+  setBYOKKey as storeBYOKKey,
+  setEuPrivacyMode as storeEuPrivacyMode,
+  getUserSettings,
+  type BYOKProvider,
+} from '@/src/lib/firestore/user-settings';
+
+const PROVIDER_VALIDATION_ENDPOINT: Record<BYOKProvider, string | null> = {
+  // Provider-direct probes; same pattern as desktop's BYOKValidator.swift.
+  openai: 'https://api.openai.com/v1/models',
+  anthropic: 'https://api.anthropic.com/v1/models',
+  gemini: 'https://generativelanguage.googleapis.com/v1beta/models',
+  deepgram: 'https://api.deepgram.com/v1/projects',
+  regolo: 'https://api.regolo.ai/v1/models',
+};
+
+export interface SettingsSnapshot {
+  eu_privacy_mode: boolean;
+  configured_providers: BYOKProvider[];
+}
+
+/**
+ * Read the user's settings snapshot for display. Never returns plaintext
+ * keys — only which providers are configured.
+ */
+export async function fetchSettingsSnapshot(uid: string): Promise<SettingsSnapshot> {
+  if (!uid) throw new Error('uid is required');
+  const settings = await getUserSettings(uid);
+  return {
+    eu_privacy_mode: settings.eu_privacy_mode,
+    configured_providers: BYOK_PROVIDERS.filter((p) => settings.byok_keys[p]),
+  };
+}
+
+export async function saveBYOKKey(
+  uid: string,
+  provider: BYOKProvider,
+  plaintextKey: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!uid) return { ok: false, error: 'uid is required' };
+  try {
+    await storeBYOKKey(uid, provider, plaintextKey.trim());
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };
+  }
+}
+
+export async function saveEuPrivacyMode(
+  uid: string,
+  enabled: boolean,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!uid) return { ok: false, error: 'uid is required' };
+  try {
+    await storeEuPrivacyMode(uid, enabled);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };
+  }
+}
+
+/**
+ * Test a plaintext key against the provider's models endpoint without
+ * persisting it. The plaintext is sent server-side to the provider only;
+ * we don't store anything from this call. Mirrors desktop's BYOKValidator
+ * behavior — see desktop/Desktop/Sources/BYOKValidator.swift.
+ *
+ * Returns ok=true on 2xx, ok=false with a short error reason otherwise.
+ */
+export async function testBYOKConnection(
+  provider: BYOKProvider,
+  plaintextKey: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!plaintextKey || !plaintextKey.trim()) {
+    return { ok: false, error: 'Key is empty' };
+  }
+
+  const endpoint = PROVIDER_VALIDATION_ENDPOINT[provider];
+  if (!endpoint) {
+    return { ok: false, error: `No validation endpoint for ${provider}` };
+  }
+
+  // Each provider has its own auth header convention. Match the desktop's
+  // BYOKValidator pattern: most use Authorization: Bearer; Anthropic uses
+  // x-api-key; Gemini puts the key in a query param.
+  const trimmed = plaintextKey.trim();
+  const init: RequestInit = { method: 'GET', cache: 'no-store' };
+  let url = endpoint;
+
+  if (provider === 'anthropic') {
+    init.headers = { 'x-api-key': trimmed, 'anthropic-version': '2023-06-01' };
+  } else if (provider === 'gemini') {
+    url = `${endpoint}?key=${encodeURIComponent(trimmed)}`;
+  } else if (provider === 'deepgram') {
+    init.headers = { Authorization: `Token ${trimmed}` };
+  } else {
+    init.headers = { Authorization: `Bearer ${trimmed}` };
+  }
+
+  try {
+    const res = await fetch(url, init);
+    if (res.ok) return { ok: true };
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, error: `Rejected (HTTP ${res.status})` };
+    }
+    return { ok: false, error: `HTTP ${res.status}` };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'network error' };
+  }
+}

--- a/web/frontend/src/app/settings/page.tsx
+++ b/web/frontend/src/app/settings/page.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useAuth } from '@/src/hooks/useAuth';
+import { Button } from '@/src/components/ui/button';
+import { Card } from '@/src/components/ui/card';
+import { Input } from '@/src/components/ui/input';
+import { Label } from '@/src/components/ui/label';
+import {
+  fetchSettingsSnapshot,
+  saveBYOKKey,
+  saveEuPrivacyMode,
+  testBYOKConnection,
+  type SettingsSnapshot,
+} from '@/src/app/settings/actions';
+
+type Provider = 'openai' | 'anthropic' | 'gemini' | 'deepgram' | 'regolo';
+
+interface ProviderRow {
+  id: Provider;
+  label: string;
+  subtitle: string;
+}
+
+const PROVIDER_ROWS: ProviderRow[] = [
+  { id: 'openai', label: 'OpenAI API Key', subtitle: 'For GPT calls.' },
+  { id: 'anthropic', label: 'Anthropic API Key', subtitle: 'For chat (Claude).' },
+  {
+    id: 'gemini',
+    label: 'Gemini API Key',
+    subtitle: 'For proactive AI (memory, tasks, insights, focus).',
+  },
+  { id: 'deepgram', label: 'Deepgram API Key', subtitle: 'For live transcription.' },
+  {
+    id: 'regolo',
+    label: 'Regolo API Key',
+    subtitle: 'For EU Privacy Mode (Italy-hosted, zero retention). Optional.',
+  },
+];
+
+type ConnectionStatus =
+  | { kind: 'idle' }
+  | { kind: 'testing' }
+  | { kind: 'ok' }
+  | { kind: 'error'; message: string };
+
+export default function SettingsPage() {
+  const { user, loading, isAuthenticated, signIn } = useAuth();
+
+  if (loading) {
+    return <div className="mx-auto max-w-2xl p-8">Loading…</div>;
+  }
+  if (!isAuthenticated || !user) {
+    return (
+      <div className="mx-auto max-w-2xl p-8">
+        <h1 className="text-2xl font-semibold">Settings</h1>
+        <p className="mt-4 text-sm text-zinc-400">
+          Sign in to manage your API keys and EU Privacy Mode preferences.
+        </p>
+        <Button className="mt-6" onClick={signIn}>
+          Sign in with Google
+        </Button>
+      </div>
+    );
+  }
+
+  return <SettingsContent uid={user.uid} />;
+}
+
+function SettingsContent({ uid }: { uid: string }) {
+  const [snapshot, setSnapshot] = useState<SettingsSnapshot | null>(null);
+  const [keyDrafts, setKeyDrafts] = useState<Record<Provider, string>>({
+    openai: '',
+    anthropic: '',
+    gemini: '',
+    deepgram: '',
+    regolo: '',
+  });
+  const [statuses, setStatuses] = useState<Record<Provider, ConnectionStatus>>({
+    openai: { kind: 'idle' },
+    anthropic: { kind: 'idle' },
+    gemini: { kind: 'idle' },
+    deepgram: { kind: 'idle' },
+    regolo: { kind: 'idle' },
+  });
+  const [pending, startTransition] = useTransition();
+
+  useEffect(() => {
+    fetchSettingsSnapshot(uid).then(setSnapshot).catch(() => setSnapshot(null));
+  }, [uid]);
+
+  const handleSaveKey = (provider: Provider) => {
+    const draft = keyDrafts[provider];
+    startTransition(async () => {
+      const result = await saveBYOKKey(uid, provider, draft);
+      if (result.ok) {
+        setKeyDrafts((d) => ({ ...d, [provider]: '' }));
+        const fresh = await fetchSettingsSnapshot(uid);
+        setSnapshot(fresh);
+      } else {
+        setStatuses((s) => ({ ...s, [provider]: { kind: 'error', message: result.error } }));
+      }
+    });
+  };
+
+  const handleTestKey = (provider: Provider) => {
+    const draft = keyDrafts[provider];
+    setStatuses((s) => ({ ...s, [provider]: { kind: 'testing' } }));
+    startTransition(async () => {
+      const result = await testBYOKConnection(provider, draft);
+      setStatuses((s) => ({
+        ...s,
+        [provider]: result.ok ? { kind: 'ok' } : { kind: 'error', message: result.error },
+      }));
+    });
+  };
+
+  const handleClearKey = (provider: Provider) => {
+    startTransition(async () => {
+      await saveBYOKKey(uid, provider, '');
+      const fresh = await fetchSettingsSnapshot(uid);
+      setSnapshot(fresh);
+      setStatuses((s) => ({ ...s, [provider]: { kind: 'idle' } }));
+    });
+  };
+
+  const handlePrivacyToggle = () => {
+    if (!snapshot) return;
+    const next = !snapshot.eu_privacy_mode;
+    setSnapshot({ ...snapshot, eu_privacy_mode: next });
+    startTransition(async () => {
+      await saveEuPrivacyMode(uid, next);
+    });
+  };
+
+  const isConfigured = (p: Provider) => snapshot?.configured_providers.includes(p) ?? false;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-8 p-8">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+
+      {/* EU Privacy Mode */}
+      <Card className="space-y-3 p-6">
+        <div className="flex items-start gap-3">
+          <div className="flex-1">
+            <h2 className="text-lg font-medium">EU Privacy Mode</h2>
+            <p className="mt-1 text-sm text-zinc-400">
+              Route AI traffic through regolo.ai in Italy — GDPR-compliant, zero data retention.
+              Requires a Regolo API key configured below. Vision features stay on Gemini; you'll
+              see a banner per request that leaves the EU.
+            </p>
+          </div>
+          <Button
+            variant={snapshot?.eu_privacy_mode ? 'default' : 'outline'}
+            onClick={handlePrivacyToggle}
+            disabled={!snapshot || pending}
+            aria-pressed={snapshot?.eu_privacy_mode}
+          >
+            {snapshot?.eu_privacy_mode ? 'On' : 'Off'}
+          </Button>
+        </div>
+      </Card>
+
+      {/* Developer API Keys */}
+      <section className="space-y-4">
+        <h2 className="text-lg font-medium">Developer API Keys</h2>
+        <p className="text-sm text-zinc-400">
+          Optional. Bring your own keys to use your own provider quotas. Keys are encrypted at rest
+          (AES-GCM with a per-user-derived key) and never shown back to you.
+        </p>
+
+        {PROVIDER_ROWS.map((row) => (
+          <Card key={row.id} className="space-y-3 p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <Label htmlFor={`key-${row.id}`} className="font-medium">
+                  {row.label}
+                </Label>
+                <p className="mt-1 text-sm text-zinc-400">{row.subtitle}</p>
+              </div>
+              {isConfigured(row.id) && (
+                <span className="text-xs uppercase tracking-wide text-emerald-500">
+                  Configured
+                </span>
+              )}
+            </div>
+            <Input
+              id={`key-${row.id}`}
+              type="password"
+              autoComplete="off"
+              placeholder={isConfigured(row.id) ? '•••• key on file ••••' : 'Paste key…'}
+              value={keyDrafts[row.id]}
+              onChange={(e) =>
+                setKeyDrafts((d) => ({ ...d, [row.id]: e.target.value }))
+              }
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                onClick={() => handleSaveKey(row.id)}
+                disabled={pending || keyDrafts[row.id].trim() === ''}
+              >
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => handleTestKey(row.id)}
+                disabled={pending || keyDrafts[row.id].trim() === ''}
+              >
+                Test connection
+              </Button>
+              {isConfigured(row.id) && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleClearKey(row.id)}
+                  disabled={pending}
+                >
+                  Clear
+                </Button>
+              )}
+              {statuses[row.id].kind === 'testing' && (
+                <span className="text-xs text-zinc-400">Testing…</span>
+              )}
+              {statuses[row.id].kind === 'ok' && (
+                <span className="text-xs text-emerald-500">✓ Connection OK</span>
+              )}
+              {statuses[row.id].kind === 'error' && (
+                <span className="text-xs text-red-500">
+                  ✗ {(statuses[row.id] as { kind: 'error'; message: string }).message}
+                </span>
+              )}
+            </div>
+          </Card>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/web/frontend/src/components/shared/app-header.tsx
+++ b/web/frontend/src/components/shared/app-header.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import ShareButton from '../memories/share-button';
+import PrivacyModeShield from './privacy-mode-shield';
 import { usePathname, useRouter } from 'next/navigation';
 import { useAuth } from '../../hooks/useAuth';
 
@@ -221,6 +222,7 @@ export default function AppHeader({
         </h1>
 
         <nav className="hidden items-center space-x-4 md:flex">
+          <PrivacyModeShield />
           {navItems.map((item) => (
             <button
               key={item.label}

--- a/web/frontend/src/components/shared/privacy-mode-shield.tsx
+++ b/web/frontend/src/components/shared/privacy-mode-shield.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+/**
+ * Small shield indicator surfaced in the app header when the authenticated
+ * user has EU Privacy Mode enabled. Mirrors the desktop's status-bar shield
+ * (see desktop/Desktop/Sources/OmiApp.swift::applyMenuBarPrivacyShield).
+ *
+ * Behavior:
+ * - Hidden when the user is anonymous, when Privacy Mode is off, or while
+ *   the snapshot is loading. No layout shift in the header chrome.
+ * - Re-fetches the snapshot whenever the window regains focus so a toggle
+ *   in /settings reflects in the header without a full page reload.
+ *
+ * Renders a single SF-Symbols-style "shield" glyph + accessible label.
+ * Intentionally subtle — the EU Privacy claim is communicated by the
+ * /settings card; this is a passive indicator, not a CTA.
+ */
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/src/hooks/useAuth';
+import { fetchSettingsSnapshot } from '@/src/app/settings/actions';
+
+export default function PrivacyModeShield() {
+  const { user, isAuthenticated } = useAuth();
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !user) {
+      setEnabled(null);
+      return;
+    }
+
+    let cancelled = false;
+    const refresh = () => {
+      fetchSettingsSnapshot(user.uid)
+        .then((snap) => {
+          if (!cancelled) setEnabled(snap.eu_privacy_mode);
+        })
+        .catch(() => {
+          if (!cancelled) setEnabled(null);
+        });
+    };
+
+    refresh();
+    window.addEventListener('focus', refresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', refresh);
+    };
+  }, [isAuthenticated, user]);
+
+  if (!enabled) return null;
+
+  return (
+    <span
+      role="status"
+      aria-label="EU Privacy Mode is on"
+      title="EU Privacy Mode is on — AI traffic routes through regolo.ai (Italy)"
+      className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-500"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="h-3.5 w-3.5"
+        aria-hidden="true"
+      >
+        <path d="M12 2 4 5v6c0 5 3.5 9.5 8 11 4.5-1.5 8-6 8-11V5l-8-3zm0 2.18 6 2.25v4.57c0 4.07-2.74 7.83-6 9.07-3.26-1.24-6-5-6-9.07V6.43l6-2.25z" />
+      </svg>
+      EU Privacy
+    </span>
+  );
+}

--- a/web/frontend/src/constants/envConfig.ts
+++ b/web/frontend/src/constants/envConfig.ts
@@ -9,6 +9,11 @@ const envConfig = {
   ALGOLIA_INDEX_NAME: process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME ?? 'memories',
   ADMIN_KEY: process.env.ADMIN_KEY,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  // Server-side only — used by web/frontend/src/lib/firestore/encryption.ts to
+  // derive per-user AES-GCM keys for BYOK encryption-at-rest. Must be 32+ bytes
+  // of cryptographic randomness, base64-encoded. Never set as NEXT_PUBLIC_*.
+  // See desktop/docs/M4-decisions.md § Decision 1 for rationale.
+  BYOK_MASTER_PEPPER: process.env.BYOK_MASTER_PEPPER,
 };
 
 export default envConfig;

--- a/web/frontend/src/hooks/__tests__/privacyFallbackMessage.test.mjs
+++ b/web/frontend/src/hooks/__tests__/privacyFallbackMessage.test.mjs
@@ -1,0 +1,55 @@
+/**
+ * Tests for the privacyFallbackMessage pure mapper.
+ *
+ * Run: node --test web/frontend/src/hooks/__tests__/privacyFallbackMessage.test.mjs
+ *
+ * Same node:test pattern as src/lib/firestore/__tests__/encryption.test.mjs.
+ * Re-implements the mapping inline because the source uses 'use client' +
+ * sonner import which won't load under node:test.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const REASON_COPY = {
+  vision_unsupported:
+    "Vision isn't available on regolo.ai — this screenshot was processed by Gemini.",
+  regolo_outage: 'Regolo.ai is unreachable — falling back to your regular LLM provider.',
+  regolo_rate_limited: 'Regolo.ai rate limit hit — falling back to your regular LLM provider.',
+  no_regolo_key: 'EU Privacy Mode is on but no Regolo key is configured. Add one in Settings.',
+  other: 'This request left the EU.',
+};
+
+function privacyFallbackMessage(rawReason) {
+  const reason = rawReason in REASON_COPY ? rawReason : 'other';
+  return REASON_COPY[reason];
+}
+
+describe('privacyFallbackMessage', () => {
+  it('maps each known reason to its specific copy', () => {
+    assert.match(privacyFallbackMessage('vision_unsupported'), /Vision isn't available/);
+    assert.match(privacyFallbackMessage('regolo_outage'), /unreachable/);
+    assert.match(privacyFallbackMessage('regolo_rate_limited'), /rate limit hit/);
+    assert.match(privacyFallbackMessage('no_regolo_key'), /no Regolo key is configured/);
+    assert.match(privacyFallbackMessage('other'), /left the EU/);
+  });
+
+  it('falls back to generic copy for unknown reasons', () => {
+    assert.equal(privacyFallbackMessage('unknown_xyz'), REASON_COPY.other);
+    assert.equal(privacyFallbackMessage(''), REASON_COPY.other);
+    assert.equal(privacyFallbackMessage('VISION_UNSUPPORTED'), REASON_COPY.other); // case-sensitive on purpose
+  });
+
+  it('matches the desktop observer reason set 1:1', () => {
+    // These must be in sync with desktop/Desktop/Sources/PrivacyModeFallbackObserver.swift
+    // and backend/utils/byok.py PRIVACY_FALLBACK_* constants.
+    const expected = [
+      'vision_unsupported',
+      'regolo_outage',
+      'regolo_rate_limited',
+      'no_regolo_key',
+      'other',
+    ];
+    assert.deepEqual(Object.keys(REASON_COPY).sort(), expected.sort());
+  });
+});

--- a/web/frontend/src/hooks/usePrivacyFallbackToast.ts
+++ b/web/frontend/src/hooks/usePrivacyFallbackToast.ts
@@ -1,0 +1,72 @@
+'use client';
+
+/**
+ * Notify the user when an EU Privacy Mode request had to fall back to a
+ * non-EU provider. Mirrors the desktop's `PrivacyModeFallbackObserver`
+ * (`desktop/Desktop/Sources/PrivacyModeFallbackObserver.swift`) reason
+ * enum and copy so the two surfaces feel consistent.
+ *
+ * Usage:
+ * ```ts
+ * 'use client';
+ * const notify = usePrivacyFallbackToast();
+ * // After a backend call returns:
+ * const reason = response.headers.get('X-Privacy-Mode-Fallback');
+ * if (reason) notify(reason);
+ * ```
+ *
+ * Backend contract: when the user sent `X-Privacy-Mode: on` but the
+ * request could not actually be served by regolo.ai, the response carries
+ * `X-Privacy-Mode-Fallback: <reason>`. Reasons map to friendly copy below;
+ * unknown reasons fall back to a generic message rather than dropping
+ * silently.
+ *
+ * Requires `<Toaster />` (from sonner) to be mounted in the app's root
+ * layout — see `src/app/layout.tsx`.
+ */
+
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Backend-defined reason tokens — kept in sync with the
+ * PRIVACY_FALLBACK_* constants in backend/utils/byok.py and the desktop
+ * observer's `Reason` enum. Unknown reasons surface as `other`.
+ */
+export type PrivacyFallbackReason =
+  | 'vision_unsupported'
+  | 'regolo_outage'
+  | 'regolo_rate_limited'
+  | 'no_regolo_key'
+  | 'other';
+
+const REASON_COPY: Record<PrivacyFallbackReason, string> = {
+  vision_unsupported:
+    "Vision isn't available on regolo.ai — this screenshot was processed by Gemini.",
+  regolo_outage: 'Regolo.ai is unreachable — falling back to your regular LLM provider.',
+  regolo_rate_limited: 'Regolo.ai rate limit hit — falling back to your regular LLM provider.',
+  no_regolo_key: 'EU Privacy Mode is on but no Regolo key is configured. Add one in Settings.',
+  other: 'This request left the EU.',
+};
+
+/** Pure mapping from raw header value → friendly copy. Exported for tests. */
+export function privacyFallbackMessage(rawReason: string): string {
+  const reason = (rawReason as PrivacyFallbackReason) in REASON_COPY
+    ? (rawReason as PrivacyFallbackReason)
+    : 'other';
+  return REASON_COPY[reason];
+}
+
+export function usePrivacyFallbackToast() {
+  return useCallback((rawReason: string) => {
+    const message = privacyFallbackMessage(rawReason);
+    toast.error(message, { duration: 6000, dismissible: true });
+  }, []);
+}
+
+/**
+ * Non-hook helper for non-React contexts (Server Actions handing back
+ * results to a client component, etc.). Same mapping; caller is
+ * responsible for invoking the toast on the client side.
+ */
+export const PRIVACY_FALLBACK_REASONS = REASON_COPY;

--- a/web/frontend/src/lib/api/__tests__/regolo-forwarder.test.mjs
+++ b/web/frontend/src/lib/api/__tests__/regolo-forwarder.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * Tests for the regolo-forwarder pure header-assembly logic.
+ *
+ * Run: node --test web/frontend/src/lib/api/__tests__/regolo-forwarder.test.mjs
+ *
+ * Same node:test pattern as the M4.1 + M4.5 tests. Re-implements the pure
+ * mapping inline because the source uses Next.js path aliases (@/src/...)
+ * that node:test can't resolve. Contract is documented at the top of
+ * regolo-forwarder.ts; keep the inline copy in sync.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const BYOK_PROVIDERS = ['openai', 'anthropic', 'gemini', 'deepgram', 'regolo'];
+
+const PROVIDER_HEADER = {
+  openai: 'X-BYOK-OpenAI',
+  anthropic: 'X-BYOK-Anthropic',
+  gemini: 'X-BYOK-Gemini',
+  deepgram: 'X-BYOK-Deepgram',
+  regolo: 'X-BYOK-Regolo',
+};
+
+function buildHeadersFromSettings(settings, idToken, resolveByokKey, options = {}) {
+  if (!idToken) throw new Error('idToken is required for backend header forwarding');
+
+  const headers = new Headers(options.extraHeaders);
+  headers.set('Authorization', `Bearer ${idToken}`);
+
+  for (const provider of BYOK_PROVIDERS) {
+    if (!settings.byok_keys[provider]) continue;
+    const plaintext = resolveByokKey(provider);
+    if (plaintext) headers.set(PROVIDER_HEADER[provider], plaintext);
+  }
+
+  if (settings.eu_privacy_mode) {
+    headers.set('X-Privacy-Mode', 'on');
+  }
+
+  return headers;
+}
+
+const stubResolver = (keys) => (provider) => keys[provider] ?? null;
+
+describe('buildHeadersFromSettings', () => {
+  it('always sets Authorization Bearer with the id token', () => {
+    const h = buildHeadersFromSettings(
+      { eu_privacy_mode: false, byok_keys: {} },
+      'tok-abc',
+      stubResolver({}),
+    );
+    assert.equal(h.get('authorization'), 'Bearer tok-abc');
+  });
+
+  it('throws when idToken is empty', () => {
+    assert.throws(
+      () =>
+        buildHeadersFromSettings({ eu_privacy_mode: false, byok_keys: {} }, '', stubResolver({})),
+      /idToken is required/,
+    );
+  });
+
+  it('omits Privacy Mode header when toggle is off', () => {
+    const h = buildHeadersFromSettings(
+      { eu_privacy_mode: false, byok_keys: {} },
+      'tok-abc',
+      stubResolver({}),
+    );
+    assert.equal(h.get('x-privacy-mode'), null);
+  });
+
+  it('sets X-Privacy-Mode: on when toggle is true', () => {
+    const h = buildHeadersFromSettings(
+      { eu_privacy_mode: true, byok_keys: {} },
+      'tok-abc',
+      stubResolver({}),
+    );
+    assert.equal(h.get('x-privacy-mode'), 'on');
+  });
+
+  it('forwards X-BYOK-* headers for configured providers only', () => {
+    const settings = {
+      eu_privacy_mode: false,
+      byok_keys: {
+        // Three providers configured (these would be encrypted shapes in real
+        // Firestore docs; presence/absence is what drives header inclusion).
+        openai: { ciphertext: 'x', iv: 'y', hash: 'z' },
+        regolo: { ciphertext: 'x', iv: 'y', hash: 'z' },
+        anthropic: { ciphertext: 'x', iv: 'y', hash: 'z' },
+      },
+    };
+    const h = buildHeadersFromSettings(
+      settings,
+      'tok-abc',
+      stubResolver({
+        openai: 'sk-openai-plain',
+        regolo: 'reg-plain',
+        anthropic: 'ant-plain',
+      }),
+    );
+    assert.equal(h.get('x-byok-openai'), 'sk-openai-plain');
+    assert.equal(h.get('x-byok-anthropic'), 'ant-plain');
+    assert.equal(h.get('x-byok-regolo'), 'reg-plain');
+    // Unconfigured providers must NOT have a header.
+    assert.equal(h.get('x-byok-gemini'), null);
+    assert.equal(h.get('x-byok-deepgram'), null);
+  });
+
+  it('skips a configured provider whose decryption returned null', () => {
+    // E.g. ciphertext is present but the pepper rotated and decryption
+    // failed gracefully. Forwarder should not send a malformed empty header.
+    const settings = {
+      eu_privacy_mode: false,
+      byok_keys: { openai: { ciphertext: 'x', iv: 'y', hash: 'z' } },
+    };
+    const h = buildHeadersFromSettings(
+      settings,
+      'tok-abc',
+      stubResolver({ openai: null }),
+    );
+    assert.equal(h.get('x-byok-openai'), null);
+    // Authorization still set.
+    assert.equal(h.get('authorization'), 'Bearer tok-abc');
+  });
+
+  it('merges caller-supplied extra headers, never overwrites Authorization', () => {
+    const h = buildHeadersFromSettings(
+      { eu_privacy_mode: false, byok_keys: {} },
+      'tok-abc',
+      stubResolver({}),
+      { extraHeaders: { 'Content-Type': 'application/json', Authorization: 'Bearer SHOULD-LOSE' } },
+    );
+    assert.equal(h.get('content-type'), 'application/json');
+    // Forwarder's Authorization wins over caller's.
+    assert.equal(h.get('authorization'), 'Bearer tok-abc');
+  });
+
+  it('combines BYOK forwarding + Privacy Mode + extra headers in one call', () => {
+    const settings = {
+      eu_privacy_mode: true,
+      byok_keys: {
+        regolo: { ciphertext: 'x', iv: 'y', hash: 'z' },
+      },
+    };
+    const h = buildHeadersFromSettings(
+      settings,
+      'tok-abc',
+      stubResolver({ regolo: 'reg-plain' }),
+      { extraHeaders: { 'X-Trace-Id': 'trace-42' } },
+    );
+    assert.equal(h.get('authorization'), 'Bearer tok-abc');
+    assert.equal(h.get('x-byok-regolo'), 'reg-plain');
+    assert.equal(h.get('x-privacy-mode'), 'on');
+    assert.equal(h.get('x-trace-id'), 'trace-42');
+  });
+});

--- a/web/frontend/src/lib/api/regolo-forwarder.ts
+++ b/web/frontend/src/lib/api/regolo-forwarder.ts
@@ -1,0 +1,110 @@
+/**
+ * Header forwarder for backend-routed API calls.
+ *
+ * Reads the user's per-account settings (BYOK keys + EU Privacy Mode flag)
+ * server-side and assembles the headers that omi backend's M1 dispatcher
+ * needs to make the right routing decision:
+ *
+ * - `Authorization: Bearer <firebase-id-token>` always present so the
+ *   backend can resolve the user.
+ * - `X-BYOK-<Provider>: <plaintext-key>` for each provider the user has
+ *   configured. Decryption happens here (server-side only) — plaintext
+ *   never leaves this process and never persists.
+ * - `X-Privacy-Mode: on` when the user has EU Privacy Mode enabled.
+ *
+ * Server-only — must NEVER ship in the browser bundle. Importers should be
+ * Server Actions or route handlers.
+ *
+ * Mirrors the desktop's APIClient header forwarding (see
+ * desktop/Desktop/Sources/APIClient.swift on the same branch).
+ */
+
+import {
+  BYOK_PROVIDERS,
+  getBYOKKeyForBackendForwarding,
+  getUserSettings,
+  type BYOKProvider,
+  type UserSettings,
+} from '@/src/lib/firestore/user-settings';
+
+const PROVIDER_HEADER: Record<BYOKProvider, string> = {
+  openai: 'X-BYOK-OpenAI',
+  anthropic: 'X-BYOK-Anthropic',
+  gemini: 'X-BYOK-Gemini',
+  deepgram: 'X-BYOK-Deepgram',
+  regolo: 'X-BYOK-Regolo',
+};
+
+export interface ForwarderOptions {
+  /** Additional headers the caller wants merged in (e.g. Content-Type). */
+  extraHeaders?: Record<string, string>;
+}
+
+/**
+ * Pure mapping from `(settings, idToken, byokKeyResolver, options)` to a
+ * Headers object. Exported for tests so we can exercise the assembly logic
+ * without a live Firestore connection or webcrypto-derived keys.
+ */
+export function buildHeadersFromSettings(
+  settings: UserSettings,
+  idToken: string,
+  /** Synchronous resolver: provider → plaintext key (or null). Used by tests
+   *  with stubbed keys; production path uses the async getBYOKKeyForBackendForwarding. */
+  resolveByokKey: (provider: BYOKProvider) => string | null,
+  options: ForwarderOptions = {},
+): Headers {
+  if (!idToken) {
+    throw new Error('idToken is required for backend header forwarding');
+  }
+
+  const headers = new Headers(options.extraHeaders);
+  headers.set('Authorization', `Bearer ${idToken}`);
+
+  for (const provider of BYOK_PROVIDERS) {
+    if (!settings.byok_keys[provider]) continue;
+    const plaintext = resolveByokKey(provider);
+    if (plaintext) headers.set(PROVIDER_HEADER[provider], plaintext);
+  }
+
+  if (settings.eu_privacy_mode) {
+    headers.set('X-Privacy-Mode', 'on');
+  }
+
+  return headers;
+}
+
+/**
+ * Production path: fetch user settings from Firestore, decrypt configured
+ * BYOK keys, assemble the Headers object. Caller passes the user's UID and
+ * Firebase ID token; the rest is read from `users/{uid}/settings/profile`.
+ *
+ * The returned Headers object is freshly built per call — callers can
+ * mutate it freely (e.g. set Content-Type) without affecting other calls.
+ */
+export async function buildBackendHeaders(
+  uid: string,
+  idToken: string,
+  options: ForwarderOptions = {},
+): Promise<Headers> {
+  if (!uid) throw new Error('uid is required');
+
+  const settings = await getUserSettings(uid);
+
+  // Decrypt every configured BYOK key once up-front. We need them sync
+  // for buildHeadersFromSettings, so resolve the promises into a map first.
+  const plaintextByProvider = new Map<BYOKProvider, string | null>();
+  for (const provider of BYOK_PROVIDERS) {
+    if (!settings.byok_keys[provider]) {
+      plaintextByProvider.set(provider, null);
+      continue;
+    }
+    plaintextByProvider.set(provider, await getBYOKKeyForBackendForwarding(uid, provider));
+  }
+
+  return buildHeadersFromSettings(
+    settings,
+    idToken,
+    (provider) => plaintextByProvider.get(provider) ?? null,
+    options,
+  );
+}

--- a/web/frontend/src/lib/firebase.ts
+++ b/web/frontend/src/lib/firebase.ts
@@ -8,6 +8,7 @@ import {
   onAuthStateChanged,
   User,
 } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 
 // Firebase configuration
 const firebaseConfig = {
@@ -25,6 +26,11 @@ const app = initializeApp(firebaseConfig);
 
 // Initialize Firebase Auth and get a reference to the service
 export const auth = getAuth(app);
+
+// Firestore handle — used by web/frontend/src/lib/firestore/* for the user-
+// settings store (M4.1 onward). Same Firebase project as Auth so the security
+// rules can pin reads/writes to `request.auth.uid`.
+export const db = getFirestore(app);
 
 // Initialize Google Auth Provider
 const googleProvider = new GoogleAuthProvider();

--- a/web/frontend/src/lib/firestore/__tests__/encryption.test.mjs
+++ b/web/frontend/src/lib/firestore/__tests__/encryption.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * Tests for BYOK encryption-at-rest.
+ *
+ * Run: node --test web/frontend/src/lib/firestore/__tests__/encryption.test.mjs
+ *
+ * Uses Node.js built-in test runner (node:test) — same as
+ * src/__tests__/case-status.test.mjs. No additional deps.
+ *
+ * The encryption module imports from `@/src/constants/envConfig` which
+ * uses Next.js path aliases — node:test can't resolve those, so we
+ * re-implement the same logic inline against the documented behavior. If
+ * the module surface changes, regenerate this test file from the contract
+ * in encryption.ts.
+ *
+ * All cryptography here is webcrypto.subtle, available globally in
+ * Node 20+.
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+const HKDF_INFO = new TextEncoder().encode('omi-byok-v1');
+const AES_GCM_IV_LENGTH_BYTES = 12;
+const AES_KEY_LENGTH_BITS = 256;
+
+// Test pepper — 32 bytes of fixed test-only randomness. Production must
+// supply a fresh `openssl rand -base64 32` value via BYOK_MASTER_PEPPER.
+const TEST_PEPPER_BASE64 = 'AbcdEfghIjklMnopQrstUvwxYz0123456789ABCDEFG=';
+
+function getPepperBytes(b64) {
+  const cleaned = b64.replace(/\s+/g, '').replace(/-/g, '+').replace(/_/g, '/');
+  return new Uint8Array(Buffer.from(cleaned, 'base64'));
+}
+
+async function deriveUserKey(pepperB64, uid) {
+  const pepperKey = await crypto.subtle.importKey(
+    'raw',
+    getPepperBytes(pepperB64),
+    { name: 'HKDF' },
+    false,
+    ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new TextEncoder().encode(uid),
+      info: HKDF_INFO,
+    },
+    pepperKey,
+    { name: 'AES-GCM', length: AES_KEY_LENGTH_BITS },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+function b64Encode(bytes) {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  return Buffer.from(view).toString('base64');
+}
+
+function b64Decode(s) {
+  return new Uint8Array(Buffer.from(s, 'base64'));
+}
+
+async function encrypt(pepperB64, uid, plaintext) {
+  const key = await deriveUserKey(pepperB64, uid);
+  const iv = crypto.getRandomValues(new Uint8Array(AES_GCM_IV_LENGTH_BYTES));
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  return { ciphertext: b64Encode(ct), iv: b64Encode(iv) };
+}
+
+async function decrypt(pepperB64, uid, encrypted) {
+  const key = await deriveUserKey(pepperB64, uid);
+  const pt = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: b64Decode(encrypted.iv) },
+    key,
+    b64Decode(encrypted.ciphertext),
+  );
+  return new TextDecoder().decode(pt);
+}
+
+async function hash(plaintext) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(plaintext));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+describe('BYOK encryption (HKDF-SHA256 + AES-GCM)', () => {
+  before(() => {
+    assert.ok(globalThis.crypto?.subtle, 'webcrypto.subtle required (Node 20+)');
+  });
+
+  it('round-trips plaintext through encrypt → decrypt', async () => {
+    const uid = 'user-12345';
+    const key = 'sk-test-abcdef0123456789';
+    const enc = await encrypt(TEST_PEPPER_BASE64, uid, key);
+    const dec = await decrypt(TEST_PEPPER_BASE64, uid, enc);
+    assert.equal(dec, key);
+  });
+
+  it('produces different ciphertexts for the same plaintext (random IV)', async () => {
+    const uid = 'user-12345';
+    const key = 'sk-test-abcdef0123456789';
+    const e1 = await encrypt(TEST_PEPPER_BASE64, uid, key);
+    const e2 = await encrypt(TEST_PEPPER_BASE64, uid, key);
+    assert.notEqual(e1.ciphertext, e2.ciphertext, 'ciphertext should not repeat');
+    assert.notEqual(e1.iv, e2.iv, 'IV should not repeat');
+    // Both must still decrypt to the same plaintext.
+    assert.equal(await decrypt(TEST_PEPPER_BASE64, uid, e1), key);
+    assert.equal(await decrypt(TEST_PEPPER_BASE64, uid, e2), key);
+  });
+
+  it('does not allow decryption with the wrong UID', async () => {
+    const key = 'sk-test-abcdef0123456789';
+    const enc = await encrypt(TEST_PEPPER_BASE64, 'user-A', key);
+    await assert.rejects(
+      () => decrypt(TEST_PEPPER_BASE64, 'user-B', enc),
+      /OperationError|invalid|tag/i,
+    );
+  });
+
+  it('does not allow decryption with the wrong pepper', async () => {
+    const otherPepper = 'XYZAbcdEfghIjklMnopQrstUvwxYz0123456789ABCDE='; // valid b64, different
+    const key = 'sk-test-abcdef0123456789';
+    const enc = await encrypt(TEST_PEPPER_BASE64, 'user-A', key);
+    await assert.rejects(
+      () => decrypt(otherPepper, 'user-A', enc),
+      /OperationError|invalid|tag/i,
+    );
+  });
+
+  it('rejects tampered ciphertext (auth tag mismatch)', async () => {
+    const uid = 'user-12345';
+    const enc = await encrypt(TEST_PEPPER_BASE64, uid, 'sk-test-key');
+    // Flip the last byte of the ciphertext.
+    const ctBytes = b64Decode(enc.ciphertext);
+    ctBytes[ctBytes.length - 1] ^= 0x01;
+    const tampered = { ciphertext: b64Encode(ctBytes), iv: enc.iv };
+    await assert.rejects(
+      () => decrypt(TEST_PEPPER_BASE64, uid, tampered),
+      /OperationError|invalid|tag/i,
+    );
+  });
+
+  it('hash is deterministic and matches expected SHA-256', async () => {
+    const h1 = await hash('sk-test-key');
+    const h2 = await hash('sk-test-key');
+    assert.equal(h1, h2, 'hash must be deterministic');
+    assert.equal(h1.length, 64, 'SHA-256 hex must be 64 chars');
+    // Sanity vs Node crypto module.
+    const { createHash } = await import('node:crypto');
+    const expected = createHash('sha256').update('sk-test-key').digest('hex');
+    assert.equal(h1, expected);
+  });
+
+  it('different plaintexts produce different hashes', async () => {
+    const a = await hash('sk-test-A');
+    const b = await hash('sk-test-B');
+    assert.notEqual(a, b);
+  });
+});

--- a/web/frontend/src/lib/firestore/encryption.ts
+++ b/web/frontend/src/lib/firestore/encryption.ts
@@ -1,0 +1,136 @@
+/**
+ * BYOK encryption-at-rest for the web frontend.
+ *
+ * Per `desktop/docs/M4-decisions.md` § Decision 1 (KMS choice):
+ * - App-side AES-GCM encryption.
+ * - Per-user encryption key derived from `BYOK_MASTER_PEPPER` env-var via
+ *   HKDF-SHA256 keyed by the user UID (so two users' ciphertexts cannot be
+ *   swapped, and rotating the pepper invalidates every user's keys at once).
+ * - Plaintext is never persisted; only `{ ciphertext, iv, hash }` reaches
+ *   Firestore. `hash` is the SHA-256 fingerprint of the plaintext used by
+ *   the backend's existing BYOK fingerprint comparison
+ *   (`backend/utils/byok.py:141`) without needing to decrypt.
+ *
+ * Server-only — must NEVER ship in the browser bundle. Importers should be
+ * Server Actions or route handlers that read the env-var.
+ */
+
+import envConfig from '@/src/constants/envConfig';
+
+const HKDF_INFO = new TextEncoder().encode('omi-byok-v1');
+const AES_KEY_LENGTH_BITS = 256;
+const AES_GCM_IV_LENGTH_BYTES = 12; // standard for AES-GCM per NIST SP 800-38D
+
+export class BYOKEncryptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BYOKEncryptionError';
+  }
+}
+
+function getPepperBytes(): Uint8Array {
+  const raw = envConfig.BYOK_MASTER_PEPPER;
+  if (!raw) {
+    throw new BYOKEncryptionError(
+      'BYOK_MASTER_PEPPER env-var is not set. Generate one with `openssl rand -base64 32` and ' +
+        'configure it in your server environment (NOT as NEXT_PUBLIC_*).',
+    );
+  }
+  // Accept base64 or base64url. Strip whitespace defensively.
+  const cleaned = raw.replace(/\s+/g, '').replace(/-/g, '+').replace(/_/g, '/');
+  const buf = Buffer.from(cleaned, 'base64');
+  if (buf.length < 32) {
+    throw new BYOKEncryptionError(
+      `BYOK_MASTER_PEPPER must decode to at least 32 bytes; got ${buf.length}.`,
+    );
+  }
+  return new Uint8Array(buf);
+}
+
+async function deriveUserKey(uid: string): Promise<CryptoKey> {
+  const pepperKey = await crypto.subtle.importKey(
+    'raw',
+    getPepperBytes(),
+    { name: 'HKDF' },
+    false,
+    ['deriveKey'],
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new TextEncoder().encode(uid),
+      info: HKDF_INFO,
+    },
+    pepperKey,
+    { name: 'AES-GCM', length: AES_KEY_LENGTH_BITS },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+function bytesToBase64(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  return Buffer.from(view).toString('base64');
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(b64, 'base64'));
+}
+
+export interface EncryptedBYOK {
+  ciphertext: string; // base64-encoded AES-GCM output (includes auth tag)
+  iv: string; // base64-encoded 12-byte IV
+}
+
+export async function encryptBYOK(uid: string, plaintext: string): Promise<EncryptedBYOK> {
+  if (!uid) throw new BYOKEncryptionError('uid is required');
+  if (!plaintext) throw new BYOKEncryptionError('plaintext is required');
+
+  const key = await deriveUserKey(uid);
+  const iv = crypto.getRandomValues(new Uint8Array(AES_GCM_IV_LENGTH_BYTES));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  return { ciphertext: bytesToBase64(ciphertext), iv: bytesToBase64(iv) };
+}
+
+export async function decryptBYOK(uid: string, encrypted: EncryptedBYOK): Promise<string> {
+  if (!uid) throw new BYOKEncryptionError('uid is required');
+  if (!encrypted?.ciphertext || !encrypted?.iv) {
+    throw new BYOKEncryptionError('encrypted must have ciphertext and iv');
+  }
+
+  const key = await deriveUserKey(uid);
+  try {
+    const plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64ToBytes(encrypted.iv) },
+      key,
+      base64ToBytes(encrypted.ciphertext),
+    );
+    return new TextDecoder().decode(plaintext);
+  } catch {
+    // AES-GCM auth tag mismatch — wrong UID, wrong pepper, or tampered data.
+    // Do NOT include the underlying error; it can leak timing/oracle info.
+    throw new BYOKEncryptionError(
+      'BYOK decryption failed. The pepper may have rotated or the ciphertext is corrupt.',
+    );
+  }
+}
+
+/**
+ * SHA-256 fingerprint of the plaintext key. Matches the backend's BYOK
+ * fingerprint shape (`backend/utils/byok.py:141` — same hash hex over UTF-8
+ * bytes) so the backend can compare against an enrollment record without
+ * the web frontend needing to decrypt.
+ */
+export async function hashBYOK(plaintext: string): Promise<string> {
+  if (!plaintext) throw new BYOKEncryptionError('plaintext is required');
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(plaintext));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/web/frontend/src/lib/firestore/user-settings.ts
+++ b/web/frontend/src/lib/firestore/user-settings.ts
@@ -1,0 +1,143 @@
+/**
+ * Server-side Firestore reader/writer for the per-user settings document.
+ *
+ * Schema (`users/{uid}/settings/profile`):
+ * ```
+ * {
+ *   eu_privacy_mode: boolean,
+ *   byok_keys: {
+ *     openai?:    { ciphertext: string, iv: string, hash: string },
+ *     anthropic?: ...,
+ *     gemini?:    ...,
+ *     deepgram?:  ...,
+ *     regolo?:    ...,
+ *   },
+ *   updated_at: number,  // Unix ms
+ * }
+ * ```
+ *
+ * `hash` is the SHA-256 of the plaintext key, included so the backend's
+ * fingerprint-comparison (`backend/utils/byok.py:141`) can validate without
+ * needing to decrypt. Plaintext keys never leave this module — only the
+ * encrypted shape goes to Firestore, and only the plaintext-on-demand path
+ * (for backend forwarding) returns a decrypted value.
+ *
+ * Security notes:
+ * - This file is server-only. Any caller (Server Action, route handler)
+ *   must be reachable only from server contexts — Firestore admin SDK
+ *   reads are not currently used; the Firebase web SDK Firestore is
+ *   reached via `db` from `lib/firebase.ts`. If admin-side reads become
+ *   necessary, add a separate `firestore-admin.ts` module.
+ * - Firestore security rules MUST pin reads/writes to `request.auth.uid`.
+ */
+
+import { doc, getDoc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '@/src/lib/firebase';
+import {
+  encryptBYOK,
+  hashBYOK,
+  decryptBYOK,
+  type EncryptedBYOK,
+} from '@/src/lib/firestore/encryption';
+
+export type BYOKProvider = 'openai' | 'anthropic' | 'gemini' | 'deepgram' | 'regolo';
+
+export const BYOK_PROVIDERS: readonly BYOKProvider[] = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'deepgram',
+  'regolo',
+] as const;
+
+export interface StoredBYOKKey extends EncryptedBYOK {
+  hash: string; // SHA-256 of plaintext, hex-encoded
+}
+
+export interface UserSettings {
+  eu_privacy_mode: boolean;
+  byok_keys: Partial<Record<BYOKProvider, StoredBYOKKey>>;
+  updated_at?: number;
+}
+
+const DEFAULT_SETTINGS: UserSettings = {
+  eu_privacy_mode: false,
+  byok_keys: {},
+};
+
+function settingsRef(uid: string) {
+  if (!uid) throw new Error('uid is required for Firestore settings access');
+  return doc(db, 'users', uid, 'settings', 'profile');
+}
+
+export async function getUserSettings(uid: string): Promise<UserSettings> {
+  const snap = await getDoc(settingsRef(uid));
+  if (!snap.exists()) return { ...DEFAULT_SETTINGS };
+
+  const data = snap.data();
+  return {
+    eu_privacy_mode: Boolean(data.eu_privacy_mode),
+    byok_keys: (data.byok_keys ?? {}) as UserSettings['byok_keys'],
+    updated_at: typeof data.updated_at === 'number' ? data.updated_at : undefined,
+  };
+}
+
+/** Toggle EU Privacy Mode without touching BYOK keys. */
+export async function setEuPrivacyMode(uid: string, enabled: boolean): Promise<void> {
+  const current = await getUserSettings(uid);
+  await setDoc(
+    settingsRef(uid),
+    {
+      ...current,
+      eu_privacy_mode: enabled,
+      updated_at: Date.now(),
+    },
+    { merge: true },
+  );
+}
+
+/**
+ * Encrypt and persist a BYOK key. Caller passes plaintext exactly once;
+ * this function discards it after encryption. Empty string clears the key.
+ */
+export async function setBYOKKey(
+  uid: string,
+  provider: BYOKProvider,
+  plaintextKey: string,
+): Promise<void> {
+  const current = await getUserSettings(uid);
+  const nextByok = { ...current.byok_keys };
+
+  if (plaintextKey === '') {
+    delete nextByok[provider];
+  } else {
+    const encrypted = await encryptBYOK(uid, plaintextKey);
+    const hash = await hashBYOK(plaintextKey);
+    nextByok[provider] = { ...encrypted, hash };
+  }
+
+  await setDoc(
+    settingsRef(uid),
+    {
+      ...current,
+      byok_keys: nextByok,
+      updated_at: Date.now(),
+    },
+    { merge: true },
+  );
+}
+
+/**
+ * Decrypt a stored BYOK key for backend header forwarding. Returns null if
+ * the user hasn't configured a key for this provider. Callers must use the
+ * returned plaintext immediately and never persist or log it.
+ */
+export async function getBYOKKeyForBackendForwarding(
+  uid: string,
+  provider: BYOKProvider,
+): Promise<string | null> {
+  const settings = await getUserSettings(uid);
+  const stored = settings.byok_keys[provider];
+  if (!stored) return null;
+  return decryptBYOK(uid, stored);
+}


### PR DESCRIPTION
## Status: DRAFT — for visibility, not yet ready for merge

Cross-surface Regolo.ai EU Privacy Mode integration developed by Euraika-Labs. Backend + audit docs landed first via the sister Euraika GitLab repo (`euraika/omi-regolo-integration`); this PR carries the desktop polish + web frontend implementation + M2.5 documentation that pair with them.

**Sister-repo MRs (all merged to GitLab; mirrored on github.com/Euraika-Labs/omi-regolo-integration):**
- !1 M0 spec hygiene + probes doc — ✅ merged
- !2 M1.1 sync + M1.2 async/streaming wrappers — ✅ merged
- !3 M1.3 retry policy honoring Retry-After — ✅ merged
- !4 M1.4 provider=regolo telemetry tags — ✅ merged
- !5 M2 embedding audit (HARD STOP, M2.5 plan, write-path privacy gap disclosure) — ✅ merged
- !6 M2.5 embedding migration code half — 🟡 open, depends on infra provisioning the second Pinecone index

## What's in this PR (50 commits)

### Phase 1 backend + desktop scaffolding (~21 commits)
Backend BYOK header registration, `_RegoloOpenAIProxy`, privacy QoS profile + middleware, response fallback signalling. Desktop `BYOKProvider.regolo` + `BYOKValidator` ping + `APIClient` `X-Privacy-Mode` header + Settings toggle + `PrivacyModeFallbackObserver` + banner.

### M0 spec hygiene (4 commits)
`regolo-probes.md` empirical probe record (P1–P11). Corrected `REGOLO_INTEGRATION.md`: chat default `mistral-small-4-119b` not `minimax-m2.5` (P6 latency probe found 3/5 calls timed out at 60s on MiniMax). Per-model thinking-knob matrix. Vision HARD-BLOCKED.

### M3 desktop polish (6 commits, ~181 LOC)
- `OmiApp.swift` — `PrivacyModeFallbackBanner` mounted via `safeAreaInset(.top)`.
- `ModelQoS.swift` — `ModelQoS.Regolo` namespace with empirical model picks.
- `SettingsPage.swift` — Regolo API Key row + 7-day rolling fallback counter + first-run intro card.
- `PrivacyModeFallbackObserver.swift` — `weeklyFallbackCount` `@Published` state with UserDefaults persistence.
- `OmiApp.swift` — status-bar shield indicator with reactive `UserDefaults.didChangeNotification` observer.

### M4 web frontend implementation (8 commits, ~580 LOC + 1 dep + 18 unit tests)
- M4.1 BYOK encryption-at-rest: webcrypto.subtle HKDF-SHA256 → AES-GCM-256 with 12-byte random IVs, per-user key derived from `BYOK_MASTER_PEPPER` env-var. Server-side only.
- M4.1 Firestore prefs store at `users/{uid}/settings/profile`: `eu_privacy_mode` + `byok_keys.<provider> = { ciphertext, iv, hash }`.
- M4.2 `/settings` route: 5-row API key manager (OpenAI / Anthropic / Gemini / Deepgram / Regolo) with Save / Test connection / Clear. EU Privacy Mode toggle. Reuses existing shadcn primitives.
- M4.4 `regolo-forwarder.ts` — server-side header builder (`Authorization: Bearer` + per-provider `X-BYOK-*` + `X-Privacy-Mode: on`).
- M4.5 sonner `<Toaster />` mounted in root layout + `usePrivacyFallbackToast` hook (5 reasons, 1:1 with desktop).
- M4.5b `PrivacyModeShield` — small green shield + "EU Privacy" chip in app header for authenticated users with toggle on.
- M4 revised-scope doc: `chat-with-memory.ts` is anonymous (URL-token auth, no Firebase Auth) — original M4.3 doesn't apply.

### M4 design + verification (4 doc commits)
- `M4-web-frontend-audit.md` — original 5-phase plan.
- `M4-decisions.md` — KMS choice (env-var pepper + HKDF; rejected GCP KMS / passphrase / plaintext).
- `M4-revised-scope.md` — discovery from M4.3 spike.
- `M4-M2.5-security-verification.md` — TypeScript strict + Semgrep + manual review against awesome-secure-defaults categories. **0 findings, 0 net new TS errors, 35 unit tests across both halves all green.**

## Test plan

- [ ] `cd backend && bash test.sh` — sister-repo backend regression (covered by !2/!3/!4/!5/!6 CI; not in this PR).
- [ ] `cd web/frontend && node --test src/lib/firestore/__tests__/*.test.mjs src/lib/api/__tests__/*.test.mjs src/hooks/__tests__/*.test.mjs src/app/settings/__tests__/*.test.mjs` — 26 web frontend unit tests.
- [ ] `xcrun swift build -c debug --package-path desktop/Desktop` — desktop compile (Mac only; Linux WSL2 host can't build Swift, hence draft).
- [ ] Launch via `OMI_APP_NAME=omi-regolo-integration ./run.sh`; confirm M3 acceptance criteria: Settings shows Regolo row + Privacy toggle + first-run card; menu-bar shield appears with toggle on; banner appears when backend signals `X-Privacy-Mode-Fallback`; counter increments after a fallback.
- [ ] No regressions on existing Claude/Gemini/OpenAI/Deepgram BYOK paths (F8 from design doc).
- [ ] `next build` clean on web frontend; `/settings` route renders for authenticated users + sign-in gate for anonymous.
- [ ] Smoke test: log in via Google → /settings → save Regolo BYOK key → flip Privacy Mode on → AppHeader shield appears.

## Out of scope for this PR

- M1 backend (lands via sister-repo MRs !2/!3/!4 — already merged).
- M2.5 backend embedding adapter ([sister-repo MR !6](https://git.euraika.net/euraika/omi-regolo-integration/-/merge_requests/6) — open, dormant until `PINECONE_INDEX_NAME_EU` is set AND the upstream `database/vector_db.py` patches land per `desktop/docs/M2.5-implementation-runbook.md`).
- Vision via Regolo — `qwen3-vl-32b` not on PAYG; HARD_BLOCKED with banner fallback to Gemini.
- M5 DPA + GA rollout — gates on legal turnaround.

## Notes for upstream maintainers

- Author / development contact: bert@euraika.net.
- This PR is draft until: sister-repo MR chain fully reviewed AND desktop changes verified via Mac build (needs maintainer with macOS access; this work was done on Linux WSL2).
- Web frontend additions are server-rendered authenticated-user surfaces; chat-with-memory anonymous flow unchanged.
- Security verification doc on sister repo covers TypeScript strict + Semgrep auto + awesome-secure-defaults checklist — 0 findings.
