### PR TITLE
chore: lower free-tier transcription cap from 1200 to 600 min/month

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -257,7 +257,7 @@ env:
         name: prod-omi-backend-secrets
         key: ENCRYPTION_SECRET
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
-    value: "1200"
+    value: "600"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -252,7 +252,7 @@ env:
         name: prod-omi-backend-secrets
         key: STT_SERVICE_MODELS
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
-    value: "1200"
+    value: "600"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH


### PR DESCRIPTION
## Summary
- Lower `BASIC_TIER_MINUTES_LIMIT_PER_MONTH` from `1200` to `600` in both prod helm chart values.
- Affects free (basic) plan users only — paid plans (Operator/Neo/Architect) are uncapped and BYOK users bypass the gate entirely.
- Both `backend-listen` and `pusher` must agree because backend-listen enforces the gate and pusher surfaces cap-related notifications.

## Files
- `backend/charts/backend-listen/prod_omi_backend_listen_values.yaml`
- `backend/charts/pusher/prod_omi_pusher_values.yaml`

## How the cap works
- Read by `backend/utils/subscription.py:234` → `BASIC_TIER_MONTHLY_SECONDS_LIMIT = minutes * 60` (now 36,000s vs prior 72,000s).
- Gate is `has_transcription_credits()` in `backend/utils/subscription.py:577` — once monthly transcription_seconds ≥ limit, free users start hitting the freemium freeze + fair-use graduated enforcement (warning → throttle → restrict).
- Monthly usage is counted from `SUBSCRIPTION_LAUNCH_DATE=2025-08-21` forward; current cycle resets monthly.
- Dev cluster value (`1000000`) is unchanged.

## Test plan
- [ ] After deploy, hit `/v1/users/me/usage-quota` as a free user and confirm `limit` now reflects 600 min equivalent.
- [ ] Verify a free user already over 600 min (but under 1200 min) for the current cycle is correctly transitioned into freemium / fair-use stage on next session.
- [ ] Confirm paid plans + BYOK users are unaffected (sanity check: `has_transcription_credits` returns True regardless of usage).
- [ ] Watch error rates and 402 chat-quota responses for a spike after rollout.

## Rollback
Revert this PR (single-line value flip in two files), redeploy via `gcp_backend.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)