### PR TITLE
fix(desktop/tasks): + button works on empty list

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Task analyzer now extracts every distinct commitment in a frame instead of stopping after the first \u2014 a chat asking for two unrelated deliverables in one message creates two tasks"
+    "Task analyzer now extracts every distinct commitment in a frame instead of stopping after the first \u2014 a chat asking for two unrelated deliverables in one message creates two tasks",
+    "Fixed Tasks page \"+\" button doing nothing when the task list was empty"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2367,9 +2367,13 @@ struct TasksPage: View {
                 loadingView
             } else if let error = viewModel.error, viewModel.tasks.isEmpty {
                 errorView(error)
-            } else if viewModel.displayTasks.isEmpty {
+            } else if viewModel.displayTasks.isEmpty && !viewModel.isInlineCreating {
                 emptyView
             } else {
+                // Render the list view (which hosts the InlineTaskCreationRow) whenever
+                // the user is inline-creating, even if the underlying task list is empty.
+                // Without this guard, clicking "+" on an empty list flips isInlineCreating
+                // but the empty view ignores it, so the input field never appears.
                 tasksListView
             }
         }


### PR DESCRIPTION
## Summary
Clicking the "+" button (or Cmd+N) on the Tasks page did nothing when the task list was empty.

`tasksContent` switched to `emptyView` whenever `displayTasks.isEmpty`, regardless of `isInlineCreating`. The empty view doesn't render the `InlineTaskCreationRow`, so flipping the flag had no visible effect — the click looked like a no-op and users couldn't create their first task from a fresh Tasks page.

Fix: render `tasksListView` (which hosts the inline-create row) whenever we're inline-creating, even if the list is empty.

## Test plan
- [x] Compile clean
- [ ] Open Tasks page with zero tasks → click "+" → input field appears, type + Enter → task created
- [ ] Cmd+N from empty list → same
- [ ] Empty + filter on → no regression (filter messaging still works once user cancels create)
- [ ] Non-empty list → no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)