### PR TITLE
fix: add langchain-google-genai to pusher requirements

### DIFF
--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -49,6 +49,7 @@ groq==0.9.0
 langchain==0.3.27
 langchain-community==0.3.31
 langchain-core==0.3.79
+langchain-google-genai==2.1.12
 langchain-openai==0.3.35
 langchain-pinecone==0.2.12
 langchain-text-splitters==0.3.11


### PR DESCRIPTION
## Summary
- Add `langchain-google-genai==2.1.12` to `backend/pusher/requirements.txt`
- Fixes pusher startup crash: `ModuleNotFoundError: No module named 'langchain_google_genai'`

## Root cause
PR #6942 (QoS architecture refactor) added `from langchain_google_genai import ChatGoogleGenerativeAI` to `utils/llm/clients.py`. This module is in pusher's import chain:

```
pusher/main.py → routers/pusher.py → utils/apps.py → utils/llm/persona.py → utils/llm/clients.py
```

The package was added to `backend/requirements.txt` (Cloud Run) but not to `backend/pusher/requirements.txt` (GKE pusher), which maintains a separate lightweight dependency list.

## Deploy Prerequisites
- Pusher redeploy required (GKE) — the new package needs to be installed in the pusher Docker image

## Test plan
- [x] Verified `langchain-google-genai==2.1.12` version matches `backend/requirements.txt`
- [x] Traced full import chain confirming pusher reaches `clients.py`

_by AI for @beastoin_