### PR TITLE
Reland: Desktop Rust BYOK fingerprint validation + native paywall (#7357)

### DIFF
--- a/desktop/Backend-Rust/src/auth.rs
+++ b/desktop/Backend-Rust/src/auth.rs
@@ -82,6 +82,8 @@ impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         let status = if self.error == "trial_expired" {
             StatusCode::PAYMENT_REQUIRED
+        } else if self.error == "byok_validation_failed" {
+            StatusCode::FORBIDDEN
         } else {
             StatusCode::UNAUTHORIZED
         };
@@ -232,12 +234,16 @@ impl From<PaywalledAuthUser> for AuthUser {
     }
 }
 
-/// Authenticated user extractor that ALSO enforces the desktop trial paywall.
+/// Authenticated user extractor that ALSO enforces:
+/// 1. BYOK fingerprint validation (SHA-256 against Firestore enrollment)
+/// 2. Desktop trial paywall (plan + BYOK + account age)
 ///
-/// Same token-verification flow as `AuthUser`, then a follow-up call to the
-/// Python `/v1/users/me/paywall` endpoint (cached 5min in-memory). If the
-/// user is past their trial, the extractor short-circuits with
-/// `error: "trial_expired"` which `AuthError::IntoResponse` maps to HTTP 402.
+/// If the user is BYOK-active but sends mismatched fingerprints → HTTP 403.
+/// If the user is past their trial → HTTP 402.
+///
+/// `byok_stripped`: true if the request carried BYOK headers that were silently
+/// cleared (non-enrolled user or expired heartbeat). Route handlers should check
+/// this flag and ignore BYOK headers when true.
 ///
 /// Use this for every $-incurring route handler in the Rust backend:
 /// proxy.rs (Gemini), chat_completions.rs (Anthropic), screen_activity.rs
@@ -247,6 +253,7 @@ pub struct PaywalledAuthUser {
     pub uid: String,
     pub name: Option<String>,
     pub email: Option<String>,
+    pub byok_stripped: bool,
 }
 
 #[async_trait]
@@ -257,7 +264,7 @@ where
     type Rejection = AuthError;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        // Get + extract bearer token (we'll forward it to the paywall endpoint)
+        // Get + extract bearer token
         let auth_header = parts
             .headers
             .get("Authorization")
@@ -285,10 +292,44 @@ where
 
         let (uid, name, email) = firebase_auth.0.verify_token(token).await?;
 
-        // Paywall check — fail open if Python is unreachable so a backend
+        // BYOK fingerprint validation (issue #7357).
+        // Validates SHA-256 fingerprints against Firestore enrollment.
+        // Non-BYOK users who send BYOK headers get them silently cleared.
+        let mut byok_stripped = false;
+        if let Some(byok_ext) = parts.extensions.get::<crate::byok::ByokCacheExt>() {
+            // Get the Firestore service from the paywall checker (shares the same Arc)
+            if let Some(checker) = parts.extensions.get::<crate::paywall::PaywallCheckerExt>() {
+                let byok_state = byok_ext
+                    .0
+                    .get_or_fetch(&uid, &checker.0.firestore)
+                    .await;
+
+                match crate::byok::validate_byok_request(&uid, &parts.headers, &byok_state) {
+                    Ok(crate::byok::ByokValidation::Active) => {
+                        // BYOK keys validated, proceed with user's keys
+                    }
+                    Ok(crate::byok::ByokValidation::Inactive { clear_headers }) => {
+                        byok_stripped = clear_headers;
+                    }
+                    Err(error_msg) => {
+                        tracing::warn!(
+                            "BYOK validation failed for uid={}: {}",
+                            uid,
+                            error_msg
+                        );
+                        return Err(AuthError {
+                            error: "byok_validation_failed".to_string(),
+                            message: error_msg,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Paywall check — fail open if Firestore is unreachable so a backend
         // outage never makes paying users look paywalled.
         if let Some(checker) = parts.extensions.get::<crate::paywall::PaywallCheckerExt>() {
-            if checker.0.is_paywalled(&uid, token).await {
+            if checker.0.is_paywalled(&uid, &parts.headers, byok_stripped).await {
                 return Err(AuthError {
                     error: "trial_expired".to_string(),
                     message: "Desktop trial expired. Upgrade or bring your own keys.".to_string(),
@@ -296,12 +337,17 @@ where
             }
         } else {
             tracing::warn!(
-                "PaywalledAuthUser: PaywallChecker extension missing, falling open for uid={}",
+                "PaywalledAuthUser: PaywallChecker extension missing, failing open for uid={}",
                 uid
             );
         }
 
-        Ok(PaywalledAuthUser { uid, name, email })
+        Ok(PaywalledAuthUser {
+            uid,
+            name,
+            email,
+            byok_stripped,
+        })
     }
 }
 
@@ -310,4 +356,11 @@ pub fn paywall_checker_extension(
     checker: Arc<crate::paywall::PaywallChecker>,
 ) -> axum::Extension<crate::paywall::PaywallCheckerExt> {
     axum::Extension(crate::paywall::PaywallCheckerExt(checker))
+}
+
+/// Layer that adds the BYOK state cache to request extensions.
+pub fn byok_cache_extension(
+    cache: Arc<crate::byok::ByokStateCache>,
+) -> axum::Extension<crate::byok::ByokCacheExt> {
+    axum::Extension(crate::byok::ByokCacheExt(cache))
 }

--- a/desktop/Backend-Rust/src/byok.rs
+++ b/desktop/Backend-Rust/src/byok.rs
@@ -1,0 +1,708 @@
+// BYOK (Bring Your Own Keys) — header helpers, fingerprint validation, and state cache.
+//
+// Desktop Swift client sends X-BYOK-{OpenAI,Anthropic,Gemini,Deepgram} headers
+// on every request via APIKeyService. These helpers extract, validate, and cache
+// BYOK state from Firestore.
+//
+// Validation flow (mirrors Python `_check_byok_validity` in `backend/utils/byok.py`):
+//   1. No BYOK headers → fast-path skip (no Firestore read)
+//   2. User not BYOK-active (or heartbeat expired) → silently clear headers
+//   3. User BYOK-active → SHA-256 hash each header, compare against enrolled fingerprints
+//      → 403 on mismatch, proceed on match
+
+use axum::http::HeaderMap;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+use crate::services::FirestoreService;
+
+/// Header names for each BYOK provider (case-insensitive in HTTP).
+pub const HEADER_OPENAI: &str = "x-byok-openai";
+pub const HEADER_ANTHROPIC: &str = "x-byok-anthropic";
+pub const HEADER_GEMINI: &str = "x-byok-gemini";
+pub const HEADER_DEEPGRAM: &str = "x-byok-deepgram";
+
+/// All four required BYOK headers. Python's `_request_has_all_byok_keys()` checks
+/// the same set — a fully enrolled BYOK user sends all four on every request.
+const ALL_BYOK_HEADERS: &[&str] = &[
+    HEADER_OPENAI,
+    HEADER_ANTHROPIC,
+    HEADER_GEMINI,
+    HEADER_DEEPGRAM,
+];
+
+/// Map from header name to provider name (used for fingerprint lookup).
+const HEADER_TO_PROVIDER: &[(&str, &str)] = &[
+    (HEADER_OPENAI, "openai"),
+    (HEADER_ANTHROPIC, "anthropic"),
+    (HEADER_GEMINI, "gemini"),
+    (HEADER_DEEPGRAM, "deepgram"),
+];
+
+/// Heartbeat TTL: BYOK is considered inactive if last_seen_at is older than this.
+/// Matches Python's `BYOK_HEARTBEAT_TTL_SECONDS` in `database/users.py`.
+pub const BYOK_HEARTBEAT_TTL_SECS: i64 = 7 * 24 * 60 * 60; // 7 days
+
+/// Cache TTL for BYOK state from Firestore.
+/// Matches Python's 30-second cache in `utils/byok.py`.
+const BYOK_CACHE_TTL: Duration = Duration::from_secs(30);
+
+/// Maximum cache entries (matches Python's `maxsize=1024`).
+const BYOK_CACHE_MAX_ENTRIES: usize = 1024;
+
+// ---------------------------------------------------------------------------
+// Header extraction (unchanged from original)
+// ---------------------------------------------------------------------------
+
+/// Extract a single BYOK header value, trimmed and non-empty.
+/// Returns `None` if the header is missing, empty, or whitespace-only.
+pub fn get_byok_key<'a>(headers: &'a HeaderMap, header_name: &str) -> Option<&'a str> {
+    headers
+        .get(header_name)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+}
+
+/// Extract a BYOK key for a provider, respecting the `byok_stripped` flag.
+///
+/// When `byok_stripped` is true (non-enrolled user or expired heartbeat), returns
+/// `None` regardless of header presence — forcing fallback to server-managed keys.
+/// Route handlers should use this instead of calling `get_byok_key` directly.
+pub fn get_byok_key_if_active<'a>(
+    headers: &'a HeaderMap,
+    header_name: &str,
+    byok_stripped: bool,
+) -> Option<&'a str> {
+    if byok_stripped {
+        None
+    } else {
+        get_byok_key(headers, header_name)
+    }
+}
+
+/// True if the request carries non-empty values for all four BYOK provider headers.
+///
+/// This mirrors Python's `_request_has_all_byok_keys()`. Presence of all four
+/// headers signals the user has fully enrolled BYOK keys. The paywall escape
+/// hatch trusts presence here — fingerprint validation runs separately.
+pub fn has_all_byok_keys(headers: &HeaderMap) -> bool {
+    ALL_BYOK_HEADERS
+        .iter()
+        .all(|h| get_byok_key(headers, h).is_some())
+}
+
+// ---------------------------------------------------------------------------
+// BYOK state from Firestore
+// ---------------------------------------------------------------------------
+
+/// BYOK enrollment state for a user, read from `users/{uid}.byok` in Firestore.
+#[derive(Debug, Clone)]
+pub struct ByokState {
+    pub active: bool,
+    /// Provider name → SHA-256 hex fingerprint of the enrolled key.
+    pub fingerprints: HashMap<String, String>,
+    pub last_seen_at: Option<DateTime<Utc>>,
+}
+
+impl Default for ByokState {
+    fn default() -> Self {
+        Self {
+            active: false,
+            fingerprints: HashMap::new(),
+            last_seen_at: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation result
+// ---------------------------------------------------------------------------
+
+/// Result of per-request BYOK validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ByokValidation {
+    /// User is BYOK-active and all fingerprints match. Use the user's keys.
+    Active,
+    /// User is not BYOK-active (or no BYOK headers sent).
+    /// `clear_headers`: if true, the request carried BYOK headers that should be
+    /// silently ignored (non-enrolled user or expired heartbeat).
+    Inactive { clear_headers: bool },
+}
+
+/// Validate BYOK headers against enrolled Firestore state.
+///
+/// This is a pure function — no I/O. The caller provides the `ByokState`
+/// (typically from `ByokStateCache`).
+///
+/// Returns `Ok(ByokValidation)` on success, `Err(message)` on fingerprint
+/// mismatch (caller should return HTTP 403).
+pub fn validate_byok_request(
+    _uid: &str,
+    headers: &HeaderMap,
+    state: &ByokState,
+) -> Result<ByokValidation, String> {
+    // Fast path: no BYOK headers on this request → nothing to validate.
+    let has_any_byok = HEADER_TO_PROVIDER
+        .iter()
+        .any(|(h, _)| get_byok_key(headers, h).is_some());
+
+    if !has_any_byok {
+        return Ok(ByokValidation::Inactive {
+            clear_headers: false,
+        });
+    }
+
+    // Check if user is BYOK-active with valid heartbeat.
+    let is_active = state.active && {
+        match state.last_seen_at {
+            Some(last_seen) => {
+                let age = Utc::now()
+                    .signed_duration_since(last_seen)
+                    .num_seconds();
+                age <= BYOK_HEARTBEAT_TTL_SECS
+            }
+            None => false,
+        }
+    };
+
+    if !is_active {
+        // Non-enrolled user (or expired heartbeat) sent BYOK headers.
+        // Silently discard them so downstream code uses Omi's own keys.
+        return Ok(ByokValidation::Inactive {
+            clear_headers: true,
+        });
+    }
+
+    // BYOK-active user with headers present — validate every enrolled
+    // provider fingerprint.
+    for (provider, stored_fp) in &state.fingerprints {
+        // Find the header for this provider
+        let header_name = HEADER_TO_PROVIDER
+            .iter()
+            .find(|(_, p)| p == provider)
+            .map(|(h, _)| *h);
+
+        let header_name = match header_name {
+            Some(h) => h,
+            None => continue, // Unknown provider in fingerprints — skip
+        };
+
+        let raw_key = match get_byok_key(headers, header_name) {
+            Some(k) => k,
+            None => {
+                return Err(format!(
+                    "BYOK key header missing for enrolled provider: {}",
+                    provider
+                ));
+            }
+        };
+
+        let request_fp = hex::encode(Sha256::digest(raw_key.as_bytes()));
+        if request_fp != *stored_fp {
+            return Err(format!(
+                "BYOK key fingerprint mismatch for provider: {}",
+                provider
+            ));
+        }
+    }
+
+    Ok(ByokValidation::Active)
+}
+
+// ---------------------------------------------------------------------------
+// In-memory cache for BYOK state (30s TTL, 1024 max entries)
+// ---------------------------------------------------------------------------
+
+struct CacheEntry {
+    state: ByokState,
+    cached_at: Instant,
+}
+
+/// In-memory cache for BYOK state fetched from Firestore.
+/// Mirrors Python's `@lru_cache(maxsize=1024)` with 30-second TTL.
+pub struct ByokStateCache {
+    cache: Mutex<HashMap<String, CacheEntry>>,
+}
+
+impl ByokStateCache {
+    pub fn new() -> Self {
+        Self {
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get BYOK state for a user, using cache if fresh (< 30s).
+    /// On Firestore error, returns default inactive state (fail-open).
+    pub async fn get_or_fetch(
+        &self,
+        uid: &str,
+        firestore: &FirestoreService,
+    ) -> ByokState {
+        // Cache hit
+        {
+            let cache = self.cache.lock().await;
+            if let Some(entry) = cache.get(uid) {
+                if entry.cached_at.elapsed() < BYOK_CACHE_TTL {
+                    return entry.state.clone();
+                }
+            }
+        }
+
+        // Cache miss or stale — fetch from Firestore
+        let (state, should_cache) = match firestore.get_user_byok_state(uid).await {
+            Ok(s) => (s, true),
+            Err(e) => {
+                // Fail open but do NOT cache the error-default. A transient
+                // Firestore blip should not poison the cache and make an
+                // active BYOK user look paywalled for 30 seconds.
+                tracing::warn!(
+                    "byok: failed to fetch BYOK state for uid={}: {}, failing open (not cached)",
+                    uid,
+                    e
+                );
+                return ByokState::default();
+            }
+        };
+
+        // Store successful results in cache (evict oldest if at capacity)
+        if should_cache {
+            let mut cache = self.cache.lock().await;
+            if cache.len() >= BYOK_CACHE_MAX_ENTRIES && !cache.contains_key(uid) {
+                // Evict the oldest entry
+                if let Some(oldest_key) = cache
+                    .iter()
+                    .min_by_key(|(_, v)| v.cached_at)
+                    .map(|(k, _)| k.clone())
+                {
+                    cache.remove(&oldest_key);
+                }
+            }
+            cache.insert(
+                uid.to_string(),
+                CacheEntry {
+                    state: state.clone(),
+                    cached_at: Instant::now(),
+                },
+            );
+        }
+
+        state
+    }
+}
+
+/// Wrapper for storing ByokStateCache in Axum Extension.
+#[derive(Clone)]
+pub struct ByokCacheExt(pub Arc<ByokStateCache>);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (k, v) in pairs {
+            map.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        map
+    }
+
+    fn all_byok_headers_with_keys() -> HeaderMap {
+        headers_with(&[
+            ("x-byok-openai", "sk-o"),
+            ("x-byok-anthropic", "sk-a"),
+            ("x-byok-gemini", "sk-g"),
+            ("x-byok-deepgram", "sk-d"),
+        ])
+    }
+
+    fn fingerprints_for_keys() -> HashMap<String, String> {
+        let mut fp = HashMap::new();
+        fp.insert(
+            "openai".to_string(),
+            hex::encode(Sha256::digest(b"sk-o")),
+        );
+        fp.insert(
+            "anthropic".to_string(),
+            hex::encode(Sha256::digest(b"sk-a")),
+        );
+        fp.insert(
+            "gemini".to_string(),
+            hex::encode(Sha256::digest(b"sk-g")),
+        );
+        fp.insert(
+            "deepgram".to_string(),
+            hex::encode(Sha256::digest(b"sk-d")),
+        );
+        fp
+    }
+
+    fn active_state_with_fingerprints(fingerprints: HashMap<String, String>) -> ByokState {
+        ByokState {
+            active: true,
+            fingerprints,
+            last_seen_at: Some(Utc::now()),
+        }
+    }
+
+    // --- Header extraction tests (unchanged) ---
+
+    #[test]
+    fn get_byok_key_present() {
+        let h = headers_with(&[("x-byok-openai", "sk-test123")]);
+        assert_eq!(get_byok_key(&h, HEADER_OPENAI), Some("sk-test123"));
+    }
+
+    #[test]
+    fn get_byok_key_trimmed() {
+        let h = headers_with(&[("x-byok-openai", "  sk-test  ")]);
+        assert_eq!(get_byok_key(&h, HEADER_OPENAI), Some("sk-test"));
+    }
+
+    #[test]
+    fn get_byok_key_empty() {
+        let h = headers_with(&[("x-byok-openai", "")]);
+        assert_eq!(get_byok_key(&h, HEADER_OPENAI), None);
+    }
+
+    #[test]
+    fn get_byok_key_whitespace_only() {
+        let h = headers_with(&[("x-byok-openai", "   ")]);
+        assert_eq!(get_byok_key(&h, HEADER_OPENAI), None);
+    }
+
+    #[test]
+    fn get_byok_key_missing() {
+        let h = HeaderMap::new();
+        assert_eq!(get_byok_key(&h, HEADER_OPENAI), None);
+    }
+
+    #[test]
+    fn has_all_byok_keys_all_present() {
+        let h = all_byok_headers_with_keys();
+        assert!(has_all_byok_keys(&h));
+    }
+
+    #[test]
+    fn has_all_byok_keys_missing_one() {
+        let h = headers_with(&[
+            ("x-byok-openai", "sk-o"),
+            ("x-byok-anthropic", "sk-a"),
+            ("x-byok-gemini", "sk-g"),
+        ]);
+        assert!(!has_all_byok_keys(&h));
+    }
+
+    #[test]
+    fn has_all_byok_keys_one_empty() {
+        let h = headers_with(&[
+            ("x-byok-openai", "sk-o"),
+            ("x-byok-anthropic", ""),
+            ("x-byok-gemini", "sk-g"),
+            ("x-byok-deepgram", "sk-d"),
+        ]);
+        assert!(!has_all_byok_keys(&h));
+    }
+
+    #[test]
+    fn has_all_byok_keys_none() {
+        let h = HeaderMap::new();
+        assert!(!has_all_byok_keys(&h));
+    }
+
+    // --- Fingerprint validation tests ---
+
+    #[test]
+    fn fingerprint_sha256_matches_known_value() {
+        let fp = hex::encode(Sha256::digest(b"sk-test123"));
+        assert_eq!(
+            fp,
+            "bc372bdb48322359f05049dcf298b69067d926cd9f0aa42bb0660de7970b7e29"
+        );
+    }
+
+    #[test]
+    fn validate_active_byok_valid_fingerprints() {
+        let state = active_state_with_fingerprints(fingerprints_for_keys());
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(result, Ok(ByokValidation::Active));
+    }
+
+    #[test]
+    fn validate_active_byok_mismatched_fingerprint() {
+        let mut fp = fingerprints_for_keys();
+        fp.insert("openai".to_string(), "wrong_fingerprint".to_string());
+        let state = active_state_with_fingerprints(fp);
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("mismatch"));
+    }
+
+    #[test]
+    fn validate_non_byok_user_with_headers_strips() {
+        let state = ByokState::default();
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(
+            result,
+            Ok(ByokValidation::Inactive {
+                clear_headers: true
+            })
+        );
+    }
+
+    #[test]
+    fn validate_no_headers_no_action() {
+        let state = ByokState::default();
+        let headers = HeaderMap::new();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(
+            result,
+            Ok(ByokValidation::Inactive {
+                clear_headers: false
+            })
+        );
+    }
+
+    #[test]
+    fn validate_expired_heartbeat_strips() {
+        let state = ByokState {
+            active: true,
+            fingerprints: fingerprints_for_keys(),
+            last_seen_at: Some(Utc::now() - chrono::Duration::days(8)),
+        };
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(
+            result,
+            Ok(ByokValidation::Inactive {
+                clear_headers: true
+            })
+        );
+    }
+
+    #[test]
+    fn validate_missing_enrolled_provider_header() {
+        // BYOK-active user enrolled for all 4 but request only has openai
+        let state = active_state_with_fingerprints(fingerprints_for_keys());
+        let headers = headers_with(&[("x-byok-openai", "sk-o")]);
+        let result = validate_byok_request("uid", &headers, &state);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("missing"));
+    }
+
+    #[test]
+    fn validate_active_byok_no_headers_no_error() {
+        // BYOK-active user sends no headers — not an error, just no BYOK for this request
+        let state = active_state_with_fingerprints(fingerprints_for_keys());
+        let headers = HeaderMap::new();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(
+            result,
+            Ok(ByokValidation::Inactive {
+                clear_headers: false
+            })
+        );
+    }
+
+    #[test]
+    fn validate_heartbeat_within_ttl_valid() {
+        // Heartbeat 6 days ago — still within 7-day TTL
+        let state = ByokState {
+            active: true,
+            fingerprints: fingerprints_for_keys(),
+            last_seen_at: Some(Utc::now() - chrono::Duration::days(6)),
+        };
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(result, Ok(ByokValidation::Active));
+    }
+
+    #[test]
+    fn validate_active_no_last_seen_strips() {
+        // Active flag but no last_seen_at — treat as expired heartbeat
+        let state = ByokState {
+            active: true,
+            fingerprints: fingerprints_for_keys(),
+            last_seen_at: None,
+        };
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(
+            result,
+            Ok(ByokValidation::Inactive {
+                clear_headers: true
+            })
+        );
+    }
+
+    // --- Edge cases: empty / partial fingerprints ---
+
+    #[test]
+    fn validate_active_byok_empty_fingerprints() {
+        // Active BYOK user with empty fingerprint map — all headers pass
+        // (no enrolled fingerprints to check against)
+        let state = ByokState {
+            active: true,
+            fingerprints: HashMap::new(),
+            last_seen_at: Some(Utc::now()),
+        };
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(result, Ok(ByokValidation::Active));
+    }
+
+    #[test]
+    fn validate_active_byok_partial_enrollment() {
+        // Active BYOK user enrolled for only openai + gemini.
+        // Request sends all 4 headers — validates only the 2 enrolled.
+        let mut fp = HashMap::new();
+        fp.insert("openai".to_string(), hex::encode(Sha256::digest(b"sk-o")));
+        fp.insert("gemini".to_string(), hex::encode(Sha256::digest(b"sk-g")));
+        let state = active_state_with_fingerprints(fp);
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(result, Ok(ByokValidation::Active));
+    }
+
+    #[test]
+    fn validate_active_byok_partial_enrollment_mismatch() {
+        // Active BYOK user enrolled for openai + gemini, but request sends
+        // wrong key for gemini → mismatch even though anthropic/deepgram are ok
+        let mut fp = HashMap::new();
+        fp.insert("openai".to_string(), hex::encode(Sha256::digest(b"sk-o")));
+        fp.insert("gemini".to_string(), hex::encode(Sha256::digest(b"WRONG")));
+        let state = active_state_with_fingerprints(fp);
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("gemini"));
+    }
+
+    #[test]
+    fn validate_active_byok_partial_headers_match_enrollment() {
+        // Active user enrolled for only openai. Request sends only openai header.
+        // Should pass — the one enrolled fingerprint matches.
+        let mut fp = HashMap::new();
+        fp.insert("openai".to_string(), hex::encode(Sha256::digest(b"sk-o")));
+        let state = active_state_with_fingerprints(fp);
+        let headers = headers_with(&[("x-byok-openai", "sk-o")]);
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(result, Ok(ByokValidation::Active));
+    }
+
+    #[test]
+    fn validate_active_byok_unknown_provider_in_fingerprints_skipped() {
+        // Fingerprints contain a provider not in HEADER_TO_PROVIDER — should be skipped
+        let mut fp = fingerprints_for_keys();
+        fp.insert("unknown_provider".to_string(), "deadbeef".to_string());
+        let state = active_state_with_fingerprints(fp);
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(result, Ok(ByokValidation::Active));
+    }
+
+    #[test]
+    fn validate_heartbeat_exactly_at_ttl_boundary() {
+        // Heartbeat exactly at 7 days (604800 seconds) — should still be valid (<=)
+        let state = ByokState {
+            active: true,
+            fingerprints: fingerprints_for_keys(),
+            last_seen_at: Some(Utc::now() - chrono::Duration::seconds(BYOK_HEARTBEAT_TTL_SECS)),
+        };
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(result, Ok(ByokValidation::Active));
+    }
+
+    #[test]
+    fn validate_heartbeat_one_second_past_ttl() {
+        // Heartbeat at 7 days + 1 second — should be expired
+        let state = ByokState {
+            active: true,
+            fingerprints: fingerprints_for_keys(),
+            last_seen_at: Some(
+                Utc::now() - chrono::Duration::seconds(BYOK_HEARTBEAT_TTL_SECS + 1),
+            ),
+        };
+        let headers = all_byok_headers_with_keys();
+        let result = validate_byok_request("uid", &headers, &state);
+        assert_eq!(
+            result,
+            Ok(ByokValidation::Inactive {
+                clear_headers: true
+            })
+        );
+    }
+
+    // --- get_byok_key_if_active tests (used by route handlers) ---
+
+    #[test]
+    fn key_if_active_stripped_returns_none() {
+        // byok_stripped=true → always returns None, even if header is present
+        let h = headers_with(&[("x-byok-gemini", "sk-real-key")]);
+        assert_eq!(get_byok_key_if_active(&h, HEADER_GEMINI, true), None);
+    }
+
+    #[test]
+    fn key_if_active_not_stripped_returns_key() {
+        // byok_stripped=false → returns the header value
+        let h = headers_with(&[("x-byok-gemini", "sk-real-key")]);
+        assert_eq!(
+            get_byok_key_if_active(&h, HEADER_GEMINI, false),
+            Some("sk-real-key")
+        );
+    }
+
+    #[test]
+    fn key_if_active_not_stripped_missing_header_returns_none() {
+        // byok_stripped=false but header missing → None (natural fallback)
+        let h = HeaderMap::new();
+        assert_eq!(get_byok_key_if_active(&h, HEADER_GEMINI, false), None);
+    }
+
+    #[test]
+    fn key_if_active_all_providers_stripped() {
+        // Verify all 4 provider headers are blocked when stripped
+        let h = all_byok_headers_with_keys();
+        assert_eq!(get_byok_key_if_active(&h, HEADER_OPENAI, true), None);
+        assert_eq!(get_byok_key_if_active(&h, HEADER_ANTHROPIC, true), None);
+        assert_eq!(get_byok_key_if_active(&h, HEADER_GEMINI, true), None);
+        assert_eq!(get_byok_key_if_active(&h, HEADER_DEEPGRAM, true), None);
+    }
+
+    #[test]
+    fn key_if_active_all_providers_not_stripped() {
+        // Verify all 4 provider headers are returned when not stripped
+        let h = all_byok_headers_with_keys();
+        assert_eq!(
+            get_byok_key_if_active(&h, HEADER_OPENAI, false),
+            Some("sk-o")
+        );
+        assert_eq!(
+            get_byok_key_if_active(&h, HEADER_ANTHROPIC, false),
+            Some("sk-a")
+        );
+        assert_eq!(
+            get_byok_key_if_active(&h, HEADER_GEMINI, false),
+            Some("sk-g")
+        );
+        assert_eq!(
+            get_byok_key_if_active(&h, HEADER_DEEPGRAM, false),
+            Some("sk-d")
+        );
+    }
+}

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -80,9 +80,6 @@ pub struct Config {
     pub vertex_project_id: Option<String>,
     /// GCP region for Vertex AI (default: us-central1)
     pub vertex_location: String,
-    /// Python backend base URL used for cross-service calls (e.g. paywall status).
-    /// Defaults to https://api.omi.me; override with OMI_PYTHON_API_URL for staging/dev.
-    pub python_api_base: String,
 }
 
 impl Config {
@@ -152,10 +149,6 @@ impl Config {
                 .ok(),
             vertex_location: env::var("GCP_LOCATION")
                 .unwrap_or_else(|_| "us-central1".to_string()),
-            python_api_base: env::var("OMI_PYTHON_API_URL")
-                .unwrap_or_else(|_| "https://api.omi.me".to_string())
-                .trim_end_matches('/')
-                .to_string(),
         }
     }
 

--- a/desktop/Backend-Rust/src/main.rs
+++ b/desktop/Backend-Rust/src/main.rs
@@ -23,6 +23,7 @@ impl FormatTime for BackendTimer {
 }
 
 mod auth;
+mod byok;
 mod config;
 mod encryption;
 mod llm;
@@ -32,7 +33,8 @@ mod routes;
 mod services;
 mod vertex;
 
-use auth::{firebase_auth_extension, paywall_checker_extension, FirebaseAuth};
+use auth::{byok_cache_extension, firebase_auth_extension, paywall_checker_extension, FirebaseAuth};
+use byok::ByokStateCache;
 use paywall::PaywallChecker;
 use config::Config;
 use routes::{
@@ -121,7 +123,7 @@ async fn main() {
     let auth_project_id = config.firebase_auth_project_id.clone()
         .or_else(|| config.firebase_project_id.clone())
         .expect("FIREBASE_AUTH_PROJECT_ID or FIREBASE_PROJECT_ID must be set");
-    let firebase_auth = Arc::new(FirebaseAuth::new(auth_project_id));
+    let firebase_auth = Arc::new(FirebaseAuth::new(auth_project_id.clone()));
 
     // Refresh Firebase keys with retry (transient network failures at startup)
     {
@@ -232,8 +234,15 @@ async fn main() {
         });
     }
 
-    // Paywall checker — calls Python `/v1/users/me/paywall`, caches 5min.
-    let paywall_checker = Arc::new(PaywallChecker::new(config.python_api_base.clone()));
+    // BYOK state cache — caches Firestore BYOK state per-uid for 30s.
+    let byok_cache = Arc::new(ByokStateCache::new());
+
+    // Paywall checker — reads subscription/BYOK/account-age from Firestore + Firebase Auth.
+    let paywall_checker = Arc::new(PaywallChecker::new(
+        firestore.clone(),
+        auth_project_id.clone(),
+        byok_cache.clone(),
+    ));
 
     let state = AppState {
         firestore,
@@ -277,6 +286,7 @@ async fn main() {
         .merge(auth_router)
         .layer(firebase_auth_extension(firebase_auth))
         .layer(paywall_checker_extension(paywall_checker))
+        .layer(byok_cache_extension(byok_cache))
         .layer(cors)
         .layer(TraceLayer::new_for_http());
 

--- a/desktop/Backend-Rust/src/paywall.rs
+++ b/desktop/Backend-Rust/src/paywall.rs
@@ -1,26 +1,33 @@
-// Trial-paywall middleware for the Rust desktop-backend.
+// Trial-paywall logic for the Rust desktop-backend.
 //
-// Delegates the decision to Python (`GET /v1/users/me/paywall`) which owns
-// the canonical paywall logic (basic plan + no BYOK + Firebase account >3d
-// old + platform=macos/desktop). We cache the boolean per-uid in-memory for
-// 5 minutes so chat / proxy / TTS / screen-activity calls don't fan out to
-// Python on every request.
+// Previously delegated to Python (`GET /v1/users/me/paywall`). Now runs
+// natively by reading subscription plan, BYOK state, and account creation
+// time directly from Firestore / Firebase Auth.
 //
-// Mobile is not a concern here — the Rust desktop-backend is only ever
-// called by the macOS Swift client, so every paywall check goes in with
-// `X-App-Platform: macos`. Python `is_trial_paywalled` enforces the
-// platform gate; if it ever returns `paywalled=true` for an iOS / Android
-// caller (which can't happen via this code path), this layer would still
-// return 402 — but that situation cannot arise from real traffic.
+// Logic (mirrors Python `_is_trial_expired_uncached` in `utils/subscription.py`):
+//   1. BYOK escape hatch: request with all 4 BYOK headers → never paywalled
+//   2. Non-"basic" plan → not paywalled
+//   3. BYOK active (heartbeat within TTL) → not paywalled
+//   4. Account created < 3 days ago → not paywalled (trial active)
+//   5. Otherwise → paywalled
+//
+// Errors fail open (return false) so a Firestore/Auth outage never makes
+// paying users look paywalled.
 
-use reqwest::Client;
-use serde::Deserialize;
+use axum::http::HeaderMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
+use crate::byok;
+use crate::services::FirestoreService;
+
+/// Cache TTL for paywall results (5 minutes, matching previous Python-delegation cache).
 const CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// Trial length: 3 days in seconds (matches Python `TRIAL_LENGTH_SECONDS`).
+const TRIAL_LENGTH_SECONDS: i64 = 3 * 24 * 60 * 60;
 
 #[derive(Debug, Clone, Copy)]
 struct CacheEntry {
@@ -28,87 +35,74 @@ struct CacheEntry {
     cached_at: Instant,
 }
 
-#[derive(Deserialize)]
-struct PaywallStatus {
-    paywalled: bool,
-}
-
-/// Singleton helper that calls Python's `/v1/users/me/paywall` and caches
-/// the result in-memory. Held inside `AppState` and exposed to extractors
-/// via an Axum `Extension`.
+/// Native paywall checker that reads directly from Firestore and Firebase Auth.
+/// Held inside `AppState` and exposed to extractors via an Axum `Extension`.
 pub struct PaywallChecker {
-    python_api_base: String,
-    http: Client,
-    cache: Arc<Mutex<HashMap<String, CacheEntry>>>,
+    pub firestore: Arc<FirestoreService>,
+    firebase_auth_project_id: String,
+    byok_cache: Arc<byok::ByokStateCache>,
+    cache: Mutex<HashMap<String, CacheEntry>>,
 }
 
 impl PaywallChecker {
-    pub fn new(python_api_base: String) -> Self {
-        let http = Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build()
-            .unwrap_or_else(|_| Client::new());
+    pub fn new(
+        firestore: Arc<FirestoreService>,
+        firebase_auth_project_id: String,
+        byok_cache: Arc<byok::ByokStateCache>,
+    ) -> Self {
         Self {
-            python_api_base: python_api_base.trim_end_matches('/').to_string(),
-            http,
-            cache: Arc::new(Mutex::new(HashMap::new())),
+            firestore,
+            firebase_auth_project_id,
+            byok_cache,
+            cache: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Returns true iff the user is past their desktop trial. Errors fail
-    /// open (return false) so a Python outage never makes paying users
-    /// look paywalled.
-    pub async fn is_paywalled(&self, uid: &str, bearer_token: &str) -> bool {
+    /// Returns true iff the user is past their desktop trial.
+    ///
+    /// When the request carries all 4 BYOK headers, the user is never
+    /// paywalled (escape hatch for stale Firestore cache). Otherwise,
+    /// checks subscription plan, BYOK active state, and account age.
+    ///
+    /// Errors fail open (return false).
+    /// `byok_stripped`: true if BYOK validation determined the user is not
+    /// BYOK-enrolled (headers were silently cleared). When true, the BYOK
+    /// escape hatch is disabled — the raw headers cannot be trusted.
+    pub async fn is_paywalled(
+        &self,
+        uid: &str,
+        request_headers: &HeaderMap,
+        byok_stripped: bool,
+    ) -> bool {
+        // BYOK escape hatch: a request carrying all 4 BYOK provider headers
+        // is never paywalled, regardless of cached state. This handles the
+        // race where Firestore hasn't caught up after BYOK activation.
+        // SECURITY: Only trust the escape hatch if BYOK validation did NOT
+        // strip the headers (i.e. the user is actually BYOK-enrolled or
+        // validation hasn't run). A non-enrolled user forging all 4 headers
+        // will have byok_stripped=true, so they can't bypass the paywall.
+        if !byok_stripped && byok::has_all_byok_keys(request_headers) {
+            return false;
+        }
+
+        let cache_key = uid.to_string();
+
         // Cache hit
         {
             let cache = self.cache.lock().await;
-            if let Some(entry) = cache.get(uid) {
+            if let Some(entry) = cache.get(&cache_key) {
                 if entry.cached_at.elapsed() < CACHE_TTL {
                     return entry.paywalled;
                 }
             }
         }
 
-        let url = format!("{}/v1/users/me/paywall", self.python_api_base);
-        let response = self
-            .http
-            .get(&url)
-            .header("Authorization", format!("Bearer {}", bearer_token))
-            .header("X-App-Platform", "macos")
-            .send()
-            .await;
+        let paywalled = self.check_trial_expired(uid).await;
 
-        let paywalled = match response {
-            Ok(r) if r.status().is_success() => match r.json::<PaywallStatus>().await {
-                Ok(body) => body.paywalled,
-                Err(e) => {
-                    tracing::warn!(
-                        "paywall: failed to parse Python response for uid={}: {}",
-                        uid,
-                        e
-                    );
-                    false
-                }
-            },
-            Ok(r) => {
-                tracing::warn!(
-                    "paywall: Python returned {} for uid={}, failing open",
-                    r.status(),
-                    uid
-                );
-                false
-            }
-            Err(e) => {
-                tracing::warn!("paywall: Python call failed for uid={}: {}", uid, e);
-                false
-            }
-        };
-
-        // Cache (even false results — limits Python load when many requests
-        // arrive in quick succession for the same uid)
+        // Cache result
         let mut cache = self.cache.lock().await;
         cache.insert(
-            uid.to_string(),
+            cache_key,
             CacheEntry {
                 paywalled,
                 cached_at: Instant::now(),
@@ -117,9 +111,222 @@ impl PaywallChecker {
 
         paywalled
     }
+
+    /// Core trial-expiry check. Mirrors Python `_is_trial_expired_uncached`.
+    /// Returns false (not paywalled) on any error (fail-open).
+    async fn check_trial_expired(&self, uid: &str) -> bool {
+        // Step 1: Read effective subscription plan (checks current_period_end for paid plans)
+        let plan = match self.firestore.get_user_effective_plan(uid).await {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    "paywall: failed to read subscription plan for uid={}: {}, failing open",
+                    uid,
+                    e
+                );
+                return false;
+            }
+        };
+
+        // Non-basic plan → not paywalled
+        if plan != "basic" {
+            return false;
+        }
+
+        // Step 2: Check BYOK active (with heartbeat TTL)
+        let byok_state = self.byok_cache.get_or_fetch(uid, &self.firestore).await;
+        let byok_active = byok_state.active && {
+            match byok_state.last_seen_at {
+                Some(last_seen) => {
+                    let age = chrono::Utc::now()
+                        .signed_duration_since(last_seen)
+                        .num_seconds();
+                    age <= byok::BYOK_HEARTBEAT_TTL_SECS
+                }
+                None => false,
+            }
+        };
+        if byok_active {
+            return false;
+        }
+
+        // Step 3: Check account age from Firebase Auth
+        let creation_ms = match self
+            .firestore
+            .get_user_creation_time(&self.firebase_auth_project_id, uid)
+            .await
+        {
+            Ok(Some(ms)) => ms,
+            Ok(None) => {
+                tracing::warn!(
+                    "paywall: no creation time for uid={}, failing open",
+                    uid
+                );
+                return false;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "paywall: failed to get creation time for uid={}: {}, failing open",
+                    uid,
+                    e
+                );
+                return false;
+            }
+        };
+
+        let now_ms = chrono::Utc::now().timestamp() * 1000;
+        let age_seconds = (now_ms - creation_ms) / 1000;
+
+        age_seconds > TRIAL_LENGTH_SECONDS
+    }
 }
 
 /// Wrapper for storing in Axum Extension so extractors can pull it
 /// without owning `AppState`.
 #[derive(Clone)]
 pub struct PaywallCheckerExt(pub Arc<PaywallChecker>);
+
+/// Pure function for testing: is the trial expired given these inputs?
+/// This is the core logic extracted for unit testing without Firestore.
+#[cfg(test)]
+fn is_trial_expired(plan: &str, byok_active: bool, creation_time_ms: Option<i64>) -> bool {
+    if plan != "basic" {
+        return false;
+    }
+    if byok_active {
+        return false;
+    }
+    let creation_ms = match creation_time_ms {
+        Some(ms) => ms,
+        None => return false, // fail-open
+    };
+    let now_ms = chrono::Utc::now().timestamp() * 1000;
+    let age_seconds = (now_ms - creation_ms) / 1000;
+    age_seconds > TRIAL_LENGTH_SECONDS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (k, v) in pairs {
+            map.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        map
+    }
+
+    fn all_byok_headers() -> HeaderMap {
+        headers_with(&[
+            ("x-byok-openai", "sk-o"),
+            ("x-byok-anthropic", "sk-a"),
+            ("x-byok-gemini", "sk-g"),
+            ("x-byok-deepgram", "sk-d"),
+        ])
+    }
+
+    // --- Pure function tests for is_trial_expired ---
+
+    #[test]
+    fn paid_plan_not_paywalled() {
+        assert!(!is_trial_expired("pro", false, Some(0)));
+        assert!(!is_trial_expired("enterprise", false, Some(0)));
+        assert!(!is_trial_expired("unlimited", false, Some(0)));
+    }
+
+    #[test]
+    fn basic_plan_byok_active_not_paywalled() {
+        // Basic plan + BYOK active → not paywalled regardless of age
+        assert!(!is_trial_expired("basic", true, Some(0)));
+    }
+
+    #[test]
+    fn basic_plan_new_account_not_paywalled() {
+        // Account created just now → within 3-day trial
+        let now_ms = chrono::Utc::now().timestamp() * 1000;
+        assert!(!is_trial_expired("basic", false, Some(now_ms)));
+    }
+
+    #[test]
+    fn basic_plan_old_account_no_byok_paywalled() {
+        // Account created 10 days ago → past 3-day trial
+        let ten_days_ago_ms =
+            (chrono::Utc::now().timestamp() - 10 * 24 * 60 * 60) * 1000;
+        assert!(is_trial_expired("basic", false, Some(ten_days_ago_ms)));
+    }
+
+    #[test]
+    fn basic_plan_exactly_3_days_not_paywalled() {
+        // Account created exactly 3 days ago → age == TRIAL_LENGTH, not > TRIAL_LENGTH
+        let exactly_3d_ms =
+            (chrono::Utc::now().timestamp() - TRIAL_LENGTH_SECONDS) * 1000;
+        assert!(!is_trial_expired("basic", false, Some(exactly_3d_ms)));
+    }
+
+    #[test]
+    fn basic_plan_just_over_3_days_paywalled() {
+        // Account created 3 days + 1 second ago
+        let just_over_3d_ms =
+            (chrono::Utc::now().timestamp() - TRIAL_LENGTH_SECONDS - 1) * 1000;
+        assert!(is_trial_expired("basic", false, Some(just_over_3d_ms)));
+    }
+
+    #[test]
+    fn missing_creation_time_fails_open() {
+        assert!(!is_trial_expired("basic", false, None));
+    }
+
+    #[test]
+    fn free_plan_treated_as_basic() {
+        // "free" should have been migrated to "basic" by Firestore reader,
+        // but even if not, it won't match "basic" → not paywalled (fail-open)
+        assert!(!is_trial_expired("free", false, Some(0)));
+    }
+
+    // --- BYOK escape hatch tests (header-level) ---
+
+    #[test]
+    fn byok_escape_hatch_all_headers_present() {
+        let h = all_byok_headers();
+        assert!(byok::has_all_byok_keys(&h), "all 4 → escape hatch fires");
+    }
+
+    #[test]
+    fn byok_escape_hatch_missing_header() {
+        let h = headers_with(&[
+            ("x-byok-openai", "sk-o"),
+            ("x-byok-anthropic", "sk-a"),
+            ("x-byok-gemini", "sk-g"),
+        ]);
+        assert!(
+            !byok::has_all_byok_keys(&h),
+            "missing deepgram → escape hatch does not fire"
+        );
+    }
+
+    // --- byok_stripped prevents paywall escape hatch ---
+
+    #[test]
+    fn byok_stripped_disables_escape_hatch() {
+        // Even with all 4 BYOK headers present, if byok_stripped=true,
+        // the escape hatch must NOT fire. Verified at the logic level:
+        // is_paywalled checks `!byok_stripped && has_all_byok_keys`.
+        let h = all_byok_headers();
+        let byok_stripped = true;
+        // The escape hatch condition:
+        let would_escape = !byok_stripped && byok::has_all_byok_keys(&h);
+        assert!(!would_escape, "stripped headers must not trigger escape hatch");
+    }
+
+    #[test]
+    fn non_stripped_allows_escape_hatch() {
+        let h = all_byok_headers();
+        let byok_stripped = false;
+        let would_escape = !byok_stripped && byok::has_all_byok_keys(&h);
+        assert!(would_escape, "validated headers should trigger escape hatch");
+    }
+}

--- a/desktop/Backend-Rust/src/routes/chat_completions.rs
+++ b/desktop/Backend-Rust/src/routes/chat_completions.rs
@@ -8,7 +8,7 @@
 use axum::{
     body::Bytes,
     extract::{DefaultBodyLimit, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::post,
     Json, Router,
@@ -17,6 +17,7 @@ use futures::StreamExt;
 use serde_json::json;
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
+use crate::byok;
 use crate::models::chat_completions::*;
 use crate::AppState;
 
@@ -449,8 +450,10 @@ fn make_chunk(
 async fn chat_completions(
     State(state): State<AppState>,
     user: PaywalledAuthUser,
+    headers: HeaderMap,
     Json(req): Json<ChatCompletionRequest>,
 ) -> Result<Response, StatusCode> {
+    let byok_stripped = user.byok_stripped;
     let user: AuthUser = user.into();
     // Validate model
     let route = resolve_model(&req.model).ok_or_else(|| {
@@ -462,32 +465,45 @@ async fn chat_completions(
         StatusCode::BAD_REQUEST
     })?;
 
-    // Rate limiting
-    let decision = state
-        .gemini_rate_limiter
-        .check_and_record(&user.uid, state.redis.as_ref())
-        .await;
-    if decision == RateDecision::Reject {
-        return Ok(Response::builder()
-            .status(StatusCode::TOO_MANY_REQUESTS)
-            .header("content-type", "application/json")
-            .header("retry-after", "60")
-            .body(axum::body::Body::from(
-                json!({"error": {"message": "Rate limit exceeded", "type": "rate_limit_error", "code": 429}}).to_string()
-            ))
-            .unwrap());
+    // BYOK: check for user-provided Anthropic API key (issue #7357).
+    // When present, use the user's key and skip server-key rate limiting.
+    let byok_anthropic_key = byok::get_byok_key_if_active(&headers, byok::HEADER_ANTHROPIC, byok_stripped);
+    let is_byok = byok_anthropic_key.is_some();
+
+    // Rate limiting — skip when using BYOK key
+    if !is_byok {
+        let decision = state
+            .gemini_rate_limiter
+            .check_and_record(&user.uid, state.redis.as_ref())
+            .await;
+        if decision == RateDecision::Reject {
+            return Ok(Response::builder()
+                .status(StatusCode::TOO_MANY_REQUESTS)
+                .header("content-type", "application/json")
+                .header("retry-after", "60")
+                .body(axum::body::Body::from(
+                    json!({"error": {"message": "Rate limit exceeded", "type": "rate_limit_error", "code": 429}}).to_string()
+                ))
+                .unwrap());
+        }
     }
 
-    // Get API key
-    let api_key = match route.provider {
-        Provider::Anthropic => state
-            .config
-            .anthropic_api_key
-            .as_ref()
-            .ok_or_else(|| {
-                tracing::error!("chat_completions: ANTHROPIC_API_KEY not configured");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?,
+    // Get API key — prefer BYOK, fall back to server key
+    let api_key: String = if let Some(byok_key) = byok_anthropic_key {
+        tracing::info!("chat_completions: using BYOK Anthropic key for uid={}", user.uid);
+        byok_key.to_string()
+    } else {
+        match route.provider {
+            Provider::Anthropic => state
+                .config
+                .anthropic_api_key
+                .as_ref()
+                .ok_or_else(|| {
+                    tracing::error!("chat_completions: ANTHROPIC_API_KEY not configured");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                })?
+                .clone(),
+        }
     };
 
     // Translate request
@@ -501,21 +517,23 @@ async fn chat_completions(
     if req.stream {
         handle_streaming(
             &client,
-            api_key,
+            &api_key,
             &anthropic_req,
             route,
             &user,
             &state,
+            is_byok,
         )
         .await
     } else {
         handle_non_streaming(
             &client,
-            api_key,
+            &api_key,
             &anthropic_req,
             route,
             &user,
             &state,
+            is_byok,
         )
         .await
     }
@@ -528,6 +546,7 @@ async fn handle_non_streaming(
     route: &ModelRoute,
     user: &AuthUser,
     state: &AppState,
+    is_byok: bool,
 ) -> Result<Response, StatusCode> {
     let upstream_resp = client
         .post(ANTHROPIC_API_URL)
@@ -563,9 +582,12 @@ async fn handle_non_streaming(
         StatusCode::BAD_GATEWAY
     })?;
 
-    // Log usage
-    let cost = compute_cost(&anthropic_resp.usage, route.upstream_model);
-    log_usage(state, user, &anthropic_resp.usage, cost).await;
+    // Log usage — skip for BYOK since the user pays their own bill and
+    // including it would overstate Omi's spend in cost dashboards.
+    if !is_byok {
+        let cost = compute_cost(&anthropic_resp.usage, route.upstream_model);
+        log_usage(state, user, &anthropic_resp.usage, cost).await;
+    }
 
     let openai_resp = translate_response(&anthropic_resp, route.public_model);
 
@@ -579,6 +601,7 @@ async fn handle_streaming(
     route: &ModelRoute,
     user: &AuthUser,
     state: &AppState,
+    is_byok: bool,
 ) -> Result<Response, StatusCode> {
     let upstream_resp = client
         .post(ANTHROPIC_API_URL)
@@ -817,7 +840,8 @@ async fn handle_streaming(
                     AnthropicStreamEvent::MessageStop {} => {
                         yield Ok(Bytes::from_static(b"data: [DONE]\n\n"));
 
-                        // Log usage asynchronously
+                        // Log usage asynchronously — skip for BYOK (user pays own bill)
+                        if !is_byok {
                         if let Some(ref fu) = final_usage {
                             let merged = AnthropicUsage {
                                 input_tokens: initial_usage.as_ref().map_or(0, |u| u.input_tokens),
@@ -844,6 +868,7 @@ async fn handle_streaming(
                                 }
                             });
                         }
+                        } // if !is_byok
                     }
 
                     AnthropicStreamEvent::Ping {} => {}

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -8,13 +8,14 @@
 use axum::{
     body::Bytes,
     extract::{DefaultBodyLimit, Path, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::post,
     Router,
 };
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
+use crate::byok;
 use crate::AppState;
 
 use super::rate_limit::{self, RateDecision};
@@ -80,9 +81,11 @@ impl IntoResponse for ProxyError {
 async fn gemini_proxy(
     State(state): State<AppState>,
     user: PaywalledAuthUser,
+    headers: HeaderMap,
     Path(path): Path<String>,
     body: Bytes,
 ) -> Result<Response, ProxyError> {
+    let byok_stripped = user.byok_stripped;
     let user: AuthUser = user.into();
     // Rewrite preview models to stable equivalents (old app compat)
     let path = crate::llm::model_qos::rewrite_preview_model(&path);
@@ -108,24 +111,79 @@ async fn gemini_proxy(
         ProxyError::Status(StatusCode::BAD_REQUEST)
     })?;
 
-    // Rate limit check
-    let decision = state.gemini_rate_limiter.check_and_record(&user.uid, state.redis.as_ref()).await;
-    if decision == RateDecision::Reject {
-        tracing::warn!("gemini_proxy: rate limit rejected uid={}", user.uid);
-        return Err(ProxyError::RateLimited);
+    // BYOK: check for user-provided Gemini API key (issue #7357).
+    // When present, use AI Studio with the user's key, skip Vertex AI routing
+    // and server-key rate limiting (the user pays their own bill).
+    // If byok_stripped, the user is not BYOK-enrolled — ignore their headers.
+    let byok_gemini_key = byok::get_byok_key_if_active(&headers, byok::HEADER_GEMINI, byok_stripped);
+    let is_byok = byok_gemini_key.is_some();
+
+    // Rate limit check — skip when using BYOK key
+    if !is_byok {
+        let decision = state.gemini_rate_limiter.check_and_record(&user.uid, state.redis.as_ref()).await;
+        if decision == RateDecision::Reject {
+            tracing::warn!("gemini_proxy: rate limit rejected uid={}", user.uid);
+            return Err(ProxyError::RateLimited);
+        }
+
+        // Apply model degradation if needed
+        let effective_path = rate_limit::maybe_rewrite_model_path(&path, &decision, action);
+        if effective_path != path {
+            tracing::info!(
+                "gemini_proxy: degraded uid={} {} -> {}",
+                user.uid,
+                path,
+                effective_path
+            );
+        }
+
+        // Non-BYOK path: use server key with Vertex AI / AI Studio routing
+        return gemini_proxy_server_key(
+            &state, &user, &effective_path, action, model, &sanitized_body,
+        )
+        .await;
     }
 
-    // Apply model degradation if needed
-    let effective_path = rate_limit::maybe_rewrite_model_path(&path, &decision, action);
-    if effective_path != path {
-        tracing::info!(
-            "gemini_proxy: degraded uid={} {} -> {}",
-            user.uid,
-            path,
-            effective_path
-        );
-    }
+    // BYOK path: always use AI Studio with the user's API key.
+    // Vertex AI requires our service account — can't mix with user's API key.
+    // Skip Vertex-specific transforms (embedContent→predict) since AI Studio
+    // handles embedContent natively.
+    let byok_key = byok_gemini_key.unwrap();
+    tracing::info!("gemini_proxy: using BYOK Gemini key for uid={}", user.uid);
 
+    let url = build_gemini_url(&path, byok_key);
+    let upstream = reqwest::Client::new()
+        .post(&url)
+        .header("content-type", "application/json")
+        .body(sanitized_body)
+        .send()
+        .await
+        .map_err(|e| {
+            // Use without_url() to avoid leaking BYOK API key from the query string
+            tracing::error!("gemini_proxy: BYOK upstream request failed: {}", e.without_url());
+            ProxyError::Status(StatusCode::BAD_GATEWAY)
+        })?;
+
+    let status =
+        StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let bytes = upstream.bytes().await.map_err(|e| {
+        tracing::error!("gemini_proxy: failed to read upstream body: {}", e.without_url());
+        ProxyError::Status(StatusCode::BAD_GATEWAY)
+    })?;
+
+    Ok((status, bytes).into_response())
+}
+
+/// Non-BYOK Gemini proxy: uses server key with Vertex AI / AI Studio routing,
+/// rate limiting, model degradation, and body transforms.
+async fn gemini_proxy_server_key(
+    state: &AppState,
+    user: &AuthUser,
+    effective_path: &str,
+    action: &str,
+    model: &str,
+    sanitized_body: &[u8],
+) -> Result<Response, ProxyError> {
     // Resolve provider route: single dispatch point for all provider-specific behavior.
     // Returns provider, action override, and body transforms needed.
     use crate::llm::model_qos::{resolve_route, BodyTransform, Provider, ResponseTransform};
@@ -133,12 +191,12 @@ async fn gemini_proxy(
 
     // Apply request body transform if needed (e.g., embedContent → predict format)
     let request_body = match route.request_transform {
-        BodyTransform::EmbedToPredict => transform_embed_request_to_vertex(&sanitized_body)
+        BodyTransform::EmbedToPredict => transform_embed_request_to_vertex(sanitized_body)
             .map_err(|e| {
                 tracing::warn!("gemini_proxy: embed body transform failed: {}", e);
                 ProxyError::Status(StatusCode::BAD_REQUEST)
             })?,
-        BodyTransform::None => sanitized_body.clone(),
+        BodyTransform::None => sanitized_body.to_vec(),
     };
 
     // Apply Vertex action override (e.g., :embedContent → :predict)
@@ -171,11 +229,11 @@ async fn gemini_proxy(
                 Err(e) => {
                     if let Some(gemini_key) = state.config.gemini_api_key.as_ref() {
                         tracing::warn!("gemini_proxy: Vertex AI token failed, falling back to API key: {}", e);
-                        let url = build_gemini_url(&effective_path, gemini_key);
+                        let url = build_gemini_url(effective_path, gemini_key);
                         reqwest::Client::new()
                             .post(&url)
                             .header("content-type", "application/json")
-                            .body(sanitized_body.clone())
+                            .body(sanitized_body.to_vec())
                             .send()
                             .await
                     } else {
@@ -188,11 +246,11 @@ async fn gemini_proxy(
             // Vertex AI requested but not configured → AI Studio
             let gemini_key = state.config.gemini_api_key.as_ref()
                 .ok_or(ProxyError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
-            let url = build_gemini_url(&effective_path, gemini_key);
+            let url = build_gemini_url(effective_path, gemini_key);
             reqwest::Client::new()
                 .post(&url)
                 .header("content-type", "application/json")
-                .body(sanitized_body.clone())
+                .body(sanitized_body.to_vec())
                 .send()
                 .await
         }
@@ -200,11 +258,11 @@ async fn gemini_proxy(
         // AI Studio route
         let gemini_key = state.config.gemini_api_key.as_ref()
             .ok_or(ProxyError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
-        let url = build_gemini_url(&effective_path, gemini_key);
+        let url = build_gemini_url(effective_path, gemini_key);
         reqwest::Client::new()
             .post(&url)
             .header("content-type", "application/json")
-            .body(sanitized_body.clone())
+            .body(sanitized_body.to_vec())
             .send()
             .await
     };
@@ -245,10 +303,12 @@ async fn gemini_proxy(
 async fn gemini_stream_proxy(
     State(state): State<AppState>,
     user: PaywalledAuthUser,
+    headers: HeaderMap,
     Path(path): Path<String>,
     axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>,
     body: Bytes,
 ) -> Result<Response, ProxyError> {
+    let byok_stripped = user.byok_stripped;
     let user: AuthUser = user.into();
     // Rewrite preview models to stable equivalents (old app compat)
     let path = crate::llm::model_qos::rewrite_preview_model(&path);
@@ -273,24 +333,72 @@ async fn gemini_stream_proxy(
         ProxyError::Status(StatusCode::BAD_REQUEST)
     })?;
 
-    // Rate limit check
-    let decision = state.gemini_rate_limiter.check_and_record(&user.uid, state.redis.as_ref()).await;
-    if decision == RateDecision::Reject {
-        tracing::warn!("gemini_stream_proxy: rate limit rejected uid={}", user.uid);
-        return Err(ProxyError::RateLimited);
+    // BYOK: check for user-provided Gemini API key (issue #7357).
+    let byok_gemini_key = byok::get_byok_key_if_active(&headers, byok::HEADER_GEMINI, byok_stripped);
+    let is_byok = byok_gemini_key.is_some();
+
+    // Rate limit check — skip when using BYOK key
+    if !is_byok {
+        let decision = state.gemini_rate_limiter.check_and_record(&user.uid, state.redis.as_ref()).await;
+        if decision == RateDecision::Reject {
+            tracing::warn!("gemini_stream_proxy: rate limit rejected uid={}", user.uid);
+            return Err(ProxyError::RateLimited);
+        }
+
+        // Apply model degradation if needed
+        let effective_path = rate_limit::maybe_rewrite_model_path(&path, &decision, action);
+        if effective_path != path {
+            tracing::info!(
+                "gemini_stream_proxy: degraded uid={} {} -> {}",
+                user.uid,
+                path,
+                effective_path
+            );
+        }
+
+        // Non-BYOK: server key with Vertex AI / AI Studio routing
+        return gemini_stream_server_key(&state, &effective_path, action, model, sanitized_body, &query).await;
     }
 
-    // Apply model degradation if needed
-    let effective_path = rate_limit::maybe_rewrite_model_path(&path, &decision, action);
-    if effective_path != path {
-        tracing::info!(
-            "gemini_stream_proxy: degraded uid={} {} -> {}",
-            user.uid,
-            path,
-            effective_path
-        );
-    }
+    // BYOK path: always use AI Studio with user's key, skip Vertex AI.
+    let byok_key = byok_gemini_key.unwrap();
+    tracing::info!("gemini_stream_proxy: using BYOK Gemini key for uid={}", user.uid);
 
+    let upstream_url = build_gemini_stream_url(&path, byok_key, &query);
+    let upstream = reqwest::Client::new()
+        .post(&upstream_url)
+        .header("content-type", "application/json")
+        .body(sanitized_body)
+        .send()
+        .await
+        .map_err(|e| {
+            // Use without_url() to avoid leaking BYOK API key from the query string
+            tracing::error!("gemini_stream_proxy: BYOK upstream request failed: {}", e.without_url());
+            ProxyError::Status(StatusCode::BAD_GATEWAY)
+        })?;
+
+    let status =
+        StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+
+    let stream = upstream.bytes_stream();
+    let body = axum::body::Body::from_stream(stream);
+
+    Ok(Response::builder()
+        .status(status)
+        .header("content-type", "text/event-stream")
+        .body(body)
+        .unwrap())
+}
+
+/// Non-BYOK streaming Gemini proxy: server key with Vertex AI / AI Studio routing.
+async fn gemini_stream_server_key(
+    state: &AppState,
+    effective_path: &str,
+    action: &str,
+    model: &str,
+    sanitized_body: Vec<u8>,
+    query: &std::collections::HashMap<String, String>,
+) -> Result<Response, ProxyError> {
     // Resolve provider route (same dispatch as non-streaming proxy)
     use crate::llm::model_qos::{resolve_route, Provider};
     let route = resolve_route(model, action);
@@ -298,12 +406,12 @@ async fn gemini_stream_proxy(
     // Build and send request: Vertex AI or AI Studio
     let upstream = if route.provider == Provider::VertexAi {
         if let Some(ref vertex) = state.vertex_auth {
-            let mut url = vertex.build_url_from_path(&effective_path).ok_or_else(|| {
+            let mut url = vertex.build_url_from_path(effective_path).ok_or_else(|| {
                 tracing::error!("gemini_stream_proxy: failed to parse path for Vertex AI: {}", effective_path);
                 ProxyError::Status(StatusCode::BAD_REQUEST)
             })?;
             // Append extra query params (e.g., alt=sse) for streaming
-            for (k, v) in &query {
+            for (k, v) in query {
                 url.push(if url.contains('?') { '&' } else { '?' });
                 url.push_str(&urlencoding::encode(k));
                 url.push('=');
@@ -322,7 +430,7 @@ async fn gemini_stream_proxy(
                 Err(e) => {
                     if let Some(gemini_key) = state.config.gemini_api_key.as_ref() {
                         tracing::warn!("gemini_stream_proxy: Vertex AI token failed, falling back to API key: {}", e);
-                        let upstream_url = build_gemini_stream_url(&effective_path, gemini_key, &query);
+                        let upstream_url = build_gemini_stream_url(effective_path, gemini_key, query);
                         reqwest::Client::new()
                             .post(&upstream_url)
                             .header("content-type", "application/json")
@@ -339,7 +447,7 @@ async fn gemini_stream_proxy(
             // Vertex AI requested but not configured → AI Studio
             let gemini_key = state.config.gemini_api_key.as_ref()
                 .ok_or(ProxyError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
-            let upstream_url = build_gemini_stream_url(&effective_path, gemini_key, &query);
+            let upstream_url = build_gemini_stream_url(effective_path, gemini_key, query);
             reqwest::Client::new()
                 .post(&upstream_url)
                 .header("content-type", "application/json")
@@ -351,7 +459,7 @@ async fn gemini_stream_proxy(
         // AI Studio route
         let gemini_key = state.config.gemini_api_key.as_ref()
             .ok_or(ProxyError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
-        let upstream_url = build_gemini_stream_url(&effective_path, gemini_key, &query);
+        let upstream_url = build_gemini_stream_url(effective_path, gemini_key, query);
         reqwest::Client::new()
             .post(&upstream_url)
             .header("content-type", "application/json")

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -12,6 +12,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 
 use crate::auth::{AuthUser, PaywalledAuthUser};
+use crate::byok;
 use crate::AppState;
 
 const OPENAI_TTS_MODEL_ID: &str = "gpt-4o-mini-tts";
@@ -90,6 +91,7 @@ async fn tts_synthesize(
     headers: HeaderMap,
     Json(request): Json<TtsSynthesizeRequest>,
 ) -> Result<Response, TtsProxyError> {
+    let byok_stripped = user.byok_stripped;
     let user: AuthUser = user.into();
     let text = request.text.trim();
     if text.is_empty() {
@@ -111,7 +113,7 @@ async fn tts_synthesize(
         .map(str::trim)
         .filter(|value| !value.is_empty());
 
-    let (api_key, uses_server_key) = openai_key_for_request(&state, &headers)?;
+    let (api_key, uses_server_key) = openai_key_for_request(&state, &headers, byok_stripped)?;
     if uses_server_key {
         check_server_tts_rate_limit(&state, &user.uid, char_count).await?;
     }
@@ -160,13 +162,9 @@ async fn tts_synthesize(
 fn openai_key_for_request<'a>(
     state: &'a AppState,
     headers: &'a HeaderMap,
+    byok_stripped: bool,
 ) -> Result<(&'a str, bool), TtsProxyError> {
-    if let Some(value) = headers
-        .get("x-byok-openai")
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
+    if let Some(value) = byok::get_byok_key_if_active(headers, byok::HEADER_OPENAI, byok_stripped) {
         return Ok((value, false));
     }
 

--- a/desktop/Backend-Rust/src/services/firestore.rs
+++ b/desktop/Backend-Rust/src/services/firestore.rs
@@ -4696,6 +4696,104 @@ impl FirestoreService {
         Ok(doc)
     }
 
+    // =========================================================================
+    // BYOK & SUBSCRIPTION (used by paywall + BYOK validation)
+    // =========================================================================
+
+    /// Read the BYOK enrollment state from `users/{uid}.byok` in Firestore.
+    ///
+    /// Returns `ByokState::default()` (inactive) on any parse error so a
+    /// Firestore blip never blocks a user.
+    pub async fn get_user_byok_state(
+        &self,
+        uid: &str,
+    ) -> Result<crate::byok::ByokState, Box<dyn std::error::Error + Send + Sync>> {
+        let doc = self.get_user_document(uid).await?;
+        Ok(parse_byok_state_from_doc(&doc))
+    }
+
+    /// Read the effective subscription plan for paywall purposes.
+    ///
+    /// Mirrors Python's `get_user_valid_subscription()`:
+    /// - Basic plan with active status → returns "basic"
+    /// - Paid plan with `current_period_end` still in the future → returns the plan name
+    /// - Paid plan with expired `current_period_end` → falls back to "basic"
+    /// - Missing/unparseable → returns "basic" (fail-open)
+    /// - Handles legacy `"free"` → `"basic"` migration
+    pub async fn get_user_effective_plan(
+        &self,
+        uid: &str,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        let doc = self.get_user_document(uid).await?;
+        let plan = parse_effective_plan_from_doc(&doc);
+
+        // Log interesting fallback cases for paid plans
+        if let Some(fields) = doc.get("fields") {
+            if let Some(sub_fields) = fields
+                .get("subscription")
+                .and_then(|v| v.get("mapValue"))
+                .and_then(|v| v.get("fields"))
+            {
+                let raw_plan = sub_fields
+                    .get("plan")
+                    .and_then(|v| v.get("stringValue"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("basic");
+
+                if raw_plan != "basic" && raw_plan != "free" && plan == "basic" {
+                    tracing::info!(
+                        "paywall: paid plan '{}' fell back to basic for uid={} (expired or missing period_end)",
+                        raw_plan, uid
+                    );
+                }
+            }
+        }
+
+        Ok(plan)
+    }
+
+    /// Get user account creation time from Firebase Auth Identity Toolkit REST API.
+    ///
+    /// Returns creation timestamp in milliseconds, or None if lookup fails.
+    /// Uses the same service-account auth as `delete_firebase_auth_user`.
+    pub async fn get_user_creation_time(
+        &self,
+        project_id: &str,
+        uid: &str,
+    ) -> Result<Option<i64>, Box<dyn std::error::Error + Send + Sync>> {
+        let access_token = self.get_access_token().await?;
+        let url = format!(
+            "https://identitytoolkit.googleapis.com/v1/projects/{}/accounts:lookup",
+            project_id
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(access_token)
+            .json(&serde_json::json!({ "localId": [uid] }))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(format!("Firebase accounts:lookup failed: {}", error_text).into());
+        }
+
+        let body: serde_json::Value = response.json().await?;
+
+        // Response: { "users": [{ "createdAt": "1234567890000", ... }] }
+        let created_at_ms = body
+            .get("users")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|user| user.get("createdAt"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<i64>().ok());
+
+        Ok(created_at_ms)
+    }
+
     /// Update user document fields (partial update)
     async fn update_user_fields(
         &self,
@@ -9754,6 +9852,112 @@ impl Default for Structured {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Pure parsing functions (extracted from FirestoreService for testability)
+// ---------------------------------------------------------------------------
+
+/// Parse BYOK state from a Firestore user document JSON.
+/// Returns `ByokState::default()` (inactive) if the byok field is missing or malformed.
+fn parse_byok_state_from_doc(doc: &Value) -> crate::byok::ByokState {
+    let fields = match doc.get("fields") {
+        Some(f) => f,
+        None => return crate::byok::ByokState::default(),
+    };
+
+    let byok_fields = match fields
+        .get("byok")
+        .and_then(|v| v.get("mapValue"))
+        .and_then(|v| v.get("fields"))
+    {
+        Some(f) => f,
+        None => return crate::byok::ByokState::default(),
+    };
+
+    let active = byok_fields
+        .get("active")
+        .and_then(|v| v.get("booleanValue"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let mut fingerprints = std::collections::HashMap::new();
+    if let Some(fp_fields) = byok_fields
+        .get("fingerprints")
+        .and_then(|v| v.get("mapValue"))
+        .and_then(|v| v.get("fields"))
+        .and_then(|v| v.as_object())
+    {
+        for (provider, val) in fp_fields {
+            if let Some(fp_str) = val.get("stringValue").and_then(|v| v.as_str()) {
+                fingerprints.insert(provider.clone(), fp_str.to_string());
+            }
+        }
+    }
+
+    let last_seen_at = byok_fields
+        .get("last_seen_at")
+        .and_then(|v| v.get("timestampValue"))
+        .and_then(|v| v.as_str())
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc));
+
+    crate::byok::ByokState {
+        active,
+        fingerprints,
+        last_seen_at,
+    }
+}
+
+/// Parse effective subscription plan from a Firestore user document JSON.
+/// Returns "basic" if the subscription field is missing, malformed, or expired.
+fn parse_effective_plan_from_doc(doc: &Value) -> String {
+    let fields = match doc.get("fields") {
+        Some(f) => f,
+        None => return "basic".to_string(),
+    };
+
+    let sub_fields = match fields
+        .get("subscription")
+        .and_then(|v| v.get("mapValue"))
+        .and_then(|v| v.get("fields"))
+    {
+        Some(f) => f,
+        None => return "basic".to_string(),
+    };
+
+    let mut plan = sub_fields
+        .get("plan")
+        .and_then(|v| v.get("stringValue"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("basic")
+        .to_string();
+
+    if plan == "free" {
+        plan = "basic".to_string();
+    }
+
+    if plan == "basic" {
+        return plan;
+    }
+
+    // Paid plan: check current_period_end
+    match sub_fields
+        .get("current_period_end")
+        .and_then(|v| v.get("integerValue"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<i64>().ok())
+    {
+        Some(period_end) => {
+            let now_epoch = chrono::Utc::now().timestamp();
+            if period_end < now_epoch {
+                "basic".to_string()
+            } else {
+                plan
+            }
+        }
+        None => "basic".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -9764,5 +9968,227 @@ mod tests {
         assert_eq!(id.len(), 20);
         assert_eq!(id, document_id_from_seed("test content"));
         assert_ne!(id, document_id_from_seed("different content"));
+    }
+
+    // --- Firestore BYOK state parsing tests ---
+
+    #[test]
+    fn parse_byok_state_full_document() {
+        let doc = json!({
+            "fields": {
+                "byok": {
+                    "mapValue": {
+                        "fields": {
+                            "active": { "booleanValue": true },
+                            "fingerprints": {
+                                "mapValue": {
+                                    "fields": {
+                                        "openai": { "stringValue": "abc123" },
+                                        "anthropic": { "stringValue": "def456" }
+                                    }
+                                }
+                            },
+                            "last_seen_at": {
+                                "timestampValue": "2026-05-18T10:00:00Z"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        let state = parse_byok_state_from_doc(&doc);
+        assert!(state.active);
+        assert_eq!(state.fingerprints.len(), 2);
+        assert_eq!(state.fingerprints.get("openai").unwrap(), "abc123");
+        assert_eq!(state.fingerprints.get("anthropic").unwrap(), "def456");
+        assert!(state.last_seen_at.is_some());
+    }
+
+    #[test]
+    fn parse_byok_state_missing_byok_field() {
+        let doc = json!({ "fields": { "name": { "stringValue": "Alice" } } });
+        let state = parse_byok_state_from_doc(&doc);
+        assert!(!state.active);
+        assert!(state.fingerprints.is_empty());
+        assert!(state.last_seen_at.is_none());
+    }
+
+    #[test]
+    fn parse_byok_state_missing_fields() {
+        let doc = json!({});
+        let state = parse_byok_state_from_doc(&doc);
+        assert!(!state.active);
+    }
+
+    #[test]
+    fn parse_byok_state_active_false() {
+        let doc = json!({
+            "fields": {
+                "byok": {
+                    "mapValue": {
+                        "fields": {
+                            "active": { "booleanValue": false }
+                        }
+                    }
+                }
+            }
+        });
+        let state = parse_byok_state_from_doc(&doc);
+        assert!(!state.active);
+        assert!(state.fingerprints.is_empty());
+    }
+
+    #[test]
+    fn parse_byok_state_no_fingerprints() {
+        let doc = json!({
+            "fields": {
+                "byok": {
+                    "mapValue": {
+                        "fields": {
+                            "active": { "booleanValue": true },
+                            "last_seen_at": { "timestampValue": "2026-05-18T10:00:00Z" }
+                        }
+                    }
+                }
+            }
+        });
+        let state = parse_byok_state_from_doc(&doc);
+        assert!(state.active);
+        assert!(state.fingerprints.is_empty());
+    }
+
+    #[test]
+    fn parse_byok_state_malformed_timestamp() {
+        let doc = json!({
+            "fields": {
+                "byok": {
+                    "mapValue": {
+                        "fields": {
+                            "active": { "booleanValue": true },
+                            "last_seen_at": { "timestampValue": "not-a-date" }
+                        }
+                    }
+                }
+            }
+        });
+        let state = parse_byok_state_from_doc(&doc);
+        assert!(state.active);
+        assert!(state.last_seen_at.is_none());
+    }
+
+    // --- Firestore subscription plan parsing tests ---
+
+    #[test]
+    fn parse_plan_pro_with_future_expiry() {
+        let future_ts = chrono::Utc::now().timestamp() + 86400; // +1 day
+        let doc = json!({
+            "fields": {
+                "subscription": {
+                    "mapValue": {
+                        "fields": {
+                            "plan": { "stringValue": "pro" },
+                            "current_period_end": { "integerValue": future_ts.to_string() }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(parse_effective_plan_from_doc(&doc), "pro");
+    }
+
+    #[test]
+    fn parse_plan_pro_expired() {
+        let past_ts = chrono::Utc::now().timestamp() - 86400; // -1 day
+        let doc = json!({
+            "fields": {
+                "subscription": {
+                    "mapValue": {
+                        "fields": {
+                            "plan": { "stringValue": "pro" },
+                            "current_period_end": { "integerValue": past_ts.to_string() }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(parse_effective_plan_from_doc(&doc), "basic");
+    }
+
+    #[test]
+    fn parse_plan_pro_missing_period_end() {
+        let doc = json!({
+            "fields": {
+                "subscription": {
+                    "mapValue": {
+                        "fields": {
+                            "plan": { "stringValue": "pro" }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(parse_effective_plan_from_doc(&doc), "basic");
+    }
+
+    #[test]
+    fn parse_plan_basic() {
+        let doc = json!({
+            "fields": {
+                "subscription": {
+                    "mapValue": {
+                        "fields": {
+                            "plan": { "stringValue": "basic" }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(parse_effective_plan_from_doc(&doc), "basic");
+    }
+
+    #[test]
+    fn parse_plan_free_migrated_to_basic() {
+        let doc = json!({
+            "fields": {
+                "subscription": {
+                    "mapValue": {
+                        "fields": {
+                            "plan": { "stringValue": "free" }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(parse_effective_plan_from_doc(&doc), "basic");
+    }
+
+    #[test]
+    fn parse_plan_missing_subscription() {
+        let doc = json!({ "fields": {} });
+        assert_eq!(parse_effective_plan_from_doc(&doc), "basic");
+    }
+
+    #[test]
+    fn parse_plan_missing_fields_key() {
+        let doc = json!({});
+        assert_eq!(parse_effective_plan_from_doc(&doc), "basic");
+    }
+
+    #[test]
+    fn parse_plan_enterprise_valid() {
+        let future_ts = chrono::Utc::now().timestamp() + 86400;
+        let doc = json!({
+            "fields": {
+                "subscription": {
+                    "mapValue": {
+                        "fields": {
+                            "plan": { "stringValue": "enterprise" },
+                            "current_period_end": { "integerValue": future_ts.to_string() }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(parse_effective_plan_from_doc(&doc), "enterprise");
     }
 }

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed BYOK keys not being used for Gemini and Anthropic requests \u2014 users who bring their own API keys now bypass server keys and rate limits for all AI features"
+  ],
   "releases": [
     {
       "version": "0.11.409",


### PR DESCRIPTION
## Summary

Relands #7359 (reverted in e6ccdf4e3) — identical code, new PR for proper approval flow.

- **Fill BYOK gaps**: SHA-256 fingerprint validation, heartbeat TTL (7-day) checks, silent header clearing for non-BYOK users, 30s TTL caching of BYOK state — matching the Python backend's full BYOK validation flow
- **Native paywall**: Replaced Python delegation (`GET /v1/users/me/paywall`) with native Rust logic reading subscription plan, BYOK state, and account creation time directly from Firestore/Firebase Auth — removes latency and Python dependency
- **Security fixes**: `byok_stripped` flag prevents non-BYOK users from forging BYOK headers to bypass paywall; expired paid plans correctly fall back to basic; Firestore errors not cached (prevents cache poisoning); `without_url()` on reqwest errors prevents BYOK Gemini API key leaks in logs
- **247 tests** (42 new) covering BYOK validation, Firestore document parsing, paywall logic, and edge cases

## Changes

| File | What |
|------|------|
| `byok.rs` | New module: `ByokState`, `ByokStateCache` (30s TTL), `validate_byok_request()` (SHA-256 fingerprint check), `ByokValidation` enum, `get_byok_key_if_active` helper, `ByokCacheExt`, 23 tests |
| `paywall.rs` | Rewritten: native `PaywallChecker` (plan + BYOK + account age), `byok_stripped` escape hatch guard, `is_trial_expired` pure function, 10 tests |
| `auth.rs` | `PaywalledAuthUser.byok_stripped` field, BYOK validation step in extractor, 403 for fingerprint mismatch |
| `services/firestore.rs` | `get_user_byok_state()`, `get_user_effective_plan()` (with `current_period_end` expiry check), `get_user_creation_time()` (Firebase Identity Toolkit), extracted pure parsing functions, 14 tests |
| `routes/proxy.rs` | Gate BYOK key on `byok_stripped` via `get_byok_key_if_active`; `e.without_url()` to prevent API key leak in error logs |
| `routes/chat_completions.rs` | Gate BYOK key on `byok_stripped` via `get_byok_key_if_active` |
| `routes/tts.rs` | Gate BYOK key on `byok_stripped` via `get_byok_key_if_active` |
| `main.rs` | Wire `ByokStateCache` + updated `PaywallChecker` (no more Python delegation) |
| `config.rs` | Remove `python_api_base` (no longer needed) |

## Security fixes (from review cycle)

1. **Paywall escape hatch bypass**: Non-BYOK users forging all 4 BYOK headers could bypass paywall → Fixed: `byok_stripped` param disables escape hatch for non-BYOK users
2. **Expired paid plans**: Rust only read `plan` without checking `current_period_end` → Fixed: `get_user_effective_plan` validates period end, falls back to "basic"
3. **Cache poisoning**: Firestore errors were cached as inactive state → Fixed: errors return default without caching
4. **BYOK Gemini API key leak**: `reqwest::Error` includes URL (Gemini puts key in `?key=...`) → Fixed: `e.without_url()` in both streaming and non-streaming paths

## Live test evidence (from #7359)

### Build
- Rust backend: `cargo build` (0 errors)
- Swift app: `xcrun swift build -c debug --package-path Desktop` — Build complete (15.30s)
- Named bundle: `/Applications/omi-byok-7357.app` (`com.omi.omi-byok-7357`)
- Backend health: `{"status":"healthy","service":"omi-desktop-backend","version":"0.1.0"}`

### Functional tests (curl + backend logs)

| Test | Request | Expected | Actual | Path IDs |
|------|---------|----------|--------|----------|
| Unauthenticated | POST `/v1/proxy/gemini/...` no auth | 401 | `{"error":"missing_token"}` **401** | P6 |
| Paywall: expired plan | POST with auth, no BYOK | 402 | `{"error":"trial_expired"}` **402** | P5, P6, P13 |
| Paywall: TTS | POST `/v1/tts/synthesize` with auth | 402 | `{"error":"trial_expired"}` **402** | P11 |
| Paywall: chat | POST `/v2/chat/completions` with auth | 402 | `{"error":"trial_expired"}` **402** | P10 |
| BYOK escape blocked | POST with auth + 4 fake BYOK headers | 402 (not bypass) | `{"error":"trial_expired"}` **402** | P4, P8 |
| Plan fallback | Backend log | `unlimited` falls back to `basic` | Log: `paid plan 'unlimited' fell back to basic (expired or missing period_end)` | P13 |

### Backend log evidence

```
request{method=POST uri=/v1/proxy/gemini/...}: paywall: paid plan 'unlimited' fell back to basic for uid=... (expired or missing period_end)
request{method=POST uri=/v1/tts/synthesize}: finished processing request latency=297 ms status=402
request{method=POST uri=/v2/chat/completions}: finished processing request latency=1242 ms status=402
```

### Path coverage summary

| Path ID | Status | Evidence |
|---|---|---|
| P1-P3 | PASS (unit) | 23 byok.rs tests |
| P4 | PASS (live) | Escape hatch blocked when BYOK headers forged |
| P5 | PASS (live + unit) | Trial expired for basic plan user; 10 paywall.rs tests |
| P6 | PASS (live) | PaywalledAuthUser returns 401/402 correctly |
| P7 | PASS (unit) | AuthError maps byok_validation_failed to 403 |
| P8-P9 | PASS (live) | Gemini proxy returns 402 (paywall enforced before proxy) |
| P10 | PASS (live) | Chat completions returns 402 |
| P11 | PASS (live) | TTS returns 402 |
| P12-P13 | PASS (live + unit) | Firestore parsing correct; plan fallback logged; 14 parsing tests |
| P14 | PASS (live) | Backend called Firebase Auth Identity Toolkit (paywall check ran) |

## Test plan

- [x] `cargo test` — 247 tests pass (0 failures)
- [x] L1: Build + run `OMI_APP_NAME="omi-byok-7357" ./run.sh`, standalone curl tests
- [x] L2: Integrated test with app + backend, paywall/BYOK flow verified end-to-end

Closes #7357

🤖 Generated with [Claude Code](https://claude.com/claude-code)