### PR TITLE
fix(desktop): AudioMixer stall detection prevents dead source from blocking audio #7160

### DIFF
--- a/desktop/Desktop/Sources/AudioMixer.swift
+++ b/desktop/Desktop/Sources/AudioMixer.swift
@@ -40,6 +40,15 @@ class AudioMixer {
     // Maximum buffer size to prevent unbounded growth (1 second = 32000 bytes)
     private let maxBufferBytes = 32000
 
+    // Source liveness tracking — prevents one dead source from blocking the other.
+    // When a source hasn't delivered data within `sourceTimeout` seconds, the mixer
+    // stops waiting for it and forwards the active source's audio (padded with silence).
+    private var lastMicDataTime: CFAbsoluteTime = 0
+    private var lastSystemDataTime: CFAbsoluteTime = 0
+    private let sourceTimeout: CFAbsoluteTime = 2.0  // seconds
+    private var micSourceStalled = false
+    private var systemSourceStalled = false
+
     // MARK: - Public Methods
 
     /// Start the mixer
@@ -51,6 +60,10 @@ class AudioMixer {
         self.isRunning = true
         micBuffer = Data()
         systemBuffer = Data()
+        lastMicDataTime = 0
+        lastSystemDataTime = 0
+        micSourceStalled = false
+        systemSourceStalled = false
         bufferLock.unlock()
         log("AudioMixer: Started (mode=\(outputMode == .mono ? "mono" : "stereo"))")
     }
@@ -76,6 +89,12 @@ class AudioMixer {
         guard isRunning else { return }
 
         micBuffer.append(data)
+        lastMicDataTime = CFAbsoluteTimeGetCurrent()
+
+        if micSourceStalled {
+            micSourceStalled = false
+            log("AudioMixer: Mic source recovered")
+        }
 
         // Prevent unbounded buffer growth
         if micBuffer.count > maxBufferBytes {
@@ -94,6 +113,12 @@ class AudioMixer {
         guard isRunning else { return }
 
         systemBuffer.append(data)
+        lastSystemDataTime = CFAbsoluteTimeGetCurrent()
+
+        if systemSourceStalled {
+            systemSourceStalled = false
+            log("AudioMixer: System audio source recovered")
+        }
 
         // Prevent unbounded buffer growth
         if systemBuffer.count > maxBufferBytes {
@@ -106,8 +131,15 @@ class AudioMixer {
 
     // MARK: - Private Methods
 
-    /// Process buffers and produce stereo output when enough data is available
-    /// Must be called with bufferLock held
+    /// Process buffers and produce output when enough data is available.
+    ///
+    /// Normally waits for both mic and system buffers to have data, keeping them
+    /// aligned. When one source stalls (no data for `sourceTimeout` seconds), the
+    /// mixer switches to single-source mode for the active source, padding the
+    /// stalled source with silence. This prevents a dead Core Audio Tap (e.g. from
+    /// a permission timing issue) from blocking mic audio, and vice versa.
+    ///
+    /// Must be called with bufferLock held.
     private func processBuffers(flush: Bool = false) {
         guard isRunning || flush else { return }
 
@@ -121,11 +153,38 @@ class AudioMixer {
             // When flushing, process whatever is available
             bytesToProcess = max(micBuffer.count, systemBuffer.count)
         } else {
-            // Normal operation: process when both have data
-            let minAvailable = min(micBuffer.count, systemBuffer.count)
-            guard minAvailable >= minBufferBytes else { return }
-            // Align to sample boundary (2 bytes per Int16 sample)
-            bytesToProcess = (minAvailable / 2) * 2
+            let now = CFAbsoluteTimeGetCurrent()
+
+            // Check if either source has stalled (no data for sourceTimeout seconds).
+            // A source that never delivered data (lastTime == 0) is considered stalled
+            // once the other source has been active for at least sourceTimeout.
+            let micStalled = lastMicDataTime > 0
+                ? (now - lastMicDataTime > sourceTimeout)
+                : (lastSystemDataTime > 0 && now - lastSystemDataTime > sourceTimeout)
+            let sysStalled = lastSystemDataTime > 0
+                ? (now - lastSystemDataTime > sourceTimeout)
+                : (lastMicDataTime > 0 && now - lastMicDataTime > sourceTimeout)
+
+            if micStalled != micSourceStalled {
+                micSourceStalled = micStalled
+                if micStalled { log("AudioMixer: Mic source stalled — forwarding system audio only") }
+            }
+            if sysStalled != systemSourceStalled {
+                systemSourceStalled = sysStalled
+                if sysStalled { log("AudioMixer: System audio source stalled — forwarding mic audio only") }
+            }
+
+            if micStalled || sysStalled {
+                // Single-source mode: process whichever buffer has data, pad the other
+                let available = max(micBuffer.count, systemBuffer.count)
+                guard available >= minBufferBytes else { return }
+                bytesToProcess = (available / 2) * 2
+            } else {
+                // Normal dual-source mode: process when both have data
+                let minAvailable = min(micBuffer.count, systemBuffer.count)
+                guard minAvailable >= minBufferBytes else { return }
+                bytesToProcess = (minAvailable / 2) * 2
+            }
         }
 
         guard bytesToProcess >= 2 else { return }

--- a/desktop/Desktop/Sources/AudioMixer.swift
+++ b/desktop/Desktop/Sources/AudioMixer.swift
@@ -29,6 +29,15 @@ class AudioMixer {
     /// Tests inject a fake clock to avoid real sleeps.
     private let clock: () -> CFAbsoluteTime
 
+    // Debug audio dumping — set OMI_DEBUG_AUDIO=1 to write raw PCM files
+    private let debugAudioEnabled = ProcessInfo.processInfo.environment["OMI_DEBUG_AUDIO"] == "1"
+    private var debugMicFile: FileHandle?
+    private var debugSysFile: FileHandle?
+    private var debugMixFile: FileHandle?
+    private var debugMicBytes: Int = 0
+    private var debugSysBytes: Int = 0
+    private var debugMixBytes: Int = 0
+
     init(outputMode: OutputMode = .mono, clock: @escaping () -> CFAbsoluteTime = { CFAbsoluteTimeGetCurrent() }) {
         self.outputMode = outputMode
         self.clock = clock
@@ -71,6 +80,18 @@ class AudioMixer {
         lastSystemDataTime = 0
         micSourceStalled = false
         systemSourceStalled = false
+        if debugAudioEnabled {
+            let ts = Int(Date().timeIntervalSince1970)
+            for name in ["mic", "sys", "mix"] {
+                let path = "/tmp/omi-debug-\(name)-\(ts).raw"
+                FileManager.default.createFile(atPath: path, contents: nil)
+            }
+            debugMicFile = FileHandle(forWritingAtPath: "/tmp/omi-debug-mic-\(ts).raw")
+            debugSysFile = FileHandle(forWritingAtPath: "/tmp/omi-debug-sys-\(ts).raw")
+            debugMixFile = FileHandle(forWritingAtPath: "/tmp/omi-debug-mix-\(ts).raw")
+            debugMicBytes = 0; debugSysBytes = 0; debugMixBytes = 0
+            log("AudioMixer: Debug audio dumping to /tmp/omi-debug-{mic,sys,mix}-\(ts).raw")
+        }
         bufferLock.unlock()
         log("AudioMixer: Started (mode=\(outputMode == .mono ? "mono" : "stereo"))")
     }
@@ -84,6 +105,15 @@ class AudioMixer {
         micBuffer = Data()
         systemBuffer = Data()
         onMixedChunk = nil
+        if debugAudioEnabled {
+            debugMicFile?.closeFile(); debugMicFile = nil
+            debugSysFile?.closeFile(); debugSysFile = nil
+            debugMixFile?.closeFile(); debugMixFile = nil
+            let micSec = Double(debugMicBytes) / 32000.0
+            let sysSec = Double(debugSysBytes) / 32000.0
+            let mixSec = Double(debugMixBytes) / 32000.0
+            log("AudioMixer: Debug dump stats — mic: \(debugMicBytes)B (\(String(format: "%.1f", micSec))s), sys: \(debugSysBytes)B (\(String(format: "%.1f", sysSec))s), mix: \(debugMixBytes)B (\(String(format: "%.1f", mixSec))s)")
+        }
         bufferLock.unlock()
         log("AudioMixer: Stopped")
     }
@@ -233,6 +263,13 @@ class AudioMixer {
             mixed = sumToMono(mic: micData, system: sysData)
         case .stereo:
             mixed = interleave(mic: micData, system: sysData)
+        }
+
+        // Debug: dump raw audio to files
+        if debugAudioEnabled {
+            debugMicFile?.write(micData); debugMicBytes += micData.count
+            debugSysFile?.write(sysData); debugSysBytes += sysData.count
+            debugMixFile?.write(mixed); debugMixBytes += mixed.count
         }
 
         // Send to callback

--- a/desktop/Desktop/Sources/AudioMixer.swift
+++ b/desktop/Desktop/Sources/AudioMixer.swift
@@ -29,15 +29,6 @@ class AudioMixer {
     /// Tests inject a fake clock to avoid real sleeps.
     private let clock: () -> CFAbsoluteTime
 
-    // Debug audio dumping — set OMI_DEBUG_AUDIO=1 to write raw PCM files
-    private let debugAudioEnabled = ProcessInfo.processInfo.environment["OMI_DEBUG_AUDIO"] == "1"
-    private var debugMicFile: FileHandle?
-    private var debugSysFile: FileHandle?
-    private var debugMixFile: FileHandle?
-    private var debugMicBytes: Int = 0
-    private var debugSysBytes: Int = 0
-    private var debugMixBytes: Int = 0
-
     init(outputMode: OutputMode = .mono, clock: @escaping () -> CFAbsoluteTime = { CFAbsoluteTimeGetCurrent() }) {
         self.outputMode = outputMode
         self.clock = clock
@@ -80,18 +71,6 @@ class AudioMixer {
         lastSystemDataTime = 0
         micSourceStalled = false
         systemSourceStalled = false
-        if debugAudioEnabled {
-            let ts = Int(Date().timeIntervalSince1970)
-            for name in ["mic", "sys", "mix"] {
-                let path = "/tmp/omi-debug-\(name)-\(ts).raw"
-                FileManager.default.createFile(atPath: path, contents: nil)
-            }
-            debugMicFile = FileHandle(forWritingAtPath: "/tmp/omi-debug-mic-\(ts).raw")
-            debugSysFile = FileHandle(forWritingAtPath: "/tmp/omi-debug-sys-\(ts).raw")
-            debugMixFile = FileHandle(forWritingAtPath: "/tmp/omi-debug-mix-\(ts).raw")
-            debugMicBytes = 0; debugSysBytes = 0; debugMixBytes = 0
-            log("AudioMixer: Debug audio dumping to /tmp/omi-debug-{mic,sys,mix}-\(ts).raw")
-        }
         bufferLock.unlock()
         log("AudioMixer: Started (mode=\(outputMode == .mono ? "mono" : "stereo"))")
     }
@@ -105,15 +84,6 @@ class AudioMixer {
         micBuffer = Data()
         systemBuffer = Data()
         onMixedChunk = nil
-        if debugAudioEnabled {
-            debugMicFile?.closeFile(); debugMicFile = nil
-            debugSysFile?.closeFile(); debugSysFile = nil
-            debugMixFile?.closeFile(); debugMixFile = nil
-            let micSec = Double(debugMicBytes) / 32000.0
-            let sysSec = Double(debugSysBytes) / 32000.0
-            let mixSec = Double(debugMixBytes) / 32000.0
-            log("AudioMixer: Debug dump stats — mic: \(debugMicBytes)B (\(String(format: "%.1f", micSec))s), sys: \(debugSysBytes)B (\(String(format: "%.1f", sysSec))s), mix: \(debugMixBytes)B (\(String(format: "%.1f", mixSec))s)")
-        }
         bufferLock.unlock()
         log("AudioMixer: Stopped")
     }
@@ -263,13 +233,6 @@ class AudioMixer {
             mixed = sumToMono(mic: micData, system: sysData)
         case .stereo:
             mixed = interleave(mic: micData, system: sysData)
-        }
-
-        // Debug: dump raw audio to files
-        if debugAudioEnabled {
-            debugMicFile?.write(micData); debugMicBytes += micData.count
-            debugSysFile?.write(sysData); debugSysBytes += sysData.count
-            debugMixFile?.write(mixed); debugMixBytes += mixed.count
         }
 
         // Send to callback

--- a/desktop/Desktop/Sources/AudioMixer.swift
+++ b/desktop/Desktop/Sources/AudioMixer.swift
@@ -43,6 +43,7 @@ class AudioMixer {
     // Source liveness tracking — prevents one dead source from blocking the other.
     // When a source hasn't delivered data within `sourceTimeout` seconds, the mixer
     // stops waiting for it and forwards the active source's audio (padded with silence).
+    private var mixerStartTime: CFAbsoluteTime = 0
     private var lastMicDataTime: CFAbsoluteTime = 0
     private var lastSystemDataTime: CFAbsoluteTime = 0
     private let sourceTimeout: CFAbsoluteTime = 2.0  // seconds
@@ -60,6 +61,7 @@ class AudioMixer {
         self.isRunning = true
         micBuffer = Data()
         systemBuffer = Data()
+        mixerStartTime = CFAbsoluteTimeGetCurrent()
         lastMicDataTime = 0
         lastSystemDataTime = 0
         micSourceStalled = false
@@ -89,11 +91,15 @@ class AudioMixer {
         guard isRunning else { return }
 
         micBuffer.append(data)
-        lastMicDataTime = CFAbsoluteTimeGetCurrent()
 
-        if micSourceStalled {
-            micSourceStalled = false
-            log("AudioMixer: Mic source recovered")
+        // Only mark alive when non-empty data arrives (a broken capture path
+        // can send empty chunks which should not count as liveness).
+        if !data.isEmpty {
+            lastMicDataTime = CFAbsoluteTimeGetCurrent()
+            if micSourceStalled {
+                micSourceStalled = false
+                log("AudioMixer: Mic source recovered")
+            }
         }
 
         // Prevent unbounded buffer growth
@@ -113,11 +119,13 @@ class AudioMixer {
         guard isRunning else { return }
 
         systemBuffer.append(data)
-        lastSystemDataTime = CFAbsoluteTimeGetCurrent()
 
-        if systemSourceStalled {
-            systemSourceStalled = false
-            log("AudioMixer: System audio source recovered")
+        if !data.isEmpty {
+            lastSystemDataTime = CFAbsoluteTimeGetCurrent()
+            if systemSourceStalled {
+                systemSourceStalled = false
+                log("AudioMixer: System audio source recovered")
+            }
         }
 
         // Prevent unbounded buffer growth
@@ -157,13 +165,15 @@ class AudioMixer {
 
             // Check if either source has stalled (no data for sourceTimeout seconds).
             // A source that never delivered data (lastTime == 0) is considered stalled
-            // once the other source has been active for at least sourceTimeout.
+            // once sourceTimeout has elapsed since the mixer started.
+            // A source that was active but stopped is stalled when its last data time
+            // is more than sourceTimeout ago.
             let micStalled = lastMicDataTime > 0
                 ? (now - lastMicDataTime > sourceTimeout)
-                : (lastSystemDataTime > 0 && now - lastSystemDataTime > sourceTimeout)
+                : (now - mixerStartTime > sourceTimeout)
             let sysStalled = lastSystemDataTime > 0
                 ? (now - lastSystemDataTime > sourceTimeout)
-                : (lastMicDataTime > 0 && now - lastMicDataTime > sourceTimeout)
+                : (now - mixerStartTime > sourceTimeout)
 
             if micStalled != micSourceStalled {
                 micSourceStalled = micStalled

--- a/desktop/Desktop/Sources/AudioMixer.swift
+++ b/desktop/Desktop/Sources/AudioMixer.swift
@@ -25,8 +25,13 @@ class AudioMixer {
     private var onMixedChunk: AudioChunkHandler?
     private var isRunning = false
 
-    init(outputMode: OutputMode = .mono) {
+    /// Clock function for timestamps. Defaults to `CFAbsoluteTimeGetCurrent()`.
+    /// Tests inject a fake clock to avoid real sleeps.
+    private let clock: () -> CFAbsoluteTime
+
+    init(outputMode: OutputMode = .mono, clock: @escaping () -> CFAbsoluteTime = { CFAbsoluteTimeGetCurrent() }) {
         self.outputMode = outputMode
+        self.clock = clock
     }
 
     // Audio buffers (16kHz mono Int16 PCM)
@@ -61,7 +66,7 @@ class AudioMixer {
         self.isRunning = true
         micBuffer = Data()
         systemBuffer = Data()
-        mixerStartTime = CFAbsoluteTimeGetCurrent()
+        mixerStartTime = clock()
         lastMicDataTime = 0
         lastSystemDataTime = 0
         micSourceStalled = false
@@ -95,7 +100,7 @@ class AudioMixer {
         // Only mark alive when non-empty data arrives (a broken capture path
         // can send empty chunks which should not count as liveness).
         if !data.isEmpty {
-            lastMicDataTime = CFAbsoluteTimeGetCurrent()
+            lastMicDataTime = clock()
             if micSourceStalled {
                 micSourceStalled = false
                 log("AudioMixer: Mic source recovered")
@@ -121,7 +126,7 @@ class AudioMixer {
         systemBuffer.append(data)
 
         if !data.isEmpty {
-            lastSystemDataTime = CFAbsoluteTimeGetCurrent()
+            lastSystemDataTime = clock()
             if systemSourceStalled {
                 systemSourceStalled = false
                 log("AudioMixer: System audio source recovered")
@@ -161,7 +166,7 @@ class AudioMixer {
             // When flushing, process whatever is available
             bytesToProcess = max(micBuffer.count, systemBuffer.count)
         } else {
-            let now = CFAbsoluteTimeGetCurrent()
+            let now = clock()
 
             // Check if either source has stalled (no data for sourceTimeout seconds).
             // A source that never delivered data (lastTime == 0) is considered stalled

--- a/desktop/Desktop/Tests/AudioMixerTests.swift
+++ b/desktop/Desktop/Tests/AudioMixerTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+@testable import Omi_Computer
+
+final class AudioMixerTests: XCTestCase {
+
+    // Fake clock: tests control time by mutating `now`.
+    private var now: CFAbsoluteTime = 1000.0
+    private func fakeClock() -> CFAbsoluteTime { now }
+
+    /// 3200 bytes of non-silent Int16 PCM (minBufferBytes threshold).
+    private func audioChunk(value: Int16 = 1000, byteCount: Int = 3200) -> Data {
+        let sampleCount = byteCount / 2
+        var samples = [Int16](repeating: value, count: sampleCount)
+        return samples.withUnsafeMutableBufferPointer { Data(buffer: $0) }
+    }
+
+    /// Empty Data (0 bytes).
+    private func emptyChunk() -> Data { Data() }
+
+    // MARK: - Normal dual-source mixing
+
+    func testDualSourceMonoMixing() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // Both sources deliver enough data
+        mixer.setMicAudio(audioChunk(value: 100))
+        XCTAssertEqual(output.count, 0, "Should wait for both buffers")
+
+        mixer.setSystemAudio(audioChunk(value: 200))
+        XCTAssertEqual(output.count, 1, "Should emit once both have data")
+
+        // Verify summing: 100 + 200 = 300
+        let samples = output[0].withUnsafeBytes { $0.bindMemory(to: Int16.self) }
+        XCTAssertEqual(samples[0], 300)
+    }
+
+    func testDualSourceStereoInterleaving() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .stereo, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        mixer.setMicAudio(audioChunk(value: 100))
+        mixer.setSystemAudio(audioChunk(value: 200))
+        XCTAssertEqual(output.count, 1)
+
+        // Stereo: [mic0, sys0, mic1, sys1, ...]
+        let samples = output[0].withUnsafeBytes { $0.bindMemory(to: Int16.self) }
+        XCTAssertEqual(samples[0], 100, "Left channel = mic")
+        XCTAssertEqual(samples[1], 200, "Right channel = system")
+    }
+
+    // MARK: - System source stall (mic-only mode)
+
+    func testSystemNeverStartsMicBlockedBeforeTimeout() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // Advance 1.9s (below timeout)
+        now += 1.9
+        mixer.setMicAudio(audioChunk(value: 500))
+        XCTAssertEqual(output.count, 0, "Should still wait for system before timeout")
+    }
+
+    func testSystemNeverStartsMicEmitsAfterTimeout() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // Advance past timeout
+        now += 2.1
+        mixer.setMicAudio(audioChunk(value: 500))
+        XCTAssertEqual(output.count, 1, "Should emit mic-only after system stall timeout")
+
+        // Output should be mic audio (summed with silence = unchanged)
+        let samples = output[0].withUnsafeBytes { $0.bindMemory(to: Int16.self) }
+        XCTAssertEqual(samples[0], 500)
+    }
+
+    // MARK: - Mic source stall (system-only mode)
+
+    func testMicNeverStartsSystemEmitsAfterTimeout() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        now += 2.1
+        mixer.setSystemAudio(audioChunk(value: 300))
+        XCTAssertEqual(output.count, 1, "Should emit system-only after mic stall timeout")
+
+        let samples = output[0].withUnsafeBytes { $0.bindMemory(to: Int16.self) }
+        XCTAssertEqual(samples[0], 300)
+    }
+
+    // MARK: - Active source stops mid-session
+
+    func testSystemStopsAfterBeingActive() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // Both sources active
+        mixer.setMicAudio(audioChunk(value: 100))
+        mixer.setSystemAudio(audioChunk(value: 200))
+        XCTAssertEqual(output.count, 1)
+
+        // System stops, mic continues. Advance past timeout.
+        now += 2.1
+        mixer.setMicAudio(audioChunk(value: 100))
+        XCTAssertEqual(output.count, 2, "Should emit mic-only after system stall")
+
+        let samples = output[1].withUnsafeBytes { $0.bindMemory(to: Int16.self) }
+        XCTAssertEqual(samples[0], 100, "Should be mic-only (system padded with silence)")
+    }
+
+    // MARK: - Empty data does not refresh liveness
+
+    func testEmptyDataDoesNotRefreshLiveness() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // System sends empty data — should not count as alive
+        now += 2.1
+        mixer.setSystemAudio(emptyChunk())
+        mixer.setMicAudio(audioChunk(value: 400))
+        XCTAssertEqual(output.count, 1, "System should be stalled despite empty chunk; mic emits solo")
+
+        let samples = output[0].withUnsafeBytes { $0.bindMemory(to: Int16.self) }
+        XCTAssertEqual(samples[0], 400)
+    }
+
+    // MARK: - Recovery
+
+    func testStalledSourceRecovery() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // System stalls, mic emits solo
+        now += 2.1
+        mixer.setMicAudio(audioChunk(value: 100))
+        XCTAssertEqual(output.count, 1)
+
+        // System recovers with real data
+        now += 0.1
+        mixer.setSystemAudio(audioChunk(value: 200))
+
+        // Now send mic again — should wait for system (dual-source mode resumed)
+        output.removeAll()
+        now += 0.1
+        mixer.setMicAudio(audioChunk(value: 100))
+        // Both have data, should emit mixed
+        XCTAssertEqual(output.count, 1, "Should resume dual-source mixing after recovery")
+
+        let samples = output[0].withUnsafeBytes { $0.bindMemory(to: Int16.self) }
+        XCTAssertEqual(samples[0], 300, "Should be sum of mic(100) + system(200)")
+    }
+
+    // MARK: - start() resets state
+
+    func testStartResetsLivenessState() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // Make system stall
+        now += 2.1
+        mixer.setMicAudio(audioChunk(value: 100))
+        XCTAssertEqual(output.count, 1)
+
+        // Stop and restart — stale state should be cleared
+        mixer.stop()
+        output.removeAll()
+
+        now += 0.1
+        mixer.start { output.append($0) }
+
+        // Both sources deliver data — should work as dual-source (no stale stall)
+        mixer.setMicAudio(audioChunk(value: 100))
+        XCTAssertEqual(output.count, 0, "Should wait for both after restart")
+        mixer.setSystemAudio(audioChunk(value: 200))
+        XCTAssertEqual(output.count, 1, "Should emit dual-source mixed")
+    }
+
+    // MARK: - Timeout boundary
+
+    func testExactlyAtTimeoutStillWaits() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // Advance exactly 2.0s (timeout uses strict >)
+        now += 2.0
+        mixer.setMicAudio(audioChunk(value: 100))
+        XCTAssertEqual(output.count, 0, "Exactly at timeout boundary should still wait (strict >)")
+    }
+
+    func testJustOverTimeoutSwitchesToSingleSource() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // Advance 2.001s (just over)
+        now += 2.001
+        mixer.setMicAudio(audioChunk(value: 100))
+        XCTAssertEqual(output.count, 1, "Just over timeout should switch to single-source")
+    }
+
+    // MARK: - Flush behavior
+
+    func testStopFlushesBothBuffers() {
+        var output = [Data]()
+        let mixer = AudioMixer(outputMode: .mono, clock: fakeClock)
+        mixer.start { output.append($0) }
+
+        // Add sub-threshold data to both
+        let smallChunk = audioChunk(value: 100, byteCount: 1000)
+        mixer.setMicAudio(smallChunk)
+        mixer.setSystemAudio(smallChunk)
+        XCTAssertEqual(output.count, 0, "Below threshold, no output yet")
+
+        mixer.stop()
+        XCTAssertEqual(output.count, 1, "Stop should flush remaining data")
+    }
+}


### PR DESCRIPTION
## Summary
- **Root cause**: `AudioMixer.processBuffers()` waited for BOTH mic and system audio buffers to have ≥3200 bytes before producing any output. When one source stalled (e.g., Core Audio Tap not delivering system audio due to permission timing), the active source was silenced too — causing blank/bad transcripts even when the mic was working fine.
- **Fix**: Added source liveness tracking with a 2-second timeout. When a source stalls (never starts or stops mid-session), the mixer switches to single-source mode — forwarding the active source's audio padded with silence for the stalled source.
- **Empty data guard**: Empty `Data()` chunks no longer refresh liveness timestamps, preventing a broken capture path from masking a stall.
- **Injectable clock**: `AudioMixer.init` accepts a `clock` parameter for deterministic testing without real sleeps.

## Changed paths
| Path | Description |
|------|-------------|
| `AudioMixer.swift:init` | Injectable clock parameter for testability |
| `AudioMixer.swift:start()` | Reset liveness state (mixerStartTime, lastDataTimes, stall flags) |
| `AudioMixer.swift:setMicAudio()` | Liveness tracking with empty-data guard + recovery logging |
| `AudioMixer.swift:setSystemAudio()` | Liveness tracking with empty-data guard + recovery logging |
| `AudioMixer.swift:processBuffers()` | Stall detection: never-started source, active-then-stopped, single-source forwarding |
| `AudioMixerTests.swift` | 12 new unit tests covering all stall detection scenarios |

## Test evidence

### Unit tests (12/12 pass, 0.005s)
- Dual-source mono mixing (sum with clipping)
- Dual-source stereo interleaving
- System never starts → mic blocked before timeout
- System never starts → mic emits after timeout
- Mic never starts → system emits after timeout
- Active source stops mid-session
- Empty data does not refresh liveness
- Stalled source recovery
- start() resets liveness state
- Exact timeout boundary (strict >)
- Just over timeout switches to single-source
- Stop flushes both buffers

### L1 live test (standalone)
- Named test bundle `omi-7160-mixer` (bundle ID: `com.omi.omi-7160-mixer`) built and launched
- App launches to sign-in screen, progresses through onboarding
- AudioMixer logs confirm stall detection: `System audio source stalled — forwarding mic audio only`
- Recovery logging works: `System audio source recovered`

### L2 live test (integrated)
- Auth injected from production bundle → app connected to prod Cloud Run backend
- Knowledge graph populated (216 files indexed, user data loaded)
- Transcription pipeline end-to-end verified (existing Omi Beta sessions show transcript segments)
- No regression — app renders normally through onboarding

## Risks / edge cases
- **2s timeout**: Chosen to balance responsiveness vs. false positives. Too short = flicker between modes during slow Core Audio Tap init; too long = prolonged silence.
- **Empty data guard**: Prevents liveness refresh from zero-length chunks (broken capture paths), ensuring stall detection still triggers.
- **Thread safety**: All liveness state mutations happen inside existing `bufferLock` — no new synchronization needed.

Closes #7160