### PR TITLE
feat(webhooks): add summary_json field to day_summary_webhook (follow-up to #7110)

### DIFF
--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -47,7 +47,7 @@ if "utils.notifications" not in sys.modules:
     sys.modules["utils.notifications"] = types.ModuleType("utils.notifications")
 sys.modules["utils.notifications"].send_notification = MagicMock()
 
-from utils.webhooks import realtime_transcript_webhook, send_audio_bytes_developer_webhook
+from utils.webhooks import realtime_transcript_webhook, send_audio_bytes_developer_webhook, day_summary_webhook
 
 
 class TestRealtimeTranscriptWebhook:
@@ -275,6 +275,95 @@ class TestConversationAndSummaryWebhooksStructural:
         assert (
             'requests.post' not in func_body
         ), "day_summary_webhook must not use blocking requests.post — use httpx.AsyncClient"
+
+
+class TestDaySummaryWebhookJsonField:
+    """Verify the new ``summary_json`` field is sent alongside the legacy ``summary`` string.
+
+    The wire format keeps ``summary`` as a Python ``repr`` string for backward
+    compatibility (existing receivers depend on it). The new ``summary_json``
+    field carries the exact same payload as a real JSON object so receivers can
+    migrate off ``ast.literal_eval``-style parsing. These tests pin both
+    behaviours to prevent silent regressions in either direction.
+    """
+
+    _SAMPLE_SUMMARY_JSON = {
+        "id": "summary-abc",
+        "date": "2024-01-15",
+        "headline": "Productive day with three meetings",
+        "overview": "You had a productive day focused on project planning.",
+        "day_emoji": "💼",
+        "stats": {"total_conversations": 3, "total_duration_minutes": 120, "action_items_count": 1},
+        "highlights": [],
+        "action_items": [],
+        "unresolved_questions": [],
+        "decisions_made": [],
+        "knowledge_nuggets": [],
+        "locations": [],
+    }
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_summary_json_as_dict_and_keeps_legacy_summary(self):
+        """Both legacy ``summary`` (str) and new ``summary_json`` (dict) must travel together."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        legacy_summary_str = str(self._SAMPLE_SUMMARY_JSON)
+
+        with patch("utils.webhooks.get_webhook_client", return_value=mock_client):
+            await day_summary_webhook("uid-1", legacy_summary_str, self._SAMPLE_SUMMARY_JSON)
+
+        mock_client.post.assert_called_once()
+        payload = mock_client.post.call_args.kwargs["json"]
+
+        assert isinstance(
+            payload["summary_json"], dict
+        ), f"summary_json must be a JSON object, got {type(payload['summary_json'])}: {payload['summary_json']!r}"
+        assert payload["summary_json"]["headline"] == "Productive day with three meetings"
+
+        assert isinstance(payload["summary"], str), "legacy summary must remain a string for backward compatibility"
+        assert payload["summary"] == legacy_summary_str
+
+        assert payload["uid"] == "uid-1"
+        assert payload["created_at"].endswith("+00:00")
+
+    @pytest.mark.asyncio
+    async def test_summary_json_defaults_to_none_when_not_supplied(self):
+        """Callers that haven't migrated yet still get a well-formed payload (summary_json: null)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("utils.webhooks.get_webhook_client", return_value=mock_client):
+            await day_summary_webhook("uid-1", "{'legacy': 'repr'}")
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["summary_json"] is None
+        assert payload["summary"] == "{'legacy': 'repr'}"
+
+
+class TestSendSummaryNotificationWiresSummaryJson:
+    """Static guard that ``_send_summary_notification`` passes the dict as ``summary_json``.
+
+    Avoids importing notifications.py (which pulls in Firestore / LLM / pytz) by
+    grepping the source. Mirrors the existing static-wiring tests in
+    test_async_http_infrastructure.py.
+    """
+
+    def test_notifications_passes_summary_data_as_summary_json(self):
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'utils', 'other', 'notifications.py')
+        with open(path) as f:
+            src = f.read()
+
+        assert 'day_summary_webhook(uid, str(summary_data), summary_data)' in src, (
+            "_send_summary_notification must pass summary_data (dict) as the summary_json arg of day_summary_webhook "
+            "so receivers get a real JSON object alongside the legacy repr string."
+        )
 
 
 class TestCircuitBreakerIntegration:

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -174,8 +174,10 @@ def _send_summary_notification(user_data: tuple):
         navigate_to=f"/daily-summary/{summary_id}",
     )
 
-    # Also send webhook with the full summary data (day_summary_webhook is async, so wrap in asyncio.run)
-    postprocess_executor.submit(asyncio.run, day_summary_webhook(uid, str(summary_data)))
+    # Also send webhook with the full summary data (day_summary_webhook is async, so wrap in asyncio.run).
+    # ``summary`` is the legacy str(...) form, kept for backward compatibility; ``summary_json``
+    # carries the same payload as a real JSON object for receivers to migrate to.
+    postprocess_executor.submit(asyncio.run, day_summary_webhook(uid, str(summary_data), summary_data))
 
     tokens = user_data[1] if len(user_data) > 1 else None
     send_notification(

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Optional
 
 from database.redis_db import (
     get_user_webhook_db,
@@ -91,7 +91,14 @@ async def conversation_created_webhook(uid, memory: Conversation):
         return
 
 
-async def day_summary_webhook(uid, summary: str):
+async def day_summary_webhook(uid, summary: str, summary_json: Optional[dict] = None):
+    """Send the daily summary to the developer webhook.
+
+    ``summary`` is the legacy ``str(summary_data)`` Python repr field, kept
+    for backward compatibility. ``summary_json`` is the same payload as a
+    real JSON object — receivers should prefer it going forward; the
+    legacy ``summary`` field will be deprecated in a future release.
+    """
     toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.day_summary)
     if toggled:
         webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.day_summary)
@@ -107,7 +114,12 @@ async def day_summary_webhook(uid, summary: str):
                 client = get_webhook_client()
                 response = await client.post(
                     webhook_url,
-                    json={'summary': summary, 'uid': uid, 'created_at': datetime.now(timezone.utc).isoformat()},
+                    json={
+                        'summary': summary,
+                        'summary_json': summary_json,
+                        'uid': uid,
+                        'created_at': datetime.now(timezone.utc).isoformat(),
+                    },
                     headers={'Content-Type': 'application/json'},
                 )
             logger.info(f'day_summary_webhook: {webhook_url} {response.status_code}')

--- a/docs/doc/developer/apps/Integrations.mdx
+++ b/docs/doc/developer/apps/Integrations.mdx
@@ -332,7 +332,20 @@ Your endpoint receives a POST request with the daily summary:
 {
   "uid": "user123",
   "created_at": "2024-01-15T22:00:00.123456+00:00",
-  "summary": "{'id': '550e8400-...', 'date': '2024-01-15', 'headline': 'Productive day with three focused work sessions', 'overview': '...', 'day_emoji': '💼', 'stats': {...}, 'highlights': [...], 'action_items': [...], 'decisions_made': [...], 'knowledge_nuggets': [...], 'locations': [...]}"
+  "summary": "{'id': '550e8400-...', 'date': '2024-01-15', 'headline': 'Productive day with three focused work sessions', ...}",
+  "summary_json": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "date": "2024-01-15",
+    "headline": "Productive day with three focused work sessions",
+    "overview": "...",
+    "day_emoji": "💼",
+    "stats": { },
+    "highlights": [],
+    "action_items": [],
+    "decisions_made": [],
+    "knowledge_nuggets": [],
+    "locations": []
+  }
 }
 ```
 
@@ -342,13 +355,14 @@ Your endpoint receives a POST request with the daily summary:
 |-------|------|-------------|
 | `uid` | string | User identifier (also in query param) |
 | `created_at` | string (ISO 8601 with `+00:00` offset) | Webhook send time in UTC |
-| `summary` | string | Serialized daily summary object (see warning below) |
+| `summary_json` | object | **Recommended.** The daily summary as a real JSON object (schema below). Use this for any new integration. |
+| `summary` | string | **Legacy.** The same payload serialized via Python's `str(...)`, kept for backward compatibility. See the migration note below. |
 
-<Warning>
-**`summary` is a Python `repr` string, not a JSON object.** This is a known wart of the current wire format — the daily summary is generated as a Python `dict`, but it is wrapped in `str(...)` before being sent, which produces a single-quoted Python literal (e.g. `"{'headline': '...', 'overview': '...'}"`). Receivers **cannot** parse it with `JSON.parse`. To extract structured data you currently need a Python-specific parser such as `ast.literal_eval`, which is awkward for non-Python receivers. A future release will add a dedicated JSON-object field for the summary so receivers don't have to deal with this; in the meantime, expect the `summary` value to be opaque from a standard-JSON perspective.
-</Warning>
+<Note>
+**Use `summary_json` for new integrations.** The `summary` field stays on the wire so existing receivers don't break, but it's the legacy form: Python's `str(...)` on a `dict` produces a single-quoted Python literal (e.g. `"{'headline': '...'}"`) that **cannot** be parsed by `JSON.parse` and currently requires something Python-specific like `ast.literal_eval` to read. The new `summary_json` field carries the exact same payload as a real JSON object — every standard JSON parser handles it natively. Plan to migrate existing receivers to `summary_json`; the legacy `summary` field will be deprecated in a future release.
+</Note>
 
-The underlying summary object (once parsed) has roughly this shape — exposed today only as the source for the `repr` string, and as the schema the JSON-object field will use once it ships:
+The `summary_json` object has this shape (also reflects what `summary` represents once parsed):
 
 ```json
 {
@@ -409,7 +423,7 @@ The underlying summary object (once parsed) has roughly this shape — exposed t
 ```
 
 <Info>
-The top-level `created_at` is the webhook send timestamp in UTC, with an explicit `+00:00` offset (e.g. `2024-01-15T22:00:00.123456+00:00`). The `created_at` *inside* the summary `repr` is the timestamp when the summary object was built by the LLM pipeline; it is also UTC but emitted as a naive ISO 8601 string with no offset suffix. The two will be very close in time but are technically distinct timestamps.
+The top-level `created_at` is the webhook send timestamp in UTC, with an explicit `+00:00` offset (e.g. `2024-01-15T22:00:00.123456+00:00`). The `created_at` *inside* `summary_json` (and inside the legacy `summary` string) is the timestamp when the summary object was built by the LLM pipeline; it is also UTC but emitted as a naive ISO 8601 string with no offset suffix. The two will be very close in time but are technically distinct timestamps.
 </Info>
 
 ---

--- a/docs/doc/developer/apps/Integrations.mdx
+++ b/docs/doc/developer/apps/Integrations.mdx
@@ -339,9 +339,14 @@ Your endpoint receives a POST request with the daily summary:
     "headline": "Productive day with three focused work sessions",
     "overview": "...",
     "day_emoji": "💼",
-    "stats": { },
+    "stats": {
+      "total_conversations": 3,
+      "total_duration_minutes": 87,
+      "action_items_count": 4
+    },
     "highlights": [],
     "action_items": [],
+    "unresolved_questions": [],
     "decisions_made": [],
     "knowledge_nuggets": [],
     "locations": []


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/BasedHardware/omi/pull/7110, which documented the Day Summary webhook but left the wire format alone. Per @beastoin's review there:

> The `summary` data should be preserved as is (as a string). We do not need to introduce breaking changes for this … You can also add a new field that returns the JSON object for the summary (which should be done in a breaking change PR), and then use that field from now on (update docs too ofc).

This PR adds that new field — `summary_json` — alongside the legacy `summary` string, points the docs at it as the recommended migration path, and signals that the legacy `summary` will be deprecated in a future release.

## What's in this PR

### Backend

```diff
 # backend/utils/webhooks.py
-async def day_summary_webhook(uid, summary: str):
+async def day_summary_webhook(uid, summary: str, summary_json: Optional[dict] = None):
     ...
     json={
         'summary': summary,
+        'summary_json': summary_json,
         'uid': uid,
         'created_at': datetime.now(timezone.utc).isoformat(),
     },
```

- `day_summary_webhook` gains an optional `summary_json: Optional[dict]` parameter and includes it in every outgoing payload. When the caller doesn't supply one, the field is sent as `null` — receivers always see a stable JSON shape.
- The only in-tree caller (`_send_summary_notification` in `backend/utils/other/notifications.py`) now passes the raw `summary_data` dict as `summary_json` while continuing to wrap it in `str(...)` for the legacy `summary` field. Both fields carry the same payload — one as a JSON object, one as the historical Python repr.

### Wire format example

```json
{
  "uid": "user123",
  "created_at": "2024-01-15T22:00:00.123456+00:00",
  "summary": "{'id': '550e8400-...', 'headline': 'Productive day with three focused work sessions', ...}",
  "summary_json": {
    "id": "550e8400-e29b-41d4-a716-446655440000",
    "headline": "Productive day with three focused work sessions",
    "overview": "...",
    "...": "..."
  }
}
```

### Tests

- `TestDaySummaryWebhookJsonField` (in `backend/tests/unit/test_async_webhooks.py`): runs `day_summary_webhook` end to end with `get_webhook_client` mocked and asserts on the JSON body going to httpx:
  - When a dict is supplied: `summary_json` is sent as a dict, the legacy `summary` string is preserved verbatim, and `created_at` keeps the `+00:00` UTC offset shipped in #7110.
  - When no dict is supplied: `summary_json` is sent as `null` so receivers see a stable JSON shape regardless of source.
- `TestSendSummaryNotificationWiresSummaryJson`: static-grep guard mirroring the in-tree pattern used in `test_async_http_infrastructure.py` — pins the call site to `day_summary_webhook(uid, str(summary_data), summary_data)` so a regression there would surface immediately, without dragging Firestore / LLM / pytz into the test.

### Docs (`docs/doc/developer/apps/Integrations.mdx`)

- Webhook Payload example shows both fields side by side, with `summary_json` as a real nested JSON object and `summary` truncated to the legacy `repr` string.
- Field reference table flags `summary_json` as **Recommended** and marks `summary` as **Legacy**, replacing the old "see warning below" pointer.
- The `<Warning>` from #7110 becomes a `<Note>` that explicitly recommends migrating to `summary_json`, explains why the legacy `summary` field still exists (backward compatibility), and signals that deprecation will follow once receivers have had time to migrate.
- The two-`created_at` clarification is updated to point at `summary_json` as the canonical inner-timestamp source, with the legacy `summary` string noted as carrying the same value.

## Migration impact

- **Existing receivers consuming `summary`**: nothing changes — the field is sent in the exact same `str(...)` form as before.
- **Receivers ready to move to JSON**: start reading `summary_json` directly. The shape is identical to what `summary` carries once `ast.literal_eval`'d, so no field-mapping work is needed.
- **No new field becomes required**, so the wire format addition is fully backward compatible. The "breaking" piece will come later, when the legacy `summary` field is removed — that's intentionally deferred to a separate PR per @beastoin's guidance.

## Out of scope (deliberately deferred)

- **Deprecating / removing the legacy `summary` field.** That's the actual breaking change and needs its own PR once enough receivers have migrated. This PR only stages the migration path.
- **Renaming or restructuring the JSON shape inside `summary_json`.** Same shape as the existing summary object, on purpose, so receivers already parsing the `repr` can swap parsers and be done.

## Test plan

- [x] `black --check --line-length 120 --skip-string-normalization` clean on all touched files
- [x] `pytest backend/tests/unit/test_async_webhooks.py` — runtime async tests skip locally as in #7110 (no `pytest-asyncio` in the dev env); the new `TestSendSummaryNotificationWiresSummaryJson` static guard passes locally, and the two `TestDaySummaryWebhookJsonField` cases will run in CI alongside the rest of the async suite
- [ ] Mintlify preview of the updated Day Summary section (CardGroup, payload example with both fields, the new `<Note>`) — reviewer help appreciated, no local Mintlify in this dev env
