### PR TITLE
chore(plugins/whoop+twitter-chat-tools): remediate Dependabot vulns (#7327)

### DIFF
--- a/plugins/omi-twitter-chat-tools-app/requirements.txt
+++ b/plugins/omi-twitter-chat-tools-app/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.104.1
 uvicorn==0.24.0
-python-dotenv==1.0.0
-requests==2.31.0
+python-dotenv==1.2.2
+requests==2.34.2
 pydantic==2.5.2
 redis==5.0.1

--- a/plugins/omi-whoop-app/requirements.txt
+++ b/plugins/omi-whoop-app/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.104.1
 uvicorn==0.24.0
-python-dotenv==1.0.0
-requests==2.31.0
+python-dotenv==1.2.2
+requests==2.34.2
 pydantic==2.5.2
 redis==5.0.1


### PR DESCRIPTION
Part of #7327. Per-plugin `requirements.txt` remediation — group 5.

Two **byte-identical** plugin services (md5 `b8ffeedf047e`). Only `python-dotenv` + `requests` are Dependabot-flagged.

## Minimal bumps (16 → see below; 8 alerts total, 4 each)
| package | from | to |
|---|---|---|
| python-dotenv | 1.0.0 | 1.2.2 |
| requests | 2.31.0 | 2.34.2 |

**Unflagged pins kept at exact original** (`fastapi==0.104.1`, `uvicorn==0.24.0`, `pydantic==2.5.2`, `redis==5.0.1`).

## Validation
- Resolves cleanly; flagged pins audit clean.

## Documented residual (pre-existing, transitive, NOT flagged here)
`fastapi 0.104.1` / `starlette 0.27.0` transitive CVEs — not pinned/flagged in these manifests. Optional follow-up: `fastapi>=0.109.1`.

## Alerts cleared
~8 (omi-whoop-app + omi-twitter-chat-tools-app).
