### PR TITLE
Update CHANGELOG.json for v0.11.427 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Added an X (Twitter) connector to import your tweets and bookmarks into Omi"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.427",
+      "date": "2026-05-27",
+      "changes": [
+        "Added an X (Twitter) connector to import your tweets and bookmarks into Omi"
+      ]
+    },
     {
       "version": "0.11.426",
       "date": "2026-05-26",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.427 and clears the unreleased array.