### PR TITLE
fix(desktop): log Gemini proxy forwarded uid

### DIFF
--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -142,11 +142,13 @@ async fn gemini_proxy(
             &state, &user, &effective_path, action, model, &sanitized_body,
         )
         .await?;
-        tracing::info!(
-            "gemini_proxy: forwarded uid={} path={}",
-            user.uid,
-            effective_path
-        );
+        if response.status().is_success() {
+            tracing::info!(
+                "gemini_proxy: forwarded uid={} path={}",
+                user.uid,
+                effective_path
+            );
+        }
         return Ok(response);
     }
 
@@ -372,11 +374,13 @@ async fn gemini_stream_proxy(
             &query,
         )
         .await?;
-        tracing::info!(
-            "gemini_stream_proxy: forwarded uid={} path={}",
-            user.uid,
-            effective_path
-        );
+        if response.status().is_success() {
+            tracing::info!(
+                "gemini_stream_proxy: forwarded uid={} path={}",
+                user.uid,
+                effective_path
+            );
+        }
         return Ok(response);
     }
 

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -138,10 +138,16 @@ async fn gemini_proxy(
         }
 
         // Non-BYOK path: use server key with Vertex AI / AI Studio routing
-        return gemini_proxy_server_key(
+        let response = gemini_proxy_server_key(
             &state, &user, &effective_path, action, model, &sanitized_body,
         )
-        .await;
+        .await?;
+        tracing::info!(
+            "gemini_proxy: forwarded uid={} path={}",
+            user.uid,
+            effective_path
+        );
+        return Ok(response);
     }
 
     // BYOK path: always use AI Studio with the user's API key.
@@ -357,7 +363,21 @@ async fn gemini_stream_proxy(
         }
 
         // Non-BYOK: server key with Vertex AI / AI Studio routing
-        return gemini_stream_server_key(&state, &effective_path, action, model, sanitized_body, &query).await;
+        let response = gemini_stream_server_key(
+            &state,
+            &effective_path,
+            action,
+            model,
+            sanitized_body,
+            &query,
+        )
+        .await?;
+        tracing::info!(
+            "gemini_stream_proxy: forwarded uid={} path={}",
+            user.uid,
+            effective_path
+        );
+        return Ok(response);
     }
 
     // BYOK path: always use AI Studio with user's key, skip Vertex AI.


### PR DESCRIPTION
## Summary
- log successful non-BYOK Gemini proxy forwards with `uid` and forwarded `path`
- cover both non-streaming and streaming Gemini proxy paths

Fixes #7624.

## Verification
- `git diff --check`

Not run locally: `cargo check && cargo test` because this Windows host does not have `cargo`/`rustc` installed.