### PR TITLE
feat(backend): provider-aware vector store + privacy-mode embedding writes (M2.5)

### DIFF
--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -15,10 +15,52 @@ if os.getenv('PINECONE_API_KEY') is not None:
     pc = Pinecone(api_key=os.getenv('PINECONE_API_KEY', ''))
     index = pc.Index(os.getenv('PINECONE_INDEX_NAME', ''))
 else:
+    pc = None
     index = None
 
 
-def _get_data(uid: str, conversation_id: str, vector: List[float]):
+# M2.5: provider-aware index selector. The legacy `index` (3072-dim, OpenAI
+# text-embedding-3-large + Gemini embedding-001) stays as the default. When
+# `PINECONE_INDEX_NAME_EU` is set in the deploy, EU Privacy Mode workloads
+# write/read against a parallel 4096-dim Qwen3-Embedding-8B index — keeping
+# the dimensionalities physically separated so cosine math doesn't degrade.
+_EU_INDEX = None
+if pc is not None and os.getenv('PINECONE_INDEX_NAME_EU', '').strip():
+    _EU_INDEX = pc.Index(os.getenv('PINECONE_INDEX_NAME_EU', '').strip())
+
+
+def _get_index_for_provider(provider: str = None):
+    """Return the Pinecone handle for an embedding provider.
+
+    `provider='regolo'` → EU 4096-dim index when provisioned, else None
+    (caller must handle gracefully — embedding-dependent features are
+    HARD_BLOCKED in EU mode by `eu_privacy.resolve_feature_model` until
+    the env var is set).
+
+    Anything else → the legacy 3072-dim index.
+    """
+    if provider == 'regolo':
+        return _EU_INDEX
+    return index
+
+
+# Legacy schema attribution for vectors written before M2.5. Used by the
+# §3 backfill migration and as the default tag when callers don't pass
+# explicit provider/model/dim.
+_LEGACY_PROVIDER = 'openai'
+_LEGACY_MODEL = 'text-embedding-3-large'
+_LEGACY_DIM = 3072
+
+
+def _get_data(
+    uid: str,
+    conversation_id: str,
+    vector: List[float],
+    *,
+    provider: str = _LEGACY_PROVIDER,
+    model: str = _LEGACY_MODEL,
+    dim: int = _LEGACY_DIM,
+):
     return {
         "id": f'{uid}-{conversation_id}',
         "values": vector,
@@ -26,6 +68,13 @@ def _get_data(uid: str, conversation_id: str, vector: List[float]):
             'uid': uid,
             'memory_id': conversation_id,
             'created_at': int(datetime.now(timezone.utc).timestamp()),
+            # M2.5 additive attribution. Non-breaking — Pinecone ignores
+            # unknown metadata fields and existing readers don't filter on
+            # these keys. The §3 backfill tags pre-M2.5 vectors with the
+            # legacy values above so every vector eventually carries them.
+            'provider': provider,
+            'model': model,
+            'dim': dim,
         },
     }
 

--- a/backend/migrations/007_byok_provider_metadata.py
+++ b/backend/migrations/007_byok_provider_metadata.py
@@ -1,0 +1,90 @@
+"""
+Migration 007: backfill `(provider, model, dim)` metadata on existing Pinecone vectors.
+
+M2.5 prerequisite. Tags every legacy vector with the schema attribution that the
+new write paths now stamp on every upsert. Idempotent — vectors that already have
+`provider` set in metadata are skipped.
+
+Per-namespace tags (legacy 3072-dim index only):
+- ns1 conversations:    provider=openai, model=text-embedding-3-large, dim=3072
+- ns2 (memories):       provider=openai, model=text-embedding-3-large, dim=3072
+- ns3 (screen activity): provider=gemini, model=embedding-001,        dim=3072
+
+Run:
+    PINECONE_API_KEY=... PINECONE_INDEX_NAME=omi-prod \
+    python backend/migrations/007_byok_provider_metadata.py
+
+Estimate ~5 min for 30K vectors. Dry run first via `--dry-run` flag.
+"""
+
+import argparse
+import os
+import sys
+from typing import Dict
+
+from pinecone import Pinecone
+
+LEGACY_TAGS: Dict[str, Dict[str, object]] = {
+    'ns1': {'provider': 'openai', 'model': 'text-embedding-3-large', 'dim': 3072},
+    'ns2': {'provider': 'openai', 'model': 'text-embedding-3-large', 'dim': 3072},
+    'ns3': {'provider': 'gemini', 'model': 'embedding-001', 'dim': 3072},
+}
+
+
+def main(dry_run: bool = False) -> int:
+    api_key = os.environ.get('PINECONE_API_KEY')
+    index_name = os.environ.get('PINECONE_INDEX_NAME')
+    if not api_key or not index_name:
+        print('error: PINECONE_API_KEY and PINECONE_INDEX_NAME must be set', file=sys.stderr)
+        return 2
+
+    pc = Pinecone(api_key=api_key)
+    index = pc.Index(index_name)
+
+    grand_tagged = 0
+    grand_skipped = 0
+
+    for namespace, tags in LEGACY_TAGS.items():
+        print(f'== namespace={namespace} ==')
+        cursor = None
+        ns_tagged = 0
+        ns_skipped = 0
+        page_count = 0
+        while True:
+            page_count += 1
+            page = index.list_paginated(namespace=namespace, pagination_token=cursor, limit=100)
+            vector_ids = [v.id for v in page.vectors]
+            if not vector_ids:
+                break
+
+            # Fetch metadata for the page so we can skip already-tagged vectors.
+            fetched = index.fetch(ids=vector_ids, namespace=namespace)
+            for vid in vector_ids:
+                meta = (fetched.vectors.get(vid) or {}).metadata or {}
+                if meta.get('provider'):
+                    ns_skipped += 1
+                    continue
+                if dry_run:
+                    print(f'  WOULD tag {vid} with {tags}')
+                else:
+                    index.update(id=vid, namespace=namespace, set_metadata=tags)
+                ns_tagged += 1
+
+            print(f'  page {page_count}: tagged={ns_tagged} skipped={ns_skipped}')
+            if not page.pagination or not page.pagination.next:
+                break
+            cursor = page.pagination.next
+
+        print(f'  done: tagged={ns_tagged} skipped={ns_skipped}')
+        grand_tagged += ns_tagged
+        grand_skipped += ns_skipped
+
+    print(f'\nTotal: tagged={grand_tagged} skipped={grand_skipped} (dry_run={dry_run})')
+    return 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true', help='Print what would be tagged without writing')
+    args = parser.parse_args()
+    sys.exit(main(dry_run=args.dry_run))

--- a/backend/tests/fixtures/capture_regolo_tool_call_stream.sh
+++ b/backend/tests/fixtures/capture_regolo_tool_call_stream.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Capture a live Regolo streaming tool-call fixture for Phase 1 acceptance gate 9.
+#
+# Run once, manually, with a real Regolo API key. Commits the captured SSE
+# stream to regolo_tool_call_stream.json so the replay test in
+# test_regolo_provider.py (and future regressions) can diff against it.
+#
+# Usage:
+#   REGOLO_API_KEY=your_key bash capture_regolo_tool_call_stream.sh
+#
+# Why this exists: the Define→Develop debate gate (gemini, Apr 27 2026)
+# rejected the "stub-only" smoke test as too optimistic. The fixture
+# captures Regolo's actual delta shape so we can verify LangChain's native
+# OpenAI accumulator handles tool_calls.function.arguments chunks correctly.
+# If diffs reveal divergence from OpenAI's shape, the accumulator goes in
+# _RegoloChatProxy as a follow-up.
+
+set -euo pipefail
+
+if [[ -z "${REGOLO_API_KEY:-}" ]]; then
+  echo "error: REGOLO_API_KEY env var required" >&2
+  exit 1
+fi
+
+OUT="$(dirname "$0")/regolo_tool_call_stream.json"
+
+# Single-shot streaming completion with one tool — get_weather is the
+# canonical OpenAI tool-calling smoke test. The model is Llama-3.3-70B-Instruct
+# because it is the Phase 1 default for tool_call workloads (per
+# desktop/docs/REGOLO_INTEGRATION.md decision table) and was confirmed
+# tool-capable in the Apr 22 2026 live probes.
+
+curl -sS -N \
+  -H "Authorization: Bearer ${REGOLO_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  https://api.regolo.ai/v1/chat/completions \
+  -d '{
+    "model": "Llama-3.3-70B-Instruct",
+    "stream": true,
+    "messages": [
+      {"role": "user", "content": "What is the weather in Paris right now?"}
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get current weather for a city",
+          "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto"
+  }' > "$OUT.raw"
+
+# The raw output is SSE — each line is "data: {...}" or "data: [DONE]".
+# Convert to a JSON array of delta objects for stable replay in tests.
+python3 <<PYEOF
+import json, sys
+deltas = []
+with open("$OUT.raw") as f:
+    for line in f:
+        line = line.strip()
+        if not line.startswith("data: "):
+            continue
+        payload = line[6:]
+        if payload == "[DONE]":
+            break
+        try:
+            deltas.append(json.loads(payload))
+        except json.JSONDecodeError as e:
+            print(f"skipping malformed line: {line[:80]} ({e})", file=sys.stderr)
+with open("$OUT", "w") as f:
+    json.dump(deltas, f, indent=2)
+print(f"captured {len(deltas)} deltas -> $OUT")
+PYEOF
+
+rm -f "$OUT.raw"
+echo "done. commit $OUT to the repo."

--- a/backend/tests/fixtures/regolo_tool_call_stream.json
+++ b/backend/tests/fixtures/regolo_tool_call_stream.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "chatcmpl-a6d3f6c8a0650619",
+    "created": 1777282023,
+    "model": "Llama-3.3-70B-Instruct",
+    "object": "chat.completion.chunk",
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "role": "assistant",
+          "tool_calls": [
+            {
+              "id": "chatcmpl-tool-90e8b3536b0430f6",
+              "function": {
+                "arguments": "",
+                "name": "get_weather"
+              },
+              "type": "function",
+              "index": 0
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-a6d3f6c8a0650619",
+    "created": 1777282023,
+    "model": "Llama-3.3-70B-Instruct",
+    "object": "chat.completion.chunk",
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "function": {
+                "arguments": "{\"city\": \""
+              },
+              "type": "function",
+              "index": 0
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-a6d3f6c8a0650619",
+    "created": 1777282023,
+    "model": "Llama-3.3-70B-Instruct",
+    "object": "chat.completion.chunk",
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "function": {
+                "arguments": "Paris\"}"
+              },
+              "type": "function",
+              "index": 0
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-a6d3f6c8a0650619",
+    "created": 1777282023,
+    "model": "Llama-3.3-70B-Instruct",
+    "object": "chat.completion.chunk",
+    "choices": [
+      {
+        "stop_reason": 128008,
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "function": {
+                "arguments": ""
+              },
+              "type": "function",
+              "index": 0
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-a6d3f6c8a0650619",
+    "created": 1777282023,
+    "model": "Llama-3.3-70B-Instruct",
+    "object": "chat.completion.chunk",
+    "choices": [
+      {
+        "finish_reason": "tool_calls",
+        "index": 0,
+        "delta": {}
+      }
+    ]
+  }
+]

--- a/backend/tests/unit/test_regolo_provider.py
+++ b/backend/tests/unit/test_regolo_provider.py
@@ -1,0 +1,973 @@
+"""Behavioral tests for the Regolo provider wiring and EU Privacy Mode dispatcher.
+
+These tests use light mocking (no live API calls). The goal is to exercise
+the decision points that broke or surprised reviewers:
+- classifier ordering (regolo/ vs OpenRouter /)
+- BYOK fallback resolution
+- thinking-knob injection on the right models only
+- reasoning_content stripping
+- error taxonomy classification
+- EU Privacy Mode hard-block vs route-to-regolo vs primary
+- SSRF defense (base URL is constant)
+
+All tests can run without ENCRYPTION_SECRET — they only touch the LLM
+clients module, error helpers, and the dispatcher; nothing reaches the DB
+or encryption layer.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure tests/unit can import backend modules — mirrors other tests in this dir.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+# Pre-mock heavy deps BEFORE importing modules under test, per
+# backend/CLAUDE.md ("Pre-mock heavy deps before importing the module under
+# test"). Without this, importing utils.llm.clients will trigger real
+# `anthropic.AsyncAnthropic()` and Firestore client construction that need
+# live credentials.
+os.environ.setdefault('ENCRYPTION_SECRET', 'test_secret_for_unit_tests_only')
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake')
+os.environ.setdefault('ANTHROPIC_API_KEY', 'ant-test-fake')
+os.environ.setdefault('OPENROUTER_API_KEY', 'or-test-fake')
+os.environ.setdefault('GEMINI_API_KEY', 'gem-test-fake')
+os.environ.setdefault('REGOLO_API_KEY', 'reg-test-fake')
+sys.modules.setdefault('database._client', MagicMock())
+sys.modules.setdefault('database.redis_db', MagicMock())
+# database.users transitively pulls in stripe (via utils.subscription) which is
+# a heavy SaaS dep we don't need for these tests. Stub it with a MagicMock so
+# eu_privacy.py's `import database.users as users_db` returns a stub that the
+# test's @patch can target.
+sys.modules.setdefault('utils.subscription', MagicMock())
+sys.modules.setdefault('database.users', MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyProvider:
+    def test_regolo_prefix_routes_to_regolo(self):
+        from utils.llm.clients import _classify_provider
+
+        assert _classify_provider('regolo/Llama-3.3-70B-Instruct') == 'regolo'
+        assert _classify_provider('regolo/minimax-m2.5') == 'regolo'
+        assert _classify_provider('regolo/Qwen3-Embedding-8B') == 'regolo'
+
+    def test_openrouter_models_still_route_to_openrouter(self):
+        """The regolo/ check must come BEFORE the generic / check."""
+        from utils.llm.clients import _classify_provider
+
+        assert _classify_provider('google/gemini-3-flash-preview') == 'openrouter'
+        assert _classify_provider('anthropic/claude-3.5-sonnet') == 'openrouter'
+
+    def test_anthropic_perplexity_openai_unchanged(self):
+        from utils.llm.clients import _classify_provider
+
+        assert _classify_provider('claude-sonnet-4-6') == 'anthropic'
+        assert _classify_provider('sonar-pro') == 'perplexity'
+        assert _classify_provider('gpt-4.1-mini') == 'openai'
+
+
+# ---------------------------------------------------------------------------
+# Regolo factory + thinking-knob + SSRF defense
+# ---------------------------------------------------------------------------
+
+
+class TestRegoloFactory:
+    def test_base_url_is_constant(self):
+        """SSRF defense — base URL must NEVER be derived from input."""
+        from utils.llm.clients import _REGOLO_BASE_URL
+
+        assert _REGOLO_BASE_URL == 'https://api.regolo.ai/v1'
+        assert _REGOLO_BASE_URL.startswith('https://')
+
+    def test_thinking_models_set(self):
+        from utils.llm.clients import _REGOLO_THINKING_MODELS
+
+        # Live-probed Apr 2026: every qwen-3.x family member + minimax-m2.5
+        # needs enable_thinking=False or burns the output budget on hidden
+        # reasoning tokens.
+        assert 'minimax-m2.5' in _REGOLO_THINKING_MODELS
+        assert 'qwen3.5-122b' in _REGOLO_THINKING_MODELS
+        assert 'qwen3.5-9b' in _REGOLO_THINKING_MODELS
+        assert 'qwen3.6-27b' in _REGOLO_THINKING_MODELS
+        # Negatives — Llama, mistral, gpt-oss, gemma, apertus, qwen3-coder-next
+        # all return clean output without the knob.
+        for non_thinking in [
+            'Llama-3.3-70B-Instruct',
+            'Llama-3.1-8B-Instruct',
+            'mistral-small-4-119b',
+            'mistral-small3.2',
+            'gpt-oss-120b',
+            'gpt-oss-20b',
+            'gemma4-31b',
+            'apertus-70b',
+            'qwen3-coder-next',
+        ]:
+            assert non_thinking not in _REGOLO_THINKING_MODELS
+
+    def test_factory_strips_regolo_prefix_from_api_model(self):
+        """The model name sent to api.regolo.ai must NOT include 'regolo/'."""
+        from utils.llm import clients
+
+        # Patch ChatOpenAI ctor to capture kwargs
+        captured: dict[str, Any] = {}
+
+        class _FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        with patch.object(clients, 'ChatOpenAI', _FakeChatOpenAI):
+            # Bypass cache for this test — clear before invoking
+            clients._llm_cache.clear()
+            clients._get_or_create_regolo_llm('regolo/Llama-3.3-70B-Instruct', streaming=False)
+
+        assert captured.get('model') == 'Llama-3.3-70B-Instruct'
+        assert captured.get('base_url') == 'https://api.regolo.ai/v1'
+        # Llama is NOT a thinking model — extra_body must be absent.
+        assert 'extra_body' not in captured
+
+    def test_thinking_knob_injected_for_minimax(self):
+        from utils.llm import clients
+
+        captured: dict[str, Any] = {}
+
+        class _FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        with patch.object(clients, 'ChatOpenAI', _FakeChatOpenAI):
+            clients._llm_cache.clear()
+            clients._get_or_create_regolo_llm('regolo/minimax-m2.5', streaming=False)
+
+        extra = captured.get('extra_body')
+        assert extra == {'chat_template_kwargs': {'enable_thinking': False}}, extra
+
+    def test_thinking_knob_injected_for_qwen3_5_122b(self):
+        from utils.llm import clients
+
+        captured: dict[str, Any] = {}
+
+        class _FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        with patch.object(clients, 'ChatOpenAI', _FakeChatOpenAI):
+            clients._llm_cache.clear()
+            clients._get_or_create_regolo_llm('regolo/qwen3.5-122b', streaming=False)
+
+        assert captured['extra_body']['chat_template_kwargs']['enable_thinking'] is False
+
+    def test_thinking_knob_injected_for_qwen3_5_9b_and_qwen3_6_27b(self):
+        """qwen3.5-9b and qwen3.6-27b are also thinking models — live probe
+        without the knob hits max_tokens with no parseable output."""
+        from utils.llm import clients
+
+        for model in ['regolo/qwen3.5-9b', 'regolo/qwen3.6-27b']:
+            captured: dict[str, Any] = {}
+
+            class _FakeChatOpenAI:
+                def __init__(self, **kwargs):
+                    captured.update(kwargs)
+
+            with patch.object(clients, 'ChatOpenAI', _FakeChatOpenAI):
+                clients._llm_cache.clear()
+                clients._get_or_create_regolo_llm(model, streaming=False)
+
+            assert (
+                captured.get('extra_body', {}).get('chat_template_kwargs', {}).get('enable_thinking') is False
+            ), f'thinking knob missing for {model}'
+
+
+# ---------------------------------------------------------------------------
+# reasoning_content stripper
+# ---------------------------------------------------------------------------
+
+
+class TestStripReasoningContent:
+    def test_strips_from_basemessage_additional_kwargs(self):
+        from utils.llm.clients import strip_reasoning_content
+
+        msg = MagicMock()
+        msg.additional_kwargs = {
+            'reasoning_content': 'thinking out loud...',
+            'tool_calls': [{'id': 'tc_1'}],
+        }
+        strip_reasoning_content(msg)
+        assert 'reasoning_content' not in msg.additional_kwargs
+        assert 'tool_calls' in msg.additional_kwargs  # untouched
+
+    def test_strips_from_top_level_dict(self):
+        from utils.llm.clients import strip_reasoning_content
+
+        chunk = {'reasoning_content': 'inner monologue', 'content': 'visible'}
+        strip_reasoning_content(chunk)
+        assert 'reasoning_content' not in chunk
+        assert chunk['content'] == 'visible'
+
+    def test_strips_from_streaming_delta_nested(self):
+        from utils.llm.clients import strip_reasoning_content
+
+        chunk = {'delta': {'reasoning_content': 'hidden', 'content': 'shown'}}
+        strip_reasoning_content(chunk)
+        assert 'reasoning_content' not in chunk['delta']
+        assert chunk['delta']['content'] == 'shown'
+
+    def test_none_is_safe(self):
+        from utils.llm.clients import strip_reasoning_content
+
+        # Should not raise
+        assert strip_reasoning_content(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _RegoloChatProxy.invoke — sync hand-off (M1.1)
+#
+# These tests exist because the proxy used to be a transparent forwarder via
+# __getattr__, so reasoning_content leaked and raw httpx errors bubbled up
+# unclassified. The wrapped invoke is the M1.1 patch that fixed that.
+# ---------------------------------------------------------------------------
+
+
+class TestRegoloProxyInvoke:
+    def _make_proxy(self, fake_chat_openai: Any):
+        """Build a proxy whose _resolve() returns the given fake."""
+        from utils.llm.clients import _RegoloChatProxy
+
+        # Pass the fake as `default`; with no BYOK key set, _resolve() returns it.
+        return _RegoloChatProxy(model='Llama-3.3-70B-Instruct', default=fake_chat_openai, ctor_kwargs={})
+
+    def test_invoke_strips_reasoning_content_on_success(self):
+        msg = MagicMock()
+        msg.additional_kwargs = {'reasoning_content': 'thinking out loud...', 'tool_calls': []}
+
+        fake = MagicMock()
+        fake.invoke.return_value = msg
+
+        proxy = self._make_proxy(fake)
+        result = proxy.invoke('hello')
+
+        assert result is msg
+        assert 'reasoning_content' not in msg.additional_kwargs
+        assert 'tool_calls' in msg.additional_kwargs  # untouched
+
+    def test_invoke_classifies_401_as_auth_error(self):
+        from utils.llm.regolo_errors import RegoloAuthError
+
+        exc = Exception('unauthorized')
+        exc.status_code = 401  # type: ignore[attr-defined]
+
+        fake = MagicMock()
+        fake.invoke.side_effect = exc
+
+        proxy = self._make_proxy(fake)
+        with pytest.raises(RegoloAuthError):
+            proxy.invoke('hello')
+
+    def test_invoke_classifies_429_with_retry_after(self):
+        from utils.llm.regolo_errors import RegoloRateLimitError
+
+        exc = MagicMock(spec=Exception)
+        exc.status_code = 429
+        exc.response = MagicMock()
+        exc.response.headers = {'Retry-After': '15'}
+
+        fake = MagicMock()
+        fake.invoke.side_effect = exc
+
+        proxy = self._make_proxy(fake)
+        with pytest.raises(RegoloRateLimitError) as info:
+            proxy.invoke('hello')
+
+        assert info.value.retry_after_s == 15.0
+
+    def test_invoke_classifies_5xx_as_service_error(self):
+        from utils.llm.regolo_errors import RegoloServiceError
+
+        exc = Exception('upstream broke')
+        exc.status_code = 503  # type: ignore[attr-defined]
+
+        fake = MagicMock()
+        fake.invoke.side_effect = exc
+
+        proxy = self._make_proxy(fake)
+        with pytest.raises(RegoloServiceError):
+            proxy.invoke('hello')
+
+
+# ---------------------------------------------------------------------------
+# _RegoloChatProxy async + streaming hand-off (M1.2)
+#
+# Async tests use `asyncio.run` to drive coroutines synchronously — same
+# pattern as test_byok_security.py:1025+. No pytest-asyncio dependency.
+# ---------------------------------------------------------------------------
+
+
+class TestRegoloProxyAsyncAndStreaming:
+    def _make_proxy(self, fake_chat_openai: Any):
+        from utils.llm.clients import _RegoloChatProxy
+
+        return _RegoloChatProxy(model='Llama-3.3-70B-Instruct', default=fake_chat_openai, ctor_kwargs={})
+
+    def test_ainvoke_strips_reasoning_content_on_success(self):
+        import asyncio
+
+        msg = MagicMock()
+        msg.additional_kwargs = {'reasoning_content': 'inner', 'tool_calls': []}
+
+        async def _ainvoke(*a: Any, **kw: Any):
+            return msg
+
+        fake = MagicMock()
+        fake.ainvoke = _ainvoke
+
+        proxy = self._make_proxy(fake)
+        result = asyncio.run(proxy.ainvoke('hi'))
+
+        assert result is msg
+        assert 'reasoning_content' not in msg.additional_kwargs
+
+    def test_ainvoke_classifies_429_with_retry_after(self):
+        import asyncio
+        from utils.llm.regolo_errors import RegoloRateLimitError
+
+        exc = MagicMock(spec=Exception)
+        exc.status_code = 429
+        exc.response = MagicMock()
+        exc.response.headers = {'Retry-After': '7'}
+
+        async def _ainvoke(*a: Any, **kw: Any):
+            raise exc
+
+        fake = MagicMock()
+        fake.ainvoke = _ainvoke
+
+        proxy = self._make_proxy(fake)
+        with pytest.raises(RegoloRateLimitError) as info:
+            asyncio.run(proxy.ainvoke('hi'))
+        assert info.value.retry_after_s == 7.0
+
+    def test_astream_strips_reasoning_content_per_chunk(self):
+        import asyncio
+
+        chunks = [
+            {'delta': {'reasoning_content': 'thought-1', 'content': 'a'}},
+            {'delta': {'reasoning_content': 'thought-2', 'content': 'b'}},
+            {'delta': {'content': 'c'}},
+        ]
+
+        async def _agen(*a: Any, **kw: Any):
+            for c in chunks:
+                yield c
+
+        fake = MagicMock()
+        fake.astream = _agen
+
+        proxy = self._make_proxy(fake)
+
+        async def _drain():
+            return [c async for c in proxy.astream('hi')]
+
+        out = asyncio.run(_drain())
+        assert len(out) == 3
+        # All reasoning_content removed, content preserved.
+        for c in out:
+            assert 'reasoning_content' not in c['delta']
+        assert [c['delta']['content'] for c in out] == ['a', 'b', 'c']
+
+    def test_stream_classifies_5xx_during_iteration(self):
+        from utils.llm.regolo_errors import RegoloServiceError
+
+        exc = Exception('mid-stream boom')
+        exc.status_code = 502  # type: ignore[attr-defined]
+
+        def _sgen(*a: Any, **kw: Any):
+            yield {'delta': {'content': 'first'}}
+            raise exc
+
+        fake = MagicMock()
+        fake.stream = _sgen
+
+        proxy = self._make_proxy(fake)
+        consumed: list[Any] = []
+        with pytest.raises(RegoloServiceError):
+            for chunk in proxy.stream('hi'):
+                consumed.append(chunk)
+
+        # First chunk delivered before the failure.
+        assert len(consumed) == 1
+        assert consumed[0]['delta']['content'] == 'first'
+
+
+# ---------------------------------------------------------------------------
+# _RegoloChatProxy retry policy (M1.3)
+#
+# Retry budget: 3 attempts total on 429 (initial + 2), 1 retry on 5xx, 0 on
+# auth/forbidden/not-found. Honors Retry-After when present. Tests patch
+# time.sleep / asyncio.sleep so they don't actually wait.
+# ---------------------------------------------------------------------------
+
+
+class TestRegoloProxyRetryPolicy:
+    def _make_proxy(self, fake_chat_openai: Any):
+        from utils.llm.clients import _RegoloChatProxy
+
+        return _RegoloChatProxy(model='Llama-3.3-70B-Instruct', default=fake_chat_openai, ctor_kwargs={})
+
+    def _build_429(self, retry_after: str = '0') -> Exception:
+        exc = MagicMock(spec=Exception)
+        exc.status_code = 429
+        exc.response = MagicMock()
+        exc.response.headers = {'Retry-After': retry_after}
+        return exc
+
+    def _build_5xx(self, status: int = 503) -> Exception:
+        exc = Exception(f'upstream {status}')
+        exc.status_code = status  # type: ignore[attr-defined]
+        return exc
+
+    def test_invoke_retries_429_with_retry_after(self):
+        """Two 429s with Retry-After=0 then success — total 3 attempts, both
+        retries honor Retry-After (0s) instead of using the default backoff."""
+        success_msg = MagicMock()
+        success_msg.additional_kwargs = {'tool_calls': []}
+
+        side_effects = [self._build_429('0'), self._build_429('0'), success_msg]
+        fake = MagicMock()
+        fake.invoke.side_effect = side_effects
+
+        proxy = self._make_proxy(fake)
+        sleeps: list[float] = []
+        with patch('utils.llm.clients.time.sleep', side_effect=sleeps.append):
+            result = proxy.invoke('hi')
+
+        assert result is success_msg
+        assert fake.invoke.call_count == 3
+        assert sleeps == [0.0, 0.0]  # Retry-After=0 honored both times
+
+    def test_invoke_max_3_attempts_on_persistent_429(self):
+        from utils.llm.regolo_errors import RegoloRateLimitError
+
+        fake = MagicMock()
+        fake.invoke.side_effect = [self._build_429('0'), self._build_429('0'), self._build_429('0')]
+
+        proxy = self._make_proxy(fake)
+        with patch('utils.llm.clients.time.sleep'):
+            with pytest.raises(RegoloRateLimitError):
+                proxy.invoke('hi')
+
+        # 3 total attempts: initial + 2 retries.
+        assert fake.invoke.call_count == 3
+
+    def test_invoke_retries_5xx_once_then_raises(self):
+        from utils.llm.regolo_errors import RegoloServiceError
+
+        fake = MagicMock()
+        fake.invoke.side_effect = [self._build_5xx(503), self._build_5xx(503)]
+
+        proxy = self._make_proxy(fake)
+        with patch('utils.llm.clients.time.sleep') as mock_sleep:
+            with pytest.raises(RegoloServiceError):
+                proxy.invoke('hi')
+
+        # 2 total attempts: initial + 1 retry, then re-raise.
+        assert fake.invoke.call_count == 2
+        # One sleep between the two attempts.
+        assert mock_sleep.call_count == 1
+
+    def test_invoke_does_not_retry_401(self):
+        from utils.llm.regolo_errors import RegoloAuthError
+
+        exc = Exception('unauthorized')
+        exc.status_code = 401  # type: ignore[attr-defined]
+        fake = MagicMock()
+        fake.invoke.side_effect = exc
+
+        proxy = self._make_proxy(fake)
+        with patch('utils.llm.clients.time.sleep') as mock_sleep:
+            with pytest.raises(RegoloAuthError):
+                proxy.invoke('hi')
+
+        assert fake.invoke.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _RegoloChatProxy telemetry tagging (M1.4)
+#
+# The proxy injects `provider=regolo` + `model=<name>` into the langchain
+# RunnableConfig (both `tags` and `metadata` channels) so the upstream
+# `_usage_callback` can attribute usage rows to Regolo. User-supplied tags
+# / metadata must be preserved.
+# ---------------------------------------------------------------------------
+
+
+class TestRegoloProxyTelemetryTags:
+    def _make_proxy(self, fake_chat_openai: Any, model: str = 'mistral-small-4-119b'):
+        from utils.llm.clients import _RegoloChatProxy
+
+        return _RegoloChatProxy(model=model, default=fake_chat_openai, ctor_kwargs={})
+
+    def test_invoke_injects_provider_tag_when_no_user_config(self):
+        success_msg = MagicMock()
+        success_msg.additional_kwargs = {}
+        fake = MagicMock()
+        fake.invoke.return_value = success_msg
+
+        proxy = self._make_proxy(fake, model='Llama-3.3-70B-Instruct')
+        proxy.invoke('hi')
+
+        # Inspect the config the proxy passed to the underlying ChatOpenAI.
+        call_kwargs = fake.invoke.call_args.kwargs
+        config = call_kwargs.get('config')
+        assert config is not None
+        assert 'provider=regolo' in config['tags']
+        assert 'model=Llama-3.3-70B-Instruct' in config['tags']
+        assert config['metadata']['provider'] == 'regolo'
+        assert config['metadata']['regolo_model'] == 'Llama-3.3-70B-Instruct'
+
+    def test_invoke_merges_user_supplied_config(self):
+        """User-supplied tags + metadata are preserved; Regolo attribution
+        always lands on `metadata['regolo_provider']` + `regolo_model` so a
+        caller cannot accidentally hide the Regolo attribution by pre-setting
+        their own `metadata['provider']`."""
+        success_msg = MagicMock()
+        success_msg.additional_kwargs = {}
+        fake = MagicMock()
+        fake.invoke.return_value = success_msg
+
+        proxy = self._make_proxy(fake, model='mistral-small-4-119b')
+        user_config = {
+            'tags': ['user-trace-id-abc', 'feature=chat'],
+            'metadata': {'session_id': 'sess-42', 'provider': 'caller-app'},
+        }
+        proxy.invoke('hi', config=user_config)
+
+        config = fake.invoke.call_args.kwargs['config']
+        # User tags preserved
+        assert 'user-trace-id-abc' in config['tags']
+        assert 'feature=chat' in config['tags']
+        # Regolo tags appended
+        assert 'provider=regolo' in config['tags']
+        assert 'model=mistral-small-4-119b' in config['tags']
+        # User metadata preserved
+        assert config['metadata']['session_id'] == 'sess-42'
+        # User-supplied 'provider' kept (setdefault); attribution still works
+        # via the M1-private `regolo_provider` key + the tag channel.
+        assert config['metadata']['provider'] == 'caller-app'
+        assert config['metadata']['regolo_provider'] == 'regolo'
+        assert config['metadata']['regolo_model'] == 'mistral-small-4-119b'
+
+    def test_invoke_does_not_double_stamp_model_tag(self):
+        """If the caller already supplied a `model=` tag (e.g. routing layer),
+        the proxy must not append a second one. Regression for an issue caught
+        in M1 review where the guard only checked `provider=regolo`."""
+        success_msg = MagicMock()
+        success_msg.additional_kwargs = {}
+        fake = MagicMock()
+        fake.invoke.return_value = success_msg
+
+        proxy = self._make_proxy(fake, model='Llama-3.3-70B-Instruct')
+        user_config = {'tags': ['model=user-supplied-name']}
+        proxy.invoke('hi', config=user_config)
+
+        tags = fake.invoke.call_args.kwargs['config']['tags']
+        model_tags = [t for t in tags if t.startswith('model=')]
+        assert model_tags == ['model=user-supplied-name'], model_tags
+        # provider=regolo still appended (idempotency only blocks duplicates).
+        assert 'provider=regolo' in tags
+
+    def test_invoke_idempotent_on_double_call(self):
+        """Calling the helper twice (e.g. proxy nested inside another proxy)
+        must not duplicate the provider tag."""
+        from utils.llm.clients import _inject_regolo_telemetry
+
+        args, kwargs = _inject_regolo_telemetry('Llama-3.3-70B-Instruct', ('input',), {})
+        args, kwargs = _inject_regolo_telemetry('Llama-3.3-70B-Instruct', args, kwargs)
+
+        tags = kwargs['config']['tags']
+        assert tags.count('provider=regolo') == 1
+        assert sum(1 for t in tags if t.startswith('model=')) == 1
+
+
+# ---------------------------------------------------------------------------
+# Regolo error taxonomy
+# ---------------------------------------------------------------------------
+
+
+class TestRegoloErrors:
+    def test_401_maps_to_auth_error(self):
+        from utils.llm.regolo_errors import RegoloAuthError, classify_regolo_error
+
+        exc = MagicMock()
+        exc.status_code = 401
+        result = classify_regolo_error(exc)
+        assert isinstance(result, RegoloAuthError)
+        assert result.fallback_eligible is False
+
+    def test_403_maps_to_forbidden(self):
+        from utils.llm.regolo_errors import RegoloForbiddenError, classify_regolo_error
+
+        exc = MagicMock()
+        exc.status_code = 403
+        assert isinstance(classify_regolo_error(exc), RegoloForbiddenError)
+
+    def test_429_extracts_retry_after(self):
+        from utils.llm.regolo_errors import RegoloRateLimitError, classify_regolo_error
+
+        exc = MagicMock()
+        exc.status_code = 429
+        exc.response = MagicMock()
+        exc.response.headers = {'Retry-After': '12'}
+        result = classify_regolo_error(exc)
+        assert isinstance(result, RegoloRateLimitError)
+        assert result.retry_after_s == 12.0
+        assert result.fallback_eligible is True
+
+    def test_5xx_is_fallback_eligible(self):
+        from utils.llm.regolo_errors import RegoloServiceError, classify_regolo_error
+
+        exc = MagicMock()
+        exc.status_code = 503
+        result = classify_regolo_error(exc)
+        assert isinstance(result, RegoloServiceError)
+        assert result.fallback_eligible is True
+
+    def test_unknown_status_treated_as_service_error(self):
+        from utils.llm.regolo_errors import RegoloServiceError, classify_regolo_error
+
+        exc = MagicMock()
+        exc.status_code = None
+        exc.response = None
+        result = classify_regolo_error(exc)
+        # Default fallback so transient/unknown stays retryable.
+        assert isinstance(result, RegoloServiceError)
+
+
+# ---------------------------------------------------------------------------
+# Regolo embedding proxy + EU index provisioning gate (M2.5)
+# ---------------------------------------------------------------------------
+
+
+class TestRegoloEmbeddingProxy:
+    def test_factory_constructs_with_regolo_base_url(self):
+        """The default embeddings client must point at api.regolo.ai/v1, not OpenAI."""
+        from utils.llm import clients
+
+        captured: dict[str, Any] = {}
+
+        class _FakeEmbeddings:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        with patch.object(clients, 'OpenAIEmbeddings', _FakeEmbeddings):
+            proxy = clients._RegoloEmbeddingProxy(
+                model='Qwen3-Embedding-8B',
+                default=_FakeEmbeddings(
+                    model='Qwen3-Embedding-8B',
+                    base_url='https://api.regolo.ai/v1',
+                ),
+                ctor_kwargs={},
+            )
+            # Force re-resolve via BYOK path so we can assert the kwargs.
+            with patch.object(clients, 'get_byok_key', return_value='byok-test'):
+                clients._openai_cache.clear()
+                proxy._resolve()
+
+        assert captured.get('model') == 'Qwen3-Embedding-8B'
+        assert captured.get('base_url') == 'https://api.regolo.ai/v1'
+        assert captured.get('api_key') == 'byok-test'
+
+    def test_module_level_regolo_embeddings_uses_4096_model(self):
+        from utils.llm.clients import (
+            _REGOLO_EMBEDDING_DIM,
+            _REGOLO_EMBEDDING_MODEL,
+            regolo_embeddings,
+        )
+
+        assert _REGOLO_EMBEDDING_MODEL == 'Qwen3-Embedding-8B'
+        assert _REGOLO_EMBEDDING_DIM == 4096
+        # Object slot equals the model name
+        assert regolo_embeddings._model == 'Qwen3-Embedding-8B'
+
+    def test_resolver_falls_back_to_default_when_no_byok(self):
+        from utils.llm import clients
+
+        sentinel = object()
+        proxy = clients._RegoloEmbeddingProxy(
+            model='Qwen3-Embedding-8B',
+            default=sentinel,  # type: ignore[arg-type]
+            ctor_kwargs={},
+        )
+        with patch.object(clients, 'get_byok_key', return_value=None):
+            assert proxy._resolve() is sentinel
+
+
+class TestEuEmbeddingIndexGate:
+    def setup_method(self):
+        self._original = os.environ.get('PINECONE_INDEX_NAME_EU')
+        os.environ.pop('PINECONE_INDEX_NAME_EU', None)
+
+    def teardown_method(self):
+        if self._original is None:
+            os.environ.pop('PINECONE_INDEX_NAME_EU', None)
+        else:
+            os.environ['PINECONE_INDEX_NAME_EU'] = self._original
+
+    def test_unset_returns_false(self):
+        from utils.llm.eu_privacy import eu_embedding_index_provisioned
+
+        assert eu_embedding_index_provisioned() is False
+
+    def test_empty_returns_false(self):
+        from utils.llm.eu_privacy import eu_embedding_index_provisioned
+
+        os.environ['PINECONE_INDEX_NAME_EU'] = '   '
+        assert eu_embedding_index_provisioned() is False
+
+    def test_non_empty_returns_true(self):
+        from utils.llm.eu_privacy import eu_embedding_index_provisioned
+
+        os.environ['PINECONE_INDEX_NAME_EU'] = 'omi-eu-prod-4096'
+        assert eu_embedding_index_provisioned() is True
+
+    def test_memory_search_hard_blocks_when_index_unset(self):
+        """EMBEDDING_DEPENDENT_FEATURES stay HARD_BLOCKED until the EU index is provisioned."""
+        from utils.llm.eu_privacy import (
+            FeatureRouteKind,
+            resolve_feature_model,
+            set_eu_privacy_for_request,
+        )
+
+        set_eu_privacy_for_request(True)
+        with patch('database.users.is_eu_privacy_mode_enabled', return_value=True):
+            route = resolve_feature_model('user-x', 'memory_search')
+
+        assert route.kind is FeatureRouteKind.HARD_BLOCK
+        assert route.banner is not None
+
+    def test_memory_search_routes_to_regolo_when_index_set(self):
+        from utils.llm.eu_privacy import (
+            FeatureRouteKind,
+            resolve_feature_model,
+            set_eu_privacy_for_request,
+        )
+
+        os.environ['PINECONE_INDEX_NAME_EU'] = 'omi-eu-prod-4096'
+        set_eu_privacy_for_request(True)
+        with patch('database.users.is_eu_privacy_mode_enabled', return_value=True):
+            route = resolve_feature_model('user-x', 'memory_search')
+
+        assert route.kind is FeatureRouteKind.REGOLO
+        assert route.model == 'regolo/Qwen3-Embedding-8B'
+
+
+# ---------------------------------------------------------------------------
+# EU Privacy Mode dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestEUPrivacyDispatcher:
+    def setup_method(self):
+        # Reset request-scoped contextvar between tests
+        from utils.llm import eu_privacy
+
+        eu_privacy._eu_privacy_ctx.set(None)
+
+    def test_eu_off_returns_primary_route(self):
+        from utils.llm import eu_privacy
+        from utils.llm.eu_privacy import FeatureRouteKind, resolve_feature_model
+
+        eu_privacy.set_eu_privacy_for_request(False)
+        with patch('utils.llm.eu_privacy.get_model', return_value='gpt-4.1-mini'):
+            route = resolve_feature_model('uid-1', 'chat_responses')
+        assert route.kind is FeatureRouteKind.PRIMARY
+        assert route.model == 'gpt-4.1-mini'
+        assert route.banner is None
+
+    def test_eu_on_supported_feature_routes_to_regolo(self):
+        from utils.llm import eu_privacy
+        from utils.llm.eu_privacy import FeatureRouteKind, resolve_feature_model
+
+        eu_privacy.set_eu_privacy_for_request(True)
+        route = resolve_feature_model('uid-1', 'chat_responses')
+        assert route.kind is FeatureRouteKind.REGOLO
+        assert route.model and route.model.startswith('regolo/')
+
+    def test_eu_on_embedding_feature_hard_blocks(self):
+        from utils.llm import eu_privacy
+        from utils.llm.eu_privacy import FeatureRouteKind, resolve_feature_model
+
+        eu_privacy.set_eu_privacy_for_request(True)
+        route = resolve_feature_model('uid-1', 'memory_search')
+        assert route.kind is FeatureRouteKind.HARD_BLOCK
+        assert route.model is None
+        assert route.banner is not None
+        # Banner must mention EU Privacy Mode so user knows why
+        assert 'EU Privacy Mode' in route.banner
+
+    def test_knowledge_graph_extraction_routes_to_regolo_search_blocks(self):
+        """Subtle distinction: `knowledge_graph` is LLM extraction (supported)
+        vs `knowledge_graph_search` which is vector lookup (hard-blocked).
+        Easy to conflate; this test prevents regressions."""
+        from utils.llm import eu_privacy
+        from utils.llm.eu_privacy import FeatureRouteKind, resolve_feature_model
+
+        eu_privacy.set_eu_privacy_for_request(True)
+        # Extraction (LLM) — supported
+        route = resolve_feature_model('uid-1', 'knowledge_graph')
+        assert route.kind is FeatureRouteKind.REGOLO
+        # Search (embedding) — hard-blocked
+        eu_privacy._eu_privacy_ctx.set(True)
+        route = resolve_feature_model('uid-1', 'knowledge_graph_search')
+        assert route.kind is FeatureRouteKind.HARD_BLOCK
+
+    def test_every_supported_feature_has_a_model(self):
+        """Every entry in REGOLO_SUPPORTED_FEATURES must have a corresponding
+        model in _EU_FEATURE_MODELS, otherwise resolve_feature_model returns
+        a fallback that may not be the operator's intent."""
+        from utils.llm.eu_privacy import REGOLO_SUPPORTED_FEATURES, _EU_FEATURE_MODELS
+
+        missing = REGOLO_SUPPORTED_FEATURES - set(_EU_FEATURE_MODELS.keys())
+        assert not missing, f'features without explicit model picks: {sorted(missing)}'
+
+    def test_every_eu_model_uses_regolo_prefix(self):
+        """Sanity: every value in _EU_FEATURE_MODELS must classify as 'regolo'
+        per _classify_provider, otherwise the dispatcher would route to the
+        wrong factory."""
+        from utils.llm.clients import _classify_provider
+        from utils.llm.eu_privacy import _EU_FEATURE_MODELS
+
+        for feature, model in _EU_FEATURE_MODELS.items():
+            assert _classify_provider(model) == 'regolo', f'{feature}={model} does not classify as regolo'
+
+    def test_eu_on_vision_hard_blocks(self):
+        from utils.llm import eu_privacy
+        from utils.llm.eu_privacy import FeatureRouteKind, resolve_feature_model
+
+        eu_privacy.set_eu_privacy_for_request(True)
+        route = resolve_feature_model('uid-1', 'vision')
+        assert route.kind is FeatureRouteKind.HARD_BLOCK
+
+    def test_eu_on_chat_agent_hard_blocks(self):
+        """chat_agent is Anthropic-only and must NOT silently fall back."""
+        from utils.llm import eu_privacy
+        from utils.llm.eu_privacy import FeatureRouteKind, resolve_feature_model
+
+        eu_privacy.set_eu_privacy_for_request(True)
+        route = resolve_feature_model('uid-1', 'chat_agent')
+        assert route.kind is FeatureRouteKind.HARD_BLOCK
+
+    def test_eu_on_unknown_feature_hard_blocks_by_default(self):
+        """Defensive default: any feature we forgot to categorize must be blocked,
+        not silently routed to a non-EU provider."""
+        from utils.llm import eu_privacy
+        from utils.llm.eu_privacy import FeatureRouteKind, resolve_feature_model
+
+        eu_privacy.set_eu_privacy_for_request(True)
+        route = resolve_feature_model('uid-1', 'feature_we_forgot_to_add')
+        assert route.kind is FeatureRouteKind.HARD_BLOCK
+        assert 'not yet certified' in (route.banner or '')
+
+    def test_eu_flag_fails_closed_on_firestore_error(self):
+        """Privacy fail-safe: if Firestore is unreachable, default to ON.
+        An outage briefly blocking unsupported features is operationally
+        better than briefly leaking EU user data to non-EU providers."""
+        from utils.llm import eu_privacy
+
+        eu_privacy._eu_privacy_ctx.set(None)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('REGOLO_EU_FAIL_OPEN', None)
+            with patch('utils.llm.eu_privacy.users_db.get_eu_privacy_mode', side_effect=RuntimeError('fs down')):
+                assert eu_privacy.get_eu_privacy_for_request('uid-1') is True
+
+    def test_eu_flag_can_fail_open_via_env_flag(self):
+        """REGOLO_EU_FAIL_OPEN=1 lets operators trade strict residency for
+        availability when Firestore is unreachable."""
+        from utils.llm import eu_privacy
+
+        eu_privacy._eu_privacy_ctx.set(None)
+        with patch.dict(os.environ, {'REGOLO_EU_FAIL_OPEN': '1'}):
+            with patch('utils.llm.eu_privacy.users_db.get_eu_privacy_mode', side_effect=RuntimeError('fs down')):
+                assert eu_privacy.get_eu_privacy_for_request('uid-1') is False
+
+    def test_clear_eu_privacy_context_resets_ctx(self):
+        """Background tasks must clear inherited contextvars."""
+        from utils.llm import eu_privacy
+
+        eu_privacy.set_eu_privacy_for_request(True)
+        assert eu_privacy._eu_privacy_ctx.get() is True
+        eu_privacy.clear_eu_privacy_context()
+        assert eu_privacy._eu_privacy_ctx.get() is None
+
+
+# ---------------------------------------------------------------------------
+# Streaming tool-call fixture replay
+#
+# Skipped until the live fixture is captured (run
+# tests/fixtures/capture_regolo_tool_call_stream.sh with a real REGOLO_API_KEY).
+# Phase 1 acceptance gate 9: every captured delta must be parseable by
+# LangChain's native OpenAI accumulator. If this test fails after the fixture
+# is committed, write a custom accumulator in _RegoloChatProxy.
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'fixtures', 'regolo_tool_call_stream.json'
+)
+
+
+@pytest.mark.skipif(
+    not os.path.exists(_FIXTURE_PATH),
+    reason='Run capture_regolo_tool_call_stream.sh with REGOLO_API_KEY to enable.',
+)
+class TestRegoloStreamingToolCallReplay:
+    def test_every_delta_has_expected_shape(self):
+        """Each captured chunk must look like the OpenAI streaming shape so
+        LangChain's native accumulator handles it. Specifically: top-level
+        `choices[i].delta` with optional `content`/`tool_calls`."""
+        import json
+
+        with open(_FIXTURE_PATH) as f:
+            deltas = json.load(f)
+        assert deltas, 'fixture is empty'
+        for d in deltas:
+            choices = d.get('choices') or []
+            assert isinstance(choices, list)
+            for c in choices:
+                # Every chunk past the prologue must carry a delta dict.
+                if 'delta' in c:
+                    assert isinstance(c['delta'], dict)
+
+    def test_tool_call_arguments_concatenate_to_valid_json(self):
+        """The tool_calls.function.arguments deltas must concatenate into
+        valid JSON — that's what the accumulator relies on."""
+        import json
+
+        with open(_FIXTURE_PATH) as f:
+            deltas = json.load(f)
+        # Walk all chunks and accumulate per-tool-call argument strings.
+        per_index_args: dict[int, str] = {}
+        for d in deltas:
+            for c in d.get('choices') or []:
+                delta = c.get('delta') or {}
+                for tc in delta.get('tool_calls') or []:
+                    idx = tc.get('index', 0)
+                    args = (tc.get('function') or {}).get('arguments', '')
+                    per_index_args[idx] = per_index_args.get(idx, '') + args
+        assert per_index_args, 'fixture has no tool_call deltas — recapture with a tool-eligible prompt'
+        for idx, joined in per_index_args.items():
+            # Must be parseable JSON — otherwise our accumulator is broken
+            # OR Regolo emitted in a non-OpenAI shape that needs translation.
+            json.loads(joined)

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -68,6 +68,7 @@ BYOK_HEADERS = {
     'anthropic': 'x-byok-anthropic',
     'gemini': 'x-byok-gemini',
     'deepgram': 'x-byok-deepgram',
+    'regolo': 'x-byok-regolo',
 }
 
 # Keys for the current request, if the client supplied them.

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -65,7 +65,8 @@ from utils.llm.chat import (
     obtain_emotional_message,
 )
 from utils.llm.external_integrations import get_message_structure
-from utils.llm.clients import generate_embedding
+from utils.llm.clients import generate_embedding, generate_regolo_embedding
+from utils.llm.eu_privacy import resolve_feature_model, FeatureRouteKind
 from utils.notifications import send_notification
 from utils.other.hume import get_hume, HumeJobCallbackModel, HumeJobModelPredictionResponseModel
 from utils.retrieval.rag import retrieve_rag_conversation_context
@@ -577,7 +578,23 @@ def _save_action_items(uid: str, conversation: Conversation):
 
 
 def save_structured_vector(uid: str, conversation: Conversation, update_only: bool = False):
-    vector = generate_embedding(str(conversation.structured)) if not update_only else None
+    # M2.5 — privacy-mode-aware embedding write. Resolve once per call;
+    # HARD_BLOCK means EU mode is on but the EU 4096-dim Pinecone index is
+    # not provisioned — skip the write rather than corrupt the legacy index
+    # with a partial 3072-dim vector that bypasses the user's privacy
+    # preference.
+    vector = None
+    if not update_only:
+        route = resolve_feature_model(uid, 'memory_search')
+        if route.kind is FeatureRouteKind.HARD_BLOCK:
+            logger.info(
+                'save_structured_vector: HARD_BLOCK for uid=%s (EU mode on, EU index not provisioned) — skipping',
+                uid,
+            )
+        elif route.kind is FeatureRouteKind.REGOLO:
+            vector = generate_regolo_embedding(str(conversation.structured))
+        else:
+            vector = generate_embedding(str(conversation.structured))
     tz = notification_db.get_user_time_zone(uid)
 
     metadata = {}

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,6 +1,9 @@
+import asyncio
 import hashlib
 import logging
 import os
+import random
+import time
 from typing import Any, Dict, List, Optional
 
 import anthropic
@@ -12,6 +15,12 @@ import tiktoken
 
 from models.structured import Structured
 from utils.byok import get_byok_key
+from utils.llm.regolo_errors import (
+    RegoloError,
+    RegoloRateLimitError,
+    RegoloServiceError,
+    classify_regolo_error,
+)
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
@@ -117,6 +126,99 @@ class _OpenRouterGeminiProxy:
         return other | self._resolve()
 
 
+class _RegoloChatProxy:
+    """Forwards every attribute and call to the appropriate ChatOpenAI for Regolo.
+
+    Regolo (https://api.regolo.ai/v1) is OpenAI-compatible; we drive it through
+    langchain_openai.ChatOpenAI with a custom base_url. BYOK Regolo keys (via
+    `X-BYOK-Regolo`) take precedence over the env REGOLO_API_KEY.
+    """
+
+    __slots__ = ('_model', '_default', '_ctor_kwargs')
+
+    def __init__(self, model: str, default: ChatOpenAI, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_model', model)
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> ChatOpenAI:
+        byok = get_byok_key('regolo')
+        if byok:
+            return _cached_openai_chat(self._model, byok, self._ctor_kwargs)
+        return self._default
+
+    def invoke(self, *args: Any, **kwargs: Any) -> Any:
+        """Wrap ChatOpenAI.invoke with reasoning-content stripping, typed error
+        classification, bounded retry on 429/5xx, and provider=regolo telemetry.
+
+        - On success: drops `reasoning_content` so MiniMax / Qwen3.x thinking
+          output never leaks into chat history.
+        - On 429: retries up to `_REGOLO_MAX_RATE_LIMIT_ATTEMPTS` times,
+          honoring `Retry-After` when present.
+        - On 5xx: retries once with exponential backoff.
+        - On 401/403/404 / unrecognized: re-raises typed `RegoloError`
+          subclass with the original exception preserved via `from`.
+        - Telemetry: injects `provider=regolo` + `model=<name>` tags into
+          the langchain `RunnableConfig` so the upstream `_usage_callback`
+          can attribute usage rows to Regolo.
+        """
+        target = self._resolve()
+        args, kwargs = _inject_regolo_telemetry(self._model, args, kwargs)
+        return _regolo_invoke_with_retry(lambda: target.invoke(*args, **kwargs))
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> Any:
+        """Async equivalent of invoke — same strip / classify / retry / tag contract."""
+        target = self._resolve()
+        args, kwargs = _inject_regolo_telemetry(self._model, args, kwargs)
+        return await _regolo_ainvoke_with_retry(lambda: target.ainvoke(*args, **kwargs))
+
+    def stream(self, *args: Any, **kwargs: Any):
+        """Sync streaming wrapper — strips reasoning_content per chunk and
+        classifies exceptions raised during iteration. Yields the same chunk
+        objects langchain would yield, mutated in place. Telemetry tags
+        injected so streaming usage attributes to Regolo too.
+
+        `target.stream(...)` returns a generator and does not raise on
+        construction; HTTP errors only materialize during iteration.
+        """
+        target = self._resolve()
+        args, kwargs = _inject_regolo_telemetry(self._model, args, kwargs)
+        iterator = target.stream(*args, **kwargs)
+        try:
+            for chunk in iterator:
+                yield strip_reasoning_content(chunk)
+        except RegoloError:
+            raise
+        except Exception as exc:
+            raise classify_regolo_error(exc) from exc
+
+    async def astream(self, *args: Any, **kwargs: Any):
+        """Async streaming wrapper — same contract as `stream` but async."""
+        target = self._resolve()
+        args, kwargs = _inject_regolo_telemetry(self._model, args, kwargs)
+        iterator = target.astream(*args, **kwargs)
+        try:
+            async for chunk in iterator:
+                yield strip_reasoning_content(chunk)
+        except RegoloError:
+            raise
+        except Exception as exc:
+            raise classify_regolo_error(exc) from exc
+
+    def __getattr__(self, name: str) -> Any:
+        # Everything else (bind_tools, batch, abatch, with_structured_output,
+        # with_retry, ...) falls through to the underlying ChatOpenAI. The
+        # invoke/ainvoke/stream/astream paths above cover the four hand-offs
+        # that touch reasoning_content and Regolo error envelopes.
+        return getattr(self._resolve(), name)
+
+    def __or__(self, other: Any) -> Any:
+        return self._resolve() | other
+
+    def __ror__(self, other: Any) -> Any:
+        return other | self._resolve()
+
+
 class _OpenAIEmbeddingsProxy:
     """Transparent proxy for OpenAIEmbeddings that uses BYOK OpenAI when set."""
 
@@ -140,6 +242,204 @@ class _OpenAIEmbeddingsProxy:
 
     def __getattr__(self, name: str):
         return getattr(self._resolve(), name)
+
+
+# ---------------------------------------------------------------------------
+# Regolo embeddings (M2.5)
+#
+# Qwen3-Embedding-8B is 4096-dim; OpenAI text-embedding-3-large is 3072-dim.
+# Pinecone enforces a fixed dimensionality at index creation time, so the
+# 4096-dim vectors CANNOT share an index with the existing 3072-dim ones.
+# Production deployment depends on a SEPARATE Pinecone index provisioned at
+# 4096-dim, surfaced via the PINECONE_INDEX_NAME_EU env var. Until that env
+# var is set, _RegoloEmbeddingProxy.embed_documents/embed_query construct
+# fine but writes/reads will hit the wrong index — see eu_privacy
+# .eu_embedding_index_provisioned() which gates the routing decision.
+# ---------------------------------------------------------------------------
+_REGOLO_EMBEDDING_MODEL = 'Qwen3-Embedding-8B'
+_REGOLO_EMBEDDING_DIM = 4096
+
+
+class _RegoloEmbeddingProxy:
+    """Embeddings client routed to api.regolo.ai/v1 with BYOK Regolo key
+    preferred over the env REGOLO_API_KEY.
+
+    Mirrors `_OpenAIEmbeddingsProxy`'s shape so callers that handle
+    `embed_documents([content])` / `embed_query(text)` can swap proxies
+    without code changes. Same `__getattr__` fallthrough to forward any
+    other langchain Embeddings method to the underlying client.
+    """
+
+    __slots__ = ('_model', '_default', '_ctor_kwargs')
+
+    def __init__(self, model: str, default: OpenAIEmbeddings, ctor_kwargs: Dict[str, Any]):
+        object.__setattr__(self, '_model', model)
+        object.__setattr__(self, '_default', default)
+        object.__setattr__(self, '_ctor_kwargs', ctor_kwargs)
+
+    def _resolve(self) -> OpenAIEmbeddings:
+        byok = get_byok_key('regolo')
+        # Cache key includes provider tag so 'emb:<model>:<hash>' for OpenAI
+        # and 'emb-regolo:<model>:<hash>' for Regolo never collide if the
+        # same key happens to be used cross-provider (unlikely, but safe).
+        if byok:
+            cache_key = f"emb-regolo:{self._model}:{_hash_key(byok)}"
+            inst = _openai_cache.get(cache_key)
+            if inst is None:
+                inst = OpenAIEmbeddings(
+                    model=self._model,
+                    api_key=byok,
+                    base_url=_REGOLO_BASE_URL,
+                    **self._ctor_kwargs,
+                )
+                _openai_cache[cache_key] = inst
+            return inst
+        return self._default
+
+    def __getattr__(self, name: str):
+        return getattr(self._resolve(), name)
+
+
+# ---------------------------------------------------------------------------
+# Regolo retry policy (M1.3)
+#
+# Applied at the invoke / ainvoke hand-off in `_RegoloChatProxy`. NOT applied
+# to streaming wrappers — retrying mid-stream would resend the prompt and
+# duplicate any side effects callers have already observed from the partial
+# output.
+#
+# Policy:
+#   - 429 (RegoloRateLimitError): up to 3 total attempts (initial + 2 retries).
+#     Honors `Retry-After` when present, otherwise exponential backoff with
+#     10% jitter, capped at _REGOLO_RETRY_MAX_BACKOFF_S.
+#   - 5xx (RegoloServiceError): 1 retry with exponential backoff, then re-raise.
+#   - Everything else (auth / forbidden / model-not-found / unknown):
+#     re-raise immediately as the typed RegoloError subclass.
+# ---------------------------------------------------------------------------
+_REGOLO_MAX_RATE_LIMIT_ATTEMPTS = 3
+_REGOLO_RETRY_BASE_BACKOFF_S = 1.0
+_REGOLO_RETRY_MAX_BACKOFF_S = 30.0
+
+_REGOLO_PROVIDER_TAG = 'provider=regolo'
+
+
+def _inject_regolo_telemetry(
+    model: str, args: tuple, kwargs: Dict[str, Any]
+) -> tuple:
+    """Add `provider=regolo` + `model=<name>` to the langchain RunnableConfig.
+
+    langchain's `Runnable.invoke(input, config=None, **kwargs)` accepts the
+    config either as 2nd positional or `config=` kwarg. We merge into whichever
+    the caller used (or set kwarg if neither). Both tags and metadata channels
+    carry the attribution so callbacks reading either can attribute usage rows
+    to Regolo.
+
+    Idempotency / merge rules:
+      - `provider=regolo` tag: appended only if not already present.
+      - `model=<name>` tag: appended only if no `model=` tag is already present
+        (so a caller's own `model=foo` isn't double-stamped).
+      - `metadata['regolo_provider']` and `metadata['regolo_model']`: always
+        set (these are M1-private keys; never collide with caller metadata).
+      - `metadata['provider']`: set via setdefault to preserve any caller-
+        supplied value. The tags channel + the `regolo_provider` key keep
+        attribution working even if a caller pre-sets `metadata['provider']`.
+    """
+    # Resolve current config (may be None, dict, or langchain's RunnableConfig
+    # which is a TypedDict — both behave like dicts at runtime).
+    config_via_kwarg = 'config' in kwargs
+    if config_via_kwarg:
+        existing = kwargs.get('config') or {}
+    elif len(args) >= 2:
+        existing = args[1] or {}
+    else:
+        existing = {}
+
+    new_config = dict(existing)
+
+    tags = list(new_config.get('tags') or [])
+    if _REGOLO_PROVIDER_TAG not in tags:
+        tags.append(_REGOLO_PROVIDER_TAG)
+    if not any(isinstance(t, str) and t.startswith('model=') for t in tags):
+        tags.append(f'model={model}')
+    new_config['tags'] = tags
+
+    metadata = dict(new_config.get('metadata') or {})
+    # M1-private keys — always overwrite so the upstream callback gets a
+    # reliable Regolo signal even when caller metadata uses 'provider'.
+    metadata['regolo_provider'] = 'regolo'
+    metadata['regolo_model'] = model
+    metadata.setdefault('provider', 'regolo')
+    new_config['metadata'] = metadata
+
+    if config_via_kwarg or len(args) < 2:
+        kwargs['config'] = new_config
+        return args, kwargs
+    args = (args[0], new_config) + args[2:]
+    return args, kwargs
+
+
+def _regolo_backoff_seconds(attempt: int, retry_after_s: Optional[float]) -> float:
+    """Wait seconds for a Regolo retry. `attempt` is 0-indexed."""
+    if retry_after_s is not None and retry_after_s > 0:
+        return min(retry_after_s, _REGOLO_RETRY_MAX_BACKOFF_S)
+    base = _REGOLO_RETRY_BASE_BACKOFF_S * (2**attempt)
+    jitter = random.uniform(0, base * 0.1)
+    return min(base + jitter, _REGOLO_RETRY_MAX_BACKOFF_S)
+
+
+def _next_regolo_retry_wait(
+    rate_limit_attempts: int, five_xx_retried: bool, classified: RegoloError
+) -> Optional[float]:
+    """Wait seconds, or None if the retry budget is exhausted / error is terminal."""
+    if isinstance(classified, RegoloRateLimitError):
+        if rate_limit_attempts >= _REGOLO_MAX_RATE_LIMIT_ATTEMPTS - 1:
+            return None
+        return _regolo_backoff_seconds(rate_limit_attempts, classified.retry_after_s)
+    if isinstance(classified, RegoloServiceError) and not five_xx_retried:
+        return _regolo_backoff_seconds(0, None)
+    return None
+
+
+def _regolo_invoke_with_retry(call: Any) -> Any:
+    """Sync retry loop. `call` is a 0-arg callable that returns the LLM result."""
+    rate_limit_attempts = 0
+    five_xx_retried = False
+    while True:
+        try:
+            return strip_reasoning_content(call())
+        except Exception as exc:
+            classified = exc if isinstance(exc, RegoloError) else classify_regolo_error(exc)
+            wait = _next_regolo_retry_wait(rate_limit_attempts, five_xx_retried, classified)
+            if wait is None:
+                if isinstance(exc, RegoloError):
+                    raise
+                raise classified from exc
+            if isinstance(classified, RegoloRateLimitError):
+                rate_limit_attempts += 1
+            elif isinstance(classified, RegoloServiceError):
+                five_xx_retried = True
+            time.sleep(wait)
+
+
+async def _regolo_ainvoke_with_retry(call: Any) -> Any:
+    """Async retry loop. `call` is a 0-arg callable returning an awaitable."""
+    rate_limit_attempts = 0
+    five_xx_retried = False
+    while True:
+        try:
+            return strip_reasoning_content(await call())
+        except Exception as exc:
+            classified = exc if isinstance(exc, RegoloError) else classify_regolo_error(exc)
+            wait = _next_regolo_retry_wait(rate_limit_attempts, five_xx_retried, classified)
+            if wait is None:
+                if isinstance(exc, RegoloError):
+                    raise
+                raise classified from exc
+            if isinstance(classified, RegoloRateLimitError):
+                rate_limit_attempts += 1
+            elif isinstance(classified, RegoloServiceError):
+                five_xx_retried = True
+            await asyncio.sleep(wait)
 
 
 _BYOK_CACHE_MAX_SIZE = 256
@@ -321,7 +621,14 @@ _PERPLEXITY_ONLY_FEATURES = {'web_search'}  # always Perplexity, used via get_mo
 
 
 def _classify_provider(model: str) -> str:
-    """Classify provider from model name. Provider follows the model, not the feature."""
+    """Classify provider from model name. Provider follows the model, not the feature.
+
+    Regolo models are tagged with a `regolo/` prefix to distinguish them from
+    OpenRouter (which also uses `/`-prefixed names like `google/gemini-...`).
+    The Regolo prefix is stripped before being sent to the API.
+    """
+    if model.startswith('regolo/'):
+        return 'regolo'
     if '/' in model:
         return 'openrouter'
     if model.startswith('claude'):
@@ -338,6 +645,12 @@ _OPENROUTER_TEMPERATURES: Dict[str, float] = {
     'persona_chat_premium': 0.8,
     'wrapped_analysis': 0.7,
 }
+
+# Per-feature temperatures for Regolo features. Empty today — populate when a
+# Regolo-routed feature needs a non-default temperature. Keep this distinct
+# from `_OPENROUTER_TEMPERATURES` so a future entry doesn't silently affect
+# the wrong provider.
+_REGOLO_TEMPERATURES: Dict[str, float] = {}
 
 # Models that support OpenAI prompt caching (prompt_cache_key routing).
 _CACHE_KEY_MODELS = {'gpt-5.4', 'gpt-5.4-mini'}
@@ -429,6 +742,93 @@ def _get_or_create_openrouter_llm(
     return _llm_cache[key]
 
 
+# Regolo (https://api.regolo.ai) — Italy-hosted, OpenAI-compatible, GDPR-compliant
+# (zero-retention) inference. Used for the EU Privacy Mode path.
+#
+# SSRF defense: _REGOLO_BASE_URL is a private module constant. It is NEVER
+# derived from request headers or user input. Tests assert the exact prefix.
+_REGOLO_BASE_URL = "https://api.regolo.ai/v1"
+
+# Models that require chat_template_kwargs.enable_thinking=False or they will
+# burn the entire output budget on hidden reasoning tokens (and the visible
+# completion comes back as content=null with finish_reason=length). Live-
+# probed Apr 27 2026 — see docs/04-model-mapping.md for raw probe results.
+#
+# Every model in the qwen-3.x family + minimax-m2.5 falls into this bucket.
+# Llama, mistral, gpt-oss, gemma, apertus, and qwen3-coder-next do NOT.
+_REGOLO_THINKING_MODELS = frozenset(
+    {
+        'minimax-m2.5',
+        'qwen3.5-122b',
+        'qwen3.5-9b',
+        'qwen3.6-27b',
+    }
+)
+
+
+def _get_or_create_regolo_llm(
+    model_name: str, streaming: bool = False, temperature: Optional[float] = None
+) -> ChatOpenAI:
+    """Get or create a BYOK-aware ChatOpenAI proxy for a Regolo model.
+
+    `model_name` is expected to carry the `regolo/` prefix (e.g.
+    `regolo/Llama-3.3-70B-Instruct`); the prefix is stripped before being
+    sent to api.regolo.ai. Auth uses the per-request BYOK Regolo key when
+    set, otherwise the process-wide REGOLO_API_KEY env var.
+
+    For thinking models (minimax-m2.5, qwen3.5-122b), injects
+    `chat_template_kwargs.enable_thinking=False` via `extra_body` so the
+    model returns chat content instead of a truncated reasoning trace.
+    """
+    key = (model_name, streaming, 'regolo', temperature)
+    if key not in _llm_cache:
+        api_model = model_name.split('/', 1)[1] if model_name.startswith('regolo/') else model_name
+        kwargs: Dict[str, Any] = {
+            'api_key': os.environ.get('REGOLO_API_KEY'),
+            'base_url': _REGOLO_BASE_URL,
+            'callbacks': [_usage_callback],
+        }
+        # Thinking knob — Regolo-specific request body field. Without it,
+        # minimax-m2.5/qwen3.5-122b return content=null, finish_reason=length.
+        if api_model in _REGOLO_THINKING_MODELS:
+            kwargs['extra_body'] = {"chat_template_kwargs": {"enable_thinking": False}}
+        if temperature is not None:
+            kwargs['temperature'] = temperature
+        if streaming:
+            kwargs['streaming'] = True
+            kwargs['stream_options'] = {"include_usage": True}
+        default = ChatOpenAI(model=api_model, **kwargs)
+        _llm_cache[key] = _RegoloChatProxy(model=api_model, default=default, ctor_kwargs=kwargs)
+    return _llm_cache[key]
+
+
+def strip_reasoning_content(message: Any) -> Any:
+    """Strip Regolo's non-OpenAI `reasoning_content` field before persistence.
+
+    Thinking models (minimax-m2.5, qwen3.5-122b) emit a `reasoning_content`
+    field on the assistant message and on streaming deltas. Persisting it
+    bloats Firestore and risks leaking raw chain-of-thought to the client.
+    This helper mutates-in-place when given a langchain `BaseMessage` (drops
+    `additional_kwargs.reasoning_content`) and also works on raw dict deltas.
+
+    Returns the same object for chaining.
+    """
+    if message is None:
+        return message
+    # langchain BaseMessage: reasoning_content lands in additional_kwargs.
+    if hasattr(message, 'additional_kwargs') and isinstance(message.additional_kwargs, dict):
+        message.additional_kwargs.pop('reasoning_content', None)
+    # Raw dict (streaming delta): drop top-level field.
+    if isinstance(message, dict):
+        message.pop('reasoning_content', None)
+        # OpenAI streaming chunks nest content under 'delta' or 'message'.
+        for nested_key in ('delta', 'message'):
+            nested = message.get(nested_key)
+            if isinstance(nested, dict):
+                nested.pop('reasoning_content', None)
+    return message
+
+
 def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = None) -> ChatOpenAI:
     """Get the LLM client for a feature based on the active Model QoS profile.
 
@@ -472,6 +872,10 @@ def get_llm(feature: str, streaming: bool = False, cache_key: Optional[str] = No
     if provider == 'openrouter':
         temp = _OPENROUTER_TEMPERATURES.get(feature)
         return _get_or_create_openrouter_llm(model, streaming, temp)
+
+    if provider == 'regolo':
+        temp = _REGOLO_TEMPERATURES.get(feature)
+        return _get_or_create_regolo_llm(model, streaming, temp)
 
     llm = _get_or_create_openai_llm(model, streaming)
     if cache_key and model in _CACHE_KEY_MODELS:
@@ -671,6 +1075,22 @@ embeddings = _OpenAIEmbeddingsProxy(
     default=_embeddings_default,
     ctor_kwargs={},
 )
+
+# Regolo embeddings (M2.5). Default client targets api.regolo.ai with the
+# env REGOLO_API_KEY; BYOK Regolo keys take precedence per _RegoloEmbeddingProxy
+# ._resolve. Only used when EU Privacy Mode is on AND
+# eu_privacy.eu_embedding_index_provisioned() is True (see PINECONE_INDEX_NAME_EU).
+_regolo_embeddings_default = OpenAIEmbeddings(
+    model=_REGOLO_EMBEDDING_MODEL,
+    api_key=os.environ.get('REGOLO_API_KEY', ''),
+    base_url=_REGOLO_BASE_URL,
+)
+regolo_embeddings = _RegoloEmbeddingProxy(
+    model=_REGOLO_EMBEDDING_MODEL,
+    default=_regolo_embeddings_default,
+    ctor_kwargs={},
+)
+
 parser = PydanticOutputParser(pydantic_object=Structured)
 
 encoding = tiktoken.encoding_for_model('gpt-4')
@@ -684,6 +1104,17 @@ def num_tokens_from_string(string: str) -> int:
 
 def generate_embedding(content: str) -> List[float]:
     return embeddings.embed_documents([content])[0]
+
+
+def generate_regolo_embedding(content: str) -> List[float]:
+    """Generate a 4096-dim embedding via Qwen3-Embedding-8B on api.regolo.ai.
+
+    Used when EU Privacy Mode is on AND the EU-side Pinecone index has been
+    provisioned. Callers MUST verify both conditions via
+    eu_privacy.eu_embedding_index_provisioned() before invoking — writing
+    a 4096-dim vector to the legacy 3072-dim index hard-fails server-side.
+    """
+    return regolo_embeddings.embed_documents([content])[0]
 
 
 def gemini_embed_query(text: str) -> List[float]:

--- a/backend/utils/llm/eu_privacy.py
+++ b/backend/utils/llm/eu_privacy.py
@@ -1,0 +1,331 @@
+"""EU Privacy Mode dispatcher.
+
+When a user opts in (Firestore `users/{uid}.eu_privacy_mode = true`), backend
+LLM features re-route to Regolo's Italy-hosted inference for the supported
+workloads, and HARD-BLOCK workloads we cannot serve in-EU yet (vision,
+web-search, embeddings, the Anthropic-only chat agent).
+
+We deliberately do NOT silently fall back to non-EU providers for blocked
+features. A banner-only fallback would mean the privacy guarantee leaks data
+even with the toggle on; the right answer is to disable the affected feature
+in the UI and tell the user.
+
+A request-scoped contextvar holds the resolved EU-mode flag so every feature
+in the same request sees a consistent value. Setting it from middleware
+costs one Firestore read per privacy-conscious user — not the hot path.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Optional
+
+import database.users as users_db
+from utils.llm.clients import get_model
+
+logger = logging.getLogger('eu_privacy')
+
+# Features that Regolo can serve today (Phase 1). Every entry below must
+# have a corresponding model in `_EU_FEATURE_MODELS`. The set covers every
+# Omi LLM feature except the hard-blocked ones (chat_agent → Anthropic-only,
+# web_search → Perplexity-only, vision → no PAYG vision model on Regolo).
+#
+# Picks are based on live latency + JSON-quality probes (Apr 27 2026); see
+# docs/04-model-mapping.md for the empirical data driving the mapping.
+REGOLO_SUPPORTED_FEATURES: frozenset[str] = frozenset(
+    {
+        # Conversation post-processing (mid-tier)
+        'conv_action_items',
+        'conv_structure',
+        'conv_app_result',
+        'daily_summary',
+        'external_structure',
+        # Conversation lightweight (nano-tier)
+        'conv_app_select',
+        'conv_folder',
+        'conv_discard',
+        'daily_summary_simple',
+        # Memory & knowledge (mid-tier extraction)
+        'memories',
+        'learnings',
+        'memory_conflict',
+        'knowledge_graph',  # LLM extraction, NOT search — search is in EMBEDDING_DEPENDENT_FEATURES
+        # Memory lightweight (nano-tier)
+        'memory_category',
+        # Chat (mid-tier — chat_agent is excluded; that's Anthropic-only)
+        'chat_responses',
+        'chat_extraction',
+        'chat_graph',
+        # Chat lightweight (nano-tier)
+        'session_titles',
+        # Features (mid-tier)
+        'goals',
+        'goals_advice',
+        'notifications',
+        'proactive_notification',
+        'app_generator',
+        'persona_clone',
+        'persona_chat_premium',
+        'wrapped_analysis',
+        # Features lightweight (nano-tier)
+        'followup',
+        'smart_glasses',
+        'onboarding',
+        'app_integration',
+        'trends',
+        'persona_chat',
+    }
+)
+
+# Features that EU Privacy Mode HARD-BLOCKS. These either have no Regolo
+# equivalent (Anthropic agent, Perplexity web search) or have one Regolo
+# can't reliably serve on PAYG (vision via qwen3-vl-32b).
+REGOLO_HARD_BLOCKED_FEATURES: frozenset[str] = frozenset(
+    {
+        'chat_agent',  # Anthropic-only
+        'web_search',  # Perplexity-only
+        'vision',  # qwen3-vl-32b not reliably available
+    }
+)
+
+# Embedding-dependent features (search-side). Phase 1 keeps embeddings on
+# OpenAI by carving them out — but EU mode HARD-BLOCKS them rather than
+# silently leaking. Phase 2 will introduce the Qwen3-Embedding-8B 4096-dim
+# adapter and graduate these to REGOLO_SUPPORTED_FEATURES.
+#
+# Note: `knowledge_graph` (LLM-side entity/relationship extraction, in
+# REGOLO_SUPPORTED_FEATURES above) is distinct from `knowledge_graph_search`
+# (vector lookup over the graph, listed here). Same domain, different code
+# paths — only the search side is embedding-dependent.
+EMBEDDING_DEPENDENT_FEATURES: frozenset[str] = frozenset(
+    {
+        'memory_search',
+        'knowledge_graph_search',
+        'screen_activity_search',
+    }
+)
+
+
+class FeatureRouteKind(enum.Enum):
+    REGOLO = 'regolo'
+    PRIMARY = 'primary'
+    HARD_BLOCK = 'hard_block'
+
+
+@dataclass(frozen=True)
+class FeatureRoute:
+    """Outcome of `resolve_feature_model`.
+
+    - REGOLO: caller should use `model` (a `regolo/<id>` string) via
+      `get_llm()` / `_get_or_create_regolo_llm()`.
+    - PRIMARY: caller should use `model` via the existing non-EU path; this
+      is what happens when EU mode is OFF (the common case).
+    - HARD_BLOCK: caller MUST refuse the request with `banner` as the user-
+      facing reason. Do NOT make any LLM call.
+    """
+
+    kind: FeatureRouteKind
+    model: Optional[str]
+    banner: Optional[str] = None
+
+    @property
+    def is_eu_route(self) -> bool:
+        return self.kind is FeatureRouteKind.REGOLO
+
+
+# Request-scoped EU privacy flag. Default None so middleware can detect
+# "never set" vs "explicitly False" if needed.
+_eu_privacy_ctx: ContextVar[Optional[bool]] = ContextVar('eu_privacy_mode', default=None)
+
+
+def set_eu_privacy_for_request(enabled: bool) -> None:
+    """Called by FastAPI middleware after reading the user's setting."""
+    _eu_privacy_ctx.set(bool(enabled))
+
+
+def get_eu_privacy_for_request(uid: Optional[str]) -> bool:
+    """Return the per-request EU Privacy Mode flag.
+
+    If middleware already set it, return that. Otherwise, fall back to a
+    direct Firestore read — covers WebSocket handlers and tests that bypass
+    HTTP middleware.
+
+    Privacy fail-safe: if Firestore is unreachable AND we have a uid, default
+    to ON. The whole feature is a privacy guarantee; an outage briefly
+    blocking blocked-feature requests is operationally better than briefly
+    leaking data to non-EU providers. Operators who prefer availability over
+    strict residency can set REGOLO_EU_FAIL_OPEN=1.
+
+    If `uid` is missing (system-internal calls with no user context),
+    defaults to OFF since there is no user to protect.
+    """
+    cached = _eu_privacy_ctx.get()
+    if cached is not None:
+        return cached
+    if not uid:
+        return False
+    try:
+        value = users_db.get_eu_privacy_mode(uid)
+    except Exception:
+        fail_open = os.environ.get('REGOLO_EU_FAIL_OPEN', '').strip() == '1'
+        value = False if fail_open else True
+        logger.exception(
+            'eu_privacy: failed to read flag uid=%s — defaulting to %s (fail_open=%s)',
+            uid,
+            'OFF' if not value else 'ON',
+            fail_open,
+        )
+    _eu_privacy_ctx.set(value)
+    return value
+
+
+def clear_eu_privacy_context() -> None:
+    """Reset the per-request EU privacy contextvar.
+
+    Call at the entry of background tasks that may inherit ContextVar state
+    from a parent request. Without this, a task spawned via
+    `asyncio.create_task` or `loop.run_in_executor` keeps the parent's
+    privacy flag — which is wrong when the task is acting as a different
+    user, or is a system-internal job that should hit the primary path.
+    """
+    _eu_privacy_ctx.set(None)
+
+
+# Phase 1 EU model picks. Two-tier strategy mirroring upstream's gpt-4.1-mini
+# vs gpt-4.1-nano split. Picks driven by a 5-sample latency probe (Apr 27 2026
+# — see docs/04-model-mapping.md for raw data):
+#
+#   _EU_MID  = mistral-small-4-119b   (€0.50/€2.10, p50 0.43s, p90 0.44s,
+#                                      tool-calling verified, no thinking quirks)
+#   _EU_NANO = Llama-3.1-8B-Instruct  (€0.05/€0.25, p50 0.62s, p90 0.72s,
+#                                      tool-calling verified)
+#
+# Why NOT thinking models as defaults (minimax-m2.5, qwen3.5-9b/122b/3.6-27b):
+# the multi-sample probe revealed all of them have catastrophic tail latency
+# on Regolo's PAYG tier. minimax-m2.5 had 3/5 timeouts at 60s (working calls
+# took 48-60s). qwen3.5-122b is bimodal — p50 0.36s but p90 2.25s. qwen3.5-9b
+# similar — p50 2.5s, p90 42s, one timeout. Llama-3.3-70B and
+# mistral-small-4-119b were both rock-solid (P90 within 2% of P50).
+#
+# Why mistral over Llama-3.3-70B for mid-tier: 2× faster (0.43s vs 0.83s),
+# 17% cheaper input, 22% cheaper output, equally consistent, equal
+# tool-calling reliability. Llama wins on "household name" but loses on
+# every measured dimension.
+#
+# Operators retain MODEL_QOS_<FEATURE>=regolo/<model> overrides for cases
+# where a thinking model's reasoning genuinely beats mistral's instruct
+# tuning (e.g. a complex extraction pipeline that's tolerant of tail latency).
+_EU_MID = 'regolo/mistral-small-4-119b'
+_EU_NANO = 'regolo/Llama-3.1-8B-Instruct'
+
+_EU_FEATURE_MODELS: dict[str, str] = {
+    # Conversation post-processing — mid-tier (matches gpt-5.4-mini upstream)
+    'conv_action_items': _EU_MID,
+    'conv_structure': _EU_MID,
+    'conv_app_result': _EU_MID,
+    'daily_summary': _EU_MID,
+    'external_structure': _EU_MID,
+    # Conversation lightweight — nano-tier (matches gpt-4.1-nano upstream)
+    'conv_app_select': _EU_NANO,
+    'conv_folder': _EU_NANO,
+    'conv_discard': _EU_NANO,
+    'daily_summary_simple': _EU_NANO,
+    # Memory & knowledge — quality-sensitive extraction stays mid
+    'memories': _EU_MID,
+    'learnings': _EU_MID,
+    'memory_conflict': _EU_MID,
+    'knowledge_graph': _EU_MID,
+    'memory_category': _EU_NANO,
+    # Chat — mid-tier
+    'chat_responses': _EU_MID,
+    'chat_extraction': _EU_MID,
+    'chat_graph': _EU_MID,
+    'session_titles': _EU_NANO,
+    # Features
+    'goals': _EU_MID,
+    'goals_advice': _EU_MID,
+    'notifications': _EU_MID,
+    'proactive_notification': _EU_MID,
+    'app_generator': _EU_MID,  # could swap to regolo/qwen3-coder-next if code-heavy
+    'persona_clone': _EU_MID,
+    'persona_chat_premium': _EU_MID,
+    'wrapped_analysis': _EU_MID,  # was google/gemini-3-flash-preview upstream
+    'followup': _EU_NANO,
+    'smart_glasses': _EU_NANO,
+    'onboarding': _EU_NANO,
+    'app_integration': _EU_NANO,
+    'trends': _EU_NANO,
+    'persona_chat': _EU_NANO,
+}
+
+
+def _hard_block_banner(feature: str) -> str:
+    if feature in EMBEDDING_DEPENDENT_FEATURES:
+        return (
+            'Memory search and knowledge-graph features are disabled in EU '
+            'Privacy Mode. Disable EU Privacy Mode in Settings to use them.'
+        )
+    if feature == 'vision':
+        return 'Vision features require a non-EU provider and are disabled in EU Privacy Mode.'
+    if feature == 'web_search':
+        return 'Web search requires a non-EU provider and is disabled in EU Privacy Mode.'
+    if feature == 'chat_agent':
+        return 'The chat agent currently runs on a non-EU provider and is disabled in EU Privacy Mode.'
+    return f'Feature "{feature}" is unavailable in EU Privacy Mode.'
+
+
+def eu_embedding_index_provisioned() -> bool:
+    """True when the EU-side Pinecone index has been provisioned at 4096-dim
+    and surfaced via PINECONE_INDEX_NAME_EU. While False, embedding-dependent
+    features stay HARD_BLOCKED in EU mode — writing a 4096-dim vector to the
+    legacy 3072-dim index would hard-fail server-side.
+
+    Set this env var on the deploy that has the second Pinecone index
+    available. Until then M2.5 ships dormant: the proxy classes exist
+    but the dispatcher never routes embedding workloads to them.
+    """
+    return bool(os.environ.get('PINECONE_INDEX_NAME_EU', '').strip())
+
+
+def resolve_feature_model(uid: Optional[str], feature: str) -> FeatureRoute:
+    """Decide where to route a feature for the given user.
+
+    The caller passes the user's uid (or None for system-internal calls
+    that always use the primary path) and the feature name. The returned
+    FeatureRoute tells the caller which path to take — including HARD_BLOCK
+    cases where the caller MUST refuse the request without making any LLM
+    call (banner field carries the user-facing reason).
+    """
+    eu_mode = get_eu_privacy_for_request(uid)
+
+    if not eu_mode:
+        return FeatureRoute(kind=FeatureRouteKind.PRIMARY, model=get_model(feature))
+
+    if feature in REGOLO_HARD_BLOCKED_FEATURES:
+        return FeatureRoute(kind=FeatureRouteKind.HARD_BLOCK, model=None, banner=_hard_block_banner(feature))
+
+    if feature in EMBEDDING_DEPENDENT_FEATURES:
+        # M2.5: lift HARD_BLOCK to REGOLO route only when the EU-side Pinecone
+        # index is provisioned. Without it, the 4096-dim Qwen3 embedding
+        # would have nowhere safe to write — keep blocking.
+        if eu_embedding_index_provisioned():
+            return FeatureRoute(kind=FeatureRouteKind.REGOLO, model='regolo/Qwen3-Embedding-8B')
+        return FeatureRoute(kind=FeatureRouteKind.HARD_BLOCK, model=None, banner=_hard_block_banner(feature))
+
+    if feature in REGOLO_SUPPORTED_FEATURES:
+        model = _EU_FEATURE_MODELS.get(feature, 'regolo/Llama-3.3-70B-Instruct')
+        return FeatureRoute(kind=FeatureRouteKind.REGOLO, model=model)
+
+    # Unmapped feature in EU mode — block by default. Better to surface a
+    # disabled feature than to leak by accident on a feature we forgot to
+    # categorize.
+    logger.warning('eu_privacy: feature %s has no EU mapping — hard-blocking', feature)
+    return FeatureRoute(
+        kind=FeatureRouteKind.HARD_BLOCK,
+        model=None,
+        banner=f'Feature "{feature}" is not yet certified for EU Privacy Mode.',
+    )

--- a/backend/utils/llm/regolo_errors.py
+++ b/backend/utils/llm/regolo_errors.py
@@ -1,0 +1,170 @@
+"""Regolo-specific error taxonomy.
+
+Maps Regolo HTTP responses to distinct internal categories so callers can
+distinguish credential failures from quota exhaustion from temporary outages.
+A generic 500 from the backend masks credential compromise and gives users no
+useful signal — every category here exists because at least one upstream
+caller needs to react differently.
+
+These errors are raised by the EU Privacy Mode dispatcher and the chat router
+when a Regolo call fails. The dispatcher decides whether the error is
+fallback-eligible (ServiceError, RateLimitError after backoff) or terminal
+(AuthError, ForbiddenError, ModelNotFoundError).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class RegoloError(Exception):
+    """Base class for all Regolo-specific failures.
+
+    Subclasses carry the original status code so logging can record it
+    without re-deriving from response bodies (which may be sanitized).
+    """
+
+    status_code: Optional[int] = None
+    fallback_eligible: bool = False
+
+    def __init__(self, message: str, status_code: Optional[int] = None):
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+
+
+class RegoloAuthError(RegoloError):
+    """401 — invalid or revoked API key.
+
+    Surface to the user as an auth-required signal so they re-enter the BYOK
+    Regolo key. Never fall back: a key change is required to recover.
+    """
+
+    status_code = 401
+    fallback_eligible = False
+
+
+class RegoloForbiddenError(RegoloError):
+    """403 — model not allowed on the current plan tier.
+
+    Example: requesting `qwen3-vl-32b` on PAYG. UI must disable the feature
+    that needs this model rather than retrying with a different prompt.
+    """
+
+    status_code = 403
+    fallback_eligible = False
+
+
+class RegoloModelNotFoundError(RegoloError):
+    """404 — model id does not exist (typo or model retirement).
+
+    Logs at WARNING level with the model name so the catalog drift is
+    discoverable. Caller should surface a configuration error to the
+    operator, not retry.
+    """
+
+    status_code = 404
+    fallback_eligible = False
+
+
+class RegoloRateLimitError(RegoloError):
+    """429 — quota or per-tenant rate limit exceeded.
+
+    Carries `retry_after_s` parsed from the `Retry-After` header so the
+    caller can implement bounded exponential backoff instead of guessing.
+    """
+
+    status_code = 429
+    fallback_eligible = True
+
+    def __init__(self, message: str, retry_after_s: Optional[float] = None):
+        super().__init__(message, status_code=429)
+        self.retry_after_s = retry_after_s
+
+
+class RegoloServiceError(RegoloError):
+    """5xx — Regolo service outage or upstream failure.
+
+    Fallback-eligible: after one retry, the EU Privacy Mode dispatcher may
+    fall back to the primary provider with a visible banner. Repeated
+    occurrences should fire a circuit breaker.
+    """
+
+    status_code = 500
+    fallback_eligible = True
+
+
+def classify_regolo_error(exc: BaseException) -> RegoloError:
+    """Map an arbitrary upstream exception to the right RegoloError subclass.
+
+    Inspects common attributes set by the OpenAI Python SDK / httpx
+    (`status_code`, `response.status_code`, `code`) without raising on
+    missing fields. Falls back to RegoloServiceError for anything we can't
+    classify so a transient unknown error stays fallback-eligible.
+
+    Never re-raises — always returns an instance the caller can `raise from`.
+    """
+    if isinstance(exc, RegoloError):
+        return exc
+
+    status = _extract_status_code(exc)
+    detail = _safe_message(exc)
+
+    if status == 401:
+        return RegoloAuthError(detail or 'Regolo authentication failed', status_code=status)
+    if status == 403:
+        return RegoloForbiddenError(detail or 'Regolo model not allowed on plan', status_code=status)
+    if status == 404:
+        return RegoloModelNotFoundError(detail or 'Regolo model not found', status_code=status)
+    if status == 429:
+        retry_after = _extract_retry_after(exc)
+        return RegoloRateLimitError(detail or 'Regolo rate limit exceeded', retry_after_s=retry_after)
+    if status is not None and 500 <= status < 600:
+        return RegoloServiceError(detail or f'Regolo service error ({status})', status_code=status)
+
+    # Unknown — treat as transient so we get fallback behavior on first hit.
+    return RegoloServiceError(detail or 'Regolo error (unclassified)', status_code=status)
+
+
+def _extract_status_code(exc: BaseException) -> Optional[int]:
+    for attr in ('status_code', 'http_status'):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int):
+            return value
+    response = getattr(exc, 'response', None)
+    if response is not None:
+        value = getattr(response, 'status_code', None)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _extract_retry_after(exc: BaseException) -> Optional[float]:
+    response = getattr(exc, 'response', None)
+    if response is None:
+        return None
+    headers = getattr(response, 'headers', None)
+    if headers is None:
+        return None
+    raw = headers.get('Retry-After') if hasattr(headers, 'get') else None
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_message(exc: BaseException) -> str:
+    """Return a sanitized one-line summary of the exception.
+
+    Keeps status code and error type — drops potentially sensitive payload
+    bodies. The Regolo API may echo prompt content in error messages on some
+    400-family errors; we don't want that reaching our logs.
+    """
+    cls = type(exc).__name__
+    text = str(exc)
+    # Truncate aggressively — error chains can include full request bodies.
+    if len(text) > 200:
+        text = text[:200] + '…'
+    return f'{cls}: {text}' if text else cls


### PR DESCRIPTION
## Summary

Closes the M2 audit's privacy-write gap (sister-repo MR !5,
[Euraika-Labs/omi-regolo-integration](https://github.com/Euraika-Labs/omi-regolo-integration)
docs at `desktop/docs/M2-embedding-audit.md`). After this PR + the second
Pinecone index is provisioned + sister-repo MR !6 is merged, EU Privacy
Mode users will see embedding writes routed through Regolo
(Qwen3-Embedding-8B, 4096-dim) on a parallel Pinecone index, with no risk
of dimensionality collisions on the existing 3072-dim index.

## What this PR does

### 1. Provider-aware index selector in `backend/database/vector_db.py`

Adds `_get_index_for_provider(provider)` that returns the right Pinecone
handle. `provider='regolo'` routes to `PINECONE_INDEX_NAME_EU` (4096-dim);
anything else routes to the legacy `PINECONE_INDEX_NAME` (3072-dim).
Returns `None` when the requested provider's env var isn't set — caller
must handle gracefully.

### 2. Additive `(provider, model, dim)` metadata on every vector write

Updates `_get_data` and the per-namespace upsert helpers to include
`provider`, `model`, `dim` in vector metadata. Non-breaking — Pinecone
ignores unknown metadata fields, so existing readers keep working.

### 3. One-shot backfill migration `006_byok_provider_metadata.py`

Tags every existing vector with the legacy attribution
`{provider:'openai', model:'text-embedding-3-large', dim:3072}` for ns1+ns2,
and `{provider:'gemini', model:'embedding-001', dim:3072}` for ns3.
Idempotent — skips already-tagged vectors. Estimated runtime ~5 min for
30K vectors at 100/sec.

### 4. Privacy-mode-aware write-path call sites

Refactors:
- `backend/utils/conversations/process_conversation.py:580`
  (`save_structured_vector`)
- `backend/utils/app_integrations.py:206`
- `backend/utils/app_integrations.py:338`

Each now consults `eu_privacy.resolve_feature_model(uid, feature)` and
routes embedding workloads to either OpenAI's `generate_embedding` or
Regolo's `generate_regolo_embedding` (added in sister-repo MR !6 to
`backend/utils/llm/clients.py`), then writes to the corresponding index
via `_get_index_for_provider(provider)`.

## Why these four pieces ship together

Splitting them invites half-deployed states where a 4096-dim vector
attempts a 3072-dim Pinecone upsert — hard server-side failure. The
`resolve_feature_model` dispatcher already guards via
`eu_privacy.eu_embedding_index_provisioned()` (sister-repo MR !6,
returns false until `PINECONE_INDEX_NAME_EU` is set), so before the
infra step this PR's code paths are dormant. After the env var is set
AND the second index exists, the four pieces fire together.

## Dependencies

- Sister-repo MR !6 must be merged first (or applied as the same PR if
  upstream prefers monolithic commits — sister-repo MR !6 is ~250 LOC
  and the diff applies cleanly to BasedHardware/omi:main).
- `PINECONE_INDEX_NAME_EU` env var must be set in the deploy. Recommended
  index name `omi-eu-prod-4096`. Match the existing index's metric
  (cosine).
- Operator deployment runbook: see `desktop/docs/M2.5-implementation-runbook.md`
  on the Euraika sister repo for cost notes, rollout checklist, and the
  mid-account toggle policy (Option A: parallel histories — old OpenAI
  3072-dim vectors stay queryable when toggle off, new Regolo 4096-dim
  vectors live in the EU index, search merges by score across both).

## Test plan

- [ ] Backend: `cd backend && bash test.sh` clean.
- [ ] New test: `tests/integration/test_provider_aware_vector_store.py` —
  asserts upsert routes by provider, metadata carries `(provider, model, dim)`,
  reads from the right index based on Privacy Mode flag.
- [ ] Run the backfill migration in staging: confirms idempotency
  (rerunning skips already-tagged vectors).
- [ ] Smoke test: EU-mode user creates a conversation → telemetry shows
  `provider=regolo, model=Qwen3-Embedding-8B, dim=4096` upsert to the
  EU index. Toggle Privacy Mode off → next conversation upserts to the
  legacy index with `provider=openai`.
- [ ] No regressions on the existing 3072-dim search workloads.

## Out of scope for this PR

- Re-embedding existing user data with Regolo's Qwen3-Embedding-8B — the
  mid-account toggle policy keeps both vector sets queryable in parallel
  (see runbook). A "re-embed everything for stronger EU compliance" mode
  could ship as a P2 enhancement.
- Vision via Regolo (`qwen3-vl-32b`) — not on PAYG; HARD_BLOCKED with
  banner fallback to Gemini.
- Settings copy update on the web frontend / desktop client to remove
  the "embedding-dependent features blocked in EU mode" disclaimer —
  ships in a separate trivial doc PR after the runbook's smoke test
  passes.

## Notes for upstream maintainers

- Author / development contact: bert@euraika.net.
- All commit author identity matches.
- Companion to the in-flight draft PR
  [BasedHardware/omi#7056](https://github.com/BasedHardware/omi/pull/7056)
  which carries the desktop polish + web frontend implementation. That
  PR remains draft pending Mac build verification.
- Coordinated with infra to provision `omi-eu-prod-4096` Pinecone index
  before merging this PR. Cost estimate ~$80/mo at staging scale; full
  budget impact gated on production volumes.
