### PR TITLE
chore(scripts): parallelize conversation-timestamp migration + add --uid

### DIFF
--- a/backend/scripts/migrate_conversation_timestamps.py
+++ b/backend/scripts/migrate_conversation_timestamps.py
@@ -1,6 +1,6 @@
 """One-time migration: rewrite ISO-string conversation timestamps back to Firestore Timestamps.
 
-Between the deploy of PR #7101 and the fix in this PR, `process_conversation.py`
+Between the deploy of PR #7101 (2026-05-26) and the fix in #7580, `process_conversation.py`
 wrote `created_at` / `started_at` / `finished_at` as ISO-8601 strings (via
 `Conversation.as_dict_cleaned_dates()`) instead of native Firestore Timestamps.
 A field that holds both strings and timestamps sorts strings above timestamps and
@@ -17,17 +17,23 @@ therefore yields the string cluster first, then the timestamp cluster — so onc
 native-datetime `created_at` is seen, the rest of that user are already correct and
 the scan can stop early. Pass `--full-scan` to disable the early stop.
 
-Usage:
-    python scripts/migrate_conversation_timestamps.py --dry-run --limit 50
-    python scripts/migrate_conversation_timestamps.py                 # full run
-    python scripts/migrate_conversation_timestamps.py --full-scan     # no early stop
+Usage (run as a module from backend/):
+    python -m scripts.migrate_conversation_timestamps --dry-run --uid <UID>   # one user, no writes
+    python -m scripts.migrate_conversation_timestamps --uid <UID>             # one user, apply
+    python -m scripts.migrate_conversation_timestamps --dry-run               # all users, no writes
+    python -m scripts.migrate_conversation_timestamps                         # full run
+    python -m scripts.migrate_conversation_timestamps --workers 20            # tune parallelism
+    python -m scripts.migrate_conversation_timestamps --full-scan             # no early stop
 """
 
 import argparse
+import sys
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
-import firebase_admin
-from firebase_admin import firestore
+from google.cloud import firestore
+
+from database._client import db, get_users_uid
 
 TIMESTAMP_FIELDS = ('created_at', 'started_at', 'finished_at')
 
@@ -50,9 +56,39 @@ def build_updates(data: dict) -> dict:
     return updates
 
 
+def process_user(uid: str, dry_run: bool, full_scan: bool) -> dict:
+    """Fix string-typed timestamps for one user's conversations."""
+    fixed = 0
+    try:
+        convs = (
+            db.collection('users')
+            .document(uid)
+            .collection('conversations')
+            .order_by('created_at', direction=firestore.Query.DESCENDING)
+            .stream()
+        )
+        for conv in convs:
+            data = conv.to_dict() or {}
+            updates = build_updates(data)
+            if not updates:
+                if not full_scan and isinstance(data.get('created_at'), datetime):
+                    break
+                continue
+            if dry_run:
+                print(f'DRY {uid}/{conv.id}: {sorted(updates.keys())}')
+            else:
+                conv.reference.update(updates)
+            fixed += 1
+        return {'uid': uid, 'fixed': fixed, 'status': 'ok'}
+    except Exception as e:  # noqa: BLE001 — one user shouldn't abort the run
+        return {'uid': uid, 'fixed': fixed, 'status': f'error: {e}'}
+
+
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description='Rewrite ISO-string conversation timestamps to Firestore Timestamps')
     parser.add_argument('--dry-run', action='store_true', help='Only print what would change')
+    parser.add_argument('--uid', help='Process a single user by uid instead of all users')
+    parser.add_argument('--workers', type=int, default=10, help='Number of parallel workers (default 10)')
     parser.add_argument('--limit', type=int, default=0, help='Max users to process (0 = all)')
     parser.add_argument(
         '--full-scan',
@@ -61,73 +97,38 @@ def main():
     )
     args = parser.parse_args()
 
-    if not firebase_admin._apps:
-        firebase_admin.initialize_app()
-    db = firestore.client()
+    print(f'Conversation timestamp migration — {"DRY RUN" if args.dry_run else "APPLY"}')
 
-    page_size = 500
-    users_scanned = 0
-    convs_fixed = 0
-    users_with_fixes = 0
-    last_doc = None
+    if args.uid:
+        uids = [args.uid]
+    else:
+        uids = get_users_uid()
+        if args.limit:
+            uids = uids[: args.limit]
+    print(f'Processing {len(uids)} user(s) with {args.workers} workers')
 
-    while True:
-        if args.limit and users_scanned >= args.limit:
-            break
-        query = db.collection('users').order_by('__name__').limit(page_size)
-        if last_doc is not None:
-            query = query.start_after(last_doc)
-        batch = list(query.stream())
-        if not batch:
-            break
+    results = []
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = [executor.submit(process_user, uid, args.dry_run, args.full_scan) for uid in uids]
+        for i, future in enumerate(futures):
+            results.append(future.result())
+            if (i + 1) % 1000 == 0:
+                done = sum(r['fixed'] for r in results)
+                print(f'  processed {i + 1}/{len(uids)} users, convs_fixed={done}...', flush=True)
 
-        for user_snapshot in batch:
-            if args.limit and users_scanned >= args.limit:
-                break
-            users_scanned += 1
-            uid = user_snapshot.id
+    convs_fixed = sum(r['fixed'] for r in results)
+    users_with_fixes = sum(1 for r in results if r['fixed'])
+    errors = [r for r in results if r['status'].startswith('error')]
 
-            user_fixed = 0
-            try:
-                convs = (
-                    user_snapshot.reference.collection('conversations')
-                    .order_by('created_at', direction=firestore.Query.DESCENDING)
-                    .stream()
-                )
-                for conv in convs:
-                    data = conv.to_dict() or {}
-                    updates = build_updates(data)
-                    if not updates:
-                        if not args.full_scan and isinstance(data.get('created_at'), datetime):
-                            break
-                        continue
-                    if args.dry_run:
-                        print(f'DRY {uid}/{conv.id}: {sorted(updates.keys())}')
-                    else:
-                        conv.reference.update(updates)
-                    user_fixed += 1
-            except Exception as e:  # noqa: BLE001 — one user shouldn't abort the run
-                print(f'WARN conversations scan failed for {uid}: {e}')
+    print('=' * 60)
+    print(f'users_scanned={len(results)} users_with_fixes={users_with_fixes} convs_fixed={convs_fixed}', end='')
+    print(' (dry-run, no writes)' if args.dry_run else '')
+    print(f'errors={len(errors)}')
+    for r in errors:
+        print(f'  {r["uid"]}: {r["status"]}')
 
-            if user_fixed:
-                users_with_fixes += 1
-                convs_fixed += user_fixed
-
-            if users_scanned % 1000 == 0:
-                print(
-                    f'users_scanned={users_scanned} users_with_fixes={users_with_fixes} convs_fixed={convs_fixed}',
-                    flush=True,
-                )
-
-        last_doc = batch[-1]
-        if len(batch) < page_size:
-            break
-
-    print(
-        f'Done. users_scanned={users_scanned} users_with_fixes={users_with_fixes} convs_fixed={convs_fixed}'
-        + (' (dry-run, no writes)' if args.dry_run else '')
-    )
+    return 1 if errors else 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #7580 (which fixed #7579). The one-time migration in `backend/scripts/migrate_conversation_timestamps.py` ran single-threaded, which is slow over the full `users` collection.

## Changes

- **Parallelism** — fetch all uids via `get_users_uid()` and process users concurrently with `ThreadPoolExecutor(max_workers=--workers)` (default 10), matching the existing pattern in `migrate_chat_usage.py`. The `google.cloud.firestore` client is thread-safe, so the shared `db` is used across workers.
- **`--uid`** — process a single user (used during verification of #7579).
- **Error isolation** — per-user errors are collected and printed in the summary instead of aborting the run.
- **Invocation** — now imports from `database._client`, so it runs as a module: `python -m scripts.migrate_conversation_timestamps`.

Unchanged: the DESC early-stop scan (with `--full-scan` to disable), `--dry-run`, `--limit`, and idempotency (already-Timestamp docs are skipped).

## Usage

```bash
# single user, no writes
python -m scripts.migrate_conversation_timestamps --dry-run --uid <UID>

# all users, dry run
python -m scripts.migrate_conversation_timestamps --dry-run

# apply, tuned parallelism
python -m scripts.migrate_conversation_timestamps --workers 20
```

## Testing

- `--help` and module import verified.
- Single-user dry-run parity confirmed against real data during #7579 verification (same affected docs as the single-threaded version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)