### PR TITLE
diarizer: sync 10 dep pins from backend (no langchain stack)

### DIFF
--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -88,7 +88,7 @@ pytorch-lightning==2.6.0
 pytorch-metric-learning==2.9.0
 pytz==2025.2
 pyyaml==6.0.3
-requests==2.32.5
+requests~=2.33.0
 rich==14.2.0
 safetensors==0.7.0
 scikit-learn==1.8.0

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -88,7 +88,7 @@ pytorch-lightning==2.6.0
 pytorch-metric-learning==2.9.0
 pytz==2025.2
 pyyaml==6.0.3
-requests~=2.33.0
+requests==2.33.1
 rich==14.2.0
 safetensors==0.7.0
 scikit-learn==1.8.0

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -15,7 +15,7 @@ contourpy==1.3.3
 cycler==0.12.1
 einops==0.8.1
 fastapi==0.112.0
-filelock==3.20.1
+filelock==3.20.3
 fonttools==4.61.1
 frozenlist==1.8.0
 fsspec[http]==2025.12.0

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -83,7 +83,7 @@ pydantic-core==2.20.1
 pygments==2.19.2
 pyparsing==3.3.0
 python-dateutil==2.9.0.post0
-python-multipart==0.0.21
+python-multipart==0.0.26
 pytorch-lightning==2.6.0
 pytorch-metric-learning==2.9.0
 pytz==2025.2

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -14,7 +14,7 @@ colorlog==6.10.1
 contourpy==1.3.3
 cycler==0.12.1
 einops==0.8.1
-fastapi==0.112.0
+fastapi==0.121.0
 filelock==3.20.3
 fonttools==4.61.1
 frozenlist==1.8.0
@@ -97,7 +97,7 @@ six==1.17.0
 sortedcontainers==2.4.0
 soundfile==0.13.1
 sqlalchemy==2.0.45
-starlette==0.37.2
+starlette==0.49.1
 sympy==1.14.0
 threadpoolctl==3.6.0
 torch==2.8.0

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -32,7 +32,7 @@ julius==0.2.7
 kiwisolver==1.4.9
 lightning==2.6.0
 lightning-utilities==0.15.2
-mako==1.3.10
+mako==1.3.11
 markdown-it-py==4.0.0
 markupsafe==3.0.3
 matplotlib==3.10.8

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -67,7 +67,7 @@ opentelemetry-semantic-conventions==0.60b1
 optuna==4.6.0
 packaging==25.0
 pandas==2.3.3
-pillow==12.0.0
+pillow==12.2.0
 primepy==1.3
 propcache==0.4.1
 protobuf==6.33.2

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.13.2
+aiohttp==3.13.4
 aiosignal==1.4.0
 alembic==1.17.2
 annotated-types==0.7.0

--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -78,8 +78,8 @@ pyannote-metrics==4.0.0
 pyannote-pipeline==4.0.0
 pyannoteai-sdk==0.3.0
 pycparser==2.23
-pydantic==2.8.2
-pydantic-core==2.20.1
+pydantic==2.11.10
+pydantic-core==2.33.2
 pygments==2.19.2
 pyparsing==3.3.0
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Third of four service-sync PRs propagating backend's #7126 + #7127 + #7146 + #7149 bumps to the sub-services that don't auto-inherit `backend/requirements.txt`. Follows #7173 (agent-proxy) and #7177 (pusher).

## What this PR does

8 atomic commits, 10 pins lifted to match backend. Diarizer doesn't use langchain so no major-cascade work — much smaller than pusher.

| # | Commit | Package(s) | Was → Now |
|---|---|---|---|
| 1 | aiohttp | aiohttp | 3.13.2 → 3.13.4 |
| 2 | python-multipart | python-multipart | 0.0.21 → 0.0.26 |
| 3 | requests | requests | 2.32.5 → ~=2.33.0 |
| 4 | filelock | filelock | 3.20.1 → 3.20.3 |
| 5 | mako | mako | 1.3.10 → 1.3.11 |
| 6 | pillow | pillow | 12.0.0 → 12.2.0 |
| 7 | fastapi+starlette | fastapi / starlette | 0.112.0 / 0.37.2 → 0.121.0 / 0.49.1 |
| 8 | pydantic+pydantic-core | pydantic / pydantic-core | 2.8.2 / 2.20.1 → 2.11.10 / 2.33.2 |

Diarizer was already mostly aligned with backend after #7157 (the recent base-image bump). The other 47 shared packages either match exactly or are AHEAD of backend (e.g. `aiohappyeyeballs 2.6.1 > 2.5.0`, `anyio 4.12.0 > 4.4.0`, `numpy 2.4.0 > 1.26.4`, `protobuf 6.33.2 > 5.29.6`) — those were left untouched. Never downgrade.

## CVEs closed (~14)

- **From #7126 / #7146 (aiohttp 3.13.x rollup):** 4× MEDIUM CVE-2026-22815 / -34515 / -34516 / -34525 + 6× LOW (CVE-2026-34520 et al.)
- **From #7127 + #7146 (fastapi/starlette):** HIGH 7.5 CVE-2024-47874, HIGH 7.5 CVE-2025-62727, MEDIUM 5.3 CVE-2025-54121
- **From #7146 (Python MEDIUMs):** MEDIUM CVE-2025-68146 + CVE-2026-22701 (filelock), MEDIUM 7.5 CVE-2026-41205 (mako), MEDIUM 5.3 CVE-2026-40347 (python-multipart), MEDIUM 5.5 CVE-2026-25645 (requests)
- **From #7127 (pillow cascade):** HIGH 7.5 CVE-2026-25990, HIGH 7.5 CVE-2026-40192

## Test plan

End-to-end smoke test in a Python 3.12 venv (local platform: ARM64; diarizer's runtime target is amd64+CUDA):

- [x] `pip install` of all bumped packages clean; `pip check` reports no broken deps
- [x] All 12 bumped packages resolve to expected pins; `typing_extensions==4.15.0` auto-resolved
- [x] **Full `uvicorn main:app` boot** with `diarization` and `embedding` modules stubbed (pyannote-audio's transitive `torchcodec==0.7.0` is amd64-only — pre-existing platform pin, not affected by these bumps):
  - `Started server process` + `Application startup complete` — zero errors, zero warnings
  - `GET /health` → 200 `{"status":"healthy"}`
  - `POST /v1/diarization` with multipart file upload → 200 (exercises `starlette 0.49.1` + `python-multipart 0.0.26` upload hot path under `fastapi 0.121`)
  - `POST /v2/embedding` with multipart upload → 200
  - `GET /openapi.json` → 200, schema is OpenAPI 3.1.0 (fastapi 0.121's output)
  - All four endpoints registered with proper signatures
  - Clean shutdown
- [x] `pydantic 2.11.10` + `fastapi 0.121.0` + `starlette 0.49.1` interop verified (built diarizer-shape app, instantiated `BaseModel`, validation round-trip)
- [ ] Confirm post-deploy Artifact Registry rescan shows the targeted CVEs cleared on the diarizer GKE image

### On `pydantic 2.11` + `torch` / `lightning` / `pyannote-audio` interop

Can't fully exercise locally because `pyannote-audio 4.0.3` requires `torchcodec==0.7.0` which is amd64-only (only `0.0.0.dev0` / `0.11.x` are available on Python 3.12 + aarch64). This is a pre-existing platform constraint, not affected by my bumps.

The combination is implicitly proven by backend's #7149 (`pydantic==2.11.10` running in prod since this morning) and `backend/modal` (which combines `torch` + `lightning` + `pyannote-audio` + `pydantic 2.11` — already inherits backend's `requirements.txt` via `-r ../requirements.txt` and is running in prod on modal today).

## Follow-ups in this series

- plugins (`plugins/`) — 110 shared packages, biggest fan-out

vad (`backend/modal/`) and notifications-job already auto-inherit `backend/requirements.txt` via `-r ../requirements.txt`.