### PR TITLE
pusher: sync 20 dep pins from backend (incl. langchain 0.3 → 1.x)

### DIFF
--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -2,10 +2,10 @@
 # No torch, onnxruntime, pyannote, speechbrain, librosa, matplotlib, pandas, scipy
 
 # Web framework
-fastapi==0.112.0
+fastapi==0.121.0
 uvicorn==0.30.5
 uvloop==0.20.0
-starlette==0.37.2
+starlette==0.49.1
 websockets==12.0
 httpx==0.28.0
 python-multipart==0.0.26

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -8,7 +8,7 @@ uvloop==0.20.0
 starlette==0.37.2
 websockets==12.0
 httpx==0.28.0
-python-multipart==0.0.9
+python-multipart==0.0.26
 
 # Data validation
 pydantic==2.8.2

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -73,7 +73,7 @@ cryptography==43.0.0
 python-dotenv==1.0.1
 tenacity==8.2.3
 python-dateutil==2.9.0.post0
-orjson==3.10.6
+orjson==3.11.6
 tiktoken==0.7.0
 jiwer==3.0.4
 python-ulid==3.0.0

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -67,7 +67,7 @@ neo4j==5.23.1
 deepgram-sdk==4.8.1
 
 # Security & encryption
-cryptography==43.0.0
+cryptography==46.0.7
 
 # Utilities
 python-dotenv==1.2.2

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -11,9 +11,9 @@ httpx==0.28.0
 python-multipart==0.0.26
 
 # Data validation
-pydantic==2.8.2
+pydantic==2.11.10
 pydantic-settings==2.10.1
-pydantic_core==2.20.1
+pydantic_core==2.33.2
 
 # Google Cloud
 firebase-admin==6.5.0

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -70,7 +70,7 @@ deepgram-sdk==4.8.1
 cryptography==43.0.0
 
 # Utilities
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 tenacity==8.2.3
 python-dateutil==2.9.0.post0
 orjson==3.11.6

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -17,7 +17,7 @@ pydantic_core==2.20.1
 
 # Google Cloud
 firebase-admin==6.5.0
-google-cloud-firestore==2.17.0
+google-cloud-firestore==2.20.0
 google-cloud-storage==2.18.0
 google-cloud-translate==3.20.2
 google-auth==2.32.0

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -44,7 +44,7 @@ prometheus-client==0.21.1
 
 # LLM services (for process_conversation)
 anthropic>=0.52.0
-openai==1.104.2
+openai==1.109.1
 groq==0.9.0
 langchain==0.3.27
 langchain-community==0.3.31

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -27,7 +27,7 @@ google-api-python-client==2.139.0
 redis==5.0.8
 
 # HTTP
-requests~=2.32.5
+requests~=2.33.0
 
 # Audio encoding & processing
 opuslib==3.0.1

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -46,15 +46,15 @@ prometheus-client==0.21.1
 anthropic>=0.52.0
 openai==1.109.1
 groq==0.9.0
-langchain==0.3.27
-langchain-community==0.3.31
-langchain-core==0.3.79
-langchain-google-genai==2.1.12
-langchain-openai==0.3.35
-langchain-pinecone==0.2.12
-langchain-text-splitters==0.3.11
-langgraph==0.6.10
-langsmith==0.4.37
+langchain==1.2.9
+langchain-community==0.4.1
+langchain-core==1.3.2
+langchain-google-genai==3.2.0
+langchain-openai==1.1.9
+langchain-pinecone==0.2.13
+langchain-text-splitters==1.1.2
+langgraph==1.0.10
+langsmith==0.7.31
 
 # Vector databases
 pinecone==7.3.0


### PR DESCRIPTION
Second of four service-sync PRs propagating backend's #7126 + #7127 + #7146 + #7149 bumps to the sub-services that don't auto-inherit `backend/requirements.txt`. Follows #7173 (agent-proxy).

## What this PR does

10 atomic commits, one per package family. 20 pins lifted to match backend.

| # | Commit | Package(s) | Was → Now |
|---|---|---|---|
| 1 | orjson | orjson | 3.10.6 → 3.11.6 |
| 2 | python-multipart | python-multipart | 0.0.9 → 0.0.26 |
| 3 | python-dotenv | python-dotenv | 1.0.1 → 1.2.2 |
| 4 | requests | requests | ~=2.32.5 → ~=2.33.0 |
| 5 | cryptography | cryptography | 43.0.0 → 46.0.7 |
| 6 | google-cloud-firestore | google-cloud-firestore | 2.17.0 → 2.20.0 |
| 7 | fastapi+starlette | fastapi / starlette | 0.112.0 / 0.37.2 → 0.121.0 / 0.49.1 |
| 8 | pydantic+pydantic_core | pydantic / pydantic_core | 2.8.2 / 2.20.1 → 2.11.10 / 2.33.2 |
| 9 | openai | openai | 1.104.2 → 1.109.1 |
| 10 | langchain stack | langchain / langchain-community / langchain-core / langchain-google-genai / langchain-openai / langchain-pinecone / langchain-text-splitters / langgraph / langsmith | 0.3.x → 1.x cascade |

## CVEs closed

Mirroring backend's PRs:

- **From #7126 (safe bumps):** HIGH 7.5 CVE-2025-67221 (orjson), HIGH 7.5 CVE-2024-53981 + CVE-2026-24486 (python-multipart)
- **From #7127 (cascades):** HIGH 7.5 CVE-2024-47874 (starlette via fastapi), HIGH 6.5 CVE-2026-26007 (cryptography)
- **From #7146 (Python MEDIUMs + 1 HIGH):** HIGH 7.5 CVE-2025-62727 (starlette via fastapi), MEDIUM 5.3 CVE-2025-54121 (starlette), MEDIUM (CVSS 9.8) CVE-2026-39892 (cryptography), MEDIUM 7.5 CVE-2026-40347 (python-multipart), MEDIUM 6.6 CVE-2026-28684 (python-dotenv), MEDIUM 5.5 CVE-2026-25645 (requests)
- **From #7149 (langchain 1.x cascade):** HIGH 7.5 CVE-2026-34070 (langchain-core), HIGH 0 CVE-2025-64439 (langgraph-checkpoint, transitive of langgraph 1.x), CRITICAL 8.2 CVE-2025-68664 + HIGH CVE-2025-65106 (langchain-core), MEDIUM 7.2 CVE-2026-28277 (langgraph), MEDIUM 6.6 CVE-2026-27794 (langgraph-checkpoint, transitive), MEDIUM 6.5 CVE-2026-41481 (langchain-text-splitters), MEDIUM 5.3 CVE-2026-40087 (langchain-core), 2× MEDIUM CVE-2026-25528 + CVE-2026-41182 (langsmith)

## Why no shared-code changes

Pusher's Dockerfile COPYs `backend/utils/`, `backend/routers/`, `backend/database/`, `backend/models/`. Those modules were already migrated to the langchain 1.x import paths in #7149 (e.g. `backend/utils/llm/persona.py` uses `from langchain_core.messages` instead of the removed `from langchain.schema`). Greped all four directories for any stale `langchain.schema` / `langchain.chat_models` / `langchain.tools` / `langchain.runnables` imports — none found. No code change needed in pusher itself.

`langgraph-checkpoint`, `langgraph-prebuilt`, `langgraph-sdk`, and `typing_extensions` are left unpinned in pusher and resolve transitively through `langchain-core 1.3.2` and `langgraph 1.0.10`. Verified the resolver picks `typing_extensions==4.15.0` (matches backend's explicit pin).

## Test plan

End-to-end smoke test in a Python 3.12 venv, with all 16 prod secrets pulled from GSM (sourced + shredded — no values left on disk):

- [x] `pip install -r requirements.txt` clean (lc3py built locally from the same liblc3 upstream the Dockerfile uses); `pip check` reports no broken deps
- [x] All 21 bumped packages resolve to the expected pins; `typing_extensions==4.15.0` auto-resolved
- [x] `langchain_core` 1.x imports verified (the full set used in shared `utils/llm/`, `utils/retrieval/`, `utils/observability/`): `SystemMessage` / `HumanMessage` / `AIMessage` / `ChatPromptTemplate` / `RunnableConfig` / `tool` / `StructuredTool` / `PydanticOutputParser` / `BaseCallbackHandler` / `LLMResult` / `LangChainTracer` / `BaseChatModel` — all import clean
- [x] fastapi 0.121 + pydantic 2.11 + starlette 0.49 interop verified (FastAPI app + pydantic v2 BaseModel + validation round-trip)
- [x] cryptography 46.0.7 AESGCM + HKDF round-trip works (the primitives `pusher`'s encryption code uses)
- [x] **Full `uvicorn pusher.main:app` boot** with prod env (PINECONE/REDIS/OPENAI/FAL/GROQ/DEEPGRAM/STRIPE/TYPESENSE/LANGCHAIN/ENCRYPTION/etc.):
  - `utils/llm/clients.py` module-loads **all 35 QoS LLM clients** (gpt-5.4-mini, gpt-4.1-mini/nano, gemini-2.5-flash-lite, claude-sonnet-4-6, sonar-pro, openrouter) without errors under langchain-core 1.3.2 + langchain-openai 1.1.9 + langchain-google-genai 3.2.0 + langchain-anthropic
  - BYOK QoS profile loads
  - `Started server process` + `Application startup complete` — zero errors, zero warnings
  - `GET /health` → 200 `{"status":"healthy"}`
  - `GET /metrics` → 401 (auth-required, correct)
  - `GET /openapi.json` → 200, schema is OpenAPI 3.1.0 (fastapi 0.121's output)
  - Clean shutdown
- [ ] Confirm post-deploy Artifact Registry rescan shows the targeted CVEs cleared on the pusher GKE image

## Follow-ups in this series

- diarizer (`backend/diarizer/`) — 57 shared packages with backend
- plugins (`plugins/`) — 110 shared packages, biggest fan-out

vad (`backend/modal/`) and notifications-job already auto-inherit `backend/requirements.txt` via `-r ../requirements.txt`.