### PR TITLE
Update CHANGELOG.json for v0.11.380 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Beta builds now talk to the development backend for faster fixes \u2014 your data still lives in production"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.380",
+      "date": "2026-05-10",
+      "changes": [
+        "Beta builds now talk to the development backend for faster fixes \u2014 your data still lives in production"
+      ]
+    },
     {
       "version": "0.11.379",
       "date": "2026-05-07",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.380 and clears the unreleased array.