### PR TITLE
Fix duplicate subscription race condition

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -381,7 +381,9 @@ def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = 
     # Normal checkout flow for new subscriptions (Scenario B or first-time subscribers)
     idempotency_key = str(uuid.uuid4())
     existing_customer_id = users_db.get_stripe_customer_id(uid)
-    session = stripe_utils.create_subscription_checkout_session(uid, request.price_id, idempotency_key, customer_id=existing_customer_id)
+    session = stripe_utils.create_subscription_checkout_session(
+        uid, request.price_id, idempotency_key, customer_id=existing_customer_id
+    )
     if not session:
         raise HTTPException(status_code=500, detail="Could not create checkout session.")
     return {"url": session.url, "session_id": session.id}

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -380,7 +380,8 @@ def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = 
 
     # Normal checkout flow for new subscriptions (Scenario B or first-time subscribers)
     idempotency_key = str(uuid.uuid4())
-    session = stripe_utils.create_subscription_checkout_session(uid, request.price_id, idempotency_key)
+    existing_customer_id = users_db.get_stripe_customer_id(uid)
+    session = stripe_utils.create_subscription_checkout_session(uid, request.price_id, idempotency_key, customer_id=existing_customer_id)
     if not session:
         raise HTTPException(status_code=500, detail="Could not create checkout session.")
     return {"url": session.url, "session_id": session.id}

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -70,6 +70,7 @@ def create_subscription_checkout_session(uid: str, price_id: str, idempotency_ke
 
         if customer_id:
             session_params['customer'] = customer_id
+            session_params['customer_update'] = {'name': 'auto', 'address': 'auto'}
 
         if idempotency_key:
             session_params['idempotency_key'] = idempotency_key

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -36,7 +36,7 @@ def create_app_monthly_recurring_price(product_id: str, amount_in_cents: int, cu
     return price
 
 
-def create_subscription_checkout_session(uid: str, price_id: str, idempotency_key: str = None):
+def create_subscription_checkout_session(uid: str, price_id: str, idempotency_key: str = None, customer_id: str = None):
     """Create a Stripe Checkout session for a subscription."""
     try:
         success_url = urljoin(base_url, 'v1/payments/success?session_id={CHECKOUT_SESSION_ID}')
@@ -67,6 +67,9 @@ def create_subscription_checkout_session(uid: str, price_id: str, idempotency_ke
                 }
             },
         }
+
+        if customer_id:
+            session_params['customer'] = customer_id
 
         if idempotency_key:
             session_params['idempotency_key'] = idempotency_key

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -474,6 +474,8 @@ def _has_active_stripe_subscription(uid: str) -> bool:
         subs = stripe.Subscription.list(customer=customer_id, status='active', limit=5)
         for sub in subs.data:
             sub_dict = sub.to_dict()
+            if sub_dict.get('cancel_at_period_end'):
+                continue
             if sub_dict.get('metadata', {}).get('uid') == uid:
                 return True
     except Exception as e:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -478,6 +478,7 @@ def _has_active_stripe_subscription(uid: str) -> bool:
                 return True
     except Exception as e:
         logger.error(f"Error checking Stripe for active subscriptions: {e}")
+        return True  # fail-closed: block checkout if Stripe is unreachable
     return False
 
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -461,6 +461,26 @@ def get_plan_features(plan: PlanType, simplified: bool = False) -> List[str]:
     ]
 
 
+def _has_active_stripe_subscription(uid: str) -> bool:
+    """Check Stripe directly for active subscriptions owned by this user.
+
+    This catches cases where Firestore hasn't been updated yet (e.g. webhook
+    write hasn't propagated) but Stripe already has an active subscription.
+    """
+    customer_id = users_db.get_stripe_customer_id(uid)
+    if not customer_id:
+        return False
+    try:
+        subs = stripe.Subscription.list(customer=customer_id, status='active', limit=5)
+        for sub in subs.data:
+            sub_dict = sub.to_dict()
+            if sub_dict.get('metadata', {}).get('uid') == uid:
+                return True
+    except Exception as e:
+        logger.error(f"Error checking Stripe for active subscriptions: {e}")
+    return False
+
+
 def can_user_make_payment(uid: str, target_price_id: str = None) -> tuple[bool, str]:
     """
     Checks if a user can make a new payment based on their current subscription status.
@@ -474,8 +494,11 @@ def can_user_make_payment(uid: str, target_price_id: str = None) -> tuple[bool, 
     """
     subscription = users_db.get_user_valid_subscription(uid)
 
-    # If no subscription or basic plan, user can pay
+    # If no subscription or basic plan, check Stripe as source of truth
+    # to guard against Firestore read-after-write lag
     if not subscription or subscription.plan == PlanType.basic:
+        if _has_active_stripe_subscription(uid):
+            return False, "User already has an active subscription (pending sync)"
         return True, "User can make payment"
 
     # If unlimited plan but inactive, user can pay


### PR DESCRIPTION
## Summary

- **Root cause:** A user completed checkout for Omi Unlimited, but the app showed "not subscribed" 4 seconds later because the webhook write to Firestore hadn't propagated yet. The user retried, paid again, and ended up with two active subscriptions under two different Stripe customers — double-billed over 4 months.
- `can_user_make_payment()` now checks Stripe directly (source of truth) when Firestore shows no active subscription, blocking the second checkout attempt during the Firestore sync window
- `create_subscription_checkout_session()` accepts and passes an existing `customer_id` so Stripe reuses the same customer object instead of creating a duplicate
- Checkout endpoint looks up existing `stripe_customer_id` from Firestore and passes it through

## Test plan

- [ ] Verify existing checkout flow still works for new users (no stripe_customer_id yet)
- [ ] Verify returning users with stripe_customer_id get a checkout session tied to their existing customer
- [ ] Simulate the race: create a subscription via Stripe, verify `can_user_make_payment()` blocks before Firestore sync
- [ ] Verify upgrade/downgrade flows still work (different price_id should still be allowed)
- [ ] Verify reactivation flow (cancel_at_period_end=True, same plan) still works