### PR TITLE
fix(app/ios): Apple Watch connectivity & reliability hardening

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
@@ -792,6 +792,40 @@ class WatchRecorderFlutterAPI(private val binaryMessenger: BinaryMessenger, priv
       } 
     }
   }
+  fun onWatchReachabilityChanged(isReachableArg: Boolean, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchReachabilityChanged$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(isReachableArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+  fun onWatchStateChanged(isPairedArg: Boolean, isWatchAppInstalledArg: Boolean, isReachableArg: Boolean, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchStateChanged$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(isPairedArg, isWatchAppInstalledArg, isReachableArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(PigeonCommunicatorPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
 }
 /**
  * Dart → Native: commands sent from Flutter to the native BLE module.

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -543,6 +543,21 @@ extension AppDelegate: WCSessionDelegate {
             }
             
             switch method {
+            case "startRecording":
+                self.isRecordingActive = true
+                self.audioChunks.removeAll()
+                self.nextExpectedChunkIndex = 0
+
+                DispatchQueue.main.async {
+                    self.flutterWatchAPI?.onRecordingStarted() { result in
+                        switch result {
+                        case .success:
+                            break
+                        case .failure(let error):
+                            print("Recording started (background) sent to Flutter - Error: \(error.message)")
+                        }
+                    }
+                }
             case "sendAudioChunk":
                 self.handleAudioChunk(userInfo)
             case "stopRecording":

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -448,6 +448,24 @@ extension AppDelegate: WCSessionDelegate {
         print("Session Watch Deactivate")
         WCSession.default.activate()
     }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        let isReachable = session.isReachable
+        NSLog("[Watch] reachability changed: \(isReachable)")
+        DispatchQueue.main.async {
+            self.flutterWatchAPI?.onWatchReachabilityChanged(isReachable: isReachable) { _ in }
+        }
+    }
+
+    func sessionWatchStateDidChange(_ session: WCSession) {
+        let isPaired = session.isPaired
+        let isInstalled = session.isWatchAppInstalled
+        let isReachable = session.isReachable
+        NSLog("[Watch] state changed paired=\(isPaired) installed=\(isInstalled) reachable=\(isReachable)")
+        DispatchQueue.main.async {
+            self.flutterWatchAPI?.onWatchStateChanged(isPaired: isPaired, isWatchAppInstalled: isInstalled, isReachable: isReachable) { _ in }
+        }
+    }
     
     // Receive a message from watch (foreground/active)
     func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -425,7 +425,13 @@ func registerPlugins(registry: FlutterPluginRegistry) {
 
 extension AppDelegate: WCSessionDelegate {
     
-    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) { }
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if let error = error {
+            NSLog("[Watch] phone-side WCSession activation failed: \(error.localizedDescription)")
+        } else {
+            NSLog("[Watch] phone-side WCSession activated state=\(activationState.rawValue)")
+        }
+    }
 
     func session(_ session: WCSession, didFinishUserInfoTransfer userInfoTransfer: WCSessionUserInfoTransfer, error: Error?) {
         if let error = error {

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -345,16 +345,28 @@ final class QuickActionsIconPatcher: NSObject {
     }
 
     private func handleAudioChunk(_ message: [String: Any]) {
-        guard isRecordingActive else {
-            print("Ignoring audio chunk - recording not active") // probably started recording with main omi app closed
-            return
-        }
-
         guard let audioChunk = message["audioChunk"] as? Data,
               let chunkIndex = message["chunkIndex"] as? Int,
               let isLast = message["isLast"] as? Bool,
               let sampleRate = message["sampleRate"] as? Double else {
             return
+        }
+
+        if !isRecordingActive {
+            NSLog("[Watch] Audio chunk arrived without prior startRecording — recovering state (chunkIndex=\(chunkIndex))")
+            isRecordingActive = true
+            audioChunks.removeAll()
+            nextExpectedChunkIndex = 0
+            DispatchQueue.main.async {
+                self.flutterWatchAPI?.onRecordingStarted() { result in
+                    switch result {
+                    case .success:
+                        break
+                    case .failure(let error):
+                        print("Recording started (recovered from divergence) sent to Flutter - Error: \(error.message)")
+                    }
+                }
+            }
         }
 
         audioChunks[chunkIndex] = (audioChunk, sampleRate)

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -426,7 +426,14 @@ func registerPlugins(registry: FlutterPluginRegistry) {
 extension AppDelegate: WCSessionDelegate {
     
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) { }
-    
+
+    func session(_ session: WCSession, didFinishUserInfoTransfer userInfoTransfer: WCSessionUserInfoTransfer, error: Error?) {
+        if let error = error {
+            let method = userInfoTransfer.userInfo["method"] as? String ?? "unknown"
+            NSLog("[Watch] phone-side transferUserInfo failed (method=\(method)): \(error.localizedDescription)")
+        }
+    }
+
     func sessionDidBecomeInactive(_ session: WCSession) {
         print("Session Watch Become Inactive")
     }

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -430,9 +430,10 @@ extension AppDelegate: WCSessionDelegate {
     func sessionDidBecomeInactive(_ session: WCSession) {
         print("Session Watch Become Inactive")
     }
-    
+
     func sessionDidDeactivate(_ session: WCSession) {
         print("Session Watch Deactivate")
+        WCSession.default.activate()
     }
     
     // Receive a message from watch (foreground/active)

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -433,7 +433,7 @@ extension AppDelegate: WCSessionDelegate {
         }
     }
 
-    func session(_ session: WCSession, didFinishUserInfoTransfer userInfoTransfer: WCSessionUserInfoTransfer, error: Error?) {
+    func session(_ session: WCSession, didFinish userInfoTransfer: WCSessionUserInfoTransfer, error: Error?) {
         if let error = error {
             let method = userInfoTransfer.userInfo["method"] as? String ?? "unknown"
             NSLog("[Watch] phone-side transferUserInfo failed (method=\(method)): \(error.localizedDescription)")

--- a/app/ios/Runner/PigeonCommunicator.g.swift
+++ b/app/ios/Runner/PigeonCommunicator.g.swift
@@ -648,6 +648,8 @@ protocol WatchRecorderFlutterAPIProtocol {
   func onMicrophonePermissionResult(granted grantedArg: Bool, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onMainAppMicrophonePermissionResult(granted grantedArg: Bool, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onWatchBatteryUpdate(batteryLevel batteryLevelArg: Double, batteryState batteryStateArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onWatchReachabilityChanged(isReachable isReachableArg: Bool, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onWatchStateChanged(isPaired isPairedArg: Bool, isWatchAppInstalled isWatchAppInstalledArg: Bool, isReachable isReachableArg: Bool, completion: @escaping (Result<Void, PigeonError>) -> Void)
 }
 class WatchRecorderFlutterAPI: WatchRecorderFlutterAPIProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
@@ -789,6 +791,42 @@ class WatchRecorderFlutterAPI: WatchRecorderFlutterAPIProtocol {
     let channelName: String = "dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchBatteryUpdate\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([batteryLevelArg, batteryStateArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onWatchReachabilityChanged(isReachable isReachableArg: Bool, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchReachabilityChanged\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([isReachableArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  func onWatchStateChanged(isPaired isPairedArg: Bool, isWatchAppInstalled isWatchAppInstalledArg: Bool, isReachable isReachableArg: Bool, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchStateChanged\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([isPairedArg, isWatchAppInstalledArg, isReachableArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return

--- a/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
+++ b/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
@@ -397,7 +397,7 @@ extension WatchAudioRecorderViewModel: WCSessionDelegate {
         }
     }
 
-    func session(_ session: WCSession, didFinishUserInfoTransfer userInfoTransfer: WCSessionUserInfoTransfer, error: (any Error)?) {
+    func session(_ session: WCSession, didFinish userInfoTransfer: WCSessionUserInfoTransfer, error: (any Error)?) {
         if let error = error {
             let method = userInfoTransfer.userInfo["method"] as? String ?? "unknown"
             NSLog("[Watch] transferUserInfo failed (method=\(method)): \(error.localizedDescription)")

--- a/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
+++ b/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
@@ -46,9 +46,9 @@ class WatchAudioRecorderViewModel: NSObject, ObservableObject {
             if success {
                 self.setupAudioStreaming()
                 self.isRecording = true
-                self.session.sendMessage(["method": "startRecording"], replyHandler: nil)
+                self.sendReliably(["method": "startRecording"])
             } else {
-                self.session.sendMessage(["method": "recordingError", "error": "Microphone permission denied"], replyHandler: nil)
+                self.sendReliably(["method": "recordingError", "error": "Microphone permission denied"])
             }
         }
     }
@@ -79,7 +79,7 @@ class WatchAudioRecorderViewModel: NSObject, ObservableObject {
         chunkBuffer = Data()
         bufferStartTime = nil
 
-        session.sendMessage(["method": "stopRecording"], replyHandler: nil)
+        sendReliably(["method": "stopRecording"])
     }
 
     private func bufferAndSendAudioData(_ audioData: Data) {
@@ -202,25 +202,24 @@ class WatchAudioRecorderViewModel: NSObject, ObservableObject {
         
         switch permissionStatus {
         case .granted:
-            session.sendMessage(["method": "microphonePermissionResult", "granted": true], replyHandler: nil)
-            
+            sendReliably(["method": "microphonePermissionResult", "granted": true])
+
         case .denied:
-            session.sendMessage(["method": "microphonePermissionResult", "granted": false], replyHandler: nil)
-            
+            sendReliably(["method": "microphonePermissionResult", "granted": false])
+
         case .undetermined:
             // Request permission - this will show the permission dialog
             audioSession.requestRecordPermission { [weak self] granted in
                 DispatchQueue.main.async {
-                    self?.session.sendMessage([
-                        "method": "microphonePermissionResult", 
+                    self?.sendReliably([
+                        "method": "microphonePermissionResult",
                         "granted": granted
-                    ], replyHandler: nil)
+                    ])
                 }
             }
-            
+
         @unknown default:
-            // Send failure result to main app
-            session.sendMessage(["method": "microphonePermissionResult", "granted": false], replyHandler: nil)
+            sendReliably(["method": "microphonePermissionResult", "granted": false])
         }
     }
 
@@ -338,6 +337,16 @@ class WatchAudioRecorderViewModel: NSObject, ObservableObject {
 
         // Buffer audio data for target-duration chunks
         bufferAndSendAudioData(byteData)
+    }
+
+    private func sendReliably(_ message: [String: Any]) {
+        if session.isReachable {
+            session.sendMessage(message, replyHandler: nil) { error in
+                self.session.transferUserInfo(message)
+            }
+        } else {
+            session.transferUserInfo(message)
+        }
     }
 }
 

--- a/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
+++ b/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
@@ -404,6 +404,10 @@ extension WatchAudioRecorderViewModel: WCSessionDelegate {
         }
     }
 
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        NSLog("[Watch] reachability changed: \(session.isReachable)")
+    }
+
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
         Task { @MainActor in
             guard let method = applicationContext["method"] as? String else { return }

--- a/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
+++ b/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
@@ -355,7 +355,13 @@ extension WatchAudioRecorderViewModel: WCSessionDelegate {
     public func sessionDidBecomeInactive(_ session: WCSession) { }
     public func sessionDidDeactivate(_ session: WCSession) { }
 #endif
-    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: (any Error)?) {}
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: (any Error)?) {
+        if let error = error {
+            NSLog("[Watch] WCSession activation failed: \(error.localizedDescription)")
+        } else {
+            NSLog("[Watch] WCSession activated state=\(activationState.rawValue)")
+        }
+    }
     
     func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
         Task {

--- a/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
+++ b/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
@@ -391,6 +391,13 @@ extension WatchAudioRecorderViewModel: WCSessionDelegate {
         }
     }
 
+    func session(_ session: WCSession, didFinishUserInfoTransfer userInfoTransfer: WCSessionUserInfoTransfer, error: (any Error)?) {
+        if let error = error {
+            let method = userInfoTransfer.userInfo["method"] as? String ?? "unknown"
+            NSLog("[Watch] transferUserInfo failed (method=\(method)): \(error.localizedDescription)")
+        }
+    }
+
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
         Task { @MainActor in
             guard let method = applicationContext["method"] as? String else { return }

--- a/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
+++ b/app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift
@@ -390,6 +390,22 @@ extension WatchAudioRecorderViewModel: WCSessionDelegate {
             }
         }
     }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        Task { @MainActor in
+            guard let method = applicationContext["method"] as? String else { return }
+            switch method {
+            case "startRecording":
+                self.startRecording()
+            case "stopRecording":
+                self.stopRecording()
+            case "requestMicrophonePermission":
+                self.requestMicrophonePermissionOnly()
+            default:
+                print("Unknown applicationContext method: \(method)")
+            }
+        }
+    }
 }
 
 

--- a/app/lib/gen/pigeon_communicator.g.dart
+++ b/app/lib/gen/pigeon_communicator.g.dart
@@ -816,6 +816,10 @@ abstract class WatchRecorderFlutterAPI {
 
   void onWatchBatteryUpdate(double batteryLevel, int batteryState);
 
+  void onWatchReachabilityChanged(bool isReachable);
+
+  void onWatchStateChanged(bool isPaired, bool isWatchAppInstalled, bool isReachable);
+
   static void setUp(WatchRecorderFlutterAPI? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
@@ -1009,6 +1013,62 @@ abstract class WatchRecorderFlutterAPI {
               'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchBatteryUpdate was null, expected non-null int.');
           try {
             api.onWatchBatteryUpdate(arg_batteryLevel!, arg_batteryState!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchReachabilityChanged$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchReachabilityChanged was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final bool? arg_isReachable = (args[0] as bool?);
+          assert(arg_isReachable != null,
+              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchReachabilityChanged was null, expected non-null bool.');
+          try {
+            api.onWatchReachabilityChanged(arg_isReachable!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchStateChanged$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchStateChanged was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final bool? arg_isPaired = (args[0] as bool?);
+          assert(arg_isPaired != null,
+              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchStateChanged was null, expected non-null bool.');
+          final bool? arg_isWatchAppInstalled = (args[1] as bool?);
+          assert(arg_isWatchAppInstalled != null,
+              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchStateChanged was null, expected non-null bool.');
+          final bool? arg_isReachable = (args[2] as bool?);
+          assert(arg_isReachable != null,
+              'Argument for dev.flutter.pigeon.omi_pigeon.WatchRecorderFlutterAPI.onWatchStateChanged was null, expected non-null bool.');
+          try {
+            api.onWatchStateChanged(arg_isPaired!, arg_isWatchAppInstalled!, arg_isReachable!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/app/lib/pigeon_interfaces.dart
+++ b/app/lib/pigeon_interfaces.dart
@@ -58,6 +58,8 @@ abstract class WatchRecorderFlutterAPI {
   void onMicrophonePermissionResult(bool granted);
   void onMainAppMicrophonePermissionResult(bool granted);
   void onWatchBatteryUpdate(double batteryLevel, int batteryState);
+  void onWatchReachabilityChanged(bool isReachable);
+  void onWatchStateChanged(bool isPaired, bool isWatchAppInstalled, bool isReachable);
 }
 
 // =============================================================================

--- a/app/lib/services/bridges/apple_watch_bridge.dart
+++ b/app/lib/services/bridges/apple_watch_bridge.dart
@@ -11,6 +11,8 @@ class AppleWatchFlutterBridge implements WatchRecorderFlutterAPI {
   final void Function(bool granted)? onMicPermissionCb;
   final void Function(bool granted)? onMainAppMicPermissionCb;
   final void Function(double batteryLevel, int batteryState)? onBatteryUpdateCb;
+  final void Function(bool isReachable)? onReachabilityChangedCb;
+  final void Function(bool isPaired, bool isWatchAppInstalled, bool isReachable)? onWatchStateChangedCb;
 
   AppleWatchFlutterBridge({
     this.onChunk,
@@ -20,6 +22,8 @@ class AppleWatchFlutterBridge implements WatchRecorderFlutterAPI {
     this.onMicPermissionCb,
     this.onMainAppMicPermissionCb,
     this.onBatteryUpdateCb,
+    this.onReachabilityChangedCb,
+    this.onWatchStateChangedCb,
   });
 
   @override
@@ -58,5 +62,15 @@ class AppleWatchFlutterBridge implements WatchRecorderFlutterAPI {
   @override
   void onWatchBatteryUpdate(double batteryLevel, int batteryState) {
     onBatteryUpdateCb?.call(batteryLevel, batteryState);
+  }
+
+  @override
+  void onWatchReachabilityChanged(bool isReachable) {
+    onReachabilityChangedCb?.call(isReachable);
+  }
+
+  @override
+  void onWatchStateChanged(bool isPaired, bool isWatchAppInstalled, bool isReachable) {
+    onWatchStateChangedCb?.call(isPaired, isWatchAppInstalled, isReachable);
   }
 }

--- a/app/lib/services/devices/transports/watch_transport.dart
+++ b/app/lib/services/devices/transports/watch_transport.dart
@@ -82,6 +82,12 @@ class WatchTransport extends DeviceTransport {
             }
           }
         },
+        onReachabilityChangedCb: (bool isReachable) {
+          Logger.debug('Watch Transport: Reachability changed: $isReachable');
+        },
+        onWatchStateChangedCb: (bool isPaired, bool isWatchAppInstalled, bool isReachable) {
+          Logger.debug('Watch Transport: State changed paired=$isPaired installed=$isWatchAppInstalled reachable=$isReachable');
+        },
       );
       WatchRecorderFlutterAPI.setUp(_bridge!);
     }


### PR DESCRIPTION
## Summary

Apple Watch ↔ phone audio streaming had several silent failure modes where the Watch UI showed \"recording\" but the iOS app received nothing. This PR addresses each one. The headline bug — **silent audio chunk drop on state divergence** — is fixed three ways for defense in depth: at the source (Watch sends start with a durable fallback), at the destination (phone now handles start in the background path), and at the symptom (chunks arriving without a prior start auto-recover instead of being dropped).

No new dependencies. No new background runtime modes. No protocol changes — just plugging holes in the existing WCSession lifecycle.

## What's broken in main today

| # | File | Bug |
|---|------|-----|
| 1 | `app/ios/Runner/AppDelegate.swift:538` | `didReceiveUserInfo` (background path) had cases for `sendAudioChunk`/`stopRecording`/etc but **no case for `startRecording`**. Phone backgrounded when Watch starts → start message routed via `transferUserInfo` arrives, never flips `isRecordingActive`, every audio chunk silently dropped. |
| 2 | `app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift:49,82` | Watch sent `startRecording`/`stopRecording`/`recordingError`/`microphonePermissionResult` via `sendMessage` only, **no errorHandler**. Phone unreachable → message lost, no retry path. |
| 3 | `app/ios/Runner/AppDelegate.swift:347` | `handleAudioChunk` dropped any chunk arriving while `isRecordingActive=false` and only printed to console. Watch UI showed recording, phone received nothing. |
| 4 | `app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift` | `RecorderHostApiImpl` falls back to `updateApplicationContext` for start/stop/permission, but the Watch had **no `didReceiveApplicationContext` handler** — dead-code fallback. |
| 5 | `app/ios/Runner/AppDelegate.swift:422` | `sessionDidDeactivate` was a `print`-only stub. Apple's docs require `WCSession.default.activate()` here for multi-Watch swap; without it the session stays dead until app restart. |
| 6 | both sides | `didFinishUserInfoTransfer:error:` unimplemented — durable-queue failures were completely silent. |
| 7 | both sides | `activationDidCompleteWith` empty stub — activation failures proceeded silently. |
| 8 | both sides | No `sessionReachabilityDidChange:` / `sessionWatchStateDidChange:` — Flutter could only learn state by polling. |

## Commit-by-commit

Each commit is independently revertable.

1. `fix(app/ios): handle startRecording in background WCSession path` — phone-side `didReceiveUserInfo` now has a `startRecording` case mirroring the foreground handler.
2. `fix(app/ios): give Watch state messages a transferUserInfo fallback` — `sendReliably(_:)` helper applied to start/stop/error/permission messages.
3. `fix(app/ios): recover from Watch↔phone recording state divergence` — chunks arriving without a prior start now log loudly, flip `isRecordingActive`, notify Flutter, and continue processing instead of dropping.
4. `fix(app/ios): wire Watch handler for applicationContext commands` — `session:didReceiveApplicationContext:` dispatches start/stop/permission to the same handlers as `didReceiveMessage`.
5. `fix(app/ios): reactivate WCSession on sessionDidDeactivate` — Apple's documented multi-Watch pattern.
6. `fix(app/ios): log transferUserInfo failures on both sides` — durable-queue errors now visible in Console.app.
7. `fix(app/ios): log WCSession activation outcome on both sides` — activation failures no longer silent.
8. `feat(app/ios): surface Watch reachability and state changes to Flutter` — two new Pigeon FlutterAPI callbacks (`onWatchReachabilityChanged`, `onWatchStateChanged`); generated code regenerated for Dart, Swift, Kotlin.

## Why no Opus / VAD / extended-runtime / custom ack protocol

Considered and dropped after design review:

- **No application-level per-chunk ack protocol.** WCSession's built-in delivery (`sendMessage:replyHandler:errorHandler:` for foreground ack, `transferUserInfo` for system-managed durable queue) is sufficient. A custom sequence-number protocol on top would amplify load and duplicate work the OS already does.
- **No `WKExtendedRuntimeSession`.** The standard audio background mode (already declared in `Info.plist`) keeps the Watch app alive while actively recording. Extended-runtime sessions are for screen-off recording continuation — a separate UX feature, not a reliability fix.
- **No Opus encoding / VAD on Watch.** Out of scope for connectivity & reliability. Each is a substantial dependency-introduction that wants its own PR for binary-size + battery review.
- **No custom watchdog timer.** The reliability gaps were all in lifecycle handlers we hadn't implemented; once those are wired the standard WCSession lifecycle covers reconnection.

## Test plan

This needs **physical iPhone + Apple Watch hardware** — WatchConnectivity behavior cannot be exercised in the simulator. The Linux build environment used here cannot compile iOS Swift, so the Swift changes were validated by static reading and adjacent-pattern comparison; Dart code passes `flutter analyze` (the only finding is a pre-existing `pigeon` import diagnostic on `pigeon_interfaces.dart`).

### Golden path
- [ ] iPhone foreground, Watch foreground: tap record on Watch → phone receives audio within 1.5s.
- [ ] iPhone foreground, Watch foreground: tap stop on Watch → phone stops within 1.5s.
- [ ] Phone-initiated start (Flutter UI): Watch starts recording.

### State divergence (the headline failure mode)
- [ ] Force-quit iOS app. Open Watch app, tap record. Reopen iOS app within ~10s. **Expected:** iOS shows recording, audio chunks flowing. Console.app log shows `[Watch] Audio chunk arrived without prior startRecording — recovering state`.
- [ ] iOS app backgrounded (not killed). Tap record on Watch. Bring iOS to foreground. **Expected:** recording state visible immediately, no audio loss.
- [ ] iOS app foreground, then user puts Watch in airplane mode briefly while recording. Re-enable. **Expected:** chunks queued during airplane mode delivered when reachable; recording continues.

### Lifecycle hardening
- [ ] Pair a second Apple Watch (settings → My Watch → All Watches). Trigger Watch swap. **Expected:** iOS app stays responsive to the new Watch (`sessionDidDeactivate` reactivation).
- [ ] Force-quit iOS app while Watch is recording. Relaunch. **Expected:** activation logs visible in Console.app; first audio chunk triggers recovery.
- [ ] Uninstall Watch app from paired Watch. **Expected:** `onWatchStateChanged(isPaired:true, isWatchAppInstalled:false, ...)` fires (visible in Flutter debug log).

### Reachability
- [ ] iOS in foreground, Watch on same wrist, recording. Walk out of Bluetooth range (~10m+ wall). **Expected:** `[Watch] reachability changed: false` log; chunks queued; on return, queue flushes and audio resumes.
- [ ] iOS app backgrounded with screen off. Recording active. **Expected:** chunks delivered via `transferUserInfo` system queue with no loss visible in final transcript.

### Negative
- [ ] Tap record on Watch with phone bluetooth off entirely. **Expected:** `recordingError` surfaces with permission/connectivity error message instead of silent failure.
- [ ] Force a WCSession activation failure (e.g. revoke entitlements in dev build). **Expected:** activation failure logged in Console.app; no silent no-op.

## Files touched

- `app/ios/Runner/AppDelegate.swift` — phone-side delegate hardening, silent-drop fix, new Pigeon callbacks
- `app/ios/omiWatchApp/WatchAudioRecorderViewModel.swift` — Watch-side delegate hardening, `sendReliably(_:)` helper, `didReceiveApplicationContext` handler
- `app/lib/pigeon_interfaces.dart` — two new FlutterAPI callbacks
- `app/lib/services/bridges/apple_watch_bridge.dart` — bridge implementations
- `app/lib/services/devices/transports/watch_transport.dart` — debug logging for new callbacks
- `app/lib/gen/pigeon_communicator.g.dart`, `app/ios/Runner/PigeonCommunicator.g.swift`, `app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt` — Pigeon regen

## Out of scope (deliberate)

State persistence via `updateApplicationContext` for `isRecordingActive` truth — the recovery path in commit 3 covers the same failure mode reactively. UI plumbing for the new reachability/state callbacks beyond debug logging — bridge and Pigeon channel are in place; downstream subscribers can attach without further iOS changes.