### PR TITLE
feat(mcp): add search_memories to Python MCP server

### DIFF
--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -86,8 +86,12 @@ def delete_memory(memory_id: str, uid: str = Depends(get_uid_from_mcp_api_key)):
 
 @router.patch("/v1/mcp/memories/{memory_id}", tags=["mcp"])
 def edit_memory(memory_id: str, value: str, uid: str = Depends(get_uid_from_mcp_api_key)):
-    _validate_mcp_memory(uid, memory_id)
+    memory = _validate_mcp_memory(uid, memory_id)
     memories_db.edit_memory(uid, memory_id, value)
+    try:
+        upsert_memory_vector(uid, memory_id, value, memory.get('category', 'other'))
+    except Exception:
+        logger.exception("Vector upsert failed uid=%s memory_id=%s (memory edited, vector stale)", uid, memory_id)
     return {"status": "ok"}
 
 

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -125,13 +125,12 @@ def search_memories(
     for m in memories_data:
         if m.get('user_review') is False:
             continue
-        content = m.get("content", "")
-        if m.get("is_locked", False):
-            content = (content[:70] + "...") if len(content) > 70 else content
+        if m.get('is_locked', False):
+            continue
         results.append(
             {
                 "id": m.get("id", ""),
-                "content": content,
+                "content": m.get("content", ""),
                 "category": m.get("category", "other"),
                 "relevance_score": round(scores.get(m.get("id"), 0), 4),
             }

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -88,6 +88,43 @@ class CleanerMemory(BaseModel):
     category: MemoryCategory
 
 
+class SearchedMemory(CleanerMemory):
+    relevance_score: float
+
+
+@router.get("/v1/mcp/memories/search", tags=["mcp"], response_model=List[SearchedMemory])
+def search_memories(
+    query: str,
+    limit: int = 10,
+    uid: str = Depends(get_uid_from_mcp_api_key),
+):
+    logger.info(f"search_memories {uid} query={sanitize_pii(query)} limit={limit}")
+    limit = min(limit, 20)
+    matches = vector_db.find_similar_memories(uid, query, threshold=0.0, limit=limit)
+    if not matches:
+        return []
+    memory_ids = [m.get("memory_id") for m in matches if m.get("memory_id")]
+    scores = {m.get("memory_id"): m.get("score", 0) for m in matches}
+    if not memory_ids:
+        return []
+    memories_data = memories_db.get_memories_by_ids(uid, memory_ids)
+    results = []
+    for m in memories_data:
+        content = m.get("content", "")
+        if m.get("is_locked", False):
+            content = (content[:70] + "...") if len(content) > 70 else content
+        results.append(
+            {
+                "id": m.get("id", ""),
+                "content": content,
+                "category": m.get("category", "other"),
+                "relevance_score": round(scores.get(m.get("id"), 0), 4),
+            }
+        )
+    results.sort(key=lambda x: x["relevance_score"], reverse=True)
+    return results
+
+
 @router.get("/v1/mcp/memories", tags=["mcp"], response_model=List[CleanerMemory])
 def get_memories(
     uid: str = Depends(get_uid_from_mcp_api_key),

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -11,6 +11,7 @@ import database.conversations as conversations_db
 
 # from database.redis_db import get_filter_category_items
 # from database.vector_db import query_vectors_by_metadata
+from database.vector_db import upsert_memory_vector
 import database.vector_db as vector_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.conversation_enums import CategoryEnum
@@ -55,6 +56,10 @@ def create_memory(memory: Memory, uid: str = Depends(with_rate_limit(get_uid_fro
     memory.category = identify_category_for_memory(memory.content)
     memory_db = MemoryDB.from_memory(memory, uid, None, True)
     memories_db.create_memory(uid, memory_db.model_dump())
+    try:
+        upsert_memory_vector(uid, memory_db.id, memory_db.content, memory_db.category.value)
+    except Exception:
+        logger.exception("Vector upsert failed uid=%s memory_id=%s (memory saved, vector missing)", uid, memory_db.id)
     postprocess_executor.submit(update_personas_async, uid)
     return memory_db
 
@@ -99,7 +104,7 @@ def search_memories(
     uid: str = Depends(get_uid_from_mcp_api_key),
 ):
     logger.info(f"search_memories {uid} query={sanitize_pii(query)} limit={limit}")
-    limit = min(limit, 20)
+    limit = max(1, min(limit, 20))
     matches = vector_db.find_similar_memories(uid, query, threshold=0.0, limit=limit)
     if not matches:
         return []

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -11,7 +11,7 @@ import database.conversations as conversations_db
 
 # from database.redis_db import get_filter_category_items
 # from database.vector_db import query_vectors_by_metadata
-from database.vector_db import upsert_memory_vector
+from database.vector_db import upsert_memory_vector, delete_memory_vector
 import database.vector_db as vector_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.conversation_enums import CategoryEnum
@@ -77,6 +77,10 @@ def _validate_mcp_memory(uid: str, memory_id: str) -> dict:
 def delete_memory(memory_id: str, uid: str = Depends(get_uid_from_mcp_api_key)):
     _validate_mcp_memory(uid, memory_id)
     memories_db.delete_memory(uid, memory_id)
+    try:
+        delete_memory_vector(uid, memory_id)
+    except Exception:
+        logger.exception("Vector delete failed uid=%s memory_id=%s (Firestore deleted)", uid, memory_id)
     return {"status": "ok"}
 
 

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -119,6 +119,8 @@ def search_memories(
     memories_data = memories_db.get_memories_by_ids(uid, memory_ids)
     results = []
     for m in memories_data:
+        if m.get('user_review') is False:
+            continue
         content = m.get("content", "")
         if m.get("is_locked", False):
             content = (content[:70] + "...") if len(content) > 70 else content

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -113,7 +113,8 @@ def search_memories(
 ):
     logger.info(f"search_memories {uid} query={sanitize_pii(query)} limit={limit}")
     limit = max(1, min(limit, 20))
-    matches = vector_db.find_similar_memories(uid, query, threshold=0.0, limit=limit)
+    fetch_limit = min(limit * 3, 60)
+    matches = vector_db.find_similar_memories(uid, query, threshold=0.0, limit=fetch_limit)
     if not matches:
         return []
     memory_ids = [m.get("memory_id") for m in matches if m.get("memory_id")]
@@ -136,7 +137,7 @@ def search_memories(
             }
         )
     results.sort(key=lambda x: x["relevance_score"], reverse=True)
-    return results
+    return results[:limit]
 
 
 @router.get("/v1/mcp/memories", tags=["mcp"], response_model=List[CleanerMemory])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -18,6 +18,7 @@ pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_speaker_id_pipeline.py -v
 pytest tests/unit/test_user_speaker_embedding.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
+pytest tests/unit/test_mcp_search_memories.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v
 pytest tests/unit/test_llm_usage_db.py -v

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -123,31 +123,20 @@ class TestSearchMemoriesEndpoint:
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')
-    def test_locked_memory_truncates_content(self, mock_vector_db, mock_memories_db):
-        long_content = "A" * 200
+    def test_locked_memory_excluded_from_search(self, mock_vector_db, mock_memories_db):
+        # Search drops locked hits entirely (matches tool_services/memories.py behaviour);
+        # even short content must not leak via an MCP API key.
         mock_vector_db.find_similar_memories.return_value = [
             {'memory_id': 'mem-1', 'category': 'other', 'score': 0.9},
+            {'memory_id': 'mem-2', 'category': 'other', 'score': 0.8},
         ]
         mock_memories_db.get_memories_by_ids.return_value = [
-            self._make_memory('mem-1', long_content, 'other', locked=True),
+            self._make_memory('mem-1', 'Short locked', 'other', locked=True),
+            self._make_memory('mem-2', 'Unlocked memory', 'other', locked=False),
         ]
         result = search_memories(query="test", limit=10, uid="user-1")
         assert len(result) == 1
-        assert result[0]['content'] == "A" * 70 + "..."
-        assert result[0]['relevance_score'] == 0.9
-
-    @patch('routers.mcp.memories_db')
-    @patch('routers.mcp.vector_db')
-    def test_locked_memory_short_content_not_truncated(self, mock_vector_db, mock_memories_db):
-        short_content = "Short memory"
-        mock_vector_db.find_similar_memories.return_value = [
-            {'memory_id': 'mem-1', 'category': 'other', 'score': 0.9},
-        ]
-        mock_memories_db.get_memories_by_ids.return_value = [
-            self._make_memory('mem-1', short_content, 'other', locked=True),
-        ]
-        result = search_memories(query="test", limit=10, uid="user-1")
-        assert result[0]['content'] == "Short memory"
+        assert result[0]['id'] == 'mem-2'
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -82,7 +82,7 @@ sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenErr
 sys.modules['firebase_admin.auth'].CertificateFetchError = type('CertificateFetchError', (Exception,), {})
 sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError', (Exception,), {})
 
-from routers.mcp import search_memories, delete_memory
+from routers.mcp import search_memories, delete_memory, edit_memory
 
 
 class TestSearchMemoriesEndpoint:
@@ -262,6 +262,38 @@ class TestSearchMemoriesUserReview:
         ]
         result = search_memories(query="test", limit=10, uid="user-1")
         assert result == []
+
+
+class TestEditMemoryVectorSync:
+    """edit_memory must re-embed the new content so search finds the edited text."""
+
+    @patch('routers.mcp.upsert_memory_vector')
+    @patch('routers.mcp.memories_db')
+    def test_edit_upserts_vector_with_new_content(self, mock_memories_db, mock_upsert_vector):
+        mock_memories_db.get_memory.return_value = {
+            'id': 'mem-1',
+            'content': 'old text',
+            'category': 'hobbies',
+            'is_locked': False,
+        }
+        result = edit_memory(memory_id="mem-1", value="new text", uid="user-1")
+        assert result == {"status": "ok"}
+        mock_memories_db.edit_memory.assert_called_once_with("user-1", "mem-1", "new text")
+        mock_upsert_vector.assert_called_once_with("user-1", "mem-1", "new text", "hobbies")
+
+    @patch('routers.mcp.upsert_memory_vector')
+    @patch('routers.mcp.memories_db')
+    def test_edit_succeeds_when_vector_upsert_fails(self, mock_memories_db, mock_upsert_vector):
+        mock_memories_db.get_memory.return_value = {
+            'id': 'mem-1',
+            'content': 'old text',
+            'category': 'other',
+            'is_locked': False,
+        }
+        mock_upsert_vector.side_effect = Exception("pinecone down")
+        result = edit_memory(memory_id="mem-1", value="new text", uid="user-1")
+        assert result == {"status": "ok"}
+        mock_memories_db.edit_memory.assert_called_once_with("user-1", "mem-1", "new text")
 
 
 class TestDeleteMemoryVectorSync:

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -1,0 +1,206 @@
+"""Unit tests for the search_memories MCP endpoint.
+
+Tests the endpoint logic with mocked database calls,
+following the pattern in test_lock_bypass_fixes.py.
+"""
+
+from unittest.mock import patch, MagicMock
+import os
+import pytest
+import sys
+from types import ModuleType
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+
+class _AutoMockModule(ModuleType):
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+_stubs = [
+    'database._client',
+    'database.redis_db',
+    'database.conversations',
+    'database.memories',
+    'database.action_items',
+    'database.folders',
+    'database.users',
+    'database.user_usage',
+    'database.vector_db',
+    'database.chat',
+    'database.apps',
+    'database.goals',
+    'database.notifications',
+    'database.mem_db',
+    'database.mcp_api_key',
+    'database.daily_summaries',
+    'database.fair_use',
+    'database.auth',
+    'database.dev_api_key',
+    'firebase_admin',
+    'firebase_admin.messaging',
+    'firebase_admin.auth',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'google.cloud.firestore_v1.FieldFilter',
+    'google',
+    'google.cloud',
+    'pinecone',
+    'typesense',
+    'opuslib',
+    'pydub',
+    'pusher',
+    'modal',
+    'utils.other.storage',
+    'utils.other.endpoints',
+    'utils.stt.pre_recorded',
+    'utils.stt.vad',
+    'utils.fair_use',
+    'utils.subscription',
+    'utils.conversations.process_conversation',
+    'utils.conversations.render',
+    'utils.notifications',
+    'utils.apps',
+    'utils.llm.memories',
+    'utils.llm.chat',
+    'utils.log_sanitizer',
+    'utils.executors',
+]
+for mod_name in _stubs:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = _AutoMockModule(mod_name)
+
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].ExpiredIdTokenError = type('ExpiredIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenError', (Exception,), {})
+sys.modules['firebase_admin.auth'].CertificateFetchError = type('CertificateFetchError', (Exception,), {})
+sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError', (Exception,), {})
+
+from routers.mcp import search_memories
+
+
+class TestSearchMemoriesEndpoint:
+
+    def _make_memory(self, memory_id='mem-1', content='Test memory content', category='other', locked=False):
+        return {
+            'id': memory_id,
+            'content': content,
+            'category': category,
+            'is_locked': locked,
+        }
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_returns_empty_when_no_matches(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = []
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert result == []
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=10)
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_returns_ranked_results(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'category': 'work', 'score': 0.95},
+            {'memory_id': 'mem-2', 'category': 'hobbies', 'score': 0.80},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            self._make_memory('mem-1', 'Work memory', 'work'),
+            self._make_memory('mem-2', 'Hobby memory', 'hobbies'),
+        ]
+        result = search_memories(query="work stuff", limit=10, uid="user-1")
+        assert len(result) == 2
+        assert result[0]['id'] == 'mem-1'
+        assert result[0]['relevance_score'] == 0.95
+        assert result[1]['id'] == 'mem-2'
+        assert result[1]['relevance_score'] == 0.80
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_locked_memory_truncates_content(self, mock_vector_db, mock_memories_db):
+        long_content = "A" * 200
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'category': 'other', 'score': 0.9},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            self._make_memory('mem-1', long_content, 'other', locked=True),
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert len(result) == 1
+        assert result[0]['content'] == "A" * 70 + "..."
+        assert result[0]['relevance_score'] == 0.9
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_locked_memory_short_content_not_truncated(self, mock_vector_db, mock_memories_db):
+        short_content = "Short memory"
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'category': 'other', 'score': 0.9},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            self._make_memory('mem-1', short_content, 'other', locked=True),
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert result[0]['content'] == "Short memory"
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_limit_capped_at_20(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = []
+        search_memories(query="test", limit=100, uid="user-1")
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=20)
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_results_sorted_by_relevance_desc(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'score': 0.5},
+            {'memory_id': 'mem-2', 'score': 0.99},
+            {'memory_id': 'mem-3', 'score': 0.75},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            self._make_memory('mem-1', 'Low relevance'),
+            self._make_memory('mem-2', 'High relevance'),
+            self._make_memory('mem-3', 'Mid relevance'),
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert [r['relevance_score'] for r in result] == [0.99, 0.75, 0.5]
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_skips_matches_with_no_memory_id(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'score': 0.9},
+            {'category': 'other', 'score': 0.5},
+            {'memory_id': None, 'score': 0.3},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            self._make_memory('mem-1', 'Valid memory'),
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert len(result) == 1
+        assert result[0]['id'] == 'mem-1'
+        mock_memories_db.get_memories_by_ids.assert_called_once_with("user-1", ['mem-1'])
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_returns_empty_when_all_ids_filtered(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = [
+            {'category': 'other', 'score': 0.5},
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert result == []
+        mock_memories_db.get_memories_by_ids.assert_not_called()
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_default_limit_is_10(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = []
+        search_memories(query="test", uid="user-1")
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=10)

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -158,6 +158,20 @@ class TestSearchMemoriesEndpoint:
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')
+    def test_limit_zero_clamped_to_1(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = []
+        search_memories(query="test", limit=0, uid="user-1")
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=1)
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_negative_limit_clamped_to_1(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = []
+        search_memories(query="test", limit=-5, uid="user-1")
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=1)
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
     def test_results_sorted_by_relevance_desc(self, mock_vector_db, mock_memories_db):
         mock_vector_db.find_similar_memories.return_value = [
             {'memory_id': 'mem-1', 'score': 0.5},

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -101,7 +101,8 @@ class TestSearchMemoriesEndpoint:
         mock_vector_db.find_similar_memories.return_value = []
         result = search_memories(query="test", limit=10, uid="user-1")
         assert result == []
-        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=10)
+        # limit=10 → fetch_limit = min(10*3, 60) = 30
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=30)
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')
@@ -140,24 +141,27 @@ class TestSearchMemoriesEndpoint:
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')
-    def test_limit_capped_at_20(self, mock_vector_db, mock_memories_db):
+    def test_limit_capped_at_20_fetches_60_candidates(self, mock_vector_db, mock_memories_db):
         mock_vector_db.find_similar_memories.return_value = []
         search_memories(query="test", limit=100, uid="user-1")
-        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=20)
+        # limit clamps to 20, fetch_limit = min(20*3, 60) = 60
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=60)
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')
-    def test_limit_zero_clamped_to_1(self, mock_vector_db, mock_memories_db):
+    def test_limit_zero_clamped_to_1_fetches_3_candidates(self, mock_vector_db, mock_memories_db):
         mock_vector_db.find_similar_memories.return_value = []
         search_memories(query="test", limit=0, uid="user-1")
-        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=1)
+        # limit clamps to 1, fetch_limit = min(1*3, 60) = 3
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=3)
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')
-    def test_negative_limit_clamped_to_1(self, mock_vector_db, mock_memories_db):
+    def test_negative_limit_clamped_to_1_fetches_3_candidates(self, mock_vector_db, mock_memories_db):
         mock_vector_db.find_similar_memories.return_value = []
         search_memories(query="test", limit=-5, uid="user-1")
-        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=1)
+        # limit clamps to 1, fetch_limit = min(1*3, 60) = 3
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=3)
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')
@@ -203,10 +207,28 @@ class TestSearchMemoriesEndpoint:
 
     @patch('routers.mcp.memories_db')
     @patch('routers.mcp.vector_db')
-    def test_default_limit_is_10(self, mock_vector_db, mock_memories_db):
+    def test_default_limit_fetches_3x_candidates(self, mock_vector_db, mock_memories_db):
         mock_vector_db.find_similar_memories.return_value = []
         search_memories(query="test", uid="user-1")
-        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=10)
+        # default limit=10, fetch_limit = min(10*3, 60) = 30
+        mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=30)
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_locked_top_hit_does_not_exhaust_budget(self, mock_vector_db, mock_memories_db):
+        # Reviewer's exact scenario: best Pinecone hit is locked, second is accessible.
+        # With exact-limit fetching this returned [], now returns the accessible memory.
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-locked', 'score': 0.99},
+            {'memory_id': 'mem-ok', 'score': 0.80},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            self._make_memory('mem-locked', 'secret', 'other', locked=True),
+            self._make_memory('mem-ok', 'visible', 'other', locked=False),
+        ]
+        result = search_memories(query="test", limit=1, uid="user-1")
+        assert len(result) == 1
+        assert result[0]['id'] == 'mem-ok'
 
 
 class TestSearchMemoriesUserReview:

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -82,7 +82,7 @@ sys.modules['firebase_admin.auth'].RevokedIdTokenError = type('RevokedIdTokenErr
 sys.modules['firebase_admin.auth'].CertificateFetchError = type('CertificateFetchError', (Exception,), {})
 sys.modules['firebase_admin.auth'].UserNotFoundError = type('UserNotFoundError', (Exception,), {})
 
-from routers.mcp import search_memories
+from routers.mcp import search_memories, delete_memory
 
 
 class TestSearchMemoriesEndpoint:
@@ -218,3 +218,26 @@ class TestSearchMemoriesEndpoint:
         mock_vector_db.find_similar_memories.return_value = []
         search_memories(query="test", uid="user-1")
         mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=10)
+
+
+class TestDeleteMemoryVectorSync:
+    """delete_memory must also remove the Pinecone vector so search_memories
+    does not return stale top-K slots for deleted memories."""
+
+    @patch('routers.mcp.delete_memory_vector')
+    @patch('routers.mcp.memories_db')
+    def test_delete_removes_vector(self, mock_memories_db, mock_delete_vector):
+        mock_memories_db.get_memory.return_value = {'id': 'mem-1', 'content': 'x', 'is_locked': False}
+        result = delete_memory(memory_id="mem-1", uid="user-1")
+        assert result == {"status": "ok"}
+        mock_memories_db.delete_memory.assert_called_once_with("user-1", "mem-1")
+        mock_delete_vector.assert_called_once_with("user-1", "mem-1")
+
+    @patch('routers.mcp.delete_memory_vector')
+    @patch('routers.mcp.memories_db')
+    def test_delete_succeeds_when_vector_delete_fails(self, mock_memories_db, mock_delete_vector):
+        mock_memories_db.get_memory.return_value = {'id': 'mem-1', 'content': 'x', 'is_locked': False}
+        mock_delete_vector.side_effect = Exception("pinecone down")
+        result = delete_memory(memory_id="mem-1", uid="user-1")
+        assert result == {"status": "ok"}
+        mock_memories_db.delete_memory.assert_called_once_with("user-1", "mem-1")

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -220,6 +220,50 @@ class TestSearchMemoriesEndpoint:
         mock_vector_db.find_similar_memories.assert_called_once_with("user-1", "test", threshold=0.0, limit=10)
 
 
+class TestSearchMemoriesUserReview:
+    """search_memories must not surface memories the user explicitly rejected."""
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_rejected_memory_excluded(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'score': 0.9},
+            {'memory_id': 'mem-2', 'score': 0.8},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            {'id': 'mem-1', 'content': 'accepted', 'category': 'other', 'is_locked': False, 'user_review': True},
+            {'id': 'mem-2', 'content': 'rejected', 'category': 'other', 'is_locked': False, 'user_review': False},
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert len(result) == 1
+        assert result[0]['id'] == 'mem-1'
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_unreviewed_memory_included(self, mock_vector_db, mock_memories_db):
+        # user_review=None means not yet reviewed — should still appear
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'score': 0.9},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            {'id': 'mem-1', 'content': 'pending review', 'category': 'other', 'is_locked': False},
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert len(result) == 1
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_all_rejected_returns_empty(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'score': 0.9},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            {'id': 'mem-1', 'content': 'rejected', 'category': 'other', 'is_locked': False, 'user_review': False},
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert result == []
+
+
 class TestDeleteMemoryVectorSync:
     """delete_memory must also remove the Pinecone vector so search_memories
     does not return stale top-K slots for deleted memories."""

--- a/mcp/src/mcp_server_omi/server.py
+++ b/mcp/src/mcp_server_omi/server.py
@@ -66,6 +66,7 @@ if not base_url or base_url == "":
 
 class OmiTools(str, Enum):
     GET_MEMORIES = "get_memories"
+    SEARCH_MEMORIES = "search_memories"
     CREATE_MEMORY = "create_memory"
     DELETE_MEMORY = "delete_memory"
     EDIT_MEMORY = "edit_memory"
@@ -108,6 +109,15 @@ class EditMemory(BaseModel):
     )
     memory_id: str = Field(description="The ID of the memory to edit.")
     content: str = Field(description="The new content for the memory.")
+
+
+class SearchMemories(BaseModel):
+    api_key: Optional[str] = Field(
+        description="The user's MCP API key. If not provided, it will be read from the OMI_API_KEY environment variable. For more details, see https://docs.omi.me/doc/developer/MCP",
+        default=None,
+    )
+    query: str = Field(description="Natural language search query to find relevant memories.")
+    limit: int = Field(description="Maximum number of results to return.", default=10)
 
 
 class GetConversations(BaseModel):
@@ -189,6 +199,22 @@ def edit_memory(api_key: str, memory_id: str, content: str) -> dict:
         headers={"Authorization": f"Bearer {api_key}"},
         params={"value": content},
     )
+    return response.json()
+
+
+def search_memories(
+    logger: logging.Logger,
+    api_key: str,
+    query: str,
+    limit: int = 10,
+) -> List:
+    logger.info(f"Searching memories with limit={limit}")
+    response = requests.get(
+        f"{base_url}memories/search",
+        params={"query": query, "limit": limit},
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    response.raise_for_status()
     return response.json()
 
 
@@ -274,6 +300,11 @@ async def serve(uid: str | None) -> None:
                 inputSchema=GetMemories.model_json_schema(),
             ),
             Tool(
+                name=OmiTools.SEARCH_MEMORIES,
+                description="Semantic search across memories. Returns memories ranked by relevance to a natural language query.",
+                inputSchema=SearchMemories.model_json_schema(),
+            ),
+            Tool(
                 name=OmiTools.CREATE_MEMORY,
                 description="Create a new memory. A memory is a known fact about the user across multiple domains.",
                 inputSchema=CreateMemory.model_json_schema(),
@@ -331,6 +362,18 @@ async def serve(uid: str | None) -> None:
                 offset=arguments.get("offset", 0),
                 limit=arguments.get("limit", 100),
                 categories=categories_enum,
+            )
+            return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+        elif name == OmiTools.SEARCH_MEMORIES:
+            query = arguments.get("query")
+            if not query:
+                raise ValueError("query is required for search_memories")
+            result = search_memories(
+                logger,
+                api_key,
+                query=query,
+                limit=arguments.get("limit", 10),
             )
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
 

--- a/mcp/tests/test_search_conversations.py
+++ b/mcp/tests/test_search_conversations.py
@@ -129,5 +129,17 @@ class TestOmiToolsEnum:
     def test_search_conversations_in_enum(self):
         assert OmiTools.SEARCH_CONVERSATIONS == "search_conversations"
 
-    def test_total_tool_count(self):
-        assert len(OmiTools) == 7
+    def test_search_memories_in_enum(self):
+        assert OmiTools.SEARCH_MEMORIES == "search_memories"
+
+    def test_expected_tools(self):
+        assert {t.value for t in OmiTools} == {
+            "get_memories",
+            "search_memories",
+            "create_memory",
+            "delete_memory",
+            "edit_memory",
+            "get_conversations",
+            "get_conversation_by_id",
+            "search_conversations",
+        }


### PR DESCRIPTION
## Summary

- Adds `search_memories` semantic search tool to the Python MCP server (`mcp/src/mcp_server_omi/server.py`), enabling Claude Desktop, Cursor, ChatGPT, and other MCP clients to search the user's memories by meaning.
- Adds `GET /v1/mcp/memories/search` REST endpoint to `backend/routers/mcp.py`, returning memories ranked by relevance with `relevance_score`.

## The gap

The SSE MCP server (`mcp_sse.py`) already has `search_memories` (added in PR #6572, fixed in #6609, requested in #6555). The Python MCP server — which is what developers connect from Claude Desktop, Cursor, and ChatGPT — only has `get_memories` (paginated list) and `search_conversations`, but **no semantic memory search**.

This PR closes that gap by wiring the same `vector_db.find_similar_memories` backend into the Python MCP path.

## Before/After

| MCP Client | Before | After |
|---|---|---|
| Claude Desktop | `get_memories` only (paginated) | `search_memories("machine learning")` returns ranked results |
| Cursor, ChatGPT | No way to find memories by topic | Semantic search with relevance scores |

## Implementation

- Backend route follows the exact same pattern as the existing `GET /v1/mcp/conversations/search` in the same file
- Uses `vector_db.find_similar_memories(uid, query, threshold=0.0, limit=limit)` — same function the SSE server uses
- Returns `SearchedMemory` with `id`, `content`, `category`, `relevance_score`
- Filters locked memories (consistent with existing `get_memories` behavior)
- Caps `limit` at 20 to match the SSE server behavior
- Python MCP server mirrors the existing `search_conversations` tool pattern exactly

## Files

| File | Change |
|---|---|
| `backend/routers/mcp.py` | New `SearchedMemory` model and `GET /v1/mcp/memories/search` route |
| `mcp/src/mcp_server_omi/server.py` | New `SearchMemories` model, `search_memories` function, tool registration, and handler |

## Related

- PR #6572 — added `search_memories` to the SSE MCP server
- PR #6609 — fixed the SSE `search_memories` 500 bug
- Issue #6555 — original feature request for MCP search
- Issue #6621 — open request for `search_conversations` to search transcripts (separate concern)

🤖 Generated with OpenCode
