### PR TITLE
fix conversation detail download audio Navigator null crash

### DIFF
--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -539,8 +539,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
 
         await Future.delayed(const Duration(milliseconds: 500));
 
-        if (mounted) {
-          Navigator.of(sheetContext).pop();
+        if (sheetContext.mounted) {
+          Navigator.maybeOf(sheetContext)?.pop();
         }
 
         await Share.shareXFiles([XFile(file.path, mimeType: 'audio/wav')]);
@@ -556,8 +556,8 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
 
         await service.cleanup();
       } else {
-        if (mounted) {
-          Navigator.of(sheetContext).pop();
+        if (sheetContext.mounted) {
+          Navigator.maybeOf(sheetContext)?.pop();
         }
 
         // Track failure (no audio available)
@@ -580,9 +580,10 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
 
       await Future.delayed(const Duration(seconds: 2));
 
-      if (mounted) {
-        Navigator.of(sheetContext).pop();
-
+      if (sheetContext.mounted) {
+        Navigator.maybeOf(sheetContext)?.pop();
+      }
+      if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(context.l10n.audioDownloadFailed),
@@ -739,7 +740,7 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                                         provider.conversation.id,
                                         newStarredState,
                                       );
-                                      if (!mounted) return;
+                                      if (!context.mounted) return;
                                       if (success) {
                                         provider.conversation.starred = newStarredState;
                                         // Update in conversation provider
@@ -2091,7 +2092,9 @@ class _ActionItemDetailWidgetState extends State<ActionItemDetailWidget> {
 
           if (!await _appReviewService.hasCompletedFirstActionItem()) {
             await _appReviewService.markFirstActionItemCompleted();
-            _appReviewService.showReviewPromptIfNeeded(context, isProcessingFirstConversation: false);
+            if (mounted) {
+              _appReviewService.showReviewPromptIfNeeded(context, isProcessingFirstConversation: false);
+            }
           }
         } else {
           PlatformManager.instance.analytics.uncheckedActionItem(provider.conversation, currentIndex);

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -1434,6 +1434,21 @@ class _GetDevToolsOptionsState extends State<GetDevToolsOptions> {
   }
 }
 
+_copyContent(BuildContext context, String content) {
+  Clipboard.setData(ClipboardData(text: content));
+  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.transcriptCopiedToClipboard)));
+  HapticFeedback.lightImpact();
+  Navigator.pop(context);
+}
+
+_getLoadingIndicator() {
+  return const SizedBox(
+    width: 24,
+    height: 24,
+    child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
+  );
+}
+
 class CalendarEventDetailsSheet extends StatefulWidget {
   final CalendarEventLink calendarEvent;
   final Future<void> Function()? onUnlink;

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -1434,21 +1434,6 @@ class _GetDevToolsOptionsState extends State<GetDevToolsOptions> {
   }
 }
 
-_copyContent(BuildContext context, String content) {
-  Clipboard.setData(ClipboardData(text: content));
-  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.transcriptCopiedToClipboard)));
-  HapticFeedback.lightImpact();
-  Navigator.pop(context);
-}
-
-_getLoadingIndicator() {
-  return const SizedBox(
-    width: 24,
-    height: 24,
-    child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
-  );
-}
-
 class CalendarEventDetailsSheet extends StatefulWidget {
   final CalendarEventLink calendarEvent;
   final Future<void> Function()? onUnlink;


### PR DESCRIPTION
## Crash

`_ConversationDetailPageState._downloadAudio`

**Error:** `FlutterError - Null check operator used on a null value`
`package:omi/pages/conversation_detail/page.dart:584`

**Crashlytics:** https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/9847dad06f42b3d650cb74fa0a169732?time=7d&types=crash&sessionEventKey=2b3db86de2c341d5814d995b3ce760c9_2223656953270793706

**Logs:**
```
Fatal Exception: FlutterError
0  ???  0x0 StatefulElement.state + 5840 (framework.dart:5840)
1  ???  0x0 Navigator.of + 2900 (navigator.dart:2900)
2  ???  0x0 _ConversationDetailPageState._downloadAudio + 584 (page.dart:584)
3  ???  0x0 _ConversationDetailPageState._handleMenuSelection + 341 (page.dart:341)
```

## Fix

**Primary crash:** `Navigator.of(sheetContext)` internally force-unwraps the navigator ancestor. If the page is popped during the long audio download (network + processing), the context is no longer in the tree and the unwrap crashes. Fixed by replacing all three `Navigator.of(sheetContext).pop()` calls with `Navigator.maybeOf(sheetContext)?.pop()`, which safely no-ops when the navigator is gone.

**Context guard fixes found alongside:**
- `if (mounted)` was guarding `sheetContext`-based Navigator pops — should be `sheetContext.mounted` since `mounted` (State) and the sheet's context are unrelated
- `ScaffoldMessenger.of(context)` in the catch block was guarded by State `mounted` — changed to `context.mounted` since `context` is the parameter `BuildContext`, not `this.context`
- Star toggle button: `if (!mounted) return` guarded `context.read<>()` and `ScaffoldMessenger.of(context)` — changed to `context.mounted` for the same reason
- `showReviewPromptIfNeeded(context, ...)` after two awaits in action item toggle had no mounted guard — added `if (mounted)` before the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)