### PR TITLE
fix(backend/stripe): paginate CountrySpec.list so countries past R aren't dropped

### DIFF
--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -219,16 +219,22 @@ def is_onboarding_complete(account_id: str):
 def get_supported_countries():
     if countries := redis_db.get_generic_cache('stripe_supported_countries'):
         return countries
-    data = stripe.CountrySpec.list(limit=100)
-    country_codes = [country['id'] for country in data.data]
+    country_codes: list[str] = []
+    starting_after: str | None = None
+    while True:
+        kwargs = {"limit": 100}
+        if starting_after:
+            kwargs["starting_after"] = starting_after
+        page = stripe.CountrySpec.list(**kwargs)
+        country_codes.extend(c['id'] for c in page.data)
+        if not page.has_more or not page.data:
+            break
+        starting_after = page.data[-1]['id']
     # Gibraltar is not supported by us since it does not allow transfers
-    if "GI" in country_codes:
-        country_codes.remove("GI")
+    country_codes = [c for c in country_codes if c != "GI"]
     if "US" not in country_codes:
         country_codes.append("US")
-    if "TR" not in country_codes:
-        country_codes.append("TR")
-    country_codes.sort()
+    country_codes = sorted(set(country_codes))
     countries = [
         {"id": code, "name": pycountry.countries.get(alpha_2=code).name}
         for code in country_codes


### PR DESCRIPTION
## Summary

`backend/utils/stripe.py::get_supported_countries()` calls `stripe.CountrySpec.list(limit=100)` and never paginates. Stripe currently has **121** country specs, so the call silently drops the 21 entries that fall after the alphabetic cutoff at `RO`. The mobile app's Stripe Connect onboarding dropdown (served by `GET /v1/stripe/supported-countries`) is missing affiliate / payout countries including:

```
RU, SA, SE, SG, SI, SK, SN, SV, TH, TN, TR, TT, TW, TZ, UY, UZ, VN, ZA
```

The current ad-hoc `if "TR" not in country_codes: append("TR")` is a partial bandaid for the same root cause — someone noticed Turkey was missing and patched only Turkey.

## Fix

Walk pages with `starting_after` until `has_more` is `false`. Dedupe + sort once after collection so the manual `US` push survives. Drop the TR special-case (paginated list now contains it).

## Verification

Same fix shipped on the affiliates dashboard in BasedHardware/affiliates#3 (already merged). Walking the live Stripe API pages returned 121 codes total across 2 pages with VN + the other previously-missing codes all present.

## Test plan

- [ ] After deploy and a redis cache flush of `stripe_supported_countries`, `GET /v1/stripe/supported-countries` returns ≥ 120 countries including VN, SG, SA, TH, ZA.
- [ ] Mobile app payouts dropdown lists Vietnam and the other previously-missing entries.
- [ ] Selecting Vietnam and submitting completes the existing connect flow (Stripe Connect supports VN at the API level — verified end-to-end on the affiliates app).