### PR TITLE
fix(desktop/tasks): promote on start, not 5min later

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Fixed Tasks page \"+\" button doing nothing when the task list was empty"
+    "Fixed Tasks page \"+\" button doing nothing when the task list was empty",
+    "Task notifications fire within seconds instead of waiting up to 5 minutes \u2014 promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
@@ -14,10 +14,18 @@ actor TaskPromotionService {
 
     // MARK: - Lifecycle
 
-    /// Start the 5-minute safety-net timer
+    /// Promote any pending staged tasks immediately on service start, then keep a
+    /// short safety-net ticking to catch anything that slips through event-driven paths.
     func start() {
         startSafetyTimer()
         log("TaskPromotion: Service started")
+        // Fire an immediate promote so a staged task that was inserted while the service
+        // was stopped (e.g. across an app restart, or via manual backend insert during a
+        // demo) gets a notification within seconds instead of waiting for the first
+        // safety-timer tick.
+        Task { [weak self] in
+            await self?.promoteIfNeeded()
+        }
     }
 
     func stop() {
@@ -30,7 +38,7 @@ actor TaskPromotionService {
         safetyTimer?.cancel()
         safetyTimer = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)  // 5 minutes
+                try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)  // 60 seconds
                 guard !Task.isCancelled else { break }
                 guard let self = self else { break }
                 log("TaskPromotion: Safety-net timer fired")


### PR DESCRIPTION
## Summary
\`TaskPromotionService\` sat idle for 5 min after launch waiting for its first safety-timer tick. A staged task waiting in backend (from a previous session, manually inserted, or anything the event-driven paths missed) wouldn't surface until that first tick — which is brutal on app restarts and during demos.

- \`start()\` now calls \`promoteIfNeeded()\` immediately, so any pending staged task fires a notification within seconds of monitoring coming up.
- Safety-net cadence dropped 5 min → 60 s as a tighter backstop for anything that slips past the event-driven trigger paths (task complete/delete, my recent immediate-on-save patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)