### PR TITLE
fix(desktop): gate menu bar Screen Capture + Mic toggles on paywall

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Fixed memories created on desktop showing up under \"Manual\" on mobile \u2014 they now appear under \"About You\" or \"Insights\" based on their type"
+    "Fixed memories created on desktop showing up under \"Manual\" on mobile \u2014 they now appear under \"About You\" or \"Insights\" based on their type",
+    "Screen Capture and Microphone menu bar toggles now show as off when your trial has expired or you hit your usage limit, and tapping them brings up the upgrade prompt"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -791,12 +791,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Create menu
     let menu = NSMenu()
 
-    // Quick toggles for screen capture and audio recording
+    // Quick toggles for screen capture and audio recording.
+    // When paywalled (trial expired / usage limit hit) both render OFF — the
+    // features can't run, and tapping a toggle surfaces the upgrade popup.
+    let paywalled = UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
     let screenCaptureItem = NSMenuItem()
     let screenCaptureView = makeToggleItemView(
       title: "Screen Capture",
       iconName: "rectangle.dashed.badge.record",
-      isOn: AssistantSettings.shared.screenAnalysisEnabled
+      isOn: !paywalled && AssistantSettings.shared.screenAnalysisEnabled
         && ProactiveAssistantsPlugin.shared.isMonitoring,
       action: #selector(screenCaptureToggled(_:))
     )
@@ -807,7 +810,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     let audioRecordingView = makeToggleItemView(
       title: "Audio Recording",
       iconName: "mic.fill",
-      isOn: AssistantSettings.shared.transcriptionEnabled,
+      isOn: !paywalled && AssistantSettings.shared.transcriptionEnabled,
       action: #selector(audioRecordingToggled(_:))
     )
     audioRecordingItem.view = audioRecordingView
@@ -999,6 +1002,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     AnalyticsManager.shared.settingToggled(setting: "monitoring", enabled: enabled)
 
     if enabled {
+      // Paywall gate: trial expired / usage limit hit. Refuse to enable,
+      // revert the toggle, and surface the same upgrade popup as everywhere else.
+      if UserDefaults.standard.bool(forKey: "desktop_isPaywalled") {
+        sender.state = .off
+        NotificationCenter.default.post(
+          name: .showUsageLimitPopup, object: nil, userInfo: ["reason": "trial_expired"])
+        return
+      }
       if !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
         // No permission — revert toggle and open preferences
         sender.state = .off
@@ -1028,6 +1039,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       action: enabled ? "audio_recording_on" : "audio_recording_off")
     AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
 
+    // Paywall gate: trial expired / usage limit hit. Refuse to enable,
+    // revert the toggle, and surface the same upgrade popup as everywhere else.
+    if enabled && UserDefaults.standard.bool(forKey: "desktop_isPaywalled") {
+      sender.state = .off
+      NotificationCenter.default.post(
+        name: .showUsageLimitPopup, object: nil, userInfo: ["reason": "trial_expired"])
+      return
+    }
+
     AssistantSettings.shared.transcriptionEnabled = enabled
     // Request the main view to start/stop transcription (needs AppState)
     NotificationCenter.default.post(
@@ -1041,9 +1061,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   func menuWillOpen(_ menu: NSMenu) {
     log("AppDelegate: [MENUBAR] Menu opened by user")
     AnalyticsManager.shared.menuBarOpened()
-    // Refresh toggle states to match current runtime state
-    screenCaptureSwitch?.state = ProactiveAssistantsPlugin.shared.isMonitoring ? .on : .off
-    audioRecordingSwitch?.state = AssistantSettings.shared.transcriptionEnabled ? .on : .off
+    // Refresh toggle states to match current runtime state. When paywalled,
+    // force both OFF — the features can't run until the user upgrades.
+    let paywalled = UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+    screenCaptureSwitch?.state =
+      (!paywalled && ProactiveAssistantsPlugin.shared.isMonitoring) ? .on : .off
+    audioRecordingSwitch?.state =
+      (!paywalled && AssistantSettings.shared.transcriptionEnabled) ? .on : .off
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {


### PR DESCRIPTION
## Problem

On an expired-trial / usage-limited account, the menu bar **Screen Capture** and **Microphone** toggles still rendered green (ON). Tapping them either silently flipped the persisted setting (mic) or relied on the async monitoring failure to revert (screen capture).

## Fix

The paywall infra already exists (`desktop_isPaywalled`, the upgrade popup, and hard-stops in `startMonitoring`/`startTranscription`). This wires the menu bar toggle UI into it (`OmiApp.swift`):

1. **Initial render** — both toggles compute `isOn` with a `!paywalled &&` guard, so they show OFF when the trial is expired / limit hit.
2. **`menuWillOpen`** — re-syncs both switches to OFF whenever the menu reopens while paywalled.
3. **Toggle handlers** — `screenCaptureToggled` / `audioRecordingToggled` check `desktop_isPaywalled` up front: revert the switch to OFF and post `.showUsageLimitPopup` (the same notification every other paywalled path uses). Also fixes a latent bug where the mic toggle set `transcriptionEnabled = true` before any block, leaving it stuck green.

## Verification

Built + ran locally as a named bundle (`omi-trial-toggle`) with the paywalled flag set:
- Both toggles rendered **OFF** in the menu.
- Clicking **Screen Capture** → reverted to OFF, popup notification posted.
- Clicking **Audio Recording** → reverted to OFF, `transcriptionEnabled` stayed false (old bug gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)