### PR TITLE
fix action items stale index RangeError in updateActionItemDueDate revert

### DIFF
--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -320,18 +320,24 @@ class ActionItemsProvider extends ChangeNotifier {
         }
         _pushUpdateToAppleReminder(item, dueDate: dueDate);
       } else {
-        // Revert on failure
-        if (index != -1 && originalItem != null) {
-          _actionItems[index] = originalItem;
-          notifyListeners();
+        // Revert on failure — re-find index in case list changed during await
+        if (originalItem != null) {
+          final revertIdx = _actionItems.indexWhere((i) => i.id == item.id);
+          if (revertIdx != -1) {
+            _actionItems[revertIdx] = originalItem;
+            notifyListeners();
+          }
         }
         Logger.debug('Failed to update action item due date on server');
       }
     } catch (e) {
-      // Revert on error
-      if (index != -1 && originalItem != null) {
-        _actionItems[index] = originalItem;
-        notifyListeners();
+      // Revert on error — re-find index in case list changed during await
+      if (originalItem != null) {
+        final revertIdx = _actionItems.indexWhere((i) => i.id == item.id);
+        if (revertIdx != -1) {
+          _actionItems[revertIdx] = originalItem;
+          notifyListeners();
+        }
       }
       Logger.debug('Error updating action item due date: $e');
     }


### PR DESCRIPTION
## Crash

ActionItemsProvider.updateActionItemDueDate

FlutterError - RangeError (length): Invalid value: Valid value range is empty: 3

package:omi/providers/action_items_provider.dart

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/d90ecbfbbb09ebbe4a55c0a08a034316?time=7d&types=crash&sessionEventKey=cbdc14cb933e4f28b52514202667422a_2225757600315898109

Logs:

```
Fatal Exception: FlutterError
0  ???  0x0 ActionItemsProvider.updateActionItemDueDate (action_items_provider.dart)
```

## Fix

`index` was captured before `await api.updateActionItem(...)`. If `_actionItems` is modified during that await (e.g. user deletes items or list is refreshed), the stale `index` (e.g. 3) used in the catch/else revert blocks crashes with RangeError when the list now has fewer elements.

Both revert paths now re-find the item by ID with `indexWhere` after the await instead of using the pre-await index, matching the pattern already used in the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)