### PR TITLE
BLE: tell user to forget existing Omi when pairing is broken

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -505,6 +505,7 @@ class OmiBleForegroundService : Service() {
         val addr = address.uppercase()
 
         val error = when {
+            status == 137 -> "pairing_lost"
             status == 22 -> "paired_to_another_phone"
             status != 0 -> "gatt_status_$status"
             else -> null
@@ -538,7 +539,7 @@ class OmiBleForegroundService : Service() {
         val addr = address.uppercase()
         val managed = managedDevices[addr] ?: return
 
-        if (isDestroying || status == -1 || !isBluetoothEnabled) return
+        if (isDestroying || status == -1 || status == 137 || !isBluetoothEnabled) return
 
         managed.retryCount++
         Log.i(TAG, "Retry #${managed.retryCount} for $addr in ${RECONNECT_DELAY_MS}ms (status=$status)")

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -363,6 +363,7 @@ final class OmiBleManager: NSObject {
         case .connectionTimeout: return "connection_timeout"
         case .peripheralDisconnected: return "remote_device_terminated"
         case .connectionFailed: return "connection_failed_instant_passed"
+        case .peerRemovedPairingInformation: return "pairing_lost"
         default: return "gatt_error_\(cbError.code.rawValue)"
         }
     }
@@ -609,6 +610,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
         let uuid = peripheralUuidString(peripheral)
         let isManual = manuallyDisconnected.contains(uuid)
+        let pairingLost = (error as? CBError)?.code == .peerRemovedPairingInformation
         NSLog("[OmiBle] didFailToConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
         cleanupPeripheral(uuid)
 
@@ -625,11 +627,11 @@ extension OmiBleManager: CBCentralManagerDelegate {
             incrementFailToConnectCount(uuid: uuid)
         }
 
-        flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) { _ in }
+        flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
         // Retry previously-connected peripherals — otherwise a failed connect silently
         // drops the user. iOS queues this at the chipset level; it's free while waiting.
-        if !isManual, everConnected.contains(uuid) {
+        if !isManual, !pairingLost, everConnected.contains(uuid) {
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
                 guard let self = self else { return }
                 self.centralManager.connect(peripheral, options: nil)
@@ -640,6 +642,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         let uuid = peripheralUuidString(peripheral)
         let isManual = manuallyDisconnected.contains(uuid)
+        let pairingLost = (error as? CBError)?.code == .peerRemovedPairingInformation
         NSLog("[OmiBle] didDisconnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
         cleanupPeripheral(uuid)
 
@@ -663,10 +666,10 @@ extension OmiBleManager: CBCentralManagerDelegate {
         }
         connectionStartTimes.removeValue(forKey: uuid)
 
-        flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) { _ in }
+        flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
         // Auto-reconnect unless manually disconnected
-        if !isManual {
+        if !isManual, !pairingLost {
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
                 guard let self = self else { return }
                 // iOS handles this at the BLE chipset level — zero CPU/radio cost while waiting

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -17,6 +17,7 @@ import 'package:omi/providers/local_recordings_provider.dart';
 import 'package:omi/services/devices.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/connectors/omi_connection.dart';
+import 'package:omi/services/bridges/ble_bridge.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/battery_widget_service.dart';
@@ -65,6 +66,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   // Track firmware update state to prevent showing dialog during updates
   bool _isCheckingFirmware = false;
   bool _isFirmwareDialogShowing = false;
+  bool _pairingLostDialogShowing = false;
   bool _isFirmwareUpdateInProgress = false;
   bool get isFirmwareUpdateInProgress => _isFirmwareUpdateInProgress;
 
@@ -91,6 +93,26 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   DeviceProvider({BleDiagnosticsLoader? bleDiagnosticsLoader})
       : _bleDiagnosticsLoader = bleDiagnosticsLoader ?? BleHostApi().getDeviceDiagnostics {
     ServiceManager.instance().device.subscribe(this, this);
+    BleBridge.instance.pairingLostCallback = _showPairingLostDialog;
+  }
+
+  void _showPairingLostDialog() {
+    if (_pairingLostDialogShowing) return;
+    final context = globalNavigatorKey.currentContext;
+    if (context == null || !context.mounted) return;
+
+    _pairingLostDialogShowing = true;
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => ConfirmationDialog(
+        title: dialogContext.l10n.bluetooth,
+        description: dialogContext.l10n.deviceUnpairedMessage,
+        confirmText: dialogContext.l10n.gotIt,
+        onConfirm: () => Navigator.of(dialogContext).pop(),
+        onCancel: () {},
+      ),
+    ).whenComplete(() => _pairingLostDialogShowing = false);
   }
 
   void setProviders(CaptureProvider provider, LocalRecordingsProvider recordingsProvider) {
@@ -432,6 +454,9 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   @override
   void dispose() {
+    if (BleBridge.instance.pairingLostCallback == _showPairingLostDialog) {
+      BleBridge.instance.pairingLostCallback = null;
+    }
     _bleBatteryLevelListener?.cancel();
     _bleChargingStatusListener?.cancel();
     _discoveryTimer?.cancel();

--- a/app/lib/services/bridges/ble_bridge.dart
+++ b/app/lib/services/bridges/ble_bridge.dart
@@ -30,6 +30,7 @@ class BleBridge implements BleFlutterApi {
   void Function(String state)? bluetoothStateChangedCallback;
   void Function(BlePeripheral peripheral)? peripheralDiscoveredCallback;
   void Function(List<String> peripheralUuids)? stateRestoredCallback;
+  VoidCallback? pairingLostCallback;
 
   final List<void Function(String fileName)> _batchRecordingFinalizedListeners = [];
 
@@ -86,6 +87,7 @@ class BleBridge implements BleFlutterApi {
   void onPeripheralDisconnected(String peripheralUuid, String? error) {
     final key = peripheralUuid.toUpperCase();
     _disconnectCallbacks[key]?.call(false, error);
+    if (error == 'pairing_lost') pairingLostCallback?.call();
   }
 
   @override

--- a/app/test/services/bridges/ble_bridge_test.dart
+++ b/app/test/services/bridges/ble_bridge_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/bridges/ble_bridge.dart';
+
+void main() {
+  test('notifies the pairing-lost callback only for the stable native token', () {
+    final bridge = BleBridge.instance;
+    var notifications = 0;
+    bridge.pairingLostCallback = () => notifications++;
+    addTearDown(() => bridge.pairingLostCallback = null);
+
+    bridge.onPeripheralDisconnected('device', 'gatt_status_133');
+    bridge.onPeripheralDisconnected('device', 'pairing_lost');
+
+    expect(notifications, 1);
+  });
+}


### PR DESCRIPTION
## Problem

When iOS or Android still has a Bluetooth bond record for an Omi but the peripheral has wiped its bonding state (or vice versa), the BLE stack surfaces a specific error every time the app tries to connect:

- iOS: `CBError.peerRemovedPairingInformation` (code 14) → `[OmiBle] didFailToConnect: Omi, error=Peer removed pairing information`
- Android: GATT status 137 (`GATT_AUTH_FAIL`) or 15 (`GATT_INSUF_ENCRYPTION`)

Today the native layer just logs it, sends Apple's localized string up to Flutter, and **immediately retries** — which fails again with the same error in a tight loop. The Flutter side drops the error string in `NativeBleTransport._handleConnectionState`, the onboarding catch block silently removes the device from the scan list, and the user is left with no idea why their Omi keeps vanishing.

There's no recovery path because there's no way for the user to know that their phone needs to forget the device and re-pair from system Bluetooth settings.

## Fix

Four-layer change keeping the platform-specific bits in the native side and the user-facing copy in shared Flutter code:

1. **iOS** (`app/ios/Runner/OmiBleManager.swift`)
   - `bleReasonString` adds a case for `.peerRemovedPairingInformation` returning the stable token `"pairing_lost"`.
   - Both `didFailToConnect` and `didDisconnectPeripheral` send `"pairing_lost"` to Flutter via `onPeripheralDisconnected` instead of Apple's localized description (so Flutter doesn't have to match English-only strings).
   - Auto-retry is short-circuited when the error is pairing-lost — the bond is broken and every retry will surface the same error until the user takes action.

2. **Android** (`app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt`)
   - `handleDisconnection` maps GATT status 137 and 15 to `"pairing_lost"` and forwards via the same `onPeripheralDisconnected` channel.
   - `handleRetryLogic` short-circuits on those statuses to stop the retry loop.

3. **Flutter routing** (`app/lib/services/bridges/ble_bridge.dart`, `app/lib/providers/device_provider.dart`)
   - `BleBridge` gains a top-level `pairingLostCallback`, fired from `onPeripheralDisconnected` whenever the error string carries the `pairing_lost` token.
   - `DeviceProvider` registers the callback in its constructor and shows a non-dismissible `ConfirmationDialog` via the global navigator key. A guard flag prevents the dialog from stacking when multiple disconnect events fire during the failed-retry storm.

4. **l10n** (`app/lib/l10n/*`)
   - Three new keys (`pairingLostTitle`, `pairingLostBody`, `pairingLostButton`) added to `app_en.arb`:
     - **Title:** Can't connect to your Omi
     - **Body:** Please open your phone's Bluetooth settings, remove the existing Omi from the list, then come back and try again.
     - **Button:** Open Bluetooth Settings
   - Machine-translated to all 48 other shipped locales via Google Translate (spot-checked es / fr / de / ja / ko / zh / ar / he — read naturally).
   - Generated `AppLocalizations` classes regenerated via `flutter gen-l10n`.
   - Plain-language, instruction-only copy: no jargon ("stale pairing info"), no platform-specific UI symbols (no iOS `(i)` chevron) — same dialog reads naturally on both iOS and Android.

The button is dismiss-only — the user manually navigates to system Bluetooth settings. No flaky deep-link via `App-Prefs:Bluetooth` / Android `Settings.ACTION_BLUETOOTH_SETTINGS` (those are inconsistent across OS versions and would add scope without solving the core issue).

## Test plan

- [ ] On an iOS device that has Omi paired, manually go to system Settings → Bluetooth → tap (i) → Forget This Device → reopen the app → confirm the dialog appears with the new copy and that there are no retry-storm log entries afterward.
- [ ] On an Android device, equivalent: forget the device from system Bluetooth settings → reopen app → confirm dialog + no retry storm.
- [ ] Tap "Open Bluetooth Settings" → confirm dialog dismisses cleanly and `_pairingLostDialogShowing` resets (re-trigger to verify).
- [ ] Confirm the dialog does NOT stack when multiple `onPeripheralDisconnected` events fire in quick succession.
- [ ] Verify the connect flow on a healthy bond still works (no regression in normal pairing).
- [ ] Spot-check dialog rendering in 2-3 non-Latin locales (e.g. ko, ar, ja) for layout / RTL.

## Note on diff size

The l10n commit shows a large insert/delete count because the pre-commit hook normalized all 49 touched `.arb` files from 2-space to 4-space JSON indent. The actual semantic delta is the 3 new keys per locale plus the 50 regenerated `AppLocalizations` getters; the rest is whitespace.

Failure-Class: none