### PR TITLE
fix(desktop/tasks): cut task notification latency from minutes to ~15s

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Smarter task analyzer dedupe \u2014 per-chat/window throttle instead of one global 60s cooldown, so opening multiple chats in quick succession no longer drops tasks"
+  ],
   "releases": [
     {
       "version": "0.11.395",

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -38,8 +38,26 @@ actor TaskAssistant: ProactiveAssistant {
     private var latestFrame: CapturedFrame?
     /// Fallback timer that fires after extractionInterval if no context switch occurs
     private var fallbackTimerTask: Task<Void, Never>?
-    /// Timestamp of last context switch yield, for throttling rapid switches
-    private var lastContextSwitchYieldTime: Date = .distantPast
+    // Per-(app, normalized-window) timestamp of the last yielded context switch.
+    // Replaces the old global throttle so 10 different chats in <60s all flow through,
+    // while bouncing back to the same chat re-uses the cached analysis.
+    private var lastAnalyzedByKey: [String: Date] = [:]
+
+    /// Apps where new content arrives while the user stays in-app, so a context-switch
+    /// trigger is too slow. Frames arriving for these apps fire analysis immediately
+    /// (subject to the per-window dedupe TTL below).
+    private static let messagingFastPathApps: Set<String> = [
+        "Telegram",
+        "Messages",
+        "iMessage",
+        "WhatsApp",
+        "Signal",
+        "Slack",
+        "Discord",
+        "Messenger",
+    ]
+
+    private static let messagingFastPathDelay: TimeInterval = 15.0
 
     // Cached goals (refreshed every 5 minutes)
     private var cachedGoals: [Goal] = []
@@ -256,7 +274,35 @@ actor TaskAssistant: ProactiveAssistant {
             startFallbackTimer()
         }
 
+        // Fast in-app trigger: for messaging apps, arm a ~15s timer keyed to the
+        // current (app, window). Lets a new chat message turn into a task without
+        // requiring the user to leave the app.
+        armFastFallbackIfNeeded(frame: frame)
+
         return nil
+    }
+
+    /// For messaging apps, fire analysis immediately when a frame for a fresh window
+    /// arrives (subject to the per-window dedupe TTL). Lets chat content turn into a task
+    /// without requiring the user to leave the app. Non-messaging apps continue to rely on
+    /// the regular context-switch + fallback-timer path.
+    private func armFastFallbackIfNeeded(frame: CapturedFrame) {
+        guard Self.messagingFastPathApps.contains(frame.appName) else { return }
+
+        let key = Self.analyzedKey(for: frame)
+
+        // Per-window dedupe — same chat within the TTL is suppressed; the next eligible
+        // frame fires immediately.
+        if let last = lastAnalyzedByKey[key] {
+            let elapsed = Date().timeIntervalSince(last)
+            if elapsed < Self.messagingFastPathDelay {
+                return
+            }
+        }
+
+        log("Task: Fast in-app trigger firing immediately for messaging window '\(key)'")
+        lastAnalyzedByKey[key] = Date()
+        triggerContinuation.yield(.timerFallback(frame))
     }
 
     func handleResult(_ result: AssistantResult, sendEvent: @escaping (String, [String: Any]) -> Void) async {
@@ -474,6 +520,15 @@ actor TaskAssistant: ProactiveAssistant {
             )
 
             log("Task: Synced to staged_tasks backend (id: \(response.id))")
+
+            // Fast-path promotion: don't wait up to 5 min for the safety-net timer to
+            // promote this new task into action_items + fire a notification. Kicking off
+            // the promote loop immediately means the user sees the notification within
+            // seconds of the task being saved, not minutes later.
+            Task {
+                await TaskPromotionService.shared.promoteIfNeeded()
+            }
+
             return response.id
         } catch {
             logError("Task: Failed to sync to backend", error: error)
@@ -529,13 +584,23 @@ actor TaskAssistant: ProactiveAssistant {
 
         log("Task: Context switch from \(frame.appName) (window: \(frame.windowTitle ?? "nil")) -> \(newApp)")
 
-        // Throttle context switch yields using the analysis delay setting
+        // Per-window dedupe instead of one global cooldown. A different chat / window /
+        // browser tab has a different key, so 10 chats with 10 people in <60s all flow
+        // through. Re-entering the same chat within the dedupe window is skipped (the
+        // semantic dedupe inside the Claude prompt already catches duplicate tasks if
+        // we ever do re-analyze the same window later).
+        // Messaging apps use a shorter dedupe so a new message in the same chat doesn't
+        // wait a full minute before getting re-analyzed.
         let analysisDelay = await MainActor.run { AssistantSettings.shared.analysisDelay }
-        if analysisDelay > 0 {
-            let elapsed = Date().timeIntervalSince(lastContextSwitchYieldTime)
-            if elapsed < TimeInterval(analysisDelay) {
-                log("Task: Context switch throttled (\(Int(elapsed))s < \(analysisDelay)s delay)")
-                // Still cancel fallback timer so it resets
+        let dedupeKey = Self.analyzedKey(for: frame)
+        let dedupeTTL: TimeInterval = Self.messagingFastPathApps.contains(frame.appName)
+            ? Self.messagingFastPathDelay
+            : TimeInterval(analysisDelay)
+        let now = Date()
+        if dedupeTTL > 0, let last = lastAnalyzedByKey[dedupeKey] {
+            let elapsed = now.timeIntervalSince(last)
+            if elapsed < dedupeTTL {
+                log("Task: Context switch dedupe — already analyzed '\(dedupeKey)' \(Int(elapsed))s ago (<\(Int(dedupeTTL))s), skipping")
                 fallbackTimerTask?.cancel()
                 fallbackTimerTask = nil
                 return
@@ -547,8 +612,34 @@ actor TaskAssistant: ProactiveAssistant {
         fallbackTimerTask = nil
 
         // Yield context switch trigger with the frame
-        lastContextSwitchYieldTime = Date()
+        lastAnalyzedByKey[dedupeKey] = now
+        pruneStaleDedupeEntries(now: now, ttl: TimeInterval(max(analysisDelay, 60) * 5))
         triggerContinuation.yield(.contextSwitch(frame))
+    }
+
+    /// Normalize (app, window) into a stable dedupe key. Strips Telegram-style trailing
+    /// counters and collapses whitespace so the same chat across reopens hashes the same.
+    static func analyzedKey(for frame: CapturedFrame) -> String {
+        let app = frame.appName.lowercased()
+        let title = normalizedWindowTitle(frame.windowTitle)
+        return "\(app)::\(title)"
+    }
+
+    private static func normalizedWindowTitle(_ title: String?) -> String {
+        guard let raw = title, !raw.isEmpty else { return "" }
+        var t = raw.lowercased()
+        // Strip Telegram-style trailing message counters: " (247887)" / "(247887)".
+        if let range = t.range(of: #"\s*\(\d+\)\s*$"#, options: .regularExpression) {
+            t.removeSubrange(range)
+        }
+        // Collapse whitespace runs so " foo   bar " == "foo bar".
+        t = t.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        return t
+    }
+
+    private func pruneStaleDedupeEntries(now: Date, ttl: TimeInterval) {
+        let cutoff = now.addingTimeInterval(-ttl)
+        lastAnalyzedByKey = lastAnalyzedByKey.filter { $0.value >= cutoff }
     }
 
     func clearPendingWork() async {

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
@@ -121,11 +121,12 @@ class TaskAssistantSettings {
         1. Analyze the screenshot to understand the conversation context
         2. If clearly no conversation (code editor, terminal, settings, media, dashboards) → call no_task_found immediately
         3. If a conversation is visible → read the FULL conversation flow to understand context
-        4. Look for TWO patterns (in priority order):
+        4. IDENTIFY THE LATEST EXCHANGE (most recent incoming message + the user's most recent reply). Older messages are CONTEXT ONLY — they may already be tracked as tasks; do not let them block extraction of a new commitment from the latest exchange.
+        5. Look for TWO patterns in the LATEST exchange (in priority order):
            a. USER AGREED TO A TASK: Someone asked/suggested something AND the user agreed, accepted, or committed to doing it
            b. UNADDRESSED REQUEST: Someone asked the user to do something and the user hasn't responded yet
-        5. If potential task found → search for duplicates using search_similar and/or search_keywords
-        6. Based on results → call extract_task (new task) or reject_task (duplicate/completed/rejected)
+        6. If potential task found → search for duplicates of THAT specific commitment using search_similar and/or search_keywords
+        7. Based on results → call extract_task (new task) or reject_task (only if the LATEST commitment itself is a duplicate)
 
         AVAILABLE TOOLS:
         - search_similar(query): Find semantically similar existing tasks (vector similarity)
@@ -137,9 +138,11 @@ class TaskAssistantSettings {
         SEARCH RULES:
         - You MUST search at least once before calling extract_task
         - You may call search_similar and search_keywords with different queries
-        - Similarity > 0.8 + status "active" → duplicate → reject_task
+        - Build the search query from the LATEST commitment only (not a summary of the whole chat). If you search for "Q3 report" but the latest message is about a memories bug, your search is wrong.
+        - Similarity > 0.8 + status "active" → duplicate → reject_task ONLY if the matched task is about the same thing as the LATEST commitment. A duplicate match against an older message in the same chat does NOT block extracting a different new commitment.
         - Status "completed" → user already handled this, it attracted their attention and was relevant enough to complete → reject_task (but related follow-ups are okay)
         - Status "deleted" → user rejected → reject_task
+        - When a chat contains multiple historical asks (some already in your task list, one new), extract the NEW one. Never reject the whole frame because an older message in the same chat happens to be a duplicate.
 
         CORE QUESTION: "Has the user committed to doing something in this conversation, or is someone waiting for the user to act?"
 

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
@@ -87,11 +87,15 @@ actor TaskPromotionService {
                         let message = "New task: \(promotedTask.description)"
                         let context = Self.buildNotificationContext(from: promotedTask)
                         await MainActor.run {
+                            // Tasks bypass the ambient frequency throttle — they're explicit
+                            // commitments the user agreed to, not background chatter. A user on
+                            // Balanced (1/10min) still wants to see every real task land.
                             NotificationService.shared.sendNotification(
                                 title: "Task",
                                 message: message,
                                 assistantId: "task",
-                                context: context
+                                context: context,
+                                respectFrequency: false
                             )
                         }
                     }

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -76,6 +76,14 @@ public class ProactiveAssistantsPlugin: NSObject {
     private var lastDistributionTime: Date = .distantPast
     /// Fallback interval: re-distribute even without context change to catch visual-only updates.
     private let distributionFallbackInterval: TimeInterval = 60
+    private let messagingDistributionFallbackInterval: TimeInterval = 15
+
+    /// Apps where new content can arrive while the user stays focused. Reusing the same
+    /// list TaskAssistant uses for its fast in-app trigger so the two layers stay aligned.
+    private static let messagingFastPathApps: Set<String> = [
+        "Telegram", "Messages", "iMessage", "WhatsApp", "Signal",
+        "Slack", "Discord", "Messenger",
+    ]
 
     /// Apps whose primary purpose is video/audio calls.
     private static let videoCallApps: Set<String> = [
@@ -921,7 +929,12 @@ public class ProactiveAssistantsPlugin: NSObject {
         )
 
         let timeSinceLastDistribution = Date().timeIntervalSince(lastDistributionTime)
-        let fallbackDue = timeSinceLastDistribution >= distributionFallbackInterval
+        // Messaging apps get a much shorter same-context fallback so a new chat message
+        // reaches the analyzer in ~15s, even when you stay in the app the whole time.
+        let activeFallbackInterval = Self.messagingFastPathApps.contains(frame.appName)
+            ? messagingDistributionFallbackInterval
+            : distributionFallbackInterval
+        let fallbackDue = timeSinceLastDistribution >= activeFallbackInterval
 
         if contextChanged {
             // Update tracking immediately so subsequent captures in the same new context


### PR DESCRIPTION
## Summary
Five connected fixes so tasks promised in a chat surface as floating-bar notifications within seconds of you confirming, not minutes later.

1. **Per-window dedupe replaces the global 60s cooldown.** Ten different chats with ten different people opened in <60s now all flow through; only revisits to the same chat get skipped. Messaging windows get a 15s dedupe TTL (vs the 60s default elsewhere).
2. **Fast in-app trigger for messaging apps** (Telegram, Messages, iMessage, WhatsApp, Signal, Slack, Discord, Messenger). Frame arrives for a non-deduped messaging window → analysis fires immediately, no need to leave the app.
3. **Distribution fallback shortened to 15s for messaging apps** (was 60s for all). Frames reach the analyzer while you sit in the chat, not only when you switch away.
4. **Prompt fix.** The analyzer was rejecting the whole frame when any older message in a chat matched an existing task; now the duplicate-check only applies to the LATEST commitment, never the whole frame.
5. **Staged tasks fire promotion immediately.** The 5-minute `TaskPromotionService` safety timer was the dominant latency once extraction worked. Saving a staged task now kicks `promoteIfNeeded()` and the notification fires within seconds. Tasks also bypass the ambient frequency throttle (`respectFrequency: false`) since they're explicit commitments, not background chatter.

Net effect: send a Telegram message + "sure" reply → task + floating-bar notification in ~15-20s, even if you stay in the chat the whole time.

## Test plan
- [x] Compile clean
- [x] Live test: Telegram chat with multiple people; new tasks surface as floating-bar notifications
- [x] Live test: revisiting same chat doesn't fire duplicate analyses
- [x] Live test: notification fires immediately on staged-task promotion (no 5-min wait)
- [ ] Smoke: notification frequency slider continues to throttle non-task surfaces (insight, focus, memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)