### PR TITLE
chore(backend/modal): bump torch 2.3.1 → 2.8.0 (#7327)

### DIFF
--- a/backend/modal/requirements.txt
+++ b/backend/modal/requirements.txt
@@ -1,7 +1,7 @@
 # GPU services requirements — extends backend deps with torch/pyannote/speechbrain
 -r ../requirements.txt
-torch==2.3.1
-torchaudio==2.3.1
+torch==2.8.0
+torchaudio==2.8.0
 pyannote.audio==3.3.1
 speechbrain>=1.0.0,<2.0.0
 pandas==2.2.2


### PR DESCRIPTION
Part of #7327 — backend Tier-1 (modal). Branched from fresh `main`; single commit.

## Changes
| pkg | from → to | sev |
|---|---|---|
| torch | 2.3.1 → 2.8.0 | **CRITICAL** (+ CVE-2025-2953 / CVE-2025-3730) |
| torchaudio | 2.3.1 → 2.8.0 | matches torch's version line |

`torch 2.6.0` (the original Dependabot first-patched) clears the CRITICAL but is itself still vulnerable to CVE-2025-2953 / CVE-2025-3730 — fully clean only at **2.8.0**. 2.8.0 is the same torch already pinned & audited clean in `backend/diarizer`; it satisfies `pyannote.audio 3.3.1` (torch≥2.0, torchaudio≥2.2) and `speechbrain` (torch≥1.9).

## Inherited (not duplicated here)
modal does `-r ../requirements.txt`, so its other alerts (langchain-core, langsmith, urllib3, GitPython, python-multipart, Mako, Pygments — all transitive) are resolved by the **listen PR #7352**. `langchain-openai` remains a documented **LOW** residual there (fix requires a breaking openai 1.x→2.x major). No modal-specific residuals.

> Depends on #7352 for the inherited transitive fixes.

## Validation
`pip-audit` of `torch==2.8.0` / `torchaudio==2.8.0` → no known vulnerabilities. Full install/tests infeasible in CI sandbox (torch/CUDA wheels + Modal runtime + infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)