### PR TITLE
backend: send freemium event on connect so paywalled popup fires on short sessions

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -410,6 +410,21 @@ async def _stream_handler(
 
     freemium_threshold_sent = False  # Track if we've sent the freemium threshold notification
 
+    # Push the freemium threshold event upfront for already-exhausted users so
+    # the desktop popup appears immediately on connect, instead of waiting for
+    # the periodic loop's first 60s tick (typical desktop session is shorter).
+    if not user_has_credits:
+        try:
+            await websocket.send_json(
+                FreemiumThresholdReachedEvent(
+                    remaining_seconds=0,
+                    action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT,
+                ).to_json()
+            )
+            freemium_threshold_sent = True
+        except Exception as e:
+            logger.error(f"Error sending freemium threshold event on connect: {e} {uid} {session_id}")
+
     # Credit cache: avoid querying ~720 Firestore docs every 60s per stream (#5439 sub-task 1)
     CREDITS_REFRESH_SECONDS = 900  # 15 min
     remaining_seconds_cache: Optional[int] = None  # None = not yet fetched (distinct from unlimited)


### PR DESCRIPTION
## Summary

Bigbeeme33 paywall test (#7226) deployed cleanly — `has_transcription_credits` correctly returns False, mobile push notification fires. But the desktop popup never showed because the WS event that triggers it (`FreemiumThresholdReachedEvent`) only fires from the 60s periodic loop in `_record_usage_periodically`, and the user's desktop sessions were 5–45s.

This sends the same event upfront at WS connect when the user is already credit-exhausted, so the popup appears immediately. `freemium_threshold_sent` is set after the early send so the periodic loop doesn't double-fire.

## Test plan

- [x] Syntax check
- [ ] After deploy, bigbeeme33 reconnects → popup shows within seconds
- [ ] Verify periodic loop doesn't re-send for the same session

🤖 Generated with [Claude Code](https://claude.com/claude-code)