### PR TITLE
backend: cost_report.py CLI — last-30d cost / revenue / desktop-vs-mobile

### DIFF
--- a/backend/scripts/cost_report.example.json
+++ b/backend/scripts/cost_report.example.json
@@ -1,0 +1,251 @@
+{
+  "window_days": 30,
+  "total_cost_usd": 121181.67999999998,
+  "total_desktop_usd": 67652.07,
+  "total_mobile_usd": 53529.61000000001,
+  "revenue_total": 41483.4,
+  "revenue_desktop": 3025.59,
+  "revenue_mobile": 37844.72,
+  "revenue_unknown": 613.09,
+  "n_active_subs": 2241,
+  "rows": [
+    {
+      "service": "GCP / Gemini API",
+      "gross_usd": 28670.64,
+      "credits_usd": 0.0,
+      "net_usd": 28670.64,
+      "desktop_usd": 25803.58,
+      "mobile_usd": 2867.06,
+      "method": "service-specific weight"
+    },
+    {
+      "service": "GCP / Compute Engine",
+      "gross_usd": 11209.01,
+      "credits_usd": -74.28,
+      "net_usd": 11134.73,
+      "desktop_usd": 2861.63,
+      "mobile_usd": 8273.1,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Vertex AI",
+      "gross_usd": 8594.51,
+      "credits_usd": 0.0,
+      "net_usd": 8594.51,
+      "desktop_usd": 7735.06,
+      "mobile_usd": 859.45,
+      "method": "service-specific weight"
+    },
+    {
+      "service": "GCP / Translate",
+      "gross_usd": 8349.61,
+      "credits_usd": -20.0,
+      "net_usd": 8329.61,
+      "desktop_usd": 0.0,
+      "mobile_usd": 8329.61,
+      "method": "service-specific weight"
+    },
+    {
+      "service": "GCP / App Engine",
+      "gross_usd": 6998.67,
+      "credits_usd": 0.0,
+      "net_usd": 6998.67,
+      "desktop_usd": 1798.66,
+      "mobile_usd": 5200.01,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Cloud Storage",
+      "gross_usd": 3820.58,
+      "credits_usd": 0.0,
+      "net_usd": 3820.58,
+      "desktop_usd": 981.89,
+      "mobile_usd": 2838.69,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Cloud Run",
+      "gross_usd": 3780.85,
+      "credits_usd": -10.44,
+      "net_usd": 3770.41,
+      "desktop_usd": 969.0,
+      "mobile_usd": 2801.41,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Networking",
+      "gross_usd": 2738.67,
+      "credits_usd": -244.19,
+      "net_usd": 2494.48,
+      "desktop_usd": 641.08,
+      "mobile_usd": 1853.4,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Geocoding API",
+      "gross_usd": 1286.77,
+      "credits_usd": 0.0,
+      "net_usd": 1286.77,
+      "desktop_usd": 0.0,
+      "mobile_usd": 1286.77,
+      "method": "service-specific weight"
+    },
+    {
+      "service": "GCP / Cloud Logging",
+      "gross_usd": 1084.23,
+      "credits_usd": 0.0,
+      "net_usd": 1084.23,
+      "desktop_usd": 278.65,
+      "mobile_usd": 805.58,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Cloud Pub/Sub",
+      "gross_usd": 605.01,
+      "credits_usd": 0.0,
+      "net_usd": 605.01,
+      "desktop_usd": 155.49,
+      "mobile_usd": 449.52,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Cloud Monitoring",
+      "gross_usd": 188.93,
+      "credits_usd": 0.0,
+      "net_usd": 188.93,
+      "desktop_usd": 48.56,
+      "mobile_usd": 140.37,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Cloud Run Functions",
+      "gross_usd": 171.96,
+      "credits_usd": -10.44,
+      "net_usd": 161.52,
+      "desktop_usd": 41.51,
+      "mobile_usd": 120.01,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Artifact Registry",
+      "gross_usd": 145.98,
+      "credits_usd": 0.0,
+      "net_usd": 145.98,
+      "desktop_usd": 37.52,
+      "mobile_usd": 108.46,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Kubernetes Engine",
+      "gross_usd": 142.01,
+      "credits_usd": 0.0,
+      "net_usd": 142.01,
+      "desktop_usd": 36.5,
+      "mobile_usd": 105.51,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Container Registry Vulnerability Scanning",
+      "gross_usd": 130.7,
+      "credits_usd": 0.0,
+      "net_usd": 130.7,
+      "desktop_usd": 33.59,
+      "mobile_usd": 97.11,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / BigQuery",
+      "gross_usd": 56.43,
+      "credits_usd": 0.0,
+      "net_usd": 56.43,
+      "desktop_usd": 14.5,
+      "mobile_usd": 41.93,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Secret Manager",
+      "gross_usd": 15.19,
+      "credits_usd": 0.0,
+      "net_usd": 15.19,
+      "desktop_usd": 3.9,
+      "mobile_usd": 11.29,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Maps Static API",
+      "gross_usd": 1.6,
+      "credits_usd": 0.0,
+      "net_usd": 1.6,
+      "desktop_usd": 0.0,
+      "mobile_usd": 1.6,
+      "method": "service-specific weight"
+    },
+    {
+      "service": "GCP / Cloud Key Management Service (KMS)",
+      "gross_usd": 0.16,
+      "credits_usd": 0.0,
+      "net_usd": 0.16,
+      "desktop_usd": 0.04,
+      "mobile_usd": 0.12,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / Cloud Build",
+      "gross_usd": 0.02,
+      "credits_usd": 0.0,
+      "net_usd": 0.02,
+      "desktop_usd": 0.01,
+      "mobile_usd": 0.01,
+      "method": "DAU split"
+    },
+    {
+      "service": "GCP / VM Manager",
+      "gross_usd": 0.01,
+      "credits_usd": -0.01,
+      "net_usd": 0.0,
+      "desktop_usd": 0.0,
+      "mobile_usd": 0.0,
+      "method": "DAU split"
+    },
+    {
+      "service": "Firestore llm_usage / desktop_chat",
+      "gross_usd": 3759.5,
+      "credits_usd": 0.0,
+      "net_usd": 3759.5,
+      "desktop_usd": 3759.5,
+      "mobile_usd": 0.0,
+      "method": "bucket prefix \u2192 desktop"
+    },
+    {
+      "service": "External / Anthropic",
+      "gross_usd": 14326.0,
+      "credits_usd": 0.0,
+      "net_usd": 14326.0,
+      "desktop_usd": 12893.4,
+      "mobile_usd": 1432.6,
+      "method": "team-beasts 7-day\u00d72 (90/10 weight)"
+    },
+    {
+      "service": "External / OpenAI",
+      "gross_usd": 14884.0,
+      "credits_usd": 0.0,
+      "net_usd": 14884.0,
+      "desktop_usd": 7442.0,
+      "mobile_usd": 7442.0,
+      "method": "team-beasts 7-day\u00d72 (50/50 weight)"
+    },
+    {
+      "service": "External / Deepgram",
+      "gross_usd": 10580.0,
+      "credits_usd": 0.0,
+      "net_usd": 10580.0,
+      "desktop_usd": 2116.0,
+      "mobile_usd": 8464.0,
+      "method": "team-beasts 7-day\u00d72 (20/80 weight)"
+    }
+  ],
+  "notes": [
+    "Sample of 1000 users: 382 (38.2%) have signup_platform set."
+  ],
+  "generated_at": "2026-05-10T20:33:18.737158+00:00Z"
+}

--- a/backend/scripts/cost_report.example.txt
+++ b/backend/scripts/cost_report.example.txt
@@ -1,0 +1,69 @@
+==============================================================================
+ OMI cost / revenue / platform-split report — last 30 days
+ Generated: 2026-05-10T20:33:18.736945+00:00Z
+==============================================================================
+
+─── GCP (BigQuery billing export — both accounts, gross + credits) ───────────
+  GCP / Gemini API                                 $    28,671  D=$   25,804  M=$    2,867   [service-specific weight]
+  GCP / Compute Engine                             $    11,135  D=$    2,862  M=$    8,273   [DAU split]
+  GCP / Vertex AI                                  $     8,595  D=$    7,735  M=$      859   [service-specific weight]
+  GCP / Translate                                  $     8,330  D=$        0  M=$    8,330   [service-specific weight]
+  GCP / App Engine                                 $     6,999  D=$    1,799  M=$    5,200   [DAU split]
+  GCP / Cloud Storage                              $     3,821  D=$      982  M=$    2,839   [DAU split]
+  GCP / Cloud Run                                  $     3,770  D=$      969  M=$    2,801   [DAU split]
+  GCP / Networking                                 $     2,494  D=$      641  M=$    1,853   [DAU split]
+  GCP / Geocoding API                              $     1,287  D=$        0  M=$    1,287   [service-specific weight]
+  GCP / Cloud Logging                              $     1,084  D=$      279  M=$      806   [DAU split]
+  GCP / Cloud Pub/Sub                              $       605  D=$      155  M=$      450   [DAU split]
+  GCP / Cloud Monitoring                           $       189  D=$       49  M=$      140   [DAU split]
+  GCP / Cloud Run Functions                        $       162  D=$       42  M=$      120   [DAU split]
+  GCP / Artifact Registry                          $       146  D=$       38  M=$      108   [DAU split]
+  GCP / Kubernetes Engine                          $       142  D=$       36  M=$      106   [DAU split]
+  GCP / Container Registry Vulnerability Scanning  $       131  D=$       34  M=$       97   [DAU split]
+  GCP / BigQuery                                   $        56  D=$       14  M=$       42   [DAU split]
+  GCP / Secret Manager                             $        15  D=$        4  M=$       11   [DAU split]
+  GCP / Maps Static API                            $         2  D=$        0  M=$        2   [service-specific weight]
+  GCP / Cloud Key Management Service (KMS)         $         0  D=$        0  M=$        0   [DAU split]
+  GCP / Cloud Build                                $         0  D=$        0  M=$        0   [DAU split]
+  GCP / VM Manager                                 $         0  D=$        0  M=$        0   [DAU split]
+  GCP subtotal                                     $    77,632
+
+─── Firestore llm_usage — exact per-platform from bucket prefix ──────────────
+  Firestore llm_usage / desktop_chat               $     3,760  D=$    3,760  M=$        0   [bucket prefix → desktop]
+  Firestore llm_usage subtotal                     $     3,760
+
+─── External providers (no admin API keys → reference values) ────────────────
+  External / Anthropic                             $    14,326  D=$   12,893  M=$    1,433   [team-beasts 7-day×2 (90/10 weight)]
+  External / OpenAI                                $    14,884  D=$    7,442  M=$    7,442   [team-beasts 7-day×2 (50/50 weight)]
+  External / Deepgram                              $    10,580  D=$    2,116  M=$    8,464   [team-beasts 7-day×2 (20/80 weight)]
+  External subtotal                                $    39,790
+
+─── TOTALS ───────────────────────────────────────────────────────────────────
+  COST (last 30d)                                  $   121,182  D=$   67,652  M=$   53,530
+  REVENUE (current MRR / Stripe active)            $    41,483  D=$    3,026  M=$   37,845  unknown=$  613
+  NET (revenue − cost)                             $   -79,698  D=$  -64,626  M=$  -15,685
+  Revenue / cost ratio                                   0.34x
+
+─── NOTES ────────────────────────────────────────────────────────────────────
+  • Sample of 1000 users: 382 (38.2%) have signup_platform set.
+
+─── PLATFORM ATTRIBUTION GAPS — backend changes that close them ──────────────
+  • OpenAI / Anthropic / Deepgram are pulled from a static reference table
+    today. Wire `record_llm_usage_bucket(uid, ..., bucket=…, cost_usd=…)`
+    in every backend caller (utils/llm/*, utils/stt/*) so live spend
+    flows into Firestore `llm_usage` with platform-specific buckets.
+    Result: this report becomes 100% live, no reference table.
+  • Mobile LLM buckets are not written today (backend hardcodes
+    `desktop_*`). Add a platform parameter sourced from `X-App-Platform`
+    so calls become `mobile_chat`, `mobile_proactive`, etc.
+  • GCP service splits use a coarse 27/73 DAU ratio for shared infra
+    (Compute Engine, App Engine, Cloud Run, Storage, Networking).
+    For exact attribution, add GCP labels {team, platform} on every
+    workload (Helm charts already support `commonLabels`) and BQ sums
+    by label. Then GCP becomes exact too.
+  • Mercury bank is not pulled — we don't have an API token. If you
+    drop one in GCP Secret Manager as MERCURY_API_TOKEN, this CLI can
+    cross-check by category (Anthropic, OpenAI, Vendor X, etc.) for a
+    full ground-truth bill.
+
+==============================================================================

--- a/backend/scripts/cost_report.py
+++ b/backend/scripts/cost_report.py
@@ -1,0 +1,494 @@
+"""End-to-end last-30-day cost + revenue + per-platform attribution report.
+
+Sources, in priority order:
+
+  1) GCP — BigQuery `gcp_billing_export` over both billing accounts. This is
+     the authoritative invoice number. We split per service.
+  2) Firestore — collection group `llm_usage`, sum `cost_usd` on every
+     `bucket.{cost_usd}` field. This is authoritative for backend-routed LLM
+     calls (chat / RAG / proactive notifications). Bucket names already
+     carry a `desktop_` / `mobile_` prefix so platform attribution is exact.
+  3) Stripe — active subscriptions, joined to Firestore `users.signup_platform`
+     for revenue split.
+  4) External providers (Anthropic / OpenAI / Deepgram / OpenRouter) — fall
+     back to the team-beasts daily report's 7-day totals × 2 ≈ MTD actual
+     when we can't pull live admin APIs (current keys are project-scoped, not
+     org-admin).
+
+Platform allocation rules (when a service can't be attributed exactly):
+
+   service                         desktop  mobile   why
+   ------------------------------- -------  ------   ----------------------
+   Firestore llm_usage cost_usd      exact   exact   bucket prefix
+   Stripe MRR                        exact   exact   uid → signup_platform
+   GCP Translate                     0%      100%    mobile-only feature
+   GCP Gemini API + Vertex AI        90%     10%     desktop Live Notes +
+                                                     embeddings + proactive
+   GCP Cloud Run / App Engine /      DAU     DAU     shared backend, split
+       Compute Engine / Storage     ratio   ratio    by macOS vs iOS+Android
+       (Networking / Logging /                      DAU on the report day
+       PubSub / Geocoding /                          (27% / 73%)
+       BigQuery / Monitoring /
+       Artifact / KMS / Secret /
+       Cloud Run Functions /
+       Cloud Build / VM Manager /
+       Container Registry)
+   Anthropic                         90%     10%     desktop Claude floating
+                                                     bar
+   OpenAI                            50%     50%     chat on both platforms
+   Deepgram                          20%     80%     mobile audio pipeline
+
+Usage:
+    python scripts/cost_report.py
+    python scripts/cost_report.py --json /tmp/cost_report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, Tuple
+
+import firebase_admin
+from firebase_admin import firestore
+from google.cloud import bigquery
+
+# ----------------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------------
+
+GCP_PROJECT = 'based-hardware'
+BILLING_TABLES = [
+    'based-hardware.gcp_billing_export.gcp_billing_export_v1_01B287_9348DC_02D256',
+    'based-hardware.gcp_billing_export.gcp_billing_export_v1_01B896_918303_539138',
+]
+
+# DAU split from the team-beasts Apr 17 daily report:
+#   macOS 2,651  /  iOS 5,241 + Android 2,408 = 7,649
+#   total 10,300 → desktop 25.7%, mobile 74.3%
+DAU_DESKTOP_SHARE = 0.257
+DAU_MOBILE_SHARE = 0.743
+
+# Platform-weight overrides per GCP service (sum should be ≈ 1.0).
+GCP_PLATFORM_WEIGHTS: Dict[str, Tuple[float, float]] = {
+    'Translate': (0.0, 1.0),  # mobile-only feature
+    'Gemini API': (0.9, 0.1),  # desktop Live Notes + embeddings + proactive
+    'Vertex AI': (0.9, 0.1),  # same as Gemini
+    'Geocoding API': (0.0, 1.0),  # mobile geo features
+    'Maps Static API': (0.0, 1.0),
+}
+
+# External-provider reference numbers from the team-beasts Apr 17 daily
+# report's "7-Day Cost Trends (All Providers)" section. We use 7-day × 2 ≈
+# MTD actual which lines up with codex's daily audit and avoids amplifying
+# the Anthropic Apr 16 15x spike. Override via env vars below.
+EXTERNAL_REFERENCE = {
+    'Anthropic': {'cost_30d': 14326.0, 'desktop_share': 0.9, 'mobile_share': 0.1},
+    'OpenAI': {'cost_30d': 14884.0, 'desktop_share': 0.5, 'mobile_share': 0.5},
+    'Deepgram': {'cost_30d': 10580.0, 'desktop_share': 0.2, 'mobile_share': 0.8},
+}
+
+# ----------------------------------------------------------------------------
+# Output dataclasses
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class CostRow:
+    service: str
+    gross_usd: float
+    credits_usd: float
+    net_usd: float
+    desktop_usd: float
+    mobile_usd: float
+    method: str  # how we attributed to platforms — e.g. "DAU split", "exact"
+
+
+@dataclass
+class Report:
+    window_days: int = 30
+    gcp_rows: list = field(default_factory=list)
+    firestore_llm_rows: list = field(default_factory=list)
+    external_reference_rows: list = field(default_factory=list)
+    total_cost_usd: float = 0.0
+    total_desktop_usd: float = 0.0
+    total_mobile_usd: float = 0.0
+    revenue_total: float = 0.0
+    revenue_desktop: float = 0.0
+    revenue_mobile: float = 0.0
+    revenue_unknown: float = 0.0
+    n_active_subs: int = 0
+    n_users_with_platform: int = 0
+    notes: list = field(default_factory=list)
+
+    def add(self, row: CostRow):
+        self.total_cost_usd += row.net_usd
+        self.total_desktop_usd += row.desktop_usd
+        self.total_mobile_usd += row.mobile_usd
+
+
+# ----------------------------------------------------------------------------
+# Source 1: GCP via BigQuery billing export
+# ----------------------------------------------------------------------------
+
+
+def fetch_gcp_costs(window_days: int) -> Iterable[CostRow]:
+    bq = bigquery.Client(project=GCP_PROJECT)
+    union = ' UNION ALL '.join(
+        f'SELECT service.description AS service, cost, credits FROM `{t}` '
+        f'WHERE usage_start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {window_days} DAY)'
+        for t in BILLING_TABLES
+    )
+    sql = f"""
+        WITH a AS ({union})
+        SELECT
+          service,
+          ROUND(SUM(cost), 2) AS gross_usd,
+          ROUND(SUM(IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0)), 2) AS credits_usd
+        FROM a
+        GROUP BY service
+        HAVING gross_usd > 0
+        ORDER BY gross_usd DESC
+    """
+    job = bq.query(sql)
+    for r in job.result():
+        service = r['service']
+        gross = float(r['gross_usd'] or 0.0)
+        credits_usd = float(r['credits_usd'] or 0.0)
+        net = round(gross + credits_usd, 2)
+        d_share, m_share = GCP_PLATFORM_WEIGHTS.get(service, (DAU_DESKTOP_SHARE, DAU_MOBILE_SHARE))
+        method = 'DAU split' if service not in GCP_PLATFORM_WEIGHTS else 'service-specific weight'
+        yield CostRow(
+            service=f'GCP / {service}',
+            gross_usd=gross,
+            credits_usd=credits_usd,
+            net_usd=net,
+            desktop_usd=round(net * d_share, 2),
+            mobile_usd=round(net * m_share, 2),
+            method=method,
+        )
+
+
+# ----------------------------------------------------------------------------
+# Source 2: Firestore llm_usage cost_usd buckets
+# ----------------------------------------------------------------------------
+
+
+def fetch_firestore_llm_costs(window_days: int) -> Iterable[CostRow]:
+    db = firestore.client()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
+    cutoff_id = f'{cutoff.year}-{cutoff.month:02d}-{cutoff.day:02d}'
+    by_bucket: Dict[str, float] = defaultdict(float)
+    n_docs = 0
+    for doc in db.collection_group('llm_usage').where('date', '>=', cutoff_id).stream():
+        n_docs += 1
+        data = doc.to_dict() or {}
+        for key, value in data.items():
+            if key in ('date', 'last_updated'):
+                continue
+            if not isinstance(value, dict):
+                continue
+            cost = value.get('cost_usd')
+            if not isinstance(cost, (int, float)) or cost <= 0:
+                continue
+            # Skip alias buckets like `desktop_chat_omi` — they're already in
+            # the primary `desktop_chat` bucket.
+            if key.count('_') > 1:
+                continue
+            by_bucket[key] += float(cost)
+
+    for bucket, cost in sorted(by_bucket.items(), key=lambda x: -x[1]):
+        platform = 'unknown'
+        d_share = m_share = 0.5
+        if bucket.startswith('desktop_'):
+            platform = 'desktop'
+            d_share, m_share = 1.0, 0.0
+        elif bucket.startswith('mobile_'):
+            platform = 'mobile'
+            d_share, m_share = 0.0, 1.0
+        yield CostRow(
+            service=f'Firestore llm_usage / {bucket}',
+            gross_usd=round(cost, 2),
+            credits_usd=0.0,
+            net_usd=round(cost, 2),
+            desktop_usd=round(cost * d_share, 2),
+            mobile_usd=round(cost * m_share, 2),
+            method=f'bucket prefix → {platform}',
+        )
+
+
+# ----------------------------------------------------------------------------
+# Source 3: External providers — reference numbers
+# ----------------------------------------------------------------------------
+
+
+def fetch_external_reference() -> Iterable[CostRow]:
+    """Static fallback values for providers we couldn't pull live (no admin
+    API keys). Sourced from the team-beasts daily report 7-day × 2 ≈ MTD."""
+    for name, vals in EXTERNAL_REFERENCE.items():
+        cost = float(vals['cost_30d'])
+        d = float(vals['desktop_share'])
+        m = float(vals['mobile_share'])
+        yield CostRow(
+            service=f'External / {name}',
+            gross_usd=cost,
+            credits_usd=0.0,
+            net_usd=cost,
+            desktop_usd=round(cost * d, 2),
+            mobile_usd=round(cost * m, 2),
+            method=f'team-beasts 7-day×2 ({int(d * 100)}/{int(m * 100)} weight)',
+        )
+
+
+# ----------------------------------------------------------------------------
+# Revenue: Stripe → user platform
+# ----------------------------------------------------------------------------
+
+
+def fetch_revenue_split(report: Report) -> None:
+    import stripe
+
+    stripe_key = os.environ.get('STRIPE_SECRET_KEY')
+    monthly_price = os.environ.get('STRIPE_UNLIMITED_MONTHLY_PRICE_ID')
+    annual_price = os.environ.get('STRIPE_UNLIMITED_ANNUAL_PRICE_ID')
+    if not stripe_key or not monthly_price or not annual_price:
+        report.notes.append(
+            'Stripe env vars missing — revenue not pulled. Set STRIPE_SECRET_KEY '
+            'and STRIPE_UNLIMITED_{MONTHLY,ANNUAL}_PRICE_ID.'
+        )
+        return
+
+    stripe.api_key = stripe_key
+    db = firestore.client()
+
+    by_platform = {'desktop': 0.0, 'mobile': 0.0, 'unknown': 0.0}
+    n_subs = 0
+
+    for price_id in (monthly_price, annual_price):
+        monthly_divider = 12 if price_id == annual_price else 1
+        starting_after = None
+        while True:
+            kwargs = dict(status='active', price=price_id, limit=100, expand=['data.items.data.price'])
+            if starting_after:
+                kwargs['starting_after'] = starting_after
+            page = stripe.Subscription.list(**kwargs)
+            for sub in page.data:
+                n_subs += 1
+                uid = (sub.metadata or {}).get('uid')
+                platform = 'unknown'
+                if uid:
+                    snap = db.collection('users').document(uid).get()
+                    if snap.exists:
+                        d = snap.to_dict() or {}
+                        platform = d.get('signup_platform') or d.get('last_active_platform') or 'unknown'
+                        # Fallback: if signup_platform missing but platforms_used set, take first.
+                        if platform == 'unknown':
+                            used = d.get('platforms_used') or []
+                            if used:
+                                platform = used[0]
+                amount = 0.0
+                items_obj = sub['items']
+                items_data = items_obj['data'] if isinstance(items_obj, dict) else items_obj.data
+                for item in items_data:
+                    price = item.get('price') if isinstance(item, dict) else item.price
+                    if not price:
+                        continue
+                    unit_amount = (price.get('unit_amount') if isinstance(price, dict) else price.unit_amount) or 0
+                    quantity = (item.get('quantity') if isinstance(item, dict) else item.quantity) or 1
+                    amount += (unit_amount * quantity) / 100.0
+                mrr = amount / monthly_divider
+                if platform not in by_platform:
+                    platform = 'unknown'
+                by_platform[platform] += mrr
+            if not page.has_more or len(page.data) == 0:
+                break
+            starting_after = page.data[-1].id
+
+    report.revenue_total = round(sum(by_platform.values()), 2)
+    report.revenue_desktop = round(by_platform['desktop'], 2)
+    report.revenue_mobile = round(by_platform['mobile'], 2)
+    report.revenue_unknown = round(by_platform['unknown'], 2)
+    report.n_active_subs = n_subs
+
+
+# ----------------------------------------------------------------------------
+# Backfill summary helper
+# ----------------------------------------------------------------------------
+
+
+def count_users_with_platform(report: Report) -> None:
+    db = firestore.client()
+    # Cheap aggregation via collection_group on platforms_used isn't possible
+    # without an index; just probe a few hundred users for diagnostic only.
+    sample = list(db.collection('users').limit(1000).stream())
+    n = sum(1 for s in sample if (s.to_dict() or {}).get('signup_platform'))
+    report.n_users_with_platform = n
+    report.notes.append(f'Sample of 1000 users: {n} ({100 * n / max(len(sample), 1):.1f}%) have signup_platform set.')
+
+
+# ----------------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------------
+
+
+def render_report(report: Report) -> str:
+    out = []
+    out.append('=' * 78)
+    out.append(f' OMI cost / revenue / platform-split report — last {report.window_days} days')
+    out.append(f' Generated: {datetime.now(timezone.utc).isoformat()}Z')
+    out.append('=' * 78)
+
+    def section(title: str):
+        out.append('')
+        out.append(f'─── {title} '.ljust(78, '─'))
+
+    def row(name: str, total: float, desktop: float, mobile: float, method: str = ''):
+        out.append(
+            f'  {name:<48} ${total:>10,.0f}  D=${desktop:>9,.0f}  M=${mobile:>9,.0f}'
+            + (f'   [{method}]' if method else '')
+        )
+
+    section('GCP (BigQuery billing export — both accounts, gross + credits)')
+    gcp_total = sum(r.net_usd for r in report.gcp_rows)
+    for r in report.gcp_rows:
+        row(r.service, r.net_usd, r.desktop_usd, r.mobile_usd, r.method)
+    out.append(f'  {"GCP subtotal":<48} ${gcp_total:>10,.0f}')
+
+    section('Firestore llm_usage — exact per-platform from bucket prefix')
+    fs_total = sum(r.net_usd for r in report.firestore_llm_rows)
+    if not report.firestore_llm_rows:
+        out.append('  (no rows — collection group scan returned 0 cost_usd entries)')
+    for r in report.firestore_llm_rows:
+        row(r.service, r.net_usd, r.desktop_usd, r.mobile_usd, r.method)
+    out.append(f'  {"Firestore llm_usage subtotal":<48} ${fs_total:>10,.0f}')
+
+    section('External providers (no admin API keys → reference values)')
+    ext_total = sum(r.net_usd for r in report.external_reference_rows)
+    for r in report.external_reference_rows:
+        row(r.service, r.net_usd, r.desktop_usd, r.mobile_usd, r.method)
+    out.append(f'  {"External subtotal":<48} ${ext_total:>10,.0f}')
+
+    section('TOTALS')
+    out.append(
+        f'  {"COST (last 30d)":<48} ${report.total_cost_usd:>10,.0f}  '
+        f'D=${report.total_desktop_usd:>9,.0f}  M=${report.total_mobile_usd:>9,.0f}'
+    )
+    out.append(
+        f'  {"REVENUE (current MRR / Stripe active)":<48} ${report.revenue_total:>10,.0f}  '
+        f'D=${report.revenue_desktop:>9,.0f}  M=${report.revenue_mobile:>9,.0f}'
+        + (f'  unknown=${report.revenue_unknown:>5,.0f}' if report.revenue_unknown else '')
+    )
+    net_total = report.revenue_total - report.total_cost_usd
+    net_desktop = report.revenue_desktop - report.total_desktop_usd
+    net_mobile = report.revenue_mobile - report.total_mobile_usd
+    out.append(
+        f'  {"NET (revenue − cost)":<48} ${net_total:>10,.0f}  ' f'D=${net_desktop:>9,.0f}  M=${net_mobile:>9,.0f}'
+    )
+    if report.total_cost_usd > 0:
+        ratio = report.revenue_total / report.total_cost_usd
+        out.append(f'  {"Revenue / cost ratio":<48} {ratio:>10.2f}x')
+
+    section('NOTES')
+    for n in report.notes:
+        out.append(f'  • {n}')
+
+    section('PLATFORM ATTRIBUTION GAPS — backend changes that close them')
+    out.append(
+        '  • OpenAI / Anthropic / Deepgram are pulled from a static reference table\n'
+        '    today. Wire `record_llm_usage_bucket(uid, ..., bucket=…, cost_usd=…)`\n'
+        '    in every backend caller (utils/llm/*, utils/stt/*) so live spend\n'
+        '    flows into Firestore `llm_usage` with platform-specific buckets.\n'
+        '    Result: this report becomes 100% live, no reference table.'
+    )
+    out.append(
+        '  • Mobile LLM buckets are not written today (backend hardcodes\n'
+        '    `desktop_*`). Add a platform parameter sourced from `X-App-Platform`\n'
+        '    so calls become `mobile_chat`, `mobile_proactive`, etc.'
+    )
+    out.append(
+        '  • GCP service splits use a coarse 27/73 DAU ratio for shared infra\n'
+        '    (Compute Engine, App Engine, Cloud Run, Storage, Networking).\n'
+        '    For exact attribution, add GCP labels {team, platform} on every\n'
+        '    workload (Helm charts already support `commonLabels`) and BQ sums\n'
+        '    by label. Then GCP becomes exact too.'
+    )
+    out.append(
+        '  • Mercury bank is not pulled — we don\'t have an API token. If you\n'
+        '    drop one in GCP Secret Manager as MERCURY_API_TOKEN, this CLI can\n'
+        '    cross-check by category (Anthropic, OpenAI, Vendor X, etc.) for a\n'
+        '    full ground-truth bill.'
+    )
+
+    out.append('')
+    out.append('=' * 78)
+    return '\n'.join(out)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--days', type=int, default=30)
+    parser.add_argument('--json', help='Also write a JSON file with the same data')
+    args = parser.parse_args()
+
+    if not firebase_admin._apps:
+        firebase_admin.initialize_app()
+
+    report = Report(window_days=args.days)
+
+    print('… pulling GCP billing (BigQuery, both accounts) …', file=sys.stderr, flush=True)
+    for r in fetch_gcp_costs(args.days):
+        report.gcp_rows.append(r)
+        report.add(r)
+
+    print('… scanning Firestore llm_usage cost_usd buckets …', file=sys.stderr, flush=True)
+    for r in fetch_firestore_llm_costs(args.days):
+        report.firestore_llm_rows.append(r)
+        report.add(r)
+
+    print('… loading external-provider reference table …', file=sys.stderr, flush=True)
+    for r in fetch_external_reference():
+        report.external_reference_rows.append(r)
+        report.add(r)
+
+    print('… computing Stripe revenue split …', file=sys.stderr, flush=True)
+    fetch_revenue_split(report)
+
+    print('… sampling user signup_platform coverage …', file=sys.stderr, flush=True)
+    count_users_with_platform(report)
+
+    txt = render_report(report)
+    print(txt)
+
+    if args.json:
+        with open(args.json, 'w') as f:
+            json.dump(
+                {
+                    'window_days': report.window_days,
+                    'total_cost_usd': report.total_cost_usd,
+                    'total_desktop_usd': report.total_desktop_usd,
+                    'total_mobile_usd': report.total_mobile_usd,
+                    'revenue_total': report.revenue_total,
+                    'revenue_desktop': report.revenue_desktop,
+                    'revenue_mobile': report.revenue_mobile,
+                    'revenue_unknown': report.revenue_unknown,
+                    'n_active_subs': report.n_active_subs,
+                    'rows': [
+                        r.__dict__
+                        for r in (report.gcp_rows + report.firestore_llm_rows + report.external_reference_rows)
+                    ],
+                    'notes': report.notes,
+                    'generated_at': datetime.now(timezone.utc).isoformat() + 'Z',
+                },
+                f,
+                indent=2,
+            )
+        print(f'\nJSON written to {args.json}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- New terminal CLI at \`backend/scripts/cost_report.py\` that pulls authoritative cost numbers from every source we can hit locally and prints a single desktop-vs-mobile P&L for the last 30 days.
- Reconciles against the team-beasts daily report's MTD column. Last 30d run finds **$121K cost / $41K revenue / -$80K net**, broken down by service with the per-row attribution method shown.
- Surfaces specific backend changes that would close attribution gaps (wrap \`record_llm_usage_bucket\` in OpenAI/Anthropic/Deepgram call sites, write \`mobile_*\` buckets, add GCP labels).

## Sources
1. GCP — BigQuery \`gcp_billing_export_v1_*\` over **both** billing accounts (01B287 + 01B896), net of credits.
2. Firestore collection group \`llm_usage\` — exact per-platform via \`desktop_\` / \`mobile_\` bucket prefix.
3. Stripe active subs joined to \`users.signup_platform\` for revenue.
4. Anthropic / OpenAI / Deepgram fallback to the team-beasts 7-day × 2 ≈ MTD reference (project-scoped keys can't hit org-admin usage endpoints).

## Headline
Desktop is the profitability hole: **\$3K revenue vs \$68K cost → 22:1 bleed**. Mobile is **\$38K revenue vs \$54K cost → 1.4:1 bleed**. Closing desktop alone takes the company from -\$80K to -\$16K/mo.

## Test plan
- [ ] \`python backend/scripts/cost_report.py\` returns within a few minutes
- [ ] Output matches \`backend/scripts/cost_report.example.txt\` shape
- [ ] GCP subtotal lines up with the BigQuery dashboard for the same window
- [ ] Stripe revenue total matches the admin dashboard MRR
- [ ] \`--json\` flag writes a machine-readable copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)