### PR TITLE
Update CHANGELOG.json for v0.11.424 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,9 +1,14 @@
 {
-  "unreleased": [
-    "Redesigned the Apps page connectors as a compact list and added one-tap MCP connection for Claude, ChatGPT, Claude Code, and Codex",
-    "Added an Execute button on MCP connectors so Omi sets up Claude/ChatGPT/Claude Code/Codex for you as a task"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.424",
+      "date": "2026-05-26",
+      "changes": [
+        "Redesigned the Apps page connectors as a compact list and added one-tap MCP connection for Claude, ChatGPT, Claude Code, and Codex",
+        "Added an Execute button on MCP connectors so Omi sets up Claude/ChatGPT/Claude Code/Codex for you as a task"
+      ]
+    },
     {
       "version": "0.11.423",
       "date": "2026-05-25",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.424 and clears the unreleased array.