### PR TITLE
Make LC3 transcribe dependency optional

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -20,7 +20,10 @@ import av
 import numpy as np
 import opuslib  # type: ignore
 
-import lc3  # lc3py
+try:
+    import lc3  # lc3py
+except ImportError:
+    lc3 = None
 
 from fastapi import APIRouter, Depends
 from fastapi.websockets import WebSocket, WebSocketDisconnect
@@ -2416,6 +2419,11 @@ async def _stream_handler(
     elif codec == 'aac':
         aac_decoder = AACDecoder(uid=uid, session_id=session_id, sample_rate=sample_rate, channels=channels)
     elif codec == 'lc3':
+        if lc3 is None:
+            websocket_close_code = 1011
+            logger.error(f"LC3 codec requested but lc3py is not installed {uid} {session_id}")
+            await websocket.close(code=websocket_close_code, reason="LC3 codec is not available")
+            return
         lc3_decoder = lc3.Decoder(lc3_frame_duration_us, sample_rate)
 
     async def receive_data(stt_socket):

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -96,6 +96,7 @@ pytest tests/unit/test_billable_transcription_seconds.py -v
 pytest tests/unit/test_sync_fair_use_gate.py -v
 pytest tests/unit/test_sync_pcm_decode.py -v
 pytest tests/unit/test_sync_opus_decode.py -v
+pytest tests/unit/test_transcribe_lc3_optional.py -v
 pytest tests/unit/test_sync_silent_failure.py -v
 pytest tests/unit/test_sync_ordered_assignment.py -v
 pytest tests/unit/test_fair_use_free_tier.py -v

--- a/backend/tests/unit/test_transcribe_lc3_optional.py
+++ b/backend/tests/unit/test_transcribe_lc3_optional.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+TRANSCRIBE_SOURCE = Path(__file__).resolve().parents[2] / 'routers' / 'transcribe.py'
+
+
+def _read_source() -> str:
+    return TRANSCRIBE_SOURCE.read_text(encoding='utf-8')
+
+
+def test_lc3_import_is_optional():
+    source = _read_source()
+
+    assert 'try:\n    import lc3  # lc3py\nexcept ImportError:\n    lc3 = None' in source
+
+
+def test_lc3_codec_closes_cleanly_when_dependency_missing():
+    source = _read_source()
+
+    assert "elif codec == 'lc3':" in source
+    assert 'if lc3 is None:' in source
+    assert 'LC3 codec requested but lc3py is not installed' in source
+    assert 'await websocket.close(code=websocket_close_code, reason="LC3 codec is not available")' in source


### PR DESCRIPTION
## Summary
- allow `routers/transcribe.py` to import when `lc3py` is not installed
- close LC3 websocket sessions with a clear 1011 error when the LC3 codec is requested without the dependency
- add focused coverage for optional LC3 import behavior and wire it into `backend/test.sh`

## Verification
- `python -m pytest backend\tests\unit\test_transcribe_lc3_optional.py -q --tb=short`
  - 2 passed
- `python -m black --line-length 120 --skip-string-normalization --check backend\routers\transcribe.py backend\tests\unit\test_transcribe_lc3_optional.py`
  - 2 files would be left unchanged
- `python -m py_compile backend\routers\transcribe.py backend\tests\unit\test_transcribe_lc3_optional.py`
- `git diff --check origin/main...HEAD`
- `scripts/pre-commit` via Git for Windows `sh.exe` with the backend venv on `PATH`

## Notes
- Rebased onto current `main` (`953e75d686`).
- Checked and fixed the previous local lint issue by applying the repository Black settings.
- Kept the PR as one focused backend commit.