### PR TITLE
feat(parakeet): basic online speaker diarization (mobile)

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2972,7 +2972,7 @@ async def listen_handler(
         codec,
         channels,
         include_speech_profile,
-        None,
+        stt_service,  # pass the client's requested engine through (e.g. 'parakeet')
         conversation_timeout=conversation_timeout,
         source=source,
         custom_stt_mode=custom_stt_mode,

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -17,6 +17,7 @@ pytest tests/unit/test_voice_message_language.py -v
 pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_speaker_id_pipeline.py -v
 pytest tests/unit/test_user_speaker_embedding.py -v
+pytest tests/unit/test_parakeet_diarization.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
 pytest tests/unit/test_mcp_search_memories.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v

--- a/backend/tests/unit/test_parakeet_diarization.py
+++ b/backend/tests/unit/test_parakeet_diarization.py
@@ -1,0 +1,88 @@
+"""Unit tests for the basic online diarization in ParakeetStreamingSocket.
+
+The embedding service is mocked — these assert the clustering/fallback logic only
+(same voice -> same SPEAKER_N across windows, new voice -> new label, short or
+disabled clips fall back safely), not the hosted embedding model itself.
+"""
+
+import asyncio
+import os
+
+import numpy as np
+
+os.environ.setdefault('HOSTED_SPEAKER_EMBEDDING_API_URL', 'http://fake')  # enables _diarize
+os.environ.setdefault('DEEPGRAM_API_KEY', 'x')
+
+import utils.stt.streaming as st  # noqa: E402
+
+
+def _dir_vec(idx: int, rng) -> np.ndarray:
+    """A unit direction in dim `idx` plus small within-speaker noise -> (1, 256)."""
+    v = np.zeros((1, 256), np.float32)
+    v[0, idx] = 1.0
+    return v + 0.01 * rng.standard_normal((1, 256)).astype(np.float32)
+
+
+def _make_socket(diarize=True):
+    sock = st.ParakeetStreamingSocket(lambda segs: None, 'http://fake', 16000)
+    sock._diarize = diarize
+    return sock
+
+
+def _patch_embeddings(monkeypatch, seq):
+    calls = {'i': 0}
+
+    async def fake_embed(audio_data, filename="audio.wav"):
+        v = seq[calls['i']]
+        calls['i'] += 1
+        return v
+
+    monkeypatch.setattr(st, 'async_extract_embedding_from_bytes', fake_embed)
+    return calls
+
+
+def test_clusters_two_speakers_stably(monkeypatch):
+    rng = np.random.default_rng(0)
+    seq = [_dir_vec(0, rng), _dir_vec(0, rng), _dir_vec(1, rng), _dir_vec(0, rng), _dir_vec(1, rng)]
+    _patch_embeddings(monkeypatch, seq)
+    sock = _make_socket()
+    long_pcm = b'\x01\x00' * 16000  # 1s, above the 0.6s embed threshold
+
+    got = [asyncio.run(sock._assign_speaker(long_pcm)) for _ in range(5)]
+    assert got == [0, 0, 1, 0, 1]
+
+
+def test_short_clip_inherits_last_speaker_without_embedding(monkeypatch):
+    rng = np.random.default_rng(1)
+    calls = _patch_embeddings(monkeypatch, [_dir_vec(1, rng)])
+    sock = _make_socket()
+    asyncio.run(sock._assign_speaker(b'\x01\x00' * 16000))  # speaker 0 (first), consumes 1 call
+    before = calls['i']
+
+    short = b'\x01\x00' * (16000 // 10)  # 0.1s < 0.6s threshold
+    spk = asyncio.run(sock._assign_speaker(short))
+    assert spk == sock._last_speaker
+    assert calls['i'] == before  # no embedding call for a too-short clip
+
+
+def test_diarization_disabled_returns_zero():
+    sock = _make_socket(diarize=False)
+    assert asyncio.run(sock._assign_speaker(b'\x01\x00' * 16000)) == 0
+
+
+def test_embedding_failure_falls_back_to_last_speaker(monkeypatch):
+    async def boom(audio_data, filename="audio.wav"):
+        raise RuntimeError("embedding service down")
+
+    monkeypatch.setattr(st, 'async_extract_embedding_from_bytes', boom)
+    sock = _make_socket()
+    sock._last_speaker = 2
+    assert asyncio.run(sock._assign_speaker(b'\x01\x00' * 16000)) == 2  # never drops the segment
+
+
+def test_slice_pcm_bounds():
+    sock = _make_socket()
+    pcm = b'\x00\x00' * 16000  # 1s @ 16kHz int16
+    assert len(sock._slice_pcm(pcm, 0.0, 0.5)) == 16000  # 0.5s -> 8000 samples * 2 bytes
+    assert sock._slice_pcm(pcm, 0.9, 0.1) == b''  # inverted window -> empty
+    assert len(sock._slice_pcm(pcm, 0.5, 99.0)) == 16000  # clamps to buffer end

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -9,6 +9,7 @@ import wave as _wave
 from enum import Enum
 from typing import Callable, List, Optional
 
+import numpy as np
 import websockets
 from deepgram import DeepgramClient, DeepgramClientOptions, LiveTranscriptionEvents
 from deepgram.clients.live.v1 import LiveOptions
@@ -19,6 +20,11 @@ from utils.executors import sync_executor, run_blocking
 from utils.http_client import get_stt_client, get_stt_semaphore
 from utils.stt.safe_socket import KeepaliveConfig, SafeDeepgramSocket  # noqa: F401 — re-exported for backward compat
 from utils.stt.socket import STTSocket
+from utils.stt.speaker_embedding import (
+    SPEAKER_MATCH_THRESHOLD,
+    async_extract_embedding_from_bytes,
+    compare_embeddings,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -796,6 +802,16 @@ class ParakeetStreamingSocket(STTSocket):
         self._dead = False
         self._dead_reason: Optional[str] = None
 
+        # Basic online diarization: Parakeet returns no speaker info, so we embed each segment's
+        # voice (via the same hosted embedding service the listen pipeline uses downstream) and
+        # cluster into session-stable SPEAKER_N labels. Opt-in: only when that service is wired up.
+        self._diarize = bool(os.getenv('HOSTED_SPEAKER_EMBEDDING_API_URL')) and (
+            os.getenv('PARAKEET_DIARIZATION', '1') == '1'
+        )
+        self._spk_centroids: List[np.ndarray] = []  # running-mean embedding per discovered speaker
+        self._spk_counts: List[int] = []
+        self._last_speaker = 0  # reused for clips too short to embed / on transient embed failures
+
     def start(self):
         # Named + tracked so it's supervised/drained like the other WS-scoped tasks.
         self._pump_task = create_named_task(self._pump(), name="parakeet_stt_pump")
@@ -880,6 +896,52 @@ class ParakeetStreamingSocket(STTSocket):
         if segments:
             self._stream_transcript(segments)
 
+    async def _assign_speaker(self, seg_pcm: bytes) -> int:
+        """Cluster a segment's voice embedding into a session-stable speaker index.
+
+        Online greedy clustering: embed the clip, match it to the nearest known speaker
+        centroid (cosine < SPEAKER_MATCH_THRESHOLD) or start a new one. Falls back to the
+        previous speaker when diarization is off, the clip is too short to embed, or the
+        embedding service errs — so a transient failure never drops or mislabels the segment.
+        """
+        if not self._diarize:
+            return 0
+        # async_extract_embedding_from_bytes needs >= MIN_EMBEDDING_AUDIO_DURATION (0.5s); give a
+        # little margin. Shorter clips (back-channels, one-word turns) inherit the running speaker.
+        if len(seg_pcm) < int(self._sample_rate * 2 * 0.6):
+            return self._last_speaker
+        try:
+            wav = _pcm16_to_wav_bytes(seg_pcm, self._sample_rate)
+            emb = await async_extract_embedding_from_bytes(wav)
+        except Exception as e:
+            logger.warning(f"Parakeet diarization embed failed; reusing speaker {self._last_speaker}: {e}")
+            return self._last_speaker
+
+        best_i, best_dist = -1, 1e9
+        for i, centroid in enumerate(self._spk_centroids):
+            d = compare_embeddings(emb, centroid)
+            if d < best_dist:
+                best_i, best_dist = i, d
+
+        if best_i >= 0 and best_dist < SPEAKER_MATCH_THRESHOLD:
+            # Running-mean keeps the centroid stable as the speaker keeps talking.
+            n = self._spk_counts[best_i]
+            self._spk_centroids[best_i] = (self._spk_centroids[best_i] * n + emb) / (n + 1)
+            self._spk_counts[best_i] = n + 1
+            self._last_speaker = best_i
+            return best_i
+
+        self._spk_centroids.append(emb)
+        self._spk_counts.append(1)
+        self._last_speaker = len(self._spk_centroids) - 1
+        return self._last_speaker
+
+    def _slice_pcm(self, pcm: bytes, rel_start: float, rel_end: float) -> bytes:
+        """Window-relative [rel_start, rel_end] seconds → PCM16 byte slice (clamped)."""
+        b0 = max(0, int(rel_start * self._sample_rate) * 2)
+        b1 = min(len(pcm), int(rel_end * self._sample_rate) * 2)
+        return pcm[b0:b1] if b1 > b0 else b''
+
     async def _transcribe_chunk(self, pcm: bytes, start: float, dur: float) -> List[dict]:
         wav = _pcm16_to_wav_bytes(pcm, self._sample_rate)
         # Shared-secret auth for the (publicly-reachable) Parakeet endpoint.
@@ -900,20 +962,24 @@ class ParakeetStreamingSocket(STTSocket):
             text = (s.get('text') or '').strip()
             if not text:
                 continue
+            rel_start = float(s.get('start', 0.0))
+            rel_end = float(s.get('end', rel_start))
+            speaker = await self._assign_speaker(self._slice_pcm(pcm, rel_start, rel_end))
             out.append(
                 {
-                    'speaker': 'SPEAKER_0',
-                    'start': start + float(s.get('start', 0.0)),
-                    'end': start + float(s.get('end', 0.0)),
+                    'speaker': f'SPEAKER_{speaker}',
+                    'start': start + rel_start,
+                    'end': start + rel_end,
                     'text': text,
                     'is_user': False,
                     'person_id': None,
                 }
             )
         if not out and (data.get('text') or '').strip():
+            speaker = await self._assign_speaker(pcm)
             out.append(
                 {
-                    'speaker': 'SPEAKER_0',
+                    'speaker': f'SPEAKER_{speaker}',
                     'start': start,
                     'end': start + dur,
                     'text': data['text'].strip(),


### PR DESCRIPTION
## What
Adds **basic speaker diarization** to the opt-in Parakeet STT path. The Parakeet service returns text-only (no speaker info), so segments were all labeled `SPEAKER_0`. Now each segment's audio slice is embedded and clustered into session-stable `SPEAKER_N` labels — mainly for the **mobile cloud path** where a conversation has multiple speakers.

## How
- In `ParakeetStreamingSocket`, for each transcript segment, slice its audio out of the window and embed it via the **existing hosted speaker-embedding service** (`HOSTED_SPEAKER_EMBEDDING_API_URL`, `/v2/embedding`) — the same service the listen pipeline already uses downstream for person matching, so no new model/infra.
- Greedy online clustering: match the embedding to the nearest known speaker centroid (cosine `< SPEAKER_MATCH_THRESHOLD`, 0.45) or start a new speaker; centroids updated as a running mean for stability.
- Stable `SPEAKER_N` labels feed Omi's existing downstream `speaker_to_person_map` / embedding-based person identification unchanged.

## Opt-in & fail-safe
- Active only when `HOSTED_SPEAKER_EMBEDDING_API_URL` is set; `PARAKEET_DIARIZATION=0` disables. When off → previous behavior (`SPEAKER_0`).
- Clips too short to embed (<0.6s), embed errors, or disabled mode **fall back to the previous speaker** — a segment is never dropped or mislabeled by a transient failure.

## Tests
`tests/unit/test_parakeet_diarization.py` (mocked embedding service, added to `test.sh`): two-speaker clustering is stable across windows `[0,0,1,0,1]`, short clips inherit the last speaker without an embed call, disabled mode returns 0, embed failures fall back, PCM slicing clamps. **5 passed.**

> Note: the clustering/fallback logic is unit-verified; live end-to-end with the real embedding model + two real speakers through staging is the remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Also includes: routing pass-through fix
`listen_handler` was hardcoding `None` for `_listen`'s `stt_service` (regression lost in the main merge of #7645), leaving the merged Parakeet routing inert. Fixed to forward the client's query param — required for the engine to be selectable at all.

### ✅ Live end-to-end verified
Deployed to staging `backend-listen` and streamed a 2-distinct-voice sample through `wss://api.omiapi.com/v4/listen?...&stt_service=parakeet`:
```
[SPEAKER_0] Hey. Are you free to grab lunch tomorrow? ...project timeline.
[SPEAKER_1] Sure. Tomorrow works. How about noon? ...numbers from the report.
[SPEAKER_0] Noon is perfect. Let's meet at the cafe ...Main Street.
[SPEAKER_1] Great.
```
Distinct, cross-window-consistent speaker labels matching the real A/B/A/B turns.