### PR TITLE
fix: prevent stale memory_id from overwriting active conversation_id

### DIFF
--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -447,9 +447,6 @@ async def _websocket_util_trigger(
                     res = json.loads(bytes(data[4:]).decode("utf-8"))
                     segments = res.get('segments')
                     memory_id = res.get('memory_id')
-                    # Update conversation_id from transcript if provided
-                    if memory_id:
-                        current_conversation_id = memory_id
                     if len(transcript_queue) >= TRANSCRIPT_QUEUE_WARN_SIZE:
                         logger.warning(f"Warning: transcript_queue size {len(transcript_queue)} {uid}")
                     # Use memory_id if available, otherwise use current_conversation_id for conversations

--- a/backend/tests/unit/test_listen_pipeline.py
+++ b/backend/tests/unit/test_listen_pipeline.py
@@ -633,15 +633,15 @@ class TestPusherHeaderDemux:
         assert len(private_cloud_queue[0]['data']) == 500
         assert len(private_cloud_sync_buffer) == 0
 
-    def test_flaw_header_102_memory_id_updates_conversation_id(self):
-        """FLAW TEST: memory_id in transcript should update current_conversation_id."""
+    def test_header_102_memory_id_does_not_update_conversation_id(self):
+        """Inline logic test: verifies current_conversation_id is not mutated."""
         current_conversation_id = 'old-conv'
         payload = {'segments': [], 'memory_id': 'new-conv-from-memory'}
         res = payload
         memory_id = res.get('memory_id')
-        if memory_id:
-            current_conversation_id = memory_id
-        assert current_conversation_id == 'new-conv-from-memory'
+        conversation_or_memory_id = memory_id or current_conversation_id
+        assert conversation_or_memory_id == 'new-conv-from-memory'
+        assert current_conversation_id == 'old-conv'
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Remove code that allowed transcript memory_id to overwrite current_conversation_id
- transcript_queue still uses memory_id when available (queue entry only)
## Fixes #6952 (P1 Critical)
## Root Cause
Lines 450-452 in pusher.py were overwriting current_conversation_id with 
transcript memory_id, causing stale backend conversation IDs to be injected 
into newer recording sessions. This corrupts session state and causes timestamp 
reconciliation failures.
## Solution
Remove the 3 lines that overwrote current_conversation_id. The queue entry 
still correctly uses memory_id when present (memory_id or current_conversation_id).