### PR TITLE
fix(desktop-rust): bump Docker builder to rust 1.88 — unblocks broken release pipeline

### DIFF
--- a/desktop/Backend-Rust/Dockerfile
+++ b/desktop/Backend-Rust/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for smaller image size
 
 # Build stage
-FROM rust:1.85-slim AS builder
+FROM rust:1.88-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Urgent — desktop release broken since 5/19

The `deploy-desktop-backend` job fails at **"Build and Push Desktop Backend Image"**, which skips both `deploy-desktop-backend-prod` and `tag-release`. **No desktop change has shipped to prod since ~5/18** — including the paywall cost-leak fixes.

## Root cause

Dependabot remediation #7327 pulled in `time@0.3.47` / `time-core@0.1.8` / `time-macros@0.2.27`, which require **rustc 1.88.0**. The Dockerfile pinned `rust:1.85-slim`:

```
error: rustc 1.85.1 is not supported by the following packages:
  time@0.3.47 requires rustc 1.88.0
```

## Fix

`FROM rust:1.85-slim` → `rust:1.88-slim`. Only constraint (no rust-toolchain.toml / Cargo MSRV pin). Local builds pass on 1.93.

## After merge

Desktop release pipeline should go green → tag a version → Codemagic builds + deploys the Rust backend (carrying the paywall fail-closed fix #7416) to Cloud Run prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)