### PR TITLE
fix private cloud sync crash null check on setState after async

### DIFF
--- a/app/lib/pages/conversations/private_cloud_sync_page.dart
+++ b/app/lib/pages/conversations/private_cloud_sync_page.dart
@@ -38,11 +38,9 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
       print('Error toggling cloud storage: $e');
       if (!mounted) return;
       setState(() => _isSaving = false);
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.failedToUpdateSettings(e.toString())), backgroundColor: Colors.red),
-        );
-      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.failedToUpdateSettings(e.toString())), backgroundColor: Colors.red),
+      );
     }
   }
 

--- a/app/lib/pages/conversations/private_cloud_sync_page.dart
+++ b/app/lib/pages/conversations/private_cloud_sync_page.dart
@@ -26,17 +26,17 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
     setState(() => _isSaving = true);
     try {
       await context.read<UserProvider>().setPrivateCloudSync(value);
+      if (!mounted) return;
       setState(() => _isSaving = false);
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(value ? context.l10n.cloudStorageEnabled : context.l10n.cloudStorageDisabled),
-            backgroundColor: Colors.green,
-          ),
-        );
-      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(value ? context.l10n.cloudStorageEnabled : context.l10n.cloudStorageDisabled),
+          backgroundColor: Colors.green,
+        ),
+      );
     } catch (e) {
       print('Error toggling cloud storage: $e');
+      if (!mounted) return;
       setState(() => _isSaving = false);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
_PrivateCloudSyncPageState._togglePrivateCloudSync

FlutterError - Null check operator used on a null value
package:omi/pages/conversations/private_cloud_sync_page.dart:38

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/e7852afd4cea7c46c1dc28f74307269b?time=7d&types=crash&sessionEventKey=6d5ef0f376e64b77a918690bd892e7ed_2219864452166344969

logs

```
Fatal Exception: FlutterError
0  ???                            0x0 State.setState + 1219 (framework.dart:1219)
1  ???                            0x0 _PrivateCloudSyncPageState._togglePrivateCloudSync + 40 (private_cloud_sync_page.dart:40)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)