### PR TITLE
Reapply: route desktop beta channel to dev backend

### DIFF
--- a/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
+++ b/desktop/Desktop/Sources/DesktopBackendEnvironment.swift
@@ -8,20 +8,34 @@ enum DesktopBackendEnvironment {
   static var shouldUseDevelopmentBackends: Bool {
     shouldUseDevelopmentBackends(
       bundleIdentifier: AppBuild.bundleIdentifier,
-      updateChannel: AppBuild.currentUpdateChannel
+      updateChannel: AppBuild.currentUpdateChannel,
+      forceOverride: currentEnvironmentValue("OMI_FORCE_DEV_BACKENDS")
     )
   }
 
   static func shouldUseDevelopmentBackends(
     bundleIdentifier: String,
-    updateChannel: String
+    updateChannel: String,
+    forceOverride: String? = nil
   ) -> Bool {
-    // Beta-to-dev routing disabled: signed-in users were landing in fresh empty
-    // Firebase accounts (e.g. caLCFj7… instead of viUv7Gtdo… for kodjima33),
-    // because the dev backend's auth path mints custom tokens for new UIDs
-    // instead of linking to the existing prod user. Keep beta on prod backends
-    // until the auth flow is fixed.
-    return false
+    // Beta channel of the production bundle routes to the dev backend
+    // (api.omiapi.com + dev Cloud Run desktop-backend). The dev backend is
+    // configured to use prod Firebase (project_id=based-hardware, prod service
+    // account, prod FIREBASE_API_KEY), so custom tokens it mints resolve to the
+    // same UID a user has on prod — and reads/writes hit prod Firestore. Same
+    // pattern as mobile TestFlight → staging.
+    //
+    // PR #7014 (April 2026) was reverted because at that time the dev backend
+    // was wired to the based-hardware-dev Firebase project, so beta users
+    // ended up signed in as fresh empty UIDs. The infra has since been moved
+    // onto prod Firebase. Verify before any future revert: dev backend
+    // /v1/auth/token must mint custom tokens whose UID matches prod.
+    if isAffirmative(forceOverride) {
+      return true
+    }
+
+    return bundleIdentifier == AppBuild.productionBundleIdentifier
+      && normalizedChannel(updateChannel) == "beta"
   }
 
   static func pythonBaseURL(
@@ -101,5 +115,11 @@ enum DesktopBackendEnvironment {
       return nil
     }
     return string
+  }
+
+  private static func isAffirmative(_ value: String?) -> Bool {
+    guard let value else { return false }
+    let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return normalized == "1" || normalized == "true" || normalized == "yes"
   }
 }

--- a/desktop/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/Desktop/Tests/APIClientRoutingTests.swift
@@ -154,23 +154,53 @@ final class APIClientRoutingTests: XCTestCase {
         XCTAssertEqual(url, "https://desktop-backend-hhibjajaja-uc.a.run.app/")
     }
 
-    func testDevelopmentBackendRoutingDisabled() {
-        // Beta-to-dev routing disabled — see DesktopBackendEnvironment for context.
-        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+    func testBetaProductionBundleRoutesToDevelopmentBackends() {
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "beta"
         ))
-        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+        // "staging" is normalized to "beta" — same routing.
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "staging"
         ))
+    }
+
+    func testStableProductionBundleKeepsProductionBackends() {
         XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.computer-macos",
             updateChannel: "stable"
         ))
+    }
+
+    func testNonProductionBundleSkipsAutomaticBetaRouting() {
+        // Dev bundle and named test bundles never trigger beta-to-dev routing
+        // automatically. They must opt in via OMI_FORCE_DEV_BACKENDS or env URLs.
         XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
             bundleIdentifier: "com.omi.desktop-dev",
             updateChannel: "beta"
+        ))
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.omi-beta-dev-test",
+            updateChannel: "beta"
+        ))
+    }
+
+    func testForceOverrideEnablesDevelopmentBackendsForAnyBundle() {
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.desktop-dev",
+            updateChannel: "stable",
+            forceOverride: "1"
+        ))
+        XCTAssertTrue(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.omi-beta-dev-test",
+            updateChannel: "stable",
+            forceOverride: "true"
+        ))
+        XCTAssertFalse(DesktopBackendEnvironment.shouldUseDevelopmentBackends(
+            bundleIdentifier: "com.omi.computer-macos",
+            updateChannel: "stable",
+            forceOverride: "0"
         ))
     }
 


### PR DESCRIPTION
Reapplies #7224 after the #7230 revert. Verified locally this time:

- Named bundle (`com.omi.omi-beta-dev-test`) launched with shell-bundled dev URLs (`OMI_PYTHON_API_URL=https://api.omiapi.com/`, `OMI_DESKTOP_API_URL=https://desktop-backend-dt5lrfkkoa-uc.a.run.app/`).
- Signed in with `kodjima33@gmail.com` — landed on **prod UID `viUv7GtdoHXbK1UBCDlPuTDuPgJ2`** (not a ghost dev UID).
- Existing chat history and tasks loaded.
- New requests go through dev backend: `POST https://api.omiapi.com/v2/desktop/messages`, `/v3/memories`, `/v1/action-items` — all succeeding, AgentSync pushing rows.
- Confirms dev backend's `SERVICE_ACCOUNT_JSON`, `FIREBASE_API_KEY`, `FIREBASE_PROJECT_ID` are all on prod Firebase (`based-hardware`), so dev-issued custom tokens resolve to the same prod UID.

This time the change ships through the existing #7227 diagnostic patch (already on main), so if Codemagic's universal-bundle step trips again we'll get a real error instead of a 0.6s opaque failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)