### PR TITLE
fix(backend): unblock 202 fast path from storage_executor saturation

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -157,7 +157,7 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
     - `stripe_executor` (4w) — Stripe API calls
     - `sync_executor` (12w) — sync endpoint pipeline work
     - `postprocess_executor` (8w) — post-conversation processing, coordinator functions
-    - `storage_executor` (16w) — GCS uploads/downloads, audio chunk I/O
+    - `storage_executor` (32w) — GCS uploads/downloads, audio chunk I/O
   - **Deadlock prevention — 4 rules:**
     1. **Worker threads are leaf operations only.** Never `.result()` on another pool from inside a worker thread. If pool A thread submits to pool B and calls `.result()`, and vice versa, both pools deadlock.
     2. **Orchestration stays in async code.** The async handler coordinates via `await run_blocking(pool, fn)` — sequentially or with `asyncio.gather`. The event loop never blocks, pools stay independent.

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1664,7 +1664,9 @@ async def sync_local_files_v2(
 
     try:
         # --- Fast path: save raw files only (< 2s typical) ---
-        paths = await run_blocking(storage_executor, _retrieve_file_paths_v2, files, uid, job_id)
+        # Use sync_executor, NOT storage_executor — storage is saturated with
+        # background pipeline cleanup/GCS work and would queue the 202 response.
+        paths = await run_blocking(sync_executor, _retrieve_file_paths_v2, files, uid, job_id)
 
         # Create Redis job — total_segments=0 until VAD completes in background
         await run_blocking(db_executor, create_sync_job, uid, total_files=len(files), total_segments=0, job_id=job_id)

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -215,6 +215,22 @@ class TestSyncV2Structure:
         assert 'get_user_transcription_preferences' not in func_body, "prefs fetch moved to bg"
         assert 'build_person_embeddings_cache' not in func_body, "cache build moved to bg"
 
+    def test_v2_fast_path_uses_sync_executor(self):
+        """Fast-path file save must use sync_executor, not storage_executor (#7372)."""
+        source = self._read_sync_source()
+        start = source.index('async def sync_local_files_v2')
+        next_section = source.find('\n@router.', start + 1)
+        if next_section == -1:
+            next_section = len(source)
+        func_body = source[start:next_section]
+
+        assert (
+            'run_blocking(sync_executor' in func_body
+        ), "fast-path file save must use sync_executor to avoid storage_executor saturation (#7372)"
+        assert (
+            'run_blocking(storage_executor' not in func_body
+        ), "fast-path must NOT use storage_executor — background pipeline saturates it (#7372)"
+
 
 # ---------------------------------------------------------------------------
 # 2. Redis sync_jobs module tests
@@ -2073,6 +2089,9 @@ class TestBulkheadExecutors:
         assert 'max_workers=12' in source
         assert 'postprocess_executor = MonitoredThreadPoolExecutor(' in source
         assert 'max_workers=8' in source
+        from utils.executors import storage_executor
+
+        assert storage_executor._max_workers == 32, "storage_executor must have 32 workers (#7372)"
 
     def test_all_executors_in_shutdown(self):
         source = self._read_executors_source()

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -61,7 +61,7 @@ llm_executor = MonitoredThreadPoolExecutor(name="llm", max_workers=4, thread_nam
 stripe_executor = MonitoredThreadPoolExecutor(name="stripe", max_workers=4, thread_name_prefix="stripe")
 sync_executor = MonitoredThreadPoolExecutor(name="sync", max_workers=12, thread_name_prefix="sync")
 postprocess_executor = MonitoredThreadPoolExecutor(name="postprocess", max_workers=8, thread_name_prefix="postproc")
-storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=16, thread_name_prefix="storage")
+storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=32, thread_name_prefix="storage")
 
 _ALL_EXECUTORS = [
     critical_executor,


### PR DESCRIPTION
## Summary

Hotfix for 202 fast-path latency regression discovered post-deploy of PR #7362 (executor bulkhead).

**Root cause:** The sync v2 fast path calls `run_blocking(storage_executor, _retrieve_file_paths_v2, ...)` to save uploaded files *before* returning 202. When background pipeline work saturated `storage_executor` (queue depth peaked at 301), this blocked the 202 response — P50 went from 0.1s to 48.3s.

**Fix (2 changes):**
1. **Pool separation** (`routers/sync.py`): Fast-path file save now uses `sync_executor` (12w, idle during file-save phase) instead of `storage_executor`
2. **Pool sizing** (`utils/executors.py`): `storage_executor` bumped 16 → 32 workers to reduce background queue depth

Closes #7361

## Changed paths

| Path ID | Changed path | Description |
|---|---|---|
| P1 | `routers/sync.py:sync_local_files_v2` | Fast-path pool switch: storage→sync executor |
| P2 | `utils/executors.py:storage_executor` | max_workers 16 → 32 |
| P3 | `CLAUDE.md` | Docs: pool size update (non-executable) |
| P4 | `tests/unit/test_sync_v2.py` | New test assertions (test-only) |

## Test evidence

**172 tests pass** (test_sync_v2.py + test_executors.py):
- `test_v2_fast_path_uses_sync_executor` — asserts `run_blocking(sync_executor` in fast path, asserts `storage_executor` NOT used
- `test_executor_worker_counts` — asserts `storage_executor._max_workers == 32`
- All 148 existing sync v2 tests + 24 executor tests pass

**Live test (L1 + L2):**
- `beast omi dev boot-check --full`: import clean + uvicorn health OK
- Runtime pool verification: `storage_executor.max_workers=32`, `sync_executor.max_workers=12`
- Source verification: fast path uses `sync_executor`, not `storage_executor`

**Pre-existing failure:** `test_process_conversation_usage_context.py` fails on main (upstream `find_similar_action_items` import error) — not related to this PR.

## Codex review

PR_APPROVED_LGTM — no blocking issues. Reviewer confirmed pool separation correctly addresses the saturation cascade and thread safety is maintained.

## Risk

- **Low:** Only changes which thread pool runs the file save — no API contract, no behavior change
- **Reviewer note:** sync_executor could theoretically saturate under heavy concurrent VAD/STT work, but background pipeline is capped/chunked. A dedicated fast-path upload executor would be the next hardening step if metrics show sync queueing.

_by AI for @beastoin_