### PR TITLE
Fix Vertex AI system role rejection in Python backend

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -10,6 +10,7 @@ from ulid import ULID
 from fastapi import APIRouter, Depends, Form, UploadFile, File, HTTPException, Header, Query
 from fastapi.responses import HTMLResponse
 
+from langchain_core.messages import SystemMessage, HumanMessage
 from utils.apps import fetch_app_chat_tools_from_manifest
 from utils.executors import storage_executor
 from utils.http_client import get_webhook_client
@@ -1175,8 +1176,8 @@ Be creative, fun, and varied. No generic ideas."""
         with track_usage(uid, Features.APP_GENERATOR):
             response = await get_llm('app_integration').ainvoke(
                 [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": "Generate 5 creative app ideas now"},
+                    SystemMessage(content=system_prompt),
+                    HumanMessage(content="Generate 5 creative app ideas now"),
                 ]
             )
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -107,6 +107,7 @@ pytest tests/unit/test_async_http_infrastructure.py -v
 pytest tests/unit/test_clean_sweep_migrations.py -v
 pytest tests/unit/test_omi_qos_tiers.py -v
 pytest tests/unit/test_byok_security.py -v
+pytest tests/unit/test_vertex_ai_system_role.py -v
 pytest tests/unit/test_tts.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)

--- a/backend/tests/unit/test_vertex_ai_system_role.py
+++ b/backend/tests/unit/test_vertex_ai_system_role.py
@@ -100,3 +100,48 @@ def test_generate_description_and_emoji_uses_langchain_messages():
         generate_description_and_emoji("TestApp", "do something cool")
 
     _assert_langchain_messages(capture.captured_messages)
+
+
+def test_apps_router_uses_langchain_messages_not_raw_dicts():
+    """apps.py generate_sample_prompts_endpoint must use SystemMessage/HumanMessage, not raw dicts.
+
+    Since routers/apps.py has heavy import dependencies that can't be easily mocked,
+    we verify the source code directly — the ainvoke call must use SystemMessage/HumanMessage
+    and must NOT contain raw dict patterns like {"role": "system"}.
+    """
+    import ast
+    import pathlib
+
+    apps_path = pathlib.Path(__file__).resolve().parents[2] / 'routers' / 'apps.py'
+    source = apps_path.read_text()
+
+    # Find the generate_sample_prompts_endpoint function
+    tree = ast.parse(source)
+    found_endpoint = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == 'generate_sample_prompts_endpoint':
+            found_endpoint = True
+            # Get the source lines for this function
+            func_source = ast.get_source_segment(source, node)
+            assert func_source is not None, "Could not extract function source"
+
+            # Must NOT contain raw dict message patterns
+            assert '{"role": "system"' not in func_source, (
+                "generate_sample_prompts_endpoint still uses raw dict {'role': 'system'}. "
+                "Must use SystemMessage() for Vertex AI compatibility."
+            )
+            assert "{'role': 'system'" not in func_source, (
+                "generate_sample_prompts_endpoint still uses raw dict {'role': 'system'}. "
+                "Must use SystemMessage() for Vertex AI compatibility."
+            )
+
+            # Must contain LangChain message objects
+            assert (
+                'SystemMessage(' in func_source
+            ), "generate_sample_prompts_endpoint must use SystemMessage() from langchain_core.messages"
+            assert (
+                'HumanMessage(' in func_source
+            ), "generate_sample_prompts_endpoint must use HumanMessage() from langchain_core.messages"
+            break
+
+    assert found_endpoint, "generate_sample_prompts_endpoint not found in routers/apps.py"

--- a/backend/tests/unit/test_vertex_ai_system_role.py
+++ b/backend/tests/unit/test_vertex_ai_system_role.py
@@ -1,0 +1,102 @@
+"""
+Regression test: LLM call sites must use LangChain message objects, not raw dicts.
+
+Vertex AI rejects "system" role in contents array. LangChain SystemMessage/HumanMessage
+auto-convert to the correct Gemini format (systemInstruction field). Raw dicts bypass
+this conversion and cause HTTP 400 errors.
+
+See: issue #7085, PR #7084
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import SystemMessage, HumanMessage
+
+# ---------------------------------------------------------------------------
+# Pre-mock heavy deps before any imports touch them (same pattern as test_omi_qos_tiers.py)
+# ---------------------------------------------------------------------------
+_HEAVY_MOCKS = {
+    'firebase_admin': MagicMock(),
+    'firebase_admin.auth': MagicMock(),
+    'firebase_admin.firestore': MagicMock(),
+    'firebase_admin.messaging': MagicMock(),
+    'firebase_admin.storage': MagicMock(),
+    'google.cloud.firestore': MagicMock(),
+    'google.cloud.firestore_v1': MagicMock(),
+    'google.cloud.firestore_v1.base_query': MagicMock(),
+    'google.cloud.storage': MagicMock(),
+    'database': MagicMock(),
+    'database._client': MagicMock(),
+    'database.llm_usage': MagicMock(),
+    'database.redis_db': MagicMock(),
+    'database.vector_db': MagicMock(),
+}
+
+for _mod, _mock in _HEAVY_MOCKS.items():
+    sys.modules.setdefault(_mod, _mock)
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-key-for-unit-tests')
+os.environ.setdefault('ANTHROPIC_API_KEY', 'sk-ant-test-fake-key')
+
+
+class _CaptureInvoke:
+    """Mock LLM that captures the messages passed to invoke/ainvoke."""
+
+    def __init__(self, content='[]'):
+        self.captured_messages = None
+        self.content = content
+
+    def invoke(self, messages, *args, **kwargs):
+        self.captured_messages = messages
+        resp = MagicMock()
+        resp.content = self.content
+        return resp
+
+    async def ainvoke(self, messages, *args, **kwargs):
+        self.captured_messages = messages
+        resp = MagicMock()
+        resp.content = self.content
+        return resp
+
+
+def _assert_langchain_messages(messages):
+    """Assert messages are LangChain objects, not raw dicts."""
+    assert isinstance(messages, list), f"Expected list, got {type(messages)}"
+    assert len(messages) >= 2, f"Expected at least 2 messages, got {len(messages)}"
+    for msg in messages:
+        assert not isinstance(msg, dict), (
+            f"Raw dict message found: {msg}. " "Must use SystemMessage/HumanMessage for Vertex AI compatibility."
+        )
+    assert isinstance(messages[0], SystemMessage), f"First message should be SystemMessage, got {type(messages[0])}"
+    assert isinstance(messages[1], HumanMessage), f"Second message should be HumanMessage, got {type(messages[1])}"
+
+
+@pytest.mark.asyncio
+async def test_generate_app_from_prompt_uses_langchain_messages():
+    """app_generator.generate_app_from_prompt must pass SystemMessage/HumanMessage."""
+    from utils.llm.app_generator import generate_app_from_prompt
+
+    capture = _CaptureInvoke(
+        '{"name": "Test", "description": "A test app", "category": "other", '
+        '"capabilities": ["chat"], "chat_prompt": "Be helpful"}'
+    )
+
+    with patch('utils.llm.app_generator.get_llm', return_value=capture):
+        await generate_app_from_prompt("Make a test app")
+
+    _assert_langchain_messages(capture.captured_messages)
+
+
+def test_generate_description_and_emoji_uses_langchain_messages():
+    """app_generator.generate_description_and_emoji must pass SystemMessage/HumanMessage."""
+    from utils.llm.app_generator import generate_description_and_emoji
+
+    capture = _CaptureInvoke('{"description": "A great app", "emoji": "🎯"}')
+
+    with patch('utils.llm.app_generator.get_llm', return_value=capture):
+        generate_description_and_emoji("TestApp", "do something cool")
+
+    _assert_langchain_messages(capture.captured_messages)

--- a/backend/utils/llm/app_generator.py
+++ b/backend/utils/llm/app_generator.py
@@ -10,6 +10,7 @@ from typing import Optional
 from pydantic import BaseModel
 from openai import OpenAI
 
+from langchain_core.messages import SystemMessage, HumanMessage
 from utils.llm.clients import get_llm
 
 # App categories available in the system
@@ -102,8 +103,8 @@ async def generate_app_from_prompt(user_prompt: str) -> GeneratedAppData:
     system_message = SYSTEM_PROMPT.format(categories=categories_str)
 
     messages = [
-        {"role": "system", "content": system_message},
-        {"role": "user", "content": f"Create an app based on this description:\n\n{user_prompt}"},
+        SystemMessage(content=system_message),
+        HumanMessage(content=f"Create an app based on this description:\n\n{user_prompt}"),
     ]
 
     response = await get_llm('app_generator').ainvoke(messages)
@@ -220,7 +221,7 @@ Respond ONLY with the JSON object, no other text."""
 What it does: {prompt}"""
 
     response = get_llm('app_integration').invoke(
-        [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
+        [SystemMessage(content=system_prompt), HumanMessage(content=user_prompt)]
     )
 
     content = response.content.strip()


### PR DESCRIPTION
## Summary
- Replace raw dict `{"role": "system", ...}` messages with LangChain `SystemMessage`/`HumanMessage` objects in 3 call sites
- Vertex AI rejects "system" role in the `contents` array — LangChain message objects auto-convert to the `systemInstruction` field
- Fixes 1000+ HTTP 400 errors/hour since USE_VERTEX_AI=true deployment

### Changed files
- `backend/routers/apps.py` — 1 call site (`generate_app_ideas` endpoint, line 1178)
- `backend/utils/llm/app_generator.py` — 2 call sites (`generate_app_from_prompt` line 105, `generate_description_and_emoji` line 223)

### Why LangChain objects fix this
Raw dicts `{"role": "system", ...}` pass through to Gemini's `contents` array as-is. Vertex AI only accepts `user` and `model` roles there — `system` must go in the `systemInstruction` field. LangChain's `SystemMessage` objects are automatically converted to `systemInstruction` by `ChatGoogleGenerativeAI`.

### Other call sites audited (not affected)
- `persona.py` — routes to OpenAI (`persona_clone` feature), not Gemini
- `fair_use_classifier.py` — uses `ChatOpenAI` directly, never routes to Vertex AI

## Test evidence
- `py_compile` passes on both files and all 43 routers
- 89/89 QoS tier tests pass
- Backend boots successfully (Application startup complete)
- CODEx review confirms approach is correct

## Test plan
- [ ] Verify `generate_app_ideas` endpoint returns valid ideas via Vertex AI
- [ ] Verify `generate_app_from_prompt` generates valid app config
- [ ] Verify `generate_description_and_emoji` returns description + emoji
- [ ] Confirm HTTP 400 rate drops to zero after deployment

## Risk
Zero — only changes message object type, same content, same LLM routing path. LangChain handles the Gemini format conversion.

Fixes #7085
Rust desktop proxy fix handled separately by kai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_