### PR TITLE
ci(app): auto-resolve iOS build version from TestFlight + App Store

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -140,8 +140,18 @@ workflows:
             BUILD_NAME=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f1)
             BUILD_NUMBER=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f2)
           else
-            HIGHEST_V=$(printf '%s\n%s\n' "$TF_V" "$AS_V" | sort -V | tail -1)
-            if [ "$HIGHEST_V" = "$TF_V" ] && [ "$TF_V" != "$AS_V" ]; then
+            semver_gt() {
+              IFS='.' read -r a1 a2 a3 <<< "$1"
+              IFS='.' read -r b1 b2 b3 <<< "$2"
+              [ "$a1" -gt "$b1" ] && return 0
+              [ "$a1" -lt "$b1" ] && return 1
+              [ "$a2" -gt "$b2" ] && return 0
+              [ "$a2" -lt "$b2" ] && return 1
+              [ "$a3" -gt "$b3" ] && return 0
+              return 1
+            }
+
+            if semver_gt "$TF_V" "$AS_V"; then
               BUILD_NAME="$TF_V"
               echo "TF ahead of App Store -> reusing TF version $BUILD_NAME"
             else

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -116,21 +116,52 @@ workflows:
         script: |
           cd ios && pod install --repo-update
 
+      - name: Resolve next version from TestFlight + App Store
+        script: |
+          set -e
+
+          EMPTY='{"version":"0.0.0","build_number":"0"}'
+          TF_RAW=$(app-store-connect get-latest-testflight-build-number "$APP_ID" --include-version --json 2>/dev/null) || TF_RAW=""
+          AS_RAW=$(app-store-connect get-latest-app-store-build-number "$APP_ID" --include-version --json 2>/dev/null) || AS_RAW=""
+          [ -z "$TF_RAW" ] && TF_RAW="$EMPTY"
+          [ -z "$AS_RAW" ] && AS_RAW="$EMPTY"
+
+          TF_V=$(echo "$TF_RAW" | jq -r '.version // "0.0.0"')
+          TF_B=$(echo "$TF_RAW" | jq -r '.build_number // "0"')
+          AS_V=$(echo "$AS_RAW" | jq -r '.version // "0.0.0"')
+          AS_B=$(echo "$AS_RAW" | jq -r '.build_number // "0"')
+
+          echo "TestFlight latest: ${TF_V}+${TF_B}"
+          echo "App Store latest:  ${AS_V}+${AS_B}"
+
+          if [ "$TF_V" = "0.0.0" ] && [ "$AS_V" = "0.0.0" ]; then
+            echo "WARNING: No TestFlight or App Store history. Seeding from pubspec.yaml."
+            PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' ')
+            BUILD_NAME=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f1)
+            BUILD_NUMBER=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f2)
+          else
+            if [ "$TF_V" = "$AS_V" ]; then
+              IFS='.' read -r MAJ MIN PATCH <<< "$AS_V"
+              BUILD_NAME="${MAJ}.${MIN}.$((PATCH + 1))"
+              echo "TF and App Store at same version ($AS_V) -> bumping patch to $BUILD_NAME"
+            else
+              BUILD_NAME="$TF_V"
+              echo "TF ahead of App Store -> reusing TF version $BUILD_NAME"
+            fi
+
+            MAX_B=$TF_B
+            [ "$AS_B" -gt "$MAX_B" ] && MAX_B=$AS_B
+            [ "${PROJECT_BUILD_NUMBER:-0}" -gt "$MAX_B" ] && MAX_B=$PROJECT_BUILD_NUMBER
+            BUILD_NUMBER=$((MAX_B + 1))
+          fi
+
+          echo "Resolved next version: ${BUILD_NAME}+${BUILD_NUMBER}"
+          echo BUILD_NAME="$BUILD_NAME" >> $CM_ENV
+          echo BUILD_NUMBER="$BUILD_NUMBER" >> $CM_ENV
+
       - name: Flutter build ipa
         script: |
           xcode-project use-profiles
-
-          # Extract version from pubspec.yaml (source of truth for both name and build number)
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' ')
-          BUILD_NAME=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f1)  # e.g., "1.0.525"
-          BUILD_NUMBER=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f2)  # e.g., "758"
-
-          # Skip if this build number is already on TestFlight
-          LATEST_BUILD=$(app-store-connect get-latest-testflight-build-number $APP_ID || echo "0")
-          if [ "$BUILD_NUMBER" -le "$LATEST_BUILD" ]; then
-            echo "Build $BUILD_NUMBER already on TestFlight (latest: $LATEST_BUILD). Skipping."
-            exit 0
-          fi
 
           echo "Building iOS with version $BUILD_NAME ($BUILD_NUMBER)"
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -120,16 +120,16 @@ workflows:
         script: |
           set -e
 
-          EMPTY='{"version":"0.0.0","build_number":"0"}'
+          EMPTY='{"version":"0.0.0","buildNumber":"0"}'
           TF_RAW=$(app-store-connect get-latest-testflight-build-number "$APP_ID" --include-version --json 2>/dev/null) || TF_RAW=""
           AS_RAW=$(app-store-connect get-latest-app-store-build-number "$APP_ID" --include-version --json 2>/dev/null) || AS_RAW=""
           [ -z "$TF_RAW" ] && TF_RAW="$EMPTY"
           [ -z "$AS_RAW" ] && AS_RAW="$EMPTY"
 
           TF_V=$(echo "$TF_RAW" | jq -r '.version // "0.0.0"')
-          TF_B=$(echo "$TF_RAW" | jq -r '.build_number // "0"')
+          TF_B=$(echo "$TF_RAW" | jq -r '.buildNumber // "0"')
           AS_V=$(echo "$AS_RAW" | jq -r '.version // "0.0.0"')
-          AS_B=$(echo "$AS_RAW" | jq -r '.build_number // "0"')
+          AS_B=$(echo "$AS_RAW" | jq -r '.buildNumber // "0"')
 
           echo "TestFlight latest: ${TF_V}+${TF_B}"
           echo "App Store latest:  ${AS_V}+${AS_B}"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -166,7 +166,6 @@ workflows:
 
             MAX_B=$TF_B
             [ "$AS_B" -gt "$MAX_B" ] && MAX_B=$AS_B
-            [ "${PROJECT_BUILD_NUMBER:-0}" -gt "$MAX_B" ] && MAX_B=$PROJECT_BUILD_NUMBER
             BUILD_NUMBER=$((MAX_B + 1))
           fi
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -140,13 +140,14 @@ workflows:
             BUILD_NAME=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f1)
             BUILD_NUMBER=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f2)
           else
-            if [ "$TF_V" = "$AS_V" ]; then
-              IFS='.' read -r MAJ MIN PATCH <<< "$AS_V"
-              BUILD_NAME="${MAJ}.${MIN}.$((PATCH + 1))"
-              echo "TF and App Store at same version ($AS_V) -> bumping patch to $BUILD_NAME"
-            else
+            HIGHEST_V=$(printf '%s\n%s\n' "$TF_V" "$AS_V" | sort -V | tail -1)
+            if [ "$HIGHEST_V" = "$TF_V" ] && [ "$TF_V" != "$AS_V" ]; then
               BUILD_NAME="$TF_V"
               echo "TF ahead of App Store -> reusing TF version $BUILD_NAME"
+            else
+              IFS='.' read -r MAJ MIN PATCH <<< "$AS_V"
+              BUILD_NAME="${MAJ}.${MIN}.$((PATCH + 1))"
+              echo "TF (${TF_V}) <= AS (${AS_V}) -> bumping patch to $BUILD_NAME"
             fi
 
             MAX_B=$TF_B

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -157,7 +157,11 @@ workflows:
             else
               IFS='.' read -r MAJ MIN PATCH <<< "$AS_V"
               BUILD_NAME="${MAJ}.${MIN}.$((PATCH + 1))"
-              echo "TF (${TF_V}) <= AS (${AS_V}) -> bumping patch to $BUILD_NAME"
+              if [ "$TF_V" = "0.0.0" ]; then
+                echo "No TestFlight history -> bumping App Store patch to $BUILD_NAME"
+              else
+                echo "TF (${TF_V}) <= AS (${AS_V}) -> bumping patch to $BUILD_NAME"
+              fi
             fi
 
             MAX_B=$TF_B


### PR DESCRIPTION
## Summary

Replaces the manual `pubspec.yaml` version bump (and silent skip-on-collision) in `ios-internal-auto` with a CI step that queries App Store Connect directly and computes the next version.

## Problem

`ios-internal-auto` (push → main, `app/**`) reads `version: 1.0.534+835` from `pubspec.yaml` and exits 0 if the build number is already on TestFlight. PRs that don't bump pubspec silently don't publish, and the Android `android-prod-internal` workflow even has a `# Should use bump version automatically by CI` TODO. ~17 of the last ~100 commits to `app/pubspec.yaml` are manual bumps.

## Behaviour

Before each iOS build, query both `app-store-connect get-latest-testflight-build-number $APP_ID --include-version --json` and `get-latest-app-store-build-number ...`, then:

- if TestFlight `version_name` == App Store `version_name` → bump the patch component (e.g. both at `1.0.530+600` → next `1.0.531+601`)
- otherwise reuse the TestFlight `version_name` (already ahead) and just bump the build number (e.g. App Store `1.0.530+600`, TestFlight `1.0.531+620` → next `1.0.531+621`)
- `build_number = max(TF_build, AS_build, $PROJECT_BUILD_NUMBER) + 1` so the build number is strictly increasing and tolerates back-to-back merges via Codemagic's per-project counter

The `flutter build ipa --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER` flags override pubspec at build time, so `pubspec.yaml` no longer has to be touched per PR.

Scope is iOS only; Android will track parity via the iOS-driven version (per manager).

## Cold start

If both queries return nothing (brand-new app, no TF or App Store history), the resolver falls back to the existing `pubspec.yaml` value with a warning. This preserves the current first-build path.

## Race-window mitigation

Two PRs merging within minutes of each other could each compute `latest + 1`. Mitigation: `BUILD_NUMBER = max(TF, AS, $PROJECT_BUILD_NUMBER) + 1` — Codemagic's monotonic per-project counter breaks the tie without retry logic.

## Out of scope

- `android-internal-auto` (parity from iOS per manager)
- Tag-based prod workflows (`ios-prod-testflight`, `android-prod-internal`) — they parse the version from `$CM_TAG` and stay explicit-tag-driven
- Removing future manual `version:` bumps from `pubspec.yaml` (the line still exists for the cold-start path; only the build-time override changes)

## Test plan

Resolver logic was unit-tested locally against a mocked CLI output, covering all six scenarios:

- TF ahead of AS (manager's example 1: `AS 1.0.530+600`, `TF 1.0.531+620` → `1.0.531+621`)
- TF == AS at same build (manager's example 2: both `1.0.530+600` → `1.0.531+601`)
- TF == AS version_name but TF build ahead (`1.0.530+601` vs `+600` → `1.0.531+602`)
- No App Store release yet (TF only)
- Cold start, both queries empty (falls back to pubspec)
- `PROJECT_BUILD_NUMBER` higher than TF/AS (race tie-break)

CI smoke: first run after merge will exercise the live App Store Connect query path against the existing `codemagic_v4` integration.