### PR TITLE
fix(backend): tag BYOK LLM errors by source

### DIFF
--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -25,7 +25,7 @@ from utils.app_integrations import (
     trigger_external_integrations,
 )
 from utils.conversations.location import async_get_google_maps_location
-from utils.byok import set_byok_keys
+from utils.byok import set_byok_keys, set_byok_uid
 from utils.conversations.process_conversation import process_conversation
 from utils.executors import db_executor, storage_executor, run_blocking
 from utils.async_tasks import supervise_tasks, drain_tasks, create_named_task, wait_for_event
@@ -91,6 +91,7 @@ async def _process_conversation_task(
     """
     if byok_keys:
         set_byok_keys(byok_keys)
+        set_byok_uid(uid)
     try:
         conversation_data = await run_blocking(db_executor, conversations_db.get_conversation, uid, conversation_id)
         if not conversation_data:

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -59,7 +59,7 @@ from utils.other.storage import (
 )
 
 from utils import encryption
-from utils.byok import get_byok_keys, set_byok_keys
+from utils.byok import get_byok_keys, set_byok_keys, set_byok_uid
 from utils.http_client import _get_semaphore
 from utils.log_sanitizer import sanitize
 from utils.stt.pre_recorded import postprocess_words, prerecorded
@@ -1390,6 +1390,7 @@ async def _run_full_pipeline_background_async(
     slots — only leaf operations use threads, and only for their actual duration.
     """
     async with _get_sync_pipeline_semaphore():
+        set_byok_uid(uid if get_byok_keys() else None)
         segmented_paths = set()
         wav_paths = []
         stage_timings = {}
@@ -1638,6 +1639,7 @@ async def _run_full_pipeline_background_async(
                 pass
         finally:
             set_byok_keys({})
+            set_byok_uid(None)
             await run_blocking(storage_executor, _cleanup_files, list(segmented_paths))
             await run_blocking(storage_executor, _cleanup_files, wav_paths)
             try:

--- a/backend/tests/unit/test_byok_llm_logging.py
+++ b/backend/tests/unit/test_byok_llm_logging.py
@@ -1,0 +1,194 @@
+import os
+import sys
+import types
+from importlib.util import find_spec
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-for-unit-tests')
+os.environ.setdefault('ANTHROPIC_API_KEY', 'ant-test-fake-for-unit-tests')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+sys.modules.setdefault('database._client', MagicMock())
+llm_usage_stub = types.ModuleType('database.llm_usage')
+llm_usage_stub.record_llm_usage = MagicMock()
+sys.modules.setdefault('database.llm_usage', llm_usage_stub)
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return find_spec(name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+if not _module_available('cachetools'):
+    cachetools_stub = types.ModuleType('cachetools')
+
+    class _TTLCache(dict):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    cachetools_stub.TTLCache = _TTLCache
+    sys.modules['cachetools'] = cachetools_stub
+
+if not _module_available('fastapi'):
+    fastapi_stub = types.ModuleType('fastapi')
+
+    class _HTTPException(Exception):
+        def __init__(self, status_code: int = 500, detail: str = ''):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    fastapi_stub.HTTPException = _HTTPException
+    fastapi_stub.Request = MagicMock()
+    sys.modules['fastapi'] = fastapi_stub
+
+if not _module_available('starlette.middleware.base'):
+    starlette_stub = types.ModuleType('starlette')
+    middleware_stub = types.ModuleType('starlette.middleware')
+    base_stub = types.ModuleType('starlette.middleware.base')
+    base_stub.BaseHTTPMiddleware = object
+    sys.modules.setdefault('starlette', starlette_stub)
+    sys.modules.setdefault('starlette.middleware', middleware_stub)
+    sys.modules['starlette.middleware.base'] = base_stub
+
+if not _module_available('starlette.websockets'):
+    websockets_stub = types.ModuleType('starlette.websockets')
+    websockets_stub.WebSocket = MagicMock()
+    sys.modules['starlette.websockets'] = websockets_stub
+
+
+class _HTTPError(Exception):
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def test_classify_byok_llm_error_authentication():
+    from utils.llm.byok_errors import classify_byok_llm_error
+
+    assert classify_byok_llm_error(_HTTPError("bad api key", 401)) == 'invalid'
+
+
+def test_classify_byok_llm_error_permission():
+    from utils.llm.byok_errors import classify_byok_llm_error
+
+    assert classify_byok_llm_error(_HTTPError("project denied", 403)) == 'permission'
+
+
+def test_classify_byok_llm_error_insufficient_quota():
+    from utils.llm.byok_errors import classify_byok_llm_error
+
+    assert classify_byok_llm_error(_HTTPError("insufficient_quota", 429)) == 'quota'
+
+
+def test_classify_byok_llm_error_ignores_transient_rate_limit():
+    from utils.llm.byok_errors import classify_byok_llm_error
+
+    assert classify_byok_llm_error(_HTTPError("rate limit reached, retry later", 429)) is None
+
+
+@patch('utils.llm.byok_errors.get_byok_uid', return_value='user-1')
+@patch('utils.llm.byok_errors.get_byok_key', return_value='sk-user')
+def test_handle_llm_error_logs_byok_source(mock_get_key, mock_get_uid):
+    from utils.llm.byok_errors import handle_llm_error
+
+    with patch('utils.llm.byok_errors.logger.error') as mock_log:
+        handle_llm_error(_HTTPError("insufficient_quota", 429), 'openai', feature='memories', model='gpt-test')
+
+    log_args = mock_log.call_args.args
+    assert 'LLM error source=%s' in log_args[0]
+    assert log_args[1] == 'byok'
+    assert log_args[2] == 'openai'
+    assert log_args[8] == 'quota'
+
+
+@patch('utils.llm.byok_errors.get_byok_uid', return_value='user-1')
+@patch('utils.llm.byok_errors.get_byok_key', return_value=None)
+def test_handle_llm_error_logs_platform_source(mock_get_key, mock_get_uid):
+    from utils.llm.byok_errors import handle_llm_error
+
+    with patch('utils.llm.byok_errors.logger.error') as mock_log:
+        handle_llm_error(_HTTPError("server error", 500), 'openai', feature='memories', model='gpt-test')
+
+    assert mock_log.call_args.args[1] == 'platform'
+    assert mock_log.call_args.args[8] == 'unknown'
+
+
+def test_validate_byok_request_records_current_uid():
+    from utils.byok import get_byok_uid, validate_byok_request
+
+    with patch('utils.byok._check_byok_validity', return_value=None):
+        validate_byok_request('user-1')
+
+    assert get_byok_uid() == 'user-1'
+
+
+def test_llm_error_callback_uses_provider_context():
+    class _BaseCallbackHandler:
+        pass
+
+    class _DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def bind(self, *args, **kwargs):
+            return self
+
+    class _DummyParser:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _DummyEncoding:
+        def encode(self, value):
+            return value.split()
+
+    anthropic_stub = types.ModuleType('anthropic')
+    anthropic_stub.AsyncAnthropic = _DummyClient
+
+    callbacks_stub = types.ModuleType('langchain_core.callbacks')
+    callbacks_stub.BaseCallbackHandler = _BaseCallbackHandler
+    language_models_stub = types.ModuleType('langchain_core.language_models')
+    language_models_stub.BaseChatModel = _DummyClient
+    output_parsers_stub = types.ModuleType('langchain_core.output_parsers')
+    output_parsers_stub.PydanticOutputParser = _DummyParser
+
+    google_genai_stub = types.ModuleType('langchain_google_genai')
+    google_genai_stub.ChatGoogleGenerativeAI = _DummyClient
+    openai_stub = types.ModuleType('langchain_openai')
+    openai_stub.ChatOpenAI = _DummyClient
+    openai_stub.OpenAIEmbeddings = _DummyClient
+    tiktoken_stub = types.ModuleType('tiktoken')
+    tiktoken_stub.encoding_for_model = MagicMock(return_value=_DummyEncoding())
+    structured_stub = types.ModuleType('models.structured')
+    structured_stub.Structured = MagicMock()
+    usage_tracker_stub = types.ModuleType('utils.llm.usage_tracker')
+    usage_tracker_stub.get_usage_callback = MagicMock(return_value=object())
+
+    module_stubs = {
+        'anthropic': anthropic_stub,
+        'langchain_core.callbacks': callbacks_stub,
+        'langchain_core.language_models': language_models_stub,
+        'langchain_core.output_parsers': output_parsers_stub,
+        'langchain_google_genai': google_genai_stub,
+        'langchain_openai': openai_stub,
+        'tiktoken': tiktoken_stub,
+        'models.structured': structured_stub,
+        'utils.llm.usage_tracker': usage_tracker_stub,
+    }
+
+    with patch.dict(sys.modules, module_stubs):
+        sys.modules.pop('utils.llm.clients', None)
+        from utils.llm.clients import _LLMErrorCallback
+
+        callback = _LLMErrorCallback('openai', model='gpt-test', feature='memories')
+        error = _HTTPError('bad key', 401)
+
+        with patch('utils.llm.clients.handle_llm_error') as mock_handle:
+            callback.on_llm_error(error)
+
+        mock_handle.assert_called_once()
+        assert mock_handle.call_args.args[:2] == (error, 'openai')
+
+    sys.modules.pop('utils.llm.clients', None)

--- a/backend/tests/unit/test_byok_llm_logging.py
+++ b/backend/tests/unit/test_byok_llm_logging.py
@@ -15,9 +15,11 @@ sys.modules.setdefault('database.llm_usage', llm_usage_stub)
 
 
 def _module_available(name: str) -> bool:
+    if name in sys.modules:
+        return True
     try:
         return find_spec(name) is not None
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ValueError):
         return False
 
 
@@ -190,5 +192,71 @@ def test_llm_error_callback_uses_provider_context():
 
         mock_handle.assert_called_once()
         assert mock_handle.call_args.args[:2] == (error, 'openai')
+
+    sys.modules.pop('utils.llm.clients', None)
+
+
+def test_openai_embeddings_proxy_tags_sync_byok_failure():
+    """The explicit sync embed_query/embed_documents methods bypass the
+    __getattr__ wrapper, so route their BYOK failures through handle_llm_error
+    (for source tagging) before falling back to Omi's key."""
+
+    class _DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    anthropic_stub = types.ModuleType('anthropic')
+    anthropic_stub.AsyncAnthropic = _DummyClient
+    callbacks_stub = types.ModuleType('langchain_core.callbacks')
+    callbacks_stub.BaseCallbackHandler = object
+    language_models_stub = types.ModuleType('langchain_core.language_models')
+    language_models_stub.BaseChatModel = _DummyClient
+    output_parsers_stub = types.ModuleType('langchain_core.output_parsers')
+    output_parsers_stub.PydanticOutputParser = _DummyClient
+    google_genai_stub = types.ModuleType('langchain_google_genai')
+    google_genai_stub.ChatGoogleGenerativeAI = _DummyClient
+    openai_stub = types.ModuleType('langchain_openai')
+    openai_stub.ChatOpenAI = _DummyClient
+    openai_stub.OpenAIEmbeddings = _DummyClient
+    tiktoken_stub = types.ModuleType('tiktoken')
+    tiktoken_stub.encoding_for_model = MagicMock(return_value=MagicMock())
+    structured_stub = types.ModuleType('models.structured')
+    structured_stub.Structured = MagicMock()
+    usage_tracker_stub = types.ModuleType('utils.llm.usage_tracker')
+    usage_tracker_stub.get_usage_callback = MagicMock(return_value=object())
+
+    module_stubs = {
+        'anthropic': anthropic_stub,
+        'langchain_core.callbacks': callbacks_stub,
+        'langchain_core.language_models': language_models_stub,
+        'langchain_core.output_parsers': output_parsers_stub,
+        'langchain_google_genai': google_genai_stub,
+        'langchain_openai': openai_stub,
+        'tiktoken': tiktoken_stub,
+        'models.structured': structured_stub,
+        'utils.llm.usage_tracker': usage_tracker_stub,
+    }
+
+    with patch.dict(sys.modules, module_stubs):
+        sys.modules.pop('utils.llm.clients', None)
+        from utils.llm.clients import _OpenAIEmbeddingsProxy
+
+        default = MagicMock()
+        default.embed_query.return_value = [0.1, 0.2]
+        proxy = _OpenAIEmbeddingsProxy('text-embedding-3-small', default, {})
+
+        byok_inst = MagicMock()
+        byok_inst.embed_query.side_effect = _HTTPError('invalid_api_key', 401)
+
+        with patch.object(_OpenAIEmbeddingsProxy, '_resolve', return_value=byok_inst), patch(
+            'utils.llm.clients.handle_llm_error'
+        ) as mock_handle:
+            result = proxy.embed_query('hello world')
+
+        mock_handle.assert_called_once()
+        assert mock_handle.call_args.args[1] == 'openai'
+        assert mock_handle.call_args.kwargs.get('operation') == 'embed_query'
+        default.embed_query.assert_called_once_with('hello world')
+        assert result == [0.1, 0.2]
 
     sys.modules.pop('utils.llm.clients', None)

--- a/backend/tests/unit/test_byok_llm_logging.py
+++ b/backend/tests/unit/test_byok_llm_logging.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-fake-for-unit-tests')
 os.environ.setdefault('ANTHROPIC_API_KEY', 'ant-test-fake-for-unit-tests')
-os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_test-fake-encryption-secret-for-unit-tests')
 
 sys.modules.setdefault('database._client', MagicMock())
 llm_usage_stub = types.ModuleType('database.llm_usage')

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -844,6 +844,13 @@ class TestAsyncCoordinatorStructure:
         finally_idx = body.rindex('finally:')
         after_finally = body[finally_idx:]
         assert 'set_byok_keys({})' in after_finally
+        assert 'set_byok_uid(None)' in after_finally
+
+    def test_async_coordinator_sets_byok_uid_from_context(self):
+        """Async coordinator must attach uid when inherited BYOK keys are present."""
+        body = self._get_bg_func_body()
+        setup_section = body[body.index('async with _get_sync_pipeline_semaphore') : body.index('try:')]
+        assert 'set_byok_uid(uid if get_byok_keys() else None)' in setup_section
 
     def test_async_coordinator_handles_empty_decode(self):
         """Async coordinator must handle empty wav_paths (complete with 0 segments)."""
@@ -1309,6 +1316,7 @@ class TestAsyncCoordinatorBehavioral:
         sys.modules['utils.fair_use'].trigger_classifier_if_needed = MagicMock()
         sys.modules['utils.fair_use'].record_dg_usage_ms = MagicMock()
         sys.modules['utils.byok'].set_byok_keys = MagicMock()
+        sys.modules['utils.byok'].set_byok_uid = MagicMock()
         sys.modules['utils.byok'].get_byok_keys = MagicMock(return_value={})
         sys.modules['utils.analytics'].record_usage = MagicMock()
         sys.modules['models.conversation_enums'].ConversationSource = MagicMock()
@@ -2192,6 +2200,18 @@ class TestBYOKContextPropagation:
         func_body = source[start:next_boundary]
 
         assert 'set_byok_keys({})' in func_body, "Async coordinator must clear BYOK keys in finally"
+        assert 'set_byok_uid(None)' in func_body, "Async coordinator must clear BYOK uid in finally"
+
+    def test_async_coordinator_sets_byok_uid_before_work(self):
+        """Async coordinator must attach the uid to inherited BYOK key context."""
+        source = self._read_sync_source()
+        start = source.index('async def _run_full_pipeline_background_async')
+        next_boundary = source.find('\n@router.', start + 1)
+        if next_boundary == -1:
+            next_boundary = len(source)
+        func_body = source[start:next_boundary]
+
+        assert 'set_byok_uid(uid if get_byok_keys() else None)' in func_body
 
     def test_no_plain_submit_in_sync(self):
         """All executor .submit() calls in sync.py must use submit_with_context."""

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -73,6 +73,7 @@ BYOK_HEADERS = {
 # Keys for the current request, if the client supplied them.
 # Default is None (not {}) to avoid sharing a mutable object across contexts.
 _byok_ctx: ContextVar[Optional[Dict[str, str]]] = ContextVar('byok_keys', default=None)
+_byok_uid_ctx: ContextVar[Optional[str]] = ContextVar('byok_uid', default=None)
 
 
 def get_byok_keys() -> Dict[str, str]:
@@ -85,6 +86,16 @@ def get_byok_key(provider: str) -> Optional[str]:
     if keys is None:
         return None
     return keys.get(provider)
+
+
+def get_byok_uid() -> Optional[str]:
+    """Return the authenticated uid for the current request, when known."""
+    return _byok_uid_ctx.get()
+
+
+def set_byok_uid(uid: Optional[str]) -> None:
+    """Attach the authenticated uid to the current request context."""
+    _byok_uid_ctx.set(uid)
 
 
 def has_byok_keys() -> bool:
@@ -127,10 +138,12 @@ class BYOKMiddleware(BaseHTTPMiddleware):
             if value:
                 keys[provider] = value
         token = _byok_ctx.set(keys)
+        uid_token = _byok_uid_ctx.set(None)
         try:
             return await call_next(request)
         finally:
             _byok_ctx.reset(token)
+            _byok_uid_ctx.reset(uid_token)
 
 
 # ---------------------------------------------------------------------------
@@ -203,6 +216,7 @@ def validate_byok_request(uid: str) -> None:
     if error:
         logger.warning('BYOK validation failed uid=%s: %s', uid, error)
         raise HTTPException(status_code=403, detail=error)
+    set_byok_uid(uid)
 
 
 def validate_byok_websocket(uid: str) -> Optional[str]:
@@ -215,4 +229,6 @@ def validate_byok_websocket(uid: str) -> Optional[str]:
     error = _check_byok_validity(uid)
     if error:
         logger.warning('BYOK WS validation failed uid=%s: %s', uid, error)
+    else:
+        set_byok_uid(uid)
     return error

--- a/backend/utils/llm/byok_errors.py
+++ b/backend/utils/llm/byok_errors.py
@@ -1,0 +1,90 @@
+import asyncio
+import logging
+from typing import Optional
+
+from utils.byok import get_byok_key, get_byok_uid
+from utils.executors import storage_executor, submit_with_context
+from utils.log_sanitizer import sanitize
+
+logger = logging.getLogger(__name__)
+
+_QUOTA_ERROR_NAMES = frozenset({'RateLimitError'})
+
+
+def get_llm_error_source(provider: Optional[str]) -> str:
+    """Return platform/byok for the current request and provider."""
+    if provider and get_byok_key(provider):
+        return 'byok'
+    return 'platform'
+
+
+def classify_byok_llm_error(error: Exception) -> Optional[str]:
+    """Classify user-actionable BYOK failures for structured logging."""
+    status_code = _get_status_code(error)
+    error_name = type(error).__name__
+    error_text = sanitize(str(error)).lower()
+
+    if status_code == 401 or error_name == 'AuthenticationError':
+        return 'invalid'
+    if status_code == 403 or error_name == 'PermissionDeniedError':
+        return 'permission'
+    if status_code == 429 or error_name in _QUOTA_ERROR_NAMES:
+        if 'insufficient_quota' in error_text or 'quota' in error_text:
+            return 'quota'
+    return None
+
+
+def handle_llm_error(
+    error: Exception,
+    provider: Optional[str],
+    feature: Optional[str] = None,
+    model: Optional[str] = None,
+    operation: str = 'chat',
+) -> None:
+    """Log LLM failures with source context."""
+    source = get_llm_error_source(provider)
+    reason = classify_byok_llm_error(error) if source == 'byok' else None
+    uid = get_byok_uid()
+    status_code = _get_status_code(error)
+
+    logger.error(
+        'LLM error source=%s provider=%s feature=%s model=%s operation=%s uid=%s status_code=%s reason=%s '
+        'error_type=%s error=%s',
+        source,
+        provider or 'unknown',
+        feature or 'unknown',
+        model or 'unknown',
+        operation,
+        uid or 'unknown',
+        status_code or 'unknown',
+        reason or 'unknown',
+        type(error).__name__,
+        sanitize(str(error)),
+    )
+
+
+async def handle_llm_error_async(
+    error: Exception,
+    provider: Optional[str],
+    feature: Optional[str] = None,
+    model: Optional[str] = None,
+    operation: str = 'chat',
+) -> None:
+    """Run LLM error handling off the event loop while preserving BYOK context."""
+    future = submit_with_context(storage_executor, handle_llm_error, error, provider, feature, model, operation)
+    try:
+        await asyncio.wrap_future(future)
+    except Exception as e:
+        logger.error('Async LLM error handler failed provider=%s feature=%s: %s', provider, feature, e)
+
+
+def _get_status_code(error: Exception) -> Optional[int]:
+    status_code = getattr(error, 'status_code', None)
+    if isinstance(status_code, int):
+        return status_code
+
+    response = getattr(error, 'response', None)
+    response_status = getattr(response, 'status_code', None)
+    if isinstance(response_status, int):
+        return response_status
+    return None

--- a/backend/utils/llm/byok_errors.py
+++ b/backend/utils/llm/byok_errors.py
@@ -75,7 +75,9 @@ async def handle_llm_error_async(
     try:
         await asyncio.wrap_future(future)
     except Exception as e:
-        logger.error('Async LLM error handler failed provider=%s feature=%s: %s', provider, feature, e)
+        logger.error(
+            'Async LLM error handler failed provider=%s feature=%s: %s', provider, feature, sanitize(str(e))
+        )
 
 
 def _get_status_code(error: Exception) -> Optional[int]:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import anthropic
 import httpx
 from cachetools import TTLCache
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseChatModel
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -14,11 +15,48 @@ import tiktoken
 
 from models.structured import Structured
 from utils.byok import get_byok_key
+from utils.llm.byok_errors import handle_llm_error
 from utils.llm.usage_tracker import get_usage_callback
 
 logger = logging.getLogger(__name__)
 
 _usage_callback = get_usage_callback()
+
+
+class _LLMErrorCallback(BaseCallbackHandler):
+    """LangChain callback that tags provider errors with platform/BYOK source."""
+
+    def __init__(self, provider: str, model: str = '', feature: str = ''):
+        self.provider = provider
+        self.model = model
+        self.feature = feature
+
+    def on_llm_error(self, error: BaseException, **kwargs) -> None:
+        if isinstance(error, Exception):
+            handle_llm_error(error, self.provider, feature=self.feature, model=self.model)
+
+
+_llm_error_callbacks: Dict[Tuple[str, str, str], _LLMErrorCallback] = {}
+
+
+def _get_llm_error_callback(provider: str, model: str = '', feature: str = '') -> _LLMErrorCallback:
+    key = (provider, model, feature)
+    if key not in _llm_error_callbacks:
+        _llm_error_callbacks[key] = _LLMErrorCallback(provider, model=model, feature=feature)
+    return _llm_error_callbacks[key]
+
+
+def _with_llm_callbacks(kwargs: Dict[str, Any], provider: str, model: str = '', feature: str = '') -> Dict[str, Any]:
+    result = dict(kwargs)
+    callbacks = list(result.get('callbacks') or [])
+    if _usage_callback not in callbacks:
+        callbacks.append(_usage_callback)
+    error_callback = _get_llm_error_callback(provider, model=model, feature=feature)
+    if error_callback not in callbacks:
+        callbacks.append(error_callback)
+    result['callbacks'] = callbacks
+    return result
+
 
 # ---------------------------------------------------------------------------
 # BYOK (Bring Your Own Key)
@@ -56,6 +94,7 @@ class _OpenAIEmbeddingsProxy:
     """Transparent proxy for OpenAIEmbeddings that uses BYOK OpenAI when set."""
 
     __slots__ = ('_model', '_default', '_ctor_kwargs')
+    _METHODS_TO_WRAP = {'embed_documents', 'aembed_documents', 'embed_query', 'aembed_query'}
 
     def __init__(self, model: str, default: OpenAIEmbeddings, ctor_kwargs: Dict[str, Any]):
         object.__setattr__(self, '_model', model)
@@ -115,7 +154,28 @@ class _OpenAIEmbeddingsProxy:
             raise
 
     def __getattr__(self, name: str):
-        return getattr(self._resolve(), name)
+        attr = getattr(self._resolve(), name)
+        if name not in self._METHODS_TO_WRAP or not callable(attr):
+            return attr
+        if name.startswith('a'):
+
+            async def _wrapped_async(*args, **kwargs):
+                try:
+                    return await attr(*args, **kwargs)
+                except Exception as e:
+                    handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation=name)
+                    raise
+
+            return _wrapped_async
+
+        def _wrapped(*args, **kwargs):
+            try:
+                return attr(*args, **kwargs)
+            except Exception as e:
+                handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation=name)
+                raise
+
+        return _wrapped
 
 
 _BYOK_CACHE_MAX_SIZE = 256
@@ -152,7 +212,10 @@ def _create_byok_client(
     model: str, provider: str, byok_key: str, streaming: bool = False, feature: str = ''
 ) -> Optional[ChatOpenAI]:
     """Create a ChatOpenAI using the user's BYOK key. Returns None if BYOK not supported for this provider."""
-    kwargs: Dict[str, Any] = {'callbacks': [_usage_callback], 'request_timeout': 120, 'max_retries': 1}
+    callback_provider = _effective_byok_provider(model, provider)
+    kwargs: Dict[str, Any] = _with_llm_callbacks(
+        {'request_timeout': 120, 'max_retries': 1}, callback_provider, model=model, feature=feature
+    )
     if model == 'gpt-5.1':
         kwargs['extra_body'] = {"prompt_cache_retention": "24h"}
     if streaming:
@@ -189,6 +252,7 @@ def get_anthropic_client() -> anthropic.AsyncAnthropic:
 
 def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
     """Explicit factory; equivalent to using the module-level proxies."""
+    kwargs = _with_llm_callbacks(kwargs, 'openai', model=model)
     byok = get_byok_key('openai')
     if byok:
         return _cached_openai_chat(model, byok, kwargs)
@@ -458,11 +522,9 @@ def _get_or_create_openai_llm(model_name: str, streaming: bool = False) -> ChatO
     """Get or create a cached ChatOpenAI for an OpenAI model."""
     key = (model_name, streaming, 'openai')
     if key not in _llm_cache:
-        kwargs: Dict[str, Any] = {
-            'callbacks': [_usage_callback],
-            'request_timeout': 120,
-            'max_retries': 1,
-        }
+        kwargs: Dict[str, Any] = _with_llm_callbacks(
+            {'request_timeout': 120, 'max_retries': 1}, 'openai', model=model_name
+        )
         if model_name == 'gpt-5.1':
             kwargs['extra_body'] = {"prompt_cache_retention": "24h"}
         if streaming:
@@ -488,10 +550,10 @@ def _get_or_create_openrouter_llm(
             'api_key': os.environ.get('OPENROUTER_API_KEY'),
             'base_url': "https://openrouter.ai/api/v1",
             'default_headers': {"X-Title": "Omi Chat"},
-            'callbacks': [_usage_callback],
             'request_timeout': 120,
             'max_retries': 1,
         }
+        kwargs = _with_llm_callbacks(kwargs, 'openrouter', model=api_model)
         if temperature is not None:
             kwargs['temperature'] = temperature
         if streaming:
@@ -527,7 +589,7 @@ def _get_or_create_gemini_llm(
         use_vertex = os.environ.get('USE_VERTEX_AI', '').lower() == 'true'
         gcp_project = os.environ.get('GOOGLE_CLOUD_PROJECT', '') if use_vertex else ''
         gemini_key = os.environ.get('GEMINI_API_KEY', '')
-        kwargs: Dict[str, Any] = {'callbacks': [_usage_callback], 'timeout': 120, 'max_retries': 1}
+        kwargs: Dict[str, Any] = _with_llm_callbacks({'timeout': 120, 'max_retries': 1}, 'gemini', model=model_name)
         if streaming:
             kwargs['streaming'] = True
         if thinking_budget is not None and model_name.startswith('gemini-2.5'):
@@ -678,7 +740,10 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = get_model('chat_agent')
 # Legacy module-level alias (kept for test compatibility).
 # Production code should use get_llm(feature) exclusively.
 # ---------------------------------------------------------------------------
-llm_mini = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback], request_timeout=120, max_retries=1)
+llm_mini = ChatOpenAI(
+    model='gpt-4.1-mini',
+    **_with_llm_callbacks({'request_timeout': 120, 'max_retries': 1}, 'openai', model='gpt-4.1-mini'),
+)
 
 # ---------------------------------------------------------------------------
 # Embeddings, parser, utilities
@@ -721,6 +786,10 @@ def gemini_embed_query(text: str) -> List[float]:
         'taskType': 'RETRIEVAL_QUERY',
     }
     headers = {'x-goog-api-key': api_key, 'Content-Type': 'application/json'}
-    resp = httpx.post(url, json=payload, headers=headers, timeout=10)
-    resp.raise_for_status()
-    return resp.json()['embedding']['values']
+    try:
+        resp = httpx.post(url, json=payload, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return resp.json()['embedding']['values']
+    except Exception as e:
+        handle_llm_error(e, 'gemini', feature='embeddings', model='embedding-001', operation='embed_query')
+        raise

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -141,7 +141,11 @@ class _OpenAIEmbeddingsProxy:
             if inst is not self._default:
                 # Explicit methods bypass the __getattr__ wrapper, so tag the BYOK
                 # source here too before falling back to Omi's key or re-raising.
-                handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation='embed_query')
+                # Guard the tagging call so it can never break the fallback below.
+                try:
+                    handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation='embed_query')
+                except Exception:
+                    logger.exception("handle_llm_error failed during embeddings error handling")
                 if self._is_key_failure(e):
                     logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
                     return self._default.embed_query(text)
@@ -153,7 +157,10 @@ class _OpenAIEmbeddingsProxy:
             return inst.embed_documents(texts)
         except Exception as e:
             if inst is not self._default:
-                handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation='embed_documents')
+                try:
+                    handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation='embed_documents')
+                except Exception:
+                    logger.exception("handle_llm_error failed during embeddings error handling")
                 if self._is_key_failure(e):
                     logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
                     return self._default.embed_documents(texts)
@@ -169,7 +176,10 @@ class _OpenAIEmbeddingsProxy:
                 try:
                     return await attr(*args, **kwargs)
                 except Exception as e:
-                    handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation=name)
+                    try:
+                        handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation=name)
+                    except Exception:
+                        logger.exception("handle_llm_error failed during embeddings error handling")
                     raise
 
             return _wrapped_async
@@ -178,7 +188,10 @@ class _OpenAIEmbeddingsProxy:
             try:
                 return attr(*args, **kwargs)
             except Exception as e:
-                handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation=name)
+                try:
+                    handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation=name)
+                except Exception:
+                    logger.exception("handle_llm_error failed during embeddings error handling")
                 raise
 
         return _wrapped

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -138,9 +138,13 @@ class _OpenAIEmbeddingsProxy:
         try:
             return inst.embed_query(text)
         except Exception as e:
-            if inst is not self._default and self._is_key_failure(e):
-                logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
-                return self._default.embed_query(text)
+            if inst is not self._default:
+                # Explicit methods bypass the __getattr__ wrapper, so tag the BYOK
+                # source here too before falling back to Omi's key or re-raising.
+                handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation='embed_query')
+                if self._is_key_failure(e):
+                    logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
+                    return self._default.embed_query(text)
             raise
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
@@ -148,9 +152,11 @@ class _OpenAIEmbeddingsProxy:
         try:
             return inst.embed_documents(texts)
         except Exception as e:
-            if inst is not self._default and self._is_key_failure(e):
-                logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
-                return self._default.embed_documents(texts)
+            if inst is not self._default:
+                handle_llm_error(e, 'openai', feature='embeddings', model=self._model, operation='embed_documents')
+                if self._is_key_failure(e):
+                    logger.warning("BYOK OpenAI embeddings failed (%s); falling back to Omi key", type(e).__name__)
+                    return self._default.embed_documents(texts)
             raise
 
     def __getattr__(self, name: str):

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -48,6 +48,7 @@ from utils.retrieval.tools import (
 )
 from utils.retrieval.tools.app_tools import load_app_tools, get_tool_status_message
 from utils.retrieval.safety import AgentSafetyGuard, SafetyGuardError
+from utils.llm.byok_errors import handle_llm_error_async
 from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL
 from utils.llm.chat import _get_agentic_qa_prompt
 from utils.other.endpoints import timeit
@@ -423,7 +424,7 @@ async def _run_anthropic_agent_stream(
                 response = await stream.get_final_message()
 
         except Exception as e:
-            logger.error(f"Anthropic API error: {e}")
+            await handle_llm_error_async(e, 'anthropic', feature='chat_agent', model=ANTHROPIC_AGENT_MODEL)
             await callback.put_data(f"\n\nSorry, I encountered an error. Please try again.")
             await callback.end()
             return


### PR DESCRIPTION
## Summary
- add BYOK uid context propagation for HTTP, WebSocket, and background processing
- log LLM failures with platform vs BYOK source, provider, feature, model, operation, uid, status, and reason
- attach LangChain error callbacks to OpenAI, OpenRouter, Gemini, and embedding clients
- offload async Anthropic-agent error handling to the shared executor so logging work does not block the event loop

Closes #7290

## Verification
- PATH=/tmp/omi-backend-py311/bin:$PATH ./test-preflight.sh
- PATH=/tmp/omi-backend-py311/bin:$PATH pytest tests/unit/test_byok_llm_logging.py -q