### PR TITLE
chore(plugins/zapier/omi-zap): remediate form-data critical + lodash CVEs (#7327)

### DIFF
--- a/plugins/zapier/omi-zap/package-lock.json
+++ b/plugins/zapier/omi-zap/package-lock.json
@@ -1819,6 +1819,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
@@ -1963,13 +1978,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -3168,9 +3185,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {

--- a/plugins/zapier/omi-zap/package.json
+++ b/plugins/zapier/omi-zap/package.json
@@ -16,6 +16,10 @@
   "devDependencies": {
     "jest": "^29.6.0"
   },
+  "overrides": {
+    "form-data": "^4.0.4",
+    "lodash": "^4.18.0"
+  },
   "private": true,
   "zapier": {
     "convertedByCLIVersion": "15.11.1"


### PR DESCRIPTION
## Summary
Closes **all 4 open Dependabot alerts** on `plugins/zapier/omi-zap/package-lock.json` (including 1 **critical**) via npm \`overrides\`. No direct dependency changes.

### Overrides
| Package | Before | After | Alerts addressed |
|---|---|---|---|
| `form-data` | 4.0.0 (transitive via `zapier-platform-core`) | **4.0.5** | 1 critical (CVE-2025-7783 — unsafe random boundary) |
| `lodash` | 4.17.21 (transitive via `zapier-platform-core` + `zapier-platform-schema`) | **4.18.1** | 1 high + 2 medium |

`npm audit` post-change: **0 vulnerabilities**.

## Test plan (executed locally)
- [x] Fresh `npm install --legacy-peer-deps` resolves cleanly
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm test` (jest) parity vs origin/main:
  - **`test/triggers/on_memory_created.test.js`** → PASS (both)
  - **`test/creates/create_memory.test.js`** → FAIL on both (pre-existing; the test makes a real HTTP call to `https://based-hardware--plugins-api.modal.run/zapier/action/memories` which returns 404 — unrelated to dep bumps)
- [ ] Confirm Dependabot rescan closes the 4 alerts after merge