### PR TITLE
fix(backend): bump protobuf to 4.25.8 for langchain-google-genai compat

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -145,7 +145,7 @@ posthog==3.5.2
 primePy==1.3
 prompt_toolkit==3.0.47
 proto-plus==1.24.0
-protobuf==4.25.4
+protobuf==4.25.8
 ptyprocess==0.7.0
 pure_eval==0.2.3
 pyarrow==17.0.0


### PR DESCRIPTION
## Summary
- Bumps `protobuf` from `4.25.4` to `4.25.8`
- `google-ai-generativelanguage==0.11.0` (dependency of `langchain-google-genai==2.1.12` added in PR #6942) requires `protobuf>=4.25.8`, causing pip resolution failure during Docker build

## Test plan
- [ ] CI Docker build passes (pip install succeeds)
- [ ] Backend deploys to Cloud Run via `gcp_backend.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)