### PR TITLE
feat(mcp): expose X posts to agents (search_x_posts + get_x_posts)

### DIFF
--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -290,6 +290,63 @@ def delete_memory_vector(uid: str, memory_id: str):
 
 
 # ==========================================
+# X (Twitter) Post Vector Functions
+# Semantic search over the user's raw imported tweets/bookmarks.
+# ==========================================
+
+X_POSTS_NAMESPACE = "ns_x"
+
+
+def upsert_x_post_vectors_batch(uid: str, items: List[dict]) -> int:
+    """Upsert X post embeddings in one request. Each item: {'post_id', 'content', 'kind'}.
+    Returns the number of vectors written (0 if Pinecone is not configured)."""
+    if index is None:
+        logger.warning('Pinecone index not initialized, skipping x_post vector batch upsert')
+        return 0
+    items = [it for it in items if (it.get('content') or '').strip()]
+    if not items:
+        return 0
+
+    vectors = embeddings.embed_documents([it['content'] for it in items])
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+    payload = [
+        {
+            "id": f"{uid}-x-{it['post_id']}",
+            "values": vectors[i],
+            "metadata": {
+                "uid": uid,
+                "post_id": str(it['post_id']),
+                "kind": it.get('kind', 'tweet'),
+                "created_at": now_ts,
+            },
+        }
+        for i, it in enumerate(items)
+    ]
+    res = index.upsert(vectors=payload, namespace=X_POSTS_NAMESPACE)
+    logger.info(f'upsert_x_post_vectors_batch count={len(payload)} {res}')
+    return len(payload)
+
+
+def find_similar_x_posts(uid: str, content: str, limit: int = 10) -> List[dict]:
+    """Semantic search over the user's X posts. Returns [{post_id, kind, score}]."""
+    if index is None:
+        logger.warning('Pinecone index not initialized, skipping x_post similarity search')
+        return []
+    vector = embeddings.embed_query(content)
+    xc = index.query(
+        vector=vector, top_k=limit, include_metadata=True, filter={'uid': uid}, namespace=X_POSTS_NAMESPACE
+    )
+    return [
+        {
+            'post_id': m['metadata'].get('post_id'),
+            'kind': m['metadata'].get('kind'),
+            'score': m['score'],
+        }
+        for m in xc.get('matches', [])
+    ]
+
+
+# ==========================================
 # Screen Activity Vector Functions
 # For screenshot embeddings (Gemini embedding-001, 3072-dim)
 # ==========================================

--- a/backend/database/x_posts.py
+++ b/backend/database/x_posts.py
@@ -72,12 +72,31 @@ def save_x_posts(uid: str, posts: List[dict]) -> int:
 
 
 def get_x_posts(uid: str, limit: int = 100, kind: Optional[str] = None) -> List[dict]:
-    """Return stored posts, newest first. Optionally filter by kind."""
-    query = _posts_ref(uid)
+    """Return stored posts, newest first. Optionally filter by kind.
+
+    A kind filter + order_by would require a composite index, so when filtering
+    by kind we use the single-field equality query (auto-indexed) and sort in
+    Python — post volumes per user are small enough for this to be cheap.
+    """
+    coll = _posts_ref(uid)
     if kind:
-        query = query.where(filter=FieldFilter('kind', '==', kind))
-    query = query.order_by('created_at', direction=firestore.Query.DESCENDING).limit(limit)
+        docs = [d.to_dict() for d in coll.where(filter=FieldFilter('kind', '==', kind)).limit(limit * 3).stream()]
+        docs.sort(key=lambda d: d.get('created_at') or '', reverse=True)
+        return docs[:limit]
+    query = coll.order_by('created_at', direction=firestore.Query.DESCENDING).limit(limit)
     return [d.to_dict() for d in query.stream()]
+
+
+def get_x_posts_by_ids(uid: str, ids: List[str]) -> List[dict]:
+    """Fetch specific posts by id (used by semantic search to hydrate matches)."""
+    if not ids:
+        return []
+    coll = _posts_ref(uid)
+    out = []
+    for snap in db.get_all([coll.document(str(i)) for i in ids]):
+        if snap.exists:
+            out.append(snap.to_dict())
+    return out
 
 
 def count_x_posts(uid: str) -> int:

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -23,6 +23,7 @@ import database.memories as memories_db
 import database.conversations as conversations_db
 import database.mcp_api_key as mcp_api_key_db
 import database.vector_db as vector_db
+import database.x_posts as x_posts_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from utils.conversations.render import redact_conversation_for_list
 from models.conversation_enums import CategoryEnum
@@ -238,6 +239,43 @@ MCP_TOOLS = [
                 "limit": {"type": "integer", "description": "Maximum number of results to return", "default": 10},
             },
             "required": ["query"],
+        },
+    },
+    {
+        "name": "search_x_posts",
+        "description": (
+            "Semantic search across the user's imported X (Twitter) posts — their actual tweets and "
+            "bookmarks, not just extracted memories. Returns posts ranked by relevance to the query."
+        ),
+        "annotations": READ_ONLY_ANNOTATIONS,
+        "securitySchemes": MEMORIES_READ_SECURITY,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Natural language search query"},
+                "limit": {"type": "integer", "description": "Maximum number of results to return", "default": 10},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "get_x_posts",
+        "description": (
+            "Retrieve the user's imported X (Twitter) posts, newest first. Optionally filter by kind "
+            "(tweet or bookmark). Returns the raw post text, created_at, and id."
+        ),
+        "annotations": READ_ONLY_ANNOTATIONS,
+        "securitySchemes": MEMORIES_READ_SECURITY,
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": ["tweet", "bookmark"],
+                    "description": "Filter to only tweets or only bookmarks (omit for all)",
+                },
+                "limit": {"type": "integer", "description": "Number of posts to retrieve", "default": 50},
+            },
         },
     },
 ]
@@ -500,6 +538,42 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
             )
 
         return {"conversations": results}
+
+    elif tool_name == "search_x_posts":
+        query = arguments.get("query")
+        if not query:
+            raise ToolExecutionError("query is required")
+        limit = arguments.get("limit", 10)
+
+        matches = vector_db.find_similar_x_posts(user_id, query, limit=limit)
+        if not matches:
+            return {"posts": []}
+
+        score_map = {str(m['post_id']): m.get('score', 0) for m in matches}
+        posts = x_posts_db.get_x_posts_by_ids(user_id, [m['post_id'] for m in matches])
+        results = []
+        for p in posts:
+            results.append(
+                {
+                    "id": p.get("id"),
+                    "text": p.get("text"),
+                    "kind": p.get("kind"),
+                    "created_at": p.get("created_at"),
+                    "relevance_score": round(score_map.get(str(p.get("id")), 0), 4),
+                }
+            )
+        results.sort(key=lambda x: x.get("relevance_score", 0), reverse=True)
+        return {"posts": results}
+
+    elif tool_name == "get_x_posts":
+        limit = arguments.get("limit", 50)
+        kind = arguments.get("kind")
+        posts = x_posts_db.get_x_posts(user_id, limit=limit, kind=kind)
+        results = [
+            {"id": p.get("id"), "text": p.get("text"), "kind": p.get("kind"), "created_at": p.get("created_at")}
+            for p in posts
+        ]
+        return {"posts": results}
 
     else:
         raise ToolExecutionError(f"Unknown tool: {tool_name}", code=-32601)

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -32,7 +32,7 @@ from database import users as users_db
 from database import x_posts as x_posts_db
 from database import memories as memories_db
 from database._client import db
-from database.vector_db import upsert_memory_vectors_batch
+from database.vector_db import upsert_memory_vectors_batch, upsert_x_post_vectors_batch
 from models.memories import MemoryDB
 from utils.llm.memories import extract_memories_from_text
 from utils import social
@@ -399,6 +399,15 @@ async def sync_x_for_user(uid: str) -> Dict:
     # Only mine memories from posts we hadn't seen before (the raw store dedupes,
     # but extraction is the expensive part — restrict it to genuinely new text).
     fresh = new_posts if written == len(new_posts) else new_posts[:written]
+    # Vector-index the raw posts so agents can semantically search the actual
+    # tweets (not just the extracted memories) via the MCP search_x_posts tool.
+    try:
+        upsert_x_post_vectors_batch(
+            uid,
+            [{'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in fresh],
+        )
+    except Exception as e:
+        logger.warning(f'x_connector: failed to index x_posts for uid={uid}: {e}')
     memories_created = _extract_and_index(uid, fresh)
 
     users_db.set_integration(


### PR DESCRIPTION
## What

Lets any agent connected to the **Omi MCP** (`api.omi.me/v1/mcp/sse`) — Claude, ChatGPT, Claude Code, Codex, **Hermes/openclaw**, etc. — read the user's **actual tweets and bookmarks**, not just the memories Omi extracted from them.

Modeled on how **mem0 / supermemory** expose sources: a semantic `search` tool as the primary interface, plus a `get/list` with filters.

## Tools added (hosted `mcp_sse.py`)
- **`search_x_posts(query, limit)`** — semantic search over the user's raw X posts, ranked by relevance.
- **`get_x_posts(limit, kind?)`** — recent posts, optionally filtered to `tweet` or `bookmark`.

## Plumbing
- `vector_db`: `X_POSTS_NAMESPACE` (ns_x) + `upsert_x_post_vectors_batch` + `find_similar_x_posts`.
- `x_connector`: vector-indexes raw posts on every sync (OAuth + RapidAPI paths), so tweet text is searchable alongside memory extraction.
- `x_posts`: `get_x_posts_by_ids`; `get_x_posts` kind filter avoids a composite index (single-field query + Python sort).

## Verified
End-to-end on 511 real posts (@kodjima33): semantic queries return the right tweets/bookmarks ranked by relevance ("shopify growth hacking" → the growthack tweet 0.58; "immigration and visas" → visa replies; etc.); `get_x_posts` kind filter works.

## Note
Posts imported **before** this deploys won't be searchable until re-indexed (the sync only indexes new posts via `since_id`). Since the connector isn't live in prod yet, all prod connects will be fresh → indexed on import, so no backfill is needed for rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)