### PR TITLE
fix(sync): don't mark queued jobs as failed in stale guard (#7469)

### DIFF
--- a/backend/database/sync_jobs.py
+++ b/backend/database/sync_jobs.py
@@ -70,14 +70,15 @@ def get_sync_job(job_id: str) -> Optional[dict]:
         return None
     job = json.loads(data)
 
-    # Stale-job detection: if processing for too long, mark failed
-    if job['status'] in ('queued', 'processing'):
+    # Stale-job detection: if processing for too long, mark failed.
+    # Only applies to 'processing' jobs where a worker actually died.
+    # 'queued' jobs are still waiting for capacity — not a failure.
+    if job['status'] == 'processing':
         updated_at = job.get('updated_at') or job.get('created_at', 0)
         if time.time() - updated_at > STALE_THRESHOLD_SECONDS:
             job['status'] = 'failed'
             job['error'] = 'Job timed out (background worker likely died)'
             job['completed_at'] = time.time()
-            # Persist the failure status
             r.set(key, json.dumps(job, default=str), ex=JOB_TTL_SECONDS)
 
     return job

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -316,6 +316,22 @@ class TestSyncJobsRedis:
         assert result['status'] == 'failed'
         assert 'timed out' in result['error']
 
+    def test_get_sync_job_does_not_mark_stale_queued_as_failed(self):
+        """Queued jobs waiting for capacity must NOT be marked as failed."""
+        mod, mock_redis = self._load_sync_jobs_module()
+        stale_queued = {
+            'job_id': 'sq-1',
+            'uid': 'uid',
+            'status': 'queued',
+            'updated_at': time.time() - 700,
+            'created_at': time.time() - 800,
+        }
+        mock_redis.get.return_value = json.dumps(stale_queued).encode()
+
+        result = mod.get_sync_job('sq-1')
+        assert result['status'] == 'queued'
+        assert result.get('error') is None
+
     def test_get_sync_job_does_not_mark_fresh_as_stale(self):
         """Processing jobs within threshold should not be marked failed."""
         mod, mock_redis = self._load_sync_jobs_module()


### PR DESCRIPTION
## Problem

`database/sync_jobs.py:get_sync_job()` treats `queued` and `processing` identically in the stale guard — after 10 minutes both get marked as `failed` with `"Job timed out (background worker likely died)"`.

This is wrong for `queued` jobs: they were **never picked up** by a worker because pools were saturated. No worker died — none was available. Users see "Couldn't process — retrying" and burn retry budgets for what is fundamentally a capacity issue, not a content failure.

## Fix

One-line change: the stale guard now only applies to `status == 'processing'` (where a worker actually died mid-pipeline). `queued` jobs remain queued and naturally expire via the 24h Redis TTL.

```python
# Before
if job['status'] in ('queued', 'processing'):

# After  
if job['status'] == 'processing':
```

## Why this is correct

- Jobs start as `queued` → acquire semaphore → transition to `processing` (via `mark_job_processing()`)
- A `queued` job simply has not acquired a semaphore slot yet. Under load (pools at 100% utilization, semaphore at 16 concurrent), a job can sit `queued` for well over 10 minutes
- The client-side workaround in #7451 already pattern-matches the error string — the right fix is on the backend

## Test coverage

- Existing test `test_get_sync_job_detects_stale` validates `processing` jobs are still correctly failed (unchanged)
- New test `test_get_sync_job_does_not_mark_stale_queued_as_failed` validates `queued` jobs are NOT flipped to failed

## Evidence from production

```
12:09:43  job ceee6bb3 → "queued", 0/0 segments
12:20:22  REVERT job 64457303 → "failed", error="Job timed out (background worker likely died)"

executor_pool_health:
  storage: 96/96 workers, 29 deep queue, 100% utilization
  postprocess: 24/24 workers, 80 deep queue, 100% utilization
```

Closes #7469