### PR TITLE
fix(audio-share): replace synchronous merge with async job + poll (#4586)

### DIFF
--- a/app/lib/backend/http/api/audio.dart
+++ b/app/lib/backend/http/api/audio.dart
@@ -82,3 +82,130 @@ Future<List<AudioFileUrlInfo>> getConversationAudioSignedUrls(String conversatio
     return [];
   }
 }
+
+/// Status of an async audio-share job. Mirrors the backend status field
+/// (queued | processing | completed | failed). Synthetic shortcut: when
+/// every audio file is already cached, the backend skips the job entirely
+/// and returns `completed` directly.
+enum AudioShareJobStatus { queued, processing, completed, failed }
+
+AudioShareJobStatus _parseShareStatus(String? raw) {
+  switch (raw) {
+    case 'queued':
+      return AudioShareJobStatus.queued;
+    case 'processing':
+      return AudioShareJobStatus.processing;
+    case 'completed':
+      return AudioShareJobStatus.completed;
+    case 'failed':
+      return AudioShareJobStatus.failed;
+    default:
+      return AudioShareJobStatus.queued;
+  }
+}
+
+/// One snapshot of an audio-share job. Returned by both the POST /share
+/// kickoff and each GET /share/{job_id} poll.
+class AudioShareJob {
+  /// `null` only when the backend short-circuited on a fully-cached conversation.
+  final String? jobId;
+  final AudioShareJobStatus status;
+  final double progressPct;
+  final List<AudioFileUrlInfo> audioFiles;
+  final String? error;
+  final int pollAfterMs;
+
+  AudioShareJob({
+    required this.jobId,
+    required this.status,
+    required this.progressPct,
+    required this.audioFiles,
+    this.error,
+    required this.pollAfterMs,
+  });
+
+  factory AudioShareJob.fromJson(Map<String, dynamic> json) {
+    final files = (json['audio_files'] as List<dynamic>? ?? [])
+        .map((af) => AudioFileUrlInfo.fromJson(af as Map<String, dynamic>))
+        .toList();
+    return AudioShareJob(
+      jobId: json['job_id'] as String?,
+      status: _parseShareStatus(json['status'] as String?),
+      progressPct: (json['progress_pct'] ?? 0).toDouble(),
+      audioFiles: files,
+      error: json['error'] as String?,
+      pollAfterMs: (json['poll_after_ms'] ?? 3000) as int,
+    );
+  }
+
+  bool get isTerminal => status == AudioShareJobStatus.completed || status == AudioShareJobStatus.failed;
+}
+
+/// Kick off (or rejoin) an async share-audio merge. Returns immediately:
+/// either `completed` (cache hit, signed URLs populated) or `queued/processing`
+/// with a job_id to poll via [getAudioShareJob].
+Future<AudioShareJob?> requestAudioShare(String conversationId) async {
+  try {
+    final headers = await buildHeaders(requireAuthCheck: true);
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}v1/sync/audio/$conversationId/share',
+      headers: headers,
+      method: 'POST',
+      body: '',
+    );
+
+    if (response == null) {
+      return null;
+    }
+    // 200 (cache hit, completed) and 202 (job started/rejoined) both have a body
+    if (response.statusCode != 200 && response.statusCode != 202) {
+      Logger.debug('requestAudioShare: unexpected status ${response.statusCode}');
+      return null;
+    }
+
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    return AudioShareJob.fromJson(decoded);
+  } catch (e) {
+    Logger.debug('Error requesting audio share: $e');
+    return null;
+  }
+}
+
+/// Poll an audio-share job by id. Returns `null` only on transport failure;
+/// terminal failures (404, expired, error) come back as a populated [AudioShareJob]
+/// with `status == failed`.
+Future<AudioShareJob?> getAudioShareJob(String conversationId, String jobId) async {
+  try {
+    final headers = await buildHeaders(requireAuthCheck: true);
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}v1/sync/audio/$conversationId/share/$jobId',
+      headers: headers,
+      method: 'GET',
+      body: '',
+    );
+
+    if (response == null) {
+      return null;
+    }
+    if (response.statusCode == 404) {
+      return AudioShareJob(
+        jobId: jobId,
+        status: AudioShareJobStatus.failed,
+        progressPct: 0.0,
+        audioFiles: const [],
+        error: 'Job not found or expired',
+        pollAfterMs: 0,
+      );
+    }
+    if (response.statusCode != 200) {
+      Logger.debug('getAudioShareJob: unexpected status ${response.statusCode}');
+      return null;
+    }
+
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    return AudioShareJob.fromJson(decoded);
+  } catch (e) {
+    Logger.debug('Error polling audio share job: $e');
+    return null;
+  }
+}

--- a/app/lib/services/audio_download_service.dart
+++ b/app/lib/services/audio_download_service.dart
@@ -10,6 +10,17 @@ import 'package:omi/utils/logger.dart';
 
 enum AudioDownloadStage { preparing, downloading, processing }
 
+/// Total wallclock allowed for the merge phase before we give up. Backend
+/// stale-job detection kicks in at 25 min; client gives one extra minute of
+/// slack to account for poll cadence + network jitter.
+const Duration _shareMergeMaxWait = Duration(minutes: 26);
+
+/// Floor and ceiling for the server-suggested poll interval — even if the
+/// backend asks for something silly, the client never busy-loops or sleeps so
+/// long that progress goes stale.
+const Duration _shareMergePollFloor = Duration(seconds: 1);
+const Duration _shareMergePollCeiling = Duration(seconds: 10);
+
 class AudioDownloadService {
   final http.Client _client = http.Client();
   final List<File> _tempFiles = [];
@@ -27,17 +38,55 @@ class AudioDownloadService {
 
       onStageChange?.call(AudioDownloadStage.preparing);
 
-      final audioFileInfos = await getConversationAudioSignedUrls(conversation.id);
-
-      if (audioFileInfos.isEmpty) {
-        Logger.debug('No audio file URLs available');
+      // POST /share kicks off (or rejoins) the merge job. For a fully-cached
+      // conversation the response is already `completed` with signed URLs.
+      AudioShareJob? job = await requestAudioShare(conversation.id);
+      if (job == null) {
+        Logger.debug('Failed to start audio share job');
         return null;
       }
 
-      final cachedFiles = audioFileInfos.where((info) => info.isCached).toList();
+      // Poll the job until it reaches a terminal state, surfacing server-side
+      // merge progress through onProgress so the UI stops showing an
+      // indeterminate spinner.
+      final mergeDeadline = DateTime.now().add(_shareMergeMaxWait);
+      while (!job!.isTerminal) {
+        // Bound the poll cadence regardless of what the server suggested.
+        // .clamp on int returns num in some Dart positions, so .toInt() avoids
+        // an implicit downcast warning when passed to Duration.
+        final ms =
+            job.pollAfterMs.clamp(_shareMergePollFloor.inMilliseconds, _shareMergePollCeiling.inMilliseconds).toInt();
+        await Future.delayed(Duration(milliseconds: ms));
+
+        if (DateTime.now().isAfter(mergeDeadline)) {
+          throw Exception('Audio share timed out waiting for merge to complete');
+        }
+        // Surface "merge progress" inside the preparing stage. The downloader
+        // will overwrite onProgress once the cache is ready.
+        onProgress?.call(job.progressPct / 100.0);
+
+        if (job.jobId == null) {
+          // No job_id but not terminal — should only happen on a malformed
+          // server response. Bail rather than tight-loop.
+          break;
+        }
+
+        final next = await getAudioShareJob(conversation.id, job.jobId!);
+        if (next == null) {
+          // Transient network failure: keep the previous snapshot and retry.
+          continue;
+        }
+        job = next;
+      }
+
+      if (job.status == AudioShareJobStatus.failed) {
+        throw Exception('Audio share failed: ${job.error ?? "unknown error"}');
+      }
+
+      final cachedFiles = job.audioFiles.where((info) => info.isCached).toList();
 
       if (cachedFiles.isEmpty) {
-        Logger.debug('No cached audio files available');
+        Logger.debug('Audio share completed but no cached files returned');
         return null;
       }
 

--- a/backend/database/audio_share_jobs.py
+++ b/backend/database/audio_share_jobs.py
@@ -1,0 +1,189 @@
+"""
+Redis-backed job storage for async audio-share merge jobs.
+
+Same shape as `sync_jobs.py` but with audio-specific fields. The merge work
+takes 4-10+ minutes for long conversations, which used to blow Cloud Run's
+600s edge timeout when run inline in /urls (issue #4586). The job model
+moves the work off the request thread; the app polls until terminal.
+
+Key format:
+  audio_share_job:{job_id}             -> the job dict
+  audio_share_active:{uid}:{conv_id}   -> job_id of the active (non-terminal) job, if any
+
+TTL: 1 hour (refreshed on each update). Active-job pointer shares the same TTL.
+"""
+
+import json
+import logging
+import time
+import uuid
+from typing import Optional
+
+from database.redis_db import r
+
+logger = logging.getLogger(__name__)
+
+JOB_KEY_PREFIX = 'audio_share_job:'
+ACTIVE_KEY_PREFIX = 'audio_share_active:'
+JOB_TTL_SECONDS = 3600  # 1 hour
+# Audio merges can run 4-10+ minutes. Keep stale threshold well above the worst case
+# so genuine long merges aren't auto-failed by the safety net.
+STALE_THRESHOLD_SECONDS = 1500  # 25 minutes
+
+TERMINAL_STATUSES = ('completed', 'failed')
+
+
+def _job_key(job_id: str) -> str:
+    return f'{JOB_KEY_PREFIX}{job_id}'
+
+
+def _active_key(uid: str, conversation_id: str) -> str:
+    return f'{ACTIVE_KEY_PREFIX}{uid}:{conversation_id}'
+
+
+def get_active_job_id(uid: str, conversation_id: str) -> Optional[str]:
+    """Return the job_id of the active (non-terminal) job for this (uid, conv), if any."""
+    job_id = r.get(_active_key(uid, conversation_id))
+    if not job_id:
+        return None
+    if isinstance(job_id, bytes):
+        job_id = job_id.decode('utf-8')
+    return job_id
+
+
+def create_audio_share_job(
+    uid: str,
+    conversation_id: str,
+    audio_files: list,
+    job_id: Optional[str] = None,
+) -> dict:
+    """Create a new audio-share job and store in Redis. Returns the job dict.
+
+    `audio_files` is a list of {id, duration} dicts (one per audio file in the conv).
+    """
+    if job_id is None:
+        job_id = str(uuid.uuid4())
+    now = time.time()
+    job = {
+        'job_id': job_id,
+        'uid': uid,
+        'conversation_id': conversation_id,
+        'status': 'queued',
+        'progress_pct': 0.0,
+        'audio_files': [
+            {
+                'id': af.get('id'),
+                'status': 'pending',
+                'signed_url': None,
+                'duration': af.get('duration', 0),
+            }
+            for af in audio_files
+        ],
+        'error': None,
+        'created_at': now,
+        'started_at': None,
+        'updated_at': now,
+        'completed_at': None,
+    }
+    r.set(_job_key(job_id), json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
+    r.set(_active_key(uid, conversation_id), job_id, ex=JOB_TTL_SECONDS)
+    return job
+
+
+def get_audio_share_job(job_id: str) -> Optional[dict]:
+    """Get a job by ID. Returns None if not found or expired.
+
+    Applies a stale-job safety net: if a queued/processing job hasn't been touched
+    within STALE_THRESHOLD_SECONDS, mark it failed (worker likely died).
+    """
+    data = r.get(_job_key(job_id))
+    if not data:
+        return None
+    job = json.loads(data)
+
+    if job['status'] not in TERMINAL_STATUSES:
+        updated_at = job.get('updated_at') or job.get('created_at', 0)
+        if time.time() - updated_at > STALE_THRESHOLD_SECONDS:
+            job['status'] = 'failed'
+            job['error'] = 'Job timed out (background worker likely died)'
+            job['completed_at'] = time.time()
+            r.set(_job_key(job_id), json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
+            _clear_active_pointer(job['uid'], job['conversation_id'], job_id)
+
+    return job
+
+
+def update_audio_share_job(job_id: str, updates: dict) -> Optional[dict]:
+    """Update a job. Returns updated job or None if not found."""
+    data = r.get(_job_key(job_id))
+    if not data:
+        return None
+    job = json.loads(data)
+    job.update(updates)
+    job['updated_at'] = time.time()
+    r.set(_job_key(job_id), json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
+    # Refresh active pointer TTL so it doesn't expire mid-run on long merges
+    if job['status'] not in TERMINAL_STATUSES:
+        r.expire(_active_key(job['uid'], job['conversation_id']), JOB_TTL_SECONDS)
+    return job
+
+
+def mark_processing(job_id: str) -> Optional[dict]:
+    return update_audio_share_job(
+        job_id,
+        {'status': 'processing', 'started_at': time.time()},
+    )
+
+
+def update_audio_file_url(job_id: str, audio_file_id: str, signed_url: str, progress_pct: float) -> Optional[dict]:
+    """Mark one audio_file as ready with its signed URL. Updates progress_pct."""
+    data = r.get(_job_key(job_id))
+    if not data:
+        return None
+    job = json.loads(data)
+    for af in job.get('audio_files', []):
+        if af.get('id') == audio_file_id:
+            af['status'] = 'cached'
+            af['signed_url'] = signed_url
+            break
+    job['progress_pct'] = max(0.0, min(100.0, progress_pct))
+    job['updated_at'] = time.time()
+    r.set(_job_key(job_id), json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
+    r.expire(_active_key(job['uid'], job['conversation_id']), JOB_TTL_SECONDS)
+    return job
+
+
+def mark_completed(job_id: str) -> Optional[dict]:
+    """Transition to terminal completed state and clear the active pointer."""
+    job = update_audio_share_job(
+        job_id,
+        {'status': 'completed', 'progress_pct': 100.0, 'completed_at': time.time()},
+    )
+    if job:
+        _clear_active_pointer(job['uid'], job['conversation_id'], job_id)
+    return job
+
+
+def mark_failed(job_id: str, error: str) -> Optional[dict]:
+    job = update_audio_share_job(
+        job_id,
+        {'status': 'failed', 'error': error, 'completed_at': time.time()},
+    )
+    if job:
+        _clear_active_pointer(job['uid'], job['conversation_id'], job_id)
+    return job
+
+
+def _clear_active_pointer(uid: str, conversation_id: str, expected_job_id: str) -> None:
+    """Clear active-job pointer, but only if it still points at this job_id.
+
+    Avoids races where a new job started before we clean up an older completed one.
+    """
+    try:
+        current = r.get(_active_key(uid, conversation_id))
+        if isinstance(current, bytes):
+            current = current.decode('utf-8')
+        if current == expected_job_id:
+            r.delete(_active_key(uid, conversation_id))
+    except Exception as e:
+        logger.warning(f'audio_share_jobs: failed to clear active pointer for {uid}/{conversation_id}: {e}')

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -33,6 +33,15 @@ from database.sync_jobs import (
     mark_job_completed,
     mark_job_failed,
 )
+from database.audio_share_jobs import (
+    create_audio_share_job,
+    get_audio_share_job,
+    get_active_job_id as get_active_audio_share_job_id,
+    mark_processing as mark_audio_share_processing,
+    update_audio_file_url,
+    mark_completed as mark_audio_share_completed,
+    mark_failed as mark_audio_share_failed,
+)
 from models.conversation import Conversation, CreateConversation
 from models.conversation_enums import ConversationSource
 from utils.conversations.factory import deserialize_conversation
@@ -301,6 +310,213 @@ def get_audio_signed_urls_endpoint(
         critical_executor.submit(_cache_uncached_parallel)
 
     return {"audio_files": result}
+
+
+# **********************************************
+# ******** AUDIO SHARE (ASYNC JOB) *************
+# **********************************************
+# v1 GET /v1/sync/audio/{conv}/urls runs the chunk-merge inline. For long
+# conversations the merge takes 4-10+ minutes; Cloud Run kills the request
+# at 600s and the share UI ends up stuck or shows "Failed to download audio"
+# (issue #4586). The endpoints below replace that with a job-model: POST
+# returns immediately with a job_id, the merge runs in the background, and
+# the app polls GET /share/{job_id} until terminal.
+#
+# Modeled on the existing v2 sync-local-files pattern (Redis job state,
+# loop.run_in_executor with default executor to avoid nested-pool deadlock,
+# heartbeat updates so the staleness safety-net doesn't kill long merges).
+# **********************************************
+
+
+def _share_audio_background(job_id: str, uid: str, conversation_id: str, audio_files: list):
+    """Background worker for /share. Merges each audio_file synchronously, persists the
+    cache blob, generates a signed URL, and updates the job per file as a heartbeat."""
+    try:
+        mark_audio_share_processing(job_id)
+
+        total = len(audio_files)
+        if total == 0:
+            mark_audio_share_completed(job_id)
+            return
+
+        completed = 0
+        last_error: Optional[str] = None
+
+        for af in audio_files:
+            audio_file_id = af.get('id')
+            timestamps = af.get('chunk_timestamps')
+            if not audio_file_id or not timestamps:
+                logger.warning(f'audio_share: skipping audio_file with missing id or timestamps in job {job_id}')
+                completed += 1
+                continue
+
+            try:
+                # await_upload=True closes the race that broke /urls: cache blob is
+                # guaranteed to exist by the time get_merged_audio_signed_url runs.
+                get_or_create_merged_audio(
+                    uid=uid,
+                    conversation_id=conversation_id,
+                    audio_file_id=audio_file_id,
+                    timestamps=timestamps,
+                    pcm_to_wav_func=pcm_to_wav,
+                    fill_gaps=True,
+                    sample_rate=AUDIO_SAMPLE_RATE,
+                    await_upload=True,
+                )
+                signed_url = get_merged_audio_signed_url(uid, conversation_id, audio_file_id)
+                if not signed_url:
+                    raise RuntimeError(f'cache upload reported success but blob missing for {audio_file_id}')
+                completed += 1
+                progress_pct = (completed / total) * 100.0
+                update_audio_file_url(job_id, audio_file_id, signed_url, progress_pct)
+            except Exception as e:
+                last_error = str(e)
+                logger.error(f'audio_share: error merging audio_file {audio_file_id} in job {job_id}: {e}')
+
+        # Finalize: completed if every file got a signed URL, failed otherwise.
+        # Use the freshest job state to avoid clobbering a per-file update.
+        final_job = get_audio_share_job(job_id)
+        if not final_job:
+            return
+        ready = sum(1 for af in final_job.get('audio_files', []) if af.get('signed_url'))
+        if ready == total:
+            mark_audio_share_completed(job_id)
+        else:
+            mark_audio_share_failed(job_id, last_error or f'Only {ready}/{total} audio files merged successfully')
+    except Exception as e:
+        logger.error(f'audio_share: background worker crashed for job {job_id}: {e}')
+        try:
+            mark_audio_share_failed(job_id, str(e))
+        except Exception:
+            pass
+
+
+@router.post("/v1/sync/audio/{conversation_id}/share", tags=['v1'])
+async def request_audio_share_endpoint(
+    conversation_id: str,
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """Kick off (or rejoin) an async audio-share merge job for a conversation.
+
+    Returns 202 with `{job_id, status, poll_after_ms}`. The app should poll
+    GET /v1/sync/audio/{conversation_id}/share/{job_id} until status is terminal
+    (`completed` or `failed`).
+
+    Idempotent: if there's already an active job for this (uid, conversation), its
+    job_id is returned. If every audio file is already cached, a synthetic
+    `completed` job is returned with the signed URLs inline.
+    """
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if conversation.get('is_locked', False):
+        raise HTTPException(status_code=402, detail="A paid plan is required to access this conversation.")
+
+    audio_files = conversation.get('audio_files', [])
+    if not audio_files:
+        raise HTTPException(status_code=404, detail="No audio files in conversation")
+
+    # Fast path: if every file is already cached and unexpired, return URLs synchronously.
+    cached_urls = []
+    all_cached = True
+    for af in audio_files:
+        audio_file_id = af.get('id')
+        if not audio_file_id:
+            all_cached = False
+            break
+        signed_url = get_merged_audio_signed_url(uid, conversation_id, audio_file_id)
+        if not signed_url:
+            all_cached = False
+            break
+        cached_urls.append(
+            {
+                'id': audio_file_id,
+                'status': 'cached',
+                'signed_url': signed_url,
+                'duration': af.get('duration', 0),
+            }
+        )
+
+    if all_cached and cached_urls:
+        return JSONResponse(
+            status_code=200,
+            content={
+                'job_id': None,
+                'status': 'completed',
+                'progress_pct': 100.0,
+                'audio_files': cached_urls,
+                'poll_after_ms': 0,
+            },
+        )
+
+    # Idempotency: rejoin an in-flight job for this (uid, conv) instead of starting a new one.
+    existing_job_id = get_active_audio_share_job_id(uid, conversation_id)
+    if existing_job_id:
+        existing = get_audio_share_job(existing_job_id)
+        # `existing` may be None if it just expired between the active-pointer lookup
+        # and the job-key lookup, or if get_audio_share_job auto-failed it. In either
+        # case fall through to start a new one.
+        if existing and existing.get('status') not in ('completed', 'failed'):
+            return JSONResponse(
+                status_code=202,
+                content={
+                    'job_id': existing['job_id'],
+                    'status': existing['status'],
+                    'progress_pct': existing.get('progress_pct', 0.0),
+                    'audio_files': existing.get('audio_files', []),
+                    'poll_after_ms': 3000,
+                },
+            )
+
+    job = create_audio_share_job(uid, conversation_id, audio_files)
+    job_id = job['job_id']
+
+    # Run on the default executor (NOT critical_executor / storage_executor): the worker
+    # itself dispatches chunk downloads back to storage_executor, so nesting both in the
+    # same pool risks deadlock under concurrent load — same constraint sync_v2 documents.
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _share_audio_background, job_id, uid, conversation_id, audio_files)
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            'job_id': job_id,
+            'status': 'queued',
+            'progress_pct': 0.0,
+            'audio_files': job['audio_files'],
+            'poll_after_ms': 3000,
+        },
+    )
+
+
+@router.get("/v1/sync/audio/{conversation_id}/share/{job_id}", tags=['v1'])
+def get_audio_share_status_endpoint(
+    conversation_id: str,
+    job_id: str,
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """Poll the status of an audio-share job started via POST /share.
+
+    Returns `{job_id, status, progress_pct, audio_files, error?, poll_after_ms}`.
+    Status is one of: queued, processing, completed, failed.
+    """
+    job = get_audio_share_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Audio share job not found or expired")
+    if job.get('uid') != uid:
+        raise HTTPException(status_code=403, detail="Not authorized to view this job")
+    if job.get('conversation_id') != conversation_id:
+        raise HTTPException(status_code=400, detail="Job does not belong to this conversation")
+
+    poll_after_ms = 0 if job['status'] in ('completed', 'failed') else 3000
+    return {
+        'job_id': job['job_id'],
+        'status': job['status'],
+        'progress_pct': job.get('progress_pct', 0.0),
+        'audio_files': job.get('audio_files', []),
+        'error': job.get('error'),
+        'poll_after_ms': poll_after_ms,
+    }
 
 
 # **********************************************

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -87,6 +87,8 @@ pytest tests/unit/test_memories_create.py -v
 pytest tests/unit/test_sync_v2.py -v
 pytest tests/unit/test_sync_transcription_prefs.py -v
 pytest tests/unit/test_sync_record_usage.py -v
+pytest tests/unit/test_audio_share_jobs.py -v
+pytest tests/unit/test_audio_share_endpoints.py -v
 pytest tests/unit/test_vision_stream_async.py -v
 pytest tests/unit/test_desktop_transcribe.py -v
 pytest tests/unit/test_desktop_migration.py -v

--- a/backend/tests/unit/test_audio_share_endpoints.py
+++ b/backend/tests/unit/test_audio_share_endpoints.py
@@ -1,0 +1,128 @@
+"""
+Structural tests for the async audio-share endpoints (#4586).
+
+Verifies the new POST/GET /v1/sync/audio/{conv}/share endpoints exist with
+the right shape: 202 on POST kickoff, idempotent rejoin via the active-job
+pointer, default executor for the background worker (avoids the nested-pool
+deadlock the v2 sync-local-files comments warn about), and await_upload=True
+so the merge completes before the signed URL is generated.
+"""
+
+import os
+import unittest
+
+
+class TestAudioShareEndpointStructure(unittest.TestCase):
+    @staticmethod
+    def _read_sync_source():
+        sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
+        with open(sync_path) as f:
+            return f.read()
+
+    @staticmethod
+    def _read_storage_source():
+        storage_path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'other', 'storage.py')
+        with open(storage_path) as f:
+            return f.read()
+
+    def test_post_share_endpoint_exists(self):
+        source = self._read_sync_source()
+        self.assertIn('"/v1/sync/audio/{conversation_id}/share"', source)
+        self.assertIn('async def request_audio_share_endpoint', source)
+
+    def test_get_share_status_endpoint_exists(self):
+        source = self._read_sync_source()
+        self.assertIn('"/v1/sync/audio/{conversation_id}/share/{job_id}"', source)
+        self.assertIn('def get_audio_share_status_endpoint', source)
+
+    def test_post_returns_202_with_job_id(self):
+        source = self._read_sync_source()
+        start = source.index('async def request_audio_share_endpoint')
+        nxt = source.find('\n@router.', start + 1)
+        body = source[start : nxt if nxt != -1 else len(source)]
+        # 202 for the queued case, 200 for the cache-hit shortcut
+        self.assertIn('status_code=202', body)
+        self.assertIn('status_code=200', body)
+        self.assertIn("'job_id'", body)
+        self.assertIn("'poll_after_ms'", body)
+
+    def test_post_uses_default_executor(self):
+        """Worker must run on the default executor — the worker itself dispatches
+        chunk downloads to storage_executor, and nesting both in the same pool
+        risks deadlock (same constraint sync_v2 documents)."""
+        source = self._read_sync_source()
+        start = source.index('async def request_audio_share_endpoint')
+        nxt = source.find('\n@router.', start + 1)
+        body = source[start : nxt if nxt != -1 else len(source)]
+        self.assertIn('run_in_executor(None,', body)
+        self.assertIn('_share_audio_background', body)
+
+    def test_post_is_idempotent(self):
+        """POST must rejoin an in-flight job via the active-job pointer."""
+        source = self._read_sync_source()
+        start = source.index('async def request_audio_share_endpoint')
+        nxt = source.find('\n@router.', start + 1)
+        body = source[start : nxt if nxt != -1 else len(source)]
+        self.assertIn('get_active_audio_share_job_id', body)
+        self.assertIn('rejoin', body.lower())
+
+    def test_post_fastpath_when_all_cached(self):
+        """If every audio file has a valid cached signed URL, POST must short-
+        circuit and return signed URLs immediately without creating a job."""
+        source = self._read_sync_source()
+        start = source.index('async def request_audio_share_endpoint')
+        nxt = source.find('\n@router.', start + 1)
+        body = source[start : nxt if nxt != -1 else len(source)]
+        self.assertIn('all_cached', body)
+        self.assertIn('get_merged_audio_signed_url', body)
+
+    def test_get_status_validates_uid_and_conversation(self):
+        """The poll endpoint must reject jobs that don't belong to the caller
+        or to the conversation in the URL."""
+        source = self._read_sync_source()
+        start = source.index('def get_audio_share_status_endpoint')
+        nxt = source.find('\n@router.', start + 1)
+        body = source[start : nxt if nxt != -1 else len(source)]
+        self.assertIn('status_code=403', body)
+        self.assertIn('status_code=400', body)
+        self.assertIn('status_code=404', body)
+
+    def test_background_worker_uses_await_upload(self):
+        """The race that broke /urls (#4586) — checking the cache before the
+        fire-and-forget upload finishes — is closed by passing await_upload=True."""
+        source = self._read_sync_source()
+        start = source.index('def _share_audio_background')
+        # Scan until next top-level def or @router
+        nxt = min(
+            (
+                pos
+                for pos in (
+                    source.find('\n@router.', start + 1),
+                    source.find('\nasync def ', start + 1),
+                    source.find('\ndef ', start + 1),
+                )
+                if pos != -1
+            ),
+            default=len(source),
+        )
+        body = source[start:nxt]
+        self.assertIn('await_upload=True', body)
+        self.assertIn('mark_audio_share_processing', body)
+        self.assertIn('update_audio_file_url', body)
+
+    def test_storage_get_or_create_supports_await_upload(self):
+        """storage.get_or_create_merged_audio must accept await_upload and
+        call future.result() so the upload completes before returning."""
+        source = self._read_storage_source()
+        self.assertIn('await_upload: bool = False', source)
+        # Inside the function: when await_upload is True, the upload future is
+        # waited on. Look for the .result() pattern near a storage_executor.submit.
+        start = source.index('def get_or_create_merged_audio')
+        nxt = source.find('\ndef ', start + 1)
+        body = source[start : nxt if nxt != -1 else len(source)]
+        self.assertIn('if await_upload', body)
+        self.assertIn('future.result()', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/test_audio_share_jobs.py
+++ b/backend/tests/unit/test_audio_share_jobs.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for the Redis-backed audio_share_jobs module (#4586).
+
+Mirrors the test_sync_v2 isolation pattern: the module is loaded via
+importlib.util with database.redis_db stubbed out, so we don't pull a real
+Redis client into the test process.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+import unittest
+from unittest.mock import MagicMock
+
+
+def _load_audio_share_jobs_module():
+    """Load database/audio_share_jobs.py with database.redis_db.r faked.
+
+    Mirrors test_sync_v2.TestSyncJobsRedis._load_sync_jobs_module: stub
+    `database.redis_db` (and the `database` package itself, since pytest may
+    have already imported it for sibling tests) before exec_module.
+    """
+    fake_r = _FakeRedis()
+    saved_modules = {}
+    modules_to_stub = {
+        'database': MagicMock(),
+        'database.redis_db': MagicMock(r=fake_r),
+    }
+    for mod, mock in modules_to_stub.items():
+        saved_modules[mod] = sys.modules.get(mod)
+        sys.modules[mod] = mock
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            'audio_share_jobs',
+            os.path.join(os.path.dirname(__file__), '..', '..', 'database', 'audio_share_jobs.py'),
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module, fake_r
+    finally:
+        for mod, original in saved_modules.items():
+            if original is None:
+                sys.modules.pop(mod, None)
+            else:
+                sys.modules[mod] = original
+
+
+class _FakeRedis:
+    """Minimal Redis stand-in: get/set/delete/expire with TTL bookkeeping."""
+
+    def __init__(self):
+        self._store: dict = {}
+        self._ttl: dict = {}
+
+    def _gc(self, key):
+        ttl = self._ttl.get(key)
+        if ttl is not None and time.time() > ttl:
+            self._store.pop(key, None)
+            self._ttl.pop(key, None)
+
+    def get(self, key):
+        self._gc(key)
+        return self._store.get(key)
+
+    def set(self, key, value, ex=None):
+        if isinstance(value, str):
+            value = value.encode('utf-8')
+        self._store[key] = value
+        if ex is not None:
+            self._ttl[key] = time.time() + ex
+        return True
+
+    def delete(self, key):
+        self._store.pop(key, None)
+        self._ttl.pop(key, None)
+        return 1
+
+    def expire(self, key, seconds):
+        if key in self._store:
+            self._ttl[key] = time.time() + seconds
+            return 1
+        return 0
+
+
+class TestAudioShareJobsLifecycle(unittest.TestCase):
+    def setUp(self):
+        self.mod, self.r = _load_audio_share_jobs_module()
+
+    def test_create_persists_job_and_active_pointer(self):
+        job = self.mod.create_audio_share_job(
+            uid='u1',
+            conversation_id='c1',
+            audio_files=[{'id': 'a1', 'duration': 10.0}, {'id': 'a2', 'duration': 5.0}],
+        )
+
+        self.assertEqual(job['uid'], 'u1')
+        self.assertEqual(job['conversation_id'], 'c1')
+        self.assertEqual(job['status'], 'queued')
+        self.assertEqual(job['progress_pct'], 0.0)
+        self.assertEqual(len(job['audio_files']), 2)
+        self.assertTrue(all(af['status'] == 'pending' for af in job['audio_files']))
+
+        # Both keys present
+        self.assertIsNotNone(self.r.get(f'audio_share_job:{job["job_id"]}'))
+        self.assertEqual(self.mod.get_active_job_id('u1', 'c1'), job['job_id'])
+
+    def test_get_returns_none_for_missing(self):
+        self.assertIsNone(self.mod.get_audio_share_job('does-not-exist'))
+
+    def test_mark_processing_sets_started_at(self):
+        job = self.mod.create_audio_share_job('u1', 'c1', [{'id': 'a1'}])
+        before = time.time()
+        updated = self.mod.mark_processing(job['job_id'])
+        self.assertEqual(updated['status'], 'processing')
+        self.assertGreaterEqual(updated['started_at'], before)
+
+    def test_update_audio_file_url_advances_progress(self):
+        job = self.mod.create_audio_share_job('u1', 'c1', [{'id': 'a1'}, {'id': 'a2'}, {'id': 'a3'}])
+        self.mod.mark_processing(job['job_id'])
+
+        updated = self.mod.update_audio_file_url(job['job_id'], 'a1', 'https://example/a1', 33.3)
+        self.assertEqual(updated['progress_pct'], 33.3)
+        target = next(af for af in updated['audio_files'] if af['id'] == 'a1')
+        self.assertEqual(target['status'], 'cached')
+        self.assertEqual(target['signed_url'], 'https://example/a1')
+
+        # Other files untouched
+        for other_id in ('a2', 'a3'):
+            af = next(af for af in updated['audio_files'] if af['id'] == other_id)
+            self.assertEqual(af['status'], 'pending')
+            self.assertIsNone(af['signed_url'])
+
+    def test_mark_completed_clears_active_pointer(self):
+        job = self.mod.create_audio_share_job('u1', 'c1', [{'id': 'a1'}])
+        self.assertIsNotNone(self.mod.get_active_job_id('u1', 'c1'))
+
+        self.mod.mark_completed(job['job_id'])
+
+        # Active pointer is gone; job itself stays around for polling.
+        self.assertIsNone(self.mod.get_active_job_id('u1', 'c1'))
+        final = self.mod.get_audio_share_job(job['job_id'])
+        self.assertEqual(final['status'], 'completed')
+        self.assertEqual(final['progress_pct'], 100.0)
+
+    def test_mark_failed_records_error_and_clears_pointer(self):
+        job = self.mod.create_audio_share_job('u1', 'c1', [{'id': 'a1'}])
+        self.mod.mark_failed(job['job_id'], 'merge blew up')
+
+        self.assertIsNone(self.mod.get_active_job_id('u1', 'c1'))
+        final = self.mod.get_audio_share_job(job['job_id'])
+        self.assertEqual(final['status'], 'failed')
+        self.assertEqual(final['error'], 'merge blew up')
+
+    def test_idempotency_pointer_only_cleared_when_owner(self):
+        """The active pointer must only be cleared if it still points at the
+        job we're finishing — protects against a new job that started while
+        we were finalizing."""
+        job_a = self.mod.create_audio_share_job('u1', 'c1', [{'id': 'a1'}])
+        # Simulate a second job that took the active slot
+        job_b_id = 'job-b'
+        self.r.set('audio_share_active:u1:c1', job_b_id, ex=3600)
+        # Finishing job_a must NOT clear job_b's pointer
+        self.mod.mark_completed(job_a['job_id'])
+        self.assertEqual(self.mod.get_active_job_id('u1', 'c1'), job_b_id)
+
+    def test_stale_safety_net_marks_failed(self):
+        """A job that hasn't been touched within STALE_THRESHOLD_SECONDS must
+        be auto-failed by get(). The threshold is generous (25 min) so genuine
+        long merges aren't killed."""
+        job = self.mod.create_audio_share_job('u1', 'c1', [{'id': 'a1'}])
+        key = f'audio_share_job:{job["job_id"]}'
+        stored = json.loads(self.r.get(key))
+        stored['updated_at'] = time.time() - self.mod.STALE_THRESHOLD_SECONDS - 60
+        self.r.set(key, json.dumps(stored), ex=3600)
+
+        result = self.mod.get_audio_share_job(job['job_id'])
+        self.assertEqual(result['status'], 'failed')
+        self.assertIn('timed out', result['error'].lower())
+        self.assertIsNone(self.mod.get_active_job_id('u1', 'c1'))
+
+    def test_active_pointer_ttl_refreshed_on_progress(self):
+        """Updating a non-terminal job must refresh the active-pointer TTL so
+        long merges don't lose their idempotency anchor mid-run."""
+        job = self.mod.create_audio_share_job('u1', 'c1', [{'id': 'a1'}])
+        # Force the active-pointer TTL to nearly expire
+        self.r._ttl['audio_share_active:u1:c1'] = time.time() + 1
+        self.mod.update_audio_file_url(job['job_id'], 'a1', 'https://example/a1', 50.0)
+        self.assertGreater(self.r._ttl['audio_share_active:u1:c1'], time.time() + 100)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -838,6 +838,7 @@ def get_or_create_merged_audio(
     pcm_to_wav_func,
     fill_gaps: bool = True,
     sample_rate: int = 16000,
+    await_upload: bool = False,
 ) -> tuple[bytes, bool]:
     """
     Get merged audio from cache or create it.
@@ -851,6 +852,11 @@ def get_or_create_merged_audio(
         pcm_to_wav_func: Function to convert PCM to WAV
         fill_gaps: If True, insert silence between chunks to maintain time alignment. Default True.
         sample_rate: Audio sample rate in Hz (default 16000)
+        await_upload: If True, the cache upload runs synchronously and the function only
+            returns once the blob exists in GCS. Used by the audio-share flow so a caller
+            calling get_merged_audio_signed_url() immediately after won't race the
+            background upload. Default False preserves the original fire-and-forget
+            behavior used by precache.
 
     Returns:
         Tuple of (audio_data_bytes, was_cached)
@@ -890,20 +896,29 @@ def get_or_create_merged_audio(
     wav_data = pcm_to_wav_func(pcm_data)
     del pcm_data  # Free PCM data immediately after WAV conversion
 
-    # Upload to cache in background thread with 3-day TTL
+    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=3)
+    cache_metadata = {
+        'expires_at': expires_at.isoformat(),
+        'audio_file_id': audio_file_id,
+    }
+
     def _upload_to_cache():
         try:
-            expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=3)
-            cache_blob.metadata = {
-                'expires_at': expires_at.isoformat(),
-                'audio_file_id': audio_file_id,
-            }
+            cache_blob.metadata = cache_metadata
             cache_blob.upload_from_string(wav_data, content_type='audio/wav')
             logger.info(f"Cached merged audio at: {cache_path}")
         except Exception as e:
             logger.error(f"Error uploading audio cache: {e}")
+            raise
 
-    storage_executor.submit(_upload_to_cache)
+    if await_upload:
+        # Caller (e.g. share flow) needs the blob to exist before it generates a signed URL.
+        # Run the upload on storage_executor and block on the result so we don't tie up the
+        # current thread's GCS connection pool.
+        future = storage_executor.submit(_upload_to_cache)
+        future.result()
+    else:
+        storage_executor.submit(_upload_to_cache)
 
     return wav_data, False
 

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -842,7 +842,12 @@ def get_or_create_merged_audio(
 ) -> tuple[bytes, bool]:
     """
     Get merged audio from cache or create it.
-    Cached files are stored in GCS with 1-day TTL (via lifecycle policy).
+    Cached files are stored in GCS with a 30-day TTL via the bucket lifecycle
+    policy (prefix `merged/`). Issue #4586 — the previous 1-day lifecycle deleted
+    cached audio faster than the share flow could reuse it, causing every share
+    to re-merge from chunks (and time out on long convs). The application-level
+    expires_at metadata mirrors the bucket lifecycle so we don't serve stale
+    cache after the bucket cleans it up.
 
     Args:
         uid: User ID
@@ -896,7 +901,8 @@ def get_or_create_merged_audio(
     wav_data = pcm_to_wav_func(pcm_data)
     del pcm_data  # Free PCM data immediately after WAV conversion
 
-    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=3)
+    # 30-day expiry to match the bucket lifecycle policy (see docstring + issue #4586).
+    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30)
     cache_metadata = {
         'expires_at': expires_at.isoformat(),
         'audio_file_id': audio_file_id,


### PR DESCRIPTION
## Why

\`GET /v1/sync/audio/{conv}/urls\` runs the chunk-merge inline. For long conversations the merge takes 4–10+ minutes; Cloud Run kills the request at 600 s, so 31% of \`/urls\` calls 504 today and ~5,000 5xx in the last 14 days. The Share Audio button hangs or shows "Failed to download audio" (issue #4586).

A second, related defect: \`storage.get_or_create_merged_audio\` fires the cache upload via \`storage_executor.submit(...)\` and returns immediately, so \`get_merged_audio_signed_url\` ran by the same caller checks \`cache_blob.exists()\` before the upload completes — every first attempt returns \`pending\`, the second attempt works. (Manager confirmed this manual repro: "No cached audio files available" first, works second.)

A third, downstream defect: bucket lifecycle on \`merged/\` was 1 day, deleting cached audio faster than the share flow could reuse it. Every share re-merged from chunks.

## What changed

Mirrors the existing v2-async-sync-local-files pattern (PR #5941 / #6157) — same problem class, same Redis job-state shape, same \`run_in_executor(None, ...)\` discipline.

**Backend**

- \`database/audio_share_jobs.py\` — new Redis-backed job model with an active-job pointer for idempotent rejoin. 25-min stale threshold (audio merges run long; v2-sync's 10-min threshold would falsely fail them).
- \`utils/other/storage.py\` — \`get_or_create_merged_audio\` accepts \`await_upload: bool = False\`. When True, the upload runs synchronously so the caller's signed-URL lookup can't race ahead. Default behavior preserved for \`precache\`. Cache TTL bumped 3d → 30d to match the new bucket lifecycle plan.
- \`routers/sync.py\`:
  - \`POST /v1/sync/audio/{conv}/share\` — 202 + \`{job_id, status, poll_after_ms}\`. Idempotent rejoin via the active-job pointer. Fast-path: returns 200 with signed URLs immediately when every file is already cached.
  - \`GET /v1/sync/audio/{conv}/share/{job_id}\` — \`{status, progress_pct, audio_files, error?, poll_after_ms}\`. Validates uid + conv on every poll.
  - \`_share_audio_background\` worker dispatched on the **default executor**, not \`critical_executor\`/\`storage_executor\` — same nested-pool deadlock constraint that v2 sync-local-files documents.

**Flutter**

- \`backend/http/api/audio.dart\` — new \`AudioShareJob\` schema + \`requestAudioShare\` / \`getAudioShareJob\` clients. Existing \`AudioFileUrlInfo\` and \`getConversationAudioSignedUrls\` left intact (no other consumers migrated yet).
- \`services/audio_download_service.dart\` — POST→poll→download. Server-driven \`progress_pct\` is wired into \`onProgress\` during the preparing stage so the share modal stops sitting at an indeterminate spinner. Poll cadence clamped to [1s, 10s]; 26-min wallclock ceiling matches backend's 25-min stale-job detector + 1 min slack.
- \`pages/conversation_detail/page.dart\` unchanged — the existing \`onProgress\`/\`onStageChange\` callbacks now receive real merge progress + a useful error message on failure.

**Tests**

- \`tests/unit/test_audio_share_jobs.py\` — 9 cases: lifecycle (create/processing/per-file URL/completed/failed), active-pointer ownership (don't clear someone else's pointer), 25-min stale safety net, TTL refresh on progress.
- \`tests/unit/test_audio_share_endpoints.py\` — 9 structural cases pinning the bulkhead invariants (202+job_id, idempotent rejoin, default-executor dispatch, await_upload=True in worker, uid/conv validation in poll).
- Registered in \`backend/test.sh\` so CI runs them.

## Deploy notes (must apply alongside merge)

GCS bucket lifecycle on the \`omi-private-cloud-sync\` bucket needs the \`merged/\` prefix delete-after-30-days, not 1 day. Code-side metadata is updated to match in this PR; bucket-side has to be applied via gcloud:

\`\`\`bash
gcloud storage buckets update gs://omi-private-cloud-sync --lifecycle-file=lifecycle.json
\`\`\`

…with the \`merged/\` rule set to \`age = 30\`. Do this **before or with** the merge so caches stay around long enough for users to retry.

## Test plan

- [ ] \`bash backend/test.sh\` — confirm both new test files pass alongside the existing suite.
- [ ] Manual: never-cached conversation → tap Share Audio → modal shows real merge progress (not indeterminate spinner) → download starts → file shares successfully. Should also work on the conversation manager manually reproduced ("No cached audio files available" first attempt).
- [ ] Manual: tap Share Audio twice in quick succession on the same conv → second tap rejoins the same job (idempotency); no double work.
- [ ] Manual: tap Share Audio on a long (10+ min) conversation → no 600 s 504; merge completes; file shares.
- [ ] Manual: tap Share Audio on a fully-cached conversation → 200 immediate (fast-path), no \`processing\` state observed.
- [ ] Verify Cloud Run logs: \`/v1/sync/audio/.../share\` POSTs are sub-second; merge work shows up in the \`backend-sync\` worker stderr, not as request-handler latency.

## Linked issues / PRs

- Closes #4586 (Can't share audio)
- Pattern reference: #5941 / #6157 (v2 async sync-local-files — same 504-on-long-sync class of bug)
- Umbrella: #3215 (Private Cloud Sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)