### PR TITLE
Rollback VAD min replica to 2

### DIFF
--- a/backend/charts/vad/prod_omi_vad_values.yaml
+++ b/backend/charts/vad/prod_omi_vad_values.yaml
@@ -124,7 +124,7 @@ startupProbe:
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: true
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 10
   behavior:
     scaleDown:


### PR DESCRIPTION
**Changes:** 

- High error rate on backend-sync since reduced min replica of VAD to 1 (for cost optimization) and depend on HPA to scale out. Backend sync relies heavily on VAD to trim down the slience from the audio before STT. => Rollback min replica of VAD to 2