### PR TITLE
fix(mcp): raise per-user mcp:sse rate limit 200→2000/hr

### DIFF
--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -52,7 +52,12 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # Platform tools — backend RAG endpoints
     "tools:search": (60, 3600),
     "tools:mutate": (60, 3600),
-    "mcp:sse": (200, 3600),
+    # MCP transport POSTs (initialize/tools-list/tool-calls) are cheap reads, but
+    # one user often runs many concurrent MCP clients (multiple IDE/agent sessions)
+    # under a single account, and clients reconnect in bursts. A tight cap here turns
+    # a reconnect storm into a 429 death-spiral, so this is sized for heavy multi-session
+    # use rather than a single client. Tune via RATE_LIMIT_BOOST for events.
+    "mcp:sse": (2000, 3600),
     # Memories — single LLM call each
     "memories:create": (60, 3600),
     # Memory batch writes — each request can create up to 100 memories, so the


### PR DESCRIPTION
## Problem
`/v1/mcp/sse` (the MCP streamable-HTTP transport) is rate-limited at **200 requests/hour per user** (`mcp:sse` policy). 

A single user routinely runs **many concurrent MCP clients** — multiple IDE/agent sessions (Claude Code, Codex, etc.) under one omi account. Each client's connect does `initialize` + `tools/list`, and clients **retry aggressively** when a connect fails. With ~20-30 sessions under one account, 200/hr is exhausted in seconds, every subsequent connect gets `429`, retries amplify, and it becomes a death-spiral that surfaces to the user as **"omi-memory MCP failed to connect."**

Verified live: rapid connects to `https://api.omi.me/v1/mcp/sse` flip `200 → 429 → 429` and Claude Code drops the server.

## Fix
Raise `mcp:sse` from `(200, 3600)` to `(2000, 3600)`.
- These transport POSTs are cheap reads (`initialize`/`tools/list`/tool dispatch).
- The limit is **per-user**, so a higher cap doesn't meaningfully weaken cross-user abuse protection.
- `RATE_LIMIT_BOOST` env multiplier still available to relax further during events.

## Test
- `tests/unit/test_rate_limiting.py -k mcp` → 2 passed (wiring intact).
- Config imports clean; `get_effective_limit('mcp:sse') == (2000, 3600)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)