### PR TITLE
Close local transcription sessions on completion

### DIFF
--- a/desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -107,10 +107,13 @@ actor TranscriptionStorage {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
+            let completedAt = Date()
             record.status = .completed
+            record.conversationStatus = .completed
+            record.finishedAt = record.finishedAt ?? completedAt
             record.backendId = backendId
             record.backendSynced = true
-            record.updatedAt = Date()
+            record.updatedAt = completedAt
             try record.update(database)
         }
 


### PR DESCRIPTION
## Summary
- mark local transcription rows as fully completed after successful upload
- set conversationStatus to completed and fill finishedAt when missing
- keep backend sync fields unchanged

Fixes #6955

## Verification
- Mac mini: `cd ~/projects/omi/desktop/Desktop && swift build 2>&1 | tail -5`
- Build complete on Mac mini