### PR TITLE
fix(notifications): show actual battery level in low-battery alert

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2164,7 +2164,7 @@
     "selected": "محدد",
     "selectOption": "اختر",
     "lowBatteryAlertTitle": "تنبيه انخفاض البطارية",
-    "lowBatteryAlertBody": "بطارية جهازك منخفضة. حان وقت إعادة الشحن! 🔋",
+    "lowBatteryAlertBody": "بطاريتك عند {level}٪. حان وقت إعادة الشحن! 🔋",
     "batteryFullyChargedTitle": "أومي مشحون بالكامل",
     "batteryFullyChargedBody": "جهاز Omi الخاص بك مشحون بالكامل. يمكنك فصله الآن!",
     "deviceDisconnectedNotificationTitle": "تم قطع اتصال جهاز Omi",
@@ -3024,5 +3024,13 @@
     "syncStatusOnDevice": "في انتظار Omi",
     "syncStatusDownloadingFromDevice": "جارٍ التنزيل من Omi",
     "newestFirst": "الأحدث أولاً",
-    "noSyncedRecordingsYet": "لا توجد تسجيلات متزامنة بعد"
+    "noSyncedRecordingsYet": "لا توجد تسجيلات متزامنة بعد",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "Ваша прыстасаванне буквальна вычарпвае батарэю. Час пазарадзіць! 🔋",
+    "lowBatteryAlertBody": "Ваша батарэя на {level}%. Час пазарадзіць! 🔋",
     "batteryFullyChargedTitle": "Omi поўнасцю зараджаны",
     "batteryFullyChargedBody": "Ваш прылада Omi поўнасцю зараджана. Можаце адключыць!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "Ваша прыстасаванне Omi адключылося",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2166,7 +2166,7 @@
     "selected": "Избрано",
     "selectOption": "Избери",
     "lowBatteryAlertTitle": "Предупреждение за изтощена батерия",
-    "lowBatteryAlertBody": "Батерията на устройството ви е изтощена. Време е за презареждане! 🔋",
+    "lowBatteryAlertBody": "Батерията ви е на {level}%. Време е за презареждане! 🔋",
     "batteryFullyChargedTitle": "Omi е напълно зареден",
     "batteryFullyChargedBody": "Вашето устройство Omi е напълно заредено. Можете да го изключите!",
     "deviceDisconnectedNotificationTitle": "Вашето Omi устройство е изключено",
@@ -3026,5 +3026,13 @@
     "syncStatusOnDevice": "Изчаква Omi",
     "syncStatusDownloadingFromDevice": "Изтегляне от Omi",
     "newestFirst": "Първо най-новите",
-    "noSyncedRecordingsYet": "Все още няма синхронизирани записи"
+    "noSyncedRecordingsYet": "Все още няма синхронизирани записи",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "আপনার ডিভাইসের ব্যাটারি কম হয়ে যাচ্ছে। চার্জ করার সময় এসেছে! 🔋",
+    "lowBatteryAlertBody": "আপনার ব্যাটারি {level}% এ আছে। চার্জ করার সময় এসেছে! 🔋",
     "batteryFullyChargedTitle": "Omi সম্পূর্ণ চার্জ হয়েছে",
     "batteryFullyChargedBody": "আপনার Omi ডিভাইস সম্পূর্ণ চার্জ হয়েছে। আনপ্লাগ করতে পারেন!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "আপনার Omi ডিভাইস সংযোগ বিচ্ছিন্ন হয়েছে",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "Vaš uređaj ima nisku bateriju. Vrijeme je za ponovno punjena! 🔋",
+    "lowBatteryAlertBody": "Vaša baterija je na {level}%. Vrijeme je za punjenje! 🔋",
     "batteryFullyChargedTitle": "Omi je potpuno napunjen",
     "batteryFullyChargedBody": "Vaš Omi uređaj je potpuno napunjen. Možete ga iskopčati!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "Vaš Omi uređaj se odvojio",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2166,7 +2166,7 @@
     "selected": "Seleccionat",
     "selectOption": "Seleccionar",
     "lowBatteryAlertTitle": "Alerta de bateria baixa",
-    "lowBatteryAlertBody": "La bateria del teu dispositiu és baixa. És hora de carregar! 🔋",
+    "lowBatteryAlertBody": "La teva bateria és al {level}%. És hora de carregar! 🔋",
     "batteryFullyChargedTitle": "L'Omi està completament carregat",
     "batteryFullyChargedBody": "El teu dispositiu Omi està completament carregat. Pots desconnectar-lo!",
     "deviceDisconnectedNotificationTitle": "El teu dispositiu Omi s'ha desconnectat",
@@ -3026,5 +3026,13 @@
     "syncStatusOnDevice": "Esperant a Omi",
     "syncStatusDownloadingFromDevice": "Baixant des d'Omi",
     "newestFirst": "Més recents primer",
-    "noSyncedRecordingsYet": "Encara no hi ha enregistraments sincronitzats"
+    "noSyncedRecordingsYet": "Encara no hi ha enregistraments sincronitzats",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2143,7 +2143,7 @@
     "selected": "Vybráno",
     "selectOption": "Vybrat",
     "lowBatteryAlertTitle": "Upozornění na vybitou baterii",
-    "lowBatteryAlertBody": "Baterie vašeho zařízení je vybitá. Je čas ji dobít! 🔋",
+    "lowBatteryAlertBody": "Vaše baterie je na {level}%. Je čas ji dobít! 🔋",
     "batteryFullyChargedTitle": "Omi je plně nabitý",
     "batteryFullyChargedBody": "Vaše zařízení Omi je plně nabité. Můžete jej odpojit!",
     "deviceDisconnectedNotificationTitle": "Vaše zařízení Omi bylo odpojeno",
@@ -3026,5 +3026,13 @@
     "syncStatusOnDevice": "Čeká na Omi",
     "syncStatusDownloadingFromDevice": "Stahování z Omi",
     "newestFirst": "Nejnovější první",
-    "noSyncedRecordingsYet": "Zatím žádné synchronizované nahrávky"
+    "noSyncedRecordingsYet": "Zatím žádné synchronizované nahrávky",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2141,7 +2141,7 @@
     "selected": "Valgt",
     "selectOption": "Vælg",
     "lowBatteryAlertTitle": "Advarsel om lavt batteri",
-    "lowBatteryAlertBody": "Din enheds batteri er lavt. Det er tid til at genoplade! 🔋",
+    "lowBatteryAlertBody": "Dit batteri er på {level}%. Tid til at lade op! 🔋",
     "batteryFullyChargedTitle": "Omi er fuldt opladet",
     "batteryFullyChargedBody": "Din Omi-enhed er fuldt opladet. Du kan frakoble den nu!",
     "deviceDisconnectedNotificationTitle": "Din Omi-enhed er afbrudt",
@@ -3066,5 +3066,13 @@
     "syncStatusOnDevice": "Venter på Omi",
     "syncStatusDownloadingFromDevice": "Downloader fra Omi",
     "newestFirst": "Nyeste først",
-    "noSyncedRecordingsYet": "Ingen synkroniserede optagelser endnu"
+    "noSyncedRecordingsYet": "Ingen synkroniserede optagelser endnu",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2165,7 +2165,7 @@
     "selected": "Ausgewählt",
     "selectOption": "Auswählen",
     "lowBatteryAlertTitle": "Warnung: Niedriger Akkustand",
-    "lowBatteryAlertBody": "Der Akkustand Ihres Geräts ist niedrig. Zeit zum Aufladen! 🔋",
+    "lowBatteryAlertBody": "Dein Akku ist bei {level}%. Zeit zum Aufladen! 🔋",
     "batteryFullyChargedTitle": "Omi ist vollständig geladen",
     "batteryFullyChargedBody": "Dein Omi-Gerät ist vollständig geladen. Du kannst es jetzt ausstecken!",
     "deviceDisconnectedNotificationTitle": "Ihr Omi-Gerät wurde getrennt",
@@ -3025,5 +3025,13 @@
     "syncStatusOnDevice": "Wartet auf Omi",
     "syncStatusDownloadingFromDevice": "Wird von Omi heruntergeladen",
     "newestFirst": "Neueste zuerst",
-    "noSyncedRecordingsYet": "Noch keine synchronisierten Aufnahmen"
+    "noSyncedRecordingsYet": "Noch keine synchronisierten Aufnahmen",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2183,7 +2183,7 @@
     "selected": "Επιλεγμένο",
     "selectOption": "Επιλογή",
     "lowBatteryAlertTitle": "Ειδοποίηση χαμηλής μπαταρίας",
-    "lowBatteryAlertBody": "Η μπαταρία της συσκευής σας είναι χαμηλή. Ώρα για επαναφόρτιση! 🔋",
+    "lowBatteryAlertBody": "Η μπαταρία σας είναι στο {level}%. Ώρα για φόρτιση! 🔋",
     "batteryFullyChargedTitle": "Το Omi έχει φορτιστεί πλήρως",
     "batteryFullyChargedBody": "Η συσκευή Omi σου είναι πλήρως φορτισμένη. Μπορείς να την αποσυνδέσεις!",
     "deviceDisconnectedNotificationTitle": "Η συσκευή Omi σας αποσυνδέθηκε",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Σε αναμονή στο Omi",
     "syncStatusDownloadingFromDevice": "Λήψη από το Omi",
     "newestFirst": "Νεότερες πρώτα",
-    "noSyncedRecordingsYet": "Δεν υπάρχουν ακόμα συγχρονισμένες εγγραφές"
+    "noSyncedRecordingsYet": "Δεν υπάρχουν ακόμα συγχρονισμένες εγγραφές",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -8401,11 +8401,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "Your device is running low on battery. Time for a recharge! 🔋",
+    "lowBatteryAlertBody": "Your battery is at {level}%. Time for a recharge! 🔋",
     "batteryFullyChargedTitle": "Omi is fully charged",
     "batteryFullyChargedBody": "Your Omi device is fully charged. Feel free to unplug!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "Your Omi Device Disconnected",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2184,7 +2184,7 @@
     "selected": "Seleccionado",
     "selectOption": "Seleccionar",
     "lowBatteryAlertTitle": "Alerta de batería baja",
-    "lowBatteryAlertBody": "La batería de tu dispositivo está baja. ¡Es hora de recargar! 🔋",
+    "lowBatteryAlertBody": "Tu batería está al {level}%. ¡Es hora de recargar! 🔋",
     "batteryFullyChargedTitle": "Omi está completamente cargado",
     "batteryFullyChargedBody": "Tu dispositivo Omi está completamente cargado. ¡Puedes desenchufarlo!",
     "deviceDisconnectedNotificationTitle": "Tu dispositivo Omi se desconectó",
@@ -3058,5 +3058,13 @@
     "syncStatusOnDevice": "Esperando en Omi",
     "syncStatusDownloadingFromDevice": "Descargando de Omi",
     "newestFirst": "Más recientes primero",
-    "noSyncedRecordingsYet": "Aún no hay grabaciones sincronizadas"
+    "noSyncedRecordingsYet": "Aún no hay grabaciones sincronizadas",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2183,7 +2183,7 @@
     "selected": "Valitud",
     "selectOption": "Vali",
     "lowBatteryAlertTitle": "Tühja aku hoiatus",
-    "lowBatteryAlertBody": "Teie seadme aku on tühi. Aeg laadida! 🔋",
+    "lowBatteryAlertBody": "Sinu aku on {level}%. Aeg laadida! 🔋",
     "batteryFullyChargedTitle": "Omi on täielikult laetud",
     "batteryFullyChargedBody": "Teie Omi seade on täielikult laetud. Võite selle lahti ühendada!",
     "deviceDisconnectedNotificationTitle": "Teie Omi seade on lahti ühendatud",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Ootab Omis",
     "syncStatusDownloadingFromDevice": "Allalaadimine Omist",
     "newestFirst": "Uusimad esmalt",
-    "noSyncedRecordingsYet": "Sünkroonitud salvestisi pole veel"
+    "noSyncedRecordingsYet": "Sünkroonitud salvestisi pole veel",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "باتری دستگاه شما تقریباً تمام است. وقت شارژ کردن است! 🔋",
+    "lowBatteryAlertBody": "باتری شما {level}٪ است. وقت شارژ کردن است! 🔋",
     "batteryFullyChargedTitle": "Omi کاملاً شارژ شد",
     "batteryFullyChargedBody": "دستگاه Omi شما کاملاً شارژ شده است. می‌توانید آن را جدا کنید!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "دستگاه Omi شما قطع شد",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2183,7 +2183,7 @@
     "selected": "Valittu",
     "selectOption": "Valitse",
     "lowBatteryAlertTitle": "Alhaisen akun varoitus",
-    "lowBatteryAlertBody": "Laitteesi akku on alhainen. Aika ladata! 🔋",
+    "lowBatteryAlertBody": "Akkusi on {level}%. Aika ladata! 🔋",
     "batteryFullyChargedTitle": "Omi on ladattu täyteen",
     "batteryFullyChargedBody": "Omi-laitteesi on ladattu täyteen. Voit irrottaa sen nyt!",
     "deviceDisconnectedNotificationTitle": "Omi-laitteesi yhteys katkesi",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Odottaa Omissa",
     "syncStatusDownloadingFromDevice": "Ladataan Omista",
     "newestFirst": "Uusimmat ensin",
-    "noSyncedRecordingsYet": "Ei vielä synkronoituja nauhoituksia"
+    "noSyncedRecordingsYet": "Ei vielä synkronoituja nauhoituksia",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2183,7 +2183,7 @@
     "selected": "Sélectionné",
     "selectOption": "Sélectionner",
     "lowBatteryAlertTitle": "Alerte de batterie faible",
-    "lowBatteryAlertBody": "La batterie de votre appareil est faible. Il est temps de recharger ! 🔋",
+    "lowBatteryAlertBody": "Votre batterie est à {level} %. Il est temps de recharger ! 🔋",
     "batteryFullyChargedTitle": "Omi est complètement chargé",
     "batteryFullyChargedBody": "Votre appareil Omi est complètement chargé. Vous pouvez le débrancher !",
     "deviceDisconnectedNotificationTitle": "Votre appareil Omi s'est déconnecté",
@@ -3092,5 +3092,13 @@
     "syncStatusOnDevice": "En attente sur Omi",
     "syncStatusDownloadingFromDevice": "Téléchargement depuis Omi",
     "newestFirst": "Plus récents d'abord",
-    "noSyncedRecordingsYet": "Aucun enregistrement synchronisé pour l'instant"
+    "noSyncedRecordingsYet": "Aucun enregistrement synchronisé pour l'instant",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "ההתקן שלך נמצא בסוללה נמוכה. הגיע הזמן לטעינה מחדש! 🔋",
+    "lowBatteryAlertBody": "הסוללה שלך ב-{level}%. הגיע הזמן לטעון! 🔋",
     "batteryFullyChargedTitle": "Omi טעון לגמרי",
     "batteryFullyChargedBody": "מכשיר Omi שלך טעון לגמרי. אפשר לנתק אותו!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "התקן Omi שלך התנתק",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2184,7 +2184,7 @@
     "selected": "चयनित",
     "selectOption": "चुनें",
     "lowBatteryAlertTitle": "कम बैटरी अलर्ट",
-    "lowBatteryAlertBody": "आपके डिवाइस की बैटरी कम है। रिचार्ज करने का समय! 🔋",
+    "lowBatteryAlertBody": "आपकी बैटरी {level}% पर है। रिचार्ज करने का समय! 🔋",
     "batteryFullyChargedTitle": "Omi पूरी तरह चार्ज हो गया है",
     "batteryFullyChargedBody": "आपका Omi डिवाइस पूरी तरह चार्ज हो गया है। इसे अनप्लग कर सकते हैं!",
     "deviceDisconnectedNotificationTitle": "आपका Omi डिवाइस डिस्कनेक्ट हो गया",
@@ -3058,5 +3058,13 @@
     "syncStatusOnDevice": "Omi पर प्रतीक्षारत",
     "syncStatusDownloadingFromDevice": "Omi से डाउनलोड हो रहा है",
     "newestFirst": "सबसे नई पहले",
-    "noSyncedRecordingsYet": "अभी तक कोई सिंक की गई रिकॉर्डिंग नहीं"
+    "noSyncedRecordingsYet": "अभी तक कोई सिंक की गई रिकॉर्डिंग नहीं",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "Vaš uređaj ima nisku bateriju. Vrijeme je za puniranje! 🔋",
+    "lowBatteryAlertBody": "Vaša baterija je na {level}%. Vrijeme je za punjenje! 🔋",
     "batteryFullyChargedTitle": "Omi je potpuno napunjen",
     "batteryFullyChargedBody": "Vaš Omi uređaj je potpuno napunjen. Možete ga iskopčati!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "Vaš Omi Uređaj Je Odspoj",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -2183,7 +2183,7 @@
     "selected": "Kiválasztva",
     "selectOption": "Kiválasztás",
     "lowBatteryAlertTitle": "Alacsony akkumulátor figyelmeztetés",
-    "lowBatteryAlertBody": "Az eszköz akkumulátora alacsony. Ideje feltölteni! 🔋",
+    "lowBatteryAlertBody": "Az akkumulátorod {level}%-on van. Ideje feltölteni! 🔋",
     "batteryFullyChargedTitle": "Az Omi teljesen feltöltődött",
     "batteryFullyChargedBody": "Az Omi eszköz teljesen feltöltődött. Leválaszthatod!",
     "deviceDisconnectedNotificationTitle": "Az Omi eszköz lecsatlakozott",
@@ -3153,5 +3153,13 @@
     "syncStatusOnDevice": "Az Omin várakozik",
     "syncStatusDownloadingFromDevice": "Letöltés az Omiról",
     "newestFirst": "Legújabbak elöl",
-    "noSyncedRecordingsYet": "Még nincsenek szinkronizált felvételek"
+    "noSyncedRecordingsYet": "Még nincsenek szinkronizált felvételek",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2183,7 +2183,7 @@
     "selected": "Dipilih",
     "selectOption": "Pilih",
     "lowBatteryAlertTitle": "Peringatan Baterai Lemah",
-    "lowBatteryAlertBody": "Baterai perangkat Anda lemah. Saatnya mengisi ulang! 🔋",
+    "lowBatteryAlertBody": "Baterai Anda di {level}%. Saatnya mengisi ulang! 🔋",
     "batteryFullyChargedTitle": "Omi sudah terisi penuh",
     "batteryFullyChargedBody": "Perangkat Omi Anda sudah terisi penuh. Silakan cabut kabelnya!",
     "deviceDisconnectedNotificationTitle": "Perangkat Omi Anda Terputus",
@@ -3099,5 +3099,13 @@
     "syncStatusOnDevice": "Menunggu di Omi",
     "syncStatusDownloadingFromDevice": "Mengunduh dari Omi",
     "newestFirst": "Terbaru lebih dulu",
-    "noSyncedRecordingsYet": "Belum ada rekaman yang tersinkronisasi"
+    "noSyncedRecordingsYet": "Belum ada rekaman yang tersinkronisasi",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2183,7 +2183,7 @@
     "selected": "Selezionato",
     "selectOption": "Seleziona",
     "lowBatteryAlertTitle": "Avviso batteria scarica",
-    "lowBatteryAlertBody": "La batteria del dispositivo è scarica. È ora di ricaricare! 🔋",
+    "lowBatteryAlertBody": "La tua batteria è al {level}%. È ora di ricaricare! 🔋",
     "batteryFullyChargedTitle": "Omi è completamente carico",
     "batteryFullyChargedBody": "Il tuo dispositivo Omi è completamente carico. Puoi scollegarlo!",
     "deviceDisconnectedNotificationTitle": "Il tuo dispositivo Omi si è disconnesso",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "In attesa su Omi",
     "syncStatusDownloadingFromDevice": "Download da Omi",
     "newestFirst": "Più recenti prima",
-    "noSyncedRecordingsYet": "Nessuna registrazione sincronizzata"
+    "noSyncedRecordingsYet": "Nessuna registrazione sincronizzata",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2184,7 +2184,7 @@
     "selected": "選択済み",
     "selectOption": "選択",
     "lowBatteryAlertTitle": "バッテリー残量低下アラート",
-    "lowBatteryAlertBody": "デバイスのバッテリーが少なくなっています。充電してください！🔋",
+    "lowBatteryAlertBody": "バッテリー残量は {level}% です。充電してください！🔋",
     "batteryFullyChargedTitle": "Omiは満充電です",
     "batteryFullyChargedBody": "Omiデバイスが満充電になりました。充電ケーブルを外してください！",
     "deviceDisconnectedNotificationTitle": "Omiデバイスが切断されました",
@@ -3058,5 +3058,13 @@
     "syncStatusOnDevice": "Omiで待機中",
     "syncStatusDownloadingFromDevice": "Omiからダウンロード中",
     "newestFirst": "新しい順",
-    "noSyncedRecordingsYet": "同期済みの録音はまだありません"
+    "noSyncedRecordingsYet": "同期済みの録音はまだありません",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "ನಿಮ್ಮ ಸಾಧನವು ಬ್ಯಾಟರಿ ಕಡಿಮೆಯಿದೆ. ಚಾರ್ಜ್ ಮಾಡುವ ಸಮಯ! 🔋",
+    "lowBatteryAlertBody": "ನಿಮ್ಮ ಬ್ಯಾಟರಿ {level}% ನಲ್ಲಿದೆ. ಚಾರ್ಜ್ ಮಾಡುವ ಸಮಯ! 🔋",
     "batteryFullyChargedTitle": "Omi ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ",
     "batteryFullyChargedBody": "ನಿಮ್ಮ Omi ಸಾಧನ ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ. ಅನ್‌ಪ್ಲಗ್ ಮಾಡಬಹುದು!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "ನಿಮ್ಮ Omi ಸಾಧನ ಸಂಪರ್ಕ ಸ್ವಲ್ಪ",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2183,7 +2183,7 @@
     "selected": "선택됨",
     "selectOption": "선택",
     "lowBatteryAlertTitle": "배터리 부족 알림",
-    "lowBatteryAlertBody": "기기의 배터리가 부족합니다. 충전할 시간입니다! 🔋",
+    "lowBatteryAlertBody": "배터리가 {level}%입니다. 충전할 시간입니다! 🔋",
     "batteryFullyChargedTitle": "Omi가 완전히 충전되었습니다",
     "batteryFullyChargedBody": "Omi 기기가 완전히 충전되었습니다. 이제 플러그를 뽑으셔도 됩니다!",
     "deviceDisconnectedNotificationTitle": "Omi 기기가 연결 해제되었습니다",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Omi에서 대기 중",
     "syncStatusDownloadingFromDevice": "Omi에서 다운로드 중",
     "newestFirst": "최신순",
-    "noSyncedRecordingsYet": "아직 동기화된 녹음이 없습니다"
+    "noSyncedRecordingsYet": "아직 동기화된 녹음이 없습니다",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -12888,8 +12888,8 @@ abstract class AppLocalizations {
   /// Body text for low battery notification
   ///
   /// In en, this message translates to:
-  /// **'Your device is running low on battery. Time for a recharge! 🔋'**
-  String get lowBatteryAlertBody;
+  /// **'Your battery is at {level}%. Time for a recharge! 🔋'**
+  String lowBatteryAlertBody(int level);
 
   /// No description provided for @batteryFullyChargedTitle.
   ///

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -6786,7 +6786,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get lowBatteryAlertTitle => 'تنبيه انخفاض البطارية';
 
   @override
-  String get lowBatteryAlertBody => 'بطارية جهازك منخفضة. حان وقت إعادة الشحن! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'بطاريتك عند $level٪. حان وقت إعادة الشحن! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'أومي مشحون بالكامل';

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -6857,7 +6857,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Абвяшчэнне пра нізкі заряд батарэі';
 
   @override
-  String get lowBatteryAlertBody => 'Ваша прыстасаванне буквальна вычарпвае батарэю. Час пазарадзіць! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Ваша батарэя на $level%. Час пазарадзіць! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi поўнасцю зараджаны';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -6861,7 +6861,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Предупреждение за изтощена батерия';
 
   @override
-  String get lowBatteryAlertBody => 'Батерията на устройството ви е изтощена. Време е за презареждане! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Батерията ви е на $level%. Време е за презареждане! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi е напълно зареден';

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -6846,7 +6846,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get lowBatteryAlertTitle => 'কম ব্যাটারির সতর্কতা';
 
   @override
-  String get lowBatteryAlertBody => 'আপনার ডিভাইসের ব্যাটারি কম হয়ে যাচ্ছে। চার্জ করার সময় এসেছে! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'আপনার ব্যাটারি $level% এ আছে। চার্জ করার সময় এসেছে! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi সম্পূর্ণ চার্জ হয়েছে';

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -6852,7 +6852,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Upozorenje o niskoj bateriji';
 
   @override
-  String get lowBatteryAlertBody => 'Vaš uređaj ima nisku bateriju. Vrijeme je za ponovno punjena! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Vaša baterija je na $level%. Vrijeme je za punjenje! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi je potpuno napunjen';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -6874,7 +6874,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Alerta de bateria baixa';
 
   @override
-  String get lowBatteryAlertBody => 'La bateria del teu dispositiu és baixa. És hora de carregar! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'La teva bateria és al $level%. És hora de carregar! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'L\'Omi està completament carregat';

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -6826,7 +6826,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Upozornění na vybitou baterii';
 
   @override
-  String get lowBatteryAlertBody => 'Baterie vašeho zařízení je vybitá. Je čas ji dobít! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Vaše baterie je na $level%. Je čas ji dobít! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi je plně nabitý';

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -6818,7 +6818,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Advarsel om lavt batteri';
 
   @override
-  String get lowBatteryAlertBody => 'Din enheds batteri er lavt. Det er tid til at genoplade! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Dit batteri er på $level%. Tid til at lade op! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi er fuldt opladet';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -6886,7 +6886,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Warnung: Niedriger Akkustand';
 
   @override
-  String get lowBatteryAlertBody => 'Der Akkustand Ihres Geräts ist niedrig. Zeit zum Aufladen! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Dein Akku ist bei $level%. Zeit zum Aufladen! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi ist vollständig geladen';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -6884,7 +6884,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Ειδοποίηση χαμηλής μπαταρίας';
 
   @override
-  String get lowBatteryAlertBody => 'Η μπαταρία της συσκευής σας είναι χαμηλή. Ώρα για επαναφόρτιση! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Η μπαταρία σας είναι στο $level%. Ώρα για φόρτιση! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Το Omi έχει φορτιστεί πλήρως';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -6832,7 +6832,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Low Battery Alert';
 
   @override
-  String get lowBatteryAlertBody => 'Your device is running low on battery. Time for a recharge! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Your battery is at $level%. Time for a recharge! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi is fully charged';

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -6841,7 +6841,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Alerta de batería baja';
 
   @override
-  String get lowBatteryAlertBody => 'La batería de tu dispositivo está baja. ¡Es hora de recargar! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Tu batería está al $level%. ¡Es hora de recargar! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi está completamente cargado';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -6838,7 +6838,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Tühja aku hoiatus';
 
   @override
-  String get lowBatteryAlertBody => 'Teie seadme aku on tühi. Aeg laadida! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Sinu aku on $level%. Aeg laadida! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi on täielikult laetud';

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -6840,7 +6840,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get lowBatteryAlertTitle => 'هشدار باتری کم';
 
   @override
-  String get lowBatteryAlertBody => 'باتری دستگاه شما تقریباً تمام است. وقت شارژ کردن است! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'باتری شما $level٪ است. وقت شارژ کردن است! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi کاملاً شارژ شد';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -6838,7 +6838,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Alhaisen akun varoitus';
 
   @override
-  String get lowBatteryAlertBody => 'Laitteesi akku on alhainen. Aika ladata! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Akkusi on $level%. Aika ladata! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi on ladattu täyteen';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -6895,7 +6895,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Alerte de batterie faible';
 
   @override
-  String get lowBatteryAlertBody => 'La batterie de votre appareil est faible. Il est temps de recharger ! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Votre batterie est à $level %. Il est temps de recharger ! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi est complètement chargé';

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -6782,7 +6782,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get lowBatteryAlertTitle => 'התראת סוללה נמוכה';
 
   @override
-  String get lowBatteryAlertBody => 'ההתקן שלך נמצא בסוללה נמוכה. הגיע הזמן לטעינה מחדש! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'הסוללה שלך ב-$level%. הגיע הזמן לטעון! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi טעון לגמרי';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -6812,7 +6812,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get lowBatteryAlertTitle => 'कम बैटरी अलर्ट';
 
   @override
-  String get lowBatteryAlertBody => 'आपके डिवाइस की बैटरी कम है। रिचार्ज करने का समय! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'आपकी बैटरी $level% पर है। रिचार्ज करने का समय! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi पूरी तरह चार्ज हो गया है';

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -6855,7 +6855,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Upozorenje o Niskoj Bateriji';
 
   @override
-  String get lowBatteryAlertBody => 'Vaš uređaj ima nisku bateriju. Vrijeme je za puniranje! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Vaša baterija je na $level%. Vrijeme je za punjenje! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi je potpuno napunjen';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -6868,7 +6868,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Alacsony akkumulátor figyelmeztetés';
 
   @override
-  String get lowBatteryAlertBody => 'Az eszköz akkumulátora alacsony. Ideje feltölteni! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Az akkumulátorod $level%-on van. Ideje feltölteni! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Az Omi teljesen feltöltődött';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -6852,7 +6852,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Peringatan Baterai Lemah';
 
   @override
-  String get lowBatteryAlertBody => 'Baterai perangkat Anda lemah. Saatnya mengisi ulang! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Baterai Anda di $level%. Saatnya mengisi ulang! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi sudah terisi penuh';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -6877,7 +6877,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Avviso batteria scarica';
 
   @override
-  String get lowBatteryAlertBody => 'La batteria del dispositivo è scarica. È ora di ricaricare! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'La tua batteria è al $level%. È ora di ricaricare! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi è completamente carico';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -6716,7 +6716,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get lowBatteryAlertTitle => 'バッテリー残量低下アラート';
 
   @override
-  String get lowBatteryAlertBody => 'デバイスのバッテリーが少なくなっています。充電してください！🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'バッテリー残量は $level% です。充電してください！🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omiは満充電です';

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -6861,7 +6861,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get lowBatteryAlertTitle => 'ಕಡಿಮೆ ಬ್ಯಾಟರಿ ಎಚ್ಚರಿಕೆ';
 
   @override
-  String get lowBatteryAlertBody => 'ನಿಮ್ಮ ಸಾಧನವು ಬ್ಯಾಟರಿ ಕಡಿಮೆಯಿದೆ. ಚಾರ್ಜ್ ಮಾಡುವ ಸಮಯ! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'ನಿಮ್ಮ ಬ್ಯಾಟರಿ $level% ನಲ್ಲಿದೆ. ಚಾರ್ಜ್ ಮಾಡುವ ಸಮಯ! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi ಸಂಪೂರ್ಣ ಚಾರ್ಜ್ ಆಗಿದೆ';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -6718,7 +6718,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get lowBatteryAlertTitle => '배터리 부족 알림';
 
   @override
-  String get lowBatteryAlertBody => '기기의 배터리가 부족합니다. 충전할 시간입니다! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return '배터리가 $level%입니다. 충전할 시간입니다! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi가 완전히 충전되었습니다';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -6839,7 +6839,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Įspėjimas apie senką bateriją';
 
   @override
-  String get lowBatteryAlertBody => 'Jūsų įrenginio baterija senka. Laikas įkrauti! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Jūsų baterija yra $level%. Laikas įkrauti! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi yra visiškai įkrautas';

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -6849,7 +6849,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Zema akumulatora brīdinājums';
 
   @override
-  String get lowBatteryAlertBody => 'Jūsu ierīces akumulators ir zems. Laiks uzlādēt! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Tavs akumulators ir $level%. Laiks uzlādēt! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi ir pilnībā uzlādēts';

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -6870,7 +6870,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Предупредување за Мала Батерија';
 
   @override
-  String get lowBatteryAlertBody => 'Вашиот уред има ниска батерија. Време е за полнење! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Вашата батерија е на $level%. Време е за полнење! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi е целосно наполнет';

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -6847,7 +6847,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get lowBatteryAlertTitle => 'कमी बॅटरी सूचना';
 
   @override
-  String get lowBatteryAlertBody => 'आपली डिव्हाइस बॅटरीवर कमी चल रही आहे. रिचार्जने वेळ आली! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'तुमची बॅटरी $level% आहे. रिचार्ज करण्याची वेळ! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi पूर्णपणे चार्ज झाला आहे';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -6857,7 +6857,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Amaran Bateri Lemah';
 
   @override
-  String get lowBatteryAlertBody => 'Bateri peranti anda lemah. Masa untuk mengecas semula! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Bateri anda berada di $level%. Masa untuk mengecas semula! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi telah dicas penuh';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -6857,7 +6857,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Waarschuwing lage batterij';
 
   @override
-  String get lowBatteryAlertBody => 'De batterij van uw apparaat is bijna leeg. Tijd om op te laden! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Je batterij staat op $level%. Tijd om op te laden! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi is volledig opgeladen';

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -6833,7 +6833,9 @@ class AppLocalizationsNo extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Advarsel om lavt batteri';
 
   @override
-  String get lowBatteryAlertBody => 'Enhetens batteri er lavt. På tide å lade! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Batteriet ditt er på $level%. På tide å lade! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi er fulladet';

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -6849,7 +6849,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Alert niskiego poziomu baterii';
 
   @override
-  String get lowBatteryAlertBody => 'Bateria Twojego urządzenia jest na wyczerpaniu. Czas na ładowanie! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Twoja bateria ma $level%. Czas naładować! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi jest w pełni naładowany';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -6829,7 +6829,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Alerta de bateria fraca';
 
   @override
-  String get lowBatteryAlertBody => 'A bateria do seu dispositivo está fraca. Hora de recarregar! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Sua bateria está em $level%. Hora de recarregar! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi está totalmente carregado';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -6870,7 +6870,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Alertă baterie descărcată';
 
   @override
-  String get lowBatteryAlertBody => 'Bateria dispozitivului este descărcată. E timpul să reîncărcați! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Bateria ta este la $level%. E timpul să reîncărcați! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi este complet încărcat';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -6854,7 +6854,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Предупреждение о низком заряде';
 
   @override
-  String get lowBatteryAlertBody => 'Батарея вашего устройства разряжена. Пора зарядить! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Заряд батареи $level%. Пора зарядить! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi полностью заряжен';

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -6834,7 +6834,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Upozornenie na nízku batériu';
 
   @override
-  String get lowBatteryAlertBody => 'Batéria vášho zariadenia je vybitá. Je čas ju nabiť! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Vaša batéria je na $level%. Je čas ju nabiť! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi je plne nabitý';

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -6849,7 +6849,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Opozorilo o Nizki Bateriji';
 
   @override
-  String get lowBatteryAlertBody => 'Vaša naprava ima nizko baterijo. Čas je za polnjenje! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Vaša baterija je na $level%. Čas je za polnjenje! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi je popolnoma napolnjen';

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -6845,7 +6845,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Обавештење о слабој батерији';
 
   @override
-  String get lowBatteryAlertBody => 'Батерија вашег уређаја је скоро празна. Време је за пуњење! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Батерија вам је на $level%. Време је за пуњење! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi је потпуно напуњен';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -6839,7 +6839,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Varning för lågt batteri';
 
   @override
-  String get lowBatteryAlertBody => 'Enhetens batteri är lågt. Dags att ladda! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Ditt batteri är på $level%. Dags att ladda! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi är fulladdad';

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -6884,8 +6884,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get lowBatteryAlertTitle => 'குறைந்த பேட்டரி எச்சரிக்கை';
 
   @override
-  String get lowBatteryAlertBody =>
-      'உங்கள் சாதனத்தின் பேட்டரி குறைந்து விட்டது. மீண்டும் சார்ஜ் செய்ய வேண்டிய நேரம்! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'உங்கள் பேட்டரி $level% இல் உள்ளது. மீண்டும் சார்ஜ் செய்ய வேண்டிய நேரம்! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi முழுமையாக சார்ஜ் ஆகியது';

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -6876,7 +6876,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get lowBatteryAlertTitle => 'తక్కువ బ్యాటరీ సতর్కత';
 
   @override
-  String get lowBatteryAlertBody => 'మీ పరికరం తక్కువ బ్యాటరీలో ఉంది. రీఛార్జ్ చేయడానికి సమయం! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'మీ బ్యాటరీ $level% వద్ద ఉంది. రీఛార్జ్ చేయడానికి సమయం! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi పూర్తిగా చార్జ్ అయింది';

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -6803,7 +6803,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get lowBatteryAlertTitle => 'การแจ้งเตือนแบตเตอรี่ต่ำ';
 
   @override
-  String get lowBatteryAlertBody => 'แบตเตอรี่ของอุปกรณ์ของคุณต่ำ ถึงเวลาชาร์จแล้ว! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'แบตเตอรี่ของคุณอยู่ที่ $level% ถึงเวลาชาร์จแล้ว! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi ชาร์จเต็มแล้ว';

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -6894,7 +6894,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Low Battery Alert';
 
   @override
-  String get lowBatteryAlertBody => 'Ang iyong device ay mababa na sa baterya. Panahon na para mag-recharge! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Ang iyong baterya ay nasa $level%. Panahon na para mag-recharge! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Naka-charge na ang Omi';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -6847,7 +6847,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Düşük Pil Uyarısı';
 
   @override
-  String get lowBatteryAlertBody => 'Cihazınızın pili azaldı. Şarj etme zamanı! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Pil seviyeniz %$level. Şarj etme zamanı! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi tamamen şarj oldu';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -6846,7 +6846,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Попередження про низький заряд батареї';
 
   @override
-  String get lowBatteryAlertBody => 'Батарея вашого пристрою розряджена. Час зарядити! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Заряд батареї $level%. Час зарядити! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi повністю заряджений';

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -6847,7 +6847,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get lowBatteryAlertTitle => 'کم بیٹری الرٹ';
 
   @override
-  String get lowBatteryAlertBody => 'آپ کا ڈیوائس بیٹری میں کم ہو رہا ہے۔ دوبارہ چارج کرنے کا وقت! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'آپ کی بیٹری $level٪ پر ہے۔ دوبارہ چارج کرنے کا وقت! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi مکمل طور پر چارج ہو گیا';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -6842,7 +6842,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get lowBatteryAlertTitle => 'Cảnh báo pin yếu';
 
   @override
-  String get lowBatteryAlertBody => 'Pin thiết bị của bạn đang yếu. Đã đến lúc sạc! 🔋';
+  String lowBatteryAlertBody(int level) {
+    return 'Pin của bạn còn $level%. Đã đến lúc sạc! 🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi đã sạc đầy';

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -6707,7 +6707,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get lowBatteryAlertTitle => '电池电量低警告';
 
   @override
-  String get lowBatteryAlertBody => '您的设备电池电量低。是时候充电了！🔋';
+  String lowBatteryAlertBody(int level) {
+    return '您的电池电量为 $level%。是时候充电了！🔋';
+  }
 
   @override
   String get batteryFullyChargedTitle => 'Omi已充满电';

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -1185,7 +1185,7 @@
     "logs": "Žurnalai",
     "logsCopied": "Žurnalai nukopijuoti",
     "lovingOmi": "Patinka Omi?",
-    "lowBatteryAlertBody": "Jūsų įrenginio baterija senka. Laikas įkrauti! 🔋",
+    "lowBatteryAlertBody": "Jūsų baterija yra {level}%. Laikas įkrauti! 🔋",
     "batteryFullyChargedTitle": "Omi yra visiškai įkrautas",
     "batteryFullyChargedBody": "Jūsų Omi įrenginys yra visiškai įkrautas. Galite jį atjungti!",
     "lowBatteryAlertTitle": "Įspėjimas apie senką bateriją",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Laukia Omi",
     "syncStatusDownloadingFromDevice": "Atsisiunčiama iš Omi",
     "newestFirst": "Pirma naujausi",
-    "noSyncedRecordingsYet": "Sinchronizuotų įrašų dar nėra"
+    "noSyncedRecordingsYet": "Sinchronizuotų įrašų dar nėra",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2183,7 +2183,7 @@
     "selected": "Atlasīts",
     "selectOption": "Atlasīt",
     "lowBatteryAlertTitle": "Zema akumulatora brīdinājums",
-    "lowBatteryAlertBody": "Jūsu ierīces akumulators ir zems. Laiks uzlādēt! 🔋",
+    "lowBatteryAlertBody": "Tavs akumulators ir {level}%. Laiks uzlādēt! 🔋",
     "batteryFullyChargedTitle": "Omi ir pilnībā uzlādēts",
     "batteryFullyChargedBody": "Jūsu Omi ierīce ir pilnībā uzlādēta. Varat to atvienot!",
     "deviceDisconnectedNotificationTitle": "Jūsu Omi ierīce ir atvienota",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Gaida Omi",
     "syncStatusDownloadingFromDevice": "Lejupielādē no Omi",
     "newestFirst": "Vispirms jaunākie",
-    "noSyncedRecordingsYet": "Vēl nav sinhronizētu ierakstu"
+    "noSyncedRecordingsYet": "Vēl nav sinhronizētu ierakstu",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "Вашиот уред има ниска батерија. Време е за полнење! 🔋",
+    "lowBatteryAlertBody": "Вашата батерија е на {level}%. Време е за полнење! 🔋",
     "batteryFullyChargedTitle": "Omi е целосно наполнет",
     "batteryFullyChargedBody": "Вашиот Omi уред е целосно наполнет. Можете да го исклучите!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "Вашиот Omi Уред се Откачи",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "आपली डिव्हाइस बॅटरीवर कमी चल रही आहे. रिचार्जने वेळ आली! 🔋",
+    "lowBatteryAlertBody": "तुमची बॅटरी {level}% आहे. रिचार्ज करण्याची वेळ! 🔋",
     "batteryFullyChargedTitle": "Omi पूर्णपणे चार्ज झाला आहे",
     "batteryFullyChargedBody": "तुमचे Omi डिव्हाइस पूर्णपणे चार्ज झाले आहे. अनप्लग करू शकता!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "आपली Omi डिव्हाइस डिस्कनेक्ट झाली",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2183,7 +2183,7 @@
     "selected": "Dipilih",
     "selectOption": "Pilih",
     "lowBatteryAlertTitle": "Amaran Bateri Lemah",
-    "lowBatteryAlertBody": "Bateri peranti anda lemah. Masa untuk mengecas semula! 🔋",
+    "lowBatteryAlertBody": "Bateri anda berada di {level}%. Masa untuk mengecas semula! 🔋",
     "batteryFullyChargedTitle": "Omi telah dicas penuh",
     "batteryFullyChargedBody": "Peranti Omi anda telah dicas sepenuhnya. Anda boleh mencabutnya!",
     "deviceDisconnectedNotificationTitle": "Peranti Omi Anda Terputus",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Menunggu di Omi",
     "syncStatusDownloadingFromDevice": "Memuat turun dari Omi",
     "newestFirst": "Terbaharu dahulu",
-    "noSyncedRecordingsYet": "Belum ada rakaman yang disegerakkan"
+    "noSyncedRecordingsYet": "Belum ada rakaman yang disegerakkan",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2183,7 +2183,7 @@
     "selected": "Geselecteerd",
     "selectOption": "Selecteren",
     "lowBatteryAlertTitle": "Waarschuwing lage batterij",
-    "lowBatteryAlertBody": "De batterij van uw apparaat is bijna leeg. Tijd om op te laden! 🔋",
+    "lowBatteryAlertBody": "Je batterij staat op {level}%. Tijd om op te laden! 🔋",
     "batteryFullyChargedTitle": "Omi is volledig opgeladen",
     "batteryFullyChargedBody": "Uw Omi-apparaat is volledig opgeladen. U kunt het loskoppelen!",
     "deviceDisconnectedNotificationTitle": "Uw Omi-apparaat is losgekoppeld",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Wacht op Omi",
     "syncStatusDownloadingFromDevice": "Downloaden van Omi",
     "newestFirst": "Nieuwste eerst",
-    "noSyncedRecordingsYet": "Nog geen gesynchroniseerde opnames"
+    "noSyncedRecordingsYet": "Nog geen gesynchroniseerde opnames",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2183,7 +2183,7 @@
     "selected": "Valgt",
     "selectOption": "Velg",
     "lowBatteryAlertTitle": "Advarsel om lavt batteri",
-    "lowBatteryAlertBody": "Enhetens batteri er lavt. På tide å lade! 🔋",
+    "lowBatteryAlertBody": "Batteriet ditt er på {level}%. På tide å lade! 🔋",
     "batteryFullyChargedTitle": "Omi er fulladet",
     "batteryFullyChargedBody": "Omi-enheten din er fulladet. Du kan koble den fra nå!",
     "deviceDisconnectedNotificationTitle": "Omi-enheten din ble frakoblet",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Venter på Omi",
     "syncStatusDownloadingFromDevice": "Laster ned fra Omi",
     "newestFirst": "Nyeste først",
-    "noSyncedRecordingsYet": "Ingen synkroniserte opptak ennå"
+    "noSyncedRecordingsYet": "Ingen synkroniserte opptak ennå",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2183,7 +2183,7 @@
     "selected": "Wybrano",
     "selectOption": "Wybierz",
     "lowBatteryAlertTitle": "Alert niskiego poziomu baterii",
-    "lowBatteryAlertBody": "Bateria Twojego urządzenia jest na wyczerpaniu. Czas na ładowanie! 🔋",
+    "lowBatteryAlertBody": "Twoja bateria ma {level}%. Czas naładować! 🔋",
     "batteryFullyChargedTitle": "Omi jest w pełni naładowany",
     "batteryFullyChargedBody": "Twoje urządzenie Omi jest w pełni naładowane. Możesz je odłączyć!",
     "deviceDisconnectedNotificationTitle": "Twoje urządzenie Omi zostało rozłączone",
@@ -3092,5 +3092,13 @@
     "syncStatusOnDevice": "Czeka na Omi",
     "syncStatusDownloadingFromDevice": "Pobieranie z Omi",
     "newestFirst": "Najpierw najnowsze",
-    "noSyncedRecordingsYet": "Brak zsynchronizowanych nagrań"
+    "noSyncedRecordingsYet": "Brak zsynchronizowanych nagrań",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2184,7 +2184,7 @@
     "selected": "Selecionado",
     "selectOption": "Selecionar",
     "lowBatteryAlertTitle": "Alerta de bateria fraca",
-    "lowBatteryAlertBody": "A bateria do seu dispositivo está fraca. Hora de recarregar! 🔋",
+    "lowBatteryAlertBody": "Sua bateria está em {level}%. Hora de recarregar! 🔋",
     "batteryFullyChargedTitle": "Omi está totalmente carregado",
     "batteryFullyChargedBody": "Seu dispositivo Omi está totalmente carregado. Você pode desligá-lo!",
     "deviceDisconnectedNotificationTitle": "Seu dispositivo Omi foi desconectado",
@@ -3093,5 +3093,13 @@
     "syncStatusOnDevice": "Aguardando no Omi",
     "syncStatusDownloadingFromDevice": "Baixando de Omi",
     "newestFirst": "Mais recentes primeiro",
-    "noSyncedRecordingsYet": "Ainda não há gravações sincronizadas"
+    "noSyncedRecordingsYet": "Ainda não há gravações sincronizadas",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2183,7 +2183,7 @@
     "selected": "Selectat",
     "selectOption": "Selectează",
     "lowBatteryAlertTitle": "Alertă baterie descărcată",
-    "lowBatteryAlertBody": "Bateria dispozitivului este descărcată. E timpul să reîncărcați! 🔋",
+    "lowBatteryAlertBody": "Bateria ta este la {level}%. E timpul să reîncărcați! 🔋",
     "batteryFullyChargedTitle": "Omi este complet încărcat",
     "batteryFullyChargedBody": "Dispozitivul tău Omi este complet încărcat. Îl poți decupla acum!",
     "deviceDisconnectedNotificationTitle": "Dispozitivul Omi a fost deconectat",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Așteaptă pe Omi",
     "syncStatusDownloadingFromDevice": "Se descarcă de pe Omi",
     "newestFirst": "Cele mai noi primele",
-    "noSyncedRecordingsYet": "Încă nu există înregistrări sincronizate"
+    "noSyncedRecordingsYet": "Încă nu există înregistrări sincronizate",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2183,7 +2183,7 @@
     "selected": "Выбрано",
     "selectOption": "Выбрать",
     "lowBatteryAlertTitle": "Предупреждение о низком заряде",
-    "lowBatteryAlertBody": "Батарея вашего устройства разряжена. Пора зарядить! 🔋",
+    "lowBatteryAlertBody": "Заряд батареи {level}%. Пора зарядить! 🔋",
     "batteryFullyChargedTitle": "Omi полностью заряжен",
     "batteryFullyChargedBody": "Ваше устройство Omi полностью заряжено. Можно отключить от зарядки!",
     "deviceDisconnectedNotificationTitle": "Ваше устройство Omi отключено",
@@ -3092,5 +3092,13 @@
     "syncStatusOnDevice": "Ожидает на Omi",
     "syncStatusDownloadingFromDevice": "Загрузка с Omi",
     "newestFirst": "Сначала новые",
-    "noSyncedRecordingsYet": "Пока нет синхронизированных записей"
+    "noSyncedRecordingsYet": "Пока нет синхронизированных записей",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2183,7 +2183,7 @@
     "selected": "Vybrané",
     "selectOption": "Vybrať",
     "lowBatteryAlertTitle": "Upozornenie na nízku batériu",
-    "lowBatteryAlertBody": "Batéria vášho zariadenia je vybitá. Je čas ju nabiť! 🔋",
+    "lowBatteryAlertBody": "Vaša batéria je na {level}%. Je čas ju nabiť! 🔋",
     "batteryFullyChargedTitle": "Omi je plne nabitý",
     "batteryFullyChargedBody": "Vaše zariadenie Omi je plne nabité. Môžete ho odpojiť!",
     "deviceDisconnectedNotificationTitle": "Vaše zariadenie Omi bolo odpojené",
@@ -3062,5 +3062,13 @@
     "syncStatusOnDevice": "Čaká na Omi",
     "syncStatusDownloadingFromDevice": "Sťahuje sa z Omi",
     "newestFirst": "Najnovšie ako prvé",
-    "noSyncedRecordingsYet": "Zatiaľ žiadne synchronizované nahrávky"
+    "noSyncedRecordingsYet": "Zatiaľ žiadne synchronizované nahrávky",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "Vaša naprava ima nizko baterijo. Čas je za polnjenje! 🔋",
+    "lowBatteryAlertBody": "Vaša baterija je na {level}%. Čas je za polnjenje! 🔋",
     "batteryFullyChargedTitle": "Omi je popolnoma napolnjen",
     "batteryFullyChargedBody": "Vaša naprava Omi je popolnoma napolnjena. Lahko jo odklopite!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "Vaša Naprava Omi je Odklopljena",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "Батерија вашег уређаја је скоро празна. Време је за пуњење! 🔋",
+    "lowBatteryAlertBody": "Батерија вам је на {level}%. Време је за пуњење! 🔋",
     "batteryFullyChargedTitle": "Omi је потпуно напуњен",
     "batteryFullyChargedBody": "Ваш Omi уређај је потпуно напуњен. Можете га искључити!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "Ваш Omi уређај је одсоединут",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2183,7 +2183,7 @@
     "selected": "Vald",
     "selectOption": "Välj",
     "lowBatteryAlertTitle": "Varning för lågt batteri",
-    "lowBatteryAlertBody": "Enhetens batteri är lågt. Dags att ladda! 🔋",
+    "lowBatteryAlertBody": "Ditt batteri är på {level}%. Dags att ladda! 🔋",
     "batteryFullyChargedTitle": "Omi är fulladdad",
     "batteryFullyChargedBody": "Din Omi-enhet är fulladdad. Du kan koppla ur den nu!",
     "deviceDisconnectedNotificationTitle": "Din Omi-enhet har kopplats från",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Väntar på Omi",
     "syncStatusDownloadingFromDevice": "Laddar ner från Omi",
     "newestFirst": "Nyaste först",
-    "noSyncedRecordingsYet": "Inga synkroniserade inspelningar än"
+    "noSyncedRecordingsYet": "Inga synkroniserade inspelningar än",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "உங்கள் சாதனத்தின் பேட்டரி குறைந்து விட்டது. மீண்டும் சார்ஜ் செய்ய வேண்டிய நேரம்! 🔋",
+    "lowBatteryAlertBody": "உங்கள் பேட்டரி {level}% இல் உள்ளது. மீண்டும் சார்ஜ் செய்ய வேண்டிய நேரம்! 🔋",
     "batteryFullyChargedTitle": "Omi முழுமையாக சார்ஜ் ஆகியது",
     "batteryFullyChargedBody": "உங்கள் Omi சாதனம் முழுமையாக சார்ஜ் ஆகியது. அனப்ளக் செய்யலாம்!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "உங்கள் Omi சாதனம் துண்டிக்கப்பட்டது",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "మీ పరికరం తక్కువ బ్యాటరీలో ఉంది. రీఛార్జ్ చేయడానికి సమయం! 🔋",
+    "lowBatteryAlertBody": "మీ బ్యాటరీ {level}% వద్ద ఉంది. రీఛార్జ్ చేయడానికి సమయం! 🔋",
     "batteryFullyChargedTitle": "Omi పూర్తిగా చార్జ్ అయింది",
     "batteryFullyChargedBody": "మీ Omi పరికరం పూర్తిగా చార్జ్ అయింది. అన్‌ప్లగ్ చేయవచ్చు!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "మీ Omi పరికరం డిస్‌కనెక్ట్ చేయబడింది",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2183,7 +2183,7 @@
     "selected": "เลือกแล้ว",
     "selectOption": "เลือก",
     "lowBatteryAlertTitle": "การแจ้งเตือนแบตเตอรี่ต่ำ",
-    "lowBatteryAlertBody": "แบตเตอรี่ของอุปกรณ์ของคุณต่ำ ถึงเวลาชาร์จแล้ว! 🔋",
+    "lowBatteryAlertBody": "แบตเตอรี่ของคุณอยู่ที่ {level}% ถึงเวลาชาร์จแล้ว! 🔋",
     "batteryFullyChargedTitle": "Omi ชาร์จเต็มแล้ว",
     "batteryFullyChargedBody": "อุปกรณ์ Omi ของคุณชาร์จเต็มแล้ว รู้สึกอิสระที่จะถอดปลั๊กได้!",
     "deviceDisconnectedNotificationTitle": "อุปกรณ์ Omi ของคุณถูกตัดการเชื่อมต่อ",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "รอที่ Omi",
     "syncStatusDownloadingFromDevice": "กำลังดาวน์โหลดจาก Omi",
     "newestFirst": "ใหม่สุดก่อน",
-    "noSyncedRecordingsYet": "ยังไม่มีการบันทึกที่ซิงค์แล้ว"
+    "noSyncedRecordingsYet": "ยังไม่มีการบันทึกที่ซิงค์แล้ว",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "Ang iyong device ay mababa na sa baterya. Panahon na para mag-recharge! 🔋",
+    "lowBatteryAlertBody": "Ang iyong baterya ay nasa {level}%. Panahon na para mag-recharge! 🔋",
     "batteryFullyChargedTitle": "Naka-charge na ang Omi",
     "batteryFullyChargedBody": "Ang iyong Omi device ay ganap nang na-charge. Maaari mo na itong i-unplug!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "Ang Iyong Omi Device ay Nadiskonekta",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2183,7 +2183,7 @@
     "selected": "Seçildi",
     "selectOption": "Seç",
     "lowBatteryAlertTitle": "Düşük Pil Uyarısı",
-    "lowBatteryAlertBody": "Cihazınızın pili azaldı. Şarj etme zamanı! 🔋",
+    "lowBatteryAlertBody": "Pil seviyeniz %{level}. Şarj etme zamanı! 🔋",
     "batteryFullyChargedTitle": "Omi tamamen şarj oldu",
     "batteryFullyChargedBody": "Omi cihazınız tamamen şarj oldu. Fişini çekebilirsiniz!",
     "deviceDisconnectedNotificationTitle": "Omi Cihazınız Bağlantı Kesildi",
@@ -3092,5 +3092,13 @@
     "syncStatusOnDevice": "Omi'de bekliyor",
     "syncStatusDownloadingFromDevice": "Omi'den indiriliyor",
     "newestFirst": "Önce en yeniler",
-    "noSyncedRecordingsYet": "Henüz senkronize edilmiş kayıt yok"
+    "noSyncedRecordingsYet": "Henüz senkronize edilmiş kayıt yok",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2183,7 +2183,7 @@
     "selected": "Вибрано",
     "selectOption": "Вибрати",
     "lowBatteryAlertTitle": "Попередження про низький заряд батареї",
-    "lowBatteryAlertBody": "Батарея вашого пристрою розряджена. Час зарядити! 🔋",
+    "lowBatteryAlertBody": "Заряд батареї {level}%. Час зарядити! 🔋",
     "batteryFullyChargedTitle": "Omi повністю заряджений",
     "batteryFullyChargedBody": "Ваш пристрій Omi повністю заряджений. Можна відключити від зарядки!",
     "deviceDisconnectedNotificationTitle": "Ваш пристрій Omi відключено",
@@ -3057,5 +3057,13 @@
     "syncStatusOnDevice": "Очікує на Omi",
     "syncStatusDownloadingFromDevice": "Завантаження з Omi",
     "newestFirst": "Спочатку нові",
-    "noSyncedRecordingsYet": "Синхронізованих записів ще немає"
+    "noSyncedRecordingsYet": "Синхронізованих записів ще немає",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -8397,11 +8397,16 @@
     "@lowBatteryAlertTitle": {
         "description": "Title for low battery notification"
     },
-    "lowBatteryAlertBody": "آپ کا ڈیوائس بیٹری میں کم ہو رہا ہے۔ دوبارہ چارج کرنے کا وقت! 🔋",
+    "lowBatteryAlertBody": "آپ کی بیٹری {level}٪ پر ہے۔ دوبارہ چارج کرنے کا وقت! 🔋",
     "batteryFullyChargedTitle": "Omi مکمل طور پر چارج ہو گیا",
     "batteryFullyChargedBody": "آپ کا Omi ڈیوائس مکمل طور پر چارج ہو گئی ہے۔ اسے ان پلگ کر سکتے ہیں!",
     "@lowBatteryAlertBody": {
-        "description": "Body text for low battery notification"
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
     },
     "deviceDisconnectedNotificationTitle": "آپ کا Omi ڈیوائس منقطع ہو گیا",
     "@deviceDisconnectedNotificationTitle": {

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2183,7 +2183,7 @@
     "selected": "Đã chọn",
     "selectOption": "Chọn",
     "lowBatteryAlertTitle": "Cảnh báo pin yếu",
-    "lowBatteryAlertBody": "Pin thiết bị của bạn đang yếu. Đã đến lúc sạc! 🔋",
+    "lowBatteryAlertBody": "Pin của bạn còn {level}%. Đã đến lúc sạc! 🔋",
     "batteryFullyChargedTitle": "Omi đã sạc đầy",
     "batteryFullyChargedBody": "Thiết bị Omi của bạn đã sạc đầy. Bạn có thể rút cáp ra!",
     "deviceDisconnectedNotificationTitle": "Thiết bị Omi của bạn đã ngắt kết nối",
@@ -3062,5 +3062,13 @@
     "syncStatusOnDevice": "Đang chờ trên Omi",
     "syncStatusDownloadingFromDevice": "Đang tải xuống từ Omi",
     "newestFirst": "Mới nhất trước",
-    "noSyncedRecordingsYet": "Chưa có bản ghi nào được đồng bộ"
+    "noSyncedRecordingsYet": "Chưa có bản ghi nào được đồng bộ",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2184,7 +2184,7 @@
     "selected": "已选择",
     "selectOption": "选择",
     "lowBatteryAlertTitle": "电池电量低警告",
-    "lowBatteryAlertBody": "您的设备电池电量低。是时候充电了！🔋",
+    "lowBatteryAlertBody": "您的电池电量为 {level}%。是时候充电了！🔋",
     "batteryFullyChargedTitle": "Omi已充满电",
     "batteryFullyChargedBody": "您的Omi设备已充满电，可以拔掉充电线了！",
     "deviceDisconnectedNotificationTitle": "您的 Omi 设备已断开连接",
@@ -3079,5 +3079,13 @@
     "syncStatusOnDevice": "等待 Omi",
     "syncStatusDownloadingFromDevice": "正在从 Omi 下载",
     "newestFirst": "最新优先",
-    "noSyncedRecordingsYet": "还没有已同步的录音"
+    "noSyncedRecordingsYet": "还没有已同步的录音",
+    "@lowBatteryAlertBody": {
+        "description": "Body text for low battery notification",
+        "placeholders": {
+            "level": {
+                "type": "int"
+            }
+        }
+    }
 }

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -168,7 +168,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
           final ctx = globalNavigatorKey.currentContext;
           NotificationService.instance.createNotification(
             title: ctx?.l10n.lowBatteryAlertTitle ?? "Low Battery Alert",
-            body: ctx?.l10n.lowBatteryAlertBody ?? "Your device is running low on battery. Time for a recharge! 🔋",
+            body: ctx?.l10n.lowBatteryAlertBody(value) ?? "Your battery is at $value%. Time for a recharge! 🔋",
           );
         } else if (batteryLevel > 20) {
           _hasLowBatteryAlerted = false;


### PR DESCRIPTION
## Summary
- Replace the vague *"Your device is running low on battery. Time for a recharge! 🔋"* notification with one that includes the actual percentage, e.g. *"Your battery is at 15%. Time for a recharge! 🔋"*.
- Adds an `int level` placeholder to `lowBatteryAlertBody` in `app_en.arb` and threads `batteryLevel` through the call site in `device_provider.dart`.
- Translates the new phrasing across all 48 non-English locales and regenerates `app_localizations*.dart`.

## Test plan
- [ ] Let device drain below 20% and confirm the system notification reads *"Your battery is at <N>%. Time for a recharge! 🔋"*.
- [ ] Switch the device locale (e.g. Spanish, French, Japanese, Arabic) and confirm the translated body interpolates the percentage correctly.
- [ ] `flutter gen-l10n` reports zero "untranslated message(s)" warnings.