### PR TITLE
omi-cli 0.2.2: fix stale __version__ + single-source the version

### DIFF
--- a/.github/workflows/publish_omi_cli.yml
+++ b/.github/workflows/publish_omi_cli.yml
@@ -60,14 +60,18 @@ jobs:
           python -m pip install build twine
           python -m pip install -e ".[dev]"
 
-      - name: Verify tag matches pyproject version
+      - name: Verify tag matches package version
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          PYPROJECT_VERSION="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+          # Version is single-sourced from omi_cli.__version__ (pyproject uses
+          # [tool.setuptools.dynamic]). Read the resolved value from the
+          # installed package so the tag, the wheel, and `omi --version` are
+          # all checked against the same literal.
+          PKG_VERSION="$(python -c "import omi_cli; print(omi_cli.__version__)")"
           TAG_VERSION="${GITHUB_REF_NAME#omi-cli-v}"
-          echo "tag=$GITHUB_REF_NAME -> $TAG_VERSION ; pyproject=$PYPROJECT_VERSION"
-          if [ "$PYPROJECT_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME (-> $TAG_VERSION) does not match pyproject version $PYPROJECT_VERSION. Bump pyproject.toml or fix the tag."
+          echo "tag=$GITHUB_REF_NAME -> $TAG_VERSION ; package=$PKG_VERSION"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (-> $TAG_VERSION) does not match omi_cli.__version__ $PKG_VERSION. Bump omi_cli/__init__.py or fix the tag."
             exit 1
           fi
 

--- a/sdks/python-cli/omi_cli/__init__.py
+++ b/sdks/python-cli/omi_cli/__init__.py
@@ -4,5 +4,5 @@ Provides scoped access to memories, conversations, action items, and goals via
 the developer API surface (`/v1/dev/*`). Designed for agents and humans alike.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.2"
 __all__ = ["__version__"]

--- a/sdks/python-cli/pyproject.toml
+++ b/sdks/python-cli/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omi-cli"
-version = "0.2.1"
+# Single source of truth is ``omi_cli.__version__`` (see [tool.setuptools.dynamic]
+# below). ``omi --version`` and the client User-Agent read that same attribute,
+# so the published wheel and the runtime can never disagree again.
+dynamic = ["version"]
 description = "Command-line interface for Omi — talk to memories, conversations, action items, and goals from your terminal."
 readme = "README.md"
 license = { text = "MIT" }
@@ -68,6 +71,12 @@ dev = [
     "build>=1.0,<2.0",
     "twine>=5.0,<7.0",
 ]
+
+[tool.setuptools.dynamic]
+# Resolve the package version from omi_cli/__init__.py:__version__ at build
+# time — keeps the wheel/PyPI version and the runtime ``omi --version`` in
+# lockstep from one literal.
+version = { attr = "omi_cli.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Why

0.2.1 published the browser-OAuth fix correctly, but `omi --version` and the client User-Agent still reported **0.2.0** — `omi_cli/__init__.py` held a second, independent version string that wasn't bumped. Anyone upgrading to verify the fix would see "0.2.0" and think it failed. PyPI versions are immutable, so this is corrected forward in 0.2.2.

## What

- `omi_cli/__init__.py` → `__version__ = "0.2.2"` (now the single source of truth).
- `pyproject.toml` → `[tool.setuptools.dynamic]` resolves the build/PyPI version from `omi_cli.__version__`. One literal drives release version + `omi --version` + User-Agent; they can't diverge again.
- Release workflow's tag guard now checks the tag against the resolved package version (pyproject has no static version anymore).

## Verified

- Build resolves to `omi_cli-0.2.2`; `twine check` PASSED.
- `omi --version` → `omi-cli 0.2.2`; wheel metadata `0.2.2`; User-Agent `omi-cli/0.2.2`; OAuth Windows-key fix intact.
- All 92 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)