### PR TITLE
ci: bump iOS workflows to Xcode 26.0.1 for App Store SDK requirement

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -25,7 +25,7 @@ workflows:
         APP_ID: 6502156163
         STAGING_API_URL: "https://api.omiapi.com/"
       flutter: 3.35.3
-      xcode: 16.4
+      xcode: 26.0.1
       cocoapods: 1.16.2
     cache:
       cache_paths:
@@ -377,7 +377,7 @@ workflows:
         APP_ID: 6502156163
         STAGING_API_URL: "https://api.omiapi.com/"
       flutter: 3.35.3
-      xcode: 16.4
+      xcode: 26.0.1
       cocoapods: 1.16.2
     cache:
       cache_paths:
@@ -931,7 +931,7 @@ workflows:
         APP_ID: 6502156163
         STAGING_API_URL: "https://api.omiapi.com/"
       flutter: 3.35.3
-      xcode: 16.4
+      xcode: 26.0.1
       cocoapods: 1.16.2
     cache:
       cache_paths:


### PR DESCRIPTION
## Summary
- Bumps `ios-internal-auto`, `ios-prod-testflight`, and `ios-prod-patch` from Xcode 16.4 → 26.0.1 in `codemagic.yaml`.
- App Store Connect now rejects builds compiled with the iOS 18.5 SDK (Xcode 16.4) — Apple requires the iOS 26 SDK or later as of April 2026. Latest TestFlight upload failed with `STATE_ERROR.VALIDATION_ERROR` / SDK version issue (id 9e3792cc-9860-4e83-bdad-c60a984946c2).
- 26.0.1 is already used successfully by `macos-prod-appstore` and the desktop build, so the image is known-good on Codemagic.

## Not changed
- Android workflows (`android-internal-auto`, `android-prod-internal`, `android-prod-patch`) stay on 16.4 — they don't link the iOS SDK.
- `omi-desktop-swift-release` stays on 16.4 — it ships a notarized DMG outside the App Store, so the iOS-26 SDK rule doesn't apply.

## Test plan
- [ ] Re-run `Release iOS to Testflight` on Codemagic against this branch and confirm the IPA uploads to App Store Connect without the SDK validation error.
- [ ] Smoke-test the resulting TestFlight build on a device (cold launch + onboarding) to make sure Xcode 26 didn't regress anything at runtime.
- [ ] After this lands, run `Auto Deploy iOS to Internal TestFlight` (push to main) and `Patch iOS to Production` (Shorebird patch tag) at least once to validate the bump on those workflows too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)