### PR TITLE
fix(desktop/tasks): unblock release builds — fix TaskTestRunnerWindow call

### DIFF
--- a/desktop/Desktop/Sources/ProactiveAssistants/UI/TaskTestRunnerWindow.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/UI/TaskTestRunnerWindow.swift
@@ -529,8 +529,12 @@ struct TaskTestRunnerView: View {
 
                     // Run extraction pipeline
                     let analyzeStart = Date()
-                    let (result, searchCount) = try await taskAssistant.testAnalyze(jpegData: jpegData, appName: screenshot.appName)
+                    let (allResults, searchCount) = try await taskAssistant.testAnalyze(jpegData: jpegData, appName: screenshot.appName)
                     let duration = Date().timeIntervalSince(analyzeStart)
+
+                    // Pick the first task-bearing result for display; fall back to the first
+                    // result (e.g. no_task_found terminator) when nothing was extracted.
+                    let result: TaskExtractionResult? = allResults.first(where: { $0.hasNewTask }) ?? allResults.first
 
                     await MainActor.run {
                         results.append(TaskTestResult(


### PR DESCRIPTION
## Summary
Every desktop auto-release since v0.11.402 has been failing on Codemagic at the Swift release-build step. The error:

\`\`\`
TaskTestRunnerWindow.swift:541:37: error: cannot convert value of type 
'[TaskExtractionResult]' to expected argument type 'TaskExtractionResult'
\`\`\`

My **multi-task-extract** PR changed \`testAnalyze\` to return \`[TaskExtractionResult]\` (array) instead of \`TaskExtractionResult?\` (single optional), but \`TaskTestRunnerWindow\` (debug test-runner UI) still destructured it as a single optional. \`xcrun swift build -c debug\` didn't surface this locally — Codemagic's clean release build did.

Fix: pick the first task-bearing result; fall back to the first result (terminator like \`no_task_found\`) when nothing was extracted.

Once this lands, all four queued auto-release tags should rebuild and ship: multi-task extract, empty-list "+" fix, promote-on-start, 5s Rewind first chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)