### PR TITLE
feat(desktop): route beta channel to dev backend

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Beta builds now talk to the development backend for faster fixes \u2014 your data still lives in production"
+  ],
   "releases": [
     {
       "version": "0.11.379",

--- a/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -8,20 +8,34 @@ enum DesktopBackendEnvironment {
   static var shouldUseDevelopmentBackends: Bool {
     shouldUseDevelopmentBackends(
       bundleIdentifier: AppBuild.bundleIdentifier,
-      updateChannel: AppBuild.currentUpdateChannel
+      updateChannel: AppBuild.currentUpdateChannel,
+      forceOverride: currentEnvironmentValue("OMI_FORCE_DEV_BACKENDS")
     )
   }
 
   static func shouldUseDevelopmentBackends(
     bundleIdentifier: String,
-    updateChannel: String
+    updateChannel: String,
+    forceOverride: String? = nil
   ) -> Bool {
-    // Beta-to-dev routing disabled: signed-in users were landing in fresh empty
-    // Firebase accounts (e.g. caLCFj7… instead of viUv7Gtdo… for kodjima33),
-    // because the dev backend's auth path mints custom tokens for new UIDs
-    // instead of linking to the existing prod user. Keep beta on prod backends
-    // until the auth flow is fixed.
-    return false
+    // Beta channel of the production bundle routes to the dev backend
+    // (api.omiapi.com + dev Cloud Run desktop-backend). The dev backend is
+    // configured to use prod Firebase (project_id=based-hardware, prod service
+    // account, prod FIREBASE_API_KEY), so custom tokens it mints resolve to the
+    // same UID a user has on prod — and reads/writes hit prod Firestore. Same
+    // pattern as mobile TestFlight → staging.
+    //
+    // PR #7014 (April 2026) was reverted because at that time the dev backend
+    // was wired to the based-hardware-dev Firebase project, so beta users
+    // ended up signed in as fresh empty UIDs. The infra has since been moved
+    // onto prod Firebase. Verify before any future revert: dev backend
+    // /v1/auth/token must mint custom tokens whose UID matches prod.
+    if isAffirmative(forceOverride) {
+      return true
+    }
+
+    return bundleIdentifier == AppBuild.productionBundleIdentifier
+      && normalizedChannel(updateChannel) == "beta"
   }
 
   static func pythonBaseURL(
@@ -101,5 +115,11 @@ enum DesktopBackendEnvironment {
       return nil
     }
     return string
+  }
+
+  private static func isAffirmative(_ value: String?) -> Bool {
+    guard let value else { return false }
+    let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return normalized == "1" || normalized == "true" || normalized == "yes"
   }
 }

--- a/desktop/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/Desktop/Tests/APIClientRoutingTests.swift
@@ -154,23 +154,53 @@ final class APIClientRoutingTests: XCTestCase {
         XCTAssertEqual(url, "https://desktop-backend-hhibjajaja-uc.a.run.app/")
     }
 
-    func testDevelopmentBackendRoutingDisabled() {
-        // Beta-to-dev routing disabled — see DesktopBackendEnvironment for context.
-        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+    func testBetaProductionBundleRoutesToDevelopmentBackends() {
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "beta"
         ))
-        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+        // "staging" is normalized to "beta" — same routing.
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "staging"
         ))
+    }
+
+    func testStableProductionBundleKeepsProductionBackends() {
         XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "stable"
         ))
+    }
+
+    func testNonProductionBundleSkipsAutomaticBetaRouting() {
+        // Dev bundle and named test bundles never trigger beta-to-dev routing
+        // automatically. They must opt in via OMI_FORCE_DEV_BACKENDS or env URLs.
         XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.desktop-dev",
             updateChannel: "beta"
+        ))
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.omi-beta-dev-test",
+            updateChannel: "beta"
+        ))
+    }
+
+    func testForceOverrideEnablesDevelopmentBackendsForAnyBundle() {
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.desktop-dev",
+            updateChannel: "stable",
+            forceOverride: "1"
+        ))
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.omi-beta-dev-test",
+            updateChannel: "stable",
+            forceOverride: "true"
+        ))
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.computer-macos",
+            updateChannel: "stable",
+            forceOverride: "0"
         ))
     }
 


### PR DESCRIPTION
## Summary

- Beta channel of the production bundle (`com.omi.computer-macos`) now routes to the dev backend (`api.omiapi.com` Python + dev Cloud Run desktop-backend), matching mobile's TestFlight → staging pattern.
- Stable channel and non-prod bundles are unchanged.
- New `OMI_FORCE_DEV_BACKENDS=1` env override lets a named test bundle opt into dev backends without flipping its channel — handy for side-by-side validation.

## Why this won't repeat the PR #7014 outage

PR #7014 (April 2026) was reverted because the dev backend was wired to the `based-hardware-dev` Firebase project, so beta users signed in as fresh empty UIDs (e.g. `caLCFj7…` instead of prod's `viUv7Gtdo…`). The dev backend infra has since been moved onto prod Firebase. Verified against the live deployments:

```
$ gcloud run services describe backend --project=based-hardware-dev …
  FIREBASE_PROJECT_ID = based-hardware
  FIREBASE_AUTH_DOMAIN = based-hardware.firebaseapp.com
  GOOGLE_CLOUD_PROJECT = based-hardware
  FIREBASE_API_KEY = AIzaSyA88g…   (matches prod)
  SERVICE_ACCOUNT_JSON.project_id = based-hardware
  client_email = nik-164@based-hardware.iam.gserviceaccount.com

$ gcloud run services describe desktop-backend --project=based-hardware-dev …
  FIREBASE_PROJECT_ID = based-hardware
  FIREBASE_API_KEY = AIzaSyA88g…   (matches prod)
```

So custom tokens minted by the dev backend resolve to the **same UID** the user has on prod, and reads/writes hit prod Firestore.

## Test plan

- [x] `swift test --filter APIClientRoutingTests` (46/46 passing)
- [ ] Codemagic builds Beta DMG from this branch on merge
- [ ] Install Beta DMG on Mac mini, sign in with kodjima33@gmail.com
- [ ] Confirm `auth_userId` defaults shows the prod UID (`viUv7Gtdo…`), not a fresh one
- [ ] Confirm existing conversations + memories load
- [ ] Record a new conversation; confirm it appears in prod Firestore for the prod UID
- [ ] Confirm stable channel of the same prod bundle keeps using `api.omi.me`

🤖 Generated with [Claude Code](https://claude.com/claude-code)