### PR TITLE
perf: reduce create_staged_task dedup from O(N) to O(1)

### DIFF
--- a/backend/database/staged_tasks.py
+++ b/backend/database/staged_tasks.py
@@ -33,22 +33,31 @@ def _commit_batch(batch, count):
 
 
 def create_staged_task(uid: str, description: str, **kwargs) -> dict:
-    """Create a staged task.  Deduplicates by case-insensitive description."""
+    """Create a staged task.  Deduplicates by case-insensitive description.
+
+    Uses a ``description_lower`` indexed field so dedup is a single-document
+    equality query (O(1)) instead of an unfiltered collection scan (O(N)).
+    """
     col = _user_col(uid, 'staged_tasks')
 
-    # Deduplicate
+    # Deduplicate — single equality lookup via stored lowercased field
     desc_lower = description.strip().lower()
-    for doc in col.stream():
-        if doc.to_dict().get('description', '').strip().lower() == desc_lower:
-            existing = doc.to_dict()
-            existing['id'] = doc.id
-            return existing
+    existing = (
+        col.where(filter=FieldFilter('description_lower', '==', desc_lower))
+        .limit(1)
+        .stream()
+    )
+    for doc in existing:
+        data = doc.to_dict()
+        data['id'] = doc.id
+        return data
 
     task_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc)
     doc = {
         'id': task_id,
         'description': description,
+        'description_lower': desc_lower,
         'completed': False,
         'created_at': now,
         'updated_at': now,


### PR DESCRIPTION
## Problem

 deduplicates by streaming **ALL** staged tasks for the user () and comparing descriptions case-insensitively in Python. This is **O(N) reads per call** where N = total staged tasks. At 78+ create calls/hr this generates significant read amplification (Firestore write alert: 714 writes/s vs 200/s threshold).

## Root Cause

The dedup loop in  uses an unfiltered collection scan:



There is no indexed field to query against, so every call must read every document in the collection, even when a matching task is the very first document.

## Changes

1. **Store  on creation** — the lowercased, stripped description is written to every new staged task document.
2. **Replace the O(N) scan with a single-document equality query** —  returns at most one match.
3. **Backward compatible** — existing documents without  are simply never matched by the new query, so they won't prevent creation of an equivalent task (acceptable — they'd need a one-time backfill for full coverage, but the perf win for new tasks is immediate).

### Before (O(N))



### After (O(1))



Closes #7440