### PR TITLE
fix(desktop): wire up notification frequency setting + slider UI

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed notification frequency setting being ignored, and replaced the dropdown with a stepped slider in Settings"
+  ],
   "releases": [
     {
       "version": "0.11.387",

--- a/desktop/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/Desktop/Sources/MainWindow/CrispManager.swift
@@ -146,7 +146,8 @@ class CrispManager: ObservableObject {
                     NotificationService.shared.sendNotification(
                         title: "Help from Founder",
                         message: preview,
-                        assistantId: "crisp"
+                        assistantId: "crisp",
+                        respectFrequency: false
                     )
                 }
 

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -1350,21 +1350,7 @@ struct SettingsContentView: View {
             Divider()
               .background(OmiColors.backgroundQuaternary)
 
-            settingRow(
-              title: "Frequency", subtitle: "How often to receive notifications",
-              settingId: "notifications.frequency"
-            ) {
-              Picker("", selection: $notificationFrequency) {
-                ForEach(frequencyOptions, id: \.0) { option in
-                  Text(option.1).tag(option.0)
-                }
-              }
-              .pickerStyle(.menu)
-              .frame(width: 120)
-              .onChange(of: notificationFrequency) { _, newValue in
-                updateNotificationSettings(frequency: newValue)
-              }
-            }
+            notificationFrequencySlider(settingId: "notifications.frequency")
 
             settingRow(
               title: "Focus Notifications", subtitle: "Show notification on focus changes",
@@ -5503,6 +5489,102 @@ struct SettingsContentView: View {
     }
   }
 
+  /// Stepped slider for `notifications.frequency` matching the voice-speed slider
+  /// pattern. Six positions: Off / Minimal / Low / Balanced / High / Maximum.
+  /// Sits inside the existing Notifications card, so it does not wrap itself in
+  /// another `settingsCard` — it just applies the highlight modifier directly.
+  private func notificationFrequencySlider(settingId: String) -> some View {
+    let stepCount = frequencyOptions.count  // 6
+    let segmentCount = CGFloat(stepCount - 1)
+    let currentIndex = max(0, min(stepCount - 1, notificationFrequency))
+    let currentLabel = frequencyOptions[currentIndex].1
+
+    let body = VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .center) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Frequency")
+            .scaledFont(size: 14)
+            .foregroundColor(OmiColors.textSecondary)
+          Text("How often to receive notifications")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+        }
+        Spacer()
+        Text(currentLabel)
+          .scaledFont(size: 13, weight: .semibold)
+          .foregroundColor(OmiColors.purplePrimary)
+          .padding(.horizontal, 10)
+          .padding(.vertical, 4)
+          .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+              .fill(OmiColors.purplePrimary.opacity(0.15))
+          )
+      }
+
+      GeometryReader { geo in
+        let trackWidth = geo.size.width
+
+        ZStack(alignment: .leading) {
+          RoundedRectangle(cornerRadius: 4)
+            .fill(OmiColors.backgroundQuaternary)
+            .frame(height: 6)
+
+          RoundedRectangle(cornerRadius: 4)
+            .fill(OmiColors.purplePrimary)
+            .frame(width: trackWidth * CGFloat(currentIndex) / segmentCount, height: 6)
+
+          ForEach(0..<stepCount, id: \.self) { i in
+            Circle()
+              .fill(
+                i <= currentIndex ? OmiColors.purplePrimary : OmiColors.backgroundQuaternary
+              )
+              .frame(width: 8, height: 8)
+              .position(
+                x: trackWidth * CGFloat(i) / segmentCount,
+                y: 3
+              )
+          }
+
+          Circle()
+            .fill(Color.white)
+            .frame(width: 22, height: 22)
+            .shadow(color: .black.opacity(0.25), radius: 3, y: 1)
+            .position(
+              x: trackWidth * CGFloat(currentIndex) / segmentCount,
+              y: 3
+            )
+            .gesture(
+              DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                  let fraction = max(0, min(1, value.location.x / trackWidth))
+                  let nearestIndex = Int(round(fraction * segmentCount))
+                  let clamped = max(0, min(stepCount - 1, nearestIndex))
+                  if clamped != notificationFrequency {
+                    notificationFrequency = clamped
+                    updateNotificationSettings(frequency: clamped)
+                  }
+                }
+            )
+        }
+      }
+      .frame(height: 22)
+
+      HStack {
+        Text(frequencyOptions.first?.1 ?? "Off")
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+        Spacer()
+        Text(frequencyOptions.last?.1 ?? "Maximum")
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+      }
+    }
+
+    return body.modifier(
+      SettingHighlightModifier(
+        settingId: settingId, highlightedSettingId: $highlightedSettingId))
+  }
+
   private func tierPickerRow(tier: Int, label: String, subtitle: String) -> some View {
     let isSelected = currentTierLevel == tier
     return Button(action: {
@@ -6725,6 +6807,8 @@ struct SettingsContentView: View {
           dailySummaryHour = dailySummary.hour
           notificationsEnabled = notifications.enabled
           notificationFrequency = notifications.frequency
+          // Mirror to UserDefaults so NotificationService can throttle without a backend roundtrip.
+          UserDefaults.standard.set(notifications.frequency, forKey: NotificationService.frequencyDefaultsKey)
           userLanguage = language.language
           recordingPermissionEnabled = recording.enabled
           privateCloudSyncEnabled = cloudSync.enabled
@@ -7082,6 +7166,11 @@ struct SettingsContentView: View {
   }
 
   private func updateNotificationSettings(enabled: Bool? = nil, frequency: Int? = nil) {
+    if let frequency {
+      // Mirror locally so NotificationService picks up the new throttle level immediately,
+      // even before the backend round-trip completes.
+      UserDefaults.standard.set(frequency, forKey: NotificationService.frequencyDefaultsKey)
+    }
     Task {
       do {
         let _ = try await APIClient.shared.updateNotificationSettings(

--- a/desktop/Desktop/Sources/OnboardingNotificationStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingNotificationStepView.swift
@@ -131,7 +131,8 @@ struct OnboardingNotificationStepView: View {
                 NotificationService.shared.sendNotification(
                     title: insightHeadline,
                     message: insightText,
-                    assistantId: "onboarding"
+                    assistantId: "onboarding",
+                    respectFrequency: false
                 )
 
                 // Show "notification sent" + continue after a beat

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -1274,7 +1274,8 @@ public class ProactiveAssistantsPlugin: NSObject {
             NotificationService.shared.sendNotification(
                 title: "Screen Recording Permission Required",
                 message: "omi needs screen recording permission to continue monitoring. Please re-enable it in System Settings.",
-                deliverSystemBanner: true
+                deliverSystemBanner: true,
+                respectFrequency: false
             )
         }
     }
@@ -1582,7 +1583,8 @@ public class ProactiveAssistantsPlugin: NSObject {
             NotificationService.shared.sendNotification(
                 title: NotificationService.screenCaptureResetTitle,
                 message: "Screen recording permission needs to be re-enabled. Click to open Settings.",
-                deliverSystemBanner: true
+                deliverSystemBanner: true,
+                respectFrequency: false
             )
             return
         }
@@ -1596,7 +1598,8 @@ public class ProactiveAssistantsPlugin: NSObject {
         NotificationService.shared.sendNotification(
             title: NotificationService.screenCaptureResetTitle,
             message: "Screen recording permission needs to be re-enabled. Click to open Settings.",
-            deliverSystemBanner: true
+            deliverSystemBanner: true,
+            respectFrequency: false
         )
     }
 }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -70,12 +70,30 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     /// so a new breakage re-notifies exactly once.
     static let screenCaptureResetShownKey = "screenCaptureResetNotificationShown"
 
+    /// UserDefaults key mirroring the user's `notification_frequency` setting from the backend.
+    /// 0=Off, 1=Minimal, 2=Low, 3=Balanced (default), 4=High, 5=Maximum.
+    /// The Settings page writes this on load and on slider change; `sendNotification`
+    /// reads it synchronously to throttle proactive notifications.
+    static let frequencyDefaultsKey = "notification_frequency"
+
+    /// Default level used when the key has never been written (e.g. first run before
+    /// the Settings page has hydrated from the backend). Mirrors the backend default.
+    private static let defaultFrequencyLevel = 3
+
     /// Stores metadata for sent notifications so we can retrieve it in delegate callbacks
     /// Key: notification identifier, Value: (title, assistantId)
     private var notificationMetadata: [String: (title: String, assistantId: String)] = [:]
 
     /// Last time we triggered a notification repair (debounce to avoid hammering lsregister)
     private var lastRepairAttempt: Date?
+
+    /// Last proactive-notification timestamp per assistantId. Used by the frequency
+    /// throttle so one chatty assistant cannot starve another.
+    private var lastNotificationAt: [String: Date] = [:]
+
+    /// Last proactive-notification timestamp across all assistants. Used by the
+    /// frequency throttle as a global rate limit.
+    private var lastNotificationAtGlobal: Date?
 
     private override init() {
         super.init()
@@ -222,7 +240,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         sound: NotificationSound = .default,
         context: FloatingBarNotificationContext? = nil,
         screenshotData: Data? = nil,
-        deliverSystemBanner: Bool = false
+        deliverSystemBanner: Bool = false,
+        respectFrequency: Bool = true
     ) {
         // Rate-limit the screen-capture reset notification to one per broken-capture
         // episode. The recovery loop in ProactiveAssistantsPlugin.attemptAutoReset
@@ -241,6 +260,14 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         // macOS banner — the user opted into "no notifications for 2h".
         if FloatingControlBarManager.shared.isSnoozed {
             log("NotificationService: suppressing notification because floating bar is snoozed")
+            return
+        }
+
+        // Proactive notifications honor the user's frequency setting. Functional
+        // notifications (Crisp support replies, screen-recording permission prompts,
+        // onboarding test) pass `respectFrequency: false` to bypass the gate.
+        if respectFrequency && !shouldAllowProactiveNotification(assistantId: assistantId) {
+            log("NotificationService: throttled \(assistantId) notification (frequency=\(Self.currentFrequencyLevel()))")
             return
         }
 
@@ -334,6 +361,55 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
                 }
             }
         }
+    }
+
+    // MARK: - Frequency throttle
+
+    /// Current frequency level from UserDefaults, clamped to [0, 5]. Falls back to
+    /// `defaultFrequencyLevel` when the key is absent (first run before sync).
+    static func currentFrequencyLevel() -> Int {
+        guard UserDefaults.standard.object(forKey: Self.frequencyDefaultsKey) != nil else {
+            return Self.defaultFrequencyLevel
+        }
+        let raw = UserDefaults.standard.integer(forKey: Self.frequencyDefaultsKey)
+        return max(0, min(5, raw))
+    }
+
+    /// Minimum interval between proactive notifications for a given level.
+    /// `nil` means no throttle (Maximum); `.infinity` means drop everything (Off).
+    private static func minInterval(forLevel level: Int) -> TimeInterval? {
+        switch level {
+        case 0: return .infinity   // Off
+        case 1: return 60 * 60     // Minimal:  1 per hour
+        case 2: return 30 * 60     // Low:      1 per 30 min
+        case 3: return 10 * 60     // Balanced: 1 per 10 min
+        case 4: return 3 * 60      // High:     1 per 3 min
+        default: return nil        // Maximum:  no throttle
+        }
+    }
+
+    /// Decide whether a proactive notification from `assistantId` should be delivered.
+    /// Records the timestamp when allowed so subsequent calls within the window are
+    /// suppressed. Per-assistant + global limits combine so a chatty assistant cannot
+    /// starve another.
+    private func shouldAllowProactiveNotification(assistantId: String) -> Bool {
+        let level = Self.currentFrequencyLevel()
+        guard let interval = Self.minInterval(forLevel: level) else {
+            return true  // Maximum
+        }
+        if interval == .infinity {
+            return false  // Off
+        }
+        let now = Date()
+        if let last = lastNotificationAtGlobal, now.timeIntervalSince(last) < interval {
+            return false
+        }
+        if let last = lastNotificationAt[assistantId], now.timeIntervalSince(last) < interval {
+            return false
+        }
+        lastNotificationAt[assistantId] = now
+        lastNotificationAtGlobal = now
+        return true
     }
 }
 // Updated Gemini API key in Codemagic secret — triggering release


### PR DESCRIPTION
## Summary

The notification frequency setting in Settings (Off / Minimal / Low / Balanced / High / Maximum) was being persisted to the backend but never read by the Swift app — `NotificationService.sendNotification` had no throttle gate, so every proactive trigger went straight to the user regardless of what they picked. Default felt like Max because nothing was filtering.

- Add a per-assistant + global throttle in `NotificationService`, keyed on a `notification_frequency` UserDefaults mirror. Intervals: Off (drop), Minimal (1/hr), Low (1/30m), Balanced (1/10m), High (1/3m), Maximum (no throttle).
- Mirror the value to UserDefaults in `SettingsPage` on load and on slider change so the consumer reads it synchronously without a backend round-trip.
- Replace the dropdown picker with a stepped slider matching the voice-speed pattern (draggable thumb, dot indicators, "Off" / "Maximum" end labels, purple chip showing the active level).
- Functional notifications (Crisp support replies, onboarding test, screen-recording permission prompts) bypass the throttle via a new `respectFrequency: false` parameter — they're not subject to the user's proactive-notification budget.

## Test plan

- [ ] Build named bundle (`OMI_APP_NAME="omi-notif-throttle" ./run.sh`)
- [ ] Open Settings → Notifications, drag the slider through all six positions
- [ ] Confirm chip label updates and value persists across app restart
- [ ] Trigger several proactive notifications in quick succession at "Low" and verify only one fires per 30-minute window
- [ ] Set "Off" — confirm proactive notifications drop, but onboarding test and Crisp replies still surface
- [ ] Set "Maximum" — confirm no throttling

🤖 Generated with [Claude Code](https://claude.com/claude-code)