### PR TITLE
l10n: translate bulk action snackbar strings (48 locales)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,8 @@ If a PR changes how audio streaming, transcription, conversation lifecycle, spea
 ### App (Flutter)
 
 - All user-facing strings must use l10n (`context.l10n.keyName`). Add keys to ARB files using `jq` to avoid reading large files.
-- When adding new l10n keys, translate all 33 non-English locales — never leave English text in non-English ARB files. Use `omi-add-missing-language-keys-l10n` skill for translations. Ensure `{parameter}` placeholders match the English ARB exactly.
-- After modifying ARB files in `app/lib/l10n/`, regenerate localizations: `cd app && flutter gen-l10n`
+- When adding new l10n keys, translate all 48 non-English locales — never leave English text in non-English ARB files. Don't hardcode the count from memory; the authoritative list is whatever `ls app/lib/l10n/app_*.arb` returns minus `app_en.arb`. Use the `omi-add-missing-language-keys-l10n` skill for translations and ensure `{parameter}` placeholders match the English ARB exactly.
+- After modifying ARB files in `app/lib/l10n/`, regenerate localizations: `cd app && flutter gen-l10n`. The task is only done when this command emits zero "untranslated message(s)" warnings.
 
 #### Verifying UI Changes (agent-flutter)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ See service descriptions in AGENTS.md. Update both files when service boundaries
 ### Localization
 - All user-facing strings must use l10n: `context.l10n.keyName` instead of hardcoded strings.
 - Add new keys via `jq` (never read full ARB files). See skill `add-a-new-localization-key-l10n-arb`.
-- **Translate all 33 locales** — no English text in non-English ARB files. Use `omi-add-missing-language-keys-l10n` skill.
+- **Translate all 48 non-English locales** — no English text in non-English ARB files. The exact list is whatever `ls app/lib/l10n/app_*.arb` returns minus `app_en.arb`; don't hardcode a count from memory. After adding any key, run the `omi-add-missing-language-keys-l10n` skill to fill missing translations, then verify with `cd app && flutter gen-l10n` — zero "untranslated message(s)" warnings means done.
 - Regenerate after changes: `cd app && flutter gen-l10n`
 
 ### Firebase Prod Config

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -81,7 +81,7 @@ flutter test test/unit/  # specific directory
 ## Localization (l10n)
 
 - All user-facing strings must use `context.l10n.keyName`
-- 49 locales: English (template) + 48 translations in `lib/l10n/`. Don't trust this count from memory — enumerate with `ls app/lib/l10n/app_*.arb`.
+- 49 locales: English (template) + 48 translations in `lib/l10n/`. Don't trust this count from memory — enumerate with `ls lib/l10n/app_*.arb`.
 - Template: `lib/l10n/app_en.arb`
 - Add keys via `jq` (never read full ARB — they're large). Use skill `add-a-new-localization-key-l10n-arb`
 - Translate all locales — use skill `omi-add-missing-language-keys-l10n` for real translations

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -81,11 +81,11 @@ flutter test test/unit/  # specific directory
 ## Localization (l10n)
 
 - All user-facing strings must use `context.l10n.keyName`
-- 34 locales: English (template) + 33 translations in `lib/l10n/`
+- 49 locales: English (template) + 48 translations in `lib/l10n/`. Don't trust this count from memory — enumerate with `ls app/lib/l10n/app_*.arb`.
 - Template: `lib/l10n/app_en.arb`
 - Add keys via `jq` (never read full ARB — they're large). Use skill `add-a-new-localization-key-l10n-arb`
 - Translate all locales — use skill `omi-add-missing-language-keys-l10n` for real translations
-- Regenerate after changes: `flutter gen-l10n`
+- Regenerate after changes: `flutter gen-l10n`. Task is only complete when this command emits zero "untranslated message(s)" warnings. To get the exact missing-key list, temporarily add `untranslated-messages-file: /tmp/untranslated.json` to `l10n.yaml` and re-run.
 
 ## Auth & Security
 

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2982,5 +2982,7 @@
     "selectAllTasksMenu": "تحديد الكل",
     "showCompletedTasks": "إظهار المكتملة",
     "startCallRecording": "بدء تسجيل المكالمة",
-    "startVoiceRecording": "بدء التسجيل الصوتي"
+    "startVoiceRecording": "بدء التسجيل الصوتي",
+    "bulkExportAlreadyExported": "تم تصدير جميع المهام المحددة بالفعل",
+    "bulkDeleteFailed": "تعذّر حذف المهام. يُرجى المحاولة مرة أخرى."
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "Выбраць усе",
     "showCompletedTasks": "Паказаць завершаныя",
     "startCallRecording": "Пачаць запіс званка",
-    "startVoiceRecording": "Пачаць галасавы запіс"
+    "startVoiceRecording": "Пачаць галасавы запіс",
+    "bulkExportAlreadyExported": "Усе выбраныя задачы ўжо экспартаваны",
+    "bulkDeleteFailed": "Не ўдалося выдаліць задачы. Калі ласка, паспрабуйце яшчэ раз."
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2984,5 +2984,7 @@
     "selectAllTasksMenu": "Избиране на всички",
     "showCompletedTasks": "Показване на завършените",
     "startCallRecording": "Стартиране на запис на разговор",
-    "startVoiceRecording": "Стартиране на гласов запис"
+    "startVoiceRecording": "Стартиране на гласов запис",
+    "bulkExportAlreadyExported": "Всички избрани задачи вече са експортирани",
+    "bulkDeleteFailed": "Задачите не можаха да бъдат изтрити. Моля, опитайте отново."
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "সমস্ত নির্বাচন",
     "showCompletedTasks": "সম্পন্ন দেখান",
     "startCallRecording": "কল রেকর্ডিং শুরু করুন",
-    "startVoiceRecording": "ভয়েস রেকর্ডিং শুরু করুন"
+    "startVoiceRecording": "ভয়েস রেকর্ডিং শুরু করুন",
+    "bulkExportAlreadyExported": "নির্বাচিত সব কাজ ইতিমধ্যেই রপ্তানি করা হয়েছে",
+    "bulkDeleteFailed": "কাজগুলো মুছে ফেলা যায়নি। আবার চেষ্টা করুন।"
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "Odaberi sve",
     "showCompletedTasks": "Prikaži završene",
     "startCallRecording": "Pokreni snimanje poziva",
-    "startVoiceRecording": "Pokreni glasovno snimanje"
+    "startVoiceRecording": "Pokreni glasovno snimanje",
+    "bulkExportAlreadyExported": "Svi odabrani zadaci već su izvezeni",
+    "bulkDeleteFailed": "Zadaci nisu mogli biti obrisani. Molimo pokušajte ponovo."
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2984,5 +2984,7 @@
     "selectAllTasksMenu": "Selecciona tot",
     "showCompletedTasks": "Mostra les completades",
     "startCallRecording": "Inicia l'enregistrament de trucada",
-    "startVoiceRecording": "Inicia l'enregistrament de veu"
+    "startVoiceRecording": "Inicia l'enregistrament de veu",
+    "bulkExportAlreadyExported": "Totes les tasques seleccionades ja s'han exportat",
+    "bulkDeleteFailed": "No s'han pogut eliminar les tasques. Torna-ho a provar."
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2984,5 +2984,7 @@
     "selectAllTasksMenu": "Vybrat vše",
     "showCompletedTasks": "Zobrazit dokončené",
     "startCallRecording": "Zahájit nahrávání hovoru",
-    "startVoiceRecording": "Zahájit hlasový záznam"
+    "startVoiceRecording": "Zahájit hlasový záznam",
+    "bulkExportAlreadyExported": "Všechny vybrané úkoly už byly exportovány",
+    "bulkDeleteFailed": "Úkoly se nepodařilo smazat. Zkuste to prosím znovu."
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3024,5 +3024,7 @@
     "selectAllTasksMenu": "Vælg alle",
     "showCompletedTasks": "Vis fuldførte",
     "startCallRecording": "Start opkaldsoptagelse",
-    "startVoiceRecording": "Start stemmeoptagelse"
+    "startVoiceRecording": "Start stemmeoptagelse",
+    "bulkExportAlreadyExported": "Alle valgte opgaver er allerede eksporteret",
+    "bulkDeleteFailed": "Opgaverne kunne ikke slettes. Prøv igen."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2983,5 +2983,7 @@
     "selectAllTasksMenu": "Alle auswählen",
     "showCompletedTasks": "Erledigte anzeigen",
     "startCallRecording": "Anrufaufnahme starten",
-    "startVoiceRecording": "Sprachaufnahme starten"
+    "startVoiceRecording": "Sprachaufnahme starten",
+    "bulkExportAlreadyExported": "Alle ausgewählten Aufgaben wurden bereits exportiert",
+    "bulkDeleteFailed": "Aufgaben konnten nicht gelöscht werden. Bitte erneut versuchen."
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Επιλογή όλων",
     "showCompletedTasks": "Εμφάνιση ολοκληρωμένων",
     "startCallRecording": "Έναρξη εγγραφής κλήσης",
-    "startVoiceRecording": "Έναρξη ηχογράφησης"
+    "startVoiceRecording": "Έναρξη ηχογράφησης",
+    "bulkExportAlreadyExported": "Όλες οι επιλεγμένες εργασίες έχουν ήδη εξαχθεί",
+    "bulkDeleteFailed": "Δεν ήταν δυνατή η διαγραφή των εργασιών. Δοκιμάστε ξανά."
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3016,5 +3016,7 @@
     "selectAllTasksMenu": "Seleccionar todo",
     "showCompletedTasks": "Mostrar completadas",
     "startCallRecording": "Iniciar grabación de llamada",
-    "startVoiceRecording": "Iniciar grabación de voz"
+    "startVoiceRecording": "Iniciar grabación de voz",
+    "bulkExportAlreadyExported": "Todas las tareas seleccionadas ya están exportadas",
+    "bulkDeleteFailed": "No se pudieron eliminar las tareas. Inténtalo de nuevo."
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Vali kõik",
     "showCompletedTasks": "Kuva lõpetatud",
     "startCallRecording": "Alusta kõne salvestamist",
-    "startVoiceRecording": "Alusta häälsalvestust"
+    "startVoiceRecording": "Alusta häälsalvestust",
+    "bulkExportAlreadyExported": "Kõik valitud ülesanded on juba eksporditud",
+    "bulkDeleteFailed": "Ülesandeid ei õnnestunud kustutada. Palun proovi uuesti."
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "انتخاب همه",
     "showCompletedTasks": "نمایش انجام‌شده‌ها",
     "startCallRecording": "شروع ضبط تماس",
-    "startVoiceRecording": "شروع ضبط صدا"
+    "startVoiceRecording": "شروع ضبط صدا",
+    "bulkExportAlreadyExported": "همهٔ کارهای انتخاب‌شده قبلاً صادر شده‌اند",
+    "bulkDeleteFailed": "حذف کارها ممکن نشد. لطفاً دوباره تلاش کنید."
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Valitse kaikki",
     "showCompletedTasks": "Näytä valmiit",
     "startCallRecording": "Aloita puhelun nauhoitus",
-    "startVoiceRecording": "Aloita ääninauhoitus"
+    "startVoiceRecording": "Aloita ääninauhoitus",
+    "bulkExportAlreadyExported": "Kaikki valitut tehtävät on jo viety",
+    "bulkDeleteFailed": "Tehtävien poistaminen epäonnistui. Yritä uudelleen."
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3050,5 +3050,7 @@
     "selectAllTasksMenu": "Tout sélectionner",
     "showCompletedTasks": "Afficher les terminées",
     "startCallRecording": "Démarrer l'enregistrement d'appel",
-    "startVoiceRecording": "Démarrer l'enregistrement vocal"
+    "startVoiceRecording": "Démarrer l'enregistrement vocal",
+    "bulkExportAlreadyExported": "Toutes les tâches sélectionnées sont déjà exportées",
+    "bulkDeleteFailed": "Impossible de supprimer les tâches. Veuillez réessayer."
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "בחר הכל",
     "showCompletedTasks": "הצג הושלמו",
     "startCallRecording": "התחל הקלטת שיחה",
-    "startVoiceRecording": "התחל הקלטה קולית"
+    "startVoiceRecording": "התחל הקלטה קולית",
+    "bulkExportAlreadyExported": "כל המשימות שנבחרו כבר יוצאו",
+    "bulkDeleteFailed": "לא ניתן למחוק את המשימות. אנא נסה שוב."
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3016,5 +3016,7 @@
     "selectAllTasksMenu": "सभी चुनें",
     "showCompletedTasks": "पूर्ण दिखाएं",
     "startCallRecording": "कॉल रिकॉर्डिंग शुरू करें",
-    "startVoiceRecording": "वॉइस रिकॉर्डिंग शुरू करें"
+    "startVoiceRecording": "वॉइस रिकॉर्डिंग शुरू करें",
+    "bulkExportAlreadyExported": "सभी चयनित कार्य पहले ही निर्यात किए जा चुके हैं",
+    "bulkDeleteFailed": "कार्य हटाए नहीं जा सके। कृपया पुनः प्रयास करें।"
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "Odaberi sve",
     "showCompletedTasks": "Prikaži dovršene",
     "startCallRecording": "Pokreni snimanje poziva",
-    "startVoiceRecording": "Pokreni glasovno snimanje"
+    "startVoiceRecording": "Pokreni glasovno snimanje",
+    "bulkExportAlreadyExported": "Svi odabrani zadaci već su izvezeni",
+    "bulkDeleteFailed": "Zadatke nije bilo moguće izbrisati. Pokušajte ponovno."
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3111,5 +3111,7 @@
     "selectAllTasksMenu": "Összes kijelölése",
     "showCompletedTasks": "Befejezettek megjelenítése",
     "startCallRecording": "Hívásfelvétel indítása",
-    "startVoiceRecording": "Hangfelvétel indítása"
+    "startVoiceRecording": "Hangfelvétel indítása",
+    "bulkExportAlreadyExported": "Az összes kiválasztott feladat már exportálva van",
+    "bulkDeleteFailed": "A feladatokat nem sikerült törölni. Kérjük, próbáld újra."
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3057,5 +3057,7 @@
     "selectAllTasksMenu": "Pilih semua",
     "showCompletedTasks": "Tampilkan selesai",
     "startCallRecording": "Mulai rekaman panggilan",
-    "startVoiceRecording": "Mulai rekaman suara"
+    "startVoiceRecording": "Mulai rekaman suara",
+    "bulkExportAlreadyExported": "Semua tugas yang dipilih sudah diekspor",
+    "bulkDeleteFailed": "Tidak dapat menghapus tugas. Silakan coba lagi."
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Seleziona tutto",
     "showCompletedTasks": "Mostra completate",
     "startCallRecording": "Avvia registrazione chiamata",
-    "startVoiceRecording": "Avvia registrazione vocale"
+    "startVoiceRecording": "Avvia registrazione vocale",
+    "bulkExportAlreadyExported": "Tutte le attività selezionate sono già state esportate",
+    "bulkDeleteFailed": "Impossibile eliminare le attività. Riprova."
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3016,5 +3016,7 @@
     "selectAllTasksMenu": "すべて選択",
     "showCompletedTasks": "完了を表示",
     "startCallRecording": "通話録音を開始",
-    "startVoiceRecording": "音声録音を開始"
+    "startVoiceRecording": "音声録音を開始",
+    "bulkExportAlreadyExported": "選択したタスクはすべてエクスポート済みです",
+    "bulkDeleteFailed": "タスクを削除できませんでした。もう一度お試しください。"
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "ಎಲ್ಲವನ್ನೂ ಆಯ್ಕೆ ಮಾಡಿ",
     "showCompletedTasks": "ಪೂರ್ಣಗೊಂಡವು ತೋರಿಸಿ",
     "startCallRecording": "ಕರೆ ರೆಕಾರ್ಡಿಂಗ್ ಪ್ರಾರಂಭಿಸಿ",
-    "startVoiceRecording": "ಧ್ವನಿ ರೆಕಾರ್ಡಿಂಗ್ ಪ್ರಾರಂಭಿಸಿ"
+    "startVoiceRecording": "ಧ್ವನಿ ರೆಕಾರ್ಡಿಂಗ್ ಪ್ರಾರಂಭಿಸಿ",
+    "bulkExportAlreadyExported": "ಆಯ್ಕೆಮಾಡಿದ ಎಲ್ಲಾ ಕಾರ್ಯಗಳು ಈಗಾಗಲೇ ರಫ್ತಾಗಿವೆ",
+    "bulkDeleteFailed": "ಕಾರ್ಯಗಳನ್ನು ಅಳಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ."
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "모두 선택",
     "showCompletedTasks": "완료 보기",
     "startCallRecording": "통화 녹음 시작",
-    "startVoiceRecording": "음성 녹음 시작"
+    "startVoiceRecording": "음성 녹음 시작",
+    "bulkExportAlreadyExported": "선택한 모든 작업이 이미 내보내졌습니다",
+    "bulkDeleteFailed": "작업을 삭제할 수 없습니다. 다시 시도해 주세요."
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9175,8 +9175,8 @@ class AppLocalizationsAr extends AppLocalizations {
   String get deselectAllTasksMenu => 'إلغاء تحديد الكل';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'تم تصدير جميع المهام المحددة بالفعل';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'تعذّر حذف المهام. يُرجى المحاولة مرة أخرى.';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9262,8 +9262,8 @@ class AppLocalizationsBe extends AppLocalizations {
   String get deselectAllTasksMenu => 'Зняць выбар усіх';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Усе выбраныя задачы ўжо экспартаваны';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Не ўдалося выдаліць задачы. Калі ласка, паспрабуйце яшчэ раз.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9271,8 +9271,8 @@ class AppLocalizationsBg extends AppLocalizations {
   String get deselectAllTasksMenu => 'Премахване на избора';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Всички избрани задачи вече са експортирани';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Задачите не можаха да бъдат изтрити. Моля, опитайте отново.';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9245,8 +9245,8 @@ class AppLocalizationsBn extends AppLocalizations {
   String get deselectAllTasksMenu => 'সমস্ত নির্বাচন বাতিল';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'নির্বাচিত সব কাজ ইতিমধ্যেই রপ্তানি করা হয়েছে';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'কাজগুলো মুছে ফেলা যায়নি। আবার চেষ্টা করুন।';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9260,8 +9260,8 @@ class AppLocalizationsBs extends AppLocalizations {
   String get deselectAllTasksMenu => 'Poništi odabir svih';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Svi odabrani zadaci već su izvezeni';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Zadaci nisu mogli biti obrisani. Molimo pokušajte ponovo.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9290,8 +9290,8 @@ class AppLocalizationsCa extends AppLocalizations {
   String get deselectAllTasksMenu => 'Desselecciona tot';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Totes les tasques seleccionades ja s\'han exportat';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'No s\'han pogut eliminar les tasques. Torna-ho a provar.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9232,8 +9232,8 @@ class AppLocalizationsCs extends AppLocalizations {
   String get deselectAllTasksMenu => 'Zrušit výběr všech';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Všechny vybrané úkoly už byly exportovány';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Úkoly se nepodařilo smazat. Zkuste to prosím znovu.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9222,8 +9222,8 @@ class AppLocalizationsDa extends AppLocalizations {
   String get deselectAllTasksMenu => 'Fravælg alle';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Alle valgte opgaver er allerede eksporteret';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Opgaverne kunne ikke slettes. Prøv igen.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9313,8 +9313,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deselectAllTasksMenu => 'Alle abwählen';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Alle ausgewählten Aufgaben wurden bereits exportiert';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Aufgaben konnten nicht gelöscht werden. Bitte erneut versuchen.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9301,8 +9301,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get deselectAllTasksMenu => 'Αποεπιλογή όλων';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Όλες οι επιλεγμένες εργασίες έχουν ήδη εξαχθεί';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Δεν ήταν δυνατή η διαγραφή των εργασιών. Δοκιμάστε ξανά.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9257,8 +9257,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get deselectAllTasksMenu => 'Deseleccionar todo';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Todas las tareas seleccionadas ya están exportadas';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'No se pudieron eliminar las tareas. Inténtalo de nuevo.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9233,8 +9233,8 @@ class AppLocalizationsEt extends AppLocalizations {
   String get deselectAllTasksMenu => 'Tühista kõigi valik';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Kõik valitud ülesanded on juba eksporditud';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Ülesandeid ei õnnestunud kustutada. Palun proovi uuesti.';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9239,8 +9239,8 @@ class AppLocalizationsFa extends AppLocalizations {
   String get deselectAllTasksMenu => 'لغو انتخاب همه';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'همهٔ کارهای انتخاب‌شده قبلاً صادر شده‌اند';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'حذف کارها ممکن نشد. لطفاً دوباره تلاش کنید.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9235,8 +9235,8 @@ class AppLocalizationsFi extends AppLocalizations {
   String get deselectAllTasksMenu => 'Poista kaikkien valinta';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Kaikki valitut tehtävät on jo viety';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Tehtävien poistaminen epäonnistui. Yritä uudelleen.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9319,8 +9319,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deselectAllTasksMenu => 'Tout désélectionner';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Toutes les tâches sélectionnées sont déjà exportées';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Impossible de supprimer les tâches. Veuillez réessayer.';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9164,8 +9164,8 @@ class AppLocalizationsHe extends AppLocalizations {
   String get deselectAllTasksMenu => 'בטל בחירת הכל';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'כל המשימות שנבחרו כבר יוצאו';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'לא ניתן למחוק את המשימות. אנא נסה שוב.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9216,8 +9216,8 @@ class AppLocalizationsHi extends AppLocalizations {
   String get deselectAllTasksMenu => 'सभी का चयन हटाएं';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'सभी चयनित कार्य पहले ही निर्यात किए जा चुके हैं';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'कार्य हटाए नहीं जा सके। कृपया पुनः प्रयास करें।';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9266,8 +9266,8 @@ class AppLocalizationsHr extends AppLocalizations {
   String get deselectAllTasksMenu => 'Poništi odabir svih';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Svi odabrani zadaci već su izvezeni';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Zadatke nije bilo moguće izbrisati. Pokušajte ponovno.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9275,8 +9275,8 @@ class AppLocalizationsHu extends AppLocalizations {
   String get deselectAllTasksMenu => 'Összes kijelölés törlése';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Az összes kiválasztott feladat már exportálva van';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'A feladatokat nem sikerült törölni. Kérjük, próbáld újra.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9246,8 +9246,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get deselectAllTasksMenu => 'Batalkan pilihan semua';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Semua tugas yang dipilih sudah diekspor';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Tidak dapat menghapus tugas. Silakan coba lagi.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9291,8 +9291,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get deselectAllTasksMenu => 'Deseleziona tutto';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Tutte le attività selezionate sono già state esportate';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Impossibile eliminare le attività. Riprova.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9087,8 +9087,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get deselectAllTasksMenu => 'すべて選択解除';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => '選択したタスクはすべてエクスポート済みです';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'タスクを削除できませんでした。もう一度お試しください。';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9268,8 +9268,8 @@ class AppLocalizationsKn extends AppLocalizations {
   String get deselectAllTasksMenu => 'ಎಲ್ಲವನ್ನೂ ಆಯ್ಕೆ ರದ್ದು ಮಾಡಿ';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'ಆಯ್ಕೆಮಾಡಿದ ಎಲ್ಲಾ ಕಾರ್ಯಗಳು ಈಗಾಗಲೇ ರಫ್ತಾಗಿವೆ';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'ಕಾರ್ಯಗಳನ್ನು ಅಳಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9088,8 +9088,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get deselectAllTasksMenu => '모두 선택 해제';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => '선택한 모든 작업이 이미 내보내졌습니다';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => '작업을 삭제할 수 없습니다. 다시 시도해 주세요.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9245,8 +9245,8 @@ class AppLocalizationsLt extends AppLocalizations {
   String get deselectAllTasksMenu => 'Atžymėti viską';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Visos pasirinktos užduotys jau eksportuotos';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Nepavyko ištrinti užduočių. Bandykite dar kartą.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9254,8 +9254,8 @@ class AppLocalizationsLv extends AppLocalizations {
   String get deselectAllTasksMenu => 'Noņemt visu atlasi';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Visi atlasītie uzdevumi jau ir eksportēti';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Neizdevās dzēst uzdevumus. Lūdzu, mēģiniet vēlreiz.';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9285,8 +9285,8 @@ class AppLocalizationsMk extends AppLocalizations {
   String get deselectAllTasksMenu => 'Одселектирај ги сите';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Сите избрани задачи се веќе извезени';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Задачите не можеа да се избришат. Обидете се повторно.';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9247,8 +9247,8 @@ class AppLocalizationsMr extends AppLocalizations {
   String get deselectAllTasksMenu => 'सर्वांची निवड रद्द करा';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'निवडलेली सर्व कार्ये आधीच निर्यात केली आहेत';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'कार्ये हटवता आली नाहीत. कृपया पुन्हा प्रयत्न करा.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9260,8 +9260,8 @@ class AppLocalizationsMs extends AppLocalizations {
   String get deselectAllTasksMenu => 'Nyahpilih semua';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Semua tugasan yang dipilih telah dieksport';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Tidak dapat memadam tugasan. Sila cuba lagi.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9264,8 +9264,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get deselectAllTasksMenu => 'Alles deselecteren';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Alle geselecteerde taken zijn al geëxporteerd';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Taken konden niet worden verwijderd. Probeer het opnieuw.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9232,8 +9232,8 @@ class AppLocalizationsNo extends AppLocalizations {
   String get deselectAllTasksMenu => 'Fjern alle valg';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Alle valgte oppgaver er allerede eksportert';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Kunne ikke slette oppgavene. Prøv igjen.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9256,8 +9256,8 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deselectAllTasksMenu => 'Odznacz wszystkie';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Wszystkie wybrane zadania zostały już wyeksportowane';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Nie udało się usunąć zadań. Spróbuj ponownie.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9240,8 +9240,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get deselectAllTasksMenu => 'Desmarcar todos';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Todas as tarefas selecionadas já foram exportadas';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Não foi possível excluir as tarefas. Tente novamente.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9279,8 +9279,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get deselectAllTasksMenu => 'Deselectați tot';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Toate sarcinile selectate sunt deja exportate';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Nu am putut șterge sarcinile. Vă rugăm să încercați din nou.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9265,8 +9265,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get deselectAllTasksMenu => 'Снять выделение со всех';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Все выбранные задачи уже экспортированы';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Не удалось удалить задачи. Пожалуйста, попробуйте ещё раз.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9224,8 +9224,8 @@ class AppLocalizationsSk extends AppLocalizations {
   String get deselectAllTasksMenu => 'Zrušiť výber všetkých';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Všetky vybrané úlohy už boli exportované';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Úlohy sa nepodarilo odstrániť. Skúste to znova.';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9260,8 +9260,8 @@ class AppLocalizationsSl extends AppLocalizations {
   String get deselectAllTasksMenu => 'Prekliči izbor vseh';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Vse izbrane naloge so že izvožene';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Nalog ni bilo mogoče izbrisati. Poskusite znova.';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9249,8 +9249,8 @@ class AppLocalizationsSr extends AppLocalizations {
   String get deselectAllTasksMenu => 'Поништи избор свих';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Сви изабрани задаци су већ извезени';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Задаци нису могли бити обрисани. Покушајте поново.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9240,8 +9240,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get deselectAllTasksMenu => 'Avmarkera alla';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Alla valda uppgifter är redan exporterade';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Det gick inte att ta bort uppgifterna. Försök igen.';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9305,8 +9305,8 @@ class AppLocalizationsTa extends AppLocalizations {
   String get deselectAllTasksMenu => 'அனைத்தையும் தேர்வு நீக்கு';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'தேர்ந்தெடுக்கப்பட்ட அனைத்து பணிகளும் ஏற்கனவே ஏற்றுமதி செய்யப்பட்டுள்ளன';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'பணிகளை நீக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9286,8 +9286,8 @@ class AppLocalizationsTe extends AppLocalizations {
   String get deselectAllTasksMenu => 'అన్ని ఎంపికలు తొలగించు';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'ఎంచుకున్న అన్ని పనులు ఇప్పటికే ఎగుమతి చేయబడ్డాయి';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'పనులను తొలగించలేకపోయింది. దయచేసి మళ్లీ ప్రయత్నించండి.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9190,8 +9190,8 @@ class AppLocalizationsTh extends AppLocalizations {
   String get deselectAllTasksMenu => 'ยกเลิกเลือกทั้งหมด';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'งานที่เลือกทั้งหมดถูกส่งออกแล้ว';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'ลบงานไม่สำเร็จ โปรดลองอีกครั้ง';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9321,8 +9321,8 @@ class AppLocalizationsTl extends AppLocalizations {
   String get deselectAllTasksMenu => 'I-deselect lahat';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Lahat ng napiling gawain ay na-export na';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Hindi matanggal ang mga gawain. Pakisubukang muli.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9249,8 +9249,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deselectAllTasksMenu => 'Tümünün seçimini kaldır';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Seçilen tüm görevler zaten dışa aktarıldı';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Görevler silinemedi. Lütfen tekrar deneyin.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9250,8 +9250,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get deselectAllTasksMenu => 'Зняти виділення з усіх';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Усі вибрані завдання вже експортовано';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Не вдалося видалити завдання. Спробуйте ще раз.';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9253,8 +9253,8 @@ class AppLocalizationsUr extends AppLocalizations {
   String get deselectAllTasksMenu => 'تمام کا انتخاب ختم کریں';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'منتخب کردہ تمام کام پہلے ہی برآمد کیے جا چکے ہیں';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'کام حذف نہیں کیے جا سکے۔ براہ کرم دوبارہ کوشش کریں۔';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9236,8 +9236,8 @@ class AppLocalizationsVi extends AppLocalizations {
   String get deselectAllTasksMenu => 'Bỏ chọn tất cả';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => 'Tất cả các tác vụ đã chọn đều đã được xuất';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => 'Không thể xóa các tác vụ. Vui lòng thử lại.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9073,8 +9073,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get deselectAllTasksMenu => '取消全选';
 
   @override
-  String get bulkExportAlreadyExported => 'All selected tasks already exported';
+  String get bulkExportAlreadyExported => '所选任务已全部导出';
 
   @override
-  String get bulkDeleteFailed => 'Could not delete tasks. Please try again.';
+  String get bulkDeleteFailed => '无法删除任务，请重试。';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Pasirinkti viską",
     "showCompletedTasks": "Rodyti užbaigtas",
     "startCallRecording": "Pradėti skambučio įrašymą",
-    "startVoiceRecording": "Pradėti balso įrašymą"
+    "startVoiceRecording": "Pradėti balso įrašymą",
+    "bulkExportAlreadyExported": "Visos pasirinktos užduotys jau eksportuotos",
+    "bulkDeleteFailed": "Nepavyko ištrinti užduočių. Bandykite dar kartą."
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Atlasīt visus",
     "showCompletedTasks": "Rādīt pabeigtās",
     "startCallRecording": "Sākt zvana ierakstīšanu",
-    "startVoiceRecording": "Sākt balss ierakstīšanu"
+    "startVoiceRecording": "Sākt balss ierakstīšanu",
+    "bulkExportAlreadyExported": "Visi atlasītie uzdevumi jau ir eksportēti",
+    "bulkDeleteFailed": "Neizdevās dzēst uzdevumus. Lūdzu, mēģiniet vēlreiz."
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "Избери ги сите",
     "showCompletedTasks": "Прикажи завршени",
     "startCallRecording": "Започни снимање повик",
-    "startVoiceRecording": "Започни гласовно снимање"
+    "startVoiceRecording": "Започни гласовно снимање",
+    "bulkExportAlreadyExported": "Сите избрани задачи се веќе извезени",
+    "bulkDeleteFailed": "Задачите не можеа да се избришат. Обидете се повторно."
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "सर्व निवडा",
     "showCompletedTasks": "पूर्ण झालेले दाखवा",
     "startCallRecording": "कॉल रेकॉर्डिंग सुरू करा",
-    "startVoiceRecording": "व्हॉइस रेकॉर्डिंग सुरू करा"
+    "startVoiceRecording": "व्हॉइस रेकॉर्डिंग सुरू करा",
+    "bulkExportAlreadyExported": "निवडलेली सर्व कार्ये आधीच निर्यात केली आहेत",
+    "bulkDeleteFailed": "कार्ये हटवता आली नाहीत. कृपया पुन्हा प्रयत्न करा."
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Pilih semua",
     "showCompletedTasks": "Tunjukkan selesai",
     "startCallRecording": "Mula rakaman panggilan",
-    "startVoiceRecording": "Mula rakaman suara"
+    "startVoiceRecording": "Mula rakaman suara",
+    "bulkExportAlreadyExported": "Semua tugasan yang dipilih telah dieksport",
+    "bulkDeleteFailed": "Tidak dapat memadam tugasan. Sila cuba lagi."
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Alles selecteren",
     "showCompletedTasks": "Voltooide tonen",
     "startCallRecording": "Gespreksopname starten",
-    "startVoiceRecording": "Spraakopname starten"
+    "startVoiceRecording": "Spraakopname starten",
+    "bulkExportAlreadyExported": "Alle geselecteerde taken zijn al geëxporteerd",
+    "bulkDeleteFailed": "Taken konden niet worden verwijderd. Probeer het opnieuw."
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Velg alle",
     "showCompletedTasks": "Vis fullførte",
     "startCallRecording": "Start samtaleopptak",
-    "startVoiceRecording": "Start stemmeopptak"
+    "startVoiceRecording": "Start stemmeopptak",
+    "bulkExportAlreadyExported": "Alle valgte oppgaver er allerede eksportert",
+    "bulkDeleteFailed": "Kunne ikke slette oppgavene. Prøv igjen."
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3050,5 +3050,7 @@
     "selectAllTasksMenu": "Zaznacz wszystkie",
     "showCompletedTasks": "Pokaż ukończone",
     "startCallRecording": "Rozpocznij nagrywanie rozmowy",
-    "startVoiceRecording": "Rozpocznij nagrywanie głosu"
+    "startVoiceRecording": "Rozpocznij nagrywanie głosu",
+    "bulkExportAlreadyExported": "Wszystkie wybrane zadania zostały już wyeksportowane",
+    "bulkDeleteFailed": "Nie udało się usunąć zadań. Spróbuj ponownie."
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3051,5 +3051,7 @@
     "selectAllTasksMenu": "Selecionar todos",
     "showCompletedTasks": "Mostrar concluídas",
     "startCallRecording": "Iniciar gravação de chamada",
-    "startVoiceRecording": "Iniciar gravação de voz"
+    "startVoiceRecording": "Iniciar gravação de voz",
+    "bulkExportAlreadyExported": "Todas as tarefas selecionadas já foram exportadas",
+    "bulkDeleteFailed": "Não foi possível excluir as tarefas. Tente novamente."
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Selectați tot",
     "showCompletedTasks": "Afișați finalizate",
     "startCallRecording": "Porniți înregistrarea apelului",
-    "startVoiceRecording": "Porniți înregistrarea vocală"
+    "startVoiceRecording": "Porniți înregistrarea vocală",
+    "bulkExportAlreadyExported": "Toate sarcinile selectate sunt deja exportate",
+    "bulkDeleteFailed": "Nu am putut șterge sarcinile. Vă rugăm să încercați din nou."
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3050,5 +3050,7 @@
     "selectAllTasksMenu": "Выбрать все",
     "showCompletedTasks": "Показать завершённые",
     "startCallRecording": "Начать запись звонка",
-    "startVoiceRecording": "Начать голосовую запись"
+    "startVoiceRecording": "Начать голосовую запись",
+    "bulkExportAlreadyExported": "Все выбранные задачи уже экспортированы",
+    "bulkDeleteFailed": "Не удалось удалить задачи. Пожалуйста, попробуйте ещё раз."
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3020,5 +3020,7 @@
     "selectAllTasksMenu": "Vybrať všetko",
     "showCompletedTasks": "Zobraziť dokončené",
     "startCallRecording": "Spustiť nahrávanie hovoru",
-    "startVoiceRecording": "Spustiť hlasový záznam"
+    "startVoiceRecording": "Spustiť hlasový záznam",
+    "bulkExportAlreadyExported": "Všetky vybrané úlohy už boli exportované",
+    "bulkDeleteFailed": "Úlohy sa nepodarilo odstrániť. Skúste to znova."
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "Izberi vse",
     "showCompletedTasks": "Prikaži dokončane",
     "startCallRecording": "Začni snemanje klica",
-    "startVoiceRecording": "Začni glasovno snemanje"
+    "startVoiceRecording": "Začni glasovno snemanje",
+    "bulkExportAlreadyExported": "Vse izbrane naloge so že izvožene",
+    "bulkDeleteFailed": "Nalog ni bilo mogoče izbrisati. Poskusite znova."
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "Изабери све",
     "showCompletedTasks": "Прикажи завршене",
     "startCallRecording": "Покрени снимање позива",
-    "startVoiceRecording": "Покрени гласовно снимање"
+    "startVoiceRecording": "Покрени гласовно снимање",
+    "bulkExportAlreadyExported": "Сви изабрани задаци су већ извезени",
+    "bulkDeleteFailed": "Задаци нису могли бити обрисани. Покушајте поново."
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Välj alla",
     "showCompletedTasks": "Visa slutförda",
     "startCallRecording": "Starta samtalsinspelning",
-    "startVoiceRecording": "Starta röstinspelning"
+    "startVoiceRecording": "Starta röstinspelning",
+    "bulkExportAlreadyExported": "Alla valda uppgifter är redan exporterade",
+    "bulkDeleteFailed": "Det gick inte att ta bort uppgifterna. Försök igen."
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "அனைத்தையும் தேர்ந்தெடு",
     "showCompletedTasks": "முடிந்தவற்றைக் காட்டு",
     "startCallRecording": "அழைப்பு பதிவைத் தொடங்கு",
-    "startVoiceRecording": "குரல் பதிவைத் தொடங்கு"
+    "startVoiceRecording": "குரல் பதிவைத் தொடங்கு",
+    "bulkExportAlreadyExported": "தேர்ந்தெடுக்கப்பட்ட அனைத்து பணிகளும் ஏற்கனவே ஏற்றுமதி செய்யப்பட்டுள்ளன",
+    "bulkDeleteFailed": "பணிகளை நீக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்."
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "అన్నీ ఎంచుకోండి",
     "showCompletedTasks": "పూర్తయినవి చూపించు",
     "startCallRecording": "కాల్ రికార్డింగ్ ప్రారంభించండి",
-    "startVoiceRecording": "వాయిస్ రికార్డింగ్ ప్రారంభించండి"
+    "startVoiceRecording": "వాయిస్ రికార్డింగ్ ప్రారంభించండి",
+    "bulkExportAlreadyExported": "ఎంచుకున్న అన్ని పనులు ఇప్పటికే ఎగుమతి చేయబడ్డాయి",
+    "bulkDeleteFailed": "పనులను తొలగించలేకపోయింది. దయచేసి మళ్లీ ప్రయత్నించండి."
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "เลือกทั้งหมด",
     "showCompletedTasks": "แสดงที่เสร็จแล้ว",
     "startCallRecording": "เริ่มบันทึกการโทร",
-    "startVoiceRecording": "เริ่มบันทึกเสียง"
+    "startVoiceRecording": "เริ่มบันทึกเสียง",
+    "bulkExportAlreadyExported": "งานที่เลือกทั้งหมดถูกส่งออกแล้ว",
+    "bulkDeleteFailed": "ลบงานไม่สำเร็จ โปรดลองอีกครั้ง"
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "Piliin lahat",
     "showCompletedTasks": "Ipakita ang tapos na",
     "startCallRecording": "Simulan ang pag-record ng tawag",
-    "startVoiceRecording": "Simulan ang voice recording"
+    "startVoiceRecording": "Simulan ang voice recording",
+    "bulkExportAlreadyExported": "Lahat ng napiling gawain ay na-export na",
+    "bulkDeleteFailed": "Hindi matanggal ang mga gawain. Pakisubukang muli."
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3050,5 +3050,7 @@
     "selectAllTasksMenu": "Tümünü seç",
     "showCompletedTasks": "Tamamlananları göster",
     "startCallRecording": "Arama kaydını başlat",
-    "startVoiceRecording": "Ses kaydını başlat"
+    "startVoiceRecording": "Ses kaydını başlat",
+    "bulkExportAlreadyExported": "Seçilen tüm görevler zaten dışa aktarıldı",
+    "bulkDeleteFailed": "Görevler silinemedi. Lütfen tekrar deneyin."
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3015,5 +3015,7 @@
     "selectAllTasksMenu": "Вибрати все",
     "showCompletedTasks": "Показати завершені",
     "startCallRecording": "Почати запис дзвінка",
-    "startVoiceRecording": "Почати голосовий запис"
+    "startVoiceRecording": "Почати голосовий запис",
+    "bulkExportAlreadyExported": "Усі вибрані завдання вже експортовано",
+    "bulkDeleteFailed": "Не вдалося видалити завдання. Спробуйте ще раз."
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10723,5 +10723,7 @@
     "selectAllTasksMenu": "سب منتخب کریں",
     "showCompletedTasks": "مکمل شدہ دکھائیں",
     "startCallRecording": "کال ریکارڈنگ شروع کریں",
-    "startVoiceRecording": "وائس ریکارڈنگ شروع کریں"
+    "startVoiceRecording": "وائس ریکارڈنگ شروع کریں",
+    "bulkExportAlreadyExported": "منتخب کردہ تمام کام پہلے ہی برآمد کیے جا چکے ہیں",
+    "bulkDeleteFailed": "کام حذف نہیں کیے جا سکے۔ براہ کرم دوبارہ کوشش کریں۔"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3020,5 +3020,7 @@
     "selectAllTasksMenu": "Chọn tất cả",
     "showCompletedTasks": "Hiện đã hoàn thành",
     "startCallRecording": "Bắt đầu ghi âm cuộc gọi",
-    "startVoiceRecording": "Bắt đầu ghi âm giọng nói"
+    "startVoiceRecording": "Bắt đầu ghi âm giọng nói",
+    "bulkExportAlreadyExported": "Tất cả các tác vụ đã chọn đều đã được xuất",
+    "bulkDeleteFailed": "Không thể xóa các tác vụ. Vui lòng thử lại."
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3037,5 +3037,7 @@
     "selectAllTasksMenu": "全选",
     "showCompletedTasks": "显示已完成",
     "startCallRecording": "开始通话录音",
-    "startVoiceRecording": "开始语音录音"
+    "startVoiceRecording": "开始语音录音",
+    "bulkExportAlreadyExported": "所选任务已全部导出",
+    "bulkDeleteFailed": "无法删除任务，请重试。"
 }


### PR DESCRIPTION
## Summary
- Translates `bulkExportAlreadyExported` and `bulkDeleteFailed` into all 48 non-English locales — `flutter gen-l10n` now reports zero `untranslated message(s)` warnings.
- Regenerates `app/lib/l10n/app_localizations_*.dart` accordingly.
- Fixes the stale "33 / 34 locales" count in `CLAUDE.md`, `AGENTS.md`, and `app/CLAUDE.md` (actual count is 48 non-English + 1 English template). Docs now point at `ls app/lib/l10n/app_*.arb` as the source of truth and define "done" as zero `untranslated message(s)` warnings — which is why agents kept missing locales.

## Test plan
- [ ] `cd app && flutter gen-l10n` emits no `untranslated message(s)` warnings.
- [ ] Spot-check a handful of locales (e.g. `de`, `ja`, `ar`, `pt`, `zh`) to confirm translations read naturally and `{parameter}` placeholders match the English ARB.
- [ ] App builds (`cd app && flutter analyze` / debug build) — no broken references to `bulkExportAlreadyExported` / `bulkDeleteFailed`.