### PR TITLE
fix(app/chat): remove dead space between input field and bottom nav

### DIFF
--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -891,7 +891,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                     },
                   ),
                 ),
-                SizedBox(height: textFieldFocusNode.hasFocus ? 12 : 14),
                 if (!textFieldFocusNode.hasFocus)
                   BottomNavBar(
                     onTabTap: (index, isRepeat) {


### PR DESCRIPTION
## Summary
- Drops the `SizedBox(height: 12-14)` between the chat input pill and the `BottomNavBar` on the chat page
- The `BottomNavBar` already has 20px internal top padding plus a transparent-to-dark gradient, which provides sufficient visual separation on its own

## Test plan
- [ ] Open chat page — verify the input field sits flush against the nav bar with no awkward gap
- [ ] Tap the input field — verify keyboard slides up cleanly (nav bar hides while focused, unchanged behavior)
- [ ] Dismiss keyboard — verify nav bar reappears with the new tighter spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)