### PR TITLE
backend: narrow DG/PTT paywall cutoffs to desktop-only (mobile untouched)

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -518,9 +518,11 @@ async def transcribe_voice_message(
 
     Returns {"transcript": "...", "language": "..."}.
     """
-    # Paywalled desktop users hit the same 402 the chat endpoint returns.
-    # Without this gate, every PTT press would still bill us Deepgram.
-    enforce_chat_quota(uid, platform=x_app_platform)
+    # Trial paywall: reject paywalled desktop PTT before hitting Deepgram.
+    # Narrow to trial-only on purpose — full enforce_chat_quota here would
+    # change mobile behavior for users past their existing 30/mo chat cap.
+    if is_trial_paywalled(uid, x_app_platform):
+        raise HTTPException(status_code=402, detail={'error': 'quota_exceeded', 'plan_type': 'basic'})
 
     content_type = request.headers.get("content-type", "")
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -88,7 +88,7 @@ from utils.fair_use import (
     is_dg_budget_exhausted,
     record_dg_usage_ms,
 )
-from utils.subscription import has_transcription_credits, get_remaining_transcription_seconds
+from utils.subscription import has_transcription_credits, get_remaining_transcription_seconds, is_trial_paywalled
 from utils.translation import TranslationService
 from utils.translation_cache import (
     TranscriptSegmentLanguageCache,
@@ -274,6 +274,11 @@ async def _stream_handler(
         return
 
     user_has_credits = True if use_custom_stt else has_transcription_credits(uid, source=source)
+    # Computed once: only the desktop trial paywall path should also drop
+    # audio at the Deepgram-send gate. Mobile over-freemium users keep their
+    # pre-existing behavior (audio still forwarded; transcripts already
+    # suppressed elsewhere).
+    is_paywalled_desktop = is_trial_paywalled(uid, source)
     if not user_has_credits:
         try:
             await send_credit_limit_notification(uid)
@@ -2360,11 +2365,11 @@ async def _stream_handler(
 
             if dg_socket is not None:
                 # DG budget gate: skip sending if daily budget is exhausted (#5746, #6083),
-                # or if the user has no transcription credits (free quota / trial paywall).
-                # Without this, audio still flows to Deepgram for paywalled users and
-                # we pay for STT we'll never return to them.
-                if fair_use_dg_budget_exhausted or not user_has_credits:
-                    pass  # Audio not forwarded to DG — budget/credits exhausted
+                # or if this is a desktop trial-paywalled session. Mobile users over
+                # the existing freemium quota keep their pre-existing behavior so this
+                # rollout doesn't change anything on mobile.
+                if fair_use_dg_budget_exhausted or is_paywalled_desktop:
+                    pass  # Audio not forwarded to DG — budget exhausted or trial paywall
                 else:
                     dg_socket.send(chunk)
                     # Accumulate DG usage locally, flushed every 60s (#5854)


### PR DESCRIPTION
## Summary

Tightens the cutoff scope from PR #7245 so mobile freemium behavior is bit-for-bit identical to pre-trial-paywall.

#7245 used `user_has_credits` and `enforce_chat_quota` for the DG/PTT cutoffs, which also covers the existing mobile freemium caps (72k seconds/month transcription, 30 questions/month chat). That counted as a mobile behavior change.

Re-narrows both to the trial paywall path only:

- `/v4/listen`: caches `is_trial_paywalled(uid, source)` once at WS open, gates `dg_socket.send` on that. Mobile users hitting the existing 72k-sec cap still send audio to DG (pre-existing leaky behavior preserved).
- `/v2/voice-message/transcribe`: replaces `enforce_chat_quota` with a direct `is_trial_paywalled` check.
- `/v2/voice-message/transcribe-stream`: already trial-only, no change.

Net result: **mobile is bit-for-bit unchanged**. Only desktop trial-expired users hit the cutoffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)