### PR TITLE
fix(memories): stop forcing desktop-created memories into the Manual category

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -53,8 +53,14 @@ async def create_memory(
     memory: Memory,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:create")),
 ):
-    memory.category = MemoryCategory.manual
-    memory_db = MemoryDB.from_memory(memory, uid, None, True)
+    # Honor the client-supplied category (the Memory model defaults it to
+    # `interesting`). Only memories the user explicitly typed in arrive as
+    # `manual`; auto-extracted ones (system/interesting) keep their category so
+    # the mobile app files them under "About You"/"Insights" instead of dumping
+    # everything into "Manual". manually_added tracks human entry, so derive it
+    # from the category rather than forcing it True for every API caller.
+    manually_added = memory.category == MemoryCategory.manual
+    memory_db = MemoryDB.from_memory(memory, uid, None, manually_added)
 
     # Build payload outside try so serialization bugs aren't misreported as
     # transient 503s — only the Firestore write should be retryable.
@@ -102,13 +108,15 @@ async def create_memories_batch(
     if not request.memories:
         return BatchMemoriesResponse(memories=[], created_count=0)
 
-    # Hardcode category to manual to match the single-create endpoint. Callers
-    # that need auto-categorization should use the dev API.
+    # Honor each item's category (defaults to `interesting` per the Memory
+    # model). Desktop import/extraction paths send `system`/`interesting` so
+    # they land under "About You"/"Insights"; only user-typed memories send
+    # `manual`. Derive manually_added from the category instead of forcing it.
     memory_dbs: List[MemoryDB] = []
     has_public = False
     for memory in request.memories:
-        memory.category = MemoryCategory.manual
-        memory_db = MemoryDB.from_memory(memory, uid, None, True)
+        manually_added = memory.category == MemoryCategory.manual
+        memory_db = MemoryDB.from_memory(memory, uid, None, manually_added)
         memory_dbs.append(memory_db)
         if memory.visibility == 'public':
             has_public = True

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed memories created on desktop showing up under \"Manual\" on mobile \u2014 they now appear under \"About You\" or \"Insights\" based on their type"
+  ],
   "releases": [
     {
       "version": "0.11.411",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -1451,18 +1451,25 @@ struct CreateMemoryResponse: Codable {
 }
 
 /// One item in a POST /v3/memories/batch payload. Mirrors the `Memory` model
-/// in `backend/models/memories.py` (the server hardcodes category=manual on
-/// batch creation, so we intentionally don't send it).
+/// in `backend/models/memories.py`. The server honors `category`, so batch
+/// imports default to `.system` ("About You") rather than landing in "Manual".
 struct MemoryBatchItem: Encodable {
   let content: String
   let visibility: String
+  let category: String
   let tags: [String]
   let headline: String?
 
-  init(content: String, visibility: String = "private", tags: [String] = [], headline: String? = nil)
-  {
+  init(
+    content: String,
+    visibility: String = "private",
+    category: MemoryCategory = .system,
+    tags: [String] = [],
+    headline: String? = nil
+  ) {
     self.content = content
     self.visibility = visibility
+    self.category = category.rawValue
     self.tags = tags
     self.headline = headline
   }

--- a/desktop/Desktop/Sources/AppleNotesReaderService.swift
+++ b/desktop/Desktop/Sources/AppleNotesReaderService.swift
@@ -168,6 +168,7 @@ actor AppleNotesReaderService {
           _ = try await APIClient.shared.createMemory(
             content: memory,
             visibility: "private",
+            category: .system,
             tags: ["apple_notes", "import", "profile"],
             source: "apple_notes",
             headline: "Apple Notes Insight"
@@ -348,6 +349,7 @@ actor AppleNotesReaderService {
       _ = try await APIClient.shared.createMemory(
         content: content,
         visibility: "private",
+        category: .system,
         tags: ["apple_notes", "import", "note"],
         source: "apple_notes",
         windowTitle: "Apple Notes — \(dateFormatter.string(from: note.modifiedAt))",

--- a/desktop/Desktop/Sources/CalendarReaderService.swift
+++ b/desktop/Desktop/Sources/CalendarReaderService.swift
@@ -239,6 +239,7 @@ actor CalendarReaderService {
           _ = try await APIClient.shared.createMemory(
             content: memory,
             visibility: "private",
+            category: .system,
             tags: ["calendar", "onboarding", "profile"],
             source: "google_calendar",
             headline: "Calendar Profile Insight"
@@ -727,6 +728,7 @@ actor CalendarReaderService {
       _ = try await APIClient.shared.createMemory(
         content: content,
         visibility: "private",
+        category: .system,
         tags: ["calendar", "onboarding", "event"],
         source: "google_calendar",
         headline: event.summary

--- a/desktop/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/Desktop/Sources/GmailReaderService.swift
@@ -310,6 +310,7 @@ actor GmailReaderService {
           _ = try await APIClient.shared.createMemory(
             content: memory,
             visibility: "private",
+            category: .system,
             tags: ["gmail", "onboarding", "profile"],
             source: "gmail",
             headline: "Email Profile Insight"
@@ -982,6 +983,7 @@ actor GmailReaderService {
       _ = try await APIClient.shared.createMemory(
         content: content,
         visibility: "private",
+        category: .system,
         tags: ["gmail", "email"],
         source: "gmail",
         windowTitle: "Gmail — \(dateStr)",

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -695,7 +695,7 @@ class MemoriesViewModel: ObservableObject {
     guard !newMemoryText.isEmpty else { return }
 
     do {
-      _ = try await APIClient.shared.createMemory(content: newMemoryText)
+      _ = try await APIClient.shared.createMemory(content: newMemoryText, category: .manual)
       showingAddMemory = false
       newMemoryText = ""
       await loadMemories()

--- a/desktop/Desktop/Sources/OnboardingMemoryLogImportService.swift
+++ b/desktop/Desktop/Sources/OnboardingMemoryLogImportService.swift
@@ -119,6 +119,7 @@ actor OnboardingMemoryLogImportService {
           _ = try await APIClient.shared.createMemory(
             content: memory,
             visibility: "private",
+            category: .system,
             tags: source.tags,
             source: source.memorySource,
             headline: source.headline

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -328,7 +328,7 @@ actor InsightAssistant: ProactiveAssistant {
             let response = try await APIClient.shared.createMemory(
                 content: insight.insight,
                 visibility: "private",
-                category: .system,
+                category: .interesting,
                 confidence: insight.confidence,
                 sourceApp: insight.sourceApp,
                 contextSummary: insightResult.contextSummary,


### PR DESCRIPTION
## Problem

Memories created on the **desktop** app show up under **"Manual"** on mobile, even though they were auto-extracted (not typed by the user).

**Root cause:** the backend `POST /v3/memories` and `/v3/memories/batch` endpoints unconditionally overwrote the client-supplied `category` with `MemoryCategory.manual` (and forced `manually_added=True`). Mobile buckets memories purely by `category` (`system`→"About You", `interesting`→"Insights", `manual`→"Manual"), so every desktop memory landed in "Manual" regardless of what the desktop sent.

## Fix

**Backend** (`backend/routers/memories.py`)
- Both endpoints now **honor the client-supplied category** (model default stays `interesting`) and derive `manually_added` from whether the category is actually `manual`.

**Desktop** — each source now sends the correct category (the backend now respects it):
- Manual text-box entry (`MemoriesPage`) → `.manual`
- `InsightAssistant` (contextual tips/suggestions) → `.interesting`
- Reader/import services (Apple Notes, Gmail, Calendar, onboarding memory-log import + batch) → `.system` ("About You")
- `MemoryAssistant` / `FocusAssistant` already sent correct categories — untouched
- `MemoryBatchItem` gains a `category` field (defaults to `.system`)

Mobile needs no change — it already routes by `category`. Verified mobile's manual-entry path sends `category: 'manual'` explicitly, so it keeps working.

## Verification
- Desktop builds clean (`xcrun swift build -c debug`)
- Backend syntax-checked + black-formatted
- No backend tests assert the old forced-`manual` behavior

## Note
This only affects **newly created** memories. Existing rows already saved as `manual` need a separate one-off data migration (handled out-of-band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)