### PR TITLE
fix(desktop/rewind): show screenshots within ~5s of launch

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Task notifications fire within seconds instead of waiting up to 5 minutes \u2014 promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min"
+    "Task notifications fire within seconds instead of waiting up to 5 minutes \u2014 promote runs immediately on monitoring start and the safety-net cadence dropped from 5 min to 1 min",
+    "Rewind shows screenshots within ~5 seconds of launch instead of waiting up to a minute for the first video chunk to fill up"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift
@@ -15,6 +15,11 @@ actor VideoChunkEncoder {
     // MARK: - Configuration
 
     private let chunkDuration: TimeInterval = 60.0 // 60-second chunks
+    /// First chunk after launch finalizes faster so Rewind shows screenshots within
+    /// seconds of monitoring starting, instead of waiting up to 60s + 10s stale grace.
+    /// The Rewind UI filters out the active (unfinalized) chunk, so without this you'd
+    /// see nothing on the Rewind page for ~1-2 minutes after every launch.
+    private let firstChunkDuration: TimeInterval = 5.0
     private var frameRate: Double {
         let interval = UserDefaults.standard.object(forKey: "rewindCaptureInterval") as? Double ?? 1.0
         return 1.0 / interval // e.g. 0.5s interval = 2 FPS
@@ -66,6 +71,11 @@ actor VideoChunkEncoder {
 
     private var videosDirectory: URL?
     private var isInitialized = false
+
+    /// True after the first chunk finalizes. Until then we use `firstChunkDuration`
+    /// instead of `chunkDuration` so Rewind UI starts showing frames within seconds
+    /// of launch.
+    private var hasFinalizedAnyChunk = false
 
     // MARK: - Types
 
@@ -198,12 +208,16 @@ actor VideoChunkEncoder {
             throw error
         }
 
-        // Check if chunk duration exceeded
+        // Check if chunk duration exceeded.
+        // First chunk uses the shorter `firstChunkDuration` so Rewind starts showing
+        // frames within ~5s of launch instead of waiting out the full 60s window.
+        let effectiveDuration = hasFinalizedAnyChunk ? chunkDuration : firstChunkDuration
         if let startTime = currentChunkStartTime,
-           timestamp.timeIntervalSince(startTime) >= chunkDuration
+           timestamp.timeIntervalSince(startTime) >= effectiveDuration
         {
             // Finalize current chunk
             try await finalizeCurrentChunk()
+            hasFinalizedAnyChunk = true
             return frameInfo
         }
 


### PR DESCRIPTION
## Summary
The Rewind UI filters out frames in the currently-encoding (unfinalized) video chunk. With \`chunkDuration = 60s\` and a 70s stale grace, the Rewind page was blank for over a minute every launch — even though screenshots were being captured to SQLite the whole time.

First chunk after launch now finalizes at **5s** instead of 60s. Once \`hasFinalizedAnyChunk\` flips, every subsequent chunk uses the regular 60s duration so we don't fragment storage into thousands of tiny mp4 files.

User-visible effect: open the Rewind page, see fresh screenshots within ~5–8s of monitoring starting, every launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)