### PR TITLE
ci(app): port iOS auto-resolver to android-internal-auto

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -232,6 +232,8 @@ workflows:
     name: Auto Deploy Android to Internal Play Store
     instance_type: mac_mini_m2
     max_build_duration: 120
+    integrations:
+      app_store_connect: codemagic_v4
     environment:
       android_signing:
         - prod_android_upload_keystore
@@ -242,6 +244,7 @@ workflows:
         - shorebird
       vars:
         PACKAGE_NAME: "com.friend.ios"
+        APP_ID: 6502156163
         JAVA_TOOL_OPTIONS: "-Xmx8g"
         STAGING_API_URL: "https://api.omiapi.com/"
       flutter: 3.35.3
@@ -354,20 +357,69 @@ workflows:
         script: |
           dart run build_runner build --delete-conflicting-outputs
 
-      - name: Build AAB with Flutter
+      - name: Resolve next version from TestFlight + App Store + Play Store
         script: |
-          # Extract version from pubspec.yaml (source of truth for both name and build number)
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' ')
-          BUILD_NAME=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f1)  # e.g., "1.0.525"
-          BUILD_NUMBER=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f2)  # e.g., "758"
+          set -e
 
-          # Skip if this build number is already on Google Play
-          LATEST_BUILD=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME" --tracks internal || echo "0")
-          if [ "$BUILD_NUMBER" -le "$LATEST_BUILD" ]; then
-            echo "Build $BUILD_NUMBER already on Google Play (latest: $LATEST_BUILD). Skipping."
-            exit 0
+          EMPTY='{"version":"0.0.0","buildNumber":"0"}'
+          TF_RAW=$(app-store-connect get-latest-testflight-build-number "$APP_ID" --include-version --json 2>/dev/null) || TF_RAW=""
+          AS_RAW=$(app-store-connect get-latest-app-store-build-number "$APP_ID" --include-version --json 2>/dev/null) || AS_RAW=""
+          [ -z "$TF_RAW" ] && TF_RAW="$EMPTY"
+          [ -z "$AS_RAW" ] && AS_RAW="$EMPTY"
+
+          TF_V=$(echo "$TF_RAW" | jq -r '.version // "0.0.0"')
+          TF_B=$(echo "$TF_RAW" | jq -r '.buildNumber // "0"')
+          AS_V=$(echo "$AS_RAW" | jq -r '.version // "0.0.0"')
+          AS_B=$(echo "$AS_RAW" | jq -r '.buildNumber // "0"')
+          PLAY_B=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME" --tracks internal 2>/dev/null || echo "0")
+
+          echo "TestFlight latest: ${TF_V}+${TF_B}"
+          echo "App Store latest:  ${AS_V}+${AS_B}"
+          echo "Play Store latest: +${PLAY_B}"
+
+          if [ "$TF_V" = "0.0.0" ] && [ "$AS_V" = "0.0.0" ]; then
+            echo "WARNING: No TestFlight or App Store history. Seeding from pubspec.yaml."
+            PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' ')
+            BUILD_NAME=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f1)
+            BUILD_NUMBER=$(echo "$PUBSPEC_VERSION" | cut -d'+' -f2)
+            [ "$PLAY_B" -ge "$BUILD_NUMBER" ] && BUILD_NUMBER=$((PLAY_B + 1))
+          else
+            semver_gt() {
+              IFS='.' read -r a1 a2 a3 <<< "$1"
+              IFS='.' read -r b1 b2 b3 <<< "$2"
+              [ "$a1" -gt "$b1" ] && return 0
+              [ "$a1" -lt "$b1" ] && return 1
+              [ "$a2" -gt "$b2" ] && return 0
+              [ "$a2" -lt "$b2" ] && return 1
+              [ "$a3" -gt "$b3" ] && return 0
+              return 1
+            }
+
+            if semver_gt "$TF_V" "$AS_V"; then
+              BUILD_NAME="$TF_V"
+              echo "TF ahead of App Store -> reusing TF version $BUILD_NAME"
+            else
+              IFS='.' read -r MAJ MIN PATCH <<< "$AS_V"
+              BUILD_NAME="${MAJ}.${MIN}.$((PATCH + 1))"
+              if [ "$TF_V" = "0.0.0" ]; then
+                echo "No TestFlight history -> bumping App Store patch to $BUILD_NAME"
+              else
+                echo "TF (${TF_V}) <= AS (${AS_V}) -> bumping patch to $BUILD_NAME"
+              fi
+            fi
+
+            MAX_B=$TF_B
+            [ "$AS_B" -gt "$MAX_B" ] && MAX_B=$AS_B
+            [ "$PLAY_B" -gt "$MAX_B" ] && MAX_B=$PLAY_B
+            BUILD_NUMBER=$((MAX_B + 1))
           fi
 
+          echo "Resolved next version: ${BUILD_NAME}+${BUILD_NUMBER}"
+          echo BUILD_NAME="$BUILD_NAME" >> $CM_ENV
+          echo BUILD_NUMBER="$BUILD_NUMBER" >> $CM_ENV
+
+      - name: Build AAB with Flutter
+        script: |
           echo "Building Android with version $BUILD_NAME ($BUILD_NUMBER)"
 
           flutter build appbundle \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -372,10 +372,11 @@ workflows:
           AS_V=$(echo "$AS_RAW" | jq -r '.version // "0.0.0"')
           AS_B=$(echo "$AS_RAW" | jq -r '.buildNumber // "0"')
           PLAY_B=$(google-play get-latest-build-number --package-name "$PACKAGE_NAME" --tracks internal 2>/dev/null || echo "0")
+          PLAY_B="${PLAY_B:-0}"
 
           echo "TestFlight latest: ${TF_V}+${TF_B}"
           echo "App Store latest:  ${AS_V}+${AS_B}"
-          echo "Play Store latest: +${PLAY_B}"
+          echo "Play Store latest: ${PLAY_B}"
 
           if [ "$TF_V" = "0.0.0" ] && [ "$AS_V" = "0.0.0" ]; then
             echo "WARNING: No TestFlight or App Store history. Seeding from pubspec.yaml."


### PR DESCRIPTION
## Summary

Mirrors the TestFlight + App Store version-resolution step that `ios-internal-auto` already runs (#7108), extended to also query Google Play internal track. Both workflows now compute `BUILD_NAME` / `BUILD_NUMBER` from store APIs, so TestFlight and Play Store internal stay in lockstep instead of Android silently skipping when its track is ahead of the literal pubspec.yaml version.

## Problem

After #7108, `ios-internal-auto` auto-resolves the next iOS version against TestFlight + App Store and uploads (e.g. resolves `1.0.534+843` when TF is at `1.0.534+842`). `android-internal-auto` was not updated and still does:

```bash
PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml ...)   # → 1.0.534+835
LATEST_BUILD=$(google-play get-latest-build-number ...) # → 835
[ "$BUILD_NUMBER" -le "$LATEST_BUILD" ] && exit 0       # silent skip
```

So whenever pubspec is even one build behind Play, every push silently skips Android. Result: TestFlight steadily moves ahead while Play stays frozen.

## Behaviour

New step `Resolve next version from TestFlight + App Store + Play Store` runs before the AAB build. Same shape as the iOS resolver, plus:

- Adds `app_store_connect: codemagic_v4` integration + `APP_ID` var to the workflow so it can query App Store Connect.
- Queries `google-play get-latest-build-number ... --tracks internal` for `PLAY_B`.
- Logs all three latest values for traceability.
- `MAX_B = max(TF_B, AS_B, PLAY_B)`; resolved `BUILD_NUMBER = MAX_B + 1`.
- Cold-start branch (no TF / no App Store history) still seeds `BUILD_NAME` from pubspec but bumps `BUILD_NUMBER` past Play if Play is ahead.

Both workflows trigger off the same commit and run in parallel. Their resolver steps execute within the first ~2 minutes (before either has uploaded), so they query identical state and arrive at the same `BUILD_NAME` / `BUILD_NUMBER`. Bounded ±1 build-number drift is possible only if one workflow finishes uploading before the other queries (~12–15 min apart) — `BUILD_NAME` stays in lockstep regardless.

## Test plan

- [ ] Trigger `android-internal-auto` workflow on this branch in Codemagic; confirm the resolver logs `TestFlight latest:` / `App Store latest:` / `Play Store latest:` and resolves to a build number > current Play internal latest.
- [ ] Confirm AAB builds with the resolved `BUILD_NAME` + `BUILD_NUMBER` and uploads to Play Store internal track.
- [ ] After the next push to `main`, confirm iOS and Android resolve to the same `BUILD_NAME` and adjacent `BUILD_NUMBER` values.