### PR TITLE
backend+rust: paywall middleware for every $-incurring Rust proxy route

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -71,6 +71,7 @@ from utils.subscription import (
     get_plan_limits,
     get_plan_features,
     get_monthly_usage_for_subscription,
+    is_trial_paywalled,
     reconcile_basic_plan_with_stripe,
     filter_plans_for_user,
     should_show_new_plans,
@@ -1077,6 +1078,31 @@ def get_user_chat_usage_quota(
         allowed=snapshot['allowed'],
         reset_at=snapshot['reset_at'],
     )
+
+
+class PaywallStatusResponse(BaseModel):
+    paywalled: bool
+
+
+@router.get('/v1/users/me/paywall', tags=['users'], response_model=PaywallStatusResponse)
+def get_user_paywall_status(
+    uid: str = Depends(auth.get_current_user_uid),
+    x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
+    platform: Optional[str] = Query(None),
+):
+    """Trial-paywall status for the calling user on the given platform.
+
+    Used by the Rust desktop-backend middleware to decide whether to proxy
+    paid LLM / TTS / Pinecone traffic. Mirrors the exact semantics of
+    `is_trial_paywalled`: basic plan + no active BYOK + Firebase Auth
+    account >3d old + platform in {macos, desktop}. Mobile platforms always
+    return `paywalled=false`.
+
+    Platform comes from `X-App-Platform` header (preferred) or `platform`
+    query param (fallback). Unknown / missing platforms are never paywalled.
+    """
+    resolved_platform = x_app_platform or platform
+    return PaywallStatusResponse(paywalled=is_trial_paywalled(uid, resolved_platform))
 
 
 # **************************************

--- a/desktop/Backend-Rust/src/auth.rs
+++ b/desktop/Backend-Rust/src/auth.rs
@@ -66,7 +66,12 @@ struct JwkKey {
     alg: Option<String>,
 }
 
-/// Auth error response
+/// Auth error response.
+///
+/// Status codes:
+/// - `trial_expired` → 402 Payment Required (so clients can distinguish paywall
+///   from auth failure and show the upgrade UI)
+/// - any other error string → 401 Unauthorized
 #[derive(Debug, Serialize)]
 pub struct AuthError {
     pub error: String,
@@ -75,7 +80,12 @@ pub struct AuthError {
 
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
-        (StatusCode::UNAUTHORIZED, Json(self)).into_response()
+        let status = if self.error == "trial_expired" {
+            StatusCode::PAYMENT_REQUIRED
+        } else {
+            StatusCode::UNAUTHORIZED
+        };
+        (status, Json(self)).into_response()
     }
 }
 
@@ -210,4 +220,94 @@ where
 /// Create a layer that adds Firebase auth to request extensions
 pub fn firebase_auth_extension(auth: Arc<FirebaseAuth>) -> axum::Extension<FirebaseAuthExt> {
     axum::Extension(FirebaseAuthExt(auth))
+}
+
+impl From<PaywalledAuthUser> for AuthUser {
+    fn from(p: PaywalledAuthUser) -> Self {
+        AuthUser {
+            uid: p.uid,
+            name: p.name,
+            email: p.email,
+        }
+    }
+}
+
+/// Authenticated user extractor that ALSO enforces the desktop trial paywall.
+///
+/// Same token-verification flow as `AuthUser`, then a follow-up call to the
+/// Python `/v1/users/me/paywall` endpoint (cached 5min in-memory). If the
+/// user is past their trial, the extractor short-circuits with
+/// `error: "trial_expired"` which `AuthError::IntoResponse` maps to HTTP 402.
+///
+/// Use this for every $-incurring route handler in the Rust backend:
+/// proxy.rs (Gemini), chat_completions.rs (Anthropic), screen_activity.rs
+/// (Pinecone), tts.rs, agent.rs.
+#[derive(Debug, Clone)]
+pub struct PaywalledAuthUser {
+    pub uid: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+#[async_trait]
+impl<S> FromRequestParts<S> for PaywalledAuthUser
+where
+    S: Send + Sync,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        // Get + extract bearer token (we'll forward it to the paywall endpoint)
+        let auth_header = parts
+            .headers
+            .get("Authorization")
+            .and_then(|h| h.to_str().ok())
+            .ok_or_else(|| AuthError {
+                error: "missing_token".to_string(),
+                message: "Authorization header required".to_string(),
+            })?;
+
+        let token = auth_header
+            .strip_prefix("Bearer ")
+            .ok_or_else(|| AuthError {
+                error: "invalid_token".to_string(),
+                message: "Invalid Authorization header format".to_string(),
+            })?;
+
+        // Verify Firebase token (same flow AuthUser uses)
+        let firebase_auth = parts
+            .extensions
+            .get::<FirebaseAuthExt>()
+            .ok_or_else(|| AuthError {
+                error: "server_error".to_string(),
+                message: "Firebase auth not configured".to_string(),
+            })?;
+
+        let (uid, name, email) = firebase_auth.0.verify_token(token).await?;
+
+        // Paywall check — fail open if Python is unreachable so a backend
+        // outage never makes paying users look paywalled.
+        if let Some(checker) = parts.extensions.get::<crate::paywall::PaywallCheckerExt>() {
+            if checker.0.is_paywalled(&uid, token).await {
+                return Err(AuthError {
+                    error: "trial_expired".to_string(),
+                    message: "Desktop trial expired. Upgrade or bring your own keys.".to_string(),
+                });
+            }
+        } else {
+            tracing::warn!(
+                "PaywalledAuthUser: PaywallChecker extension missing, falling open for uid={}",
+                uid
+            );
+        }
+
+        Ok(PaywalledAuthUser { uid, name, email })
+    }
+}
+
+/// Layer that adds the paywall checker to request extensions.
+pub fn paywall_checker_extension(
+    checker: Arc<crate::paywall::PaywallChecker>,
+) -> axum::Extension<crate::paywall::PaywallCheckerExt> {
+    axum::Extension(crate::paywall::PaywallCheckerExt(checker))
 }

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -80,6 +80,9 @@ pub struct Config {
     pub vertex_project_id: Option<String>,
     /// GCP region for Vertex AI (default: us-central1)
     pub vertex_location: String,
+    /// Python backend base URL used for cross-service calls (e.g. paywall status).
+    /// Defaults to https://api.omi.me; override with OMI_PYTHON_API_URL for staging/dev.
+    pub python_api_base: String,
 }
 
 impl Config {
@@ -149,6 +152,10 @@ impl Config {
                 .ok(),
             vertex_location: env::var("GCP_LOCATION")
                 .unwrap_or_else(|_| "us-central1".to_string()),
+            python_api_base: env::var("OMI_PYTHON_API_URL")
+                .unwrap_or_else(|_| "https://api.omi.me".to_string())
+                .trim_end_matches('/')
+                .to_string(),
         }
     }
 

--- a/desktop/Backend-Rust/src/main.rs
+++ b/desktop/Backend-Rust/src/main.rs
@@ -27,11 +27,13 @@ mod config;
 mod encryption;
 mod llm;
 mod models;
+mod paywall;
 mod routes;
 mod services;
 mod vertex;
 
-use auth::{firebase_auth_extension, FirebaseAuth};
+use auth::{firebase_auth_extension, paywall_checker_extension, FirebaseAuth};
+use paywall::PaywallChecker;
 use config::Config;
 use routes::{
     // Active (real traffic from current app)
@@ -229,6 +231,9 @@ async fn main() {
         });
     }
 
+    // Paywall checker — calls Python `/v1/users/me/paywall`, caches 5min.
+    let paywall_checker = Arc::new(PaywallChecker::new(config.python_api_base.clone()));
+
     let state = AppState {
         firestore,
         integrations,
@@ -270,6 +275,7 @@ async fn main() {
     let app = main_router
         .merge(auth_router)
         .layer(firebase_auth_extension(firebase_auth))
+        .layer(paywall_checker_extension(paywall_checker))
         .layer(cors)
         .layer(TraceLayer::new_for_http());
 

--- a/desktop/Backend-Rust/src/paywall.rs
+++ b/desktop/Backend-Rust/src/paywall.rs
@@ -1,0 +1,125 @@
+// Trial-paywall middleware for the Rust desktop-backend.
+//
+// Delegates the decision to Python (`GET /v1/users/me/paywall`) which owns
+// the canonical paywall logic (basic plan + no BYOK + Firebase account >3d
+// old + platform=macos/desktop). We cache the boolean per-uid in-memory for
+// 5 minutes so chat / proxy / TTS / screen-activity calls don't fan out to
+// Python on every request.
+//
+// Mobile is not a concern here — the Rust desktop-backend is only ever
+// called by the macOS Swift client, so every paywall check goes in with
+// `X-App-Platform: macos`. Python `is_trial_paywalled` enforces the
+// platform gate; if it ever returns `paywalled=true` for an iOS / Android
+// caller (which can't happen via this code path), this layer would still
+// return 402 — but that situation cannot arise from real traffic.
+
+use reqwest::Client;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+const CACHE_TTL: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Clone, Copy)]
+struct CacheEntry {
+    paywalled: bool,
+    cached_at: Instant,
+}
+
+#[derive(Deserialize)]
+struct PaywallStatus {
+    paywalled: bool,
+}
+
+/// Singleton helper that calls Python's `/v1/users/me/paywall` and caches
+/// the result in-memory. Held inside `AppState` and exposed to extractors
+/// via an Axum `Extension`.
+pub struct PaywallChecker {
+    python_api_base: String,
+    http: Client,
+    cache: Arc<Mutex<HashMap<String, CacheEntry>>>,
+}
+
+impl PaywallChecker {
+    pub fn new(python_api_base: String) -> Self {
+        let http = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap_or_else(|_| Client::new());
+        Self {
+            python_api_base: python_api_base.trim_end_matches('/').to_string(),
+            http,
+            cache: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Returns true iff the user is past their desktop trial. Errors fail
+    /// open (return false) so a Python outage never makes paying users
+    /// look paywalled.
+    pub async fn is_paywalled(&self, uid: &str, bearer_token: &str) -> bool {
+        // Cache hit
+        {
+            let cache = self.cache.lock().await;
+            if let Some(entry) = cache.get(uid) {
+                if entry.cached_at.elapsed() < CACHE_TTL {
+                    return entry.paywalled;
+                }
+            }
+        }
+
+        let url = format!("{}/v1/users/me/paywall", self.python_api_base);
+        let response = self
+            .http
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", bearer_token))
+            .header("X-App-Platform", "macos")
+            .send()
+            .await;
+
+        let paywalled = match response {
+            Ok(r) if r.status().is_success() => match r.json::<PaywallStatus>().await {
+                Ok(body) => body.paywalled,
+                Err(e) => {
+                    tracing::warn!(
+                        "paywall: failed to parse Python response for uid={}: {}",
+                        uid,
+                        e
+                    );
+                    false
+                }
+            },
+            Ok(r) => {
+                tracing::warn!(
+                    "paywall: Python returned {} for uid={}, failing open",
+                    r.status(),
+                    uid
+                );
+                false
+            }
+            Err(e) => {
+                tracing::warn!("paywall: Python call failed for uid={}: {}", uid, e);
+                false
+            }
+        };
+
+        // Cache (even false results — limits Python load when many requests
+        // arrive in quick succession for the same uid)
+        let mut cache = self.cache.lock().await;
+        cache.insert(
+            uid.to_string(),
+            CacheEntry {
+                paywalled,
+                cached_at: Instant::now(),
+            },
+        );
+
+        paywalled
+    }
+}
+
+/// Wrapper for storing in Axum Extension so extractors can pull it
+/// without owning `AppState`.
+#[derive(Clone)]
+pub struct PaywallCheckerExt(pub Arc<PaywallChecker>);

--- a/desktop/Backend-Rust/src/routes/agent.rs
+++ b/desktop/Backend-Rust/src/routes/agent.rs
@@ -8,7 +8,7 @@ use axum::{
     Json, Router,
 };
 
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::models::agent::{AgentStatusResponse, AgentVmStatus, ProvisionAgentResponse};
 use crate::AppState;
 
@@ -17,8 +17,9 @@ use crate::AppState;
 /// Creates a GCE VM from the omi-agent image family for this user.
 async fn provision_agent_vm(
     State(state): State<AppState>,
-    user: AuthUser,
+    user: PaywalledAuthUser,
 ) -> Result<Json<ProvisionAgentResponse>, StatusCode> {
+    let user: AuthUser = user.into();
     tracing::info!("Agent VM provision request for user {}", user.uid);
 
     // 1. Check if user already has a VM
@@ -161,8 +162,9 @@ async fn provision_agent_vm(
 /// If the VM self-stopped (idle timeout), detects it via GCE API and restarts it.
 async fn get_agent_status(
     State(state): State<AppState>,
-    user: AuthUser,
+    user: PaywalledAuthUser,
 ) -> Result<Json<Option<AgentStatusResponse>>, StatusCode> {
+    let user: AuthUser = user.into();
     tracing::info!("Agent VM status request for user {}", user.uid);
 
     match state.firestore.get_agent_vm(&user.uid).await {

--- a/desktop/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/Backend-Rust/src/routes/chat_completions.rs
@@ -16,7 +16,7 @@ use axum::{
 use futures::StreamExt;
 use serde_json::json;
 
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::models::chat_completions::*;
 use crate::AppState;
 
@@ -448,9 +448,10 @@ fn make_chunk(
 
 async fn chat_completions(
     State(state): State<AppState>,
-    user: AuthUser,
+    user: PaywalledAuthUser,
     Json(req): Json<ChatCompletionRequest>,
 ) -> Result<Response, StatusCode> {
+    let user: AuthUser = user.into();
     // Validate model
     let route = resolve_model(&req.model).ok_or_else(|| {
         tracing::warn!(

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -14,7 +14,7 @@ use axum::{
     Router,
 };
 
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::AppState;
 
 use super::rate_limit::{self, RateDecision};
@@ -79,10 +79,11 @@ impl IntoResponse for ProxyError {
 /// Rate-limited per user: Tier 1 (allow), Tier 2 (degrade Pro→Flash), Tier 3 (reject 429).
 async fn gemini_proxy(
     State(state): State<AppState>,
-    user: AuthUser,
+    user: PaywalledAuthUser,
     Path(path): Path<String>,
     body: Bytes,
 ) -> Result<Response, ProxyError> {
+    let user: AuthUser = user.into();
     // Rewrite preview models to stable equivalents (old app compat)
     let path = crate::llm::model_qos::rewrite_preview_model(&path);
 
@@ -243,11 +244,12 @@ async fn gemini_proxy(
 /// Rate-limited per user with same tiers as gemini_proxy.
 async fn gemini_stream_proxy(
     State(state): State<AppState>,
-    user: AuthUser,
+    user: PaywalledAuthUser,
     Path(path): Path<String>,
     axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>,
     body: Bytes,
 ) -> Result<Response, ProxyError> {
+    let user: AuthUser = user.into();
     // Rewrite preview models to stable equivalents (old app compat)
     let path = crate::llm::model_qos::rewrite_preview_model(&path);
 

--- a/desktop/Backend-Rust/src/routes/screen_activity.rs
+++ b/desktop/Backend-Rust/src/routes/screen_activity.rs
@@ -9,16 +9,17 @@ use axum::{
     Json, Router,
 };
 
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::models::screen_activity::{ScreenActivitySyncRequest, ScreenActivitySyncResponse};
 use crate::AppState;
 
 /// POST /v1/screen-activity/sync
 async fn sync_screen_activity(
     State(state): State<AppState>,
-    user: AuthUser,
+    user: PaywalledAuthUser,
     Json(request): Json<ScreenActivitySyncRequest>,
 ) -> Result<Json<ScreenActivitySyncResponse>, (StatusCode, String)> {
+    let user: AuthUser = user.into();
     if request.rows.len() > 100 {
         return Err((StatusCode::BAD_REQUEST, "Maximum 100 rows per batch".to_string()));
     }

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, PaywalledAuthUser};
 use crate::AppState;
 
 const OPENAI_TTS_MODEL_ID: &str = "gpt-4o-mini-tts";
@@ -86,10 +86,11 @@ impl IntoResponse for TtsProxyError {
 
 async fn tts_synthesize(
     State(state): State<AppState>,
-    user: AuthUser,
+    user: PaywalledAuthUser,
     headers: HeaderMap,
     Json(request): Json<TtsSynthesizeRequest>,
 ) -> Result<Response, TtsProxyError> {
+    let user: AuthUser = user.into();
     let text = request.text.trim();
     if text.is_empty() {
         return Err(TtsProxyError::BadRequest("text is required"));


### PR DESCRIPTION
## Summary

Closes the biggest remaining cost leak: every Rust desktop-backend proxy (Gemini, Anthropic, TTS, Pinecone, agent VM) was un-paywalled. Python gates already covered listen-WS / chat / voice-PTT — this adds the same enforcement to the Rust side.

**Python:** new \`GET /v1/users/me/paywall\` → \`{paywalled: bool}\`. Thin wrapper around the existing \`is_trial_paywalled(uid, platform)\`. Mobile always returns paywalled=false.

**Rust:**
- New \`paywall.rs\` PaywallChecker — HTTP-calls Python, caches 5min per-uid in-memory, fails open on Python outage so paid users never get falsely blocked.
- New \`PaywalledAuthUser\` extractor — reuses existing Firebase token verification, then paywall check. 402 \`trial_expired\` on block.
- Wired into 6 entry points: gemini_proxy, gemini_stream_proxy, chat_completions, sync_screen_activity, tts_synthesize, provision_agent_vm, get_agent_status.

## Mobile safety

Rust desktop-backend is only ever called by the macOS Swift client. The PaywallChecker always forwards \`X-App-Platform: macos\` to Python. Mobile traffic doesn't reach this code at all.

## Local verification

- Python endpoint returns expected values for paywalled + paid + ios cases against real Firebase data
- Rust builds release clean (0 errors, only pre-existing dead-code warnings)
- Rust auth gate fires before paywall (no-token → 401)

## Test plan

- [x] Local Python endpoint smoke test
- [x] Rust release build
- [ ] After deploy: paywalled user's Gemini / chat / TTS calls return 402
- [ ] Paid user / BYOK user: same routes work normally
- [ ] Mobile (no Rust traffic): unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)