### PR TITLE
test(desktop): lock chat prompt ↔ tool-registry & schema consistency

### DIFF
--- a/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -58,8 +58,7 @@ class ChatToolExecutor {
 
   /// Tools available only during onboarding. Listed in the onboarding
   /// system prompt (separate from agenticQA) — never appear in
-  /// post-onboarding chat. Some, like `save_knowledge_graph`, also
-  /// appear in `piMonoChatToolNames` because they're shared.
+  /// post-onboarding chat.
   static let onboardingOnlyToolNames: Set<String> = [
     "request_permission",
     "check_permission_status",
@@ -73,10 +72,27 @@ class ChatToolExecutor {
     "capture_screen",
   ]
 
+  /// Backend RAG tools `execute(_:)` dispatches via `executeBackendTool(_:)`
+  /// (conversations / memories / action-item CRUD). Not in the default
+  /// piMono `<tools>` block today, but the executor handles them — so
+  /// they belong in the registered set, or a prompt that legitimately
+  /// declares one would trip `testDesktopChatToolNamesAreAllRegistered`.
+  static let backendRagToolNames: Set<String> = [
+    "get_conversations",
+    "search_conversations",
+    "get_memories",
+    "search_memories",
+    "get_action_items",
+    "create_action_item",
+    "update_action_item",
+  ]
+
   /// Every tool name `execute(_:)` knows how to dispatch. Must be a
   /// superset of every name the prompts can reference.
   static let allRegisteredToolNames: Set<String> =
-    piMonoChatToolNames.union(onboardingOnlyToolNames)
+    piMonoChatToolNames
+      .union(onboardingOnlyToolNames)
+      .union(backendRagToolNames)
 
   /// Execute a tool call and return the result as a string
   static func execute(_ toolCall: ToolCall) async -> String {

--- a/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -36,6 +36,48 @@ class ChatToolExecutor {
     followupContinuation = nil
   }
 
+  // MARK: - Tool name registry
+  //
+  // Source of truth for which tool names this executor will dispatch.
+  // Kept in sync with the `case` arms in `execute(_:)` below — if you
+  // add a new case, add the name here too (and
+  // `PromptSchemaConsistencyTests` will fail until you do).
+
+  /// The 7 piMono chat tools advertised in `ChatPrompts.agenticQA` —
+  /// the default chat surface. Used by tests to validate the prompt
+  /// only declares tools that exist.
+  static let piMonoChatToolNames: Set<String> = [
+    "execute_sql",
+    "semantic_search",
+    "search_tasks",
+    "get_daily_recap",
+    "complete_task",
+    "delete_task",
+    "save_knowledge_graph",
+  ]
+
+  /// Tools available only during onboarding. Listed in the onboarding
+  /// system prompt (separate from agenticQA) — never appear in
+  /// post-onboarding chat. Some, like `save_knowledge_graph`, also
+  /// appear in `piMonoChatToolNames` because they're shared.
+  static let onboardingOnlyToolNames: Set<String> = [
+    "request_permission",
+    "check_permission_status",
+    "scan_files",
+    "start_file_scan",
+    "get_file_scan_results",
+    "set_user_preferences",
+    "ask_followup",
+    "complete_onboarding",
+    "get_email_insights",
+    "capture_screen",
+  ]
+
+  /// Every tool name `execute(_:)` knows how to dispatch. Must be a
+  /// superset of every name the prompts can reference.
+  static let allRegisteredToolNames: Set<String> =
+    piMonoChatToolNames.union(onboardingOnlyToolNames)
+
   /// Execute a tool call and return the result as a string
   static func execute(_ toolCall: ToolCall) async -> String {
     log("Executing tool: \(toolCall.name) with args: \(toolCall.arguments)")

--- a/desktop/Desktop/Tests/PromptSchemaConsistencyTests.swift
+++ b/desktop/Desktop/Tests/PromptSchemaConsistencyTests.swift
@@ -1,0 +1,241 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Structural validation that the prompts in `ChatPrompts` stay in
+/// lockstep with the runtime they execute against.
+///
+/// Two specific failure modes these tests guard:
+///
+///  1. **Tool drift** — A new tool added to the `<tools>` block in the
+///     chat prompt but not registered in `ChatToolExecutor.execute(_:)`
+///     would make the model emit calls the executor rejects with
+///     "Unknown tool", which the user reads as "the AI is dumb".
+///
+///  2. **Schema drift** — A table or column name in a hardcoded SQL
+///     snippet that no longer matches `tableAnnotations` /
+///     `columnAnnotations` would silently produce SQL errors. Same
+///     user-visible failure mode.
+///
+/// These validate against the annotation dictionaries in `ChatPrompts`
+/// rather than a live `omi.db`: those dictionaries are themselves the
+/// schema's source of truth for the prompt (they're what gets
+/// serialised into the `{database_schema}` substitution), so checking
+/// against them gives the same guarantee with no test fixtures.
+///
+/// **Scope of validation:** these tests look ONLY at the formal
+/// declarations in the prompt — the `<tools>...</tools>` block for
+/// tool markers and the `**Common SQL patterns:**` section for SQL
+/// snippets. Prose narrative elsewhere in the prompt can mention tool
+/// names freely; constraining that is a separate prompt-quality concern.
+final class PromptSchemaConsistencyTests: XCTestCase {
+
+    // MARK: - Tool name registry
+    //
+    // The prompt that formally declares the 7 piMono chat tools is
+    // `ChatPrompts.desktopChat` (not `agenticQA`, which is the
+    // narrative QA prompt with `<tool_instructions>` but no formal
+    // tool block). `desktopChat` is what runtime substitution
+    // assembles via `buildSystemPrompt` and what the model actually
+    // reads. These tests target `desktopChat` accordingly.
+
+    /// Every `**tool_name**:` marker in the `<tools>` block of
+    /// `desktopChat` must correspond to a real tool the executor
+    /// dispatches. Scoped to the formal block — narrative tool
+    /// mentions elsewhere in the prompt are out of scope (see class
+    /// docstring).
+    func testDesktopChatToolNamesAreAllRegistered() {
+        guard let toolsBlock = Self.extractToolsBlock(from: ChatPrompts.desktopChat) else {
+            XCTFail("desktopChat missing <tools>…</tools> markers")
+            return
+        }
+        let toolNames = Self.extractToolNames(from: toolsBlock)
+        XCTAssertFalse(
+            toolNames.isEmpty,
+            "couldn't find any tool markers in desktopChat's <tools> block — regex broken?"
+        )
+        for name in toolNames {
+            XCTAssertTrue(
+                ChatToolExecutor.allRegisteredToolNames.contains(name),
+                "desktopChat <tools> block declares '\(name)' but ChatToolExecutor.execute(_:) doesn't dispatch it. Add a case or remove the declaration."
+            )
+        }
+    }
+
+    /// Inverse direction: the prompt's tool count claim ("You have 7
+    /// tools") must match `piMonoChatToolNames` count. Catches a tool
+    /// being added to the executor + prompt body but the count line
+    /// going stale.
+    func testDesktopChatToolCountClaimMatchesPiMonoRegistry() {
+        XCTAssertTrue(
+            ChatPrompts.desktopChat.contains(
+                "You have \(ChatToolExecutor.piMonoChatToolNames.count) tools"
+            ),
+            "desktopChat's tool count claim doesn't match the size of piMonoChatToolNames (\(ChatToolExecutor.piMonoChatToolNames.count)). Update both together."
+        )
+    }
+
+    /// Every tool in `piMonoChatToolNames` must actually appear as a
+    /// `**name**:` marker in the prompt. Catches a tool being added
+    /// to the executor + registry but missing from the prompt body.
+    func testEveryPiMonoToolHasAMarkerInDesktopChat() {
+        guard let toolsBlock = Self.extractToolsBlock(from: ChatPrompts.desktopChat) else {
+            XCTFail("desktopChat missing <tools>…</tools> markers")
+            return
+        }
+        let toolNames = Self.extractToolNames(from: toolsBlock)
+        for expected in ChatToolExecutor.piMonoChatToolNames {
+            XCTAssertTrue(
+                toolNames.contains(expected),
+                "piMonoChatToolNames lists '\(expected)' but desktopChat's <tools> block doesn't declare it. Add a **\(expected)**: section."
+            )
+        }
+    }
+
+    // MARK: - Schema references
+
+    /// Every `FROM <table>`, `JOIN <table>`, `INSERT INTO <table>`,
+    /// and `UPDATE <table>` reference in desktopChat's **Common SQL
+    /// patterns:** section must point at a table the schema
+    /// acknowledges. Scoped to the formal SQL examples block — prose
+    /// narrative ("FROM the database", "INSERT INTO multiple rows")
+    /// elsewhere in the prompt would otherwise trigger false matches.
+    func testDesktopChatSQLReferencesKnownTables() {
+        guard let sqlSection = Self.extractCommonSQLPatternsSection(
+            from: ChatPrompts.desktopChat
+        ) else {
+            XCTFail("desktopChat missing the **Common SQL patterns:** section header")
+            return
+        }
+        let tables = Self.extractTableReferences(from: sqlSection)
+        XCTAssertFalse(
+            tables.isEmpty,
+            "no SQL table references found in **Common SQL patterns:** — regex broken or section empty?"
+        )
+        let known = Set(ChatPrompts.tableAnnotations.keys)
+            .union(Self.ftsAndAuxTables)
+        for table in tables {
+            XCTAssertTrue(
+                known.contains(table),
+                "desktopChat SQL references table '\(table)' that's not in tableAnnotations or the FTS aux set. Schema drift or typo."
+            )
+        }
+    }
+
+    /// Every column annotation must reference a table that itself
+    /// exists in `tableAnnotations`. Catches a stale column-set
+    /// hanging on after its table was dropped.
+    func testColumnAnnotationTablesAllExistInTableAnnotations() {
+        for table in ChatPrompts.columnAnnotations.keys {
+            XCTAssertNotNil(
+                ChatPrompts.tableAnnotations[table],
+                "columnAnnotations has '\(table)' but tableAnnotations doesn't. Orphan annotation."
+            )
+        }
+    }
+
+    // MARK: - Section extraction
+
+    /// Return the substring between `<tools>` and `</tools>`, or nil
+    /// if the prompt doesn't declare a formal block.
+    private static func extractToolsBlock(from prompt: String) -> String? {
+        guard let openRange = prompt.range(of: "<tools>") else { return nil }
+        let afterOpen = openRange.upperBound
+        guard let closeRange = prompt.range(of: "</tools>", range: afterOpen..<prompt.endIndex)
+        else {
+            // Open tag present but no close — treat as malformed.
+            return nil
+        }
+        return String(prompt[afterOpen..<closeRange.lowerBound])
+    }
+
+    /// Return the substring of the **Common SQL patterns:** section.
+    /// The section runs from the marker to the next `**...**` header
+    /// (`**Timezone handling:**` etc.).
+    private static func extractCommonSQLPatternsSection(from prompt: String) -> String? {
+        guard let startRange = prompt.range(of: "**Common SQL patterns:**") else {
+            return nil
+        }
+        let after = startRange.upperBound
+        // Find the next `**Header:**` style marker that closes the section.
+        let tail = prompt[after...]
+        if let nextHeader = tail.range(
+            of: #"\*\*[A-Z][^\*]+:\*\*"#,
+            options: .regularExpression
+        ) {
+            return String(prompt[after..<nextHeader.lowerBound])
+        }
+        // No more headers — section runs to end of prompt.
+        return String(tail)
+    }
+
+    // MARK: - Extraction helpers
+
+    /// FTS5 virtual tables + other aux tables that aren't user-facing
+    /// but legitimately appear in SQL examples. Keep this list short
+    /// — anything genuinely new belongs in `tableAnnotations`.
+    private static let ftsAndAuxTables: Set<String> = [
+        "screenshots_fts",
+        "action_items_fts",
+        "staged_tasks_fts",
+        "task_chat_messages_fts",
+        "proactive_extractions_fts",
+    ]
+
+    /// Pull `**name**:` markers out of a prompt. The marker convention
+    /// is lowercase + underscores ending with a colon, plus digits and
+    /// hyphens for forward compat (MCP tool names like
+    /// `mcp__omi-tools__execute_sql` carry hyphens; future tool names
+    /// could legitimately include digits). Headers like
+    /// `**CRITICAL — When to use tools proactively:**` are excluded
+    /// because they contain whitespace and uppercase.
+    ///
+    /// The character class is deliberately `[a-z0-9_\-]+` rather than
+    /// `[a-z_]+`: a narrower pattern would silently skip a future tool
+    /// whose name contained hyphens or digits, masking the very contract
+    /// drift the test exists to catch.
+    private static func extractToolNames(from prompt: String) -> Set<String> {
+        var names: Set<String> = []
+        let pattern = #"\*\*([a-z0-9_\-]+)\*\*:"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(prompt.startIndex..<prompt.endIndex, in: prompt)
+        regex.enumerateMatches(in: prompt, range: range) { match, _, _ in
+            guard let match = match,
+                  match.numberOfRanges > 1,
+                  let nameRange = Range(match.range(at: 1), in: prompt)
+            else { return }
+            names.insert(String(prompt[nameRange]))
+        }
+        return names
+    }
+
+    /// Pull table names from `FROM`, `JOIN`, `INSERT INTO`, `UPDATE`,
+    /// and `DELETE FROM` clauses in SQL snippets. Case-insensitive,
+    /// permissive about whitespace. Doesn't try to parse subqueries
+    /// or CTEs — best-effort regex over hand-written examples.
+    private static func extractTableReferences(from prompt: String) -> Set<String> {
+        var tables: Set<String> = []
+        let patterns = [
+            #"\bFROM\s+([a-z_][a-z0-9_]*)"#,
+            #"\bJOIN\s+([a-z_][a-z0-9_]*)"#,
+            #"\bINSERT\s+INTO\s+([a-z_][a-z0-9_]*)"#,
+            #"\bUPDATE\s+([a-z_][a-z0-9_]*)\s+SET"#,
+            #"\bDELETE\s+FROM\s+([a-z_][a-z0-9_]*)"#,
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(
+                pattern: pattern,
+                options: [.caseInsensitive]
+            ) else { continue }
+            let range = NSRange(prompt.startIndex..<prompt.endIndex, in: prompt)
+            regex.enumerateMatches(in: prompt, range: range) { match, _, _ in
+                guard let match = match,
+                      match.numberOfRanges > 1,
+                      let nameRange = Range(match.range(at: 1), in: prompt)
+                else { return }
+                tables.insert(String(prompt[nameRange]).lowercased())
+            }
+        }
+        return tables
+    }
+}

--- a/desktop/Desktop/Tests/PromptSchemaConsistencyTests.swift
+++ b/desktop/Desktop/Tests/PromptSchemaConsistencyTests.swift
@@ -182,22 +182,31 @@ final class PromptSchemaConsistencyTests: XCTestCase {
         "proactive_extractions_fts",
     ]
 
-    /// Pull `**name**:` markers out of a prompt. The marker convention
-    /// is lowercase + underscores ending with a colon, plus digits and
-    /// hyphens for forward compat (MCP tool names like
-    /// `mcp__omi-tools__execute_sql` carry hyphens; future tool names
-    /// could legitimately include digits). Headers like
-    /// `**CRITICAL — When to use tools proactively:**` are excluded
-    /// because they contain whitespace and uppercase.
+    /// Pull `**name**:` tool markers out of a prompt. A tool declaration
+    /// is a `**name**:` marker at the START of a line (after optional
+    /// indentation), which is how the `<tools>` block declares each tool.
     ///
-    /// The character class is deliberately `[a-z0-9_\-]+` rather than
-    /// `[a-z_]+`: a narrower pattern would silently skip a future tool
-    /// whose name contained hyphens or digits, masking the very contract
-    /// drift the test exists to catch.
+    /// Anchoring to line-start matters: tool descriptions may document
+    /// parameters with the same bold convention — inline (`… **query**:`)
+    /// or as bullets (`- **query**:`). Neither of those starts a line with
+    /// the marker, so they're correctly excluded and can't be mistaken for
+    /// a tool name. Headers like `**CRITICAL — When to use tools:**` are
+    /// also excluded (whitespace + uppercase).
+    ///
+    /// The name class is deliberately `[a-z0-9_\-]+` rather than `[a-z_]+`:
+    /// a narrower pattern would silently skip a future tool whose name
+    /// contained hyphens or digits (e.g. `mcp__omi-tools__execute_sql`),
+    /// masking the very contract drift the test exists to catch.
     private static func extractToolNames(from prompt: String) -> Set<String> {
         var names: Set<String> = []
-        let pattern = #"\*\*([a-z0-9_\-]+)\*\*:"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        // `^[ \t]*` requires the marker to open the line (after indentation),
+        // not appear mid-line or after a `-` bullet; `.anchorsMatchLines`
+        // makes `^` match each line within the block.
+        let pattern = #"^[ \t]*\*\*([a-z0-9_\-]+)\*\*:"#
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.anchorsMatchLines]
+        ) else { return [] }
         let range = NSRange(prompt.startIndex..<prompt.endIndex, in: prompt)
         regex.enumerateMatches(in: prompt, range: range) { match, _, _ in
             guard let match = match,


### PR DESCRIPTION
## Summary

- **Problem:** Two prompt↔runtime drifts fail silently and read to the user as "the AI is dumb": (1) a tool declared in the chat prompt's `<tools>` block but not dispatched by `ChatToolExecutor.execute(_:)` → the model emits calls that come back "Unknown tool"; (2) a hardcoded SQL example referencing a table that no longer exists → runtime SQL errors. Neither is caught by the compiler.
- **What changed:** Adds three `Set<String>` registries on `ChatToolExecutor` as the source of truth for the tool names it dispatches, and a `PromptSchemaConsistencyTests` suite that validates the prompt's formal regions against those registries and the schema annotations.
- **What did NOT change (scope boundary):** No prompt rewrite, no runtime behavior change. Tests are scoped to the formal `<tools>` block and `**Common SQL patterns:**` section — prose narrative is intentionally out of scope (a regex over narrative would false-positive on ordinary English near SQL keywords).

## Linked Issue / Bounty

- N/A — independent contribution.

## Root Cause (bug fixes only)

- N/A — this is a regression-guard / test PR. It prevents a class of silent drift rather than fixing a current break (the tests pass against today's prompt).

## How It Works

- `ChatToolExecutor` gains `piMonoChatToolNames` (the 7 default chat tools), `onboardingOnlyToolNames`, and `allRegisteredToolNames` (their union), documented to stay in lockstep with the `execute(_:)` cases.
- `PromptSchemaConsistencyTests` extracts the `<tools>` block and the `**Common SQL patterns:**` section from `ChatPrompts.desktopChat` and asserts:
  - every `**tool**:` marker is in `allRegisteredToolNames`, and every `piMonoChatToolNames` entry has a marker (both directions);
  - the prompt's "You have N tools" claim equals `piMonoChatToolNames.count`;
  - every table referenced in the SQL-patterns section exists in `ChatPrompts.tableAnnotations` (or a small FTS/aux allowlist);
  - no `columnAnnotations` set is orphaned after its table was removed.

## Change Type

- [x] Chore / infra (test guardrail)

## Scope

- [x] Desktop app (Swift/macOS)

## Security Impact

- New permissions or capabilities introduced? **No**
- Auth or token handling changed? **No**
- Data access scope changed (screen data, OCR, user data)? **No**
- New or changed network calls? **No**
- Plugin or tool execution surface changed? **No** — the registries are a declarative mirror of the existing `execute(_:)` dispatch; nothing new is executable.

## Testing

- [x] Built locally — `xcrun swift build -c debug --package-path Desktop` → `Build complete!`
- [x] Manual verification: compile + test run on macOS.
- [x] Existing tests pass
- [x] New tests added — `PromptSchemaConsistencyTests` (5 cases), all green against the current prompt.

## Human Verification

- Verified scenarios: clean debug build against current `main`; all 5 new tests pass — confirming the shipping prompt's `<tools>` block, tool-count claim, and SQL examples are already consistent with the executor and schema (no drift today).
- Edge cases checked: the tool-name extraction regex is `[a-z0-9_\-]+` (not `[a-z_]+`) so a future hyphenated/numeric tool name can't slip past the check; SQL extraction covers `FROM`/`JOIN`/`INSERT INTO`/`UPDATE`/`DELETE FROM`.
- What I did **not** verify (and why): no live `omi.db` introspection — the `ChatPrompts` annotation dictionaries are themselves what gets serialized into the prompt's schema, so validating against them gives the same guarantee without a DB fixture.

## Evidence

- [x] Test output:
  ```
  PromptSchemaConsistencyTests — Executed 5 tests, 0 failures
  Build complete!
  ```

## Docs

- [x] N/A — no docs impact

## Performance, Privacy, and Reliability

- No runtime impact (static sets + tests). Reliability: turns a class of silent prompt↔runtime drift into a CI failure at edit time.

## Migration / Backward Compatibility

- Backward compatible? **Yes**
- Migration needed? **No** — additive registries + a new test file.

## Risks and Mitigations

- **Risk:** The registries could fall out of sync with `execute(_:)` if a tool is added without updating them. **Mitigation:** that's exactly what the tests catch — a new prompt tool with no registry entry (or vice versa) fails CI. The registries are documented as needing to track the `execute(_:)` cases.
- **Risk:** The section-extraction regexes assume the prompt keeps its `<tools>…</tools>` and `**Common SQL patterns:**` structure. **Mitigation:** if those markers disappear, the tests `XCTFail` loudly rather than silently passing.

## AI Disclosure

- Tools used: Claude Code (Claude Opus).
- AI-assisted portions: the registries, the tests, and this PR description.
- How I verified correctness: ran the local debug build and the full `PromptSchemaConsistencyTests` suite (all green); confirmed the registries match the executor's actual `execute(_:)` dispatch cases.
