### PR TITLE
desktop: clarify Neo desktop status on Plan & Usage (consumes #7513)

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Plan & Usage: Neo subscribers now see a clear notice about when their desktop access ends, and post-policy Neo subscribers get plan-specific copy instead of \"Trial Ended\""
+  ],
   "releases": [
     {
       "version": "0.11.427",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -3768,6 +3768,10 @@ struct UserSubscriptionResponse: Codable {
   let memoriesCreatedLimit: Int
   let availablePlans: [SubscriptionPlanOption]
   let showSubscriptionUI: Bool
+  // Set for Neo subscribers whose current billing period started before the
+  // policy change in #7496 — they retain desktop access until this unix-seconds
+  // timestamp (their `current_period_end`). Null for everyone else.
+  let desktopGrandfatherUntil: Int?
 
   enum CodingKeys: String, CodingKey {
     case subscription
@@ -3781,6 +3785,7 @@ struct UserSubscriptionResponse: Codable {
     case memoriesCreatedLimit = "memories_created_limit"
     case availablePlans = "available_plans"
     case showSubscriptionUI = "show_subscription_ui"
+    case desktopGrandfatherUntil = "desktop_grandfather_until"
   }
 
   // Defensive decode: only `subscription` is required. The usage counters and
@@ -3801,6 +3806,7 @@ struct UserSubscriptionResponse: Codable {
     memoriesCreatedLimit = try c.decodeIfPresent(Int.self, forKey: .memoriesCreatedLimit) ?? 0
     availablePlans = try c.decodeIfPresent([SubscriptionPlanOption].self, forKey: .availablePlans) ?? []
     showSubscriptionUI = try c.decodeIfPresent(Bool.self, forKey: .showSubscriptionUI) ?? true
+    desktopGrandfatherUntil = try c.decodeIfPresent(Int.self, forKey: .desktopGrandfatherUntil)
   }
 }
 

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -1782,6 +1782,13 @@ struct SettingsContentView: View {
         }
       }
     } else if let trial = appState.trialMetadata, trial.trialExpired {
+      // Neo subscribers who aren't grandfathered land on this card too because
+      // Neo doesn't grant desktop access (per #7496). The generic "Trial Ended"
+      // copy is confusing for them — they're on a paid plan, just not one that
+      // includes Mac. Detect that case and switch to plan-specific copy.
+      let isNeoWithoutDesktop =
+        userSubscription?.subscription.plan == .unlimited
+        && userSubscription?.desktopGrandfatherUntil == nil
       settingsCard(settingId: "planusage.trial-expired") {
         VStack(alignment: .leading, spacing: 14) {
           HStack(spacing: 16) {
@@ -1790,13 +1797,75 @@ struct SettingsContentView: View {
               .foregroundColor(OmiColors.warning)
 
             VStack(alignment: .leading, spacing: 4) {
-              Text("Trial Ended")
+              Text(isNeoWithoutDesktop ? "Desktop access not included" : "Trial Ended")
                 .scaledFont(size: 16, weight: .semibold)
                 .foregroundColor(OmiColors.textPrimary)
 
-              Text("Upgrade to keep unlimited access")
-                .scaledFont(size: 13)
-                .foregroundColor(OmiColors.textSecondary)
+              Text(
+                isNeoWithoutDesktop
+                  ? "Neo is available on mobile and web. To use Omi on Mac, upgrade to Operator or Architect."
+                  : "Upgrade to keep unlimited access"
+              )
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textSecondary)
+            }
+
+            Spacer()
+          }
+
+          Divider().overlay(OmiColors.backgroundQuaternary)
+
+          Button(action: {
+            selectedPlanIdForCheckout = "operator"
+          }) {
+            Text("View Plans")
+              .scaledFont(size: 13, weight: .semibold)
+              .padding(.horizontal, 16)
+              .padding(.vertical, 8)
+          }
+          .buttonStyle(.borderedProminent)
+          .tint(OmiColors.purplePrimary)
+        }
+      }
+    }
+  }
+
+  // MARK: - Neo desktop grandfather notice
+  //
+  // Surfaced for Neo subscribers whose current billing period started before
+  // the #7496 policy change. They keep desktop access until their period
+  // ends — this card tells them when, so the change doesn't surprise them
+  // at the next renewal. Backend computes the date as
+  // `desktop_grandfather_until` on /v1/users/me/subscription (#7513).
+  @ViewBuilder
+  private var neoDesktopGrandfatherCard: some View {
+    if let until = userSubscription?.desktopGrandfatherUntil,
+      userSubscription?.subscription.plan == .unlimited
+    {
+      let endsOn = Date(timeIntervalSince1970: TimeInterval(until))
+      let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .long
+        f.timeStyle = .none
+        return f
+      }()
+      settingsCard(settingId: "planusage.neo-grandfather") {
+        VStack(alignment: .leading, spacing: 14) {
+          HStack(spacing: 16) {
+            Image(systemName: "info.circle.fill")
+              .scaledFont(size: 28)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Neo desktop access ends \(formatter.string(from: endsOn))")
+                .scaledFont(size: 16, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text(
+                "Your Neo plan continues to include desktop access through this billing period. After it ends, upgrade to Operator or Architect to keep using Omi on Mac."
+              )
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textSecondary)
             }
 
             Spacer()
@@ -1866,6 +1935,7 @@ struct SettingsContentView: View {
   private var planUsageSection: some View {
     VStack(spacing: 20) {
       trialCountdownCard
+      neoDesktopGrandfatherCard
 
       settingsCard(settingId: "planusage.current") {
         VStack(alignment: .leading, spacing: 14) {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -1781,14 +1781,21 @@ struct SettingsContentView: View {
           }
         }
       }
-    } else if let trial = appState.trialMetadata, trial.trialExpired {
+    } else if let trial = appState.trialMetadata,
+      trial.trialExpired,
+      // Suppress the trial-expired card entirely for grandfathered Neo users.
+      // The backend already returns trial_expired=false for them, but
+      // trialMetadata is polled on a 60s timer; defensive guard so a stale
+      // cached value during/after a backend deploy doesn't briefly stack the
+      // "Trial Ended" card on top of the grandfather notice. The grandfather
+      // notice is rendered separately via neoDesktopGrandfatherCard.
+      userSubscription?.desktopGrandfatherUntil == nil
+    {
       // Neo subscribers who aren't grandfathered land on this card too because
       // Neo doesn't grant desktop access (per #7496). The generic "Trial Ended"
       // copy is confusing for them — they're on a paid plan, just not one that
       // includes Mac. Detect that case and switch to plan-specific copy.
-      let isNeoWithoutDesktop =
-        userSubscription?.subscription.plan == .unlimited
-        && userSubscription?.desktopGrandfatherUntil == nil
+      let isNeoWithoutDesktop = userSubscription?.subscription.plan == .unlimited
       settingsCard(settingId: "planusage.trial-expired") {
         VStack(alignment: .leading, spacing: 14) {
           HStack(spacing: 16) {


### PR DESCRIPTION
## Summary

Follow-up to #7513 (backend grandfather) and #7508 / #7496 (the policy change). Two clarifications on the Plan & Usage page so Neo subscribers know exactly where they stand on macOS — instead of seeing a generic "Trial Ended" banner that's been confusing them.

### 1. Grandfathered Neo subscribers get a heads-up notice

When the backend returns `desktop_grandfather_until` on `/v1/users/me/subscription` (a Neo subscriber whose current billing period started before #7496), a new card appears above the plan card:

> **Neo desktop access ends \<long-formatted date>**
> Your Neo plan continues to include desktop access through this billing period. After it ends, upgrade to Operator or Architect to keep using Omi on Mac.
> \[View Plans]

So a user who bought Neo before the policy change sees their end-of-grandfather date the next time they open the app, with plenty of lead time to upgrade before renewal.

### 2. Non-grandfathered Neo subscribers get plan-specific copy

These users land on the existing trial-expired card because Neo isn't in `DESKTOP_ENTITLED_PLAN_TYPES`. The generic "Trial Ended / Upgrade to keep unlimited access" copy is misleading — they're on a paid plan, just not one that includes Mac. Now when the user is on Neo without a grandfather, the card swaps to:

> **Desktop access not included**
> Neo is available on mobile and web. To use Omi on Mac, upgrade to Operator or Architect.
> \[View Plans]

Same CTA, same card layout, just plan-appropriate words.

### Out of scope for non-Neo users

The trial-active / trial-expired (for non-Neo basic users) / Operator / Architect paths are unchanged. Only the two Neo-specific branches above are new.

## Files

| File | Change |
|---|---|
| `desktop/Desktop/Sources/APIClient.swift` | + `UserSubscriptionResponse.desktopGrandfatherUntil: Int?` (defensive `decodeIfPresent`) |
| `desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift` | Trial-expired card switches copy when user is Neo without grandfather; new `neoDesktopGrandfatherCard` rendered in `planUsageSection` between `trialCountdownCard` and the current-plan card |
| `desktop/CHANGELOG.json` | Unreleased entry |

## Test plan

I don't have a Mac available to compile from this box, so the change is read-checked rather than build-checked. Codemagic will catch any Swift issues on push.

Once it builds, can be verified with the named-bundle workflow from desktop/CLAUDE.md:

- [ ] **Grandfathered Neo (one of the users from #7508)**: launch a named test bundle, log in as the grandfathered user, open Plan & Usage. Expect the new "Neo desktop access ends \<date>" card, **no** Trial Ended banner, and chat usage showing the user's real Neo cap (no longer the forged 30/30).
- [ ] **Non-grandfathered Neo (fresh Neo signup post-#7496)**: open Plan & Usage. Expect "Desktop access not included" copy in place of "Trial Ended" — same card structure, same View Plans button.
- [ ] **Active trial (basic user inside the 3-day window)**: unchanged "Premium Trial Active" card.
- [ ] **Trial-expired basic user (no Neo)**: unchanged "Trial Ended / Upgrade to keep unlimited access" copy.
- [ ] **Operator / Architect subscriber**: neither the trial cards nor the grandfather card render.

Refs: #7513, #7508, #7496