### PR TITLE
fix(backend): close paywalled desktop WS before gauge inc to stop HPA leak (#7318)

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -29,6 +29,7 @@ from utils.subscription import (
     filter_plans_for_user,
     should_show_new_plans,
     adapt_plans_for_legacy_client,
+    clear_trial_paywall_cache,
 )
 from database.users import (
     get_stripe_connect_account_id,
@@ -451,6 +452,7 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
             if new_subscription:
                 users_db.update_user_subscription(uid, new_subscription.dict())
                 set_credits_invalidation_signal(uid)
+                clear_trial_paywall_cache(uid)
                 if is_paid_plan(new_subscription.plan):
                     conversations_db.unlock_all_conversations(uid)
                     memories_db.unlock_all_memories(uid)
@@ -666,6 +668,7 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
 
             _update_subscription_from_session(uid, session)
             set_credits_invalidation_signal(uid)
+            clear_trial_paywall_cache(uid)
             subscription = users_db.get_user_subscription(uid)
             if subscription and is_paid_plan(subscription.plan):
                 conversations_db.unlock_all_conversations(uid)
@@ -731,6 +734,7 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                         action_items_db.unlock_all_action_items(uid)
                     users_db.update_user_subscription(uid, new_subscription.dict())
                     set_credits_invalidation_signal(uid)
+                    clear_trial_paywall_cache(uid)
                     if new_subscription.status == SubscriptionStatus.active and is_paid_plan(new_subscription.plan):
                         clear_fair_use_on_upgrade(uid)
                     logger.info(f"Subscription for user {uid} updated from webhook event: {event['type']}.")
@@ -773,6 +777,7 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                         else:
                             users_db.update_user_subscription(uid, new_subscription.dict())
                             set_credits_invalidation_signal(uid)
+                            clear_trial_paywall_cache(uid)
                             if is_paid_plan(new_subscription.plan):
                                 clear_fair_use_on_upgrade(uid)
                             logger.info(
@@ -803,6 +808,7 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
                             new_subscription.cancel_at_period_end = True
                             users_db.update_user_subscription(uid, new_subscription.dict())
                             set_credits_invalidation_signal(uid)
+                            clear_trial_paywall_cache(uid)
                             logger.info(
                                 f"Subscription schedule canceled for user {uid}. Subscription: {subscription_id}"
                             )

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import hashlib
 import io
 import json
@@ -112,17 +111,6 @@ from utils.metrics import (
     PUSHER_CIRCUIT_BREAKER_STATE,
     PUSHER_SESSION_DEGRADED,
 )
-
-
-@contextlib.asynccontextmanager
-async def track_active_ws():
-    BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
-    try:
-        yield
-    finally:
-        BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
-
-
 from utils.stt.speaker_embedding import (
     extract_embedding_from_bytes,
     compare_embeddings,
@@ -248,7 +236,6 @@ async def _stream_handler(
     """
     session_id = str(uuid.uuid4())
 
-    # --- Admission phase: reject before allocating session resources or incrementing the gauge ---
     if not uid or len(uid) <= 0:
         await websocket.close(code=1008, reason="Bad uid")
         return
@@ -262,60 +249,12 @@ async def _stream_handler(
             logger.error(f"Error closing paywalled WS: {e} {uid} {session_id}")
         return
 
-    use_custom_stt = custom_stt_mode == CustomSttMode.enabled
-    user_has_credits = True if use_custom_stt else has_transcription_credits(uid, source=source)
-
-    # --- Admitted: track as active session (gauge inc/dec guaranteed by context manager) ---
-    async with track_active_ws():
-        await _run_stream_session(
-            websocket=websocket,
-            uid=uid,
-            language=language,
-            sample_rate=sample_rate,
-            codec=codec,
-            channels=channels,
-            include_speech_profile=include_speech_profile,
-            stt_service=stt_service,
-            conversation_timeout=conversation_timeout,
-            source=source,
-            custom_stt_mode=custom_stt_mode,
-            onboarding_mode=onboarding_mode,
-            speaker_auto_assign_enabled=speaker_auto_assign_enabled,
-            vad_gate_override=vad_gate_override,
-            call_id=call_id,
-            session_id=session_id,
-            use_custom_stt=use_custom_stt,
-            user_has_credits=user_has_credits,
-        )
-
-    logger.info(f"_stream_handler ended {uid} {session_id}")
-
-
-async def _run_stream_session(
-    websocket: WebSocket,
-    uid: str,
-    language: str,
-    sample_rate: int,
-    codec: str,
-    channels: int,
-    include_speech_profile: bool,
-    stt_service: Optional[str],
-    conversation_timeout: int,
-    source: Optional[str],
-    custom_stt_mode: CustomSttMode,
-    onboarding_mode: bool,
-    speaker_auto_assign_enabled: bool,
-    vad_gate_override: Optional[str],
-    call_id: Optional[str],
-    session_id: str,
-    use_custom_stt: bool,
-    user_has_credits: bool,
-):
-    """Run the active streaming session. Gauge is managed by the caller's context manager."""
+    BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
     logger.info(
-        f'_run_stream_session {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode}'
+        f'_stream_handler {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode}'
     )
 
+    use_custom_stt = custom_stt_mode == CustomSttMode.enabled
     is_multi_channel = channels >= 2
 
     # Multi-channel state (only allocated when channels >= 2)
@@ -347,6 +286,8 @@ async def _run_stream_session(
     # Onboarding mode overrides: no speech profile (creating new one), single language
     if onboarding_mode:
         include_speech_profile = False
+
+    user_has_credits = True if use_custom_stt else has_transcription_credits(uid, source=source)
     if not user_has_credits:
         try:
             await send_credit_limit_notification(uid)
@@ -481,8 +422,11 @@ async def _run_stream_session(
     last_transcript_time: Optional[float] = None
     current_conversation_id = None
 
-    freemium_threshold_sent = False
+    freemium_threshold_sent = False  # Track if we've sent the freemium threshold notification
 
+    # Push the freemium threshold event upfront for already-exhausted users so
+    # the desktop popup appears immediately on connect, instead of waiting for
+    # the periodic loop's first 60s tick (typical desktop session is shorter).
     if not user_has_credits:
         try:
             await websocket.send_json(
@@ -2731,6 +2675,7 @@ async def _run_stream_session(
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e} {uid} {session_id}")
     finally:
+        BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
         if not use_custom_stt and last_usage_record_timestamp:
             transcription_seconds = int(time.time() - last_usage_record_timestamp)
             words_to_record = words_transcribed_since_last_record
@@ -2857,6 +2802,8 @@ async def _run_stream_session(
                 translation_service.translation_cache.clear()
         except NameError:
             pass
+
+    logger.info(f"_stream_handler ended {uid} {session_id}")
 
 
 async def _listen(

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -255,7 +255,6 @@ async def _stream_handler(
             logger.error(f"Error closing paywalled WS: {e} {uid} {session_id}")
         return
 
-    BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
     logger.info(
         f'_stream_handler {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode}'
     )
@@ -2603,6 +2602,7 @@ async def _stream_handler(
 
     # Start
     #
+    BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
     try:
         # Init STT
         _send_message_event(MessageServiceStatusEvent(status="stt_initiating", status_text="STT Service Starting"))

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import hashlib
 import io
 import json
@@ -92,8 +93,6 @@ from utils.subscription import (
     has_transcription_credits,
     get_remaining_transcription_seconds,
     is_trial_paywalled,
-    check_trial_paywall_ws_cooldown,
-    set_trial_paywall_ws_cooldown,
 )
 from utils.translation import TranslationService
 from utils.translation_cache import (
@@ -113,6 +112,17 @@ from utils.metrics import (
     PUSHER_CIRCUIT_BREAKER_STATE,
     PUSHER_SESSION_DEGRADED,
 )
+
+
+@contextlib.asynccontextmanager
+async def track_active_ws():
+    BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
+    try:
+        yield
+    finally:
+        BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
+
+
 from utils.stt.speaker_embedding import (
     extract_embedding_from_bytes,
     compare_embeddings,
@@ -238,20 +248,85 @@ async def _stream_handler(
     """
     session_id = str(uuid.uuid4())
 
-    if source and source.lower() in ('macos', 'desktop') and check_trial_paywall_ws_cooldown(uid):
-        logger.info("trial paywall: cooldown reject uid=%s session=%s", uid, session_id)
-        try:
-            await websocket.close(code=1008, reason="trial_expired_cooldown")
-        except Exception:
-            pass
+    # --- Admission phase: reject before allocating session resources or incrementing the gauge ---
+    if not uid or len(uid) <= 0:
+        await websocket.close(code=1008, reason="Bad uid")
         return
 
-    BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
+    use_custom_stt = custom_stt_mode == CustomSttMode.enabled
+    user_has_credits = True if use_custom_stt else has_transcription_credits(uid, source=source)
+    is_paywalled_desktop = is_trial_paywalled(uid, source)
+
+    if is_paywalled_desktop:
+        logger.info("trial paywall: closing desktop WS uid=%s session=%s reason=trial_expired", uid, session_id)
+        if not user_has_credits:
+            try:
+                await websocket.send_json(
+                    FreemiumThresholdReachedEvent(
+                        remaining_seconds=0,
+                        action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT,
+                    ).to_json()
+                )
+            except Exception as e:
+                logger.error(f"Error sending freemium threshold event on connect: {e} {uid} {session_id}")
+        try:
+            await asyncio.sleep(0.5)
+            await websocket.close(code=1008, reason="trial_expired")
+        except Exception as e:
+            logger.error(f"Error closing paywalled WS: {e} {uid} {session_id}")
+        return
+
+    # --- Admitted: track as active session (gauge inc/dec guaranteed by context manager) ---
+    async with track_active_ws():
+        await _run_stream_session(
+            websocket=websocket,
+            uid=uid,
+            language=language,
+            sample_rate=sample_rate,
+            codec=codec,
+            channels=channels,
+            include_speech_profile=include_speech_profile,
+            stt_service=stt_service,
+            conversation_timeout=conversation_timeout,
+            source=source,
+            custom_stt_mode=custom_stt_mode,
+            onboarding_mode=onboarding_mode,
+            speaker_auto_assign_enabled=speaker_auto_assign_enabled,
+            vad_gate_override=vad_gate_override,
+            call_id=call_id,
+            session_id=session_id,
+            use_custom_stt=use_custom_stt,
+            user_has_credits=user_has_credits,
+        )
+
+    logger.info(f"_stream_handler ended {uid} {session_id}")
+
+
+async def _run_stream_session(
+    websocket: WebSocket,
+    uid: str,
+    language: str,
+    sample_rate: int,
+    codec: str,
+    channels: int,
+    include_speech_profile: bool,
+    stt_service: Optional[str],
+    conversation_timeout: int,
+    source: Optional[str],
+    custom_stt_mode: CustomSttMode,
+    onboarding_mode: bool,
+    speaker_auto_assign_enabled: bool,
+    vad_gate_override: Optional[str],
+    call_id: Optional[str],
+    session_id: str,
+    use_custom_stt: bool,
+    user_has_credits: bool,
+):
+    """Run the active streaming session. Gauge is managed by the caller's context manager."""
     logger.info(
-        f'_stream_handler {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode}'
+        f'_run_stream_session {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode}'
     )
 
-    use_custom_stt = custom_stt_mode == CustomSttMode.enabled
     is_multi_channel = channels >= 2
 
     # Multi-channel state (only allocated when channels >= 2)
@@ -283,17 +358,6 @@ async def _stream_handler(
     # Onboarding mode overrides: no speech profile (creating new one), single language
     if onboarding_mode:
         include_speech_profile = False
-
-    if not uid or len(uid) <= 0:
-        await websocket.close(code=1008, reason="Bad uid")
-        return
-
-    user_has_credits = True if use_custom_stt else has_transcription_credits(uid, source=source)
-    # Computed once: only the desktop trial paywall path should also drop
-    # audio at the Deepgram-send gate. Mobile over-freemium users keep their
-    # pre-existing behavior (audio still forwarded; transcripts already
-    # suppressed elsewhere).
-    is_paywalled_desktop = is_trial_paywalled(uid, source)
     if not user_has_credits:
         try:
             await send_credit_limit_notification(uid)
@@ -428,11 +492,8 @@ async def _stream_handler(
     last_transcript_time: Optional[float] = None
     current_conversation_id = None
 
-    freemium_threshold_sent = False  # Track if we've sent the freemium threshold notification
+    freemium_threshold_sent = False
 
-    # Push the freemium threshold event upfront for already-exhausted users so
-    # the desktop popup appears immediately on connect, instead of waiting for
-    # the periodic loop's first 60s tick (typical desktop session is shorter).
     if not user_has_credits:
         try:
             await websocket.send_json(
@@ -444,27 +505,6 @@ async def _stream_handler(
             freemium_threshold_sent = True
         except Exception as e:
             logger.error(f"Error sending freemium threshold event on connect: {e} {uid} {session_id}")
-
-    # Hard-close the WS for paywalled DESKTOP users only — keeps GKE pods free
-    # and prevents bandwidth/audio buffering. Mobile freemium users (source!=desktop)
-    # are not affected: the gate above is desktop-scoped. The freemium event we just
-    # sent gives the client a chance to render the paywall popup before close.
-    if is_paywalled_desktop:
-        logger.info(
-            "trial paywall: closing desktop WS uid=%s session=%s reason=trial_expired",
-            uid,
-            session_id,
-        )
-        try:
-            set_trial_paywall_ws_cooldown(uid)
-            await asyncio.sleep(0.5)  # let the freemium event flush before close
-            await websocket.close(code=1008, reason="trial_expired")
-        except Exception as e:
-            logger.error(f"Error closing paywalled WS: {e} {uid} {session_id}")
-        finally:
-            BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
-        websocket_active = False
-        return
 
     # Credit cache: avoid querying ~720 Firestore docs every 60s per stream (#5439 sub-task 1)
     CREDITS_REFRESH_SECONDS = 900  # 15 min
@@ -2400,11 +2440,8 @@ async def _stream_handler(
                 dg_socket = None  # Stop sending to dead connection
 
             if dg_socket is not None:
-                # DG budget gate: skip sending if daily budget is exhausted (#5746, #6083),
-                # or if this is a desktop trial-paywalled session. Mobile users over
-                # the existing freemium quota keep their pre-existing behavior so this
-                # rollout doesn't change anything on mobile.
-                if fair_use_dg_budget_exhausted or is_paywalled_desktop:
+                # DG budget gate: skip sending if daily budget is exhausted (#5746, #6083).
+                if fair_use_dg_budget_exhausted:
                     pass  # Audio not forwarded to DG — budget exhausted or trial paywall
                 else:
                     dg_socket.send(chunk)
@@ -2705,7 +2742,6 @@ async def _stream_handler(
     except Exception as e:
         logger.error(f"Error during WebSocket operation: {e} {uid} {session_id}")
     finally:
-        BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
         if not use_custom_stt and last_usage_record_timestamp:
             transcription_seconds = int(time.time() - last_usage_record_timestamp)
             words_to_record = words_transcribed_since_last_record
@@ -2832,8 +2868,6 @@ async def _stream_handler(
                 translation_service.translation_cache.clear()
         except NameError:
             pass
-
-    logger.info(f"_stream_handler ended {uid} {session_id}")
 
 
 async def _listen(

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -243,6 +243,12 @@ async def _stream_handler(
     if is_trial_paywalled(uid, source):
         logger.info("trial paywall: closing desktop WS uid=%s session=%s reason=trial_expired", uid, session_id)
         try:
+            await websocket.send_json(
+                FreemiumThresholdReachedEvent(
+                    remaining_seconds=0,
+                    action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT,
+                ).to_json()
+            )
             await asyncio.sleep(0.5)
             await websocket.close(code=1008, reason="trial_expired")
         except Exception as e:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -88,7 +88,13 @@ from utils.fair_use import (
     is_dg_budget_exhausted,
     record_dg_usage_ms,
 )
-from utils.subscription import has_transcription_credits, get_remaining_transcription_seconds, is_trial_paywalled
+from utils.subscription import (
+    has_transcription_credits,
+    get_remaining_transcription_seconds,
+    is_trial_paywalled,
+    check_trial_paywall_ws_cooldown,
+    set_trial_paywall_ws_cooldown,
+)
 from utils.translation import TranslationService
 from utils.translation_cache import (
     TranscriptSegmentLanguageCache,
@@ -231,6 +237,15 @@ async def _stream_handler(
     This function is called by both _listen (for app clients) and web_listen_handler (for web clients).
     """
     session_id = str(uuid.uuid4())
+
+    if source and source.lower() in ('macos', 'desktop') and check_trial_paywall_ws_cooldown(uid):
+        logger.info("trial paywall: cooldown reject uid=%s session=%s", uid, session_id)
+        try:
+            await websocket.close(code=1008, reason="trial_expired_cooldown")
+        except Exception:
+            pass
+        return
+
     BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()
     logger.info(
         f'_stream_handler {uid} {session_id} {language} {sample_rate} {codec} {include_speech_profile} {stt_service} {conversation_timeout} custom_stt={custom_stt_mode} onboarding={onboarding_mode}'
@@ -440,11 +455,14 @@ async def _stream_handler(
             uid,
             session_id,
         )
+        set_trial_paywall_ws_cooldown(uid)
         try:
             await asyncio.sleep(0.5)  # let the freemium event flush before close
             await websocket.close(code=1008, reason="trial_expired")
         except Exception as e:
             logger.error(f"Error closing paywalled WS: {e} {uid} {session_id}")
+        finally:
+            BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()
         websocket_active = False
         return
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -455,8 +455,8 @@ async def _stream_handler(
             uid,
             session_id,
         )
-        set_trial_paywall_ws_cooldown(uid)
         try:
+            set_trial_paywall_ws_cooldown(uid)
             await asyncio.sleep(0.5)  # let the freemium event flush before close
             await websocket.close(code=1008, reason="trial_expired")
         except Exception as e:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -253,28 +253,17 @@ async def _stream_handler(
         await websocket.close(code=1008, reason="Bad uid")
         return
 
-    use_custom_stt = custom_stt_mode == CustomSttMode.enabled
-    user_has_credits = True if use_custom_stt else has_transcription_credits(uid, source=source)
-    is_paywalled_desktop = is_trial_paywalled(uid, source)
-
-    if is_paywalled_desktop:
+    if is_trial_paywalled(uid, source):
         logger.info("trial paywall: closing desktop WS uid=%s session=%s reason=trial_expired", uid, session_id)
-        if not user_has_credits:
-            try:
-                await websocket.send_json(
-                    FreemiumThresholdReachedEvent(
-                        remaining_seconds=0,
-                        action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT,
-                    ).to_json()
-                )
-            except Exception as e:
-                logger.error(f"Error sending freemium threshold event on connect: {e} {uid} {session_id}")
         try:
             await asyncio.sleep(0.5)
             await websocket.close(code=1008, reason="trial_expired")
         except Exception as e:
             logger.error(f"Error closing paywalled WS: {e} {uid} {session_id}")
         return
+
+    use_custom_stt = custom_stt_mode == CustomSttMode.enabled
+    user_has_credits = True if use_custom_stt else has_transcription_credits(uid, source=source)
 
     # --- Admitted: track as active session (gauge inc/dec guaranteed by context manager) ---
     async with track_active_ws():

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -77,6 +77,7 @@ from utils.subscription import (
     should_show_new_plans,
     adapt_plans_for_legacy_client,
     legacy_plan_features,
+    clear_trial_paywall_cache,
 )
 from database import user_usage as user_usage_db
 from utils import stripe as stripe_utils
@@ -797,6 +798,7 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
             )
     users_db.set_byok_active(uid, data.fingerprints)
     invalidate_byok_state_cache(uid)
+    clear_trial_paywall_cache(uid)
     return {"active": True}
 
 
@@ -805,6 +807,7 @@ def deactivate_byok_endpoint(uid: str = Depends(auth.get_current_user_uid_no_byo
     """Drop the user off the BYOK free plan (keys were cleared client-side)."""
     users_db.clear_byok_active(uid)
     invalidate_byok_state_cache(uid)
+    clear_trial_paywall_cache(uid)
     return {"active": False}
 
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -112,6 +112,7 @@ pytest tests/unit/test_async_http_infrastructure.py -v
 pytest tests/unit/test_clean_sweep_migrations.py -v
 pytest tests/unit/test_omi_qos_tiers.py -v
 pytest tests/unit/test_byok_security.py -v
+pytest tests/unit/test_paywall_reconnect_gate.py -v
 pytest tests/unit/test_vertex_ai_system_role.py -v
 pytest tests/unit/test_tts.py -v
 

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -5,7 +5,10 @@ Validates:
 - No paywall close block inside the session body (removed, handled in admission)
 - Cache invalidation on payment/BYOK changes
 - is_trial_paywalled handles platform filtering (only desktop/macos affected)
+- Behavioral tests for is_trial_paywalled and clear_trial_paywall_cache
 """
+
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -258,3 +261,125 @@ class TestPlatformFiltering:
         assert (
             'is_trial_paywalled(uid, source)' in admission_body
         ), "admission phase must call is_trial_paywalled with uid and source"
+
+
+class TestIsTrialPaywalledBehavioral:
+    """Behavioral tests for is_trial_paywalled() — mock internals, test logic directly.
+
+    Uses sys.modules stubs to avoid triggering Firestore/Firebase init on import.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_subscription(self):
+        import sys
+        import types
+
+        def _stub(name):
+            if name not in sys.modules:
+                sys.modules[name] = types.ModuleType(name)
+            return sys.modules[name]
+
+        saved = {}
+        stubs = [
+            'google.cloud',
+            'google.cloud.firestore',
+            'google.cloud.firestore_v1',
+            'firebase_admin',
+            'firebase_admin.auth',
+            'firebase_admin.firestore',
+            'database._client',
+            'database.redis_db',
+            'database.users',
+            'database.user_usage',
+            'database.announcements',
+        ]
+        for name in stubs:
+            saved[name] = sys.modules.get(name)
+            mod = _stub(name)
+            if name == 'database._client':
+                mod.db = MagicMock()
+            elif name == 'database.redis_db':
+                mod.get_generic_cache = MagicMock(return_value=None)
+                mod.set_generic_cache = MagicMock()
+                mod.delete_generic_cache = MagicMock()
+            elif name == 'database.users':
+                mod.get_user_valid_subscription = MagicMock(return_value=None)
+                mod.is_byok_active = MagicMock(return_value=False)
+            elif name == 'database.user_usage':
+                pass
+            elif name == 'database.announcements':
+                mod.compare_versions = MagicMock()
+            elif name == 'firebase_admin.auth':
+                mock_user = MagicMock()
+                mock_user.user_metadata.creation_timestamp = 0
+                mod.get_user = MagicMock(return_value=mock_user)
+
+        if 'utils.subscription' in sys.modules:
+            del sys.modules['utils.subscription']
+
+        import utils.subscription as sub
+
+        self._sub = sub
+        self._mock_expired = MagicMock(return_value=True)
+        self._orig_expired = sub._is_trial_expired_cached
+        sub._is_trial_expired_cached = self._mock_expired
+        sub._TRIAL_PAYWALL_ENABLED = True
+        sub._TRIAL_PAYWALL_TEST_UIDS = set()
+
+        yield
+
+        sub._is_trial_expired_cached = self._orig_expired
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+    def test_desktop_expired_returns_true(self):
+        assert self._sub.is_trial_paywalled('uid1', 'desktop') is True
+
+    def test_macos_expired_returns_true(self):
+        assert self._sub.is_trial_paywalled('uid1', 'macos') is True
+
+    def test_ios_returns_false(self):
+        assert self._sub.is_trial_paywalled('uid1', 'ios') is False
+        self._mock_expired.assert_not_called()
+
+    def test_android_returns_false(self):
+        assert self._sub.is_trial_paywalled('uid1', 'android') is False
+        self._mock_expired.assert_not_called()
+
+    def test_none_platform_returns_false(self):
+        assert self._sub.is_trial_paywalled('uid1', None) is False
+        self._mock_expired.assert_not_called()
+
+    def test_unknown_platform_returns_false(self):
+        assert self._sub.is_trial_paywalled('uid1', 'phone_call') is False
+        self._mock_expired.assert_not_called()
+
+    def test_mixed_case_desktop(self):
+        assert self._sub.is_trial_paywalled('uid1', 'Desktop') is True
+        assert self._sub.is_trial_paywalled('uid1', 'MACOS') is True
+
+    def test_kill_switch_disabled(self):
+        self._sub._TRIAL_PAYWALL_ENABLED = False
+        assert self._sub.is_trial_paywalled('uid1', 'desktop') is False
+        self._sub._TRIAL_PAYWALL_ENABLED = True
+
+    def test_test_uid_gating_allows_listed(self):
+        self._sub._TRIAL_PAYWALL_TEST_UIDS = {'uid1', 'uid2'}
+        assert self._sub.is_trial_paywalled('uid1', 'desktop') is True
+        self._sub._TRIAL_PAYWALL_TEST_UIDS = set()
+
+    def test_test_uid_gating_blocks_unlisted(self):
+        self._sub._TRIAL_PAYWALL_TEST_UIDS = {'uid1', 'uid2'}
+        assert self._sub.is_trial_paywalled('uid99', 'desktop') is False
+        self._sub._TRIAL_PAYWALL_TEST_UIDS = set()
+
+    def test_not_expired_returns_false(self):
+        self._mock_expired.return_value = False
+        assert self._sub.is_trial_paywalled('uid1', 'desktop') is False
+
+    def test_clear_cache_calls_redis_delete(self):
+        self._sub.clear_trial_paywall_cache('test-uid-123')
+        self._sub.redis_db.delete_generic_cache.assert_called_with('trial_paywall:expired:test-uid-123')

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -86,6 +86,37 @@ class TestAdmissionPhase:
         assert event_pos < close_pos, "freemium event must be sent before websocket close"
 
 
+class TestGaugeIncTryFinally:
+    """Verify gauge inc is immediately before the try/finally that decrements it — no leakable returns."""
+
+    def test_inc_immediately_before_try(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        inc_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        try_pos = handler_body.find('try:', inc_pos)
+        between = handler_body[inc_pos + len('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()') : try_pos]
+        assert 'return' not in between, "no return statements allowed between gauge inc and try block"
+
+    def test_unsupported_language_return_before_gauge(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        lang_pos = handler_body.find('The language is not supported')
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        assert lang_pos != -1, "unsupported language check not found"
+        assert lang_pos < gauge_pos, "unsupported language return must come before gauge inc"
+
+    def test_bad_user_return_before_gauge(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        user_pos = handler_body.find('Bad user')
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        assert user_pos != -1, "bad user check not found"
+        assert user_pos < gauge_pos, "bad user return must come before gauge inc"
+
+
 class TestNoPaywallBlockInSession:
     """Verify the old paywall close block was removed from inside the session."""
 

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -2,8 +2,7 @@
 
 Validates:
 - Admission phase rejects paywalled desktop before gauge increment
-- Context manager guarantees gauge inc/dec balance
-- No early returns inside session can leak the gauge
+- No paywall close block inside the session body (removed, handled in admission)
 - Cache invalidation on payment/BYOK changes
 - is_trial_paywalled handles platform filtering (only desktop/macos affected)
 """
@@ -24,153 +23,82 @@ def _read_source(path):
 class TestAdmissionPhase:
     """Verify paywalled desktop users are rejected in the admission phase, before gauge increment."""
 
-    def test_paywall_check_before_gauge_context_manager(self):
+    def test_paywall_check_before_gauge_inc(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         handler_start = src.find('async def _stream_handler(')
         handler_body = src[handler_start:]
         paywall_pos = handler_body.find('is_trial_paywalled(uid, source)')
-        gauge_pos = handler_body.find('async with track_active_ws():')
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
         assert paywall_pos != -1, "is_trial_paywalled call not found in _stream_handler"
-        assert gauge_pos != -1, "track_active_ws context manager not found in _stream_handler"
-        assert paywall_pos < gauge_pos, "paywall check must come before gauge context manager"
+        assert gauge_pos != -1, "gauge inc not found in _stream_handler"
+        assert paywall_pos < gauge_pos, "paywall check must come before gauge inc"
 
     def test_paywall_rejection_returns_before_gauge(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        in_paywall_block = False
-        found_return_before_gauge = False
-        for i, line in enumerate(lines):
-            if 'if is_trial_paywalled(' in line:
-                in_paywall_block = True
-            if in_paywall_block and line.strip() == 'return':
-                found_return_before_gauge = True
-                break
-            if in_paywall_block and 'track_active_ws()' in line:
-                break
-        assert found_return_before_gauge, "paywall rejection must return before gauge context manager"
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        paywall_pos = handler_body.find('if is_trial_paywalled(')
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        paywall_block = handler_body[paywall_pos:gauge_pos]
+        assert 'return' in paywall_block, "paywall rejection must return before gauge inc"
 
     def test_paywall_close_uses_1008(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        in_admission_paywall = False
-        found_close = False
-        for line in lines:
-            if 'if is_trial_paywalled(' in line:
-                in_admission_paywall = True
-            if in_admission_paywall and 'websocket.close' in line and '1008' in line:
-                found_close = True
-                break
-            if in_admission_paywall and 'track_active_ws()' in line:
-                break
-        assert found_close, "admission paywall must close with code 1008"
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        paywall_pos = handler_body.find('if is_trial_paywalled(')
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        paywall_block = handler_body[paywall_pos:gauge_pos]
+        assert (
+            'websocket.close' in paywall_block and '1008' in paywall_block
+        ), "admission paywall must close with code 1008"
 
     def test_paywall_close_reason_is_trial_expired(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        in_admission_paywall = False
-        for line in lines:
-            if 'if is_trial_paywalled(' in line:
-                in_admission_paywall = True
-            if in_admission_paywall and 'trial_expired' in line and 'websocket.close' in line:
-                assert 'trial_expired' in line
-                return
-            if in_admission_paywall and 'track_active_ws()' in line:
-                break
-        pytest.fail("paywall close must use reason 'trial_expired'")
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        paywall_pos = handler_body.find('if is_trial_paywalled(')
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        paywall_block = handler_body[paywall_pos:gauge_pos]
+        assert 'trial_expired' in paywall_block, "paywall close must use reason 'trial_expired'"
 
     def test_uid_check_before_gauge(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         handler_start = src.find('async def _stream_handler(')
         handler_body = src[handler_start:]
         uid_check_pos = handler_body.find('Bad uid')
-        gauge_pos = handler_body.find('async with track_active_ws():')
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
         assert uid_check_pos != -1, "uid check not found in _stream_handler"
-        assert gauge_pos != -1, "gauge context manager not found in _stream_handler"
-        assert uid_check_pos < gauge_pos, "uid check must come before gauge"
+        assert gauge_pos != -1, "gauge inc not found in _stream_handler"
+        assert uid_check_pos < gauge_pos, "uid check must come before gauge inc"
 
 
-class TestGaugeContextManager:
-    """Verify the gauge is managed via a context manager, not manual inc/dec."""
+class TestNoPaywallBlockInSession:
+    """Verify the old paywall close block was removed from inside the session."""
 
-    def test_track_active_ws_context_manager_exists(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        assert (
-            'async def track_active_ws()' in src or 'def track_active_ws()' in src
-        ), "track_active_ws context manager must be defined"
-
-    def test_context_manager_increments_gauge(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        cm_start = src.find('def track_active_ws()')
-        assert cm_start != -1
-        cm_body = src[cm_start : src.find('\n\n\n', cm_start)]
-        assert 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()' in cm_body
-
-    def test_context_manager_decrements_in_finally(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        cm_start = src.find('def track_active_ws()')
-        assert cm_start != -1
-        cm_body = src[cm_start : src.find('\n\n\n', cm_start)]
-        assert 'finally:' in cm_body
-        assert 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' in cm_body
-
-    def test_session_runs_inside_context_manager(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        assert 'async with track_active_ws():' in src, "_run_stream_session must run inside track_active_ws"
-
-    def test_no_manual_gauge_dec_in_session(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        session_start = src.find('async def _run_stream_session(')
-        assert session_start != -1
-        session_body = src[session_start:]
-        next_fn = session_body.find('\nasync def _listen(')
-        if next_fn != -1:
-            session_body = session_body[:next_fn]
-        assert (
-            'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' not in session_body
-        ), "_run_stream_session must not manually dec the gauge — context manager handles it"
-
-    def test_no_manual_gauge_inc_outside_context_manager(self):
+    def test_no_paywalled_desktop_variable(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         handler_start = src.find('async def _stream_handler(')
-        handler_end = src.find('async def _run_stream_session(')
-        handler_body = src[handler_start:handler_end]
+        handler_body = src[handler_start:]
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        after_gauge = handler_body[gauge_pos:]
         assert (
-            'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()' not in handler_body
-        ), "_stream_handler must not manually inc the gauge — context manager handles it"
+            'is_paywalled_desktop' not in after_gauge
+        ), "is_paywalled_desktop variable should not exist after gauge inc — handled in admission"
 
-
-class TestNoGaugeLeakOnEarlyReturn:
-    """Verify that early returns inside _run_stream_session cannot leak the gauge."""
-
-    def test_unsupported_language_return_is_inside_session(self):
+    def test_no_cooldown_calls(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        session_start = src.find('async def _run_stream_session(')
-        assert session_start != -1
-        session_body = src[session_start:]
-        assert (
-            'The language is not supported' in session_body
-        ), "language check should be inside _run_stream_session (protected by context manager)"
+        assert 'check_trial_paywall_ws_cooldown' not in src, "cooldown check removed"
+        assert 'set_trial_paywall_ws_cooldown' not in src, "cooldown set removed"
 
-    def test_bad_user_return_is_inside_session(self):
+    def test_gauge_dec_in_finally(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        session_start = src.find('async def _run_stream_session(')
-        assert session_start != -1
-        session_body = src[session_start:]
-        assert (
-            'Bad user' in session_body
-        ), "user existence check should be inside _run_stream_session (protected by context manager)"
-
-    def test_no_paywall_check_in_session(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        session_start = src.find('async def _run_stream_session(')
-        assert session_start != -1
-        session_body = src[session_start:]
-        next_fn = session_body.find('\nasync def _listen(')
-        if next_fn != -1:
-            session_body = session_body[:next_fn]
-        assert (
-            'is_trial_paywalled' not in session_body
-        ), "is_trial_paywalled should not exist in _run_stream_session — handled in admission"
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        finally_pos = handler_body.rfind('finally:')
+        assert finally_pos != -1
+        finally_block = handler_body[finally_pos:]
+        assert 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' in finally_block, "gauge dec must be in the finally block"
 
 
 class TestCacheInvalidation:
@@ -231,7 +159,7 @@ class TestCacheInvalidation:
 
 
 class TestCacheInvalidationBehavioral:
-    """Execute clear_trial_paywall_cache with mocked Redis to verify runtime behavior."""
+    """Verify clear_trial_paywall_cache implementation."""
 
     def test_clear_cache_deletes_expired_key(self):
         src = _read_source(SUBSCRIPTION_SRC_PATH)
@@ -280,36 +208,9 @@ class TestPlatformFiltering:
     def test_admission_calls_is_trial_paywalled_with_source(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         handler_start = src.find('async def _stream_handler(')
-        handler_end = src.find('async def _run_stream_session(')
-        handler_body = src[handler_start:handler_end]
+        handler_body = src[handler_start:]
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        admission_body = handler_body[:gauge_pos]
         assert (
-            'is_trial_paywalled(uid, source)' in handler_body
+            'is_trial_paywalled(uid, source)' in admission_body
         ), "admission phase must call is_trial_paywalled with uid and source"
-
-
-class TestArchitecturalSplit:
-    """Verify the _stream_handler / _run_stream_session split is correct."""
-
-    def test_stream_handler_exists(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        assert 'async def _stream_handler(' in src
-
-    def test_run_stream_session_exists(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        assert 'async def _run_stream_session(' in src
-
-    def test_stream_handler_calls_run_stream_session(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        handler_start = src.find('async def _stream_handler(')
-        handler_end = src.find('async def _run_stream_session(')
-        handler_body = src[handler_start:handler_end]
-        assert '_run_stream_session(' in handler_body
-
-    def test_no_freemium_event_in_admission(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        handler_start = src.find('async def _stream_handler(')
-        handler_end = src.find('async def _run_stream_session(')
-        handler_body = src[handler_start:handler_end]
-        assert (
-            'FreemiumThresholdReachedEvent' not in handler_body
-        ), "admission phase should not send freemium event — close reason 'trial_expired' is the signal"

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -1,0 +1,243 @@
+"""Tests for the desktop trial paywall reconnect gate (#7318).
+
+Validates:
+- Redis cooldown fast-reject before gauge increment
+- Cooldown set on paywall close
+- Gauge balance on paywall close path
+- Cache invalidation on payment/BYOK changes
+- Source filtering (only desktop/macos affected)
+"""
+
+import ast
+import inspect
+import textwrap
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+TRANSCRIBE_SRC_PATH = 'routers/transcribe.py'
+PAYMENT_SRC_PATH = 'routers/payment.py'
+USERS_SRC_PATH = 'routers/users.py'
+SUBSCRIPTION_SRC_PATH = 'utils/subscription.py'
+
+
+def _read_source(path):
+    with open(path) as f:
+        return f.read()
+
+
+class TestCooldownGate:
+    """Verify the Redis cooldown fast-reject is wired correctly in _stream_handler."""
+
+    def test_cooldown_check_before_gauge_inc(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        cooldown_pos = src.find('check_trial_paywall_ws_cooldown')
+        gauge_pos = src.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        assert cooldown_pos != -1, "cooldown check not found in transcribe.py"
+        assert gauge_pos != -1, "gauge inc not found in transcribe.py"
+        assert cooldown_pos < gauge_pos, "cooldown check must come before gauge inc"
+
+    def test_cooldown_check_uses_source_filter(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        cooldown_line = None
+        for i, line in enumerate(lines):
+            if 'check_trial_paywall_ws_cooldown(uid)' in line:
+                block = '\n'.join(lines[max(0, i - 3) : i + 1])
+                cooldown_line = block
+                break
+        assert cooldown_line is not None, "cooldown function call not found"
+        assert (
+            'macos' in cooldown_line or 'desktop' in cooldown_line
+        ), "cooldown check must filter by desktop/macos source"
+
+    def test_cooldown_reject_closes_with_1008(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        in_cooldown_block = False
+        found_close = False
+        for line in lines:
+            if 'check_trial_paywall_ws_cooldown(uid)' in line:
+                in_cooldown_block = True
+            if in_cooldown_block and 'websocket.close' in line and '1008' in line:
+                found_close = True
+                break
+            if in_cooldown_block and 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS' in line:
+                break
+        assert found_close, "cooldown reject must close with code 1008"
+
+    def test_cooldown_reason_is_cooldown_specific(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        assert (
+            'trial_expired_cooldown' in src
+        ), "cooldown close reason must be 'trial_expired_cooldown' (distinct from 'trial_expired')"
+
+
+class TestPaywallCloseGaugeFix:
+    """Verify gauge balance on the paywall close path."""
+
+    def test_paywall_close_sets_cooldown(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        found_set_before_close = False
+        for i, line in enumerate(lines):
+            if 'set_trial_paywall_ws_cooldown' in line:
+                remaining = '\n'.join(lines[i : i + 10])
+                if 'trial_expired' in remaining and 'websocket.close' in remaining:
+                    found_set_before_close = True
+                    break
+        assert found_set_before_close, "paywall close path must call set_trial_paywall_ws_cooldown before close"
+
+    def test_paywall_close_decrements_gauge(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        in_paywall_block = False
+        found_dec = False
+        for i, line in enumerate(lines):
+            if 'is_paywalled_desktop' in line and 'if ' in line:
+                in_paywall_block = True
+            if in_paywall_block:
+                if 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' in line:
+                    found_dec = True
+                    break
+                if line.strip() == 'return' and found_dec:
+                    break
+                if line.strip().startswith('# Credit cache') or line.strip().startswith('# Fair-use'):
+                    break
+        assert found_dec, "paywall close path must decrement the gauge before return"
+
+    def test_gauge_dec_in_finally(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        in_paywall_block = False
+        found_try = False
+        found_finally_dec = False
+        for i, line in enumerate(lines):
+            if 'is_paywalled_desktop' in line and 'if ' in line:
+                in_paywall_block = True
+            if in_paywall_block and 'asyncio.sleep(0.5)' in line:
+                found_try = True
+            if in_paywall_block and found_try and 'finally:' in line:
+                next_lines = '\n'.join(lines[i : i + 3])
+                if 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' in next_lines:
+                    found_finally_dec = True
+                break
+            if in_paywall_block and 'return' in line and not found_try:
+                break
+        assert found_finally_dec, "gauge dec on paywall path should be in a finally block"
+
+
+class TestCacheInvalidation:
+    """Verify trial paywall cache is cleared on subscription and BYOK changes."""
+
+    def test_clear_trial_paywall_cache_clears_both_keys(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        assert 'trial_paywall:expired:' in src, "clear function must delete expired cache"
+        assert 'trial_paywall:ws_cooldown:' in src, "clear function must delete cooldown cache"
+
+        fn_start = src.find('def clear_trial_paywall_cache')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert (
+            fn_body.count('delete_generic_cache') == 2
+        ), "clear_trial_paywall_cache must call delete_generic_cache twice (expired + cooldown)"
+
+    def test_payment_clears_paywall_cache_at_all_invalidation_sites(self):
+        src = _read_source(PAYMENT_SRC_PATH)
+        signal_count = src.count('set_credits_invalidation_signal(uid)')
+        clear_count = src.count('clear_trial_paywall_cache(uid)')
+        assert signal_count == clear_count, (
+            f"payment.py has {signal_count} set_credits_invalidation_signal calls "
+            f"but only {clear_count} clear_trial_paywall_cache calls — must match"
+        )
+
+    def test_payment_imports_clear_function(self):
+        src = _read_source(PAYMENT_SRC_PATH)
+        assert (
+            'clear_trial_paywall_cache' in src.split('from utils.subscription import')[1].split(')')[0]
+        ), "payment.py must import clear_trial_paywall_cache from utils.subscription"
+
+    def test_byok_activate_clears_paywall_cache(self):
+        src = _read_source(USERS_SRC_PATH)
+        lines = src.split('\n')
+        in_activate = False
+        found_clear = False
+        for line in lines:
+            if 'def activate_byok_endpoint' in line:
+                in_activate = True
+            if in_activate and 'clear_trial_paywall_cache' in line:
+                found_clear = True
+                break
+            if in_activate and line.strip().startswith('def ') and 'activate_byok' not in line:
+                break
+        assert found_clear, "activate_byok_endpoint must call clear_trial_paywall_cache"
+
+    def test_byok_deactivate_clears_paywall_cache(self):
+        src = _read_source(USERS_SRC_PATH)
+        lines = src.split('\n')
+        in_deactivate = False
+        found_clear = False
+        for line in lines:
+            if 'def deactivate_byok_endpoint' in line:
+                in_deactivate = True
+            if in_deactivate and 'clear_trial_paywall_cache' in line:
+                found_clear = True
+                break
+            if in_deactivate and line.strip().startswith('def ') and 'deactivate_byok' not in line:
+                break
+        assert found_clear, "deactivate_byok_endpoint must call clear_trial_paywall_cache"
+
+
+class TestSubscriptionHelpers:
+    """Verify the cooldown/cache helper function logic via source inspection."""
+
+    def test_set_cooldown_uses_correct_key_and_ttl(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        fn_start = src.find('def set_trial_paywall_ws_cooldown')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert 'set_generic_cache' in fn_body
+        assert 'TRIAL_PAYWALL_WS_COOLDOWN_PREFIX' in fn_body or 'trial_paywall:ws_cooldown:' in fn_body
+        assert 'TRIAL_PAYWALL_WS_COOLDOWN_TTL' in fn_body or 'ttl=' in fn_body
+
+    def test_check_cooldown_uses_get_generic_cache(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        fn_start = src.find('def check_trial_paywall_ws_cooldown')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert 'get_generic_cache' in fn_body
+        assert 'TRIAL_PAYWALL_WS_COOLDOWN_PREFIX' in fn_body or 'trial_paywall:ws_cooldown:' in fn_body
+
+    def test_clear_cache_deletes_both_keys(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        fn_start = src.find('def clear_trial_paywall_cache')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert fn_body.count('delete_generic_cache') == 2
+        assert 'trial_paywall:expired:' in fn_body
+        assert 'trial_paywall:ws_cooldown:' in fn_body or 'TRIAL_PAYWALL_WS_COOLDOWN_PREFIX' in fn_body
+
+
+class TestCooldownTTL:
+    """Verify cooldown TTL is reasonable for the reconnect loop scenario."""
+
+    def test_cooldown_ttl_between_30_and_120(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        assert 'TRIAL_PAYWALL_WS_COOLDOWN_TTL = ' in src
+        for line in src.split('\n'):
+            if 'TRIAL_PAYWALL_WS_COOLDOWN_TTL = ' in line:
+                ttl = int(line.split('=')[1].strip())
+                assert 30 <= ttl <= 120, f"cooldown TTL {ttl}s should be 30-120s"
+                break
+
+    def test_cooldown_ttl_shorter_than_expired_cache_ttl(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        cooldown_ttl = None
+        expired_ttl = None
+        for line in src.split('\n'):
+            if 'TRIAL_PAYWALL_WS_COOLDOWN_TTL = ' in line:
+                cooldown_ttl = int(line.split('=')[1].strip())
+            if '_TRIAL_PAYWALL_CACHE_TTL_SECONDS = ' in line:
+                expired_ttl = int(line.split('=')[1].strip())
+        assert cooldown_ttl is not None and expired_ttl is not None
+        assert cooldown_ttl < expired_ttl, "cooldown TTL should be shorter than the expired cache TTL"

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -72,6 +72,19 @@ class TestAdmissionPhase:
         assert gauge_pos != -1, "gauge inc not found in _stream_handler"
         assert uid_check_pos < gauge_pos, "uid check must come before gauge inc"
 
+    def test_freemium_event_sent_before_close(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        paywall_pos = handler_body.find('if is_trial_paywalled(')
+        gauge_pos = handler_body.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
+        paywall_block = handler_body[paywall_pos:gauge_pos]
+        event_pos = paywall_block.find('FreemiumThresholdReachedEvent')
+        close_pos = paywall_block.find('websocket.close')
+        assert event_pos != -1, "admission must send FreemiumThresholdReachedEvent for desktop client"
+        assert close_pos != -1
+        assert event_pos < close_pos, "freemium event must be sent before websocket close"
+
 
 class TestNoPaywallBlockInSession:
     """Verify the old paywall close block was removed from inside the session."""

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -106,6 +106,21 @@ class TestPaywallCloseGaugeFix:
                     break
         assert found_dec, "paywall close path must decrement the gauge before return"
 
+    def test_cooldown_set_inside_try(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        in_paywall_block = False
+        found_try_before_set = False
+        for i, line in enumerate(lines):
+            if 'is_paywalled_desktop' in line and 'if ' in line:
+                in_paywall_block = True
+            if in_paywall_block and line.strip() == 'try:':
+                remaining = '\n'.join(lines[i : i + 5])
+                if 'set_trial_paywall_ws_cooldown' in remaining:
+                    found_try_before_set = True
+                break
+        assert found_try_before_set, "set_trial_paywall_ws_cooldown must be inside the try block to avoid gauge leak"
+
     def test_gauge_dec_in_finally(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         lines = src.split('\n')
@@ -207,6 +222,20 @@ class TestSubscriptionHelpers:
         fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
         assert 'get_generic_cache' in fn_body
         assert 'TRIAL_PAYWALL_WS_COOLDOWN_PREFIX' in fn_body or 'trial_paywall:ws_cooldown:' in fn_body
+
+    def test_check_cooldown_respects_kill_switch(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        fn_start = src.find('def check_trial_paywall_ws_cooldown')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert '_TRIAL_PAYWALL_ENABLED' in fn_body, "check_cooldown must respect the kill switch"
+
+    def test_check_cooldown_respects_test_uid_gating(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        fn_start = src.find('def check_trial_paywall_ws_cooldown')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert '_TRIAL_PAYWALL_TEST_UIDS' in fn_body, "check_cooldown must respect test UID gating"
 
     def test_clear_cache_deletes_both_keys(self):
         src = _read_source(SUBSCRIPTION_SRC_PATH)

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -8,10 +8,6 @@ Validates:
 - is_trial_paywalled handles platform filtering (only desktop/macos affected)
 """
 
-import ast
-import textwrap
-from unittest.mock import MagicMock
-
 import pytest
 
 TRANSCRIBE_SRC_PATH = 'routers/transcribe.py'
@@ -44,7 +40,7 @@ class TestAdmissionPhase:
         in_paywall_block = False
         found_return_before_gauge = False
         for i, line in enumerate(lines):
-            if 'if is_paywalled_desktop:' in line:
+            if 'if is_trial_paywalled(' in line:
                 in_paywall_block = True
             if in_paywall_block and line.strip() == 'return':
                 found_return_before_gauge = True
@@ -59,7 +55,7 @@ class TestAdmissionPhase:
         in_admission_paywall = False
         found_close = False
         for line in lines:
-            if 'if is_paywalled_desktop:' in line:
+            if 'if is_trial_paywalled(' in line:
                 in_admission_paywall = True
             if in_admission_paywall and 'websocket.close' in line and '1008' in line:
                 found_close = True
@@ -73,7 +69,7 @@ class TestAdmissionPhase:
         lines = src.split('\n')
         in_admission_paywall = False
         for line in lines:
-            if 'if is_paywalled_desktop:' in line:
+            if 'if is_trial_paywalled(' in line:
                 in_admission_paywall = True
             if in_admission_paywall and 'trial_expired' in line and 'websocket.close' in line:
                 assert 'trial_expired' in line
@@ -164,7 +160,7 @@ class TestNoGaugeLeakOnEarlyReturn:
             'Bad user' in session_body
         ), "user existence check should be inside _run_stream_session (protected by context manager)"
 
-    def test_no_is_paywalled_desktop_in_session(self):
+    def test_no_paywall_check_in_session(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         session_start = src.find('async def _run_stream_session(')
         assert session_start != -1
@@ -173,8 +169,8 @@ class TestNoGaugeLeakOnEarlyReturn:
         if next_fn != -1:
             session_body = session_body[:next_fn]
         assert (
-            'is_paywalled_desktop' not in session_body
-        ), "is_paywalled_desktop should not exist in _run_stream_session — handled in admission"
+            'is_trial_paywalled' not in session_body
+        ), "is_trial_paywalled should not exist in _run_stream_session — handled in admission"
 
 
 class TestCacheInvalidation:
@@ -309,11 +305,11 @@ class TestArchitecturalSplit:
         handler_body = src[handler_start:handler_end]
         assert '_run_stream_session(' in handler_body
 
-    def test_freemium_event_sent_for_paywalled_users(self):
+    def test_no_freemium_event_in_admission(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         handler_start = src.find('async def _stream_handler(')
         handler_end = src.find('async def _run_stream_session(')
         handler_body = src[handler_start:handler_end]
         assert (
-            'FreemiumThresholdReachedEvent' in handler_body
-        ), "admission phase must send freemium event before paywall close"
+            'FreemiumThresholdReachedEvent' not in handler_body
+        ), "admission phase should not send freemium event — close reason 'trial_expired' is the signal"

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -218,6 +218,135 @@ class TestSubscriptionHelpers:
         assert 'trial_paywall:ws_cooldown:' in fn_body or 'TRIAL_PAYWALL_WS_COOLDOWN_PREFIX' in fn_body
 
 
+class TestSubscriptionHelpersBehavioral:
+    """Execute the helper functions with mocked Redis to verify runtime behavior."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_deps(self):
+        import sys
+
+        mock_redis = MagicMock()
+        mock_db_client = MagicMock()
+        mock_users_db = MagicMock()
+        mock_user_usage_db = MagicMock()
+        mock_byok = MagicMock()
+        mock_firebase_auth = MagicMock()
+        saved = {}
+        for mod_name in [
+            'database._client',
+            'database.users',
+            'database.user_usage',
+            'database.redis_db',
+            'database.announcements',
+            'utils.byok',
+            'firebase_admin',
+            'firebase_admin.auth',
+        ]:
+            saved[mod_name] = sys.modules.get(mod_name)
+
+        sys.modules['database._client'] = mock_db_client
+        sys.modules['database.users'] = mock_users_db
+        sys.modules['database.user_usage'] = mock_user_usage_db
+        sys.modules['database.redis_db'] = mock_redis
+        mock_announcements = MagicMock()
+        mock_announcements.compare_versions = lambda a, b: 0
+        sys.modules['database.announcements'] = mock_announcements
+        sys.modules['utils.byok'] = mock_byok
+        sys.modules['firebase_admin'] = MagicMock()
+        sys.modules['firebase_admin.auth'] = mock_firebase_auth
+
+        if 'utils.subscription' in sys.modules:
+            del sys.modules['utils.subscription']
+
+        self.mock_redis = mock_redis
+        yield
+
+        if 'utils.subscription' in sys.modules:
+            del sys.modules['utils.subscription']
+        for mod_name, orig in saved.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+    def test_set_cooldown_exact_key_and_ttl(self):
+        from utils.subscription import set_trial_paywall_ws_cooldown
+
+        set_trial_paywall_ws_cooldown('test_uid_123')
+        self.mock_redis.set_generic_cache.assert_called_once()
+        args = self.mock_redis.set_generic_cache.call_args
+        key = args[0][0]
+        assert key == 'trial_paywall:ws_cooldown:test_uid_123'
+        assert args[1].get('ttl') == 60 or (len(args[0]) > 2 and args[0][2] == 60)
+
+    def test_check_cooldown_true_when_cached(self):
+        from utils.subscription import check_trial_paywall_ws_cooldown
+
+        self.mock_redis.get_generic_cache.return_value = True
+        assert check_trial_paywall_ws_cooldown('uid_x') is True
+        self.mock_redis.get_generic_cache.assert_called_once_with('trial_paywall:ws_cooldown:uid_x')
+
+    def test_check_cooldown_false_when_absent(self):
+        from utils.subscription import check_trial_paywall_ws_cooldown
+
+        self.mock_redis.get_generic_cache.return_value = None
+        assert check_trial_paywall_ws_cooldown('uid_y') is False
+
+    def test_clear_cache_deletes_exact_keys(self):
+        from utils.subscription import clear_trial_paywall_cache
+
+        clear_trial_paywall_cache('uid_z')
+        calls = [c[0][0] for c in self.mock_redis.delete_generic_cache.call_args_list]
+        assert 'trial_paywall:expired:uid_z' in calls
+        assert 'trial_paywall:ws_cooldown:uid_z' in calls
+        assert len(calls) == 2
+
+
+class TestPlatformFiltering:
+    """Verify only desktop/macos sources trigger cooldown, not mobile/omi."""
+
+    def test_cooldown_gate_includes_macos(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        for line in lines:
+            if 'check_trial_paywall_ws_cooldown(uid)' in line:
+                assert "'macos'" in line, "cooldown gate must include 'macos' in platform check"
+                break
+
+    def test_cooldown_gate_includes_desktop(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        for line in lines:
+            if 'check_trial_paywall_ws_cooldown(uid)' in line:
+                assert "'desktop'" in line, "cooldown gate must include 'desktop' in platform check"
+                break
+
+    def test_cooldown_gate_uses_lower_for_case_insensitivity(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        for line in lines:
+            if 'check_trial_paywall_ws_cooldown(uid)' in line:
+                assert '.lower()' in line, "cooldown gate must use .lower() for case-insensitive matching"
+                break
+
+    def test_mobile_sources_not_in_cooldown_filter(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        for line in lines:
+            if 'check_trial_paywall_ws_cooldown(uid)' in line:
+                assert "'ios'" not in line, "ios must not be in cooldown platform filter"
+                assert "'android'" not in line, "android must not be in cooldown platform filter"
+                break
+
+    def test_cooldown_gate_checks_source_not_none(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        for line in lines:
+            if 'check_trial_paywall_ws_cooldown(uid)' in line:
+                assert 'source and' in line or 'if source' in line, "cooldown gate must guard against None source"
+                break
+
+
 class TestCooldownTTL:
     """Verify cooldown TTL is reasonable for the reconnect loop scenario."""
 

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -1,17 +1,16 @@
 """Tests for the desktop trial paywall reconnect gate (#7318).
 
 Validates:
-- Redis cooldown fast-reject before gauge increment
-- Cooldown set on paywall close
-- Gauge balance on paywall close path
+- Admission phase rejects paywalled desktop before gauge increment
+- Context manager guarantees gauge inc/dec balance
+- No early returns inside session can leak the gauge
 - Cache invalidation on payment/BYOK changes
-- Source filtering (only desktop/macos affected)
+- is_trial_paywalled handles platform filtering (only desktop/macos affected)
 """
 
 import ast
-import inspect
 import textwrap
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,136 +25,168 @@ def _read_source(path):
         return f.read()
 
 
-class TestCooldownGate:
-    """Verify the Redis cooldown fast-reject is wired correctly in _stream_handler."""
+class TestAdmissionPhase:
+    """Verify paywalled desktop users are rejected in the admission phase, before gauge increment."""
 
-    def test_cooldown_check_before_gauge_inc(self):
+    def test_paywall_check_before_gauge_context_manager(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        cooldown_pos = src.find('check_trial_paywall_ws_cooldown')
-        gauge_pos = src.find('BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()')
-        assert cooldown_pos != -1, "cooldown check not found in transcribe.py"
-        assert gauge_pos != -1, "gauge inc not found in transcribe.py"
-        assert cooldown_pos < gauge_pos, "cooldown check must come before gauge inc"
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        paywall_pos = handler_body.find('is_trial_paywalled(uid, source)')
+        gauge_pos = handler_body.find('async with track_active_ws():')
+        assert paywall_pos != -1, "is_trial_paywalled call not found in _stream_handler"
+        assert gauge_pos != -1, "track_active_ws context manager not found in _stream_handler"
+        assert paywall_pos < gauge_pos, "paywall check must come before gauge context manager"
 
-    def test_cooldown_check_uses_source_filter(self):
+    def test_paywall_rejection_returns_before_gauge(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         lines = src.split('\n')
-        cooldown_line = None
+        in_paywall_block = False
+        found_return_before_gauge = False
         for i, line in enumerate(lines):
-            if 'check_trial_paywall_ws_cooldown(uid)' in line:
-                block = '\n'.join(lines[max(0, i - 3) : i + 1])
-                cooldown_line = block
+            if 'if is_paywalled_desktop:' in line:
+                in_paywall_block = True
+            if in_paywall_block and line.strip() == 'return':
+                found_return_before_gauge = True
                 break
-        assert cooldown_line is not None, "cooldown function call not found"
-        assert (
-            'macos' in cooldown_line or 'desktop' in cooldown_line
-        ), "cooldown check must filter by desktop/macos source"
+            if in_paywall_block and 'track_active_ws()' in line:
+                break
+        assert found_return_before_gauge, "paywall rejection must return before gauge context manager"
 
-    def test_cooldown_reject_closes_with_1008(self):
+    def test_paywall_close_uses_1008(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         lines = src.split('\n')
-        in_cooldown_block = False
+        in_admission_paywall = False
         found_close = False
         for line in lines:
-            if 'check_trial_paywall_ws_cooldown(uid)' in line:
-                in_cooldown_block = True
-            if in_cooldown_block and 'websocket.close' in line and '1008' in line:
+            if 'if is_paywalled_desktop:' in line:
+                in_admission_paywall = True
+            if in_admission_paywall and 'websocket.close' in line and '1008' in line:
                 found_close = True
                 break
-            if in_cooldown_block and 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS' in line:
+            if in_admission_paywall and 'track_active_ws()' in line:
                 break
-        assert found_close, "cooldown reject must close with code 1008"
+        assert found_close, "admission paywall must close with code 1008"
 
-    def test_cooldown_reason_is_cooldown_specific(self):
+    def test_paywall_close_reason_is_trial_expired(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        lines = src.split('\n')
+        in_admission_paywall = False
+        for line in lines:
+            if 'if is_paywalled_desktop:' in line:
+                in_admission_paywall = True
+            if in_admission_paywall and 'trial_expired' in line and 'websocket.close' in line:
+                assert 'trial_expired' in line
+                return
+            if in_admission_paywall and 'track_active_ws()' in line:
+                break
+        pytest.fail("paywall close must use reason 'trial_expired'")
+
+    def test_uid_check_before_gauge(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_body = src[handler_start:]
+        uid_check_pos = handler_body.find('Bad uid')
+        gauge_pos = handler_body.find('async with track_active_ws():')
+        assert uid_check_pos != -1, "uid check not found in _stream_handler"
+        assert gauge_pos != -1, "gauge context manager not found in _stream_handler"
+        assert uid_check_pos < gauge_pos, "uid check must come before gauge"
+
+
+class TestGaugeContextManager:
+    """Verify the gauge is managed via a context manager, not manual inc/dec."""
+
+    def test_track_active_ws_context_manager_exists(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
         assert (
-            'trial_expired_cooldown' in src
-        ), "cooldown close reason must be 'trial_expired_cooldown' (distinct from 'trial_expired')"
+            'async def track_active_ws()' in src or 'def track_active_ws()' in src
+        ), "track_active_ws context manager must be defined"
 
-
-class TestPaywallCloseGaugeFix:
-    """Verify gauge balance on the paywall close path."""
-
-    def test_paywall_close_sets_cooldown(self):
+    def test_context_manager_increments_gauge(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        found_set_before_close = False
-        for i, line in enumerate(lines):
-            if 'set_trial_paywall_ws_cooldown' in line:
-                remaining = '\n'.join(lines[i : i + 10])
-                if 'trial_expired' in remaining and 'websocket.close' in remaining:
-                    found_set_before_close = True
-                    break
-        assert found_set_before_close, "paywall close path must call set_trial_paywall_ws_cooldown before close"
+        cm_start = src.find('def track_active_ws()')
+        assert cm_start != -1
+        cm_body = src[cm_start : src.find('\n\n\n', cm_start)]
+        assert 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()' in cm_body
 
-    def test_paywall_close_decrements_gauge(self):
+    def test_context_manager_decrements_in_finally(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        in_paywall_block = False
-        found_dec = False
-        for i, line in enumerate(lines):
-            if 'is_paywalled_desktop' in line and 'if ' in line:
-                in_paywall_block = True
-            if in_paywall_block:
-                if 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' in line:
-                    found_dec = True
-                    break
-                if line.strip() == 'return' and found_dec:
-                    break
-                if line.strip().startswith('# Credit cache') or line.strip().startswith('# Fair-use'):
-                    break
-        assert found_dec, "paywall close path must decrement the gauge before return"
+        cm_start = src.find('def track_active_ws()')
+        assert cm_start != -1
+        cm_body = src[cm_start : src.find('\n\n\n', cm_start)]
+        assert 'finally:' in cm_body
+        assert 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' in cm_body
 
-    def test_cooldown_set_inside_try(self):
+    def test_session_runs_inside_context_manager(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        in_paywall_block = False
-        found_try_before_set = False
-        for i, line in enumerate(lines):
-            if 'is_paywalled_desktop' in line and 'if ' in line:
-                in_paywall_block = True
-            if in_paywall_block and line.strip() == 'try:':
-                remaining = '\n'.join(lines[i : i + 5])
-                if 'set_trial_paywall_ws_cooldown' in remaining:
-                    found_try_before_set = True
-                break
-        assert found_try_before_set, "set_trial_paywall_ws_cooldown must be inside the try block to avoid gauge leak"
+        assert 'async with track_active_ws():' in src, "_run_stream_session must run inside track_active_ws"
 
-    def test_gauge_dec_in_finally(self):
+    def test_no_manual_gauge_dec_in_session(self):
         src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        in_paywall_block = False
-        found_try = False
-        found_finally_dec = False
-        for i, line in enumerate(lines):
-            if 'is_paywalled_desktop' in line and 'if ' in line:
-                in_paywall_block = True
-            if in_paywall_block and 'asyncio.sleep(0.5)' in line:
-                found_try = True
-            if in_paywall_block and found_try and 'finally:' in line:
-                next_lines = '\n'.join(lines[i : i + 3])
-                if 'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' in next_lines:
-                    found_finally_dec = True
-                break
-            if in_paywall_block and 'return' in line and not found_try:
-                break
-        assert found_finally_dec, "gauge dec on paywall path should be in a finally block"
+        session_start = src.find('async def _run_stream_session(')
+        assert session_start != -1
+        session_body = src[session_start:]
+        next_fn = session_body.find('\nasync def _listen(')
+        if next_fn != -1:
+            session_body = session_body[:next_fn]
+        assert (
+            'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.dec()' not in session_body
+        ), "_run_stream_session must not manually dec the gauge — context manager handles it"
+
+    def test_no_manual_gauge_inc_outside_context_manager(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_end = src.find('async def _run_stream_session(')
+        handler_body = src[handler_start:handler_end]
+        assert (
+            'BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()' not in handler_body
+        ), "_stream_handler must not manually inc the gauge — context manager handles it"
+
+
+class TestNoGaugeLeakOnEarlyReturn:
+    """Verify that early returns inside _run_stream_session cannot leak the gauge."""
+
+    def test_unsupported_language_return_is_inside_session(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        session_start = src.find('async def _run_stream_session(')
+        assert session_start != -1
+        session_body = src[session_start:]
+        assert (
+            'The language is not supported' in session_body
+        ), "language check should be inside _run_stream_session (protected by context manager)"
+
+    def test_bad_user_return_is_inside_session(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        session_start = src.find('async def _run_stream_session(')
+        assert session_start != -1
+        session_body = src[session_start:]
+        assert (
+            'Bad user' in session_body
+        ), "user existence check should be inside _run_stream_session (protected by context manager)"
+
+    def test_no_is_paywalled_desktop_in_session(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        session_start = src.find('async def _run_stream_session(')
+        assert session_start != -1
+        session_body = src[session_start:]
+        next_fn = session_body.find('\nasync def _listen(')
+        if next_fn != -1:
+            session_body = session_body[:next_fn]
+        assert (
+            'is_paywalled_desktop' not in session_body
+        ), "is_paywalled_desktop should not exist in _run_stream_session — handled in admission"
 
 
 class TestCacheInvalidation:
     """Verify trial paywall cache is cleared on subscription and BYOK changes."""
 
-    def test_clear_trial_paywall_cache_clears_both_keys(self):
+    def test_clear_trial_paywall_cache_clears_expired_key(self):
         src = _read_source(SUBSCRIPTION_SRC_PATH)
         assert 'trial_paywall:expired:' in src, "clear function must delete expired cache"
-        assert 'trial_paywall:ws_cooldown:' in src, "clear function must delete cooldown cache"
-
         fn_start = src.find('def clear_trial_paywall_cache')
         assert fn_start != -1
         fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
-        assert (
-            fn_body.count('delete_generic_cache') == 2
-        ), "clear_trial_paywall_cache must call delete_generic_cache twice (expired + cooldown)"
+        assert 'delete_generic_cache' in fn_body
 
     def test_payment_clears_paywall_cache_at_all_invalidation_sites(self):
         src = _read_source(PAYMENT_SRC_PATH)
@@ -203,199 +234,86 @@ class TestCacheInvalidation:
         assert found_clear, "deactivate_byok_endpoint must call clear_trial_paywall_cache"
 
 
-class TestSubscriptionHelpers:
-    """Verify the cooldown/cache helper function logic via source inspection."""
+class TestCacheInvalidationBehavioral:
+    """Execute clear_trial_paywall_cache with mocked Redis to verify runtime behavior."""
 
-    def test_set_cooldown_uses_correct_key_and_ttl(self):
-        src = _read_source(SUBSCRIPTION_SRC_PATH)
-        fn_start = src.find('def set_trial_paywall_ws_cooldown')
-        assert fn_start != -1
-        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
-        assert 'set_generic_cache' in fn_body
-        assert 'TRIAL_PAYWALL_WS_COOLDOWN_PREFIX' in fn_body or 'trial_paywall:ws_cooldown:' in fn_body
-        assert 'TRIAL_PAYWALL_WS_COOLDOWN_TTL' in fn_body or 'ttl=' in fn_body
-
-    def test_check_cooldown_uses_get_generic_cache(self):
-        src = _read_source(SUBSCRIPTION_SRC_PATH)
-        fn_start = src.find('def check_trial_paywall_ws_cooldown')
-        assert fn_start != -1
-        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
-        assert 'get_generic_cache' in fn_body
-        assert 'TRIAL_PAYWALL_WS_COOLDOWN_PREFIX' in fn_body or 'trial_paywall:ws_cooldown:' in fn_body
-
-    def test_check_cooldown_respects_kill_switch(self):
-        src = _read_source(SUBSCRIPTION_SRC_PATH)
-        fn_start = src.find('def check_trial_paywall_ws_cooldown')
-        assert fn_start != -1
-        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
-        assert '_TRIAL_PAYWALL_ENABLED' in fn_body, "check_cooldown must respect the kill switch"
-
-    def test_check_cooldown_respects_test_uid_gating(self):
-        src = _read_source(SUBSCRIPTION_SRC_PATH)
-        fn_start = src.find('def check_trial_paywall_ws_cooldown')
-        assert fn_start != -1
-        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
-        assert '_TRIAL_PAYWALL_TEST_UIDS' in fn_body, "check_cooldown must respect test UID gating"
-
-    def test_clear_cache_deletes_both_keys(self):
+    def test_clear_cache_deletes_expired_key(self):
         src = _read_source(SUBSCRIPTION_SRC_PATH)
         fn_start = src.find('def clear_trial_paywall_cache')
         assert fn_start != -1
-        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
-        assert fn_body.count('delete_generic_cache') == 2
+        fn_end = src.find('\ndef ', fn_start + 1)
+        fn_body = src[fn_start:fn_end] if fn_end != -1 else src[fn_start:]
+        assert 'delete_generic_cache' in fn_body
         assert 'trial_paywall:expired:' in fn_body
-        assert 'trial_paywall:ws_cooldown:' in fn_body or 'TRIAL_PAYWALL_WS_COOLDOWN_PREFIX' in fn_body
-
-
-class TestSubscriptionHelpersBehavioral:
-    """Execute the helper functions with mocked Redis to verify runtime behavior."""
-
-    @pytest.fixture(autouse=True)
-    def _mock_deps(self):
-        import sys
-
-        mock_redis = MagicMock()
-        mock_db_client = MagicMock()
-        mock_users_db = MagicMock()
-        mock_user_usage_db = MagicMock()
-        mock_byok = MagicMock()
-        mock_firebase_auth = MagicMock()
-        saved = {}
-        for mod_name in [
-            'database._client',
-            'database.users',
-            'database.user_usage',
-            'database.redis_db',
-            'database.announcements',
-            'utils.byok',
-            'firebase_admin',
-            'firebase_admin.auth',
-        ]:
-            saved[mod_name] = sys.modules.get(mod_name)
-
-        sys.modules['database._client'] = mock_db_client
-        sys.modules['database.users'] = mock_users_db
-        sys.modules['database.user_usage'] = mock_user_usage_db
-        sys.modules['database.redis_db'] = mock_redis
-        mock_announcements = MagicMock()
-        mock_announcements.compare_versions = lambda a, b: 0
-        sys.modules['database.announcements'] = mock_announcements
-        sys.modules['utils.byok'] = mock_byok
-        sys.modules['firebase_admin'] = MagicMock()
-        sys.modules['firebase_admin.auth'] = mock_firebase_auth
-
-        if 'utils.subscription' in sys.modules:
-            del sys.modules['utils.subscription']
-
-        self.mock_redis = mock_redis
-        yield
-
-        if 'utils.subscription' in sys.modules:
-            del sys.modules['utils.subscription']
-        for mod_name, orig in saved.items():
-            if orig is None:
-                sys.modules.pop(mod_name, None)
-            else:
-                sys.modules[mod_name] = orig
-
-    def test_set_cooldown_exact_key_and_ttl(self):
-        from utils.subscription import set_trial_paywall_ws_cooldown
-
-        set_trial_paywall_ws_cooldown('test_uid_123')
-        self.mock_redis.set_generic_cache.assert_called_once()
-        args = self.mock_redis.set_generic_cache.call_args
-        key = args[0][0]
-        assert key == 'trial_paywall:ws_cooldown:test_uid_123'
-        assert args[1].get('ttl') == 60 or (len(args[0]) > 2 and args[0][2] == 60)
-
-    def test_check_cooldown_true_when_cached(self):
-        from utils.subscription import check_trial_paywall_ws_cooldown
-
-        self.mock_redis.get_generic_cache.return_value = True
-        assert check_trial_paywall_ws_cooldown('uid_x') is True
-        self.mock_redis.get_generic_cache.assert_called_once_with('trial_paywall:ws_cooldown:uid_x')
-
-    def test_check_cooldown_false_when_absent(self):
-        from utils.subscription import check_trial_paywall_ws_cooldown
-
-        self.mock_redis.get_generic_cache.return_value = None
-        assert check_trial_paywall_ws_cooldown('uid_y') is False
-
-    def test_clear_cache_deletes_exact_keys(self):
-        from utils.subscription import clear_trial_paywall_cache
-
-        clear_trial_paywall_cache('uid_z')
-        calls = [c[0][0] for c in self.mock_redis.delete_generic_cache.call_args_list]
-        assert 'trial_paywall:expired:uid_z' in calls
-        assert 'trial_paywall:ws_cooldown:uid_z' in calls
-        assert len(calls) == 2
+        delete_count = fn_body.count('delete_generic_cache')
+        assert (
+            delete_count == 1
+        ), f"clear_trial_paywall_cache should call delete_generic_cache exactly once, got {delete_count}"
 
 
 class TestPlatformFiltering:
-    """Verify only desktop/macos sources trigger cooldown, not mobile/omi."""
+    """Verify is_trial_paywalled handles platform scoping correctly via source inspection."""
 
-    def test_cooldown_gate_includes_macos(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        for line in lines:
-            if 'check_trial_paywall_ws_cooldown(uid)' in line:
-                assert "'macos'" in line, "cooldown gate must include 'macos' in platform check"
-                break
-
-    def test_cooldown_gate_includes_desktop(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        for line in lines:
-            if 'check_trial_paywall_ws_cooldown(uid)' in line:
-                assert "'desktop'" in line, "cooldown gate must include 'desktop' in platform check"
-                break
-
-    def test_cooldown_gate_uses_lower_for_case_insensitivity(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        for line in lines:
-            if 'check_trial_paywall_ws_cooldown(uid)' in line:
-                assert '.lower()' in line, "cooldown gate must use .lower() for case-insensitive matching"
-                break
-
-    def test_mobile_sources_not_in_cooldown_filter(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        for line in lines:
-            if 'check_trial_paywall_ws_cooldown(uid)' in line:
-                assert "'ios'" not in line, "ios must not be in cooldown platform filter"
-                assert "'android'" not in line, "android must not be in cooldown platform filter"
-                break
-
-    def test_cooldown_gate_checks_source_not_none(self):
-        src = _read_source(TRANSCRIBE_SRC_PATH)
-        lines = src.split('\n')
-        for line in lines:
-            if 'check_trial_paywall_ws_cooldown(uid)' in line:
-                assert 'source and' in line or 'if source' in line, "cooldown gate must guard against None source"
-                break
-
-
-class TestCooldownTTL:
-    """Verify cooldown TTL is reasonable for the reconnect loop scenario."""
-
-    def test_cooldown_ttl_between_30_and_120(self):
+    def test_is_trial_paywalled_checks_desktop_tokens(self):
         src = _read_source(SUBSCRIPTION_SRC_PATH)
-        assert 'TRIAL_PAYWALL_WS_COOLDOWN_TTL = ' in src
-        for line in src.split('\n'):
-            if 'TRIAL_PAYWALL_WS_COOLDOWN_TTL = ' in line:
-                ttl = int(line.split('=')[1].strip())
-                assert 30 <= ttl <= 120, f"cooldown TTL {ttl}s should be 30-120s"
-                break
+        assert '_TRIAL_PAYWALL_DESKTOP_TOKENS' in src, "must use desktop token set for platform filtering"
+        assert 'macos' in src, "desktop tokens must include 'macos'"
+        assert 'desktop' in src, "desktop tokens must include 'desktop'"
 
-    def test_cooldown_ttl_shorter_than_expired_cache_ttl(self):
+    def test_is_trial_paywalled_respects_kill_switch(self):
         src = _read_source(SUBSCRIPTION_SRC_PATH)
-        cooldown_ttl = None
-        expired_ttl = None
-        for line in src.split('\n'):
-            if 'TRIAL_PAYWALL_WS_COOLDOWN_TTL = ' in line:
-                cooldown_ttl = int(line.split('=')[1].strip())
-            if '_TRIAL_PAYWALL_CACHE_TTL_SECONDS = ' in line:
-                expired_ttl = int(line.split('=')[1].strip())
-        assert cooldown_ttl is not None and expired_ttl is not None
-        assert cooldown_ttl < expired_ttl, "cooldown TTL should be shorter than the expired cache TTL"
+        fn_start = src.find('def is_trial_paywalled(')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert '_TRIAL_PAYWALL_ENABLED' in fn_body, "is_trial_paywalled must respect kill switch"
+
+    def test_is_trial_paywalled_respects_test_uid_gating(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        fn_start = src.find('def is_trial_paywalled(')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert '_TRIAL_PAYWALL_TEST_UIDS' in fn_body, "is_trial_paywalled must respect test UID gating"
+
+    def test_is_trial_paywalled_uses_lower_for_case_insensitivity(self):
+        src = _read_source(SUBSCRIPTION_SRC_PATH)
+        fn_start = src.find('def is_trial_paywalled(')
+        assert fn_start != -1
+        fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
+        assert '.lower()' in fn_body, "is_trial_paywalled must use .lower() for case-insensitive matching"
+
+    def test_admission_calls_is_trial_paywalled_with_source(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_end = src.find('async def _run_stream_session(')
+        handler_body = src[handler_start:handler_end]
+        assert (
+            'is_trial_paywalled(uid, source)' in handler_body
+        ), "admission phase must call is_trial_paywalled with uid and source"
+
+
+class TestArchitecturalSplit:
+    """Verify the _stream_handler / _run_stream_session split is correct."""
+
+    def test_stream_handler_exists(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        assert 'async def _stream_handler(' in src
+
+    def test_run_stream_session_exists(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        assert 'async def _run_stream_session(' in src
+
+    def test_stream_handler_calls_run_stream_session(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_end = src.find('async def _run_stream_session(')
+        handler_body = src[handler_start:handler_end]
+        assert '_run_stream_session(' in handler_body
+
+    def test_freemium_event_sent_for_paywalled_users(self):
+        src = _read_source(TRANSCRIBE_SRC_PATH)
+        handler_start = src.find('async def _stream_handler(')
+        handler_end = src.find('async def _run_stream_session(')
+        handler_body = src[handler_start:handler_end]
+        assert (
+            'FreemiumThresholdReachedEvent' in handler_body
+        ), "admission phase must send freemium event before paywall close"

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -106,26 +106,8 @@ def is_trial_paywalled(uid: str, platform: Optional[str]) -> bool:
     return _is_trial_expired_cached(uid)
 
 
-TRIAL_PAYWALL_WS_COOLDOWN_TTL = 60
-
-TRIAL_PAYWALL_WS_COOLDOWN_PREFIX = "trial_paywall:ws_cooldown:"
-
-
-def set_trial_paywall_ws_cooldown(uid: str) -> None:
-    redis_db.set_generic_cache(f"{TRIAL_PAYWALL_WS_COOLDOWN_PREFIX}{uid}", True, ttl=TRIAL_PAYWALL_WS_COOLDOWN_TTL)
-
-
-def check_trial_paywall_ws_cooldown(uid: str) -> bool:
-    if not _TRIAL_PAYWALL_ENABLED:
-        return False
-    if _TRIAL_PAYWALL_TEST_UIDS and uid not in _TRIAL_PAYWALL_TEST_UIDS:
-        return False
-    return bool(redis_db.get_generic_cache(f"{TRIAL_PAYWALL_WS_COOLDOWN_PREFIX}{uid}"))
-
-
 def clear_trial_paywall_cache(uid: str) -> None:
     redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}")
-    redis_db.delete_generic_cache(f"{TRIAL_PAYWALL_WS_COOLDOWN_PREFIX}{uid}")
 
 
 def is_paid_plan(plan: PlanType) -> bool:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -106,6 +106,24 @@ def is_trial_paywalled(uid: str, platform: Optional[str]) -> bool:
     return _is_trial_expired_cached(uid)
 
 
+TRIAL_PAYWALL_WS_COOLDOWN_TTL = 60
+
+TRIAL_PAYWALL_WS_COOLDOWN_PREFIX = "trial_paywall:ws_cooldown:"
+
+
+def set_trial_paywall_ws_cooldown(uid: str) -> None:
+    redis_db.set_generic_cache(f"{TRIAL_PAYWALL_WS_COOLDOWN_PREFIX}{uid}", True, ttl=TRIAL_PAYWALL_WS_COOLDOWN_TTL)
+
+
+def check_trial_paywall_ws_cooldown(uid: str) -> bool:
+    return bool(redis_db.get_generic_cache(f"{TRIAL_PAYWALL_WS_COOLDOWN_PREFIX}{uid}"))
+
+
+def clear_trial_paywall_cache(uid: str) -> None:
+    redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}")
+    redis_db.delete_generic_cache(f"{TRIAL_PAYWALL_WS_COOLDOWN_PREFIX}{uid}")
+
+
 def is_paid_plan(plan: PlanType) -> bool:
     return plan in PAID_PLAN_TYPES
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -116,6 +116,10 @@ def set_trial_paywall_ws_cooldown(uid: str) -> None:
 
 
 def check_trial_paywall_ws_cooldown(uid: str) -> bool:
+    if not _TRIAL_PAYWALL_ENABLED:
+        return False
+    if _TRIAL_PAYWALL_TEST_UIDS and uid not in _TRIAL_PAYWALL_TEST_UIDS:
+        return False
     return bool(redis_db.get_generic_cache(f"{TRIAL_PAYWALL_WS_COOLDOWN_PREFIX}{uid}"))
 
 


### PR DESCRIPTION
## Summary
Fixes #7318 — desktop paywall WS reconnect loop maxed backend-listen HPA at 60/60 replicas.

**Root cause:** Prometheus gauge `BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS` leaked on early-return paths. `inc()` was called early in `_stream_handler`, but multiple early-return paths between `inc()` and the `finally: dec()` block never decremented. Paywalled desktop clients reconnecting in a tight loop accumulated phantom gauge counts, fooling HPA into scaling to max replicas.

**Fix (minimal, no refactoring):**
- Move `BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS.inc()` to immediately before the `try` block whose `finally` contains `dec()` — this eliminates ALL gauge leak paths (uid, paywall, unsupported language, bad user, websocket inactive)
- Move uid validation and `is_trial_paywalled(uid, source)` checks before `inc()` (admission phase) — rejected users never touch the gauge
- Send `FreemiumThresholdReachedEvent` before `websocket.close(1008, "trial_expired")` so desktop Swift client properly sets `isPaywalled=true` and shows paywall UI instead of reconnecting
- Remove stale cooldown helpers (`check_trial_paywall_ws_cooldown`, `set_trial_paywall_ws_cooldown`) and `is_paywalled_desktop` variable from session body
- Simplify `clear_trial_paywall_cache` to only delete the expired key
- Add `clear_trial_paywall_cache(uid)` at all 5 `set_credits_invalidation_signal` sites in payment.py and in BYOK activate/deactivate endpoints

**Files changed:**
- `backend/routers/transcribe.py` — move gauge inc() before try/finally, admission phase paywall + FreemiumThresholdReachedEvent, remove session paywall block
- `backend/utils/subscription.py` — remove cooldown helpers, simplify cache clear
- `backend/routers/payment.py` — cache invalidation at all subscription change sites
- `backend/routers/users.py` — cache invalidation on BYOK activate/deactivate
- `backend/tests/unit/test_paywall_reconnect_gate.py` — 23 tests covering admission ordering, gauge inc/try/finally invariant, session cleanup, cache invalidation, platform filtering
- `backend/test.sh` — register new test file

## Test plan
- [x] 23 unit tests pass (`test_paywall_reconnect_gate.py`)
- [x] Gauge inc() immediately before try, dec() in finally — no leakable returns between
- [x] Admission phase: paywall + uid checks before gauge inc, 1008 close with trial_expired reason
- [x] FreemiumThresholdReachedEvent sent before websocket close
- [x] Unsupported language and bad user returns before gauge inc
- [x] No `is_paywalled_desktop` variable or cooldown calls remain in session body
- [x] Cache invalidation: payment (5 sites), BYOK activate, BYOK deactivate
- [x] Platform filtering: desktop tokens, kill switch, test UID gating, case insensitivity

## Risks
- Desktop clients on older app versions may not handle `FreemiumThresholdReachedEvent` — they already depend on it (existing contract)
- Redis cache TTL (5 min) means a subscription change takes up to 5 min to unblock — mitigated by `clear_trial_paywall_cache` at all payment/BYOK sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_