### PR TITLE
chore(plugins/omi-linear+omi-hive): remediate Dependabot vulns (#7327)

### DIFF
--- a/plugins/omi-hive-app/requirements.txt
+++ b/plugins/omi-hive-app/requirements.txt
@@ -1,11 +1,11 @@
 fastapi==0.111.1
 uvicorn==0.30.3
-python-dotenv==1.0.1
-requests==2.31.0
+python-dotenv==1.2.2
+requests==2.34.2
 pydantic==2.8.2
-Jinja2==3.1.4
-python-multipart==0.0.9
-aiohttp==3.9.5
+Jinja2==3.1.6
+python-multipart==0.0.29
+aiohttp==3.13.5
 redis==5.0.1
 
 

--- a/plugins/omi-linear-app/requirements.txt
+++ b/plugins/omi-linear-app/requirements.txt
@@ -1,10 +1,10 @@
 fastapi==0.111.1
 uvicorn==0.30.3
-python-dotenv==1.0.1
-requests==2.31.0
+python-dotenv==1.2.2
+requests==2.34.2
 pydantic==2.8.2
-Jinja2==3.1.4
-python-multipart==0.0.9
-aiohttp==3.9.5
+Jinja2==3.1.6
+python-multipart==0.0.29
+aiohttp==3.13.5
 redis==5.0.1
 


### PR DESCRIPTION
Part of #7327. Per-plugin `requirements.txt` remediation — group 1 of the plugin batch.

These two plugin services have **byte-identical** dependency sets, so they're remediated together (one commit per file).

## Minimal bumps (only the Dependabot-flagged pins)
| package | from | to | why |
|---|---|---|---|
| python-dotenv | 1.0.1 | 1.2.2 | flagged |
| requests | 2.31.0 | 2.34.2 | CVE-2024-35195 / CVE-2024-47081 (netrc leak) |
| Jinja2 | 3.1.4 | 3.1.6 | CVE-2024-56326 / CVE-2025-27516 |
| python-multipart | 0.0.9 | 0.0.29 | CVE-2024-53981 (DoS) |
| aiohttp | 3.9.5 | 3.13.5 | 20 alerts (multiple CVEs) |

Patched versions match those already merged & review-passed in #7385 (`plugins/requirements.txt`), for consistency.

**Unflagged pins kept at exact original** (`fastapi==0.111.1`, `uvicorn==0.30.3`, `pydantic==2.8.2`, `redis==5.0.1`) — minimal-bump policy, no unrelated sweep.

## Validation
- Dependency set resolves cleanly (`pip install --dry-run`).
- `pip-audit` of the bumped pins → **clean**.

## Documented residual (pre-existing, transitive, NOT introduced by this PR)
`pip-audit` reports `starlette 0.37.2` (CVE-2024-47874, CVE-2025-54121), pulled transitively by the **unchanged** `fastapi==0.111.1`. It is **not a Dependabot alert on these manifests** (requirements.txt doesn't pin starlette) and is not regressed by this change. Clearing it requires bumping `fastapi` (out of the flagged set). Optional follow-up if the manager wants it in scope: `fastapi==0.111.1 → >=0.115` pulls patched starlette ≥0.41.

## Alerts cleared
~62 (31 omi-linear-app + 31 omi-hive-app).
