### PR TITLE
Update CHANGELOG.json for v0.11.400 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Added file/screenshot attachments to chat (paperclip + drag-drop)"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.400",
+      "date": "2026-05-14",
+      "changes": [
+        "Added file/screenshot attachments to chat (paperclip + drag-drop)"
+      ]
+    },
     {
       "version": "0.11.398",
       "date": "2026-05-14",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.400 and clears the unreleased array.