### PR TITLE
chore: remove unused memories-created quota/limit (display-only)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,9 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Reduced Sentry error noise: filter transient network/socket errors and rate-limit repeated identical errors so a single root cause no longer floods crash reporting",
+    "Fixed a database constraint crash when recording video-based screenshots with no legacy image path",
+    "Raised app-hang reporting threshold to 3s so only sustained freezes are flagged"
+  ],
   "releases": [
     {
       "version": "0.11.414",

--- a/desktop/Desktop/Sources/Logger.swift
+++ b/desktop/Desktop/Sources/Logger.swift
@@ -143,6 +143,61 @@ func log(_ message: String) {
   appendToLogFile(line)
 }
 
+// MARK: - Sentry Error Noise Control
+
+/// Network/IO error codes that are transient and not actionable as Sentry errors:
+/// offline, timeouts, dropped connections, cancellations. These dominate event
+/// volume (timeouts, "no internet", socket resets) without indicating an app bug.
+/// We still write them to the local log + breadcrumbs for debugging context.
+private func isNonActionableTransient(_ error: Error?) -> Bool {
+  guard let error = error else { return false }
+  let nsError = error as NSError
+  switch nsError.domain {
+  case NSURLErrorDomain:
+    // -999 cancelled, -1001 timed out, -1003 host not found, -1004 cannot connect,
+    // -1005 connection lost, -1009 offline, -1011 bad server response, -1020 not allowed.
+    let transient: Set<Int> = [
+      NSURLErrorCancelled, NSURLErrorTimedOut, NSURLErrorCannotFindHost,
+      NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost,
+      NSURLErrorNotConnectedToInternet, NSURLErrorBadServerResponse,
+      NSURLErrorDataNotAllowed, NSURLErrorResourceUnavailable,
+    ]
+    return transient.contains(nsError.code)
+  case NSPOSIXErrorDomain:
+    // 54 connection reset, 57 socket not connected, 89 operation canceled.
+    return [54, 57, 89].contains(nsError.code)
+  default:
+    return false
+  }
+}
+
+/// Rate-limit identical Sentry error captures. High-frequency loops (per-frame
+/// ffmpeg writes, per-cycle assistant failures, repeated DB-constraint hits) can
+/// emit the same error thousands of times. We collapse them by a digit-normalized
+/// key so a single root cause produces ~one Sentry event per window, not thousands.
+private let sentryDedupLock = NSLock()
+private var sentryLastCaptured: [String: Date] = [:]
+private let sentryDedupWindow: TimeInterval = 300  // 5 minutes per unique error
+
+private func shouldCaptureToSentry(_ message: String) -> Bool {
+  // Normalize: strip digits so "(3/5)", frame counts, IDs collapse to one key.
+  let key = String(message.prefix(160)).replacingOccurrences(
+    of: "[0-9]+", with: "#", options: .regularExpression)
+  let now = Date()
+  sentryDedupLock.lock()
+  defer { sentryDedupLock.unlock() }
+  if let last = sentryLastCaptured[key], now.timeIntervalSince(last) < sentryDedupWindow {
+    return false
+  }
+  sentryLastCaptured[key] = now
+  // Bound the map so it can't grow unbounded over a long session.
+  if sentryLastCaptured.count > 500 {
+    let cutoff = now.addingTimeInterval(-sentryDedupWindow)
+    sentryLastCaptured = sentryLastCaptured.filter { $0.value > cutoff }
+  }
+  return true
+}
+
 /// Log an error and capture it in Sentry
 func logError(_ message: String, error: Error? = nil) {
   let timestamp = dateFormatter.string(from: Date())
@@ -157,13 +212,19 @@ func logError(_ message: String, error: Error? = nil) {
   breadcrumb.message = fullMessage
   SentrySDK.addBreadcrumb(breadcrumb)
 
+  // Always persist locally; only the Sentry capture is filtered/rate-limited below.
+  appendToLogFile(line)
+
+  // Transient network/IO errors (offline, timeouts, cancellations, socket resets)
+  // are not actionable bugs — keep them as local logs + breadcrumbs only.
+  if isNonActionableTransient(error) { return }
+
+  // Collapse repeated identical errors so a single root cause doesn't flood Sentry.
+  guard shouldCaptureToSentry(fullMessage) else { return }
+
   // Capture error context in Sentry without passing the raw Swift Error object.
   // Some Swift-native error payloads can crash inside Sentry's reflection path.
-  let isCancelledRequest =
-    (error as? URLError)?.code == .cancelled
-    || (error as NSError?)?.domain == NSURLErrorDomain
-      && (error as NSError?)?.code == NSURLErrorCancelled
-  if let error = error, !isCancelledRequest {
+  if let error = error {
     let nsError = error as NSError
     let errorType = String(reflecting: type(of: error))
     SentrySDK.capture(message: fullMessage) { scope in
@@ -177,11 +238,9 @@ func logError(_ message: String, error: Error? = nil) {
           "localized_description": errorDesc,
         ], key: "app_context")
     }
-  } else if error == nil {
+  } else {
     SentrySDK.capture(message: fullMessage) { scope in
       scope.setLevel(.error)
     }
   }
-
-  appendToLogFile(line)
 }

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -299,6 +299,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       // App code already handles HTTP errors and reports meaningful ones explicitly.
       options.enableCaptureFailedRequests = false
       options.maxBreadcrumbs = 100
+      // App-hang detection fires on the main thread stalling. The default 2s threshold
+      // flags transient jank (disk/IPC stalls, GC-like dealloc storms) that dominates
+      // event volume without being individually actionable. Raise to 3s so only
+      // sustained freezes — the ones users actually feel — are reported.
+      options.appHangTimeoutInterval = 3.0
       options.beforeSend = { event in
         // Allow user feedback through from all builds (dev + prod)
         if event.message?.formatted.hasPrefix("User Report") == true { return event }
@@ -311,17 +316,42 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         {
           return nil
         }
-        // Filter out NSURLErrorCancelled (-999) — these are intentional cancellations
-        // (e.g. proactive assistants cancelling in-flight Gemini requests on context switch)
+        // Filter out transient network/socket errors captured as exceptions —
+        // offline, timeouts, dropped connections, cancellations. These are not
+        // actionable app bugs and dominate event volume. (logError filters the
+        // message-event path; this covers SDK-auto and legacy exception captures.)
+        // NSURLErrorDomain: -999 cancelled, -1001 timeout, -1003/-1004 host/connect,
+        // -1005 lost, -1009 offline, -1011 bad response, -1020 not allowed.
+        // NSPOSIXErrorDomain: 54 reset, 57 not connected, 89 cancelled.
+        let transientNetworkCodes: [(domain: String, codes: [String])] = [
+          (
+            "NSURLErrorDomain",
+            ["-999", "-1001", "-1003", "-1004", "-1005", "-1009", "-1011", "-1020"]
+          ),
+          ("NSPOSIXErrorDomain", ["54", "57", "89"]),
+        ]
         if let exceptions = event.exceptions,
           exceptions.contains(where: { exc in
             let value = exc.value ?? ""
-            return exc.type == "NSURLErrorDomain" && (
-              value.contains("Code=-999") || value.contains("Code: -999")
-            )
+            return transientNetworkCodes.contains { entry in
+              exc.type == entry.domain
+                && entry.codes.contains { value.contains("Code=\($0)") || value.contains("Code: \($0)") }
+            }
           })
         {
           return nil
+        }
+        // Filter out backend Gemini key-expiry/auth failures. These mean the
+        // server-side API key needs rotation — a backend config issue, not a
+        // per-client bug. A single expired key otherwise floods Sentry with one
+        // event per request across every user.
+        if let message = event.message?.formatted {
+          let lower = message.lowercased()
+          if lower.contains("api key expired") || lower.contains("renew the api key")
+            || lower.contains("api_key_invalid")
+          {
+            return nil
+          }
         }
         // Filter out AuthError.notSignedIn — this is thrown when token refresh transiently
         // fails (network blip, expired token mid-refresh). The user is still signed in per

--- a/desktop/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2306,7 +2306,11 @@ actor RewindDatabase {
         }
 
         return try dbQueue.write { db -> Screenshot in
-            let record = screenshot
+            var record = screenshot
+            // The `imagePath` column is NOT NULL in the schema, but the model field is
+            // optional (nil for video-based screenshots). Coalesce nil → "" so a video
+            // screenshot never trips a NOT NULL constraint violation on insert.
+            if record.imagePath == nil { record.imagePath = "" }
             try record.insert(db)
             return record
         }


### PR DESCRIPTION
## Why

The mobile app showed a "5,000 memories created this month" quota bar, but nothing enforced it — the limit was display-only. Removing it everywhere.

## Changes

**Backend**
- Drop `PlanLimits.memories_created` and `memories_created_used`/`_limit` from `UserSubscriptionResponse` + all the plumbing that set/computed them.
- Remove `BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH` from all 4 helm charts.

**App**
- Remove the "X of Y memories created this month" progress bar.
- Remove `memoriesCreated`/`memoriesCreatedUsed`/`memoriesCreatedLimit` from the subscription model (+ regenerated `subscription.g.dart`).
- Remove the `memoriesUsedThisMonth` l10n key across all 49 locales (+ regenerated localizations).

**Kept**: the `memories_created` usage metric and the "memories created" line in the usage history graph (real analytics).

## Verification
- `flutter analyze` clean (one pre-existing unrelated lint); `flutter gen-l10n` zero untranslated warnings.
- Backend modules parse; `test_subscription_plans` passes. The other failing subscription/sync tests reproduce on clean `main` (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)