### PR TITLE
Set Shimmer as default desktop TTS voice

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -478,10 +478,12 @@ class ShortcutSettings: ObservableObject {
         ),
     ]
 
-    static let defaultVoiceID = openAIOnyxVoiceID
+    static let defaultVoiceID = openAIShimmerVoiceID
 
     static func voiceOption(for id: String) -> VoiceOption {
-        availableVoices.first(where: { $0.id == id }) ?? availableVoices[0]
+        availableVoices.first(where: { $0.id == id })
+            ?? availableVoices.first(where: { $0.id == defaultVoiceID })
+            ?? availableVoices[0]
     }
 
     /// Selected voice ID for floating-bar TTS replies.

--- a/desktop/Desktop/Tests/FloatingBarVoiceResponseSettingsTests.swift
+++ b/desktop/Desktop/Tests/FloatingBarVoiceResponseSettingsTests.swift
@@ -4,14 +4,15 @@ import XCTest
 @MainActor
 final class FloatingBarVoiceResponseSettingsTests: XCTestCase {
 
-    func testDefaultVoiceIsOnyxOpenAIHumanVoice() {
-        XCTAssertEqual(ShortcutSettings.defaultVoiceID, ShortcutSettings.openAIOnyxVoiceID)
+    func testDefaultVoiceIsShimmerOpenAIHumanVoice() {
+        XCTAssertEqual(ShortcutSettings.defaultVoiceID, ShortcutSettings.openAIShimmerVoiceID)
 
         let voice = ShortcutSettings.voiceOption(for: ShortcutSettings.defaultVoiceID)
-        XCTAssertEqual(voice.name, "Onyx")
+        XCTAssertEqual(voice.name, "Shimmer")
+        XCTAssertEqual(voice.gender, .female)
         XCTAssertTrue(voice.isOpenAI)
         XCTAssertEqual(voice.provider, .openAI)
-        XCTAssertEqual(voice.openAIVoice, "onyx")
+        XCTAssertEqual(voice.openAIVoice, "shimmer")
     }
 
     func testShimmerVoiceHasNeutralDisplayName() {
@@ -37,7 +38,7 @@ final class FloatingBarVoiceResponseSettingsTests: XCTestCase {
         let voice = ShortcutSettings.voiceOption(for: "missing")
         XCTAssertEqual(voice.id, ShortcutSettings.defaultVoiceID)
         XCTAssertTrue(voice.isOpenAI)
-        XCTAssertEqual(voice.openAIVoice, "onyx")
+        XCTAssertEqual(voice.openAIVoice, "shimmer")
     }
 
     func testVoiceQueryUsesVoiceToggle() {


### PR DESCRIPTION
Sets Shimmer as the default OpenAI TTS voice for desktop voice replies and makes invalid/missing voice IDs resolve to that default.