### PR TITLE
fix(sync): add missing record_usage to sync endpoints + deprecate v1

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -272,40 +272,6 @@ Future<bool> deleteConversationActionItem(String conversationId, ActionItem item
   return response.statusCode == 204;
 }
 
-Future<SyncLocalFilesResponse> syncLocalFiles(List<File> files, {UploadProgressCallback? onUploadProgress}) async {
-  try {
-    var response = await makeMultipartApiCall(
-      url: '${Env.apiBaseUrl}v1/sync-local-files',
-      files: files,
-      onUploadProgress: onUploadProgress,
-    );
-
-    if (response.statusCode == 200 || response.statusCode == 207) {
-      var result = SyncLocalFilesResponse.fromJson(jsonDecode(response.body));
-      if (response.statusCode == 207) {
-        Logger.debug(
-          'syncLocalFiles partial failure: ${result.failedSegments}/${result.totalSegments} segments failed, '
-          'errors: ${result.errors}',
-        );
-      } else {
-        Logger.debug('syncLocalFile Response body: ${jsonDecode(response.body)}');
-      }
-      return result;
-    } else if (response.statusCode == 400) {
-      throw Exception('Audio file could not be processed by server');
-    } else if (response.statusCode == 413) {
-      throw Exception('Audio file is too large to upload');
-    } else if (response.statusCode >= 500) {
-      throw Exception('Server is temporarily unavailable');
-    } else {
-      throw Exception('Upload failed unexpectedly');
-    }
-  } catch (e) {
-    Logger.debug('syncLocalFiles error: $e');
-    rethrow;
-  }
-}
-
 /// v2 async sync: POST files → 202 with job_id, then poll until terminal.
 /// Returns the same SyncLocalFilesResponse as v1 once processing is confirmed complete.
 typedef SyncJobPollCallback = void Function(SyncJobStatusResponse status);

--- a/app/lib/services/wals/storage_sync.dart
+++ b/app/lib/services/wals/storage_sync.dart
@@ -604,7 +604,7 @@ class StorageSyncImpl implements StorageSync {
   }
 
   /// Write opus frames to disk in WAL format: [frame_length_u32_le][frame_data]...
-  /// This format is compatible with /v1/sync-local-files backend endpoint.
+  /// This format is compatible with /v2/sync-local-files backend endpoint.
   /// Uses same ByteData conversion as SDCardWalSync._flushToDisk for consistency.
   Future<File> _flushToDisk(Wal wal, List<List<int>> frames, int timerStart) async {
     final directory = await getApplicationDocumentsDirectory();

--- a/app/lib/services/wals/wal_interfaces.dart
+++ b/app/lib/services/wals/wal_interfaces.dart
@@ -5,7 +5,7 @@ import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/wals/wal.dart';
 
 // Re-export for convenience
-export 'package:omi/backend/http/api/conversations.dart' show syncLocalFiles, syncLocalFilesV2, SyncJobPollCallback;
+export 'package:omi/backend/http/api/conversations.dart' show syncLocalFilesV2, SyncJobPollCallback;
 
 abstract class IWalSyncProgressListener {
   void onWalSyncedProgress(

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -38,6 +38,7 @@ from models.conversation_enums import ConversationSource
 from utils.conversations.factory import deserialize_conversation
 from models.transcript_segment import TranscriptSegment
 from utils.conversations.process_conversation import process_conversation
+from utils.analytics import record_usage
 from utils.other import endpoints as auth
 from utils.other.storage import (
     get_syncing_file_temporal_signed_url,
@@ -1085,14 +1086,23 @@ def _cleanup_files(file_paths):
             logger.error(f"Failed to cleanup file {path}: {e}")
 
 
-@router.post("/v1/sync-local-files")
+@router.post("/v1/sync-local-files", deprecated=True)
 async def sync_local_files(
+    request: Request,
+    response: Response,
     files: List[UploadFile] = File(...),
     uid: str = Depends(auth.get_current_user_uid),
     conversation_id: str = Query(
         None, description="Target conversation ID to attach audio to (auto-sync from live capture)"
     ),
 ):
+    logger.warning(
+        f'sync: deprecated v1 sync-local-files called uid={uid} files={len(files)} '
+        f'user_agent={request.headers.get("user-agent", "")}'
+    )
+    response.headers['Deprecation'] = 'true'
+    response.headers['Link'] = '</v2/sync-local-files>; rel="successor-version"'
+
     # Pre-check gates (#5854)
     if is_hard_restricted(uid):
         raise HTTPException(status_code=429, detail="Account temporarily restricted due to fair-use policy")
@@ -1175,6 +1185,7 @@ async def sync_local_files(
             _cleanup_files(list(segmented_paths))
             return JSONResponse(
                 status_code=429,
+                headers={'Deprecation': 'true', 'Link': '</v2/sync-local-files>; rel="successor-version"'},
                 content={
                     'new_memories': [],
                     'updated_memories': [],
@@ -1225,6 +1236,14 @@ async def sync_local_files(
             except Exception as e:
                 logger.error(f'sync: DG usage record error for {uid}: {e}')
 
+        # Record subscription usage (transcription credits)
+        try:
+            usage_seconds = int(total_speech_seconds)
+            if usage_seconds > 0:
+                record_usage(uid, transcription_seconds=usage_seconds, speech_seconds=usage_seconds)
+        except Exception as e:
+            logger.error(f'sync: usage record error for {uid}: {e}')
+
         # Build JSON-serializable response
         result = {
             'new_memories': sorted(response['new_memories']),
@@ -1252,7 +1271,11 @@ async def sync_local_files(
 
         if failed_segments > 0:
             # Partial failure — return 207 Multi-Status so old clients retry the batch
-            return JSONResponse(status_code=207, content=result)
+            return JSONResponse(
+                status_code=207,
+                headers={'Deprecation': 'true', 'Link': '</v2/sync-local-files>; rel="successor-version"'},
+                content=result,
+            )
 
         return result
     finally:
@@ -1365,6 +1388,14 @@ def _process_segments_background(
                     record_dg_usage_ms(uid, dg_ms)
             except Exception as e:
                 logger.error(f'sync_v2: DG usage record error for {uid}: {e}')
+
+        # Record subscription usage (transcription credits)
+        try:
+            usage_seconds = int(total_speech_seconds)
+            if usage_seconds > 0:
+                record_usage(uid, transcription_seconds=usage_seconds, speech_seconds=usage_seconds)
+        except Exception as e:
+            logger.error(f'sync_v2: usage record error for {uid}: {e}')
 
         # Build result matching v1 response shape
         failed_segments = len(segment_errors)

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1127,8 +1127,11 @@ async def sync_local_files(
     segmented_paths = set()
 
     try:
-        paths = retrieve_file_paths(files, uid)
-        wav_paths = decode_files_to_wav(paths)
+        try:
+            paths = retrieve_file_paths(files, uid)
+            wav_paths = decode_files_to_wav(paths)
+        except HTTPException as e:
+            raise HTTPException(status_code=e.status_code, detail=e.detail, headers=_V1_DEPRECATION_HEADERS)
 
         vad_errors = []
 
@@ -1241,14 +1244,6 @@ async def sync_local_files(
             except Exception as e:
                 logger.error(f'sync: DG usage record error for {uid}: {e}')
 
-        # Record subscription usage (transcription credits)
-        try:
-            usage_seconds = int(total_speech_seconds)
-            if usage_seconds > 0:
-                record_usage(uid, transcription_seconds=usage_seconds, speech_seconds=usage_seconds)
-        except Exception as e:
-            logger.error(f'sync: usage record error for {uid}: {e}')
-
         # Build JSON-serializable response
         result = {
             'new_memories': sorted(response['new_memories']),
@@ -1274,6 +1269,14 @@ async def sync_local_files(
                 detail=f"All {total_segments} segment(s) failed processing: {'; '.join(segment_errors[:3])}",
                 headers=_V1_DEPRECATION_HEADERS,
             )
+
+        # Record subscription usage only when at least one segment succeeded
+        try:
+            usage_seconds = int(total_speech_seconds)
+            if usage_seconds > 0:
+                record_usage(uid, transcription_seconds=usage_seconds, speech_seconds=usage_seconds)
+        except Exception as e:
+            logger.error(f'sync: usage record error for {uid}: {e}')
 
         if failed_segments > 0:
             # Partial failure — return 207 Multi-Status so old clients retry the batch
@@ -1395,16 +1398,9 @@ def _process_segments_background(
             except Exception as e:
                 logger.error(f'sync_v2: DG usage record error for {uid}: {e}')
 
-        # Record subscription usage (transcription credits)
-        try:
-            usage_seconds = int(total_speech_seconds)
-            if usage_seconds > 0:
-                record_usage(uid, transcription_seconds=usage_seconds, speech_seconds=usage_seconds)
-        except Exception as e:
-            logger.error(f'sync_v2: usage record error for {uid}: {e}')
-
         # Build result matching v1 response shape
         failed_segments = len(segment_errors)
+        successful_segments = total_segments - failed_segments
         result = {
             'new_memories': sorted(response['new_memories']),
             'updated_memories': sorted(response['updated_memories']),
@@ -1413,6 +1409,15 @@ def _process_segments_background(
             result['failed_segments'] = failed_segments
             result['total_segments'] = total_segments
             result['errors'] = segment_errors[:10]
+
+        # Record subscription usage only when at least one segment succeeded
+        if successful_segments > 0:
+            try:
+                usage_seconds = int(total_speech_seconds)
+                if usage_seconds > 0:
+                    record_usage(uid, transcription_seconds=usage_seconds, speech_seconds=usage_seconds)
+            except Exception as e:
+                logger.error(f'sync_v2: usage record error for {uid}: {e}')
 
         mark_job_completed(
             job_id,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -78,6 +78,8 @@ logger = logging.getLogger(__name__)
 # Audio constants
 AUDIO_SAMPLE_RATE = 16000
 
+_V1_DEPRECATION_HEADERS = {'Deprecation': 'true', 'Link': '</v2/sync-local-files>; rel="successor-version"'}
+
 router = APIRouter()
 
 
@@ -1100,12 +1102,15 @@ async def sync_local_files(
         f'sync: deprecated v1 sync-local-files called uid={uid} files={len(files)} '
         f'user_agent={request.headers.get("user-agent", "")}'
     )
-    response.headers['Deprecation'] = 'true'
-    response.headers['Link'] = '</v2/sync-local-files>; rel="successor-version"'
+    response.headers.update(_V1_DEPRECATION_HEADERS)
 
     # Pre-check gates (#5854)
     if is_hard_restricted(uid):
-        raise HTTPException(status_code=429, detail="Account temporarily restricted due to fair-use policy")
+        raise HTTPException(
+            status_code=429,
+            detail="Account temporarily restricted due to fair-use policy",
+            headers=_V1_DEPRECATION_HEADERS,
+        )
 
     # Check credits: if exhausted, still process but lock the conversation so user can pay to unlock
     should_lock = not has_transcription_credits(uid)
@@ -1142,7 +1147,7 @@ async def sync_local_files(
             error_detail = f"VAD processing failed for {len(vad_errors)} file(s): {'; '.join(vad_errors[:3])}"
             if len(vad_errors) > 3:
                 error_detail += f" (and {len(vad_errors) - 3} more)"
-            raise HTTPException(status_code=500, detail=error_detail)
+            raise HTTPException(status_code=500, detail=error_detail, headers=_V1_DEPRECATION_HEADERS)
 
         # Fair-use speech tracking from raw VAD segments (#5854)
         # Compute duration from raw segments BEFORE merging (silence gaps not counted)
@@ -1185,7 +1190,7 @@ async def sync_local_files(
             _cleanup_files(list(segmented_paths))
             return JSONResponse(
                 status_code=429,
-                headers={'Deprecation': 'true', 'Link': '</v2/sync-local-files>; rel="successor-version"'},
+                headers=_V1_DEPRECATION_HEADERS,
                 content={
                     'new_memories': [],
                     'updated_memories': [],
@@ -1267,13 +1272,14 @@ async def sync_local_files(
             raise HTTPException(
                 status_code=500,
                 detail=f"All {total_segments} segment(s) failed processing: {'; '.join(segment_errors[:3])}",
+                headers=_V1_DEPRECATION_HEADERS,
             )
 
         if failed_segments > 0:
             # Partial failure — return 207 Multi-Status so old clients retry the batch
             return JSONResponse(
                 status_code=207,
-                headers={'Deprecation': 'true', 'Link': '</v2/sync-local-files>; rel="successor-version"'},
+                headers=_V1_DEPRECATION_HEADERS,
                 content=result,
             )
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -86,6 +86,7 @@ pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_memories_create.py -v
 pytest tests/unit/test_sync_v2.py -v
 pytest tests/unit/test_sync_transcription_prefs.py -v
+pytest tests/unit/test_sync_record_usage.py -v
 pytest tests/unit/test_vision_stream_async.py -v
 pytest tests/unit/test_desktop_transcribe.py -v
 pytest tests/unit/test_desktop_migration.py -v

--- a/backend/tests/unit/test_sync_record_usage.py
+++ b/backend/tests/unit/test_sync_record_usage.py
@@ -1,0 +1,231 @@
+"""
+Tests for record_usage placement and v1 deprecation in sync endpoints (#7123).
+
+Verifies:
+- record_usage is called after successful segment processing (v1 + v2)
+- record_usage is NOT called when all segments fail
+- record_usage failure does not break the sync response
+- v1 deprecation headers appear on all response paths
+"""
+
+import os
+import re
+
+import pytest
+
+
+def _read_sync_source():
+    sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
+    with open(sync_path) as f:
+        return f.read()
+
+
+def _extract_function_body(source, func_name):
+    """Extract the body of a function from source code."""
+    pattern = rf'(async\s+)?def {re.escape(func_name)}\('
+    match = re.search(pattern, source)
+    if not match:
+        return None
+    start = match.start()
+    # Find the next top-level def or class or decorator at the same indent
+    next_def = re.search(r'\n(?:@router\.|def |async def |class )', source[start + 1 :])
+    end = start + 1 + next_def.start() if next_def else len(source)
+    return source[start:end]
+
+
+# ---------------------------------------------------------------------------
+# record_usage import
+# ---------------------------------------------------------------------------
+
+
+class TestRecordUsageImport:
+    def test_record_usage_imported(self):
+        source = _read_sync_source()
+        assert 'from utils.analytics import record_usage' in source
+
+    def test_import_at_module_level(self):
+        source = _read_sync_source()
+        lines = source.split('\n')
+        for line in lines:
+            if 'from utils.analytics import record_usage' in line:
+                assert not line.startswith(' '), "import must be at module top level"
+                break
+
+
+# ---------------------------------------------------------------------------
+# v1 record_usage placement
+# ---------------------------------------------------------------------------
+
+
+class TestV1RecordUsage:
+    @staticmethod
+    def _get_v1_body():
+        return _extract_function_body(_read_sync_source(), 'sync_local_files')
+
+    def test_record_usage_called_in_v1(self):
+        body = self._get_v1_body()
+        assert 'record_usage(' in body, "v1 must call record_usage"
+
+    def test_record_usage_after_failed_segments_check(self):
+        """record_usage must come after the all-segments-failed guard."""
+        body = self._get_v1_body()
+        all_failed_pos = body.find('successful_segments == 0')
+        record_pos = body.find('record_usage(')
+        assert all_failed_pos > 0, "all-segments-failed guard must exist"
+        assert record_pos > 0, "record_usage must exist"
+        assert record_pos > all_failed_pos, "record_usage must come after all-segments-failed check"
+
+    def test_record_usage_not_under_fair_use_guard(self):
+        """record_usage must NOT be nested inside fair_use_restrict_dg block."""
+        body = self._get_v1_body()
+        # Find the record_usage call
+        record_idx = body.find('record_usage(')
+        # Walk backwards to find the enclosing if-block
+        preceding = body[:record_idx]
+        lines = preceding.split('\n')
+        # The record_usage call should be at try/except level, not under if fair_use_restrict_dg
+        for line in reversed(lines):
+            stripped = line.strip()
+            if stripped.startswith('if fair_use_restrict_dg'):
+                # Check if we've left that block's scope
+                record_line = body[record_idx:].split('\n')[0]
+                record_indent = len(record_line) - len(record_line.lstrip())
+                if_indent = len(line) - len(line.lstrip())
+                assert record_indent <= if_indent, "record_usage must not be inside fair_use_restrict_dg block"
+                break
+
+    def test_record_usage_wrapped_in_try_except(self):
+        """record_usage must be protected by try/except."""
+        body = self._get_v1_body()
+        record_idx = body.find('record_usage(')
+        # Check there's a try: before it (within ~5 lines)
+        preceding_chunk = body[max(0, record_idx - 200) : record_idx]
+        assert 'try:' in preceding_chunk, "record_usage must be inside a try block"
+        # Check there's an except after it
+        following_chunk = body[record_idx : record_idx + 200]
+        assert 'except Exception' in following_chunk, "record_usage must have an except handler"
+
+    def test_record_usage_logs_error_on_failure(self):
+        """Error from record_usage must be logged, not silenced."""
+        body = self._get_v1_body()
+        record_idx = body.find('record_usage(')
+        following = body[record_idx : record_idx + 300]
+        assert 'logger.error' in following, "record_usage failure must be logged"
+
+
+# ---------------------------------------------------------------------------
+# v2 record_usage placement
+# ---------------------------------------------------------------------------
+
+
+class TestV2RecordUsage:
+    @staticmethod
+    def _get_v2_body():
+        return _extract_function_body(_read_sync_source(), '_process_segments_background')
+
+    def test_record_usage_called_in_v2(self):
+        body = self._get_v2_body()
+        assert 'record_usage(' in body, "v2 background worker must call record_usage"
+
+    def test_record_usage_after_failed_segments_check(self):
+        """record_usage must come after failed_segments is computed."""
+        body = self._get_v2_body()
+        failed_pos = body.find('failed_segments = len(segment_errors)')
+        record_pos = body.find('record_usage(')
+        assert failed_pos > 0
+        assert record_pos > 0
+        assert record_pos > failed_pos, "record_usage must come after failed_segments computation"
+
+    def test_record_usage_guarded_by_successful_segments(self):
+        """record_usage should only run when successful_segments > 0."""
+        body = self._get_v2_body()
+        record_idx = body.find('record_usage(')
+        preceding = body[max(0, record_idx - 300) : record_idx]
+        assert 'successful_segments > 0' in preceding, "record_usage must be guarded by successful_segments > 0"
+
+    def test_record_usage_before_mark_job_completed(self):
+        """record_usage must run before mark_job_completed."""
+        body = self._get_v2_body()
+        record_pos = body.find('record_usage(')
+        complete_pos = body.find('mark_job_completed(')
+        assert record_pos > 0
+        assert complete_pos > 0
+        assert record_pos < complete_pos, "record_usage must run before mark_job_completed"
+
+    def test_record_usage_wrapped_in_try_except(self):
+        body = self._get_v2_body()
+        record_idx = body.find('record_usage(')
+        preceding = body[max(0, record_idx - 200) : record_idx]
+        assert 'try:' in preceding, "record_usage must be inside a try block"
+        following = body[record_idx : record_idx + 200]
+        assert 'except Exception' in following, "record_usage must have an except handler"
+
+
+# ---------------------------------------------------------------------------
+# v1 deprecation
+# ---------------------------------------------------------------------------
+
+
+class TestV1Deprecation:
+    @staticmethod
+    def _get_v1_body():
+        return _extract_function_body(_read_sync_source(), 'sync_local_files')
+
+    def test_v1_endpoint_marked_deprecated(self):
+        source = _read_sync_source()
+        v1_idx = source.find('"/v1/sync-local-files"')
+        decorator_region = source[max(0, v1_idx - 200) : v1_idx + 50]
+        assert 'deprecated=True' in decorator_region, "v1 endpoint must have deprecated=True"
+
+    def test_v1_logs_deprecation_warning(self):
+        body = self._get_v1_body()
+        assert 'logger.warning' in body, "v1 must log a deprecation warning"
+        assert 'deprecated' in body.lower(), "warning must mention deprecation"
+
+    def test_v1_sets_deprecation_header(self):
+        body = self._get_v1_body()
+        assert '_V1_DEPRECATION_HEADERS' in body, "v1 must use deprecation headers constant"
+
+    def test_v1_deprecation_headers_constant_exists(self):
+        source = _read_sync_source()
+        assert '_V1_DEPRECATION_HEADERS' in source
+        assert "'Deprecation'" in source
+        assert "'true'" in source
+        assert 'successor-version' in source
+
+    def test_v1_httpexceptions_have_deprecation_headers(self):
+        """All HTTPException raises in v1 must include deprecation headers."""
+        body = self._get_v1_body()
+        exceptions = [m.start() for m in re.finditer(r'raise HTTPException\(', body)]
+        assert len(exceptions) > 0, "v1 must have HTTPException raises"
+        for exc_start in exceptions:
+            # Find the matching closing paren (handle nested parens)
+            depth = 0
+            end = exc_start
+            for i, ch in enumerate(body[exc_start:], start=exc_start):
+                if ch == '(':
+                    depth += 1
+                elif ch == ')':
+                    depth -= 1
+                    if depth == 0:
+                        end = i + 1
+                        break
+            exc_args = body[exc_start:end]
+            assert (
+                '_V1_DEPRECATION_HEADERS' in exc_args
+            ), f"HTTPException at offset {exc_start} missing deprecation headers: {exc_args[:100]}"
+
+    def test_v1_helper_exceptions_re_raised_with_headers(self):
+        """Shared helpers (retrieve_file_paths, decode_files_to_wav) must be wrapped."""
+        body = self._get_v1_body()
+        assert 'except HTTPException' in body, "v1 must catch helper HTTPExceptions to re-raise with headers"
+
+    def test_v1_jsonresponses_have_deprecation_headers(self):
+        """All JSONResponse returns in v1 must include deprecation headers."""
+        body = self._get_v1_body()
+        json_responses = [m.start() for m in re.finditer(r'return JSONResponse\(', body)]
+        for resp_start in json_responses:
+            resp_block = body[resp_start : resp_start + 300]
+            assert (
+                '_V1_DEPRECATION_HEADERS' in resp_block
+            ), f"JSONResponse at offset {resp_start} missing deprecation headers"


### PR DESCRIPTION
## Summary

- Adds `record_usage(uid, transcription_seconds=..., speech_seconds=...)` to both v1 `sync_local_files()` and v2 `_process_segments_background()` after successful segment processing
- Marks v1 `POST /v1/sync-local-files` as deprecated with `Deprecation: true` header, successor-version link, and warning log
- **Removes v1 client code** — deleted `syncLocalFiles()` from Flutter app, removed its export from WAL interfaces

## Context

PR #5863 originally added `record_usage` to sync endpoints. PR #5875 reverted it. PR #5878 re-added fair-use gates but **did not re-add `record_usage`**, leaving sync transcription invisible to the subscription credit system. Basic-plan users could sync without usage being counted toward their monthly limit.

## Changes

| File | Change |
|------|--------|
| `backend/routers/sync.py` | Import `record_usage`, add calls in v1 and v2 paths, deprecate v1 endpoint with headers on all response paths |
| `backend/tests/unit/test_sync_record_usage.py` | 19 structural tests for record_usage placement and v1 deprecation |
| `backend/test.sh` | Add new test file to CI |
| `app/lib/backend/http/api/conversations.dart` | Remove v1 `syncLocalFiles()` function |
| `app/lib/services/wals/wal_interfaces.dart` | Remove v1 export |
| `app/lib/services/wals/storage_sync.dart` | Update comment to reference v2 |

## Live test evidence

### L1 — v1 endpoint with real audio (PCM16 3s)
```
$ curl -D- -X POST "http://localhost:8700/v1/sync-local-files" \
  -H "Authorization: Bearer ADMIN_KEY123test-uid" \
  -F "files=@audio_phonemic_pcm16_16000_1_fs160_1777697725.bin"

HTTP/1.1 200 OK
deprecation: true
link: </v2/sync-local-files>; rel="successor-version"
{"new_memories":[],"updated_memories":[]}
```

Backend log:
```
WARNING:routers.sync:sync: deprecated v1 sync-local-files called uid=123 files=1 user_agent=curl/8.5.0
INFO:routers.sync:sync_local_files len(segmented_paths) 0 speech_seconds=0
```

### L1 — v2 endpoint with same audio (no deprecation headers)
```
$ curl -D- -X POST "http://localhost:8700/v2/sync-local-files" \
  -H "Authorization: Bearer ADMIN_KEY123test-uid" \
  -F "files=@audio_phonemic_pcm16_16000_1_fs160_1777697725.bin"

HTTP/1.1 200 OK
(no deprecation headers)
{"new_memories":[],"updated_memories":[]}
```

### L2 — Client cannot use v1
- `syncLocalFiles()` function removed from `conversations.dart`
- Export removed from `wal_interfaces.dart`  
- All callers use `syncLocalFilesV2()` exclusively
- `grep -rn "syncLocalFiles\b" app/lib/ | grep -v V2` returns empty

## Review cycle changes

- **Round 1**: Added `_V1_DEPRECATION_HEADERS` constant and `headers=` param to all `HTTPException` raises in v1
- **Round 2**: Wrapped shared-helper calls in try/except to re-raise with deprecation headers. Moved `record_usage` after all-segments-failed guard.
- **Round 3**: Removed v1 client code per manager feedback.

## Test plan

- [x] Boot check passes (no import/syntax errors)
- [x] Real curl test: v1 returns `Deprecation: true` header with audio file
- [x] Real curl test: v2 works without deprecation headers
- [x] `record_usage` only runs when `successful_segments > 0`
- [x] All v1 response paths (200, 207, 429, 500, 400) carry deprecation headers
- [x] v1 client code removed — no Flutter/Desktop callers can use v1
- [x] 19 unit tests pass in `test_sync_record_usage.py`

## Risks

- `record_usage` calls Firestore — wrapped in try/except so failure is logged but doesn't break sync
- v1 backend endpoint kept for backward compatibility with old app versions still in the wild

Closes #7123

🤖 Generated with [Claude Code](https://claude.com/claude-code)