### PR TITLE
fix(desktop): reduce group chat task false positives

### DIFF
--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
@@ -170,6 +170,14 @@ class TaskAssistantSettings {
         - Questions expecting an answer: "What's the status of…?", "When will you…?"
         - Assigned items: "@user", "assigned to you", review requests
 
+        CRITICAL FOR PUBLIC/GROUP CHANNELS:
+        In Discord, Slack, Teams, community chats, and other public/group channels, extract ONLY when the visible evidence shows the user is directly involved:
+        - The message explicitly @mentions the user by name or handle
+        - It is a direct message (DM) thread, not a public or community channel
+        - The user has already replied in the same thread and is an active participant
+        If the user is merely observing a public channel, or if you cannot tell whether the request is directed at them, call no_task_found.
+        Do NOT extract tasks from broad bug reports, feature requests, or questions posted to the community at large.
+
         WHO COUNTS AS "SOMEONE":
         - A coworker in Slack, Teams, Discord, email
         - A friend/family member in iMessage, WhatsApp, Telegram, Messenger

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
@@ -173,8 +173,8 @@ class TaskAssistantSettings {
         CRITICAL FOR PUBLIC/GROUP CHANNELS:
         In Discord, Slack, Teams, community chats, and other public/group channels, extract ONLY when the visible evidence shows the user is directly involved:
         - The message explicitly @mentions the user by name or handle
-        - It is a direct message (DM) thread, not a public or community channel
         - The user has already replied in the same thread and is an active participant
+        - The message is otherwise clearly addressed to the user by name, role, or visible thread context
         If the user is merely observing a public channel, or if you cannot tell whether the request is directed at them, call no_task_found.
         Do NOT extract tasks from broad bug reports, feature requests, or questions posted to the community at large.
 

--- a/desktop/Desktop/Tests/TaskAssistantPromptTests.swift
+++ b/desktop/Desktop/Tests/TaskAssistantPromptTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Omi_Computer
+
+final class TaskAssistantPromptTests: XCTestCase {
+    @MainActor
+    func testDefaultPromptSkipsPublicChannelRequestsNotDirectedAtUser() {
+        let prompt = TaskAssistantSettings.defaultAnalysisPrompt
+
+        XCTAssertTrue(prompt.contains("CRITICAL FOR PUBLIC/GROUP CHANNELS"))
+        XCTAssertTrue(prompt.contains("visible evidence shows the user is directly involved"))
+        XCTAssertTrue(prompt.contains("call no_task_found"))
+        XCTAssertTrue(prompt.contains("questions posted to the community at large"))
+    }
+}

--- a/desktop/Desktop/Tests/TaskAssistantPromptTests.swift
+++ b/desktop/Desktop/Tests/TaskAssistantPromptTests.swift
@@ -8,7 +8,10 @@ final class TaskAssistantPromptTests: XCTestCase {
 
         XCTAssertTrue(prompt.contains("CRITICAL FOR PUBLIC/GROUP CHANNELS"))
         XCTAssertTrue(prompt.contains("visible evidence shows the user is directly involved"))
-        XCTAssertTrue(prompt.contains("call no_task_found"))
+        XCTAssertTrue(prompt.contains("merely observing a public channel"))
+        XCTAssertTrue(prompt.contains("cannot tell whether the request is directed at them"))
+        XCTAssertTrue(prompt.contains("otherwise clearly addressed to the user"))
         XCTAssertTrue(prompt.contains("questions posted to the community at large"))
+        XCTAssertFalse(prompt.contains("It is a direct message (DM) thread, not a public or community channel"))
     }
 }


### PR DESCRIPTION
Bot fit:
- For desktop: yes
- Bug fix: yes

Summary:
- Tightens task extraction prompt for public/group channels.
- Requires visible direct user involvement before extracting a task from community channels.
- Adds a regression test that the default prompt includes the no_task_found guard.

Tests:
- git diff --check origin/main..HEAD
- xcrun swift test --package-path Desktop --filter TaskAssistantPromptTests

Notes:
- Focused test passes; build/test output still includes existing upstream Swift 6/deprecation warnings and libwebp link target warning.