### PR TITLE
Support promo codes for subscription upgrades (desktop)

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -70,6 +70,7 @@ class CreateCheckoutRequest(BaseModel):
 
 class UpgradeSubscriptionRequest(BaseModel):
     price_id: str
+    promotion_code: Optional[str] = None
 
 
 class PricingOption(BaseModel):
@@ -189,6 +190,45 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
         logger.error(f"Error checking for reactivation: {e}")
 
     return None
+
+
+def _stripe_object_value(obj, key: str):
+    if isinstance(obj, dict):
+        return obj.get(key)
+    if hasattr(obj, 'get'):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _resolve_promotion_code_id(code: Optional[str], customer_id: Optional[str]) -> Optional[str]:
+    stripped_code = code.strip() if code else ''
+    if not stripped_code:
+        return None
+
+    if customer_id:
+        customer_codes = stripe.PromotionCode.list(
+            code=stripped_code,
+            active=True,
+            customer=customer_id,
+            limit=1,
+        )
+        if customer_codes.data:
+            return _stripe_object_value(customer_codes.data[0], 'id')
+
+    promotion_codes = stripe.PromotionCode.list(
+        code=stripped_code,
+        active=True,
+        limit=1,
+    )
+    if not promotion_codes.data:
+        raise HTTPException(status_code=400, detail="Invalid promotion code.")
+
+    promotion_code = promotion_codes.data[0]
+    restricted_customer = _stripe_object_value(promotion_code, 'customer')
+    if restricted_customer and restricted_customer != customer_id:
+        raise HTTPException(status_code=400, detail="Invalid promotion code.")
+
+    return _stripe_object_value(promotion_code, 'id')
 
 
 @router.get('/v1/payments/available-plans', response_model=AvailablePlansResponse)
@@ -422,6 +462,8 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
         stripe_sub = stripe.Subscription.retrieve(current_subscription.stripe_subscription_id).to_dict()
         current_price_id = stripe_sub['items']['data'][0]['price']['id']
         current_item_id = stripe_sub['items']['data'][0]['id']
+        promotion_code_id = _resolve_promotion_code_id(request.promotion_code, stripe_sub.get('customer'))
+        discount_params = {'discounts': [{'promotion_code': promotion_code_id}]} if promotion_code_id else {}
 
         # Check if user is trying to upgrade to the same plan
         if current_price_id == request.price_id:
@@ -449,6 +491,7 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
                 items=[{'id': current_item_id, 'price': request.price_id}],
                 proration_behavior='always_invoice',
                 metadata={'uid': uid, 'sub_type': target_plan.value},
+                **discount_params,
             )
 
             # Update our database immediately
@@ -497,6 +540,7 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
                             'price': request.price_id,
                         }
                     ],
+                    **discount_params,
                 },
             ],
             metadata={'uid': uid, 'upgrade_type': f'{current_plan.value}_{target_interval}'},
@@ -517,6 +561,9 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
 
     except HTTPException:
         raise
+    except stripe.error.InvalidRequestError as e:
+        message = getattr(e, 'user_message', None) or str(e)
+        raise HTTPException(status_code=400, detail=sanitize(message))
     except Exception as e:
         logger.error(f"Error processing subscription change: {sanitize(str(e))}")
         raise HTTPException(status_code=500, detail="Failed to process subscription change. Please try again.")

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -73,6 +73,7 @@ def _compare_versions(a, b):
 
 
 _announcements_mod._compare_versions = _compare_versions
+_announcements_mod.compare_versions = _compare_versions
 
 # database.users needs the functions payment.py imports by name
 _users_mod = sys.modules["database.users"]
@@ -126,6 +127,7 @@ _stripe_utils.create_subscription_checkout_session = MagicMock()
 
 _endpoints_mod = sys.modules["utils.other.endpoints"]
 _endpoints_mod.get_current_user_uid = lambda: "test-user"
+_endpoints_mod.get_current_user_uid_no_byok_validation = lambda: "test-user"
 
 # Ensure utils.other has endpoints attr for `from utils.other import endpoints`
 sys.modules["utils.other"].endpoints = _endpoints_mod
@@ -306,3 +308,121 @@ def test_all_prices_fail_returns_500():
     response = client.get("/v1/payments/available-plans")
 
     assert response.status_code == 500
+
+
+def _make_subscription(price_id=UNLIM_MONTHLY, cancel_at_period_end=False):
+    from models.users import PlanType, Subscription, SubscriptionStatus
+
+    return Subscription(
+        plan=PlanType.unlimited,
+        status=SubscriptionStatus.active,
+        stripe_subscription_id="sub_test_123",
+        cancel_at_period_end=cancel_at_period_end,
+    )
+
+
+def _make_stripe_subscription(price_id=UNLIM_MONTHLY, customer="cus_test_123"):
+    stripe_sub = MagicMock()
+    stripe_sub.to_dict.return_value = {
+        "id": "sub_test_123",
+        "customer": customer,
+        "status": "active",
+        "current_period_start": 1_700_000_000,
+        "current_period_end": 1_700_086_400,
+        "cancel_at_period_end": False,
+        "items": {"data": [{"id": "si_test_123", "price": {"id": price_id}}]},
+    }
+    return stripe_sub
+
+
+def _setup_upgrade_mocks(current_price=UNLIM_MONTHLY, target_interval="month"):
+    _users_mod.get_user_subscription.return_value = _make_subscription(price_id=current_price)
+    _users_mod.update_user_subscription = MagicMock()
+    payment_router.set_credits_invalidation_signal = MagicMock()
+    payment_router.clear_trial_paywall_cache = MagicMock()
+    payment_router.clear_fair_use_on_upgrade = MagicMock()
+    payment_router.conversations_db.unlock_all_conversations = MagicMock()
+    payment_router.memories_db.unlock_all_memories = MagicMock()
+    payment_router.action_items_db.unlock_all_action_items = MagicMock()
+    stripe.Subscription.retrieve = MagicMock(return_value=_make_stripe_subscription(price_id=current_price))
+    stripe.Price.retrieve = MagicMock(return_value=_make_stripe_price("target", 9900, target_interval))
+
+
+def test_upgrade_subscription_invalid_promotion_code_returns_400():
+    _setup_upgrade_mocks()
+    stripe.PromotionCode.list = MagicMock(return_value=MagicMock(data=[]))
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": ARCH_MONTHLY, "promotion_code": "NOPE"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid promotion code."
+
+
+def test_upgrade_subscription_cross_plan_applies_promotion_code_discount():
+    _setup_upgrade_mocks()
+    promo = {"id": "promo_customer_match", "customer": "cus_test_123"}
+    stripe.PromotionCode.list = MagicMock(return_value=MagicMock(data=[promo]))
+    updated_sub = _make_stripe_subscription(price_id=ARCH_MONTHLY)
+    stripe.Subscription.modify = MagicMock(return_value=updated_sub)
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": ARCH_MONTHLY, "promotion_code": "SAVE20"},
+    )
+
+    assert response.status_code == 200
+    assert stripe.PromotionCode.list.call_args_list[0].kwargs["customer"] == "cus_test_123"
+    modify_kwargs = stripe.Subscription.modify.call_args.kwargs
+    assert modify_kwargs["discounts"] == [{"promotion_code": "promo_customer_match"}]
+
+
+def test_upgrade_subscription_same_plan_applies_promotion_code_to_future_phase():
+    _setup_upgrade_mocks(current_price=UNLIM_MONTHLY, target_interval="year")
+    stripe.PromotionCode.list = MagicMock(return_value=MagicMock(data=[{"id": "promo_global", "customer": None}]))
+    stripe.SubscriptionSchedule.create = MagicMock(return_value=MagicMock(id="sub_sched_test_123"))
+    stripe.SubscriptionSchedule.modify = MagicMock(return_value=MagicMock())
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": UNLIM_ANNUAL, "promotion_code": "SAVE20"},
+    )
+
+    assert response.status_code == 200
+    phases = stripe.SubscriptionSchedule.modify.call_args.kwargs["phases"]
+    assert "discounts" not in phases[0]
+    assert phases[1]["discounts"] == [{"promotion_code": "promo_global"}]
+
+
+def test_upgrade_subscription_blank_promotion_code_omits_discounts():
+    _setup_upgrade_mocks()
+    updated_sub = _make_stripe_subscription(price_id=ARCH_MONTHLY)
+    stripe.Subscription.modify = MagicMock(return_value=updated_sub)
+    stripe.PromotionCode.list = MagicMock()
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": ARCH_MONTHLY, "promotion_code": "   "},
+    )
+
+    assert response.status_code == 200
+    assert "discounts" not in stripe.Subscription.modify.call_args.kwargs
+    stripe.PromotionCode.list.assert_not_called()
+
+
+def test_upgrade_subscription_stripe_invalid_request_returns_message():
+    _setup_upgrade_mocks()
+    stripe.PromotionCode.list = MagicMock(return_value=MagicMock(data=[{"id": "promo_bad", "customer": None}]))
+    stripe.Subscription.modify = MagicMock(
+        side_effect=stripe.error.InvalidRequestError("Promotion code is not applicable", "discounts")
+    )
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": ARCH_MONTHLY, "promotion_code": "SAVE20"},
+    )
+
+    assert response.status_code == 400
+    assert "Promotion code is not applicable" in response.json()["detail"]

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -426,3 +426,72 @@ def test_upgrade_subscription_stripe_invalid_request_returns_message():
 
     assert response.status_code == 400
     assert "Promotion code is not applicable" in response.json()["detail"]
+
+
+def test_upgrade_subscription_global_promo_fallback_when_customer_lookup_empty():
+    _setup_upgrade_mocks()
+    customer_result = MagicMock(data=[])
+    global_result = MagicMock(data=[{"id": "promo_global_fallback", "customer": None}])
+    stripe.PromotionCode.list = MagicMock(side_effect=[customer_result, global_result])
+    updated_sub = _make_stripe_subscription(price_id=ARCH_MONTHLY)
+    stripe.Subscription.modify = MagicMock(return_value=updated_sub)
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": ARCH_MONTHLY, "promotion_code": "GLOBAL20"},
+    )
+
+    assert response.status_code == 200
+    calls = stripe.PromotionCode.list.call_args_list
+    assert calls[0].kwargs.get("customer") == "cus_test_123"
+    assert "customer" not in calls[1].kwargs
+    assert stripe.Subscription.modify.call_args.kwargs["discounts"] == [{"promotion_code": "promo_global_fallback"}]
+
+
+def test_upgrade_subscription_customer_restricted_promo_for_other_customer_returns_400():
+    _setup_upgrade_mocks()
+    customer_result = MagicMock(data=[])
+    global_result = MagicMock(data=[{"id": "promo_other", "customer": "cus_someone_else"}])
+    stripe.PromotionCode.list = MagicMock(side_effect=[customer_result, global_result])
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": ARCH_MONTHLY, "promotion_code": "RESTRICTED"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid promotion code."
+
+
+def test_upgrade_subscription_promo_code_whitespace_trimmed():
+    _setup_upgrade_mocks()
+    promo = {"id": "promo_trimmed", "customer": None}
+    stripe.PromotionCode.list = MagicMock(return_value=MagicMock(data=[promo]))
+    updated_sub = _make_stripe_subscription(price_id=ARCH_MONTHLY)
+    stripe.Subscription.modify = MagicMock(return_value=updated_sub)
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": ARCH_MONTHLY, "promotion_code": "  SAVE20\n "},
+    )
+
+    assert response.status_code == 200
+    assert stripe.PromotionCode.list.call_args.kwargs["code"] == "SAVE20"
+
+
+def test_upgrade_subscription_promo_with_stripe_object_attrs():
+    from types import SimpleNamespace
+
+    _setup_upgrade_mocks()
+    promo_obj = SimpleNamespace(id="promo_attr_style", customer=None)
+    stripe.PromotionCode.list = MagicMock(return_value=MagicMock(data=[promo_obj]))
+    updated_sub = _make_stripe_subscription(price_id=ARCH_MONTHLY)
+    stripe.Subscription.modify = MagicMock(return_value=updated_sub)
+
+    response = client.post(
+        "/v1/payments/upgrade-subscription",
+        json={"price_id": ARCH_MONTHLY, "promotion_code": "OBJSTYLE"},
+    )
+
+    assert response.status_code == 200
+    assert stripe.Subscription.modify.call_args.kwargs["discounts"] == [{"promotion_code": "promo_attr_style"}]

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -248,6 +248,7 @@ enum APIError: LocalizedError {
   case invalidResponse
   case unauthorized
   case httpError(statusCode: Int)
+  case serverMessage(statusCode: Int, message: String)
   case decodingError(Error)
 
   var errorDescription: String? {
@@ -258,6 +259,8 @@ enum APIError: LocalizedError {
       return "Unauthorized - please sign in again"
     case .httpError(let statusCode):
       return "HTTP error: \(statusCode)"
+    case .serverMessage(_, let message):
+      return message
     case .decodingError(let error):
       return "Failed to decode response: \(error.localizedDescription)"
     }
@@ -4560,16 +4563,71 @@ extension APIClient {
     return try await post("v1/payments/checkout-session", body: Request(priceId: priceId))
   }
 
-  func upgradeSubscription(priceId: String) async throws -> UpgradeSubscriptionResponse {
+  func upgradeSubscription(priceId: String, promotionCode: String? = nil) async throws -> UpgradeSubscriptionResponse {
     struct Request: Encodable {
       let priceId: String
+      let promotionCode: String?
 
       enum CodingKeys: String, CodingKey {
         case priceId = "price_id"
+        case promotionCode = "promotion_code"
       }
     }
 
-    return try await post("v1/payments/upgrade-subscription", body: Request(priceId: priceId))
+    struct ErrorResponse: Decodable {
+      let detail: String?
+    }
+
+    let url = URL(string: baseURL + "v1/payments/upgrade-subscription")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.allHTTPHeaderFields = try await buildHeaders()
+    request.httpBody = try JSONEncoder().encode(
+      Request(priceId: priceId, promotionCode: promotionCode?.trimmingCharacters(in: .whitespacesAndNewlines))
+    )
+
+    let (data, response) = try await session.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+    if httpResponse.statusCode == 401 {
+      let authService = await MainActor.run { AuthService.shared }
+      _ = try await authService.getIdToken(forceRefresh: true)
+
+      var retryRequest = request
+      retryRequest.setValue(
+        try await authService.getAuthHeader(), forHTTPHeaderField: "Authorization")
+
+      let (retryData, retryResponse) = try await session.data(for: retryRequest)
+      guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
+        throw APIError.invalidResponse
+      }
+      if retryHttpResponse.statusCode == 401 {
+        throw APIError.unauthorized
+      }
+      guard (200...299).contains(retryHttpResponse.statusCode) else {
+        if let errorResponse = try? decoder.decode(ErrorResponse.self, from: retryData),
+           let detail = errorResponse.detail,
+           !detail.isEmpty
+        {
+          throw APIError.serverMessage(statusCode: retryHttpResponse.statusCode, message: detail)
+        }
+        throw APIError.httpError(statusCode: retryHttpResponse.statusCode)
+      }
+
+      return try decoder.decode(UpgradeSubscriptionResponse.self, from: retryData)
+    }
+    guard (200...299).contains(httpResponse.statusCode) else {
+      if let errorResponse = try? decoder.decode(ErrorResponse.self, from: data),
+         let detail = errorResponse.detail,
+         !detail.isEmpty
+      {
+        throw APIError.serverMessage(statusCode: httpResponse.statusCode, message: detail)
+      }
+      throw APIError.httpError(statusCode: httpResponse.statusCode)
+    }
+
+    return try decoder.decode(UpgradeSubscriptionResponse.self, from: data)
   }
 
   func createCustomerPortalSession() async throws -> CustomerPortalResponse {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -235,6 +235,7 @@ struct SettingsContentView: View {
   @State private var fallbackPlanCatalog: [SubscriptionPlanOption] = []
   @State private var activeCheckoutPriceId: String?
   @State private var selectedPlanIdForCheckout: String?
+  @State private var upgradePromotionCode = ""
   @State private var isOpeningCustomerPortal: Bool = false
   @State private var activeBillingWebFlow: BillingWebFlow?
   @State private var pendingSubscriptionPriceId: String?
@@ -6759,6 +6760,7 @@ struct SettingsContentView: View {
       || userSubscription?.subscription.plan == .pro
     let isDowngrade = isArchitectUser && plan.id == "unlimited"
     let canPurchase = !isCurrentPlan && !isDowngrade
+    let acceptsPromotionCode = hasPaidSubscription && !(userSubscription?.subscription.cancelAtPeriodEnd ?? false)
 
     VStack(alignment: .leading, spacing: 16) {
       HStack(alignment: .top, spacing: 12) {
@@ -6829,7 +6831,10 @@ struct SettingsContentView: View {
           HStack(spacing: 10) {
             ForEach(sortedPrices(for: plan)) { price in
               Button(action: {
-                startCheckout(for: price.id)
+                startCheckout(
+                  for: price.id,
+                  promotionCode: acceptsPromotionCode ? upgradePromotionCode : nil
+                )
               }) {
                 Group {
                   if activeCheckoutPriceId == price.id {
@@ -6854,6 +6859,12 @@ struct SettingsContentView: View {
               .tint(accent)
               .disabled(activeCheckoutPriceId != nil)
             }
+          }
+
+          if acceptsPromotionCode {
+            TextField("Promo code", text: $upgradePromotionCode)
+              .textFieldStyle(.roundedBorder)
+              .disabled(activeCheckoutPriceId != nil)
           }
         }
       } else if isCurrentPlan {
@@ -7267,11 +7278,13 @@ struct SettingsContentView: View {
     }
   }
 
-  private func startCheckout(for priceId: String) {
+  private func startCheckout(for priceId: String, promotionCode: String? = nil) {
     guard activeCheckoutPriceId == nil else { return }
     activeCheckoutPriceId = priceId
     pendingSubscriptionPriceId = priceId
     subscriptionError = nil
+    let trimmedPromotionCode = promotionCode?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let upgradePromotionCode = trimmedPromotionCode?.isEmpty == false ? trimmedPromotionCode : nil
 
     // If user already has an active paid subscription (not canceled), use upgrade endpoint
     // to schedule the plan change at end of billing period (no double-charging)
@@ -7281,7 +7294,10 @@ struct SettingsContentView: View {
     {
       Task {
         do {
-          _ = try await APIClient.shared.upgradeSubscription(priceId: priceId)
+          _ = try await APIClient.shared.upgradeSubscription(
+            priceId: priceId,
+            promotionCode: upgradePromotionCode
+          )
           await MainActor.run {
             activeCheckoutPriceId = nil
             pendingSubscriptionPriceId = nil
@@ -7293,7 +7309,7 @@ struct SettingsContentView: View {
           await MainActor.run {
             activeCheckoutPriceId = nil
             pendingSubscriptionPriceId = nil
-            subscriptionError = "Failed to schedule plan change."
+            subscriptionError = error.localizedDescription
           }
         }
       }

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -6862,9 +6862,30 @@ struct SettingsContentView: View {
           }
 
           if acceptsPromotionCode {
-            TextField("Promo code", text: $upgradePromotionCode)
-              .textFieldStyle(.roundedBorder)
-              .disabled(activeCheckoutPriceId != nil)
+            VStack(alignment: .leading, spacing: 6) {
+              HStack(spacing: 8) {
+                Image(systemName: "tag")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+                TextField("Promo code", text: $upgradePromotionCode)
+                  .textFieldStyle(.roundedBorder)
+                  .scaledFont(size: 13)
+                  .disabled(activeCheckoutPriceId != nil)
+                  .onChange(of: upgradePromotionCode) { _ in
+                    subscriptionError = nil
+                  }
+              }
+
+              if let error = subscriptionError {
+                HStack(spacing: 4) {
+                  Image(systemName: "exclamationmark.circle")
+                    .scaledFont(size: 11)
+                  Text(error)
+                    .scaledFont(size: 11)
+                }
+                .foregroundColor(OmiColors.warning)
+              }
+            }
           }
         }
       } else if isCurrentPlan {
@@ -7302,6 +7323,7 @@ struct SettingsContentView: View {
             activeCheckoutPriceId = nil
             pendingSubscriptionPriceId = nil
             subscriptionError = nil
+            self.upgradePromotionCode = ""
             loadSubscriptionInfo()
           }
         } catch {


### PR DESCRIPTION
## Summary

Adds promotion code support to the subscription upgrade flow so existing paid subscribers can apply promo codes when changing plans. Previously, upgrades used `Subscription.modify()` directly — bypassing Stripe Checkout (the only place promo codes were supported).

**Backend:**
- Added optional `promotion_code` field to `UpgradeSubscriptionRequest`
- Validates via `stripe.PromotionCode.list()` with customer-specific matching
- Applies discount via `discounts` param on `Subscription.modify()` (cross-plan) and `SubscriptionSchedule.modify()` (interval changes)
- Catches `InvalidRequestError` from Stripe for graceful error messages

**Desktop:**
- Added promo code text field below billing buttons for existing paid subscribers
- Added `APIError.serverMessage` to surface backend validation errors
- Updated `upgradeSubscription()` API call to pass promo code

Preserves existing billing semantics: proration for cross-plan changes, period-end scheduling for interval changes. Only adds the discount application on top.

Mobile UI needs a matching change (will coordinate with mobile team separately).

## Test plan

### Unit tests (14 pass)
| Test | Scenario | Result |
|---|---|---|
| test_upgrade_subscription_invalid_promotion_code_returns_400 | Invalid code → 400 | PASS |
| test_upgrade_subscription_cross_plan_applies_promotion_code_discount | Cross-plan with promo → discounts applied | PASS |
| test_upgrade_subscription_same_plan_applies_promotion_code_to_future_phase | Same-plan interval change with promo | PASS |
| test_upgrade_subscription_blank_promotion_code_omits_discounts | Blank code → no discounts param | PASS |
| test_upgrade_subscription_stripe_invalid_request_returns_message | Stripe error → 400 with message | PASS |
| test_upgrade_subscription_global_promo_fallback_when_customer_lookup_empty | Customer miss → global fallback | PASS |
| test_upgrade_subscription_customer_restricted_promo_for_other_customer_returns_400 | Customer-restricted mismatch → 400 | PASS |
| test_upgrade_subscription_promo_code_whitespace_trimmed | Whitespace trimming | PASS |
| test_upgrade_subscription_promo_with_stripe_object_attrs | Stripe object attr style | PASS |

### Live tests
- [x] Swift build succeeds (8.28s)
- [ ] Desktop app launches with promo code field visible for paid subscribers
- [ ] Promo code validation error displays correctly
- [ ] Upgrade without promo code still works

Closes #7557

_by AI for @beastoin_