### PR TITLE
Fix create_app: set uid server-side from authenticated session

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -467,6 +467,7 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
     data['status'] = 'under-review'
     data['name'] = (data.get('name') or '').strip()
     data['id'] = str(ULID())
+    data['uid'] = uid
     if not data.get('author') and not data.get('email'):
         user = get_user_from_uid(uid)
         data['author'] = user.get('display_name', '')


### PR DESCRIPTION
Closes #7055.

## Problem

`POST /v1/apps` (`backend/routers/apps.py:create_app`) never assigned `data['uid'] = uid` server-side. It resolved `uid` from the bearer token via `Depends(auth.get_current_user_uid)` but only used it for author/email lookup and the payment link — `uid` was never written into the dict passed to `add_app_to_db`.

`AppCreate.uid` is `Optional[str] = None`, so validation passed and `model_dump(exclude_unset=True)` dropped the field. The Firestore document landed with no `uid`, and `get_app_details` then 404'd on `not app.approved and app.uid != uid`. Fresh apps were unreachable to their own creator and missing from "My Apps".

The Flutter mobile client populates `'uid': SharedPreferencesUtil().uid` in the request body (e.g. `app/lib/pages/apps/providers/add_app_provider.dart:519`), which had been masking the gap. The Next.js web portal sends only the bearer token in `Authorization` and does not echo `uid` — so the bug surfaced there once `app.omi.me/my-apps/new` became the canonical developer portal.

## Fix

One line in `create_app`, mirroring `create_persona` at line 553:

```python
data['id'] = str(ULID())
data['uid'] = uid
```

Server is now authoritative for identity. The mobile client's pre-set value becomes a no-op (server overwrites with the same authenticated value).

## Test plan

- [ ] On a dev backend, POST `/v1/apps` from a curl call with only `Authorization: Bearer <token>` (no `uid` in `app_data`) — confirm 200 and that the returned `app_id` is reachable via `GET /v1/apps/{app_id}` for the same token.
- [ ] Repeat from the web portal at app.omi.me/my-apps/new — confirm the created app appears under My Apps and the detail page loads.
- [ ] Create from the Flutter app — confirm no regression (the pre-set `uid` should still produce a valid record).
- [ ] Confirm Firestore doc for the new app has the correct `uid` field.

## Out of scope

Backfilling the orphan `plugins_data` documents already created via the web flow (they have no `uid` and remain unreachable). Best handled as a one-off script run by ops; happy to follow up if you want it bundled.