### PR TITLE
conversations: fix day-group ordering when started_at and created_at diverge

### DIFF
--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -550,37 +550,40 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void _groupSearchConvosByDateWithoutNotify() {
-    groupedConversations = {};
-    for (var conversation in _filterOutConvos(searchedConversations)) {
-      var effectiveDate = conversation.startedAt ?? conversation.createdAt;
-      var date = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
-      if (!groupedConversations.containsKey(date)) {
-        groupedConversations[date] = [];
-      }
-      groupedConversations[date]?.add(conversation);
-    }
-
-    // Sort
-    for (final date in groupedConversations.keys) {
-      groupedConversations[date]?.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
-    }
+    groupedConversations = _buildGroupedByDate(_filterOutConvos(searchedConversations));
   }
 
   void _groupConversationsByDateWithoutNotify() {
-    groupedConversations = {};
-    for (var conversation in _filterOutConvos(conversations)) {
-      var effectiveDate = conversation.startedAt ?? conversation.createdAt;
-      var date = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
-      if (!groupedConversations.containsKey(date)) {
-        groupedConversations[date] = [];
-      }
-      groupedConversations[date]?.add(conversation);
+    groupedConversations = _buildGroupedByDate(_filterOutConvos(conversations));
+  }
+
+  /// Buckets conversations into day-keyed groups, sorted newest-first both
+  /// at the day-group level and within each day.
+  ///
+  /// Why the explicit re-ordering at the end matters: the backend returns
+  /// conversations ordered by `created_at` DESC, but we bucket by
+  /// `started_at` (falling back to `created_at`). For re-processed or
+  /// merged conversations these two timestamps diverge — a conversation
+  /// merged today with the original recording date of, say, May 9 lands
+  /// at the top of the API response (newest `created_at`) and creates
+  /// the `May 9` day-bucket first. Dart's default Map iterates in
+  /// insertion order, so without this sort step the UI would render
+  /// `May 9` above today/yesterday. Rebuilding the map in descending
+  /// key order fixes the day-group display order.
+  Map<DateTime, List<ServerConversation>> _buildGroupedByDate(Iterable<ServerConversation> source) {
+    final grouped = <DateTime, List<ServerConversation>>{};
+    for (final conversation in source) {
+      final effectiveDate = conversation.startedAt ?? conversation.createdAt;
+      final date = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
+      grouped.putIfAbsent(date, () => []).add(conversation);
     }
 
-    // Sort
-    for (final date in groupedConversations.keys) {
-      groupedConversations[date]?.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
+    for (final list in grouped.values) {
+      list.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
     }
+
+    final sortedKeys = grouped.keys.toList()..sort((a, b) => b.compareTo(a));
+    return {for (final k in sortedKeys) k: grouped[k]!};
   }
 
   void groupConversationsByDate() {


### PR DESCRIPTION
## Summary
Older day-groups were rendering above newer ones in the conversations list for users with re-processed or merged conversations. Concrete repro: a merged conversation whose `started_at` is, say, `May 9` (the original recording date) but `created_at` is *today* would land at the very top of the conversations page, with today's and yesterday's conversations rendered *below* it.

## Root cause

Three pieces lined up badly:

1. **Backend orders conversations by `created_at` DESC** — `backend/database/conversations.py:210`:
   ```python
   conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
   ```

2. **Dart groups by `started_at` (with `created_at` fallback)** — `conversation_provider.dart:_groupConversationsByDateWithoutNotify`:
   ```dart
   var effectiveDate = conversation.startedAt ?? conversation.createdAt;
   var date = DateTime(effectiveDate.year, effectiveDate.month, effectiveDate.day);
   if (!groupedConversations.containsKey(date)) {
     groupedConversations[date] = [];   // bucket created in iteration order
   }
   ```

3. **Dart renders by map insertion order** — `conversations_page.dart:418`:
   ```dart
   var date = convoProvider.groupedConversations.keys.elementAt(index);
   ```
   Dart's default `Map` is a `LinkedHashMap` whose `.keys` iterate in insertion order, not key order.

When `started_at` equals `created_at` (the common case), the three line up and the UI is correct. When they diverge — typically for a re-processed or merged conversation — the day-bucket whose date matches the conversation's `started_at` gets created when that conversation is first encountered. Since the backend's order is by `created_at`, an old-recording-but-newly-created conversation arrives at the top of the API response → its old-date bucket gets created first → that bucket renders above today's and yesterday's in the UI.

Same root cause also explains user @u17Y…'s prior complaint about "fewer conversations on the page than under the date filter" (#previous-conversation): with `created_at` pagination + `started_at` grouping, the cumulative paginated set under-represents older days, while a date filter forces a day-scoped server query that fills the bucket properly.

## What this PR changes

`app/lib/providers/conversation_provider.dart` only.

Both `_groupConversationsByDateWithoutNotify` (main list) and `_groupSearchConvosByDateWithoutNotify` (search results) had copy-paste identical bodies. Collapsed them into a single shared helper `_buildGroupedByDate(Iterable<ServerConversation>)`, and at the end of bucketing, **rebuild the map with keys sorted descending**:

```dart
final sortedKeys = grouped.keys.toList()..sort((a, b) => b.compareTo(a));
return {for (final k in sortedKeys) k: grouped[k]!};
```

This way the rendered day-group order is always chronological-newest-first regardless of which timestamp the backend sorted by or which timestamp we bucketed by. Within-day sort (already present) is preserved.

## Verification

- ✅ `flutter analyze lib/providers/conversation_provider.dart` → No issues found
- ✅ `dart format --line-length 120 --set-exit-if-changed` → clean
- ✅ `flutter test test/unit/conversation_duration_test.dart test/widgets/processing_conversation_widget_test.dart test/widgets/conversation_detail_copy_id_test.dart` → all 18 pass
- ✅ **Android debug APK build on Mac** → `flutter build apk --debug --flavor dev` produced `build/app/outputs/flutter-apk/app-dev-debug.apk`

## Test plan

- [ ] Open the conversations page → confirm day-groups render in descending chronological order (today first, then yesterday, then older days)
- [ ] User with re-processed/merged conversations (where started_at < created_at): confirm the merged conversation appears under its `started_at` day-bucket, NOT at the top of the list
- [ ] Search a query that surfaces results across multiple days: confirm day-groups in the search results are also in descending chronological order
- [ ] Date-filter mode unchanged: pick a specific date in the filter, confirm only that day's conversations appear

## Out of scope (intentional)

- The pagination/`started_at`-vs-`created_at` mismatch for the *cumulative set* is a deeper issue and would need a backend-side change (order by `started_at`, or return day-grouped pages with `has_more` per day). That's a larger surface and a separate PR. This PR fixes only the *visible day-order* bug — which is the user-facing symptom most people are hitting today.