### PR TITLE
Block clickjacking: frame-ancestors + X-Frame-Options on app & admin

### DIFF
--- a/web/admin/next.config.js
+++ b/web/admin/next.config.js
@@ -13,6 +13,18 @@ const nextConfig = {
       { source: '/dashboard/analytics', destination: '/dashboard', permanent: false },
     ];
   },
+  async headers() {
+    // Prevent clickjacking: disallow embedding any page (incl. /login) in a frame.
+    return [
+      {
+        source: '/(.*)?',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/web/app/.prettierrc.js
+++ b/web/app/.prettierrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  printWidth: 90,
+  tabWidth: 2,
+  endOfLine: 'auto',
+  htmlWhitespaceSensitivity: 'css',
+  singleAttributePerLine: false,
+};

--- a/web/app/next.config.js
+++ b/web/app/next.config.js
@@ -81,6 +81,18 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    // Prevent clickjacking: disallow embedding any page (incl. /login) in a frame.
+    return [
+      {
+        source: '/(.*)?',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary

Fixes a reported **clickjacking** finding: `https://app.omi.me/login` (and every other `app.omi.me` page) was served with **no `X-Frame-Options` and no `Content-Security-Policy`**, so it could be embedded in an `<iframe>` on any origin and used for UI-redress attacks.

- `app.omi.me` is served by `web/app`, whose `next.config.js` had no `headers()` block at all.
- While verifying, I found **`admin.omi.me` has the identical gap** (`web/admin`) — the admin dashboard is higher-value, so it's fixed here too.
- `web/frontend` already denies framing (`X-Frame-Options: DENY`), so it was not affected and is left as-is.

## Changes

- `web/app/next.config.js` — add `headers()` denying framing on all routes
- `web/admin/next.config.js` — same
- `web/app/.prettierrc.js` — **(supporting change)** `web/app` was the only web app missing the shared Prettier config that `web/frontend` and `web/personas-open-source` have. Without it the pre-commit Prettier hook fell back to defaults and rewrote the whole file's quote style. Adding the shared config (identical to siblings) keeps this PR a minimal diff and fixes the underlying inconsistency.

Each app gets both headers (belt-and-suspenders): `X-Frame-Options: DENY` for older browsers and `Content-Security-Policy: frame-ancestors 'none'` (the modern equivalent, covers browsers that ignore XFO).

```js
async headers() {
  return [{
    source: '/(.*)?',
    headers: [
      { key: 'X-Frame-Options', value: 'DENY' },
      { key: 'Content-Security-Policy', value: "frame-ancestors 'none'" },
    ],
  }];
}
```

## Verification

- Both configs load and their `headers()` return the two headers for `source: '/(.*)?'` (verified via Node).
- `prettier --check` on the changed `web/app` files passes with the new config (no quote churn).
- ⚠️ Runtime header presence should be confirmed on a preview/deploy of `web/app` and `web/admin` — I validated the config contract, not a built server.

## Test plan

- [ ] Build/deploy `web/app`; `curl -I https://<preview>/login` shows `x-frame-options: DENY` and `content-security-policy: frame-ancestors 'none'`.
- [ ] Same for `web/admin`.
- [ ] The PoC `iframe src="…/login"` renders blank / refused instead of loading the page.
- [ ] App still loads normally top-level (not regressed by the headers).
