### PR TITLE
fix(app): compute conversation duration from transcript, not session span

### DIFF
--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -411,7 +411,9 @@ class ServerConversation {
   }
 
   int getDurationInSeconds() {
-    if (finishedAt != null && startedAt != null) {
+    // started_at is the streaming-session origin, not this conversation's start,
+    // so finishedAt - startedAt over-counts; prefer the transcript span (#4056).
+    if (transcriptSegments.isEmpty && finishedAt != null && startedAt != null) {
       return finishedAt!.difference(startedAt!).inSeconds;
     }
     return _getDurationInSecondsByTranscripts();

--- a/app/test/unit/conversation_duration_test.dart
+++ b/app/test/unit/conversation_duration_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+
+TranscriptSegment _segment({required double start, required double end}) {
+  return TranscriptSegment(
+    id: 'seg',
+    text: 'hello',
+    speaker: 'SPEAKER_0',
+    isUser: true,
+    personId: null,
+    start: start,
+    end: end,
+    translations: [],
+  );
+}
+
+ServerConversation _conversation({
+  List<TranscriptSegment> segments = const [],
+  DateTime? startedAt,
+  DateTime? finishedAt,
+}) {
+  return ServerConversation(
+    id: 'test-id',
+    createdAt: DateTime.now(),
+    structured: Structured('Test', 'Test'),
+    transcriptSegments: segments,
+    startedAt: startedAt,
+    finishedAt: finishedAt,
+  );
+}
+
+void main() {
+  group('ServerConversation.getDurationInSeconds()', () {
+    test('uses transcript span when segments exist, not the inflated session timestamp delta', () {
+      // started_at is the streaming-session origin: finishedAt - startedAt is 600s,
+      // but only 12s of speech was transcribed. Duration should reflect the speech.
+      final conv = _conversation(
+        segments: [_segment(start: 0, end: 12)],
+        startedAt: DateTime.utc(2026, 1, 1, 12, 0, 0),
+        finishedAt: DateTime.utc(2026, 1, 1, 12, 10, 0),
+      );
+      expect(conv.getDurationInSeconds(), 12);
+    });
+
+    test('uses the last segment end across multiple segments', () {
+      final conv = _conversation(
+        segments: [_segment(start: 0, end: 8), _segment(start: 8, end: 27)],
+        startedAt: DateTime.utc(2026, 1, 1, 12, 0, 0),
+        finishedAt: DateTime.utc(2026, 1, 1, 12, 30, 0),
+      );
+      expect(conv.getDurationInSeconds(), 27);
+    });
+
+    test('falls back to finishedAt - startedAt when there are no segments', () {
+      final conv = _conversation(
+        startedAt: DateTime.utc(2026, 1, 1, 12, 0, 0),
+        finishedAt: DateTime.utc(2026, 1, 1, 12, 0, 45),
+      );
+      expect(conv.getDurationInSeconds(), 45);
+    });
+
+    test('returns 0 when there are neither segments nor timestamps', () {
+      expect(_conversation().getDurationInSeconds(), 0);
+    });
+
+    // Regression: behavior for these paths is unchanged by the fix.
+    test('with segments but no timestamps, still returns the transcript span', () {
+      final conv = _conversation(segments: [_segment(start: 0, end: 15)]);
+      expect(conv.getDurationInSeconds(), 15);
+    });
+
+    test('with no segments and only one timestamp set, returns 0', () {
+      final conv = _conversation(startedAt: DateTime.utc(2026, 1, 1, 12, 0, 0));
+      expect(conv.getDurationInSeconds(), 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Hello! Thanks for this wonderful omi app and open source software. I opened this draft PR to address this [issue I just re-opened](https://github.com/BasedHardware/omi/issues/4056). Please feel free to comment, open your own PR, or provide any feedback. Please note that I updated the code and PR (mostly refactors, tests, and description changes) after the bot checked this PR.

## Bug
The conversation duration is far longer than the actual conversation. This is happening whether I use my own local STT server or a cloud provider's like Deepgram's. 

`ServerConversation.getDurationInSeconds()` returned `finishedAt - startedAt` whenever both timestamps were set. `started_at` is set to the audio-streaming session origin not to the individual conversation, so for short conversations the displayed duration over-counts by however long the streaming session had been open which is often waylonger than the actual duration.


## Root cause
`getDurationInSeconds()` preferred `finishedAt.difference(startedAt)`. A correct transcript-based calculation already exists (`_getDurationInSecondsByTranscripts()`), but was only used as a fallback when timestamps were null. Because `started_at` reflects when the streaming session opened and persists across conversations until the stream resets, multiple conversations created in one session share an early `started_at`, and processing promptly does not help. I would notice multiple conversations have a similar length of time/duration padding.

## Fix
Prefer the transcript-derived duration when transcript segments exist and keep the `finishedAt - startedAt` delta only as a fallback for segment-less conversations. No API or schema changes and minimal changes in the branching.


## Before / After
For ~10s of speech recorded during a streaming session that had been open ~10 minutes:
- **Before:** ~600s shown
- **After:** ~10s shown

## Verification
- Logic-only change in a model method. No API, type, or generated files affected.
- Reproduced the bug and traced the fix against live conversation data.
- Behavior is provider-independent (observed on both cloud services like Deepgram and local STT).
- Wrote unit tests and regression tests.