### PR TITLE
desktop: make 'Execute' button actually run the task end-to-end

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -297,7 +297,8 @@ final class AgentPillsManager: ObservableObject {
         model: String,
         fromVoice: Bool = false,
         preFetchedTitle: String? = nil,
-        preFetchedAck: String? = nil
+        preFetchedAck: String? = nil,
+        systemPromptSuffix: String? = nil
     ) -> AgentPill {
         let pill = AgentPill(query: query, model: model)
         if let preFetchedTitle, !preFetchedTitle.isEmpty {
@@ -381,6 +382,7 @@ final class AgentPillsManager: ObservableObject {
             await provider.sendMessage(
                 pill.query,
                 model: pill.model,
+                systemPromptSuffix: systemPromptSuffix,
                 systemPromptPrefix: ChatProvider.floatingBarSystemPromptPrefix,
                 sessionKey: "agent-\(pill.id.uuidString)"
             )

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -222,8 +222,15 @@ struct FloatingControlBarView: View {
                         let model = ShortcutSettings.shared.selectedModel.isEmpty
                             ? "claude-sonnet-4-6"
                             : ShortcutSettings.shared.selectedModel
-                        let query = "Handle this notification: \(notification.title). \(notification.message)"
-                        AgentPillsManager.shared.spawn(query: query, model: model)
+                        let query = ProactiveTaskExecute.buildQuery(
+                            title: notification.title,
+                            message: notification.message
+                        )
+                        _ = AgentPillsManager.shared.spawn(
+                            query: query,
+                            model: model,
+                            systemPromptSuffix: ProactiveTaskExecute.systemPromptSuffix
+                        )
                         FloatingControlBarManager.shared.dismissCurrentNotification()
                     } label: {
                         HStack(spacing: 4) {

--- a/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ProactiveTaskExecute.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Prompt fragments for the "Execute" button on a proactive task notification.
+///
+/// The floating-bar agent normally lives under `floatingBarSystemPromptPrefix`,
+/// which tells it to answer in 1–2 sentences and never ask follow-ups. That's
+/// the opposite of what we want when the user explicitly clicks **Execute** —
+/// the user wants the task *done*, not described.
+///
+/// `systemPromptSuffix` is appended after the main system prompt so it takes
+/// precedence over the floating-bar concise-answer rules, and `buildQuery`
+/// rewrites the prompt as an imperative.
+enum ProactiveTaskExecute {
+
+    /// Imperative restatement of the task. Tells the agent the user already
+    /// chose to act — so finish the work end-to-end (which may legitimately
+    /// include summarizing, drafting, or describing if that *is* the task).
+    static func buildQuery(title: String, message: String) -> String {
+        """
+        Execute this task end-to-end now.
+
+        Task: \(title)
+        Details: \(message)
+        """
+    }
+
+    /// Appended to the system prompt for execute-mode pills only. Overrides
+    /// the floating-bar "1-2 sentence concise answer" stance for this pill —
+    /// the user already chose to act, so finish the work with tools rather
+    /// than asking. Summarizing/describing is fine when *that's the task*,
+    /// but not as a substitute for delivering the result.
+    static let systemPromptSuffix = """
+================================================================================
+🛠 EXECUTE MODE — OVERRIDES the floating-bar "concise answer" rules above
+================================================================================
+The user clicked "Execute" on a proactive task notification — they want the
+task carried out end-to-end. Use as many tool calls as you need; the earlier
+"1-2 sentence, no follow-ups" rules only apply to your FINAL report.
+
+Don't ask the user for clarification. Look up names/contacts/channels in
+memories and facts (semantic_search, get_memories, execute_sql) and pick the
+most likely target. If you're wrong, the user will course-correct on the
+next notification — being wrong is cheaper than asking.
+
+YOU HAVE FULL DESKTOP ACCESS — USE IT:
+- Browser: Playwright MCP can open and drive web.telegram.org, slack.com,
+  mail.google.com, x.com, calendar.google.com, etc. Sign-in cookies persist
+  between calls.
+- Native macOS apps: shell + osascript can drive Telegram.app, Messages, Mail,
+  Notes, Reminders, Calendar, Slack desktop, Finder, etc. AppleScript /
+  System Events can click buttons, type text, read window contents.
+- Filesystem: read/write any file the user can. Drop drafts to
+  ~/Desktop or ~/Documents if you need a working file.
+- Omi data: execute_sql, get_memories, search_memories, get_conversations,
+  get_action_items — gather context (recent activity, the actual content
+  the task is referring to) BEFORE composing a message.
+- Accessibility API is granted to this app — you can drive any visible UI
+  element via osascript / System Events.
+
+PREFERRED CHANNELS when the task implies a destination:
+- "Telegram" / a contact known to use Telegram → Telegram.app via osascript,
+  or web.telegram.org via Playwright. Telegram.app is faster when running.
+- "Slack" / a workspace contact → Slack desktop via osascript, fall back to
+  slack.com via Playwright.
+- "Email" / unknown channel → Gmail via Playwright (mail.google.com).
+- "Text" / iPhone contact → Messages.app via osascript.
+
+VERIFY BEFORE REPORTING DONE:
+- Screenshot the conversation showing the sent message, OR
+- Read back the sent message from the app, OR
+- Confirm the file was written (ls / stat).
+Never claim "done" without proof.
+
+FINAL REPORT FORMAT: ONE short sentence — what you did + where. Examples:
+"Sent the summary to Daniel on Telegram." / "Drafted the email in Gmail
+(saved to drafts)." / "Created the file at ~/Desktop/q4-summary.md."
+No headers, no lists.
+================================================================================
+"""
+}


### PR DESCRIPTION
## Summary
Clicking **Execute** on a proactive task notification now tells the agent to *do* the task with its full desktop toolset, instead of summarizing what it would do.

## Why
Previously the button sent ``"Handle this notification: <title>. <message>"`` to a generic agent pill under the floating-bar system prompt — which itself demands "answer in 1-2 sentences, never ask follow-ups." Result: the agent treats every task as a Q&A and answers in prose, even when the task literally says "send X to Y on Telegram."

## What changed
- **New `ProactiveTaskExecute`** (Sources/FloatingControlBar/ProactiveTaskExecute.swift): imperative query + execute-mode system-prompt suffix. The suffix lists the desktop tools the agent has — Playwright (browser → Telegram web / Slack / Gmail), osascript (Telegram.app, Messages, Mail, Notes), shell, filesystem, accessibility, omi-tools — and tells it to verify success before reporting done.
- **`AgentPillsManager.spawn`** now accepts an optional `systemPromptSuffix` passed through to `sendMessage`, so this code path can override the floating-bar concise-answer stance without affecting voice queries.
- **`FloatingControlBarView`** Execute button calls the new helper.

## Test plan
- [ ] Trigger a proactive task notification with "send/email/post" wording → click Execute → agent should open the relevant app/site, type, send, and report one short success line.
- [ ] Pure-summarize task → still works (the suffix doesn't ban summarizing, it bans summarizing *instead of* delivering).
- [ ] Voice queries / non-task notifications unchanged (`spawn` callers without `systemPromptSuffix` behave as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)