### PR TITLE
chore(plugins/composio): remediate Dependabot vulns (#7327)

### DIFF
--- a/plugins/composio/requirements.txt
+++ b/plugins/composio/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.104.1
 uvicorn==0.24.0
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 httpx==0.24.1
-jinja2==3.1.2
-python-multipart==0.0.6
+jinja2==3.1.6
+python-multipart==0.0.29
 pydantic==2.4.2
-requests==2.31.0 
+requests==2.34.2


### PR DESCRIPTION
Part of #7327. Per-plugin `requirements.txt` remediation — group 3 (composio).

## Minimal bumps (only the Dependabot-flagged pins — 14 alerts)
| package | from | to | why |
|---|---|---|---|
| python-dotenv | 1.0.0 | 1.2.2 | flagged |
| jinja2 | 3.1.2 | 3.1.6 | CVE-2024-34064 / 56326 / CVE-2025-27516 |
| python-multipart | 0.0.6 | 0.0.29 | CVE-2024-53981 + the ReDoS behind PYSEC-2024-38 |
| requests | 2.31.0 | 2.34.2 | CVE-2024-35195 / CVE-2024-47081 |

**Unflagged pins kept at exact original** (`fastapi==0.104.1`, `uvicorn==0.24.0`, `httpx==0.24.1`, `pydantic==2.4.2`) — minimal-bump policy.

## Validation
- Resolves cleanly; the 4 flagged pins audit clean.

## Documented residuals (pre-existing, transitive, NOT Dependabot alerts here, NOT regressed)
- `fastapi 0.104.1` → pip-audit version-flags **PYSEC-2024-38**, but that advisory's actual root cause is the **python-multipart ReDoS**, which **is fixed** by the `python-multipart 0.0.6→0.0.29` bump above. The residual is a version-string match only.
- `starlette 0.27.0` (CVE-2024-47874 / CVE-2025-54121) and `h11 0.14.0` (CVE-2025-43859) — pulled transitively by the unchanged `fastapi==0.104.1` / `httpx==0.24.1`; not pinned in the manifest, not Dependabot-flagged here. Optional follow-up if wanted in scope: `fastapi>=0.109.1` + `httpx>=0.27` clears them.

## Alerts cleared
~14 (composio).
