### PR TITLE
fix(payments): hide Neo plan from mobile catalog for new/never-paid users

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -270,8 +270,11 @@ def get_available_plans_endpoint(
                 scheduled_price_id = price_map.get(scheduled_price_id, scheduled_price_id)
 
         current_plan = current_subscription.plan if current_subscription else PlanType.basic
+        ever_purchased = subscription_utils.has_ever_purchased(uid, current_subscription)
         pricing_options: List[PricingOption] = []
-        for definition in filter_plans_for_user(all_definitions, current_plan, platform=x_app_platform):
+        for definition in filter_plans_for_user(
+            all_definitions, current_plan, platform=x_app_platform, ever_purchased=ever_purchased
+        ):
             monthly_price_id = definition["monthly_price_id"]
             annual_price_id = definition["annual_price_id"]
             if monthly_price_id:

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -81,6 +81,7 @@ from utils.subscription import (
     neo_grandfather_until,
     reconcile_basic_plan_with_stripe,
     filter_plans_for_user,
+    has_ever_purchased,
     should_show_new_plans,
     adapt_plans_for_legacy_client,
     legacy_plan_features,
@@ -938,7 +939,10 @@ def get_user_subscription_endpoint(
     if not new_plans_enabled:
         all_definitions = adapt_plans_for_legacy_client(all_definitions)
     available_plans: List[SubscriptionPlan] = []
-    definitions_for_user = filter_plans_for_user(all_definitions, subscription.plan, platform=x_app_platform)
+    ever_purchased = has_ever_purchased(uid, raw_subscription)
+    definitions_for_user = filter_plans_for_user(
+        all_definitions, subscription.plan, platform=x_app_platform, ever_purchased=ever_purchased
+    )
     for definition in definitions_for_user:
         plan_prices: List[PricingOption] = []
         monthly_price_id = definition["monthly_price_id"]

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -73,6 +73,8 @@ def _compare_versions(a, b):
 
 
 _announcements_mod._compare_versions = _compare_versions
+# subscription.py imports the public name `compare_versions`.
+_announcements_mod.compare_versions = _compare_versions
 
 # database.users needs the functions payment.py imports by name
 _users_mod = sys.modules["database.users"]
@@ -88,6 +90,9 @@ for _attr in [
     "get_paypal_payment_details",
 ]:
     setattr(_users_mod, _attr, MagicMock())
+# has_ever_purchased() (via the available-plans endpoint) reads the Stripe
+# customer id; default to None so test users look like never-purchased.
+_users_mod.get_stripe_customer_id = MagicMock(return_value=None)
 
 # database.redis_db
 _redis_mod = sys.modules["database.redis_db"]
@@ -126,6 +131,7 @@ _stripe_utils.create_subscription_checkout_session = MagicMock()
 
 _endpoints_mod = sys.modules["utils.other.endpoints"]
 _endpoints_mod.get_current_user_uid = lambda: "test-user"
+_endpoints_mod.get_current_user_uid_no_byok_validation = lambda: "test-user"
 
 # Ensure utils.other has endpoints attr for `from utils.other import endpoints`
 sys.modules["utils.other"].endpoints = _endpoints_mod

--- a/backend/tests/unit/test_llm_usage_endpoints.py
+++ b/backend/tests/unit/test_llm_usage_endpoints.py
@@ -105,6 +105,7 @@ for attr in [
     "get_chat_quota_snapshot",
     "get_plan_display_name",
     "filter_plans_for_user",
+    "has_ever_purchased",
     "should_show_new_plans",
     "adapt_plans_for_legacy_client",
     "legacy_plan_features",

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -19,6 +19,10 @@ def _compare_versions(a, b):
 
 
 _announcements_mod._compare_versions = _compare_versions
+# subscription.py imports the public name `compare_versions`; expose it on the
+# mock too so this module runs standalone (not just inside the full suite where
+# the real database.announcements already loaded first).
+_announcements_mod.compare_versions = _compare_versions
 sys.modules.setdefault("database.users", types.SimpleNamespace())
 sys.modules.setdefault("database.user_usage", types.SimpleNamespace())
 sys.modules.setdefault("database.announcements", _announcements_mod)
@@ -104,6 +108,66 @@ def test_filter_plans_keeps_legacy_for_current_subscriber():
     assert 'unlimited' in plan_ids
     assert 'operator' in plan_ids
     assert 'architect' in plan_ids
+
+
+def test_filter_plans_hides_neo_on_mobile_for_new_user():
+    """New / never-paid mobile users don't see Neo (unlimited) in the catalog."""
+    from utils.subscription import get_paid_plan_definitions, filter_plans_for_user
+
+    definitions = get_paid_plan_definitions()
+    for platform in ('ios', 'android'):
+        filtered = filter_plans_for_user(definitions, PlanType.basic, platform=platform, ever_purchased=False)
+        plan_ids = [d['plan_id'] for d in filtered]
+        assert 'unlimited' not in plan_ids, platform
+        assert 'operator' in plan_ids
+        assert 'architect' in plan_ids
+
+
+def test_filter_plans_shows_neo_on_mobile_for_past_purchaser():
+    """Mobile users who have bought a plan before still see Neo (resubscribe)."""
+    from utils.subscription import get_paid_plan_definitions, filter_plans_for_user
+
+    definitions = get_paid_plan_definitions()
+    filtered = filter_plans_for_user(definitions, PlanType.basic, platform='ios', ever_purchased=True)
+    assert 'unlimited' in [d['plan_id'] for d in filtered]
+
+
+def test_filter_plans_shows_neo_on_mobile_for_current_neo_subscriber():
+    """Current Neo subscribers always see Neo even without ever_purchased flag."""
+    from utils.subscription import get_paid_plan_definitions, filter_plans_for_user
+
+    definitions = get_paid_plan_definitions()
+    filtered = filter_plans_for_user(definitions, PlanType.unlimited, platform='android', ever_purchased=False)
+    assert 'unlimited' in [d['plan_id'] for d in filtered]
+
+
+def test_filter_plans_keeps_neo_on_web_for_new_user():
+    """Web / unknown platform is unaffected — Neo stays in the catalog."""
+    from utils.subscription import get_paid_plan_definitions, filter_plans_for_user
+
+    definitions = get_paid_plan_definitions()
+    filtered = filter_plans_for_user(definitions, PlanType.basic, platform=None, ever_purchased=False)
+    assert 'unlimited' in [d['plan_id'] for d in filtered]
+
+
+def test_has_ever_purchased_signals(monkeypatch):
+    """Paid plan, stored stripe sub id, or a stripe customer id each count as purchased."""
+    import utils.subscription as sub_mod
+
+    monkeypatch.setattr(sub_mod.users_db, 'get_stripe_customer_id', lambda uid: None, raising=False)
+
+    paid = Subscription(plan=PlanType.operator, limits=PlanLimits())
+    assert sub_mod.has_ever_purchased('u', paid)
+
+    lapsed = Subscription(plan=PlanType.basic, stripe_subscription_id='sub_123', limits=PlanLimits())
+    assert sub_mod.has_ever_purchased('u', lapsed)
+
+    new_user = Subscription(plan=PlanType.basic, limits=PlanLimits())
+    assert not sub_mod.has_ever_purchased('u', new_user)
+
+    # No cheap signal on the subscription, but a stored Stripe customer id exists.
+    monkeypatch.setattr(sub_mod.users_db, 'get_stripe_customer_id', lambda uid: 'cus_123', raising=False)
+    assert sub_mod.has_ever_purchased('u', new_user)
 
 
 def test_legacy_client_adaptation():

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -307,37 +307,75 @@ LEGACY_PRICE_MAP = {
 }
 
 
+# Platform identifiers for the two mobile clients (X-App-Platform header).
+_MOBILE_PLATFORM_TOKENS = {'ios', 'android'}
+
+
 def _platform_hidden_plans(platform: Optional[str]) -> set:
     """Plans that are hidden from the purchase catalog for the given platform.
 
     Desktop (macOS) sells Operator + Architect (pricier tier with usage-based
-    overage on Operator), so Neo is dropped from the desktop picker. Mobile
-    and all other clients are left alone — their catalog is unchanged.
+    overage on Operator), so Neo is dropped from the desktop picker.
+
+    Mobile (ios/android): Neo is deprecated for new acquisition — it's hidden
+    from the purchase catalog on every mobile build so brand-new / never-paid
+    users only see Operator + Architect. Existing Neo subscribers and anyone
+    who has ever bought a plan are re-included by `filter_plans_for_user`'s
+    escapes, so their resubscribe / manage UI still works.
+
+    Web and any other client are left alone — their catalog is unchanged.
     """
-    if (platform or '').lower() == 'macos':
+    p = (platform or '').lower()
+    if p == 'macos' or p in _MOBILE_PLATFORM_TOKENS:
         return {PlanType.unlimited}
     return set()
+
+
+def has_ever_purchased(uid: str, subscription: Optional[Subscription] = None) -> bool:
+    """True if the user has ever gone through subscription checkout.
+
+    Used to keep the deprecated Neo plan visible on mobile to lapsed/returning
+    subscribers (so they can resubscribe) while hiding it from brand-new users
+    who never bought a plan. A Stripe customer id is created at first checkout
+    and persists across cancellations and plan changes; a current paid plan or
+    a stored stripe_subscription_id are cheaper positive signals checked first.
+    """
+    if subscription is not None:
+        if is_paid_plan(subscription.plan):
+            return True
+        if subscription.stripe_subscription_id:
+            return True
+    return bool(users_db.get_stripe_customer_id(uid))
 
 
 def filter_plans_for_user(
     definitions: list[dict],
     current_plan: PlanType,
     platform: Optional[str] = None,
+    ever_purchased: bool = False,
 ) -> list[dict]:
     """Drop legacy / platform-hidden plans from the purchase catalog.
 
     Subscribers already on a "wrong-platform" plan (e.g. a Neo subscriber
     opening the desktop app) still see their current plan so the management UI
-    works. Only the *purchase* catalog is filtered.
+    works. On mobile, Neo also stays visible to anyone who has ever purchased a
+    plan (`ever_purchased`) so lapsed subscribers can resubscribe — new /
+    never-paid users don't see it. Only the *purchase* catalog is filtered.
     """
     hidden = _platform_hidden_plans(platform)
+    is_mobile = (platform or '').lower() in _MOBILE_PLATFORM_TOKENS
     out: list[dict] = []
     for d in definitions:
         plan_type = d.get('plan_type')
         if d.get('legacy') and plan_type != current_plan:
             continue
         if plan_type in hidden and plan_type != current_plan:
-            continue
+            # Mobile-only escape: keep the deprecated Neo plan visible to users
+            # who have bought a plan before (so they can resubscribe/manage).
+            if is_mobile and plan_type == PlanType.unlimited and ever_purchased:
+                pass
+            else:
+                continue
         out.append(d)
     return out
 


### PR DESCRIPTION
Hide the **Neo** (`unlimited`) plan from the mobile purchase catalog for new / never-paid users, server-side. Desktop/macOS already hid Neo the same way.

### Behavior
`filter_plans_for_user` (in `backend/utils/subscription.py`) now drops Neo on **ios/android** (all builds), but keeps it visible to:
- **current Neo subscribers** (so their manage/resubscribe UI works), and
- **anyone who has ever purchased a plan** (`has_ever_purchased` → Stripe customer id / past subscription), so lapsed subscribers can resubscribe.

New / never-paid mobile users only see Operator + Architect. Web and other platforms are unchanged.

Both catalog endpoints pass `ever_purchased`: `GET /v1/payments/available-plans` and `GET /v1/users/me/subscription`.

### Tests
Added coverage in `test_subscription_restructure.py` (mobile hiding, past-purchaser/current-Neo escapes, web unaffected, `has_ever_purchased` signals) and fixed pre-existing stale mocks so the touched test files run standalone. Affected suites pass.

### Status
Already deployed to **dev** (`api.omiapi.com`) for verification. Prod takes effect on the next backend prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)