### PR TITLE
fix(desktop+backend): omni PTT relay auth + single-fire dedup (Gemini & GPT Realtime 2)

### DIFF
--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -4,12 +4,22 @@ import os
 from urllib.parse import quote
 
 import websockets
-from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Header, WebSocket, WebSocketDisconnect
 
-from utils.other.endpoints import get_current_user_uid_ws_listen
+from utils.executors import critical_executor, run_blocking
+from utils.other.endpoints import _verify_ws_auth
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+async def _relay_uid(authorization: str = Header(None)) -> str:
+    """Token-only WS auth for the relay. Unlike get_current_user_uid_ws_listen,
+    it does NOT run BYOK validation — the relay uses platform keys server-side,
+    so a BYOK-enrolled user without forwarded BYOK headers must not be rejected.
+    No rate limit either (PTT reconnects every turn)."""
+    return await run_blocking(critical_executor, _verify_ws_auth, authorization)
+
 
 # Realtime "omni" relay.
 #
@@ -49,7 +59,7 @@ def _upstream(provider: str, model: str | None):
 
 
 @router.websocket("/v1/omni/relay")
-async def omni_relay(websocket: WebSocket, uid: str = Depends(get_current_user_uid_ws_listen)):
+async def omni_relay(websocket: WebSocket, uid: str = Depends(_relay_uid)):
     provider = websocket.query_params.get("provider", "gemini")
     model = websocket.query_params.get("model")
     upstream_cfg, err = _upstream(provider, model)

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -4,10 +4,17 @@ import os
 from urllib.parse import quote
 
 import websockets
-from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, WebSocketException
 
-from utils.byok import get_byok_key
-from utils.other.endpoints import get_current_user_uid_ws_listen
+from utils.byok import (
+    BYOK_HEADERS,
+    extract_byok_from_websocket,
+    get_byok_key,
+    set_byok_keys,
+    validate_byok_websocket,
+)
+from utils.executors import critical_executor, run_blocking
+from utils.other.endpoints import _verify_ws_auth
 from utils.subscription import is_trial_paywalled
 
 router = APIRouter()
@@ -56,12 +63,39 @@ def _upstream(provider: str, model: str | None):
 
 
 @router.websocket("/v1/omni/relay")
-async def omni_relay(websocket: WebSocket, uid: str = Depends(get_current_user_uid_ws_listen)):
-    # Same desktop gate as /v4/listen: entitled plans (Operator/Architect) and
-    # BYOK users pass; un-entitled desktop users past their trial are paywalled.
+async def omni_relay(websocket: WebSocket):
+    # Manual auth (read the header directly so we control logging and avoid any
+    # WS header-DI surprises). Token first, then BYOK validate, then the gate.
+    authz = websocket.headers.get("authorization")
+    byok_present = [p for p, h in BYOK_HEADERS.items() if websocket.headers.get(h)]
+    logger.info(
+        f"omni relay connect: auth_present={bool(authz)} byok={byok_present} "
+        f"provider={websocket.query_params.get('provider')}"
+    )
+    try:
+        uid = await run_blocking(critical_executor, _verify_ws_auth, authz)
+    except WebSocketException as e:
+        logger.warning(f"omni relay auth rejected: code={e.code} reason={e.reason}")
+        await websocket.close(code=e.code, reason=e.reason or "unauthorized")
+        return
+
+    # BYOK: validate forwarded keys (same as /v4/listen). Keys then resolve via get_byok_key.
+    byok = extract_byok_from_websocket(websocket)
+    if byok:
+        set_byok_keys(byok)
+        byok_err = await run_blocking(critical_executor, validate_byok_websocket, uid)
+        if byok_err:
+            logger.warning(f"omni relay BYOK invalid uid={uid}: {byok_err}")
+            await websocket.close(code=4003, reason=byok_err)
+            return
+
+    # Same desktop gate as /v4/listen: Operator/Architect + BYOK pass; un-entitled
+    # desktop users past their trial are paywalled.
     if is_trial_paywalled(uid, "desktop"):
+        logger.info(f"omni relay paywalled uid={uid}")
         await websocket.close(code=1008, reason="trial_expired")
         return
+
     provider = websocket.query_params.get("provider", "gemini")
     model = websocket.query_params.get("model")
     upstream_cfg, err = _upstream(provider, model)

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -4,21 +4,14 @@ import os
 from urllib.parse import quote
 
 import websockets
-from fastapi import APIRouter, Depends, Header, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 
-from utils.executors import critical_executor, run_blocking
-from utils.other.endpoints import _verify_ws_auth
+from utils.byok import get_byok_key
+from utils.other.endpoints import get_current_user_uid_ws_listen
+from utils.subscription import is_trial_paywalled
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-
-async def _relay_uid(authorization: str = Header(None)) -> str:
-    """Token-only WS auth for the relay. Unlike get_current_user_uid_ws_listen,
-    it does NOT run BYOK validation — the relay uses platform keys server-side,
-    so a BYOK-enrolled user without forwarded BYOK headers must not be rejected.
-    No rate limit either (PTT reconnects every turn)."""
-    return await run_blocking(critical_executor, _verify_ws_auth, authorization)
 
 
 # Realtime "omni" relay.
@@ -42,16 +35,20 @@ OPENAI_URL = "wss://api.openai.com/v1/realtime?model={model}"
 
 
 def _upstream(provider: str, model: str | None):
-    """Return (url, headers) for the chosen provider, or (None, reason)."""
+    """Return (url, headers) for the chosen provider, or (None, reason).
+
+    Prefers the caller's BYOK key (so BYOK users pay their own way, same as the
+    rest of the API); falls back to the platform key for entitled non-BYOK users.
+    """
     if provider == "gemini":
-        key = os.getenv("GEMINI_API_KEY")
+        key = get_byok_key("gemini") or os.getenv("GEMINI_API_KEY")
         if not key:
-            return None, "GEMINI_API_KEY not configured"
+            return None, "no Gemini key (BYOK or platform)"
         return (GEMINI_URL.format(key=key), {}), None
     if provider == "openai":
-        key = os.getenv("OPENAI_API_KEY")
+        key = get_byok_key("openai") or os.getenv("OPENAI_API_KEY")
         if not key:
-            return None, "OPENAI_API_KEY not configured"
+            return None, "no OpenAI key (BYOK or platform)"
         # URL-encode the client-supplied model so it can't inject extra query params.
         url = OPENAI_URL.format(model=quote(model or "gpt-realtime-2", safe=""))
         return (url, {"Authorization": f"Bearer {key}"}), None
@@ -59,7 +56,12 @@ def _upstream(provider: str, model: str | None):
 
 
 @router.websocket("/v1/omni/relay")
-async def omni_relay(websocket: WebSocket, uid: str = Depends(_relay_uid)):
+async def omni_relay(websocket: WebSocket, uid: str = Depends(get_current_user_uid_ws_listen)):
+    # Same desktop gate as /v4/listen: entitled plans (Operator/Architect) and
+    # BYOK users pass; un-entitled desktop users past their trial are paywalled.
+    if is_trial_paywalled(uid, "desktop"):
+        await websocket.close(code=1008, reason="trial_expired")
+        return
     provider = websocket.query_params.get("provider", "gemini")
     model = websocket.query_params.get("model")
     upstream_cfg, err = _upstream(provider, model)

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -48,6 +48,7 @@ class PushToTalkManager: ObservableObject {
   // True once the omni model returned any transcript this turn — gates the
   // Deepgram fallback so a benign trailing socket error doesn't trigger it.
   private var omniReceivedTranscript = false
+  private var omniTurnSent = false  // dedup: send/fallback the omni turn at most once
   private var audioCaptureService: AudioCaptureService?
   private var transcriptSegments: [String] = []
   private var lastInterimText: String = ""
@@ -727,6 +728,7 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
     let provider = RealtimeOmniSettings.shared.effectiveProvider
     isOmniSTT = true
     omniReceivedTranscript = false
+    omniTurnSent = false
     omniPreconnectBuffer.removeAll()
     // Keep a copy of the whole turn so we can fall back to Deepgram if the relay
     // is unreachable (e.g. backend not yet on prod) — PTT must never break.
@@ -810,6 +812,8 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
       if state == .finalizing {
         liveFinalizationTimeout?.cancel()
         liveFinalizationTimeout = nil
+        guard !omniTurnSent else { return }
+        omniTurnSent = true
         sendTranscript()
       }
     } else {
@@ -827,6 +831,8 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
     if state == .finalizing {
       liveFinalizationTimeout?.cancel()
       liveFinalizationTimeout = nil
+      guard !omniTurnSent else { return }
+      omniTurnSent = true
       sendTranscript()
     }
   }
@@ -845,6 +851,8 @@ extension PushToTalkManager: RealtimeOmniServiceDelegate {
 
   /// Transcribe the buffered turn audio via Deepgram when omni is unavailable.
   fileprivate func fallBackToDeepgram() {
+    guard !omniTurnSent else { return }
+    omniTurnSent = true
     log("PushToTalkManager: omni unavailable — falling back to Deepgram for this turn")
     isOmniSTT = false
     realtimeOmniService?.stop()

--- a/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -254,6 +254,11 @@ final class RealtimeOmniService: NSObject {
         guard let url = comps.url else { return nil }
         var r = URLRequest(url: url)
         r.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        // Forward BYOK keys so BYOK users connect with their own provider key
+        // (the backend validates them and uses them upstream — same as /v4/listen).
+        for (provider, entry) in APIKeyService.byokSnapshot {
+            r.setValue(entry.key, forHTTPHeaderField: provider.headerName)
+        }
         return r
     }
 

--- a/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -46,6 +46,7 @@ final class RealtimeOmniService: NSObject {
     private var task: URLSessionWebSocketTask?
     private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
     private var isOpen = false
+    private var terminated = false  // fire omniDidError at most once per turn
     private var pendingAudio: [Data] = []
 
     // Gemini's Live endpoint resets BOTH of Apple's WebSocket stacks
@@ -76,10 +77,21 @@ final class RealtimeOmniService: NSObject {
 
     // MARK: Lifecycle
 
+    /// Fire omniDidError at most once — a single WS teardown raises receive-fail
+    /// + didClose + didComplete, which previously fanned out into many fallbacks.
+    private func notifyError(_ message: String) {
+        Task { @MainActor in
+            guard !self.terminated else { return }
+            self.terminated = true
+            self.delegate?.omniDidError(message)
+        }
+    }
+
+
     func start() {
         guard let request = makeRequest(), let url = request.url else {
             let name = provider.displayName
-            Task { @MainActor in self.delegate?.omniDidError("Could not build \(name) request URL") }
+            notifyError("Could not build \(name) request URL")
             return
         }
         log("RealtimeOmni: connecting \(provider.displayName) → \(url.host ?? "?")")
@@ -123,7 +135,7 @@ final class RealtimeOmniService: NSObject {
                 self.receiveNW()
                 self.sendSessionSetup()
             case .failed(let err):
-                Task { @MainActor in self.delegate?.omniDidError("NW failed: \(err)") }
+                notifyError("NW failed: \(err)")
             case .cancelled:
                 break
             default:
@@ -137,7 +149,7 @@ final class RealtimeOmniService: NSObject {
         nw?.receiveMessage { [weak self] data, _, _, error in
             guard let self else { return }
             if let error {
-                Task { @MainActor in self.delegate?.omniDidError("NW receive: \(error)") }
+                notifyError("NW receive: \(error)")
                 return
             }
             if let data { Task { @MainActor in self.handleMessage(data) } }
@@ -151,7 +163,7 @@ final class RealtimeOmniService: NSObject {
         let ctx = NWConnection.ContentContext(identifier: "send", metadata: [meta])
         conn.send(content: Data(text.utf8), contentContext: ctx, isComplete: true,
                   completion: .contentProcessed { [weak self] error in
-            if let error { Task { @MainActor in self?.delegate?.omniDidError("NW send: \(error)") } }
+            if let error { self?.notifyError("NW send: \(error)") }
         })
     }
 
@@ -270,7 +282,7 @@ final class RealtimeOmniService: NSObject {
             switch result {
             case .failure(let error):
                 log("RealtimeOmni: receive failed: \(error)")
-                Task { @MainActor in self.delegate?.omniDidError(error.localizedDescription) }
+                notifyError(error.localizedDescription)
             case .success(let message):
                 let data: Data?
                 switch message {
@@ -309,7 +321,7 @@ final class RealtimeOmniService: NSObject {
             delegate?.omniDidFinishTurn()
         case "error":
             let msg = (e["error"] as? [String: Any])?["message"] as? String ?? "OpenAI realtime error"
-            delegate?.omniDidError(msg)
+            if !terminated { terminated = true; delegate?.omniDidError(msg) }
         default:
             break
         }
@@ -361,7 +373,7 @@ final class RealtimeOmniService: NSObject {
             return
         }
         task?.send(.string(text)) { [weak self] error in
-            if let error { Task { @MainActor in self?.delegate?.omniDidError(error.localizedDescription) } }
+            if let error { self?.notifyError(error.localizedDescription) }
         }
     }
 }
@@ -380,13 +392,13 @@ extension RealtimeOmniService: URLSessionWebSocketDelegate {
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask,
                     didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
         let r = reason.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-        Task { @MainActor in self.delegate?.omniDidError("WebSocket closed (\(closeCode.rawValue)) \(r)") }
+        notifyError("WebSocket closed (\(closeCode.rawValue)) \(r)")
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         log("RealtimeOmni: didComplete err=\(String(describing: error))")
         if let error {
-            Task { @MainActor in self.delegate?.omniDidError("WebSocket failed: \(error.localizedDescription)") }
+            notifyError("WebSocket failed: \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
## What

Fixes the two real bugs that made desktop PTT "press, unpress, nothing happens" (and then no chat reply) for both Gemini 3.1 Flash Live and GPT Realtime 2, on top of the merged omni feature (#7601).

### 1. Relay 403'd real (non-BYOK) users — `backend/routers/omni_relay.py`
The merged relay authed via FastAPI header DI, which came back empty for the desktop WS and rejected entitled users (e.g. Operator) → connection closed → "nothing happens". Now:
- **Manual + logged auth**: read the `Authorization` header directly and verify via `_verify_ws_auth` (same path as `/v4/listen`), with a connect log so auth/BYOK/provider are visible.
- **BYOK passthrough**: forwarded BYOK keys are validated and used (`get_byok_key(...) or platform key`), so BYOK users pay their own way.
- **Gate**: `is_trial_paywalled(uid, "desktop")` — un-entitled past-trial desktop users are paywalled, matching `/v4/listen`.

### 2. Multi-fire fallback tripped omi's own rate limiter — desktop
One PTT press could fire the transcript send / Deepgram fallback multiple times, hammering the chat endpoint and tripping the 30/min `GeminiRateLimiter` burst → `rate_limit_error` → no reply. Now single-fire:
- `RealtimeOmniService`: `terminated` flag so `omniDidError` fires at most once across receive-fail + didClose + didComplete.
- `PushToTalkManager`: `omniTurnSent` guard so a press sends at most one transcript / one fallback.

## Test
- Clean release build (`rm -rf .build && swift build -c release --triple arm64-apple-macosx`).
- Local named bundle against dev backend: full PTT loop (STT → chat → reply) verified for both Gemini Flash Live and GPT Realtime 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
