### PR TITLE
Update CHANGELOG.json for v0.11.407 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed BYOK users hitting \"trial_expired\" / monthly-limit popup even with all 4 keys configured \u2014 request-level BYOK headers now bypass the trial paywall regardless of Firestore heartbeat state, and the listen WebSocket extracts BYOK headers before the paywall check"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.407",
+      "date": "2026-05-16",
+      "changes": [
+        "Fixed BYOK users hitting \"trial_expired\" / monthly-limit popup even with all 4 keys configured \u2014 request-level BYOK headers now bypass the trial paywall regardless of Firestore heartbeat state, and the listen WebSocket extracts BYOK headers before the paywall check"
+      ]
+    },
     {
       "version": "0.11.406",
       "date": "2026-05-15",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.407 and clears the unreleased array.