### PR TITLE
chore(plugins/hume-ai+manual-import): remediate Dependabot vulns (#7327)

### DIFF
--- a/plugins/hume-ai/requirements.txt
+++ b/plugins/hume-ai/requirements.txt
@@ -2,9 +2,9 @@
 fastapi==0.115.0
 uvicorn[standard]==0.32.0
 hume==0.13.1
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 httpx==0.27.0
-jinja2==3.1.4
+jinja2==3.1.6
 
 # Audio processing
 pydub==0.25.1

--- a/plugins/import/manual-import/requirements.txt
+++ b/plugins/import/manual-import/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.1
-requests==2.26.0
+Flask==3.1.3
+requests==2.34.2
 openai==1.3.0
 httpx>=0.23.0,<0.25.0 


### PR DESCRIPTION
Part of #7327. Per-plugin `requirements.txt` remediation — group 6 (final group of the plugin batch).

Two unrelated small leftover manifests, batched to cut review overhead.

## plugins/hume-ai — minimal bumps (4 alerts)
| package | from | to |
|---|---|---|
| python-dotenv | 1.0.0 | 1.2.2 |
| jinja2 | 3.1.4 | 3.1.6 |

Unflagged pins kept at exact original (`fastapi==0.115.0`, `uvicorn[standard]==0.32.0`, `hume==0.13.1`, `httpx==0.27.0`, `pydub==0.25.1`).
Residual (pre-existing, transitive, not flagged): `starlette 0.38.6` via unchanged `fastapi==0.115.0`.

## plugins/import/manual-import — Dependabot-flagged bumps (6 alerts)
| package | from | to | note |
|---|---|---|---|
| requests | 2.26.0 | 2.34.2 | CVE-2024-35195 / CVE-2024-47081 |
| **Flask** | **2.0.1** | **3.1.3** | **major 2→3** — required to clear the **high-severity** Flask alert (its first-patched version is 3.1.3; the only-`<3` option, 2.2.5, clears just the low-sev one) |

> ⚠️ **Flask 2→3 is a major bump.** `manual-import` is a non-prod, one-off import utility (not a deployed service) with no automated test harness, so this is a deliberate Tier-3 judgment to clear the high-sev alert. Flask 3 resolves cleanly (pulls Werkzeug 3.1.8); a simple script-style Flask app is very unlikely to hit Flask-3 breakings. **Fallback if you'd rather avoid the major:** pin `Flask==2.2.5` instead — clears only the low-sev alert and leaves one high-sev residual. Defaulted to 3.1.3 (clears both); say the word to switch.

Unflagged pins kept at exact original (`openai==1.3.0`, `httpx>=0.23.0,<0.25.0`).
Residual (pre-existing, transitive, not flagged): `h11 0.14.0` via the unchanged httpx range.

## Validation
- Both resolve cleanly; flagged pins audit clean.

## Alerts cleared
~10 (4 hume-ai + 6 manual-import).
