### PR TITLE
fix(app): write Apple Reminders to default list instead of creating one per task

### DIFF
--- a/app/ios/Runner/AppleRemindersService.swift
+++ b/app/ios/Runner/AppleRemindersService.swift
@@ -288,7 +288,7 @@ class AppleRemindersService {
         }
 
         let notes = args["notes"] as? String
-        let listName = args["listName"] as? String ?? "Reminders"
+        let listName = args["listName"] as? String
         let dueDate: Date? = {
             if let dueDateMs = args["dueDate"] as? Int64 {
                 return Date(timeIntervalSince1970: TimeInterval(dueDateMs) / 1000.0)
@@ -301,29 +301,18 @@ class AppleRemindersService {
             return
         }
 
-        // Find or create the calendar
+        // Never auto-create a list: title matching ("Reminders") fails on
+        // non-English systems (e.g. "提醒事项") and used to spawn one list per task.
         var targetCalendar: EKCalendar?
-        let calendars = eventStore.calendars(for: .reminder)
-        targetCalendar = calendars.first { $0.title == listName }
-
+        if let name = listName, !name.isEmpty {
+            targetCalendar = eventStore.calendars(for: .reminder).first { $0.title == name }
+        }
         if targetCalendar == nil {
-            targetCalendar = EKCalendar(for: .reminder, eventStore: eventStore)
-            targetCalendar?.title = listName
-            targetCalendar?.cgColor = UIColor.systemBlue.cgColor
-
-            if let defaultSource = eventStore.defaultCalendarForNewReminders()?.source {
-                targetCalendar?.source = defaultSource
-            }
-
-            do {
-                try eventStore.saveCalendar(targetCalendar!, commit: true)
-            } catch {
-                targetCalendar = eventStore.defaultCalendarForNewReminders()
-            }
+            targetCalendar = eventStore.defaultCalendarForNewReminders()
         }
 
         guard let calendar = targetCalendar else {
-            result(FlutterError(code: "NO_CALENDAR", message: "Could not find or create calendar", details: nil))
+            result(FlutterError(code: "NO_CALENDAR", message: "No reminders calendar available", details: nil))
             return
         }
 

--- a/app/ios/Runner/AppleRemindersService.swift
+++ b/app/ios/Runner/AppleRemindersService.swift
@@ -342,20 +342,26 @@ class AppleRemindersService {
             return
         }
 
-        let listName = args["listName"] as? String ?? "Reminders"
+        let listName = args["listName"] as? String
 
         guard hasRemindersAccess() else {
             result([])
             return
         }
 
-        let calendars = eventStore.calendars(for: .reminder)
-        guard let targetCalendar = calendars.first(where: { $0.title == listName }) else {
+        var targetCalendar: EKCalendar?
+        if let name = listName, !name.isEmpty {
+            targetCalendar = eventStore.calendars(for: .reminder).first { $0.title == name }
+        }
+        if targetCalendar == nil {
+            targetCalendar = eventStore.defaultCalendarForNewReminders()
+        }
+        guard let calendar = targetCalendar else {
             result([])
             return
         }
 
-        let predicate = eventStore.predicateForReminders(in: [targetCalendar])
+        let predicate = eventStore.predicateForReminders(in: [calendar])
 
         eventStore.fetchReminders(matching: predicate) { reminders in
             DispatchQueue.main.async {
@@ -376,20 +382,26 @@ class AppleRemindersService {
             return
         }
 
-        let listName = args["listName"] as? String ?? "Reminders"
+        let listName = args["listName"] as? String
 
         guard hasRemindersAccess() else {
             result(false)
             return
         }
 
-        let calendars = eventStore.calendars(for: .reminder)
-        guard let targetCalendar = calendars.first(where: { $0.title == listName }) else {
+        var targetCalendar: EKCalendar?
+        if let name = listName, !name.isEmpty {
+            targetCalendar = eventStore.calendars(for: .reminder).first { $0.title == name }
+        }
+        if targetCalendar == nil {
+            targetCalendar = eventStore.defaultCalendarForNewReminders()
+        }
+        guard let calendar = targetCalendar else {
             result(false)
             return
         }
 
-        let predicate = eventStore.predicateForReminders(in: [targetCalendar])
+        let predicate = eventStore.predicateForReminders(in: [calendar])
 
         eventStore.fetchReminders(matching: predicate) { reminders in
             DispatchQueue.main.async {

--- a/app/lib/pages/action_items/services/action_item_export_service.dart
+++ b/app/lib/pages/action_items/services/action_item_export_service.dart
@@ -140,7 +140,6 @@ class ActionItemExportService {
         title: item.description,
         notes: 'From Omi',
         dueDate: item.dueAt,
-        listName: 'Reminders',
       );
       if (calendarItemId == null) return ExportResult.failed;
 

--- a/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
+++ b/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
@@ -848,7 +848,6 @@ class _ActionItemTileWidgetState extends State<ActionItemTileWidget> {
       title: widget.actionItem.description,
       notes: 'From Omi',
       dueDate: widget.actionItem.dueAt,
-      listName: 'Reminders',
     );
 
     final success = calendarItemId != null;

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -480,7 +480,6 @@ class ActionItemsProvider extends ChangeNotifier {
           title: item.description,
           notes: 'From Omi',
           dueDate: item.dueAt,
-          listName: 'Reminders',
         );
 
         if (calendarItemId != null) {

--- a/app/lib/services/apple_reminders_service.dart
+++ b/app/lib/services/apple_reminders_service.dart
@@ -181,7 +181,9 @@ class AppleRemindersService {
     if (!isAvailable) return [];
 
     try {
-      final result = await _channel.invokeMethod('getReminders', {'listName': listName ?? 'Reminders'});
+      final args = <String, dynamic>{};
+      if (listName != null) args['listName'] = listName;
+      final result = await _channel.invokeMethod('getReminders', args);
       if (result is List) {
         return result.cast<String>();
       }
@@ -201,10 +203,9 @@ class AppleRemindersService {
     if (!isAvailable) return false;
 
     try {
-      final result = await _channel.invokeMethod('completeReminder', {
-        'title': title,
-        'listName': listName ?? 'Reminders',
-      });
+      final args = <String, dynamic>{'title': title};
+      if (listName != null) args['listName'] = listName;
+      final result = await _channel.invokeMethod('completeReminder', args);
       return result == true;
     } catch (e) {
       Logger.debug('Error completing reminder: $e');

--- a/app/lib/services/apple_reminders_service.dart
+++ b/app/lib/services/apple_reminders_service.dart
@@ -80,12 +80,13 @@ class AppleRemindersService {
     }
 
     try {
-      final result = await _channel.invokeMethod('addReminder', {
+      final args = <String, dynamic>{
         'title': title,
         'notes': notes,
         'dueDate': dueDate?.millisecondsSinceEpoch,
-        'listName': listName ?? 'Reminders',
-      });
+      };
+      if (listName != null) args['listName'] = listName;
+      final result = await _channel.invokeMethod('addReminder', args);
 
       if (result is String) {
         return result;
@@ -224,7 +225,7 @@ class AppleRemindersService {
       }
     }
 
-    final calendarItemId = await addReminder(title: actionItemDescription, notes: 'From Omi', listName: 'Reminders');
+    final calendarItemId = await addReminder(title: actionItemDescription, notes: 'From Omi');
     return calendarItemId != null ? AppleRemindersResult.success : AppleRemindersResult.failed;
   }
 }

--- a/app/lib/services/apple_reminders_sync_service.dart
+++ b/app/lib/services/apple_reminders_sync_service.dart
@@ -57,7 +57,6 @@ class AppleRemindersSyncService {
         title: item.description,
         notes: 'From Omi',
         dueDate: item.dueAt,
-        listName: 'Reminders',
       );
 
       if (calendarItemId != null) {


### PR DESCRIPTION
## Summary

On non-English iOS systems, exporting tasks to Apple Reminders created a brand-new "Reminders" list for every task instead of writing into the user's existing list. Result: a "提醒事项" sidebar full of duplicate "Reminders" lists with one task each.

Root cause is in the single-reminder add path. `AppleRemindersService.addReminder()` looked up the target calendar by exact title (`"Reminders"`), and on a miss fell into a "create a new list with that title" branch. The system list is localized (e.g. `"提醒事项"` on zh, `"Erinnerungen"` on de), so the lookup never matched and a fresh `EKCalendar` was saved for every call.

The FCM batch path (`syncBatchFromJSON`) already does the right thing — it writes directly to `defaultCalendarForNewReminders()`. This change brings the single-add path in line with that.

## Fix

- **iOS bridge** (`AppleRemindersService.swift`): treat `listName` as opt-in. If the caller passes a name AND a calendar with that exact title exists, use it; otherwise fall back to `defaultCalendarForNewReminders()`. Never auto-create a new list.
- **Dart**: drop the hardcoded `listName: 'Reminders'` from all four call sites (`apple_reminders_service.dart`, `apple_reminders_sync_service.dart`, `action_items_provider.dart`, `action_item_tile_widget.dart`) and only forward the key to the platform channel when explicitly set.

There is no UI today for selecting a target list, so dropping the hardcoded value is safe — no existing user configuration depends on it.

## Verification

- Code review only — no on-device run yet. Needs a quick smoke on a Chinese-locale device to confirm new reminders land in the system "提醒事项" list and no extra lists are created. English-locale behavior is unchanged (default list is titled "Reminders", which the existing match still finds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)