### PR TITLE
feat: realtime omni voice (Gemini 3.1 Flash Live + GPT Realtime 2) for desktop PTT

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,8 @@ from routers import (
     chat,
     firmware,
     transcribe,
+    omni_relay,
+    auto_model,
     notifications,
     speech_profile,
     agents,
@@ -89,6 +91,8 @@ MultiPartParser.max_part_size = 200 * 1024 * 1024  # 200 MB
 app = FastAPI()
 
 app.include_router(transcribe.router)
+app.include_router(omni_relay.router)
+app.include_router(auto_model.router)
 app.include_router(conversations.router)
 app.include_router(action_items.router)
 app.include_router(task_integrations.router)

--- a/backend/routers/auto_model.py
+++ b/backend/routers/auto_model.py
@@ -1,9 +1,12 @@
+import asyncio
 import logging
 import os
 import time
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from utils.other.endpoints import get_current_user_uid
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -30,6 +33,7 @@ TTL_SECONDS = 24 * 3600
 AA_URL = "https://artificialanalysis.ai/api/v2/data/llms/models"
 
 _cache = {"provider": None, "ts": 0.0, "detail": {}}
+_cache_lock = asyncio.Lock()
 
 
 def _score(quality, speed):
@@ -73,17 +77,21 @@ async def _fetch_and_score():
 
 
 @router.get("/v1/auto/model-pick")
-async def auto_model_pick():
+async def auto_model_pick(uid: str = Depends(get_current_user_uid)):
     """Current best realtime-voice provider for 'Auto' users (daily-cached)."""
     now = time.time()
     if _cache["provider"] is None or (now - _cache["ts"]) > TTL_SECONDS:
-        try:
-            provider, detail = await _fetch_and_score()
-            _cache.update(provider=provider, ts=now, detail=detail)
-        except Exception as e:
-            logger.error(f"auto model-pick fetch failed: {e}")
-            if _cache["provider"] is None:
-                _cache.update(provider="geminiFlashLive", ts=now, detail={"reason": f"error: {e}"})
+        # Serialize concurrent refreshes so a cache miss fires only one AA fetch.
+        async with _cache_lock:
+            now = time.time()  # re-check after acquiring the lock
+            if _cache["provider"] is None or (now - _cache["ts"]) > TTL_SECONDS:
+                try:
+                    provider, detail = await _fetch_and_score()
+                    _cache.update(provider=provider, ts=now, detail=detail)
+                except Exception as e:
+                    logger.error(f"auto model-pick fetch failed: {e}")
+                    if _cache["provider"] is None:
+                        _cache.update(provider="geminiFlashLive", ts=now, detail={"reason": f"error: {e}"})
     return {
         "provider": _cache["provider"],
         "updated_at": _cache["ts"],

--- a/backend/routers/auto_model.py
+++ b/backend/routers/auto_model.py
@@ -1,0 +1,92 @@
+import logging
+import os
+import time
+
+import httpx
+from fastapi import APIRouter
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# "Auto" realtime-voice model selection.
+#
+# Picks the realtime provider whose underlying model scores best on a simple
+# quality/speed formula, refreshed once a day from Artificial Analysis
+# (https://artificialanalysis.ai — attribution required). Done server-side so the
+# AA key never ships in the client and the response is cached (per AA's terms).
+# All desktop clients on "Auto" read the same pick from /v1/auto/model-pick.
+
+# Desktop provider id -> AA model slug substring used as the quality/speed proxy
+# (the realtime audio variants aren't in AA's LLM index, so we use the closest
+# representative model).
+PROXY = {
+    "geminiFlashLive": "gemini-3-1-flash",
+    "gptRealtime2": "gpt-realtime",
+}
+QUALITY_WEIGHT = 0.65
+SPEED_WEIGHT = 0.35
+SPEED_CAP = 250.0  # tokens/sec, for normalization
+TTL_SECONDS = 24 * 3600
+AA_URL = "https://artificialanalysis.ai/api/v2/data/llms/models"
+
+_cache = {"provider": None, "ts": 0.0, "detail": {}}
+
+
+def _score(quality, speed):
+    q = min(max(quality, 0.0), 100.0) / 100.0
+    s = min(max(speed, 0.0), SPEED_CAP) / SPEED_CAP
+    return QUALITY_WEIGHT * q + SPEED_WEIGHT * s
+
+
+async def _fetch_and_score():
+    key = os.getenv("ARTIFICIALANALYSIS_API_KEY")
+    if not key:
+        return "geminiFlashLive", {"reason": "no ARTIFICIALANALYSIS_API_KEY; default to Gemini"}
+
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        resp = await client.get(AA_URL, headers={"x-api-key": key})
+        resp.raise_for_status()
+        models = resp.json().get("data", [])
+
+    def best_score(substr):
+        best = None
+        for m in models:
+            slug = (m.get("slug") or m.get("id") or m.get("name") or "").lower()
+            if substr not in slug:
+                continue
+            evals = m.get("evaluations") or {}
+            quality = evals.get("artificial_analysis_intelligence_index")
+            speed = m.get("median_output_tokens_per_second")
+            if quality is None or speed is None:
+                continue
+            sc = _score(quality, speed)
+            if best is None or sc > best:
+                best = sc
+        return best
+
+    scores = {p: best_score(sub) for p, sub in PROXY.items()}
+    scores = {p: round(s, 4) for p, s in scores.items() if s is not None}
+    if not scores:
+        return "geminiFlashLive", {"reason": "no matching AA models", "scores": {}}
+    pick = max(scores, key=scores.get)
+    return pick, {"scores": scores}
+
+
+@router.get("/v1/auto/model-pick")
+async def auto_model_pick():
+    """Current best realtime-voice provider for 'Auto' users (daily-cached)."""
+    now = time.time()
+    if _cache["provider"] is None or (now - _cache["ts"]) > TTL_SECONDS:
+        try:
+            provider, detail = await _fetch_and_score()
+            _cache.update(provider=provider, ts=now, detail=detail)
+        except Exception as e:
+            logger.error(f"auto model-pick fetch failed: {e}")
+            if _cache["provider"] is None:
+                _cache.update(provider="geminiFlashLive", ts=now, detail={"reason": f"error: {e}"})
+    return {
+        "provider": _cache["provider"],
+        "updated_at": _cache["ts"],
+        "detail": _cache["detail"],
+        "attribution": "https://artificialanalysis.ai/",
+    }

--- a/backend/routers/auto_model.py
+++ b/backend/routers/auto_model.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 # (the realtime audio variants aren't in AA's LLM index, so we use the closest
 # representative model).
 PROXY = {
-    "geminiFlashLive": "gemini-3-1-flash",
-    "gptRealtime2": "gpt-realtime",
+    "geminiFlashLive": "gemini-3-5-flash",
+    "gptRealtime2": "gpt-5",
 }
 QUALITY_WEIGHT = 0.65
 SPEED_WEIGHT = 0.35

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from urllib.parse import quote
 
 import websockets
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -41,7 +42,8 @@ def _upstream(provider: str, model: str | None):
         key = os.getenv("OPENAI_API_KEY")
         if not key:
             return None, "OPENAI_API_KEY not configured"
-        url = OPENAI_URL.format(model=model or "gpt-realtime-2")
+        # URL-encode the client-supplied model so it can't inject extra query params.
+        url = OPENAI_URL.format(model=quote(model or "gpt-realtime-2", safe=""))
         return (url, {"Authorization": f"Bearer {key}"}), None
     return None, f"unsupported provider: {provider}"
 

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -1,0 +1,98 @@
+import asyncio
+import logging
+import os
+
+import websockets
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+
+from utils.other.endpoints import get_current_user_uid_ws_listen
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Realtime "omni" relay.
+#
+# The desktop floating bar connects here (authenticated, like /v4/listen) and we
+# pipe every frame, verbatim, to the chosen provider's realtime WebSocket. This
+# exists because:
+#   1) Apple's WebSocket stacks (URLSessionWebSocketTask / Network.framework)
+#      cannot hold a direct connection to Gemini's Live endpoint (Google's
+#      frontend resets them); a server-side `websockets` client connects fine.
+#   2) Provider API keys stay server-side instead of shipping in the client.
+#
+# Protocol is provider-native and opaque to the relay — the desktop speaks raw
+# OpenAI Realtime / Gemini Live JSON; we just forward bytes both ways.
+
+GEMINI_URL = (
+    "wss://generativelanguage.googleapis.com/ws/"
+    "google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key={key}"
+)
+OPENAI_URL = "wss://api.openai.com/v1/realtime?model={model}"
+
+
+def _upstream(provider: str, model: str | None):
+    """Return (url, headers) for the chosen provider, or (None, reason)."""
+    if provider == "gemini":
+        key = os.getenv("GEMINI_API_KEY")
+        if not key:
+            return None, "GEMINI_API_KEY not configured"
+        return (GEMINI_URL.format(key=key), {}), None
+    if provider == "openai":
+        key = os.getenv("OPENAI_API_KEY")
+        if not key:
+            return None, "OPENAI_API_KEY not configured"
+        url = OPENAI_URL.format(model=model or "gpt-realtime-2")
+        return (url, {"Authorization": f"Bearer {key}"}), None
+    return None, f"unsupported provider: {provider}"
+
+
+@router.websocket("/v1/omni/relay")
+async def omni_relay(websocket: WebSocket, uid: str = Depends(get_current_user_uid_ws_listen)):
+    provider = websocket.query_params.get("provider", "gemini")
+    model = websocket.query_params.get("model")
+    upstream_cfg, err = _upstream(provider, model)
+    if err:
+        await websocket.close(code=1011, reason=err)
+        return
+    url, headers = upstream_cfg
+
+    await websocket.accept()
+    try:
+        async with websockets.connect(
+            url, extra_headers=headers or None, max_size=None, ping_interval=20, ping_timeout=20
+        ) as upstream:
+
+            async def client_to_upstream():
+                while True:
+                    msg = await websocket.receive()
+                    if msg.get("type") == "websocket.disconnect":
+                        return
+                    if (text := msg.get("text")) is not None:
+                        await upstream.send(text)
+                    elif (data := msg.get("bytes")) is not None:
+                        await upstream.send(data)
+
+            async def upstream_to_client():
+                async for message in upstream:
+                    if isinstance(message, (bytes, bytearray)):
+                        await websocket.send_bytes(message)
+                    else:
+                        await websocket.send_text(message)
+
+            t1 = asyncio.create_task(client_to_upstream(), name=f"ws:{uid}:omni_c2u")
+            t2 = asyncio.create_task(upstream_to_client(), name=f"ws:{uid}:omni_u2c")
+            done, pending = await asyncio.wait({t1, t2}, return_when=asyncio.FIRST_COMPLETED)
+            for t in pending:
+                t.cancel()
+            for t in done:
+                if t.exception():
+                    logger.warning(f"omni relay task ended: {t.exception()}")
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        logger.error(f"omni relay error (uid={uid}, provider={provider}): {e}")
+    finally:
+        try:
+            await websocket.close()
+        except Exception:
+            pass

--- a/desktop/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/Desktop/Sources/DesktopAutomationBridge.swift
@@ -208,6 +208,32 @@ final class DesktopAutomationActionRegistry {
         name: .toggleTranscriptionRequested, object: nil, userInfo: ["enabled": enabled])
       return ["enabled": enabled ? "true" : "false"]
     }
+
+    // Fake-voice end-to-end test: inject a raw PCM16/16kHz-mono file through the
+    // real realtime omni STT path and return the transcript. No mic, no human.
+    register(
+      name: "omni_test_turn",
+      summary: "Inject a raw PCM16/16kHz mono file through the omni STT path; returns the transcript",
+      params: ["pcm", "timeout", "provider"]
+    ) { params in
+      guard let path = params["pcm"],
+            let data = try? Data(contentsOf: URL(fileURLWithPath: path)), !data.isEmpty else {
+        return ["error": "missing or unreadable 'pcm' file (expected raw s16le 16k mono)"]
+      }
+      let provider = params["provider"].flatMap(RealtimeOmniProvider.init(rawValue:))
+        ?? RealtimeOmniSettings.shared.effectiveProvider
+      let base = DesktopBackendEnvironment.pythonBaseURL()
+      let authHeader: String
+      do {
+        authHeader = try await AuthService.shared.getAuthHeader()
+      } catch {
+        return ["error": "auth failed: \(error.localizedDescription)"]
+      }
+      let timeout = Double(params["timeout"] ?? "") ?? 20
+      let harness = RealtimeOmniTestHarness(
+        provider: provider, relayBaseURL: base, authHeader: authHeader, pcm16k: data)
+      return await harness.run(timeoutSeconds: timeout)
+    }
   }
 }
 

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -45,6 +45,9 @@ class PushToTalkManager: ObservableObject {
   // Mic chunks captured before the relay finishes connecting (raw 16k PCM),
   // flushed once the service exists so the user's first words aren't clipped.
   private var omniPreconnectBuffer: [Data] = []
+  // True once the omni model returned any transcript this turn — gates the
+  // Deepgram fallback so a benign trailing socket error doesn't trigger it.
+  private var omniReceivedTranscript = false
   private var audioCaptureService: AudioCaptureService?
   private var transcriptSegments: [String] = []
   private var lastInterimText: String = ""
@@ -612,6 +615,10 @@ class PushToTalkManager: ObservableObject {
               } else {
                 self.omniPreconnectBuffer.append(audioData)
               }
+              // Also retain the raw turn for a Deepgram fallback if omni fails.
+              self.batchAudioLock.lock()
+              self.batchAudioBuffer.append(audioData)
+              self.batchAudioLock.unlock()
             } else if batchMode {
               // Batch mode: accumulate audio in buffer
               self.batchAudioLock.lock()
@@ -719,7 +726,11 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
   fileprivate func startOmniTranscription() -> Bool {
     let provider = RealtimeOmniSettings.shared.effectiveProvider
     isOmniSTT = true
+    omniReceivedTranscript = false
     omniPreconnectBuffer.removeAll()
+    // Keep a copy of the whole turn so we can fall back to Deepgram if the relay
+    // is unreachable (e.g. backend not yet on prod) — PTT must never break.
+    batchAudioLock.lock(); batchAudioBuffer = Data(); batchAudioLock.unlock()
     startMicCapture()  // capture immediately; chunks buffer until the relay connects
     Task { @MainActor [weak self] in
       guard let self, self.isOmniSTT else { return }
@@ -788,6 +799,7 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
   func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool) {
     guard state == .listening || state == .lockedListening
             || state == .pendingLockDecision || state == .finalizing else { return }
+    if !text.isEmpty { omniReceivedTranscript = true }
     if isFinal {
       let finalText = text.isEmpty ? lastInterimText : text
       let trimmed = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -821,6 +833,41 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
 
   func omniDidError(_ message: String) {
     logError("PushToTalkManager: omni STT error: \(message)")
-    stopListening()
+    // If the omni model already gave us a transcript this turn, the error is a
+    // benign teardown — ignore it. Otherwise the relay is unreachable (e.g. the
+    // backend isn't on prod yet): fall back to Deepgram so PTT never breaks.
+    guard !omniReceivedTranscript,
+          state == .listening || state == .lockedListening
+            || state == .pendingLockDecision || state == .finalizing
+    else { return }
+    fallBackToDeepgram()
+  }
+
+  /// Transcribe the buffered turn audio via Deepgram when omni is unavailable.
+  fileprivate func fallBackToDeepgram() {
+    log("PushToTalkManager: omni unavailable — falling back to Deepgram for this turn")
+    isOmniSTT = false
+    realtimeOmniService?.stop()
+    realtimeOmniService = nil
+    batchAudioLock.lock()
+    let audio = batchAudioBuffer
+    batchAudioLock.unlock()
+    guard !audio.isEmpty else { sendTranscript(); return }
+    barState?.voiceTranscript = "Transcribing…"
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      do {
+        let language = AssistantSettings.shared.effectiveTranscriptionLanguage
+        let transcript = try await TranscriptionService.batchTranscribe(
+          audioData: audio, language: language,
+          contextKeywords: self.currentContextSnapshot?.keywords ?? [])
+        if let transcript, !transcript.isEmpty { self.transcriptSegments = [transcript] }
+      } catch {
+        logError("PushToTalkManager: Deepgram fallback failed", error: error)
+      }
+      self.liveFinalizationTimeout?.cancel()
+      self.liveFinalizationTimeout = nil
+      self.sendTranscript()
+    }
   }
 }

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -39,6 +39,12 @@ class PushToTalkManager: ObservableObject {
 
   // Transcription
   private var transcriptionService: TranscriptionService?
+  // Realtime omni STT (replaces Deepgram). Connects through the omi backend relay.
+  private var realtimeOmniService: RealtimeOmniService?
+  private var isOmniSTT = false
+  // Mic chunks captured before the relay finishes connecting (raw 16k PCM),
+  // flushed once the service exists so the user's first words aren't clipped.
+  private var omniPreconnectBuffer: [Data] = []
   private var audioCaptureService: AudioCaptureService?
   private var transcriptSegments: [String] = []
   private var lastInterimText: String = ""
@@ -335,6 +341,25 @@ class PushToTalkManager: ObservableObject {
       sound?.play()
     }
 
+    // Realtime omni: commit the turn and wait for the final transcript.
+    if isOmniSTT {
+      realtimeOmniService?.commitInputTurn()
+      log("PushToTalkManager: finalizing (omni STT) — waiting for final transcript")
+      let timeout = DispatchWorkItem { [weak self] in
+        Task { @MainActor in
+          guard let self, self.state == .finalizing else { return }
+          log("PushToTalkManager: omni finalization timeout — sending transcript")
+          self.sendTranscript()
+        }
+      }
+      liveFinalizationTimeout = timeout
+      // Safety net only — the real send happens the instant the omni model
+      // returns its final transcript (omniDidReceiveInputTranscript isFinal /
+      // omniDidFinishTurn). Generous so the relay round-trip can complete.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 8.0, execute: timeout)
+      return
+    }
+
     let isBatchMode = ShortcutSettings.shared.pttTranscriptionMode == .batch
 
     if isBatchMode {
@@ -501,6 +526,12 @@ class PushToTalkManager: ObservableObject {
       return
     }
 
+    // The floating bar's STT is the realtime omni model (replaces Deepgram):
+    // one omni model transcribes; reasoning/tools/TTS are untouched (the final
+    // transcript still goes to ChatProvider via sendTranscript()/sendQuery()).
+    // Falls back to legacy Deepgram STT only if no provider key is available.
+    if startOmniTranscription() { return }
+
     let isBatchMode = ShortcutSettings.shared.pttTranscriptionMode == .batch
 
     if isBatchMode {
@@ -573,7 +604,15 @@ class PushToTalkManager: ObservableObject {
         try await capture.startCapture(
           onAudioChunk: { [weak self] audioData in
             guard let self else { return }
-            if batchMode {
+            if self.isOmniSTT {
+              // Realtime omni: stream mic PCM (resampled to the provider's rate),
+              // or buffer raw until the relay finishes connecting.
+              if let svc = self.realtimeOmniService {
+                svc.sendAudio(self.resampleForOmni(audioData))
+              } else {
+                self.omniPreconnectBuffer.append(audioData)
+              }
+            } else if batchMode {
               // Batch mode: accumulate audio in buffer
               self.batchAudioLock.lock()
               self.batchAudioBuffer.append(audioData)
@@ -614,6 +653,10 @@ class PushToTalkManager: ObservableObject {
     audioCaptureService?.stopCapture()
     transcriptionService?.stop()
     transcriptionService = nil
+    realtimeOmniService?.stop()
+    realtimeOmniService = nil
+    isOmniSTT = false
+    omniPreconnectBuffer.removeAll()
   }
 
   private func handleTranscriptSegments(_ segments: [TranscriptionService.BackendSegment]) {
@@ -659,5 +702,125 @@ class PushToTalkManager: ObservableObject {
     } else if !barState.isVoiceListening && wasListening {
       FloatingControlBarManager.shared.resizeForPTT(expanded: false)
     }
+  }
+}
+
+// MARK: - Realtime Omni STT integration
+//
+// When "Realtime Voice" is enabled, one omni model (Gemini 3.1 Flash Live or
+// GPT Realtime 2) transcribes the PTT turn instead of Deepgram. The final
+// transcript flows through the unchanged sendTranscript() → ChatProvider path,
+// so agents, tools, memory, vision, and the text input all keep working.
+extension PushToTalkManager: RealtimeOmniServiceDelegate {
+
+  /// Starts realtime omni STT via the omi backend relay. Always returns true
+  /// (omni is the floating bar's STT); on auth failure it stops the turn.
+  @discardableResult
+  fileprivate func startOmniTranscription() -> Bool {
+    let provider = RealtimeOmniSettings.shared.effectiveProvider
+    isOmniSTT = true
+    omniPreconnectBuffer.removeAll()
+    startMicCapture()  // capture immediately; chunks buffer until the relay connects
+    Task { @MainActor [weak self] in
+      guard let self, self.isOmniSTT else { return }
+      do {
+        let authHeader = try await AuthService.shared.getAuthHeader()
+        let base = DesktopBackendEnvironment.pythonBaseURL()
+        let service = RealtimeOmniService(
+          provider: provider, relayBaseURL: base, authHeader: authHeader, sttOnly: true, delegate: self)
+        self.realtimeOmniService = service
+        // Flush anything captured while we were fetching auth.
+        for raw in self.omniPreconnectBuffer { service.sendAudio(self.resampleForOmni(raw)) }
+        self.omniPreconnectBuffer.removeAll()
+        service.start()
+        log("PushToTalkManager: started omni STT (\(provider.displayName)) via backend relay")
+      } catch {
+        logError("PushToTalkManager: omni auth failed", error: error)
+        self.stopListening()
+      }
+    }
+    return true
+  }
+
+  // Phase 1 key resolution: env (dev) → TODO BYOK / backend-minted token.
+  fileprivate func resolveOmniKey(for provider: RealtimeOmniProvider) -> String? {
+    let env = ProcessInfo.processInfo.environment
+    let raw: String?
+    switch provider {
+    case .gptRealtime2: raw = env["OPENAI_API_KEY"]
+    case .geminiFlashLive, .auto: raw = env["GEMINI_API_KEY"] ?? env["GOOGLE_API_KEY"]
+    }
+    guard let raw, !raw.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+    return raw
+  }
+
+  // Mic is 16kHz PCM16; OpenAI realtime requires ≥24kHz, Gemini wants 16kHz.
+  fileprivate func resampleForOmni(_ pcm16k: Data) -> Data {
+    guard let target = realtimeOmniService?.requiredInputSampleRate, target != 16000 else { return pcm16k }
+    return Self.resamplePCM16(pcm16k, from: 16000, to: target)
+  }
+
+  static func resamplePCM16(_ data: Data, from src: Int, to dst: Int) -> Data {
+    let count = data.count / 2
+    guard count > 1, src != dst else { return data }
+    var input = [Int16](repeating: 0, count: count)
+    _ = input.withUnsafeMutableBytes { data.copyBytes(to: $0, count: count * 2) }
+    let ratio = Double(src) / Double(dst)
+    let outCount = max(1, Int(Double(count) / ratio))
+    var out = [Int16](repeating: 0, count: outCount)
+    for i in 0..<outCount {
+      let pos = Double(i) * ratio
+      let i0 = Int(pos)
+      let i1 = Swift.min(i0 + 1, count - 1)
+      let frac = pos - Double(i0)
+      let s = Double(input[i0]) * (1 - frac) + Double(input[i1]) * frac
+      out[i] = Int16(Swift.max(-32768, Swift.min(32767, s)))
+    }
+    return out.withUnsafeBytes { Data($0) }
+  }
+
+  // MARK: RealtimeOmniServiceDelegate
+
+  func omniDidConnect() {
+    log("PushToTalkManager: omni STT connected")
+  }
+
+  func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool) {
+    guard state == .listening || state == .lockedListening
+            || state == .pendingLockDecision || state == .finalizing else { return }
+    if isFinal {
+      let finalText = text.isEmpty ? lastInterimText : text
+      let trimmed = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !trimmed.isEmpty && !transcriptSegments.contains(trimmed) {
+        transcriptSegments.append(trimmed)
+      }
+      lastInterimText = ""
+      if state == .finalizing {
+        liveFinalizationTimeout?.cancel()
+        liveFinalizationTimeout = nil
+        sendTranscript()
+      }
+    } else {
+      lastInterimText += text
+      barState?.voiceTranscript = lastInterimText
+    }
+  }
+
+  func omniDidReceiveAudio(_ pcm24k: Data) {
+    // STT-only: the omni model's own voice is unused; Claude's reply is spoken
+    // by the existing FloatingBarVoicePlaybackService.
+  }
+
+  func omniDidFinishTurn() {
+    if state == .finalizing {
+      liveFinalizationTimeout?.cancel()
+      liveFinalizationTimeout = nil
+      sendTranscript()
+    }
+  }
+
+  func omniDidError(_ message: String) {
+    logError("PushToTalkManager: omni STT error: \(message)")
+    stopListening()
   }
 }

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -270,6 +270,7 @@ struct SettingsContentView: View {
 
   // AI Chat settings
   @AppStorage("chatBridgeMode") private var chatBridgeMode: String = "piMono"
+  @AppStorage("realtimeOmniProvider") private var realtimeOmniProvider: String = RealtimeOmniProvider.auto.rawValue
   @AppStorage("askModeEnabled") private var askModeEnabled = false
   @AppStorage("claudeMdEnabled") private var claudeMdEnabled = true
   @AppStorage("projectClaudeMdEnabled") private var projectClaudeMdEnabled = true
@@ -3473,6 +3474,45 @@ struct SettingsContentView: View {
 
   private var aiSetupSubsection: some View {
     VStack(spacing: 20) {
+      settingsCard(settingId: "aichat.realtimevoice") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "waveform")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Text("Voice Model")
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Picker("", selection: $realtimeOmniProvider) {
+              ForEach(RealtimeOmniProvider.allCases, id: \.rawValue) { p in
+                Text(p.displayName).tag(p.rawValue)
+              }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 200)
+            .onChange(of: realtimeOmniProvider) { _, newValue in
+              if newValue == RealtimeOmniProvider.auto.rawValue {
+                AutoModelSelector.shared.refreshIfStale()
+              }
+            }
+          }
+
+          if let p = RealtimeOmniProvider(rawValue: realtimeOmniProvider), p == .auto {
+            Text("\(p.subtitle) · currently \(RealtimeOmniSettings.shared.effectiveProvider.displayName)")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+          } else if let p = RealtimeOmniProvider(rawValue: realtimeOmniProvider) {
+            Text(p.subtitle)
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+        }
+      }
+
       settingsCard(settingId: "aichat.provider") {
         VStack(alignment: .leading, spacing: 12) {
           HStack {

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -241,6 +241,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     log("AppDelegate: applicationDidFinishLaunching started (mode: \(OMIApp.launchMode.rawValue))")
     log("AppDelegate: AuthState.isSignedIn=\(AuthState.shared.isSignedIn)")
 
+    // Refresh the "Auto" realtime-voice model pick from Artificial Analysis (daily, cached).
+    AutoModelSelector.shared.refreshIfStale()
+
     // Force macOS to use the correct app icon (bypasses icon cache).
     // Apply squircle mask with proper margins because NSApp.applicationIconImage
     // renders the raw image without macOS auto-masking.

--- a/desktop/Desktop/Sources/RealtimeOmni/AutoModelSelector.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/AutoModelSelector.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+// MARK: - Auto model selector
+//
+// When the user picks "Auto", we choose the realtime provider whose underlying
+// model currently scores best on a simple quality/speed formula, refreshed once
+// a day from Artificial Analysis (https://artificialanalysis.ai — attribution
+// required by their free API terms).
+//
+// The realtime audio variants aren't always in AA's LLM index, so each selectable
+// provider maps to the closest representative model slug as a quality/speed proxy.
+// The whole thing degrades gracefully: no key / network error / unknown schema →
+// we keep the last good pick, or fall back to Gemini (cheapest + fastest).
+//
+// Production note: for "all Auto users to agree", the canonical pick should come
+// from a backend cron writing one value all clients read. This client-side daily
+// fetch is the same formula and a safe fallback when that endpoint is absent;
+// `applyServerPick(_:)` lets the backend override.
+
+@MainActor
+final class AutoModelSelector {
+    static let shared = AutoModelSelector()
+
+    private let pickKey = "realtimeOmniAutoPick"
+    private let pickDateKey = "realtimeOmniAutoPickDate"
+    private let refreshInterval: TimeInterval = 24 * 60 * 60
+
+    // Quality vs speed weighting. Quality leads; speed breaks ties.
+    private let qualityWeight = 0.65
+    private let speedWeight = 0.35
+    private let speedCapTokensPerSec = 250.0  // normalize tok/s into [0,1]
+
+    /// AA model slug used as the quality/speed proxy for each realtime provider.
+    private let proxySlug: [RealtimeOmniProvider: String] = [
+        .geminiFlashLive: "gemini-3-1-flash",
+        .gptRealtime2: "gpt-realtime",
+    ]
+
+    private init() {}
+
+    /// The current cached pick, if any.
+    var currentPick: RealtimeOmniProvider? {
+        UserDefaults.standard.string(forKey: pickKey).flatMap(RealtimeOmniProvider.init(rawValue:))
+    }
+
+    private var lastRefresh: Date? {
+        UserDefaults.standard.object(forKey: pickDateKey) as? Date
+    }
+
+    private var apiKey: String? {
+        if let k = UserDefaults.standard.string(forKey: "artificialAnalysisAPIKey"), !k.isEmpty { return k }
+        if let k = ProcessInfo.processInfo.environment["ARTIFICIAL_ANALYSIS_API_KEY"], !k.isEmpty { return k }
+        return nil
+    }
+
+    /// Call at launch and once a day. No-op if a fresh pick already exists.
+    func refreshIfStale() {
+        if let last = lastRefresh, Date().timeIntervalSince(last) < refreshInterval, currentPick != nil {
+            return
+        }
+        Task { await refresh() }
+    }
+
+    /// Lets a backend-provided pick win over the local computation.
+    func applyServerPick(_ provider: RealtimeOmniProvider) {
+        store(provider)
+    }
+
+    func refresh() async {
+        guard let scores = await fetchScores() else {
+            // Keep last pick; only seed a default if we've never picked.
+            if currentPick == nil { store(.geminiFlashLive) }
+            return
+        }
+        let best = RealtimeOmniProvider.selectable
+            .compactMap { p in scores[p].map { (p, $0) } }
+            .max { $0.1 < $1.1 }?
+            .0
+        store(best ?? .geminiFlashLive)
+    }
+
+    private func store(_ provider: RealtimeOmniProvider) {
+        UserDefaults.standard.set(provider.rawValue, forKey: pickKey)
+        UserDefaults.standard.set(Date(), forKey: pickDateKey)
+        NotificationCenter.default.post(name: .realtimeOmniSettingsDidChange, object: nil)
+        log("AutoModelSelector: picked \(provider.displayName)")
+    }
+
+    // MARK: - Artificial Analysis fetch + scoring
+
+    /// Returns a normalized [0,1]-ish score per selectable provider, or nil on failure.
+    private func fetchScores() async -> [RealtimeOmniProvider: Double]? {
+        guard let key = apiKey else {
+            log("AutoModelSelector: no Artificial Analysis API key; using fallback")
+            return nil
+        }
+        guard let url = URL(string: "https://artificialanalysis.ai/api/v2/data/llms/models") else { return nil }
+        var req = URLRequest(url: url)
+        req.setValue(key, forHTTPHeaderField: "x-api-key")
+        req.timeoutInterval = 20
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                log("AutoModelSelector: AA HTTP error")
+                return nil
+            }
+            let models = parseModels(data)
+            guard !models.isEmpty else { return nil }
+
+            var result: [RealtimeOmniProvider: Double] = [:]
+            for provider in RealtimeOmniProvider.selectable {
+                guard let slug = proxySlug[provider],
+                      let metrics = bestMatch(slug: slug, in: models) else { continue }
+                result[provider] = score(quality: metrics.quality, speed: metrics.speed)
+            }
+            return result.isEmpty ? nil : result
+        } catch {
+            logError("AutoModelSelector: AA fetch failed", error: error)
+            return nil
+        }
+    }
+
+    private func score(quality: Double, speed: Double) -> Double {
+        let q = max(0, min(1, quality / 100.0))                 // intelligence index is ~0-100
+        let s = max(0, min(1, speed / speedCapTokensPerSec))    // output tok/s
+        return qualityWeight * q + speedWeight * s
+    }
+
+    private struct ModelMetrics { let slug: String; let quality: Double; let speed: Double }
+
+    /// Tolerant parse: AA's schema may drift, so we read fields by several plausible
+    /// keys rather than a rigid Codable model.
+    private func parseModels(_ data: Data) -> [ModelMetrics] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) else { return [] }
+        let array: [[String: Any]]
+        if let dict = root as? [String: Any], let d = dict["data"] as? [[String: Any]] {
+            array = d
+        } else if let a = root as? [[String: Any]] {
+            array = a
+        } else {
+            return []
+        }
+
+        return array.compactMap { item in
+            let slug = (item["slug"] as? String)
+                ?? (item["id"] as? String)
+                ?? (item["name"] as? String)
+            guard let slug else { return nil }
+
+            let quality = firstNumber(item, [
+                "artificial_analysis_intelligence_index",
+                "intelligence_index", "intelligence", "quality_index", "quality",
+            ], nested: item["evaluations"] as? [String: Any])
+
+            let speed = firstNumber(item, [
+                "median_output_tokens_per_second", "output_tokens_per_second",
+                "output_speed", "tokens_per_second",
+            ], nested: item["performance"] as? [String: Any])
+
+            guard let quality, let speed else { return nil }
+            return ModelMetrics(slug: slug.lowercased(), quality: quality, speed: speed)
+        }
+    }
+
+    /// Pick the highest-quality model whose slug contains the proxy slug.
+    private func bestMatch(slug: String, in models: [ModelMetrics]) -> ModelMetrics? {
+        let needle = slug.lowercased()
+        return models
+            .filter { $0.slug.contains(needle) }
+            .max { $0.quality < $1.quality }
+    }
+
+    private func firstNumber(_ item: [String: Any], _ keys: [String], nested: [String: Any]?) -> Double? {
+        for key in keys {
+            if let v = numberValue(item[key]) { return v }
+            if let n = nested, let v = numberValue(n[key]) { return v }
+        }
+        return nil
+    }
+
+    private func numberValue(_ any: Any?) -> Double? {
+        if let d = any as? Double { return d }
+        if let i = any as? Int { return Double(i) }
+        if let s = any as? String { return Double(s) }
+        return nil
+    }
+}

--- a/desktop/Desktop/Sources/RealtimeOmni/AutoModelSelector.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/AutoModelSelector.swift
@@ -25,17 +25,6 @@ final class AutoModelSelector {
     private let pickDateKey = "realtimeOmniAutoPickDate"
     private let refreshInterval: TimeInterval = 24 * 60 * 60
 
-    // Quality vs speed weighting. Quality leads; speed breaks ties.
-    private let qualityWeight = 0.65
-    private let speedWeight = 0.35
-    private let speedCapTokensPerSec = 250.0  // normalize tok/s into [0,1]
-
-    /// AA model slug used as the quality/speed proxy for each realtime provider.
-    private let proxySlug: [RealtimeOmniProvider: String] = [
-        .geminiFlashLive: "gemini-3-1-flash",
-        .gptRealtime2: "gpt-realtime",
-    ]
-
     private init() {}
 
     /// The current cached pick, if any.
@@ -45,12 +34,6 @@ final class AutoModelSelector {
 
     private var lastRefresh: Date? {
         UserDefaults.standard.object(forKey: pickDateKey) as? Date
-    }
-
-    private var apiKey: String? {
-        if let k = UserDefaults.standard.string(forKey: "artificialAnalysisAPIKey"), !k.isEmpty { return k }
-        if let k = ProcessInfo.processInfo.environment["ARTIFICIAL_ANALYSIS_API_KEY"], !k.isEmpty { return k }
-        return nil
     }
 
     /// Call at launch and once a day. No-op if a fresh pick already exists.
@@ -66,17 +49,36 @@ final class AutoModelSelector {
         store(provider)
     }
 
+    /// Read the daily pick from the omi backend (which runs the Artificial
+    /// Analysis quality/speed scoring server-side, keeping the AA key off the
+    /// client). Falls back to Gemini only if we've never had a pick.
     func refresh() async {
-        guard let scores = await fetchScores() else {
-            // Keep last pick; only seed a default if we've never picked.
+        let httpBase = DesktopBackendEnvironment.pythonBaseURL()
+            .replacingOccurrences(of: "wss://", with: "https://")
+            .replacingOccurrences(of: "ws://", with: "http://")
+        let base = httpBase.hasSuffix("/") ? String(httpBase.dropLast()) : httpBase
+        guard let url = URL(string: "\(base)/v1/auto/model-pick") else {
             if currentPick == nil { store(.geminiFlashLive) }
             return
         }
-        let best = RealtimeOmniProvider.selectable
-            .compactMap { p in scores[p].map { (p, $0) } }
-            .max { $0.1 < $1.1 }?
-            .0
-        store(best ?? .geminiFlashLive)
+        do {
+            var req = URLRequest(url: url)
+            req.timeoutInterval = 15
+            if let auth = try? await AuthService.shared.getAuthHeader() {
+                req.setValue(auth, forHTTPHeaderField: "Authorization")
+            }
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let raw = obj["provider"] as? String,
+                  let provider = RealtimeOmniProvider(rawValue: raw) else {
+                if currentPick == nil { store(.geminiFlashLive) }
+                return
+            }
+            store(provider)
+        } catch {
+            if currentPick == nil { store(.geminiFlashLive) }
+        }
     }
 
     private func store(_ provider: RealtimeOmniProvider) {
@@ -86,103 +88,4 @@ final class AutoModelSelector {
         log("AutoModelSelector: picked \(provider.displayName)")
     }
 
-    // MARK: - Artificial Analysis fetch + scoring
-
-    /// Returns a normalized [0,1]-ish score per selectable provider, or nil on failure.
-    private func fetchScores() async -> [RealtimeOmniProvider: Double]? {
-        guard let key = apiKey else {
-            log("AutoModelSelector: no Artificial Analysis API key; using fallback")
-            return nil
-        }
-        guard let url = URL(string: "https://artificialanalysis.ai/api/v2/data/llms/models") else { return nil }
-        var req = URLRequest(url: url)
-        req.setValue(key, forHTTPHeaderField: "x-api-key")
-        req.timeoutInterval = 20
-
-        do {
-            let (data, response) = try await URLSession.shared.data(for: req)
-            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-                log("AutoModelSelector: AA HTTP error")
-                return nil
-            }
-            let models = parseModels(data)
-            guard !models.isEmpty else { return nil }
-
-            var result: [RealtimeOmniProvider: Double] = [:]
-            for provider in RealtimeOmniProvider.selectable {
-                guard let slug = proxySlug[provider],
-                      let metrics = bestMatch(slug: slug, in: models) else { continue }
-                result[provider] = score(quality: metrics.quality, speed: metrics.speed)
-            }
-            return result.isEmpty ? nil : result
-        } catch {
-            logError("AutoModelSelector: AA fetch failed", error: error)
-            return nil
-        }
-    }
-
-    private func score(quality: Double, speed: Double) -> Double {
-        let q = max(0, min(1, quality / 100.0))                 // intelligence index is ~0-100
-        let s = max(0, min(1, speed / speedCapTokensPerSec))    // output tok/s
-        return qualityWeight * q + speedWeight * s
-    }
-
-    private struct ModelMetrics { let slug: String; let quality: Double; let speed: Double }
-
-    /// Tolerant parse: AA's schema may drift, so we read fields by several plausible
-    /// keys rather than a rigid Codable model.
-    private func parseModels(_ data: Data) -> [ModelMetrics] {
-        guard let root = try? JSONSerialization.jsonObject(with: data) else { return [] }
-        let array: [[String: Any]]
-        if let dict = root as? [String: Any], let d = dict["data"] as? [[String: Any]] {
-            array = d
-        } else if let a = root as? [[String: Any]] {
-            array = a
-        } else {
-            return []
-        }
-
-        return array.compactMap { item in
-            let slug = (item["slug"] as? String)
-                ?? (item["id"] as? String)
-                ?? (item["name"] as? String)
-            guard let slug else { return nil }
-
-            let quality = firstNumber(item, [
-                "artificial_analysis_intelligence_index",
-                "intelligence_index", "intelligence", "quality_index", "quality",
-            ], nested: item["evaluations"] as? [String: Any])
-
-            let speed = firstNumber(item, [
-                "median_output_tokens_per_second", "output_tokens_per_second",
-                "output_speed", "tokens_per_second",
-            ], nested: item["performance"] as? [String: Any])
-
-            guard let quality, let speed else { return nil }
-            return ModelMetrics(slug: slug.lowercased(), quality: quality, speed: speed)
-        }
-    }
-
-    /// Pick the highest-quality model whose slug contains the proxy slug.
-    private func bestMatch(slug: String, in models: [ModelMetrics]) -> ModelMetrics? {
-        let needle = slug.lowercased()
-        return models
-            .filter { $0.slug.contains(needle) }
-            .max { $0.quality < $1.quality }
-    }
-
-    private func firstNumber(_ item: [String: Any], _ keys: [String], nested: [String: Any]?) -> Double? {
-        for key in keys {
-            if let v = numberValue(item[key]) { return v }
-            if let n = nested, let v = numberValue(n[key]) { return v }
-        }
-        return nil
-    }
-
-    private func numberValue(_ any: Any?) -> Double? {
-        if let d = any as? Double { return d }
-        if let i = any as? Int { return Double(i) }
-        if let s = any as? String { return Double(s) }
-        return nil
-    }
 }

--- a/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -1,0 +1,387 @@
+import Foundation
+import Network
+
+// MARK: - Realtime Omni Service
+//
+// One WebSocket client that talks to either Gemini 3.1 Flash Live or
+// OpenAI gpt-realtime-2 and exposes two capabilities the floating bar needs:
+//
+//   • STT  — stream mic PCM in, receive the user's transcript out.
+//   • TTS  — send assistant text in, receive spoken PCM audio out.
+//
+// Reasoning/tools are NOT done here — the transcript goes to ChatProvider
+// (pi-mono/Claude + tools) exactly as before; this service is only the voice
+// shell that replaces Deepgram (STT) + OpenAI TTS in the cascade.
+//
+// Wire protocols are the ones verified in the realtime-voice-demos web app:
+//   OpenAI GA:  session.update {audio.input/output pcm}, input_audio_buffer.append,
+//               response.create, response.output_audio(.delta), input transcription.
+//   Gemini Live: BidiGenerateContentSetup, realtimeInput{audio}, clientContent,
+//               serverContent.modelTurn.parts.inlineData / inputTranscription.
+//
+// Key resolution (phase 1): BYOK / env. Production should proxy through the omi
+// backend so keys stay server-side and usage is metered — see `resolveKey`.
+
+@MainActor
+protocol RealtimeOmniServiceDelegate: AnyObject {
+    func omniDidConnect()
+    func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool)
+    func omniDidReceiveAudio(_ pcm24k: Data)
+    func omniDidFinishTurn()
+    func omniDidError(_ message: String)
+}
+
+final class RealtimeOmniService: NSObject {
+    private let provider: RealtimeOmniProvider  // always concrete (never .auto)
+    private let model: String
+    /// omi backend base URL (https) — we connect to its /v1/omni/relay WS, which
+    /// holds the provider keys and forwards to OpenAI/Gemini server-side.
+    private let relayBaseURL: String
+    private let authHeader: String
+    /// STT-only: don't have the omni model speak — Claude generates the reply,
+    /// existing TTS voices it. (When false, the model can speak via `speak`.)
+    private let sttOnly: Bool
+    private weak var delegate: RealtimeOmniServiceDelegate?
+
+    private var task: URLSessionWebSocketTask?
+    private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    private var isOpen = false
+    private var pendingAudio: [Data] = []
+
+    // Gemini's Live endpoint resets BOTH of Apple's WebSocket stacks
+    // (URLSession drops after the HTTP/2 upgrade; Network.framework gets
+    // ECONNABORTED). Node's `ws` connects fine, so Gemini is reached through a
+    // small WS relay (localhost in dev → omi backend in prod). OpenAI connects
+    // client-direct. So everything now goes over URLSession; NW is unused.
+    private var usesNW: Bool { false }
+    private var nw: NWConnection?
+
+    /// Mic PCM input rate per provider (Gemini 16k, OpenAI GA requires ≥24k).
+    var requiredInputSampleRate: Int { provider == .gptRealtime2 ? 24000 : 16000 }
+    /// Both providers emit 24kHz PCM16.
+    let outputSampleRate = 24000
+
+    /// `provider` must be concrete (resolve `.auto` via RealtimeOmniSettings.effectiveProvider
+    /// first). `apiKey` is resolved by the caller from BYOK / backend token.
+    init(provider: RealtimeOmniProvider, relayBaseURL: String, authHeader: String,
+         sttOnly: Bool = true, delegate: RealtimeOmniServiceDelegate) {
+        self.provider = provider == .auto ? .geminiFlashLive : provider
+        self.model = self.provider.modelID
+        self.relayBaseURL = relayBaseURL
+        self.authHeader = authHeader
+        self.sttOnly = sttOnly
+        self.delegate = delegate
+        super.init()
+    }
+
+    // MARK: Lifecycle
+
+    func start() {
+        guard let request = makeRequest(), let url = request.url else {
+            let name = provider.displayName
+            Task { @MainActor in self.delegate?.omniDidError("Could not build \(name) request URL") }
+            return
+        }
+        log("RealtimeOmni: connecting \(provider.displayName) → \(url.host ?? "?")")
+        if usesNW {
+            startNW(url: url)
+            return
+        }
+        let t = session.webSocketTask(with: request)
+        task = t
+        t.resume()
+        // Receive loop + session setup start from didOpenWithProtocol — touching
+        // the socket before the handshake completes yields "Socket is not connected".
+    }
+
+    func stop() {
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+        nw?.cancel()
+        nw = nil
+        isOpen = false
+        pendingAudio.removeAll()
+    }
+
+    // MARK: - Network.framework transport (Gemini, HTTP/1.1 WebSocket)
+
+    private func startNW(url: URL) {
+        let opts = NWProtocolWebSocket.Options()
+        opts.autoReplyPing = true
+        let tls = NWProtocolTLS.Options()
+        let params = NWParameters(tls: tls)
+        params.defaultProtocolStack.applicationProtocols.insert(opts, at: 0)
+        // NWEndpoint.url carries the path + query so the WS Upgrade hits the
+        // BidiGenerateContent path with ?key=… intact.
+        let conn = NWConnection(to: .url(url), using: params)
+        nw = conn
+        conn.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                log("RealtimeOmni: NW WS ready")
+                self.receiveNW()
+                self.sendSessionSetup()
+            case .failed(let err):
+                Task { @MainActor in self.delegate?.omniDidError("NW failed: \(err)") }
+            case .cancelled:
+                break
+            default:
+                break
+            }
+        }
+        conn.start(queue: .global(qos: .userInitiated))
+    }
+
+    private func receiveNW() {
+        nw?.receiveMessage { [weak self] data, _, _, error in
+            guard let self else { return }
+            if let error {
+                Task { @MainActor in self.delegate?.omniDidError("NW receive: \(error)") }
+                return
+            }
+            if let data { Task { @MainActor in self.handleMessage(data) } }
+            if self.nw?.state == .ready { self.receiveNW() }
+        }
+    }
+
+    private func sendNW(_ text: String) {
+        guard let conn = nw else { return }
+        let meta = NWProtocolWebSocket.Metadata(opcode: .text)
+        let ctx = NWConnection.ContentContext(identifier: "send", metadata: [meta])
+        conn.send(content: Data(text.utf8), contentContext: ctx, isComplete: true,
+                  completion: .contentProcessed { [weak self] error in
+            if let error { Task { @MainActor in self?.delegate?.omniDidError("NW send: \(error)") } }
+        })
+    }
+
+    // MARK: STT — stream mic audio in
+
+    /// Feed mic PCM16 mono at `requiredInputSampleRate`. Caller is responsible for
+    /// resampling to that rate (16k mic → 24k for OpenAI).
+    func sendAudio(_ pcm: Data) {
+        let b64 = pcm.base64EncodedString()
+        switch provider {
+        case .gptRealtime2:
+            send(json: ["type": "input_audio_buffer.append", "audio": b64])
+        case .geminiFlashLive, .auto:
+            send(json: ["realtimeInput": ["audio": ["data": b64, "mimeType": "audio/pcm;rate=16000"]]])
+        }
+    }
+
+    /// Signal end of the user's PTT turn.
+    func commitInputTurn() {
+        switch provider {
+        case .gptRealtime2:
+            send(json: ["type": "input_audio_buffer.commit"])
+        case .geminiFlashLive, .auto:
+            send(json: ["realtimeInput": ["activityEnd": [:]]])
+        }
+    }
+
+    // MARK: TTS — speak assistant text out
+
+    /// Speak `text` through the omni model's native voice.
+    func speak(_ text: String) {
+        switch provider {
+        case .gptRealtime2:
+            send(json: [
+                "type": "conversation.item.create",
+                "item": ["type": "message", "role": "assistant",
+                         "content": [["type": "output_text", "text": text]]],
+            ])
+            send(json: ["type": "response.create"])
+        case .geminiFlashLive, .auto:
+            send(json: ["clientContent": [
+                "turns": [["role": "user", "parts": [["text": "Read this aloud verbatim: \(text)"]]]],
+                "turnComplete": true,
+            ]])
+        }
+    }
+
+    // MARK: - Session setup per provider
+
+    private func sendSessionSetup() {
+        switch provider {
+        case .gptRealtime2:
+            send(json: [
+                "type": "session.update",
+                "session": [
+                    "type": "realtime",
+                    "output_modalities": ["audio"],
+                    "audio": [
+                        "input": [
+                            "format": ["type": "audio/pcm", "rate": 24000],
+                            // Manual turn control: PTT decides start/stop.
+                            "turn_detection": NSNull(),
+                            "transcription": ["model": "whisper-1"],
+                        ],
+                        "output": ["format": ["type": "audio/pcm", "rate": 24000], "voice": "marin"],
+                    ],
+                ],
+            ])
+        case .geminiFlashLive, .auto:
+            // gemini-3.1-flash-live only supports AUDIO output (TEXT is rejected
+            // with close 1007). For STT-only we ignore the audio and read
+            // inputAudioTranscription. PTT controls turns manually, so disable
+            // Gemini's automatic VAD and bracket the turn with activityStart/End.
+            send(json: [
+                "setup": [
+                    "model": "models/\(model)",
+                    "generationConfig": ["responseModalities": ["AUDIO"]],
+                    "inputAudioTranscription": [:],
+                    "outputAudioTranscription": [:],
+                    "realtimeInputConfig": ["automaticActivityDetection": ["disabled": true]],
+                ],
+            ])
+        }
+    }
+
+    private func makeRequest() -> URLRequest? {
+        // Connect to the omi backend's omni relay. The backend holds the provider
+        // keys and forwards to OpenAI/Gemini — so no keys ship in the client, and
+        // Gemini works (server-side `websockets` connects where Apple's stacks can't).
+        let base = relayBaseURL
+            .replacingOccurrences(of: "https://", with: "wss://")
+            .replacingOccurrences(of: "http://", with: "ws://")
+        let wsBase = base.hasSuffix("/") ? String(base.dropLast()) : base
+        let providerParam = provider == .gptRealtime2 ? "openai" : "gemini"
+        guard var comps = URLComponents(string: "\(wsBase)/v1/omni/relay") else { return nil }
+        comps.queryItems = [
+            URLQueryItem(name: "provider", value: providerParam),
+            URLQueryItem(name: "model", value: model),
+        ]
+        guard let url = comps.url else { return nil }
+        var r = URLRequest(url: url)
+        r.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        return r
+    }
+
+    // MARK: - Receive loop + parsing
+
+    private func receiveLoop() {
+        task?.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .failure(let error):
+                log("RealtimeOmni: receive failed: \(error)")
+                Task { @MainActor in self.delegate?.omniDidError(error.localizedDescription) }
+            case .success(let message):
+                let data: Data?
+                switch message {
+                case .string(let text): data = Data(text.utf8)
+                case .data(let d): data = d
+                @unknown default: data = nil
+                }
+                if let data { Task { @MainActor in self.handleMessage(data) } }
+                self.receiveLoop()
+            }
+        }
+    }
+
+    @MainActor
+    private func handleMessage(_ data: Data) {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+        switch provider {
+        case .gptRealtime2: handleOpenAI(obj)
+        case .geminiFlashLive, .auto: handleGemini(obj)
+        }
+    }
+
+    @MainActor
+    private func handleOpenAI(_ e: [String: Any]) {
+        guard let type = e["type"] as? String else { return }
+        switch type {
+        case "session.updated", "session.created":
+            markReady()
+        case "response.output_audio.delta":
+            if let b64 = e["delta"] as? String, let d = Data(base64Encoded: b64) { delegate?.omniDidReceiveAudio(d) }
+        case "conversation.item.input_audio_transcription.delta":
+            if let t = e["delta"] as? String { delegate?.omniDidReceiveInputTranscript(t, isFinal: false) }
+        case "conversation.item.input_audio_transcription.completed":
+            if let t = e["transcript"] as? String { delegate?.omniDidReceiveInputTranscript(t, isFinal: true) }
+        case "response.done":
+            delegate?.omniDidFinishTurn()
+        case "error":
+            let msg = (e["error"] as? [String: Any])?["message"] as? String ?? "OpenAI realtime error"
+            delegate?.omniDidError(msg)
+        default:
+            break
+        }
+    }
+
+    @MainActor
+    private func handleGemini(_ e: [String: Any]) {
+        if e["setupComplete"] != nil { markReady(); return }
+        guard let sc = e["serverContent"] as? [String: Any] else { return }
+        if let it = sc["inputTranscription"] as? [String: Any], let t = it["text"] as? String {
+            delegate?.omniDidReceiveInputTranscript(t, isFinal: false)
+        }
+        if let parts = (sc["modelTurn"] as? [String: Any])?["parts"] as? [[String: Any]] {
+            for p in parts {
+                if let inline = p["inlineData"] as? [String: Any],
+                   let mime = inline["mimeType"] as? String, mime.contains("audio/pcm"),
+                   let b64 = inline["data"] as? String, let d = Data(base64Encoded: b64) {
+                    delegate?.omniDidReceiveAudio(d)
+                }
+            }
+        }
+        if (sc["turnComplete"] as? Bool) == true {
+            delegate?.omniDidReceiveInputTranscript("", isFinal: true)
+            delegate?.omniDidFinishTurn()
+        }
+    }
+
+    @MainActor
+    private func markReady() {
+        log("RealtimeOmni: setup complete (ready)")
+        guard !isOpen else { return }
+        isOpen = true
+        // Open the PTT turn before audio flows (Gemini manual-VAD).
+        if provider == .geminiFlashLive || provider == .auto {
+            send(json: ["realtimeInput": ["activityStart": [:]]])
+        }
+        for chunk in pendingAudio { sendAudio(chunk) }
+        pendingAudio.removeAll()
+        delegate?.omniDidConnect()
+    }
+
+    // MARK: - Send helpers
+
+    private func send(json: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: json),
+              let text = String(data: data, encoding: .utf8) else { return }
+        if usesNW {
+            sendNW(text)
+            return
+        }
+        task?.send(.string(text)) { [weak self] error in
+            if let error { Task { @MainActor in self?.delegate?.omniDidError(error.localizedDescription) } }
+        }
+    }
+}
+
+// MARK: - URLSessionWebSocketDelegate
+
+extension RealtimeOmniService: URLSessionWebSocketDelegate {
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask,
+                    didOpenWithProtocol protocol: String?) {
+        log("RealtimeOmni: WS didOpen")
+        // Connection is up — now it's safe to receive and send the setup.
+        receiveLoop()
+        sendSessionSetup()
+    }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask,
+                    didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        let r = reason.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+        Task { @MainActor in self.delegate?.omniDidError("WebSocket closed (\(closeCode.rawValue)) \(r)") }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        log("RealtimeOmni: didComplete err=\(String(describing: error))")
+        if let error {
+            Task { @MainActor in self.delegate?.omniDidError("WebSocket failed: \(error.localizedDescription)") }
+        }
+    }
+}

--- a/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniSettings.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniSettings.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+// MARK: - Realtime Omni Provider
+//
+// A single realtime "omni" model handles voice I/O for the floating bar:
+//   - speech-to-text (replaces Deepgram)
+//   - text-to-speech (replaces OpenAI TTS)
+// Reasoning + every agent/tool still runs through ChatProvider (pi-mono/Claude),
+// so the omni model is only the voice shell — nothing about tools changes.
+//
+// The user picks a provider in Advanced settings. "Auto" defers to
+// AutoModelSelector, which refreshes a best-by-quality/speed pick daily from
+// Artificial Analysis (https://artificialanalysis.ai).
+
+enum RealtimeOmniProvider: String, CaseIterable, Sendable {
+    case auto
+    case geminiFlashLive
+    case gptRealtime2
+
+    var displayName: String {
+        switch self {
+        case .auto:           return "Auto"
+        case .geminiFlashLive: return "Gemini 3.1 Flash Live"
+        case .gptRealtime2:    return "GPT Realtime 2"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .auto:           return "Daily-picks the best model by quality & speed"
+        case .geminiFlashLive: return "Google · native audio + vision, lowest cost"
+        case .gptRealtime2:    return "OpenAI · GA speech-to-speech"
+        }
+    }
+
+    /// Concrete model identifier sent to the provider. `.auto` resolves elsewhere.
+    var modelID: String {
+        switch self {
+        case .auto:           return RealtimeOmniProvider.geminiFlashLive.modelID
+        case .geminiFlashLive: return "gemini-3.1-flash-live-preview"
+        case .gptRealtime2:    return "gpt-realtime-2"
+        }
+    }
+
+    /// Concrete providers the resolver may choose from for `.auto`.
+    static var selectable: [RealtimeOmniProvider] { [.geminiFlashLive, .gptRealtime2] }
+}
+
+// MARK: - Settings store (mirrors AssistantSettings persistence pattern)
+
+@MainActor
+final class RealtimeOmniSettings {
+    static let shared = RealtimeOmniSettings()
+
+    private let providerKey = "realtimeOmniProvider"
+    /// Master switch: when off, the floating bar keeps using the legacy
+    /// Deepgram STT + OpenAI/system TTS cascade. Lets us ship behind a flag.
+    private let enabledKey = "realtimeOmniEnabled"
+
+    private init() {
+        UserDefaults.standard.register(defaults: [
+            providerKey: RealtimeOmniProvider.auto.rawValue,
+            enabledKey: false,
+        ])
+    }
+
+    var isEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: enabledKey) }
+        set {
+            UserDefaults.standard.set(newValue, forKey: enabledKey)
+            NotificationCenter.default.post(name: .realtimeOmniSettingsDidChange, object: nil)
+        }
+    }
+
+    /// The provider as configured by the user (may be `.auto`).
+    var selectedProvider: RealtimeOmniProvider {
+        get {
+            let raw = UserDefaults.standard.string(forKey: providerKey)
+            return raw.flatMap(RealtimeOmniProvider.init(rawValue:)) ?? .auto
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: providerKey)
+            NotificationCenter.default.post(name: .realtimeOmniSettingsDidChange, object: nil)
+        }
+    }
+
+    /// The concrete provider to actually use right now. Resolves `.auto` via the
+    /// cached daily benchmark pick (falling back to Gemini when no pick exists).
+    var effectiveProvider: RealtimeOmniProvider {
+        guard selectedProvider == .auto else { return selectedProvider }
+        return AutoModelSelector.shared.currentPick ?? .geminiFlashLive
+    }
+}
+
+extension Notification.Name {
+    static let realtimeOmniSettingsDidChange = Notification.Name("realtimeOmniSettingsDidChange")
+}

--- a/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+// MARK: - Fake-voice E2E test harness
+//
+// Injects a raw PCM16/16kHz-mono buffer through the real RealtimeOmniService
+// (the exact STT path the floating bar uses) and returns the transcript — so the
+// whole omni voice loop can be tested headlessly with synthetic speech, no mic,
+// no TCC prompt, no human talking. Driven via the `omni_test_turn` automation
+// action (see DesktopAutomationBridge.registerBuiltins).
+
+@MainActor
+final class RealtimeOmniTestHarness: NSObject, RealtimeOmniServiceDelegate {
+    private let provider: RealtimeOmniProvider
+    private let relayBaseURL: String
+    private let authHeader: String
+    private let pcm16k: Data
+
+    private var service: RealtimeOmniService?
+    private var feed = Data()
+    private var sendIndex = 0
+    private var interim = ""
+    private var finalText = ""
+    private var connected = false
+    private var errorMsg: String?
+    private var done = false
+    private var continuation: CheckedContinuation<[String: String], Never>?
+
+    init(provider: RealtimeOmniProvider, relayBaseURL: String, authHeader: String, pcm16k: Data) {
+        self.provider = provider
+        self.relayBaseURL = relayBaseURL
+        self.authHeader = authHeader
+        self.pcm16k = pcm16k
+        super.init()
+    }
+
+    func run(timeoutSeconds: Double) async -> [String: String] {
+        let svc = RealtimeOmniService(
+            provider: provider, relayBaseURL: relayBaseURL, authHeader: authHeader, sttOnly: true, delegate: self)
+        service = svc
+        svc.start()
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+            self?.finish(reason: "timeout")
+        }
+        return await withCheckedContinuation { continuation = $0 }
+    }
+
+    // MARK: RealtimeOmniServiceDelegate
+
+    func omniDidConnect() {
+        connected = true
+        let rate = service?.requiredInputSampleRate ?? 16000
+        feed = rate == 16000 ? pcm16k : PushToTalkManager.resamplePCM16(pcm16k, from: 16000, to: rate)
+        sendIndex = 0
+        pump()
+    }
+
+    private func pump() {
+        guard let svc = service, !done else { return }
+        let chunkBytes = (svc.requiredInputSampleRate / 10) * 2  // ~100ms of PCM16
+        if sendIndex >= feed.count {
+            svc.commitInputTurn()  // OpenAI manual VAD; no-op for Gemini
+            return
+        }
+        let end = min(sendIndex + chunkBytes, feed.count)
+        svc.sendAudio(feed.subdata(in: sendIndex..<end))
+        sendIndex = end
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in self?.pump() }
+    }
+
+    func omniDidReceiveInputTranscript(_ text: String, isFinal: Bool) {
+        if isFinal {
+            if !text.isEmpty { finalText = text }
+            finish(reason: "final_transcript")  // STT done — no need to wait for turn end
+        } else {
+            interim += text
+        }
+    }
+
+    func omniDidReceiveAudio(_ pcm24k: Data) {}  // STT-only: model voice unused
+
+    func omniDidFinishTurn() { finish(reason: "turn_complete") }
+
+    func omniDidError(_ message: String) {
+        errorMsg = message
+        finish(reason: "error")
+    }
+
+    private func finish(reason: String) {
+        guard !done else { return }
+        done = true
+        service?.stop()
+        service = nil
+        let transcript = finalText.isEmpty ? interim : finalText
+        let result: [String: String] = [
+            "provider": provider.displayName,
+            "connected": connected ? "true" : "false",
+            "transcript": transcript.trimmingCharacters(in: .whitespacesAndNewlines),
+            "reason": reason,
+            "error": errorMsg ?? "",
+        ]
+        log("RealtimeOmniTestHarness: \(result)")
+        continuation?.resume(returning: result)
+        continuation = nil
+    }
+}


### PR DESCRIPTION
## What
Replaces the floating-bar PTT cascade (Deepgram STT + cloud TTS) with **one realtime omni model** for voice I/O. Adds an **Advanced → Voice Model** picker (Auto / Gemini 3.1 Flash Live / GPT Realtime 2). Reasoning/agents/tools/text chat are **unchanged** — only the STT transport changes; the final transcript still flows through `ChatProvider` → `AgentBridge` (Claude + tools).

## Architecture (keys server-side)
`desktop → omi backend /v1/omni/relay (WS) → OpenAI/Gemini`. Apple's WebSocket stacks can't hold a direct Gemini connection (Google frontend resets them), and provider keys shouldn't ship in the client — so the backend relays. `Auto` reads `/v1/auto/model-pick` (daily Artificial Analysis quality/speed score, cached server-side).

### Backend (this PR)
- `routers/omni_relay.py` — authenticated WS relay to OpenAI/Gemini realtime (keys server-side).
- `routers/auto_model.py` — `GET /v1/auto/model-pick`, daily-cached Artificial Analysis quality/speed pick.

### Desktop (this PR)
- `RealtimeOmni/` — settings (+Auto), backend-relay STT/TTS client, Auto selector, fake-voice test harness.
- `PushToTalkManager` — PTT uses omni STT via the relay (buffers audio until connected).
- Advanced **Voice Model** picker (no toggle — the picker is the control).
- `omni_test_turn` automation action — headless fake-voice E2E test (debug bundles only).

## Verified (fake-voice, headless, through the deployed dev relay)
- ✅ Gemini 3.1 Flash Live → connected, correct transcript.
- ✅ GPT Realtime 2 → connected, correct transcript.
- ✅ Real-voice PTT (OpenAI) confirmed in live sessions; Claude reasoning + chat replies intact.

## ⚠️ Before merge/release (merging `desktop/` auto-releases via Codemagic)
1. **Deploy backend to prod** — `/v1/omni/relay` + `/v1/auto/model-pick` are dev-only; prod returns 404. Desktop release must not precede this.
2. **Add `ARTIFICIALANALYSIS_API_KEY`** to backend secrets — without it Auto defaults to Gemini (no live benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)