### PR TITLE
fix(desktop): harden conversation reconciliation

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -32,6 +32,56 @@ enum FinishConversationResult {
   case error(String)
 }
 
+enum DesktopConversationMatchPolicy {
+  /// Backend and local clocks can differ slightly around WebSocket close/reconnect.
+  static let startedAtTolerance: TimeInterval = 10
+
+  static func matchesDesktopConversation(
+    startedAt conversationStartedAt: Date?,
+    source: ConversationSource?,
+    sessionStartedAt: Date
+  ) -> Bool {
+    guard let conversationStartedAt else { return false }
+    guard source == .desktop else { return false }
+    return abs(conversationStartedAt.timeIntervalSince(sessionStartedAt)) < startedAtTolerance
+  }
+
+  static func memoryEventMatchesFinishedSession(
+    _ memory: [String: Any]?,
+    sessionStartedAt: Date
+  ) -> Bool {
+    guard let memory else { return false }
+
+    if let source = memory["source"] as? String, source != "desktop" {
+      return false
+    }
+
+    guard let memoryStartedAt = parseMemoryEventDate(memory["started_at"] ?? memory["startedAt"]) else {
+      return false
+    }
+
+    return abs(memoryStartedAt.timeIntervalSince(sessionStartedAt)) < startedAtTolerance
+  }
+
+  static func parseMemoryEventDate(_ value: Any?) -> Date? {
+    if let date = value as? Date {
+      return date
+    }
+    guard let string = value as? String else {
+      return nil
+    }
+
+    let fractionalFormatter = ISO8601DateFormatter()
+    fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = fractionalFormatter.date(from: string) {
+      return date
+    }
+
+    let formatter = ISO8601DateFormatter()
+    return formatter.date(from: string)
+  }
+}
+
 @MainActor
 class AppState: ObservableObject {
   /// Weak reference to the current AppState instance, set on init.
@@ -1868,9 +1918,10 @@ class AppState: ObservableObject {
         if let conversation = try await APIClient.shared.forceProcessConversation() {
           // Validate the returned conversation matches the session we just stopped
           if let sessionId = capturedSessionId, let startTime = capturedStartTime,
-             let convStarted = conversation.startedAt,
-             abs(convStarted.timeIntervalSince(startTime)) < 10,
-             conversation.source == .desktop {
+             DesktopConversationMatchPolicy.matchesDesktopConversation(
+              startedAt: conversation.startedAt,
+              source: conversation.source,
+              sessionStartedAt: startTime) {
             try? await TranscriptionStorage.shared.markSessionCompleted(
               id: sessionId, backendId: conversation.id)
             log("Transcription: Force-processed conversation \(conversation.id), session \(sessionId) completed")
@@ -1906,10 +1957,10 @@ class AppState: ObservableObject {
         endDate: Date().addingTimeInterval(5)
       )
       if let match = conversations.first(where: { conv in
-        guard let convStarted = conv.startedAt else { return false }
-        // Must be a desktop conversation with matching start time
-        guard conv.source == .desktop else { return false }
-        return abs(convStarted.timeIntervalSince(startTime)) < 10
+        DesktopConversationMatchPolicy.matchesDesktopConversation(
+          startedAt: conv.startedAt,
+          source: conv.source,
+          sessionStartedAt: startTime)
       }) {
         try await TranscriptionStorage.shared.markSessionCompleted(
           id: sessionId, backendId: match.id)
@@ -2798,12 +2849,19 @@ class AppState: ObservableObject {
       isSavingConversation = false
 
       // Mark DB session as completed so TranscriptionRetryService won't re-upload.
-      // Use finishedSessionId (captured before session rotation) to avoid race with finishConversation().
-      let targetSessionId = finishedSessionId ?? currentSessionId
-      let targetStartTime = finishedRecordingStartTime ?? recordingStartTime
-      if let sessionId = targetSessionId, memoryId != "?" {
+      // Only bind the session captured before rotation; live events may arrive while
+      // the next recording is already active.
+      let targetSessionId = finishedSessionId
+      let targetStartTime = finishedRecordingStartTime
+      let didBindLocalSession: Bool
+      if let sessionId = targetSessionId,
+         let startTime = targetStartTime,
+         memoryId != "?",
+         DesktopConversationMatchPolicy.memoryEventMatchesFinishedSession(
+          memory, sessionStartedAt: startTime) {
         finishedSessionId = nil  // Consume once
         finishedRecordingStartTime = nil
+        didBindLocalSession = true
         Task {
           do {
             try await TranscriptionStorage.shared.markSessionCompleted(
@@ -2814,10 +2872,23 @@ class AppState: ObservableObject {
               "Transcription: Failed to mark DB session \(sessionId) completed", error: error)
           }
         }
+      } else {
+        didBindLocalSession = false
+        if memoryId != "?" {
+          if let startTime = targetStartTime,
+             let memoryStartedAt = DesktopConversationMatchPolicy.parseMemoryEventDate(
+              memory?["started_at"] ?? memory?["startedAt"]) {
+            let delta = abs(memoryStartedAt.timeIntervalSince(startTime))
+            if delta >= DesktopConversationMatchPolicy.startedAtTolerance {
+              log("Transcription: Ignoring memory_created event; started_at delta \(String(format: "%.1f", delta))s exceeds session match tolerance")
+            }
+          }
+          log("Transcription: Waiting for API reconciliation before binding memory_created \(memoryId) to a local session")
+        }
       }
 
       // Track conversation creation — use captured start time for accurate duration after session rotation
-      if let startTime = targetStartTime {
+      if didBindLocalSession, let startTime = targetStartTime {
         let durationSeconds = Int(Date().timeIntervalSince(startTime))
         AnalyticsManager.shared.conversationCreated(
           conversationId: memoryId,

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -52,6 +52,8 @@ enum DesktopConversationMatchPolicy {
   ) -> Bool {
     guard let memory else { return false }
 
+    // Older backend lifecycle events may omit source; accept missing source for
+    // compatibility, but reject an explicit non-desktop source.
     if let source = memory["source"] as? String, source != "desktop" {
       return false
     }
@@ -2875,15 +2877,18 @@ class AppState: ObservableObject {
       } else {
         didBindLocalSession = false
         if memoryId != "?" {
-          if let startTime = targetStartTime,
-             let memoryStartedAt = DesktopConversationMatchPolicy.parseMemoryEventDate(
+          if targetSessionId == nil || targetStartTime == nil {
+            log("Transcription: Ignoring memory_created \(memoryId); no finished local session is awaiting backend binding")
+          } else if let sessionId = targetSessionId, let startTime = targetStartTime {
+            if let memoryStartedAt = DesktopConversationMatchPolicy.parseMemoryEventDate(
               memory?["started_at"] ?? memory?["startedAt"]) {
-            let delta = abs(memoryStartedAt.timeIntervalSince(startTime))
-            if delta >= DesktopConversationMatchPolicy.startedAtTolerance {
-              log("Transcription: Ignoring memory_created event; started_at delta \(String(format: "%.1f", delta))s exceeds session match tolerance")
+              let delta = abs(memoryStartedAt.timeIntervalSince(startTime))
+              if delta >= DesktopConversationMatchPolicy.startedAtTolerance {
+                log("Transcription: Ignoring memory_created event; started_at delta \(String(format: "%.1f", delta))s exceeds session match tolerance")
+              }
             }
+            log("Transcription: Waiting for API reconciliation before binding memory_created \(memoryId) to local session \(sessionId)")
           }
-          log("Transcription: Waiting for API reconciliation before binding memory_created \(memoryId) to a local session")
         }
       }
 

--- a/desktop/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
@@ -157,6 +157,19 @@ struct TranscriptionSessionRecord: Codable, FetchableRecord, PersistableRecord, 
         retryCount < 5
     }
 
+    /// True once the local session has been associated with a backend conversation.
+    var hasSyncedBackendIdentity: Bool {
+        backendSynced || !(backendId?.isEmpty ?? true)
+    }
+
+    /// Whether a completion event can attach this backend conversation ID.
+    func canAcceptCompletion(backendId incomingBackendId: String) -> Bool {
+        guard let existingBackendId = backendId, !existingBackendId.isEmpty else {
+            return true
+        }
+        return existingBackendId == incomingBackendId
+    }
+
     /// Calculate backoff delay in seconds based on retry count
     var retryBackoffSeconds: TimeInterval {
         // Exponential backoff: 2^retryCount minutes

--- a/desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -74,23 +74,26 @@ actor TranscriptionStorage {
     func finishSession(id: Int64) async throws {
         let db = try await ensureInitialized()
 
-        try await db.write { database in
+        let didFinish = try await db.write { database -> Bool in
             guard var record = try TranscriptionSessionRecord.fetchOne(database, key: id) else {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
             guard !record.hasSyncedBackendIdentity else {
                 log("TranscriptionStorage: Skipping finishSession for backend-synced session \(id)")
-                return
+                return false
             }
 
             record.finishedAt = Date()
             record.status = .pendingUpload
             record.updatedAt = Date()
             try record.update(database)
+            return true
         }
 
-        log("TranscriptionStorage: Finished session \(id)")
+        if didFinish {
+            log("TranscriptionStorage: Finished session \(id)")
+        }
     }
 
     /// Mark session as pending upload

--- a/desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -79,6 +79,11 @@ actor TranscriptionStorage {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
+            guard !record.hasSyncedBackendIdentity else {
+                log("TranscriptionStorage: Skipping finishSession for backend-synced session \(id)")
+                return
+            }
+
             record.finishedAt = Date()
             record.status = .pendingUpload
             record.updatedAt = Date()
@@ -107,12 +112,19 @@ actor TranscriptionStorage {
                 throw TranscriptionStorageError.sessionNotFound
             }
 
+            guard record.canAcceptCompletion(backendId: backendId) else {
+                log("TranscriptionStorage: Skipping conflicting completion for session \(id) (existing: \(record.backendId ?? "nil"), incoming: \(backendId))")
+                return
+            }
+
             let completedAt = Date()
             record.status = .completed
             record.conversationStatus = .completed
             record.finishedAt = record.finishedAt ?? completedAt
             record.backendId = backendId
             record.backendSynced = true
+            record.retryCount = 0
+            record.lastError = nil
             record.updatedAt = completedAt
             try record.update(database)
         }
@@ -133,6 +145,10 @@ actor TranscriptionStorage {
             // Don't regress a completed session back to failed
             guard record.status != .completed else {
                 log("TranscriptionStorage: Skipping markSessionFailed for already-completed session \(id)")
+                return
+            }
+            guard !record.hasSyncedBackendIdentity else {
+                log("TranscriptionStorage: Skipping markSessionFailed for backend-synced session \(id)")
                 return
             }
 
@@ -158,6 +174,10 @@ actor TranscriptionStorage {
             // Don't modify a completed session
             guard record.status != .completed else {
                 log("TranscriptionStorage: Skipping incrementRetryCount for already-completed session \(id)")
+                return
+            }
+            guard !record.hasSyncedBackendIdentity else {
+                log("TranscriptionStorage: Skipping incrementRetryCount for backend-synced session \(id)")
                 return
             }
 
@@ -190,6 +210,11 @@ actor TranscriptionStorage {
         try await db.write { database in
             guard var record = try TranscriptionSessionRecord.fetchOne(database, key: id) else {
                 throw TranscriptionStorageError.sessionNotFound
+            }
+
+            guard !record.hasSyncedBackendIdentity else {
+                log("TranscriptionStorage: Skipping status update for backend-synced session \(id)")
+                return
             }
 
             record.status = status
@@ -499,6 +524,8 @@ actor TranscriptionStorage {
         return try await db.read { database in
             try TranscriptionSessionRecord
                 .filter(Column("status") == TranscriptionSessionStatus.pendingUpload.rawValue)
+                .filter(Column("backendSynced") == false)
+                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("createdAt").asc)
                 .fetchAll(database)
         }
@@ -512,6 +539,8 @@ actor TranscriptionStorage {
             try TranscriptionSessionRecord
                 .filter(Column("status") == TranscriptionSessionStatus.failed.rawValue)
                 .filter(Column("retryCount") < maxRetries)
+                .filter(Column("backendSynced") == false)
+                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("updatedAt").asc)
                 .fetchAll(database)
         }
@@ -524,6 +553,8 @@ actor TranscriptionStorage {
         return try await db.read { database in
             try TranscriptionSessionRecord
                 .filter(Column("status") == TranscriptionSessionStatus.recording.rawValue)
+                .filter(Column("backendSynced") == false)
+                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("createdAt").asc)
                 .fetchAll(database)
         }
@@ -539,6 +570,8 @@ actor TranscriptionStorage {
             try TranscriptionSessionRecord
                 .filter(Column("status") == TranscriptionSessionStatus.uploading.rawValue)
                 .filter(Column("updatedAt") < cutoff)
+                .filter(Column("backendSynced") == false)
+                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("createdAt").asc)
                 .fetchAll(database)
         }
@@ -573,6 +606,8 @@ actor TranscriptionStorage {
                     Column("status") == TranscriptionSessionStatus.pendingUpload.rawValue ||
                     (Column("status") == TranscriptionSessionStatus.failed.rawValue && Column("retryCount") < 5)
                 )
+                .filter(Column("backendSynced") == false)
+                .filter((Column("backendId") == nil) || (Column("backendId") == ""))
                 .order(Column("createdAt").asc)
                 .fetchAll(database)
         }

--- a/desktop/Desktop/Sources/TranscriptionRetryService.swift
+++ b/desktop/Desktop/Sources/TranscriptionRetryService.swift
@@ -222,10 +222,11 @@ class TranscriptionRetryService {
                 startDate: session.startedAt.addingTimeInterval(-5),
                 endDate: finishedAt.addingTimeInterval(5)
             ), let match = existing.first(where: { conv in
-                guard let convStarted = conv.startedAt else { return false }
-                // Must be a desktop conversation with matching start time
-                guard conv.source == .desktop else { return false }
-                return abs(convStarted.timeIntervalSince(session.startedAt)) < 10
+                DesktopConversationMatchPolicy.matchesDesktopConversation(
+                    startedAt: conv.startedAt,
+                    source: conv.source,
+                    sessionStartedAt: session.startedAt
+                )
             }) {
                 log("TranscriptionRetryService: Session \(sessionId) found on backend as \(match.id), marking completed")
                 try await TranscriptionStorage.shared.markSessionCompleted(id: sessionId, backendId: match.id)

--- a/desktop/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/Desktop/Tests/StopReconciliationTests.swift
@@ -62,8 +62,11 @@ final class StopReconciliationTests: XCTestCase {
         let convStartedAt = sessionStartTime.addingTimeInterval(2) // 2s offset
         let convSource: ConversationSource = .desktop
 
-        let matches = convSource == .desktop
-            && abs(convStartedAt.timeIntervalSince(sessionStartTime)) < 10
+        let matches = DesktopConversationMatchPolicy.matchesDesktopConversation(
+            startedAt: convStartedAt,
+            source: convSource,
+            sessionStartedAt: sessionStartTime
+        )
 
         XCTAssertTrue(matches, "Conversation within 10s and source=desktop should match")
     }
@@ -73,8 +76,11 @@ final class StopReconciliationTests: XCTestCase {
         let convStartedAt = sessionStartTime.addingTimeInterval(15) // 15s offset
         let convSource: ConversationSource = .desktop
 
-        let matches = convSource == .desktop
-            && abs(convStartedAt.timeIntervalSince(sessionStartTime)) < 10
+        let matches = DesktopConversationMatchPolicy.matchesDesktopConversation(
+            startedAt: convStartedAt,
+            source: convSource,
+            sessionStartedAt: sessionStartTime
+        )
 
         XCTAssertFalse(matches, "Conversation >10s away should not match")
     }
@@ -84,8 +90,11 @@ final class StopReconciliationTests: XCTestCase {
         let convStartedAt = sessionStartTime.addingTimeInterval(1) // 1s offset
         let convSource: ConversationSource = .phone
 
-        let matches = convSource == .desktop
-            && abs(convStartedAt.timeIntervalSince(sessionStartTime)) < 10
+        let matches = DesktopConversationMatchPolicy.matchesDesktopConversation(
+            startedAt: convStartedAt,
+            source: convSource,
+            sessionStartedAt: sessionStartTime
+        )
 
         XCTAssertFalse(matches, "Non-desktop conversation should not match")
     }
@@ -95,8 +104,11 @@ final class StopReconciliationTests: XCTestCase {
         let convStartedAt = sessionStartTime.addingTimeInterval(20)
         let convSource: ConversationSource = .omi
 
-        let matches = convSource == .desktop
-            && abs(convStartedAt.timeIntervalSince(sessionStartTime)) < 10
+        let matches = DesktopConversationMatchPolicy.matchesDesktopConversation(
+            startedAt: convStartedAt,
+            source: convSource,
+            sessionStartedAt: sessionStartTime
+        )
 
         XCTAssertFalse(matches, "Both time and source mismatch should not match")
     }
@@ -106,11 +118,14 @@ final class StopReconciliationTests: XCTestCase {
     func testValidationAtExactBoundary() {
         let sessionStartTime = Date()
         // Exactly 10s — should NOT match (condition is < 10, not <=)
-        let convStartedAt = sessionStartTime.addingTimeInterval(10)
+        let convStartedAt = sessionStartTime.addingTimeInterval(DesktopConversationMatchPolicy.startedAtTolerance)
         let convSource: ConversationSource = .desktop
 
-        let matches = convSource == .desktop
-            && abs(convStartedAt.timeIntervalSince(sessionStartTime)) < 10
+        let matches = DesktopConversationMatchPolicy.matchesDesktopConversation(
+            startedAt: convStartedAt,
+            source: convSource,
+            sessionStartedAt: sessionStartTime
+        )
 
         XCTAssertFalse(matches, "Exactly 10s offset should not match (< 10 boundary)")
     }
@@ -120,8 +135,11 @@ final class StopReconciliationTests: XCTestCase {
         let convStartedAt = sessionStartTime.addingTimeInterval(9.99)
         let convSource: ConversationSource = .desktop
 
-        let matches = convSource == .desktop
-            && abs(convStartedAt.timeIntervalSince(sessionStartTime)) < 10
+        let matches = DesktopConversationMatchPolicy.matchesDesktopConversation(
+            startedAt: convStartedAt,
+            source: convSource,
+            sessionStartedAt: sessionStartTime
+        )
 
         XCTAssertTrue(matches, "9.99s offset should match")
     }
@@ -132,9 +150,73 @@ final class StopReconciliationTests: XCTestCase {
         let convStartedAt = sessionStartTime.addingTimeInterval(-3)
         let convSource: ConversationSource = .desktop
 
-        let matches = convSource == .desktop
-            && abs(convStartedAt.timeIntervalSince(sessionStartTime)) < 10
+        let matches = DesktopConversationMatchPolicy.matchesDesktopConversation(
+            startedAt: convStartedAt,
+            source: convSource,
+            sessionStartedAt: sessionStartTime
+        )
 
         XCTAssertTrue(matches, "Negative offset within 10s should match (abs)")
+    }
+
+    // MARK: - memory_created Event Matching
+
+    func testMemoryCreatedEventAcceptsMatchingDesktopStartedAt() {
+        let sessionStartTime = Date()
+        let memory: [String: Any] = [
+            "source": "desktop",
+            "started_at": sessionStartTime.addingTimeInterval(2).iso8601String
+        ]
+
+        XCTAssertTrue(DesktopConversationMatchPolicy.memoryEventMatchesFinishedSession(
+            memory,
+            sessionStartedAt: sessionStartTime
+        ))
+    }
+
+    func testMemoryCreatedEventRejectsLiveRecordingStartedAt() {
+        let sessionStartTime = Date()
+        let memory: [String: Any] = [
+            "source": "desktop",
+            "started_at": sessionStartTime
+                .addingTimeInterval(DesktopConversationMatchPolicy.startedAtTolerance + 1)
+                .iso8601String
+        ]
+
+        XCTAssertFalse(DesktopConversationMatchPolicy.memoryEventMatchesFinishedSession(
+            memory,
+            sessionStartedAt: sessionStartTime
+        ))
+    }
+
+    func testMemoryCreatedEventRejectsNonDesktopSource() {
+        let sessionStartTime = Date()
+        let memory: [String: Any] = [
+            "source": "phone",
+            "started_at": sessionStartTime.iso8601String
+        ]
+
+        XCTAssertFalse(DesktopConversationMatchPolicy.memoryEventMatchesFinishedSession(
+            memory,
+            sessionStartedAt: sessionStartTime
+        ))
+    }
+
+    func testMemoryCreatedEventAllowsMissingSourceWhenStartedAtMatches() {
+        let sessionStartTime = Date()
+        let memory: [String: Any] = [
+            "started_at": sessionStartTime.iso8601String
+        ]
+
+        XCTAssertTrue(DesktopConversationMatchPolicy.memoryEventMatchesFinishedSession(
+            memory,
+            sessionStartedAt: sessionStartTime
+        ))
+    }
+}
+
+private extension Date {
+    var iso8601String: String {
+        ISO8601DateFormatter().string(from: self)
     }
 }

--- a/desktop/Desktop/Tests/TranscriptionSessionRecordTests.swift
+++ b/desktop/Desktop/Tests/TranscriptionSessionRecordTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Omi_Computer
+
+final class TranscriptionSessionRecordTests: XCTestCase {
+    func testBackendIdentityExistsWhenBackendIdIsPresent() {
+        let record = TranscriptionSessionRecord(
+            source: "desktop",
+            backendId: "conversation-a",
+            backendSynced: false
+        )
+
+        XCTAssertTrue(record.hasSyncedBackendIdentity)
+    }
+
+    func testBackendIdentityExistsWhenBackendSyncedIsTrue() {
+        let record = TranscriptionSessionRecord(
+            source: "desktop",
+            backendId: nil,
+            backendSynced: true
+        )
+
+        XCTAssertTrue(record.hasSyncedBackendIdentity)
+    }
+
+    func testCompletionAcceptsEmptyBackendIdentity() {
+        let record = TranscriptionSessionRecord(
+            source: "desktop",
+            backendId: nil,
+            backendSynced: false
+        )
+
+        XCTAssertTrue(record.canAcceptCompletion(backendId: "conversation-a"))
+    }
+
+    func testCompletionAcceptsSameBackendId() {
+        let record = TranscriptionSessionRecord(
+            source: "desktop",
+            backendId: "conversation-a",
+            backendSynced: true
+        )
+
+        XCTAssertTrue(record.canAcceptCompletion(backendId: "conversation-a"))
+    }
+
+    func testCompletionRejectsConflictingBackendId() {
+        let record = TranscriptionSessionRecord(
+            source: "desktop",
+            backendId: "conversation-a",
+            backendSynced: true
+        )
+
+        XCTAssertFalse(record.canAcceptCompletion(backendId: "conversation-b"))
+    }
+}


### PR DESCRIPTION
## Summary

Addresses #6418.
Related to #6952.

Desktop reconciliation could still regress a local transcription session after the backend had already associated it with a conversation. This hardens the client-side path by:
- centralizing desktop conversation matching around source + started_at tolerance
- only binding `memory_created` events to the session captured before rotation
- rejecting conflicting backend conversation IDs once a session already has a backend identity
- excluding backend-linked sessions from retry/recovery queues so retry does not mark them failed with `No matching desktop conversation found on backend`

## Files touched

- `desktop/Desktop/Sources/AppState.swift`
- `desktop/Desktop/Sources/TranscriptionRetryService.swift`
- `desktop/Desktop/Sources/Rewind/Core/TranscriptionModels.swift`
- `desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift`
- `desktop/Desktop/Tests/StopReconciliationTests.swift`
- `desktop/Desktop/Tests/TranscriptionSessionRecordTests.swift`

## Test plan

- [x] `xcrun swift test --package-path Desktop --filter StopReconciliationTests`
- [x] `xcrun swift test --package-path Desktop --filter TranscriptionSessionRecordTests`
- [x] `git diff --check`
