### PR TITLE
Update CHANGELOG.json for v0.11.404 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Task notifications fire within seconds instead of waiting up to 5 minutes \u2014 promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.404",
+      "date": "2026-05-15",
+      "changes": [
+        "Task notifications fire within seconds instead of waiting up to 5 minutes \u2014 promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min"
+      ]
+    },
     {
       "version": "0.11.403",
       "date": "2026-05-15",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.404 and clears the unreleased array.