### PR TITLE
fix(subscription): map live Neo Monthly Stripe price (renewals were downgrading subs)

### DIFF
--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -242,6 +242,10 @@ LEGACY_PRICE_MAP = {
     # Old Unlimited ($19.99/mo, $199.99/yr) → PlanType.unlimited (now Neo)
     'price_1RtJPm1F8wnoWYvwhVJ38kLb': PlanType.unlimited,
     'price_1RtJQ71F8wnoWYvwKMPaGlGY': PlanType.unlimited,
+    # "Neo Monthly" ($20/mo). A live Neo price that isn't wired into the
+    # env-based plan definitions, so renewal webhooks were raising
+    # "unknown price ID" and dropping active Neo subscribers to free.
+    'price_1TNIHd1F8wnoWYvwkIrekcQZ': PlanType.unlimited,
     # Old Pro ($199/mo, $1999/yr) → PlanType.architect
     'price_1TAfBB1F8wnoWYvw8XBFM1dX': PlanType.architect,
     'price_1TLFac1F8wnoWYvwtPxZhtzE': PlanType.architect,

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -242,10 +242,14 @@ LEGACY_PRICE_MAP = {
     # Old Unlimited ($19.99/mo, $199.99/yr) → PlanType.unlimited (now Neo)
     'price_1RtJPm1F8wnoWYvwhVJ38kLb': PlanType.unlimited,
     'price_1RtJQ71F8wnoWYvwKMPaGlGY': PlanType.unlimited,
-    # "Neo Monthly" ($20/mo). A live Neo price that isn't wired into the
-    # env-based plan definitions, so renewal webhooks were raising
-    # "unknown price ID" and dropping active Neo subscribers to free.
-    'price_1TNIHd1F8wnoWYvwkIrekcQZ': PlanType.unlimited,
+    # Orphaned from the Apr 17–20 Neo-product window: between f30245338 (added
+    # a separate Stripe product `prod_UM0IIpZ4iOgfk5` "Neo" wired via
+    # STRIPE_NEO_* env vars) and 2e71145ab (reverted to STRIPE_UNLIMITED_*),
+    # desktop signups landed on these prices. Stripe keeps billing them, but
+    # post-revert code recognizes neither, so renewals raise "unknown price ID"
+    # and drop active subscribers to free.
+    'price_1TNIHd1F8wnoWYvwkIrekcQZ': PlanType.unlimited,  # Neo Monthly ($20/mo)
+    'price_1TNIHd1F8wnoWYvwlKywJ8TO': PlanType.unlimited,  # Neo Annual ($200/yr)
     # Old Pro ($199/mo, $1999/yr) → PlanType.architect
     'price_1TAfBB1F8wnoWYvw8XBFM1dX': PlanType.architect,
     'price_1TLFac1F8wnoWYvwtPxZhtzE': PlanType.architect,


### PR DESCRIPTION
## Summary

A live **"Neo Monthly"** Stripe price was not recognized by the backend, so its **renewal webhooks failed and silently downgraded active subscribers to the free tier**.

### Root cause
- `get_plan_type_from_price_id()` resolves a price via the active plan definitions (env-configured price IDs) first, then `LEGACY_PRICE_MAP`, else **raises** `ValueError("... unknown plan")`.
- This Neo Monthly price is live in Stripe but is in **neither** place, so every webhook for it raised "unknown price ID" (visible as `WARNING:routers.payment: ... could not build subscription ... unknown price ID`).
- The webhook handler then bailed **without advancing `current_period_end`** on the user's Firestore `subscription`.
- `get_user_valid_subscription()` validates paid plans by **`current_period_end >= now` only** (it ignores `status` and never reconciles against Stripe). So once the period end went stale, the user's active Neo sub was treated as expired and `/v1/users/me/subscription` returned **basic/free** → the app showed "no subscription."

### Fix
Map the price to `PlanType.unlimited` in `LEGACY_PRICE_MAP` so the webhook resolves it and updates the subscription normally.

## Impact
- Affects **any** subscriber on this Neo Monthly price — they drop to free at their next renewal until this lands.
- (Already-affected users were restored out-of-band by syncing `current_period_end` from Stripe; this PR stops it recurring.)

## Recommended follow-ups (not in this PR)
1. **Wire current prices to the active plan definitions** (the env-based `STRIPE_*_PRICE_ID`s) so live prices don't depend on the legacy map; audit for any other live prices missing from both.
2. **Make `get_plan_type_from_price_id` fail-soft** — an unmapped price should log + no-op the affected field, not hard-raise and abort the whole webhook (so one bad price can't silently free-tier paying customers).
3. **Harden `get_user_valid_subscription`** — honor `status == active` with a short grace window (or reconcile against Stripe) so a single missed/late renewal webhook can't downgrade an active payer.

## Test plan
- [ ] Unit: `get_plan_type_from_price_id('price_1TNIHd1F8wnoWYvwkIrekcQZ')` returns `PlanType.unlimited`.
- [ ] Replay a renewal webhook for a sub on this price → Firestore `subscription.current_period_end` advances, no "unknown price ID" warning.
- [ ] `/v1/users/me/subscription` returns the unlimited plan for such a user.
