### PR TITLE
chore remove unused _copyContent and _getLoadingIndicator from widgets.dart

### DIFF
--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -1434,21 +1434,6 @@ class _GetDevToolsOptionsState extends State<GetDevToolsOptions> {
   }
 }
 
-_copyContent(BuildContext context, String content) {
-  Clipboard.setData(ClipboardData(text: content));
-  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.transcriptCopiedToClipboard)));
-  HapticFeedback.lightImpact();
-  Navigator.pop(context);
-}
-
-_getLoadingIndicator() {
-  return const SizedBox(
-    width: 24,
-    height: 24,
-    child: CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
-  );
-}
-
 class CalendarEventDetailsSheet extends StatefulWidget {
   final CalendarEventLink calendarEvent;
   final Future<void> Function()? onUnlink;


### PR DESCRIPTION
## Summary
- Removes two dead top-level functions (`_copyContent`, `_getLoadingIndicator`) from `app/lib/pages/conversation_detail/widgets.dart` that were never referenced
- The real `_copyContent` lives in `page.dart` where it is actively used

## Test plan
- [ ] Build the app and verify `conversation_detail` page loads and copy/share actions still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)