### PR TITLE
feat: X (Twitter) connector — import tweets & bookmarks into Omi

### DIFF
--- a/backend/database/x_posts.py
+++ b/backend/database/x_posts.py
@@ -1,0 +1,109 @@
+"""Raw storage for X (Twitter) posts ingested by the X connector.
+
+Unlike the legacy persona flow (which fetched tweets, distilled a few memories,
+and threw the raw tweets away), the X connector keeps every post as a
+first-class source item under `users/{uid}/x_posts`. Documents are keyed by the
+tweet id so re-syncs are idempotent (a post is never stored twice). Memory
+extraction + vector indexing run on top of this raw store, mirroring how
+conversations are kept raw and then mined for memories.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldFilter
+
+from ._client import db
+
+logger = logging.getLogger(__name__)
+
+users_collection = 'users'
+x_posts_collection = 'x_posts'
+
+# Post "kinds" stored under the same collection, distinguished by the `kind` field.
+KIND_TWEET = 'tweet'
+KIND_BOOKMARK = 'bookmark'
+KIND_LIKE = 'like'
+
+
+def _posts_ref(uid: str):
+    return db.collection(users_collection).document(uid).collection(x_posts_collection)
+
+
+def save_x_posts(uid: str, posts: List[dict]) -> int:
+    """Idempotently store raw X posts. Returns the number of NEW posts written.
+
+    Each post dict must contain at least: id (tweet id, str), text, created_at,
+    kind. We dedupe on the document id (the tweet id), so calling this repeatedly
+    with overlapping pages only ever inserts each post once.
+    """
+    if not posts:
+        return 0
+
+    coll = _posts_ref(uid)
+    # Find which ids already exist so we can report an accurate delta and avoid
+    # clobbering `ingested_at` on re-sync.
+    ids = [str(p['id']) for p in posts if p.get('id') is not None]
+    existing: set = set()
+    # get_all is efficient for the modest page sizes the connector pulls (<=100).
+    for snap in db.get_all([coll.document(i) for i in ids]):
+        if snap.exists:
+            existing.add(snap.id)
+
+    now = datetime.now(timezone.utc)
+    batch = db.batch()
+    new_count = 0
+    for p in posts:
+        pid = str(p.get('id')) if p.get('id') is not None else None
+        if not pid:
+            continue
+        doc = dict(p)
+        doc['id'] = pid
+        doc['updated_at'] = now
+        if pid not in existing:
+            doc['ingested_at'] = now
+            new_count += 1
+        batch.set(coll.document(pid), doc, merge=True)
+    batch.commit()
+    logger.info(f'save_x_posts uid={uid} received={len(posts)} new={new_count}')
+    return new_count
+
+
+def get_x_posts(uid: str, limit: int = 100, kind: Optional[str] = None) -> List[dict]:
+    """Return stored posts, newest first. Optionally filter by kind."""
+    query = _posts_ref(uid)
+    if kind:
+        query = query.where(filter=FieldFilter('kind', '==', kind))
+    query = query.order_by('created_at', direction=firestore.Query.DESCENDING).limit(limit)
+    return [d.to_dict() for d in query.stream()]
+
+
+def count_x_posts(uid: str) -> int:
+    """Total number of stored X posts for the user."""
+    agg = _posts_ref(uid).count().get()
+    # Firestore aggregation returns a list of AggregationResult rows.
+    try:
+        return int(agg[0][0].value)
+    except Exception:
+        return len(list(_posts_ref(uid).stream()))
+
+
+def get_newest_tweet_id(uid: str) -> Optional[str]:
+    """Highest stored tweet id for incremental sync (X `since_id`).
+
+    Tweet ids are snowflake ids — lexicographically larger ids are newer once
+    zero-padded, but they're numeric strings of equal-ish length so we compare
+    as ints to be safe.
+    """
+    docs = list(_posts_ref(uid).where(filter=FieldFilter('kind', '==', KIND_TWEET)).stream())
+    best: Optional[int] = None
+    for d in docs:
+        try:
+            v = int(d.id)
+        except (TypeError, ValueError):
+            continue
+        if best is None or v > best:
+            best = v
+    return str(best) if best is not None else None

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ from routers import (
     action_items,
     task_integrations,
     integrations,
+    x_connector,
     other,
     developer,
     updates,
@@ -92,6 +93,7 @@ app.include_router(conversations.router)
 app.include_router(action_items.router)
 app.include_router(task_integrations.router)
 app.include_router(integrations.router)
+app.include_router(x_connector.router)
 app.include_router(memories.router)
 app.include_router(chat.router)
 app.include_router(speech_profile.router)

--- a/backend/routers/x_connector.py
+++ b/backend/routers/x_connector.py
@@ -1,0 +1,119 @@
+"""X (Twitter) connector routes.
+
+Connect flow (backend-mediated OAuth2 + PKCE, mirrors the existing integrations):
+  1. Desktop GET /v1/x/oauth-url?success_redirect_url=<app deep link>
+       -> { auth_url }. App opens auth_url in the system browser.
+  2. X redirects to GET /v2/integrations/x/callback?code&state
+       -> backend exchanges the code, stores tokens, kicks off the first sync,
+          and returns an HTML page that redirects to the app's deep link.
+  3. Desktop polls GET /v1/x/connection-status until connected.
+
+The desktop passes its own URL scheme as success_redirect_url, so dev
+(omi-computer-dev://) and prod (omi://) builds each get redirected back to
+themselves without the backend needing to know which is calling.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
+from utils import x_connector
+from utils.executors import start_background_task
+from utils.other import endpoints as auth
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+DEFAULT_DEEP_LINK = 'omi://x/callback'
+
+
+class OAuthUrlResponse(BaseModel):
+    success: bool
+    auth_url: Optional[str] = None
+    error: Optional[str] = None
+
+
+@router.get('/v1/x/oauth-url', response_model=OAuthUrlResponse, tags=['x'])
+def x_oauth_url(
+    success_redirect_url: Optional[str] = Query(None),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    if not x_connector.is_oauth_configured():
+        return OAuthUrlResponse(success=False, error='x_oauth_not_configured')
+    try:
+        url = x_connector.build_authorize_url(uid, success_redirect_url=success_redirect_url)
+        return OAuthUrlResponse(success=True, auth_url=url)
+    except Exception as e:
+        logger.error(f'x_oauth_url failed for uid={uid}: {e}')
+        return OAuthUrlResponse(success=False, error='internal_error')
+
+
+def _redirect_html(deep_link: str, ok: bool, message: str) -> HTMLResponse:
+    icon = '✓' if ok else '⚠️'
+    safe_link = deep_link.replace('"', '%22')
+    html = f"""<!doctype html><html><head><meta charset="utf-8">
+<title>X · Omi</title>
+<meta http-equiv="refresh" content="0;url={safe_link}">
+<style>body{{font-family:-apple-system,system-ui,sans-serif;background:#0b0b0f;color:#eaeaea;
+display:flex;height:100vh;margin:0;align-items:center;justify-content:center;text-align:center}}
+.c{{max-width:360px}}.i{{font-size:42px}}</style></head>
+<body><div class="c"><div class="i">{icon}</div><h2>{message}</h2>
+<p>Returning to Omi…</p></div>
+<script>setTimeout(function(){{window.location.href="{safe_link}";}},150);</script>
+</body></html>"""
+    return HTMLResponse(content=html)
+
+
+@router.get('/v2/integrations/x/callback', response_class=HTMLResponse, tags=['x'])
+async def x_oauth_callback(
+    request: Request,
+    code: Optional[str] = Query(None),
+    state: Optional[str] = Query(None),
+    error: Optional[str] = Query(None),
+):
+    if error or not code or not state:
+        return _redirect_html(f'{DEFAULT_DEEP_LINK}?error={error or "missing_code"}', False, 'Connection cancelled')
+
+    st = x_connector.consume_oauth_state(state)
+    if not st:
+        return _redirect_html(f'{DEFAULT_DEEP_LINK}?error=invalid_state', False, 'Link expired')
+
+    uid = st['uid']
+    deep_link = st.get('success_redirect_url') or DEFAULT_DEEP_LINK
+    try:
+        token_resp = await x_connector.exchange_code(code, st['verifier'])
+        # Resolve the account so we can store the handle for status + RapidAPI fallback.
+        handle = None
+        x_user_id = None
+        try:
+            me = await x_connector.fetch_me(token_resp['access_token'])
+            handle = me.get('username')
+            x_user_id = str(me.get('id')) if me.get('id') else None
+        except Exception as e:
+            logger.info(f'x callback: fetch_me failed (non-fatal): {e}')
+        x_connector._store_tokens(uid, token_resp, handle=handle, x_user_id=x_user_id)
+        # First ingest in the background so the browser redirect is instant.
+        start_background_task(x_connector.sync_x_for_user(uid), name=f'x_initial_sync_{uid}')
+        return _redirect_html(f'{deep_link}?status=success', True, 'X connected')
+    except Exception as e:
+        logger.error(f'x callback failed for uid={uid}: {e}')
+        return _redirect_html(f'{deep_link}?error=exchange_failed', False, 'Connection failed')
+
+
+@router.get('/v1/x/connection-status', tags=['x'])
+def x_connection_status(uid: str = Depends(auth.get_current_user_uid)):
+    return x_connector.connection_status(uid)
+
+
+@router.post('/v1/x/sync', tags=['x'])
+async def x_sync(uid: str = Depends(auth.get_current_user_uid)):
+    return await x_connector.sync_x_for_user(uid)
+
+
+@router.post('/v1/x/disconnect', tags=['x'])
+def x_disconnect(uid: str = Depends(auth.get_current_user_uid)):
+    x_connector.disconnect(uid)
+    return {'success': True}

--- a/backend/routers/x_connector.py
+++ b/backend/routers/x_connector.py
@@ -67,7 +67,7 @@ display:flex;height:100vh;margin:0;align-items:center;justify-content:center;tex
     return HTMLResponse(content=html)
 
 
-@router.get('/v2/integrations/x/callback', response_class=HTMLResponse, tags=['x'])
+@router.get('/v1/x/oauth/callback', response_class=HTMLResponse, tags=['x'])
 async def x_oauth_callback(
     request: Request,
     code: Optional[str] = Query(None),

--- a/backend/utils/other/jobs.py
+++ b/backend/utils/other/jobs.py
@@ -1,8 +1,13 @@
 from utils.other.notifications import should_run_job as should_run_daily_notification_job
 from utils.other.notifications import start_cron_job as start_cron_notification_job
+from utils.x_connector import should_run_x_sync_job, run_x_sync_job
 
 
 async def start_job():
     # Notification
     if should_run_daily_notification_job():
         await start_cron_notification_job()
+
+    # X (Twitter) connector — incremental background sync every few hours.
+    if should_run_x_sync_job():
+        await run_x_sync_job()

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -15,6 +15,7 @@ Required env (X developer app — confidential client):
   (optional) X_OAUTH_SCOPES — defaults to the read scopes + offline.access.
 """
 
+import asyncio
 import base64
 import hashlib
 import logging
@@ -30,6 +31,7 @@ from database import redis_db
 from database import users as users_db
 from database import x_posts as x_posts_db
 from database import memories as memories_db
+from database._client import db
 from database.vector_db import upsert_memory_vectors_batch
 from models.memories import MemoryDB
 from utils.llm.memories import extract_memories_from_text
@@ -53,6 +55,13 @@ API_BASE = 'https://api.x.com/2'
 
 OAUTH_STATE_TTL = 600  # seconds
 _STATE_PREFIX = 'x_oauth_state:'
+
+# Lightweight registry of connected users so the periodic sync job can enumerate
+# them without a collection-group query/index. Written on connect, removed on
+# disconnect.
+_REGISTRY_COLLECTION = 'x_connector_users'
+SYNC_JOB_INTERVAL_HOURS = 6  # background sync cadence (the cron fires hourly)
+_SYNC_JOB_USER_SPACING_SEC = 1.5  # gap between users to stay gentle on X limits
 
 # Cap how much we pull per sync to stay well within X rate limits.
 MAX_TWEET_PAGES = 4  # ~4 * 100 = up to 400 recent tweets per sync
@@ -170,6 +179,23 @@ def _store_tokens(uid: str, token_resp: Dict, handle: Optional[str] = None, x_us
     if x_user_id:
         data['x_user_id'] = x_user_id
     users_db.set_integration(uid, INTEGRATION_KEY, data)
+    _register_user(uid)
+
+
+def _register_user(uid: str) -> None:
+    try:
+        db.collection(_REGISTRY_COLLECTION).document(uid).set(
+            {'uid': uid, 'updated_at': datetime.now(timezone.utc)}, merge=True
+        )
+    except Exception as e:
+        logger.warning(f'x_connector: failed to register user {uid} for sync: {e}')
+
+
+def _unregister_user(uid: str) -> None:
+    try:
+        db.collection(_REGISTRY_COLLECTION).document(uid).delete()
+    except Exception as e:
+        logger.warning(f'x_connector: failed to unregister user {uid}: {e}')
 
 
 async def get_valid_access_token(uid: str) -> Optional[str]:
@@ -412,3 +438,39 @@ def connection_status(uid: str) -> Dict:
 
 def disconnect(uid: str) -> None:
     users_db.set_integration(uid, INTEGRATION_KEY, {'connected': False, 'access_token': '', 'refresh_token': ''})
+    _unregister_user(uid)
+
+
+# ----------------------------------------------------------------------------
+# Periodic background sync (driven by the hourly cron in modal/job.py)
+# ----------------------------------------------------------------------------
+
+
+def should_run_x_sync_job() -> bool:
+    """Gate the sync to every SYNC_JOB_INTERVAL_HOURS (the cron fires hourly)."""
+    return datetime.now(timezone.utc).hour % SYNC_JOB_INTERVAL_HOURS == 0
+
+
+async def run_x_sync_job() -> Dict:
+    """Incrementally sync every connected X user. Errors are isolated per user;
+    a slow/failed account never blocks the others."""
+    try:
+        uids = [d.id for d in db.collection(_REGISTRY_COLLECTION).stream()]
+    except Exception as e:
+        logger.error(f'x_connector: sync job could not list users: {e}')
+        return {'users': 0, 'synced': 0, 'new_posts': 0}
+
+    synced = 0
+    new_posts = 0
+    for uid in uids:
+        try:
+            result = await sync_x_for_user(uid)
+            if result.get('success'):
+                synced += 1
+                new_posts += int(result.get('new_posts', 0))
+        except Exception as e:
+            logger.warning(f'x_connector: sync job failed for uid={uid}: {e}')
+        await asyncio.sleep(_SYNC_JOB_USER_SPACING_SEC)
+
+    logger.info(f'x_connector: sync job done — users={len(uids)} synced={synced} new_posts={new_posts}')
+    return {'users': len(uids), 'synced': synced, 'new_posts': new_posts}

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -1,0 +1,399 @@
+"""X (Twitter) connector: OAuth2 + incremental ingest with a RapidAPI fallback.
+
+Design (see also database/x_posts.py):
+  * Connect via the official X API using OAuth2 Authorization Code + PKCE. Tokens
+    (incl. the offline.access refresh token) are stored server-side per user.
+  * Sync pulls the user's recent tweets + bookmarks via X API v2, stores every
+    post RAW under users/{uid}/x_posts, then runs Omi's memory extraction +
+    Pinecone indexing over the new posts so they integrate with chat/RAG/persona.
+  * If there is no usable token (not connected, refresh failed, or the API
+    rate-limits / errors), we fall back to the existing RapidAPI handle-based
+    timeline fetch for the user's PUBLIC tweets. Same downstream pipeline.
+
+Required env (X developer app — confidential client):
+  X_OAUTH_CLIENT_ID, X_OAUTH_CLIENT_SECRET, X_OAUTH_REDIRECT_URI
+  (optional) X_OAUTH_SCOPES — defaults to the read scopes + offline.access.
+"""
+
+import base64
+import hashlib
+import logging
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urlencode
+
+import httpx
+
+from database import redis_db
+from database import users as users_db
+from database import x_posts as x_posts_db
+from database import memories as memories_db
+from database.vector_db import upsert_memory_vectors_batch
+from models.memories import MemoryDB
+from utils.llm.memories import extract_memories_from_text
+from utils import social
+
+logger = logging.getLogger(__name__)
+
+INTEGRATION_KEY = 'x'  # users/{uid}/integrations/x
+
+X_CLIENT_ID = os.getenv('X_OAUTH_CLIENT_ID')
+X_CLIENT_SECRET = os.getenv('X_OAUTH_CLIENT_SECRET')
+X_REDIRECT_URI = os.getenv('X_OAUTH_REDIRECT_URI')
+X_SCOPES = os.getenv('X_OAUTH_SCOPES', 'tweet.read users.read bookmark.read like.read offline.access')
+
+AUTHORIZE_URL = 'https://twitter.com/i/oauth2/authorize'
+TOKEN_URL = 'https://api.twitter.com/2/oauth2/token'
+API_BASE = 'https://api.twitter.com/2'
+
+OAUTH_STATE_TTL = 600  # seconds
+_STATE_PREFIX = 'x_oauth_state:'
+
+# Cap how much we pull per sync to stay well within X rate limits.
+MAX_TWEET_PAGES = 4  # ~4 * 100 = up to 400 recent tweets per sync
+MAX_BOOKMARK_PAGES = 2
+MEMORY_BATCH_CHARS = 8000  # group post text into ~8k-char chunks for extraction
+
+
+def is_oauth_configured() -> bool:
+    return bool(X_CLIENT_ID and X_CLIENT_SECRET and X_REDIRECT_URI)
+
+
+# ----------------------------------------------------------------------------
+# OAuth2 + PKCE
+# ----------------------------------------------------------------------------
+
+
+def _gen_pkce() -> Tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(64)).rstrip(b'=').decode('ascii')
+    digest = hashlib.sha256(verifier.encode('ascii')).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b'=').decode('ascii')
+    return verifier, challenge
+
+
+def build_authorize_url(uid: str, success_redirect_url: Optional[str] = None) -> str:
+    """Create the X authorize URL and stash the PKCE verifier + uid in Redis,
+    keyed by the opaque `state` we hand to X."""
+    if not is_oauth_configured():
+        raise RuntimeError('X OAuth is not configured (missing X_OAUTH_CLIENT_ID/SECRET/REDIRECT_URI)')
+
+    verifier, challenge = _gen_pkce()
+    state = secrets.token_urlsafe(32)
+
+    payload = {'uid': uid, 'verifier': verifier}
+    if success_redirect_url:
+        payload['success_redirect_url'] = success_redirect_url
+    # store as a simple delimited string to avoid json import churn
+    redis_db.r.setex(
+        f'{_STATE_PREFIX}{state}',
+        OAUTH_STATE_TTL,
+        f"{uid}\n{verifier}\n{success_redirect_url or ''}",
+    )
+
+    params = {
+        'response_type': 'code',
+        'client_id': X_CLIENT_ID,
+        'redirect_uri': X_REDIRECT_URI,
+        'scope': X_SCOPES,
+        'state': state,
+        'code_challenge': challenge,
+        'code_challenge_method': 'S256',
+    }
+    return f'{AUTHORIZE_URL}?{urlencode(params)}'
+
+
+def consume_oauth_state(state: str) -> Optional[Dict[str, str]]:
+    raw = redis_db.r.get(f'{_STATE_PREFIX}{state}')
+    if not raw:
+        return None
+    redis_db.r.delete(f'{_STATE_PREFIX}{state}')
+    if isinstance(raw, bytes):
+        raw = raw.decode('utf-8')
+    parts = raw.split('\n')
+    if len(parts) < 2:
+        return None
+    return {
+        'uid': parts[0],
+        'verifier': parts[1],
+        'success_redirect_url': parts[2] if len(parts) > 2 else '',
+    }
+
+
+def _basic_auth_header() -> Dict[str, str]:
+    token = base64.b64encode(f'{X_CLIENT_ID}:{X_CLIENT_SECRET}'.encode()).decode()
+    return {'Authorization': f'Basic {token}'}
+
+
+async def exchange_code(code: str, verifier: str) -> Dict:
+    data = {
+        'grant_type': 'authorization_code',
+        'code': code,
+        'redirect_uri': X_REDIRECT_URI,
+        'code_verifier': verifier,
+        'client_id': X_CLIENT_ID,
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=3.0)) as client:
+        resp = await client.post(TOKEN_URL, data=data, headers=_basic_auth_header())
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _refresh(refresh_token: str) -> Dict:
+    data = {
+        'grant_type': 'refresh_token',
+        'refresh_token': refresh_token,
+        'client_id': X_CLIENT_ID,
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=3.0)) as client:
+        resp = await client.post(TOKEN_URL, data=data, headers=_basic_auth_header())
+        resp.raise_for_status()
+        return resp.json()
+
+
+def _store_tokens(uid: str, token_resp: Dict, handle: Optional[str] = None, x_user_id: Optional[str] = None):
+    expires_in = int(token_resp.get('expires_in', 7200))
+    data = {
+        'connected': True,
+        'access_token': token_resp['access_token'],
+        'expires_at': (datetime.now(timezone.utc) + timedelta(seconds=expires_in)).isoformat(),
+        'scope': token_resp.get('scope', X_SCOPES),
+    }
+    if token_resp.get('refresh_token'):
+        data['refresh_token'] = token_resp['refresh_token']
+    if handle:
+        data['handle'] = handle
+    if x_user_id:
+        data['x_user_id'] = x_user_id
+    users_db.set_integration(uid, INTEGRATION_KEY, data)
+
+
+async def get_valid_access_token(uid: str) -> Optional[str]:
+    """Return a non-expired access token, refreshing if needed. None if not
+    connected or refresh is impossible."""
+    integ = users_db.get_integration(uid, INTEGRATION_KEY)
+    if not integ or not integ.get('access_token'):
+        return None
+    try:
+        expires_at = datetime.fromisoformat(integ['expires_at'])
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+    except Exception:
+        expires_at = datetime.now(timezone.utc)
+
+    if datetime.now(timezone.utc) < expires_at - timedelta(seconds=60):
+        return integ['access_token']
+
+    refresh = integ.get('refresh_token')
+    if not refresh:
+        return integ['access_token']  # best effort; may be expired
+    try:
+        token_resp = await _refresh(refresh)
+        _store_tokens(uid, token_resp, handle=integ.get('handle'), x_user_id=integ.get('x_user_id'))
+        return token_resp['access_token']
+    except Exception as e:
+        logger.warning(f'x_connector: token refresh failed for uid={uid}: {e}')
+        return None
+
+
+# ----------------------------------------------------------------------------
+# X API v2 fetch
+# ----------------------------------------------------------------------------
+
+
+async def _api_get(token: str, path: str, params: Dict) -> Dict:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(20.0, connect=3.0)) as client:
+        resp = await client.get(f'{API_BASE}{path}', params=params, headers={'Authorization': f'Bearer {token}'})
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def fetch_me(token: str) -> Dict:
+    data = await _api_get(token, '/users/me', {})
+    return data.get('data', {})
+
+
+def _tweet_to_post(t: Dict, kind: str) -> Dict:
+    return {
+        'id': str(t.get('id')),
+        'text': t.get('text', ''),
+        'created_at': t.get('created_at', ''),
+        'kind': kind,
+        'lang': t.get('lang'),
+        'metrics': t.get('public_metrics'),
+    }
+
+
+async def _fetch_paged(token: str, path: str, kind: str, max_pages: int, extra: Dict) -> List[Dict]:
+    posts: List[Dict] = []
+    params = {
+        'max_results': 100,
+        'tweet.fields': 'created_at,lang,public_metrics',
+    }
+    params.update(extra)
+    pagination_token = None
+    for _ in range(max_pages):
+        if pagination_token:
+            params['pagination_token'] = pagination_token
+        data = await _api_get(token, path, params)
+        for t in data.get('data', []) or []:
+            posts.append(_tweet_to_post(t, kind))
+        pagination_token = data.get('meta', {}).get('next_token')
+        if not pagination_token:
+            break
+    return posts
+
+
+async def fetch_tweets(token: str, x_user_id: str, since_id: Optional[str]) -> List[Dict]:
+    extra = {'exclude': 'retweets'}
+    if since_id:
+        extra['since_id'] = since_id
+    return await _fetch_paged(token, f'/users/{x_user_id}/tweets', x_posts_db.KIND_TWEET, MAX_TWEET_PAGES, extra)
+
+
+async def fetch_bookmarks(token: str, x_user_id: str) -> List[Dict]:
+    try:
+        return await _fetch_paged(
+            token, f'/users/{x_user_id}/bookmarks', x_posts_db.KIND_BOOKMARK, MAX_BOOKMARK_PAGES, {}
+        )
+    except Exception as e:
+        logger.info(f'x_connector: bookmarks fetch skipped/failed: {e}')
+        return []
+
+
+# ----------------------------------------------------------------------------
+# Memory extraction + indexing over new raw posts
+# ----------------------------------------------------------------------------
+
+
+def _extract_and_index(uid: str, posts: List[Dict]) -> int:
+    """Run memory extraction over the given posts (grouped into chunks) and
+    vector-index the resulting memories. Returns memories created."""
+    if not posts:
+        return 0
+
+    chunks: List[str] = []
+    buf: List[str] = []
+    size = 0
+    for p in posts:
+        line = f"{p.get('text', '')} (Posted: {p.get('created_at', '')})"
+        if size + len(line) > MEMORY_BATCH_CHARS and buf:
+            chunks.append('\n'.join(buf))
+            buf, size = [], 0
+        buf.append(line)
+        size += len(line)
+    if buf:
+        chunks.append('\n'.join(buf))
+
+    total = 0
+    for chunk in chunks:
+        extracted = extract_memories_from_text(uid, chunk, 'twitter_tweets')
+        if not extracted:
+            continue
+        memory_dbs: List[MemoryDB] = []
+        for m in extracted:
+            mdb = MemoryDB.from_memory(m, uid, None, False)
+            mdb.manually_added = False
+            memory_dbs.append(mdb)
+        memories_db.save_memories(uid, [m.dict() for m in memory_dbs])
+        upsert_memory_vectors_batch(
+            uid,
+            [{'memory_id': m.id, 'content': m.content, 'category': m.category.value} for m in memory_dbs],
+        )
+        total += len(memory_dbs)
+    return total
+
+
+# ----------------------------------------------------------------------------
+# Sync orchestrator (official API first, RapidAPI fallback)
+# ----------------------------------------------------------------------------
+
+
+async def sync_x_for_user(uid: str) -> Dict:
+    """Pull new X posts, store raw, extract memories. Returns a summary dict."""
+    integ = users_db.get_integration(uid, INTEGRATION_KEY) or {}
+    since_id = x_posts_db.get_newest_tweet_id(uid)
+
+    new_posts: List[Dict] = []
+    source = None
+    token = await get_valid_access_token(uid)
+
+    if token:
+        try:
+            x_user_id = integ.get('x_user_id')
+            handle = integ.get('handle')
+            if not x_user_id:
+                me = await fetch_me(token)
+                x_user_id = str(me.get('id')) if me.get('id') else None
+                handle = me.get('username') or handle
+                if x_user_id:
+                    users_db.set_integration(uid, INTEGRATION_KEY, {'x_user_id': x_user_id, 'handle': handle})
+            if x_user_id:
+                tweets = await fetch_tweets(token, x_user_id, since_id)
+                bookmarks = await fetch_bookmarks(token, x_user_id)
+                new_posts = tweets + bookmarks
+                source = 'oauth'
+        except Exception as e:
+            logger.warning(f'x_connector: official API sync failed for uid={uid}, falling back: {e}')
+
+    # Fallback: RapidAPI public timeline by handle.
+    if source is None:
+        handle = integ.get('handle')
+        if not handle:
+            return {'success': False, 'error': 'not_connected', 'new_posts': 0, 'memories_created': 0}
+        try:
+            timeline = await social.get_twitter_timeline(handle)
+            new_posts = [
+                {
+                    'id': str(t.id),
+                    'text': t.text,
+                    'created_at': t.created_at,
+                    'kind': x_posts_db.KIND_TWEET,
+                }
+                for t in timeline.timeline
+            ]
+            source = 'rapidapi'
+        except Exception as e:
+            logger.error(f'x_connector: RapidAPI fallback failed for uid={uid}: {e}')
+            return {'success': False, 'error': 'fetch_failed', 'new_posts': 0, 'memories_created': 0}
+
+    written = x_posts_db.save_x_posts(uid, new_posts)
+    # Only mine memories from posts we hadn't seen before (the raw store dedupes,
+    # but extraction is the expensive part — restrict it to genuinely new text).
+    fresh = new_posts if written == len(new_posts) else new_posts[:written]
+    memories_created = _extract_and_index(uid, fresh)
+
+    users_db.set_integration(
+        uid,
+        INTEGRATION_KEY,
+        {
+            'last_synced_at': datetime.now(timezone.utc).isoformat(),
+            'last_sync_source': source,
+            'post_count': x_posts_db.count_x_posts(uid),
+        },
+    )
+    return {
+        'success': True,
+        'source': source,
+        'new_posts': written,
+        'memories_created': memories_created,
+    }
+
+
+def connection_status(uid: str) -> Dict:
+    integ = users_db.get_integration(uid, INTEGRATION_KEY)
+    if not integ or not integ.get('connected'):
+        return {'success': True, 'connected': False}
+    return {
+        'success': True,
+        'connected': True,
+        'handle': integ.get('handle'),
+        'post_count': integ.get('post_count', 0),
+        'last_synced_at': integ.get('last_synced_at'),
+        'last_sync_source': integ.get('last_sync_source'),
+    }
+
+
+def disconnect(uid: str) -> None:
+    users_db.set_integration(uid, INTEGRATION_KEY, {'connected': False, 'access_token': '', 'refresh_token': ''})

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -298,6 +298,9 @@ def _extract_and_index(uid: str, posts: List[Dict]) -> int:
         for m in extracted:
             mdb = MemoryDB.from_memory(m, uid, None, False)
             mdb.manually_added = False
+            # Tag with the connector key so X-derived memories are identifiable
+            # (and cleanly removable on disconnect / re-import).
+            mdb.app_id = INTEGRATION_KEY
             memory_dbs.append(mdb)
         memories_db.save_memories(uid, [m.dict() for m in memory_dbs])
         upsert_memory_vectors_batch(
@@ -316,6 +319,9 @@ def _extract_and_index(uid: str, posts: List[Dict]) -> int:
 async def sync_x_for_user(uid: str) -> Dict:
     """Pull new X posts, store raw, extract memories. Returns a summary dict."""
     integ = users_db.get_integration(uid, INTEGRATION_KEY) or {}
+    # Mark syncing so the desktop can show live progress while this runs in the
+    # background (the OAuth callback kicks this off as a background task).
+    users_db.set_integration(uid, INTEGRATION_KEY, {'syncing': True})
     since_id = x_posts_db.get_newest_tweet_id(uid)
 
     new_posts: List[Dict] = []
@@ -344,6 +350,7 @@ async def sync_x_for_user(uid: str) -> Dict:
     if source is None:
         handle = integ.get('handle')
         if not handle:
+            users_db.set_integration(uid, INTEGRATION_KEY, {'syncing': False})
             return {'success': False, 'error': 'not_connected', 'new_posts': 0, 'memories_created': 0}
         try:
             timeline = await social.get_twitter_timeline(handle)
@@ -359,6 +366,7 @@ async def sync_x_for_user(uid: str) -> Dict:
             source = 'rapidapi'
         except Exception as e:
             logger.error(f'x_connector: RapidAPI fallback failed for uid={uid}: {e}')
+            users_db.set_integration(uid, INTEGRATION_KEY, {'syncing': False})
             return {'success': False, 'error': 'fetch_failed', 'new_posts': 0, 'memories_created': 0}
 
     written = x_posts_db.save_x_posts(uid, new_posts)
@@ -374,6 +382,8 @@ async def sync_x_for_user(uid: str) -> Dict:
             'last_synced_at': datetime.now(timezone.utc).isoformat(),
             'last_sync_source': source,
             'post_count': x_posts_db.count_x_posts(uid),
+            'memory_count': int(integ.get('memory_count', 0)) + memories_created,
+            'syncing': False,
         },
     )
     return {
@@ -393,6 +403,8 @@ def connection_status(uid: str) -> Dict:
         'connected': True,
         'handle': integ.get('handle'),
         'post_count': integ.get('post_count', 0),
+        'memory_count': integ.get('memory_count', 0),
+        'syncing': bool(integ.get('syncing', False)),
         'last_synced_at': integ.get('last_synced_at'),
         'last_sync_source': integ.get('last_sync_source'),
     }

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -44,9 +44,12 @@ X_CLIENT_SECRET = os.getenv('X_OAUTH_CLIENT_SECRET')
 X_REDIRECT_URI = os.getenv('X_OAUTH_REDIRECT_URI')
 X_SCOPES = os.getenv('X_OAUTH_SCOPES', 'tweet.read users.read bookmark.read like.read offline.access')
 
-AUTHORIZE_URL = 'https://twitter.com/i/oauth2/authorize'
-TOKEN_URL = 'https://api.twitter.com/2/oauth2/token'
-API_BASE = 'https://api.twitter.com/2'
+# Use x.com (not twitter.com): after X's domain migration the user's auth
+# session cookies live on x.com, so the twitter.com authorize page shows a
+# "you have to be logged in to X" loop even for logged-in users.
+AUTHORIZE_URL = 'https://x.com/i/oauth2/authorize'
+TOKEN_URL = 'https://api.x.com/2/oauth2/token'
+API_BASE = 'https://api.x.com/2'
 
 OAUTH_STATE_TTL = 600  # seconds
 _STATE_PREFIX = 'x_oauth_state:'

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added an X (Twitter) connector to import your tweets and bookmarks into Omi"
+  ],
   "releases": [
     {
       "version": "0.11.426",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -4994,6 +4994,8 @@ struct XConnectionStatus: Decodable {
   let connected: Bool
   let handle: String?
   let postCount: Int?
+  let memoryCount: Int?
+  let syncing: Bool?
   let lastSyncedAt: String?
   let lastSyncSource: String?
   enum CodingKeys: String, CodingKey {
@@ -5001,6 +5003,8 @@ struct XConnectionStatus: Decodable {
     case connected
     case handle
     case postCount = "post_count"
+    case memoryCount = "memory_count"
+    case syncing
     case lastSyncedAt = "last_synced_at"
     case lastSyncSource = "last_sync_source"
   }

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -4954,4 +4954,73 @@ extension APIClient {
     let body = UpdateActionItemRequest(completed: completed, description: description, dueAt: dueAt)
     return try await patch("v1/tools/action-items/\(id)", body: body, customBaseURL: nil)
   }
+
+  // MARK: - X (Twitter) Connector
+
+  /// Ask the Python backend for the X OAuth authorize URL. The desktop passes
+  /// its own deep link so the backend can redirect back to this exact build.
+  func xOAuthURL(successRedirectURL: String) async throws -> XOAuthURLResponse {
+    let encoded = successRedirectURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    return try await get("v1/x/oauth-url?success_redirect_url=\(encoded)")
+  }
+
+  func xConnectionStatus() async throws -> XConnectionStatus {
+    try await get("v1/x/connection-status")
+  }
+
+  @discardableResult
+  func xSync() async throws -> XSyncResult {
+    try await post("v1/x/sync")
+  }
+
+  func xDisconnect() async throws {
+    let _: XSimpleOK = try await post("v1/x/disconnect")
+  }
+}
+
+struct XOAuthURLResponse: Decodable {
+  let success: Bool
+  let authUrl: String?
+  let error: String?
+  enum CodingKeys: String, CodingKey {
+    case success
+    case authUrl = "auth_url"
+    case error
+  }
+}
+
+struct XConnectionStatus: Decodable {
+  let success: Bool
+  let connected: Bool
+  let handle: String?
+  let postCount: Int?
+  let lastSyncedAt: String?
+  let lastSyncSource: String?
+  enum CodingKeys: String, CodingKey {
+    case success
+    case connected
+    case handle
+    case postCount = "post_count"
+    case lastSyncedAt = "last_synced_at"
+    case lastSyncSource = "last_sync_source"
+  }
+}
+
+struct XSyncResult: Decodable {
+  let success: Bool
+  let source: String?
+  let newPosts: Int?
+  let memoriesCreated: Int?
+  let error: String?
+  enum CodingKeys: String, CodingKey {
+    case success
+    case source
+    case newPosts = "new_posts"
+    case memoriesCreated = "memories_created"
+    case error
+  }
+}
+
+struct XSimpleOK: Decodable {
+  let success: Bool
 }

--- a/desktop/Desktop/Sources/ConnectorBrandIcon.swift
+++ b/desktop/Desktop/Sources/ConnectorBrandIcon.swift
@@ -13,6 +13,7 @@ enum ConnectorBrand: String, Sendable {
   case gemini
   case claudeCode
   case codex
+  case x
 
   fileprivate var appPath: String? {
     switch self {
@@ -30,7 +31,7 @@ enum ConnectorBrand: String, Sendable {
     case .codex:
       // Codex is OpenAI's CLI — reuse the ChatGPT app icon as the brand mark.
       return "/Applications/ChatGPT.app"
-    case .calendar, .gmail, .localFiles, .gemini:
+    case .calendar, .gmail, .localFiles, .gemini, .x:
       return nil
     }
   }
@@ -81,6 +82,9 @@ enum ConnectorBrand: String, Sendable {
       return "terminal.fill"
     case .codex:
       return "chevron.left.forwardslash.chevron.right"
+    case .x:
+      // SF Symbols has no X/Twitter mark — rendered as the 𝕏 glyph in the view.
+      return "at"
     }
   }
 }
@@ -175,7 +179,12 @@ struct ConnectorBrandIcon: View {
             .stroke(Color.white.opacity(0.06), lineWidth: 1)
         )
 
-      if let image = ConnectorBrandImageLoader.image(for: brand) {
+      if brand == .x {
+        // X's wordmark glyph — no SF Symbol or app icon exists for it.
+        Text("𝕏")
+          .font(.system(size: size * 0.5, weight: .bold))
+          .foregroundColor(OmiColors.textPrimary)
+      } else if let image = ConnectorBrandImageLoader.image(for: brand) {
         Image(nsImage: image)
           .resizable()
           .interpolation(.high)

--- a/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -870,6 +870,8 @@ final class ImportConnectorStatusStore: ObservableObject {
             return count == 1 ? "file indexed" : "files indexed"
         case "apple-notes":
             return count == 1 ? "note" : "notes"
+        case "x":
+            return count == 1 ? "post" : "posts"
         default:
             return count == 1 ? "item" : "items"
         }

--- a/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -1160,26 +1160,49 @@ private final class ImportConnectorSheetModel: ObservableObject {
                 detail: "Approve access in your browser. This window updates automatically."
             )
 
-            // Poll connection-status for up to ~2 minutes.
+            // Phase 1: wait until the account is linked (callback completed).
+            var linked: XConnectionStatus?
             for _ in 0..<60 {
                 try? await Task.sleep(for: .seconds(2))
                 if let status = try? await APIClient.shared.xConnectionStatus(), status.connected {
-                    updateProgress(
-                        title: "Importing your X data",
-                        detail: "Reading recent tweets and bookmarks and turning them into memories."
-                    )
-                    // Ensure at least one sync has run and grab counts.
-                    let sync = try? await APIClient.shared.xSync()
-                    let postCount = status.postCount ?? sync?.newPosts
-                    let memoryCount = sync?.memoriesCreated
-                    statusMessage = "Connected to X as @\(status.handle ?? "you")."
-                    return SyncResult(
-                        sourceCount: postCount, memoryCount: memoryCount, newItems: sync?.newPosts
-                    )
+                    linked = status
+                    break
                 }
             }
-            errorMessage = "Didn't hear back from X. If you approved access, try Sync again."
-            return nil
+            guard let linked else {
+                errorMessage = "Didn't hear back from X. If you approved access, try again."
+                return nil
+            }
+
+            let handle = linked.handle ?? "you"
+
+            // Phase 2: the OAuth callback kicks off the first import in the
+            // background. Poll while it runs, surfacing live counts, until the
+            // backend marks syncing complete (or counts stop growing).
+            var posts = linked.postCount ?? 0
+            var memories = linked.memoryCount ?? 0
+            for _ in 0..<90 {
+                let status = try? await APIClient.shared.xConnectionStatus()
+                posts = status?.postCount ?? posts
+                memories = status?.memoryCount ?? memories
+                updateProgress(
+                    title: "Importing your X data",
+                    detail: "Saved \(posts.formatted()) posts · \(memories.formatted()) memories so far…"
+                )
+                // Done once the backend clears the syncing flag and we have data.
+                if status?.syncing == false && posts > 0 { break }
+                try? await Task.sleep(for: .seconds(2))
+            }
+
+            if posts > 0 {
+                let memClause = memories > 0
+                    ? " — \(memories.formatted()) memories added. View them in Memories."
+                    : ". Extracted memories appear in Memories."
+                statusMessage = "Imported \(posts.formatted()) posts from @\(handle)\(memClause)"
+            } else {
+                statusMessage = "Connected to X as @\(handle). Import is still running; check back shortly."
+            }
+            return SyncResult(sourceCount: posts, memoryCount: memories > 0 ? memories : nil, newItems: posts)
         } catch {
             errorMessage = error.localizedDescription
             return nil

--- a/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -584,6 +584,17 @@ struct ImportConnector: Identifiable {
             isConnected: false
         ),
         ImportConnector(
+            id: "x",
+            title: "X (Twitter)",
+            subtitle: "Your posts & bookmarks",
+            description: "Connect your X account so Omi learns from your tweets and bookmarks.",
+            brand: .x,
+            statusText: "Not connected",
+            metricText: nil,
+            actionTitle: "Connect",
+            isConnected: false
+        ),
+        ImportConnector(
             id: "chatgpt",
             title: "ChatGPT",
             subtitle: "Memory import",
@@ -1121,6 +1132,71 @@ private final class ImportConnectorSheetModel: ObservableObject {
         }
     }
 
+    /// Connect X via backend-mediated OAuth: open the authorize URL in the
+    /// browser, then poll the backend until the account is linked. The backend
+    /// kicks off the first ingest, so once connected we surface the synced count.
+    func connectX() async -> SyncResult? {
+        beginRun(
+            title: "Connecting to X",
+            detail: "Opening x.com to authorize access to your posts and bookmarks."
+        )
+        defer { finishRun() }
+
+        // Deep link back to THIS build (dev vs prod URL schemes differ).
+        let scheme = Self.appURLScheme()
+        let redirect = "\(scheme)://x/callback"
+
+        do {
+            let resp = try await APIClient.shared.xOAuthURL(successRedirectURL: redirect)
+            guard resp.success, let authUrl = resp.authUrl, let url = URL(string: authUrl) else {
+                errorMessage = resp.error == "x_oauth_not_configured"
+                    ? "X connector isn't configured on the server yet."
+                    : "Couldn't start the X connection."
+                return nil
+            }
+            NSWorkspace.shared.open(url)
+            updateProgress(
+                title: "Waiting for X authorization",
+                detail: "Approve access in your browser. This window updates automatically."
+            )
+
+            // Poll connection-status for up to ~2 minutes.
+            for _ in 0..<60 {
+                try? await Task.sleep(for: .seconds(2))
+                if let status = try? await APIClient.shared.xConnectionStatus(), status.connected {
+                    updateProgress(
+                        title: "Importing your X data",
+                        detail: "Reading recent tweets and bookmarks and turning them into memories."
+                    )
+                    // Ensure at least one sync has run and grab counts.
+                    let sync = try? await APIClient.shared.xSync()
+                    let postCount = status.postCount ?? sync?.newPosts
+                    let memoryCount = sync?.memoriesCreated
+                    statusMessage = "Connected to X as @\(status.handle ?? "you")."
+                    return SyncResult(
+                        sourceCount: postCount, memoryCount: memoryCount, newItems: sync?.newPosts
+                    )
+                }
+            }
+            errorMessage = "Didn't hear back from X. If you approved access, try Sync again."
+            return nil
+        } catch {
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
+
+    static func appURLScheme() -> String {
+        if let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
+            let first = urlTypes.first,
+            let schemes = first["CFBundleURLSchemes"] as? [String],
+            let scheme = schemes.first
+        {
+            return scheme
+        }
+        return "omi-computer"
+    }
+
     func importCalendar() async -> SyncResult? {
         beginRun(
             title: "Connecting to Calendar",
@@ -1375,6 +1451,16 @@ struct ImportConnectorSheet: View {
                                 lastDeltaCount: result.newItems
                             )
                         }
+                    case "x":
+                        if let result = await model.connectX() {
+                            statusStore.markSynced(
+                                connectorID: connector.id,
+                                sourceCount: result.sourceCount,
+                                memoryCount: result.memoryCount,
+                                lastDeltaCount: result.newItems,
+                                availabilityText: "Posts & bookmarks"
+                            )
+                        }
                     case "apple-notes":
                         if let result = await model.importAppleNotes() {
                             statusStore.markSynced(
@@ -1476,6 +1562,8 @@ struct ImportConnectorSheet: View {
             return model.isRunning ? "Importing…" : "Connect Gmail"
         case "apple-notes":
             return model.isRunning ? "Importing…" : "Connect Apple Notes"
+        case "x":
+            return model.isRunning ? "Connecting…" : "Connect X"
         case "local-files":
             return model.isRunning ? "Reindexing…" : "Reindex Local Files"
         default:


### PR DESCRIPTION
## What

Adds an **X (Twitter) connector** to Omi desktop: connect your X account and Omi imports your tweets + bookmarks, keeps the raw posts, extracts memories from them, and keeps them fresh with a background sync.

Modeled on Sentience's connector UX, but built on Omi's own conversation-grade pipeline (**store raw → extract memories → vector-index**) with a RapidAPI fallback.

## How it works
- **Connect**: backend-mediated OAuth2 + PKCE on `x.com` (`/v1/x/oauth-url` → browser → `/v1/x/oauth/callback`). Tokens stored server-side with `offline.access` refresh.
- **Ingest**: fetches tweets + bookmarks via X API v2, stores every post raw in `users/{uid}/x_posts` (idempotent on tweet id — the raw source of truth we previously discarded), then runs memory extraction + Pinecone indexing. Falls back to the existing RapidAPI handle-based timeline for public tweets if the token path fails.
- **Auto-sync**: connected users are synced **every 6h** via the existing hourly cron (`modal/job.py → jobs.py`), incremental (`since_id`), rate-limit-spaced, per-user error isolation.
- **Desktop UX**: "X (Twitter)" connector card (𝕏), live import progress ("Saved N posts · M memories so far…"), and a result line ("Imported N posts from @handle — M memories. View them in Memories.").

## Verified live (real account @kodjima33)
- OAuth completes end-to-end; **511 posts** stored raw, **memories extracted + vector-indexed**, zero errors.
- Clean release build (arm64) green.
- Two bugs found + fixed during testing: `twitter.com`→`x.com` authorize domain (login-loop), and callback path collision with the generic `/v2/integrations/{app_key}/callback` route.

## ⚠️ Prod enablement required before it works for users
The desktop ships gracefully (shows "not configured" until the backend is ready). To go live:
1. Deploy backend to prod (`gh workflow run gcp_backend.yml -f environment=prod -f branch=main`).
2. Set `X_OAUTH_CLIENT_ID` / `X_OAUTH_CLIENT_SECRET` / `X_OAUTH_REDIRECT_URI` (= `https://api.omi.me/v1/x/oauth/callback`) in the prod backend secrets.
3. Register that prod callback URL in the X developer app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)