### PR TITLE
app(sync): keep backendBusy cooldown in-memory only

### DIFF
--- a/app/lib/services/wals/sync_rate_limiter.dart
+++ b/app/lib/services/wals/sync_rate_limiter.dart
@@ -65,13 +65,16 @@ class SyncRateLimiter extends ChangeNotifier {
 
   RateLimitReason? get reason {
     final now = DateTime.now().millisecondsSinceEpoch;
-    if (_backendBusyUntilMs > now) return RateLimitReason.backendBusy;
     final persisted = SharedPreferencesUtil().getInt(_prefKeyUntil);
-    if (persisted > now) {
-      final name = SharedPreferencesUtil().getString(_prefKeyReason);
-      return RateLimitReason.values.asNameMap()[name] ?? RateLimitReason.rateLimit;
+    final busyActive = _backendBusyUntilMs > now;
+    final rateActive = persisted > now;
+    if (!busyActive && !rateActive) return null;
+    // Match `until`'s max-based pick so reason and deadline refer to the same cooldown.
+    if (busyActive && (!rateActive || _backendBusyUntilMs >= persisted)) {
+      return RateLimitReason.backendBusy;
     }
-    return null;
+    final name = SharedPreferencesUtil().getString(_prefKeyReason);
+    return RateLimitReason.values.asNameMap()[name] ?? RateLimitReason.rateLimit;
   }
 
   /// Pause uploads. Honors the server's Retry-After (seconds) when present,
@@ -80,9 +83,8 @@ class SyncRateLimiter extends ChangeNotifier {
   /// also picks the persistence mode (rateLimit persists, backendBusy is
   /// in-memory only).
   void markLimited({int? retryAfterSeconds, RateLimitReason reason = RateLimitReason.rateLimit}) {
-    final requested = (retryAfterSeconds != null && retryAfterSeconds > 0)
-        ? retryAfterSeconds
-        : _defaultCooldownSeconds;
+    final requested =
+        (retryAfterSeconds != null && retryAfterSeconds > 0) ? retryAfterSeconds : _defaultCooldownSeconds;
     final secs = requested > _maxCooldownSeconds ? _maxCooldownSeconds : requested;
     final untilMs = DateTime.now().add(Duration(seconds: secs)).millisecondsSinceEpoch;
     if (reason == RateLimitReason.backendBusy) {

--- a/app/lib/services/wals/sync_rate_limiter.dart
+++ b/app/lib/services/wals/sync_rate_limiter.dart
@@ -2,12 +2,15 @@ import 'package:flutter/foundation.dart';
 import 'package:omi/backend/preferences.dart';
 
 /// Why uploads are currently paused.
-/// - [rateLimit]   : server returned HTTP 429 (fair-use cap).
+/// - [rateLimit]   : server returned HTTP 429 (fair-use cap). Persisted —
+///                   mirrors server-side enforcement that survives client
+///                   restarts (the server keeps a 30-day restrict window).
 /// - [backendBusy] : server marked a job `failed` with the stale-guard error
 ///                   ("Job timed out (background worker likely died)") — i.e.
 ///                   the job sat queued because the backend pipeline is
-///                   saturated and never picked it up. Not the user's fault;
-///                   no `retryCount` bump and the UI surfaces this distinctly.
+///                   saturated and never picked it up. In-memory only — once
+///                   the app restarts, the cooldown clears so the user sees
+///                   fresh state if the server has since recovered.
 enum RateLimitReason { rateLimit, backendBusy }
 
 /// Account-global cooldown for fair-use throttling (HTTP 429) on sync uploads.
@@ -15,10 +18,23 @@ enum RateLimitReason { rateLimit, backendBusy }
 /// When the server rate-limits uploads, the app must stop firing requests
 /// until the window passes — otherwise it hammers the endpoint every minute,
 /// amplifies the 429 storm, and burns each recording's retry budget so a
-/// throttle is mislabelled as "couldn't process". Persisted so a relaunch
-/// during the window doesn't immediately resume hammering.
+/// throttle is mislabelled as "couldn't process".
+///
+/// `rateLimit` cooldowns are persisted (a relaunch during the window
+/// shouldn't immediately resume hammering). `backendBusy` cooldowns are
+/// in-memory only — they reflect transient server pressure and should not
+/// survive an app restart that the user just did to "try again".
 class SyncRateLimiter extends ChangeNotifier {
-  SyncRateLimiter._();
+  SyncRateLimiter._() {
+    // Migration: older versions persisted backendBusy cooldowns. Clear any
+    // stuck persisted backendBusy state so users coming from a healthy
+    // server don't keep seeing "Omi servers are busy" indefinitely.
+    final persistedReason = SharedPreferencesUtil().getString(_prefKeyReason);
+    if (persistedReason == RateLimitReason.backendBusy.name) {
+      SharedPreferencesUtil().saveInt(_prefKeyUntil, 0);
+      SharedPreferencesUtil().saveString(_prefKeyReason, '');
+    }
+  }
   static final SyncRateLimiter instance = SyncRateLimiter._();
 
   static const String _prefKeyUntil = 'syncRateLimitedUntilMs';
@@ -26,37 +42,61 @@ class SyncRateLimiter extends ChangeNotifier {
   static const int _defaultCooldownSeconds = 1800; // 30 minutes
   static const int _maxCooldownSeconds = 24 * 60 * 60; // hard ceiling — guard against a misconfigured Retry-After
 
+  // In-memory cooldown for backendBusy. Intentionally not persisted so an
+  // app restart re-probes the backend state instead of trusting a stale
+  // local timer.
+  int _backendBusyUntilMs = 0;
+
   bool get isLimited {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    if (_backendBusyUntilMs > now) return true;
     final until = SharedPreferencesUtil().getInt(_prefKeyUntil);
-    return until > 0 && DateTime.now().millisecondsSinceEpoch < until;
+    return until > 0 && now < until;
   }
 
   DateTime? get until {
-    final ms = SharedPreferencesUtil().getInt(_prefKeyUntil);
-    return ms > 0 ? DateTime.fromMillisecondsSinceEpoch(ms) : null;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final persisted = SharedPreferencesUtil().getInt(_prefKeyUntil);
+    final inMemory = _backendBusyUntilMs;
+    final candidates = <int>[if (inMemory > now) inMemory, if (persisted > now) persisted];
+    if (candidates.isEmpty) return null;
+    return DateTime.fromMillisecondsSinceEpoch(candidates.reduce((a, b) => a > b ? a : b));
   }
 
   RateLimitReason? get reason {
-    if (!isLimited) return null;
-    final name = SharedPreferencesUtil().getString(_prefKeyReason);
-    return RateLimitReason.values.asNameMap()[name] ?? RateLimitReason.rateLimit;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    if (_backendBusyUntilMs > now) return RateLimitReason.backendBusy;
+    final persisted = SharedPreferencesUtil().getInt(_prefKeyUntil);
+    if (persisted > now) {
+      final name = SharedPreferencesUtil().getString(_prefKeyReason);
+      return RateLimitReason.values.asNameMap()[name] ?? RateLimitReason.rateLimit;
+    }
+    return null;
   }
 
   /// Pause uploads. Honors the server's Retry-After (seconds) when present,
   /// otherwise falls back to a 30-minute cooldown. [reason] picks the
-  /// user-facing message ("Fair-use limit reached" vs "Backend busy").
+  /// user-facing message ("Fair-use limit reached" vs "Backend busy") and
+  /// also picks the persistence mode (rateLimit persists, backendBusy is
+  /// in-memory only).
   void markLimited({int? retryAfterSeconds, RateLimitReason reason = RateLimitReason.rateLimit}) {
-    final requested =
-        (retryAfterSeconds != null && retryAfterSeconds > 0) ? retryAfterSeconds : _defaultCooldownSeconds;
+    final requested = (retryAfterSeconds != null && retryAfterSeconds > 0)
+        ? retryAfterSeconds
+        : _defaultCooldownSeconds;
     final secs = requested > _maxCooldownSeconds ? _maxCooldownSeconds : requested;
     final untilMs = DateTime.now().add(Duration(seconds: secs)).millisecondsSinceEpoch;
-    SharedPreferencesUtil().saveInt(_prefKeyUntil, untilMs);
-    SharedPreferencesUtil().saveString(_prefKeyReason, reason.name);
+    if (reason == RateLimitReason.backendBusy) {
+      _backendBusyUntilMs = untilMs;
+    } else {
+      SharedPreferencesUtil().saveInt(_prefKeyUntil, untilMs);
+      SharedPreferencesUtil().saveString(_prefKeyReason, reason.name);
+    }
     notifyListeners();
   }
 
   /// Clear the cooldown after any successful upload.
   void clear() {
+    _backendBusyUntilMs = 0;
     SharedPreferencesUtil().saveInt(_prefKeyUntil, 0);
     SharedPreferencesUtil().saveString(_prefKeyReason, '');
     notifyListeners();


### PR DESCRIPTION
## Summary
- `SyncRateLimiter` now persists only the `rateLimit` cooldown. `backendBusy` cooldowns live in an in-memory field that clears on app restart.
- Constructor clears any pre-existing persisted `backendBusy` entry from older app versions, so users coming from a healthy server get unstuck on next launch.

## Why
The "Omi servers are busy" banner was surviving app restarts even when the backend had long since recovered. The cooldown was saved to `SharedPreferences` for both `rateLimit` (HTTP 429) and `backendBusy` (stale-guard) cases.

`rateLimit` cooldowns SHOULD persist — they mirror server-side fair-use enforcement that is itself sticky across restarts (30-day restrict window). But `backendBusy` reflects transient backend pipeline pressure. If a user restarts the app to retry, the cooldown should clear and the next sync should re-probe the backend, not trust a local timer set during an earlier rough patch.

Backend data (last 7 days): zero stale-guard fires globally, yet some users still report seeing the banner. Their app state is stuck from an earlier server hiccup that has long since resolved.

## Behavior

| State | Before | After |
|---|---|---|
| Server returns 429 (rateLimit) | 30 min cooldown, persists across restart | unchanged — still persists |
| Reconciler sees stale-guard (backendBusy) | 10 min cooldown, persists across restart | 10 min cooldown, in-memory only |
| App restart while in backendBusy | banner persists until 10 min wall-clock elapses | banner clears immediately, next sync re-probes |
| User upgrades from old version with stuck backendBusy | banner persists | one-time migration clears it on first launch |

## Test plan
- [ ] Manual: mark backendBusy via debug hook (or hit the trigger condition), kill app, relaunch — banner gone
- [ ] Manual: mark rateLimit (e.g. fair-use 429), kill app, relaunch — banner still there, cooldown still ticking
- [ ] Manual: install build over an older one that had persisted backendBusy state — banner gone after launch
- [ ] No regression in successful-sync flow (banner clears on success)