### PR TITLE
fix(backend) google tasks auto-sync blocked by vector upsert ordering

### DIFF
--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -611,6 +611,14 @@ def _save_action_items(uid: str, conversation: Conversation):
                     due_at=action_item.due_at.isoformat(),
                 )
 
+        # Auto-sync to task integration — submit before vector ops so it always runs
+        created_items = [{"id": aid, **data} for aid, data in zip(action_item_ids, action_items_data)]
+
+        def _run_auto_sync():
+            asyncio.run(auto_sync_action_items_batch(uid, created_items))
+
+        submit_with_context(critical_executor, _run_auto_sync)
+
         upsert_action_item_vectors_batch(
             uid,
             [
@@ -618,14 +626,6 @@ def _save_action_items(uid: str, conversation: Conversation):
                 for aid, data in zip(action_item_ids, action_items_data)
             ],
         )
-
-        # Auto-sync to task integration
-        created_items = [{"id": aid, **data} for aid, data in zip(action_item_ids, action_items_data)]
-
-        def _run_auto_sync():
-            asyncio.run(auto_sync_action_items_batch(uid, created_items))
-
-        submit_with_context(critical_executor, _run_auto_sync)
 
 
 def save_structured_vector(uid: str, conversation: Conversation, update_only: bool = False):


### PR DESCRIPTION
## Summary

- Move `_run_auto_sync` submit ahead of `upsert_action_item_vectors_batch` in `_save_action_items`
- Previously if the OpenAI embeddings call or Pinecone upsert inside `upsert_action_item_vectors_batch` raised (rate limit, transient error), the executor submit for `_run_auto_sync` was never reached — automatically created action items silently skipped Google Tasks sync
- Manually created items appeared to work because the single-item `embed_query` path is far less likely to fail under load than the batch `embed_documents` used for conversations

## Test plan

- [ ] Have a conversation → confirm action items are auto-synced to Google Tasks
- [ ] Repeat with 2+ action items extracted from one conversation
- [ ] Manually create an action item → still syncs as before

Closes #7272

🤖 Generated with [Claude Code](https://claude.com/claude-code)