### PR TITLE
Fix desktop builds: bundle Sentry and onnxruntime frameworks

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2260,6 +2260,22 @@ workflows:
           fi
           cp -R "$SPARKLE_FW" "$APP_BUNDLE/Contents/Frameworks/"
 
+          # Copy Sentry framework
+          SENTRY_FW="Desktop/.build/x86_64-apple-macosx/release/Sentry.framework"
+          [ ! -d "$SENTRY_FW" ] && SENTRY_FW="Desktop/.build/arm64-apple-macosx/release/Sentry.framework"
+          if [ -d "$SENTRY_FW" ]; then
+            cp -R "$SENTRY_FW" "$APP_BUNDLE/Contents/Frameworks/"
+            echo "Bundled Sentry framework"
+          fi
+
+          # Copy onnxruntime framework
+          ONNX_FW="Desktop/.build/x86_64-apple-macosx/release/onnxruntime.framework"
+          [ ! -d "$ONNX_FW" ] && ONNX_FW="Desktop/.build/arm64-apple-macosx/release/onnxruntime.framework"
+          if [ -d "$ONNX_FW" ]; then
+            cp -R "$ONNX_FW" "$APP_BUNDLE/Contents/Frameworks/"
+            echo "Bundled onnxruntime framework"
+          fi
+
           # Add rpath so Sparkle can be found at runtime
           install_name_tool -add_rpath "@executable_path/../Frameworks" \
             "$APP_BUNDLE/Contents/MacOS/$BINARY_NAME"

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -399,6 +399,22 @@ if [ -d "$SPARKLE_FRAMEWORK" ]; then
     cp -R "$SPARKLE_FRAMEWORK" "$APP_BUNDLE/Contents/Frameworks/"
 fi
 
+# Copy Sentry framework
+SENTRY_FRAMEWORK="Desktop/.build/arm64-apple-macosx/debug/Sentry.framework"
+if [ -d "$SENTRY_FRAMEWORK" ]; then
+    substep "Copying Sentry framework"
+    rm -rf "$APP_BUNDLE/Contents/Frameworks/Sentry.framework"
+    cp -R "$SENTRY_FRAMEWORK" "$APP_BUNDLE/Contents/Frameworks/"
+fi
+
+# Copy onnxruntime framework
+ONNX_FRAMEWORK="Desktop/.build/arm64-apple-macosx/debug/onnxruntime.framework"
+if [ -d "$ONNX_FRAMEWORK" ]; then
+    substep "Copying onnxruntime framework"
+    rm -rf "$APP_BUNDLE/Contents/Frameworks/onnxruntime.framework"
+    cp -R "$ONNX_FRAMEWORK" "$APP_BUNDLE/Contents/Frameworks/"
+fi
+
 # Copy libwebp dylibs and rewrite load paths
 WEBP_LIB="$(pkg-config --variable=libdir libwebp 2>/dev/null)/libwebp.7.dylib"
 if [ -f "$WEBP_LIB" ]; then
@@ -552,6 +568,14 @@ if [ -n "$SIGN_IDENTITY" ]; then
     if [ -d "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework" ]; then
         substep "Signing Sparkle framework"
         codesign --force --options runtime --sign "$SIGN_IDENTITY" "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+    fi
+    if [ -d "$APP_BUNDLE/Contents/Frameworks/Sentry.framework" ]; then
+        substep "Signing Sentry framework"
+        codesign --force --options runtime --sign "$SIGN_IDENTITY" "$APP_BUNDLE/Contents/Frameworks/Sentry.framework"
+    fi
+    if [ -d "$APP_BUNDLE/Contents/Frameworks/onnxruntime.framework" ]; then
+        substep "Signing onnxruntime framework"
+        codesign --force --options runtime --sign "$SIGN_IDENTITY" "$APP_BUNDLE/Contents/Frameworks/onnxruntime.framework"
     fi
     if [ -f "$APP_BUNDLE/Contents/Frameworks/libsharpyuv.0.dylib" ]; then
         substep "Signing libsharpyuv"


### PR DESCRIPTION
## Summary
- `run.sh` and `codemagic.yaml` copy Sparkle framework into the app bundle but were missing **Sentry** and **onnxruntime** — both are SwiftPM dependencies in `Package.swift`
- Missing frameworks cause runtime crashes (dyld: Library not loaded) for named test bundles and potentially production builds
- Adds copy + codesign entries for both frameworks in `run.sh` (dev builds) and `codemagic.yaml` (release builds)

## Test plan
- [ ] Build named test bundle on Mac Mini: `OMI_APP_NAME="omi-framework-test" ./run.sh`
- [ ] Verify `Sentry.framework` and `onnxruntime.framework` appear in `Contents/Frameworks/`
- [ ] Launch app — no dyld crash on startup
- [ ] Verify Codemagic release build bundles both frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)