### PR TITLE
fix name speaker sheet setLoading setState after dismount crash

### DIFF
--- a/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
@@ -46,6 +46,7 @@ class _NameSpeakerBottomSheetState extends State<NameSpeakerBottomSheet> {
 
   void setLoading(bool value) {
     if (loading == value) return;
+    if (!mounted) return;
     setState(() {
       loading = value;
     });

--- a/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
@@ -373,7 +373,7 @@ class _NameSpeakerBottomSheetState extends State<NameSpeakerBottomSheet> {
               padding: const EdgeInsets.only(right: 8.0),
               child: Text(
                 context.l10n.managePeople,
-                style: TextStyle(
+                style: const TextStyle(
                   color: Colors.white70,
                   fontSize: 14,
                   decoration: TextDecoration.underline,


### PR DESCRIPTION
## Crash

`_NameSpeakerBottomSheetState.setLoading`

**Error:** `FlutterError - Null check operator used on a null value`
`package:omi/pages/conversation_detail/widgets/name_speaker_sheet.dart:46`

**Crashlytics:** https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/7bdba9d5e1a0c447879ff76136832aa5?time=7d&types=crash&sessionEventKey=c58779409a924ba5a2bf195c09125e1a_2223379907360506788

**Logs:**
```
Fatal Exception: FlutterError
0  ???  0x0 State.setState + 1219 (framework.dart:1219)
1  ???  0x0 _NameSpeakerBottomSheetState.setLoading + 49 (name_speaker_sheet.dart:49)
2  ???  0x0 _NameSpeakerBottomSheetState._buildSaveButton.<fn> + 458 (name_speaker_sheet.dart:458)
```

## Fix

`setLoading(false)` is called after `await widget.onSpeakerAssigned(...)` in the save button callback. If the bottom sheet is dismissed while that async operation is in flight, the widget is unmounted and Flutter's `setState` crashes on its internal `_element!` null check. Added `if (!mounted) return;` in `setLoading` before the `setState` call so it safely no-ops when the widget is already gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)