### PR TITLE
chore: bump idna -> 3.15 across backend + sdks/python (#7327)

### DIFF
--- a/backend/diarizer/requirements.txt
+++ b/backend/diarizer/requirements.txt
@@ -24,7 +24,7 @@ greenlet==3.3.0
 grpcio==1.76.0
 h11==0.16.0
 huggingface-hub==0.28.1
-idna==3.11
+idna==3.15
 importlib-metadata==8.7.1
 jinja2==3.1.6
 joblib==1.5.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -80,7 +80,7 @@ httpx-sse==0.4.0
 huggingface-hub==0.24.5
 humanfriendly==10.0
 hyperframe==6.1.0
-idna==3.7
+idna==3.15
 ipython==8.26.0
 jedi==0.19.1
 Jinja2==3.1.6

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "h11==0.16.0",
     "httpcore==1.0.9",
     "httpx==0.28.1",
-    "idna==3.10",
+    "idna==3.15",
     "marshmallow==3.26.2",
     "multidict==6.2.0",
     "mypy-extensions==1.0.0",

--- a/sdks/python/requirements.txt
+++ b/sdks/python/requirements.txt
@@ -16,7 +16,7 @@ frozenlist==1.5.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
-idna==3.10
+idna==3.15
 marshmallow==3.26.2
 multidict==6.2.0
 mypy-extensions==1.0.0


### PR DESCRIPTION
## Summary
Closes the `idna < 3.15` advisory (CVE-2024-...) across every manifest that pins it below 3.15. Pure-Python patch bump — no API changes.

| Manifest | Before | After |
|---|---|---|
| `backend/requirements.txt` | 3.7 | **3.15** |
| `backend/diarizer/requirements.txt` | 3.11 | **3.15** |
| `sdks/python/requirements.txt` | 3.10 | **3.15** |
| `sdks/python/pyproject.toml` | 3.10 | **3.15** |

### Coverage notes
- `backend/modal/requirements.txt` doesn't pin idna directly — it does `-r ../requirements.txt`, so the `backend/requirements.txt` bump resolves its idna alert too.
- `backend/pyproject.toml` has no dependency list (only `[tool.black]` / `[tool.pytest]`); its idna alert is transitive and resolves once the environment installs idna 3.15.

### Out of scope (same manifests, not addressed here)
- `langchain-openai` (modal/pusher/backend) → needs the deferred openai 1.x→2.x major
- `pytorch-lightning` (diarizer/backend) → Dependabot lists no upstream fix
- `torch` (backend, transitive) → deferred
- `python-multipart`, `langchain-core`, `langsmith` in `backend/requirements.txt` are already at their patched versions (phantom rescan-lag)

## Test plan
- [x] `idna==3.15` installs + imports + IDNA-encodes correctly (`münchen.de` → `xn--mnchen-3ya.de`)
- [x] Co-resolves cleanly with `requests==2.34.2` + `httpx==0.28.1` (both declare `idna<4`)
- [ ] Confirm Dependabot rescan closes the idna alerts after merge