### PR TITLE
desktop: local BYOK always exempts from paywall (fixes blocked chat + recordings)

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -156,8 +156,25 @@ class AppState: ObservableObject {
   ///
   /// Use at the entry point of every toggle/start function that drives a
   /// $-cost path (transcription, screen analysis, proactive monitoring, etc).
+  /// Single source of truth for "should the UI block $-cost features". A BYOK
+  /// user (all four keys configured locally) is never paywalled, regardless of
+  /// the persisted `desktop_isPaywalled` flag, which can lag behind BYOK
+  /// activation. Use this anywhere that only has UserDefaults access.
+  nonisolated static var isPaywalledEffective: Bool {
+    !APIKeyService.isByokActive && UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+  }
+
   @discardableResult
   func blockIfPaywalled(reason: String = "trial_expired") -> Bool {
+    // BYOK users are never paywalled. If the user has all four BYOK keys
+    // configured locally, every backend request carries them and the server
+    // exempts the user — so the client must not block capture either, even if
+    // a stale `isPaywalled` flag is still set (e.g. trial expired *before*
+    // they added keys, and the backend heartbeat hasn't refreshed yet).
+    if APIKeyService.isByokActive {
+      if isPaywalled { isPaywalled = false }
+      return false
+    }
     guard isPaywalled else { return false }
     NotificationCenter.default.post(
       name: .showUsageLimitPopup,
@@ -179,7 +196,12 @@ class AppState: ObservableObject {
       do {
         let metadata = try await APIClient.shared.getTrialMetadata()
         self.trialMetadata = metadata
-        if metadata.trialExpired && !self.isPaywalled {
+        // Local BYOK always wins — never re-block a user who has all four keys
+        // configured, regardless of what the (possibly heartbeat-lagged)
+        // backend trial state says.
+        if APIKeyService.isByokActive {
+          if self.isPaywalled { self.isPaywalled = false }
+        } else if metadata.trialExpired && !self.isPaywalled {
           self.isPaywalled = true
         } else if !metadata.trialExpired && self.isPaywalled {
           self.isPaywalled = false
@@ -354,8 +376,11 @@ class AppState: ObservableObject {
     AppState.current = self
 
     // Restore paywall flag from prior session so toggles + auto-restart respect
-    // it before any backend call has a chance to refresh state.
-    self.isPaywalled = UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+    // it before any backend call has a chance to refresh state — but a BYOK
+    // user (all four keys configured) is never paywalled, so clear any stale
+    // flag immediately on launch.
+    self.isPaywalled =
+      !APIKeyService.isByokActive && UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
 
     // Resolve beta/stable before loading backend URLs so beta releases use dev services.
     AppBuild.prepareUpdateChannelForBackendRouting()
@@ -2656,6 +2681,14 @@ class AppState: ObservableObject {
     case "freemium_threshold_reached":
       let remaining = event.raw["remaining_seconds"] as? Int ?? 0
       log("Transcription: Freemium threshold reached, \(remaining)s remaining")
+      // BYOK users must never be paywalled. The backend exempts them, but a
+      // heartbeat/Firestore lag can briefly let this event slip through right
+      // after activation — ignore it so we don't kill a BYOK user's capture.
+      if APIKeyService.isByokActive {
+        log("Paywall: ignoring freemium threshold — BYOK active locally")
+        if isPaywalled { isPaywalled = false }
+        break
+      }
       triggerUsageLimitPopup(reason: "transcription")
       // Hard-stop client-side capture so the mic LED and screen-recording
       // indicator actually turn off. Without this, popup shows but the user

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -63,6 +63,12 @@ final class FloatingBarUsageLimiter: ObservableObject {
     }
 
     var isLimitReached: Bool {
+        // BYOK users pay their own LLM bill and are never limited. Honor local
+        // BYOK state so a heartbeat-lagged server quota (allowed=false right
+        // after activation) can't block chat for a fully-configured BYOK user.
+        if APIKeyService.isByokActive {
+            return false
+        }
         guard let quota = serverQuota else {
             // No server data yet — allow the query (server will enforce).
             return false

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -794,7 +794,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Quick toggles for screen capture and audio recording.
     // When paywalled (trial expired / usage limit hit) both render OFF — the
     // features can't run, and tapping a toggle surfaces the upgrade popup.
-    let paywalled = UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+    let paywalled = AppState.isPaywalledEffective
     let screenCaptureItem = NSMenuItem()
     let screenCaptureView = makeToggleItemView(
       title: "Screen Capture",
@@ -1004,7 +1004,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     if enabled {
       // Paywall gate: trial expired / usage limit hit. Refuse to enable,
       // revert the toggle, and surface the same upgrade popup as everywhere else.
-      if UserDefaults.standard.bool(forKey: "desktop_isPaywalled") {
+      if AppState.isPaywalledEffective {
         sender.state = .off
         NotificationCenter.default.post(
           name: .showUsageLimitPopup, object: nil, userInfo: ["reason": "trial_expired"])
@@ -1041,7 +1041,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // Paywall gate: trial expired / usage limit hit. Refuse to enable,
     // revert the toggle, and surface the same upgrade popup as everywhere else.
-    if enabled && UserDefaults.standard.bool(forKey: "desktop_isPaywalled") {
+    if enabled && AppState.isPaywalledEffective {
       sender.state = .off
       NotificationCenter.default.post(
         name: .showUsageLimitPopup, object: nil, userInfo: ["reason": "trial_expired"])
@@ -1063,7 +1063,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     AnalyticsManager.shared.menuBarOpened()
     // Refresh toggle states to match current runtime state. When paywalled,
     // force both OFF — the features can't run until the user upgrades.
-    let paywalled = UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+    let paywalled = AppState.isPaywalledEffective
     screenCaptureSwitch?.state =
       (!paywalled && ProactiveAssistantsPlugin.shared.isMonitoring) ? .on : .off
     audioRecordingSwitch?.state =

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -244,7 +244,9 @@ public class ProactiveAssistantsPlugin: NSObject {
         // when the user is past their trial. `AppState` writes
         // `desktop_isPaywalled` to UserDefaults whenever it flips so other
         // singletons can synchronously check. Toggle UI also gates on this.
-        if UserDefaults.standard.bool(forKey: "desktop_isPaywalled") {
+        // BYOK users (all four keys configured locally) are never paywalled,
+        // so they bypass this gate even if the flag is transiently stale.
+        if !APIKeyService.isByokActive && UserDefaults.standard.bool(forKey: "desktop_isPaywalled") {
             log("Paywall: refusing startMonitoring (trial expired)")
             NotificationCenter.default.post(
                 name: .showUsageLimitPopup,

--- a/desktop/Desktop/Tests/BYOKPaywallTests.swift
+++ b/desktop/Desktop/Tests/BYOKPaywallTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Verifies the BYOK-vs-paywall precedence fix: a user with all four BYOK
+/// keys configured locally is never paywalled, regardless of the persisted
+/// `desktop_isPaywalled` flag.
+@MainActor
+final class BYOKPaywallTests: XCTestCase {
+    private let paywallKey = "desktop_isPaywalled"
+
+    private func setAllBYOKKeys() {
+        for p in BYOKProvider.allCases {
+            UserDefaults.standard.set("sk-test-\(p.rawValue)", forKey: p.storageKey)
+        }
+    }
+
+    private func clearAllBYOKKeys() {
+        for p in BYOKProvider.allCases {
+            UserDefaults.standard.removeObject(forKey: p.storageKey)
+        }
+    }
+
+    override func tearDown() {
+        clearAllBYOKKeys()
+        UserDefaults.standard.removeObject(forKey: paywallKey)
+        super.tearDown()
+    }
+
+    func testByokActiveRequiresAllFourKeys() {
+        clearAllBYOKKeys()
+        XCTAssertFalse(APIKeyService.isByokActive)
+
+        // Three of four → still not active
+        for p in BYOKProvider.allCases.dropLast() {
+            UserDefaults.standard.set("k", forKey: p.storageKey)
+        }
+        XCTAssertFalse(APIKeyService.isByokActive, "3/4 keys must not count as BYOK")
+
+        // All four → active
+        setAllBYOKKeys()
+        XCTAssertTrue(APIKeyService.isByokActive)
+    }
+
+    func testPaywallFlagSuppressedWhenByokActive() {
+        // The exact bug: trial-expired flag set, then user adds all 4 BYOK keys.
+        UserDefaults.standard.set(true, forKey: paywallKey)
+        setAllBYOKKeys()
+        XCTAssertFalse(
+            AppState.isPaywalledEffective,
+            "BYOK-active user must NOT be paywalled even with the flag set")
+    }
+
+    func testPaywallFlagAppliesWhenNotByok() {
+        UserDefaults.standard.set(true, forKey: paywallKey)
+        clearAllBYOKKeys()
+        XCTAssertTrue(
+            AppState.isPaywalledEffective,
+            "Non-BYOK trial-expired user stays paywalled")
+    }
+
+    func testNotPaywalledWhenFlagUnset() {
+        UserDefaults.standard.set(false, forKey: paywallKey)
+        clearAllBYOKKeys()
+        XCTAssertFalse(AppState.isPaywalledEffective)
+    }
+
+    func testRemovingOneByokKeyReappliesPaywall() {
+        UserDefaults.standard.set(true, forKey: paywallKey)
+        setAllBYOKKeys()
+        XCTAssertFalse(AppState.isPaywalledEffective)
+
+        // User clears their Deepgram key → no longer fully BYOK → paywall returns.
+        UserDefaults.standard.removeObject(forKey: BYOKProvider.deepgram.storageKey)
+        XCTAssertTrue(AppState.isPaywalledEffective)
+    }
+}


### PR DESCRIPTION
## Bug (reported on Discord)

Users who configured BYOK (confirmed in UI) still got "You've hit your monthly limit" and **couldn't reactivate recordings or chat**.

## Root cause

The client treated the sticky `isPaywalled` flag as authoritative above local BYOK state. It cleared in only one narrow Settings flow; a later `fetchTrialMetadata()` poll or app relaunch re-set it → re-blocked fully-configured BYOK users.

## Fix — local BYOK (`APIKeyService.isByokActive`, all 4 keys) wins at every gate

- `blockIfPaywalled()` → false for BYOK (clears stale flag)
- `fetchTrialMetadata()` → never re-sets flag for BYOK
- `freemium_threshold_reached` → ignored for BYOK (no mic/screen kill)
- init restore → clears stale persisted flag on launch
- new `AppState.isPaywalledEffective` (flag AND !BYOK) → replaces raw `desktop_isPaywalled` reads in OmiApp's 4 menu-bar gates + `ProactiveAssistantsPlugin.startMonitoring`
- `FloatingBarUsageLimiter.isLimitReached` → false for BYOK (fixes floating-bar chat block on heartbeat-lagged quota)

## Scope

Backend already exempts BYOK (request-level all-4-headers escape hatch + Firestore `byok.active`, 7-day heartbeat). This aligns the client UI gates with the backend.

## Test plan

- [x] clean release build (arm64) passes
- [ ] BYOK user: recordings + chat work, no popup
- [ ] trial-expired non-BYOK user: still paywalled (unchanged)
- [ ] paid user: unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)