### PR TITLE
Bump build number to 900 for mobile release v1.0.538

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.534+835
+version: 1.0.538+900
 
 
 environment:


### PR DESCRIPTION
## Summary
- Bumps `app/pubspec.yaml` from `1.0.534+835` to `1.0.538+900`
- Required for mobile release: TestFlight is at build 898, Google Play internal at 899
- New build 900 is strictly greater than both store builds

## Deployment
Deploys automatically via Codemagic auto-deploy on merge to main. No manual steps required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)