### PR TITLE
Enforce Neo = no desktop; fix stale-subscription plan clobber

### DIFF
--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -47,7 +47,6 @@ class PlansSheet extends StatefulWidget {
 class _PlansSheetState extends State<PlansSheet> {
   String selectedPlan = 'yearly'; // 'yearly' or 'monthly'  (billing period)
   String? selectedTierId; // 'unlimited', 'operator', 'architect'
-  final Set<String> _expandedTierIds = {}; // tracks which tier cards show full features
   bool _isUpgrading = false;
   bool _showTrainingDataOptIn = false; // Control visibility of training data opt-in
   bool _isSwitchingToFree = false;
@@ -1580,17 +1579,7 @@ class _PlansSheetState extends State<PlansSheet> {
               isPopular: eyebrow == 'Most popular',
               featureSummary: planSubtitle,
               features: planFeatures,
-              isExpanded: _expandedTierIds.contains(tierId),
-              onToggleExpand: () {
-                HapticFeedback.lightImpact();
-                setState(() {
-                  if (_expandedTierIds.contains(tierId)) {
-                    _expandedTierIds.remove(tierId);
-                  } else {
-                    _expandedTierIds.add(tierId);
-                  }
-                });
-              },
+              desktopAccess: _tierGrantsDesktop(tierId),
               onTap: () {
                 HapticFeedback.lightImpact();
                 setState(() => selectedTierId = tierId);
@@ -1689,8 +1678,7 @@ class _PlansSheetState extends State<PlansSheet> {
     String? endsOnDate,
     String? featureSummary,
     List<String> features = const [],
-    bool isExpanded = false,
-    VoidCallback? onToggleExpand,
+    bool? desktopAccess,
   }) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
@@ -1813,56 +1801,28 @@ class _PlansSheetState extends State<PlansSheet> {
               ],
             ),
           ),
-          // Feature summary + expand/collapse — separate tap target
-          if (featureSummary != null && features.isNotEmpty) ...[
+          // Plan details — always visible (no expand/collapse toggle).
+          if (featureSummary != null || desktopAccess != null || features.isNotEmpty) ...[
             const SizedBox(height: 10),
-            GestureDetector(
-              onTap: onToggleExpand,
-              behavior: HitTestBehavior.opaque,
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      featureSummary,
-                      style: TextStyle(color: Colors.grey[400], fontSize: 12),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+            if (featureSummary != null) Text(featureSummary, style: TextStyle(color: Colors.grey[400], fontSize: 12)),
+            if (featureSummary != null && (desktopAccess != null || features.isNotEmpty)) const SizedBox(height: 8),
+            // Desktop access — explicit ✓/✗ so Neo (mobile/web only) is clearly
+            // distinguished from Operator/Architect.
+            if (desktopAccess != null) _buildDesktopAccessRow(desktopAccess),
+            ...features.map(
+              (f) => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(Icons.check, color: Colors.green[400], size: 14),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(f, style: TextStyle(color: Colors.grey[300], fontSize: 12, height: 1.3)),
                     ),
-                  ),
-                  Icon(
-                    isExpanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
-                    color: Colors.grey[500],
-                    size: 18,
-                  ),
-                ],
-              ),
-            ),
-            AnimatedCrossFade(
-              firstChild: const SizedBox.shrink(),
-              secondChild: Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Column(
-                  children: features
-                      .map(
-                        (f) => Padding(
-                          padding: const EdgeInsets.only(bottom: 4),
-                          child: Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Icon(Icons.check, color: Colors.green[400], size: 14),
-                              const SizedBox(width: 6),
-                              Expanded(
-                                child: Text(f, style: TextStyle(color: Colors.grey[300], fontSize: 12, height: 1.3)),
-                              ),
-                            ],
-                          ),
-                        ),
-                      )
-                      .toList(),
+                  ],
                 ),
               ),
-              crossFadeState: isExpanded ? CrossFadeState.showSecond : CrossFadeState.showFirst,
-              duration: const Duration(milliseconds: 200),
             ),
           ],
         ],
@@ -1961,8 +1921,7 @@ class _PlansSheetState extends State<PlansSheet> {
     bool isPopular = false,
     String? featureSummary,
     List<String> features = const [],
-    bool isExpanded = false,
-    VoidCallback? onToggleExpand,
+    bool? desktopAccess,
     required VoidCallback onTap,
   }) {
     final title = planData['title'] as String;
@@ -1998,8 +1957,50 @@ class _PlansSheetState extends State<PlansSheet> {
       endsOnDate: endsOnDate,
       featureSummary: featureSummary,
       features: features,
-      isExpanded: isExpanded,
-      onToggleExpand: onToggleExpand,
+      desktopAccess: desktopAccess,
+    );
+  }
+
+  /// Whether a plan tier includes the desktop (macOS) app. Neo (unlimited) is
+  /// mobile/web only; Operator and Architect include desktop. Keep in sync with
+  /// backend `DESKTOP_ENTITLED_PLAN_TYPES`. Returns null for unknown tiers.
+  bool? _tierGrantsDesktop(String tierId) {
+    switch (tierId) {
+      case 'operator':
+      case 'architect':
+        return true;
+      case 'unlimited':
+        return false;
+      default:
+        return null;
+    }
+  }
+
+  Widget _buildDesktopAccessRow(bool granted) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            granted ? Icons.check : Icons.close,
+            color: granted ? Colors.green[400] : Colors.red[400],
+            size: 14,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              granted ? 'Works on Desktop' : "Doesn't work on Desktop",
+              style: TextStyle(
+                color: granted ? Colors.grey[300] : Colors.red[300],
+                fontSize: 12,
+                height: 1.3,
+                fontWeight: granted ? FontWeight.w400 : FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -30,6 +30,7 @@ from utils.subscription import (
     should_show_new_plans,
     adapt_plans_for_legacy_client,
     clear_trial_paywall_cache,
+    find_active_paid_subscription_for_user,
 )
 from database.users import (
     get_stripe_connect_account_id,
@@ -742,6 +743,21 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
         if uid:
             new_subscription = _build_subscription_from_stripe_object(subscription_obj)
             if new_subscription:
+                # Guard against a stale/old subscription's cancellation clobbering an
+                # active plan. If this event downgrades the user to a non-paid plan
+                # (e.g. an old sub got canceled) but they still have a *different*
+                # active paid subscription — they canceled one sub and started
+                # another near-simultaneously, possibly on a new Stripe customer —
+                # don't overwrite their plan with basic. Adopt the active paid sub.
+                if not is_paid_plan(new_subscription.plan):
+                    event_sub_id = subscription_obj.get('id')
+                    active_paid = await run_blocking(stripe_executor, find_active_paid_subscription_for_user, uid)
+                    if active_paid and active_paid.stripe_subscription_id != event_sub_id:
+                        logger.info(
+                            f"Ignoring downgrade from {event['type']} (sub {event_sub_id}) for user {uid}: "
+                            f"a different active paid sub {active_paid.stripe_subscription_id} exists."
+                        )
+                        new_subscription = active_paid
                 try:
                     if new_subscription.status == SubscriptionStatus.active and is_paid_plan(new_subscription.plan):
                         await run_blocking(db_executor, conversations_db.unlock_all_conversations, uid)

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -20,12 +20,26 @@ logger = logging.getLogger(__name__)
 
 PAID_PLAN_TYPES = {PlanType.unlimited, PlanType.architect, PlanType.operator}
 
+# Plans that unlock the desktop (macOS) app. Neo (unlimited) is a mobile/web
+# plan — it does NOT include desktop access, so on desktop a Neo subscriber is
+# treated like basic for the trial paywall. Operator and Architect include the
+# desktop app. Keep this in sync with the per-plan feature copy + the mobile
+# plans sheet (Operator shows "Desktop app", Neo shows "No desktop access").
+DESKTOP_ENTITLED_PLAN_TYPES = {PlanType.operator, PlanType.architect}
+
+
+def plan_grants_desktop(plan: PlanType) -> bool:
+    """True iff this plan unlocks the desktop (macOS) app."""
+    return plan in DESKTOP_ENTITLED_PLAN_TYPES
+
+
 # Desktop-only 3-day trial paywall.
 #
-# Applies to ALL desktop users on the basic plan once their Firebase Auth
-# account is older than TRIAL_LENGTH_SECONDS and they don't have BYOK
-# active. Mobile (ios / android), Omi devices, paid plans, BYOK users,
-# and accounts inside the trial window are exempt.
+# Applies to desktop users without a desktop-entitled plan (basic OR Neo) once
+# their Firebase Auth account is older than TRIAL_LENGTH_SECONDS and they don't
+# have BYOK active. Mobile (ios / android), Omi devices, desktop-entitled plans
+# (Operator / Architect), BYOK users, and accounts inside the trial window are
+# exempt.
 TRIAL_LENGTH_SECONDS = 3 * 24 * 60 * 60  # 3 days
 
 # Platform identifiers that count as desktop for paywall purposes. The Swift
@@ -62,14 +76,14 @@ def _request_has_all_byok_keys() -> bool:
 def _is_trial_expired_uncached(uid: str) -> bool:
     """Is this user past their 3-day desktop trial?
 
-    Trial only applies to the basic plan; BYOK users are bypassed (they're
-    paying their own LLM/STT bill). Returns False on any lookup error so a
-    Firebase blip never paywalls a paying user.
+    The trial applies to anyone without a desktop-entitled plan (basic OR Neo);
+    BYOK users are bypassed (they're paying their own LLM/STT bill). Returns
+    False on any lookup error so a Firebase blip never paywalls a paying user.
     """
     try:
         subscription = users_db.get_user_valid_subscription(uid)
         plan = subscription.plan if subscription else PlanType.basic
-        if plan != PlanType.basic:
+        if plan_grants_desktop(plan):
             return False
         if users_db.is_byok_active(uid):
             return False
@@ -136,11 +150,13 @@ def get_trial_metadata(uid: str) -> TrialMetadata:
         subscription = users_db.get_user_valid_subscription(uid)
         plan = subscription.plan if subscription else PlanType.basic
 
-        # Paid-plan or BYOK users: trial is moot — they have full access.
+        # Desktop-entitled (Operator / Architect) or BYOK users: trial is moot —
+        # they have full desktop access. Neo (unlimited) is mobile/web only, so
+        # it falls through to the trial computation just like basic.
         # Same request-level escape hatch as `_is_trial_expired_cached`: a request
         # carrying all 4 BYOK provider headers is treated as BYOK-active even if
         # Firestore hasn't caught up yet.
-        if plan != PlanType.basic or users_db.is_byok_active(uid) or _request_has_all_byok_keys():
+        if plan_grants_desktop(plan) or users_db.is_byok_active(uid) or _request_has_all_byok_keys():
             return TrialMetadata(
                 trial_expired=False,
                 trial_duration_seconds=TRIAL_LENGTH_SECONDS,
@@ -640,7 +656,8 @@ def get_plan_features(plan: PlanType, simplified: bool = False) -> List[str]:
             f"{NEO_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
             "Unlimited listening and transcription",
             "Unlimited memories and insights",
-            "Available on Mac, mobile, and web",
+            # Neo is mobile/web only — no desktop app (see DESKTOP_ENTITLED_PLAN_TYPES).
+            "Available on mobile and web",
         ]
 
     # Basic plan
@@ -685,6 +702,55 @@ def _has_active_stripe_subscription(uid: str) -> bool:
         logger.error(f"Error checking Stripe for active subscriptions: {e}")
         return True  # fail-closed: block checkout if Stripe is unreachable
     return False
+
+
+def find_active_paid_subscription_for_user(uid: str) -> Optional[Subscription]:
+    """Resolve the user's current active *paid* subscription straight from Stripe.
+
+    Lists the customer's active subscriptions and returns the first one that
+    maps to a paid plan (matching this uid's metadata when present). Returns
+    None if there's no customer, no active paid sub, or Stripe is unreachable.
+
+    Used to (a) self-heal a Firestore record stuck on `basic` whose stored
+    subscription id points at an old/canceled sub, and (b) stop an old
+    subscription's cancellation webhook from clobbering an active plan when the
+    user canceled one sub and started another near-simultaneously (possibly on a
+    different Stripe customer).
+    """
+    customer_id = users_db.get_stripe_customer_id(uid)
+    if not customer_id:
+        return None
+    try:
+        subs = stripe.Subscription.list(customer=customer_id, status='active', limit=10)
+    except Exception as e:
+        logger.error(f"[find_active_paid_subscription_for_user] Stripe lookup failed for uid={uid}: {e}")
+        return None
+
+    for sub in subs.data:
+        d = sub.to_dict()
+        sub_uid = d.get('metadata', {}).get('uid')
+        if sub_uid and sub_uid != uid:
+            continue
+        items = d.get('items', {}).get('data') or []
+        if not items or not items[0].get('price'):
+            continue
+        price_id = items[0]['price'].get('id')
+        try:
+            plan = get_plan_type_from_price_id(price_id)
+        except ValueError:
+            continue
+        if not is_paid_plan(plan):
+            continue
+        return Subscription(
+            plan=plan,
+            status=SubscriptionStatus.active,
+            stripe_subscription_id=d.get('id'),
+            current_price_id=price_id,
+            current_period_end=d.get('current_period_end'),
+            cancel_at_period_end=d.get('cancel_at_period_end', False),
+            limits=get_plan_limits(plan),
+        )
+    return None
 
 
 def can_user_make_payment(uid: str, target_price_id: str = None) -> tuple[bool, str]:
@@ -877,25 +943,34 @@ def reconcile_basic_plan_with_stripe(uid: str, subscription: Subscription | None
             price_id = items[0]['price'].get('id')
 
         stripe_status = stripe_sub_dict.get('status')
-        if stripe_status not in ('active', 'trialing') or not price_id:
-            return subscription
+        if stripe_status in ('active', 'trialing') and price_id:
+            try:
+                plan_type = get_plan_type_from_price_id(price_id)
+            except ValueError:
+                plan_type = None
 
-        try:
-            plan_type = get_plan_type_from_price_id(price_id)
-        except ValueError:
-            plan_type = None
+            # If the stored Stripe sub is actually a paid plan, fix our local record.
+            if plan_type and is_paid_plan(plan_type):
+                subscription.plan = plan_type
+                subscription.status = SubscriptionStatus.active
+                subscription.current_period_end = stripe_sub_dict.get('current_period_end')
+                subscription.cancel_at_period_end = stripe_sub_dict.get('cancel_at_period_end', False)
+                subscription.current_price_id = price_id
+                subscription.limits = get_plan_limits(plan_type)
 
-        # If Stripe says this is actually a paid plan, fix our local record.
-        if plan_type and is_paid_plan(plan_type):
-            subscription.plan = plan_type
-            subscription.status = SubscriptionStatus.active
-            subscription.current_period_end = stripe_sub_dict.get('current_period_end')
-            subscription.cancel_at_period_end = stripe_sub_dict.get('cancel_at_period_end', False)
-            subscription.current_price_id = price_id
-            subscription.limits = get_plan_limits(plan_type)
+                # Persist the corrected subscription back to Firestore (without dynamic fields).
+                users_db.update_user_subscription(uid, subscription.dict())
+                return subscription
 
-            # Persist the corrected subscription back to Firestore (without dynamic fields).
-            users_db.update_user_subscription(uid, subscription.dict())
+        # Stored sub is canceled / unknown / not a paid plan. The user may have
+        # canceled it and started a *different* active subscription (possibly on
+        # a new Stripe customer) — the stored sub id alone can't see that. Adopt
+        # the customer's current active paid sub so an old sub's cancellation
+        # can't leave a paying user stranded on basic.
+        active = find_active_paid_subscription_for_user(uid)
+        if active:
+            users_db.update_user_subscription(uid, active.dict())
+            return active
 
     except Exception as e:
         # Don't break user flows on reconciliation issues; just log and continue with existing data.


### PR DESCRIPTION
## Why
Investigating user `hHJT1rMd62VLpK63rp0JW2vZX6q2` ("bought a paid plan but features didn't activate"):

- He bought **Neo** (`$19.99/mo`, `unlimited`) **on iOS**. Active Stripe sub `sub_1TZY9i…`, paid through 2026-06-21.
- On 2026-05-21 he cancelled an old sub and started a new one ~6s apart **on a different Stripe customer**. The old sub's `customer.subscription.deleted` webhook landed last and **overwrote his Firestore record to `basic`** → features locked.
- The existing self-heal `reconcile_basic_plan_with_stripe` couldn't recover it: it only re-checks the *stored* sub id, which pointed at the now-cancelled old sub (status `canceled` → bailed).

His prod record has already been corrected to `unlimited` manually.

## What
**Backend**
1. **Webhook guard** (`payment.py`) — a downgrade event is ignored when the user has a *different* active paid subscription (new `find_active_paid_subscription_for_user`).
2. **Reconcile fallback** (`subscription.py`) — when the stored sub is cancelled/unknown, adopt the customer's current active paid sub. Self-heals records like this one on next subscription fetch.
3. **Neo = no desktop** — `DESKTOP_ENTITLED_PLAN_TYPES = {operator, architect}` + `plan_grants_desktop()`. Neo is now treated like basic on the desktop trial paywall (mobile/web only). Removed the false "Available on Mac…" from Neo's feature copy.

**Mobile plans sheet** (`plans_sheet.dart`)
4. Per-plan desktop indicator, **always visible** (expand/collapse toggles removed): Operator/Architect show green ✓ **"Works on Desktop"**, Neo shows red ✗ **"Doesn't work on Desktop"**.

## Verified
- Backend: `py_compile` + `black` clean.
- iOS: built & ran on simulator (dev backend), drove the plans sheet — confirmed Neo ✗ / Operator+Architect ✓ render always-visible. Screenshots in the thread.

## ⚠️ Rollout note
Enforcing Neo = no desktop means **existing Neo subscribers lose desktop access** on deploy. Neo is hidden from the desktop purchase catalog, so this set is expected to be tiny, but worth a heads-up. Suggest deploying to **dev** first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)