### PR TITLE
fix(backend): register missing conversations:from-segments rate-limit policy (unblocks deploys)

### DIFF
--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -39,6 +39,10 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "conversations:create": (10, 3600),
     "conversations:reprocess": (3, 3600),
     "conversations:merge": (5, 3600),
+    # From-segments: on-device-STT upload path (segments already transcribed, so
+    # cheaper than :create — no Deepgram, just LLM structuring). Used per finished
+    # conversation by Parakeet/local-STT users, so a bit more headroom than :create.
+    "conversations:from-segments": (30, 3600),
     # Chat — 2-6 LLM calls per message
     "chat:send_message": (120, 3600),
     "chat:initial": (60, 3600),


### PR DESCRIPTION
## Critical: unblocks all backend deploys

#7604 added the `POST /v1/conversations/from-segments` endpoint guarded by `with_rate_limit(..., "conversations:from-segments")`, but never added that policy to `RATE_POLICIES`. `with_rate_limit()` validates the policy name at **import time** and raises `ValueError: Unknown rate limit policy: conversations:from-segments` → uvicorn fails to load the app → the container never listens on PORT 8080 → **every backend deploy fails its health check** (prod + dev). Cloud Run kept serving the prior healthy revision, so there was no outage, but no backend change could ship.

## Fix
Register the policy: `"conversations:from-segments": (30, 3600)` — 30/hr, slightly more headroom than `conversations:create` (10/hr) since the segments are already transcribed on-device (no Deepgram, just LLM structuring), and it's the primary path for Parakeet/local-STT users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)