### PR TITLE
fix(desktop): make run.sh work in non-English locales

### DIFF
--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Force C locale for numeric formatting so `printf %f` accepts the
+# dot-decimal values produced by `bc` even when the user's shell runs in
+# a non-English locale (e.g. de_DE.UTF-8 expects a comma separator).
+export LC_NUMERIC=C
+
 # ─── Help ──────────────────────────────────────────────────────────────
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     cat <<'USAGE'


### PR DESCRIPTION
## Summary
- `desktop/run.sh` fails on first run for users whose shell runs in a non-English locale (e.g. `de_DE.UTF-8`):
  ```
  ./run.sh: line 81: printf: .018953000: invalid number
  ```
- Root cause: the `step()` / `substep()` timing helpers feed `bc` output (dot-decimal, e.g. `.018953000`) into bash's `printf "%6.1f"`, which respects `LC_NUMERIC` and rejects the dot when the locale expects a comma as decimal separator.
- Fix: `export LC_NUMERIC=C` near the top of `run.sh` so numeric formatting stays POSIX regardless of the user's shell locale. Other locale categories (messages, etc.) are untouched.

## Test plan
- [x] Reproduced the original error locally under `LANG=de_DE.UTF-8`: `printf: .018953000: invalid number`
- [x] With the fix applied, the same `printf` call prints `[   0.0s]` cleanly under `LANG=de_DE.UTF-8`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)