### PR TITLE
Affiliate payouts: fix mark-as-paid, Stripe validation, cooldown date

### DIFF
--- a/web/admin/app/api/omi/affiliate-payouts/route.ts
+++ b/web/admin/app/api/omi/affiliate-payouts/route.ts
@@ -257,16 +257,24 @@ export async function POST(request: NextRequest) {
         { idempotencyKey }
       );
 
-      // 2. Mark as paid in GoAffPro
+      // 2. Fetch unpaid transaction IDs, then mark as paid in GoAffPro
       // If this fails, return partial success with transfer_id so admin can reconcile
       try {
-        await goaffproPost('/admin/payments', {
-          payments: [
+        const unpaidRes = await goaffproGet(
+          `/admin/payments/transactions/unpaid?affiliate_id=${affiliate_id}&upto=${new Date().toISOString().split('T')[0]}`
+        );
+        const txIds = (unpaidRes.transactions || [])
+          .map((t: { tx_id: number }) => t.tx_id)
+          .filter(Boolean);
+
+        await goaffproPost('/admin/payments/transactions/pay', {
+          items: [
             {
-              affiliate_id: String(affiliate_id),
+              affiliate_id: Number(affiliate_id),
               amount,
+              tx_ids: txIds,
               payment_method: 'stripe',
-              admin_note: `Stripe transfer ${transfer.id}`,
+              payment_note: `Stripe transfer ${transfer.id}`,
             },
           ],
         });

--- a/web/admin/app/api/omi/affiliate-payouts/route.ts
+++ b/web/admin/app/api/omi/affiliate-payouts/route.ts
@@ -197,9 +197,14 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      // Same 2-month-ago cutoff as the GET handler
+      const now = new Date();
+      const lastDayTwoMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 1, 0);
+      const upto = lastDayTwoMonthsAgo.toISOString().split('T')[0];
+
       // Re-fetch pending amount and Stripe account server-side (never trust client)
       const pendingRes = await goaffproGet(
-        `/admin/payments/pending?affiliate_id=${affiliate_id}`
+        `/admin/payments/pending?affiliate_id=${affiliate_id}&upto=${upto}`
       );
       const pendingEntry = (pendingRes.pending || [])[0];
       if (!pendingEntry || pendingEntry.pending < 10) {
@@ -267,11 +272,20 @@ export async function POST(request: NextRequest) {
       // If this fails, return partial success with transfer_id so admin can reconcile
       try {
         const unpaidRes = await goaffproGet(
-          `/admin/payments/transactions/unpaid?affiliate_id=${affiliate_id}&upto=${new Date().toISOString().split('T')[0]}`
+          `/admin/payments/transactions/unpaid?affiliate_id=${affiliate_id}&upto=${upto}`
         );
         const txIds = (unpaidRes.transactions || [])
           .map((t: { tx_id: number }) => t.tx_id)
           .filter(Boolean);
+
+        if (txIds.length === 0) {
+          return NextResponse.json({
+            success: true,
+            partial: true,
+            transfer_id: transfer.id,
+            warning: 'Transfer sent but no unpaid transactions found to mark as paid in GoAffPro. Transfer ID: ' + transfer.id,
+          });
+        }
 
         await goaffproPost('/admin/payments/transactions/pay', {
           items: [

--- a/web/admin/app/api/omi/affiliate-payouts/route.ts
+++ b/web/admin/app/api/omi/affiliate-payouts/route.ts
@@ -65,7 +65,12 @@ export async function GET(request: NextRequest) {
 
     if (action === 'pending') {
       // Get pending payouts with affiliate details
-      const pendingRes = await goaffproGet('/admin/payments/pending');
+      // upto = last day of previous month (current month's transactions aren't payable yet)
+      const now = new Date();
+      const lastDayPrevMonth = new Date(now.getFullYear(), now.getMonth(), 0);
+      const upto = lastDayPrevMonth.toISOString().split('T')[0];
+
+      const pendingRes = await goaffproGet(`/admin/payments/pending?upto=${upto}`);
       const pending = pendingRes.pending || [];
 
       // Get order details for affiliates with pending amounts

--- a/web/admin/app/api/omi/affiliate-payouts/route.ts
+++ b/web/admin/app/api/omi/affiliate-payouts/route.ts
@@ -65,10 +65,11 @@ export async function GET(request: NextRequest) {
 
     if (action === 'pending') {
       // Get pending payouts with affiliate details
-      // upto = last day of previous month (current month's transactions aren't payable yet)
+      // upto = last day of 2 months ago (30-day cooldown + payout at start of month)
+      // e.g. In May → March 31, In April → Feb 28, In July → May 31
       const now = new Date();
-      const lastDayPrevMonth = new Date(now.getFullYear(), now.getMonth(), 0);
-      const upto = lastDayPrevMonth.toISOString().split('T')[0];
+      const lastDayTwoMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 1, 0);
+      const upto = lastDayTwoMonthsAgo.toISOString().split('T')[0];
 
       const pendingRes = await goaffproGet(`/admin/payments/pending?upto=${upto}`);
       const pending = pendingRes.pending || [];


### PR DESCRIPTION
## Summary
Follow-up fixes to #7100 (merged):

- **Fix mark-as-paid:** Use `POST /admin/payments/transactions/pay` with `tx_ids` instead of `POST /admin/payments` which returned 500
- **Validate Stripe accounts:** Verify each `acct_` ID exists on our Stripe platform before showing as "Ready for Transfer" or executing a transfer
- **30-day cooldown:** Pending amounts now use `upto` = last day of 2 months ago (e.g. in May → March 31, April → Feb 28)

## Test plan
- [ ] Verify pending amounts reflect cooldown (should be lower than before)
- [ ] Verify invalid Stripe accounts excluded from "Ready for Transfer"
- [ ] Verify transfer marks as paid in GoAffPro with correct tx_ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)