### PR TITLE
fix(pusher): add missing pillow dependency to fix CrashLoopBackOff

### DIFF
--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -69,6 +69,9 @@ deepgram-sdk==4.8.1
 # Security & encryption
 cryptography==46.0.7
 
+# Image processing (via tools/__init__ -> file_tools -> chat_file -> PIL)
+pillow==12.2.0
+
 # Utilities
 python-dotenv==1.2.2
 tenacity==8.2.3


### PR DESCRIPTION
## Summary

Pusher pods are in CrashLoopBackOff after latest deploy — `ImportError: No module named 'PIL'`.

## Root Cause

**Import chain** (all at module-level, triggers on startup):
1. `pusher/main.py` → `routers/pusher.py` line 29: `from utils.conversations.process_conversation import process_conversation`
2. `process_conversation.py` line 83: `from utils.conversations.calendar_linking import ...`
3. `calendar_linking.py` line 14: `from utils.retrieval.tools.calendar_tools import ...`
4. Python initializes `utils/retrieval/tools/__init__.py` (package init)
5. `__init__.py` line 40: `from .file_tools import search_files_tool`
6. `file_tools.py` line 13: `from utils.other.chat_file import FileChatTool`
7. `chat_file.py` line 10: `from PIL import Image` → **ImportError**

Pillow is in `backend/requirements.txt` (used by main backend) but was never added to `backend/pusher/requirements.txt`.

## Who introduced what

| Date | Commit | Author | What |
|---|---|---|---|
| Nov 2025 | `cae828adb` | @beastoin | Added `file_tools` to `utils/retrieval/tools/__init__.py` |
| Feb 2025 | `19bb19b48` | @nquanq | Added `from PIL import Image` in `chat_file.py` |
| Dec 2025 | `2d2e18132` | @aaravgarg | Added `calendar_linking` import to `process_conversation.py` — **this created the chain from pusher to PIL** |

## Fix

Add `pillow==12.2.0` to `backend/pusher/requirements.txt` (matches main backend version).

## Test

- Old pusher pods still serving — no outage currently
- After merge, pusher redeploy will pick up the dependency

Fixes CrashLoopBackOff on pusher pods.

_by AI for @beastoin_