### PR TITLE
docs: clarify Developer API and MCP keys

### DIFF
--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -20,6 +20,12 @@ Authorization: Bearer omi_dev_your_api_key_here
 
 Get your key from **Settings → Developer → Create Key** in the Omi app.
 
+<Warning>
+MCP keys (`omi_mcp_...`) are only for the MCP server at `/v1/mcp/sse`. They are not accepted by REST
+Developer API endpoints. Use a Developer API key (`omi_dev_...`) for endpoints such as
+`/v1/dev/user/memories` and `/v1/dev/user/conversations`.
+</Warning>
+
 ## Rate Limits
 
 | Limit | Value |

--- a/docs/doc/developer/api/overview.mdx
+++ b/docs/doc/developer/api/overview.mdx
@@ -136,6 +136,13 @@ Authorization: Bearer omi_dev_your_api_key_here
 ```
 
 <Warning>
+MCP keys (`omi_mcp_...`) only authenticate MCP clients against `/v1/mcp/sse`. They do not authenticate
+REST Developer API calls. For memories, conversations, folders, and action items over HTTP, create a
+Developer API key (`omi_dev_...`) and call endpoints under `/v1/dev/user/...` such as
+`/v1/dev/user/memories`.
+</Warning>
+
+<Warning>
 Never commit API keys to version control or share them publicly!
 </Warning>
 
@@ -217,6 +224,12 @@ If a key is compromised, revoke it immediately from **Settings → Developer** i
 | **Use Case** | Custom apps, dashboards, automation | Claude Desktop, AI agents |
 | **Authentication** | Bearer token | Environment variable |
 | **Best For** | Web apps, integrations, batch operations | AI-powered workflows |
+
+<Info>
+If you see `404 Not Found` for `/v1/memories` or `/v2/memories`, use the Developer API path
+`/v1/dev/user/memories` instead. If you see `401 Unauthorized` while using an `omi_mcp_...` key, create
+and use an `omi_dev_...` key for REST API requests.
+</Info>
 
 <CardGroup cols={2}>
   <Card title="Use Developer API when you need" icon="code" color="#3b82f6">

--- a/docs/doc/developer/api/overview.mdx
+++ b/docs/doc/developer/api/overview.mdx
@@ -139,11 +139,7 @@ Authorization: Bearer omi_dev_your_api_key_here
 MCP keys (`omi_mcp_...`) only authenticate MCP clients against `/v1/mcp/sse`. They do not authenticate
 REST Developer API calls. For memories, conversations, folders, and action items over HTTP, create a
 Developer API key (`omi_dev_...`) and call endpoints under `/v1/dev/user/...` such as
-`/v1/dev/user/memories`.
-</Warning>
-
-<Warning>
-Never commit API keys to version control or share them publicly!
+`/v1/dev/user/memories`. Never commit API keys to version control or share them publicly.
 </Warning>
 
 ---
@@ -226,9 +222,9 @@ If a key is compromised, revoke it immediately from **Settings → Developer** i
 | **Best For** | Web apps, integrations, batch operations | AI-powered workflows |
 
 <Info>
-If you see `404 Not Found` for `/v1/memories` or `/v2/memories`, use the Developer API path
-`/v1/dev/user/memories` instead. If you see `401 Unauthorized` while using an `omi_mcp_...` key, create
-and use an `omi_dev_...` key for REST API requests.
+If you see `404 Not Found` for legacy memory paths such as `/v1/memories` or `/v2/memories`, use the
+Developer API path `/v1/dev/user/memories` instead. If you see `401 Unauthorized` while using an
+`omi_mcp_...` key, create and use an `omi_dev_...` key for REST API requests.
 </Info>
 
 <CardGroup cols={2}>

--- a/docs/doc/developer/mcp/setup.mdx
+++ b/docs/doc/developer/mcp/setup.mdx
@@ -13,6 +13,12 @@ The fastest way to get started — no installation required.
     Open the Omi app and navigate to **Settings → Developer → MCP** to generate your API key.
 
     Your key will look like: `omi_mcp_...`
+
+    <Note>
+    This key is only for MCP clients. To call REST Developer API endpoints directly, create a separate
+    Developer API key from **Settings → Developer → Create Key**. Developer API keys look like
+    `omi_dev_...`.
+    </Note>
   </Step>
   <Step title="Configure Your Client" icon="sliders">
     Use the following connection details:


### PR DESCRIPTION
## Summary
- clarify that `omi_mcp_...` keys only authenticate MCP clients at `/v1/mcp/sse`
- point REST integrations to `omi_dev_...` keys and `/v1/dev/user/...` endpoints
- add troubleshooting copy for `/v1/memories`/`/v2/memories` 404s and MCP-key 401s

Addresses #7506.

## Verification
- `git diff --check`
- checked public docs for internal-process leakage markers

Not run locally: no docs build/test script is defined in `docs/package.json`.