### PR TITLE
feat(mcp): expose user profile via Omi MCP (get_user_profile)

### DIFF
--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 import database.memories as memories_db
 import database.conversations as conversations_db
+import database.users as users_db
 
 # from database.redis_db import get_filter_category_items
 # from database.vector_db import query_vectors_by_metadata
@@ -93,6 +94,24 @@ def edit_memory(memory_id: str, value: str, uid: str = Depends(get_uid_from_mcp_
     except Exception:
         logger.exception("Vector upsert failed uid=%s memory_id=%s (memory edited, vector stale)", uid, memory_id)
     return {"status": "ok"}
+
+
+class UserProfile(BaseModel):
+    profile_text: Optional[str] = None
+    generated_at: Optional[str] = None
+    data_sources_used: Optional[int] = None
+
+
+@router.get("/v1/mcp/profile", tags=["mcp"], response_model=UserProfile)
+def get_user_profile(uid: str = Depends(get_uid_from_mcp_api_key)):
+    """The user's consolidated, always-current profile. Read this first for facts about the user."""
+    profile = users_db.get_ai_user_profile(uid) or {}
+    generated_at = profile.get("generated_at")
+    return UserProfile(
+        profile_text=profile.get("profile_text"),
+        generated_at=str(generated_at) if generated_at is not None else None,
+        data_sources_used=profile.get("data_sources_used"),
+    )
 
 
 class CleanerMemory(BaseModel):

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -24,6 +24,7 @@ import database.conversations as conversations_db
 import database.mcp_api_key as mcp_api_key_db
 import database.vector_db as vector_db
 import database.x_posts as x_posts_db
+import database.users as users_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from utils.conversations.render import redact_conversation_for_list
 from models.conversation_enums import CategoryEnum
@@ -115,6 +116,18 @@ def invalid_mcp_auth_exception(
 
 # MCP Tool Definitions
 MCP_TOOLS = [
+    {
+        "name": "get_user_profile",
+        "description": (
+            "Get the user's profile — a single consolidated, always-current summary of who the user is "
+            "(identity, contacts, work, projects, tools, preferences, and current goals). This is the most "
+            "complete and authoritative source of facts about the user. ALWAYS call this first when you need "
+            "any context about the user, before searching individual memories or conversations."
+        ),
+        "annotations": READ_ONLY_ANNOTATIONS,
+        "securitySchemes": MEMORIES_READ_SECURITY,
+        "inputSchema": {"type": "object", "properties": {}},
+    },
     {
         "name": "get_memories",
         "description": "Retrieve a list of memories. A memory is a known fact about the user across multiple domains.",
@@ -323,7 +336,17 @@ class ToolExecutionError(Exception):
 def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
     """Execute an MCP tool and return the result. Raises ToolExecutionError on failure."""
 
-    if tool_name == "get_memories":
+    if tool_name == "get_user_profile":
+        profile = users_db.get_ai_user_profile(user_id)
+        if not profile or not profile.get("profile_text"):
+            return {"profile": None, "message": "No profile has been generated for this user yet."}
+        return {
+            "profile_text": profile.get("profile_text"),
+            "generated_at": profile.get("generated_at"),
+            "data_sources_used": profile.get("data_sources_used"),
+        }
+
+    elif tool_name == "get_memories":
         categories = arguments.get("categories", [])
         limit = arguments.get("limit", 100)
         offset = arguments.get("offset", 0)
@@ -616,6 +639,13 @@ def handle_mcp_message(
                     "protocolVersion": "2025-03-26",
                     "capabilities": {"tools": {}},
                     "serverInfo": {"name": "omi-mcp-server", "version": "1.0.0"},
+                    "instructions": (
+                        "This server exposes the user's Omi memory (their personal AI memory bank). "
+                        "A consolidated, always-current user profile is available via the `get_user_profile` "
+                        "tool — consult it FIRST for any question about who the user is (identity, contacts, "
+                        "work, projects, preferences, goals) before falling back to `search_memories` or "
+                        "`get_memories` for finer-grained or historical details."
+                    ),
                 },
             ),
             new_session_id,


### PR DESCRIPTION
## What
Surfaces the user's consolidated profile (`ai_user_profile`) through the Omi MCP so connecting clients (Hermes, Claude, ChatGPT, etc.) read the canonical, always-current user profile instead of browsing recency-windowed memories.

### Problem
The profile was readable via `GET /v1/users/ai-profile` but **invisible to the MCP**. MCP clients only had `get_memories` (recency-N) and `search_memories`, so a generic "what do you know about me" lookup missed stable identity facts (DOB, phone, address) that exist but fall outside the recency window. The always-injected profile was never exposed to the MCP path.

### Changes
- **`get_user_profile` MCP tool** (`mcp_sse.py`) — returns `profile_text` + `generated_at` + `data_sources_used`, described as the authoritative "consult first" source.
- **`instructions` on MCP `initialize`** — every connecting client is told a consolidated profile exists and to read it before falling back to memory search.
- **`GET /v1/mcp/profile`** REST endpoint (`mcp.py`) — REST parity for the hosted-wrapper / direct REST clients.

Purely additive. No changes to existing tools or storage.

### Source of the profile
`ai_user_profile` is generated client-side by the desktop app (`AIUserProfileService`) and synced via `PATCH /v1/users/ai-profile`. It auto-regenerates daily (>24h) while the desktop app runs.

### Verification
- `py_compile` + `black` clean
- AST-verified wiring: tool advertised in `tools/list`, execute branch present, `instructions` on initialize, REST route registered
- Data read hits the same `users/{uid}.ai_user_profile` field confirmed present in prod
- Live end-to-end MCP call requires a backend deploy (separate step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)