### PR TITLE
fix(desktop): stop WS reconnect loop on 1008 policy-violation close

### DIFF
--- a/desktop/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/Desktop/Sources/TranscriptionService.swift
@@ -513,6 +513,12 @@ class TranscriptionService {
 
             case .failure(let error):
                 guard self.isConnected else { return }
+                // 1008 policy violation = server-side hard reject (e.g. trial_expired).
+                // Don't reconnect — the server will keep closing immediately and we'd loop.
+                if self.webSocketTask?.closeCode == .policyViolation {
+                    log("TranscriptionService: Server closed with policy violation (1008) — disabling reconnect")
+                    self.shouldReconnect = false
+                }
                 logError("TranscriptionService: Receive error", error: error)
                 self.handleDisconnection()
             }


### PR DESCRIPTION
## Root Cause

Three commits shipped in sequence that created an infinite WebSocket reconnect loop for paywalled desktop users:

- **`b0c72d3ca` (May 10)** — Backend starts sending `freemium_threshold_reached` at WS connect time (not just from the 60s periodic loop).
- **`3984d42e9` (May 14, 16:27)** — Backend closes the WS with code **1008 `trial_expired`** for paywalled desktop users, 0.5s after sending the freemium event.
- **`c3c39e850` (May 14, 16:33)** — Desktop adds `isPaywalled` + `blockIfPaywalled()` in `startTranscription()` + calls `stopTranscription()` on the freemium
event (the intended client-side fix).

The backend 1008-close was deployed globally. Desktop users on older app versions (before `c3c39e850`) — which don't call `stopTranscription()` on the freemium
event — hit this loop:

1. Client connects → server sends `freemium_threshold_reached` → client shows popup but **`shouldReconnect` stays `true`**
2. Server closes with 1008 → `receiveMessage` failure → `handleDisconnection()` → **reconnects in 2s**
3. Repeat forever

### Why exponential backoff didn't protect against it

`reconnectAttempts = 0`. Backoff is stuck permanently at `2^1 = 2s` and `maxReconnectAttempts = 10` never accumulates — **~1 new WS connection every 3–4s per paywalled user, indefinitely**.

### Why `c3c39e850` alone isn't sufficient

Even on updated clients there's a race: the freemium event dispatches to Main via `Task { @MainActor in }`. If the Main thread is busy, the 1008 close can arrive and
`handleDisconnection()` can run before `stopTranscription()` sets `shouldReconnect = false`, causing at least one spurious reconnect per session.

## Fix

Check `webSocketTask?.closeCode == .policyViolation` (1008) in the `receiveMessage` failure handler and set `shouldReconnect = false` synchronously before calling
`handleDisconnection()`. No Main-thread dispatch, no timing dependency — works on every client version.

```swift
if self.webSocketTask?.closeCode == .policyViolation {
  log("TranscriptionService: Server closed with policy violation (1008) — disabling reconnect")
  self.shouldReconnect = false
}