### PR TITLE
fix(desktop): conversation title edit hits nonexistent endpoint, never saves

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed editing a conversation title not saving"
+  ],
   "releases": [
     {
       "version": "0.11.421",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -369,15 +369,12 @@ extension APIClient {
 
   /// Updates the title of a conversation
   func updateConversationTitle(id: String, title: String) async throws {
-    struct TitleUpdate: Encodable {
-      let title: String
-    }
-
-    let url = URL(string: baseURL + "v1/conversations/\(id)")!
+    var components = URLComponents(string: baseURL + "v1/conversations/\(id)/title")!
+    components.queryItems = [URLQueryItem(name: "title", value: title)]
+    let url = components.url!
     var request = URLRequest(url: url)
     request.httpMethod = "PATCH"
     request.allHTTPHeaderFields = try await buildHeaders(requireAuth: true)
-    request.httpBody = try JSONEncoder().encode(TitleUpdate(title: title))
 
     let (_, response) = try await session.data(for: request)
     guard let httpResponse = response as? HTTPURLResponse,


### PR DESCRIPTION
## Problem

Editing a conversation title in the macOS desktop app silently fails and the title never persists. The same edit on mobile works.

## Root cause

`APIClient.updateConversationTitle` sent `PATCH /v1/conversations/{id}` with the title in a JSON body. The Python backend has no such route. The only title route is `PATCH /v1/conversations/{id}/title` with the title as a query param (`backend/routers/conversations.py:177`), which the Flutter app already calls (`app/lib/backend/http/api/conversations.dart:146`). The desktop request 404s, the guard throws `APIError.httpError`, and the edit is lost.

## Fix

Point the desktop call at `/v1/conversations/{id}/title` with the title as a query item, matching the backend contract and the mobile client. Uses `URLComponents` so the title is percent-encoded. Removes the unused `TitleUpdate` body struct.

## Testing

Edited a conversation title in the desktop app and confirmed it persists across a refresh.