### PR TITLE
Update CHANGELOG.json for v0.11.378 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -2,6 +2,13 @@
   "unreleased": [],
   "releases": [
     {
+      "version": "0.11.378",
+      "date": "2026-05-06",
+      "changes": [
+        "Bug fixes and improvements"
+      ]
+    },
+    {
       "version": "0.11.377",
       "date": "2026-05-05",
       "changes": [


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.378 and clears the unreleased array.