### PR TITLE
feat auto-write conversation link to Google Calendar event on link

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -138,23 +138,6 @@ Future<bool> unlinkCalendarEvent(String conversationId) async {
   return response.statusCode == 200;
 }
 
-/// Add conversation summary to the linked calendar event description.
-/// Returns the htmlLink to open the event if successful, null otherwise.
-Future<String?> addSummaryToCalendarEvent(String conversationId) async {
-  var response = await makeApiCall(
-    url: '${Env.apiBaseUrl}v1/conversations/$conversationId/calendar-event/add-summary',
-    headers: {},
-    method: 'POST',
-    body: '',
-  );
-  if (response == null) return null;
-  if (response.statusCode == 200) {
-    final data = jsonDecode(response.body);
-    return data['html_link'] as String?;
-  }
-  return null;
-}
-
 /// Link a specific Google Calendar event to a conversation.
 /// Returns the linked CalendarEventLink if successful, null otherwise.
 Future<CalendarEventLink?> linkCalendarEvent(String conversationId, String eventId) async {

--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -8,9 +8,9 @@ import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:omi/backend/http/api/apps.dart';
 import 'package:omi/backend/http/api/audio.dart';
 import 'package:omi/backend/http/api/conversations.dart'
-    hide unlinkCalendarEvent, addSummaryToCalendarEvent, autoLinkCalendarEvent, linkCalendarEvent;
+    hide unlinkCalendarEvent, autoLinkCalendarEvent, linkCalendarEvent;
 import 'package:omi/backend/http/api/conversations.dart' as conv_api
-    show unlinkCalendarEvent, addSummaryToCalendarEvent, autoLinkCalendarEvent, linkCalendarEvent;
+    show unlinkCalendarEvent, autoLinkCalendarEvent, linkCalendarEvent;
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
@@ -600,16 +600,6 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
       return false;
     } catch (e) {
       return false;
-    }
-  }
-
-  /// Adds conversation summary to the linked calendar event and returns the event link
-  Future<String?> addSummaryToCalendarEvent() async {
-    try {
-      final htmlLink = await conv_api.addSummaryToCalendarEvent(conversation.id);
-      return htmlLink;
-    } catch (e) {
-      return null;
     }
   }
 

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -152,7 +152,6 @@ class GetSummaryWidgets extends StatelessWidget {
         onUnlink: () async {
           await provider.unlinkCalendarEvent();
         },
-        onAddSummary: () => provider.addSummaryToCalendarEvent(),
       ),
     );
   }
@@ -1453,13 +1452,11 @@ _getLoadingIndicator() {
 class CalendarEventDetailsSheet extends StatefulWidget {
   final CalendarEventLink calendarEvent;
   final Future<void> Function()? onUnlink;
-  final Future<String?> Function()? onAddSummary;
 
   const CalendarEventDetailsSheet({
     super.key,
     required this.calendarEvent,
     this.onUnlink,
-    this.onAddSummary,
   });
 
   @override
@@ -1468,8 +1465,6 @@ class CalendarEventDetailsSheet extends StatefulWidget {
 
 class _CalendarEventDetailsSheetState extends State<CalendarEventDetailsSheet> {
   bool _unlinking = false;
-  bool _addingSummary = false;
-  bool _summaryAdded = false;
 
   String _fmt(DateTime dt) {
     final h = dt.hour % 12 == 0 ? 12 : dt.hour % 12;
@@ -1552,41 +1547,6 @@ class _CalendarEventDetailsSheetState extends State<CalendarEventDetailsSheet> {
           const SizedBox(height: 24),
           const Divider(color: Color(0xFF2C2C2E)),
           const SizedBox(height: 8),
-          // Add Summary button
-          if (widget.onAddSummary != null && !_summaryAdded)
-            _ActionRow(
-              icon: Icons.note_add_outlined,
-              label: 'Add summary to event',
-              loading: _addingSummary,
-              onTap: () async {
-                setState(() => _addingSummary = true);
-                final link = await widget.onAddSummary!();
-                if (!mounted) return;
-                if (link != null) {
-                  setState(() {
-                    _addingSummary = false;
-                    _summaryAdded = true;
-                  });
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Summary added to calendar event')),
-                  );
-                } else {
-                  setState(() => _addingSummary = false);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Failed to add summary')),
-                  );
-                }
-              },
-            ),
-          if (_summaryAdded)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 12, horizontal: 4),
-              child: Row(children: [
-                Icon(Icons.check_circle_outline, size: 20, color: Colors.green),
-                SizedBox(width: 12),
-                Text('Summary added', style: TextStyle(color: Colors.green, fontSize: 15)),
-              ]),
-            ),
           // Share with attendees button
           if (widget.calendarEvent.attendeeEmails.isNotEmpty)
             _ActionRow(

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -45,9 +45,12 @@ from utils.speaker_identification import extract_speaker_samples
 from utils.other import endpoints as auth
 from utils.other.storage import get_conversation_recording_if_exists
 from utils.app_integrations import trigger_external_integrations
-from utils.conversations.calendar_linking import get_overlapping_calendar_event
+from utils.conversations.calendar_linking import (
+    get_overlapping_calendar_event,
+    write_conversation_link_to_calendar_event,
+)
 from utils.conversations.calendar_utils import extract_attendees, parse_event_times
-from utils.retrieval.tools.calendar_tools import get_google_calendar_event, update_google_calendar_event
+from utils.retrieval.tools.calendar_tools import get_google_calendar_event
 from utils.retrieval.tools.google_utils import refresh_google_token
 from utils.conversations.location import get_google_maps_location
 import logging
@@ -271,6 +274,9 @@ async def link_calendar_event(
         uid, conversation_id, {'calendar_event': calendar_event.model_dump(mode='json')}
     )
 
+    # Automatically write the conversation link into the calendar event description
+    await write_conversation_link_to_calendar_event(uid, calendar_event.event_id, conversation_id)
+
     return calendar_event
 
 
@@ -323,87 +329,10 @@ async def auto_link_calendar_event(conversation_id: str, uid: str = Depends(auth
         uid, conversation_id, {'calendar_event': calendar_event.model_dump(mode='json')}
     )
 
+    # Automatically write the conversation link into the calendar event description
+    await write_conversation_link_to_calendar_event(uid, calendar_event.event_id, conversation_id)
+
     return calendar_event
-
-
-async def _add_summary_to_calendar_event_with_token(
-    access_token: str,
-    event_id: str,
-    conversation_id: str,
-) -> dict:
-    """Helper function to add summary link to calendar event with given token."""
-    # Get existing event to preserve current description
-    existing_event = await get_google_calendar_event(access_token, event_id)
-    current_description = existing_event.get('description', '') or ''
-
-    # Build the conversation link
-    conversation_link = f"https://h.omi.me/memories/{conversation_id}"
-
-    # Check if we already added the link (to avoid duplicates)
-    if conversation_link in current_description:
-        return {
-            'status': 'Ok',
-            'html_link': existing_event.get('htmlLink'),
-        }
-
-    # Append just the link
-    if current_description:
-        new_description = f"{current_description}\n\n{conversation_link}"
-    else:
-        new_description = conversation_link
-
-    # Update the calendar event
-    updated_event = await update_google_calendar_event(
-        access_token=access_token,
-        event_id=event_id,
-        description=new_description,
-    )
-
-    return {
-        'status': 'Ok',
-        'html_link': updated_event.get('htmlLink'),
-    }
-
-
-@router.post("/v1/conversations/{conversation_id}/calendar-event/add-summary", tags=['conversations'])
-async def add_summary_to_calendar_event(conversation_id: str, uid: str = Depends(auth.get_current_user_uid)):
-    """
-    Add conversation summary to the linked calendar event description.
-    """
-    conversation = _get_valid_conversation_by_id(uid, conversation_id)
-
-    calendar_event = conversation.get('calendar_event')
-    if not calendar_event:
-        raise HTTPException(status_code=400, detail="No calendar event linked to this conversation")
-
-    event_id = calendar_event.get('event_id')
-    if not event_id:
-        raise HTTPException(status_code=400, detail="Calendar event ID not found")
-
-    # Get Google Calendar access token
-    integration = users_db.get_integration(uid, 'google_calendar')
-    if not integration or not integration.get('connected'):
-        raise HTTPException(status_code=400, detail="Google Calendar not connected")
-
-    access_token = integration.get('access_token')
-    if not access_token:
-        raise HTTPException(status_code=400, detail="No access token found")
-
-    try:
-        return await _add_summary_to_calendar_event_with_token(access_token, event_id, conversation_id)
-    except Exception as e:
-        error_msg = str(e)
-
-        # Try to refresh token if authentication failed
-        if "error 401" in error_msg.lower() or "authentication failed" in error_msg.lower():
-            new_token = await refresh_google_token(uid, integration)
-            if new_token:
-                try:
-                    return await _add_summary_to_calendar_event_with_token(new_token, event_id, conversation_id)
-                except Exception as retry_error:
-                    raise HTTPException(status_code=500, detail=f"Failed after token refresh: {str(retry_error)}")
-
-        raise HTTPException(status_code=500, detail=f"Failed to update calendar event: {error_msg}")
 
 
 @router.patch("/v1/conversations/{conversation_id}/summary", tags=['conversations'])

--- a/backend/utils/conversations/calendar_linking.py
+++ b/backend/utils/conversations/calendar_linking.py
@@ -10,7 +10,11 @@ from typing import Optional
 import database.users as users_db
 from models.conversation import CalendarEventLink
 from utils.conversations.calendar_utils import extract_attendees, parse_event_times
-from utils.retrieval.tools.calendar_tools import get_google_calendar_events
+from utils.retrieval.tools.calendar_tools import (
+    get_google_calendar_events,
+    get_google_calendar_event,
+    update_google_calendar_event,
+)
 from utils.retrieval.tools.google_utils import refresh_google_token
 
 # Minimum overlap duration in seconds to consider a match (10 seconds)
@@ -129,3 +133,46 @@ async def get_overlapping_calendar_event(
         end_time=event_end,
         html_link=best_match.get('htmlLink'),
     )
+
+
+async def write_conversation_link_to_calendar_event(
+    uid: str,
+    event_id: str,
+    conversation_id: str,
+) -> None:
+    """
+    Write the conversation link into the Google Calendar event description.
+
+    Appends https://h.omi.me/conversations/<conversation_id> to the event description.
+    Silently no-ops on any error — linking the conversation to the event is the primary
+    action; failing to write the description link should not block the caller.
+    """
+    integration = users_db.get_integration(uid, 'google_calendar')
+    if not integration or not integration.get('connected'):
+        return
+
+    access_token = integration.get('access_token')
+    if not access_token:
+        return
+
+    conversation_link = f"https://h.omi.me/conversations/{conversation_id}"
+
+    async def _write(token: str) -> None:
+        existing = await get_google_calendar_event(token, event_id)
+        current_description = existing.get('description', '') or ''
+        if conversation_link in current_description:
+            return
+        new_description = f"{current_description}\n\n{conversation_link}" if current_description else conversation_link
+        await update_google_calendar_event(access_token=token, event_id=event_id, description=new_description)
+
+    try:
+        await _write(access_token)
+    except Exception as e:
+        error_msg = str(e)
+        if "error 401" in error_msg.lower() or "authentication failed" in error_msg.lower():
+            new_token = await refresh_google_token(uid, integration)
+            if new_token:
+                try:
+                    await _write(new_token)
+                except Exception:
+                    pass

--- a/backend/utils/conversations/calendar_linking.py
+++ b/backend/utils/conversations/calendar_linking.py
@@ -4,6 +4,7 @@ Calendar event linking for conversations.
 Detects and links conversations to Google Calendar events when they overlap in time.
 """
 
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -16,6 +17,8 @@ from utils.retrieval.tools.calendar_tools import (
     update_google_calendar_event,
 )
 from utils.retrieval.tools.google_utils import refresh_google_token
+
+logger = logging.getLogger(__name__)
 
 # Minimum overlap duration in seconds to consider a match (10 seconds)
 MIN_OVERLAP_SECONDS = 10
@@ -174,5 +177,11 @@ async def write_conversation_link_to_calendar_event(
             if new_token:
                 try:
                     await _write(new_token)
-                except Exception:
-                    pass
+                except Exception as retry_error:
+                    logger.warning(
+                        f"write_conversation_link_to_calendar_event failed after token refresh: {retry_error}"
+                    )
+        else:
+            logger.warning(
+                f"write_conversation_link_to_calendar_event failed for conversation {conversation_id}: {error_msg}"
+            )

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -80,7 +80,10 @@ from utils.retrieval.rag import retrieve_rag_conversation_context
 from utils.webhooks import conversation_created_webhook
 from utils.notifications import send_action_item_data_message
 from utils.task_sync import auto_sync_action_items_batch
-from utils.conversations.calendar_linking import get_overlapping_calendar_event
+from utils.conversations.calendar_linking import (
+    get_overlapping_calendar_event,
+    write_conversation_link_to_calendar_event,
+)
 from utils.other.storage import precache_conversation_audio
 
 logger = logging.getLogger(__name__)
@@ -743,7 +746,7 @@ def process_conversation(
     structured, discarded = _get_structured(uid, language_code, conversation, force_process, people=people)
     conversation = _get_conversation_obj(uid, structured, conversation)
 
-    # Check for overlapping calendar events
+    # Check for overlapping calendar events and auto-write conversation link to the event description
     if not discarded and conversation.started_at and conversation.finished_at and conversation.calendar_event is None:
         try:
             calendar_event = asyncio.run(
@@ -755,6 +758,7 @@ def process_conversation(
             )
             if calendar_event:
                 conversation.calendar_event = calendar_event
+                asyncio.run(write_conversation_link_to_calendar_event(uid, calendar_event.event_id, conversation.id))
         except Exception as e:
             logger.error(f"Error during calendar event linking: {e}")
             pass


### PR DESCRIPTION
## Summary

- When a conversation is linked to a Google Calendar event (auto-link or manual), the conversation URL (`https://h.omi.me/conversations/<id>`) is now **automatically written into the calendar event's description** — no extra user action needed
- Removed the manual "Add summary to event" button from the calendar event details sheet
- Removed the `/v1/conversations/{id}/calendar-event/add-summary` backend endpoint (no longer needed)

## Changes

**Backend**
- `calendar_linking.py` — new `write_conversation_link_to_calendar_event()` helper: appends the conversation URL to the Google Calendar event description, with duplicate-check and token refresh handling; silently no-ops on error so it never blocks the link action
- `conversations.py` — both `link_calendar_event` (manual) and `auto_link_calendar_event` endpoints call it automatically after persisting; removed `add_summary_to_calendar_event` endpoint and its helper
- `process_conversation.py` — auto-link during conversation processing also calls it

**Flutter**
- Removed `addSummaryToCalendarEvent` from `conversations.dart` API, `conversation_detail_provider.dart`, and the "Add summary to event" / "Summary added" UI from `CalendarEventDetailsSheet`

## Test plan

- [ ] Record a conversation during an active Google Calendar event → open Google Calendar → confirm the conversation URL appears in the event description automatically
- [ ] Manually link a conversation via "Link Event" → confirm URL appears in event description immediately
- [ ] Link the same conversation twice → confirm URL appears only once (duplicate check)
- [ ] Confirm "Add summary to event" button is gone from the calendar event details sheet
- [ ] Unlink and re-link → confirm URL is re-added to description

🤖 Generated with [Claude Code](https://claude.com/claude-code)