### PR TITLE
docs: minor copy edit in Python SDK page

### DIFF
--- a/docs/doc/developer/sdk/python.mdx
+++ b/docs/doc/developer/sdk/python.mdx
@@ -207,7 +207,7 @@ pip install -e ".[dev]"
 
 ## License
 
-MIT License — this is an unofficial SDK built by the community.
+MIT License — built by the community.
 
 ---
 


### PR DESCRIPTION
Trivial docs edit to test Omi CI Bot app token integration (#7275).

The `sync-docs.yml` workflow should trigger on merge and the auto-merge PR should appear as `omi-ci-bot[bot]` instead of @beastoin.