### PR TITLE
chore(backend/diarizer): bump 5 vulnerable pins to patched (#7327)

### DIFF
--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -32,7 +32,7 @@ julius==0.2.7
 kiwisolver==1.4.9
 lightning==2.6.0
 lightning-utilities==0.15.2
-mako==1.3.11
+mako==1.3.12
 markdown-it-py==4.0.0
 markupsafe==3.0.3
 matplotlib==3.10.8
@@ -70,7 +70,7 @@ pandas==2.3.3
 pillow==12.2.0
 primepy==1.3
 propcache==0.4.1
-protobuf==6.33.2
+protobuf==6.33.5
 pyannote-audio==4.0.3
 pyannote-core==6.0.1
 pyannote-database==6.1.1
@@ -80,10 +80,10 @@ pyannoteai-sdk==0.3.0
 pycparser==2.23
 pydantic==2.11.10
 pydantic-core==2.33.2
-pygments==2.19.2
+pygments==2.20.0
 pyparsing==3.3.0
 python-dateutil==2.9.0.post0
-python-multipart==0.0.26
+python-multipart==0.0.27
 pytorch-lightning==2.6.0
 pytorch-metric-learning==2.9.0
 pytz==2025.2
@@ -110,7 +110,7 @@ tqdm==4.67.1
 triton==3.4.0
 typing-extensions==4.15.0
 tzdata==2025.3
-urllib3==2.6.2
+urllib3==2.7.0
 uvicorn==0.40.0
 uvloop==0.20.0
 yarl==1.22.0


### PR DESCRIPTION
Part of #7327 — backend Tier-1 (diarizer). Branched from fresh `main`; single commit.

## Changes — minimal security bumps (no major versions)
| pkg | from → to | sev |
|---|---|---|
| protobuf | 6.33.2 → 6.33.5 | HIGH (CVE-2026-0994) |
| mako | 1.3.11 → 1.3.12 | HIGH (CVE-2026-44307) |
| python-multipart | 0.0.26 → 0.0.27 | HIGH (CVE-2026-42561) |
| urllib3 | 2.6.2 → 2.7.0 | HIGH (CVE-2026-44431/44432/21441) |
| pygments | 2.19.2 → 2.20.0 | LOW (CVE-2026-4539) |

**No residuals.** Diarizer has no langchain/openai coupling, and `torch` is already pinned at `2.8.0` (≥ the torch-CVE fix 2.6.0) — not vulnerable. (The #7327 `torch` alert was misattributed to backend/requirements.txt, which has no torch.)

## Validation
`pip-audit` of diarizer's pinned set → exactly these 5, no hidden advisories; the 5 targets audit clean. `protobuf 6.33.5` is an in-`6.33.x` patch (grpcio 1.76 / google libs compatible). Full-manifest install/tests infeasible in CI sandbox (torch/native ML wheels + infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)