### PR TITLE
fix(desktop): debounce staged task promotion

### DIFF
--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
@@ -44,7 +44,7 @@ actor TaskPromotionService {
                 guard !Task.isCancelled else { break }
                 guard let self = self else { break }
                 log("TaskPromotion: Safety-net timer fired")
-                await self.promoteIfNeeded()
+                await self.promoteIfNeeded(bypassDebounce: true)
             }
         }
     }
@@ -56,13 +56,13 @@ actor TaskPromotionService {
     /// (either cap reached or no staged tasks available).
     /// Returns the list of promoted tasks so callers can insert them directly.
     @discardableResult
-    func promoteIfNeeded(shouldNotify: Bool = true) async -> [TaskActionItem] {
+    func promoteIfNeeded(shouldNotify: Bool = true, bypassDebounce: Bool = false) async -> [TaskActionItem] {
         guard !isPromoting else {
             log("TaskPromotion: Already promoting, skipping")
             return []
         }
         let secondsSinceLastPromotion = Date().timeIntervalSince(lastPromotedAt)
-        guard secondsSinceLastPromotion >= promotionDebounceInterval else {
+        guard bypassDebounce || secondsSinceLastPromotion >= promotionDebounceInterval else {
             log("TaskPromotion: Debounced — promoted \(Int(secondsSinceLastPromotion))s ago")
             return []
         }
@@ -82,6 +82,7 @@ actor TaskPromotionService {
                 let response = try await APIClient.shared.promoteTopStagedTask()
 
                 if response.promoted, let promotedTask = response.promotedTask {
+                    lastPromotedAt = Date()
                     promotedTasks.append(promotedTask)
                     log("TaskPromotion: Promoted task \(promotedTask.id) — \"\(promotedTask.description.prefix(60))\"")
 
@@ -126,7 +127,6 @@ actor TaskPromotionService {
         }
 
         if !promotedTasks.isEmpty {
-            lastPromotedAt = Date()
             let count = promotedTasks.count
             log("TaskPromotion: Promoted \(count) tasks total")
             await MainActor.run {

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
@@ -7,8 +7,10 @@ actor TaskPromotionService {
     static let shared = TaskPromotionService()
 
     private let targetCount = 5
+    private let promotionDebounceInterval: TimeInterval = 30
     private var safetyTimer: Task<Void, Never>?
     private var isPromoting = false
+    private var lastPromotedAt = Date.distantPast
 
     private init() {}
 
@@ -57,6 +59,11 @@ actor TaskPromotionService {
     func promoteIfNeeded(shouldNotify: Bool = true) async -> [TaskActionItem] {
         guard !isPromoting else {
             log("TaskPromotion: Already promoting, skipping")
+            return []
+        }
+        let secondsSinceLastPromotion = Date().timeIntervalSince(lastPromotedAt)
+        guard secondsSinceLastPromotion >= promotionDebounceInterval else {
+            log("TaskPromotion: Debounced — promoted \(Int(secondsSinceLastPromotion))s ago")
             return []
         }
         isPromoting = true
@@ -119,6 +126,7 @@ actor TaskPromotionService {
         }
 
         if !promotedTasks.isEmpty {
+            lastPromotedAt = Date()
             let count = promotedTasks.count
             log("TaskPromotion: Promoted \(count) tasks total")
             await MainActor.run {


### PR DESCRIPTION
## Summary

- Add a 30-second successful-promotion debounce inside `TaskPromotionService.promoteIfNeeded()`
- Collapse rapid staged-task promotion bursts from save/complete/delete/startup/timer call sites into one backend promotion window
- Keep startup and no-op checks from delaying the first real staged task promotion by only starting the cooldown after a task is actually promoted

Closes #7439
Closes #7441

## Why

The desktop app currently calls `promoteIfNeeded()` from five places:

- app startup
- the 60s safety timer
- after saving a staged task
- after completing a screenshot-sourced task
- after deleting a screenshot-sourced task

The actor already prevents overlapping calls with `isPromoting`, but it does not debounce sequential calls. If several triggers fire a few seconds apart, each one still reaches `POST /v1/staged-tasks/promote`, which contributes to the Firestore write spike described in #7439/#7441.

## Implementation details

- Adds `promotionDebounceInterval = 30` seconds
- Tracks `lastPromotedAt` inside the actor, so no extra locking is needed
- Skips only calls that happen within 30s after a successful promotion
- Does not update the cooldown when the backend returns no promoted task or when the API call fails

That last point matters: if there is no staged task at startup, the first later real staged task promotion is not blocked by a stale no-op cooldown.

## Relation to existing work

This is complementary to backend dedup/idempotency work like #7092/#7093. Those PRs reduce duplicate task creation. This PR reduces the desktop call frequency that was causing promote endpoint write amplification.

## Verification

- `xcrun swift build -c debug --package-path Desktop`