### PR TITLE
fix multipart upload crash ClientException Bad file descriptor

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -46,7 +46,8 @@ bool _isTransientNetworkError(Object e) {
         m.contains('Connection closed') ||
         m.contains('Connection reset') ||
         m.contains('Failed host lookup') ||
-        m.contains('Network is unreachable');
+        m.contains('Network is unreachable') ||
+        m.contains('Bad file descriptor');
   }
   return false;
 }
@@ -236,13 +237,19 @@ Future<http.StreamedResponse> _sendMultipartWithProgress(
   streamedRequest.headers.addAll(request.headers);
   streamedRequest.contentLength = totalBytes;
 
-  progressStream.listen(
+  final subscription = progressStream.listen(
     streamedRequest.sink.add,
-    onError: streamedRequest.sink.addError,
+    onError: (Object e, StackTrace st) {
+      streamedRequest.sink.addError(e, st);
+      streamedRequest.sink.close();
+    },
     onDone: streamedRequest.sink.close,
+    cancelOnError: true,
   );
 
-  return HttpPoolManager.instance.sendStreaming(streamedRequest);
+  final future = HttpPoolManager.instance.sendStreaming(streamedRequest);
+  future.whenComplete(subscription.cancel);
+  return future;
 }
 
 Future<http.MultipartRequest> _buildMultipartRequest({


### PR DESCRIPTION
## Crash

`(null).makeMultipartApiCall`

**Error:** `FlutterError - ClientException: Bad file descriptor, uri=https://api.omi.me/v1/sync-local-files`

**Crashlytics:** https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/780a8bb89b21adf52eabdac3034cd749?time=7d&types=crash&sessionEventKey=6453a786b0ce4ba0a4c6c96707e1aae3_2222621226552694960

**Logs:**
```
Fatal Exception: FlutterError
0  ???  0x0 Future.timeout.<fn> (dart:async)
1  ???  0x0 (null).makeMultipartApiCall + 271 (shared.dart:271)
2  ???  0x0 (null).syncLocalFilesV2 + 304 (conversations.dart:304)
3  ???  0x0 LocalWalSyncImpl.syncAll + 619 (local_wal_sync.dart:619)
4  ???  0x0 SyncProvider._performSync + 271 (sync_provider.dart:271)
5  ???  0x0 SyncProvider._autoUploadPendingPhoneFiles + 175 (sync_provider.dart:175)
```

## Fix

Two changes in `shared.dart`:

1. **Added `Bad file descriptor` to `_isTransientNetworkError`** — when a multipart upload times out, the HTTP layer closes the socket and subsequent reads on the in-flight file stream raise `EBADF` wrapped in a `ClientException`. This is an OS-level transient error, not a code bug, so it was being incorrectly reported to Crashlytics. Adding it to the transient list stops the false crash report; the error still rethrows and is caught gracefully by the WAL sync retry loop.

2. **Fixed `_sendMultipartWithProgress` stream subscription lifecycle** — the progress-stream subscription was fire-and-forget with no error handler that closed the sink. On timeout or error, the orphaned subscription would continue pumping data into a closed sink, causing unhandled zone errors. Now the subscription is stored, `cancelOnError: true` stops it on first error, the `onError` handler closes the sink immediately, and `future.whenComplete(subscription.cancel)` cleans it up when the send finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)