### PR TITLE
fix(desktop): bump Rust toolchain to 1.85 for hyper-rustls compat

### DIFF
--- a/desktop/Backend-Rust/Dockerfile
+++ b/desktop/Backend-Rust/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for smaller image size
 
 # Build stage
-FROM rust:1.83-slim AS builder
+FROM rust:1.85-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Bumps `rust:1.83-slim` → `rust:1.85-slim` in desktop backend Dockerfile
- `hyper-rustls@0.27.9` in Cargo.lock requires rustc 1.85+, causing all desktop backend CI builds to fail since PR #7021 merge

## Test plan
- [ ] CI build passes (this was the only failure point)
- [ ] Desktop backend deploys to dev and prod via auto-release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)