### PR TITLE
fix(android): R8 missing-class for firebase KTX in release build

### DIFF
--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -48,6 +48,11 @@
 
 # You might not be using firebase
 -keep class com.google.firebase.** { *; }
+# firebase-auth-ktx references com.google.firebase.ktx.Firebase, which was removed
+# from firebase-common in the BoM pulled by recent firebase_core. The KTX
+# Firebase.auth extension isn't invoked at runtime (the firebase_auth plugin uses
+# the Java API), so suppress R8's missing-class error for the transitional KTX pkg.
+-dontwarn com.google.firebase.ktx.**
 -keep class com.builttoroam.devicecalendar.** { *; }
 
 -keep class com.pravera.flutter_foreground_task.service.** { *; }


### PR DESCRIPTION
## Summary

The **prod release AAB build fails at R8 minification** with:
```
ERROR: R8: Missing class com.google.firebase.ktx.Firebase
(referenced from: ...AuthKt.auth(com.google.firebase.ktx.Firebase, com.google.firebase.FirebaseApp) and 4 other contexts)
Execution failed for task ':app:minifyProdReleaseWithR8'.
```

### Root cause
`com.google.firebase.ktx.Firebase` was **removed** from `firebase-common` in the Firebase Android BoM pulled by the current `firebase_core` (3.13.0), but the transitional **`firebase-auth-ktx`** artifact still references it via the `Firebase.auth` Kotlin extension. R8 sees the dangling reference during minification and (in current AGP) treats a missing referenced class as a hard error rather than a warning.

`proguard-rules.pro` has `-keep class com.google.firebase.** { *; }`, but `-keep` only retains classes that **exist** — it does not suppress *missing-class* errors. R8 itself prescribes the fix in `missing_rules.txt`: a `-dontwarn` for the missing reference.

The KTX `Firebase.auth` extension is **not used at runtime** (the `firebase_auth` Flutter plugin uses the Java `FirebaseAuth` API), so suppressing the reference is safe.

### Fix
Add to `app/android/app/proguard-rules.pro`:
```
-dontwarn com.google.firebase.ktx.**
```

## Verification
- Building a **dev release** AAB (`flutter build appbundle --flavor dev --release`) on macOS exercises the **same** `proguard-rules.pro` + Firebase deps + `minify…ReleaseWithR8` task as the failing prod build (flavor doesn't change Firebase versions; the `release` buildType sets `minifyEnabled true` for both flavors). Build in progress — I'll confirm R8 passes and the bundle is produced.
- (Prod-flavor build needs `.prod.env`/release keystore not present in the dev sandbox, so dev-release is used for the R8 check; the R8 rules are identical.)

## Test plan
- [ ] `flutter build appbundle --flavor dev --release` gets past `minifyDevReleaseWithR8` and produces an `.aab`.
- [ ] CI prod build (`bundleProdRelease`) passes `minifyProdReleaseWithR8`.
- [ ] Smoke-test a release build: Firebase Auth (Google/Apple sign-in) still works (confirms the suppressed KTX path is genuinely unused).
