### PR TITLE
backend: extend bigbeeme paywall to chat + proactive notifications

### DIFF
--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -22,6 +22,7 @@ from database.apps import record_app_usage
 from database.chat import add_app_message, get_app_messages
 from database.goals import get_user_goals
 from database.notifications import get_mentor_notification_frequency
+from utils.subscription import is_trial_paywalled
 from database.redis_db import (
     get_generic_cache,
     set_generic_cache,
@@ -540,6 +541,12 @@ async def _async_trigger_realtime_audio_bytes(uid: str, sample_rate: int, data: 
 
 
 async def _async_trigger_realtime_integrations(uid: str, segments: List[dict], conversation_id: str | None) -> dict:
+    # Paywall test: skip mentor + third-party proactive notifications for the
+    # cohort entirely (no LLM spend, no FCM push). Reactivates automatically
+    # once the user is removed from the allowlist.
+    if is_trial_paywalled(uid):
+        return {}
+
     # Process mentor notification first (built-in feature) — sync, runs in thread
     mentor_results = {}
     loop = asyncio.get_running_loop()

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -272,6 +272,20 @@ def get_chat_quota_snapshot(uid: str) -> dict:
     """Cheap computation of `is_allowed / used / limit / unit / plan` — shared
     between the `/v1/users/me/usage-quota` endpoint and the enforcement helper.
     """
+    # Paywall test override — surface as exhausted Free-plan quota so the
+    # client renders the same over-limit popup it shows for normal users
+    # past 30/mo.
+    if is_trial_paywalled(uid):
+        usage = user_usage_db.get_monthly_chat_usage(uid)
+        return {
+            'plan': PlanType.basic,
+            'unit': 'questions',
+            'used': float(FREE_CHAT_QUESTIONS_PER_MONTH),
+            'limit': float(FREE_CHAT_QUESTIONS_PER_MONTH),
+            'allowed': False,
+            'reset_at': usage['reset_at'],
+        }
+
     subscription = users_db.get_user_valid_subscription(uid)
     plan = subscription.plan if subscription else PlanType.basic
     limits = get_plan_limits(plan)
@@ -316,6 +330,24 @@ def enforce_chat_quota(uid: str) -> None:
     - Free plan past its cap: blocked (no card on file) → 402, which the
       chat endpoint converts into a canned AI reply for mobile UX.
     """
+    # Paywall test override — bypass BYOK + plan checks so the same 402
+    # surfaces that a free user past 30 questions would hit. The chat
+    # router converts this into the existing canned over-limit reply.
+    if is_trial_paywalled(uid):
+        snapshot = get_chat_quota_snapshot(uid)
+        raise HTTPException(
+            status_code=402,
+            detail={
+                'error': 'quota_exceeded',
+                'plan': get_plan_display_name(PlanType.basic),
+                'plan_type': PlanType.basic.value,
+                'unit': snapshot['unit'],
+                'used': round(snapshot['used'], 4),
+                'limit': snapshot['limit'],
+                'reset_at': snapshot['reset_at'],
+            },
+        )
+
     # BYOK users pay their own LLM provider — no Omi-side cost to cap.
     # Require an LLM provider key on this request (not just any BYOK header)
     # so a user can't activate with fake fingerprints or send only x-byok-deepgram


### PR DESCRIPTION
## Summary

Mirrors the existing Free over-limit UX (mobile + desktop) for the paywall test cohort:

- **Chat quota snapshot** returns `allowed=False, used==limit` so the desktop FloatingBarUsageLimiter renders the existing usage-limit popup before the chat send leaves the client (both `ChatProvider.sendMessage` and the floating bar gate on `isLimitReached`)
- **enforce_chat_quota** raises the same `402 quota_exceeded` a Free user past 30 questions hits — chat router converts to the canned reply on mobile
- **Proactive notifications** (mentor + third-party app) early-return at `_async_trigger_realtime_integrations` for paywalled UIDs

Combined with #7228 (transcription deny + freemium-event-on-connect), the cohort experiences the same lockdown a Free user past every limit would: no recording, no chat (popup shown), no proactive pings.

Cohort: `bigbeeme33@gmail.com`. Reactivates automatically by removing from the env-overridable allowlist.

## Test plan

- [x] `get_chat_quota_snapshot('bigbeeme')` → `allowed=False, used=30, limit=30`
- [x] `enforce_chat_quota('bigbeeme')` → `HTTPException 402(quota_exceeded)`
- [x] `enforce_chat_quota('kodjima' [unlimited])` → passes
- [ ] After deploy, bigbeeme tries chat → popup shows
- [ ] After deploy, no proactive notifications fire for cohort

🤖 Generated with [Claude Code](https://claude.com/claude-code)