### PR TITLE
omi-cli 0.2.3: browser OAuth mints a dev API key (fixes 'Invalid API Key')

### DIFF
--- a/sdks/python-cli/omi_cli/__init__.py
+++ b/sdks/python-cli/omi_cli/__init__.py
@@ -4,5 +4,5 @@ Provides scoped access to memories, conversations, action items, and goals via
 the developer API surface (`/v1/dev/*`). Designed for agents and humans alike.
 """
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __all__ = ["__version__"]

--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import html
 import http.server
 import secrets
+import socket
 import socketserver
 import threading
 import time
@@ -33,7 +34,7 @@ from typing import Any, Optional
 import httpx
 
 from omi_cli import config as cfg
-from omi_cli.auth.store import store_oauth_tokens, update_oauth_id_token
+from omi_cli.auth.store import store_api_key, store_oauth_tokens, update_oauth_id_token
 from omi_cli.config import Profile
 from omi_cli.errors import AuthError, UsageError
 
@@ -61,6 +62,23 @@ _HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 # Refresh slightly before the server-quoted expiry to absorb clock skew + the
 # round-trip time of the upcoming API call.
 _REFRESH_MARGIN_SECONDS = 60
+
+# Dev-key management endpoint. POST mints a key, GET lists, DELETE revokes —
+# all authenticated by the Firebase ID token (backend get_current_user_id),
+# unlike the /v1/dev/* data endpoints which require the minted key itself.
+_DEV_KEYS_PATH = "/v1/dev/keys"
+# Full read+write so every CLI subcommand works. The backend defaults to
+# read-only when scopes are omitted, so the CLI must request them explicitly.
+_CLI_KEY_SCOPES = [
+    "conversations:read",
+    "conversations:write",
+    "memories:read",
+    "memories:write",
+    "action_items:read",
+    "action_items:write",
+    "goals:read",
+    "goals:write",
+]
 
 
 # --- Browser flow ----------------------------------------------------------
@@ -151,15 +169,16 @@ def login_with_browser(
         )
 
     custom_token = _exchange_code_for_custom_token(api_base, code, redirect_uri)
-    id_token, refresh_token, expires_in = _firebase_signin_with_custom_token(custom_token)
+    id_token, _refresh_token, _expires_in = _firebase_signin_with_custom_token(custom_token)
 
-    return store_oauth_tokens(
-        profile_name,
-        id_token=id_token,
-        refresh_token=refresh_token,
-        expires_at=time.time() + expires_in - _REFRESH_MARGIN_SECONDS,
-        api_base=api_base,
-    )
+    # Every /v1/dev/* endpoint the CLI actually uses authenticates with a
+    # *developer API key*, not a Firebase ID token — so storing the Firebase
+    # token directly would 401 ("Invalid API Key") on the very first call.
+    # The Firebase session DOES authenticate POST /v1/dev/keys, so use it once
+    # to mint a long-lived dev key and store that. Browser OAuth is, in effect,
+    # just a friendlier way to obtain a key without visiting the dashboard.
+    raw_key = _exchange_firebase_token_for_dev_key(api_base, id_token)
+    return store_api_key(profile_name, raw_key, api_base=api_base)
 
 
 # --- Refresh ---------------------------------------------------------------
@@ -238,6 +257,66 @@ def needs_refresh(profile: Profile, now: Optional[float] = None) -> bool:
 
 
 # --- Internals -------------------------------------------------------------
+
+
+def _cli_key_name() -> str:
+    """Stable, recognizable name for the CLI's own dev key.
+
+    Per-host so the user can tell which machine a key belongs to in the
+    dashboard, and stable so re-login replaces it instead of piling up.
+    """
+    host = socket.gethostname() or "unknown-host"
+    return f"omi-cli ({host})"
+
+
+def _exchange_firebase_token_for_dev_key(api_base: str, id_token: str) -> str:
+    """Mint a developer API key using the Firebase ID token.
+
+    The Firebase session authenticates ``/v1/dev/keys`` (backend
+    ``get_current_user_id``); the returned dev key is what every other
+    ``/v1/dev/*`` endpoint requires. Re-login first deletes the CLI's own
+    prior keys — matched by our exact :func:`_cli_key_name` only, so a user's
+    other keys are never touched — then mints a fresh one.
+    """
+    base = api_base.rstrip("/")
+    headers = {"Authorization": f"Bearer {id_token}"}
+    key_name = _cli_key_name()
+
+    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        # Best-effort cleanup of our own stale keys. Non-critical: if listing
+        # or deleting fails, still try to create — a duplicate is recoverable,
+        # a failed login is not.
+        try:
+            listing = client.get(f"{base}{_DEV_KEYS_PATH}", headers=headers)
+            if listing.status_code == 200:
+                for key in listing.json():
+                    if isinstance(key, dict) and key.get("name") == key_name and key.get("id"):
+                        client.delete(f"{base}{_DEV_KEYS_PATH}/{key['id']}", headers=headers)
+        except httpx.HTTPError:
+            pass
+
+        resp = client.post(
+            f"{base}{_DEV_KEYS_PATH}",
+            headers=headers,
+            json={"name": key_name, "scopes": _CLI_KEY_SCOPES},
+        )
+
+    if resp.status_code not in (200, 201):
+        raise AuthError(
+            message=f"Could not create an API key for the CLI ({resp.status_code})",
+            detail=(
+                "OAuth sign-in succeeded, but minting a developer API key failed. "
+                "Try again, or use `omi auth login --api-key`."
+            ),
+        )
+
+    raw_key = resp.json().get("key")
+    if not raw_key:
+        raise AuthError(
+            message="Key-mint response was missing the API key",
+            detail="The /v1/dev/keys response did not include a `key` field.",
+        )
+    return str(raw_key)
 
 
 def _exchange_code_for_custom_token(api_base: str, code: str, redirect_uri: str) -> str:

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -114,6 +114,11 @@ def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
         )
 
     ctx.renderer.success(f"Logged in via [bold]{provider}[/bold] OAuth as profile [bold]{profile.name}[/bold].")
+    if not ctx.renderer.json_mode:
+        ctx.renderer.info(
+            "A developer API key for this machine was created in your Omi dashboard "
+            "(re-running browser login replaces it). Manage or revoke it there anytime."
+        )
     if ctx.renderer.json_mode:
         ctx.renderer.emit(
             {

--- a/sdks/python-cli/tests/test_auth_oauth.py
+++ b/sdks/python-cli/tests/test_auth_oauth.py
@@ -215,3 +215,76 @@ def test_firebase_signin_raises_on_missing_tokens(monkeypatch) -> None:
     monkeypatch.setattr(httpx.Client, "post", fake_post)
     with pytest.raises(AuthError):
         oauth._firebase_signin_with_custom_token("ct")
+
+
+# ---- Firebase session -> dev API key exchange -----------------------------
+
+
+def test_exchange_firebase_token_mints_key_and_replaces_own(monkeypatch) -> None:
+    calls: dict = {"deleted": [], "post": None}
+    name = oauth._cli_key_name()
+
+    def fake_get(self, url, **kwargs):  # noqa: ANN001
+        # One key that's ours (exact name match) + one unrelated key.
+        return httpx.Response(
+            200,
+            json=[
+                {"id": "ours-1", "name": name},
+                {"id": "other", "name": "someone elses key"},
+            ],
+        )
+
+    def fake_delete(self, url, **kwargs):  # noqa: ANN001
+        calls["deleted"].append(url)
+        return httpx.Response(204)
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        calls["post"] = (url, kwargs.get("json"), kwargs.get("headers"))
+        return httpx.Response(200, json={"id": "new", "name": name, "key": "omi_dev_minted"})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "delete", fake_delete)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+
+    key = oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local/", "fb_id_tok")
+
+    assert key == "omi_dev_minted"
+    # Only our own key was deleted; the unrelated one was left alone.
+    assert calls["deleted"] == ["https://api.test.omi.local/v1/dev/keys/ours-1"]
+    url, body, headers = calls["post"]
+    assert url == "https://api.test.omi.local/v1/dev/keys"
+    assert body["name"] == name
+    assert body["scopes"] == oauth._CLI_KEY_SCOPES
+    assert headers["Authorization"] == "Bearer fb_id_tok"
+
+
+def test_exchange_firebase_token_proceeds_when_listing_fails(monkeypatch) -> None:
+    def fake_get(self, url, **kwargs):  # noqa: ANN001
+        raise httpx.ConnectError("listing unavailable")
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(200, json={"key": "omi_dev_after_failed_list"})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+
+    key = oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
+    assert key == "omi_dev_after_failed_list"
+
+
+def test_exchange_firebase_token_raises_on_non_200(monkeypatch) -> None:
+    monkeypatch.setattr(httpx.Client, "get", lambda self, url, **kw: httpx.Response(200, json=[]))
+    monkeypatch.setattr(httpx.Client, "post", lambda self, url, **kw: httpx.Response(403, json={"detail": "nope"}))
+    with pytest.raises(AuthError) as info:
+        oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
+    assert "create an api key" in str(info.value).lower()
+
+
+def test_exchange_firebase_token_raises_when_key_field_missing(monkeypatch) -> None:
+    monkeypatch.setattr(httpx.Client, "get", lambda self, url, **kw: httpx.Response(200, json=[]))
+    monkeypatch.setattr(
+        httpx.Client, "post", lambda self, url, **kw: httpx.Response(200, json={"id": "x", "name": "y"})
+    )
+    with pytest.raises(AuthError) as info:
+        oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
+    assert "missing the api key" in str(info.value).lower()


### PR DESCRIPTION
## Why

After 0.2.2, browser OAuth gets past Firebase but fails with `✗ Authentication failed / Invalid API Key`. Root cause is architectural, not a key/typo:

- Every `/v1/dev/*` endpoint the CLI uses authenticates via a **developer API key** (`get_api_key_auth` → `dev_api_key_db`).
- The OAuth flow produced a **Firebase ID token** and stored it directly, so the first `/v1/dev/user/memories` call → 401 `Invalid API Key`.
- The flow never performed the missing step: exchange the Firebase session for a dev key.

## What

- After Firebase sign-in, call `POST /v1/dev/keys` (which *is* Firebase-authed via `get_current_user_id`) to mint a long-lived dev key with full read+write scopes, and store **that** as a normal `api_key` profile. Browser OAuth is now just a friendlier way to obtain a key.
- Re-login deletes only the CLI's own prior key (matched by exact name `omi-cli (<host>)`) then mints fresh — no key sprawl, other keys never touched.
- Login now tells the user a dashboard key was created (discoverable/revocable).
- Tests: mint + selective-replace + listing-failure-tolerance + error paths.

## Verified

- 96 tests pass; `black --check` clean; build → `omi_cli-0.2.3`; `twine check` PASSED.
- `omi --version` → `omi-cli 0.2.3`; `login_with_browser` mints key + stores api_key (no more `store_oauth_tokens`).
- (`tomli` mypy note is pre-existing on `config.py:28`, unrelated; CI gates on pytest.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)