### PR TITLE
ci: auto-sync backend secrets to GKE + Cloud Run on chart changes

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -116,6 +116,18 @@ jobs:
           region: ${{ env.REGION }}
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
 
+      # Mirror every secret declared in the backend-secrets chart into the
+      # three Cloud Run revisions (additive). GKE picks them up via the helm
+      # chart's ExternalSecret + deployment env refs; Cloud Run needs the
+      # matching --update-secrets bindings. Without this, a new chart key
+      # ships to GKE but stays undefined on Cloud Run, and the new code
+      # reads None even though everything looks deployed.
+      - name: Sync Cloud Run secrets from backend-secrets chart
+        run: |
+          curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          bash backend/scripts/sync_cloudrun_secrets_from_chart.sh ${{ vars.ENV }} backend backend-sync backend-integration
+
       # If required, use the Cloud Run url output in later steps
       - name: Show Output
         run: echo ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/gcp_backend_auto_dev.yml
+++ b/.github/workflows/gcp_backend_auto_dev.yml
@@ -64,6 +64,18 @@ jobs:
             SERVICE_ACCOUNT_JSON=SERVICE_ACCOUNT_JSON:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
 
+      # Mirror every secret declared in backend-secrets chart into Cloud Run
+      # (additive). The GKE pods get them via the helm chart's ExternalSecret;
+      # Cloud Run needs the matching --update-secrets bindings. Without this,
+      # a new chart key (e.g. X_OAUTH_CLIENT_ID) ships to GKE but stays
+      # undefined on the Cloud Run revisions that api.omi.me / api.omiapi.com
+      # actually serve, and the new code reads None.
+      - name: Sync Cloud Run secrets from backend-secrets chart
+        run: |
+          curl -sL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          bash backend/scripts/sync_cloudrun_secrets_from_chart.sh dev backend backend-sync backend-integration
+
       - name: Deploy ${{ env.SERVICE }}-sync to Cloud Run
         id: deploy-backend-sync
         uses: google-github-actions/deploy-cloudrun@v2

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -1,6 +1,13 @@
 name: Upgrade Backend Listen Helm Chart
 
 on:
+  # Auto-apply when chart values or templates change on main, so new secret
+  # bindings / env-var references ship to GKE without a manual workflow_dispatch.
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'backend/charts/backend-listen/**'
+      - 'backend/charts/backend-secrets/**'
   workflow_dispatch:
     inputs:
       environment:
@@ -17,7 +24,9 @@ env:
 
 jobs:
   helm-upgrade:
-    environment: ${{ github.event.inputs.environment }}
+    # On manual dispatch use the chosen environment; on auto push only deploy
+    # to dev (prod still requires an explicit workflow_dispatch for safety).
+    environment: ${{ github.event.inputs.environment || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -25,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Environment Input
+        if: github.event_name == 'workflow_dispatch'
         run: |
           if [[ "${{ github.event.inputs.environment }}" != "development" && "${{ github.event.inputs.environment }}" != "prod" ]]; then
             echo "Invalid environment: ${{ github.event.inputs.environment }}. Must be 'development' or 'prod'."
@@ -34,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Install Helm
         uses: azure/setup-helm@v3
@@ -62,6 +72,23 @@ jobs:
             ./backend/charts/backend-listen \
             -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
             --dry-run
+
+      # The ExternalSecret resource (which tells external-secrets which GCP
+      # Secret Manager keys to sync into the K8s `*-omi-backend-secrets`
+      # secret) lives in this chart. Without re-applying it, a new chart key
+      # never reaches K8s, and the deployment's secretKeyRef resolves to an
+      # empty value — code reads os.getenv(...) as None.
+      - name: Upgrade backend-secrets Helm chart
+        run: |
+          helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-secrets \
+            ./backend/charts/backend-secrets \
+            -f ./backend/charts/backend-secrets/${{ vars.ENV }}_omi_backend_secrets_values.yaml
+          # Trigger an immediate sync so newly-listed keys are pulled before the
+          # listen deployment restarts (otherwise its env refs resolve empty).
+          kubectl -n ${{ vars.ENV }}-omi-backend annotate externalsecret \
+            ${{ vars.ENV }}-omi-backend-external-secret \
+            force-sync="$(date +%s)" --overwrite
+          sleep 10
 
       - name: Upgrade backend-listen Helm chart
         run: |

--- a/backend/scripts/sync_cloudrun_secrets_from_chart.sh
+++ b/backend/scripts/sync_cloudrun_secrets_from_chart.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Sync all secret env-var bindings from the backend-secrets Helm chart values
+# file into the Cloud Run backend service(s) for a given environment.
+#
+# Background: api.omi.me / api.omiapi.com route to Cloud Run services that
+# have their OWN env-var configuration, separate from the GKE backend-listen
+# pods. Adding a new key to backend-secrets/{env}_omi_backend_secrets_values.yaml
+# updates the K8s ExternalSecret (via helm), but Cloud Run won't see it until
+# someone runs `gcloud run services update --update-secrets …` for each service.
+# This script does that automatically from the chart's `externalSecret.secretKeys`
+# list, so every chart change reliably propagates.
+#
+# Usage:
+#   sync_cloudrun_secrets_from_chart.sh <env> [<service> …]
+#
+#   env       one of: dev | prod
+#   services  defaults to: backend backend-sync backend-integration
+#
+# Requires: yq (mikefarah), gcloud authed for the target project.
+
+set -euo pipefail
+
+ENV="${1:-}"
+shift || true
+SERVICES=("${@:-backend backend-sync backend-integration}")
+
+case "$ENV" in
+  dev)
+    PROJECT="based-hardware-dev"
+    VALUES_FILE="backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml"
+    ;;
+  prod)
+    PROJECT="based-hardware"
+    VALUES_FILE="backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml"
+    ;;
+  *)
+    echo "usage: $0 <dev|prod> [<service> …]" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "yq (mikefarah) is required: https://github.com/mikefarah/yq" >&2
+  exit 2
+fi
+
+# Build "K=GCP_KEY:latest,K2=GCP_KEY2:latest,…" from the chart's secretKeys list.
+SECRETS_FLAG=$(
+  yq -r '.externalSecret.secretKeys[] | "\(.secretKey)=\(.remoteKey):latest"' "$VALUES_FILE" \
+    | paste -sd "," -
+)
+
+if [ -z "$SECRETS_FLAG" ]; then
+  echo "No secretKeys found in $VALUES_FILE" >&2
+  exit 1
+fi
+
+echo "Project: $PROJECT"
+echo "Services: ${SERVICES[*]}"
+echo "Secrets to sync ($(echo "$SECRETS_FLAG" | tr ',' '\n' | wc -l | tr -d ' ')): $(echo "$SECRETS_FLAG" | cut -d, -f1-3)…"
+
+for SVC in "${SERVICES[@]}"; do
+  echo ""
+  echo "▶ $SVC"
+  gcloud run services update "$SVC" \
+    --project="$PROJECT" \
+    --region="us-central1" \
+    --update-secrets="$SECRETS_FLAG" \
+    --quiet
+done


### PR DESCRIPTION
## Why

A new key in `backend/charts/backend-secrets/{env}_values.yaml` on its own does **nothing** — three separate things have to happen before the code reads it as non-empty:

1. **backend-secrets** chart re-applied → ExternalSecret learns the new key, operator syncs it into the K8s secret.
2. **backend-listen** chart re-applied → Deployment env-var ref points at the new key, pod restarts.
3. **Cloud Run** services (`backend`, `backend-sync`, `backend-integration`) get the matching `--update-secrets` binding — these are what `api.omi.me` / `api.omiapi.com` actually serve, and they have their own env config entirely separate from GKE.

Today none of those auto-fire on a chart edit. The X connector PR (#7535) shipped the chart and the code, the auto-deploy updated the Docker image — and the new code still read `X_OAUTH_CLIENT_ID=None` on every revision, so Connect X silently did nothing for beta users.

## Changes

- **`gcp_backend_listen_helm.yml`**: also triggers on `push` to main when `backend/charts/backend-listen/**` or `backend/charts/backend-secrets/**` change (auto-deploys to **dev**; prod still requires explicit `workflow_dispatch` for safety). It now applies **backend-secrets first**, force-syncs the ExternalSecret, then applies backend-listen — so the new K8s secret keys exist before the deployment rolls. Validation/inputs gated to the dispatch path so push events work.
- **`gcp_backend_auto_dev.yml`** + **`gcp_backend.yml`**: after the `deploy-cloudrun` steps, run `backend/scripts/sync_cloudrun_secrets_from_chart.sh`. It's an **additive** `gcloud run services update --update-secrets` pulled directly from the chart's `externalSecret.secretKeys`, so every chart key is also bound on Cloud Run without anyone touching workflow yaml.
- **`backend/scripts/sync_cloudrun_secrets_from_chart.sh`**: reads the per-environment backend-secrets values file with `yq` and applies it to the three Cloud Run services. Uses `--update-secrets` (additive), so existing bindings (`SERVICE_ACCOUNT_JSON`, `ENCRYPTION_SECRET`) that the chart doesn't enumerate stay intact.

## Net effect

A future contributor adding `- secretKey: FOO` to the chart and pushing to main automatically gets `FOO` synced into both **GKE** and **Cloud Run**. No more "merged but still reads None".

The immediate dev + prod state has already been fixed manually for the X connector secrets, so this just future-proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)