### PR TITLE
fix: sync 504 timeouts — thread pool bulkheads, timeouts, and observability (#7281)

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1387,14 +1387,17 @@ def _run_full_pipeline_background(
         vad_errors = []
 
         def _run_vad_bg(path):
-            retrieve_vad_segments(path, segmented_paths, vad_errors)
+            try:
+                retrieve_vad_segments(path, segmented_paths, vad_errors)
+            except Exception as e:
+                vad_errors.append(f'{path}: {e}')
 
         futures = [critical_executor.submit(_run_vad_bg, path) for path in wav_paths]
         for future in futures:
             try:
                 future.result()
             except Exception as e:
-                logger.error(f'sync_v2 bg: VAD error: {e}')
+                vad_errors.append(f'VAD executor error: {e}')
 
         _cleanup_files(wav_paths)
         wav_paths = []

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1399,8 +1399,13 @@ def _run_full_pipeline_background(
         _cleanup_files(wav_paths)
         wav_paths = []
 
-        if vad_errors and not segmented_paths:
-            mark_job_failed(job_id, f'VAD failed for all files: {"; ".join(vad_errors[:3])}')
+        if vad_errors:
+            error_detail = f'VAD failed for {len(vad_errors)} file(s): {"; ".join(vad_errors[:3])}'
+            if len(vad_errors) > 3:
+                error_detail += f' (and {len(vad_errors) - 3} more)'
+            _cleanup_files(list(segmented_paths))
+            segmented_paths = set()
+            mark_job_failed(job_id, error_detail)
             return
 
         # --- Phase 3: Speech metrics & fair-use ---
@@ -1430,7 +1435,10 @@ def _run_full_pipeline_background(
             if triggered_caps:
                 logger.info(f'sync_v2 bg: soft caps triggered for {uid}: {triggered_caps}')
                 if event_loop:
-                    asyncio.run_coroutine_threadsafe(trigger_classifier_if_needed(uid, triggered_caps), event_loop)
+                    try:
+                        asyncio.run_coroutine_threadsafe(trigger_classifier_if_needed(uid, triggered_caps), event_loop)
+                    except Exception as e:
+                        logger.error(f'sync_v2 bg: classifier scheduling failed for {uid}: {e}')
 
         # DG budget gate
         fair_use_restrict_dg = False

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1353,8 +1353,7 @@ def _run_full_pipeline_background(
 
     Moved ALL heavy processing here so the v2 endpoint returns 202 immediately.
     """
-    if byok_keys:
-        set_byok_keys(byok_keys)
+    set_byok_keys(byok_keys or {})
     segmented_paths = set()
     wav_paths = []
     stage_timings = {}
@@ -1575,6 +1574,7 @@ def _run_full_pipeline_background(
         except Exception:
             pass
     finally:
+        set_byok_keys({})
         _cleanup_files(list(segmented_paths))
         _cleanup_files(wav_paths)
         try:

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1400,7 +1400,7 @@ def _run_full_pipeline_background(
             except Exception as e:
                 vad_errors.append(f'{path}: {e}')
 
-        futures = [sync_executor.submit(_run_vad_bg, path) for path in wav_paths]
+        futures = [submit_with_context(sync_executor, _run_vad_bg, path) for path in wav_paths]
         for future in futures:
             try:
                 future.result(timeout=300)

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -49,6 +49,7 @@ from utils.other.storage import (
 )
 
 from utils import encryption
+from utils.byok import get_byok_keys, set_byok_keys
 from utils.log_sanitizer import sanitize
 from utils.stt.pre_recorded import deepgram_prerecorded, get_deepgram_model_for_language, postprocess_words
 from utils.stt.vad import vad_is_empty
@@ -1346,11 +1347,14 @@ def _run_full_pipeline_background(
     job_dir: str,
     target_conversation_id: str = None,
     event_loop=None,
+    byok_keys: dict = None,
 ):
     """Background worker: runs the full sync pipeline (decode → VAD → fair-use → STT → LLM).
 
     Moved ALL heavy processing here so the v2 endpoint returns 202 immediately.
     """
+    if byok_keys:
+        set_byok_keys(byok_keys)
     segmented_paths = set()
     wav_paths = []
     stage_timings = {}
@@ -1622,6 +1626,9 @@ async def sync_local_files_v2(
         # Capture event loop for async calls from background thread
         loop_v2 = asyncio.get_running_loop()
 
+        # Capture BYOK keys from the request context before dispatching to thread
+        captured_byok = get_byok_keys()
+
         # Transfer ownership of raw paths to the background thread
         owned_paths = list(paths)
         paths = []  # Prevent finally cleanup of files now owned by bg thread
@@ -1638,6 +1645,7 @@ async def sync_local_files_v2(
             job_dir,
             conversation_id,
             loop_v2,
+            captured_byok,
         )
 
         return JSONResponse(

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1298,9 +1298,10 @@ async def sync_local_files(
 # v2 async sync-local-files
 # ---------------------------------------------------------------------------
 # v1 processes segments synchronously (80-180s for large payloads → 504).
-# v2 does the fast path (decode, VAD) inline, then hands off STT+LLM to a
-# background thread. The app polls GET /v2/sync-local-files/{job_id} until
-# the job reaches a terminal status.
+# v2 returns 202 immediately after saving raw files, then runs the full
+# pipeline (decode → VAD → fair-use → STT → LLM) in a background thread.
+# The app polls GET /v2/sync-local-files/{job_id} until the job reaches
+# a terminal status.
 # ---------------------------------------------------------------------------
 
 
@@ -1336,27 +1337,143 @@ def _retrieve_file_paths_v2(files: List[UploadFile], uid: str, job_id: str):
     return paths
 
 
-def _process_segments_background(
+def _run_full_pipeline_background(
     job_id: str,
     uid: str,
-    segmented_paths: list,
+    raw_paths: list,
     source,
-    is_locked: bool,
-    fair_use_restrict_dg: bool,
-    total_speech_seconds: float,
+    should_lock: bool,
     job_dir: str,
-    transcription_prefs: Optional[dict] = None,
-    person_embeddings_cache: Optional[Dict[str, dict]] = None,
     target_conversation_id: str = None,
+    event_loop=None,
 ):
-    """Background worker: runs segment processing and updates Redis job status."""
+    """Background worker: runs the full sync pipeline (decode → VAD → fair-use → STT → LLM).
+
+    Moved ALL heavy processing here so the v2 endpoint returns 202 immediately.
+    """
+    segmented_paths = set()
+    wav_paths = []
     try:
         mark_job_processing(job_id)
 
+        # --- Phase 1: Decode ---
+        update_sync_job(job_id, {'stage': 'decoding'})
+        try:
+            wav_paths = decode_files_to_wav(raw_paths)
+        except HTTPException as e:
+            mark_job_failed(job_id, f'Decode failed: {e.detail}')
+            return
+        except Exception as e:
+            mark_job_failed(job_id, f'Decode failed: {e}')
+            return
+        finally:
+            _cleanup_files(raw_paths)
+
+        if not wav_paths:
+            mark_job_completed(
+                job_id,
+                {
+                    'new_memories': [],
+                    'updated_memories': [],
+                    'failed_segments': 0,
+                    'total_segments': 0,
+                    'errors': [],
+                },
+            )
+            return
+
+        # --- Phase 2: VAD ---
+        update_sync_job(job_id, {'stage': 'vad'})
+        vad_errors = []
+
+        def _run_vad_bg(path):
+            retrieve_vad_segments(path, segmented_paths, vad_errors)
+
+        futures = [critical_executor.submit(_run_vad_bg, path) for path in wav_paths]
+        for future in futures:
+            try:
+                future.result()
+            except Exception as e:
+                logger.error(f'sync_v2 bg: VAD error: {e}')
+
+        _cleanup_files(wav_paths)
+        wav_paths = []
+
+        if vad_errors and not segmented_paths:
+            mark_job_failed(job_id, f'VAD failed for all files: {"; ".join(vad_errors[:3])}')
+            return
+
+        # --- Phase 3: Speech metrics & fair-use ---
+        total_speech_seconds = sum(get_wav_duration(p) for p in segmented_paths)
+        total_speech_ms = int(total_speech_seconds * 1000)
+        total_segments = len(segmented_paths)
+
+        update_sync_job(job_id, {'total_segments': total_segments, 'stage': 'processing'})
+
+        if total_segments == 0:
+            mark_job_completed(
+                job_id,
+                {
+                    'new_memories': [],
+                    'updated_memories': [],
+                    'failed_segments': 0,
+                    'total_segments': 0,
+                    'errors': [],
+                },
+            )
+            return
+
+        if FAIR_USE_ENABLED and total_speech_ms > 0:
+            record_speech_ms(uid, total_speech_ms, source='sync')
+            speech_totals = get_rolling_speech_ms(uid)
+            triggered_caps = check_soft_caps(uid, speech_totals=speech_totals)
+            if triggered_caps:
+                logger.info(f'sync_v2 bg: soft caps triggered for {uid}: {triggered_caps}')
+                if event_loop:
+                    asyncio.run_coroutine_threadsafe(trigger_classifier_if_needed(uid, triggered_caps), event_loop)
+
+        # DG budget gate
+        fair_use_restrict_dg = False
+        if FAIR_USE_ENABLED:
+            try:
+                fair_use_stage = get_enforcement_stage(uid)
+                if fair_use_stage == 'restrict' and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
+                    fair_use_restrict_dg = True
+                    if is_dg_budget_exhausted(uid):
+                        _cleanup_files(list(segmented_paths))
+                        segmented_paths = set()
+                        mark_job_completed(
+                            job_id,
+                            {
+                                'new_memories': [],
+                                'updated_memories': [],
+                                'failed_segments': 0,
+                                'total_segments': total_segments,
+                                'errors': [],
+                                'dg_budget_exhausted': True,
+                                'skipped_segments': total_segments,
+                            },
+                        )
+                        return
+            except Exception as e:
+                logger.error(f'sync_v2 bg: DG budget check error for {uid}: {e}')
+
+        is_locked = should_lock
+
+        # --- Phase 4: Fetch prefs & embeddings ---
+        transcription_prefs = users_db.get_user_transcription_preferences(uid)
+        try:
+            person_embeddings_cache = build_person_embeddings_cache(uid)
+            if person_embeddings_cache:
+                logger.info(f'sync_v2 bg: loaded {len(person_embeddings_cache)} person embeddings uid={uid}')
+        except Exception as e:
+            logger.warning(f'sync_v2 bg: failed to load person embeddings uid={uid}: {e}')
+            person_embeddings_cache = {}
+
+        # --- Phase 5: Process segments (STT + LLM) ---
         response = {'updated_memories': set(), 'new_memories': set()}
         segment_errors = []
         segment_lock = threading.Lock()
-        total_segments = len(segmented_paths)
 
         def _process_one_segment(path):
             process_segment(
@@ -1372,33 +1489,31 @@ def _process_segments_background(
                 target_conversation_id,
             )
 
-        # Process in chunks of 5, with heartbeat after each chunk
         chunk_size = 5
         segment_list = list(segmented_paths)
         for i in range(0, len(segment_list), chunk_size):
             chunk = segment_list[i : i + chunk_size]
-            futures = [critical_executor.submit(_process_one_segment, path) for path in chunk]
-            for future in futures:
+            seg_futures = [critical_executor.submit(_process_one_segment, path) for path in chunk]
+            for future in seg_futures:
                 try:
                     future.result()
                 except Exception as e:
-                    logger.error(f"Error processing segment: {e}")
-            # Heartbeat: refresh updated_at so stale detection doesn't kill active jobs
+                    logger.error(f'sync_v2 bg: segment error: {e}')
             try:
                 update_sync_job(job_id, {'processed_segments': min(i + chunk_size, len(segment_list))})
             except Exception:
-                pass  # Non-fatal: stale detection is a safety net, not a hard gate
+                pass
 
-        # Record DG usage after processing (not before, to avoid charging on retries)
+        # Record DG usage after processing
         if fair_use_restrict_dg:
             try:
                 dg_ms = int(total_speech_seconds * 1000)
                 if dg_ms > 0:
                     record_dg_usage_ms(uid, dg_ms)
             except Exception as e:
-                logger.error(f'sync_v2: DG usage record error for {uid}: {e}')
+                logger.error(f'sync_v2 bg: DG usage record error for {uid}: {e}')
 
-        # Build result matching v1 response shape
+        # Build result
         failed_segments = len(segment_errors)
         successful_segments = total_segments - failed_segments
         result = {
@@ -1410,14 +1525,13 @@ def _process_segments_background(
             result['total_segments'] = total_segments
             result['errors'] = segment_errors[:10]
 
-        # Record subscription usage only when at least one segment succeeded
         if successful_segments > 0:
             try:
                 usage_seconds = int(total_speech_seconds)
                 if usage_seconds > 0:
                     record_usage(uid, transcription_seconds=usage_seconds, speech_seconds=usage_seconds)
             except Exception as e:
-                logger.error(f'sync_v2: usage record error for {uid}: {e}')
+                logger.error(f'sync_v2 bg: usage record error for {uid}: {e}')
 
         mark_job_completed(
             job_id,
@@ -1430,25 +1544,21 @@ def _process_segments_background(
             },
         )
 
-        logger.info(
-            f'sync_v2 background complete job={job_id} uid={uid} '
-            f'success={total_segments - failed_segments}/{total_segments}'
-        )
+        logger.info(f'sync_v2 bg complete job={job_id} uid={uid} ' f'success={successful_segments}/{total_segments}')
     except Exception as e:
-        logger.error(f'sync_v2 background failed job={job_id} uid={uid}: {e}')
+        logger.error(f'sync_v2 bg failed job={job_id} uid={uid}: {e}')
         try:
             mark_job_failed(job_id, str(e))
         except Exception:
             pass
     finally:
-        # Clean up segmented wav files
         _cleanup_files(list(segmented_paths))
-        # Clean up job directory
+        _cleanup_files(wav_paths)
         try:
             if job_dir and os.path.isdir(job_dir):
                 shutil.rmtree(job_dir, ignore_errors=True)
         except Exception as e:
-            logger.error(f'sync_v2: failed to cleanup job dir {job_dir}: {e}')
+            logger.error(f'sync_v2 bg: failed to cleanup job dir {job_dir}: {e}')
 
 
 @router.post("/v2/sync-local-files")
@@ -1460,8 +1570,9 @@ async def sync_local_files_v2(
     ),
 ):
     """
-    Async version of sync-local-files. Does fast-path work (decode, VAD) inline,
-    then starts background processing and returns 202 with a job_id for polling.
+    Async version of sync-local-files. Saves raw files and returns 202
+    immediately, then runs the full pipeline (decode → VAD → STT → LLM) in
+    a background thread. The app polls GET /v2/sync-local-files/{job_id}.
     """
     # Pre-check gates (same as v1)
     if is_hard_restricted(uid):
@@ -1481,112 +1592,33 @@ async def sync_local_files_v2(
     job_dir = f'syncing/{uid}/{job_id}'
 
     paths = []
-    wav_paths = []
-    segmented_paths = set()
 
     try:
-        # --- Fast path (inline, <5s typically) ---
+        # --- Fast path: save raw files only (< 2s typical) ---
         paths = _retrieve_file_paths_v2(files, uid, job_id)
-        wav_paths = decode_files_to_wav(paths)
 
-        vad_errors = []
+        # Create Redis job — total_segments=0 until VAD completes in background
+        create_sync_job(uid, total_files=len(files), total_segments=0, job_id=job_id)
 
-        def _run_vad_v2(path):
-            retrieve_vad_segments(path, segmented_paths, vad_errors)
-
+        # Capture event loop for async calls from background thread
         loop_v2 = asyncio.get_running_loop()
-        await asyncio.gather(*[loop_v2.run_in_executor(critical_executor, _run_vad_v2, path) for path in wav_paths])
 
-        _cleanup_files(wav_paths)
-        wav_paths = []
+        # Transfer ownership of raw paths to the background thread
+        owned_paths = list(paths)
+        paths = []  # Prevent finally cleanup of files now owned by bg thread
 
-        if vad_errors:
-            error_detail = f"VAD processing failed for {len(vad_errors)} file(s): {'; '.join(vad_errors[:3])}"
-            if len(vad_errors) > 3:
-                error_detail += f" (and {len(vad_errors) - 3} more)"
-            raise HTTPException(status_code=500, detail=error_detail)
-
-        # Fair-use speech tracking
-        total_speech_seconds = sum(get_wav_duration(p) for p in segmented_paths)
-        total_speech_ms = int(total_speech_seconds * 1000)
-
-        if FAIR_USE_ENABLED and total_speech_ms > 0:
-            record_speech_ms(uid, total_speech_ms, source='sync')
-            speech_totals = get_rolling_speech_ms(uid)
-            triggered_caps = check_soft_caps(uid, speech_totals=speech_totals)
-            if triggered_caps:
-                logger.info(f'sync_v2: soft caps triggered for {uid}: {triggered_caps}')
-                asyncio.create_task(trigger_classifier_if_needed(uid, triggered_caps))
-
-        # DG budget gate
-        fair_use_restrict_dg = False
-        if FAIR_USE_ENABLED:
-            try:
-                fair_use_stage = get_enforcement_stage(uid)
-                if fair_use_stage == 'restrict' and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
-                    fair_use_restrict_dg = True
-                    if is_dg_budget_exhausted(uid):
-                        _cleanup_files(list(segmented_paths))
-                        return JSONResponse(
-                            status_code=429,
-                            content={
-                                'dg_budget_exhausted': True,
-                                'skipped_segments': len(segmented_paths),
-                            },
-                        )
-            except Exception as e:
-                logger.error(f'sync_v2: DG budget check error for {uid}: {e}')
-
-        total_segments = len(segmented_paths)
-
-        if total_segments == 0:
-            # Nothing to process — return completed immediately
-            return JSONResponse(
-                status_code=200,
-                content={
-                    'new_memories': [],
-                    'updated_memories': [],
-                },
-            )
-
-        # --- Create Redis job and start background thread ---
-        job = create_sync_job(uid, total_files=len(files), total_segments=total_segments, job_id=job_id)
-
-        # Fetch user transcription preferences once before spawning background thread
-        transcription_prefs = users_db.get_user_transcription_preferences(uid)
-
-        # Build speaker embeddings cache once for all segments (voice + text identification)
-        try:
-            person_embeddings_cache = build_person_embeddings_cache(uid)
-            if person_embeddings_cache:
-                logger.info(
-                    f'sync_v2: loaded {len(person_embeddings_cache)} person embeddings for speaker ID uid={uid}'
-                )
-        except Exception as e:
-            logger.warning(f'sync_v2: failed to load person embeddings, skipping speaker ID uid={uid}: {e}')
-            person_embeddings_cache = {}
-
-        # Transfer ownership of segmented_paths to the background thread
-        owned_paths = list(segmented_paths)
-        segmented_paths = set()  # Prevent finally cleanup of files now owned by bg thread
-
-        # Run in default executor (not critical_executor) because _process_segments_background
-        # is a coordinator that submits child tasks to critical_executor — nesting both
-        # in the same pool causes deadlock under concurrent load.
+        # Run in default executor (not critical_executor) to avoid deadlock
         loop_v2.run_in_executor(
             None,
-            _process_segments_background,
+            _run_full_pipeline_background,
             job_id,
             uid,
             owned_paths,
             source,
             should_lock,
-            fair_use_restrict_dg,
-            total_speech_seconds,
             job_dir,
-            transcription_prefs,
-            person_embeddings_cache,
             conversation_id,
+            loop_v2,
         )
 
         return JSONResponse(
@@ -1595,7 +1627,7 @@ async def sync_local_files_v2(
                 'job_id': job_id,
                 'status': 'queued',
                 'total_files': len(files),
-                'total_segments': total_segments,
+                'total_segments': 0,
                 'poll_after_ms': 3000,
             },
         )
@@ -1606,8 +1638,6 @@ async def sync_local_files_v2(
         raise HTTPException(status_code=500, detail=str(e))
     finally:
         _cleanup_files(paths)
-        _cleanup_files(wav_paths)
-        _cleanup_files(list(segmented_paths))
 
 
 @router.get("/v2/sync-local-files/{job_id}")

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -195,7 +195,9 @@ def precache_conversation_audio_endpoint(
     # Start background parallel pre-caching for all audio files using storage_executor
     def _precache_all_parallel():
         logger.info(f"Pre-caching all {len(audio_files)} audio files for conversation {conversation_id} (parallel)")
-        futures = [storage_executor.submit(_precache_audio_file, uid, conversation_id, af) for af in audio_files]
+        futures = [
+            submit_with_context(storage_executor, _precache_audio_file, uid, conversation_id, af) for af in audio_files
+        ]
         for future in futures:
             try:
                 future.result()
@@ -203,7 +205,7 @@ def precache_conversation_audio_endpoint(
                 logger.error(f"Error in parallel precache: {e}")
         logger.info(f"Completed pre-cache for conversation {conversation_id}")
 
-    critical_executor.submit(_precache_all_parallel)
+    submit_with_context(critical_executor, _precache_all_parallel)
 
     return {"status": "started", "audio_file_count": len(audio_files)}
 
@@ -292,14 +294,17 @@ def get_audio_signed_urls_endpoint(
     if uncached_files:
 
         def _cache_uncached_parallel():
-            futures = [storage_executor.submit(_precache_audio_file, uid, conversation_id, af) for af in uncached_files]
+            futures = [
+                submit_with_context(storage_executor, _precache_audio_file, uid, conversation_id, af)
+                for af in uncached_files
+            ]
             for future in futures:
                 try:
                     future.result()
                 except Exception as e:
                     logger.error(f"Error in parallel cache: {e}")
 
-        critical_executor.submit(_cache_uncached_parallel)
+        submit_with_context(critical_executor, _cache_uncached_parallel)
 
     return {"audio_files": result}
 
@@ -932,7 +937,7 @@ def process_segment(
             time.sleep(480)
             delete_syncing_temporal_file(path)
 
-        storage_executor.submit(delete_file)
+        submit_with_context(storage_executor, delete_file)
 
         # Apply user transcription preferences (vocabulary, language, model)
         prefs = transcription_prefs or {}

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1453,18 +1453,7 @@ def _run_full_pipeline_background(
                     if is_dg_budget_exhausted(uid):
                         _cleanup_files(list(segmented_paths))
                         segmented_paths = set()
-                        mark_job_completed(
-                            job_id,
-                            {
-                                'new_memories': [],
-                                'updated_memories': [],
-                                'failed_segments': 0,
-                                'total_segments': total_segments,
-                                'errors': [],
-                                'dg_budget_exhausted': True,
-                                'skipped_segments': total_segments,
-                            },
-                        )
+                        mark_job_failed(job_id, 'DG budget exhausted — audio retained for retry')
                         return
             except Exception as e:
                 logger.error(f'sync_v2 bg: DG budget check error for {uid}: {e}')

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional, Tuple
 import numpy as np
 import httpx
 
-from utils.executors import critical_executor, storage_executor
+from utils.executors import critical_executor, storage_executor, sync_executor, submit_with_context
 
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, Query, Header, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -1139,7 +1139,7 @@ async def sync_local_files(
             retrieve_vad_segments(path, segmented_paths, vad_errors)
 
         loop = asyncio.get_running_loop()
-        await asyncio.gather(*[loop.run_in_executor(critical_executor, _run_vad, path) for path in wav_paths])
+        await asyncio.gather(*[loop.run_in_executor(sync_executor, _run_vad, path) for path in wav_paths])
 
         # Clean up original wav files after VAD segmentation (segments are now in segmented_paths)
         _cleanup_files(wav_paths)
@@ -1218,7 +1218,7 @@ async def sync_local_files(
         await asyncio.gather(
             *[
                 loop.run_in_executor(
-                    critical_executor,
+                    sync_executor,
                     process_segment,
                     path,
                     uid,
@@ -1353,11 +1353,14 @@ def _run_full_pipeline_background(
     """
     segmented_paths = set()
     wav_paths = []
+    stage_timings = {}
+    pipeline_start = time.monotonic()
     try:
         mark_job_processing(job_id)
 
         # --- Phase 1: Decode ---
         update_sync_job(job_id, {'stage': 'decoding'})
+        t0 = time.monotonic()
         try:
             wav_paths = decode_files_to_wav(raw_paths)
         except HTTPException as e:
@@ -1368,6 +1371,7 @@ def _run_full_pipeline_background(
             return
         finally:
             _cleanup_files(raw_paths)
+        stage_timings['decode_ms'] = int((time.monotonic() - t0) * 1000)
 
         if not wav_paths:
             mark_job_completed(
@@ -1384,6 +1388,7 @@ def _run_full_pipeline_background(
 
         # --- Phase 2: VAD ---
         update_sync_job(job_id, {'stage': 'vad'})
+        t0 = time.monotonic()
         vad_errors = []
 
         def _run_vad_bg(path):
@@ -1392,13 +1397,14 @@ def _run_full_pipeline_background(
             except Exception as e:
                 vad_errors.append(f'{path}: {e}')
 
-        futures = [critical_executor.submit(_run_vad_bg, path) for path in wav_paths]
+        futures = [sync_executor.submit(_run_vad_bg, path) for path in wav_paths]
         for future in futures:
             try:
-                future.result()
+                future.result(timeout=300)
             except Exception as e:
                 vad_errors.append(f'VAD executor error: {e}')
 
+        stage_timings['vad_ms'] = int((time.monotonic() - t0) * 1000)
         _cleanup_files(wav_paths)
         wav_paths = []
 
@@ -1471,6 +1477,8 @@ def _run_full_pipeline_background(
             person_embeddings_cache = {}
 
         # --- Phase 5: Process segments (STT + LLM) ---
+        update_sync_job(job_id, {'stage': 'stt_llm'})
+        t0 = time.monotonic()
         response = {'updated_memories': set(), 'new_memories': set()}
         segment_errors = []
         segment_lock = threading.Lock()
@@ -1493,16 +1501,21 @@ def _run_full_pipeline_background(
         segment_list = list(segmented_paths)
         for i in range(0, len(segment_list), chunk_size):
             chunk = segment_list[i : i + chunk_size]
-            seg_futures = [critical_executor.submit(_process_one_segment, path) for path in chunk]
+            seg_futures = [submit_with_context(sync_executor, _process_one_segment, path) for path in chunk]
             for future in seg_futures:
                 try:
-                    future.result()
+                    future.result(timeout=300)
+                except TimeoutError:
+                    segment_errors.append(f'Segment timed out after 300s')
+                    logger.error(f'sync_v2 bg: segment timed out job={job_id}')
                 except Exception as e:
                     logger.error(f'sync_v2 bg: segment error: {e}')
             try:
                 update_sync_job(job_id, {'processed_segments': min(i + chunk_size, len(segment_list))})
             except Exception:
                 pass
+
+        stage_timings['stt_llm_ms'] = int((time.monotonic() - t0) * 1000)
 
         # Record DG usage after processing
         if fair_use_restrict_dg:
@@ -1533,6 +1546,7 @@ def _run_full_pipeline_background(
             except Exception as e:
                 logger.error(f'sync_v2 bg: usage record error for {uid}: {e}')
 
+        stage_timings['total_ms'] = int((time.monotonic() - pipeline_start) * 1000)
         mark_job_completed(
             job_id,
             {
@@ -1541,10 +1555,15 @@ def _run_full_pipeline_background(
                 'failed_segments': failed_segments,
                 'total_segments': total_segments,
                 'errors': segment_errors[:10] if segment_errors else [],
+                'stage_timings': stage_timings,
             },
         )
 
-        logger.info(f'sync_v2 bg complete job={job_id} uid={uid} ' f'success={successful_segments}/{total_segments}')
+        logger.info(
+            f'sync_v2 bg complete job={job_id} uid={uid} '
+            f'success={successful_segments}/{total_segments} '
+            f'timings={stage_timings}'
+        )
     except Exception as e:
         logger.error(f'sync_v2 bg failed job={job_id} uid={uid}: {e}')
         try:

--- a/backend/tests/unit/test_sync_record_usage.py
+++ b/backend/tests/unit/test_sync_record_usage.py
@@ -121,7 +121,7 @@ class TestV1RecordUsage:
 class TestV2RecordUsage:
     @staticmethod
     def _get_v2_body():
-        return _extract_function_body(_read_sync_source(), '_process_segments_background')
+        return _extract_function_body(_read_sync_source(), '_run_full_pipeline_background')
 
     def test_record_usage_called_in_v2(self):
         body = self._get_v2_body()
@@ -143,14 +143,14 @@ class TestV2RecordUsage:
         preceding = body[max(0, record_idx - 300) : record_idx]
         assert 'successful_segments > 0' in preceding, "record_usage must be guarded by successful_segments > 0"
 
-    def test_record_usage_before_mark_job_completed(self):
-        """record_usage must run before mark_job_completed."""
+    def test_record_usage_before_final_mark_job_completed(self):
+        """record_usage must run before the final mark_job_completed (after segment processing)."""
         body = self._get_v2_body()
         record_pos = body.find('record_usage(')
-        complete_pos = body.find('mark_job_completed(')
-        assert record_pos > 0
-        assert complete_pos > 0
-        assert record_pos < complete_pos, "record_usage must run before mark_job_completed"
+        assert record_pos > 0, "record_usage must exist"
+        complete_pos = body.rfind('mark_job_completed(')
+        assert complete_pos > 0, "mark_job_completed must exist"
+        assert record_pos < complete_pos, "record_usage must run before the final mark_job_completed"
 
     def test_record_usage_wrapped_in_try_except(self):
         body = self._get_v2_body()

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -763,6 +763,7 @@ class TestBackgroundWorkerBehavioral:
         ]
         utils_subs = [
             'utils',
+            'utils.byok',
             'utils.conversations',
             'utils.conversations.process_conversation',
             'utils.conversations.factory',
@@ -1319,6 +1320,7 @@ class TestV2EndpointExecution:
             'models.transcript_segment',
             'utils',
             'utils.analytics',
+            'utils.byok',
             'utils.conversations',
             'utils.conversations.process_conversation',
             'utils.conversations.factory',

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1699,3 +1699,274 @@ class TestPusherCoordinatorExecutor:
             "pusher._process_conversation_task must NOT pass critical_executor for process_conversation — "
             "use None (default executor) to prevent deadlock"
         )
+
+
+# ---------------------------------------------------------------------------
+# 14. Bulkhead executor infrastructure tests
+# ---------------------------------------------------------------------------
+
+
+class TestBulkheadExecutors:
+    """Verify bulkhead executor configuration in utils/executors.py."""
+
+    @staticmethod
+    def _read_executors_source():
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'executors.py')
+        with open(path) as f:
+            return f.read()
+
+    def test_sync_executor_exists(self):
+        source = self._read_executors_source()
+        assert 'sync_executor' in source
+        assert "thread_name_prefix=\"sync\"" in source or "thread_name_prefix='sync'" in source
+
+    def test_postprocess_executor_exists(self):
+        source = self._read_executors_source()
+        assert 'postprocess_executor' in source
+        assert "thread_name_prefix=\"postproc\"" in source or "thread_name_prefix='postproc'" in source
+
+    def test_executor_worker_counts(self):
+        source = self._read_executors_source()
+        assert 'sync_executor = ThreadPoolExecutor(max_workers=12' in source
+        assert 'postprocess_executor = ThreadPoolExecutor(max_workers=8' in source
+
+    def test_all_executors_in_shutdown(self):
+        source = self._read_executors_source()
+        for name in ['critical', 'sync', 'postprocess', 'storage']:
+            assert f"'{name}'" in source or f'"{name}"' in source, f"Executor '{name}' must be in shutdown_executors"
+
+    def test_submit_with_context_exists(self):
+        source = self._read_executors_source()
+        assert 'def submit_with_context(' in source
+        assert 'contextvars.copy_context()' in source
+
+    def test_submit_with_context_propagates_contextvars(self):
+        """submit_with_context must propagate ContextVar values to the submitted thread."""
+        import contextvars
+        from concurrent.futures import ThreadPoolExecutor
+
+        test_var = contextvars.ContextVar('test_key', default=None)
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix='test_ctx')
+
+        try:
+            test_var.set('hello')
+            ctx = contextvars.copy_context()
+            future = executor.submit(ctx.run, test_var.get)
+            assert future.result(timeout=5) == 'hello'
+
+            test_var.set('different')
+            ctx2 = contextvars.copy_context()
+            future2 = executor.submit(ctx2.run, test_var.get)
+            assert future2.result(timeout=5) == 'different'
+        finally:
+            executor.shutdown(wait=False)
+
+    def test_executor_isolation_different_pools(self):
+        """sync_executor and postprocess_executor must be distinct objects."""
+        source = self._read_executors_source()
+        lines = source.strip().split('\n')
+        sync_lines = [l for l in lines if l.startswith('sync_executor')]
+        post_lines = [l for l in lines if l.startswith('postprocess_executor')]
+        assert len(sync_lines) >= 1, "sync_executor must be defined at module level"
+        assert len(post_lines) >= 1, "postprocess_executor must be defined at module level"
+        assert sync_lines[0] != post_lines[0], "sync and postprocess executors must be separate"
+
+
+# ---------------------------------------------------------------------------
+# 15. BYOK context propagation tests
+# ---------------------------------------------------------------------------
+
+
+class TestBYOKContextPropagation:
+    """Verify BYOK context lifecycle in the sync pipeline."""
+
+    @staticmethod
+    def _read_sync_source():
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
+        with open(path) as f:
+            return f.read()
+
+    def test_v2_captures_byok_before_dispatch(self):
+        """v2 endpoint must capture BYOK keys before run_in_executor dispatch."""
+        source = self._read_sync_source()
+        start = source.index('async def sync_local_files_v2')
+        next_section = source.find('\n@router.', start + 1)
+        if next_section == -1:
+            next_section = len(source)
+        func_body = source[start:next_section]
+
+        assert 'get_byok_keys()' in func_body, "v2 must capture BYOK keys before dispatch"
+        assert 'captured_byok' in func_body, "v2 must store captured BYOK in a variable"
+
+    def test_v2_passes_byok_to_background(self):
+        """v2 must pass captured BYOK keys as an argument to the background worker."""
+        source = self._read_sync_source()
+        start = source.index('async def sync_local_files_v2')
+        next_section = source.find('\n@router.', start + 1)
+        if next_section == -1:
+            next_section = len(source)
+        func_body = source[start:next_section]
+
+        assert 'captured_byok' in func_body
+        dispatch_section = func_body[func_body.index('run_in_executor') :]
+        assert 'captured_byok' in dispatch_section, "captured BYOK must be passed to run_in_executor call"
+
+    def test_background_worker_accepts_byok_parameter(self):
+        """_run_full_pipeline_background must accept a byok_keys parameter."""
+        source = self._read_sync_source()
+        start = source.index('def _run_full_pipeline_background')
+        next_def = source.find('\ndef ', start + 1)
+        if next_def == -1:
+            next_def = len(source)
+        func_body = source[start:next_def]
+        assert 'byok_keys' in func_body, "Background worker must accept byok_keys parameter"
+
+    def test_background_worker_sets_byok_unconditionally(self):
+        """Background worker must call set_byok_keys unconditionally (not guarded by if)."""
+        source = self._read_sync_source()
+        start = source.index('def _run_full_pipeline_background')
+        next_def = source.find('\ndef ', start + 1)
+        if next_def == -1:
+            next_def = len(source)
+        func_body = source[start:next_def]
+
+        assert (
+            'set_byok_keys(byok_keys or {})' in func_body
+        ), "Worker must set BYOK unconditionally with empty dict fallback"
+
+    def test_background_worker_clears_byok_in_finally(self):
+        """Background worker must clear BYOK context in its finally block."""
+        source = self._read_sync_source()
+        start = source.index('def _run_full_pipeline_background')
+        next_def = source.find('\ndef ', start + 1)
+        if next_def == -1:
+            next_def = len(source)
+        func_body = source[start:next_def]
+
+        assert 'set_byok_keys({})' in func_body, "Worker must clear BYOK keys (expected in finally block)"
+
+    def test_no_plain_submit_in_sync(self):
+        """All executor .submit() calls in sync.py must use submit_with_context."""
+        source = self._read_sync_source()
+        import re as _re
+
+        plain_submits = _re.findall(
+            r'(?:critical_executor|sync_executor|storage_executor|postprocess_executor)\.submit\(', source
+        )
+        assert (
+            len(plain_submits) == 0
+        ), f"Found {len(plain_submits)} plain .submit() calls — must use submit_with_context"
+
+    def test_no_plain_submit_in_process_conversation(self):
+        """All executor .submit() calls in process_conversation.py must use submit_with_context."""
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'conversations', 'process_conversation.py')
+        with open(path) as f:
+            source = f.read()
+        import re as _re
+
+        plain_submits = _re.findall(
+            r'(?:critical_executor|sync_executor|storage_executor|postprocess_executor)\.submit\(', source
+        )
+        assert (
+            len(plain_submits) == 0
+        ), f"Found {len(plain_submits)} plain .submit() calls — must use submit_with_context"
+
+
+# ---------------------------------------------------------------------------
+# 16. Timeout configuration tests
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutConfiguration:
+    """Verify timeout settings on LLM and STT clients."""
+
+    @staticmethod
+    def _read_clients_source():
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'llm', 'clients.py')
+        with open(path) as f:
+            return f.read()
+
+    @staticmethod
+    def _read_pre_recorded_source():
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'stt', 'pre_recorded.py')
+        with open(path) as f:
+            return f.read()
+
+    @staticmethod
+    def _read_classifier_source():
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'llm', 'fair_use_classifier.py')
+        with open(path) as f:
+            return f.read()
+
+    def test_llm_mini_has_timeout(self):
+        source = self._read_clients_source()
+        llm_mini_line = [l for l in source.split('\n') if 'llm_mini' in l and 'ChatOpenAI' in l][0]
+        assert 'request_timeout=120' in llm_mini_line
+        assert 'max_retries=1' in llm_mini_line
+
+    def test_anthropic_default_has_timeout(self):
+        source = self._read_clients_source()
+        default_line = [l for l in source.split('\n') if '_default_anthropic_client' in l and 'AsyncAnthropic' in l][0]
+        assert 'timeout=120' in default_line
+        assert 'max_retries=1' in default_line
+
+    def test_anthropic_byok_has_timeout(self):
+        source = self._read_clients_source()
+        start = source.index('def _cached_anthropic')
+        end = source.find('\ndef ', start + 1)
+        func_body = source[start:end]
+        assert 'timeout=120' in func_body
+        assert 'max_retries=1' in func_body
+
+    def test_byok_client_has_timeout(self):
+        source = self._read_clients_source()
+        start = source.index('def _create_byok_client')
+        end = source.find('\ndef ', start + 1)
+        func_body = source[start:end]
+        assert "'request_timeout': 120" in func_body
+        assert "'max_retries': 1" in func_body
+
+    def test_classifier_llm_has_timeout(self):
+        source = self._read_classifier_source()
+        start = source.index('_classifier_llm')
+        end = source.index('\n', source.index(')', start))
+        constructor_call = source[start:end]
+        assert 'request_timeout=120' in constructor_call
+        assert 'max_retries=1' in constructor_call
+
+    def test_dg_timeout_read_within_budget(self):
+        """DG read timeout must be <= 150s so 2 attempts fit within 300s segment budget."""
+        source = self._read_pre_recorded_source()
+        assert 'read=120.0' in source, "DG read timeout must be 120s"
+
+    def test_dg_timeout_connect_reasonable(self):
+        source = self._read_pre_recorded_source()
+        assert 'connect=10.0' in source
+
+    def test_dg_max_two_attempts(self):
+        """Deepgram prerecorded must retry at most once (2 total attempts)."""
+        source = self._read_pre_recorded_source()
+        start = source.index('def deepgram_prerecorded(')
+        end = source.find('\ndef ', start + 1)
+        func_body = source[start:end]
+        assert 'attempts < 1' in func_body, "DG url transcription must use attempts < 1 (max 2 attempts)"
+
+    def test_dg_from_bytes_max_two_attempts(self):
+        """Deepgram prerecorded_from_bytes must retry at most once (2 total attempts)."""
+        source = self._read_pre_recorded_source()
+        start = source.index('def deepgram_prerecorded_from_bytes(')
+        end = source.find('\ndef ', start + 1)
+        if end == -1:
+            end = len(source)
+        func_body = source[start:end]
+        assert 'attempts < 1' in func_body, "DG bytes transcription must use attempts < 1 (max 2 attempts)"
+
+    def test_segment_future_timeout_budget(self):
+        """Segment futures in v2 background must use timeout=300."""
+        sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
+        with open(sync_path) as f:
+            source = f.read()
+        start = source.index('def _run_full_pipeline_background')
+        end = source.find('\ndef ', start + 1)
+        func_body = source[start:end]
+        assert 'future.result(timeout=300)' in func_body, "Segment futures must have 300s timeout"

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1575,6 +1575,52 @@ class TestV2EndpointExecution:
         finally:
             self._cleanup_modules(saved)
 
+    def test_post_returns_202_and_schedules_background(self):
+        """POST /v2/sync-local-files must return 202, create job, and schedule background work."""
+        saved, mock_sync_jobs, _ = self._build_test_app()
+        mock_sync_jobs.create_sync_job = MagicMock(
+            return_value={
+                'job_id': 'created-job',
+                'uid': 'test-uid',
+                'status': 'queued',
+                'total_files': 1,
+                'total_segments': 0,
+            }
+        )
+
+        try:
+            sys.modules.pop('routers.sync', None)
+            import importlib.util
+
+            spec = importlib.util.spec_from_file_location(
+                'sync_post_202',
+                os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py'),
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+            module._retrieve_file_paths_v2 = MagicMock(return_value=['/tmp/fake.opus'])
+            module._run_full_pipeline_background = MagicMock()
+
+            from fastapi import FastAPI
+            from fastapi.testclient import TestClient
+
+            app = FastAPI()
+            app.include_router(module.router)
+            app.dependency_overrides[module.auth.get_current_user_uid] = lambda: 'test-uid'
+
+            client = TestClient(app)
+            resp = client.post('/v2/sync-local-files', files=[('files', ('test.opus', b'\x00' * 10, 'audio/opus'))])
+
+            assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+            body = resp.json()
+            assert 'job_id' in body
+            assert body['status'] == 'queued'
+            assert body['poll_after_ms'] == 3000
+            mock_sync_jobs.create_sync_job.assert_called_once()
+        finally:
+            self._cleanup_modules(saved)
+
 
 # ---------------------------------------------------------------------------
 # Pusher coordinator executor pattern

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1,9 +1,9 @@
 """
-Tests for v2 async sync-local-files endpoints (#5941).
+Tests for v2 async sync-local-files endpoints (#5941, #7281).
 
-v2 does fast-path work (decode, VAD) inline, then hands off STT+LLM to a
-background thread. The app polls GET /v2/sync-local-files/{job_id} until
-the job reaches a terminal status.
+v2 saves raw files and returns 202 immediately, then runs the full pipeline
+(decode → VAD → fair-use → STT → LLM) in a background thread. The app
+polls GET /v2/sync-local-files/{job_id} until the job reaches a terminal status.
 
 v1 remains completely unchanged.
 """
@@ -65,8 +65,8 @@ class TestSyncV2Structure:
         assert "'job_id'" in func_body, "v2 response must include job_id"
         assert "'poll_after_ms'" in func_body, "v2 response must include poll_after_ms"
 
-    def test_v2_submits_to_critical_executor(self):
-        """v2 must submit background work to the shared critical_executor."""
+    def test_v2_submits_to_default_executor(self):
+        """v2 must submit background work via run_in_executor(None, ...) to avoid deadlock."""
         source = self._read_sync_source()
         start = source.index('async def sync_local_files_v2')
         next_section = source.find('\n@router.', start + 1)
@@ -75,19 +75,15 @@ class TestSyncV2Structure:
         func_body = source[start:next_section]
 
         assert 'run_in_executor' in func_body, "v2 must use run_in_executor for background worker"
-        assert '_process_segments_background' in func_body, "v2 must submit the background worker function"
-        # The coordinator dispatch must use run_in_executor with None (default executor),
-        # not critical_executor, to avoid deadlock when the coordinator itself submits to
-        # critical_executor internally.
-        # Accept both inline and multi-line forms: run_in_executor(None, and run_in_executor(\n..None,
+        assert '_run_full_pipeline_background' in func_body, "v2 must submit the full pipeline background worker"
         none_executor_pattern = re.compile(r'run_in_executor\(\s*None\s*,')
         assert none_executor_pattern.search(func_body), (
             "v2 coordinator dispatch must use run_in_executor(None, ...) — "
             "passing critical_executor would nest executors and cause deadlock"
         )
 
-    def test_v2_has_fair_use_gates(self):
-        """v2 must check fair-use and DG budget (same gates as v1)."""
+    def test_v2_has_hard_restriction_gate(self):
+        """v2 inline path must check hard restriction (fast 429 for restricted users)."""
         source = self._read_sync_source()
         start = source.index('async def sync_local_files_v2')
         next_section = source.find('\n@router.', start + 1)
@@ -95,8 +91,20 @@ class TestSyncV2Structure:
             next_section = len(source)
         func_body = source[start:next_section]
 
-        assert 'is_hard_restricted' in func_body, "v2 must check hard restriction"
-        assert 'is_dg_budget_exhausted' in func_body, "v2 must check DG budget"
+        assert 'is_hard_restricted' in func_body, "v2 must check hard restriction inline"
+
+    def test_v2_does_not_decode_inline(self):
+        """v2 fast path must NOT run decode/VAD inline (#7281)."""
+        source = self._read_sync_source()
+        start = source.index('async def sync_local_files_v2')
+        next_section = source.find('\n@router.', start + 1)
+        if next_section == -1:
+            next_section = len(source)
+        func_body = source[start:next_section]
+
+        assert 'decode_files_to_wav' not in func_body, "v2 must NOT decode inline"
+        assert 'retrieve_vad_segments' not in func_body, "v2 must NOT run VAD inline"
+        assert 'build_person_embeddings_cache' not in func_body, "v2 must NOT build embeddings inline"
 
     def test_v2_uses_job_specific_directory(self):
         """v2 must use syncing/{uid}/{job_id}/ to avoid concurrency conflicts."""
@@ -113,8 +121,7 @@ class TestSyncV2Structure:
     def test_v2_background_has_cleanup(self):
         """Background worker must clean up files in finally block."""
         source = self._read_sync_source()
-        start = source.index('def _process_segments_background')
-        # Find next top-level def or decorator
+        start = source.index('def _run_full_pipeline_background')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
@@ -127,16 +134,42 @@ class TestSyncV2Structure:
     def test_v2_background_records_dg_after_processing(self):
         """DG usage must be recorded after processing, not before."""
         source = self._read_sync_source()
-        start = source.index('def _process_segments_background')
+        start = source.index('def _run_full_pipeline_background')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
         func_body = source[start:next_boundary]
 
-        # record_dg_usage_ms must come after critical_executor.submit / future.result processing
         dg_pos = func_body.index('record_dg_usage_ms')
         processing_pos = func_body.index('future.result()')
         assert dg_pos > processing_pos, "DG usage must be recorded AFTER segment processing"
+
+    def test_v2_background_does_decode_and_vad(self):
+        """Background worker must run decode and VAD (#7281 — moved from inline)."""
+        source = self._read_sync_source()
+        start = source.index('def _run_full_pipeline_background')
+        next_boundary = source.find('\n@router.', start + 1)
+        if next_boundary == -1:
+            next_boundary = len(source)
+        func_body = source[start:next_boundary]
+
+        assert 'decode_files_to_wav' in func_body, "Background must decode files"
+        assert 'retrieve_vad_segments' in func_body, "Background must run VAD"
+        assert 'build_person_embeddings_cache' in func_body, "Background must build person embeddings"
+        assert 'is_dg_budget_exhausted' in func_body, "Background must check DG budget"
+
+    def test_v2_background_has_stage_heartbeats(self):
+        """Background worker must heartbeat with stage info during decode and VAD."""
+        source = self._read_sync_source()
+        start = source.index('def _run_full_pipeline_background')
+        next_boundary = source.find('\n@router.', start + 1)
+        if next_boundary == -1:
+            next_boundary = len(source)
+        func_body = source[start:next_boundary]
+
+        assert "'stage': 'decoding'" in func_body, "Background must heartbeat decode stage"
+        assert "'stage': 'vad'" in func_body, "Background must heartbeat VAD stage"
+        assert "'stage': 'processing'" in func_body, "Background must heartbeat processing stage"
 
     def test_v2_get_checks_ownership(self):
         """GET endpoint must verify job belongs to requesting user."""
@@ -155,8 +188,20 @@ class TestSyncV2Structure:
 
         assert '404' in func_body, "GET must return 404 for missing job"
 
-    def test_v2_fetches_prefs_and_cache_before_executor_submit(self):
-        """v2 must fetch transcription_prefs and build person_embeddings_cache before submitting to executor."""
+    def test_v2_bg_worker_fetches_prefs_and_cache(self):
+        """Background worker must fetch transcription prefs and build person embeddings cache."""
+        source = self._read_sync_source()
+        start = source.index('def _run_full_pipeline_background')
+        next_boundary = source.find('\n@router.', start + 1)
+        if next_boundary == -1:
+            next_boundary = len(source)
+        func_body = source[start:next_boundary]
+
+        assert 'get_user_transcription_preferences' in func_body, "bg worker must fetch prefs"
+        assert 'build_person_embeddings_cache' in func_body, "bg worker must build embeddings cache"
+
+    def test_v2_fast_path_only_saves_files(self):
+        """v2 fast path must only save raw files — no decode, no VAD, no prefs/cache fetch."""
         source = self._read_sync_source()
         start = source.index('async def sync_local_files_v2')
         next_section = source.find('\n@router.', start + 1)
@@ -164,44 +209,10 @@ class TestSyncV2Structure:
             next_section = len(source)
         func_body = source[start:next_section]
 
-        assert 'get_user_transcription_preferences' in func_body, "v2 must fetch transcription preferences"
-        assert 'build_person_embeddings_cache' in func_body, "v2 must build person embeddings cache"
-
-        # Both must appear before the background worker dispatch
-        prefs_pos = func_body.index('get_user_transcription_preferences')
-        cache_pos = func_body.index('build_person_embeddings_cache')
-        submit_pos = func_body.index('_process_segments_background')
-        assert prefs_pos < submit_pos, "Prefs must be fetched before background worker dispatch"
-        assert cache_pos < submit_pos, "Cache must be built before background worker dispatch"
-
-    def test_v2_bg_worker_accepts_prefs_and_cache_params(self):
-        """_process_segments_background must accept transcription_prefs and person_embeddings_cache."""
-        source = self._read_sync_source()
-        start = source.index('def _process_segments_background')
-        # Find the closing paren of the signature (handles multi-line)
-        sig_end = source.index('):', start)
-        func_sig = source[start : sig_end + 2]
-
-        assert 'transcription_prefs' in func_sig, "bg worker must accept transcription_prefs param"
-        assert 'person_embeddings_cache' in func_sig, "bg worker must accept person_embeddings_cache param"
-
-    def test_v2_passes_prefs_and_cache_to_executor_submit(self):
-        """v2 must pass transcription_prefs and person_embeddings_cache in executor submit args."""
-        source = self._read_sync_source()
-        start = source.index('async def sync_local_files_v2')
-        next_section = source.find('\n@router.', start + 1)
-        if next_section == -1:
-            next_section = len(source)
-        func_body = source[start:next_section]
-
-        # Find the background worker dispatch block
-        submit_start = func_body.index('_process_segments_background')
-        # Find the closing — look for the return statement after it
-        submit_end = func_body.index('return JSONResponse', submit_start)
-        submit_block = func_body[submit_start:submit_end]
-
-        assert 'transcription_prefs' in submit_block, "v2 must pass transcription_prefs to background worker"
-        assert 'person_embeddings_cache' in submit_block, "v2 must pass person_embeddings_cache to background worker"
+        assert '_retrieve_file_paths_v2' in func_body, "v2 must save raw files"
+        assert 'create_sync_job' in func_body, "v2 must create Redis job"
+        assert 'get_user_transcription_preferences' not in func_body, "prefs fetch moved to bg"
+        assert 'build_person_embeddings_cache' not in func_body, "cache build moved to bg"
 
 
 # ---------------------------------------------------------------------------
@@ -376,15 +387,15 @@ class TestSyncJobsRedis:
 # ---------------------------------------------------------------------------
 
 
-class TestProcessSegmentsBackground:
-    """Test _process_segments_background worker function."""
+class TestFullPipelineBackground:
+    """Test _run_full_pipeline_background worker function."""
 
     @staticmethod
     def _get_bg_func_body():
         sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
         with open(sync_path) as f:
             source = f.read()
-        start = source.index('def _process_segments_background')
+        start = source.index('def _run_full_pipeline_background')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
@@ -418,10 +429,18 @@ class TestProcessSegmentsBackground:
         """Worker must heartbeat (update_sync_job) during processing to prevent stale detection."""
         body = self._get_bg_func_body()
         assert 'update_sync_job(' in body, "Worker must call update_sync_job for heartbeat"
-        # Heartbeat must be inside the chunk loop, after futures are resolved
-        heartbeat_pos = body.index('update_sync_job(')
+        heartbeat_pos = body.rindex('update_sync_job(')
         result_pos = body.index('future.result()')
         assert heartbeat_pos > result_pos, "Heartbeat must come after future.result()"
+
+    def test_background_pipeline_order(self):
+        """Worker must run: decode → VAD → fair-use → STT in correct order."""
+        body = self._get_bg_func_body()
+        decode_pos = body.index('decode_files_to_wav')
+        vad_pos = body.index('retrieve_vad_segments')
+        speech_pos = body.index('record_speech_ms')
+        segment_pos = body.index('process_segment')
+        assert decode_pos < vad_pos < speech_pos < segment_pos
 
 
 # ---------------------------------------------------------------------------
@@ -513,23 +532,11 @@ class TestV2EndpointContract:
             next_section = len(source)
         return source[start:next_section]
 
-    def test_v2_handles_empty_segments(self):
-        """v2 must return 200 immediately when no segments found (no job needed)."""
-        body = self._get_v2_post_body()
-        assert 'total_segments == 0' in body
-        assert "'new_memories': []" in body
-
     def test_v2_transfers_file_ownership_to_bg_thread(self):
-        """v2 must transfer segmented_paths ownership to prevent double cleanup."""
+        """v2 must transfer raw path ownership to prevent double cleanup."""
         body = self._get_v2_post_body()
-        assert 'owned_paths = list(segmented_paths)' in body
-        assert 'segmented_paths = set()' in body
-
-    def test_v2_handles_429_dg_budget(self):
-        """v2 must return 429 when DG budget is exhausted."""
-        body = self._get_v2_post_body()
-        assert 'dg_budget_exhausted' in body
-        assert 'status_code=429' in body
+        assert 'owned_paths = list(paths)' in body
+        assert 'paths = []' in body
 
     def test_v2_handles_429_hard_restricted(self):
         """v2 must check hard restriction at the top."""
@@ -543,12 +550,11 @@ class TestV2EndpointContract:
         assert 'raise' in body[body.index('except HTTPException:') :]
 
     def test_v2_finally_cleans_up_on_fast_path_failure(self):
-        """v2 finally block must clean up files if fast-path fails."""
+        """v2 finally block must clean up raw files if fast-path fails."""
         body = self._get_v2_post_body()
         finally_idx = body.rindex('finally:')
         finally_block = body[finally_idx:]
         assert '_cleanup_files(paths)' in finally_block
-        assert '_cleanup_files(wav_paths)' in finally_block
 
 
 # ---------------------------------------------------------------------------
@@ -728,7 +734,7 @@ class TestSyncJobsRedisBoundary:
 
 
 class TestBackgroundWorkerBehavioral:
-    """Behavioral tests for _process_segments_background using mocks."""
+    """Behavioral tests for _run_full_pipeline_background using mocks."""
 
     @staticmethod
     def _load_bg_worker():
@@ -737,7 +743,6 @@ class TestBackgroundWorkerBehavioral:
         mock_sync_jobs = MagicMock()
 
         saved_modules = {}
-        # Core deps
         heavy_deps = [
             'redis',
             'database',
@@ -753,13 +758,14 @@ class TestBackgroundWorkerBehavioral:
             'pydub',
             'models',
             'models.conversation',
+            'models.conversation_enums',
             'models.transcript_segment',
         ]
-        # utils namespace — must stub all submodules sync.py imports
         utils_subs = [
             'utils',
             'utils.conversations',
             'utils.conversations.process_conversation',
+            'utils.conversations.factory',
             'utils.other',
             'utils.other.endpoints',
             'utils.other.storage',
@@ -771,10 +777,12 @@ class TestBackgroundWorkerBehavioral:
             'utils.subscription',
             'utils.observability',
             'utils.log_sanitizer',
+            'utils.analytics',
             'utils.speaker_assignment',
             'utils.speaker_identification',
             'utils.stt.speaker_embedding',
             'utils.executors',
+            'utils.http_client',
         ]
         heavy_deps.extend(utils_subs)
 
@@ -782,17 +790,19 @@ class TestBackgroundWorkerBehavioral:
             saved_modules[mod] = sys.modules.get(mod)
             sys.modules[mod] = MagicMock()
 
-        # Provide a working critical_executor stub (submit runs the function synchronously)
         from concurrent.futures import ThreadPoolExecutor
 
         _test_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix='test')
         sys.modules['utils.executors'].critical_executor = _test_executor
         sys.modules['utils.executors'].storage_executor = _test_executor
 
-        # Set up specific mocks
         sys.modules['database.redis_db'] = MagicMock(r=mock_redis)
         saved_modules['database.sync_jobs'] = sys.modules.get('database.sync_jobs')
         sys.modules['database.sync_jobs'] = mock_sync_jobs
+
+        # Fair-use defaults
+        sys.modules['utils.fair_use'].FAIR_USE_ENABLED = False
+        sys.modules['utils.fair_use'].FAIR_USE_RESTRICT_DAILY_DG_MS = 0
 
         try:
             import importlib.util
@@ -803,6 +813,21 @@ class TestBackgroundWorkerBehavioral:
             )
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
+
+            # Mock decode+VAD to pass through paths as segments
+            def _mock_decode(paths):
+                return list(paths)
+
+            def _mock_vad(path, segmented_paths, errors=None):
+                segmented_paths.add(path)
+
+            module.decode_files_to_wav = _mock_decode
+            module.retrieve_vad_segments = _mock_vad
+            module.get_wav_duration = lambda p: 5.0
+            module.build_person_embeddings_cache = MagicMock(return_value={})
+            module.users_db = MagicMock()
+            module.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+
             return module, mock_sync_jobs
         except Exception:
             return None, None
@@ -822,14 +847,12 @@ class TestBackgroundWorkerBehavioral:
         # Mock process_segment to do nothing
         mod.process_segment = MagicMock()
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='test-job',
             uid='test-uid',
-            segmented_paths=['/tmp/fake1.wav', '/tmp/fake2.wav'],
+            raw_paths=['/tmp/fake1.wav', '/tmp/fake2.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=10.0,
+            should_lock=False,
             job_dir='/tmp/fake-job-dir',
         )
 
@@ -847,14 +870,12 @@ class TestBackgroundWorkerBehavioral:
         # Make mark_job_processing raise to simulate early failure
         mock_sync_jobs.mark_job_processing.side_effect = Exception("Redis down")
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='test-job',
             uid='test-uid',
-            segmented_paths=['/tmp/fake.wav'],
+            raw_paths=['/tmp/fake.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=5.0,
+            should_lock=False,
             job_dir='/tmp/fake-dir',
         )
 
@@ -872,14 +893,12 @@ class TestBackgroundWorkerBehavioral:
         # Use enough segments to trigger at least one heartbeat (chunk_size=5)
         paths = [f'/tmp/seg{i}.wav' for i in range(6)]
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='hb-job',
             uid='uid',
-            segmented_paths=paths,
+            raw_paths=paths,
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=30.0,
+            should_lock=False,
             job_dir='/tmp/hb-dir',
         )
 
@@ -907,14 +926,12 @@ class TestBackgroundWorkerBehavioral:
 
         mod.process_segment = mock_process_segment
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='partial-job',
             uid='test-uid',
-            segmented_paths=['/tmp/s1.wav', '/tmp/s2.wav', '/tmp/s3.wav', '/tmp/s4.wav'],
+            raw_paths=['/tmp/s1.wav', '/tmp/s2.wav', '/tmp/s3.wav', '/tmp/s4.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=20.0,
+            should_lock=False,
             job_dir='/tmp/partial-dir',
         )
 
@@ -938,14 +955,12 @@ class TestBackgroundWorkerBehavioral:
 
         mod.process_segment = mock_process_segment
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='allfail-job',
             uid='test-uid',
-            segmented_paths=['/tmp/f1.wav', '/tmp/f2.wav'],
+            raw_paths=['/tmp/f1.wav', '/tmp/f2.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=10.0,
+            should_lock=False,
             job_dir='/tmp/allfail-dir',
         )
 
@@ -956,7 +971,7 @@ class TestBackgroundWorkerBehavioral:
         assert len(result_arg['errors']) == 2
 
     def test_bg_worker_records_dg_usage_when_enabled(self):
-        """Worker must call record_dg_usage_ms when fair_use_restrict_dg=True."""
+        """Worker must call record_dg_usage_ms when FAIR_USE_ENABLED and enforcement=restrict."""
         mod, mock_sync_jobs = self._load_bg_worker()
         if mod is None:
             pytest.skip("Cannot load sync router due to import chain")
@@ -964,22 +979,27 @@ class TestBackgroundWorkerBehavioral:
         mod.process_segment = MagicMock()
         mock_record_dg = MagicMock()
         mod.record_dg_usage_ms = mock_record_dg
+        mod.FAIR_USE_ENABLED = True
+        mod.FAIR_USE_RESTRICT_DAILY_DG_MS = 1000
+        mod.get_enforcement_stage = MagicMock(return_value='restrict')
+        mod.is_dg_budget_exhausted = MagicMock(return_value=False)
+        mod.record_speech_ms = MagicMock()
+        mod.get_rolling_speech_ms = MagicMock(return_value={})
+        mod.check_soft_caps = MagicMock(return_value=[])
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='dg-job',
             uid='test-uid',
-            segmented_paths=['/tmp/d1.wav'],
+            raw_paths=['/tmp/d1.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=True,
-            total_speech_seconds=15.5,
+            should_lock=False,
             job_dir='/tmp/dg-dir',
         )
 
-        mock_record_dg.assert_called_once_with('test-uid', 15500)
+        mock_record_dg.assert_called_once_with('test-uid', 5000)
 
     def test_bg_worker_skips_dg_recording_when_disabled(self):
-        """Worker must NOT call record_dg_usage_ms when fair_use_restrict_dg=False."""
+        """Worker must NOT call record_dg_usage_ms when FAIR_USE_ENABLED=False."""
         mod, mock_sync_jobs = self._load_bg_worker()
         if mod is None:
             pytest.skip("Cannot load sync router due to import chain")
@@ -987,15 +1007,14 @@ class TestBackgroundWorkerBehavioral:
         mod.process_segment = MagicMock()
         mock_record_dg = MagicMock()
         mod.record_dg_usage_ms = mock_record_dg
+        mod.FAIR_USE_ENABLED = False
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='no-dg-job',
             uid='test-uid',
-            segmented_paths=['/tmp/d1.wav'],
+            raw_paths=['/tmp/d1.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=15.5,
+            should_lock=False,
             job_dir='/tmp/no-dg-dir',
         )
 
@@ -1015,14 +1034,12 @@ class TestBackgroundWorkerBehavioral:
         job_dir = tempfile.mkdtemp(prefix='sync_v2_test_')
         assert os.path.isdir(job_dir)
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='cleanup-job',
             uid='test-uid',
-            segmented_paths=[],
+            raw_paths=[],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=0.0,
+            should_lock=False,
             job_dir=job_dir,
         )
 
@@ -1041,21 +1058,19 @@ class TestBackgroundWorkerBehavioral:
         job_dir = tempfile.mkdtemp(prefix='sync_v2_test_fail_')
         assert os.path.isdir(job_dir)
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='cleanup-fail-job',
             uid='test-uid',
-            segmented_paths=[],
+            raw_paths=[],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=0.0,
+            should_lock=False,
             job_dir=job_dir,
         )
 
         assert not os.path.exists(job_dir), "Job directory must be cleaned up even on failure"
 
-    def test_bg_worker_forwards_prefs_and_cache_to_process_segment(self):
-        """Worker must forward transcription_prefs and person_embeddings_cache to each process_segment call."""
+    def test_bg_worker_fetches_and_forwards_prefs_to_process_segment(self):
+        """Worker must fetch prefs/cache internally and forward to each process_segment call."""
         mod, mock_sync_jobs = self._load_bg_worker()
         if mod is None:
             pytest.skip("Cannot load sync router due to import chain")
@@ -1071,54 +1086,22 @@ class TestBackgroundWorkerBehavioral:
 
         test_prefs = {'language': 'es', 'model': 'nova-3'}
         test_cache = {'p-alice': {'name': 'Alice', 'embedding': [0.1, 0.2]}}
+        mod.users_db.get_user_transcription_preferences = MagicMock(return_value=test_prefs)
+        mod.build_person_embeddings_cache = MagicMock(return_value=test_cache)
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='prefs-job',
             uid='test-uid',
-            segmented_paths=['/tmp/p1.wav', '/tmp/p2.wav'],
+            raw_paths=['/tmp/p1.wav', '/tmp/p2.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=10.0,
+            should_lock=False,
             job_dir='/tmp/prefs-dir',
-            transcription_prefs=test_prefs,
-            person_embeddings_cache=test_cache,
         )
 
         assert len(received_args) == 2
         for args in received_args:
             assert args['prefs'] is test_prefs
             assert args['cache'] is test_cache
-
-    def test_bg_worker_defaults_prefs_and_cache_to_none(self):
-        """Worker must default transcription_prefs and person_embeddings_cache to None when not provided."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        received_args = []
-
-        def mock_process_segment(
-            path, uid, response, lock, errors, source, is_locked, prefs=None, cache=None, target_conversation_id=None
-        ):
-            received_args.append({'prefs': prefs, 'cache': cache})
-
-        mod.process_segment = mock_process_segment
-
-        mod._process_segments_background(
-            job_id='noprefs-job',
-            uid='test-uid',
-            segmented_paths=['/tmp/n1.wav'],
-            source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=5.0,
-            job_dir='/tmp/noprefs-dir',
-        )
-
-        assert len(received_args) == 1
-        assert received_args[0]['prefs'] is None
-        assert received_args[0]['cache'] is None
 
     def test_bg_worker_forwards_target_conversation_id_to_process_segment(self):
         """Worker must forward target_conversation_id to each process_segment call."""
@@ -1135,14 +1118,12 @@ class TestBackgroundWorkerBehavioral:
 
         mod.process_segment = mock_process_segment
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='target-conv-job',
             uid='test-uid',
-            segmented_paths=['/tmp/tc1.wav', '/tmp/tc2.wav'],
+            raw_paths=['/tmp/tc1.wav', '/tmp/tc2.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=10.0,
+            should_lock=False,
             job_dir='/tmp/target-conv-dir',
             target_conversation_id='conv-123',
         )
@@ -1166,14 +1147,12 @@ class TestBackgroundWorkerBehavioral:
 
         mod.process_segment = mock_process_segment
 
-        mod._process_segments_background(
+        mod._run_full_pipeline_background(
             job_id='no-target-conv-job',
             uid='test-uid',
-            segmented_paths=['/tmp/nt1.wav'],
+            raw_paths=['/tmp/nt1.wav'],
             source='omi',
-            is_locked=False,
-            fair_use_restrict_dg=False,
-            total_speech_seconds=5.0,
+            should_lock=False,
             job_dir='/tmp/no-target-conv-dir',
         )
 
@@ -1212,10 +1191,13 @@ class TestV2EndpointExecution:
             'pydub',
             'models',
             'models.conversation',
+            'models.conversation_enums',
             'models.transcript_segment',
             'utils',
+            'utils.analytics',
             'utils.conversations',
             'utils.conversations.process_conversation',
+            'utils.conversations.factory',
             'utils.other',
             'utils.other.endpoints',
             'utils.other.storage',
@@ -1227,6 +1209,7 @@ class TestV2EndpointExecution:
             'utils.subscription',
             'utils.observability',
             'utils.log_sanitizer',
+            'utils.http_client',
             'utils.speaker_assignment',
             'utils.speaker_identification',
             'utils.stt.speaker_embedding',

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -141,7 +141,7 @@ class TestSyncV2Structure:
         func_body = source[start:next_boundary]
 
         dg_pos = func_body.index('record_dg_usage_ms')
-        processing_pos = func_body.index('future.result()')
+        processing_pos = func_body.index('future.result(')
         assert dg_pos > processing_pos, "DG usage must be recorded AFTER segment processing"
 
     def test_v2_background_does_decode_and_vad(self):
@@ -430,7 +430,7 @@ class TestFullPipelineBackground:
         body = self._get_bg_func_body()
         assert 'update_sync_job(' in body, "Worker must call update_sync_job for heartbeat"
         heartbeat_pos = body.rindex('update_sync_job(')
-        result_pos = body.index('future.result()')
+        result_pos = body.index('future.result(')
         assert heartbeat_pos > result_pos, "Heartbeat must come after future.result()"
 
     def test_background_pipeline_order(self):
@@ -484,7 +484,7 @@ class TestV1Unchanged:
         body = self._get_v1_body()
         assert 'asyncio.gather' in body, "v1 must use asyncio.gather for segment processing"
         assert 'run_in_executor' in body, "v1 must use run_in_executor for blocking segment work"
-        assert 'critical_executor' in body, "v1 must use critical_executor (Lane 2 architecture)"
+        assert 'sync_executor' in body, "v1 must use sync_executor for segment work"
 
     def test_v1_cleanup_in_finally(self):
         """v1 must still clean up files in finally block."""
@@ -790,11 +790,20 @@ class TestBackgroundWorkerBehavioral:
             saved_modules[mod] = sys.modules.get(mod)
             sys.modules[mod] = MagicMock()
 
-        from concurrent.futures import ThreadPoolExecutor
+        import contextvars
+        from concurrent.futures import Future, ThreadPoolExecutor
 
         _test_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix='test')
+
+        def _submit_with_context(executor, fn, *args, **kwargs):
+            ctx = contextvars.copy_context()
+            return executor.submit(ctx.run, fn, *args, **kwargs)
+
         sys.modules['utils.executors'].critical_executor = _test_executor
+        sys.modules['utils.executors'].sync_executor = _test_executor
+        sys.modules['utils.executors'].postprocess_executor = _test_executor
         sys.modules['utils.executors'].storage_executor = _test_executor
+        sys.modules['utils.executors'].submit_with_context = _submit_with_context
 
         sys.modules['database.redis_db'] = MagicMock(r=mock_redis)
         saved_modules['database.sync_jobs'] = sys.modules.get('database.sync_jobs')
@@ -1334,10 +1343,19 @@ class TestV2EndpointExecution:
             saved_modules[mod_name] = sys.modules.get(mod_name)
             sys.modules[mod_name] = MagicMock()
 
-        # Stub utils.executors with a real-ish critical_executor mock
+        # Stub utils.executors with real-ish executor mocks
+        import contextvars
+
+        def _submit_with_context(executor, fn, *args, **kwargs):
+            ctx = contextvars.copy_context()
+            return executor.submit(ctx.run, fn, *args, **kwargs)
+
         mock_executors = MagicMock()
         mock_executors.critical_executor = MagicMock()
+        mock_executors.sync_executor = MagicMock()
+        mock_executors.postprocess_executor = MagicMock()
         mock_executors.storage_executor = MagicMock()
+        mock_executors.submit_with_context = _submit_with_context
         saved_modules['utils.executors'] = sys.modules.get('utils.executors')
         sys.modules['utils.executors'] = mock_executors
 

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1159,6 +1159,121 @@ class TestBackgroundWorkerBehavioral:
         assert len(received_args) == 1
         assert received_args[0]['target_conversation_id'] is None
 
+    def test_bg_worker_decode_failure_marks_job_failed(self):
+        """Worker must mark_job_failed when decode_files_to_wav raises."""
+        mod, mock_sync_jobs = self._load_bg_worker()
+        if mod is None:
+            pytest.skip("Cannot load sync router due to import chain")
+
+        mod.decode_files_to_wav = MagicMock(side_effect=Exception("corrupt opus frame"))
+
+        mod._run_full_pipeline_background(
+            job_id='decode-fail-job',
+            uid='test-uid',
+            raw_paths=['/tmp/bad.opus'],
+            source='omi',
+            should_lock=False,
+            job_dir='/tmp/decode-fail-dir',
+        )
+
+        mock_sync_jobs.mark_job_failed.assert_called_once()
+        assert 'corrupt opus frame' in mock_sync_jobs.mark_job_failed.call_args[0][1]
+
+    def test_bg_worker_vad_error_aborts_job(self):
+        """Worker must fail the job when retrieve_vad_segments produces errors."""
+        mod, mock_sync_jobs = self._load_bg_worker()
+        if mod is None:
+            pytest.skip("Cannot load sync router due to import chain")
+
+        def _bad_vad(path, segmented_paths, errors=None):
+            if errors is not None:
+                errors.append(f'VAD failed: {path}')
+
+        mod.retrieve_vad_segments = _bad_vad
+
+        mod._run_full_pipeline_background(
+            job_id='vad-fail-job',
+            uid='test-uid',
+            raw_paths=['/tmp/v1.wav'],
+            source='omi',
+            should_lock=False,
+            job_dir='/tmp/vad-fail-dir',
+        )
+
+        mock_sync_jobs.mark_job_failed.assert_called_once()
+        assert 'VAD failed' in mock_sync_jobs.mark_job_failed.call_args[0][1]
+        mock_sync_jobs.mark_job_completed.assert_not_called()
+
+    def test_bg_worker_vad_exception_aborts_job(self):
+        """Worker must fail the job when retrieve_vad_segments raises an exception."""
+        mod, mock_sync_jobs = self._load_bg_worker()
+        if mod is None:
+            pytest.skip("Cannot load sync router due to import chain")
+
+        mod.retrieve_vad_segments = MagicMock(side_effect=RuntimeError("AudioSegment export failed"))
+
+        mod._run_full_pipeline_background(
+            job_id='vad-exc-job',
+            uid='test-uid',
+            raw_paths=['/tmp/v1.wav'],
+            source='omi',
+            should_lock=False,
+            job_dir='/tmp/vad-exc-dir',
+        )
+
+        mock_sync_jobs.mark_job_failed.assert_called_once()
+        assert 'AudioSegment export failed' in mock_sync_jobs.mark_job_failed.call_args[0][1]
+
+    def test_bg_worker_dg_budget_exhausted_fails_job(self):
+        """Worker must mark_job_failed when DG budget is exhausted."""
+        mod, mock_sync_jobs = self._load_bg_worker()
+        if mod is None:
+            pytest.skip("Cannot load sync router due to import chain")
+
+        mod.FAIR_USE_ENABLED = True
+        mod.FAIR_USE_RESTRICT_DAILY_DG_MS = 1000
+        mod.get_enforcement_stage = MagicMock(return_value='restrict')
+        mod.is_dg_budget_exhausted = MagicMock(return_value=True)
+        mod.record_speech_ms = MagicMock()
+        mod.get_rolling_speech_ms = MagicMock(return_value={})
+        mod.check_soft_caps = MagicMock(return_value=[])
+        mod.process_segment = MagicMock()
+
+        mod._run_full_pipeline_background(
+            job_id='dg-exhaust-job',
+            uid='test-uid',
+            raw_paths=['/tmp/e1.wav'],
+            source='omi',
+            should_lock=False,
+            job_dir='/tmp/dg-exhaust-dir',
+        )
+
+        mock_sync_jobs.mark_job_failed.assert_called_once()
+        assert 'budget exhausted' in mock_sync_jobs.mark_job_failed.call_args[0][1].lower()
+        mod.process_segment.assert_not_called()
+
+    def test_bg_worker_empty_wav_paths_completes_with_zero(self):
+        """Worker must complete with zero segments when decode returns empty list."""
+        mod, mock_sync_jobs = self._load_bg_worker()
+        if mod is None:
+            pytest.skip("Cannot load sync router due to import chain")
+
+        mod.decode_files_to_wav = MagicMock(return_value=[])
+
+        mod._run_full_pipeline_background(
+            job_id='empty-job',
+            uid='test-uid',
+            raw_paths=['/tmp/empty.opus'],
+            source='omi',
+            should_lock=False,
+            job_dir='/tmp/empty-dir',
+        )
+
+        mock_sync_jobs.mark_job_completed.assert_called_once()
+        result = mock_sync_jobs.mark_job_completed.call_args[0][1]
+        assert result['total_segments'] == 0
+        assert result['failed_segments'] == 0
+
 
 # ---------------------------------------------------------------------------
 # 8. v2 endpoint execution tests via FastAPI TestClient

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -49,7 +49,7 @@ from models.task import Task, TaskStatus, TaskAction, TaskActionProvider
 from models.trend import Trend
 from models.notification_message import NotificationMessage
 from utils.apps import get_available_apps, update_personas_async, update_persona_prompt
-from utils.executors import critical_executor, postprocess_executor
+from utils.executors import critical_executor, postprocess_executor, submit_with_context
 from utils.llm.conversation_processing import (
     get_transcript_structure,
     get_app_result,
@@ -772,11 +772,11 @@ def process_conversation(
             uid, conversation, is_reprocess=is_reprocess, app_id=app_id, language_code=language_code, people=people
         )
         if not is_reprocess:
-            postprocess_executor.submit(save_structured_vector, uid, conversation)
-        postprocess_executor.submit(_extract_memories, uid, conversation)
-        postprocess_executor.submit(_extract_trends, uid, conversation)
-        postprocess_executor.submit(_save_action_items, uid, conversation)
-        postprocess_executor.submit(_update_goal_progress, uid, conversation)
+            submit_with_context(postprocess_executor, save_structured_vector, uid, conversation)
+        submit_with_context(postprocess_executor, _extract_memories, uid, conversation)
+        submit_with_context(postprocess_executor, _extract_trends, uid, conversation)
+        submit_with_context(postprocess_executor, _save_action_items, uid, conversation)
+        submit_with_context(postprocess_executor, _update_goal_progress, uid, conversation)
 
     # Create audio files from chunks if private cloud sync was enabled
     if not is_reprocess and conversation.private_cloud_sync_enabled:
@@ -804,8 +804,8 @@ def process_conversation(
         def _run_webhook():
             asyncio.run(conversation_created_webhook(uid, conversation))
 
-        postprocess_executor.submit(_run_webhook)
-        postprocess_executor.submit(update_personas_async, uid)
+        submit_with_context(postprocess_executor, _run_webhook)
+        submit_with_context(postprocess_executor, update_personas_async, uid)
 
         # Disable important conversation for now
         # Send important conversation notification for long conversations (>30 minutes)

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -49,7 +49,7 @@ from models.task import Task, TaskStatus, TaskAction, TaskActionProvider
 from models.trend import Trend
 from models.notification_message import NotificationMessage
 from utils.apps import get_available_apps, update_personas_async, update_persona_prompt
-from utils.executors import critical_executor
+from utils.executors import critical_executor, postprocess_executor
 from utils.llm.conversation_processing import (
     get_transcript_structure,
     get_app_result,
@@ -772,11 +772,11 @@ def process_conversation(
             uid, conversation, is_reprocess=is_reprocess, app_id=app_id, language_code=language_code, people=people
         )
         if not is_reprocess:
-            critical_executor.submit(save_structured_vector, uid, conversation)
-        critical_executor.submit(_extract_memories, uid, conversation)
-        critical_executor.submit(_extract_trends, uid, conversation)
-        critical_executor.submit(_save_action_items, uid, conversation)
-        critical_executor.submit(_update_goal_progress, uid, conversation)
+            postprocess_executor.submit(save_structured_vector, uid, conversation)
+        postprocess_executor.submit(_extract_memories, uid, conversation)
+        postprocess_executor.submit(_extract_trends, uid, conversation)
+        postprocess_executor.submit(_save_action_items, uid, conversation)
+        postprocess_executor.submit(_update_goal_progress, uid, conversation)
 
     # Create audio files from chunks if private cloud sync was enabled
     if not is_reprocess and conversation.private_cloud_sync_enabled:
@@ -804,9 +804,8 @@ def process_conversation(
         def _run_webhook():
             asyncio.run(conversation_created_webhook(uid, conversation))
 
-        critical_executor.submit(_run_webhook)
-        # Update persona prompts with new conversation
-        critical_executor.submit(update_personas_async, uid)
+        postprocess_executor.submit(_run_webhook)
+        postprocess_executor.submit(update_personas_async, uid)
 
         # Disable important conversation for now
         # Send important conversation notification for long conversations (>30 minutes)

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -404,7 +404,7 @@ def _trigger_apps(
         if not is_reprocess:
             record_app_usage(uid, app.id, UsageHistoryType.memory_created_prompt, conversation_id=conversation.id)
 
-    futures = [critical_executor.submit(execute_app, app) for app in filtered_apps]
+    futures = [submit_with_context(critical_executor, execute_app, app) for app in filtered_apps]
     for future in futures:
         try:
             future.result()
@@ -624,7 +624,7 @@ def _save_action_items(uid: str, conversation: Conversation):
         def _run_auto_sync():
             asyncio.run(auto_sync_action_items_batch(uid, created_items))
 
-        critical_executor.submit(_run_auto_sync)
+        submit_with_context(critical_executor, _run_auto_sync)
 
 
 def save_structured_vector(uid: str, conversation: Conversation, update_only: bool = False):

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -1,9 +1,13 @@
 """Dedicated ThreadPoolExecutors for Lane 2 of the 3-lane async architecture (issue #6369).
 
-Provides two shared executors with strict separation:
+Provides shared executors with strict separation (bulkhead pattern):
 - critical_executor: process_conversation, memory extraction, action items, trends,
   goal progress, persona updates, webhook delivery, vector operations.
-  Never shared with best-effort work.
+- sync_executor: sync pipeline VAD/STT/segment processing. Isolated from critical
+  to prevent sync load from starving real-time conversation processing.
+- postprocess_executor: best-effort post-processing (memories, trends, vectors,
+  action items, goals). Separated so slow LLM retries cannot block sync or
+  conversation processing.
 - storage_executor: audio file precaching, GCS operations.
 
 These replace ad-hoc ThreadPoolExecutor creation throughout the codebase,
@@ -11,18 +15,32 @@ preventing thread proliferation and providing bounded concurrency.
 """
 
 import atexit
+import contextvars
 import logging
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
 critical_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="critical")
+sync_executor = ThreadPoolExecutor(max_workers=12, thread_name_prefix="sync")
+postprocess_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="postproc")
 storage_executor = ThreadPoolExecutor(max_workers=16, thread_name_prefix="storage")
+
+
+def submit_with_context(executor: ThreadPoolExecutor, fn, *args, **kwargs) -> Future:
+    """Submit *fn* to *executor*, propagating the current contextvars (BYOK keys, etc.)."""
+    ctx = contextvars.copy_context()
+    return executor.submit(ctx.run, fn, *args, **kwargs)
 
 
 def shutdown_executors():
     """Shut down all shared executors. Called at app shutdown."""
-    for name, executor in [('critical', critical_executor), ('storage', storage_executor)]:
+    for name, executor in [
+        ('critical', critical_executor),
+        ('sync', sync_executor),
+        ('postprocess', postprocess_executor),
+        ('storage', storage_executor),
+    ]:
         try:
             executor.shutdown(wait=False, cancel_futures=True)
         except Exception as e:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -102,7 +102,7 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
     cache_key = _hash_key(api_key)
     inst = _anthropic_cache.get(cache_key)
     if inst is None:
-        inst = anthropic.AsyncAnthropic(api_key=api_key)
+        inst = anthropic.AsyncAnthropic(api_key=api_key, timeout=120.0, max_retries=1)
         _anthropic_cache[cache_key] = inst
     return inst
 
@@ -137,7 +137,7 @@ def _create_byok_client(
 
 
 # Anthropic client for chat agent (module-level, BYOK-aware)
-_default_anthropic_client = anthropic.AsyncAnthropic()  # uses ANTHROPIC_API_KEY env var
+_default_anthropic_client = anthropic.AsyncAnthropic(timeout=120.0, max_retries=1)
 anthropic_client = _AnthropicClientProxy(_default_anthropic_client)
 
 
@@ -624,7 +624,7 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = get_model('chat_agent')
 # Legacy module-level alias (kept for test compatibility).
 # Production code should use get_llm(feature) exclusively.
 # ---------------------------------------------------------------------------
-llm_mini = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback])
+llm_mini = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback], request_timeout=120, max_retries=1)
 
 # ---------------------------------------------------------------------------
 # Embeddings, parser, utilities

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -111,7 +111,7 @@ def _create_byok_client(
     model: str, provider: str, byok_key: str, streaming: bool = False, feature: str = ''
 ) -> Optional[ChatOpenAI]:
     """Create a ChatOpenAI using the user's BYOK key. Returns None if BYOK not supported for this provider."""
-    kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
+    kwargs: Dict[str, Any] = {'callbacks': [_usage_callback], 'request_timeout': 120, 'max_retries': 1}
     if model == 'gpt-5.1':
         kwargs['extra_body'] = {"prompt_cache_retention": "24h"}
     if streaming:
@@ -417,7 +417,11 @@ def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> ChatO
     """Get or create a cached ChatOpenAI for an OpenAI model."""
     key = (model_name, streaming, 'openai')
     if key not in _llm_cache:
-        kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
+        kwargs: Dict[str, Any] = {
+            'callbacks': [_usage_callback],
+            'request_timeout': 120,
+            'max_retries': 1,
+        }
         if model_name == 'gpt-5.1':
             kwargs['extra_body'] = {"prompt_cache_retention": "24h"}
         if streaming:
@@ -444,6 +448,8 @@ def _get_or_create_openrouter_llm(
             'base_url': "https://openrouter.ai/api/v1",
             'default_headers': {"X-Title": "Omi Chat"},
             'callbacks': [_usage_callback],
+            'request_timeout': 120,
+            'max_retries': 1,
         }
         if temperature is not None:
             kwargs['temperature'] = temperature
@@ -472,22 +478,19 @@ def _get_or_create_gemini_llm(model_name: str, streaming: bool = False) -> BaseC
         use_vertex = os.environ.get('USE_VERTEX_AI', '').lower() == 'true'
         gcp_project = os.environ.get('GOOGLE_CLOUD_PROJECT', '') if use_vertex else ''
         gemini_key = os.environ.get('GEMINI_API_KEY', '')
-        kwargs: Dict[str, Any] = {'callbacks': [_usage_callback]}
+        kwargs: Dict[str, Any] = {'callbacks': [_usage_callback], 'timeout': 120, 'max_retries': 1}
         if streaming:
             kwargs['streaming'] = True
 
         if gcp_project:
-            # Vertex AI — explicit opt-in, uses ADC (GOOGLE_APPLICATION_CREDENTIALS)
             gcp_location = os.environ.get('GCP_LOCATION', 'us-central1')
             _llm_cache[key] = ChatGoogleGenerativeAI(
                 model=model_name, project=gcp_project, location=gcp_location, **kwargs
             )
         elif gemini_key:
-            # AI Studio — uses API key, paid-tier quota
             kwargs['google_api_key'] = gemini_key
             _llm_cache[key] = ChatGoogleGenerativeAI(model=model_name, **kwargs)
         else:
-            # No credentials — constructable placeholder, fails at invoke time
             logger.warning('No USE_VERTEX_AI or GEMINI_API_KEY — Gemini calls will fail at invoke time')
             _llm_cache[key] = ChatOpenAI(
                 model=model_name, api_key='not-set', base_url=_GEMINI_OPENAI_BASE_URL, **kwargs

--- a/backend/utils/llm/fair_use_classifier.py
+++ b/backend/utils/llm/fair_use_classifier.py
@@ -18,7 +18,9 @@ from utils.llm.usage_tracker import get_usage_callback
 logger = logging.getLogger(__name__)
 
 CLASSIFIER_MODEL = os.getenv('FAIR_USE_CLASSIFIER_MODEL', 'gpt-5.1')
-_classifier_llm = ChatOpenAI(model=CLASSIFIER_MODEL, callbacks=[get_usage_callback()])
+_classifier_llm = ChatOpenAI(
+    model=CLASSIFIER_MODEL, callbacks=[get_usage_callback()], request_timeout=120, max_retries=1
+)
 CLASSIFIER_LOOKBACK_DAYS = int(os.getenv('FAIR_USE_CLASSIFIER_LOOKBACK_DAYS', '7'))
 CLASSIFIER_MAX_CONVERSATIONS = 30
 

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -244,7 +244,7 @@ def deepgram_prerecorded(
 
     except Exception as e:
         logger.error(f'Deepgram prerecorded error: {e}')
-        if attempts < 2:
+        if attempts < 1:
             return deepgram_prerecorded(
                 audio_url,
                 speakers_count,
@@ -376,7 +376,7 @@ def deepgram_prerecorded_from_bytes(
 
     except Exception as e:
         logger.error(f'Deepgram prerecorded from bytes error: {e}')
-        if attempts < 2:
+        if attempts < 1:
             return deepgram_prerecorded_from_bytes(
                 audio_bytes,
                 sample_rate,

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -12,7 +12,7 @@ from utils.byok import get_byok_key
 from utils.other.endpoints import timeit
 import logging
 
-_DG_TIMEOUT = httpx.Timeout(connect=10.0, read=180.0, write=30.0, pool=10.0)
+_DG_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=10.0)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -4,12 +4,15 @@ from io import BytesIO
 from typing import List, Optional, Sequence, Tuple, Union
 
 import fal_client
+import httpx
 from deepgram import DeepgramClient, DeepgramClientOptions
 
 from models.transcript_segment import TranscriptSegment
 from utils.byok import get_byok_key
 from utils.other.endpoints import timeit
 import logging
+
+_DG_TIMEOUT = httpx.Timeout(connect=10.0, read=180.0, write=30.0, pool=10.0)
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +193,11 @@ def deepgram_prerecorded(
             else:
                 options["keywords"] = list(keywords)
 
-        response = _deepgram_client_for_request().listen.rest.v("1").transcribe_url({"url": audio_url}, options)
+        response = (
+            _deepgram_client_for_request()
+            .listen.rest.v("1")
+            .transcribe_url({"url": audio_url}, options, timeout=_DG_TIMEOUT)
+        )
 
         # Extract words from response
         result = response.to_dict()
@@ -322,7 +329,9 @@ def deepgram_prerecorded_from_bytes(
         mimetype = "audio/raw" if encoding else "audio/wav"
         source = {"buffer": audio_buffer, "mimetype": mimetype}
 
-        response = _deepgram_client_for_request().listen.rest.v("1").transcribe_file(source, options)
+        response = (
+            _deepgram_client_for_request().listen.rest.v("1").transcribe_file(source, options, timeout=_DG_TIMEOUT)
+        )
 
         # Extract words from response
         result = response.to_dict()


### PR DESCRIPTION
## Summary

Fixes #7281 — sync `/v2/sync-local-files` chronic 504 timeouts (25-93% error rate) caused by thread pool starvation.

### Root Cause
The shared `critical_executor` (8 workers) was used by both sync pipeline processing AND conversation post-processing. Long-running operations (OpenAI 60s retries, Deepgram unbounded reads, LLM calls with no timeout) would exhaust all 8 threads, causing new sync jobs to queue indefinitely until Cloud Run's 600s timeout fired.

### Changes

**Thread pool bulkhead pattern** (`utils/executors.py`)
- New `sync_executor` (12 workers) — isolated pool for sync VAD/STT/segment processing
- New `postprocess_executor` (8 workers) — isolated pool for memories, trends, vectors, goals
- `submit_with_context()` helper — propagates `ContextVar`s (BYOK keys) to thread pool workers

**BYOK context propagation** (`routers/sync.py`, `utils/conversations/process_conversation.py`)
- Capture BYOK keys from request context before dispatching to background thread
- Pass keys explicitly to `_run_full_pipeline_background` and restore via `set_byok_keys()`
- Always set BYOK context (including empty dict) to prevent stale key leakage across thread reuse
- Clear BYOK context in `finally` block
- All executor submissions use `submit_with_context()` — no plain `.submit()` in modified files

**Timeout enforcement on all external calls**
- LLM clients: 120s request timeout + max 1 retry (OpenAI, Gemini, OpenRouter, BYOK, llm_mini, fair_use_classifier)
- Anthropic clients: 120s timeout + max 1 retry (default and BYOK)
- Deepgram STT: 120s read timeout via `httpx.Timeout`, retries reduced from 3 to 2 (max 240s < 300s budget)
- Segment futures: 300s bounded wait with error logging on timeout

**Post-processing isolation** (`utils/conversations/process_conversation.py`)
- All `postprocess_executor` submissions use `submit_with_context()` for BYOK propagation
- Covers: vector save, memory extraction, trends, action items, goals, webhooks, personas, app execution, auto-sync

**Per-stage timing instrumentation** (`routers/sync.py`)
- Tracks `decode_ms`, `vad_ms`, `stt_llm_ms`, `total_ms` in Redis job result
- Enables monitoring without code changes

## Test plan

- [x] 103 `test_sync_v2.py` tests pass (structural, behavioral, boundary, execution, coverage)
- [x] Pre-commit formatting passes
- [x] `lint_async_blockers.py` — no new violations in changed files
- [x] `beast omi dev boot-check --full` — import clean + uvicorn healthy on :8700
- [x] Executor module verified: 4 pools, correct worker counts, submit_with_context propagates ContextVars
- [x] Backend starts, v1/v2 sync endpoints respond (401 = auth required, routes registered)
- [x] **Integration tests: 7/7 PASS** (OpenAI, Anthropic, Gemini, OpenRouter, Deepgram, BYOK OpenAI, BYOK Anthropic)
- [ ] Deploy to dev and verify 504 rate drops
- [ ] Monitor stage_timings in Redis for bottleneck identification

### Integration test results (2026-05-13)

| Provider | Model | Mode | Result | Latency |
|----------|-------|------|--------|---------|
| OpenAI | gpt-4.1-mini | Default | PASS | 1.87s |
| Anthropic | claude-sonnet-4 | Default | PASS | 1.16s |
| Gemini | gemini-2.5-flash | Default | PASS | 2.64s |
| OpenRouter | gemini-2.0-flash | Default | PASS | 2.02s |
| Deepgram | nova-2 | STT | PASS | 7.92s |
| OpenAI | gpt-4.1-mini | BYOK simulated | PASS | 1.35s |
| Anthropic | claude-sonnet-4 | BYOK simulated | PASS | 1.23s |

## Risk assessment

- **Low risk**: Thread pool changes are additive (new pools) not destructive (existing `critical_executor` unchanged)
- **Low risk**: Timeout values (120s LLM, 120s DG read) are generous — only catch runaway operations
- **Medium risk**: DG retry reduction from 3→2 may surface more transient failures, but 2 attempts is still resilient

Closes #7281

_by AI for @beastoin_