### PR TITLE
feat(payments): remove PayPal, add 'more methods coming soon' card

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3032,5 +3032,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "المزيد من طرق الدفع قريبًا",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Чакае на Omi",
     "syncStatusDownloadingFromDevice": "Спампоўка з Omi",
     "newestFirst": "Спачатку новыя",
-    "noSyncedRecordingsYet": "Пакуль няма сінхранізаваных запісаў"
+    "noSyncedRecordingsYet": "Пакуль няма сінхранізаваных запісаў",
+    "morePaymentMethodsComingSoon": "Хутка з'явяцца новыя спосабы аплаты",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3034,5 +3034,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Скоро ще има още методи на плащане",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Omi-এ অপেক্ষমাণ",
     "syncStatusDownloadingFromDevice": "Omi থেকে ডাউনলোড হচ্ছে",
     "newestFirst": "নতুনগুলি আগে",
-    "noSyncedRecordingsYet": "এখনও কোনো সিঙ্ক করা রেকর্ডিং নেই"
+    "noSyncedRecordingsYet": "এখনও কোনো সিঙ্ক করা রেকর্ডিং নেই",
+    "morePaymentMethodsComingSoon": "শীঘ্রই আরও পেমেন্ট পদ্ধতি আসছে",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Čeka na Omi",
     "syncStatusDownloadingFromDevice": "Preuzimanje sa Omi",
     "newestFirst": "Prvo najnoviji",
-    "noSyncedRecordingsYet": "Još nema sinhronizovanih snimaka"
+    "noSyncedRecordingsYet": "Još nema sinhronizovanih snimaka",
+    "morePaymentMethodsComingSoon": "Uskoro stižu novi načini plaćanja",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3034,5 +3034,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Aviat hi haurà més mètodes de pagament",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3034,5 +3034,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Brzy přibudou další platební metody",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3074,5 +3074,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Flere betalingsmetoder kommer snart",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3033,5 +3033,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Weitere Zahlungsmethoden in Kürze",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Σύντομα περισσότεροι τρόποι πληρωμής",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11131,5 +11131,9 @@
     "noSyncedRecordingsYet": "No synced recordings yet",
     "@noSyncedRecordingsYet": {
         "description": "Empty-state message when the Synced filter is active but no recording has finished backing up."
+    },
+    "morePaymentMethodsComingSoon": "More payment methods coming soon",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3066,5 +3066,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Próximamente más métodos de pago",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Peagi rohkem makseviise",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "در انتظار Omi",
     "syncStatusDownloadingFromDevice": "در حال دانلود از Omi",
     "newestFirst": "ابتدا جدیدترین‌ها",
-    "noSyncedRecordingsYet": "هنوز ضبط همگام‌سازی‌شده‌ای وجود ندارد"
+    "noSyncedRecordingsYet": "هنوز ضبط همگام‌سازی‌شده‌ای وجود ندارد",
+    "morePaymentMethodsComingSoon": "روش‌های پرداخت بیشتر به‌زودی",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Lisää maksutapoja tulossa pian",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3100,5 +3100,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "D'autres moyens de paiement bientôt disponibles",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "ממתין ב-Omi",
     "syncStatusDownloadingFromDevice": "מוריד מ-Omi",
     "newestFirst": "החדשות ביותר תחילה",
-    "noSyncedRecordingsYet": "אין עדיין הקלטות מסונכרנות"
+    "noSyncedRecordingsYet": "אין עדיין הקלטות מסונכרנות",
+    "morePaymentMethodsComingSoon": "אמצעי תשלום נוספים בקרוב",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3066,5 +3066,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "जल्द ही और भुगतान विकल्प",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Čeka na Omi",
     "syncStatusDownloadingFromDevice": "Preuzimanje s Omi",
     "newestFirst": "Najnovije prvo",
-    "noSyncedRecordingsYet": "Još nema sinkroniziranih snimaka"
+    "noSyncedRecordingsYet": "Još nema sinkroniziranih snimaka",
+    "morePaymentMethodsComingSoon": "Uskoro stižu novi načini plaćanja",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3161,5 +3161,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Hamarosan további fizetési módok",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3107,5 +3107,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Metode pembayaran lainnya segera hadir",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Presto altri metodi di pagamento",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3066,5 +3066,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "他の支払い方法を近日追加予定",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Omi ನಲ್ಲಿ ಕಾಯುತ್ತಿದೆ",
     "syncStatusDownloadingFromDevice": "Omi ಯಿಂದ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ",
     "newestFirst": "ಹೊಸದು ಮೊದಲು",
-    "noSyncedRecordingsYet": "ಇನ್ನೂ ಸಿಂಕ್ ಆದ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳಿಲ್ಲ"
+    "noSyncedRecordingsYet": "ಇನ್ನೂ ಸಿಂಕ್ ಆದ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳಿಲ್ಲ",
+    "morePaymentMethodsComingSoon": "ಶೀಘ್ರದಲ್ಲೇ ಹೆಚ್ಚಿನ ಪಾವತಿ ವಿಧಾನಗಳು",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "더 많은 결제 수단이 곧 추가됩니다",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -17486,6 +17486,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No synced recordings yet'**
   String get noSyncedRecordingsYet;
+
+  /// Placeholder card text shown under available payment methods
+  ///
+  /// In en, this message translates to:
+  /// **'More payment methods coming soon'**
+  String get morePaymentMethodsComingSoon;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9329,4 +9329,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'لا توجد تسجيلات متزامنة بعد';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'المزيد من طرق الدفع قريبًا';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9414,4 +9414,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Пакуль няма сінхранізаваных запісаў';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Хутка з\'явяцца новыя спосабы аплаты';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9419,4 +9419,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Все още няма синхронизирани записи';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Скоро ще има още методи на плащане';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9392,4 +9392,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'এখনও কোনো সিঙ্ক করা রেকর্ডিং নেই';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'শীঘ্রই আরও পেমেন্ট পদ্ধতি আসছে';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9409,4 +9409,7 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Još nema sinhronizovanih snimaka';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Uskoro stižu novi načini plaćanja';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9438,4 +9438,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Encara no hi ha enregistraments sincronitzats';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Aviat hi haurà més mètodes de pagament';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9384,4 +9384,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Zatím žádné synchronizované nahrávky';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Brzy přibudou další platební metody';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9370,4 +9370,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Ingen synkroniserede optagelser endnu';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Flere betalingsmetoder kommer snart';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9461,4 +9461,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Noch keine synchronisierten Aufnahmen';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Weitere Zahlungsmethoden in Kürze';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9449,4 +9449,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Δεν υπάρχουν ακόμα συγχρονισμένες εγγραφές';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Σύντομα περισσότεροι τρόποι πληρωμής';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9380,4 +9380,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'No synced recordings yet';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'More payment methods coming soon';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9405,4 +9405,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Aún no hay grabaciones sincronizadas';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Próximamente más métodos de pago';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9381,4 +9381,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Sünkroonitud salvestisi pole veel';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Peagi rohkem makseviise';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9387,4 +9387,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'هنوز ضبط همگام‌سازی‌شده‌ای وجود ندارد';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'روش‌های پرداخت بیشتر به‌زودی';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9383,4 +9383,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Ei vielä synkronoituja nauhoituksia';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Lisää maksutapoja tulossa pian';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9467,4 +9467,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Aucun enregistrement synchronisé pour l\'instant';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'D\'autres moyens de paiement bientôt disponibles';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9314,4 +9314,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'אין עדיין הקלטות מסונכרנות';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'אמצעי תשלום נוספים בקרוב';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9364,4 +9364,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'अभी तक कोई सिंक की गई रिकॉर्डिंग नहीं';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'जल्द ही और भुगतान विकल्प';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9415,4 +9415,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Još nema sinkroniziranih snimaka';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Uskoro stižu novi načini plaćanja';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9423,4 +9423,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Még nincsenek szinkronizált felvételek';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Hamarosan további fizetési módok';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9392,4 +9392,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Belum ada rekaman yang tersinkronisasi';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Metode pembayaran lainnya segera hadir';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9439,4 +9439,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Nessuna registrazione sincronizzata';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Presto altri metodi di pagamento';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9229,4 +9229,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => '同期済みの録音はまだありません';
+
+  @override
+  String get morePaymentMethodsComingSoon => '他の支払い方法を近日追加予定';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9416,4 +9416,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'ಇನ್ನೂ ಸಿಂಕ್ ಆದ ರೆಕಾರ್ಡಿಂಗ್‌ಗಳಿಲ್ಲ';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'ಶೀಘ್ರದಲ್ಲೇ ಹೆಚ್ಚಿನ ಪಾವತಿ ವಿಧಾನಗಳು';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9231,4 +9231,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => '아직 동기화된 녹음이 없습니다';
+
+  @override
+  String get morePaymentMethodsComingSoon => '더 많은 결제 수단이 곧 추가됩니다';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9397,4 +9397,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Sinchronizuotų įrašų dar nėra';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Netrukus daugiau mokėjimo būdų';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9404,4 +9404,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Vēl nav sinhronizētu ierakstu';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Drīzumā vairāk maksājumu veidu';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9433,4 +9433,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Сè уште нема синхронизирани записи';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Наскоро повеќе начини на плаќање';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9395,4 +9395,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'अद्याप कोणतीही सिंक केलेली रेकॉर्डिंग नाही';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'लवकरच आणखी पेमेंट पद्धती';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9406,4 +9406,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Belum ada rakaman yang disegerakkan';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Lebih banyak kaedah pembayaran akan datang';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9412,4 +9412,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Nog geen gesynchroniseerde opnames';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Meer betaalmethoden binnenkort';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9380,4 +9380,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Ingen synkroniserte opptak ennå';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Flere betalingsmåter kommer snart';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9408,4 +9408,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Brak zsynchronizowanych nagrań';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Więcej metod płatności już wkrótce';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9388,4 +9388,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Ainda não há gravações sincronizadas';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Em breve mais métodos de pagamento';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9429,4 +9429,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Încă nu există înregistrări sincronizate';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'În curând mai multe metode de plată';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9417,4 +9417,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Пока нет синхронизированных записей';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Скоро добавим новые способы оплаты';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9375,4 +9375,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Zatiaľ žiadne synchronizované nahrávky';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Čoskoro ďalšie platobné metódy';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9411,4 +9411,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Sinhroniziranih posnetkov še ni';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Kmalu več načinov plačila';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9397,4 +9397,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Још нема синхронизованих снимака';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Ускоро више начина плаћања';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9388,4 +9388,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Inga synkroniserade inspelningar än';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Fler betalningsmetoder kommer snart';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9452,4 +9452,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'ஒத்திசைக்கப்பட்ட பதிவுகள் இன்னும் இல்லை';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'மேலும் கட்டண முறைகள் விரைவில்';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9433,4 +9433,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'ఇంకా సమకాలీకరించిన రికార్డింగ్‌లు లేవు';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'మరిన్ని చెల్లింపు పద్ధతులు త్వరలో';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9334,4 +9334,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'ยังไม่มีการบันทึกที่ซิงค์แล้ว';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'วิธีการชำระเงินอื่นๆ เร็วๆ นี้';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9469,4 +9469,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Wala pang naka-sync na recording';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Mas maraming paraan ng pagbabayad na malapit nang dumating';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9396,4 +9396,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Henüz senkronize edilmiş kayıt yok';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Daha fazla ödeme yöntemi yakında';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9402,4 +9402,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Синхронізованих записів ще немає';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Незабаром більше способів оплати';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9401,4 +9401,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'ابھی تک کوئی سنک شدہ ریکارڈنگ نہیں';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'مزید ادائیگی کے طریقے جلد آرہے ہیں';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9381,4 +9381,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => 'Chưa có bản ghi nào được đồng bộ';
+
+  @override
+  String get morePaymentMethodsComingSoon => 'Sắp có thêm phương thức thanh toán';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9215,4 +9215,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get noSyncedRecordingsYet => '还没有已同步的录音';
+
+  @override
+  String get morePaymentMethodsComingSoon => '更多支付方式即将推出';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Netrukus daugiau mokėjimo būdų",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Drīzumā vairāk maksājumu veidu",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Чека на Omi",
     "syncStatusDownloadingFromDevice": "Се презема од Omi",
     "newestFirst": "Прво најнови",
-    "noSyncedRecordingsYet": "Сè уште нема синхронизирани записи"
+    "noSyncedRecordingsYet": "Сè уште нема синхронизирани записи",
+    "morePaymentMethodsComingSoon": "Наскоро повеќе начини на плаќање",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Omi वर प्रतीक्षेत",
     "syncStatusDownloadingFromDevice": "Omi वरून डाउनलोड होत आहे",
     "newestFirst": "नवीन आधी",
-    "noSyncedRecordingsYet": "अद्याप कोणतीही सिंक केलेली रेकॉर्डिंग नाही"
+    "noSyncedRecordingsYet": "अद्याप कोणतीही सिंक केलेली रेकॉर्डिंग नाही",
+    "morePaymentMethodsComingSoon": "लवकरच आणखी पेमेंट पद्धती",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Lebih banyak kaedah pembayaran akan datang",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Meer betaalmethoden binnenkort",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Flere betalingsmåter kommer snart",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3100,5 +3100,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Więcej metod płatności już wkrótce",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3101,5 +3101,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Em breve mais métodos de pagamento",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "În curând mai multe metode de plată",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3100,5 +3100,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Скоро добавим новые способы оплаты",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3070,5 +3070,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Čoskoro ďalšie platobné metódy",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Čaka na Omi",
     "syncStatusDownloadingFromDevice": "Prenašanje iz Omi",
     "newestFirst": "Najprej najnovejši",
-    "noSyncedRecordingsYet": "Sinhroniziranih posnetkov še ni"
+    "noSyncedRecordingsYet": "Sinhroniziranih posnetkov še ni",
+    "morePaymentMethodsComingSoon": "Kmalu več načinov plačila",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Чека на Omi",
     "syncStatusDownloadingFromDevice": "Преузимање са Omi",
     "newestFirst": "Прво најновије",
-    "noSyncedRecordingsYet": "Још нема синхронизованих снимака"
+    "noSyncedRecordingsYet": "Још нема синхронизованих снимака",
+    "morePaymentMethodsComingSoon": "Ускоро више начина плаћања",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Fler betalningsmetoder kommer snart",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Omi-இல் காத்திருக்கிறது",
     "syncStatusDownloadingFromDevice": "Omi-இலிருந்து பதிவிறக்கப்படுகிறது",
     "newestFirst": "புதியவை முதலில்",
-    "noSyncedRecordingsYet": "ஒத்திசைக்கப்பட்ட பதிவுகள் இன்னும் இல்லை"
+    "noSyncedRecordingsYet": "ஒத்திசைக்கப்பட்ட பதிவுகள் இன்னும் இல்லை",
+    "morePaymentMethodsComingSoon": "மேலும் கட்டண முறைகள் விரைவில்",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Omi లో వేచి ఉంది",
     "syncStatusDownloadingFromDevice": "Omi నుండి డౌన్‌లోడ్ అవుతోంది",
     "newestFirst": "కొత్తవి మొదట",
-    "noSyncedRecordingsYet": "ఇంకా సమకాలీకరించిన రికార్డింగ్‌లు లేవు"
+    "noSyncedRecordingsYet": "ఇంకా సమకాలీకరించిన రికార్డింగ్‌లు లేవు",
+    "morePaymentMethodsComingSoon": "మరిన్ని చెల్లింపు పద్ధతులు త్వరలో",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "วิธีการชำระเงินอื่นๆ เร็วๆ นี้",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Naghihintay sa Omi",
     "syncStatusDownloadingFromDevice": "Dina-download mula sa Omi",
     "newestFirst": "Pinakabago muna",
-    "noSyncedRecordingsYet": "Wala pang naka-sync na recording"
+    "noSyncedRecordingsYet": "Wala pang naka-sync na recording",
+    "morePaymentMethodsComingSoon": "Mas maraming paraan ng pagbabayad na malapit nang dumating",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3100,5 +3100,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Daha fazla ödeme yöntemi yakında",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3065,5 +3065,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Незабаром більше способів оплати",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10770,5 +10770,9 @@
     "syncStatusOnDevice": "Omi پر منتظر",
     "syncStatusDownloadingFromDevice": "Omi سے ڈاؤن لوڈ ہو رہا ہے",
     "newestFirst": "پہلے نئی ترین",
-    "noSyncedRecordingsYet": "ابھی تک کوئی سنک شدہ ریکارڈنگ نہیں"
+    "noSyncedRecordingsYet": "ابھی تک کوئی سنک شدہ ریکارڈنگ نہیں",
+    "morePaymentMethodsComingSoon": "مزید ادائیگی کے طریقے جلد آرہے ہیں",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
+    }
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3070,5 +3070,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "Sắp có thêm phương thức thanh toán",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3087,5 +3087,9 @@
                 "type": "int"
             }
         }
+    },
+    "morePaymentMethodsComingSoon": "更多支付方式即将推出",
+    "@morePaymentMethodsComingSoon": {
+        "description": "Placeholder card text shown under available payment methods"
     }
 }

--- a/app/lib/pages/payments/payments_page.dart
+++ b/app/lib/pages/payments/payments_page.dart
@@ -5,7 +5,6 @@ import 'package:provider/provider.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 import 'package:omi/pages/payments/payment_method_provider.dart';
-import 'package:omi/pages/payments/paypal_setup_page.dart';
 import 'package:omi/pages/payments/stripe_connect_setup.dart';
 import 'package:omi/pages/payments/widgets/payment_method_card.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -87,7 +86,9 @@ class _PaymentsPageState extends State<PaymentsPage> {
                     const SizedBox(height: 18),
                     Consumer<PaymentMethodProvider>(
                       builder: (context, provider, child) {
-                        final activeMethod = provider.activeMethod;
+                        // PayPal is no longer offered; only treat Stripe as a valid active method.
+                        final activeMethod =
+                            provider.activeMethod == PaymentMethodType.stripe ? provider.activeMethod : null;
                         final hasActiveMethod = activeMethod != null;
 
                         return Column(
@@ -95,7 +96,7 @@ class _PaymentsPageState extends State<PaymentsPage> {
                           children: [
                             if (!hasActiveMethod) ...[_buildInfoCard(), const SizedBox(height: 28)],
                             if (hasActiveMethod) ...[
-                              _buildActiveMethodCard(activeMethod, provider),
+                              _buildActiveMethodCard(provider),
                               const SizedBox(height: 24),
                             ],
                             Text(
@@ -104,6 +105,8 @@ class _PaymentsPageState extends State<PaymentsPage> {
                             ),
                             const SizedBox(height: 16),
                             ..._buildOtherMethodCards(provider, activeMethod),
+                            const SizedBox(height: 12),
+                            _buildComingSoonCard(),
                           ],
                         );
                       },
@@ -118,28 +121,51 @@ class _PaymentsPageState extends State<PaymentsPage> {
     );
   }
 
-  Widget _buildActiveMethodCard(PaymentMethodType method, PaymentMethodProvider provider) {
-    final config = method == PaymentMethodType.stripe
-        ? PaymentMethodConfig.stripe(
-            title: context.l10n.paymentMethodStripe,
-            subtitle: _getPaymentSubtitle(isActive: true, isConnected: true),
-            onManageTap: () {
-              PlatformManager.instance.analytics.paymentMethodSelected(methodName: 'Stripe');
-              routeToPage(context, const StripeConnectSetup());
-            },
-            isActive: true,
-            isConnected: true,
-          )
-        : PaymentMethodConfig.paypal(
-            title: context.l10n.paymentMethodPayPal,
-            subtitle: _getPaymentSubtitle(isActive: true, isConnected: true),
-            onManageTap: () {
-              PlatformManager.instance.analytics.paymentMethodSelected(methodName: 'PayPal');
-              routeToPage(context, const PaypalSetupPage());
-            },
-            isActive: true,
-            isConnected: true,
-          );
+  Widget _buildComingSoonCard() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+      decoration: BoxDecoration(
+        color: const Color(0xFF14141A),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white.withOpacity(0.06), width: 1),
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.04),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(Icons.schedule_outlined, color: Colors.white.withOpacity(0.45), size: 22),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Text(
+              context.l10n.morePaymentMethodsComingSoon,
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.6),
+                fontSize: 15,
+                fontWeight: FontWeight.w400,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActiveMethodCard(PaymentMethodProvider provider) {
+    final config = PaymentMethodConfig.stripe(
+      title: context.l10n.paymentMethodStripe,
+      subtitle: _getPaymentSubtitle(isActive: true, isConnected: true),
+      onManageTap: () {
+        PlatformManager.instance.analytics.paymentMethodSelected(methodName: 'Stripe');
+        routeToPage(context, const StripeConnectSetup());
+      },
+      isActive: true,
+      isConnected: true,
+    );
 
     return PaymentMethodCard(
       icon: config.icon,
@@ -173,24 +199,6 @@ class _PaymentsPageState extends State<PaymentsPage> {
           ),
           true,
         ),
-      if (provider.isPayPalConnected && activeMethod != PaymentMethodType.paypal)
-        (
-          PaymentMethodConfig.paypal(
-            title: context.l10n.paymentMethodPayPal,
-            subtitle: _getPaymentSubtitle(isActive: false, isConnected: true),
-            onManageTap: () {
-              PlatformManager.instance.analytics.track('Manage PayPal');
-              routeToPage(context, const PaypalSetupPage());
-            },
-            onSetActiveTap: () {
-              provider.setActiveMethod(PaymentMethodType.paypal);
-              PlatformManager.instance.analytics.track('Set PayPal as active');
-            },
-            isConnected: true,
-            isActive: false,
-          ),
-          false,
-        ),
       if (!provider.isStripeConnected)
         (
           PaymentMethodConfig.stripe(
@@ -203,19 +211,6 @@ class _PaymentsPageState extends State<PaymentsPage> {
             isConnected: false,
           ),
           true,
-        ),
-      if (!provider.isPayPalConnected)
-        (
-          PaymentMethodConfig.paypal(
-            title: context.l10n.paymentMethodPayPal,
-            subtitle: _getPaymentSubtitle(isActive: false, isConnected: false),
-            onManageTap: () {
-              PlatformManager.instance.analytics.track('Manage PayPal');
-              routeToPage(context, const PaypalSetupPage());
-            },
-            isConnected: false,
-          ),
-          false,
         ),
     ];
 


### PR DESCRIPTION
## Summary
- Remove PayPal from the payment-methods list on the profile settings → Payments page. Only Stripe is offered now.
- If the backend reports PayPal as the active method, the page falls back to the empty/info state instead of rendering a stale PayPal card.
- Add a quiet placeholder card under the available methods reading *"More payment methods coming soon"* so the single-Stripe list doesn't feel sparse.
- Translate the new string across all 48 non-English locales and regenerate `app_localizations*.dart`.

The PayPal backend (`v1/paypal/...`), `PaymentMethodProvider` state, and `PaypalSetupPage` are intentionally left in place — the only thing removed is the settings-page UI surface that exposes them. We can sweep the dead code later if/when we confirm PayPal isn't coming back.

## Test plan
- [x] Open Profile → Payments. Verify only one card (Stripe) appears under *Available payment methods*, followed by the muted *"More payment methods coming soon"* card.
- [x] As a user with no payment method connected, confirm the empty/info card still shows above the available list.
- [ ] As a user whose backend default is PayPal, confirm the active-method card is **not** shown and the empty/info card takes its place.
- [ ] Switch the device locale (e.g. Spanish, French, Japanese, Arabic, Hindi) and confirm the new card text is localized.
- [ ] `flutter gen-l10n` reports zero "untranslated message(s)" warnings.