### PR TITLE
Update CHANGELOG.json for v0.11.431 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed editing a conversation title not saving"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.431",
+      "date": "2026-05-29",
+      "changes": [
+        "Fixed editing a conversation title not saving"
+      ]
+    },
     {
       "version": "0.11.429",
       "date": "2026-05-28",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.431 and clears the unreleased array.