### PR TITLE
Fix WAL indicator showing during live transcription with connected WebSocket

### DIFF
--- a/app/lib/pages/conversation_capturing/page.dart
+++ b/app/lib/pages/conversation_capturing/page.dart
@@ -223,6 +223,7 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                         // Transcripts, photos + inline WAL safety indicator
                         Column(
                           children: [
+                            _buildUnsyncedWalIndicator(provider.unsyncedSessionWals, provider.inFlightAudioSeconds),
                             Expanded(
                               child: provider.segments.isEmpty && provider.photos.isEmpty
                                   ? Center(
@@ -290,7 +291,6 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                                           },
                                         ),
                             ),
-                            _buildUnsyncedWalIndicator(provider.unsyncedSessionWals, provider.inFlightAudioSeconds),
                           ],
                         ),
                         // Summary Tab

--- a/app/lib/services/wals/local_wal_sync.dart
+++ b/app/lib/services/wals/local_wal_sync.dart
@@ -444,11 +444,16 @@ class LocalWalSyncImpl implements LocalWalSync {
     await _saveWalsToFile();
   }
 
-  /// Returns the approximate duration (in seconds) of audio frames still in memory
-  /// that haven't been chunked/flushed to disk yet.
+  /// Returns the approximate duration (in seconds) of UNSYNCED audio frames
+  /// still in memory. Frames already delivered via WebSocket are excluded so
+  /// the "Audio Saved Locally" indicator only appears when data is at risk.
   int getInFlightSeconds() {
     if (_framesPerSecond <= 0) return 0;
-    return _frames.length ~/ _framesPerSecond;
+    int unsyncedCount = 0;
+    for (int i = 0; i < _frameSynced.length; i++) {
+      if (!_frameSynced[i]) unsyncedCount++;
+    }
+    return unsyncedCount ~/ _framesPerSecond;
   }
 
   @override

--- a/app/test/unit/wal_recovery_test.dart
+++ b/app/test/unit/wal_recovery_test.dart
@@ -234,6 +234,28 @@ void main() {
       }
       expect(sync.getInFlightSeconds(), 5); // 500 frames / 100 fps = 5s
     });
+
+    test('returns 0 when all frames are synced', () {
+      for (int i = 0; i < 500; i++) {
+        final key = FrameSyncKey([i & 0xFF]);
+        sync.onFrameCaptured(WalFrame(payload: [0, 1, 2], syncKey: key));
+        sync.markFrameSynced(key);
+      }
+      expect(sync.getInFlightSeconds(), 0);
+    });
+
+    test('counts only unsynced frames', () {
+      // 300 synced + 200 unsynced = 200 unsynced / 100 fps = 2s
+      for (int i = 0; i < 300; i++) {
+        final key = FrameSyncKey([i & 0xFF, (i >> 8) & 0xFF]);
+        sync.onFrameCaptured(WalFrame(payload: [0, 1, 2], syncKey: key));
+        sync.markFrameSynced(key);
+      }
+      for (int i = 300; i < 500; i++) {
+        sync.onFrameCaptured(WalFrame(payload: [0, 1, 2], syncKey: FrameSyncKey([i & 0xFF, (i >> 8) & 0xFF])));
+      }
+      expect(sync.getInFlightSeconds(), 2);
+    });
   });
 
   group('finalizeCurrentSession', () {


### PR DESCRIPTION
## Summary

Fixes #7095 — The "Audio Saved Locally" WAL indicator was always visible during live transcription, even when the WebSocket was connected and all audio frames were being delivered successfully.

**Root causes:**
- `getInFlightSeconds()` counted ALL buffered frames (synced + unsynced), so it was always >0 during recording
- The indicator widget was positioned at the bottom of the Column, covered by the "Process Now" FAB

**Changes:**
- `getInFlightSeconds()` now counts only unsynced frames — returns 0 when all frames are delivered via WebSocket
- WAL indicator moved above the transcript content so it's never covered by the FAB
- 2 new unit tests verifying the unsynced-only counting behavior

## Test plan

- [x] `flutter test test/unit/wal_recovery_test.dart` — 21/21 pass (2 new)
- [x] Full test suite — 410 pass, 3 fail (all pre-existing)
- [x] `dart format` clean
- [ ] L1: Build app, verify indicator hidden during connected recording
- [ ] L2: Build app with local backend, verify integrated flow

_by AI for @beastoin_