### PR TITLE
Fix Stripe Connect webhook KeyError for affiliate accounts

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -779,7 +779,7 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
         account = event['data']['object']
         if account['charges_enabled'] and account['details_submitted']:
             # account is fully onboarded
-            uid = account.get('metadata', {}).get('uid')
+            uid = (account.get('metadata') or {}).get('uid')
             if uid and get_default_payment_method(uid) is None:
                 set_default_payment_method(uid, 'stripe')
 

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -779,8 +779,8 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
         account = event['data']['object']
         if account['charges_enabled'] and account['details_submitted']:
             # account is fully onboarded
-            uid = account['metadata']['uid']
-            if get_default_payment_method(uid) is None:
+            uid = account.get('metadata', {}).get('uid')
+            if uid and get_default_payment_method(uid) is None:
                 set_default_payment_method(uid, 'stripe')
 
     # TODO: handle this event to link transfers?


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'uid'` crash in the `/v1/stripe/connect/webhook` handler
- Connect accounts from the affiliates dashboard store `affiliate_id` in metadata, not `uid` — the webhook assumed all accounts have `uid`, crashing on affiliate account updates
- Use safe `.get()` access and skip accounts without `uid` metadata

## Test plan
- [ ] Verify affiliate Connect account `account.updated` events no longer crash
- [ ] Verify omi app Connect accounts still set default payment method on onboarding completion