### PR TITLE
docs(agents): reverts merge right away

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ These rules apply to every AI agent working in this repository. This file is the
 - Never push directly to `main`. Land changes through a PR only. Never squash-merge — use a regular merge.
 - Never push or create PRs unless explicitly asked — commit locally by default.
 - **Nothing lands on `main` until the user explicitly says so.** Do not commit, merge, push, or open a PR against `main` until the user gives an explicit go-ahead in that turn. Keep all work on feature branches; a prior approval never carries over to later changes.
+- **Exception — reverts merge right away.** When the user asks to revert a previously merged PR/commit, open the revert PR and merge it immediately without waiting for a separate merge go-ahead; the revert request itself is the approval.
 - **Prefer testing locally first.** The user prefers to build and run the app locally to verify a change works before it goes to a PR or merge. Default to a local named-bundle build + run for desktop changes (and the equivalent local run for other components) before proposing to land anything.
 
 ## Coding Guidelines


### PR DESCRIPTION
Adds an explicit exception to the "nothing lands on main until told" rule: a revert request is itself the approval, so revert PRs merge immediately.