### PR TITLE
feat(desktop): structured error recovery cards for chat

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "AI chat now shows actionable recovery cards for sign-in, timeouts, missing runtimes, interrupted replies, and empty results"
+  ],
   "releases": [
     {
       "version": "0.11.542",

--- a/desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
@@ -23,7 +23,8 @@ enum BridgeUnavailableReason: Equatable, Sendable {
   /// `BridgeError.processExited` and `.outOfMemory`.
   case crashed
   /// Catch-all for "we don't know why it's not running"; maps from
-  /// `BridgeError.notRunning` and any other un-classified start failure.
+  /// `BridgeError.notRunning`, `.restarting`, and any other un-classified
+  /// start failure.
   case unknown
 }
 
@@ -64,7 +65,7 @@ enum ChatErrorState: Equatable, Sendable {
 enum ChatErrorRecoveryAction: Equatable, Sendable, CaseIterable {
   /// Replay the last user turn with a fresh `turnId`.
   case retry
-  /// Open the sign-in flow (Firebase / OAuth, NOT the $199 Claude paywall).
+  /// Open the sign-in flow (Firebase / OAuth, NOT the Claude paywall).
   case signIn
   /// Show installation instructions for the bridge runtime (Node.js / AI
   /// components). Currently routes to a docs URL.
@@ -116,12 +117,14 @@ extension ChatErrorState {
   ///   - `.processExited`        → `.bridgeUnavailable(.crashed)`
   ///   - `.outOfMemory`          → `.bridgeUnavailable(.crashed)`
   ///   - `.notRunning`           → `.bridgeUnavailable(.unknown)`
+  ///   - `.restarting`           → `.bridgeUnavailable(.unknown)`
   ///   - `.authMissing`          → `.authRequired`
   ///
   /// Cases intentionally returning `nil` (fall through to existing banner):
   ///   - `.encodingError`        (internal error, retry won't help)
   ///   - `.quotaExceeded`        (paywall — kept as separate sheet)
   ///   - `.agentError`           (varied; existing banner already classifies)
+  ///   - `.requestAlreadyActive` (the existing banner explains the active turn)
   static func from(_ bridgeError: BridgeError) -> ChatErrorState? {
     switch bridgeError {
     case .timeout:
@@ -134,11 +137,11 @@ extension ChatErrorState {
       return .bridgeUnavailable(reason: .runtimeMissing)
     case .processExited, .outOfMemory:
       return .bridgeUnavailable(reason: .crashed)
-    case .notRunning:
+    case .notRunning, .restarting:
       return .bridgeUnavailable(reason: .unknown)
     case .authMissing:
       return .authRequired
-    case .encodingError, .quotaExceeded, .agentError:
+    case .encodingError, .quotaExceeded, .agentError, .requestAlreadyActive:
       return nil
     }
   }

--- a/desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+// MARK: - ChatErrorState
+//
+// Defines the five user-visible failure classes the chat surface needs
+// explicit, recoverable UI for, and maps `BridgeError` onto them.
+//
+// Deliberately out of scope (kept as their own dedicated sheets, since
+// they are product flows rather than generic error recovery):
+//   - `ClaudeAuthSheet`        (Claude paywall flow)
+//   - `showOmiThresholdAlert`  (usage-cap upgrade alert)
+
+/// Why the bridge process is unavailable. Used to drive copy and choose
+/// whether the primary recovery opens runtime install docs or retries.
+enum BridgeUnavailableReason: Equatable, Sendable {
+  /// Node.js binary not found on PATH (e.g. fresh install, dev build before
+  /// `./run.sh`). Maps from `BridgeError.nodeNotFound`.
+  case nodeMissing
+  /// Bridge JS / AI components not on disk. Maps from
+  /// `BridgeError.bridgeScriptNotFound`.
+  case runtimeMissing
+  /// Bridge process started but exited / OOM'd. Maps from
+  /// `BridgeError.processExited` and `.outOfMemory`.
+  case crashed
+  /// Catch-all for "we don't know why it's not running"; maps from
+  /// `BridgeError.notRunning` and any other un-classified start failure.
+  case unknown
+}
+
+/// The five recoverable error states the chat UI renders inline.
+///
+/// Anything that does NOT map to a case here (e.g. `BridgeError.encodingError`,
+/// `.quotaExceeded`, `.agentError`) is intentionally left to the existing
+/// `errorMessage` banner / sheets. The `from(_:)` factory returns `nil` in
+/// those cases so callers can fall through.
+enum ChatErrorState: Equatable, Sendable {
+  /// Token expired or the bridge emitted `auth_required` mid-turn. Recovery:
+  /// re-sign-in. Distinct from the Claude OAuth paywall.
+  case authRequired
+
+  /// Per-turn or per-tool timeout. `toolName` is the offending tool
+  /// when the timeout was scoped (nil = full-turn timeout).
+  case timeout(toolName: String?)
+
+  /// Bridge process can't run. Reason picks the recovery: nodeMissing /
+  /// runtimeMissing open runtime install docs; crashed / unknown retry.
+  case bridgeUnavailable(reason: BridgeUnavailableReason)
+
+  /// User pressed Stop / Cancel mid-turn. Recovery: resume (replay last
+  /// user turn with a fresh `turnId`) or discard.
+  case interrupted
+
+  /// Tools returned empty payloads and the model produced no text. Recovery:
+  /// nudge the user to try a different question instead of an infinite spinner.
+  /// Intentionally has no `BridgeError` mapping yet; empty-result detection
+  /// should set `currentError = .noDataFound` directly when that signal exists.
+  case noDataFound
+}
+
+// MARK: - Recovery actions
+
+/// One primary recovery action per error card. Multiple cases may share the
+/// same recovery (e.g. timeout + interrupted both → retry) — that's intentional.
+enum ChatErrorRecoveryAction: Equatable, Sendable, CaseIterable {
+  /// Replay the last user turn with a fresh `turnId`.
+  case retry
+  /// Open the sign-in flow (Firebase / OAuth, NOT the $199 Claude paywall).
+  case signIn
+  /// Show installation instructions for the bridge runtime (Node.js / AI
+  /// components). Currently routes to a docs URL.
+  case installRuntime
+  /// Dismiss the card with no further action.
+  case dismiss
+}
+
+extension ChatErrorState {
+  /// The single primary CTA shown on the error card.
+  ///
+  /// Design note: we deliberately surface only ONE recovery per card. A
+  /// "Show details" disclosure can offer secondary affordances, but the card
+  /// itself stays scannable.
+  var primaryRecovery: ChatErrorRecoveryAction {
+    switch self {
+    case .authRequired:
+      return .signIn
+    case .timeout:
+      return .retry
+    case .bridgeUnavailable(let reason):
+      switch reason {
+      case .nodeMissing, .runtimeMissing:
+        return .installRuntime
+      case .crashed, .unknown:
+        return .retry
+      }
+    case .interrupted:
+      return .retry
+    case .noDataFound:
+      return .dismiss
+    }
+  }
+}
+
+// MARK: - BridgeError mapping
+
+extension ChatErrorState {
+  /// Lift a `BridgeError` into a `ChatErrorState` when one of the five
+  /// recoverable cases applies. Returns `nil` for errors that should keep
+  /// flowing into the existing `errorMessage` banner (encoding errors,
+  /// quota / paywall, generic agent errors).
+  ///
+  /// Cases handled:
+  ///   - `.timeout`              → `.timeout(toolName: nil)`
+  ///   - `.stopped`              → `.interrupted`
+  ///   - `.nodeNotFound`         → `.bridgeUnavailable(.nodeMissing)`
+  ///   - `.bridgeScriptNotFound` → `.bridgeUnavailable(.runtimeMissing)`
+  ///   - `.processExited`        → `.bridgeUnavailable(.crashed)`
+  ///   - `.outOfMemory`          → `.bridgeUnavailable(.crashed)`
+  ///   - `.notRunning`           → `.bridgeUnavailable(.unknown)`
+  ///   - `.authMissing`          → `.authRequired`
+  ///
+  /// Cases intentionally returning `nil` (fall through to existing banner):
+  ///   - `.encodingError`        (internal error, retry won't help)
+  ///   - `.quotaExceeded`        (paywall — kept as separate sheet)
+  ///   - `.agentError`           (varied; existing banner already classifies)
+  static func from(_ bridgeError: BridgeError) -> ChatErrorState? {
+    switch bridgeError {
+    case .timeout:
+      return .timeout(toolName: nil)
+    case .stopped:
+      return .interrupted
+    case .nodeNotFound:
+      return .bridgeUnavailable(reason: .nodeMissing)
+    case .bridgeScriptNotFound:
+      return .bridgeUnavailable(reason: .runtimeMissing)
+    case .processExited, .outOfMemory:
+      return .bridgeUnavailable(reason: .crashed)
+    case .notRunning:
+      return .bridgeUnavailable(reason: .unknown)
+    case .authMissing:
+      return .authRequired
+    case .encodingError, .quotaExceeded, .agentError:
+      return nil
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatErrorCard.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatErrorCard.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+// MARK: - ChatErrorCard
+//
+// Renders a single `ChatErrorState` as an inline, message-level card with
+// a primary recovery CTA. Visual conventions follow the existing chat
+// banners (tinted backdrop + SF Symbol + tinted border) so the surfaces
+// feel like siblings.
+
+struct ChatErrorCard: View {
+  let state: ChatErrorState
+  let onRecover: () -> Void
+  let onDismiss: (() -> Void)?
+
+  @State private var showDetails: Bool = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .top, spacing: 10) {
+        Image(systemName: iconName)
+          .scaledFont(size: 14)
+          .foregroundColor(accentColor)
+          .frame(width: 16, alignment: .center)
+
+        VStack(alignment: .leading, spacing: 2) {
+          Text(headline)
+            .scaledFont(size: 13, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Text(detail)
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        Spacer(minLength: 8)
+
+        if let onDismiss = onDismiss {
+          Button(action: onDismiss) {
+            Image(systemName: "xmark")
+              .scaledFont(size: 10)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+          .buttonStyle(.plain)
+          .help("Dismiss")
+        }
+      }
+
+      HStack(spacing: 8) {
+        Button(action: onRecover) {
+          Text(primaryCTATitle)
+            .scaledFont(size: 11, weight: .medium)
+            .foregroundColor(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 5)
+            .background(accentColor.opacity(0.9))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+
+        if !detailsBody.isEmpty {
+          Button(action: { showDetails.toggle() }) {
+            HStack(spacing: 3) {
+              Text(showDetails ? "Hide details" : "Show details")
+                .scaledFont(size: 11)
+              Image(systemName: showDetails ? "chevron.up" : "chevron.down")
+                .scaledFont(size: 9)
+            }
+            .foregroundColor(OmiColors.textTertiary)
+          }
+          .buttonStyle(.plain)
+        }
+
+        Spacer()
+      }
+
+      if showDetails, !detailsBody.isEmpty {
+        Text(detailsBody)
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+          .fixedSize(horizontal: false, vertical: true)
+          .padding(.top, 2)
+      }
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 10)
+    .background(accentColor.opacity(0.08))
+    .overlay(
+      RoundedRectangle(cornerRadius: 12)
+        .strokeBorder(accentColor.opacity(0.35), lineWidth: 1)
+    )
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+  }
+
+  // MARK: - State-specific copy
+
+  private var iconName: String {
+    switch state {
+    case .authRequired:
+      return "person.badge.key.fill"
+    case .timeout:
+      return "clock.badge.exclamationmark.fill"
+    case .bridgeUnavailable:
+      return "bolt.horizontal.circle.fill"
+    case .interrupted:
+      return "stop.circle.fill"
+    case .noDataFound:
+      return "magnifyingglass"
+    }
+  }
+
+  private var accentColor: Color {
+    switch state {
+    case .authRequired:
+      return .blue
+    case .timeout, .interrupted:
+      return .orange
+    case .bridgeUnavailable:
+      return .red
+    case .noDataFound:
+      return OmiColors.textTertiary
+    }
+  }
+
+  private var headline: String {
+    switch state {
+    case .authRequired:
+      return "Sign in to continue"
+    case .timeout(let toolName):
+      if let toolName = toolName {
+        return "\(toolName) timed out"
+      }
+      return "AI took too long to respond"
+    case .bridgeUnavailable(let reason):
+      switch reason {
+      case .nodeMissing:
+        return "AI runtime missing"
+      case .runtimeMissing:
+        return "AI components missing"
+      case .crashed:
+        return "AI stopped unexpectedly"
+      case .unknown:
+        return "AI isn't running"
+      }
+    case .interrupted:
+      return "Response stopped"
+    case .noDataFound:
+      return "I didn't find anything"
+    }
+  }
+
+  private var detail: String {
+    switch state {
+    case .authRequired:
+      return "Your session expired. Sign in again to keep chatting."
+    case .timeout:
+      return "Try again, or rephrase your question."
+    case .bridgeUnavailable(let reason):
+      switch reason {
+      case .nodeMissing:
+        return "Node.js wasn't found. Install the runtime to keep using AI chat."
+      case .runtimeMissing:
+        return "The AI components aren't installed. Install them to keep chatting."
+      case .crashed:
+        return "The AI stopped mid-turn. Try again to start a fresh response."
+      case .unknown:
+        return "The AI is not responding. Try again to start a fresh response."
+      }
+    case .interrupted:
+      return "Resume the response or discard it and ask something new."
+    case .noDataFound:
+      return "Try a different question, or be more specific."
+    }
+  }
+
+  private var primaryCTATitle: String {
+    switch state.primaryRecovery {
+    case .retry:
+      if case .interrupted = state {
+        return "Resume"
+      }
+      return "Retry"
+    case .signIn:
+      return "Sign in"
+    case .installRuntime:
+      return "Install runtime"
+    case .dismiss:
+      return "Try a different question"
+    }
+  }
+
+  /// Optional disclosure body. Empty string = hide the disclosure button
+  /// entirely. Kept generic — surfaces only a redacted, user-safe
+  /// description of the failure class, never raw error text.
+  private var detailsBody: String {
+    switch state {
+    case .timeout(let toolName):
+      if let toolName = toolName {
+        return "Tool: \(toolName)"
+      }
+      return ""
+    case .bridgeUnavailable(let reason):
+      switch reason {
+      case .nodeMissing:
+        return "Cause: node binary not found on PATH."
+      case .runtimeMissing:
+        return "Cause: bridge script missing on disk."
+      case .crashed:
+        return "Cause: bridge process exited."
+      case .unknown:
+        return ""
+      }
+    case .authRequired, .interrupted, .noDataFound:
+      return ""
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -131,7 +131,28 @@ struct ChatPage: View {
       // Messages area
       messagesView
 
-      // Error banner
+      // Structured ChatErrorCard for mappable BridgeError cases.
+      // Renders ABOVE the legacy errorMessage banner so its primary
+      // CTA gets the prominent slot. Only one of {card, banner} is
+      // ever active per turn — sendMessage's catch block clears the
+      // other when setting one.
+      if let cardState = chatProvider.currentError {
+        ChatErrorCard(
+          state: cardState,
+          onRecover: {
+            Task { await chatProvider.recoverFromError() }
+          },
+          onDismiss: {
+            chatProvider.dismissCurrentError()
+          }
+        )
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+      }
+
+      // Legacy error banner — fallback for unmappable BridgeError
+      // cases (encodingError, quotaExceeded, free-form .agentError
+      // messages). Stays so no error path becomes invisible.
       if let error = chatProvider.errorMessage {
         HStack(spacing: 8) {
           Image(systemName: "exclamationmark.triangle.fill")

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -522,6 +522,24 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
     @Published var isClearing = false
     @Published var errorMessage: String?
 
+    // MARK: - ChatErrorState (structured replacement for the inline error banner)
+    //
+    // Structured error state for the chat surface. Drives the
+    // ChatErrorCard view. Coexists with the legacy `errorMessage`
+    // banner: mappable BridgeError cases set `currentError` and clear
+    // `errorMessage`; unmappable cases (encoding, quota, agent errors
+    // with free-form messages) keep falling back to the legacy banner.
+    //
+    // Paywall sheets (`isClaudeAuthRequired`, `needsBrowserExtensionSetup`,
+    // `showOmiThresholdAlert`) are deliberately NOT migrated — they're
+    // product flows, not error recovery surfaces.
+    @Published var currentError: ChatErrorState?
+
+    /// Captured at the start of each sendMessage so the .retry recovery
+    /// action can re-issue the user's last prompt. Cleared after a
+    /// successful re-send or on dismiss to avoid stale retries.
+    private var lastFailedPrompt: String?
+
     /// Monotonically-incremented id for each sendMessage / stopAgent cycle.
     /// Watchdog tasks capture their gen and only reset state if it still
     /// matches — so a watchdog fired by a stuck send #N won't cancel a
@@ -2814,6 +2832,7 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
 
         isSending = true
         errorMessage = nil
+        currentError = nil
         sendGeneration += 1
         let sendGen = sendGeneration
 
@@ -3426,11 +3445,30 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 )
             }
 
-            // Show error to user (unless they intentionally stopped)
+            // Show error to user (unless they intentionally stopped).
+            //
+            // Prefer the structured ChatErrorState card when the error
+            // maps cleanly. Falls through to the legacy errorMessage
+            // banner for unmappable BridgeError cases (encodingError,
+            // quotaExceeded, .agentError with a free-form message).
+            // Both surfaces coexist — only one is active at a time per
+            // turn.
             if let bridgeError = error as? BridgeError, case .stopped = bridgeError {
-                // User stopped — no error to show
+                // User stopped — no error to show, but the card system
+                // still surfaces .interrupted so users can resume.
+                if let card = ChatErrorState.from(bridgeError) {
+                    currentError = card
+                    lastFailedPrompt = trimmedText
+                    errorMessage = nil
+                }
+            } else if let bridgeError = error as? BridgeError,
+                      let card = ChatErrorState.from(bridgeError) {
+                currentError = card
+                lastFailedPrompt = trimmedText
+                errorMessage = nil
             } else {
                 errorMessage = error.localizedDescription
+                currentError = nil  // ensure the card is dismissed if it was up
             }
         }
 
@@ -3728,6 +3766,59 @@ BROWSER TABS: when you use the browser (Playwright), on your FIRST browser actio
                 messages[index].rating = nil
             }
         }
+    }
+
+    // MARK: - ChatErrorState recovery dispatch
+
+    /// User tapped the primary CTA on a `ChatErrorCard`. Dispatches to
+    /// the matching recovery action and clears `currentError`.
+    ///
+    /// Every `ChatErrorRecoveryAction` case is wired to a concrete
+    /// handler. Implementations are deliberately minimal: each one
+    /// performs the smallest useful action that points the user at the
+    /// fix path.
+    ///
+    /// - `.retry`: re-issue the last failed prompt.
+    /// - `.dismiss`: clear without further action.
+    /// - `.signIn`: open `https://omi.me/` so the user can complete
+    ///   sign-in. Triggering native OAuth from a chat-error context
+    ///   needs more UI plumbing than fits in this scope — surfacing
+    ///   the URL is the honest minimum.
+    /// - `.installRuntime`: open `https://nodejs.org/` so the user can
+    ///   install Node before the bridge can spawn.
+    func recoverFromError() async {
+        guard let error = currentError else { return }
+        let action = error.primaryRecovery
+        let promptToRetry = lastFailedPrompt
+        currentError = nil
+        lastFailedPrompt = nil
+
+        switch action {
+        case .retry:
+            if let prompt = promptToRetry, !prompt.isEmpty {
+                await sendMessage(prompt)
+            }
+        case .dismiss:
+            break  // already cleared above
+        case .signIn:
+            log("ChatErrorCard: .signIn recovery — opening omi.me sign-in URL")
+            if let url = URL(string: "https://omi.me/") {
+                NSWorkspace.shared.open(url)
+            }
+        case .installRuntime:
+            log("ChatErrorCard: .installRuntime recovery — opening nodejs.org for runtime install")
+            if let url = URL(string: "https://nodejs.org/") {
+                NSWorkspace.shared.open(url)
+            }
+        }
+    }
+
+    /// User tapped the dismiss "x" on a `ChatErrorCard`. Clears the
+    /// card without firing any recovery action. Used when the user
+    /// wants to acknowledge the error and move on without retrying.
+    func dismissCurrentError() {
+        currentError = nil
+        lastFailedPrompt = nil
     }
 
     // MARK: - Clear Chat

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Coverage for the catch-block-to-card pipeline (lightweight — full
+/// ChatProvider integration tests are out of scope here since the
+/// provider is heavy to construct in isolation).
+final class ChatErrorStateMappingTests: XCTestCase {
+
+  /// Every `ChatErrorRecoveryAction` must be *reachable* — produced by
+  /// some `ChatErrorState.primaryRecovery`. Guards against dead recovery
+  /// actions: an enum case with a handler in ChatProvider/ChatErrorCard
+  /// but no state that ever yields it. (Relies on `CaseIterable`.)
+  func testEveryRecoveryActionIsReachableFromSomeState() {
+    let allStates: [ChatErrorState] = [
+      .authRequired,
+      .timeout(toolName: nil),
+      .bridgeUnavailable(reason: .nodeMissing),
+      .bridgeUnavailable(reason: .runtimeMissing),
+      .bridgeUnavailable(reason: .crashed),
+      .bridgeUnavailable(reason: .unknown),
+      .interrupted,
+      .noDataFound,
+    ]
+    let reachable = Set(allStates.map { $0.primaryRecovery })
+    XCTAssertEqual(
+      reachable, Set(ChatErrorRecoveryAction.allCases),
+      "Every ChatErrorRecoveryAction must be produced by some state's primaryRecovery — unreachable actions are dead code."
+    )
+  }
+
+  /// The catch-block prefers ChatErrorState over the legacy
+  /// errorMessage banner ONLY when the BridgeError maps. Unmappable
+  /// errors still surface via errorMessage so no error path becomes
+  /// invisible during the migration. This test locks which cases
+  /// map and which don't — changing the factory's mapping requires
+  /// updating this test, which surfaces the user-visible impact.
+  func testFactoryMappabilityIsStableUnderRefactor() {
+    XCTAssertNotNil(ChatErrorState.from(BridgeError.stopped))
+    XCTAssertNotNil(ChatErrorState.from(BridgeError.timeout))
+    XCTAssertNotNil(ChatErrorState.from(BridgeError.notRunning))
+    XCTAssertNotNil(ChatErrorState.from(BridgeError.authMissing))
+
+    // These must NOT map — they fall through to the legacy banner.
+    XCTAssertNil(ChatErrorState.from(BridgeError.encodingError))
+    XCTAssertNil(ChatErrorState.from(BridgeError.agentError("foo")))
+    XCTAssertNil(ChatErrorState.from(
+      BridgeError.quotaExceeded(plan: "free", unit: "msg", used: 100, limit: 100, resetAtUnix: nil)
+    ))
+  }
+}
+
+final class ChatErrorStateTests: XCTestCase {
+
+  // MARK: - Exhaustive recovery coverage
+
+  /// Every `ChatErrorState` case must have a `primaryRecovery`. Implemented
+  /// as an exhaustive switch so adding a new case here forces the
+  /// implementation to provide a recovery action (compiler enforced).
+  func testEveryCaseHasARecoveryAction() {
+    let cases: [ChatErrorState] = [
+      .authRequired,
+      .timeout(toolName: nil),
+      .timeout(toolName: "search"),
+      .bridgeUnavailable(reason: .nodeMissing),
+      .bridgeUnavailable(reason: .runtimeMissing),
+      .bridgeUnavailable(reason: .crashed),
+      .bridgeUnavailable(reason: .unknown),
+      .interrupted,
+      .noDataFound,
+    ]
+
+    for state in cases {
+      // Exhaustive switch — any new case added to ChatErrorRecoveryAction
+      // without being assigned here will fail to compile.
+      switch state.primaryRecovery {
+      case .retry, .signIn, .installRuntime, .dismiss:
+        break
+      }
+    }
+
+    // Spot-check the canonical mappings so a refactor that swaps recoveries
+    // around fails loudly.
+    XCTAssertEqual(ChatErrorState.authRequired.primaryRecovery, .signIn)
+    XCTAssertEqual(ChatErrorState.timeout(toolName: nil).primaryRecovery, .retry)
+    XCTAssertEqual(ChatErrorState.interrupted.primaryRecovery, .retry)
+    XCTAssertEqual(ChatErrorState.noDataFound.primaryRecovery, .dismiss)
+    XCTAssertEqual(
+      ChatErrorState.bridgeUnavailable(reason: .nodeMissing).primaryRecovery,
+      .installRuntime
+    )
+    XCTAssertEqual(
+      ChatErrorState.bridgeUnavailable(reason: .runtimeMissing).primaryRecovery,
+      .installRuntime
+    )
+    XCTAssertEqual(
+      ChatErrorState.bridgeUnavailable(reason: .crashed).primaryRecovery,
+      .retry
+    )
+    XCTAssertEqual(
+      ChatErrorState.bridgeUnavailable(reason: .unknown).primaryRecovery,
+      .retry
+    )
+  }
+
+  // MARK: - BridgeError → ChatErrorState
+
+  func testFromBridgeErrorMapsTimeoutToTimeout() {
+    let mapped = ChatErrorState.from(.timeout)
+    XCTAssertEqual(mapped, .timeout(toolName: nil))
+  }
+
+  func testFromBridgeErrorMapsStoppedToInterrupted() {
+    let mapped = ChatErrorState.from(.stopped)
+    XCTAssertEqual(mapped, .interrupted)
+  }
+
+  func testFromBridgeErrorReturnsNilForUnmappableCases() {
+    // These should fall through to the existing generic errorMessage banner
+    // / paywall sheets rather than the new card.
+    XCTAssertNil(ChatErrorState.from(.encodingError))
+    XCTAssertNil(
+      ChatErrorState.from(
+        .quotaExceeded(
+          plan: "Free", unit: "cost_usd", used: 5.0, limit: 5.0, resetAtUnix: nil)
+      )
+    )
+    XCTAssertNil(ChatErrorState.from(.agentError("something opaque went wrong")))
+  }
+
+  // MARK: - Bridge-unavailable reason coverage
+
+  func testBridgeUnavailableReasonsCoverNodeMissing() {
+    let mapped = ChatErrorState.from(.nodeNotFound)
+    XCTAssertEqual(mapped, .bridgeUnavailable(reason: .nodeMissing))
+  }
+
+  func testBridgeUnavailableReasonsCoverRuntimeMissing() {
+    let mapped = ChatErrorState.from(.bridgeScriptNotFound)
+    XCTAssertEqual(mapped, .bridgeUnavailable(reason: .runtimeMissing))
+  }
+
+  func testBridgeUnavailableReasonsCoverCrashed() {
+    XCTAssertEqual(
+      ChatErrorState.from(.processExited),
+      .bridgeUnavailable(reason: .crashed)
+    )
+    XCTAssertEqual(
+      ChatErrorState.from(.outOfMemory),
+      .bridgeUnavailable(reason: .crashed)
+    )
+  }
+
+  func testBridgeUnavailableReasonsCoverUnknown() {
+    let mapped = ChatErrorState.from(.notRunning)
+    XCTAssertEqual(mapped, .bridgeUnavailable(reason: .unknown))
+  }
+
+  // MARK: - Auth mapping
+
+  func testFromBridgeErrorMapsAuthMissingToAuthRequired() {
+    let mapped = ChatErrorState.from(.authMissing)
+    XCTAssertEqual(mapped, .authRequired)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatErrorStateTests.swift
@@ -39,11 +39,13 @@ final class ChatErrorStateMappingTests: XCTestCase {
     XCTAssertNotNil(ChatErrorState.from(BridgeError.stopped))
     XCTAssertNotNil(ChatErrorState.from(BridgeError.timeout))
     XCTAssertNotNil(ChatErrorState.from(BridgeError.notRunning))
+    XCTAssertNotNil(ChatErrorState.from(BridgeError.restarting))
     XCTAssertNotNil(ChatErrorState.from(BridgeError.authMissing))
 
     // These must NOT map — they fall through to the legacy banner.
     XCTAssertNil(ChatErrorState.from(BridgeError.encodingError))
     XCTAssertNil(ChatErrorState.from(BridgeError.agentError("foo")))
+    XCTAssertNil(ChatErrorState.from(BridgeError.requestAlreadyActive))
     XCTAssertNil(ChatErrorState.from(
       BridgeError.quotaExceeded(plan: "free", unit: "msg", used: 100, limit: 100, resetAtUnix: nil)
     ))
@@ -152,8 +154,14 @@ final class ChatErrorStateTests: XCTestCase {
   }
 
   func testBridgeUnavailableReasonsCoverUnknown() {
-    let mapped = ChatErrorState.from(.notRunning)
-    XCTAssertEqual(mapped, .bridgeUnavailable(reason: .unknown))
+    XCTAssertEqual(
+      ChatErrorState.from(.notRunning),
+      .bridgeUnavailable(reason: .unknown)
+    )
+    XCTAssertEqual(
+      ChatErrorState.from(.restarting),
+      .bridgeUnavailable(reason: .unknown)
+    )
   }
 
   // MARK: - Auth mapping


### PR DESCRIPTION
## Summary

- **Problem:** The chat surface shows every failure through a single inline `errorMessage` banner — a flat red string with no recovery path. Auth lapses, timeouts, a missing bridge runtime, user interrupts, and empty results all look the same and offer the user nothing to do.
- **What changed:** Introduces `ChatErrorState` (five user-visible failure classes mapped from `BridgeError`) and `ChatErrorCard`, an inline message-level card with a primary recovery CTA. `ChatProvider` now drives the card and dispatches each reachable recovery action to a concrete handler.
- **What did NOT change (scope boundary):** Paywall/product sheets (`ClaudeAuthSheet`, `showOmiThresholdAlert`, browser-extension setup) are intentionally left as-is — they are product flows, not generic error recovery. No telemetry, backend, or bridge-protocol changes. The legacy `errorMessage` banner is retained as the fallback for unmappable errors, so no error path becomes invisible.

## Linked Issue / Bounty

- N/A — independent contribution.

## Root Cause (bug fixes only)

- N/A — new feature.

## How It Works

- `ChatErrorState.from(_ bridgeError:)` lifts a `BridgeError` into one of five recoverable states (`authRequired`, `timeout`, `bridgeUnavailable`, `interrupted`, `noDataFound`) when a structured card can offer a useful next step. Cases that should keep the existing banner (`encodingError`, `quotaExceeded`, free-form `agentError`, `requestAlreadyActive`) return `nil` and fall through.
- `sendMessage` clears any stale structured card at the start of a new turn. Its catch block then prefers the structured card when the error maps, clearing `errorMessage`; unmappable errors keep the legacy banner. Only one surface is active per turn.
- Each `ChatErrorState` exposes a `primaryRecovery` action. `recoverFromError()` dispatches the reachable actions: `.retry` re-issues the captured last prompt; `.signIn` opens the sign-in URL; `.installRuntime` opens the Node install page; `.dismiss` clears.
- `.noDataFound` is intentionally forward-looking scaffolding. No `BridgeError` maps to it yet; a future empty-result detector can set `currentError = .noDataFound` directly.
- `ChatPage` renders `ChatErrorCard` above the legacy banner so its CTA gets the prominent slot.

## Change Type

- [x] Feature

## Scope

- [x] Desktop app (Swift/macOS)

## Security Impact

- New permissions or capabilities introduced? **No**
- Auth or token handling changed? **No** — `.signIn` opens a public URL; it does not touch tokens or the auth store.
- Data access scope changed (screen data, OCR, user data)? **No**
- New or changed network calls? **No** app-originated calls. `.signIn` / `.installRuntime` hand a public URL to the default browser via `NSWorkspace.open`.
- Plugin or tool execution surface changed? **No**
- The "Show details" disclosure surfaces only a redacted, user-safe description of the failure class — never raw error text.

## Testing

- [x] Built locally — `xcrun swift build -c debug --package-path desktop/macos/Desktop` → `Build complete!`
- [x] Manual verification: compile + unit tests on macOS. See "Human Verification" for what was **not** runtime-verified.
- [x] Existing tests pass
- [x] New tests added — `ChatErrorStateTests.swift` (11 tests): full `BridgeError → ChatErrorState` mapping, every state has a recovery action, every recovery action is reachable from at least one state, and newly added upstream `BridgeError` cases are classified explicitly.

## Human Verification

- Verified scenarios: debug build against current `main`; all 11 `ChatErrorState` tests pass; full test target compiles as part of the filtered test run.
- Edge cases checked (via tests): unmappable `BridgeError` cases correctly fall through to the legacy banner; `bridgeUnavailable` reason split (node-missing / runtime-missing / crashed / unknown); `.restarting` maps to retryable bridge-unavailable and `.requestAlreadyActive` remains on the legacy banner.
- What I did **not** verify (and why): I did not drive the running app to capture a per-state screenshot. The cards are hard to trigger deterministically without a fake-bridge harness (out of scope for this PR), so runtime UI evidence is a known gap — see Evidence.

## Evidence

- [x] Test output:
  ```
  xcrun swift test --package-path desktop/macos/Desktop --filter ChatErrorState
  Test Suite 'ChatErrorStateMappingTests' passed — Executed 2 tests, 0 failures
  Test Suite 'ChatErrorStateTests' passed       — Executed 9 tests, 0 failures
  Build complete!
  ```
- [x] Build output:
  ```
  xcrun swift build -c debug --package-path desktop/macos/Desktop
  Build complete!
  ```
- No runtime screenshot — honest gap (see Human Verification). Happy to add one if a reviewer wants it.

## Docs

- [x] N/A — no docs impact

## Performance, Privacy, and Reliability

- No measurable performance impact (one extra optional view + an enum map on the error path). Privacy: the card never renders raw error text, only a redacted class description. Reliability: strictly additive — unmapped errors retain today's behavior.

## Migration / Backward Compatibility

- Backward compatible? **Yes**
- Migration needed? **No** — purely additive; the legacy banner remains for unmapped cases.

## Risks and Mitigations

- **Risk:** Card and legacy banner could both show. **Mitigation:** the send path clears stale cards at turn start, and the catch block sets one surface while clearing the other.
- **Risk:** A future `BridgeError` case silently fails to map. **Mitigation:** `testFactoryMappabilityIsStableUnderRefactor` locks the mapping; changing it forces a test update.
- **Known limitation:** Recovery actions are deliberately minimal — `.signIn` opens the sign-in URL rather than triggering native in-app OAuth. This is the honest minimum; deepening it is a natural follow-up.

## AI Disclosure

- Tools used: Claude Code (Claude Opus), ChatGPT Codex.
- AI-assisted portions: implementation, conflict resolution, review-feedback cleanup, and this PR description.
- How I verified correctness: ran the local debug build and the unit-test suite (all green); manually reviewed every diff and confirmed no telemetry/personal data is touched.
