### PR TITLE
Update CHANGELOG.json for v0.11.409 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed BYOK keys not being used for Gemini and Anthropic requests \u2014 users who bring their own API keys now bypass server keys and rate limits for all AI features"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.409",
+      "date": "2026-05-18",
+      "changes": [
+        "Fixed BYOK keys not being used for Gemini and Anthropic requests \u2014 users who bring their own API keys now bypass server keys and rate limits for all AI features"
+      ]
+    },
     {
       "version": "0.11.408",
       "date": "2026-05-17",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.409 and clears the unreleased array.