### PR TITLE
chore(plugins/twitter+slack+github+clickup): remediate Dependabot vulns (#7327)

### DIFF
--- a/plugins/omi-clickup-app/requirements.txt
+++ b/plugins/omi-clickup-app/requirements.txt
@@ -1,9 +1,9 @@
 fastapi==0.104.1
 uvicorn==0.24.0
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 pydantic==2.5.0
 httpx==0.25.2
 openai==1.3.7
-requests==2.31.0
+requests==2.34.2
 pytz==2023.3
 

--- a/plugins/omi-github-app/requirements.txt
+++ b/plugins/omi-github-app/requirements.txt
@@ -1,9 +1,9 @@
 fastapi==0.104.1
 uvicorn==0.24.0
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 pydantic==2.5.0
 httpx==0.25.2
 openai==1.3.7
-requests==2.31.0
+requests==2.34.2
 anthropic==0.39.0
 

--- a/plugins/omi-slack-app/requirements.txt
+++ b/plugins/omi-slack-app/requirements.txt
@@ -1,9 +1,9 @@
 fastapi==0.104.1
 uvicorn==0.24.0
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 pydantic==2.5.0
 httpx==0.25.2
 openai==1.3.7
-requests==2.31.0
+requests==2.34.2
 slack-sdk==3.27.1
 

--- a/plugins/omi-twitter-app/requirements.txt
+++ b/plugins/omi-twitter-app/requirements.txt
@@ -1,12 +1,12 @@
 fastapi==0.104.1
 uvicorn==0.24.0
 tweepy==4.14.0
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 pydantic==2.5.0
 sqlalchemy==2.0.23
 aiosqlite==0.19.0
 greenlet==3.0.3
 httpx==0.25.2
 openai==1.3.7
-requests==2.31.0
+requests==2.34.2
 


### PR DESCRIPTION
Part of #7327. Per-plugin `requirements.txt` remediation — group 4.

Four near-identical openai-cluster plugin services. Only **`python-dotenv` + `requests`** are Dependabot-flagged in these manifests (no Jinja2 / python-multipart present), so the bump set is intentionally tiny.

## Minimal bumps (only the Dependabot-flagged pins — 16 alerts, 4 each)
| package | from | to |
|---|---|---|
| python-dotenv | 1.0.0 | 1.2.2 |
| requests | 2.31.0 | 2.34.2 |

**Every other pin kept at exact original** (`fastapi`, `uvicorn`, `pydantic`, `httpx`, `openai`, plus per-app `tweepy`/`sqlalchemy`/`aiosqlite`/`greenlet`/`slack-sdk`/`anthropic`/`pytz`) — strict minimal-bump policy, zero unrelated sweep.

## Validation
- All four resolve cleanly; the 2 flagged pins audit clean.

## Documented residuals (pre-existing, transitive, NOT Dependabot alerts here, NOT regressed)
`fastapi 0.104.1` (PYSEC-2024-38, version-string) and `starlette 0.27.0` (CVE-2024-47874 / CVE-2025-54121, transitive via fastapi) — not pinned/flagged in these manifests; out of the flagged set. Optional follow-up: `fastapi>=0.109.1`.

## Alerts cleared
~16 (4× omi-twitter-app + omi-slack-app + omi-github-app + omi-clickup-app).
