### PR TITLE
Update CHANGELOG.json for v0.11.375 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -2,6 +2,13 @@
   "unreleased": [],
   "releases": [
     {
+      "version": "0.11.375",
+      "date": "2026-05-04",
+      "changes": [
+        "Bug fixes and improvements"
+      ]
+    },
+    {
       "version": "0.11.374",
       "date": "2026-05-03",
       "changes": [


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.375 and clears the unreleased array.