### PR TITLE
fix(backend): tune executor pool sizing from 48h production monitoring

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -152,12 +152,12 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
   - **Long-running pipelines must be async coordinators.** Each blocking step uses `await run_blocking(pool, fn)`, borrowing a thread only for that step. Never hold a thread pool slot across await points or for >60s.
   - **Pool assignment** (match work type to pool):
     - `critical_executor` (8w) — auth gates only: `_verify_ws_auth`, `validate_byok_websocket`, `check_rate_limit`, `is_hard_restricted`, session/code Redis ops in `auth.py`
-    - `db_executor` (16w) — Firestore/Redis CRUD, vector DB queries
-    - `llm_executor` (4w) — LLM API calls (`get_llm().invoke()`, `get_app_result()`, persona generation)
+    - `db_executor` (24w) — Firestore/Redis CRUD, vector DB queries
+    - `llm_executor` (6w) — LLM API calls (`get_llm().invoke()`, `get_app_result()`, persona generation)
     - `stripe_executor` (4w) — Stripe API calls
-    - `sync_executor` (12w) — sync endpoint pipeline work
-    - `postprocess_executor` (8w) — post-conversation processing, coordinator functions
-    - `storage_executor` (32w) — GCS uploads/downloads, audio chunk I/O
+    - `sync_executor` (16w) — sync endpoint pipeline work
+    - `postprocess_executor` (24w) — post-conversation processing, coordinator functions
+    - `storage_executor` (64w) — GCS uploads/downloads, audio chunk I/O
   - **Deadlock prevention — 4 rules:**
     1. **Worker threads are leaf operations only.** Never `.result()` on another pool from inside a worker thread. If pool A thread submits to pool B and calls `.result()`, and vice versa, both pools deadlock.
     2. **Orchestration stays in async code.** The async handler coordinates via `await run_blocking(pool, fn)` — sequentially or with `asyncio.gather`. The event loop never blocks, pools stay independent.

--- a/backend/tests/unit/test_async_http_infrastructure.py
+++ b/backend/tests/unit/test_async_http_infrastructure.py
@@ -386,9 +386,9 @@ class TestExecutorConfiguration:
         """critical_executor documented as 8 workers for latency-sensitive work."""
         assert critical_executor._max_workers == 8
 
-    def test_storage_executor_has_16_workers(self):
-        """storage_executor sized for 16 workers to handle concurrent private cloud uploads."""
-        assert storage_executor._max_workers == 16
+    def test_storage_executor_has_64_workers(self):
+        """storage_executor sized for 64 workers to handle concurrent private cloud uploads (#7376)."""
+        assert storage_executor._max_workers == 64
 
 
 class TestNotificationWebhookWiring:

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -2086,12 +2086,12 @@ class TestBulkheadExecutors:
     def test_executor_worker_counts(self):
         source = self._read_executors_source()
         assert 'sync_executor = MonitoredThreadPoolExecutor(' in source
-        assert 'max_workers=12' in source
+        assert 'max_workers=16' in source
         assert 'postprocess_executor = MonitoredThreadPoolExecutor(' in source
-        assert 'max_workers=8' in source
+        assert 'max_workers=24' in source
         from utils.executors import storage_executor
 
-        assert storage_executor._max_workers == 32, "storage_executor must have 32 workers (#7372)"
+        assert storage_executor._max_workers == 64, "storage_executor must have 64 workers (#7376)"
 
     def test_all_executors_in_shutdown(self):
         source = self._read_executors_source()

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -56,12 +56,12 @@ class MonitoredThreadPoolExecutor(ThreadPoolExecutor):
 
 
 critical_executor = MonitoredThreadPoolExecutor(name="critical", max_workers=8, thread_name_prefix="critical")
-db_executor = MonitoredThreadPoolExecutor(name="db", max_workers=16, thread_name_prefix="db")
-llm_executor = MonitoredThreadPoolExecutor(name="llm", max_workers=4, thread_name_prefix="llm")
+db_executor = MonitoredThreadPoolExecutor(name="db", max_workers=24, thread_name_prefix="db")
+llm_executor = MonitoredThreadPoolExecutor(name="llm", max_workers=6, thread_name_prefix="llm")
 stripe_executor = MonitoredThreadPoolExecutor(name="stripe", max_workers=4, thread_name_prefix="stripe")
-sync_executor = MonitoredThreadPoolExecutor(name="sync", max_workers=12, thread_name_prefix="sync")
-postprocess_executor = MonitoredThreadPoolExecutor(name="postprocess", max_workers=8, thread_name_prefix="postproc")
-storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=32, thread_name_prefix="storage")
+sync_executor = MonitoredThreadPoolExecutor(name="sync", max_workers=16, thread_name_prefix="sync")
+postprocess_executor = MonitoredThreadPoolExecutor(name="postprocess", max_workers=24, thread_name_prefix="postproc")
+storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=64, thread_name_prefix="storage")
 
 _ALL_EXECUTORS = [
     critical_executor,


### PR DESCRIPTION
## Summary

Closes #7376

Tunes executor thread pool sizes based on 48h production monitoring data collected by @mon after the bulkhead architecture deploy (PR #7343).

- **postprocess**: 8 → 24 workers (CRITICAL — queue grew unboundedly to 1,239 tasks in 8h)
- **storage**: 32 → 64 workers (WARNING — re-saturated within 1h of previous bump, queue peaks at 896)
- **db**: 16 → 24 workers (proportional — absorb increased Firestore pressure from bigger postprocess/storage)
- **llm**: 4 → 6 workers (proportional — postprocess expansion will feed more LLM work)
- **sync**: 12 → 16 workers (ELEVATED — 97% util with no headroom)
- **critical**: 8 → 8 (unchanged — auth gates, must stay isolated)
- **stripe**: 4 → 4 (unchanged — deliberate API throttle)

Total threads: 84 → 146 (+74%). All I/O-bound, minimal CPU/memory impact.

## Decision Logic

Sizing based on Codex consultation using Little's Law (`workers >= arrival_rate × avg_service_time`) with 25-50% headroom for Cloud Run burst traffic. Key principle: **proportional scaling with downstream protection** — don't oversize postprocess without matching db/llm capacity, or the bottleneck just shifts downstream.

Deliberate throttles kept on `llm_executor` (API rate limit backpressure) and `stripe_executor` (external API). If postprocess queue still grows at 24, next step is durable background processing (Cloud Tasks), not more threads.

Full decision rationale in #7376.

## Test plan

- [x] `test_executors.py` — 24 tests pass (pool metrics, health logging, monitoring)
- [x] `test_sync_v2.py` — executor worker count assertions updated
- [x] `test_async_http_infrastructure.py` — pool sizing assertions updated
- [ ] Post-deploy: monitor `executor_pool_health` logs for 4h — verify postprocess/storage queues drain
- [ ] Post-deploy: verify Cloud Run instance count decreases (less queue memory pressure)
- [ ] Post-deploy: watch db/llm pool utilization for bottleneck shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)