### PR TITLE
fix usage share crash null GlobalKey context before tab renders

### DIFF
--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -64,9 +64,11 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
     final provider = context.read<UsageProvider>();
     final localeName = l10n.localeName;
 
-    final RenderRepaintBoundary boundary =
-        _screenshotKeys[_tabController.index].currentContext!.findRenderObject() as RenderRepaintBoundary;
+    final captureContext = _screenshotKeys[_tabController.index].currentContext;
+    if (captureContext == null || !mounted) return;
+    final RenderRepaintBoundary boundary = captureContext.findRenderObject() as RenderRepaintBoundary;
     final ui.Image image = await boundary.toImage(pixelRatio: 3.0);
+    if (!mounted) return;
 
     // Load logo
     final ByteData logoData = await rootBundle.load('assets/images/herologo.png');


### PR DESCRIPTION
## Crash

`_UsagePageState._shareUsage`

**Error:** `FlutterError - Null check operator used on a null value`
`package:omi/pages/settings/usage_page.dart:172`

**Crashlytics:** https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/85cdd34aeecb1d6a0b50cdc14083ef78?time=7d&types=crash&sessionEventKey=16956422ab7248b6940d706ae0b6eb02_2222284095727765224

**Logs:**
```
Fatal Exception: FlutterError
0  ???  0x0 _UsagePageState._shareUsage + 68 (usage_page.dart:68)
1  ???  0x0 _InkResponseState.handleTap + 1204 (ink_well.dart:1204)
2  ???  0x0 GestureRecognizer.invokeCallback + 345 (recognizer.dart:345)
3  ???  0x0 TapGestureRecognizer.handleTapUp + 758 (tap.dart:758)
4  ???  0x0 BaseTapGestureRecognizer._checkUp + 383 (tap.dart:383)
5  ???  0x0 BaseTapGestureRecognizer.handlePrimaryPointer + 314 (tap.tap:314)
6  ???  0x0 PrimaryPointerGestureRecognizer.handleEvent + 721 (recognizer.dart:721)
7  ???  0x0 PointerRouter._dispatch + 97 (pointer_router.dart:97)
8  ???  0x0 PointerRouter._dispatchEventToRoutes.<fn> + 142 (pointer_router.dart:142)
9  ???  0x0 _LinkedHashMapMixin.forEach (dart:_compact_hash)
10 ???  0x0 PointerRouter._dispatchEventToRoutes + 140 (pointer_router.dart:140)
11 ???  0x0 PointerRouter.route + 130 (pointer_router.dart:130)
12 ???  0x0 GestureBinding.handleEvent + 528 (binding.dart:528)
13 ???  0x0 GestureBinding.dispatchEvent + 498 (binding.dart:498)
14 ???  0x0 RendererBinding.dispatchEvent + 473 (binding.dart:473)
15 ???  0x0 GestureBinding._handlePointerEventImmediately + 437 (binding.dart:437)
16 ???  0x0 GestureBinding.handlePointerEvent + 394 (binding.dart:394)
17 ???  0x0 GestureBinding._flushPointerEventQueue + 341 (binding.dart:341)
18 ???  0x0 GestureBinding._handlePointerDataPacket + 308 (binding.dart:308)
```

## Fix

`_screenshotKeys[index].currentContext!` crashed when the tab's widget hadn't rendered yet — the `GlobalKey` has no context until the tab is visited. Replaced the force-unwrap with a null guard that returns early, and added a `!mounted` check after the first `await` to bail if the widget is disposed during image capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)