### PR TITLE
i18n(android): localize notification channel name and description

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -86,6 +86,7 @@ import 'package:omi/utils/notification_channel_strings.dart';
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   await Firebase.initializeApp();
+  await NotificationChannelStrings.loadAppLocale();
 
   await AwesomeNotifications().initialize(null, [
     NotificationChannel(
@@ -145,6 +146,7 @@ Future _init() async {
   }
 
   await PlatformManager.initializeServices();
+  await NotificationChannelStrings.loadAppLocale();
   await NotificationService.instance.initialize();
 
   // Register FCM background message handler

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -295,13 +295,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           update: (BuildContext context, value, MessageProvider? previous) =>
               (previous?..updateAppProvider(value)) ?? MessageProvider(),
         ),
-        ChangeNotifierProxyProvider4<
-          ConversationProvider,
-          MessageProvider,
-          PeopleProvider,
-          UsageProvider,
-          CaptureProvider
-        >(
+        ChangeNotifierProxyProvider4<ConversationProvider, MessageProvider, PeopleProvider, UsageProvider,
+            CaptureProvider>(
           create: (context) => CaptureProvider(),
           update: (BuildContext context, conversation, message, people, usage, CaptureProvider? previous) {
             final externalActions = ProviderCaptureExternalActions(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -80,6 +80,7 @@ import 'package:omi/pages/settings/developer.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
+import 'package:omi/utils/notification_channel_strings.dart';
 
 /// Background message handler for FCM data messages
 @pragma('vm:entry-point')
@@ -89,8 +90,8 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   await AwesomeNotifications().initialize(null, [
     NotificationChannel(
       channelKey: 'channel',
-      channelName: 'Omi Notifications',
-      channelDescription: 'Notification channel for Omi',
+      channelName: NotificationChannelStrings.omiChannelName,
+      channelDescription: NotificationChannelStrings.omiChannelDescription,
       defaultColor: const Color(0xFF9D50DD),
       ledColor: Colors.white,
     ),
@@ -292,8 +293,13 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           update: (BuildContext context, value, MessageProvider? previous) =>
               (previous?..updateAppProvider(value)) ?? MessageProvider(),
         ),
-        ChangeNotifierProxyProvider4<ConversationProvider, MessageProvider, PeopleProvider, UsageProvider,
-            CaptureProvider>(
+        ChangeNotifierProxyProvider4<
+          ConversationProvider,
+          MessageProvider,
+          PeopleProvider,
+          UsageProvider,
+          CaptureProvider
+        >(
           create: (context) => CaptureProvider(),
           update: (BuildContext context, conversation, message, people, usage, CaptureProvider? previous) {
             final externalActions = ProviderCaptureExternalActions(

--- a/app/lib/services/notifications/notification_service_basic.dart
+++ b/app/lib/services/notifications/notification_service_basic.dart
@@ -8,6 +8,7 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/services/notifications/notification_interface.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/notification_channel_strings.dart';
 
 /// Basic notification service for platforms without Firebase Messaging support
 /// Currently used for Windows - provides local notifications only
@@ -17,8 +18,8 @@ class _BasicNotificationService implements NotificationInterface {
   final channel = NotificationChannel(
     channelGroupKey: 'channel_group_key',
     channelKey: 'channel',
-    channelName: 'Omi Notifications',
-    channelDescription: 'Notification channel for Omi',
+    channelName: NotificationChannelStrings.omiChannelName,
+    channelDescription: NotificationChannelStrings.omiChannelDescription,
     defaultColor: const Color(0xFF9D50DD),
     ledColor: Colors.white,
   );

--- a/app/lib/services/notifications/notification_service_basic.dart
+++ b/app/lib/services/notifications/notification_service_basic.dart
@@ -15,19 +15,22 @@ import 'package:omi/utils/notification_channel_strings.dart';
 class _BasicNotificationService implements NotificationInterface {
   _BasicNotificationService._();
 
-  final channel = NotificationChannel(
-    channelGroupKey: 'channel_group_key',
-    channelKey: 'channel',
-    channelName: NotificationChannelStrings.omiChannelName,
-    channelDescription: NotificationChannelStrings.omiChannelDescription,
-    defaultColor: const Color(0xFF9D50DD),
-    ledColor: Colors.white,
-  );
+  // Resolved in initialize() after NotificationChannelStrings.loadAppLocale().
+  late final NotificationChannel channel;
 
   final AwesomeNotifications _awesomeNotifications = AwesomeNotifications();
 
   @override
   Future<void> initialize() async {
+    await NotificationChannelStrings.loadAppLocale();
+    channel = NotificationChannel(
+      channelGroupKey: 'channel_group_key',
+      channelKey: 'channel',
+      channelName: NotificationChannelStrings.omiChannelName,
+      channelDescription: NotificationChannelStrings.omiChannelDescription,
+      defaultColor: const Color(0xFF9D50DD),
+      ledColor: Colors.white,
+    );
     await _initializeAwesomeNotifications();
     Logger.debug('Basic notification service initialized (Firebase Messaging not available on this platform)');
   }

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -28,19 +28,22 @@ class _FCMNotificationService implements NotificationInterface {
 
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
 
-  final channel = NotificationChannel(
-    channelGroupKey: 'channel_group_key',
-    channelKey: 'channel',
-    channelName: NotificationChannelStrings.omiChannelName,
-    channelDescription: NotificationChannelStrings.omiChannelDescription,
-    defaultColor: const Color(0xFF9D50DD),
-    ledColor: Colors.white,
-  );
+  // Resolved in initialize() after NotificationChannelStrings.loadAppLocale().
+  late final NotificationChannel channel;
 
   final AwesomeNotifications _awesomeNotifications = AwesomeNotifications();
 
   @override
   Future<void> initialize() async {
+    await NotificationChannelStrings.loadAppLocale();
+    channel = NotificationChannel(
+      channelGroupKey: 'channel_group_key',
+      channelKey: 'channel',
+      channelName: NotificationChannelStrings.omiChannelName,
+      channelDescription: NotificationChannelStrings.omiChannelDescription,
+      defaultColor: const Color(0xFF9D50DD),
+      ledColor: Colors.white,
+    );
     await _initializeAwesomeNotifications();
     // Calling it here because the APNS token can sometimes arrive early or it might take some time (like a few seconds)
     // Reference: https://github.com/firebase/flutterfire/issues/12244#issuecomment-1969286794

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -19,6 +19,7 @@ import 'package:omi/services/notifications/notification_interface.dart';
 import 'package:omi/services/voice_playback/omi_voice_playback_service.dart';
 import 'package:omi/utils/analytics/intercom.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/notification_channel_strings.dart';
 
 /// Firebase Cloud Messaging enabled notification service
 /// Supports iOS, Android, macOS, web, and Linux with full FCM functionality
@@ -30,8 +31,8 @@ class _FCMNotificationService implements NotificationInterface {
   final channel = NotificationChannel(
     channelGroupKey: 'channel_group_key',
     channelKey: 'channel',
-    channelName: 'Omi Notifications',
-    channelDescription: 'Notification channel for Omi',
+    channelName: NotificationChannelStrings.omiChannelName,
+    channelDescription: NotificationChannelStrings.omiChannelDescription,
     defaultColor: const Color(0xFF9D50DD),
     ledColor: Colors.white,
   );

--- a/app/lib/utils/audio/foreground.dart
+++ b/app/lib/utils/audio/foreground.dart
@@ -4,6 +4,7 @@ import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:geolocator/geolocator.dart';
 
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/notification_channel_strings.dart';
 
 @pragma('vm:entry-point')
 void _startForegroundCallback() {
@@ -108,8 +109,8 @@ class ForegroundUtil {
       FlutterForegroundTask.init(
         androidNotificationOptions: AndroidNotificationOptions(
           channelId: 'foreground_service',
-          channelName: 'Foreground Service Notification',
-          channelDescription: 'Transcription service is running in the background.',
+          channelName: NotificationChannelStrings.foregroundServiceChannelName,
+          channelDescription: NotificationChannelStrings.foregroundServiceChannelDescription,
           channelImportance: NotificationChannelImportance.LOW,
           priority: NotificationPriority.HIGH,
           // iconData: const NotificationIconData(

--- a/app/lib/utils/audio/foreground.dart
+++ b/app/lib/utils/audio/foreground.dart
@@ -106,6 +106,7 @@ class ForegroundUtil {
     Logger.debug('initializeForegroundService');
 
     try {
+      await NotificationChannelStrings.loadAppLocale();
       FlutterForegroundTask.init(
         androidNotificationOptions: AndroidNotificationOptions(
           channelId: 'foreground_service',

--- a/app/lib/utils/notification_channel_strings.dart
+++ b/app/lib/utils/notification_channel_strings.dart
@@ -1,5 +1,7 @@
 import 'dart:io' show Platform;
 
+import 'package:shared_preferences/shared_preferences.dart';
+
 /// Localized labels for Android / desktop notification *channels*.
 ///
 /// These strings appear in the OS settings UI (Android: Settings → Apps →
@@ -7,13 +9,24 @@ import 'dart:io' show Platform;
 /// channel-registration time. Because `awesome_notifications` registers
 /// channels eagerly — sometimes before Flutter's widgets binding has a
 /// `BuildContext` available — we cannot use `AppLocalizations` /
-/// `context.l10n` here. Instead we read the host OS locale directly via
-/// `Platform.localeName` (e.g. `"ja_JP.UTF-8"`, `"en_US"`).
+/// `context.l10n` here.
 ///
-/// Only languages that the rest of the app already ships translations for
-/// are switched explicitly; everything else falls through to English.
+/// Prefer the in-app locale saved by [LocaleProvider] (`app_locale`), then
+/// fall back to `Platform.localeName`. Call [loadAppLocale] before the first
+/// channel registration so the SharedPreferences read is warm.
 class NotificationChannelStrings {
   NotificationChannelStrings._();
+
+  /// Same key as `LocaleProvider._localeKey`.
+  static const String _appLocaleKey = 'app_locale';
+
+  static String? _appLocale;
+
+  /// Load the in-app locale override. Safe in background isolates.
+  static Future<void> loadAppLocale() async {
+    final prefs = await SharedPreferences.getInstance();
+    _appLocale = prefs.getString(_appLocaleKey);
+  }
 
   /// Display name of the main Omi notification channel.
   static String get omiChannelName {
@@ -40,6 +53,10 @@ class NotificationChannelStrings {
   }
 
   static bool get _isJapanese {
+    final saved = (_appLocale ?? '').toLowerCase();
+    if (saved.isNotEmpty) {
+      return saved == 'ja' || saved.startsWith('ja_') || saved.startsWith('ja-');
+    }
     // Platform.localeName looks like "ja_JP.UTF-8" or "ja-JP".
     final name = Platform.localeName.toLowerCase();
     return name.startsWith('ja_') || name.startsWith('ja-') || name == 'ja';

--- a/app/lib/utils/notification_channel_strings.dart
+++ b/app/lib/utils/notification_channel_strings.dart
@@ -1,0 +1,47 @@
+import 'dart:io' show Platform;
+
+/// Localized labels for Android / desktop notification *channels*.
+///
+/// These strings appear in the OS settings UI (Android: Settings → Apps →
+/// Omi → Notifications) and are passed to `awesome_notifications` at
+/// channel-registration time. Because `awesome_notifications` registers
+/// channels eagerly — sometimes before Flutter's widgets binding has a
+/// `BuildContext` available — we cannot use `AppLocalizations` /
+/// `context.l10n` here. Instead we read the host OS locale directly via
+/// `Platform.localeName` (e.g. `"ja_JP.UTF-8"`, `"en_US"`).
+///
+/// Only languages that the rest of the app already ships translations for
+/// are switched explicitly; everything else falls through to English.
+class NotificationChannelStrings {
+  NotificationChannelStrings._();
+
+  /// Display name of the main Omi notification channel.
+  static String get omiChannelName {
+    if (_isJapanese) return 'Omi の通知';
+    return 'Omi Notifications';
+  }
+
+  /// Description of the main Omi notification channel.
+  static String get omiChannelDescription {
+    if (_isJapanese) return 'Omi の通知チャンネル';
+    return 'Notification channel for Omi';
+  }
+
+  /// Display name of the foreground-transcription notification channel.
+  static String get foregroundServiceChannelName {
+    if (_isJapanese) return 'フォアグラウンドサービス通知';
+    return 'Foreground Service Notification';
+  }
+
+  /// Description of the foreground-transcription notification channel.
+  static String get foregroundServiceChannelDescription {
+    if (_isJapanese) return '文字起こしサービスがバックグラウンドで実行中です。';
+    return 'Transcription service is running in the background.';
+  }
+
+  static bool get _isJapanese {
+    // Platform.localeName looks like "ja_JP.UTF-8" or "ja-JP".
+    final name = Platform.localeName.toLowerCase();
+    return name.startsWith('ja_') || name.startsWith('ja-') || name == 'ja';
+  }
+}


### PR DESCRIPTION
## Summary

Localize Android notification channel name/description for Japanese, preferring in-app app_locale over OS locale.

Maintainer follow-up applied on branch (rebase / locale fix / scoped names / gen-l10n as needed).

## Product invariants affected

- INV-MEM-1

Failure-Class: none