### PR TITLE
fix: distinguish queued vs processing in sync-job stale guard (#7469)

### DIFF
--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -80,6 +80,7 @@ def get_sync_job(job_id: str) -> Optional[dict]:
     if job['status'] in ('queued', 'processing'):
         updated_at = job.get('updated_at') or job.get('created_at', 0)
         if time.time() - updated_at > STALE_THRESHOLD_SECONDS:
+            original_status = job['status']
             if job['status'] == 'queued':
                 # Job was never picked up — backend capacity issue, not a failure.
                 job['status'] = 'queued_too_long'
@@ -93,8 +94,8 @@ def get_sync_job(job_id: str) -> Optional[dict]:
             r.set(key, json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
             logger.info(
                 "Stale guard transitioned sync_job %s from %s to %s",
-                job_id, job['status'],
-                'queued_too_long' if job['status'] == 'queued' else 'failed',
+                job_id, original_status,
+                'queued_too_long' if original_status == 'queued' else 'failed',
             )
 
     return job

--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -70,15 +70,32 @@ def get_sync_job(job_id: str) -> Optional[dict]:
         return None
     job = json.loads(data)
 
-    # Stale-job detection: if processing for too long, mark failed
+    # Stale-job detection: if processing for too long, mark failed.
+    #
+    # Distinguishes two scenarios:
+    #   1. status == 'processing' and stale — worker likely died mid-pipeline.
+    #      Keep the existing failure semantics; the worker really did fail.
+    #   2. status == 'queued' and stale — never picked up; backend was saturated.
+    #      Not a job failure; the client should retry later.
     if job['status'] in ('queued', 'processing'):
         updated_at = job.get('updated_at') or job.get('created_at', 0)
         if time.time() - updated_at > STALE_THRESHOLD_SECONDS:
-            job['status'] = 'failed'
-            job['error'] = 'Job timed out (background worker likely died)'
+            if job['status'] == 'queued':
+                # Job was never picked up — backend capacity issue, not a failure.
+                job['status'] = 'queued_too_long'
+                job['error'] = 'Backend capacity exhausted before pickup — retry later'
+            else:
+                # Job was being processed but stalled — worker likely died.
+                job['status'] = 'failed'
+                job['error'] = 'Job timed out (background worker likely died)'
             job['completed_at'] = time.time()
-            # Persist the failure status
+            # Persist the status transition
             r.set(key, json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
+            logger.info(
+                "Stale guard transitioned sync_job %s from %s to %s",
+                job_id, job['status'],
+                'queued_too_long' if job['status'] == 'queued' else 'failed',
+            )
 
     return job
 


### PR DESCRIPTION
## Problem

The stale-guard in `get_sync_job()` treats both `queued` and `processing` statuses identically — after 10 minutes both get marked as `failed` with the error `"Job timed out (background worker likely died)"`.

This is incorrect for `queued` jobs: a job sitting in `queued` was **never picked up** by a worker (pools are saturated). No worker died — none was available. The current behavior causes the client to show "Couldn't process — retrying" and burn retry budgets for what is fundamentally a backend capacity issue, not a content failure.

## Root Cause

The stale guard in `get_sync_job()` uses a single condition for both statuses:

```python
if job['status'] in ('queued', 'processing'):
    ...
    if time.time() - updated_at > STALE_THRESHOLD_SECONDS:
        job['status'] = 'failed'
        job['error'] = 'Job timed out (background worker likely died)'
```

It never checks *which* status the job is in. A `queued` job that times out is factually different from a `processing` job that timed out, but they get the same treatment.

## Changes

1. **Distinguish `processing` (worker died) from `queued` (never picked up):**
   - `status == 'processing'` and stale → remains `failed` with the original `"Job timed out (background worker likely died)"` message
   - `status == 'queued'` and stale → transitions to `queued_too_long` with message `"Backend capacity exhausted before pickup — retry later"`

2. **Add structured logging** so the stale-guard transitions are visible in the service logs (currently silent — the transition is invisible in stdout).

3. **The distinct `queued_too_long` status** allows the client's reconciler to pattern-match on status (not error string) and decide: re-queue without bumping retry, or show a capacity-busy message.

Closes #7469