### PR TITLE
desktop: cheap OpenAI TTS + free local voices in voice picker

### DIFF
--- a/backend/models/tts.py
+++ b/backend/models/tts.py
@@ -28,3 +28,6 @@ class TtsSynthesizeRequest(BaseModel):
     model_id: str = DEFAULT_MODEL_ID
     output_format: str = DEFAULT_OUTPUT_FORMAT
     voice_settings: Optional[TtsVoiceSettings] = None
+    # Provider selector. Defaults to "elevenlabs" when omitted (backward compat).
+    # Valid values: "elevenlabs", "openai".
+    provider: Optional[str] = None

--- a/backend/routers/tts.py
+++ b/backend/routers/tts.py
@@ -1,8 +1,10 @@
-"""TTS proxy route — proxies ElevenLabs text-to-speech server-side.
+"""TTS proxy route — server-side text-to-speech with pluggable providers.
 
-Mirrors `desktop/Backend-Rust/src/routes/tts.rs` so mobile clients can play
-Omi's spoken responses in background / lock-screen scenarios without shipping
-an ElevenLabs API key to the client.
+Mirrors `desktop/Backend-Rust/src/routes/tts.rs`.
+
+Providers (selected via request `provider` field):
+  - "elevenlabs" (default) — premium quality, ~$99-330 per 1M chars
+  - "openai"               — ~6.6x cheaper at $15/1M chars, MP3 output
 
 Rate limits per user (Redis-backed sliding-window + daily counter):
   - 50 requests per rolling 60 seconds → 429
@@ -34,6 +36,21 @@ _TTS_BURST_WINDOW_SECS = 60
 _TTS_REQUEST_CHAR_LIMIT = 5_000
 
 _ELEVENLABS_URL = "https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+_OPENAI_TTS_URL = "https://api.openai.com/v1/audio/speech"
+
+_OPENAI_VOICES = {
+    "alloy",
+    "ash",
+    "ballad",
+    "coral",
+    "echo",
+    "fable",
+    "nova",
+    "onyx",
+    "sage",
+    "shimmer",
+    "verse",
+}
 
 
 def _is_valid_voice_id(voice_id: str) -> bool:
@@ -43,19 +60,34 @@ def _is_valid_voice_id(voice_id: str) -> bool:
     return 1 <= len(voice_id) <= 128 and voice_id.isalnum()
 
 
+def _is_valid_openai_voice(voice_id: str) -> bool:
+    return voice_id in _OPENAI_VOICES
+
+
 @router.post('/v2/tts/synthesize', tags=['tts'])
 async def tts_synthesize(
     req: TtsSynthesizeRequest,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "tts:synthesize")),
 ):
-    """Proxy a TTS request to ElevenLabs. Per-user rate limited."""
-    api_key = os.getenv('ELEVENLABS_API_KEY')
-    if not api_key:
-        logger.error("tts_synthesize: ELEVENLABS_API_KEY not configured")
-        raise HTTPException(status_code=503, detail="TTS service not configured")
+    """Proxy a TTS request to the selected provider. Per-user rate limited."""
+    provider = (req.provider or "elevenlabs").lower()
 
-    if not _is_valid_voice_id(req.voice_id):
-        raise HTTPException(status_code=400, detail="invalid voice_id")
+    if provider == "elevenlabs":
+        api_key = os.getenv('ELEVENLABS_API_KEY')
+        if not api_key:
+            logger.error("tts_synthesize: ELEVENLABS_API_KEY not configured")
+            raise HTTPException(status_code=503, detail="ElevenLabs TTS not configured")
+        if not _is_valid_voice_id(req.voice_id):
+            raise HTTPException(status_code=400, detail="invalid voice_id")
+    elif provider == "openai":
+        api_key = os.getenv('OPENAI_API_KEY')
+        if not api_key:
+            logger.error("tts_synthesize: OPENAI_API_KEY not configured")
+            raise HTTPException(status_code=503, detail="OpenAI TTS not configured")
+        if not _is_valid_openai_voice(req.voice_id):
+            raise HTTPException(status_code=400, detail="invalid voice_id for openai provider")
+    else:
+        raise HTTPException(status_code=400, detail="invalid provider (must be 'elevenlabs' or 'openai')")
 
     text = req.text.strip()
     if not text:
@@ -91,20 +123,34 @@ async def tts_synthesize(
         )
     # status == -1 (Redis error): fail-open intentionally — TTS is best-effort.
 
-    body: dict = {
-        "text": text,
-        "model_id": req.model_id,
-        "output_format": req.output_format,
-    }
-    if req.voice_settings is not None:
-        body["voice_settings"] = req.voice_settings.model_dump(exclude_none=True)
-
-    url = _ELEVENLABS_URL.format(voice_id=req.voice_id)
-    headers = {
-        "Content-Type": "application/json",
-        "Accept": "audio/mpeg",
-        "xi-api-key": api_key,
-    }
+    if provider == "openai":
+        openai_model = req.model_id if req.model_id in ("tts-1", "tts-1-hd") else "gpt-4o-mini-tts"
+        body = {
+            "model": openai_model,
+            "input": text,
+            "voice": req.voice_id,
+            "response_format": "mp3",
+        }
+        url = _OPENAI_TTS_URL
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "audio/mpeg",
+            "Authorization": f"Bearer {api_key}",
+        }
+    else:
+        body = {
+            "text": text,
+            "model_id": req.model_id,
+            "output_format": req.output_format,
+        }
+        if req.voice_settings is not None:
+            body["voice_settings"] = req.voice_settings.model_dump(exclude_none=True)
+        url = _ELEVENLABS_URL.format(voice_id=req.voice_id)
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "audio/mpeg",
+            "xi-api-key": api_key,
+        }
 
     client = get_tts_client()
     semaphore = get_tts_semaphore()
@@ -128,7 +174,7 @@ async def tts_synthesize(
             await upstream_cm.__aexit__(None, None, None)
             semaphore.release()
             logger.warning(
-                f"tts_synthesize: ElevenLabs returned {resp.status_code} uid={uid}: " f"{sanitize(err_text)}"
+                f"tts_synthesize: provider={provider} returned {resp.status_code} uid={uid}: {sanitize(err_text)}"
             )
             raise HTTPException(status_code=resp.status_code, detail="TTS upstream error")
     except HTTPException:

--- a/backend/tests/unit/test_tts.py
+++ b/backend/tests/unit/test_tts.py
@@ -184,6 +184,7 @@ def test_request_model_applies_defaults():
     assert req.model_id == "eleven_turbo_v2_5"
     assert req.output_format == "mp3_44100_128"
     assert req.voice_settings is None
+    assert req.provider is None
 
 
 def test_request_model_rejects_empty_text():
@@ -193,3 +194,22 @@ def test_request_model_rejects_empty_text():
 
     with pytest.raises(ValidationError):
         TtsSynthesizeRequest(text="")
+
+
+# ---------------------------------------------------------------------------
+# OpenAI provider
+# ---------------------------------------------------------------------------
+def test_openai_voice_validation():
+    for v in ("alloy", "shimmer", "nova", "coral", "sage", "onyx"):
+        assert tts_router._is_valid_openai_voice(v), v
+    assert not tts_router._is_valid_openai_voice("Shimmer")  # case-sensitive
+    assert not tts_router._is_valid_openai_voice("not-a-voice")
+    assert not tts_router._is_valid_openai_voice("")
+
+
+def test_request_model_accepts_openai_provider():
+    from models.tts import TtsSynthesizeRequest
+
+    req = TtsSynthesizeRequest(text="hi", voice_id="shimmer", provider="openai")
+    assert req.provider == "openai"
+    assert req.voice_id == "shimmer"

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -71,6 +71,8 @@ pub struct Config {
     pub desktop_legacy_anthropic_key: Option<String>,
     /// ElevenLabs API key for TTS proxy (used server-side by /v1/tts/synthesize, never served to clients)
     pub elevenlabs_api_key: Option<String>,
+    /// OpenAI API key for the OpenAI TTS provider in /v1/tts/synthesize (~6.6x cheaper than ElevenLabs, MP3 output)
+    pub openai_api_key: Option<String>,
     /// Google Calendar API key (served to desktop clients)
     pub google_calendar_api_key: Option<String>,
     /// When true, omit ElevenLabs API key from /v1/config/api-keys response.
@@ -143,6 +145,7 @@ impl Config {
             anthropic_api_key: env::var("ANTHROPIC_API_KEY").ok(),
             desktop_legacy_anthropic_key: env::var("DESKTOP_LEGACY_ANTHROPIC_KEY").ok(),
             elevenlabs_api_key: env::var("ELEVENLABS_API_KEY").ok(),
+            openai_api_key: env::var("OPENAI_API_KEY").ok(),
             google_calendar_api_key: env::var("GOOGLE_CALENDAR_API_KEY").ok(),
             disable_elevenlabs_key_response: env::var("DISABLE_ELEVENLABS_KEY_RESPONSE")
                 .map(|v| v == "true" || v == "1")

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -1,5 +1,15 @@
-// TTS proxy route — proxies ElevenLabs text-to-speech requests server-side.
-// Key stays on the backend; desktop client authenticates via Firebase token only.
+// TTS proxy route — server-side text-to-speech with pluggable providers.
+//
+// Providers:
+//   - "elevenlabs" (default) — premium quality, ~$99-330 per 1M chars
+//   - "openai"               — ~6.6x cheaper at $15/1M chars, MP3 output,
+//                              voices: alloy/ash/ballad/coral/echo/fable/nova/
+//                              onyx/sage/shimmer/verse
+//
+// Selected via the `provider` field in the request body; default remains
+// "elevenlabs" for backward compatibility.
+//
+// Keys stay on the backend; desktop client authenticates via Firebase token only.
 //
 // Per-user rate limits (Redis-backed):
 //   - 50 requests per rolling 60-second window → 429
@@ -41,6 +51,19 @@ struct TtsSynthesizeRequest {
     #[serde(default = "default_output_format")]
     output_format: String,
     voice_settings: Option<VoiceSettings>,
+    /// Provider selector. Defaults to "elevenlabs" when omitted (backward compat).
+    /// Valid values: "elevenlabs", "openai".
+    #[serde(default)]
+    provider: Option<String>,
+}
+
+/// OpenAI TTS voice names accepted by `/v1/audio/speech`.
+const OPENAI_VOICES: &[&str] = &[
+    "alloy", "ash", "ballad", "coral", "echo", "fable", "nova", "onyx", "sage", "shimmer", "verse",
+];
+
+fn is_valid_openai_voice(id: &str) -> bool {
+    OPENAI_VOICES.contains(&id)
 }
 
 #[derive(Deserialize, Serialize)]
@@ -75,28 +98,47 @@ struct TtsErrorDetail {
 }
 
 /// POST /v1/tts/synthesize
-/// Proxies TTS requests to ElevenLabs API. Per-user rate limited.
+/// Proxies TTS requests to the selected provider (default: ElevenLabs). Per-user rate limited.
 async fn tts_synthesize(
     State(state): State<AppState>,
     user: AuthUser,
     Json(req): Json<TtsSynthesizeRequest>,
 ) -> Result<Response, Response> {
-    let elevenlabs_key = state.config.elevenlabs_api_key.as_ref().ok_or_else(|| {
-        tracing::error!("tts_synthesize: ELEVENLABS_API_KEY not configured");
-        StatusCode::SERVICE_UNAVAILABLE.into_response()
-    })?;
+    let provider = req
+        .provider
+        .as_deref()
+        .map(|p| p.to_ascii_lowercase())
+        .unwrap_or_else(|| "elevenlabs".to_string());
 
-    // Validate voice_id: must be alphanumeric (ElevenLabs IDs are 20-char base62).
-    // Prevents path traversal (e.g. "../../history") that could retarget the xi-api-key.
-    if !is_valid_voice_id(&req.voice_id) {
-        return Err(error_response(StatusCode::BAD_REQUEST, "invalid voice_id"));
+    // Validate voice_id per provider before any external work.
+    match provider.as_str() {
+        "elevenlabs" => {
+            if !is_valid_voice_id(&req.voice_id) {
+                return Err(error_response(StatusCode::BAD_REQUEST, "invalid voice_id"));
+            }
+        }
+        "openai" => {
+            if !is_valid_openai_voice(&req.voice_id) {
+                return Err(error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid voice_id for openai provider",
+                ));
+            }
+        }
+        other => {
+            tracing::warn!("tts_synthesize: unknown provider '{}'", other);
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid provider (must be 'elevenlabs' or 'openai')",
+            ));
+        }
     }
 
     // Validate text is not empty and not excessively long (single request cap: 5000 chars)
     let char_count = validate_text(&req.text)
         .map_err(|message| error_response(StatusCode::BAD_REQUEST, message))?;
 
-    // Rate limit check (Redis-backed, fail closed)
+    // Rate limit check (Redis-backed, fail closed) — shared limits across providers
     let redis = state.redis.as_ref().ok_or_else(|| {
         tracing::error!("tts_synthesize: Redis not configured — TTS rate limiting requires Redis");
         error_response(
@@ -142,34 +184,84 @@ async fn tts_synthesize(
         }
     }
 
-    // Build ElevenLabs upstream request
-    let upstream_url = format!(
-        "https://api.elevenlabs.io/v1/text-to-speech/{}",
-        req.voice_id
-    );
+    let (upstream_url, headers, body) = match provider.as_str() {
+        "openai" => {
+            let key = state.config.openai_api_key.as_ref().ok_or_else(|| {
+                tracing::error!("tts_synthesize: OPENAI_API_KEY not configured");
+                error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "OpenAI TTS not configured",
+                )
+            })?;
+            // OpenAI model: prefer "gpt-4o-mini-tts" (cheaper + better voices) when the
+            // client didn't override model_id with an OpenAI-specific name; fall back
+            // to "tts-1" if the caller asked for it explicitly.
+            let openai_model = if req.model_id == "tts-1" || req.model_id == "tts-1-hd" {
+                req.model_id.clone()
+            } else {
+                "gpt-4o-mini-tts".to_string()
+            };
+            let body = serde_json::json!({
+                "model": openai_model,
+                "input": req.text,
+                "voice": req.voice_id,
+                "response_format": "mp3",
+            });
+            let headers = vec![
+                ("Content-Type", "application/json".to_string()),
+                ("Accept", "audio/mpeg".to_string()),
+                ("Authorization", format!("Bearer {}", key)),
+            ];
+            (
+                "https://api.openai.com/v1/audio/speech".to_string(),
+                headers,
+                body,
+            )
+        }
+        _ => {
+            let key = state.config.elevenlabs_api_key.as_ref().ok_or_else(|| {
+                tracing::error!("tts_synthesize: ELEVENLABS_API_KEY not configured");
+                error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "ElevenLabs TTS not configured",
+                )
+            })?;
+            let mut body = serde_json::json!({
+                "text": req.text,
+                "model_id": req.model_id,
+                "output_format": req.output_format,
+            });
+            if let Some(vs) = &req.voice_settings {
+                body["voice_settings"] = serde_json::to_value(vs).unwrap_or_default();
+            }
+            let headers = vec![
+                ("Content-Type", "application/json".to_string()),
+                ("Accept", "audio/mpeg".to_string()),
+                ("xi-api-key", key.clone()),
+            ];
+            let url = format!(
+                "https://api.elevenlabs.io/v1/text-to-speech/{}",
+                req.voice_id
+            );
+            (url, headers, body)
+        }
+    };
 
-    let mut body = serde_json::json!({
-        "text": req.text,
-        "model_id": req.model_id,
-        "output_format": req.output_format,
-    });
-    if let Some(vs) = &req.voice_settings {
-        body["voice_settings"] = serde_json::to_value(vs).unwrap_or_default();
-    }
-
-    let upstream = reqwest::Client::new()
+    let mut request_builder = reqwest::Client::new()
         .post(&upstream_url)
-        .header("Content-Type", "application/json")
-        .header("Accept", "audio/mpeg")
-        .header("xi-api-key", elevenlabs_key)
         .body(serde_json::to_vec(&body).unwrap_or_default())
-        .timeout(std::time::Duration::from_secs(60))
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!("tts_synthesize: upstream request failed: {}", e);
-            StatusCode::BAD_GATEWAY.into_response()
-        })?;
+        .timeout(std::time::Duration::from_secs(60));
+    for (name, value) in &headers {
+        request_builder = request_builder.header(*name, value);
+    }
+    let upstream = request_builder.send().await.map_err(|e| {
+        tracing::error!(
+            "tts_synthesize: upstream request failed (provider={}): {}",
+            provider,
+            e
+        );
+        StatusCode::BAD_GATEWAY.into_response()
+    })?;
 
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
@@ -177,7 +269,8 @@ async fn tts_synthesize(
     if !status.is_success() {
         let error_body = upstream.text().await.unwrap_or_default();
         tracing::warn!(
-            "tts_synthesize: ElevenLabs returned {} for uid={}: {}",
+            "tts_synthesize: provider={} returned {} for uid={}: {}",
+            provider,
             status.as_u16(),
             user.uid,
             &error_body[..error_body.len().min(200)]
@@ -333,6 +426,29 @@ mod tests {
         assert_eq!(req.model_id, default_model_id());
         assert_eq!(req.output_format, default_output_format());
         assert!(req.voice_settings.is_none());
+        assert!(req.provider.is_none());
+    }
+
+    #[test]
+    fn openai_voice_validation() {
+        for v in ["alloy", "shimmer", "nova", "coral", "sage", "onyx"] {
+            assert!(is_valid_openai_voice(v), "expected {v} to be valid");
+        }
+        assert!(!is_valid_openai_voice("Shimmer")); // case-sensitive
+        assert!(!is_valid_openai_voice("not-a-voice"));
+        assert!(!is_valid_openai_voice(""));
+    }
+
+    #[test]
+    fn deserialize_request_with_openai_provider() {
+        let req: TtsSynthesizeRequest = serde_json::from_value(serde_json::json!({
+            "text": "hello",
+            "voice_id": "shimmer",
+            "provider": "openai",
+        }))
+        .unwrap();
+        assert_eq!(req.provider.as_deref(), Some("openai"));
+        assert_eq!(req.voice_id, "shimmer");
     }
 
     #[test]

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added OpenAI TTS (~6.6x cheaper than ElevenLabs) and free on-device Apple voices to the voice picker, with new default voice Shimmer"
+  ],
   "releases": [
     {
       "version": "0.11.385",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -4629,7 +4629,10 @@ extension APIClient {
     let voiceId: String
     let modelId: String
     let outputFormat: String
-    let voiceSettings: TtsVoiceSettings
+    let voiceSettings: TtsVoiceSettings?
+    /// Optional provider override. "openai" routes to OpenAI TTS, "elevenlabs"
+    /// (or omitted) routes to ElevenLabs.
+    let provider: String?
 
     enum CodingKeys: String, CodingKey {
       case text
@@ -4637,6 +4640,7 @@ extension APIClient {
       case modelId = "model_id"
       case outputFormat = "output_format"
       case voiceSettings = "voice_settings"
+      case provider
     }
   }
 

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -7,8 +7,8 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
   static let devVoiceIDDefaultsKey = "dev_elevenlabs_voice_id"
 
-  nonisolated private static let defaultVoiceID = "BAMYoBHLZM7lJgJAmFz0"  // Sloane
-  nonisolated private static let defaultModelID = "eleven_turbo_v2_5"
+  nonisolated private static let defaultVoiceID = "shimmer"  // OpenAI Shimmer (sultry, $15/1M)
+  nonisolated private static let elevenLabsModelID = "eleven_turbo_v2_5"
   // First chunk stays small so playback starts fast.
   nonisolated private static let firstChunkMinimumLength = 40
   nonisolated private static let firstChunkPreferredLength = 120
@@ -67,14 +67,16 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     if currentMode == nil {
       currentMode = resolvePlaybackMode()
     }
-    guard let mode = currentMode, case .elevenLabs(let voiceID) = mode else { return }
+    // Cloud-provider filler only — local AVSpeechSynthesizer starts speaking
+    // instantly, so it has no use for a "let me check" filler.
+    guard let mode = currentMode, case .backend(let voiceID, let provider) = mode else { return }
 
     hasStartedRealPlayback = false
     let phrase = Self.fillerPhrases.randomElement()!
     fillerTask = Task { [weak self] in
       do {
         let audioData = try await Self.synthesizeSpeech(
-          text: phrase, voiceID: voiceID)
+          text: phrase, voiceID: voiceID, provider: provider)
         try Task.checkCancellation()
         await MainActor.run {
           guard let self, !self.hasStartedRealPlayback else { return }
@@ -145,14 +147,21 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   }
 
   private func resolvePlaybackMode() -> PlaybackMode {
-    // TTS is now proxied through the backend — no client-side API key needed.
-    // Fall back to system voice only if the backend URL is not configured.
-    guard getenv("OMI_DESKTOP_API_URL") != nil else {
-      return .systemFallback
-    }
     let voiceID = ShortcutSettings.shared.selectedVoiceID
     let resolvedVoiceID = voiceID.isEmpty ? Self.defaultVoiceID : voiceID
-    return .elevenLabs(voiceID: resolvedVoiceID)
+    let option = ShortcutSettings.voiceOption(for: resolvedVoiceID)
+    switch option.provider {
+    case .local:
+      return .local(voiceKey: option.id)
+    case .openai, .elevenLabs:
+      // Backend-routed providers require the desktop API URL. Fall back to a
+      // local Apple voice if the backend isn't configured (e.g. dev with no
+      // tunnel) so the user still hears speech.
+      guard getenv("OMI_DESKTOP_API_URL") != nil else {
+        return .local(voiceKey: option.name)
+      }
+      return .backend(voiceID: resolvedVoiceID, provider: option.provider)
+    }
   }
 
   private func drainBufferedText(isFinal: Bool, mode: PlaybackMode) {
@@ -171,9 +180,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
   private func enqueueChunk(_ text: String, mode: PlaybackMode) {
     switch mode {
-    case .systemFallback:
-      enqueueSystemSpeech(text)
-    case .elevenLabs:
+    case .local(let voiceKey):
+      enqueueSystemSpeech(text, voiceKey: voiceKey)
+    case .backend:
       synthesisQueue.append(text)
       startSynthesisIfNeeded(mode: mode)
     }
@@ -181,7 +190,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
   private func startSynthesisIfNeeded(mode: PlaybackMode) {
     guard !isSynthesizing else { return }
-    guard case .elevenLabs(let voiceID) = mode else { return }
+    guard case .backend(let voiceID, let provider) = mode else { return }
     guard !synthesisQueue.isEmpty else { return }
 
     let text = synthesisQueue.removeFirst()
@@ -190,7 +199,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     playbackTask = Task { [weak self] in
       do {
         let audioData = try await Self.synthesizeSpeech(
-          text: text, voiceID: voiceID)
+          text: text, voiceID: voiceID, provider: provider)
         try Task.checkCancellation()
         await MainActor.run {
           guard let self else { return }
@@ -219,9 +228,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
           guard let self else { return }
           self.isSynthesizing = false
           log(
-            "FloatingBarVoicePlaybackService: ElevenLabs chunk synthesis failed, falling back to system voice: \(error.localizedDescription)"
+            "FloatingBarVoicePlaybackService: \(provider.rawValue) chunk synthesis failed, falling back to system voice: \(error.localizedDescription)"
           )
-          self.enqueueSystemSpeech(text)
+          self.enqueueSystemSpeech(text, voiceKey: nil)
           self.startSynthesisIfNeeded(mode: mode)
         }
       }
@@ -235,8 +244,8 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     shouldInterruptNextResponse = false
   }
 
-  /// Play a short preview of the given ElevenLabs voice so the user can hear it
-  /// when switching voices in settings.
+  /// Play a short preview of the given voice so the user can hear it when
+  /// switching voices in settings. Routes to the correct provider.
   func playVoiceSample(voiceID: String) {
     resetPlaybackPipeline(clearMode: true)
     currentResponseID = nil
@@ -244,17 +253,26 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     shouldInterruptNextResponse = false
 
     let phrase = Self.voiceSampleText
+    let option = ShortcutSettings.voiceOption(for: voiceID)
 
-    // Without the backend URL the service falls back to the system voice, which
-    // wouldn't demo the ElevenLabs voice anyway.
+    // Local voices are demoed via AVSpeechSynthesizer with the named voice;
+    // no network round-trip and no API cost.
+    if option.provider == .local {
+      enqueueSystemSpeech(phrase, voiceKey: option.id)
+      return
+    }
+
+    // Backend-routed providers need the desktop API URL. Without it fall back
+    // to the on-device system voice so the user still hears _something_.
     guard getenv("OMI_DESKTOP_API_URL") != nil else {
-      enqueueSystemSpeech(phrase)
+      enqueueSystemSpeech(phrase, voiceKey: nil)
       return
     }
 
     playbackTask = Task { [weak self] in
       do {
-        let audioData = try await Self.synthesizeSpeech(text: phrase, voiceID: voiceID)
+        let audioData = try await Self.synthesizeSpeech(
+          text: phrase, voiceID: voiceID, provider: option.provider)
         try Task.checkCancellation()
         await MainActor.run {
           guard let self else { return }
@@ -265,37 +283,38 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
       } catch {
         if Self.isCancellation(error) { return }
         log(
-          "FloatingBarVoicePlaybackService: voice sample failed: \(error.localizedDescription)"
+          "FloatingBarVoicePlaybackService: voice sample failed (\(option.provider.rawValue)): \(error.localizedDescription)"
         )
       }
     }
   }
 
-  /// Synthesize and play a single short phrase via ElevenLabs (or fall back to
-  /// the system voice). Used by agent pills to speak a short acknowledgement
-  /// like "On it" before the agent kicks off.
+  /// Synthesize and play a single short phrase via the current provider (or fall
+  /// back to the system voice). Used by agent pills to speak a short
+  /// acknowledgement like "On it" before the agent kicks off.
   func speakOneShot(_ text: String) {
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
     let mode = currentMode ?? resolvePlaybackMode()
     currentMode = mode
     switch mode {
-    case .elevenLabs(let voiceID):
+    case .backend(let voiceID, let provider):
       Task { [weak self] in
         do {
-          let audio = try await Self.synthesizeSpeech(text: trimmed, voiceID: voiceID)
+          let audio = try await Self.synthesizeSpeech(
+            text: trimmed, voiceID: voiceID, provider: provider)
           await MainActor.run {
             self?.startPlayback(audio)
           }
         } catch {
           // Network/API error — fall back to system voice on the main thread.
           await MainActor.run {
-            self?.enqueueSystemSpeech(trimmed)
+            self?.enqueueSystemSpeech(trimmed, voiceKey: nil)
           }
         }
       }
-    case .systemFallback:
-      enqueueSystemSpeech(trimmed)
+    case .local(let voiceKey):
+      enqueueSystemSpeech(trimmed, voiceKey: voiceKey)
     }
   }
 
@@ -331,12 +350,12 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     }
   }
 
-  private func enqueueSystemSpeech(_ text: String) {
+  private func enqueueSystemSpeech(_ text: String, voiceKey: String?) {
     let utterance = AVSpeechUtterance(string: text)
     utterance.rate = 0.47
     utterance.pitchMultiplier = 1.02
     utterance.volume = 1.0
-    utterance.voice = preferredSystemVoice()
+    utterance.voice = preferredSystemVoice(matching: voiceKey)
     speechSynthesizer.speak(utterance)
   }
 
@@ -368,10 +387,30 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     speechSynthesizer.stopSpeaking(at: .immediate)
   }
 
-  private func preferredSystemVoice() -> AVSpeechSynthesisVoice? {
-    let preferredNames = ["Ava", "Allison", "Samantha", "Karen", "Moira"]
-    for name in preferredNames {
-      if let voice = AVSpeechSynthesisVoice.speechVoices().first(where: {
+  /// Pick an installed Apple voice. When `voiceKey` is provided we look for a
+  /// voice whose name contains that key (e.g. "Ava", "Zoe"). When it's nil or
+  /// no match is found we fall through to a curated preference list, then to
+  /// any en-US voice.
+  private func preferredSystemVoice(matching voiceKey: String?) -> AVSpeechSynthesisVoice? {
+    let installed = AVSpeechSynthesisVoice.speechVoices()
+
+    if let key = voiceKey, !key.isEmpty {
+      // Prefer premium / enhanced variants of the requested voice when installed.
+      let matches = installed.filter { $0.name.localizedCaseInsensitiveContains(key) }
+      if let premium = matches.first(where: { $0.quality == .premium }) {
+        return premium
+      }
+      if let enhanced = matches.first(where: { $0.quality == .enhanced }) {
+        return enhanced
+      }
+      if let any = matches.first {
+        return any
+      }
+    }
+
+    let fallbackNames = ["Ava", "Allison", "Samantha", "Karen", "Moira"]
+    for name in fallbackNames {
+      if let voice = installed.first(where: {
         $0.name.localizedCaseInsensitiveContains(name)
       }) {
         return voice
@@ -380,21 +419,26 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     return AVSpeechSynthesisVoice(language: "en-US")
   }
 
-  /// Synthesize speech via the backend TTS proxy (ElevenLabs key stays server-side).
-  private nonisolated static func synthesizeSpeech(text: String, voiceID: String)
+  /// Synthesize speech via the backend TTS proxy. The provider (ElevenLabs or
+  /// OpenAI) is selected server-side via the request's `provider` field; keys
+  /// stay on the backend.
+  private nonisolated static func synthesizeSpeech(
+    text: String, voiceID: String, provider: ShortcutSettings.VoiceOption.Provider
+  )
     async throws -> Data
   {
+    // ElevenLabs needs `model_id` + voice_settings (stability/similarity/style);
+    // OpenAI ignores those and uses model="gpt-4o-mini-tts" (set server-side).
+    let isElevenLabs = (provider == .elevenLabs)
     let request = APIClient.TtsSynthesizeRequest(
       text: text,
       voiceId: voiceID,
-      modelId: defaultModelID,
+      modelId: isElevenLabs ? elevenLabsModelID : "tts",
       outputFormat: "mp3_44100_128",
-      voiceSettings: .init(
-        stability: 0.34,
-        similarityBoost: 0.88,
-        style: 0.12,
-        useSpeakerBoost: true
-      )
+      voiceSettings: isElevenLabs
+        ? .init(stability: 0.34, similarityBoost: 0.88, style: 0.12, useSpeakerBoost: true)
+        : nil,
+      provider: provider.backendValue
     )
     return try await APIClient.shared.synthesizeSpeech(request: request)
   }
@@ -502,8 +546,12 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 }
 
 private enum PlaybackMode {
-  case elevenLabs(voiceID: String)
-  case systemFallback
+  /// A cloud TTS provider routed through the backend proxy. `voiceID` is the
+  /// upstream-specific id ("shimmer" for OpenAI, base62 for ElevenLabs).
+  case backend(voiceID: String, provider: ShortcutSettings.VoiceOption.Provider)
+  /// Apple's on-device `AVSpeechSynthesizer`. `voiceKey` is matched against the
+  /// installed voice catalog (e.g. "Ava", "Zoe", "Samantha").
+  case local(voiceKey: String)
 }
 
 private enum FloatingBarVoicePlaybackError: LocalizedError {

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -391,34 +391,129 @@ class ShortcutSettings: ObservableObject {
         return "Maximum"
     }
 
-    /// A selectable ElevenLabs voice for floating-bar replies.
+    /// A selectable TTS voice for floating-bar replies. Provider determines how
+    /// audio is synthesized:
+    ///   - `.local`      — Apple's built-in `AVSpeechSynthesizer` (free, on-device)
+    ///   - `.openai`     — OpenAI `/v1/audio/speech` via backend proxy (~$15/1M chars)
+    ///   - `.elevenLabs` — ElevenLabs via backend proxy (~$99-330/1M chars)
+    ///
+    /// The `id` is what's sent to the provider:
+    ///   - elevenLabs: 20-char base62 voice id (e.g. "BAMYoBHLZM7lJgJAmFz0")
+    ///   - openai:     voice name (e.g. "shimmer", "nova")
+    ///   - local:      a search key matched against installed AVSpeechSynthesisVoices
     struct VoiceOption: Identifiable, Equatable {
         enum Gender: String {
             case female
             case male
         }
 
+        enum Provider: String {
+            case elevenLabs
+            case openai
+            case local
+
+            /// Short pricing label rendered next to each provider section.
+            var costLabel: String {
+                switch self {
+                case .local: return "Free"
+                case .openai: return "$15/M"
+                case .elevenLabs: return "$99/M"
+                }
+            }
+
+            /// Display name for the picker's section header.
+            var displayName: String {
+                switch self {
+                case .local: return "Local (on-device)"
+                case .openai: return "OpenAI"
+                case .elevenLabs: return "ElevenLabs"
+                }
+            }
+
+            /// String the backend uses to dispatch the request.
+            var backendValue: String? {
+                switch self {
+                case .local: return nil
+                case .openai: return "openai"
+                case .elevenLabs: return "elevenlabs"
+                }
+            }
+        }
+
         let id: String
         let name: String
         let gender: Gender
         let description: String
+        let provider: Provider
     }
 
-    /// Curated ElevenLabs voices available from the voice picker.
+    /// Curated voices available from the voice picker, grouped by provider.
+    /// Order within each provider is female-first so the default (sultry female)
+    /// surfaces near the top of each section.
     static let availableVoices: [VoiceOption] = [
-        VoiceOption(id: "BAMYoBHLZM7lJgJAmFz0", name: "Sloane", gender: .female, description: "Warm, confident"),
-        VoiceOption(id: "XB0fDUnXU5powFXDhCwa", name: "Charlotte", gender: .female, description: "Smooth, sultry"),
-        VoiceOption(id: "21m00Tcm4TlvDq8ikWAM", name: "Rachel", gender: .female, description: "Calm, breathy"),
-        VoiceOption(id: "XrExE9yKIg1WjnnlVkGX", name: "Matilda", gender: .female, description: "Soft, mature"),
-        VoiceOption(id: "piTKgcLEGmPE4e6mEKli", name: "Nicole", gender: .female, description: "Whispery, intimate"),
-        VoiceOption(id: "pNInz6obpgDQGcFmaJgB", name: "Adam", gender: .male, description: "Deep American"),
-        VoiceOption(id: "ErXwobaYiN019PkySvjV", name: "Antoni", gender: .male, description: "Warm, friendly"),
-        VoiceOption(id: "TxGEqnHWrfWFTfGW9XjX", name: "Josh", gender: .male, description: "Young, deep"),
-        VoiceOption(id: "N2lVS1w4EtoT3dr4eOWO", name: "Callum", gender: .male, description: "Intense, gravelly"),
-        VoiceOption(id: "onwK4e9ZLuTAKqWW03F9", name: "Daniel", gender: .male, description: "Authoritative British"),
+        // ── OpenAI (~$15/1M chars, MP3, low latency) ──────────────────────
+        VoiceOption(id: "shimmer", name: "Shimmer", gender: .female,
+                    description: "Soft, sultry", provider: .openai),
+        VoiceOption(id: "nova", name: "Nova", gender: .female,
+                    description: "Warm, energetic", provider: .openai),
+        VoiceOption(id: "coral", name: "Coral", gender: .female,
+                    description: "Bright, confident", provider: .openai),
+        VoiceOption(id: "sage", name: "Sage", gender: .female,
+                    description: "Calm, mature", provider: .openai),
+        VoiceOption(id: "ballad", name: "Ballad", gender: .male,
+                    description: "Smooth, lyrical", provider: .openai),
+        VoiceOption(id: "ash", name: "Ash", gender: .male,
+                    description: "Crisp, articulate", provider: .openai),
+        VoiceOption(id: "onyx", name: "Onyx", gender: .male,
+                    description: "Deep, authoritative", provider: .openai),
+        VoiceOption(id: "echo", name: "Echo", gender: .male,
+                    description: "Neutral, clear", provider: .openai),
+
+        // ── Local Apple voices (free, on-device, no API) ───────────────────
+        // `id` is a search key matched against installed AVSpeechSynthesisVoices
+        // — premium/enhanced variants are preferred when available.
+        VoiceOption(id: "Ava", name: "Ava", gender: .female,
+                    description: "US English, premium", provider: .local),
+        VoiceOption(id: "Zoe", name: "Zoe", gender: .female,
+                    description: "US English, expressive", provider: .local),
+        VoiceOption(id: "Samantha", name: "Samantha", gender: .female,
+                    description: "US English, classic", provider: .local),
+        VoiceOption(id: "Allison", name: "Allison", gender: .female,
+                    description: "US English, soft", provider: .local),
+        VoiceOption(id: "Moira", name: "Moira", gender: .female,
+                    description: "Irish, warm", provider: .local),
+        VoiceOption(id: "Karen", name: "Karen", gender: .female,
+                    description: "Australian, bright", provider: .local),
+        VoiceOption(id: "Tom", name: "Tom", gender: .male,
+                    description: "US English, neutral", provider: .local),
+        VoiceOption(id: "Daniel", name: "Daniel", gender: .male,
+                    description: "British, authoritative", provider: .local),
+
+        // ── ElevenLabs (premium, ~$99-330/1M chars — kept for comparison) ──
+        VoiceOption(id: "BAMYoBHLZM7lJgJAmFz0", name: "Sloane", gender: .female,
+                    description: "Warm, confident", provider: .elevenLabs),
+        VoiceOption(id: "XB0fDUnXU5powFXDhCwa", name: "Charlotte", gender: .female,
+                    description: "Smooth, sultry", provider: .elevenLabs),
+        VoiceOption(id: "21m00Tcm4TlvDq8ikWAM", name: "Rachel", gender: .female,
+                    description: "Calm, breathy", provider: .elevenLabs),
+        VoiceOption(id: "XrExE9yKIg1WjnnlVkGX", name: "Matilda", gender: .female,
+                    description: "Soft, mature", provider: .elevenLabs),
+        VoiceOption(id: "piTKgcLEGmPE4e6mEKli", name: "Nicole", gender: .female,
+                    description: "Whispery, intimate", provider: .elevenLabs),
+        VoiceOption(id: "pNInz6obpgDQGcFmaJgB", name: "Adam", gender: .male,
+                    description: "Deep American", provider: .elevenLabs),
+        VoiceOption(id: "ErXwobaYiN019PkySvjV", name: "Antoni", gender: .male,
+                    description: "Warm, friendly", provider: .elevenLabs),
+        VoiceOption(id: "TxGEqnHWrfWFTfGW9XjX", name: "Josh", gender: .male,
+                    description: "Young, deep", provider: .elevenLabs),
+        VoiceOption(id: "N2lVS1w4EtoT3dr4eOWO", name: "Callum", gender: .male,
+                    description: "Intense, gravelly", provider: .elevenLabs),
+        VoiceOption(id: "onwK4e9ZLuTAKqWW03F9", name: "Daniel", gender: .male,
+                    description: "Authoritative British", provider: .elevenLabs),
     ]
 
-    static let defaultVoiceID = "BAMYoBHLZM7lJgJAmFz0"
+    /// Default voice — OpenAI Shimmer (soft, sultry; ~6.6x cheaper than ElevenLabs).
+    static let defaultVoiceID = "shimmer"
 
     static func voiceOption(for id: String) -> VoiceOption {
         availableVoices.first(where: { $0.id == id }) ?? availableVoices[0]

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -2269,34 +2269,42 @@ struct SettingsContentView: View {
   }
 
   private func voicePicker(settingId: String) -> some View {
-    settingsCard(settingId: settingId) {
+    let current = ShortcutSettings.voiceOption(for: shortcutSettings.selectedVoiceID)
+    return settingsCard(settingId: settingId) {
       HStack(spacing: 16) {
         VStack(alignment: .leading, spacing: 4) {
           Text("Voice")
             .scaledFont(size: 16, weight: .semibold)
             .foregroundColor(OmiColors.textPrimary)
           Text(
-            ShortcutSettings.voiceOption(for: shortcutSettings.selectedVoiceID).description
+            "\(current.description) · \(current.provider.displayName) · \(current.provider.costLabel)"
           )
           .scaledFont(size: 13)
           .foregroundColor(OmiColors.textSecondary)
         }
         Spacer()
         Picker("", selection: $shortcutSettings.selectedVoiceID) {
-          Section("Female") {
-            ForEach(ShortcutSettings.availableVoices.filter { $0.gender == .female }) { voice in
-              Text(voice.name).tag(voice.id)
-            }
-          }
-          Section("Male") {
-            ForEach(ShortcutSettings.availableVoices.filter { $0.gender == .male }) { voice in
-              Text(voice.name).tag(voice.id)
+          // Grouped by provider, with cost label in the section header so the
+          // free / cheap / premium tradeoff is visible right in the picker.
+          ForEach(
+            [
+              ShortcutSettings.VoiceOption.Provider.openai,
+              .local,
+              .elevenLabs,
+            ],
+            id: \.rawValue
+          ) { provider in
+            Section("\(provider.displayName) — \(provider.costLabel)") {
+              ForEach(ShortcutSettings.availableVoices.filter { $0.provider == provider }) {
+                voice in
+                Text("\(voice.name) · \(voice.description)").tag(voice.id)
+              }
             }
           }
         }
         .pickerStyle(.menu)
         .labelsHidden()
-        .frame(width: 180)
+        .frame(width: 260)
         .tint(OmiColors.purplePrimary)
       }
     }


### PR DESCRIPTION
## Summary

- Adds **OpenAI TTS** as a backend-side provider (~$15/1M chars, ~6.6x cheaper than ElevenLabs' cheapest tier and ~22x cheaper than v3).
- Adds **on-device Apple voices** (Ava/Zoe/Samantha/Allison/Moira/Karen/Tom/Daniel) — free, no API, instant playback.
- Voice picker now groups by provider with cost labels: \`OpenAI — \$15/M\`, \`Local (on-device) — Free\`, \`ElevenLabs — \$99/M\`.
- Default voice flips from ElevenLabs Sloane → **OpenAI Shimmer** (soft/sultry).
- All three tiers can be A/B-tested side by side in the same picker.

### Why

ElevenLabs at \$99-330 per 1M characters dominates Omi's TTS spend. OpenAI's \`gpt-4o-mini-tts\` is the obvious next step: same MP3 streaming contract, comparable latency, and pricing in a different universe. Apple's premium voices give a true \$0 fallback on macOS.

### Demo

```bash
OMI_APP_NAME=omi-tts-demo ./desktop/run.sh
```
Then Settings → Voice → pick any voice and hit the sample button. Each provider section is labelled with its per-million-character cost so the tradeoff is visible in the UI.

### Wire format

Adds an optional \`provider\` field to \`POST /v1/tts/synthesize\` (Rust) and \`POST /v2/tts/synthesize\` (Python). Omitted = ElevenLabs (backward compatible). \`provider="openai"\` routes to \`https://api.openai.com/v1/audio/speech\` with model \`gpt-4o-mini-tts\` (or \`tts-1\`/\`-hd\` if the client overrides \`model_id\`). Same MP3 audio response, same rate limits (50/min, 10k chars/day, 5k chars/request).

OpenAI voice IDs are whitelist-validated against the 11 official names (alloy/ash/ballad/coral/echo/fable/nova/onyx/sage/shimmer/verse) so the path-traversal guard ElevenLabs already had stays intact for the new path.

## Test plan
- [ ] Sign in on the \`omi-tts-demo\` bundle (Mac mini)
- [ ] Settings → Voice Questions → enable
- [ ] Voice picker shows three labelled sections: OpenAI / Local / ElevenLabs
- [ ] Default voice is OpenAI Shimmer
- [ ] Selecting Shimmer plays a sample via OpenAI (network round-trip)
- [ ] Selecting Ava plays a sample via the on-device synthesizer (no network)
- [ ] Selecting Sloane still plays via ElevenLabs (regression check)
- [ ] PTT / typed question → AI answer is spoken in the selected voice
- [ ] Switching providers mid-conversation doesn't crash or replay old audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)