### PR TITLE
Update CHANGELOG.json for v0.11.416 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,10 +1,15 @@
 {
-  "unreleased": [
-    "Reduced Sentry error noise: filter transient network/socket errors and rate-limit repeated identical errors so a single root cause no longer floods crash reporting",
-    "Fixed a database constraint crash when recording video-based screenshots with no legacy image path",
-    "Raised app-hang reporting threshold to 3s so only sustained freezes are flagged"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.416",
+      "date": "2026-05-21",
+      "changes": [
+        "Reduced Sentry error noise: filter transient network/socket errors and rate-limit repeated identical errors so a single root cause no longer floods crash reporting",
+        "Fixed a database constraint crash when recording video-based screenshots with no legacy image path",
+        "Raised app-hang reporting threshold to 3s so only sustained freezes are flagged"
+      ]
+    },
     {
       "version": "0.11.415",
       "date": "2026-05-21",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.416 and clears the unreleased array.