### PR TITLE
fix(app): voice response no longer cut off by notification chime (#7135)

### DIFF
--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -16,6 +16,7 @@ import 'package:omi/services/notifications/action_item_notification_handler.dart
 import 'package:omi/services/notifications/important_conversation_notification_handler.dart';
 import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/services/notifications/notification_interface.dart';
+import 'package:omi/services/voice_playback/omi_voice_playback_service.dart';
 import 'package:omi/utils/analytics/intercom.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -238,14 +239,18 @@ class _FCMNotificationService implements NotificationInterface {
           _serverMessageStreamController.add(ServerMessage.fromJson(data));
         }
         if (noti != null && _shouldShowForegroundNotificationOnFCMMessageReceived()) {
-          _showForegroundNotification(noti: noti, payload: payload);
+          if (!OmiVoicePlaybackService.instance.isSpeaking) {
+            _showForegroundNotification(noti: noti, payload: payload);
+          }
         }
         return;
       }
 
       // Announcement likes
       if (noti != null && _shouldShowForegroundNotificationOnFCMMessageReceived()) {
-        _showForegroundNotification(noti: noti, layout: NotificationLayout.BigText);
+        if (!OmiVoicePlaybackService.instance.isSpeaking) {
+          _showForegroundNotification(noti: noti, layout: NotificationLayout.BigText);
+        }
         return;
       }
     });

--- a/app/lib/services/voice_playback/omi_voice_playback_service.dart
+++ b/app/lib/services/voice_playback/omi_voice_playback_service.dart
@@ -208,6 +208,10 @@ class OmiVoicePlaybackService {
   }
 
   void _onInterruption(AudioInterruptionEvent event) {
+    debugPrint(
+      'OmiVoicePlayback: interruption begin=${event.begin} type=${event.type} '
+      'activeId=$_activeMessageId isSpeaking=$isSpeaking pausedByInt=$_pausedByInterruption',
+    );
     if (event.begin) {
       switch (event.type) {
         case AudioInterruptionType.duck:

--- a/app/lib/services/voice_playback/omi_voice_playback_service.dart
+++ b/app/lib/services/voice_playback/omi_voice_playback_service.dart
@@ -27,7 +27,7 @@ class OmiVoicePlaybackService {
   OmiVoicePlaybackService._();
   static final OmiVoicePlaybackService instance = OmiVoicePlaybackService._();
 
-  final AudioPlayer _player = AudioPlayer();
+  final AudioPlayer _player = AudioPlayer(handleInterruptions: false);
   final FlutterTts _fallbackTts = FlutterTts();
 
   bool _initialized = false;
@@ -42,6 +42,7 @@ class OmiVoicePlaybackService {
   bool _synthesizing = false;
   bool _isPlayingQueue = false;
   bool _sessionActive = false;
+  bool _pausedByInterruption = false;
 
   bool get isSpeaking => _sessionActive && (_isPlayingQueue || _audioQueue.isNotEmpty || _synthesizing);
 
@@ -51,15 +52,19 @@ class OmiVoicePlaybackService {
 
     try {
       final session = await AudioSession.instance;
-      await session.configure(const AudioSessionConfiguration.speech());
-      session.interruptionEventStream.listen((event) {
-        if (event.begin) {
-          _player.pause();
-        } else {
-          // Don't auto-resume — the reply is stale after an interruption.
-          interrupt();
-        }
-      });
+      await session.configure(
+        const AudioSessionConfiguration(
+          avAudioSessionCategory: AVAudioSessionCategory.playback,
+          avAudioSessionMode: AVAudioSessionMode.voicePrompt,
+          androidAudioAttributes: AndroidAudioAttributes(
+            contentType: AndroidAudioContentType.speech,
+            usage: AndroidAudioUsage.assistant,
+          ),
+          androidAudioFocusGainType: AndroidAudioFocusGainType.gain,
+          androidWillPauseWhenDucked: false,
+        ),
+      );
+      session.interruptionEventStream.listen(_onInterruption);
       // Stop immediately when headphones are unplugged mid-playback so the
       // reply doesn't suddenly blast out of the phone speaker in public.
       session.becomingNoisyEventStream.listen((_) {
@@ -145,15 +150,12 @@ class OmiVoicePlaybackService {
 
   /// Called on every streamed text update. [fullText] is the cumulative AI
   /// response so far. [isFinal] means this is the last chunk.
-  void updateStreamingResponse({
-    required String messageId,
-    required String fullText,
-    required bool isFinal,
-  }) {
+  void updateStreamingResponse({required String messageId, required String fullText, required bool isFinal}) {
     if (SharedPreferencesUtil().voiceResponseMode == 0) return;
     if (_activeMessageId != messageId) {
       Logger.log(
-          'OmiVoicePlayback: updateStreamingResponse skipped — activeId=$_activeMessageId != incoming=$messageId');
+        'OmiVoicePlayback: updateStreamingResponse skipped — activeId=$_activeMessageId != incoming=$messageId',
+      );
       return;
     }
     Logger.log('OmiVoicePlayback: updateStreamingResponse len=${fullText.length} isFinal=$isFinal spoken=$_spoken');
@@ -195,6 +197,7 @@ class OmiVoicePlaybackService {
     _audioQueue.clear();
     _synthesizing = false;
     _isPlayingQueue = false;
+    _pausedByInterruption = false;
     try {
       await _player.stop();
     } catch (_) {}
@@ -202,6 +205,37 @@ class OmiVoicePlaybackService {
       await _fallbackTts.stop();
     } catch (_) {}
     await _deactivateSession();
+  }
+
+  void _onInterruption(AudioInterruptionEvent event) {
+    if (event.begin) {
+      switch (event.type) {
+        case AudioInterruptionType.duck:
+          break;
+        case AudioInterruptionType.pause:
+          if (_player.playing) {
+            _pausedByInterruption = true;
+            _player.pause();
+          }
+          break;
+        case AudioInterruptionType.unknown:
+          interrupt();
+          break;
+      }
+    } else {
+      switch (event.type) {
+        case AudioInterruptionType.duck:
+          break;
+        case AudioInterruptionType.pause:
+          if (_pausedByInterruption) {
+            _pausedByInterruption = false;
+            _player.play();
+          }
+          break;
+        case AudioInterruptionType.unknown:
+          break;
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -347,12 +381,7 @@ class OmiVoicePlaybackService {
 
   /// Returns the index at which to cut the next chunk, or null if we should
   /// wait for more text. Mirrors `FloatingBarVoicePlaybackService.nextChunkBoundary`.
-  int? _nextChunkBoundary(
-    String text, {
-    required int start,
-    required bool isFirstChunk,
-    required bool isFinal,
-  }) {
+  int? _nextChunkBoundary(String text, {required int start, required bool isFirstChunk, required bool isFinal}) {
     final remaining = text.length - start;
     final minChars = isFirstChunk ? _firstChunkMinChars : _chunkMinChars;
     final idealChars = isFirstChunk ? _firstChunkIdealChars : _chunkIdealChars;

--- a/app/lib/services/voice_playback/omi_voice_playback_service.dart
+++ b/app/lib/services/voice_playback/omi_voice_playback_service.dart
@@ -107,8 +107,8 @@ class OmiVoicePlaybackService {
       }
     }
 
-    if (_activeMessageId == messageId) {
-      // Same response already in-flight; no-op.
+    if (_activeMessageId == messageId && isSpeaking) {
+      // Same response actively in-flight; no-op (rapid-double-call guard).
       return;
     }
 

--- a/app/lib/services/voice_playback/omi_voice_playback_service.dart
+++ b/app/lib/services/voice_playback/omi_voice_playback_service.dart
@@ -247,6 +247,7 @@ class OmiVoicePlaybackService {
     _audioQueue.clear();
     _synthesizing = false;
     _isPlayingQueue = false;
+    _pausedByInterruption = false;
     try {
       await _player.stop();
     } catch (_) {}


### PR DESCRIPTION
## Summary

Resolves #7135 — voice response on Android cut off by the chat-reply notification chime, and (cascading from that) "voice stops playing after 1-2 questions, only notification delivered."

Two complementary commits, each independently revertable:

### Commit 1 — interruption handler + audio attributes (`omi_voice_playback_service.dart`)

The previous interruption handler called `interrupt()` on **every** `interruptionEventStream` end event, regardless of `event.type`. A notification chime triggers a transient pause-style focus loss; the end event then nuked the queue, cleared `_activeMessageId`, and deactivated the session. Subsequent `updateStreamingResponse` calls dropped at the activeId check. Repeat across 1-2 questions → user perceives "voice broken."

Fix follows the audio_session README pattern (and just_audio's own internal handler):
- `AudioPlayer(handleInterruptions: false)` — disable just_audio's built-in handler so it doesn't race with ours
- `_onInterruption` branches on `event.type`:
  - begin+pause → `_player.pause()` + remember we paused
  - begin+duck → no-op (OS handles ducking)
  - begin+unknown → `interrupt()` (permanent loss only)
  - end+pause → `_player.play()` if we paused
  - end+duck → no-op
  - end+unknown → no-op (already cleared on begin)
- Replaced `AudioSessionConfiguration.speech()` with an explicit config:
  - `androidAudioAttributes.usage = USAGE_ASSISTANT` (was MEDIA — semantically correct for assistant feedback; affects audio policy treatment of notification ducking)
  - `androidWillPauseWhenDucked = false` (let OS duck volume during a brief notification rather than collapsing duck into pause)
  - `avAudioSessionMode = voicePrompt` (Apple's recommended TTS mode; was spokenAudio which is for podcasts)
- `becomingNoisyEventStream` full-stop preserved (intentional — don't blast reply out of the phone speaker after unplugging headphones)

### Commit 2 — suppress chat-reply foreground notification while speaking (`notification_service_fcm.dart`)

The most common bug trigger: the backend sends an FCM with `notification_type=plugin` for every AI chat reply (`backend/utils/chat.py:246, 374`). On Android in foreground we re-display it via `_showForegroundNotification` using the default channel sound — that chime competes with the in-flight voice playback for audio focus.

Skip the local notification when `OmiVoicePlaybackService.instance.isSpeaking`. The chat-message stream still adds the message to the chat UI; the spoken reply is the audible signal — no double-ding.

## Cross-platform behavior

| Platform / state | Bug? | Fix |
|---|---|---|
| Android foreground | Yes (reported) | Both commits — eliminates Omi's own chime + survives any other app's chime |
| Android background | N/A — voice playback is foreground-only in our flow | — |
| iOS foreground | No — `_shouldShowForegroundNotificationOnFCMMessageReceived()` returns Android only, and FlutterFire's `willPresent` default is `UNNotificationPresentationOptionNone` so iOS doesn't display foreground FCMs | Commit 2 gate is harmless no-op; commit 1 still benefits any other app's notification |
| iOS background | APNS displays directly; can't suppress client-side. iOS audio policy ducks our voice during chime; commit 1 ensures clean resume | Commit 1 only |

To fully silence iOS background notifications during voice playback we'd need a backend change to drop `aps.sound` from chat-reply pushes — out of scope for this bug; flag if iOS background reports come in.

## Research evidence

- audio_session README's recommended interruption handler shape: <https://github.com/ryanheise/audio_session/blob/master/README.md#reacting-to-audio-interruptions>
- just_audio's own internal handler (`just_audio-0.9.46/lib/just_audio.dart:302-348`) implements the same shape — pause/duck/unknown distinct, only resume on pause-end, never on unknown
- `AudioSessionConfiguration.speech()` source (`audio_session-0.1.25/lib/src/core.dart:561-571`) confirms it sets `usage: media` and `willPauseWhenDucked: true` — both wrong for assistant feedback
- Android `USAGE_ASSISTANT` is documented as the correct attribute for "voice control feedback, hot-word detection, prompts and responses for voice queries"
- FlutterFire iOS willPresent default returns `UNNotificationPresentationOptionNone` (`firebase_messaging-15.2.10/ios/.../FLTFirebaseMessagingPlugin.m:343`) — confirms iOS foreground silence is the default

## Test plan

- [x] Manual on Android (samsung S938B / 16 if available, otherwise generic emulator): set Voice Response to "Always". Ask Omi a question, let voice reply start. Confirm no chat-reply notification chime fires; voice plays fully.
- [x] Manual on Android: with Voice Response Always, ask 5+ questions in a row. Confirm voice still plays on every reply (no degradation).
- [x] Manual on Android: while voice is playing, send a WhatsApp / SMS / any third-party notification. Confirm voice pauses briefly (or ducks) and **resumes** instead of being killed.
- [ ] Manual on Android: while voice is playing, unplug Bluetooth headphones. Confirm voice stops fully (existing intentional behavior preserved).
- [x] Manual on iOS: set Voice Response to "Always". Ask Omi a question. Confirm voice plays fully and no notification banner/sound appears in foreground.
- [x] Manual on iOS: while voice is playing in app foreground, trigger a Slack/iMessage chime. Confirm voice ducks and resumes.