### PR TITLE
backend: stop billing Deepgram/LLM for paywalled users

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -54,7 +54,7 @@ from utils.llm.goals import extract_and_update_goal_progress
 from database.redis_db import try_acquire_goal_extraction_lock, check_rate_limit, store_chat_share, get_chat_share
 from database.users import set_chat_message_rating_score
 from utils.rate_limit_config import get_effective_limit, RATE_LIMIT_SHADOW
-from utils.subscription import enforce_chat_quota
+from utils.subscription import enforce_chat_quota, is_trial_paywalled
 from utils.other import endpoints as auth, storage
 from utils.other.chat_file import FileChatTool
 from utils.retrieval.graph import execute_graph_chat, execute_chat_stream, execute_persona_chat_stream
@@ -508,6 +508,7 @@ async def create_voice_message_stream(
 async def transcribe_voice_message(
     request: Request,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "voice:transcribe")),
+    x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
 ):
     """Transcribe audio and return the transcript text.
 
@@ -517,6 +518,10 @@ async def transcribe_voice_message(
 
     Returns {"transcript": "...", "language": "..."}.
     """
+    # Paywalled desktop users hit the same 402 the chat endpoint returns.
+    # Without this gate, every PTT press would still bill us Deepgram.
+    enforce_chat_quota(uid, platform=x_app_platform)
+
     content_type = request.headers.get("content-type", "")
 
     if "application/octet-stream" in content_type:
@@ -696,6 +701,7 @@ async def transcribe_voice_message_stream(
     codec: str = 'linear16',
     channels: int = 1,
     keywords: Optional[str] = None,
+    x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
 ):
     """WebSocket endpoint for PTT live mode transcription-only streaming.
 
@@ -718,6 +724,12 @@ async def transcribe_voice_message_stream(
           "is_user": false, "person_id": null}]
     """
     await websocket.accept()
+
+    # Paywalled desktop users — close before opening DG connection so we don't
+    # bill Deepgram for a PTT stream that wouldn't be allowed to chat anyway.
+    if is_trial_paywalled(uid, x_app_platform):
+        await websocket.close(code=1008, reason='trial_expired')
+        return
 
     if codec != 'linear16':
         await websocket.close(code=1008, reason='Unsupported codec; only linear16 is supported')

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2359,8 +2359,11 @@ async def _stream_handler(
                 dg_socket = None  # Stop sending to dead connection
 
             if dg_socket is not None:
-                # DG budget gate: skip sending if daily budget is exhausted (#5746, #6083)
-                if fair_use_dg_budget_exhausted:
+                # DG budget gate: skip sending if daily budget is exhausted (#5746, #6083),
+                # or if the user has no transcription credits (free quota / trial paywall).
+                # Without this, audio still flows to Deepgram for paywalled users and
+                # we pay for STT we'll never return to them.
+                if fair_use_dg_budget_exhausted or not user_has_credits:
                     pass  # Audio not forwarded to DG — budget/credits exhausted
                 else:
                     dg_socket.send(chunk)


### PR DESCRIPTION
## Summary

Three leak paths were still billing us Deepgram for paywalled users:

1. `/v4/listen` — `dg_socket.send(chunk)` ignored `user_has_credits`, so audio still flowed to Deepgram. Now gates DG sends on credits.
2. `/v2/voice-message/transcribe` (PTT one-shot) — no quota gate. Added `enforce_chat_quota` so paywalled PTT returns 402 without hitting DG.
3. `/v2/voice-message/transcribe-stream` (PTT WebSocket) — opened DG socket before any auth check. Now closes with 1008 trial_expired before the DG connection opens.

Combined with the prior chat-quota 402 (blocks Gemini/Claude) and proactive-notification early return, paywalled desktop users now incur **zero** LLM/STT cost on Omi infra.

## Test plan

- [x] Syntax check
- [ ] After deploy, confirm DG usage drops for paywalled UIDs (Datadog STT metrics)
- [ ] PTT-on-desktop for paywalled user returns 402 (not Deepgram-billed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)