### PR TITLE
fix(payments): existing subscribers can't switch plans (release attached schedule)

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -421,6 +421,35 @@ def create_checkout_session_endpoint(request: CreateCheckoutRequest, uid: str = 
     return {"url": session.url, "session_id": session.id}
 
 
+def _release_attached_schedules(stripe_sub: dict) -> None:
+    """Detach any active/not-started SubscriptionSchedule from this subscription.
+
+    Stripe rejects both Subscription.modify() and SubscriptionSchedule.create()
+    with "You cannot migrate a subscription that is already attached to a
+    schedule" once a schedule is attached — e.g. a user who earlier scheduled a
+    monthly→annual change. That left those users unable to change plans at all.
+    Releasing detaches the schedule without canceling the subscription (billing
+    continues on the current phase), which unblocks the new change. Mirrors the
+    release pattern already used by the cancel-subscription endpoint.
+    """
+    customer_id = stripe_sub.get('customer')
+    sub_id = stripe_sub.get('id')
+    if not customer_id or not sub_id:
+        return
+    try:
+        schedules = stripe.SubscriptionSchedule.list(customer=customer_id, limit=10)
+    except Exception as e:
+        logger.error(f"Error listing subscription schedules before plan change: {sanitize(str(e))}")
+        return
+    for schedule in schedules.data:
+        if schedule.status in ('active', 'not_started') and getattr(schedule, 'subscription', None) == sub_id:
+            try:
+                stripe.SubscriptionSchedule.release(schedule.id)
+                logger.info(f"Released subscription schedule {schedule.id} for {sub_id} before plan change")
+            except Exception as e:
+                logger.error(f"Error releasing subscription schedule {schedule.id}: {sanitize(str(e))}")
+
+
 @router.post('/v1/payments/upgrade-subscription')
 def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str = Depends(auth.get_current_user_uid)):
     """Upgrade or change a user's subscription plan.
@@ -470,6 +499,11 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
             if not promo_list.data:
                 raise HTTPException(status_code=400, detail="Invalid or expired promotion code.")
             resolved_promo_id = promo_list.data[0].id
+
+        # A previously-scheduled change (e.g. monthly→annual) leaves a schedule
+        # attached to the subscription, which Stripe then refuses to modify or
+        # re-schedule. Release it first so the user can switch plans again.
+        _release_attached_schedules(stripe_sub)
 
         # Cross-plan change (e.g. Unlimited→Architect): immediate swap with proration
         if current_plan != target_plan:

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -74,6 +74,20 @@ def test_upgrade_catches_stripe_invalid_request_error():
     assert "stripe.error.InvalidRequestError" in upgrade_section
 
 
+def test_upgrade_releases_attached_schedule_before_change():
+    """A subscription already attached to a schedule must be released before
+    Subscription.modify() / SubscriptionSchedule.create(), otherwise Stripe
+    rejects the change ("cannot migrate a subscription already attached to a
+    schedule") and the user can never switch plans."""
+    source = PAYMENT_SOURCE.read_text()
+    assert "def _release_attached_schedules" in source
+    upgrade_section = source[source.index("def upgrade_subscription_endpoint") :]
+    assert "_release_attached_schedules(stripe_sub)" in upgrade_section
+    release_pos = upgrade_section.index("_release_attached_schedules(stripe_sub)")
+    assert release_pos < upgrade_section.index("stripe.Subscription.modify"), "release must precede modify"
+    assert release_pos < upgrade_section.index("SubscriptionSchedule.create"), "release must precede schedule create"
+
+
 def test_checkout_catches_stripe_invalid_request_error():
     source = PAYMENT_SOURCE.read_text()
     checkout_start = source.index("def create_checkout_session_endpoint")
@@ -266,3 +280,44 @@ def test_checkout_no_promo_omits_promo_id():
     assert response.status_code == 200
     call_kwargs = router.stripe_utils.create_subscription_checkout_session.call_args
     assert call_kwargs[1].get("promotion_code_id") is None
+
+
+# --- _release_attached_schedules helper ---
+
+
+def test_release_attached_schedules_releases_only_matching_active():
+    """Releases active/not_started schedules attached to THIS subscription;
+    skips completed schedules and schedules for other subscriptions."""
+    client, router = _setup_payment_module()
+
+    sched_match = MagicMock(id="ss_active", status="active", subscription="sub_1")
+    sched_not_started = MagicMock(id="ss_pending", status="not_started", subscription="sub_1")
+    sched_other_sub = MagicMock(id="ss_other", status="active", subscription="sub_OTHER")
+    sched_completed = MagicMock(id="ss_done", status="completed", subscription="sub_1")
+
+    with patch.object(router.stripe, "SubscriptionSchedule") as mock_ss:
+        mock_ss.list.return_value = MagicMock(data=[sched_match, sched_not_started, sched_other_sub, sched_completed])
+        router._release_attached_schedules({"id": "sub_1", "customer": "cus_1"})
+
+    mock_ss.list.assert_called_once_with(customer="cus_1", limit=10)
+    released = {c.args[0] for c in mock_ss.release.call_args_list}
+    assert released == {"ss_active", "ss_pending"}
+
+
+def test_release_attached_schedules_noop_without_customer():
+    """No customer/sub id -> no Stripe calls (defensive)."""
+    client, router = _setup_payment_module()
+    with patch.object(router.stripe, "SubscriptionSchedule") as mock_ss:
+        router._release_attached_schedules({"id": "sub_1"})  # missing customer
+        router._release_attached_schedules({"customer": "cus_1"})  # missing id
+    mock_ss.list.assert_not_called()
+
+
+def test_release_attached_schedules_swallows_list_errors():
+    """A Stripe failure while listing schedules must not break the upgrade."""
+    client, router = _setup_payment_module()
+    with patch.object(router.stripe, "SubscriptionSchedule") as mock_ss:
+        mock_ss.list.side_effect = Exception("stripe down")
+        # Should not raise
+        router._release_attached_schedules({"id": "sub_1", "customer": "cus_1"})
+    mock_ss.release.assert_not_called()


### PR DESCRIPTION
## Problem
Users on mobile **and** desktop reported that **if there is/was an existing subscription, it's impossible to switch to another plan**.

## Root cause (evidenced in prod logs)
Both clients route an active subscriber's plan change through `POST /v1/payments/upgrade-subscription`. Once a user has *ever* made a scheduled change (e.g. monthly→annual, which creates a `SubscriptionSchedule` at `payment.py` ~L509), the subscription stays **attached to that schedule**, and Stripe then rejects every subsequent change:

```
Stripe rejected subscription change: You cannot migrate a subscription
that is already attached to a schedule: `sub_…`
```

Prod backend logs (last 30d): **33** failed `/upgrade-subscription` calls, the dominant cause being this schedule-attachment error, recurring across multiple subscriptions.

## Fix
Before applying the change, release any active/not-started `SubscriptionSchedule` attached to the subscription (`_release_attached_schedules`). Releasing **detaches** the schedule without canceling the subscription (billing continues on the current phase), which unblocks both the cross-plan `Subscription.modify()` and the same-interval `SubscriptionSchedule.create()`. This mirrors the release pattern the cancel-subscription endpoint already uses.

## Tests
`tests/unit/test_payment_promotion_codes.py`: release runs before modify/create; releases only active/not-started schedules for *this* subscription; no-ops without customer/sub id; swallows Stripe list errors. All payment/subscription unit suites pass (16 + 5 + 23 + 3).

## Follow-ups (not in this PR)
- **Mobile, annual subscribers**: `plans_sheet.dart` shows annual users *"You're on the Annual Plan — No changes needed"* with no plan options (leftover from the single-tier era) — they can't initiate a tier switch at all. Needs a Flutter change + verification with an annual-subscriber account.
- Two minor backend log causes: a stale/legacy `price_id` from the client ("unknown plan", 4×) and one user whose stored `stripe_subscription_id` is a `pm_…` id (data repair).

🤖 Generated with [Claude Code](https://claude.com/claude-code)