### PR TITLE
feat: prod-enable X connector + Settings → Advanced → MCP section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,8 @@ Rules:
 
 #### Self-Testing the App (end-to-end)
 
+**Hard rule: you may not ask the user to verify a feature you have not actually exercised yourself.** Compiling, "looks correct from the code", or "scroll down to see it" are not verification. If the obvious path is blocked (permission, focus, missing tool), try a long sequence of alternatives before involving the user — extend the bridge with a new action, add a temporary in-process hook, search the web for a workaround, grant the missing permission yourself if you can, write a tiny standalone harness. Roughly: spend ten serious attempts across different approaches before you escalate. Asking the user is the last move, not the first.
+
 Agents can and should self-test the running app — don't stop at a successful compile. The fast path skips the slow parts (web login, sidebar click-through):
 
 1. **Build + launch a named bundle:** `OMI_APP_NAME="omi-<feature>" ./run.sh` (add `OMI_SKIP_TUNNEL=1` for a local backend without a tunnel; `OMI_SKIP_BACKEND=1 OMI_DESKTOP_API_URL=…` to point at a remote backend).

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -344,6 +344,21 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: CONVERSATION_SUMMARIZED_APP_IDS
+  - name: X_OAUTH_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: X_OAUTH_CLIENT_ID
+  - name: X_OAUTH_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: X_OAUTH_CLIENT_SECRET
+  - name: X_OAUTH_REDIRECT_URI
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: X_OAUTH_REDIRECT_URI
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -339,6 +339,21 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: METRICS_SECRET
+  - name: X_OAUTH_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: X_OAUTH_CLIENT_ID
+  - name: X_OAUTH_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: X_OAUTH_CLIENT_SECRET
+  - name: X_OAUTH_REDIRECT_URI
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: X_OAUTH_REDIRECT_URI
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
@@ -80,3 +80,9 @@ externalSecret:
       remoteKey: RAPID_API_KEY
     - secretKey: CONVERSATION_SUMMARIZED_APP_IDS
       remoteKey: CONVERSATION_SUMMARIZED_APP_IDS
+    - secretKey: X_OAUTH_CLIENT_ID
+      remoteKey: X_OAUTH_CLIENT_ID
+    - secretKey: X_OAUTH_CLIENT_SECRET
+      remoteKey: X_OAUTH_CLIENT_SECRET
+    - secretKey: X_OAUTH_REDIRECT_URI
+      remoteKey: X_OAUTH_REDIRECT_URI

--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -78,3 +78,9 @@ externalSecret:
       remoteKey: TWILIO_TWIML_APP_SID
     - secretKey: METRICS_SECRET
       remoteKey: METRICS_SECRET
+    - secretKey: X_OAUTH_CLIENT_ID
+      remoteKey: X_OAUTH_CLIENT_ID
+    - secretKey: X_OAUTH_CLIENT_SECRET
+      remoteKey: X_OAUTH_CLIENT_SECRET
+    - secretKey: X_OAUTH_REDIRECT_URI
+      remoteKey: X_OAUTH_REDIRECT_URI

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -139,6 +139,7 @@ def _basic_auth_header() -> Dict[str, str]:
 
 
 async def exchange_code(code: str, verifier: str) -> Dict:
+    logger.info(f'exchange_code: using redirect_uri={X_REDIRECT_URI!r} client_id={X_CLIENT_ID[:8]!r}…')
     data = {
         'grant_type': 'authorization_code',
         'code': code,
@@ -148,6 +149,8 @@ async def exchange_code(code: str, verifier: str) -> Dict:
     }
     async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=3.0)) as client:
         resp = await client.post(TOKEN_URL, data=data, headers=_basic_auth_header())
+        if resp.status_code >= 400:
+            logger.error(f'exchange_code: X returned {resp.status_code}: {resp.text[:500]}')
         resp.raise_for_status()
         return resp.json()
 
@@ -401,13 +404,15 @@ async def sync_x_for_user(uid: str) -> Dict:
     fresh = new_posts if written == len(new_posts) else new_posts[:written]
     # Vector-index the raw posts so agents can semantically search the actual
     # tweets (not just the extracted memories) via the MCP search_x_posts tool.
-    try:
-        upsert_x_post_vectors_batch(
-            uid,
-            [{'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in fresh],
-        )
-    except Exception as e:
-        logger.warning(f'x_connector: failed to index x_posts for uid={uid}: {e}')
+    # Chunk to stay within Pinecone's per-upsert vector limit (~100).
+    items_to_index = [
+        {'post_id': p['id'], 'content': p.get('text', ''), 'kind': p.get('kind', 'tweet')} for p in fresh
+    ]
+    for i in range(0, len(items_to_index), 100):
+        try:
+            upsert_x_post_vectors_batch(uid, items_to_index[i : i + 100])
+        except Exception as e:
+            logger.warning(f'x_connector: failed to index x_posts chunk[{i}:{i+100}] for uid={uid}: {e}')
     memories_created = _extract_and_index(uid, fresh)
 
     users_db.set_integration(

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -146,6 +146,8 @@ class AppState: ObservableObject {
   /// Trigger the monthly-limit popup. Safe to call repeatedly — SwiftUI's
   /// `@Published` dedupes identical-value writes automatically.
   func triggerUsageLimitPopup(reason: String) {
+    // Debug escape hatch for self-test runs that don't want the overage modal in the way.
+    if ProcessInfo.processInfo.environment["OMI_SKIP_USAGE_POPUP"] == "1" { return }
     usageLimitReason = reason
     showUsageLimitPopup = true
   }

--- a/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -128,9 +128,11 @@ struct AppsPage: View {
             // Content
             if appProvider.isLoading {
                 loadingShimmerView
-            } else if appProvider.apps.isEmpty && appProvider.popularApps.isEmpty {
-                emptyView
             } else {
+                // Always render the page (Imports/Exports are local connectors
+                // and must show even when the marketplace API returned no apps).
+                // The marketplace sections inside the else branch are each
+                // self-gated and skip when empty.
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 24) {
                         if !searchText.isEmpty || hasActiveFilters {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -380,6 +380,11 @@ struct SettingsContentView: View {
   @State private var byokKeyStatuses: [BYOKProvider: BYOKValidator.Status] = [:]
   @State private var byokActivationError: String?
 
+  // MCP key creation state (Settings → Advanced → MCP)
+  @State private var mcpCreatedKey: String?
+  @State private var mcpIsCreatingKey: Bool = false
+  @State private var mcpError: String?
+
   init(
     appState: AppState,
     selectedSection: Binding<SettingsSection>,
@@ -3285,8 +3290,148 @@ struct SettingsContentView: View {
       advancedCategoryHeader(title: "Developer API Keys", icon: "key")
       developerKeysSubsection
 
+      advancedCategoryHeader(title: "MCP", icon: "antenna.radiowaves.left.and.right")
+      mcpSubsection
+
       advancedCategoryHeader(title: "Dev Tools", icon: "hammer")
       devToolsSubsection
+    }
+  }
+
+  // MARK: - MCP Subsection
+
+  private var mcpSubsection: some View {
+    VStack(spacing: 20) {
+      // Server URL — channel-aware (beta hits dev backend, stable hits prod).
+      settingsCard(settingId: "advanced.mcp.serverurl") {
+        VStack(alignment: .leading, spacing: 8) {
+          HStack(spacing: 10) {
+            Image(systemName: "link")
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.textSecondary)
+            Text("Server URL")
+              .scaledFont(size: 14, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+            Spacer()
+            Button {
+              NSPasteboard.general.clearContents()
+              NSPasteboard.general.setString(MemoryExportDestination.mcpServerURL, forType: .string)
+            } label: {
+              HStack(spacing: 6) {
+                Image(systemName: "doc.on.doc")
+                Text("Copy")
+              }
+              .scaledFont(size: 12, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+              .padding(.horizontal, 10)
+              .padding(.vertical, 6)
+              .background(
+                RoundedRectangle(cornerRadius: 8).fill(OmiColors.backgroundQuaternary.opacity(0.6)))
+            }
+            .buttonStyle(.plain)
+          }
+          Text(MemoryExportDestination.mcpServerURL)
+            .scaledFont(size: 12, weight: .medium)
+            .foregroundColor(OmiColors.textSecondary)
+            .textSelection(.enabled)
+          Text(
+            AppBuild.currentUpdateChannel == "beta"
+              ? "Beta channel — points at the dev backend."
+              : "Stable channel — points at production."
+          )
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+        }
+      }
+
+      // Create an MCP key — shown once after creation; user copies + pastes into Claude/ChatGPT/etc.
+      settingsCard(settingId: "advanced.mcp.createkey") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack(spacing: 10) {
+            Image(systemName: "key.fill")
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.textSecondary)
+            VStack(alignment: .leading, spacing: 2) {
+              Text("MCP API Key")
+                .scaledFont(size: 14, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+              Text("Use this key as the OAuth Client Secret in Claude/ChatGPT/your agent.")
+                .scaledFont(size: 11)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+            Spacer()
+            Button {
+              Task { await createMCPKeyFromSettings() }
+            } label: {
+              Text(mcpIsCreatingKey ? "Creating…" : "Create Key")
+                .scaledFont(size: 12, weight: .medium)
+                .foregroundColor(.black)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.white))
+            }
+            .buttonStyle(.plain)
+            .disabled(mcpIsCreatingKey)
+          }
+
+          if let key = mcpCreatedKey {
+            VStack(alignment: .leading, spacing: 8) {
+              Text("Copy this now — it's only shown once.")
+                .scaledFont(size: 11)
+                .foregroundColor(OmiColors.warning)
+              HStack(spacing: 8) {
+                Text(key)
+                  .scaledFont(size: 12, weight: .medium)
+                  .foregroundColor(OmiColors.textPrimary)
+                  .textSelection(.enabled)
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                Button {
+                  NSPasteboard.general.clearContents()
+                  NSPasteboard.general.setString(key, forType: .string)
+                } label: {
+                  Image(systemName: "doc.on.doc")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textPrimary)
+                    .padding(6)
+                    .background(
+                      RoundedRectangle(cornerRadius: 6)
+                        .fill(OmiColors.backgroundQuaternary.opacity(0.6)))
+                }
+                .buttonStyle(.plain)
+              }
+              .padding(10)
+              .background(
+                RoundedRectangle(cornerRadius: 8)
+                  .fill(OmiColors.backgroundSecondary.opacity(0.6)))
+            }
+          }
+
+          if let err = mcpError {
+            HStack(spacing: 8) {
+              Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(OmiColors.warning)
+              Text(err)
+                .scaledFont(size: 11)
+                .foregroundColor(OmiColors.warning)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @MainActor
+  private func createMCPKeyFromSettings() async {
+    mcpError = nil
+    mcpIsCreatingKey = true
+    defer { mcpIsCreatingKey = false }
+    do {
+      let key = try await APIClient.shared.createMCPKey(name: "Desktop")
+      mcpCreatedKey = key
+    } catch {
+      mcpError = "Couldn't create key: \(error.localizedDescription)"
     }
   }
 

--- a/desktop/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/Desktop/Sources/MemoryExportService.swift
@@ -12,8 +12,18 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
 
   var id: String { rawValue }
 
-  /// The hosted Omi MCP endpoint every client connects to.
-  static let mcpServerURL = "https://api.omi.me/v1/mcp/sse"
+  /// Base of the hosted Omi API for this build — stable channel hits prod
+  /// (api.omi.me), beta hits dev (api.omiapi.com). Always ends with "/".
+  static var mcpBaseURL: String {
+    DesktopBackendEnvironment.pythonBaseURL()
+  }
+
+  /// The hosted Omi MCP SSE endpoint every client connects to.
+  static var mcpServerURL: String { "\(mcpBaseURL)v1/mcp/sse" }
+
+  /// OAuth endpoints exposed by the same backend for MCP custom-connector setup.
+  static var mcpAuthorizeURL: String { "\(mcpBaseURL)authorize" }
+  static var mcpTokenURL: String { "\(mcpBaseURL)token" }
 
   var title: String {
     switch self {
@@ -188,7 +198,7 @@ enum MemoryExportDestination: String, CaseIterable, Identifiable, Sendable {
           "Open ChatGPT → Settings → Apps → Advanced, enable Developer mode",
           "Create app → name it “Omi Memory” and paste the server URL below",
           "Authentication: OAuth. In Advanced OAuth settings set Client ID “omi”, Client Secret to your key, token auth method “client_secret_post”",
-          "Auth URL: https://api.omi.me/authorize · Token URL: https://api.omi.me/token",
+          "Auth URL: \(Self.mcpAuthorizeURL) · Token URL: \(Self.mcpTokenURL)",
           "Create, then Connect. Syncs to ChatGPT desktop + mobile automatically.",
         ],
         openURL: URL(string: "https://chatgpt.com/"),


### PR DESCRIPTION
## What

Wires the X connector for **both dev and prod** environments and adds a **MCP** section to desktop **Settings → Advanced** (mirroring mobile).

## Backend (Helm + secrets)
- `backend-secrets` (dev + prod): added `X_OAUTH_CLIENT_ID` / `X_OAUTH_CLIENT_SECRET` / `X_OAUTH_REDIRECT_URI` to the externalSecret `secretKeys`.
- `backend-listen` (dev + prod): wired them as env vars from the synced K8s secret.
- Secrets already created in **GCP Secret Manager** for `based-hardware-dev` and `based-hardware`.
- **Prod** redirect URI registered in the X developer app: `https://api.omi.me/v1/x/oauth/callback`. Dev was already registered.

## Backend (`utils/x_connector.py`)
- Chunked `upsert_x_post_vectors_batch` into **100-vector batches** — Pinecone's per-request limit was returning 400 on ~512-post imports, the whole raw-post index step was silently failing (`semantic search_x_posts returned empty`). Fixed.
- Log X's token-endpoint response body on exchange failure so OAuth issues are diagnosable from logs.

## Desktop
- **`MemoryExportService.mcpServerURL` is now channel-aware** via `DesktopBackendEnvironment.pythonBaseURL()`. So:
  - **Stable** → `https://api.omi.me/v1/mcp/sse`
  - **Beta** (prod bundle on beta channel) → `https://api.omiapi.com/v1/mcp/sse`
  Same for the ChatGPT MCP setup's `auth/token` URLs that were hardcoded to prod.
- **`SettingsPage.swift` — new "MCP" subsection** in Settings → Advanced with the channel-aware server URL (+ Copy + Stable/Beta hint) and a **Create Key** button calling `APIClient.createMCPKey`, surfacing the full key once for paste into Claude/ChatGPT/Hermes/etc.
- **`AppsPage.swift`** — Imports/Exports sections now **always render** — the early empty-state branch was hiding them whenever the marketplace returned no apps (e.g. with `OMI_SKIP_BACKEND` or a fresh dev tenant), even though the connectors are local.
- **`AppState.swift`** — small debug escape hatch (`OMI_SKIP_USAGE_POPUP=1`) so agent self-test runs can drive the Apps page without the overage modal blocking input.

## AGENTS.md
- Self-Testing section now opens with a **hard rule**: agents may not hand off verification to the user before exercising the feature themselves; try ~10 unblocking approaches first.

## Verified
- Backend OAuth + ingest end-to-end on a real X account: token exchange OK, 4 pages tweets + 2 pages bookmarks via `api.x.com`, **512 posts** saved, **91 memories** extracted + indexed.
- `search_x_posts` MCP tool returns relevant tweets (e.g. "immigration visa" → visa replies ranked 0.44).
- Settings → Advanced → MCP card renders the right channel-aware URL.
- Apps page shows "X (Twitter) — Sync now" (= connected state) after a sync.
- Clean release build (arm64) green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)