### PR TITLE
chore(plugins/shipbob+notion+gcal): remediate Dependabot vulns (#7327)

### DIFF
--- a/plugins/omi-google-calendar-app/requirements.txt
+++ b/plugins/omi-google-calendar-app/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.111.1
 uvicorn==0.30.3
-python-dotenv==1.0.1
-requests==2.31.0
+python-dotenv==1.2.2
+requests==2.34.2
 pydantic==2.8.2
-Jinja2==3.1.4
-python-multipart==0.0.9
+Jinja2==3.1.6
+python-multipart==0.0.29
 redis==5.0.1

--- a/plugins/omi-notion-app/requirements.txt
+++ b/plugins/omi-notion-app/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.111.1
 uvicorn==0.30.3
-python-dotenv==1.0.1
-requests==2.31.0
+python-dotenv==1.2.2
+requests==2.34.2
 pydantic==2.8.2
-Jinja2==3.1.4
-python-multipart==0.0.9
+Jinja2==3.1.6
+python-multipart==0.0.29
 redis==5.0.1

--- a/plugins/omi-shipbob-app/requirements.txt
+++ b/plugins/omi-shipbob-app/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.111.1
 uvicorn==0.30.3
-python-dotenv==1.0.1
-requests==2.31.0
+python-dotenv==1.2.2
+requests==2.34.2
 pydantic==2.8.2
-Jinja2==3.1.4
-python-multipart==0.0.9
+Jinja2==3.1.6
+python-multipart==0.0.29
 redis==5.0.1


### PR DESCRIPTION
Part of #7327. Per-plugin `requirements.txt` remediation — group 2 of the plugin batch.

These three plugin services have **byte-identical** dependency files (md5 `e505cef78ad7`), remediated together (one commit per file).

## Minimal bumps (only the Dependabot-flagged pins)
| package | from | to | why |
|---|---|---|---|
| python-dotenv | 1.0.1 | 1.2.2 | flagged |
| requests | 2.31.0 | 2.34.2 | CVE-2024-35195 / CVE-2024-47081 |
| Jinja2 | 3.1.4 | 3.1.6 | CVE-2024-56326 / CVE-2025-27516 |
| python-multipart | 0.0.9 | 0.0.29 | CVE-2024-53981 (DoS) |

Versions match those merged & review-passed in #7385, for consistency.

**Unflagged pins kept at exact original** (`fastapi==0.111.1`, `uvicorn==0.30.3`, `pydantic==2.8.2`, `redis==5.0.1`).

## Validation
- Resolves cleanly (`pip install --dry-run`); `pip-audit` of bumped pins → clean.

## Documented residual (pre-existing, transitive, NOT introduced here)
`starlette 0.37.2` (CVE-2024-47874, CVE-2025-54121) is pulled transitively by the **unchanged** `fastapi==0.111.1`; not a Dependabot alert on these manifests (starlette isn't pinned), not regressed by this PR. Optional follow-up: `fastapi>=0.115` pulls patched starlette.

## Alerts cleared
~33 (11 shipbob + 11 notion + 11 google-calendar).
