### PR TITLE
feat(desktop): agent fast-path for testing — seeded auth + automation bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,11 @@ After any Swift UI edit, verify programmatically with [agent-swift](https://gith
 
 Requires: Accessibility permission for Terminal.app (System Settings → Privacy & Security → Accessibility).
 
+Fast-path (skip the slow parts): a signed-in session can be cloned between dev bundles, and a local control bridge jumps straight to any screen — so you avoid the web login and sidebar click-through. See "Fast-Path for Local Iteration" in `desktop/e2e/SKILL.md`:
+- `cd desktop && ./scripts/omi-auth-dump.sh` once, then `./scripts/omi-auth-seed.sh com.omi.<bundle>` → boots signed-in, no browser.
+- `./scripts/omi-ctl navigate <screen>` → jump to a screen in ~150ms (bridge auto-enabled on non-prod bundles; `omi-ctl screens` lists targets).
+- Use the seeded-auth/onboarding shortcut for iterating on other screens only — validate auth/onboarding flows and flow-walker E2E with the real flow.
+
 Edit → Verify → Evidence loop:
 1. Edit code, rebuild: `cd desktop && ./run.sh`
 2. Connect: `agent-swift connect --bundle-id com.omi.desktop-dev`

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -87,3 +87,7 @@ demo/out/
 
 # Claude project instructions (user-local, contains absolute paths)
 CLAUDE.md
+
+# Captured dev auth session (omi-auth-dump.sh) — contains real tokens, never commit
+tmp/desktop-auth.json
+tmp/

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -137,6 +137,8 @@ This creates `/Applications/omi-fix-rewind.app` with bundle ID `com.omi.omi-fix-
 - Keep the name short and descriptive (it becomes both the app name and bundle ID suffix)
 - The named bundle gets its own permissions, database, and auth state — the user may need to re-grant permissions and sign in
 - To connect agent-swift: `agent-swift connect --bundle-id com.omi.omi-fix-rewind`
+- **Skip the web login:** sign into "Omi Dev" once, then `./scripts/omi-auth-dump.sh && ./scripts/omi-auth-seed.sh com.omi.omi-fix-rewind` clones the session so the named bundle boots signed-in
+- **Jump to a screen without clicking:** the automation bridge auto-enables on non-prod bundles — `./scripts/omi-ctl navigate <screen>` (e.g. `rewind`, `memories`, `settings rewind`). See "Fast-Path for Local Iteration" in `e2e/SKILL.md`.
 
 ### After Implementing Changes
 - `xcrun swift build` is for **compile checks only** — it does NOT start the backend

--- a/desktop/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/Desktop/Sources/DesktopAutomationBridge.swift
@@ -8,8 +8,16 @@ enum DesktopAutomationLaunchOptions {
   static let defaultPort: UInt16 = 47777
 
   static var isEnabled: Bool {
-    CommandLine.arguments.contains(enableFlag)
+    // Explicit opt-out always wins, so a dev build can be run "clean" if needed.
+    if ProcessInfo.processInfo.environment["OMI_DISABLE_LOCAL_AUTOMATION"] == "1" {
+      return false
+    }
+    // Auto-enable on any non-production bundle (Omi Dev + every `omi-*` named test
+    // bundle) so agents can drive the app without remembering a launch flag. The
+    // listener only binds to 127.0.0.1 and is never enabled on the production bundle.
+    return CommandLine.arguments.contains(enableFlag)
       || ProcessInfo.processInfo.environment["OMI_ENABLE_LOCAL_AUTOMATION"] == "1"
+      || AppBuild.isNonProduction
   }
 
   static var port: UInt16 {

--- a/desktop/e2e/SKILL.md
+++ b/desktop/e2e/SKILL.md
@@ -8,6 +8,42 @@ allowed-tools: Bash, Read, Glob, Grep
 
 This skill teaches you the Omi desktop macOS app's navigation structure, screen architecture, and SwiftUI patterns. Use it when developing features (to understand how the app works), fixing bugs (to navigate to the affected screen), or verifying changes (to confirm your code works in the live app).
 
+## Fast-Path for Local Iteration (start here)
+
+Two things make iterating on the desktop app slow: signing in (web OAuth) and clicking through the UI to reach a screen. Both are solved — use these before reaching for `agent-swift`.
+
+### 1. Skip the web login (seed auth once, reuse forever)
+Dev/named bundles store auth in UserDefaults (not Keychain), so a signed-in session can be cloned between bundles. Sign in **once** in "Omi Dev", then replay it into any test bundle:
+```bash
+cd desktop
+./scripts/omi-auth-dump.sh                                  # capture Omi Dev's session -> tmp/desktop-auth.json
+./scripts/omi-auth-seed.sh com.omi.omi-myfeature           # replay into a named bundle (run BEFORE launch)
+```
+The seeded bundle boots already signed-in and past onboarding — no browser. The captured Firebase idToken expires (~1h); re-run `omi-auth-dump.sh` after signing in again if backend calls start 401ing. **Scope:** this is for dev iteration only — when validating the onboarding or auth flows themselves (or running flow-walker E2E), use the real flow per Guard Conditions below.
+
+### 2. Jump straight to any screen (automation bridge)
+The app runs a local HTTP control bridge (`DesktopAutomationBridge.swift`) that **auto-enables on every non-production bundle** (off on prod). `scripts/omi-ctl` drives it — jump to a screen in ~150ms instead of clicking through the sidebar:
+```bash
+./scripts/omi-ctl wait-ready                 # block until app reaches "main" state
+./scripts/omi-ctl navigate rewind            # jump to the Rewind screen
+./scripts/omi-ctl navigate settings rewind   # Settings page, Rewind sub-section
+./scripts/omi-ctl state                       # read selected tab / auth / onboarding state as JSON
+./scripts/omi-ctl screens                     # list valid targets
+```
+Disable with `OMI_DISABLE_LOCAL_AUTOMATION=1` to run a dev build "clean". Running several named bundles at once? Give each its own `OMI_AUTOMATION_PORT` (default 47777).
+
+### The full loop
+```bash
+cd desktop
+OMI_APP_NAME="omi-myfeature" ./run.sh &                 # build + launch once
+./scripts/omi-auth-seed.sh com.omi.omi-myfeature        # (first run, or after re-dump) — relaunch to apply
+./scripts/omi-ctl wait-ready
+./scripts/omi-ctl navigate memories                      # jump to the screen you changed
+agent-swift connect --bundle-id com.omi.omi-myfeature    # then drive/inspect with agent-swift
+agent-swift snapshot -i --json
+```
+After a code change, an incremental `xcrun swift build` + relaunch is fast — the slow parts (login, navigation) are gone. For pure visual checks without launching at all, SwiftUI snapshot tests are an option, but most pages are entangled with `AppState.shared`/Firebase singletons, so the live-app bridge loop above is usually the better path.
+
 ## How to Explore the App
 
 You can interact with the running app via `agent-swift` — a CLI that clicks elements, reads the accessibility tree, and captures screenshots through the macOS Accessibility API. Works with any macOS app, no app-side instrumentation needed.
@@ -163,8 +199,7 @@ After making changes, verify them in the live app:
 
 **NEVER:**
 - Kill or restart the production Omi app
-- Use development env vars to bypass auth — test real auth flows
-- Set `hasCompletedOnboarding` to skip onboarding — test the real flow
+- Enable the automation bridge or seed auth on the production bundle (`com.omi.computer-macos`) — both are gated to non-production builds; keep it that way
 - Modify source code to make tests pass — report the failure instead
 
-**NOTE:** The beta app (`com.omi.computer-macos`) is the standard target for flow-walker E2E testing. The dev app (`com.omi.desktop-dev`) is for local development only.
+**When validating auth or onboarding themselves, or running flow-walker E2E:** drive the real flows — do NOT use the seeded-auth / `hasCompletedOnboarding` fast-path, which exists only for iterating on *other* screens. The beta app (`com.omi.computer-macos`) is the standard target for flow-walker E2E testing; the dev app (`com.omi.desktop-dev`) and named `omi-*` bundles are for local development only.

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -20,7 +20,9 @@ Options (via environment variables):
   OMI_APP_NAME="Omi Dev"   App name (default: "Omi Dev")
   OMI_PYTHON_API_URL="..."  Python backend URL (subscriptions, payments, etc; default: https://api.omi.me)
   OMI_SIGN_IDENTITY="..."  Code signing identity (auto-detected if not set)
-  OMI_ENABLE_LOCAL_AUTOMATION=1  Enable agent-swift automation bridge
+  OMI_ENABLE_LOCAL_AUTOMATION=1   Force the automation bridge on (auto-on for non-prod bundles; see scripts/omi-ctl)
+  OMI_DISABLE_LOCAL_AUTOMATION=1  Run a dev build "clean" with the bridge off
+  OMI_AUTOMATION_PORT=47777       Bridge port (set per bundle when running several at once)
 
 Required files:
   Backend-Rust/.env         Environment variables (copy from ../.env.example)

--- a/desktop/scripts/omi-auth-dump.sh
+++ b/desktop/scripts/omi-auth-dump.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# omi-auth-dump.sh — capture a signed-in dev bundle's auth session to JSON.
+#
+# Dev/named bundles store auth in UserDefaults (not Keychain) — see
+# AuthService.restoreAuthState(). This script copies those keys verbatim so they
+# can be replayed into other test bundles with omi-auth-seed.sh, letting an agent
+# skip the web OAuth login on every run.
+#
+# It does NOT mint or refresh tokens — it copies whatever the source session has.
+# The captured Firebase idToken expires (~1h); re-run this after signing in again.
+#
+# Usage: omi-auth-dump.sh [source-bundle-id] [out-file]
+#   source-bundle-id  default: com.omi.desktop-dev   (the "Omi Dev" build)
+#   out-file          default: desktop/tmp/desktop-auth.json (gitignored)
+set -euo pipefail
+
+SRC="${1:-com.omi.desktop-dev}"
+OUT="${2:-$(cd "$(dirname "$0")/.." && pwd)/tmp/desktop-auth.json}"
+KEYS=(auth_isSignedIn auth_userEmail auth_userId auth_givenName auth_familyName \
+      auth_idToken auth_refreshToken auth_tokenExpiry auth_tokenUserId hasCompletedOnboarding)
+
+mkdir -p "$(dirname "$OUT")"
+
+python3 - "$SRC" "$OUT" "${KEYS[@]}" <<'PY'
+import json, subprocess, sys
+src, out, keys = sys.argv[1], sys.argv[2], sys.argv[3:]
+
+def defaults(*args):
+    return subprocess.run(["defaults", *args], capture_output=True, text=True)
+
+data = {}
+for k in keys:
+    t = defaults("read-type", src, k)
+    if t.returncode != 0:
+        continue
+    v = defaults("read", src, k)
+    if v.returncode != 0:
+        continue
+    data[k] = {"type": t.stdout.strip().replace("Type is ", ""), "value": v.stdout.strip()}
+
+with open(out, "w") as f:
+    json.dump(data, f, indent=2)
+
+print(f"Dumped {len(data)} keys from {src} -> {out}")
+print(f"  signed_in={data.get('auth_isSignedIn', {}).get('value')} "
+      f"email={data.get('auth_userEmail', {}).get('value')}")
+if "auth_idToken" not in data:
+    sys.exit("WARNING: no auth_idToken found — is the source bundle signed in?")
+PY

--- a/desktop/scripts/omi-auth-seed.sh
+++ b/desktop/scripts/omi-auth-seed.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# omi-auth-seed.sh — replay a captured auth session into a test bundle.
+#
+# Writes the auth_* UserDefaults keys (and hasCompletedOnboarding) captured by
+# omi-auth-dump.sh into the target bundle's domain. On next launch the app's
+# restoreAuthState() picks them up and boots already-signed-in — no browser.
+#
+# Run this BEFORE launching the bundle (UserDefaults is read at startup).
+#
+# Usage: omi-auth-seed.sh <target-bundle-id> [in-file]
+#   target-bundle-id  e.g. com.omi.omi-fix-rewind  (a named test bundle)
+#   in-file           default: desktop/tmp/desktop-auth.json
+set -euo pipefail
+
+TARGET="${1:?usage: omi-auth-seed.sh <target-bundle-id> [in-file]}"
+IN="${2:-$(cd "$(dirname "$0")/.." && pwd)/tmp/desktop-auth.json}"
+
+[ -f "$IN" ] || { echo "No auth file at $IN — run omi-auth-dump.sh first." >&2; exit 1; }
+
+python3 - "$TARGET" "$IN" <<'PY'
+import json, subprocess, sys
+target, inp = sys.argv[1], sys.argv[2]
+data = json.load(open(inp))
+
+flag = {"boolean": "-bool", "string": "-string", "integer": "-int",
+        "float": "-float", "date": "-date", "data": "-data"}
+
+n = 0
+for k, info in data.items():
+    typ, val = info["type"], info["value"]
+    # `defaults read` prints booleans as 1/0, but `defaults write -bool` only
+    # accepts true/false/yes/no — convert so the write doesn't fail.
+    if typ == "boolean":
+        val = "true" if val.strip().lower() in ("1", "true", "yes") else "false"
+    subprocess.run(["defaults", "write", target, k, flag.get(typ, "-string"), val], check=True)
+    n += 1
+print(f"Seeded {n} keys into {target}")
+PY
+
+echo "Done — launch $TARGET and it boots signed-in (no web login)."

--- a/desktop/scripts/omi-ctl
+++ b/desktop/scripts/omi-ctl
@@ -1,0 +1,63 @@
+#!/bin/bash
+# omi-ctl — drive the running Omi desktop app via its local automation bridge.
+#
+# The bridge (DesktopAutomationBridge.swift) auto-enables on every non-production
+# bundle and listens on 127.0.0.1:47777. It lets an agent jump straight to any
+# screen and read app state without clicking through the UI.
+#
+# Env: OMI_AUTOMATION_PORT (default 47777) — set this per bundle if running
+#      several named test bundles side-by-side (each needs its own port).
+set -euo pipefail
+
+PORT="${OMI_AUTOMATION_PORT:-47777}"
+BASE="http://127.0.0.1:${PORT}"
+
+cmd="${1:-help}"; shift || true
+case "$cmd" in
+  state|health)
+    curl -fsS "$BASE/$cmd"; echo ;;
+  navigate)
+    target="${1:?usage: omi-ctl navigate <screen> [settings-section]}"
+    section="${2:-}"
+    body="{\"target\":\"$target\""
+    [ -n "$section" ] && body="$body,\"settingsSection\":\"$section\""
+    body="$body}"
+    curl -fsS -X POST "$BASE/navigate" -d "$body" >/dev/null
+    # The POST snapshot races the animated tab switch — settle, then report fresh state.
+    sleep 0.3
+    curl -fsS "$BASE/state"; echo ;;
+  open-conversation)
+    id="${1:?usage: omi-ctl open-conversation <id> [--transcript]}"
+    show=false; [ "${2:-}" = "--transcript" ] && show=true
+    curl -fsS -X POST "$BASE/conversation/open" \
+      -d "{\"conversationId\":\"$id\",\"showTranscript\":$show}"; echo ;;
+  wait-ready)
+    tries="${1:-30}"
+    for _ in $(seq 1 "$tries"); do
+      s=$(curl -fsS "$BASE/state" 2>/dev/null || true)
+      if echo "$s" | grep -q '"appState" : "main"'; then echo "$s"; exit 0; fi
+      sleep 0.5
+    done
+    echo "omi-ctl: timed out waiting for app to reach \"main\" state" >&2; exit 1 ;;
+  screens)
+    echo "dashboard|home  conversations  chat  memories  tasks  focus  insight  rewind  apps|integrations  settings  permissions  device  help" ;;
+  *)
+    cat <<EOF
+omi-ctl — drive the Omi desktop app via the local automation bridge
+
+Usage:
+  omi-ctl state                          App state snapshot (selected tab, auth, onboarding)
+  omi-ctl navigate <screen> [section]    Jump to a screen; optional settings sub-section
+  omi-ctl open-conversation <id> [--transcript]
+  omi-ctl wait-ready [tries]             Block until app reaches "main" state (0.5s/try)
+  omi-ctl screens                        List valid screen targets
+
+Examples:
+  omi-ctl navigate rewind
+  omi-ctl navigate settings rewind       # Settings page, Rewind sub-section
+  omi-ctl wait-ready && omi-ctl navigate memories
+
+Env: OMI_AUTOMATION_PORT (default 47777)
+EOF
+    ;;
+esac


### PR DESCRIPTION
## Why
Three things made the desktop app slow for agents to test: web OAuth login, clicking through the UI to reach a screen, and an existing automation bridge nobody used because it was off-by-default and undocumented. This wires up a fast local-iteration path.

## What
- **`scripts/omi-auth-dump.sh` / `omi-auth-seed.sh`** — clone a signed-in dev session's UserDefaults between bundles so a test bundle boots already-signed-in (no browser). Pure shell; **zero changes to the OAuth/prod code path** (relies on the existing `restoreAuthState()` ad-hoc-signing branch).
- **`scripts/omi-ctl`** — thin CLI for the existing `DesktopAutomationBridge` (`navigate <screen>`, `state`, `open-conversation`, `wait-ready`). Jumps to any screen in ~150ms.
- **Auto-enable the automation bridge on non-production bundles** (`DesktopAutomationBridge.swift`), gated by `AppBuild.isNonProduction`, opt-out via `OMI_DISABLE_LOCAL_AUTOMATION=1`. **Production behavior unchanged** — the bridge never enables on `com.omi.computer-macos`.
- **Docs** — new "Fast-Path for Local Iteration" section in `e2e/SKILL.md` (+ reconciled Guard Conditions), plus `desktop/CLAUDE.md`, `AGENTS.md`, `run.sh` help.

## Verification (end-to-end, named bundle `omi-agent-test`)
- Bridge auto-enabled without any env var (`bridgeEnabled: true`).
- Seeded auth → app booted signed-in, past onboarding, `appState: main` — no web login.
- `omi-ctl navigate` drove rewind / memories / dashboard / settings+section correctly.
- Clean debug build green; clean release build run as pre-merge insurance.

Note: merging triggers the automated desktop release, but the only Swift change is gated to non-production bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)