### PR TITLE
fix(desktop): agent-pill router strips markdown fences from Haiku response

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed: agent pills now spawn correctly when the Haiku router wraps its decision JSON in markdown code fences"
+  ],
   "releases": [
     {
       "version": "0.11.385",

--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -174,8 +174,21 @@ final class AgentPillsManager: ObservableObject {
                 log("AgentPill: router response shape unexpected, defaulting to chat")
                 return nil
             }
+            // Haiku occasionally ignores the "no markdown" instruction and
+            // wraps the JSON in ```json ... ``` fences, or emits leading
+            // prose. Extract the first balanced {...} object instead of
+            // trusting the whole response to be raw JSON.
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard let payloadData = trimmed.data(using: .utf8),
+            let jsonBody: String
+            if let firstBrace = trimmed.firstIndex(of: "{"),
+                let lastBrace = trimmed.lastIndex(of: "}"),
+                firstBrace < lastBrace
+            {
+                jsonBody = String(trimmed[firstBrace...lastBrace])
+            } else {
+                jsonBody = trimmed
+            }
+            guard let payloadData = jsonBody.data(using: .utf8),
                 let payload = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
                 let routeStr = (payload["route"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             else {


### PR DESCRIPTION
## What

Live log from a user session:
```
AgentPill: router JSON parse failed — raw: ```json
{"route":"agent","title":"Build Snake Game Project","ack":"Starting your snake game builder now"}
```

Haiku classified the request as `agent` correctly, but wrapped the JSON in ```json … ``` markdown fences. The Swift parser passes the whole response to `JSONSerialization` which then fails because the bytes start with backticks. Falls back to chat → agent never spawns.

## Fix

Extract the first balanced `{…}` from the response before JSON parsing. Robust to markdown fences, leading prose, trailing prose. No prompt change needed.

This is the **second** of two bugs blocking natural-language agent-pill spawning. The first (server-side, model not allowlisted) was just fixed in #7249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)