### PR TITLE
app: stop reporting transient network errors to Crashlytics

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -30,6 +30,27 @@ class AuthTokenUnavailableException implements Exception {
   String toString() => 'AuthTokenUnavailableException: $message';
 }
 
+// Normal-mode connectivity failures on mobile (no network, DNS failure,
+// connection reset, TLS handshake during reconnect, request timeout). Reporting
+// these to Crashlytics drowns out real signal — caller logs them locally and
+// either returns null or rethrows for the upstream sync state machine.
+bool _isTransientNetworkError(Object e) {
+  if (e is SocketException) return true;
+  if (e is HandshakeException) return true;
+  if (e is TimeoutException) return true;
+  if (e is http.ClientException) {
+    final m = e.message;
+    return m.contains('SocketException') ||
+        m.contains('HandshakeException') ||
+        m.contains('TimeoutException') ||
+        m.contains('Connection closed') ||
+        m.contains('Connection reset') ||
+        m.contains('Failed host lookup') ||
+        m.contains('Network is unreachable');
+  }
+  return false;
+}
+
 Future<String> getAuthHeader() async {
   DateTime? expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
   bool hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
@@ -169,7 +190,9 @@ Future<http.Response?> makeApiCall({
     return response;
   } catch (e, stackTrace) {
     Logger.debug('HTTP request failed: $e, $stackTrace');
-    PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
+    if (!_isTransientNetworkError(e)) {
+      PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
+    }
     return null;
   }
 }
@@ -309,7 +332,9 @@ Future<http.Response> makeMultipartApiCall({
     return response;
   } catch (e, stackTrace) {
     Logger.debug('Multipart HTTP request failed: $e, $stackTrace');
-    PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
+    if (!_isTransientNetworkError(e)) {
+      PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
+    }
     rethrow;
   }
 }
@@ -382,7 +407,9 @@ Future<http.Response> makeMultipartApiCallUnpooled({
     return response;
   } catch (e, stackTrace) {
     Logger.debug('Unpooled multipart HTTP request failed: $e, $stackTrace');
-    PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
+    if (!_isTransientNetworkError(e)) {
+      PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
+    }
     rethrow;
   } finally {
     client.close();
@@ -445,7 +472,9 @@ Stream<String> makeStreamingApiCall({
     }
   } catch (e, stackTrace) {
     Logger.error('Streaming request error: $e');
-    PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
+    if (!_isTransientNetworkError(e)) {
+      PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': method});
+    }
   }
 }
 
@@ -537,7 +566,9 @@ Stream<String> makeMultipartStreamingApiCall({
     }
   } catch (e, stackTrace) {
     Logger.error('Multipart streaming request error: $e');
-    PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': 'POST'});
+    if (!_isTransientNetworkError(e)) {
+      PlatformManager.instance.crashReporter.reportCrash(e, stackTrace, userAttributes: {'url': url, 'method': 'POST'});
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- The HTTP catch sites in `app/lib/backend/http/shared.dart` were calling `crashReporter.reportCrash` for every `SocketException` / `TimeoutException` / `HandshakeException`. On mobile those are normal-mode connectivity events (BG sync after WiFi sleep, brief DNS hiccups during a network handoff, server unreachable in low-signal zones) — they were drowning out real signal in Crashlytics.
- One symptom: a long-lived issue with 12 variants spanning many app versions kept flipping between *closed* and *regressed* every time it spiked, because the underlying cause was just users with flaky networks, not a bug.
- Adds a single private helper `_isTransientNetworkError(Object e)` that matches `SocketException`, `TimeoutException`, `HandshakeException`, and `http.ClientException` wrapping any of those (covers errno-7 "Failed host lookup", errno-101 "Network is unreachable", "Connection reset/closed", etc.).
- Guards all 5 HTTP catch sites: `makeApiCall`, `makeMultipartApiCall`, `makeMultipartApiCallUnpooled`, `makeStreamingApiCall`, `makeMultipartStreamingApiCall`. The response-parsing `reportCrash` in `extractContentFromResponse` is left alone (different category — actual server-side decode error).
- **Control flow is unchanged** — still `return null` / `rethrow` exactly as before, so upstream sync state machines and callers behave identically. Only the Crashlytics reporting call is gated.

## Test plan

- [ ] `dart analyze app/lib/backend/http/shared.dart` is clean (only 2 pre-existing unrelated `@visibleForTesting` warnings).
- [ ] Manually verify on device: turn airplane mode on while a sync is in flight → confirm no new entries appear in Crashlytics for that session; sync state machine still reports the error to the user UI and retries when network returns.
- [ ] Smoke test normal flows (open app, send chat, fetch conversations) — no behavior change for non-network errors.
- [ ] After merge: monitor the affected Crashlytics issue — event volume should drop to ~zero within 24-48h of rollout. After a clean week, mark the issue CLOSED. Any new regression on the same signature is real signal.