### PR TITLE
feat - refactor nand flash as ring buffer

### DIFF
--- a/omi/firmware/omi/src/lib/core/sd_card.h
+++ b/omi/firmware/omi/src/lib/core/sd_card.h
@@ -6,291 +6,53 @@
 #include <sys/types.h>
 #include <zephyr/kernel.h>
 
-#define MAX_STORAGE_BYTES 0x1E000000 // 480MB
-#define MAX_WRITE_SIZE 440
+#define MAX_STORAGE_BYTES 0x1E000000U
+#define MAX_WRITE_SIZE 440U
+#define RAW_AUDIO_TIMESTAMP_BYTES 4U
+#define RAW_AUDIO_PACKET_BYTES (RAW_AUDIO_TIMESTAMP_BYTES + MAX_WRITE_SIZE)
 #define MAX_FILENAME_LEN 64
 #define MAX_AUDIO_FILES 100
-#define FILE_ROTATION_INTERVAL_MS (30 * 60 * 1000) // 30 minutes in milliseconds
 
-/* Request types for the SD worker */
-typedef enum {
-    REQ_CLEAR_AUDIO_DIR,
-    REQ_WRITE_DATA,
-    REQ_READ_DATA,
-    REQ_SAVE_OFFSET,
-    REQ_CREATE_NEW_FILE,
-    REQ_GET_FILE_STATS,
-    REQ_GET_FILE_LIST,
-    REQ_DELETE_FILE,
-    REQ_FLUSH_FILE,
-    REQ_TIME_SYNCED,
-    REQ_UNMOUNT,
-} sd_req_type_t;
-
-/* Read request response object */
-struct read_resp {
-    struct k_sem sem;
-    int res;
-    ssize_t read_bytes;
-};
-
-/* File statistics response */
-struct file_stats_resp {
-    struct k_sem sem;
-    int res;
-    uint32_t file_count;
-    uint64_t total_size;
-};
-
-/* File list response */
-struct file_list_resp {
-    struct k_sem sem;
-    int res;
-    int count;
-};
-
-/* Offset info structure stored in info.txt */
 typedef struct {
-    char oldest_filename[MAX_FILENAME_LEN]; // Oldest file being read
-    uint32_t offset_in_file;                // Offset within that file
-} sd_offset_info_t;
+    uint64_t read_seq;
+    uint64_t write_seq;
+    uint64_t dropped_packets;
+    uint32_t capacity_packets;
+} sd_ring_info_t;
 
-/* Generic request message passed to worker */
-typedef struct {
-    sd_req_type_t type;
-    union {
-        struct {
-            uint8_t buf[MAX_WRITE_SIZE];
-            size_t len;
-            struct read_resp *resp;
-        } write;
-        struct {
-            char filename[MAX_FILENAME_LEN]; // Specific file to read from
-            uint32_t offset;
-            uint32_t length;
-            uint8_t *out_buf;
-            struct read_resp *resp;
-        } read;
-        struct {
-            sd_offset_info_t offset_info;
-        } info;
-        struct {
-            struct read_resp *resp;
-        } clear_dir;
-        struct {
-            struct read_resp *resp;
-        } create_file;
-        struct {
-            struct file_stats_resp *resp;
-        } file_stats;
-        struct {
-            char (*filenames)[MAX_FILENAME_LEN];
-            uint32_t *sizes;
-            int max_files;
-            struct file_list_resp *resp;
-        } file_list;
-        struct {
-            char filename[MAX_FILENAME_LEN];
-            struct read_resp *resp;
-        } delete_file;
-        struct {
-            uint32_t utc_time;
-        } time_synced;
-    } u;
-} sd_req_t;
-
-/**
- * @brief Initialize the SD card module interface.
- *
- * @return 0 on success, negative error code otherwise.
- */
 int app_sd_init(void);
-
-/**
- * @brief Put the SD card interface (controller) into a low-power (suspend) state.
- *        Note: This typically suspends the SPI controller managing the SD card slot.
- *
- * @return 0 on success, negative error code on failure to suspend.
- */
 int app_sd_off(void);
-
-/**
- * @brief Pause or resume SD card writes (keeps SD powered and mounted).
- *        Used by AAD to stop writing during VAD silence without
- *        unmounting the filesystem.
- */
 void sd_write_pause(bool pause);
+bool is_sd_on(void);
 
 #ifdef CONFIG_OMI_ENABLE_OFFLINE_STORAGE
 
-/**
- * @brief Write to the current audio file specified by the write pointer
- *
- * @param data Buffer containing data to write
- * @param length Number of bytes to write
- * @return number of bytes written
- */
 uint32_t write_to_file(uint8_t *data, uint32_t length);
 
-/**
- * @brief Read from a specific audio file
- *
- * @param filename Name of the file to read from (e.g., "1234567890.txt")
- * @param buf Buffer to read data into
- * @param amount Number of bytes to read
- * @param offset Offset within the file to read from
- * @return number of bytes read, or negative error code
- */
+int sd_ring_get_info(sd_ring_info_t *info);
+int sd_ring_read(uint64_t start_seq,
+                 uint8_t *buf,
+                 uint32_t max_bytes,
+                 uint32_t *bytes_read,
+                 uint32_t *packets_read);
+int sd_ring_advance(uint64_t new_read_seq);
+int sd_ring_clear(void);
+
+uint32_t get_file_size(void);
+int get_current_filename(char *buf, size_t buf_size);
+int clear_audio_directory(void);
+int save_offset(const char *filename, uint32_t offset);
+int get_offset(char *filename, uint32_t *offset);
+int create_new_audio_file(void);
+void sd_notify_ble_state(bool connected);
+int get_audio_file_stats(uint32_t *file_count, uint64_t *total_size);
+int get_audio_file_list(char filenames[][MAX_FILENAME_LEN], int max_files, int *count);
+int get_audio_file_list_with_sizes(char filenames[][MAX_FILENAME_LEN], uint32_t *sizes, int max_files, int *count);
+int delete_audio_file(const char *filename);
+int sd_flush_current_file(void);
+void sd_notify_time_synced(uint32_t utc_time);
 int read_audio_data(const char *filename, uint8_t *buf, int amount, int offset);
 
-/**
- * @brief Get the size of the current writing file
- * @return size of the file in bytes
- */
-uint32_t get_file_size(void);
+#endif
 
-/**
- * @brief Get the name of the current writing file
- * @param buf Buffer to store the filename
- * @param buf_size Size of the buffer
- * @return 0 on success, negative error code otherwise
- */
-int get_current_filename(char *buf, size_t buf_size);
-
-/**
- * @brief Clear the audio directory.
- *
- * This deletes all audio files in the audio directory.
- * @return 0 if successful, negative errno code if error
- */
-int clear_audio_directory(void);
-
-/**
- * @brief Save the current offset info to the info file
- *
- * @param filename The oldest file being read
- * @param offset Offset within that file
- * @return 0 if successful, negative errno code if error
- */
-int save_offset(const char *filename, uint32_t offset);
-
-/**
- * @brief Get the saved offset info from the info file
- *
- * @param filename Buffer to store the oldest filename (must be at least MAX_FILENAME_LEN)
- * @param offset Pointer to store the offset value
- * @return 0 on success, negative errno code if error
- */
-int get_offset(char *filename, uint32_t *offset);
-
-/**
- * @brief Create a new audio file with current timestamp
- *
- * This forces creation of a new file, useful when BLE connection
- * has been active for a long time.
- * @return 0 if successful, negative errno code if error
- */
-int create_new_audio_file(void);
-
-/**
- * @brief Notify that BLE connection state has changed
- *
- * Call this when BLE connects/disconnects to manage file rotation.
- * @param connected true if BLE is now connected, false if disconnected
- */
-void sd_notify_ble_state(bool connected);
-
-/**
- * @brief Get file statistics
- *
- * @param file_count Pointer to store the number of audio files
- * @param total_size Pointer to store the total size of all audio files
- * @return 0 on success, negative error code otherwise
- */
-int get_audio_file_stats(uint32_t *file_count, uint64_t *total_size);
-
-/**
- * @brief Get list of audio files sorted by timestamp (oldest first)
- *
- * @param filenames Array of filename buffers
- * @param max_files Maximum number of files to retrieve
- * @param count Pointer to store the actual number of files found
- * @return 0 on success, negative error code otherwise
- */
-int get_audio_file_list(char filenames[][MAX_FILENAME_LEN], int max_files, int *count);
-
-/**
- * @brief Get audio file list with per-file sizes (synchronous)
- *
- * @param filenames Array of filename buffers
- * @param sizes Array to store per-file sizes (may be NULL to skip)
- * @param max_files Maximum number of files to retrieve
- * @param count Pointer to store the actual number of files found
- * @return 0 on success, negative error code otherwise
- */
-int get_audio_file_list_with_sizes(char filenames[][MAX_FILENAME_LEN], uint32_t *sizes, int max_files, int *count);
-
-/**
- * @brief Delete a specific audio file by name.
- *
- * If the file is currently being recorded to, the SD worker will stop
- * using it (flushing and closing), mark it as deleted, and the next
- * BLE disconnect will trigger creation of a new file.
- *
- * @param filename Name of the audio file to delete.
- * @return 0 on success, negative error code otherwise
- */
-int delete_audio_file(const char *filename);
-
-/**
- * @brief Flush current audio file to SD card.
- *
- * Flushes the batch write buffer and syncs the file to ensure all
- * pending data is written to SD. Useful before sync operations to ensure
- * file sizes are accurate.
- *
- * @return 0 on success, negative error code otherwise
- */
-int sd_flush_current_file(void);
-
-/**
- * @brief Update current audio filename after receiving time sync from BLE
- *
- * When device boots without RTC time, it creates file with uptime-based name.
- * After receiving real timestamp from BLE, this function calculates the correct
- * timestamp and renames the file accordingly.
- *
- * @param synced_utc_time The UTC timestamp received from BLE time sync
- */
-void sd_update_filename_after_timesync(uint32_t synced_utc_time);
-
-/**
- * @brief Notify SD card module that time has been synced
- *
- * Renames any temporary audio files to use correct UTC timestamp.
- * Safe to call from any thread (uses message queue internally).
- *
- * @param utc_time The UTC timestamp that was just synced
- */
-void sd_notify_time_synced(uint32_t utc_time);
-
-/**
- * @brief Turn on SD card power
- */
-void sd_on(void);
-
-/**
- * @brief Turn off SD card power
- */
-void sd_off(void);
-
-/**
- * @brief Check if SD card is powered on
- *
- * @return true if SD card is on, false otherwise
- */
-bool is_sd_on(void);
-
-#endif // CONFIG_OMI_ENABLE_OFFLINE_STORAGE
-
-#endif // SD_CARD_H
+#endif

--- a/omi/firmware/omi/src/lib/core/storage.c
+++ b/omi/firmware/omi/src/lib/core/storage.c
@@ -42,9 +42,10 @@ LOG_MODULE_REGISTER(storage, CONFIG_LOG_DEFAULT_LEVEL);
 #define STORAGE_WRITE_NOTIFY_ATTR_IDX 2
 #define STORAGE_STATUS_REFRESH_MS 250
 
-#define STORAGE_CHUNK_COUNT 20
+#define STORAGE_CHUNK_COUNT 36U
 #define STORAGE_BUFFER_SIZE (RAW_AUDIO_PACKET_BYTES * STORAGE_CHUNK_COUNT)
 #define STORAGE_CONTROL_NOTIFY_SIZE 32
+#define STORAGE_NOTIFY_VALUE_MAX_LEN ((CONFIG_BT_L2CAP_TX_MTU > 3U) ? (CONFIG_BT_L2CAP_TX_MTU - 3U) : 20U)
 
 #define SYNC_SPEED_LOG_INTERVAL_MS (30 * 1000)
 
@@ -92,7 +93,7 @@ static struct bt_gatt_attr storage_service_attr[] = {
 struct bt_gatt_service storage_service = BT_GATT_SERVICE(storage_service_attr);
 
 static uint8_t storage_buffer[STORAGE_BUFFER_SIZE];
-static uint8_t data_notify_buf[1 + STORAGE_BUFFER_SIZE];
+static uint8_t data_notify_buf[STORAGE_NOTIFY_VALUE_MAX_LEN];
 static uint8_t control_notify_buf[STORAGE_CONTROL_NOTIFY_SIZE];
 
 bool storage_is_on = false;

--- a/omi/firmware/omi/src/lib/core/storage.c
+++ b/omi/firmware/omi/src/lib/core/storage.c
@@ -1,7 +1,6 @@
 #include "storage.h"
 
 #include <errno.h>
-#include <stdio.h>
 #include <string.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>
@@ -11,47 +10,44 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
 
+#include "rtc.h"
 #include "sd_card.h"
 #include "transport.h"
 #include "utils.h"
 
 LOG_MODULE_REGISTER(storage, CONFIG_LOG_DEFAULT_LEVEL);
 
-/* Current file being read for transfer */
-static char current_read_filename[MAX_FILENAME_LEN] = {0};
-static uint32_t current_read_offset = 0;
-
-#define MAX_PACKET_LENGTH 256
-#define OPUS_ENTRY_LENGTH 80
-#define FRAME_PREFIX_LENGTH 3
-
-/* Control commands */
 #define CMD_STOP_SYNC      0x03
+#define CMD_RING_INFO      0x10
+#define CMD_RING_READ      0x11
+#define CMD_RING_ADVANCE   0x12
+#define CMD_RING_CLEAR     0x13
 
-/* New multi-file sync commands */
-#define CMD_LIST_FILES      0x10   // Get list of audio files
-#define CMD_READ_FILE       0x11   // Read specific file: [cmd][file_index][offset:4]
-#define CMD_DELETE_FILE     0x12   // Delete specific file: [cmd][file_index]
+#define STORAGE_DEFERRED 0xFF
 
 #define INVALID_COMMAND 6
-#define FILE_NOT_FOUND 7
-#define FILE_INDEX_OUT_OF_RANGE 8
 #define STORAGE_NOT_READY 9
-#define STORAGE_LIST_MAX_FILES_PER_RESPONSE 50
-#define STORAGE_FILE_LIST_ENTRY_SIZE 8
+#define SEQ_OUT_OF_RANGE 10
 
-#define MAX_HEARTBEAT_FRAMES 100
+#define NOTIFY_ACK        0x01
+#define NOTIFY_INFO       0x02
+#define NOTIFY_DATA       0x03
+#define NOTIFY_DONE       0x04
+#define NOTIFY_READ_BEGIN 0x05
+
 #define HEARTBEAT 50
 
-/* Multi-file sync state */
-static char sync_file_list[MAX_AUDIO_FILES][MAX_FILENAME_LEN];
-static uint32_t sync_file_sizes[MAX_AUDIO_FILES];
-static int sync_file_count = 0;
-static int current_sync_file_index = -1;
-static uint8_t list_files_requested = 0;  /* Deferred to storage thread */
-static int8_t delete_file_index = -1;     /* -1 = no delete, >=0 = file index to delete */
-static uint8_t transfer_end_status = 0;
+#define STORAGE_IDLE_POLL_MS_OFFLINE 2000
+#define STORAGE_IDLE_POLL_MS_CONNECTED 1
+#define STORAGE_WRITE_NOTIFY_ATTR_IDX 2
+
+#define STORAGE_CHUNK_COUNT 20
+#define STORAGE_BUFFER_SIZE (RAW_AUDIO_PACKET_BYTES * STORAGE_CHUNK_COUNT)
+#define STORAGE_CONTROL_NOTIFY_SIZE 32
+
+#define SYNC_SPEED_LOG_INTERVAL_MS (30 * 1000)
 
 static void storage_config_changed_handler(const struct bt_gatt_attr *attr, uint16_t value);
 static ssize_t storage_write_handler(struct bt_conn *conn,
@@ -60,6 +56,11 @@ static ssize_t storage_write_handler(struct bt_conn *conn,
                                      uint16_t len,
                                      uint16_t offset,
                                      uint8_t flags);
+static ssize_t storage_read_characteristic(struct bt_conn *conn,
+                                           const struct bt_gatt_attr *attr,
+                                           void *buf,
+                                           uint16_t len,
+                                           uint16_t offset);
 
 static struct bt_uuid_128 storage_service_uuid =
     BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x30295780, 0x4301, 0xEABD, 0x2904, 0x2849ADFEAE43));
@@ -67,16 +68,9 @@ static struct bt_uuid_128 storage_write_uuid =
     BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x30295781, 0x4301, 0xEABD, 0x2904, 0x2849ADFEAE43));
 static struct bt_uuid_128 storage_read_uuid =
     BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x30295782, 0x4301, 0xEABD, 0x2904, 0x2849ADFEAE43));
-static ssize_t storage_read_characteristic(struct bt_conn *conn,
-                                           const struct bt_gatt_attr *attr,
-                                           void *buf,
-                                           uint16_t len,
-                                           uint16_t offset);
 
 K_THREAD_STACK_DEFINE(storage_stack, 4096);
 static struct k_thread storage_thread;
-
-void broadcast_storage_packet(struct k_work *work_item);
 
 static struct bt_gatt_attr storage_service_attr[] = {
     BT_GATT_PRIMARY_SERVICE(&storage_service_uuid),
@@ -98,15 +92,64 @@ static struct bt_gatt_attr storage_service_attr[] = {
 
 struct bt_gatt_service storage_service = BT_GATT_SERVICE(storage_service_attr);
 
-#define STORAGE_IDLE_POLL_MS_OFFLINE 2000
-#define STORAGE_IDLE_POLL_MS_CONNECTED 1
-
-#define STORAGE_WRITE_NOTIFY_ATTR_IDX 2
+static uint8_t storage_buffer[STORAGE_BUFFER_SIZE];
+static uint8_t data_notify_buf[1 + STORAGE_BUFFER_SIZE];
+static uint8_t control_notify_buf[STORAGE_CONTROL_NOTIFY_SIZE];
 
 bool storage_is_on = false;
-static uint32_t cached_file_count = 0;
-static uint64_t cached_total_size = 0;
-static int64_t storage_stats_next_refresh_ms = 0;
+
+static uint8_t info_requested;
+static uint8_t clear_requested;
+static uint8_t read_request_pending;
+static uint8_t advance_request_pending;
+static uint8_t stop_requested;
+static uint8_t heartbeat_count;
+
+static uint64_t pending_start_seq;
+static uint32_t pending_packet_count;
+static uint64_t pending_advance_seq;
+
+static bool transfer_active;
+static bool read_begin_sent;
+static bool done_pending;
+static uint64_t transfer_start_seq;
+static uint64_t current_read_seq;
+static uint32_t remaining_packets;
+static uint8_t transfer_end_status;
+
+typedef enum {
+    SYNC_SPEED_MODE_NONE = 0,
+    SYNC_SPEED_MODE_BLE,
+} sync_speed_mode_t;
+
+static sync_speed_mode_t sync_speed_mode = SYNC_SPEED_MODE_NONE;
+static int64_t sync_speed_window_start_ms;
+static uint64_t sync_speed_window_bytes;
+
+static void sync_speed_reset(sync_speed_mode_t mode)
+{
+    sync_speed_mode = mode;
+    sync_speed_window_start_ms = k_uptime_get();
+    sync_speed_window_bytes = 0;
+}
+
+static void sync_speed_add_bytes(uint32_t bytes)
+{
+    if (sync_speed_mode == SYNC_SPEED_MODE_NONE || bytes == 0U) {
+        return;
+    }
+
+    sync_speed_window_bytes += bytes;
+    int64_t now = k_uptime_get();
+    int64_t elapsed_ms = now - sync_speed_window_start_ms;
+
+    if (elapsed_ms >= SYNC_SPEED_LOG_INTERVAL_MS) {
+        uint64_t kbps = (sync_speed_window_bytes * 1000U) / (elapsed_ms * 1024U);
+        LOG_INF("Sync speed (BLE): %u KB/s", (uint32_t)kbps);
+        sync_speed_window_start_ms = now;
+        sync_speed_window_bytes = 0;
+    }
+}
 
 static bool storage_notify_ready(struct bt_conn *conn)
 {
@@ -126,101 +169,23 @@ static int storage_notify(struct bt_conn *conn, const void *data, uint16_t len)
 
 static void storage_config_changed_handler(const struct bt_gatt_attr *attr, uint16_t value)
 {
+    ARG_UNUSED(attr);
 
     storage_is_on = true;
     if (value == BT_GATT_CCC_NOTIFY) {
-        LOG_INF("Client subscribed for notifications");
+        LOG_INF("Client subscribed for storage notifications");
     } else if (value == 0) {
-        LOG_INF("Client unsubscribed from notifications");
+        LOG_INF("Client unsubscribed from storage notifications");
     } else {
-        LOG_ERR("Invalid CCC value: %u", value);
-    }
-}
-
-static ssize_t storage_read_characteristic(struct bt_conn *conn,
-                                           const struct bt_gatt_attr *attr,
-                                           void *buf,
-                                           uint16_t len,
-                                           uint16_t offset)
-{
-    int64_t now = k_uptime_get();
-    if (now >= storage_stats_next_refresh_ms) {
-        uint32_t file_count = 0;
-        uint64_t total_size = 0;
-        if (get_audio_file_stats(&file_count, &total_size) == 0) {
-            cached_file_count = file_count;
-            cached_total_size = total_size;
-            storage_stats_next_refresh_ms = now + 2000;
-        } else {
-            storage_stats_next_refresh_ms = now + 500;
-        }
-    }
-    
-    /* Phone app expects (little-endian):
-     *   [0..3]  total_used_bytes  (uint32)
-     *   [4..7]  file_count        (uint32)
-     *   [8..11] free_bytes        (uint32)  — optional, newer firmware
-     *   [12..15] status_flags     (uint32)  — optional, newer firmware
-     */
-    uint32_t payload[4] = {0};
-    payload[0] = (uint32_t)cached_total_size;   /* total used bytes */
-    payload[1] = cached_file_count;             /* number of audio files */
-    payload[2] = 0;                      /* free_bytes — TODO: implement disk_access_ioctl */
-    payload[3] = 0;                      /* status_flags: bit0=charging, bit1=warning, bit2=error */
-    
-    LOG_INF("Storage read: used=%u bytes, files=%u", payload[0], payload[1]);
-    return bt_gatt_attr_read(conn, attr, buf, len, offset, payload, sizeof(payload));
-}
-
-uint8_t transport_started = 0;
-#define SD_BLE_SIZE 440
-#define STORAGE_CHUNK_COUNT 20
-#define STORAGE_BUFFER_SIZE (SD_BLE_SIZE * STORAGE_CHUNK_COUNT + 5 * STORAGE_CHUNK_COUNT)  /* ~8.9KB */
-static uint8_t storage_buffer[STORAGE_BUFFER_SIZE];
-static uint8_t stop_started = 0;
-uint32_t remaining_length = 0;
-
-#define SYNC_SPEED_LOG_INTERVAL_MS (30 * 1000)
-
-typedef enum {
-    SYNC_SPEED_MODE_NONE = 0,
-    SYNC_SPEED_MODE_BLE,
-} sync_speed_mode_t;
-
-static sync_speed_mode_t sync_speed_mode = SYNC_SPEED_MODE_NONE;
-static int64_t sync_speed_window_start_ms = 0;
-static uint64_t sync_speed_window_bytes = 0;
-
-static void sync_speed_reset(sync_speed_mode_t mode)
-{
-    sync_speed_mode = mode;
-    sync_speed_window_start_ms = k_uptime_get();
-    sync_speed_window_bytes = 0;
-}
-
-static void sync_speed_add_bytes(uint32_t bytes)
-{
-    if (sync_speed_mode == SYNC_SPEED_MODE_NONE || bytes == 0) {
-        return;
-    }
-
-    sync_speed_window_bytes += bytes;
-    int64_t now = k_uptime_get();
-    int64_t elapsed_ms = now - sync_speed_window_start_ms;
-
-    if (elapsed_ms >= SYNC_SPEED_LOG_INTERVAL_MS) {
-        uint64_t kbps = (sync_speed_window_bytes * 1000U) / (elapsed_ms * 1024U);
-        const char *mode_str = "BLE";
-        LOG_INF("Sync speed (%s): %u KB/s", mode_str, (uint32_t)kbps);
-
-        sync_speed_window_start_ms = now;
-        sync_speed_window_bytes = 0;
+        LOG_ERR("Invalid storage CCC value: %u", value);
     }
 }
 
 static uint8_t storage_status_from_error(int err, uint8_t fallback_status)
 {
     switch (err) {
+    case -ERANGE:
+        return SEQ_OUT_OF_RANGE;
     case -ETIMEDOUT:
     case -EBUSY:
     case -ECANCELED:
@@ -231,73 +196,10 @@ static uint8_t storage_status_from_error(int err, uint8_t fallback_status)
     }
 }
 
-static uint16_t get_ble_chunk_size(struct bt_conn *conn, uint8_t include_timestamp)
+static uint16_t get_ble_data_chunk_size(struct bt_conn *conn)
 {
-    if (!conn) {
-        return SD_BLE_SIZE;
-    }
-
-    uint16_t mtu = bt_gatt_get_mtu(conn);
-    if (mtu <= 3) {
-        return 20;
-    }
-
-    uint16_t att_payload = mtu - 3;
-    uint16_t protocol_overhead = include_timestamp ? 4 : 0;
-
-    if (att_payload <= protocol_overhead + 8) {
-        return 20;
-    }
-
-    uint16_t chunk = att_payload - protocol_overhead;
-    return MIN(chunk, (uint16_t)SD_BLE_SIZE);
-}
-
-static uint8_t heartbeat_count = 0;
-
-/**
- * @brief Refresh file list cache for multi-file sync
- */
-static int refresh_file_list_cache(void)
-{
-    int ret = get_audio_file_list_with_sizes(sync_file_list, sync_file_sizes,
-                                             MAX_AUDIO_FILES, &sync_file_count);
-    if (ret < 0) {
-        LOG_ERR("Failed to get file list: %d", ret);
-        sync_file_count = 0;
-        return ret;
-    }
-    
-    LOG_INF("File list refreshed: %d files", sync_file_count);
-    return sync_file_count;
-}
-
-/**
- * @brief Send file list response
- * Format: [count:1][ts1:4][sz1:4][ts2:4][sz2:4]...
- *
- * Assumes the file list cache (sync_file_list/sync_file_sizes/sync_file_count)
- * has already been populated by the caller via refresh_file_list_cache().
- * Refreshes only when the cache is empty (sync_file_count == 0).
- */
-static int send_file_list_response(struct bt_conn *conn)
-{
-    if (sync_file_count == 0) {
-        int ret = refresh_file_list_cache();
-        if (ret < 0) {
-            uint8_t error_resp[1] = {storage_status_from_error(ret, STORAGE_NOT_READY)};
-            storage_notify(conn, error_resp, 1);
-            return ret;
-        }
-    }
-
-    if (sync_file_count == 0) {
-        uint8_t empty_resp[1] = {0};
-        storage_notify(conn, empty_resp, 1);
-        return 0;
-    }
-
     uint16_t att_payload = 20;
+
     if (conn) {
         uint16_t mtu = bt_gatt_get_mtu(conn);
         if (mtu > 3U) {
@@ -305,159 +207,257 @@ static int send_file_list_response(struct bt_conn *conn)
         }
     }
 
-    int max_files_by_payload = (att_payload > 1U) ? ((att_payload - 1U) / STORAGE_FILE_LIST_ENTRY_SIZE) : 0;
-    int response_file_count = MIN(sync_file_count, STORAGE_LIST_MAX_FILES_PER_RESPONSE);
-    response_file_count = MIN(response_file_count, max_files_by_payload);
+    if (att_payload <= 1U) {
+        return 20;
+    }
 
-    if (response_file_count < 0) {
-        response_file_count = 0;
-    }
-    
-    /* Use storage_buffer to build response (max 4440 bytes) */
-    /* Each file: ts(4) + size(4) = 8 bytes, max ~550 files */
-    int resp_len = 0;
-    
-    storage_buffer[resp_len++] = (uint8_t)response_file_count;
-    
-    for (int i = 0; i < response_file_count && resp_len + STORAGE_FILE_LIST_ENTRY_SIZE <= STORAGE_BUFFER_SIZE; i++) {
-        uint32_t timestamp = (uint32_t)strtoul(sync_file_list[i], NULL, 16);
-        uint32_t size = sync_file_sizes[i];
-        
-        storage_buffer[resp_len++] = (timestamp >> 24) & 0xFF;
-        storage_buffer[resp_len++] = (timestamp >> 16) & 0xFF;
-        storage_buffer[resp_len++] = (timestamp >> 8) & 0xFF;
-        storage_buffer[resp_len++] = timestamp & 0xFF;
-        
-        storage_buffer[resp_len++] = (size >> 24) & 0xFF;
-        storage_buffer[resp_len++] = (size >> 16) & 0xFF;
-        storage_buffer[resp_len++] = (size >> 8) & 0xFF;
-        storage_buffer[resp_len++] = size & 0xFF;
-    }
-    
-    LOG_INF("Sending file list: %d/%d files, %d bytes (att_payload=%u)",
-            response_file_count,
-            sync_file_count,
-            resp_len,
-            att_payload);
-    return storage_notify(conn, storage_buffer, resp_len);
+    return att_payload - 1U;
 }
 
-/**
- * @brief Setup transfer for specific file by index
- */
-static int setup_file_transfer(int file_index, uint32_t start_offset)
+static int send_ack(struct bt_conn *conn, uint8_t status)
 {
-    if (file_index < 0 || file_index >= sync_file_count) {
-        LOG_ERR("File index out of range: %d", file_index);
-        return -1;
-    }
-    
-    strncpy(current_read_filename, sync_file_list[file_index], MAX_FILENAME_LEN - 1);
-    current_read_offset = start_offset;
-    current_sync_file_index = file_index;
-    transfer_end_status = 0;
-    
-    if (current_read_offset < sync_file_sizes[file_index]) {
-        remaining_length = sync_file_sizes[file_index] - current_read_offset;
-    } else {
-        remaining_length = 0;
-    }
-    
-    LOG_INF("Setup transfer: file[%d]=%s, offset=%u, remaining=%u", 
-            file_index, current_read_filename, current_read_offset, remaining_length);
-    return 0;
+    control_notify_buf[0] = NOTIFY_ACK;
+    control_notify_buf[1] = status;
+    return storage_notify(conn, control_notify_buf, 2);
 }
 
-/**
- * @brief Delete specific file by index
- */
-static int delete_file_by_index(int file_index)
+static int send_done(struct bt_conn *conn, uint8_t status, uint64_t next_seq)
 {
-    if (file_index < 0 || file_index >= sync_file_count) {
-        return -1;
-    }
-    /* Copy target filename so we are robust to list refreshes */
-    char target_name[MAX_FILENAME_LEN] = {0};
-    strncpy(target_name, sync_file_list[file_index], MAX_FILENAME_LEN - 1);
+    control_notify_buf[0] = NOTIFY_DONE;
+    control_notify_buf[1] = status;
+    sys_put_be64(next_seq, control_notify_buf + 2);
+    return storage_notify(conn, control_notify_buf, 10);
+}
 
-    /* Delegate deletion to SD worker so it can safely handle
-     * the case where this is the currently-recording file. */
-    int ret = delete_audio_file(target_name);
+static int send_ring_info_response(struct bt_conn *conn)
+{
+    sd_ring_info_t info;
+    int ret = sd_ring_get_info(&info);
     if (ret < 0) {
-        LOG_ERR("Failed to delete file[%d]: %s (err=%d)", file_index, target_name, ret);
-        return ret;
+        return send_ack(conn, storage_status_from_error(ret, STORAGE_NOT_READY));
     }
 
-    LOG_INF("Deleted file[%d]: %s", file_index, target_name);
-    refresh_file_list_cache();
+    control_notify_buf[0] = NOTIFY_INFO;
+    sys_put_be64(info.read_seq, control_notify_buf + 1);
+    sys_put_be64(info.write_seq, control_notify_buf + 9);
+    sys_put_be32(info.capacity_packets, control_notify_buf + 17);
+    sys_put_be64(info.dropped_packets, control_notify_buf + 21);
+    sys_put_be16(RAW_AUDIO_PACKET_BYTES, control_notify_buf + 29);
+    return storage_notify(conn, control_notify_buf, 31);
+}
+
+static void reset_transfer_state(void)
+{
+    transfer_active = false;
+    read_begin_sent = false;
+    done_pending = false;
+    transfer_start_seq = 0;
+    current_read_seq = 0;
+    remaining_packets = 0;
+    transfer_end_status = 0;
+}
+
+void storage_stop_transfer(void)
+{
+    reset_transfer_state();
+}
+
+bool storage_transfer_active(void)
+{
+    return transfer_active;
+}
+
+static int start_pending_read(struct bt_conn *conn)
+{
+    sd_ring_info_t info;
+    int ret = sd_ring_get_info(&info);
+    if (ret < 0) {
+        return send_ack(conn, storage_status_from_error(ret, STORAGE_NOT_READY));
+    }
+
+    if (pending_start_seq < info.read_seq || pending_start_seq > info.write_seq) {
+        return send_ack(conn, SEQ_OUT_OF_RANGE);
+    }
+
+    uint64_t available_packets = info.write_seq - pending_start_seq;
+    uint32_t requested_packets = pending_packet_count;
+    if (requested_packets == 0U || (uint64_t)requested_packets > available_packets) {
+        requested_packets = (available_packets > UINT32_MAX) ? UINT32_MAX : (uint32_t)available_packets;
+    }
+
+    transfer_active = true;
+    read_begin_sent = false;
+    done_pending = false;
+    transfer_start_seq = pending_start_seq;
+    current_read_seq = pending_start_seq;
+    remaining_packets = requested_packets;
+    transfer_end_status = 0;
+    heartbeat_count = 0;
+    sync_speed_mode = SYNC_SPEED_MODE_NONE;
+    sync_speed_window_bytes = 0;
+    sync_speed_window_start_ms = 0;
+
     return 0;
 }
 
-static uint8_t parse_storage_command(void *buf, uint16_t len, struct bt_conn *conn)
+static void write_to_gatt(struct bt_conn *conn)
 {
-    if (len < 1) {
+    if (!transfer_active || done_pending) {
+        return;
+    }
+
+    if (!read_begin_sent) {
+        control_notify_buf[0] = NOTIFY_READ_BEGIN;
+        sys_put_be64(transfer_start_seq, control_notify_buf + 1);
+        sys_put_be32(remaining_packets, control_notify_buf + 9);
+
+        int err = storage_notify(conn, control_notify_buf, 13);
+        if (err == -ENOMEM) {
+            k_yield();
+            return;
+        }
+        if (err == -EAGAIN) {
+            return;
+        }
+        if (err) {
+            transfer_end_status = storage_status_from_error(err, STORAGE_NOT_READY);
+            done_pending = true;
+            remaining_packets = 0;
+            return;
+        }
+
+        read_begin_sent = true;
+    }
+
+    if (remaining_packets == 0U) {
+        done_pending = true;
+        return;
+    }
+
+    if (sync_speed_mode != SYNC_SPEED_MODE_BLE) {
+        sync_speed_reset(SYNC_SPEED_MODE_BLE);
+    }
+
+    uint16_t ble_chunk = get_ble_data_chunk_size(conn);
+
+    while (remaining_packets > 0U) {
+        uint32_t packets_to_read = MIN(remaining_packets, (uint32_t)STORAGE_CHUNK_COUNT);
+        uint32_t bytes_read = 0;
+        uint32_t packets_read = 0;
+        int ret = sd_ring_read(current_read_seq,
+                               storage_buffer,
+                               packets_to_read * RAW_AUDIO_PACKET_BYTES,
+                               &bytes_read,
+                               &packets_read);
+        if (ret < 0) {
+            transfer_end_status = storage_status_from_error(ret, STORAGE_NOT_READY);
+            done_pending = true;
+            remaining_packets = 0;
+            return;
+        }
+        if (packets_read == 0U || bytes_read == 0U) {
+            done_pending = true;
+            remaining_packets = 0;
+            return;
+        }
+
+        uint32_t bytes_sent = 0;
+        while (bytes_sent < bytes_read) {
+            uint32_t payload = MIN(bytes_read - bytes_sent, (uint32_t)ble_chunk);
+            data_notify_buf[0] = NOTIFY_DATA;
+            memcpy(data_notify_buf + 1, storage_buffer + bytes_sent, payload);
+
+            int err = storage_notify(conn, data_notify_buf, payload + 1U);
+            if (err == -ENOMEM) {
+                k_yield();
+                continue;
+            }
+            if (err == -EAGAIN) {
+                return;
+            }
+            if (err) {
+                transfer_end_status = storage_status_from_error(err, STORAGE_NOT_READY);
+                done_pending = true;
+                remaining_packets = 0;
+                return;
+            }
+
+            bytes_sent += payload;
+            sync_speed_add_bytes(payload);
+        }
+
+        current_read_seq += packets_read;
+        remaining_packets -= packets_read;
+    }
+
+    done_pending = true;
+}
+
+static ssize_t storage_read_characteristic(struct bt_conn *conn,
+                                           const struct bt_gatt_attr *attr,
+                                           void *buf,
+                                           uint16_t len,
+                                           uint16_t offset)
+{
+    uint32_t payload[4] = {0};
+    sd_ring_info_t info;
+
+    if (sd_ring_get_info(&info) == 0) {
+        uint64_t unread_packets = info.write_seq - info.read_seq;
+        uint64_t used_bytes = unread_packets * RAW_AUDIO_PACKET_BYTES;
+        uint64_t free_bytes = ((uint64_t)info.capacity_packets - unread_packets) * RAW_AUDIO_PACKET_BYTES;
+
+        payload[0] = (used_bytes > UINT32_MAX) ? UINT32_MAX : (uint32_t)used_bytes;
+        payload[1] = (unread_packets > UINT32_MAX) ? UINT32_MAX : (uint32_t)unread_packets;
+        payload[2] = (free_bytes > UINT32_MAX) ? UINT32_MAX : (uint32_t)free_bytes;
+        payload[3] = rtc_is_valid() ? 1U : 0U;
+    }
+
+    return bt_gatt_attr_read(conn, attr, buf, len, offset, payload, sizeof(payload));
+}
+
+static uint8_t parse_storage_command(void *buf, uint16_t len)
+{
+    if (len < 1U) {
         return INVALID_COMMAND;
     }
-    
-    const uint8_t command = ((uint8_t *) buf)[0];
-    LOG_INF("Storage command: 0x%02X, len=%d", command, len);
-    
-    /* ===== NEW MULTI-FILE COMMANDS ===== */
-    
-    if (command == CMD_LIST_FILES) {
-        list_files_requested = 1;  /* Defer to storage thread to avoid stack overflow */
-        return 0xFF;  /* Will be processed in storage thread */
-    }
-    
-    if (command == CMD_READ_FILE) {
-        if (len < 2) return INVALID_COMMAND;
-        
-        uint8_t file_index = ((uint8_t *) buf)[1];
-        uint32_t request_offset = 0;
-        if (len >= 6) {
-            request_offset = ((uint8_t *) buf)[2] << 24 | ((uint8_t *) buf)[3] << 16 | 
-                            ((uint8_t *) buf)[4] << 8 | ((uint8_t *) buf)[5];
-        }
-        
-        if (sync_file_count == 0) {
-            int ret = refresh_file_list_cache();
-            if (ret < 0) {
-                return storage_status_from_error(ret, STORAGE_NOT_READY);
-            }
-        }
-        
-        if (file_index >= sync_file_count) {
-            return FILE_INDEX_OUT_OF_RANGE;
-        }
-        
-        if (setup_file_transfer(file_index, request_offset) < 0) {
-            return FILE_NOT_FOUND;
-        }
-        
-        transport_started = 1;
-        return 0;
-    }
-    
-    if (command == CMD_DELETE_FILE) {
-        if (len < 2) return INVALID_COMMAND;
-        
-        uint8_t file_index = ((uint8_t *) buf)[1];
-        if (sync_file_count == 0) {
-            /* File list not cached, defer refresh + delete to storage thread */
-            delete_file_index = file_index;
-            return 0xFF;
-        }
-        if (file_index >= sync_file_count) {
-            return FILE_INDEX_OUT_OF_RANGE;
-        }
-        
-        delete_file_index = file_index;  /* Defer to storage thread */
-        return 0xFF;
+
+    const uint8_t *bytes = buf;
+    const uint8_t command = bytes[0];
+
+    if (command == CMD_RING_INFO) {
+        info_requested = 1;
+        return STORAGE_DEFERRED;
     }
 
-    /* Control commands */
+    if (command == CMD_RING_READ) {
+        if (len != 9U && len != 13U) {
+            return INVALID_COMMAND;
+        }
+
+        pending_start_seq = sys_get_be64(bytes + 1);
+        pending_packet_count = (len == 13U) ? sys_get_be32(bytes + 9) : 0U;
+        read_request_pending = 1;
+        return STORAGE_DEFERRED;
+    }
+
+    if (command == CMD_RING_ADVANCE) {
+        if (len != 9U) {
+            return INVALID_COMMAND;
+        }
+
+        pending_advance_seq = sys_get_be64(bytes + 1);
+        advance_request_pending = 1;
+        return STORAGE_DEFERRED;
+    }
+
+    if (command == CMD_RING_CLEAR) {
+        clear_requested = 1;
+        return STORAGE_DEFERRED;
+    }
+
     if (command == CMD_STOP_SYNC) {
-        storage_stop_transfer();
+        stop_requested = 1;
         return 0;
     }
 
@@ -466,7 +466,6 @@ static uint8_t parse_storage_command(void *buf, uint16_t len, struct bt_conn *co
         return 0;
     }
 
-    /* Accept only multi-file protocol commands above. */
     return INVALID_COMMAND;
 }
 
@@ -477,270 +476,86 @@ static ssize_t storage_write_handler(struct bt_conn *conn,
                                      uint16_t offset,
                                      uint8_t flags)
 {
-    if (len < 1) {
-        uint8_t result_buffer[1] = {INVALID_COMMAND};
-        LOG_WRN("storage write with empty payload");
-        storage_notify(conn, &result_buffer, 1);
+    ARG_UNUSED(attr);
+    ARG_UNUSED(offset);
+    ARG_UNUSED(flags);
+
+    if (len < 1U) {
+        (void)send_ack(conn, INVALID_COMMAND);
         return len;
     }
 
-    LOG_INF("about to schedule the storage");
-    LOG_INF("was sent %d  ", ((uint8_t *) buf)[0]);
-
-    uint8_t result = parse_storage_command((void *)buf, len, conn);
-    
-    /* 0xFF means response was already sent */
-    if (result != 0xFF) {
-        uint8_t result_buffer[1] = {result};
-        LOG_INF("length of storage write: %d, result: %d", len, result);
-        storage_notify(conn, &result_buffer, 1);
+    uint8_t result = parse_storage_command((void *)buf, len);
+    if (result != STORAGE_DEFERRED) {
+        (void)send_ack(conn, result);
     }
-    
+
     return len;
 }
 
-/*
- * Batch-read buffer for BLE sync: reuse storage_buffer (4450 bytes).
- * Only need a small separate buffer for building BLE notifications.
- */
-#define BLE_BATCH_PACKETS 20
-static uint8_t ble_notify_buf[4 + SD_BLE_SIZE];
-
-static void write_to_gatt(struct bt_conn *conn)
+static void storage_write(void)
 {
-    int err;
-    if (sync_speed_mode != SYNC_SPEED_MODE_BLE) {
-        sync_speed_reset(SYNC_SPEED_MODE_BLE);
-    }
-    uint16_t ble_chunk = get_ble_chunk_size(conn, current_sync_file_index >= 0);
-    
-    if (current_sync_file_index < 0) {
-        LOG_ERR("write_to_gatt called without active multi-file transfer");
-        remaining_length = 0;
-        return;
-    }
-
-    /* New protocol: add 4-byte timestamp prefix */
-    uint32_t timestamp = (uint32_t)strtoul(sync_file_list[current_sync_file_index], NULL, 16);
-        
-        /* Build timestamp header once */
-        ble_notify_buf[0] = (timestamp >> 24) & 0xFF;
-        ble_notify_buf[1] = (timestamp >> 16) & 0xFF;
-        ble_notify_buf[2] = (timestamp >> 8) & 0xFF;
-        ble_notify_buf[3] = timestamp & 0xFF;
-
-        /*
-         * Multi-batch send loop: keep reading+sending until BLE TX buffers
-         * saturate or we run out of data.  Previously we did ONE batch per
-         * call (~4.4 KB) then returned to the main loop, which limited
-         * throughput to 10-15 KB/s.  Now we keep going until -ENOMEM
-         * persists, which lets BLE run at full connection-event throughput.
-         */
-        while (remaining_length > 0) {
-            if (stop_started) {
-                remaining_length = 0;
-                return;
-            }
-
-            uint32_t batch_audio_size = MIN(remaining_length, (uint32_t)(ble_chunk * BLE_BATCH_PACKETS));
-            if (batch_audio_size > STORAGE_BUFFER_SIZE) {
-                batch_audio_size = STORAGE_BUFFER_SIZE;
-            }
-
-            int r = read_audio_data(current_read_filename, storage_buffer, batch_audio_size, current_read_offset);
-            if (r <= 0) {
-                LOG_ERR("Failed to read audio data: %d", r);
-                transfer_end_status = storage_status_from_error(r, FILE_NOT_FOUND);
-                remaining_length = 0;
-                return;
-            }
-            uint32_t bytes_read = (uint32_t)r;
-            uint32_t bytes_sent = 0;
-
-            while (bytes_sent < bytes_read && remaining_length > 0) {
-                if (stop_started) {
-                    remaining_length = 0;
-                    return;
-                }
-
-                uint32_t chunk = MIN(bytes_read - bytes_sent, ble_chunk);
-                memcpy(ble_notify_buf + 4, storage_buffer + bytes_sent, chunk);
-
-                err = storage_notify(conn, ble_notify_buf, 4 + chunk);
-                if (err == -ENOMEM) {
-                    if (stop_started) {
-                        remaining_length = 0;
-                        return;
-                    }
-                    k_yield();
-                    continue;
-                }
-                if (err == -EAGAIN) {
-                    return;
-                }
-                if (err && err != -ENOMEM) {
-                    LOG_ERR("GATT notify error: %d", err);
-                    return;
-                }
-
-                bytes_sent += chunk;
-                sync_speed_add_bytes(chunk);
-                current_read_offset += chunk;
-                remaining_length -= chunk;
-            }
-        }
-}
-
-void storage_stop_transfer()
-{
-    remaining_length = 0;
-    stop_started = 1;
-}
-
-bool storage_transfer_active(void)
-{
-    return (remaining_length > 0) || (transport_started != 0);
-}
-
-void storage_write(void)
-{
-    uint32_t total_sent = 0;
-    uint32_t consecutive_errors = 0;
-
     while (1) {
         struct bt_conn *conn = get_current_connection();
 
-        if (transport_started) {
-            LOG_INF("transport started in side : %d", transport_started);
-            sync_speed_mode = SYNC_SPEED_MODE_NONE;
-            sync_speed_window_bytes = 0;
-            sync_speed_window_start_ms = 0;
-            if (current_sync_file_index < 0) {
-                LOG_ERR("Transfer start requested without CMD_READ_FILE setup");
-                remaining_length = 0;
-            }
-            transport_started = 0;  /* Clear flag after setup */
-        }
-        if (list_files_requested) {
-            list_files_requested = 0;
-            /* Always refresh cache so the response is up-to-date, then send.
-             * send_file_list_response() will not re-refresh if count > 0. */
-            if (conn) {
-                int ret = refresh_file_list_cache();
-                if (ret < 0) {
-                    uint8_t result = storage_status_from_error(ret, STORAGE_NOT_READY);
-                    storage_notify(conn, &result, 1);
-                } else {
-                    send_file_list_response(conn);
-                }
-            }
-        }
-        if (delete_file_index >= 0) {
-            int8_t idx = delete_file_index;
-            delete_file_index = -1;
-            uint8_t result = 0;
-            
-            /* Ensure file list is cached */
-            if (sync_file_count == 0) {
-                int ret = refresh_file_list_cache();
-                if (ret < 0) {
-                    result = storage_status_from_error(ret, STORAGE_NOT_READY);
-                }
-            }
-            
-            if (result == 0 && idx >= sync_file_count) {
-                result = FILE_INDEX_OUT_OF_RANGE;
-            } else if (result == 0) {
-                int delete_ret = delete_file_by_index(idx);
-                if (delete_ret < 0) {
-                    result = storage_status_from_error(delete_ret, FILE_NOT_FOUND);
-                }
-            }
-            
-            if (conn) {
-                storage_notify(conn, &result, 1);
-            }
-            LOG_INF("Delete file[%d] result: %d", idx, result);
-        }
-        if (stop_started) {
-            remaining_length = 0;
-            stop_started = 0;
-            save_offset(current_read_filename, current_read_offset);
-        }
-        if (heartbeat_count == MAX_HEARTBEAT_FRAMES) {
-            LOG_INF("no heartbeat sent");
-            save_offset(current_read_filename, current_read_offset);
-            // ensure heartbeat count resets
-            heartbeat_count = 0;
+        if (stop_requested) {
+            stop_requested = 0;
+            storage_stop_transfer();
         }
 
-        if (remaining_length > 0) {
+        if (info_requested) {
+            info_requested = 0;
+            if (conn) {
+                (void)send_ring_info_response(conn);
+            }
+        }
+
+        if (clear_requested) {
+            clear_requested = 0;
+            if (conn) {
+                int ret = sd_ring_clear();
+                (void)send_ack(conn, ret < 0 ? storage_status_from_error(ret, STORAGE_NOT_READY) : 0);
+            }
+        }
+
+        if (advance_request_pending) {
+            advance_request_pending = 0;
+            if (conn) {
+                int ret = sd_ring_advance(pending_advance_seq);
+                (void)send_ack(conn, ret < 0 ? storage_status_from_error(ret, SEQ_OUT_OF_RANGE) : 0);
+            }
+        }
+
+        if (read_request_pending) {
+            read_request_pending = 0;
+            if (conn) {
+                int ret = start_pending_read(conn);
+                if (ret < 0) {
+                    (void)send_ack(conn, storage_status_from_error(ret, STORAGE_NOT_READY));
+                }
+            }
+        }
+
+        if (transfer_active) {
             if (conn == NULL) {
-                LOG_ERR("invalid connection");
-                remaining_length = 0;
-                save_offset(current_read_filename, current_read_offset);
-                // save offset to flash
-                continue;
-                // k_yield();
-            }
-
-            write_to_gatt(conn);
-            heartbeat_count = (heartbeat_count + 1) % (MAX_HEARTBEAT_FRAMES + 1);
-
-            transport_started = 0;
-            if (remaining_length == 0) {
-                if (stop_started) {
-                    stop_started = 0;
-                    transfer_end_status = 0;
-                    current_sync_file_index = -1;
-                } else if (transfer_end_status != 0) {
-                    uint8_t result = transfer_end_status;
-                    save_offset(current_read_filename, current_read_offset);
-                    LOG_WRN("Transfer aborted for %s with status %u", current_read_filename, result);
-                    transfer_end_status = 0;
-                    current_sync_file_index = -1;
-                    if (conn) {
-                        (void)storage_notify(conn, &result, 1);
-                    }
+                storage_stop_transfer();
+            } else if (done_pending) {
+                int err = send_done(conn, transfer_end_status, current_read_seq);
+                if (err == -ENOMEM) {
+                    k_yield();
+                } else if (err == -EAGAIN) {
+                    /* wait for subscription/connection to recover */
                 } else {
-                    save_offset(current_read_filename, current_read_offset);
-                    LOG_INF("File done: %s", current_read_filename);
-
-                    /* Auto-delete after successful multi-file sync. */
-                    {
-                        char recording_name[MAX_FILENAME_LEN] = {0};
-                        get_current_filename(recording_name, sizeof(recording_name));
-                        bool is_recording_file = (recording_name[0] != '\0' &&
-                            strcmp(current_read_filename, recording_name) == 0);
-
-                        if (!is_recording_file && current_read_filename[0] != '\0') {
-                            LOG_INF("Auto-delete synced file: %s", current_read_filename);
-                            int del_ret = delete_audio_file(current_read_filename);
-                            if (del_ret < 0) {
-                                LOG_ERR("Failed to auto-delete %s: %d", current_read_filename, del_ret);
-                            }
-                            /* Clear saved offset since deleted file is gone */
-                            save_offset("", 0);
-                        } else if (is_recording_file) {
-                            LOG_INF("Skipping delete of active recording file: %s", current_read_filename);
-                        }
-                    }
-
-                    /* BLE: notify completion */
-                    LOG_PRINTK("done. attempting to download more files\n");
-                    uint8_t stop_result[1] = {100};
-                    (void)storage_notify(get_current_connection(), &stop_result, 1);
-                    current_sync_file_index = -1;
-                    k_msleep(10);
+                    reset_transfer_state();
                 }
+            } else {
+                write_to_gatt(conn);
+                heartbeat_count = (heartbeat_count + 1U) % 101U;
             }
         }
 
-        // Sleep when there's no work
-        if (remaining_length == 0 && !stop_started) {
-            uint32_t idle_sleep_ms = get_current_connection()
-                ? STORAGE_IDLE_POLL_MS_CONNECTED
-                : STORAGE_IDLE_POLL_MS_OFFLINE;
+        if (!transfer_active) {
+            uint32_t idle_sleep_ms = conn ? STORAGE_IDLE_POLL_MS_CONNECTED : STORAGE_IDLE_POLL_MS_OFFLINE;
             k_msleep(idle_sleep_ms);
         } else {
             k_yield();
@@ -753,7 +568,7 @@ int storage_init()
     k_thread_create(&storage_thread,
                     storage_stack,
                     K_THREAD_STACK_SIZEOF(storage_stack),
-                    (k_thread_entry_t) storage_write,
+                    (k_thread_entry_t)storage_write,
                     NULL,
                     NULL,
                     NULL,

--- a/omi/firmware/omi/src/lib/core/storage.c
+++ b/omi/firmware/omi/src/lib/core/storage.c
@@ -37,11 +37,10 @@ LOG_MODULE_REGISTER(storage, CONFIG_LOG_DEFAULT_LEVEL);
 #define NOTIFY_DONE       0x04
 #define NOTIFY_READ_BEGIN 0x05
 
-#define HEARTBEAT 50
-
 #define STORAGE_IDLE_POLL_MS_OFFLINE 2000
 #define STORAGE_IDLE_POLL_MS_CONNECTED 1
 #define STORAGE_WRITE_NOTIFY_ATTR_IDX 2
+#define STORAGE_STATUS_REFRESH_MS 250
 
 #define STORAGE_CHUNK_COUNT 20
 #define STORAGE_BUFFER_SIZE (RAW_AUDIO_PACKET_BYTES * STORAGE_CHUNK_COUNT)
@@ -103,7 +102,6 @@ static uint8_t clear_requested;
 static uint8_t read_request_pending;
 static uint8_t advance_request_pending;
 static uint8_t stop_requested;
-static uint8_t heartbeat_count;
 
 static uint64_t pending_start_seq;
 static uint32_t pending_packet_count;
@@ -116,6 +114,12 @@ static uint64_t transfer_start_seq;
 static uint64_t current_read_seq;
 static uint32_t remaining_packets;
 static uint8_t transfer_end_status;
+
+static atomic_t storage_status_used_bytes = ATOMIC_INIT(0);
+static atomic_t storage_status_unread_packets = ATOMIC_INIT(0);
+static atomic_t storage_status_free_bytes = ATOMIC_INIT(0);
+static atomic_t storage_status_rtc_valid = ATOMIC_INIT(0);
+static int64_t storage_status_refresh_deadline_ms;
 
 typedef enum {
     SYNC_SPEED_MODE_NONE = 0,
@@ -149,6 +153,43 @@ static void sync_speed_add_bytes(uint32_t bytes)
         sync_speed_window_start_ms = now;
         sync_speed_window_bytes = 0;
     }
+}
+
+static void storage_status_cache_set(const sd_ring_info_t *info)
+{
+    if (!info) {
+        return;
+    }
+
+    uint64_t unread_packets = info->write_seq - info->read_seq;
+    uint64_t used_bytes = unread_packets * RAW_AUDIO_PACKET_BYTES;
+    uint64_t free_bytes = ((uint64_t)info->capacity_packets - unread_packets) * RAW_AUDIO_PACKET_BYTES;
+
+    atomic_set(&storage_status_used_bytes, (atomic_val_t)MIN(used_bytes, (uint64_t)UINT32_MAX));
+    atomic_set(&storage_status_unread_packets, (atomic_val_t)MIN(unread_packets, (uint64_t)UINT32_MAX));
+    atomic_set(&storage_status_free_bytes, (atomic_val_t)MIN(free_bytes, (uint64_t)UINT32_MAX));
+    atomic_set(&storage_status_rtc_valid, rtc_is_valid() ? 1 : 0);
+}
+
+static void storage_status_cache_refresh(void)
+{
+    sd_ring_info_t info;
+
+    if (sd_ring_get_info(&info) == 0) {
+        storage_status_cache_set(&info);
+    }
+}
+
+static void storage_status_cache_maybe_refresh(bool force)
+{
+    int64_t now = k_uptime_get();
+
+    if (!force && now < storage_status_refresh_deadline_ms) {
+        return;
+    }
+
+    storage_status_refresh_deadline_ms = now + STORAGE_STATUS_REFRESH_MS;
+    storage_status_cache_refresh();
 }
 
 static bool storage_notify_ready(struct bt_conn *conn)
@@ -237,6 +278,8 @@ static int send_ring_info_response(struct bt_conn *conn)
         return send_ack(conn, storage_status_from_error(ret, STORAGE_NOT_READY));
     }
 
+    storage_status_cache_set(&info);
+
     control_notify_buf[0] = NOTIFY_INFO;
     sys_put_be64(info.read_seq, control_notify_buf + 1);
     sys_put_be64(info.write_seq, control_notify_buf + 9);
@@ -267,6 +310,17 @@ bool storage_transfer_active(void)
     return transfer_active;
 }
 
+static bool consume_stop_request(void)
+{
+    if (!stop_requested) {
+        return false;
+    }
+
+    stop_requested = 0;
+    storage_stop_transfer();
+    return true;
+}
+
 static int start_pending_read(struct bt_conn *conn)
 {
     sd_ring_info_t info;
@@ -278,6 +332,8 @@ static int start_pending_read(struct bt_conn *conn)
     if (pending_start_seq < info.read_seq || pending_start_seq > info.write_seq) {
         return send_ack(conn, SEQ_OUT_OF_RANGE);
     }
+
+    storage_status_cache_set(&info);
 
     uint64_t available_packets = info.write_seq - pending_start_seq;
     uint32_t requested_packets = pending_packet_count;
@@ -292,7 +348,6 @@ static int start_pending_read(struct bt_conn *conn)
     current_read_seq = pending_start_seq;
     remaining_packets = requested_packets;
     transfer_end_status = 0;
-    heartbeat_count = 0;
     sync_speed_mode = SYNC_SPEED_MODE_NONE;
     sync_speed_window_bytes = 0;
     sync_speed_window_start_ms = 0;
@@ -306,6 +361,10 @@ static void write_to_gatt(struct bt_conn *conn)
         return;
     }
 
+    if (consume_stop_request()) {
+        return;
+    }
+
     if (!read_begin_sent) {
         control_notify_buf[0] = NOTIFY_READ_BEGIN;
         sys_put_be64(transfer_start_seq, control_notify_buf + 1);
@@ -314,9 +373,11 @@ static void write_to_gatt(struct bt_conn *conn)
         int err = storage_notify(conn, control_notify_buf, 13);
         if (err == -ENOMEM) {
             k_yield();
+            consume_stop_request();
             return;
         }
         if (err == -EAGAIN) {
+            storage_stop_transfer();
             return;
         }
         if (err) {
@@ -341,6 +402,10 @@ static void write_to_gatt(struct bt_conn *conn)
     uint16_t ble_chunk = get_ble_data_chunk_size(conn);
 
     while (remaining_packets > 0U) {
+        if (consume_stop_request()) {
+            return;
+        }
+
         uint32_t packets_to_read = MIN(remaining_packets, (uint32_t)STORAGE_CHUNK_COUNT);
         uint32_t bytes_read = 0;
         uint32_t packets_read = 0;
@@ -363,6 +428,10 @@ static void write_to_gatt(struct bt_conn *conn)
 
         uint32_t bytes_sent = 0;
         while (bytes_sent < bytes_read) {
+            if (consume_stop_request()) {
+                return;
+            }
+
             uint32_t payload = MIN(bytes_read - bytes_sent, (uint32_t)ble_chunk);
             data_notify_buf[0] = NOTIFY_DATA;
             memcpy(data_notify_buf + 1, storage_buffer + bytes_sent, payload);
@@ -370,9 +439,13 @@ static void write_to_gatt(struct bt_conn *conn)
             int err = storage_notify(conn, data_notify_buf, payload + 1U);
             if (err == -ENOMEM) {
                 k_yield();
+                if (consume_stop_request()) {
+                    return;
+                }
                 continue;
             }
             if (err == -EAGAIN) {
+                storage_stop_transfer();
                 return;
             }
             if (err) {
@@ -399,19 +472,12 @@ static ssize_t storage_read_characteristic(struct bt_conn *conn,
                                            uint16_t len,
                                            uint16_t offset)
 {
-    uint32_t payload[4] = {0};
-    sd_ring_info_t info;
-
-    if (sd_ring_get_info(&info) == 0) {
-        uint64_t unread_packets = info.write_seq - info.read_seq;
-        uint64_t used_bytes = unread_packets * RAW_AUDIO_PACKET_BYTES;
-        uint64_t free_bytes = ((uint64_t)info.capacity_packets - unread_packets) * RAW_AUDIO_PACKET_BYTES;
-
-        payload[0] = (used_bytes > UINT32_MAX) ? UINT32_MAX : (uint32_t)used_bytes;
-        payload[1] = (unread_packets > UINT32_MAX) ? UINT32_MAX : (uint32_t)unread_packets;
-        payload[2] = (free_bytes > UINT32_MAX) ? UINT32_MAX : (uint32_t)free_bytes;
-        payload[3] = rtc_is_valid() ? 1U : 0U;
-    }
+    uint32_t payload[4] = {
+        (uint32_t)atomic_get(&storage_status_used_bytes),
+        (uint32_t)atomic_get(&storage_status_unread_packets),
+        (uint32_t)atomic_get(&storage_status_free_bytes),
+        (uint32_t)atomic_get(&storage_status_rtc_valid),
+    };
 
     return bt_gatt_attr_read(conn, attr, buf, len, offset, payload, sizeof(payload));
 }
@@ -461,11 +527,6 @@ static uint8_t parse_storage_command(void *buf, uint16_t len)
         return 0;
     }
 
-    if (command == HEARTBEAT) {
-        heartbeat_count = 0;
-        return 0;
-    }
-
     return INVALID_COMMAND;
 }
 
@@ -498,9 +559,8 @@ static void storage_write(void)
     while (1) {
         struct bt_conn *conn = get_current_connection();
 
-        if (stop_requested) {
-            stop_requested = 0;
-            storage_stop_transfer();
+        if (consume_stop_request()) {
+            storage_status_cache_maybe_refresh(true);
         }
 
         if (info_requested) {
@@ -514,6 +574,9 @@ static void storage_write(void)
             clear_requested = 0;
             if (conn) {
                 int ret = sd_ring_clear();
+                if (ret >= 0) {
+                    storage_status_cache_maybe_refresh(true);
+                }
                 (void)send_ack(conn, ret < 0 ? storage_status_from_error(ret, STORAGE_NOT_READY) : 0);
             }
         }
@@ -522,6 +585,9 @@ static void storage_write(void)
             advance_request_pending = 0;
             if (conn) {
                 int ret = sd_ring_advance(pending_advance_seq);
+                if (ret >= 0) {
+                    storage_status_cache_maybe_refresh(true);
+                }
                 (void)send_ack(conn, ret < 0 ? storage_status_from_error(ret, SEQ_OUT_OF_RANGE) : 0);
             }
         }
@@ -544,17 +610,19 @@ static void storage_write(void)
                 if (err == -ENOMEM) {
                     k_yield();
                 } else if (err == -EAGAIN) {
-                    /* wait for subscription/connection to recover */
+                    reset_transfer_state();
                 } else {
                     reset_transfer_state();
                 }
             } else {
                 write_to_gatt(conn);
-                heartbeat_count = (heartbeat_count + 1U) % 101U;
             }
         }
 
         if (!transfer_active) {
+            if (conn) {
+                storage_status_cache_maybe_refresh(false);
+            }
             uint32_t idle_sleep_ms = conn ? STORAGE_IDLE_POLL_MS_CONNECTED : STORAGE_IDLE_POLL_MS_OFFLINE;
             k_msleep(idle_sleep_ms);
         } else {

--- a/omi/firmware/omi/src/lib/core/transport.c
+++ b/omi/firmware/omi/src/lib/core/transport.c
@@ -1075,7 +1075,6 @@ static bool push_to_gatt(struct bt_conn *conn)
 
 #define OPUS_PREFIX_LENGTH 1
 #define OPUS_PADDED_LENGTH 80
-#define MAX_WRITE_SIZE 440
 static uint32_t offset = 0;
 static uint16_t buffer_offset = 0;
 
@@ -1180,12 +1179,12 @@ void pusher(void)
                 bt_conn_unref(conn);
             } else if (!conn) {
 #ifdef CONFIG_OMI_ENABLE_OFFLINE_STORAGE
-                if (get_file_size() < MAX_STORAGE_BYTES && is_sd_on()) {
+                if (is_sd_on()) {
                     storage_full_warned = false;
                     write_to_storage();
                 } else {
                     if (!storage_full_warned) {
-                        LOG_WRN("Storage full, stopping offline storage");
+                        LOG_WRN("Offline storage unavailable");
                         storage_full_warned = true;
                     }
                 }

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -63,6 +63,7 @@ struct raw_batch_header {
 
 struct read_resp {
     struct k_sem sem;
+    atomic_t *busy_flag;
     int res;
     uint32_t bytes_read;
     uint32_t packets_read;
@@ -70,14 +71,23 @@ struct read_resp {
 
 struct status_resp {
     struct k_sem sem;
+    atomic_t *busy_flag;
     int res;
 };
 
 struct info_resp {
     struct k_sem sem;
+    atomic_t *busy_flag;
     int res;
     sd_ring_info_t info;
 };
+
+static void release_resp_busy(atomic_t *busy_flag)
+{
+    if (busy_flag) {
+        atomic_clear(busy_flag);
+    }
+}
 
 typedef enum {
     REQ_WRITE_DATA,
@@ -150,8 +160,11 @@ static uint8_t batch_read_buffer[RAW_BATCH_BYTES];
 static uint8_t sector_buffer[DISK_SECTOR_SIZE];
 static uint16_t current_batch_packets;
 static uint64_t current_batch_base_seq;
+static uint64_t cached_read_batch_base_seq = UINT64_MAX;
+static struct raw_batch_header cached_read_batch_header;
 static bool current_batch_loaded;
 static bool current_batch_dirty;
+static bool cached_read_batch_valid;
 static int64_t last_batch_activity_ms;
 static uint8_t writing_error_counter;
 
@@ -166,6 +179,12 @@ static uint32_t compat_saved_offset;
 static void sd_worker_thread(void);
 static void sd_set_io_low_power(bool enable);
 static int flush_current_batch(bool sync_media);
+
+static void invalidate_read_batch_cache(void)
+{
+    cached_read_batch_valid = false;
+    cached_read_batch_base_seq = UINT64_MAX;
+}
 
 static bool pm_action_is_unsupported(int ret)
 {
@@ -344,6 +363,14 @@ static int load_batch_for_seq(uint64_t seq, uint8_t *buffer, struct raw_batch_he
     }
 
     uint64_t base_seq = (seq / RAW_PACKETS_PER_BATCH) * RAW_PACKETS_PER_BATCH;
+    if (cached_read_batch_valid && cached_read_batch_base_seq == base_seq) {
+        if (buffer != batch_read_buffer) {
+            memcpy(buffer, batch_read_buffer, sizeof(batch_read_buffer));
+        }
+        *header = cached_read_batch_header;
+        return 0;
+    }
+
     uint32_t sector = batch_sector_for_base_seq(base_seq);
     int ret = disk_access_read(DISK_DRIVE_NAME, buffer, sector, RAW_BATCH_SECTORS);
     if (ret != 0) {
@@ -364,6 +391,13 @@ static int load_batch_for_seq(uint64_t seq, uint8_t *buffer, struct raw_batch_he
                 (unsigned long long)base_seq);
         return -EIO;
     }
+
+    if (buffer != batch_read_buffer) {
+        memcpy(batch_read_buffer, buffer, sizeof(batch_read_buffer));
+    }
+    cached_read_batch_base_seq = base_seq;
+    cached_read_batch_header = *header;
+    cached_read_batch_valid = true;
 
     return 0;
 }
@@ -455,6 +489,7 @@ static int flush_current_batch(bool sync_requested)
     }
 
     current_batch_dirty = false;
+    invalidate_read_batch_cache();
     writing_error_counter = 0;
 
     if (current_batch_packets >= RAW_PACKETS_PER_BATCH) {
@@ -472,6 +507,7 @@ static int clear_ring_internal(bool sync_requested)
     compat_current_name[0] = '\0';
     compat_saved_name[0] = '\0';
     compat_saved_offset = 0;
+    invalidate_read_batch_cache();
     start_empty_batch(0);
 
     int ret = persist_ring_metadata();
@@ -904,6 +940,7 @@ handle_req:
                 req.u.info.resp->info = ring_state;
                 req.u.info.resp->res = 0;
                 k_sem_give(&req.u.info.resp->sem);
+                release_resp_busy(req.u.info.resp->busy_flag);
             }
             break;
 
@@ -915,6 +952,7 @@ handle_req:
                                                              &req.u.read.resp->bytes_read,
                                                              &req.u.read.resp->packets_read);
                 k_sem_give(&req.u.read.resp->sem);
+                release_resp_busy(req.u.read.resp->busy_flag);
             }
             break;
 
@@ -922,6 +960,7 @@ handle_req:
             if (req.u.advance.resp) {
                 req.u.advance.resp->res = advance_read_seq_internal(req.u.advance.new_read_seq, false);
                 k_sem_give(&req.u.advance.resp->sem);
+                release_resp_busy(req.u.advance.resp->busy_flag);
             }
             break;
 
@@ -929,6 +968,7 @@ handle_req:
             if (req.u.status.resp) {
                 req.u.status.resp->res = clear_ring_internal(false);
                 k_sem_give(&req.u.status.resp->sem);
+                release_resp_busy(req.u.status.resp->busy_flag);
             }
             break;
 
@@ -936,6 +976,7 @@ handle_req:
             if (req.u.status.resp) {
                 req.u.status.resp->res = flush_current_batch(true);
                 k_sem_give(&req.u.status.resp->sem);
+                release_resp_busy(req.u.status.resp->busy_flag);
             } else {
                 (void)flush_current_batch(true);
             }
@@ -947,6 +988,7 @@ handle_req:
             if (req.u.status.resp) {
                 req.u.status.resp->res = res;
                 k_sem_give(&req.u.status.resp->sem);
+                release_resp_busy(req.u.status.resp->busy_flag);
             }
             break;
         }
@@ -986,6 +1028,7 @@ int app_sd_off(void)
     if (is_mounted && sd_worker_tid) {
         struct status_resp resp;
         k_sem_init(&resp.sem, 0, 1);
+        resp.busy_flag = NULL;
         resp.res = 0;
 
         sd_req_t req = {0};
@@ -1117,17 +1160,14 @@ int sd_ring_get_info(sd_ring_info_t *info)
     }
 
     static struct info_resp resp;
-    static volatile bool info_in_flight;
+    static atomic_t info_in_flight = ATOMIC_INIT(0);
 
-    if (info_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
-            return -EBUSY;
-        }
-        info_in_flight = false;
+    if (!atomic_cas(&info_in_flight, 0, 1)) {
+        return -EBUSY;
     }
 
-    info_in_flight = true;
     k_sem_init(&resp.sem, 0, 1);
+    resp.busy_flag = &info_in_flight;
 
     sd_req_t req = {0};
     req.type = REQ_GET_RING_INFO;
@@ -1135,7 +1175,8 @@ int sd_ring_get_info(sd_ring_info_t *info)
 
     int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
-        info_in_flight = false;
+        resp.busy_flag = NULL;
+        atomic_clear(&info_in_flight);
         return ret;
     }
 
@@ -1143,7 +1184,6 @@ int sd_ring_get_info(sd_ring_info_t *info)
         return -ETIMEDOUT;
     }
 
-    info_in_flight = false;
     *info = resp.info;
     return resp.res;
 }
@@ -1159,17 +1199,14 @@ int sd_ring_read(uint64_t start_seq,
     }
 
     static struct read_resp resp;
-    static volatile bool read_in_flight;
+    static atomic_t read_in_flight = ATOMIC_INIT(0);
 
-    if (read_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
-            return -EBUSY;
-        }
-        read_in_flight = false;
+    if (!atomic_cas(&read_in_flight, 0, 1)) {
+        return -EBUSY;
     }
 
-    read_in_flight = true;
     k_sem_init(&resp.sem, 0, 1);
+    resp.busy_flag = &read_in_flight;
     resp.bytes_read = 0;
     resp.packets_read = 0;
 
@@ -1182,7 +1219,8 @@ int sd_ring_read(uint64_t start_seq,
 
     int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
-        read_in_flight = false;
+        resp.busy_flag = NULL;
+        atomic_clear(&read_in_flight);
         return ret;
     }
 
@@ -1190,7 +1228,6 @@ int sd_ring_read(uint64_t start_seq,
         return -ETIMEDOUT;
     }
 
-    read_in_flight = false;
     *bytes_read = resp.bytes_read;
     *packets_read = resp.packets_read;
     return resp.res;
@@ -1199,17 +1236,14 @@ int sd_ring_read(uint64_t start_seq,
 int sd_ring_advance(uint64_t new_read_seq)
 {
     static struct status_resp resp;
-    static volatile bool advance_in_flight;
+    static atomic_t advance_in_flight = ATOMIC_INIT(0);
 
-    if (advance_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
-            return -EBUSY;
-        }
-        advance_in_flight = false;
+    if (!atomic_cas(&advance_in_flight, 0, 1)) {
+        return -EBUSY;
     }
 
-    advance_in_flight = true;
     k_sem_init(&resp.sem, 0, 1);
+    resp.busy_flag = &advance_in_flight;
 
     sd_req_t req = {0};
     req.type = REQ_ADVANCE_READ;
@@ -1218,7 +1252,8 @@ int sd_ring_advance(uint64_t new_read_seq)
 
     int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
-        advance_in_flight = false;
+        resp.busy_flag = NULL;
+        atomic_clear(&advance_in_flight);
         return ret;
     }
 
@@ -1226,24 +1261,20 @@ int sd_ring_advance(uint64_t new_read_seq)
         return -ETIMEDOUT;
     }
 
-    advance_in_flight = false;
     return resp.res;
 }
 
 int sd_ring_clear(void)
 {
     static struct status_resp resp;
-    static volatile bool clear_in_flight;
+    static atomic_t clear_in_flight = ATOMIC_INIT(0);
 
-    if (clear_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
-            return -EBUSY;
-        }
-        clear_in_flight = false;
+    if (!atomic_cas(&clear_in_flight, 0, 1)) {
+        return -EBUSY;
     }
 
-    clear_in_flight = true;
     k_sem_init(&resp.sem, 0, 1);
+    resp.busy_flag = &clear_in_flight;
 
     sd_req_t req = {0};
     req.type = REQ_CLEAR_RING;
@@ -1251,7 +1282,8 @@ int sd_ring_clear(void)
 
     int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
-        clear_in_flight = false;
+        resp.busy_flag = NULL;
+        atomic_clear(&clear_in_flight);
         return ret;
     }
 
@@ -1259,24 +1291,20 @@ int sd_ring_clear(void)
         return -ETIMEDOUT;
     }
 
-    clear_in_flight = false;
     return resp.res;
 }
 
 int sd_flush_current_file(void)
 {
     static struct status_resp resp;
-    static volatile bool flush_in_flight;
+    static atomic_t flush_in_flight = ATOMIC_INIT(0);
 
-    if (flush_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
-            return -EBUSY;
-        }
-        flush_in_flight = false;
+    if (!atomic_cas(&flush_in_flight, 0, 1)) {
+        return -EBUSY;
     }
 
-    flush_in_flight = true;
     k_sem_init(&resp.sem, 0, 1);
+    resp.busy_flag = &flush_in_flight;
 
     sd_req_t req = {0};
     req.type = REQ_FLUSH;
@@ -1284,7 +1312,8 @@ int sd_flush_current_file(void)
 
     int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
-        flush_in_flight = false;
+        resp.busy_flag = NULL;
+        atomic_clear(&flush_in_flight);
         return ret;
     }
 
@@ -1292,7 +1321,6 @@ int sd_flush_current_file(void)
         return -ETIMEDOUT;
     }
 
-    flush_in_flight = false;
     return resp.res;
 }
 

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -694,9 +694,7 @@ static void drain_pending_write_queue_for_shutdown(void)
 
 static void sd_set_io_low_power(bool enable)
 {
-    const struct device *spi_dev = DEVICE_DT_GET(DT_NODELABEL(spi3));
-
-    if (!sd_enabled || !device_is_ready(spi_dev)) {
+    if (!sd_enabled) {
         return;
     }
 
@@ -705,6 +703,7 @@ static void sd_set_io_low_power(bool enable)
             return;
         }
 
+        /* spi3 is shared with OTA external flash; only suspend the SD slot itself. */
         int ret_sd = 0;
         if (atomic_get(&sd_dev_pm_supported)) {
             ret_sd = pm_device_action_run(sd_dev, PM_DEVICE_ACTION_SUSPEND);
@@ -712,16 +711,14 @@ static void sd_set_io_low_power(bool enable)
                 atomic_set(&sd_dev_pm_supported, 0);
             }
         }
-        int ret_spi = pm_device_action_run(spi_dev, PM_DEVICE_ACTION_SUSPEND);
-        if (!pm_action_is_ok(ret_sd) || !pm_action_is_ok(ret_spi)) {
-            LOG_WRN("SD suspend failed (sd=%d spi=%d)", ret_sd, ret_spi);
+        if (!pm_action_is_ok(ret_sd)) {
+            LOG_WRN("SD suspend failed (sd=%d)", ret_sd);
         }
     } else {
         if (!atomic_cas(&sd_io_low_power, 1, 0)) {
             return;
         }
 
-        int ret_spi = pm_device_action_run(spi_dev, PM_DEVICE_ACTION_RESUME);
         int ret_sd = 0;
         if (atomic_get(&sd_dev_pm_supported)) {
             ret_sd = pm_device_action_run(sd_dev, PM_DEVICE_ACTION_RESUME);
@@ -729,8 +726,8 @@ static void sd_set_io_low_power(bool enable)
                 atomic_set(&sd_dev_pm_supported, 0);
             }
         }
-        if (!pm_action_is_ok(ret_sd) || !pm_action_is_ok(ret_spi)) {
-            LOG_WRN("SD resume failed (sd=%d spi=%d)", ret_sd, ret_spi);
+        if (!pm_action_is_ok(ret_sd)) {
+            LOG_WRN("SD resume failed (sd=%d)", ret_sd);
         }
     }
 }
@@ -739,30 +736,29 @@ static int sd_enable_power(bool enable)
 {
     int ret;
     gpio_pin_configure_dt(&sd_en, GPIO_OUTPUT);
-    const struct device *spi_dev = DEVICE_DT_GET(DT_NODELABEL(spi3));
 
     if (enable) {
         ret = gpio_pin_set_dt(&sd_en, 1);
-        if (device_is_ready(spi_dev)) {
-            pm_device_action_run(spi_dev, PM_DEVICE_ACTION_RESUME);
-            if (atomic_get(&sd_dev_pm_supported)) {
-                int ret_sd = pm_device_action_run(sd_dev, PM_DEVICE_ACTION_RESUME);
-                if (pm_action_is_unsupported(ret_sd)) {
-                    atomic_set(&sd_dev_pm_supported, 0);
-                }
+        if (atomic_get(&sd_dev_pm_supported)) {
+            int ret_sd = pm_device_action_run(sd_dev, PM_DEVICE_ACTION_RESUME);
+            if (pm_action_is_unsupported(ret_sd)) {
+                atomic_set(&sd_dev_pm_supported, 0);
+            }
+            if (!pm_action_is_ok(ret_sd)) {
+                LOG_WRN("SD power-on resume failed (sd=%d)", ret_sd);
             }
         }
         atomic_set(&sd_io_low_power, 0);
         sd_enabled = true;
     } else {
-        if (device_is_ready(spi_dev)) {
-            if (atomic_get(&sd_dev_pm_supported)) {
-                int ret_sd = pm_device_action_run(sd_dev, PM_DEVICE_ACTION_SUSPEND);
-                if (pm_action_is_unsupported(ret_sd)) {
-                    atomic_set(&sd_dev_pm_supported, 0);
-                }
+        if (atomic_get(&sd_dev_pm_supported)) {
+            int ret_sd = pm_device_action_run(sd_dev, PM_DEVICE_ACTION_SUSPEND);
+            if (pm_action_is_unsupported(ret_sd)) {
+                atomic_set(&sd_dev_pm_supported, 0);
             }
-            pm_device_action_run(spi_dev, PM_DEVICE_ACTION_SUSPEND);
+            if (!pm_action_is_ok(ret_sd)) {
+                LOG_WRN("SD power-off suspend failed (sd=%d)", ret_sd);
+            }
         }
         gpio_pin_configure(DEVICE_DT_GET(DT_NODELABEL(gpio1)), 11, GPIO_DISCONNECTED);
         ret = gpio_pin_set_dt(&sd_en, 0);

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -1053,6 +1053,14 @@ int app_sd_off(void)
             sd_enable_power(false);
         }
         sd_enabled = false;
+
+        const struct device *spi_dev = DEVICE_DT_GET(DT_NODELABEL(spi3));
+        if (device_is_ready(spi_dev)) {
+            int ret = pm_device_action_run(spi_dev, PM_DEVICE_ACTION_SUSPEND);
+            if (ret < 0 && ret != -EALREADY && ret != -ENOSYS && ret != -ENOTSUP) {
+                LOG_WRN("SPI3 shutdown suspend failed: %d", ret);
+            }
+        }
     }
 
     return 0;

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -843,27 +843,16 @@ static int sd_unmount(void)
     return 0;
 }
 
-static int get_oldest_packet_name(char *buf, size_t buf_size)
+static int get_packet_name_for_seq(uint64_t seq, char *buf, size_t buf_size)
 {
     if (!buf || buf_size == 0U) {
         return -EINVAL;
     }
 
-    sd_ring_info_t info;
-    int ret = sd_ring_get_info(&info);
-    if (ret < 0) {
-        return ret;
-    }
-
-    if (info.read_seq == info.write_seq) {
-        buf[0] = '\0';
-        return 0;
-    }
-
     uint8_t packet[RAW_AUDIO_PACKET_BYTES];
     uint32_t bytes_read = 0;
     uint32_t packets_read = 0;
-    ret = sd_ring_read(info.read_seq, packet, sizeof(packet), &bytes_read, &packets_read);
+    int ret = sd_ring_read(seq, packet, sizeof(packet), &bytes_read, &packets_read);
     if (ret < 0 || packets_read == 0U) {
         return (ret < 0) ? ret : -ENOENT;
     }
@@ -1403,29 +1392,36 @@ int get_audio_file_list_with_sizes(char filenames[][MAX_FILENAME_LEN], uint32_t 
         return -EINVAL;
     }
 
-    sd_ring_info_t info;
-    int ret = sd_ring_get_info(&info);
-    if (ret < 0) {
-        return ret;
-    }
+    for (int attempt = 0; attempt < 3; attempt++) {
+        sd_ring_info_t info;
+        int ret = sd_ring_get_info(&info);
+        if (ret < 0) {
+            return ret;
+        }
 
-    if (info.read_seq == info.write_seq) {
-        *count = 0;
+        if (info.read_seq == info.write_seq) {
+            *count = 0;
+            return 0;
+        }
+
+        ret = get_packet_name_for_seq(info.read_seq, filenames[0], MAX_FILENAME_LEN);
+        if (ret == -ERANGE) {
+            continue;
+        }
+        if (ret < 0) {
+            return ret;
+        }
+
+        if (sizes) {
+            uint64_t used = (info.write_seq - info.read_seq) * RAW_AUDIO_PACKET_BYTES;
+            sizes[0] = (used > UINT32_MAX) ? UINT32_MAX : (uint32_t)used;
+        }
+
+        *count = 1;
         return 0;
     }
 
-    ret = get_oldest_packet_name(filenames[0], MAX_FILENAME_LEN);
-    if (ret < 0) {
-        return ret;
-    }
-
-    if (sizes) {
-        uint64_t used = (info.write_seq - info.read_seq) * RAW_AUDIO_PACKET_BYTES;
-        sizes[0] = (used > UINT32_MAX) ? UINT32_MAX : (uint32_t)used;
-    }
-
-    *count = 1;
-    return 0;
+    return -EAGAIN;
 }
 
 int delete_audio_file(const char *filename)

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -1,24 +1,8 @@
-/*
- * sd_card.c â€” LittleFS over disk_access (SD NAND via SPI SD protocol)
- *
- * Architecture:
- *   SD NAND chip â†’ SD SPI stack (disk_access) â†’ LittleFS block callbacks
- *
- * Why LittleFS instead of FATFS:
- *   - Copy-on-write metadata: filesystem is always consistent after power loss
- *   - No "dirty bit" that causes FATFS to refuse writes after ungraceful shutdown
- *   - Journaling: data integrity without complex recovery code
- *   - SD card handles erase internally â†’ erase callback is a no-op
- *   - SD card has internal wear leveling â†’ block_cycles = -1
- */
 #include "lib/core/sd_card.h"
 
-#include <ctype.h>
 #include <errno.h>
-#include <lfs.h>
-#include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
@@ -26,300 +10,620 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/storage/disk_access.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
 #include "rtc.h"
 
 LOG_MODULE_REGISTER(sd_card, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define DISK_DRIVE_NAME CONFIG_SDMMC_VOLUME_NAME
+#define DISK_SECTOR_SIZE 512U
+
 #define SD_REQ_QUEUE_MSGS 100
-#define SD_FSYNC_INTERVAL_MS (60 * 1000)
-#define WRITE_BATCH_COUNT 100
+#define SD_PRIO_QUEUE_MSGS 10
 #define WRITE_DRAIN_BURST 16
+
+#define RAW_META_SECTORS 64U
+#define RAW_BATCH_SECTORS 32U
+#define RAW_BATCH_BYTES (RAW_BATCH_SECTORS * DISK_SECTOR_SIZE)
+#define RAW_BATCH_HEADER_BYTES 32U
+#define RAW_PACKETS_PER_BATCH ((RAW_BATCH_BYTES - RAW_BATCH_HEADER_BYTES) / RAW_AUDIO_PACKET_BYTES)
+#define RAW_FLUSH_INTERVAL_MS 1000
+
+#define RAW_META_MAGIC 0x4F4D4952U
+#define RAW_BATCH_MAGIC 0x4F4D4942U
+#define RAW_LAYOUT_VERSION 1U
+
 #define ERROR_THRESHOLD 5
-#define FILE_CACHE_TTL_MS (30 * 1000)
-#define BOOT_MIN_AUDIO_FILE_SIZE 10000
 
-/* LittleFS paths are relative to FS root (no mount-point prefix) */
-#define FILE_DATA_DIR "audio"
-#define FILE_INFO_PATH "info.txt"
+BUILD_ASSERT((RAW_BATCH_HEADER_BYTES + RAW_PACKETS_PER_BATCH * RAW_AUDIO_PACKET_BYTES) <= RAW_BATCH_BYTES,
+             "raw batch layout exceeds batch size");
 
-/* ------------------------------------------------------------------ */
-/* LittleFS state                                                     */
-/* ------------------------------------------------------------------ */
-
-/* Raw LFS instance */
-static lfs_t lfs_fs;
-
-/* Open file handles */
-static lfs_file_t lfs_fil_data;
-static lfs_file_t lfs_fil_info;
-
-/* Static buffers for lfs_file_opencfg (avoids heap allocation)
- * Size must match cache_size (LFS_CACHE_SIZE = 4096). */
-static uint8_t lfs_fdata_buf[4096];
-static uint8_t lfs_finfo_buf[4096];
-static struct lfs_file_config lfs_fdata_cfg = {.buffer = lfs_fdata_buf};
-static struct lfs_file_config lfs_finfo_cfg = {.buffer = lfs_finfo_buf};
-
-/* LFS I/O buffers — sized to cache_size (4096) for multi-sector I/O */
-static uint8_t lfs_read_buf[4096];
-static uint8_t lfs_prog_buf[4096];
-/* Lookahead buffer sizing:
- * 128 bytes = 1024 blocks = 4 MB window → too small for 512 MB SD (128K blocks).
- * Every time the window is exhausted, LFS triggers a FULL filesystem traversal
- * (lfs_alloc_scan → lfs_fs_traverse_) which reads every block in every file.
- * With 200 MB of data (~50K blocks) this costs 10-50+ seconds per scan over SPI.
- *
- * 2048 bytes = 16384 blocks = 64 MB window → only ~8 scans to cover entire disk.
- * Reduces scan frequency from every ~4 MB written to every ~64 MB written.
- * Cost: 1920 bytes extra static RAM (nRF52840 has 256 KB). */
-#define LFS_LOOKAHEAD_SIZE 2048
-static uint8_t lfs_lookahead_buf[LFS_LOOKAHEAD_SIZE];
-
-/* Shared temp sector buffer â€” only used from worker thread, safe as static */
-static uint8_t _lfs_io_tmp[512];
-
-/* ------------------------------------------------------------------ */
-/* Disk sector size (always 512 for SD) */
-#define DISK_SECTOR_SIZE 512
-/* LFS block size: groups 8 sectors into one LFS block.
- * With 512-byte blocks, a 512 MB SD has 1M blocks and LFS metadata overhead
- * is enormous (CTZ skip-lists, lookahead scans).  4096-byte blocks reduce
- * the block count to ~128K and cut metadata overhead by ~8x. */
-#define LFS_BLOCK_SIZE 4096
-#define LFS_CACHE_SIZE LFS_BLOCK_SIZE                         /* cache = 1 full block for multi-sector I/O */
-#define SECTORS_PER_BLOCK (LFS_BLOCK_SIZE / DISK_SECTOR_SIZE) /* 8 */
-/* LittleFS disk_access callbacks                                      */
-/* ------------------------------------------------------------------ */
-
-/*
- * Map LFS (block, offset) to disk sector.
- *   LFS block N at byte offset K  →  disk sector  N * SECTORS_PER_BLOCK + K/512
- * With cache_size == 4096 (== block_size), LFS typically calls us with
- * size == 4096 and off == 0.  The fast path handles any aligned multi-sector
- * read in a single disk_access call (CMD18 multi-block read).
- */
-static int lfs_disk_read_cb(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size)
-{
-    (void) c;
-    uint32_t sector = (uint32_t) block * SECTORS_PER_BLOCK + off / DISK_SECTOR_SIZE;
-    uint32_t sec_off = off % DISK_SECTOR_SIZE;
-
-    /* Fast path: aligned multi-sector read (the common case with cache_size=4096) */
-    if (sec_off == 0 && (size % DISK_SECTOR_SIZE) == 0) {
-        uint32_t nsec = size / DISK_SECTOR_SIZE;
-        return disk_access_read(DISK_DRIVE_NAME, buffer, sector, nsec) == 0 ? LFS_ERR_OK : LFS_ERR_IO;
-    }
-    /* Generic path: partial / unaligned */
-    uint8_t *dst = (uint8_t *) buffer;
-    while (size > 0) {
-        if (disk_access_read(DISK_DRIVE_NAME, _lfs_io_tmp, sector, 1) != 0)
-            return LFS_ERR_IO;
-        lfs_size_t chunk = DISK_SECTOR_SIZE - sec_off;
-        if (chunk > size)
-            chunk = size;
-        memcpy(dst, _lfs_io_tmp + sec_off, chunk);
-        dst += chunk;
-        size -= chunk;
-        sec_off = 0;
-        sector++;
-    }
-    return LFS_ERR_OK;
-}
-
-static int
-lfs_disk_prog_cb(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size)
-{
-    (void) c;
-    uint32_t sector = (uint32_t) block * SECTORS_PER_BLOCK + off / DISK_SECTOR_SIZE;
-    uint32_t sec_off = off % DISK_SECTOR_SIZE;
-
-    /* Fast path: aligned multi-sector write (CMD25 multi-block write) */
-    if (sec_off == 0 && (size % DISK_SECTOR_SIZE) == 0) {
-        uint32_t nsec = size / DISK_SECTOR_SIZE;
-        return disk_access_write(DISK_DRIVE_NAME, buffer, sector, nsec) == 0 ? LFS_ERR_OK : LFS_ERR_IO;
-    }
-    /* Generic path: read-modify-write per sector */
-    const uint8_t *src = (const uint8_t *) buffer;
-    while (size > 0) {
-        if (disk_access_read(DISK_DRIVE_NAME, _lfs_io_tmp, sector, 1) != 0)
-            return LFS_ERR_IO;
-        lfs_size_t chunk = DISK_SECTOR_SIZE - sec_off;
-        if (chunk > size)
-            chunk = size;
-        memcpy(_lfs_io_tmp + sec_off, src, chunk);
-        if (disk_access_write(DISK_DRIVE_NAME, _lfs_io_tmp, sector, 1) != 0)
-            return LFS_ERR_IO;
-        src += chunk;
-        size -= chunk;
-        sec_off = 0;
-        sector++;
-    }
-    return LFS_ERR_OK;
-}
-
-static int lfs_disk_erase_cb(const struct lfs_config *c, lfs_block_t block)
-{
-    /* SD card erases blocks internally on write â€” this is a true no-op. */
-    (void) c;
-    (void) block;
-    return LFS_ERR_OK;
-}
-
-static int lfs_disk_sync_cb(const struct lfs_config *c)
-{
-    (void) c;
-    (void) disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_CTRL_SYNC, NULL);
-    return LFS_ERR_OK;
-}
-
-/* LFS config â€” block_count filled at runtime from DISK_IOCTL_GET_SECTOR_COUNT */
-static struct lfs_config lfs_cfg = {
-    .read = lfs_disk_read_cb,
-    .prog = lfs_disk_prog_cb,
-    .erase = lfs_disk_erase_cb,
-    .sync = lfs_disk_sync_cb,
-
-    .read_size = DISK_SECTOR_SIZE,
-    .prog_size = DISK_SECTOR_SIZE,
-    .block_size = LFS_BLOCK_SIZE,
-    .block_count = 0,                     /* set at mount time */
-    .cache_size = LFS_CACHE_SIZE,         /* 4096: full-block cache → multi-sector I/O */
-    .lookahead_size = LFS_LOOKAHEAD_SIZE, /* 2048 bytes = 16384 blocks = 64 MB window */
-
-    .read_buffer = lfs_read_buf,
-    .prog_buffer = lfs_prog_buf,
-    .lookahead_buffer = lfs_lookahead_buf,
-
-    /* SD card has internal wear leveling â†’ disable LFS wear leveling */
-    .block_cycles = -1,
-
-#if LFS_VERSION >= 0x00020009
-    /* Disable metadata compaction during lfs_fs_gc() -- we only want
-     * the allocator pre-warm (lookahead scan), not expensive compaction.
-     * compact_thresh was added in LFS 2.9. */
-    .compact_thresh = (lfs_size_t) -1,
-#endif
+struct raw_meta_record {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t reserved0;
+    uint64_t generation;
+    uint64_t read_seq;
+    uint64_t write_seq;
+    uint64_t dropped_packets;
+    uint32_t reserved1;
 };
 
-/* ------------------------------------------------------------------ */
-/* Batch write buffer & general state                                  */
-/* ------------------------------------------------------------------ */
+struct raw_batch_header {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t packet_count;
+    uint64_t generation;
+    uint64_t start_seq;
+    uint32_t reserved0;
+    uint32_t reserved1;
+};
 
-static uint8_t write_batch_buffer[WRITE_BATCH_COUNT * MAX_WRITE_SIZE];
-static size_t write_batch_offset = 0;
-static int write_batch_counter = 0;
-static uint8_t writing_error_counter = 0;
-static bool sd_write_blocked = false;
-static int64_t last_write_blocked_log_ms = 0;
-static uint32_t write_drop_packets = 0;
-static uint32_t write_drop_bytes = 0;
+struct read_resp {
+    struct k_sem sem;
+    int res;
+    uint32_t bytes_read;
+    uint32_t packets_read;
+};
 
-/* SD boot readiness gate: cleared during init, set after pre-warm + file open.
- * write_to_file() silently discards data while this is 0, preventing the message
- * queue from filling up while lfs_fs_gc() is running on the worker thread. */
-static atomic_t sd_boot_ready;
+struct status_resp {
+    struct k_sem sem;
+    int res;
+};
 
-/* Deferred control requests when prio queue is temporarily saturated */
-static atomic_t pending_flush_on_ble_connect;
-static atomic_t pending_time_synced;
-static uint32_t pending_time_synced_utc = 0;
+struct info_resp {
+    struct k_sem sem;
+    int res;
+    sd_ring_info_t info;
+};
 
-static bool is_mounted = false;
-static bool sd_enabled = false;
-static bool sd_shutdown_in_progress = false;
-static atomic_t sd_io_low_power = ATOMIC_INIT(0);
-/* 1: supported/unknown, 0: unsupported (ENOSYS/ENOTSUP observed) */
-static atomic_t sd_dev_pm_supported = ATOMIC_INIT(1);
-static uint32_t current_file_size = 0;
-static size_t bytes_since_sync = 0;
-static int64_t last_file_sync_uptime_ms = 0;
+typedef enum {
+    REQ_WRITE_DATA,
+    REQ_GET_RING_INFO,
+    REQ_READ_PACKETS,
+    REQ_ADVANCE_READ,
+    REQ_CLEAR_RING,
+    REQ_FLUSH,
+    REQ_UNMOUNT,
+} sd_req_type_t;
 
-/* Current writing file info */
-static char current_filename[MAX_FILENAME_LEN] = {0};
-static char current_file_path[64] = {0};
-static int64_t current_file_created_uptime_ms = 0;
-static bool current_file_needs_rename = false;
-static bool deferred_timesync_rename_pending = false;
-static uint32_t deferred_timesync_utc_time = 0;
-static uint32_t cached_stats_file_count = 0;
-static uint64_t cached_stats_total_size = 0;
-static int64_t cached_stats_valid_until_ms = 0;
-static bool file_cache_valid = false;
-static int cached_file_list_count = 0;
-static uint32_t cached_total_file_count = 0;
-static uint64_t cached_total_file_size = 0;
-static char cached_file_names[MAX_AUDIO_FILES][MAX_FILENAME_LEN] = {0};
-static uint32_t cached_file_sizes[MAX_AUDIO_FILES] = {0};
+typedef struct {
+    sd_req_type_t type;
+    union {
+        struct {
+            uint8_t buf[MAX_WRITE_SIZE];
+            size_t len;
+        } write;
+        struct {
+            uint64_t start_seq;
+            uint32_t max_bytes;
+            uint8_t *out_buf;
+            struct read_resp *resp;
+        } read;
+        struct {
+            uint64_t new_read_seq;
+            struct status_resp *resp;
+        } advance;
+        struct {
+            struct info_resp *resp;
+        } info;
+        struct {
+            struct status_resp *resp;
+        } status;
+    } u;
+} sd_req_t;
 
-/* BLE connection tracking for file rotation */
-static bool ble_connected = false;
-static int64_t ble_connect_time_ms = 0;
-
-/* Track if active file was deleted while BLE connected */
-static bool current_file_deleted = false;
-
-/* Offset info (oldest file + byte offset) */
-static sd_offset_info_t current_offset_info = {0};
-
-/* Hardware device references */
 static const struct device *const sd_dev = DEVICE_DT_GET(DT_NODELABEL(sdhc0));
 static const struct gpio_dt_spec sd_en = GPIO_DT_SPEC_GET_OR(DT_NODELABEL(sdcard_en_pin), gpios, {0});
 
 K_MSGQ_DEFINE(sd_msgq, sizeof(sd_req_t), SD_REQ_QUEUE_MSGS, 4);
-
-/* Priority queue for reads, flushes, and control operations.
- * The worker checks this BEFORE the regular write queue, so reads
- * never wait behind 100 pending audio writes. */
-#define SD_PRIO_QUEUE_MSGS 10
 K_MSGQ_DEFINE(sd_prio_msgq, sizeof(sd_req_t), SD_PRIO_QUEUE_MSGS, 4);
 
-/* Persistent read file handle — kept open between read_audio_data calls
- * so we avoid the expensive LFS open/seek/close on every read.
- * With 512-byte blocks and a 1 MB+ file, an open+seek costs O(sqrt(N/512))
- * block reads (≈50 SPI transactions), making each read 100–300 ms.
- * Keeping the handle open reduces this to a simple sequential read (~5 ms). */
-static lfs_file_t lfs_read_handle;
-static uint8_t lfs_read_handle_buf[4096];
-static struct lfs_file_config lfs_read_handle_cfg = {.buffer = lfs_read_handle_buf};
-static char read_handle_filename[MAX_FILENAME_LEN] = {0};
-static bool read_handle_open = false;
-static lfs_soff_t read_handle_pos = 0;
+#define SD_WORKER_STACK_SIZE 8192
+#define SD_WORKER_PRIORITY 7
+K_THREAD_STACK_DEFINE(sd_worker_stack, SD_WORKER_STACK_SIZE);
+static struct k_thread sd_worker_thread_data;
+static k_tid_t sd_worker_tid;
 
-/* Sync generation: incremented every time lfs_fil_data is synced.
- * The read handle records which generation it was opened at;
- * if it doesn't match, the handle is stale (file grew) and must reopen. */
-static uint32_t data_sync_gen = 0;
-static uint32_t read_handle_gen = 0;
+static atomic_t sd_boot_ready;
+static atomic_t sd_io_low_power = ATOMIC_INIT(0);
+static atomic_t sd_dev_pm_supported = ATOMIC_INIT(1);
+static atomic_t pending_flush_on_ble_connect;
 
-/* Forward declarations */
-void sd_worker_thread(void);
-static void process_write_data_req(const sd_req_t *req);
-static int create_audio_file_with_timestamp(void);
-static int flush_batch_buffer(void);
-static bool should_rotate_file(void);
-static void build_file_path(const char *filename, char *path, size_t path_size);
-static void invalidate_file_cache(void);
-static void update_current_file_cache_size(uint32_t delta);
-static void sort_cached_file_entries(void);
+static bool is_mounted;
+static bool sd_enabled;
+static bool sd_shutdown_in_progress;
+static bool sd_write_blocked;
+static bool sd_write_paused;
+static bool ble_connected;
+
+static uint32_t disk_sector_count;
+static uint32_t data_batch_count;
+static uint32_t meta_next_slot;
+static uint64_t meta_generation;
+static sd_ring_info_t ring_state;
+
+static uint8_t current_batch[RAW_BATCH_BYTES];
+static uint8_t batch_read_buffer[RAW_BATCH_BYTES];
+static uint8_t sector_buffer[DISK_SECTOR_SIZE];
+static uint16_t current_batch_packets;
+static uint64_t current_batch_base_seq;
+static bool current_batch_loaded;
+static bool current_batch_dirty;
+static int64_t last_batch_activity_ms;
+static uint8_t writing_error_counter;
+
+static uint32_t write_drop_packets;
+static uint32_t write_drop_bytes;
+static int64_t last_write_blocked_log_ms;
+
+static char compat_current_name[MAX_FILENAME_LEN];
+static char compat_saved_name[MAX_FILENAME_LEN];
+static uint32_t compat_saved_offset;
+
+static void sd_worker_thread(void);
 static void sd_set_io_low_power(bool enable);
+static int flush_current_batch(bool sync_media);
 
-static void process_save_offset_req(const sd_req_t *req)
+static bool pm_action_is_unsupported(int ret)
 {
-    if (sd_write_blocked)
-        return;
+    return (ret == -ENOSYS || ret == -ENOTSUP);
+}
 
-    sd_set_io_low_power(false);
-    lfs_file_seek(&lfs_fs, &lfs_fil_info, 0, LFS_SEEK_SET);
-    lfs_ssize_t bw = lfs_file_write(&lfs_fs, &lfs_fil_info, &req->u.info.offset_info, sizeof(sd_offset_info_t));
-    if (bw == (lfs_ssize_t) sizeof(sd_offset_info_t)) {
-        lfs_file_sync(&lfs_fs, &lfs_fil_info);
-        memcpy(&current_offset_info, &req->u.info.offset_info, sizeof(sd_offset_info_t));
-    } else {
-        LOG_ERR("[SD_WORK] save offset write err %d", (int) bw);
+static bool pm_action_is_ok(int ret)
+{
+    return (ret == 0 || ret == -EALREADY || pm_action_is_unsupported(ret));
+}
+
+static void format_timestamp_name(uint32_t timestamp, char *buf, size_t buf_size)
+{
+    if (!buf || buf_size == 0U) {
+        return;
     }
-    sd_set_io_low_power(true);
+
+    snprintk(buf, buf_size, "%08X.txt", timestamp);
+}
+
+static uint64_t ring_used_packets(void)
+{
+    uint64_t committed = ring_state.write_seq - ring_state.read_seq;
+
+    if (!current_batch_loaded || current_batch_packets == 0U) {
+        return committed;
+    }
+
+    if (current_batch_base_seq + current_batch_packets <= ring_state.write_seq) {
+        return committed;
+    }
+
+    return committed + (current_batch_base_seq + current_batch_packets - ring_state.write_seq);
+}
+
+static uint64_t ring_used_bytes(void)
+{
+    return ring_used_packets() * RAW_AUDIO_PACKET_BYTES;
+}
+
+static uint32_t batch_sector_for_base_seq(uint64_t base_seq)
+{
+    uint64_t batch_index = base_seq / RAW_PACKETS_PER_BATCH;
+    uint32_t slot = (uint32_t)(batch_index % data_batch_count);
+    return RAW_META_SECTORS + (slot * RAW_BATCH_SECTORS);
+}
+
+static void start_empty_batch(uint64_t base_seq)
+{
+    memset(current_batch, 0, sizeof(current_batch));
+    current_batch_base_seq = base_seq;
+    current_batch_packets = 0;
+    current_batch_loaded = true;
+    current_batch_dirty = false;
+}
+
+static int sync_media(void)
+{
+    return disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_CTRL_SYNC, NULL);
+}
+
+static bool meta_record_valid(const struct raw_meta_record *record)
+{
+    if (!record) {
+        return false;
+    }
+
+    if (record->magic != RAW_META_MAGIC || record->version != RAW_LAYOUT_VERSION) {
+        return false;
+    }
+
+    if (record->write_seq < record->read_seq) {
+        return false;
+    }
+
+    if ((record->write_seq - record->read_seq) > ring_state.capacity_packets) {
+        return false;
+    }
+
+    return true;
+}
+
+static bool batch_header_valid(const struct raw_batch_header *header)
+{
+    if (!header) {
+        return false;
+    }
+
+    if (header->magic != RAW_BATCH_MAGIC || header->version != RAW_LAYOUT_VERSION) {
+        return false;
+    }
+
+    if (header->packet_count > RAW_PACKETS_PER_BATCH) {
+        return false;
+    }
+
+    if ((header->start_seq % RAW_PACKETS_PER_BATCH) != 0U) {
+        return false;
+    }
+
+    return true;
+}
+
+static int persist_ring_metadata(void)
+{
+    struct raw_meta_record record = {
+        .magic = RAW_META_MAGIC,
+        .version = RAW_LAYOUT_VERSION,
+        .generation = ++meta_generation,
+        .read_seq = ring_state.read_seq,
+        .write_seq = ring_state.write_seq,
+        .dropped_packets = ring_state.dropped_packets,
+    };
+
+    memset(sector_buffer, 0, sizeof(sector_buffer));
+    memcpy(sector_buffer, &record, sizeof(record));
+
+    int ret = disk_access_write(DISK_DRIVE_NAME, sector_buffer, meta_next_slot, 1);
+    if (ret != 0) {
+        LOG_ERR("metadata write failed at slot %u: %d", meta_next_slot, ret);
+        meta_generation--;
+        return -EIO;
+    }
+
+    meta_next_slot = (meta_next_slot + 1U) % RAW_META_SECTORS;
+    return 0;
+}
+
+static int load_ring_metadata(void)
+{
+    struct raw_meta_record best_record = {0};
+    bool found = false;
+    uint32_t best_slot = 0;
+
+    for (uint32_t slot = 0; slot < RAW_META_SECTORS; slot++) {
+        int ret = disk_access_read(DISK_DRIVE_NAME, sector_buffer, slot, 1);
+        if (ret != 0) {
+            LOG_WRN("metadata read failed at slot %u: %d", slot, ret);
+            continue;
+        }
+
+        struct raw_meta_record record;
+        memcpy(&record, sector_buffer, sizeof(record));
+        if (!meta_record_valid(&record)) {
+            continue;
+        }
+
+        if (!found || record.generation > best_record.generation) {
+            best_record = record;
+            best_slot = slot;
+            found = true;
+        }
+    }
+
+    if (!found) {
+        ring_state.read_seq = 0;
+        ring_state.write_seq = 0;
+        ring_state.dropped_packets = 0;
+        meta_generation = 0;
+        meta_next_slot = 0;
+        return persist_ring_metadata();
+    }
+
+    ring_state.read_seq = best_record.read_seq;
+    ring_state.write_seq = best_record.write_seq;
+    ring_state.dropped_packets = best_record.dropped_packets;
+    meta_generation = best_record.generation;
+    meta_next_slot = (best_slot + 1U) % RAW_META_SECTORS;
+    return 0;
+}
+
+static int load_batch_for_seq(uint64_t seq, uint8_t *buffer, struct raw_batch_header *header)
+{
+    if (!buffer || !header || data_batch_count == 0U) {
+        return -EINVAL;
+    }
+
+    uint64_t base_seq = (seq / RAW_PACKETS_PER_BATCH) * RAW_PACKETS_PER_BATCH;
+    uint32_t sector = batch_sector_for_base_seq(base_seq);
+    int ret = disk_access_read(DISK_DRIVE_NAME, buffer, sector, RAW_BATCH_SECTORS);
+    if (ret != 0) {
+        LOG_ERR("batch read failed at sector %u: %d", sector, ret);
+        return -EIO;
+    }
+
+    memcpy(header, buffer, sizeof(*header));
+    if (!batch_header_valid(header)) {
+        LOG_ERR("invalid batch header for seq %llu", (unsigned long long)seq);
+        return -EIO;
+    }
+
+    if (header->start_seq != base_seq) {
+        LOG_ERR("batch start mismatch for seq %llu: hdr=%llu base=%llu",
+                (unsigned long long)seq,
+                (unsigned long long)header->start_seq,
+                (unsigned long long)base_seq);
+        return -EIO;
+    }
+
+    return 0;
+}
+
+static int restore_tail_batch(void)
+{
+    uint32_t partial_packets = (uint32_t)(ring_state.write_seq % RAW_PACKETS_PER_BATCH);
+    if (partial_packets == 0U) {
+        start_empty_batch(ring_state.write_seq);
+        return 0;
+    }
+
+    uint64_t base_seq = ring_state.write_seq - partial_packets;
+    struct raw_batch_header header;
+    int ret = load_batch_for_seq(base_seq, current_batch, &header);
+    if (ret < 0) {
+        LOG_WRN("dropping incomplete tail batch after recovery error: %d", ret);
+        ring_state.write_seq = base_seq;
+        if (ring_state.read_seq > ring_state.write_seq) {
+            ring_state.read_seq = ring_state.write_seq;
+        }
+        (void)persist_ring_metadata();
+        start_empty_batch(ring_state.write_seq);
+        return ret;
+    }
+
+    if (header.packet_count != partial_packets) {
+        LOG_WRN("tail packet count mismatch, truncating tail from %u to %u",
+                partial_packets,
+                header.packet_count);
+        ring_state.write_seq = header.start_seq + header.packet_count;
+        if (ring_state.read_seq > ring_state.write_seq) {
+            ring_state.read_seq = ring_state.write_seq;
+        }
+        (void)persist_ring_metadata();
+    }
+
+    current_batch_base_seq = header.start_seq;
+    current_batch_packets = header.packet_count;
+    current_batch_loaded = true;
+    current_batch_dirty = false;
+    return 0;
+}
+
+static int flush_current_batch(bool sync_requested)
+{
+    if (!current_batch_loaded || !current_batch_dirty || current_batch_packets == 0U) {
+        if (sync_requested) {
+            (void)sync_media();
+        }
+        return 0;
+    }
+
+    struct raw_batch_header header = {
+        .magic = RAW_BATCH_MAGIC,
+        .version = RAW_LAYOUT_VERSION,
+        .packet_count = current_batch_packets,
+        .generation = meta_generation + 1U,
+        .start_seq = current_batch_base_seq,
+    };
+    memcpy(current_batch, &header, sizeof(header));
+
+    uint32_t sector = batch_sector_for_base_seq(current_batch_base_seq);
+    int ret = disk_access_write(DISK_DRIVE_NAME, current_batch, sector, RAW_BATCH_SECTORS);
+    if (ret != 0) {
+        writing_error_counter++;
+        LOG_ERR("batch write failed at sector %u: %d", sector, ret);
+        if (writing_error_counter > ERROR_THRESHOLD) {
+            sd_write_blocked = true;
+        }
+        return -EIO;
+    }
+
+    uint64_t new_write_seq = current_batch_base_seq + current_batch_packets;
+    if ((new_write_seq - ring_state.read_seq) > ring_state.capacity_packets) {
+        uint64_t overflow = (new_write_seq - ring_state.read_seq) - ring_state.capacity_packets;
+        ring_state.read_seq += overflow;
+        ring_state.dropped_packets += overflow;
+    }
+    ring_state.write_seq = new_write_seq;
+
+    ret = persist_ring_metadata();
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (sync_requested) {
+        (void)sync_media();
+    }
+
+    current_batch_dirty = false;
+    writing_error_counter = 0;
+
+    if (current_batch_packets >= RAW_PACKETS_PER_BATCH) {
+        start_empty_batch(ring_state.write_seq);
+    }
+
+    return 0;
+}
+
+static int clear_ring_internal(bool sync_requested)
+{
+    ring_state.read_seq = 0;
+    ring_state.write_seq = 0;
+    ring_state.dropped_packets = 0;
+    compat_current_name[0] = '\0';
+    compat_saved_name[0] = '\0';
+    compat_saved_offset = 0;
+    start_empty_batch(0);
+
+    int ret = persist_ring_metadata();
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (sync_requested) {
+        (void)sync_media();
+    }
+
+    return 0;
+}
+
+static int read_packets_internal(uint64_t start_seq,
+                                 uint8_t *out_buf,
+                                 uint32_t max_bytes,
+                                 uint32_t *bytes_read,
+                                 uint32_t *packets_read)
+{
+    if (!out_buf || !bytes_read || !packets_read) {
+        return -EINVAL;
+    }
+
+    *bytes_read = 0;
+    *packets_read = 0;
+
+    if (!is_mounted) {
+        return -ENODEV;
+    }
+
+    if (current_batch_dirty) {
+        int flush_ret = flush_current_batch(false);
+        if (flush_ret < 0) {
+            return flush_ret;
+        }
+    }
+
+    if (start_seq < ring_state.read_seq || start_seq > ring_state.write_seq) {
+        return -ERANGE;
+    }
+
+    if (start_seq == ring_state.write_seq || max_bytes < RAW_AUDIO_PACKET_BYTES) {
+        return 0;
+    }
+
+    uint32_t max_packets = max_bytes / RAW_AUDIO_PACKET_BYTES;
+    uint64_t available_packets = ring_state.write_seq - start_seq;
+    if ((uint64_t)max_packets > available_packets) {
+        max_packets = (uint32_t)available_packets;
+    }
+
+    uint64_t seq = start_seq;
+    uint32_t copied_packets = 0;
+    uint64_t loaded_batch_base = UINT64_MAX;
+    struct raw_batch_header loaded_header = {0};
+
+    while (copied_packets < max_packets) {
+        uint64_t batch_base = (seq / RAW_PACKETS_PER_BATCH) * RAW_PACKETS_PER_BATCH;
+        if (batch_base != loaded_batch_base) {
+            int ret = load_batch_for_seq(seq, batch_read_buffer, &loaded_header);
+            if (ret < 0) {
+                return ret;
+            }
+            loaded_batch_base = batch_base;
+        }
+
+        uint32_t packet_offset = (uint32_t)(seq - loaded_header.start_seq);
+        if (packet_offset >= loaded_header.packet_count) {
+            return -EIO;
+        }
+
+        uint32_t remaining_in_batch = loaded_header.packet_count - packet_offset;
+        uint32_t copy_packets = MIN(max_packets - copied_packets, remaining_in_batch);
+        size_t src_offset = RAW_BATCH_HEADER_BYTES + ((size_t)packet_offset * RAW_AUDIO_PACKET_BYTES);
+        size_t copy_bytes = (size_t)copy_packets * RAW_AUDIO_PACKET_BYTES;
+        memcpy(out_buf + (*bytes_read), batch_read_buffer + src_offset, copy_bytes);
+
+        *bytes_read += (uint32_t)copy_bytes;
+        copied_packets += copy_packets;
+        seq += copy_packets;
+    }
+
+    *packets_read = copied_packets;
+    return 0;
+}
+
+static int advance_read_seq_internal(uint64_t new_read_seq, bool sync_requested)
+{
+    if (new_read_seq < ring_state.read_seq || new_read_seq > ring_state.write_seq) {
+        return -ERANGE;
+    }
+
+    if (new_read_seq == ring_state.read_seq) {
+        return 0;
+    }
+
+    ring_state.read_seq = new_read_seq;
+    int ret = persist_ring_metadata();
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (sync_requested) {
+        (void)sync_media();
+    }
+
+    return 0;
+}
+
+static void process_write_data_req(const sd_req_t *req)
+{
+    if (sd_write_blocked || sd_write_paused || !req) {
+        return;
+    }
+
+    if (req->u.write.len != MAX_WRITE_SIZE) {
+        LOG_WRN("unexpected write size %u", (unsigned)req->u.write.len);
+        return;
+    }
+
+    if (!rtc_is_valid()) {
+        return;
+    }
+
+    uint32_t timestamp = get_utc_time();
+    if (timestamp == 0U || timestamp < 1700000000U) {
+        return;
+    }
+
+    if (!current_batch_loaded) {
+        start_empty_batch(ring_state.write_seq);
+    }
+
+    if (current_batch_packets >= RAW_PACKETS_PER_BATCH) {
+        start_empty_batch(ring_state.write_seq);
+    }
+
+    size_t dst_offset = RAW_BATCH_HEADER_BYTES + ((size_t)current_batch_packets * RAW_AUDIO_PACKET_BYTES);
+    sys_put_be32(timestamp, current_batch + dst_offset);
+    memcpy(current_batch + dst_offset + RAW_AUDIO_TIMESTAMP_BYTES, req->u.write.buf, MAX_WRITE_SIZE);
+    current_batch_packets++;
+    current_batch_dirty = true;
+    last_batch_activity_ms = k_uptime_get();
+    format_timestamp_name(timestamp, compat_current_name, sizeof(compat_current_name));
+
+    bool queue_pressure_high = k_msgq_num_used_get(&sd_msgq) >= (SD_REQ_QUEUE_MSGS / 3);
+    if (current_batch_packets >= RAW_PACKETS_PER_BATCH || queue_pressure_high) {
+        sd_set_io_low_power(false);
+        (void)flush_current_batch(false);
+        sd_set_io_low_power(true);
+    }
 }
 
 static void drain_pending_write_queue_for_shutdown(void)
@@ -332,100 +636,8 @@ static void drain_pending_write_queue_for_shutdown(void)
 
         if (pending_req.type == REQ_WRITE_DATA) {
             process_write_data_req(&pending_req);
-        } else if (pending_req.type == REQ_SAVE_OFFSET) {
-            process_save_offset_req(&pending_req);
         }
     }
-}
-
-static void process_write_data_req(const sd_req_t *req)
-{
-    if (sd_write_blocked)
-        return;
-    if (current_file_deleted && ble_connected)
-        return;
-
-    /* Track whether we woke SPI for I/O in this call so we can
-     * suspend it once at the end — keeps SPI + SD card powered
-     * only during actual flash operations, not during the long
-     * batch-accumulation window between flushes. */
-    bool spi_woken = false;
-
-    if (current_filename[0] == '\0') {
-        sd_set_io_low_power(false);
-        spi_woken = true;
-        int res = create_audio_file_with_timestamp();
-        if (res < 0) {
-            sd_write_blocked = true;
-            goto done;
-        }
-    }
-
-    if (should_rotate_file()) {
-        LOG_INF("[SD_WORK] Rotating file after 30 min");
-        if (!spi_woken) { sd_set_io_low_power(false); spi_woken = true; }
-        flush_batch_buffer();
-        create_audio_file_with_timestamp();
-    }
-
-    if (write_batch_offset + req->u.write.len > sizeof(write_batch_buffer)) {
-        if (!spi_woken) { sd_set_io_low_power(false); spi_woken = true; }
-        flush_batch_buffer();
-        if (write_batch_offset + req->u.write.len > sizeof(write_batch_buffer)) {
-            LOG_ERR("[SD_WORK] batch buffer overflow guard len=%u off=%u",
-                    (unsigned) req->u.write.len,
-                    (unsigned) write_batch_offset);
-            goto done;
-        }
-    }
-
-    memcpy(write_batch_buffer + write_batch_offset, req->u.write.buf, req->u.write.len);
-    write_batch_offset += req->u.write.len;
-    write_batch_counter++;
-
-    int queued_writes = k_msgq_num_used_get(&sd_msgq);
-    bool queue_pressure_high = queued_writes >= (SD_REQ_QUEUE_MSGS / 3);
-
-    if (write_batch_counter >= WRITE_BATCH_COUNT || queue_pressure_high) {
-        if (!spi_woken) { sd_set_io_low_power(false); spi_woken = true; }
-        flush_batch_buffer();
-    }
-
-    bool sync_due_to_interval =
-        (bytes_since_sync > 0) && ((k_uptime_get() - last_file_sync_uptime_ms) >= SD_FSYNC_INTERVAL_MS);
-
-    if (sync_due_to_interval) {
-        if (!spi_woken) { sd_set_io_low_power(false); spi_woken = true; }
-        lfs_file_sync(&lfs_fs, &lfs_fil_data);
-        data_sync_gen++;
-        bytes_since_sync = 0;
-        last_file_sync_uptime_ms = k_uptime_get();
-    }
-
-done:
-    if (spi_woken) {
-        sd_set_io_low_power(true);
-    }
-}
-
-static void close_read_handle(void)
-{
-    if (read_handle_open) {
-        lfs_file_close(&lfs_fs, &lfs_read_handle);
-        read_handle_open = false;
-        read_handle_filename[0] = '\0';
-        read_handle_pos = 0;
-    }
-}
-
-static bool pm_action_is_unsupported(int ret)
-{
-    return (ret == -ENOSYS || ret == -ENOTSUP);
-}
-
-static bool pm_action_is_ok(int ret)
-{
-    return (ret == 0 || ret == -EALREADY || pm_action_is_unsupported(ret));
 }
 
 static void sd_set_io_low_power(bool enable)
@@ -446,12 +658,11 @@ static void sd_set_io_low_power(bool enable)
             ret_sd = pm_device_action_run(sd_dev, PM_DEVICE_ACTION_SUSPEND);
             if (pm_action_is_unsupported(ret_sd)) {
                 atomic_set(&sd_dev_pm_supported, 0);
-                LOG_INF("SD device PM suspend unsupported, keep using SPI PM only");
             }
         }
         int ret_spi = pm_device_action_run(spi_dev, PM_DEVICE_ACTION_SUSPEND);
         if (!pm_action_is_ok(ret_sd) || !pm_action_is_ok(ret_spi)) {
-            LOG_WRN("SD low-power suspend failed (sd=%d spi=%d)", ret_sd, ret_spi);
+            LOG_WRN("SD suspend failed (sd=%d spi=%d)", ret_sd, ret_spi);
         }
     } else {
         if (!atomic_cas(&sd_io_low_power, 1, 0)) {
@@ -464,24 +675,20 @@ static void sd_set_io_low_power(bool enable)
             ret_sd = pm_device_action_run(sd_dev, PM_DEVICE_ACTION_RESUME);
             if (pm_action_is_unsupported(ret_sd)) {
                 atomic_set(&sd_dev_pm_supported, 0);
-                LOG_INF("SD device PM resume unsupported, keep using SPI PM only");
             }
         }
         if (!pm_action_is_ok(ret_sd) || !pm_action_is_ok(ret_spi)) {
-            LOG_WRN("SD low-power resume failed (sd=%d spi=%d)", ret_sd, ret_spi);
+            LOG_WRN("SD resume failed (sd=%d spi=%d)", ret_sd, ret_spi);
         }
     }
 }
-
-/* ------------------------------------------------------------------ */
-/* Power management                                                    */
-/* ------------------------------------------------------------------ */
 
 static int sd_enable_power(bool enable)
 {
     int ret;
     gpio_pin_configure_dt(&sd_en, GPIO_OUTPUT);
     const struct device *spi_dev = DEVICE_DT_GET(DT_NODELABEL(spi3));
+
     if (enable) {
         ret = gpio_pin_set_dt(&sd_en, 1);
         if (device_is_ready(spi_dev)) {
@@ -510,38 +717,18 @@ static int sd_enable_power(bool enable)
         atomic_set(&sd_io_low_power, 0);
         sd_enabled = false;
     }
+
     return ret;
 }
 
-/* ------------------------------------------------------------------ */
-/* LittleFS mount / unmount                                            */
-/* ------------------------------------------------------------------ */
-
-static void lfs_close_files(void)
-{
-    lfs_file_close(&lfs_fs, &lfs_fil_data);
-    lfs_file_close(&lfs_fs, &lfs_fil_info);
-    current_filename[0] = '\0';
-    current_file_path[0] = '\0';
-}
-
-/*
- * Mount the filesystem.  LittleFS mounts existing FS or formats on first use.
- *
- * Key difference from FATFS: if there is any corruption LittleFS recovers
- * from its journal automatically â€” no mkfs needed, no power-loss dirty bit.
- */
 static int sd_mount(void)
 {
     if (is_mounted) {
         return 0;
     }
 
-    /* Retry loop: SD NAND needs up to ~200 ms to stabilise after power-on.
-     * CTRL_INIT returns EINVAL (-22) or EIO (-5) when the card isn't ready. */
-    uint32_t sector_count = 0;
-    uint32_t sector_size = 0;
     int ret = -EIO;
+    uint32_t sector_size = 0;
 
     for (int attempt = 1; attempt <= 5; attempt++) {
         ret = sd_enable_power(true);
@@ -550,16 +737,14 @@ static int sd_mount(void)
             return ret;
         }
 
-        /* Progressive back-off: 50, 100, 150, 200, 250 ms */
         k_msleep(50 * attempt);
-
         ret = disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_CTRL_INIT, NULL);
         if (ret == 0) {
-            break; /* init succeeded */
+            break;
         }
 
         LOG_WRN("SD CTRL_INIT attempt %d/5 failed: %d", attempt, ret);
-        (void) disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_CTRL_DEINIT, NULL);
+        (void)disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_CTRL_DEINIT, NULL);
         sd_enable_power(false);
         k_msleep(50);
     }
@@ -569,1096 +754,219 @@ static int sd_mount(void)
         return ret;
     }
 
-    disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_GET_SECTOR_COUNT, &sector_count);
-    disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_GET_SECTOR_SIZE, &sector_size);
+    (void)disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_GET_SECTOR_COUNT, &disk_sector_count);
+    (void)disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_GET_SECTOR_SIZE, &sector_size);
 
-    /* LittleFS only needs the disk to be 'initialised' from here on;
-     * keep driver active (no CTRL_DEINIT) so callbacks work. */
-    LOG_INF("SD: %u sectors x %u bytes = %u MB",
-            sector_count,
-            sector_size,
-            (unsigned) ((uint64_t) sector_count * sector_size >> 20));
-
-    /* read/prog stay at sector granularity (512);
-     * cache = full block (4096) for multi-sector I/O. */
-    uint32_t ss = (sector_size > 0) ? sector_size : DISK_SECTOR_SIZE;
-    lfs_cfg.read_size = ss;
-    lfs_cfg.prog_size = ss;
-    lfs_cfg.cache_size = LFS_CACHE_SIZE;
-    lfs_cfg.block_size = LFS_BLOCK_SIZE;
-    lfs_cfg.block_count = sector_count / (LFS_BLOCK_SIZE / ss);
-
-    /* Try to mount existing filesystem */
-    int64_t mount_start_ms = k_uptime_get();
-    ret = lfs_mount(&lfs_fs, &lfs_cfg);
-    LOG_INF("[SD_BOOT] lfs_mount took %lld ms (ret=%d)", k_uptime_get() - mount_start_ms, ret);
-    if (ret != LFS_ERR_OK) {
-        LOG_WRN("LFS mount failed (%d), formattingâ€¦", ret);
-        ret = lfs_format(&lfs_fs, &lfs_cfg);
-        if (ret != LFS_ERR_OK) {
-            LOG_ERR("LFS format failed: %d", ret);
-            sd_enable_power(false);
-            return -EIO;
-        }
-        ret = lfs_mount(&lfs_fs, &lfs_cfg);
-        if (ret != LFS_ERR_OK) {
-            LOG_ERR("LFS mount after format failed: %d", ret);
-            sd_enable_power(false);
-            return -EIO;
-        }
+    if (sector_size != DISK_SECTOR_SIZE || disk_sector_count <= RAW_META_SECTORS) {
+        LOG_ERR("unexpected SD layout: sectors=%u size=%u", disk_sector_count, sector_size);
+        sd_enable_power(false);
+        return -EINVAL;
     }
 
+    data_batch_count = (disk_sector_count - RAW_META_SECTORS) / RAW_BATCH_SECTORS;
+    if (data_batch_count == 0U) {
+        LOG_ERR("not enough sectors for raw ring layout");
+        sd_enable_power(false);
+        return -ENOSPC;
+    }
+
+    ring_state.capacity_packets = data_batch_count * RAW_PACKETS_PER_BATCH;
+
+    ret = load_ring_metadata();
+    if (ret < 0) {
+        LOG_ERR("failed to load raw ring metadata: %d", ret);
+        sd_enable_power(false);
+        return ret;
+    }
+
+    (void)restore_tail_batch();
     is_mounted = true;
-    LOG_INF("LittleFS mounted OK (block_size=%u, block_count=%u, lookahead=%u bytes = %u blocks window)",
-            (unsigned) lfs_cfg.block_size,
-            (unsigned) lfs_cfg.block_count,
-            (unsigned) lfs_cfg.lookahead_size,
-            (unsigned) lfs_cfg.lookahead_size * 8);
+
+    LOG_INF("Raw SD ring mounted: sectors=%u, batches=%u, capacity=%u packets",
+            disk_sector_count,
+            data_batch_count,
+            ring_state.capacity_packets);
     return 0;
 }
 
 static int sd_unmount(void)
 {
-    if (write_batch_offset > 0) {
-        flush_batch_buffer();
+    if (current_batch_dirty) {
+        (void)flush_current_batch(true);
+    } else {
+        (void)sync_media();
     }
-    close_read_handle();
-    lfs_close_files();
+
     if (is_mounted) {
-        lfs_unmount(&lfs_fs);
+        (void)disk_access_ioctl(DISK_DRIVE_NAME, DISK_IOCTL_CTRL_DEINIT, NULL);
         is_mounted = false;
     }
+
     sd_enable_power(false);
-    LOG_INF("LittleFS unmounted");
+    LOG_INF("Raw SD ring unmounted");
     return 0;
 }
 
-/* ------------------------------------------------------------------ */
-/* Path helpers                                                        */
-/* ------------------------------------------------------------------ */
-
-static void build_file_path(const char *filename, char *path, size_t path_size)
+static int get_oldest_packet_name(char *buf, size_t buf_size)
 {
-    snprintf(path, path_size, "%s/%s", FILE_DATA_DIR, filename);
-}
-
-static bool filename_equals_ignore_case(const char *a, const char *b)
-{
-    if (!a || !b)
-        return false;
-    for (size_t i = 0; i < MAX_FILENAME_LEN; i++) {
-        if (tolower((unsigned char) a[i]) != tolower((unsigned char) b[i]))
-            return false;
-        if (a[i] == '\0' || b[i] == '\0')
-            break;
-    }
-    return true;
-}
-
-static void cleanup_audio_files_at_boot(void)
-{
-    uint32_t removed_total = 0;
-    uint32_t removed_tmp = 0;
-    uint32_t removed_small = 0;
-
-    while (1) {
-        lfs_dir_t dir;
-        struct lfs_info info;
-        char target_name[MAX_FILENAME_LEN] = {0};
-        bool target_is_tmp = false;
-        bool target_is_small = false;
-
-        if (lfs_dir_open(&lfs_fs, &dir, FILE_DATA_DIR) < 0) {
-            break;
-        }
-
-        while (lfs_dir_read(&lfs_fs, &dir, &info) > 0) {
-            if (info.type != LFS_TYPE_REG) {
-                continue;
-            }
-
-            char *dot = strrchr(info.name, '.');
-            if (!dot || strcasecmp(dot, ".txt") != 0) {
-                continue;
-            }
-
-            bool is_tmp = (strncasecmp(info.name, "TMP_", 4) == 0);
-            bool is_small = (info.size < BOOT_MIN_AUDIO_FILE_SIZE);
-            if (!is_tmp && !is_small) {
-                continue;
-            }
-
-            strncpy(target_name, info.name, sizeof(target_name) - 1);
-            target_is_tmp = is_tmp;
-            target_is_small = is_small;
-            break;
-        }
-
-        lfs_dir_close(&lfs_fs, &dir);
-
-        if (target_name[0] == '\0') {
-            break;
-        }
-
-        char path[64];
-        build_file_path(target_name, path, sizeof(path));
-        int rm = lfs_remove(&lfs_fs, path);
-        if (rm < 0) {
-            LOG_WRN("[SD_BOOT] cleanup rm %s failed: %d", path, rm);
-            continue;
-        }
-
-        removed_total++;
-        if (target_is_tmp) {
-            removed_tmp++;
-        }
-        if (target_is_small) {
-            removed_small++;
-        }
+    if (!buf || buf_size == 0U) {
+        return -EINVAL;
     }
 
-    if (removed_total > 0) {
-        LOG_INF("[SD_BOOT] cleanup removed %u file(s) (tmp=%u, small<%uB=%u)",
-                removed_total,
-                removed_tmp,
-                BOOT_MIN_AUDIO_FILE_SIZE,
-                removed_small);
-        invalidate_file_cache();
-    }
-}
-
-/* ------------------------------------------------------------------ */
-/* Boot: list existing audio files                                     */
-/* ------------------------------------------------------------------ */
-
-static void print_audio_files_at_boot(void)
-{
-    lfs_dir_t dir;
-    struct lfs_info info;
-    uint32_t file_count = 0;
-    uint64_t total_size = 0;
-
-    if (lfs_dir_open(&lfs_fs, &dir, FILE_DATA_DIR) < 0) {
-        LOG_INF("[SD_BOOT] No audio directory found");
-        return;
-    }
-
-    /* Clear file cache arrays before populating */
-    memset(cached_file_names, 0, sizeof(cached_file_names));
-    memset(cached_file_sizes, 0, sizeof(cached_file_sizes));
-    int list_count = 0;
-
-    LOG_INF("========== AUDIO FILES ON SD CARD ==========");
-    while (lfs_dir_read(&lfs_fs, &dir, &info) > 0) {
-        if (info.type != LFS_TYPE_REG)
-            continue;
-        char *dot = strrchr(info.name, '.');
-        if (dot && strcasecmp(dot, ".txt") == 0) {
-            LOG_INF("  [%u] %s - %u bytes", file_count + 1, info.name, (unsigned) info.size);
-            total_size += info.size;
-            file_count++;
-            /* Also populate the file list cache so that get_file_list
-             * can return data immediately during the long gc pre-warm. */
-            if (list_count < MAX_AUDIO_FILES) {
-                strncpy(cached_file_names[list_count], info.name, MAX_FILENAME_LEN - 1);
-                cached_file_names[list_count][MAX_FILENAME_LEN - 1] = '\0';
-                cached_file_sizes[list_count] = (uint32_t) info.size;
-                list_count++;
-            }
-        }
-    }
-    lfs_dir_close(&lfs_fs, &dir);
-    cached_file_list_count = list_count;
-    sort_cached_file_entries();
-    cached_stats_file_count = file_count;
-    cached_stats_total_size = total_size;
-    cached_stats_valid_until_ms = k_uptime_get() + FILE_CACHE_TTL_MS;
-    cached_total_file_count = file_count;
-    cached_total_file_size = total_size;
-    file_cache_valid = true;
-    LOG_INF("[SD_BOOT] %u files, %u bytes total", file_count, (unsigned) total_size);
-    LOG_INF("=============================================");
-}
-
-/* ------------------------------------------------------------------ */
-/* File creation / continuation at boot                               */
-/* ------------------------------------------------------------------ */
-
-#define FILE_CONTINUE_THRESHOLD_SEC (60)
-
-static int try_continue_latest_file(void)
-{
-    uint32_t current_time = get_utc_time();
-    if (current_time == 0 || current_time < 1700000000U) {
-        LOG_INF("[SD_BOOT] RTC not valid, will create new file");
-        return -1;
-    }
-
-    lfs_dir_t dir;
-    struct lfs_info info;
-    if (lfs_dir_open(&lfs_fs, &dir, FILE_DATA_DIR) < 0) {
-        return -1;
-    }
-
-    char latest_filename[MAX_FILENAME_LEN] = {0};
-    uint32_t latest_timestamp = 0;
-
-    while (lfs_dir_read(&lfs_fs, &dir, &info) > 0) {
-        if (info.type != LFS_TYPE_REG)
-            continue;
-        char *dot = strrchr(info.name, '.');
-        if (dot && strcasecmp(dot, ".txt") == 0) {
-            uint32_t ts = (uint32_t) strtoul(info.name, NULL, 16);
-            if (ts > latest_timestamp) {
-                latest_timestamp = ts;
-                strncpy(latest_filename, info.name, sizeof(latest_filename) - 1);
-            }
-        }
-    }
-    lfs_dir_close(&lfs_fs, &dir);
-
-    if (latest_filename[0] == '\0')
-        return -1;
-
-    int32_t diff = (int32_t) (current_time - latest_timestamp);
-    LOG_INF("[SD_BOOT] Latest file: %s diff=%d s", latest_filename, diff);
-
-    if (diff < 0 || diff > FILE_CONTINUE_THRESHOLD_SEC)
-        return -1;
-
-    strncpy(current_filename, latest_filename, sizeof(current_filename) - 1);
-    build_file_path(current_filename, current_file_path, sizeof(current_file_path));
-
-    int ret = lfs_file_opencfg(&lfs_fs, &lfs_fil_data, current_file_path, LFS_O_RDWR | LFS_O_APPEND, &lfs_fdata_cfg);
+    sd_ring_info_t info;
+    int ret = sd_ring_get_info(&info);
     if (ret < 0) {
-        LOG_ERR("[SD_BOOT] open existing file failed: %d", ret);
-        current_filename[0] = '\0';
-        return -1;
-    }
-
-    current_file_size = (uint32_t) lfs_file_size(&lfs_fs, &lfs_fil_data);
-    bytes_since_sync = 0;
-    write_batch_offset = 0;
-    write_batch_counter = 0;
-    last_file_sync_uptime_ms = k_uptime_get();
-    current_file_created_uptime_ms = k_uptime_get();
-    current_file_needs_rename = false;
-
-    LOG_INF("[SD_BOOT] Continuing file: %s (%u bytes)", current_filename, current_file_size);
-    return 0;
-}
-
-static int create_audio_file_with_timestamp(void)
-{
-    bool rtc_valid = rtc_is_valid();
-    uint32_t timestamp = 0;
-
-    if (rtc_valid) {
-        timestamp = get_utc_time();
-        if (timestamp == 0 || timestamp < 1700000000U)
-            rtc_valid = false;
-    }
-
-    /* Close current file if open */
-    if (current_filename[0] != '\0') {
-        if (write_batch_offset > 0)
-            flush_batch_buffer();
-        lfs_file_close(&lfs_fs, &lfs_fil_data);
-        current_filename[0] = '\0';
-    }
-
-    /* Ensure audio directory exists */
-    struct lfs_info dir_info;
-    if (lfs_stat(&lfs_fs, FILE_DATA_DIR, &dir_info) < 0) {
-        int mk = lfs_mkdir(&lfs_fs, FILE_DATA_DIR);
-        if (mk < 0 && mk != LFS_ERR_EXIST) {
-            LOG_ERR("mkdir %s failed: %d", FILE_DATA_DIR, mk);
-            return mk;
-        }
-    }
-
-    if (rtc_valid) {
-        snprintf(current_filename, sizeof(current_filename), "%08X.txt", timestamp);
-        current_file_needs_rename = false;
-    } else {
-        uint32_t boot_tag = (uint32_t) k_uptime_get_32();
-        uint32_t cycle_tag = (uint32_t) k_cycle_get_32();
-        snprintf(current_filename, sizeof(current_filename), "TMP_%08X_%04X.txt", boot_tag, cycle_tag & 0xFFFFU);
-        current_file_needs_rename = true;
-        LOG_WRN("RTC not synced, temp file: %s", current_filename);
-    }
-
-    build_file_path(current_filename, current_file_path, sizeof(current_file_path));
-    LOG_INF("Creating audio file: %s", current_file_path);
-
-    int ret = lfs_file_opencfg(
-        &lfs_fs, &lfs_fil_data, current_file_path, LFS_O_CREAT | LFS_O_RDWR | LFS_O_APPEND, &lfs_fdata_cfg);
-    if (ret < 0) {
-        LOG_ERR("Failed to create %s: %d", current_file_path, ret);
-        current_filename[0] = '\0';
-        current_file_path[0] = '\0';
         return ret;
     }
 
-    current_file_size = 0;
-    bytes_since_sync = 0;
-    write_batch_offset = 0;
-    write_batch_counter = 0;
-    writing_error_counter = 0;
-    sd_write_blocked = false;
-    last_file_sync_uptime_ms = k_uptime_get();
-    current_file_created_uptime_ms = k_uptime_get();
-
-    LOG_INF("Audio file created: %s", current_filename);
-    invalidate_file_cache();
-    return 0;
-}
-
-/* ------------------------------------------------------------------ */
-/* Batch buffer flush                                                  */
-/* ------------------------------------------------------------------ */
-
-static int flush_batch_buffer(void)
-{
-    if (write_batch_offset == 0)
-        return 0;
-
-    if (sd_write_blocked) {
-        write_batch_offset = 0;
-        write_batch_counter = 0;
-        return -EIO;
-    }
-
-    int64_t flush_start_ms = k_uptime_get();
-    lfs_ssize_t bw = lfs_file_write(&lfs_fs, &lfs_fil_data, write_batch_buffer, write_batch_offset);
-    int64_t flush_cost_ms = k_uptime_get() - flush_start_ms;
-    if (flush_cost_ms > 2000) {
-        LOG_WRN("[SD_PERF] flush_batch_buffer took %lld ms (wrote %u bytes, batch=%d)",
-                flush_cost_ms,
-                (unsigned) write_batch_offset,
-                write_batch_counter);
-    }
-    if (bw < 0 || (size_t) bw != write_batch_offset) {
-        writing_error_counter++;
-        LOG_ERR("batch write error bw=%d wanted=%u", (int) bw, (unsigned) write_batch_offset);
-
-        if (writing_error_counter > ERROR_THRESHOLD) {
-            sd_write_blocked = true;
-            LOG_ERR("Too many write errors, blocking write queue");
-        }
-        write_batch_offset = 0;
-        write_batch_counter = 0;
-        return -EIO;
-    }
-
-    bytes_since_sync += (size_t) bw;
-    current_file_size += (uint32_t) bw;
-    update_current_file_cache_size((uint32_t) bw);
-    LOG_DBG("[SD] wrote %u bytes -> %s (total=%u)", (unsigned) bw, current_filename, current_file_size);
-    write_batch_offset = 0;
-    write_batch_counter = 0;
-    writing_error_counter = 0;
-    return 0;
-}
-
-/* ------------------------------------------------------------------ */
-/* File rotation helper                                                */
-/* ------------------------------------------------------------------ */
-
-static bool should_rotate_file(void)
-{
-    if (current_file_created_uptime_ms == 0)
-        return false;
-    return (k_uptime_get() - current_file_created_uptime_ms) >= FILE_ROTATION_INTERVAL_MS;
-}
-
-/* ------------------------------------------------------------------ */
-/* Filename sort (hex timestamp, oldest first)                        */
-/* ------------------------------------------------------------------ */
-
-static int compare_filenames(const void *a, const void *b)
-{
-    uint32_t ta = (uint32_t) strtoul((const char *) a, NULL, 16);
-    uint32_t tb = (uint32_t) strtoul((const char *) b, NULL, 16);
-    return (ta < tb) ? -1 : (ta > tb) ? 1 : 0;
-}
-
-static void invalidate_file_cache(void)
-{
-    file_cache_valid = false;
-    cached_stats_valid_until_ms = 0;
-}
-
-static void sort_cached_file_entries(void)
-{
-    if (cached_file_list_count <= 1) {
-        return;
-    }
-
-    for (int i = 1; i < cached_file_list_count; i++) {
-        char tmp_name[MAX_FILENAME_LEN] = {0};
-        uint32_t tmp_size = cached_file_sizes[i];
-        strncpy(tmp_name, cached_file_names[i], MAX_FILENAME_LEN - 1);
-
-        int j = i - 1;
-        while (j >= 0 && compare_filenames(cached_file_names[j], tmp_name) > 0) {
-            strncpy(cached_file_names[j + 1], cached_file_names[j], MAX_FILENAME_LEN);
-            cached_file_sizes[j + 1] = cached_file_sizes[j];
-            j--;
-        }
-
-        strncpy(cached_file_names[j + 1], tmp_name, MAX_FILENAME_LEN);
-        cached_file_sizes[j + 1] = tmp_size;
-    }
-}
-
-static void update_current_file_cache_size(uint32_t delta)
-{
-    if (!file_cache_valid || delta == 0 || current_filename[0] == '\0') {
-        return;
-    }
-
-    cached_total_file_size += delta;
-    cached_stats_total_size = cached_total_file_size;
-    cached_stats_file_count = cached_total_file_count;
-    cached_stats_valid_until_ms = k_uptime_get() + FILE_CACHE_TTL_MS;
-
-    for (int i = 0; i < cached_file_list_count; i++) {
-        if (strcmp(cached_file_names[i], current_filename) == 0) {
-            cached_file_sizes[i] += delta;
-            return;
-        }
-    }
-
-    /* Cache became stale (e.g. filename not indexed due truncation). */
-    invalidate_file_cache();
-}
-
-static int refresh_file_cache(void)
-{
-    if (!is_mounted) {
-        return -ENODEV;
-    }
-
-    lfs_dir_t dir;
-    struct lfs_info info;
-    int list_count = 0;
-    uint32_t total_count = 0;
-    uint64_t total_size = 0;
-
-    memset(cached_file_names, 0, sizeof(cached_file_names));
-    memset(cached_file_sizes, 0, sizeof(cached_file_sizes));
-
-    int dres = lfs_dir_open(&lfs_fs, &dir, FILE_DATA_DIR);
-    if (dres < 0) {
-        if (dres == LFS_ERR_NOENT) {
-            cached_file_list_count = 0;
-            cached_total_file_count = 0;
-            cached_total_file_size = 0;
-            cached_stats_file_count = 0;
-            cached_stats_total_size = 0;
-            cached_stats_valid_until_ms = k_uptime_get() + FILE_CACHE_TTL_MS;
-            file_cache_valid = true;
-            return 0;
-        }
-        return dres;
-    }
-
-    while (lfs_dir_read(&lfs_fs, &dir, &info) > 0) {
-        if (info.type != LFS_TYPE_REG) {
-            continue;
-        }
-
-        char *dot = strrchr(info.name, '.');
-        if (!dot || strcasecmp(dot, ".txt") != 0) {
-            continue;
-        }
-
-        total_count++;
-        total_size += info.size;
-
-        if (list_count < MAX_AUDIO_FILES) {
-            strncpy(cached_file_names[list_count], info.name, MAX_FILENAME_LEN - 1);
-            cached_file_names[list_count][MAX_FILENAME_LEN - 1] = '\0';
-            cached_file_sizes[list_count] = (uint32_t) info.size;
-            list_count++;
-        }
-    }
-    lfs_dir_close(&lfs_fs, &dir);
-
-    cached_file_list_count = list_count;
-    sort_cached_file_entries();
-
-    if (current_filename[0] != '\0') {
-        for (int i = 0; i < cached_file_list_count; i++) {
-            if (strcmp(cached_file_names[i], current_filename) == 0) {
-                total_size = total_size - cached_file_sizes[i] + current_file_size;
-                cached_file_sizes[i] = current_file_size;
-                break;
-            }
-        }
-    }
-
-    cached_total_file_count = total_count;
-    cached_total_file_size = total_size;
-    cached_stats_file_count = total_count;
-    cached_stats_total_size = total_size;
-    cached_stats_valid_until_ms = k_uptime_get() + FILE_CACHE_TTL_MS;
-    file_cache_valid = true;
-
-    return 0;
-}
-
-static int ensure_file_cache(void)
-{
-    if (file_cache_valid) {
+    if (info.read_seq == info.write_seq) {
+        buf[0] = '\0';
         return 0;
     }
-    return refresh_file_cache();
-}
 
-/* ------------------------------------------------------------------ */
-/* Filename rename after time-sync                                     */
-/* ------------------------------------------------------------------ */
-
-void sd_update_filename_after_timesync(uint32_t synced_utc_time)
-{
-    if (!current_file_needs_rename || current_filename[0] == '\0' || !is_mounted)
-        return;
-
-    int64_t now_ms = k_uptime_get();
-    uint32_t elapsed = (uint32_t) (now_ms - current_file_created_uptime_ms);
-    uint32_t correct_ts = synced_utc_time - (elapsed / 1000U);
-
-    char new_filename[MAX_FILENAME_LEN];
-    snprintf(new_filename, sizeof(new_filename), "%08X.txt", correct_ts);
-    LOG_INF("Rename: %s -> %s (elapsed=%u ms)", current_filename, new_filename, elapsed);
-
-    if (write_batch_offset > 0)
-        flush_batch_buffer();
-    lfs_file_sync(&lfs_fs, &lfs_fil_data);
-    data_sync_gen++;
-    bytes_since_sync = 0;
-    last_file_sync_uptime_ms = k_uptime_get();
-    lfs_file_close(&lfs_fs, &lfs_fil_data);
-
-    char new_path[64];
-    build_file_path(new_filename, new_path, sizeof(new_path));
-    int ret = lfs_rename(&lfs_fs, current_file_path, new_path);
-    if (ret < 0) {
-        LOG_ERR("Rename failed: %d", ret);
-        /* Re-open old file */
-        lfs_file_opencfg(&lfs_fs, &lfs_fil_data, current_file_path, LFS_O_RDWR | LFS_O_APPEND, &lfs_fdata_cfg);
-        return;
+    uint8_t packet[RAW_AUDIO_PACKET_BYTES];
+    uint32_t bytes_read = 0;
+    uint32_t packets_read = 0;
+    ret = sd_ring_read(info.read_seq, packet, sizeof(packet), &bytes_read, &packets_read);
+    if (ret < 0 || packets_read == 0U) {
+        return (ret < 0) ? ret : -ENOENT;
     }
 
-    strncpy(current_filename, new_filename, sizeof(current_filename) - 1);
-    strncpy(current_file_path, new_path, sizeof(current_file_path) - 1);
-    current_file_needs_rename = false;
-
-    lfs_file_opencfg(&lfs_fs, &lfs_fil_data, current_file_path, LFS_O_RDWR | LFS_O_APPEND, &lfs_fdata_cfg);
-    LOG_INF("File renamed OK: %s", current_filename);
-}
-
-/* ------------------------------------------------------------------ */
-/* Worker thread & task definitions                                    */
-/* ------------------------------------------------------------------ */
-
-#define SD_WORKER_STACK_SIZE 16384
-#define SD_WORKER_PRIORITY 7
-K_THREAD_STACK_DEFINE(sd_worker_stack, SD_WORKER_STACK_SIZE);
-static struct k_thread sd_worker_thread_data;
-static k_tid_t sd_worker_tid = NULL;
-
-/* ------------------------------------------------------------------ */
-/* Internal helpers: file list, file stats                            */
-/* ------------------------------------------------------------------ */
-
-static int get_audio_file_list_internal(char filenames[][MAX_FILENAME_LEN], uint32_t *sizes, int max_files, int *count)
-{
-    if (!filenames || !count || max_files <= 0)
-        return -EINVAL;
-    if (!is_mounted)
-        return -ENODEV;
-
-    int cache_res = ensure_file_cache();
-    if (cache_res < 0) {
-        return cache_res;
-    }
-
-    int file_count = cached_file_list_count;
-    if (file_count > max_files) {
-        file_count = max_files;
-    }
-
-    for (int i = 0; i < file_count; i++) {
-        strncpy(filenames[i], cached_file_names[i], MAX_FILENAME_LEN - 1);
-        filenames[i][MAX_FILENAME_LEN - 1] = '\0';
-        if (sizes) {
-            sizes[i] = cached_file_sizes[i];
-        }
-    }
-
-    *count = file_count;
+    format_timestamp_name(sys_get_be32(packet), buf, buf_size);
     return 0;
 }
-
-/* ------------------------------------------------------------------ */
-/* SD worker thread                                                    */
-/* ------------------------------------------------------------------ */
 
 void sd_worker_thread(void)
 {
     sd_req_t req;
-    int res;
 
-    /* ---- Mount ---- */
-    res = sd_mount();
+    int res = sd_mount();
     if (res != 0) {
         LOG_ERR("[SD_WORK] mount failed: %d", res);
         sd_write_blocked = true;
         return;
     }
 
-    /* ---- Ensure audio directory exists ---- */
-    struct lfs_info dir_info;
-    if (lfs_stat(&lfs_fs, FILE_DATA_DIR, &dir_info) < 0) {
-        int mk = lfs_mkdir(&lfs_fs, FILE_DATA_DIR);
-        if (mk < 0 && mk != LFS_ERR_EXIST) {
-            LOG_ERR("[SD_WORK] mkdir audio failed: %d â€” write path blocked", mk);
-            sd_write_blocked = true;
-        }
-    }
-
-    /* ---- Boot cleanup: remove stale temp/small files ---- */
-    cleanup_audio_files_at_boot();
-
-    /* ---- Print existing files at boot ---- */
-    print_audio_files_at_boot();
-
-    /* ---- Pre-warm LFS block allocator ---- */
-    /* After mount, the LFS lookahead buffer is EMPTY and the start position
-     * is random (seed % block_count).  The very first lfs_alloc() would
-     * trigger lfs_alloc_scan() — a full O(used_blocks) filesystem traversal
-     * over SPI SD that can take 10-50+ seconds with 100-200 MB of data.
-     *
-     * By calling lfs_fs_gc() here (with compact_thresh=-1 so it skips
-     * metadata compaction), we force that expensive scan to happen NOW,
-     * during boot init, BEFORE the audio pipeline starts feeding data.
-     * This moves the latency spike from the real-time write path to a
-     * one-time boot cost where dropping audio is acceptable. */
-    {
-        int64_t gc_start_ms = k_uptime_get();
-        LOG_INF("[SD_BOOT] Pre-warming LFS allocator (lookahead=%u bytes, %u blocks window)...",
-                LFS_LOOKAHEAD_SIZE,
-                LFS_LOOKAHEAD_SIZE * 8);
-        int gc_res = lfs_fs_gc(&lfs_fs);
-        int64_t gc_elapsed_ms = k_uptime_get() - gc_start_ms;
-        if (gc_res < 0) {
-            LOG_WRN("[SD_BOOT] lfs_fs_gc failed: %d (took %lld ms)", gc_res, gc_elapsed_ms);
-        } else {
-            LOG_INF("[SD_BOOT] LFS allocator pre-warmed OK in %lld ms", gc_elapsed_ms);
-        }
-    }
-
-    /* ---- Open / create info file ---- */
-    {
-        struct lfs_info info_lstat;
-        bool info_exists = (lfs_stat(&lfs_fs, FILE_INFO_PATH, &info_lstat) == 0);
-        bool need_init_off = !info_exists || (info_lstat.size < sizeof(sd_offset_info_t));
-
-        res = lfs_file_opencfg(&lfs_fs, &lfs_fil_info, FILE_INFO_PATH, LFS_O_CREAT | LFS_O_RDWR, &lfs_finfo_cfg);
-        if (res < 0) {
-            LOG_ERR("[SD_WORK] open info failed: %d", res);
-            sd_write_blocked = true;
-        } else if (need_init_off) {
-            memset(&current_offset_info, 0, sizeof(current_offset_info));
-            lfs_ssize_t bw = lfs_file_write(&lfs_fs, &lfs_fil_info, &current_offset_info, sizeof(current_offset_info));
-            if (bw != (lfs_ssize_t) sizeof(current_offset_info)) {
-                LOG_ERR("[SD_WORK] init info write failed: %d", (int) bw);
-            } else {
-                lfs_file_sync(&lfs_fs, &lfs_fil_info);
-            }
-        } else {
-            lfs_file_seek(&lfs_fs, &lfs_fil_info, 0, LFS_SEEK_SET);
-            lfs_ssize_t rb = lfs_file_read(&lfs_fs, &lfs_fil_info, &current_offset_info, sizeof(current_offset_info));
-            if (rb != (lfs_ssize_t) sizeof(current_offset_info)) {
-                LOG_ERR("[SD_WORK] read offset info failed: %d", (int) rb);
-                memset(&current_offset_info, 0, sizeof(current_offset_info));
-            } else {
-                LOG_INF("[SD_WORK] Loaded offset: file=%s off=%u",
-                        current_offset_info.oldest_filename,
-                        current_offset_info.offset_in_file);
-            }
-        }
-    }
-
-    /* ---- Open initial audio file ---- */
-    res = try_continue_latest_file();
-    if (res < 0) {
-        res = create_audio_file_with_timestamp();
-        if (res < 0) {
-            LOG_ERR("[SD_WORK] initial file create failed: %d â€” write blocked", res);
-            sd_write_blocked = true;
-        }
-    }
-
-    /* ---- SD boot init complete, allow writes ---- */
     atomic_set(&sd_boot_ready, 1);
-    LOG_INF("[SD_BOOT] SD card ready for audio writes (boot took %lld ms)", k_uptime_get());
-
-    /* Suspend SPI + SD until the first batch flush actually needs I/O.
-     * Saves ~0.5 mA idle current during the initial accumulation window. */
+    LOG_INF("[SD_BOOT] raw ring ready (used=%llu bytes)", (unsigned long long)ring_used_bytes());
     sd_set_io_low_power(true);
 
-    /* ---- Main loop ---- */
     while (1) {
-        /* Handle deferred control requests first (when queue was saturated). */
         if (atomic_cas(&pending_flush_on_ble_connect, 1, 0)) {
-            req.type = REQ_FLUSH_FILE;
-            req.u.create_file.resp = NULL;
-            goto handle_req;
-        }
-        if (atomic_cas(&pending_time_synced, 1, 0)) {
-            req.type = REQ_TIME_SYNCED;
-            req.u.time_synced.utc_time = pending_time_synced_utc;
+            req.type = REQ_FLUSH;
+            req.u.status.resp = NULL;
             goto handle_req;
         }
 
-        /* Priority queue first: reads, flush, file-list, delete, etc.
-         * These never wait behind pending audio writes. */
         if (k_msgq_get(&sd_prio_msgq, &req, K_NO_WAIT) == 0) {
             goto handle_req;
         }
 
-        /* Regular write queue timeout: short when BLE connected (keep read/sync responsive),
-         * long when offline (save power). */
-        k_timeout_t write_wait = ble_connected ? K_MSEC(50) : K_MSEC(2000);
-        if (k_msgq_get(&sd_msgq, &req, write_wait) != 0)
+        k_timeout_t write_wait = ble_connected ? K_MSEC(50) : K_MSEC(250);
+        if (k_msgq_get(&sd_msgq, &req, write_wait) != 0) {
+            if (current_batch_dirty && (k_uptime_get() - last_batch_activity_ms) >= RAW_FLUSH_INTERVAL_MS) {
+                sd_set_io_low_power(false);
+                (void)flush_current_batch(false);
+                sd_set_io_low_power(true);
+            }
             continue;
+        }
 
-    handle_req:
-        /* Wake SPI for request types that need filesystem I/O.
-         * REQ_WRITE_DATA manages its own SPI gating internally
-         * (only wakes when a batch flush actually occurs). */
+handle_req:
         if (req.type != REQ_WRITE_DATA) {
             sd_set_io_low_power(false);
         }
 
         switch (req.type) {
-
-        /* ---- Write data ---- */
         case REQ_WRITE_DATA:
             process_write_data_req(&req);
-
-            /* Drain additional queued write/save_offset messages in one pass.
-             * This reduces queue churn and improves effective SD throughput. */
             for (int i = 0; i < WRITE_DRAIN_BURST; i++) {
                 if (k_msgq_num_used_get(&sd_prio_msgq) > 0) {
                     break;
                 }
+
                 sd_req_t next_req;
                 if (k_msgq_get(&sd_msgq, &next_req, K_NO_WAIT) != 0) {
                     break;
                 }
+
                 if (next_req.type == REQ_WRITE_DATA) {
                     process_write_data_req(&next_req);
-                } else if (next_req.type == REQ_SAVE_OFFSET) {
-                    process_save_offset_req(&next_req);
                 }
             }
             break;
 
-        /* ---- Read audio data (uses persistent file handle) ---- */
-        case REQ_READ_DATA: {
-            char read_path[64];
-            build_file_path(req.u.read.filename, read_path, sizeof(read_path));
-
-            bool is_active_file = (current_filename[0] != '\0' && strcmp(req.u.read.filename, current_filename) == 0);
-
-            /* Close handle if different file requested */
-            if (read_handle_open && strcmp(read_handle_filename, req.u.read.filename) != 0) {
-                close_read_handle();
+        case REQ_GET_RING_INFO:
+            if (current_batch_dirty) {
+                (void)flush_current_batch(false);
             }
-
-            /* Reopen if handle is stale (file was synced since handle opened) */
-            if (read_handle_open && read_handle_gen != data_sync_gen) {
-                close_read_handle();
+            if (req.u.info.resp) {
+                req.u.info.resp->info = ring_state;
+                req.u.info.resp->res = 0;
+                k_sem_give(&req.u.info.resp->sem);
             }
+            break;
 
-            /* Open file if not already open */
-            if (!read_handle_open) {
-                res = lfs_file_opencfg(&lfs_fs, &lfs_read_handle, read_path, LFS_O_RDONLY, &lfs_read_handle_cfg);
-                if (res < 0) {
-                    LOG_ERR("[SD_WORK] open read failed: %s err=%d", read_path, res);
-                    if (req.u.read.resp) {
-                        req.u.read.resp->res = res;
-                        req.u.read.resp->read_bytes = 0;
-                        k_sem_give(&req.u.read.resp->sem);
-                    }
-                    break;
-                }
-                strncpy(read_handle_filename, req.u.read.filename, MAX_FILENAME_LEN - 1);
-                read_handle_open = true;
-                read_handle_pos = 0;
-                read_handle_gen = data_sync_gen;
-            }
-
-            /* Only seek if position doesn't match (sequential reads skip seek) */
-            if (read_handle_pos != (lfs_soff_t) req.u.read.offset) {
-                lfs_file_seek(&lfs_fs, &lfs_read_handle, (lfs_soff_t) req.u.read.offset, LFS_SEEK_SET);
-                read_handle_pos = (lfs_soff_t) req.u.read.offset;
-            }
-
-            lfs_ssize_t br = lfs_file_read(&lfs_fs, &lfs_read_handle, req.u.read.out_buf, req.u.read.length);
-
-            /* Lazy sync: if we got 0 bytes (EOF) on the active file and
-             * there is uncommitted data, flush+sync now and retry once.
-             * This avoids the expensive lfs_file_sync on EVERY read
-             * (was ~50-100 ms each) — we only pay the cost when we
-             * actually hit the stale-EOF boundary. */
-            if (br == 0 && is_active_file && (write_batch_offset > 0 || bytes_since_sync > 0)) {
-                if (write_batch_offset > 0) {
-                    flush_batch_buffer();
-                }
-                if (bytes_since_sync > 0) {
-                    lfs_file_sync(&lfs_fs, &lfs_fil_data);
-                    data_sync_gen++;
-                    bytes_since_sync = 0;
-                    last_file_sync_uptime_ms = k_uptime_get();
-                }
-                /* Reopen read handle to pick up new file size */
-                close_read_handle();
-                res = lfs_file_opencfg(&lfs_fs, &lfs_read_handle, read_path, LFS_O_RDONLY, &lfs_read_handle_cfg);
-                if (res < 0) {
-                    if (req.u.read.resp) {
-                        req.u.read.resp->res = res;
-                        req.u.read.resp->read_bytes = 0;
-                        k_sem_give(&req.u.read.resp->sem);
-                    }
-                    break;
-                }
-                strncpy(read_handle_filename, req.u.read.filename, MAX_FILENAME_LEN - 1);
-                read_handle_open = true;
-                read_handle_pos = 0;
-                read_handle_gen = data_sync_gen;
-
-                lfs_file_seek(&lfs_fs, &lfs_read_handle, (lfs_soff_t) req.u.read.offset, LFS_SEEK_SET);
-                read_handle_pos = (lfs_soff_t) req.u.read.offset;
-
-                br = lfs_file_read(&lfs_fs, &lfs_read_handle, req.u.read.out_buf, req.u.read.length);
-            }
-
-            if (br > 0) {
-                read_handle_pos += br;
-            }
-
+        case REQ_READ_PACKETS:
             if (req.u.read.resp) {
-                req.u.read.resp->res = (br < 0) ? (int) br : 0;
-                req.u.read.resp->read_bytes = (br < 0) ? 0 : (int) br;
+                req.u.read.resp->res = read_packets_internal(req.u.read.start_seq,
+                                                             req.u.read.out_buf,
+                                                             req.u.read.max_bytes,
+                                                             &req.u.read.resp->bytes_read,
+                                                             &req.u.read.resp->packets_read);
                 k_sem_give(&req.u.read.resp->sem);
             }
             break;
-        }
 
-        /* ---- Save offset ---- */
-        case REQ_SAVE_OFFSET:
-            process_save_offset_req(&req);
-            break;
-
-        /* ---- Clear audio directory ---- */
-        case REQ_CLEAR_AUDIO_DIR: {
-            flush_batch_buffer();
-            close_read_handle();
-            lfs_file_close(&lfs_fs, &lfs_fil_data);
-            current_filename[0] = '\0';
-
-            lfs_dir_t dir;
-            struct lfs_info info;
-            char fpath[64];
-
-            if (lfs_dir_open(&lfs_fs, &dir, FILE_DATA_DIR) == 0) {
-                while (lfs_dir_read(&lfs_fs, &dir, &info) > 0) {
-                    if (info.type != LFS_TYPE_REG)
-                        continue;
-                    build_file_path(info.name, fpath, sizeof(fpath));
-                    int rm = lfs_remove(&lfs_fs, fpath);
-                    if (rm < 0)
-                        LOG_ERR("[SD_WORK] rm %s: %d", fpath, rm);
-                }
-                lfs_dir_close(&lfs_fs, &dir);
-            }
-
-            /* Reset offset info */
-            memset(&current_offset_info, 0, sizeof(current_offset_info));
-            lfs_file_seek(&lfs_fs, &lfs_fil_info, 0, LFS_SEEK_SET);
-            lfs_file_write(&lfs_fs, &lfs_fil_info, &current_offset_info, sizeof(current_offset_info));
-            lfs_file_sync(&lfs_fs, &lfs_fil_info);
-            invalidate_file_cache();
-
-            res = create_audio_file_with_timestamp();
-
-            if (req.u.clear_dir.resp) {
-                req.u.clear_dir.resp->res = res;
-                k_sem_give(&req.u.clear_dir.resp->sem);
-            }
-            break;
-        }
-
-        /* ---- Create new file ---- */
-        case REQ_CREATE_NEW_FILE:
-            flush_batch_buffer();
-            res = create_audio_file_with_timestamp();
-            if (req.u.create_file.resp) {
-                req.u.create_file.resp->res = res;
-                k_sem_give(&req.u.create_file.resp->sem);
+        case REQ_ADVANCE_READ:
+            if (req.u.advance.resp) {
+                req.u.advance.resp->res = advance_read_seq_internal(req.u.advance.new_read_seq, false);
+                k_sem_give(&req.u.advance.resp->sem);
             }
             break;
 
-        /* ---- Get file stats ---- */
-        case REQ_GET_FILE_STATS: {
-            res = ensure_file_cache();
-
-            if (req.u.file_stats.resp) {
-                req.u.file_stats.resp->res = res;
-                req.u.file_stats.resp->file_count = (res == 0) ? cached_total_file_count : 0;
-                req.u.file_stats.resp->total_size = (res == 0) ? cached_total_file_size : 0;
-                k_sem_give(&req.u.file_stats.resp->sem);
+        case REQ_CLEAR_RING:
+            if (req.u.status.resp) {
+                req.u.status.resp->res = clear_ring_internal(false);
+                k_sem_give(&req.u.status.resp->sem);
             }
             break;
-        }
 
-        /* ---- Get file list ---- */
-        case REQ_GET_FILE_LIST: {
-            int list_count = 0;
-            res = get_audio_file_list_internal(
-                req.u.file_list.filenames, req.u.file_list.sizes, req.u.file_list.max_files, &list_count);
-            if (req.u.file_list.resp) {
-                req.u.file_list.resp->res = res;
-                req.u.file_list.resp->count = (res == 0) ? list_count : 0;
-                k_sem_give(&req.u.file_list.resp->sem);
-            }
-            break;
-        }
-
-        /* ---- Flush current file ---- */
-        case REQ_FLUSH_FILE: {
-            int flush_res = 0;
-            if (!current_file_deleted && current_filename[0] != '\0') {
-                flush_res = flush_batch_buffer();
-                if (flush_res == 0) {
-                    int sr = lfs_file_sync(&lfs_fs, &lfs_fil_data);
-                    if (sr < 0) {
-                        LOG_ERR("[SD_WORK] lfs_file_sync failed: %d", sr);
-                        flush_res = sr;
-                    } else {
-                        data_sync_gen++;
-                        bytes_since_sync = 0;
-                        last_file_sync_uptime_ms = k_uptime_get();
-                        LOG_INF("[SD_WORK] Flushed %s (%u bytes)", current_filename, current_file_size);
-                    }
-                }
-            }
-            if (req.u.create_file.resp) {
-                req.u.create_file.resp->res = flush_res;
-                k_sem_give(&req.u.create_file.resp->sem);
-            }
-            break;
-        }
-
-        /* ---- Unmount SD/LFS (must run on worker thread) ---- */
-        case REQ_UNMOUNT: {
-            /* Shutdown path: stop accepting new writes and drain queued writes
-             * so data already enqueued by mic thread is persisted before unmount. */
-            drain_pending_write_queue_for_shutdown();
-            int off_res = sd_unmount();
-            if (req.u.create_file.resp) {
-                req.u.create_file.resp->res = off_res;
-                k_sem_give(&req.u.create_file.resp->sem);
-            }
-            break;
-        }
-
-        /* ---- Delete file ---- */
-        case REQ_DELETE_FILE: {
-            char del_path[64];
-            build_file_path(req.u.delete_file.filename, del_path, sizeof(del_path));
-
-            /* Close read handle if we're about to delete the file being read */
-            if (read_handle_open && filename_equals_ignore_case(read_handle_filename, req.u.delete_file.filename)) {
-                close_read_handle();
-            }
-
-            if (current_filename[0] != '\0' &&
-                filename_equals_ignore_case(current_filename, req.u.delete_file.filename)) {
-                LOG_INF("[SD_WORK] Deleting active recording file");
-                flush_batch_buffer();
-                lfs_file_close(&lfs_fs, &lfs_fil_data);
-                current_filename[0] = '\0';
-                current_file_path[0] = '\0';
-                current_file_size = 0;
-                bytes_since_sync = 0;
-                last_file_sync_uptime_ms = 0;
-                write_batch_offset = 0;
-                write_batch_counter = 0;
-                current_file_deleted = true;
-            }
-
-            int rm = lfs_remove(&lfs_fs, del_path);
-            if (rm < 0 && rm != LFS_ERR_NOENT) {
-                LOG_ERR("[SD_WORK] remove %s failed: %d", del_path, rm);
+        case REQ_FLUSH:
+            if (req.u.status.resp) {
+                req.u.status.resp->res = flush_current_batch(true);
+                k_sem_give(&req.u.status.resp->sem);
             } else {
-                invalidate_file_cache();
+                (void)flush_current_batch(true);
             }
-            if (req.u.delete_file.resp) {
-                req.u.delete_file.resp->res = rm;
-                k_sem_give(&req.u.delete_file.resp->sem);
+            break;
+
+        case REQ_UNMOUNT:
+            drain_pending_write_queue_for_shutdown();
+            res = sd_unmount();
+            if (req.u.status.resp) {
+                req.u.status.resp->res = res;
+                k_sem_give(&req.u.status.resp->sem);
             }
             break;
         }
 
-        /* ---- Time synced ---- */
-        case REQ_TIME_SYNCED:
-            if (current_file_needs_rename && current_filename[0] != '\0') {
-                if (ble_connected) {
-                    deferred_timesync_rename_pending = true;
-                    deferred_timesync_utc_time = req.u.time_synced.utc_time;
-                    LOG_INF("[SD_WORK] Deferring TMP rename while BLE connected");
-                } else {
-                    sd_update_filename_after_timesync(req.u.time_synced.utc_time);
-                    invalidate_file_cache();
-                    deferred_timesync_rename_pending = false;
-                }
-            } else if (current_filename[0] == '\0') {
-                res = create_audio_file_with_timestamp();
-                if (res < 0)
-                    LOG_ERR("[SD_WORK] create after time sync failed: %d", res);
-            }
-            break;
-
-        default:
-            LOG_ERR("[SD_WORK] unknown request type %d", req.type);
-        }
-
-        /* Suspend SPI after non-write requests complete */
         if (req.type != REQ_WRITE_DATA) {
             sd_set_io_low_power(true);
         }
     }
 }
 
-/* ------------------------------------------------------------------ */
-/* Public API                                                          */
-/* ------------------------------------------------------------------ */
-
 int app_sd_init(void)
 {
     sd_shutdown_in_progress = false;
+    sd_write_blocked = false;
+    sd_write_paused = false;
     if (!sd_worker_tid) {
         sd_worker_tid = k_thread_create(&sd_worker_thread_data,
                                         sd_worker_stack,
                                         SD_WORKER_STACK_SIZE,
-                                        (k_thread_entry_t) sd_worker_thread,
+                                        (k_thread_entry_t)sd_worker_thread,
                                         NULL,
                                         NULL,
                                         NULL,
@@ -1676,30 +984,26 @@ int app_sd_off(void)
     bool unmount_completed = false;
 
     if (is_mounted && sd_worker_tid) {
-        struct read_resp resp;
+        struct status_resp resp;
         k_sem_init(&resp.sem, 0, 1);
         resp.res = 0;
 
         sd_req_t req = {0};
         req.type = REQ_UNMOUNT;
-        req.u.create_file.resp = &resp;
+        req.u.status.resp = &resp;
 
         int qret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(2000));
         if (qret == 0) {
-            if (k_sem_take(&resp.sem, K_MSEC(45000)) != 0) {
-                LOG_ERR("Timeout waiting for sd_worker unmount; skip force SD power-off");
-            } else if (resp.res < 0) {
-                LOG_ERR("sd_worker unmount failed: %d", resp.res);
-            } else {
+            if (k_sem_take(&resp.sem, K_MSEC(45000)) == 0 && resp.res >= 0) {
                 unmount_completed = true;
+            } else {
+                LOG_ERR("Timeout waiting for raw ring unmount");
             }
         } else {
-            LOG_ERR("Failed to queue sd unmount request: %d", qret);
+            LOG_ERR("Failed to queue raw ring unmount request: %d", qret);
         }
     }
 
-    /* Avoid forcing SD power-off while worker may still be writing/syncing,
-     * which can trigger SPI transfer timeouts and filesystem corruption. */
     if (unmount_completed || !is_mounted) {
         if (sd_enabled) {
             sd_enable_power(false);
@@ -1715,77 +1019,30 @@ bool is_sd_on(void)
     return sd_enabled;
 }
 
-uint32_t get_file_size(void)
+void sd_write_pause(bool pause)
 {
-    return current_file_size;
+    sd_write_paused = pause;
 }
 
-int get_current_filename(char *buf, size_t buf_size)
-{
-    if (!buf || buf_size < MAX_FILENAME_LEN)
-        return -EINVAL;
-    strncpy(buf, current_filename, buf_size - 1);
-    buf[buf_size - 1] = '\0';
-    return 0;
-}
+#ifdef CONFIG_OMI_ENABLE_OFFLINE_STORAGE
 
 void sd_notify_time_synced(uint32_t utc_time)
 {
-    pending_time_synced_utc = utc_time;
-    atomic_set(&pending_time_synced, 1);
-
-    sd_req_t req = {0};
-    req.type = REQ_TIME_SYNCED;
-    req.u.time_synced.utc_time = utc_time;
-    /* Use priority queue if possible; otherwise worker will handle deferred flag. */
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_NO_WAIT);
-    if (ret == 0) {
-        atomic_set(&pending_time_synced, 0);
-    }
+    ARG_UNUSED(utc_time);
 }
 
 void sd_notify_ble_state(bool connected)
 {
     if (connected && !ble_connected) {
-        ble_connect_time_ms = k_uptime_get();
-        LOG_INF("BLE connected");
-        /* Fire-and-forget flush via prio queue.
-         * Do NOT block here — this runs on the BLE callback thread;
-         * a blocking call would freeze the BLE stack and cause
-         * ATT Timeout → disconnect.  The storage auto-sync will
-         * flush before reading anyway. */
         sd_req_t req = {0};
-        req.type = REQ_FLUSH_FILE;
-        req.u.create_file.resp = NULL; /* no response needed */
+        req.type = REQ_FLUSH;
+        req.u.status.resp = NULL;
         int ret = k_msgq_put(&sd_prio_msgq, &req, K_NO_WAIT);
-        if (ret) {
+        if (ret != 0) {
             atomic_set(&pending_flush_on_ble_connect, 1);
-            LOG_WRN("Flush on BLE connect deferred (%d)", ret);
-        }
-    } else if (!connected && ble_connected) {
-        LOG_INF("BLE disconnected");
-        if (deferred_timesync_rename_pending) {
-            sd_req_t req = {0};
-            req.type = REQ_TIME_SYNCED;
-            req.u.time_synced.utc_time = deferred_timesync_utc_time;
-            int ret = k_msgq_put(&sd_prio_msgq, &req, K_NO_WAIT);
-            if (ret == 0) {
-                deferred_timesync_rename_pending = false;
-                LOG_INF("Queued deferred TMP rename after BLE disconnect");
-            } else {
-                pending_time_synced_utc = deferred_timesync_utc_time;
-                atomic_set(&pending_time_synced, 1);
-                LOG_WRN("Deferred TMP rename pending (%d)", ret);
-            }
-        }
-        if (current_file_deleted) {
-            int cr = create_new_audio_file();
-            if (cr < 0)
-                LOG_ERR("create file on BLE disconnect failed: %d", cr);
-            else
-                current_file_deleted = false;
         }
     }
+
     ble_connected = connected;
 }
 
@@ -1793,25 +1050,21 @@ uint32_t write_to_file(uint8_t *data, uint32_t length)
 {
     static int64_t last_write_err_log_ms;
     static int64_t last_shutdown_drop_log_ms;
+    static int64_t last_not_ready_log_ms;
 
-    /* Silently discard data while SD boot init is still running
-     * (mount + lfs_fs_gc pre-warm + file open). No logging here to
-     * avoid flooding — the worker thread logs when ready. */
     if (!atomic_get(&sd_boot_ready)) {
-        static int64_t last_not_ready_log_ms;
         int64_t now = k_uptime_get();
         if (now - last_not_ready_log_ms > 5000) {
-            LOG_WRN("write_to_file dropped: SD not ready (boot in progress)");
+            LOG_WRN("write_to_file dropped: SD not ready");
             last_not_ready_log_ms = now;
         }
         return 0;
     }
 
-    if (sd_shutdown_in_progress) {
+    if (sd_shutdown_in_progress || sd_write_paused) {
         int64_t now = k_uptime_get();
         if (now - last_shutdown_drop_log_ms > 1000) {
-            LOG_WRN("write_to_file dropped: SD %s",
-                    sd_shutdown_in_progress ? "shutdown" : "paused");
+            LOG_WRN("write_to_file dropped: SD paused/shutdown");
             last_shutdown_drop_log_ms = now;
         }
         return 0;
@@ -1825,22 +1078,22 @@ uint32_t write_to_file(uint8_t *data, uint32_t length)
         }
         return 0;
     }
+
+    if (!data || length != MAX_WRITE_SIZE) {
+        return 0;
+    }
+
     sd_req_t req = {0};
     req.type = REQ_WRITE_DATA;
     memcpy(req.u.write.buf, data, length);
     req.u.write.len = length;
-    /* Fast path: non-blocking enqueue first. */
-    int ret = k_msgq_put(&sd_msgq, &req, K_NO_WAIT);
 
-    /* Backpressure: if queue is temporarily full, wait a very short time
-     * for worker to drain instead of dropping immediately.
-     * This reduces packet loss and CPU spin when SD path stalls briefly. */
+    int ret = k_msgq_put(&sd_msgq, &req, K_NO_WAIT);
     if (ret != 0) {
-        k_timeout_t retry_wait = ble_connected ? K_MSEC(1) : K_MSEC(5);
-        ret = k_msgq_put(&sd_msgq, &req, retry_wait);
+        ret = k_msgq_put(&sd_msgq, &req, ble_connected ? K_MSEC(1) : K_MSEC(5));
     }
 
-    if (ret) {
+    if (ret != 0) {
         write_drop_packets++;
         write_drop_bytes += length;
         int64_t now = k_uptime_get();
@@ -1853,453 +1106,355 @@ uint32_t write_to_file(uint8_t *data, uint32_t length)
         }
         return 0;
     }
+
     return length;
 }
 
-int read_audio_data(const char *filename, uint8_t *buf, int amount, int offset)
+int sd_ring_get_info(sd_ring_info_t *info)
 {
-    /* Static resp so worker never writes to freed stack memory on timeout */
+    if (!info) {
+        return -EINVAL;
+    }
+
+    static struct info_resp resp;
+    static volatile bool info_in_flight;
+
+    if (info_in_flight) {
+        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
+            return -EBUSY;
+        }
+        info_in_flight = false;
+    }
+
+    info_in_flight = true;
+    k_sem_init(&resp.sem, 0, 1);
+
+    sd_req_t req = {0};
+    req.type = REQ_GET_RING_INFO;
+    req.u.info.resp = &resp;
+
+    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    if (ret != 0) {
+        info_in_flight = false;
+        return ret;
+    }
+
+    if (k_sem_take(&resp.sem, K_MSEC(5000)) != 0) {
+        return -ETIMEDOUT;
+    }
+
+    info_in_flight = false;
+    *info = resp.info;
+    return resp.res;
+}
+
+int sd_ring_read(uint64_t start_seq,
+                 uint8_t *buf,
+                 uint32_t max_bytes,
+                 uint32_t *bytes_read,
+                 uint32_t *packets_read)
+{
+    if (!buf || !bytes_read || !packets_read) {
+        return -EINVAL;
+    }
+
     static struct read_resp resp;
     static volatile bool read_in_flight;
 
     if (read_in_flight) {
-        /* Check if late worker response arrived */
-        if (k_sem_take(&resp.sem, K_NO_WAIT) == 0) {
-            read_in_flight = false; /* Worker caught up */
-        } else {
-            LOG_WRN("read_audio_data: previous request still in-flight");
+        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
             return -EBUSY;
         }
+        read_in_flight = false;
     }
+
     read_in_flight = true;
     k_sem_init(&resp.sem, 0, 1);
+    resp.bytes_read = 0;
+    resp.packets_read = 0;
 
     sd_req_t req = {0};
-    req.type = REQ_READ_DATA;
-    strncpy(req.u.read.filename, filename, MAX_FILENAME_LEN - 1);
+    req.type = REQ_READ_PACKETS;
+    req.u.read.start_seq = start_seq;
+    req.u.read.max_bytes = max_bytes;
     req.u.read.out_buf = buf;
-    req.u.read.length = amount;
-    req.u.read.offset = offset;
     req.u.read.resp = &resp;
 
     int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
-    if (ret) {
-        LOG_ERR("Failed to queue read: %d", ret);
+    if (ret != 0) {
         read_in_flight = false;
         return ret;
     }
 
     if (k_sem_take(&resp.sem, K_MSEC(15000)) != 0) {
-        LOG_ERR("Timeout waiting for read");
-        /* Worker may still write to static resp later — that's safe.
-         * Next call will check if worker caught up via sem. */
         return -ETIMEDOUT;
     }
+
     read_in_flight = false;
-    if (resp.res) {
-        LOG_ERR("read_audio_data failed: %d", resp.res);
-        return -1;
+    *bytes_read = resp.bytes_read;
+    *packets_read = resp.packets_read;
+    return resp.res;
+}
+
+int sd_ring_advance(uint64_t new_read_seq)
+{
+    static struct status_resp resp;
+    static volatile bool advance_in_flight;
+
+    if (advance_in_flight) {
+        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
+            return -EBUSY;
+        }
+        advance_in_flight = false;
     }
-    return resp.read_bytes;
+
+    advance_in_flight = true;
+    k_sem_init(&resp.sem, 0, 1);
+
+    sd_req_t req = {0};
+    req.type = REQ_ADVANCE_READ;
+    req.u.advance.new_read_seq = new_read_seq;
+    req.u.advance.resp = &resp;
+
+    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    if (ret != 0) {
+        advance_in_flight = false;
+        return ret;
+    }
+
+    if (k_sem_take(&resp.sem, K_MSEC(5000)) != 0) {
+        return -ETIMEDOUT;
+    }
+
+    advance_in_flight = false;
+    return resp.res;
+}
+
+int sd_ring_clear(void)
+{
+    static struct status_resp resp;
+    static volatile bool clear_in_flight;
+
+    if (clear_in_flight) {
+        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
+            return -EBUSY;
+        }
+        clear_in_flight = false;
+    }
+
+    clear_in_flight = true;
+    k_sem_init(&resp.sem, 0, 1);
+
+    sd_req_t req = {0};
+    req.type = REQ_CLEAR_RING;
+    req.u.status.resp = &resp;
+
+    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    if (ret != 0) {
+        clear_in_flight = false;
+        return ret;
+    }
+
+    if (k_sem_take(&resp.sem, K_MSEC(15000)) != 0) {
+        return -ETIMEDOUT;
+    }
+
+    clear_in_flight = false;
+    return resp.res;
 }
 
 int sd_flush_current_file(void)
 {
-    static struct read_resp resp;
+    static struct status_resp resp;
     static volatile bool flush_in_flight;
 
     if (flush_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) == 0) {
-            flush_in_flight = false;
-        } else {
-            LOG_WRN("sd_flush: previous flush still in-flight");
+        if (k_sem_take(&resp.sem, K_NO_WAIT) != 0) {
             return -EBUSY;
         }
+        flush_in_flight = false;
     }
+
     flush_in_flight = true;
     k_sem_init(&resp.sem, 0, 1);
 
     sd_req_t req = {0};
-    req.type = REQ_FLUSH_FILE;
-    req.u.create_file.resp = &resp;
+    req.type = REQ_FLUSH;
+    req.u.status.resp = &resp;
 
     int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
-    if (ret) {
-        LOG_ERR("Failed to queue flush: %d", ret);
+    if (ret != 0) {
         flush_in_flight = false;
         return ret;
     }
 
     if (k_sem_take(&resp.sem, K_MSEC(30000)) != 0) {
-        LOG_ERR("Timeout waiting for flush");
         return -ETIMEDOUT;
     }
+
     flush_in_flight = false;
     return resp.res;
 }
 
-int delete_audio_file(const char *filename)
+uint32_t get_file_size(void)
 {
-    if (!filename)
+    uint64_t used = ring_used_bytes();
+    return (used > UINT32_MAX) ? UINT32_MAX : (uint32_t)used;
+}
+
+int get_current_filename(char *buf, size_t buf_size)
+{
+    if (!buf || buf_size < MAX_FILENAME_LEN) {
         return -EINVAL;
-
-    static struct read_resp resp;
-    static volatile bool delete_in_flight;
-
-    if (delete_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) == 0) {
-            delete_in_flight = false;
-        } else {
-            LOG_WRN("delete_audio_file: previous delete still in-flight");
-            return -EBUSY;
-        }
-    }
-    delete_in_flight = true;
-    k_sem_init(&resp.sem, 0, 1);
-
-    sd_req_t req = {0};
-    req.type = REQ_DELETE_FILE;
-    strncpy(req.u.delete_file.filename, filename, MAX_FILENAME_LEN - 1);
-    req.u.delete_file.resp = &resp;
-
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
-    if (ret) {
-        LOG_ERR("Failed to queue delete: %d", ret);
-        delete_in_flight = false;
-        return ret;
     }
 
-    if (k_sem_take(&resp.sem, K_MSEC(30000)) != 0) {
-        LOG_ERR("Timeout waiting for delete");
-        return -ETIMEDOUT;
-    }
-    delete_in_flight = false;
-    if (resp.res < 0 && resp.res != -ENOENT) {
-        LOG_ERR("delete_audio_file %s failed: %d", filename, resp.res);
-        return resp.res;
-    }
+    strncpy(buf, compat_current_name, buf_size - 1);
+    buf[buf_size - 1] = '\0';
     return 0;
 }
 
 int clear_audio_directory(void)
 {
-    static struct read_resp resp;
-    static volatile bool clear_in_flight;
-
-    if (clear_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) == 0) {
-            clear_in_flight = false;
-        } else {
-            LOG_WRN("clear_audio_directory: previous clear still in-flight");
-            return -EBUSY;
-        }
-    }
-    clear_in_flight = true;
-    k_sem_init(&resp.sem, 0, 1);
-
-    sd_req_t req = {0};
-    req.type = REQ_CLEAR_AUDIO_DIR;
-    req.u.clear_dir.resp = &resp;
-
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
-    if (ret) {
-        LOG_ERR("Failed to queue clear_dir: %d", ret);
-        clear_in_flight = false;
-        return -1;
-    }
-
-    if (k_sem_take(&resp.sem, K_MSEC(60000)) != 0) {
-        LOG_ERR("Timeout waiting for clear_dir");
-        return -1;
-    }
-    clear_in_flight = false;
-    if (resp.res) {
-        LOG_ERR("clear_audio_directory failed: %d", resp.res);
-        return -1;
-    }
-    return 0;
+    return sd_ring_clear();
 }
 
 int save_offset(const char *filename, uint32_t offset)
 {
-    sd_req_t req = {0};
-    req.type = REQ_SAVE_OFFSET;
-    strncpy(req.u.info.offset_info.oldest_filename, filename, MAX_FILENAME_LEN - 1);
-    req.u.info.offset_info.offset_in_file = offset;
-
-    int ret = k_msgq_put(&sd_msgq, &req, K_MSEC(20));
-    if (ret) {
-        LOG_ERR("Failed to queue save_offset: %d", ret);
-        return -1;
+    if (filename) {
+        strncpy(compat_saved_name, filename, sizeof(compat_saved_name) - 1);
+        compat_saved_name[sizeof(compat_saved_name) - 1] = '\0';
+    } else {
+        compat_saved_name[0] = '\0';
     }
+    compat_saved_offset = offset;
     return 0;
 }
 
 int get_offset(char *filename, uint32_t *offset)
 {
-    if (!filename || !offset)
+    if (!filename || !offset) {
         return -EINVAL;
-    strncpy(filename, current_offset_info.oldest_filename, MAX_FILENAME_LEN - 1);
+    }
+
+    strncpy(filename, compat_saved_name, MAX_FILENAME_LEN - 1);
     filename[MAX_FILENAME_LEN - 1] = '\0';
-    *offset = current_offset_info.offset_in_file;
+    *offset = compat_saved_offset;
     return 0;
 }
 
 int create_new_audio_file(void)
 {
-    static struct read_resp resp;
-    static volatile bool create_in_flight;
-
-    if (create_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) == 0) {
-            create_in_flight = false;
-        } else {
-            LOG_WRN("create_new_audio_file: previous request still in-flight");
-            return -EBUSY;
-        }
-    }
-    create_in_flight = true;
-    k_sem_init(&resp.sem, 0, 1);
-
-    sd_req_t req = {0};
-    req.type = REQ_CREATE_NEW_FILE;
-    req.u.create_file.resp = &resp;
-
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(2000));
-    if (ret) {
-        LOG_ERR("Failed to queue create_new_audio_file: %d", ret);
-        create_in_flight = false;
-        return -1;
-    }
-
-    if (k_sem_take(&resp.sem, K_MSEC(15000)) != 0) {
-        LOG_ERR("Timeout waiting for create_new_audio_file");
-        return -1;
-    }
-    create_in_flight = false;
-    if (resp.res) {
-        LOG_ERR("create_new_audio_file failed: %d", resp.res);
-        return -1;
-    }
-
-    if (ble_connected)
-        ble_connect_time_ms = k_uptime_get();
-    return 0;
+    return sd_flush_current_file();
 }
 
 int get_audio_file_stats(uint32_t *file_count, uint64_t *total_size)
 {
-    if (!file_count || !total_size)
+    if (!file_count || !total_size) {
         return -EINVAL;
-
-    if (sd_shutdown_in_progress) {
-        if (cached_stats_valid_until_ms > 0) {
-            *file_count = cached_stats_file_count;
-            *total_size = cached_stats_total_size;
-            return 0;
-        }
-        return -ECANCELED;
     }
 
-    static struct file_stats_resp resp;
-    static volatile bool stats_in_flight;
-    int64_t now = k_uptime_get();
-    k_timeout_t wait_timeout = ble_connected ? K_MSEC(1000) : K_MSEC(30000);
-
-    if (now < cached_stats_valid_until_ms) {
-        *file_count = cached_stats_file_count;
-        *total_size = cached_stats_total_size;
-        return 0;
+    sd_ring_info_t info;
+    int ret = sd_ring_get_info(&info);
+    if (ret < 0) {
+        return ret;
     }
 
-    if (stats_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) == 0) {
-            stats_in_flight = false;
-        } else {
-            LOG_WRN("get_audio_file_stats: previous request still in-flight");
-            if (cached_stats_valid_until_ms > 0) {
-                *file_count = cached_stats_file_count;
-                *total_size = cached_stats_total_size;
-                return 0;
-            }
-            return -EBUSY;
-        }
-    }
-    stats_in_flight = true;
-    k_sem_init(&resp.sem, 0, 1);
-
-    sd_req_t req = {0};
-    req.type = REQ_GET_FILE_STATS;
-    req.u.file_stats.resp = &resp;
-
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(2000));
-    if (ret) {
-        LOG_ERR("Failed to queue get_file_stats: %d", ret);
-        stats_in_flight = false;
-        if (cached_stats_valid_until_ms > 0) {
-            *file_count = cached_stats_file_count;
-            *total_size = cached_stats_total_size;
-            return 0;
-        }
-        return -1;
-    }
-
-    if (k_sem_take(&resp.sem, wait_timeout) != 0) {
-        LOG_ERR("Timeout waiting for get_file_stats");
-        stats_in_flight = false;
-        if (cached_stats_valid_until_ms > 0) {
-            *file_count = cached_stats_file_count;
-            *total_size = cached_stats_total_size;
-            return 0;
-        }
-        return -ETIMEDOUT;
-    }
-    stats_in_flight = false;
-    if (resp.res) {
-        LOG_ERR("get_audio_file_stats failed: %d", resp.res);
-        return -1;
-    }
-
-    cached_stats_file_count = resp.file_count;
-    cached_stats_total_size = resp.total_size;
-    cached_stats_valid_until_ms = k_uptime_get() + FILE_CACHE_TTL_MS;
-
-    *file_count = resp.file_count;
-    *total_size = resp.total_size;
+    *file_count = (info.write_seq > info.read_seq) ? 1U : 0U;
+    *total_size = (info.write_seq - info.read_seq) * RAW_AUDIO_PACKET_BYTES;
     return 0;
 }
 
 int get_audio_file_list(char filenames[][MAX_FILENAME_LEN], int max_files, int *count)
 {
-    if (!filenames || !count || max_files <= 0)
-        return -EINVAL;
-
-    if (sd_shutdown_in_progress) {
-        return -ECANCELED;
-    }
-
-    /* Fast path: during boot the worker is blocked in lfs_fs_gc(),
-     * so it cannot service the priority queue.  Return the file list
-     * that was cached during print_audio_files_at_boot() instead. */
-    if (!atomic_get(&sd_boot_ready) && file_cache_valid) {
-        int n = cached_file_list_count < max_files ? cached_file_list_count : max_files;
-        for (int i = 0; i < n; i++) {
-            strncpy(filenames[i], cached_file_names[i], MAX_FILENAME_LEN - 1);
-            filenames[i][MAX_FILENAME_LEN - 1] = '\0';
-        }
-        *count = n;
-        return 0;
-    }
-
-    static struct file_list_resp resp;
-    static volatile bool list_in_flight;
-
-    if (list_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) == 0) {
-            list_in_flight = false;
-        } else {
-            LOG_WRN("get_audio_file_list: previous request still in-flight");
-            return -EBUSY;
-        }
-    }
-    list_in_flight = true;
-    k_sem_init(&resp.sem, 0, 1);
-    resp.count = 0;
-
-    sd_req_t req = {0};
-    req.type = REQ_GET_FILE_LIST;
-    req.u.file_list.filenames = filenames;
-    req.u.file_list.sizes = NULL; /* no sizes requested */
-    req.u.file_list.max_files = max_files;
-    req.u.file_list.resp = &resp;
-
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(2000));
-    if (ret) {
-        LOG_ERR("Failed to queue get_file_list: %d", ret);
-        list_in_flight = false;
-        return ret;
-    }
-
-    if (k_sem_take(&resp.sem, K_MSEC(5000)) != 0) {
-        LOG_ERR("Timeout waiting for get_file_list");
-        list_in_flight = false;
-        return -ETIMEDOUT;
-    }
-    list_in_flight = false;
-    if (resp.res) {
-        LOG_ERR("get_audio_file_list failed: %d", resp.res);
-        return resp.res;
-    }
-
-    *count = resp.count;
-    return 0;
+    return get_audio_file_list_with_sizes(filenames, NULL, max_files, count);
 }
 
 int get_audio_file_list_with_sizes(char filenames[][MAX_FILENAME_LEN], uint32_t *sizes, int max_files, int *count)
 {
-    if (!filenames || !count || max_files <= 0)
+    if (!filenames || !count || max_files <= 0) {
         return -EINVAL;
-
-    if (sd_shutdown_in_progress) {
-        return -ECANCELED;
     }
 
-    /* Fast path: during boot the worker is blocked in lfs_fs_gc(),
-     * so it cannot service the priority queue.  Return the file list
-     * that was cached during print_audio_files_at_boot() instead. */
-    if (!atomic_get(&sd_boot_ready) && file_cache_valid) {
-        int n = cached_file_list_count < max_files ? cached_file_list_count : max_files;
-        for (int i = 0; i < n; i++) {
-            strncpy(filenames[i], cached_file_names[i], MAX_FILENAME_LEN - 1);
-            filenames[i][MAX_FILENAME_LEN - 1] = '\0';
-            if (sizes) {
-                sizes[i] = cached_file_sizes[i];
-            }
-        }
-        *count = n;
-        return 0;
-    }
-
-    static struct file_list_resp resp;
-    static volatile bool list_sizes_in_flight;
-
-    if (list_sizes_in_flight) {
-        if (k_sem_take(&resp.sem, K_NO_WAIT) == 0) {
-            list_sizes_in_flight = false;
-        } else {
-            LOG_WRN("get_audio_file_list_with_sizes: previous request still in-flight");
-            return -EBUSY;
-        }
-    }
-    list_sizes_in_flight = true;
-    k_sem_init(&resp.sem, 0, 1);
-    resp.count = 0;
-
-    sd_req_t req = {0};
-    req.type = REQ_GET_FILE_LIST;
-    req.u.file_list.filenames = filenames;
-    req.u.file_list.sizes = sizes;
-    req.u.file_list.max_files = max_files;
-    req.u.file_list.resp = &resp;
-
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
-    if (ret) {
-        LOG_ERR("Failed to queue get_file_list: %d", ret);
-        list_sizes_in_flight = false;
+    sd_ring_info_t info;
+    int ret = sd_ring_get_info(&info);
+    if (ret < 0) {
         return ret;
     }
 
-    if (k_sem_take(&resp.sem, K_MSEC(5000)) != 0) {
-        LOG_ERR("Timeout waiting for get_file_list");
-        list_sizes_in_flight = false;
-        return -ETIMEDOUT;
-    }
-    list_sizes_in_flight = false;
-    if (resp.res) {
-        LOG_ERR("get_audio_file_list_with_sizes failed: %d", resp.res);
-        return resp.res;
+    if (info.read_seq == info.write_seq) {
+        *count = 0;
+        return 0;
     }
 
-    *count = resp.count;
+    ret = get_oldest_packet_name(filenames[0], MAX_FILENAME_LEN);
+    if (ret < 0) {
+        return ret;
+    }
+
+    if (sizes) {
+        uint64_t used = (info.write_seq - info.read_seq) * RAW_AUDIO_PACKET_BYTES;
+        sizes[0] = (used > UINT32_MAX) ? UINT32_MAX : (uint32_t)used;
+    }
+
+    *count = 1;
     return 0;
 }
+
+int delete_audio_file(const char *filename)
+{
+    ARG_UNUSED(filename);
+    return sd_ring_clear();
+}
+
+int read_audio_data(const char *filename, uint8_t *buf, int amount, int offset)
+{
+    ARG_UNUSED(filename);
+
+    if (!buf || amount <= 0 || offset < 0) {
+        return -EINVAL;
+    }
+
+    int flush_ret = sd_flush_current_file();
+    if (flush_ret < 0) {
+        return flush_ret;
+    }
+
+    sd_ring_info_t info;
+    int ret = sd_ring_get_info(&info);
+    if (ret < 0) {
+        return ret;
+    }
+
+    uint64_t stream_bytes = (info.write_seq - info.read_seq) * RAW_AUDIO_PACKET_BYTES;
+    if ((uint64_t)offset >= stream_bytes) {
+        return 0;
+    }
+
+    static uint8_t compat_buffer[RAW_AUDIO_PACKET_BYTES * 8U];
+    uint64_t seq = info.read_seq + ((uint32_t)offset / RAW_AUDIO_PACKET_BYTES);
+    uint32_t inner_offset = (uint32_t)offset % RAW_AUDIO_PACKET_BYTES;
+    int total_read = 0;
+
+    while (total_read < amount && seq < info.write_seq) {
+        uint32_t bytes_read = 0;
+        uint32_t packets_read = 0;
+        ret = sd_ring_read(seq, compat_buffer, sizeof(compat_buffer), &bytes_read, &packets_read);
+        if (ret < 0) {
+            return (total_read > 0) ? total_read : ret;
+        }
+        if (bytes_read <= inner_offset || packets_read == 0U) {
+            break;
+        }
+
+        uint32_t available = bytes_read - inner_offset;
+        uint32_t copy_bytes = MIN((uint32_t)(amount - total_read), available);
+        memcpy(buf + total_read, compat_buffer + inner_offset, copy_bytes);
+        total_read += (int)copy_bytes;
+        seq += packets_read;
+        inner_offset = 0;
+    }
+
+    return total_read;
+}
+
+#endif

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -89,6 +89,22 @@ static void release_resp_busy(atomic_t *busy_flag)
     }
 }
 
+static int wait_for_sd_worker_response(struct k_sem *sem, int timeout_ms, const char *op_name)
+{
+    if (!sem || !op_name) {
+        return -EINVAL;
+    }
+
+    if (k_sem_take(sem, K_MSEC(timeout_ms)) == 0) {
+        return 0;
+    }
+
+        LOG_WRN("%s timed out after %d ms waiting for SD worker; subsequent calls may return -EBUSY until the pending request completes",
+            op_name,
+            timeout_ms);
+    return -ETIMEDOUT;
+}
+
 typedef enum {
     REQ_WRITE_DATA,
     REQ_GET_RING_INFO,
@@ -1169,8 +1185,9 @@ int sd_ring_get_info(sd_ring_info_t *info)
         return ret;
     }
 
-    if (k_sem_take(&resp.sem, K_MSEC(5000)) != 0) {
-        return -ETIMEDOUT;
+    ret = wait_for_sd_worker_response(&resp.sem, 5000, "sd_ring_get_info");
+    if (ret < 0) {
+        return ret;
     }
 
     *info = resp.info;
@@ -1213,8 +1230,9 @@ int sd_ring_read(uint64_t start_seq,
         return ret;
     }
 
-    if (k_sem_take(&resp.sem, K_MSEC(15000)) != 0) {
-        return -ETIMEDOUT;
+    ret = wait_for_sd_worker_response(&resp.sem, 15000, "sd_ring_read");
+    if (ret < 0) {
+        return ret;
     }
 
     *bytes_read = resp.bytes_read;
@@ -1246,8 +1264,9 @@ int sd_ring_advance(uint64_t new_read_seq)
         return ret;
     }
 
-    if (k_sem_take(&resp.sem, K_MSEC(5000)) != 0) {
-        return -ETIMEDOUT;
+    ret = wait_for_sd_worker_response(&resp.sem, 5000, "sd_ring_advance");
+    if (ret < 0) {
+        return ret;
     }
 
     return resp.res;
@@ -1276,8 +1295,9 @@ int sd_ring_clear(void)
         return ret;
     }
 
-    if (k_sem_take(&resp.sem, K_MSEC(15000)) != 0) {
-        return -ETIMEDOUT;
+    ret = wait_for_sd_worker_response(&resp.sem, 15000, "sd_ring_clear");
+    if (ret < 0) {
+        return ret;
     }
 
     return resp.res;
@@ -1306,8 +1326,9 @@ int sd_flush_current_file(void)
         return ret;
     }
 
-    if (k_sem_take(&resp.sem, K_MSEC(30000)) != 0) {
-        return -ETIMEDOUT;
+    ret = wait_for_sd_worker_response(&resp.sem, 30000, "sd_flush_current_file");
+    if (ret < 0) {
+        return ret;
     }
 
     return resp.res;

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -401,6 +401,22 @@ static int load_batch_for_seq(uint64_t seq, uint8_t *buffer, struct raw_batch_he
     }
 
     if (header->start_seq != base_seq) {
+        if (header->start_seq > base_seq && ring_state.capacity_packets != 0U &&
+            ((header->start_seq - base_seq) % ring_state.capacity_packets) == 0U) {
+            uint64_t overwritten_end_seq = base_seq + RAW_PACKETS_PER_BATCH;
+            if (ring_state.read_seq < overwritten_end_seq) {
+                ring_state.dropped_packets += overwritten_end_seq - ring_state.read_seq;
+                ring_state.read_seq = overwritten_end_seq;
+                (void)persist_ring_metadata();
+            }
+
+            LOG_WRN("stale read window for seq %llu: slot now holds batch %llu, advancing read_seq to %llu",
+                    (unsigned long long)seq,
+                    (unsigned long long)header->start_seq,
+                    (unsigned long long)ring_state.read_seq);
+            return -ERANGE;
+        }
+
         LOG_ERR("batch start mismatch for seq %llu: hdr=%llu base=%llu",
                 (unsigned long long)seq,
                 (unsigned long long)header->start_seq,
@@ -488,6 +504,15 @@ static int flush_current_batch(bool sync_requested)
     }
 
     uint64_t new_write_seq = current_batch_base_seq + current_batch_packets;
+
+    if (ring_state.write_seq <= current_batch_base_seq && current_batch_base_seq >= ring_state.capacity_packets) {
+        uint64_t overwritten_end_seq = current_batch_base_seq - ring_state.capacity_packets + RAW_PACKETS_PER_BATCH;
+        if (ring_state.read_seq < overwritten_end_seq) {
+            ring_state.dropped_packets += overwritten_end_seq - ring_state.read_seq;
+            ring_state.read_seq = overwritten_end_seq;
+        }
+    }
+
     if ((new_write_seq - ring_state.read_seq) > ring_state.capacity_packets) {
         uint64_t overflow = (new_write_seq - ring_state.read_seq) - ring_state.capacity_packets;
         ring_state.read_seq += overflow;


### PR DESCRIPTION
## Core Idea

- Offline audio is a sequence-based ring buffer, not a file list.
- One logical record = `444 bytes`:
  - `0..3`: UTC timestamp, `uint32 BE`
  - `4..443`: audio payload, `440 bytes`
- Reading does not acknowledge data.
- Only `CMD_RING_ADVANCE` persists consumer progress.

## GATT

- Service: `30295780-4301-EABD-2904-2849ADFEAE43`
- Control char: `30295781-4301-EABD-2904-2849ADFEAE43`
  - properties: `Write + Notify`
  - use this for commands and protocol notifications
- Status char: `30295782-4301-EABD-2904-2849ADFEAE43`
  - properties: `Read + Notify`
  - mainly used for cached status polling

Subscribe to notifications on the Control characteristic.

## Status Char Read

Returns `16 bytes` = `4 x uint32 LE`:

- `0..3`: `used_bytes`
- `4..7`: `unread_packets`
- `8..11`: `free_bytes`
- `12..15`: `rtc_valid`

## Commands

Write commands to the Control characteristic.

### `0x10` `CMD_RING_INFO`

- Request: `[0x10]`
- Meaning: request current ring state

### `0x11` `CMD_RING_READ`

- Request: `[0x11][start_seq: u64 BE]`
- Or: `[0x11][start_seq: u64 BE][packet_count: u32 BE]`
- If `packet_count` is omitted or `0`, firmware streams everything available from `start_seq`

### `0x12` `CMD_RING_ADVANCE`

- Request: `[0x12][new_read_seq: u64 BE]`
- Meaning: durably commit consumer progress

### `0x13` `CMD_RING_CLEAR`

- Request: `[0x13]`
- Meaning: clear the entire ring

### `0x03` `CMD_STOP_SYNC`

- Request: `[0x03]`
- Meaning: stop current transfer only
- Does not persist progress

## Notifications

All notifications are sent on the Control characteristic.

### `0x01` `NOTIFY_ACK`

- Format: `[0x01][status]`

### `0x02` `NOTIFY_INFO`

- Format:
  `[0x02][read_seq: u64 BE][write_seq: u64 BE][capacity_packets: u32 BE][dropped_packets: u64 BE][packet_size: u16 BE]`
- Current `packet_size = 444`

### `0x05` `NOTIFY_READ_BEGIN`

- Format:
  `[0x05][transfer_start_seq: u64 BE][packet_count: u32 BE]`

### `0x03` `NOTIFY_DATA`

- Format:
  `[0x03][raw_bytes...]`
- Important: these are BLE chunks, not guaranteed to align to `444-byte` records
- The app must concatenate all payload bytes and rebuild full records itself

### `0x04` `NOTIFY_DONE`

- Format:
  `[0x04][status][next_seq: u64 BE]`
- If the app stored everything successfully, use `next_seq` in `CMD_RING_ADVANCE`

## Status Codes

- `0`: success
- `6`: invalid command
- `9`: storage not ready
- `10`: sequence out of range

## Important Semantics

- `read_seq` = oldest unread packet
- `write_seq` = next sequence after newest committed packet
- if the ring overwrites old data:
  - firmware auto-advances `read_seq`
  - firmware increments `dropped_packets`
- if the app requests a `start_seq` older than current `read_seq`, firmware returns `10`

## Recommended App Flow

1. Connect.
2. Subscribe to Control notifications.
3. Send `CMD_RING_INFO`.
4. Wait for `NOTIFY_INFO`.
5. Send `CMD_RING_READ(read_seq)`.
6. Wait for `NOTIFY_READ_BEGIN`.
7. Collect `NOTIFY_DATA` chunks and rebuild `444-byte` records.
8. Wait for `NOTIFY_DONE`.
9. If data is safely saved, send `CMD_RING_ADVANCE(next_seq)`.
10. Repeat until `read_seq == write_seq`.

## Migration Note

Old flow was file-based:

- list files
- read file
- delete file

New flow is ring-based:

- get ring info
- read by sequence
- advance by sequence
- clear ring
