### PR TITLE
fix(byok): honor in-request BYOK headers when checking trial paywall

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -36,7 +36,7 @@ from utils.speaker_assignment import (
 import database.conversations as conversations_db
 import database.calendar_meetings as calendar_db
 import database.users as user_db
-from utils.byok import get_byok_keys
+from utils.byok import get_byok_keys, extract_byok_from_websocket, set_byok_keys
 from database.users import get_user_transcription_preferences
 from database import redis_db
 from database.redis_db import check_credits_invalidation
@@ -239,6 +239,13 @@ async def _stream_handler(
     if not uid or len(uid) <= 0:
         await websocket.close(code=1008, reason="Bad uid")
         return
+
+    # BYOKMiddleware doesn't fire for WebSocket upgrades (HTTP-only). Extract
+    # BYOK headers from the upgrade request and stash them in the contextvar
+    # BEFORE the paywall check, so a user sending all 4 keys gets the
+    # request-level BYOK escape hatch instead of being closed with trial_expired
+    # whenever their Firestore BYOK heartbeat is briefly stale.
+    set_byok_keys(extract_byok_from_websocket(websocket))
 
     if is_trial_paywalled(uid, source):
         logger.info("trial paywall: closing desktop WS uid=%s session=%s reason=trial_expired", uid, session_id)

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -383,3 +383,129 @@ class TestIsTrialPaywalledBehavioral:
     def test_clear_cache_calls_redis_delete(self):
         self._sub.clear_trial_paywall_cache('test-uid-123')
         self._sub.redis_db.delete_generic_cache.assert_called_with('trial_paywall:expired:test-uid-123')
+
+
+class TestByokRequestEscapeHatch:
+    """A request carrying all 4 BYOK provider headers must short-circuit the
+    trial paywall, even when Firestore says BYOK is inactive (heartbeat expired,
+    activation pending, cross-region sync gap).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_subscription(self):
+        import sys
+        import types
+
+        def _stub(name):
+            if name not in sys.modules:
+                sys.modules[name] = types.ModuleType(name)
+            return sys.modules[name]
+
+        saved = {}
+        stubs = [
+            'google.cloud',
+            'google.cloud.firestore',
+            'google.cloud.firestore_v1',
+            'firebase_admin',
+            'firebase_admin.auth',
+            'firebase_admin.firestore',
+            'database._client',
+            'database.redis_db',
+            'database.users',
+            'database.user_usage',
+            'database.announcements',
+        ]
+        for name in stubs:
+            saved[name] = sys.modules.get(name)
+            mod = _stub(name)
+            if name == 'database._client':
+                mod.db = MagicMock()
+            elif name == 'database.redis_db':
+                # Simulate a hot cache that says "expired" — escape hatch must beat it
+                mod.get_generic_cache = MagicMock(return_value=True)
+                mod.set_generic_cache = MagicMock()
+                mod.delete_generic_cache = MagicMock()
+            elif name == 'database.users':
+                # Firestore says BYOK NOT active — only the request headers should save us
+                mod.get_user_valid_subscription = MagicMock(return_value=None)
+                mod.is_byok_active = MagicMock(return_value=False)
+            elif name == 'database.user_usage':
+                pass
+            elif name == 'database.announcements':
+                mod.compare_versions = MagicMock()
+            elif name == 'firebase_admin.auth':
+                mock_user = MagicMock()
+                mock_user.user_metadata.creation_timestamp = 0
+                mod.get_user = MagicMock(return_value=mock_user)
+
+        if 'utils.subscription' in sys.modules:
+            del sys.modules['utils.subscription']
+
+        import utils.subscription as sub
+        from utils import byok
+
+        self._sub = sub
+        self._byok = byok
+        sub._TRIAL_PAYWALL_ENABLED = True
+        sub._TRIAL_PAYWALL_TEST_UIDS = set()
+
+        yield
+
+        # Reset BYOK contextvar between tests so leftover keys don't bleed.
+        byok._byok_ctx.set(None)
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+    def test_all_4_byok_headers_bypass_paywall(self):
+        self._byok.set_byok_keys(
+            {
+                'openai': 'sk-stub-openai',
+                'anthropic': 'sk-stub-anthropic',
+                'gemini': 'stub-gemini',
+                'deepgram': 'stub-deepgram',
+            }
+        )
+        assert self._sub.is_trial_paywalled('uid-stale-firestore', 'desktop') is False
+
+    def test_partial_byok_headers_still_paywall(self):
+        # Only 3 of 4 — not a fully-enrolled BYOK request, paywall remains.
+        self._byok.set_byok_keys(
+            {
+                'openai': 'sk-stub',
+                'anthropic': 'sk-stub',
+                'gemini': 'stub',
+                # deepgram missing
+            }
+        )
+        assert self._sub.is_trial_paywalled('uid-stale-firestore', 'desktop') is True
+
+    def test_empty_byok_keys_still_paywall(self):
+        self._byok.set_byok_keys({})
+        assert self._sub.is_trial_paywalled('uid-stale-firestore', 'desktop') is True
+
+    def test_blank_byok_value_does_not_count(self):
+        # A header whose value is empty string shouldn't count as "provided".
+        self._byok.set_byok_keys(
+            {
+                'openai': 'sk-stub',
+                'anthropic': 'sk-stub',
+                'gemini': 'stub',
+                'deepgram': '',
+            }
+        )
+        assert self._sub.is_trial_paywalled('uid-stale-firestore', 'desktop') is True
+
+    def test_get_trial_metadata_byok_headers_not_expired(self):
+        self._byok.set_byok_keys(
+            {
+                'openai': 'sk-stub-openai',
+                'anthropic': 'sk-stub-anthropic',
+                'gemini': 'stub-gemini',
+                'deepgram': 'stub-deepgram',
+            }
+        )
+        meta = self._sub.get_trial_metadata('uid-stale-firestore')
+        assert meta.trial_expired is False

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -12,7 +12,7 @@ import database.user_usage as user_usage_db
 from database import redis_db
 from database.announcements import compare_versions
 from models.users import PlanType, SubscriptionStatus, Subscription, PlanLimits, TrialMetadata
-from utils.byok import get_byok_key
+from utils.byok import get_byok_key, get_byok_keys
 from utils.log_sanitizer import sanitize
 import logging
 
@@ -50,6 +50,27 @@ _TRIAL_PAYWALL_DESKTOP_TOKENS = {"macos", "desktop"}
 # so chat-quota polling doesn't fan out to Firebase on every request.
 _TRIAL_PAYWALL_CACHE_TTL_SECONDS = 300
 
+# Providers a fully-enrolled BYOK desktop client always sends headers for.
+# Used by the request-level escape hatch in `_is_trial_expired_cached`.
+_BYOK_REQUIRED_PROVIDERS = ("openai", "anthropic", "gemini", "deepgram")
+
+
+def _request_has_all_byok_keys() -> bool:
+    """True if the *current request* carries headers for all 4 enrolled BYOK
+    providers.
+
+    Firestore BYOK state is the source of truth for fingerprint validation,
+    but it can be temporarily stale — heartbeat just expired, activation
+    POST hasn't landed yet, cross-region read replica lag, etc. A user who is
+    literally sending all 4 valid API keys on this request should never be
+    paywalled because of a Firestore sync gap. The actual fingerprint check
+    in `utils.byok._check_byok_validity` runs separately and still rejects
+    forged headers (mismatched SHA-256 against the enrolled fingerprints) —
+    we trust the headers' *presence* here, not their *contents*.
+    """
+    keys = get_byok_keys()
+    return all(p in keys and keys[p] for p in _BYOK_REQUIRED_PROVIDERS)
+
 
 def _is_trial_expired_uncached(uid: str) -> bool:
     """Is this user past their 3-day desktop trial?
@@ -77,6 +98,14 @@ def _is_trial_expired_uncached(uid: str) -> bool:
 
 
 def _is_trial_expired_cached(uid: str) -> bool:
+    # Request-level escape hatch: a request carrying all 4 BYOK provider
+    # headers is never paywalled, regardless of cached Firestore state. The
+    # cache TTL is 5 min and Firestore's BYOK `is_active` heartbeat is 24 h,
+    # so even a perfectly-configured BYOK user can transiently look stale to
+    # Firestore. Trust the live request.
+    if _request_has_all_byok_keys():
+        return False
+
     cache_key = f"trial_paywall:expired:{uid}"
     cached = redis_db.get_generic_cache(cache_key)
     if cached is not None:
@@ -125,7 +154,10 @@ def get_trial_metadata(uid: str) -> TrialMetadata:
         plan = subscription.plan if subscription else PlanType.basic
 
         # Paid-plan or BYOK users: trial is moot — they have full access.
-        if plan != PlanType.basic or users_db.is_byok_active(uid):
+        # Same request-level escape hatch as `_is_trial_expired_cached`: a request
+        # carrying all 4 BYOK provider headers is treated as BYOK-active even if
+        # Firestore hasn't caught up yet.
+        if plan != PlanType.basic or users_db.is_byok_active(uid) or _request_has_all_byok_keys():
             return TrialMetadata(
                 trial_expired=False,
                 trial_duration_seconds=TRIAL_LENGTH_SECONDS,

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed BYOK users hitting \"trial_expired\" / monthly-limit popup even with all 4 keys configured \u2014 request-level BYOK headers now bypass the trial paywall regardless of Firestore heartbeat state, and the listen WebSocket extracts BYOK headers before the paywall check"
+  ],
   "releases": [
     {
       "version": "0.11.406",

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -5288,6 +5288,10 @@ struct SettingsContentView: View {
           try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
           await FloatingBarUsageLimiter.shared.fetchPlan()
           await MainActor.run {
+            // Clear any sticky paywall flag from a prior `freemium_threshold_reached`
+            // event — once all 4 BYOK keys validate, the user is on the free BYOK
+            // plan and shouldn't be locked out of capture/transcription anymore.
+            AppState.current?.isPaywalled = false
             byokKeyStatuses = results
             byokActivationError = nil
           }
@@ -6853,6 +6857,17 @@ struct SettingsContentView: View {
             subscription.subscription.plan.rawValue == selectedPlanIdForCheckout
           {
             self.selectedPlanIdForCheckout = nil
+          }
+          // Clear the sticky paywall flag whenever the subscription endpoint
+          // reports a non-basic active plan. Catches the case where a paid user
+          // hit the paywall once (e.g. WS connected before payment cleared
+          // the trial cache) — without this they'd stay paywalled until the
+          // next app restart even after their Operator/Architect plan is active.
+          if subscription.subscription.plan != .basic,
+             subscription.subscription.status == .active,
+             AppState.current?.isPaywalled == true {
+            AppState.current?.isPaywalled = false
+            log("Paywall: cleared sticky flag — subscription \(subscription.subscription.plan.rawValue) is active")
           }
           isLoadingSubscription = false
         }


### PR DESCRIPTION
## Summary
Multiple prod users reported hitting "trial_expired" / monthly-limit popup even after providing all 4 BYOK keys. T3 in Discord: *"Free with keys wasn't working, so I just shelled out \$50 and it's giving me the same error."*

Root cause is a three-layer mismatch — the request is carrying valid keys but every layer ignores them in favor of stale Firestore state:

1. **Backend trial check ignored request headers.** `utils/subscription.py` consulted `users_db.is_byok_active(uid)` which reads Firestore. Firestore's BYOK heartbeat TTL is 24 h and there's a 5-min Redis cache on top; a perfectly-configured user transiently looks stale (heartbeat just expired, activation POST hasn't landed yet, cross-region replica lag). Headers were ignored.
2. **WS handler never extracted BYOK headers.** `BYOKMiddleware` only fires for HTTP scope. The listen WebSocket handler had to call `extract_byok_from_websocket` + `set_byok_keys` manually but didn't — the contextvar was empty when `is_trial_paywalled` ran on every desktop WS connect.
3. **Swift's `isPaywalled` flag is sticky across restarts.** Once a user got `freemium_threshold_reached` from a transiently-paywalled WS, the flag in `UserDefaults.desktop_isPaywalled` stayed true forever — neither a successful BYOK activation nor a paid-plan upgrade cleared it.

## Fix, layered

- **`utils/subscription.py`**: new `_request_has_all_byok_keys()` escape hatch in `_is_trial_expired_cached` and `get_trial_metadata`. A request carrying all 4 enrolled provider headers is never paywalled, regardless of Firestore state. The actual fingerprint validation in `utils.byok._check_byok_validity` runs separately and still rejects forged headers (SHA-256 mismatch).
- **`routers/transcribe.py`**: call `set_byok_keys(extract_byok_from_websocket(websocket))` BEFORE `is_trial_paywalled` so the WS path gets the same escape hatch as HTTP.
- **`SettingsPage.swift`**: clear `AppState.current?.isPaywalled = false` after a successful BYOK activation. Also clear it in `loadSubscriptionInfo` when the user is on a non-basic active plan — catches paid users whose paywall flag was set transiently before payment cleared the cache.

## Test plan
- [x] 5 new tests in `test_paywall_reconnect_gate.py::TestByokRequestEscapeHatch` (all-4-bypass, 3-of-4 still paywalls, empty doesn't bypass, blank value doesn't count, `get_trial_metadata` reports trial_expired=False)
- [x] All 40 paywall tests pass
- [x] Clean `swift build -c release --triple arm64-apple-macosx` succeeds (95 MB binary)
- [ ] Beta verification after deploy: log in with all 4 BYOK keys → connect listen WS → confirm no `trial_expired` close in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)