### PR TITLE
desktop: scope notification Execute button to task notifications only

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -202,7 +202,9 @@ struct FloatingControlBarView: View {
                 Spacer(minLength: 0)
 
                 // Reserve space so text never runs under the overlaid action buttons.
-                Color.clear.frame(width: 90, height: 18)
+                // Wider for actionable (task) notifications that also show Execute.
+                Color.clear
+                    .frame(width: notification.assistantId == "task" ? 90 : 36, height: 18)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 12)
@@ -212,30 +214,33 @@ struct FloatingControlBarView: View {
         .buttonStyle(.plain)
         .overlay(alignment: .topTrailing) {
             HStack(spacing: 6) {
-                // Spawn an agent pill that handles whatever the notification is
-                // about — reuses the same parallel-pill bridge flow.
-                Button {
-                    let model = ShortcutSettings.shared.selectedModel.isEmpty
-                        ? "claude-sonnet-4-6"
-                        : ShortcutSettings.shared.selectedModel
-                    let query = "Handle this notification: \(notification.title). \(notification.message)"
-                    AgentPillsManager.shared.spawn(query: query, model: model)
-                    FloatingControlBarManager.shared.dismissCurrentNotification()
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "sparkles")
-                            .font(.system(size: 9, weight: .bold))
-                        Text("Execute")
-                            .scaledFont(size: 10, weight: .semibold)
+                // Execute is only meaningful for actionable notifications (tasks).
+                // Focus / Insight (tips) / other passive notifications are
+                // informational — spawning an agent there made no sense.
+                if notification.assistantId == "task" {
+                    Button {
+                        let model = ShortcutSettings.shared.selectedModel.isEmpty
+                            ? "claude-sonnet-4-6"
+                            : ShortcutSettings.shared.selectedModel
+                        let query = "Handle this notification: \(notification.title). \(notification.message)"
+                        AgentPillsManager.shared.spawn(query: query, model: model)
+                        FloatingControlBarManager.shared.dismissCurrentNotification()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "sparkles")
+                                .font(.system(size: 9, weight: .bold))
+                            Text("Execute")
+                                .scaledFont(size: 10, weight: .semibold)
+                        }
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.white.opacity(0.18))
+                        .clipShape(Capsule())
                     }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color.white.opacity(0.18))
-                    .clipShape(Capsule())
+                    .buttonStyle(.plain)
+                    .help("Spawn an agent to handle this")
                 }
-                .buttonStyle(.plain)
-                .help("Spawn an agent to handle this")
 
                 Button {
                     FloatingControlBarManager.shared.dismissCurrentNotification()


### PR DESCRIPTION
## Summary

The \"Execute\" capsule on floating-bar notifications was rendering for every notification type — including passive Focus suggestions and Tips (Insight). Spawning an agent to \"handle\" a tip made no sense.

Gates Execute on \`notification.assistantId == \"task\"\`:

- **task** → Execute + X (unchanged)
- **focus** → X only
- **insight** (tips) → X only
- everything else → X only

Trimmed reserved right-side spacing on non-task notifications too so message text isn't artificially indented for an action button that no longer renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)