### PR TITLE
docs: remove stale Related Files section from INDEX.md

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -72,9 +72,3 @@ Complete index of all documentation in the Omi codebase.
 
 - [docs.omi.me](https://docs.omi.me/) - Complete online documentation
 - [API Reference](api-reference/introduction.mdx) - API endpoint reference
-
-## Related Files
-
-- Architecture: `.cursor/ARCHITECTURE.md`
-- API Reference: `.cursor/API_REFERENCE.md`
-- Data Flow: `.cursor/DATA_FLOW.md`


### PR DESCRIPTION
## Summary
- Remove the "Related Files" section from `docs/INDEX.md` — all 3 referenced files (`.cursor/ARCHITECTURE.md`, `.cursor/API_REFERENCE.md`, `.cursor/DATA_FLOW.md`) no longer exist
- Runbooks were already removed from main in #7046

Supersedes #6817 (which was based on a pre-removal branch and would have re-introduced deleted runbooks).

## Test plan
- [x] Verified referenced `.cursor/*.md` files don't exist on main
- [x] Verified `docs/runbooks/` already removed by #7046

🤖 Generated with [Claude Code](https://claude.com/claude-code)