### PR TITLE
backend: lower precache concurrency cap 4 → 2 to free storage_executor for sync

### DIFF
--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 # Per-request fan-out limits for storage_executor (#7387)
 _STORAGE_CHUNK_SEM = threading.BoundedSemaphore(32)
-_PRECACHE_FILE_SEM = threading.BoundedSemaphore(4)
+_PRECACHE_FILE_SEM = threading.BoundedSemaphore(2)
 _CHUNK_WINDOW_SIZE = 8
 
 _merge_tracker_lock = threading.Lock()


### PR DESCRIPTION
## Summary
- Halve `_PRECACHE_FILE_SEM` from 4 → 2 in `backend/utils/other/storage.py`.

## Why
The `storage_executor` (96 workers) is shared between the sync v2 pipeline and the playback / precache flows. Under load, precache fan-out can pin up to ~36 workers per instance (4 outer slots × up to 9 each for chunk downloads), starving the sync pipeline's GCS reads.

Recent prod data (48h, all services):
- `caller=process_conversation`: 7,914 events (37% of audio_merge work)
- `caller=precache_endpoint`: 8,430 events (40%)
- `caller=sync_urls_first`: 3,562 events (17%)
- `caller=sync_urls_bg`: 1,285 events (6%)

Storage pool saturation warnings on `backend-sync` were averaging 96% utilization with peak queue depth 67. Sync's decode_ms p95 was sitting at 252s, largely queue wait.

Halving the cap drops precache's worst-case storage footprint to ~18 workers per instance, leaving ~78 free for sync.

## Tradeoff
Speculative cache warming takes longer. Users see a one-off slowdown only if they open a brand-new conversation before warming finishes; on-demand `/v1/sync/audio/{conv}/urls` playback is unchanged.

## Test plan
- [ ] Watch `executor_pool_health` warnings on `backend-sync` for 30 min post-deploy — `storage` pool max_q should drop noticeably
- [ ] Watch `sync_v2 bg complete` decode_ms p95 — should improve toward p50
- [ ] No new 5xx errors on `/v2/sync-local-files` or `/v1/sync/audio/*/precache`
- [ ] Smoke: open a few recently-created conversations and confirm playback still works