### PR TITLE
fix app detail crash null check on setState in initState

### DIFF
--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -230,7 +230,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
               '](assets/',
               '](https://raw.githubusercontent.com/BasedHardware/Omi/main/plugins/instructions/${app.id}/assets/',
             );
-            setState(() => instructionsMarkdown = value);
+            if (mounted) setState(() => instructionsMarkdown = value);
           });
         }
       }


### PR DESCRIPTION
_AppDetailPageState.initState.<fn>

FlutterError - Null check operator used on a null value
package:omi/pages/apps/app_detail/app_detail.dart:110


https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/123c986a6d328c995be16e6ac9d76801?time=7d&types=crash&sessionEventKey=7f17b3d696da42a79e6b2571df515114_2220451201077102008

logs

```
Fatal Exception: FlutterError
0  ???                            0x0 State.setState + 1219 (framework.dart:1219)
1  ???                            0x0 _AppDetailPageState.initState.<fn> + 230 (app_detail.dart:230)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)