### PR TITLE
desktop: add Ctrl as a Push-to-Talk preset

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -279,6 +279,7 @@ class ShortcutSettings: ObservableObject {
         KeyboardShortcut(modifierOnly: .option),
         KeyboardShortcut(modifierOnly: .command, requiresRightCommand: true),
         KeyboardShortcut(modifierOnly: .function),
+        KeyboardShortcut(modifierOnly: .control),
     ]
 
     @Published var pttShortcut: KeyboardShortcut {


### PR DESCRIPTION
## Summary

Appends `KeyboardShortcut(modifierOnly: .control)` to the shared `pttPresets` array in `ShortcutSettings.swift`. Both surfaces consume that array via `ForEach`:

- Onboarding shortcut step (`OnboardingVoiceShortcutStepView`)
- Settings → Shortcuts → Push to Talk (`ShortcutsSettingsSection`)

So the new `⌃` tile shows up in both pickers without any other code change. Display token and `legacyPTTShortcut` mapping route through the existing `modifierTokens` / `displayLabel` switch which already handles `.control`.

Verified visually in a named-bundle build — `⌃` renders as the 5th tile next to Option / Right ⌘ / fn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)