### PR TITLE
fix(desktop): respect auto-detect language in PTT batch transcription

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed push-to-talk ignoring auto-detect language setting, causing non-English (e.g. Russian) speech to be force-transcribed as English"
+  ],
   "releases": [
     {
       "version": "0.11.391",

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -359,7 +359,7 @@ class PushToTalkManager: ObservableObject {
       Task {
         do {
           await self.contextCaptureTask?.value
-          let language = self.pttBatchTranscriptionLanguage()
+          let language = AssistantSettings.shared.effectiveTranscriptionLanguage
           let audioSeconds = Double(audioData.count) / (16000.0 * 2.0)
           log("PushToTalkManager: batch audio \(audioData.count) bytes (\(String(format: "%.1f", audioSeconds))s), pttLanguage=\(language), selectedLanguage=\(AssistantSettings.shared.transcriptionLanguage), autoDetect=\(AssistantSettings.shared.transcriptionAutoDetect)")
 
@@ -369,7 +369,7 @@ class PushToTalkManager: ObservableObject {
             contextKeywords: self.currentContextSnapshot?.keywords ?? []
           )
 
-          if (transcript == nil || transcript?.isEmpty == true) && language != "en" && audioSeconds < 5.0 {
+          if (transcript == nil || transcript?.isEmpty == true) && language != "en" && language != "multi" && audioSeconds < 5.0 {
             log("PushToTalkManager: selected language returned empty on short audio, retrying with 'en'")
             transcript = try await TranscriptionService.batchTranscribe(
               audioData: audioData,
@@ -408,15 +408,6 @@ class PushToTalkManager: ObservableObject {
       liveFinalizationTimeout = timeout
       DispatchQueue.main.asyncAfter(deadline: .now() + 3.0, execute: timeout)
     }
-  }
-
-  private func pttBatchTranscriptionLanguage() -> String {
-    let selected = AssistantSettings.shared.transcriptionLanguage
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    if selected.isEmpty || selected == "multi" || selected == "auto" {
-      return "en"
-    }
-    return selected
   }
 
   private func sendTranscript() {


### PR DESCRIPTION
## Summary
- PTT batch mode was reading `transcriptionLanguage` directly and ignoring `transcriptionAutoDetect`
- Users with auto-detect on + stored language "en" had Russian (and any other non-English) PTT speech force-transcribed as English
- Switch batch mode to `effectiveTranscriptionLanguage`, the same source live (streaming) PTT already uses
- Skip the en-fallback retry when language is "multi" since multi already covers all supported languages

## Test plan
- [x] Compile-clean (`xcrun swift build -c debug`)
- [x] Local launch via `OMI_APP_NAME="omi-ptt-ru" ./run.sh --yolo`
- [ ] PTT a Russian phrase, confirm `pttLanguage=multi` in `/private/tmp/omi-ptt-ru*.log` and a correct Russian transcript lands in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)