### PR TITLE
fix(backend): NameError on BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH

### DIFF
--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -1,6 +1,9 @@
 import sys
 import types
 
+_announcements_mod = types.ModuleType("database.announcements")
+_announcements_mod.compare_versions = lambda a, b: 0
+sys.modules.setdefault("database.announcements", _announcements_mod)
 sys.modules.setdefault("database.users", types.SimpleNamespace())
 sys.modules.setdefault("database.user_usage", types.SimpleNamespace())
 
@@ -25,3 +28,8 @@ def test_architect_is_treated_as_paid_unlimited_plan():
     assert get_plan_limits(PlanType.architect).transcription_seconds is None
     assert "Automations and vibe coding" in get_plan_features(PlanType.architect)
     assert "Unlimited listening, memories, and insights" in get_plan_features(PlanType.architect)
+
+
+def test_basic_plan_features_include_unlimited_memories():
+    features = get_plan_features(PlanType.basic)
+    assert "Unlimited memories" in features

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -660,11 +660,7 @@ def get_plan_features(plan: PlanType, simplified: bool = False) -> List[str]:
             if BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH > 0
             else "Unlimited insights"
         ),
-        (
-            f"{BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH} memories per month"
-            if BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH > 0
-            else "Unlimited memories"
-        ),
+        "Unlimited memories",
     ]
 
 


### PR DESCRIPTION
## Summary
- Fixes `NameError: name 'BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH' is not defined` crashing `get_plan_features()` for all basic (free) plan users
- PR #7427 removed the variable definition but missed two references in `get_plan_features()` (lines 664-665)
- The variable was always `0` (env default), so the conditional always evaluated to `"Unlimited memories"` — replaced the 4-line dead conditional with the literal string
- Added regression test `test_basic_plan_features_include_unlimited_memories` and fixed `database.announcements` stub in test collection

## Changes
1. `backend/utils/subscription.py`: Replace 4-line conditional referencing undefined variable with `"Unlimited memories"` literal (1 insertion, 5 deletions)
2. `backend/tests/unit/test_subscription_plans.py`: Add regression test + fix `database.announcements` import stub for CI

## Test plan
- [x] `py_compile` passes on `subscription.py` and `users.py`
- [x] No remaining references to `BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH` in backend/
- [x] 3/3 subscription plan tests pass (including new regression test)
- [x] CODEx review confirmed fix is correct and `legacy_plan_features()` also covered (falls through to `get_plan_features`)

## Risks
- Low: no risk of masking a future memory cap — PR #7427 explicitly removed this quota entirely
- `legacy_plan_features(PlanType.basic)` falls through to `get_plan_features()`, so this fix covers both paths

Closes #7466

🤖 Generated with [Claude Code](https://claude.com/claude-code)