### PR TITLE
fix(onboarding): keep consent CTA visible at large text scaling

### DIFF
--- a/app/lib/pages/onboarding/ai_consent_widget.dart
+++ b/app/lib/pages/onboarding/ai_consent_widget.dart
@@ -36,82 +36,98 @@ class _AiConsentWidgetState extends State<AiConsentWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
     return Column(
       children: [
         Expanded(child: Container()),
-        Container(
-          width: double.infinity,
-          padding: EdgeInsets.fromLTRB(32, 26, 32, MediaQuery.of(context).padding.bottom + 8),
-          decoration: const BoxDecoration(
-            color: Colors.black,
-            borderRadius: BorderRadius.only(topLeft: Radius.circular(40), topRight: Radius.circular(40)),
+        ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: mediaQuery.size.height - mediaQuery.padding.top - 16,
           ),
-          child: SafeArea(
-            top: false,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  context.l10n.dataAndPrivacy,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 28,
-                    fontWeight: FontWeight.bold,
-                    height: 1.2,
-                    fontFamily: 'Manrope',
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  context.l10n.consentDataMessage,
-                  style: const TextStyle(color: Colors.white, fontSize: 15, height: 1.5, fontFamily: 'Manrope'),
-                ),
-                const SizedBox(height: 16),
-                RichText(
-                  text: TextSpan(
-                    style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.7),
-                      fontSize: 13,
-                      height: 1.4,
-                      fontFamily: 'Manrope',
-                    ),
-                    children: [
-                      TextSpan(text: context.l10n.yourDataIsProtected),
-                      TextSpan(
-                        text: context.l10n.privacyPolicy,
-                        style: const TextStyle(color: Colors.white, decoration: TextDecoration.underline),
-                        recognizer: _privacyRecognizer,
+          child: Container(
+            width: double.infinity,
+            padding: EdgeInsets.fromLTRB(32, 26, 32, mediaQuery.padding.bottom + 8),
+            decoration: const BoxDecoration(
+              color: Colors.black,
+              borderRadius: BorderRadius.only(topLeft: Radius.circular(40), topRight: Radius.circular(40)),
+            ),
+            child: SafeArea(
+              top: false,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Flexible(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            context.l10n.dataAndPrivacy,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 28,
+                              fontWeight: FontWeight.bold,
+                              height: 1.2,
+                              fontFamily: 'Manrope',
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            context.l10n.consentDataMessage,
+                            style:
+                                const TextStyle(color: Colors.white, fontSize: 15, height: 1.5, fontFamily: 'Manrope'),
+                          ),
+                          const SizedBox(height: 16),
+                          RichText(
+                            text: TextSpan(
+                              style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.7),
+                                fontSize: 13,
+                                height: 1.4,
+                                fontFamily: 'Manrope',
+                              ),
+                              children: [
+                                TextSpan(text: context.l10n.yourDataIsProtected),
+                                TextSpan(
+                                  text: context.l10n.privacyPolicy,
+                                  style: const TextStyle(color: Colors.white, decoration: TextDecoration.underline),
+                                  recognizer: _privacyRecognizer,
+                                ),
+                                TextSpan(text: context.l10n.and),
+                                TextSpan(
+                                  text: context.l10n.termsOfService,
+                                  style: const TextStyle(color: Colors.white, decoration: TextDecoration.underline),
+                                  recognizer: _termsRecognizer,
+                                ),
+                                const TextSpan(text: '.'),
+                              ],
+                            ),
+                          ),
+                        ],
                       ),
-                      TextSpan(text: context.l10n.and),
-                      TextSpan(
-                        text: context.l10n.termsOfService,
-                        style: const TextStyle(color: Colors.white, decoration: TextDecoration.underline),
-                        recognizer: _termsRecognizer,
+                    ),
+                  ),
+                  const SizedBox(height: 28),
+                  SizedBox(
+                    width: double.infinity,
+                    height: 56,
+                    child: ElevatedButton(
+                      onPressed: widget.onAgree,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        foregroundColor: Colors.black,
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+                        elevation: 0,
                       ),
-                      const TextSpan(text: '.'),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 28),
-                SizedBox(
-                  width: double.infinity,
-                  height: 56,
-                  child: ElevatedButton(
-                    onPressed: widget.onAgree,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: Colors.black,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-                      elevation: 0,
-                    ),
-                    child: Text(
-                      context.l10n.agreeAndContinue,
-                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
+                      child: Text(
+                        context.l10n.agreeAndContinue,
+                        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- `Data & Privacy` consent screen pushed the **Agree and continue** button off-screen when system text scaling was set to a large accessibility size (heading + body filled the entire viewport, button + footer link clipped below the bottom edge).
- Cap the bottom card at the available viewport height (`screen - safeAreaTop - 16`) and wrap the heading/body/footer in a `Flexible(SingleChildScrollView)` so the body scrolls while the CTA stays pinned at the bottom.

## Files
- `app/lib/pages/onboarding/ai_consent_widget.dart`

## Test plan
- [ ] Default text size (iPhone 15 Pro / Pixel 8a): screen looks identical to before — bottom card with rounded top corners, heading + body fit without scroll, button pinned at bottom.
- [ ] iOS Settings → Display & Brightness → Text Size → max: heading and body remain readable, body is scrollable inside the card, **Agree and continue** button stays visible and tappable.
- [ ] iOS Settings → Accessibility → Larger Text → max accessibility size: same as above.
- [ ] Android Settings → Display → Font size → largest: same as above.
- [ ] Privacy Policy and Terms of Service link taps still work (recognizers preserved).
- [ ] No regressions on rotation / split-view (iPad).