### PR TITLE
chore: gitignore .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ CLAUDE.md
 web/app/next-env.d.ts
 .claude/settings.local.json
 .claude/worktrees/
+.mcp.json
 LOCAL_DEV_SETUP.md
 app/macos/Config/Prod/GoogleService-Info.plist
 app/.metadata


### PR DESCRIPTION
## Summary

Add \`.mcp.json\` to \`.gitignore\`. This file holds local Model Context Protocol server configuration for editor integrations (Claude Code, Cursor) and routinely contains plaintext credentials — Grafana service-account tokens, Stripe wrappers, FeatureBase bearer keys, PostHog API keys, etc.

Without an ignore rule, a routine \`git add -A\` would stage the file and a single careless commit could leak every key in it.

## Test plan

- [x] \`git check-ignore .mcp.json\` returns 0 after the change.
- [x] Existing repo state unchanged for everyone who doesn't have a local \`.mcp.json\` (no removal — file was never tracked).