### PR TITLE
replacing the floating pill bar with an AI cursor

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/CuaActionDriver.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CuaActionDriver.swift
@@ -1,0 +1,265 @@
+import AppKit
+
+@MainActor
+final class CuaActionDriver: OmiActionDriver {
+
+    // MARK: - click
+
+    func click(at point: CGPoint, targetApp: NSRunningApplication?) async throws {
+        if let app = targetApp {
+            app.activate(options: .activateIgnoringOtherApps)
+            try await Task.sleep(for: .milliseconds(80))
+        }
+
+        // `point` is already in CG screen space (top-left origin) from
+        // OmiElementResolver — no flip needed for CGEvent.
+        let cgPoint = point
+
+        let src = CGEventSource(stateID: .hidSystemState)
+        let move = CGEvent(mouseEventSource: src, mouseType: .mouseMoved,      mouseCursorPosition: cgPoint, mouseButton: .left)
+        let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown,   mouseCursorPosition: cgPoint, mouseButton: .left)
+        let up   = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp,     mouseCursorPosition: cgPoint, mouseButton: .left)
+        move?.post(tap: .cghidEventTap)
+        down?.post(tap: .cghidEventTap)
+        up?.post(tap: .cghidEventTap)
+
+        log("CuaActionDriver: clicked at \(cgPoint)")
+    }
+
+    // MARK: - type
+
+    func type(text: String, targetApp: NSRunningApplication?) async throws {
+        if let app = targetApp {
+            app.activate(options: .activateIgnoringOtherApps)
+            try await Task.sleep(for: .milliseconds(80))
+        }
+
+        // Try AX direct insertion first
+        let systemWide = AXUIElementCreateSystemWide()
+        var focusedElement: CFTypeRef?
+        let focusResult = AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focusedElement)
+
+        if focusResult == .success, let focused = focusedElement {
+            let axElement = focused as! AXUIElement
+            let setResult = AXUIElementSetAttributeValue(axElement, kAXSelectedTextAttribute as CFString, text as CFTypeRef)
+            if setResult == .success {
+                log("CuaActionDriver: typed via AX direct insertion")
+                return
+            }
+        }
+
+        // Fallback — clipboard staging
+        log("CuaActionDriver: falling back to clipboard paste for type")
+        let pasteboard = NSPasteboard.general
+        let previous = pasteboard.string(forType: .string)
+
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+
+        // Post Cmd+V (key code 9)
+        let src = CGEventSource(stateID: .hidSystemState)
+        let keyDown = CGEvent(keyboardEventSource: src, virtualKey: 9, keyDown: true)
+        let keyUp   = CGEvent(keyboardEventSource: src, virtualKey: 9, keyDown: false)
+        keyDown?.flags = .maskCommand
+        keyUp?.flags   = .maskCommand
+        keyDown?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cghidEventTap)
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        if let previous {
+            pasteboard.clearContents()
+            pasteboard.setString(previous, forType: .string)
+        }
+    }
+
+    // MARK: - pressShortcut
+
+    func pressShortcut(_ keys: String, targetApp: NSRunningApplication?) async throws {
+        if let app = targetApp {
+            app.activate(options: .activateIgnoringOtherApps)
+            try await Task.sleep(for: .milliseconds(80))
+        }
+
+        let tokens = keys.components(separatedBy: "+").map { $0.trimmingCharacters(in: .whitespaces) }
+        guard !tokens.isEmpty else { throw OmiActionDriverError.unparseableShortcut(keys) }
+
+        var modifiers = CGEventFlags()
+        let modifierTokens = tokens.dropLast()
+        let keyToken = tokens.last!
+
+        for token in modifierTokens {
+            switch token.lowercased() {
+            case "cmd", "command":
+                modifiers.insert(.maskCommand)
+            case "shift":
+                modifiers.insert(.maskShift)
+            case "opt", "option", "alt":
+                modifiers.insert(.maskAlternate)
+            case "ctrl", "control":
+                modifiers.insert(.maskControl)
+            default:
+                throw OmiActionDriverError.unparseableShortcut(keys)
+            }
+        }
+
+        guard let keyCode = keyCodeFor(keyToken) else {
+            throw OmiActionDriverError.unparseableShortcut(keys)
+        }
+
+        let src = CGEventSource(stateID: .hidSystemState)
+        let keyDown = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: true)
+        let keyUp   = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: false)
+        keyDown?.flags = modifiers
+        keyUp?.flags   = modifiers
+        keyDown?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cghidEventTap)
+
+        log("CuaActionDriver: pressed shortcut \(keys)")
+    }
+
+    // MARK: - scroll
+
+    func scroll(direction: String, amount: Int, targetApp: NSRunningApplication?) async throws {
+        if let app = targetApp {
+            app.activate(options: .activateIgnoringOtherApps)
+            try await Task.sleep(for: .milliseconds(80))
+        }
+
+        let mouseLocation = NSEvent.mouseLocation
+        let screenHeight = NSScreen.screens.first?.frame.height ?? 0
+        let cgPoint = CGPoint(x: mouseLocation.x, y: screenHeight - mouseLocation.y)
+
+        var scroll1: Int32 = 0
+        var scroll2: Int32 = 0
+
+        switch direction.lowercased() {
+        case "up":    scroll1 = Int32(amount)
+        case "down":  scroll1 = -Int32(amount)
+        case "left":  scroll2 = Int32(amount)
+        case "right": scroll2 = -Int32(amount)
+        default:
+            log("CuaActionDriver: unknown scroll direction '\(direction)', defaulting to down")
+            scroll1 = -Int32(amount)
+        }
+
+        let src = CGEventSource(stateID: .hidSystemState)
+        let event = CGEvent(
+            scrollWheelEvent2Source: src,
+            units: .line,
+            wheelCount: 2,
+            wheel1: scroll1,
+            wheel2: scroll2,
+            wheel3: 0
+        )
+        event?.location = cgPoint
+        event?.post(tap: CGEventTapLocation.cghidEventTap)
+
+        log("CuaActionDriver: scrolled \(direction) by \(amount) at \(cgPoint)")
+    }
+
+    // MARK: - openApp
+
+    func openApp(named: String) async throws {
+        let workspace = NSWorkspace.shared
+
+        // Try to find running app first
+        if let running = workspace.runningApplications.first(where: {
+            $0.localizedName?.lowercased() == named.lowercased()
+        }) {
+            running.activate(options: .activateIgnoringOtherApps)
+            log("CuaActionDriver: activated already-running app '\(named)'")
+            return
+        }
+
+        // Try to launch by name
+        guard workspace.launchApplication(named) else {
+            throw OmiActionDriverError.appNotFound(name: named)
+        }
+
+        log("CuaActionDriver: launched app '\(named)', waiting for it to become frontmost")
+
+        // Wait up to 3 seconds for it to become frontmost
+        for _ in 0..<30 {
+            try await Task.sleep(for: .milliseconds(100))
+            if NSWorkspace.shared.frontmostApplication?.localizedName?.lowercased() == named.lowercased() {
+                log("CuaActionDriver: '\(named)' is now frontmost")
+                return
+            }
+        }
+
+        log("CuaActionDriver: '\(named)' launched but did not become frontmost within 3 s")
+    }
+
+    // MARK: - Private helpers
+
+    private func keyCodeFor(_ token: String) -> CGKeyCode? {
+        let lower = token.lowercased()
+
+        // Named keys
+        switch lower {
+        case "space":          return 49
+        case "return", "enter": return 36
+        case "escape", "esc":  return 53
+        case "tab":            return 48
+        case "delete", "backspace": return 51
+        case "up":             return 126
+        case "down":           return 125
+        case "left":           return 123
+        case "right":          return 124
+        default: break
+        }
+
+        // Single character keys
+        if token.count == 1, let char = token.unicodeScalars.first {
+            if let code = charKeyCodeMap[char.value] {
+                return code
+            }
+        }
+
+        return nil
+    }
+
+    // US-ANSI key code map for a-z and 0-9
+    private let charKeyCodeMap: [UInt32: CGKeyCode] = [
+        // a-z
+        UInt32(("a" as UnicodeScalar).value): 0,
+        UInt32(("s" as UnicodeScalar).value): 1,
+        UInt32(("d" as UnicodeScalar).value): 2,
+        UInt32(("f" as UnicodeScalar).value): 3,
+        UInt32(("h" as UnicodeScalar).value): 4,
+        UInt32(("g" as UnicodeScalar).value): 5,
+        UInt32(("z" as UnicodeScalar).value): 6,
+        UInt32(("x" as UnicodeScalar).value): 7,
+        UInt32(("c" as UnicodeScalar).value): 8,
+        UInt32(("v" as UnicodeScalar).value): 9,
+        UInt32(("b" as UnicodeScalar).value): 11,
+        UInt32(("q" as UnicodeScalar).value): 12,
+        UInt32(("w" as UnicodeScalar).value): 13,
+        UInt32(("e" as UnicodeScalar).value): 14,
+        UInt32(("r" as UnicodeScalar).value): 15,
+        UInt32(("y" as UnicodeScalar).value): 16,
+        UInt32(("t" as UnicodeScalar).value): 17,
+        UInt32(("1" as UnicodeScalar).value): 18,
+        UInt32(("2" as UnicodeScalar).value): 19,
+        UInt32(("3" as UnicodeScalar).value): 20,
+        UInt32(("4" as UnicodeScalar).value): 21,
+        UInt32(("6" as UnicodeScalar).value): 22,
+        UInt32(("5" as UnicodeScalar).value): 23,
+        UInt32(("=" as UnicodeScalar).value): 24,
+        UInt32(("9" as UnicodeScalar).value): 25,
+        UInt32(("7" as UnicodeScalar).value): 26,
+        UInt32(("-" as UnicodeScalar).value): 27,
+        UInt32(("8" as UnicodeScalar).value): 28,
+        UInt32(("0" as UnicodeScalar).value): 29,
+        UInt32(("o" as UnicodeScalar).value): 31,
+        UInt32(("u" as UnicodeScalar).value): 32,
+        UInt32(("i" as UnicodeScalar).value): 34,
+        UInt32(("p" as UnicodeScalar).value): 35,
+        UInt32(("l" as UnicodeScalar).value): 37,
+        UInt32(("j" as UnicodeScalar).value): 38,
+        UInt32(("k" as UnicodeScalar).value): 40,
+        UInt32(("n" as UnicodeScalar).value): 45,
+        UInt32(("m" as UnicodeScalar).value): 46,
+    ]
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/CuaActionDriver.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CuaActionDriver.swift
@@ -48,15 +48,11 @@ final class CuaActionDriver: OmiActionDriver {
             }
         }
 
-        // Fallback — clipboard staging
         log("CuaActionDriver: falling back to clipboard paste for type")
         let pasteboard = NSPasteboard.general
-        let previous = pasteboard.string(forType: .string)
-
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
 
-        // Post Cmd+V (key code 9)
         let src = CGEventSource(stateID: .hidSystemState)
         let keyDown = CGEvent(keyboardEventSource: src, virtualKey: 9, keyDown: true)
         let keyUp   = CGEvent(keyboardEventSource: src, virtualKey: 9, keyDown: false)
@@ -64,13 +60,6 @@ final class CuaActionDriver: OmiActionDriver {
         keyUp?.flags   = .maskCommand
         keyDown?.post(tap: .cghidEventTap)
         keyUp?.post(tap: .cghidEventTap)
-
-        try await Task.sleep(for: .milliseconds(100))
-
-        if let previous {
-            pasteboard.clearContents()
-            pasteboard.setString(previous, forType: .string)
-        }
     }
 
     // MARK: - pressShortcut
@@ -127,7 +116,8 @@ final class CuaActionDriver: OmiActionDriver {
         }
 
         let mouseLocation = NSEvent.mouseLocation
-        let screenHeight = NSScreen.screens.first?.frame.height ?? 0
+        let targetScreen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) }) ?? NSScreen.main ?? NSScreen.screens.first
+        let screenHeight = targetScreen?.frame.height ?? 0
         let cgPoint = CGPoint(x: mouseLocation.x, y: screenHeight - mouseLocation.y)
 
         var scroll1: Int32 = 0

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorBubbleView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorBubbleView.swift
@@ -1,0 +1,244 @@
+import SwiftUI
+
+/// Full-screen transparent SwiftUI view rendering all cursor overlay states.
+/// Positioned at `state.cursorPosition` (panel-local coords, top-left origin).
+struct CursorBubbleView: View {
+    @ObservedObject var state: CursorPTTOverlayState
+    @State private var isPulsingRings = false
+    @State private var isSpinning = false
+    @State private var blinkVisible = true
+    @State private var dotIndex = 0
+
+    /// Offset so indicator sits below-right of cursor tip.
+    private let offset = CGPoint(x: 22, y: -6)
+    private let bubbleMaxWidth: CGFloat = 340
+
+    var body: some View {
+        GeometryReader { geometry in
+            if state.phase != .hidden {
+                indicator
+                    .position(clampedPosition(in: geometry))
+            }
+        }
+        .ignoresSafeArea()
+    }
+
+    // MARK: - Position
+
+    private func clampedPosition(in geometry: GeometryProxy) -> CGPoint {
+        // cursorPosition is already in panel-local coords (top-left origin) — no Y-flip needed
+        let rawX = state.cursorPosition.x + offset.x
+        let rawY = state.cursorPosition.y + offset.y
+        // Use a tight clamp for the idle dot; wider clamp for bubbles so they don't overflow
+        let hClamp: CGFloat = state.phase == .idle ? 10 : bubbleMaxWidth / 2 + 20
+        let x = max(hClamp, min(rawX, geometry.size.width - hClamp))
+        let y = max(min(rawY, geometry.size.height - 10), 10)
+        return CGPoint(x: x, y: y)
+    }
+
+    // MARK: - State Router
+
+    @ViewBuilder
+    private var indicator: some View {
+        switch state.phase {
+        case .hidden:
+            EmptyView()
+        case .idle:
+            idleDot
+        case .listening:
+            listeningView
+        case .processing:
+            processingView
+        case .responding, .notifying:
+            respondingBubble
+        }
+    }
+
+    // MARK: - Idle Dot
+
+    private var idleDot: some View {
+        Circle()
+            .fill(Color.indigo)
+            .frame(width: 7, height: 7)
+            .shadow(color: Color.indigo.opacity(0.6), radius: 3)
+            .opacity(0.75)
+    }
+
+    // MARK: - Listening
+
+    private var listeningView: some View {
+        HStack(alignment: .top, spacing: 0) {
+            pulsingDot
+            if !state.transcriptText.isEmpty {
+                transcriptBubble
+                    .padding(.leading, 10)
+            }
+        }
+    }
+
+    private var pulsingDot: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.indigo.opacity(isPulsingRings ? 0.15 : 0.04), lineWidth: 1)
+                .frame(width: isPulsingRings ? 44 : 38, height: isPulsingRings ? 44 : 38)
+                .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: isPulsingRings)
+            Circle()
+                .stroke(Color.indigo.opacity(isPulsingRings ? 0.32 : 0.10), lineWidth: 1.5)
+                .frame(width: isPulsingRings ? 30 : 26, height: isPulsingRings ? 30 : 26)
+                .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true).delay(0.12), value: isPulsingRings)
+            Circle()
+                .fill(Color.indigo)
+                .frame(width: 8, height: 8)
+                .shadow(color: Color.indigo.opacity(0.9), radius: 4)
+        }
+        .frame(width: 44, height: 44)
+        .onAppear { isPulsingRings = true }
+        .onDisappear { isPulsingRings = false }
+    }
+
+    private var transcriptBubble: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("You")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(Color.indigo.opacity(0.8))
+                .textCase(.uppercase)
+                .tracking(0.5)
+            Text(state.transcriptText)
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: bubbleMaxWidth, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(bubble(border: Color.indigo.opacity(0.3)))
+        .environment(\.colorScheme, .dark)
+    }
+
+    // MARK: - Processing
+
+    private var processingView: some View {
+        HStack(alignment: .top, spacing: 0) {
+            spinningDot
+            VStack(alignment: .leading, spacing: 4) {
+                if !state.transcriptText.isEmpty {
+                    Text(state.transcriptText)
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: bubbleMaxWidth, alignment: .leading)
+                }
+                processingDots
+            }
+            .padding(.leading, 10)
+        }
+    }
+
+    private var spinningDot: some View {
+        ZStack {
+            Circle()
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [Color.indigo.opacity(0.8), Color.indigo.opacity(0.1)]),
+                        center: .center
+                    ),
+                    lineWidth: 1.5
+                )
+                .frame(width: 20, height: 20)
+                .rotationEffect(.degrees(isSpinning ? 360 : 0))
+                .animation(.linear(duration: 0.9).repeatForever(autoreverses: false), value: isSpinning)
+            Circle()
+                .fill(Color.indigo)
+                .frame(width: 7, height: 7)
+                .shadow(color: Color.indigo.opacity(0.8), radius: 3)
+        }
+        .frame(width: 22, height: 22)
+        .onAppear { isSpinning = true }
+        .onDisappear { isSpinning = false }
+    }
+
+    private var processingDots: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("omi")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(Color.indigo.opacity(0.8))
+                .textCase(.uppercase)
+                .tracking(0.5)
+            HStack(spacing: 4) {
+                ForEach(0..<3, id: \.self) { i in
+                    Circle()
+                        .fill(Color.indigo)
+                        .frame(width: 5, height: 5)
+                        .opacity(dotIndex == i ? 1.0 : 0.25)
+                }
+            }
+            .task {
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 300_000_000)
+                    dotIndex = (dotIndex + 1) % 3
+                }
+            }
+        }
+        .frame(maxWidth: bubbleMaxWidth, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(bubble(border: Color.indigo.opacity(0.2)))
+        .environment(\.colorScheme, .dark)
+    }
+
+    // MARK: - Responding
+
+    private var respondingBubble: some View {
+        let isNotification = state.phase == .notifying
+        let accentColor = isNotification ? Color.orange : Color.indigo
+        return VStack(alignment: .leading, spacing: 0) {
+            if !state.displayedQuery.isEmpty {
+                Text(isNotification ? state.displayedQuery : "\u{201C}\(state.displayedQuery)\u{201D}")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                    .italic(!isNotification)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, 6)
+                Divider().overlay(Color.white.opacity(0.08))
+                    .padding(.bottom, 6)
+            }
+            Text("omi")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(accentColor.opacity(0.9))
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .padding(.bottom, 3)
+            if state.streamingText.isEmpty {
+                blinkingCursor(color: accentColor)
+            } else {
+                Text(state.streamingText)
+                    .font(.system(size: 13))
+                    .foregroundColor(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: bubbleMaxWidth, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(bubble(border: accentColor.opacity(0.5)))
+        .environment(\.colorScheme, .dark)
+    }
+
+    private func blinkingCursor(color: Color) -> some View {
+        RoundedRectangle(cornerRadius: 1)
+            .fill(color)
+            .frame(width: 6, height: 13)
+            .opacity(blinkVisible ? 1 : 0)
+            .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: blinkVisible)
+            .onAppear { blinkVisible = false }
+            .onDisappear { blinkVisible = true }
+    }
+
+    // MARK: - Shared
+
+    private func bubble(border: Color) -> some View {
+        RoundedRectangle(cornerRadius: 11)
+            .fill(Color(red: 12/255, green: 12/255, blue: 18/255).opacity(0.96))
+            .overlay(RoundedRectangle(cornerRadius: 11).stroke(border, lineWidth: 1))
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorBubbleView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorBubbleView.swift
@@ -8,6 +8,7 @@ struct CursorBubbleView: View {
     @State private var isSpinning = false
     @State private var blinkVisible = true
     @State private var dotIndex = 0
+    @State private var executingPulse = false
 
     /// Offset so indicator sits below-right of cursor tip.
     private let offset = CGPoint(x: 22, y: -6)
@@ -51,6 +52,8 @@ struct CursorBubbleView: View {
             processingView
         case .responding, .notifying:
             respondingBubble
+        case .executing:
+            executingCard
         }
     }
 
@@ -66,6 +69,8 @@ struct CursorBubbleView: View {
 
     // MARK: - Listening
 
+    private var listeningAccent: Color { Color.red }
+
     private var listeningView: some View {
         HStack(alignment: .top, spacing: 0) {
             pulsingDot
@@ -79,17 +84,17 @@ struct CursorBubbleView: View {
     private var pulsingDot: some View {
         ZStack {
             Circle()
-                .stroke(Color.indigo.opacity(isPulsingRings ? 0.15 : 0.04), lineWidth: 1)
+                .stroke(listeningAccent.opacity(isPulsingRings ? 0.15 : 0.04), lineWidth: 1)
                 .frame(width: isPulsingRings ? 44 : 38, height: isPulsingRings ? 44 : 38)
                 .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: isPulsingRings)
             Circle()
-                .stroke(Color.indigo.opacity(isPulsingRings ? 0.32 : 0.10), lineWidth: 1.5)
+                .stroke(listeningAccent.opacity(isPulsingRings ? 0.32 : 0.10), lineWidth: 1.5)
                 .frame(width: isPulsingRings ? 30 : 26, height: isPulsingRings ? 30 : 26)
                 .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true).delay(0.12), value: isPulsingRings)
             Circle()
-                .fill(Color.indigo)
+                .fill(listeningAccent)
                 .frame(width: 8, height: 8)
-                .shadow(color: Color.indigo.opacity(0.9), radius: 4)
+                .shadow(color: listeningAccent.opacity(0.9), radius: 4)
         }
         .frame(width: 44, height: 44)
         .onAppear { isPulsingRings = true }
@@ -100,7 +105,7 @@ struct CursorBubbleView: View {
         VStack(alignment: .leading, spacing: 2) {
             Text("You")
                 .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(Color.indigo.opacity(0.8))
+                .foregroundColor(listeningAccent.opacity(0.8))
                 .textCase(.uppercase)
                 .tracking(0.5)
             Text(state.transcriptText)
@@ -111,7 +116,7 @@ struct CursorBubbleView: View {
         .frame(maxWidth: bubbleMaxWidth, alignment: .leading)
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
-        .background(bubble(border: Color.indigo.opacity(0.3)))
+        .background(bubble(border: listeningAccent.opacity(0.3)))
         .environment(\.colorScheme, .dark)
     }
 
@@ -232,6 +237,83 @@ struct CursorBubbleView: View {
             .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: blinkVisible)
             .onAppear { blinkVisible = false }
             .onDisappear { blinkVisible = true }
+    }
+
+    // MARK: - Executing
+
+    private var executingCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header: indigo dot + "omi" label
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(Color.indigo)
+                    .frame(width: 5, height: 5)
+                Text("omi")
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Color.indigo.opacity(0.9))
+                    .textCase(.uppercase)
+                    .tracking(0.5)
+            }
+            .padding(.bottom, 4)
+
+            // Plan description
+            if !state.executingPlanDescription.isEmpty {
+                Text(state.executingPlanDescription)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                    .italic()
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, 6)
+            }
+
+            // Current step description
+            if !state.executingStepDescription.isEmpty {
+                Text(state.executingStepDescription)
+                    .font(.system(size: 13))
+                    .foregroundColor(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, 6)
+            }
+
+            // Progress dots — only when multi-step
+            if state.executingTotalSteps > 1 {
+                HStack(spacing: 5) {
+                    ForEach(0..<state.executingTotalSteps, id: \.self) { i in
+                        if i < state.executingStepIndex {
+                            // Completed step — filled indigo
+                            Circle()
+                                .fill(Color.indigo)
+                                .frame(width: 6, height: 6)
+                        } else if i == state.executingStepIndex {
+                            // Current step — pulsing filled
+                            Circle()
+                                .fill(Color.indigo)
+                                .frame(width: 6, height: 6)
+                                .opacity(executingPulse ? 0.4 : 1.0)
+                                .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: executingPulse)
+                        } else {
+                            // Upcoming step — empty circle
+                            Circle()
+                                .stroke(Color.indigo.opacity(0.35), lineWidth: 1)
+                                .frame(width: 6, height: 6)
+                        }
+                    }
+                }
+                .onAppear { executingPulse = true }
+                .onDisappear { executingPulse = false }
+                .padding(.bottom, 6)
+            }
+
+            // Bottom hint
+            Text("esc · cancel")
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundColor(.primary.opacity(0.3))
+        }
+        .frame(maxWidth: bubbleMaxWidth, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(bubble(border: Color.indigo.opacity(0.4)))
+        .environment(\.colorScheme, .dark)
     }
 
     // MARK: - Shared

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorBubbleView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorBubbleView.swift
@@ -8,7 +8,6 @@ struct CursorBubbleView: View {
     @State private var isSpinning = false
     @State private var blinkVisible = true
     @State private var dotIndex = 0
-    @State private var executingPulse = false
 
     /// Offset so indicator sits below-right of cursor tip.
     private let offset = CGPoint(x: 22, y: -6)
@@ -242,76 +241,16 @@ struct CursorBubbleView: View {
     // MARK: - Executing
 
     private var executingCard: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header: indigo dot + "omi" label
-            HStack(spacing: 4) {
-                Circle()
-                    .fill(Color.indigo)
-                    .frame(width: 5, height: 5)
-                Text("omi")
-                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                    .foregroundColor(Color.indigo.opacity(0.9))
-                    .textCase(.uppercase)
-                    .tracking(0.5)
-            }
-            .padding(.bottom, 4)
-
-            // Plan description
-            if !state.executingPlanDescription.isEmpty {
-                Text(state.executingPlanDescription)
-                    .font(.system(size: 10))
-                    .foregroundColor(.secondary)
-                    .italic()
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.bottom, 6)
-            }
-
-            // Current step description
-            if !state.executingStepDescription.isEmpty {
-                Text(state.executingStepDescription)
-                    .font(.system(size: 13))
-                    .foregroundColor(.primary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.bottom, 6)
-            }
-
-            // Progress dots — only when multi-step
-            if state.executingTotalSteps > 1 {
-                HStack(spacing: 5) {
-                    ForEach(0..<state.executingTotalSteps, id: \.self) { i in
-                        if i < state.executingStepIndex {
-                            // Completed step — filled indigo
-                            Circle()
-                                .fill(Color.indigo)
-                                .frame(width: 6, height: 6)
-                        } else if i == state.executingStepIndex {
-                            // Current step — pulsing filled
-                            Circle()
-                                .fill(Color.indigo)
-                                .frame(width: 6, height: 6)
-                                .opacity(executingPulse ? 0.4 : 1.0)
-                                .animation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true), value: executingPulse)
-                        } else {
-                            // Upcoming step — empty circle
-                            Circle()
-                                .stroke(Color.indigo.opacity(0.35), lineWidth: 1)
-                                .frame(width: 6, height: 6)
-                        }
-                    }
-                }
-                .onAppear { executingPulse = true }
-                .onDisappear { executingPulse = false }
-                .padding(.bottom, 6)
-            }
-
-            // Bottom hint
+        HStack(spacing: 6) {
+            Circle()
+                .fill(Color.indigo)
+                .frame(width: 5, height: 5)
             Text("esc · cancel")
                 .font(.system(size: 9, design: .monospaced))
                 .foregroundColor(.primary.opacity(0.3))
         }
-        .frame(maxWidth: bubbleMaxWidth, alignment: .leading)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
         .background(bubble(border: Color.indigo.opacity(0.4)))
         .environment(\.colorScheme, .dark)
     }

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayManager.swift
@@ -1,0 +1,218 @@
+import AppKit
+import Combine
+import SwiftUI
+
+/// Manages the full-screen transparent cursor overlay.
+///
+/// Lifecycle:
+///   showIdle()            — called once at startup; tiny dot follows cursor always
+///   startListening(barState:) — pulsing dot + live transcript; subscribes to voiceTranscript
+///   startProcessing()     — spinning ring; between Option release and first AI token
+///   startResponding(barState:) — streaming bubble; intercepts mouse clicks for dismiss
+///   showNotification(_:)  — amber bubble for proactive alerts
+///   dismiss()             — returns to idle; never restores the floating bar
+@MainActor
+final class CursorPTTOverlayManager {
+    static let shared = CursorPTTOverlayManager()
+
+    private(set) var overlayState = CursorPTTOverlayState()
+
+    private var panel: NSPanel?
+    private var cursorTrackingSource: DispatchSourceTimer?
+    private var barStateCancellable: AnyCancellable?
+    private var transcriptCancellable: AnyCancellable?
+    private var queryCancellable: AnyCancellable?
+    private var autoDismissWork: DispatchWorkItem?
+
+    private init() {}
+
+    // MARK: - Public API
+
+    func showIdle() {
+        overlayState.phase = .idle
+        showPanel(interceptMouse: false)
+        startCursorTimer()
+    }
+
+    func startListening(barState: FloatingControlBarState) {
+        autoDismissWork?.cancel()
+        autoDismissWork = nil
+        // Cancel previous response subscriptions so a completing prior response can't
+        // schedule an auto-dismiss that fires and kills the incoming new response.
+        cancelResponseSubscriptions()
+        resetContent()
+        overlayState.phase = .listening
+        panel?.ignoresMouseEvents = true
+
+        transcriptCancellable = barState.$voiceTranscript
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] text in
+                self?.overlayState.transcriptText = text
+            }
+    }
+
+    func startProcessing() {
+        // Keep transcriptCancellable alive — batch transcript arrives during this phase
+        overlayState.phase = .processing
+        panel?.ignoresMouseEvents = true
+    }
+
+    func startResponding(barState: FloatingControlBarState) {
+        cancelResponseSubscriptions()
+        resetContent()
+        // Clear stale message before subscribing so the publisher doesn't immediately
+        // fire with an old complete message and trigger a premature auto-dismiss.
+        barState.currentAIMessage = nil
+        overlayState.phase = .responding
+        panel?.ignoresMouseEvents = false
+
+        queryCancellable = barState.$displayedQuery
+            .receive(on: DispatchQueue.main)
+            .filter { !$0.isEmpty }
+            .sink { [weak self] query in
+                self?.overlayState.displayedQuery = query
+            }
+
+        barStateCancellable = barState.$currentAIMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] message in
+                guard let self else { return }
+                self.overlayState.streamingText = message?.text ?? ""
+                if let message, message.isStreaming {
+                    // New content arriving — cancel any stale auto-dismiss timer
+                    self.autoDismissWork?.cancel()
+                    self.autoDismissWork = nil
+                } else if let message, !message.isStreaming, !message.text.isEmpty {
+                    self.scheduleAutoDismiss(after: 5.0)
+                }
+            }
+    }
+
+    func showNotification(_ notification: FloatingBarNotification) {
+        autoDismissWork?.cancel()
+        cancelResponseSubscriptions()
+        transcriptCancellable = nil
+        overlayState.displayedQuery = notification.title
+        overlayState.streamingText = notification.message
+        overlayState.phase = .notifying
+        panel?.ignoresMouseEvents = false
+        scheduleAutoDismiss(after: 6.0)
+    }
+
+    func dismiss() {
+        autoDismissWork?.cancel()
+        autoDismissWork = nil
+        cancelResponseSubscriptions()
+        transcriptCancellable = nil
+        resetContent()
+        overlayState.phase = .idle
+        panel?.ignoresMouseEvents = true
+    }
+
+    // MARK: - Panel
+
+    private func showPanel(interceptMouse: Bool) {
+        if panel == nil {
+            panel = makePTTPanel()
+        }
+        panel?.ignoresMouseEvents = !interceptMouse
+        panel?.orderFrontRegardless()
+    }
+
+    private func makePTTPanel() -> NSPanel? {
+        let screen = NSScreen.main ?? NSScreen.screens.first
+        let frame = screen?.frame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let p = NSPanel(
+            contentRect: frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        p.isOpaque = false
+        p.backgroundColor = .clear
+        p.level = .screenSaver
+        p.ignoresMouseEvents = true
+        p.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        p.isReleasedWhenClosed = false
+        p.hasShadow = false
+        p.hidesOnDeactivate = false
+
+        // Wrap in a container NSView — assigning NSHostingView directly as contentView
+        // of a borderless panel causes re-entrant constraint crashes (see FloatingControlBarWindow).
+        let hosting = NSHostingView(
+            rootView: CursorBubbleView(state: overlayState)
+                .onTapGesture { [weak self] in self?.dismiss() }
+        )
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        let container = NSView()
+        p.contentView = container
+        container.addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: container.topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        return p
+    }
+
+    // MARK: - Cursor Tracking
+
+    private func startCursorTimer() {
+        stopCursorTimer()
+        let source = DispatchSource.makeTimerSource(queue: .main)
+        source.schedule(deadline: .now(), repeating: .milliseconds(16))
+        source.setEventHandler { [weak self] in
+            guard let self, let panel = self.panel else { return }
+            let globalLoc = NSEvent.mouseLocation
+            let localX = globalLoc.x - panel.frame.minX
+            let localY = panel.frame.height - (globalLoc.y - panel.frame.minY)
+            let newPos = CGPoint(x: localX, y: localY)
+            let dx = newPos.x - self.overlayState.cursorPosition.x
+            let dy = newPos.y - self.overlayState.cursorPosition.y
+            if dx * dx + dy * dy > 1 {
+                self.overlayState.cursorPosition = newPos
+            }
+            self.updatePanelScreenIfNeeded(for: globalLoc)
+        }
+        source.resume()
+        cursorTrackingSource = source
+    }
+
+    private func stopCursorTimer() {
+        cursorTrackingSource?.cancel()
+        cursorTrackingSource = nil
+    }
+
+    private func updatePanelScreenIfNeeded(for location: CGPoint) {
+        guard let panel,
+              let screen = NSScreen.screens.first(where: { NSMouseInRect(location, $0.frame, false) }),
+              screen.frame != panel.frame else { return }
+        panel.setFrame(screen.frame, display: false)
+        panel.orderFrontRegardless()
+    }
+
+    // MARK: - Auto-Dismiss
+
+    private func scheduleAutoDismiss(after delay: TimeInterval) {
+        autoDismissWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.dismiss()
+        }
+        autoDismissWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    // MARK: - Helpers
+
+    private func cancelResponseSubscriptions() {
+        barStateCancellable = nil
+        queryCancellable = nil
+    }
+
+    private func resetContent() {
+        overlayState.streamingText = ""
+        overlayState.transcriptText = ""
+        overlayState.displayedQuery = ""
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayManager.swift
@@ -77,7 +77,7 @@ final class CursorPTTOverlayManager {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] message in
                 guard let self else { return }
-                self.overlayState.streamingText = message?.text ?? ""
+                self.overlayState.streamingText = Self.sanitizeForCursorBubble(message?.text ?? "")
                 if let message, message.isStreaming {
                     // New content arriving — cancel any stale auto-dismiss timer
                     self.autoDismissWork?.cancel()
@@ -107,6 +107,63 @@ final class CursorPTTOverlayManager {
         resetContent()
         overlayState.phase = .idle
         panel?.ignoresMouseEvents = true
+    }
+
+    func startExecution(_ planDescription: String, totalSteps: Int) {
+        autoDismissWork?.cancel()
+        autoDismissWork = nil
+        cancelResponseSubscriptions()
+        transcriptCancellable = nil
+        overlayState.executingPlanDescription = planDescription
+        overlayState.executingStepDescription = ""
+        overlayState.executingStepIndex = 0
+        overlayState.executingTotalSteps = totalSteps
+        overlayState.phase = .executing
+        panel?.ignoresMouseEvents = false
+    }
+
+    func updateExecutingStep(_ stepDescription: String, stepIndex: Int) {
+        overlayState.executingStepDescription = stepDescription
+        overlayState.executingStepIndex = stepIndex
+    }
+
+    func cancelExecution() {
+        overlayState.phase = .idle
+        overlayState.executingPlanDescription = ""
+        overlayState.executingStepDescription = ""
+        panel?.ignoresMouseEvents = true
+    }
+
+    func finishExecution() {
+        overlayState.executingStepDescription = "done"
+        scheduleAutoDismiss(after: 0.8)
+    }
+
+    // MARK: - Cursor-Bubble Sanitization
+
+    /// Strip the `<computer_use>...</computer_use>` block from streaming text
+    /// so the cursor bubble only carries the plain-English preamble. The
+    /// plan window already visualizes the steps separately.
+    static func sanitizeForCursorBubble(_ raw: String) -> String {
+        // Fast path: no opener anywhere, nothing to do.
+        guard raw.contains("<") else { return raw }
+
+        var cleaned = raw
+        let openTag = OmiComputerUseTool.openTag
+
+        // Drop everything from the first opener onward — covers both the
+        // "complete block" and "mid-stream, no closer yet" cases.
+        if let openRange = cleaned.range(of: openTag) {
+            cleaned = String(cleaned[..<openRange.lowerBound])
+        } else if let lastLT = cleaned.lastIndex(of: "<"),
+                  openTag.hasPrefix(String(cleaned[lastLT...]))
+        {
+            // Pre-opener: trailing "<" / "<c" / "<comp"… while the model
+            // is partway through emitting the tag.
+            cleaned = String(cleaned[..<lastLT])
+        }
+
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Panel

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayManager.swift
@@ -109,33 +109,21 @@ final class CursorPTTOverlayManager {
         panel?.ignoresMouseEvents = true
     }
 
-    func startExecution(_ planDescription: String, totalSteps: Int) {
+    func startExecution() {
         autoDismissWork?.cancel()
         autoDismissWork = nil
         cancelResponseSubscriptions()
         transcriptCancellable = nil
-        overlayState.executingPlanDescription = planDescription
-        overlayState.executingStepDescription = ""
-        overlayState.executingStepIndex = 0
-        overlayState.executingTotalSteps = totalSteps
         overlayState.phase = .executing
         panel?.ignoresMouseEvents = false
     }
 
-    func updateExecutingStep(_ stepDescription: String, stepIndex: Int) {
-        overlayState.executingStepDescription = stepDescription
-        overlayState.executingStepIndex = stepIndex
-    }
-
     func cancelExecution() {
         overlayState.phase = .idle
-        overlayState.executingPlanDescription = ""
-        overlayState.executingStepDescription = ""
         panel?.ignoresMouseEvents = true
     }
 
     func finishExecution() {
-        overlayState.executingStepDescription = "done"
         scheduleAutoDismiss(after: 0.8)
     }
 

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayState.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayState.swift
@@ -10,6 +10,7 @@ final class CursorPTTOverlayState: ObservableObject {
         case processing  // spinning ring + animated dots (between release and first token)
         case responding  // response bubble streaming
         case notifying   // proactive notification (amber styling)
+        case executing   // executing a plan (step-by-step progress card)
     }
 
     @Published var phase: Phase = .hidden
@@ -17,4 +18,8 @@ final class CursorPTTOverlayState: ObservableObject {
     @Published var transcriptText: String = ""
     @Published var displayedQuery: String = ""
     @Published var cursorPosition: CGPoint = .zero
+    @Published var executingPlanDescription: String = ""
+    @Published var executingStepDescription: String = ""
+    @Published var executingStepIndex: Int = 0
+    @Published var executingTotalSteps: Int = 0
 }

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayState.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayState.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@MainActor
+final class CursorPTTOverlayState: ObservableObject {
+
+    enum Phase: Equatable {
+        case hidden      // app not ready yet (pre-setup)
+        case idle        // always-on tiny dot
+        case listening   // pulsing dot + live transcript
+        case processing  // spinning ring + animated dots (between release and first token)
+        case responding  // response bubble streaming
+        case notifying   // proactive notification (amber styling)
+    }
+
+    @Published var phase: Phase = .hidden
+    @Published var streamingText: String = ""
+    @Published var transcriptText: String = ""
+    @Published var displayedQuery: String = ""
+    @Published var cursorPosition: CGPoint = .zero
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayState.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/CursorPTTOverlayState.swift
@@ -18,8 +18,4 @@ final class CursorPTTOverlayState: ObservableObject {
     @Published var transcriptText: String = ""
     @Published var displayedQuery: String = ""
     @Published var cursorPosition: CGPoint = .zero
-    @Published var executingPlanDescription: String = ""
-    @Published var executingStepDescription: String = ""
-    @Published var executingStepIndex: Int = 0
-    @Published var executingTotalSteps: Int = 0
 }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1282,25 +1282,10 @@ class FloatingControlBarManager {
             }
         }
 
-        if !window.isVisible {
-            // Show window without persisting enabled state — if the user has the bar
-            // disabled, it will hide again when the AI conversation closes.
-            window.makeKeyAndOrderFront(nil)
-        }
-
-        // Cancel any in-flight windowDidResignKey dismiss animation before saving the
-        // pre-chat center. Without this, the stale completion block fires after the new
-        // query opens and immediately closes it.
+        // Cursor overlay mode: bar stays hidden — do not show window for PTT queries
         window.cancelPendingDismiss()
-
-        // Save pre-chat center so closeAIConversation can restore the original position.
-        // Without this, Escape after a PTT query places the bar at the response window's
-        // center instead of where it was before the chat opened.
         window.savePreChatCenterIfNeeded()
-
-        // Mark the query source before sending so playback behavior is correct.
         window.state.currentQueryFromVoice = fromVoice
-        window.orderFrontRegardless()
 
         // Auto-send the query. PTT bypasses the typed onSendQuery closure, so
         // we need to apply the same router rule here ourselves.
@@ -1339,6 +1324,7 @@ class FloatingControlBarManager {
             // Tear down the inline state we set up for the thinking spinner.
             barWindow.state.aiInputText = ""
             barWindow.closeAIConversation()
+            CursorPTTOverlayManager.shared.dismiss()
             return
         }
         // Chat route: continue with the normal inline flow. sendAIQuery will
@@ -1400,14 +1386,10 @@ class FloatingControlBarManager {
     private func presentNotification(_ notification: FloatingBarNotification, in window: FloatingControlBarWindow) {
         persistNotificationMessageIfNeeded(notification)
 
-        if !window.isVisible {
-            notificationWasTemporarilyShown = true
-            window.orderFrontRegardless()
-        } else {
-            notificationWasTemporarilyShown = false
-        }
-
+        CursorPTTOverlayManager.shared.showNotification(notification)
+        // Also update the hidden bar's state so the dismiss queue and analytics remain consistent
         window.showNotification(notification)
+
         AnalyticsManager.shared.notificationSent(
             notificationId: notification.id.uuidString,
             title: notification.title,
@@ -1415,11 +1397,12 @@ class FloatingControlBarManager {
             surface: "floating_bar"
         )
 
+        // Keep dismiss queue in sync so pending notifications advance correctly
         let dismissWorkItem = DispatchWorkItem { [weak self] in
             self?.dismissNotificationAndAdvanceQueue(trackDismissal: true)
         }
         notificationDismissWorkItem = dismissWorkItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 6.0, execute: dismissWorkItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6.5, execute: dismissWorkItem)
     }
 
     private func dismissNotificationAndAdvanceQueue(trackDismissal: Bool) {
@@ -1578,11 +1561,6 @@ class FloatingControlBarManager {
         return window?.state
     }
 
-    /// Resize the floating bar for PTT state changes.
-    func resizeForPTT(expanded: Bool) {
-        window?.resizeForPTTState(expanded: expanded)
-    }
-
     // MARK: - AI Query
 
     private func prepareVisibleQueryState(_ message: String, in barWindow: FloatingControlBarWindow, fromVoice: Bool) {
@@ -1642,7 +1620,6 @@ class FloatingControlBarManager {
         let screenshotData = await Task.detached { () -> Data? in
             return ScreenCaptureManager.captureScreenData()
         }.value
-        barWindow.orderFrontRegardless()
 
         AnalyticsManager.shared.floatingBarQuerySent(messageLength: message.count, hasScreenshot: screenshotData != nil)
 

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiActionDriver.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiActionDriver.swift
@@ -1,0 +1,30 @@
+import AppKit
+
+@MainActor
+protocol OmiActionDriver: AnyObject {
+    func click(at point: CGPoint, targetApp: NSRunningApplication?) async throws
+    func type(text: String, targetApp: NSRunningApplication?) async throws
+    func pressShortcut(_ keys: String, targetApp: NSRunningApplication?) async throws
+    func scroll(direction: String, amount: Int, targetApp: NSRunningApplication?) async throws
+    func openApp(named: String) async throws
+}
+
+enum OmiActionDriverError: LocalizedError {
+    case elementNotFound(label: String)
+    case appNotFound(name: String)
+    case unparseableShortcut(String)
+    case axPermissionDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .elementNotFound(let label):
+            return "UI element not found: \(label)"
+        case .appNotFound(let name):
+            return "Application not found: \(name)"
+        case .unparseableShortcut(let shortcut):
+            return "Could not parse shortcut: \(shortcut)"
+        case .axPermissionDenied:
+            return "Accessibility permission denied. Grant access in System Settings > Privacy & Security > Accessibility."
+        }
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiActionExecutor.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiActionExecutor.swift
@@ -1,0 +1,109 @@
+import AppKit
+
+@MainActor
+final class OmiActionExecutor {
+    static let shared = OmiActionExecutor()
+    private let driver: OmiActionDriver = CuaActionDriver()
+    private var runningTask: Task<Void, Never>?
+    private init() {}
+
+    func execute(plan: OmiWorkflowPlan, transcript: String) {
+        // Cancel any in-flight plan before starting a new one
+        runningTask?.cancel()
+
+        runningTask = Task {
+            await runPlan(plan, transcript: transcript)
+        }
+    }
+
+    func cancel() {
+        runningTask?.cancel()
+        runningTask = nil
+        OmiEscapeMonitor.shared.disarm()
+        CursorPTTOverlayManager.shared.cancelExecution()
+        OmiPlanWindow.shared.cancelExecution()
+        log("OmiActionExecutor: plan cancelled")
+    }
+
+    // MARK: - Private
+
+    private func runPlan(_ plan: OmiWorkflowPlan, transcript: String) async {
+        let resolved = OmiContextResolver.shared.resolve(plan, transcript: transcript)
+
+        OmiEscapeMonitor.shared.arm { [weak self] in
+            Task { @MainActor in self?.cancel() }
+        }
+
+        CursorPTTOverlayManager.shared.startExecution(resolved.description, totalSteps: resolved.steps.count)
+        OmiPlanWindow.shared.startExecution(
+            planDescription: resolved.description,
+            steps: resolved.steps.map { $0.stepDescription }
+        )
+        log("OmiActionExecutor: starting plan '\(resolved.description)' with \(resolved.steps.count) step(s)")
+
+        var failedIndex: Int?
+        for (index, step) in resolved.steps.enumerated() {
+            guard !Task.isCancelled else { break }
+
+            CursorPTTOverlayManager.shared.updateExecutingStep(step.stepDescription, stepIndex: index)
+            OmiPlanWindow.shared.updateStep(index: index)
+            log("OmiActionExecutor: step \(index + 1)/\(resolved.steps.count) — \(step.stepDescription)")
+
+            do {
+                try await executeStep(step)
+            } catch {
+                log("OmiActionExecutor: step failed — \(error.localizedDescription)")
+                failedIndex = index
+                break
+            }
+
+            // Brief settle between steps — gives the previous action's UI
+            // transition (menu open, window switch) time to land.
+            if index < resolved.steps.count - 1 {
+                try? await Task.sleep(for: .milliseconds(350))
+            }
+        }
+
+        OmiEscapeMonitor.shared.disarm()
+        if !Task.isCancelled {
+            if let failedIndex {
+                OmiPlanWindow.shared.markStepFailed(index: failedIndex)
+            } else {
+                OmiPlanWindow.shared.finishExecution()
+            }
+            CursorPTTOverlayManager.shared.finishExecution()
+            log("OmiActionExecutor: plan complete")
+        }
+        runningTask = nil
+    }
+
+    private func executeStep(_ step: OmiWorkflowStep) async throws {
+        switch step.action {
+        case .click:
+            let label = step.target ?? step.value ?? ""
+            guard !label.isEmpty else { return }
+            guard let result = await OmiElementResolver.shared.resolve(label: label) else {
+                throw OmiActionDriverError.elementNotFound(label: label)
+            }
+            try await driver.click(at: result.point, targetApp: result.app)
+
+        case .type:
+            let text = step.value ?? ""
+            try await driver.type(text: text, targetApp: nil)
+
+        case .shortcut:
+            let keys = step.value ?? ""
+            try await driver.pressShortcut(keys, targetApp: nil)
+
+        case .scroll:
+            let direction = step.scrollDirection ?? "down"
+            let amount = step.scrollAmount ?? 3
+            try await driver.scroll(direction: direction, amount: amount, targetApp: nil)
+
+        case .openApp:
+            let name = step.value ?? step.target ?? ""
+            guard !name.isEmpty else { return }
+            try await driver.openApp(named: name)
+        }
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiActionExecutor.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiActionExecutor.swift
@@ -34,7 +34,7 @@ final class OmiActionExecutor {
             Task { @MainActor in self?.cancel() }
         }
 
-        CursorPTTOverlayManager.shared.startExecution(resolved.description, totalSteps: resolved.steps.count)
+        CursorPTTOverlayManager.shared.startExecution()
         OmiPlanWindow.shared.startExecution(
             planDescription: resolved.description,
             steps: resolved.steps.map { $0.stepDescription }
@@ -45,7 +45,6 @@ final class OmiActionExecutor {
         for (index, step) in resolved.steps.enumerated() {
             guard !Task.isCancelled else { break }
 
-            CursorPTTOverlayManager.shared.updateExecutingStep(step.stepDescription, stepIndex: index)
             OmiPlanWindow.shared.updateStep(index: index)
             log("OmiActionExecutor: step \(index + 1)/\(resolved.steps.count) — \(step.stepDescription)")
 

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiComputerUseTool.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiComputerUseTool.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+enum OmiComputerUseTool {
+
+    static let openTag = "<computer_use>"
+    static let closeTag = "</computer_use>"
+
+    // The text to append to Claude's system prompt.
+    static let systemPromptFragment: String = """
+
+    ## Computer Use
+    When the user asks you to perform an action on their computer — clicking a button, \
+    typing text, opening an app, pressing a keyboard shortcut, scrolling — respond with \
+    a VERY BRIEF (one short sentence, ≤ 12 words) plain-English preamble AND a computer \
+    action plan on its own line at the end.
+
+    Examples of good preambles:
+      "On it — opening Notes."
+      "Got it. Drafting that for you."
+      "Sure, searching Spotify."
+
+    DO NOT in the preamble:
+      - Repeat or quote anything you are about to type (no email bodies, no note contents).
+      - List or narrate the steps ("First I'll open Notes, then…"). The step list is \
+        rendered separately from the `<computer_use>` block.
+      - Add commentary, caveats, or context the user did not ask for.
+
+    The action plan format:
+
+    <computer_use>
+    {"description":"<what you are doing>","steps":[
+      {"action":"<type>","target":"<element label>","value":"<text>","step_description":"<brief label>"}
+    ]}
+    </computer_use>
+
+    Action types: click, type, shortcut, scroll, open_app
+    Value may include context variables: {{selection}} (selected text), {{clipboard}}, \
+    {{transcript}} (what user just said), {{app}} (frontmost app name).
+
+    ### CRITICAL: target labels for `click` steps
+    The `target` is matched against real macOS Accessibility labels. To match, it MUST be:
+      - The EXACT visible button/menu text only — nothing else.
+      - Short (≤ 4 words). One or two words is best.
+      - No descriptions, no positional words, no parentheticals, no icons.
+
+    GOOD: "target":"New Note"          BAD: "target":"New Note button (pencil icon) in toolbar"
+    GOOD: "target":"Send"              BAD: "target":"the blue Send button at the bottom"
+    GOOD: "target":"File"              BAD: "target":"File menu in the menu bar"
+    GOOD: "target":"Search"            BAD: "target":"search input field labeled What do you want to play?"
+
+    If the visible label isn't obvious (e.g. an unlabeled icon), prefer a keyboard \
+    shortcut over a guessed click. Examples: Cmd+N (new), Cmd+F (find), Cmd+L (URL/search), \
+    Cmd+K (command palette), Cmd+, (settings).
+
+    Emit multiple steps for compound commands ("add this to notes" = open Notes + Cmd+N + type).
+    Emit one step for simple commands ("click Export").
+    Only emit one <computer_use> block per response.
+    If you cannot determine the target, ask the user to clarify instead of guessing.
+    """
+
+    /// Scans accumulated text for a complete <computer_use>...</computer_use> block.
+    /// Returns (plan, textWithTagRemoved) if found, nil if no complete tag present.
+    static func parse(from accumulatedText: String) -> (plan: OmiWorkflowPlan, cleanText: String)? {
+        guard let openRange = accumulatedText.range(of: openTag),
+              let closeRange = accumulatedText.range(of: closeTag),
+              openRange.upperBound <= closeRange.lowerBound
+        else { return nil }
+
+        let jsonSubstring = accumulatedText[openRange.upperBound..<closeRange.lowerBound]
+        let jsonString = jsonSubstring.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let jsonData = jsonString.data(using: .utf8) else {
+            log("OmiComputerUseTool: failed to encode JSON string as UTF-8")
+            return nil
+        }
+
+        let decoder = JSONDecoder()
+
+        do {
+            let plan = try decoder.decode(OmiWorkflowPlan.self, from: jsonData)
+
+            // Remove the entire tag block plus surrounding whitespace
+            let fullTagRange = openRange.lowerBound..<closeRange.upperBound
+            var cleanText = accumulatedText
+            cleanText.replaceSubrange(fullTagRange, with: "")
+            cleanText = cleanText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            return (plan, cleanText)
+        } catch {
+            log("OmiComputerUseTool: failed to decode plan — \(error)")
+            return nil
+        }
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiContextResolver.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiContextResolver.swift
@@ -1,0 +1,60 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class OmiContextResolver {
+    static let shared = OmiContextResolver()
+    private init() {}
+
+    /// Resolves all {{variable}} tokens in step values.
+    /// - transcript: the user's PTT voice transcript for this session
+    /// Returns a new OmiWorkflowPlan with all variables substituted.
+    func resolve(_ plan: OmiWorkflowPlan, transcript: String) -> OmiWorkflowPlan {
+        let selection = axSelectedText()
+        let resolvedSelection = selection.isEmpty
+            ? (NSPasteboard.general.string(forType: .string) ?? "")
+            : selection
+
+        let variables: [String: String] = [
+            "{{selection}}": resolvedSelection,
+            "{{clipboard}}": NSPasteboard.general.string(forType: .string) ?? "",
+            "{{transcript}}": transcript,
+            "{{app}}": NSWorkspace.shared.frontmostApplication?.localizedName ?? "",
+        ]
+
+        let resolvedSteps = plan.steps.map { step -> OmiWorkflowStep in
+            var resolvedValue = step.value
+            if var v = resolvedValue {
+                for (token, replacement) in variables {
+                    v = v.replacingOccurrences(
+                        of: token,
+                        with: replacement,
+                        options: .caseInsensitive
+                    )
+                }
+                resolvedValue = v
+            }
+            return OmiWorkflowStep(
+                action: step.action,
+                target: step.target,
+                value: resolvedValue,
+                scrollDirection: step.scrollDirection,
+                scrollAmount: step.scrollAmount,
+                stepDescription: step.stepDescription
+            )
+        }
+
+        return OmiWorkflowPlan(description: plan.description, steps: resolvedSteps)
+    }
+
+    private func axSelectedText() -> String {
+        let system = AXUIElementCreateSystemWide()
+        var focusedRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
+              let focusedRef = focusedRef else { return "" }
+        var selRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(focusedRef as! AXUIElement, kAXSelectedTextAttribute as CFString, &selRef) == .success,
+              let sel = selRef as? String, !sel.isEmpty else { return "" }
+        return sel
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiContextResolver.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiContextResolver.swift
@@ -52,8 +52,9 @@ final class OmiContextResolver {
         var focusedRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &focusedRef) == .success,
               let focusedRef = focusedRef else { return "" }
+        let axElement = focusedRef as! AXUIElement
         var selRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(focusedRef as! AXUIElement, kAXSelectedTextAttribute as CFString, &selRef) == .success,
+        guard AXUIElementCopyAttributeValue(axElement, kAXSelectedTextAttribute as CFString, &selRef) == .success,
               let sel = selRef as? String, !sel.isEmpty else { return "" }
         return sel
     }

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiElementResolver.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiElementResolver.swift
@@ -1,0 +1,342 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+/// Resolves a label to a screen coordinate by walking the frontmost app's AX tree.
+/// Returns CG screen coordinates (top-left origin) so callers can post CGEvents
+/// directly without a coordinate-space round-trip.
+///
+/// Does NOT gate on AXIsProcessTrusted() — it returns stale `false` on macOS 26
+/// and after app re-signs even when permission is granted (see
+/// AppState.checkAccessibilityPermission for the workaround).
+final class OmiElementResolver: @unchecked Sendable {
+    static let shared = OmiElementResolver()
+    private init() {}
+
+    func resolve(label: String) async -> (point: CGPoint, app: NSRunningApplication)? {
+        guard let frontmostApp = await MainActor.run(body: { NSWorkspace.shared.frontmostApplication }) else {
+            log("OmiElementResolver: no frontmost application found")
+            return nil
+        }
+
+        let pid = frontmostApp.processIdentifier
+        let bundleId = frontmostApp.bundleIdentifier ?? frontmostApp.localizedName ?? "unknown"
+
+        let frame: CGRect? = await Task.detached(priority: .userInitiated) {
+            let appElement = AXUIElementCreateApplication(pid)
+            AXUIElementSetMessagingTimeout(appElement, 0.4)
+
+            // Electron apps (Spotify, Slack, VS Code, Discord, Cursor, Notion,
+            // Figma) only expose their full AX tree when this is set. Native
+            // apps return kAXErrorAttributeUnsupported — ignore.
+            _ = AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+
+            return Self.findBestMatch(in: appElement, query: label)
+        }.value
+
+        guard let frame else {
+            log("OmiElementResolver: no matching element found for label '\(label)' in app \(bundleId)")
+            return nil
+        }
+
+        let centerPoint = CGPoint(x: frame.midX, y: frame.midY)
+        log("OmiElementResolver: resolved '\(label)' to point \(centerPoint) in app \(bundleId)")
+        return (point: centerPoint, app: frontmostApp)
+    }
+
+    private static func findBestMatch(in appElement: AXUIElement, query: String) -> CGRect? {
+        let queryNormalized = normalizeLabel(query)
+        guard !queryNormalized.isEmpty else { return nil }
+        let queryWords = meaningfulWords(from: queryNormalized)
+
+        var bestScore = 0
+        var bestFrame: CGRect?
+
+        let deadline = Date().addingTimeInterval(0.5)
+        var nodesVisited = 0
+        let nodeBudget = 3000
+        // Anything ≥ 110 means exact label match with role boost — no chance
+        // a deeper node beats it, so we stop walking.
+        let earlyExitScore = 110
+
+        func walk(_ node: AXUIElement, depth: Int) {
+            guard depth < 14,
+                  nodesVisited < nodeBudget,
+                  Date() < deadline,
+                  bestScore < earlyExitScore
+            else { return }
+            nodesVisited += 1
+
+            if let attrs = batchReadAttributes(node) {
+                let role = attrs.role
+                let roleMatters = role.isEmpty || pointableRoles.contains(role) || role == "AXStaticText"
+                if roleMatters,
+                   let score = scoreCandidate(
+                       queryNormalized: queryNormalized,
+                       queryWords: queryWords,
+                       role: role,
+                       title: attrs.title,
+                       description: attrs.description,
+                       value: attrs.value,
+                       help: attrs.help
+                   ),
+                   score > bestScore,
+                   let frame = attrs.frame,
+                   frame.width > 0, frame.height > 0,
+                   frame.width <= 800, frame.height <= 800,
+                   !isDisabled(node)
+                {
+                    bestScore = score
+                    bestFrame = frame
+                    if bestScore >= earlyExitScore { return }
+                }
+            }
+
+            var childrenRef: AnyObject?
+            if AXUIElementCopyAttributeValue(node, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+               let children = childrenRef as? [AXUIElement] {
+                for child in children {
+                    if Date() > deadline || nodesVisited >= nodeBudget || bestScore >= earlyExitScore { return }
+                    walk(child, depth: depth + 1)
+                }
+            }
+        }
+
+        walk(appElement, depth: 0)
+
+        // Menu bar items aren't reachable from the focused window tree but
+        // are highly relevant ("click File menu"). Skip if budget exhausted.
+        if bestScore < earlyExitScore, Date() < deadline, nodesVisited < nodeBudget {
+            var menuBarRef: AnyObject?
+            if AXUIElementCopyAttributeValue(appElement, kAXMenuBarAttribute as CFString, &menuBarRef) == .success,
+               let menuBar = menuBarRef {
+                walk(menuBar as! AXUIElement, depth: 0)
+            }
+        }
+
+        return bestFrame
+    }
+
+    private static let pointableRoles: Set<String> = [
+        "AXButton", "AXMenuItem", "AXMenuBarItem", "AXPopUpButton",
+        "AXCheckBox", "AXRadioButton", "AXLink", "AXTabGroup",
+        "AXTextField", "AXTextArea", "AXComboBox", "AXSlider",
+        "AXMenuButton", "AXToolbar", "AXImage", "AXCell", "AXRow"
+    ]
+
+    private static let roleHintKeywords: [String: Set<String>] = [
+        "menu": ["AXMenu", "AXMenuItem", "AXMenuBarItem", "AXMenuButton", "AXPopUpButton"],
+        "button": ["AXButton", "AXMenuButton", "AXPopUpButton"],
+        "tab": ["AXTabGroup"],
+        "field": ["AXTextField", "AXTextArea", "AXComboBox"],
+        "input": ["AXTextField", "AXTextArea", "AXComboBox"],
+        "search": ["AXTextField", "AXSearchField", "AXComboBox"],
+        "textbox": ["AXTextField", "AXTextArea"],
+        "checkbox": ["AXCheckBox"],
+        "radio": ["AXRadioButton"],
+        "link": ["AXLink"],
+        "slider": ["AXSlider"],
+        "cell": ["AXCell", "AXRow"],
+        "row": ["AXRow", "AXCell"],
+        "image": ["AXImage"],
+        "icon": ["AXImage", "AXButton"],
+        "toolbar": ["AXToolbar"]
+    ]
+
+    private static func scoreCandidate(
+        queryNormalized: String,
+        queryWords: Set<String>,
+        role: String,
+        title: String,
+        description: String,
+        value: String,
+        help: String
+    ) -> Int? {
+        let isPointable = pointableRoles.contains(role)
+        var roleBoost = isPointable ? 10 : 0
+        for (keyword, matchingRoles) in roleHintKeywords {
+            if queryNormalized.contains(keyword) && matchingRoles.contains(role) {
+                roleBoost += 8
+                break
+            }
+        }
+
+        let candidateTexts = [title, description, value, help].filter { !$0.isEmpty }
+        guard !candidateTexts.isEmpty else { return nil }
+
+        var bestScore = 0
+        for text in candidateTexts {
+            let normalized = normalizeLabel(text)
+            if normalized.isEmpty { continue }
+
+            if normalized == queryNormalized {
+                bestScore = max(bestScore, 100)
+                continue
+            }
+            if normalized.hasPrefix(queryNormalized) || normalized.hasSuffix(queryNormalized) {
+                bestScore = max(bestScore, 80)
+                continue
+            }
+            if normalized.contains(queryNormalized) || queryNormalized.contains(normalized) {
+                bestScore = max(bestScore, 60)
+                continue
+            }
+            let textWords = meaningfulWords(from: normalized)
+            let overlap = textWords.intersection(queryWords)
+            if !overlap.isEmpty {
+                let coverage = Double(overlap.count) / Double(max(queryWords.count, 1))
+                bestScore = max(bestScore, Int(coverage * 40))
+            }
+            if bestScore < 30, jaroWinklerSimilarity(normalized, queryNormalized) >= 0.85 {
+                let similarity = jaroWinklerSimilarity(normalized, queryNormalized)
+                bestScore = max(bestScore, Int(similarity * 35))
+            }
+        }
+
+        guard bestScore > 0 else { return nil }
+        return bestScore + roleBoost
+    }
+
+    private static func normalizeLabel(_ raw: String) -> String {
+        var s = raw.lowercased()
+        s = s.replacingOccurrences(of: "&", with: "")
+        s = s.replacingOccurrences(of: "…", with: "")
+        s = s.replacingOccurrences(of: "...", with: "")
+        if let parenIndex = s.firstIndex(of: "(") {
+            s = String(s[..<parenIndex])
+        }
+        let collapsed = s
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static let stopWords: Set<String> = [
+        "the", "a", "an", "this", "that", "these", "those",
+        "button", "icon", "menu", "bar", "tab", "panel", "item", "option",
+        "link", "field", "input", "box", "area", "section", "row", "cell",
+        "on", "in", "at", "of", "to", "for", "with"
+    ]
+
+    private static func meaningfulWords(from text: String) -> Set<String> {
+        let rawWords = text.split { !$0.isLetter && !$0.isNumber }.map(String.init)
+        let filtered = rawWords.filter { !stopWords.contains($0) && $0.count > 1 }
+        return Set(filtered.isEmpty ? rawWords : filtered)
+    }
+
+    private static func jaroWinklerSimilarity(_ s1: String, _ s2: String) -> Double {
+        let a = Array(s1)
+        let b = Array(s2)
+        if a.isEmpty && b.isEmpty { return 1.0 }
+        if a.isEmpty || b.isEmpty { return 0.0 }
+
+        let matchDistance = max(a.count, b.count) / 2 - 1
+        var aMatches = [Bool](repeating: false, count: a.count)
+        var bMatches = [Bool](repeating: false, count: b.count)
+        var matches = 0
+
+        for i in 0..<a.count {
+            let start = max(0, i - matchDistance)
+            let end = min(i + matchDistance + 1, b.count)
+            guard start < end else { continue }
+            for j in start..<end {
+                if bMatches[j] { continue }
+                if a[i] != b[j] { continue }
+                aMatches[i] = true
+                bMatches[j] = true
+                matches += 1
+                break
+            }
+        }
+
+        if matches == 0 { return 0.0 }
+
+        var transpositions = 0
+        var k = 0
+        for i in 0..<a.count where aMatches[i] {
+            while !bMatches[k] { k += 1 }
+            if a[i] != b[k] { transpositions += 1 }
+            k += 1
+        }
+
+        let m = Double(matches)
+        let jaro = (m / Double(a.count)
+                    + m / Double(b.count)
+                    + (m - Double(transpositions) / 2.0) / m) / 3.0
+
+        var prefixLength = 0
+        for i in 0..<min(4, min(a.count, b.count)) {
+            if a[i] == b[i] { prefixLength += 1 } else { break }
+        }
+        return jaro + Double(prefixLength) * 0.1 * (1.0 - jaro)
+    }
+
+    private struct BatchedAttributes {
+        let role: String
+        let title: String
+        let description: String
+        let value: String
+        let help: String
+        let frame: CGRect?
+    }
+
+    private static let batchedAttributeNames: [CFString] = [
+        kAXRoleAttribute as CFString,
+        kAXTitleAttribute as CFString,
+        kAXDescriptionAttribute as CFString,
+        kAXValueAttribute as CFString,
+        kAXHelpAttribute as CFString,
+        kAXPositionAttribute as CFString,
+        kAXSizeAttribute as CFString
+    ]
+
+    private static func batchReadAttributes(_ node: AXUIElement) -> BatchedAttributes? {
+        var rawValues: CFArray?
+        let status = AXUIElementCopyMultipleAttributeValues(
+            node,
+            batchedAttributeNames as CFArray,
+            AXCopyMultipleAttributeOptions(rawValue: 0),
+            &rawValues
+        )
+        guard status == .success,
+              let rawValues = rawValues as [AnyObject]?,
+              rawValues.count == batchedAttributeNames.count
+        else {
+            return nil
+        }
+
+        func stringAt(_ index: Int) -> String {
+            if let s = rawValues[index] as? String { return s }
+            return ""
+        }
+
+        var frame: CGRect?
+        let positionRaw = rawValues[5]
+        let sizeRaw = rawValues[6]
+        if CFGetTypeID(positionRaw) == AXValueGetTypeID(),
+           CFGetTypeID(sizeRaw) == AXValueGetTypeID() {
+            var position = CGPoint.zero
+            var size = CGSize.zero
+            AXValueGetValue(positionRaw as! AXValue, .cgPoint, &position)
+            AXValueGetValue(sizeRaw as! AXValue, .cgSize, &size)
+            frame = CGRect(origin: position, size: size)
+        }
+
+        return BatchedAttributes(
+            role: stringAt(0),
+            title: stringAt(1),
+            description: stringAt(2),
+            value: stringAt(3),
+            help: stringAt(4),
+            frame: frame
+        )
+    }
+
+    private static func isDisabled(_ node: AXUIElement) -> Bool {
+        var valueRef: AnyObject?
+        guard AXUIElementCopyAttributeValue(node, kAXEnabledAttribute as CFString, &valueRef) == .success else {
+            return false
+        }
+        return (valueRef as? Bool) == false
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiEscapeMonitor.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiEscapeMonitor.swift
@@ -7,17 +7,17 @@ final class OmiEscapeMonitor {
     private var onCancel: (() -> Void)?
     private init() {}
 
+    // Global monitor fires even when Omi is in the background (which is always the
+    // case during plan execution). Trade-off: global monitors cannot consume events,
+    // so ESC also propagates to the frontmost app.
     func arm(onCancel: @escaping () -> Void) {
         // Disarm any existing monitor first (safety)
         disarm()
         self.onCancel = onCancel
-        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            // Escape keyCode is 53
+        monitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == 53 {
                 self?.fire()
-                return nil  // consume the event
             }
-            return event
         }
         log("OmiEscapeMonitor: armed")
     }

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiEscapeMonitor.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiEscapeMonitor.swift
@@ -1,0 +1,39 @@
+import AppKit
+
+@MainActor
+final class OmiEscapeMonitor {
+    static let shared = OmiEscapeMonitor()
+    private var monitor: Any?
+    private var onCancel: (() -> Void)?
+    private init() {}
+
+    func arm(onCancel: @escaping () -> Void) {
+        // Disarm any existing monitor first (safety)
+        disarm()
+        self.onCancel = onCancel
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            // Escape keyCode is 53
+            if event.keyCode == 53 {
+                self?.fire()
+                return nil  // consume the event
+            }
+            return event
+        }
+        log("OmiEscapeMonitor: armed")
+    }
+
+    func disarm() {
+        if let m = monitor {
+            NSEvent.removeMonitor(m)
+            monitor = nil
+        }
+        onCancel = nil
+        log("OmiEscapeMonitor: disarmed")
+    }
+
+    private func fire() {
+        log("OmiEscapeMonitor: Escape pressed — cancelling plan")
+        onCancel?()
+        disarm()
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiPlanWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiPlanWindow.swift
@@ -1,0 +1,250 @@
+import AppKit
+import SwiftUI
+
+/// Standalone floating window that lists every step of a computer-use plan
+/// with progress indicators. Lives independently of the cursor bubble so
+/// the user can read the full plan while the cursor does its work.
+@MainActor
+final class OmiPlanWindow {
+    static let shared = OmiPlanWindow()
+
+    private let state = OmiPlanWindowState()
+    private var panel: NSPanel?
+    private var autoDismissWork: DispatchWorkItem?
+
+    private init() {}
+
+    // MARK: - Public API (called from OmiActionExecutor)
+
+    func startExecution(planDescription: String, steps: [String]) {
+        autoDismissWork?.cancel()
+        autoDismissWork = nil
+
+        state.planDescription = planDescription
+        state.stepDescriptions = steps
+        state.activeStepIndex = 0
+        state.failedStepIndex = nil
+
+        showPanel()
+    }
+
+    func updateStep(index: Int) {
+        state.activeStepIndex = index
+    }
+
+    func markStepFailed(index: Int) {
+        state.failedStepIndex = index
+        scheduleDismiss(after: 3.0)
+    }
+
+    func cancelExecution() {
+        scheduleDismiss(after: 0.5)
+    }
+
+    func finishExecution() {
+        // Bumping the active index past the end makes every row render as
+        // .completed — no separate "isFinished" flag needed.
+        state.activeStepIndex = state.stepDescriptions.count
+        scheduleDismiss(after: 1.5)
+    }
+
+    // MARK: - Panel Lifecycle
+
+    private func showPanel() {
+        if panel == nil {
+            panel = makePanel()
+        }
+        positionPanel()
+        panel?.orderFrontRegardless()
+    }
+
+    private func dismiss() {
+        panel?.orderOut(nil)
+    }
+
+    private func scheduleDismiss(after seconds: TimeInterval) {
+        autoDismissWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            Task { @MainActor in self?.dismiss() }
+        }
+        autoDismissWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: work)
+    }
+
+    private func makePanel() -> NSPanel {
+        let initialSize = NSRect(x: 0, y: 0, width: 320, height: 200)
+        let p = NSPanel(
+            contentRect: initialSize,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        p.isOpaque = false
+        p.backgroundColor = .clear
+        p.level = .floating
+        p.hasShadow = true
+        p.isMovableByWindowBackground = true
+        p.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        p.isReleasedWhenClosed = false
+        p.hidesOnDeactivate = false
+
+        // Borderless panels crash if NSHostingView is assigned directly as
+        // contentView. Wrap in a plain container (same pattern as
+        // CursorPTTOverlayManager).
+        let hosting = NSHostingView(rootView: OmiPlanWindowView(state: state))
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        let container = NSView()
+        p.contentView = container
+        container.addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: container.topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        return p
+    }
+
+    /// Anchor the panel to the top-right of the screen containing the
+    /// cursor, with a comfortable inset from the menu bar.
+    private func positionPanel() {
+        guard let panel else { return }
+        let mouseLocation = NSEvent.mouseLocation
+        let targetScreen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        guard let targetScreen else { return }
+
+        let panelSize = panel.frame.size
+        let inset: CGFloat = 18
+        let topInset: CGFloat = 44 // clear of the menu bar
+        let origin = CGPoint(
+            x: targetScreen.visibleFrame.maxX - panelSize.width - inset,
+            y: targetScreen.visibleFrame.maxY - panelSize.height - topInset
+        )
+        panel.setFrameOrigin(origin)
+    }
+}
+
+// MARK: - State
+
+@MainActor
+final class OmiPlanWindowState: ObservableObject {
+    @Published var planDescription: String = ""
+    @Published var stepDescriptions: [String] = []
+    @Published var activeStepIndex: Int = 0
+    @Published var failedStepIndex: Int? = nil
+}
+
+// MARK: - View
+
+private struct OmiPlanWindowView: View {
+    @ObservedObject var state: OmiPlanWindowState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Header
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.indigo)
+                    .frame(width: 6, height: 6)
+                Text("OMI · COMPUTER USE")
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .tracking(0.8)
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text("esc · cancel")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundColor(.secondary.opacity(0.6))
+            }
+
+            if !state.planDescription.isEmpty {
+                Text(state.planDescription)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Divider().opacity(0.4)
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(Array(state.stepDescriptions.enumerated()), id: \.offset) { index, description in
+                    stepRow(index: index, description: description)
+                }
+            }
+        }
+        .padding(14)
+        .frame(width: 320, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(.ultraThinMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+        )
+    }
+
+    @ViewBuilder
+    private func stepRow(index: Int, description: String) -> some View {
+        let status = statusFor(index: index)
+        HStack(alignment: .top, spacing: 10) {
+            indicator(for: status)
+                .frame(width: 14, height: 14)
+                .padding(.top, 1)
+            Text(description)
+                .font(.system(size: 12))
+                .foregroundColor(textColor(for: status))
+                .strikethrough(status == .completed, color: .secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private enum StepStatus { case completed, active, pending, failed }
+
+    private func statusFor(index: Int) -> StepStatus {
+        if state.failedStepIndex == index { return .failed }
+        if index < state.activeStepIndex { return .completed }
+        if index == state.activeStepIndex { return .active }
+        return .pending
+    }
+
+    @ViewBuilder
+    private func indicator(for status: StepStatus) -> some View {
+        switch status {
+        case .completed:
+            ZStack {
+                Circle().fill(Color.indigo)
+                Image(systemName: "checkmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundColor(.white)
+            }
+        case .active:
+            ZStack {
+                Circle().stroke(Color.indigo, lineWidth: 1.5)
+                Circle()
+                    .fill(Color.indigo)
+                    .frame(width: 6, height: 6)
+            }
+        case .pending:
+            Circle().stroke(Color.secondary.opacity(0.35), lineWidth: 1)
+        case .failed:
+            ZStack {
+                Circle().fill(Color.red)
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundColor(.white)
+            }
+        }
+    }
+
+    private func textColor(for status: StepStatus) -> Color {
+        switch status {
+        case .completed: return .secondary
+        case .active: return .primary
+        case .pending: return .secondary.opacity(0.7)
+        case .failed: return .red
+        }
+    }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/OmiWorkflowPlan.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/OmiWorkflowPlan.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum OmiActionType: String, Codable {
+    case click
+    case type
+    case shortcut
+    case scroll
+    case openApp = "open_app"
+}
+
+struct OmiWorkflowStep: Codable {
+    let action: OmiActionType
+    let target: String?
+    let value: String?
+    let scrollDirection: String?
+    let scrollAmount: Int?
+    let stepDescription: String
+
+    enum CodingKeys: String, CodingKey {
+        case action
+        case target
+        case value
+        case scrollDirection = "scroll_direction"
+        case scrollAmount = "scroll_amount"
+        case stepDescription = "step_description"
+    }
+}
+
+struct OmiWorkflowPlan: Codable {
+    let description: String
+    let steps: [OmiWorkflowStep]
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -136,15 +136,6 @@ class PushToTalkManager: ObservableObject {
       return
     }
 
-    // Let the first shortcut press reveal the compact bar instead of requiring it
-    // to already be visible. This keeps onboarding step 3 quiet on entry while
-    // still allowing the user to trigger the bar by pressing the key.
-    if pttActive, !FloatingControlBarManager.shared.isVisible {
-      FloatingControlBarManager.shared.show()
-    }
-
-    guard FloatingControlBarManager.shared.isVisible else { return }
-
     if pttActive {
       handleShortcutDown()
     } else if shortcut.modifierOnly {
@@ -445,6 +436,7 @@ class PushToTalkManager: ObservableObject {
 
     guard hasQuery else {
       log("PushToTalkManager: no transcript to send")
+      CursorPTTOverlayManager.shared.dismiss()
       return
     }
 
@@ -463,6 +455,9 @@ class PushToTalkManager: ObservableObject {
     } else {
       log("PushToTalkManager: sending query (\(query.count) chars): \(query)")
       FloatingControlBarManager.shared.openAIInputWithQuery(query, fromVoice: true)
+    }
+    if let barState {
+      CursorPTTOverlayManager.shared.startResponding(barState: barState)
     }
   }
 
@@ -626,6 +621,7 @@ class PushToTalkManager: ObservableObject {
       transcriptSegments.append(segment.text)
     }
     lastInterimText = ""
+    barState?.voiceTranscript = transcriptSegments.joined(separator: " ")
 
     // In finalizing state, segments mean backend is done — send immediately
     if state == .finalizing {
@@ -650,14 +646,18 @@ class PushToTalkManager: ObservableObject {
       barState.voiceFollowUpTranscript = ""
     }
 
-    // Skip resize when in follow-up mode, expanded AI conversation, or during onboarding
-    // (during onboarding the floating bar shouldn't appear as a separate window)
-    let isOnboarding = !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-    guard !skipResize && !barState.isVoiceFollowUp && !barState.showingAIConversation && !isOnboarding else { return }
-    if barState.isVoiceListening && !wasListening {
-      FloatingControlBarManager.shared.resizeForPTT(expanded: true)
-    } else if !barState.isVoiceListening && wasListening {
-      FloatingControlBarManager.shared.resizeForPTT(expanded: false)
+    // Drive cursor overlay
+    let overlayPhase = CursorPTTOverlayManager.shared.overlayState.phase
+    if isShowingVoiceUI && !wasListening {
+      CursorPTTOverlayManager.shared.startListening(barState: barState)
+    } else if !isShowingVoiceUI && overlayPhase == .listening {
+      if state == .idle {
+        // Cancelled or immediate finalize with no audio — return to idle dot
+        CursorPTTOverlayManager.shared.dismiss()
+      } else {
+        // Any finalization path (finalizing, pendingLockDecision) — show spinner
+        CursorPTTOverlayManager.shared.startProcessing()
+      }
     }
   }
 }

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -204,13 +204,11 @@ struct DesktopHomeView: View {
               // Set up floating control bar (only show if user hasn't disabled it)
               FloatingControlBarManager.shared.setup(
                 appState: appState, chatProvider: viewModelContainer.chatProvider)
-              if FloatingControlBarManager.shared.isEnabled {
-                FloatingControlBarManager.shared.show()
-              }
 
               // Set up push-to-talk voice input
               if let barState = FloatingControlBarManager.shared.barState {
                 PushToTalkManager.shared.setup(barState: barState)
+                CursorPTTOverlayManager.shared.showIdle()
               }
             }
             .task {

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -2766,7 +2766,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 // Strip computer_use tag from final text and fire executor
                 if let computeResult = OmiComputerUseTool.parse(from: messageText) {
                     messageText = computeResult.cleanText
-                    OmiActionExecutor.shared.execute(plan: computeResult.plan, transcript: "")
+                    OmiActionExecutor.shared.execute(plan: computeResult.plan, transcript: trimmedText)
                     log("OmiComputerUseTool: fired executor for plan '\(computeResult.plan.description)'")
                 }
 

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -1698,6 +1698,9 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             "project_claude_md:\(projectClaudeMdContent?.count ?? 0)c, " +
             "skills:\(skillsSectionSize)c")
 
+        // Append computer use capability instructions
+        prompt += OmiComputerUseTool.systemPromptFragment
+
         return prompt
     }
 
@@ -2755,10 +2758,18 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             flushStreamingBuffer()
 
             // Determine the final text to display and save
-            let messageText: String
+            var messageText: String
             if let index = messages.firstIndex(where: { $0.id == aiMessageId }) {
                 // Message still in memory — update it in-place
                 messageText = messages[index].text.isEmpty ? queryResult.text : messages[index].text
+
+                // Strip computer_use tag from final text and fire executor
+                if let computeResult = OmiComputerUseTool.parse(from: messageText) {
+                    messageText = computeResult.cleanText
+                    OmiActionExecutor.shared.execute(plan: computeResult.plan, transcript: "")
+                    log("OmiComputerUseTool: fired executor for plan '\(computeResult.plan.description)'")
+                }
+
                 messages[index].text = messageText
                 messages[index].isStreaming = false
                 messages[index].metadata = MessageMetadata(


### PR DESCRIPTION
## Summary

adds **computer use** to the Omi desktop app on top of a new cursor-anchored PTT overlay. The assistant can now drive the Mac directly: "open Notes and add this", etc.

## Demo
[![Watch Demo Here](https://drive.google.com/file/d/1qIeyHRrGrEKBgvKmNdAasnOaD4lWxSKz/view?usp=sharing)](https://drive.google.com/file/d/1qIeyHRrGrEKBgvKmNdAasnOaD4lWxSKz/view?usp=sharing)

## What's in it

**Cursor PTT overlay** — replaces the floating pill bar with a compact indicator that lives next to the mouse pointer. Idle dot → pulsing listening dot + live transcript → spinner → streaming response bubble. Doesn't steal focus, doesn't fight for screen space.

**Computer use** — the assistant emits a `<computer_use>` JSON plan; the app parses it and executes each step.
- Action types: `click`, `type`, `shortcut`, `scroll`, `open_app`
- `OmiElementResolver` resolves `click` targets against the frontmost app's macOS Accessibility tree (batched reads, role-aware scoring, label normalization, Jaro-Winkler fuzzy fallback, 500ms / 3000-node deadline)
- `CuaActionDriver` posts CGEvents; typing prefers AX direct insertion with a clipboard-staged Cmd+V fallback
- Context variables: `{{selection}}`, `{{clipboard}}`, `{{transcript}}`, `{{app}}`
- ESC cancels in-flight plans

**Plan window** — standalone floating panel listing every step with done / active / pending / failed indicators. Auto-dismisses on completion.

**Streaming hygiene** — the cursor bubble strips the `<computer_use>` block (including partial mid-stream openers) so the user only sees the brief prose preamble, not the JSON.

## Design notes

- `AXIsProcessTrusted()` is **not** used as a gate — it returns stale `false` on macOS 26 / after re-signs.
- `AXManualAccessibility = true` is set per-app so Electron apps that respect it (VS Code, Slack, Notion) populate their AX tree.
- Coordinates flow end-to-end in CG screen space — no AppKit round-trip, so multi-monitor clicks land correctly.
- System prompt steers the model toward short, AX-style click targets and a brief plain-English preamble (no narrated step lists, no echoing typed contents).

## Known limitations

Time-boxed demo, so a few rough edges remain — all solvable, just out of scope here:

- **Electron apps that ignore `AXManualAccessibility` (notably Spotify)** expose almost nothing through AX, so `click` steps miss. Solvable with a vision fallback (CoreML/OCR refinement of the LLM's coordinate hint).
- **No retry on a failed step.** Plan aborts on first error; a one-shot re-resolve after a short settle would handle most transient misses.

## How to try it

Push to talk, then:
- "Open Notes and write down: meeting with Sofia tomorrow at 3"
- "Open Spoify"

Watch the plan window list each step as it runs.