### PR TITLE
backend: order conversations by started_at instead of created_at

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -200,16 +200,18 @@ def get_conversations(
     if starred is not None:
         conversations_ref = conversations_ref.where(filter=FieldFilter('starred', '==', starred))
 
-    # Apply date range filters if provided
+    # Filter and order by `started_at` (recording time), not `created_at`
+    # (commit time): the two diverge for re-processed/merged conversations
+    # and `started_at` is what the user means by "this conversation's date".
     if start_date:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '>=', start_date))
+        conversations_ref = conversations_ref.where(filter=FieldFilter('started_at', '>=', start_date))
     if end_date:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '<=', end_date))
+        conversations_ref = conversations_ref.where(filter=FieldFilter('started_at', '<=', end_date))
 
-    # Sort
-    conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
+    conversations_ref = conversations_ref.order_by('started_at', direction=firestore.Query.DESCENDING).order_by(
+        'created_at', direction=firestore.Query.DESCENDING
+    )
 
-    # Limits
     conversations_ref = conversations_ref.limit(limit).offset(offset)
 
     conversations = [doc.to_dict() for doc in conversations_ref.stream()]
@@ -258,16 +260,15 @@ def get_conversations_without_photos(
     if starred is not None:
         conversations_ref = conversations_ref.where(filter=FieldFilter('starred', '==', starred))
 
-    # Apply date range filters if provided
     if start_date:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '>=', start_date))
+        conversations_ref = conversations_ref.where(filter=FieldFilter('started_at', '>=', start_date))
     if end_date:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '<=', end_date))
+        conversations_ref = conversations_ref.where(filter=FieldFilter('started_at', '<=', end_date))
 
-    # Sort
-    conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
+    conversations_ref = conversations_ref.order_by('started_at', direction=firestore.Query.DESCENDING).order_by(
+        'created_at', direction=firestore.Query.DESCENDING
+    )
 
-    # Limits
     conversations_ref = conversations_ref.limit(limit).offset(offset)
 
     conversations = [doc.to_dict() for doc in conversations_ref.stream()]


### PR DESCRIPTION
## Summary

The user-facing conversations list endpoints (`get_conversations` and `get_conversations_without_photos`) ordered by `created_at` DESC and filtered date ranges by `created_at`. The Flutter side then grouped the resulting page by `started_at` into day-buckets. **The two timestamps diverge for re-processed or merged conversations** — `created_at = today` (Firestore commit time at merge), `started_at = May 9` (original recording time).

That mismatch produced three user-visible bugs, all the same root cause:

1. A merged-today-from-May-9 conversation lands at the top of the API response (newest `created_at`) and then renders in the **May 9 day bucket** — visually breaking the day-group ordering. *(Client-side ordering of day groups is fixed separately in #7576.)*
2. The first 50 conversations returned cover the most recently **committed** conversations, not the most recently **recorded** ones. Older recording dates are under-represented in the cumulative paginated set until the user scrolls deep enough.
3. The date filter ("show conversations on May 9") filtered by `created_at` — returning conversations committed on May 9, not recorded on May 9. For the normal case where `started_at == created_at` these match; for reprocessed/merged ones they don't.

Concretely, manager hit (1) testing on their own account: "I see a May 9 conversation at the top, then yesterday's conversation after it." Manager observed (2) and (3) for `u17YmZraPZYCZPuQGfqgmekY93F2`: "user gets limited number of conversations shown for a specific day, and if he adds the date filter and chooses that same day then it shows all the conversations." Same bug, different surface.

## What this PR changes

`backend/database/conversations.py` only. Two functions:
- `get_conversations` (line 176-219)
- `get_conversations_without_photos` (line 230-274)

Both now:
- **Filter date range by `started_at`** instead of `created_at` — so the date param matches what the user picked ("conversations FROM May 9" = recorded on May 9).
- **Order by `started_at` DESC** with `created_at` DESC as tiebreaker (for the rare case of duplicate start timestamps — legacy data with second-level precision could produce ties).

The two changes must go together because Firestore requires that the first `order_by` field match any inequality (`>=`, `<=`) filter field — you can't order by `started_at` while filtering inequality by `created_at`.

### Why only these two functions

Other `order_by('created_at')` sites in the same file deliberately left alone:
- `iter_all_conversations` — data export, ordering by commit time matches the write order of the export stream
- `get_in_progress_conversation` — single status-filtered result; ordering only matters for tie-breaking between multiple in-progress entries, where commit time is fine
- `get_action_items` — internal helper for action-item flattening; not user-facing pagination
- `get_closest_conversation_to_timestamps` — timestamp lookup that scans all matches and picks the nearest; the `order_by` is essentially a non-functional default
- `get_last_completed_conversation` — single-result query, ordering by commit time is correct for "most recently committed completed"

## Deployment notes (read before merging)

### 🔴 Composite index changes required

Firestore will refuse `where(...).order_by('started_at')` until a composite index exists for each combination of where-clauses. Expected new indexes (auto-suggested by Firestore on first failed query):

- `(discarded ASC, started_at DESC, created_at DESC, __name__ ASC)` — base case
- Same shape with `status` IN, `structured.category` IN, `folder_id` ==, `starred` ==, and combinations
- With/without the date-range filter (with-range needs `started_at` to be the inequality field, which it now is)

**Recommended deploy order:**
1. Pre-create the most likely indexes via Firebase console or `firebase deploy --only firestore:indexes` BEFORE rolling the code out.
2. Deploy with canary traffic / 10% rollout — first failed query gives an auto-suggest URL that creates the missing index in one click. New indexes build in seconds-to-minutes depending on collection size.
3. Don't promote to 100% until error rate is clean.

If we just deploy without prep, the symptom is 500s on `/v1/conversations` until indexes are created (the first one gets created on first failure; subsequent shape combinations need their own one-click creates). Recoverable but disruptive.

### 🟡 `started_at` storage type consistency

I observed mixed storage on user `u17YmZraPZYCZPuQGfqgmekY93F2`: some conversations have `started_at` as Firestore Timestamp (`timestampValue`), others as ISO-8601 string (`stringValue`). Firestore's cross-type sort orders by type-rank first (`Timestamp < String`), so a user with a mix will get a sort discontinuity — all of one type clusters above all of the other regardless of actual chronological value.

Worth a one-off audit before promoting to prod:

```
# Quickly count type distribution per user (run from a Firestore Admin script)
for snapshot in db.collection_group('conversations').stream():
    sa = snapshot.get('started_at')
    print(type(sa).__name__)
```

If the mix is significant (>5% of conversations), a one-shot normalization migration is the right preparation step. If it's just a few legacy edge cases, ship and let them be visually out of order for those edge cases.

## Verification

- ✅ `black --line-length 120 --skip-string-normalization` → clean
- ✅ Python AST parse → syntax OK
- ✅ Pre-existing tests in `tests/unit/` that mock `get_conversations` (e.g. `test_daily_summary_race_condition.py`) — mock the function entirely, so behavior change inside the function doesn't affect them. No assertions on the internal `order_by`.
- ⚠️ I couldn't run the integration tests from the worktree (firebase_admin not installed in the env) — please confirm `bash backend/test.sh` passes in CI.

## Test plan

- [ ] Build + deploy to staging
- [ ] First-call to `/v1/conversations` after deploy: confirm no `failed precondition: requires an index` errors (or click the auto-suggest URL once if there are)
- [ ] Open conversations page in app: confirm day groups appear in chronological order (today first, then yesterday, then older days). This should be redundant after #7576 lands but worth confirming.
- [ ] Open conversations page for a user with a re-processed/merged conversation: confirm the merged conversation now lives in its `started_at` day bucket, not at the top of the list.
- [ ] Apply date filter for a day with conversations: confirm the returned set matches what should be expected for "recorded on that day" (i.e. `started_at` in range).
- [ ] Spot-check the photoless variant (used by some bulk endpoints) — same set, same order as the photo variant.

## Companion PRs

- #7576 — Flutter-side: sort day-group keys descending so the rendered order matches chronology regardless of insertion order. That's the visible-symptom fix; this PR is the underlying-cause fix.