### PR TITLE
android bg transcription: support Fieldy/Bee/Plaud (partial fix for #7548)

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBackgroundAudioStreamer.kt
@@ -63,6 +63,14 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
     @Volatile
     private var lastFailureAtMs = 0L
 
+    // Per-device byte accumulator. Used by device types whose audio payload
+    // straddles BLE notifications (Bee: ADTS-framed AAC; Plaud: 80-byte chunking
+    // of variable-length opus payloads). Reset whenever the active config
+    // changes or the socket is torn down so we never mix bytes from two
+    // sessions. Other device types (omi/openglass/friendPendant/fieldy) ignore
+    // this buffer and remain pure transforms.
+    private val rxBuffer = ArrayDeque<Byte>()
+
     fun isConfiguredFor(address: String): Boolean {
         val config = loadConfig() ?: return false
         return config.deviceId.equals(address, ignoreCase = true)
@@ -87,6 +95,7 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
             activeUrl = null
             activeConfig = null
             pendingFrames.clear()
+            rxBuffer.clear()
         }
         socketToClose?.close(1000, reason)
     }
@@ -137,6 +146,96 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
                     frames
                 }
             }
+            // Fieldy: each notification carries N back-to-back 40-byte Opus
+            // frames (typically 6 → 240 bytes). Mirrors FieldyDeviceConnection
+            // .performGetBleAudioBytesListener — split on 40-byte boundaries,
+            // forward any final partial frame only if it starts with the
+            // expected Opus TOC byte 0xb8 (avoids forwarding stray bytes).
+            "fieldy" -> {
+                val frames = mutableListOf<ByteArray>()
+                var offset = 0
+                while (offset + 40 <= value.size) {
+                    frames.add(value.copyOfRange(offset, offset + 40))
+                    offset += 40
+                }
+                if (offset < value.size && value[offset] == 0xb8.toByte()) {
+                    frames.add(value.copyOfRange(offset, value.size))
+                }
+                frames
+            }
+            // Bee: notifications carry a 2-byte transport header followed by
+            // ADTS-framed AAC. Frames straddle notifications, so we accumulate
+            // into rxBuffer and slice on each complete ADTS frame. Mirrors
+            // BeeDeviceConnection.processAudioPacket exactly: scan for the
+            // sync word (0xFF + high-nibble 0xF), read the 13-bit ADTS frame
+            // length from bytes 3-5, emit when the buffer holds the full
+            // frame. Drop a single byte on resync mismatch.
+            "bee" -> {
+                if (value.size < 2) {
+                    emptyList()
+                } else {
+                    for (i in 2 until value.size) rxBuffer.addLast(value[i])
+                    val frames = mutableListOf<ByteArray>()
+                    while (rxBuffer.size >= 7) {
+                        val b0 = rxBuffer.elementAt(0).toInt() and 0xFF
+                        val b1 = rxBuffer.elementAt(1).toInt() and 0xFF
+                        if (b0 != 0xFF || (b1 and 0xF0) != 0xF0) {
+                            rxBuffer.removeFirst()
+                            continue
+                        }
+                        val b3 = rxBuffer.elementAt(3).toInt() and 0xFF
+                        val b4 = rxBuffer.elementAt(4).toInt() and 0xFF
+                        val b5 = rxBuffer.elementAt(5).toInt() and 0xFF
+                        val frameLength = ((b3 and 0x03) shl 11) or (b4 shl 3) or ((b5 and 0xE0) ushr 5)
+                        // Sanity-check the frame length against ADTS constraints
+                        // before consuming. Out-of-range values mean we're
+                        // mid-stream of noise — resync by one byte.
+                        if (frameLength < 7 || frameLength > 8192) {
+                            rxBuffer.removeFirst()
+                            continue
+                        }
+                        if (rxBuffer.size < frameLength) break
+                        val frame = ByteArray(frameLength) { rxBuffer.removeFirst() }
+                        frames.add(frame)
+                    }
+                    frames
+                }
+            }
+            // Plaud: notify characteristic carries both command responses and
+            // audio. Audio packets start with type byte 0x02; everything else
+            // is dropped (responses can't reach the WS — they're not audio).
+            // Layout: [0]=type, [1..4]=metadata, [5..8]=position (LE uint32,
+            // 0xFFFFFFFF = end-of-stream sentinel), [9]=length, [10..10+len]
+            // =audio payload. The payload is then re-chunked into 80-byte
+            // frames before sending — matches PlaudDeviceConnection's
+            // accumulator (the backend expects opus_fs320 in fixed chunks).
+            "plaud" -> {
+                if (value.size < 10 || (value[0].toInt() and 0xFF) != 2) {
+                    emptyList()
+                } else {
+                    val posB0 = value[5].toInt() and 0xFF
+                    val posB1 = value[6].toInt() and 0xFF
+                    val posB2 = value[7].toInt() and 0xFF
+                    val posB3 = value[8].toInt() and 0xFF
+                    val isEndMarker = posB0 == 0xFF && posB1 == 0xFF && posB2 == 0xFF && posB3 == 0xFF
+                    if (isEndMarker) {
+                        emptyList()
+                    } else {
+                        val length = value[9].toInt() and 0xFF
+                        if (length == 0 || 10 + length > value.size) {
+                            emptyList()
+                        } else {
+                            for (i in 10 until 10 + length) rxBuffer.addLast(value[i])
+                            val frames = mutableListOf<ByteArray>()
+                            while (rxBuffer.size >= 80) {
+                                val chunk = ByteArray(80) { rxBuffer.removeFirst() }
+                                frames.add(chunk)
+                            }
+                            frames
+                        }
+                    }
+                }
+            }
             else -> {
                 Log.w(TAG, "Unsupported background BLE audio device type: ${config.deviceType}")
                 emptyList()
@@ -162,6 +261,7 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
             activeUrl = url
             activeConfig = config
             sentFrames = 0
+            rxBuffer.clear()
 
             Log.i(TAG, "Opening background transcription websocket (codec=${config.codec}, source=${config.source})")
             socket = client.newWebSocket(request, listener())

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -937,12 +937,25 @@ class CaptureProvider extends ChangeNotifier
         return const MapEntry(omiServiceUuid, audioDataStreamCharacteristicUuid);
       case DeviceType.friendPendant:
         return const MapEntry(friendPendantServiceUuid, friendPendantAudioCharacteristicUuid);
-      case DeviceType.appleWatch:
       case DeviceType.bee:
+        return const MapEntry(beeServiceUuid, beeAudioCharacteristicUuid);
       case DeviceType.fieldy:
+        return const MapEntry(fieldyServiceUuid, fieldyAudioCharacteristicUuid);
+      case DeviceType.plaud:
+        // Plaud's notify characteristic carries both command responses and
+        // audio data on the same channel. The native streamer's `plaud`
+        // branch in transformFrames filters on the leading type byte (0x02)
+        // so non-audio packets are dropped before they reach the websocket.
+        return const MapEntry(plaudServiceUuid, plaudNotifyCharUuid);
+      case DeviceType.appleWatch:
       case DeviceType.frame:
       case DeviceType.limitless:
-      case DeviceType.plaud:
+        // Limitless background streaming intentionally not yet implemented:
+        // its BLE protocol uses protobuf-fragment reassembly + nested Opus
+        // extraction that needs to be ported with a real Limitless device on
+        // hand to verify. Tracked as a follow-up. AppleWatch and Frame
+        // require their own native packet/control flow handling that hasn't
+        // been mirrored yet either.
         return null;
     }
   }

--- a/app/lib/services/devices/models.dart
+++ b/app/lib/services/devices/models.dart
@@ -57,8 +57,10 @@ const String plaudWriteCharUuid = "00002bb1-0000-1000-8000-00805f9b34fb";
 const String plaudNotifyCharUuid = "00002bb0-0000-1000-8000-00805f9b34fb";
 
 const String beeServiceUuid = "03d5d5c4-a86c-11ee-9d89-8f2089a49e7e";
+const String beeAudioCharacteristicUuid = "b189a505-a86c-11ee-a5fb-8f2089a49e7e";
 
 const String fieldyServiceUuid = "4fafc201-1fb5-459e-8fcc-c5c9c331914b";
+const String fieldyAudioCharacteristicUuid = "82a48422-3ca9-4156-ae67-4170f58666e0";
 
 const String friendPendantServiceUuid = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da";
 const String friendPendantAudioCharacteristicUuid = "01000000-1111-1111-1111-111111111111";


### PR DESCRIPTION
## Summary
Extends the Android background BLE transcription feature added in #7483 to cover three more device types — Fieldy, Bee, and Plaud — so users on those devices no longer silently lose audio when the app is closed.

Partial fix for #7548. Limitless is intentionally **not** in this PR — see below.

## What changed

### Native side (`OmiBackgroundAudioStreamer.kt`)
Three new branches in `transformFrames`, each mirroring the per-device byte-stripping that the existing Flutter device-connection classes already do:

- **`fieldy`** — each BLE notification carries N back-to-back 40-byte Opus frames (typically 6 → 240 bytes). Split on 40-byte boundaries; forward trailing remainder only if it starts with Opus TOC byte `0xb8`. Stateless. Mirrors `FieldyDeviceConnection.performGetBleAudioBytesListener`.
- **`bee`** — strip the 2-byte transport header, accumulate into `rxBuffer`, scan for the ADTS sync word (`0xFF` + `byte1 & 0xF0 == 0xF0`), read the 13-bit frame length from bytes 3–5, emit each complete frame as soon as the buffer holds it; resync one byte at a time on sync-word or length mismatch. Stateful (frames straddle notifications). Mirrors `BeeDeviceConnection.processAudioPacket`.
- **`plaud`** — Plaud's notify characteristic carries both audio (leading type byte `0x02`) and command responses on the same channel. Filter by type byte, drop end-of-stream sentinel packets (position `0xFFFFFFFF`), extract the variable-length payload, then re-chunk the byte stream into 80-byte frames before sending. Stateful (80-byte accumulator). Mirrors `PlaudDeviceConnection._handleNotification` + `_parseAudioChunk` + the 80-byte buffer step.

To support the two stateful devices, a per-streamer `rxBuffer: ArrayDeque<Byte>` is added and reset on both `stop()` and `ensureSocket()` reconfigure so we never mix bytes across sessions.

### Flutter side (`capture_provider.dart`, `models.dart`)
- `_nativeBleAudioTarget` now returns concrete `(service, characteristic)` UUIDs for `DeviceType.bee` / `.fieldy` / `.plaud` instead of `null` (which was forcing `nativeBleStreamingEnabled=false` and dropping audio).
- Added `beeAudioCharacteristicUuid` and `fieldyAudioCharacteristicUuid` constants to `models.dart` (they were hardcoded inside their `*_connection.dart` files before).

## What's NOT in this PR

**Limitless** is still in the `null`-returning branch. Its BLE protocol uses:
- protobuf varint parsing for the BLE-wrapper envelope,
- multi-fragment reassembly keyed by `(index, seq, num_frags)`,
- recursive nested-protobuf walking to extract Opus frames from a flash-page structure.

That's ~hundreds of lines of stateful parsing in `LimitlessDeviceConnection` (1843 LOC). Porting it to Kotlin without a real Limitless device to verify each step would risk shipping framing that's silently wrong — strictly worse than today's "drops on the Flutter side" because the wrong framing would still consume backend resources and pollute the conversation. Filed as the long-tail item on #7548; will do as a follow-up once a Limitless device is available for verification.

**AppleWatch** and **Frame** also remain `null` — neither was covered in #7483's original scope, and adding them is independent work.

## Sessions and reconnection

For all three new devices, the architectural caveat from #7483 still applies:
- The background streamer relies on the BLE characteristic subscription that Flutter set up when the user started recording. If the device disconnects entirely (e.g., BLE goes out of range) while the app is closed, the streamer can't re-issue the device-specific control writes that Plaud and Bee need to start a fresh recording session — those are stateful protocols (`_setupRecordingSession` for Plaud, `unmuteCommandCode` for Bee) that need to run from Flutter's connection lifecycle. In the steady state where the device stays connected through the close-and-reopen window, audio keeps flowing.
- This is the same trade-off that Omi / OpenGlass / FriendPendant make today. Fixing it for the disconnect-mid-close case would require moving more of the connection setup into the foreground service, which is a bigger structural change (and likely belongs in the discussed-internally socket-to-native rewrite, not here).

## Verification
- ✅ `flutter analyze` on both edited Dart files → no new issues (3 unrelated pre-existing lints in capture_provider.dart imports, confirmed they exist on `main`)
- ✅ `dart format --line-length 120 --set-exit-if-changed` → clean
- ✅ **Android debug APK build on Mac** → `flutter build apk --debug --flavor dev` produced `build/app/outputs/flutter-apk/app-dev-debug.apk` (287 MB). Kotlin compiles, Dart compiles, no errors.
- ⚠️ **Not exercised end-to-end against real devices yet** — I don't have Fieldy / Bee / Plaud pendants on this Linux host. Recommend testers on each device type run the close-and-speak-and-reopen flow before promoting to prod, particularly Bee (ADTS framing is the most fragile of the three since AAC sync recovery is byte-level).

## Test plan
For each of Fieldy, Bee, and Plaud:
- [ ] Pair the device from the app
- [ ] Start recording, confirm transcript appears in real time
- [ ] Swipe the app away from recents
- [ ] Speak for ~1–2 minutes
- [ ] Reopen the app
- [ ] Confirm a transcript exists covering what was spoken while the app was closed (verifies the framing is correct end-to-end)
- [ ] Confirm there's only ONE in-progress conversation, not two (verifies the Redis-based conversation continuity from `transcribe.py` is intact)

For regression coverage:
- [ ] Re-run the same flow on Omi / OpenGlass / FriendPendant — confirm no behavior change for the existing device types