### PR TITLE
fix developer export share crash empty title PlatformException

### DIFF
--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -823,6 +823,8 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
                         ? null
                         : () async {
                             if (provider.loadingExportMemories) return;
+                            // Capture l10n before async gaps
+                            final exportTitle = context.l10n.exportAllData;
                             setState(() => provider.loadingExportMemories = true);
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
@@ -834,25 +836,29 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
                             final filePath = '${directory.path}/omi-export.json';
                             final exportedPath = await exportUserDataToFile(filePath);
                             if (exportedPath == null) {
+                              // Always reset the flag so the button is re-enabled even if widget is unmounted
+                              provider.loadingExportMemories = false;
                               if (context.mounted) {
                                 ScaffoldMessenger.of(
                                   context,
                                 ).showSnackBar(const SnackBar(content: Text('Export failed. Please try again.')));
-                                setState(() => provider.loadingExportMemories = false);
+                                setState(() {});
                               }
                               return;
                             }
 
                             final result = await Share.shareXFiles(
                               [XFile(exportedPath)],
-                              subject: 'Exported Data from Omi',
-                              text: 'Exported Data from Omi',
+                              subject: exportTitle,
+                              text: exportTitle,
                             );
                             if (result.status == ShareResultStatus.success) {
                               Logger.debug('Export shared');
                             }
                             PlatformManager.instance.analytics.exportMemories();
-                            if (mounted) setState(() => provider.loadingExportMemories = false);
+                            // Always reset the flag so the button is re-enabled even if widget is unmounted
+                            provider.loadingExportMemories = false;
+                            if (mounted) setState(() {});
                           },
                     child: Container(
                       padding: const EdgeInsets.all(16),

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -838,19 +838,21 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
                                 ScaffoldMessenger.of(
                                   context,
                                 ).showSnackBar(const SnackBar(content: Text('Export failed. Please try again.')));
+                                setState(() => provider.loadingExportMemories = false);
                               }
-                              setState(() => provider.loadingExportMemories = false);
                               return;
                             }
 
-                            final result = await Share.shareXFiles([
-                              XFile(exportedPath),
-                            ], text: 'Exported Data from Omi');
+                            final result = await Share.shareXFiles(
+                              [XFile(exportedPath)],
+                              subject: 'Exported Data from Omi',
+                              text: 'Exported Data from Omi',
+                            );
                             if (result.status == ShareResultStatus.success) {
                               Logger.debug('Export shared');
                             }
                             PlatformManager.instance.analytics.exportMemories();
-                            setState(() => provider.loadingExportMemories = false);
+                            if (mounted) setState(() => provider.loadingExportMemories = false);
                           },
                     child: Container(
                       padding: const EdgeInsets.all(16),


### PR DESCRIPTION
MethodChannelShare.share

FlutterError - PlatformException(error, Non-empty title expected, null, null)
package:share_plus_platform_interface/method_channel/method_channel_share.dart:25

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 StandardMethodCodec.decodeEnvelope + 653 (message_codecs.dart:653)
1  ???                            0x0 MethodChannel._invokeMethod + 367 (platform_channel.dart:367)
2  ???                            0x0 MethodChannelShare.share + 25 (method_channel_share.dart:25)
3  ???                            0x0 _DeveloperSettingsPageState.build.<fn>.<fn> + 846 (developer.dart:846)
```

Fix: Added `subject: 'Exported Data from Omi'` to `Share.shareXFiles` — Android requires a non-empty subject when sharing files. Also moved the failure-path `setState` inside the `context.mounted` guard, and added `if (mounted)` before the success-path `setState` to prevent calling it on a disposed widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)