### PR TITLE
desktop: stop dev/test bundles from auto-launching on login

### DIFF
--- a/desktop/Desktop/Sources/LaunchAtLoginManager.swift
+++ b/desktop/Desktop/Sources/LaunchAtLoginManager.swift
@@ -44,6 +44,18 @@ class LaunchAtLoginManager: ObservableObject {
     /// - Returns: true if the operation succeeded
     @discardableResult
     func setEnabled(_ enabled: Bool) -> Bool {
+        // Only the production/beta bundle (com.omi.computer-macos) is allowed to manage login items.
+        // Dev (com.omi.desktop-dev) and named test bundles (com.omi.<slug>) must never register —
+        // otherwise every local build piles up in System Settings > Login Items and relaunches on
+        // every restart. If such a bundle was previously registered, unregister it now to self-clean.
+        guard AppBuild.isProductionBundle else {
+            if enabled {
+                try? SMAppService.mainApp.unregister()
+                log("LaunchAtLogin: Skipped + unregistered non-production bundle '\(AppBuild.bundleIdentifier)'")
+            }
+            updateStatus()
+            return false
+        }
         do {
             if enabled {
                 try SMAppService.mainApp.register()

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -1234,6 +1234,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   }
 
   private func updateOnboardingLifecyclePolicy(reason: String) {
+    // Only the production/beta bundle (com.omi.computer-macos) should relaunch on login.
+    // Dev and named test bundles must always opt out — otherwise every local build that was
+    // open at shutdown gets relaunched on the next restart, swarming the screen with dev apps.
+    guard AppBuild.isProductionBundle else {
+      guard !relaunchOnLoginSuppressedForOnboarding else { return }
+      NSApp.disableRelaunchOnLogin()
+      relaunchOnLoginSuppressedForOnboarding = true
+      log("AppDelegate: Disabled relaunch on login for non-production bundle (\(reason))")
+      return
+    }
+
     let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
 
     if hasCompletedOnboarding {


### PR DESCRIPTION
## Problem
Dev (`com.omi.desktop-dev`) and named `omi-*` test bundles were opting into macOS relaunch-on-login via `NSApp.enableRelaunchOnLogin()`. Any dev build left running at shutdown relaunched on the next restart, swarming the screen with dozens of dev-app icons.

(Verified on my machine: the login-items / BTM database only had legit entries — `omi.app`, `Omi Cheap Voice`. The swarm came from the relaunch-on-login path, not `SMAppService` login items.)

## Fix
Gate both login mechanisms on `AppBuild.isProductionBundle`:

- `LaunchAtLoginManager.setEnabled` — non-prod bundles refuse to register as a login item, and unregister themselves if previously registered.
- `OmiApp.updateOnboardingLifecyclePolicy` — non-prod bundles always `disableRelaunchOnLogin()` instead of enabling it.

`isProductionBundle` (`com.omi.computer-macos`) covers **both prod and beta** (they share the bundle id), so only the shipped app auto-launches. No behavior change for end users.

## Test
- `swift build -c debug` clean.
- Clean release build (`rm -rf .build && swift build -c release --triple arm64-apple-macosx`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)