### PR TITLE
Keep Android BLE transcription running when the app is closed

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -87,6 +87,7 @@
          <service
             android:name="id.flutter.flutter_background_service.BackgroundService"
             android:foregroundServiceType="microphone"
+            android:stopWithTask="false"
             tools:node="merge" />
 
         <service
@@ -191,6 +192,7 @@
         <service
             android:name="com.friend.ios.OmiBleForegroundService"
             android:foregroundServiceType="connectedDevice"
+            android:stopWithTask="false"
             android:exported="false" />
 
     </application>

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -87,7 +87,6 @@
          <service
             android:name="id.flutter.flutter_background_service.BackgroundService"
             android:foregroundServiceType="microphone"
-            android:stopWithTask="false"
             tools:node="merge" />
 
         <service

--- a/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
@@ -27,6 +27,10 @@ class MainActivity: FlutterActivity() {
 
         // Register Native BLE Pigeon APIs
         OmiBleManager.initialize(application)
+        getSharedPreferences("FlutterSharedPreferences", MODE_PRIVATE)
+            .edit()
+            .putBoolean("flutter.nativeBleForegroundReady", false)
+            .apply()
         OmiBleManager.isFlutterAlive = true
         OmiBleManager.instance.flutterApi = BleFlutterApi(flutterEngine.dartExecutor.binaryMessenger)
         val hostApi = BleHostApiImpl { this }
@@ -75,11 +79,10 @@ class MainActivity: FlutterActivity() {
     }
 
     override fun onDestroy() {
-        // When user closes the app (swipe away), stop the foreground service.
-        // The service handles disconnecting all managed devices in onDestroy.
+        // The BLE foreground service owns the pendant connection and must survive
+        // a normal task close so the pendant can keep recording in the background.
         if (isFinishing) {
             OmiBleManager.isFlutterAlive = false
-            OmiBleForegroundService.stopService(this)
         }
         super.onDestroy()
     }

--- a/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
@@ -14,6 +14,7 @@ import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "com.friend.ios/notifyOnKill"
+    private val NATIVE_BLE_TRANSCRIPT_CHANNEL = "com.friend.ios/native_ble_transcript"
     private var bleHostApiImpl: BleHostApiImpl? = null
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
@@ -37,6 +38,14 @@ class MainActivity: FlutterActivity() {
         hostApi.initCompanionManager(this)
         bleHostApiImpl = hostApi
         BleHostApi.setUp(flutterEngine.dartExecutor.binaryMessenger, hostApi)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, NATIVE_BLE_TRANSCRIPT_CHANNEL).setMethodCallHandler {
+            call, result ->
+            if (call.method == "drain") {
+                result.success(OmiBackgroundAudioStreamer.drainCachedTranscriptMessages())
+            } else {
+                result.notImplemented()
+            }
+        }
 
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
             call, result ->

--- a/app/android/app/src/main/kotlin/com/friend/ios/BleCompanionService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/BleCompanionService.kt
@@ -13,10 +13,6 @@ import java.util.Locale
 /**
  * CompanionDeviceService that receives device appear/disappear events from the OS,
  * even when the app is not running.
- *
- * Omi streams audio via WebSocket which requires the Flutter app. So this service
- * only acts when the app is alive (isFlutterAlive). If the app is dead, starting
- * the foreground service is pointless — there's no WebSocket to stream audio to.
  */
 class BleCompanionService : CompanionDeviceService() {
 
@@ -38,19 +34,10 @@ class BleCompanionService : CompanionDeviceService() {
         return cdm.myAssociations.find { it.id == assocId }
     }
 
-    /**
-     * Check if the Flutter app is alive. Set true in MainActivity.configureFlutterEngine,
-     * set false in MainActivity.onDestroy(isFinishing). Without Flutter, there's no
-     * WebSocket to stream audio to — BLE connection is useless.
-     */
-    private fun isAppAlive(): Boolean {
-        return OmiBleManager.isFlutterAlive
-    }
-
     private fun handleDeviceAppeared(address: String) {
         Log.i(TAG, "Device appeared: $address")
 
-        if (!isAppAlive() || !hasBluetoothPermission()) return
+        if (!hasBluetoothPermission()) return
 
         val prefs = applicationContext.getSharedPreferences("ble_config", Context.MODE_PRIVATE)
         if (prefs.getBoolean("user_disconnected", false)) return
@@ -78,7 +65,7 @@ class BleCompanionService : CompanionDeviceService() {
         super.onCreate()
         Log.i(TAG, "onCreate")
 
-        if (!isAppAlive() || !hasBluetoothPermission()) return
+        if (!hasBluetoothPermission()) return
 
         val prefs = applicationContext.getSharedPreferences("ble_config", Context.MODE_PRIVATE)
         if (prefs.getBoolean("user_disconnected", false)) return

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
@@ -25,6 +25,20 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         private const val OMI_AUDIO_CHAR_UUID = "19b10001-e8f2-537e-4f6c-d104768a1214"
         private const val FRIEND_SERVICE_UUID = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da"
         private const val FRIEND_AUDIO_CHAR_UUID = "01000000-1111-1111-1111-111111111111"
+        private const val MAX_CACHED_TRANSCRIPT_MESSAGES = 200
+        private val transcriptCacheLock = Any()
+        private val cachedTranscriptMessages = ArrayDeque<String>()
+
+        fun drainCachedTranscriptMessages(): List<String> =
+            synchronized(transcriptCacheLock) {
+                if (cachedTranscriptMessages.isEmpty()) {
+                    emptyList()
+                } else {
+                    val messages = cachedTranscriptMessages.toList()
+                    cachedTranscriptMessages.clear()
+                    messages
+                }
+            }
     }
 
     private data class Config(
@@ -168,6 +182,7 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         }
 
         override fun onMessage(webSocket: WebSocket, text: String) {
+            cacheTranscriptMessage(text)
             Log.d(TAG, "Background transcription message received (${text.length} chars)")
         }
 
@@ -223,6 +238,18 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
             }
         }
         return sent
+    }
+
+    private fun cacheTranscriptMessage(text: String) {
+        val trimmed = text.trimStart()
+        if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) return
+
+        synchronized(transcriptCacheLock) {
+            if (cachedTranscriptMessages.size >= MAX_CACHED_TRANSCRIPT_MESSAGES) {
+                cachedTranscriptMessages.removeFirst()
+            }
+            cachedTranscriptMessages.addLast(text)
+        }
     }
 
     private fun queueFrameLocked(frame: ByteArray) {

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
@@ -64,6 +64,7 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
     private var activeUrl: String? = null
     private var activeConfig: Config? = null
     private var sentFrames = 0
+    @Volatile
     private var lastFailureAtMs = 0L
 
     fun isConfiguredFor(address: String): Boolean {
@@ -232,9 +233,12 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
     private fun sendFrame(webSocket: WebSocket, frame: ByteArray): Boolean {
         val sent = webSocket.send(frame.toByteString())
         if (sent) {
-            sentFrames += 1
-            if (sentFrames % 100 == 0) {
-                Log.i(TAG, "Sent $sentFrames background BLE audio frames")
+            val totalSent = synchronized(lock) {
+                sentFrames += 1
+                sentFrames
+            }
+            if (totalSent % 100 == 0) {
+                Log.i(TAG, "Sent $totalSent background BLE audio frames")
             }
         }
         return sent
@@ -341,11 +345,17 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
     }
 
     private fun normalizeBaseUrl(value: String): String {
-        var base = value.trim()
-        if (!base.startsWith("http://") && !base.startsWith("https://")) {
-            base = "https://$base"
+        var base = value.trim().ifEmpty { DEFAULT_API_BASE_URL }
+        val lowerBase = base.lowercase(Locale.US)
+        if (lowerBase.startsWith("wss://") || lowerBase.startsWith("ws://")) {
+            base = lowerBase.substringBefore("://") + "://" + base.substringAfter("://")
+            return if (base.endsWith("/")) base else "$base/"
         }
-        base = base.replaceFirst("https://", "wss://").replaceFirst("http://", "ws://")
+        base = when {
+            lowerBase.startsWith("https://") -> "wss://" + base.substring("https://".length)
+            lowerBase.startsWith("http://") -> "ws://" + base.substring("http://".length)
+            else -> "wss://$base"
+        }
         return if (base.endsWith("/")) base else "$base/"
     }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
@@ -1,0 +1,352 @@
+package com.friend.ios
+
+import android.content.Context
+import android.util.Log
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString.Companion.toByteString
+import org.json.JSONObject
+import java.net.URLEncoder
+import java.util.ArrayDeque
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+class OmiBackgroundAudioStreamer(private val context: Context) {
+    companion object {
+        private const val TAG = "OmiBle.BgAudio"
+        private const val FLUTTER_PREFS = "FlutterSharedPreferences"
+        private const val DEFAULT_API_BASE_URL = "https://api.omiapi.com/"
+        private const val MAX_PENDING_FRAMES = 200
+        private const val RECONNECT_BACKOFF_MS = 3_000L
+        private const val OMI_SERVICE_UUID = "19b10000-e8f2-537e-4f6c-d104768a1214"
+        private const val OMI_AUDIO_CHAR_UUID = "19b10001-e8f2-537e-4f6c-d104768a1214"
+        private const val FRIEND_SERVICE_UUID = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da"
+        private const val FRIEND_AUDIO_CHAR_UUID = "01000000-1111-1111-1111-111111111111"
+    }
+
+    private data class Config(
+        val deviceId: String,
+        val codec: String,
+        val sampleRate: Int,
+        val source: String,
+        val apiBaseUrl: String,
+        val serviceUuid: String,
+        val characteristicUuid: String,
+        val deviceType: String
+    )
+
+    private val client = OkHttpClient.Builder()
+        .pingInterval(20, TimeUnit.SECONDS)
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .build()
+    private val lock = Any()
+    private val pendingFrames = ArrayDeque<ByteArray>()
+    private var socket: WebSocket? = null
+    private var connecting = false
+    private var connected = false
+    private var activeUrl: String? = null
+    private var activeConfig: Config? = null
+    private var sentFrames = 0
+    private var lastFailureAtMs = 0L
+
+    fun isConfiguredFor(address: String): Boolean {
+        val config = loadConfig() ?: return false
+        return config.deviceId.equals(address, ignoreCase = true)
+    }
+
+    fun stop(reason: String) {
+        var socketToClose: WebSocket? = null
+        synchronized(lock) {
+            socketToClose = socket
+            if (socketToClose != null) {
+                Log.i(TAG, "Stopping background transcription websocket ($reason)")
+            }
+            socket = null
+            connecting = false
+            connected = false
+            activeUrl = null
+            activeConfig = null
+            pendingFrames.clear()
+        }
+        socketToClose?.close(1000, reason)
+    }
+
+    fun handleCharacteristic(address: String, serviceUuid: String, characteristicUuid: String, value: ByteArray) {
+        val config = loadConfig()
+        if (config == null) {
+            if (socket != null) stop("disabled")
+            return
+        }
+        if (OmiBleManager.isFlutterAlive && boolPref("nativeBleForegroundReady", false)) {
+            if (socket != null) stop("foreground_ready")
+            return
+        }
+        if (!config.deviceId.equals(address, ignoreCase = true)) return
+        if (!matches(config, serviceUuid, characteristicUuid)) return
+
+        val frames = transformFrames(serviceUuid, characteristicUuid, value)
+        if (frames.isEmpty()) return
+
+        ensureSocket(config)
+
+        for (frame in frames) {
+            sendOrQueue(frame)
+        }
+    }
+
+    private fun matches(config: Config, serviceUuid: String, characteristicUuid: String): Boolean =
+        config.serviceUuid.equals(serviceUuid, ignoreCase = true) &&
+            config.characteristicUuid.equals(characteristicUuid, ignoreCase = true)
+
+    private fun transformFrames(serviceUuid: String, characteristicUuid: String, value: ByteArray): List<ByteArray> {
+        val svc = serviceUuid.lowercase(Locale.US)
+        val chr = characteristicUuid.lowercase(Locale.US)
+
+        if (svc == OMI_SERVICE_UUID && chr == OMI_AUDIO_CHAR_UUID) {
+            if (value.size <= 3) return emptyList()
+            return listOf(value.copyOfRange(3, value.size))
+        }
+
+        if (svc == FRIEND_SERVICE_UUID && chr == FRIEND_AUDIO_CHAR_UUID) {
+            if (value.size <= 5) return emptyList()
+            val payload = value.copyOfRange(0, value.size - 5)
+            val frames = mutableListOf<ByteArray>()
+            var offset = 0
+            while (offset + 30 <= payload.size) {
+                frames.add(payload.copyOfRange(offset, offset + 30))
+                offset += 30
+            }
+            return frames
+        }
+
+        return listOf(value.copyOf())
+    }
+
+    private fun ensureSocket(config: Config) {
+        val now = System.currentTimeMillis()
+        if (now - lastFailureAtMs < RECONNECT_BACKOFF_MS) return
+
+        val url = buildUrl(config) ?: return
+        val request = buildRequest(url) ?: return
+
+        synchronized(lock) {
+            if ((connecting || connected) && activeUrl == url && activeConfig == config && socket != null) {
+                return
+            }
+
+            socket?.close(1000, "reconfigure")
+            socket = null
+            connecting = true
+            connected = false
+            activeUrl = url
+            activeConfig = config
+            sentFrames = 0
+
+            Log.i(TAG, "Opening background transcription websocket (codec=${config.codec}, source=${config.source})")
+            socket = client.newWebSocket(request, listener())
+        }
+    }
+
+    private fun listener(): WebSocketListener = object : WebSocketListener() {
+        override fun onOpen(webSocket: WebSocket, response: Response) {
+            val queued = mutableListOf<ByteArray>()
+            synchronized(lock) {
+                if (webSocket != socket) return
+                connecting = false
+                connected = true
+                while (pendingFrames.isNotEmpty()) {
+                    queued.add(pendingFrames.removeFirst())
+                }
+            }
+            Log.i(TAG, "Background transcription socket connected")
+            for (frame in queued) {
+                sendFrame(webSocket, frame)
+            }
+        }
+
+        override fun onMessage(webSocket: WebSocket, text: String) {
+            Log.d(TAG, "Background transcription message received (${text.length} chars)")
+        }
+
+        override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+            webSocket.close(code, reason)
+        }
+
+        override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+            synchronized(lock) {
+                if (webSocket != socket) return
+                socket = null
+                connecting = false
+                connected = false
+            }
+            Log.i(TAG, "Background transcription socket closed (code=$code)")
+        }
+
+        override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+            synchronized(lock) {
+                if (webSocket != socket) return
+                socket = null
+                connecting = false
+                connected = false
+                lastFailureAtMs = System.currentTimeMillis()
+            }
+            Log.w(TAG, "Background transcription socket failed: ${t.message}")
+        }
+    }
+
+    private fun sendOrQueue(frame: ByteArray) {
+        var target: WebSocket? = null
+        synchronized(lock) {
+            target = if (connected) socket else null
+            if (target == null) {
+                queueFrameLocked(frame)
+                return
+            }
+        }
+        val webSocket = target ?: return
+        if (!sendFrame(webSocket, frame)) {
+            synchronized(lock) {
+                queueFrameLocked(frame)
+            }
+        }
+    }
+
+    private fun sendFrame(webSocket: WebSocket, frame: ByteArray): Boolean {
+        val sent = webSocket.send(frame.toByteString())
+        if (sent) {
+            sentFrames += 1
+            if (sentFrames % 100 == 0) {
+                Log.i(TAG, "Sent $sentFrames background BLE audio frames")
+            }
+        }
+        return sent
+    }
+
+    private fun queueFrameLocked(frame: ByteArray) {
+        if (pendingFrames.size >= MAX_PENDING_FRAMES) {
+            pendingFrames.removeFirst()
+        }
+        pendingFrames.addLast(frame.copyOf())
+    }
+
+    private fun loadConfig(): Config? {
+        if (!boolPref("nativeBleStreamingEnabled", false)) return null
+        val raw = stringPref("nativeBleStreamConfig")
+        if (raw.isEmpty()) return null
+
+        return try {
+            val json = JSONObject(raw)
+            val deviceId = json.optString("deviceId")
+            val serviceUuid = json.optString("serviceUuid").lowercase(Locale.US)
+            val characteristicUuid = json.optString("characteristicUuid").lowercase(Locale.US)
+            if (deviceId.isEmpty() || serviceUuid.isEmpty() || characteristicUuid.isEmpty()) return null
+
+            Config(
+                deviceId = deviceId,
+                codec = json.optString("codec", "pcm8"),
+                sampleRate = json.optInt("sampleRate", 16000),
+                source = json.optString("source"),
+                apiBaseUrl = json.optString("apiBaseUrl"),
+                serviceUuid = serviceUuid,
+                characteristicUuid = characteristicUuid,
+                deviceType = json.optString("deviceType")
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "Invalid native BLE stream config: ${e.message}")
+            null
+        }
+    }
+
+    private fun buildRequest(url: String): Request? {
+        val token = stringPref("authToken")
+        if (token.isEmpty()) {
+            Log.w(TAG, "Cannot open background transcription socket without auth token")
+            return null
+        }
+
+        return Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $token")
+            .header("X-Request-Start-Time", (System.currentTimeMillis().toDouble() / 1000.0).toString())
+            .header("X-App-Platform", "android")
+            .header("X-Device-Id-Hash", stringPref("deviceIdHash"))
+            .header("X-App-Version", BuildConfig.VERSION_NAME)
+            .build()
+    }
+
+    private fun buildUrl(config: Config): String? {
+        val uid = stringPref("uid")
+        if (uid.isEmpty()) {
+            Log.w(TAG, "Cannot open background transcription socket without uid")
+            return null
+        }
+
+        val language = if (boolPref("hasSetPrimaryLanguage", false)) {
+            stringPref("userPrimaryLanguage", "multi").ifEmpty { "multi" }
+        } else {
+            "multi"
+        }
+        val sttService = stringPref("transcriptionModel3", "soniox").ifEmpty { "soniox" }
+        val timeout = intPref("conversationSilenceDuration", 120).takeIf { it > 0 } ?: 120
+        val base = normalizeBaseUrl(config.apiBaseUrl.ifEmpty { DEFAULT_API_BASE_URL })
+
+        val params = mutableListOf(
+            "language=${enc(language)}",
+            "sample_rate=${config.sampleRate}",
+            "codec=${enc(config.codec)}",
+            "uid=${enc(uid)}",
+            "include_speech_profile=true",
+            "stt_service=${enc(sttService)}",
+            "conversation_timeout=$timeout"
+        )
+        if (config.source.isNotEmpty()) {
+            params.add("source=${enc(config.source)}")
+        }
+        params.add("speaker_auto_assign=enabled")
+        if (boolPref("vadGateEnabled", false)) {
+            params.add("vad_gate=enabled")
+        }
+
+        return "${base}v4/listen?${params.joinToString("&")}"
+    }
+
+    private fun normalizeBaseUrl(value: String): String {
+        var base = value.trim()
+        if (!base.startsWith("http://") && !base.startsWith("https://")) {
+            base = "https://$base"
+        }
+        base = base.replaceFirst("https://", "wss://").replaceFirst("http://", "ws://")
+        return if (base.endsWith("/")) base else "$base/"
+    }
+
+    private fun prefs() = context.getSharedPreferences(FLUTTER_PREFS, Context.MODE_PRIVATE)
+
+    private fun prefValue(key: String): Any? = prefs().all["flutter.$key"]
+
+    private fun stringPref(key: String, defaultValue: String = ""): String =
+        when (val value = prefValue(key)) {
+            is String -> value
+            null -> defaultValue
+            else -> value.toString()
+        }
+
+    private fun boolPref(key: String, defaultValue: Boolean): Boolean =
+        when (val value = prefValue(key)) {
+            is Boolean -> value
+            is String -> value.toBooleanStrictOrNull() ?: defaultValue
+            else -> defaultValue
+        }
+
+    private fun intPref(key: String, defaultValue: Int): Int =
+        when (val value = prefValue(key)) {
+            is Int -> value
+            is Long -> value.toInt()
+            is String -> value.toIntOrNull() ?: defaultValue
+            else -> defaultValue
+        }
+
+    private fun enc(value: String): String = URLEncoder.encode(value, "UTF-8")
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
@@ -21,10 +21,6 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         private const val DEFAULT_API_BASE_URL = "https://api.omiapi.com/"
         private const val MAX_PENDING_FRAMES = 200
         private const val RECONNECT_BACKOFF_MS = 3_000L
-        private const val OMI_SERVICE_UUID = "19b10000-e8f2-537e-4f6c-d104768a1214"
-        private const val OMI_AUDIO_CHAR_UUID = "19b10001-e8f2-537e-4f6c-d104768a1214"
-        private const val FRIEND_SERVICE_UUID = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da"
-        private const val FRIEND_AUDIO_CHAR_UUID = "01000000-1111-1111-1111-111111111111"
         private const val MAX_CACHED_TRANSCRIPT_MESSAGES = 200
         private val transcriptCacheLock = Any()
         private val cachedTranscriptMessages = ArrayDeque<String>()
@@ -72,6 +68,12 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         return config.deviceId.equals(address, ignoreCase = true)
     }
 
+    fun configuredAudioTargetFor(address: String): Pair<String, String>? {
+        val config = loadConfig() ?: return null
+        if (!config.deviceId.equals(address, ignoreCase = true)) return null
+        return config.serviceUuid to config.characteristicUuid
+    }
+
     fun stop(reason: String) {
         var socketToClose: WebSocket? = null
         synchronized(lock) {
@@ -102,7 +104,7 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         if (!config.deviceId.equals(address, ignoreCase = true)) return
         if (!matches(config, serviceUuid, characteristicUuid)) return
 
-        val frames = transformFrames(serviceUuid, characteristicUuid, value)
+        val frames = transformFrames(config, value)
         if (frames.isEmpty()) return
 
         ensureSocket(config)
@@ -116,29 +118,30 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         config.serviceUuid.equals(serviceUuid, ignoreCase = true) &&
             config.characteristicUuid.equals(characteristicUuid, ignoreCase = true)
 
-    private fun transformFrames(serviceUuid: String, characteristicUuid: String, value: ByteArray): List<ByteArray> {
-        val svc = serviceUuid.lowercase(Locale.US)
-        val chr = characteristicUuid.lowercase(Locale.US)
-
-        if (svc == OMI_SERVICE_UUID && chr == OMI_AUDIO_CHAR_UUID) {
-            if (value.size <= 3) return emptyList()
-            return listOf(value.copyOfRange(3, value.size))
-        }
-
-        if (svc == FRIEND_SERVICE_UUID && chr == FRIEND_AUDIO_CHAR_UUID) {
-            if (value.size <= 5) return emptyList()
-            val payload = value.copyOfRange(0, value.size - 5)
-            val frames = mutableListOf<ByteArray>()
-            var offset = 0
-            while (offset + 30 <= payload.size) {
-                frames.add(payload.copyOfRange(offset, offset + 30))
-                offset += 30
+    private fun transformFrames(config: Config, value: ByteArray): List<ByteArray> =
+        when (config.deviceType) {
+            "omi", "openglass" -> {
+                if (value.size <= 3) emptyList() else listOf(value.copyOfRange(3, value.size))
             }
-            return frames
+            "friendPendant" -> {
+                if (value.size <= 5) {
+                    emptyList()
+                } else {
+                    val payload = value.copyOfRange(0, value.size - 5)
+                    val frames = mutableListOf<ByteArray>()
+                    var offset = 0
+                    while (offset + 30 <= payload.size) {
+                        frames.add(payload.copyOfRange(offset, offset + 30))
+                        offset += 30
+                    }
+                    frames
+                }
+            }
+            else -> {
+                Log.w(TAG, "Unsupported background BLE audio device type: ${config.deviceType}")
+                emptyList()
+            }
         }
-
-        return listOf(value.copyOf())
-    }
 
     private fun ensureSocket(config: Config) {
         val now = System.currentTimeMillis()

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -5,6 +5,7 @@ import android.app.*
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattService
 import android.content.*
 import android.os.Handler
 import android.os.IBinder
@@ -47,6 +48,10 @@ class OmiBleForegroundService : Service() {
         private const val MAX_DISCONNECT_HISTORY = 20
         private const val RSSI_TREND_WINDOW_MS = 15_000L
         private const val RSSI_TREND_FADING_DROP_DB = 10
+        private const val OMI_SERVICE_UUID = "19b10000-e8f2-537e-4f6c-d104768a1214"
+        private const val OMI_AUDIO_CHAR_UUID = "19b10001-e8f2-537e-4f6c-d104768a1214"
+        private const val FRIEND_SERVICE_UUID = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da"
+        private const val FRIEND_AUDIO_CHAR_UUID = "01000000-1111-1111-1111-111111111111"
 
         /** Classify the RSSI trajectory in the window before [nowMs]. See BleDisconnectEvent.rssiTrend
          *  for the semantics of each label. */
@@ -138,6 +143,7 @@ class OmiBleForegroundService : Service() {
     private var isBluetoothEnabled = true
     private val syncLock = Any()
     private val bleManager get() = OmiBleManager.instance
+    private val backgroundAudioStreamer by lazy { OmiBackgroundAudioStreamer(applicationContext) }
 
     // ── Connection listener — receives GATT events from OmiBleManager ──
 
@@ -237,9 +243,59 @@ class OmiBleForegroundService : Service() {
 
     private fun fireDeviceReady(address: String, services: List<BleService>) {
         val addr = address.uppercase()
-        bleManager.mainHandler.post {
-            bleManager.flutterApi?.onDeviceReady(addr, services) {}
+        ensureBackgroundAudioSubscription(addr, services)
+        if (OmiBleManager.isFlutterAlive) {
+            bleManager.mainHandler.post {
+                bleManager.flutterApi?.onDeviceReady(addr, services) {}
+            }
         }
+    }
+
+    private fun ensureBackgroundAudioSubscription(address: String, services: List<BleService>) {
+        if (OmiBleManager.isFlutterAlive) return
+        if (!backgroundAudioStreamer.isConfiguredFor(address)) return
+
+        val target = listOf(
+            OMI_SERVICE_UUID to OMI_AUDIO_CHAR_UUID,
+            FRIEND_SERVICE_UUID to FRIEND_AUDIO_CHAR_UUID
+        ).firstOrNull { (serviceUuid, characteristicUuid) ->
+            services.any { service ->
+                service.uuid.equals(serviceUuid, ignoreCase = true) &&
+                    service.characteristicUuids.any { it.equals(characteristicUuid, ignoreCase = true) }
+            }
+        } ?: return
+
+        Log.i(TAG, "Ensuring BLE audio subscription for background transcription on $address")
+        bleManager.subscribeCharacteristic(address, target.first, target.second)
+    }
+
+    private fun mapGattServices(services: List<BluetoothGattService>): List<BleService> =
+        services.map { service ->
+            BleService(
+                uuid = service.uuid.toString().lowercase(),
+                characteristicUuids = service.characteristics?.map { it.uuid.toString().lowercase() } ?: emptyList()
+            )
+        }
+
+    private fun notifyReadyForConnectedGatt(address: String): Boolean {
+        val addr = address.uppercase()
+        val gatt = bleManager.connectedGatts[addr] ?: return false
+        val services = gatt.services
+
+        if (!services.isNullOrEmpty()) {
+            Log.i(TAG, "notifyReadyForConnectedGatt: re-emitting ready for $addr (${services.size} services)")
+            fireDeviceReady(addr, mapGattServices(services))
+            return true
+        }
+
+        Log.i(TAG, "notifyReadyForConnectedGatt: rediscovering services for already-connected $addr")
+        bleManager.enqueueCommand {
+            if (!gatt.discoverServices()) {
+                Log.e(TAG, "notifyReadyForConnectedGatt: discoverServices returned false for $addr")
+                bleManager.completeCommand()
+            }
+        }
+        return true
     }
 
     // ── Managed device lifecycle ──
@@ -260,7 +316,16 @@ class OmiBleForegroundService : Service() {
         }
 
         val existing = managedDevices[addr]
-        if (existing != null && bleManager.isPeripheralConnected(addr)) return
+        if (existing != null && bleManager.isPeripheralConnected(addr)) {
+            if (requiresBond && !existing.requiresBond) existing.requiresBond = true
+            existing.retryCount = 0
+            existing.currentGattHash = bleManager.connectedGatts[addr]?.hashCode()
+            existing.hasEverConnected = true
+            existing.currentAttemptEstablished = true
+            updateNotification("Connected to Omi")
+            notifyReadyForConnectedGatt(addr)
+            return
+        }
 
         if (existing != null) {
             if (requiresBond && !existing.requiresBond) existing.requiresBond = true
@@ -530,6 +595,16 @@ class OmiBleForegroundService : Service() {
             RECEIVER_NOT_EXPORTED
         )
         bleManager.connectionListener = connectionListener
+        bleManager.characteristicValueListener = object : OmiBleManager.CharacteristicValueListener {
+            override fun onCharacteristicValue(
+                address: String,
+                serviceUuid: String,
+                characteristicUuid: String,
+                value: ByteArray
+            ) {
+                backgroundAudioStreamer.handleCharacteristic(address, serviceUuid, characteristicUuid, value)
+            }
+        }
         Log.d(TAG, "Service created")
     }
 
@@ -537,23 +612,34 @@ class OmiBleForegroundService : Service() {
         startForeground(NOTIFICATION_ID, buildNotification("Connecting to Omi..."))
 
         val address = intent?.getStringExtra("device_address")
+        val requiresBond = intent?.getBooleanExtra("requires_bond", false) ?: false
 
         if (address != null) {
-            val requiresBond = intent.getBooleanExtra("requires_bond", false)
             manageDevice(address, requiresBond)
         } else {
-            // No device specified — Omi streams via WebSocket which needs the app.
-            // No point keeping BLE alive without it.
-            Log.i(TAG, "onStartCommand: no device address, stopping")
-            stopSelf()
+            val saved = getSharedPreferences(PREFS_NAME, MODE_PRIVATE).getString(PREFS_KEY, null)
+            val parts = saved?.split("|")
+            if (parts?.size == 2) {
+                Log.i(TAG, "onStartCommand: restoring saved device ${parts[0]}")
+                manageDevice(parts[0], parts[1].toBoolean())
+            } else {
+                Log.i(TAG, "onStartCommand: no device address or saved device, stopping")
+                stopSelf()
+            }
         }
 
-        return START_NOT_STICKY
+        return START_STICKY
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Log.i(TAG, "Task removed; keeping BLE foreground service alive")
+        super.onTaskRemoved(rootIntent)
     }
 
     override fun onDestroy() {
         Log.d(TAG, "Service destroying")
         isDestroying = true
+        backgroundAudioStreamer.stop("service_destroyed")
 
         for ((addr, managed) in managedDevices) {
             managed.pendingReconnect?.let { handler.removeCallbacks(it) }
@@ -568,6 +654,7 @@ class OmiBleForegroundService : Service() {
         managedDevices.clear()
 
         bleManager.connectionListener = null
+        bleManager.characteristicValueListener = null
         instance = null
 
         try { unregisterReceiver(bluetoothReceiver) } catch (_: Exception) {}

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -48,11 +48,6 @@ class OmiBleForegroundService : Service() {
         private const val MAX_DISCONNECT_HISTORY = 20
         private const val RSSI_TREND_WINDOW_MS = 15_000L
         private const val RSSI_TREND_FADING_DROP_DB = 10
-        private const val OMI_SERVICE_UUID = "19b10000-e8f2-537e-4f6c-d104768a1214"
-        private const val OMI_AUDIO_CHAR_UUID = "19b10001-e8f2-537e-4f6c-d104768a1214"
-        private const val FRIEND_SERVICE_UUID = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da"
-        private const val FRIEND_AUDIO_CHAR_UUID = "01000000-1111-1111-1111-111111111111"
-
         /** Classify the RSSI trajectory in the window before [nowMs]. See BleDisconnectEvent.rssiTrend
          *  for the semantics of each label. */
         private fun classifyRssiTrend(samples: List<Pair<Long, Int>>, nowMs: Long): String {
@@ -253,17 +248,12 @@ class OmiBleForegroundService : Service() {
 
     private fun ensureBackgroundAudioSubscription(address: String, services: List<BleService>) {
         if (OmiBleManager.isFlutterAlive) return
-        if (!backgroundAudioStreamer.isConfiguredFor(address)) return
-
-        val target = listOf(
-            OMI_SERVICE_UUID to OMI_AUDIO_CHAR_UUID,
-            FRIEND_SERVICE_UUID to FRIEND_AUDIO_CHAR_UUID
-        ).firstOrNull { (serviceUuid, characteristicUuid) ->
-            services.any { service ->
-                service.uuid.equals(serviceUuid, ignoreCase = true) &&
-                    service.characteristicUuids.any { it.equals(characteristicUuid, ignoreCase = true) }
-            }
-        } ?: return
+        val target = backgroundAudioStreamer.configuredAudioTargetFor(address) ?: return
+        val hasTarget = services.any { service ->
+            service.uuid.equals(target.first, ignoreCase = true) &&
+                service.characteristicUuids.any { it.equals(target.second, ignoreCase = true) }
+        }
+        if (!hasTarget) return
 
         Log.i(TAG, "Ensuring BLE audio subscription for background transcription on $address")
         bleManager.subscribeCharacteristic(address, target.first, target.second)

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -47,9 +47,8 @@ class OmiBleManager private constructor(private val application: Application) {
             get() = _instance != null
 
         /** True while the Flutter engine is alive. Set in MainActivity.configureFlutterEngine,
-         *  cleared in MainActivity.onDestroy(isFinishing). CompanionService checks this to
-         *  avoid starting the foreground service when the app is dead — Omi needs the Flutter
-         *  app for WebSocket audio streaming. */
+         *  cleared in MainActivity.onDestroy(isFinishing). The BLE foreground service can
+         *  continue running after this becomes false. */
         @Volatile
         var isFlutterAlive: Boolean = false
 
@@ -83,6 +82,13 @@ class OmiBleManager private constructor(private val application: Application) {
 
     @Volatile
     var connectionListener: BleConnectionListener? = null
+
+    interface CharacteristicValueListener {
+        fun onCharacteristicValue(address: String, serviceUuid: String, characteristicUuid: String, value: ByteArray)
+    }
+
+    @Volatile
+    var characteristicValueListener: CharacteristicValueListener? = null
 
     @Volatile
     var flutterApi: BleFlutterApi? = null
@@ -633,6 +639,7 @@ class OmiBleManager private constructor(private val application: Application) {
 
             if (servicesDiscoveredFor.contains(address)) {
                 Log.i(TAG, "Ignoring duplicate onServicesDiscovered for $address")
+                completeCommand()
                 return
             }
 
@@ -675,8 +682,11 @@ class OmiBleManager private constructor(private val application: Application) {
                 persistBatteryReading(address, value[0].toInt() and 0xFF)
             }
 
-            mainHandler.post {
-                flutterApi?.onCharacteristicValueUpdated(address, serviceUuid, charUuid, value) {}
+            characteristicValueListener?.onCharacteristicValue(address, serviceUuid, charUuid, value.copyOf())
+            if (isFlutterAlive) {
+                mainHandler.post {
+                    flutterApi?.onCharacteristicValueUpdated(address, serviceUuid, charUuid, value) {}
+                }
             }
         }
 

--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -53,7 +53,15 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
 
         return GestureDetector(
           onTap: () async {
-            if (provider.segments.isEmpty && provider.photos.isEmpty) return;
+            final isCaptureActive = provider.recordingState == RecordingState.record ||
+                provider.recordingState == RecordingState.systemAudioRecord ||
+                provider.recordingState == RecordingState.deviceRecord ||
+                provider.recordingState == RecordingState.initialising ||
+                provider.recordingState == RecordingState.interrupted ||
+                provider.recordingState == RecordingState.pause ||
+                provider.havingRecordingDevice ||
+                provider.isPaused;
+            if (!isCaptureActive && provider.segments.isEmpty && provider.photos.isEmpty) return;
             PlatformManager.instance.analytics.liveTranscriptCardClicked(
               hasSegments: provider.segments.isNotEmpty,
               hasPhotos: provider.photos.isNotEmpty,

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -66,6 +66,10 @@ import 'package:omi/backend/schema/message_event.dart'
 class CaptureProvider extends ChangeNotifier
     with MessageNotifierMixin
     implements ITransctiptSegmentSocketServiceListener {
+  static const MethodChannel _nativeBleTranscriptChannel = MethodChannel('com.friend.ios/native_ble_transcript');
+  static const int _maxInProgressConversationRefreshAttempts = 30;
+  static const Duration _inProgressConversationRefreshInterval = Duration(seconds: 2);
+
   ConversationProvider? conversationProvider;
   MessageProvider? messageProvider;
   PeopleProvider? peopleProvider;
@@ -77,6 +81,9 @@ class CaptureProvider extends ChangeNotifier
   TranscriptSegmentSocketService? _socket;
   Timer? _keepAliveTimer;
   DateTime? _keepAliveLastExecutedAt;
+  Timer? _inProgressConversationRefreshTimer;
+  int _inProgressConversationRefreshAttempts = 0;
+  bool _isRefreshingInProgressConversation = false;
 
   IWalService get _wal => ServiceManager.instance().wal;
 
@@ -443,6 +450,7 @@ class CaptureProvider extends ChangeNotifier
   }
 
   Future _resetStateVariables() async {
+    _stopInProgressConversationRefresh();
     segments = [];
     photos = [];
     hasTranscripts = false;
@@ -551,7 +559,9 @@ class CaptureProvider extends ChangeNotifier
       _sessionStartSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     }
 
-    _loadInProgressConversation();
+    await _loadInProgressConversation();
+    await _drainNativeBleTranscriptMessages();
+    _startInProgressConversationRefresh();
 
     notifyListeners();
   }
@@ -799,6 +809,7 @@ class CaptureProvider extends ChangeNotifier
   }
 
   Future _cleanupCurrentState({bool disableNativeBackground = false}) async {
+    _stopInProgressConversationRefresh();
     await _closeBleStream(disableNativeBackground: disableNativeBackground);
     _activeSource = null;
     notifyListeners();
@@ -1064,6 +1075,7 @@ class CaptureProvider extends ChangeNotifier
     _blePhotoStream?.cancel();
     _socket?.unsubscribe(this);
     _keepAliveTimer?.cancel();
+    _inProgressConversationRefreshTimer?.cancel();
     _connectionStateListener?.cancel();
     _audioInterruptionSubscription?.cancel();
     _metricsTimer?.cancel();
@@ -1289,6 +1301,99 @@ class CaptureProvider extends ChangeNotifier
 
   Future refreshInProgressConversations() async {
     _loadInProgressConversation();
+  }
+
+  bool get _canRefreshInProgressConversation =>
+      recordingDeviceServiceReady ||
+      recordingState == RecordingState.initialising ||
+      recordingState == RecordingState.interrupted ||
+      recordingState == RecordingState.pause ||
+      recordingState == RecordingState.deviceRecord;
+
+  void _startInProgressConversationRefresh() {
+    if (!_canRefreshInProgressConversation || segments.isNotEmpty || photos.isNotEmpty) return;
+
+    _stopInProgressConversationRefresh();
+    _inProgressConversationRefreshAttempts = 0;
+    _inProgressConversationRefreshTimer = Timer.periodic(_inProgressConversationRefreshInterval, (_) {
+      _refreshInProgressConversationTick();
+    });
+  }
+
+  void _stopInProgressConversationRefresh() {
+    _inProgressConversationRefreshTimer?.cancel();
+    _inProgressConversationRefreshTimer = null;
+    _inProgressConversationRefreshAttempts = 0;
+    _isRefreshingInProgressConversation = false;
+  }
+
+  Future<void> _refreshInProgressConversationTick() async {
+    if (_isRefreshingInProgressConversation) return;
+    if (!_canRefreshInProgressConversation ||
+        segments.isNotEmpty ||
+        photos.isNotEmpty ||
+        _inProgressConversationRefreshAttempts >= _maxInProgressConversationRefreshAttempts) {
+      _stopInProgressConversationRefresh();
+      return;
+    }
+
+    _inProgressConversationRefreshAttempts++;
+    _isRefreshingInProgressConversation = true;
+    try {
+      await _drainNativeBleTranscriptMessages();
+      if (segments.isEmpty && photos.isEmpty) {
+        await _loadInProgressConversation();
+      }
+    } finally {
+      _isRefreshingInProgressConversation = false;
+    }
+
+    if (segments.isNotEmpty ||
+        photos.isNotEmpty ||
+        _inProgressConversationRefreshAttempts >= _maxInProgressConversationRefreshAttempts) {
+      _stopInProgressConversationRefresh();
+    }
+  }
+
+  Future<void> _drainNativeBleTranscriptMessages() async {
+    if (!Platform.isAndroid) return;
+
+    List<String>? messages;
+    try {
+      messages = await _nativeBleTranscriptChannel.invokeListMethod<String>('drain');
+    } on MissingPluginException {
+      return;
+    } catch (e) {
+      Logger.debug('Failed to drain native BLE transcript messages: $e');
+      return;
+    }
+
+    if (messages == null || messages.isEmpty) return;
+    Logger.debug('Draining ${messages.length} native BLE transcript messages');
+
+    for (final message in messages) {
+      await _handleNativeBleTranscriptMessage(message);
+    }
+  }
+
+  Future<void> _handleNativeBleTranscriptMessage(String message) async {
+    dynamic jsonEvent;
+    try {
+      jsonEvent = jsonDecode(message);
+    } catch (e) {
+      Logger.debug('Failed to decode native BLE transcript message: $e');
+      return;
+    }
+
+    if (jsonEvent is List) {
+      final newSegments = jsonEvent.map((e) => TranscriptSegment.fromJson(e)).toList();
+      await _processNewSegmentReceived(newSegments);
+      return;
+    }
+
+    if (jsonEvent is Map && jsonEvent.containsKey('type')) {
+      onMessageEventReceived(MessageEvent.fromJson(Map<String, dynamic>.from(jsonEvent)));
+    }
   }
 
   Future _loadInProgressConversation() async {
@@ -1759,7 +1864,7 @@ class CaptureProvider extends ChangeNotifier
     _processNewSegmentReceived(newSegments);
   }
 
-  void _processNewSegmentReceived(List<TranscriptSegment> newSegments) async {
+  Future<void> _processNewSegmentReceived(List<TranscriptSegment> newSegments) async {
     if (newSegments.isEmpty) return;
 
     if (segments.isEmpty && !_isLoadingInProgressConversation) {

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -906,12 +906,11 @@ class CaptureProvider extends ChangeNotifier
   }
 
   Future<void> _saveNativeBleStreamConfig(BtDevice device, BleAudioCodec codec) async {
-    var serviceUuid = omiServiceUuid;
-    var characteristicUuid = audioDataStreamCharacteristicUuid;
-
-    if (device.type == DeviceType.friendPendant) {
-      serviceUuid = friendPendantServiceUuid;
-      characteristicUuid = friendPendantAudioCharacteristicUuid;
+    final audioTarget = _nativeBleAudioTarget(device);
+    if (audioTarget == null) {
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+      return;
     }
 
     await SharedPreferencesUtil().saveString(
@@ -922,13 +921,30 @@ class CaptureProvider extends ChangeNotifier
         'sampleRate': mapCodecToSampleRate(codec),
         'source': _getConversationSourceFromDevice(),
         'apiBaseUrl': Env.apiBaseUrl ?? 'https://api.omiapi.com/',
-        'serviceUuid': serviceUuid,
-        'characteristicUuid': characteristicUuid,
+        'serviceUuid': audioTarget.key,
+        'characteristicUuid': audioTarget.value,
         'deviceType': device.type.name,
       }),
     );
     await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
     await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', true);
+  }
+
+  MapEntry<String, String>? _nativeBleAudioTarget(BtDevice device) {
+    switch (device.type) {
+      case DeviceType.omi:
+      case DeviceType.openglass:
+        return const MapEntry(omiServiceUuid, audioDataStreamCharacteristicUuid);
+      case DeviceType.friendPendant:
+        return const MapEntry(friendPendantServiceUuid, friendPendantAudioCharacteristicUuid);
+      case DeviceType.appleWatch:
+      case DeviceType.bee:
+      case DeviceType.fieldy:
+      case DeviceType.frame:
+      case DeviceType.limitless:
+      case DeviceType.plaud:
+        return null;
+    }
   }
 
   Future<void> _initiateDevicePhotoStreaming() async {

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -25,6 +25,7 @@ import 'package:omi/backend/schema/message.dart';
 import 'package:omi/backend/schema/person.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/env/env.dart';
 import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/models/stt_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
@@ -37,6 +38,7 @@ import 'package:omi/services/voice_playback/omi_voice_playback_service.dart';
 import 'package:omi/services/sockets/transcription_service.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/audio_sources/ble_device_source.dart';
+import 'package:omi/services/devices/models.dart';
 import 'package:omi/services/audio_sources/phone_mic_source.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
@@ -716,11 +718,11 @@ class CaptureProvider extends ChangeNotifier
     );
   }
 
-  Future streamAudioToWs(String deviceId, BleAudioCodec codec) async {
+  Future<bool> streamAudioToWs(String deviceId, BleAudioCodec codec) async {
     Logger.debug('streamAudioToWs in capture_provider');
     _bleBytesStream?.cancel();
     _startMetricsTracking();
-    _bleBytesStream = await _getBleAudioBytesListener(
+    final subscription = await _getBleAudioBytesListener(
       deviceId,
       onAudioBytesReceived: (List<int> value) {
         final snapshot = List<int>.from(value);
@@ -772,7 +774,9 @@ class CaptureProvider extends ChangeNotifier
         }
       },
     );
+    _bleBytesStream = subscription;
     notifyListeners();
+    return subscription != null;
   }
 
   Future<void> _resetState() async {
@@ -794,8 +798,8 @@ class CaptureProvider extends ChangeNotifier
     notifyListeners();
   }
 
-  Future _cleanupCurrentState() async {
-    await _closeBleStream();
+  Future _cleanupCurrentState({bool disableNativeBackground = false}) async {
+    await _closeBleStream(disableNativeBackground: disableNativeBackground);
     _activeSource = null;
     notifyListeners();
   }
@@ -869,6 +873,7 @@ class CaptureProvider extends ChangeNotifier
     if (connection == null) return;
     final codec = await _getAudioCodec(deviceId);
     await _wal.getSyncs().phone.onAudioCodecChanged(codec);
+    await _saveNativeBleStreamConfig(device, codec);
 
     // Create audio source for BLE device
     final pd = await device.getDeviceInfo(connection);
@@ -879,11 +884,40 @@ class CaptureProvider extends ChangeNotifier
     _wal.getSyncs().phone.setDeviceInfo(deviceId, deviceModel);
 
     await streamButton(deviceId);
-    await streamAudioToWs(deviceId, codec);
+    final foregroundAudioReady = await streamAudioToWs(deviceId, codec);
+    if (foregroundAudioReady) {
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', true);
+    }
 
     // Update state
     updateRecordingState(RecordingState.deviceRecord);
     notifyListeners();
+  }
+
+  Future<void> _saveNativeBleStreamConfig(BtDevice device, BleAudioCodec codec) async {
+    var serviceUuid = omiServiceUuid;
+    var characteristicUuid = audioDataStreamCharacteristicUuid;
+
+    if (device.type == DeviceType.friendPendant) {
+      serviceUuid = friendPendantServiceUuid;
+      characteristicUuid = friendPendantAudioCharacteristicUuid;
+    }
+
+    await SharedPreferencesUtil().saveString(
+      'nativeBleStreamConfig',
+      jsonEncode({
+        'deviceId': device.id,
+        'codec': codec.toString(),
+        'sampleRate': mapCodecToSampleRate(codec),
+        'source': _getConversationSourceFromDevice(),
+        'apiBaseUrl': Env.apiBaseUrl ?? 'https://api.omiapi.com/',
+        'serviceUuid': serviceUuid,
+        'characteristicUuid': characteristicUuid,
+        'deviceType': device.type.name,
+      }),
+    );
+    await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+    await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', true);
   }
 
   Future<void> _initiateDevicePhotoStreaming() async {
@@ -1005,10 +1039,16 @@ class CaptureProvider extends ChangeNotifier
     _calculateMetricsRates();
   }
 
-  Future _closeBleStream() async {
+  Future _closeBleStream({bool disableNativeBackground = false}) async {
     await _bleBytesStream?.cancel();
     await _blePhotoStream?.cancel();
     _stopMetricsTracking();
+    if (disableNativeBackground) {
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+      await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
+    } else {
+      await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+    }
     if (_recordingDevice != null) {
       var connection = await ServiceManager.instance().device.ensureConnection(_recordingDevice!.id);
       if (connection != null && await connection.hasPhotoStreamingCharacteristic()) {
@@ -1127,7 +1167,7 @@ class CaptureProvider extends ChangeNotifier
       }
       _phoneMicWalActive = false;
     }
-    await _cleanupCurrentState();
+    await _cleanupCurrentState(disableNativeBackground: true);
     ServiceManager.instance().mic.stop();
     updateRecordingState(RecordingState.stop);
     await _socket?.stop(reason: 'stop stream recording');
@@ -1151,7 +1191,7 @@ class CaptureProvider extends ChangeNotifier
   }
 
   Future stopStreamDeviceRecording({bool cleanDevice = false}) async {
-    await _cleanupCurrentState();
+    await _cleanupCurrentState(disableNativeBackground: true);
     if (cleanDevice) {
       _updateRecordingDevice(null);
     }
@@ -1817,6 +1857,8 @@ class CaptureProvider extends ChangeNotifier
     await BatteryWidgetService().updateMuteState(true);
     // Pause the BLE stream but keep the device connection
     await _bleBytesStream?.cancel();
+    await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
+    await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', false);
     _isPaused = true;
     updateRecordingState(RecordingState.pause);
     notifyListeners();
@@ -1829,12 +1871,6 @@ class CaptureProvider extends ChangeNotifier
     BatteryWidgetService().updateMuteState(false);
     // Resume streaming from the device
     await _initiateDeviceAudioStreaming();
-
-    final deviceId = _recordingDevice!.id;
-    BleAudioCodec codec = await _getAudioCodec(deviceId);
-    await _wal.getSyncs().phone.onAudioCodecChanged(codec);
-
-    await streamAudioToWs(deviceId, codec);
 
     updateRecordingState(RecordingState.deviceRecord);
     notifyListeners();


### PR DESCRIPTION
## Summary
This came from feedback on a weekly Omi call: an Android user noted that other AI wearables can keep recording and transcribing even after the companion app is closed. This PR makes the stock Android Omi app behave that way for BLE pendant capture, so users do not have to reopen or check the app just to confirm transcription is still running. The pendant on/off state remains the user control point for recording and privacy.

## Related issue
- Relates to https://github.com/BasedHardware/omi/issues/5898

## What changed
- keeps the Android BLE foreground service alive when the Flutter task is closed
- starts a native Android BLE audio streamer that sends pendant audio to the existing `/v4/listen` websocket while Flutter is not running
- saves the stock API/auth config and active BLE audio endpoint from Flutter so the native service can reconnect through the same backend path
- caches recent native transcript websocket messages and drains them into Flutter on app relaunch
- refreshes the in-progress conversation after relaunch so the live transcript view hydrates after a cold start
- lets the live transcript card open while capture is active, even before the first visible segment has arrived

## Device support note
The native background path does not hardcode an individual device ID. It uses the active device ID and audio service/characteristic saved by Flutter. Packet handling is currently enabled for Omi/OpenGlass-style audio and Friend Pendant audio. Other BLE device families keep the existing foreground app behavior until their packet parsing and start/stop control flows are mirrored natively.

## Testing
- Hardware testing so far was done only with DK2.
- Manual Android DK2 pendant test: pendant connects, light stays blue after closing the app, and audio continues transcribing while the app task is closed.
- Manual reopen test: relaunching the app while capture is active hydrates the live transcript state and the transcript view becomes interactive.
- Repeated close/reopen counting tests: no obvious transcript gap in the tested warm path.
- `flutter build apk --debug --flavor dev` passed.
- `bash test.sh` ran; the current app suite reports 465 passing and 7 unrelated baseline failures:
  - `AudioWavePainter shouldRepaint returns false when level differs by 0.01 or less`
  - `AudioWavePainter shouldRepaint returns false when level differs by clearly less than 0.01`
  - `env_test.dart`, `env_staging_test.dart`, and `env_empty_staging_test.dart` fail to compile because test EnvFields stubs do not implement `posthogApiKey`
  - `RingProtocol.parseAudioPayload parses a frame that exactly fills the buffer (boundary)`
  - `RingProtocol.parseAudioPayload parses tightly-packed frames with no trailing padding (440B exactly)`

## Additional tester request
This touches Android foreground service, BLE, Flutter lifecycle behavior, and has only been tested on DK2 so far. Please test on additional Android models, OS versions, and supported Omi/OpenGlass/Friend Pendant devices by starting pendant capture, closing the app task, speaking for a while, reopening the app, and confirming the pendant stays connected and the transcript catches up without losing audio.