### PR TITLE
fix(backend): Stripe webhook 500s on deleted users

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -90,7 +90,19 @@ def _build_subscription_from_stripe_object(stripe_sub: dict) -> Subscription | N
     """Builds a Subscription object from a Stripe Subscription object."""
     stripe_status = stripe_sub['status']
 
-    # Get price ID from subscription items
+    # For inactive subscriptions (canceled, unpaid, etc.), always downgrade to Basic
+    # regardless of price ID — ensures deleted/canceled users don't keep paid access
+    if stripe_status not in ('active', 'trialing'):
+        return Subscription(
+            plan=PlanType.basic,
+            status=SubscriptionStatus.active,
+            current_period_end=stripe_sub.get('current_period_end'),
+            stripe_subscription_id=stripe_sub['id'],
+            cancel_at_period_end=False,
+            limits=get_basic_plan_limits(),
+        )
+
+    # Active subscriptions: resolve plan from price ID
     price_id = stripe_sub['items']['data'][0]['price']['id'] if stripe_sub['items']['data'] else None
 
     if not price_id:
@@ -101,25 +113,13 @@ def _build_subscription_from_stripe_object(stripe_sub: dict) -> Subscription | N
     except ValueError:
         return None
 
-    if stripe_status in ('active', 'trialing'):
-        status = SubscriptionStatus.active
-        limits = get_plan_limits(plan)
-        cancel_at_period_end = stripe_sub.get('cancel_at_period_end', False)
-    else:  # including 'canceled', 'unpaid', etc.
-        # When a Stripe subscription is not active anymore, fall back to Basic plan
-        # and mark it ACTIVE so the user retains free-tier access immediately.
-        plan = PlanType.basic
-        status = SubscriptionStatus.active
-        limits = get_basic_plan_limits()
-        cancel_at_period_end = False
-
     return Subscription(
         plan=plan,
-        status=status,
+        status=SubscriptionStatus.active,
         current_period_end=stripe_sub.get('current_period_end'),
         stripe_subscription_id=stripe_sub['id'],
-        cancel_at_period_end=cancel_at_period_end,
-        limits=limits,
+        cancel_at_period_end=stripe_sub.get('cancel_at_period_end', False),
+        limits=get_plan_limits(plan),
     )
 
 
@@ -634,6 +634,14 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
             logger.info(
                 f"Processing subscription for user {uid} (from {'client_reference_id' if client_reference_id else 'metadata'})"
             )
+
+            # Verify user exists before processing — the subscription getter has
+            # create-on-miss behavior that would resurrect a deleted user's doc
+            if not users_db.get_user_profile(uid):
+                logger.warning(
+                    f"Stripe webhook: user {uid} not found in Firestore, " f"skipping checkout session processing"
+                )
+                return {"status": "success"}
 
             # Check if user already has an active subscription to prevent duplicates
             existing_subscription = users_db.get_user_valid_subscription(uid)

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -127,16 +127,21 @@ def _update_subscription_from_session(uid: str, session: stripe.checkout.Session
     customer_id = session.get('customer')
     subscription_id = session.get('subscription')
 
-    if customer_id:
-        users_db.set_stripe_customer_id(uid, customer_id)
+    try:
+        if customer_id:
+            users_db.set_stripe_customer_id(uid, customer_id)
 
-    if subscription_id:
-        stripe_sub = stripe.Subscription.retrieve(subscription_id)
-        if stripe_sub:
-            new_subscription = _build_subscription_from_stripe_object(stripe_sub.to_dict())
-            if new_subscription:
-                users_db.update_user_subscription(uid, new_subscription.dict())
-                logger.info(f"Subscription for user {uid} updated from session {session.id}.")
+        if subscription_id:
+            stripe_sub = stripe.Subscription.retrieve(subscription_id)
+            if stripe_sub:
+                new_subscription = _build_subscription_from_stripe_object(stripe_sub.to_dict())
+                if new_subscription:
+                    users_db.update_user_subscription(uid, new_subscription.dict())
+                    logger.info(f"Subscription for user {uid} updated from session {session.id}.")
+    except FirestoreNotFound:
+        logger.warning(
+            f"Stripe webhook: user {uid} not found in Firestore, " f"skipping checkout session subscription update"
+        )
 
 
 def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
@@ -726,6 +731,15 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                         f"Stripe webhook: user {uid} not found in Firestore, "
                         f"skipping subscription update for event {event['type']}"
                     )
+            else:
+                subscription_id = subscription_obj.get('id', 'unknown')
+                price_id = 'unknown'
+                if subscription_obj.get('items', {}).get('data'):
+                    price_id = subscription_obj['items']['data'][0].get('price', {}).get('id', 'unknown')
+                logger.warning(
+                    f"Stripe webhook: could not build subscription for user {uid}, "
+                    f"subscription {subscription_id}, price {price_id} — unknown price ID"
+                )
 
     # Handle subscription schedule events
     if event['type'] in [

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 
 from fastapi import Request, Header, HTTPException, APIRouter, Depends, Query
+from google.api_core.exceptions import NotFound as FirestoreNotFound
 import stripe
 from pydantic import BaseModel
 from typing import List, Optional
@@ -672,20 +673,23 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                 except Exception as e:
                     logger.error(f"Error updating subscription metadata: {e}")
 
-                # Get subscription details
-                stripe_sub = stripe.Subscription.retrieve(subscription_id)
-                if stripe_sub:
-                    subscription_obj = stripe_sub.to_dict()
-                    if subscription_obj and subscription_obj['items']['data']:
-                        price_id = subscription_obj['items']['data'][0]['price']['id']
-                        try:
-                            plan_type = get_plan_type_from_price_id(price_id)
-                            if is_paid_plan(plan_type):
-                                await send_subscription_paid_personalized_notification(uid)
-                        except ValueError:
-                            logger.warning(
-                                f"Ignoring checkout session for subscription with unknown price_id: {price_id}"
-                            )
+                # Send paid notification if applicable
+                try:
+                    stripe_sub = stripe.Subscription.retrieve(subscription_id)
+                    if stripe_sub:
+                        subscription_obj = stripe_sub.to_dict()
+                        if subscription_obj and subscription_obj['items']['data']:
+                            price_id = subscription_obj['items']['data'][0]['price']['id']
+                            try:
+                                plan_type = get_plan_type_from_price_id(price_id)
+                                if is_paid_plan(plan_type):
+                                    await send_subscription_paid_personalized_notification(uid)
+                            except ValueError:
+                                logger.warning(
+                                    f"Ignoring checkout session for subscription with unknown price_id: {price_id}"
+                                )
+                except Exception as e:
+                    logger.error(f"Error retrieving subscription for notification: {sanitize(str(e))}")
 
     if event['type'] in [
         'customer.subscription.updated',
@@ -707,15 +711,21 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
         if uid:
             new_subscription = _build_subscription_from_stripe_object(subscription_obj)
             if new_subscription:
-                if new_subscription.status == SubscriptionStatus.active and is_paid_plan(new_subscription.plan):
-                    conversations_db.unlock_all_conversations(uid)
-                    memories_db.unlock_all_memories(uid)
-                    action_items_db.unlock_all_action_items(uid)
-                users_db.update_user_subscription(uid, new_subscription.dict())
-                set_credits_invalidation_signal(uid)
-                if new_subscription.status == SubscriptionStatus.active and is_paid_plan(new_subscription.plan):
-                    clear_fair_use_on_upgrade(uid)
-                logger.info(f"Subscription for user {uid} updated from webhook event: {event['type']}.")
+                try:
+                    if new_subscription.status == SubscriptionStatus.active and is_paid_plan(new_subscription.plan):
+                        conversations_db.unlock_all_conversations(uid)
+                        memories_db.unlock_all_memories(uid)
+                        action_items_db.unlock_all_action_items(uid)
+                    users_db.update_user_subscription(uid, new_subscription.dict())
+                    set_credits_invalidation_signal(uid)
+                    if new_subscription.status == SubscriptionStatus.active and is_paid_plan(new_subscription.plan):
+                        clear_fair_use_on_upgrade(uid)
+                    logger.info(f"Subscription for user {uid} updated from webhook event: {event['type']}.")
+                except FirestoreNotFound:
+                    logger.warning(
+                        f"Stripe webhook: user {uid} not found in Firestore, "
+                        f"skipping subscription update for event {event['type']}"
+                    )
 
     # Handle subscription schedule events
     if event['type'] in [
@@ -733,13 +743,23 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                         new_subscription_id = schedule_obj['subscription']
                         new_stripe_sub = stripe.Subscription.retrieve(new_subscription_id)
                         new_subscription = _build_subscription_from_stripe_object(new_stripe_sub.to_dict())
-                        users_db.update_user_subscription(uid, new_subscription.dict())
-                        set_credits_invalidation_signal(uid)
-                        if new_subscription and is_paid_plan(new_subscription.plan):
-                            clear_fair_use_on_upgrade(uid)
-                        logger.info(
-                            f"Scheduled upgrade completed for user {uid}. New subscription: {new_subscription_id}"
-                        )
+                        if not new_subscription:
+                            logger.warning(
+                                f"Could not build subscription from scheduled upgrade for user {uid}, "
+                                f"subscription {new_subscription_id} — unknown price ID"
+                            )
+                        else:
+                            users_db.update_user_subscription(uid, new_subscription.dict())
+                            set_credits_invalidation_signal(uid)
+                            if is_paid_plan(new_subscription.plan):
+                                clear_fair_use_on_upgrade(uid)
+                            logger.info(
+                                f"Scheduled upgrade completed for user {uid}. New subscription: {new_subscription_id}"
+                            )
+                except FirestoreNotFound:
+                    logger.warning(
+                        f"Stripe webhook: user {uid} not found in Firestore, " f"skipping scheduled upgrade update"
+                    )
                 except Exception as e:
                     logger.error(f"Error updating subscription after scheduled upgrade: {e}")
             elif schedule_obj.get('status') == 'canceled':
@@ -752,11 +772,22 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
 
                         # Build subscription object with cancellation status
                         new_subscription = _build_subscription_from_stripe_object(subscription_obj)
-                        new_subscription.cancel_at_period_end = True
-
-                        users_db.update_user_subscription(uid, new_subscription.dict())
-                        set_credits_invalidation_signal(uid)
-                        logger.info(f"Subscription schedule canceled for user {uid}. Subscription: {subscription_id}")
+                        if not new_subscription:
+                            logger.warning(
+                                f"Could not build subscription from schedule cancellation for user {uid}, "
+                                f"subscription {subscription_id} — unknown price ID"
+                            )
+                        else:
+                            new_subscription.cancel_at_period_end = True
+                            users_db.update_user_subscription(uid, new_subscription.dict())
+                            set_credits_invalidation_signal(uid)
+                            logger.info(
+                                f"Subscription schedule canceled for user {uid}. Subscription: {subscription_id}"
+                            )
+                except FirestoreNotFound:
+                    logger.warning(
+                        f"Stripe webhook: user {uid} not found in Firestore, " f"skipping schedule cancellation update"
+                    )
                 except Exception as e:
                     logger.error(f"Error updating subscription after schedule cancellation: {e}")
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -98,6 +98,7 @@ pytest tests/unit/test_chat_quota.py -v
 pytest tests/unit/test_subscription_plans.py -v
 pytest tests/unit/test_payment_available_plans_source.py -v
 pytest tests/unit/test_stripe_webhook_none_guard.py -v
+pytest tests/unit/test_stripe_webhook_behavioral.py -v
 pytest tests/unit/test_voice_duration_limiter.py -v
 pytest tests/unit/test_async_webhooks.py -v
 pytest tests/unit/test_async_app_integrations.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -97,6 +97,7 @@ pytest tests/unit/test_subscription_restructure.py -v
 pytest tests/unit/test_chat_quota.py -v
 pytest tests/unit/test_subscription_plans.py -v
 pytest tests/unit/test_payment_available_plans_source.py -v
+pytest tests/unit/test_stripe_webhook_none_guard.py -v
 pytest tests/unit/test_voice_duration_limiter.py -v
 pytest tests/unit/test_async_webhooks.py -v
 pytest tests/unit/test_async_app_integrations.py -v

--- a/backend/tests/unit/test_stripe_webhook_behavioral.py
+++ b/backend/tests/unit/test_stripe_webhook_behavioral.py
@@ -1,0 +1,142 @@
+"""Behavioral tests for Stripe webhook error handling (#7282).
+
+These tests verify actual function behavior (not just source patterns) by extracting
+the _build_subscription_from_stripe_object function and testing it with controlled inputs.
+
+The full import chain (routers.payment → database._client → Firestore) requires GCP
+credentials and Python 3.10+, so we extract and test the function logic directly.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Models import cleanly without database chain
+from models.users import PlanType, SubscriptionStatus, Subscription
+
+# ── Helper: extract and compile _build_subscription_from_stripe_object ──────
+
+
+def _get_build_subscription_fn():
+    """Extract _build_subscription_from_stripe_object from payment.py source and
+    compile it into an executable function with controlled dependencies."""
+    source = (Path(__file__).resolve().parents[2] / "routers" / "payment.py").read_text()
+    func_start = source.index('def _build_subscription_from_stripe_object')
+    next_func = source.index('\ndef ', func_start + 1)
+    func_source = source[func_start:next_func]
+
+    # Strip Python 3.10+ type union syntax (Subscription | None) for 3.9 compat
+    func_source = func_source.replace('Subscription | None', 'object')
+
+    # Build a namespace with the dependencies the function needs
+    namespace = {
+        'PlanType': PlanType,
+        'SubscriptionStatus': SubscriptionStatus,
+        'Subscription': Subscription,
+        'get_plan_type_from_price_id': None,  # set per-test
+        'get_plan_limits': None,  # set per-test
+        'get_basic_plan_limits': lambda: {'daily_chat_message_limit': 10, 'daily_speech_hours_limit': 1},
+    }
+    exec(compile(func_source, '<payment.py>', 'exec'), namespace)
+    return namespace['_build_subscription_from_stripe_object'], namespace
+
+
+# ── Behavioral tests for _build_subscription_from_stripe_object ─────────────
+
+
+def _make_stripe_sub(status='active', price_id='price_test_123', cancel_at_period_end=False):
+    """Create a minimal Stripe subscription dict for testing."""
+    return {
+        'id': 'sub_test_abc',
+        'status': status,
+        'items': {'data': [{'price': {'id': price_id}}]},
+        'current_period_end': 1700000000,
+        'cancel_at_period_end': cancel_at_period_end,
+    }
+
+
+class TestBuildSubscriptionFromStripeObject:
+    """Test _build_subscription_from_stripe_object behavior with various inputs."""
+
+    def setup_method(self):
+        self.fn, self.ns = _get_build_subscription_fn()
+        # Default stubs
+        self.ns['get_plan_type_from_price_id'] = lambda price_id: PlanType.unlimited
+        self.ns['get_plan_limits'] = lambda plan: {'daily_chat_message_limit': 100, 'daily_speech_hours_limit': 10}
+
+    def test_active_subscription_with_valid_price(self):
+        """Active subscription with known price ID returns correct Subscription."""
+        result = self.fn(_make_stripe_sub(status='active', price_id='price_known'))
+        assert result is not None
+        assert result.plan == PlanType.unlimited
+        assert result.status == SubscriptionStatus.active
+        assert result.stripe_subscription_id == 'sub_test_abc'
+        assert result.cancel_at_period_end is False
+
+    def test_trialing_subscription_with_valid_price(self):
+        """Trialing subscription treated same as active."""
+        result = self.fn(_make_stripe_sub(status='trialing', price_id='price_known'))
+        assert result is not None
+        assert result.plan == PlanType.unlimited
+        assert result.status == SubscriptionStatus.active
+
+    def test_active_subscription_with_unknown_price_returns_none(self):
+        """Active subscription with unknown price ID returns None (can't determine plan)."""
+        self.ns['get_plan_type_from_price_id'] = MagicMock(side_effect=ValueError("Unknown price"))
+        result = self.fn(_make_stripe_sub(status='active', price_id='price_unknown'))
+        assert result is None
+
+    def test_active_subscription_with_empty_items_returns_none(self):
+        """Active subscription with no price items returns None."""
+        sub = _make_stripe_sub(status='active')
+        sub['items']['data'] = []
+        result = self.fn(sub)
+        assert result is None
+
+    def test_canceled_subscription_downgrades_to_basic(self):
+        """Canceled subscription always downgrades to Basic regardless of price ID."""
+        result = self.fn(_make_stripe_sub(status='canceled', price_id='price_anything'))
+        assert result is not None
+        assert result.plan == PlanType.basic
+        assert result.status == SubscriptionStatus.active
+        assert result.cancel_at_period_end is False
+
+    def test_canceled_subscription_with_unknown_price_still_downgrades(self):
+        """Canceled subscription with unknown price ID still downgrades to Basic.
+        This is the key fix — before PR #7284, this would return None and leave
+        stale paid access."""
+        self.ns['get_plan_type_from_price_id'] = MagicMock(side_effect=ValueError("Unknown"))
+        result = self.fn(_make_stripe_sub(status='canceled', price_id='price_unknown'))
+        assert result is not None
+        assert result.plan == PlanType.basic
+
+    def test_unpaid_subscription_downgrades_to_basic(self):
+        """Unpaid subscription downgrades to Basic."""
+        result = self.fn(_make_stripe_sub(status='unpaid', price_id='price_test'))
+        assert result is not None
+        assert result.plan == PlanType.basic
+
+    def test_active_with_cancel_at_period_end(self):
+        """Active subscription with cancel_at_period_end preserves that flag."""
+        result = self.fn(_make_stripe_sub(status='active', cancel_at_period_end=True))
+        assert result is not None
+        assert result.cancel_at_period_end is True
+
+    def test_canceled_ignores_cancel_at_period_end(self):
+        """Canceled subscription always sets cancel_at_period_end to False."""
+        result = self.fn(_make_stripe_sub(status='canceled', cancel_at_period_end=True))
+        assert result is not None
+        assert result.cancel_at_period_end is False
+
+    def test_subscription_includes_stripe_id(self):
+        """Result always includes the Stripe subscription ID."""
+        result = self.fn(_make_stripe_sub())
+        assert result.stripe_subscription_id == 'sub_test_abc'
+
+    def test_subscription_includes_period_end(self):
+        """Result always includes current_period_end."""
+        result = self.fn(_make_stripe_sub())
+        assert result.current_period_end == 1700000000

--- a/backend/tests/unit/test_stripe_webhook_none_guard.py
+++ b/backend/tests/unit/test_stripe_webhook_none_guard.py
@@ -5,9 +5,11 @@ The update_user_subscription() call uses Firestore .update() which requires the 
 to exist — deleted or never-created users cause google.api_core.exceptions.NotFound.
 
 Fixes verified via source-level analysis (no heavy imports needed):
-1. FirestoreNotFound catch at all update_user_subscription call sites
+1. FirestoreNotFound catch at all update_user_subscription call sites (4 total:
+   checkout session, customer.subscription.*, schedule completed, schedule canceled)
 2. None-guard for _build_subscription_from_stripe_object in schedule handlers
 3. try/except for notification stripe.Subscription.retrieve
+4. Logging when _build_subscription_from_stripe_object returns None
 """
 
 from pathlib import Path
@@ -29,18 +31,19 @@ def test_imports_firestore_not_found():
 
 
 def test_catches_firestore_not_found_at_all_update_sites():
-    """All three webhook paths that call update_user_subscription must catch FirestoreNotFound.
+    """All four webhook paths that call update_user_subscription must catch FirestoreNotFound.
 
     Call sites:
-    1. customer.subscription.* handler (the actual crash site from logs)
-    2. subscription_schedule.completed handler
-    3. subscription_schedule.canceled handler
+    1. _update_subscription_from_session (checkout.session.completed path)
+    2. customer.subscription.* handler (the actual crash site from logs)
+    3. subscription_schedule.completed handler
+    4. subscription_schedule.canceled handler
     """
     source = _read_source()
     catches = source.count('except FirestoreNotFound:')
-    assert catches >= 3, (
-        f"Expected at least 3 FirestoreNotFound catches "
-        f"(subscription update, schedule completion, schedule cancellation), "
+    assert catches >= 4, (
+        f"Expected at least 4 FirestoreNotFound catches "
+        f"(checkout session, subscription update, schedule completion, schedule cancellation), "
         f"found {catches}"
     )
 
@@ -48,8 +51,8 @@ def test_catches_firestore_not_found_at_all_update_sites():
 def test_logs_uid_in_firestore_not_found_warning():
     """FirestoreNotFound catches must include 'not found in Firestore' for debugging."""
     source = _read_source()
-    # All three handlers should log a warning with the user context
-    assert source.count('not found in Firestore') >= 3
+    # All four handlers should log a warning with the user context
+    assert source.count('not found in Firestore') >= 4
 
 
 # ── Fix 2: None-guard for _build_subscription_from_stripe_object ─────────────
@@ -121,3 +124,33 @@ def test_webhook_returns_success():
     func_section = source[func_start:]
     # The function should end with return {"status": "success"}
     assert 'return {"status": "success"}' in func_section
+
+
+# ── Fix 4: Checkout path FirestoreNotFound guard (CODEx-identified gap) ────
+
+
+def test_checkout_session_path_guarded():
+    """_update_subscription_from_session must catch FirestoreNotFound for deleted users.
+
+    This function is called from checkout.session.completed (line 654) and writes
+    via set_stripe_customer_id() and update_user_subscription() — both use .update().
+    """
+    source = _read_source()
+    func_start = source.index('def _update_subscription_from_session')
+    next_func = source.index('\ndef ', func_start + 1)
+    func_body = source[func_start:next_func]
+
+    assert 'except FirestoreNotFound:' in func_body, "_update_subscription_from_session must catch FirestoreNotFound"
+    assert 'not found in Firestore' in func_body
+
+
+def test_customer_subscription_logs_none_subscription():
+    """customer.subscription.* handler must log when _build_subscription_from_stripe_object returns None."""
+    source = _read_source()
+    handler_start = source.index("'customer.subscription.updated'")
+    handler_section = source[handler_start : handler_start + 2500]
+
+    # Must log unknown price ID when subscription build fails
+    assert (
+        'unknown price ID' in handler_section
+    ), "customer.subscription.* handler must log when subscription build returns None"

--- a/backend/tests/unit/test_stripe_webhook_none_guard.py
+++ b/backend/tests/unit/test_stripe_webhook_none_guard.py
@@ -1,0 +1,123 @@
+"""Tests for Stripe webhook error handling fixes (#7282).
+
+Root cause: Stripe webhooks crash with 500 when user doc doesn't exist in Firestore.
+The update_user_subscription() call uses Firestore .update() which requires the doc
+to exist — deleted or never-created users cause google.api_core.exceptions.NotFound.
+
+Fixes verified via source-level analysis (no heavy imports needed):
+1. FirestoreNotFound catch at all update_user_subscription call sites
+2. None-guard for _build_subscription_from_stripe_object in schedule handlers
+3. try/except for notification stripe.Subscription.retrieve
+"""
+
+from pathlib import Path
+
+PAYMENT_SOURCE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
+
+
+def _read_source():
+    return PAYMENT_SOURCE.read_text()
+
+
+# ── Fix 1: FirestoreNotFound guard for deleted users ─────────────────────────
+
+
+def test_imports_firestore_not_found():
+    """payment.py must import FirestoreNotFound for the deleted-user guard."""
+    source = _read_source()
+    assert 'from google.api_core.exceptions import NotFound as FirestoreNotFound' in source
+
+
+def test_catches_firestore_not_found_at_all_update_sites():
+    """All three webhook paths that call update_user_subscription must catch FirestoreNotFound.
+
+    Call sites:
+    1. customer.subscription.* handler (the actual crash site from logs)
+    2. subscription_schedule.completed handler
+    3. subscription_schedule.canceled handler
+    """
+    source = _read_source()
+    catches = source.count('except FirestoreNotFound:')
+    assert catches >= 3, (
+        f"Expected at least 3 FirestoreNotFound catches "
+        f"(subscription update, schedule completion, schedule cancellation), "
+        f"found {catches}"
+    )
+
+
+def test_logs_uid_in_firestore_not_found_warning():
+    """FirestoreNotFound catches must include 'not found in Firestore' for debugging."""
+    source = _read_source()
+    # All three handlers should log a warning with the user context
+    assert source.count('not found in Firestore') >= 3
+
+
+# ── Fix 2: None-guard for _build_subscription_from_stripe_object ─────────────
+
+
+def test_build_subscription_catches_unknown_price_id():
+    """_build_subscription_from_stripe_object catches ValueError and returns None."""
+    source = _read_source()
+    # Find the function definition
+    func_start = source.index('def _build_subscription_from_stripe_object')
+    # Find the next function definition to bound our search
+    next_func = source.index('\ndef ', func_start + 1)
+    func_body = source[func_start:next_func]
+
+    assert 'except ValueError:' in func_body
+    assert 'return None' in func_body
+
+
+def test_schedule_completion_checks_none_subscription():
+    """Schedule completion handler must check for None before .dict() call."""
+    source = _read_source()
+    # The fix adds: if not new_subscription: ... else: update
+    assert 'if not new_subscription:' in source
+    assert 'unknown price ID' in source
+
+
+def test_schedule_cancellation_checks_none_subscription():
+    """Schedule cancellation handler must check for None before .cancel_at_period_end = True."""
+    source = _read_source()
+    # Find the cancellation handler section
+    cancel_section_start = source.index("schedule_obj.get('status') == 'canceled'")
+    cancel_section = source[cancel_section_start : cancel_section_start + 1500]
+
+    # Must have the None guard before setting cancel_at_period_end
+    none_check_pos = cancel_section.index('if not new_subscription:')
+    cancel_attr_pos = cancel_section.index('cancel_at_period_end = True')
+    assert none_check_pos < cancel_attr_pos, "None check must appear before cancel_at_period_end assignment"
+
+
+# ── Fix 3: Notification retrieve wrapped in try/except ──────────────────────
+
+
+def test_notification_retrieve_wrapped():
+    """The second stripe.Subscription.retrieve for notifications must be in try/except."""
+    source = _read_source()
+    assert 'Error retrieving subscription for notification' in source
+
+
+# ── Existing behavior preserved ──────────────────────────────────────────────
+
+
+def test_customer_subscription_handler_still_guards_none():
+    """customer.subscription.* handler already had 'if new_subscription:' guard — verify it's intact."""
+    source = _read_source()
+    # Find the customer.subscription handler section
+    handler_start = source.index("'customer.subscription.updated'")
+    handler_section = source[handler_start : handler_start + 1500]
+
+    # Must still have the None guard from _build_subscription_from_stripe_object
+    assert 'if new_subscription:' in handler_section
+
+
+def test_webhook_returns_success():
+    """Webhook must always return {"status": "success"} at the end (Stripe expects 2xx)."""
+    source = _read_source()
+    # Find the stripe_webhook function
+    func_start = source.index("async def stripe_webhook(request: Request, stripe_signature: str = Header(None)):")
+    # Get to the return at the end of the function
+    func_section = source[func_start:]
+    # The function should end with return {"status": "success"}
+    assert 'return {"status": "success"}' in func_section

--- a/backend/tests/unit/test_stripe_webhook_none_guard.py
+++ b/backend/tests/unit/test_stripe_webhook_none_guard.py
@@ -51,8 +51,8 @@ def test_catches_firestore_not_found_at_all_update_sites():
 def test_logs_uid_in_firestore_not_found_warning():
     """FirestoreNotFound catches must include 'not found in Firestore' for debugging."""
     source = _read_source()
-    # All four handlers should log a warning with the user context
-    assert source.count('not found in Firestore') >= 4
+    # All handlers should log a warning with the user context (4 FirestoreNotFound + 1 checkout existence check)
+    assert source.count('not found in Firestore') >= 5
 
 
 # ── Fix 2: None-guard for _build_subscription_from_stripe_object ─────────────
@@ -154,3 +154,44 @@ def test_customer_subscription_logs_none_subscription():
     assert (
         'unknown price ID' in handler_section
     ), "customer.subscription.* handler must log when subscription build returns None"
+
+
+# ── Fix 5: Inactive subscriptions downgrade without needing valid price ID ──
+
+
+def test_build_subscription_downgrades_inactive_without_price_check():
+    """_build_subscription_from_stripe_object must downgrade inactive subs to Basic
+    without requiring a known price ID — prevents stale paid access on deletion."""
+    source = _read_source()
+    func_start = source.index('def _build_subscription_from_stripe_object')
+    next_func = source.index('\ndef ', func_start + 1)
+    func_body = source[func_start:next_func]
+
+    # The inactive branch must come BEFORE the price ID resolution
+    inactive_check_pos = func_body.index("not in ('active', 'trialing')")
+    price_resolve_pos = func_body.index('get_plan_type_from_price_id')
+    assert inactive_check_pos < price_resolve_pos, (
+        "Inactive status check must precede price ID resolution so deleted/canceled "
+        "subscriptions downgrade to Basic even with unknown price IDs"
+    )
+
+
+# ── Fix 6: Checkout path user existence check prevents doc resurrection ────
+
+
+def test_checkout_path_checks_user_exists_before_processing():
+    """checkout.session.completed handler must verify user exists before calling
+    get_user_valid_subscription (which has create-on-miss behavior)."""
+    source = _read_source()
+    # Find the regular user subscription branch within checkout handler
+    branch_start = source.index("# Regular user subscription")
+    branch_section = source[branch_start : branch_start + 1500]
+
+    # Must have user existence check before get_user_valid_subscription
+    assert 'get_user_profile' in branch_section, (
+        "Checkout handler must check user exists (via get_user_profile) "
+        "before get_user_valid_subscription to prevent doc resurrection"
+    )
+    profile_pos = branch_section.index('get_user_profile')
+    valid_sub_pos = branch_section.index('get_user_valid_subscription')
+    assert profile_pos < valid_sub_pos, "User existence check must come before get_user_valid_subscription"


### PR DESCRIPTION
## Summary

Fix Stripe webhook 500 errors caused by `Firestore .update()` on deleted user documents (#7282).

**Root cause:** `users_db.update_user_subscription()` uses `Firestore .update()` which requires the document to exist. When a user is deleted but Stripe still sends webhook events (subscription updates, schedule completions/cancellations), the handler crashes with `google.api_core.exceptions.NotFound` → HTTP 500.

**Evidence:** 4 occurrences in Cloud Run logs (confirmed by mon), all same deleted UID, crash at `payment.py:714`.

## Changes

### Fix 1: FirestoreNotFound guard at all 4 update sites
- `_update_subscription_from_session()` — checkout.session.completed path (CODEx-identified gap)
- `customer.subscription.*` handler — the actual crash site from logs
- `subscription_schedule.completed` handler
- `subscription_schedule.canceled` handler

### Fix 2: None-guard for `_build_subscription_from_stripe_object`
- Schedule completion: check for None before `.dict()` call
- Schedule cancellation: check for None before `.cancel_at_period_end = True`
- Customer subscription: log unknown price ID when build returns None

### Fix 3: Notification retrieve wrapped
- `stripe.Subscription.retrieve` for notifications wrapped in try/except

### Fix 4: Inactive subscription downgrade (reviewer feedback)
- Restructured `_build_subscription_from_stripe_object` to check inactive status BEFORE price ID resolution
- Ensures canceled/deleted subscriptions downgrade to Basic even with unknown price IDs

### Fix 5: Checkout user existence check (reviewer feedback)
- Added `get_user_profile(uid)` check before `get_user_valid_subscription()` in checkout path
- Prevents doc resurrection via `get_user_valid_subscription()`'s create-on-miss behavior

## Design Decision

`.update()` + `FirestoreNotFound` catch is correct (not `.set(merge=True)`) — `.set(merge=True)` would create zombie/partial user documents from stale Stripe events. Confirmed by CODEx consultation.

## Testing

**24 unit tests** (13 source-level + 11 behavioral), all passing on Python 3.11.

### Source-level tests (`test_stripe_webhook_none_guard.py` — 13 tests):
- Import verification, FirestoreNotFound catch count (>=4), warning log count (>=5)
- ValueError catch in build function, None guards in schedule handlers
- Notification retrieve wrapped, webhook returns success
- Checkout path FirestoreNotFound guard, None-subscription logging
- Inactive sub downgrade ordering, checkout user existence check

### Behavioral tests (`test_stripe_webhook_behavioral.py` — 11 tests):
- `_build_subscription_from_stripe_object` extracted via exec + namespace injection
- Active/trialing with valid price → correct Subscription
- Active with unknown price → None
- Active with empty items → None
- **Canceled with unknown price → Basic** (key regression fix)
- Unpaid → Basic
- cancel_at_period_end propagation (active preserves, canceled resets)
- stripe_subscription_id and current_period_end preservation

```
24 passed in 0.12s
```

### Live testing (CP9A — L1 standalone backend)

Backend started via `uvicorn main:app --port 18080` with Python 3.11.15.

**Happy paths (all PASS):**
| Path | Test | Result |
|---|---|---|
| `_build_subscription_from_stripe_object` (canceled) | Canceled sub → Basic downgrade | PASS |
| `_build_subscription_from_stripe_object` (unpaid) | Unpaid sub → Basic downgrade | PASS |
| `_build_subscription_from_stripe_object` (empty items) | Empty items → None (graceful) | PASS |
| `payment.py` import | FirestoreNotFound import loads | PASS |
| `_update_subscription_from_session` | Function exists and loads | PASS |

**Non-happy paths (all PASS):**
| Path | Test | Result |
|---|---|---|
| Canceled + unknown price ID | Still downgrades to Basic (KEY FIX) | PASS |
| Active + ValueError from price lookup | catch + return None | PASS |
| FirestoreNotFound exception | Catchable and handled | PASS |
| All webhook handlers | 4 FirestoreNotFound catch blocks | PASS |
| Schedule handlers | 2 None guards for build result | PASS |
| Checkout path | get_user_profile existence check | PASS |

### Live testing (CP9B — L2 integration, backend running)

| Test | Expected | Actual | Result |
|---|---|---|---|
| Webhook: missing signature | HTTP 400 | HTTP 400 | PASS |
| Webhook: invalid signature | HTTP 400 | HTTP 400 | PASS |
| Webhook: null signature | HTTP 400 | HTTP 400 | PASS |
| Backend health after 5 bad requests | HTTP 200 (OpenAPI) | HTTP 200 | PASS |
| Backend log errors | 0 unhandled | 0 unhandled | PASS |

## Omi PR Workflow Checkpoints

| CP | Description | Status |
|---|---|---|
| CP0 | Skills discovery & preflight | ✅ |
| CP1 | Issue understood, acceptance criteria | ✅ |
| CP2 | Workspace clean, branch created | ✅ |
| CP3 | Exploration complete, approach planned | ✅ |
| CP4 | CODEx consult (3 turns) | ✅ |
| CP5 | Implementation + tests | ✅ |
| CP6 | PR created | ✅ |
| CP7 | Review loop approved | ✅ |
| CP8 | Test cycle approved (24/24) | ✅ |
| CP9A | L1 live test (standalone backend) | ✅ |
| CP9B | L2 live test (integration) | ✅ |

## Risks / Edge Cases

- **Deleted user events are silently skipped** — intentional; there's nothing to update
- **Unknown price IDs** now logged with subscription and price ID for debugging
- **Inactive subs always downgrade to Basic** regardless of price ID — prevents stale paid access
- **Checkout path**: user existence check prevents doc resurrection
- **Retry semantics**: Schedule handlers catch broad `Exception` (pre-existing) — could be tightened in follow-up

## Review Cycle

- **Iteration 1**: Reviewer found 2 gaps — inactive sub downgrade and checkout doc resurrection
- **Iteration 2**: Both addressed → PR_APPROVED_LGTM
- **Tester round 1**: Requested behavioral tests → added 11 executable tests
- **Tester round 2**: TESTS_APPROVED (24/24 pass)

Closes #7282

_by AI for @beastoin_