### PR TITLE
Pass OpenAI key to desktop backend deploy

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -74,6 +74,7 @@ jobs:
             AGENT_GCS_BUCKET=based-hardware-agent
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
+            OPENAI_API_KEY=OPENAI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             REDIS_DB_PASSWORD=REDIS_DB_PASSWORD:latest
             FIREBASE_API_KEY=FIREBASE_API_KEY:latest
@@ -141,6 +142,7 @@ jobs:
           secrets: |
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             GEMINI_API_KEY=DESKTOP_GEMINI_API_KEY:latest
+            OPENAI_API_KEY=OPENAI_API_KEY:latest
             REDIS_DB_PASSWORD=DESKTOP_REDIS_DB_PASSWORD:latest
             FIREBASE_API_KEY=DESKTOP_FIREBASE_API_KEY:latest
             REDIS_DB_HOST=DESKTOP_REDIS_DB_HOST:latest

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -63,6 +63,7 @@ jobs:
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
+            OPENAI_API_KEY=OPENAI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             REDIS_DB_PASSWORD=REDIS_DB_PASSWORD:latest
             FIREBASE_API_KEY=FIREBASE_API_KEY:latest


### PR DESCRIPTION
## Summary
- pass OPENAI_API_KEY into the desktop backend Cloud Run deploys
- covers both standalone dev backend deploy and desktop auto-release dev/prod backend deploy jobs

## Verification
- Local: git diff --check

## Context
The OpenAI TTS proxy merged in PR #7264 needs OPENAI_API_KEY at runtime. Without this workflow env mapping, production beta would still fall back to system speech because the backend route would be unconfigured.