### PR TITLE
feat(neo): mobile "Upgrade" button + desktop Neo no-desktop banner

### DIFF
--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -311,7 +311,8 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
       ),
       body: Consumer<UsageProvider>(
         builder: (context, provider, child) {
-          final hasAnyData = provider.todayUsage != null ||
+          final hasAnyData =
+              provider.todayUsage != null ||
               provider.monthlyUsage != null ||
               provider.yearlyUsage != null ||
               provider.allTimeUsage != null;
@@ -473,10 +474,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
                     : Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Text(
-                            context.l10n.upgradeToUnlimited,
-                            style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
-                          ),
+                          Text(context.l10n.upgrade, style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600)),
                           const SizedBox(width: 8),
                           const Icon(Icons.arrow_forward, size: 18),
                         ],
@@ -1058,7 +1056,10 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(value, style: TextStyle(fontSize: 36, fontWeight: FontWeight.bold, color: color, height: 1.1)),
+            Text(
+              value,
+              style: TextStyle(fontSize: 36, fontWeight: FontWeight.bold, color: color, height: 1.1),
+            ),
             const SizedBox(height: 12),
             Row(
               children: [
@@ -1141,8 +1142,8 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
                 builder: (context) {
                   final minutesUsed = (subscription.transcriptionSecondsUsed / 60).round();
                   final minutesLimit = (subscription.transcriptionSecondsLimit / 60).round();
-                  final percentage =
-                      (subscription.transcriptionSecondsUsed / subscription.transcriptionSecondsLimit).clamp(0.0, 1.0);
+                  final percentage = (subscription.transcriptionSecondsUsed / subscription.transcriptionSecondsLimit)
+                      .clamp(0.0, 1.0);
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -13,6 +13,11 @@ final class FloatingBarUsageLimiter: ObservableObject {
 
     @Published private(set) var hasPaidPlan: Bool = false
 
+    /// True when the user is on Neo (unlimited) without desktop access — Neo is a
+    /// mobile/web plan, so on desktop we surface a banner nudging them to Operator.
+    /// Grandfathered Neo subscribers (desktopGrandfatherUntil set) are excluded.
+    @Published private(set) var neoNeedsDesktopUpgrade: Bool = false
+
     /// Server-reported quota snapshot, plus an optimistic local delta for queries
     /// sent since the last server sync.
     private(set) var serverQuota: APIClient.ChatUsageQuota?
@@ -29,6 +34,15 @@ final class FloatingBarUsageLimiter: ObservableObject {
         do {
             let response = try await APIClient.shared.getUserSubscription()
             applyPlan(plan: response.subscription.plan, status: response.subscription.status)
+            // Neo (unlimited) has no desktop entitlement; show the upgrade banner
+            // unless this subscriber is grandfathered for the current period or is
+            // BYOK-active (BYOK users pay their own LLM/STT bill and the backend
+            // grants them desktop access, so the "upgrade to Operator" nudge would
+            // be wrong for them).
+            neoNeedsDesktopUpgrade =
+                response.subscription.plan == .unlimited
+                && response.desktopGrandfatherUntil == nil
+                && !APIKeyService.isByokActive
         } catch {
             log("FloatingBarUsageLimiter: failed to fetch plan: \(error.localizedDescription)")
         }
@@ -59,6 +73,7 @@ final class FloatingBarUsageLimiter: ObservableObject {
         serverQuota = nil
         optimisticDelta = 0
         hasPaidPlan = false
+        neoNeedsDesktopUpgrade = false
         UserDefaults.standard.removeObject(forKey: Self.cachedPlanKey)
     }
 

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -16,6 +16,7 @@ struct DesktopHomeView: View {
   @StateObject private var viewModelContainer = ViewModelContainer()
   @ObservedObject private var authState = AuthState.shared
   @ObservedObject private var apiKeyService = APIKeyService.shared
+  @ObservedObject private var usageLimiter = FloatingBarUsageLimiter.shared
   @State private var selectedIndex: Int = {
     if OMIApp.launchMode == .rewind { return SidebarNavItem.rewind.rawValue }
     let tier = UserDefaults.standard.integer(forKey: "currentTierLevel")
@@ -33,6 +34,8 @@ struct DesktopHomeView: View {
   @State private var previousIndexBeforeSettings: Int = 0
   @State private var logoPulse = false
   @State private var lastActivationRefresh = Date.distantPast
+  // Dismiss state for the Neo "no desktop access" banner (resets each launch).
+  @State private var neoDesktopBannerDismissed = false
 
   // Pre-loaded hero logo to avoid NSImage init crashes during SwiftUI body evaluation
   private static let heroLogoImage: NSImage? = {
@@ -668,6 +671,24 @@ struct DesktopHomeView: View {
       }
       .padding(14)
     }
+    .safeAreaInset(edge: .top, spacing: 0) {
+      if usageLimiter.neoNeedsDesktopUpgrade && !neoDesktopBannerDismissed {
+        NeoDesktopBanner(
+          onUpgrade: {
+            selectedSettingsSection = .planUsage
+            withAnimation(.easeInOut(duration: 0.2)) {
+              selectedIndex = SidebarNavItem.settings.rawValue
+            }
+          },
+          onDismiss: {
+            withAnimation(.easeInOut(duration: 0.2)) {
+              neoDesktopBannerDismissed = true
+            }
+          }
+        )
+        .transition(.move(edge: .top).combined(with: .opacity))
+      }
+    }
     .overlay {
       // Goal completion celebration overlay
       GoalCelebrationView()
@@ -781,6 +802,54 @@ struct DesktopHomeView: View {
       // but macOS restores the expanded window frame from the previous session.
       restorePreChatWindowWidth()
     }
+  }
+}
+
+/// Dismissible top banner shown when a Neo (unlimited) user opens the desktop app.
+/// Neo is a mobile/web plan with no desktop access; the CTA routes to Settings →
+/// Plan & Usage where the existing Operator upgrade flow lives.
+private struct NeoDesktopBanner: View {
+  var onUpgrade: () -> Void
+  var onDismiss: () -> Void
+
+  var body: some View {
+    HStack(spacing: 12) {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .scaledFont(size: 14, weight: .semibold)
+        .foregroundColor(OmiColors.warning)
+
+      Text("Neo doesn't include desktop access. Upgrade to Operator to use Omi on Mac.")
+        .scaledFont(size: 13, weight: .medium)
+        .foregroundColor(OmiColors.textPrimary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      Spacer(minLength: 12)
+
+      Button(action: onUpgrade) {
+        Text("Upgrade to Operator")
+          .scaledFont(size: 13, weight: .semibold)
+          .foregroundColor(.white)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 7)
+          .background(RoundedRectangle(cornerRadius: 8).fill(OmiColors.purplePrimary))
+      }
+      .buttonStyle(.plain)
+
+      Button(action: onDismiss) {
+        Image(systemName: "xmark")
+          .scaledFont(size: 12, weight: .semibold)
+          .foregroundColor(OmiColors.textSecondary)
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.horizontal, 18)
+    .padding(.vertical, 10)
+    .frame(maxWidth: .infinity)
+    .background(OmiColors.backgroundSecondary)
+    .overlay(
+      Rectangle().fill(OmiColors.border.opacity(0.4)).frame(height: 1),
+      alignment: .bottom
+    )
   }
 }
 


### PR DESCRIPTION
Part of deprecating **Neo** in the client UX.

### Mobile (Flutter)
- Insights/Plan usage page upgrade CTA now reads **"Upgrade"** (existing localized `upgrade` key) instead of "Upgrade to unlimited".

### Desktop (macOS Swift)
- When a **Neo (unlimited)** user opens the desktop app, show a **dismissible top banner**: *"Neo doesn't include desktop access. Upgrade to Operator to use Omi on Mac."* with an **Upgrade to Operator** button (routes to Settings → Plan & Usage, reusing the existing Operator checkout) and an ✕.
- `FloatingBarUsageLimiter` publishes `neoNeedsDesktopUpgrade` from the subscription it already fetches on launch (no extra API call).
- **Excludes** BYOK-active users (they pay their own LLM/STT bill and the backend grants them desktop access) and grandfathered Neo subscribers. **Fail-open**: an unknown/offline plan never shows the banner.

### Verification
- Mobile: localized key swap, no new strings.
- Desktop: clean release build; banner rendering visually verified in a running "Omi Dev" build (forced flag for the screenshot, then reverted). Confirmed it does **not** show for a non-Neo/BYOK account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)