### PR TITLE
Update CHANGELOG.json for v0.11.402 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Task analyzer now extracts every distinct commitment in a frame instead of stopping after the first \u2014 a chat asking for two unrelated deliverables in one message creates two tasks"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.402",
+      "date": "2026-05-15",
+      "changes": [
+        "Task analyzer now extracts every distinct commitment in a frame instead of stopping after the first \u2014 a chat asking for two unrelated deliverables in one message creates two tasks"
+      ]
+    },
     {
       "version": "0.11.401",
       "date": "2026-05-14",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.402 and clears the unreleased array.