### PR TITLE
Enhance VAD and Diarizer in term of operations

### DIFF
--- a/backend/charts/diarizer/dev_omi_diarizer_values.yaml
+++ b/backend/charts/diarizer/dev_omi_diarizer_values.yaml
@@ -128,9 +128,31 @@ startupProbe:
 autoscaling:
   enabled: true
   minReplicas: 1
-  maxReplicas: 10
-  targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 70
+  maxReplicas: 3
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 300
+      - type: Pods
+        value: 1
+        periodSeconds: 120
+      selectPolicy: Min
+    scaleUp:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 15
+      - type: Pods
+        value: 1
+        periodSeconds: 15
+      selectPolicy: Max
+  # targetCPUUtilizationPercentage: 70
+  # targetMemoryUtilizationPercentage: 70
+  requestLatencyP99: 300   # milliseconds
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/backend/charts/diarizer/prod_omi_diarizer_values.yaml
+++ b/backend/charts/diarizer/prod_omi_diarizer_values.yaml
@@ -141,7 +141,7 @@ autoscaling:
         periodSeconds: 120
       selectPolicy: Min
     scaleUp:
-      stabilizationWindowSeconds: 120
+      stabilizationWindowSeconds: 300
       policies:
       - type: Percent
         value: 20

--- a/backend/charts/diarizer/prod_omi_diarizer_values.yaml
+++ b/backend/charts/diarizer/prod_omi_diarizer_values.yaml
@@ -97,12 +97,12 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
-    cpu: 1
-    memory: 4Gi
-    nvidia.com/gpu: 1
-  limits:
     cpu: 2
     memory: 6Gi
+    nvidia.com/gpu: 1
+  limits:
+    cpu: 3
+    memory: 12Gi
     nvidia.com/gpu: 1
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -129,8 +129,30 @@ autoscaling:
   enabled: true
   minReplicas: 1
   maxReplicas: 10
-  targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 300
+      - type: Pods
+        value: 1
+        periodSeconds: 120
+      selectPolicy: Min
+    scaleUp:
+      stabilizationWindowSeconds: 120
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 15
+      - type: Pods
+        value: 1
+        periodSeconds: 15
+      selectPolicy: Max
+  # targetCPUUtilizationPercentage: 70
+  # targetMemoryUtilizationPercentage: 70
+  requestLatencyP99: 300   # milliseconds
 
 # Additional volumes on the output Deployment definition.
 volumes: []
@@ -157,7 +179,7 @@ affinity:
             - key: service
               operator: In
               values:
-                - vad
+                - diarizer
             - key: env
               operator: In
               values:

--- a/backend/charts/diarizer/templates/hpa.yaml
+++ b/backend/charts/diarizer/templates/hpa.yaml
@@ -39,7 +39,7 @@ spec:
         metric:
           name: diarizer_request_latency_p99
         target:
-          type: Value
+          type: AverageValue
           value: {{ .Values.autoscaling.requestLatencyP99 }}
     {{- end }}
 {{- end }}

--- a/backend/charts/diarizer/templates/hpa.yaml
+++ b/backend/charts/diarizer/templates/hpa.yaml
@@ -12,6 +12,10 @@ spec:
     name: {{ include "diarizer.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
@@ -28,5 +32,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.requestLatencyP99 }}
+    - type: External
+      external:
+        metric:
+          name: diarizer_request_latency_p99
+        target:
+          type: Value
+          value: {{ .Values.autoscaling.requestLatencyP99 }}
     {{- end }}
 {{- end }}

--- a/backend/charts/diarizer/templates/hpa.yaml
+++ b/backend/charts/diarizer/templates/hpa.yaml
@@ -39,7 +39,7 @@ spec:
         metric:
           name: diarizer_request_latency_p99
         target:
-          type: AverageValue
+          type: Value
           value: {{ .Values.autoscaling.requestLatencyP99 }}
     {{- end }}
 {{- end }}

--- a/backend/charts/diarizer/values.yaml
+++ b/backend/charts/diarizer/values.yaml
@@ -100,7 +100,7 @@ autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
+  # targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
 # Additional volumes on the output Deployment definition.

--- a/backend/charts/monitoring/prometheus-adapter/dev_omi_prometheus_adapter.yaml
+++ b/backend/charts/monitoring/prometheus-adapter/dev_omi_prometheus_adapter.yaml
@@ -17,6 +17,22 @@ rules:
       resources:
         overrides:
           namespace: { resource: "namespace" }
+    # p99 VAD request latency from the internal HTTPS LB histogram for HPA
+    - name:
+        as: "vad_request_latency_p99"
+      seriesQuery: 'stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{backend_target_name="k8s1-ffeea2fe-dev-omi-backend-dev-omi-vad-8080-b32ae1f2"}'
+      metricsQuery: 'histogram_quantile(0.99, sum by (le) (rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{backend_target_name="k8s1-ffeea2fe-dev-omi-backend-dev-omi-vad-8080-b32ae1f2"}[5m])))'
+      resources:
+        overrides:
+          namespace: { resource: "namespace" }
+    # p99 Diarizer request latency from the internal HTTPS LB histogram for HPA
+    - name:
+        as: "diarizer_request_latency_p99"
+      seriesQuery: 'stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{backend_target_name="k8s1-ffeea2fe-dev-omi-backend-dev-omi-diarizer-8080-48c29aca"}'
+      metricsQuery: 'histogram_quantile(0.99, sum by (le) (rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{backend_target_name="k8s1-ffeea2fe-dev-omi-backend-dev-omi-diarizer-8080-48c29aca"}[5m])))'
+      resources:
+        overrides:
+          namespace: { resource: "namespace" }
     - name:
         as: "backend_listen_response_code_500"
       seriesQuery: 'stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="dev-backend-listen"}'

--- a/backend/charts/monitoring/prometheus-adapter/prod_omi_prometheus_adapter.yaml
+++ b/backend/charts/monitoring/prometheus-adapter/prod_omi_prometheus_adapter.yaml
@@ -17,6 +17,22 @@ rules:
       resources:
         overrides:
           namespace: { resource: "namespace" }
+    # p99 VAD request latency from the internal HTTPS LB histogram for HPA
+    - name:
+        as: "vad_request_latency_p99"
+      seriesQuery: 'stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{backend_target_name="k8s1-5245918b-prod-omi-backend-prod-omi-vad-8080-cb5bc8b7"}'
+      metricsQuery: 'histogram_quantile(0.99, sum by (le) (rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{backend_target_name="k8s1-5245918b-prod-omi-backend-prod-omi-vad-8080-cb5bc8b7"}[5m])))'
+      resources:
+        overrides:
+          namespace: { resource: "namespace" }
+    # p99 Diarizer request latency from the internal HTTPS LB histogram for HPA
+    - name:
+        as: "diarizer_request_latency_p99"
+      seriesQuery: 'stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{backend_target_name="k8s1-5245918b-prod-omi-backend-prod-omi-diarizer-8080-cb654677"}'
+      metricsQuery: 'histogram_quantile(0.99, sum by (le) (rate(stackdriver_internal_http_lb_rule_loadbalancing_googleapis_com_https_internal_backend_latencies_bucket{backend_target_name="k8s1-5245918b-prod-omi-backend-prod-omi-diarizer-8080-cb654677"}[5m])))'
+      resources:
+        overrides:
+          namespace: { resource: "namespace" }
     - name:
         as: "backend_listen_response_code_500"
       seriesQuery: 'stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be"}'

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_stackdriver_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_stackdriver_exporter.yaml
@@ -4,6 +4,7 @@ stackdriver:
   metrics:
     prefixes:
       - 'loadbalancing.googleapis.com/https/backend_request_count'
+      - 'loadbalancing.googleapis.com/https/internal/backend_latencies'
     # The filters to refine the metrics query by using Filter objects that Google provides.
     # Filter objects: project, group.id, resource.type, resource.labels.[KEY], metric.type, metric.labels.[KEY]
     # https://cloud.google.com/monitoring/api/v3/filters

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml
@@ -4,6 +4,7 @@ stackdriver:
   metrics:
     prefixes:
       - 'loadbalancing.googleapis.com/https/backend_request_count'
+      - 'loadbalancing.googleapis.com/https/internal/backend_latencies'
     filters:
       - 'loadbalancing.googleapis.com/https/backend_request_count:resource.labels.backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be"'
     interval: '1m'

--- a/backend/charts/vad/dev_omi_vad_values.yaml
+++ b/backend/charts/vad/dev_omi_vad_values.yaml
@@ -125,9 +125,31 @@ startupProbe:
 autoscaling:
   enabled: true
   minReplicas: 1
-  maxReplicas: 10
-  targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 70
+  maxReplicas: 3
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 300
+      - type: Pods
+        value: 1
+        periodSeconds: 120
+      selectPolicy: Min
+    scaleUp:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 15
+      - type: Pods
+        value: 1
+        periodSeconds: 15
+      selectPolicy: Max
+  # targetCPUUtilizationPercentage: 70
+  # targetMemoryUtilizationPercentage: 70
+  requestLatencyP99: 2000 # milliseconds
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/backend/charts/vad/prod_omi_vad_values.yaml
+++ b/backend/charts/vad/prod_omi_vad_values.yaml
@@ -138,7 +138,7 @@ autoscaling:
         periodSeconds: 120
       selectPolicy: Min
     scaleUp:
-      stabilizationWindowSeconds: 120
+      stabilizationWindowSeconds: 300
       policies:
       - type: Percent
         value: 20

--- a/backend/charts/vad/prod_omi_vad_values.yaml
+++ b/backend/charts/vad/prod_omi_vad_values.yaml
@@ -94,12 +94,12 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
-    cpu: 1
-    memory: 4Gi
-    nvidia.com/gpu: 1
-  limits:
     cpu: 2
     memory: 6Gi
+    nvidia.com/gpu: 1
+  limits:
+    cpu: 3
+    memory: 12Gi
     nvidia.com/gpu: 1
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -126,8 +126,30 @@ autoscaling:
   enabled: true
   minReplicas: 1
   maxReplicas: 10
-  targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 300
+      - type: Pods
+        value: 1
+        periodSeconds: 120
+      selectPolicy: Min
+    scaleUp:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 20
+        periodSeconds: 15
+      - type: Pods
+        value: 1
+        periodSeconds: 15
+      selectPolicy: Max
+  # targetCPUUtilizationPercentage: 70
+  # targetMemoryUtilizationPercentage: 70
+  requestLatencyP99: 2000 # milliseconds
 
 # Additional volumes on the output Deployment definition.
 volumes: []
@@ -159,3 +181,7 @@ affinity:
               operator: In
               values:
                 - prod
+            - key: version
+              operator: In
+              values:
+                - v2

--- a/backend/charts/vad/prod_omi_vad_values.yaml
+++ b/backend/charts/vad/prod_omi_vad_values.yaml
@@ -138,7 +138,7 @@ autoscaling:
         periodSeconds: 120
       selectPolicy: Min
     scaleUp:
-      stabilizationWindowSeconds: 300
+      stabilizationWindowSeconds: 120
       policies:
       - type: Percent
         value: 20

--- a/backend/charts/vad/templates/hpa.yaml
+++ b/backend/charts/vad/templates/hpa.yaml
@@ -12,6 +12,10 @@ spec:
     name: {{ include "vad.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
@@ -29,4 +33,14 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- if .Values.autoscaling.requestLatencyP99 }}
+    - type: External
+      external:
+        metric:
+          name: vad_request_latency_p99
+        target:
+          type: Value
+          value: {{ .Values.autoscaling.requestLatencyP99 }}
+    {{- end }}
+
 {{- end }}

--- a/backend/charts/vad/templates/hpa.yaml
+++ b/backend/charts/vad/templates/hpa.yaml
@@ -39,7 +39,7 @@ spec:
         metric:
           name: vad_request_latency_p99
         target:
-          type: Value
+          type: AverageValue
           value: {{ .Values.autoscaling.requestLatencyP99 }}
     {{- end }}
 

--- a/backend/charts/vad/templates/hpa.yaml
+++ b/backend/charts/vad/templates/hpa.yaml
@@ -39,7 +39,7 @@ spec:
         metric:
           name: vad_request_latency_p99
         target:
-          type: AverageValue
+          type: Value
           value: {{ .Values.autoscaling.requestLatencyP99 }}
     {{- end }}
 

--- a/backend/charts/vad/values.yaml
+++ b/backend/charts/vad/values.yaml
@@ -100,7 +100,7 @@ autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
+  # targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
 # Additional volumes on the output Deployment definition.


### PR DESCRIPTION
**Changes:**

- Separate Diarizer and VAD into 2 different node pools.
- Migrate Diarizer and VAD to stronger instance types to reduce CPU pressure.
- Create new dashboard (GPU active time) for Diarizer and VAD on Grafana.
- Implement better HPA (based on request latency p99) for Diarizer and VAD.