### PR TITLE
feat(phone): support clipboard paste on dialpad number display

### DIFF
--- a/app/lib/pages/phone_calls/phone_calls_page.dart
+++ b/app/lib/pages/phone_calls/phone_calls_page.dart
@@ -298,16 +298,20 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
                 // Invisible spacer to balance the backspace button
                 const SizedBox(width: 48),
                 Expanded(
-                  child: Text(
-                    hasDigits ? _dialpadController.text : context.l10n.phoneEnterNumber,
-                    textAlign: TextAlign.center,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: hasDigits ? (_dialpadController.text.length > 12 ? 24 : 32) : 20,
-                      fontWeight: FontWeight.w300,
-                      letterSpacing: hasDigits ? 2 : 0,
-                      color: hasDigits ? Colors.white : Colors.grey[600],
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onLongPressStart: (details) => _showPasteMenu(details.globalPosition),
+                    child: Text(
+                      hasDigits ? _dialpadController.text : context.l10n.phoneEnterNumber,
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: hasDigits ? (_dialpadController.text.length > 12 ? 24 : 32) : 20,
+                        fontWeight: FontWeight.w300,
+                        letterSpacing: hasDigits ? 2 : 0,
+                        color: hasDigits ? Colors.white : Colors.grey[600],
+                      ),
                     ),
                   ),
                 ),
@@ -415,6 +419,68 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
         }),
       ),
     );
+  }
+
+  /// Keep only dialpad-valid characters (digits, *, #) plus a leading +.
+  /// Strips spaces, dashes, parens, dots, and other formatting from pasted text
+  /// like "+1 (415) 555-1234" → "+14155551234".
+  String _sanitizePastedNumber(String input) {
+    final buf = StringBuffer();
+    var seenPlus = false;
+    for (var i = 0; i < input.length; i++) {
+      final ch = input[i];
+      if (ch == '+' && !seenPlus && buf.isEmpty) {
+        buf.write('+');
+        seenPlus = true;
+      } else if (ch.codeUnitAt(0) >= 0x30 && ch.codeUnitAt(0) <= 0x39) {
+        buf.write(ch);
+      } else if (ch == '*' || ch == '#') {
+        buf.write(ch);
+      }
+    }
+    return buf.toString();
+  }
+
+  Future<void> _showPasteMenu(Offset globalPosition) async {
+    HapticFeedback.lightImpact();
+    final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+    if (!mounted) return;
+
+    final raw = clipboardData?.text;
+    if (raw == null || raw.trim().isEmpty) return;
+
+    final sanitized = _sanitizePastedNumber(raw);
+    if (sanitized.isEmpty) return;
+
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox?;
+    if (overlay == null) return;
+
+    final selected = await showMenu<String>(
+      context: context,
+      color: const Color(0xFF2A2A2E),
+      position: RelativeRect.fromLTRB(
+        globalPosition.dx,
+        globalPosition.dy,
+        overlay.size.width - globalPosition.dx,
+        overlay.size.height - globalPosition.dy,
+      ),
+      items: [
+        PopupMenuItem<String>(
+          value: 'paste',
+          child: Text(
+            context.l10n.paste,
+            style: const TextStyle(color: Colors.white),
+          ),
+        ),
+      ],
+    );
+
+    if (selected == 'paste' && mounted) {
+      HapticFeedback.mediumImpact();
+      setState(() {
+        _dialpadController.text = sanitized;
+      });
+    }
   }
 
   /// Extracts the country code (e.g. "+1", "+91") from an E.164 phone number


### PR DESCRIPTION
## Summary
- Phone dialer's keypad tab had no way to paste a number — only digit-by-digit tap entry.
- Long-press on the number display now shows a Paste popup. Tap → pastes clipboard content into the dialpad.
- Pasted text is sanitized to keep `0-9`, `*`, `#`, and a leading `+`. Strips spaces, dashes, parens, dots, etc., so `+1 (415) 555-1234` becomes `+14155551234`.

## Notes
- Reuses existing `context.l10n.paste` key (already translated in all 49 ARBs from the vocabulary settings flow), so no l10n changes.
- Long-press is consistent with the existing convention on this screen (backspace button's long-press = clear-all).
- Haptic feedback: light tap on long-press, medium on successful paste.

## Test plan
- [ ] Copy "+1 (415) 555-1234" to clipboard, open dialer keypad, long-press the number display → "Paste" menu appears → tap → field shows "+14155551234"
- [ ] Copy a plain digits-only number → same flow → digits appear as-is
- [ ] Copy text with no digits ("hello world") → long-press → menu does not appear (sanitized empty)
- [ ] Empty clipboard → long-press → no menu
- [ ] Paste replaces any existing typed digits (matches iOS dialer behavior)