### PR TITLE
agent-proxy: sync fastapi + cryptography pins from backend

### DIFF
--- a/backend/agent-proxy/requirements.txt
+++ b/backend/agent-proxy/requirements.txt
@@ -3,6 +3,6 @@ uvicorn[standard]==0.30.6
 uvloop==0.20.0
 websockets==12.0
 firebase-admin==6.5.0
-cryptography
+cryptography==46.0.7
 httpx==0.28.0
 google-auth==2.32.0

--- a/backend/agent-proxy/requirements.txt
+++ b/backend/agent-proxy/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.115.0
+fastapi==0.121.0
 uvicorn[standard]==0.30.6
 uvloop==0.20.0
 websockets==12.0


### PR DESCRIPTION
First of four service-sync PRs propagating the security bumps from backend (#7126, #7127, #7146, #7149) to the sub-services that don't auto-inherit `backend/requirements.txt`.

## What this PR does

Two atomic commits:

| Package | Before | After | Why |
|---|---|---|---|
| `fastapi` | `0.115.0` | `0.121.0` | matches backend's pin from #7146 |
| `cryptography` | unpinned | `46.0.7` | matches backend's pin from #7146 |

`uvicorn[standard]` is already at `0.30.6` (one patch ahead of backend's `0.30.5`), left alone. Everything else (`uvloop`, `websockets`, `firebase-admin`, `httpx`, `google-auth`) already matches backend.

## CVEs closed

| CVE | Severity | Package | Fix at |
|---|---|---|---|
| CVE-2024-47874 | HIGH 7.5 | starlette (transitive of fastapi) | starlette 0.40 — fastapi 0.118 caps |
| CVE-2025-62727 | HIGH 7.5 | starlette (transitive of fastapi) | starlette 0.49 — fastapi 0.121 caps |
| CVE-2026-39892 | MEDIUM (CVSS 9.8) | cryptography | 46.0.7 |
| CVE-2026-26007 | HIGH 6.5 | cryptography | 46.0.5 (also covered by the 46.0.7 pin) |

## Test plan

End-to-end smoke test in a clean Python 3.12 venv with the mohsins-agents service account exported via `GOOGLE_APPLICATION_CREDENTIALS`:

- [x] `pip install -r requirements.txt` clean; `pip check` reports no broken dependencies
- [x] Resolved versions match: `fastapi 0.121.0`, `starlette 0.49.3`, `cryptography 46.0.7`, `uvicorn 0.30.6`, `httpx 0.28.0`
- [x] All `main.py` top-level imports resolve (firebase_admin, fastapi, AESGCM + HKDF from cryptography.hazmat, websockets, google.cloud.firestore_v1, etc.)
- [x] `uvicorn main:app --loop uvloop` boots clean: `Application startup complete`, zero warnings
- [x] `GET /health` returns 200 `{"status":"ok"}`
- [x] `GET /openapi.json` returns 200, schema is OpenAPI 3.1.0 (fastapi 0.121's output)
- [x] `GET /v1/agent/ws` (over HTTP) returns 404 — correct, it's a WebSocket-only endpoint
- [x] `WS /v1/agent/ws` without `Authorization: Bearer` header is rejected with HTTP 403; log shows `WS rejected: missing Authorization header` — auth code path executes correctly under starlette 0.49.3
- [x] Clean shutdown
- [ ] Confirm post-deploy Artifact Registry rescan shows the 4 CVEs cleared on the agent-proxy image

## Follow-ups in this series

- pusher (`backend/pusher/`) — 57 shared packages with backend
- diarizer (`backend/diarizer/`) — 57 shared packages
- plugins (`plugins/`) — 110 shared packages, biggest fan-out

vad (`backend/modal/`) and notifications-job already auto-inherit `backend/requirements.txt` via `-r ../requirements.txt`, so they're not in this series.