### PR TITLE
chore(backend): bump 6 vulnerable pins to patched (#7327)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -51,7 +51,7 @@ fonttools==4.60.2
 frozenlist==1.4.1
 fsspec==2024.6.1
 gitdb==4.0.11
-GitPython==3.1.47
+GitPython==3.1.50
 google-ai-generativelanguage==0.11.0
 google-api-core==2.19.1
 google-api-python-client==2.139.0
@@ -94,7 +94,7 @@ jsonschema-specifications==2023.12.1
 kiwisolver==1.4.5
 langchain==1.2.9
 langchain-community==0.4.1
-langchain-core==1.3.2
+langchain-core==1.3.3
 langchain-google-genai==3.2.0
 langchain-openai==1.1.9
 langchain-pinecone==0.2.13
@@ -104,10 +104,10 @@ langgraph==1.0.10
 langgraph-checkpoint==4.0.0
 langgraph-prebuilt==1.0.8
 langgraph-sdk==0.3.0
-langsmith==0.7.31
+langsmith==0.8.0
 lazy_loader==0.4
 llvmlite==0.43.0
-Mako==1.3.11
+Mako==1.3.12
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 marshmallow==3.26.2
@@ -158,14 +158,14 @@ pydantic-settings==2.10.1
 pydantic_core==2.33.2
 pydeck==0.9.1
 pydub==0.25.1
-Pygments==2.18.0
+Pygments==2.20.0
 PyJWT==2.12.0
 pynndescent==0.5.13
 PyOgg @ git+https://github.com/TeamPyOgg/PyOgg@6871a4f234e8a3a346c4874a12509bfa02c4c63a
 pyparsing==3.1.2
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
-python-multipart==0.0.26
+python-multipart==0.0.27
 python-slugify==8.0.4
 python-ulid==3.0.0
 pytz==2024.1
@@ -212,7 +212,7 @@ typing_extensions==4.15.0
 tzdata==2024.1
 umap-learn==0.5.6
 uritemplate==4.1.1
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.30.5
 uvloop==0.20.0
 watchdog==4.0.2


### PR DESCRIPTION
Part of #7327 — backend Tier-1 (listen). Branched from fresh `main`; single commit, **7 lines**.

## Changes — minimal security bumps (no major versions)
| pkg | from → to | sev |
|---|---|---|
| langchain-core | 1.3.2 → 1.3.3 | HIGH (CVE-2026-44843) |
| GitPython | 3.1.47 → 3.1.50 | HIGH |
| langsmith | 0.7.31 → 0.8.0 | HIGH |
| Mako | 1.3.11 → 1.3.12 | HIGH |
| python-multipart | 0.0.26 → 0.0.27 | HIGH |
| urllib3 | 2.6.3 → 2.7.0 | HIGH |
| Pygments | 2.18.0 → 2.20.0 | LOW |

`langchain-core 1.3.2 → 1.3.3` was added on review: `pip-audit` flagged CVE-2026-44843 in 1.3.2 (grouped Dependabot data had hidden it under older advisory ranges). The other open `backend/requirements.txt` alerts reconcile against the **current** pins as already-satisfied — `main` moved well past the stale #7327-era set (starlette 0.49.1, cryptography 46.0.7, aiohttp 3.13.4, pillow 12.2.0, orjson 3.11.6, …). Those auto-close.

## Residuals (flagged, not force-applied)
- **langchain-openai**: fix `1.1.14` requires `openai>=2.26,<3`; backend pins `openai==1.109.1` → a **breaking openai 1.x→2.x major** across the whole backend. Advisory is **LOW**. Kept at 1.1.9 — needs a separate deliberate openai-major migration.
- **torch** (CRIT alert): not a direct pin / not in this manifest's resolved tree — stale/misattributed.

## Validation
Full-manifest install + backend tests infeasible in CI sandbox (native pkgs like `lc3py` have no resolvable wheel here; backend needs Firestore/Redis/Deepgram). Validated via:
- `pip-audit` of the **7** target versions → **no known vulnerabilities**
- targeted `uv pip compile` (py3.11) of the langchain stack with **`langchain-core==1.3.3`** + `langsmith==0.8.0` → resolves clean (langchain 1.2.9 / langgraph 1.0.10 / langchain-community 0.4.1 / openai 1.109.1 all satisfied)
- targeted resolve of the 5 leaf bumps + key dependents (fastapi 0.121.0, starlette 0.49.1, requests ~2.33, twilio, qdrant, deepgram) → clean
- local install+import smoke: all 7 bumped packages install and import at the pinned target versions; the full bumped manifest (minus the unmodified, ARM-incompatible `lc3py`) resolves & imports with zero conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
