### PR TITLE
fix conversation delete crash stale index RangeError

### DIFF
--- a/app/lib/pages/conversations/widgets/conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/conversation_list_item.dart
@@ -291,9 +291,8 @@ class _ConversationListItemState extends State<ConversationListItem> {
                         },
                         onDismissed: (direction) async {
                           var conversation = widget.conversation;
-                          var conversationIdx = widget.conversationIdx;
                           PlatformManager.instance.analytics.conversationSwipedToDelete(conversation);
-                          provider.deleteConversationLocally(conversation, conversationIdx, widget.date);
+                          provider.deleteConversationLocally(conversation, widget.date);
                         },
                         child: Padding(
                           padding: PlatformService.isMobile

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -758,7 +758,7 @@ class ConversationProvider extends ChangeNotifier {
   String? lastDeletedConversationId;
   Map<String, DateTime> deleteTimestamps = {};
 
-  void deleteConversationLocally(ServerConversation conversation, int index, DateTime date) {
+  void deleteConversationLocally(ServerConversation conversation, DateTime date) {
     if (lastDeletedConversationId != null &&
         memoriesToDelete.containsKey(lastDeletedConversationId) &&
         DateTime.now().difference(deleteTimestamps[lastDeletedConversationId]!) < const Duration(seconds: 3)) {
@@ -769,9 +769,12 @@ class ConversationProvider extends ChangeNotifier {
     lastDeletedConversationId = conversation.id;
     deleteTimestamps[conversation.id] = DateTime.now();
     conversations.removeWhere((element) => element.id == conversation.id);
-    groupedConversations[date]!.removeAt(index);
-    if (groupedConversations[date]!.isEmpty) {
-      groupedConversations.remove(date);
+    final group = groupedConversations[date];
+    if (group != null) {
+      group.removeWhere((e) => e.id == conversation.id);
+      if (group.isEmpty) {
+        groupedConversations.remove(date);
+      }
     }
     notifyListeners();
     Future.delayed(const Duration(seconds: 3), () {


### PR DESCRIPTION
ConversationProvider.deleteConversationLocally

FlutterError - RangeError (length): Invalid value: Only valid value is 0: 1
package:omi/providers/conversation_provider.dart:696

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/f4872fcd6a76c2568d22683acf70bd34?time=7d&types=crash&sessionEventKey=13381b1d131141e3a543bfccc9e0a4b7_2221310016610942035

Logs

```
Fatal Exception: FlutterError
0  ???                            0x0 List.removeAt (dart:core)
1  ???                            0x0 ConversationProvider.deleteConversationLocally + 696 (conversation_provider.dart:696)
2  ???                            0x0 _ConversationListItemState.build.<fn>.<fn> + 296 (conversation_list_item.dart:296)
3  ???                            0x0 _DismissibleState._handleResizeProgressChanged + 601 (dismissible.dart:601)
4  ???                            0x0 AnimationLocalListenersMixin.notifyListeners + 160 (listener_helpers.dart:160)
5  ???                            0x0 AnimationController._tick + 957 (animation_controller.dart:957)
6  ???                            0x0 Ticker._tick + 269 (ticker.dart:269)
7  ???                            0x0 SchedulerBinding._invokeFrameCallback + 1434 (binding.dart:1434)
8  ???                            0x0 SchedulerBinding.handleBeginFrame.<fn> + 1265 (binding.dart:1265)
9  ???                            0x0 _LinkedHashMapMixin.forEach (dart:_compact_hash)
10 ???                            0x0 SchedulerBinding.handleBeginFrame + 1263 (binding.dart:1263)
11 ???                            0x0 SchedulerBinding._handleBeginFrame + 1179 (binding.dart:1179)
```

Fix:

Replaced stale `removeAt(index)` with `removeWhere` by ID and added null guard on the date group, eliminating the `RangeError` when concurrent deletions shift list indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)