### PR TITLE
chore(desktop/Backend-Rust): remediate Cargo CVEs — jsonwebtoken, openssl, rand (#7327)

### DIFF
--- a/desktop/Backend-Rust/Cargo.lock
+++ b/desktop/Backend-Rust/Cargo.lock
@@ -594,10 +594,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1023,17 +1021,19 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1240,9 +1240,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -1437,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1838,6 +1838,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2262,7 +2271,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.3",
  "web-time",
 ]
 
@@ -2829,6 +2838,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/desktop/Backend-Rust/Cargo.toml
+++ b/desktop/Backend-Rust/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 
 # Authentication
-jsonwebtoken = "9"
+jsonwebtoken = "10"
 
 # Utilities
 dotenvy = "0.15"


### PR DESCRIPTION
## Summary
Closes **all 3 open Dependabot alerts** on `desktop/Backend-Rust/Cargo.lock`.

| Crate | Before | After | Severity | Notes |
|---|---|---|---|---|
| `jsonwebtoken` | 9.3.1 | **10.4.0** | medium | Direct dep (`Cargo.toml` `"9"` → `"10"`). 9.x has no backported fix — major required. |
| `openssl` | 0.10.79 | **0.10.80** | medium | Clean minor bump. |
| `rand` | 0.9.2 | **0.9.3** | low | Clean patch bump. (A separate transitive `rand` 0.8.6 copy is outside the vulnerable range `>=0.9.0,<0.9.3` and is left untouched.) |

## jsonwebtoken 9→10 — why it's safe
The auth code (`src/auth.rs`, `src/routes/auth.rs`, `src/services/firestore.rs`) uses only APIs that are stable across the major: `Validation::new`, `set_audience`, `set_issuer`, `decode`, `decode_header`, `encode`, `EncodingKey`/`DecodingKey`, `Algorithm::RS256`. The Firebase token-validation flow sets audience + issuer explicitly, so the v10 stricter-default behavior doesn't change anything here.

## Test plan (executed locally)
- [x] `cargo check` → clean (pre-existing warnings only, no errors)
- [x] `cargo test` → **247 passed, 0 failed** (includes `services::firestore` tests that exercise JWT encode)
- [x] No source changes required for the jsonwebtoken major
- [ ] Confirm Dependabot rescan closes all 3 alerts after merge