### PR TITLE
chore(agent-vm): Fix Requested disk size cannot be smaller than the image size (50 GB)

### DIFF
--- a/desktop/Backend-Rust/src/routes/agent.rs
+++ b/desktop/Backend-Rust/src/routes/agent.rs
@@ -499,7 +499,7 @@ async fn create_gce_vm(
             "autoDelete": true,
             "initializeParams": {
                 "sourceImage": source_image,
-                "diskSizeGb": "30",
+                "diskSizeGb": "50",
                 "diskType": format!("zones/{}/diskTypes/pd-balanced", zone)
             }
         }],


### PR DESCRIPTION
**Error:** message: "Invalid value for field 'resource.disks[0].initializeParams.diskSizeGb': '30'. Requested disk size cannot be smaller than the image size (50 GB)"

Change:
- Rollback disk size to **50GB**, keep diskType as **pd-balanced**.