### PR TITLE
fix: import deleteDailySummary in daily summary detail page

### DIFF
--- a/app/lib/pages/settings/daily_summary_detail_page.dart
+++ b/app/lib/pages/settings/daily_summary_detail_page.dart
@@ -8,7 +8,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:omi/backend/http/api/conversations.dart' as conversations_api;
-import 'package:omi/backend/http/api/users.dart' show getDailySummary, setDailySummaryVisibility;
+import 'package:omi/backend/http/api/users.dart' show deleteDailySummary, getDailySummary, setDailySummaryVisibility;
 import 'package:omi/backend/schema/daily_summary.dart';
 import 'package:omi/pages/conversation_detail/maps_util.dart';
 import 'package:omi/pages/conversation_detail/page.dart';


### PR DESCRIPTION
## Summary
- `_deleteRecap` in `daily_summary_detail_page.dart` called `deleteDailySummary()` but the function wasn't in the `show` clause of the `users.dart` import, breaking the build.
- Added `deleteDailySummary` to the import.

## Test plan
- [ ] `flutter analyze` passes
- [ ] Open a daily summary, tap the 3-dot menu → Delete → confirm; recap is deleted and page pops back with `{deleted: true, summaryId}`