### PR TITLE
fix(app): keep conversation filter chips visible on empty filtered results

### DIFF
--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -133,6 +133,15 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
     return provider.conversations.where((c) => !c.discarded).length;
   }
 
+  // True when any conversation filter is active. When filters are on, the
+  // `conversations` list reflects filtered server results (e.g. an empty list
+  // when "Starred" + a folder yield no matches). Without this, the title and
+  // folder-tab chips would hide on empty filtered results, leaving no way to
+  // clear filters short of restarting the app.
+  bool _hasActiveFilter(ConversationProvider provider) {
+    return provider.showStarredOnly || provider.selectedFolderId != null || provider.selectedDate != null;
+  }
+
   Widget _buildNoConversationsHero(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(32, 0, 32, 120),
@@ -309,7 +318,8 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
               if (convoProvider.showDailySummaries ||
                   _nonDiscardedConversationCount(convoProvider) > 0 ||
                   convoProvider.isLoadingConversations ||
-                  convoProvider.isFetchingConversations)
+                  convoProvider.isFetchingConversations ||
+                  _hasActiveFilter(convoProvider))
                 SliverToBoxAdapter(
                   child: Builder(
                     builder: (context) => Padding(
@@ -329,11 +339,14 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                 ),
 
               // Folder tabs - hide when showing daily recaps OR when the user
-              // has no conversations yet (matches the title).
+              // has no conversations yet (matches the title). Keep chips
+              // visible whenever a filter is active so the user can always
+              // clear it, even when the filtered result is empty.
               if (!convoProvider.showDailySummaries &&
                   (_nonDiscardedConversationCount(convoProvider) > 0 ||
                       convoProvider.isLoadingConversations ||
-                      convoProvider.isFetchingConversations))
+                      convoProvider.isFetchingConversations ||
+                      _hasActiveFilter(convoProvider)))
                 Consumer2<FolderProvider, ConversationProvider>(
                   builder: (context, folderProvider, convoProvider, _) {
                     return SliverToBoxAdapter(
@@ -359,8 +372,7 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                   !convoProvider.isLoadingConversations &&
                   !convoProvider.isFetchingConversations &&
                   !convoProvider.isAwaitingInitialFetchRetry &&
-                  !convoProvider.showStarredOnly &&
-                  convoProvider.selectedFolderId == null)
+                  !_hasActiveFilter(convoProvider))
                 // Friendly hero for brand-new users with zero conversations —
                 // matches the polished Tasks empty state.
                 SliverFillRemaining(


### PR DESCRIPTION
## Summary
- Conversations page hid the section title and the folder/Starred chip row whenever the filtered result was empty, so combining filters (e.g. a folder + Starred) with no matches left the user with no way to clear the filter short of restarting the app.
- The guard for both rows checked `conversations.length > 0` only — once the filtered fetch came back empty, the chips vanished.
- This adds a small `_hasActiveFilter` helper (covers `showStarredOnly`, `selectedFolderId`, `selectedDate`) and ORs it into the title and folder-tabs visibility guards so the chips remain reachable whenever a filter is on.
- Also reuses the helper in the "no conversations yet" hero guard, which previously inlined only the starred + folder checks and would mistakenly show the brand-new-user hero when only a date filter yielded zero results.

## Test plan
- [ ] With one or more conversations, tap a folder chip → folder filter active, conversation list filters, chips stay visible.
- [ ] With folder filter on, tap Starred → if no starred conversation in that folder, empty-state copy shows AND both chips remain visible so the user can clear either filter.
- [ ] Clear both chips → list returns to default.
- [ ] Brand-new account with zero conversations and no filter active → still shows the "No conversations yet" hero (unchanged).
- [ ] With a date filter set and zero matches → empty-filter state shows (not the brand-new-user hero), chips visible.