### PR TITLE
feat(memories): constantly-updated brain — temporal supersession, hybrid retrieval, re-embed-on-edit

### DIFF
--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -71,6 +71,7 @@ def get_memories(
     categories: List[str] = [],
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
+    include_invalidated: bool = False,
 ):
     logger.info(f'get_memories db {uid} {limit} {offset} {categories} {start_date} {end_date}')
     memories_ref = db.collection(users_collection).document(uid).collection(memories_collection)
@@ -94,7 +95,14 @@ def get_memories(
     # TODO: put user review to firestore query
     memories = [doc.to_dict() for doc in memories_ref.stream()]
     logger.info(f"get_memories {len(memories)}")
-    result = [memory for memory in memories if memory.get('user_review') is not False]
+    # Exclude user-rejected memories, and (by default) superseded/retracted ones.
+    # invalid_at is filtered in Python: old docs lack the field (-> None -> active),
+    # which a Firestore `== None` filter would wrongly drop.
+    result = [
+        memory
+        for memory in memories
+        if memory.get('user_review') is not False and (include_invalidated or memory.get('invalid_at') is None)
+    ]
     return result
 
 
@@ -245,6 +253,27 @@ def edit_memory(uid: str, memory_id: str, value: str):
         content = encryption.encrypt(content, uid)
 
     memory_ref.update({'content': content, 'edited': True, 'updated_at': datetime.now(timezone.utc)})
+
+
+def invalidate_memory(
+    uid: str, memory_id: str, superseded_by: Optional[str] = None, invalid_at: Optional[datetime] = None
+):
+    """Soft-invalidate a memory that has been superseded or retracted.
+
+    Unlike delete_memory this keeps the document (history) but stamps invalid_at so
+    every retrieval path excludes it — the "constantly updated brain" stops surfacing
+    a fact the moment it stops being true. Callers should also drop the Pinecone vector
+    so the memory disappears from semantic search too.
+    """
+    if invalid_at is None:
+        invalid_at = datetime.now(timezone.utc)
+    user_ref = db.collection(users_collection).document(uid)
+    memories_ref = user_ref.collection(memories_collection)
+    memory_ref = memories_ref.document(memory_id)
+    update_payload = {'invalid_at': invalid_at, 'updated_at': datetime.now(timezone.utc)}
+    if superseded_by is not None:
+        update_payload['superseded_by'] = superseded_by
+    memory_ref.update(update_payload)
 
 
 def delete_memory(uid: str, memory_id: str):

--- a/backend/models/memories.py
+++ b/backend/models/memories.py
@@ -127,9 +127,25 @@ class MemoryDB(Memory):
     is_locked: bool = False
     kg_extracted: bool = False
 
+    # Temporal lifecycle — the "constantly updated brain". All optional, so existing
+    # docs (which lack these fields) read back as active with no migration.
+    #   valid_at:      when the fact became true (defaults to created_at)
+    #   invalid_at:    when the fact stopped being true; None == currently active.
+    #                  A superseded/retracted memory is invalidated (not deleted) so
+    #                  history is kept, but it is excluded from every retrieval path.
+    #   superseded_by: id of the newer memory that replaced this one (if any).
+    valid_at: Optional[datetime] = None
+    invalid_at: Optional[datetime] = None
+    superseded_by: Optional[str] = None
+
     def __init__(self, **data):
         super().__init__(**data)
         self.memory_id = self.conversation_id
+
+    @property
+    def is_active(self) -> bool:
+        """A memory is active (currently true) until it is invalidated."""
+        return self.invalid_at is None
 
     @staticmethod
     def calculate_score(memory: 'MemoryDB') -> 'MemoryDB':
@@ -143,14 +159,16 @@ class MemoryDB(Memory):
 
     @staticmethod
     def from_memory(memory: Memory, uid: str, conversation_id: str, manually_added: bool) -> 'MemoryDB':
+        now = datetime.now(timezone.utc)
         memory_db = MemoryDB(
             id=document_id_from_seed(memory.content),
             uid=uid,
             content=memory.content,
             category=memory.category,
             tags=memory.tags,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=now,
+            updated_at=now,
+            valid_at=now,
             conversation_id=conversation_id,
             manually_added=manually_added,
             user_review=True if manually_added else None,

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -18,6 +18,7 @@ from models.conversation_enums import CategoryEnum
 from utils.conversations.render import populate_speaker_names, redact_conversations_for_list
 from utils.apps import update_personas_async
 from utils.llm.memories import identify_category_for_memory
+from utils.retrieval.hybrid import rrf_rerank
 from dependencies import get_uid_from_mcp_api_key, get_current_user_id
 from utils.other.endpoints import with_rate_limit
 from utils.log_sanitizer import sanitize_pii
@@ -121,23 +122,39 @@ def search_memories(
     scores = {m.get("memory_id"): m.get("score", 0) for m in matches}
     if not memory_ids:
         return []
-    memories_data = memories_db.get_memories_by_ids(uid, memory_ids)
-    results = []
-    for m in memories_data:
-        if m.get('user_review') is False:
+    docs = {m.get("id"): m for m in memories_db.get_memories_by_ids(uid, memory_ids)}
+
+    # Build candidates in vector-relevance order, excluding rejected / locked / superseded
+    # memories so the brain never returns a fact that is no longer true.
+    candidates = []
+    for mid in memory_ids:
+        m = docs.get(mid)
+        if not m:
             continue
-        if m.get('is_locked', False):
+        if m.get('user_review') is False or m.get('is_locked', False) or m.get('invalid_at') is not None:
             continue
-        results.append(
+        candidates.append(
             {
                 "id": m.get("id", ""),
                 "content": m.get("content", ""),
                 "category": m.get("category", "other"),
-                "relevance_score": round(scores.get(m.get("id"), 0), 4),
+                "vector_score": scores.get(mid, 0),
             }
         )
-    results.sort(key=lambda x: x["relevance_score"], reverse=True)
-    return results[:limit]
+
+    # Order by semantic score first (RRF uses this as the vector rank), then fuse with
+    # keyword (BM25) ranking so exact-keyword lookups surface reliably.
+    candidates.sort(key=lambda c: c.get("vector_score", 0), reverse=True)
+    reranked = rrf_rerank(query, candidates, limit)
+    return [
+        {
+            "id": c["id"],
+            "content": c["content"],
+            "category": c["category"],
+            "relevance_score": round(c.get("vector_score", 0), 4),
+        }
+        for c in reranked
+    ]
 
 
 @router.get("/v1/mcp/memories", tags=["mcp"], response_model=List[CleanerMemory])

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -208,8 +208,15 @@ def edit_memory(
     value: str,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:modify")),
 ):
-    _validate_memory(uid, memory_id)
+    memory = _validate_memory(uid, memory_id)
     memories_db.edit_memory(uid, memory_id, value)
+    # Re-embed so semantic search reflects the new content. Without this the Pinecone
+    # vector keeps matching the OLD text — a silent staleness bug that breaks the
+    # "constantly updated brain" (search would still surface the pre-edit fact).
+    try:
+        upsert_memory_vector(uid, memory_id, value, memory.get('category', 'system'))
+    except Exception:
+        logger.exception("Vector upsert failed uid=%s memory_id=%s (memory edited, vector stale)", uid, memory_id)
     return {'status': 'ok'}
 
 

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -20,6 +20,7 @@ pytest tests/unit/test_user_speaker_embedding.py -v
 pytest tests/unit/test_parakeet_diarization.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
 pytest tests/unit/test_mcp_search_memories.py -v
+pytest tests/unit/test_memory_temporal_brain.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v
 pytest tests/unit/test_llm_usage_db.py -v

--- a/backend/tests/unit/test_mcp_search_memories.py
+++ b/backend/tests/unit/test_mcp_search_memories.py
@@ -275,6 +275,47 @@ class TestSearchMemoriesUserReview:
         assert result == []
 
 
+class TestSearchMemoriesInvalidated:
+    """search_memories must not surface superseded/invalidated memories — the brain
+    only returns facts that are currently true."""
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_invalidated_memory_excluded(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-old', 'score': 0.95},
+            {'memory_id': 'mem-new', 'score': 0.80},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            # superseded "loves ice cream" — higher vector score but invalidated
+            {
+                'id': 'mem-old',
+                'content': 'loves ice cream',
+                'category': 'system',
+                'is_locked': False,
+                'invalid_at': '2026-06-01T00:00:00+00:00',
+                'superseded_by': 'mem-new',
+            },
+            {'id': 'mem-new', 'content': 'hates ice cream', 'category': 'system', 'is_locked': False},
+        ]
+        result = search_memories(query="ice cream", limit=10, uid="user-1")
+        assert len(result) == 1
+        assert result[0]['id'] == 'mem-new'
+
+    @patch('routers.mcp.memories_db')
+    @patch('routers.mcp.vector_db')
+    def test_active_memory_with_null_invalid_at_included(self, mock_vector_db, mock_memories_db):
+        mock_vector_db.find_similar_memories.return_value = [
+            {'memory_id': 'mem-1', 'score': 0.9},
+        ]
+        mock_memories_db.get_memories_by_ids.return_value = [
+            {'id': 'mem-1', 'content': 'active', 'category': 'system', 'is_locked': False, 'invalid_at': None},
+        ]
+        result = search_memories(query="test", limit=10, uid="user-1")
+        assert len(result) == 1
+        assert result[0]['id'] == 'mem-1'
+
+
 class TestEditMemoryVectorSync:
     """edit_memory must re-embed the new content so search finds the edited text."""
 

--- a/backend/tests/unit/test_memory_temporal_brain.py
+++ b/backend/tests/unit/test_memory_temporal_brain.py
@@ -1,0 +1,100 @@
+"""Unit tests for the temporal-memory "constantly updated brain" + hybrid retrieval.
+
+Covers the deterministic pieces that don't need Firestore/Pinecone/LLM:
+  - BM25 + Reciprocal Rank Fusion (hybrid retrieval, point #2)
+  - MemoryDB temporal lifecycle fields (valid_at / invalid_at / is_active, point #3)
+"""
+
+import os
+import sys
+from types import ModuleType
+from datetime import datetime, timezone
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_test_secret_key_for_unit_tests_only_000000000000000000')
+
+# Stub database._client so importing models.memories doesn't spin up Firestore.
+if 'database' not in sys.modules:
+    sys.modules['database'] = ModuleType('database')
+_client_stub = ModuleType('database._client')
+_client_stub.document_id_from_seed = lambda seed: 'id-' + str(abs(hash(seed)) % (10**12))
+sys.modules['database._client'] = _client_stub
+
+from utils.retrieval.hybrid import bm25_scores, rrf_rerank  # noqa: E402
+from models.memories import Memory, MemoryDB, MemoryCategory  # noqa: E402
+
+
+class TestBM25:
+    def test_exact_keyword_match_scores_highest(self):
+        docs = [
+            "the user phone number is 12345",
+            "the user likes hiking",
+            "favorite food is pizza",
+        ]
+        scores = bm25_scores("phone number", docs)
+        assert len(scores) == 3
+        assert scores[0] == max(scores) > 0
+        assert scores[1] == 0.0 and scores[2] == 0.0
+
+    def test_empty_docs(self):
+        assert bm25_scores("anything", []) == []
+
+    def test_no_query_term_match(self):
+        assert bm25_scores("zzz", ["hello world"]) == [0.0]
+
+
+class TestRRF:
+    def test_keyword_lifts_buried_vector_hit(self):
+        # Vector order is a, b, c (c last). The keyword query matches only c, so fusion
+        # must lift c above b — proof the keyword signal is actually applied.
+        candidates = [
+            {'id': 'a', 'content': 'user enjoys hiking and trails'},
+            {'id': 'b', 'content': 'user likes pizza'},
+            {'id': 'c', 'content': 'user phone number is 415 555 1234'},
+        ]
+        out = rrf_rerank("phone number", candidates, limit=3)
+        ids = [o['id'] for o in out]
+        assert ids.index('c') < ids.index('b')
+        assert all('_hybrid_score' in o for o in out)
+
+    def test_limit_truncates(self):
+        cands = [{'id': str(i), 'content': f'memory number {i}'} for i in range(10)]
+        assert len(rrf_rerank("memory", cands, limit=3)) == 3
+
+    def test_does_not_mutate_input(self):
+        cands = [{'id': 'a', 'content': 'x'}]
+        rrf_rerank("x", cands, 1)
+        assert '_hybrid_score' not in cands[0]
+
+    def test_empty(self):
+        assert rrf_rerank("q", [], 5) == []
+
+
+class TestMemoryLifecycle:
+    def _bare(self, **over):
+        base = dict(
+            id='x',
+            uid='u',
+            content='c',
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        base.update(over)
+        return MemoryDB(**base)
+
+    def test_new_memory_defaults_to_active(self):
+        m = self._bare()
+        assert m.invalid_at is None
+        assert m.superseded_by is None
+        assert m.is_active is True
+
+    def test_from_memory_sets_valid_at_and_active(self):
+        mem = Memory(content='Loves ice cream', category=MemoryCategory.system)
+        db = MemoryDB.from_memory(mem, uid='u', conversation_id='conv1', manually_added=False)
+        assert db.valid_at is not None
+        assert db.invalid_at is None
+        assert db.is_active is True
+
+    def test_invalidated_memory_is_not_active(self):
+        m = self._bare(invalid_at=datetime.now(timezone.utc), superseded_by='y')
+        assert m.is_active is False
+        assert m.superseded_by == 'y'

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -470,17 +470,27 @@ def _extract_memories_inner(uid: str, conversation: Conversation):
 
     is_locked = conversation.is_locked
     parsed_memories = []
-    memories_to_delete = []
+    # (old_memory_id, new_memory_id) pairs to invalidate after the new memories are saved.
+    invalidations = []
+    # Cheap exact-duplicate guard within this batch (avoids redundant conflict LLM calls).
+    seen_norm = set()
 
     for memory in new_memories:
-        # Find similar existing memories
-        similar_matches = find_similar_memories(uid, memory.content, threshold=0.7, limit=3)
+        norm = ' '.join((memory.content or '').lower().split())
+        if not norm or norm in seen_norm:
+            continue
+        seen_norm.add(norm)
 
-        # Fetch content for each similar memory
+        # Wider net (lower threshold, more candidates) than before so cross-phrasing
+        # contradictions are caught — "loves ice cream" vs "hates ice cream",
+        # "lives in NYC" vs "lives in LA" — then let the LLM decide what's outdated.
+        similar_matches = find_similar_memories(uid, memory.content, threshold=0.6, limit=8)
+
+        # Only compare against currently-active memories (never resurface superseded ones).
         similar_memories = []
         for match in similar_matches:
             memory_data = memories_db.get_memory(uid, match['memory_id'])
-            if memory_data:
+            if memory_data and memory_data.get('invalid_at') is None:
                 similar_memories.append(
                     {
                         'memory_id': match['memory_id'],
@@ -490,28 +500,30 @@ def _extract_memories_inner(uid: str, conversation: Conversation):
                     }
                 )
 
+        supersede_ids = []
         if similar_memories:
             resolution = resolve_memory_conflict(memory.content, similar_memories, language=language)
 
-            if resolution.action == 'keep_existing':
+            if resolution.action == 'skip':
                 continue
 
-            elif resolution.action == 'merge':
-                # Replace existing memory with merged version
-                if resolution.merged_content:
-                    memories_to_delete.append(similar_memories[0]['memory_id'])
-                    memory.content = resolution.merged_content
+            if resolution.action == 'merge' and resolution.merged_content:
+                memory.content = resolution.merged_content
 
-            elif resolution.action == 'keep_both':
-                pass
+            if resolution.action in ('update', 'merge'):
+                for idx in resolution.supersedes or []:
+                    if isinstance(idx, int) and 1 <= idx <= len(similar_memories):
+                        supersede_ids.append(similar_memories[idx - 1]['memory_id'])
 
         memory_db_obj = MemoryDB.from_memory(memory, uid, conversation.id, False)
         memory_db_obj.is_locked = is_locked
         parsed_memories.append(memory_db_obj)
 
-    for memory_id in memories_to_delete:
-        delete_memory_vector(uid, memory_id)
-        memories_db.delete_memory(uid, memory_id)
+        for old_id in supersede_ids:
+            # Guard against superseding the very memory we're about to (re)write — the
+            # merged content can hash to an existing id.
+            if old_id and old_id != memory_db_obj.id:
+                invalidations.append((old_id, memory_db_obj.id))
 
     if len(parsed_memories) == 0:
         logger.info(f"No memories extracted for conversation {conversation.id}")
@@ -522,6 +534,16 @@ def _extract_memories_inner(uid: str, conversation: Conversation):
 
     for memory_db_obj in parsed_memories:
         upsert_memory_vector(uid, memory_db_obj.id, memory_db_obj.content, memory_db_obj.category.value)
+
+    # Invalidate (not delete) superseded memories: keep them as history but drop them from
+    # every retrieval path. Removing the vector also pulls them out of semantic search.
+    for old_id, new_id in invalidations:
+        try:
+            memories_db.invalidate_memory(uid, old_id, superseded_by=new_id)
+            delete_memory_vector(uid, old_id)
+            logger.info(f"Invalidated superseded memory {old_id} -> {new_id}")
+        except Exception:
+            logger.exception(f"Failed to invalidate superseded memory {old_id}")
 
     if len(parsed_memories) > 0:
         record_usage(uid, memories_created=len(parsed_memories))

--- a/backend/utils/llm/memories.py
+++ b/backend/utils/llm/memories.py
@@ -231,15 +231,39 @@ Respond with ONLY "system" or "interesting" - nothing else."""
 
 
 class MemoryResolution(BaseModel):
-    """Result of resolving a new memory against similar existing memories."""
+    """Result of resolving a new memory against similar existing memories.
+
+    Drives the "constantly updated brain": when a new fact changes the truth of an
+    older one (e.g. loved ice cream -> now hates it, lived in NYC -> now LA, age 25 -> 26),
+    the older memory is listed in `supersedes` so it gets invalidated, while the new fact
+    is stored as the current truth.
+    """
 
     action: str = Field(
-        description="Action to take: 'keep_new' (add new memory), 'keep_existing' (skip new, existing is sufficient), 'merge' (replace existing with merged version), 'keep_both' (both provide distinct value)"
+        description=(
+            "One of: 'add' (store the new memory; existing facts stay untouched), "
+            "'skip' (new is a duplicate / already known — do not store), "
+            "'update' (new fact makes one or more existing facts outdated/false — store new AND list them in supersedes), "
+            "'merge' (new + existing should become a single richer fact — provide merged_content AND list the ones it replaces in supersedes), "
+            "'keep_both' (related but BOTH remain true at the same time — store new, supersede nothing)"
+        )
+    )
+    supersedes: List[int] = Field(
+        default=[],
+        description=(
+            "1-based indices (from the numbered EXISTING list) of memories that are now "
+            "OUTDATED or FALSE and must be invalidated. Only for 'update' / 'merge'. "
+            "Never include a fact that can still be true alongside the new one."
+        ),
     )
     merged_content: Optional[str] = Field(
-        default=None, description="If action is 'merge', the combined/refined memory content. Must be under 10 words."
+        default=None, description="If action is 'merge', the combined/refined memory content. Keep under 12 words."
     )
-    reasoning: str = Field(description="Brief explanation of why this action was chosen")
+    reasoning: str = Field(default="", description="Brief explanation of why this action was chosen")
+
+
+# Backwards-compatible action aliases (older callers/tests used these names).
+_LEGACY_ACTION_ALIASES = {'keep_new': 'add', 'keep_existing': 'skip'}
 
 
 def resolve_memory_conflict(
@@ -248,56 +272,65 @@ def resolve_memory_conflict(
     language: Optional[str] = None,
 ) -> MemoryResolution:
     """
-    Use LLM to decide how to handle a new memory that's similar to existing ones.
+    Use an LLM to decide how a newly extracted memory relates to existing similar ones,
+    and which (if any) existing memories it makes outdated.
 
     Args:
         new_memory: The newly extracted memory content
-        similar_memories: List of similar existing memories with 'content' and 'score' keys
+        similar_memories: Ordered list of similar existing memories, each a dict with at
+            least 'content' (and usually 'memory_id', 'score'). The 1-based position in
+            this list is what `MemoryResolution.supersedes` refers to.
         language: Language code for merged content output
 
     Returns:
-        MemoryResolution with action and optional merged content
+        MemoryResolution with action, supersedes indices, and optional merged content.
     """
     if not similar_memories:
-        return MemoryResolution(action='keep_new', reasoning='No similar memories found')
+        return MemoryResolution(action='add', reasoning='No similar memories found')
 
-    existing_str = "\n".join([f"- \"{m['content']}\" (similarity: {m['score']:.2f})" for m in similar_memories])
+    existing_str = "\n".join(
+        [f"{i + 1}. \"{m['content']}\" (similarity: {m.get('score', 0):.2f})" for i, m in enumerate(similar_memories)]
+    )
 
     language_note = ""
     if language and language != 'en':
-        language_note = (
-            f"\n5. If action is 'merge', write merged_content in {language} (same language as the memories)."
-        )
+        language_note = f"\n- If action is 'merge', write merged_content in {language} (same language as the memories)."
 
-    prompt = f"""You are a memory management system. A new memory has been extracted that is similar to existing memories.
-Decide the best action to maintain an accurate, non-redundant knowledge base.
+    prompt = f"""You maintain a personal knowledge base of true facts about a user. A NEW fact was just learned.
+Decide how it relates to the EXISTING facts so the knowledge base always reflects the CURRENT truth.
 
-NEW MEMORY: "{new_memory}"
+NEW FACT: "{new_memory}"
 
-SIMILAR EXISTING MEMORIES:
+EXISTING FACTS (numbered):
 {existing_str}
 
-RULES:
-1. "keep_new" - The new memory adds genuinely NEW information not in existing memories
-2. "keep_existing" - The new memory is redundant; existing memories already capture this
-3. "merge" - The new memory REFINES or UPDATES existing knowledge (e.g., adds specificity, corrects, or combines info). Provide merged_content (max 10 words)
-4. "keep_both" - Both memories provide distinct, non-conflicting value (rare - only if truly different aspects){language_note}
+Choose ONE action:
+- "add": the new fact is genuinely new and does not change any existing fact. Store it.
+- "skip": the new fact is already captured by an existing fact (a duplicate / no new info). Do not store it.
+- "update": the new fact makes one or more existing facts OUTDATED or FALSE (the same attribute now has a different value). Store the new fact AND put the indices of every outdated fact in "supersedes".
+- "merge": the new fact and an existing one should become a SINGLE richer fact. Provide "merged_content" AND put the replaced indices in "supersedes".
+- "keep_both": the new fact and the existing ones are all still TRUE at the same time. Store the new fact, supersede nothing.
+
+CRITICAL — only put a fact in "supersedes" if it is now genuinely FALSE or OUTDATED. Two preferences that can both be true at once must NEVER supersede each other.{language_note}
 
 EXAMPLES:
-- Existing: "Likes pancakes" + New: "Doesn't like blueberry pancakes" → merge: "Likes pancakes but not blueberry ones"
-- Existing: "Works at Google" + New: "Works at Google as engineer" → merge: "Works at Google as engineer"
-- Existing: "Has a dog" + New: "Has a dog named Max" → merge: "Has a dog named Max"
-- Existing: "Enjoys hiking" + New: "Enjoys hiking" → keep_existing (duplicate)
-- Existing: "Lives in NYC" + New: "Has apartment in Brooklyn" → keep_both (complementary info)
+- New: "Hates ice cream" | Existing: 1."Loves ice cream" → update, supersedes [1] (preference flipped — the old one is now false)
+- New: "Lives in Los Angeles" | Existing: 1."Lives in New York City" → update, supersedes [1] (moved — can't live in both)
+- New: "Is 26 years old" | Existing: 1."Is 25 years old" → update, supersedes [1] (age changed)
+- New: "Works at Google as engineer" | Existing: 1."Works at Google" → merge: "Works at Google as engineer", supersedes [1]
+- New: "Enjoys hiking" | Existing: 1."Enjoys hiking" → skip (duplicate)
+- New: "Likes tennis" | Existing: 1."Likes basketball" → keep_both (can like both sports)
+- New: "Has a dog named Max" | Existing: 1."Has a dog", 2."Lives in NYC" → merge: "Has a dog named Max", supersedes [1]
 
-Respond with the action and reasoning."""
+Respond with action, supersedes (indices), merged_content (only for merge), and reasoning."""
 
     try:
         parser = PydanticOutputParser(pydantic_object=MemoryResolution)
         chain = get_llm('memory_conflict') | parser
         response: MemoryResolution = chain.invoke(prompt + f"\n\n{parser.get_format_instructions()}")
+        response.action = _LEGACY_ACTION_ALIASES.get(response.action, response.action)
         return response
     except Exception as e:
         logger.error(f'Error resolving memory conflict: {e}')
-        # Default to keeping new if resolution fails
-        return MemoryResolution(action='keep_new', reasoning=f'Resolution failed: {e}')
+        # Default to storing the new memory if resolution fails (never lose information).
+        return MemoryResolution(action='add', reasoning=f'Resolution failed: {e}')

--- a/backend/utils/retrieval/hybrid.py
+++ b/backend/utils/retrieval/hybrid.py
@@ -1,0 +1,85 @@
+"""
+Hybrid retrieval helpers — fuse semantic (vector) ranking with keyword (BM25) ranking.
+
+Pure vector search misses exact-keyword queries ("phone number", a specific name,
+an acronym) where the literal token matters more than semantic similarity. We rerank
+the over-fetched vector candidates with BM25 over their text and fuse the two rankings
+with Reciprocal Rank Fusion (RRF). This is the mem0-V3 / Graphiti pattern and needs no
+extra dependency or index — BM25 runs in-memory over the small candidate set.
+"""
+
+import math
+import re
+from typing import List, Dict
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> List[str]:
+    return _TOKEN_RE.findall((text or "").lower())
+
+
+def bm25_scores(query: str, docs: List[str], k1: float = 1.5, b: float = 0.75) -> List[float]:
+    """Classic Okapi BM25 score of `query` against each doc in `docs` (same order)."""
+    doc_tokens = [_tokenize(d) for d in docs]
+    n = len(doc_tokens)
+    if n == 0:
+        return []
+
+    avgdl = (sum(len(d) for d in doc_tokens) / n) or 1.0
+
+    df: Dict[str, int] = {}
+    for toks in doc_tokens:
+        for t in set(toks):
+            df[t] = df.get(t, 0) + 1
+
+    q_terms = _tokenize(query)
+    scores: List[float] = []
+    for toks in doc_tokens:
+        if not toks:
+            scores.append(0.0)
+            continue
+        freq: Dict[str, int] = {}
+        for t in toks:
+            freq[t] = freq.get(t, 0) + 1
+        dl = len(toks)
+        s = 0.0
+        for t in q_terms:
+            tf = freq.get(t)
+            if not tf:
+                continue
+            n_t = df.get(t, 0)
+            idf = math.log(1 + (n - n_t + 0.5) / (n_t + 0.5))
+            s += idf * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl / avgdl))
+        scores.append(s)
+    return scores
+
+
+def rrf_rerank(query: str, candidates: List[dict], limit: int, k: int = 60) -> List[dict]:
+    """Rerank vector candidates by fusing their vector rank with a BM25 keyword rank.
+
+    `candidates` must be ordered best-first by vector relevance and each must carry a
+    'content' key. Returns a new list (copies), best-first, truncated to `limit`, each
+    annotated with '_hybrid_score' and '_bm25'.
+    """
+    if not candidates:
+        return []
+
+    contents = [c.get("content", "") for c in candidates]
+    bm = bm25_scores(query, contents)
+
+    # vector rank = position in the input list (0 = best)
+    vec_rank = {i: i for i in range(len(candidates))}
+    # bm25 rank = position after sorting by BM25 score desc (stable on ties)
+    bm_order = sorted(range(len(candidates)), key=lambda i: (bm[i], -i), reverse=True)
+    bm_rank = {i: r for r, i in enumerate(bm_order)}
+
+    fused: List[dict] = []
+    for i, c in enumerate(candidates):
+        item = dict(c)
+        item["_bm25"] = bm[i]
+        item["_hybrid_score"] = 1.0 / (k + vec_rank[i] + 1) + 1.0 / (k + bm_rank[i] + 1)
+        fused.append(item)
+
+    fused.sort(key=lambda x: x["_hybrid_score"], reverse=True)
+    return fused[: max(0, limit)]

--- a/backend/utils/retrieval/tools/memory_tools.py
+++ b/backend/utils/retrieval/tools/memory_tools.py
@@ -12,6 +12,7 @@ from langchain_core.runnables import RunnableConfig
 import database.memories as memory_db
 import database.vector_db as vector_db
 from models.memories import MemoryDB
+from utils.retrieval.hybrid import rrf_rerank
 import logging
 
 logger = logging.getLogger(__name__)
@@ -263,8 +264,10 @@ def search_memories_tool(
     limit = min(limit, 20)
 
     try:
-        # Perform vector search on memories (no threshold, just return top matches)
-        matches = vector_db.find_similar_memories(uid, query, threshold=0.0, limit=limit)
+        # Over-fetch then rerank: pull more vector candidates than we need so the
+        # keyword (BM25) signal can promote exact-term matches the vector ranking buried.
+        fetch_limit = min(limit * 3, 60)
+        matches = vector_db.find_similar_memories(uid, query, threshold=0.0, limit=fetch_limit)
 
         logger.info(f"📊 search_memories_tool - found {len(matches)} results for query: '{query}'")
 
@@ -281,21 +284,39 @@ def search_memories_tool(
         if not memory_ids:
             return f"Found matches but no valid memory IDs for query: '{query}'"
 
-        memories_data = memory_db.get_memories_by_ids(uid, memory_ids)
+        docs_by_id = {m.get('id'): m for m in memory_db.get_memories_by_ids(uid, memory_ids)}
 
-        # Filter out locked memories (paid plan required)
-        memories_data = [m for m in memories_data if not m.get('is_locked', False)]
+        # Preserve vector order, and drop locked / rejected / superseded memories so the
+        # agent never reasons over a fact that is no longer true.
+        candidates = []
+        for mid in memory_ids:
+            m = docs_by_id.get(mid)
+            if not m:
+                continue
+            if m.get('is_locked', False) or m.get('user_review') is False or m.get('invalid_at') is not None:
+                continue
+            candidates.append(
+                {
+                    'id': m.get('id'),
+                    'content': m.get('content', ''),
+                    'vector_score': scores_by_id.get(mid, 0),
+                    '_doc': m,
+                }
+            )
 
-        if not memories_data:
+        if not candidates:
             return f"No memories found matching '{query}'. The content may require a paid plan to access."
+
+        # Semantic score sets the vector rank; RRF then fuses in the BM25 keyword rank.
+        candidates.sort(key=lambda c: c.get('vector_score', 0), reverse=True)
+        candidates = rrf_rerank(query, candidates, limit)
 
         # Convert to MemoryDB objects with scores
         memory_objects = []
-        for memory_data in memories_data:
+        for cand in candidates:
             try:
-                memory_obj = MemoryDB(**memory_data)
-                score = scores_by_id.get(memory_data.get('id'), 0)
-                memory_objects.append({'memory': memory_obj, 'score': score})
+                memory_obj = MemoryDB(**cand['_doc'])
+                memory_objects.append({'memory': memory_obj, 'score': cand.get('vector_score', 0)})
             except Exception as e:
                 logger.error(f"Error creating MemoryDB object: {e}")
                 continue


### PR DESCRIPTION
## What & why

Makes Omi's memory a **constantly-updated brain**: when a new fact changes the truth of an older one (loves → **hates ice cream**, age 25 → 26, NYC → LA), the old memory is **invalidated (not deleted)** and every retrieval path stops returning it. Plus hybrid retrieval and a stale-embedding fix.

Implements points #2 (hybrid retrieval), #3 (temporal supersession, "done best"), #4 (bug fixes) from a memory-system audit vs mem0 / Graphiti / supermemory. (Point #1, the canonical user profile, is intentionally out of scope — separate work.)

### #3 Temporal supersession (the core)
- New backward-compatible lifecycle fields on `MemoryDB`: `valid_at` / `invalid_at` / `superseded_by` (+ `is_active`). All Optional → existing docs read as active, **zero migration**.
- `resolve_memory_conflict` upgraded to mem0+Graphiti semantics: `add / skip / update / merge / keep_both`, returning the indices of existing facts a new fact makes outdated.
- On extraction, superseded memories are **invalidated and their vectors dropped** (kept in Firestore as history, excluded from all retrieval). Safeguard: coexisting facts (likes tennis + basketball) are never superseded.

### #2 Hybrid retrieval
- New dependency-free `utils/retrieval/hybrid.py` (BM25 + Reciprocal Rank Fusion).
- Wired into MCP `/v1/mcp/memories/search` and the agentic-RAG `search_memories_tool`; exact-keyword lookups now surface even when vector-buried. All retrieval is active-only.

### #4 Bug fixes
- PATCH `/v3/memories` now **re-embeds** on edit (it was leaving the Pinecone vector stale — silently breaking semantic search after any edit/supersession).
- Exact-duplicate pre-filter to skip redundant conflict-resolution LLM calls.

## Verification
- **30 deterministic unit tests pass** — BM25/RRF fusion, temporal lifecycle model, and invalidated/locked/rejected exclusion from search (`test_memory_temporal_brain.py`, `test_mcp_search_memories.py`).
- **Live LLM judgment verified** against real `gpt-4.1-mini` (7/7): love→hate, 25→26, NYC→LA → `update`; tennis+basketball → `keep_both`; duplicate → `skip`; refine → `merge`; unrelated → `add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)