### PR TITLE
fix(desktop): sanitize Gemini roles in proxy for Vertex AI compat

### DIFF
--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -627,16 +627,54 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
     obj.remove("cached_content");
     obj.remove("cachedContent");
 
-    // Inject missing "role" field into contents array.
-    // Vertex AI requires each content object to have a "role" field ("user" or "model"),
-    // while AI Studio defaults to "user" when absent. Old Swift app versions send
-    // contents without role, causing Vertex AI to return 400 INVALID_ARGUMENT.
+    // Sanitize role fields in contents array:
+    // 1. Inject missing "role" → default to "user" (Vertex AI requires it)
+    // 2. Move "role":"system" contents → systemInstruction (Vertex AI rejects "system" role)
+    //
+    // Vertex AI only accepts "user" or "model" in contents[].role.
+    // AI Studio silently handles missing roles and "system", but Vertex does not.
     if let Some(contents) = obj.get_mut("contents").and_then(|v| v.as_array_mut()) {
+        // First pass: inject missing roles
         for content in contents.iter_mut() {
             if let Some(content_obj) = content.as_object_mut() {
                 if !content_obj.contains_key("role") {
                     content_obj.insert("role".to_string(), serde_json::Value::String("user".to_string()));
                 }
+            }
+        }
+
+        // Second pass: extract "system" role contents → systemInstruction
+        let mut system_parts: Vec<serde_json::Value> = Vec::new();
+        contents.retain(|content| {
+            if let Some(role) = content.get("role").and_then(|r| r.as_str()) {
+                if role == "system" {
+                    if let Some(parts) = content.get("parts") {
+                        if let Some(arr) = parts.as_array() {
+                            system_parts.extend(arr.iter().cloned());
+                        }
+                    }
+                    return false; // remove from contents
+                }
+            }
+            true
+        });
+
+        if !system_parts.is_empty() {
+            // Merge into existing systemInstruction or create new one
+            let si_key = if obj.contains_key("system_instruction") {
+                "system_instruction"
+            } else {
+                "systemInstruction"
+            };
+            if let Some(existing) = obj.get_mut(si_key).and_then(|v| v.as_object_mut()) {
+                if let Some(existing_parts) = existing.get_mut("parts").and_then(|v| v.as_array_mut()) {
+                    existing_parts.extend(system_parts);
+                }
+            } else {
+                obj.insert(
+                    "systemInstruction".to_string(),
+                    serde_json::json!({"parts": system_parts}),
+                );
             }
         }
     }
@@ -1334,6 +1372,113 @@ mod tests {
         ).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert_eq!(parsed["contents"][0]["role"], "");
+    }
+
+    #[test]
+    fn sanitize_moves_system_role_to_system_instruction() {
+        // role:"system" in contents should be moved to systemInstruction
+        let body = serde_json::json!({
+            "contents": [
+                {"role": "system", "parts": [{"text": "You are a helpful assistant."}]},
+                {"role": "user", "parts": [{"text": "Hello"}]}
+            ]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        // System content removed from contents
+        assert_eq!(parsed["contents"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["contents"][0]["role"], "user");
+        // Moved to systemInstruction
+        assert_eq!(
+            parsed["systemInstruction"]["parts"][0]["text"],
+            "You are a helpful assistant."
+        );
+    }
+
+    #[test]
+    fn sanitize_merges_system_role_into_existing_system_instruction() {
+        // When systemInstruction already exists, system-role parts are appended
+        let body = serde_json::json!({
+            "systemInstruction": {"parts": [{"text": "Be concise."}]},
+            "contents": [
+                {"role": "system", "parts": [{"text": "Always respond in English."}]},
+                {"role": "user", "parts": [{"text": "Hi"}]}
+            ]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["contents"].as_array().unwrap().len(), 1);
+        let si_parts = parsed["systemInstruction"]["parts"].as_array().unwrap();
+        assert_eq!(si_parts.len(), 2);
+        assert_eq!(si_parts[0]["text"], "Be concise.");
+        assert_eq!(si_parts[1]["text"], "Always respond in English.");
+    }
+
+    #[test]
+    fn sanitize_merges_system_role_into_snake_case_system_instruction() {
+        // system_instruction (snake_case) should also work
+        let body = serde_json::json!({
+            "system_instruction": {"parts": [{"text": "Be concise."}]},
+            "contents": [
+                {"role": "system", "parts": [{"text": "Extra instruction."}]},
+                {"role": "user", "parts": [{"text": "Hi"}]}
+            ]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        let si_parts = parsed["system_instruction"]["parts"].as_array().unwrap();
+        assert_eq!(si_parts.len(), 2);
+        assert_eq!(si_parts[0]["text"], "Be concise.");
+        assert_eq!(si_parts[1]["text"], "Extra instruction.");
+    }
+
+    #[test]
+    fn sanitize_handles_multiple_system_role_contents() {
+        // Multiple system-role contents should all be collected
+        let body = serde_json::json!({
+            "contents": [
+                {"role": "system", "parts": [{"text": "Instruction 1"}]},
+                {"role": "user", "parts": [{"text": "Hello"}]},
+                {"role": "system", "parts": [{"text": "Instruction 2"}]}
+            ]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["contents"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["contents"][0]["role"], "user");
+        let si_parts = parsed["systemInstruction"]["parts"].as_array().unwrap();
+        assert_eq!(si_parts.len(), 2);
+        assert_eq!(si_parts[0]["text"], "Instruction 1");
+        assert_eq!(si_parts[1]["text"], "Instruction 2");
+    }
+
+    #[test]
+    fn sanitize_no_system_role_no_system_instruction_added() {
+        // When no system role exists, systemInstruction should not be created
+        let body = serde_json::json!({
+            "contents": [
+                {"role": "user", "parts": [{"text": "Hello"}]}
+            ]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(parsed.get("systemInstruction").is_none());
+        assert!(parsed.get("system_instruction").is_none());
     }
 
     #[test]

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -627,6 +627,20 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
     obj.remove("cached_content");
     obj.remove("cachedContent");
 
+    // Inject missing "role" field into contents array.
+    // Vertex AI requires each content object to have a "role" field ("user" or "model"),
+    // while AI Studio defaults to "user" when absent. Old Swift app versions send
+    // contents without role, causing Vertex AI to return 400 INVALID_ARGUMENT.
+    if let Some(contents) = obj.get_mut("contents").and_then(|v| v.as_array_mut()) {
+        for content in contents.iter_mut() {
+            if let Some(content_obj) = content.as_object_mut() {
+                if !content_obj.contains_key("role") {
+                    content_obj.insert("role".to_string(), serde_json::Value::String("user".to_string()));
+                }
+            }
+        }
+    }
+
     // Generation-specific validation (not for embed actions)
     let is_embed = action == "embedContent" || action == "batchEmbedContents";
     if !is_embed {
@@ -1227,6 +1241,57 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert!(parsed.get("cachedContent").is_none());
         assert!(parsed.get("cached_content").is_none());
+    }
+
+    #[test]
+    fn sanitize_injects_role_when_missing() {
+        // Old Swift app versions send contents without role field.
+        // Vertex AI requires role ("user"/"model"), AI Studio defaults to "user".
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["contents"][0]["role"], "user");
+    }
+
+    #[test]
+    fn sanitize_preserves_existing_role() {
+        let body = serde_json::json!({
+            "contents": [
+                {"role": "user", "parts": [{"text": "hello"}]},
+                {"role": "model", "parts": [{"text": "hi"}]}
+            ]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["contents"][0]["role"], "user");
+        assert_eq!(parsed["contents"][1]["role"], "model");
+    }
+
+    #[test]
+    fn sanitize_injects_role_for_multiple_contents() {
+        let body = serde_json::json!({
+            "contents": [
+                {"parts": [{"text": "hello"}]},
+                {"role": "model", "parts": [{"text": "hi"}]},
+                {"parts": [{"text": "thanks"}]}
+            ]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["contents"][0]["role"], "user");
+        assert_eq!(parsed["contents"][1]["role"], "model");
+        assert_eq!(parsed["contents"][2]["role"], "user");
     }
 
     #[test]

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -1295,6 +1295,48 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_allows_empty_contents_without_role_injection() {
+        let body = serde_json::json!({
+            "contents": []
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(parsed["contents"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sanitize_preserves_null_role() {
+        // role key exists but is null — preserves it (no override of explicit values)
+        let body = serde_json::json!({
+            "contents": [{"role": null, "parts": [{"text": "hello"}]}]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        // key exists so we don't inject — preserves explicit null
+        assert!(parsed["contents"][0]["role"].is_null());
+    }
+
+    #[test]
+    fn sanitize_preserves_empty_string_role() {
+        // role key exists but is "" — preserves it (no override of explicit values)
+        let body = serde_json::json!({
+            "contents": [{"role": "", "parts": [{"text": "hello"}]}]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["contents"][0]["role"], "");
+    }
+
+    #[test]
     fn sanitize_preserves_tools_field() {
         let body = serde_json::json!({
             "contents": [{"parts": [{"text": "hello"}]}],


### PR DESCRIPTION
## Summary
- Fixes 400 INVALID_ARGUMENT errors from Vertex AI caused by missing `role` field in request contents
- Fixes 1000+ 400s/hr from `role: "system"` in contents — transforms to `systemInstruction` field
- Vertex AI requires each content object to have a `role` field ("user" or "model"), while AI Studio silently defaults to "user" when absent
- Vertex AI rejects `role: "system"` in contents — system prompts must use the `systemInstruction` top-level field
- Backend-side fix in `sanitize_gemini_body()` handles both issues:
  1. Injects `"role": "user"` into content objects missing a role
  2. Extracts `role: "system"` contents and moves them to `systemInstruction`

## Root cause
**Missing role** — `GeminiClient.swift:16-18` — `GeminiRequest.Content` struct has no `role` property:
```swift
struct Content: Encodable {
    let parts: [Part]  // missing: let role: String
}
```

**System role** — Some code paths send `role: "system"` in contents. Vertex AI rejects this with 400 INVALID_ARGUMENT. The Gemini API expects system-level instructions in `systemInstruction`, not in `contents`.

## Test plan
- [x] 11 unit tests covering role injection and system role transformation
- [x] All 216 Rust tests pass
- [x] Live test: request WITHOUT role → proxy injects role → Vertex AI 200 OK
- [x] Live test: direct Vertex WITHOUT role → 400 INVALID_ARGUMENT (proves fix needed)
- [x] Named bundle app (`omi-role-fix`) running on Mac Mini, connected to local backend via tunnel
- [ ] Deploy and monitor 400 rate drops to near-zero

## Live evidence

**Gemini proxy (through fix):** Request without role field → 200 OK, response: "Four"
```
POST /v1/proxy/gemini/models/gemini-2.5-flash:generateContent
Body: {"contents":[{"parts":[{"text":"What is 2+2? Answer in one word."}]}]}
Response: 200 OK — {"candidates":[{"content":{"role":"model","parts":[{"text":"Four"}]}}]}
```

**Direct Vertex AI (no fix):** Same request → 400 INVALID_ARGUMENT
```
POST https://us-central1-aiplatform.googleapis.com/.../gemini-2.5-flash:generateContent
Response: 400 — {"error":{"status":"INVALID_ARGUMENT"}}
```

Fixes post-deployment 400 errors from #7078

🤖 Generated with [Claude Code](https://claude.com/claude-code)