### PR TITLE
desktop: connector Execute fixes — autonomous Do-it-for-me, scrollable sheet, dedicated browser tab

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -3272,6 +3272,10 @@ extension Notification.Name {
   /// Posted by the local desktop automation bridge to expand the transcript drawer.
   static let desktopAutomationShowConversationTranscriptRequested = Notification.Name(
     "desktopAutomationShowConversationTranscriptRequested")
+  /// Posted by the local desktop automation bridge to open an export connector sheet
+  /// (userInfo: ["destination": rawValue]) — for headless e2e inspection.
+  static let desktopAutomationOpenExportRequested = Notification.Name(
+    "desktopAutomationOpenExportRequested")
   /// Posted when file indexing completes (userInfo: ["totalFiles": Int])
   static let fileIndexingComplete = Notification.Name("fileIndexingComplete")
   /// Posted from Settings to trigger the file indexing sheet

--- a/desktop/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/Desktop/Sources/DesktopAutomationBridge.swift
@@ -451,6 +451,36 @@ final class DesktopAutomationBridge {
           statusCode: 400
         )
       }
+    case ("POST", "/open-export"):
+      struct OpenResult: Codable { let destination: String }
+      do {
+        let payload = try JSONDecoder().decode(
+          DesktopAutomationExecuteExportRequest.self, from: request.body)
+        guard MemoryExportDestination(rawValue: payload.destination) != nil else {
+          return jsonResponse(
+            DesktopAutomationResponse<OpenResult>(
+              ok: false, result: nil, error: "unknown destination: \(payload.destination)"),
+            statusCode: 400)
+        }
+        await MainActor.run {
+          NSApp.activate()
+          if let window = NSApp.windows.first(where: { $0.title.lowercased().hasPrefix("omi") }) {
+            window.makeKeyAndOrderFront(nil)
+          }
+          NotificationCenter.default.post(
+            name: .desktopAutomationOpenExportRequested, object: nil,
+            userInfo: ["destination": payload.destination])
+        }
+        try await Task.sleep(for: .milliseconds(300))
+        return jsonResponse(
+          DesktopAutomationResponse(
+            ok: true, result: OpenResult(destination: payload.destination), error: nil))
+      } catch {
+        return jsonResponse(
+          DesktopAutomationResponse<OpenResult>(
+            ok: false, result: nil, error: error.localizedDescription),
+          statusCode: 500)
+      }
     case ("POST", "/gmail-read"):
       do {
         let emails = try await GmailReaderService.shared.readRecentEmails(maxResults: 50)

--- a/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -296,6 +296,12 @@ struct AppsPage: View {
             )
             .frame(width: 520, height: 620)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .desktopAutomationOpenExportRequested)) { note in
+            if let raw = note.userInfo?["destination"] as? String,
+                let dest = MemoryExportDestination(rawValue: raw) {
+                selectedExportDestination = dest
+            }
+        }
         .onAppear {
             // If apps are already loaded, notify sidebar to clear loading indicator
             if !appProvider.isLoading {

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -313,21 +313,26 @@ struct MemoryExportDestinationSheet: View {
         DismissButton(action: onDismiss)
       }
 
-      content
+      // Scrollable so the full connector flow (Execute + live-connection steps +
+      // memory pack) never clips inside the fixed-height sheet.
+      ScrollView {
+        VStack(alignment: .leading, spacing: 18) {
+          content
 
-      if let statusMessage = model.statusMessage {
-        Text(statusMessage)
-          .scaledFont(size: 12, weight: .medium)
-          .foregroundColor(OmiColors.success)
+          if let statusMessage = model.statusMessage {
+            Text(statusMessage)
+              .scaledFont(size: 12, weight: .medium)
+              .foregroundColor(OmiColors.success)
+          }
+
+          if let errorMessage = model.errorMessage {
+            Text(errorMessage)
+              .scaledFont(size: 12, weight: .medium)
+              .foregroundColor(OmiColors.warning)
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
-
-      if let errorMessage = model.errorMessage {
-        Text(errorMessage)
-          .scaledFont(size: 12, weight: .medium)
-          .foregroundColor(OmiColors.warning)
-      }
-
-      Spacer(minLength: 0)
     }
     .padding(24)
     .background(OmiColors.backgroundPrimary)
@@ -375,14 +380,14 @@ struct MemoryExportDestinationSheet: View {
   }
 
   private var executeButtonTitle: String {
-    destination.mcpExecuteKind == .autonomous ? "Execute" : "Open & copy key"
+    destination.mcpExecuteKind == .autonomous ? "Do it for me" : "Open & copy key"
   }
 
   private var executeBlockSubtitle: String {
     switch destination.mcpExecuteKind {
     case .autonomous:
       return
-        "Omi sets up \(destination.title) for you automatically — it runs as an Omi task you can watch in the floating bar."
+        "Omi sets up \(destination.title) for you — it runs as an Omi task you can watch in the floating bar. If it gets stuck, use the manual steps below."
     case .assisted:
       return
         "Omi opens \(destination.title) and copies your key, then you confirm the quick steps below."

--- a/desktop/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/Desktop/Sources/MemoryExportService.swift
@@ -91,8 +91,8 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
   enum MCPExecuteKind { case autonomous, assisted }
   var mcpExecuteKind: MCPExecuteKind {
     switch self {
-    case .claudeCode, .codex: return .autonomous
-    case .chatgpt, .claude, .notion, .obsidian, .gemini: return .assisted
+    case .chatgpt, .claude, .claudeCode, .codex: return .autonomous
+    case .notion, .obsidian, .gemini: return .assisted
     }
   }
 

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -477,6 +477,7 @@ If a screenshot is attached and the user asks a deictic question like "which one
 If the screenshot already clearly shows the relevant options, do not ignore it just because the query is short or ambiguous.
 Respond concisely in 1-2 sentences. No lists. No headers. NEVER ask follow-up questions — just answer.
 A screenshot may be attached — use it silently only if relevant. Never mention or acknowledge it.
+BROWSER TABS: when you use the browser (Playwright), on your FIRST browser action open ONE dedicated tab with the browser_tabs tool (action: "new"), then do ALL browser work in that single tab and reuse it for every step. NEVER navigate, reload, switch, or close the user's other tabs, and never hijack their active tab — work only in the tab you opened so you don't interfere with what the user is doing.
 ================================================================================
 """
 


### PR DESCRIPTION
Follow-up to the MCP-connectors feature, fixing issues found on beta v0.11.424.

## Changes
- **ChatGPT/Claude Execute is now autonomous** ("Do it for me") like Codex/Claude Code — spawns the agent to set up the connector, with the manual steps as fallback. (Previously assisted "open & copy key".)
- **Scrollable connector sheet** — the sheet had a fixed 620px height with no ScrollView, so the tall flow (Execute + live-connection steps + memory pack) clipped at the bottom. Now scrolls cleanly.
- **Agent uses a dedicated browser tab** — added tab discipline to the shared floating-bar system prompt so Playwright opens ONE dedicated tab and reuses it, never hijacking the user's active tab or touching their other tabs.
- **`/open-export` automation-bridge route** (non-prod bundles only) — opens a connector sheet headlessly for e2e inspection.

## Testing
- Clean release build passes (`rm -rf .build && swift build -c release`).
- Verified locally (named bundle): "Do it for me" button renders + routes to the autonomous agent; sheet scrolls (no clipping); active Chrome tab not hijacked during a browser Execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)