### PR TITLE
fix share usage crash empty title PlatformException

### DIFF
--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -123,7 +123,8 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
     // Convert the canvas to a new image and then to bytes
     final watermarkedImage = await recorder.endRecording().toImage(image.width, image.height);
     final ByteData? byteData = await watermarkedImage.toByteData(format: ui.ImageByteFormat.png);
-    final Uint8List pngBytes = byteData!.buffer.asUint8List();
+    if (byteData == null) return;
+    final Uint8List pngBytes = byteData.buffer.asUint8List();
 
     final tempDir = await getTemporaryDirectory();
     final file = await File('${tempDir.path}/omi_usage.png').create();
@@ -194,7 +195,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
       shareText = baseText;
     }
 
-    await SharePlus.instance.share(ShareParams(files: [XFile(file.path)], text: shareText));
+    await SharePlus.instance.share(ShareParams(files: [XFile(file.path)], subject: periodTitle, text: shareText));
   }
 
   String _getPeriodForIndex(int index) {

--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -123,7 +123,10 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
     // Convert the canvas to a new image and then to bytes
     final watermarkedImage = await recorder.endRecording().toImage(image.width, image.height);
     final ByteData? byteData = await watermarkedImage.toByteData(format: ui.ImageByteFormat.png);
-    if (byteData == null) return;
+    if (byteData == null) {
+      if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.wrappedFailedToShare)));
+      return;
+    }
     final Uint8List pngBytes = byteData.buffer.asUint8List();
 
     final tempDir = await getTemporaryDirectory();


### PR DESCRIPTION
MethodChannelShare.share

FlutterError - PlatformException(error, Non-empty title expected, null, null)
package:share_plus_platform_interface/method_channel/method_channel_share.dart:25

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 StandardMethodCodec.decodeEnvelope + 653 (message_codecs.dart:653)
1  ???                            0x0 MethodChannel._invokeMethod + 367 (platform_channel.dart:367)
2  ???                            0x0 MethodChannelShare.share + 25 (method_channel_share.dart:25)
3  ???                            0x0 _UsagePageState._shareUsage + 197 (usage_page.dart:197)
```

Fix: Added `subject: periodTitle` to `ShareParams` — Android requires a non-empty subject when sharing files. Also replaced a `byteData!` force-unwrap with a null guard to prevent a secondary crash if PNG encoding fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)