### PR TITLE
app: fix keyboard flicker on conversation-detail search field

### DIFF
--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -1073,6 +1073,12 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
               // Floating bottom bar — hidden while keyboard is up (e.g. inline summary edit)
               if (MediaQuery.of(context).viewInsets.bottom == 0)
                 Positioned(
+                  // Stable key so the body Stack's collection-`if` diff matches
+                  // by identity, not by slot+type. Without it the surviving
+                  // search-overlay Positioned below was being reused into this
+                  // slot when the keyboard rose, tearing down the search
+                  // TextField subtree and dropping the IME mid-frame.
+                  key: const ValueKey('detail_floating_bottom_bar'),
                   bottom: 32,
                   left: 0,
                   right: 0,
@@ -1228,6 +1234,11 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
               // Search overlay
               if (_isSearching)
                 Positioned(
+                  // Stable key — same reason as the floating bottom bar above.
+                  // Without it the keyboard pop-up flickered closed because
+                  // the body Stack's diff was reusing this Positioned's
+                  // element into the bar's slot and remounting the TextField.
+                  key: const ValueKey('detail_search_overlay'),
                   top: 0,
                   left: 0,
                   right: 0,

--- a/app/test/widgets/stack_keyed_overlay_test.dart
+++ b/app/test/widgets/stack_keyed_overlay_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Reproduces the structural bug behind the keyboard-flicker on
+/// `conversation_detail/page.dart`: a body `Stack` whose two conditional
+/// children (a floating bottom bar that hides when the keyboard rises, and
+/// a search overlay that holds the search `TextField`) are both `Positioned`
+/// widgets with no `Key`.
+///
+/// When the bottom bar's `if` flips false, Flutter's element diff
+/// (`canUpdate == same runtimeType && same key`) walks the new children
+/// `[GD, SearchOverlay]` against the old `[GD, BottomBar, SearchOverlay]`
+/// and matches the surviving Positioned to the *first* slot it sees — the
+/// one previously held by BottomBar. The old SearchOverlay element at
+/// slot 2 is deactivated. That tears down the entire subtree below it,
+/// including the `TextField`'s `State`. In the real app this drops the
+/// `TextInputConnection` mid-frame and the soft keyboard collapses.
+///
+/// These tests assert that fact with a `_DisposeCounter` inside the
+/// "overlay" subtree — a buggy structure recreates its `State` when the
+/// sibling drops out; a keyed structure does not.
+
+class _DisposeCounter extends StatefulWidget {
+  const _DisposeCounter({required this.counter});
+  final _LifecycleLog counter;
+
+  @override
+  State<_DisposeCounter> createState() => _DisposeCounterState();
+}
+
+class _LifecycleLog {
+  int initCount = 0;
+  int disposeCount = 0;
+}
+
+class _DisposeCounterState extends State<_DisposeCounter> {
+  @override
+  void initState() {
+    super.initState();
+    widget.counter.initCount += 1;
+  }
+
+  @override
+  void dispose() {
+    widget.counter.disposeCount += 1;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(width: 10, height: 10);
+  }
+}
+
+/// Builds the same shape as the production body Stack:
+/// `[GestureDetector, if(showBar) Positioned(bar), if(showOverlay) Positioned(overlay)]`.
+/// `useKeys` toggles whether the two conditional children carry a stable
+/// `ValueKey` — i.e. the fix.
+Widget _buildHarness({
+  required bool showBar,
+  required bool showOverlay,
+  required _LifecycleLog overlayCounter,
+  required bool useKeys,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Stack(
+        children: [
+          GestureDetector(onTap: () {}, child: const SizedBox.expand()),
+          if (showBar)
+            Positioned(
+              key: useKeys ? const ValueKey('bar') : null,
+              bottom: 32,
+              left: 0,
+              right: 0,
+              child: const SizedBox(height: 40),
+            ),
+          if (showOverlay)
+            Positioned(
+              key: useKeys ? const ValueKey('overlay') : null,
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              // The Stack > Positioned > Container > SafeArea > _DisposeCounter
+              // shape mirrors the real search overlay's wrapper chain so the
+              // diff has the same depth as production.
+              child: Stack(
+                children: [
+                  Positioned(
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    child: Container(
+                      padding: const EdgeInsets.all(16),
+                      child: SafeArea(
+                        child: _DisposeCounter(counter: overlayCounter),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('without keys: removing the bottom-bar sibling tears down the overlay subtree', (tester) async {
+    final overlay = _LifecycleLog();
+
+    await tester.pumpWidget(_buildHarness(
+      showBar: true,
+      showOverlay: true,
+      overlayCounter: overlay,
+      useKeys: false,
+    ));
+    expect(overlay.initCount, 1, reason: 'overlay child should mount once');
+    expect(overlay.disposeCount, 0);
+
+    // Simulates the keyboard rising: bottom bar's `if` flips false. Overlay is
+    // still requested; production sees the same children-list collapse.
+    await tester.pumpWidget(_buildHarness(
+      showBar: false,
+      showOverlay: true,
+      overlayCounter: overlay,
+      useKeys: false,
+    ));
+
+    // The bug: Flutter reuses the bar's Positioned element for the overlay's
+    // new slot, deactivating the old overlay element. The overlay subtree is
+    // disposed and rebuilt — which in production hides the IME.
+    expect(overlay.disposeCount, 1, reason: 'buggy diff disposes the overlay subtree');
+    expect(overlay.initCount, 2, reason: 'and immediately remounts it (new State)');
+  });
+
+  testWidgets('with keys: removing the bottom-bar sibling preserves the overlay subtree', (tester) async {
+    final overlay = _LifecycleLog();
+
+    await tester.pumpWidget(_buildHarness(
+      showBar: true,
+      showOverlay: true,
+      overlayCounter: overlay,
+      useKeys: true,
+    ));
+    expect(overlay.initCount, 1);
+    expect(overlay.disposeCount, 0);
+
+    await tester.pumpWidget(_buildHarness(
+      showBar: false,
+      showOverlay: true,
+      overlayCounter: overlay,
+      useKeys: true,
+    ));
+
+    // With ValueKeys, the surviving overlay element is matched by key, not by
+    // slot+type, so its subtree is preserved. The TextField in production
+    // keeps its TextInputConnection → keyboard stays open.
+    expect(overlay.disposeCount, 0, reason: 'keyed diff keeps the overlay element');
+    expect(overlay.initCount, 1, reason: 'no remount');
+  });
+}


### PR DESCRIPTION
## Problem

Tapping the in-page search icon on the conversation detail page surfaces a search `TextField`. Tapping that `TextField` flashes the keyboard open, then immediately closes it again — sometimes oscillating until the user gives up.

## Root cause

The body Stack on `app/lib/pages/conversation_detail/page.dart` had three children:

1. `GestureDetector(...)` — always present
2. `if (MediaQuery.of(context).viewInsets.bottom == 0) Positioned(bottom: 32, ...)` — floating bottom bar, dropped while the keyboard is up
3. `if (_isSearching) Positioned(top: 0, bottom: 0, ...)` — search overlay, contains the `TextField`

Neither conditional child carried a `Key`. Sequence:

1. Tap search icon → `_isSearching = true`. Children are `[GD, BottomBar, SearchOverlay]`. `TextField` mounts at slot 2.
2. Tap `TextField` → focus request → keyboard rises.
3. `MediaQuery.viewInsets.bottom` jumps from 0 → ~300. The page rebuilds (line 1074 reads `MediaQuery.of(context)` inside `build`).
4. On rebuild the bottom bar's `if` is false; children collapse to `[GD, SearchOverlay]`.
5. Flutter's element diff (`canUpdate == same runtimeType && same key`) walks the new list against the old. Both surviving conditional widgets are keyless `Positioned`s → Flutter reuses the bar's old element for the new overlay slot and **deactivates the original overlay element**.
6. The old overlay subtree is disposed, so `_TextFieldState` → `EditableText.dispose()` → `_closeInputConnectionIfNeeded()` fires. The platform IME hides.
7. A brand-new `TextField` mounts at slot 1 and tries to reopen the connection — too late, the keyboard is already collapsing.

## Verification

`app/test/widgets/stack_keyed_overlay_test.dart` builds the same three-child Stack shape with a `_DisposeCounter` standing in for the `TextField` subtree:

- **Without keys**, after the bar's `if` flips false: `disposeCount == 1`, `initCount == 2`. The overlay subtree was disposed and remounted — exactly the production failure mode.
- **With keys**: `disposeCount == 0`, `initCount == 1`. Overlay element preserved across the collapse.

Both tests pass on this branch.

## Fix

Two-line change in `page.dart`: stable `ValueKey`s on the two conditional `Positioned` children so the diff matches by identity instead of slot+type.

```dart
if (MediaQuery.of(context).viewInsets.bottom == 0)
  Positioned(key: const ValueKey('detail_floating_bottom_bar'), ...),
if (_isSearching)
  Positioned(key: const ValueKey('detail_search_overlay'), ...),
```

## Test plan

- [x] `flutter test test/widgets/stack_keyed_overlay_test.dart` → 2 passed
- [x] `flutter test test/widgets/conversation_detail_copy_id_test.dart` (nearest existing test) → 4 passed, no regression
- [x] `flutter analyze lib/pages/conversation_detail/page.dart` clean (only pre-existing info-level lints)
- [ ] Manual on device: open a conversation → tap search → tap the TextField → keyboard opens and stays open while typing