### PR TITLE
Fix mic mute toggle state and active capture control

### DIFF
--- a/app/lib/pages/conversation_capturing/page.dart
+++ b/app/lib/pages/conversation_capturing/page.dart
@@ -211,7 +211,7 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                     tooltip: effectivelyMuted ? context.l10n.phoneUnmute : context.l10n.mute,
                     onPressed: provider.isCallActive ? null : () => _toggleMute(provider),
                     icon: Icon(
-                      effectivelyMuted ? Icons.mic : Icons.mic_off,
+                      effectivelyMuted ? Icons.mic_off : Icons.mic,
                       color: effectivelyMuted ? const Color(0xFFFF6B6B) : Colors.white70,
                       size: 24,
                     ),
@@ -379,7 +379,7 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                                 ),
                               ],
                             ),
-                            child: Icon(effectivelyMuted ? Icons.mic : Icons.mic_off, color: Colors.white, size: 24),
+                            child: Icon(effectivelyMuted ? Icons.mic_off : Icons.mic, color: Colors.white, size: 24),
                           ),
                         ),
                       ),

--- a/app/lib/pages/conversation_capturing/page.dart
+++ b/app/lib/pages/conversation_capturing/page.dart
@@ -36,7 +36,6 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
   TabController? _controller;
   late bool showSummarizeConfirmation;
   late AnimationController _animationController;
-  bool _isMuted = false;
   final ScrollController _timelineScrollController = ScrollController();
 
   @override
@@ -49,20 +48,22 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
     super.initState();
   }
 
+  bool _isCaptureMuted(CaptureProvider provider) =>
+      provider.isPaused || provider.recordingState == RecordingState.pause || provider.isCallActive;
+
   Future<void> _toggleMute(CaptureProvider provider) async {
-    if (_isMuted) {
+    if (provider.isCallActive) return;
+
+    if (_isCaptureMuted(provider)) {
       // Unmute - resume recording
       HapticFeedback.mediumImpact();
-      setState(() {
-        _isMuted = false;
-      });
 
       if (provider.havingRecordingDevice) {
         // Device recording (Omi device)
         await provider.resumeDeviceRecording();
       } else {
         // Phone mic
-        await provider.streamRecording();
+        await provider.resumePhoneMicRecording();
         PlatformManager.instance.analytics.phoneMicRecordingStarted();
       }
     } else {
@@ -70,16 +71,13 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
       HapticFeedback.heavyImpact();
       await Future.delayed(const Duration(milliseconds: 80));
       HapticFeedback.lightImpact();
-      setState(() {
-        _isMuted = true;
-      });
 
       if (provider.havingRecordingDevice) {
         // Device recording (Omi device)
         await provider.pauseDeviceRecording();
       } else {
         // Phone mic
-        await provider.stopStreamRecording();
+        await provider.pausePhoneMicRecording();
         PlatformManager.instance.analytics.phoneMicRecordingStopped();
       }
     }
@@ -172,7 +170,7 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
   Widget build(BuildContext context) {
     return Consumer2<CaptureProvider, DeviceProvider>(
       builder: (context, provider, deviceProvider, child) {
-        final effectivelyMuted = _isMuted || provider.isCallActive;
+        final effectivelyMuted = _isCaptureMuted(provider);
         return PopScope(
           canPop: true,
           child: Scaffold(
@@ -207,6 +205,15 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                       provider.photos.isNotEmpty
                           ? 'Capturing'
                           : (effectivelyMuted ? context.l10n.muted : context.l10n.listening),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: effectivelyMuted ? context.l10n.phoneUnmute : context.l10n.mute,
+                    onPressed: provider.isCallActive ? null : () => _toggleMute(provider),
+                    icon: Icon(
+                      effectivelyMuted ? Icons.mic : Icons.mic_off,
+                      color: effectivelyMuted ? const Color(0xFFFF6B6B) : Colors.white70,
+                      size: 24,
                     ),
                   ),
                 ],
@@ -353,24 +360,27 @@ class _ConversationCapturingPageState extends State<ConversationCapturingPage> w
                       ),
                       const SizedBox(width: 12),
                       // Mute button
-                      GestureDetector(
-                        onTap: () => _toggleMute(provider),
-                        child: Container(
-                          width: 52,
-                          height: 52,
-                          decoration: BoxDecoration(
-                            color: effectivelyMuted ? Colors.red : const Color(0xFF35343B),
-                            shape: BoxShape.circle,
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.black.withValues(alpha: 0.25),
-                                spreadRadius: 2,
-                                blurRadius: 8,
-                                offset: const Offset(0, 4),
-                              ),
-                            ],
+                      Tooltip(
+                        message: effectivelyMuted ? context.l10n.phoneUnmute : context.l10n.mute,
+                        child: GestureDetector(
+                          onTap: provider.isCallActive ? null : () => _toggleMute(provider),
+                          child: Container(
+                            width: 52,
+                            height: 52,
+                            decoration: BoxDecoration(
+                              color: effectivelyMuted ? Colors.red : const Color(0xFF35343B),
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withValues(alpha: 0.25),
+                                  spreadRadius: 2,
+                                  blurRadius: 8,
+                                  offset: const Offset(0, 4),
+                                ),
+                              ],
+                            ),
+                            child: Icon(effectivelyMuted ? Icons.mic : Icons.mic_off, color: Colors.white, size: 24),
                           ),
-                          child: const Icon(Icons.mic_off, color: Colors.white, size: 24),
                         ),
                       ),
                     ],

--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -28,8 +28,6 @@ class ConversationCaptureWidget extends StatefulWidget {
 }
 
 class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
-  bool _isPhoneMicPaused = false;
-
   @override
   Widget build(BuildContext context) {
     // Hide capture widget when a phone call is in progress (banner replaces it)
@@ -90,6 +88,9 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
 
   _toggleRecording(BuildContext context, CaptureProvider provider) async {
     var recordingState = provider.recordingState;
+    final isPhoneMicPaused = !provider.havingRecordingDevice &&
+        provider.isPaused &&
+        recordingState == RecordingState.pause;
 
     if (provider.havingRecordingDevice) {
       // Device recording logic - add pause/resume for device recording
@@ -101,27 +102,16 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
         await provider.resumeDeviceRecording();
       }
     } else {
-      // Phone mic logic - use local state to track pause
-      if (recordingState == RecordingState.record && !_isPhoneMicPaused) {
-        // Pause recording
-        setState(() {
-          _isPhoneMicPaused = true;
-        });
-        await provider.stopStreamRecording();
+      if ((recordingState == RecordingState.record || recordingState == RecordingState.interrupted) &&
+          !isPhoneMicPaused) {
+        await provider.pausePhoneMicRecording();
         PlatformManager.instance.analytics.phoneMicRecordingStopped();
-      } else if (_isPhoneMicPaused) {
-        // Resume recording
-        setState(() {
-          _isPhoneMicPaused = false;
-        });
-        await provider.streamRecording();
+      } else if (isPhoneMicPaused) {
+        await provider.resumePhoneMicRecording();
         PlatformManager.instance.analytics.phoneMicRecordingStarted();
       } else if (recordingState == RecordingState.initialising) {
         Logger.debug('initialising, have to wait');
       } else {
-        setState(() {
-          _isPhoneMicPaused = false;
-        });
         await provider.streamRecording();
         PlatformManager.instance.analytics.phoneMicRecordingStarted();
       }
@@ -151,8 +141,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
         captureProvider.recordingState == RecordingState.initialising ||
         captureProvider.recordingState == RecordingState.pause ||
         captureProvider.recordingState == RecordingState.interrupted ||
-        captureProvider.isPaused ||
-        _isPhoneMicPaused;
+        captureProvider.isPaused;
 
     // Hide the widget when no recording is active and there are no segments or photos
     if (!isAnyRecordingActive && !isHavingTranscript && !isHavingPhotos && !isHavingRecordingDevice) {
@@ -167,7 +156,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
           context,
           () => _toggleRecording(context, captureProvider),
           captureProvider.recordingState,
-          isPhoneMicPaused: _isPhoneMicPaused,
+          isPhoneMicPaused: captureProvider.isPaused && captureProvider.recordingState == RecordingState.pause,
         ),
       );
     } else if (!isAnyRecordingActive &&
@@ -221,7 +210,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     if (captureProvider.recordingState == RecordingState.interrupted && captureProvider.isCallActive) {
       stateText = context.l10n.paused;
       statusIndicator = const PausedStatusIndicator();
-    } else if (captureProvider.isPaused || _isPhoneMicPaused) {
+    } else if (captureProvider.isPaused) {
       stateText = context.l10n.paused;
       statusIndicator = const PausedStatusIndicator();
     } else if (!isHavingRecordingDevice && !isUsingPhoneMic) {
@@ -280,7 +269,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
         provider.recordingState == RecordingState.systemAudioRecord ||
         provider.recordingState == RecordingState.initialising ||
         provider.recordingState == RecordingState.interrupted ||
-        _isPhoneMicPaused;
+        provider.recordingState == RecordingState.pause;
 
     // Determine pause state based on recording type.
     // Call-active interruption is treated as paused for button/dot display.
@@ -289,7 +278,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     if (isDeviceRecording) {
       isPaused = provider.isPaused && provider.recordingState == RecordingState.pause;
     } else if (isPhoneRecording) {
-      isPaused = _isPhoneMicPaused || provider.isPaused || isCallInterrupted;
+      isPaused = provider.isPaused || isCallInterrupted;
     }
 
     // Determine if this is an OmiGlass-type device (captures photos)
@@ -571,7 +560,7 @@ getPhoneMicRecordingButton(
         decoration: const BoxDecoration(color: Colors.orange, shape: BoxShape.circle),
         child: const Center(child: Icon(Icons.pause, color: Colors.white, size: 14)),
       );
-    } else if (isPhoneMicPaused) {
+    } else if (isPhoneMicPaused || currentActualState == RecordingState.pause) {
       text = context.l10n.resumeRecording;
       icon = Container(
         margin: const EdgeInsets.only(right: 4),

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -231,6 +231,7 @@ class CaptureProvider extends ChangeNotifier
 
   // Restarts mic only — preserves existing socket and conversation segments.
   Future<void> _resumeMicRecording() async {
+    _manualPhoneMicPause = false;
     updateRecordingState(RecordingState.initialising);
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
@@ -249,7 +250,9 @@ class CaptureProvider extends ChangeNotifier
             updateRecordingState(RecordingState.record);
           },
           onStop: () {
-            if (!_callActive) {
+            if (_manualPhoneMicPause) {
+              updateRecordingState(RecordingState.pause);
+            } else if (!_callActive) {
               updateRecordingState(RecordingState.stop);
             }
           },
@@ -258,6 +261,20 @@ class CaptureProvider extends ChangeNotifier
           },
           onStalled: _onMicStalled,
         );
+  }
+
+  void _flushPhoneMicWalBuffer() {
+    if (!_phoneMicWalActive) return;
+
+    final flushed = _activeSource?.flush() ?? [];
+    for (final frame in flushed) {
+      _wal.getSyncs().phone.onFrameCaptured(frame);
+      if (_socket?.state == SocketServiceState.connected) {
+        _socket?.send(frame.payload);
+        _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
+      }
+    }
+    _phoneMicWalActive = false;
   }
 
   void _onMicStalled() {
@@ -384,6 +401,7 @@ class CaptureProvider extends ChangeNotifier
   RecordingState recordingState = RecordingState.stop;
 
   bool _isPaused = false;
+  bool _manualPhoneMicPause = false;
   bool get isPaused => _isPaused;
   bool get isCallActive => _callActive;
 
@@ -406,13 +424,13 @@ class CaptureProvider extends ChangeNotifier
   bool get transcriptServiceReady => _transcriptServiceReady && _isConnected;
 
   // having a connected device or using the phone's mic for recording.
-  // Includes `interrupted` so the keep-alive/reconnect path keeps running
-  // while the phone mic is in a transiently-broken state (e.g., iOS audio
-  // session interruption after an incoming call).
+  // Includes temporary stop states so the in-session UI keeps the capture
+  // context alive while audio is paused or reconnecting.
   bool get recordingDeviceServiceReady =>
       _recordingDevice != null ||
       recordingState == RecordingState.record ||
       recordingState == RecordingState.interrupted ||
+      recordingState == RecordingState.pause ||
       recordingState == RecordingState.systemAudioRecord;
 
   bool get havingRecordingDevice => _recordingDevice != null;
@@ -1068,6 +1086,8 @@ class CaptureProvider extends ChangeNotifier
   }
 
   streamRecording() async {
+    _manualPhoneMicPause = false;
+    _isPaused = false;
     updateRecordingState(RecordingState.initialising);
     await Permission.microphone.request();
 
@@ -1103,7 +1123,9 @@ class CaptureProvider extends ChangeNotifier
             updateRecordingState(RecordingState.record);
           },
           onStop: () {
-            if (!_callActive) {
+            if (_manualPhoneMicPause) {
+              updateRecordingState(RecordingState.pause);
+            } else if (!_callActive) {
               updateRecordingState(RecordingState.stop);
             }
           },
@@ -1114,19 +1136,42 @@ class CaptureProvider extends ChangeNotifier
         );
   }
 
-  stopStreamRecording() async {
-    // Flush remaining phone mic WAL buffer before stopping
-    if (_phoneMicWalActive) {
-      final flushed = _activeSource?.flush() ?? [];
-      for (final frame in flushed) {
-        _wal.getSyncs().phone.onFrameCaptured(frame);
-        if (_socket?.state == SocketServiceState.connected) {
-          _socket?.send(frame.payload);
-          _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
-        }
-      }
-      _phoneMicWalActive = false;
+  Future<void> pausePhoneMicRecording() async {
+    if (_recordingDevice != null) return;
+    if (_activeSource is! PhoneMicSource &&
+        recordingState != RecordingState.record &&
+        recordingState != RecordingState.initialising &&
+        recordingState != RecordingState.interrupted) {
+      return;
     }
+
+    _manualPhoneMicPause = true;
+    _isPaused = true;
+    _flushPhoneMicWalBuffer();
+    try {
+      ServiceManager.instance().mic.stop();
+    } catch (e) {
+      Logger.debug("Error pausing phone mic recording: $e");
+    }
+    updateRecordingState(RecordingState.pause);
+    notifyListeners();
+  }
+
+  Future<void> resumePhoneMicRecording() async {
+    if (_recordingDevice != null) return;
+    if (!_isPaused && recordingState != RecordingState.pause) return;
+
+    _isPaused = false;
+    _manualPhoneMicPause = false;
+    await _resumeMicRecording();
+    notifyListeners();
+  }
+
+  stopStreamRecording() async {
+    _manualPhoneMicPause = false;
+    _isPaused = false;
+    // Flush remaining phone mic WAL buffer before stopping
+    _flushPhoneMicWalBuffer();
     await _cleanupCurrentState();
     ServiceManager.instance().mic.stop();
     updateRecordingState(RecordingState.stop);
@@ -1213,7 +1258,9 @@ class CaptureProvider extends ChangeNotifier
         await _initiateWebsocket(audioCodec: codec, source: _getConversationSourceFromDevice());
         return;
       }
-      if (recordingState == RecordingState.record || recordingState == RecordingState.interrupted) {
+      if (recordingState == RecordingState.record ||
+          recordingState == RecordingState.interrupted ||
+          recordingState == RecordingState.pause) {
         await _initiateWebsocket(
           audioCodec: BleAudioCodec.pcm16,
           sampleRate: 16000,

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -198,6 +198,11 @@ class CaptureProvider extends ChangeNotifier
   void _onAudioInterruptionEnded() {
     if (_activeSource is! PhoneMicSource) return;
     _callActive = false;
+    if (_manualPhoneMicPause) {
+      updateRecordingState(RecordingState.pause);
+      notifyListeners();
+      return;
+    }
     _restartPhoneMicRecording();
   }
 
@@ -231,7 +236,6 @@ class CaptureProvider extends ChangeNotifier
 
   // Restarts mic only — preserves existing socket and conversation segments.
   Future<void> _resumeMicRecording() async {
-    _manualPhoneMicPause = false;
     updateRecordingState(RecordingState.initialising);
     _activeSource = PhoneMicSource();
     _phoneMicWalActive = true;
@@ -1138,8 +1142,8 @@ class CaptureProvider extends ChangeNotifier
 
   Future<void> pausePhoneMicRecording() async {
     if (_recordingDevice != null) return;
-    if (_activeSource is! PhoneMicSource &&
-        recordingState != RecordingState.record &&
+    if (_activeSource is! PhoneMicSource) return;
+    if (recordingState != RecordingState.record &&
         recordingState != RecordingState.initialising &&
         recordingState != RecordingState.interrupted) {
       return;


### PR DESCRIPTION
## Summary
- Add provider-level phone mic pause/resume so mute does not tear down the active capture session/socket.
- Use the shared capture pause state in the home capture card instead of widget-local phone mic state.
- Add a top mute/unmute action to the active capture screen and keep the lower action button in sync.

## Testing
- `git diff --check`
- Not run: Flutter/Dart SDK is not available in this local Windows environment.

Fixes #1643
/claim #1643