### PR TITLE
desktop: clear sticky paywalled flag on launch for paid-plan users (follow-up to #7514)

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -376,11 +376,26 @@ class AppState: ObservableObject {
     AppState.current = self
 
     // Restore paywall flag from prior session so toggles + auto-restart respect
-    // it before any backend call has a chance to refresh state — but a BYOK
-    // user (all four keys configured) is never paywalled, so clear any stale
-    // flag immediately on launch.
-    self.isPaywalled =
-      !APIKeyService.isByokActive && UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+    // it before any backend call has a chance to refresh state — but never for
+    // a BYOK user (all four keys configured) or a user whose cached plan is
+    // paid. The paid-plan carve-out fixes a popup-on-launch bug for Neo
+    // subscribers grandfathered onto desktop by #7513: their last session
+    // pre-grandfather wrote isPaywalled=true; without this clear, the next
+    // launch shows the monthly-limit popup until fetchTrialMetadata returns
+    // (~1-2s) AND callers that read UserDefaults synchronously
+    // (ProactiveAssistantsPlugin, isPaywalledEffective) keep blocking until
+    // didSet writes the new value. Only basic-tier users have a legitimate
+    // pre-fetch paywalled state to preserve.
+    let cachedPlan = UserDefaults.standard.string(forKey: "floatingBar_cachedPlan")
+    let cachedPlanIsPaid = cachedPlan != nil && cachedPlan != "basic"
+    if APIKeyService.isByokActive || cachedPlanIsPaid {
+      self.isPaywalled = false
+      // didSet doesn't fire from init, so flush UserDefaults explicitly for
+      // singletons that read the key directly.
+      UserDefaults.standard.set(false, forKey: "desktop_isPaywalled")
+    } else {
+      self.isPaywalled = UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+    }
 
     // Resolve beta/stable before loading backend URLs so beta releases use dev services.
     AppBuild.prepareUpdateChannelForBackendRouting()


### PR DESCRIPTION
## Summary

Reported by Mohsin: a user grandfathered onto Neo desktop (Stripe `sub_1TYpAM…`, period ends 2026-06-19) opens the macOS app and gets the **"You've hit your monthly limit"** popup. The backend is correct — `/v1/users/me/trial` returns `trial_expired: false`, `/v1/users/me/usage-quota` returns `Neo, 0/200, allowed: true`, and their transcription WS is actively streaming (40-minute live session). The popup is purely client-side.

### Root cause

`AppState.init` line 382-383 optimistically restores `isPaywalled` from `UserDefaults["desktop_isPaywalled"]` before any backend fetch. For users who were paywalled *pre-#7513* (Neo on desktop = paywall), that flag is sticky across launches. `fetchTrialMetadata` does clear it after ~1-2s when the backend returns the new `trial_expired: false`, but in the startup window:

- `ProactiveAssistantsPlugin.startMonitoring` (`ProactiveAssistantsPlugin.swift:246`) reads `UserDefaults[desktop_isPaywalled]` synchronously and fires the popup if true.
- `AppState.isPaywalledEffective` (`AppState.swift:163`) does the same — used by menu-bar toggle handlers and `blockIfPaywalled`.
- The popup is shown for ~1-2s on every launch until `fetchTrialMetadata` resolves, and any user-initiated capture toggle in that window also fires it.

### Fix

Skip the optimistic restore for users whose cached plan is non-basic. The cache is already maintained by `FloatingBarUsageLimiter.cachedPlanKey` (set on every `getUserSubscription`). Paid plans shouldn't carry a paywalled flag at all:
- **Neo**: desktop status is now decided by the backend grandfather (#7513).
- **Operator / Architect**: always grant desktop.
- **BYOK**: already exempt elsewhere.

For basic-tier users, keep the existing optimistic restore — that's a legitimate paywall state worth preserving across launches.

Also flushes UserDefaults explicitly inside `init` because `didSet` doesn't fire from inits — without that, the synchronous readers (`ProactiveAssistantsPlugin`, `isPaywalledEffective`) would keep seeing the stale TRUE even though the in-memory `isPaywalled` was set to false.

## Files

| File | Change |
|---|---|
| `desktop/Desktop/Sources/AppState.swift` | Init: skip stale-paywalled restore when cached plan is paid; flush UserDefaults inline |

## Test plan

I can't drive the desktop app from this Linux box, but verifiable on Mac via the named-bundle workflow:

- [ ] **Grandfathered Neo user (Mohsin's repro case)** with `desktop_isPaywalled = true` cached in UserDefaults and `floatingBar_cachedPlan = "unlimited"`: launch the app, expect no "monthly limit" popup, expect screen-monitoring + transcription toggles to work immediately without going through `fetchTrialMetadata`.
- [ ] **Basic-tier user past trial** (`floatingBar_cachedPlan = "basic"`, `desktop_isPaywalled = true`): launch the app, expect popup behavior unchanged — the flag is still restored, gates still fire, fetchTrialMetadata still confirms.
- [ ] **BYOK user**: unchanged — BYOK branch still clears.
- [ ] After fetchTrialMetadata completes, `isPaywalled` should reflect the current backend state for all cohorts.

Refs: #7513, #7514, #7496, #7508