### PR TITLE
ci: replace PAT_TOKEN with GitHub App token (Omi Bot)

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -161,12 +161,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate Omi Bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.OMI_BOT_APP_ID }}
+          private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
+
       - name: Wait for previous desktop release build
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "PAT_TOKEN is not configured; cannot inspect previous release build status."
+            echo "Omi Bot token not available; cannot inspect previous release build status."
             exit 1
           fi
 
@@ -276,10 +283,10 @@ jobs:
 
       - name: Create and auto-merge PR to sync changelog back to main
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "PAT_TOKEN is not configured; cannot auto-merge changelog PR."
+            echo "Omi Bot token not available; cannot auto-merge changelog PR."
             exit 1
           fi
 

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -84,10 +84,17 @@ jobs:
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
 
+      - name: Generate Omi Bot token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.OMI_BOT_APP_ID }}
+          private-key: ${{ secrets.OMI_BOT_PRIVATE_KEY }}
+
       - name: Auto-merge PR
         if: steps.create_pr.outputs.pull-request-operation == 'created'
         run: |
           gh pr merge --squash --delete-branch --admin "$PR_URL"
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ steps.create_pr.outputs.pull-request-url }}


### PR DESCRIPTION
## Summary
- Replaces `secrets.PAT_TOKEN` (long-lived personal access token) with short-lived GitHub App tokens via `actions/create-github-app-token@v1` in all 3 locations
- Automated PRs will appear as `omi-bot[bot]` instead of @beastoin
- Tokens are auto-rotated (1h lifetime), scoped to this repo only

## Changes
| Workflow | Location | Before | After |
|---|---|---|---|
| `desktop_auto_release.yml` | L166 (check previous build) | `secrets.PAT_TOKEN` | `steps.app-token.outputs.token` |
| `desktop_auto_release.yml` | L279 (create+merge changelog PR) | `secrets.PAT_TOKEN` | `steps.app-token.outputs.token` |
| `sync-docs.yml` | L92 (auto-merge docs PR) | `secrets.PAT_TOKEN` | `steps.app-token.outputs.token` |

## Prerequisites (before merging)
1. **Create** a private GitHub App named "Omi Bot" in BasedHardware org settings
   - Permissions: `contents: write`, `pull_requests: write`, `checks: read`, `administration: write`
2. **Install** the app on `BasedHardware/omi`
3. **Add repo secrets**: `OMI_BOT_APP_ID` and `OMI_BOT_PRIVATE_KEY`
4. After merge: delete the `PAT_TOKEN` secret

Closes #7275

---
_by AI for @beastoin_