### PR TITLE
fix synced conversation crash null check on setState after async

### DIFF
--- a/app/lib/pages/conversations/widgets/synced_conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/synced_conversation_list_item.dart
@@ -40,10 +40,8 @@ class _SyncedConversationListItemState extends State<SyncedConversationListItem>
 
   @override
   void initState() {
-    setState(() {
-      conversation = widget.conversation;
-    });
     super.initState();
+    conversation = widget.conversation;
   }
 
   @override

--- a/app/lib/pages/conversations/widgets/synced_conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/synced_conversation_list_item.dart
@@ -35,7 +35,7 @@ class _SyncedConversationListItemState extends State<SyncedConversationListItem>
 
   void setReprocessing(bool value) {
     isReprocessing = value;
-    setState(() {});
+    if (mounted) setState(() {});
   }
 
   @override
@@ -102,6 +102,7 @@ class _SyncedConversationListItemState extends State<SyncedConversationListItem>
                         onTap: () async {
                           setReprocessing(true);
                           var mem = await reProcessConversationServer(conversation.id);
+                          if (!mounted) return;
                           if (mem != null) {
                             setState(() {
                               conversation = mem;


### PR DESCRIPTION
_SyncedConversationListItemState.build.<fn>
FlutterError - Null check operator used on a null value
package:omi/pages/conversations/widgets/synced_conversation_list_item.dart:110

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/6b464a6c253a9f8025e9882b7ea10835?time=7d&types=crash&sessionEventKey=9647bfcfc7a64c2fb9330de4374576a9_2220857668020858369

logs

```
Fatal Exception: FlutterError
0  ???                            0x0 State.setState + 1219 (framework.dart:1219)
1  ???                            0x0 _SyncedConversationListItemState.build.<fn> + 106 (synced_conversation_list_item.dart:106)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)