### PR TITLE
feat(desktop): default USE_VERTEX_AI to true

### DIFF
--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -151,8 +151,8 @@ impl Config {
                 .map(|v| v == "true" || v == "1")
                 .unwrap_or(false),
             use_vertex_ai: env::var("USE_VERTEX_AI")
-                .map(|v| v == "true" || v == "1")
-                .unwrap_or(false),
+                .map(|v| v != "false" && v != "0")
+                .unwrap_or(true),
             vertex_project_id: env::var("GCP_PROJECT_ID")
                 .or_else(|_| env::var("FIREBASE_PROJECT_ID"))
                 .ok(),


### PR DESCRIPTION
## Summary
- Default `USE_VERTEX_AI` to `true` in the Rust backend config
- Vertex AI infra confirmed ready by mon: SA has `aiplatform.endpoints.predict`, API enabled, billing active
- Set `USE_VERTEX_AI=false` to explicitly disable

Follow-up to PR #7021 (Vertex AI provider routing).

_by AI for @beastoin_