### PR TITLE
backend: raise storage_executor pool 96 → 128

### DIFF
--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -61,7 +61,7 @@ llm_executor = MonitoredThreadPoolExecutor(name="llm", max_workers=6, thread_nam
 stripe_executor = MonitoredThreadPoolExecutor(name="stripe", max_workers=4, thread_name_prefix="stripe")
 sync_executor = MonitoredThreadPoolExecutor(name="sync", max_workers=16, thread_name_prefix="sync")
 postprocess_executor = MonitoredThreadPoolExecutor(name="postprocess", max_workers=24, thread_name_prefix="postproc")
-storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=96, thread_name_prefix="storage")
+storage_executor = MonitoredThreadPoolExecutor(name="storage", max_workers=128, thread_name_prefix="storage")
 
 _ALL_EXECUTORS = [
     critical_executor,


### PR DESCRIPTION
## Summary
- Raise `storage_executor` max_workers from 96 → 128 in `backend/utils/executors.py`.

## Why
After the previous round of changes (`minScale=10`, `concurrency=6`, `_PRECACHE_FILE_SEM=2`) the storage pool on `backend-sync` is still pegged at 100% utilization. The queue depth distribution over the past 30 minutes (steady-state on the new revision):

| Percentile | Queue depth |
|---|---:|
| p50 | 19 |
| p95 | 30 |
| p99 | 38 |
| max | 43 |

96 + 32 ≈ **128** cleanly absorbs the observed p95 queue depth. Sync work that was waiting in this queue should drop to near zero in the common case.

## Safety analysis (verified, not assumed)

**Memory:**
- Current memory p99 per instance: 13% of 8 GB
- Linux lazy-commits pthread stacks — virtual address space grows ~64 MB (32 × 2 MB) but actual RSS impact is ~1–2 MB per instance for idle/I/O-bound threads
- Plenty of headroom

**CPU:**
- Current CPU p99 per instance: 84% (bursty, not sustained)
- Storage work is mostly I/O-bound (GCS, network) — Python releases the GIL during blocking syscalls, so additional threads scale with I/O latency, not with CPU
- CPU-bound portion (PCM merge / WAV encoding) is bounded by the 2 vCPU ceiling regardless of thread count

**Cloud Run autoscaler:** unaffected. Autoscales on CPU + request concurrency; thread count is a per-instance knob.

## Test plan
- [ ] Watch `executor_pool_health` warnings on `backend-sync` for 15–30 min post-deploy — storage `max_q` should drop substantially (target: well under 10 in p95)
- [ ] Watch memory utilization — should not exceed 25% per instance even at peak
- [ ] No new 5xx errors on `/v2/sync-local-files` or `/v1/sync/audio/*`
- [ ] If `max_q` still > 10 consistently after this, follow-up bump to 140 (one-line change)