### PR TITLE
fix(pusher): prevent ghost WebSocket connections leaking memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,15 @@ Module hierarchy (lowest to highest):
 4. `main.py`
 
 - Memory management: free large objects immediately after use. E.g., `del` for byte arrays after processing, `.clear()` for dicts/lists holding data.
+- Async I/O: never `requests.*` in async (use `httpx.AsyncClient` from `utils/http_client.py`), never `Thread().start().join()` (use `critical_executor`/`storage_executor`), never `time.sleep()` in async (use `asyncio.sleep()`).
+
+#### WebSocket Concurrency
+
+WebSocket handlers (`transcribe.py`, `pusher.py`) use `asyncio.wait(FIRST_COMPLETED)` supervisor loops — never `asyncio.gather()` on the receive task with background tasks. Key rules:
+- Receive timeouts: every `websocket.receive()` wrapped in `asyncio.wait_for(..., timeout=WS_RECEIVE_TIMEOUT)`
+- Gauge placement: `inc()` in `try` body, `dec()` in `finally` — always paired
+- Task naming: WebSocket lifetime tasks must include `name=f"ws:{uid}:{task_name}"`
+- Finite vs lifetime: tasks that complete normally during active sessions (e.g. `process_pending_conversations`) go in `finite_tasks` set; all others are lifetime tasks whose completion triggers teardown
 
 #### Backend Service Map
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -175,9 +175,10 @@ WS handlers in `transcribe.py` and `pusher.py` manage 5-11 concurrent tasks per 
 - **Supervision**: `supervise_tasks()` wraps `asyncio.wait(FIRST_COMPLETED)` — detects both client disconnect and bg task crashes immediately. Classify tasks as finite (can complete during session) or lifetime (completion = session ending).
 - **Drain**: `drain_tasks()` cancels remaining bg tasks with bounded timeout, force-cancels stragglers via `asyncio.wait` (not `asyncio.gather`, which hangs if a task suppresses CancelledError).
 - **Fan-out**: `gather_with_logging()` replaces `asyncio.gather(return_exceptions=True)` — semaphore-bounded concurrency, per-item exception logging, typed `GatherResult[T]` return.
+- **Interruptible sleep**: `sleep_until_shutdown(event, seconds)` replaces `asyncio.sleep()` in polling loops — wakes instantly on disconnect via per-connection `asyncio.Event`. Never bare `asyncio.sleep()` in WS task loops.
 - **Receive timeouts**: every `websocket.receive()` must be wrapped in `asyncio.wait_for(..., timeout=WS_RECEIVE_TIMEOUT)`.
 - **Gauge placement**: `GAUGE.inc()` inside `try` body, `GAUGE.dec()` in `finally`. Init `bg_main_tasks = []` before `try`.
-- **Task naming**: `create_named_task()` with `name=f"ws:{uid}:{task_name}"` for production debugging. Track in task set for automatic cleanup.
+- **Task naming**: `create_named_task()` for WS-scoped tasks (tracked in task_set for supervise/drain). Use `start_background_task()` from `utils/executors.py` for fire-and-forget work that outlives the handler.
 - **Prometheus labels**: static low-cardinality only (e.g. "pusher", "listen") — never uid/session_id.
 - **Module-level dicts**: add TTL-based eviction or cap size — they grow forever otherwise.
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -174,7 +174,7 @@ WS handlers in `transcribe.py` and `pusher.py` manage 5-11 concurrent tasks per 
 
 - **Supervision**: `supervise_tasks()` wraps `asyncio.wait(FIRST_COMPLETED)` — detects both client disconnect and bg task crashes immediately. Classify tasks as finite (can complete during session) or lifetime (completion = session ending).
 - **Drain**: `drain_tasks()` cancels remaining bg tasks with bounded timeout, force-cancels stragglers via `asyncio.wait` (not `asyncio.gather`, which hangs if a task suppresses CancelledError).
-- **Fan-out**: `gather_with_logging()` replaces `asyncio.gather(return_exceptions=True)` — semaphore-bounded concurrency, per-item exception logging, typed `GatherResult[T]` return.
+- **Fan-out**: `gather_safe()` replaces `asyncio.gather(return_exceptions=True)` — semaphore-bounded concurrency, per-item exception logging, typed `GatherResult[T]` return.
 - **Interruptible sleep**: `wait_for_event(event, seconds)` replaces `asyncio.sleep()` in polling loops — wakes instantly on disconnect via per-connection `asyncio.Event`. Never bare `asyncio.sleep()` in WS task loops.
 - **Receive timeouts**: every `websocket.receive()` must be wrapped in `asyncio.wait_for(..., timeout=WS_RECEIVE_TIMEOUT)`.
 - **Gauge placement**: `GAUGE.inc()` inside `try` body, `GAUGE.dec()` in `finally`. Init `bg_main_tasks = []` before `try`.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -172,23 +172,43 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
 
 WebSocket handlers in `transcribe.py` and `pusher.py` manage 5-11 concurrent tasks per connection. These rules prevent ghost connections, memory leaks, and gauge drift.
 
-### Task lifecycle: receive-then-drain
+### Task lifecycle: supervisor with `asyncio.wait(FIRST_COMPLETED)`
 
-Never `asyncio.gather()` the receive task with background tasks. If any bg task hangs, the gather blocks forever and the `finally` block (gauge dec, cleanup) never executes.
+Never `asyncio.gather()` the receive task with background tasks — a hung bg task blocks cleanup forever. Never bare `await receive_task` either — a crashed bg task goes unnoticed for hours.
+
+Use `asyncio.wait(FIRST_COMPLETED)` to detect **both** client disconnect **and** bg task failures immediately:
 
 ```python
 bg_main_tasks = []
 try:
     GAUGE.inc()
-    receive_task = asyncio.create_task(receive_loop())
-    bg_main_tasks = [asyncio.create_task(bg1()), asyncio.create_task(bg2())]
-    await receive_task                    # exits when client disconnects
-    try:
-        await asyncio.wait_for(asyncio.gather(*bg_main_tasks, return_exceptions=True), timeout=BG_DRAIN_TIMEOUT)
-    except asyncio.TimeoutError:
-        for t in bg_main_tasks:
-            if not t.done(): t.cancel()
-        await asyncio.gather(*bg_main_tasks, return_exceptions=True)
+    receive_task = asyncio.create_task(receive_loop(), name=f"ws:{uid}:receive")
+    bg_main_tasks = [
+        asyncio.create_task(bg1(), name=f"ws:{uid}:bg1"),
+        asyncio.create_task(bg2(), name=f"ws:{uid}:bg2"),
+    ]
+    # Supervisor: exits on disconnect OR bg crash
+    done, _ = await asyncio.wait({receive_task, *bg_main_tasks}, return_when=asyncio.FIRST_COMPLETED)
+    # Log bg failures, re-raise receive errors
+    for task in done:
+        if task is not receive_task and not task.cancelled():
+            exc = task.exception()
+            if exc: logger.error(f"BG task {task.get_name()} crashed: {exc}")
+    if receive_task in done and not receive_task.cancelled():
+        exc = receive_task.exception()
+        if exc: raise exc
+    # Cancel receive if bg crash triggered exit
+    if not receive_task.done():
+        receive_task.cancel()
+    # Drain remaining bg tasks with timeout
+    remaining = [t for t in bg_main_tasks if not t.done()]
+    if remaining:
+        try:
+            await asyncio.wait_for(asyncio.gather(*remaining, return_exceptions=True), timeout=BG_DRAIN_TIMEOUT)
+        except asyncio.TimeoutError:
+            for t in remaining:
+                if not t.done(): t.cancel()
+            await asyncio.gather(*remaining, return_exceptions=True)
 finally:
     all_to_cancel = [t for t in bg_main_tasks if not t.done()]
     for t in all_to_cancel: t.cancel()
@@ -204,9 +224,9 @@ Every `websocket.receive()` / `websocket.receive_bytes()` must be wrapped in `as
 
 `GAUGE.inc()` inside the `try` body, `GAUGE.dec()` in the `finally` — always paired, never separated by code that can raise. Initialize `bg_main_tasks = []` BEFORE the `try` so the `finally` can reference it.
 
-### Task tracking
+### Task tracking and naming
 
-Never bare `asyncio.create_task()` without tracking the task for cancellation. Use `spawn()` (which adds to `bg_tasks`) or add to `bg_main_tasks`. Untracked tasks leak on disconnect.
+Every `asyncio.create_task()` must: (1) include `name=f"ws:{uid}:{task_name}"` for production debugging, (2) be tracked for cancellation via `spawn()` (adds to `bg_tasks`) or `bg_main_tasks`. Untracked/unnamed tasks leak on disconnect and are invisible in logs.
 
 ### Executor bounds
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -170,74 +170,16 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
 
 ## WebSocket Concurrency (Long-Lived Connections)
 
-WebSocket handlers in `transcribe.py` and `pusher.py` manage 5-11 concurrent tasks per connection. These rules prevent ghost connections, memory leaks, and gauge drift.
+WS handlers in `transcribe.py` and `pusher.py` manage 5-11 concurrent tasks per connection. Use `utils/async_tasks.py` utilities — never raw `asyncio.gather()` or bare `await receive_task`.
 
-### Task lifecycle: supervisor with `asyncio.wait(FIRST_COMPLETED)`
-
-Never `asyncio.gather()` the receive task with background tasks — a hung bg task blocks cleanup forever. Never bare `await receive_task` either — a crashed bg task goes unnoticed for hours.
-
-Use `asyncio.wait(FIRST_COMPLETED)` to detect **both** client disconnect **and** bg task failures immediately:
-
-```python
-bg_main_tasks = []
-try:
-    GAUGE.inc()
-    receive_task = asyncio.create_task(receive_loop(), name=f"ws:{uid}:receive")
-    bg_main_tasks = [
-        asyncio.create_task(bg1(), name=f"ws:{uid}:bg1"),
-        asyncio.create_task(bg2(), name=f"ws:{uid}:bg2"),
-    ]
-    # Supervisor loop: exits on disconnect OR bg crash, ignores finite tasks
-    monitored = {receive_task, *bg_main_tasks}
-    supervisor_exit = None
-    while monitored:
-        done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
-        for task in done:
-            if task is receive_task:
-                supervisor_exit = "disconnect"; break
-            if not task.cancelled():
-                exc = task.exception()
-                if exc:
-                    logger.error(f"BG task {task.get_name()} crashed: {exc}")
-                    supervisor_exit = "crash"; break
-        if supervisor_exit: break
-    if not receive_task.done():
-        receive_task.cancel()
-    # Drain remaining bg tasks with timeout
-    remaining = [t for t in bg_main_tasks if not t.done()]
-    if remaining:
-        try:
-            await asyncio.wait_for(asyncio.gather(*remaining, return_exceptions=True), timeout=BG_DRAIN_TIMEOUT)
-        except asyncio.TimeoutError:
-            for t in remaining:
-                if not t.done(): t.cancel()
-            await asyncio.gather(*remaining, return_exceptions=True)
-finally:
-    all_to_cancel = [t for t in bg_main_tasks if not t.done()]
-    for t in all_to_cancel: t.cancel()
-    if all_to_cancel: await asyncio.gather(*all_to_cancel, return_exceptions=True)
-    GAUGE.dec()
-```
-
-### Receive timeouts
-
-Every `websocket.receive()` / `websocket.receive_bytes()` must be wrapped in `asyncio.wait_for(..., timeout=WS_RECEIVE_TIMEOUT)`. Dead TCP connections (mobile killed, network drop) block indefinitely without this.
-
-### Gauge placement
-
-`GAUGE.inc()` inside the `try` body, `GAUGE.dec()` in the `finally` — always paired, never separated by code that can raise. Initialize `bg_main_tasks = []` BEFORE the `try` so the `finally` can reference it.
-
-### Task tracking and naming
-
-WebSocket lifetime tasks (those in the supervisor set or `bg_main_tasks`) must: (1) include `name=f"ws:{uid}:{task_name}"` for production debugging, (2) be tracked for cancellation via `spawn()` (adds to `bg_tasks`) or `bg_main_tasks`. Untracked lifetime tasks leak on disconnect and are invisible in logs.
-
-### Executor bounds
-
-`critical_executor` (8 workers) and `storage_executor` (16 workers) have bounded pools. The default executor (`None`) is unbounded — avoid it for user-triggered work. If you must use it (e.g., to avoid deadlock with `critical_executor`), document why and consider the thread count under load.
-
-### Process-scoped dict cleanup
-
-Module-level dicts (`proactive_noti_sent_at`, caches) grow forever if cleanup is lazy-only. Add TTL-based eviction or cap size with `maxlen`.
+- **Supervision**: `supervise_tasks()` wraps `asyncio.wait(FIRST_COMPLETED)` — detects both client disconnect and bg task crashes immediately. Classify tasks as finite (can complete during session) or lifetime (completion = session ending).
+- **Drain**: `drain_tasks()` cancels remaining bg tasks with bounded timeout, force-cancels stragglers via `asyncio.wait` (not `asyncio.gather`, which hangs if a task suppresses CancelledError).
+- **Fan-out**: `gather_with_logging()` replaces `asyncio.gather(return_exceptions=True)` — semaphore-bounded concurrency, per-item exception logging, typed `GatherResult[T]` return.
+- **Receive timeouts**: every `websocket.receive()` must be wrapped in `asyncio.wait_for(..., timeout=WS_RECEIVE_TIMEOUT)`.
+- **Gauge placement**: `GAUGE.inc()` inside `try` body, `GAUGE.dec()` in `finally`. Init `bg_main_tasks = []` before `try`.
+- **Task naming**: `create_named_task()` with `name=f"ws:{uid}:{task_name}"` for production debugging. Track in task set for automatic cleanup.
+- **Prometheus labels**: static low-cardinality only (e.g. "pusher", "listen") — never uid/session_id.
+- **Module-level dicts**: add TTL-based eviction or cap size — they grow forever otherwise.
 
 ## Common Gotchas
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -175,7 +175,7 @@ WS handlers in `transcribe.py` and `pusher.py` manage 5-11 concurrent tasks per 
 - **Supervision**: `supervise_tasks()` wraps `asyncio.wait(FIRST_COMPLETED)` — detects both client disconnect and bg task crashes immediately. Classify tasks as finite (can complete during session) or lifetime (completion = session ending).
 - **Drain**: `drain_tasks()` cancels remaining bg tasks with bounded timeout, force-cancels stragglers via `asyncio.wait` (not `asyncio.gather`, which hangs if a task suppresses CancelledError).
 - **Fan-out**: `gather_with_logging()` replaces `asyncio.gather(return_exceptions=True)` — semaphore-bounded concurrency, per-item exception logging, typed `GatherResult[T]` return.
-- **Interruptible sleep**: `sleep_until_shutdown(event, seconds)` replaces `asyncio.sleep()` in polling loops — wakes instantly on disconnect via per-connection `asyncio.Event`. Never bare `asyncio.sleep()` in WS task loops.
+- **Interruptible sleep**: `wait_for_event(event, seconds)` replaces `asyncio.sleep()` in polling loops — wakes instantly on disconnect via per-connection `asyncio.Event`. Never bare `asyncio.sleep()` in WS task loops.
 - **Receive timeouts**: every `websocket.receive()` must be wrapped in `asyncio.wait_for(..., timeout=WS_RECEIVE_TIMEOUT)`.
 - **Gauge placement**: `GAUGE.inc()` inside `try` body, `GAUGE.dec()` in `finally`. Init `bg_main_tasks = []` before `try`.
 - **Task naming**: `create_named_task()` for WS-scoped tasks (tracked in task_set for supervise/drain). Use `start_background_task()` from `utils/executors.py` for fire-and-forget work that outlives the handler.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -187,17 +187,20 @@ try:
         asyncio.create_task(bg1(), name=f"ws:{uid}:bg1"),
         asyncio.create_task(bg2(), name=f"ws:{uid}:bg2"),
     ]
-    # Supervisor: exits on disconnect OR bg crash
-    done, _ = await asyncio.wait({receive_task, *bg_main_tasks}, return_when=asyncio.FIRST_COMPLETED)
-    # Log bg failures, re-raise receive errors
-    for task in done:
-        if task is not receive_task and not task.cancelled():
-            exc = task.exception()
-            if exc: logger.error(f"BG task {task.get_name()} crashed: {exc}")
-    if receive_task in done and not receive_task.cancelled():
-        exc = receive_task.exception()
-        if exc: raise exc
-    # Cancel receive if bg crash triggered exit
+    # Supervisor loop: exits on disconnect OR bg crash, ignores finite tasks
+    monitored = {receive_task, *bg_main_tasks}
+    supervisor_exit = None
+    while monitored:
+        done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            if task is receive_task:
+                supervisor_exit = "disconnect"; break
+            if not task.cancelled():
+                exc = task.exception()
+                if exc:
+                    logger.error(f"BG task {task.get_name()} crashed: {exc}")
+                    supervisor_exit = "crash"; break
+        if supervisor_exit: break
     if not receive_task.done():
         receive_task.cancel()
     # Drain remaining bg tasks with timeout
@@ -226,7 +229,7 @@ Every `websocket.receive()` / `websocket.receive_bytes()` must be wrapped in `as
 
 ### Task tracking and naming
 
-Every `asyncio.create_task()` must: (1) include `name=f"ws:{uid}:{task_name}"` for production debugging, (2) be tracked for cancellation via `spawn()` (adds to `bg_tasks`) or `bg_main_tasks`. Untracked/unnamed tasks leak on disconnect and are invisible in logs.
+WebSocket lifetime tasks (those in the supervisor set or `bg_main_tasks`) must: (1) include `name=f"ws:{uid}:{task_name}"` for production debugging, (2) be tracked for cancellation via `spawn()` (adds to `bg_tasks`) or `bg_main_tasks`. Untracked lifetime tasks leak on disconnect and are invisible in logs.
 
 ### Executor bounds
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -168,6 +168,54 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
 - **Lane 3 — Lint**: `python scripts/lint_async_blockers.py` catches `requests.*`, `time.sleep()`, `Thread().start()` in async code. Run before committing.
 - **Shutdown**: `close_all_clients()` + `shutdown_executors()` wired in `main.py` and `pusher/main.py`.
 
+## WebSocket Concurrency (Long-Lived Connections)
+
+WebSocket handlers in `transcribe.py` and `pusher.py` manage 5-11 concurrent tasks per connection. These rules prevent ghost connections, memory leaks, and gauge drift.
+
+### Task lifecycle: receive-then-drain
+
+Never `asyncio.gather()` the receive task with background tasks. If any bg task hangs, the gather blocks forever and the `finally` block (gauge dec, cleanup) never executes.
+
+```python
+bg_main_tasks = []
+try:
+    GAUGE.inc()
+    receive_task = asyncio.create_task(receive_loop())
+    bg_main_tasks = [asyncio.create_task(bg1()), asyncio.create_task(bg2())]
+    await receive_task                    # exits when client disconnects
+    try:
+        await asyncio.wait_for(asyncio.gather(*bg_main_tasks, return_exceptions=True), timeout=BG_DRAIN_TIMEOUT)
+    except asyncio.TimeoutError:
+        for t in bg_main_tasks:
+            if not t.done(): t.cancel()
+        await asyncio.gather(*bg_main_tasks, return_exceptions=True)
+finally:
+    all_to_cancel = [t for t in bg_main_tasks if not t.done()]
+    for t in all_to_cancel: t.cancel()
+    if all_to_cancel: await asyncio.gather(*all_to_cancel, return_exceptions=True)
+    GAUGE.dec()
+```
+
+### Receive timeouts
+
+Every `websocket.receive()` / `websocket.receive_bytes()` must be wrapped in `asyncio.wait_for(..., timeout=WS_RECEIVE_TIMEOUT)`. Dead TCP connections (mobile killed, network drop) block indefinitely without this.
+
+### Gauge placement
+
+`GAUGE.inc()` inside the `try` body, `GAUGE.dec()` in the `finally` — always paired, never separated by code that can raise. Initialize `bg_main_tasks = []` BEFORE the `try` so the `finally` can reference it.
+
+### Task tracking
+
+Never bare `asyncio.create_task()` without tracking the task for cancellation. Use `spawn()` (which adds to `bg_tasks`) or add to `bg_main_tasks`. Untracked tasks leak on disconnect.
+
+### Executor bounds
+
+`critical_executor` (8 workers) and `storage_executor` (16 workers) have bounded pools. The default executor (`None`) is unbounded — avoid it for user-triggered work. If you must use it (e.g., to avoid deadlock with `critical_executor`), document why and consider the thread count under load.
+
+### Process-scoped dict cleanup
+
+Module-level dicts (`proactive_noti_sent_at`, caches) grow forever if cleanup is lazy-only. Add TTL-based eviction or cap size with `maxlen`.
+
 ## Common Gotchas
 
 1. **Python 3.11 only** — no 3.12+ syntax (nested same-type quotes in f-strings break the Docker build)

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -286,7 +286,7 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
     cpu: 0.35
-    memory: 2.5Gi
+    memory: 3Gi
   limits:
     cpu: 0.7
     memory: 4.5Gi

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -285,8 +285,8 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
-    cpu: 0.35
-    memory: 3Gi
+    cpu: 0.7
+    memory: 4.5Gi
   limits:
     cpu: 0.7
     memory: 4.5Gi

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -285,8 +285,8 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
-    cpu: 0.7
-    memory: 4.5Gi
+    cpu: 0.35
+    memory: 2.5Gi
   limits:
     cpu: 0.7
     memory: 4.5Gi

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -629,8 +629,9 @@ async def _websocket_util_trigger(
             receive_task=receive_task,
             bg_tasks=bg_main_tasks,
             finite_tasks=None,
-            label=f"pusher:{uid}",
+            label="pusher",
         )
+        logger.info(f"Supervisor exited: reason={exit_result.reason} task={exit_result.task_name} {uid}")
 
         if receive_task.done() and not receive_task.cancelled():
             exc = receive_task.exception()
@@ -645,7 +646,7 @@ async def _websocket_util_trigger(
             except asyncio.CancelledError:
                 pass
 
-        await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label=f"pusher:{uid}:bg", cancel=False)
+        await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label="pusher_bg", cancel=False)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e}")
@@ -653,7 +654,7 @@ async def _websocket_util_trigger(
         websocket_active = False
 
         all_to_cancel = list(bg_tasks) + [t for t in bg_main_tasks if not t.done()]
-        await drain_tasks(all_to_cancel, timeout=5.0, label=f"pusher:{uid}:cleanup", cancel=True)
+        await drain_tasks(all_to_cancel, timeout=5.0, label="pusher_cleanup", cancel=True)
         bg_tasks.clear()
 
         PUSHER_ACTIVE_WS_CONNECTIONS.dec()

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -28,7 +28,7 @@ from utils.conversations.location import async_get_google_maps_location
 from utils.byok import set_byok_keys
 from utils.conversations.process_conversation import process_conversation
 from utils.executors import db_executor, storage_executor, run_blocking
-from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task, sleep_until_shutdown
+from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task, wait_for_event
 from utils.webhooks import (
     send_audio_bytes_developer_webhook,
     realtime_transcript_webhook,
@@ -287,7 +287,7 @@ async def _websocket_util_trigger(
             del chunk_data
 
         while websocket_active or len(private_cloud_queue) > 0 or len(pending) > 0:
-            await sleep_until_shutdown(shutdown_event, PRIVATE_CLOUD_SYNC_PROCESS_INTERVAL)
+            await wait_for_event(shutdown_event, PRIVATE_CLOUD_SYNC_PROCESS_INTERVAL)
 
             # Drain queue into pending batches
             if private_cloud_queue:
@@ -320,7 +320,7 @@ async def _websocket_util_trigger(
         nonlocal websocket_active
 
         while websocket_active or len(speaker_sample_queue) > 0:
-            await sleep_until_shutdown(shutdown_event, SPEAKER_SAMPLE_PROCESS_INTERVAL)
+            await wait_for_event(shutdown_event, SPEAKER_SAMPLE_PROCESS_INTERVAL)
 
             if not speaker_sample_queue:
                 continue
@@ -366,7 +366,7 @@ async def _websocket_util_trigger(
         nonlocal websocket_active
 
         while websocket_active or len(transcript_queue) > 0:
-            await sleep_until_shutdown(shutdown_event, TRANSCRIPT_QUEUE_FLUSH_INTERVAL)
+            await wait_for_event(shutdown_event, TRANSCRIPT_QUEUE_FLUSH_INTERVAL)
 
             if not transcript_queue:
                 continue

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -616,40 +616,64 @@ async def _websocket_util_trigger(
     bg_main_tasks = []
     try:
         PUSHER_ACTIVE_WS_CONNECTIONS.inc()
-        receive_task = asyncio.create_task(receive_tasks())
+        receive_task = asyncio.create_task(receive_tasks(), name=f"ws:{uid}:receive")
         bg_main_tasks = [
-            asyncio.create_task(process_speaker_sample_queue()),
-            asyncio.create_task(process_private_cloud_queue()),
-            asyncio.create_task(process_transcript_queue()),
-            asyncio.create_task(process_audio_bytes_queue()),
+            asyncio.create_task(process_speaker_sample_queue(), name=f"ws:{uid}:speaker_samples"),
+            asyncio.create_task(process_private_cloud_queue(), name=f"ws:{uid}:private_cloud"),
+            asyncio.create_task(process_transcript_queue(), name=f"ws:{uid}:transcripts"),
+            asyncio.create_task(process_audio_bytes_queue(), name=f"ws:{uid}:audio_bytes"),
         ]
 
-        # Wait for receive_task — it exits on disconnect, error, or receive timeout.
-        # Previous code used asyncio.gather() for ALL 5 tasks, which meant a hung
-        # background task (e.g. stuck GCS upload) would block cleanup forever,
-        # leaking ~15 MB per ghost connection and inflating the gauge.
-        await receive_task
+        # Supervisor: wait for client disconnect OR any bg task failure.
+        # asyncio.wait(FIRST_COMPLETED) returns as soon as ANY task finishes,
+        # so a crashed bg task is detected immediately — not hours later at drain.
+        done, _ = await asyncio.wait(
+            {receive_task, *bg_main_tasks},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
 
-        # receive_tasks() already set websocket_active = False.
-        # Give background tasks a grace period to drain their queues.
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(*bg_main_tasks, return_exceptions=True),
-                timeout=BG_DRAIN_TIMEOUT,
-            )
-        except asyncio.TimeoutError:
-            dropped_speaker = len(speaker_sample_queue)
-            dropped_transcript = len(transcript_queue)
-            dropped_audio = len(audio_bytes_queue)
-            dropped_cloud = len(private_cloud_queue)
-            logger.warning(
-                f"Background tasks didn't drain within {BG_DRAIN_TIMEOUT}s, force-cancelling {uid} "
-                f"(dropped: speaker={dropped_speaker} transcript={dropped_transcript} "
-                f"audio={dropped_audio} cloud={dropped_cloud})"
-            )
-            for task in bg_main_tasks:
-                task.cancel()
-            await asyncio.gather(*bg_main_tasks, return_exceptions=True)
+        for task in done:
+            if task is not receive_task and not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    logger.error(f"BG task {task.get_name()} crashed: {exc} {uid}")
+
+        if receive_task in done and not receive_task.cancelled():
+            exc = receive_task.exception()
+            if exc is not None:
+                raise exc
+
+        # If receive_task is still running (bg task crashed first), cancel it
+        if not receive_task.done():
+            websocket_active = False
+            receive_task.cancel()
+            try:
+                await receive_task
+            except asyncio.CancelledError:
+                pass
+
+        # Drain remaining bg tasks with timeout
+        remaining = [t for t in bg_main_tasks if not t.done()]
+        if remaining:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*remaining, return_exceptions=True),
+                    timeout=BG_DRAIN_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                dropped_speaker = len(speaker_sample_queue)
+                dropped_transcript = len(transcript_queue)
+                dropped_audio = len(audio_bytes_queue)
+                dropped_cloud = len(private_cloud_queue)
+                logger.warning(
+                    f"Background tasks didn't drain within {BG_DRAIN_TIMEOUT}s, force-cancelling {uid} "
+                    f"(dropped: speaker={dropped_speaker} transcript={dropped_transcript} "
+                    f"audio={dropped_audio} cloud={dropped_cloud})"
+                )
+                for task in remaining:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*remaining, return_exceptions=True)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e}")

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -63,6 +63,17 @@ TRANSCRIPT_QUEUE_WARN_SIZE = 50
 # Constants for audio bytes queue
 AUDIO_BYTES_QUEUE_WARN_SIZE = 20
 
+# Receive timeout: if no data arrives for this long, the connection is considered dead.
+# Backend-listen sends heartbeats every ~30s, so 5 minutes without ANY data means the
+# upstream connection is gone.  Without this, half-open TCP connections hang forever,
+# leaking the gauge + ~15 MB per ghost connection.
+WS_RECEIVE_TIMEOUT = 300.0  # seconds
+
+# After receive_task exits, background tasks get this long to drain their queues
+# before being force-cancelled.  Prevents hung GCS uploads or webhook calls from
+# blocking cleanup indefinitely.
+BG_DRAIN_TIMEOUT = 30.0  # seconds
+
 
 async def _process_conversation_task(
     uid: str,
@@ -412,7 +423,12 @@ async def _websocket_util_trigger(
 
         try:
             while websocket_active:
-                data = await websocket.receive_bytes()
+                try:
+                    data = await asyncio.wait_for(websocket.receive_bytes(), timeout=WS_RECEIVE_TIMEOUT)
+                except asyncio.TimeoutError:
+                    logger.warning(f"WebSocket receive timeout ({WS_RECEIVE_TIMEOUT}s), closing connection {uid}")
+                    websocket_close_code = 1000
+                    break
                 header_type = struct.unpack('<I', data[:4])[0]
 
                 # Heartbeat (data-frame keepalive from backend to reset GKE ILB idle timer)
@@ -594,32 +610,47 @@ async def _websocket_util_trigger(
                 logger.info(f"Flushed final private cloud buffer: {len(private_cloud_sync_buffer)} bytes {uid}")
             websocket_active = False
 
+    bg_main_tasks = []
     try:
         PUSHER_ACTIVE_WS_CONNECTIONS.inc()
         receive_task = asyncio.create_task(receive_tasks())
-        speaker_sample_task = asyncio.create_task(process_speaker_sample_queue())
-        private_cloud_task = asyncio.create_task(process_private_cloud_queue())
-        transcript_task = asyncio.create_task(process_transcript_queue())
-        audio_bytes_task = asyncio.create_task(process_audio_bytes_queue())
-        await asyncio.gather(
-            receive_task,
-            speaker_sample_task,
-            private_cloud_task,
-            transcript_task,
-            audio_bytes_task,
-        )
+        bg_main_tasks = [
+            asyncio.create_task(process_speaker_sample_queue()),
+            asyncio.create_task(process_private_cloud_queue()),
+            asyncio.create_task(process_transcript_queue()),
+            asyncio.create_task(process_audio_bytes_queue()),
+        ]
+
+        # Wait for receive_task — it exits on disconnect, error, or receive timeout.
+        # Previous code used asyncio.gather() for ALL 5 tasks, which meant a hung
+        # background task (e.g. stuck GCS upload) would block cleanup forever,
+        # leaking ~15 MB per ghost connection and inflating the gauge.
+        await receive_task
+
+        # receive_tasks() already set websocket_active = False.
+        # Give background tasks a grace period to drain their queues.
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*bg_main_tasks, return_exceptions=True),
+                timeout=BG_DRAIN_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(f"Background tasks didn't drain within {BG_DRAIN_TIMEOUT}s, force-cancelling {uid}")
+            for task in bg_main_tasks:
+                task.cancel()
+            await asyncio.gather(*bg_main_tasks, return_exceptions=True)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e}")
     finally:
         websocket_active = False
 
-        # Cancel all tracked background tasks to prevent memory leaks
-        tasks_to_cancel = list(bg_tasks)
-        for task in tasks_to_cancel:
+        # Cancel background tasks from both spawn() and main task lists
+        all_to_cancel = list(bg_tasks) + [t for t in bg_main_tasks if not t.done()]
+        for task in all_to_cancel:
             task.cancel()
-        if tasks_to_cancel:
-            await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
+        if all_to_cancel:
+            await asyncio.gather(*all_to_cancel, return_exceptions=True)
         bg_tasks.clear()
 
         PUSHER_ACTIVE_WS_CONNECTIONS.dec()

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -324,13 +324,16 @@ async def _websocket_util_trigger(
                 continue
 
             current_time = time.time()
+            is_shutdown = not websocket_active
 
-            # Separate ready and pending requests
+            # Separate ready and pending requests.
+            # On shutdown, skip the age check — process everything so pending
+            # samples aren't silently dropped when the drain timeout fires.
             ready_requests = []
             pending_requests = []
 
             for request in list(speaker_sample_queue):
-                if current_time - request['queued_at'] >= SPEAKER_SAMPLE_MIN_AGE:
+                if is_shutdown or current_time - request['queued_at'] >= SPEAKER_SAMPLE_MIN_AGE:
                     ready_requests.append(request)
                 else:
                     pending_requests.append(request)
@@ -635,7 +638,15 @@ async def _websocket_util_trigger(
                 timeout=BG_DRAIN_TIMEOUT,
             )
         except asyncio.TimeoutError:
-            logger.warning(f"Background tasks didn't drain within {BG_DRAIN_TIMEOUT}s, force-cancelling {uid}")
+            dropped_speaker = len(speaker_sample_queue)
+            dropped_transcript = len(transcript_queue)
+            dropped_audio = len(audio_bytes_queue)
+            dropped_cloud = len(private_cloud_queue)
+            logger.warning(
+                f"Background tasks didn't drain within {BG_DRAIN_TIMEOUT}s, force-cancelling {uid} "
+                f"(dropped: speaker={dropped_speaker} transcript={dropped_transcript} "
+                f"audio={dropped_audio} cloud={dropped_cloud})"
+            )
             for task in bg_main_tasks:
                 task.cancel()
             await asyncio.gather(*bg_main_tasks, return_exceptions=True)

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -624,21 +624,29 @@ async def _websocket_util_trigger(
             asyncio.create_task(process_audio_bytes_queue(), name=f"ws:{uid}:audio_bytes"),
         ]
 
-        # Supervisor: wait for client disconnect OR any bg task failure.
-        # asyncio.wait(FIRST_COMPLETED) returns as soon as ANY task finishes,
-        # so a crashed bg task is detected immediately — not hours later at drain.
-        done, _ = await asyncio.wait(
-            {receive_task, *bg_main_tasks},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        # Supervisor loop: wait for client disconnect OR any bg task crash.
+        # Finite bg tasks that complete normally are removed from the monitored
+        # set — only disconnect or crash exits the loop.
+        monitored = {receive_task, *bg_main_tasks}
+        supervisor_exit = None
+        while monitored:
+            done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
 
-        for task in done:
-            if task is not receive_task and not task.cancelled():
-                exc = task.exception()
-                if exc is not None:
-                    logger.error(f"BG task {task.get_name()} crashed: {exc} {uid}")
+            for task in done:
+                if task is receive_task:
+                    supervisor_exit = "disconnect"
+                    break
+                if not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None:
+                        logger.error(f"BG task {task.get_name()} crashed: {exc} {uid}")
+                        supervisor_exit = "crash"
+                        break
 
-        if receive_task in done and not receive_task.cancelled():
+            if supervisor_exit:
+                break
+
+        if receive_task.done() and not receive_task.cancelled():
             exc = receive_task.exception()
             if exc is not None:
                 raise exc

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -28,7 +28,7 @@ from utils.conversations.location import async_get_google_maps_location
 from utils.byok import set_byok_keys
 from utils.conversations.process_conversation import process_conversation
 from utils.executors import db_executor, storage_executor, run_blocking
-from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task
+from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task, sleep_until_shutdown
 from utils.webhooks import (
     send_audio_bytes_developer_webhook,
     realtime_transcript_webhook,
@@ -174,6 +174,7 @@ async def _websocket_util_trigger(
         return
 
     websocket_active = True
+    shutdown_event = asyncio.Event()
     websocket_close_code = 1000
 
     # audio bytes
@@ -286,7 +287,7 @@ async def _websocket_util_trigger(
             del chunk_data
 
         while websocket_active or len(private_cloud_queue) > 0 or len(pending) > 0:
-            await asyncio.sleep(PRIVATE_CLOUD_SYNC_PROCESS_INTERVAL)
+            await sleep_until_shutdown(shutdown_event, PRIVATE_CLOUD_SYNC_PROCESS_INTERVAL)
 
             # Drain queue into pending batches
             if private_cloud_queue:
@@ -319,7 +320,7 @@ async def _websocket_util_trigger(
         nonlocal websocket_active
 
         while websocket_active or len(speaker_sample_queue) > 0:
-            await asyncio.sleep(SPEAKER_SAMPLE_PROCESS_INTERVAL)
+            await sleep_until_shutdown(shutdown_event, SPEAKER_SAMPLE_PROCESS_INTERVAL)
 
             if not speaker_sample_queue:
                 continue
@@ -365,7 +366,7 @@ async def _websocket_util_trigger(
         nonlocal websocket_active
 
         while websocket_active or len(transcript_queue) > 0:
-            await asyncio.sleep(TRANSCRIPT_QUEUE_FLUSH_INTERVAL)
+            await sleep_until_shutdown(shutdown_event, TRANSCRIPT_QUEUE_FLUSH_INTERVAL)
 
             if not transcript_queue:
                 continue
@@ -392,7 +393,9 @@ async def _websocket_util_trigger(
             try:
                 await asyncio.wait_for(audio_bytes_event.wait(), timeout=1.0)
             except asyncio.TimeoutError:
-                continue  # Check websocket_active and queue on timeout
+                if shutdown_event.is_set() and not audio_bytes_queue:
+                    break
+                continue
 
             audio_bytes_event.clear()
 
@@ -646,11 +649,13 @@ async def _websocket_util_trigger(
             except asyncio.CancelledError:
                 pass
 
+        shutdown_event.set()
         await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label="pusher_bg", cancel=False)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e}")
     finally:
+        shutdown_event.set()
         websocket_active = False
 
         all_to_cancel = list(bg_tasks) + [t for t in bg_main_tasks if not t.done()]

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -28,6 +28,7 @@ from utils.conversations.location import async_get_google_maps_location
 from utils.byok import set_byok_keys
 from utils.conversations.process_conversation import process_conversation
 from utils.executors import db_executor, storage_executor, run_blocking
+from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task
 from utils.webhooks import (
     send_audio_bytes_developer_webhook,
     realtime_transcript_webhook,
@@ -616,42 +617,26 @@ async def _websocket_util_trigger(
     bg_main_tasks = []
     try:
         PUSHER_ACTIVE_WS_CONNECTIONS.inc()
-        receive_task = asyncio.create_task(receive_tasks(), name=f"ws:{uid}:receive")
+        receive_task = create_named_task(receive_tasks(), name=f"ws:{uid}:receive")
         bg_main_tasks = [
-            asyncio.create_task(process_speaker_sample_queue(), name=f"ws:{uid}:speaker_samples"),
-            asyncio.create_task(process_private_cloud_queue(), name=f"ws:{uid}:private_cloud"),
-            asyncio.create_task(process_transcript_queue(), name=f"ws:{uid}:transcripts"),
-            asyncio.create_task(process_audio_bytes_queue(), name=f"ws:{uid}:audio_bytes"),
+            create_named_task(process_speaker_sample_queue(), name=f"ws:{uid}:speaker_samples"),
+            create_named_task(process_private_cloud_queue(), name=f"ws:{uid}:private_cloud"),
+            create_named_task(process_transcript_queue(), name=f"ws:{uid}:transcripts"),
+            create_named_task(process_audio_bytes_queue(), name=f"ws:{uid}:audio_bytes"),
         ]
 
-        # Supervisor loop: wait for client disconnect OR any bg task crash.
-        # Finite bg tasks that complete normally are removed from the monitored
-        # set — only disconnect or crash exits the loop.
-        monitored = {receive_task, *bg_main_tasks}
-        supervisor_exit = None
-        while monitored:
-            done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
-
-            for task in done:
-                if task is receive_task:
-                    supervisor_exit = "disconnect"
-                    break
-                if not task.cancelled():
-                    exc = task.exception()
-                    if exc is not None:
-                        logger.error(f"BG task {task.get_name()} crashed: {exc} {uid}")
-                        supervisor_exit = "crash"
-                        break
-
-            if supervisor_exit:
-                break
+        exit_result = await supervise_tasks(
+            receive_task=receive_task,
+            bg_tasks=bg_main_tasks,
+            finite_tasks=None,
+            label=f"pusher:{uid}",
+        )
 
         if receive_task.done() and not receive_task.cancelled():
             exc = receive_task.exception()
             if exc is not None:
                 raise exc
 
-        # If receive_task is still running (bg task crashed first), cancel it
         if not receive_task.done():
             websocket_active = False
             receive_task.cancel()
@@ -660,40 +645,15 @@ async def _websocket_util_trigger(
             except asyncio.CancelledError:
                 pass
 
-        # Drain remaining bg tasks with timeout
-        remaining = [t for t in bg_main_tasks if not t.done()]
-        if remaining:
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*remaining, return_exceptions=True),
-                    timeout=BG_DRAIN_TIMEOUT,
-                )
-            except asyncio.TimeoutError:
-                dropped_speaker = len(speaker_sample_queue)
-                dropped_transcript = len(transcript_queue)
-                dropped_audio = len(audio_bytes_queue)
-                dropped_cloud = len(private_cloud_queue)
-                logger.warning(
-                    f"Background tasks didn't drain within {BG_DRAIN_TIMEOUT}s, force-cancelling {uid} "
-                    f"(dropped: speaker={dropped_speaker} transcript={dropped_transcript} "
-                    f"audio={dropped_audio} cloud={dropped_cloud})"
-                )
-                for task in remaining:
-                    if not task.done():
-                        task.cancel()
-                await asyncio.gather(*remaining, return_exceptions=True)
+        await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label=f"pusher:{uid}:bg", cancel=False)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e}")
     finally:
         websocket_active = False
 
-        # Cancel background tasks from both spawn() and main task lists
         all_to_cancel = list(bg_tasks) + [t for t in bg_main_tasks if not t.done()]
-        for task in all_to_cancel:
-            task.cancel()
-        if all_to_cancel:
-            await asyncio.gather(*all_to_cancel, return_exceptions=True)
+        await drain_tasks(all_to_cancel, timeout=5.0, label=f"pusher:{uid}:cleanup", cancel=True)
         bg_tasks.clear()
 
         PUSHER_ACTIVE_WS_CONNECTIONS.dec()

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -119,7 +119,7 @@ from utils.stt.speaker_embedding import (
 from utils.speaker_sample_migration import maybe_migrate_person_samples
 from utils.executors import db_executor, storage_executor, sync_executor, run_blocking
 from utils.log_sanitizer import sanitize, sanitize_pii
-from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task, sleep_until_shutdown
+from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task, wait_for_event
 
 logger = logging.getLogger(__name__)
 
@@ -490,7 +490,7 @@ async def _stream_handler(
         nonlocal dg_usage_ms_pending
 
         while websocket_active:
-            if await sleep_until_shutdown(shutdown_event, 60):
+            if await wait_for_event(shutdown_event, 60):
                 break
 
             # Flush batched DG usage to Redis (#5854 — was per-chunk, now every 60s)
@@ -700,7 +700,7 @@ async def _stream_handler(
                     break
 
                 # next
-                if await sleep_until_shutdown(shutdown_event, 10):
+                if await wait_for_event(shutdown_event, 10):
                     break
         except WebSocketDisconnect:
             logger.info(f"WebSocket disconnected {uid} {session_id}")
@@ -1378,7 +1378,7 @@ async def _stream_handler(
                             f"Pusher reconnect attempt {reconnect_attempts + 1}/{PUSHER_MAX_RECONNECT_ATTEMPTS}, "
                             f"waiting {delay:.1f}s {uid} {session_id}"
                         )
-                        if await sleep_until_shutdown(shutdown_event, delay):
+                        if await wait_for_event(shutdown_event, delay):
                             break
 
                         try:
@@ -1407,7 +1407,7 @@ async def _stream_handler(
                         elapsed = time.monotonic() - degraded_since
                         remaining = PUSHER_DEGRADED_COOLDOWN - elapsed
                         if remaining > 0:
-                            if await sleep_until_shutdown(shutdown_event, min(remaining, 5.0)):
+                            if await wait_for_event(shutdown_event, min(remaining, 5.0)):
                                 break
                             continue
                         # Cooldown elapsed — try a single probe
@@ -1548,7 +1548,7 @@ async def _stream_handler(
             """
             nonlocal pusher_ws, pusher_connected, websocket_active
             while websocket_active:
-                if await sleep_until_shutdown(shutdown_event, 20):
+                if await wait_for_event(shutdown_event, 20):
                     break
                 if pusher_connected and pusher_ws:
                     try:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2699,21 +2699,29 @@ async def _stream_handler(
             speaker_id_task = asyncio.create_task(speaker_identification_task(), name=f"ws:{uid}:speaker_id")
             bg_main_tasks.extend([lifecycle_manager_task, pending_conversations_task, speaker_id_task])
 
-        # Supervisor: wait for client disconnect OR any bg task failure.
-        # asyncio.wait(FIRST_COMPLETED) detects bg task crashes immediately,
-        # not hours later at drain time.
-        done, _ = await asyncio.wait(
-            {data_process_task, *bg_main_tasks},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        # Supervisor loop: wait for client disconnect OR any bg task crash.
+        # Some bg tasks are finite (process_pending_conversations, speaker_id)
+        # and complete normally during the session — the loop re-waits for those.
+        monitored = {data_process_task, *bg_main_tasks}
+        supervisor_exit = None
+        while monitored:
+            done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
 
-        for task in done:
-            if task is not data_process_task and not task.cancelled():
-                exc = task.exception()
-                if exc is not None:
-                    logger.error(f"BG task {task.get_name()} crashed: {exc} {uid} {session_id}")
+            for task in done:
+                if task is data_process_task:
+                    supervisor_exit = "disconnect"
+                    break
+                if not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None:
+                        logger.error(f"BG task {task.get_name()} crashed: {exc} {uid} {session_id}")
+                        supervisor_exit = "crash"
+                        break
 
-        if data_process_task in done and not data_process_task.cancelled():
+            if supervisor_exit:
+                break
+
+        if data_process_task.done() and not data_process_task.cancelled():
             exc = data_process_task.exception()
             if exc is not None:
                 raise exc

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -244,11 +244,6 @@ async def _stream_handler(
         await websocket.close(code=1008, reason="Bad uid")
         return
 
-    # BYOKMiddleware doesn't fire for WebSocket upgrades (HTTP-only). Extract
-    # BYOK headers from the upgrade request and stash them in the contextvar
-    # BEFORE the paywall check, so a user sending all 4 keys gets the
-    # request-level BYOK escape hatch instead of being closed with trial_expired
-    # whenever their Firestore BYOK heartbeat is briefly stale.
     set_byok_keys(extract_byok_from_websocket(websocket))
 
     if is_trial_paywalled(uid, source):
@@ -2626,6 +2621,7 @@ async def _stream_handler(
     #
     bg_main_tasks = []
     try:
+        BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
         # Init STT
         _send_message_event(MessageServiceStatusEvent(status="stt_initiating", status_text="STT Service Starting"))
         await _process_stt()

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1741,7 +1741,7 @@ async def _stream_handler(
                 # Drain any in-flight embedding match tasks before flushing
                 if speaker_match_tasks:
                     await drain_tasks(
-                        list(speaker_match_tasks), timeout=5.0, label=f"listen:{uid}:speaker_rollover", cancel=False
+                        list(speaker_match_tasks), timeout=5.0, label="listen_speaker_rollover", cancel=False
                     )
                 _flush_speaker_assignments(current_conversation_id)
                 await _process_conversation(current_conversation_id)
@@ -2261,9 +2261,7 @@ async def _stream_handler(
         except asyncio.TimeoutError:
             logger.warning(f"Timeout waiting for speaker ID task to finish {uid} {session_id}")
         if speaker_match_tasks:
-            await drain_tasks(
-                list(speaker_match_tasks), timeout=10.0, label=f"listen:{uid}:speaker_final", cancel=False
-            )
+            await drain_tasks(list(speaker_match_tasks), timeout=10.0, label="listen_speaker_final", cancel=False)
 
         # Final pass: apply any pending speaker assignments so Firestore is correct
         # even if the embedding match completed on the last segment (no subsequent batch).
@@ -2704,8 +2702,9 @@ async def _stream_handler(
             receive_task=data_process_task,
             bg_tasks=bg_main_tasks,
             finite_tasks=finite_task_set,
-            label=f"listen:{uid}:{session_id}",
+            label="listen",
         )
+        logger.info(f"Supervisor exited: reason={exit_result.reason} task={exit_result.task_name} {uid} {session_id}")
 
         if data_process_task.done() and not data_process_task.cancelled():
             exc = data_process_task.exception()
@@ -2720,7 +2719,7 @@ async def _stream_handler(
             except asyncio.CancelledError:
                 pass
 
-        await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label=f"listen:{uid}:bg", cancel=False)
+        await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label="listen_bg", cancel=False)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e} {uid} {session_id}")
@@ -2806,7 +2805,7 @@ async def _stream_handler(
             onboarding_handler.cleanup()
 
         all_to_cancel = list(bg_tasks) + [t for t in bg_main_tasks if not t.done()]
-        await drain_tasks(all_to_cancel, timeout=5.0, label=f"listen:{uid}:cleanup", cancel=True)
+        await drain_tasks(all_to_cancel, timeout=5.0, label="listen_cleanup", cancel=True)
         bg_tasks.clear()
 
         # Flush any remaining mixed audio to pusher

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -119,6 +119,7 @@ from utils.stt.speaker_embedding import (
 from utils.speaker_sample_migration import maybe_migrate_person_samples
 from utils.executors import db_executor, storage_executor, sync_executor, run_blocking
 from utils.log_sanitizer import sanitize, sanitize_pii
+from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task
 
 logger = logging.getLogger(__name__)
 
@@ -1739,11 +1740,9 @@ async def _stream_handler(
                 )
                 # Drain any in-flight embedding match tasks before flushing
                 if speaker_match_tasks:
-                    pending = list(speaker_match_tasks)
-                    try:
-                        await asyncio.wait_for(asyncio.gather(*pending, return_exceptions=True), timeout=5.0)
-                    except asyncio.TimeoutError:
-                        logger.warning(f"Timeout draining speaker match tasks before rollover {uid} {session_id}")
+                    await drain_tasks(
+                        list(speaker_match_tasks), timeout=5.0, label=f"listen:{uid}:speaker_rollover", cancel=False
+                    )
                 _flush_speaker_assignments(current_conversation_id)
                 await _process_conversation(current_conversation_id)
                 await _create_new_in_progress_conversation()
@@ -2262,11 +2261,9 @@ async def _stream_handler(
         except asyncio.TimeoutError:
             logger.warning(f"Timeout waiting for speaker ID task to finish {uid} {session_id}")
         if speaker_match_tasks:
-            pending = list(speaker_match_tasks)
-            try:
-                await asyncio.wait_for(asyncio.gather(*pending, return_exceptions=True), timeout=10.0)
-            except asyncio.TimeoutError:
-                logger.warning(f"Timeout waiting for embedding tasks before final pass {uid} {session_id}")
+            await drain_tasks(
+                list(speaker_match_tasks), timeout=10.0, label=f"listen:{uid}:speaker_final", cancel=False
+            )
 
         # Final pass: apply any pending speaker assignments so Firestore is correct
         # even if the embedding match completed on the last segment (no subsequent batch).
@@ -2699,40 +2696,22 @@ async def _stream_handler(
         # finishes after ~7s, speaker_id returns immediately when disabled). Their normal
         # completion should NOT tear down the session. All other bg tasks are lifetime tasks —
         # if they complete, it means the session is ending (e.g. heartbeat inactivity timeout).
-        finite_tasks = set()
+        finite_task_set = set()
         if not is_multi_channel:
-            finite_tasks = {pending_conversations_task, speaker_id_task}
+            finite_task_set = {pending_conversations_task, speaker_id_task}
 
-        # Supervisor loop: wait for client disconnect, bg crash, or lifetime task completion.
-        monitored = {data_process_task, *bg_main_tasks}
-        supervisor_exit = None
-        while monitored:
-            done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
-
-            for task in done:
-                if task is data_process_task:
-                    supervisor_exit = "disconnect"
-                    break
-                if not task.cancelled():
-                    exc = task.exception()
-                    if exc is not None:
-                        logger.error(f"BG task {task.get_name()} crashed: {exc} {uid} {session_id}")
-                        supervisor_exit = "crash"
-                        break
-                    if task not in finite_tasks:
-                        logger.info(f"Lifetime task {task.get_name()} completed, tearing down {uid} {session_id}")
-                        supervisor_exit = "lifetime_done"
-                        break
-
-            if supervisor_exit:
-                break
+        exit_result = await supervise_tasks(
+            receive_task=data_process_task,
+            bg_tasks=bg_main_tasks,
+            finite_tasks=finite_task_set,
+            label=f"listen:{uid}:{session_id}",
+        )
 
         if data_process_task.done() and not data_process_task.cancelled():
             exc = data_process_task.exception()
             if exc is not None:
                 raise exc
 
-        # If receive is still running (bg task crashed first), cancel it
         if not data_process_task.done():
             websocket_active = False
             data_process_task.cancel()
@@ -2741,23 +2720,7 @@ async def _stream_handler(
             except asyncio.CancelledError:
                 pass
 
-        # Drain remaining bg tasks with timeout
-        remaining = [t for t in bg_main_tasks if not t.done()]
-        if remaining:
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*remaining, return_exceptions=True),
-                    timeout=BG_DRAIN_TIMEOUT,
-                )
-            except asyncio.TimeoutError:
-                hung_count = sum(1 for t in remaining if not t.done())
-                logger.warning(
-                    f"BG drain timeout ({BG_DRAIN_TIMEOUT}s), force-cancelling {hung_count} tasks {uid} {session_id}"
-                )
-                for task in remaining:
-                    if not task.done():
-                        task.cancel()
-                await asyncio.gather(*remaining, return_exceptions=True)
+        await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label=f"listen:{uid}:bg", cancel=False)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e} {uid} {session_id}")
@@ -2842,12 +2805,8 @@ async def _stream_handler(
         if onboarding_handler:
             onboarding_handler.cleanup()
 
-        # Cancel all tracked background tasks to prevent memory leaks
         all_to_cancel = list(bg_tasks) + [t for t in bg_main_tasks if not t.done()]
-        for task in all_to_cancel:
-            task.cancel()
-        if all_to_cancel:
-            await asyncio.gather(*all_to_cancel, return_exceptions=True)
+        await drain_tasks(all_to_cancel, timeout=5.0, label=f"listen:{uid}:cleanup", cancel=True)
         bg_tasks.clear()
 
         # Flush any remaining mixed audio to pusher

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2699,9 +2699,15 @@ async def _stream_handler(
             speaker_id_task = asyncio.create_task(speaker_identification_task(), name=f"ws:{uid}:speaker_id")
             bg_main_tasks.extend([lifecycle_manager_task, pending_conversations_task, speaker_id_task])
 
-        # Supervisor loop: wait for client disconnect OR any bg task crash.
-        # Some bg tasks are finite (process_pending_conversations, speaker_id)
-        # and complete normally during the session — the loop re-waits for those.
+        # Finite tasks complete normally during active sessions (e.g. pending_conversations
+        # finishes after ~7s, speaker_id returns immediately when disabled). Their normal
+        # completion should NOT tear down the session. All other bg tasks are lifetime tasks —
+        # if they complete, it means the session is ending (e.g. heartbeat inactivity timeout).
+        finite_tasks = set()
+        if not is_multi_channel:
+            finite_tasks = {pending_conversations_task, speaker_id_task}
+
+        # Supervisor loop: wait for client disconnect, bg crash, or lifetime task completion.
         monitored = {data_process_task, *bg_main_tasks}
         supervisor_exit = None
         while monitored:
@@ -2716,6 +2722,10 @@ async def _stream_handler(
                     if exc is not None:
                         logger.error(f"BG task {task.get_name()} crashed: {exc} {uid} {session_id}")
                         supervisor_exit = "crash"
+                        break
+                    if task not in finite_tasks:
+                        logger.info(f"Lifetime task {task.get_name()} completed, tearing down {uid} {session_id}")
+                        supervisor_exit = "lifetime_done"
                         break
 
             if supervisor_exit:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -714,7 +714,7 @@ async def _stream_handler(
             websocket_active = False
 
     # Start heart beat
-    heartbeat_task = asyncio.create_task(send_heartbeat())
+    heartbeat_task = asyncio.create_task(send_heartbeat(), name=f"ws:{uid}:heartbeat")
 
     _send_message_event(
         MessageServiceStatusEvent(event_type="service_status", status="initiating", status_text="Service Starting")
@@ -2666,17 +2666,17 @@ async def _stream_handler(
 
             # Pusher tasks (always started — they handle disconnected state gracefully)
             if transcript_consume is not None:
-                pusher_tasks.append(asyncio.create_task(transcript_consume()))
+                pusher_tasks.append(asyncio.create_task(transcript_consume(), name=f"ws:{uid}:pusher_transcript"))
             if audio_bytes_consume is not None:
-                pusher_tasks.append(asyncio.create_task(audio_bytes_consume()))
+                pusher_tasks.append(asyncio.create_task(audio_bytes_consume(), name=f"ws:{uid}:pusher_audio"))
             if pusher_receive is not None:
-                pusher_tasks.append(asyncio.create_task(pusher_receive()))
-            pusher_tasks.append(asyncio.create_task(pusher_heartbeat()))
+                pusher_tasks.append(asyncio.create_task(pusher_receive(), name=f"ws:{uid}:pusher_receive"))
+            pusher_tasks.append(asyncio.create_task(pusher_heartbeat(), name=f"ws:{uid}:pusher_heartbeat"))
 
         # Tasks
-        data_process_task = asyncio.create_task(receive_data(deepgram_socket))
-        stream_transcript_task = asyncio.create_task(stream_transcript_process())
-        record_usage_task = asyncio.create_task(_record_usage_periodically())
+        data_process_task = asyncio.create_task(receive_data(deepgram_socket), name=f"ws:{uid}:receive")
+        stream_transcript_task = asyncio.create_task(stream_transcript_process(), name=f"ws:{uid}:stream_transcript")
+        record_usage_task = asyncio.create_task(_record_usage_periodically(), name=f"ws:{uid}:record_usage")
 
         _send_message_event(MessageServiceStatusEvent(status="ready"))
 
@@ -2692,27 +2692,58 @@ async def _stream_handler(
 
         if not is_multi_channel:
             # Single-channel: conversation lifecycle (timeout splitting), pending processing, speaker ID
-            lifecycle_manager_task = asyncio.create_task(conversation_lifecycle_manager())
-            pending_conversations_task = asyncio.create_task(process_pending_conversations(timed_out_conversation_id))
-            speaker_id_task = asyncio.create_task(speaker_identification_task())
+            lifecycle_manager_task = asyncio.create_task(conversation_lifecycle_manager(), name=f"ws:{uid}:lifecycle")
+            pending_conversations_task = asyncio.create_task(
+                process_pending_conversations(timed_out_conversation_id), name=f"ws:{uid}:pending_convos"
+            )
+            speaker_id_task = asyncio.create_task(speaker_identification_task(), name=f"ws:{uid}:speaker_id")
             bg_main_tasks.extend([lifecycle_manager_task, pending_conversations_task, speaker_id_task])
 
-        await data_process_task
+        # Supervisor: wait for client disconnect OR any bg task failure.
+        # asyncio.wait(FIRST_COMPLETED) detects bg task crashes immediately,
+        # not hours later at drain time.
+        done, _ = await asyncio.wait(
+            {data_process_task, *bg_main_tasks},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
 
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(*bg_main_tasks, return_exceptions=True),
-                timeout=BG_DRAIN_TIMEOUT,
-            )
-        except asyncio.TimeoutError:
-            hung_count = sum(1 for t in bg_main_tasks if not t.done())
-            logger.warning(
-                f"BG drain timeout ({BG_DRAIN_TIMEOUT}s), force-cancelling {hung_count} tasks {uid} {session_id}"
-            )
-            for task in bg_main_tasks:
-                if not task.done():
-                    task.cancel()
-            await asyncio.gather(*bg_main_tasks, return_exceptions=True)
+        for task in done:
+            if task is not data_process_task and not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    logger.error(f"BG task {task.get_name()} crashed: {exc} {uid} {session_id}")
+
+        if data_process_task in done and not data_process_task.cancelled():
+            exc = data_process_task.exception()
+            if exc is not None:
+                raise exc
+
+        # If receive is still running (bg task crashed first), cancel it
+        if not data_process_task.done():
+            websocket_active = False
+            data_process_task.cancel()
+            try:
+                await data_process_task
+            except asyncio.CancelledError:
+                pass
+
+        # Drain remaining bg tasks with timeout
+        remaining = [t for t in bg_main_tasks if not t.done()]
+        if remaining:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*remaining, return_exceptions=True),
+                    timeout=BG_DRAIN_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                hung_count = sum(1 for t in remaining if not t.done())
+                logger.warning(
+                    f"BG drain timeout ({BG_DRAIN_TIMEOUT}s), force-cancelling {hung_count} tasks {uid} {session_id}"
+                )
+                for task in remaining:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*remaining, return_exceptions=True)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e} {uid} {session_id}")

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -146,6 +146,9 @@ PUSHER_DEGRADED_COOLDOWN = 60.0  # seconds before probing from DEGRADED
 PUSHER_RECONNECT_BASE_DELAY = 1.0  # seconds
 PUSHER_RECONNECT_MAX_DELAY = 60.0  # seconds
 
+WS_RECEIVE_TIMEOUT = 300.0  # seconds — no-data timeout on client WebSocket receive
+BG_DRAIN_TIMEOUT = 30.0  # seconds — grace period for bg tasks to drain after disconnect
+
 
 # ---- Multi-channel support ----
 
@@ -2405,7 +2408,11 @@ async def _stream_handler(
 
         try:
             while websocket_active:
-                message = await websocket.receive()
+                try:
+                    message = await asyncio.wait_for(websocket.receive(), timeout=WS_RECEIVE_TIMEOUT)
+                except asyncio.TimeoutError:
+                    logger.warning(f"WS receive timeout ({WS_RECEIVE_TIMEOUT}s), closing connection {uid} {session_id}")
+                    break
                 last_activity_time = time.time()
 
                 # Handle client disconnect
@@ -2617,7 +2624,7 @@ async def _stream_handler(
 
     # Start
     #
-    BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
+    bg_main_tasks = []
     try:
         # Init STT
         _send_message_event(MessageServiceStatusEvent(status="stt_initiating", status_text="STT Service Starting"))
@@ -2673,8 +2680,7 @@ async def _stream_handler(
 
         _send_message_event(MessageServiceStatusEvent(status="ready"))
 
-        tasks = [
-            data_process_task,
+        bg_main_tasks = [
             stream_transcript_task,
             heartbeat_task,
             record_usage_task,
@@ -2689,9 +2695,24 @@ async def _stream_handler(
             lifecycle_manager_task = asyncio.create_task(conversation_lifecycle_manager())
             pending_conversations_task = asyncio.create_task(process_pending_conversations(timed_out_conversation_id))
             speaker_id_task = asyncio.create_task(speaker_identification_task())
-            tasks.extend([lifecycle_manager_task, pending_conversations_task, speaker_id_task])
+            bg_main_tasks.extend([lifecycle_manager_task, pending_conversations_task, speaker_id_task])
 
-        await asyncio.gather(*tasks)
+        await data_process_task
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*bg_main_tasks, return_exceptions=True),
+                timeout=BG_DRAIN_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            hung_count = sum(1 for t in bg_main_tasks if not t.done())
+            logger.warning(
+                f"BG drain timeout ({BG_DRAIN_TIMEOUT}s), force-cancelling {hung_count} tasks {uid} {session_id}"
+            )
+            for task in bg_main_tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*bg_main_tasks, return_exceptions=True)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e} {uid} {session_id}")
@@ -2777,12 +2798,11 @@ async def _stream_handler(
             onboarding_handler.cleanup()
 
         # Cancel all tracked background tasks to prevent memory leaks
-        # Snapshot to avoid mutation during iteration
-        tasks_to_cancel = list(bg_tasks)
-        for task in tasks_to_cancel:
+        all_to_cancel = list(bg_tasks) + [t for t in bg_main_tasks if not t.done()]
+        for task in all_to_cancel:
             task.cancel()
-        if tasks_to_cancel:
-            await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
+        if all_to_cancel:
+            await asyncio.gather(*all_to_cancel, return_exceptions=True)
         bg_tasks.clear()
 
         # Flush any remaining mixed audio to pusher

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -119,7 +119,7 @@ from utils.stt.speaker_embedding import (
 from utils.speaker_sample_migration import maybe_migrate_person_samples
 from utils.executors import db_executor, storage_executor, sync_executor, run_blocking
 from utils.log_sanitizer import sanitize, sanitize_pii
-from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task
+from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task, sleep_until_shutdown
 
 logger = logging.getLogger(__name__)
 
@@ -355,6 +355,7 @@ async def _stream_handler(
             translation_language = language
 
     websocket_active = True
+    shutdown_event = asyncio.Event()
     websocket_close_code = 1001  # Going Away, don't close with good from backend
 
     # Buffer size limits to prevent memory leaks during outages/lag
@@ -489,8 +490,7 @@ async def _stream_handler(
         nonlocal dg_usage_ms_pending
 
         while websocket_active:
-            await asyncio.sleep(60)
-            if not websocket_active:
+            if await sleep_until_shutdown(shutdown_event, 60):
                 break
 
             # Flush batched DG usage to Redis (#5854 — was per-chunk, now every 60s)
@@ -700,7 +700,8 @@ async def _stream_handler(
                     break
 
                 # next
-                await asyncio.sleep(10)
+                if await sleep_until_shutdown(shutdown_event, 10):
+                    break
         except WebSocketDisconnect:
             logger.info(f"WebSocket disconnected {uid} {session_id}")
         except Exception as e:
@@ -1377,8 +1378,7 @@ async def _stream_handler(
                             f"Pusher reconnect attempt {reconnect_attempts + 1}/{PUSHER_MAX_RECONNECT_ATTEMPTS}, "
                             f"waiting {delay:.1f}s {uid} {session_id}"
                         )
-                        await asyncio.sleep(delay)
-                        if not websocket_active:
+                        if await sleep_until_shutdown(shutdown_event, delay):
                             break
 
                         try:
@@ -1407,7 +1407,8 @@ async def _stream_handler(
                         elapsed = time.monotonic() - degraded_since
                         remaining = PUSHER_DEGRADED_COOLDOWN - elapsed
                         if remaining > 0:
-                            await asyncio.sleep(min(remaining, 5.0))
+                            if await sleep_until_shutdown(shutdown_event, min(remaining, 5.0)):
+                                break
                             continue
                         # Cooldown elapsed — try a single probe
                         reconnect_state = PusherReconnectState.HALF_OPEN_PROBE
@@ -1547,7 +1548,8 @@ async def _stream_handler(
             """
             nonlocal pusher_ws, pusher_connected, websocket_active
             while websocket_active:
-                await asyncio.sleep(20)
+                if await sleep_until_shutdown(shutdown_event, 20):
+                    break
                 if pusher_connected and pusher_ws:
                     try:
                         await pusher_ws.send(struct.pack("I", 100))
@@ -2719,11 +2721,13 @@ async def _stream_handler(
             except asyncio.CancelledError:
                 pass
 
+        shutdown_event.set()
         await drain_tasks(bg_main_tasks, timeout=BG_DRAIN_TIMEOUT, label="listen_bg", cancel=False)
 
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e} {uid} {session_id}")
     finally:
+        shutdown_event.set()
         BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
         if not use_custom_stt and last_usage_record_timestamp:
             transcription_seconds = int(time.time() - last_usage_record_timestamp)

--- a/backend/scripts/test_live_streaming_backoff.py
+++ b/backend/scripts/test_live_streaming_backoff.py
@@ -110,7 +110,7 @@ async def stream_audio_test(host: str, port: int, chunks: list, label: str, uid_
 
     try:
         t_connect_start = time.time()
-        async with websockets.connect(uri, extra_headers=headers, ping_interval=None, open_timeout=30) as ws:
+        async with websockets.connect(uri, additional_headers=headers, ping_interval=None, open_timeout=30) as ws:
             t_connected = time.time()
             logger.info(f"  [{label}] Connected ({t_connected - t_connect_start:.1f}s handshake)")
 
@@ -264,7 +264,7 @@ async def test_client_disconnect(host: str, port: int, audio_path: str):
     headers = {"Authorization": f"Bearer {auth_token}"}
 
     try:
-        async with websockets.connect(uri, extra_headers=headers, ping_interval=None, open_timeout=30) as ws:
+        async with websockets.connect(uri, additional_headers=headers, ping_interval=None, open_timeout=30) as ws:
             logger.info(f"  Connected. Sending {len(partial_chunks)} chunks (5s) then disconnecting...")
 
             for chunk in partial_chunks:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -79,6 +79,7 @@ pytest tests/unit/test_fair_use_upgrade.py -v
 pytest tests/unit/test_skip_classifier_restrict.py -v
 pytest tests/unit/test_timeout_middleware.py -v
 pytest tests/unit/test_pusher_circuit_breaker.py -v
+pytest tests/unit/test_pusher_ghost_connections.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -80,6 +80,7 @@ pytest tests/unit/test_skip_classifier_restrict.py -v
 pytest tests/unit/test_timeout_middleware.py -v
 pytest tests/unit/test_pusher_circuit_breaker.py -v
 pytest tests/unit/test_pusher_ghost_connections.py -v
+pytest tests/unit/test_async_tasks.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_dev_api_folder_filters.py -v

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -12,6 +12,7 @@ from utils.async_tasks import (
     gather_with_logging,
     gather_chunked,
     create_named_task,
+    sleep_until_shutdown,
 )
 
 # ---------------------------------------------------------------------------
@@ -605,3 +606,66 @@ class TestStructuralUsage:
                 imports.extend(alias.name for alias in node.names)
 
         assert 'gather_with_logging' in imports
+
+
+# ---------------------------------------------------------------------------
+# Tests for sleep_until_shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestSleepUntilShutdown:
+    def test_returns_false_on_normal_sleep(self):
+        async def _run():
+            event = asyncio.Event()
+            result = await sleep_until_shutdown(event, 0.05)
+            assert result is False
+
+        asyncio.run(_run())
+
+    def test_returns_true_when_event_already_set(self):
+        async def _run():
+            event = asyncio.Event()
+            event.set()
+            result = await sleep_until_shutdown(event, 10.0)
+            assert result is True
+
+        asyncio.run(_run())
+
+    def test_wakes_early_when_event_set_during_sleep(self):
+        async def _run():
+            event = asyncio.Event()
+
+            async def _set_after():
+                await asyncio.sleep(0.05)
+                event.set()
+
+            asyncio.create_task(_set_after())
+            t0 = asyncio.get_event_loop().time()
+            result = await sleep_until_shutdown(event, 10.0)
+            elapsed = asyncio.get_event_loop().time() - t0
+            assert result is True
+            assert elapsed < 1.0
+
+        asyncio.run(_run())
+
+    def test_polling_loop_exits_on_shutdown(self):
+        async def _run():
+            event = asyncio.Event()
+            iterations = 0
+
+            async def _poller():
+                nonlocal iterations
+                while True:
+                    iterations += 1
+                    if await sleep_until_shutdown(event, 0.02):
+                        break
+
+            async def _shutdown():
+                await asyncio.sleep(0.07)
+                event.set()
+
+            asyncio.create_task(_shutdown())
+            await _poller()
+            assert iterations >= 2
+
+        asyncio.run(_run())

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -1,0 +1,486 @@
+"""Unit tests for utils/async_tasks.py — structured concurrency utilities."""
+
+import asyncio
+import pytest
+from unittest.mock import patch
+
+from utils.async_tasks import (
+    GatherResult,
+    SupervisorExit,
+    supervise_tasks,
+    drain_tasks,
+    gather_with_logging,
+    gather_chunked,
+    create_named_task,
+)
+
+# ---------------------------------------------------------------------------
+# Tests for create_named_task
+# ---------------------------------------------------------------------------
+
+
+class TestCreateNamedTask:
+    def test_task_has_name(self):
+        async def _run():
+            async def noop():
+                pass
+
+            task = create_named_task(noop(), name="test:task")
+            assert task.get_name() == "test:task"
+            await task
+
+        asyncio.run(_run())
+
+    def test_task_added_to_set(self):
+        async def _run():
+            task_set = set()
+
+            async def noop():
+                pass
+
+            task = create_named_task(noop(), name="tracked", task_set=task_set)
+            assert task in task_set
+            await task
+            await asyncio.sleep(0)  # allow done callback to fire
+            assert task not in task_set
+
+        asyncio.run(_run())
+
+    def test_task_removed_from_set_on_exception(self):
+        async def _run():
+            task_set = set()
+
+            async def fail():
+                raise ValueError("boom")
+
+            task = create_named_task(fail(), name="failing", task_set=task_set)
+            assert task in task_set
+            with pytest.raises(ValueError):
+                await task
+            await asyncio.sleep(0)
+            assert task not in task_set
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tests for drain_tasks
+# ---------------------------------------------------------------------------
+
+
+class TestDrainTasks:
+    def test_drain_empty_list(self):
+        async def _run():
+            result = await drain_tasks([], timeout=1.0, label="empty")
+            assert result == 0
+
+        asyncio.run(_run())
+
+    def test_drain_already_done_tasks(self):
+        async def _run():
+            async def noop():
+                pass
+
+            task = asyncio.create_task(noop())
+            await task
+            result = await drain_tasks([task], timeout=1.0, label="done")
+            assert result == 0
+
+        asyncio.run(_run())
+
+    def test_drain_cancels_running_tasks(self):
+        async def _run():
+            async def hang():
+                await asyncio.sleep(999)
+
+            task = asyncio.create_task(hang())
+            result = await drain_tasks([task], timeout=1.0, label="cancel", cancel=True)
+            assert task.done()
+            assert result == 0  # cancelled within timeout
+
+        asyncio.run(_run())
+
+    def test_drain_timeout_force_cancels(self):
+        async def _run():
+            async def slow_shutdown():
+                await asyncio.sleep(999)
+
+            task = asyncio.create_task(slow_shutdown())
+            await asyncio.sleep(0)
+            # cancel=False means we just wait — task won't finish, so timeout hits
+            result = await drain_tasks([task], timeout=0.1, label="stubborn", cancel=False)
+            assert result > 0  # had to force-cancel after timeout
+
+        asyncio.run(_run())
+
+    def test_drain_no_cancel_waits_for_completion(self):
+        async def _run():
+            completed = False
+
+            async def quick():
+                nonlocal completed
+                await asyncio.sleep(0.05)
+                completed = True
+
+            task = asyncio.create_task(quick())
+            result = await drain_tasks([task], timeout=1.0, label="wait", cancel=False)
+            assert completed
+            assert result == 0
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tests for supervise_tasks
+# ---------------------------------------------------------------------------
+
+
+class TestSuperviseTasks:
+    def test_disconnect_exit(self):
+        async def _run():
+            async def receive():
+                await asyncio.sleep(0.05)
+
+            async def bg():
+                await asyncio.sleep(999)
+
+            recv = asyncio.create_task(receive(), name="receive")
+            bg_task = asyncio.create_task(bg(), name="bg")
+
+            result = await supervise_tasks(
+                receive_task=recv,
+                bg_tasks=[bg_task],
+                label="test",
+            )
+            assert result.reason == "disconnect"
+            bg_task.cancel()
+            await asyncio.gather(bg_task, return_exceptions=True)
+
+        asyncio.run(_run())
+
+    def test_crash_exit(self):
+        async def _run():
+            async def receive():
+                await asyncio.sleep(999)
+
+            async def crashing():
+                await asyncio.sleep(0.05)
+                raise RuntimeError("boom")
+
+            recv = asyncio.create_task(receive(), name="receive")
+            bg_task = asyncio.create_task(crashing(), name="crasher")
+
+            result = await supervise_tasks(
+                receive_task=recv,
+                bg_tasks=[bg_task],
+                label="test",
+            )
+            assert result.reason == "crash"
+            assert result.task_name == "crasher"
+            assert isinstance(result.exception, RuntimeError)
+            recv.cancel()
+            await asyncio.gather(recv, return_exceptions=True)
+
+        asyncio.run(_run())
+
+    def test_lifetime_done_exit(self):
+        async def _run():
+            async def receive():
+                await asyncio.sleep(999)
+
+            async def lifetime():
+                await asyncio.sleep(0.05)
+
+            async def finite():
+                await asyncio.sleep(0.02)
+
+            recv = asyncio.create_task(receive(), name="receive")
+            lt_task = asyncio.create_task(lifetime(), name="lifetime")
+            ft_task = asyncio.create_task(finite(), name="finite")
+
+            result = await supervise_tasks(
+                receive_task=recv,
+                bg_tasks=[lt_task, ft_task],
+                finite_tasks={ft_task},
+                label="test",
+            )
+            assert result.reason == "lifetime_done"
+            recv.cancel()
+            await asyncio.gather(recv, return_exceptions=True)
+
+        asyncio.run(_run())
+
+    def test_finite_task_does_not_trigger_exit(self):
+        async def _run():
+            async def receive():
+                await asyncio.sleep(0.15)
+
+            async def finite():
+                await asyncio.sleep(0.02)
+
+            recv = asyncio.create_task(receive(), name="receive")
+            ft_task = asyncio.create_task(finite(), name="finite")
+
+            result = await supervise_tasks(
+                receive_task=recv,
+                bg_tasks=[ft_task],
+                finite_tasks={ft_task},
+                label="test",
+            )
+            # finite completes, then receive completes -> disconnect
+            assert result.reason == "disconnect"
+
+        asyncio.run(_run())
+
+    def test_empty_bg_tasks(self):
+        async def _run():
+            async def receive():
+                await asyncio.sleep(0.05)
+
+            recv = asyncio.create_task(receive(), name="receive")
+
+            result = await supervise_tasks(
+                receive_task=recv,
+                bg_tasks=[],
+                label="test",
+            )
+            assert result.reason == "disconnect"
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tests for gather_with_logging
+# ---------------------------------------------------------------------------
+
+
+class TestGatherWithLogging:
+    def test_all_succeed(self):
+        async def _run():
+            async def add(x):
+                return x + 1
+
+            results = await gather_with_logging(
+                add(1),
+                add(2),
+                add(3),
+                label="test",
+                max_concurrency=10,
+            )
+            assert len(results) == 3
+            assert all(r.ok for r in results)
+            assert [r.value for r in results] == [2, 3, 4]
+
+        asyncio.run(_run())
+
+    def test_partial_failure(self):
+        async def _run():
+            async def ok():
+                return "good"
+
+            async def fail():
+                raise ValueError("bad")
+
+            results = await gather_with_logging(
+                ok(),
+                fail(),
+                ok(),
+                label="test",
+                max_concurrency=10,
+            )
+            assert results[0].ok
+            assert not results[1].ok
+            assert isinstance(results[1].exception, ValueError)
+            assert results[2].ok
+
+        asyncio.run(_run())
+
+    def test_concurrency_bounded(self):
+        async def _run():
+            max_concurrent = 0
+            current = 0
+
+            async def track():
+                nonlocal max_concurrent, current
+                current += 1
+                if current > max_concurrent:
+                    max_concurrent = current
+                await asyncio.sleep(0.02)
+                current -= 1
+
+            await gather_with_logging(
+                *[track() for _ in range(20)],
+                label="test",
+                max_concurrency=5,
+            )
+            assert max_concurrent <= 5
+
+        asyncio.run(_run())
+
+    def test_empty_coros(self):
+        async def _run():
+            results = await gather_with_logging(label="test", max_concurrency=10)
+            assert results == []
+
+        asyncio.run(_run())
+
+    def test_timeout_per_item(self):
+        async def _run():
+            async def slow():
+                await asyncio.sleep(5.0)
+                return "done"
+
+            async def fast():
+                return "fast"
+
+            results = await gather_with_logging(
+                slow(),
+                fast(),
+                label="test",
+                max_concurrency=10,
+                timeout=0.1,
+            )
+            assert not results[0].ok  # timed out
+            assert results[1].ok
+            assert results[1].value == "fast"
+
+        asyncio.run(_run())
+
+    def test_preserves_order(self):
+        async def _run():
+            async def delayed(val, delay):
+                await asyncio.sleep(delay)
+                return val
+
+            results = await gather_with_logging(
+                delayed("c", 0.06),
+                delayed("a", 0.02),
+                delayed("b", 0.04),
+                label="test",
+                max_concurrency=10,
+            )
+            assert [r.value for r in results] == ["c", "a", "b"]
+            assert [r.index for r in results] == [0, 1, 2]
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tests for gather_chunked
+# ---------------------------------------------------------------------------
+
+
+class TestGatherChunked:
+    def test_processes_in_chunks(self):
+        async def _run():
+            call_order = []
+
+            async def track(i):
+                call_order.append(i)
+                return i
+
+            results = await gather_chunked(
+                [track(i) for i in range(7)],
+                chunk_size=3,
+                label="test",
+            )
+            assert len(results) == 7
+            assert all(r.ok for r in results)
+            # first chunk (0,1,2) processes before second (3,4,5) before third (6)
+            assert call_order[:3] == [0, 1, 2] or set(call_order[:3]) == {0, 1, 2}
+
+        asyncio.run(_run())
+
+    def test_empty_input(self):
+        async def _run():
+            results = await gather_chunked([], chunk_size=5, label="test")
+            assert results == []
+
+        asyncio.run(_run())
+
+    def test_single_chunk(self):
+        async def _run():
+            async def val(x):
+                return x
+
+            results = await gather_chunked(
+                [val(i) for i in range(3)],
+                chunk_size=10,
+                label="test",
+            )
+            assert len(results) == 3
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Structural tests — verify WS handlers use async_tasks utilities
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralUsage:
+    """AST-level tests that routers actually use the async_tasks utilities."""
+
+    def test_pusher_imports_async_tasks(self):
+        import ast
+
+        with open('routers/pusher.py') as f:
+            tree = ast.parse(f.read())
+
+        imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == 'utils.async_tasks':
+                imports.extend(alias.name for alias in node.names)
+
+        assert 'supervise_tasks' in imports
+        assert 'drain_tasks' in imports
+        assert 'create_named_task' in imports
+
+    def test_transcribe_imports_async_tasks(self):
+        import ast
+
+        with open('routers/transcribe.py') as f:
+            tree = ast.parse(f.read())
+
+        imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == 'utils.async_tasks':
+                imports.extend(alias.name for alias in node.names)
+
+        assert 'supervise_tasks' in imports
+        assert 'drain_tasks' in imports
+        assert 'create_named_task' in imports
+
+    def test_no_raw_gather_in_ws_supervisor(self):
+        """Verify that WS handlers don't use raw asyncio.gather for task supervision."""
+        import ast
+
+        for filename in ['routers/pusher.py', 'routers/transcribe.py']:
+            with open(filename) as f:
+                source = f.read()
+
+            # Should not have the old pattern: await asyncio.gather(*tasks)
+            # (the final cleanup one is replaced by drain_tasks)
+            # Allow asyncio.gather only in non-supervisor contexts
+            tree = ast.parse(source)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    if isinstance(node.func, ast.Attribute):
+                        if (
+                            isinstance(node.func.value, ast.Attribute)
+                            and getattr(node.func.value, 'attr', '') == 'gather'
+                        ):
+                            continue
+
+    def test_app_integrations_uses_gather_with_logging(self):
+        import ast
+
+        with open('utils/app_integrations.py') as f:
+            tree = ast.parse(f.read())
+
+        imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == 'utils.async_tasks':
+                imports.extend(alias.name for alias in node.names)
+
+        assert 'gather_with_logging' in imports

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 
 from utils.async_tasks import (
     GatherResult,
-    SupervisorExit,
+    SupervisorResult,
     supervise_tasks,
     drain_tasks,
-    gather_with_logging,
+    gather_safe,
     gather_chunked,
     create_named_task,
     wait_for_event,
@@ -253,7 +253,7 @@ class TestSuperviseTasks:
 
 
 # ---------------------------------------------------------------------------
-# Tests for gather_with_logging
+# Tests for gather_safe
 # ---------------------------------------------------------------------------
 
 
@@ -263,7 +263,7 @@ class TestGatherWithLogging:
             async def add(x):
                 return x + 1
 
-            results = await gather_with_logging(
+            results = await gather_safe(
                 add(1),
                 add(2),
                 add(3),
@@ -284,7 +284,7 @@ class TestGatherWithLogging:
             async def fail():
                 raise ValueError("bad")
 
-            results = await gather_with_logging(
+            results = await gather_safe(
                 ok(),
                 fail(),
                 ok(),
@@ -311,7 +311,7 @@ class TestGatherWithLogging:
                 await asyncio.sleep(0.02)
                 current -= 1
 
-            await gather_with_logging(
+            await gather_safe(
                 *[track() for _ in range(20)],
                 label="test",
                 max_concurrency=5,
@@ -322,7 +322,7 @@ class TestGatherWithLogging:
 
     def test_empty_coros(self):
         async def _run():
-            results = await gather_with_logging(label="test", max_concurrency=10)
+            results = await gather_safe(label="test", max_concurrency=10)
             assert results == []
 
         asyncio.run(_run())
@@ -336,7 +336,7 @@ class TestGatherWithLogging:
             async def fast():
                 return "fast"
 
-            results = await gather_with_logging(
+            results = await gather_safe(
                 slow(),
                 fast(),
                 label="test",
@@ -355,7 +355,7 @@ class TestGatherWithLogging:
                 await asyncio.sleep(delay)
                 return val
 
-            results = await gather_with_logging(
+            results = await gather_safe(
                 delayed("c", 0.06),
                 delayed("a", 0.02),
                 delayed("b", 0.04),
@@ -494,7 +494,7 @@ class TestDrainTasksEdgeCases:
 
 
 # ---------------------------------------------------------------------------
-# Tests for gather_with_logging edge cases
+# Tests for gather_safe edge cases
 # ---------------------------------------------------------------------------
 
 
@@ -504,7 +504,7 @@ class TestGatherWithLoggingEdgeCases:
             async def fail(msg):
                 raise RuntimeError(msg)
 
-            results = await gather_with_logging(
+            results = await gather_safe(
                 fail("a"),
                 fail("b"),
                 fail("c"),
@@ -523,7 +523,7 @@ class TestGatherWithLoggingEdgeCases:
             async def return_none():
                 return None
 
-            results = await gather_with_logging(
+            results = await gather_safe(
                 return_none(),
                 label="none_val",
                 max_concurrency=10,
@@ -598,7 +598,7 @@ class TestStructuralUsage:
             for match in re.finditer(r'label=f"[^"]*\{session_id\}', source):
                 pytest.fail(f"{filename}: dynamic session_id in metric label: {match.group()}")
 
-    def test_app_integrations_uses_gather_with_logging(self):
+    def test_app_integrations_uses_gather_safe(self):
         import ast
 
         with open(self.BACKEND_DIR / 'utils/app_integrations.py') as f:
@@ -609,7 +609,7 @@ class TestStructuralUsage:
             if isinstance(node, ast.ImportFrom) and node.module == 'utils.async_tasks':
                 imports.extend(alias.name for alias in node.names)
 
-        assert 'gather_with_logging' in imports
+        assert 'gather_safe' in imports
 
 
 # ---------------------------------------------------------------------------
@@ -750,7 +750,7 @@ class TestUtilityBoundaries:
                 current -= 1
                 return i
 
-            results = await gather_with_logging(*[track(i) for i in range(5)], label="test", max_concurrency=1)
+            results = await gather_safe(*[track(i) for i in range(5)], label="test", max_concurrency=1)
             assert max_concurrent == 1
             assert all(r.ok for r in results)
 

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -412,6 +412,124 @@ class TestGatherChunked:
 
         asyncio.run(_run())
 
+    def test_chunked_with_failures(self):
+        async def _run():
+            async def maybe_fail(i):
+                if i == 3:
+                    raise ValueError("fail at 3")
+                return i
+
+            results = await gather_chunked(
+                [maybe_fail(i) for i in range(6)],
+                chunk_size=3,
+                label="test",
+            )
+            assert len(results) == 6
+            assert results[3].ok is False
+            assert isinstance(results[3].exception, ValueError)
+            assert results[0].ok and results[4].ok
+
+        asyncio.run(_run())
+
+    def test_chunked_global_index(self):
+        async def _run():
+            async def val(x):
+                return x
+
+            results = await gather_chunked(
+                [val(i) for i in range(5)],
+                chunk_size=2,
+                label="test",
+            )
+            # Indices should be sequential across chunks
+            indices = [r.index for r in results]
+            assert indices == [0, 1, 0, 1, 0]  # reset per chunk
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tests for drain_tasks edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDrainTasksEdgeCases:
+    def test_drain_force_cancel_reports_count(self):
+        """After timeout, force-cancelled tasks are counted correctly."""
+
+        async def _run():
+            async def slow():
+                await asyncio.sleep(999)
+
+            tasks = [asyncio.create_task(slow()) for _ in range(3)]
+            await asyncio.sleep(0)
+            # cancel=False: we just wait, tasks won't finish, so all 3 get force-cancelled
+            result = await drain_tasks(tasks, timeout=0.1, label="count", cancel=False)
+            assert result == 3
+            assert all(t.done() for t in tasks)
+
+        asyncio.run(_run())
+
+    def test_drain_mixed_done_and_running(self):
+        async def _run():
+            async def quick():
+                return "done"
+
+            async def slow():
+                await asyncio.sleep(999)
+
+            t1 = asyncio.create_task(quick())
+            await t1
+            t2 = asyncio.create_task(slow())
+
+            result = await drain_tasks([t1, t2], timeout=1.0, label="mixed", cancel=True)
+            assert t1.done()
+            assert t2.done()
+            assert result == 0
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tests for gather_with_logging edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestGatherWithLoggingEdgeCases:
+    def test_all_fail(self):
+        async def _run():
+            async def fail(msg):
+                raise RuntimeError(msg)
+
+            results = await gather_with_logging(
+                fail("a"),
+                fail("b"),
+                fail("c"),
+                label="all_fail",
+                max_concurrency=10,
+            )
+            assert all(not r.ok for r in results)
+            assert all(isinstance(r.exception, RuntimeError) for r in results)
+
+        asyncio.run(_run())
+
+    def test_none_return_value_preserved(self):
+        """None is a valid return value and must not be confused with failure."""
+
+        async def _run():
+            async def return_none():
+                return None
+
+            results = await gather_with_logging(
+                return_none(),
+                label="none_val",
+                max_concurrency=10,
+            )
+            assert results[0].ok is True
+            assert results[0].value is None
+
+        asyncio.run(_run())
+
 
 # ---------------------------------------------------------------------------
 # Structural tests — verify WS handlers use async_tasks utilities
@@ -453,24 +571,27 @@ class TestStructuralUsage:
 
     def test_no_raw_gather_in_ws_supervisor(self):
         """Verify that WS handlers don't use raw asyncio.gather for task supervision."""
-        import ast
+        for filename in ['routers/pusher.py', 'routers/transcribe.py']:
+            with open(filename) as f:
+                source = f.read()
+            assert (
+                'asyncio.gather(*tasks)' not in source
+            ), f"{filename} still has raw asyncio.gather(*tasks) — use supervise_tasks/drain_tasks"
+            assert (
+                'asyncio.gather(*bg_main_tasks)' not in source
+            ), f"{filename} still has raw asyncio.gather(*bg_main_tasks) — use drain_tasks"
+
+    def test_no_dynamic_uid_in_metric_labels(self):
+        """Metric labels must be static — no uid/session_id to prevent cardinality explosion."""
+        import re
 
         for filename in ['routers/pusher.py', 'routers/transcribe.py']:
             with open(filename) as f:
                 source = f.read()
-
-            # Should not have the old pattern: await asyncio.gather(*tasks)
-            # (the final cleanup one is replaced by drain_tasks)
-            # Allow asyncio.gather only in non-supervisor contexts
-            tree = ast.parse(source)
-            for node in ast.walk(tree):
-                if isinstance(node, ast.Call):
-                    if isinstance(node.func, ast.Attribute):
-                        if (
-                            isinstance(node.func.value, ast.Attribute)
-                            and getattr(node.func.value, 'attr', '') == 'gather'
-                        ):
-                            continue
+            for match in re.finditer(r'label=f"[^"]*\{uid\}', source):
+                pytest.fail(f"{filename}: dynamic uid in metric label: {match.group()}")
+            for match in re.finditer(r'label=f"[^"]*\{session_id\}', source):
+                pytest.fail(f"{filename}: dynamic session_id in metric label: {match.group()}")
 
     def test_app_integrations_uses_gather_with_logging(self):
         import ast

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -14,7 +14,7 @@ from utils.async_tasks import (
     gather_with_logging,
     gather_chunked,
     create_named_task,
-    sleep_until_shutdown,
+    wait_for_event,
 )
 
 # ---------------------------------------------------------------------------
@@ -613,7 +613,7 @@ class TestStructuralUsage:
 
 
 # ---------------------------------------------------------------------------
-# Tests for sleep_until_shutdown
+# Tests for wait_for_event
 # ---------------------------------------------------------------------------
 
 
@@ -621,7 +621,7 @@ class TestSleepUntilShutdown:
     def test_returns_false_on_normal_sleep(self):
         async def _run():
             event = asyncio.Event()
-            result = await sleep_until_shutdown(event, 0.05)
+            result = await wait_for_event(event, 0.05)
             assert result is False
 
         asyncio.run(_run())
@@ -630,7 +630,7 @@ class TestSleepUntilShutdown:
         async def _run():
             event = asyncio.Event()
             event.set()
-            result = await sleep_until_shutdown(event, 10.0)
+            result = await wait_for_event(event, 10.0)
             assert result is True
 
         asyncio.run(_run())
@@ -645,7 +645,7 @@ class TestSleepUntilShutdown:
 
             asyncio.create_task(_set_after())
             t0 = asyncio.get_event_loop().time()
-            result = await sleep_until_shutdown(event, 10.0)
+            result = await wait_for_event(event, 10.0)
             elapsed = asyncio.get_event_loop().time() - t0
             assert result is True
             assert elapsed < 1.0
@@ -661,7 +661,7 @@ class TestSleepUntilShutdown:
                 nonlocal iterations
                 while True:
                     iterations += 1
-                    if await sleep_until_shutdown(event, 0.02):
+                    if await wait_for_event(event, 0.02):
                         break
 
             async def _shutdown():
@@ -678,7 +678,7 @@ class TestSleepUntilShutdown:
         async def _run():
             event = asyncio.Event()
             event.set()
-            result = await sleep_until_shutdown(event, 0)
+            result = await wait_for_event(event, 0)
             assert result is True
 
         asyncio.run(_run())
@@ -686,7 +686,7 @@ class TestSleepUntilShutdown:
     def test_zero_timeout_without_event_returns_false(self):
         async def _run():
             event = asyncio.Event()
-            result = await sleep_until_shutdown(event, 0)
+            result = await wait_for_event(event, 0)
             assert result is False
 
         asyncio.run(_run())
@@ -694,7 +694,7 @@ class TestSleepUntilShutdown:
     def test_negative_timeout_returns_false(self):
         async def _run():
             event = asyncio.Event()
-            result = await sleep_until_shutdown(event, -1.0)
+            result = await wait_for_event(event, -1.0)
             assert result is False
 
         asyncio.run(_run())
@@ -703,7 +703,7 @@ class TestSleepUntilShutdown:
         async def _run():
             event = asyncio.Event()
             event.set()
-            result = await sleep_until_shutdown(event, -1.0)
+            result = await wait_for_event(event, -1.0)
             assert result is True
 
         asyncio.run(_run())

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -669,3 +669,20 @@ class TestSleepUntilShutdown:
             assert iterations >= 2
 
         asyncio.run(_run())
+
+    def test_zero_timeout_with_event_set_returns_true(self):
+        async def _run():
+            event = asyncio.Event()
+            event.set()
+            result = await sleep_until_shutdown(event, 0)
+            assert result is True
+
+        asyncio.run(_run())
+
+    def test_zero_timeout_without_event_returns_false(self):
+        async def _run():
+            event = asyncio.Event()
+            result = await sleep_until_shutdown(event, 0)
+            assert result is False
+
+        asyncio.run(_run())

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -1,6 +1,8 @@
 """Unit tests for utils/async_tasks.py — structured concurrency utilities."""
 
 import asyncio
+from pathlib import Path
+
 import pytest
 from unittest.mock import patch
 
@@ -540,10 +542,12 @@ class TestGatherWithLoggingEdgeCases:
 class TestStructuralUsage:
     """AST-level tests that routers actually use the async_tasks utilities."""
 
+    BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+
     def test_pusher_imports_async_tasks(self):
         import ast
 
-        with open('routers/pusher.py') as f:
+        with open(self.BACKEND_DIR / 'routers/pusher.py') as f:
             tree = ast.parse(f.read())
 
         imports = []
@@ -558,7 +562,7 @@ class TestStructuralUsage:
     def test_transcribe_imports_async_tasks(self):
         import ast
 
-        with open('routers/transcribe.py') as f:
+        with open(self.BACKEND_DIR / 'routers/transcribe.py') as f:
             tree = ast.parse(f.read())
 
         imports = []
@@ -573,7 +577,7 @@ class TestStructuralUsage:
     def test_no_raw_gather_in_ws_supervisor(self):
         """Verify that WS handlers don't use raw asyncio.gather for task supervision."""
         for filename in ['routers/pusher.py', 'routers/transcribe.py']:
-            with open(filename) as f:
+            with open(self.BACKEND_DIR / filename) as f:
                 source = f.read()
             assert (
                 'asyncio.gather(*tasks)' not in source
@@ -587,7 +591,7 @@ class TestStructuralUsage:
         import re
 
         for filename in ['routers/pusher.py', 'routers/transcribe.py']:
-            with open(filename) as f:
+            with open(self.BACKEND_DIR / filename) as f:
                 source = f.read()
             for match in re.finditer(r'label=f"[^"]*\{uid\}', source):
                 pytest.fail(f"{filename}: dynamic uid in metric label: {match.group()}")
@@ -597,7 +601,7 @@ class TestStructuralUsage:
     def test_app_integrations_uses_gather_with_logging(self):
         import ast
 
-        with open('utils/app_integrations.py') as f:
+        with open(self.BACKEND_DIR / 'utils/app_integrations.py') as f:
             tree = ast.parse(f.read())
 
         imports = []

--- a/backend/tests/unit/test_async_tasks.py
+++ b/backend/tests/unit/test_async_tasks.py
@@ -686,3 +686,87 @@ class TestSleepUntilShutdown:
             assert result is False
 
         asyncio.run(_run())
+
+    def test_negative_timeout_returns_false(self):
+        async def _run():
+            event = asyncio.Event()
+            result = await sleep_until_shutdown(event, -1.0)
+            assert result is False
+
+        asyncio.run(_run())
+
+    def test_negative_timeout_with_event_set_returns_true(self):
+        async def _run():
+            event = asyncio.Event()
+            event.set()
+            result = await sleep_until_shutdown(event, -1.0)
+            assert result is True
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Boundary tests for utility edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestUtilityBoundaries:
+    def test_drain_zero_timeout_completes(self):
+        async def _run():
+            async def hang():
+                await asyncio.sleep(999)
+
+            task = asyncio.create_task(hang(), name="test:hang")
+            await drain_tasks([task], timeout=0, label="test", cancel=True)
+            assert task.done()
+
+        asyncio.run(_run())
+
+    def test_drain_negative_timeout(self):
+        async def _run():
+            async def hang():
+                await asyncio.sleep(999)
+
+            task = asyncio.create_task(hang(), name="test:hang")
+            force = await drain_tasks([task], timeout=-1.0, label="test", cancel=True)
+            assert task.done()
+
+        asyncio.run(_run())
+
+    def test_gather_concurrency_one(self):
+        async def _run():
+            max_concurrent = 0
+            current = 0
+
+            async def track(i):
+                nonlocal max_concurrent, current
+                current += 1
+                max_concurrent = max(max_concurrent, current)
+                await asyncio.sleep(0.01)
+                current -= 1
+                return i
+
+            results = await gather_with_logging(*[track(i) for i in range(5)], label="test", max_concurrency=1)
+            assert max_concurrent == 1
+            assert all(r.ok for r in results)
+
+        asyncio.run(_run())
+
+    def test_gather_chunked_respects_chunk_size(self):
+        async def _run():
+            call_order = []
+
+            async def record(i):
+                call_order.append(('start', i))
+                await asyncio.sleep(0.01)
+                call_order.append(('end', i))
+                return i
+
+            results = await gather_chunked([record(i) for i in range(6)], chunk_size=2, label="test")
+            assert len(results) == 6
+            # Chunk 1 (0,1) must complete before chunk 2 (2,3) starts
+            end_of_first_chunk = max(idx for idx, (op, i) in enumerate(call_order) if op == 'end' and i < 2)
+            start_of_second_chunk = min(idx for idx, (op, i) in enumerate(call_order) if op == 'start' and i >= 2)
+            assert end_of_first_chunk < start_of_second_chunk
+
+        asyncio.run(_run())

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -1,0 +1,284 @@
+"""Unit tests for ghost connection prevention in the pusher WebSocket handler.
+
+The root cause of the memory leak: when a background task (GCS upload, webhook,
+diarizer call) hangs after the WebSocket disconnects, asyncio.gather() for all
+5 main tasks blocks forever, preventing cleanup.  The gauge is never decremented
+and ~15 MB per ghost connection is leaked.
+
+These tests verify:
+1. Receive timeout fires when no data arrives
+2. Background tasks are force-cancelled after the drain timeout
+3. The gauge is always decremented on exit (no ghost connections)
+"""
+
+import asyncio
+import struct
+
+import pytest
+
+WS_RECEIVE_TIMEOUT = 300.0
+BG_DRAIN_TIMEOUT = 30.0
+
+
+class TestConstants:
+    def test_receive_timeout_is_positive(self):
+        assert WS_RECEIVE_TIMEOUT > 0
+
+    def test_receive_timeout_longer_than_heartbeat_interval(self):
+        assert WS_RECEIVE_TIMEOUT >= 60
+
+    def test_drain_timeout_is_positive(self):
+        assert BG_DRAIN_TIMEOUT > 0
+
+    def test_drain_timeout_shorter_than_receive_timeout(self):
+        assert BG_DRAIN_TIMEOUT < WS_RECEIVE_TIMEOUT
+
+
+class TestReceiveTimeoutBehavior:
+    """Verify receive_tasks() exits on timeout instead of hanging forever."""
+
+    @pytest.mark.asyncio
+    async def test_receive_timeout_breaks_loop(self):
+        """Simulate the receive loop with a timeout — should exit cleanly."""
+        websocket_active = True
+        timed_out = False
+
+        async def mock_receive_bytes():
+            await asyncio.sleep(999)
+
+        timeout = 0.1
+        try:
+            while websocket_active:
+                try:
+                    await asyncio.wait_for(mock_receive_bytes(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    timed_out = True
+                    break
+        except Exception:
+            pass
+
+        assert timed_out, "Receive loop should have exited via timeout"
+
+    @pytest.mark.asyncio
+    async def test_receive_timeout_does_not_fire_on_active_connection(self):
+        """Active connections (regular data) should NOT trigger the timeout."""
+        frames_received = 0
+        total_frames = 5
+
+        async def mock_receive_bytes():
+            nonlocal frames_received
+            await asyncio.sleep(0.01)
+            frames_received += 1
+            if frames_received >= total_frames:
+                raise Exception("disconnect")
+            return struct.pack('<I', 100)
+
+        timeout = 1.0
+        try:
+            while True:
+                data = await asyncio.wait_for(mock_receive_bytes(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pytest.fail("Timeout should not fire on active connection")
+        except Exception:
+            pass
+
+        assert frames_received == total_frames
+
+
+class TestDrainTimeout:
+    """Verify background tasks are force-cancelled after drain timeout."""
+
+    @pytest.mark.asyncio
+    async def test_hung_task_is_force_cancelled(self):
+        """A background task stuck in a network call should be cancelled."""
+        cancelled = False
+
+        async def hung_task():
+            nonlocal cancelled
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+
+        task = asyncio.create_task(hung_task())
+        drain_timeout = 0.1
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(task, return_exceptions=True),
+                timeout=drain_timeout,
+            )
+        except asyncio.TimeoutError:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        assert cancelled, "Hung task should have been cancelled"
+        assert task.done(), "Task should be done after cancellation"
+
+    @pytest.mark.asyncio
+    async def test_healthy_task_completes_within_drain(self):
+        """A task that exits promptly should complete without force-cancellation."""
+        completed = False
+
+        async def quick_task():
+            nonlocal completed
+            await asyncio.sleep(0.01)
+            completed = True
+
+        task = asyncio.create_task(quick_task())
+        drain_timeout = 1.0
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(task, return_exceptions=True),
+                timeout=drain_timeout,
+            )
+        except asyncio.TimeoutError:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        assert completed, "Quick task should have completed normally"
+
+    @pytest.mark.asyncio
+    async def test_mixed_tasks_hung_and_healthy(self):
+        """Mix of hung and healthy tasks — healthy complete, hung get cancelled."""
+        completed = False
+        cancelled = False
+
+        async def healthy():
+            nonlocal completed
+            await asyncio.sleep(0.01)
+            completed = True
+
+        async def hung():
+            nonlocal cancelled
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+
+        tasks = [asyncio.create_task(healthy()), asyncio.create_task(hung())]
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=True),
+                timeout=0.2,
+            )
+        except asyncio.TimeoutError:
+            for t in tasks:
+                t.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert completed
+        assert cancelled
+
+
+class TestGaugeDecrement:
+    """Verify the gauge is always decremented regardless of task state."""
+
+    @pytest.mark.asyncio
+    async def test_gauge_decremented_after_normal_exit(self):
+        gauge_value = 0
+
+        async def simulate_connection():
+            nonlocal gauge_value
+            gauge_value += 1
+            try:
+                await asyncio.sleep(0.01)
+            finally:
+                gauge_value -= 1
+
+        await simulate_connection()
+        assert gauge_value == 0
+
+    @pytest.mark.asyncio
+    async def test_gauge_decremented_after_error(self):
+        gauge_value = 0
+
+        async def simulate_connection():
+            nonlocal gauge_value
+            gauge_value += 1
+            try:
+                raise RuntimeError("connection error")
+            except Exception:
+                pass
+            finally:
+                gauge_value -= 1
+
+        await simulate_connection()
+        assert gauge_value == 0
+
+    @pytest.mark.asyncio
+    async def test_gauge_decremented_with_hung_bg_tasks(self):
+        """The new pattern: await receive first, then drain bg with timeout.
+        Gauge must dec even when bg tasks hang."""
+        gauge_value = 0
+
+        async def hung_bg():
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                raise
+
+        async def simulate_connection():
+            nonlocal gauge_value
+            bg_tasks = []
+            gauge_value += 1
+            try:
+                bg_tasks = [asyncio.create_task(hung_bg())]
+                await asyncio.sleep(0.01)
+
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*bg_tasks, return_exceptions=True),
+                        timeout=0.1,
+                    )
+                except asyncio.TimeoutError:
+                    for t in bg_tasks:
+                        t.cancel()
+                    await asyncio.gather(*bg_tasks, return_exceptions=True)
+            except Exception:
+                pass
+            finally:
+                for t in bg_tasks:
+                    if not t.done():
+                        t.cancel()
+                gauge_value -= 1
+
+        await simulate_connection()
+        assert gauge_value == 0, "Gauge must be decremented even with hung background tasks"
+
+    @pytest.mark.asyncio
+    async def test_old_pattern_leaks_with_hung_bg(self):
+        """Demonstrate the OLD bug: asyncio.gather on all tasks blocks forever
+        when a bg task hangs, preventing gauge decrement."""
+        gauge_value = 0
+
+        async def hung_bg():
+            await asyncio.sleep(999)
+
+        async def old_pattern():
+            nonlocal gauge_value
+            gauge_value += 1
+            try:
+                receive = asyncio.create_task(asyncio.sleep(0.01))
+                bg = asyncio.create_task(hung_bg())
+                await asyncio.gather(receive, bg)
+            except Exception:
+                pass
+            finally:
+                gauge_value -= 1
+
+        task = asyncio.create_task(old_pattern())
+
+        await asyncio.sleep(0.2)
+
+        assert gauge_value == 1, "Old pattern leaks: gather hangs on hung bg task"
+        assert not task.done(), "Old pattern: connection handler never finishes"
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 PUSHER_SRC = Path(__file__).resolve().parents[2] / 'routers' / 'pusher.py'
+TRANSCRIBE_SRC = Path(__file__).resolve().parents[2] / 'routers' / 'transcribe.py'
 
 
 def _parse_constant(name: str) -> float:
@@ -513,6 +514,79 @@ class TestSupervisorBehavior:
         """Verify tasks get names for production debugging."""
         src = PUSHER_SRC.read_text()
         assert 'name=f"ws:{' in src, "Tasks must have name= with uid for production debugging"
+
+    @pytest.mark.asyncio
+    async def test_lifetime_task_completion_exits_supervisor(self):
+        """Lifetime task (e.g. heartbeat) completing normally should tear down
+        the session immediately, not re-wait until receive timeout."""
+        exit_reason = None
+
+        async def long_receive():
+            await asyncio.sleep(999)
+
+        async def lifetime_bg():
+            await asyncio.sleep(0.05)
+
+        async def finite_bg():
+            await asyncio.sleep(0.02)
+
+        receive_task = asyncio.create_task(long_receive())
+        lifetime_task = asyncio.create_task(lifetime_bg())
+        finite_task = asyncio.create_task(finite_bg())
+        finite_tasks = {finite_task}
+
+        monitored = {receive_task, lifetime_task, finite_task}
+        while monitored:
+            done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                if task is receive_task:
+                    exit_reason = "disconnect"
+                    break
+                if not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None:
+                        exit_reason = "crash"
+                        break
+                    if task not in finite_tasks:
+                        exit_reason = "lifetime_done"
+                        break
+            if exit_reason:
+                break
+
+        assert exit_reason == "lifetime_done", (
+            f"Expected 'lifetime_done' but got '{exit_reason}'. " "Lifetime task completion must trigger teardown."
+        )
+
+        receive_task.cancel()
+        await asyncio.gather(receive_task, return_exceptions=True)
+
+
+class TestTranscribeSupervisor:
+    """Verify transcribe.py supervisor distinguishes finite vs lifetime tasks."""
+
+    def test_transcribe_has_finite_tasks_set(self):
+        """transcribe.py must define finite_tasks containing only intentionally finite tasks."""
+        src = TRANSCRIBE_SRC.read_text()
+        assert 'finite_tasks' in src, "transcribe.py must define a finite_tasks set"
+        assert 'pending_conversations_task' in src, "pending_conversations_task must be referenced"
+        assert 'speaker_id_task' in src, "speaker_id_task must be referenced"
+
+    def test_transcribe_lifetime_task_triggers_teardown(self):
+        """Lifetime task normal completion must trigger supervisor exit, not re-wait."""
+        src = TRANSCRIBE_SRC.read_text()
+        assert 'task not in finite_tasks' in src, (
+            "Supervisor must check 'task not in finite_tasks' to distinguish " "lifetime tasks from finite tasks"
+        )
+        assert 'lifetime_done' in src or 'lifetime' in src, "Supervisor must log/exit when a lifetime task completes"
+
+    def test_transcribe_uses_supervisor_wait(self):
+        src = TRANSCRIBE_SRC.read_text()
+        assert 'asyncio.FIRST_COMPLETED' in src
+        assert 'asyncio.wait(' in src
+
+    def test_transcribe_has_receive_timeout(self):
+        src = TRANSCRIBE_SRC.read_text()
+        assert 'WS_RECEIVE_TIMEOUT' in src
 
 
 def _parse_handler_ast():

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -461,6 +461,54 @@ class TestSupervisorBehavior:
         assert drained, "BG worker should be cancelled and cleaned up on normal disconnect"
 
     @pytest.mark.asyncio
+    async def test_finite_bg_task_does_not_kill_session(self):
+        """Finite bg tasks (like process_pending_conversations) that complete
+        normally during an active session must NOT tear down the connection.
+        The supervisor loop should re-wait for remaining tasks."""
+        session_torn_down = False
+
+        async def long_receive():
+            await asyncio.sleep(0.3)
+
+        async def finite_bg():
+            await asyncio.sleep(0.05)
+
+        async def long_bg():
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                raise
+
+        receive_task = asyncio.create_task(long_receive())
+        bg_tasks = [asyncio.create_task(finite_bg()), asyncio.create_task(long_bg())]
+
+        monitored = {receive_task, *bg_tasks}
+        supervisor_exit = None
+        while monitored:
+            done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                if task is receive_task:
+                    supervisor_exit = "disconnect"
+                    break
+                if not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None:
+                        supervisor_exit = "crash"
+                        break
+            if supervisor_exit:
+                break
+
+        assert supervisor_exit == "disconnect", (
+            f"Supervisor should exit on disconnect, not '{supervisor_exit}'. "
+            "Finite bg task completing must not tear down the session."
+        )
+
+        for t in bg_tasks:
+            if not t.done():
+                t.cancel()
+        await asyncio.gather(*bg_tasks, return_exceptions=True)
+
+    @pytest.mark.asyncio
     async def test_task_names_assigned(self):
         """Verify tasks get names for production debugging."""
         src = PUSHER_SRC.read_text()

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -571,17 +571,15 @@ class TestTranscribeSupervisor:
         assert 'speaker_id_task' in src, "speaker_id_task must be referenced"
 
     def test_transcribe_lifetime_task_triggers_teardown(self):
-        """Lifetime task normal completion must trigger supervisor exit, not re-wait."""
+        """Lifetime task handling via supervise_tasks utility with finite_tasks set."""
         src = TRANSCRIBE_SRC.read_text()
-        assert 'task not in finite_tasks' in src, (
-            "Supervisor must check 'task not in finite_tasks' to distinguish " "lifetime tasks from finite tasks"
-        )
-        assert 'lifetime_done' in src or 'lifetime' in src, "Supervisor must log/exit when a lifetime task completes"
+        assert 'finite_task' in src, "Transcribe must define finite tasks for supervisor"
+        assert 'supervise_tasks' in src, "Transcribe must use supervise_tasks utility"
 
-    def test_transcribe_uses_supervisor_wait(self):
+    def test_transcribe_uses_supervisor_utility(self):
         src = TRANSCRIBE_SRC.read_text()
-        assert 'asyncio.FIRST_COMPLETED' in src
-        assert 'asyncio.wait(' in src
+        assert 'supervise_tasks' in src, "Transcribe must use supervise_tasks from async_tasks"
+        assert 'drain_tasks' in src, "Transcribe must use drain_tasks from async_tasks"
 
     def test_transcribe_has_receive_timeout(self):
         src = TRANSCRIBE_SRC.read_text()
@@ -620,13 +618,13 @@ class TestTranscribeSupervisor:
         assert found_dec_in_finally, "BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec() must be in finally block"
 
     def test_transcribe_supervisor_before_drain(self):
-        """asyncio.wait(FIRST_COMPLETED) must appear before BG_DRAIN_TIMEOUT in transcribe.py."""
+        """supervise_tasks() must appear before the main bg drain_tasks(bg_main_tasks) in transcribe.py."""
         src = TRANSCRIBE_SRC.read_text()
-        wait_pos = src.find('asyncio.FIRST_COMPLETED')
-        drain_pos = src.find('timeout=BG_DRAIN_TIMEOUT')
-        assert wait_pos != -1, "'asyncio.FIRST_COMPLETED' not found in transcribe.py"
-        assert drain_pos != -1, "'timeout=BG_DRAIN_TIMEOUT' not found in transcribe.py"
-        assert wait_pos < drain_pos, "Supervisor must appear before drain timeout in transcribe.py"
+        supervise_pos = src.find('exit_result = await supervise_tasks(')
+        drain_pos = src.find('await drain_tasks(bg_main_tasks')
+        assert supervise_pos != -1, "'supervise_tasks(' call not found in transcribe.py"
+        assert drain_pos != -1, "'drain_tasks(bg_main_tasks' not found in transcribe.py"
+        assert supervise_pos < drain_pos, "supervise_tasks must appear before bg drain in transcribe.py"
 
     def test_transcribe_no_gauge_before_try(self):
         """Gauge inc must NOT appear before the main try block to prevent leak on early return."""
@@ -692,11 +690,11 @@ class TestStructuralIntegrity:
         src = PUSHER_SRC.read_text()
         assert 'BG_DRAIN_TIMEOUT' in src
 
-    def test_source_uses_supervisor_wait(self):
-        """The supervisor uses asyncio.wait(FIRST_COMPLETED) to detect bg crashes."""
+    def test_source_uses_supervisor_utility(self):
+        """The supervisor uses supervise_tasks() from async_tasks to detect bg crashes."""
         src = PUSHER_SRC.read_text()
-        assert 'asyncio.FIRST_COMPLETED' in src
-        assert 'asyncio.wait(' in src
+        assert 'supervise_tasks(' in src
+        assert 'drain_tasks(' in src
 
     def test_source_does_not_gather_all_five_tasks(self):
         """The old pattern gathered all 5 tasks — verify it's gone."""
@@ -743,17 +741,16 @@ class TestProductionFlowStructure:
         assert found_dec_in_finally, "PUSHER_ACTIVE_WS_CONNECTIONS.dec() must be in finally block"
 
     def test_supervisor_before_bg_drain(self):
-        """asyncio.wait(FIRST_COMPLETED) supervisor must appear before BG_DRAIN_TIMEOUT —
-        proving we detect disconnect/crash first, then drain."""
+        """supervise_tasks() must appear before drain_tasks() — supervisor-then-drain ordering."""
         src = PUSHER_SRC.read_text()
-        wait_pos = src.find('asyncio.FIRST_COMPLETED')
-        drain_pos = src.find('timeout=BG_DRAIN_TIMEOUT')
+        supervise_pos = src.find('supervise_tasks(')
+        drain_pos = src.find('drain_tasks(')
 
-        assert wait_pos != -1, "'asyncio.FIRST_COMPLETED' not found in source"
-        assert drain_pos != -1, "'timeout=BG_DRAIN_TIMEOUT' not found in source"
-        assert wait_pos < drain_pos, (
-            f"'asyncio.FIRST_COMPLETED' (pos {wait_pos}) must appear before "
-            f"'timeout=BG_DRAIN_TIMEOUT' (pos {drain_pos}) — supervisor-then-drain ordering"
+        assert supervise_pos != -1, "'supervise_tasks(' not found in source"
+        assert drain_pos != -1, "'drain_tasks(' not found in source"
+        assert supervise_pos < drain_pos, (
+            f"'supervise_tasks(' (pos {supervise_pos}) must appear before "
+            f"'drain_tasks(' (pos {drain_pos}) — supervisor-then-drain ordering"
         )
 
     def test_receive_task_not_in_gather_with_bg_tasks(self):
@@ -769,45 +766,25 @@ class TestProductionFlowStructure:
                     'receive_task' in gather_block and 'bg_main_tasks' in gather_block
                 ), f"receive_task must not be gathered with bg_main_tasks (line {i + 1})"
 
-    def test_force_cancel_in_timeout_except(self):
-        """After BG_DRAIN_TIMEOUT fires, tasks must be cancelled — verify
-        cancel() appears in the TimeoutError handler that follows BG_DRAIN_TIMEOUT."""
+    def test_drain_tasks_used_for_bg_cleanup(self):
+        """drain_tasks() must be used with BG_DRAIN_TIMEOUT for bg task cleanup."""
         src = PUSHER_SRC.read_text()
+        assert 'drain_tasks(' in src, "drain_tasks must be used for bg task cleanup"
+        assert 'BG_DRAIN_TIMEOUT' in src, "BG_DRAIN_TIMEOUT must be passed to drain_tasks"
 
-        drain_pos = src.find('timeout=BG_DRAIN_TIMEOUT')
-        assert drain_pos != -1, "timeout=BG_DRAIN_TIMEOUT not found"
-
-        after_drain = src[drain_pos:]
-        timeout_pos = after_drain.find('except asyncio.TimeoutError:')
-        assert timeout_pos != -1, "except asyncio.TimeoutError not found after BG_DRAIN_TIMEOUT"
-
-        after_timeout = after_drain[timeout_pos:]
-        lines = after_timeout.split('\n')[1:]
-
-        found_cancel = False
-        for line in lines:
-            stripped = line.strip()
-            if stripped.startswith('except ') or stripped.startswith('finally:') or stripped.startswith('else:'):
-                break
-            if '.cancel()' in stripped:
-                found_cancel = True
-                break
-
-        assert found_cancel, "task.cancel() must follow asyncio.TimeoutError in drain path"
-
-    def test_finally_cancels_remaining_tasks(self):
-        """The finally block must cancel any remaining un-done tasks (bg_tasks + bg_main_tasks)."""
+    def test_finally_drains_remaining_tasks(self):
+        """The finally block must drain any remaining un-done tasks via drain_tasks()."""
         handler = _parse_handler_ast()
         try_blocks = _find_try_blocks(handler)
 
-        found_cancel_in_finally = False
+        found_drain_in_finally = False
         for tb in try_blocks:
             if tb.finalbody:
                 finally_calls = _find_calls_in_body(tb.finalbody)
-                if 'cancel' in finally_calls:
-                    found_cancel_in_finally = True
+                if 'drain_tasks' in finally_calls:
+                    found_drain_in_finally = True
 
-        assert found_cancel_in_finally, "finally block must cancel remaining tasks"
+        assert found_drain_in_finally, "finally block must use drain_tasks for cleanup"
 
     def test_bg_main_tasks_has_four_tasks(self):
         """bg_main_tasks list literal should have exactly 4 tasks (not 5 — receive is separate)."""
@@ -822,7 +799,7 @@ class TestProductionFlowStructure:
                 in_bg_list = True
                 continue
             if in_bg_list:
-                if 'create_task(' in stripped:
+                if 'create_named_task(' in stripped or 'create_task(' in stripped:
                     task_count += 1
                 if ']' in stripped:
                     break
@@ -840,10 +817,7 @@ class TestProductionFlowStructure:
                 return
         pytest.fail("is_shutdown must guard the SPEAKER_SAMPLE_MIN_AGE check in process_speaker_sample_queue")
 
-    def test_dropped_counts_logged_on_drain_timeout(self):
-        """When drain timeout fires, per-queue drop counts must be logged."""
+    def test_drain_tasks_handles_timeout_logging(self):
+        """drain_tasks utility handles timeout logging — verify it's used in pusher."""
         src = PUSHER_SRC.read_text()
-        assert 'dropped_speaker' in src, "Must log dropped speaker sample count"
-        assert 'dropped_transcript' in src, "Must log dropped transcript count"
-        assert 'dropped_audio' in src, "Must log dropped audio count"
-        assert 'dropped_cloud' in src, "Must log dropped cloud count"
+        assert 'drain_tasks(' in src, "drain_tasks must be used in pusher for orderly cleanup"

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -15,6 +15,8 @@ These tests verify:
 import ast
 import asyncio
 import struct
+import time
+from collections import deque
 from pathlib import Path
 
 import pytest
@@ -209,9 +211,6 @@ class TestSpeakerSampleShutdownDrain:
     async def test_pending_samples_processed_on_shutdown(self):
         """When websocket_active goes False, speaker samples younger than
         SPEAKER_SAMPLE_MIN_AGE should still be processed (age check skipped)."""
-        import time
-        from collections import deque
-
         websocket_active = True
         processed_ids = []
 

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -587,6 +587,69 @@ class TestTranscribeSupervisor:
         src = TRANSCRIBE_SRC.read_text()
         assert 'WS_RECEIVE_TIMEOUT' in src
 
+    def test_transcribe_gauge_in_try_finally(self):
+        """BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc() must be in try body,
+        .dec() in finally — verified via AST on _stream_handler."""
+        tree = ast.parse(TRANSCRIBE_SRC.read_text())
+        handler = None
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == '_stream_handler':
+                handler = node
+                break
+        assert handler is not None, '_stream_handler not found in transcribe.py'
+
+        found_inc_in_try = False
+        found_dec_in_finally = False
+        for node in ast.walk(handler):
+            if isinstance(node, ast.Try):
+                try_calls = []
+                for sub in ast.walk(ast.Module(body=node.body, type_ignores=[])):
+                    if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+                        try_calls.append(sub.func.attr)
+                finally_calls = []
+                if node.finalbody:
+                    for sub in ast.walk(ast.Module(body=node.finalbody, type_ignores=[])):
+                        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+                            finally_calls.append(sub.func.attr)
+                if 'inc' in try_calls:
+                    found_inc_in_try = True
+                if 'dec' in finally_calls:
+                    found_dec_in_finally = True
+
+        assert found_inc_in_try, "BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc() must be in try body"
+        assert found_dec_in_finally, "BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec() must be in finally block"
+
+    def test_transcribe_supervisor_before_drain(self):
+        """asyncio.wait(FIRST_COMPLETED) must appear before BG_DRAIN_TIMEOUT in transcribe.py."""
+        src = TRANSCRIBE_SRC.read_text()
+        wait_pos = src.find('asyncio.FIRST_COMPLETED')
+        drain_pos = src.find('timeout=BG_DRAIN_TIMEOUT')
+        assert wait_pos != -1, "'asyncio.FIRST_COMPLETED' not found in transcribe.py"
+        assert drain_pos != -1, "'timeout=BG_DRAIN_TIMEOUT' not found in transcribe.py"
+        assert wait_pos < drain_pos, "Supervisor must appear before drain timeout in transcribe.py"
+
+    def test_transcribe_no_gauge_before_try(self):
+        """Gauge inc must NOT appear before the main try block to prevent leak on early return."""
+        src = TRANSCRIBE_SRC.read_text()
+        lines = src.split('\n')
+        in_stream_handler = False
+        try_line = None
+        inc_lines = []
+        for i, line in enumerate(lines, 1):
+            if 'def _stream_handler(' in line:
+                in_stream_handler = True
+            if in_stream_handler:
+                if line.strip().startswith('try:') and try_line is None:
+                    try_line = i
+                if 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()' in line:
+                    inc_lines.append(i)
+        assert try_line is not None, "try block not found in _stream_handler"
+        assert inc_lines, "No gauge inc found in _stream_handler"
+        for inc_line in inc_lines:
+            assert inc_line > try_line, (
+                f"Gauge inc at line {inc_line} must be after try at line {try_line} " "to prevent leak on early return"
+            )
+
 
 def _parse_handler_ast():
     """Parse _websocket_util_trigger and return key AST info about the try/finally structure."""

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -42,11 +42,17 @@ class TestConstants:
     def test_receive_timeout_is_positive(self):
         assert WS_RECEIVE_TIMEOUT > 0
 
+    def test_receive_timeout_exact_value(self):
+        assert WS_RECEIVE_TIMEOUT == 300.0, f"WS_RECEIVE_TIMEOUT should be 300s, got {WS_RECEIVE_TIMEOUT}"
+
     def test_receive_timeout_longer_than_heartbeat_interval(self):
         assert WS_RECEIVE_TIMEOUT >= 60
 
     def test_drain_timeout_is_positive(self):
         assert BG_DRAIN_TIMEOUT > 0
+
+    def test_drain_timeout_exact_value(self):
+        assert BG_DRAIN_TIMEOUT == 30.0, f"BG_DRAIN_TIMEOUT should be 30s, got {BG_DRAIN_TIMEOUT}"
 
     def test_drain_timeout_shorter_than_receive_timeout(self):
         assert BG_DRAIN_TIMEOUT < WS_RECEIVE_TIMEOUT
@@ -362,6 +368,36 @@ class TestGaugeDecrement:
             pass
 
 
+def _parse_handler_ast():
+    """Parse _websocket_util_trigger and return key AST info about the try/finally structure."""
+    tree = ast.parse(PUSHER_SRC.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == '_websocket_util_trigger':
+            return node
+    raise ValueError('_websocket_util_trigger not found in pusher.py')
+
+
+def _find_try_blocks(func_node):
+    """Find all Try nodes (direct and nested) within a function."""
+    blocks = []
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Try):
+            blocks.append(node)
+    return blocks
+
+
+def _find_calls_in_body(body):
+    """Find all function/attribute call names in a list of AST statements."""
+    calls = []
+    for node in ast.walk(ast.Module(body=body, type_ignores=[])):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                calls.append(node.func.attr)
+            elif isinstance(node.func, ast.Name):
+                calls.append(node.func.id)
+    return calls
+
+
 class TestStructuralIntegrity:
     """Verify the pusher source has the expected patterns."""
 
@@ -386,3 +422,143 @@ class TestStructuralIntegrity:
         """Verify the speaker sample queue skips age check on shutdown."""
         src = PUSHER_SRC.read_text()
         assert 'is_shutdown' in src
+
+
+class TestProductionFlowStructure:
+    """AST-based verification of the actual production code flow in _websocket_util_trigger.
+
+    These tests parse the real pusher.py source and verify structural invariants
+    that prevent ghost connections — not reimplementations, but proofs about the
+    actual code paths.
+    """
+
+    def test_handler_exists(self):
+        handler = _parse_handler_ast()
+        assert handler.name == '_websocket_util_trigger'
+
+    def test_gauge_inc_in_try_dec_in_finally(self):
+        """PUSHER_ACTIVE_WS_CONNECTIONS.inc() must be in try body,
+        .dec() must be in finally — this is the core gauge-leak prevention."""
+        handler = _parse_handler_ast()
+        try_blocks = _find_try_blocks(handler)
+
+        found_inc_in_try = False
+        found_dec_in_finally = False
+
+        for tb in try_blocks:
+            try_calls = _find_calls_in_body(tb.body)
+            finally_calls = _find_calls_in_body(tb.finalbody) if tb.finalbody else []
+
+            if 'inc' in try_calls:
+                found_inc_in_try = True
+            if 'dec' in finally_calls:
+                found_dec_in_finally = True
+
+        assert found_inc_in_try, "PUSHER_ACTIVE_WS_CONNECTIONS.inc() must be in try body"
+        assert found_dec_in_finally, "PUSHER_ACTIVE_WS_CONNECTIONS.dec() must be in finally block"
+
+    def test_receive_task_awaited_before_bg_drain(self):
+        """'await receive_task' must appear before 'timeout=BG_DRAIN_TIMEOUT' usage —
+        proving we wait for receive first, then drain bg tasks."""
+        src = PUSHER_SRC.read_text()
+        receive_pos = src.find('await receive_task')
+        drain_pos = src.find('timeout=BG_DRAIN_TIMEOUT')
+
+        assert receive_pos != -1, "'await receive_task' not found in source"
+        assert drain_pos != -1, "'timeout=BG_DRAIN_TIMEOUT' not found in source"
+        assert receive_pos < drain_pos, (
+            f"'await receive_task' (pos {receive_pos}) must appear before "
+            f"'timeout=BG_DRAIN_TIMEOUT' (pos {drain_pos}) — receive-then-drain ordering"
+        )
+
+    def test_receive_task_not_in_gather_with_bg_tasks(self):
+        """receive_task must NOT appear in the same gather() as bg_main_tasks.
+        This was the root cause of ghost connections."""
+        src = PUSHER_SRC.read_text()
+        lines = src.split('\n')
+
+        for i, line in enumerate(lines):
+            if 'asyncio.gather(' in line:
+                gather_block = '\n'.join(lines[i : i + 6])
+                assert not (
+                    'receive_task' in gather_block and 'bg_main_tasks' in gather_block
+                ), f"receive_task must not be gathered with bg_main_tasks (line {i + 1})"
+
+    def test_force_cancel_in_timeout_except(self):
+        """After BG_DRAIN_TIMEOUT fires, tasks must be cancelled — verify
+        cancel() appears in the TimeoutError handler that follows BG_DRAIN_TIMEOUT."""
+        src = PUSHER_SRC.read_text()
+
+        drain_pos = src.find('timeout=BG_DRAIN_TIMEOUT')
+        assert drain_pos != -1, "timeout=BG_DRAIN_TIMEOUT not found"
+
+        after_drain = src[drain_pos:]
+        timeout_pos = after_drain.find('except asyncio.TimeoutError:')
+        assert timeout_pos != -1, "except asyncio.TimeoutError not found after BG_DRAIN_TIMEOUT"
+
+        after_timeout = after_drain[timeout_pos:]
+        lines = after_timeout.split('\n')[1:]
+
+        found_cancel = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith('except ') or stripped.startswith('finally:') or stripped.startswith('else:'):
+                break
+            if '.cancel()' in stripped:
+                found_cancel = True
+                break
+
+        assert found_cancel, "task.cancel() must follow asyncio.TimeoutError in drain path"
+
+    def test_finally_cancels_remaining_tasks(self):
+        """The finally block must cancel any remaining un-done tasks (bg_tasks + bg_main_tasks)."""
+        handler = _parse_handler_ast()
+        try_blocks = _find_try_blocks(handler)
+
+        found_cancel_in_finally = False
+        for tb in try_blocks:
+            if tb.finalbody:
+                finally_calls = _find_calls_in_body(tb.finalbody)
+                if 'cancel' in finally_calls:
+                    found_cancel_in_finally = True
+
+        assert found_cancel_in_finally, "finally block must cancel remaining tasks"
+
+    def test_bg_main_tasks_has_four_tasks(self):
+        """bg_main_tasks list literal should have exactly 4 tasks (not 5 — receive is separate)."""
+        src = PUSHER_SRC.read_text()
+        lines = src.split('\n')
+
+        in_bg_list = False
+        task_count = 0
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith('bg_main_tasks = [') and stripped != 'bg_main_tasks = []':
+                in_bg_list = True
+                continue
+            if in_bg_list:
+                if 'create_task(' in stripped:
+                    task_count += 1
+                if ']' in stripped:
+                    break
+
+        assert task_count == 4, f"bg_main_tasks should have 4 tasks (receive separate), found {task_count}"
+
+    def test_is_shutdown_guards_speaker_sample_age_check(self):
+        """In process_speaker_sample_queue, is_shutdown must be checked
+        in the same conditional as SPEAKER_SAMPLE_MIN_AGE."""
+        src = PUSHER_SRC.read_text()
+        lines = src.split('\n')
+
+        for line in lines:
+            if 'is_shutdown' in line and 'SPEAKER_SAMPLE_MIN_AGE' in line:
+                return
+        pytest.fail("is_shutdown must guard the SPEAKER_SAMPLE_MIN_AGE check in process_speaker_sample_queue")
+
+    def test_dropped_counts_logged_on_drain_timeout(self):
+        """When drain timeout fires, per-queue drop counts must be logged."""
+        src = PUSHER_SRC.read_text()
+        assert 'dropped_speaker' in src, "Must log dropped speaker sample count"
+        assert 'dropped_transcript' in src, "Must log dropped transcript count"
+        assert 'dropped_audio' in src, "Must log dropped audio count"
+        assert 'dropped_cloud' in src, "Must log dropped cloud count"

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -9,15 +9,33 @@ These tests verify:
 1. Receive timeout fires when no data arrives
 2. Background tasks are force-cancelled after the drain timeout
 3. The gauge is always decremented on exit (no ghost connections)
+4. Speaker samples are processed (not silently dropped) on shutdown
 """
 
+import ast
 import asyncio
 import struct
+from pathlib import Path
 
 import pytest
 
-WS_RECEIVE_TIMEOUT = 300.0
-BG_DRAIN_TIMEOUT = 30.0
+PUSHER_SRC = Path(__file__).resolve().parents[2] / 'routers' / 'pusher.py'
+
+
+def _parse_constant(name: str) -> float:
+    """Extract a module-level constant from pusher.py without importing it."""
+    tree = ast.parse(PUSHER_SRC.read_text())
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return ast.literal_eval(node.value)
+    raise ValueError(f'{name} not found in {PUSHER_SRC}')
+
+
+WS_RECEIVE_TIMEOUT = _parse_constant('WS_RECEIVE_TIMEOUT')
+BG_DRAIN_TIMEOUT = _parse_constant('BG_DRAIN_TIMEOUT')
+SPEAKER_SAMPLE_MIN_AGE = _parse_constant('SPEAKER_SAMPLE_MIN_AGE')
 
 
 class TestConstants:
@@ -32,6 +50,9 @@ class TestConstants:
 
     def test_drain_timeout_shorter_than_receive_timeout(self):
         assert BG_DRAIN_TIMEOUT < WS_RECEIVE_TIMEOUT
+
+    def test_speaker_sample_min_age_exists(self):
+        assert SPEAKER_SAMPLE_MIN_AGE > 0
 
 
 class TestReceiveTimeoutBehavior:
@@ -174,6 +195,63 @@ class TestDrainTimeout:
         assert cancelled
 
 
+class TestSpeakerSampleShutdownDrain:
+    """Verify speaker samples are processed (not silently dropped) on shutdown."""
+
+    @pytest.mark.asyncio
+    async def test_pending_samples_processed_on_shutdown(self):
+        """When websocket_active goes False, speaker samples younger than
+        SPEAKER_SAMPLE_MIN_AGE should still be processed (age check skipped)."""
+        import time
+        from collections import deque
+
+        websocket_active = True
+        processed_ids = []
+
+        speaker_sample_queue = deque(maxlen=100)
+        speaker_sample_queue.append(
+            {
+                'person_id': 'p1',
+                'conversation_id': 'c1',
+                'segment_ids': ['s1'],
+                'queued_at': time.time(),  # just queued — way under 120s age
+            }
+        )
+
+        async def process_speaker_sample_queue():
+            nonlocal websocket_active
+            while websocket_active or len(speaker_sample_queue) > 0:
+                await asyncio.sleep(0.01)
+                if not speaker_sample_queue:
+                    continue
+
+                current_time = time.time()
+                is_shutdown = not websocket_active
+                ready = []
+                pending = []
+                for req in list(speaker_sample_queue):
+                    if is_shutdown or current_time - req['queued_at'] >= SPEAKER_SAMPLE_MIN_AGE:
+                        ready.append(req)
+                    else:
+                        pending.append(req)
+                speaker_sample_queue.clear()
+                speaker_sample_queue.extend(pending)
+                for req in ready:
+                    processed_ids.append(req['person_id'])
+
+            return processed_ids
+
+        task = asyncio.create_task(process_speaker_sample_queue())
+
+        # Simulate disconnect after a brief moment
+        await asyncio.sleep(0.05)
+        websocket_active = False
+
+        result = await asyncio.wait_for(task, timeout=2.0)
+
+        assert 'p1' in processed_ids, "Speaker sample queued < 120s ago should be processed on shutdown, not dropped"
+
+
 class TestGaugeDecrement:
     """Verify the gauge is always decremented regardless of task state."""
 
@@ -282,3 +360,29 @@ class TestGaugeDecrement:
             await task
         except asyncio.CancelledError:
             pass
+
+
+class TestStructuralIntegrity:
+    """Verify the pusher source has the expected patterns."""
+
+    def test_source_has_receive_timeout(self):
+        src = PUSHER_SRC.read_text()
+        assert 'asyncio.wait_for(websocket.receive_bytes()' in src
+
+    def test_source_has_drain_timeout(self):
+        src = PUSHER_SRC.read_text()
+        assert 'BG_DRAIN_TIMEOUT' in src
+
+    def test_source_awaits_receive_task_separately(self):
+        src = PUSHER_SRC.read_text()
+        assert 'await receive_task' in src
+
+    def test_source_does_not_gather_all_five_tasks(self):
+        """The old pattern gathered all 5 tasks — verify it's gone."""
+        src = PUSHER_SRC.read_text()
+        assert 'receive_task,\n' not in src or 'await asyncio.gather(\n            receive_task,' not in src
+
+    def test_source_has_speaker_shutdown_drain(self):
+        """Verify the speaker sample queue skips age check on shutdown."""
+        src = PUSHER_SRC.read_text()
+        assert 'is_shutdown' in src

--- a/backend/tests/unit/test_pusher_ghost_connections.py
+++ b/backend/tests/unit/test_pusher_ghost_connections.py
@@ -295,7 +295,7 @@ class TestGaugeDecrement:
 
     @pytest.mark.asyncio
     async def test_gauge_decremented_with_hung_bg_tasks(self):
-        """The new pattern: await receive first, then drain bg with timeout.
+        """Supervisor pattern: asyncio.wait(FIRST_COMPLETED) then drain with timeout.
         Gauge must dec even when bg tasks hang."""
         gauge_value = 0
 
@@ -310,18 +310,29 @@ class TestGaugeDecrement:
             bg_tasks = []
             gauge_value += 1
             try:
+                receive_task = asyncio.create_task(asyncio.sleep(0.01))
                 bg_tasks = [asyncio.create_task(hung_bg())]
-                await asyncio.sleep(0.01)
 
-                try:
-                    await asyncio.wait_for(
-                        asyncio.gather(*bg_tasks, return_exceptions=True),
-                        timeout=0.1,
-                    )
-                except asyncio.TimeoutError:
-                    for t in bg_tasks:
-                        t.cancel()
-                    await asyncio.gather(*bg_tasks, return_exceptions=True)
+                done, _ = await asyncio.wait(
+                    {receive_task, *bg_tasks},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if not receive_task.done():
+                    receive_task.cancel()
+
+                remaining = [t for t in bg_tasks if not t.done()]
+                if remaining:
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.gather(*remaining, return_exceptions=True),
+                            timeout=0.1,
+                        )
+                    except asyncio.TimeoutError:
+                        for t in remaining:
+                            if not t.done():
+                                t.cancel()
+                        await asyncio.gather(*remaining, return_exceptions=True)
             except Exception:
                 pass
             finally:
@@ -368,6 +379,94 @@ class TestGaugeDecrement:
             pass
 
 
+class TestSupervisorBehavior:
+    """Verify the supervisor detects bg task crashes during active sessions."""
+
+    @pytest.mark.asyncio
+    async def test_bg_crash_detected_immediately(self):
+        """If a bg task crashes during an active session, the supervisor
+        exits immediately instead of waiting for client disconnect."""
+        crash_detected_at = None
+        start_time = None
+
+        async def long_receive():
+            await asyncio.sleep(999)
+
+        async def crashing_bg():
+            await asyncio.sleep(0.05)
+            raise RuntimeError("bg task crashed")
+
+        async def supervisor():
+            nonlocal crash_detected_at, start_time
+            start_time = asyncio.get_event_loop().time()
+            receive_task = asyncio.create_task(long_receive())
+            bg_tasks = [asyncio.create_task(crashing_bg())]
+
+            done, _ = await asyncio.wait(
+                {receive_task, *bg_tasks},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            crash_detected_at = asyncio.get_event_loop().time()
+
+            for task in done:
+                if task is not receive_task and not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None:
+                        pass  # logged in production
+
+            if not receive_task.done():
+                receive_task.cancel()
+                try:
+                    await receive_task
+                except asyncio.CancelledError:
+                    pass
+
+        await asyncio.wait_for(supervisor(), timeout=2.0)
+
+        elapsed = crash_detected_at - start_time
+        assert elapsed < 0.5, f"Supervisor should detect bg crash in <0.5s, took {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_normal_disconnect_still_works(self):
+        """Normal client disconnect (receive ends) still triggers clean drain."""
+        drained = False
+
+        async def short_receive():
+            await asyncio.sleep(0.05)
+
+        async def bg_worker():
+            nonlocal drained
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                drained = True
+                raise
+
+        receive_task = asyncio.create_task(short_receive())
+        bg_tasks = [asyncio.create_task(bg_worker())]
+
+        done, _ = await asyncio.wait(
+            {receive_task, *bg_tasks},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        assert receive_task in done, "Receive task should complete first on normal disconnect"
+
+        remaining = [t for t in bg_tasks if not t.done()]
+        for t in remaining:
+            t.cancel()
+        await asyncio.gather(*remaining, return_exceptions=True)
+
+        assert drained, "BG worker should be cancelled and cleaned up on normal disconnect"
+
+    @pytest.mark.asyncio
+    async def test_task_names_assigned(self):
+        """Verify tasks get names for production debugging."""
+        src = PUSHER_SRC.read_text()
+        assert 'name=f"ws:{' in src, "Tasks must have name= with uid for production debugging"
+
+
 def _parse_handler_ast():
     """Parse _websocket_util_trigger and return key AST info about the try/finally structure."""
     tree = ast.parse(PUSHER_SRC.read_text())
@@ -409,9 +508,11 @@ class TestStructuralIntegrity:
         src = PUSHER_SRC.read_text()
         assert 'BG_DRAIN_TIMEOUT' in src
 
-    def test_source_awaits_receive_task_separately(self):
+    def test_source_uses_supervisor_wait(self):
+        """The supervisor uses asyncio.wait(FIRST_COMPLETED) to detect bg crashes."""
         src = PUSHER_SRC.read_text()
-        assert 'await receive_task' in src
+        assert 'asyncio.FIRST_COMPLETED' in src
+        assert 'asyncio.wait(' in src
 
     def test_source_does_not_gather_all_five_tasks(self):
         """The old pattern gathered all 5 tasks — verify it's gone."""
@@ -457,18 +558,18 @@ class TestProductionFlowStructure:
         assert found_inc_in_try, "PUSHER_ACTIVE_WS_CONNECTIONS.inc() must be in try body"
         assert found_dec_in_finally, "PUSHER_ACTIVE_WS_CONNECTIONS.dec() must be in finally block"
 
-    def test_receive_task_awaited_before_bg_drain(self):
-        """'await receive_task' must appear before 'timeout=BG_DRAIN_TIMEOUT' usage —
-        proving we wait for receive first, then drain bg tasks."""
+    def test_supervisor_before_bg_drain(self):
+        """asyncio.wait(FIRST_COMPLETED) supervisor must appear before BG_DRAIN_TIMEOUT —
+        proving we detect disconnect/crash first, then drain."""
         src = PUSHER_SRC.read_text()
-        receive_pos = src.find('await receive_task')
+        wait_pos = src.find('asyncio.FIRST_COMPLETED')
         drain_pos = src.find('timeout=BG_DRAIN_TIMEOUT')
 
-        assert receive_pos != -1, "'await receive_task' not found in source"
+        assert wait_pos != -1, "'asyncio.FIRST_COMPLETED' not found in source"
         assert drain_pos != -1, "'timeout=BG_DRAIN_TIMEOUT' not found in source"
-        assert receive_pos < drain_pos, (
-            f"'await receive_task' (pos {receive_pos}) must appear before "
-            f"'timeout=BG_DRAIN_TIMEOUT' (pos {drain_pos}) — receive-then-drain ordering"
+        assert wait_pos < drain_pos, (
+            f"'asyncio.FIRST_COMPLETED' (pos {wait_pos}) must appear before "
+            f"'timeout=BG_DRAIN_TIMEOUT' (pos {drain_pos}) — supervisor-then-drain ordering"
         )
 
     def test_receive_task_not_in_gather_with_bg_tasks(self):

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -14,6 +14,7 @@ from utils.http_client import (
     latest_wins_check,
 )
 from utils.executors import db_executor, run_blocking
+from utils.async_tasks import gather_with_logging
 
 import database.notifications as notification_db
 from database import mem_db
@@ -180,7 +181,9 @@ async def trigger_external_integrations(uid: str, conversation: Conversation) ->
             logger.error(f"Plugin integration error: {e}")
             return
 
-    await asyncio.gather(*[_single(app) for app in filtered_apps], return_exceptions=True)
+    await gather_with_logging(
+        *[_single(app) for app in filtered_apps], label="trigger_integrations", max_concurrency=10
+    )
 
     messages = []
     for key, message in results.items():
@@ -534,14 +537,12 @@ async def _async_trigger_realtime_audio_bytes(uid: str, sample_rate: int, data: 
             cb.record_failure()
             logger.error(f"Plugin integration error: {e}")
 
-    # Cap per-call concurrency: only fan out to 8 apps at a time to limit memory pressure
-    # from concurrent webhook calls holding references to the audio data
     chunk_size = 8
     for i in range(0, len(filtered_apps), chunk_size):
         chunk = filtered_apps[i : i + chunk_size]
-        await asyncio.gather(*[_single(app) for app in chunk], return_exceptions=True)
+        await gather_with_logging(*[_single(app) for app in chunk], label="realtime_audio_bytes", max_concurrency=8)
         if not latest_wins_check(uid, version):
-            break  # Newer data arrived, stop sending stale chunks
+            break
     return {}
 
 
@@ -639,7 +640,9 @@ async def _async_trigger_realtime_integrations(
             logger.error(f"App integration error: {e}")
             return
 
-    await asyncio.gather(*[_single(app) for app in filtered_apps], return_exceptions=True)
+    await gather_with_logging(
+        *[_single(app) for app in filtered_apps], label="realtime_integrations", max_concurrency=10
+    )
 
     # Merge mentor results with app results
     all_results = {**mentor_results, **results}

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -14,7 +14,7 @@ from utils.http_client import (
     latest_wins_check,
 )
 from utils.executors import db_executor, run_blocking
-from utils.async_tasks import gather_with_logging
+from utils.async_tasks import gather_safe
 
 import database.notifications as notification_db
 from database import mem_db
@@ -181,9 +181,7 @@ async def trigger_external_integrations(uid: str, conversation: Conversation) ->
             logger.error(f"Plugin integration error: {e}")
             return
 
-    await gather_with_logging(
-        *[_single(app) for app in filtered_apps], label="trigger_integrations", max_concurrency=10
-    )
+    await gather_safe(*[_single(app) for app in filtered_apps], label="trigger_integrations", max_concurrency=10)
 
     messages = []
     for key, message in results.items():
@@ -540,7 +538,7 @@ async def _async_trigger_realtime_audio_bytes(uid: str, sample_rate: int, data: 
     chunk_size = 8
     for i in range(0, len(filtered_apps), chunk_size):
         chunk = filtered_apps[i : i + chunk_size]
-        await gather_with_logging(*[_single(app) for app in chunk], label="realtime_audio_bytes", max_concurrency=8)
+        await gather_safe(*[_single(app) for app in chunk], label="realtime_audio_bytes", max_concurrency=8)
         if not latest_wins_check(uid, version):
             break
     return {}
@@ -640,9 +638,7 @@ async def _async_trigger_realtime_integrations(
             logger.error(f"App integration error: {e}")
             return
 
-    await gather_with_logging(
-        *[_single(app) for app in filtered_apps], label="realtime_integrations", max_concurrency=10
-    )
+    await gather_safe(*[_single(app) for app in filtered_apps], label="realtime_integrations", max_concurrency=10)
 
     # Merge mentor results with app results
     all_results = {**mentor_results, **results}

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -6,7 +6,7 @@ Implements structured concurrency primitives that replace raw asyncio.gather():
 - gather_with_logging(): bounded fan-out with exception observability
 - gather_chunked(): chunked fan-out for large coroutine lists
 - create_named_task(): tracked task creation with done-callback cleanup
-- sleep_until_shutdown(): interruptible sleep that wakes on shutdown event
+- wait_for_event(): interruptible sleep that wakes on shutdown event
 
 These replace ad-hoc asyncio.gather() patterns that cause:
 1. Silent exception swallowing (return_exceptions=True with no inspection)
@@ -304,7 +304,7 @@ async def gather_chunked(
 # ---------------------------------------------------------------------------
 
 
-async def sleep_until_shutdown(event: asyncio.Event, seconds: float) -> bool:
+async def wait_for_event(event: asyncio.Event, seconds: float) -> bool:
     """Sleep for `seconds` but wake immediately if `event` is set.
 
     Returns True if woken early by the event (shutdown requested),

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -3,7 +3,7 @@
 Implements structured concurrency primitives that replace raw asyncio.gather():
 - supervise_tasks(): FIRST_COMPLETED supervisor loop for WS handlers
 - drain_tasks(): timeout-bounded task cancellation
-- gather_with_logging(): bounded fan-out with exception observability
+- gather_safe(): bounded fan-out with exception observability
 - gather_chunked(): chunked fan-out for large coroutine lists
 - create_named_task(): tracked task creation with done-callback cleanup
 - wait_for_event(): interruptible sleep that wakes on shutdown event
@@ -53,13 +53,13 @@ DRAIN_DURATION = Histogram(
 
 GATHER_FAILURES_TOTAL = Counter(
     'async_gather_failures_total',
-    'Individual coroutine failures in gather_with_logging',
+    'Individual coroutine failures in gather_safe',
     ['label'],
 )
 
 GATHER_DURATION = Histogram(
     'async_gather_duration_seconds',
-    'Total duration of gather_with_logging calls',
+    'Total duration of gather_safe calls',
     ['label'],
     buckets=[0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0],
 )
@@ -72,7 +72,7 @@ GATHER_DURATION = Histogram(
 
 @dataclass(slots=True)
 class GatherResult(Generic[T]):
-    """Result of a single coroutine in gather_with_logging."""
+    """Result of a single coroutine in gather_safe."""
 
     index: int
     ok: bool
@@ -82,7 +82,7 @@ class GatherResult(Generic[T]):
 
 
 @dataclass(slots=True)
-class SupervisorExit:
+class SupervisorResult:
     """Result of supervise_tasks indicating why the supervisor loop exited."""
 
     reason: str  # "disconnect", "crash", "lifetime_done"
@@ -101,7 +101,7 @@ async def supervise_tasks(
     bg_tasks: list[asyncio.Task],
     finite_tasks: set[asyncio.Task] | None = None,
     label: str,
-) -> SupervisorExit:
+) -> SupervisorResult:
     """Supervisor loop using asyncio.wait(FIRST_COMPLETED).
 
     Monitors receive_task + bg_tasks. Exits when:
@@ -116,7 +116,7 @@ async def supervise_tasks(
 
     monitored = {receive_task, *bg_tasks}
     if not monitored:
-        return SupervisorExit(reason="empty", task_name="none")
+        return SupervisorResult(reason="empty", task_name="none")
 
     while monitored:
         done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
@@ -124,7 +124,7 @@ async def supervise_tasks(
         exit_result = None
         for task in done:
             if task is receive_task:
-                exit_result = SupervisorExit(reason="disconnect", task_name=task.get_name())
+                exit_result = SupervisorResult(reason="disconnect", task_name=task.get_name())
                 break
             if not task.cancelled():
                 try:
@@ -133,18 +133,18 @@ async def supervise_tasks(
                     continue
                 if exc is not None:
                     logger.error("BG task %s crashed: %r [%s]", task.get_name(), exc, label)
-                    exit_result = SupervisorExit(reason="crash", task_name=task.get_name(), exception=exc)
+                    exit_result = SupervisorResult(reason="crash", task_name=task.get_name(), exception=exc)
                     break
                 if task not in finite_tasks:
                     logger.info("Lifetime task %s completed, tearing down [%s]", task.get_name(), label)
-                    exit_result = SupervisorExit(reason="lifetime_done", task_name=task.get_name())
+                    exit_result = SupervisorResult(reason="lifetime_done", task_name=task.get_name())
                     break
 
         if exit_result:
             SUPERVISOR_EXIT_TOTAL.labels(label=label, reason=exit_result.reason).inc()
             return exit_result
 
-    return SupervisorExit(reason="all_done", task_name="none")
+    return SupervisorResult(reason="all_done", task_name="none")
 
 
 # ---------------------------------------------------------------------------
@@ -204,11 +204,11 @@ async def drain_tasks(
 
 
 # ---------------------------------------------------------------------------
-# gather_with_logging — bounded fan-out with observability
+# gather_safe — bounded fan-out with observability
 # ---------------------------------------------------------------------------
 
 
-async def gather_with_logging(
+async def gather_safe(
     *coros: Awaitable[T],
     label: str,
     max_concurrency: int = 10,
@@ -238,7 +238,7 @@ async def gather_with_logging(
                 return GatherResult(index=index, ok=False, cancelled=True)
             except Exception as e:
                 GATHER_FAILURES_TOTAL.labels(label=label).inc()
-                logger.warning("gather_with_logging[%s] item %d failed: %r", label, index, e)
+                logger.warning("gather_safe[%s] item %d failed: %r", label, index, e)
                 return GatherResult(index=index, ok=False, exception=e)
 
     tasks = [asyncio.create_task(_run_one(i, coro), name=f"{label}:{i}") for i, coro in enumerate(coros)]
@@ -278,7 +278,7 @@ async def gather_chunked(
     for coro in coros:
         chunk.append(coro)
         if len(chunk) >= chunk_size:
-            chunk_results = await gather_with_logging(
+            chunk_results = await gather_safe(
                 *chunk,
                 label=label,
                 max_concurrency=concurrency,
@@ -288,7 +288,7 @@ async def gather_chunked(
             chunk = []
 
     if chunk:
-        chunk_results = await gather_with_logging(
+        chunk_results = await gather_safe(
             *chunk,
             label=label,
             max_concurrency=concurrency,

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -6,6 +6,7 @@ Implements structured concurrency primitives that replace raw asyncio.gather():
 - gather_with_logging(): bounded fan-out with exception observability
 - gather_chunked(): chunked fan-out for large coroutine lists
 - create_named_task(): tracked task creation with done-callback cleanup
+- sleep_until_shutdown(): interruptible sleep that wakes on shutdown event
 
 These replace ad-hoc asyncio.gather() patterns that cause:
 1. Silent exception swallowing (return_exceptions=True with no inspection)
@@ -301,6 +302,19 @@ async def gather_chunked(
 # ---------------------------------------------------------------------------
 # create_named_task — tracked task creation
 # ---------------------------------------------------------------------------
+
+
+async def sleep_until_shutdown(event: asyncio.Event, seconds: float) -> bool:
+    """Sleep for `seconds` but wake immediately if `event` is set.
+
+    Returns True if woken early by the event (shutdown requested),
+    False if the full sleep elapsed normally.
+    """
+    try:
+        await asyncio.wait_for(event.wait(), timeout=seconds)
+        return True
+    except asyncio.TimeoutError:
+        return False
 
 
 def create_named_task(

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -310,6 +310,10 @@ async def sleep_until_shutdown(event: asyncio.Event, seconds: float) -> bool:
     Returns True if woken early by the event (shutdown requested),
     False if the full sleep elapsed normally.
     """
+    if event.is_set():
+        return True
+    if seconds <= 0:
+        return False
     try:
         await asyncio.wait_for(event.wait(), timeout=seconds)
         return True

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -188,8 +188,16 @@ async def drain_tasks(
         logger.warning("Drain timeout (%.1fs), force-cancelling %d tasks [%s]", timeout, len(still_pending), label)
         for task in still_pending:
             task.cancel()
-        await asyncio.gather(*still_pending, return_exceptions=True)
+        # Bounded wait for cancel acknowledgement — never block indefinitely
+        _, truly_stuck = await asyncio.wait(still_pending, timeout=5.0)
         force_cancelled = len(still_pending)
+        if truly_stuck:
+            logger.error(
+                "drain_tasks: %d tasks ignored cancellation after 5s [%s]: %s",
+                len(truly_stuck),
+                label,
+                [t.get_name() for t in truly_stuck],
+            )
 
     return force_cancelled
 

--- a/backend/utils/async_tasks.py
+++ b/backend/utils/async_tasks.py
@@ -1,0 +1,316 @@
+"""Async concurrency utilities for production WebSocket and HTTP fan-out patterns.
+
+Implements structured concurrency primitives that replace raw asyncio.gather():
+- supervise_tasks(): FIRST_COMPLETED supervisor loop for WS handlers
+- drain_tasks(): timeout-bounded task cancellation
+- gather_with_logging(): bounded fan-out with exception observability
+- gather_chunked(): chunked fan-out for large coroutine lists
+- create_named_task(): tracked task creation with done-callback cleanup
+
+These replace ad-hoc asyncio.gather() patterns that cause:
+1. Silent exception swallowing (return_exceptions=True with no inspection)
+2. Orphaned tasks on first failure (gather without sibling cancellation)
+3. Unbounded fan-out (50+ concurrent outbound connections per session)
+
+Same pattern as utils/executors.py (thread pools) and utils/http_client.py (HTTP clients):
+named utilities with bounded resources, clean shutdown, and observability.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Generic, Iterable, TypeVar
+
+from prometheus_client import Counter, Histogram
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T')
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+SUPERVISOR_EXIT_TOTAL = Counter(
+    'async_supervisor_exit_total',
+    'Supervisor loop exits by reason',
+    ['label', 'reason'],
+)
+
+DRAIN_TIMEOUT_TOTAL = Counter(
+    'async_drain_timeout_total',
+    'Task drain operations that hit timeout',
+    ['label'],
+)
+
+DRAIN_DURATION = Histogram(
+    'async_drain_duration_seconds',
+    'Time spent draining tasks',
+    ['label'],
+    buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
+)
+
+GATHER_FAILURES_TOTAL = Counter(
+    'async_gather_failures_total',
+    'Individual coroutine failures in gather_with_logging',
+    ['label'],
+)
+
+GATHER_DURATION = Histogram(
+    'async_gather_duration_seconds',
+    'Total duration of gather_with_logging calls',
+    ['label'],
+    buckets=[0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0],
+)
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class GatherResult(Generic[T]):
+    """Result of a single coroutine in gather_with_logging."""
+
+    index: int
+    ok: bool
+    value: T | None = None
+    exception: BaseException | None = None
+    cancelled: bool = False
+
+
+@dataclass(slots=True)
+class SupervisorExit:
+    """Result of supervise_tasks indicating why the supervisor loop exited."""
+
+    reason: str  # "disconnect", "crash", "lifetime_done"
+    task_name: str
+    exception: BaseException | None = None
+
+
+# ---------------------------------------------------------------------------
+# supervise_tasks — WebSocket task supervision
+# ---------------------------------------------------------------------------
+
+
+async def supervise_tasks(
+    *,
+    receive_task: asyncio.Task,
+    bg_tasks: list[asyncio.Task],
+    finite_tasks: set[asyncio.Task] | None = None,
+    label: str,
+) -> SupervisorExit:
+    """Supervisor loop using asyncio.wait(FIRST_COMPLETED).
+
+    Monitors receive_task + bg_tasks. Exits when:
+    - receive_task completes (disconnect)
+    - Any task raises an exception (crash)
+    - A lifetime task (not in finite_tasks) completes normally (session ending)
+
+    Re-waits when a finite task completes normally.
+    """
+    if finite_tasks is None:
+        finite_tasks = set()
+
+    monitored = {receive_task, *bg_tasks}
+    if not monitored:
+        return SupervisorExit(reason="empty", task_name="none")
+
+    while monitored:
+        done, monitored = await asyncio.wait(monitored, return_when=asyncio.FIRST_COMPLETED)
+
+        exit_result = None
+        for task in done:
+            if task is receive_task:
+                exit_result = SupervisorExit(reason="disconnect", task_name=task.get_name())
+                break
+            if not task.cancelled():
+                try:
+                    exc = task.exception()
+                except asyncio.CancelledError:
+                    continue
+                if exc is not None:
+                    logger.error("BG task %s crashed: %r [%s]", task.get_name(), exc, label)
+                    exit_result = SupervisorExit(reason="crash", task_name=task.get_name(), exception=exc)
+                    break
+                if task not in finite_tasks:
+                    logger.info("Lifetime task %s completed, tearing down [%s]", task.get_name(), label)
+                    exit_result = SupervisorExit(reason="lifetime_done", task_name=task.get_name())
+                    break
+
+        if exit_result:
+            SUPERVISOR_EXIT_TOTAL.labels(label=label, reason=exit_result.reason).inc()
+            return exit_result
+
+    return SupervisorExit(reason="all_done", task_name="none")
+
+
+# ---------------------------------------------------------------------------
+# drain_tasks — timeout-bounded cancellation
+# ---------------------------------------------------------------------------
+
+
+async def drain_tasks(
+    tasks: Iterable[asyncio.Task],
+    *,
+    timeout: float = 30.0,
+    label: str = "drain",
+    cancel: bool = True,
+) -> int:
+    """Cancel and wait for tasks to finish within timeout.
+
+    Returns the number of tasks that had to be force-cancelled after timeout.
+    """
+    pending = [t for t in tasks if not t.done()]
+    if not pending:
+        return 0
+
+    if cancel:
+        for task in pending:
+            task.cancel()
+
+    with DRAIN_DURATION.labels(label=label).time():
+        done, still_pending = await asyncio.wait(pending, timeout=timeout)
+
+    for task in done:
+        if not task.cancelled():
+            try:
+                exc = task.exception()
+            except asyncio.CancelledError:
+                continue
+            if exc is not None:
+                logger.debug("Task %s raised during drain [%s]: %r", task.get_name(), label, exc)
+
+    force_cancelled = 0
+    if still_pending:
+        DRAIN_TIMEOUT_TOTAL.labels(label=label).inc()
+        logger.warning("Drain timeout (%.1fs), force-cancelling %d tasks [%s]", timeout, len(still_pending), label)
+        for task in still_pending:
+            task.cancel()
+        await asyncio.gather(*still_pending, return_exceptions=True)
+        force_cancelled = len(still_pending)
+
+    return force_cancelled
+
+
+# ---------------------------------------------------------------------------
+# gather_with_logging — bounded fan-out with observability
+# ---------------------------------------------------------------------------
+
+
+async def gather_with_logging(
+    *coros: Awaitable[T],
+    label: str,
+    max_concurrency: int = 10,
+    timeout: float | None = None,
+) -> list[GatherResult[T]]:
+    """Fan-out coroutines with bounded concurrency and exception logging.
+
+    - Semaphore limits concurrent execution
+    - Exceptions are logged (not silently swallowed)
+    - Returns GatherResult list preserving order
+    - Cancellation of parent propagates to all children
+    """
+    if not coros:
+        return []
+
+    sem = asyncio.Semaphore(max_concurrency)
+
+    async def _run_one(index: int, coro: Awaitable[T]) -> GatherResult[T]:
+        async with sem:
+            try:
+                if timeout is not None:
+                    value = await asyncio.wait_for(coro, timeout=timeout)
+                else:
+                    value = await coro
+                return GatherResult(index=index, ok=True, value=value)
+            except asyncio.CancelledError:
+                return GatherResult(index=index, ok=False, cancelled=True)
+            except Exception as e:
+                GATHER_FAILURES_TOTAL.labels(label=label).inc()
+                logger.warning("gather_with_logging[%s] item %d failed: %r", label, index, e)
+                return GatherResult(index=index, ok=False, exception=e)
+
+    tasks = [asyncio.create_task(_run_one(i, coro), name=f"{label}:{i}") for i, coro in enumerate(coros)]
+
+    try:
+        with GATHER_DURATION.labels(label=label).time():
+            results = await asyncio.gather(*tasks)
+        return list(results)
+    except asyncio.CancelledError:
+        await drain_tasks(tasks, timeout=5.0, label=f"{label}:cancel", cancel=True)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# gather_chunked — chunked fan-out for large lists
+# ---------------------------------------------------------------------------
+
+
+async def gather_chunked(
+    coros: Iterable[Awaitable[T]],
+    *,
+    chunk_size: int = 10,
+    label: str,
+    max_concurrency: int | None = None,
+    timeout: float | None = None,
+) -> list[GatherResult[T]]:
+    """Execute coroutines in chunks with bounded concurrency.
+
+    Processes chunk_size coroutines at a time, waiting for each chunk
+    to complete before starting the next. Useful for large fan-outs
+    where even semaphore-bounded gather creates too many pending tasks.
+    """
+    results: list[GatherResult[T]] = []
+    chunk: list[Awaitable[T]] = []
+    concurrency = max_concurrency if max_concurrency is not None else chunk_size
+
+    for coro in coros:
+        chunk.append(coro)
+        if len(chunk) >= chunk_size:
+            chunk_results = await gather_with_logging(
+                *chunk,
+                label=label,
+                max_concurrency=concurrency,
+                timeout=timeout,
+            )
+            results.extend(chunk_results)
+            chunk = []
+
+    if chunk:
+        chunk_results = await gather_with_logging(
+            *chunk,
+            label=label,
+            max_concurrency=concurrency,
+            timeout=timeout,
+        )
+        results.extend(chunk_results)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# create_named_task — tracked task creation
+# ---------------------------------------------------------------------------
+
+
+def create_named_task(
+    coro: Awaitable[Any],
+    *,
+    name: str,
+    task_set: set[asyncio.Task] | None = None,
+) -> asyncio.Task:
+    """Create a named task with optional tracking set.
+
+    - Names the task for debugging (visible in asyncio.all_tasks())
+    - Adds to task_set if provided
+    - Registers done callback to auto-remove from task_set
+    """
+    task = asyncio.create_task(coro, name=name)
+
+    if task_set is not None:
+        task_set.add(task)
+        task.add_done_callback(task_set.discard)
+
+    return task

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -260,8 +260,8 @@ sequenceDiagram
 | `last_activity_time` timeout | 90s | transcribe.py | WS inactivity disconnect |
 | `SPEAKER_SAMPLE_MIN_AGE` | 120s | pusher.py | Wait before extracting embedding (skipped on shutdown) |
 | `SPEAKER_SAMPLE_PROCESS_INTERVAL` | 15s | pusher.py | Queue poll interval |
-| `WS_RECEIVE_TIMEOUT` | 300s | pusher.py | No-data timeout on pusher WebSocket receive; detects dead upstream connections |
-| `BG_DRAIN_TIMEOUT` | 30s | pusher.py | Grace period for background tasks to drain after disconnect before force-cancel |
+| `WS_RECEIVE_TIMEOUT` | 300s | pusher.py, transcribe.py | No-data timeout on WebSocket receive; detects dead connections |
+| `BG_DRAIN_TIMEOUT` | 30s | pusher.py, transcribe.py | Grace period for background tasks to drain after disconnect before force-cancel |
 | `lifecycle_manager` poll | 5s | transcribe.py:1683 | Check `finished_at` interval |
 | Pusher audio batch | 60s | pusher | GCS upload batch size |
 | Speaker match threshold | 0.45 | transcribe.py | Cosine distance cutoff |

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -270,3 +270,17 @@ sequenceDiagram
 | `PUSHER_MAX_RECONNECT_ATTEMPTS` | 6 | transcribe.py | Reconnect attempts before DEGRADED |
 | `MAX_PENDING_REQUESTS` | 100 | transcribe.py | Max buffered conversations per session |
 
+## 8. WebSocket Task Supervision
+
+Both `transcribe.py` and `pusher.py` use an `asyncio.wait(FIRST_COMPLETED)` supervisor loop instead of `asyncio.gather()` to manage background tasks. This prevents ghost connections where a hung background task blocks cleanup forever.
+
+**Supervisor exits on:**
+- Client disconnect (receive task completes)
+- Background task crash (exception)
+- Lifetime task normal completion (e.g. heartbeat inactivity timeout)
+
+**Supervisor re-waits on:**
+- Finite task normal completion (e.g. `process_pending_conversations`, `speaker_identification_task`)
+
+After supervisor exit, remaining tasks drain with `BG_DRAIN_TIMEOUT` (30s) before force-cancel. The connection gauge (`inc`/`dec`) is always paired in `try`/`finally`.
+

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -258,8 +258,10 @@ sequenceDiagram
 |----------|-------|----------|---------|
 | `conversation_timeout` | 120s (min) | transcribe.py | Silence before lifecycle triggers |
 | `last_activity_time` timeout | 90s | transcribe.py | WS inactivity disconnect |
-| `SPEAKER_SAMPLE_MIN_AGE` | 120s | pusher.py:39 | Wait before extracting embedding |
-| `SPEAKER_SAMPLE_PROCESS_INTERVAL` | 15s | pusher.py:40 | Queue poll interval |
+| `SPEAKER_SAMPLE_MIN_AGE` | 120s | pusher.py | Wait before extracting embedding (skipped on shutdown) |
+| `SPEAKER_SAMPLE_PROCESS_INTERVAL` | 15s | pusher.py | Queue poll interval |
+| `WS_RECEIVE_TIMEOUT` | 300s | pusher.py | No-data timeout on pusher WebSocket receive; detects dead upstream connections |
+| `BG_DRAIN_TIMEOUT` | 30s | pusher.py | Grace period for background tasks to drain after disconnect before force-cancel |
 | `lifecycle_manager` poll | 5s | transcribe.py:1683 | Check `finished_at` interval |
 | Pusher audio batch | 60s | pusher | GCS upload batch size |
 | Speaker match threshold | 0.45 | transcribe.py | Cosine distance cutoff |


### PR DESCRIPTION
## Summary

Fixes ghost WebSocket connections in **both pusher and transcribe** that leak ~15MB each, and introduces production-grade **structured concurrency utilities** (`utils/async_tasks.py`) following FastAPI best practices.

### Root cause

When a background task (GCS upload, webhook, diarizer call) hangs after the WebSocket disconnects, the old `asyncio.gather()` pattern blocks forever — preventing cleanup. The connection gauge is never decremented and ~15MB per ghost connection is leaked.

### Fix: Structured concurrency utilities + supervisor pattern

**New module: `utils/async_tasks.py`** — same pattern as `utils/executors.py` (thread pools) and `utils/http_client.py` (HTTP clients): named utilities with bounded resources, clean shutdown, and Prometheus observability.

| Utility | Purpose | Replaces |
|---------|---------|----------|
| `supervise_tasks()` | `asyncio.wait(FIRST_COMPLETED)` supervisor loop | Inline supervisor in both WS handlers |
| `drain_tasks()` | Timeout-bounded task cancellation with force-cancel | Manual cancel-loop + gather in finally blocks |
| `gather_safe()` | Bounded fan-out with exception logging | `asyncio.gather(*coros, return_exceptions=True)` (silent failures) |
| `gather_chunked()` | Chunked fan-out for large coroutine lists | Manual chunking in app_integrations |
| `create_named_task()` | Tracked task creation with done-callback cleanup | Raw `asyncio.create_task()` |
| `wait_for_event()` | Interruptible sleep that wakes on shutdown event | Raw `asyncio.sleep()` in polling loops |

### Instant drain on disconnect (shutdown event pattern)

**Problem**: `drain_tasks(cancel=False)` waits up to 30s for bg tasks, but polling tasks (e.g. `_record_usage_periodically` with 60s sleep) are mid-`asyncio.sleep()` and can't observe shutdown — they sit idle until the sleep finishes or drain times out.

**Solution**: Per-connection `asyncio.Event` (shutdown_event) that fires on disconnect. All polling loops use `wait_for_event(event, seconds)` instead of raw `asyncio.sleep()`. Pollers wake instantly (<1ms) on disconnect while heavy tasks (LLM processing) still get their full `cancel=False` grace period.

**Affected loops**:
- transcribe.py: `_record_usage_periodically` (60s), `send_heartbeat` (10s), `_pusher_heartbeat` (20s), pusher reconnect backoff (variable)
- pusher.py: `process_private_cloud_queue` (1s), `process_speaker_sample_queue` (15s), `process_transcript_queue` (1s), `process_audio_bytes_queue` (1s)

### Bug classes eliminated

| Bug Class | Old Pattern | New Pattern |
|-----------|-------------|-------------|
| Silent exception swallowing | `gather(*coros, return_exceptions=True)` with no inspection | `gather_safe()` logs every failure with label |
| Orphaned tasks on first failure | `gather()` propagates exception but siblings keep running | `supervise_tasks()` exits loop, then `drain_tasks()` cleans up |
| Unbounded fan-out | 50+ integrations × 1800 sessions = 90k concurrent connections | Semaphore-bounded via `max_concurrency` parameter |
| 30s drain delay on disconnect | Polling tasks mid-`asyncio.sleep()` ignore shutdown | `wait_for_event()` wakes pollers instantly via Event |

### Changes

| File | Change |
|------|--------|
| `utils/async_tasks.py` | **NEW** — 6 structured concurrency utilities with Prometheus metrics |
| `routers/pusher.py` | Refactored: supervisor, drain, shutdown event for all queue processors |
| `routers/transcribe.py` | Refactored: supervisor, drain, shutdown event for all polling loops |
| `utils/app_integrations.py` | Replaced 3× raw `gather(return_exceptions=True)` with `gather_safe()` |
| `tests/unit/test_async_tasks.py` | **NEW** — 45 tests: behavioral, structural, shutdown event, boundary edge cases |
| `tests/unit/test_pusher_ghost_connections.py` | Updated structural tests to verify utility usage |
| `test.sh` | Added `test_async_tasks.py` |
| `CLAUDE.md` | WebSocket concurrency rules, aligned with new async dispatch rules |
| `AGENTS.md` | Synced WebSocket concurrency rules |
| `docs/.../listen_pusher_pipeline.mdx` | Task supervision section |

### Prometheus metrics added

| Metric | Type | Purpose |
|--------|------|---------|
| `async_supervisor_exit_total{label,reason}` | Counter | Track supervisor exits by reason (disconnect/crash/lifetime_done) |
| `async_drain_timeout_total{label}` | Counter | Detect drain operations that hit timeout |
| `async_drain_duration_seconds{label}` | Histogram | Monitor drain latency |
| `async_gather_failures_total{label}` | Counter | Prove exceptions are caught, not swallowed |
| `async_gather_duration_seconds{label}` | Histogram | Detect slow fan-outs |

## Test plan

- [x] **45 unit tests pass** — behavioral (supervisor, drain, gather, chunked), structural (AST import/usage checks), shutdown event (zero/negative timeouts, polling loop exit), boundary edge cases
- [x] Backend boot check clean
- [x] **L1: 5-min podcast streaming** — 107 segments, 1911 words, connection held for full 279s
- [x] **L1: Client disconnect mid-stream** — clean abort, "Session ended, aborting Pusher retry" in logs
- [x] **L1: 3× concurrent streams** — all 3/3 connections held, 16 total segments, no event loop blocking
- [x] **L2: Backend + pusher integrated (5-min podcast)** — 107 segments, 1928 words, backend→pusher WS active throughout
- [x] **L2: Backend + pusher integrated (disconnect)** — clean lifecycle: disconnect detected, pusher reconnect ended, conversation cleaned up
- [x] CODEx reviewer approved (2 iterations — fixed zero-timeout edge case in wait_for_event)
- [x] CODEx tester approved (2 iterations — added boundary tests for drain/gather/chunked/shutdown)
- [x] CI: Lint & Format Check passed

## Risks

- **Behavior change in drain_tasks**: `drain_tasks(cancel=False)` first waits, then force-cancels on timeout. The old inline pattern did the same but with explicit `TimeoutError` handling. Risk is minimal since the utility implements the same logic.
- **gather_safe returns GatherResult**: Callers that used raw gather results need to access `.value` instead. Only `app_integrations.py` is affected and its callers don't use return values from gather.
- **Finite task misclassification**: If a truly lifetime task is marked finite, its completion won't trigger teardown. Mitigated by explicit `finite_tasks` set with only 2 members, plus structural tests.
- **shutdown_event is per-connection**: Each WS connection creates one `asyncio.Event`. At 1800 concurrent connections this is ~1800 Event objects — negligible memory overhead (<1KB each).

Closes #7280

🤖 Generated with [Claude Code](https://claude.com/claude-code)