### PR TITLE
ci(desktop): patch Homebrew libwebp to universal

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2192,6 +2192,35 @@ workflows:
           # Install libwebp (required for screenshot encoding)
           brew install webp
 
+          # Homebrew's libwebp on Codemagic's Mac mini m2 is arm64-only as of
+          # 2026-05-10, which breaks Swift's x86_64 cross-compile link step:
+          #   ld: ignoring '/opt/homebrew/opt/webp/lib/libwebp.dylib': arm64 only
+          #   Undefined symbols for x86_64: _WebPEncodeRGBA, _WebPFree
+          # The earlier "Prepare universal libwebp" step builds universal dylibs
+          # at /tmp/libwebp-universal/. Overwrite Homebrew's arm64-only copies
+          # with those universal versions so pkg-config (used by Package.swift's
+          # CWebP system-lib target) resolves to a linker-compatible dylib for
+          # both archs.
+          WEBP_LIB_DIR="$(brew --prefix webp)/lib"
+          for dylib in libwebp.7.dylib libsharpyuv.0.dylib; do
+            src="/tmp/libwebp-universal/$dylib"
+            dst="$WEBP_LIB_DIR/$dylib"
+            if [ ! -f "$src" ]; then
+              echo "WARN: universal $dylib missing at $src — skipping patch"
+              continue
+            fi
+            if [ ! -e "$dst" ]; then
+              echo "WARN: Homebrew $dylib not at $dst — skipping patch"
+              continue
+            fi
+            # Resolve symlink so we overwrite the real file in the Cellar
+            real_dst=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$dst")
+            cp "$src" "$real_dst"
+            file "$real_dst" | grep -q "universal binary" \
+              && echo "Patched $real_dst to universal" \
+              || { echo "ERROR: $real_dst is not universal after patch"; exit 1; }
+          done
+
           mkdir -p "$BUILD_DIR"
           # Unset TOOLCHAINS to use Xcode's default toolchain (avoids Swift version conflicts)
           unset TOOLCHAINS


### PR DESCRIPTION
## What broke

Last 5 desktop release builds (v0.11.380 → v0.11.383) all failed at swift x86_64 cross-compile. Beta users have been pinned at v0.11.379 (May 7) for 5 days. Actual error (from Codemagic API `/builds/<id>/step/<step_id>` — not in the build JSON):

```
ld: ignoring '/opt/homebrew/opt/webp/lib/libwebp.dylib': arm64 only, required x86_64
ld: warning: Could not find or use auto-linked framework 'CoreAudioTypes'
Undefined symbols for x86_64: _WebPEncodeRGBA, _WebPFree
```

Homebrew's libwebp on Codemagic's Mac mini m2 went arm64-only sometime between May 7 and May 10. Confirmed by failing on the **revert build** v0.11.382 — no source change, same failure — so it's purely a CI/infra regression.

## Fix

The `Prepare universal libwebp` step already builds universal dylibs at `/tmp/libwebp-universal/` but they sit unused for the swift link. `Package.swift` CWebP target uses `pkgConfig: "libwebp"`, so swift build resolves library paths via Homebrew's pkg-config which points at the arm64-only Cellar dylib.

After `brew install webp`, this PR copies the universal dylib over the Cellar's arm64-only one. pkg-config still resolves to the same path; the file behind it now has both archs.

## Test plan

- [ ] Merge → auto-release → Codemagic v0.11.384 build hits "Build Swift app" step
- [ ] Step prints `Patched .../libwebp.7.dylib to universal` for both dylibs
- [ ] x86_64 link succeeds
- [ ] DMG signs, notarizes, publishes to GitHub Releases
- [ ] Beta channel appcast updates to 11384

🤖 Generated with [Claude Code](https://claude.com/claude-code)