### PR TITLE
fix(desktop): clean up lingering menu popup windows

### DIFF
--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -1098,11 +1098,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
   func menuDidClose(_ menu: NSMenu) {
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-      for window in NSApp.windows where window.title.hasPrefix("Item-") && window.isVisible {
+      for window in NSApp.windows where self.isMenuPopupWindow(window) && window.isVisible {
         log("AppDelegate: [MENUBAR] Cleaning up lingering menu popup window: \(window.frame)")
         window.orderOut(nil)
       }
     }
+  }
+
+  private func isMenuPopupWindow(_ window: NSWindow) -> Bool {
+    // AppKit menu popup windows use private classes/titles like "NSPopupMenuWindow" and "Item-0".
+    window.title.hasPrefix("Item-") && window.className.contains("PopupMenuWindow")
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -1096,6 +1096,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       (!paywalled && AssistantSettings.shared.transcriptionEnabled) ? .on : .off
   }
 
+  func menuDidClose(_ menu: NSMenu) {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      for window in NSApp.windows where window.title.hasPrefix("Item-") && window.isVisible {
+        log("AppDelegate: [MENUBAR] Cleaning up lingering menu popup window: \(window.frame)")
+        window.orderOut(nil)
+      }
+    }
+  }
+
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     let shouldTerminate = !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
     if shouldTerminate {


### PR DESCRIPTION
## Summary

- Add an `NSMenuDelegate.menuDidClose(_:)` cleanup pass for status-bar menu popup windows
- After the menu closes, order out any visible macOS menu popup windows titled `Item-*`
- Fix transparent menu windows that can remain above other apps and block clicks on external displays

Closes #7516

## Why

Issue #7516 reports a transparent Omi-owned popup-layer window left behind after dismissing the macOS status-bar menu on an external display. The window is invisible but still intercepts clicks in a rectangular area under the menu-bar icon.

Omi already filters these menu popup windows in `revealMainWindowIfAvailable()` by checking `window.title.hasPrefix("Item-")`, but there was no matching close-time cleanup.

## Implementation details

- Implements `menuDidClose(_:)` in the existing `AppDelegate: NSMenuDelegate`
- Waits 0.1s before cleanup so AppKit has a chance to remove its own menu window first
- Targets only visible `NSApp.windows` whose title starts with `Item-`
- Uses `orderOut(nil)` instead of closing unrelated app windows

The fix is intentionally narrow: it only touches AppKit menu popup windows created for the status-bar menu and leaves the main app, floating bar, and agent windows alone.

## Verification

- `xcrun swift build -c debug --package-path Desktop`