### PR TITLE
fix(desktop-backend): allowlist Haiku model for /v2/chat/completions

### DIFF
--- a/desktop/Backend-Rust/src/models/chat_completions.rs
+++ b/desktop/Backend-Rust/src/models/chat_completions.rs
@@ -339,6 +339,20 @@ pub const MODEL_ROUTES: &[ModelRoute] = &[
         upstream_model: "claude-sonnet-4-6",
         provider: Provider::Anthropic,
     },
+    // Haiku 4.5 — used by the AgentPill router classifier and ModelQoS
+    // synthesis paths. Without these entries every call 400s and the
+    // floating-bar router silently falls back to chat, so agent pills never
+    // spawn from natural-language prompts.
+    ModelRoute {
+        public_model: "claude-haiku-4-5-20251001",
+        upstream_model: "claude-haiku-4-5",
+        provider: Provider::Anthropic,
+    },
+    ModelRoute {
+        public_model: "claude-haiku-4-5",
+        upstream_model: "claude-haiku-4-5",
+        provider: Provider::Anthropic,
+    },
 ];
 
 pub fn resolve_model(model: &str) -> Option<&'static ModelRoute> {

--- a/desktop/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/Backend-Rust/src/routes/chat_completions.rs
@@ -70,6 +70,12 @@ fn model_cost(upstream_model: &str) -> ModelCost {
             cache_read_per_token: 1.50 / 1_000_000.0,
             cache_write_per_token: 18.75 / 1_000_000.0,
         },
+        "claude-haiku-4-5" => ModelCost {
+            input_per_token: 1.0 / 1_000_000.0,
+            output_per_token: 5.0 / 1_000_000.0,
+            cache_read_per_token: 0.10 / 1_000_000.0,
+            cache_write_per_token: 1.25 / 1_000_000.0,
+        },
         _ => ModelCost {
             input_per_token: 3.0 / 1_000_000.0,
             output_per_token: 15.0 / 1_000_000.0,
@@ -942,6 +948,18 @@ mod tests {
 
         let route = resolve_model("claude-sonnet-4-20250514").unwrap();
         assert_eq!(route.upstream_model, "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn test_resolve_model_haiku() {
+        // The AgentPill router classifier sends this exact dated ID; without
+        // it the /v2/chat/completions endpoint 400s and agent pills never
+        // spawn from natural-language prompts.
+        let route = resolve_model("claude-haiku-4-5-20251001").unwrap();
+        assert_eq!(route.upstream_model, "claude-haiku-4-5");
+
+        let route = resolve_model("claude-haiku-4-5").unwrap();
+        assert_eq!(route.upstream_model, "claude-haiku-4-5");
     }
 
     #[test]

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed: agent pills now spawn correctly from voice/typed Ask Omi prompts (router was 400ing server-side)"
+  ],
   "releases": [
     {
       "version": "0.11.385",


### PR DESCRIPTION
## What was broken

The AgentPill router (the Claude Haiku classifier that decides whether a floating-bar query stays in chat or spawns a background agent pill) has been **broken since the agent-pills feature shipped**. Every router call returns HTTP 400 (empty body) and the Swift client falls back to the chat route — so agent pills never spawn from natural-language prompts. Only the explicit `Execute` button on notification/task cards (which bypasses the router) ever triggers them.

Confirmed live with curl against both dev and prod desktop-backend Cloud Run services — same 400 on both.

Root cause: `MODEL_ROUTES` in `desktop/Backend-Rust/src/models/chat_completions.rs` only allowlists Sonnet/Opus variants. The router sends `claude-haiku-4-5-20251001` (defined in `ModelQoS.swift` and used in `AgentPill.swift` lines 152 + 547). `resolve_model` returns None → 400.

## Fix

- Add two MODEL_ROUTES entries: `claude-haiku-4-5-20251001` (dated) and `claude-haiku-4-5` (bare), both upstream → `claude-haiku-4-5`
- Add Anthropic-published Haiku 4.5 pricing to `model_cost` ($1/MTok in, $5/MTok out) so cost tracking is right
- Unit test for the new routes

## Deploys to

- **Dev Cloud Run** via `desktop_backend_auto_dev.yml` (auto-fires on `desktop/Backend-Rust/**` changes) — ~5 min
- **Prod Cloud Run** via Codemagic `omi-desktop-swift-release` workflow alongside the next Swift release — ~25 min

User has a launch in <7h; want this on dev first so beta channel (routed to dev backend via #7232) gets agent pills working in the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)