### PR TITLE
backend: bump 15 Python deps for ~17 MEDIUM + 1 HIGH + 6 LOW CVEs

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ av==12.0.0
 backoff==2.2.1
 blinker==1.8.2
 CacheControl==0.14.0
-cachetools==5.4.0
+cachetools==5.5.0
 certifi==2024.7.4
 cffi==2.0.0
 charset-normalizer==3.3.2
@@ -194,7 +194,7 @@ soxr==0.4.0
 SQLAlchemy==2.0.32
 stack-data==0.6.3
 starlette==0.40.0
-streamlit==1.51.0
+streamlit==1.54.0
 tabulate==0.9.0
 tenacity==8.2.3
 threadpoolctl==3.5.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,7 +44,7 @@ fastapi==0.118.0
 fastapi-cli==0.0.5
 fastapi-utilities==0.2.0
 filetype==1.2.0
-filelock==3.15.4
+filelock==3.20.3
 firebase-admin==6.5.0
 flatbuffers==24.3.25
 fonttools==4.60.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -47,7 +47,7 @@ filetype==1.2.0
 filelock==3.15.4
 firebase-admin==6.5.0
 flatbuffers==24.3.25
-fonttools==4.53.1
+fonttools==4.60.2
 frozenlist==1.4.1
 fsspec==2024.6.1
 gitdb==4.0.11

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -103,7 +103,7 @@ langchain-text-splitters==0.3.11
 langgraph==0.6.10
 langgraph-checkpoint==2.1.2
 langgraph-sdk==0.2.9
-langsmith==0.4.37
+langsmith==0.7.31
 lazy_loader==0.4
 llvmlite==0.43.0
 Mako==1.3.11

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -109,7 +109,7 @@ llvmlite==0.43.0
 Mako==1.3.11
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
-marshmallow==3.21.3
+marshmallow==3.26.2
 matplotlib-inline==0.1.7
 mdurl==0.1.2
 monotonic==1.6

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -83,7 +83,7 @@ hyperframe==6.0.1
 idna==3.7
 ipython==8.26.0
 jedi==0.19.1
-Jinja2==3.1.4
+Jinja2==3.1.6
 jiter==0.6.1
 jiwer==3.0.4
 joblib==1.4.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -106,7 +106,7 @@ langgraph-sdk==0.2.9
 langsmith==0.4.37
 lazy_loader==0.4
 llvmlite==0.43.0
-Mako==1.3.5
+Mako==1.3.11
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 marshmallow==3.21.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -70,8 +70,8 @@ grpcio-status==1.66.0
 grpcio-tools==1.66.0
 grpclib==0.4.7
 h11==0.16.0
-h2==4.1.0
-hpack==4.0.0
+h2==4.3.0
+hpack==4.1.0
 httpcore==1.0.9
 httplib2==0.22.0
 httptools==0.6.1
@@ -79,7 +79,7 @@ httpx==0.28.0
 httpx-sse==0.4.0
 huggingface-hub==0.24.5
 humanfriendly==10.0
-hyperframe==6.0.1
+hyperframe==6.1.0
 idna==3.7
 ipython==8.26.0
 jedi==0.19.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -94,7 +94,7 @@ jsonschema-specifications==2023.12.1
 kiwisolver==1.4.5
 langchain==0.3.27
 langchain-community==0.3.31
-langchain-core==0.3.81
+langchain-core==0.3.84
 langchain-google-genai==2.1.12
 langchain-openai==0.3.35
 langchain-pinecone==0.2.12

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,7 +28,7 @@ coloredlogs==15.0.1
 colorlog==6.8.2
 contourpy==1.2.1
 croniter==1.4.1
-cryptography==46.0.5
+cryptography==46.0.7
 cycler==0.12.1
 dataclasses-json==0.6.7
 decorator==5.1.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -164,7 +164,7 @@ PyOgg @ git+https://github.com/TeamPyOgg/PyOgg@6871a4f234e8a3a346c4874a12509bfa0
 pyparsing==3.1.2
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
-python-multipart==0.0.22
+python-multipart==0.0.26
 python-slugify==8.0.4
 python-ulid==3.0.0
 pytz==2024.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,7 +40,7 @@ docopt==0.6.2
 email_validator==2.2.0
 executing==2.0.1
 fal_client==0.4.1
-fastapi==0.118.0
+fastapi==0.121.0
 fastapi-cli==0.0.5
 fastapi-utilities==0.2.0
 filetype==1.2.0
@@ -193,7 +193,7 @@ soundfile==0.12.1
 soxr==0.4.0
 SQLAlchemy==2.0.32
 stack-data==0.6.3
-starlette==0.40.0
+starlette==0.49.1
 streamlit==1.54.0
 tabulate==0.9.0
 tenacity==8.2.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -174,7 +174,7 @@ rapidfuzz==3.9.7
 redis==5.0.8
 referencing==0.35.1
 regex==2024.7.24
-requests~=2.32.5
+requests~=2.33.0
 requests-toolbelt==1.0.0
 rich==13.7.1
 rpds-py==0.20.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -163,7 +163,7 @@ pynndescent==0.5.13
 PyOgg @ git+https://github.com/TeamPyOgg/PyOgg@6871a4f234e8a3a346c4874a12509bfa02c4c63a
 pyparsing==3.1.2
 python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 python-multipart==0.0.22
 python-slugify==8.0.4
 python-ulid==3.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 aenum==3.1.15
 aiofiles==24.1.0
 aiohappyeyeballs==2.5.0
-aiohttp==3.13.3
+aiohttp==3.13.4
 aiosignal==1.4.0
 aiostream==0.5.2
 alembic==1.13.2


### PR DESCRIPTION
## Summary

15 atomic commits, one per package family, closing the Python-only MEDIUM CVEs flagged by the Artifact Registry scan on the deployed backend image (`gcr.io/based-hardware/backend@sha256:348e17d6…`, revision `backend-00984-2nf`). One bump (starlette) also closes a HIGH CVE that surfaced after #7126/#7127 merged.

| Commit | Package | Was → Now | CVEs (sev) |
|---|---|---|---|
| 1 | cryptography | 46.0.5 → 46.0.7 | CVE-2026-39892 (MEDIUM, CVSS 9.8) |
| 2 | Jinja2 | 3.1.4 → 3.1.6 | CVE-2024-56201, CVE-2024-56326, CVE-2025-27516 (3× MEDIUM, sandbox escapes) |
| 3 | aiohttp | 3.13.3 → 3.13.4 | CVE-2026-22815, CVE-2026-34515, CVE-2026-34516, CVE-2026-34525 (4× MEDIUM) + CVE-2026-34520 + 5× LOW |
| 4 | fonttools | 4.53.1 → 4.60.2 | CVE-2025-66034 (MEDIUM, CVSS 9.8) |
| 5 | Mako | 1.3.5 → 1.3.11 | CVE-2026-41205 (MEDIUM 7.5) |
| 6 | requests | ~=2.32.5 → ~=2.33.0 | CVE-2026-25645 (MEDIUM 5.5) |
| 7 | python-dotenv | 1.0.1 → 1.2.2 | CVE-2026-28684 (MEDIUM 6.6) |
| 8 | filelock | 3.15.4 → 3.20.3 | CVE-2025-68146, CVE-2026-22701 (2× MEDIUM) |
| 9 | marshmallow | 3.21.3 → 3.26.2 | CVE-2025-68480 (MEDIUM 5.3) |
| 10 | python-multipart | 0.0.22 → 0.0.26 | CVE-2026-40347 (MEDIUM 5.3) |
| 11 | streamlit (+ cachetools 5.4 → 5.5) | 1.51.0 → 1.54.0 | CVE-2026-33682 (MEDIUM 4.8) |
| 12 | h2 (+ hyperframe 6.0.1 → 6.1.0, hpack 4.0.0 → 4.1.0) | 4.1.0 → 4.3.0 | CVE-2025-57804 (MEDIUM) |
| 13 | langchain-core | 0.3.81 → 0.3.84 | CVE-2026-40087 (MEDIUM 5.3, patch only — does not pull 1.x major) |
| 14 | langsmith | 0.4.37 → 0.7.31 | CVE-2026-25528, CVE-2026-41182 (2× MEDIUM) |
| 15 | starlette (+ fastapi 0.118 → 0.121) | 0.40.0 → 0.49.1 | CVE-2025-62727 (HIGH 7.5) + CVE-2025-54121 (MEDIUM 5.3) |

**Net:** 17 MEDIUM + 1 HIGH + 6 LOW CVEs closed, all atomic / independently revertible.

## Cascade summary

| Cascade | Reason |
|---|---|
| cachetools 5.4 → 5.5 | streamlit 1.54 requires cachetools >=5.5,<7 |
| hyperframe 6.0.1 → 6.1.0 | h2 4.3 requires hyperframe >=6.1 |
| hpack 4.0.0 → 4.1.0 | h2 4.3 requires hpack >=4.1 |
| fastapi 0.118 → 0.121 | fastapi 0.118 caps starlette <0.49; 0.121 is the smallest version that allows starlette 0.49 |

All cascade bumps held to the minimum version that resolves the conflict.

## Notes on starlette + main.py

starlette 0.40 (introduced in #7127) shipped a default 1 MB cap per multipart form part. The startup-time `MultiPartParser.max_part_size = 200 MB` patch in `backend/main.py` continues to work in starlette 0.49 — verified via import + override + FastAPI app instantiation smoke test. Per-route caps (tracked in #7130) become available now that we're past starlette 0.45.

## Deferred

The langchain ecosystem majors (langgraph 0.6 → 1.x, langgraph-checkpoint 2 → 4, langchain-text-splitters 0.3 → 1.x) remain parked for a separate PR. Those bumps require API migration in `backend/utils/llm/` and `backend/utils/retrieval/`.

## Test plan

For each commit:
1. Update `requirements.txt`
2. Rebuild local `Dockerfile.test` (Python 3.11-slim, requirements.txt minus the source-built `lc3py`) — only the pip install layer rebuilds
3. Run a baseline-green subset of unit tests (190 tests across 11 files; same subset as #7126/#7127)
4. Confirm bumped package version installed correctly

All 15 commits individually green. Cascade bumps were discovered by attempting the headline bump, reading the resolver error, and pinning the smallest version that resolves it.

## Verifying after deploy

- [ ] Re-scan rebuilt image; expect the listed CVEs to clear.
- [ ] Smoke `/health`, an auth route, and a multipart upload route (voice-message or persona thumbnail) to confirm the starlette/fastapi bump didn't regress request handling.