### PR TITLE
fix: hide new-user empty states while conversations are still loading

### DIFF
--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -306,7 +306,10 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
               // Hidden entirely when the user has fewer than 3 non-discarded
               // conversations (and isn't on the Daily Recaps view) — those
               // users get the empty-state hero below instead.
-              if (convoProvider.showDailySummaries || _nonDiscardedConversationCount(convoProvider) >= 3)
+              if (convoProvider.showDailySummaries ||
+                  _nonDiscardedConversationCount(convoProvider) >= 3 ||
+                  convoProvider.isLoadingConversations ||
+                  convoProvider.isFetchingConversations)
                 SliverToBoxAdapter(
                   child: Builder(
                     builder: (context) => Padding(
@@ -327,7 +330,10 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
 
               // Folder tabs - hide when showing daily recaps OR when the user
               // hasn't built up enough conversations yet (matches the title).
-              if (!convoProvider.showDailySummaries && _nonDiscardedConversationCount(convoProvider) >= 3)
+              if (!convoProvider.showDailySummaries &&
+                  (_nonDiscardedConversationCount(convoProvider) >= 3 ||
+                      convoProvider.isLoadingConversations ||
+                      convoProvider.isFetchingConversations))
                 Consumer2<FolderProvider, ConversationProvider>(
                   builder: (context, folderProvider, convoProvider, _) {
                     return SliverToBoxAdapter(

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -142,7 +142,13 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
 
                 // Bottom padding so content isn't hidden behind chat bar + nav
                 const SliverToBoxAdapter(child: SizedBox(height: 160)),
-              ] else
+              ] else if (convoProvider.isLoadingConversations || convoProvider.isFetchingConversations)
+                // Hide both the recent-convos preview AND the get-started tiles
+                // while we're still fetching — otherwise users with conversations
+                // briefly see the new-user triangle UI while the network call
+                // is in flight, which looks broken.
+                const SliverFillRemaining(hasScrollBody: false, child: SizedBox.shrink())
+              else
                 // For new users (< 3 non-discarded convos): hide the conversations
                 // preview AND the mind map. The 3 "get started" tiles fill the
                 // remaining vertical space and sit centered between Today/Daily


### PR DESCRIPTION
## Summary
On cold start `convoProvider.conversations` is empty until the network fetch comes back. With < 3 conversations triggering the new-user UI, users who actually have conversations were briefly seeing the get-started triangle (home) and the "no conversations yet" hero (conversations tab) for a few seconds before their data showed up.

- **Home:** add an explicit loading branch that renders an empty SliverFillRemaining placeholder while `isLoadingConversations`/`isFetchingConversations` is true and count < 3. Only after the load finishes do we commit to the recent-convos preview (>= 3) or the get-started tiles (< 3).
- **Conversations tab:** keep the "Conversations" title and FolderTabs row visible while the fetch is in flight so they don't flicker out and back in.

## Test plan
- [ ] Cold start with conversations → no triangle / no empty-state flash; goes straight from skeleton to data.
- [ ] Cold start without any conversations → eventually shows the triangle on home and the hero on conversations.
- [ ] Pull-to-refresh on conversations tab → title/folders stay visible during the refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)