### PR TITLE
Update CHANGELOG.json for v0.11.419 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed \"Failed to load plan information\" on the Plan & Usage page when the backend response was missing usage fields"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.419",
+      "date": "2026-05-21",
+      "changes": [
+        "Fixed \"Failed to load plan information\" on the Plan & Usage page when the backend response was missing usage fields"
+      ]
+    },
     {
       "version": "0.11.417",
       "date": "2026-05-21",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.419 and clears the unreleased array.