### PR TITLE
Remove local desktop TTS voice options

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -74,6 +74,7 @@ jobs:
             AGENT_GCS_BUCKET=based-hardware-agent
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
+            OPENAI_API_KEY=OPENAI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             REDIS_DB_PASSWORD=REDIS_DB_PASSWORD:latest
             FIREBASE_API_KEY=FIREBASE_API_KEY:latest
@@ -141,6 +142,7 @@ jobs:
           secrets: |
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             GEMINI_API_KEY=DESKTOP_GEMINI_API_KEY:latest
+            OPENAI_API_KEY=OPENAI_API_KEY:latest
             REDIS_DB_PASSWORD=DESKTOP_REDIS_DB_PASSWORD:latest
             FIREBASE_API_KEY=DESKTOP_FIREBASE_API_KEY:latest
             REDIS_DB_HOST=DESKTOP_REDIS_DB_HOST:latest

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -63,6 +63,7 @@ jobs:
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
+            OPENAI_API_KEY=OPENAI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             REDIS_DB_PASSWORD=REDIS_DB_PASSWORD:latest
             FIREBASE_API_KEY=FIREBASE_API_KEY:latest

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -68,8 +68,8 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
     guard let mode = currentMode else { return }
     switch mode {
-    case .systemVoice(let voice):
-      enqueueSystemSpeech(phrase, voice: voice)
+    case .systemVoice:
+      enqueueSystemSpeech(phrase)
     case .openAI(let voiceID, let instructions):
       fillerTask = Task { [weak self] in
         do {
@@ -174,8 +174,8 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
   private func enqueueChunk(_ text: String, mode: PlaybackMode) {
     switch mode {
-    case .systemVoice(let voice):
-      enqueueSystemSpeech(text, voice: voice)
+    case .systemVoice:
+      enqueueSystemSpeech(text)
     case .openAI:
       synthesisQueue.append(text)
       startSynthesisIfNeeded(mode: mode)
@@ -226,11 +226,10 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
         await MainActor.run {
           guard let self else { return }
           self.isSynthesizing = false
-          log(
-            "FloatingBarVoicePlaybackService: cloud TTS chunk synthesis failed, falling back to system voice: \(error.localizedDescription)"
-          )
-          self.enqueueSystemSpeech(
-            text, voice: ShortcutSettings.voiceOption(for: ShortcutSettings.localShelleyVoiceID))
+        log(
+          "FloatingBarVoicePlaybackService: cloud TTS chunk synthesis failed, falling back to system voice: \(error.localizedDescription)"
+        )
+          self.enqueueSystemSpeech(text)
           self.startSynthesisIfNeeded(mode: mode)
         }
       }
@@ -256,7 +255,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     let voice = ShortcutSettings.voiceOption(for: voiceID)
 
     if voice.isLocalSystem {
-      enqueueSystemSpeech(phrase, voice: voice)
+      enqueueSystemSpeech(phrase)
       return
     }
 
@@ -282,8 +281,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
       return
     }
 
-    enqueueSystemSpeech(
-      phrase, voice: ShortcutSettings.voiceOption(for: ShortcutSettings.localShelleyVoiceID))
+    enqueueSystemSpeech(phrase)
   }
 
   /// Synthesize and play a single short phrase via the selected voice. Used by
@@ -304,14 +302,12 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
           }
         } catch {
           await MainActor.run {
-            self?.enqueueSystemSpeech(
-              trimmed,
-              voice: ShortcutSettings.voiceOption(for: ShortcutSettings.localShelleyVoiceID))
+            self?.enqueueSystemSpeech(trimmed)
           }
         }
       }
-    case .systemVoice(let voice):
-      enqueueSystemSpeech(trimmed, voice: voice)
+    case .systemVoice:
+      enqueueSystemSpeech(trimmed)
     }
   }
 
@@ -347,33 +343,13 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     }
   }
 
-  private func enqueueSystemSpeech(_ text: String, voice: ShortcutSettings.VoiceOption) {
+  private func enqueueSystemSpeech(_ text: String) {
     let utterance = AVSpeechUtterance(string: text)
-    utterance.rate = localSpeechRate()
-    utterance.pitchMultiplier = localPitchMultiplier(for: voice)
+    utterance.rate = 0.47
+    utterance.pitchMultiplier = 1.02
     utterance.volume = 1.0
-    utterance.voice = preferredSystemVoice(for: voice)
+    utterance.voice = preferredSystemVoice()
     speechSynthesizer.speak(utterance)
-  }
-
-  private func localSpeechRate() -> Float {
-    let baseRate: Float = 0.42
-    let scaledRate = baseRate * (playbackRate / 1.4)
-    return min(
-      AVSpeechUtteranceMaximumSpeechRate,
-      max(AVSpeechUtteranceMinimumSpeechRate, scaledRate)
-    )
-  }
-
-  private func localPitchMultiplier(for voice: ShortcutSettings.VoiceOption) -> Float {
-    switch voice.id {
-    case ShortcutSettings.localShelleyVoiceID:
-      return 0.82
-    case "local:deep":
-      return 0.88
-    default:
-      return 1.02
-    }
   }
 
   nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
@@ -404,27 +380,17 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     speechSynthesizer.stopSpeaking(at: .immediate)
   }
 
-  private func preferredSystemVoice(for option: ShortcutSettings.VoiceOption) -> AVSpeechSynthesisVoice? {
+  private func preferredSystemVoice() -> AVSpeechSynthesisVoice? {
     let voices = AVSpeechSynthesisVoice.speechVoices()
-    for identifier in option.preferredSystemVoiceIdentifiers {
-      if let voice = AVSpeechSynthesisVoice(identifier: identifier) {
-        return voice
-      }
-    }
-    for name in option.preferredSystemVoiceNames {
+    let preferredNames = ["Ava", "Allison", "Samantha", "Karen", "Moira"]
+    for name in preferredNames {
       if let voice = voices.first(where: {
-        $0.language == "en-US" && $0.name.localizedCaseInsensitiveContains(name)
-      }) {
-        return voice
-      }
-      if let voice = voices.first(where: {
-        $0.language.hasPrefix("en") && $0.name.localizedCaseInsensitiveContains(name)
+        $0.name.localizedCaseInsensitiveContains(name)
       }) {
         return voice
       }
     }
-    return voices.first(where: { $0.language == "en-US" })
-      ?? AVSpeechSynthesisVoice(language: "en-US")
+    return AVSpeechSynthesisVoice(language: "en-US")
   }
 
   /// Synthesize speech through the desktop backend's OpenAI TTS proxy.

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -425,9 +425,8 @@ class ShortcutSettings: ObservableObject {
 
     static let openAIShimmerVoiceID = "openai:shimmer"
     static let openAIOnyxVoiceID = "openai:onyx"
-    static let localShelleyVoiceID = "local:shelley"
 
-    /// Curated OpenAI and local voices available from the voice picker.
+    /// Curated OpenAI voices available from the voice picker.
     static let availableVoices: [VoiceOption] = [
         VoiceOption(
             id: openAIOnyxVoiceID,
@@ -476,52 +475,6 @@ class ShortcutSettings: ObservableObject {
                 "Speak in a natural, friendly, confident tone with clear articulation and relaxed pacing.",
             preferredSystemVoiceIdentifiers: [],
             preferredSystemVoiceNames: []
-        ),
-        VoiceOption(
-            id: localShelleyVoiceID,
-            name: "Shelley Local",
-            gender: .female,
-            description: "Local Shelley voice, no usage cost",
-            provider: .localSystem,
-            openAIVoice: nil,
-            openAIInstructions: nil,
-            preferredSystemVoiceIdentifiers: [
-                "com.apple.eloquence.en-US.Shelley",
-                "com.apple.eloquence.en-GB.Shelley",
-                "com.apple.eloquence.en-US.Flo",
-                "com.apple.speech.synthesis.voice.Whisper",
-            ],
-            preferredSystemVoiceNames: ["Shelley", "Flo", "Whisper", "Superstar", "Karen", "Moira", "Samantha"]
-        ),
-        VoiceOption(
-            id: "local:soft",
-            name: "Soft Local",
-            gender: .female,
-            description: "Local, gentle, no usage cost",
-            provider: .localSystem,
-            openAIVoice: nil,
-            openAIInstructions: nil,
-            preferredSystemVoiceIdentifiers: [
-                "com.apple.eloquence.en-US.Flo",
-                "com.apple.eloquence.en-GB.Flo",
-                "com.apple.voice.compact.en-US.Samantha",
-            ],
-            preferredSystemVoiceNames: ["Flo", "Samantha", "Karen", "Moira"]
-        ),
-        VoiceOption(
-            id: "local:deep",
-            name: "Deep Local",
-            gender: .male,
-            description: "Local, low, no usage cost",
-            provider: .localSystem,
-            openAIVoice: nil,
-            openAIInstructions: nil,
-            preferredSystemVoiceIdentifiers: [
-                "com.apple.eloquence.en-US.Rocko",
-                "com.apple.eloquence.en-US.Reed",
-                "com.apple.voice.compact.en-GB.Daniel",
-            ],
-            preferredSystemVoiceNames: ["Rocko", "Reed", "Daniel", "Fred"]
         ),
     ]
 

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -2269,15 +2269,8 @@ struct SettingsContentView: View {
         }
         Spacer()
         Picker("", selection: $shortcutSettings.selectedVoiceID) {
-          Section("OpenAI Human") {
-            ForEach(ShortcutSettings.availableVoices.filter { $0.isOpenAI }) { voice in
-              Text(voice.name).tag(voice.id)
-            }
-          }
-          Section("Local") {
-            ForEach(ShortcutSettings.availableVoices.filter { $0.isLocalSystem }) { voice in
-              Text(voice.name).tag(voice.id)
-            }
+          ForEach(ShortcutSettings.availableVoices) { voice in
+            Text(voice.name).tag(voice.id)
           }
         }
         .pickerStyle(.menu)

--- a/desktop/Desktop/Tests/FloatingBarVoiceResponseSettingsTests.swift
+++ b/desktop/Desktop/Tests/FloatingBarVoiceResponseSettingsTests.swift
@@ -20,11 +20,8 @@ final class FloatingBarVoiceResponseSettingsTests: XCTestCase {
         XCTAssertEqual(voice.openAIVoice, "shimmer")
     }
 
-    func testLocalFallbackVoiceRemainsAvailableInPicker() {
-        let voice = ShortcutSettings.voiceOption(for: ShortcutSettings.localShelleyVoiceID)
-        XCTAssertEqual(voice.name, "Shelley Local")
-        XCTAssertTrue(voice.isLocalSystem)
-        XCTAssertEqual(voice.preferredSystemVoiceIdentifiers.first, "com.apple.eloquence.en-US.Shelley")
+    func testOnlyOpenAIVoicesAreAvailableInPicker() {
+        XCTAssertFalse(ShortcutSettings.availableVoices.contains { $0.isLocalSystem })
     }
 
     func testLegacyProxyVoicesAreNotAvailableInPicker() {
@@ -36,7 +33,7 @@ final class FloatingBarVoiceResponseSettingsTests: XCTestCase {
         )
     }
 
-    func testInvalidVoiceFallsBackToDefaultLocalVoice() {
+    func testInvalidVoiceFallsBackToDefaultOpenAIVoice() {
         let voice = ShortcutSettings.voiceOption(for: "missing")
         XCTAssertEqual(voice.id, ShortcutSettings.defaultVoiceID)
         XCTAssertTrue(voice.isOpenAI)


### PR DESCRIPTION
Removes the local macOS voice choices from the desktop voice picker while keeping the existing macOS AVSpeech fallback for OpenAI TTS failures.