### PR TITLE
fix(backend): bump storage_executor 64→96 — queue exceeds 300 threshold

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -157,7 +157,7 @@ Never block the event loop — it freezes health checks, HPA scaling, and all co
     - `stripe_executor` (4w) — Stripe API calls
     - `sync_executor` (16w) — sync endpoint pipeline work
     - `postprocess_executor` (24w) — post-conversation processing, coordinator functions
-    - `storage_executor` (64w) — GCS uploads/downloads, audio chunk I/O
+    - `storage_executor` (96w) — GCS uploads/downloads, audio chunk I/O
   - **Deadlock prevention — 4 rules:**
     1. **Worker threads are leaf operations only.** Never `.result()` on another pool from inside a worker thread. If pool A thread submits to pool B and calls `.result()`, and vice versa, both pools deadlock.
     2. **Orchestration stays in async code.** The async handler coordinates via `await run_blocking(pool, fn)` — sequentially or with `asyncio.gather`. The event loop never blocks, pools stay independent.

--- a/backend/tests/unit/test_async_http_infrastructure.py
+++ b/backend/tests/unit/test_async_http_infrastructure.py
@@ -386,9 +386,9 @@ class TestExecutorConfiguration:
         """critical_executor documented as 8 workers for latency-sensitive work."""
         assert critical_executor._max_workers == 8
 
-    def test_storage_executor_has_64_workers(self):
-        """storage_executor sized for 64 workers to handle concurrent private cloud uploads (#7376)."""
-        assert storage_executor._max_workers == 64
+    def test_storage_executor_has_96_workers(self):
+        """storage_executor sized for 96 workers to handle concurrent private cloud uploads (#7376)."""
+        assert storage_executor._max_workers == 96
 
 
 class TestNotificationWebhookWiring:

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -2091,7 +2091,7 @@ class TestBulkheadExecutors:
         assert 'max_workers=24' in source
         from utils.executors import storage_executor
 
-        assert storage_executor._max_workers == 64, "storage_executor must have 64 workers (#7376)"
+        assert storage_executor._max_workers == 96, "storage_executor must have 96 workers (#7376)"
 
     def test_all_executors_in_shutdown(self):
         source = self._read_executors_source()

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -61,7 +61,7 @@ llm_executor = MonitoredThreadPoolExecutor(name="llm", max_workers=6, thread_nam
 stripe_executor = MonitoredThreadPoolExecutor(name="stripe", max_workers=4, thread_name_prefix="stripe")
 sync_executor = MonitoredThreadPoolExecutor(name="sync", max_workers=16, thread_name_prefix="sync")
 postprocess_executor = MonitoredThreadPoolExecutor(name="postprocess", max_workers=24, thread_name_prefix="postproc")
-storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=64, thread_name_prefix="storage")
+storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=96, thread_name_prefix="storage")
 
 _ALL_EXECUTORS = [
     critical_executor,


### PR DESCRIPTION
## Summary

Follow-up to #7378. Bumps `storage_executor` from 64 → 96 workers.

**Evidence from T+2h post-deploy monitoring (mon):**
- backend storage max queue: 336 (threshold 300)
- backend-sync storage max queue: 608
- 100% utilization sustained at 64 workers — zero headroom
- 202 p99 latency at 4.7s, approaching 5s threshold
- 3x 504s appeared
- Avg queue ~30 (steady-state handles fine) but spikes 300-600+ during bursts

64 workers handles steady-state but cannot absorb traffic spikes. 96 provides ~50% headroom over observed peaks. Codex consultation from #7376 identified 64-96 as the practical ceiling for storage (I/O-bound GCS work).

All other pools from #7378 are confirmed resolved:
- postprocess (24w): 75% util, zero queue
- sync (16w): resolved, queue 4
- llm (6w): zero queue
- db (24w): zero Firestore contention

Closes #7376.

## Test plan

- [x] `test_executors.py` — 24 pass
- [x] `test_async_http_infrastructure.py` — executor tests pass (assertion updated 64→96)
- [x] `test_sync_v2.py` — executor worker count assertion updated
- [ ] Post-deploy: verify storage queue stays <100 during peak hours (17:00-21:00 UTC)
- [ ] Post-deploy: verify 202 p99 latency <2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)