### PR TITLE
feat(app) notify user when Omi is fully charged

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2165,6 +2165,8 @@
     "selectOption": "اختر",
     "lowBatteryAlertTitle": "تنبيه انخفاض البطارية",
     "lowBatteryAlertBody": "بطارية جهازك منخفضة. حان وقت إعادة الشحن! 🔋",
+    "batteryFullyChargedTitle": "أومي مشحون بالكامل",
+    "batteryFullyChargedBody": "جهاز Omi الخاص بك مشحون بالكامل. يمكنك فصله الآن!",
     "deviceDisconnectedNotificationTitle": "تم قطع اتصال جهاز Omi",
     "deviceDisconnectedNotificationBody": "يرجى إعادة الاتصال لمتابعة استخدام Omi.",
     "firmwareUpdateAvailable": "تحديث البرنامج الثابت متاح",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Ваша прыстасаванне буквальна вычарпвае батарэю. Час пазарадзіць! 🔋",
+    "batteryFullyChargedTitle": "Omi поўнасцю зараджаны",
+    "batteryFullyChargedBody": "Ваш прылада Omi поўнасцю зараджана. Можаце адключыць!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2167,6 +2167,8 @@
     "selectOption": "Избери",
     "lowBatteryAlertTitle": "Предупреждение за изтощена батерия",
     "lowBatteryAlertBody": "Батерията на устройството ви е изтощена. Време е за презареждане! 🔋",
+    "batteryFullyChargedTitle": "Omi е напълно зареден",
+    "batteryFullyChargedBody": "Вашето устройство Omi е напълно заредено. Можете да го изключите!",
     "deviceDisconnectedNotificationTitle": "Вашето Omi устройство е изключено",
     "deviceDisconnectedNotificationBody": "Моля, свържете се отново, за да продължите да използвате Omi.",
     "firmwareUpdateAvailable": "Налична е актуализация на фърмуера",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "আপনার ডিভাইসের ব্যাটারি কম হয়ে যাচ্ছে। চার্জ করার সময় এসেছে! 🔋",
+    "batteryFullyChargedTitle": "Omi সম্পূর্ণ চার্জ হয়েছে",
+    "batteryFullyChargedBody": "আপনার Omi ডিভাইস সম্পূর্ণ চার্জ হয়েছে। আনপ্লাগ করতে পারেন!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Vaš uređaj ima nisku bateriju. Vrijeme je za ponovno punjena! 🔋",
+    "batteryFullyChargedTitle": "Omi je potpuno napunjen",
+    "batteryFullyChargedBody": "Vaš Omi uređaj je potpuno napunjen. Možete ga iskopčati!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2167,6 +2167,8 @@
     "selectOption": "Seleccionar",
     "lowBatteryAlertTitle": "Alerta de bateria baixa",
     "lowBatteryAlertBody": "La bateria del teu dispositiu és baixa. És hora de carregar! 🔋",
+    "batteryFullyChargedTitle": "L'Omi està completament carregat",
+    "batteryFullyChargedBody": "El teu dispositiu Omi està completament carregat. Pots desconnectar-lo!",
     "deviceDisconnectedNotificationTitle": "El teu dispositiu Omi s'ha desconnectat",
     "deviceDisconnectedNotificationBody": "Si us plau, reconnecta per continuar utilitzant Omi.",
     "firmwareUpdateAvailable": "Actualització de firmware disponible",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2144,6 +2144,8 @@
     "selectOption": "Vybrat",
     "lowBatteryAlertTitle": "Upozornění na vybitou baterii",
     "lowBatteryAlertBody": "Baterie vašeho zařízení je vybitá. Je čas ji dobít! 🔋",
+    "batteryFullyChargedTitle": "Omi je plně nabitý",
+    "batteryFullyChargedBody": "Vaše zařízení Omi je plně nabité. Můžete jej odpojit!",
     "deviceDisconnectedNotificationTitle": "Vaše zařízení Omi bylo odpojeno",
     "deviceDisconnectedNotificationBody": "Prosím, znovu se připojte, abyste mohli pokračovat v používání Omi.",
     "firmwareUpdateAvailable": "K dispozici je aktualizace firmwaru",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2142,6 +2142,8 @@
     "selectOption": "Vælg",
     "lowBatteryAlertTitle": "Advarsel om lavt batteri",
     "lowBatteryAlertBody": "Din enheds batteri er lavt. Det er tid til at genoplade! 🔋",
+    "batteryFullyChargedTitle": "Omi er fuldt opladet",
+    "batteryFullyChargedBody": "Din Omi-enhed er fuldt opladet. Du kan frakoble den nu!",
     "deviceDisconnectedNotificationTitle": "Din Omi-enhed er afbrudt",
     "deviceDisconnectedNotificationBody": "Tilslut venligst igen for at fortsætte med at bruge din Omi.",
     "firmwareUpdateAvailable": "Firmwareopdatering tilgængelig",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2166,6 +2166,8 @@
     "selectOption": "Auswählen",
     "lowBatteryAlertTitle": "Warnung: Niedriger Akkustand",
     "lowBatteryAlertBody": "Der Akkustand Ihres Geräts ist niedrig. Zeit zum Aufladen! 🔋",
+    "batteryFullyChargedTitle": "Omi ist vollständig geladen",
+    "batteryFullyChargedBody": "Dein Omi-Gerät ist vollständig geladen. Du kannst es jetzt ausstecken!",
     "deviceDisconnectedNotificationTitle": "Ihr Omi-Gerät wurde getrennt",
     "deviceDisconnectedNotificationBody": "Bitte verbinden Sie sich erneut, um Ihr Omi weiter zu nutzen.",
     "firmwareUpdateAvailable": "Firmware-Update verfügbar",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Επιλογή",
     "lowBatteryAlertTitle": "Ειδοποίηση χαμηλής μπαταρίας",
     "lowBatteryAlertBody": "Η μπαταρία της συσκευής σας είναι χαμηλή. Ώρα για επαναφόρτιση! 🔋",
+    "batteryFullyChargedTitle": "Το Omi έχει φορτιστεί πλήρως",
+    "batteryFullyChargedBody": "Η συσκευή Omi σου είναι πλήρως φορτισμένη. Μπορείς να την αποσυνδέσεις!",
     "deviceDisconnectedNotificationTitle": "Η συσκευή Omi σας αποσυνδέθηκε",
     "deviceDisconnectedNotificationBody": "Παρακαλώ επανασυνδεθείτε για να συνεχίσετε να χρησιμοποιείτε το Omi.",
     "firmwareUpdateAvailable": "Διαθέσιμη ενημέρωση υλικολογισμικού",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -8402,6 +8402,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Your device is running low on battery. Time for a recharge! 🔋",
+    "batteryFullyChargedTitle": "Omi is charged fully",
+    "batteryFullyChargedBody": "Your Omi device is fully charged. Feel free to unplug!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -8402,7 +8402,7 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Your device is running low on battery. Time for a recharge! 🔋",
-    "batteryFullyChargedTitle": "Omi is charged fully",
+    "batteryFullyChargedTitle": "Omi is fully charged",
     "batteryFullyChargedBody": "Your Omi device is fully charged. Feel free to unplug!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2185,6 +2185,8 @@
     "selectOption": "Seleccionar",
     "lowBatteryAlertTitle": "Alerta de batería baja",
     "lowBatteryAlertBody": "La batería de tu dispositivo está baja. ¡Es hora de recargar! 🔋",
+    "batteryFullyChargedTitle": "Omi está completamente cargado",
+    "batteryFullyChargedBody": "Tu dispositivo Omi está completamente cargado. ¡Puedes desenchufarlo!",
     "deviceDisconnectedNotificationTitle": "Tu dispositivo Omi se desconectó",
     "deviceDisconnectedNotificationBody": "Por favor, vuelve a conectar para seguir usando tu Omi.",
     "firmwareUpdateAvailable": "Actualización de firmware disponible",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Vali",
     "lowBatteryAlertTitle": "Tühja aku hoiatus",
     "lowBatteryAlertBody": "Teie seadme aku on tühi. Aeg laadida! 🔋",
+    "batteryFullyChargedTitle": "Omi on täielikult laetud",
+    "batteryFullyChargedBody": "Teie Omi seade on täielikult laetud. Võite selle lahti ühendada!",
     "deviceDisconnectedNotificationTitle": "Teie Omi seade on lahti ühendatud",
     "deviceDisconnectedNotificationBody": "Palun ühendage uuesti, et jätkata Omi kasutamist.",
     "firmwareUpdateAvailable": "Püsivara värskendus saadaval",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "باتری دستگاه شما تقریباً تمام است. وقت شارژ کردن است! 🔋",
+    "batteryFullyChargedTitle": "Omi کاملاً شارژ شد",
+    "batteryFullyChargedBody": "دستگاه Omi شما کاملاً شارژ شده است. می‌توانید آن را جدا کنید!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Valitse",
     "lowBatteryAlertTitle": "Alhaisen akun varoitus",
     "lowBatteryAlertBody": "Laitteesi akku on alhainen. Aika ladata! 🔋",
+    "batteryFullyChargedTitle": "Omi on ladattu täyteen",
+    "batteryFullyChargedBody": "Omi-laitteesi on ladattu täyteen. Voit irrottaa sen nyt!",
     "deviceDisconnectedNotificationTitle": "Omi-laitteesi yhteys katkesi",
     "deviceDisconnectedNotificationBody": "Yhdistä uudelleen jatkaaksesi Omin käyttöä.",
     "firmwareUpdateAvailable": "Laiteohjelmistopäivitys saatavilla",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Sélectionner",
     "lowBatteryAlertTitle": "Alerte de batterie faible",
     "lowBatteryAlertBody": "La batterie de votre appareil est faible. Il est temps de recharger ! 🔋",
+    "batteryFullyChargedTitle": "Omi est complètement chargé",
+    "batteryFullyChargedBody": "Votre appareil Omi est complètement chargé. Vous pouvez le débrancher !",
     "deviceDisconnectedNotificationTitle": "Votre appareil Omi s'est déconnecté",
     "deviceDisconnectedNotificationBody": "Veuillez vous reconnecter pour continuer à utiliser votre Omi.",
     "firmwareUpdateAvailable": "Mise à jour du firmware disponible",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "ההתקן שלך נמצא בסוללה נמוכה. הגיע הזמן לטעינה מחדש! 🔋",
+    "batteryFullyChargedTitle": "Omi טעון לגמרי",
+    "batteryFullyChargedBody": "מכשיר Omi שלך טעון לגמרי. אפשר לנתק אותו!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2185,6 +2185,8 @@
     "selectOption": "चुनें",
     "lowBatteryAlertTitle": "कम बैटरी अलर्ट",
     "lowBatteryAlertBody": "आपके डिवाइस की बैटरी कम है। रिचार्ज करने का समय! 🔋",
+    "batteryFullyChargedTitle": "Omi पूरी तरह चार्ज हो गया है",
+    "batteryFullyChargedBody": "आपका Omi डिवाइस पूरी तरह चार्ज हो गया है। इसे अनप्लग कर सकते हैं!",
     "deviceDisconnectedNotificationTitle": "आपका Omi डिवाइस डिस्कनेक्ट हो गया",
     "deviceDisconnectedNotificationBody": "कृपया Omi का उपयोग जारी रखने के लिए पुनः कनेक्ट करें।",
     "firmwareUpdateAvailable": "फर्मवेयर अपडेट उपलब्ध",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Vaš uređaj ima nisku bateriju. Vrijeme je za puniranje! 🔋",
+    "batteryFullyChargedTitle": "Omi je potpuno napunjen",
+    "batteryFullyChargedBody": "Vaš Omi uređaj je potpuno napunjen. Možete ga iskopčati!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Kiválasztás",
     "lowBatteryAlertTitle": "Alacsony akkumulátor figyelmeztetés",
     "lowBatteryAlertBody": "Az eszköz akkumulátora alacsony. Ideje feltölteni! 🔋",
+    "batteryFullyChargedTitle": "Az Omi teljesen feltöltődött",
+    "batteryFullyChargedBody": "Az Omi eszköz teljesen feltöltődött. Leválaszthatod!",
     "deviceDisconnectedNotificationTitle": "Az Omi eszköz lecsatlakozott",
     "deviceDisconnectedNotificationBody": "Kérjük, csatlakozzon újra az Omi használatának folytatásához.",
     "firmwareUpdateAvailable": "Firmware frissítés elérhető",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Pilih",
     "lowBatteryAlertTitle": "Peringatan Baterai Lemah",
     "lowBatteryAlertBody": "Baterai perangkat Anda lemah. Saatnya mengisi ulang! 🔋",
+    "batteryFullyChargedTitle": "Omi sudah terisi penuh",
+    "batteryFullyChargedBody": "Perangkat Omi Anda sudah terisi penuh. Silakan cabut kabelnya!",
     "deviceDisconnectedNotificationTitle": "Perangkat Omi Anda Terputus",
     "deviceDisconnectedNotificationBody": "Silakan sambungkan kembali untuk terus menggunakan Omi.",
     "firmwareUpdateAvailable": "Pembaruan Firmware Tersedia",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Seleziona",
     "lowBatteryAlertTitle": "Avviso batteria scarica",
     "lowBatteryAlertBody": "La batteria del dispositivo è scarica. È ora di ricaricare! 🔋",
+    "batteryFullyChargedTitle": "Omi è completamente carico",
+    "batteryFullyChargedBody": "Il tuo dispositivo Omi è completamente carico. Puoi scollegarlo!",
     "deviceDisconnectedNotificationTitle": "Il tuo dispositivo Omi si è disconnesso",
     "deviceDisconnectedNotificationBody": "Riconnettiti per continuare a usare Omi.",
     "firmwareUpdateAvailable": "Aggiornamento firmware disponibile",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2185,6 +2185,8 @@
     "selectOption": "選択",
     "lowBatteryAlertTitle": "バッテリー残量低下アラート",
     "lowBatteryAlertBody": "デバイスのバッテリーが少なくなっています。充電してください！🔋",
+    "batteryFullyChargedTitle": "Omiは満充電です",
+    "batteryFullyChargedBody": "Omiデバイスが満充電になりました。充電ケーブルを外してください！",
     "deviceDisconnectedNotificationTitle": "Omiデバイスが切断されました",
     "deviceDisconnectedNotificationBody": "Omiを引き続き使用するには再接続してください。",
     "firmwareUpdateAvailable": "ファームウェアアップデートが利用可能",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "ನಿಮ್ಮ ಸಾಧನವು ಬ್ಯಾಟರಿ ಕಡಿಮೆಯಿದೆ. ಚಾರ್ಜ್ ಮಾಡುವ ಸಮಯ! 🔋",
+    "batteryFullyChargedTitle": "Omi ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ",
+    "batteryFullyChargedBody": "ನಿಮ್ಮ Omi ಸಾಧನ ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ. ಅನ್‌ಪ್ಲಗ್ ಮಾಡಬಹುದು!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "선택",
     "lowBatteryAlertTitle": "배터리 부족 알림",
     "lowBatteryAlertBody": "기기의 배터리가 부족합니다. 충전할 시간입니다! 🔋",
+    "batteryFullyChargedTitle": "Omi가 완전히 충전되었습니다",
+    "batteryFullyChargedBody": "Omi 기기가 완전히 충전되었습니다. 이제 플러그를 뽑으셔도 됩니다!",
     "deviceDisconnectedNotificationTitle": "Omi 기기가 연결 해제되었습니다",
     "deviceDisconnectedNotificationBody": "Omi를 계속 사용하려면 다시 연결해 주세요.",
     "firmwareUpdateAvailable": "펌웨어 업데이트 사용 가능",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -12894,7 +12894,7 @@ abstract class AppLocalizations {
   /// No description provided for @batteryFullyChargedTitle.
   ///
   /// In en, this message translates to:
-  /// **'Omi is charged fully'**
+  /// **'Omi is fully charged'**
   String get batteryFullyChargedTitle;
 
   /// No description provided for @batteryFullyChargedBody.

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -12891,6 +12891,18 @@ abstract class AppLocalizations {
   /// **'Your device is running low on battery. Time for a recharge! 🔋'**
   String get lowBatteryAlertBody;
 
+  /// No description provided for @batteryFullyChargedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Omi is charged fully'**
+  String get batteryFullyChargedTitle;
+
+  /// No description provided for @batteryFullyChargedBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Your Omi device is fully charged. Feel free to unplug!'**
+  String get batteryFullyChargedBody;
+
   /// Title for device disconnected notification
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -6789,6 +6789,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get lowBatteryAlertBody => 'بطارية جهازك منخفضة. حان وقت إعادة الشحن! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'أومي مشحون بالكامل';
+
+  @override
+  String get batteryFullyChargedBody => 'جهاز Omi الخاص بك مشحون بالكامل. يمكنك فصله الآن!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'تم قطع اتصال جهاز Omi';
 
   @override

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -6860,6 +6860,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get lowBatteryAlertBody => 'Ваша прыстасаванне буквальна вычарпвае батарэю. Час пазарадзіць! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi поўнасцю зараджаны';
+
+  @override
+  String get batteryFullyChargedBody => 'Ваш прылада Omi поўнасцю зараджана. Можаце адключыць!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Ваша прыстасаванне Omi адключылося';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -6864,6 +6864,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get lowBatteryAlertBody => 'Батерията на устройството ви е изтощена. Време е за презареждане! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi е напълно зареден';
+
+  @override
+  String get batteryFullyChargedBody => 'Вашето устройство Omi е напълно заредено. Можете да го изключите!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Вашето Omi устройство е изключено';
 
   @override

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -6849,6 +6849,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get lowBatteryAlertBody => 'আপনার ডিভাইসের ব্যাটারি কম হয়ে যাচ্ছে। চার্জ করার সময় এসেছে! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi সম্পূর্ণ চার্জ হয়েছে';
+
+  @override
+  String get batteryFullyChargedBody => 'আপনার Omi ডিভাইস সম্পূর্ণ চার্জ হয়েছে। আনপ্লাগ করতে পারেন!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'আপনার Omi ডিভাইস সংযোগ বিচ্ছিন্ন হয়েছে';
 
   @override

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -6855,6 +6855,12 @@ class AppLocalizationsBs extends AppLocalizations {
   String get lowBatteryAlertBody => 'Vaš uređaj ima nisku bateriju. Vrijeme je za ponovno punjena! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi je potpuno napunjen';
+
+  @override
+  String get batteryFullyChargedBody => 'Vaš Omi uređaj je potpuno napunjen. Možete ga iskopčati!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Vaš Omi uređaj se odvojio';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -6877,6 +6877,12 @@ class AppLocalizationsCa extends AppLocalizations {
   String get lowBatteryAlertBody => 'La bateria del teu dispositiu és baixa. És hora de carregar! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'L\'Omi està completament carregat';
+
+  @override
+  String get batteryFullyChargedBody => 'El teu dispositiu Omi està completament carregat. Pots desconnectar-lo!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'El teu dispositiu Omi s\'ha desconnectat';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -6829,6 +6829,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get lowBatteryAlertBody => 'Baterie vašeho zařízení je vybitá. Je čas ji dobít! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi je plně nabitý';
+
+  @override
+  String get batteryFullyChargedBody => 'Vaše zařízení Omi je plně nabité. Můžete jej odpojit!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Vaše zařízení Omi bylo odpojeno';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -6821,6 +6821,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get lowBatteryAlertBody => 'Din enheds batteri er lavt. Det er tid til at genoplade! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi er fuldt opladet';
+
+  @override
+  String get batteryFullyChargedBody => 'Din Omi-enhed er fuldt opladet. Du kan frakoble den nu!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Din Omi-enhed er afbrudt';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -6889,6 +6889,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get lowBatteryAlertBody => 'Der Akkustand Ihres Geräts ist niedrig. Zeit zum Aufladen! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi ist vollständig geladen';
+
+  @override
+  String get batteryFullyChargedBody => 'Dein Omi-Gerät ist vollständig geladen. Du kannst es jetzt ausstecken!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Ihr Omi-Gerät wurde getrennt';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -6887,6 +6887,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get lowBatteryAlertBody => 'Η μπαταρία της συσκευής σας είναι χαμηλή. Ώρα για επαναφόρτιση! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Το Omi έχει φορτιστεί πλήρως';
+
+  @override
+  String get batteryFullyChargedBody => 'Η συσκευή Omi σου είναι πλήρως φορτισμένη. Μπορείς να την αποσυνδέσεις!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Η συσκευή Omi σας αποσυνδέθηκε';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -6835,7 +6835,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get lowBatteryAlertBody => 'Your device is running low on battery. Time for a recharge! 🔋';
 
   @override
-  String get batteryFullyChargedTitle => 'Omi is charged fully';
+  String get batteryFullyChargedTitle => 'Omi is fully charged';
 
   @override
   String get batteryFullyChargedBody => 'Your Omi device is fully charged. Feel free to unplug!';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -6835,6 +6835,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get lowBatteryAlertBody => 'Your device is running low on battery. Time for a recharge! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi is charged fully';
+
+  @override
+  String get batteryFullyChargedBody => 'Your Omi device is fully charged. Feel free to unplug!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Your Omi Device Disconnected';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -6844,6 +6844,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get lowBatteryAlertBody => 'La batería de tu dispositivo está baja. ¡Es hora de recargar! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi está completamente cargado';
+
+  @override
+  String get batteryFullyChargedBody => 'Tu dispositivo Omi está completamente cargado. ¡Puedes desenchufarlo!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Tu dispositivo Omi se desconectó';
 
   @override

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -6841,6 +6841,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get lowBatteryAlertBody => 'Teie seadme aku on tühi. Aeg laadida! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi on täielikult laetud';
+
+  @override
+  String get batteryFullyChargedBody => 'Teie Omi seade on täielikult laetud. Võite selle lahti ühendada!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Teie Omi seade on lahti ühendatud';
 
   @override

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -6843,6 +6843,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get lowBatteryAlertBody => 'باتری دستگاه شما تقریباً تمام است. وقت شارژ کردن است! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi کاملاً شارژ شد';
+
+  @override
+  String get batteryFullyChargedBody => 'دستگاه Omi شما کاملاً شارژ شده است. می‌توانید آن را جدا کنید!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'دستگاه Omi شما قطع شد';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -6841,6 +6841,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get lowBatteryAlertBody => 'Laitteesi akku on alhainen. Aika ladata! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi on ladattu täyteen';
+
+  @override
+  String get batteryFullyChargedBody => 'Omi-laitteesi on ladattu täyteen. Voit irrottaa sen nyt!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Omi-laitteesi yhteys katkesi';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -6898,6 +6898,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get lowBatteryAlertBody => 'La batterie de votre appareil est faible. Il est temps de recharger ! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi est complètement chargé';
+
+  @override
+  String get batteryFullyChargedBody => 'Votre appareil Omi est complètement chargé. Vous pouvez le débrancher !';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Votre appareil Omi s\'est déconnecté';
 
   @override

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -6785,6 +6785,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get lowBatteryAlertBody => 'ההתקן שלך נמצא בסוללה נמוכה. הגיע הזמן לטעינה מחדש! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi טעון לגמרי';
+
+  @override
+  String get batteryFullyChargedBody => 'מכשיר Omi שלך טעון לגמרי. אפשר לנתק אותו!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'התקן Omi שלך התנתק';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -6815,6 +6815,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get lowBatteryAlertBody => 'आपके डिवाइस की बैटरी कम है। रिचार्ज करने का समय! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi पूरी तरह चार्ज हो गया है';
+
+  @override
+  String get batteryFullyChargedBody => 'आपका Omi डिवाइस पूरी तरह चार्ज हो गया है। इसे अनप्लग कर सकते हैं!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'आपका Omi डिवाइस डिस्कनेक्ट हो गया';
 
   @override

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -6858,6 +6858,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get lowBatteryAlertBody => 'Vaš uređaj ima nisku bateriju. Vrijeme je za puniranje! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi je potpuno napunjen';
+
+  @override
+  String get batteryFullyChargedBody => 'Vaš Omi uređaj je potpuno napunjen. Možete ga iskopčati!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Vaš Omi Uređaj Je Odspoj';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -6871,6 +6871,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get lowBatteryAlertBody => 'Az eszköz akkumulátora alacsony. Ideje feltölteni! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Az Omi teljesen feltöltődött';
+
+  @override
+  String get batteryFullyChargedBody => 'Az Omi eszköz teljesen feltöltődött. Leválaszthatod!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Az Omi eszköz lecsatlakozott';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -6855,6 +6855,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get lowBatteryAlertBody => 'Baterai perangkat Anda lemah. Saatnya mengisi ulang! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi sudah terisi penuh';
+
+  @override
+  String get batteryFullyChargedBody => 'Perangkat Omi Anda sudah terisi penuh. Silakan cabut kabelnya!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Perangkat Omi Anda Terputus';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -6880,6 +6880,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get lowBatteryAlertBody => 'La batteria del dispositivo è scarica. È ora di ricaricare! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi è completamente carico';
+
+  @override
+  String get batteryFullyChargedBody => 'Il tuo dispositivo Omi è completamente carico. Puoi scollegarlo!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Il tuo dispositivo Omi si è disconnesso';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -6719,6 +6719,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get lowBatteryAlertBody => 'デバイスのバッテリーが少なくなっています。充電してください！🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omiは満充電です';
+
+  @override
+  String get batteryFullyChargedBody => 'Omiデバイスが満充電になりました。充電ケーブルを外してください！';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Omiデバイスが切断されました';
 
   @override

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -6864,6 +6864,12 @@ class AppLocalizationsKn extends AppLocalizations {
   String get lowBatteryAlertBody => 'ನಿಮ್ಮ ಸಾಧನವು ಬ್ಯಾಟರಿ ಕಡಿಮೆಯಿದೆ. ಚಾರ್ಜ್ ಮಾಡುವ ಸಮಯ! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ';
+
+  @override
+  String get batteryFullyChargedBody => 'ನಿಮ್ಮ Omi ಸಾಧನ ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ. ಅನ್‌ಪ್ಲಗ್ ಮಾಡಬಹುದು!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'ನಿಮ್ಮ Omi ಸಾಧನ ಸಂಪರ್ಕ ಸ್ವಲ್ಪ';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -6721,6 +6721,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get lowBatteryAlertBody => '기기의 배터리가 부족합니다. 충전할 시간입니다! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi가 완전히 충전되었습니다';
+
+  @override
+  String get batteryFullyChargedBody => 'Omi 기기가 완전히 충전되었습니다. 이제 플러그를 뽑으셔도 됩니다!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Omi 기기가 연결 해제되었습니다';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -6842,6 +6842,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get lowBatteryAlertBody => 'Jūsų įrenginio baterija senka. Laikas įkrauti! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi yra visiškai įkrautas';
+
+  @override
+  String get batteryFullyChargedBody => 'Jūsų Omi įrenginys yra visiškai įkrautas. Galite jį atjungti!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Jūsų Omi įrenginys atsijungė';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -6852,6 +6852,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get lowBatteryAlertBody => 'Jūsu ierīces akumulators ir zems. Laiks uzlādēt! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi ir pilnībā uzlādēts';
+
+  @override
+  String get batteryFullyChargedBody => 'Jūsu Omi ierīce ir pilnībā uzlādēta. Varat to atvienot!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Jūsu Omi ierīce ir atvienota';
 
   @override

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -6873,6 +6873,12 @@ class AppLocalizationsMk extends AppLocalizations {
   String get lowBatteryAlertBody => 'Вашиот уред има ниска батерија. Време е за полнење! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi е целосно наполнет';
+
+  @override
+  String get batteryFullyChargedBody => 'Вашиот Omi уред е целосно наполнет. Можете да го исклучите!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Вашиот Omi Уред се Откачи';
 
   @override

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -6850,6 +6850,12 @@ class AppLocalizationsMr extends AppLocalizations {
   String get lowBatteryAlertBody => 'आपली डिव्हाइस बॅटरीवर कमी चल रही आहे. रिचार्जने वेळ आली! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi पूर्णपणे चार्ज झाला आहे';
+
+  @override
+  String get batteryFullyChargedBody => 'तुमचे Omi डिव्हाइस पूर्णपणे चार्ज झाले आहे. अनप्लग करू शकता!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'आपली Omi डिव्हाइस डिस्कनेक्ट झाली';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -6860,6 +6860,12 @@ class AppLocalizationsMs extends AppLocalizations {
   String get lowBatteryAlertBody => 'Bateri peranti anda lemah. Masa untuk mengecas semula! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi telah dicas penuh';
+
+  @override
+  String get batteryFullyChargedBody => 'Peranti Omi anda telah dicas sepenuhnya. Anda boleh mencabutnya!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Peranti Omi Anda Terputus';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -6860,6 +6860,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get lowBatteryAlertBody => 'De batterij van uw apparaat is bijna leeg. Tijd om op te laden! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi is volledig opgeladen';
+
+  @override
+  String get batteryFullyChargedBody => 'Uw Omi-apparaat is volledig opgeladen. U kunt het loskoppelen!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Uw Omi-apparaat is losgekoppeld';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -6836,6 +6836,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get lowBatteryAlertBody => 'Enhetens batteri er lavt. På tide å lade! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi er fulladet';
+
+  @override
+  String get batteryFullyChargedBody => 'Omi-enheten din er fulladet. Du kan koble den fra nå!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Omi-enheten din ble frakoblet';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -6852,6 +6852,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get lowBatteryAlertBody => 'Bateria Twojego urządzenia jest na wyczerpaniu. Czas na ładowanie! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi jest w pełni naładowany';
+
+  @override
+  String get batteryFullyChargedBody => 'Twoje urządzenie Omi jest w pełni naładowane. Możesz je odłączyć!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Twoje urządzenie Omi zostało rozłączone';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -6832,6 +6832,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get lowBatteryAlertBody => 'A bateria do seu dispositivo está fraca. Hora de recarregar! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi está totalmente carregado';
+
+  @override
+  String get batteryFullyChargedBody => 'Seu dispositivo Omi está totalmente carregado. Você pode desligá-lo!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Seu dispositivo Omi foi desconectado';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -6873,6 +6873,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get lowBatteryAlertBody => 'Bateria dispozitivului este descărcată. E timpul să reîncărcați! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi este complet încărcat';
+
+  @override
+  String get batteryFullyChargedBody => 'Dispozitivul tău Omi este complet încărcat. Îl poți decupla acum!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Dispozitivul Omi a fost deconectat';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -6857,6 +6857,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get lowBatteryAlertBody => 'Батарея вашего устройства разряжена. Пора зарядить! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi полностью заряжен';
+
+  @override
+  String get batteryFullyChargedBody => 'Ваше устройство Omi полностью заряжено. Можно отключить от зарядки!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Ваше устройство Omi отключено';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -6837,6 +6837,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get lowBatteryAlertBody => 'Batéria vášho zariadenia je vybitá. Je čas ju nabiť! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi je plne nabitý';
+
+  @override
+  String get batteryFullyChargedBody => 'Vaše zariadenie Omi je plne nabité. Môžete ho odpojiť!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Vaše zariadenie Omi bolo odpojené';
 
   @override

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -6852,6 +6852,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get lowBatteryAlertBody => 'Vaša naprava ima nizko baterijo. Čas je za polnjenje! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi je popolnoma napolnjen';
+
+  @override
+  String get batteryFullyChargedBody => 'Vaša naprava Omi je popolnoma napolnjena. Lahko jo odklopite!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Vaša Naprava Omi je Odklopljena';
 
   @override

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -6848,6 +6848,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get lowBatteryAlertBody => 'Батерија вашег уређаја је скоро празна. Време је за пуњење! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi је потпуно напуњен';
+
+  @override
+  String get batteryFullyChargedBody => 'Ваш Omi уређај је потпуно напуњен. Можете га искључити!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Ваш Omi уређај је одсоединут';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -6842,6 +6842,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get lowBatteryAlertBody => 'Enhetens batteri är lågt. Dags att ladda! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi är fulladdad';
+
+  @override
+  String get batteryFullyChargedBody => 'Din Omi-enhet är fulladdad. Du kan koppla ur den nu!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Din Omi-enhet har kopplats från';
 
   @override

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -6888,6 +6888,12 @@ class AppLocalizationsTa extends AppLocalizations {
       'உங்கள் சாதனத்தின் பேட்டரி குறைந்து விட்டது. மீண்டும் சார்ஜ் செய்ய வேண்டிய நேரம்! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi முழுமையாக சார்ஜ் ஆகியது';
+
+  @override
+  String get batteryFullyChargedBody => 'உங்கள் Omi சாதனம் முழுமையாக சார்ஜ் ஆகியது. அனப்ளக் செய்யலாம்!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'உங்கள் Omi சாதனம் துண்டிக்கப்பட்டது';
 
   @override

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -6879,6 +6879,12 @@ class AppLocalizationsTe extends AppLocalizations {
   String get lowBatteryAlertBody => 'మీ పరికరం తక్కువ బ్యాటరీలో ఉంది. రీఛార్జ్ చేయడానికి సమయం! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi పూర్తిగా చార్జ్ అయింది';
+
+  @override
+  String get batteryFullyChargedBody => 'మీ Omi పరికరం పూర్తిగా చార్జ్ అయింది. అన్‌ప్లగ్ చేయవచ్చు!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'మీ Omi పరికరం డిస్‌కనెక్ట్ చేయబడింది';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -6806,6 +6806,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get lowBatteryAlertBody => 'แบตเตอรี่ของอุปกรณ์ของคุณต่ำ ถึงเวลาชาร์จแล้ว! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi ชาร์จเต็มแล้ว';
+
+  @override
+  String get batteryFullyChargedBody => 'อุปกรณ์ Omi ของคุณชาร์จเต็มแล้ว รู้สึกอิสระที่จะถอดปลั๊กได้!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'อุปกรณ์ Omi ของคุณถูกตัดการเชื่อมต่อ';
 
   @override

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -6897,6 +6897,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get lowBatteryAlertBody => 'Ang iyong device ay mababa na sa baterya. Panahon na para mag-recharge! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Naka-charge na ang Omi';
+
+  @override
+  String get batteryFullyChargedBody => 'Ang iyong Omi device ay ganap nang na-charge. Maaari mo na itong i-unplug!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Ang Iyong Omi Device ay Nadiskonekta';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -6850,6 +6850,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get lowBatteryAlertBody => 'Cihazınızın pili azaldı. Şarj etme zamanı! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi tamamen şarj oldu';
+
+  @override
+  String get batteryFullyChargedBody => 'Omi cihazınız tamamen şarj oldu. Fişini çekebilirsiniz!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Omi Cihazınız Bağlantı Kesildi';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -6849,6 +6849,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get lowBatteryAlertBody => 'Батарея вашого пристрою розряджена. Час зарядити! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi повністю заряджений';
+
+  @override
+  String get batteryFullyChargedBody => 'Ваш пристрій Omi повністю заряджений. Можна відключити від зарядки!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Ваш пристрій Omi відключено';
 
   @override

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -6850,6 +6850,12 @@ class AppLocalizationsUr extends AppLocalizations {
   String get lowBatteryAlertBody => 'آپ کا ڈیوائس بیٹری میں کم ہو رہا ہے۔ دوبارہ چارج کرنے کا وقت! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi مکمل طور پر چارج ہو گیا';
+
+  @override
+  String get batteryFullyChargedBody => 'آپ کا Omi ڈیوائس مکمل طور پر چارج ہو گئی ہے۔ اسے ان پلگ کر سکتے ہیں!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'آپ کا Omi ڈیوائس منقطع ہو گیا';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -6845,6 +6845,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get lowBatteryAlertBody => 'Pin thiết bị của bạn đang yếu. Đã đến lúc sạc! 🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi đã sạc đầy';
+
+  @override
+  String get batteryFullyChargedBody => 'Thiết bị Omi của bạn đã sạc đầy. Bạn có thể rút cáp ra!';
+
+  @override
   String get deviceDisconnectedNotificationTitle => 'Thiết bị Omi của bạn đã ngắt kết nối';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -6710,6 +6710,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get lowBatteryAlertBody => '您的设备电池电量低。是时候充电了！🔋';
 
   @override
+  String get batteryFullyChargedTitle => 'Omi已充满电';
+
+  @override
+  String get batteryFullyChargedBody => '您的Omi设备已充满电，可以拔掉充电线了！';
+
+  @override
   String get deviceDisconnectedNotificationTitle => '您的 Omi 设备已断开连接';
 
   @override

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -1186,6 +1186,8 @@
     "logsCopied": "Žurnalai nukopijuoti",
     "lovingOmi": "Patinka Omi?",
     "lowBatteryAlertBody": "Jūsų įrenginio baterija senka. Laikas įkrauti! 🔋",
+    "batteryFullyChargedTitle": "Omi yra visiškai įkrautas",
+    "batteryFullyChargedBody": "Jūsų Omi įrenginys yra visiškai įkrautas. Galite jį atjungti!",
     "lowBatteryAlertTitle": "Įspėjimas apie senką bateriją",
     "lower": "Žemesnis",
     "macOsCalendar": "macOS kalendorius",

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Atlasīt",
     "lowBatteryAlertTitle": "Zema akumulatora brīdinājums",
     "lowBatteryAlertBody": "Jūsu ierīces akumulators ir zems. Laiks uzlādēt! 🔋",
+    "batteryFullyChargedTitle": "Omi ir pilnībā uzlādēts",
+    "batteryFullyChargedBody": "Jūsu Omi ierīce ir pilnībā uzlādēta. Varat to atvienot!",
     "deviceDisconnectedNotificationTitle": "Jūsu Omi ierīce ir atvienota",
     "deviceDisconnectedNotificationBody": "Lūdzu, pieslēdzieties atkārtoti, lai turpinātu lietot Omi.",
     "firmwareUpdateAvailable": "Pieejams programmaparatūras atjauninājums",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Вашиот уред има ниска батерија. Време е за полнење! 🔋",
+    "batteryFullyChargedTitle": "Omi е целосно наполнет",
+    "batteryFullyChargedBody": "Вашиот Omi уред е целосно наполнет. Можете да го исклучите!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "आपली डिव्हाइस बॅटरीवर कमी चल रही आहे. रिचार्जने वेळ आली! 🔋",
+    "batteryFullyChargedTitle": "Omi पूर्णपणे चार्ज झाला आहे",
+    "batteryFullyChargedBody": "तुमचे Omi डिव्हाइस पूर्णपणे चार्ज झाले आहे. अनप्लग करू शकता!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Pilih",
     "lowBatteryAlertTitle": "Amaran Bateri Lemah",
     "lowBatteryAlertBody": "Bateri peranti anda lemah. Masa untuk mengecas semula! 🔋",
+    "batteryFullyChargedTitle": "Omi telah dicas penuh",
+    "batteryFullyChargedBody": "Peranti Omi anda telah dicas sepenuhnya. Anda boleh mencabutnya!",
     "deviceDisconnectedNotificationTitle": "Peranti Omi Anda Terputus",
     "deviceDisconnectedNotificationBody": "Sila sambung semula untuk terus menggunakan Omi.",
     "firmwareUpdateAvailable": "Kemas Kini Firmware Tersedia",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Selecteren",
     "lowBatteryAlertTitle": "Waarschuwing lage batterij",
     "lowBatteryAlertBody": "De batterij van uw apparaat is bijna leeg. Tijd om op te laden! 🔋",
+    "batteryFullyChargedTitle": "Omi is volledig opgeladen",
+    "batteryFullyChargedBody": "Uw Omi-apparaat is volledig opgeladen. U kunt het loskoppelen!",
     "deviceDisconnectedNotificationTitle": "Uw Omi-apparaat is losgekoppeld",
     "deviceDisconnectedNotificationBody": "Verbind opnieuw om Omi te blijven gebruiken.",
     "firmwareUpdateAvailable": "Firmware-update beschikbaar",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Velg",
     "lowBatteryAlertTitle": "Advarsel om lavt batteri",
     "lowBatteryAlertBody": "Enhetens batteri er lavt. På tide å lade! 🔋",
+    "batteryFullyChargedTitle": "Omi er fulladet",
+    "batteryFullyChargedBody": "Omi-enheten din er fulladet. Du kan koble den fra nå!",
     "deviceDisconnectedNotificationTitle": "Omi-enheten din ble frakoblet",
     "deviceDisconnectedNotificationBody": "Koble til igjen for å fortsette å bruke Omi.",
     "firmwareUpdateAvailable": "Fastvareoppdatering tilgjengelig",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Wybierz",
     "lowBatteryAlertTitle": "Alert niskiego poziomu baterii",
     "lowBatteryAlertBody": "Bateria Twojego urządzenia jest na wyczerpaniu. Czas na ładowanie! 🔋",
+    "batteryFullyChargedTitle": "Omi jest w pełni naładowany",
+    "batteryFullyChargedBody": "Twoje urządzenie Omi jest w pełni naładowane. Możesz je odłączyć!",
     "deviceDisconnectedNotificationTitle": "Twoje urządzenie Omi zostało rozłączone",
     "deviceDisconnectedNotificationBody": "Połącz się ponownie, aby kontynuować korzystanie z Omi.",
     "firmwareUpdateAvailable": "Dostępna aktualizacja oprogramowania",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2185,6 +2185,8 @@
     "selectOption": "Selecionar",
     "lowBatteryAlertTitle": "Alerta de bateria fraca",
     "lowBatteryAlertBody": "A bateria do seu dispositivo está fraca. Hora de recarregar! 🔋",
+    "batteryFullyChargedTitle": "Omi está totalmente carregado",
+    "batteryFullyChargedBody": "Seu dispositivo Omi está totalmente carregado. Você pode desligá-lo!",
     "deviceDisconnectedNotificationTitle": "Seu dispositivo Omi foi desconectado",
     "deviceDisconnectedNotificationBody": "Por favor, reconecte para continuar usando o Omi.",
     "firmwareUpdateAvailable": "Atualização de firmware disponível",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Selectează",
     "lowBatteryAlertTitle": "Alertă baterie descărcată",
     "lowBatteryAlertBody": "Bateria dispozitivului este descărcată. E timpul să reîncărcați! 🔋",
+    "batteryFullyChargedTitle": "Omi este complet încărcat",
+    "batteryFullyChargedBody": "Dispozitivul tău Omi este complet încărcat. Îl poți decupla acum!",
     "deviceDisconnectedNotificationTitle": "Dispozitivul Omi a fost deconectat",
     "deviceDisconnectedNotificationBody": "Vă rugăm să vă reconectați pentru a continua să utilizați Omi.",
     "firmwareUpdateAvailable": "Actualizare firmware disponibilă",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Выбрать",
     "lowBatteryAlertTitle": "Предупреждение о низком заряде",
     "lowBatteryAlertBody": "Батарея вашего устройства разряжена. Пора зарядить! 🔋",
+    "batteryFullyChargedTitle": "Omi полностью заряжен",
+    "batteryFullyChargedBody": "Ваше устройство Omi полностью заряжено. Можно отключить от зарядки!",
     "deviceDisconnectedNotificationTitle": "Ваше устройство Omi отключено",
     "deviceDisconnectedNotificationBody": "Пожалуйста, подключитесь снова, чтобы продолжить использование Omi.",
     "firmwareUpdateAvailable": "Доступно обновление прошивки",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Vybrať",
     "lowBatteryAlertTitle": "Upozornenie na nízku batériu",
     "lowBatteryAlertBody": "Batéria vášho zariadenia je vybitá. Je čas ju nabiť! 🔋",
+    "batteryFullyChargedTitle": "Omi je plne nabitý",
+    "batteryFullyChargedBody": "Vaše zariadenie Omi je plne nabité. Môžete ho odpojiť!",
     "deviceDisconnectedNotificationTitle": "Vaše zariadenie Omi bolo odpojené",
     "deviceDisconnectedNotificationBody": "Prosím, znova sa pripojte, aby ste mohli pokračovať v používaní Omi.",
     "firmwareUpdateAvailable": "K dispozícii je aktualizácia firmvéru",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Vaša naprava ima nizko baterijo. Čas je za polnjenje! 🔋",
+    "batteryFullyChargedTitle": "Omi je popolnoma napolnjen",
+    "batteryFullyChargedBody": "Vaša naprava Omi je popolnoma napolnjena. Lahko jo odklopite!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Батерија вашег уређаја је скоро празна. Време је за пуњење! 🔋",
+    "batteryFullyChargedTitle": "Omi је потпуно напуњен",
+    "batteryFullyChargedBody": "Ваш Omi уређај је потпуно напуњен. Можете га искључити!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Välj",
     "lowBatteryAlertTitle": "Varning för lågt batteri",
     "lowBatteryAlertBody": "Enhetens batteri är lågt. Dags att ladda! 🔋",
+    "batteryFullyChargedTitle": "Omi är fulladdad",
+    "batteryFullyChargedBody": "Din Omi-enhet är fulladdad. Du kan koppla ur den nu!",
     "deviceDisconnectedNotificationTitle": "Din Omi-enhet har kopplats från",
     "deviceDisconnectedNotificationBody": "Anslut igen för att fortsätta använda Omi.",
     "firmwareUpdateAvailable": "Firmware-uppdatering tillgänglig",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "உங்கள் சாதனத்தின் பேட்டரி குறைந்து விட்டது. மீண்டும் சார்ஜ் செய்ய வேண்டிய நேரம்! 🔋",
+    "batteryFullyChargedTitle": "Omi முழுமையாக சார்ஜ் ஆகியது",
+    "batteryFullyChargedBody": "உங்கள் Omi சாதனம் முழுமையாக சார்ஜ் ஆகியது. அனப்ளக் செய்யலாம்!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "మీ పరికరం తక్కువ బ్యాటరీలో ఉంది. రీఛార్జ్ చేయడానికి సమయం! 🔋",
+    "batteryFullyChargedTitle": "Omi పూర్తిగా చార్జ్ అయింది",
+    "batteryFullyChargedBody": "మీ Omi పరికరం పూర్తిగా చార్జ్ అయింది. అన్‌ప్లగ్ చేయవచ్చు!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "เลือก",
     "lowBatteryAlertTitle": "การแจ้งเตือนแบตเตอรี่ต่ำ",
     "lowBatteryAlertBody": "แบตเตอรี่ของอุปกรณ์ของคุณต่ำ ถึงเวลาชาร์จแล้ว! 🔋",
+    "batteryFullyChargedTitle": "Omi ชาร์จเต็มแล้ว",
+    "batteryFullyChargedBody": "อุปกรณ์ Omi ของคุณชาร์จเต็มแล้ว รู้สึกอิสระที่จะถอดปลั๊กได้!",
     "deviceDisconnectedNotificationTitle": "อุปกรณ์ Omi ของคุณถูกตัดการเชื่อมต่อ",
     "deviceDisconnectedNotificationBody": "กรุณาเชื่อมต่อใหม่เพื่อใช้งาน Omi ต่อไป",
     "firmwareUpdateAvailable": "มีการอัปเดตเฟิร์มแวร์",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "Ang iyong device ay mababa na sa baterya. Panahon na para mag-recharge! 🔋",
+    "batteryFullyChargedTitle": "Naka-charge na ang Omi",
+    "batteryFullyChargedBody": "Ang iyong Omi device ay ganap nang na-charge. Maaari mo na itong i-unplug!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Seç",
     "lowBatteryAlertTitle": "Düşük Pil Uyarısı",
     "lowBatteryAlertBody": "Cihazınızın pili azaldı. Şarj etme zamanı! 🔋",
+    "batteryFullyChargedTitle": "Omi tamamen şarj oldu",
+    "batteryFullyChargedBody": "Omi cihazınız tamamen şarj oldu. Fişini çekebilirsiniz!",
     "deviceDisconnectedNotificationTitle": "Omi Cihazınız Bağlantı Kesildi",
     "deviceDisconnectedNotificationBody": "Omi'yi kullanmaya devam etmek için lütfen yeniden bağlanın.",
     "firmwareUpdateAvailable": "Yazılım Güncellemesi Mevcut",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Вибрати",
     "lowBatteryAlertTitle": "Попередження про низький заряд батареї",
     "lowBatteryAlertBody": "Батарея вашого пристрою розряджена. Час зарядити! 🔋",
+    "batteryFullyChargedTitle": "Omi повністю заряджений",
+    "batteryFullyChargedBody": "Ваш пристрій Omi повністю заряджений. Можна відключити від зарядки!",
     "deviceDisconnectedNotificationTitle": "Ваш пристрій Omi відключено",
     "deviceDisconnectedNotificationBody": "Будь ласка, підключіться знову, щоб продовжити використання Omi.",
     "firmwareUpdateAvailable": "Доступне оновлення прошивки",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -8398,6 +8398,8 @@
         "description": "Title for low battery notification"
     },
     "lowBatteryAlertBody": "آپ کا ڈیوائس بیٹری میں کم ہو رہا ہے۔ دوبارہ چارج کرنے کا وقت! 🔋",
+    "batteryFullyChargedTitle": "Omi مکمل طور پر چارج ہو گیا",
+    "batteryFullyChargedBody": "آپ کا Omi ڈیوائس مکمل طور پر چارج ہو گئی ہے۔ اسے ان پلگ کر سکتے ہیں!",
     "@lowBatteryAlertBody": {
         "description": "Body text for low battery notification"
     },

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2184,6 +2184,8 @@
     "selectOption": "Chọn",
     "lowBatteryAlertTitle": "Cảnh báo pin yếu",
     "lowBatteryAlertBody": "Pin thiết bị của bạn đang yếu. Đã đến lúc sạc! 🔋",
+    "batteryFullyChargedTitle": "Omi đã sạc đầy",
+    "batteryFullyChargedBody": "Thiết bị Omi của bạn đã sạc đầy. Bạn có thể rút cáp ra!",
     "deviceDisconnectedNotificationTitle": "Thiết bị Omi của bạn đã ngắt kết nối",
     "deviceDisconnectedNotificationBody": "Vui lòng kết nối lại để tiếp tục sử dụng Omi.",
     "firmwareUpdateAvailable": "Có bản cập nhật firmware",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2185,6 +2185,8 @@
     "selectOption": "选择",
     "lowBatteryAlertTitle": "电池电量低警告",
     "lowBatteryAlertBody": "您的设备电池电量低。是时候充电了！🔋",
+    "batteryFullyChargedTitle": "Omi已充满电",
+    "batteryFullyChargedBody": "您的Omi设备已充满电，可以拔掉充电线了！",
     "deviceDisconnectedNotificationTitle": "您的 Omi 设备已断开连接",
     "deviceDisconnectedNotificationBody": "请重新连接以继续使用 Omi。",
     "firmwareUpdateAvailable": "固件更新可用",

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -221,7 +221,16 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       onChargingStatusChange: (bool charging) {
         if (isCharging != charging) {
           isCharging = charging;
-          if (!charging) _hasFullyChargedAlerted = false;
+          if (!charging) {
+            _hasFullyChargedAlerted = false;
+          } else if (batteryLevel >= 100 && !_hasFullyChargedAlerted) {
+            _hasFullyChargedAlerted = true;
+            final ctx = globalNavigatorKey.currentContext;
+            NotificationService.instance.createNotification(
+              title: ctx?.l10n.batteryFullyChargedTitle ?? "Omi is fully charged",
+              body: ctx?.l10n.batteryFullyChargedBody ?? "Your Omi device is fully charged. Feel free to unplug!",
+            );
+          }
           notifyListeners();
         }
       },

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -40,6 +40,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   int _lastNotifiedBatteryLevel = -1;
   DateTime? _lastBatteryNotifyTime;
   bool _hasLowBatteryAlerted = false;
+  bool _hasFullyChargedAlerted = false;
   bool _havingNewFirmware = false;
   bool get havingNewFirmware => _havingNewFirmware && pairedDevice != null && isConnected;
 
@@ -171,6 +172,16 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
           );
         } else if (batteryLevel > 20) {
           _hasLowBatteryAlerted = false;
+        }
+        if (isCharging && batteryLevel >= 100 && !_hasFullyChargedAlerted) {
+          _hasFullyChargedAlerted = true;
+          final ctx = globalNavigatorKey.currentContext;
+          NotificationService.instance.createNotification(
+            title: ctx?.l10n.batteryFullyChargedTitle ?? "Omi is charged fully",
+            body: ctx?.l10n.batteryFullyChargedBody ?? "Your Omi device is fully charged. Feel free to unplug!",
+          );
+        } else if (!isCharging || batteryLevel < 100) {
+          _hasFullyChargedAlerted = false;
         }
         // Throttle notifyListeners to reduce battery drain from excessive UI rebuilds
         // Only notify when: first reading, >=5% change, 15min elapsed, or crosses 20% threshold

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -177,7 +177,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
           _hasFullyChargedAlerted = true;
           final ctx = globalNavigatorKey.currentContext;
           NotificationService.instance.createNotification(
-            title: ctx?.l10n.batteryFullyChargedTitle ?? "Omi is charged fully",
+            title: ctx?.l10n.batteryFullyChargedTitle ?? "Omi is fully charged",
             body: ctx?.l10n.batteryFullyChargedBody ?? "Your Omi device is fully charged. Feel free to unplug!",
           );
         } else if (!isCharging || batteryLevel < 100) {
@@ -221,6 +221,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       onChargingStatusChange: (bool charging) {
         if (isCharging != charging) {
           isCharging = charging;
+          if (!charging) _hasFullyChargedAlerted = false;
           notifyListeners();
         }
       },


### PR DESCRIPTION
## Summary

- Fires a one-shot local notification — **"Omi is charged fully"** — when the device is charging and battery level reaches 100%
- Resets the alert flag when charging stops or battery drops below 100%, so the notification re-fires on the next charge cycle
- Added `batteryFullyChargedTitle` and `batteryFullyChargedBody` l10n keys with translations for all 48 non-English locales

## Demo

<img width="1206" height="1347" alt="IMG_1CC0636A9E1A-1" src="https://github.com/user-attachments/assets/36b98581-9171-4cea-939e-6a57845c600b" />


## Test plan

- [ ] Connect an Omi device and let it charge to 100% — notification should appear once
- [ ] Unplug and replug the device and charge again — notification should re-fire
- [ ] Verify notification does not fire if battery is at 100% but not charging (`isCharging == false`)
- [ ] Confirm no regression in the existing low-battery alert (< 20%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)