### PR TITLE
fix(desktop): Gemini PTT — buffer audio until activityStart (fixes close 1007)

### DIFF
--- a/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -48,6 +48,7 @@ final class RealtimeOmniService: NSObject {
     private var isOpen = false
     private var terminated = false  // fire omniDidError at most once per turn
     private var pendingAudio: [Data] = []
+    private var pendingCommit = false  // turn ended before the session opened; commit after activityStart
 
     // Gemini's Live endpoint resets BOTH of Apple's WebSocket stacks
     // (URLSession drops after the HTTP/2 upgrade; Network.framework gets
@@ -113,6 +114,7 @@ final class RealtimeOmniService: NSObject {
         nw = nil
         isOpen = false
         pendingAudio.removeAll()
+        pendingCommit = false
     }
 
     // MARK: - Network.framework transport (Gemini, HTTP/1.1 WebSocket)
@@ -172,6 +174,14 @@ final class RealtimeOmniService: NSObject {
     /// Feed mic PCM16 mono at `requiredInputSampleRate`. Caller is responsible for
     /// resampling to that rate (16k mic → 24k for OpenAI).
     func sendAudio(_ pcm: Data) {
+        // Buffer until the session is open. PTT starts the mic immediately and
+        // streams chunks during the connect handshake (plus a pre-connect buffer
+        // flush), so audio can arrive before setup completes. Gemini in manual-VAD
+        // mode rejects any audio that precedes `activityStart` with close 1007
+        // ("invalid argument") — markReady() sends activityStart and *then* flushes
+        // pendingAudio, so queuing here preserves that ordering. (The test harness
+        // only sends after omniDidConnect, so it never exercised this race.)
+        guard isOpen else { pendingAudio.append(pcm); return }
         let b64 = pcm.base64EncodedString()
         switch provider {
         case .gptRealtime2:
@@ -183,6 +193,10 @@ final class RealtimeOmniService: NSObject {
 
     /// Signal end of the user's PTT turn.
     func commitInputTurn() {
+        // If the turn ended before the session opened (very short press), defer the
+        // commit so it can't precede setup/activityStart — markReady() flushes it
+        // after the buffered audio, keeping the frame order activityStart→audio→end.
+        guard isOpen else { pendingCommit = true; return }
         switch provider {
         case .gptRealtime2:
             send(json: ["type": "input_audio_buffer.commit"])
@@ -360,6 +374,10 @@ final class RealtimeOmniService: NSObject {
         }
         for chunk in pendingAudio { sendAudio(chunk) }
         pendingAudio.removeAll()
+        if pendingCommit {
+            pendingCommit = false
+            commitInputTurn()
+        }
         delegate?.omniDidConnect()
     }
 

--- a/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
+++ b/desktop/Desktop/Sources/RealtimeOmni/RealtimeOmniTestHarness.swift
@@ -37,7 +37,16 @@ final class RealtimeOmniTestHarness: NSObject, RealtimeOmniServiceDelegate {
         let svc = RealtimeOmniService(
             provider: provider, relayBaseURL: relayBaseURL, authHeader: authHeader, sttOnly: true, delegate: self)
         service = svc
+        // Start streaming audio immediately — BEFORE the connection handshake
+        // completes — exactly like PushToTalkManager (mic starts on key-down and
+        // chunks flow during connect). This is what surfaces the Gemini
+        // audio-before-activityStart 1007 bug; sending only after omniDidConnect
+        // (as before) hid it. The service buffers until the session is open.
+        let rate = svc.requiredInputSampleRate
+        feed = rate == 16000 ? pcm16k : PushToTalkManager.resamplePCM16(pcm16k, from: 16000, to: rate)
+        sendIndex = 0
         svc.start()
+        pump()
         Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
             self?.finish(reason: "timeout")
@@ -49,10 +58,6 @@ final class RealtimeOmniTestHarness: NSObject, RealtimeOmniServiceDelegate {
 
     func omniDidConnect() {
         connected = true
-        let rate = service?.requiredInputSampleRate ?? 16000
-        feed = rate == 16000 ? pcm16k : PushToTalkManager.resamplePCM16(pcm16k, from: 16000, to: rate)
-        sendIndex = 0
-        pump()
     }
 
     private func pump() {


### PR DESCRIPTION
## Symptom
On the beta app, **GPT Realtime 2 PTT works but Gemini doesn't** — press, nothing happens. Dev relay logs show Google closing every Gemini connection with `1007 (invalid frame payload data) — Request contains an invalid argument`, so the relay drops → desktop falls back to Deepgram → "no transcript."

## Root cause
PTT starts the mic on key-down and streams chunks **during** the relay handshake (plus flushes a pre-connect buffer). `sendAudio()` sent immediately, so audio reached Gemini **before** `markReady()` sent `activityStart`. Gemini's manual-VAD mode (`automaticActivityDetection.disabled: true`) rejects audio that precedes `activityStart` with close 1007. GPT was unaffected (OpenAI buffers input server-side until commit).

The automation harness passed because it only sent audio in `omniDidConnect()` (after `activityStart`) — it never reproduced the live race.

## Fix
- `sendAudio()` and `commitInputTurn()` buffer until `isOpen`; `markReady()` flushes `pendingAudio` (and a deferred commit) **after** `activityStart`. Frame order is now always `setup → activityStart → audio → activityEnd`. Also recovers pre-connect chunks that were silently dropped (sent before `start()`).
- Harness now streams audio **during** connect like real PTT, so it actually exercises this race (regression guard).

## Test
Named dev bundle → dev relay, early-streaming harness (replicates PTT): **both providers transcribe**, dev relay shows no 1007. Gemini: ✅ "Hey Omi, what is the capital of France?"; GPT: ✅ same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)