### PR TITLE
desktop: AI router decides chat vs agent for Ask Omi

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Improved Ask Omi routing: questions now stay in the floating bar chat instead of incorrectly spawning background agents \u2014 Claude Haiku decides whether each message is a quick answer or a real task"
+  ],
   "releases": [
     {
       "version": "0.11.369",

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -91,33 +91,110 @@ final class AgentPillsManager: ObservableObject {
 
     private init() {}
 
-    /// Whether a piece of user input looks like an "action" the agent should
-    /// execute, vs. a quick conversational question.
-    static func looksLikeAction(_ text: String) -> Bool {
-        let lower = text
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        guard !lower.isEmpty else { return false }
-        // Anything containing "agent", "pill", or "background" is intentional
-        // demo invocation — always promote.
-        let demoSignals = ["agent", "pill", "background", "in parallel"]
-        if demoSignals.contains(where: { lower.contains($0) }) { return true }
-        let actionPrefixes = [
-            "open ", "do ", "go ", "send ", "make ", "find ", "search ",
-            "build ", "fix ", "create ", "click ", "buy ", "book ",
-            "schedule ", "draft ", "write ", "reply ", "compose ", "start ",
-            "spawn ", "kick off ", "kickoff ", "launch ", "trigger ", "queue ",
-            "deploy ", "merge ", "push ", "pull ", "checkout ", "commit ",
-            "close ", "delete ", "remove ", "add ", "install ", "update ",
-            "edit ", "rename ", "move ", "copy ", "show me ", "help me ",
-            "can you ", "please ", "summarize ", "summarise ", "research ",
-            "look up ", "look at ", "fill ", "submit ", "post ", "tweet ",
-            "dm ", "email ", "call ", "navigate ", "visit ", "test ",
+    /// Routing decision for an Ask Omi message — does it stay inline in the
+    /// floating bar, or get hoisted into a background agent pill?
+    enum Route: String { case chat, agent }
+
+    /// Combined router result. Title/ack are pre-computed alongside the route
+    /// so we don't need a second Haiku call when the answer is "agent".
+    struct RouterDecision {
+        let route: Route
+        let title: String?
+        let ack: String?
+    }
+
+    /// Ask Claude Haiku whether the message is a quick info question (→ chat)
+    /// or a background task (→ agent). Falls back to `.chat` on error/timeout
+    /// so we never accidentally hijack a question into a long-running pill.
+    /// ~300-500ms via the desktop-backend's OpenAI-compatible proxy.
+    static func classify(_ query: String) async -> RouterDecision {
+        guard let result = await runRouterCall(for: query) else {
+            return RouterDecision(route: .chat, title: nil, ack: nil)
+        }
+        return result
+    }
+
+    private static func runRouterCall(for query: String) async -> RouterDecision? {
+        let baseURL = await APIClient.shared.rustBackendURL
+        guard !baseURL.isEmpty else {
+            log("AgentPill: router skipped — rustBackendURL empty, defaulting to chat")
+            return nil
+        }
+        let normalized = baseURL.hasSuffix("/") ? baseURL : baseURL + "/"
+        guard let url = URL(string: normalized + "v2/chat/completions") else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 4
+        do {
+            let headers = try await APIClient.shared.buildHeaders(requireAuth: true)
+            for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
+        } catch {
+            log("AgentPill: router skipped — auth header unavailable (\(error.localizedDescription))")
+            return nil
+        }
+
+        let prompt = """
+        The user just sent this message in the Omi floating bar:
+
+        "\(query)"
+
+        Decide whether to (a) answer it inline in the chat bar, or (b) spawn a background agent that will do work on the user's computer/apps/browser.
+
+        Reply with ONLY a single-line JSON object, no prose, no markdown:
+        {"route":"chat"|"agent","title":"<3-5 word imperative title in Title Case, no trailing punctuation>","ack":"<one short spoken acknowledgement, max 7 words, friendly tone>"}
+
+        Use "agent" ONLY when the request requires the assistant to take real actions on the user's computer/browser/apps that will plausibly take more than ~10 seconds — building/coding something, sending/posting a message, editing or creating files, multi-step browser navigation, generating a long document.
+        Use "chat" for everything else: questions, lookups (even if the user uses words like "search"/"find"/"look up"), definitions, single facts, explanations, short summaries, opinions, conversation. When in doubt, choose "chat".
+        """
+
+        let body: [String: Any] = [
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 120,
+            "messages": [["role": "user", "content": prompt]],
+            "stream": false,
         ]
-        if actionPrefixes.contains(where: { lower.hasPrefix($0) }) { return true }
-        // Long, detailed instructions are almost always actions.
-        if lower.count >= 70 { return true }
-        return false
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                log("AgentPill: router failed — no HTTP response, defaulting to chat")
+                return nil
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                let bodyText = String(data: data.prefix(200), encoding: .utf8) ?? "<binary>"
+                log("AgentPill: router HTTP \(http.statusCode) — \(bodyText), defaulting to chat")
+                return nil
+            }
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let choices = json["choices"] as? [[String: Any]],
+                let message = choices.first?["message"] as? [String: Any],
+                let text = message["content"] as? String
+            else {
+                log("AgentPill: router response shape unexpected, defaulting to chat")
+                return nil
+            }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let payloadData = trimmed.data(using: .utf8),
+                let payload = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+                let routeStr = (payload["route"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            else {
+                log("AgentPill: router JSON parse failed — raw: \(String(trimmed.prefix(200))), defaulting to chat")
+                return nil
+            }
+            let route = Route(rawValue: routeStr) ?? .chat
+            let title = (payload["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let ack = (payload["ack"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            log("AgentPill: router decided route=\(route.rawValue) title=\"\(title ?? "")\"")
+            return RouterDecision(
+                route: route,
+                title: (title?.isEmpty == false) ? String(title!.prefix(40)) : nil,
+                ack: (ack?.isEmpty == false) ? String(ack!.prefix(120)) : nil
+            )
+        } catch {
+            log("AgentPill: router threw — \(error.localizedDescription), defaulting to chat")
+            return nil
+        }
     }
 
     /// Parse phrases like "spawn 3 agents", "5 tasks", "two agents working in
@@ -160,17 +237,38 @@ final class AgentPillsManager: ObservableObject {
     /// agents" we create 3 pills (each runs the same task on the shared
     /// queue). Returns the first pill so callers can inspect it.
     @discardableResult
-    func spawnFromUserQuery(_ query: String, model: String, fromVoice: Bool = false) -> AgentPill {
+    func spawnFromUserQuery(
+        _ query: String,
+        model: String,
+        fromVoice: Bool = false,
+        preFetchedTitle: String? = nil,
+        preFetchedAck: String? = nil
+    ) -> AgentPill {
         let count = AgentPillsManager.parseAgentCount(from: query)
         if count <= 1 {
-            return spawn(query: query, model: model, fromVoice: fromVoice)
+            return spawn(
+                query: query,
+                model: model,
+                fromVoice: fromVoice,
+                preFetchedTitle: preFetchedTitle,
+                preFetchedAck: preFetchedAck
+            )
         }
         var first: AgentPill?
         for i in 1...count {
             let labelled = "[\(i)/\(count)] \(query)"
             // Only the first pill speaks the acknowledgement when N > 1,
-            // otherwise we'd hear N overlapping voices.
-            let pill = spawn(query: labelled, model: model, fromVoice: fromVoice && first == nil)
+            // otherwise we'd hear N overlapping voices. Only the first pill
+            // gets the pre-fetched title/ack — the others fall back to their
+            // own title generation since their query text differs (the
+            // [i/N] prefix changes the model's output).
+            let pill = spawn(
+                query: labelled,
+                model: model,
+                fromVoice: fromVoice && first == nil,
+                preFetchedTitle: first == nil ? preFetchedTitle : nil,
+                preFetchedAck: first == nil ? preFetchedAck : nil
+            )
             if first == nil { first = pill }
         }
         return first ?? spawn(query: query, model: model, fromVoice: fromVoice)
@@ -181,8 +279,17 @@ final class AgentPillsManager: ObservableObject {
     /// `bootChain` so we never race ACP startup; once a pill's bridge is
     /// warmed it sends concurrently with everything else.
     @discardableResult
-    func spawn(query: String, model: String, fromVoice: Bool = false) -> AgentPill {
+    func spawn(
+        query: String,
+        model: String,
+        fromVoice: Bool = false,
+        preFetchedTitle: String? = nil,
+        preFetchedAck: String? = nil
+    ) -> AgentPill {
         let pill = AgentPill(query: query, model: model)
+        if let preFetchedTitle, !preFetchedTitle.isEmpty {
+            pill.title = preFetchedTitle
+        }
 
         // Trim if we're at the cap — drop the oldest finished pill first.
         if pills.count >= maxPills {
@@ -222,23 +329,32 @@ final class AgentPillsManager: ObservableObject {
         bootChain = myBoot
 
         pill.status = .starting
-        pill.latestActivity = "Warming up…"
-
-        // For voice queries, speak an instant deterministic acknowledgement
-        // BEFORE waiting for any API call so the user always gets audible
-        // feedback that we heard them. The smart title is fetched in parallel
-        // and updates the pill silently when it arrives.
-        if fromVoice {
-            FloatingBarVoicePlaybackService.shared.speakOneShot(AgentPillsManager.randomAck())
+        if let preFetchedAck, !preFetchedAck.isEmpty {
+            pill.latestActivity = preFetchedAck
+        } else {
+            pill.latestActivity = "Warming up…"
         }
 
-        Task { [weak pill] in
-            guard let pill else { return }
-            guard let result = await AgentPillsManager.generateTitleAndAck(for: pill.query) else { return }
-            await MainActor.run {
-                pill.title = result.title
-                if pill.latestActivity == "Warming up…" || pill.latestActivity == "Starting…" {
-                    pill.latestActivity = result.ack
+        // For voice queries, speak the pre-fetched ack from the router (or a
+        // random instant ack) BEFORE waiting for the bridge so the user
+        // always hears confirmation that we heard them.
+        if fromVoice {
+            let phrase = (preFetchedAck?.isEmpty == false) ? preFetchedAck! : AgentPillsManager.randomAck()
+            FloatingBarVoicePlaybackService.shared.speakOneShot(phrase)
+        }
+
+        // If the router already returned a title we don't need a second
+        // Haiku call for title generation. Otherwise kick one off in the
+        // background to upgrade the heuristic title.
+        if preFetchedTitle == nil {
+            Task { [weak pill] in
+                guard let pill else { return }
+                guard let result = await AgentPillsManager.generateTitleAndAck(for: pill.query) else { return }
+                await MainActor.run {
+                    pill.title = result.title
+                    if pill.latestActivity == "Warming up…" || pill.latestActivity == "Starting…" {
+                        pill.latestActivity = result.ack
+                    }
                 }
             }
         }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -990,20 +990,8 @@ class FloatingControlBarManager {
 
         barWindow.onSendQuery = { [weak self, weak barWindow, weak floatingProvider] message in
             guard let self = self, let barWindow = barWindow, let provider = floatingProvider else { return }
-            // Route action-like queries to an agent pill (no inline chat). Quick
-            // questions still flow through the inline conversation.
-            if AgentPillsManager.looksLikeAction(message) {
-                let model = ShortcutSettings.shared.selectedModel.isEmpty
-                    ? "claude-sonnet-4-6"
-                    : ShortcutSettings.shared.selectedModel
-                _ = AgentPillsManager.shared.spawnFromUserQuery(message, model: model)
-                // Collapse the input so the pill is the only visible result.
-                barWindow.state.aiInputText = ""
-                barWindow.closeAIConversation()
-                return
-            }
             Task { @MainActor in
-                await self.sendAIQuery(message, barWindow: barWindow, provider: provider)
+                await self.routeQuery(message, barWindow: barWindow, provider: provider, fromVoice: false)
             }
         }
 
@@ -1285,20 +1273,12 @@ class FloatingControlBarManager {
 
         guard let provider = activeFloatingProvider() else { return }
 
-        // Re-wire the onSendQuery to use the isolated floating-bar provider
+        // Re-wire the onSendQuery to use the isolated floating-bar provider.
+        // Subsequent typed messages also go through the AI router.
         window.onSendQuery = { [weak self, weak window, weak provider] message in
             guard let self = self, let window = window, let provider = provider else { return }
-            if AgentPillsManager.looksLikeAction(message) {
-                let model = ShortcutSettings.shared.selectedModel.isEmpty
-                    ? "claude-sonnet-4-6"
-                    : ShortcutSettings.shared.selectedModel
-                _ = AgentPillsManager.shared.spawnFromUserQuery(message, model: model)
-                window.state.aiInputText = ""
-                window.closeAIConversation()
-                return
-            }
             Task { @MainActor in
-                await self.sendAIQuery(message, barWindow: window, provider: provider)
+                await self.routeQuery(message, barWindow: window, provider: provider, fromVoice: window.state.currentQueryFromVoice)
             }
         }
 
@@ -1323,19 +1303,47 @@ class FloatingControlBarManager {
         window.orderFrontRegardless()
 
         // Auto-send the query. PTT bypasses the typed onSendQuery closure, so
-        // we need to apply the same pill-routing rule here ourselves.
-        if AgentPillsManager.looksLikeAction(query) {
+        // we need to apply the same router rule here ourselves.
+        Task { @MainActor in
+            await self.routeQuery(query, barWindow: window, provider: provider, fromVoice: fromVoice)
+        }
+    }
+
+    /// Ask the router (Haiku) whether this query should stay in the inline
+    /// chat or get hoisted into a background agent pill, then dispatch to
+    /// whichever path it chose. The router call is ~300-500ms; we show the
+    /// inline "thinking" UI immediately so the user knows the message landed.
+    private func routeQuery(
+        _ message: String,
+        barWindow: FloatingControlBarWindow,
+        provider: ChatProvider,
+        fromVoice: Bool
+    ) async {
+        // Show the thinking state immediately so there's no perceptible lag
+        // while the router thinks. If the router decides "agent" we'll tear
+        // this down before the chat actually streams anything.
+        prepareVisibleQueryState(message, in: barWindow, fromVoice: fromVoice)
+
+        let decision = await AgentPillsManager.classify(message)
+        if decision.route == .agent {
             let model = ShortcutSettings.shared.selectedModel.isEmpty
                 ? "claude-sonnet-4-6"
                 : ShortcutSettings.shared.selectedModel
-            _ = AgentPillsManager.shared.spawnFromUserQuery(query, model: model, fromVoice: fromVoice)
-            window.state.aiInputText = ""
-            window.closeAIConversation()
+            _ = AgentPillsManager.shared.spawnFromUserQuery(
+                message,
+                model: model,
+                fromVoice: fromVoice,
+                preFetchedTitle: decision.title,
+                preFetchedAck: decision.ack
+            )
+            // Tear down the inline state we set up for the thinking spinner.
+            barWindow.state.aiInputText = ""
+            barWindow.closeAIConversation()
             return
         }
-        Task { @MainActor in
-            await self.sendAIQuery(query, barWindow: window, provider: provider)
-        }
+        // Chat route: continue with the normal inline flow. sendAIQuery will
+        // re-prepare the visible state, which is idempotent.
+        await sendAIQuery(message, barWindow: barWindow, provider: provider)
     }
 
     /// Send a follow-up query in the existing AI conversation (used by PTT follow-up).


### PR DESCRIPTION
## Summary
Replaces the over-aggressive `looksLikeAction` prefix heuristic on Ask Omi with a Claude Haiku router. Single ~400ms call to the desktop-backend's `/v2/chat/completions` proxy returns `{route, title, ack}` — the model decides whether to keep the message inline or hoist it into a background agent pill.

## Why
The old heuristic over-triggered. Examples that wrongly spawned pills:
- "What are USCIS processing times?" — matched the 70-char length fallback
- "Look up the weather" — matched the `look up` prefix
- "Find me a quote about persistence" — matched `find `
- "Search for X" / "Research Y" — matched `search ` / `research `

All of these are quick info questions that should stream a one-shot answer in the floating bar chat, not boot a node bridge for 7+ seconds.

## How
- New `AgentPillsManager.classify(_:)` returns `RouterDecision(route, title, ack)` from a single Haiku call. Falls back to `.chat` on any error/timeout (4s) so a flaky network never accidentally hijacks a question.
- `spawn()` and `spawnFromUserQuery()` accept optional `preFetchedTitle`/`preFetchedAck` so we don't make a second Haiku call for title generation when the router already produced them. One round trip instead of two.
- All three send paths in `FloatingControlBarWindow` (typed setup-time, typed PTT-rewire, PTT auto-send) now go through one `routeQuery()` that:
  1. Shows the inline thinking spinner immediately so the user knows the message landed.
  2. Awaits the router (~400ms).
  3. Spawns a pill with pre-fetched title/ack if `route == .agent`, otherwise continues with `sendAIQuery`.
- Drops `AgentPillsManager.looksLikeAction(_:)` entirely.

## Prompt for Haiku
> Use "agent" ONLY when the request requires the assistant to take real actions on the user's computer/browser/apps that will plausibly take more than ~10 seconds — building/coding something, sending/posting a message, editing or creating files, multi-step browser navigation, generating a long document.
> Use "chat" for everything else: questions, lookups (even if the user uses words like "search"/"find"/"look up"), definitions, single facts, explanations, short summaries, opinions, conversation. When in doubt, choose "chat".

## Test plan
- [ ] Type \`What are USCIS processing times?\` → answers inline in floating bar (no pill)
- [ ] Type \`Look up the weather\` → inline (no pill)
- [ ] Type \`Build a snake game\` → spawns pill, title appears as something like "Build Snake Game"
- [ ] Type \`Spawn 3 test agents\` → pills (manual demo phrasing still works since model treats it as task)
- [ ] PTT a quick question → answers inline + voice playback
- [ ] PTT \`open google.com and find vegan ramen\` → voice ack speaks, pill spawns
- [ ] Pill cards still work end-to-end (Execute on notifications, Execute on tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)