### PR TITLE
fix(frontend): Remove fetch to non-existent plugin-stats.json breaking app store

### DIFF
--- a/web/frontend/src/app/apps/[id]/page.tsx
+++ b/web/frontend/src/app/apps/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Plugin, PluginStat } from '../components/types';
+import { Plugin } from '../components/types';
 import { headers } from 'next/headers';
 import { CompactPluginCard } from '../components/plugin-card/compact';
 import { CategoryBreadcrumb } from '../components/category-breadcrumb';
@@ -178,11 +178,6 @@ export default async function PluginDetailView(props: {
   if (!plugin) {
     throw new Error('App not found');
   }
-
-  const statsResponse = await fetch(
-    'https://raw.githubusercontent.com/BasedHardware/omi/refs/heads/main/community-plugin-stats.json',
-  );
-  const stats = (await statsResponse.json()) as PluginStat[];
 
   const userAgent = (await headers()).get('user-agent') || '';
   const link = getPlatformLink(userAgent);
@@ -371,12 +366,7 @@ export default async function PluginDetailView(props: {
             </h2>
             <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {relatedApps.map((app, index) => (
-                <CompactPluginCard
-                  key={app.id}
-                  plugin={app}
-                  stat={stats.find((s) => s.id === app.id)}
-                  index={index + 1}
-                />
+                <CompactPluginCard key={app.id} plugin={app} index={index + 1} />
               ))}
             </div>
           </section>

--- a/web/frontend/src/app/apps/category/[category]/page.tsx
+++ b/web/frontend/src/app/apps/category/[category]/page.tsx
@@ -3,7 +3,7 @@ import { FeaturedPluginCard } from '../../components/plugin-card/featured';
 import { ScrollableCategoryNav } from '../../components/scrollable-category-nav';
 import { CategoryBreadcrumb } from '../../components/category-breadcrumb';
 import { CategoryHeader } from '../../components/category-header';
-import type { Plugin, PluginStat } from '../../components/types';
+import type { Plugin } from '../../components/types';
 import { Metadata } from 'next';
 import {
   getBaseMetadata,
@@ -23,19 +23,8 @@ interface CategoryPageProps {
 }
 
 async function getCategoryData(category: string) {
-  const [categoryPlugins, statsResponse] = await Promise.all([
-    getAppsByCategory(category),
-    fetch(
-      'https://raw.githubusercontent.com/BasedHardware/omi/refs/heads/main/community-plugin-stats.json',
-      {
-        next: { revalidate: 3600 },
-      },
-    ),
-  ]);
-
-  const stats = (await statsResponse.json()) as PluginStat[];
-
-  return { categoryPlugins, stats };
+  const categoryPlugins = await getAppsByCategory(category);
+  return { categoryPlugins };
 }
 
 export async function generateMetadata(props: CategoryPageProps): Promise<Metadata> {
@@ -103,7 +92,7 @@ function getNewOrRecentApps(plugins: Plugin[]): Plugin[] {
 
 export default async function CategoryPage(props: CategoryPageProps) {
   const params = await props.params;
-  const { categoryPlugins, stats } = await getCategoryData(params.category);
+  const { categoryPlugins } = await getCategoryData(params.category);
   const newOrRecentApps = getNewOrRecentApps(categoryPlugins);
   const mostPopular =
     categoryPlugins.length > 6
@@ -156,11 +145,7 @@ export default async function CategoryPage(props: CategoryPageProps) {
               </h3>
               <div className="grid grid-cols-2 gap-2.5 sm:gap-3 lg:grid-cols-4 lg:gap-4">
                 {newOrRecentApps.map((plugin) => (
-                  <FeaturedPluginCard
-                    key={plugin.id}
-                    plugin={plugin}
-                    stat={stats.find((s) => s.id === plugin.id)}
-                  />
+                  <FeaturedPluginCard key={plugin.id} plugin={plugin} />
                 ))}
               </div>
             </section>
@@ -176,7 +161,6 @@ export default async function CategoryPage(props: CategoryPageProps) {
                     <CompactPluginCard
                       key={plugin.id}
                       plugin={plugin}
-                      stat={stats.find((s) => s.id === plugin.id)}
                       index={index + 1}
                     />
                   ))}
@@ -191,12 +175,7 @@ export default async function CategoryPage(props: CategoryPageProps) {
               </h3>
               <div className="grid grid-cols-1 gap-y-2 sm:grid-cols-2 sm:gap-3 lg:grid-cols-3 lg:gap-4">
                 {allApps.map((plugin, index) => (
-                  <CompactPluginCard
-                    key={plugin.id}
-                    plugin={plugin}
-                    stat={stats.find((s) => s.id === plugin.id)}
-                    index={index + 1}
-                  />
+                  <CompactPluginCard key={plugin.id} plugin={plugin} index={index + 1} />
                 ))}
               </div>
             </section>

--- a/web/frontend/src/app/apps/popular/page.tsx
+++ b/web/frontend/src/app/apps/popular/page.tsx
@@ -1,29 +1,21 @@
 import envConfig from '@/src/constants/envConfig';
 import { FeaturedPluginCard } from '../components/plugin-card/featured';
 import { CategoryNav } from '../components/category-nav';
-import type { Plugin, PluginStat } from '../components/types';
+import type { Plugin } from '../components/types';
 
 async function getPluginsData() {
-  const [pluginsResponse, statsResponse] = await Promise.all([
-    fetch(`${envConfig.API_URL}/v1/approved-apps?include_reviews=true`, {
-      cache: 'no-store',
-    }),
-    fetch(
-      'https://raw.githubusercontent.com/BasedHardware/omi/refs/heads/main/community-plugin-stats.json',
-      {
-        cache: 'no-store',
-      },
-    ),
-  ]);
+  const pluginsResponse = await fetch(
+    `${envConfig.API_URL}/v1/approved-apps?include_reviews=true`,
+    { cache: 'no-store' },
+  );
 
   const plugins = (await pluginsResponse.json()) as Plugin[];
-  const stats = (await statsResponse.json()) as PluginStat[];
 
-  return { plugins, stats };
+  return { plugins };
 }
 
 export default async function PopularPage() {
-  const { plugins, stats } = await getPluginsData();
+  const { plugins } = await getPluginsData();
 
   // Sort all plugins by installs
   const sortedPlugins = [...plugins].sort((a, b) => b.installs - a.installs);
@@ -82,11 +74,7 @@ export default async function PopularPage() {
             {/* Grid of Featured Cards */}
             <div className="grid grid-cols-4 gap-6">
               {sortedPlugins.map((plugin) => (
-                <FeaturedPluginCard
-                  key={plugin.id}
-                  plugin={plugin}
-                  stat={stats.find((s) => s.id === plugin.id)}
-                />
+                <FeaturedPluginCard key={plugin.id} plugin={plugin} />
               ))}
             </div>
           </div>


### PR DESCRIPTION
## Summary

The marketplace was fetching `community-plugin-stats.json` from `raw.githubusercontent.com/BasedHardware/omi/refs/heads/main/community-plugin-stats.json` on three pages — but that file was deleted from the repo on 2026-04-20 (commit da28b085c, "Delete community-plugin-stats.json — deprecated since we moved to https://docs.omi.me/doc/developer/apps/Introduction"). The fetch has been 404'ing ever since, and `(await statsResponse.json()) as PluginStat[]` then throws on the unparseable response, taking the whole RSC render down — users land on a white screen.

<img width="1728" height="789" alt="Screenshot 2026-05-12 at 3 26 31 AM" src="https://github.com/user-attachments/assets/5e277946-6daa-44ed-ad24-edd5e4985701" /><br>

  
This PR removes the dead fetch from the three call sites and stops passing the resulting `stat` prop into the card components (which never read it anyway).

- `apps/[id]/page.tsx` — drops the fetch on every plugin detail render
- `apps/category/[category]/page.tsx` — drops it from the parallel fetch in `getCategoryData`
- `apps/popular/page.tsx` — drops it from the parallel fetch in `getPluginsData`

The optional `stat?: PluginStat` field on `CompactPluginCard` / `FeaturedPluginCard` / `PluginCard` is left in place — to reduce the blast radius of this fix allowing for immediate fix of the marketplace website, and further discussion on the future plan of stats. Note these stats were not being displayed and dead code anyways.

## Test plan

- [x] `/apps/category/[category]` renders — new/recent + all-apps grids render on `productivity-and-organization`
- [x] `/apps/[id]` renders — hero + "More …Apps" related-apps grid render (only console error is an unrelated 3rd-party `eapps.Platform` widget present on every page)
- [x] `pnpm exec tsc --noEmit` clean for the three modified files (pre-existing errors elsewhere in the repo are unrelated)

