### PR TITLE
Proxy OpenAI desktop TTS through backend

### DIFF
--- a/desktop/Backend-Rust/.env.example
+++ b/desktop/Backend-Rust/.env.example
@@ -22,6 +22,7 @@ FIREBASE_API_KEY=
 
 # ─── AI ──────────────────────────────────────────────────────────────
 GEMINI_API_KEY=
+OPENAI_API_KEY=
 
 # ─── Encryption ──────────────────────────────────────────────────────
 # Used to decrypt user data with enhanced protection level

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -10,6 +10,8 @@ pub struct Config {
     pub port: u16,
     /// Gemini API key for LLM calls
     pub gemini_api_key: Option<String>,
+    /// OpenAI API key for server-side TTS proxy calls
+    pub openai_api_key: Option<String>,
     /// Firebase project ID (used for Firestore)
     pub firebase_project_id: Option<String>,
     /// Firebase project ID for auth token validation (defaults to firebase_project_id)
@@ -92,6 +94,7 @@ impl Config {
                     10201
                 }),
             gemini_api_key: env::var("GEMINI_API_KEY").ok(),
+            openai_api_key: env::var("OPENAI_API_KEY").ok(),
             firebase_project_id: env::var("FIREBASE_PROJECT_ID").ok()
                 .or_else(|| env::var("GCP_PROJECT_ID").ok()),
             firebase_auth_project_id: env::var("FIREBASE_AUTH_PROJECT_ID").ok(),

--- a/desktop/Backend-Rust/src/main.rs
+++ b/desktop/Backend-Rust/src/main.rs
@@ -36,7 +36,7 @@ use config::Config;
 use routes::{
     // Active (real traffic from current app)
     agent_routes, auth_routes, chat_completions_routes, config_routes, crisp_routes,
-    health_routes, proxy_routes, screen_activity_routes, updates_routes, webhook_routes,
+    health_routes, proxy_routes, screen_activity_routes, tts_routes, updates_routes, webhook_routes,
     // Deprecated stubs (return 410 Gone — current app uses Python for all data CRUD)
     deprecated_routes,
 };
@@ -257,6 +257,7 @@ async fn main() {
         .merge(crisp_routes())
         .merge(proxy_routes())
         .merge(screen_activity_routes())
+        .merge(tts_routes())
         .merge(chat_completions_routes())
         .merge(updates_routes())
         .merge(webhook_routes())

--- a/desktop/Backend-Rust/src/routes/mod.rs
+++ b/desktop/Backend-Rust/src/routes/mod.rs
@@ -10,6 +10,7 @@ pub mod health;
 pub mod proxy;
 pub mod rate_limit;
 pub mod screen_activity;
+pub mod tts;
 pub mod updates;
 pub mod webhooks;
 
@@ -28,5 +29,6 @@ pub use deprecated::deprecated_routes;
 pub use health::health_routes;
 pub use proxy::proxy_routes;
 pub use screen_activity::screen_activity_routes;
+pub use tts::tts_routes;
 pub use updates::updates_routes;
 pub use webhooks::webhook_routes;

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -1,0 +1,266 @@
+// OpenAI TTS proxy route.
+// Clients authenticate with Firebase and never need a bundled OpenAI key.
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::AuthUser;
+use crate::AppState;
+
+const OPENAI_TTS_MODEL_ID: &str = "gpt-4o-mini-tts";
+const OPENAI_SPEECH_URL: &str = "https://api.openai.com/v1/audio/speech";
+const MAX_TTS_CHARS: usize = 4096;
+const SERVER_TTS_BURST_PER_MINUTE: i64 = 20;
+const SERVER_TTS_DAILY_CHARS: i64 = 50_000;
+const TTS_BURST_WINDOW_SECS: u64 = 60;
+
+#[derive(Debug, Deserialize)]
+struct TtsSynthesizeRequest {
+    text: String,
+    voice_id: String,
+    #[serde(default)]
+    instructions: Option<String>,
+}
+
+#[derive(Serialize)]
+struct OpenAISpeechRequest<'a> {
+    model: &'a str,
+    input: &'a str,
+    voice: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instructions: Option<&'a str>,
+    response_format: &'a str,
+}
+
+enum TtsProxyError {
+    BadRequest(&'static str),
+    MissingApiKey,
+    RateLimited(&'static str),
+    RateLimitUnavailable,
+    Upstream(StatusCode, String),
+    BadGateway(String),
+}
+
+impl IntoResponse for TtsProxyError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            TtsProxyError::BadRequest(message) => (StatusCode::BAD_REQUEST, message.to_string()),
+            TtsProxyError::MissingApiKey => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "OpenAI TTS is not configured".to_string(),
+            ),
+            TtsProxyError::RateLimited(message) => {
+                (StatusCode::TOO_MANY_REQUESTS, message.to_string())
+            }
+            TtsProxyError::RateLimitUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "TTS rate limiting is unavailable".to_string(),
+            ),
+            TtsProxyError::Upstream(status, body) => {
+                let safe_body = if body.chars().count() > 500 {
+                    format!("{}...", body.chars().take(500).collect::<String>())
+                } else {
+                    body
+                };
+                (status, format!("OpenAI TTS request failed: {}", safe_body))
+            }
+            TtsProxyError::BadGateway(message) => (StatusCode::BAD_GATEWAY, message),
+        };
+
+        (
+            status,
+            Json(serde_json::json!({
+                "error": message,
+            })),
+        )
+            .into_response()
+    }
+}
+
+async fn tts_synthesize(
+    State(state): State<AppState>,
+    user: AuthUser,
+    headers: HeaderMap,
+    Json(request): Json<TtsSynthesizeRequest>,
+) -> Result<Response, TtsProxyError> {
+    let text = request.text.trim();
+    if text.is_empty() {
+        return Err(TtsProxyError::BadRequest("text is required"));
+    }
+    let char_count = text.chars().count();
+    if char_count > MAX_TTS_CHARS {
+        return Err(TtsProxyError::BadRequest("text is too long"));
+    }
+
+    let voice_id = request.voice_id.trim();
+    if !is_allowed_openai_voice(voice_id) {
+        return Err(TtsProxyError::BadRequest("voice_id is not supported"));
+    }
+
+    let instructions = request
+        .instructions
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let (api_key, uses_server_key) = openai_key_for_request(&state, &headers)?;
+    if uses_server_key {
+        check_server_tts_rate_limit(&state, &user.uid, char_count).await?;
+    }
+
+    let payload = OpenAISpeechRequest {
+        model: OPENAI_TTS_MODEL_ID,
+        input: text,
+        voice: voice_id,
+        instructions,
+        response_format: "mp3",
+    };
+
+    let upstream = reqwest::Client::new()
+        .post(OPENAI_SPEECH_URL)
+        .bearer_auth(api_key)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|error| TtsProxyError::BadGateway(error.to_string()))?;
+
+    let status =
+        StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let bytes = upstream
+        .bytes()
+        .await
+        .map_err(|error| TtsProxyError::BadGateway(error.to_string()))?;
+
+    if !status.is_success() {
+        let body = String::from_utf8_lossy(&bytes).to_string();
+        tracing::warn!(
+            "tts_synthesize: OpenAI returned {} for uid={}: {}",
+            status,
+            user.uid,
+            body
+        );
+        return Err(TtsProxyError::Upstream(status, body));
+    }
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "audio/mpeg")
+        .body(Body::from(bytes))
+        .unwrap())
+}
+
+fn openai_key_for_request<'a>(
+    state: &'a AppState,
+    headers: &'a HeaderMap,
+) -> Result<(&'a str, bool), TtsProxyError> {
+    if let Some(value) = headers
+        .get("x-byok-openai")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Ok((value, false));
+    }
+
+    let key = state
+        .config
+        .openai_api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or(TtsProxyError::MissingApiKey)?;
+
+    Ok((key, true))
+}
+
+async fn check_server_tts_rate_limit(
+    state: &AppState,
+    uid: &str,
+    char_count: usize,
+) -> Result<(), TtsProxyError> {
+    let redis = state.redis.as_ref().ok_or_else(|| {
+        tracing::error!(
+            "tts_synthesize: Redis is not configured; refusing unmetered server-key TTS"
+        );
+        TtsProxyError::RateLimitUnavailable
+    })?;
+
+    let (daily_chars, burst_count) = redis
+        .check_tts_rate_limit(uid, char_count, TTS_BURST_WINDOW_SECS)
+        .await
+        .map_err(|error| {
+            tracing::error!(
+                "tts_synthesize: Redis rate-limit error for uid={}: {}",
+                uid,
+                error
+            );
+            TtsProxyError::RateLimitUnavailable
+        })?;
+
+    if burst_count > SERVER_TTS_BURST_PER_MINUTE {
+        tracing::warn!("tts_synthesize: burst rate limit exceeded uid={}", uid);
+        return Err(TtsProxyError::RateLimited("TTS burst rate limit exceeded"));
+    }
+    if daily_chars > SERVER_TTS_DAILY_CHARS {
+        tracing::warn!("tts_synthesize: daily character limit exceeded uid={}", uid);
+        return Err(TtsProxyError::RateLimited(
+            "TTS daily character limit exceeded",
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_allowed_openai_voice(voice_id: &str) -> bool {
+    matches!(
+        voice_id,
+        "alloy"
+            | "ash"
+            | "ballad"
+            | "coral"
+            | "echo"
+            | "fable"
+            | "nova"
+            | "onyx"
+            | "sage"
+            | "shimmer"
+            | "verse"
+            | "marin"
+            | "cedar"
+    )
+}
+
+pub fn tts_routes() -> Router<AppState> {
+    Router::new().route("/v1/tts/synthesize", post(tts_synthesize))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_supported_openai_voices() {
+        for voice in ["onyx", "shimmer", "coral", "nova", "marin", "cedar"] {
+            assert!(is_allowed_openai_voice(voice));
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_voice_ids() {
+        for voice in ["", "BAMYoBHLZM7lJgJAmFz0", "onyx/", "OpenAI"] {
+            assert!(!is_allowed_openai_voice(voice));
+        }
+    }
+
+    #[test]
+    fn request_character_limit_matches_openai_limit() {
+        assert_eq!(MAX_TTS_CHARS, 4096);
+    }
+}

--- a/desktop/Backend-Rust/src/services/redis.rs
+++ b/desktop/Backend-Rust/src/services/redis.rs
@@ -274,6 +274,59 @@ return {daily, burst}
         Ok((daily_count, burst_count))
     }
 
+    /// Check and record an OpenAI TTS request for rate limiting.
+    /// Uses a Lua script for atomic burst (sorted set) + daily character counter.
+    /// Returns (daily_chars, burst_count) so the caller can decide Allow/Reject.
+    pub async fn check_tts_rate_limit(
+        &self,
+        uid: &str,
+        chars: usize,
+        burst_window_secs: u64,
+    ) -> Result<(i64, i64), redis::RedisError> {
+        let mut conn = self.get_connection().await?;
+
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let day_ordinal = (now_ms / 86_400_000).to_string();
+        let cutoff_ms = now_ms - (burst_window_secs as i64 * 1000);
+
+        let burst_key = format!("tts_rl:{}:burst", uid);
+        let daily_chars_key = format!("tts_rl:{}:chars:{}", uid, day_ordinal);
+
+        // KEYS[1] = burst_key, KEYS[2] = daily_chars_key
+        // ARGV[1] = cutoff_ms, ARGV[2] = now_ms, ARGV[3] = burst_ttl,
+        // ARGV[4] = daily_ttl, ARGV[5] = character count
+        let script = r#"
+local chars = redis.call('INCRBY', KEYS[2], ARGV[5])
+redis.call('EXPIRE', KEYS[2], ARGV[4])
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[2] .. ':' .. tostring(chars))
+local burst = redis.call('ZCARD', KEYS[1])
+redis.call('EXPIRE', KEYS[1], ARGV[3])
+return {chars, burst}
+"#;
+
+        let burst_ttl = (burst_window_secs * 2) as i64;
+        let daily_ttl: i64 = 172_800;
+
+        let result: Vec<i64> = redis::cmd("EVAL")
+            .arg(script)
+            .arg(2)
+            .arg(&burst_key)
+            .arg(&daily_chars_key)
+            .arg(cutoff_ms)
+            .arg(now_ms)
+            .arg(burst_ttl)
+            .arg(daily_ttl)
+            .arg(chars as i64)
+            .query_async(&mut conn)
+            .await?;
+
+        let daily_chars = result.first().copied().unwrap_or(0);
+        let burst_count = result.get(1).copied().unwrap_or(0);
+
+        Ok((daily_chars, burst_count))
+    }
+
     // ============================================================================
     // APP INSTALLS - matches Python backend redis_db.py
     // ============================================================================

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -4620,6 +4620,62 @@ extension APIClient {
     return try await get("v1/config/api-keys", customBaseURL: rustBackendURL)
   }
 
+  struct TtsSynthesizeRequest: Encodable {
+    let text: String
+    let voiceId: String
+    let instructions: String?
+
+    enum CodingKeys: String, CodingKey {
+      case text
+      case voiceId = "voice_id"
+      case instructions
+    }
+  }
+
+  func synthesizeSpeech(request body: TtsSynthesizeRequest) async throws -> Data {
+    let base = rustBackendURL
+    guard !base.isEmpty, let url = URL(string: base + "v1/tts/synthesize") else {
+      throw APIError.invalidResponse
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.timeoutInterval = 60
+    request.allHTTPHeaderFields = try await buildHeaders()
+    request.httpBody = try JSONEncoder().encode(body)
+
+    let (data, response) = try await session.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+
+    if httpResponse.statusCode == 401 {
+      let authService = await MainActor.run { AuthService.shared }
+      _ = try await authService.getIdToken(forceRefresh: true)
+
+      var retryRequest = request
+      retryRequest.setValue(
+        try await authService.getAuthHeader(), forHTTPHeaderField: "Authorization")
+
+      let (retryData, retryResponse) = try await session.data(for: retryRequest)
+      guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
+        throw APIError.invalidResponse
+      }
+      guard retryHttpResponse.statusCode != 401 else {
+        throw APIError.unauthorized
+      }
+      guard (200...299).contains(retryHttpResponse.statusCode) else {
+        throw APIError.httpError(statusCode: retryHttpResponse.statusCode)
+      }
+      return retryData
+    }
+
+    guard (200...299).contains(httpResponse.statusCode) else {
+      throw APIError.httpError(statusCode: httpResponse.statusCode)
+    }
+
+    return data
+  }
+
   // MARK: - Platform Tools (backend RAG)
 
   struct ToolResponse: Decodable {

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -5,7 +5,6 @@ import Foundation
 final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   static let shared = FloatingBarVoicePlaybackService()
 
-  nonisolated private static let openAITTSModelID = "gpt-4o-mini-tts"
   // First chunk stays small so playback starts fast.
   nonisolated private static let firstChunkMinimumLength = 40
   nonisolated private static let firstChunkPreferredLength = 120
@@ -150,10 +149,6 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     let selectedVoice = ShortcutSettings.voiceOption(for: ShortcutSettings.shared.selectedVoiceID)
 
     if selectedVoice.isOpenAI, let openAIVoice = selectedVoice.openAIVoice {
-      guard Self.openAIAPIKey() != nil else {
-        log("FloatingBarVoicePlaybackService: OpenAI TTS selected but no OpenAI BYOK key is configured")
-        return .systemVoice(ShortcutSettings.voiceOption(for: ShortcutSettings.localShelleyVoiceID))
-      }
       return .openAI(
         voiceID: openAIVoice,
         instructions: selectedVoice.openAIInstructions ?? ""
@@ -432,55 +427,21 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
       ?? AVSpeechSynthesisVoice(language: "en-US")
   }
 
-  /// Synthesize speech directly through the user's OpenAI BYOK key.
+  /// Synthesize speech through the desktop backend's OpenAI TTS proxy.
+  /// APIClient attaches a user BYOK key when one is configured; otherwise the
+  /// backend uses its server-side key.
   private nonisolated static func synthesizeOpenAISpeech(
     text: String,
     voiceID: String,
     instructions: String
   ) async throws -> Data {
-    guard let apiKey = openAIAPIKey() else {
-      throw FloatingBarVoicePlaybackError.missingAPIKey("OpenAI")
-    }
-
-    let url = URL(string: "https://api.openai.com/v1/audio/speech")!
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.timeoutInterval = 60
-    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-    request.httpBody = try JSONEncoder().encode(
-      OpenAISpeechRequest(
-        model: openAITTSModelID,
-        input: text,
-        voice: voiceID,
-        instructions: instructions.isEmpty ? nil : instructions,
-        responseFormat: "mp3"
+    try await APIClient.shared.synthesizeSpeech(
+      request: APIClient.TtsSynthesizeRequest(
+        text: text,
+        voiceId: voiceID,
+        instructions: instructions.isEmpty ? nil : instructions
       )
     )
-
-    let (data, response) = try await URLSession.shared.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw FloatingBarVoicePlaybackError.invalidResponse
-    }
-    guard (200..<300).contains(httpResponse.statusCode) else {
-      let body = String(data: data, encoding: .utf8) ?? ""
-      throw FloatingBarVoicePlaybackError.requestFailed(statusCode: httpResponse.statusCode, body: body)
-    }
-    return data
-  }
-
-  private nonisolated static func openAIAPIKey() -> String? {
-    if let key = APIKeyService.byokKey(.openai) {
-      return key
-    }
-    if let key = ProcessInfo.processInfo.environment["OPENAI_API_KEY"]?
-      .trimmingCharacters(in: .whitespacesAndNewlines),
-      !key.isEmpty
-    {
-      return key
-    }
-    return nil
   }
 
   private nonisolated static func cleanedPlaybackText(from message: ChatMessage?) -> String {
@@ -588,37 +549,4 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 private enum PlaybackMode: Sendable {
   case openAI(voiceID: String, instructions: String)
   case systemVoice(ShortcutSettings.VoiceOption)
-}
-
-private struct OpenAISpeechRequest: Encodable {
-  let model: String
-  let input: String
-  let voice: String
-  let instructions: String?
-  let responseFormat: String
-
-  enum CodingKeys: String, CodingKey {
-    case model
-    case input
-    case voice
-    case instructions
-    case responseFormat = "response_format"
-  }
-}
-
-private enum FloatingBarVoicePlaybackError: LocalizedError {
-  case invalidResponse
-  case missingAPIKey(String)
-  case requestFailed(statusCode: Int, body: String)
-
-  var errorDescription: String? {
-    switch self {
-    case .invalidResponse:
-      return "Invalid TTS response"
-    case .missingAPIKey(let provider):
-      return "\(provider) API key is not configured"
-    case .requestFailed(let statusCode, let body):
-      return "TTS request failed (\(statusCode)): \(body)"
-  }
-}
 }

--- a/desktop/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/Desktop/Tests/APIClientRoutingTests.swift
@@ -399,6 +399,27 @@ final class APIClientRoutingTests: XCTestCase {
                      label: "fetchApiKeys")
     }
 
+    func testSynthesizeSpeechRoutesToRust() async {
+        let client = await makeTestClient()
+        _ = try? await client.synthesizeSpeech(
+            request: APIClient.TtsSynthesizeRequest(
+                text: "Hello",
+                voiceId: "onyx",
+                instructions: "Speak naturally"
+            )
+        )
+
+        let requests = URLCapture.capturedRequests
+        assertRoutes(requests, host: "rust-test", port: 9002,
+                     pathContains: "v1/tts/synthesize", method: "POST",
+                     label: "synthesizeSpeech")
+
+        let body = requests.first?.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        XCTAssertEqual(body?["text"] as? String, "Hello")
+        XCTAssertEqual(body?["voice_id"] as? String, "onyx")
+        XCTAssertEqual(body?["instructions"] as? String, "Speak naturally")
+    }
+
     // -- Assistant settings (GET → Python, migrated from Rust) --
 
     func testGetAssistantSettingsRoutesToPython() async {


### PR DESCRIPTION
## Summary
- fix production beta OpenAI voice playback by routing desktop TTS through the Rust desktop backend instead of requiring a local OpenAI key
- add an authenticated OpenAI /v1/tts/synthesize backend proxy using gpt-4o-mini-tts
- keep BYOK support by forwarding X-BYOK-OpenAI when users have their own key, otherwise use the backend server key
- add server-key TTS rate limiting and routing tests

## Verification
- Mac mini: rustfmt --edition 2021 --check src/routes/tts.rs
- Mac mini: cargo check in desktop/Backend-Rust
- Mac mini: PATH workaround + bash desktop/test.sh passed: Rust 190 tests, Swift 257 tests
- Local: git diff --check

## Notes
- This intentionally does not reintroduce ElevenLabs. The backend route uses OpenAI TTS only.
- Official OpenAI docs confirm gpt-4o-mini-tts, voice, instructions, and response_format on /v1/audio/speech.