### PR TITLE
android: strip BOOT_COMPLETED receivers from merged manifest (#4832)

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"
+        tools:node="remove" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
 
@@ -88,6 +89,13 @@
             android:name="id.flutter.flutter_background_service.BackgroundService"
             android:foregroundServiceType="microphone"
             tools:node="merge" />
+
+        <receiver
+            android:name="com.pravera.flutter_foreground_task.service.RebootReceiver"
+            tools:node="remove" />
+        <receiver
+            android:name="id.flutter.flutter_background_service.BootReceiver"
+            tools:node="remove" />
 
         <service
             android:name=".NotificationOnKillService"


### PR DESCRIPTION
## Summary

Google Play rejects targetSdk-35 builds when the merged AndroidManifest wires `BOOT_COMPLETED` receivers to restricted foreground service types (`location`, `microphone`, `dataSync`, `camera`, `mediaPlayback`, `phoneCall`, `mediaProjection`).

Two of our plugins inject such receivers via their plugin manifests:

| Plugin | Receiver | Service started | FG type |
|---|---|---|---|
| `flutter_foreground_task` 9.1.0 | `RebootReceiver` | `ForegroundService` | `location` |
| `flutter_background_service_android` 6.3.0 | `BootReceiver` | `BackgroundService` | `microphone` |

We never opt into autostart at runtime (`autoRunOnBoot: false` in `app/lib/utils/audio/foreground.dart:129`, `autoStartOnBoot: false` in `app/lib/services/services.dart:148`), so removing the receivers + the dead `RECEIVE_BOOT_COMPLETED` permission via `tools:node="remove"` is a no-op at runtime and clears the Play scan.

## Why not upgrade the plugins

Both upstreams have unfixed open issues and no shipped workaround:
- `Dev-hwang/flutter_foreground_task` — issue [#356](https://github.com/Dev-hwang/flutter_foreground_task/issues/356) open since 2025-07-31, closed [#335](https://github.com/Dev-hwang/flutter_foreground_task/issues/335) without a fix. Latest version 9.2.2 still ships the `RebootReceiver` declaration.
- `ekasetiawans/flutter_background_service` — issues [#517](https://github.com/ekasetiawans/flutter_background_service/issues/517) and [#518](https://github.com/ekasetiawans/flutter_background_service/issues/518) open since 2025-07-04. Latest 6.3.1 still ships the `BootReceiver` declaration.

## Verification

Ran `com.android.tools.build:manifest-merger` 32.2.0 locally against the app's `AndroidManifest.xml` plus both plugin manifests, with `--remove-tools-declarations` to mirror what AGP does:

**Baseline (current `main`)** merged manifest contains:
- `<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />`
- `<receiver android:name="com.pravera.flutter_foreground_task.service.RebootReceiver">` with `<action android:name="android.intent.action.BOOT_COMPLETED"/>`
- `<receiver android:name="id.flutter.flutter_background_service.BootReceiver">` with `<action android:name="android.intent.action.BOOT_COMPLETED"/>`

**With this PR applied** the merged manifest contains:
- 0 occurrences of `BOOT_COMPLETED`
- 0 occurrences of `RECEIVE_BOOT_COMPLETED`
- All foreground service declarations preserved (`location`, `microphone`, `connectedDevice`)
- `RestartReceiver` and `WatchdogReceiver` (no boot intent-filter) preserved

```
$ grep -cE 'BOOT_COMPLETED|RECEIVE_BOOT_COMPLETED' merged-fixed-clean.xml
0
```

## Test plan

- [ ] Codemagic dry-run on `caleb/android15-boot-receiver-strip` (`android-internal-auto`) — confirm gradle assembles with no manifest-merger conflict
- [ ] Pull the produced APK from the dry-run artifacts, run `aapt2 dump xmltree base.apk --file AndroidManifest.xml`, confirm no `BOOT_COMPLETED` action and no `RECEIVE_BOOT_COMPLETED` permission
- [ ] After Play Console internal track upload, confirm "Restricted foreground service types" warning no longer appears