### PR TITLE
fix(desktop): slim floating bar prompt context

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -383,7 +383,7 @@ final class AgentPillsManager: ObservableObject {
                 pill.query,
                 model: pill.model,
                 systemPromptSuffix: systemPromptSuffix,
-                systemPromptPrefix: ChatProvider.floatingBarSystemPromptPrefix,
+                systemPromptStyle: .floating,
                 sessionKey: "agent-\(pill.id.uuidString)"
             )
             self.complete(pill: pill, provider: provider)

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1707,7 +1707,7 @@ class FloatingControlBarManager {
             message,
             model: floatingModel,
             systemPromptSuffix: notificationContextSuffix,
-            systemPromptPrefix: ChatProvider.floatingBarSystemPromptPrefix,
+            systemPromptStyle: .floating,
             sessionKey: floatingSessionKey,
             imageData: screenshotData
         )

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -458,10 +458,23 @@ enum ChatMode: String, CaseIterable {
     case act
 }
 
+enum ChatSystemPromptStyle {
+    case main
+    case floating
+}
+
 /// State management for chat functionality with Claude Agent SDK
 /// Uses hybrid architecture: Swift → Claude Agent (via Node.js bridge) for AI, Backend for persistence + context
 @MainActor
 class ChatProvider: ObservableObject {
+
+    private enum PromptProfile {
+        case main
+        case floating
+
+        var includesDatabaseSchema: Bool { self == .main }
+        var includesSkills: Bool { self == .main }
+    }
 
     // MARK: - Floating Bar System Prompt Prefix
     /// Static prefix injected at the top of the system prompt for floating bar sessions.
@@ -651,6 +664,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// Conversation history from before app launch IS included (via buildConversationHistory());
     /// after session/new the ACP SDK tracks ongoing history natively.
     private var cachedMainSystemPrompt: String = ""
+    private var cachedFloatingSystemPrompt: String = ""
 
     // MARK: - CLAUDE.md & Skills (Global)
     @Published var claudeMdContent: String?
@@ -914,12 +928,14 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             )
             // Pre-warm ACP sessions with their respective system prompts.
             // This is the only place the system prompt is built and applied.
-            let mainSystemPrompt = buildSystemPrompt(contextString: formatMemoriesSection())
-            let floatingSystemPrompt = Self.floatingBarSystemPromptPrefix + "\n\n" + mainSystemPrompt
+            let promptContext = formatMemoriesSection()
+            let mainSystemPrompt = buildSystemPrompt(contextString: promptContext, profile: .main)
+            let floatingSystemPrompt = buildFloatingBarSystemPrompt(contextString: promptContext)
             let floatingModel = ShortcutSettings.shared.selectedModel.isEmpty
                 ? ModelQoS.Claude.defaultSelection
                 : ShortcutSettings.shared.selectedModel
             cachedMainSystemPrompt = mainSystemPrompt
+            cachedFloatingSystemPrompt = floatingSystemPrompt
             await agentBridge.warmupSession(cwd: workingDirectory, sessions: [
                 .init(key: "main", model: ModelQoS.Claude.chat, systemPrompt: mainSystemPrompt),
                 .init(key: "floating", model: floatingModel, systemPrompt: floatingSystemPrompt)
@@ -1618,7 +1634,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// Called once at warmup (via ensureBridgeStarted) and cached in cachedMainSystemPrompt.
     /// Conversation history is injected here so the brand-new ACP session starts with context
     /// from before the app launch. After session/new the ACP SDK owns history natively.
-    private func buildSystemPrompt(contextString: String) -> String {
+    private func buildSystemPrompt(contextString: String, profile: PromptProfile) -> String {
         // Get user name from AuthService
         let userName = AuthService.shared.displayName.isEmpty ? "there" : AuthService.shared.givenName
 
@@ -1638,7 +1654,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             goalSection: goalSection,
             tasksSection: tasksSection,
             aiProfileSection: aiProfileSection,
-            databaseSchema: cachedDatabaseSchema
+            databaseSchema: profile.includesDatabaseSchema ? cachedDatabaseSchema : ""
         )
 
         // Inject conversation history so the new ACP session has context from before app launch.
@@ -1662,7 +1678,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         // Append enabled skills as available context (global + project)
         // dev-mode is included in the list when devModeEnabled; full content loaded on demand via load_skill
         let enabledSkillNames = getEnabledSkillNames()
-        if !enabledSkillNames.isEmpty {
+        if profile.includesSkills && !enabledSkillNames.isEmpty {
             let allSkills = discoveredSkills + projectDiscoveredSkills
             let skillNames = allSkills
                 .filter { enabledSkillNames.contains($0.name) && ($0.name != "dev-mode" || devModeEnabled) }
@@ -1678,7 +1694,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         let historyInjected = !history.isEmpty
         let historyMessages = messages.filter { !$0.text.isEmpty && !$0.isStreaming }
         let historyCount = min(historyMessages.count, 20)
-        log("ChatProvider: prompt built — schema: \(!cachedDatabaseSchema.isEmpty ? "yes" : "no"), goals: \(activeGoalCount), tasks: \(cachedTasks.count), ai_profile: \(!cachedAIProfile.isEmpty ? "yes" : "no"), memories: \(cachedMemories.count), history: \(historyInjected ? "injected (\(historyCount) msgs)" : "none"), claude_md: \(claudeMdEnabled && claudeMdContent != nil ? "yes" : "no"), project_claude_md: \(projectClaudeMdEnabled && projectClaudeMdContent != nil ? "yes" : "no"), skills: \(enabledSkillNames.count), dev_mode_in_skills: \(devModeEnabled && devModeContext != nil ? "yes" : "no"), prompt_length: \(prompt.count) chars")
+        log("ChatProvider: prompt built — schema: \(profile.includesDatabaseSchema && !cachedDatabaseSchema.isEmpty ? "yes" : "no"), goals: \(activeGoalCount), tasks: \(cachedTasks.count), ai_profile: \(!cachedAIProfile.isEmpty ? "yes" : "no"), memories: \(cachedMemories.count), history: \(historyInjected ? "injected (\(historyCount) msgs)" : "none"), claude_md: \(claudeMdEnabled && claudeMdContent != nil ? "yes" : "no"), project_claude_md: \(projectClaudeMdEnabled && projectClaudeMdContent != nil ? "yes" : "no"), skills: \(profile.includesSkills ? enabledSkillNames.count : 0), dev_mode_in_skills: \(profile.includesSkills && devModeEnabled && devModeContext != nil ? "yes" : "no"), prompt_length: \(prompt.count) chars")
 
         // Log per-section character breakdown
         let baseTemplate = ChatPromptBuilder.buildDesktopChat(
@@ -1693,13 +1709,21 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             "goals:\(goalSection.count)c, " +
             "tasks:\(tasksSection.count)c, " +
             "ai_profile:\(aiProfileSection.count)c, " +
-            "schema:\(cachedDatabaseSchema.count)c, " +
+            "schema:\(profile.includesDatabaseSchema ? cachedDatabaseSchema.count : 0)c, " +
             "history:\(history.count)c, " +
             "claude_md:\(claudeMdContent?.count ?? 0)c, " +
             "project_claude_md:\(projectClaudeMdContent?.count ?? 0)c, " +
-            "skills:\(skillsSectionSize)c")
+            "skills:\(profile.includesSkills ? skillsSectionSize : 0)c")
 
         return prompt
+    }
+
+    private func buildFloatingBarSystemPrompt(contextString: String) -> String {
+        let prompt = buildSystemPrompt(
+            contextString: contextString,
+            profile: .floating
+        )
+        return Self.floatingBarSystemPromptPrefix + "\n\n" + prompt
     }
 
     /// Build system prompt for task chat sessions.
@@ -2432,7 +2456,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// - Parameters:
     ///   - text: The message text
     ///   - model: Optional model override for this query (e.g. "claude-sonnet-4-6" for floating bar)
-    func sendMessage(_ text: String, model: String? = nil, isFollowUp: Bool = false, systemPromptSuffix: String? = nil, systemPromptPrefix: String? = nil, sessionKey: String? = nil, resume: String? = nil, imageData: Data? = nil) async {
+    func sendMessage(_ text: String, model: String? = nil, isFollowUp: Bool = false, systemPromptSuffix: String? = nil, systemPromptPrefix: String? = nil, systemPromptStyle: ChatSystemPromptStyle = .main, sessionKey: String? = nil, resume: String? = nil, imageData: Data? = nil) async {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return }
 
@@ -2616,7 +2640,13 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 // with the onboarding deep-dive step.
                 systemPrompt = prefix
             } else {
-                systemPrompt = cachedMainSystemPrompt
+                if systemPromptStyle == .floating {
+                    systemPrompt = cachedFloatingSystemPrompt.isEmpty
+                        ? buildFloatingBarSystemPrompt(contextString: formatMemoriesSection())
+                        : cachedFloatingSystemPrompt
+                } else {
+                    systemPrompt = cachedMainSystemPrompt
+                }
                 if let prefix = systemPromptPrefix, !prefix.isEmpty {
                     systemPrompt = prefix + "\n\n" + systemPrompt
                 }

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -461,20 +461,15 @@ enum ChatMode: String, CaseIterable {
 enum ChatSystemPromptStyle {
     case main
     case floating
+
+    var includesDatabaseSchema: Bool { self == .main }
+    var includesSkills: Bool { self == .main }
 }
 
 /// State management for chat functionality with Claude Agent SDK
 /// Uses hybrid architecture: Swift → Claude Agent (via Node.js bridge) for AI, Backend for persistence + context
 @MainActor
 class ChatProvider: ObservableObject {
-
-    private enum PromptProfile {
-        case main
-        case floating
-
-        var includesDatabaseSchema: Bool { self == .main }
-        var includesSkills: Bool { self == .main }
-    }
 
     // MARK: - Floating Bar System Prompt Prefix
     /// Static prefix injected at the top of the system prompt for floating bar sessions.
@@ -929,7 +924,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             // Pre-warm ACP sessions with their respective system prompts.
             // This is the only place the system prompt is built and applied.
             let promptContext = formatMemoriesSection()
-            let mainSystemPrompt = buildSystemPrompt(contextString: promptContext, profile: .main)
+            let mainSystemPrompt = buildSystemPrompt(contextString: promptContext, style: .main)
             let floatingSystemPrompt = buildFloatingBarSystemPrompt(contextString: promptContext)
             let floatingModel = ShortcutSettings.shared.selectedModel.isEmpty
                 ? ModelQoS.Claude.defaultSelection
@@ -1634,7 +1629,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     /// Called once at warmup (via ensureBridgeStarted) and cached in cachedMainSystemPrompt.
     /// Conversation history is injected here so the brand-new ACP session starts with context
     /// from before the app launch. After session/new the ACP SDK owns history natively.
-    private func buildSystemPrompt(contextString: String, profile: PromptProfile) -> String {
+    private func buildSystemPrompt(contextString: String, style: ChatSystemPromptStyle) -> String {
         // Get user name from AuthService
         let userName = AuthService.shared.displayName.isEmpty ? "there" : AuthService.shared.givenName
 
@@ -1654,7 +1649,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             goalSection: goalSection,
             tasksSection: tasksSection,
             aiProfileSection: aiProfileSection,
-            databaseSchema: profile.includesDatabaseSchema ? cachedDatabaseSchema : ""
+            databaseSchema: style.includesDatabaseSchema ? cachedDatabaseSchema : ""
         )
 
         // Inject conversation history so the new ACP session has context from before app launch.
@@ -1678,7 +1673,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         // Append enabled skills as available context (global + project)
         // dev-mode is included in the list when devModeEnabled; full content loaded on demand via load_skill
         let enabledSkillNames = getEnabledSkillNames()
-        if profile.includesSkills && !enabledSkillNames.isEmpty {
+        if style.includesSkills && !enabledSkillNames.isEmpty {
             let allSkills = discoveredSkills + projectDiscoveredSkills
             let skillNames = allSkills
                 .filter { enabledSkillNames.contains($0.name) && ($0.name != "dev-mode" || devModeEnabled) }
@@ -1694,7 +1689,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
         let historyInjected = !history.isEmpty
         let historyMessages = messages.filter { !$0.text.isEmpty && !$0.isStreaming }
         let historyCount = min(historyMessages.count, 20)
-        log("ChatProvider: prompt built — schema: \(profile.includesDatabaseSchema && !cachedDatabaseSchema.isEmpty ? "yes" : "no"), goals: \(activeGoalCount), tasks: \(cachedTasks.count), ai_profile: \(!cachedAIProfile.isEmpty ? "yes" : "no"), memories: \(cachedMemories.count), history: \(historyInjected ? "injected (\(historyCount) msgs)" : "none"), claude_md: \(claudeMdEnabled && claudeMdContent != nil ? "yes" : "no"), project_claude_md: \(projectClaudeMdEnabled && projectClaudeMdContent != nil ? "yes" : "no"), skills: \(profile.includesSkills ? enabledSkillNames.count : 0), dev_mode_in_skills: \(profile.includesSkills && devModeEnabled && devModeContext != nil ? "yes" : "no"), prompt_length: \(prompt.count) chars")
+        log("ChatProvider: prompt built — schema: \(style.includesDatabaseSchema && !cachedDatabaseSchema.isEmpty ? "yes" : "no"), goals: \(activeGoalCount), tasks: \(cachedTasks.count), ai_profile: \(!cachedAIProfile.isEmpty ? "yes" : "no"), memories: \(cachedMemories.count), history: \(historyInjected ? "injected (\(historyCount) msgs)" : "none"), claude_md: \(claudeMdEnabled && claudeMdContent != nil ? "yes" : "no"), project_claude_md: \(projectClaudeMdEnabled && projectClaudeMdContent != nil ? "yes" : "no"), skills: \(style.includesSkills ? enabledSkillNames.count : 0), dev_mode_in_skills: \(style.includesSkills && devModeEnabled && devModeContext != nil ? "yes" : "no"), prompt_length: \(prompt.count) chars")
 
         // Log per-section character breakdown
         let baseTemplate = ChatPromptBuilder.buildDesktopChat(
@@ -1709,11 +1704,11 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
             "goals:\(goalSection.count)c, " +
             "tasks:\(tasksSection.count)c, " +
             "ai_profile:\(aiProfileSection.count)c, " +
-            "schema:\(profile.includesDatabaseSchema ? cachedDatabaseSchema.count : 0)c, " +
+            "schema:\(style.includesDatabaseSchema ? cachedDatabaseSchema.count : 0)c, " +
             "history:\(history.count)c, " +
             "claude_md:\(claudeMdContent?.count ?? 0)c, " +
             "project_claude_md:\(projectClaudeMdContent?.count ?? 0)c, " +
-            "skills:\(profile.includesSkills ? skillsSectionSize : 0)c")
+            "skills:\(style.includesSkills ? skillsSectionSize : 0)c")
 
         return prompt
     }
@@ -1721,7 +1716,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     private func buildFloatingBarSystemPrompt(contextString: String) -> String {
         let prompt = buildSystemPrompt(
             contextString: contextString,
-            profile: .floating
+            style: .floating
         )
         return Self.floatingBarSystemPromptPrefix + "\n\n" + prompt
     }
@@ -2641,9 +2636,10 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 systemPrompt = prefix
             } else {
                 if systemPromptStyle == .floating {
-                    systemPrompt = cachedFloatingSystemPrompt.isEmpty
-                        ? buildFloatingBarSystemPrompt(contextString: formatMemoriesSection())
-                        : cachedFloatingSystemPrompt
+                    if cachedFloatingSystemPrompt.isEmpty {
+                        cachedFloatingSystemPrompt = buildFloatingBarSystemPrompt(contextString: formatMemoriesSection())
+                    }
+                    systemPrompt = cachedFloatingSystemPrompt
                 } else {
                     systemPrompt = cachedMainSystemPrompt
                 }


### PR DESCRIPTION
## Summary

- Builds a separate floating-bar system prompt style instead of reusing the full main chat prompt
- Keeps main chat behavior unchanged: main sessions still include the local database schema and available skills
- Trims floating-bar prompts by excluding the cached SQLite database schema and available-skills section, then caches that floating prompt for warmup and query fallback
- Updates both floating entry points (`FloatingControlBarWindow` and `AgentPill`) to request the explicit `.floating` prompt style instead of relying on the floating prefix as an implicit sentinel

## Why

Issue #6981 measured floating-bar chat latency at 6.6-11.1s per query and identified the shared main-chat prompt as a major contributor. The issue breakdown shows the floating session receiving the same large prompt as main chat, including about 12,280 chars of database schema and a skills section that is not needed for "what do you see on my screen?" style floating-bar queries.

The issue comments specifically call out:

- full DB schema being sent to floating bar for both ACP and piMono paths
- skills being unnecessary in the floating-bar prompt
- a slim floating-bar prompt as the first recommended fix

This PR implements that narrow prompt-slimming recommendation without changing quota checks, save/sync timing, screenshot size, model defaults, or voice playback behavior.

## Relation to existing work

- Refs #6981
- Related but not duplicated: #6727 was a broader floating-bar latency PR with Haiku defaulting, Anthropic cache prewarm, streaming flush changes, CoreAudio warmup, transcription buffering, and voice playback fixes

## Implementation details

- Adds `ChatSystemPromptStyle` with `.main` and `.floating`
- `ChatSystemPromptStyle` owns the schema/skills inclusion policy through `includesDatabaseSchema` and `includesSkills`
- `buildSystemPrompt(..., style: .main)` preserves current main chat prompt behavior
- `buildFloatingBarSystemPrompt(...)` prepends `floatingBarSystemPromptPrefix` but uses `.floating`, which omits:
  - `cachedDatabaseSchema`
  - `<available_skills>`
- Caches `cachedFloatingSystemPrompt` during bridge warmup so floating sessions are prewarmed with the slimmer prompt
- Uses the cached floating prompt during `sendMessage(..., systemPromptStyle: .floating)` and writes fallback rebuilds back into `cachedFloatingSystemPrompt`

## Review follow-up

Addressed Greptile feedback in follow-up commit `615bc02`:

- fallback rebuild now writes back to `cachedFloatingSystemPrompt`
- removed the parallel internal `PromptProfile` enum so there is one source of truth for prompt style policy

## Expected impact

This directly removes the schema section called out in #6981 (`schema:12280c` in the posted logs) from floating-bar prompts. It should reduce prompt size, cache-write cost, and cold/warm inference latency for floating-bar queries while leaving the full main chat context intact.

## Verification

- `xcrun swift build -c debug --package-path Desktop`

🤖 Generated with OpenCode