### PR TITLE
fix flash page WAL crash null device after async gap

### DIFF
--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -101,11 +101,13 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
   }
 
   Future<List<Wal>> _getMissingWals() async {
-    if (_device == null) return [];
+    // Capture snapshot — setDevice(null) can be called concurrently during awaits
+    final device = _device;
+    if (device == null) return [];
 
-    if (_device!.type != DeviceType.limitless) return [];
+    if (device.type != DeviceType.limitless) return [];
 
-    String deviceId = _device!.id;
+    String deviceId = device.id;
     List<Wal> wals = [];
 
     var storageStatus = await _getStorageStatus(deviceId);
@@ -125,7 +127,7 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
       int timerStart = DateTime.now().millisecondsSinceEpoch ~/ 1000 - estimatedSeconds;
 
       var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
-      var pd = await _device!.getDeviceInfo(connection);
+      var pd = await device.getDeviceInfo(connection);
       String deviceModel = pd.modelNumber.isNotEmpty ? pd.modelNumber : "Limitless";
 
       wals.add(
@@ -138,7 +140,7 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
           storageOffset: _oldestPage,
           storageTotalBytes: _newestPage,
           fileNum: _currentSession,
-          device: _device!.id,
+          device: device.id,
           deviceModel: deviceModel,
           totalFrames: pageCount * framesPerFlashPage,
           syncedFrameOffset: 0,

--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -578,7 +578,11 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
   void setDevice(BtDevice? device) async {
     _device = device;
     if (device != null && device.type == DeviceType.limitless) {
-      _wals = await _getMissingWals();
+      final wals = await _getMissingWals();
+      // Only assign if _device hasn't changed during the await (e.g. concurrent setDevice(null))
+      if (_device?.id == device.id) {
+        _wals = wals;
+      }
     } else {
       _wals = [];
     }


### PR DESCRIPTION
FlashPageWalSyncImpl._getMissingWals

FlutterError - Null check operator used on a null value
package:omi/services/wals/flash_page_wal_sync.dart:124

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/567d7aefe1b1be7cd6f64fc113b54376?time=7d&types=crash&sessionEventKey=53d57f9cb449467198587a0d089231e4_2222288699738111351

Logs:

```
Fatal Exception: FlutterError
0  ???                            0x0 FlashPageWalSyncImpl._getMissingWals + 128 (flash_page_wal_sync.dart:128)
1  ???                            0x0 FlashPageWalSyncImpl.setDevice + 586 (flash_page_wal_sync.dart:586)
```

Fix: `setDevice` is `async void` — a concurrent `setDevice(null)` call sets `_device = null` while `_getMissingWals` is suspended at an `await`, causing the `_device!` force-unwrap to crash. Fixed by capturing `_device` into a local `final device` snapshot at the top of `_getMissingWals` before any await, so subsequent `setDevice(null)` calls during async gaps cannot affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)