### PR TITLE
Update CHANGELOG.json for v0.11.379 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Reduced AI processing costs with thinking budget controls"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.379",
+      "date": "2026-05-07",
+      "changes": [
+        "Reduced AI processing costs with thinking budget controls"
+      ]
+    },
     {
       "version": "0.11.378",
       "date": "2026-05-06",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.379 and clears the unreleased array.