### PR TITLE
backend(updates): keep macos.omi.me alive through GitHub outages

### DIFF
--- a/backend/routers/firmware.py
+++ b/backend/routers/firmware.py
@@ -65,7 +65,13 @@ async def get_omi_github_releases(cache_key: str, tag_filter: Optional[re.Patter
     releases whose tag_name matches the filter. Without tag_filter, returns
     the first page of releases unfiltered (sufficient for desktop releases
     which are always recent).
+
+    Resilience: if GitHub returns errors or an empty list during an upstream
+    outage, we fall back to a longer-lived "last known good" cache so the
+    macos.omi.me download endpoint keeps serving the previous DMG link.
     """
+
+    lkg_key = f"{cache_key}:lkg"
 
     # Check cache first (use `is not None` so cached empty list is a hit)
     cached_releases = get_generic_cache(cache_key)
@@ -78,43 +84,74 @@ async def get_omi_github_releases(cache_key: str, tag_filter: Optional[re.Patter
         "Authorization": f"Bearer {os.getenv('GITHUB_TOKEN')}",
     }
 
-    collected = []
-    page = 1
+    collected: List[Dict] = []
+    fetch_failed = False
 
-    async with httpx.AsyncClient() as client:
-        while page <= MAX_PAGES:
-            url = f"https://api.github.com/repos/BasedHardware/omi/releases?per_page=100&page={page}"
-            response = await client.get(url, headers=headers)
-            if response.status_code != 200:
-                logger.error(
-                    "Error fetching GitHub releases page %d: %d %s", page, response.status_code, sanitize(response.text)
-                )
-                raise HTTPException(status_code=500, detail="Failed to fetch release information")
+    try:
+        page = 1
+        async with httpx.AsyncClient() as client:
+            while page <= MAX_PAGES:
+                url = f"https://api.github.com/repos/BasedHardware/omi/releases?per_page=100&page={page}"
+                response = await client.get(url, headers=headers)
+                if response.status_code != 200:
+                    logger.error(
+                        "Error fetching GitHub releases page %d: %d %s",
+                        page,
+                        response.status_code,
+                        sanitize(response.text),
+                    )
+                    fetch_failed = True
+                    break
 
-            page_releases = response.json()
-            if not page_releases:
-                break
+                page_releases = response.json()
+                if not page_releases:
+                    break
 
-            if tag_filter:
-                for release in page_releases:
-                    tag_name = release.get("tag_name", "")
-                    if tag_filter.match(tag_name):
-                        collected.append(release)
-            else:
-                collected.extend(page_releases)
+                if tag_filter:
+                    for release in page_releases:
+                        tag_name = release.get("tag_name", "")
+                        if tag_filter.match(tag_name):
+                            collected.append(release)
+                else:
+                    collected.extend(page_releases)
 
-            # Without filter, single page is enough (desktop releases are recent)
-            if not tag_filter:
-                break
+                # Without filter, single page is enough (desktop releases are recent)
+                if not tag_filter:
+                    break
 
-            # Stop if this was the last page
-            if len(page_releases) < 100:
-                break
+                # Stop if this was the last page
+                if len(page_releases) < 100:
+                    break
 
-            page += 1
+                page += 1
+    except Exception as exc:
+        logger.exception("Exception fetching GitHub releases: %s", sanitize(str(exc)))
+        fetch_failed = True
 
-    # Cache for 5 minutes (even if empty, to avoid hammering GitHub)
+    # If the live fetch failed or returned nothing, prefer the last-known-good
+    # cache over an empty response. Re-cache LKG under the short key with a
+    # short TTL (60s) so we retry GitHub soon without hammering it.
+    if fetch_failed or not collected:
+        last_known_good = get_generic_cache(lkg_key)
+        if last_known_good:
+            logger.warning(
+                "GitHub releases fetch %s; serving last-known-good cache for %s",
+                "failed" if fetch_failed else "returned empty",
+                cache_key,
+            )
+            set_generic_cache(cache_key, last_known_good, ttl=60)
+            return last_known_good
+
+        # No fallback — short-cache the empty result so we don't hammer
+        # GitHub, but use a shorter TTL than the success path (5min) so
+        # recovery is faster once GitHub is back.
+        set_generic_cache(cache_key, collected, ttl=60)
+        return collected
+
+    # Live fetch succeeded with data: refresh both caches. The LKG TTL is
+    # 24h so it survives multi-hour GitHub outages.
     set_generic_cache(cache_key, collected, ttl=300)
+    set_generic_cache(lkg_key, collected, ttl=86400)
     return collected
 
 

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -465,8 +465,11 @@ async def clear_desktop_cache(secret_key: str = Header(...)):
     """
     Clear the GitHub releases cache for desktop updates.
     This forces the next appcast.xml request to fetch fresh data from GitHub.
+    Also clears the last-known-good fallback so a fresh LKG is established
+    on the next successful fetch.
     """
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
     delete_generic_cache("github_releases_desktop")
+    delete_generic_cache("github_releases_desktop:lkg")
     return {"success": True, "message": "Desktop releases cache cleared successfully"}

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -573,7 +573,9 @@ class TestClearCacheEndpoint:
                 resp = await client.post("/v2/desktop/clear-cache", headers={"secret-key": "real-secret"})
         assert resp.status_code == 200
         assert resp.json()["success"] is True
-        mock_delete.assert_called_once_with("github_releases_desktop")
+        # Both the live cache and the last-known-good fallback are cleared.
+        cleared_keys = {call.args[0] for call in mock_delete.call_args_list}
+        assert cleared_keys == {"github_releases_desktop", "github_releases_desktop:lkg"}
 
     @pytest.mark.asyncio
     async def test_missing_header_returns_422(self):

--- a/backend/tests/unit/test_firmware_pagination.py
+++ b/backend/tests/unit/test_firmware_pagination.py
@@ -112,8 +112,12 @@ class TestPagination:
         assert "Omi_DK2_v2.0.10" in tags
         # Verify no desktop releases leaked through
         assert not any("macos" in r["tag_name"] for r in result)
-        # Verify cache was set
-        mock_set_cache.assert_called_once()
+        # Verify both short cache (5min) and last-known-good cache (24h)
+        # were set on a successful non-empty fetch.
+        cache_keys_set = [call.args[0] for call in mock_set_cache.call_args_list]
+        assert "test_key" in cache_keys_set
+        assert "test_key:lkg" in cache_keys_set
+        assert mock_set_cache.call_count == 2
 
     @pytest.mark.asyncio
     async def test_no_pagination_without_filter(self):
@@ -201,4 +205,124 @@ class TestCacheBehavior:
             result = await get_omi_github_releases("test_key")
 
         assert result == []
-        mock_set.assert_called_once_with("test_key", [], ttl=300)
+        # Empty fetch with no LKG fallback caches with the SHORT TTL (60s)
+        # so the next request retries GitHub soon, instead of poisoning
+        # the cache with empty for the full 5-minute success TTL.
+        mock_set.assert_called_once_with("test_key", [], ttl=60)
+
+
+class TestLastKnownGoodFallback:
+    """When GitHub returns empty / errors, serve the previous good cache."""
+
+    @pytest.mark.asyncio
+    async def test_empty_fetch_falls_back_to_lkg(self):
+        """If GitHub returns [] but we have an LKG, return the LKG instead."""
+        lkg = _desktop_releases(3)
+
+        # First call (short key) misses; second call (LKG key) hits.
+        cache_calls = []
+
+        def fake_get(key):
+            cache_calls.append(key)
+            return None if key == "test_key" else lkg
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []  # GitHub outage signature
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('routers.firmware.get_generic_cache', side_effect=fake_get), patch(
+            'routers.firmware.set_generic_cache'
+        ) as mock_set, patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+            'os.environ', {'GITHUB_TOKEN': 'test-token'}
+        ):
+
+            result = await get_omi_github_releases("test_key")
+
+        assert result == lkg
+        # Both keys were consulted
+        assert "test_key" in cache_calls and "test_key:lkg" in cache_calls
+        # LKG was re-cached under the short key with a short TTL so we
+        # retry GitHub soon, but service stays up.
+        mock_set.assert_called_once_with("test_key", lkg, ttl=60)
+
+    @pytest.mark.asyncio
+    async def test_500_response_falls_back_to_lkg(self):
+        """If GitHub returns a non-200, fall back to LKG instead of raising 500."""
+        lkg = _desktop_releases(2)
+
+        def fake_get(key):
+            return None if key == "test_key" else lkg
+
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.text = "Service Unavailable"
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('routers.firmware.get_generic_cache', side_effect=fake_get), patch(
+            'routers.firmware.set_generic_cache'
+        ), patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+            'os.environ', {'GITHUB_TOKEN': 'test-token'}
+        ):
+
+            result = await get_omi_github_releases("test_key")
+
+        assert result == lkg
+
+    @pytest.mark.asyncio
+    async def test_exception_falls_back_to_lkg(self):
+        """Network exception → LKG fallback (instead of bubbling)."""
+        lkg = _desktop_releases(4)
+
+        def fake_get(key):
+            return None if key == "test_key" else lkg
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=RuntimeError("connection reset"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('routers.firmware.get_generic_cache', side_effect=fake_get), patch(
+            'routers.firmware.set_generic_cache'
+        ), patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+            'os.environ', {'GITHUB_TOKEN': 'test-token'}
+        ):
+
+            result = await get_omi_github_releases("test_key")
+
+        assert result == lkg
+
+    @pytest.mark.asyncio
+    async def test_successful_fetch_writes_both_caches(self):
+        """Non-empty fetch refreshes both short cache (5min) and LKG (24h)."""
+        releases = _desktop_releases(5)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = releases
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('routers.firmware.get_generic_cache', return_value=None), patch(
+            'routers.firmware.set_generic_cache'
+        ) as mock_set, patch('routers.firmware.httpx.AsyncClient', return_value=mock_client), patch.dict(
+            'os.environ', {'GITHUB_TOKEN': 'test-token'}
+        ):
+
+            result = await get_omi_github_releases("test_key")
+
+        assert result == releases
+        ttl_by_key = {call.args[0]: call.kwargs.get("ttl") for call in mock_set.call_args_list}
+        assert ttl_by_key["test_key"] == 300
+        assert ttl_by_key["test_key:lkg"] == 86400


### PR DESCRIPTION
## Summary
The `macos.omi.me` / `/beta` 404 right now is GitHub's fault — their releases API is intermittently returning empty `[]` arrays during a "Partial System Outage". Our previous cache logic happily cached that empty result for 5 minutes, which 404'd every download request until the cache expired.

This PR adds a last-known-good (LKG) fallback so the download link survives multi-hour GitHub outages without admin intervention.

### How it works
- A separate `<key>:lkg` Redis entry holds the last successful **non-empty** release list for 24 hours.
- On any failure path (HTTP non-200, exception, or empty array), we fall back to the LKG and re-cache it under the live key with a short 60s TTL — so service stays up but we retry GitHub soon instead of locking in a poisoned empty for the full 5 minutes.
- On success, both the live key (5min) and the LKG (24h) are refreshed.
- `/v2/desktop/clear-cache` now also nukes the LKG so a fresh one gets established on the next successful fetch.
- 5xx from GitHub no longer raises a 500 — it falls back instead.

### Tests
- 4 new tests in `test_firmware_pagination.py` covering empty-fetch fallback, 5xx fallback, exception fallback, and dual-cache write on success.
- Updated existing tests for new TTL semantics.
- 74/74 unit tests pass (`test_firmware_pagination.py` + `test_desktop_updates.py`).

### Note on DMG bytes
This fixes the **download-link resolution** path. The actual DMG bytes still live on GitHub Releases CDN — if their CDN is down (separate from the API), users still can't download. To make that resilient too, we'd need to mirror DMGs to GCS in `codemagic.yaml` and fall back to the GCS URL. Out of scope for this PR — let me know if you want that next.

## Test plan
- [ ] After merge + deploy, hit `https://macos.omi.me` and `https://macos.omi.me/beta` — should resolve to a DMG download link
- [ ] Manually expire the live cache (or wait 5min after deploy); confirm next request still returns the DMG link if GitHub is flaky
- [ ] Optional admin recovery: `POST /v2/desktop/clear-cache` with `secret-key: $ADMIN_KEY` clears both caches

🤖 Generated with [Claude Code](https://claude.com/claude-code)