### PR TITLE
backend: refuse /v2/firmware/latest with unknown current version

### DIFF
--- a/backend/routers/firmware.py
+++ b/backend/routers/firmware.py
@@ -155,14 +155,16 @@ async def get_omi_github_releases(cache_key: str, tag_filter: Optional[re.Patter
     return collected
 
 
-def _parse_firmware_version(version_str: Optional[str]) -> Tuple[int, ...]:
+def _parse_firmware_version(version_str: Optional[str]) -> Optional[Tuple[int, ...]]:
     """
     Parses a firmware version string (e.g., "v1.2.3" or "1.2.3") into a tuple of integers.
-    Returns (0,0,0) for invalid, empty, or unparsable strings to ensure comparisons
-    treat them as the lowest possible version.
+    Returns None for empty/invalid/unparsable strings. Callers MUST treat None as
+    "version unknown" — not as (0, 0, 0) — otherwise an empty current_firmware
+    matches every legacy release and surfaces a stale upgrade prompt to users
+    whose actual firmware is current.
     """
     if not version_str:
-        return (0, 0, 0)
+        return None
 
     normalized_version_str = version_str.lower()
     if normalized_version_str.startswith('v'):
@@ -175,8 +177,7 @@ def _parse_firmware_version(version_str: Optional[str]) -> Tuple[int, ...]:
         try:
             version_tuple.append(int(part))
         except ValueError:
-            # Non-integer part, treat as invalid/very old
-            return (0, 0, 0)
+            return None
 
     # Pad with zeros if less than 3 parts for consistent comparison (e.g., 1.2 -> 1.2.0)
     while len(version_tuple) < 3:
@@ -231,6 +232,9 @@ def _find_candidate_releases(
 
         if current_firmware_tuple is not None:
             release_firmware_tuple = _parse_firmware_version(release_firmware_version_str)
+            # Skip releases with unparseable release_firmware_version metadata.
+            if release_firmware_tuple is None:
+                continue
 
             # Condition A: Release must be strictly newer than current version
             if not (release_firmware_tuple > current_firmware_tuple):
@@ -240,7 +244,8 @@ def _find_candidate_releases(
             minimum_firmware_required_str = kv.get("minimum_firmware_required")
             if minimum_firmware_required_str:
                 min_req_tuple = _parse_firmware_version(minimum_firmware_required_str)
-                if not (current_firmware_tuple >= min_req_tuple):
+                # Treat unparseable min_req as no requirement — same as missing key.
+                if min_req_tuple is not None and not (current_firmware_tuple >= min_req_tuple):
                     continue
 
         candidates.append(release)
@@ -300,11 +305,21 @@ async def get_latest_version(device_model: str, firmware_revision: str, hardware
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
 
+    # Refuse to recommend an upgrade when we can't trust the current version.
+    # A missing/garbled firmware_revision used to be silently treated as 0.0.0,
+    # which made every legacy release look "newer" and surfaced stale upgrade
+    # prompts to users whose actual firmware was current. Fail loud instead.
+    current_firmware_tuple = _parse_firmware_version(firmware_revision)
+    if current_firmware_tuple is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Could not determine current firmware version",
+        )
+
     releases = await get_omi_github_releases("github_releases_omi", tag_filter=FIRMWARE_TAG_PATTERN)
     if not releases:
         raise HTTPException(status_code=404, detail="No releases found for the repository")
 
-    current_firmware_tuple = _parse_firmware_version(firmware_revision)
     release_prefix = _get_release_prefix(device)
     candidates = _find_candidate_releases(releases, release_prefix, current_firmware_tuple)
 

--- a/backend/tests/unit/test_firmware_pagination.py
+++ b/backend/tests/unit/test_firmware_pagination.py
@@ -23,7 +23,13 @@ sys.modules.setdefault('google.cloud.firestore_v1', MagicMock())
 sys.modules.setdefault('google.auth', MagicMock())
 sys.modules.setdefault('google.auth.transport.requests', MagicMock())
 
-from routers.firmware import get_omi_github_releases, FIRMWARE_TAG_PATTERN, MAX_PAGES
+from routers.firmware import (
+    get_omi_github_releases,
+    FIRMWARE_TAG_PATTERN,
+    MAX_PAGES,
+    _parse_firmware_version,
+    _find_candidate_releases,
+)
 
 
 def _make_release(tag_name, draft=False, published_at="2026-01-30T00:00:00Z"):
@@ -326,3 +332,105 @@ class TestLastKnownGoodFallback:
         ttl_by_key = {call.args[0]: call.kwargs.get("ttl") for call in mock_set.call_args_list}
         assert ttl_by_key["test_key"] == 300
         assert ttl_by_key["test_key:lkg"] == 86400
+
+
+class TestParseFirmwareVersion:
+    """`_parse_firmware_version` now returns None for unparseable input so callers can
+    distinguish "unknown" from "very old". Treating unknown as (0,0,0) is what caused
+    /v2/firmware/latest to recommend a stale legacy release to users with current
+    firmware whose BLE characteristic read transiently failed."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("3.0.19", (3, 0, 19)),
+            ("v3.0.19", (3, 0, 19)),
+            ("V3.0.19", (3, 0, 19)),
+            ("1.2", (1, 2, 0)),
+            ("1", (1, 0, 0)),
+            ("0.0.0", (0, 0, 0)),
+        ],
+    )
+    def test_parses_valid_versions(self, value, expected):
+        assert _parse_firmware_version(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            "unknown",
+            "Unknown",
+            "abc",
+            "1.x.0",
+            "1..2",
+        ],
+    )
+    def test_returns_none_for_invalid(self, value):
+        assert _parse_firmware_version(value) is None
+
+
+class TestFindCandidateReleasesGuardsAgainstBadMetadata:
+    """Defense-in-depth: releases with garbled `release_firmware_version` in their body
+    are skipped instead of crashing the comparison, and garbled `minimum_firmware_required`
+    is treated as "no requirement" (matches the missing-key behavior).
+    """
+
+    @staticmethod
+    def _release(tag, body, published_at="2026-01-30T00:00:00Z"):
+        return {
+            "tag_name": tag,
+            "body": body,
+            "draft": False,
+            "prerelease": False,
+            "published_at": published_at,
+        }
+
+    def test_skips_release_with_unparseable_release_firmware_version(self):
+        releases = [
+            self._release(
+                "Omi_CV1_v3.0.19",
+                "<!-- KEY_VALUE_START\nrelease_firmware_version:not-a-version\nKEY_VALUE_END -->",
+            ),
+            self._release(
+                "Omi_CV1_v3.0.18",
+                "<!-- KEY_VALUE_START\nrelease_firmware_version:3.0.18\nKEY_VALUE_END -->",
+            ),
+        ]
+        candidates = _find_candidate_releases(releases, "Omi_CV1", (3, 0, 17))
+        tags = [c["tag_name"] for c in candidates]
+        assert tags == ["Omi_CV1_v3.0.18"]
+
+    def test_treats_unparseable_min_req_as_unset(self):
+        releases = [
+            self._release(
+                "Omi_CV1_v3.0.19",
+                "<!-- KEY_VALUE_START\nrelease_firmware_version:3.0.19\nminimum_firmware_required:garbage\nKEY_VALUE_END -->",
+            ),
+        ]
+        # User on 1.0.0 — would normally be blocked by minimum_firmware_required:3.0.6.
+        # With garbled min_req, treat as no requirement (same as missing key).
+        candidates = _find_candidate_releases(releases, "Omi_CV1", (1, 0, 0))
+        assert len(candidates) == 1
+
+
+class TestGetLatestVersionRejectsUnknownCurrent:
+    """`/v2/firmware/latest` must refuse to recommend an upgrade when it can't trust
+    the caller's reported current firmware. Without this, an empty / garbled
+    firmware_revision matched every legacy release and surfaced stale upgrade
+    prompts to up-to-date users."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("firmware_revision", ["", "unknown", "abc"])
+    async def test_invalid_current_firmware_returns_400(self, firmware_revision):
+        from routers.firmware import get_latest_version
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            await get_latest_version(
+                device_model="Omi CV 1",
+                firmware_revision=firmware_revision,
+                hardware_revision="1",
+                manufacturer_name="Omi",
+            )
+        assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary

Defense-in-depth pair for #7481 (app fix). Stops the "phantom upgrade to a stale legacy release" bug from happening at the backend layer even if some other client (current app, older app version, an SDK, a curl test, anything) misreports its firmware revision.

### What was happening

`_parse_firmware_version("")` returned `(0, 0, 0)`. That made every legacy release "newer than current" in the upgrade filter, and the only one with a permissive `minimum_firmware_required: 1.0.0` (`Omi_CV1_v3.0.5`) survived all the other filters → returned to the user.

```
GET /v2/firmware/latest?...&firmware_revision=         → {"version":"3.0.5", ...}  ← bogus
GET /v2/firmware/latest?...&firmware_revision=unknown  → {"version":"3.0.5", ...}  ← bogus
GET /v2/firmware/latest?...&firmware_revision=3.0.19   → 404 No suitable update    ← correct
```

### What this PR does

1. **`_parse_firmware_version`** — return `Optional[Tuple]`. None means "unknown" (callers must handle it explicitly). Removes the silent (0,0,0) fallback.
2. **`get_latest_version`** — raises HTTP 400 with `"Could not determine current firmware version"` instead of treating unknown as version-zero.
3. **`_find_candidate_releases`** — skip releases whose `release_firmware_version` body metadata is garbled; treat an unparseable `minimum_firmware_required` as no requirement (matches the existing missing-key path — no behavior change for well-formed releases).

Behavior for valid inputs is unchanged. `/v2/firmware/stable` is unaffected — it never parses caller-supplied current firmware.

### Tests

Added 19 new tests in `tests/unit/test_firmware_pagination.py`:

- `TestParseFirmwareVersion` — valid versions parse correctly; empty/null/garbage returns None.
- `TestFindCandidateReleasesGuardsAgainstBadMetadata` — releases with garbled rfv are skipped; garbled min_req is treated as unset.
- `TestGetLatestVersionRejectsUnknownCurrent` — 400 for `""`, `"unknown"`, `"abc"`.

Local run: 37 passed in 0.43s.

## Test plan

- [ ] `cd backend && bash test.sh` runs clean in CI.
- [ ] After merge, hit `/v2/firmware/latest?...&firmware_revision=` against the deployed backend — expect 400, not 200 with a `3.0.5` payload.
- [ ] Confirm valid calls still work: `firmware_revision=3.0.17` → 200 with a real upgrade target.