### PR TITLE
backend: bump 10 Python deps for 1 CRITICAL + 16 HIGH CVEs

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -158,7 +158,7 @@ pydantic_core==2.20.1
 pydeck==0.9.1
 pydub==0.25.1
 Pygments==2.18.0
-PyJWT==2.9.0
+PyJWT==2.12.0
 pynndescent==0.5.13
 PyOgg @ git+https://github.com/TeamPyOgg/PyOgg@6871a4f234e8a3a346c4874a12509bfa02c4c63a
 pyparsing==3.1.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -200,7 +200,7 @@ tenacity==8.2.3
 threadpoolctl==3.5.0
 tiktoken==0.7.0
 toml==0.10.2
-tornado==6.4.1
+tornado==6.5.5
 tqdm==4.66.5
 traitlets==5.14.3
 typer==0.12.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -149,7 +149,7 @@ protobuf==4.25.8
 ptyprocess==0.7.0
 pure_eval==0.2.3
 pyarrow==17.0.0
-pyasn1==0.6.0
+pyasn1==0.6.3
 pyasn1_modules==0.4.0
 pycparser==2.22
 pydantic==2.8.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -211,7 +211,7 @@ typing_extensions==4.12.2
 tzdata==2024.1
 umap-learn==0.5.6
 uritemplate==4.1.1
-urllib3==2.2.2
+urllib3==2.6.3
 uvicorn==0.30.5
 uvloop==0.20.0
 watchdog==4.0.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,8 @@
 aenum==3.1.15
 aiofiles==24.1.0
-aiohappyeyeballs==2.3.4
-aiohttp==3.9.5
-aiosignal==1.3.1
+aiohappyeyeballs==2.5.0
+aiohttp==3.13.3
+aiosignal==1.4.0
 aiostream==0.5.2
 alembic==1.13.2
 altair==5.4.0
@@ -219,7 +219,7 @@ watchfiles==0.22.0
 wcwidth==0.2.13
 webrtcvad==2.0.10
 websockets==12.0
-yarl==1.9.4
+yarl==1.17.0
 stripe==11.3.0
 typesense==0.21.0
 pycountry==24.6.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -69,10 +69,10 @@ grpcio==1.65.4
 grpcio-status==1.62.3
 grpcio-tools==1.62.3
 grpclib==0.4.7
-h11==0.14.0
+h11==0.16.0
 h2==4.1.0
 hpack==4.0.0
-httpcore==1.0.5
+httpcore==1.0.9
 httplib2==0.22.0
 httptools==0.6.1
 httpx==0.28.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -94,7 +94,7 @@ jsonschema-specifications==2023.12.1
 kiwisolver==1.4.5
 langchain==0.3.27
 langchain-community==0.3.31
-langchain-core==0.3.79
+langchain-core==0.3.81
 langchain-google-genai==2.1.12
 langchain-openai==0.3.35
 langchain-pinecone==0.2.12

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -130,7 +130,7 @@ openai==1.104.2
 scipy==1.14.0
 optuna==3.6.1
 opuslib==3.0.1
-orjson==3.10.6
+orjson==3.11.6
 prometheus-client==0.21.1
 packaging==24.2
 parso==0.8.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -51,7 +51,7 @@ fonttools==4.53.1
 frozenlist==1.4.1
 fsspec==2024.6.1
 gitdb==4.0.11
-GitPython==3.1.43
+GitPython==3.1.47
 google-ai-generativelanguage==0.11.0
 google-api-core==2.19.1
 google-api-python-client==2.139.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -164,7 +164,7 @@ PyOgg @ git+https://github.com/TeamPyOgg/PyOgg@6871a4f234e8a3a346c4874a12509bfa0
 pyparsing==3.1.2
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-python-multipart==0.0.9
+python-multipart==0.0.22
 python-slugify==8.0.4
 python-ulid==3.0.0
 pytz==2024.1


### PR DESCRIPTION
## Summary

10 atomic commits, one per package family, fixing the safer Python CVEs flagged by Artifact Registry on the deployed backend image (`gcr.io/based-hardware/backend@sha256:a0ef24d4…`, revision `backend-00979-8l8`):

| Commit | Package | Was → Now | CVEs (sev) |
|---|---|---|---|
| 1 | h11 + httpcore | 0.14.0→0.16.0 / 1.0.5→1.0.9 | CVE-2025-43859 (**CRITICAL** 9.1) |
| 2 | urllib3 | 2.2.2→2.6.3 | CVE-2025-66471, CVE-2026-21441, CVE-2025-66418 (3× HIGH) |
| 3 | tornado | 6.4.1→6.5.5 | CVE-2025-47287, CVE-2026-31958, CVE-2024-52804, CVE-2026-35536 (4× HIGH) |
| 4 | PyJWT | 2.9.0→2.12.0 | CVE-2026-32597 (HIGH) |
| 5 | pyasn1 | 0.6.0→0.6.3 | CVE-2026-30922 (HIGH) |
| 6 | orjson | 3.10.6→3.11.6 | CVE-2025-67221 (HIGH) |
| 7 | GitPython | 3.1.43→3.1.47 | GHSA-rpm5-65cw-6hj4, GHSA-x2qx-6953-8485 (2× HIGH) |
| 8 | python-multipart | 0.0.9→0.0.22 | CVE-2024-53981, CVE-2026-24486 (2× HIGH) |
| 9 | aiohttp + cascade | 3.9.5→3.13.3 (+ aiohappyeyeballs, aiosignal, yarl) | CVE-2025-69223 (HIGH) |
| 10 | langchain-core | 0.3.79→0.3.81 | CVE-2025-68664 (**CRITICAL**), CVE-2025-65106 (HIGH) |

**Net:** 1 CRITICAL + 16 HIGH closed across 10 commits, all atomic / independently revertible.

## Deferred to a follow-up PR

Risky/major bumps live in a follow-up PR rather than this one to keep the blast radius small:
- `cryptography` 43→46 (3 majors)
- `pillow` 10.4→12.2 (2 majors)
- `protobuf` 4.25→5.x (1 major, cascades grpc)
- `starlette` 0.37→0.40 (cascades fastapi)
- `langgraph-checkpoint` 2→3 + `langchain-core` 0.3.81→1.2 (langchain stack major)
- Transitives `jaraco-context` 5.3→6.1 and `wheel` 0.45→0.46

## Test plan

For each commit:
1. Update `requirements.txt`
2. Rebuild a local `Dockerfile.test` image (Python 3.11-slim, requirements.txt minus the source-built `lc3py`) — only the pip install layer rebuilds (~30-90s)
3. Run a baseline-green subset of unit tests (190 tests across 11 files: text similarity/containment, speaker_sample, async_auth, auth_redirect_uri, prompt_caching, llm_usage_db/tracker, short_audio_embedding, voice_message_language, users_add_sample_transaction)
4. Confirm bumped package version installed correctly
5. Commit only if all tests pass

All 10 commits are individually green. Two commits required cascade pins to satisfy upstream: `httpcore` was bumped alongside `h11`, and `aiohappyeyeballs`/`aiosignal`/`yarl` were bumped alongside `aiohttp`.

## Verifying after deploy

- [ ] Re-scan the rebuilt image in Artifact Registry → Vulnerabilities; expect the 17 listed CVEs to clear.
- [ ] Smoke-check `/health` and a representative auth + transcribe endpoint.