### PR TITLE
Desktop: collapsible promo code field for all subscription plans

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -391,11 +391,23 @@ def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = 
     if reactivation_result:
         return reactivation_result
 
+    # Validate promotion code before creating checkout session
+    resolved_checkout_promo_id = None
+    if request.promotion_code:
+        promo_list = stripe.PromotionCode.list(code=request.promotion_code, active=True, limit=1)
+        if not promo_list.data:
+            raise HTTPException(status_code=400, detail="Invalid or expired promotion code.")
+        resolved_checkout_promo_id = promo_list.data[0].id
+
     # Normal checkout flow for new subscriptions (Scenario B or first-time subscribers)
     idempotency_key = str(uuid.uuid4())
     existing_customer_id = users_db.get_stripe_customer_id(uid)
     session = stripe_utils.create_subscription_checkout_session(
-        uid, request.price_id, idempotency_key, customer_id=existing_customer_id, promotion_code=request.promotion_code
+        uid,
+        request.price_id,
+        idempotency_key,
+        customer_id=existing_customer_id,
+        promotion_code_id=resolved_checkout_promo_id,
     )
     if not session:
         raise HTTPException(status_code=500, detail="Could not create checkout session.")
@@ -445,12 +457,12 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
             )
 
         # Validate and resolve promotion code if provided
-        resolved_coupon_id = None
+        resolved_promo_id = None
         if request.promotion_code:
             promo_list = stripe.PromotionCode.list(code=request.promotion_code, active=True, limit=1)
             if not promo_list.data:
                 raise HTTPException(status_code=400, detail="Invalid or expired promotion code.")
-            resolved_coupon_id = promo_list.data[0].coupon.id
+            resolved_promo_id = promo_list.data[0].id
 
         # Cross-plan change (e.g. Unlimited→Architect): immediate swap with proration
         if current_plan != target_plan:
@@ -459,8 +471,8 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
                 'proration_behavior': 'always_invoice',
                 'metadata': {'uid': uid, 'sub_type': target_plan.value},
             }
-            if resolved_coupon_id:
-                modify_params['discounts'] = [{'coupon': resolved_coupon_id}]
+            if resolved_promo_id:
+                modify_params['discounts'] = [{'promotion_code': resolved_promo_id}]
 
             updated_sub = stripe.Subscription.modify(stripe_sub['id'], **modify_params)
 
@@ -510,6 +522,7 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
                             'price': request.price_id,
                         }
                     ],
+                    **({'discounts': [{'promotion_code': resolved_promo_id}]} if resolved_promo_id else {}),
                 },
             ],
             metadata={'uid': uid, 'upgrade_type': f'{current_plan.value}_{target_interval}'},

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -386,12 +386,7 @@ def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = 
     if not can_pay:
         raise HTTPException(status_code=400, detail=reason)
 
-    # Try to reactivate canceled subscription (Scenario A)
-    reactivation_result = _try_reactivate_subscription(uid, request.price_id)
-    if reactivation_result:
-        return reactivation_result
-
-    # Validate promotion code before creating checkout session
+    # Validate promotion code early — reject invalid codes before any subscription changes
     resolved_checkout_promo_id = None
     if request.promotion_code:
         promo_list = stripe.PromotionCode.list(code=request.promotion_code, active=True, limit=1)
@@ -399,16 +394,25 @@ def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = 
             raise HTTPException(status_code=400, detail="Invalid or expired promotion code.")
         resolved_checkout_promo_id = promo_list.data[0].id
 
+    # Try to reactivate canceled subscription (Scenario A)
+    reactivation_result = _try_reactivate_subscription(uid, request.price_id)
+    if reactivation_result:
+        return reactivation_result
+
     # Normal checkout flow for new subscriptions (Scenario B or first-time subscribers)
     idempotency_key = str(uuid.uuid4())
     existing_customer_id = users_db.get_stripe_customer_id(uid)
-    session = stripe_utils.create_subscription_checkout_session(
-        uid,
-        request.price_id,
-        idempotency_key,
-        customer_id=existing_customer_id,
-        promotion_code_id=resolved_checkout_promo_id,
-    )
+    try:
+        session = stripe_utils.create_subscription_checkout_session(
+            uid,
+            request.price_id,
+            idempotency_key,
+            customer_id=existing_customer_id,
+            promotion_code_id=resolved_checkout_promo_id,
+        )
+    except stripe.error.InvalidRequestError as e:
+        detail = str(e.user_message) if hasattr(e, 'user_message') and e.user_message else str(e)
+        raise HTTPException(status_code=400, detail=detail)
     if not session:
         raise HTTPException(status_code=500, detail="Could not create checkout session.")
     return {"url": session.url, "session_id": session.id}
@@ -543,6 +547,10 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
 
     except HTTPException:
         raise
+    except stripe.error.InvalidRequestError as e:
+        logger.error(f"Stripe rejected subscription change: {sanitize(str(e))}")
+        detail = str(e.user_message) if hasattr(e, 'user_message') and e.user_message else str(e)
+        raise HTTPException(status_code=400, detail=detail)
     except Exception as e:
         logger.error(f"Error processing subscription change: {sanitize(str(e))}")
         raise HTTPException(status_code=500, detail="Failed to process subscription change. Please try again.")

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -66,10 +66,12 @@ router = APIRouter()
 
 class CreateCheckoutRequest(BaseModel):
     price_id: str
+    promotion_code: Optional[str] = None
 
 
 class UpgradeSubscriptionRequest(BaseModel):
     price_id: str
+    promotion_code: Optional[str] = None
 
 
 class PricingOption(BaseModel):
@@ -393,7 +395,7 @@ def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = 
     idempotency_key = str(uuid.uuid4())
     existing_customer_id = users_db.get_stripe_customer_id(uid)
     session = stripe_utils.create_subscription_checkout_session(
-        uid, request.price_id, idempotency_key, customer_id=existing_customer_id
+        uid, request.price_id, idempotency_key, customer_id=existing_customer_id, promotion_code=request.promotion_code
     )
     if not session:
         raise HTTPException(status_code=500, detail="Could not create checkout session.")
@@ -442,14 +444,25 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
                 detail="Downgrading from Architect to Unlimited is not available. Please contact support if you need to change your plan.",
             )
 
+        # Validate and resolve promotion code if provided
+        resolved_coupon_id = None
+        if request.promotion_code:
+            promo_list = stripe.PromotionCode.list(code=request.promotion_code, active=True, limit=1)
+            if not promo_list.data:
+                raise HTTPException(status_code=400, detail="Invalid or expired promotion code.")
+            resolved_coupon_id = promo_list.data[0].coupon.id
+
         # Cross-plan change (e.g. Unlimited→Architect): immediate swap with proration
         if current_plan != target_plan:
-            updated_sub = stripe.Subscription.modify(
-                stripe_sub['id'],
-                items=[{'id': current_item_id, 'price': request.price_id}],
-                proration_behavior='always_invoice',
-                metadata={'uid': uid, 'sub_type': target_plan.value},
-            )
+            modify_params = {
+                'items': [{'id': current_item_id, 'price': request.price_id}],
+                'proration_behavior': 'always_invoice',
+                'metadata': {'uid': uid, 'sub_type': target_plan.value},
+            }
+            if resolved_coupon_id:
+                modify_params['discounts'] = [{'coupon': resolved_coupon_id}]
+
+            updated_sub = stripe.Subscription.modify(stripe_sub['id'], **modify_params)
 
             # Update our database immediately
             new_subscription = _build_subscription_from_stripe_object(updated_sub.to_dict())

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -101,6 +101,7 @@ pytest tests/unit/test_subscription_restructure.py -v
 pytest tests/unit/test_chat_quota.py -v
 pytest tests/unit/test_subscription_plans.py -v
 pytest tests/unit/test_payment_available_plans_source.py -v
+pytest tests/unit/test_payment_promotion_codes.py -v
 pytest tests/unit/test_stripe_webhook_none_guard.py -v
 pytest tests/unit/test_stripe_webhook_behavioral.py -v
 pytest tests/unit/test_voice_duration_limiter.py -v

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+PAYMENT_SOURCE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
+STRIPE_UTILS_SOURCE = Path(__file__).resolve().parents[2] / "utils" / "stripe.py"
+
+
+def test_checkout_request_model_accepts_promotion_code():
+    source = PAYMENT_SOURCE.read_text()
+    assert 'class CreateCheckoutRequest(BaseModel):' in source
+    assert 'promotion_code: Optional[str] = None' in source
+
+
+def test_upgrade_request_model_accepts_promotion_code():
+    source = PAYMENT_SOURCE.read_text()
+    assert 'class UpgradeSubscriptionRequest(BaseModel):' in source
+    assert 'promotion_code: Optional[str] = None' in source
+
+
+def test_checkout_validates_promo_before_reactivation():
+    """Promo validation must happen before _try_reactivate_subscription."""
+    source = PAYMENT_SOURCE.read_text()
+    promo_check_pos = source.index("PromotionCode.list(code=request.promotion_code")
+    reactivation_pos = source.index("_try_reactivate_subscription(uid, request.price_id)")
+    # In checkout endpoint, the positions should be in order: first promo check occurs before reactivation
+    # Both appear — get the ones inside create_checkout_session_endpoint
+    endpoint_start = source.index("def create_checkout_session_endpoint")
+    promo_in_checkout = source.index("PromotionCode.list", endpoint_start)
+    reactivation_in_checkout = source.index("_try_reactivate_subscription", endpoint_start)
+    assert promo_in_checkout < reactivation_in_checkout, "Promo validation must run before reactivation check"
+
+
+def test_upgrade_uses_promotion_code_id_not_coupon():
+    """Upgrade must use promotion_code ID (preserves restrictions) not coupon ID."""
+    source = PAYMENT_SOURCE.read_text()
+    upgrade_start = source.index("def upgrade_subscription_endpoint")
+    upgrade_section = source[upgrade_start:]
+    assert "{'promotion_code': resolved_promo_id}" in upgrade_section
+    assert "{'coupon':" not in upgrade_section
+
+
+def test_upgrade_applies_promo_to_schedule_phases():
+    """Same-plan interval changes must apply promo discount to the target phase."""
+    source = PAYMENT_SOURCE.read_text()
+    upgrade_start = source.index("def upgrade_subscription_endpoint")
+    upgrade_section = source[upgrade_start:]
+    assert "SubscriptionSchedule.modify" in upgrade_section
+    schedule_pos = upgrade_section.index("SubscriptionSchedule.modify")
+    after_schedule = upgrade_section[schedule_pos:]
+    assert "resolved_promo_id" in after_schedule
+
+
+def test_checkout_helper_uses_discounts_when_promo_provided():
+    """With promotion_code_id, helper sets discounts and omits allow_promotion_codes."""
+    source = STRIPE_UTILS_SOURCE.read_text()
+    assert "if promotion_code_id:" in source
+    assert "session_params['discounts'] = [{'promotion_code': promotion_code_id}]" in source
+
+
+def test_checkout_helper_allows_promo_codes_when_no_promo():
+    """Without promotion_code_id, helper sets allow_promotion_codes=True."""
+    source = STRIPE_UTILS_SOURCE.read_text()
+    assert "session_params['allow_promotion_codes'] = True" in source
+
+
+def test_upgrade_catches_stripe_invalid_request_error():
+    """Stripe InvalidRequestError on upgrade must map to HTTP 400."""
+    source = PAYMENT_SOURCE.read_text()
+    upgrade_start = source.index("def upgrade_subscription_endpoint")
+    upgrade_section = source[upgrade_start:]
+    assert "stripe.error.InvalidRequestError" in upgrade_section
+
+
+def test_checkout_catches_stripe_invalid_request_error():
+    """Stripe InvalidRequestError on checkout must map to HTTP 400."""
+    source = PAYMENT_SOURCE.read_text()
+    checkout_start = source.index("def create_checkout_session_endpoint")
+    checkout_section = source[checkout_start : source.index("def upgrade_subscription_endpoint")]
+    assert "stripe.error.InvalidRequestError" in checkout_section

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -1,11 +1,18 @@
+"""Tests for promotion code support in checkout and upgrade endpoints."""
+
+import sys
+import types
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
 
 PAYMENT_SOURCE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
 STRIPE_UTILS_SOURCE = Path(__file__).resolve().parents[2] / "utils" / "stripe.py"
+
+# ---------------------------------------------------------------------------
+# Source-level structural tests (fast, no import needed)
+# ---------------------------------------------------------------------------
 
 
 def test_checkout_request_model_accepts_promotion_code():
@@ -23,10 +30,6 @@ def test_upgrade_request_model_accepts_promotion_code():
 def test_checkout_validates_promo_before_reactivation():
     """Promo validation must happen before _try_reactivate_subscription."""
     source = PAYMENT_SOURCE.read_text()
-    promo_check_pos = source.index("PromotionCode.list(code=request.promotion_code")
-    reactivation_pos = source.index("_try_reactivate_subscription(uid, request.price_id)")
-    # In checkout endpoint, the positions should be in order: first promo check occurs before reactivation
-    # Both appear — get the ones inside create_checkout_session_endpoint
     endpoint_start = source.index("def create_checkout_session_endpoint")
     promo_in_checkout = source.index("PromotionCode.list", endpoint_start)
     reactivation_in_checkout = source.index("_try_reactivate_subscription", endpoint_start)
@@ -54,20 +57,17 @@ def test_upgrade_applies_promo_to_schedule_phases():
 
 
 def test_checkout_helper_uses_discounts_when_promo_provided():
-    """With promotion_code_id, helper sets discounts and omits allow_promotion_codes."""
     source = STRIPE_UTILS_SOURCE.read_text()
     assert "if promotion_code_id:" in source
     assert "session_params['discounts'] = [{'promotion_code': promotion_code_id}]" in source
 
 
 def test_checkout_helper_allows_promo_codes_when_no_promo():
-    """Without promotion_code_id, helper sets allow_promotion_codes=True."""
     source = STRIPE_UTILS_SOURCE.read_text()
     assert "session_params['allow_promotion_codes'] = True" in source
 
 
 def test_upgrade_catches_stripe_invalid_request_error():
-    """Stripe InvalidRequestError on upgrade must map to HTTP 400."""
     source = PAYMENT_SOURCE.read_text()
     upgrade_start = source.index("def upgrade_subscription_endpoint")
     upgrade_section = source[upgrade_start:]
@@ -75,8 +75,194 @@ def test_upgrade_catches_stripe_invalid_request_error():
 
 
 def test_checkout_catches_stripe_invalid_request_error():
-    """Stripe InvalidRequestError on checkout must map to HTTP 400."""
     source = PAYMENT_SOURCE.read_text()
     checkout_start = source.index("def create_checkout_session_endpoint")
     checkout_section = source[checkout_start : source.index("def upgrade_subscription_endpoint")]
     assert "stripe.error.InvalidRequestError" in checkout_section
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests (import and call endpoints via mocked dependencies)
+# ---------------------------------------------------------------------------
+
+
+def _setup_payment_module():
+    """Import payment router with all heavy deps mocked."""
+    # Mock heavy modules before importing
+    for mod_name in [
+        "database._client",
+        "database.redis_db",
+        "database.users",
+        "database.conversations",
+        "database.memories",
+        "database.action_items",
+        "database",
+        "utils.fair_use",
+        "utils.notifications",
+        "utils.subscription",
+        "utils.stripe",
+        "utils.apps",
+        "utils.other.endpoints",
+        "utils.other",
+        "utils.overage",
+        "utils.executors",
+        "utils.log_sanitizer",
+        "models.users",
+    ]:
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+
+    # Provide required names in mocked modules
+    db_mod = sys.modules["database"]
+    db_mod.users = MagicMock()
+    db_mod.conversations = MagicMock()
+    db_mod.memories = MagicMock()
+    db_mod.action_items = MagicMock()
+
+    redis_mod = sys.modules["database.redis_db"]
+    redis_mod.set_credits_invalidation_signal = MagicMock()
+
+    fair_use_mod = sys.modules["utils.fair_use"]
+    fair_use_mod.clear_fair_use_on_upgrade = MagicMock()
+
+    notif_mod = sys.modules["utils.notifications"]
+    notif_mod.send_notification = MagicMock()
+    notif_mod.send_subscription_paid_personalized_notification = MagicMock()
+
+    sub_mod = sys.modules["utils.subscription"]
+    sub_mod.can_user_make_payment = MagicMock(return_value=(True, None))
+    sub_mod.get_basic_plan_limits = MagicMock()
+    sub_mod.get_paid_plan_definitions = MagicMock()
+    sub_mod.get_plan_type_from_price_id = MagicMock()
+    sub_mod.get_plan_limits = MagicMock()
+    sub_mod.is_paid_plan = MagicMock(return_value=True)
+    sub_mod.filter_plans_for_user = MagicMock()
+    sub_mod.should_show_new_plans = MagicMock()
+    sub_mod.adapt_plans_for_legacy_client = MagicMock()
+    sub_mod.clear_trial_paywall_cache = MagicMock()
+    sub_mod.find_active_paid_subscription_for_user = MagicMock()
+
+    stripe_utils_mod = sys.modules["utils.stripe"]
+    stripe_utils_mod.base_url = "http://test/"
+    stripe_utils_mod.create_subscription_checkout_session = MagicMock()
+    stripe_utils_mod.create_connect_account = MagicMock()
+    stripe_utils_mod.refresh_connect_account_link = MagicMock()
+    stripe_utils_mod.is_onboarding_complete = MagicMock()
+
+    apps_mod = sys.modules["utils.apps"]
+    apps_mod.find_app_subscription = MagicMock()
+    apps_mod.get_is_user_paid_app = MagicMock()
+    apps_mod.paid_app = MagicMock()
+    apps_mod.set_user_app_sub_customer_id = MagicMock()
+
+    endpoints_mod = sys.modules["utils.other.endpoints"]
+    endpoints_mod.get_current_user_uid = lambda: "test-uid"
+    endpoints_mod.get_current_user_uid_no_byok_validation = lambda: "test-uid"
+
+    overage_mod = sys.modules["utils.overage"]
+    overage_mod.OVERAGE_EXPLAINER_TITLE = ""
+    overage_mod.PROVIDER_REFERENCE_RATES = {}
+    overage_mod.build_explainer_text = MagicMock()
+    overage_mod.get_user_overage = MagicMock()
+    overage_mod.is_overage_plan = MagicMock()
+
+    exec_mod = sys.modules["utils.executors"]
+    exec_mod.db_executor = MagicMock()
+    exec_mod.stripe_executor = MagicMock()
+    exec_mod.run_blocking = MagicMock()
+
+    sanitizer_mod = sys.modules["utils.log_sanitizer"]
+    sanitizer_mod.sanitize = lambda x: x
+
+    models_mod = sys.modules["models.users"]
+    models_mod.PlanType = MagicMock()
+    models_mod.Subscription = MagicMock()
+    models_mod.SubscriptionStatus = MagicMock()
+    models_mod.PlanLimits = MagicMock()
+
+    users_db_mod = sys.modules["database.users"]
+    users_db_mod.get_stripe_connect_account_id = MagicMock()
+    users_db_mod.set_stripe_connect_account_id = MagicMock()
+    users_db_mod.set_paypal_payment_details = MagicMock()
+    users_db_mod.get_default_payment_method = MagicMock()
+    users_db_mod.set_default_payment_method = MagicMock()
+    users_db_mod.get_paypal_payment_details = MagicMock()
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    # Force re-import of payment router
+    if "routers.payment" in sys.modules:
+        del sys.modules["routers.payment"]
+
+    from routers import payment as payment_router
+
+    app = FastAPI()
+    app.include_router(payment_router.router)
+    app.dependency_overrides[payment_router.auth.get_current_user_uid] = lambda: "test-uid"
+    app.dependency_overrides[payment_router.auth.get_current_user_uid_no_byok_validation] = lambda: "test-uid"
+
+    return TestClient(app), payment_router
+
+
+# --- Checkout endpoint tests ---
+
+
+def test_checkout_invalid_promo_returns_400():
+    """Invalid promo code returns 400 and does not create a session."""
+    client, router = _setup_payment_module()
+
+    with patch.object(router.stripe, "PromotionCode") as mock_promo:
+        mock_promo.list.return_value = MagicMock(data=[])
+        response = client.post("/v1/payments/checkout-session", json={"price_id": "price_123", "promotion_code": "BAD"})
+
+    assert response.status_code == 400
+    assert "Invalid or expired" in response.json()["detail"]
+    router.stripe_utils.create_subscription_checkout_session.assert_not_called()
+
+
+def test_checkout_valid_promo_passes_id_to_session():
+    """Valid promo code resolves ID and passes it to create_subscription_checkout_session."""
+    client, router = _setup_payment_module()
+
+    mock_promo_obj = MagicMock()
+    mock_promo_obj.id = "promo_abc123"
+    mock_session = MagicMock()
+    mock_session.url = "https://checkout.stripe.com/test"
+    mock_session.id = "cs_test_123"
+
+    with patch.object(router.stripe, "PromotionCode") as mock_promo:
+        mock_promo.list.return_value = MagicMock(data=[mock_promo_obj])
+        router.stripe_utils.create_subscription_checkout_session.return_value = mock_session
+        router.subscription_utils.can_user_make_payment.return_value = (True, None)
+        router.users_db.get_stripe_customer_id.return_value = None
+
+        with patch.object(router, "_try_reactivate_subscription", return_value=None):
+            response = client.post(
+                "/v1/payments/checkout-session", json={"price_id": "price_123", "promotion_code": "WELCOME50"}
+            )
+
+    assert response.status_code == 200
+    call_kwargs = router.stripe_utils.create_subscription_checkout_session.call_args
+    assert call_kwargs[1].get("promotion_code_id") == "promo_abc123" or (
+        len(call_kwargs[0]) > 4 and call_kwargs[0][4] == "promo_abc123"
+    )
+
+
+def test_checkout_no_promo_omits_promo_id():
+    """No promo code passes None as promotion_code_id."""
+    client, router = _setup_payment_module()
+
+    mock_session = MagicMock()
+    mock_session.url = "https://checkout.stripe.com/test"
+    mock_session.id = "cs_test_456"
+    router.stripe_utils.create_subscription_checkout_session.return_value = mock_session
+    router.subscription_utils.can_user_make_payment.return_value = (True, None)
+    router.users_db.get_stripe_customer_id.return_value = None
+
+    with patch.object(router, "_try_reactivate_subscription", return_value=None):
+        response = client.post("/v1/payments/checkout-session", json={"price_id": "price_123"})
+
+    assert response.status_code == 200
+    call_kwargs = router.stripe_utils.create_subscription_checkout_session.call_args
+    assert call_kwargs[1].get("promotion_code_id") is None

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -83,6 +83,8 @@ def create_subscription_checkout_session(
 
         checkout_session = stripe.checkout.Session.create(**session_params)
         return checkout_session
+    except stripe.error.InvalidRequestError:
+        raise
     except Exception as e:
         logger.error(f"Error creating checkout session: {e}")
         return None

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -37,7 +37,7 @@ def create_app_monthly_recurring_price(product_id: str, amount_in_cents: int, cu
 
 
 def create_subscription_checkout_session(
-    uid: str, price_id: str, idempotency_key: str = None, customer_id: str = None, promotion_code: str = None
+    uid: str, price_id: str, idempotency_key: str = None, customer_id: str = None, promotion_code_id: str = None
 ):
     """Create a Stripe Checkout session for a subscription."""
     try:
@@ -69,13 +69,8 @@ def create_subscription_checkout_session(
             },
         }
 
-        # Pre-fill promo code if provided; otherwise let Stripe show its own promo UI
-        if promotion_code:
-            promo_list = stripe.PromotionCode.list(code=promotion_code, active=True, limit=1)
-            if promo_list.data:
-                session_params['discounts'] = [{'promotion_code': promo_list.data[0].id}]
-            else:
-                session_params['allow_promotion_codes'] = True
+        if promotion_code_id:
+            session_params['discounts'] = [{'promotion_code': promotion_code_id}]
         else:
             session_params['allow_promotion_codes'] = True
 

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -36,7 +36,9 @@ def create_app_monthly_recurring_price(product_id: str, amount_in_cents: int, cu
     return price
 
 
-def create_subscription_checkout_session(uid: str, price_id: str, idempotency_key: str = None, customer_id: str = None):
+def create_subscription_checkout_session(
+    uid: str, price_id: str, idempotency_key: str = None, customer_id: str = None, promotion_code: str = None
+):
     """Create a Stripe Checkout session for a subscription."""
     try:
         success_url = urljoin(base_url, 'v1/payments/success?session_id={CHECKOUT_SESSION_ID}')
@@ -55,7 +57,6 @@ def create_subscription_checkout_session(uid: str, price_id: str, idempotency_ke
             'mode': 'subscription',
             'success_url': success_url,
             'cancel_url': cancel_url,
-            'allow_promotion_codes': True,
             'metadata': {
                 'uid': uid,
                 'sub_type': 'unlimited',
@@ -67,6 +68,16 @@ def create_subscription_checkout_session(uid: str, price_id: str, idempotency_ke
                 }
             },
         }
+
+        # Pre-fill promo code if provided; otherwise let Stripe show its own promo UI
+        if promotion_code:
+            promo_list = stripe.PromotionCode.list(code=promotion_code, active=True, limit=1)
+            if promo_list.data:
+                session_params['discounts'] = [{'promotion_code': promo_list.data[0].id}]
+            else:
+                session_params['allow_promotion_codes'] = True
+        else:
+            session_params['allow_promotion_codes'] = True
 
         if customer_id:
             session_params['customer'] = customer_id

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -204,14 +204,16 @@ actor APIClient {
       }
 
       guard (200...299).contains(retryHttpResponse.statusCode) else {
-        throw APIError.httpError(statusCode: retryHttpResponse.statusCode)
+        let detail = Self.extractErrorDetail(from: retryData)
+        throw APIError.httpError(statusCode: retryHttpResponse.statusCode, detail: detail)
       }
 
       return try decoder.decode(T.self, from: retryData)
     }
 
     guard (200...299).contains(httpResponse.statusCode) else {
-      throw APIError.httpError(statusCode: httpResponse.statusCode)
+      let detail = Self.extractErrorDetail(from: data)
+      throw APIError.httpError(statusCode: httpResponse.statusCode, detail: detail)
     }
 
     do {
@@ -240,6 +242,14 @@ actor APIClient {
       throw decodingError
     }
   }
+
+  private static func extractErrorDetail(from data: Data) -> String? {
+    guard
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let detail = json["detail"] as? String
+    else { return nil }
+    return detail
+  }
 }
 
 // MARK: - API Errors
@@ -247,8 +257,13 @@ actor APIClient {
 enum APIError: LocalizedError {
   case invalidResponse
   case unauthorized
-  case httpError(statusCode: Int)
+  case httpError(statusCode: Int, detail: String? = nil)
   case decodingError(Error)
+
+  var detail: String? {
+    if case .httpError(_, let detail) = self { return detail }
+    return nil
+  }
 
   var errorDescription: String? {
     switch self {
@@ -256,7 +271,8 @@ enum APIError: LocalizedError {
       return "Invalid response from server"
     case .unauthorized:
       return "Unauthorized - please sign in again"
-    case .httpError(let statusCode):
+    case .httpError(let statusCode, let detail):
+      if let detail { return detail }
       return "HTTP error: \(statusCode)"
     case .decodingError(let error):
       return "Failed to decode response: \(error.localizedDescription)"
@@ -1256,7 +1272,7 @@ extension APIClient {
         customBaseURL: nil
       )
       return response.conversation
-    } catch APIError.httpError(let statusCode) where statusCode == 404 {
+    } catch APIError.httpError(statusCode: let statusCode, detail: _) where statusCode == 404 {
       // 404 = no in-progress conversation found — WS close handler already processed it
       return nil
     }
@@ -4548,28 +4564,40 @@ extension APIClient {
     return try await get("v1/payments/overage-info")
   }
 
-  func createCheckoutSession(priceId: String) async throws -> CheckoutSessionResponse {
+  func createCheckoutSession(priceId: String, promotionCode: String? = nil) async throws
+    -> CheckoutSessionResponse
+  {
     struct Request: Encodable {
       let priceId: String
+      let promotionCode: String?
 
       enum CodingKeys: String, CodingKey {
         case priceId = "price_id"
+        case promotionCode = "promotion_code"
       }
     }
 
-    return try await post("v1/payments/checkout-session", body: Request(priceId: priceId))
+    return try await post(
+      "v1/payments/checkout-session",
+      body: Request(priceId: priceId, promotionCode: promotionCode))
   }
 
-  func upgradeSubscription(priceId: String) async throws -> UpgradeSubscriptionResponse {
+  func upgradeSubscription(priceId: String, promotionCode: String? = nil) async throws
+    -> UpgradeSubscriptionResponse
+  {
     struct Request: Encodable {
       let priceId: String
+      let promotionCode: String?
 
       enum CodingKeys: String, CodingKey {
         case priceId = "price_id"
+        case promotionCode = "promotion_code"
       }
     }
 
-    return try await post("v1/payments/upgrade-subscription", body: Request(priceId: priceId))
+    return try await post(
+      "v1/payments/upgrade-subscription",
+      body: Request(priceId: priceId, promotionCode: promotionCode))
   }
 
   func createCustomerPortalSession() async throws -> CustomerPortalResponse {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -7389,6 +7389,14 @@ struct SettingsContentView: View {
             subscriptionError = response.message ?? "Could not start checkout."
           }
         }
+      } catch let apiError as APIError {
+        logError("Failed to create checkout session", error: apiError)
+        await MainActor.run {
+          activeCheckoutPriceId = nil
+          pendingSubscriptionPriceId = nil
+          pendingCheckoutSessionId = nil
+          subscriptionError = apiError.detail ?? "Failed to open checkout."
+        }
       } catch {
         logError("Failed to create checkout session", error: error)
         await MainActor.run {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -235,6 +235,8 @@ struct SettingsContentView: View {
   @State private var fallbackPlanCatalog: [SubscriptionPlanOption] = []
   @State private var activeCheckoutPriceId: String?
   @State private var selectedPlanIdForCheckout: String?
+  @State private var upgradePromotionCode: String = ""
+  @State private var isPromoCodeExpanded: Bool = false
   @State private var isOpeningCustomerPortal: Bool = false
   @State private var activeBillingWebFlow: BillingWebFlow?
   @State private var pendingSubscriptionPriceId: String?
@@ -6855,6 +6857,48 @@ struct SettingsContentView: View {
               .disabled(activeCheckoutPriceId != nil)
             }
           }
+
+          VStack(alignment: .leading, spacing: 6) {
+            Button(action: {
+              withAnimation(.easeInOut(duration: 0.2)) {
+                isPromoCodeExpanded.toggle()
+              }
+            }) {
+              HStack(spacing: 6) {
+                Image(systemName: "tag")
+                  .scaledFont(size: 12)
+                Text("Promo code")
+                  .scaledFont(size: 12)
+                Image(systemName: isPromoCodeExpanded ? "chevron.up" : "chevron.down")
+                  .scaledFont(size: 10)
+              }
+              .foregroundColor(OmiColors.textTertiary)
+            }
+            .buttonStyle(.plain)
+
+            if isPromoCodeExpanded {
+              VStack(alignment: .leading, spacing: 6) {
+                TextField("Enter promo code", text: $upgradePromotionCode)
+                  .textFieldStyle(.roundedBorder)
+                  .scaledFont(size: 13)
+                  .disabled(activeCheckoutPriceId != nil)
+                  .onChange(of: upgradePromotionCode) { _ in
+                    subscriptionError = nil
+                  }
+
+                if let error = subscriptionError {
+                  HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.circle")
+                      .scaledFont(size: 11)
+                    Text(error)
+                      .scaledFont(size: 11)
+                  }
+                  .foregroundColor(OmiColors.warning)
+                }
+              }
+              .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+          }
         }
       } else if isCurrentPlan {
         HStack {
@@ -7273,6 +7317,9 @@ struct SettingsContentView: View {
     pendingSubscriptionPriceId = priceId
     subscriptionError = nil
 
+    let promotionCode = upgradePromotionCode.trimmingCharacters(in: .whitespacesAndNewlines)
+    let promoToSend: String? = promotionCode.isEmpty ? nil : promotionCode
+
     // If user already has an active paid subscription (not canceled), use upgrade endpoint
     // to schedule the plan change at end of billing period (no double-charging)
     if hasPaidSubscription,
@@ -7281,12 +7328,20 @@ struct SettingsContentView: View {
     {
       Task {
         do {
-          _ = try await APIClient.shared.upgradeSubscription(priceId: priceId)
+          _ = try await APIClient.shared.upgradeSubscription(
+            priceId: priceId, promotionCode: promoToSend)
           await MainActor.run {
             activeCheckoutPriceId = nil
             pendingSubscriptionPriceId = nil
             subscriptionError = nil
+            self.upgradePromotionCode = ""
             loadSubscriptionInfo()
+          }
+        } catch let apiError as APIError {
+          await MainActor.run {
+            activeCheckoutPriceId = nil
+            pendingSubscriptionPriceId = nil
+            subscriptionError = apiError.detail ?? "Failed to schedule plan change."
           }
         } catch {
           logError("Failed to schedule plan change", error: error)
@@ -7302,7 +7357,8 @@ struct SettingsContentView: View {
 
     Task {
       do {
-        let response = try await APIClient.shared.createCheckoutSession(priceId: priceId)
+        let response = try await APIClient.shared.createCheckoutSession(
+          priceId: priceId, promotionCode: promoToSend)
         let apiBaseURL = await APIClient.shared.baseURL
         await MainActor.run {
           activeCheckoutPriceId = nil

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -6824,40 +6824,6 @@ struct SettingsContentView: View {
           .overlay(OmiColors.backgroundQuaternary)
 
         VStack(alignment: .leading, spacing: 10) {
-          Text("Choose billing")
-            .scaledFont(size: 12, weight: .semibold)
-            .foregroundColor(OmiColors.textTertiary)
-
-          HStack(spacing: 10) {
-            ForEach(sortedPrices(for: plan)) { price in
-              Button(action: {
-                startCheckout(for: price.id)
-              }) {
-                Group {
-                  if activeCheckoutPriceId == price.id {
-                    ProgressView()
-                      .controlSize(.small)
-                      .frame(maxWidth: .infinity)
-                  } else {
-                    VStack(spacing: 3) {
-                      Text(price.title)
-                        .scaledFont(size: 12, weight: .bold)
-                      Text(price.priceString)
-                        .scaledFont(size: 11)
-                        .foregroundColor(Color.white.opacity(0.92))
-                    }
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                  }
-                }
-                .padding(.vertical, 10)
-              }
-              .buttonStyle(.borderedProminent)
-              .tint(accent)
-              .disabled(activeCheckoutPriceId != nil)
-            }
-          }
-
           VStack(alignment: .leading, spacing: 6) {
             Button(action: {
               withAnimation(.easeInOut(duration: 0.2)) {
@@ -6897,6 +6863,40 @@ struct SettingsContentView: View {
                 }
               }
               .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+          }
+
+          Text("Choose billing")
+            .scaledFont(size: 12, weight: .semibold)
+            .foregroundColor(OmiColors.textTertiary)
+
+          HStack(spacing: 10) {
+            ForEach(sortedPrices(for: plan)) { price in
+              Button(action: {
+                startCheckout(for: price.id)
+              }) {
+                Group {
+                  if activeCheckoutPriceId == price.id {
+                    ProgressView()
+                      .controlSize(.small)
+                      .frame(maxWidth: .infinity)
+                  } else {
+                    VStack(spacing: 3) {
+                      Text(price.title)
+                        .scaledFont(size: 12, weight: .bold)
+                      Text(price.priceString)
+                        .scaledFont(size: 11)
+                        .foregroundColor(Color.white.opacity(0.92))
+                    }
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                  }
+                }
+                .padding(.vertical, 10)
+              }
+              .buttonStyle(.borderedProminent)
+              .tint(accent)
+              .disabled(activeCheckoutPriceId != nil)
             }
           }
         }

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -1176,7 +1176,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
           ["source_id": "user", "target_id": "goal_\(slug(title))", "label": "prioritizes"]
         ]
       )
-    } catch APIError.httpError(let statusCode) where statusCode == 429 {
+    } catch APIError.httpError(statusCode: let statusCode, detail: _) where statusCode == 429 {
       logError(
         "OnboardingPagedIntroCoordinator: Goal save rate-limited (429)",
         error: APIError.httpError(statusCode: 429))
@@ -1211,7 +1211,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
           unit: unit,
           source: "onboarding_step_flow"
         )
-      } catch APIError.httpError(let statusCode) where statusCode == 429 {
+      } catch APIError.httpError(statusCode: let statusCode, detail: _) where statusCode == 429 {
         lastError = APIError.httpError(statusCode: 429)
         guard attempt < backoffsSec.count else { break }
         log(

--- a/desktop/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/Desktop/Tests/APIClientRoutingTests.swift
@@ -591,6 +591,58 @@ final class APIClientRoutingTests: XCTestCase {
                      pathContains: "v1/users/stats/chat-messages", method: "GET",
                      label: "getChatMessageCount")
     }
+
+    // MARK: - Promotion code routing and body tests
+
+    func testCreateCheckoutSessionSendsPromotionCode() async {
+        let client = await makeTestClient()
+        _ = try? await client.createCheckoutSession(priceId: "price_abc", promotionCode: "WELCOME50")
+
+        let requests = URLCapture.capturedRequests
+        assertRoutes(requests, host: "python-test", port: 9001,
+                     pathContains: "v1/payments/checkout-session", method: "POST",
+                     label: "createCheckoutSession")
+
+        let body = requests.first?.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        XCTAssertEqual(body?["price_id"] as? String, "price_abc")
+        XCTAssertEqual(body?["promotion_code"] as? String, "WELCOME50")
+    }
+
+    func testCreateCheckoutSessionOmitsNilPromoCode() async {
+        let client = await makeTestClient()
+        _ = try? await client.createCheckoutSession(priceId: "price_abc")
+
+        let body = URLCapture.capturedRequests.first?.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        XCTAssertEqual(body?["price_id"] as? String, "price_abc")
+        XCTAssertNil(body?["promotion_code"])
+    }
+
+    func testUpgradeSubscriptionSendsPromotionCode() async {
+        let client = await makeTestClient()
+        _ = try? await client.upgradeSubscription(priceId: "price_xyz", promotionCode: "SAVE20")
+
+        let requests = URLCapture.capturedRequests
+        assertRoutes(requests, host: "python-test", port: 9001,
+                     pathContains: "v1/payments/upgrade-subscription", method: "POST",
+                     label: "upgradeSubscription")
+
+        let body = requests.first?.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        XCTAssertEqual(body?["price_id"] as? String, "price_xyz")
+        XCTAssertEqual(body?["promotion_code"] as? String, "SAVE20")
+    }
+
+    func testHttpErrorPreservesDetailFromResponse() async {
+        let client = await makeTestClient()
+        do {
+            _ = try await client.createCheckoutSession(priceId: "price_abc", promotionCode: "INVALID")
+            XCTFail("Expected httpError to be thrown")
+        } catch let error as APIError {
+            // URLCapture returns 403 with {"detail":"test"} — verify detail is preserved
+            XCTAssertEqual(error.detail, "test")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
 }
 
 // MARK: - Helper extension to set testAuthHeader from async context


### PR DESCRIPTION
## Summary

Support promo codes for subscription upgrades on desktop. Users with active subscriptions can now enter promo codes when changing plans — previously only new subscribers going through Stripe Checkout could use promo codes.

Closes #7557

## Requirements (from issue + manager feedback)

- [x] Existing paid subscribers can enter a promo code when changing plans
- [x] Invalid/expired promo codes show a clear error message
- [x] Valid promo codes apply the correct discount to the subscription
- [x] UI is polished and minimal — collapsible toggle, not always visible
- [x] Promo code field shown for ALL users (free + paid) — consistent experience
- [x] Collapsed by default behind dropdown toggle (tag icon + "Promo code" + chevron)
- [x] Promo code toggle positioned ABOVE billing buttons (per manager feedback)

## UX Design

### Collapsed (default state)
![Collapsed promo code](https://storage.googleapis.com/omi-pr-assets/promo-collapsed-7557-v2.png)

### Expanded (with code entered)
![Expanded promo code](https://storage.googleapis.com/omi-pr-assets/promo-expanded-7557-v2.png)

**UX decisions** (per manager feedback via kenji, matching mobile PR #7561):
1. Promo field collapsed behind a dropdown toggle — not everyone has a code, keep it minimal by default
2. Shown for ALL users (free + paid) when a plan is selected — consistent experience
3. Promo code toggle placed ABOVE "Choose billing" / billing buttons

## Changes

| File | Change |
|------|--------|
| `backend/routers/payment.py` | Add `promotion_code` field to `CreateCheckoutRequest` and `UpgradeSubscriptionRequest`; validate promo via `stripe.PromotionCode.list()` before reactivation; apply promotion_code discount on upgrade/schedule; catch Stripe `InvalidRequestError` |
| `backend/utils/stripe.py` | Add `promotion_code_id` param to `create_subscription_checkout_session`; pre-fill promo in Stripe Checkout or fall back to built-in promo UI; propagate `InvalidRequestError` |
| `backend/tests/unit/test_payment_promotion_codes.py` | 12 tests: 9 structural + 3 behavioral (FastAPI TestClient with mocked Stripe) |
| `backend/test.sh` | Add `test_payment_promotion_codes.py` |
| `desktop/Desktop/Sources/APIClient.swift` | Add `promotionCode` parameter to `createCheckoutSession` and `upgradeSubscription`; update `APIError` enum with error detail extraction |
| `desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift` | Add collapsible promo code toggle above billing buttons; show for all users when plan is selected; handle validation errors inline on both upgrade and checkout paths |
| `desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift` | Update `APIError` pattern matches for new `detail` parameter (2 locations) |
| `desktop/Desktop/Tests/APIClientRoutingTests.swift` | 4 new tests: checkout/upgrade promo routing + error detail preservation |

## Risks / Edge Cases

- Invalid promo code on upgrade → 400 with "Invalid or expired promotion code." shown inline
- Invalid promo code on checkout → 400 returned before session creation (not silently ignored)
- Stripe rejects promo at application time (customer/product restrictions) → 400 with Stripe's error detail
- Empty promo code → `nil` sent to API (no change from current behavior)
- Promo code field clears after successful upgrade to prevent re-use confusion
- `discounts` and `allow_promotion_codes` are mutually exclusive in Stripe API — handled correctly
- Promo validation runs before subscription reactivation to reject bad codes early

## Test plan

- [x] Verify collapsed toggle appears when selecting any plan (free and paid users) — verified via agent-swift
- [x] Verify expand/collapse animation works — verified via agent-swift click
- [x] Verify promo code text field accepts input — verified via agent-swift fill
- [x] Verify backend: invalid promo returns 400 — behavioral test passes
- [x] Verify backend: valid promo passes ID to Stripe — behavioral test passes
- [x] Verify backend: no promo omits promo ID — behavioral test passes
- [x] Verify desktop: request body includes promotion_code — routing test passes
- [x] Verify desktop: API error detail preserved — routing test passes
- [x] Verify onboarding flow compiles with updated APIError — build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)