### PR TITLE
Add 14 missing l10n translations across 48 locales

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2966,5 +2966,19 @@
   "recordWithPhoneMic": "التسجيل بميكروفون الهاتف",
   "recordWithPhoneMicSubtitle": "التقط الصوت من حولك",
   "phoneCall": "مكالمة هاتفية",
-  "phoneCallSubtitle": "سجّل مكالمة مع تفريغ مباشر"
+  "phoneCallSubtitle": "سجّل مكالمة مع تفريغ مباشر",
+  "bulkExportInProgress": "جارٍ التصدير…",
+  "bulkExportPartial": "تم تصدير {success} من {total} إلى {platform}",
+  "bulkExportSuccess": "تم تصدير {count} إلى {platform}",
+  "chooseExportDestination": "تصدير {count} عنصر(عناصر) إلى…",
+  "connectAction": "اتصال",
+  "connectTaskAppToExport": "قم بربط تطبيق مهام في الإعدادات للتصدير",
+  "deselectAllTasksMenu": "إلغاء تحديد الكل",
+  "hideCompletedTasks": "إخفاء المكتملة",
+  "searchActionItems": "البحث في عناصر الإجراء",
+  "selectActionItems": "تحديد متعدد",
+  "selectAllTasksMenu": "تحديد الكل",
+  "showCompletedTasks": "إظهار المكتملة",
+  "startCallRecording": "بدء تسجيل المكالمة",
+  "startVoiceRecording": "بدء التسجيل الصوتي"
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "Запіс мікрафонам тэлефона",
   "recordWithPhoneMicSubtitle": "Запісвайце гук вакол сябе",
   "phoneCall": "Тэлефонны званок",
-  "phoneCallSubtitle": "Запіс званка з жывой транскрыпцыяй"
+  "phoneCallSubtitle": "Запіс званка з жывой транскрыпцыяй",
+  "bulkExportInProgress": "Экспарт…",
+  "bulkExportPartial": "Экспартавана {success} з {total} у {platform}",
+  "bulkExportSuccess": "Экспартавана {count} у {platform}",
+  "chooseExportDestination": "Экспартаваць {count} элемент(аў) у…",
+  "connectAction": "Злучыць",
+  "connectTaskAppToExport": "Падключыце праграму задач у Наладах для экспарту",
+  "deselectAllTasksMenu": "Зняць выбар усіх",
+  "hideCompletedTasks": "Схаваць завершаныя",
+  "searchActionItems": "Шукаць элементы дзеянняў",
+  "selectActionItems": "Выбраць некалькі",
+  "selectAllTasksMenu": "Выбраць усе",
+  "showCompletedTasks": "Паказаць завершаныя",
+  "startCallRecording": "Пачаць запіс званка",
+  "startVoiceRecording": "Пачаць галасавы запіс"
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2968,5 +2968,19 @@
   "recordWithPhoneMic": "Запис с микрофона на телефона",
   "recordWithPhoneMicSubtitle": "Заснемайте звук около вас",
   "phoneCall": "Телефонно обаждане",
-  "phoneCallSubtitle": "Записвайте обаждане с транскрипция в реално време"
+  "phoneCallSubtitle": "Записвайте обаждане с транскрипция в реално време",
+  "bulkExportInProgress": "Експортиране…",
+  "bulkExportPartial": "Експортирани {success} от {total} в {platform}",
+  "bulkExportSuccess": "Експортирани {count} в {platform}",
+  "chooseExportDestination": "Експортиране на {count} елемент(а) в…",
+  "connectAction": "Свързване",
+  "connectTaskAppToExport": "Свържете приложение за задачи в Настройки, за да експортирате",
+  "deselectAllTasksMenu": "Премахване на избора",
+  "hideCompletedTasks": "Скриване на завършените",
+  "searchActionItems": "Търсене на действия",
+  "selectActionItems": "Избиране на няколко",
+  "selectAllTasksMenu": "Избиране на всички",
+  "showCompletedTasks": "Показване на завършените",
+  "startCallRecording": "Стартиране на запис на разговор",
+  "startVoiceRecording": "Стартиране на гласов запис"
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "ফোনের মাইক্রোফোন দিয়ে রেকর্ড করুন",
   "recordWithPhoneMicSubtitle": "আপনার চারপাশের অডিও ক্যাপচার করুন",
   "phoneCall": "ফোন কল",
-  "phoneCallSubtitle": "লাইভ ট্রান্সক্রিপশন সহ কল রেকর্ড করুন"
+  "phoneCallSubtitle": "লাইভ ট্রান্সক্রিপশন সহ কল রেকর্ড করুন",
+  "bulkExportInProgress": "রপ্তানি হচ্ছে…",
+  "bulkExportPartial": "{total}-এর মধ্যে {success}টি {platform}-এ রপ্তানি হয়েছে",
+  "bulkExportSuccess": "{count}টি {platform}-এ রপ্তানি হয়েছে",
+  "chooseExportDestination": "{count}টি আইটেম রপ্তানি করুন…",
+  "connectAction": "সংযুক্ত করুন",
+  "connectTaskAppToExport": "রপ্তানি করতে সেটিংসে একটি টাস্ক অ্যাপ সংযুক্ত করুন",
+  "deselectAllTasksMenu": "সমস্ত নির্বাচন বাতিল",
+  "hideCompletedTasks": "সম্পন্ন লুকান",
+  "searchActionItems": "অ্যাকশন আইটেম অনুসন্ধান",
+  "selectActionItems": "একাধিক নির্বাচন",
+  "selectAllTasksMenu": "সমস্ত নির্বাচন",
+  "showCompletedTasks": "সম্পন্ন দেখান",
+  "startCallRecording": "কল রেকর্ডিং শুরু করুন",
+  "startVoiceRecording": "ভয়েস রেকর্ডিং শুরু করুন"
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "Snimaj mikrofonom telefona",
   "recordWithPhoneMicSubtitle": "Snimite zvuk oko vas",
   "phoneCall": "Telefonski poziv",
-  "phoneCallSubtitle": "Snimajte poziv s transkripcijom uživo"
+  "phoneCallSubtitle": "Snimajte poziv s transkripcijom uživo",
+  "bulkExportInProgress": "Izvoz u toku…",
+  "bulkExportPartial": "Izvezeno {success} od {total} u {platform}",
+  "bulkExportSuccess": "Izvezeno {count} u {platform}",
+  "chooseExportDestination": "Izvezi {count} stavku/i u…",
+  "connectAction": "Poveži",
+  "connectTaskAppToExport": "Povežite aplikaciju za zadatke u Postavkama za izvoz",
+  "deselectAllTasksMenu": "Poništi odabir svih",
+  "hideCompletedTasks": "Sakrij završene",
+  "searchActionItems": "Pretraži akcione stavke",
+  "selectActionItems": "Odaberi više",
+  "selectAllTasksMenu": "Odaberi sve",
+  "showCompletedTasks": "Prikaži završene",
+  "startCallRecording": "Pokreni snimanje poziva",
+  "startVoiceRecording": "Pokreni glasovno snimanje"
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2968,5 +2968,19 @@
   "recordWithPhoneMic": "Grava amb el micròfon del telèfon",
   "recordWithPhoneMicSubtitle": "Captura l'àudio que t'envolta",
   "phoneCall": "Trucada",
-  "phoneCallSubtitle": "Enregistra una trucada amb transcripció en directe"
+  "phoneCallSubtitle": "Enregistra una trucada amb transcripció en directe",
+  "bulkExportInProgress": "S'està exportant…",
+  "bulkExportPartial": "S'han exportat {success} de {total} a {platform}",
+  "bulkExportSuccess": "S'han exportat {count} a {platform}",
+  "chooseExportDestination": "Exporta {count} element(s) a…",
+  "connectAction": "Connecta",
+  "connectTaskAppToExport": "Connecta una aplicació de tasques a Configuració per exportar",
+  "deselectAllTasksMenu": "Desselecciona tot",
+  "hideCompletedTasks": "Amaga les completades",
+  "searchActionItems": "Cerca elements d'acció",
+  "selectActionItems": "Selecció múltiple",
+  "selectAllTasksMenu": "Selecciona tot",
+  "showCompletedTasks": "Mostra les completades",
+  "startCallRecording": "Inicia l'enregistrament de trucada",
+  "startVoiceRecording": "Inicia l'enregistrament de veu"
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2968,5 +2968,19 @@
   "recordWithPhoneMic": "Nahrát mikrofonem telefonu",
   "recordWithPhoneMicSubtitle": "Zaznamenávejte zvuk kolem vás",
   "phoneCall": "Telefonní hovor",
-  "phoneCallSubtitle": "Nahrávejte hovor s živým přepisem"
+  "phoneCallSubtitle": "Nahrávejte hovor s živým přepisem",
+  "bulkExportInProgress": "Exportování…",
+  "bulkExportPartial": "Exportováno {success} z {total} do {platform}",
+  "bulkExportSuccess": "Exportováno {count} do {platform}",
+  "chooseExportDestination": "Exportovat {count} položek do…",
+  "connectAction": "Připojit",
+  "connectTaskAppToExport": "Pro export připojte aplikaci úkolů v Nastavení",
+  "deselectAllTasksMenu": "Zrušit výběr všech",
+  "hideCompletedTasks": "Skrýt dokončené",
+  "searchActionItems": "Hledat akční položky",
+  "selectActionItems": "Vybrat více",
+  "selectAllTasksMenu": "Vybrat vše",
+  "showCompletedTasks": "Zobrazit dokončené",
+  "startCallRecording": "Zahájit nahrávání hovoru",
+  "startVoiceRecording": "Zahájit hlasový záznam"
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3008,5 +3008,19 @@
   "recordWithPhoneMic": "Optag med telefonens mikrofon",
   "recordWithPhoneMicSubtitle": "Optag lyden omkring dig",
   "phoneCall": "Telefonopkald",
-  "phoneCallSubtitle": "Optag et opkald med live-transskription"
+  "phoneCallSubtitle": "Optag et opkald med live-transskription",
+  "bulkExportInProgress": "Eksporterer…",
+  "bulkExportPartial": "Eksporterede {success} af {total} til {platform}",
+  "bulkExportSuccess": "Eksporterede {count} til {platform}",
+  "chooseExportDestination": "Eksportér {count} element(er) til…",
+  "connectAction": "Forbind",
+  "connectTaskAppToExport": "Forbind en opgaveapp i Indstillinger for at eksportere",
+  "deselectAllTasksMenu": "Fravælg alle",
+  "hideCompletedTasks": "Skjul fuldførte",
+  "searchActionItems": "Søg i handlingspunkter",
+  "selectActionItems": "Vælg flere",
+  "selectAllTasksMenu": "Vælg alle",
+  "showCompletedTasks": "Vis fuldførte",
+  "startCallRecording": "Start opkaldsoptagelse",
+  "startVoiceRecording": "Start stemmeoptagelse"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2967,5 +2967,19 @@
   "recordWithPhoneMic": "Mit Telefonmikrofon aufnehmen",
   "recordWithPhoneMicSubtitle": "Erfasse Audio in deiner Umgebung",
   "phoneCall": "Anruf",
-  "phoneCallSubtitle": "Anruf mit Live-Transkription aufnehmen"
+  "phoneCallSubtitle": "Anruf mit Live-Transkription aufnehmen",
+  "bulkExportInProgress": "Exportieren…",
+  "bulkExportPartial": "{success} von {total} nach {platform} exportiert",
+  "bulkExportSuccess": "{count} nach {platform} exportiert",
+  "chooseExportDestination": "{count} Element(e) exportieren nach…",
+  "connectAction": "Verbinden",
+  "connectTaskAppToExport": "Verbinde eine Aufgaben-App in den Einstellungen zum Exportieren",
+  "deselectAllTasksMenu": "Alle abwählen",
+  "hideCompletedTasks": "Erledigte ausblenden",
+  "searchActionItems": "Aktionspunkte durchsuchen",
+  "selectActionItems": "Mehrere auswählen",
+  "selectAllTasksMenu": "Alle auswählen",
+  "showCompletedTasks": "Erledigte anzeigen",
+  "startCallRecording": "Anrufaufnahme starten",
+  "startVoiceRecording": "Sprachaufnahme starten"
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Εγγραφή με μικρόφωνο τηλεφώνου",
   "recordWithPhoneMicSubtitle": "Καταγράψτε ήχο γύρω σας",
   "phoneCall": "Τηλεφωνική κλήση",
-  "phoneCallSubtitle": "Καταγράψτε κλήση με ζωντανή μεταγραφή"
+  "phoneCallSubtitle": "Καταγράψτε κλήση με ζωντανή μεταγραφή",
+  "bulkExportInProgress": "Εξαγωγή…",
+  "bulkExportPartial": "Εξήχθησαν {success} από {total} στο {platform}",
+  "bulkExportSuccess": "Εξήχθησαν {count} στο {platform}",
+  "chooseExportDestination": "Εξαγωγή {count} στοιχείου/ων σε…",
+  "connectAction": "Σύνδεση",
+  "connectTaskAppToExport": "Συνδέστε μια εφαρμογή εργασιών στις Ρυθμίσεις για εξαγωγή",
+  "deselectAllTasksMenu": "Αποεπιλογή όλων",
+  "hideCompletedTasks": "Απόκρυψη ολοκληρωμένων",
+  "searchActionItems": "Αναζήτηση ενεργειών",
+  "selectActionItems": "Πολλαπλή επιλογή",
+  "selectAllTasksMenu": "Επιλογή όλων",
+  "showCompletedTasks": "Εμφάνιση ολοκληρωμένων",
+  "startCallRecording": "Έναρξη εγγραφής κλήσης",
+  "startVoiceRecording": "Έναρξη ηχογράφησης"
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3000,5 +3000,19 @@
   "recordWithPhoneMic": "Grabar con el micrófono del teléfono",
   "recordWithPhoneMicSubtitle": "Captura el audio a tu alrededor",
   "phoneCall": "Llamada telefónica",
-  "phoneCallSubtitle": "Graba una llamada con transcripción en vivo"
+  "phoneCallSubtitle": "Graba una llamada con transcripción en vivo",
+  "bulkExportInProgress": "Exportando…",
+  "bulkExportPartial": "Se exportaron {success} de {total} a {platform}",
+  "bulkExportSuccess": "Se exportaron {count} a {platform}",
+  "chooseExportDestination": "Exportar {count} elemento(s) a…",
+  "connectAction": "Conectar",
+  "connectTaskAppToExport": "Conecta una app de tareas en Ajustes para exportar",
+  "deselectAllTasksMenu": "Deseleccionar todo",
+  "hideCompletedTasks": "Ocultar completadas",
+  "searchActionItems": "Buscar elementos de acción",
+  "selectActionItems": "Seleccionar varios",
+  "selectAllTasksMenu": "Seleccionar todo",
+  "showCompletedTasks": "Mostrar completadas",
+  "startCallRecording": "Iniciar grabación de llamada",
+  "startVoiceRecording": "Iniciar grabación de voz"
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Salvesta telefoni mikrofoniga",
   "recordWithPhoneMicSubtitle": "Salvesta enda ümbruse heli",
   "phoneCall": "Telefonikõne",
-  "phoneCallSubtitle": "Salvesta kõne reaalajas transkriptsiooniga"
+  "phoneCallSubtitle": "Salvesta kõne reaalajas transkriptsiooniga",
+  "bulkExportInProgress": "Eksportimine…",
+  "bulkExportPartial": "Eksporditi {success}/{total} asukohta {platform}",
+  "bulkExportSuccess": "Eksporditi {count} asukohta {platform}",
+  "chooseExportDestination": "Ekspordi {count} üksus(t) asukohta…",
+  "connectAction": "Ühenda",
+  "connectTaskAppToExport": "Eksportimiseks ühendage Seadetes ülesannete rakendus",
+  "deselectAllTasksMenu": "Tühista kõigi valik",
+  "hideCompletedTasks": "Peida lõpetatud",
+  "searchActionItems": "Otsi tegevusüksusi",
+  "selectActionItems": "Vali mitu",
+  "selectAllTasksMenu": "Vali kõik",
+  "showCompletedTasks": "Kuva lõpetatud",
+  "startCallRecording": "Alusta kõne salvestamist",
+  "startVoiceRecording": "Alusta häälsalvestust"
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "ضبط با میکروفون تلفن",
   "recordWithPhoneMicSubtitle": "صدای اطراف خود را ضبط کنید",
   "phoneCall": "تماس تلفنی",
-  "phoneCallSubtitle": "یک تماس را با رونویسی زنده ضبط کنید"
+  "phoneCallSubtitle": "یک تماس را با رونویسی زنده ضبط کنید",
+  "bulkExportInProgress": "در حال صادرات…",
+  "bulkExportPartial": "{success} از {total} به {platform} صادر شد",
+  "bulkExportSuccess": "{count} به {platform} صادر شد",
+  "chooseExportDestination": "صادرات {count} مورد به…",
+  "connectAction": "اتصال",
+  "connectTaskAppToExport": "برای صادرات، یک برنامه وظایف را در تنظیمات متصل کنید",
+  "deselectAllTasksMenu": "لغو انتخاب همه",
+  "hideCompletedTasks": "پنهان کردن انجام‌شده‌ها",
+  "searchActionItems": "جستجوی موارد اقدام",
+  "selectActionItems": "انتخاب چندگانه",
+  "selectAllTasksMenu": "انتخاب همه",
+  "showCompletedTasks": "نمایش انجام‌شده‌ها",
+  "startCallRecording": "شروع ضبط تماس",
+  "startVoiceRecording": "شروع ضبط صدا"
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Tallenna puhelimen mikrofonilla",
   "recordWithPhoneMicSubtitle": "Tallenna ympärilläsi olevaa ääntä",
   "phoneCall": "Puhelu",
-  "phoneCallSubtitle": "Tallenna puhelu reaaliaikaisella tekstityksellä"
+  "phoneCallSubtitle": "Tallenna puhelu reaaliaikaisella tekstityksellä",
+  "bulkExportInProgress": "Viedään…",
+  "bulkExportPartial": "Viety {success}/{total} kohteeseen {platform}",
+  "bulkExportSuccess": "Viety {count} kohteeseen {platform}",
+  "chooseExportDestination": "Vie {count} kohde(tta) kohteeseen…",
+  "connectAction": "Yhdistä",
+  "connectTaskAppToExport": "Yhdistä tehtäväsovellus Asetuksissa vientiä varten",
+  "deselectAllTasksMenu": "Poista kaikkien valinta",
+  "hideCompletedTasks": "Piilota valmiit",
+  "searchActionItems": "Hae toimintakohteita",
+  "selectActionItems": "Valitse useita",
+  "selectAllTasksMenu": "Valitse kaikki",
+  "showCompletedTasks": "Näytä valmiit",
+  "startCallRecording": "Aloita puhelun nauhoitus",
+  "startVoiceRecording": "Aloita ääninauhoitus"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3034,5 +3034,19 @@
   "recordWithPhoneMic": "Enregistrer avec le micro du téléphone",
   "recordWithPhoneMicSubtitle": "Capturez l'audio autour de vous",
   "phoneCall": "Appel téléphonique",
-  "phoneCallSubtitle": "Enregistrez un appel avec transcription en direct"
+  "phoneCallSubtitle": "Enregistrez un appel avec transcription en direct",
+  "bulkExportInProgress": "Exportation…",
+  "bulkExportPartial": "{success} sur {total} exportés vers {platform}",
+  "bulkExportSuccess": "{count} exportés vers {platform}",
+  "chooseExportDestination": "Exporter {count} élément(s) vers…",
+  "connectAction": "Connecter",
+  "connectTaskAppToExport": "Connectez une application de tâches dans les Paramètres pour exporter",
+  "deselectAllTasksMenu": "Tout désélectionner",
+  "hideCompletedTasks": "Masquer les terminées",
+  "searchActionItems": "Rechercher des actions",
+  "selectActionItems": "Sélection multiple",
+  "selectAllTasksMenu": "Tout sélectionner",
+  "showCompletedTasks": "Afficher les terminées",
+  "startCallRecording": "Démarrer l'enregistrement d'appel",
+  "startVoiceRecording": "Démarrer l'enregistrement vocal"
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "הקלט עם מיקרופון הטלפון",
   "recordWithPhoneMicSubtitle": "הקלט שמע סביבך",
   "phoneCall": "שיחת טלפון",
-  "phoneCallSubtitle": "הקלט שיחה עם תמלול חי"
+  "phoneCallSubtitle": "הקלט שיחה עם תמלול חי",
+  "bulkExportInProgress": "מייצא…",
+  "bulkExportPartial": "יוצאו {success} מתוך {total} אל {platform}",
+  "bulkExportSuccess": "יוצאו {count} אל {platform}",
+  "chooseExportDestination": "ייצוא {count} פריט(ים) אל…",
+  "connectAction": "חיבור",
+  "connectTaskAppToExport": "חבר אפליקציית משימות בהגדרות כדי לייצא",
+  "deselectAllTasksMenu": "בטל בחירת הכל",
+  "hideCompletedTasks": "הסתר הושלמו",
+  "searchActionItems": "חפש פריטי פעולה",
+  "selectActionItems": "בחירה מרובה",
+  "selectAllTasksMenu": "בחר הכל",
+  "showCompletedTasks": "הצג הושלמו",
+  "startCallRecording": "התחל הקלטת שיחה",
+  "startVoiceRecording": "התחל הקלטה קולית"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3000,5 +3000,19 @@
   "recordWithPhoneMic": "फ़ोन माइक से रिकॉर्ड करें",
   "recordWithPhoneMicSubtitle": "अपने आस-पास की आवाज़ रिकॉर्ड करें",
   "phoneCall": "फ़ोन कॉल",
-  "phoneCallSubtitle": "लाइव ट्रांसक्रिप्शन के साथ कॉल रिकॉर्ड करें"
+  "phoneCallSubtitle": "लाइव ट्रांसक्रिप्शन के साथ कॉल रिकॉर्ड करें",
+  "bulkExportInProgress": "निर्यात हो रहा है…",
+  "bulkExportPartial": "{total} में से {success} को {platform} में निर्यात किया गया",
+  "bulkExportSuccess": "{count} को {platform} में निर्यात किया गया",
+  "chooseExportDestination": "{count} आइटम निर्यात करें…",
+  "connectAction": "कनेक्ट करें",
+  "connectTaskAppToExport": "निर्यात करने के लिए सेटिंग्स में एक टास्क ऐप कनेक्ट करें",
+  "deselectAllTasksMenu": "सभी का चयन हटाएं",
+  "hideCompletedTasks": "पूर्ण छिपाएं",
+  "searchActionItems": "कार्य आइटम खोजें",
+  "selectActionItems": "एकाधिक चुनें",
+  "selectAllTasksMenu": "सभी चुनें",
+  "showCompletedTasks": "पूर्ण दिखाएं",
+  "startCallRecording": "कॉल रिकॉर्डिंग शुरू करें",
+  "startVoiceRecording": "वॉइस रिकॉर्डिंग शुरू करें"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "Snimaj telefonskim mikrofonom",
   "recordWithPhoneMicSubtitle": "Snimite zvuk oko vas",
   "phoneCall": "Telefonski poziv",
-  "phoneCallSubtitle": "Snimajte poziv s transkripcijom uživo"
+  "phoneCallSubtitle": "Snimajte poziv s transkripcijom uživo",
+  "bulkExportInProgress": "Izvoz u tijeku…",
+  "bulkExportPartial": "Izvezeno {success} od {total} u {platform}",
+  "bulkExportSuccess": "Izvezeno {count} u {platform}",
+  "chooseExportDestination": "Izvezi {count} stavku/i u…",
+  "connectAction": "Poveži",
+  "connectTaskAppToExport": "Povežite aplikaciju za zadatke u Postavkama za izvoz",
+  "deselectAllTasksMenu": "Poništi odabir svih",
+  "hideCompletedTasks": "Sakrij dovršene",
+  "searchActionItems": "Pretraži akcijske stavke",
+  "selectActionItems": "Odaberi više",
+  "selectAllTasksMenu": "Odaberi sve",
+  "showCompletedTasks": "Prikaži dovršene",
+  "startCallRecording": "Pokreni snimanje poziva",
+  "startVoiceRecording": "Pokreni glasovno snimanje"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3095,5 +3095,19 @@
   "recordWithPhoneMic": "Felvétel a telefon mikrofonjával",
   "recordWithPhoneMicSubtitle": "Rögzítse a környezete hangját",
   "phoneCall": "Telefonhívás",
-  "phoneCallSubtitle": "Hívás rögzítése élő átirattal"
+  "phoneCallSubtitle": "Hívás rögzítése élő átirattal",
+  "bulkExportInProgress": "Exportálás…",
+  "bulkExportPartial": "{success}/{total} exportálva ide: {platform}",
+  "bulkExportSuccess": "{count} exportálva ide: {platform}",
+  "chooseExportDestination": "{count} elem exportálása ide…",
+  "connectAction": "Csatlakoztatás",
+  "connectTaskAppToExport": "Csatlakoztasson egy feladatalkalmazást a Beállításokban az exportáláshoz",
+  "deselectAllTasksMenu": "Összes kijelölés törlése",
+  "hideCompletedTasks": "Befejezettek elrejtése",
+  "searchActionItems": "Teendők keresése",
+  "selectActionItems": "Több kijelölése",
+  "selectAllTasksMenu": "Összes kijelölése",
+  "showCompletedTasks": "Befejezettek megjelenítése",
+  "startCallRecording": "Hívásfelvétel indítása",
+  "startVoiceRecording": "Hangfelvétel indítása"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3041,5 +3041,19 @@
   "recordWithPhoneMic": "Rekam dengan mikrofon ponsel",
   "recordWithPhoneMicSubtitle": "Tangkap audio di sekitar Anda",
   "phoneCall": "Panggilan telepon",
-  "phoneCallSubtitle": "Rekam panggilan dengan transkripsi langsung"
+  "phoneCallSubtitle": "Rekam panggilan dengan transkripsi langsung",
+  "bulkExportInProgress": "Mengekspor…",
+  "bulkExportPartial": "Diekspor {success} dari {total} ke {platform}",
+  "bulkExportSuccess": "Diekspor {count} ke {platform}",
+  "chooseExportDestination": "Ekspor {count} item ke…",
+  "connectAction": "Hubungkan",
+  "connectTaskAppToExport": "Hubungkan aplikasi tugas di Pengaturan untuk mengekspor",
+  "deselectAllTasksMenu": "Batalkan pilihan semua",
+  "hideCompletedTasks": "Sembunyikan selesai",
+  "searchActionItems": "Cari item tindakan",
+  "selectActionItems": "Pilih beberapa",
+  "selectAllTasksMenu": "Pilih semua",
+  "showCompletedTasks": "Tampilkan selesai",
+  "startCallRecording": "Mulai rekaman panggilan",
+  "startVoiceRecording": "Mulai rekaman suara"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Registra con il microfono del telefono",
   "recordWithPhoneMicSubtitle": "Cattura l'audio intorno a te",
   "phoneCall": "Chiamata",
-  "phoneCallSubtitle": "Registra una chiamata con trascrizione live"
+  "phoneCallSubtitle": "Registra una chiamata con trascrizione live",
+  "bulkExportInProgress": "Esportazione…",
+  "bulkExportPartial": "Esportati {success} di {total} su {platform}",
+  "bulkExportSuccess": "Esportati {count} su {platform}",
+  "chooseExportDestination": "Esporta {count} elemento/i su…",
+  "connectAction": "Connetti",
+  "connectTaskAppToExport": "Collega un'app attività nelle Impostazioni per esportare",
+  "deselectAllTasksMenu": "Deseleziona tutto",
+  "hideCompletedTasks": "Nascondi completate",
+  "searchActionItems": "Cerca azioni",
+  "selectActionItems": "Selezione multipla",
+  "selectAllTasksMenu": "Seleziona tutto",
+  "showCompletedTasks": "Mostra completate",
+  "startCallRecording": "Avvia registrazione chiamata",
+  "startVoiceRecording": "Avvia registrazione vocale"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3000,5 +3000,19 @@
   "recordWithPhoneMic": "電話のマイクで録音",
   "recordWithPhoneMicSubtitle": "周囲の音声を録音",
   "phoneCall": "電話",
-  "phoneCallSubtitle": "ライブ文字起こしで通話を録音"
+  "phoneCallSubtitle": "ライブ文字起こしで通話を録音",
+  "bulkExportInProgress": "エクスポート中…",
+  "bulkExportPartial": "{total}件中{success}件を{platform}にエクスポートしました",
+  "bulkExportSuccess": "{count}件を{platform}にエクスポートしました",
+  "chooseExportDestination": "{count}件をエクスポート先…",
+  "connectAction": "接続",
+  "connectTaskAppToExport": "エクスポートするには設定でタスクアプリを接続してください",
+  "deselectAllTasksMenu": "すべて選択解除",
+  "hideCompletedTasks": "完了を非表示",
+  "searchActionItems": "アクション項目を検索",
+  "selectActionItems": "複数選択",
+  "selectAllTasksMenu": "すべて選択",
+  "showCompletedTasks": "完了を表示",
+  "startCallRecording": "通話録音を開始",
+  "startVoiceRecording": "音声録音を開始"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "ಫೋನ್ ಮೈಕ್‌ನೊಂದಿಗೆ ರೆಕಾರ್ಡ್ ಮಾಡಿ",
   "recordWithPhoneMicSubtitle": "ನಿಮ್ಮ ಸುತ್ತಲಿನ ಆಡಿಯೋ ಸೆರೆಹಿಡಿಯಿರಿ",
   "phoneCall": "ಫೋನ್ ಕರೆ",
-  "phoneCallSubtitle": "ಲೈವ್ ಪ್ರತಿಲೇಖನದೊಂದಿಗೆ ಕರೆಯನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡಿ"
+  "phoneCallSubtitle": "ಲೈವ್ ಪ್ರತಿಲೇಖನದೊಂದಿಗೆ ಕರೆಯನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡಿ",
+  "bulkExportInProgress": "ರಫ್ತು ಮಾಡಲಾಗುತ್ತಿದೆ…",
+  "bulkExportPartial": "{total} ರಲ್ಲಿ {success} ಅನ್ನು {platform} ಗೆ ರಫ್ತು ಮಾಡಲಾಗಿದೆ",
+  "bulkExportSuccess": "{count} ಅನ್ನು {platform} ಗೆ ರಫ್ತು ಮಾಡಲಾಗಿದೆ",
+  "chooseExportDestination": "{count} ಐಟಂ(ಗಳನ್ನು) ರಫ್ತು ಮಾಡಿ…",
+  "connectAction": "ಸಂಪರ್ಕಿಸಿ",
+  "connectTaskAppToExport": "ರಫ್ತು ಮಾಡಲು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಕಾರ್ಯ ಅಪ್ಲಿಕೇಶನ್ ಸಂಪರ್ಕಿಸಿ",
+  "deselectAllTasksMenu": "ಎಲ್ಲವನ್ನೂ ಆಯ್ಕೆ ರದ್ದು ಮಾಡಿ",
+  "hideCompletedTasks": "ಪೂರ್ಣಗೊಂಡವು ಮರೆಮಾಡಿ",
+  "searchActionItems": "ಕ್ರಿಯಾ ಐಟಂಗಳನ್ನು ಹುಡುಕಿ",
+  "selectActionItems": "ಬಹು ಆಯ್ಕೆ",
+  "selectAllTasksMenu": "ಎಲ್ಲವನ್ನೂ ಆಯ್ಕೆ ಮಾಡಿ",
+  "showCompletedTasks": "ಪೂರ್ಣಗೊಂಡವು ತೋರಿಸಿ",
+  "startCallRecording": "ಕರೆ ರೆಕಾರ್ಡಿಂಗ್ ಪ್ರಾರಂಭಿಸಿ",
+  "startVoiceRecording": "ಧ್ವನಿ ರೆಕಾರ್ಡಿಂಗ್ ಪ್ರಾರಂಭಿಸಿ"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "휴대폰 마이크로 녹음",
   "recordWithPhoneMicSubtitle": "주변 오디오를 캡처하세요",
   "phoneCall": "전화 통화",
-  "phoneCallSubtitle": "실시간 전사로 통화 녹음"
+  "phoneCallSubtitle": "실시간 전사로 통화 녹음",
+  "bulkExportInProgress": "내보내는 중…",
+  "bulkExportPartial": "{total}개 중 {success}개를 {platform}에 내보냈습니다",
+  "bulkExportSuccess": "{count}개를 {platform}에 내보냈습니다",
+  "chooseExportDestination": "{count}개 항목 내보내기…",
+  "connectAction": "연결",
+  "connectTaskAppToExport": "내보내려면 설정에서 작업 앱을 연결하세요",
+  "deselectAllTasksMenu": "모두 선택 해제",
+  "hideCompletedTasks": "완료 숨기기",
+  "searchActionItems": "실행 항목 검색",
+  "selectActionItems": "여러 개 선택",
+  "selectAllTasksMenu": "모두 선택",
+  "showCompletedTasks": "완료 보기",
+  "startCallRecording": "통화 녹음 시작",
+  "startVoiceRecording": "음성 녹음 시작"
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9094,10 +9094,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get agreeAndContinue => 'أوافق وأتابع';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'بدء التسجيل الصوتي';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'بدء تسجيل المكالمة';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9127,44 +9127,44 @@ class AppLocalizationsAr extends AppLocalizations {
   String get phoneCallSubtitle => 'سجّل مكالمة مع تفريغ مباشر';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'البحث في عناصر الإجراء';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'تحديد متعدد';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'تصدير $count عنصر(عناصر) إلى…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'جارٍ التصدير…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'تم تصدير $count إلى $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'تم تصدير $success من $total إلى $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'إظهار المكتملة';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'إخفاء المكتملة';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'تحديد الكل';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'قم بربط تطبيق مهام في الإعدادات للتصدير';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'اتصال';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'إلغاء تحديد الكل';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9181,10 +9181,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get agreeAndContinue => 'Прыняць і працягнуць';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Пачаць галасавы запіс';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Пачаць запіс званка';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9214,44 +9214,44 @@ class AppLocalizationsBe extends AppLocalizations {
   String get phoneCallSubtitle => 'Запіс званка з жывой транскрыпцыяй';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Шукаць элементы дзеянняў';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Выбраць некалькі';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Экспартаваць $count элемент(аў) у…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Экспарт…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Экспартавана $count у $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Экспартавана $success з $total у $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Паказаць завершаныя';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Схаваць завершаныя';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Выбраць усе';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Падключыце праграму задач у Наладах для экспарту';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Злучыць';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Зняць выбар усіх';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9190,10 +9190,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get agreeAndContinue => 'Приемам и продължавам';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Стартиране на гласов запис';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Стартиране на запис на разговор';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9223,44 +9223,44 @@ class AppLocalizationsBg extends AppLocalizations {
   String get phoneCallSubtitle => 'Записвайте обаждане с транскрипция в реално време';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Търсене на действия';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Избиране на няколко';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Експортиране на $count елемент(а) в…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Експортиране…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Експортирани $count в $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Експортирани $success от $total в $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Показване на завършените';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Скриване на завършените';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Избиране на всички';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Свържете приложение за задачи в Настройки, за да експортирате';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Свързване';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Премахване на избора';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9164,10 +9164,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get agreeAndContinue => 'সম্মত হই এবং চালিয়ে যান';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'ভয়েস রেকর্ডিং শুরু করুন';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'কল রেকর্ডিং শুরু করুন';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9197,44 +9197,44 @@ class AppLocalizationsBn extends AppLocalizations {
   String get phoneCallSubtitle => 'লাইভ ট্রান্সক্রিপশন সহ কল রেকর্ড করুন';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'অ্যাকশন আইটেম অনুসন্ধান';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'একাধিক নির্বাচন';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$countটি আইটেম রপ্তানি করুন…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'রপ্তানি হচ্ছে…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$countটি $platform-এ রপ্তানি হয়েছে';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total-এর মধ্যে $successটি $platform-এ রপ্তানি হয়েছে';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'সম্পন্ন দেখান';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'সম্পন্ন লুকান';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'সমস্ত নির্বাচন';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'রপ্তানি করতে সেটিংসে একটি টাস্ক অ্যাপ সংযুক্ত করুন';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'সংযুক্ত করুন';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'সমস্ত নির্বাচন বাতিল';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9179,10 +9179,10 @@ class AppLocalizationsBs extends AppLocalizations {
   String get agreeAndContinue => 'Slažem se i nastavi';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Pokreni glasovno snimanje';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Pokreni snimanje poziva';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9212,44 +9212,44 @@ class AppLocalizationsBs extends AppLocalizations {
   String get phoneCallSubtitle => 'Snimajte poziv s transkripcijom uživo';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Pretraži akcione stavke';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Odaberi više';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Izvezi $count stavku/i u…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Izvoz u toku…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Izvezeno $count u $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Izvezeno $success od $total u $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Prikaži završene';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Sakrij završene';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Odaberi sve';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Povežite aplikaciju za zadatke u Postavkama za izvoz';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Poveži';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Poništi odabir svih';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9209,10 +9209,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get agreeAndContinue => 'Accepto i continuo';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Inicia l\'enregistrament de veu';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Inicia l\'enregistrament de trucada';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9242,44 +9242,44 @@ class AppLocalizationsCa extends AppLocalizations {
   String get phoneCallSubtitle => 'Enregistra una trucada amb transcripció en directe';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Cerca elements d\'acció';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Selecció múltiple';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Exporta $count element(s) a…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'S\'està exportant…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'S\'han exportat $count a $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'S\'han exportat $success de $total a $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Mostra les completades';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Amaga les completades';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Selecciona tot';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Connecta una aplicació de tasques a Configuració per exportar';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Connecta';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Desselecciona tot';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9151,10 +9151,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get agreeAndContinue => 'Souhlasím a pokračovat';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Zahájit hlasový záznam';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Zahájit nahrávání hovoru';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9184,44 +9184,44 @@ class AppLocalizationsCs extends AppLocalizations {
   String get phoneCallSubtitle => 'Nahrávejte hovor s živým přepisem';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Hledat akční položky';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Vybrat více';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Exportovat $count položek do…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exportování…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Exportováno $count do $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Exportováno $success z $total do $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Zobrazit dokončené';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Skrýt dokončené';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Vybrat vše';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Pro export připojte aplikaci úkolů v Nastavení';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Připojit';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Zrušit výběr všech';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9141,10 +9141,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get agreeAndContinue => 'Accepter og fortsæt';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Start stemmeoptagelse';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Start opkaldsoptagelse';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9174,44 +9174,44 @@ class AppLocalizationsDa extends AppLocalizations {
   String get phoneCallSubtitle => 'Optag et opkald med live-transskription';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Søg i handlingspunkter';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Vælg flere';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Eksportér $count element(er) til…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Eksporterer…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Eksporterede $count til $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Eksporterede $success af $total til $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Vis fuldførte';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Skjul fuldførte';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Vælg alle';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Forbind en opgaveapp i Indstillinger for at eksportere';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Forbind';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Fravælg alle';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9232,10 +9232,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get agreeAndContinue => 'Zustimmen und fortfahren';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Sprachaufnahme starten';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Anrufaufnahme starten';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9265,44 +9265,44 @@ class AppLocalizationsDe extends AppLocalizations {
   String get phoneCallSubtitle => 'Anruf mit Live-Transkription aufnehmen';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Aktionspunkte durchsuchen';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Mehrere auswählen';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count Element(e) exportieren nach…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exportieren…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count nach $platform exportiert';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$success von $total nach $platform exportiert';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Erledigte anzeigen';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Erledigte ausblenden';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Alle auswählen';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Verbinde eine Aufgaben-App in den Einstellungen zum Exportieren';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Verbinden';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Alle abwählen';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9220,10 +9220,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get agreeAndContinue => 'Συμφωνώ και Συνέχεια';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Έναρξη ηχογράφησης';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Έναρξη εγγραφής κλήσης';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9253,44 +9253,44 @@ class AppLocalizationsEl extends AppLocalizations {
   String get phoneCallSubtitle => 'Καταγράψτε κλήση με ζωντανή μεταγραφή';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Αναζήτηση ενεργειών';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Πολλαπλή επιλογή';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Εξαγωγή $count στοιχείου/ων σε…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Εξαγωγή…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Εξήχθησαν $count στο $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Εξήχθησαν $success από $total στο $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Εμφάνιση ολοκληρωμένων';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Απόκρυψη ολοκληρωμένων';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Επιλογή όλων';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Συνδέστε μια εφαρμογή εργασιών στις Ρυθμίσεις για εξαγωγή';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Σύνδεση';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Αποεπιλογή όλων';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9176,10 +9176,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get agreeAndContinue => 'Acepto y continuar';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Iniciar grabación de voz';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Iniciar grabación de llamada';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9209,44 +9209,44 @@ class AppLocalizationsEs extends AppLocalizations {
   String get phoneCallSubtitle => 'Graba una llamada con transcripción en vivo';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Buscar elementos de acción';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Seleccionar varios';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Exportar $count elemento(s) a…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exportando…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Se exportaron $count a $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Se exportaron $success de $total a $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Mostrar completadas';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Ocultar completadas';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Seleccionar todo';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Conecta una app de tareas en Ajustes para exportar';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Conectar';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Deseleccionar todo';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9152,10 +9152,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get agreeAndContinue => 'Nõustun ja jätka';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Alusta häälsalvestust';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Alusta kõne salvestamist';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9185,44 +9185,44 @@ class AppLocalizationsEt extends AppLocalizations {
   String get phoneCallSubtitle => 'Salvesta kõne reaalajas transkriptsiooniga';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Otsi tegevusüksusi';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Vali mitu';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Ekspordi $count üksus(t) asukohta…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Eksportimine…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Eksporditi $count asukohta $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Eksporditi $success/$total asukohta $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Kuva lõpetatud';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Peida lõpetatud';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Vali kõik';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Eksportimiseks ühendage Seadetes ülesannete rakendus';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Ühenda';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Tühista kõigi valik';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9158,10 +9158,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get agreeAndContinue => 'موافقم و ادامه';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'شروع ضبط صدا';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'شروع ضبط تماس';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9191,44 +9191,44 @@ class AppLocalizationsFa extends AppLocalizations {
   String get phoneCallSubtitle => 'یک تماس را با رونویسی زنده ضبط کنید';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'جستجوی موارد اقدام';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'انتخاب چندگانه';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'صادرات $count مورد به…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'در حال صادرات…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count به $platform صادر شد';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$success از $total به $platform صادر شد';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'نمایش انجام‌شده‌ها';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'پنهان کردن انجام‌شده‌ها';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'انتخاب همه';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'برای صادرات، یک برنامه وظایف را در تنظیمات متصل کنید';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'اتصال';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'لغو انتخاب همه';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9154,10 +9154,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get agreeAndContinue => 'Hyväksy ja jatka';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Aloita ääninauhoitus';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Aloita puhelun nauhoitus';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9187,44 +9187,44 @@ class AppLocalizationsFi extends AppLocalizations {
   String get phoneCallSubtitle => 'Tallenna puhelu reaaliaikaisella tekstityksellä';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Hae toimintakohteita';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Valitse useita';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Vie $count kohde(tta) kohteeseen…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Viedään…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Viety $count kohteeseen $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Viety $success/$total kohteeseen $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Näytä valmiit';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Piilota valmiit';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Valitse kaikki';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Yhdistä tehtäväsovellus Asetuksissa vientiä varten';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Yhdistä';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Poista kaikkien valinta';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9238,10 +9238,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get agreeAndContinue => 'Accepter et continuer';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Démarrer l\'enregistrement vocal';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Démarrer l\'enregistrement d\'appel';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9271,44 +9271,44 @@ class AppLocalizationsFr extends AppLocalizations {
   String get phoneCallSubtitle => 'Enregistrez un appel avec transcription en direct';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Rechercher des actions';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Sélection multiple';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Exporter $count élément(s) vers…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exportation…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count exportés vers $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$success sur $total exportés vers $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Afficher les terminées';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Masquer les terminées';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Tout sélectionner';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Connectez une application de tâches dans les Paramètres pour exporter';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Connecter';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Tout désélectionner';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9083,10 +9083,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get agreeAndContinue => 'אני מסכים והמשך';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'התחל הקלטה קולית';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'התחל הקלטת שיחה';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9116,44 +9116,44 @@ class AppLocalizationsHe extends AppLocalizations {
   String get phoneCallSubtitle => 'הקלט שיחה עם תמלול חי';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'חפש פריטי פעולה';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'בחירה מרובה';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'ייצוא $count פריט(ים) אל…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'מייצא…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'יוצאו $count אל $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'יוצאו $success מתוך $total אל $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'הצג הושלמו';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'הסתר הושלמו';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'בחר הכל';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'חבר אפליקציית משימות בהגדרות כדי לייצא';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'חיבור';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'בטל בחירת הכל';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9135,10 +9135,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get agreeAndContinue => 'सहमत हूँ और जारी रखें';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'वॉइस रिकॉर्डिंग शुरू करें';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'कॉल रिकॉर्डिंग शुरू करें';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9168,44 +9168,44 @@ class AppLocalizationsHi extends AppLocalizations {
   String get phoneCallSubtitle => 'लाइव ट्रांसक्रिप्शन के साथ कॉल रिकॉर्ड करें';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'कार्य आइटम खोजें';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'एकाधिक चुनें';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count आइटम निर्यात करें…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'निर्यात हो रहा है…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count को $platform में निर्यात किया गया';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total में से $success को $platform में निर्यात किया गया';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'पूर्ण दिखाएं';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'पूर्ण छिपाएं';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'सभी चुनें';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'निर्यात करने के लिए सेटिंग्स में एक टास्क ऐप कनेक्ट करें';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'कनेक्ट करें';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'सभी का चयन हटाएं';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9185,10 +9185,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get agreeAndContinue => 'Slažem se i nastavi';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Pokreni glasovno snimanje';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Pokreni snimanje poziva';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9218,44 +9218,44 @@ class AppLocalizationsHr extends AppLocalizations {
   String get phoneCallSubtitle => 'Snimajte poziv s transkripcijom uživo';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Pretraži akcijske stavke';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Odaberi više';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Izvezi $count stavku/i u…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Izvoz u tijeku…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Izvezeno $count u $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Izvezeno $success od $total u $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Prikaži dovršene';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Sakrij dovršene';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Odaberi sve';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Povežite aplikaciju za zadatke u Postavkama za izvoz';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Poveži';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Poništi odabir svih';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9194,10 +9194,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get agreeAndContinue => 'Elfogadom és folytatom';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Hangfelvétel indítása';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Hívásfelvétel indítása';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9227,44 +9227,44 @@ class AppLocalizationsHu extends AppLocalizations {
   String get phoneCallSubtitle => 'Hívás rögzítése élő átirattal';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Teendők keresése';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Több kijelölése';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count elem exportálása ide…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exportálás…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count exportálva ide: $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$success/$total exportálva ide: $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Befejezettek megjelenítése';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Befejezettek elrejtése';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Összes kijelölése';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Csatlakoztasson egy feladatalkalmazást a Beállításokban az exportáláshoz';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Csatlakoztatás';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Összes kijelölés törlése';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9165,10 +9165,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get agreeAndContinue => 'Setuju & Lanjutkan';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Mulai rekaman suara';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Mulai rekaman panggilan';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9198,44 +9198,44 @@ class AppLocalizationsId extends AppLocalizations {
   String get phoneCallSubtitle => 'Rekam panggilan dengan transkripsi langsung';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Cari item tindakan';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Pilih beberapa';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Ekspor $count item ke…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Mengekspor…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Diekspor $count ke $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Diekspor $success dari $total ke $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Tampilkan selesai';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Sembunyikan selesai';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Pilih semua';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Hubungkan aplikasi tugas di Pengaturan untuk mengekspor';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Hubungkan';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Batalkan pilihan semua';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9210,10 +9210,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get agreeAndContinue => 'Accetta e continua';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Avvia registrazione vocale';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Avvia registrazione chiamata';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9243,44 +9243,44 @@ class AppLocalizationsIt extends AppLocalizations {
   String get phoneCallSubtitle => 'Registra una chiamata con trascrizione live';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Cerca azioni';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Selezione multipla';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Esporta $count elemento/i su…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Esportazione…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Esportati $count su $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Esportati $success di $total su $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Mostra completate';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Nascondi completate';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Seleziona tutto';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Collega un\'app attività nelle Impostazioni per esportare';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Connetti';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Deseleziona tutto';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9006,10 +9006,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get agreeAndContinue => '同意して続ける';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => '音声録音を開始';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => '通話録音を開始';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9039,44 +9039,44 @@ class AppLocalizationsJa extends AppLocalizations {
   String get phoneCallSubtitle => 'ライブ文字起こしで通話を録音';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'アクション項目を検索';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => '複数選択';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count件をエクスポート先…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'エクスポート中…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count件を$platformにエクスポートしました';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total件中$success件を$platformにエクスポートしました';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => '完了を表示';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => '完了を非表示';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'すべて選択';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'エクスポートするには設定でタスクアプリを接続してください';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => '接続';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'すべて選択解除';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9187,10 +9187,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get agreeAndContinue => 'ಒಪ್ಪಿಗೆ ಮತ್ತು ಮುಂದುವರಿಯಿರಿ';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'ಧ್ವನಿ ರೆಕಾರ್ಡಿಂಗ್ ಪ್ರಾರಂಭಿಸಿ';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'ಕರೆ ರೆಕಾರ್ಡಿಂಗ್ ಪ್ರಾರಂಭಿಸಿ';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9220,44 +9220,44 @@ class AppLocalizationsKn extends AppLocalizations {
   String get phoneCallSubtitle => 'ಲೈವ್ ಪ್ರತಿಲೇಖನದೊಂದಿಗೆ ಕರೆಯನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡಿ';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'ಕ್ರಿಯಾ ಐಟಂಗಳನ್ನು ಹುಡುಕಿ';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'ಬಹು ಆಯ್ಕೆ';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count ಐಟಂ(ಗಳನ್ನು) ರಫ್ತು ಮಾಡಿ…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'ರಫ್ತು ಮಾಡಲಾಗುತ್ತಿದೆ…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count ಅನ್ನು $platform ಗೆ ರಫ್ತು ಮಾಡಲಾಗಿದೆ';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total ರಲ್ಲಿ $success ಅನ್ನು $platform ಗೆ ರಫ್ತು ಮಾಡಲಾಗಿದೆ';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'ಪೂರ್ಣಗೊಂಡವು ತೋರಿಸಿ';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'ಪೂರ್ಣಗೊಂಡವು ಮರೆಮಾಡಿ';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'ಎಲ್ಲವನ್ನೂ ಆಯ್ಕೆ ಮಾಡಿ';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'ರಫ್ತು ಮಾಡಲು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಕಾರ್ಯ ಅಪ್ಲಿಕೇಶನ್ ಸಂಪರ್ಕಿಸಿ';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'ಸಂಪರ್ಕಿಸಿ';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'ಎಲ್ಲವನ್ನೂ ಆಯ್ಕೆ ರದ್ದು ಮಾಡಿ';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9007,10 +9007,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get agreeAndContinue => '동의하고 계속';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => '음성 녹음 시작';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => '통화 녹음 시작';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9040,44 +9040,44 @@ class AppLocalizationsKo extends AppLocalizations {
   String get phoneCallSubtitle => '실시간 전사로 통화 녹음';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => '실행 항목 검색';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => '여러 개 선택';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count개 항목 내보내기…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => '내보내는 중…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count개를 $platform에 내보냈습니다';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total개 중 $success개를 $platform에 내보냈습니다';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => '완료 보기';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => '완료 숨기기';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => '모두 선택';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => '내보내려면 설정에서 작업 앱을 연결하세요';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => '연결';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => '모두 선택 해제';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9164,10 +9164,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get agreeAndContinue => 'Sutinku ir tęsti';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Pradėti balso įrašymą';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Pradėti skambučio įrašymą';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9197,44 +9197,44 @@ class AppLocalizationsLt extends AppLocalizations {
   String get phoneCallSubtitle => 'Įrašykite skambutį su tiesiogine transkripcija';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Ieškoti veiksmų elementų';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Pasirinkti kelis';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Eksportuoti $count elementą(-us) į…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Eksportuojama…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Eksportuota $count į $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Eksportuota $success iš $total į $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Rodyti užbaigtas';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Slėpti užbaigtas';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Pasirinkti viską';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Prijunkite užduočių programą Nustatymuose, kad galėtumėte eksportuoti';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Prijungti';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Atžymėti viską';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9173,10 +9173,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get agreeAndContinue => 'Piekrītu un turpināt';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Sākt balss ierakstīšanu';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Sākt zvana ierakstīšanu';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9206,44 +9206,44 @@ class AppLocalizationsLv extends AppLocalizations {
   String get phoneCallSubtitle => 'Ierakstiet zvanu ar tiešraides transkripciju';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Meklēt darbības vienumus';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Atlasīt vairākus';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Eksportēt $count vienību(-as) uz…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Eksportē…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Eksportēti $count uz $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Eksportēti $success no $total uz $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Rādīt pabeigtās';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Slēpt pabeigtās';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Atlasīt visus';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Savienojiet uzdevumu lietotni Iestatījumos, lai eksportētu';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Savienot';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Noņemt visu atlasi';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9204,10 +9204,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get agreeAndContinue => 'Се согласувам и продолжи';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Започни гласовно снимање';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Започни снимање повик';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9237,44 +9237,44 @@ class AppLocalizationsMk extends AppLocalizations {
   String get phoneCallSubtitle => 'Снимајте повик со транскрипција во живо';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Пребарај акциски ставки';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Избери повеќе';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Извези $count ставка/и во…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Извезување…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Извезени $count во $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Извезени $success од $total во $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Прикажи завршени';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Сокриј завршени';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Избери ги сите';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Поврзете апликација за задачи во Поставки за извоз';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Поврзи';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Одселектирај ги сите';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9166,10 +9166,10 @@ class AppLocalizationsMr extends AppLocalizations {
   String get agreeAndContinue => 'सहमत व्हा आणि सुरू ठेवा';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'व्हॉइस रेकॉर्डिंग सुरू करा';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'कॉल रेकॉर्डिंग सुरू करा';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9199,44 +9199,44 @@ class AppLocalizationsMr extends AppLocalizations {
   String get phoneCallSubtitle => 'लाइव्ह ट्रान्स्क्रिप्शनसह कॉल रेकॉर्ड करा';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'कृती आयटम शोधा';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'अनेक निवडा';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count आयटम निर्यात करा…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'निर्यात होत आहे…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count $platform वर निर्यात केले';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total पैकी $success $platform वर निर्यात केले';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'पूर्ण झालेले दाखवा';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'पूर्ण झालेले लपवा';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'सर्व निवडा';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'निर्यात करण्यासाठी सेटिंग्जमध्ये टास्क ॲप जोडा';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'जोडा';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'सर्वांची निवड रद्द करा';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9179,10 +9179,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get agreeAndContinue => 'Setuju & Teruskan';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Mula rakaman suara';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Mula rakaman panggilan';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9212,44 +9212,44 @@ class AppLocalizationsMs extends AppLocalizations {
   String get phoneCallSubtitle => 'Rakam panggilan dengan transkripsi langsung';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Cari item tindakan';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Pilih beberapa';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Eksport $count item ke…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Mengeksport…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Dieksport $count ke $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Dieksport $success daripada $total ke $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Tunjukkan selesai';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Sembunyikan selesai';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Pilih semua';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Sambungkan aplikasi tugas dalam Tetapan untuk mengeksport';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Sambung';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Nyahpilih semua';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9183,10 +9183,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get agreeAndContinue => 'Akkoord en doorgaan';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Spraakopname starten';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Gespreksopname starten';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9216,44 +9216,44 @@ class AppLocalizationsNl extends AppLocalizations {
   String get phoneCallSubtitle => 'Neem een gesprek op met live transcriptie';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Actiepunten zoeken';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Meerdere selecteren';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count item(s) exporteren naar…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exporteren…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count geëxporteerd naar $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$success van $total geëxporteerd naar $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Voltooide tonen';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Voltooide verbergen';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Alles selecteren';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Verbind een taken-app in Instellingen om te exporteren';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Verbinden';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Alles deselecteren';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9151,10 +9151,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get agreeAndContinue => 'Godta og fortsett';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Start stemmeopptak';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Start samtaleopptak';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9184,44 +9184,44 @@ class AppLocalizationsNo extends AppLocalizations {
   String get phoneCallSubtitle => 'Ta opp en samtale med direkte transkripsjon';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Søk i handlingspunkter';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Velg flere';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Eksporter $count element(er) til…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Eksporterer…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Eksporterte $count til $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Eksporterte $success av $total til $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Vis fullførte';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Skjul fullførte';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Velg alle';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Koble til en oppgaveapp i Innstillinger for å eksportere';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Koble til';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Fjern alle valg';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9175,10 +9175,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get agreeAndContinue => 'Akceptuję i kontynuuj';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Rozpocznij nagrywanie głosu';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Rozpocznij nagrywanie rozmowy';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9208,44 +9208,44 @@ class AppLocalizationsPl extends AppLocalizations {
   String get phoneCallSubtitle => 'Nagrywaj rozmowę z transkrypcją na żywo';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Szukaj pozycji działań';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Zaznacz wiele';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Eksportuj $count element(ów) do…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Eksportowanie…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Wyeksportowano $count do $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Wyeksportowano $success z $total do $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Pokaż ukończone';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Ukryj ukończone';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Zaznacz wszystkie';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Połącz aplikację zadań w Ustawieniach, aby eksportować';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Połącz';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Odznacz wszystkie';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9159,10 +9159,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get agreeAndContinue => 'Aceitar e continuar';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Iniciar gravação de voz';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Iniciar gravação de chamada';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9192,44 +9192,44 @@ class AppLocalizationsPt extends AppLocalizations {
   String get phoneCallSubtitle => 'Grave uma chamada com transcrição ao vivo';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Pesquisar itens de ação';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Selecionar vários';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Exportar $count item(ns) para…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exportando…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Exportados $count para $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Exportados $success de $total para $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Mostrar concluídas';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Ocultar concluídas';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Selecionar todos';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Conecte um aplicativo de tarefas nas Configurações para exportar';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Conectar';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Desmarcar todos';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9198,10 +9198,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get agreeAndContinue => 'Accept și continuă';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Porniți înregistrarea vocală';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Porniți înregistrarea apelului';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9231,44 +9231,44 @@ class AppLocalizationsRo extends AppLocalizations {
   String get phoneCallSubtitle => 'Înregistrează un apel cu transcriere în direct';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Căutați elemente de acțiune';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Selectare multiplă';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Exportă $count element(e) în…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Se exportă…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Exportate $count în $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Exportate $success din $total în $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Afișați finalizate';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Ascundeți finalizate';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Selectați tot';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Conectați o aplicație de sarcini în Setări pentru a exporta';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Conectare';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Deselectați tot';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9184,10 +9184,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get agreeAndContinue => 'Принять и продолжить';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Начать голосовую запись';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Начать запись звонка';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9217,44 +9217,44 @@ class AppLocalizationsRu extends AppLocalizations {
   String get phoneCallSubtitle => 'Запись звонка с транскрипцией в реальном времени';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Поиск действий';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Выбрать несколько';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Экспортировать $count элемент(ов) в…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Экспорт…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Экспортировано $count в $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Экспортировано $success из $total в $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Показать завершённые';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Скрыть завершённые';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Выбрать все';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Подключите приложение задач в Настройках для экспорта';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Подключить';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Снять выделение со всех';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9143,10 +9143,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get agreeAndContinue => 'Súhlasím a pokračovať';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Spustiť hlasový záznam';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Spustiť nahrávanie hovoru';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9176,44 +9176,44 @@ class AppLocalizationsSk extends AppLocalizations {
   String get phoneCallSubtitle => 'Nahrávajte hovor so živým prepisom';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Hľadať akčné položky';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Vybrať viacero';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Exportovať $count položku/iek do…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exportovanie…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Exportovaných $count do $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Exportovaných $success z $total do $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Zobraziť dokončené';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Skryť dokončené';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Vybrať všetko';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Pripojte aplikáciu úloh v Nastaveniach na export';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Pripojiť';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Zrušiť výber všetkých';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9179,10 +9179,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get agreeAndContinue => 'Strinjam se in nadaljuj';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Začni glasovno snemanje';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Začni snemanje klica';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9212,44 +9212,44 @@ class AppLocalizationsSl extends AppLocalizations {
   String get phoneCallSubtitle => 'Posnemite klic s prepisom v živo';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Iskanje akcijskih elementov';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Izberi več';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Izvozi $count element(ov) v…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Izvažanje…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Izvoženo $count v $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Izvoženo $success od $total v $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Prikaži dokončane';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Skrij dokončane';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Izberi vse';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Povežite aplikacijo za naloge v Nastavitvah za izvoz';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Poveži';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Prekliči izbor vseh';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9168,10 +9168,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get agreeAndContinue => 'Slažem se i nastavi';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Покрени гласовно снимање';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Покрени снимање позива';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9201,44 +9201,44 @@ class AppLocalizationsSr extends AppLocalizations {
   String get phoneCallSubtitle => 'Снимајте позив са транскрипцијом уживо';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Претражи акционе ставке';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Изабери више';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Извези $count ставку/и у…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Извоз…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Извезено $count у $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Извезено $success од $total у $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Прикажи завршене';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Сакриј завршене';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Изабери све';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Повежите апликацију за задатке у Подешавањима за извоз';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Повежи';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Поништи избор свих';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9159,10 +9159,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get agreeAndContinue => 'Godkänn och fortsätt';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Starta röstinspelning';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Starta samtalsinspelning';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9192,44 +9192,44 @@ class AppLocalizationsSv extends AppLocalizations {
   String get phoneCallSubtitle => 'Spela in samtal med live-transkribering';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Sök åtgärdspunkter';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Välj flera';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Exportera $count objekt till…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Exporterar…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Exporterade $count till $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Exporterade $success av $total till $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Visa slutförda';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Dölj slutförda';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Välj alla';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Anslut en uppgiftsapp i Inställningar för att exportera';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Anslut';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Avmarkera alla';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9224,10 +9224,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get agreeAndContinue => 'ஒப்புக்கொள் & தொடரவும்';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'குரல் பதிவைத் தொடங்கு';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'அழைப்பு பதிவைத் தொடங்கு';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9257,44 +9257,44 @@ class AppLocalizationsTa extends AppLocalizations {
   String get phoneCallSubtitle => 'நேரடி படியெடுத்தலுடன் அழைப்பைப் பதிவு செய்யவும்';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'செயல் உருப்படிகளைத் தேடு';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'பலவற்றைத் தேர்ந்தெடு';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count உருப்படி(களை) ஏற்றுமதி செய்…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'ஏற்றுமதி செய்கிறது…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count ஐ $platform க்கு ஏற்றுமதி செய்யப்பட்டது';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total இல் $success ஐ $platform க்கு ஏற்றுமதி செய்யப்பட்டது';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'முடிந்தவற்றைக் காட்டு';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'முடிந்தவற்றை மறை';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'அனைத்தையும் தேர்ந்தெடு';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'ஏற்றுமதி செய்ய அமைப்புகளில் ஒரு பணி செயலியை இணைக்கவும்';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'இணைக்கவும்';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'அனைத்தையும் தேர்வு நீக்கு';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9206,10 +9206,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get agreeAndContinue => 'అంగీకరించి కొనసాగించండి';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'వాయిస్ రికార్డింగ్ ప్రారంభించండి';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'కాల్ రికార్డింగ్ ప్రారంభించండి';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9239,44 +9239,44 @@ class AppLocalizationsTe extends AppLocalizations {
   String get phoneCallSubtitle => 'లైవ్ ట్రాన్స్‌క్రిప్షన్‌తో కాల్‌ను రికార్డ్ చేయండి';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'చర్య అంశాలను వెతకండి';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'బహుళ ఎంపిక';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count అంశం(ాలను) ఎగుమతి చేయండి…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'ఎగుమతి చేస్తోంది…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count ని $platform కు ఎగుమతి చేయబడింది';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total లో $success ని $platform కు ఎగుమతి చేయబడింది';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'పూర్తయినవి చూపించు';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'పూర్తయినవి దాచు';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'అన్నీ ఎంచుకోండి';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'ఎగుమతి చేయడానికి సెట్టింగ్‌లలో టాస్క్ యాప్‌ను కనెక్ట్ చేయండి';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'కనెక్ట్ చేయండి';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'అన్ని ఎంపికలు తొలగించు';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9109,10 +9109,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get agreeAndContinue => 'ยอมรับและดำเนินการต่อ';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'เริ่มบันทึกเสียง';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'เริ่มบันทึกการโทร';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9142,44 +9142,44 @@ class AppLocalizationsTh extends AppLocalizations {
   String get phoneCallSubtitle => 'บันทึกการโทรพร้อมถอดเสียงสด';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'ค้นหารายการดำเนินการ';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'เลือกหลายรายการ';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'ส่งออก $count รายการไปยัง…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'กำลังส่งออก…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'ส่งออกแล้ว $count ไปยัง $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'ส่งออกแล้ว $success จาก $total ไปยัง $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'แสดงที่เสร็จแล้ว';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'ซ่อนที่เสร็จแล้ว';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'เลือกทั้งหมด';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'เชื่อมต่อแอปงานในการตั้งค่าเพื่อส่งออก';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'เชื่อมต่อ';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'ยกเลิกเลือกทั้งหมด';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9240,10 +9240,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get agreeAndContinue => 'Sumasang-ayon at Magpatuloy';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Simulan ang voice recording';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Simulan ang pag-record ng tawag';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9273,44 +9273,44 @@ class AppLocalizationsTl extends AppLocalizations {
   String get phoneCallSubtitle => 'Mag-record ng tawag na may live na transkripsyon';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Maghanap ng mga action item';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Pumili ng marami';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'I-export ang $count item sa…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Nag-e-export…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Na-export ang $count sa $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Na-export ang $success sa $total sa $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Ipakita ang tapos na';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Itago ang tapos na';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Piliin lahat';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Ikonekta ang isang task app sa Settings para mag-export';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Ikonekta';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'I-deselect lahat';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9168,10 +9168,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get agreeAndContinue => 'Kabul Et ve Devam Et';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Ses kaydını başlat';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Arama kaydını başlat';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9201,44 +9201,44 @@ class AppLocalizationsTr extends AppLocalizations {
   String get phoneCallSubtitle => 'Canlı transkripsiyonla bir aramayı kaydedin';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Eylem öğelerini ara';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Birden fazla seç';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count öğeyi dışa aktar…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Dışa aktarılıyor…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count öğe $platform uygulamasına aktarıldı';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total öğeden $success tanesi $platform uygulamasına aktarıldı';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Tamamlananları göster';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Tamamlananları gizle';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Tümünü seç';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Dışa aktarmak için Ayarlar\'da bir görev uygulaması bağlayın';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Bağla';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Tümünün seçimini kaldır';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9169,10 +9169,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get agreeAndContinue => 'Прийняти та продовжити';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Почати голосовий запис';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Почати запис дзвінка';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9202,44 +9202,44 @@ class AppLocalizationsUk extends AppLocalizations {
   String get phoneCallSubtitle => 'Запис дзвінка з живою транскрипцією';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Шукати дії';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Вибрати кілька';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Експортувати $count елемент(ів) до…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Експорт…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Експортовано $count до $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Експортовано $success з $total до $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Показати завершені';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Приховати завершені';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Вибрати все';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Підключіть додаток завдань у Налаштуваннях для експорту';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Підключити';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Зняти виділення з усіх';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9172,10 +9172,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get agreeAndContinue => 'اتفاق اور جاری رکھیں';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'وائس ریکارڈنگ شروع کریں';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'کال ریکارڈنگ شروع کریں';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9205,44 +9205,44 @@ class AppLocalizationsUr extends AppLocalizations {
   String get phoneCallSubtitle => 'لائیو ٹرانسکرپشن کے ساتھ کال ریکارڈ کریں';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'ایکشن آئٹمز تلاش کریں';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'متعدد منتخب کریں';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '$count آئٹم ایکسپورٹ کریں…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'ایکسپورٹ ہو رہا ہے…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '$count کو $platform میں ایکسپورٹ کیا گیا';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '$total میں سے $success کو $platform میں ایکسپورٹ کیا گیا';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'مکمل شدہ دکھائیں';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'مکمل شدہ چھپائیں';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'سب منتخب کریں';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'ایکسپورٹ کے لیے ترتیبات میں ٹاسک ایپ جوڑیں';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'جوڑیں';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'تمام کا انتخاب ختم کریں';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9155,10 +9155,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get agreeAndContinue => 'Đồng ý và tiếp tục';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => 'Bắt đầu ghi âm giọng nói';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => 'Bắt đầu ghi âm cuộc gọi';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9188,44 +9188,44 @@ class AppLocalizationsVi extends AppLocalizations {
   String get phoneCallSubtitle => 'Ghi âm cuộc gọi với phiên âm trực tiếp';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => 'Tìm kiếm mục hành động';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => 'Chọn nhiều';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return 'Xuất $count mục sang…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => 'Đang xuất…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return 'Đã xuất $count sang $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return 'Đã xuất $success trong $total sang $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => 'Hiện đã hoàn thành';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => 'Ẩn đã hoàn thành';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => 'Chọn tất cả';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => 'Kết nối ứng dụng tác vụ trong Cài đặt để xuất';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => 'Kết nối';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => 'Bỏ chọn tất cả';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8992,10 +8992,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get agreeAndContinue => '同意并继续';
 
   @override
-  String get startVoiceRecording => 'Start voice recording';
+  String get startVoiceRecording => '开始语音录音';
 
   @override
-  String get startCallRecording => 'Start call recording';
+  String get startCallRecording => '开始通话录音';
 
   @override
   String get mindMap => 'Mind Map';
@@ -9025,44 +9025,44 @@ class AppLocalizationsZh extends AppLocalizations {
   String get phoneCallSubtitle => '录制带实时转录的通话';
 
   @override
-  String get searchActionItems => 'Search action items';
+  String get searchActionItems => '搜索操作项';
 
   @override
-  String get selectActionItems => 'Select multiple';
+  String get selectActionItems => '多选';
 
   @override
   String chooseExportDestination(int count) {
-    return 'Export $count item(s) to…';
+    return '导出 $count 个项目到…';
   }
 
   @override
-  String get bulkExportInProgress => 'Exporting…';
+  String get bulkExportInProgress => '正在导出…';
 
   @override
   String bulkExportSuccess(int count, String platform) {
-    return 'Exported $count to $platform';
+    return '已将 $count 项导出到 $platform';
   }
 
   @override
   String bulkExportPartial(int success, int total, String platform) {
-    return 'Exported $success of $total to $platform';
+    return '已将 $success/$total 导出到 $platform';
   }
 
   @override
-  String get showCompletedTasks => 'Show completed';
+  String get showCompletedTasks => '显示已完成';
 
   @override
-  String get hideCompletedTasks => 'Hide completed';
+  String get hideCompletedTasks => '隐藏已完成';
 
   @override
-  String get selectAllTasksMenu => 'Select all';
+  String get selectAllTasksMenu => '全选';
 
   @override
-  String get connectTaskAppToExport => 'Connect a task app in Settings to export';
+  String get connectTaskAppToExport => '在设置中连接任务应用以导出';
 
   @override
-  String get connectAction => 'Connect';
+  String get connectAction => '连接';
 
   @override
-  String get deselectAllTasksMenu => 'Deselect all';
+  String get deselectAllTasksMenu => '取消全选';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Įrašyti telefono mikrofonu",
   "recordWithPhoneMicSubtitle": "Užfiksuokite garsą aplink jus",
   "phoneCall": "Telefono skambutis",
-  "phoneCallSubtitle": "Įrašykite skambutį su tiesiogine transkripcija"
+  "phoneCallSubtitle": "Įrašykite skambutį su tiesiogine transkripcija",
+  "bulkExportInProgress": "Eksportuojama…",
+  "bulkExportPartial": "Eksportuota {success} iš {total} į {platform}",
+  "bulkExportSuccess": "Eksportuota {count} į {platform}",
+  "chooseExportDestination": "Eksportuoti {count} elementą(-us) į…",
+  "connectAction": "Prijungti",
+  "connectTaskAppToExport": "Prijunkite užduočių programą Nustatymuose, kad galėtumėte eksportuoti",
+  "deselectAllTasksMenu": "Atžymėti viską",
+  "hideCompletedTasks": "Slėpti užbaigtas",
+  "searchActionItems": "Ieškoti veiksmų elementų",
+  "selectActionItems": "Pasirinkti kelis",
+  "selectAllTasksMenu": "Pasirinkti viską",
+  "showCompletedTasks": "Rodyti užbaigtas",
+  "startCallRecording": "Pradėti skambučio įrašymą",
+  "startVoiceRecording": "Pradėti balso įrašymą"
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Ierakstīt ar tālruņa mikrofonu",
   "recordWithPhoneMicSubtitle": "Tveriet skaņu sev apkārt",
   "phoneCall": "Telefona zvans",
-  "phoneCallSubtitle": "Ierakstiet zvanu ar tiešraides transkripciju"
+  "phoneCallSubtitle": "Ierakstiet zvanu ar tiešraides transkripciju",
+  "bulkExportInProgress": "Eksportē…",
+  "bulkExportPartial": "Eksportēti {success} no {total} uz {platform}",
+  "bulkExportSuccess": "Eksportēti {count} uz {platform}",
+  "chooseExportDestination": "Eksportēt {count} vienību(-as) uz…",
+  "connectAction": "Savienot",
+  "connectTaskAppToExport": "Savienojiet uzdevumu lietotni Iestatījumos, lai eksportētu",
+  "deselectAllTasksMenu": "Noņemt visu atlasi",
+  "hideCompletedTasks": "Slēpt pabeigtās",
+  "searchActionItems": "Meklēt darbības vienumus",
+  "selectActionItems": "Atlasīt vairākus",
+  "selectAllTasksMenu": "Atlasīt visus",
+  "showCompletedTasks": "Rādīt pabeigtās",
+  "startCallRecording": "Sākt zvana ierakstīšanu",
+  "startVoiceRecording": "Sākt balss ierakstīšanu"
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "Снимај со микрофон на телефонот",
   "recordWithPhoneMicSubtitle": "Снимајте звук околу вас",
   "phoneCall": "Телефонски повик",
-  "phoneCallSubtitle": "Снимајте повик со транскрипција во живо"
+  "phoneCallSubtitle": "Снимајте повик со транскрипција во живо",
+  "bulkExportInProgress": "Извезување…",
+  "bulkExportPartial": "Извезени {success} од {total} во {platform}",
+  "bulkExportSuccess": "Извезени {count} во {platform}",
+  "chooseExportDestination": "Извези {count} ставка/и во…",
+  "connectAction": "Поврзи",
+  "connectTaskAppToExport": "Поврзете апликација за задачи во Поставки за извоз",
+  "deselectAllTasksMenu": "Одселектирај ги сите",
+  "hideCompletedTasks": "Сокриј завршени",
+  "searchActionItems": "Пребарај акциски ставки",
+  "selectActionItems": "Избери повеќе",
+  "selectAllTasksMenu": "Избери ги сите",
+  "showCompletedTasks": "Прикажи завршени",
+  "startCallRecording": "Започни снимање повик",
+  "startVoiceRecording": "Започни гласовно снимање"
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "फोन माइकने रेकॉर्ड करा",
   "recordWithPhoneMicSubtitle": "तुमच्या आजूबाजूचा ऑडिओ कॅप्चर करा",
   "phoneCall": "फोन कॉल",
-  "phoneCallSubtitle": "लाइव्ह ट्रान्स्क्रिप्शनसह कॉल रेकॉर्ड करा"
+  "phoneCallSubtitle": "लाइव्ह ट्रान्स्क्रिप्शनसह कॉल रेकॉर्ड करा",
+  "bulkExportInProgress": "निर्यात होत आहे…",
+  "bulkExportPartial": "{total} पैकी {success} {platform} वर निर्यात केले",
+  "bulkExportSuccess": "{count} {platform} वर निर्यात केले",
+  "chooseExportDestination": "{count} आयटम निर्यात करा…",
+  "connectAction": "जोडा",
+  "connectTaskAppToExport": "निर्यात करण्यासाठी सेटिंग्जमध्ये टास्क ॲप जोडा",
+  "deselectAllTasksMenu": "सर्वांची निवड रद्द करा",
+  "hideCompletedTasks": "पूर्ण झालेले लपवा",
+  "searchActionItems": "कृती आयटम शोधा",
+  "selectActionItems": "अनेक निवडा",
+  "selectAllTasksMenu": "सर्व निवडा",
+  "showCompletedTasks": "पूर्ण झालेले दाखवा",
+  "startCallRecording": "कॉल रेकॉर्डिंग सुरू करा",
+  "startVoiceRecording": "व्हॉइस रेकॉर्डिंग सुरू करा"
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Rakam dengan mikrofon telefon",
   "recordWithPhoneMicSubtitle": "Tangkap audio di sekeliling anda",
   "phoneCall": "Panggilan telefon",
-  "phoneCallSubtitle": "Rakam panggilan dengan transkripsi langsung"
+  "phoneCallSubtitle": "Rakam panggilan dengan transkripsi langsung",
+  "bulkExportInProgress": "Mengeksport…",
+  "bulkExportPartial": "Dieksport {success} daripada {total} ke {platform}",
+  "bulkExportSuccess": "Dieksport {count} ke {platform}",
+  "chooseExportDestination": "Eksport {count} item ke…",
+  "connectAction": "Sambung",
+  "connectTaskAppToExport": "Sambungkan aplikasi tugas dalam Tetapan untuk mengeksport",
+  "deselectAllTasksMenu": "Nyahpilih semua",
+  "hideCompletedTasks": "Sembunyikan selesai",
+  "searchActionItems": "Cari item tindakan",
+  "selectActionItems": "Pilih beberapa",
+  "selectAllTasksMenu": "Pilih semua",
+  "showCompletedTasks": "Tunjukkan selesai",
+  "startCallRecording": "Mula rakaman panggilan",
+  "startVoiceRecording": "Mula rakaman suara"
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Opnemen met telefoonmicrofoon",
   "recordWithPhoneMicSubtitle": "Leg het geluid om je heen vast",
   "phoneCall": "Telefoongesprek",
-  "phoneCallSubtitle": "Neem een gesprek op met live transcriptie"
+  "phoneCallSubtitle": "Neem een gesprek op met live transcriptie",
+  "bulkExportInProgress": "Exporteren…",
+  "bulkExportPartial": "{success} van {total} geëxporteerd naar {platform}",
+  "bulkExportSuccess": "{count} geëxporteerd naar {platform}",
+  "chooseExportDestination": "{count} item(s) exporteren naar…",
+  "connectAction": "Verbinden",
+  "connectTaskAppToExport": "Verbind een taken-app in Instellingen om te exporteren",
+  "deselectAllTasksMenu": "Alles deselecteren",
+  "hideCompletedTasks": "Voltooide verbergen",
+  "searchActionItems": "Actiepunten zoeken",
+  "selectActionItems": "Meerdere selecteren",
+  "selectAllTasksMenu": "Alles selecteren",
+  "showCompletedTasks": "Voltooide tonen",
+  "startCallRecording": "Gespreksopname starten",
+  "startVoiceRecording": "Spraakopname starten"
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Ta opp med telefonmikrofon",
   "recordWithPhoneMicSubtitle": "Fang opp lyden rundt deg",
   "phoneCall": "Telefonsamtale",
-  "phoneCallSubtitle": "Ta opp en samtale med direkte transkripsjon"
+  "phoneCallSubtitle": "Ta opp en samtale med direkte transkripsjon",
+  "bulkExportInProgress": "Eksporterer…",
+  "bulkExportPartial": "Eksporterte {success} av {total} til {platform}",
+  "bulkExportSuccess": "Eksporterte {count} til {platform}",
+  "chooseExportDestination": "Eksporter {count} element(er) til…",
+  "connectAction": "Koble til",
+  "connectTaskAppToExport": "Koble til en oppgaveapp i Innstillinger for å eksportere",
+  "deselectAllTasksMenu": "Fjern alle valg",
+  "hideCompletedTasks": "Skjul fullførte",
+  "searchActionItems": "Søk i handlingspunkter",
+  "selectActionItems": "Velg flere",
+  "selectAllTasksMenu": "Velg alle",
+  "showCompletedTasks": "Vis fullførte",
+  "startCallRecording": "Start samtaleopptak",
+  "startVoiceRecording": "Start stemmeopptak"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3034,5 +3034,19 @@
   "recordWithPhoneMic": "Nagrywaj mikrofonem telefonu",
   "recordWithPhoneMicSubtitle": "Nagrywaj dźwięk wokół ciebie",
   "phoneCall": "Połączenie telefoniczne",
-  "phoneCallSubtitle": "Nagrywaj rozmowę z transkrypcją na żywo"
+  "phoneCallSubtitle": "Nagrywaj rozmowę z transkrypcją na żywo",
+  "bulkExportInProgress": "Eksportowanie…",
+  "bulkExportPartial": "Wyeksportowano {success} z {total} do {platform}",
+  "bulkExportSuccess": "Wyeksportowano {count} do {platform}",
+  "chooseExportDestination": "Eksportuj {count} element(ów) do…",
+  "connectAction": "Połącz",
+  "connectTaskAppToExport": "Połącz aplikację zadań w Ustawieniach, aby eksportować",
+  "deselectAllTasksMenu": "Odznacz wszystkie",
+  "hideCompletedTasks": "Ukryj ukończone",
+  "searchActionItems": "Szukaj pozycji działań",
+  "selectActionItems": "Zaznacz wiele",
+  "selectAllTasksMenu": "Zaznacz wszystkie",
+  "showCompletedTasks": "Pokaż ukończone",
+  "startCallRecording": "Rozpocznij nagrywanie rozmowy",
+  "startVoiceRecording": "Rozpocznij nagrywanie głosu"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3035,5 +3035,19 @@
   "recordWithPhoneMic": "Gravar com o microfone do telefone",
   "recordWithPhoneMicSubtitle": "Capture o áudio ao seu redor",
   "phoneCall": "Chamada telefônica",
-  "phoneCallSubtitle": "Grave uma chamada com transcrição ao vivo"
+  "phoneCallSubtitle": "Grave uma chamada com transcrição ao vivo",
+  "bulkExportInProgress": "Exportando…",
+  "bulkExportPartial": "Exportados {success} de {total} para {platform}",
+  "bulkExportSuccess": "Exportados {count} para {platform}",
+  "chooseExportDestination": "Exportar {count} item(ns) para…",
+  "connectAction": "Conectar",
+  "connectTaskAppToExport": "Conecte um aplicativo de tarefas nas Configurações para exportar",
+  "deselectAllTasksMenu": "Desmarcar todos",
+  "hideCompletedTasks": "Ocultar concluídas",
+  "searchActionItems": "Pesquisar itens de ação",
+  "selectActionItems": "Selecionar vários",
+  "selectAllTasksMenu": "Selecionar todos",
+  "showCompletedTasks": "Mostrar concluídas",
+  "startCallRecording": "Iniciar gravação de chamada",
+  "startVoiceRecording": "Iniciar gravação de voz"
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Înregistrează cu microfonul telefonului",
   "recordWithPhoneMicSubtitle": "Capturează sunetul din jurul tău",
   "phoneCall": "Apel telefonic",
-  "phoneCallSubtitle": "Înregistrează un apel cu transcriere în direct"
+  "phoneCallSubtitle": "Înregistrează un apel cu transcriere în direct",
+  "bulkExportInProgress": "Se exportă…",
+  "bulkExportPartial": "Exportate {success} din {total} în {platform}",
+  "bulkExportSuccess": "Exportate {count} în {platform}",
+  "chooseExportDestination": "Exportă {count} element(e) în…",
+  "connectAction": "Conectare",
+  "connectTaskAppToExport": "Conectați o aplicație de sarcini în Setări pentru a exporta",
+  "deselectAllTasksMenu": "Deselectați tot",
+  "hideCompletedTasks": "Ascundeți finalizate",
+  "searchActionItems": "Căutați elemente de acțiune",
+  "selectActionItems": "Selectare multiplă",
+  "selectAllTasksMenu": "Selectați tot",
+  "showCompletedTasks": "Afișați finalizate",
+  "startCallRecording": "Porniți înregistrarea apelului",
+  "startVoiceRecording": "Porniți înregistrarea vocală"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3034,5 +3034,19 @@
   "recordWithPhoneMic": "Запись микрофоном телефона",
   "recordWithPhoneMicSubtitle": "Запишите звук вокруг вас",
   "phoneCall": "Телефонный звонок",
-  "phoneCallSubtitle": "Запись звонка с транскрипцией в реальном времени"
+  "phoneCallSubtitle": "Запись звонка с транскрипцией в реальном времени",
+  "bulkExportInProgress": "Экспорт…",
+  "bulkExportPartial": "Экспортировано {success} из {total} в {platform}",
+  "bulkExportSuccess": "Экспортировано {count} в {platform}",
+  "chooseExportDestination": "Экспортировать {count} элемент(ов) в…",
+  "connectAction": "Подключить",
+  "connectTaskAppToExport": "Подключите приложение задач в Настройках для экспорта",
+  "deselectAllTasksMenu": "Снять выделение со всех",
+  "hideCompletedTasks": "Скрыть завершённые",
+  "searchActionItems": "Поиск действий",
+  "selectActionItems": "Выбрать несколько",
+  "selectAllTasksMenu": "Выбрать все",
+  "showCompletedTasks": "Показать завершённые",
+  "startCallRecording": "Начать запись звонка",
+  "startVoiceRecording": "Начать голосовую запись"
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3004,5 +3004,19 @@
   "recordWithPhoneMic": "Nahrať mikrofónom telefónu",
   "recordWithPhoneMicSubtitle": "Zachyťte zvuk okolo vás",
   "phoneCall": "Telefonický hovor",
-  "phoneCallSubtitle": "Nahrávajte hovor so živým prepisom"
+  "phoneCallSubtitle": "Nahrávajte hovor so živým prepisom",
+  "bulkExportInProgress": "Exportovanie…",
+  "bulkExportPartial": "Exportovaných {success} z {total} do {platform}",
+  "bulkExportSuccess": "Exportovaných {count} do {platform}",
+  "chooseExportDestination": "Exportovať {count} položku/iek do…",
+  "connectAction": "Pripojiť",
+  "connectTaskAppToExport": "Pripojte aplikáciu úloh v Nastaveniach na export",
+  "deselectAllTasksMenu": "Zrušiť výber všetkých",
+  "hideCompletedTasks": "Skryť dokončené",
+  "searchActionItems": "Hľadať akčné položky",
+  "selectActionItems": "Vybrať viacero",
+  "selectAllTasksMenu": "Vybrať všetko",
+  "showCompletedTasks": "Zobraziť dokončené",
+  "startCallRecording": "Spustiť nahrávanie hovoru",
+  "startVoiceRecording": "Spustiť hlasový záznam"
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "Snemaj s telefonskim mikrofonom",
   "recordWithPhoneMicSubtitle": "Posnemite zvok okoli sebe",
   "phoneCall": "Telefonski klic",
-  "phoneCallSubtitle": "Posnemite klic s prepisom v živo"
+  "phoneCallSubtitle": "Posnemite klic s prepisom v živo",
+  "bulkExportInProgress": "Izvažanje…",
+  "bulkExportPartial": "Izvoženo {success} od {total} v {platform}",
+  "bulkExportSuccess": "Izvoženo {count} v {platform}",
+  "chooseExportDestination": "Izvozi {count} element(ov) v…",
+  "connectAction": "Poveži",
+  "connectTaskAppToExport": "Povežite aplikacijo za naloge v Nastavitvah za izvoz",
+  "deselectAllTasksMenu": "Prekliči izbor vseh",
+  "hideCompletedTasks": "Skrij dokončane",
+  "searchActionItems": "Iskanje akcijskih elementov",
+  "selectActionItems": "Izberi več",
+  "selectAllTasksMenu": "Izberi vse",
+  "showCompletedTasks": "Prikaži dokončane",
+  "startCallRecording": "Začni snemanje klica",
+  "startVoiceRecording": "Začni glasovno snemanje"
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "Снимај микрофоном телефона",
   "recordWithPhoneMicSubtitle": "Снимите звук око вас",
   "phoneCall": "Телефонски позив",
-  "phoneCallSubtitle": "Снимајте позив са транскрипцијом уживо"
+  "phoneCallSubtitle": "Снимајте позив са транскрипцијом уживо",
+  "bulkExportInProgress": "Извоз…",
+  "bulkExportPartial": "Извезено {success} од {total} у {platform}",
+  "bulkExportSuccess": "Извезено {count} у {platform}",
+  "chooseExportDestination": "Извези {count} ставку/и у…",
+  "connectAction": "Повежи",
+  "connectTaskAppToExport": "Повежите апликацију за задатке у Подешавањима за извоз",
+  "deselectAllTasksMenu": "Поништи избор свих",
+  "hideCompletedTasks": "Сакриј завршене",
+  "searchActionItems": "Претражи акционе ставке",
+  "selectActionItems": "Изабери више",
+  "selectAllTasksMenu": "Изабери све",
+  "showCompletedTasks": "Прикажи завршене",
+  "startCallRecording": "Покрени снимање позива",
+  "startVoiceRecording": "Покрени гласовно снимање"
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Spela in med telefonmikrofon",
   "recordWithPhoneMicSubtitle": "Fånga ljudet runt dig",
   "phoneCall": "Telefonsamtal",
-  "phoneCallSubtitle": "Spela in samtal med live-transkribering"
+  "phoneCallSubtitle": "Spela in samtal med live-transkribering",
+  "bulkExportInProgress": "Exporterar…",
+  "bulkExportPartial": "Exporterade {success} av {total} till {platform}",
+  "bulkExportSuccess": "Exporterade {count} till {platform}",
+  "chooseExportDestination": "Exportera {count} objekt till…",
+  "connectAction": "Anslut",
+  "connectTaskAppToExport": "Anslut en uppgiftsapp i Inställningar för att exportera",
+  "deselectAllTasksMenu": "Avmarkera alla",
+  "hideCompletedTasks": "Dölj slutförda",
+  "searchActionItems": "Sök åtgärdspunkter",
+  "selectActionItems": "Välj flera",
+  "selectAllTasksMenu": "Välj alla",
+  "showCompletedTasks": "Visa slutförda",
+  "startCallRecording": "Starta samtalsinspelning",
+  "startVoiceRecording": "Starta röstinspelning"
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "போன் மைக்கில் பதிவு செய்யவும்",
   "recordWithPhoneMicSubtitle": "உங்களைச் சுற்றியுள்ள ஒலியைப் பதிவு செய்யவும்",
   "phoneCall": "தொலைபேசி அழைப்பு",
-  "phoneCallSubtitle": "நேரடி படியெடுத்தலுடன் அழைப்பைப் பதிவு செய்யவும்"
+  "phoneCallSubtitle": "நேரடி படியெடுத்தலுடன் அழைப்பைப் பதிவு செய்யவும்",
+  "bulkExportInProgress": "ஏற்றுமதி செய்கிறது…",
+  "bulkExportPartial": "{total} இல் {success} ஐ {platform} க்கு ஏற்றுமதி செய்யப்பட்டது",
+  "bulkExportSuccess": "{count} ஐ {platform} க்கு ஏற்றுமதி செய்யப்பட்டது",
+  "chooseExportDestination": "{count} உருப்படி(களை) ஏற்றுமதி செய்…",
+  "connectAction": "இணைக்கவும்",
+  "connectTaskAppToExport": "ஏற்றுமதி செய்ய அமைப்புகளில் ஒரு பணி செயலியை இணைக்கவும்",
+  "deselectAllTasksMenu": "அனைத்தையும் தேர்வு நீக்கு",
+  "hideCompletedTasks": "முடிந்தவற்றை மறை",
+  "searchActionItems": "செயல் உருப்படிகளைத் தேடு",
+  "selectActionItems": "பலவற்றைத் தேர்ந்தெடு",
+  "selectAllTasksMenu": "அனைத்தையும் தேர்ந்தெடு",
+  "showCompletedTasks": "முடிந்தவற்றைக் காட்டு",
+  "startCallRecording": "அழைப்பு பதிவைத் தொடங்கு",
+  "startVoiceRecording": "குரல் பதிவைத் தொடங்கு"
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "ఫోన్ మైక్‌తో రికార్డ్ చేయండి",
   "recordWithPhoneMicSubtitle": "మీ చుట్టూ ఉన్న ఆడియోను క్యాప్చర్ చేయండి",
   "phoneCall": "ఫోన్ కాల్",
-  "phoneCallSubtitle": "లైవ్ ట్రాన్స్‌క్రిప్షన్‌తో కాల్‌ను రికార్డ్ చేయండి"
+  "phoneCallSubtitle": "లైవ్ ట్రాన్స్‌క్రిప్షన్‌తో కాల్‌ను రికార్డ్ చేయండి",
+  "bulkExportInProgress": "ఎగుమతి చేస్తోంది…",
+  "bulkExportPartial": "{total} లో {success} ని {platform} కు ఎగుమతి చేయబడింది",
+  "bulkExportSuccess": "{count} ని {platform} కు ఎగుమతి చేయబడింది",
+  "chooseExportDestination": "{count} అంశం(ాలను) ఎగుమతి చేయండి…",
+  "connectAction": "కనెక్ట్ చేయండి",
+  "connectTaskAppToExport": "ఎగుమతి చేయడానికి సెట్టింగ్‌లలో టాస్క్ యాప్‌ను కనెక్ట్ చేయండి",
+  "deselectAllTasksMenu": "అన్ని ఎంపికలు తొలగించు",
+  "hideCompletedTasks": "పూర్తయినవి దాచు",
+  "searchActionItems": "చర్య అంశాలను వెతకండి",
+  "selectActionItems": "బహుళ ఎంపిక",
+  "selectAllTasksMenu": "అన్నీ ఎంచుకోండి",
+  "showCompletedTasks": "పూర్తయినవి చూపించు",
+  "startCallRecording": "కాల్ రికార్డింగ్ ప్రారంభించండి",
+  "startVoiceRecording": "వాయిస్ రికార్డింగ్ ప్రారంభించండి"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "บันทึกด้วยไมค์โทรศัพท์",
   "recordWithPhoneMicSubtitle": "บันทึกเสียงรอบตัวคุณ",
   "phoneCall": "การโทรศัพท์",
-  "phoneCallSubtitle": "บันทึกการโทรพร้อมถอดเสียงสด"
+  "phoneCallSubtitle": "บันทึกการโทรพร้อมถอดเสียงสด",
+  "bulkExportInProgress": "กำลังส่งออก…",
+  "bulkExportPartial": "ส่งออกแล้ว {success} จาก {total} ไปยัง {platform}",
+  "bulkExportSuccess": "ส่งออกแล้ว {count} ไปยัง {platform}",
+  "chooseExportDestination": "ส่งออก {count} รายการไปยัง…",
+  "connectAction": "เชื่อมต่อ",
+  "connectTaskAppToExport": "เชื่อมต่อแอปงานในการตั้งค่าเพื่อส่งออก",
+  "deselectAllTasksMenu": "ยกเลิกเลือกทั้งหมด",
+  "hideCompletedTasks": "ซ่อนที่เสร็จแล้ว",
+  "searchActionItems": "ค้นหารายการดำเนินการ",
+  "selectActionItems": "เลือกหลายรายการ",
+  "selectAllTasksMenu": "เลือกทั้งหมด",
+  "showCompletedTasks": "แสดงที่เสร็จแล้ว",
+  "startCallRecording": "เริ่มบันทึกการโทร",
+  "startVoiceRecording": "เริ่มบันทึกเสียง"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "Mag-record gamit ang mikropono ng telepono",
   "recordWithPhoneMicSubtitle": "Kunan ang audio sa paligid mo",
   "phoneCall": "Tawag sa telepono",
-  "phoneCallSubtitle": "Mag-record ng tawag na may live na transkripsyon"
+  "phoneCallSubtitle": "Mag-record ng tawag na may live na transkripsyon",
+  "bulkExportInProgress": "Nag-e-export…",
+  "bulkExportPartial": "Na-export ang {success} sa {total} sa {platform}",
+  "bulkExportSuccess": "Na-export ang {count} sa {platform}",
+  "chooseExportDestination": "I-export ang {count} item sa…",
+  "connectAction": "Ikonekta",
+  "connectTaskAppToExport": "Ikonekta ang isang task app sa Settings para mag-export",
+  "deselectAllTasksMenu": "I-deselect lahat",
+  "hideCompletedTasks": "Itago ang tapos na",
+  "searchActionItems": "Maghanap ng mga action item",
+  "selectActionItems": "Pumili ng marami",
+  "selectAllTasksMenu": "Piliin lahat",
+  "showCompletedTasks": "Ipakita ang tapos na",
+  "startCallRecording": "Simulan ang pag-record ng tawag",
+  "startVoiceRecording": "Simulan ang voice recording"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3034,5 +3034,19 @@
   "recordWithPhoneMic": "Telefon mikrofonuyla kaydet",
   "recordWithPhoneMicSubtitle": "Etrafınızdaki sesi yakalayın",
   "phoneCall": "Telefon araması",
-  "phoneCallSubtitle": "Canlı transkripsiyonla bir aramayı kaydedin"
+  "phoneCallSubtitle": "Canlı transkripsiyonla bir aramayı kaydedin",
+  "bulkExportInProgress": "Dışa aktarılıyor…",
+  "bulkExportPartial": "{total} öğeden {success} tanesi {platform} uygulamasına aktarıldı",
+  "bulkExportSuccess": "{count} öğe {platform} uygulamasına aktarıldı",
+  "chooseExportDestination": "{count} öğeyi dışa aktar…",
+  "connectAction": "Bağla",
+  "connectTaskAppToExport": "Dışa aktarmak için Ayarlar'da bir görev uygulaması bağlayın",
+  "deselectAllTasksMenu": "Tümünün seçimini kaldır",
+  "hideCompletedTasks": "Tamamlananları gizle",
+  "searchActionItems": "Eylem öğelerini ara",
+  "selectActionItems": "Birden fazla seç",
+  "selectAllTasksMenu": "Tümünü seç",
+  "showCompletedTasks": "Tamamlananları göster",
+  "startCallRecording": "Arama kaydını başlat",
+  "startVoiceRecording": "Ses kaydını başlat"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2999,5 +2999,19 @@
   "recordWithPhoneMic": "Запис мікрофоном телефона",
   "recordWithPhoneMicSubtitle": "Записуйте звук навколо вас",
   "phoneCall": "Телефонний дзвінок",
-  "phoneCallSubtitle": "Запис дзвінка з живою транскрипцією"
+  "phoneCallSubtitle": "Запис дзвінка з живою транскрипцією",
+  "bulkExportInProgress": "Експорт…",
+  "bulkExportPartial": "Експортовано {success} з {total} до {platform}",
+  "bulkExportSuccess": "Експортовано {count} до {platform}",
+  "chooseExportDestination": "Експортувати {count} елемент(ів) до…",
+  "connectAction": "Підключити",
+  "connectTaskAppToExport": "Підключіть додаток завдань у Налаштуваннях для експорту",
+  "deselectAllTasksMenu": "Зняти виділення з усіх",
+  "hideCompletedTasks": "Приховати завершені",
+  "searchActionItems": "Шукати дії",
+  "selectActionItems": "Вибрати кілька",
+  "selectAllTasksMenu": "Вибрати все",
+  "showCompletedTasks": "Показати завершені",
+  "startCallRecording": "Почати запис дзвінка",
+  "startVoiceRecording": "Почати голосовий запис"
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10707,5 +10707,19 @@
   "recordWithPhoneMic": "فون مائیک سے ریکارڈ کریں",
   "recordWithPhoneMicSubtitle": "اپنے ارد گرد کی آواز ریکارڈ کریں",
   "phoneCall": "فون کال",
-  "phoneCallSubtitle": "لائیو ٹرانسکرپشن کے ساتھ کال ریکارڈ کریں"
+  "phoneCallSubtitle": "لائیو ٹرانسکرپشن کے ساتھ کال ریکارڈ کریں",
+  "bulkExportInProgress": "ایکسپورٹ ہو رہا ہے…",
+  "bulkExportPartial": "{total} میں سے {success} کو {platform} میں ایکسپورٹ کیا گیا",
+  "bulkExportSuccess": "{count} کو {platform} میں ایکسپورٹ کیا گیا",
+  "chooseExportDestination": "{count} آئٹم ایکسپورٹ کریں…",
+  "connectAction": "جوڑیں",
+  "connectTaskAppToExport": "ایکسپورٹ کے لیے ترتیبات میں ٹاسک ایپ جوڑیں",
+  "deselectAllTasksMenu": "تمام کا انتخاب ختم کریں",
+  "hideCompletedTasks": "مکمل شدہ چھپائیں",
+  "searchActionItems": "ایکشن آئٹمز تلاش کریں",
+  "selectActionItems": "متعدد منتخب کریں",
+  "selectAllTasksMenu": "سب منتخب کریں",
+  "showCompletedTasks": "مکمل شدہ دکھائیں",
+  "startCallRecording": "کال ریکارڈنگ شروع کریں",
+  "startVoiceRecording": "وائس ریکارڈنگ شروع کریں"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3004,5 +3004,19 @@
   "recordWithPhoneMic": "Ghi âm bằng micro điện thoại",
   "recordWithPhoneMicSubtitle": "Ghi lại âm thanh xung quanh bạn",
   "phoneCall": "Cuộc gọi điện thoại",
-  "phoneCallSubtitle": "Ghi âm cuộc gọi với phiên âm trực tiếp"
+  "phoneCallSubtitle": "Ghi âm cuộc gọi với phiên âm trực tiếp",
+  "bulkExportInProgress": "Đang xuất…",
+  "bulkExportPartial": "Đã xuất {success} trong {total} sang {platform}",
+  "bulkExportSuccess": "Đã xuất {count} sang {platform}",
+  "chooseExportDestination": "Xuất {count} mục sang…",
+  "connectAction": "Kết nối",
+  "connectTaskAppToExport": "Kết nối ứng dụng tác vụ trong Cài đặt để xuất",
+  "deselectAllTasksMenu": "Bỏ chọn tất cả",
+  "hideCompletedTasks": "Ẩn đã hoàn thành",
+  "searchActionItems": "Tìm kiếm mục hành động",
+  "selectActionItems": "Chọn nhiều",
+  "selectAllTasksMenu": "Chọn tất cả",
+  "showCompletedTasks": "Hiện đã hoàn thành",
+  "startCallRecording": "Bắt đầu ghi âm cuộc gọi",
+  "startVoiceRecording": "Bắt đầu ghi âm giọng nói"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3021,5 +3021,19 @@
   "recordWithPhoneMic": "用手机麦克风录音",
   "recordWithPhoneMicSubtitle": "捕捉您周围的声音",
   "phoneCall": "电话",
-  "phoneCallSubtitle": "录制带实时转录的通话"
+  "phoneCallSubtitle": "录制带实时转录的通话",
+  "bulkExportInProgress": "正在导出…",
+  "bulkExportPartial": "已将 {success}/{total} 导出到 {platform}",
+  "bulkExportSuccess": "已将 {count} 项导出到 {platform}",
+  "chooseExportDestination": "导出 {count} 个项目到…",
+  "connectAction": "连接",
+  "connectTaskAppToExport": "在设置中连接任务应用以导出",
+  "deselectAllTasksMenu": "取消全选",
+  "hideCompletedTasks": "隐藏已完成",
+  "searchActionItems": "搜索操作项",
+  "selectActionItems": "多选",
+  "selectAllTasksMenu": "全选",
+  "showCompletedTasks": "显示已完成",
+  "startCallRecording": "开始通话录音",
+  "startVoiceRecording": "开始语音录音"
 }


### PR DESCRIPTION
## Summary
- Adds 14 missing translation keys to all 48 non-English ARB locale files
- Resolves `flutter gen-l10n` untranslated message warnings
- Keys added: `bulkExportInProgress`, `bulkExportPartial`, `bulkExportSuccess`, `chooseExportDestination`, `connectAction`, `connectTaskAppToExport`, `deselectAllTasksMenu`, `hideCompletedTasks`, `searchActionItems`, `selectActionItems`, `selectAllTasksMenu`, `showCompletedTasks`, `startCallRecording`, `startVoiceRecording`

## Test plan
- [x] `flutter gen-l10n` passes with zero untranslated warnings
- [x] All 48 locale files validated as valid JSON
- [x] All ICU placeholders (`{success}`, `{total}`, `{platform}`, `{count}`) preserved in every translation
- [ ] Smoke test app in a non-English locale to verify strings render