### PR TITLE
fix(conversations): store finalized timestamps as Firestore Timestamps, not ISO strings

### DIFF
--- a/backend/scripts/migrate_conversation_timestamps.py
+++ b/backend/scripts/migrate_conversation_timestamps.py
@@ -1,0 +1,133 @@
+"""One-time migration: rewrite ISO-string conversation timestamps back to Firestore Timestamps.
+
+Between the deploy of PR #7101 and the fix in this PR, `process_conversation.py`
+wrote `created_at` / `started_at` / `finished_at` as ISO-8601 strings (via
+`Conversation.as_dict_cleaned_dates()`) instead of native Firestore Timestamps.
+A field that holds both strings and timestamps sorts strings above timestamps and
+is excluded from timestamp range queries, so affected conversations vanish from the
+default `created_at DESC` list and from date-range filters.
+
+This walks each user's conversations and converts any string-typed timestamp field
+back to a native datetime. Conversations written before the regression (and via merge)
+are already Timestamps and are left untouched.
+
+Scan strategy: Firestore's total type order places every string-typed value above
+every timestamp-typed value. Iterating a user's conversations by `created_at DESC`
+therefore yields the string cluster first, then the timestamp cluster — so once a
+native-datetime `created_at` is seen, the rest of that user are already correct and
+the scan can stop early. Pass `--full-scan` to disable the early stop.
+
+Usage:
+    python scripts/migrate_conversation_timestamps.py --dry-run --limit 50
+    python scripts/migrate_conversation_timestamps.py                 # full run
+    python scripts/migrate_conversation_timestamps.py --full-scan     # no early stop
+"""
+
+import argparse
+from datetime import datetime
+
+import firebase_admin
+from firebase_admin import firestore
+
+TIMESTAMP_FIELDS = ('created_at', 'started_at', 'finished_at')
+
+
+def parse_iso(value: str):
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return None
+
+
+def build_updates(data: dict) -> dict:
+    updates = {}
+    for field in TIMESTAMP_FIELDS:
+        value = data.get(field)
+        if isinstance(value, str):
+            parsed = parse_iso(value)
+            if parsed is not None:
+                updates[field] = parsed
+    return updates
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true', help='Only print what would change')
+    parser.add_argument('--limit', type=int, default=0, help='Max users to process (0 = all)')
+    parser.add_argument(
+        '--full-scan',
+        action='store_true',
+        help='Scan every conversation per user instead of stopping at the first native timestamp',
+    )
+    args = parser.parse_args()
+
+    if not firebase_admin._apps:
+        firebase_admin.initialize_app()
+    db = firestore.client()
+
+    page_size = 500
+    users_scanned = 0
+    convs_fixed = 0
+    users_with_fixes = 0
+    last_doc = None
+
+    while True:
+        if args.limit and users_scanned >= args.limit:
+            break
+        query = db.collection('users').order_by('__name__').limit(page_size)
+        if last_doc is not None:
+            query = query.start_after(last_doc)
+        batch = list(query.stream())
+        if not batch:
+            break
+
+        for user_snapshot in batch:
+            if args.limit and users_scanned >= args.limit:
+                break
+            users_scanned += 1
+            uid = user_snapshot.id
+
+            user_fixed = 0
+            try:
+                convs = (
+                    user_snapshot.reference.collection('conversations')
+                    .order_by('created_at', direction=firestore.Query.DESCENDING)
+                    .stream()
+                )
+                for conv in convs:
+                    data = conv.to_dict() or {}
+                    updates = build_updates(data)
+                    if not updates:
+                        if not args.full_scan and isinstance(data.get('created_at'), datetime):
+                            break
+                        continue
+                    if args.dry_run:
+                        print(f'DRY {uid}/{conv.id}: {sorted(updates.keys())}')
+                    else:
+                        conv.reference.update(updates)
+                    user_fixed += 1
+            except Exception as e:  # noqa: BLE001 — one user shouldn't abort the run
+                print(f'WARN conversations scan failed for {uid}: {e}')
+
+            if user_fixed:
+                users_with_fixes += 1
+                convs_fixed += user_fixed
+
+            if users_scanned % 1000 == 0:
+                print(
+                    f'users_scanned={users_scanned} users_with_fixes={users_with_fixes} convs_fixed={convs_fixed}',
+                    flush=True,
+                )
+
+        last_doc = batch[-1]
+        if len(batch) < page_size:
+            break
+
+    print(
+        f'Done. users_scanned={users_scanned} users_with_fixes={users_with_fixes} convs_fixed={convs_fixed}'
+        + (' (dry-run, no writes)' if args.dry_run else '')
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/tests/unit/test_conversation_redact_enrich.py
+++ b/backend/tests/unit/test_conversation_redact_enrich.py
@@ -351,3 +351,21 @@ class TestCallSitesMigrated:
             with open(path) as f:
                 content = f.read()
             assert '.as_dict_cleaned_dates()' not in content, f"{rel_path} still uses .as_dict_cleaned_dates()"
+
+    def test_conversation_upsert_uses_native_datetimes(self):
+        """Firestore writes must pass native datetimes so created_at/started_at/finished_at
+        are stored as Timestamps, not ISO strings (mixed types break sort + date filters)."""
+        import os
+
+        backend = os.path.join(os.path.dirname(__file__), '../..')
+        for rel_path in [
+            'utils/conversations/process_conversation.py',
+            'utils/conversations/postprocess_conversation.py',
+            'utils/conversations/merge_conversations.py',
+        ]:
+            path = os.path.join(backend, rel_path)
+            with open(path) as f:
+                content = f.read()
+            assert (
+                'upsert_conversation(uid, conversation.as_dict_cleaned_dates())' not in content
+            ), f"{rel_path} writes ISO strings to Firestore via as_dict_cleaned_dates()"

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -843,7 +843,7 @@ def process_conversation(
             logger.error(f"Error creating audio files: {e}")
 
     conversation.status = ConversationStatus.completed
-    conversations_db.upsert_conversation(uid, conversation.as_dict_cleaned_dates())
+    conversations_db.upsert_conversation(uid, conversation.dict())
 
     # Update folder conversation count after conversation is saved
     if assigned_folder_id:


### PR DESCRIPTION
Fixes #7579

## Problem

Since PR #7101 was deployed, every conversation finalized through `process_conversation.py` wrote `created_at` / `started_at` / `finished_at` to Firestore as **ISO-8601 strings** instead of native **Timestamps**. The culprit is a single line ([process_conversation.py:846](../blob/main/backend/utils/conversations/process_conversation.py#L846)):

```python
conversations_db.upsert_conversation(uid, conversation.as_dict_cleaned_dates())
```

`as_dict_cleaned_dates()` recursively converts **every** datetime in the dict to an ISO string. It was introduced to serialize a nested `CalendarEventLink` field, but applied as a blanket converter over the whole conversation — including the top-level timestamps that had always been stored as Timestamps.

Firestore's cross-type ordering places **strings above timestamps**, and timestamp range queries **exclude string-typed values**. So in a collection with both types:
- The default `created_at DESC` list returns the entire string cluster first — Timestamp-typed conversations get buried below pagination.
- Date-range filters (`created_at >= <datetime>`) silently exclude string-typed conversations entirely.

Result: the main list and the date filter return disjoint sets for any day containing both types — the reported symptom.

## Fix

1. **Revert to `conversation.dict()`** — matches every other `upsert_conversation` caller (`merge_conversations`, `transcribe`, `postprocess_conversation`, `imports/limitless`). Native datetimes serialize to Firestore Timestamps. `CalendarEventLink.start_time/end_time` are always proper `datetime`s, so they store correctly as Timestamps too — no separate serializer needed.

2. **One-time migration** (`backend/scripts/migrate_conversation_timestamps.py`) rewrites already-written ISO-string timestamps back to native Timestamps. Paginates users, scans each user's conversations by `created_at DESC`, and (since strings sort above timestamps) stops at the first native-timestamp conversation. Supports `--dry-run`, `--limit`, `--full-scan`.

3. **Guard test** asserting the storage callers don't reintroduce `as_dict_cleaned_dates()` on the Firestore write path.

## Sequencing

Deploy (1) before running (2) so the migration doesn't have a moving target.

## Testing

- `pytest tests/unit/test_conversation_redact_enrich.py` — guard tests pass.
- Migration `build_updates()` verified: ISO string → datetime, native datetime → no-op, unparseable string / `None` → skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)