### PR TITLE
chore: remove unused memories-created quota/limit (display-only)

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} من {limit} دقيقة مستخدمة هذا الشهر",
     "wordsUsedThisMonth": "{used} من {limit} كلمة مستخدمة هذا الشهر",
     "insightsUsedThisMonth": "{used} من {limit} رؤية تم اكتسابها هذا الشهر",
-    "memoriesUsedThisMonth": "{used} من {limit} ذكرى تم إنشاؤها هذا الشهر",
     "visibility": "الظهور",
     "visibilitySubtitle": "تحكم في المحادثات التي تظهر في قائمتك",
     "showShortConversations": "إظهار المحادثات القصيرة",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} з {limit} ўспаміны створаны гэты месяц",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "Рыштатнасць",
     "visibilitySubtitle": "Кантраляйце, якія размовы з'яўляюцца ў вашым спісе",
     "showShortConversations": "Паказаць коротка размовы",

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} от {limit} мин използвани този месец",
     "wordsUsedThisMonth": "{used} от {limit} думи използвани този месец",
     "insightsUsedThisMonth": "{used} от {limit} прозрения получени този месец",
-    "memoriesUsedThisMonth": "{used} от {limit} спомена създадени този месец",
     "visibility": "Видимост",
     "visibilitySubtitle": "Контролирайте кои разговори се появяват във вашия списък",
     "showShortConversations": "Показвай кратки разговори",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "এই মাসে {limit} স্মৃতির মধ্যে {used} তৈরি হয়েছে",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "দৃশ্যমানতা",
     "visibilitySubtitle": "নিয়ন্ত্রণ করুন কোন কথোপকথনগুলি আপনার তালিকায় উপস্থিত হয়",
     "showShortConversations": "সংক্ষিপ্ত কথোপকথন দেখান",

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} od {limit} uspomene kreirane ovaj mesec",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "Vidljivost",
     "visibilitySubtitle": "Kontrolišite koji se razgovori pojavljuju na vašoj listi",
     "showShortConversations": "Prikaži kratke razgovore",

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} de {limit} min utilitzats aquest mes",
     "wordsUsedThisMonth": "{used} de {limit} paraules utilitzades aquest mes",
     "insightsUsedThisMonth": "{used} de {limit} informacions obtingudes aquest mes",
-    "memoriesUsedThisMonth": "{used} de {limit} records creats aquest mes",
     "visibility": "Visibilitat",
     "visibilitySubtitle": "Controleu quines converses apareixen a la vostra llista",
     "showShortConversations": "Mostrar converses curtes",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "Tento měsíc využito {used} z {limit} min",
     "wordsUsedThisMonth": "Tento měsíc pochopeno {used} z {limit} slov",
     "insightsUsedThisMonth": "Tento měsíc získáno {used} z {limit} přehledů",
-    "memoriesUsedThisMonth": "Tento měsíc vytvořeno {used} z {limit} vzpomínek",
     "visibility": "Viditelnost",
     "visibilitySubtitle": "Kontrolujte, které konverzace se zobrazují ve vašem seznamu",
     "showShortConversations": "Zobrazit krátké konverzace",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} af {limit} min brugt denne måned",
     "wordsUsedThisMonth": "{used} af {limit} ord brugt denne måned",
     "insightsUsedThisMonth": "{used} af {limit} indsigter opnået denne måned",
-    "memoriesUsedThisMonth": "{used} af {limit} minder oprettet denne måned",
     "visibility": "Synlighed",
     "visibilitySubtitle": "Styr hvilke samtaler der vises i din liste",
     "showShortConversations": "Vis korte samtaler",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -305,7 +305,6 @@
     "minsUsedThisMonth": "{used} von {limit} Min. diesen Monat genutzt",
     "wordsUsedThisMonth": "{used} von {limit} Wörtern diesen Monat genutzt",
     "insightsUsedThisMonth": "{used} von {limit} Erkenntnissen diesen Monat gewonnen",
-    "memoriesUsedThisMonth": "{used} von {limit} Erinnerungen diesen Monat erstellt",
     "visibility": "Sichtbarkeit",
     "visibilitySubtitle": "Steuern Sie, welche Unterhaltungen in Ihrer Liste erscheinen",
     "showShortConversations": "Kurze Unterhaltungen anzeigen",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} από {limit} λεπτά χρησιμοποιήθηκαν αυτόν τον μήνα",
     "wordsUsedThisMonth": "{used} από {limit} λέξεις χρησιμοποιήθηκαν αυτόν τον μήνα",
     "insightsUsedThisMonth": "{used} από {limit} πληροφορίες αποκτήθηκαν αυτόν τον μήνα",
-    "memoriesUsedThisMonth": "{used} από {limit} αναμνήσεις δημιουργήθηκαν αυτόν τον μήνα",
     "visibility": "Ορατότητα",
     "visibilitySubtitle": "Ελέγξτε ποιες συνομιλίες εμφανίζονται στη λίστα σας",
     "showShortConversations": "Εμφάνιση Σύντομων Συνομιλιών",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1166,17 +1166,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} of {limit} memories created this month",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "Visibility",
     "visibilitySubtitle": "Control which conversations appear in your list",
     "showShortConversations": "Show Short Conversations",

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -305,7 +305,6 @@
     "minsUsedThisMonth": "{used} de {limit} mins usados este mes",
     "wordsUsedThisMonth": "{used} de {limit} palabras usadas este mes",
     "insightsUsedThisMonth": "{used} de {limit} insights obtenidos este mes",
-    "memoriesUsedThisMonth": "{used} de {limit} recuerdos hechos este mes",
     "visibility": "Visibilidad",
     "visibilitySubtitle": "Controla qué conversaciones aparecen en tu lista",
     "showShortConversations": "Mostrar conversaciones cortas",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used}/{limit} min kasutatud sel kuul",
     "wordsUsedThisMonth": "{used}/{limit} sõna kasutatud sel kuul",
     "insightsUsedThisMonth": "{used}/{limit} ülevaadet saadud sel kuul",
-    "memoriesUsedThisMonth": "{used}/{limit} mälestust loodud sel kuul",
     "visibility": "Nähtavus",
     "visibilitySubtitle": "Kontrollige, millised vestlused teie loendis kuvatakse",
     "showShortConversations": "Kuva lühikesed vestlused",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} از {limit} یادداشت این ماه ایجاد‌شده است",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "دید",
     "visibilitySubtitle": "کنترل کنید کدام گفتگوها در لیست شما نمایش داده شوند",
     "showShortConversations": "نمایش گفتگوهای کوتاه",

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used}/{limit} min käytetty tässä kuussa",
     "wordsUsedThisMonth": "{used}/{limit} sanaa käytetty tässä kuussa",
     "insightsUsedThisMonth": "{used}/{limit} näkemystä saavutettu tässä kuussa",
-    "memoriesUsedThisMonth": "{used}/{limit} muistoa luotu tässä kuussa",
     "visibility": "Näkyvyys",
     "visibilitySubtitle": "Hallitse mitä keskusteluja näkyy luettelossasi",
     "showShortConversations": "Näytä lyhyet keskustelut",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} sur {limit} min utilisées ce mois-ci",
     "wordsUsedThisMonth": "{used} sur {limit} mots utilisés ce mois-ci",
     "insightsUsedThisMonth": "{used} sur {limit} aperçus obtenus ce mois-ci",
-    "memoriesUsedThisMonth": "{used} sur {limit} mémoires créées ce mois-ci",
     "visibility": "Visibilité",
     "visibilitySubtitle": "Contrôlez quelles conversations apparaissent dans votre liste",
     "showShortConversations": "Afficher les conversations courtes",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} מתוך {limit} זיכרונות שנוצרו החודש",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "יכולת הראות",
     "visibilitySubtitle": "שלוט באילו שיחות מופיעות ברשימה שלך",
     "showShortConversations": "הצג שיחות קצרות",

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -305,7 +305,6 @@
     "minsUsedThisMonth": "इस महीने {used}/{limit} मिनट उपयोग किए गए",
     "wordsUsedThisMonth": "इस महीने {used}/{limit} शब्द उपयोग किए गए",
     "insightsUsedThisMonth": "इस महीने {used}/{limit} अंतर्दृष्टि प्राप्त कीं",
-    "memoriesUsedThisMonth": "इस महीने {used}/{limit} यादें बनाईं",
     "visibility": "दृश्यता",
     "visibilitySubtitle": "नियंत्रित करें कि आपकी सूची में कौन सी बातचीत दिखाई दे",
     "showShortConversations": "छोटी बातचीत दिखाएं",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} od {limit} uspomena kreirano ovaj mjesec",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "Vidljivost",
     "visibilitySubtitle": "Kontroliraj koji razgovori se pojavljuju u tvojoj listi",
     "showShortConversations": "Prikaži kratke razgovore",

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} / {limit} perc felhasználva ebben a hónapban",
     "wordsUsedThisMonth": "{used} / {limit} szó felhasználva ebben a hónapban",
     "insightsUsedThisMonth": "{used} / {limit} betekintés nyerve ebben a hónapban",
-    "memoriesUsedThisMonth": "{used} / {limit} emlék létrehozva ebben a hónapban",
     "visibility": "Láthatóság",
     "visibilitySubtitle": "Szabályozd, mely beszélgetések jelenjenek meg a listában",
     "showShortConversations": "Rövid beszélgetések megjelenítése",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} dari {limit} menit terpakai bulan ini",
     "wordsUsedThisMonth": "{used} dari {limit} kata terpakai bulan ini",
     "insightsUsedThisMonth": "{used} dari {limit} wawasan diperoleh bulan ini",
-    "memoriesUsedThisMonth": "{used} dari {limit} memori dibuat bulan ini",
     "visibility": "Visibilitas",
     "visibilitySubtitle": "Kontrol percakapan mana yang muncul di daftar Anda",
     "showShortConversations": "Tampilkan Percakapan Pendek",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} di {limit} min utilizzati questo mese",
     "wordsUsedThisMonth": "{used} di {limit} parole utilizzate questo mese",
     "insightsUsedThisMonth": "{used} di {limit} insight ottenuti questo mese",
-    "memoriesUsedThisMonth": "{used} di {limit} ricordi creati questo mese",
     "visibility": "Visibilità",
     "visibilitySubtitle": "Controlla quali conversazioni appaiono nella tua lista",
     "showShortConversations": "Mostra Conversazioni Brevi",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -305,7 +305,6 @@
     "minsUsedThisMonth": "今月 {limit}分中{used}分使用済み",
     "wordsUsedThisMonth": "今月 {limit}語中{used}語使用済み",
     "insightsUsedThisMonth": "今月 {limit}個中{used}個のインサイト取得済み",
-    "memoriesUsedThisMonth": "今月 {limit}個中{used}個の記憶作成済み",
     "visibility": "表示設定",
     "visibilitySubtitle": "リストに表示する会話を管理します",
     "showShortConversations": "短い会話を表示",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} of {limit} ಸ್ಮೃತಿಗಳು ಈ ತಿಂಗಳು ರಚಿತ",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "ಗೋಚರತೆ",
     "visibilitySubtitle": "ನಿಮ್ಮ ಪಟ್ಟಿಯಲ್ಲಿ ಯಾವ ಸಂವಾದ ಕಾಣಿಸಬೇಕೆ ತಿ ನಿಯಂತ್ರಿಸಿ",
     "showShortConversations": "ಸಂಕ್ಷಿಪ್ತ ಸಂವಾದ ತೋರಿಸಿ",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "이번 달 {limit}분 중 {used}분 사용",
     "wordsUsedThisMonth": "이번 달 {limit}단어 중 {used}단어 사용",
     "insightsUsedThisMonth": "이번 달 {limit}개 중 {used}개의 인사이트 획득",
-    "memoriesUsedThisMonth": "이번 달 {limit}개 중 {used}개의 기억 생성",
     "visibility": "공개 설정",
     "visibilitySubtitle": "목록에 표시할 대화 제어",
     "showShortConversations": "짧은 대화 표시",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2007,12 +2007,6 @@ abstract class AppLocalizations {
   /// **'{used} of {limit} insights gained this month'**
   String insightsUsedThisMonth(String used, String limit);
 
-  /// No description provided for @memoriesUsedThisMonth.
-  ///
-  /// In en, this message translates to:
-  /// **'{used} of {limit} memories created this month'**
-  String memoriesUsedThisMonth(String used, String limit);
-
   /// Label for memory visibility selection section
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -958,11 +958,6 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used من $limit ذكرى تم إنشاؤها هذا الشهر';
-  }
-
-  @override
   String get visibility => 'الظهور';
 
   @override

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -965,11 +965,6 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used з $limit ўспаміны створаны гэты месяц';
-  }
-
-  @override
   String get visibility => 'Рыштатнасць';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -967,11 +967,6 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used от $limit спомена създадени този месец';
-  }
-
-  @override
   String get visibility => 'Видимост';
 
   @override

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -964,11 +964,6 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'এই মাসে $limit স্মৃতির মধ্যে $used তৈরি হয়েছে';
-  }
-
-  @override
   String get visibility => 'দৃশ্যমানতা';
 
   @override

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -964,11 +964,6 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used od $limit uspomene kreirane ovaj mesec';
-  }
-
-  @override
   String get visibility => 'Vidljivost';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -968,11 +968,6 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used de $limit records creats aquest mes';
-  }
-
-  @override
   String get visibility => 'Visibilitat';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -964,11 +964,6 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'Tento měsíc vytvořeno $used z $limit vzpomínek';
-  }
-
-  @override
   String get visibility => 'Viditelnost';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -964,11 +964,6 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used af $limit minder oprettet denne måned';
-  }
-
-  @override
   String get visibility => 'Synlighed';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -970,11 +970,6 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used von $limit Erinnerungen diesen Monat erstellt';
-  }
-
-  @override
   String get visibility => 'Sichtbarkeit';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -969,11 +969,6 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used από $limit αναμνήσεις δημιουργήθηκαν αυτόν τον μήνα';
-  }
-
-  @override
   String get visibility => 'Ορατότητα';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -962,11 +962,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used of $limit memories created this month';
-  }
-
-  @override
   String get visibility => 'Visibility';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -963,11 +963,6 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used de $limit recuerdos hechos este mes';
-  }
-
-  @override
   String get visibility => 'Visibilidad';
 
   @override
@@ -8191,56 +8186,56 @@ class AppLocalizationsEs extends AppLocalizations {
   String get phoneCallsWithOmi => 'Llamadas con Omi';
 
   @override
-  String get phoneCallsSubtitle => 'Haz llamadas con transcripcion en tiempo real';
+  String get phoneCallsSubtitle => 'Haz llamadas con transcripción en tiempo real';
 
   @override
-  String get phoneSetupStep1Title => 'Verifica tu numero de telefono';
+  String get phoneSetupStep1Title => 'Verifica tu número de teléfono';
 
   @override
   String get phoneSetupStep1Subtitle => 'Te llamaremos para confirmar que es tuyo';
 
   @override
-  String get phoneSetupStep2Title => 'Ingresa un codigo de verificacion';
+  String get phoneSetupStep2Title => 'Ingresa un código de verificación';
 
   @override
-  String get phoneSetupStep2Subtitle => 'Un codigo corto que ingresaras en la llamada';
+  String get phoneSetupStep2Subtitle => 'Un código corto que ingresarás en la llamada';
 
   @override
   String get phoneSetupStep3Title => 'Comienza a llamar a tus contactos';
 
   @override
-  String get phoneSetupStep3Subtitle => 'Con transcripcion en vivo integrada';
+  String get phoneSetupStep3Subtitle => 'Con transcripción en vivo integrada';
 
   @override
   String get phoneGetStarted => 'Comenzar';
 
   @override
   String get callRecordingConsentDisclaimer =>
-      'La grabacion de llamadas puede requerir consentimiento en tu jurisdiccion';
+      'La grabación de llamadas puede requerir consentimiento en tu jurisdicción';
 
   @override
-  String get enterYourNumber => 'Ingresa tu numero';
+  String get enterYourNumber => 'Ingresa tu número';
 
   @override
-  String get phoneNumberCallerIdHint => 'Una vez verificado, este sera tu identificador de llamada';
+  String get phoneNumberCallerIdHint => 'Una vez verificado, este será tu identificador de llamada';
 
   @override
-  String get phoneNumberHint => 'Numero de telefono';
+  String get phoneNumberHint => 'Número de teléfono';
 
   @override
-  String get failedToStartVerification => 'No se pudo iniciar la verificacion';
+  String get failedToStartVerification => 'No se pudo iniciar la verificación';
 
   @override
   String get phoneContinue => 'Continuar';
 
   @override
-  String get verifyYourNumber => 'Verifica tu numero';
+  String get verifyYourNumber => 'Verifica tu número';
 
   @override
   String get answerTheCallFrom => 'Contesta la llamada de';
 
   @override
-  String get onTheCallEnterThisCode => 'En la llamada, ingresa este codigo';
+  String get onTheCallEnterThisCode => 'En la llamada, ingresa este código';
 
   @override
   String get followTheVoiceInstructions => 'Sigue las instrucciones de voz';
@@ -8264,7 +8259,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get phoneTryAgain => 'Intentar de nuevo';
 
   @override
-  String get phonePageTitle => 'Telefono';
+  String get phonePageTitle => 'Teléfono';
 
   @override
   String get phoneContactsTab => 'Contactos';
@@ -8285,7 +8280,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get phoneNoContactsFound => 'No se encontraron contactos';
 
   @override
-  String get phoneEnterNumber => 'Ingresa numero';
+  String get phoneEnterNumber => 'Ingresa número';
 
   @override
   String get failedToStartCall => 'No se pudo iniciar la llamada';
@@ -8303,7 +8298,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get callStateFailed => 'Llamada fallida';
 
   @override
-  String get transcriptPlaceholder => 'La transcripcion aparecera aqui...';
+  String get transcriptPlaceholder => 'La transcripción aparecerá aquí...';
 
   @override
   String get phoneUnmute => 'Activar sonido';
@@ -8318,7 +8313,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get phoneEndCall => 'Finalizar';
 
   @override
-  String get phoneCallSettingsTitle => 'Configuracion de llamadas';
+  String get phoneCallSettingsTitle => 'Configuración de llamadas';
 
   @override
   String get showPhoneCallButtonTitle => 'Mostrar botón de llamada';
@@ -8327,13 +8322,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showPhoneCallButtonDesc => 'Mostrar el botón de llamada telefónica en la pantalla de inicio';
 
   @override
-  String get yourVerifiedNumbers => 'Tus numeros verificados';
+  String get yourVerifiedNumbers => 'Tus números verificados';
 
   @override
-  String get verifiedNumbersDescription => 'Cuando llames a alguien, veran este numero en su telefono';
+  String get verifiedNumbersDescription => 'Cuando llames a alguien, verán este número en su teléfono';
 
   @override
-  String get noVerifiedNumbers => 'Sin numeros verificados';
+  String get noVerifiedNumbers => 'Sin números verificados';
 
   @override
   String deletePhoneNumberConfirm(String phoneNumber) {
@@ -8341,7 +8336,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get deletePhoneNumberWarning => 'Tendras que verificar de nuevo para hacer llamadas';
+  String get deletePhoneNumberWarning => 'Tendrás que verificar de nuevo para hacer llamadas';
 
   @override
   String get phoneDeleteButton => 'Eliminar';
@@ -8373,13 +8368,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get callAlreadyInProgress => 'Ya hay una llamada en curso';
 
   @override
-  String get failedToGetCallToken => 'No se pudo obtener el token. Verifica tu numero primero.';
+  String get failedToGetCallToken => 'No se pudo obtener el token. Verifica tu número primero.';
 
   @override
   String get failedToInitializeCallService => 'No se pudo inicializar el servicio de llamadas';
 
   @override
-  String get speakerLabelYou => 'Tu';
+  String get speakerLabelYou => 'Tú';
 
   @override
   String get speakerLabelUnknown => 'Desconocido';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -965,11 +965,6 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used/$limit mälestust loodud sel kuul';
-  }
-
-  @override
   String get visibility => 'Nähtavus';
 
   @override

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -965,11 +965,6 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used از $limit یادداشت این ماه ایجاد‌شده است';
-  }
-
-  @override
   String get visibility => 'دید';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -962,11 +962,6 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used/$limit muistoa luotu tässä kuussa';
-  }
-
-  @override
   String get visibility => 'Näkyvyys';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -968,11 +968,6 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used sur $limit mémoires créées ce mois-ci';
-  }
-
-  @override
   String get visibility => 'Visibilité';
 
   @override

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -960,11 +960,6 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used מתוך $limit זיכרונות שנוצרו החודש';
-  }
-
-  @override
   String get visibility => 'יכולת הראות';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -961,11 +961,6 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'इस महीने $used/$limit यादें बनाईं';
-  }
-
-  @override
   String get visibility => 'दृश्यता';
 
   @override

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -965,11 +965,6 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used od $limit uspomena kreirano ovaj mjesec';
-  }
-
-  @override
   String get visibility => 'Vidljivost';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -969,11 +969,6 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used / $limit emlék létrehozva ebben a hónapban';
-  }
-
-  @override
   String get visibility => 'Láthatóság';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -965,11 +965,6 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used dari $limit memori dibuat bulan ini';
-  }
-
-  @override
   String get visibility => 'Visibilitas';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -967,11 +967,6 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used di $limit ricordi creati questo mese';
-  }
-
-  @override
   String get visibility => 'Visibilità';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -952,11 +952,6 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '今月 $limit個中$used個の記憶作成済み';
-  }
-
-  @override
   String get visibility => '表示設定';
 
   @override

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -965,11 +965,6 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used of $limit ಸ್ಮೃತಿಗಳು ಈ ತಿಂಗಳು ರಚಿತ';
-  }
-
-  @override
   String get visibility => 'ಗೋಚರತೆ';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -951,11 +951,6 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '이번 달 $limit개 중 $used개의 기억 생성';
-  }
-
-  @override
   String get visibility => '공개 설정';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -964,11 +964,6 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'Šį mėnesį sukurta $used iš $limit prisiminimų';
-  }
-
-  @override
   String get visibility => 'Matomumas';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -965,11 +965,6 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used no $limit atmiņām izveidots šomēnes';
-  }
-
-  @override
   String get visibility => 'Redzamība';
 
   @override

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -966,11 +966,6 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used од $limit спомени креирани овој месец';
-  }
-
-  @override
   String get visibility => 'Видливост';
 
   @override

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -965,11 +965,6 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'या महिन्यात $used of $limit स्मृती तयार केली';
-  }
-
-  @override
   String get visibility => 'दृश्यमानता';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -965,11 +965,6 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used daripada $limit ingatan dicipta bulan ini';
-  }
-
-  @override
   String get visibility => 'Keterlihatan';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -966,11 +966,6 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used van $limit herinneringen aangemaakt deze maand';
-  }
-
-  @override
   String get visibility => 'Zichtbaarheid';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -965,11 +965,6 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used av $limit minner opprettet denne måneden';
-  }
-
-  @override
   String get visibility => 'Synlighet';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -965,11 +965,6 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'Utworzono $used z $limit wspomnień w tym miesiącu';
-  }
-
-  @override
   String get visibility => 'Widoczność';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -962,11 +962,6 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used de $limit memórias este mês';
-  }
-
-  @override
   String get visibility => 'Visibilidade';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -968,11 +968,6 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used din $limit amintiri create luna aceasta';
-  }
-
-  @override
   String get visibility => 'Vizibilitate';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -966,11 +966,6 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'Создано $used из $limit воспоминаний в этом месяце';
-  }
-
-  @override
   String get visibility => 'Видимость';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -967,11 +967,6 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used z $limit spomienok vytvorených tento mesiac';
-  }
-
-  @override
   String get visibility => 'Viditeľnosť';
 
   @override

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -963,11 +963,6 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used od $limit spominov ustvarjenih ta mesec';
-  }
-
-  @override
   String get visibility => 'Vidljivost';
 
   @override

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -963,11 +963,6 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used од $limit успомена направљено овог месеца';
-  }
-
-  @override
   String get visibility => 'Видљивост';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -966,11 +966,6 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used av $limit minnen skapade denna månad';
-  }
-
-  @override
   String get visibility => 'Synlighet';
 
   @override

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -968,11 +968,6 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used / $limit நினைவுகள் இந்த மாதம் உருவாக்கப்பட்டுள்ளன';
-  }
-
-  @override
   String get visibility => 'দৃশ்যমानতা';
 
   @override

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -966,11 +966,6 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used యొక్క $limit జ్ఞాపకాలు ఈ నెలలో సృష్టించబడ్డాయి';
-  }
-
-  @override
   String get visibility => 'దృశ్యమానత';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -961,11 +961,6 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'สร้างความทรงจำ $used จาก $limit รายการในเดือนนี้';
-  }
-
-  @override
   String get visibility => 'การมองเห็น';
 
   @override

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -967,11 +967,6 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used ng $limit alaala na nabuo sa buwan na ito';
-  }
-
-  @override
   String get visibility => 'Visibility';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -966,11 +966,6 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'Bu ay $limit anıdan $used oluşturuldu';
-  }
-
-  @override
   String get visibility => 'Görünürlük';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -966,11 +966,6 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '$used з $limit спогадів створено цього місяця';
-  }
-
-  @override
   String get visibility => 'Видимість';
 
   @override

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -965,11 +965,6 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'اس ماہ $used کے $limit یادیں بنائی گئیں';
-  }
-
-  @override
   String get visibility => 'نمائش';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -966,11 +966,6 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return 'Đã tạo $used trong số $limit ký ức trong tháng này';
-  }
-
-  @override
   String get visibility => 'Hiển thị';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -950,11 +950,6 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String memoriesUsedThisMonth(String used, String limit) {
-    return '本月创建 $used/$limit 条记忆';
-  }
-
-  @override
   String get visibility => '可见性';
 
   @override

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -1226,7 +1226,6 @@
     "membersAndCounting": "8000+ narių ir skaičius auga.",
     "memories": "Prisiminimai",
     "memoriesCount": "{count} atminčių",
-    "memoriesUsedThisMonth": "Šį mėnesį sukurta {used} iš {limit} prisiminimų",
     "memorizingYourVoice": "Įsimenamas jūsų balsas...",
     "memoryClearedSuccess": "Omi atmintis apie jus išvalyta",
     "memoryContentHint": "Mėgstu valgyti ledus...",

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} no {limit} min izmantots šomēnes",
     "wordsUsedThisMonth": "{used} no {limit} vārdiem izmantots šomēnes",
     "insightsUsedThisMonth": "{used} no {limit} ieskatiem iegūts šomēnes",
-    "memoriesUsedThisMonth": "{used} no {limit} atmiņām izveidots šomēnes",
     "visibility": "Redzamība",
     "visibilitySubtitle": "Kontrolējiet, kuras sarunas parādās jūsu sarakstā",
     "showShortConversations": "Rādīt īsas sarunas",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} од {limit} спомени креирани овој месец",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "Видливост",
     "visibilitySubtitle": "Контролирај кои разговори се појавуваат во твоја листа",
     "showShortConversations": "Покажи кратки разговори",

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "या महिन्यात {used} of {limit} स्मृती तयार केली",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "दृश्यमानता",
     "visibilitySubtitle": "कोण संभाषण आपल्या सूचीमध्ये दिसतात हे नियंत्रण करा",
     "showShortConversations": "लघु संभाषण दाखवा",

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} daripada {limit} minit digunakan bulan ini",
     "wordsUsedThisMonth": "{used} daripada {limit} perkataan digunakan bulan ini",
     "insightsUsedThisMonth": "{used} daripada {limit} wawasan diperoleh bulan ini",
-    "memoriesUsedThisMonth": "{used} daripada {limit} ingatan dicipta bulan ini",
     "visibility": "Keterlihatan",
     "visibilitySubtitle": "Kawal perbualan mana yang muncul dalam senarai anda",
     "showShortConversations": "Tunjukkan Perbualan Pendek",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} van {limit} min gebruikt deze maand",
     "wordsUsedThisMonth": "{used} van {limit} woorden gebruikt deze maand",
     "insightsUsedThisMonth": "{used} van {limit} inzichten verkregen deze maand",
-    "memoriesUsedThisMonth": "{used} van {limit} herinneringen aangemaakt deze maand",
     "visibility": "Zichtbaarheid",
     "visibilitySubtitle": "Bepaal welke gesprekken in je lijst verschijnen",
     "showShortConversations": "Korte gesprekken tonen",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} av {limit} min brukt denne måneden",
     "wordsUsedThisMonth": "{used} av {limit} ord brukt denne måneden",
     "insightsUsedThisMonth": "{used} av {limit} innsikter fått denne måneden",
-    "memoriesUsedThisMonth": "{used} av {limit} minner opprettet denne måneden",
     "visibility": "Synlighet",
     "visibilitySubtitle": "Kontroller hvilke samtaler som vises i listen din",
     "showShortConversations": "Vis korte samtaler",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "Wykorzystano {used} z {limit} min w tym miesiącu",
     "wordsUsedThisMonth": "Wykorzystano {used} z {limit} słów w tym miesiącu",
     "insightsUsedThisMonth": "Uzyskano {used} z {limit} spostrzeżeń w tym miesiącu",
-    "memoriesUsedThisMonth": "Utworzono {used} z {limit} wspomnień w tym miesiącu",
     "visibility": "Widoczność",
     "visibilitySubtitle": "Kontroluj, które rozmowy pojawiają się na Twojej liście",
     "showShortConversations": "Pokaż krótkie rozmowy",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -305,7 +305,6 @@
     "minsUsedThisMonth": "{used} de {limit} mins usados este mês",
     "wordsUsedThisMonth": "{used} de {limit} palavras usadas este mês",
     "insightsUsedThisMonth": "{used} de {limit} insights este mês",
-    "memoriesUsedThisMonth": "{used} de {limit} memórias este mês",
     "visibility": "Visibilidade",
     "visibilitySubtitle": "Controle quais conversas aparecem na sua lista",
     "showShortConversations": "Mostrar conversas curtas",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} din {limit} minute utilizate luna aceasta",
     "wordsUsedThisMonth": "{used} din {limit} cuvinte utilizate luna aceasta",
     "insightsUsedThisMonth": "{used} din {limit} perspective obținute luna aceasta",
-    "memoriesUsedThisMonth": "{used} din {limit} amintiri create luna aceasta",
     "visibility": "Vizibilitate",
     "visibilitySubtitle": "Controlează care conversații apar în lista ta",
     "showShortConversations": "Afișează conversații scurte",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "Использовано {used} из {limit} минут в этом месяце",
     "wordsUsedThisMonth": "Использовано {used} из {limit} слов в этом месяце",
     "insightsUsedThisMonth": "Получено {used} из {limit} инсайтов в этом месяце",
-    "memoriesUsedThisMonth": "Создано {used} из {limit} воспоминаний в этом месяце",
     "visibility": "Видимость",
     "visibilitySubtitle": "Контролируйте, какие разговоры появляются в вашем списке",
     "showShortConversations": "Показывать короткие разговоры",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} z {limit} min použitých tento mesiac",
     "wordsUsedThisMonth": "{used} z {limit} slov použitých tento mesiac",
     "insightsUsedThisMonth": "{used} z {limit} postrehov získaných tento mesiac",
-    "memoriesUsedThisMonth": "{used} z {limit} spomienok vytvorených tento mesiac",
     "visibility": "Viditeľnosť",
     "visibilitySubtitle": "Kontrolujte, ktoré konverzácie sa zobrazia vo vašom zozname",
     "showShortConversations": "Zobraziť krátke konverzácie",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} od {limit} spominov ustvarjenih ta mesec",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "Vidljivost",
     "visibilitySubtitle": "Nadzor, kateri pogovori se pojavljajo na vaši seznamu",
     "showShortConversations": "Prikaži kratke pogovore",

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} од {limit} успомена направљено овог месеца",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "Видљивост",
     "visibilitySubtitle": "Контролиши који разговори се приказују у твојој листи",
     "showShortConversations": "Прикажи кратке разговоре",

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} av {limit} min använt denna månad",
     "wordsUsedThisMonth": "{used} av {limit} ord använt denna månad",
     "insightsUsedThisMonth": "{used} av {limit} insikter vunna denna månad",
-    "memoriesUsedThisMonth": "{used} av {limit} minnen skapade denna månad",
     "visibility": "Synlighet",
     "visibilitySubtitle": "Kontrollera vilka konversationer som visas i din lista",
     "showShortConversations": "Visa korta konversationer",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} / {limit} நினைவுகள் இந்த மாதம் உருவாக்கப்பட்டுள்ளன",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "দৃশ்যমानতা",
     "visibilitySubtitle": "உங்கள் பட்டியலில் எந்த உரையாடல்கள் தோன்றுகிறது என்பதைக் கட்டுப்படுத்தவும்",
     "showShortConversations": "குறு உரையாடல்களைக் காட்டவும்",

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} యొక్క {limit} జ్ఞాపకాలు ఈ నెలలో సృష్టించబడ్డాయి",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "దృశ్యమానత",
     "visibilitySubtitle": "ఎటువంటి సంభాషణలు మీ జాబితాలో కనిపించాలో నియంత్రించండి",
     "showShortConversations": "చిన్న సంభాషణలను చూపండి",

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "ใช้ไป {used} จาก {limit} นาทีในเดือนนี้",
     "wordsUsedThisMonth": "ใช้ไป {used} จาก {limit} คำในเดือนนี้",
     "insightsUsedThisMonth": "ได้รับข้อมูลเชิงลึก {used} จาก {limit} รายการในเดือนนี้",
-    "memoriesUsedThisMonth": "สร้างความทรงจำ {used} จาก {limit} รายการในเดือนนี้",
     "visibility": "การมองเห็น",
     "visibilitySubtitle": "ควบคุมว่าบทสนทนาใดจะปรากฏในรายการของคุณ",
     "showShortConversations": "แสดงบทสนทนาสั้น",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "{used} ng {limit} alaala na nabuo sa buwan na ito",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "Visibility",
     "visibilitySubtitle": "Kontrolin kung aling mga pag-uusap ang lilitaw sa iyong lista",
     "showShortConversations": "Ipakita ang Short Conversations",

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "Bu ay {limit} dakikadan {used} kullanıldı",
     "wordsUsedThisMonth": "Bu ay {limit} kelimeden {used} kullanıldı",
     "insightsUsedThisMonth": "Bu ay {limit} içgörüden {used} elde edildi",
-    "memoriesUsedThisMonth": "Bu ay {limit} anıdan {used} oluşturuldu",
     "visibility": "Görünürlük",
     "visibilitySubtitle": "Listenizde hangi konuşmaların görüneceğini kontrol edin",
     "showShortConversations": "Kısa Konuşmaları Göster",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "{used} з {limit} хв використано цього місяця",
     "wordsUsedThisMonth": "{used} з {limit} слів використано цього місяця",
     "insightsUsedThisMonth": "{used} з {limit} insights отримано цього місяця",
-    "memoriesUsedThisMonth": "{used} з {limit} спогадів створено цього місяця",
     "visibility": "Видимість",
     "visibilitySubtitle": "Керуйте тим, які розмови відображаються у вашому списку",
     "showShortConversations": "Показувати короткі розмови",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -1160,17 +1160,6 @@
             }
         }
     },
-    "memoriesUsedThisMonth": "اس ماہ {used} کے {limit} یادیں بنائی گئیں",
-    "@memoriesUsedThisMonth": {
-        "placeholders": {
-            "used": {
-                "type": "String"
-            },
-            "limit": {
-                "type": "String"
-            }
-        }
-    },
     "visibility": "نمائش",
     "visibilitySubtitle": "کنٹرول کریں کہ کون سی بات چیتیں آپ کی فہرست میں نظر آتی ہیں",
     "showShortConversations": "مختصر بات چیتیں دکھائیں",

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -303,7 +303,6 @@
     "minsUsedThisMonth": "Đã sử dụng {used} trong số {limit} phút trong tháng này",
     "wordsUsedThisMonth": "Đã sử dụng {used} trong số {limit} từ trong tháng này",
     "insightsUsedThisMonth": "Đã thu được {used} trong số {limit} thông tin chi tiết trong tháng này",
-    "memoriesUsedThisMonth": "Đã tạo {used} trong số {limit} ký ức trong tháng này",
     "visibility": "Hiển thị",
     "visibilitySubtitle": "Kiểm soát cuộc trò chuyện nào xuất hiện trong danh sách của bạn",
     "showShortConversations": "Hiển thị cuộc trò chuyện ngắn",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -305,7 +305,6 @@
     "minsUsedThisMonth": "本月已用 {used}/{limit} 分钟",
     "wordsUsedThisMonth": "本月已用 {used}/{limit} 单词",
     "insightsUsedThisMonth": "本月获得 {used}/{limit} 条见解",
-    "memoriesUsedThisMonth": "本月创建 {used}/{limit} 条记忆",
     "visibility": "可见性",
     "visibilitySubtitle": "控制哪些对话显示在列表中",
     "showShortConversations": "显示简短对话",

--- a/app/lib/models/subscription.dart
+++ b/app/lib/models/subscription.dart
@@ -11,7 +11,6 @@ class PlanLimits {
   final int? transcriptionSeconds;
   final int? wordsTranscribed;
   final int? insightsGained;
-  final int? memoriesCreated;
   final int? chatQuestionsPerMonth;
   final double? chatCostUsdPerMonth;
 
@@ -19,7 +18,6 @@ class PlanLimits {
     this.transcriptionSeconds,
     this.wordsTranscribed,
     this.insightsGained,
-    this.memoriesCreated,
     this.chatQuestionsPerMonth,
     this.chatCostUsdPerMonth,
   });
@@ -128,8 +126,6 @@ class UserSubscriptionResponse {
   final int wordsTranscribedLimit;
   final int insightsGainedUsed;
   final int insightsGainedLimit;
-  final int memoriesCreatedUsed;
-  final int memoriesCreatedLimit;
   @JsonKey(defaultValue: [])
   final List<SubscriptionPlan> availablePlans;
   @JsonKey(defaultValue: true)
@@ -153,8 +149,6 @@ class UserSubscriptionResponse {
     required this.wordsTranscribedLimit,
     required this.insightsGainedUsed,
     required this.insightsGainedLimit,
-    required this.memoriesCreatedUsed,
-    required this.memoriesCreatedLimit,
     this.availablePlans = const [],
     this.showSubscriptionUi = true,
     this.chatQuotaUsed = 0.0,

--- a/app/lib/models/subscription.g.dart
+++ b/app/lib/models/subscription.g.dart
@@ -10,7 +10,6 @@ PlanLimits _$PlanLimitsFromJson(Map<String, dynamic> json) => PlanLimits(
       transcriptionSeconds: (json['transcription_seconds'] as num?)?.toInt(),
       wordsTranscribed: (json['words_transcribed'] as num?)?.toInt(),
       insightsGained: (json['insights_gained'] as num?)?.toInt(),
-      memoriesCreated: (json['memories_created'] as num?)?.toInt(),
       chatQuestionsPerMonth:
           (json['chat_questions_per_month'] as num?)?.toInt(),
       chatCostUsdPerMonth:
@@ -22,7 +21,6 @@ Map<String, dynamic> _$PlanLimitsToJson(PlanLimits instance) =>
       'transcription_seconds': instance.transcriptionSeconds,
       'words_transcribed': instance.wordsTranscribed,
       'insights_gained': instance.insightsGained,
-      'memories_created': instance.memoriesCreated,
       'chat_questions_per_month': instance.chatQuestionsPerMonth,
       'chat_cost_usd_per_month': instance.chatCostUsdPerMonth,
     };
@@ -151,8 +149,6 @@ UserSubscriptionResponse _$UserSubscriptionResponseFromJson(
       wordsTranscribedLimit: (json['words_transcribed_limit'] as num).toInt(),
       insightsGainedUsed: (json['insights_gained_used'] as num).toInt(),
       insightsGainedLimit: (json['insights_gained_limit'] as num).toInt(),
-      memoriesCreatedUsed: (json['memories_created_used'] as num).toInt(),
-      memoriesCreatedLimit: (json['memories_created_limit'] as num).toInt(),
       availablePlans: (json['available_plans'] as List<dynamic>?)
               ?.map((e) => SubscriptionPlan.fromJson(e as Map<String, dynamic>))
               .toList() ??
@@ -179,8 +175,6 @@ Map<String, dynamic> _$UserSubscriptionResponseToJson(
       'words_transcribed_limit': instance.wordsTranscribedLimit,
       'insights_gained_used': instance.insightsGainedUsed,
       'insights_gained_limit': instance.insightsGainedLimit,
-      'memories_created_used': instance.memoriesCreatedUsed,
-      'memories_created_limit': instance.memoriesCreatedLimit,
       'available_plans': instance.availablePlans,
       'show_subscription_ui': instance.showSubscriptionUi,
       'chat_quota_used': instance.chatQuotaUsed,

--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -1282,36 +1282,6 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
                 },
               ),
             ],
-            if (icon == FontAwesomeIcons.brain &&
-                subscription != null &&
-                subscription.subscription.plan == PlanType.basic &&
-                subscription.memoriesCreatedLimit > 0) ...[
-              const SizedBox(height: 16),
-              Builder(
-                builder: (context) {
-                  final used = subscription.memoriesCreatedUsed;
-                  final limit = subscription.memoriesCreatedLimit;
-                  final percentage = (limit > 0) ? (used / limit).clamp(0.0, 1.0) : 0.0;
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        context.l10n.memoriesUsedThisMonth(numberFormatter.format(used), numberFormatter.format(limit)),
-                        style: TextStyle(fontSize: 12, color: Colors.grey.shade400),
-                      ),
-                      const SizedBox(height: 8),
-                      LinearProgressIndicator(
-                        value: percentage,
-                        backgroundColor: Colors.grey.shade700,
-                        valueColor: AlwaysStoppedAnimation<Color>(color),
-                        minHeight: 4,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                    ],
-                  );
-                },
-              ),
-            ],
           ],
         ),
       ),

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -235,8 +235,6 @@ env:
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH
     value: "0"
-  - name: BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH
-    value: "0"
   - name: STRIPE_UNLIMITED_MONTHLY_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvwIddzR902"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -262,8 +262,6 @@ env:
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH
     value: "0"
-  - name: BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH
-    value: "0"
   - name: STRIPE_UNLIMITED_MONTHLY_PRICE_ID
     value: "price_1RtJPm1F8wnoWYvwhVJ38kLb"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -225,8 +225,6 @@ env:
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH
     value: "0"
-  - name: BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH
-    value: "0"
   - name: STRIPE_UNLIMITED_MONTHLY_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvwIddzR902"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -257,8 +257,6 @@ env:
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH
     value: "0"
-  - name: BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH
-    value: "0"
   - name: STRIPE_UNLIMITED_MONTHLY_PRICE_ID
     value: "price_1RtJPm1F8wnoWYvwhVJ38kLb"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -35,7 +35,6 @@ class PlanLimits(BaseModel):
     transcription_seconds: Optional[int] = None
     words_transcribed: Optional[int] = None
     insights_gained: Optional[int] = None
-    memories_created: Optional[int] = None
     # Chat caps. Exactly one of these is set per plan: `free` and `unlimited`
     # (displayed as "Plus") cap by question count; `architect` caps by cost_usd.
     chat_questions_per_month: Optional[int] = None
@@ -122,8 +121,6 @@ class UserSubscriptionResponse(BaseModel):
     words_transcribed_limit: int
     insights_gained_used: int
     insights_gained_limit: int
-    memories_created_used: int
-    memories_created_limit: int
     available_plans: List[SubscriptionPlan] = []
     show_subscription_ui: bool = True
     # Chat quota usage — derived from llm_usage collection

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -827,7 +827,6 @@ def _byok_unlimited_subscription() -> Subscription:
             transcription_seconds=None,
             words_transcribed=None,
             insights_gained=None,
-            memories_created=None,
         ),
     )
 
@@ -857,8 +856,6 @@ def get_user_subscription_endpoint(
             words_transcribed_limit=0,
             insights_gained_used=0,
             insights_gained_limit=0,
-            memories_created_used=0,
-            memories_created_limit=0,
             available_plans=[],
             show_subscription_ui=False,
             phone_call_quota=unlimited_phone_quota,
@@ -873,7 +870,6 @@ def get_user_subscription_endpoint(
                 transcription_seconds=None,
                 words_transcribed=None,
                 insights_gained=None,
-                memories_created=None,
             ),
         )
         return UserSubscriptionResponse(
@@ -884,8 +880,6 @@ def get_user_subscription_endpoint(
             words_transcribed_limit=0,
             insights_gained_used=0,
             insights_gained_limit=0,
-            memories_created_used=0,
-            memories_created_limit=0,
             available_plans=[],
             show_subscription_ui=False,
             phone_call_quota=unlimited_phone_quota,
@@ -929,13 +923,11 @@ def get_user_subscription_endpoint(
     transcription_seconds_used = usage.get('transcription_seconds', 0)
     words_transcribed_used = usage.get('words_transcribed', 0)
     insights_gained_used = usage.get('insights_gained', 0)
-    memories_created_used = usage.get('memories_created', 0)
 
     # Get limits from subscription (0 means unlimited)
     transcription_seconds_limit = subscription.limits.transcription_seconds or 0
     words_transcribed_limit = subscription.limits.words_transcribed or 0
     insights_gained_limit = subscription.limits.insights_gained or 0
-    memories_created_limit = subscription.limits.memories_created or 0
 
     # Build available plans. Version-gated: new clients see Operator + Architect,
     # old clients get legacy plan names. Legacy plans filtered from purchase catalog.
@@ -1032,8 +1024,6 @@ def get_user_subscription_endpoint(
         words_transcribed_limit=words_transcribed_limit,
         insights_gained_used=insights_gained_used,
         insights_gained_limit=insights_gained_limit,
-        memories_created_used=memories_created_used,
-        memories_created_limit=memories_created_limit,
         available_plans=available_plans,
         show_subscription_ui=show_subscription_ui,
         chat_quota_used=round(chat_snapshot['used'], 4),

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -402,7 +402,6 @@ BASIC_TIER_MINUTES_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_MINUTES_LIMIT_PER
 BASIC_TIER_MONTHLY_SECONDS_LIMIT = BASIC_TIER_MINUTES_LIMIT_PER_MONTH * 60
 BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH', '0'))
 BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH', '0'))
-BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH', '0'))
 
 # Chat caps per plan. Env-overridable for ops.
 FREE_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('FREE_CHAT_QUESTIONS_PER_MONTH', '30'))
@@ -555,7 +554,6 @@ def get_basic_plan_limits() -> PlanLimits:
         transcription_seconds=BASIC_TIER_MONTHLY_SECONDS_LIMIT,
         words_transcribed=BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH,
         insights_gained=BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH,
-        memories_created=BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH,
         chat_questions_per_month=FREE_CHAT_QUESTIONS_PER_MONTH,
     )
 
@@ -579,7 +577,6 @@ def get_plan_limits(plan: PlanType) -> PlanLimits:
             transcription_seconds=None,
             words_transcribed=None,
             insights_gained=None,
-            memories_created=None,
             chat_questions_per_month=OPERATOR_CHAT_QUESTIONS_PER_MONTH,
         )
     if plan == PlanType.unlimited:
@@ -587,7 +584,6 @@ def get_plan_limits(plan: PlanType) -> PlanLimits:
             transcription_seconds=None,
             words_transcribed=None,
             insights_gained=None,
-            memories_created=None,
             chat_questions_per_month=NEO_CHAT_QUESTIONS_PER_MONTH,
         )
     if plan == PlanType.architect:
@@ -595,7 +591,6 @@ def get_plan_limits(plan: PlanType) -> PlanLimits:
             transcription_seconds=None,
             words_transcribed=None,
             insights_gained=None,
-            memories_created=None,
             chat_cost_usd_per_month=ARCHITECT_CHAT_COST_USD_PER_MONTH,
         )
     return get_basic_plan_limits()


### PR DESCRIPTION
Re-do of #7426, which merged the wrong commit and did not actually land these changes.

## Why
The mobile app showed a "5,000 memories created this month" quota bar, but nothing enforced it — display-only. Removing it everywhere.

## Changes
**Backend**: drop `PlanLimits.memories_created` + `memories_created_used`/`_limit` from `UserSubscriptionResponse` and all plumbing; remove `BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH` from all 4 helm charts.
**App**: remove the quota progress bar, the `memoriesCreated*` subscription fields (+ regenerated `subscription.g.dart`), and the `memoriesUsedThisMonth` l10n key across all 49 locales (+ regenerated localizations).
**Kept**: the `memories_created` usage metric and the usage-history graph line (real analytics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)