### PR TITLE
backend: close listen WS at handshake for paywalled desktop users

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -430,6 +430,24 @@ async def _stream_handler(
         except Exception as e:
             logger.error(f"Error sending freemium threshold event on connect: {e} {uid} {session_id}")
 
+    # Hard-close the WS for paywalled DESKTOP users only — keeps GKE pods free
+    # and prevents bandwidth/audio buffering. Mobile freemium users (source!=desktop)
+    # are not affected: the gate above is desktop-scoped. The freemium event we just
+    # sent gives the client a chance to render the paywall popup before close.
+    if is_paywalled_desktop:
+        logger.info(
+            "trial paywall: closing desktop WS uid=%s session=%s reason=trial_expired",
+            uid,
+            session_id,
+        )
+        try:
+            await asyncio.sleep(0.5)  # let the freemium event flush before close
+            await websocket.close(code=1008, reason="trial_expired")
+        except Exception as e:
+            logger.error(f"Error closing paywalled WS: {e} {uid} {session_id}")
+        websocket_active = False
+        return
+
     # Credit cache: avoid querying ~720 Firestore docs every 60s per stream (#5439 sub-task 1)
     CREDITS_REFRESH_SECONDS = 900  # 15 min
     remaining_seconds_cache: Optional[int] = None  # None = not yet fetched (distinct from unlimited)


### PR DESCRIPTION
## Summary

Closes the listen WebSocket with code 1008 \`trial_expired\` for paywalled desktop users right after sending the freemium-threshold event. The client sees the popup, then disconnects — instead of holding a GKE pod open for a session whose audio we'll never bill.

## Why

Previously the trial paywall only dropped audio at the \`dg_socket.send(chunk)\` line in \`transcribe.py:~2371\`. The WS stayed open, audio buffered, GKE pod held — for traffic we'll never use.

## Mobile safety

\`is_paywalled_desktop\` is computed from \`is_trial_paywalled(uid, source)\` which already requires \`source ∈ {desktop, macos}\`. Mobile (\`source=omi\` Omi device), phone-call, and unknown sources continue with the pre-existing behavior — audio still flows, transcripts already suppressed elsewhere by the existing freemium path.

## Test plan

- [x] Syntax check passes
- [ ] After deploy, paywalled desktop user WS closes ~500ms after freemium event reaches client
- [ ] Mobile users on basic plan past 72k seconds still get pre-existing audio-flows-no-transcript behavior
- [ ] GKE listen pod count drops as paywalled connections release

🤖 Generated with [Claude Code](https://claude.com/claude-code)