### PR TITLE
chore(backend/pusher): bump 3 vulnerable pins to patched (#7327)

### DIFF
--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -8,7 +8,7 @@ uvloop==0.20.0
 starlette==0.49.1
 websockets==12.0
 httpx==0.28.0
-python-multipart==0.0.26
+python-multipart==0.0.27
 
 # Data validation
 pydantic==2.11.10
@@ -48,13 +48,13 @@ openai==1.109.1
 groq==0.9.0
 langchain==1.2.9
 langchain-community==0.4.1
-langchain-core==1.3.2
+langchain-core==1.3.3
 langchain-google-genai==3.2.0
 langchain-openai==1.1.9
 langchain-pinecone==0.2.13
 langchain-text-splitters==1.1.2
 langgraph==1.0.10
-langsmith==0.7.31
+langsmith==0.8.0
 
 # Vector databases
 pinecone==7.3.0


### PR DESCRIPTION
Part of #7327 — backend Tier-1 (pusher). Branched from fresh `main`; single commit.

## Changes — minimal security bumps
| pkg | from → to | sev |
|---|---|---|
| langchain-core | 1.3.2 → 1.3.3 | HIGH (CVE-2026-44843) |
| langsmith | 0.7.31 → 0.8.0 | HIGH |
| python-multipart | 0.0.26 → 0.0.27 | HIGH |

## Residual (flagged, not force-applied)
**langchain-openai**: fix `1.1.14` requires `openai>=2.26,<3`; pusher pins `openai==1.109.1` → breaking openai 1.x→2.x major. Advisory **LOW**. Kept at 1.1.9 — same deliberate openai-major migration needed as the listen PR (#7352).

## Validation
`pip-audit` of the 3 targets → no known vulnerabilities. `langchain-core 1.3.3` + `langsmith 0.8.0` resolve clean with pusher's pinned langchain stack (identical to backend/requirements.txt; verified via targeted `uv pip compile` py3.11). Full-manifest install/tests infeasible in CI sandbox (native pkgs + Firestore/Redis/Deepgram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)