### PR TITLE
admin: date-stamp affiliate payout idempotency key

### DIFF
--- a/web/admin/app/api/omi/affiliate-payouts/route.ts
+++ b/web/admin/app/api/omi/affiliate-payouts/route.ts
@@ -257,7 +257,8 @@ export async function POST(request: NextRequest) {
       }
 
       // 1. Send Stripe Transfer with idempotency key to prevent duplicate payments
-      const idempotencyKey = `affiliate_payout_${affiliate_id}_${Math.round(amount * 100)}`;
+      const todayUtc = new Date().toISOString().slice(0, 10);
+      const idempotencyKey = `affiliate_payout_${affiliate_id}_${Math.round(amount * 100)}_${todayUtc}`;
       const transfer = await stripe.transfers.create(
         {
           amount: Math.round(amount * 100), // cents


### PR DESCRIPTION
## Summary

The affiliate `/transfer` endpoint built its Stripe idempotency key as `affiliate_payout_${affiliate_id}_${cents}` — stable across days. Stripe caches both successful AND 4xx error responses against an idempotency key for 24 hours, so if a transfer hits a transient error (e.g. a brief `balance_insufficient` when in-flight pending volume momentarily drops the available balance below the transfer amount), every retry within that 24h window replays the cached error regardless of actual balance state. The dashboard's "Retry" button surfaces the same dead response over and over.

Append the UTC date to the key:

```
affiliate_payout_${affiliate_id}_${cents}_${YYYY-MM-DD}
```

- Same-day intra-day retries still get the desired idempotent replay (key stable for the whole UTC day).
- Cross-day retries get a fresh key, letting Stripe re-evaluate the request against the current balance.
- The `(affiliate_id, amount, day)` tuple is still unique enough to prevent double-payment from rapid double-clicks within the same day.

## Recovery context

Triggered today by an affiliate-payout retry that got trapped on a poisoned cache for ~10h until manual recovery via a one-off Stripe API call with a fresh idempotency key. With this fix the admin would have just been able to retry the next day from the dashboard.

## Test plan

- [ ] Build passes (`npm run build` in `web/admin/`)
- [ ] Smoke: confirm no behavior change for the happy path — successful transfer still returns transfer_id and marks paid in GoAffPro
- [ ] Optional: confirm two consecutive same-day clicks are idempotent (second click replays first response, no double transfer)