### PR TITLE
desktop: tolerate missing usage fields in subscription response (fixes beta 'Failed to load plan information')

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed \"Failed to load plan information\" on the Plan & Usage page when the backend response was missing usage fields"
+  ],
   "releases": [
     {
       "version": "0.11.416",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -3764,6 +3764,26 @@ struct UserSubscriptionResponse: Codable {
     case availablePlans = "available_plans"
     case showSubscriptionUI = "show_subscription_ui"
   }
+
+  // Defensive decode: only `subscription` is required. The usage counters and
+  // plan catalog default when absent so a backend that's behind on schema
+  // (notably the dev backend the beta channel routes to, which can lag prod or
+  // omit newer fields like `memories_created_used`) doesn't blank the entire
+  // Plan & Usage page with "Failed to load plan information."
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    subscription = try c.decode(UserSubscriptionInfo.self, forKey: .subscription)
+    transcriptionSecondsUsed = try c.decodeIfPresent(Int.self, forKey: .transcriptionSecondsUsed) ?? 0
+    transcriptionSecondsLimit = try c.decodeIfPresent(Int.self, forKey: .transcriptionSecondsLimit) ?? 0
+    wordsTranscribedUsed = try c.decodeIfPresent(Int.self, forKey: .wordsTranscribedUsed) ?? 0
+    wordsTranscribedLimit = try c.decodeIfPresent(Int.self, forKey: .wordsTranscribedLimit) ?? 0
+    insightsGainedUsed = try c.decodeIfPresent(Int.self, forKey: .insightsGainedUsed) ?? 0
+    insightsGainedLimit = try c.decodeIfPresent(Int.self, forKey: .insightsGainedLimit) ?? 0
+    memoriesCreatedUsed = try c.decodeIfPresent(Int.self, forKey: .memoriesCreatedUsed) ?? 0
+    memoriesCreatedLimit = try c.decodeIfPresent(Int.self, forKey: .memoriesCreatedLimit) ?? 0
+    availablePlans = try c.decodeIfPresent([SubscriptionPlanOption].self, forKey: .availablePlans) ?? []
+    showSubscriptionUI = try c.decodeIfPresent(Bool.self, forKey: .showSubscriptionUI) ?? true
+  }
 }
 
 struct CheckoutSessionResponse: Codable {


### PR DESCRIPTION
## Bug
Beta users see **"Failed to load plan information"** on Plan & Usage (reported on account bigbeeme33@gmail.com, v0.11.415 beta).

## Root cause
Beta routes to the **dev backend** (`api.omiapi.com`) by design. Dev lagged prod's schema — its `/v1/users/me/subscription` omitted `memories_created_used`. `UserSubscriptionResponse` required every usage counter, so one missing key threw a decode error and blanked the whole plan block. Client log:
```
Decoding error - key 'memories_created_used' not found
Failed to load subscription: The data couldn't be read because it is missing.
```
Prod (`api.omi.me`) returns the field → **stable unaffected**; this is beta-only.

## Fix
Custom decoder: only `subscription` is required; usage counters + plan catalog default (0 / [] / true) when absent. The beta→dev path (which will always lag prod sometimes) can't break the page anymore.

## Test plan
- [x] debug build compiles
- [ ] beta: Plan & Usage loads even when dev backend omits fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)