### PR TITLE
omi-cli 0.2.1: fix browser-login 403 + add PyPI Trusted-Publishing release workflow

### DIFF
--- a/.github/workflows/publish_omi_cli.yml
+++ b/.github/workflows/publish_omi_cli.yml
@@ -1,0 +1,114 @@
+name: Publish omi-cli to PyPI
+
+# Releases the `omi-cli` package (sdks/python-cli) to PyPI via PyPI Trusted
+# Publishing (OIDC) — no long-lived API token is stored anywhere.
+#
+# Release flow:
+#   1. Bump `version` in sdks/python-cli/pyproject.toml, merge to main.
+#   2. git tag omi-cli-vX.Y.Z   (scheme is distinct from the omi-sdk's
+#      bare vX.Y.Z tags so the two never collide)
+#   3. git push origin omi-cli-vX.Y.Z
+#   -> this workflow tests, builds, and publishes X.Y.Z.
+#
+# `workflow_dispatch` runs build + twine check only (a dry run); it never
+# publishes because there is no tag to verify the version against.
+#
+# One-time setup (cannot be scripted — done in PyPI/GitHub web UIs):
+#   * PyPI -> project omi-cli -> Settings -> Publishing -> add a Trusted
+#     Publisher: owner BasedHardware, repo omi, workflow
+#     publish_omi_cli.yml, environment pypi.
+#   * GitHub -> repo Settings -> Environments -> create `pypi`
+#     (optionally require reviewers for a manual approve-before-publish gate).
+
+on:
+  push:
+    tags:
+      - 'omi-cli-v*'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Note for this dry-run build (no publish happens).'
+        required: false
+        default: 'manual dry-run'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize per ref; never cancel an in-flight publish.
+  group: publish-omi-cli-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: sdks/python-cli
+
+jobs:
+  build:
+    name: Build & verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build + dev deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m pip install -e ".[dev]"
+
+      - name: Verify tag matches pyproject version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          PYPROJECT_VERSION="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+          TAG_VERSION="${GITHUB_REF_NAME#omi-cli-v}"
+          echo "tag=$GITHUB_REF_NAME -> $TAG_VERSION ; pyproject=$PYPROJECT_VERSION"
+          if [ "$PYPROJECT_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (-> $TAG_VERSION) does not match pyproject version $PYPROJECT_VERSION. Bump pyproject.toml or fix the tag."
+            exit 1
+          fi
+
+      - name: Run tests
+        run: pytest -q
+
+      - name: Build sdist + wheel
+        run: |
+          rm -rf dist
+          python -m build
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: omi-cli-dist
+          path: sdks/python-cli/dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing)
+    needs: build
+    # Tag pushes only — workflow_dispatch stays a dry run (no tag to verify).
+    if: startsWith(github.ref, 'refs/tags/omi-cli-v')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/omi-cli/
+    permissions:
+      id-token: write  # the ONLY elevated permission, scoped to this job
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: omi-cli-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          print-hash: true

--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -37,11 +37,19 @@ from omi_cli.auth.store import store_oauth_tokens, update_oauth_id_token
 from omi_cli.config import Profile
 from omi_cli.errors import AuthError, UsageError
 
-# Public Firebase Web API key for the ``based-hardware`` Firebase project.
+# Public Firebase API key for the ``based-hardware`` Firebase project.
 # Firebase API keys are *not* secrets — they identify which project a
 # REST request targets and are embedded in every public web/mobile build.
 # See https://firebase.google.com/docs/projects/api-keys.
-_FIREBASE_API_KEY = "AIzaSyAqRWo5RN8YhlzNzBEWJ3GxG3S_1SJlxx4"
+#
+# IMPORTANT: this MUST be a key with no application restriction. A CLI sends
+# no ``Referer`` / app-bundle, so a referrer-locked *web* key (or an Android
+# SHA / iOS bundle restricted key) 403s here with API_KEY_HTTP_REFERRER_BLOCKED.
+# This is the project's Windows key — Firebase has no Windows-app restriction
+# mechanism, so it can't be silently re-locked the way the web/android/ios
+# keys can. Do NOT swap this back to the ``based-hardware`` web key
+# (AIzaSyAqRWo5RN8Y…); that is exactly what broke browser login in 0.2.0.
+_FIREBASE_API_KEY = "AIzaSyA88gHcmiAxjN_aE23tHRWXOgFfapyO6dk"
 _FIREBASE_SIGNIN_URL = (
     "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken" f"?key={_FIREBASE_API_KEY}"
 )

--- a/sdks/python-cli/pyproject.toml
+++ b/sdks/python-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omi-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "Command-line interface for Omi — talk to memories, conversations, action items, and goals from your terminal."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## What

1. **Fix the browser-OAuth 403 in 0.2.0.** The CLI hardcoded the `based-hardware` **web** Firebase key, which is HTTP-referrer-restricted. A CLI sends no `Referer`, so `signInWithCustomToken` 403s with `API_KEY_HTTP_REFERRER_BLOCKED` — every `omi auth login` (browser) fails in prod. Verified empirically against Identity Toolkit. Swapped to the project's **Windows** key (same Firebase project — not a project mismatch; Windows has no app-restriction mechanism so it can't be silently re-locked like the web/android/ios keys). `--api-key` login was never affected.
2. **Add `.github/workflows/publish_omi_cli.yml`** — tag-triggered (`omi-cli-v*`) release to PyPI via **Trusted Publishing (OIDC)**, no stored token. Split build/publish jobs so `id-token: write` is isolated to a minimal publish job; tag must match `pyproject` version; `workflow_dispatch` is a dry run.
3. **Bump to 0.2.1.**

## Verification

- All 92 `python-cli` tests pass; `0.2.1` builds clean, `twine check` PASSED both artifacts.
- Workflow YAML structurally validated (triggers, job graph, minimal perms).

## One-time setup before first CI publish (web UIs)

- PyPI → project `omi-cli` → Settings → Publishing → add Trusted Publisher: owner `BasedHardware`, repo `omi`, workflow `publish_omi_cli.yml`, environment `pypi`.
- GitHub → Settings → Environments → create `pypi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)