### PR TITLE
feat(desktop): default to on-device Parakeet on Apple Silicon (+ backend upload endpoint)

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -39,7 +39,7 @@ from dependencies import (
     get_uid_with_goals_read,
     get_uid_with_goals_write,
 )
-from utils.other.endpoints import with_rate_limit
+from utils.other.endpoints import with_rate_limit, get_current_user_uid
 from models.dev_api_key import DevApiKey, DevApiKeyCreate, DevApiKeyCreated
 from utils.scopes import AVAILABLE_SCOPES, validate_scopes
 from utils.apps import update_personas_async
@@ -919,58 +919,12 @@ def get_conversation_endpoint(
     return conversation
 
 
-@router.post("/v1/dev/user/conversations/from-segments", response_model=ConversationResponse, tags=["developer"])
-def create_conversation_from_segments(
-    request: CreateConversationFromTranscriptRequest,
-    uid: str = Depends(with_rate_limit(get_uid_with_conversations_write, "dev:conversations")),
-):
-    """
-    Create a new conversation from structured transcript segments.
-
-    This endpoint is for advanced integrations that have speaker diarization and timing information.
-    It processes the transcript segments through the full conversation pipeline.
-
-    **Transcript Segments:**
-    - **text**: The text spoken (required)
-    - **speaker**: Speaker identifier like 'SPEAKER_00', 'SPEAKER_01' (default: 'SPEAKER_00')
-    - **speaker_id**: Numeric speaker ID (auto-calculated from speaker if not provided)
-    - **is_user**: Whether this segment is from the user (default: False)
-    - **person_id**: ID of known person speaking (optional)
-    - **start**: Start time in seconds, e.g., 0.0, 1.5, 60.2 (required)
-    - **end**: End time in seconds, e.g., 1.5, 3.0, 65.8 (required)
-
-    **Other Parameters:**
-    - **source**: Source of conversation (default: external_integration). Options:
-      - omi, friend, openglass, phone, desktop, apple_watch, bee, plaud, frame, etc.
-    - **started_at**: When conversation started (defaults to now)
-    - **finished_at**: When conversation finished (calculated from last segment if not provided)
-    - **language**: Language code (default: 'en')
-    - **geolocation**: Optional geolocation data
-
-    **Example:**
-    ```json
-    {
-      "transcript_segments": [
-        {
-          "text": "Hey, how are you doing?",
-          "speaker": "SPEAKER_00",
-          "is_user": true,
-          "start": 0.0,
-          "end": 2.5
-        },
-        {
-          "text": "I'm doing great, thanks!",
-          "speaker": "SPEAKER_01",
-          "is_user": false,
-          "start": 2.8,
-          "end": 5.2
-        }
-      ],
-      "source": "phone",
-      "language": "en"
-    }
-    ```
-    """
+def _create_conversation_from_segments(
+    uid: str, request: CreateConversationFromTranscriptRequest
+) -> ConversationResponse:
+    """Shared impl: validate already-transcribed segments, build a CreateConversation, run the full
+    processing pipeline (title, memories, action items, sync), and return the result. Used by both
+    the developer-API-key endpoint and the Firebase-authed user endpoint (on-device transcription)."""
     if not request.transcript_segments or len(request.transcript_segments) == 0:
         raise HTTPException(status_code=422, detail="transcript_segments cannot be empty")
 
@@ -1051,6 +1005,74 @@ def create_conversation_from_segments(
         status=conversation.status.value if conversation.status else 'completed',
         discarded=conversation.discarded,
     )
+
+
+@router.post("/v1/conversations/from-segments", response_model=ConversationResponse, tags=["conversations"])
+def create_conversation_from_segments_user(
+    request: CreateConversationFromTranscriptRequest,
+    uid: str = Depends(with_rate_limit(get_current_user_uid, "conversations:from-segments")),
+):
+    """Create a conversation from already-transcribed segments (Firebase-authed).
+
+    Used by clients that transcribe ON-DEVICE (e.g. the macOS desktop app with Parakeet) and need
+    the conversation persisted, processed (memories/summaries), and synced across devices — exactly
+    like a cloud-transcribed conversation, but without the live `/v4/listen` websocket."""
+    return _create_conversation_from_segments(uid, request)
+
+
+@router.post("/v1/dev/user/conversations/from-segments", response_model=ConversationResponse, tags=["developer"])
+def create_conversation_from_segments(
+    request: CreateConversationFromTranscriptRequest,
+    uid: str = Depends(with_rate_limit(get_uid_with_conversations_write, "dev:conversations")),
+):
+    """
+    Create a new conversation from structured transcript segments.
+
+    This endpoint is for advanced integrations that have speaker diarization and timing information.
+    It processes the transcript segments through the full conversation pipeline.
+
+    **Transcript Segments:**
+    - **text**: The text spoken (required)
+    - **speaker**: Speaker identifier like 'SPEAKER_00', 'SPEAKER_01' (default: 'SPEAKER_00')
+    - **speaker_id**: Numeric speaker ID (auto-calculated from speaker if not provided)
+    - **is_user**: Whether this segment is from the user (default: False)
+    - **person_id**: ID of known person speaking (optional)
+    - **start**: Start time in seconds, e.g., 0.0, 1.5, 60.2 (required)
+    - **end**: End time in seconds, e.g., 1.5, 3.0, 65.8 (required)
+
+    **Other Parameters:**
+    - **source**: Source of conversation (default: external_integration). Options:
+      - omi, friend, openglass, phone, desktop, apple_watch, bee, plaud, frame, etc.
+    - **started_at**: When conversation started (defaults to now)
+    - **finished_at**: When conversation finished (calculated from last segment if not provided)
+    - **language**: Language code (default: 'en')
+    - **geolocation**: Optional geolocation data
+
+    **Example:**
+    ```json
+    {
+      "transcript_segments": [
+        {
+          "text": "Hey, how are you doing?",
+          "speaker": "SPEAKER_00",
+          "is_user": true,
+          "start": 0.0,
+          "end": 2.5
+        },
+        {
+          "text": "I'm doing great, thanks!",
+          "speaker": "SPEAKER_01",
+          "is_user": false,
+          "start": 2.8,
+          "end": 5.2
+        }
+      ],
+      "source": "phone",
+      "language": "en"
+    }
+    ```
+    """
+    return _create_conversation_from_segments(uid, request)
 
 
 @router.delete("/v1/dev/user/conversations/{conversation_id}", tags=["developer"])

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -1282,6 +1282,45 @@ extension APIClient {
   }
 }
 
+// MARK: - Create Conversation From Segments (on-device transcription upload)
+
+extension APIClient {
+  /// One transcript segment for the from-segments upload (matches backend DevTranscriptSegment).
+  struct UploadSegment: Encodable {
+    let text: String
+    let speaker: String
+    let speaker_id: Int?
+    let is_user: Bool
+    let person_id: String?
+    let start: Double
+    let end: Double
+  }
+
+  struct CreateConversationFromSegmentsRequest: Encodable {
+    let transcript_segments: [UploadSegment]
+    let source: String
+    let started_at: String?  // ISO8601
+    let finished_at: String?  // ISO8601
+    let language: String
+  }
+
+  struct CreateConversationFromSegmentsResponse: Decodable {
+    let id: String
+    let status: String
+    let discarded: Bool
+  }
+
+  /// Upload an already-transcribed (on-device Parakeet) conversation to the backend so it is
+  /// persisted, processed (memories/summaries), and synced to every device — the same pipeline a
+  /// cloud-transcribed conversation goes through, without the live `/v4/listen` websocket.
+  /// Endpoint: POST /v1/conversations/from-segments (Firebase-authed).
+  func createConversationFromSegments(_ request: CreateConversationFromSegmentsRequest)
+    async throws -> CreateConversationFromSegmentsResponse
+  {
+    return try await post("v1/conversations/from-segments", body: request, customBaseURL: nil)
+  }
+}
+
 // MARK: - Memories API
 
 extension APIClient {

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -1828,12 +1828,15 @@ class AppState: ObservableObject {
       let sys = localSystemService
       localMicService = nil
       localSystemService = nil
+      let uploadSessionId = currentSessionId
       Task { @MainActor in
         self.stopAudioCapture()
         await mic?.finish()
         await sys?.finish()
         self.clearTranscriptionState()
         self.silentMicFallbackInProgress = false
+        // Upload the on-device transcript so the conversation syncs + gets memories/summaries.
+        if let uploadSessionId { await self.uploadLocalSession(uploadSessionId) }
       }
       return
     }
@@ -1919,6 +1922,70 @@ class AppState: ObservableObject {
     }
   }
 
+  /// Upload a finished on-device (Parakeet) conversation to the backend so it is persisted,
+  /// processed (memories/summaries), and synced to every device — the same result a cloud
+  /// conversation gets, but the transcript was produced locally. On success, marks the local
+  /// session completed with the returned backend conversation id.
+  private func uploadLocalSession(_ sessionId: Int64) async {
+    // Segment DB writes are scheduled fire-and-forget by handleBackendSegments — let them drain
+    // so the upload includes the final tail segments.
+    try? await Task.sleep(nanoseconds: 1_000_000_000)
+    do {
+      guard let bundle = try await TranscriptionStorage.shared.getSessionWithSegments(id: sessionId)
+      else { return }
+      let session = bundle.session
+      guard !bundle.segments.isEmpty else {
+        log("Transcription: Local session \(sessionId) has no segments — nothing to upload")
+        return
+      }
+
+      let raw: [APIClient.UploadSegment] = bundle.segments.map { seg in
+        APIClient.UploadSegment(
+          text: seg.text,
+          speaker: seg.speakerLabel ?? String(format: "SPEAKER_%02d", seg.speaker),
+          speaker_id: seg.speaker,
+          is_user: seg.isUser,
+          person_id: seg.personId,
+          start: seg.startTime,
+          end: seg.endTime
+        )
+      }
+      // Merge consecutive same-speaker segments to stay under the backend's 500-segment cap
+      // (Parakeet emits ~1 segment per 10s window).
+      var merged: [APIClient.UploadSegment] = []
+      for seg in raw {
+        if let last = merged.last, last.speaker_id == seg.speaker_id {
+          merged[merged.count - 1] = APIClient.UploadSegment(
+            text: last.text + " " + seg.text, speaker: last.speaker, speaker_id: last.speaker_id,
+            is_user: last.is_user, person_id: last.person_id, start: last.start, end: seg.end)
+        } else {
+          merged.append(seg)
+        }
+      }
+      if merged.count > 500 {
+        log("Transcription: Local session \(sessionId) has \(merged.count) segments (>500), truncating")
+        merged = Array(merged.prefix(500))
+      }
+
+      let iso = ISO8601DateFormatter()
+      let request = APIClient.CreateConversationFromSegmentsRequest(
+        transcript_segments: merged,
+        source: "desktop",
+        started_at: iso.string(from: session.startedAt),
+        finished_at: session.finishedAt.map { iso.string(from: $0) },
+        language: session.language
+      )
+      let response = try await APIClient.shared.createConversationFromSegments(request)
+      try? await TranscriptionStorage.shared.markSessionCompleted(
+        id: sessionId, backendId: response.id)
+      log(
+        "Transcription: Uploaded on-device session \(sessionId) → backend conversation \(response.id) (\(merged.count) segments)"
+      )
+    } catch {
+      logError("Transcription: Failed to upload on-device session \(sessionId)", error: error)
+    }
+  }
+
   /// Finish the current conversation and keep recording for a new one.
   /// Disconnects the WebSocket (triggers backend conversation processing) then reconnects.
   func finishConversation() async -> FinishConversationResult {
@@ -1952,6 +2019,12 @@ class AppState: ObservableObject {
       } catch {
         logError("Transcription: Failed to finish DB session \(sessionId)", error: error)
       }
+    }
+
+    // Local mode: upload the just-finished on-device conversation to the backend (async) so it
+    // syncs + gets memories/summaries while we keep recording the next conversation.
+    if useLocalSTT, let uploadSessionId = finishedSessionId {
+      Task { await self.uploadLocalSession(uploadSessionId) }
     }
 
     // Stop the transcription service (closes WebSocket, triggers backend conversation processing)

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -335,6 +335,17 @@ class AppState: ObservableObject {
   private var localSystemService: LocalTranscriptionService?
   private var useLocalSTT = false
 
+  /// True on Apple Silicon (M-series), where on-device Parakeet runs on the Neural Engine.
+  /// Desktop transcribes with Parakeet here by default; Intel Macs fall back to cloud STT.
+  static let isAppleSilicon: Bool = {
+    var value: Int32 = 0
+    var size = MemoryLayout<Int32>.size
+    if sysctlbyname("hw.optional.arm64", &value, &size, nil, 0) == 0 {
+      return value == 1
+    }
+    return false
+  }()
+
   // Speaker segments for diarized transcription (sliding window — older segments are in SQLite)
   private var speakerSegments: [SpeakerSegment] = []
   private let maxInMemorySegments = 200
@@ -1438,9 +1449,12 @@ class AppState: ObservableObject {
         "Transcription: Using language=\(effectiveLanguage) (autoDetect=\(AssistantSettings.shared.transcriptionAutoDetect), selected=\(AssistantSettings.shared.transcriptionLanguage))"
       )
 
-      // On-device Parakeet (FluidAudio) when OMI_LOCAL_STT=1 — bypasses the Python backend STT.
-      useLocalSTT = ProcessInfo.processInfo.environment["OMI_LOCAL_STT"] == "1"
-        || UserDefaults.standard.bool(forKey: "useLocalSTT")
+      // Desktop transcribes on-device with Parakeet by default on Apple Silicon — no Deepgram.
+      // Intel Macs (no Neural Engine) fall back to the cloud path. Force cloud for debugging with
+      // OMI_FORCE_CLOUD_STT=1 or `defaults write <bundle> forceCloudSTT -bool true`.
+      let forceCloudSTT = ProcessInfo.processInfo.environment["OMI_FORCE_CLOUD_STT"] == "1"
+        || UserDefaults.standard.bool(forKey: "forceCloudSTT")
+      useLocalSTT = !forceCloudSTT && Self.isAppleSilicon
       if useLocalSTT {
         log("Transcription: ON-DEVICE Parakeet mode (OMI_LOCAL_STT) — no cloud STT")
         // Segments are delivered on the main actor by the service, so no Task hop here.


### PR DESCRIPTION
## ⚠️ DRAFT — do not merge yet

Implements the first half of "desktop always uses Parakeet". **Blocked on the desktop upload wiring** (see TODO) — without it, on-device conversations don't sync to mobile/web or get memories/summaries.

## What's here
- **Desktop:** transcribes with on-device **Parakeet by default on Apple Silicon** (no flag). Intel Macs (no Neural Engine) fall back to the cloud path. Debug override: `OMI_FORCE_CLOUD_STT=1` / `defaults write … forceCloudSTT true`. Compiles clean.
- **Backend:** new **Firebase-authed** `POST /v1/conversations/from-segments` (reuses the existing dev endpoint's full pipeline — title, memories, action items, sync — via a shared helper; only auth differs).

## TODO before merge (the upload wiring)
- Desktop `APIClient.createConversationFromSegments(...)` → call the new endpoint on conversation finish, then mark the local session completed with the returned id. This makes on-device conversations sync + get server-side processing exactly like cloud ones.

## Follow-up PRs (separate)
- Cloud Parakeet GPU service (`backend/parakeet/` + `charts/parakeet/`, diarizer pattern) → replaces Deepgram for mobile + cloud tier.
- Mobile: add "Omi Parakeet (cloud)" as a non-default option in the Transcription settings screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)