### PR TITLE
fix(desktop/sync): adopt orphan action_items by description only

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -2,7 +2,8 @@
   "unreleased": [
     "Fixed drag handle on Tasks page not appearing when hovering over a row",
     "Fixed drag-to-reorder on Tasks page not persisting when date filters are active",
-    "Fixed drag-to-reorder on Tasks page — dragged row now visually dims while in flight"
+    "Fixed drag-to-reorder on Tasks page — dragged row now visually dims while in flight",
+    "Fixed manual tasks producing duplicate rows on every backend sync — orphan adoption now matches by description only, since the backend does not preserve the client-side source value"
   ],
   "releases": [
     {
@@ -478,7 +479,7 @@
       "version": "0.11.370",
       "date": "2026-04-29",
       "changes": [
-        "Improved Ask Omi routing: questions now stay in the floating bar chat instead of incorrectly spawning background agents \u2014 Claude Haiku decides whether each message is a quick answer or a real task"
+        "Improved Ask Omi routing: questions now stay in the floating bar chat instead of incorrectly spawning background agents — Claude Haiku decides whether each message is a quick answer or a real task"
       ]
     },
     {
@@ -499,7 +500,7 @@
       "version": "0.11.367",
       "date": "2026-04-26",
       "changes": [
-        "Stop creating up to 5 tasks (and notifications) on every app launch \u2014 task promotion now happens at the natural cadence (when you complete a task, or every 5 minutes at most one at a time)"
+        "Stop creating up to 5 tasks (and notifications) on every app launch — task promotion now happens at the natural cadence (when you complete a task, or every 5 minutes at most one at a time)"
       ]
     },
     {
@@ -521,7 +522,7 @@
       "date": "2026-04-26",
       "changes": [
         "Added agent pills: action-y Ask Omi requests (typed or voice) now spawn small floating-bar agents that run in parallel; hover any pill to see live progress and open in chat",
-        "Added Execute button on floating-bar notification cards and task rows \u2014 one click spawns an agent that handles the item end-to-end"
+        "Added Execute button on floating-bar notification cards and task rows — one click spawns an agent that handles the item end-to-end"
       ]
     },
     {
@@ -606,7 +607,7 @@
       "version": "0.11.350",
       "date": "2026-04-21",
       "changes": [
-        "Auto-updates no longer install during an active conversation \u2014 the app waits for 2 minutes of silence before restarting"
+        "Auto-updates no longer install during an active conversation — the app waits for 2 minutes of silence before restarting"
       ]
     },
     {
@@ -621,7 +622,7 @@
       "date": "2026-04-21",
       "changes": [
         "Dashboard Tasks/Goals cards now shrink to fit content instead of stretching to fill the screen",
-        "Usage-based overage on Operator plan \u2014 chat past 500 questions is billed as real provider cost + 15% at end of cycle"
+        "Usage-based overage on Operator plan — chat past 500 questions is billed as real provider cost + 15% at end of cycle"
       ]
     },
     {
@@ -1844,8 +1845,8 @@
       "version": "0.11.134",
       "date": "2026-03-18",
       "changes": [
-        "Removed intro video from Rewind tab \u2014 screenshots are shown immediately",
-        "Fixed delayed screenshot capture after onboarding \u2014 first screenshot is now taken instantly"
+        "Removed intro video from Rewind tab — screenshots are shown immediately",
+        "Fixed delayed screenshot capture after onboarding — first screenshot is now taken instantly"
       ]
     },
     {
@@ -2249,8 +2250,8 @@
         "Added live 3D knowledge graph visualization during onboarding that builds incrementally as AI discovers information about you",
         "Added interaction hints to onboarding knowledge graph (drag, zoom, pan)",
         "Fixed onboarding resuming after Quit & Reopen for screen recording permission",
-        "Parallel AI exploration during onboarding \u2014 builds your digital profile and knowledge graph while you set up permissions",
-        "Automated release notes \u2014 changes are now tracked as they happen"
+        "Parallel AI exploration during onboarding — builds your digital profile and knowledge graph while you set up permissions",
+        "Automated release notes — changes are now tracked as they happen"
       ]
     },
     {
@@ -2326,9 +2327,9 @@
         "If the Install button fails, download manually from <a href='https://macos.omi.me' style='font-weight:bold'>macos.omi.me</a> (known issue on macOS 26)",
         "Task chat session history: resume previous AI conversations about tasks across app restarts",
         "Dedicated task chat side panel with better layout isolation and session ID display",
-        "Add task button in toolbar (\u2318N) for quick inline task creation",
+        "Add task button in toolbar (⌘N) for quick inline task creation",
         "File graph keyboard hints: drag to rotate, right-drag to pan, scroll to zoom",
-        "Removed per-message timeouts in AI bridge \u2014 long-running tools no longer fail prematurely",
+        "Removed per-message timeouts in AI bridge — long-running tools no longer fail prematurely",
         "Chat memory capped at 200 messages to prevent unbounded growth",
         "Auto-restart memory threshold lowered from 4GB to 3GB for safer recovery",
         "Fixed PostHog lifecycle capture causing 2-second XPC hangs to Spotlight",
@@ -2343,7 +2344,7 @@
       "version": "0.10.9",
       "date": "2026-02-23",
       "changes": [
-        "<span style='color:red;font-size:16px;font-weight:bold'>\u26a0\ufe0f AUTO-UPDATE IS BROKEN \u2014 YOU MUST DOWNLOAD MANUALLY</span>",
+        "<span style='color:red;font-size:16px;font-weight:bold'>⚠️ AUTO-UPDATE IS BROKEN — YOU MUST DOWNLOAD MANUALLY</span>",
         "<span style='color:red'>The Install button will NOT work.</span> Please download the new version here: <a href='https://macos.omi.me' style='color:red;font-weight:bold;font-size:15px'>macos.omi.me</a>",
         "Steps: 1) Click the link above or open <a href='https://macos.omi.me'>macos.omi.me</a> in your browser  2) Download the DMG  3) Open it and drag Omi to Applications  4) Replace the existing app when prompted",
         "This is a one-time fix. After installing manually, all future updates will work normally.",
@@ -2588,7 +2589,7 @@
         "Hardware-accelerated screen recording (hevc_videotoolbox) for lower CPU usage",
         "Auto-detects video calls (Zoom, Teams, Meet) and reduces capture frequency to avoid slowdowns",
         "Floating bar shows OMI logo and no longer drifts across the screen or off-screen on monitor disconnect",
-        "AI agent turn limit removed \u2014 tasks can run as many steps as needed",
+        "AI agent turn limit removed — tasks can run as many steps as needed",
         "Capped in-memory embeddings to 5,000 entries to prevent unbounded memory growth",
         "Fixed database crashes from concurrent sync operations during memory and action item writes",
         "Reduced error noise: cleaner Sentry logs, quieter Crisp polling, slower recovery retries"
@@ -2617,7 +2618,7 @@
         "Accessibility permission reset: detects broken state after macOS updates and offers one-click fix",
         "Database upgraded to connection pool for better performance during concurrent reads",
         "Automation permission check now handles System Events not running (fixes -600 error)",
-        "Onboarding no longer blocks on permissions \u2014 grant them later from Settings",
+        "Onboarding no longer blocks on permissions — grant them later from Settings",
         "Hiding the floating bar now persists across app restarts",
         "Native notifications when support replies in Help chat",
         "Faster conversation sync by skipping unchanged sessions"
@@ -2631,7 +2632,7 @@
         "Model picker: switch between Sonnet and Opus directly from the floating bar",
         "Voice follow-up: use push-to-talk while viewing an AI response to continue the conversation",
         "Batch transcription mode: record first, transcribe after for better accuracy (Settings > Shortcuts)",
-        "Customizable Ask Omi shortcut: choose \u2318Enter, \u2318\u21e7Enter, \u2318J, or \u2318O (Settings > Shortcuts)",
+        "Customizable Ask Omi shortcut: choose ⌘Enter, ⌘⇧Enter, ⌘J, or ⌘O (Settings > Shortcuts)",
         "Push-to-talk sounds can now be toggled off in settings",
         "AI chat now includes your tasks for more context-aware responses",
         "Long chat messages are auto-truncated with Show more/less toggle",

--- a/desktop/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -571,11 +571,15 @@ actor ActionItemStorage {
                     .filter(Column("backendSynced") == false)
                     .filter(Column("backendId") == nil || Column("backendId") == "")
                     .filter(Column("description") == item.description)
-                    .filter(Column("source") == (item.source ?? ""))
                     .fetchOne(database) {
                     // Adopt orphaned local record: link it to the backend ID.
                     // This heals records where saveTaskToSQLite succeeded but
                     // markSynced failed (e.g. app crash between backend sync and local update).
+                    // Match by description only — backend may not preserve the client's
+                    // `source` (manual tasks frequently come back with source=nil),
+                    // and a stricter match here causes the orphan to never be adopted,
+                    // leaving the manual unsynced and producing a duplicate row on every
+                    // pull that returns the same task.
                     orphan.backendId = item.id
                     orphan.backendSynced = true
                     orphan.updateFrom(item)


### PR DESCRIPTION
## Symptom

Manual action_items accumulate **1 (manual) + N (backend) duplicate rows** for the same task description. N grows on every sync pull that returns the task.

Confirmed in production against an affected account: **8 distinct task descriptions × 5–6 backend duplicates each = ~50 phantom rows** in the user's SQLite.

```
id  source  backendSynced  backendId      description
10  manual  0              NULL           Follow up on the exploratory call with Volt…
20  -       1              9JnzoHyZZPvs…  Follow up on the exploratory call with Volt…
35  -       1              WNxHBdFxdIf4…  Follow up on the exploratory call with Volt…
51  -       1              0opTxHjobr6v…  Follow up on the exploratory call with Volt…
60  -       1              BtlM23vf0OnC…  Follow up on the exploratory call with Volt…
69  -       1              IxBzPvFjwN9n…  Follow up on the exploratory call with Volt…
76  -       1              Mhm2w0bf71sX…  Follow up on the exploratory call with Volt…
```

All 6 backend copies have `source=NULL`. The local manual has `source="manual"`. Six **distinct** `backendId` values — `UNIQUE` constraint is honoured; the duplicates aren't a constraint bypass.

## Root cause

`ActionItemStorage.syncTaskActionItems` adopts a local orphan (`backendSynced=false`, `backendId IS NULL`) when an incoming backend item shares the same description. The match also requires `source` to be equal:

```swift
} else if var orphan = try ActionItemRecord
    .filter(Column("backendSynced") == false)
    .filter(Column("backendId") == nil || Column("backendId") == "")
    .filter(Column("description") == item.description)
    .filter(Column("source") == (item.source ?? ""))   // ← problem
    .fetchOne(database) {
```

The backend (`api.omi.me`, `database/action_items.py`) does **not** round-trip the client-side `source` value reliably — manual tasks come back with `source=nil`. The strict match fails, the orphan is never adopted, and the next branch falls through to `INSERT`, creating a fresh row with the new `backendId`. The manual stays orphaned (`backendSynced=false`) and ready to mismatch again on the next pull.

## Fix

Drop the `source` filter from the orphan match. Keep `description` as the join key — it's already constrained to local rows that were created without ever reaching the backend, so the false-positive surface is small.

## What this fixes (and what it does not)

- ✅ The manual orphan is now adopted on the first pull that returns the same task → no more `1 manual + N backend` per description from this code path.
- ❌ Does **not** fix duplicates created entirely server-side. Each call to `database.action_items.create_action_item(...)` in `api.omi.me` allocates a fresh Firestore document ID with no content-hash idempotency, and `database.staged_tasks.promote_staged_task(...)` does not check existing active action_items before promoting. Filed separately.

## Risk

Low. The orphan filter still requires the local row to have never been synced (`backendSynced=false AND backendId IS NULL`), so this cannot adopt or merge a record the backend already knows about.

## Test plan

- [x] Builds via `xcrun swift build -c debug --package-path desktop/Desktop`
- [ ] Manual: create a manual task whose description matches an incoming backend item. Trigger a pull. Confirm the manual is adopted (single row, `backendId` populated, `backendSynced=true`).
- [ ] Regression: two manuals with same description back-to-back → one adopted, the other stays orphaned for `retryUnsyncedItems` (expected, matches `LIMIT 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
