### PR TITLE
Update CHANGELOG.json for v0.11.399 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Smarter task analyzer dedupe \u2014 per-chat/window throttle instead of one global 60s cooldown, so opening multiple chats in quick succession no longer drops tasks"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.399",
+      "date": "2026-05-14",
+      "changes": [
+        "Smarter task analyzer dedupe \u2014 per-chat/window throttle instead of one global 60s cooldown, so opening multiple chats in quick succession no longer drops tasks"
+      ]
+    },
     {
       "version": "0.11.397",
       "date": "2026-05-14",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.399 and clears the unreleased array.