### PR TITLE
Fix email app auth and send routes

### DIFF
--- a/plugins/apps-js/email/src/routes/email.js
+++ b/plugins/apps-js/email/src/routes/email.js
@@ -27,24 +27,25 @@ router.post('/webhook', webhookController.handleWebhook);
  * @desc Generate and draft an email
  * @access Private
  */
-router.post('/draft', catchAsync(async (req, res) => {
+router.post('/draft', auth, catchAsync(async (req, res) => {
   const { 
     recipientEmail,
     recipientName,
     subject,
     content,
-    userId,
     userRequest,
     tone = 'professional',
     format = 'text'
   } = req.body;
+  const userId = req.user?.id;
+  const requestedUserId = req.body.userId;
   
   if (!recipientEmail) {
     throw ErrorFactory.badRequest('Recipient email is required', 'missing_parameter');
   }
   
-  if (!userId) {
-    throw ErrorFactory.badRequest('User ID is required', 'missing_parameter');
+  if (requestedUserId && requestedUserId !== userId) {
+    throw ErrorFactory.forbidden('Authenticated user does not match requested user');
   }
   
   // Either content or userRequest must be provided
@@ -106,17 +107,22 @@ router.post('/draft', catchAsync(async (req, res) => {
  * @desc Send a drafted email
  * @access Private
  */
-router.post('/send', catchAsync(async (req, res) => {
+router.post('/send', auth, catchAsync(async (req, res) => {
   const { 
     recipientEmail,
     subject,
     content,
-    userId,
     format = 'text'
   } = req.body;
+  const userId = req.user?.id;
+  const requestedUserId = req.body.userId;
   
-  if (!recipientEmail || !subject || !content || !userId) {
-    throw ErrorFactory.badRequest('Recipient email, subject, content, and userId are required', 'missing_parameter');
+  if (!recipientEmail || !subject || !content) {
+    throw ErrorFactory.badRequest('Recipient email, subject, and content are required', 'missing_parameter');
+  }
+
+  if (requestedUserId && requestedUserId !== userId) {
+    throw ErrorFactory.forbidden('Authenticated user does not match requested user');
   }
   
   // Get authenticated user and send function
@@ -570,4 +576,4 @@ router.post('/search', auth, async (req, res) => {
   }
 });
 
-module.exports = router; 
+module.exports = router;

--- a/plugins/apps-js/public/email.html
+++ b/plugins/apps-js/public/email.html
@@ -572,7 +572,7 @@
             <section id="auth-section" class="login-info hidden">
                 <h2>Authentication</h2>
                 <p>To use Email Assistant, you need to be logged in with your email account.</p>
-                <p><a id="login-link" href="/api/email/auth/login" class="button">Login with Email</a></p>
+                <p><a id="login-link" href="/api/auth/login" class="button">Login with Email</a></p>
             </section>
 
             <section class="instructions">
@@ -685,7 +685,7 @@
                 if (omiuid) {
                     setupNotice.classList.add('hidden');
                     authSection.classList.remove('hidden');
-                    loginLink.href = `/api/email/auth/login?uid=${encodeURIComponent(omiuid)}`;
+                    loginLink.href = `/api/auth/login?uid=${encodeURIComponent(omiuid)}`;
                 } else {
                     setupNotice.classList.remove('hidden');
                     authSection.classList.add('hidden');
@@ -694,4 +694,4 @@
         };
     </script>
 </body>
-</html> 
+</html>

--- a/plugins/apps-js/public/index.html
+++ b/plugins/apps-js/public/index.html
@@ -630,7 +630,7 @@
             <section id="auth-section" class="login-info hidden">
                 <h2>Authentication</h2>
                 <p>To use the Email Assistant, you need to be logged in with your email account.</p>
-                <p><a id="login-link" href="/api/email/auth/login" class="button">Login with Email</a></p>
+                <p><a id="login-link" href="/api/auth/login" class="button">Login with Email</a></p>
                 <div class="note" style="margin-top: 20px;">
                     <p><strong>Note:</strong> Presentation Generator doesn't require separate authentication - it works directly with your Omi device.</p>
                 </div>
@@ -746,7 +746,7 @@
                 if (omiuid) {
                     setupNotice.classList.add('hidden');
                     authSection.classList.remove('hidden');
-                    loginLink.href = `/api/email/auth/login?uid=${encodeURIComponent(omiuid)}`;
+                    loginLink.href = `/api/auth/login?uid=${encodeURIComponent(omiuid)}`;
                 } else {
                     setupNotice.classList.remove('hidden');
                     authSection.classList.add('hidden');
@@ -755,4 +755,4 @@
         };
     </script>
 </body>
-</html> 
+</html>

--- a/plugins/apps-js/server.js
+++ b/plugins/apps-js/server.js
@@ -16,10 +16,12 @@ const {
 } = require('./email/src/config/constants');
 
 // Import services
-const { checkSupabaseConnection } = require('./email/src/services/authService');
+const { checkSupabaseConnection, getAuthenticatedUser } = require('./email/src/services/authService');
 const { initializeDatabase } = require('./email/src/utils/dbUtils');
 const { closeRedisConnection } = require('./email/src/utils/redisUtils');
+const { draftEmail: sendEmailWithGmail } = require('./email/src/utils/emailUtils');
 // Import routes
+const authRouter = require('./email/src/routes/auth');
 const emailRouter = require('./email/src/routes/email');
 const deckRouter = require('./deck/src/routes/deck');
 
@@ -47,6 +49,10 @@ app.use(cookieParser());
 
 // Serve static files from the 'public' directory
 app.use(express.static(path.join(__dirname, 'public')));
+
+// Shared services used by route modules.
+app.locals.getAuthenticatedUser = getAuthenticatedUser;
+app.locals.sendEmail = sendEmailWithGmail;
 
 // Rate limiting middleware
 const requestCounts = new Map();
@@ -95,6 +101,7 @@ app.use((req, res, next) => {
 
 
 // Routes
+app.use('/api/auth', authRouter);
 app.use('/api/email', emailRouter);
 app.use('/api/deck', deckRouter);
 


### PR DESCRIPTION
## Summary
- mount the email app OAuth routes under `/api/auth`
- wire the email routes to the existing user lookup and Gmail send helpers
- require authenticated callers for `/api/email/draft` and `/api/email/send` and derive the user from the verified JWT
- update the email app login links to point at the mounted OAuth routes

Related to #2315

## Tests
- `node --check plugins/apps-js/server.js`
- `node --check plugins/apps-js/email/src/routes/email.js`
- `node --check plugins/apps-js/email/src/routes/auth.js`
- `git diff --check`