### PR TITLE
fix(backend): async coordinator pattern for sync v2 pipeline (#7361)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -144,7 +144,12 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
   - Semaphores: always wrap calls — `async with get_webhook_semaphore(): await client.post(...)`
   - Circuit breakers: `get_webhook_circuit_breaker(url)` for external targets — call `cb.record_success()`/`cb.record_failure()`
   - Lifecycle: lazy singletons, closed at shutdown via `close_all_clients()`
-- **Lane 2 — Executors** (`utils/executors.py`): 7 purpose-specific thread pools. Never ad-hoc `Thread`/`ThreadPoolExecutor`. Use `await run_blocking(executor, fn)` in async code or `submit_with_context(executor, fn)` for fire-and-forget.
+- **Lane 2 — Executors** (`utils/executors.py`): 7 purpose-specific thread pools. Never ad-hoc `Thread`/`ThreadPoolExecutor`.
+  - **Async dispatch rules** (choose the right primitive):
+    - `await run_blocking(executor, fn)` — sync/CPU-bound work where the caller needs the result before continuing.
+    - `start_background_task(coro, name=...)` — async fire-and-forget work (pipelines, post-processing). Tracks the task, logs exceptions, cleans up references. Never use bare `asyncio.create_task()` for production background work.
+    - `submit_with_context(executor, fn)` — short sync fire-and-forget only (precache, small cleanups). Never for pipelines that hold a slot >10s.
+  - **Long-running pipelines must be async coordinators.** Each blocking step uses `await run_blocking(pool, fn)`, borrowing a thread only for that step. Never hold a thread pool slot across await points or for >60s.
   - **Pool assignment** (match work type to pool):
     - `critical_executor` (8w) — auth gates only: `_verify_ws_auth`, `validate_byok_websocket`, `check_rate_limit`, `is_hard_restricted`, session/code Redis ops in `auth.py`
     - `db_executor` (16w) — Firestore/Redis CRUD, vector DB queries

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -153,11 +153,13 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
     - `sync_executor` (12w) — sync endpoint pipeline work
     - `postprocess_executor` (8w) — post-conversation processing, coordinator functions
     - `storage_executor` (16w) — GCS uploads/downloads, audio chunk I/O
-  - **Deadlock prevention — 3 rules:**
+  - **Deadlock prevention — 4 rules:**
     1. **Worker threads are leaf operations only.** Never `.result()` on another pool from inside a worker thread. If pool A thread submits to pool B and calls `.result()`, and vice versa, both pools deadlock.
     2. **Orchestration stays in async code.** The async handler coordinates via `await run_blocking(pool, fn)` — sequentially or with `asyncio.gather`. The event loop never blocks, pools stay independent.
     3. **Coordinators must not share a pool with their children.** If a function fans out work to `storage_executor` and waits on `.result()`, that function must run on a different pool (e.g., `postprocess_executor`), never on `storage_executor` itself — otherwise all threads become coordinators and children can't run.
+    4. **Long-running coordinators need async orchestration or sized pools.** If a coordinator holds a thread pool slot for >10s, it must either use async coordination (`asyncio.create_task` + `await run_blocking(...)`) or run on a pool sized for `hold_time × peak_concurrency`. Prefer async coordination for any coordinator with hold time >60s — thread slots occupied by sleeping coordinators waste memory and starve other work.
   - **Audit command:** `grep -rn '\.result()' --include="*.py" | grep -v tests/ | grep -v __pycache__` — every hit must be a leaf operation or a coordinator on a different pool from its children.
+  - **Pool observability:** `get_executor_metrics()` returns active count, queue depth, and utilization % for all pools. `log_executor_health()` runs every 60s, warns when any pool exceeds 70% utilization. Wired in `main.py` startup event.
 - **Lane 3 — Lint**: `python scripts/lint_async_blockers.py` catches `requests.*`, `time.sleep()`, `Thread().start()` in async code. Run before committing.
 - **Shutdown**: `close_all_clients()` + `shutdown_executors()` wired in `main.py` and `pusher/main.py`.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,6 +61,7 @@ from utils.other.timeout import TimeoutMiddleware
 from utils.observability import log_langsmith_status
 from utils.subscription import validate_stripe_price_ids
 from utils.http_client import close_all_clients
+from utils.executors import log_executor_health
 
 # Log LangSmith tracing status at startup
 log_langsmith_status()
@@ -151,8 +152,6 @@ app.add_middleware(BYOKMiddleware)
 
 @app.on_event("startup")
 async def startup_event():
-    from utils.executors import log_executor_health
-
     asyncio.create_task(log_executor_health())
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,7 +61,7 @@ from utils.other.timeout import TimeoutMiddleware
 from utils.observability import log_langsmith_status
 from utils.subscription import validate_stripe_price_ids
 from utils.http_client import close_all_clients
-from utils.executors import log_executor_health
+from utils.executors import drain_background_tasks, log_executor_health
 
 # Log LangSmith tracing status at startup
 log_langsmith_status()
@@ -157,6 +157,7 @@ async def startup_event():
 
 @app.on_event("shutdown")
 async def shutdown_event():
+    await drain_background_tasks(timeout=10.0)
     await close_all_clients()
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -146,6 +147,13 @@ app.add_middleware(TimeoutMiddleware, methods_timeout=methods_timeout)
 from utils.byok import BYOKMiddleware
 
 app.add_middleware(BYOKMiddleware)
+
+
+@app.on_event("startup")
+async def startup_event():
+    from utils.executors import log_executor_health
+
+    asyncio.create_task(log_executor_health())
 
 
 @app.on_event("shutdown")

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -9,6 +10,7 @@ from fastapi import FastAPI
 
 from routers import pusher, metrics
 from utils.http_client import close_all_clients
+from utils.executors import drain_background_tasks, log_executor_health
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
     service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
@@ -27,8 +29,14 @@ for path in paths:
         os.makedirs(path)
 
 
+@app.on_event("startup")
+async def startup_event():
+    asyncio.create_task(log_executor_health())
+
+
 @app.on_event("shutdown")
 async def shutdown_event():
+    await drain_background_tasks(timeout=10.0)
     await close_all_clients()
 
 

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1350,7 +1350,10 @@ def _retrieve_file_paths_v2(files: List[UploadFile], uid: str, job_id: str):
     return paths
 
 
-def _run_full_pipeline_background(
+_SYNC_PIPELINE_SEMAPHORE = asyncio.Semaphore(16)
+
+
+async def _run_full_pipeline_background_async(
     job_id: str,
     uid: str,
     raw_paths: list,
@@ -1358,242 +1361,269 @@ def _run_full_pipeline_background(
     should_lock: bool,
     job_dir: str,
     target_conversation_id: str = None,
-    event_loop=None,
-    byok_keys: dict = None,
 ):
-    """Background worker: runs the full sync pipeline (decode → VAD → fair-use → STT → LLM).
+    """Async coordinator for the full sync pipeline (decode → VAD → fair-use → STT → LLM).
 
-    Moved ALL heavy processing here so the v2 endpoint returns 202 immediately.
+    Runs as an asyncio task on the event loop. All blocking work is offloaded to
+    thread pools via run_blocking(). The coordinator itself holds zero thread pool
+    slots — only leaf operations use threads, and only for their actual duration.
     """
-    set_byok_keys(byok_keys or {})
-    segmented_paths = set()
-    wav_paths = []
-    stage_timings = {}
-    pipeline_start = time.monotonic()
-    try:
-        mark_job_processing(job_id)
-
-        # --- Phase 1: Decode ---
-        update_sync_job(job_id, {'stage': 'decoding'})
-        t0 = time.monotonic()
-        try:
-            wav_paths = decode_files_to_wav(raw_paths)
-        except HTTPException as e:
-            mark_job_failed(job_id, f'Decode failed: {e.detail}')
-            return
-        except Exception as e:
-            mark_job_failed(job_id, f'Decode failed: {e}')
-            return
-        finally:
-            _cleanup_files(raw_paths)
-        stage_timings['decode_ms'] = int((time.monotonic() - t0) * 1000)
-
-        if not wav_paths:
-            mark_job_completed(
-                job_id,
-                {
-                    'new_memories': [],
-                    'updated_memories': [],
-                    'failed_segments': 0,
-                    'total_segments': 0,
-                    'errors': [],
-                },
-            )
-            return
-
-        # --- Phase 2: VAD ---
-        update_sync_job(job_id, {'stage': 'vad'})
-        t0 = time.monotonic()
-        vad_errors = []
-
-        def _run_vad_bg(path):
-            try:
-                retrieve_vad_segments(path, segmented_paths, vad_errors)
-            except Exception as e:
-                vad_errors.append(f'{path}: {e}')
-
-        futures = [submit_with_context(sync_executor, _run_vad_bg, path) for path in wav_paths]
-        for future in futures:
-            try:
-                future.result(timeout=300)
-            except Exception as e:
-                vad_errors.append(f'VAD executor error: {e}')
-
-        stage_timings['vad_ms'] = int((time.monotonic() - t0) * 1000)
-        _cleanup_files(wav_paths)
+    async with _SYNC_PIPELINE_SEMAPHORE:
+        segmented_paths = set()
         wav_paths = []
+        stage_timings = {}
+        pipeline_start = time.monotonic()
+        try:
+            await run_blocking(db_executor, mark_job_processing, job_id)
 
-        if vad_errors:
-            error_detail = f'VAD failed for {len(vad_errors)} file(s): {"; ".join(vad_errors[:3])}'
-            if len(vad_errors) > 3:
-                error_detail += f' (and {len(vad_errors) - 3} more)'
-            _cleanup_files(list(segmented_paths))
-            segmented_paths = set()
-            mark_job_failed(job_id, error_detail)
-            return
+            # --- Phase 1: Decode ---
+            await run_blocking(db_executor, update_sync_job, job_id, {'stage': 'decoding'})
+            t0 = time.monotonic()
+            try:
+                wav_paths = await run_blocking(sync_executor, decode_files_to_wav, raw_paths)
+            except HTTPException as e:
+                await run_blocking(db_executor, mark_job_failed, job_id, f'Decode failed: {e.detail}')
+                return
+            except Exception as e:
+                await run_blocking(db_executor, mark_job_failed, job_id, f'Decode failed: {e}')
+                return
+            finally:
+                await run_blocking(storage_executor, _cleanup_files, raw_paths)
+            stage_timings['decode_ms'] = int((time.monotonic() - t0) * 1000)
 
-        # --- Phase 3: Speech metrics & fair-use ---
-        total_speech_seconds = sum(get_wav_duration(p) for p in segmented_paths)
-        total_speech_ms = int(total_speech_seconds * 1000)
-        total_segments = len(segmented_paths)
+            if not wav_paths:
+                await run_blocking(
+                    db_executor,
+                    mark_job_completed,
+                    job_id,
+                    {
+                        'new_memories': [],
+                        'updated_memories': [],
+                        'failed_segments': 0,
+                        'total_segments': 0,
+                        'errors': [],
+                    },
+                )
+                return
 
-        update_sync_job(job_id, {'total_segments': total_segments, 'stage': 'processing'})
+            # --- Phase 2: VAD ---
+            await run_blocking(db_executor, update_sync_job, job_id, {'stage': 'vad'})
+            t0 = time.monotonic()
+            vad_errors = []
 
-        if total_segments == 0:
-            mark_job_completed(
-                job_id,
-                {
-                    'new_memories': [],
-                    'updated_memories': [],
-                    'failed_segments': 0,
-                    'total_segments': 0,
-                    'errors': [],
-                },
+            def _run_vad_bg(path):
+                try:
+                    retrieve_vad_segments(path, segmented_paths, vad_errors)
+                except Exception as e:
+                    vad_errors.append(f'{path}: {e}')
+
+            vad_tasks = [
+                asyncio.wait_for(run_blocking(sync_executor, _run_vad_bg, path), timeout=300) for path in wav_paths
+            ]
+            vad_results = await asyncio.gather(*vad_tasks, return_exceptions=True)
+            for r in vad_results:
+                if isinstance(r, asyncio.TimeoutError):
+                    vad_errors.append('VAD timed out after 300s')
+                elif isinstance(r, Exception):
+                    vad_errors.append(f'VAD executor error: {r}')
+
+            stage_timings['vad_ms'] = int((time.monotonic() - t0) * 1000)
+            await run_blocking(storage_executor, _cleanup_files, wav_paths)
+            wav_paths = []
+
+            if vad_errors:
+                error_detail = f'VAD failed for {len(vad_errors)} file(s): {"; ".join(vad_errors[:3])}'
+                if len(vad_errors) > 3:
+                    error_detail += f' (and {len(vad_errors) - 3} more)'
+                await run_blocking(storage_executor, _cleanup_files, list(segmented_paths))
+                segmented_paths = set()
+                await run_blocking(db_executor, mark_job_failed, job_id, error_detail)
+                return
+
+            # --- Phase 3: Speech metrics & fair-use ---
+            total_speech_seconds = await run_blocking(
+                sync_executor, lambda: sum(get_wav_duration(p) for p in segmented_paths)
             )
-            return
+            total_speech_ms = int(total_speech_seconds * 1000)
+            total_segments = len(segmented_paths)
 
-        if FAIR_USE_ENABLED and total_speech_ms > 0:
-            record_speech_ms(uid, total_speech_ms, source='sync')
-            speech_totals = get_rolling_speech_ms(uid)
-            triggered_caps = check_soft_caps(uid, speech_totals=speech_totals)
-            if triggered_caps:
-                logger.info(f'sync_v2 bg: soft caps triggered for {uid}: {triggered_caps}')
-                if event_loop:
+            await run_blocking(
+                db_executor, update_sync_job, job_id, {'total_segments': total_segments, 'stage': 'processing'}
+            )
+
+            if total_segments == 0:
+                await run_blocking(
+                    db_executor,
+                    mark_job_completed,
+                    job_id,
+                    {
+                        'new_memories': [],
+                        'updated_memories': [],
+                        'failed_segments': 0,
+                        'total_segments': 0,
+                        'errors': [],
+                    },
+                )
+                return
+
+            if FAIR_USE_ENABLED and total_speech_ms > 0:
+                await run_blocking(db_executor, record_speech_ms, uid, total_speech_ms, source='sync')
+                speech_totals = await run_blocking(db_executor, get_rolling_speech_ms, uid)
+                triggered_caps = await run_blocking(db_executor, check_soft_caps, uid, speech_totals=speech_totals)
+                if triggered_caps:
+                    logger.info(f'sync_v2 bg: soft caps triggered for {uid}: {triggered_caps}')
                     try:
-                        asyncio.run_coroutine_threadsafe(trigger_classifier_if_needed(uid, triggered_caps), event_loop)
+                        asyncio.create_task(trigger_classifier_if_needed(uid, triggered_caps))
                     except Exception as e:
                         logger.error(f'sync_v2 bg: classifier scheduling failed for {uid}: {e}')
 
-        # DG budget gate
-        fair_use_restrict_dg = False
-        if FAIR_USE_ENABLED:
+            # DG budget gate
+            fair_use_restrict_dg = False
+            if FAIR_USE_ENABLED:
+                try:
+                    fair_use_stage = await run_blocking(db_executor, get_enforcement_stage, uid)
+                    if fair_use_stage == 'restrict' and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
+                        fair_use_restrict_dg = True
+                        if await run_blocking(db_executor, is_dg_budget_exhausted, uid):
+                            await run_blocking(storage_executor, _cleanup_files, list(segmented_paths))
+                            segmented_paths = set()
+                            await run_blocking(
+                                db_executor, mark_job_failed, job_id, 'DG budget exhausted — audio retained for retry'
+                            )
+                            return
+                except Exception as e:
+                    logger.error(f'sync_v2 bg: DG budget check error for {uid}: {e}')
+
+            is_locked = should_lock
+
+            # --- Phase 4: Fetch prefs & embeddings ---
+            transcription_prefs = await run_blocking(db_executor, users_db.get_user_transcription_preferences, uid)
             try:
-                fair_use_stage = get_enforcement_stage(uid)
-                if fair_use_stage == 'restrict' and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
-                    fair_use_restrict_dg = True
-                    if is_dg_budget_exhausted(uid):
-                        _cleanup_files(list(segmented_paths))
-                        segmented_paths = set()
-                        mark_job_failed(job_id, 'DG budget exhausted — audio retained for retry')
-                        return
+                person_embeddings_cache = await run_blocking(db_executor, build_person_embeddings_cache, uid)
+                if person_embeddings_cache:
+                    logger.info(f'sync_v2 bg: loaded {len(person_embeddings_cache)} person embeddings uid={uid}')
             except Exception as e:
-                logger.error(f'sync_v2 bg: DG budget check error for {uid}: {e}')
+                logger.warning(f'sync_v2 bg: failed to load person embeddings uid={uid}: {e}')
+                person_embeddings_cache = {}
 
-        is_locked = should_lock
+            # --- Phase 5: Process segments (STT + LLM) ---
+            await run_blocking(db_executor, update_sync_job, job_id, {'stage': 'stt_llm'})
+            t0 = time.monotonic()
+            response = {'updated_memories': set(), 'new_memories': set()}
+            segment_errors = []
+            segment_lock = threading.Lock()
 
-        # --- Phase 4: Fetch prefs & embeddings ---
-        transcription_prefs = users_db.get_user_transcription_preferences(uid)
-        try:
-            person_embeddings_cache = build_person_embeddings_cache(uid)
-            if person_embeddings_cache:
-                logger.info(f'sync_v2 bg: loaded {len(person_embeddings_cache)} person embeddings uid={uid}')
-        except Exception as e:
-            logger.warning(f'sync_v2 bg: failed to load person embeddings uid={uid}: {e}')
-            person_embeddings_cache = {}
+            def _process_one_segment(path):
+                process_segment(
+                    path,
+                    uid,
+                    response,
+                    segment_lock,
+                    segment_errors,
+                    source,
+                    is_locked,
+                    transcription_prefs,
+                    person_embeddings_cache,
+                    target_conversation_id,
+                )
 
-        # --- Phase 5: Process segments (STT + LLM) ---
-        update_sync_job(job_id, {'stage': 'stt_llm'})
-        t0 = time.monotonic()
-        response = {'updated_memories': set(), 'new_memories': set()}
-        segment_errors = []
-        segment_lock = threading.Lock()
+            chunk_size = 5
+            segment_list = list(segmented_paths)
+            for i in range(0, len(segment_list), chunk_size):
+                chunk = segment_list[i : i + chunk_size]
+                seg_tasks = [
+                    asyncio.wait_for(run_blocking(sync_executor, _process_one_segment, path), timeout=300)
+                    for path in chunk
+                ]
+                seg_results = await asyncio.gather(*seg_tasks, return_exceptions=True)
+                for r in seg_results:
+                    if isinstance(r, asyncio.TimeoutError):
+                        segment_errors.append('Segment timed out after 300s')
+                        logger.error(f'sync_v2 bg: segment timed out job={job_id}')
+                    elif isinstance(r, Exception):
+                        logger.error(f'sync_v2 bg: segment error: {r}')
+                try:
+                    await run_blocking(
+                        db_executor,
+                        update_sync_job,
+                        job_id,
+                        {'processed_segments': min(i + chunk_size, len(segment_list))},
+                    )
+                except Exception:
+                    pass
 
-        def _process_one_segment(path):
-            process_segment(
-                path,
-                uid,
-                response,
-                segment_lock,
-                segment_errors,
-                source,
-                is_locked,
-                transcription_prefs,
-                person_embeddings_cache,
-                target_conversation_id,
+            stage_timings['stt_llm_ms'] = int((time.monotonic() - t0) * 1000)
+
+            # Record DG usage after processing
+            if fair_use_restrict_dg:
+                try:
+                    dg_ms = int(total_speech_seconds * 1000)
+                    if dg_ms > 0:
+                        await run_blocking(db_executor, record_dg_usage_ms, uid, dg_ms)
+                except Exception as e:
+                    logger.error(f'sync_v2 bg: DG usage record error for {uid}: {e}')
+
+            # Build result
+            failed_segments = len(segment_errors)
+            successful_segments = total_segments - failed_segments
+            result = {
+                'new_memories': sorted(response['new_memories']),
+                'updated_memories': sorted(response['updated_memories']),
+            }
+            if failed_segments > 0:
+                result['failed_segments'] = failed_segments
+                result['total_segments'] = total_segments
+                result['errors'] = segment_errors[:10]
+
+            if successful_segments > 0:
+                try:
+                    usage_seconds = int(total_speech_seconds)
+                    if usage_seconds > 0:
+                        await run_blocking(
+                            db_executor,
+                            record_usage,
+                            uid,
+                            transcription_seconds=usage_seconds,
+                            speech_seconds=usage_seconds,
+                        )
+                except Exception as e:
+                    logger.error(f'sync_v2 bg: usage record error for {uid}: {e}')
+
+            stage_timings['total_ms'] = int((time.monotonic() - pipeline_start) * 1000)
+            await run_blocking(
+                db_executor,
+                mark_job_completed,
+                job_id,
+                {
+                    'new_memories': result['new_memories'],
+                    'updated_memories': result['updated_memories'],
+                    'failed_segments': failed_segments,
+                    'total_segments': total_segments,
+                    'errors': segment_errors[:10] if segment_errors else [],
+                    'stage_timings': stage_timings,
+                },
             )
 
-        chunk_size = 5
-        segment_list = list(segmented_paths)
-        for i in range(0, len(segment_list), chunk_size):
-            chunk = segment_list[i : i + chunk_size]
-            seg_futures = [submit_with_context(sync_executor, _process_one_segment, path) for path in chunk]
-            for future in seg_futures:
-                try:
-                    future.result(timeout=300)
-                except TimeoutError:
-                    segment_errors.append(f'Segment timed out after 300s')
-                    logger.error(f'sync_v2 bg: segment timed out job={job_id}')
-                except Exception as e:
-                    logger.error(f'sync_v2 bg: segment error: {e}')
+            logger.info(
+                f'sync_v2 bg complete job={job_id} uid={uid} '
+                f'success={successful_segments}/{total_segments} '
+                f'timings={stage_timings}'
+            )
+        except Exception as e:
+            logger.error(f'sync_v2 bg failed job={job_id} uid={uid}: {e}')
             try:
-                update_sync_job(job_id, {'processed_segments': min(i + chunk_size, len(segment_list))})
+                await run_blocking(db_executor, mark_job_failed, job_id, str(e))
             except Exception:
                 pass
-
-        stage_timings['stt_llm_ms'] = int((time.monotonic() - t0) * 1000)
-
-        # Record DG usage after processing
-        if fair_use_restrict_dg:
+        finally:
+            set_byok_keys({})
+            await run_blocking(storage_executor, _cleanup_files, list(segmented_paths))
+            await run_blocking(storage_executor, _cleanup_files, wav_paths)
             try:
-                dg_ms = int(total_speech_seconds * 1000)
-                if dg_ms > 0:
-                    record_dg_usage_ms(uid, dg_ms)
+                if job_dir and os.path.isdir(job_dir):
+                    await run_blocking(storage_executor, shutil.rmtree, job_dir, True)
             except Exception as e:
-                logger.error(f'sync_v2 bg: DG usage record error for {uid}: {e}')
-
-        # Build result
-        failed_segments = len(segment_errors)
-        successful_segments = total_segments - failed_segments
-        result = {
-            'new_memories': sorted(response['new_memories']),
-            'updated_memories': sorted(response['updated_memories']),
-        }
-        if failed_segments > 0:
-            result['failed_segments'] = failed_segments
-            result['total_segments'] = total_segments
-            result['errors'] = segment_errors[:10]
-
-        if successful_segments > 0:
-            try:
-                usage_seconds = int(total_speech_seconds)
-                if usage_seconds > 0:
-                    record_usage(uid, transcription_seconds=usage_seconds, speech_seconds=usage_seconds)
-            except Exception as e:
-                logger.error(f'sync_v2 bg: usage record error for {uid}: {e}')
-
-        stage_timings['total_ms'] = int((time.monotonic() - pipeline_start) * 1000)
-        mark_job_completed(
-            job_id,
-            {
-                'new_memories': result['new_memories'],
-                'updated_memories': result['updated_memories'],
-                'failed_segments': failed_segments,
-                'total_segments': total_segments,
-                'errors': segment_errors[:10] if segment_errors else [],
-                'stage_timings': stage_timings,
-            },
-        )
-
-        logger.info(
-            f'sync_v2 bg complete job={job_id} uid={uid} '
-            f'success={successful_segments}/{total_segments} '
-            f'timings={stage_timings}'
-        )
-    except Exception as e:
-        logger.error(f'sync_v2 bg failed job={job_id} uid={uid}: {e}')
-        try:
-            mark_job_failed(job_id, str(e))
-        except Exception:
-            pass
-    finally:
-        set_byok_keys({})
-        _cleanup_files(list(segmented_paths))
-        _cleanup_files(wav_paths)
-        try:
-            if job_dir and os.path.isdir(job_dir):
-                shutil.rmtree(job_dir, ignore_errors=True)
-        except Exception as e:
-            logger.error(f'sync_v2 bg: failed to cleanup job dir {job_dir}: {e}')
+                logger.error(f'sync_v2 bg: failed to cleanup job dir {job_dir}: {e}')
 
 
 @router.post("/v2/sync-local-files")
@@ -1606,8 +1636,8 @@ async def sync_local_files_v2(
 ):
     """
     Async version of sync-local-files. Saves raw files and returns 202
-    immediately, then runs the full pipeline (decode → VAD → STT → LLM) in
-    a background thread. The app polls GET /v2/sync-local-files/{job_id}.
+    immediately, then runs the full pipeline (decode → VAD → STT → LLM) as
+    an async background task. The app polls GET /v2/sync-local-files/{job_id}.
     """
     # Pre-check gates (same as v1)
     if await run_blocking(critical_executor, is_hard_restricted, uid):
@@ -1635,30 +1665,24 @@ async def sync_local_files_v2(
         # Create Redis job — total_segments=0 until VAD completes in background
         await run_blocking(db_executor, create_sync_job, uid, total_files=len(files), total_segments=0, job_id=job_id)
 
-        # Capture event loop for async calls from background thread
-        loop_v2 = asyncio.get_running_loop()
-
-        # Capture BYOK keys from the request context before dispatching to thread
-        captured_byok = get_byok_keys()
-
-        # Transfer ownership of raw paths to the background thread
+        # Transfer ownership of raw paths to the background task
         owned_paths = list(paths)
-        paths = []  # Prevent finally cleanup of files now owned by bg thread
+        paths = []  # Prevent finally cleanup of files now owned by bg task
 
-        # Run in postprocess_executor (fire-and-forget coordinator for decode/VAD/STT/LLM)
-        submit_with_context(
-            postprocess_executor,
-            _run_full_pipeline_background,
-            job_id,
-            uid,
-            owned_paths,
-            source,
-            should_lock,
-            job_dir,
-            conversation_id,
-            loop_v2,
-            captured_byok,
+        # Async coordinator: runs on event loop, offloads blocking work to pools.
+        # No thread pool slot held for the full pipeline duration (fixes #7361).
+        task = asyncio.create_task(
+            _run_full_pipeline_background_async(
+                job_id,
+                uid,
+                owned_paths,
+                source,
+                should_lock,
+                job_dir,
+                conversation_id,
+            )
         )
+        task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
 
         return JSONResponse(
             status_code=202,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -22,6 +22,7 @@ from utils.executors import (
     storage_executor,
     sync_executor,
     run_blocking,
+    start_background_task,
     submit_with_context,
 )
 
@@ -1674,7 +1675,7 @@ async def sync_local_files_v2(
 
         # Async coordinator: runs on event loop, offloads blocking work to pools.
         # No thread pool slot held for the full pipeline duration (fixes #7361).
-        task = asyncio.create_task(
+        start_background_task(
             _run_full_pipeline_background_async(
                 job_id,
                 uid,
@@ -1683,9 +1684,9 @@ async def sync_local_files_v2(
                 should_lock,
                 job_dir,
                 conversation_id,
-            )
+            ),
+            name=f'sync_pipeline:{job_id}',
         )
-        task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
 
         return JSONResponse(
             status_code=202,

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1350,7 +1350,25 @@ def _retrieve_file_paths_v2(files: List[UploadFile], uid: str, job_id: str):
     return paths
 
 
-_SYNC_PIPELINE_SEMAPHORE = asyncio.Semaphore(16)
+_sync_semaphores: dict[tuple[int, str], asyncio.Semaphore] = {}
+
+
+def _get_sync_pipeline_semaphore() -> asyncio.Semaphore:
+    """Return a loop-scoped semaphore capping concurrent sync pipelines.
+
+    Semaphores are event-loop-bound. Using the same pattern as http_client.py
+    to key by (loop_id, name) prevents RuntimeError when multiple loops exist.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        key = (id(loop), 'sync_pipeline')
+    except RuntimeError:
+        return asyncio.Semaphore(16)
+    if key not in _sync_semaphores:
+        if len(_sync_semaphores) > 10:
+            _sync_semaphores.clear()
+        _sync_semaphores[key] = asyncio.Semaphore(16)
+    return _sync_semaphores[key]
 
 
 async def _run_full_pipeline_background_async(
@@ -1368,7 +1386,7 @@ async def _run_full_pipeline_background_async(
     thread pools via run_blocking(). The coordinator itself holds zero thread pool
     slots — only leaf operations use threads, and only for their actual duration.
     """
-    async with _SYNC_PIPELINE_SEMAPHORE:
+    async with _get_sync_pipeline_semaphore():
         segmented_paths = set()
         wav_paths = []
         stage_timings = {}

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -58,6 +58,7 @@ from utils.other.storage import (
 
 from utils import encryption
 from utils.byok import get_byok_keys, set_byok_keys
+from utils.http_client import _get_semaphore
 from utils.log_sanitizer import sanitize
 from utils.stt.pre_recorded import deepgram_prerecorded, get_deepgram_model_for_language, postprocess_words
 from utils.stt.vad import vad_is_empty
@@ -1350,25 +1351,9 @@ def _retrieve_file_paths_v2(files: List[UploadFile], uid: str, job_id: str):
     return paths
 
 
-_sync_semaphores: dict[tuple[int, str], asyncio.Semaphore] = {}
-
-
 def _get_sync_pipeline_semaphore() -> asyncio.Semaphore:
-    """Return a loop-scoped semaphore capping concurrent sync pipelines.
-
-    Semaphores are event-loop-bound. Using the same pattern as http_client.py
-    to key by (loop_id, name) prevents RuntimeError when multiple loops exist.
-    """
-    try:
-        loop = asyncio.get_running_loop()
-        key = (id(loop), 'sync_pipeline')
-    except RuntimeError:
-        return asyncio.Semaphore(16)
-    if key not in _sync_semaphores:
-        if len(_sync_semaphores) > 10:
-            _sync_semaphores.clear()
-        _sync_semaphores[key] = asyncio.Semaphore(16)
-    return _sync_semaphores[key]
+    """Return a loop-scoped semaphore capping concurrent sync pipelines."""
+    return _get_semaphore('sync_pipeline', 16)
 
 
 async def _run_full_pipeline_background_async(

--- a/backend/tests/unit/test_executors.py
+++ b/backend/tests/unit/test_executors.py
@@ -12,9 +12,13 @@ import pytest
 
 from utils.executors import (
     MonitoredThreadPoolExecutor,
+    _background_tasks,
+    drain_background_tasks,
+    get_background_task_count,
     get_executor_metrics,
     log_executor_health,
     run_blocking,
+    start_background_task,
     submit_with_context,
     _ALL_EXECUTORS,
 )
@@ -200,6 +204,99 @@ def test_all_executors_are_monitored():
     """All registered executors must be MonitoredThreadPoolExecutor instances."""
     for executor in _ALL_EXECUTORS:
         assert isinstance(executor, MonitoredThreadPoolExecutor), f'{executor} is not MonitoredThreadPoolExecutor'
+
+
+# ---------------------------------------------------------------------------
+# log_executor_health tests
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# start_background_task tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_background_task_runs_coroutine():
+    """start_background_task must execute the coroutine and return a Task."""
+    result = {}
+
+    async def work():
+        result['done'] = True
+        return 42
+
+    task = start_background_task(work(), name='test-run')
+    assert isinstance(task, asyncio.Task)
+    assert task.get_name() == 'test-run'
+    await task
+    assert result['done'] is True
+    assert task.result() == 42
+
+
+@pytest.mark.asyncio
+async def test_start_background_task_tracks_and_removes():
+    """Task must be in _background_tasks while running, removed after completion."""
+    event = asyncio.Event()
+
+    async def wait_for_signal():
+        await event.wait()
+
+    task = start_background_task(wait_for_signal(), name='test-track')
+    assert task in _background_tasks
+    assert get_background_task_count() >= 1
+    event.set()
+    await task
+    await asyncio.sleep(0)  # let done callback fire
+    assert task not in _background_tasks
+
+
+@pytest.mark.asyncio
+async def test_start_background_task_logs_exceptions(caplog):
+    """Exceptions in background tasks must be logged, not silently swallowed."""
+
+    async def fail():
+        raise RuntimeError('bg-boom')
+
+    with caplog.at_level(logging.ERROR, logger='utils.executors'):
+        task = start_background_task(fail(), name='test-exc')
+        await asyncio.sleep(0.05)
+    assert any('background_task failed: test-exc' in r.message for r in caplog.records)
+    assert task not in _background_tasks
+
+
+@pytest.mark.asyncio
+async def test_start_background_task_logs_cancellation(caplog):
+    """Cancelled background tasks must log info, not error."""
+
+    async def forever():
+        await asyncio.sleep(3600)
+
+    with caplog.at_level(logging.INFO, logger='utils.executors'):
+        task = start_background_task(forever(), name='test-cancel')
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0)
+    assert any('background_task cancelled: test-cancel' in r.message for r in caplog.records)
+    assert task not in _background_tasks
+
+
+@pytest.mark.asyncio
+async def test_drain_background_tasks_cancels_all():
+    """drain_background_tasks must cancel and await all tracked tasks."""
+    events = [asyncio.Event() for _ in range(3)]
+
+    async def wait(e):
+        await e.wait()
+
+    tasks = [start_background_task(wait(e), name=f'drain-{i}') for i, e in enumerate(events)]
+    assert get_background_task_count() >= 3
+    cancelled = await drain_background_tasks(timeout=2.0)
+    assert cancelled == 3
+    for t in tasks:
+        assert t.done()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_executors.py
+++ b/backend/tests/unit/test_executors.py
@@ -1,13 +1,20 @@
-"""Tests for utils/executors.py run_blocking and submit_with_context."""
+"""Tests for utils/executors.py run_blocking, submit_with_context, and MonitoredThreadPoolExecutor."""
 
 import asyncio
 import contextvars
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from utils.executors import run_blocking, submit_with_context
+from utils.executors import (
+    MonitoredThreadPoolExecutor,
+    get_executor_metrics,
+    run_blocking,
+    submit_with_context,
+    _ALL_EXECUTORS,
+)
 
 _test_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="test")
 _test_ctxvar = contextvars.ContextVar("test_key", default=None)
@@ -89,3 +96,104 @@ def test_submit_with_context_returns_future_with_result():
 
     future = submit_with_context(_test_executor, double, 21)
     assert future.result(timeout=5) == 42
+
+
+# ---------------------------------------------------------------------------
+# MonitoredThreadPoolExecutor tests
+# ---------------------------------------------------------------------------
+
+
+def test_monitored_executor_is_threadpoolexecutor():
+    """MonitoredThreadPoolExecutor must be a proper ThreadPoolExecutor subclass."""
+    assert issubclass(MonitoredThreadPoolExecutor, ThreadPoolExecutor)
+
+
+def test_monitored_executor_tracks_active_count():
+    """active_count must increment during task execution and decrement after."""
+    executor = MonitoredThreadPoolExecutor(name="test-active", max_workers=2)
+    assert executor.active_count == 0
+    event = threading.Event()
+    captured = {}
+
+    def block_and_capture():
+        captured['active'] = executor.active_count
+        event.wait(timeout=5)
+
+    future = executor.submit(block_and_capture)
+    time.sleep(0.05)
+    assert executor.active_count >= 1
+    event.set()
+    future.result(timeout=5)
+    time.sleep(0.05)
+    assert executor.active_count == 0
+    assert captured['active'] >= 1
+    executor.shutdown(wait=False)
+
+
+def test_monitored_executor_has_name():
+    """MonitoredThreadPoolExecutor must expose its name attribute."""
+    executor = MonitoredThreadPoolExecutor(name="my-pool", max_workers=1)
+    assert executor.name == "my-pool"
+    executor.shutdown(wait=False)
+
+
+def test_monitored_executor_submit_returns_result():
+    """submit must still return a working Future with the correct result."""
+    executor = MonitoredThreadPoolExecutor(name="test-result", max_workers=1)
+    future = executor.submit(lambda x: x * 3, 7)
+    assert future.result(timeout=5) == 21
+    executor.shutdown(wait=False)
+
+
+def test_monitored_executor_propagates_exceptions():
+    """Exceptions in submitted tasks must propagate through the Future."""
+    executor = MonitoredThreadPoolExecutor(name="test-exc", max_workers=1)
+
+    def fail():
+        raise RuntimeError("boom")
+
+    future = executor.submit(fail)
+    with pytest.raises(RuntimeError, match="boom"):
+        future.result(timeout=5)
+    assert executor.active_count == 0
+    executor.shutdown(wait=False)
+
+
+# ---------------------------------------------------------------------------
+# get_executor_metrics tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_executor_metrics_returns_all_pools():
+    """get_executor_metrics must return one entry per registered executor."""
+    metrics = get_executor_metrics()
+    assert len(metrics) == len(_ALL_EXECUTORS)
+    names = {m['name'] for m in metrics}
+    expected = {'critical', 'db', 'llm', 'stripe', 'sync', 'postprocess', 'storage'}
+    assert names == expected
+
+
+def test_get_executor_metrics_fields():
+    """Each metric entry must have the required fields."""
+    metrics = get_executor_metrics()
+    for m in metrics:
+        assert 'name' in m
+        assert 'max_workers' in m
+        assert 'active_count' in m
+        assert 'queue_depth' in m
+        assert 'utilization_pct' in m
+        assert isinstance(m['utilization_pct'], float)
+
+
+def test_get_executor_metrics_idle_utilization():
+    """Idle executors must report 0% utilization."""
+    metrics = get_executor_metrics()
+    for m in metrics:
+        assert m['active_count'] >= 0
+        assert m['utilization_pct'] >= 0.0
+
+
+def test_all_executors_are_monitored():
+    """All registered executors must be MonitoredThreadPoolExecutor instances."""
+    for executor in _ALL_EXECUTORS:
+        assert isinstance(executor, MonitoredThreadPoolExecutor), f'{executor} is not MonitoredThreadPoolExecutor'

--- a/backend/tests/unit/test_executors.py
+++ b/backend/tests/unit/test_executors.py
@@ -2,15 +2,18 @@
 
 import asyncio
 import contextvars
+import logging
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
 
 import pytest
 
 from utils.executors import (
     MonitoredThreadPoolExecutor,
     get_executor_metrics,
+    log_executor_health,
     run_blocking,
     submit_with_context,
     _ALL_EXECUTORS,
@@ -197,3 +200,60 @@ def test_all_executors_are_monitored():
     """All registered executors must be MonitoredThreadPoolExecutor instances."""
     for executor in _ALL_EXECUTORS:
         assert isinstance(executor, MonitoredThreadPoolExecutor), f'{executor} is not MonitoredThreadPoolExecutor'
+
+
+# ---------------------------------------------------------------------------
+# log_executor_health tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_executor_health_warns_above_threshold(caplog):
+    """log_executor_health must emit a warning when any pool exceeds the threshold."""
+    saturated_metrics = [
+        {'name': 'test-pool', 'max_workers': 4, 'active_count': 4, 'queue_depth': 0, 'utilization_pct': 100.0},
+    ]
+    with patch('utils.executors.get_executor_metrics', return_value=saturated_metrics):
+        with patch('utils.executors.asyncio.sleep', side_effect=[None, asyncio.CancelledError]):
+            with caplog.at_level(logging.WARNING, logger='utils.executors'):
+                try:
+                    await log_executor_health(interval_seconds=1, utilization_threshold_pct=70.0)
+                except asyncio.CancelledError:
+                    pass
+    assert any('executor_pool_health' in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_log_executor_health_silent_below_threshold(caplog):
+    """log_executor_health must not log when all pools are below the threshold."""
+    idle_metrics = [
+        {'name': 'test-pool', 'max_workers': 8, 'active_count': 1, 'queue_depth': 0, 'utilization_pct': 12.5},
+    ]
+    with patch('utils.executors.get_executor_metrics', return_value=idle_metrics):
+        with patch('utils.executors.asyncio.sleep', side_effect=[None, asyncio.CancelledError]):
+            with caplog.at_level(logging.WARNING, logger='utils.executors'):
+                try:
+                    await log_executor_health(interval_seconds=1, utilization_threshold_pct=70.0)
+                except asyncio.CancelledError:
+                    pass
+    assert not any('executor_pool_health' in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_log_executor_health_swallows_exceptions(caplog):
+    """log_executor_health must swallow exceptions from get_executor_metrics and keep looping."""
+    call_count = 0
+
+    def _exploding_metrics():
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("boom")
+
+    side_effects = [None, None, asyncio.CancelledError]
+    with patch('utils.executors.get_executor_metrics', side_effect=_exploding_metrics):
+        with patch('utils.executors.asyncio.sleep', side_effect=side_effects):
+            try:
+                await log_executor_health(interval_seconds=1)
+            except asyncio.CancelledError:
+                pass
+    assert call_count == 2, f"Expected 2 calls before cancel, got {call_count}"

--- a/backend/tests/unit/test_executors.py
+++ b/backend/tests/unit/test_executors.py
@@ -240,6 +240,22 @@ async def test_log_executor_health_silent_below_threshold(caplog):
 
 
 @pytest.mark.asyncio
+async def test_log_executor_health_silent_at_exact_threshold(caplog):
+    """Utilization at exactly the threshold (70.0) must NOT trigger a warning (> not >=)."""
+    at_threshold_metrics = [
+        {'name': 'test-pool', 'max_workers': 10, 'active_count': 7, 'queue_depth': 0, 'utilization_pct': 70.0},
+    ]
+    with patch('utils.executors.get_executor_metrics', return_value=at_threshold_metrics):
+        with patch('utils.executors.asyncio.sleep', side_effect=[None, asyncio.CancelledError]):
+            with caplog.at_level(logging.WARNING, logger='utils.executors'):
+                try:
+                    await log_executor_health(interval_seconds=1, utilization_threshold_pct=70.0)
+                except asyncio.CancelledError:
+                    pass
+    assert not any('executor_pool_health' in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_log_executor_health_swallows_exceptions(caplog):
     """log_executor_health must swallow exceptions from get_executor_metrics and keep looping."""
     call_count = 0

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -901,6 +901,290 @@ class TestAsyncCoordinatorSemaphore:
 
 
 # ---------------------------------------------------------------------------
+# 7c. Async coordinator scenario coverage tests (#7361 tester round 1)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCoordinatorScenarios:
+    """Structural tests covering pipeline scenarios: decode failure, empty decode,
+    VAD error/timeout, zero segments, DG budget, partial/all segment failure,
+    prefs/cache fallback, target_conversation_id forwarding, and cleanup."""
+
+    @staticmethod
+    def _get_bg_func_body():
+        sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
+        with open(sync_path) as f:
+            source = f.read()
+        start = source.index('async def _run_full_pipeline_background_async')
+        next_boundary = source.find('\n@router.', start + 1)
+        if next_boundary == -1:
+            next_boundary = len(source)
+        return source[start:next_boundary]
+
+    # --- Decode failure scenarios ---
+
+    def test_decode_http_exception_marks_failed(self):
+        """HTTPException during decode must mark job failed with detail."""
+        body = self._get_bg_func_body()
+        assert 'except HTTPException as e:' in body
+        http_except_idx = body.index('except HTTPException as e:')
+        after = body[http_except_idx : http_except_idx + 200]
+        assert 'mark_job_failed' in after
+        assert 'Decode failed' in after
+
+    def test_decode_generic_exception_marks_failed(self):
+        """Generic Exception during decode must mark job failed."""
+        body = self._get_bg_func_body()
+        decode_section = body[body.index('decode_files_to_wav') : body.index('stage_timings[\'decode_ms\']')]
+        except_blocks = [i for i in range(len(decode_section)) if decode_section[i:].startswith('except Exception')]
+        assert len(except_blocks) >= 1, "Decode must catch generic Exception"
+        after_except = decode_section[except_blocks[0] :]
+        assert 'mark_job_failed' in after_except
+
+    def test_decode_failure_cleans_up_raw_paths(self):
+        """Raw file cleanup must happen in finally after decode, even on failure."""
+        body = self._get_bg_func_body()
+        decode_start = body.index('decode_files_to_wav')
+        decode_region = body[decode_start : decode_start + 600]
+        assert 'finally:' in decode_region
+        finally_idx = decode_region.index('finally:')
+        after_finally = decode_region[finally_idx:]
+        assert '_cleanup_files, raw_paths' in after_finally
+
+    def test_decode_failure_returns_early(self):
+        """Decode failure must return immediately, not fall through to VAD."""
+        body = self._get_bg_func_body()
+        decode_section = body[body.index('decode_files_to_wav') : body.index('Phase 2')]
+        return_count = decode_section.count('return')
+        assert return_count >= 2, "Decode failure paths must return early (HTTPException + generic)"
+
+    # --- Empty decode ---
+
+    def test_empty_decode_completes_with_zero_segments(self):
+        """Empty wav_paths must complete job with 0 segments, not fail."""
+        body = self._get_bg_func_body()
+        empty_check_idx = body.index('if not wav_paths:')
+        vad_phase_idx = body.index('Phase 2: VAD')
+        section = body[empty_check_idx:vad_phase_idx]
+        assert 'mark_job_completed' in section
+        assert "'total_segments': 0" in section
+        assert "'failed_segments': 0" in section
+
+    def test_empty_decode_does_not_run_vad(self):
+        """Empty wav_paths must return before VAD phase."""
+        body = self._get_bg_func_body()
+        empty_check_idx = body.index('if not wav_paths:')
+        vad_phase_idx = body.index('Phase 2: VAD')
+        return_after_empty = body[empty_check_idx:vad_phase_idx]
+        assert 'return' in return_after_empty
+
+    # --- VAD error/timeout ---
+
+    def test_vad_timeout_captured_as_error(self):
+        """VAD TimeoutError must be captured and appended to vad_errors."""
+        body = self._get_bg_func_body()
+        assert 'asyncio.TimeoutError' in body
+        timeout_idx = body.index('isinstance(r, asyncio.TimeoutError)')
+        after = body[timeout_idx : timeout_idx + 200]
+        assert 'vad_errors.append' in after
+        assert 'VAD timed out' in after
+
+    def test_vad_executor_error_captured(self):
+        """Generic executor error during VAD must be captured."""
+        body = self._get_bg_func_body()
+        vad_region = body[body.index('vad_results = await asyncio.gather') : body.index('stage_timings[\'vad_ms\']')]
+        assert 'isinstance(r, Exception)' in vad_region
+        assert 'VAD executor error' in vad_region
+
+    def test_vad_errors_mark_job_failed_and_cleanup(self):
+        """VAD errors must clean up segmented paths and mark job failed."""
+        body = self._get_bg_func_body()
+        vad_error_check = body[body.index('if vad_errors:') :]
+        vad_error_section = vad_error_check[: vad_error_check.index('return') + 10]
+        assert '_cleanup_files, list(segmented_paths)' in vad_error_section
+        assert 'mark_job_failed' in vad_error_section
+        assert 'VAD failed for' in vad_error_section
+
+    def test_vad_clears_segmented_paths_on_error(self):
+        """On VAD failure, segmented_paths must be cleared after cleanup."""
+        body = self._get_bg_func_body()
+        vad_error_section = body[body.index('if vad_errors:') : body.index('Phase 3')]
+        assert 'segmented_paths = set()' in vad_error_section
+
+    def test_vad_error_detail_truncated(self):
+        """VAD error detail must truncate after 3 errors to prevent huge messages."""
+        body = self._get_bg_func_body()
+        assert 'vad_errors[:3]' in body
+        assert 'and {len(vad_errors) - 3} more' in body
+
+    # --- Zero segments after VAD ---
+
+    def test_zero_segments_completes_not_fails(self):
+        """Zero segments after VAD (all silence) must complete with 0 segments."""
+        body = self._get_bg_func_body()
+        zero_check_idx = body.index('if total_segments == 0:')
+        fair_use_idx = body.index('FAIR_USE_ENABLED')
+        section = body[zero_check_idx:fair_use_idx]
+        assert 'mark_job_completed' in section
+        assert "'total_segments': 0" in section
+        assert 'return' in section
+
+    # --- DG budget ---
+
+    def test_dg_budget_exhausted_marks_failed(self):
+        """DG budget exhausted must mark job failed with descriptive message."""
+        body = self._get_bg_func_body()
+        assert 'is_dg_budget_exhausted' in body
+        dg_section = body[body.index('is_dg_budget_exhausted') :]
+        dg_early = dg_section[:500]
+        assert 'mark_job_failed' in dg_early
+        assert 'DG budget exhausted' in dg_early
+
+    def test_dg_budget_exhausted_cleans_up_segments(self):
+        """DG budget exhaustion must clean up segmented_paths before returning."""
+        body = self._get_bg_func_body()
+        dg_section = body[body.index('is_dg_budget_exhausted') : body.index('is_locked = should_lock')]
+        assert '_cleanup_files, list(segmented_paths)' in dg_section
+
+    def test_dg_budget_not_exhausted_continues(self):
+        """When DG budget is NOT exhausted, pipeline continues to segment processing."""
+        body = self._get_bg_func_body()
+        dg_section_end = body.index('is_locked = should_lock')
+        after_dg = body[dg_section_end:]
+        assert 'Phase 4: Fetch prefs' in after_dg
+        assert '_process_one_segment' in after_dg
+
+    def test_dg_budget_check_error_is_non_fatal(self):
+        """DG budget check exception must be logged but not fail the pipeline."""
+        body = self._get_bg_func_body()
+        dg_check_region = body[body.index('DG budget gate') : body.index('is_locked = should_lock')]
+        assert "except Exception as e:" in dg_check_region
+        assert "DG budget check error" in dg_check_region
+
+    def test_dg_usage_recorded_after_processing(self):
+        """DG usage recording must happen after segment processing, not before."""
+        body = self._get_bg_func_body()
+        processing_end = body.index("stage_timings['stt_llm_ms']")
+        record_dg_idx = body.index('record_dg_usage_ms')
+        assert record_dg_idx > processing_end
+
+    # --- Partial / all segment failure ---
+
+    def test_segment_timeout_captured(self):
+        """Segment TimeoutError must be captured in segment_errors."""
+        body = self._get_bg_func_body()
+        seg_section = body[body.index('seg_results = await asyncio.gather') :]
+        seg_early = seg_section[:500]
+        assert 'isinstance(r, asyncio.TimeoutError)' in seg_early
+        assert 'Segment timed out' in seg_early
+
+    def test_segment_errors_included_in_result(self):
+        """segment_errors must be included in the final result sent to mark_job_completed."""
+        body = self._get_bg_func_body()
+        result_section = body[body.index("# Build result") :]
+        assert 'failed_segments' in result_section
+        assert 'segment_errors' in result_section
+        assert 'segment_errors[:10]' in result_section
+
+    def test_partial_failure_still_completes(self):
+        """Partial segment failure must still call mark_job_completed (not mark_job_failed)."""
+        body = self._get_bg_func_body()
+        build_result_idx = body.index("# Build result")
+        general_except_idx = body.index("sync_v2 bg failed job=")
+        result_section = body[build_result_idx:general_except_idx]
+        assert 'mark_job_completed' in result_section
+
+    def test_segment_errors_capped_at_10(self):
+        """segment_errors in result must be capped to prevent large Redis values."""
+        body = self._get_bg_func_body()
+        assert 'segment_errors[:10]' in body
+
+    # --- Prefs / cache fallback ---
+
+    def test_prefs_fetched_from_db(self):
+        """Transcription prefs must be fetched via run_blocking(db_executor, ...)."""
+        body = self._get_bg_func_body()
+        assert 'get_user_transcription_preferences' in body
+        assert 'db_executor' in body
+
+    def test_person_embeddings_fallback_on_error(self):
+        """Person embeddings cache failure must fall back to empty dict, not crash."""
+        body = self._get_bg_func_body()
+        embeddings_section = body[body.index('build_person_embeddings_cache') : body.index('Phase 5')]
+        assert 'except Exception' in embeddings_section
+        assert 'person_embeddings_cache = {}' in embeddings_section
+
+    def test_person_embeddings_logged_on_failure(self):
+        """Person embeddings failure must be logged as warning."""
+        body = self._get_bg_func_body()
+        embeddings_section = body[body.index('build_person_embeddings_cache') : body.index('Phase 5')]
+        assert 'failed to load person embeddings' in embeddings_section
+
+    # --- target_conversation_id forwarding ---
+
+    def test_target_conversation_id_in_signature(self):
+        """target_conversation_id must be in the function signature."""
+        body = self._get_bg_func_body()
+        sig_end = body.index('):')
+        sig = body[:sig_end]
+        assert 'target_conversation_id' in sig
+
+    def test_target_conversation_id_forwarded_to_process_segment(self):
+        """target_conversation_id must be passed through to _process_one_segment / process_segment."""
+        body = self._get_bg_func_body()
+        process_segment_section = body[body.index('def _process_one_segment') :]
+        process_segment_call = process_segment_section[:500]
+        assert 'target_conversation_id' in process_segment_call
+
+    # --- Cleanup on success and failure ---
+
+    def test_finally_clears_byok_keys(self):
+        """Finally block must clear BYOK keys to prevent context leaks."""
+        body = self._get_bg_func_body()
+        finally_idx = body.rindex('finally:')
+        after_finally = body[finally_idx:]
+        assert 'set_byok_keys({})' in after_finally
+
+    def test_finally_cleans_segmented_paths(self):
+        """Finally block must clean up segmented_paths."""
+        body = self._get_bg_func_body()
+        finally_idx = body.rindex('finally:')
+        after_finally = body[finally_idx:]
+        assert '_cleanup_files, list(segmented_paths)' in after_finally
+
+    def test_finally_cleans_wav_paths(self):
+        """Finally block must clean up wav_paths."""
+        body = self._get_bg_func_body()
+        finally_idx = body.rindex('finally:')
+        after_finally = body[finally_idx:]
+        assert '_cleanup_files, wav_paths' in after_finally
+
+    def test_finally_removes_job_directory(self):
+        """Finally block must remove job directory via shutil.rmtree."""
+        body = self._get_bg_func_body()
+        finally_idx = body.rindex('finally:')
+        after_finally = body[finally_idx:]
+        assert 'shutil.rmtree' in after_finally
+        assert 'job_dir' in after_finally
+
+    def test_general_exception_marks_failed(self):
+        """General except Exception must mark job failed with error message."""
+        body = self._get_bg_func_body()
+        main_except = body[body.index("except Exception as e:\n            logger.error(f'sync_v2 bg failed") :]
+        main_except_early = main_except[:200]
+        assert 'mark_job_failed' in main_except_early
+
+    def test_cleanup_order_byok_before_files(self):
+        """BYOK keys must be cleared before file cleanup in finally."""
+        body = self._get_bg_func_body()
+        finally_idx = body.rindex('finally:')
+        after_finally = body[finally_idx:]
+        byok_pos = after_finally.index('set_byok_keys({})')
+        cleanup_pos = after_finally.index('_cleanup_files')
+        assert byok_pos < cleanup_pos, "BYOK must be cleared before file cleanup"
+
+
+# ---------------------------------------------------------------------------
 # 8. v2 endpoint execution tests via FastAPI TestClient
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1185,6 +1185,446 @@ class TestAsyncCoordinatorScenarios:
 
 
 # ---------------------------------------------------------------------------
+# 7d. Behavioral async coordinator tests (invoke the actual coroutine)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCoordinatorBehavioral:
+    """Behavioral tests that invoke _run_full_pipeline_background_async with
+    mocked dependencies. Verifies actual call sequences and outcomes."""
+
+    @staticmethod
+    def _load_sync_module():
+        """Load routers/sync.py with all heavy deps stubbed, return (module, stubs)."""
+        saved_modules = {}
+        stubs = {}
+
+        heavy_deps = [
+            'redis',
+            'database',
+            'database.redis_db',
+            'database._client',
+            'database.conversations',
+            'database.users',
+            'database.user_usage',
+            'firebase_admin',
+            'google',
+            'google.cloud',
+            'google.cloud.firestore_v1',
+            'opuslib',
+            'pydub',
+            'models',
+            'models.conversation',
+            'models.conversation_enums',
+            'models.transcript_segment',
+            'utils',
+            'utils.analytics',
+            'utils.byok',
+            'utils.conversations',
+            'utils.conversations.process_conversation',
+            'utils.conversations.factory',
+            'utils.other',
+            'utils.other.endpoints',
+            'utils.other.storage',
+            'utils.encryption',
+            'utils.stt',
+            'utils.stt.pre_recorded',
+            'utils.stt.vad',
+            'utils.fair_use',
+            'utils.subscription',
+            'utils.observability',
+            'utils.log_sanitizer',
+            'utils.http_client',
+            'utils.speaker_assignment',
+            'utils.speaker_identification',
+            'utils.stt.speaker_embedding',
+        ]
+
+        for mod_name in heavy_deps:
+            saved_modules[mod_name] = sys.modules.get(mod_name)
+            sys.modules[mod_name] = MagicMock()
+
+        mock_executors = MagicMock()
+        mock_executors.critical_executor = MagicMock()
+        mock_executors.sync_executor = MagicMock()
+        mock_executors.postprocess_executor = MagicMock()
+        mock_executors.storage_executor = MagicMock()
+        mock_executors.db_executor = MagicMock()
+
+        async def _passthrough_run_blocking(_executor, fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        mock_executors.run_blocking = _passthrough_run_blocking
+        mock_executors.submit_with_context = MagicMock()
+        saved_modules['utils.executors'] = sys.modules.get('utils.executors')
+        sys.modules['utils.executors'] = mock_executors
+
+        mock_sync_jobs = MagicMock()
+        mock_sync_jobs.mark_job_processing = MagicMock()
+        mock_sync_jobs.mark_job_completed = MagicMock()
+        mock_sync_jobs.mark_job_failed = MagicMock()
+        mock_sync_jobs.update_sync_job = MagicMock()
+        mock_sync_jobs.create_sync_job = MagicMock()
+        mock_sync_jobs.get_sync_job = MagicMock()
+        saved_modules['database.sync_jobs'] = sys.modules.get('database.sync_jobs')
+        sys.modules['database.sync_jobs'] = mock_sync_jobs
+
+        sys.modules['database.redis_db'] = MagicMock(r=MagicMock())
+        sys.modules['utils.fair_use'].FAIR_USE_ENABLED = False
+        sys.modules['utils.fair_use'].FAIR_USE_RESTRICT_DAILY_DG_MS = 0
+        sys.modules['utils.fair_use'].is_hard_restricted = MagicMock(return_value=False)
+        sys.modules['utils.fair_use'].is_dg_budget_exhausted = MagicMock(return_value=False)
+        sys.modules['utils.fair_use'].get_enforcement_stage = MagicMock(return_value='off')
+        sys.modules['utils.fair_use'].record_speech_ms = MagicMock()
+        sys.modules['utils.fair_use'].get_rolling_speech_ms = MagicMock(return_value={})
+        sys.modules['utils.fair_use'].check_soft_caps = MagicMock(return_value=[])
+        sys.modules['utils.fair_use'].trigger_classifier_if_needed = MagicMock()
+        sys.modules['utils.fair_use'].record_dg_usage_ms = MagicMock()
+        sys.modules['utils.byok'].set_byok_keys = MagicMock()
+        sys.modules['utils.byok'].get_byok_keys = MagicMock(return_value={})
+        sys.modules['utils.analytics'].record_usage = MagicMock()
+        sys.modules['models.conversation_enums'].ConversationSource = MagicMock()
+        sys.modules['utils.other.endpoints'].get_current_user_uid = MagicMock(return_value='test-uid')
+        sys.modules['utils.subscription'].has_transcription_credits = MagicMock(return_value=True)
+
+        sys.modules.pop('routers.sync', None)
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            'sync_behavioral',
+            os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py'),
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        stubs['sync_jobs'] = mock_sync_jobs
+        stubs['fair_use'] = sys.modules['utils.fair_use']
+        stubs['byok'] = sys.modules['utils.byok']
+        stubs['analytics'] = sys.modules['utils.analytics']
+        stubs['saved_modules'] = saved_modules
+
+        return module, stubs
+
+    @staticmethod
+    def _cleanup(saved_modules):
+        sys.modules.pop('routers.sync', None)
+        sys.modules.pop('sync_behavioral', None)
+        for mod_name, orig in saved_modules.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+    @pytest.mark.asyncio
+    async def test_decode_http_exception_marks_failed(self):
+        """Decode raising HTTPException must mark job failed."""
+        from fastapi import HTTPException as _HTTPException
+
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(side_effect=_HTTPException(status_code=400, detail='bad format'))
+            module._cleanup_files = MagicMock()
+
+            await module._run_full_pipeline_background_async('j1', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job1')
+
+            stubs['sync_jobs'].mark_job_failed.assert_called()
+            args = stubs['sync_jobs'].mark_job_failed.call_args[0]
+            assert args[0] == 'j1'
+            assert 'Decode failed' in args[1]
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_decode_generic_exception_marks_failed(self):
+        """Decode raising generic Exception must mark job failed."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(side_effect=RuntimeError('corrupt file'))
+            module._cleanup_files = MagicMock()
+
+            await module._run_full_pipeline_background_async('j2', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job2')
+
+            stubs['sync_jobs'].mark_job_failed.assert_called()
+            args = stubs['sync_jobs'].mark_job_failed.call_args[0]
+            assert 'Decode failed' in args[1]
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_empty_decode_completes_zero_segments(self):
+        """Empty wav_paths after decode must complete job with 0 segments."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=[])
+            module._cleanup_files = MagicMock()
+
+            await module._run_full_pipeline_background_async('j3', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job3')
+
+            stubs['sync_jobs'].mark_job_completed.assert_called_once()
+            result = stubs['sync_jobs'].mark_job_completed.call_args[0][1]
+            assert result['total_segments'] == 0
+            assert result['failed_segments'] == 0
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_vad_errors_mark_failed(self):
+        """VAD errors must mark job failed and clean up."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            module._cleanup_files = MagicMock()
+
+            def _bad_vad(path, segmented_paths, errors):
+                errors.append(f'{path}: silero exploded')
+
+            module.retrieve_vad_segments = _bad_vad
+
+            await module._run_full_pipeline_background_async('j4', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job4')
+
+            stubs['sync_jobs'].mark_job_failed.assert_called()
+            args = stubs['sync_jobs'].mark_job_failed.call_args[0]
+            assert 'VAD failed' in args[1]
+            assert module._cleanup_files.call_count >= 2
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_zero_segments_after_vad_completes(self):
+        """Zero segmented_paths after VAD must complete with 0 segments."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            module._cleanup_files = MagicMock()
+            module.retrieve_vad_segments = MagicMock()
+            module.get_wav_duration = MagicMock(return_value=0.0)
+
+            await module._run_full_pipeline_background_async('j5', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job5')
+
+            stubs['sync_jobs'].mark_job_completed.assert_called_once()
+            result = stubs['sync_jobs'].mark_job_completed.call_args[0][1]
+            assert result['total_segments'] == 0
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_dg_budget_exhausted_marks_failed(self):
+        """DG budget exhausted must mark job failed."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            module._cleanup_files = MagicMock()
+
+            def _vad_with_segments(path, segmented_paths, errors):
+                segmented_paths.add('/tmp/seg1.wav')
+
+            module.retrieve_vad_segments = _vad_with_segments
+            module.get_wav_duration = MagicMock(return_value=5.0)
+            module.FAIR_USE_ENABLED = True
+            module.FAIR_USE_RESTRICT_DAILY_DG_MS = 1000
+            module.get_enforcement_stage = MagicMock(return_value='restrict')
+            module.is_dg_budget_exhausted = MagicMock(return_value=True)
+            module.record_speech_ms = MagicMock()
+            module.get_rolling_speech_ms = MagicMock(return_value={})
+            module.check_soft_caps = MagicMock(return_value=[])
+
+            await module._run_full_pipeline_background_async('j6', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job6')
+
+            stubs['sync_jobs'].mark_job_failed.assert_called()
+            args = stubs['sync_jobs'].mark_job_failed.call_args[0]
+            assert 'DG budget exhausted' in args[1]
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_dg_budget_not_exhausted_continues(self):
+        """DG budget NOT exhausted must continue to segment processing."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            module._cleanup_files = MagicMock()
+
+            def _vad_with_segments(path, segmented_paths, errors):
+                segmented_paths.add('/tmp/seg1.wav')
+
+            module.retrieve_vad_segments = _vad_with_segments
+            module.get_wav_duration = MagicMock(return_value=5.0)
+            module.FAIR_USE_ENABLED = True
+            module.FAIR_USE_RESTRICT_DAILY_DG_MS = 1000
+            module.get_enforcement_stage = MagicMock(return_value='restrict')
+            module.is_dg_budget_exhausted = MagicMock(return_value=False)
+            module.record_speech_ms = MagicMock()
+            module.get_rolling_speech_ms = MagicMock(return_value={})
+            module.check_soft_caps = MagicMock(return_value=[])
+            module.users_db = MagicMock()
+            module.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            module.build_person_embeddings_cache = MagicMock(return_value={})
+            module.process_segment = MagicMock()
+            module.record_dg_usage_ms = MagicMock()
+            module.record_usage = MagicMock()
+
+            await module._run_full_pipeline_background_async('j7', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job7')
+
+            stubs['sync_jobs'].mark_job_completed.assert_called_once()
+            module.process_segment.assert_called_once()
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_partial_segment_failure_completes(self):
+        """Partial segment failure must complete (not fail) with error count."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            module._cleanup_files = MagicMock()
+
+            def _vad_two_segments(path, segmented_paths, errors):
+                segmented_paths.add('/tmp/seg1.wav')
+                segmented_paths.add('/tmp/seg2.wav')
+
+            module.retrieve_vad_segments = _vad_two_segments
+            module.get_wav_duration = MagicMock(return_value=5.0)
+            module.users_db = MagicMock()
+            module.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            module.build_person_embeddings_cache = MagicMock(return_value={})
+            module.record_usage = MagicMock()
+            call_count = [0]
+
+            def _process_seg_fails_once(path, uid, response, lock, errors, *args):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    errors.append(f'Segment {path} failed')
+                else:
+                    response['new_memories'].add('mem1')
+
+            module.process_segment = _process_seg_fails_once
+
+            await module._run_full_pipeline_background_async('j8', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job8')
+
+            stubs['sync_jobs'].mark_job_completed.assert_called_once()
+            result = stubs['sync_jobs'].mark_job_completed.call_args[0][1]
+            assert result['failed_segments'] == 1
+            assert result['total_segments'] == 2
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_person_embeddings_fallback(self):
+        """Person embeddings failure must fall back to empty dict, not crash."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            module._cleanup_files = MagicMock()
+
+            def _vad_one_seg(path, segmented_paths, errors):
+                segmented_paths.add('/tmp/seg1.wav')
+
+            module.retrieve_vad_segments = _vad_one_seg
+            module.get_wav_duration = MagicMock(return_value=5.0)
+            module.users_db = MagicMock()
+            module.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            module.build_person_embeddings_cache = MagicMock(side_effect=RuntimeError('cache boom'))
+            captured_cache = {}
+
+            def _capture_process(path, uid, response, lock, errors, source, is_locked, prefs, cache, *args):
+                captured_cache['value'] = cache
+                response['new_memories'].add('m1')
+
+            module.process_segment = _capture_process
+            module.record_usage = MagicMock()
+
+            await module._run_full_pipeline_background_async('j9', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job9')
+
+            assert captured_cache['value'] == {}
+            stubs['sync_jobs'].mark_job_completed.assert_called_once()
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_target_conversation_id_forwarded(self):
+        """target_conversation_id must be forwarded to process_segment."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            module._cleanup_files = MagicMock()
+
+            def _vad_one_seg(path, segmented_paths, errors):
+                segmented_paths.add('/tmp/seg1.wav')
+
+            module.retrieve_vad_segments = _vad_one_seg
+            module.get_wav_duration = MagicMock(return_value=5.0)
+            module.users_db = MagicMock()
+            module.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            module.build_person_embeddings_cache = MagicMock(return_value={})
+            module.record_usage = MagicMock()
+            captured_target = {}
+
+            def _capture_target(path, uid, response, lock, errors, source, is_locked, prefs, cache, target_cid):
+                captured_target['value'] = target_cid
+                response['new_memories'].add('m1')
+
+            module.process_segment = _capture_target
+
+            await module._run_full_pipeline_background_async(
+                'j10', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job10', target_conversation_id='conv-123'
+            )
+
+            assert captured_target['value'] == 'conv-123'
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_cleanup_called_on_success(self):
+        """Cleanup must be called even on successful completion."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            cleanup_calls = []
+            module._cleanup_files = lambda paths: cleanup_calls.append(list(paths))
+
+            def _vad_one_seg(path, segmented_paths, errors):
+                segmented_paths.add('/tmp/seg1.wav')
+
+            module.retrieve_vad_segments = _vad_one_seg
+            module.get_wav_duration = MagicMock(return_value=5.0)
+            module.users_db = MagicMock()
+            module.users_db.get_user_transcription_preferences = MagicMock(return_value={})
+            module.build_person_embeddings_cache = MagicMock(return_value={})
+            module.process_segment = MagicMock()
+            module.record_usage = MagicMock()
+
+            await module._run_full_pipeline_background_async('j11', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job11')
+
+            stubs['byok'].set_byok_keys.assert_called_with({})
+            assert len(cleanup_calls) >= 3
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+    @pytest.mark.asyncio
+    async def test_cleanup_called_on_failure(self):
+        """Cleanup and BYOK clear must happen even when pipeline crashes."""
+        module, stubs = self._load_sync_module()
+        try:
+            module.decode_files_to_wav = MagicMock(return_value=['/tmp/w.wav'])
+            cleanup_calls = []
+            module._cleanup_files = lambda paths: cleanup_calls.append(list(paths))
+
+            def _vad_one_seg(path, segmented_paths, errors):
+                segmented_paths.add('/tmp/seg1.wav')
+
+            module.retrieve_vad_segments = _vad_one_seg
+            module.get_wav_duration = MagicMock(side_effect=RuntimeError('unexpected crash'))
+
+            await module._run_full_pipeline_background_async('j12', 'uid', ['/tmp/f.opus'], 'omi', False, '/tmp/job12')
+
+            stubs['byok'].set_byok_keys.assert_called_with({})
+            stubs['sync_jobs'].mark_job_failed.assert_called()
+            assert len(cleanup_calls) >= 2
+        finally:
+            self._cleanup(stubs['saved_modules'])
+
+
+# ---------------------------------------------------------------------------
 # 8. v2 endpoint execution tests via FastAPI TestClient
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -66,7 +66,7 @@ class TestSyncV2Structure:
         assert "'poll_after_ms'" in func_body, "v2 response must include poll_after_ms"
 
     def test_v2_dispatches_async_coordinator(self):
-        """v2 must dispatch background work via asyncio.create_task (async coordinator, #7361)."""
+        """v2 must dispatch background work via start_background_task (async coordinator, #7361)."""
         source = self._read_sync_source()
         start = source.index('async def sync_local_files_v2')
         next_section = source.find('\n@router.', start + 1)
@@ -74,7 +74,7 @@ class TestSyncV2Structure:
             next_section = len(source)
         func_body = source[start:next_section]
 
-        assert 'asyncio.create_task' in func_body, "v2 must use asyncio.create_task for async coordinator"
+        assert 'start_background_task' in func_body, "v2 must use start_background_task for async coordinator"
         assert '_run_full_pipeline_background_async' in func_body, "v2 must dispatch the async pipeline coordinator"
         assert 'submit_with_context' not in func_body, (
             "v2 must NOT use submit_with_context — async coordinator runs on event loop, "
@@ -2134,8 +2134,8 @@ class TestBYOKContextPropagation:
         with open(path) as f:
             return f.read()
 
-    def test_v2_uses_create_task_for_context_inheritance(self):
-        """v2 must use asyncio.create_task which auto-inherits ContextVars (BYOK keys)."""
+    def test_v2_uses_start_background_task_for_context_inheritance(self):
+        """v2 must use start_background_task which wraps create_task (auto-inherits ContextVars/BYOK)."""
         source = self._read_sync_source()
         start = source.index('async def sync_local_files_v2')
         next_section = source.find('\n@router.', start + 1)
@@ -2143,7 +2143,7 @@ class TestBYOKContextPropagation:
             next_section = len(source)
         func_body = source[start:next_section]
 
-        assert 'asyncio.create_task' in func_body, "v2 must use asyncio.create_task for context inheritance"
+        assert 'start_background_task' in func_body, "v2 must use start_background_task for context inheritance"
 
     def test_async_coordinator_clears_byok_in_finally(self):
         """Async coordinator must clear BYOK context in its finally block."""

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -872,12 +872,11 @@ class TestAsyncCoordinatorSemaphore:
         with open(sync_path) as f:
             return f.read()
 
-    def test_semaphore_is_loop_scoped(self):
-        """Semaphore must be keyed by event loop ID, not module-level."""
+    def test_semaphore_delegates_to_http_client(self):
+        """Semaphore must use http_client._get_semaphore (CLAUDE.md rule 4)."""
         source = self._read_sync_source()
         assert '_get_sync_pipeline_semaphore()' in source, "Must use loop-scoped semaphore getter"
-        assert '_sync_semaphores' in source, "Must have loop-keyed semaphore cache"
-        assert 'asyncio.get_running_loop()' in source
+        assert '_get_semaphore' in source, "Must delegate to http_client._get_semaphore"
 
     def test_semaphore_limit_is_16(self):
         """Semaphore cap must be 16 (2x the old 8-slot postprocess_executor)."""
@@ -887,17 +886,12 @@ class TestAsyncCoordinatorSemaphore:
         if end == -1:
             end = source.find('\nasync def ', start + 1)
         func_body = source[start:end]
-        assert 'Semaphore(16)' in func_body
+        assert "'sync_pipeline', 16" in func_body
 
-    def test_semaphore_cache_has_prune(self):
-        """Semaphore cache must prune when it grows large to prevent leaks."""
+    def test_semaphore_no_duplicate_cache(self):
+        """sync.py must NOT have its own _sync_semaphores cache (use http_client's)."""
         source = self._read_sync_source()
-        start = source.index('def _get_sync_pipeline_semaphore')
-        end = source.find('\ndef ', start + 1)
-        if end == -1:
-            end = source.find('\nasync def ', start + 1)
-        func_body = source[start:end]
-        assert '.clear()' in func_body
+        assert '_sync_semaphores' not in source, "Must not duplicate semaphore cache — use http_client"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -445,7 +445,7 @@ class TestFullPipelineBackground:
         body = self._get_bg_func_body()
         assert body.startswith('async def'), "Pipeline must be async — coordinator runs on event loop"
         assert 'await run_blocking(' in body, "Async coordinator must offload blocking work to pools"
-        assert '_SYNC_PIPELINE_SEMAPHORE' in body, "Async coordinator must use semaphore for concurrency cap"
+        assert '_get_sync_pipeline_semaphore' in body, "Async coordinator must use loop-scoped semaphore"
 
     def test_background_uses_asyncio_wait_for_timeout(self):
         """Segment and VAD tasks must use asyncio.wait_for with timeout=300."""
@@ -792,9 +792,9 @@ class TestAsyncCoordinatorStructure:
         assert 'run_blocking(storage_executor, shutil.rmtree' in body
 
     def test_async_coordinator_uses_semaphore(self):
-        """Async coordinator must use _SYNC_PIPELINE_SEMAPHORE for concurrency cap."""
+        """Async coordinator must use loop-scoped semaphore for concurrency cap."""
         body = self._get_bg_func_body()
-        assert '_SYNC_PIPELINE_SEMAPHORE' in body
+        assert '_get_sync_pipeline_semaphore' in body
 
     def test_async_coordinator_marks_failed_on_exception(self):
         """Async coordinator must call mark_job_failed for error cases."""
@@ -856,6 +856,48 @@ class TestAsyncCoordinatorStructure:
         body = self._get_bg_func_body()
         assert 'submit_with_context' not in body, "Async coordinator must not use submit_with_context"
         assert '.result(' not in body, "Async coordinator must not call future.result()"
+
+
+# ---------------------------------------------------------------------------
+# 7b. Async coordinator behavioral test
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCoordinatorSemaphore:
+    """Verify the loop-scoped semaphore limits concurrent sync pipelines."""
+
+    @staticmethod
+    def _read_sync_source():
+        sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
+        with open(sync_path) as f:
+            return f.read()
+
+    def test_semaphore_is_loop_scoped(self):
+        """Semaphore must be keyed by event loop ID, not module-level."""
+        source = self._read_sync_source()
+        assert '_get_sync_pipeline_semaphore()' in source, "Must use loop-scoped semaphore getter"
+        assert '_sync_semaphores' in source, "Must have loop-keyed semaphore cache"
+        assert 'asyncio.get_running_loop()' in source
+
+    def test_semaphore_limit_is_16(self):
+        """Semaphore cap must be 16 (2x the old 8-slot postprocess_executor)."""
+        source = self._read_sync_source()
+        start = source.index('def _get_sync_pipeline_semaphore')
+        end = source.find('\ndef ', start + 1)
+        if end == -1:
+            end = source.find('\nasync def ', start + 1)
+        func_body = source[start:end]
+        assert 'Semaphore(16)' in func_body
+
+    def test_semaphore_cache_has_prune(self):
+        """Semaphore cache must prune when it grows large to prevent leaks."""
+        source = self._read_sync_source()
+        start = source.index('def _get_sync_pipeline_semaphore')
+        end = source.find('\ndef ', start + 1)
+        if end == -1:
+            end = source.find('\nasync def ', start + 1)
+        func_body = source[start:end]
+        assert '.clear()' in func_body
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -65,8 +65,8 @@ class TestSyncV2Structure:
         assert "'job_id'" in func_body, "v2 response must include job_id"
         assert "'poll_after_ms'" in func_body, "v2 response must include poll_after_ms"
 
-    def test_v2_submits_to_non_critical_executor(self):
-        """v2 must submit background work via submit_with_context(postprocess_executor) to avoid deadlock."""
+    def test_v2_dispatches_async_coordinator(self):
+        """v2 must dispatch background work via asyncio.create_task (async coordinator, #7361)."""
         source = self._read_sync_source()
         start = source.index('async def sync_local_files_v2')
         next_section = source.find('\n@router.', start + 1)
@@ -74,11 +74,11 @@ class TestSyncV2Structure:
             next_section = len(source)
         func_body = source[start:next_section]
 
-        assert 'submit_with_context' in func_body, "v2 must use submit_with_context for background worker"
-        assert '_run_full_pipeline_background' in func_body, "v2 must submit the full pipeline background worker"
-        assert 'postprocess_executor' in func_body, (
-            "v2 coordinator dispatch must use postprocess_executor (not critical_executor) — "
-            "passing critical_executor would nest executors and cause deadlock"
+        assert 'asyncio.create_task' in func_body, "v2 must use asyncio.create_task for async coordinator"
+        assert '_run_full_pipeline_background_async' in func_body, "v2 must dispatch the async pipeline coordinator"
+        assert 'submit_with_context' not in func_body, (
+            "v2 must NOT use submit_with_context — async coordinator runs on event loop, "
+            "not a thread pool slot (#7361)"
         )
 
     def test_v2_has_hard_restriction_gate(self):
@@ -120,7 +120,7 @@ class TestSyncV2Structure:
     def test_v2_background_has_cleanup(self):
         """Background worker must clean up files in finally block."""
         source = self._read_sync_source()
-        start = source.index('def _run_full_pipeline_background')
+        start = source.index('async def _run_full_pipeline_background_async')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
@@ -133,20 +133,20 @@ class TestSyncV2Structure:
     def test_v2_background_records_dg_after_processing(self):
         """DG usage must be recorded after processing, not before."""
         source = self._read_sync_source()
-        start = source.index('def _run_full_pipeline_background')
+        start = source.index('async def _run_full_pipeline_background_async')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
         func_body = source[start:next_boundary]
 
         dg_pos = func_body.index('record_dg_usage_ms')
-        processing_pos = func_body.index('future.result(')
+        processing_pos = func_body.index('asyncio.wait_for(run_blocking(sync_executor, _process_one_segment')
         assert dg_pos > processing_pos, "DG usage must be recorded AFTER segment processing"
 
     def test_v2_background_does_decode_and_vad(self):
         """Background worker must run decode and VAD (#7281 — moved from inline)."""
         source = self._read_sync_source()
-        start = source.index('def _run_full_pipeline_background')
+        start = source.index('async def _run_full_pipeline_background_async')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
@@ -160,7 +160,7 @@ class TestSyncV2Structure:
     def test_v2_background_has_stage_heartbeats(self):
         """Background worker must heartbeat with stage info during decode and VAD."""
         source = self._read_sync_source()
-        start = source.index('def _run_full_pipeline_background')
+        start = source.index('async def _run_full_pipeline_background_async')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
@@ -168,7 +168,9 @@ class TestSyncV2Structure:
 
         assert "'stage': 'decoding'" in func_body, "Background must heartbeat decode stage"
         assert "'stage': 'vad'" in func_body, "Background must heartbeat VAD stage"
-        assert "'stage': 'processing'" in func_body, "Background must heartbeat processing stage"
+        assert (
+            "'stage': 'processing'" in func_body or "'stage': 'stt_llm'" in func_body
+        ), "Background must heartbeat processing stage"
 
     def test_v2_get_checks_ownership(self):
         """GET endpoint must verify job belongs to requesting user."""
@@ -190,7 +192,7 @@ class TestSyncV2Structure:
     def test_v2_bg_worker_fetches_prefs_and_cache(self):
         """Background worker must fetch transcription prefs and build person embeddings cache."""
         source = self._read_sync_source()
-        start = source.index('def _run_full_pipeline_background')
+        start = source.index('async def _run_full_pipeline_background_async')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
@@ -387,14 +389,14 @@ class TestSyncJobsRedis:
 
 
 class TestFullPipelineBackground:
-    """Test _run_full_pipeline_background worker function."""
+    """Test _run_full_pipeline_background_async async coordinator function."""
 
     @staticmethod
     def _get_bg_func_body():
         sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
         with open(sync_path) as f:
             source = f.read()
-        start = source.index('def _run_full_pipeline_background')
+        start = source.index('async def _run_full_pipeline_background_async')
         next_boundary = source.find('\n@router.', start + 1)
         if next_boundary == -1:
             next_boundary = len(source)
@@ -402,20 +404,20 @@ class TestFullPipelineBackground:
 
     def test_background_calls_mark_job_processing(self):
         """Worker must transition job to processing status."""
-        assert 'mark_job_processing(job_id)' in self._get_bg_func_body()
+        assert 'mark_job_processing, job_id' in self._get_bg_func_body()
 
     def test_background_calls_mark_job_completed(self):
         """Worker must call mark_job_completed with result."""
         body = self._get_bg_func_body()
-        assert 'mark_job_completed(' in body and 'job_id' in body
+        assert 'mark_job_completed,' in body and 'job_id' in body
 
     def test_background_calls_mark_job_failed_on_exception(self):
         """Worker must call mark_job_failed on unexpected exception."""
         body = self._get_bg_func_body()
-        assert 'mark_job_failed(' in body and 'job_id' in body
+        assert 'mark_job_failed,' in body and 'job_id' in body
 
-    def test_background_uses_chunk_threads_pattern(self):
-        """Worker must batch threads in chunks of 5 (same as v1)."""
+    def test_background_uses_chunk_pattern(self):
+        """Worker must batch segments in chunks of 5."""
         assert 'chunk_size = 5' in self._get_bg_func_body()
 
     def test_background_result_matches_v1_shape(self):
@@ -427,10 +429,7 @@ class TestFullPipelineBackground:
     def test_background_has_heartbeat(self):
         """Worker must heartbeat (update_sync_job) during processing to prevent stale detection."""
         body = self._get_bg_func_body()
-        assert 'update_sync_job(' in body, "Worker must call update_sync_job for heartbeat"
-        heartbeat_pos = body.rindex('update_sync_job(')
-        result_pos = body.index('future.result(')
-        assert heartbeat_pos > result_pos, "Heartbeat must come after future.result()"
+        assert 'update_sync_job,' in body, "Worker must call update_sync_job for heartbeat"
 
     def test_background_pipeline_order(self):
         """Worker must run: decode → VAD → fair-use → STT in correct order."""
@@ -440,6 +439,19 @@ class TestFullPipelineBackground:
         speech_pos = body.index('record_speech_ms')
         segment_pos = body.index('process_segment')
         assert decode_pos < vad_pos < speech_pos < segment_pos
+
+    def test_background_is_async_coordinator(self):
+        """Background pipeline must be an async def, not a sync function (#7361)."""
+        body = self._get_bg_func_body()
+        assert body.startswith('async def'), "Pipeline must be async — coordinator runs on event loop"
+        assert 'await run_blocking(' in body, "Async coordinator must offload blocking work to pools"
+        assert '_SYNC_PIPELINE_SEMAPHORE' in body, "Async coordinator must use semaphore for concurrency cap"
+
+    def test_background_uses_asyncio_wait_for_timeout(self):
+        """Segment and VAD tasks must use asyncio.wait_for with timeout=300."""
+        body = self._get_bg_func_body()
+        assert 'asyncio.wait_for(' in body, "Must use asyncio.wait_for for timeout enforcement"
+        assert 'timeout=300' in body, "Must use 300s timeout"
 
 
 # ---------------------------------------------------------------------------
@@ -531,7 +543,7 @@ class TestV2EndpointContract:
             next_section = len(source)
         return source[start:next_section]
 
-    def test_v2_transfers_file_ownership_to_bg_thread(self):
+    def test_v2_transfers_file_ownership_to_bg_task(self):
         """v2 must transfer raw path ownership to prevent double cleanup."""
         body = self._get_v2_post_body()
         assert 'owned_paths = list(paths)' in body
@@ -732,556 +744,118 @@ class TestSyncJobsRedisBoundary:
 # ---------------------------------------------------------------------------
 
 
-class TestBackgroundWorkerBehavioral:
-    """Behavioral tests for _run_full_pipeline_background using mocks."""
+class TestAsyncCoordinatorStructure:
+    """Structural tests for _run_full_pipeline_background_async async coordinator (#7361).
+
+    The function is now async and cannot be called from sync test context.
+    These tests verify structure via source inspection.
+    """
 
     @staticmethod
-    def _load_bg_worker():
-        """Load the background worker function with all dependencies mocked."""
-        mock_redis = MagicMock()
-        mock_sync_jobs = MagicMock()
-
-        saved_modules = {}
-        heavy_deps = [
-            'redis',
-            'database',
-            'database.redis_db',
-            'database._client',
-            'database.conversations',
-            'database.users',
-            'firebase_admin',
-            'google',
-            'google.cloud',
-            'google.cloud.firestore_v1',
-            'opuslib',
-            'pydub',
-            'models',
-            'models.conversation',
-            'models.conversation_enums',
-            'models.transcript_segment',
-        ]
-        utils_subs = [
-            'utils',
-            'utils.byok',
-            'utils.conversations',
-            'utils.conversations.process_conversation',
-            'utils.conversations.factory',
-            'utils.other',
-            'utils.other.endpoints',
-            'utils.other.storage',
-            'utils.encryption',
-            'utils.stt',
-            'utils.stt.pre_recorded',
-            'utils.stt.vad',
-            'utils.fair_use',
-            'utils.subscription',
-            'utils.observability',
-            'utils.log_sanitizer',
-            'utils.analytics',
-            'utils.speaker_assignment',
-            'utils.speaker_identification',
-            'utils.stt.speaker_embedding',
-            'utils.executors',
-            'utils.http_client',
-        ]
-        heavy_deps.extend(utils_subs)
-
-        for mod in heavy_deps:
-            saved_modules[mod] = sys.modules.get(mod)
-            sys.modules[mod] = MagicMock()
-
-        import contextvars
-        from concurrent.futures import Future, ThreadPoolExecutor
-
-        _test_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix='test')
-
-        def _submit_with_context(executor, fn, *args, **kwargs):
-            ctx = contextvars.copy_context()
-            return executor.submit(ctx.run, fn, *args, **kwargs)
-
-        sys.modules['utils.executors'].critical_executor = _test_executor
-        sys.modules['utils.executors'].sync_executor = _test_executor
-        sys.modules['utils.executors'].postprocess_executor = _test_executor
-        sys.modules['utils.executors'].storage_executor = _test_executor
-        sys.modules['utils.executors'].submit_with_context = _submit_with_context
-
-        sys.modules['database.redis_db'] = MagicMock(r=mock_redis)
-        saved_modules['database.sync_jobs'] = sys.modules.get('database.sync_jobs')
-        sys.modules['database.sync_jobs'] = mock_sync_jobs
-
-        # Fair-use defaults
-        sys.modules['utils.fair_use'].FAIR_USE_ENABLED = False
-        sys.modules['utils.fair_use'].FAIR_USE_RESTRICT_DAILY_DG_MS = 0
-
-        try:
-            import importlib.util
-
-            spec = importlib.util.spec_from_file_location(
-                'sync_router_bg',
-                os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py'),
-            )
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-
-            # Mock decode+VAD to pass through paths as segments
-            def _mock_decode(paths):
-                return list(paths)
-
-            def _mock_vad(path, segmented_paths, errors=None):
-                segmented_paths.add(path)
-
-            module.decode_files_to_wav = _mock_decode
-            module.retrieve_vad_segments = _mock_vad
-            module.get_wav_duration = lambda p: 5.0
-            module.build_person_embeddings_cache = MagicMock(return_value={})
-            module.users_db = MagicMock()
-            module.users_db.get_user_transcription_preferences = MagicMock(return_value={})
-
-            return module, mock_sync_jobs
-        except Exception:
-            return None, None
-        finally:
-            for mod, original in saved_modules.items():
-                if original is None:
-                    sys.modules.pop(mod, None)
-                else:
-                    sys.modules[mod] = original
-
-    def test_bg_worker_calls_mark_processing_then_completed(self):
-        """Worker must call mark_job_processing, then mark_job_completed."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        # Mock process_segment to do nothing
-        mod.process_segment = MagicMock()
-
-        mod._run_full_pipeline_background(
-            job_id='test-job',
-            uid='test-uid',
-            raw_paths=['/tmp/fake1.wav', '/tmp/fake2.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/fake-job-dir',
-        )
-
-        mock_sync_jobs.mark_job_processing.assert_called_once_with('test-job')
-        mock_sync_jobs.mark_job_completed.assert_called_once()
-        call_args = mock_sync_jobs.mark_job_completed.call_args
-        assert call_args[0][0] == 'test-job'
-
-    def test_bg_worker_calls_mark_failed_on_exception(self):
-        """Worker must call mark_job_failed when processing throws."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        # Make mark_job_processing raise to simulate early failure
-        mock_sync_jobs.mark_job_processing.side_effect = Exception("Redis down")
-
-        mod._run_full_pipeline_background(
-            job_id='test-job',
-            uid='test-uid',
-            raw_paths=['/tmp/fake.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/fake-dir',
-        )
-
-        mock_sync_jobs.mark_job_failed.assert_called_once()
-        assert 'Redis down' in mock_sync_jobs.mark_job_failed.call_args[0][1]
-
-    def test_bg_worker_heartbeats_during_processing(self):
-        """Worker must call update_sync_job during chunk processing."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mod.process_segment = MagicMock()
-
-        # Use enough segments to trigger at least one heartbeat (chunk_size=5)
-        paths = [f'/tmp/seg{i}.wav' for i in range(6)]
-
-        mod._run_full_pipeline_background(
-            job_id='hb-job',
-            uid='uid',
-            raw_paths=paths,
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/hb-dir',
-        )
-
-        # update_sync_job should have been called at least once for heartbeat
-        assert mock_sync_jobs.update_sync_job.called
-
-    def test_bg_worker_partial_failure_reports_correctly(self):
-        """Worker must pass failed_segments count to mark_job_completed on partial failure."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        call_count = [0]
-
-        def mock_process_segment(
-            path, uid, response, lock, errors, source, is_locked, prefs=None, cache=None, target_conversation_id=None
-        ):
-            call_count[0] += 1
-            if call_count[0] % 2 == 0:
-                with lock:
-                    errors.append(f'Failed: {path}')
-            else:
-                with lock:
-                    response['new_memories'].add(f'mem-{call_count[0]}')
-
-        mod.process_segment = mock_process_segment
-
-        mod._run_full_pipeline_background(
-            job_id='partial-job',
-            uid='test-uid',
-            raw_paths=['/tmp/s1.wav', '/tmp/s2.wav', '/tmp/s3.wav', '/tmp/s4.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/partial-dir',
-        )
-
-        mock_sync_jobs.mark_job_completed.assert_called_once()
-        result_arg = mock_sync_jobs.mark_job_completed.call_args[0][1]
-        assert result_arg['failed_segments'] == 2
-        assert result_arg['total_segments'] == 4
-        assert len(result_arg['errors']) == 2
-
-    def test_bg_worker_all_failed_reports_correctly(self):
-        """Worker must report all segments failed with errors."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        def mock_process_segment(
-            path, uid, response, lock, errors, source, is_locked, prefs=None, cache=None, target_conversation_id=None
-        ):
-            with lock:
-                errors.append(f'Failed: {path}')
-
-        mod.process_segment = mock_process_segment
-
-        mod._run_full_pipeline_background(
-            job_id='allfail-job',
-            uid='test-uid',
-            raw_paths=['/tmp/f1.wav', '/tmp/f2.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/allfail-dir',
-        )
-
-        mock_sync_jobs.mark_job_completed.assert_called_once()
-        result_arg = mock_sync_jobs.mark_job_completed.call_args[0][1]
-        assert result_arg['failed_segments'] == 2
-        assert result_arg['total_segments'] == 2
-        assert len(result_arg['errors']) == 2
-
-    def test_bg_worker_records_dg_usage_when_enabled(self):
-        """Worker must call record_dg_usage_ms when FAIR_USE_ENABLED and enforcement=restrict."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mod.process_segment = MagicMock()
-        mock_record_dg = MagicMock()
-        mod.record_dg_usage_ms = mock_record_dg
-        mod.FAIR_USE_ENABLED = True
-        mod.FAIR_USE_RESTRICT_DAILY_DG_MS = 1000
-        mod.get_enforcement_stage = MagicMock(return_value='restrict')
-        mod.is_dg_budget_exhausted = MagicMock(return_value=False)
-        mod.record_speech_ms = MagicMock()
-        mod.get_rolling_speech_ms = MagicMock(return_value={})
-        mod.check_soft_caps = MagicMock(return_value=[])
-
-        mod._run_full_pipeline_background(
-            job_id='dg-job',
-            uid='test-uid',
-            raw_paths=['/tmp/d1.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/dg-dir',
-        )
-
-        mock_record_dg.assert_called_once_with('test-uid', 5000)
-
-    def test_bg_worker_skips_dg_recording_when_disabled(self):
-        """Worker must NOT call record_dg_usage_ms when FAIR_USE_ENABLED=False."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mod.process_segment = MagicMock()
-        mock_record_dg = MagicMock()
-        mod.record_dg_usage_ms = mock_record_dg
-        mod.FAIR_USE_ENABLED = False
-
-        mod._run_full_pipeline_background(
-            job_id='no-dg-job',
-            uid='test-uid',
-            raw_paths=['/tmp/d1.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/no-dg-dir',
-        )
-
-        mock_record_dg.assert_not_called()
-
-    def test_bg_worker_cleans_up_job_dir(self):
-        """Worker must remove the job directory in finally block."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mod.process_segment = MagicMock()
-
-        # Create a real temp dir to verify cleanup
-        import tempfile
-
-        job_dir = tempfile.mkdtemp(prefix='sync_v2_test_')
-        assert os.path.isdir(job_dir)
-
-        mod._run_full_pipeline_background(
-            job_id='cleanup-job',
-            uid='test-uid',
-            raw_paths=[],
-            source='omi',
-            should_lock=False,
-            job_dir=job_dir,
-        )
-
-        assert not os.path.exists(job_dir), "Job directory must be cleaned up after processing"
-
-    def test_bg_worker_cleans_up_on_failure(self):
-        """Worker must clean up job dir even when processing fails."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mock_sync_jobs.mark_job_processing.side_effect = RuntimeError("DB failure")
-
-        import tempfile
-
-        job_dir = tempfile.mkdtemp(prefix='sync_v2_test_fail_')
-        assert os.path.isdir(job_dir)
-
-        mod._run_full_pipeline_background(
-            job_id='cleanup-fail-job',
-            uid='test-uid',
-            raw_paths=[],
-            source='omi',
-            should_lock=False,
-            job_dir=job_dir,
-        )
-
-        assert not os.path.exists(job_dir), "Job directory must be cleaned up even on failure"
-
-    def test_bg_worker_fetches_and_forwards_prefs_to_process_segment(self):
-        """Worker must fetch prefs/cache internally and forward to each process_segment call."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        received_args = []
-
-        def mock_process_segment(
-            path, uid, response, lock, errors, source, is_locked, prefs=None, cache=None, target_conversation_id=None
-        ):
-            received_args.append({'prefs': prefs, 'cache': cache})
-
-        mod.process_segment = mock_process_segment
-
-        test_prefs = {'language': 'es', 'model': 'nova-3'}
-        test_cache = {'p-alice': {'name': 'Alice', 'embedding': [0.1, 0.2]}}
-        mod.users_db.get_user_transcription_preferences = MagicMock(return_value=test_prefs)
-        mod.build_person_embeddings_cache = MagicMock(return_value=test_cache)
-
-        mod._run_full_pipeline_background(
-            job_id='prefs-job',
-            uid='test-uid',
-            raw_paths=['/tmp/p1.wav', '/tmp/p2.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/prefs-dir',
-        )
-
-        assert len(received_args) == 2
-        for args in received_args:
-            assert args['prefs'] is test_prefs
-            assert args['cache'] is test_cache
-
-    def test_bg_worker_forwards_target_conversation_id_to_process_segment(self):
-        """Worker must forward target_conversation_id to each process_segment call."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        received_args = []
-
-        def mock_process_segment(
-            path, uid, response, lock, errors, source, is_locked, prefs=None, cache=None, target_conversation_id=None
-        ):
-            received_args.append({'target_conversation_id': target_conversation_id})
-
-        mod.process_segment = mock_process_segment
-
-        mod._run_full_pipeline_background(
-            job_id='target-conv-job',
-            uid='test-uid',
-            raw_paths=['/tmp/tc1.wav', '/tmp/tc2.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/target-conv-dir',
-            target_conversation_id='conv-123',
-        )
-
-        assert len(received_args) == 2
-        for args in received_args:
-            assert args['target_conversation_id'] == 'conv-123'
-
-    def test_bg_worker_defaults_target_conversation_id_to_none(self):
-        """Worker must default target_conversation_id to None when not provided."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        received_args = []
-
-        def mock_process_segment(
-            path, uid, response, lock, errors, source, is_locked, prefs=None, cache=None, target_conversation_id=None
-        ):
-            received_args.append({'target_conversation_id': target_conversation_id})
-
-        mod.process_segment = mock_process_segment
-
-        mod._run_full_pipeline_background(
-            job_id='no-target-conv-job',
-            uid='test-uid',
-            raw_paths=['/tmp/nt1.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/no-target-conv-dir',
-        )
-
-        assert len(received_args) == 1
-        assert received_args[0]['target_conversation_id'] is None
-
-    def test_bg_worker_decode_failure_marks_job_failed(self):
-        """Worker must mark_job_failed when decode_files_to_wav raises."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mod.decode_files_to_wav = MagicMock(side_effect=Exception("corrupt opus frame"))
-
-        mod._run_full_pipeline_background(
-            job_id='decode-fail-job',
-            uid='test-uid',
-            raw_paths=['/tmp/bad.opus'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/decode-fail-dir',
-        )
-
-        mock_sync_jobs.mark_job_failed.assert_called_once()
-        assert 'corrupt opus frame' in mock_sync_jobs.mark_job_failed.call_args[0][1]
-
-    def test_bg_worker_vad_error_aborts_job(self):
-        """Worker must fail the job when retrieve_vad_segments produces errors."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        def _bad_vad(path, segmented_paths, errors=None):
-            if errors is not None:
-                errors.append(f'VAD failed: {path}')
-
-        mod.retrieve_vad_segments = _bad_vad
-
-        mod._run_full_pipeline_background(
-            job_id='vad-fail-job',
-            uid='test-uid',
-            raw_paths=['/tmp/v1.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/vad-fail-dir',
-        )
-
-        mock_sync_jobs.mark_job_failed.assert_called_once()
-        assert 'VAD failed' in mock_sync_jobs.mark_job_failed.call_args[0][1]
-        mock_sync_jobs.mark_job_completed.assert_not_called()
-
-    def test_bg_worker_vad_exception_aborts_job(self):
-        """Worker must fail the job when retrieve_vad_segments raises an exception."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mod.retrieve_vad_segments = MagicMock(side_effect=RuntimeError("AudioSegment export failed"))
-
-        mod._run_full_pipeline_background(
-            job_id='vad-exc-job',
-            uid='test-uid',
-            raw_paths=['/tmp/v1.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/vad-exc-dir',
-        )
-
-        mock_sync_jobs.mark_job_failed.assert_called_once()
-        assert 'AudioSegment export failed' in mock_sync_jobs.mark_job_failed.call_args[0][1]
-
-    def test_bg_worker_dg_budget_exhausted_fails_job(self):
-        """Worker must mark_job_failed when DG budget is exhausted."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mod.FAIR_USE_ENABLED = True
-        mod.FAIR_USE_RESTRICT_DAILY_DG_MS = 1000
-        mod.get_enforcement_stage = MagicMock(return_value='restrict')
-        mod.is_dg_budget_exhausted = MagicMock(return_value=True)
-        mod.record_speech_ms = MagicMock()
-        mod.get_rolling_speech_ms = MagicMock(return_value={})
-        mod.check_soft_caps = MagicMock(return_value=[])
-        mod.process_segment = MagicMock()
-
-        mod._run_full_pipeline_background(
-            job_id='dg-exhaust-job',
-            uid='test-uid',
-            raw_paths=['/tmp/e1.wav'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/dg-exhaust-dir',
-        )
-
-        mock_sync_jobs.mark_job_failed.assert_called_once()
-        assert 'budget exhausted' in mock_sync_jobs.mark_job_failed.call_args[0][1].lower()
-        mod.process_segment.assert_not_called()
-
-    def test_bg_worker_empty_wav_paths_completes_with_zero(self):
-        """Worker must complete with zero segments when decode returns empty list."""
-        mod, mock_sync_jobs = self._load_bg_worker()
-        if mod is None:
-            pytest.skip("Cannot load sync router due to import chain")
-
-        mod.decode_files_to_wav = MagicMock(return_value=[])
-
-        mod._run_full_pipeline_background(
-            job_id='empty-job',
-            uid='test-uid',
-            raw_paths=['/tmp/empty.opus'],
-            source='omi',
-            should_lock=False,
-            job_dir='/tmp/empty-dir',
-        )
-
-        mock_sync_jobs.mark_job_completed.assert_called_once()
-        result = mock_sync_jobs.mark_job_completed.call_args[0][1]
-        assert result['total_segments'] == 0
-        assert result['failed_segments'] == 0
+    def _get_bg_func_body():
+        sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
+        with open(sync_path) as f:
+            source = f.read()
+        start = source.index('async def _run_full_pipeline_background_async')
+        next_boundary = source.find('\n@router.', start + 1)
+        if next_boundary == -1:
+            next_boundary = len(source)
+        return source[start:next_boundary]
+
+    def test_async_coordinator_offloads_all_db_calls(self):
+        """All DB calls must go through run_blocking(db_executor, ...)."""
+        body = self._get_bg_func_body()
+        assert 'run_blocking(db_executor, mark_job_processing' in body
+        assert 'mark_job_completed' in body and 'db_executor' in body
+        assert 'run_blocking(db_executor, update_sync_job' in body
+
+    def test_async_coordinator_offloads_decode(self):
+        """Decode must be offloaded to sync_executor via run_blocking."""
+        body = self._get_bg_func_body()
+        assert 'run_blocking(sync_executor, decode_files_to_wav' in body
+
+    def test_async_coordinator_offloads_vad(self):
+        """VAD must be offloaded to sync_executor via run_blocking + asyncio.gather."""
+        body = self._get_bg_func_body()
+        assert 'run_blocking(sync_executor, _run_vad_bg' in body
+        assert 'asyncio.gather(*vad_tasks' in body
+
+    def test_async_coordinator_offloads_segment_processing(self):
+        """Segment processing must be offloaded to sync_executor via run_blocking."""
+        body = self._get_bg_func_body()
+        assert 'run_blocking(sync_executor, _process_one_segment' in body
+
+    def test_async_coordinator_offloads_cleanup_to_storage(self):
+        """File cleanup must be offloaded to storage_executor via run_blocking."""
+        body = self._get_bg_func_body()
+        assert 'run_blocking(storage_executor, _cleanup_files' in body
+        assert 'run_blocking(storage_executor, shutil.rmtree' in body
+
+    def test_async_coordinator_uses_semaphore(self):
+        """Async coordinator must use _SYNC_PIPELINE_SEMAPHORE for concurrency cap."""
+        body = self._get_bg_func_body()
+        assert '_SYNC_PIPELINE_SEMAPHORE' in body
+
+    def test_async_coordinator_marks_failed_on_exception(self):
+        """Async coordinator must call mark_job_failed for error cases."""
+        body = self._get_bg_func_body()
+        occurrences = body.count('mark_job_failed')
+        assert (
+            occurrences >= 2
+        ), f"Expected mark_job_failed called multiple times (decode errors + general except), got {occurrences}"
+
+    def test_async_coordinator_clears_byok_in_finally(self):
+        """Async coordinator must clear BYOK keys in finally block."""
+        body = self._get_bg_func_body()
+        finally_idx = body.rindex('finally:')
+        after_finally = body[finally_idx:]
+        assert 'set_byok_keys({})' in after_finally
+
+    def test_async_coordinator_handles_empty_decode(self):
+        """Async coordinator must handle empty wav_paths (complete with 0 segments)."""
+        body = self._get_bg_func_body()
+        assert 'if not wav_paths:' in body
+        assert "'total_segments': 0" in body
+
+    def test_async_coordinator_chunks_segments(self):
+        """Async coordinator must process segments in chunks of 5."""
+        body = self._get_bg_func_body()
+        assert 'chunk_size = 5' in body
+        assert 'range(0, len(segment_list), chunk_size)' in body
+
+    def test_async_coordinator_records_dg_usage_after_processing(self):
+        """DG usage must be recorded after segment processing, not before."""
+        body = self._get_bg_func_body()
+        dg_pos = body.index('record_dg_usage_ms')
+        processing_pos = body.index('_process_one_segment')
+        assert dg_pos > processing_pos
+
+    def test_async_coordinator_result_shape(self):
+        """Result must include new_memories, updated_memories, failed_segments, total_segments, errors."""
+        body = self._get_bg_func_body()
+        for field in ['new_memories', 'updated_memories', 'failed_segments', 'total_segments', 'errors']:
+            assert f"'{field}'" in body, f"Result must include {field}"
+
+    def test_async_coordinator_stage_timings(self):
+        """Async coordinator must collect stage timing metrics."""
+        body = self._get_bg_func_body()
+        assert 'stage_timings' in body
+        assert "'decode_ms'" in body
+        assert "'vad_ms'" in body
+        assert "'stt_llm_ms'" in body
+        assert "'total_ms'" in body
+
+    def test_async_coordinator_fetches_prefs_and_embeddings(self):
+        """Async coordinator must fetch transcription prefs and person embeddings."""
+        body = self._get_bg_func_body()
+        assert 'get_user_transcription_preferences' in body
+        assert 'build_person_embeddings_cache' in body
+
+    def test_no_thread_pool_slot_held_for_coordinator(self):
+        """Async coordinator must NOT use submit_with_context or hold a thread pool slot."""
+        body = self._get_bg_func_body()
+        assert 'submit_with_context' not in body, "Async coordinator must not use submit_with_context"
+        assert '.result(' not in body, "Async coordinator must not call future.result()"
 
 
 # ---------------------------------------------------------------------------
@@ -1595,7 +1169,7 @@ class TestV2EndpointExecution:
             self._cleanup_modules(saved)
 
     def test_post_returns_202_and_schedules_background(self):
-        """POST /v2/sync-local-files must return 202, create job, and schedule background work."""
+        """POST /v2/sync-local-files must return 202, create job, and schedule async background task."""
         saved, mock_sync_jobs, _ = self._build_test_app()
         mock_sync_jobs.create_sync_job = MagicMock(
             return_value={
@@ -1619,7 +1193,11 @@ class TestV2EndpointExecution:
             spec.loader.exec_module(module)
 
             module._retrieve_file_paths_v2 = MagicMock(return_value=['/tmp/fake.opus'])
-            module._run_full_pipeline_background = MagicMock()
+
+            async def _noop_pipeline(*args, **kwargs):
+                pass
+
+            module._run_full_pipeline_background_async = _noop_pipeline
 
             async def _passthrough_run_blocking(_executor, fn, *args, **kwargs):
                 return fn(*args, **kwargs)
@@ -1731,8 +1309,10 @@ class TestBulkheadExecutors:
 
     def test_executor_worker_counts(self):
         source = self._read_executors_source()
-        assert 'sync_executor = ThreadPoolExecutor(max_workers=12' in source
-        assert 'postprocess_executor = ThreadPoolExecutor(max_workers=8' in source
+        assert 'sync_executor = MonitoredThreadPoolExecutor(' in source
+        assert 'max_workers=12' in source
+        assert 'postprocess_executor = MonitoredThreadPoolExecutor(' in source
+        assert 'max_workers=8' in source
 
     def test_all_executors_in_shutdown(self):
         source = self._read_executors_source()
@@ -1782,7 +1362,11 @@ class TestBulkheadExecutors:
 
 
 class TestBYOKContextPropagation:
-    """Verify BYOK context lifecycle in the sync pipeline."""
+    """Verify BYOK context lifecycle in the async coordinator sync pipeline (#7361).
+
+    With asyncio.create_task, ContextVars (including BYOK keys) are inherited
+    automatically by the child task. The coordinator clears BYOK in finally.
+    """
 
     @staticmethod
     def _read_sync_source():
@@ -1790,8 +1374,8 @@ class TestBYOKContextPropagation:
         with open(path) as f:
             return f.read()
 
-    def test_v2_captures_byok_before_dispatch(self):
-        """v2 endpoint must capture BYOK keys before run_in_executor dispatch."""
+    def test_v2_uses_create_task_for_context_inheritance(self):
+        """v2 must use asyncio.create_task which auto-inherits ContextVars (BYOK keys)."""
         source = self._read_sync_source()
         start = source.index('async def sync_local_files_v2')
         next_section = source.find('\n@router.', start + 1)
@@ -1799,55 +1383,18 @@ class TestBYOKContextPropagation:
             next_section = len(source)
         func_body = source[start:next_section]
 
-        assert 'get_byok_keys()' in func_body, "v2 must capture BYOK keys before dispatch"
-        assert 'captured_byok' in func_body, "v2 must store captured BYOK in a variable"
+        assert 'asyncio.create_task' in func_body, "v2 must use asyncio.create_task for context inheritance"
 
-    def test_v2_passes_byok_to_background(self):
-        """v2 must pass captured BYOK keys as an argument to the background worker."""
+    def test_async_coordinator_clears_byok_in_finally(self):
+        """Async coordinator must clear BYOK context in its finally block."""
         source = self._read_sync_source()
-        start = source.index('async def sync_local_files_v2')
-        next_section = source.find('\n@router.', start + 1)
-        if next_section == -1:
-            next_section = len(source)
-        func_body = source[start:next_section]
+        start = source.index('async def _run_full_pipeline_background_async')
+        next_boundary = source.find('\n@router.', start + 1)
+        if next_boundary == -1:
+            next_boundary = len(source)
+        func_body = source[start:next_boundary]
 
-        assert 'captured_byok' in func_body
-        dispatch_section = func_body[func_body.index('submit_with_context') :]
-        assert 'captured_byok' in dispatch_section, "captured BYOK must be passed to submit_with_context call"
-
-    def test_background_worker_accepts_byok_parameter(self):
-        """_run_full_pipeline_background must accept a byok_keys parameter."""
-        source = self._read_sync_source()
-        start = source.index('def _run_full_pipeline_background')
-        next_def = source.find('\ndef ', start + 1)
-        if next_def == -1:
-            next_def = len(source)
-        func_body = source[start:next_def]
-        assert 'byok_keys' in func_body, "Background worker must accept byok_keys parameter"
-
-    def test_background_worker_sets_byok_unconditionally(self):
-        """Background worker must call set_byok_keys unconditionally (not guarded by if)."""
-        source = self._read_sync_source()
-        start = source.index('def _run_full_pipeline_background')
-        next_def = source.find('\ndef ', start + 1)
-        if next_def == -1:
-            next_def = len(source)
-        func_body = source[start:next_def]
-
-        assert (
-            'set_byok_keys(byok_keys or {})' in func_body
-        ), "Worker must set BYOK unconditionally with empty dict fallback"
-
-    def test_background_worker_clears_byok_in_finally(self):
-        """Background worker must clear BYOK context in its finally block."""
-        source = self._read_sync_source()
-        start = source.index('def _run_full_pipeline_background')
-        next_def = source.find('\ndef ', start + 1)
-        if next_def == -1:
-            next_def = len(source)
-        func_body = source[start:next_def]
-
-        assert 'set_byok_keys({})' in func_body, "Worker must clear BYOK keys (expected in finally block)"
+        assert 'set_byok_keys({})' in func_body, "Async coordinator must clear BYOK keys in finally"
 
     def test_no_plain_submit_in_sync(self):
         """All executor .submit() calls in sync.py must use submit_with_context."""
@@ -1965,12 +1512,15 @@ class TestTimeoutConfiguration:
         func_body = source[start:end]
         assert 'attempts < 1' in func_body, "DG bytes transcription must use attempts < 1 (max 2 attempts)"
 
-    def test_segment_future_timeout_budget(self):
-        """Segment futures in v2 background must use timeout=300."""
+    def test_segment_timeout_budget(self):
+        """Segment tasks in v2 async coordinator must use asyncio.wait_for with timeout=300."""
         sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
         with open(sync_path) as f:
             source = f.read()
-        start = source.index('def _run_full_pipeline_background')
-        end = source.find('\ndef ', start + 1)
+        start = source.index('async def _run_full_pipeline_background_async')
+        end = source.find('\n@router.', start + 1)
+        if end == -1:
+            end = len(source)
         func_body = source[start:end]
-        assert 'future.result(timeout=300)' in func_body, "Segment futures must have 300s timeout"
+        assert 'asyncio.wait_for(' in func_body, "Must use asyncio.wait_for for timeout enforcement"
+        assert 'timeout=300' in func_body, "Segment tasks must have 300s timeout"

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -22,17 +22,56 @@ import atexit
 import contextvars
 import functools
 import logging
+import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
-critical_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="critical")
-db_executor = ThreadPoolExecutor(max_workers=16, thread_name_prefix="db")
-llm_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="llm")
-stripe_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="stripe")
-sync_executor = ThreadPoolExecutor(max_workers=12, thread_name_prefix="sync")
-postprocess_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="postproc")
-storage_executor = ThreadPoolExecutor(max_workers=16, thread_name_prefix="storage")
+
+class MonitoredThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor with active-task tracking for observability."""
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+        self._active_count = 0
+        self._active_lock = threading.Lock()
+
+    @property
+    def active_count(self) -> int:
+        return self._active_count
+
+    def submit(self, fn, /, *args, **kwargs):
+        future = super().submit(self._tracked, fn, *args, **kwargs)
+        return future
+
+    def _tracked(self, fn, *args, **kwargs):
+        with self._active_lock:
+            self._active_count += 1
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            with self._active_lock:
+                self._active_count -= 1
+
+
+critical_executor = MonitoredThreadPoolExecutor(name="critical", max_workers=8, thread_name_prefix="critical")
+db_executor = MonitoredThreadPoolExecutor(name="db", max_workers=16, thread_name_prefix="db")
+llm_executor = MonitoredThreadPoolExecutor(name="llm", max_workers=4, thread_name_prefix="llm")
+stripe_executor = MonitoredThreadPoolExecutor(name="stripe", max_workers=4, thread_name_prefix="stripe")
+sync_executor = MonitoredThreadPoolExecutor(name="sync", max_workers=12, thread_name_prefix="sync")
+postprocess_executor = MonitoredThreadPoolExecutor(name="postprocess", max_workers=8, thread_name_prefix="postproc")
+storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=16, thread_name_prefix="storage")
+
+_ALL_EXECUTORS = [
+    critical_executor,
+    db_executor,
+    llm_executor,
+    stripe_executor,
+    sync_executor,
+    postprocess_executor,
+    storage_executor,
+]
 
 
 async def run_blocking(executor: ThreadPoolExecutor, fn, *args, **kwargs):
@@ -49,21 +88,46 @@ def submit_with_context(executor: ThreadPoolExecutor, fn, *args, **kwargs) -> Fu
     return executor.submit(ctx.run, fn, *args, **kwargs)
 
 
+def get_executor_metrics() -> list:
+    """Return health metrics for all named executor pools."""
+    metrics = []
+    for executor in _ALL_EXECUTORS:
+        max_w = executor._max_workers
+        active = executor.active_count
+        queue_depth = executor._work_queue.qsize()
+        utilization = round((active / max_w) * 100, 1) if max_w else 0.0
+        metrics.append(
+            {
+                'name': executor.name,
+                'max_workers': max_w,
+                'active_count': active,
+                'queue_depth': queue_depth,
+                'utilization_pct': utilization,
+            }
+        )
+    return metrics
+
+
+async def log_executor_health(interval_seconds: int = 60, utilization_threshold_pct: float = 70.0):
+    """Periodically log pool metrics when any pool exceeds the utilization threshold."""
+    while True:
+        await asyncio.sleep(interval_seconds)
+        try:
+            metrics = get_executor_metrics()
+            saturated = [p for p in metrics if p['utilization_pct'] > utilization_threshold_pct]
+            if saturated:
+                logger.warning('executor_pool_health: %s', saturated)
+        except Exception:
+            pass
+
+
 def shutdown_executors():
     """Shut down all shared executors. Called at app shutdown."""
-    for name, executor in [
-        ('critical', critical_executor),
-        ('db', db_executor),
-        ('llm', llm_executor),
-        ('stripe', stripe_executor),
-        ('sync', sync_executor),
-        ('postprocess', postprocess_executor),
-        ('storage', storage_executor),
-    ]:
+    for executor in _ALL_EXECUTORS:
         try:
             executor.shutdown(wait=False, cancel_futures=True)
         except Exception as e:
-            logger.warning(f"Error shutting down {name} executor: {e}")
+            logger.warning(f"Error shutting down {executor.name} executor: {e}")
 
 
 atexit.register(shutdown_executors)

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -121,6 +121,48 @@ async def log_executor_health(interval_seconds: int = 60, utilization_threshold_
             pass
 
 
+_background_tasks: set[asyncio.Task] = set()
+
+
+def start_background_task(coro, *, name: str) -> asyncio.Task:
+    """Schedule *coro* as a tracked background task with exception logging.
+
+    Use this instead of bare ``asyncio.create_task()`` for production
+    fire-and-forget work.  Bare ``create_task`` silently drops exceptions
+    and can be garbage-collected if the caller doesn't keep a reference.
+    """
+    task = asyncio.create_task(coro, name=name)
+    _background_tasks.add(task)
+
+    def _done(t: asyncio.Task) -> None:
+        _background_tasks.discard(t)
+        if t.cancelled():
+            logger.info('background_task cancelled: %s', t.get_name())
+            return
+        exc = t.exception()
+        if exc:
+            logger.error('background_task failed: %s — %s: %s', t.get_name(), type(exc).__name__, exc)
+
+    task.add_done_callback(_done)
+    return task
+
+
+def get_background_task_count() -> int:
+    """Return the number of currently tracked background tasks."""
+    return len(_background_tasks)
+
+
+async def drain_background_tasks(timeout: float = 10.0) -> int:
+    """Cancel and await all tracked background tasks at shutdown. Returns count cancelled."""
+    tasks = list(_background_tasks)
+    if not tasks:
+        return 0
+    for t in tasks:
+        t.cancel()
+    await asyncio.wait(tasks, timeout=timeout)
+    return len(tasks)
+
+
 def shutdown_executors():
     """Shut down all shared executors. Called at app shutdown."""
     for executor in _ALL_EXECUTORS:


### PR DESCRIPTION
## Summary

Fixes #7361 — sync v2 pool starvation cascade.

**Root cause:** `submit_with_context(postprocess_executor, _run_full_pipeline_background, ...)` holds 1 of 8 postprocess thread pool slots for the entire pipeline duration (60-300s). At peak concurrent syncs, all 8 slots fill → new `submit_with_context` calls block the asyncio event loop → 202 responses can't return → cascade.

**Production impact (May 18):** 202 P90 jumped from 0.39s → 409.6s. 84K 504 timeouts/week. Cloud Run scaled from 9 → 38 instances trying to cope.

**Fix:** Replace thread-holding `submit_with_context` with async coordinator pattern:
- `start_background_task(_run_full_pipeline_background_async(...), name=...)` — tracked fire-and-forget with exception logging
- Pipeline runs as async coroutine on event loop
- Each CPU-bound step uses `await run_blocking(executor, fn)` — borrows thread only for that step
- Zero thread pool slots held between steps

**New utility — `start_background_task()`** (utils/executors.py):
- Wraps `asyncio.create_task` with task tracking set, exception logging via done_callback, cancellation logging
- `drain_background_tasks()` for graceful SIGTERM shutdown
- `get_background_task_count()` for observability
- Replaces bare `create_task` which silently swallows exceptions and can be GC'd

**CLAUDE.md rules added** — async dispatch decision tree:
- `await run_blocking(executor, fn)` — sync/CPU-bound, caller needs result
- `start_background_task(coro, name=...)` — async fire-and-forget (pipelines)
- `submit_with_context(executor, fn)` — short sync fire-and-forget only, never for >10s pipelines
- Long-running pipelines must be async coordinators

**Follow-up:** #7371 — migrate to arq/SAQ task queue for persistence, retry, and cross-instance backpressure.

## Stress Test Results (12 concurrent requests)

| Metric | BEFORE (submit_with_context) | AFTER (start_background_task) | Change |
|---|---|---|---|
| Pipeline avg | 14,589ms | 10,906ms | **-25%** |
| Pipeline max | 23,165ms | 14,012ms | **-39%** |
| Total e2e max | 28,891ms | 19,093ms | **-34%** |
| Success/Fail | 12/0 | 12/0 | same |

BEFORE shows clear batching (4 jobs queued at ~23s behind 8-slot limit). AFTER has no batching — all 12 progress concurrently.

## Changes

| File | What |
|------|------|
| `utils/executors.py` | `start_background_task()`, `drain_background_tasks()`, `get_background_task_count()` |
| `routers/sync.py` | Replace `asyncio.create_task` + manual callback with `start_background_task(coro, name=...)` |
| `main.py` | Call `drain_background_tasks()` on shutdown |
| `CLAUDE.md` | Async dispatch rules (run_blocking vs start_background_task vs submit_with_context) |
| `tests/unit/test_executors.py` | 5 new tests (run, track/remove, exception logging, cancellation, drain) |
| `tests/unit/test_sync_v2.py` | Updated structural assertions for start_background_task |

## Test plan

- [x] 24 executor tests pass (including 5 new for start_background_task)
- [x] 171 sync_v2 tests pass (147 sync + 24 executor)
- [x] Stress test: 12 concurrent BEFORE vs AFTER comparison
- [x] Live integration test with real audio files
- [x] CLAUDE.md compliance verified (semaphore delegation, import rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)