### PR TITLE
feat(app+backend): bulk delete action items in one round-trip

### DIFF
--- a/app/lib/backend/http/api/action_items.dart
+++ b/app/lib/backend/http/api/action_items.dart
@@ -151,6 +151,26 @@ Future<bool> deleteActionItem(String actionItemId) async {
   return response.statusCode == 204;
 }
 
+Future<List<String>?> bulkDeleteActionItems(List<String> ids) async {
+  if (ids.isEmpty) return const [];
+  final response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/action-items/batch-delete',
+    headers: {'Content-Type': 'application/json'},
+    method: 'POST',
+    body: jsonEncode({'ids': ids}),
+  );
+
+  if (response == null) return null;
+  if (response.statusCode != 200) {
+    Logger.debug('bulkDeleteActionItems error ${response.statusCode}');
+    return null;
+  }
+
+  final body = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+  final deleted = (body['deleted_ids'] as List?)?.cast<String>() ?? const [];
+  return deleted;
+}
+
 // Task sharing
 Future<Map<String, dynamic>?> shareActionItems(List<String> taskIds) async {
   var response = await makeApiCall(

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11004,5 +11004,13 @@
     "deselectAllTasksMenu": "Deselect all",
     "@deselectAllTasksMenu": {
         "description": "Action menu entry that clears any current task selection while staying in selection mode"
+    },
+    "bulkExportAlreadyExported": "All selected tasks already exported",
+    "@bulkExportAlreadyExported": {
+        "description": "Snackbar shown when every selected task is already exported and Export is tapped"
+    },
+    "bulkDeleteFailed": "Could not delete tasks. Please try again.",
+    "@bulkDeleteFailed": {
+        "description": "Snackbar shown when the bulk delete request fails and the local list is restored"
     }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17222,6 +17222,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Deselect all'**
   String get deselectAllTasksMenu;
+
+  /// Snackbar shown when every selected task is already exported and Export is tapped
+  ///
+  /// In en, this message translates to:
+  /// **'All selected tasks already exported'**
+  String get bulkExportAlreadyExported;
+
+  /// Snackbar shown when the bulk delete request fails and the local list is restored
+  ///
+  /// In en, this message translates to:
+  /// **'Could not delete tasks. Please try again.'**
+  String get bulkDeleteFailed;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9167,4 +9167,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'إلغاء تحديد الكل';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9254,4 +9254,10 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Зняць выбар усіх';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9263,4 +9263,10 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Премахване на избора';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9237,4 +9237,10 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'সমস্ত নির্বাচন বাতিল';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9252,4 +9252,10 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Poništi odabir svih';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9282,4 +9282,10 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Desselecciona tot';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9224,4 +9224,10 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Zrušit výběr všech';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9214,4 +9214,10 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Fravælg alle';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9305,4 +9305,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Alle abwählen';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9293,4 +9293,10 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Αποεπιλογή όλων';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9225,4 +9225,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Deselect all';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9249,4 +9249,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Deseleccionar todo';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9225,4 +9225,10 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Tühista kõigi valik';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9231,4 +9231,10 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'لغو انتخاب همه';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9227,4 +9227,10 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Poista kaikkien valinta';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9311,4 +9311,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Tout désélectionner';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9156,4 +9156,10 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'בטל בחירת הכל';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9208,4 +9208,10 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'सभी का चयन हटाएं';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9258,4 +9258,10 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Poništi odabir svih';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9267,4 +9267,10 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Összes kijelölés törlése';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9238,4 +9238,10 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Batalkan pilihan semua';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9283,4 +9283,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Deseleziona tutto';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -4627,10 +4627,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String accessesAndTriggeredBy(
-    String accessDescription,
-    String triggerDescription,
-  ) {
+  String accessesAndTriggeredBy(String accessDescription, String triggerDescription) {
     return '$accessDescription、$triggerDescription。';
   }
 
@@ -9082,4 +9079,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'すべて選択解除';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9260,4 +9260,10 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'ಎಲ್ಲವನ್ನೂ ಆಯ್ಕೆ ರದ್ದು ಮಾಡಿ';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9080,4 +9080,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => '모두 선택 해제';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9237,4 +9237,10 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Atžymėti viską';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9246,4 +9246,10 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Noņemt visu atlasi';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9277,4 +9277,10 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Одселектирај ги сите';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9239,4 +9239,10 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'सर्वांची निवड रद्द करा';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9252,4 +9252,10 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Nyahpilih semua';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9256,4 +9256,10 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Alles deselecteren';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9224,4 +9224,10 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Fjern alle valg';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9248,4 +9248,10 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Odznacz wszystkie';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9232,4 +9232,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Desmarcar todos';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9271,4 +9271,10 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Deselectați tot';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9257,4 +9257,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Снять выделение со всех';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9216,4 +9216,10 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Zrušiť výber všetkých';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9252,4 +9252,10 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Prekliči izbor vseh';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9241,4 +9241,10 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Поништи избор свих';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9232,4 +9232,10 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Avmarkera alla';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9297,4 +9297,10 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'அனைத்தையும் தேர்வு நீக்கு';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9278,4 +9278,10 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'అన్ని ఎంపికలు తొలగించు';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9182,4 +9182,10 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'ยกเลิกเลือกทั้งหมด';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9313,4 +9313,10 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'I-deselect lahat';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9241,4 +9241,10 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Tümünün seçimini kaldır';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9242,4 +9242,10 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Зняти виділення з усіх';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9245,4 +9245,10 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'تمام کا انتخاب ختم کریں';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9228,4 +9228,10 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => 'Bỏ chọn tất cả';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9065,4 +9065,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get deselectAllTasksMenu => '取消全选';
+
+  @override
+  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+
+  @override
+  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
 }

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -253,12 +253,8 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
 
   Widget _buildOverflowMenu(ActionItemsProvider provider) {
     final showingCompleted = provider.showCompletedView;
-    // "Select all" flips to "Deselect all" once every selectable task is
-    // already selected. `selectAllItems()` skips items that are already
-    // exported, so we compare against the unexported count — otherwise the
-    // label never flips when any task has been exported before.
-    final selectableCount = provider.actionItems.where((i) => !i.exported).length;
-    final allSelected = selectableCount > 0 && provider.selectedCount == selectableCount;
+    final hasItems = provider.actionItems.isNotEmpty;
+    final allSelected = hasItems && provider.selectedCount == provider.actionItems.length;
 
     return PopupMenuButton<String>(
       tooltip: '',
@@ -1428,12 +1424,10 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
               // Trailing square selection box — only in selection mode.
               // Different shape + position from the leading completion circle
               // so completion vs. selection cannot be confused.
-              // Exported items show a disabled square — they can't be re-exported.
               if (provider.isSelectionMode)
                 Padding(
                   padding: const EdgeInsets.only(left: 8, right: 8),
-                  child:
-                      item.exported ? _buildSelectionSquare(false, disabled: true) : _buildSelectionSquare(isSelected),
+                  child: _buildSelectionSquare(isSelected),
                 ),
             ],
           ),
@@ -1462,19 +1456,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
   /// Trailing selection box rendered only in selection mode. Rounded **square**
   /// — different shape from the leading completion circle so users can't
   /// confuse "selected for bulk action" with "marked as done".
-  Widget _buildSelectionSquare(bool isSelected, {bool disabled = false}) {
-    if (disabled) {
-      return Container(
-        width: 22,
-        height: 22,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(6),
-          border: Border.all(color: Colors.grey[800]!, width: 1.5),
-          color: Colors.grey[850],
-        ),
-        child: Icon(Icons.check, size: 14, color: Colors.grey[600]),
-      );
-    }
+  Widget _buildSelectionSquare(bool isSelected) {
     return AnimatedContainer(
       duration: const Duration(milliseconds: 150),
       width: 22,

--- a/app/lib/pages/action_items/widgets/task_selection_action_bar.dart
+++ b/app/lib/pages/action_items/widgets/task_selection_action_bar.dart
@@ -184,7 +184,8 @@ class _TaskSelectionActionBarState extends State<TaskSelectionActionBar> with Si
       ),
     );
     if (confirmed != true) return;
-    await provider.deleteSelectedItems();
+    if (!context.mounted) return;
+    await provider.deleteSelectedItems(context: context);
   }
 }
 

--- a/app/lib/pages/action_items/widgets/task_selection_action_bar.dart
+++ b/app/lib/pages/action_items/widgets/task_selection_action_bar.dart
@@ -92,23 +92,20 @@ class _TaskSelectionActionBarState extends State<TaskSelectionActionBar> with Si
                         ),
                       ),
                       const Spacer(),
-                      // Center: count
-                      AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 150),
-                        child: Text(
-                          context.l10n.selectedCount(taskCount, taskCount),
-                          key: ValueKey(taskCount),
-                          style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w600),
-                        ),
+                      // Destructive secondary: bulk delete. Icon-only on purpose
+                      // so the Export pill stays the visual primary; the count
+                      // lives on that pill instead of in the centre to keep this
+                      // row from feeling crowded.
+                      _IconActionButton(
+                        icon: Icons.delete_outline_rounded,
+                        enabled: canExport,
+                        tint: const Color(0xFFFF453A),
+                        onTap: () => _handleDelete(context, provider, taskCount),
                       ),
-                      const Spacer(),
-                      // Export pill — single primary action. Bulk-delete is
-                      // handled per-row via swipe-left and via the Clear-completed
-                      // path in the section header — keeping the bar at one
-                      // primary action mirrors the conversations merge bar.
+                      const SizedBox(width: 8),
                       _ActionPillButton(
                         icon: Icons.ios_share_rounded,
-                        label: context.l10n.exportButton,
+                        label: canExport ? '${context.l10n.exportButton}  ·  $taskCount' : context.l10n.exportButton,
                         enabled: canExport,
                         accent: const Color(0xFF7C3AED),
                         onTap: () => _handleExport(context, provider),
@@ -151,6 +148,74 @@ class _TaskSelectionActionBarState extends State<TaskSelectionActionBar> with Si
     }
 
     await provider.bulkExportSelected(context, connected.first);
+  }
+
+  Future<void> _handleDelete(BuildContext context, ActionItemsProvider provider, int taskCount) async {
+    HapticFeedback.lightImpact();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: const Color(0xFF1F1F25),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        title: Text(
+          context.l10n.deleteSelectedItemsTitle,
+          style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w600),
+        ),
+        content: Text(
+          context.l10n.deleteSelectedItemsMessage(taskCount, taskCount > 1 ? 's' : ''),
+          style: const TextStyle(color: Color(0xFFB0B0B5), fontSize: 14),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(
+              context.l10n.cancel,
+              style: const TextStyle(color: Color(0xFF8E8E93), fontWeight: FontWeight.w500),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(
+              context.l10n.delete,
+              style: const TextStyle(color: Color(0xFFFF453A), fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await provider.deleteSelectedItems();
+  }
+}
+
+class _IconActionButton extends StatelessWidget {
+  final IconData icon;
+  final bool enabled;
+  final Color tint;
+  final VoidCallback onTap;
+
+  const _IconActionButton({
+    required this.icon,
+    required this.enabled,
+    required this.tint,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: enabled ? onTap : null,
+      child: Container(
+        width: 44,
+        height: 44,
+        alignment: Alignment.center,
+        child: Icon(
+          icon,
+          size: 22,
+          color: enabled ? tint : const Color(0xFF636366),
+        ),
+      ),
+    );
   }
 }
 

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -658,16 +658,12 @@ class ActionItemsProvider extends ChangeNotifier {
     if (_selectedItems.contains(itemId)) {
       _selectedItems.remove(itemId);
     } else {
-      final item = _actionItems.where((i) => i.id == itemId).firstOrNull;
-      if (item != null && item.exported) return;
       _selectedItems.add(itemId);
     }
     notifyListeners();
   }
 
   void selectItem(String itemId) {
-    final item = _actionItems.where((i) => i.id == itemId).firstOrNull;
-    if (item != null && item.exported) return;
     if (!_selectedItems.contains(itemId)) {
       _selectedItems.add(itemId);
       notifyListeners();
@@ -682,10 +678,9 @@ class ActionItemsProvider extends ChangeNotifier {
   }
 
   void selectAllItems() {
-    _selectedItems.clear();
-    for (final item in _actionItems) {
-      if (!item.exported) _selectedItems.add(item.id);
-    }
+    _selectedItems
+      ..clear()
+      ..addAll(_actionItems.map((i) => i.id));
     notifyListeners();
   }
 
@@ -705,9 +700,7 @@ class ActionItemsProvider extends ChangeNotifier {
         break;
     }
 
-    for (final item in itemsToSelect) {
-      if (!item.exported) _selectedItems.add(item.id);
-    }
+    _selectedItems.addAll(itemsToSelect.map((i) => i.id));
     notifyListeners();
   }
 
@@ -733,6 +726,7 @@ class ActionItemsProvider extends ChangeNotifier {
     if (_selectedItems.isEmpty) return false;
 
     final itemsToDelete = _actionItems.where((item) => _selectedItems.contains(item.id)).toList();
+    final ids = itemsToDelete.map((item) => item.id).toList(growable: false);
 
     // Dismiss UI immediately — don't wait for API
     _actionItems.removeWhere((item) => _selectedItems.contains(item.id));
@@ -740,8 +734,18 @@ class ActionItemsProvider extends ChangeNotifier {
     _isSelectionMode = false;
     notifyListeners();
 
-    final results = await Future.wait(itemsToDelete.map((item) => deleteActionItem(item)));
-    return results.every((success) => success);
+    // Apple Reminders mirror lives client-side, so it still has to fan out
+    // per-item. The action-item record itself goes through the bulk endpoint.
+    for (final item in itemsToDelete) {
+      _deleteAppleReminderIfLinked(item);
+    }
+
+    final deleted = await api.bulkDeleteActionItems(ids);
+    if (deleted == null) {
+      Logger.debug('bulkDeleteActionItems returned null');
+      return false;
+    }
+    return deleted.length == ids.length;
   }
 
   Future<bool> clearCompletedItems() async {
@@ -753,8 +757,6 @@ class ActionItemsProvider extends ChangeNotifier {
   }
 
   void startSelectionWithItem(String itemId) {
-    final item = _actionItems.where((i) => i.id == itemId).firstOrNull;
-    if (item != null && item.exported) return;
     _isSelectionMode = true;
     _selectedItems = {itemId};
     notifyListeners();
@@ -780,11 +782,21 @@ class ActionItemsProvider extends ChangeNotifier {
     if (_selectedItems.isEmpty) return;
 
     final ids = _selectedItems.toList(growable: false);
-    final items = _actionItems.where((i) => ids.contains(i.id)).toList(growable: false);
+    final selected = _actionItems.where((i) => ids.contains(i.id)).toList(growable: false);
+    // Exported items can now be selected (Delete shares the bar), but Export
+    // itself silently no-ops on them so the user doesn't double-create on the
+    // integration side.
+    final items = selected.where((i) => !i.exported).toList(growable: false);
     final total = items.length;
 
     final messenger = ScaffoldMessenger.of(context);
     messenger.clearSnackBars();
+
+    if (total == 0) {
+      endSelection();
+      return;
+    }
+
     messenger.showSnackBar(
       SnackBar(
         content: Text(context.l10n.bulkExportInProgress),

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -722,11 +722,17 @@ class ActionItemsProvider extends ChangeNotifier {
   }
 
   // Bulk operations
-  Future<bool> deleteSelectedItems() async {
+  Future<bool> deleteSelectedItems({BuildContext? context}) async {
     if (_selectedItems.isEmpty) return false;
 
     final itemsToDelete = _actionItems.where((item) => _selectedItems.contains(item.id)).toList();
     final ids = itemsToDelete.map((item) => item.id).toList(growable: false);
+    // Snapshot positions so a failed bulk delete can re-insert the rows
+    // back where the user expected them, instead of dumping them at the end.
+    final snapshot = <int, ActionItemWithMetadata>{
+      for (final item in itemsToDelete) _actionItems.indexOf(item): item,
+    };
+    final wasInSelection = _isSelectionMode;
 
     // Dismiss UI immediately — don't wait for API
     _actionItems.removeWhere((item) => _selectedItems.contains(item.id));
@@ -742,7 +748,28 @@ class ActionItemsProvider extends ChangeNotifier {
 
     final deleted = await api.bulkDeleteActionItems(ids);
     if (deleted == null) {
-      Logger.debug('bulkDeleteActionItems returned null');
+      Logger.debug('bulkDeleteActionItems returned null — rolling back local list');
+      // Re-insert rows at their original positions, oldest index first.
+      final entries = snapshot.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
+      for (final entry in entries) {
+        final idx = entry.key.clamp(0, _actionItems.length);
+        _actionItems.insert(idx, entry.value);
+      }
+      _isSelectionMode = wasInSelection;
+      _selectedItems = ids.toSet();
+      notifyListeners();
+
+      if (context != null && context.mounted) {
+        ScaffoldMessenger.of(context)
+          ..clearSnackBars()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(context.l10n.bulkDeleteFailed),
+              backgroundColor: const Color(0xFFB3261E),
+              duration: const Duration(seconds: 3),
+            ),
+          );
+      }
       return false;
     }
     return deleted.length == ids.length;
@@ -793,6 +820,13 @@ class ActionItemsProvider extends ChangeNotifier {
     messenger.clearSnackBars();
 
     if (total == 0) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.bulkExportAlreadyExported),
+          backgroundColor: const Color(0xFF2C2C2E),
+          duration: const Duration(seconds: 3),
+        ),
+      );
       endSelection();
       return;
     }

--- a/app/lib/services/notifications/action_item_notification_handler.dart
+++ b/app/lib/services/notifications/action_item_notification_handler.dart
@@ -117,4 +117,19 @@ class ActionItemNotificationHandler {
 
     await cancelNotification(actionItemId);
   }
+
+  /// Handle bulk action item deletion data message. Backend packs ids into a
+  /// comma-joined string because FCM data values must be strings; we just
+  /// fan out cancellation client-side — no network involved.
+  static Future<void> handleBatchDeletionMessage(Map<String, dynamic> data) async {
+    final raw = data['ids'];
+    if (raw == null || raw.toString().isEmpty) {
+      Logger.debug('[ActionItem] Invalid batch deletion data');
+      return;
+    }
+    final ids = raw.toString().split(',').where((id) => id.isNotEmpty);
+    for (final id in ids) {
+      await cancelNotification(id);
+    }
+  }
 }

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -220,6 +220,9 @@ class _FCMNotificationService implements NotificationInterface {
         } else if (messageType == 'action_item_delete') {
           ActionItemNotificationHandler.handleDeletionMessage(data);
           return;
+        } else if (messageType == 'action_item_batch_delete') {
+          ActionItemNotificationHandler.handleBatchDeletionMessage(data);
+          return;
         } else if (messageType == 'merge_completed') {
           MergeNotificationHandler.handleMergeCompleted(data, channel.channelKey!, isAppInForeground: true);
           return;

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -419,6 +419,44 @@ def delete_action_item(uid: str, action_item_id: str) -> bool:
     return True
 
 
+def delete_action_items_batch(uid: str, action_item_ids: List[str]) -> List[str]:
+    """
+    Delete multiple action items by id in chunked Firestore batches.
+
+    Returns the ids that were actually deleted (skipping any that don't exist),
+    so the caller can scope downstream cleanup (vectors, FCM cancellation
+    messages) to the rows that were really removed.
+    """
+    if not action_item_ids:
+        return []
+
+    user_ref = db.collection('users').document(uid)
+    action_items_ref = user_ref.collection(action_items_collection)
+
+    deleted_ids: List[str] = []
+    batch = db.batch()
+    count = 0
+
+    for item_id in action_item_ids:
+        doc_ref = action_items_ref.document(item_id)
+        snapshot = doc_ref.get()
+        if not snapshot.exists:
+            continue
+        batch.delete(doc_ref)
+        deleted_ids.append(item_id)
+        count += 1
+
+        if count >= 499:  # Firestore batch limit is 500
+            batch.commit()
+            batch = db.batch()
+            count = 0
+
+    if count > 0:
+        batch.commit()
+
+    return deleted_ids
+
+
 def delete_action_items_for_conversation(uid: str, conversation_id: str) -> int:
     """
     Delete all action items for a specific conversation.

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -423,9 +423,11 @@ def delete_action_items_batch(uid: str, action_item_ids: List[str]) -> List[str]
     """
     Delete multiple action items by id in chunked Firestore batches.
 
-    Returns the ids that were actually deleted (skipping any that don't exist),
-    so the caller can scope downstream cleanup (vectors, FCM cancellation
-    messages) to the rows that were really removed.
+    Skips the existence check — Firestore's batch.delete() is a no-op for
+    docs that don't exist, and queueing N sequential blocking get()s would
+    eat the entire latency budget on large requests. Returns the input ids
+    so the caller can fan out vector + FCM cleanup, both of which are
+    idempotent for unknown ids.
     """
     if not action_item_ids:
         return []
@@ -433,17 +435,11 @@ def delete_action_items_batch(uid: str, action_item_ids: List[str]) -> List[str]
     user_ref = db.collection('users').document(uid)
     action_items_ref = user_ref.collection(action_items_collection)
 
-    deleted_ids: List[str] = []
     batch = db.batch()
     count = 0
 
     for item_id in action_item_ids:
-        doc_ref = action_items_ref.document(item_id)
-        snapshot = doc_ref.get()
-        if not snapshot.exists:
-            continue
-        batch.delete(doc_ref)
-        deleted_ids.append(item_id)
+        batch.delete(action_items_ref.document(item_id))
         count += 1
 
         if count >= 499:  # Firestore batch limit is 500
@@ -454,7 +450,7 @@ def delete_action_items_batch(uid: str, action_item_ids: List[str]) -> List[str]
     if count > 0:
         batch.commit()
 
-    return deleted_ids
+    return list(action_item_ids)
 
 
 def delete_action_items_for_conversation(uid: str, conversation_id: str) -> int:

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -421,34 +421,30 @@ def delete_action_item(uid: str, action_item_id: str) -> bool:
 
 def delete_action_items_batch(uid: str, action_item_ids: List[str]) -> List[str]:
     """
-    Delete multiple action items by id in chunked Firestore batches.
+    Delete multiple action items by id in a single atomic Firestore batch.
 
-    Skips the existence check — Firestore's batch.delete() is a no-op for
-    docs that don't exist, and queueing N sequential blocking get()s would
-    eat the entire latency budget on large requests. Returns the input ids
-    so the caller can fan out vector + FCM cleanup, both of which are
-    idempotent for unknown ids.
+    Caller must keep the input under Firestore's 500-op batch limit (the
+    HTTP route caps at 500 to match). One commit call gives all-or-nothing
+    semantics — either every id is deleted or the commit raises and nothing
+    is — so the client's optimistic-with-rollback flow never has to deal
+    with a partially-applied state.
+
+    Skips per-id existence reads: batch.delete() is a no-op for missing
+    docs, and downstream vector + FCM cleanup are both idempotent for
+    unknown ids.
     """
     if not action_item_ids:
         return []
+    if len(action_item_ids) > 500:
+        raise ValueError(f'delete_action_items_batch: {len(action_item_ids)} ids exceeds Firestore batch limit')
 
     user_ref = db.collection('users').document(uid)
     action_items_ref = user_ref.collection(action_items_collection)
 
     batch = db.batch()
-    count = 0
-
     for item_id in action_item_ids:
         batch.delete(action_items_ref.document(item_id))
-        count += 1
-
-        if count >= 499:  # Firestore batch limit is 500
-            batch.commit()
-            batch = db.batch()
-            count = 0
-
-    if count > 0:
-        batch.commit()
+    batch.commit()
 
     return list(action_item_ids)
 

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -24,6 +24,7 @@ from utils.notifications import (
     send_action_item_data_message,
     send_action_item_update_message,
     send_action_item_deletion_message,
+    send_action_items_batch_deletion_message,
 )
 from utils.task_sync import auto_sync_action_item
 from pydantic import BaseModel, Field
@@ -419,6 +420,27 @@ def delete_action_item(action_item_id: str, uid: str = Depends(auth.get_current_
     send_action_item_deletion_message(user_id=uid, action_item_id=action_item_id)
 
     return {"status": "Ok"}
+
+
+class BatchDeleteActionItemsRequest(BaseModel):
+    ids: List[str] = Field(description="IDs of action items to delete", min_length=1, max_length=500)
+
+
+@router.post("/v1/action-items/batch-delete", tags=['action-items'])
+def batch_delete_action_items(request: BatchDeleteActionItemsRequest, uid: str = Depends(auth.get_current_user_uid)):
+    """Delete multiple action items in one request.
+
+    Firestore deletes go through chunked batched commits in the DB layer; the
+    vector store delete and the FCM cancellation message both use their batch
+    helpers — no per-id loop on this hot path.
+    """
+    deleted_ids = action_items_db.delete_action_items_batch(uid, request.ids)
+
+    if deleted_ids:
+        delete_action_item_vectors_batch(uid, deleted_ids)
+        send_action_items_batch_deletion_message(user_id=uid, action_item_ids=deleted_ids)
+
+    return {"status": "Ok", "deleted_count": len(deleted_ids), "deleted_ids": deleted_ids}
 
 
 # *****************************

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import math
+import uuid
 from typing import List
 from firebase_admin import messaging, auth
 import database.notifications as notification_db
@@ -520,13 +521,17 @@ def send_action_items_batch_deletion_message(user_id: str, action_item_ids: List
     # Action item ids are UUID-shaped (~36 chars); 100 per chunk keeps the
     # serialized payload comfortably under FCM's 4KB limit.
     chunk_size = 100
+    # Per-invocation nonce so concurrent bulk-delete calls that happen to
+    # share a leading id don't collide on FCM tags (which would let the
+    # second dispatch silently replace the first).
+    nonce = uuid.uuid4().hex[:8]
     for start in range(0, len(action_item_ids), chunk_size):
         chunk = action_item_ids[start : start + chunk_size]
         data = {
             'type': 'action_item_batch_delete',
             'ids': ','.join(chunk),
         }
-        tag = _generate_tag(f"{user_id}:action_item_batch_delete:{start}:{chunk[0]}")
+        tag = _generate_tag(f"{user_id}:action_item_batch_delete:{nonce}:{start}")
         _send_to_user(user_id, tag, data=data, is_background=True, priority='high')
     logger.info(f'send_action_items_batch_deletion_message to user {user_id} count={len(action_item_ids)}')
 

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import math
+from typing import List
 from firebase_admin import messaging, auth
 import database.notifications as notification_db
 from database.redis_db import (
@@ -504,6 +505,30 @@ def send_action_item_deletion_message(user_id: str, action_item_id: str):
     }
     tag = _generate_tag(f"{user_id}:action_item_delete:{action_item_id}")
     _send_to_user(user_id, tag, data=data, is_background=True, priority='high')
+
+
+def send_action_items_batch_deletion_message(user_id: str, action_item_ids: List[str]):
+    """
+    Bulk equivalent of send_action_item_deletion_message — one FCM data
+    message per chunk of ids (chunked to stay under FCM's 4KB data payload
+    ceiling) instead of one message per id. The app splits the comma-joined
+    ids and cancels each scheduled local notification client-side.
+    """
+    if not action_item_ids:
+        return
+
+    # Action item ids are UUID-shaped (~36 chars); 100 per chunk keeps the
+    # serialized payload comfortably under FCM's 4KB limit.
+    chunk_size = 100
+    for start in range(0, len(action_item_ids), chunk_size):
+        chunk = action_item_ids[start : start + chunk_size]
+        data = {
+            'type': 'action_item_batch_delete',
+            'ids': ','.join(chunk),
+        }
+        tag = _generate_tag(f"{user_id}:action_item_batch_delete:{start}:{chunk[0]}")
+        _send_to_user(user_id, tag, data=data, is_background=True, priority='high')
+    logger.info(f'send_action_items_batch_deletion_message to user {user_id} count={len(action_item_ids)}')
 
 
 def send_action_item_created_notification(user_id: str, action_item_description: str):


### PR DESCRIPTION
## Summary

- Selection bar gains a destructive trash button next to Export. Tap → iOS-style confirmation → bulk delete.
- New `POST /v1/action-items/batch-delete` endpoint: chunked Firestore batch + `delete_action_item_vectors_batch` + chunked FCM cancellation message — replaces N round-trips with one.
- App handles the new `action_item_batch_delete` FCM type by splitting the comma-joined ids and cancelling each scheduled local notification client-side.
- Drops the `exported = locked` gate from selection: with Delete sharing the bar, exported tasks should be selectable. Export silently skips already-exported ids so users don't double-create on the integration side.

## Test plan

- [ ] Select a few open tasks → tap trash → confirm dialog → tasks vanish, single backend request, server-side rows + vectors gone.
- [ ] Select 100+ tasks → confirm chunked Firestore commit + chunked FCM dispatch (one chunk per 100 ids).
- [ ] Schedule a reminder for one of the selected tasks, then bulk delete → verify the local notification doesn't fire later (FCM cancellation worked).
- [ ] Mix of exported + open tasks → tap Export → exported ones are skipped, open ones flow to the connected integration.
- [ ] Mix of exported + open → tap Delete → all selected (including exported) are removed.
- [ ] All-already-exported selection + Export → no error snackbar, selection just exits.
- [ ] Select-all menu flips to "Deselect all" when every task in the list is selected (regardless of exported state).