### PR TITLE
fix transcription settings Map cast crash on non-String header values

### DIFF
--- a/app/lib/pages/settings/transcription_settings_page.dart
+++ b/app/lib/pages/settings/transcription_settings_page.dart
@@ -419,15 +419,15 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
     String? audioFieldName;
 
     if (requestJson != null && _requestJsonCustomized[_selectedProvider] == true) {
-      url = requestJson['url'];
-      requestType = requestJson['request_type'];
+      url = requestJson['url']?.toString();
+      requestType = requestJson['request_type']?.toString();
       headers = requestJson['headers'] is Map
           ? (requestJson['headers'] as Map).map((k, v) => MapEntry(k.toString(), v.toString()))
           : null;
       params = requestJson['params'] is Map
           ? (requestJson['params'] as Map).map((k, v) => MapEntry(k.toString(), v.toString()))
           : null;
-      audioFieldName = requestJson['audio_field_name'];
+      audioFieldName = requestJson['audio_field_name']?.toString();
     }
 
     // Use URL from text field for custom providers

--- a/app/lib/pages/settings/transcription_settings_page.dart
+++ b/app/lib/pages/settings/transcription_settings_page.dart
@@ -40,7 +40,6 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
   bool _showAdvanced = false;
   bool _showLogs = true;
   bool _isSaving = false;
-  Timer? _logRefreshTimer;
   String? _validationError;
 
   // On-device model download state

--- a/app/lib/pages/settings/transcription_settings_page.dart
+++ b/app/lib/pages/settings/transcription_settings_page.dart
@@ -421,8 +421,12 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
     if (requestJson != null && _requestJsonCustomized[_selectedProvider] == true) {
       url = requestJson['url'];
       requestType = requestJson['request_type'];
-      headers = requestJson['headers'] != null ? Map<String, String>.from(requestJson['headers']) : null;
-      params = requestJson['params'] != null ? Map<String, String>.from(requestJson['params']) : null;
+      headers = requestJson['headers'] is Map
+          ? (requestJson['headers'] as Map).map((k, v) => MapEntry(k.toString(), v.toString()))
+          : null;
+      params = requestJson['params'] is Map
+          ? (requestJson['params'] as Map).map((k, v) => MapEntry(k.toString(), v.toString()))
+          : null;
       audioFieldName = requestJson['audio_field_name'];
     }
 


### PR DESCRIPTION
## Crash

`_TranscriptionSettingsPageState._buildCurrentConfig`

**Error:** `FlutterError - type 'bool' is not a subtype of type 'String' in type cast`
`package:omi/pages/settings/transcription_settings_page.dart:293`

**Crashlytics:** https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/2a64d646629244fdf0a70944b67c5f0a?time=7d&types=crash&sessionEventKey=47d6a65f63404b37851550687c6f0d6c_2225897673128842280

**Logs:**
```
Fatal Exception: FlutterError
0  ???  0x0 new LinkedHashMap.from (dart:collection)
1  ???  0x0 _TranscriptionSettingsPageState._buildCurrentConfig + 425 (transcription_settings_page.dart:425)
2  ???  0x0 _TranscriptionSettingsPageState._saveCurrentProviderConfig + 394 (transcription_settings_page.dart:394)
3  ???  0x0 _TranscriptionSettingsPageState._buildProviderSection.<fn> + 1218 (transcription_settings_page.dart:1218)
4  ???  0x0 _DropdownButtonState._handleTap.<fn> + 1473 (dropdown.dart:1473)
```

## Fix

`Map<String, String>.from(requestJson['headers'])` does a hard cast of every value — if the user's saved JSON config has a non-string value in `headers` or `params` (e.g. `"keepAlive": true`, `"timeout": 30`), Dart throws a type cast error inside `LinkedHashMap.from`.

Replaced both `Map<String, String>.from(...)` calls with `.map((k, v) => MapEntry(k.toString(), v.toString()))`, which safely coerces any value type to a string. Also tightened the guard from `!= null` to `is Map` so it won't attempt the conversion if the field is a non-map type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)