### PR TITLE
fix onboarding wrapper crash null check on context after async gaps

### DIFF
--- a/app/lib/pages/onboarding/wrapper.dart
+++ b/app/lib/pages/onboarding/wrapper.dart
@@ -73,6 +73,7 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
       vsync: this,
     ); // Auth, AiConsent, Name, Lang, FoundOmi, Permissions, Review, Welcome, FindDevices, SpeechProfile, KnowledgeGraph, Complete
     _controller!.addListener(() {
+      if (!mounted) return;
       setState(() {});
       // Update background image when page changes
       _updateBackgroundImage(_controller!.index);
@@ -267,6 +268,7 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
     List<Widget> pages = [
       AuthComponent(
         onSignIn: () async {
+          if (!mounted) return;
           PlatformManager.instance.analytics.onboardingStepCompleted('Auth');
           context.read<HomeProvider>().setupHasSpeakerProfile();
           IntercomManager.instance.loginIdentifiedUser(SharedPreferencesUtil().uid);

--- a/app/lib/pages/onboarding/wrapper.dart
+++ b/app/lib/pages/onboarding/wrapper.dart
@@ -286,6 +286,7 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
       ),
       AiConsentWidget(
         onAgree: () async {
+          if (!mounted) return;
           SharedPreferencesUtil().aiConsentGiven = true;
           PlatformManager.instance.analytics.onboardingStepCompleted('AI Consent');
           // If the server says this user already completed onboarding, jump


### PR DESCRIPTION
Provider._inheritedElementOf
FlutterError - Null check operator used on a null value
package:provider/src/provider.dart:377

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/a8c821212ea690bd4ecf96e4a9d696c9?time=7d&types=crash&sessionEventKey=9649f0cf48114e53b9c0b9182f9f2ef0_2221103523113004792

logs

```
Fatal Exception: FlutterError
0  ???                            0x0 Element.widget + 3598 (framework.dart:3598)
1  ???                            0x0 Provider._inheritedElementOf + 377 (provider.dart:377)
2  ???                            0x0 Provider.of + 327 (provider.dart:327)
3  ???                            0x0 ReadContext.read + 683 (provider.dart:683)
4  ???                            0x0 _OnboardingWrapperState.build.<fn> + 271 (wrapper.dart:271)
5  ???                            0x0 AuthenticationProvider._signIn + 183 (auth_provider.dart:183)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)