### PR TITLE
fix(app): show convos list with 1-2 items + fix home overflow

### DIFF
--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -303,11 +303,11 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
               ),
 
               // Section header - show "Daily Recaps" or "Conversations" with optional recording pill.
-              // Hidden entirely when the user has fewer than 3 non-discarded
+              // Hidden entirely when the user has zero non-discarded
               // conversations (and isn't on the Daily Recaps view) — those
               // users get the empty-state hero below instead.
               if (convoProvider.showDailySummaries ||
-                  _nonDiscardedConversationCount(convoProvider) >= 3 ||
+                  _nonDiscardedConversationCount(convoProvider) > 0 ||
                   convoProvider.isLoadingConversations ||
                   convoProvider.isFetchingConversations)
                 SliverToBoxAdapter(
@@ -329,9 +329,9 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                 ),
 
               // Folder tabs - hide when showing daily recaps OR when the user
-              // hasn't built up enough conversations yet (matches the title).
+              // has no conversations yet (matches the title).
               if (!convoProvider.showDailySummaries &&
-                  (_nonDiscardedConversationCount(convoProvider) >= 3 ||
+                  (_nonDiscardedConversationCount(convoProvider) > 0 ||
                       convoProvider.isLoadingConversations ||
                       convoProvider.isFetchingConversations))
                 Consumer2<FolderProvider, ConversationProvider>(
@@ -355,14 +355,14 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
               // Show daily summaries list or conversations based on filter
               if (convoProvider.showDailySummaries)
                 const DailySummariesList()
-              else if (_nonDiscardedConversationCount(convoProvider) < 3 &&
+              else if (_nonDiscardedConversationCount(convoProvider) == 0 &&
                   !convoProvider.isLoadingConversations &&
                   !convoProvider.isFetchingConversations &&
                   !convoProvider.isAwaitingInitialFetchRetry &&
                   !convoProvider.showStarredOnly &&
                   convoProvider.selectedFolderId == null)
-                // Friendly hero for users who haven't built up enough
-                // conversations yet — matches the polished Tasks empty state.
+                // Friendly hero for brand-new users with zero conversations —
+                // matches the polished Tasks empty state.
                 SliverFillRemaining(
                   hasScrollBody: false,
                   child: Center(child: _buildNoConversationsHero(context)),

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -232,10 +232,12 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
             ),
             const SizedBox(height: 10),
             SizedBox(
-              width: 96,
+              width: 120,
               child: Text(
                 label,
                 textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w500, height: 1.2),
               ),
             ),


### PR DESCRIPTION
## Summary

Two unrelated UI bugs on the app's home + conversations tabs, fixed in one PR.

### 1. Conversations tab hides the list for users with 1 or 2 conversations

The "No conversations yet" hero on the conversations tab used a `< 3` threshold (introduced in `1d0e3c599`) and rendered inside `SliverFillRemaining`, so it **replaced** the conversation list entirely whenever the user had 1 or 2 non-discarded conversations. The list was rendered fine but unreachable behind the hero.

Reported symptom: pull-to-refresh briefly revealed the conversations, normal page load showed only the empty hero. That happened because the hero is gated by `!convoProvider.isLoadingConversations` — during a refresh the loading flag flipped to `true`, the hero branch failed, and execution fell through to the list. Once the refresh finished, the hero took over again.

Fix in [app/lib/pages/conversations/conversations_page.dart](app/lib/pages/conversations/conversations_page.dart):

- Hero guard: `count < 3` → `count == 0`
- Title guard: `count >= 3` → `count > 0`
- Folder-tabs guard: `count >= 3` → `count > 0`

Net effect: users with any conversations see the list + title + folder tabs; the hero only renders for truly empty accounts.

### 2. RenderFlex overflow on the home tab Get Started options

```
flutter: A RenderFlex overflowed by 16 pixels on the bottom.
```

The label box in `_buildGetStartedOptions` ([app/lib/pages/home/home_content.dart](app/lib/pages/home/home_content.dart)) was constrained to `width: 96`, so "Record with Phone" wrapped to two lines at 13pt and added ~16px per option Column — overflowing the `SliverFillRemaining` viewport on shorter screens.

Fix: widen the label box to 120 (longest label now fits on one line) and add `maxLines: 1` + ellipsis as a safety net for future longer labels and accessibility-scaled fonts. The Row has plenty of horizontal room — 2 × 120 = 240 inside ~290 usable width on the smallest iPhones.

## Test plan

- [ ] **Conversations tab (count == 0):** fresh account, conversations tab shows the polished "No conversations yet" hero — title and folder tabs are hidden.
- [ ] **Conversations tab (count == 1):** account with exactly one conversation now shows the list + the "Conversations" title + folder tabs. Hero is not rendered.
- [ ] **Conversations tab (count == 2):** same as above — list visible, no hero.
- [ ] **Conversations tab (count >= 3):** unchanged behavior.
- [ ] **Pull-to-refresh** on the conversations tab with 1-2 conversations: list stays visible throughout, no flash of hero after refresh completes.
- [ ] **Home tab Get Started options:** no `RenderFlex overflowed` warning in console on the smallest supported iPhone (SE 3rd gen) and an Android device with similar viewport height.
- [ ] **Label rendering:** "Record with Phone", "Record Call", and "Connect Device" all render on a single line, centered under their respective icons.