### PR TITLE
Revert "feat(desktop): route beta channel to dev backend"

### DIFF
--- a/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -8,34 +8,20 @@ enum DesktopBackendEnvironment {
   static var shouldUseDevelopmentBackends: Bool {
     shouldUseDevelopmentBackends(
       bundleIdentifier: AppBuild.bundleIdentifier,
-      updateChannel: AppBuild.currentUpdateChannel,
-      forceOverride: currentEnvironmentValue("OMI_FORCE_DEV_BACKENDS")
+      updateChannel: AppBuild.currentUpdateChannel
     )
   }
 
   static func shouldUseDevelopmentBackends(
     bundleIdentifier: String,
-    updateChannel: String,
-    forceOverride: String? = nil
+    updateChannel: String
   ) -> Bool {
-    // Beta channel of the production bundle routes to the dev backend
-    // (api.omiapi.com + dev Cloud Run desktop-backend). The dev backend is
-    // configured to use prod Firebase (project_id=based-hardware, prod service
-    // account, prod FIREBASE_API_KEY), so custom tokens it mints resolve to the
-    // same UID a user has on prod — and reads/writes hit prod Firestore. Same
-    // pattern as mobile TestFlight → staging.
-    //
-    // PR #7014 (April 2026) was reverted because at that time the dev backend
-    // was wired to the based-hardware-dev Firebase project, so beta users
-    // ended up signed in as fresh empty UIDs. The infra has since been moved
-    // onto prod Firebase. Verify before any future revert: dev backend
-    // /v1/auth/token must mint custom tokens whose UID matches prod.
-    if isAffirmative(forceOverride) {
-      return true
-    }
-
-    return bundleIdentifier == AppBuild.productionBundleIdentifier
-      && normalizedChannel(updateChannel) == "beta"
+    // Beta-to-dev routing disabled: signed-in users were landing in fresh empty
+    // Firebase accounts (e.g. caLCFj7… instead of viUv7Gtdo… for kodjima33),
+    // because the dev backend's auth path mints custom tokens for new UIDs
+    // instead of linking to the existing prod user. Keep beta on prod backends
+    // until the auth flow is fixed.
+    return false
   }
 
   static func pythonBaseURL(
@@ -115,11 +101,5 @@ enum DesktopBackendEnvironment {
       return nil
     }
     return string
-  }
-
-  private static func isAffirmative(_ value: String?) -> Bool {
-    guard let value else { return false }
-    let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    return normalized == "1" || normalized == "true" || normalized == "yes"
   }
 }

--- a/desktop/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/Desktop/Tests/APIClientRoutingTests.swift
@@ -154,53 +154,23 @@ final class APIClientRoutingTests: XCTestCase {
         XCTAssertEqual(url, "https://desktop-backend-hhibjajaja-uc.a.run.app/")
     }
 
-    func testBetaProductionBundleRoutesToDevelopmentBackends() {
-        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+    func testDevelopmentBackendRoutingDisabled() {
+        // Beta-to-dev routing disabled — see DesktopBackendEnvironment for context.
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "beta"
         ))
-        // "staging" is normalized to "beta" — same routing.
-        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "staging"
         ))
-    }
-
-    func testStableProductionBundleKeepsProductionBackends() {
         XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "stable"
         ))
-    }
-
-    func testNonProductionBundleSkipsAutomaticBetaRouting() {
-        // Dev bundle and named test bundles never trigger beta-to-dev routing
-        // automatically. They must opt in via OMI_FORCE_DEV_BACKENDS or env URLs.
         XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.desktop-dev",
             updateChannel: "beta"
-        ))
-        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
-            bundleIdentifier: "com.omi.omi-beta-dev-test",
-            updateChannel: "beta"
-        ))
-    }
-
-    func testForceOverrideEnablesDevelopmentBackendsForAnyBundle() {
-        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
-            bundleIdentifier: "com.omi.desktop-dev",
-            updateChannel: "stable",
-            forceOverride: "1"
-        ))
-        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
-            bundleIdentifier: "com.omi.omi-beta-dev-test",
-            updateChannel: "stable",
-            forceOverride: "true"
-        ))
-        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
-            bundleIdentifier: "com.omi.computer-macos",
-            updateChannel: "stable",
-            forceOverride: "0"
         ))
     }
 


### PR DESCRIPTION
Reverts #7224. The change was merged before being validated locally; we want to test the dev-backend routing on a named local bundle first (using the `OMI_FORCE_DEV_BACKENDS` override I added in that PR — except the env-var didn't actually reach the launched .app because `run.sh` loads URLs via a baked `Contents/Resources/.env`, not shell env). Reverting on `main`, validating locally, then redoing.

The diagnostic PR #7227 stays — that's an unrelated workflow hardening that's useful regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)