### PR TITLE
ci(desktop): surface silent x86_64 build failures

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2214,7 +2214,19 @@ workflows:
           # Build x86_64 (cross-compile). Use --triple for explicit arch directory.
           echo "Building x86_64..."
           xcrun swift build -c release --package-path Desktop --triple x86_64-apple-macosx
+
           X86_64_PATH="Desktop/.build/x86_64-apple-macosx/release/$BINARY_NAME"
+          # Symmetric existence check — without this, a silent x86_64 build failure
+          # (exit 0 but no output) bubbles up later as "missing binary" in the
+          # universal-bundle step with no traceback. Burned a build in May 2026.
+          if [ ! -f "$X86_64_PATH" ]; then
+            echo "ERROR: x86_64 binary not found at $X86_64_PATH"
+            echo "Listing $(dirname "$X86_64_PATH"):"
+            ls -la "$(dirname "$X86_64_PATH")" 2>&1 | head -30 || true
+            echo "Listing Desktop/.build/:"
+            ls -la "Desktop/.build/" 2>&1 || true
+            exit 1
+          fi
           echo "x86_64 binary: $(file "$X86_64_PATH" | grep -oE 'arm64|x86_64' | head -1)"
 
       - name: Create universal app bundle


### PR DESCRIPTION
## Why

The `omi-desktop-swift-release` workflow's **Build Swift app** step had an existence check after the arm64 build but not after x86_64. If `xcrun swift build --triple x86_64-apple-macosx` exits 0 without producing the binary, the step silently "succeeds" and the next step (`Create universal app bundle`) fails with a generic "MISSING binary" message — no traceback to the real cause.

Burned [Codemagic build 6a010cef](https://codemagic.io/app/66c95e6ec76853c447b8bcbb/build/6a010cef41af7cbd7a303786) → [rebuild 6a011902](https://codemagic.io/app/66c95e6ec76853c447b8bcbb/build/6a011902b7dce80ea62f9ed6) on v0.11.380. Same failure both times: `Create universal app bundle` fails in 0.6s; `Build Swift app` reports success in 601s, 33s shorter than the prior 634s success — strongly implying the x86_64 build was silently skipped.

## What this changes

Add a symmetric existence check after the x86_64 build (mirroring the arm64 one). If x86_64 didn't produce output, exit early with a directory listing. The actual swift-build error (if any) remains visible in this step's stderr.

## Test plan

- [ ] Merge to main → auto-release bumps to v0.11.381 → Codemagic runs.
- [ ] If x86_64 build is silently failing: the next attempt fails with a clear error pointing at the swift-build invocation (i.e. we'll then know what to fix in the code).
- [ ] If x86_64 builds fine and the universal-bundle step still fails: rules out my hypothesis and points elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)